### PR TITLE
feat: add provider contract smoke adapter

### DIFF
--- a/scripts/provider_contract_smoke.sh
+++ b/scripts/provider_contract_smoke.sh
@@ -15,13 +15,14 @@ from pathlib import Path
 
 
 ALLOWED_PROVIDERS = {"claude", "codex", "openclaw"}
-REQUIRED_ENV = (
+REQUIRED_NONEMPTY_ENV = (
     "CLAWDND_PROVIDER",
     "CLAWDND_WORLD",
     "CLAWDND_RUN_ID",
     "CLAWDND_PLAY_PORT",
     "CLAWDND_PLAYER_MOVES",
 )
+REQUIRED_PRESENT_ENV = ("CLAWDND_PLAY_COMPANIONS",)
 SECRET_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "AUTH", "COOKIE")
 
 
@@ -57,7 +58,8 @@ def is_temp_child(path: Path) -> bool:
     return False
 
 
-missing = [name for name in REQUIRED_ENV if not os.environ.get(name, "").strip()]
+missing = [name for name in REQUIRED_NONEMPTY_ENV if not os.environ.get(name, "").strip()]
+missing.extend(name for name in REQUIRED_PRESENT_ENV if name not in os.environ)
 if missing:
     fail("missing required env: " + ", ".join(missing))
 
@@ -78,10 +80,9 @@ if not (1 <= port <= 65535):
 moves_path = Path(env_required("CLAWDND_PLAYER_MOVES"))
 if moves_path.exists() and moves_path.is_dir():
     fail(f"CLAWDND_PLAYER_MOVES points at a directory: {moves_path}")
-if not is_temp_child(moves_path) and os.environ.get("CLAWDND_PROVIDER_SMOKE_ALLOW_NON_TEMP") != "1":
+if not is_temp_child(moves_path):
     fail(
         "CLAWDND_PLAYER_MOVES must be under a temp directory for smoke mode "
-        "(set CLAWDND_PROVIDER_SMOKE_ALLOW_NON_TEMP=1 only for controlled local debugging)"
     )
 
 move = {
@@ -99,7 +100,7 @@ summary = {
     "world": world,
     "run_id": run_id,
     "port": port,
-    "companions": [item.strip() for item in companions.split(",") if item.strip()],
+    "companion_count": len([item for item in companions.split(",") if item.strip()]),
     "move_path": str(moves_path.expanduser().resolve(strict=False)),
     "redacted_env_keys": sorted(
         key for key in os.environ if any(marker in key.upper() for marker in SECRET_MARKERS)

--- a/scripts/provider_contract_smoke.sh
+++ b/scripts/provider_contract_smoke.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Deterministic provider-contract smoke adapter for the native macOS app.
+#
+# This validates the provider launch environment and appends one harmless player
+# move to a caller-provided TEMP move sink. It deliberately does not start Claude,
+# Codex, OpenClaw, engine servers, or any narrative QA harness.
+set -euo pipefail
+
+python3 - <<'PY'
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+ALLOWED_PROVIDERS = {"claude", "codex", "openclaw"}
+REQUIRED_ENV = (
+    "CLAWDND_PROVIDER",
+    "CLAWDND_WORLD",
+    "CLAWDND_RUN_ID",
+    "CLAWDND_PLAY_PORT",
+    "CLAWDND_PLAYER_MOVES",
+)
+SECRET_MARKERS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "AUTH", "COOKIE")
+
+
+def fail(message: str, code: int = 2) -> None:
+    print(f"provider contract smoke failed: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def env_required(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        fail(f"missing required env {name}")
+    return value
+
+
+def is_temp_child(path: Path) -> bool:
+    resolved = path.expanduser().resolve(strict=False)
+    candidates = {Path(tempfile.gettempdir()).resolve(strict=False)}
+    tmpdir = os.environ.get("TMPDIR", "").strip()
+    if tmpdir:
+        candidates.add(Path(tmpdir).resolve(strict=False))
+    candidates.update(
+        p.resolve(strict=False)
+        for p in (Path("/tmp"), Path("/private/tmp"), Path("/var/folders"))
+        if p.exists()
+    )
+    for root in candidates:
+        try:
+            resolved.relative_to(root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+missing = [name for name in REQUIRED_ENV if not os.environ.get(name, "").strip()]
+if missing:
+    fail("missing required env: " + ", ".join(missing))
+
+provider = env_required("CLAWDND_PROVIDER").lower()
+if provider not in ALLOWED_PROVIDERS:
+    fail(f"unknown provider {provider!r}; expected one of {sorted(ALLOWED_PROVIDERS)}")
+
+world = env_required("CLAWDND_WORLD")
+run_id = env_required("CLAWDND_RUN_ID")
+port_raw = env_required("CLAWDND_PLAY_PORT")
+try:
+    port = int(port_raw)
+except ValueError:
+    fail(f"CLAWDND_PLAY_PORT must be an integer, got {port_raw!r}")
+if not (1 <= port <= 65535):
+    fail(f"CLAWDND_PLAY_PORT out of range: {port}")
+
+moves_path = Path(env_required("CLAWDND_PLAYER_MOVES"))
+if moves_path.exists() and moves_path.is_dir():
+    fail(f"CLAWDND_PLAYER_MOVES points at a directory: {moves_path}")
+if not is_temp_child(moves_path) and os.environ.get("CLAWDND_PROVIDER_SMOKE_ALLOW_NON_TEMP") != "1":
+    fail(
+        "CLAWDND_PLAYER_MOVES must be under a temp directory for smoke mode "
+        "(set CLAWDND_PROVIDER_SMOKE_ALLOW_NON_TEMP=1 only for controlled local debugging)"
+    )
+
+move = {
+    "kind": "clarify",
+    "text": "provider contract smoke: confirm launch environment and move sink wiring",
+}
+moves_path.parent.mkdir(parents=True, exist_ok=True)
+with moves_path.open("a", encoding="utf-8") as handle:
+    handle.write(json.dumps(move, separators=(",", ":")) + "\n")
+
+companions = os.environ.get("CLAWDND_PLAY_COMPANIONS", "")
+summary = {
+    "ok": True,
+    "provider": provider,
+    "world": world,
+    "run_id": run_id,
+    "port": port,
+    "companions": [item.strip() for item in companions.split(",") if item.strip()],
+    "move_path": str(moves_path.expanduser().resolve(strict=False)),
+    "redacted_env_keys": sorted(
+        key for key in os.environ if any(marker in key.upper() for marker in SECRET_MARKERS)
+    ),
+}
+print(json.dumps(summary, indent=2, sort_keys=True))
+PY

--- a/servers/engine/tests/test_provider_contract_smoke.py
+++ b/servers/engine/tests/test_provider_contract_smoke.py
@@ -22,10 +22,11 @@ def _run(env: dict[str, str]) -> subprocess.CompletedProcess:
     }
     merged.update(env)
     return subprocess.run(
-        ["bash", str(SCRIPT)],
+        ["/bin/bash", str(SCRIPT)],
         cwd=ROOT,
         env=merged,
         capture_output=True,
+        check=False,
         text=True,
     )
 
@@ -44,12 +45,39 @@ def test_provider_contract_smoke_rejects_unknown_provider(tmp_path):
             "CLAWDND_WORLD": "baldurs-gate",
             "CLAWDND_RUN_ID": "smoke",
             "CLAWDND_PLAY_PORT": "8765",
+            "CLAWDND_PLAY_COMPANIONS": "",
             "CLAWDND_PLAYER_MOVES": str(tmp_path / "moves.jsonl"),
         }
     )
 
     assert result.returncode != 0
     assert "unknown provider" in result.stderr
+
+
+def test_provider_contract_smoke_requires_companions_key_even_when_empty(tmp_path):
+    missing = _run(
+        {
+            "CLAWDND_PROVIDER": "codex",
+            "CLAWDND_WORLD": "baldurs-gate",
+            "CLAWDND_RUN_ID": "smoke",
+            "CLAWDND_PLAY_PORT": "8765",
+            "CLAWDND_PLAYER_MOVES": str(tmp_path / "moves.jsonl"),
+        }
+    )
+    present_empty = _run(
+        {
+            "CLAWDND_PROVIDER": "codex",
+            "CLAWDND_WORLD": "baldurs-gate",
+            "CLAWDND_RUN_ID": "smoke",
+            "CLAWDND_PLAY_PORT": "8765",
+            "CLAWDND_PLAY_COMPANIONS": "",
+            "CLAWDND_PLAYER_MOVES": str(tmp_path / "moves.jsonl"),
+        }
+    )
+
+    assert missing.returncode != 0
+    assert "CLAWDND_PLAY_COMPANIONS" in missing.stderr
+    assert present_empty.returncode == 0, present_empty.stdout + present_empty.stderr
 
 
 def test_provider_contract_smoke_appends_one_legal_move_and_summary(tmp_path):
@@ -78,7 +106,8 @@ def test_provider_contract_smoke_appends_one_legal_move_and_summary(tmp_path):
     assert summary["world"] == "baldurs-gate"
     assert summary["run_id"] == "smoke"
     assert summary["port"] == 8765
-    assert summary["companions"] == ["Astarion:rogue", "Minsc:ranger"]
+    assert summary["companion_count"] == 2
+    assert "Astarion" not in result.stdout
     assert "OPENAI_API_KEY" in summary["redacted_env_keys"]
     assert "must-not-print" not in result.stdout
 
@@ -91,7 +120,9 @@ def test_provider_contract_smoke_rejects_non_temp_move_path_without_override(tmp
             "CLAWDND_WORLD": "baldurs-gate",
             "CLAWDND_RUN_ID": "smoke",
             "CLAWDND_PLAY_PORT": "8765",
+            "CLAWDND_PLAY_COMPANIONS": "",
             "CLAWDND_PLAYER_MOVES": str(moves),
+            "CLAWDND_PROVIDER_SMOKE_ALLOW_NON_TEMP": "1",
         }
     )
 

--- a/servers/engine/tests/test_provider_contract_smoke.py
+++ b/servers/engine/tests/test_provider_contract_smoke.py
@@ -1,0 +1,100 @@
+"""Provider contract smoke adapter tests.
+
+The smoke adapter is intentionally artifact-only: it validates app/provider env
+and appends one constrained player move to a temp JSONL sink. It must not start
+Claude/Codex/OpenClaw, mutate campaign state, or run narrative QA.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "provider_contract_smoke.sh"
+
+
+def _run(env: dict[str, str]) -> subprocess.CompletedProcess:
+    merged = {
+        "PATH": os.environ.get("PATH", ""),
+        "TMPDIR": os.environ.get("TMPDIR", ""),
+    }
+    merged.update(env)
+    return subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=ROOT,
+        env=merged,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_provider_contract_smoke_requires_env(tmp_path):
+    result = _run({})
+
+    assert result.returncode != 0
+    assert "missing required env" in result.stderr
+
+
+def test_provider_contract_smoke_rejects_unknown_provider(tmp_path):
+    result = _run(
+        {
+            "CLAWDND_PROVIDER": "mystery",
+            "CLAWDND_WORLD": "baldurs-gate",
+            "CLAWDND_RUN_ID": "smoke",
+            "CLAWDND_PLAY_PORT": "8765",
+            "CLAWDND_PLAYER_MOVES": str(tmp_path / "moves.jsonl"),
+        }
+    )
+
+    assert result.returncode != 0
+    assert "unknown provider" in result.stderr
+
+
+def test_provider_contract_smoke_appends_one_legal_move_and_summary(tmp_path):
+    moves = tmp_path / "moves.jsonl"
+    result = _run(
+        {
+            "CLAWDND_PROVIDER": "codex",
+            "CLAWDND_WORLD": "baldurs-gate",
+            "CLAWDND_RUN_ID": "smoke",
+            "CLAWDND_PLAY_PORT": "8765",
+            "CLAWDND_PLAY_COMPANIONS": "Astarion:rogue,Minsc:ranger",
+            "CLAWDND_PLAYER_MOVES": str(moves),
+            "OPENAI_API_KEY": "must-not-print",
+        }
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    row = json.loads(moves.read_text(encoding="utf-8"))
+    assert row == {
+        "kind": "clarify",
+        "text": "provider contract smoke: confirm launch environment and move sink wiring",
+    }
+    summary = json.loads(result.stdout)
+    assert summary["ok"] is True
+    assert summary["provider"] == "codex"
+    assert summary["world"] == "baldurs-gate"
+    assert summary["run_id"] == "smoke"
+    assert summary["port"] == 8765
+    assert summary["companions"] == ["Astarion:rogue", "Minsc:ranger"]
+    assert "OPENAI_API_KEY" in summary["redacted_env_keys"]
+    assert "must-not-print" not in result.stdout
+
+
+def test_provider_contract_smoke_rejects_non_temp_move_path_without_override(tmp_path):
+    moves = ROOT / "play-state" / "provider-contract-smoke-test.jsonl"
+    result = _run(
+        {
+            "CLAWDND_PROVIDER": "openclaw",
+            "CLAWDND_WORLD": "baldurs-gate",
+            "CLAWDND_RUN_ID": "smoke",
+            "CLAWDND_PLAY_PORT": "8765",
+            "CLAWDND_PLAYER_MOVES": str(moves),
+        }
+    )
+
+    assert result.returncode != 0
+    assert "must be under a temp directory" in result.stderr
+    assert not moves.exists()

--- a/servers/engine/tests/test_provider_contract_smoke.py
+++ b/servers/engine/tests/test_provider_contract_smoke.py
@@ -114,6 +114,7 @@ def test_provider_contract_smoke_appends_one_legal_move_and_summary(tmp_path):
 
 def test_provider_contract_smoke_rejects_non_temp_move_path_without_override(tmp_path):
     moves = ROOT / "play-state" / "provider-contract-smoke-test.jsonl"
+    moves.unlink(missing_ok=True)
     result = _run(
         {
             "CLAWDND_PROVIDER": "openclaw",
@@ -122,7 +123,6 @@ def test_provider_contract_smoke_rejects_non_temp_move_path_without_override(tmp
             "CLAWDND_PLAY_PORT": "8765",
             "CLAWDND_PLAY_COMPANIONS": "",
             "CLAWDND_PLAYER_MOVES": str(moves),
-            "CLAWDND_PROVIDER_SMOKE_ALLOW_NON_TEMP": "1",
         }
     )
 

--- a/servers/engine/tests/test_provider_contract_smoke.py
+++ b/servers/engine/tests/test_provider_contract_smoke.py
@@ -31,7 +31,7 @@ def _run(env: dict[str, str]) -> subprocess.CompletedProcess:
     )
 
 
-def test_provider_contract_smoke_requires_env(tmp_path):
+def test_provider_contract_smoke_requires_env():
     result = _run({})
 
     assert result.returncode != 0
@@ -113,7 +113,7 @@ def test_provider_contract_smoke_appends_one_legal_move_and_summary(tmp_path):
 
 
 def test_provider_contract_smoke_rejects_non_temp_move_path_without_override(tmp_path):
-    moves = ROOT / "play-state" / "provider-contract-smoke-test.jsonl"
+    moves = ROOT / "play-state" / f"provider-contract-smoke-test-{tmp_path.name}.jsonl"
     moves.unlink(missing_ok=True)
     result = _run(
         {


### PR DESCRIPTION
## Summary

Adds a deterministic provider-contract smoke adapter for the native app/provider bridge lane.

This is intentionally not a live Claude/Codex/OpenClaw session runner. It validates the launch environment that the macOS shell and future provider wrappers must provide, writes exactly one harmless player-facade move to a caller-provided temp JSONL sink, and emits a redacted JSON summary for diagnostics.

Refs #95
Refs #82

## Architecture commitments

- The engine remains the only campaign-state writer.
- The smoke adapter does not start providers, mutate `play-state`, talk to the dashboard, or run narrative QA.
- The only write is `CLAWDND_PLAYER_MOVES`, and tests assert it must be under a temp directory.
- Provider commands converge on the same env contract: `CLAWDND_PROVIDER`, `CLAWDND_WORLD`, `CLAWDND_RUN_ID`, `CLAWDND_PLAY_PORT`, `CLAWDND_PLAY_COMPANIONS`, and `CLAWDND_PLAYER_MOVES`.
- Diagnostic output reports companion count and redacted env key names, not provider secrets or companion specs.

## Files changed

- `scripts/provider_contract_smoke.sh`
  - validates required env, provider kind, port range, temp move sink, and redacted summary output.
- `servers/engine/tests/test_provider_contract_smoke.py`
  - locks required env behavior, unknown-provider rejection, companion-key presence, legal move append, redaction, and non-temp path rejection.

## Validation

Local, from `/Volumes/LEXAR/repos/ClawDnD-provider-contract-smoke`:

- `bash -n scripts/provider_contract_smoke.sh`
- `uv run --directory servers/engine --group dev pytest -q tests/test_provider_contract_smoke.py`
- `python3 -m py_compile servers/engine/tests/test_provider_contract_smoke.py`
- `git diff --check`
- manual temp move-sink smoke with `jq`

GitHub:

- CI `test`
- CI `license-check`
- CodeRabbit review, plus independent adversarial review feedback folded into follow-up commits.

## Risk and rollback

Risk is low and isolated to a new script plus focused tests. If the provider contract changes, this PR can be reverted without touching engine, viewer, macOS app, story content, or QA rubrics.
