### PR TITLE
feat(viewer): add contextual action bar

### DIFF
--- a/viewer/dashboard.html
+++ b/viewer/dashboard.html
@@ -121,6 +121,17 @@
   .cc-unit .meta { font-size:10.5px; color:var(--faint); margin-top:3px; display:flex; gap:6px; flex-wrap:wrap; }
   .cc-warn { grid-column:1 / -1; color:#e4b17f; font-size:11px; display:flex; gap:6px; flex-wrap:wrap; }
   .cc-warn span { border:1px solid #5a4020; background:#2a1c0e; border-radius:7px; padding:2px 7px; }
+  .action-bar { border-bottom:1px solid var(--line); background:#120d08; padding:8px 18px;
+    display:flex; align-items:center; gap:8px; overflow-x:auto; box-shadow:0 1px 0 rgba(232,201,138,.04) inset; }
+  .action-bar[hidden] { display:none; }
+  .action-group { display:flex; align-items:center; gap:6px; flex:none; }
+  .action-group + .action-group { border-left:1px solid #2e2416; padding-left:8px; }
+  .action-label { font-size:9px; letter-spacing:.1em; text-transform:uppercase; color:#b39c78; font-weight:800; }
+  .context-action { border:1px solid #3d3119; background:#1a140d; color:var(--ink); border-radius:8px;
+    padding:5px 9px; font-size:11.5px; line-height:1.1; cursor:pointer; white-space:nowrap; }
+  .context-action:hover { background:#2a1d0e; border-color:var(--gold2); }
+  .context-action:disabled { color:#9b8773; border-color:#32281a; background:#120e09; cursor:not-allowed; opacity:.72; }
+  .context-action .why { color:#c89084; font-size:10px; margin-left:5px; }
   .msg { max-width:760px; }
   .msg.narration, .msg.dialogue, .msg.combat, .msg.system { animation:msgin .25s ease; }
   @keyframes msgin { from { opacity:0; transform:translateY(4px); } to { opacity:1; transform:none; } }
@@ -760,6 +771,7 @@
       <span class="meta" id="when"></span><span class="meta" id="where"></span>
       <button class="gear-btn" id="gear-btn" title="Settings (read-only)" aria-label="Settings">⚙</button></div>
     <section class="combat-center" id="combat-center" hidden></section>
+    <section class="action-bar" id="action-bar" hidden></section>
     <div id="feed"><div class="empty">Waiting for the story to begin…</div></div>
     <div class="dice empty-state" id="dice"><span class="empty">No rolls yet — the dice are still.</span></div>
     <div class="palette">
@@ -1046,6 +1058,68 @@ function renderCombatCenter(s) {
     <div class="cc-order">${order || `<div class="empty">No initiative order.</div>`}</div>
     ${warnings}`;
   box.hidden = false;
+}
+
+function actionDisabledReason(action) {
+  if (!action) return "unavailable";
+  return action.disabled_reason || (action.available === false ? "unavailable" : "");
+}
+function handleContextAction(action) {
+  if (!action || action.available === false) return;
+  if (action.move) {
+    submitMove(action.move);
+    return;
+  }
+  if (action.ui === "focus-say" || action.ui === "focus-do") {
+    const ta = $("saytext");
+    if (ta) {
+      ta.focus();
+      if (action.ui === "focus-do" && !ta.value.trim()) ta.placeholder = "Describe a free-form action…";
+    }
+    return;
+  }
+  if (action.ui === "palette-skills") {
+    activeTab = "skills";
+    renderPalette();
+  } else if (action.ui === "palette-saves") {
+    activeTab = "saves";
+    renderPalette();
+  }
+}
+function renderActionBar(s) {
+  const bar = $("action-bar");
+  if (!bar) return;
+  const model = (s && s.action_model) || {};
+  const groups = (model.groups || []).filter(g => g && (g.id !== "combat" || (model.combat || {}).active));
+  if (!groups.length) {
+    bar.hidden = true;
+    bar.innerHTML = "";
+    return;
+  }
+  bar.innerHTML = "";
+  groups.forEach(group => {
+    const actions = (group.actions || []).filter(Boolean);
+    if (!actions.length) return;
+    const wrap = document.createElement("div");
+    wrap.className = "action-group";
+    const label = document.createElement("span");
+    label.className = "action-label";
+    label.textContent = group.label || group.id || "Actions";
+    wrap.appendChild(label);
+    actions.forEach(action => {
+      const reason = actionDisabledReason(action);
+      const btn = document.createElement("button");
+      btn.className = "context-action";
+      btn.type = "button";
+      btn.disabled = !!reason;
+      btn.title = reason || (action.move ? describeMove(action.move) : action.label || "Action");
+      btn.innerHTML = `${esc(action.label || "Action")}${reason ? ` <span class="why">${esc(reason)}</span>` : ""}`;
+      btn.onclick = () => handleContextAction(action);
+      wrap.appendChild(btn);
+    });
+    bar.appendChild(wrap);
+  });
+  bar.hidden = !bar.children.length;
 }
 // race + class line for a stat card, omitting whatever's blank (placeholder NPCs
 // carry empty race / [] classes — we don't want to print "Level 0" noise).
@@ -2044,6 +2118,7 @@ function renderState(s) {
     $("title").textContent = "ClawDnD";
     applyLiveMode(false);
     renderCombatCenter(s);
+    renderActionBar(s);
     const feed = $("feed");
     if (feed && !feed.children.length) feed.innerHTML = '<div class="empty">Waiting for the story to begin…</div>';
     return;
@@ -2054,6 +2129,7 @@ function renderState(s) {
   // server didn't send is_live_view.
   applyLiveMode((s.is_live_view !== undefined ? s.is_live_view : s.live) !== false);
   renderCombatCenter(s);
+  renderActionBar(s);
   if (activeView !== "play") renderSheet();   // keep an open sheet live across polls
   if ($("settings-scrim").classList.contains("open")) renderSettings();  // live while open
   $("title").textContent = s.title || "ClawDnD";

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -764,7 +764,8 @@ def build_action_model(snapshot: dict, *, live: bool, is_live_view: bool) -> dic
     disabled.
     """
     snapshot = snapshot if isinstance(snapshot, dict) else {}
-    has_campaign = bool(snapshot) and not snapshot.get("empty")
+    viewer_keys = {"action_model", "combat_view", "empty", "is_live_view", "live"}
+    has_campaign = any(k not in viewer_keys for k in snapshot) and not snapshot.get("empty")
     actor = _action_actor(snapshot) if has_campaign else None
     combat = snapshot.get("combat") if has_campaign else None
     combat_active = isinstance(combat, dict) and bool(combat.get("active"))

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -673,6 +673,199 @@ def build_combat_view(snapshot: dict) -> dict:
     return view
 
 
+def _action_actor(snapshot: dict) -> dict | None:
+    """Pick the player-facing actor for the action model from snapshot facts only."""
+    chars = snapshot.get("characters") if isinstance(snapshot, dict) else None
+    party = snapshot.get("party") if isinstance(snapshot, dict) else None
+    if not isinstance(chars, dict) or not isinstance(party, list):
+        return None
+    candidates = [chars.get(cid) for cid in party if isinstance(cid, str)]
+    actor = next((c for c in candidates if isinstance(c, dict) and c.get("kind") == "player"), None)
+    if actor is None:
+        actor = next((c for c in candidates if isinstance(c, dict)), None)
+    if actor is None:
+        return None
+    aid = actor.get("id")
+    if not isinstance(aid, str) or not aid.strip():
+        for cid in party:
+            if isinstance(cid, str) and chars.get(cid) is actor:
+                aid = cid
+                break
+    if not isinstance(aid, str) or not aid.strip():
+        return None
+    return {
+        "id": aid.strip(),
+        "name": str(actor.get("name") or aid).strip() or aid.strip(),
+        "kind": str(actor.get("kind") or "").strip(),
+    }
+
+
+def _combat_current_id(combat: object) -> str | None:
+    if not isinstance(combat, dict) or not combat.get("active"):
+        return None
+    order = combat.get("order")
+    turn_index = combat.get("turn_index")
+    if not isinstance(order, list) or not isinstance(turn_index, int) or isinstance(turn_index, bool):
+        return None
+    if not 0 <= turn_index < len(order):
+        return None
+    row = order[turn_index]
+    cid = row.get("character_id") if isinstance(row, dict) else None
+    return cid.strip() if isinstance(cid, str) and cid.strip() else None
+
+
+def _combat_row(combat: object, character_id: str | None) -> dict | None:
+    if not character_id or not isinstance(combat, dict):
+        return None
+    order = combat.get("order")
+    if not isinstance(order, list):
+        return None
+    for row in order:
+        if isinstance(row, dict) and row.get("character_id") == character_id:
+            return row
+    return None
+
+
+def _action_item(
+    action_id: str,
+    label: str,
+    *,
+    kind: str | None = None,
+    name: str | None = None,
+    text: str | None = None,
+    disabled_reason: str | None = None,
+    ui: str | None = None,
+) -> dict:
+    item = {
+        "id": action_id,
+        "label": label,
+        "available": disabled_reason is None,
+        "disabled_reason": disabled_reason,
+    }
+    move = {}
+    if kind:
+        move["kind"] = kind
+    if name:
+        move["name"] = name
+    if text:
+        move["text"] = text
+    if move:
+        item["move"] = move
+    if ui:
+        item["ui"] = ui
+    return item
+
+
+def build_action_model(snapshot: dict, *, live: bool, is_live_view: bool) -> dict:
+    """Derive a read-only dashboard action model from snapshot + move-sink facts.
+
+    This does not preview engine mutations. It only describes which existing
+    dashboard move intents are sensible to offer, and why unavailable actions are
+    disabled.
+    """
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    has_campaign = bool(snapshot) and not snapshot.get("empty")
+    actor = _action_actor(snapshot) if has_campaign else None
+    combat = snapshot.get("combat") if has_campaign else None
+    combat_active = isinstance(combat, dict) and bool(combat.get("active"))
+    current_id = _combat_current_id(combat)
+    actor_id = actor.get("id") if actor else None
+    is_current_turn = bool(actor_id and current_id and actor_id == current_id)
+    actor_row = _combat_row(combat, actor_id)
+
+    def global_reason() -> str | None:
+        if not has_campaign:
+            return "no active campaign"
+        if actor is None:
+            return "no active character"
+        if not live:
+            return "no live move sink"
+        if not is_live_view:
+            return "viewing non-live campaign"
+        return None
+
+    base_reason = global_reason()
+    action_available = False
+    bonus_available = False
+    reaction_available = False
+    if combat_active and actor is not None:
+        action_available = is_current_turn and not bool(combat.get("action_used"))
+        bonus_available = is_current_turn and not bool(combat.get("bonus_action_used"))
+        reaction_available = actor_row is not None and not bool(actor_row.get("reaction_used"))
+
+    def turn_action_reason(slot: str) -> str | None:
+        if not has_campaign:
+            return "no active campaign"
+        if not combat_active:
+            return "not in combat"
+        if actor is None:
+            return "no active character"
+        if base_reason:
+            return base_reason
+        if not is_current_turn:
+            return "not current turn"
+        if slot == "action" and not action_available:
+            return "action spent"
+        if slot == "bonus" and not bonus_available:
+            return "bonus action spent"
+        return None
+
+    def reaction_reason() -> str | None:
+        if not has_campaign:
+            return "no active campaign"
+        if not combat_active:
+            return "not in combat"
+        if actor is None:
+            return "no active character"
+        if actor_row is None:
+            return "not in combat"
+        if base_reason:
+            return base_reason
+        if not reaction_available:
+            return "reaction spent"
+        return None
+
+    model = {
+        "live": bool(live),
+        "is_live_view": bool(is_live_view),
+        "actor": actor,
+        "combat": {
+            "active": combat_active,
+            "round": _num(combat.get("round")) if isinstance(combat, dict) else None,
+            "current_actor_id": current_id,
+            "is_current_turn": is_current_turn,
+        },
+        "economy": {
+            "action_available": action_available,
+            "bonus_available": bonus_available,
+            "reaction_available": reaction_available,
+        },
+        "groups": [
+            {
+                "id": "exploration",
+                "label": "Explore",
+                "actions": [
+                    _action_item("continue", "Continue", kind="do", text="continue", disabled_reason=base_reason),
+                    _action_item("say", "Say", disabled_reason=base_reason, ui="focus-say"),
+                    _action_item("do", "Do", disabled_reason=base_reason, ui="focus-do"),
+                    _action_item("check", "Check", disabled_reason=base_reason, ui="palette-skills"),
+                    _action_item("save", "Save", disabled_reason=base_reason, ui="palette-saves"),
+                ],
+            },
+            {
+                "id": "combat",
+                "label": "Combat",
+                "actions": [
+                    _action_item("attack", "Attack", kind="attack", name="Attack", disabled_reason=turn_action_reason("action")),
+                    _action_item("bonus-action", "Bonus", kind="combat", name="Bonus Action", disabled_reason=turn_action_reason("bonus")),
+                    _action_item("reaction", "Reaction", kind="combat", name="Reaction", disabled_reason=reaction_reason()),
+                ],
+            },
+        ],
+    }
+    return model
+
+
 def _viewer_config() -> dict:
     """Read-only runtime facts for the quick-settings modal — voice backend + whether
     the voice server is present, and whether a live move sink is configured. Pure
@@ -1093,17 +1286,26 @@ class _Handler(BaseHTTPRequestHandler):
                 # No game on disk yet — serve a graceful empty state (the dashboard shows
                 # "Waiting for the story to begin…") instead of a blank read; we attach
                 # automatically once the DM mints the campaign.
-                self._json({"empty": True, "live": _live_play(), "combat_view": build_combat_view({})})
+                live = _live_play()
+                self._json({
+                    "empty": True,
+                    "live": live,
+                    "combat_view": build_combat_view({}),
+                    "action_model": build_action_model({}, live=live, is_live_view=False),
+                })
                 return
             snap = _read_snapshot(cid)
             if not isinstance(snap, dict):
                 snap = {}
+            live = _live_play()
+            is_live_view = live and cid == self.campaign_id
             snap["combat_view"] = build_combat_view(snap)
-            snap["live"] = _live_play()
+            snap["live"] = live
             # is_live_view: the move sink (CLAWDND_PLAYER_MOVES) belongs to the ATTACHED campaign;
             # a move only makes sense when the VIEWED campaign IS that one. The dashboard grays the
             # palette when this is false, so the switcher can't send moves to the wrong run (#49).
-            snap["is_live_view"] = _live_play() and cid == self.campaign_id
+            snap["is_live_view"] = is_live_view
+            snap["action_model"] = build_action_model(snap, live=live, is_live_view=is_live_view)
             self._json(snap)
         elif route == "/config":
             self._json(_viewer_config())

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1294,18 +1294,19 @@ class _Handler(BaseHTTPRequestHandler):
                     "action_model": build_action_model({}, live=live, is_live_view=False),
                 })
                 return
-            snap = _read_snapshot(cid)
-            if not isinstance(snap, dict):
-                snap = {}
+            raw_snap = _read_snapshot(cid)
+            if not isinstance(raw_snap, dict):
+                raw_snap = {}
             live = _live_play()
             is_live_view = live and cid == self.campaign_id
-            snap["combat_view"] = build_combat_view(snap)
+            snap = dict(raw_snap)
+            snap["combat_view"] = build_combat_view(raw_snap)
             snap["live"] = live
             # is_live_view: the move sink (CLAWDND_PLAYER_MOVES) belongs to the ATTACHED campaign;
             # a move only makes sense when the VIEWED campaign IS that one. The dashboard grays the
             # palette when this is false, so the switcher can't send moves to the wrong run (#49).
             snap["is_live_view"] = is_live_view
-            snap["action_model"] = build_action_model(snap, live=live, is_live_view=is_live_view)
+            snap["action_model"] = build_action_model(raw_snap, live=live, is_live_view=is_live_view)
             self._json(snap)
         elif route == "/config":
             self._json(_viewer_config())

--- a/viewer/tests/test_action_model.py
+++ b/viewer/tests/test_action_model.py
@@ -38,6 +38,15 @@ class ActionModelTests(unittest.TestCase):
         self.assertEqual(_action(model, "exploration", "continue")["disabled_reason"], "no live move sink")
         self.assertEqual(_action(model, "combat", "attack")["disabled_reason"], "not in combat")
 
+    def test_action_model_does_not_treat_viewer_only_keys_as_campaign(self):
+        model = server.build_action_model(
+            {"combat_view": {"active": False}, "live": False, "is_live_view": False},
+            live=False,
+            is_live_view=False,
+        )
+
+        self.assertEqual(_action(model, "exploration", "continue")["disabled_reason"], "no active campaign")
+
     def test_action_model_uses_combat_turn_and_action_economy(self):
         snapshot = {
             "party": ["pc"],

--- a/viewer/tests/test_action_model.py
+++ b/viewer/tests/test_action_model.py
@@ -16,6 +16,13 @@ def _action(model, group_id, action_id):
 
 
 class ActionModelTests(unittest.TestCase):
+    def test_action_model_treats_viewer_only_empty_state_as_no_campaign(self):
+        raw_model = server.build_action_model({}, live=True, is_live_view=True)
+
+        self.assertIsNone(raw_model["actor"])
+        self.assertEqual(_action(raw_model, "exploration", "continue")["disabled_reason"], "no active campaign")
+        self.assertEqual(_action(raw_model, "combat", "attack")["disabled_reason"], "no active campaign")
+
     def test_action_model_disables_exploration_without_live_move_sink(self):
         snapshot = {
             "title": "Cellar Rats",

--- a/viewer/tests/test_action_model.py
+++ b/viewer/tests/test_action_model.py
@@ -1,0 +1,105 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(server)
+
+
+def _action(model, group_id, action_id):
+    group = next(g for g in model["groups"] if g["id"] == group_id)
+    return next(a for a in group["actions"] if a["id"] == action_id)
+
+
+class ActionModelTests(unittest.TestCase):
+    def test_action_model_disables_exploration_without_live_move_sink(self):
+        snapshot = {
+            "title": "Cellar Rats",
+            "party": ["pc"],
+            "characters": {"pc": {"id": "pc", "name": "Vela", "kind": "player"}},
+        }
+
+        model = server.build_action_model(snapshot, live=False, is_live_view=False)
+
+        self.assertEqual(model["actor"], {"id": "pc", "name": "Vela", "kind": "player"})
+        self.assertIs(model["live"], False)
+        self.assertIs(model["is_live_view"], False)
+        self.assertEqual(_action(model, "exploration", "continue")["disabled_reason"], "no live move sink")
+        self.assertEqual(_action(model, "combat", "attack")["disabled_reason"], "not in combat")
+
+    def test_action_model_uses_combat_turn_and_action_economy(self):
+        snapshot = {
+            "party": ["pc"],
+            "characters": {
+                "pc": {"id": "pc", "name": "Vela", "kind": "player"},
+                "gob": {"id": "gob", "name": "Goblin", "kind": "monster"},
+            },
+            "combat": {
+                "active": True,
+                "round": 2,
+                "turn_index": 0,
+                "action_used": True,
+                "bonus_action_used": False,
+                "order": [
+                    {"character_id": "pc", "initiative": 18, "reaction_used": True},
+                    {"character_id": "gob", "initiative": 9},
+                ],
+            },
+        }
+
+        model = server.build_action_model(snapshot, live=True, is_live_view=True)
+
+        self.assertEqual(
+            model["combat"],
+            {
+                "active": True,
+                "round": 2,
+                "current_actor_id": "pc",
+                "is_current_turn": True,
+            },
+        )
+        self.assertEqual(
+            model["economy"],
+            {
+                "action_available": False,
+                "bonus_available": True,
+                "reaction_available": False,
+            },
+        )
+        self.assertEqual(_action(model, "combat", "attack")["disabled_reason"], "action spent")
+        self.assertIsNone(_action(model, "combat", "bonus-action")["disabled_reason"])
+        self.assertEqual(_action(model, "combat", "reaction")["disabled_reason"], "reaction spent")
+
+    def test_action_model_marks_party_actor_waiting_for_turn(self):
+        snapshot = {
+            "party": ["pc"],
+            "characters": {
+                "pc": {"id": "pc", "name": "Vela", "kind": "player"},
+                "gob": {"id": "gob", "name": "Goblin", "kind": "monster"},
+            },
+            "combat": {
+                "active": True,
+                "turn_index": 1,
+                "action_used": False,
+                "bonus_action_used": False,
+                "order": [
+                    {"character_id": "pc", "initiative": 18, "reaction_used": False},
+                    {"character_id": "gob", "initiative": 9},
+                ],
+            },
+        }
+
+        model = server.build_action_model(snapshot, live=True, is_live_view=True)
+
+        self.assertEqual(model["combat"]["current_actor_id"], "gob")
+        self.assertIs(model["combat"]["is_current_turn"], False)
+        self.assertEqual(_action(model, "combat", "attack")["disabled_reason"], "not current turn")
+        self.assertIsNone(_action(model, "combat", "reaction")["disabled_reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a read-only `action_model` to `/state` with actor, live-view, combat, action-economy, grouped action availability, and concise disabled reasons
- render a compact contextual action bar in `viewer/dashboard.html` from that model
- keep actions on existing `/move` intent paths only; missing or read-only state renders disabled instead of adding engine mutation endpoints

## Validation

- `python3 -m py_compile viewer/server.py`
- `python3 -m unittest viewer.tests.test_action_model`
- `git diff --check`
- Browser smoke: ran `python3 viewer/server.py smoke 9876` against a throwaway snapshot under `/Volumes/LEXAR/Codex/clawdnd-context-smoke/state`; verified dashboard rendered the combat command center and contextual action bar with disabled `no live move sink` reasons and no move sink configured.

Refs #80


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an action bar to the dashboard displaying available in-game actions that updates dynamically
  * Actions show disabled states with explanatory labels when unavailable
  * Users can interact with actions to execute moves, focus input fields, or switch action palette tabs as needed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/91?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->