### PR TITLE
feat(viewer): surface QA release readiness in monitor

### DIFF
--- a/servers/engine/tests/test_qa_monitor.py
+++ b/servers/engine/tests/test_qa_monitor.py
@@ -1,0 +1,56 @@
+"""Focused regressions for the read-only QA monitor projection."""
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _viewer():
+    spec = importlib.util.spec_from_file_location("clawdnd_viewer_under_test", ROOT / "viewer" / "server.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # main() is __name__-guarded, so no server starts
+    return mod
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+def test_qa_monitor_surfaces_release_readiness_sidecars_and_unknowns(tmp_path, monkeypatch):
+    v = _viewer()
+    repo = tmp_path / "repo"
+    monkeypatch.setattr(v, "_HERE", repo / "viewer")
+    v._monitor_card_cache.clear()
+
+    snap = repo / "qa" / "state" / "caster-run" / "campaigns" / "camp1" / "snapshot.json"
+    _write_json(snap, {"title": "QA World", "world_id": "bg3", "characters": {}, "party": []})
+    tdir = repo / "qa" / "transcripts"
+    _write_json(tdir / "caster-run.score.json", {"overall": 4.7, "gate_status": "GREEN"})
+    _write_json(tdir / "caster-run.tolkien.json", {"overall": 4.4})
+    _write_json(tdir / "caster-run.fiction.json", {"status": "FAIL", "blockers": ["canon drift"]})
+    _write_json(tdir / "caster-run.release.json", {"status": "FAIL", "release_cell": "postbg3-caster"})
+
+    monkeypatch.setattr(v, "_monitor_roots", lambda: [("qa:caster-run", snap.parents[1])])
+    first = v._monitor_campaigns()[0]
+    assert first["scores"]["mechanical"] == 4.7
+    assert first["scores"]["story"] == 4.4
+    assert first["scores"]["behavioral"] == "GREEN"
+    assert first["scores"]["fiction"] == "FAIL"
+    assert first["scores"]["release"] == "FAIL"
+    assert first["release_cell"] == "postbg3-caster"
+    assert first["blockers"] == ["canon drift"]
+    assert first["run_id"] == "caster-run"
+    assert first["readiness_updated_at"] >= first["updated_at"]
+
+    _write_json(tdir / "caster-run.release.json", {"status": "PASS", "release_cell": "postbg3-caster"})
+    os.utime(tdir / "caster-run.release.json", None)
+    second = v._monitor_campaigns()[0]
+    assert second["scores"]["release"] == "PASS"
+
+    missing = v._monitor_card("qa:empty-run", snap, {"characters": {}, "party": []})
+    assert missing["scores"]["fiction"] == "UNKNOWN"
+    assert missing["scores"]["release"] == "UNKNOWN"
+    assert missing["scores"]["behavioral"] == "UNKNOWN"

--- a/viewer/monitor.html
+++ b/viewer/monitor.html
@@ -64,6 +64,8 @@
     font-size: 12px; border-top: 1px solid var(--line); padding-top: 8px; margin-top: 2px; }
   .score { font-weight: 700; }
   .score.good { color: var(--good); } .score.mid { color: var(--qa); } .score.low { color: var(--bad); }
+  .status { font-weight: 700; }
+  .status.good { color: var(--good); } .status.low { color: var(--bad); } .status.unknown { color: var(--dim); }
   .ago { margin-left: auto; }
   .empty { color: var(--dim); padding: 72px 20px; text-align: center; font: italic 16px/1.6 Georgia, serif; }
   .empty::before { content: "❧"; display: block; font: 34px/1 var(--font-display); color: var(--gold2); margin-bottom: 12px; }
@@ -92,6 +94,12 @@ function ago(sec) {
   return Math.round(sec/86400) + 'd ago';
 }
 function scoreClass(v) { return v == null ? '' : (v >= 4.3 ? 'good' : v >= 3.5 ? 'mid' : 'low'); }
+function statusClass(v) {
+  const s = String(v ?? '').toUpperCase();
+  if (s === 'PASS' || s === 'GREEN') return 'good';
+  if (s === 'FAIL' || s === 'RED') return 'low';
+  return 'unknown';
+}
 function card(c, now) {
   const root = String(c.root ?? '');
   const isPlay = root === 'play';
@@ -124,9 +132,16 @@ function card(c, now) {
     `<span class="chip ${p.dead ? 'dead' : ''} ${p.kind === 'companion' ? 'companion' : ''}">${esc(p.name)} ${esc(p.hp)}</span>`
   ).join('');
   const scores = c.scores || {};
-  const scoreBadges = ['mechanical','story'].filter(k => scores[k] != null).map(k =>
+  const scoreBadges = ['mechanical','story'].filter(k => typeof scores[k] === 'number').map(k =>
     `<span>${k[0].toUpperCase()}: <span class="score ${scoreClass(scores[k])}">${scores[k]}</span></span>`
   ).join(' &nbsp; ');
+  const readinessBadges = (!isPlay ? ['behavioral','fiction','release'].map(k => {
+    const status = String(scores[k] ?? 'UNKNOWN').toUpperCase();
+    return `<span>${k[0].toUpperCase()}: <span class="status ${statusClass(status)}">${esc(status)}</span></span>`;
+  }).join(' &nbsp; ') : '');
+  const blockerTitle = (c.blockers || []).length ? ` title="${esc((c.blockers || []).slice(0, 3).join(' | '))}"` : '';
+  const releaseMeta = (!isPlay && (c.release_cell || c.run_id))
+    ? `<span${blockerTitle}>${c.release_cell ? `cell: ${esc(c.release_cell)}` : `run: ${esc(c.run_id)}`}</span>` : '';
   const counts = [
     (c.quest_hooks ? `${c.quest_hooks} hooks` : ''),
     (c.quest_outcomes ? `${c.quest_outcomes} quests` : ''),
@@ -141,6 +156,8 @@ function card(c, now) {
     <div class="foot">
       ${counts ? `<span>${esc(counts)}</span>` : ''}
       ${scoreBadges ? `<span>${scoreBadges}</span>` : ''}
+      ${readinessBadges ? `<span>${readinessBadges}</span>` : ''}
+      ${releaseMeta}
       <span class="ago">${ago(now - c.updated_at)}</span>
     </div>
   </div>`;

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -288,18 +288,141 @@ def _monitor_roots() -> list[tuple[str, Path]]:
     return roots
 
 
+_QA_STATUS_UNKNOWN = "UNKNOWN"
+_QA_STATUS_KEYS = ("status", "release", "fiction", "behavioral", "gate_status", "verdict")
+
+
+def _qa_transcripts_dir() -> Path:
+    return _HERE.parent / "qa" / "transcripts"
+
+
+def _qa_sidecar_paths(run: str) -> dict[str, Path]:
+    tdir = _qa_transcripts_dir()
+    return {
+        "mechanical": tdir / f"{run}.score.json",
+        "story": tdir / f"{run}.tolkien.json",
+        "behavioral_gate": tdir / f"{run}.gate.txt",
+        "fiction": tdir / f"{run}.fiction.json",
+        "release": tdir / f"{run}.release.json",
+    }
+
+
+def _qa_sidecar_signature(run: str) -> tuple[tuple[str, float], ...]:
+    """Small cache key for QA sidecars. The monitor polls often; sidecars can arrive after the
+    snapshot stops changing, so cache invalidation must include sidecar mtimes without reading
+    transcripts or any large run artifact."""
+    sig: list[tuple[str, float]] = []
+    for kind, p in _qa_sidecar_paths(run).items():
+        try:
+            sig.append((kind, p.stat().st_mtime))
+        except OSError:
+            sig.append((kind, 0.0))
+    return tuple(sig)
+
+
+def _qa_status(value: object) -> str:
+    s = str(value or "").strip().upper()
+    aliases = {
+        "OK": "PASS", "PASSED": "PASS", "READY": "PASS", "GREEN": "GREEN",
+        "FAILED": "FAIL", "BLOCKED": "FAIL", "RED": "RED",
+        "PENDING": "PENDING", "UNKNOWN": _QA_STATUS_UNKNOWN,
+    }
+    return aliases.get(s, s) if s else _QA_STATUS_UNKNOWN
+
+
+def _qa_status_from_json(data: dict, default: str = _QA_STATUS_UNKNOWN) -> str:
+    for key in _QA_STATUS_KEYS:
+        if key in data:
+            return _qa_status(data.get(key))
+    if isinstance(data.get("passed"), bool):
+        return "PASS" if data["passed"] else "FAIL"
+    if isinstance(data.get("ok"), bool):
+        return "PASS" if data["ok"] else "FAIL"
+    return default
+
+
+def _qa_blockers(data: dict) -> list[str]:
+    raw = data.get("blockers") or data.get("failures") or data.get("defects") or []
+    if isinstance(raw, str):
+        raw = [raw]
+    out: list[str] = []
+    if isinstance(raw, list):
+        for item in raw[:8]:
+            if isinstance(item, str):
+                out.append(item)
+            elif isinstance(item, dict):
+                label = item.get("name") or item.get("id") or item.get("check") or item.get("title")
+                detail = item.get("evidence") or item.get("reason") or item.get("detail")
+                text = ": ".join(str(x) for x in (label, detail) if x)
+                if text:
+                    out.append(text)
+    return out
+
+
+def _read_json_sidecar(path: Path) -> tuple[dict, float]:
+    try:
+        mtime = path.stat().st_mtime
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}, 0.0
+    return (data, mtime) if isinstance(data, dict) else ({}, mtime)
+
+
+def _read_behavioral_gate(path: Path) -> tuple[str, float]:
+    try:
+        mtime = path.stat().st_mtime
+        txt = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return _QA_STATUS_UNKNOWN, 0.0
+    if "[FAIL]" in txt or "\nRED" in txt or txt.rstrip().endswith("RED"):
+        return "RED", mtime
+    if "[PASS]" in txt or "\nGREEN" in txt or txt.rstrip().endswith("GREEN"):
+        return "GREEN", mtime
+    return _QA_STATUS_UNKNOWN, mtime
+
+
 def _qa_scores(run: str) -> dict:
-    """The mechanical + story overall scores for a QA run, if its scorecards have been written
-    (post-play). Empty while the run is still playing. Read-only."""
-    out: dict = {}
-    tdir = _HERE.parent / "qa" / "transcripts"
-    for kind, fn in (("mechanical", f"{run}.score.json"), ("story", f"{run}.tolkien.json")):
-        p = tdir / fn
-        if p.exists():
-            try:
-                out[kind] = json.loads(p.read_text(encoding="utf-8")).get("overall")
-            except (json.JSONDecodeError, OSError):
-                pass
+    """Mechanical/story scores plus release-readiness statuses for a QA run. Missing readiness
+    sidecars are explicit UNKNOWN values, never treated as pass. Read-only and bounded to small
+    sidecar files; transcripts are not parsed on monitor polls."""
+    out: dict = {"behavioral": _QA_STATUS_UNKNOWN, "fiction": _QA_STATUS_UNKNOWN, "release": _QA_STATUS_UNKNOWN}
+    paths = _qa_sidecar_paths(run)
+    mechanical, _ = _read_json_sidecar(paths["mechanical"])
+    if mechanical:
+        out["mechanical"] = mechanical.get("overall")
+        out["behavioral"] = _qa_status_from_json(mechanical, out["behavioral"])
+    story, _ = _read_json_sidecar(paths["story"])
+    if story:
+        out["story"] = story.get("overall")
+    gate_status, _ = _read_behavioral_gate(paths["behavioral_gate"])
+    if gate_status != _QA_STATUS_UNKNOWN:
+        out["behavioral"] = gate_status
+    for kind in ("fiction", "release"):
+        data, _ = _read_json_sidecar(paths[kind])
+        if data:
+            out[kind] = _qa_status_from_json(data)
+    return out
+
+
+def _qa_release_readiness(run: str) -> dict:
+    paths = _qa_sidecar_paths(run)
+    out: dict = {"run_id": run, "blockers": []}
+    updated = 0.0
+    for p in paths.values():
+        try:
+            updated = max(updated, p.stat().st_mtime)
+        except OSError:
+            pass
+    release, _ = _read_json_sidecar(paths["release"])
+    fiction, _ = _read_json_sidecar(paths["fiction"])
+    blockers = _qa_blockers(release) + _qa_blockers(fiction)
+    if blockers:
+        out["blockers"] = blockers
+    cell = release.get("release_cell") or release.get("cell") or release.get("matrix_cell")
+    if cell:
+        out["release_cell"] = str(cell)
+    if updated:
+        out["readiness_updated_at"] = updated
     return out
 
 
@@ -366,6 +489,7 @@ def _monitor_card(label: str, snap: Path, data: dict) -> dict:
     if label.startswith("qa:"):
         run = label.split("qa:", 1)[1]
         card["scores"] = _qa_scores(run)
+        card.update(_qa_release_readiness(run))
         # a distilled transcript exists once the run finished playing -> the card becomes a
         # link to read the full story (the monitor's "jump in to give feedback" affordance).
         card["transcript"] = (_HERE.parent / "qa" / "transcripts" / f"{run}.md").is_file()
@@ -378,7 +502,7 @@ def _monitor_card(label: str, snap: Path, data: dict) -> dict:
 # grows linearly with QA runs. Cache the built card per snapshot path, keyed by its mtime
 # (save_campaign rewrites the snapshot on every mutation, so mtime bumps exactly when a campaign
 # advances). On a hit we skip the read/parse/glob and only refresh the time-relative `live` flag.
-_monitor_card_cache: dict[str, tuple[float, dict]] = {}
+_monitor_card_cache: dict[str, tuple[object, dict]] = {}
 
 
 def _monitor_campaigns() -> list[dict]:
@@ -397,8 +521,11 @@ def _monitor_campaigns() -> list[dict]:
             except OSError:
                 continue
             seen.add(key)
+            sig: object = mtime
+            if label.startswith("qa:"):
+                sig = (mtime, _qa_sidecar_signature(label.split("qa:", 1)[1]))
             cached = _monitor_card_cache.get(key)
-            if cached and cached[0] == mtime:
+            if cached and cached[0] == sig:
                 card = dict(cached[1])  # reuse the parsed card; only `live` is recomputed below
             else:
                 try:
@@ -411,7 +538,7 @@ def _monitor_campaigns() -> list[dict]:
                     card = _monitor_card(label, snap, data)
                 except (OSError, TypeError, ValueError):
                     continue  # one malformed campaign must never blank the whole monitor
-                _monitor_card_cache[key] = (mtime, dict(card))
+                _monitor_card_cache[key] = (sig, dict(card))
             card["live"] = (now - card.get("updated_at", 0)) < 90  # time-relative → always fresh
             cards.append(card)
     # Drop cache entries for snapshots that vanished (a deleted QA run) so it can't grow unbounded.


### PR DESCRIPTION
## Summary
- expose QA readiness sidecar statuses in `/monitor.json` alongside mechanical/story scores
- render concise behavioral/fiction/release badges in `viewer/monitor.html`, with missing sidecars shown as `UNKNOWN`
- include run id, release cell, blockers, readiness update time, and sidecar mtimes in monitor cache invalidation

## Validation
- `pwd && python3 -m py_compile viewer/server.py`
- `pwd && python3 -m pytest servers/engine/tests/test_qa_monitor.py -q`
- `git diff --check`

Refs #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added color-coded readiness status indicators (good, low, unknown) for QA campaign cards
  * Display release metadata, blocker information, and run IDs on QA campaign cards with color-coded visual hierarchy
  * Added optional blocker tooltips displaying up to three items for release readiness tracking

* **Tests**
  * Added comprehensive regression test suite for QA monitor functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->