### PR TITLE
feat(strategy): seed optional strategic state

### DIFF
--- a/content/worlds/README.md
+++ b/content/worlds/README.md
@@ -37,6 +37,7 @@ content/worlds/_private/<id>/   # gitignored — personal seeds (e.g. third-part
 | `npc_roster` | object[] | `{id, name, voice_id, role, personality, hook, dossier?}` → seeded as **NPC Characters** (the `hook` becomes a memory fact; "pullable" — the DM brings them in or invents freely). The optional `dossier` is a **companion dossier** (see below). |
 | `story_seeds` | string[] | emergent hooks the player can stumble into (returned by `start_world`, not auto-created as quests) |
 | `quest_variants` | object[]? | the replayability layer — each MAJOR quest's outcome, resolved once at world-gen. `{id, name, outcomes[{id, when?:{facts-subset} OR random:<weight>, lore, hook?}]}`. An outcome with a `when` dict that is a subset of the world-state (the chosen ending's `facts` + the `world_tenor` dial) is ENDING-TIED (first match wins); otherwise a seeded weighted roll picks among the `random` outcomes. The resolved outcome lands on `Campaign.quest_outcomes[id]` and its `lore`/`hook` are appended to recallable lore as `[Outcome] …` / `[Hook] …` lines. Absent -> no resolution (today's behavior). Read via `get_quest_outcomes`. |
+| `strategic` | object? | optional strategy-board seed — setting-agnostic regions/assets/clocks/projects copied into `Campaign.strategic_state`. Missing -> empty state. Malformed entries or unknown faction/location refs are skipped with diagnostics. See Strategic state below. |
 | `starting_options` | object[] | `{location_id, framing}` — where the DM can drop the party |
 | `dm_guidance` | string | how to run this world as a living sandbox |
 | `license`, `attribution` | string? | for non-original seeds (see Licensing) |
@@ -88,6 +89,84 @@ systems to act on, not a biography). A malformed dossier block **degrades** (the
 simply gets none) and never aborts world creation, exactly like a malformed `companion_seeds`
 arc. Committed content is still strictly validated (a typo'd field name is rejected at
 author time via `extra="forbid"`), so a bad dossier in a shipped seed shows up in tests.
+
+## Strategic state (optional, additive)
+
+`strategic` seeds a compact strategy board for world-level pressure, control, assets, and
+downtime work. It is **not** `world_state`: `world_state` is the canonical fact header for
+the current timeline, while `strategic_state` is mutable campaign board state that future
+systems may advance. This first slice only loads and persists it; clock ticking and project
+advancement are intentionally out of scope.
+
+Shape:
+
+```json
+{
+  "strategic": {
+    "regions": [
+      {
+        "location_id": "loc-brassmoor",
+        "controller_id": "fac-concord",
+        "influence": {"fac-concord": 70},
+        "stability": 55,
+        "unrest": 20,
+        "tags": ["capital"],
+        "note": "The League holds the council chambers."
+      }
+    ],
+    "assets": [
+      {
+        "id": "asset-lantern-wardens",
+        "faction_id": "fac-lantern",
+        "name": "Lantern Wardens",
+        "kind": "army",
+        "location_id": "loc-vaels-crossing",
+        "strength": 2,
+        "tags": ["patrol"],
+        "note": "A small but trusted defensive force."
+      }
+    ],
+    "clocks": [
+      {
+        "id": "clock-seal-thins",
+        "title": "The seal thins",
+        "kind": "threat",
+        "scope": "region",
+        "region_id": "loc-vaels-crossing",
+        "progress": 1,
+        "target": 6,
+        "tick_every_days": 4,
+        "note": "Advance only when a future system owns ticking."
+      }
+    ],
+    "projects": [
+      {
+        "id": "proj-survey-seal",
+        "title": "Survey the seal",
+        "kind": "research",
+        "location_id": "loc-vaels-crossing",
+        "duration_days": 7,
+        "status": "planned",
+        "note": "A downtime lead, not an active quest."
+      }
+    ]
+  }
+}
+```
+
+Closed values:
+
+- asset `kind`: `army`, `agent`, `holding`, `resource`, `influence`, `supply`, `special`
+- clock `kind`: `threat`, `opportunity`, `mystery`, `faction`, `project`
+- clock `scope`: `world`, `region`, `faction`
+- project `kind`: `research`, `construction`, `training`, `diplomacy`, `recovery`, `crafting`, `other`
+- project `status`: `planned`, `active`, `paused`, `complete`, `failed`
+
+Reference rules: `regions[].location_id`, `assets[].faction_id`, `assets[].location_id`,
+`clocks[].region_id`, `clocks[].faction_id`, `projects[].location_id`, and
+`projects[].faction_id` must point at seeded regions/locations or factions when present.
+Unknown references and malformed optional entries are skipped with `[content]` diagnostics
+instead of aborting `start_world`.
 
 ## Licensing (each seed needs a `LICENSE.md`)
 

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -24,9 +24,13 @@ from models import (
     CompanionArc,
     CompanionDossier,
     Character,
+    DowntimeProject,
     Faction,
+    FactionAsset,
     Location,
     Quest,
+    RegionControl,
+    StrategicClock,
     WorldState,
 )
 from store import safe_path_segment  # path-containment guard for world/adventure ids
@@ -670,6 +674,113 @@ def _apply_ending_overlay(c: Campaign, overlay: dict) -> None:
                 ch.companion_dossier = dossier
 
 
+def _seed_strategic_state(c: Campaign, world: dict) -> None:
+    """Seed optional strategic board data from world.json.
+
+    The block is additive and externally-authored, so it mirrors the existing
+    world_state/companion_seeds contract: malformed entries or references to
+    missing factions/locations are skipped with diagnostics, never partially bound.
+    """
+    raw = world.get("strategic")
+    if raw is None:
+        return
+    if not isinstance(raw, dict):
+        print("[content] skipping malformed strategic block (not an object)")
+        return
+
+    def _missing_locations(ids: list[str]) -> list[str]:
+        return [x for x in ids if x and x not in c.locations]
+
+    def _missing_factions(ids: list[str]) -> list[str]:
+        return [x for x in ids if x and x not in c.factions]
+
+    for entry in _as_list_lenient(raw, "regions"):
+        if not isinstance(entry, dict):
+            print("[content] skipping strategic region (not an object)")
+            continue
+        try:
+            region = RegionControl.model_validate(entry)
+        except (ValidationError, ValueError, TypeError):
+            print("[content] skipping malformed strategic region")
+            continue
+        missing_locs = _missing_locations([region.location_id])
+        missing_factions = _missing_factions([region.controller_id, *region.influence.keys()])
+        if missing_locs or missing_factions:
+            print(
+                "[content] skipping strategic region "
+                f"{region.location_id!r}: unknown refs "
+                f"locations={missing_locs} factions={missing_factions}"
+            )
+            continue
+        c.strategic_state.regions[region.location_id] = region
+
+    for entry in _as_list_lenient(raw, "assets"):
+        if not isinstance(entry, dict):
+            print("[content] skipping strategic asset (not an object)")
+            continue
+        try:
+            asset = FactionAsset.model_validate(entry)
+        except (ValidationError, ValueError, TypeError):
+            print("[content] skipping malformed strategic asset")
+            continue
+        missing_locs = _missing_locations([asset.location_id])
+        missing_factions = _missing_factions([asset.faction_id])
+        if missing_locs or missing_factions:
+            print(
+                "[content] skipping strategic asset "
+                f"{asset.id!r}: unknown refs "
+                f"locations={missing_locs} factions={missing_factions}"
+            )
+            continue
+        c.strategic_state.assets[asset.id] = asset
+
+    for entry in _as_list_lenient(raw, "clocks"):
+        if not isinstance(entry, dict):
+            print("[content] skipping strategic clock (not an object)")
+            continue
+        try:
+            clock = StrategicClock.model_validate(entry)
+        except (ValidationError, ValueError, TypeError):
+            print("[content] skipping malformed strategic clock")
+            continue
+        if clock.scope == "region" and not clock.region_id:
+            print(f"[content] skipping strategic clock {clock.id!r}: missing region_id")
+            continue
+        if clock.scope == "faction" and not clock.faction_id:
+            print(f"[content] skipping strategic clock {clock.id!r}: missing faction_id")
+            continue
+        missing_locs = _missing_locations([clock.region_id])
+        missing_factions = _missing_factions([clock.faction_id])
+        if missing_locs or missing_factions:
+            print(
+                "[content] skipping strategic clock "
+                f"{clock.id!r}: unknown refs "
+                f"locations={missing_locs} factions={missing_factions}"
+            )
+            continue
+        c.strategic_state.clocks[clock.id] = clock
+
+    for entry in _as_list_lenient(raw, "projects"):
+        if not isinstance(entry, dict):
+            print("[content] skipping strategic project (not an object)")
+            continue
+        try:
+            project = DowntimeProject.model_validate(entry)
+        except (ValidationError, ValueError, TypeError):
+            print("[content] skipping malformed strategic project")
+            continue
+        missing_locs = _missing_locations([project.location_id])
+        missing_factions = _missing_factions([project.faction_id])
+        if missing_locs or missing_factions:
+            print(
+                "[content] skipping strategic project "
+                f"{project.id!r}: unknown refs "
+                f"locations={missing_locs} factions={missing_factions}"
+            )
+            continue
+        c.strategic_state.projects[project.id] = project
+
+
 def _seed_campaign_backlog(c: Campaign, world: dict) -> None:
     """Seed the PROACTIVE living-world backlog (P0) — the world's own off-screen to-do, so the
     campaign advances when in-fiction time passes (P1 tick_backlog) instead of only reacting to
@@ -980,6 +1091,8 @@ def seed_world(world: dict, start_at: str = "", ending: str = "") -> Campaign:
         if fac.get("id"):
             faction.id = fac["id"]
         c.factions[faction.id] = faction
+
+    _seed_strategic_state(c, world)
 
     # Roster NPCs exist in state (recallable, voiced) but are not party members — the
     # DM pulls them in or invents freely. Each NPC's hook is stored as a memory fact.

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -644,6 +644,90 @@ class WorldState(_StrictModel):
         )
 
 
+class StrategicClock(_StrictModel):
+    """A setting-agnostic strategic pressure clock.
+
+    Inert in this slice: content may seed it and snapshots persist it, but no engine
+    tick/advancement logic consumes it yet (#75 owns advancement)."""
+
+    id: str = Field(default_factory=lambda: _new_id("clock"))
+    title: str
+    kind: Literal["threat", "opportunity", "mystery", "faction", "project"] = "threat"
+    scope: Literal["world", "region", "faction"] = "world"
+    region_id: str = ""  # ref into Campaign.locations when scope/binding is regional
+    faction_id: str = ""  # ref into Campaign.factions when scope/binding is factional
+    progress: int = Field(0, ge=0)
+    target: int = Field(6, ge=1)
+    tick_every_days: int = Field(0, ge=0)  # 0 = manual/no schedule in this first slice
+    note: str = ""
+
+    @model_validator(mode="after")
+    def _progress_cannot_exceed_target(self) -> "StrategicClock":
+        self.progress = min(self.progress, self.target)
+        return self
+
+
+class FactionAsset(_StrictModel):
+    """A compact strategic asset owned by a faction.
+
+    The engine stores ownership/location/strength only; authored names and notes carry
+    the flavor so the model stays portable across settings."""
+
+    id: str = Field(default_factory=lambda: _new_id("asset"))
+    faction_id: str
+    name: str
+    kind: Literal["army", "agent", "holding", "resource", "influence", "supply", "special"] = "special"
+    location_id: str = ""  # optional ref into Campaign.locations
+    strength: int = Field(1, ge=0)
+    tags: list[str] = Field(default_factory=list)
+    note: str = ""
+
+
+class RegionControl(_StrictModel):
+    """Strategic control state for one seeded Location/region."""
+
+    location_id: str
+    controller_id: str = ""  # optional ref into Campaign.factions
+    influence: dict[str, int] = Field(default_factory=dict)  # faction_id -> 0..100-ish authored score
+    stability: int = Field(50, ge=0, le=100)
+    unrest: int = Field(0, ge=0, le=100)
+    tags: list[str] = Field(default_factory=list)
+    note: str = ""
+
+
+class DowntimeProject(_StrictModel):
+    """A strategic downtime project record.
+
+    This slice persists authored projects only; project advancement is out of scope."""
+
+    id: str = Field(default_factory=lambda: _new_id("proj"))
+    title: str
+    kind: Literal["research", "construction", "training", "diplomacy", "recovery", "crafting", "other"] = "other"
+    location_id: str = ""  # optional ref into Campaign.locations
+    faction_id: str = ""  # optional ref into Campaign.factions
+    progress_days: int = Field(0, ge=0)
+    duration_days: int = Field(1, ge=1)
+    status: Literal["planned", "active", "paused", "complete", "failed"] = "planned"
+    note: str = ""
+
+    @model_validator(mode="after")
+    def _progress_cannot_exceed_duration(self) -> "DowntimeProject":
+        self.progress_days = min(self.progress_days, self.duration_days)
+        return self
+
+
+class StrategicState(_StrictModel):
+    """The campaign's optional strategic board.
+
+    Empty defaults are additive: old snapshots that lack this field deserialize with an
+    empty board, and worlds without a `strategic` block seed unchanged."""
+
+    regions: dict[str, RegionControl] = Field(default_factory=dict)  # location_id -> control
+    assets: dict[str, FactionAsset] = Field(default_factory=dict)  # asset id -> asset
+    clocks: dict[str, StrategicClock] = Field(default_factory=dict)  # clock id -> clock
+    projects: dict[str, DowntimeProject] = Field(default_factory=dict)  # project id -> project
+
+
 class BacklogItem(_StrictModel):
     """A goal-traced unit of PROACTIVE world-work — the world's own to-do, so the campaign
     advances off-screen when in-fiction time passes instead of only reacting to the player.
@@ -799,6 +883,7 @@ class Campaign(_StrictModel):
     # spine quest_hooks (so item #1 traces to a real arc anchor). Engine sole-writer; kept a
     # strict sibling of consequences/worldsim threads (never consumed by consequences.due).
     campaign_backlog: CampaignBacklog = Field(default_factory=CampaignBacklog)
+    strategic_state: StrategicState = Field(default_factory=StrategicState)
 
     characters: dict[str, Character] = Field(default_factory=dict)  # id -> Character (PCs, companion, NPCs)
     party: list[str] = Field(default_factory=list)  # character ids that are PCs / companions

--- a/servers/engine/tests/test_content.py
+++ b/servers/engine/tests/test_content.py
@@ -105,6 +105,115 @@ def test_start_world_seeds_living_world_and_lore_is_recallable(tmp_path, monkeyp
     assert hits and any(h["kind"] == "lore" for h in hits)
 
 
+def test_seed_world_seeds_strategic_state_additively(capsys):
+    world = {
+        "id": "strategy-test",
+        "name": "Strategy Test",
+        "premise": "A compact strategic fixture.",
+        "era": "now",
+        "regions": [
+            {"id": "loc-harbor", "name": "Harbor", "description": "docks", "connections": []},
+            {"id": "loc-hill", "name": "Hill", "description": "watchpost", "connections": []},
+        ],
+        "factions": [
+            {"id": "fac-civic", "name": "Civic League", "description": "wardens", "reputation": 3},
+            {"id": "fac-rivals", "name": "Rival Compact", "description": "claimants", "reputation": -2},
+        ],
+        "npc_roster": [],
+        "history": [],
+        "standing_threads": [],
+        "starting_options": [{"location_id": "loc-harbor", "framing": "Start at the harbor."}],
+        "strategic": {
+            "regions": [
+                {
+                    "location_id": "loc-harbor",
+                    "controller_id": "fac-civic",
+                    "influence": {"fac-civic": 70, "fac-rivals": 20},
+                    "stability": 55,
+                    "unrest": 20,
+                },
+                {
+                    "location_id": "loc-missing",
+                    "controller_id": "fac-civic",
+                    "influence": {"fac-civic": 10},
+                },
+            ],
+            "assets": [
+                {
+                    "id": "asset-wardens",
+                    "faction_id": "fac-civic",
+                    "name": "Harbor Wardens",
+                    "kind": "army",
+                    "location_id": "loc-harbor",
+                    "strength": 2,
+                },
+                {
+                    "id": "asset-unknown",
+                    "faction_id": "fac-missing",
+                    "name": "Unbound Asset",
+                    "kind": "army",
+                    "location_id": "loc-harbor",
+                },
+                {"id": "asset-bad-kind", "faction_id": "fac-civic", "name": "Bad", "kind": "fleet"},
+            ],
+            "clocks": [
+                {
+                    "id": "clock-rivals",
+                    "title": "Rivals gather leverage",
+                    "kind": "threat",
+                    "scope": "region",
+                    "region_id": "loc-hill",
+                    "progress": 1,
+                    "target": 6,
+                    "tick_every_days": 4,
+                },
+                {
+                    "id": "clock-unbound",
+                    "title": "Missing place",
+                    "kind": "threat",
+                    "scope": "region",
+                    "region_id": "loc-missing",
+                },
+            ],
+            "projects": [
+                {
+                    "id": "proj-repair",
+                    "title": "Repair the quay",
+                    "kind": "construction",
+                    "location_id": "loc-harbor",
+                    "duration_days": 7,
+                },
+                {
+                    "id": "proj-unbound",
+                    "title": "Unknown sponsor",
+                    "kind": "research",
+                    "faction_id": "fac-missing",
+                    "duration_days": 3,
+                },
+            ],
+        },
+    }
+
+    c = content.seed_world(world)
+
+    assert set(c.strategic_state.regions) == {"loc-harbor"}
+    region = c.strategic_state.regions["loc-harbor"]
+    assert region.controller_id == "fac-civic"
+    assert region.influence == {"fac-civic": 70, "fac-rivals": 20}
+    assert c.strategic_state.assets["asset-wardens"].strength == 2
+    assert set(c.strategic_state.assets) == {"asset-wardens"}
+    assert c.strategic_state.clocks["clock-rivals"].target == 6
+    assert set(c.strategic_state.clocks) == {"clock-rivals"}
+    assert c.strategic_state.projects["proj-repair"].duration_days == 7
+    assert set(c.strategic_state.projects) == {"proj-repair"}
+
+    out = capsys.readouterr().out
+    assert "skipping strategic region" in out
+    assert "skipping strategic asset" in out
+    assert "skipping strategic clock" in out
+    assert "skipping strategic project" in out
+
+
 def test_seed_world_rejects_unknown_start(tmp_path, monkeypatch):
     w = content.load_world_data("sundered-reach")
     with pytest.raises(ValueError, match="not a region"):

--- a/servers/engine/tests/test_engine.py
+++ b/servers/engine/tests/test_engine.py
@@ -1,8 +1,10 @@
+import json
+
 import pytest
 from pydantic import ValidationError
 
 import store
-from models import Ability, Campaign, Character, Condition
+from models import Ability, Campaign, Character, Condition, StrategicClock
 
 
 @pytest.fixture(autouse=True)
@@ -18,6 +20,28 @@ def test_campaign_roundtrip():
     assert loaded is not None
     assert loaded.title == "Test Hold"
     assert loaded.id == c.id
+
+
+def test_campaign_roundtrips_with_empty_strategic_state():
+    c = Campaign(title="Strategic Default")
+    assert c.strategic_state.model_dump(mode="json") == {
+        "regions": {},
+        "assets": {},
+        "clocks": {},
+        "projects": {},
+    }
+
+    store.save_campaign(c)
+    loaded = store.load_campaign(c.id)
+    assert loaded is not None
+    assert loaded.strategic_state.model_dump(mode="json") == c.strategic_state.model_dump(mode="json")
+    snapshot = store._campaign_dir(c.id) / "snapshot.json"
+    assert "strategic_state" in json.loads(snapshot.read_text(encoding="utf-8"))
+
+    old = c.model_dump(mode="json")
+    old.pop("strategic_state")
+    reloaded = Campaign.model_validate(old)
+    assert reloaded.strategic_state.model_dump(mode="json") == c.strategic_state.model_dump(mode="json")
 
 
 def test_load_missing_returns_none():
@@ -99,6 +123,12 @@ def test_condition_enum_validates():
     assert Condition("prone") == Condition.PRONE
     with pytest.raises(ValueError):
         Condition("bogus")
+
+
+def test_strategic_clock_enum_validates():
+    assert StrategicClock(title="A threat", kind="threat", scope="region").kind == "threat"
+    with pytest.raises(ValidationError):
+        StrategicClock(title="Bad", kind="rumor", scope="region")
 
 
 def test_engine_tools_end_to_end():


### PR DESCRIPTION
## Summary
- add strict StrategicState models for clocks, faction assets, region control, and downtime projects
- persist an empty strategic_state on Campaign for new snapshots while old snapshots default cleanly
- seed optional world.json strategic blocks with diagnostics for malformed or unbound entries
- document the optional strategic schema and closed values

## Validation
- pwd && uv run --directory servers/engine --group dev pytest -q tests/test_content.py::test_seed_world_seeds_strategic_state_additively tests/test_engine.py::test_campaign_roundtrips_with_empty_strategic_state tests/test_engine.py::test_strategic_clock_enum_validates
- pwd && uv run --directory servers/engine python -m py_compile models.py content.py && git diff --check

Refs #74