### PR TITLE
fix(macos): report embedded dashboard load failures

### DIFF
--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/MonitorView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/MonitorView.swift
@@ -7,6 +7,7 @@ struct MonitorView: View {
     @Binding var stateDir: String
     @Binding var webURL: URL?
     @State private var alertMessage: String?
+    @State private var webViewErrorMessage: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -28,7 +29,13 @@ struct MonitorView: View {
             .padding(16)
             Divider()
             if let webURL {
-                WebView(url: webURL)
+                if let webViewErrorMessage {
+                    WebViewErrorView(message: webViewErrorMessage) {
+                        self.webViewErrorMessage = nil
+                    }
+                } else {
+                    WebView(url: webURL, navigationError: $webViewErrorMessage)
+                }
             } else {
                 EmptyStateView(title: "No Monitor Open", symbolName: "waveform.path.ecg.rectangle")
             }
@@ -42,6 +49,7 @@ struct MonitorView: View {
 
     private func openMonitor() {
         do {
+            webViewErrorMessage = nil
             let dashboard = try processService.startViewer(
                 repoPath: repoPath,
                 preferredPort: preferredPort,

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/PlayView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/PlayView.swift
@@ -18,6 +18,7 @@ struct PlayView: View {
     @State private var runID: String = PlayView.newRunID()
     @State private var companions: String = ""
     @State private var alertMessage: String?
+    @State private var webViewErrorMessage: String?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -102,7 +103,13 @@ struct PlayView: View {
     @ViewBuilder
     private var webSurface: some View {
         if let webURL {
-            WebView(url: webURL)
+            if let webViewErrorMessage {
+                WebViewErrorView(message: webViewErrorMessage) {
+                    self.webViewErrorMessage = nil
+                }
+            } else {
+                WebView(url: webURL, navigationError: $webViewErrorMessage)
+            }
         } else {
             VStack(spacing: 18) {
                 Image(systemName: "gamecontroller")
@@ -121,6 +128,7 @@ struct PlayView: View {
 
     private func startViewer() {
         do {
+            webViewErrorMessage = nil
             webURL = try processService.startViewer(
                 repoPath: repoPath,
                 preferredPort: preferredPort,
@@ -133,6 +141,7 @@ struct PlayView: View {
 
     private func startProvider() {
         do {
+            webViewErrorMessage = nil
             let provider = ProviderKind(rawValue: selectedProviderRaw) ?? .claude
             let cleanRunID = runID.trimmingCharacters(in: .whitespacesAndNewlines)
             webURL = try processService.startProviderSession(

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/WebView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/WebView.swift
@@ -3,19 +3,80 @@ import WebKit
 
 struct WebView: NSViewRepresentable {
     let url: URL?
+    @Binding var navigationError: String?
 
     func makeNSView(context: Context) -> WKWebView {
         let configuration = WKWebViewConfiguration()
         configuration.preferences.javaScriptCanOpenWindowsAutomatically = true
         let view = WKWebView(frame: .zero, configuration: configuration)
         view.allowsBackForwardNavigationGestures = true
+        view.navigationDelegate = context.coordinator
         return view
     }
 
     func updateNSView(_ view: WKWebView, context: Context) {
         guard let url else { return }
         if view.url != url {
+            navigationError = nil
             view.load(URLRequest(url: url))
         }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(navigationError: $navigationError)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate {
+        private let navigationError: Binding<String?>
+
+        init(navigationError: Binding<String?>) {
+            self.navigationError = navigationError
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            navigationError.wrappedValue = nil
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            report(error)
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            report(error)
+        }
+
+        private func report(_ error: Error) {
+            let nsError = error as NSError
+            guard nsError.domain != NSURLErrorDomain || nsError.code != NSURLErrorCancelled else { return }
+            navigationError.wrappedValue = "Dashboard failed to load: \(error.localizedDescription)"
+        }
+    }
+}
+
+struct WebViewErrorView: View {
+    let message: String
+    let retry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 42, weight: .regular))
+                .foregroundStyle(.orange)
+            Text("Dashboard Unavailable")
+                .font(.title3.weight(.semibold))
+            Text(message)
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .lineLimit(3)
+                .frame(maxWidth: 520)
+            Button {
+                retry()
+            } label: {
+                Label("Retry", systemImage: "arrow.clockwise")
+            }
+        }
+        .padding(24)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }


### PR DESCRIPTION
## Summary
- add a WKNavigationDelegate coordinator to the SwiftUI WebView wrapper
- report provisional and committed WKWebView navigation failures through a binding
- show a concise native retry affordance in Play and Monitor when the embedded dashboard cannot load

## Validation
- pwd verified under /Volumes/LEXAR/repos before build/test commands
- swift build --package-path macos/ClawDnDApp
- git diff --check

Refs #82