### PR TITLE
feat(combat): emit structured combat event cards

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import time
 from enum import Enum
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -564,6 +564,7 @@ class SessionLogEntry(_StrictModel):
     kind: str = "narration"  # narration | dialogue | roll | system | combat
     text: str
     speaker: Optional[str] = None  # character id or name
+    payload: Optional[dict[str, Any]] = None
 
 
 class Consequence(_StrictModel):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -93,6 +93,32 @@ def _char(c: Campaign, character_id: str) -> Character:
     return ch
 
 
+_COMBAT_EVENT_SCHEMA = "clawdnd.combat_event.v1"
+
+
+def _combatant_ref(ch: Character) -> dict:
+    return {"id": ch.id, "name": ch.name}
+
+
+def _log_session_entry(
+    c: Campaign,
+    *,
+    kind: str,
+    text: str,
+    speaker: str = "",
+    payload: Optional[dict] = None,
+) -> SessionLogEntry:
+    sid = _ensure_session(c)
+    entry = SessionLogEntry(kind=kind, text=text, speaker=speaker or None, payload=payload)
+    append_log(c.id, sid, entry)
+    return entry
+
+
+def _log_combat_event(c: Campaign, text: str, payload: dict, speaker: str = "") -> None:
+    payload.setdefault("schema", _COMBAT_EVENT_SCHEMA)
+    _log_session_entry(c, kind="combat", text=text, speaker=speaker, payload=payload)
+
+
 def _backlog_line(item: BacklogItem) -> str:
     """The DM-facing one-liner for a fired proactive-backlog development — what the world did
     off-screen, for the DM to weave into the scene (a crier's notice, a changed face, a door now
@@ -1830,6 +1856,22 @@ def start_combat(campaign_id: str, combatant_ids: list[str]) -> dict:
               if c.characters.get(cid) is not None and int(getattr(c.characters[cid], "extra_attacks", 0)) > 0]
         if ea:
             view["extra_attack_reminder"] = ea
+        ordered = [
+            {
+                "id": cb.character_id,
+                "name": c.characters[cb.character_id].name,
+                "initiative": cb.initiative,
+            }
+            for cb in c.combat.order
+            if cb.character_id in c.characters
+        ]
+        names = ", ".join(item["name"] for item in ordered)
+        _log_combat_event(
+            c,
+            f"Combat begins: {names}.",
+            {"event": "combat_start", "round": c.combat.round, "combatants": ordered},
+        )
+        save_campaign(c)
         return view
 
 
@@ -2259,6 +2301,38 @@ def attack(
             kx = _award_kill_xp(c, target)
             if kx:
                 result["kill_xp"] = kx
+        outcome_label = "crit" if is_crit else ("hit" if hit else "miss")
+        if hit and result["damage"]:
+            dtype = f" {damage_type}" if damage_type else ""
+            text = (
+                f"{attacker.name} critically hits {target.name} for "
+                f"{result['damage']['total']}{dtype} damage."
+                if is_crit
+                else f"{attacker.name} hits {target.name} for {result['damage']['total']}{dtype} damage."
+            )
+        else:
+            text = f"{attacker.name} misses {target.name}."
+        _log_combat_event(
+            c,
+            text,
+            {
+                "event": "attack",
+                "outcome": outcome_label,
+                "actor": _combatant_ref(attacker),
+                "target": {**_combatant_ref(target), "ac": target.armor_class},
+                "roll": {
+                    "total": atk.total,
+                    "natural": atk.natural,
+                    "detail": atk.detail,
+                    "attack_bonus": attack_bonus,
+                    "advantage": adv,
+                    "disadvantage": dis,
+                },
+                "damage": result["damage"],
+                "target_state": result.get("target_state"),
+            },
+            speaker=attacker.name,
+        )
         # Persist regardless of hit/miss: a miss still consumed the action/reaction
         # economy above, and that bookkeeping must survive (sole-writer discipline).
         save_campaign(c)
@@ -2283,6 +2357,21 @@ def apply_damage(
         kx = _award_kill_xp(c, target)
         if kx:
             out["kill_xp"] = kx
+        dtype = f" {damage_type}" if damage_type else ""
+        _log_combat_event(
+            c,
+            f"{target.name} takes {out.get('damage_to_hp', 0)}{dtype} damage.",
+            {
+                "event": "damage",
+                "target": _combatant_ref(target),
+                "amount": amount,
+                "damage_type": damage_type,
+                "crit": crit,
+                "half": half,
+                "result": out,
+            },
+            speaker=target.name,
+        )
         save_campaign(c)
         return out
 
@@ -2293,7 +2382,19 @@ def apply_healing(campaign_id: str, target_id: str, amount: int) -> dict:
     and resets death saves. Cannot revive the dead."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
-        out = combat.apply_healing(_char(c, target_id), amount)
+        target = _char(c, target_id)
+        out = combat.apply_healing(target, amount)
+        _log_combat_event(
+            c,
+            f"{target.name} regains {out.get('healed', 0)} hit points.",
+            {
+                "event": "healing",
+                "target": _combatant_ref(target),
+                "amount": amount,
+                "result": out,
+            },
+            speaker=target.name,
+        )
         save_campaign(c)
         return out
 
@@ -2421,6 +2522,7 @@ def end_combat(campaign_id: str) -> dict:
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         result: dict = {"active": False}
+        was_active = c.combat.active
         # Backstop sweep: award XP for any dead monsters still in the order that weren't
         # caught by the kill-time _award_kill_xp calls (their xp_value is already 0 in
         # the normal case — so this loop is mostly a no-op after kill-time awarding). It
@@ -2438,6 +2540,22 @@ def end_combat(campaign_id: str) -> dict:
             if all_total > 0:
                 result["xp_awarded"] = all_total
                 result["grants"] = all_grants
+        if was_active or c.combat.order:
+            ended_order = [
+                _combatant_ref(c.characters[cb.character_id])
+                for cb in c.combat.order
+                if cb.character_id in c.characters
+            ]
+            _log_combat_event(
+                c,
+                "Combat ends.",
+                {
+                    "event": "combat_end",
+                    "round": c.combat.round,
+                    "combatants": ended_order,
+                    "xp_awarded": result.get("xp_awarded", 0),
+                },
+            )
         c.combat = Combat()
         save_campaign(c)
         return result
@@ -3877,17 +3995,15 @@ def end_session(campaign_id: str, summary: str = "") -> dict:
 
 
 @mcp.tool()
-def log_event(campaign_id: str, kind: str, text: str, speaker: str = "") -> dict:
+def log_event(campaign_id: str, kind: str, text: str, speaker: str = "", payload: Optional[dict] = None) -> dict:
     """Record a story beat in the current session log (kind: narration | dialogue
     | roll | system | combat). Auto-starts a session if none is active. Powers
     recaps and post-compaction recovery."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
-        sid = _ensure_session(c)
+        entry = _log_session_entry(c, kind=kind, text=text, speaker=speaker, payload=payload)
         save_campaign(c)
-        entry = SessionLogEntry(kind=kind, text=text, speaker=speaker or None)
-        append_log(campaign_id, sid, entry)
-        return {"session_id": sid, "logged": entry.model_dump()}
+        return {"session_id": c.active_session_id, "logged": entry.model_dump()}
 
 
 @mcp.tool()

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -3,6 +3,7 @@ import pytest
 import combat
 from dice import DiceRoll
 from models import ActiveEffect, Character, Condition
+import store
 
 
 def mk(**kw) -> Character:
@@ -19,6 +20,20 @@ def _ds(total: int, natural: int) -> DiceRoll:
         crit=(natural == 20),
         fumble=(natural == 1),
     )
+
+
+def _fixed_roll(expression: str, advantage: bool = False, disadvantage: bool = False, seed: int | None = None) -> DiceRoll:
+    if expression.startswith("1d20"):
+        return DiceRoll(
+            expression=expression,
+            total=20,
+            rolls=[15],
+            modifier=5,
+            detail=f"{expression}[15] = 20",
+            is_d20=True,
+            natural=15,
+        )
+    return DiceRoll(expression=expression, total=6, rolls=[3], detail=f"{expression}[3] = 6")
 
 
 # --- crit dice-doubling ---
@@ -175,6 +190,31 @@ def test_combat_flow_end_to_end(tmp_path, monkeypatch):
     assert nt["round"] >= 1
     server.end_combat(cid)
     assert server.get_state(cid)["in_combat"] is False
+
+
+def test_attack_logs_structured_combat_event_payload(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    monkeypatch.setattr(server.dice_mod, "roll", _fixed_roll)
+
+    cid = server.create_campaign("Combat Event Cards")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=12, armor_class=12)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=7, armor_class=15)["id"]
+
+    server.start_combat(cid, [hero, gob])
+    server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+
+    camp = store.load_campaign(cid)
+    entries = store.read_log(cid, camp.active_session_id)
+    attack_entry = next(e for e in entries if e.payload and e.payload.get("event") == "attack")
+
+    assert attack_entry.kind == "combat"
+    assert attack_entry.payload["schema"] == "clawdnd.combat_event.v1"
+    assert attack_entry.payload["outcome"] == "hit"
+    assert attack_entry.payload["actor"] == {"id": hero, "name": "Hero"}
+    assert attack_entry.payload["target"]["id"] == gob
+    assert attack_entry.payload["damage"]["total"] == 6
 
 
 # --- hardening regressions (from adversarial review) ---

--- a/servers/engine/tests/test_sessions.py
+++ b/servers/engine/tests/test_sessions.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from models import SessionLogEntry
 import server
 import store
 
@@ -36,6 +37,13 @@ def test_log_event_autostarts_and_tracks_session(cid):
     camp = store.load_campaign(cid)
     assert camp.active_session_id is not None
     assert camp.session_ids == [camp.active_session_id]  # tracked in history
+
+
+def test_plain_session_log_entry_parses_without_payload():
+    entry = SessionLogEntry.model_validate(
+        {"kind": "combat", "text": "They felled the skeleton guardians."}
+    )
+    assert entry.payload is None
 
 
 def test_session_recap_falls_back_to_last_after_end(cid):

--- a/viewer/dashboard.html
+++ b/viewer/dashboard.html
@@ -149,6 +149,15 @@
   .msg .bd em, .msg.narration .bd i { color:#f0e4c8; }
   .msg.system .bd { color:var(--faint); font-size:12.5px; font-style:italic; }
   .msg.combat .bd { color:#e9c9c0; }
+  .combat-card { max-width:520px; border:1px solid #4f302b; background:#211713; border-radius:8px; padding:9px 10px; color:#ead5ca; white-space:normal; box-shadow:0 1px 0 rgba(255,255,255,.03) inset; }
+  .combat-card-top { display:flex; align-items:center; gap:8px; min-width:0; }
+  .combat-chip { flex:none; border:1px solid #6b4540; background:#2e1d19; color:#f0c3b8; border-radius:7px; padding:2px 7px; font-size:10.5px; font-weight:800; text-transform:uppercase; letter-spacing:.06em; }
+  .combat-title { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-weight:800; color:#f3dfc6; }
+  .combat-card-main { margin-top:6px; color:#dfc5b8; font-size:13px; }
+  .combat-card-meta { margin-top:6px; display:flex; flex-wrap:wrap; gap:6px; color:#bda997; font-size:11px; }
+  .combat-card-meta span { border:1px solid #3d3027; background:#18110d; border-radius:7px; padding:2px 6px; }
+  .combat-card.outcome-crit { border-color:#9b5d3b; }
+  .combat-card.outcome-miss { border-color:#3f3a35; }
   /* "The DM is narrating…" — a pending bubble while the DM's turn is in flight (the
      player has acted; the response is composing). Perception fix: turn latency read as
      "the DM isn't engaging". Three breathing dots under the DM byline. */
@@ -852,6 +861,54 @@ const $ = (id) => document.getElementById(id);
 // Escape for BOTH text nodes AND double-quoted attributes (LLM-authored names land in
 // title="..."/data-loc="..." — an unescaped " breaks out of the attribute → DOM/attr injection).
 const esc = (s) => (s ?? "").toString().replace(/[&<>"']/g, c => ({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;","'":"&#39;"}[c]));
+const COMBAT_EVENT_SCHEMA = "clawdnd.combat_event.v1";
+function hpText(state) {
+  if (!state) return "";
+  if (state.hp) return state.hp;
+  if (Number.isFinite(Number(state.current_hp))) return `${state.current_hp} HP`;
+  return "";
+}
+function combatEventCard(e) {
+  const p = e && e.payload;
+  if (!p || p.schema !== COMBAT_EVENT_SCHEMA) return "";
+  const actor = p.actor && p.actor.name ? p.actor.name : "";
+  const target = p.target && p.target.name ? p.target.name : "";
+  const title = actor && target ? `${actor} -> ${target}` : (target || actor || "Combat");
+  const meta = [];
+  let outcome = p.outcome || p.event || "combat";
+  let main = e.text || "";
+  if (p.event === "attack") {
+    outcome = p.outcome || (p.damage ? "hit" : "miss");
+    const roll = p.roll || {};
+    const ac = p.target && p.target.ac ? ` vs AC ${p.target.ac}` : "";
+    main = `Attack ${roll.total ?? "?"}${ac}`;
+    if (roll.natural) meta.push(`d20 ${roll.natural}`);
+    if (p.damage) meta.push(`Damage ${p.damage.total ?? 0}${p.damage.type ? " " + p.damage.type : ""}`);
+    const hp = hpText(p.target_state);
+    if (hp) meta.push(`HP ${hp}`);
+  } else if (p.event === "damage") {
+    outcome = "damage";
+    main = `${target || "Target"} takes ${p.result && p.result.damage_to_hp !== undefined ? p.result.damage_to_hp : p.amount || 0}${p.damage_type ? " " + p.damage_type : ""} damage`;
+    const hp = hpText(p.result);
+    if (hp) meta.push(`HP ${hp}`);
+  } else if (p.event === "healing") {
+    outcome = "healing";
+    main = `${target || "Target"} regains ${p.result && p.result.healed !== undefined ? p.result.healed : p.amount || 0} hit points`;
+    const hp = hpText(p.result);
+    if (hp) meta.push(`HP ${hp}`);
+  } else if (p.event === "combat_start") {
+    outcome = "start";
+    const names = (p.combatants || []).map(c => c.name).filter(Boolean).join(", ");
+    main = names ? `Initiative: ${names}` : (e.text || "Combat begins");
+    if (p.round) meta.push(`Round ${p.round}`);
+  } else if (p.event === "combat_end") {
+    outcome = "end";
+    main = e.text || "Combat ends";
+    if (p.round) meta.push(`Ended in round ${p.round}`);
+    if (p.xp_awarded) meta.push(`${p.xp_awarded} XP`);
+  }
+  return `<div class="combat-card outcome-${statusClass(outcome)}"><div class="combat-card-top"><span class="combat-chip">${esc(outcome)}</span><span class="combat-title">${esc(title)}</span></div><div class="combat-card-main">${esc(main)}</div>${meta.length ? `<div class="combat-card-meta">${meta.map(m=>`<span>${esc(m)}</span>`).join("")}</div>` : ""}</div>`;
+}
 const initials = (n) => (n||"?").trim().split(/\s+/).map(w=>w[0]).slice(0,2).join("").toUpperCase();
 const shortId = (id) => {
   const s = (id ?? "").toString();
@@ -2405,8 +2462,9 @@ async function poll() {
         const d = document.createElement("div"); d.className = "msg "+e.kind;
         const who = e.speaker || (e.kind==="system"?"":"Dungeon Master");
         const isNarr = e.kind==="narration";  // DM-authored prose → byline glyph + drop-cap (#3)
+        const combatCard = e.kind==="combat" ? combatEventCard(e) : "";
         d.innerHTML = (who?`<div class="hd">${e.kind==="system"?"":`<span class="av">${esc(initials(who))}</span>`}<span class="nm ${e.kind}${isNarr?" dm":""}">${esc(who)}</span></div>`:"")
-          + `<div class="bd${isNarr?" dropcap":""}">${esc(e.text)}</div>`;
+          + `<div class="bd${isNarr?" dropcap":""}">${combatCard || esc(e.text)}</div>`;
         if (e.kind!=="system" && e.text) { const hd=d.querySelector(".hd"); if (hd) addSpeaker(hd, e.text); }  // ▶ narration/dialogue (#36)
         pushBeat(e.kind, who, e.text);  // feed the Memories journal (6.1)
         feed.appendChild(d);


### PR DESCRIPTION
## Summary
- Add optional `payload` support to session log entries using `clawdnd.combat_event.v1` for structured combat events.
- Emit structured combat log entries for combat start/end, attacks, manual damage, and healing while preserving plain text log rendering.
- Render structured combat payloads as readable dashboard cards, with existing text fallback for plain log entries.

## Validation
- `pwd && uv run --directory servers/engine --group dev pytest -q tests/test_combat.py tests/test_sessions.py`
- `pwd && python3 -m py_compile servers/engine/server.py servers/engine/models.py viewer/server.py`
- `git diff --check`

Refs #66