### PR TITLE
feat(combat): complete structured combat event payloads

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1993,6 +1993,20 @@ def move_to_zone(campaign_id: str, combatant_id: str, zone: str) -> dict:
                 )
 
         cb.zone = zone
+        _log_combat_event(
+            c,
+            f"{mover.name if mover else combatant_id} moves from {from_zone or 'an unset zone'} to {zone}.",
+            {
+                "event": "zone_movement",
+                "actor": _combatant_ref(mover) if mover else {"id": combatant_id, "name": "?"},
+                "from_zone": from_zone,
+                "to_zone": zone,
+                "opportunity_attack": bool(provokers),
+                "provokers": provokers,
+                "warnings": list(warnings),
+            },
+            speaker=mover.name if mover else "",
+        )
         save_campaign(c)
         view = _combat_view(c)
     view["from"] = from_zone
@@ -2038,6 +2052,7 @@ def next_turn(campaign_id: str) -> dict:
         order = c.combat.order
         if not c.combat.active or not order:
             raise ValueError("no active combat")
+        previous = c.characters.get(c.combat.current_combatant_id)
         n = len(order)
         cur = None
         new_round = False
@@ -2078,11 +2093,26 @@ def next_turn(campaign_id: str) -> dict:
                     continue
                 for name in combat.tick_round_effects(holder):
                     expired.append({"character_id": holder.id, "name": name})
-        save_campaign(c)
         view = _combat_view(c)
         view["current_name"] = cur.name if cur else None
         view["death_save_due"] = bool(cur and cur.current_hp == 0 and not cur.dead and not cur.stable)
         view["expired_effects"] = expired
+        _log_combat_event(
+            c,
+            f"Turn advances to {cur.name}." if cur else "Turn advances with no living combatant.",
+            {
+                "event": "turn_advanced",
+                "round": c.combat.round,
+                "new_round": new_round,
+                "previous": _combatant_ref(previous) if previous else None,
+                "current": _combatant_ref(cur) if cur else None,
+                "turn_index": c.combat.turn_index,
+                "death_save_due": view["death_save_due"],
+                "expired_effects": expired,
+            },
+            speaker=cur.name if cur else "",
+        )
+        save_campaign(c)
         return view
 
 
@@ -2446,7 +2476,31 @@ def roll_death_save(campaign_id: str, character_id: str) -> dict:
         ch = _char(c, character_id)
         if ch.current_hp != 0 or ch.dead or ch.stable:
             raise ValueError("death saves apply only to a downed (0 HP), unstable, living character")
-        out = combat.resolve_death_save(ch, dice_mod.roll("1d20"))
+        roll = dice_mod.roll("1d20")
+        out = combat.resolve_death_save(ch, roll)
+        _log_combat_event(
+            c,
+            f"{ch.name} rolls a death save: {out.get('result')}.",
+            {
+                "event": "death_save",
+                "target": _combatant_ref(ch),
+                "roll": {
+                    "total": roll.total,
+                    "natural": roll.natural,
+                    "detail": roll.detail,
+                },
+                "result": out.get("result"),
+                "successes": ch.death_saves.successes,
+                "failures": ch.death_saves.failures,
+                "state": {
+                    "current_hp": ch.current_hp,
+                    "stable": ch.stable,
+                    "dead": ch.dead,
+                    "dying": ch.current_hp == 0 and not ch.dead and not ch.stable,
+                },
+            },
+            speaker=ch.name,
+        )
         save_campaign(c)
         return out
 

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -217,6 +217,54 @@ def test_attack_logs_structured_combat_event_payload(tmp_path, monkeypatch):
     assert attack_entry.payload["damage"]["total"] == 6
 
 
+def test_turn_advance_logs_structured_combat_event_payload(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Turn Event Cards")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=12, armor_class=12)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=7, armor_class=15)["id"]
+
+    before = server.start_combat(cid, [hero, gob])
+    advanced = server.next_turn(cid)
+
+    camp = store.load_campaign(cid)
+    entries = store.read_log(cid, camp.active_session_id)
+    turn_entry = next(e for e in entries if e.payload and e.payload.get("event") == "turn_advanced")
+
+    assert turn_entry.kind == "combat"
+    assert turn_entry.payload["schema"] == "clawdnd.combat_event.v1"
+    assert turn_entry.payload["previous"]["id"] == before["current"]
+    assert turn_entry.payload["current"]["id"] == advanced["current"]
+    assert turn_entry.payload["round"] == advanced["round"]
+    assert turn_entry.payload["death_save_due"] == advanced["death_save_due"]
+
+
+def test_death_save_logs_structured_combat_event_payload(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    monkeypatch.setattr(server.dice_mod, "roll", _fixed_roll)
+
+    cid = server.create_campaign("Death Save Event Cards")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=12, armor_class=12)["id"]
+    server.apply_damage(cid, hero, 12)
+
+    out = server.roll_death_save(cid, hero)
+
+    camp = store.load_campaign(cid)
+    entries = store.read_log(cid, camp.active_session_id)
+    death_entry = next(e for e in entries if e.payload and e.payload.get("event") == "death_save")
+
+    assert death_entry.kind == "combat"
+    assert death_entry.payload["schema"] == "clawdnd.combat_event.v1"
+    assert death_entry.payload["target"] == {"id": hero, "name": "Hero"}
+    assert death_entry.payload["roll"]["natural"] == 15
+    assert death_entry.payload["result"] == out["result"] == "pending"
+    assert death_entry.payload["successes"] == 1
+    assert death_entry.payload["state"]["dying"] is True
+
+
 # --- hardening regressions (from adversarial review) ---
 def test_death_save_guard_on_stable():  # C1
     ch = mk(max_hp=10, current_hp=0, stable=True)

--- a/servers/engine/tests/test_zones.py
+++ b/servers/engine/tests/test_zones.py
@@ -117,6 +117,28 @@ def test_move_leaving_zone_with_hostile_flags_opportunity_attack(fight):
     assert server._combatant(c, hero).zone == "dais"
 
 
+def test_move_to_zone_logs_structured_combat_event_payload(fight):
+    cid, hero, gob = fight
+    _scene(cid)
+    server.place_combatant(cid, hero, "doorway")
+    server.place_combatant(cid, gob, "doorway")
+
+    res = server.move_to_zone(cid, hero, "dais")
+
+    camp = store.load_campaign(cid)
+    entries = store.read_log(cid, camp.active_session_id)
+    move_entry = next(e for e in entries if e.payload and e.payload.get("event") == "zone_movement")
+
+    assert move_entry.kind == "combat"
+    assert move_entry.payload["schema"] == "clawdnd.combat_event.v1"
+    assert move_entry.payload["actor"] == {"id": hero, "name": "Hero"}
+    assert move_entry.payload["from_zone"] == "doorway"
+    assert move_entry.payload["to_zone"] == "dais"
+    assert move_entry.payload["opportunity_attack"] is True
+    assert move_entry.payload["provokers"] == [{"id": gob, "name": "Goblin"}]
+    assert move_entry.payload["warnings"] == res["warnings"]
+
+
 def test_move_no_oa_when_no_hostile_in_left_zone(fight):
     cid, hero, gob = fight
     _scene(cid)


### PR DESCRIPTION
## Summary

Completes structured `clawdnd.combat_event.v1` payload coverage for Sprint 1 combat readability.

The engine now emits machine-readable event payloads for zone movement, turn advancement, and death saves while preserving the existing text combat log and session recap path.

Refs #66
Refs #57

## Architecture commitments

- Engine remains the source of truth for combat events.
- Structured payloads are additive and do not replace existing plain-text log entries.
- Viewer/dashboard consumers can use payload fields instead of parsing prose.
- No story content, QA rubric, viewer, or macOS app changes are included.

## Files changed

- `servers/engine/server.py`
  - adds structured payload emission for `zone_movement`, `turn_advanced`, and `death_save` combat events.
- `servers/engine/tests/test_combat.py`
  - asserts death-save and turn event payload behavior.
- `servers/engine/tests/test_zones.py`
  - asserts zone movement event payload behavior.

## Validation

Local, from `/Volumes/LEXAR/repos/ClawDnD-combat-event-completion`:

- `uv run --directory servers/engine --group dev pytest -q tests/test_combat.py tests/test_sessions.py tests/test_zones.py`
- `python3 -m py_compile servers/engine/server.py servers/engine/models.py`
- `git diff --check`

GitHub:

- CI `test`
- CI `license-check`
- CodeRabbit status is green; no actionable review threads were present.

## Risk and rollback

Risk is medium-low: engine event payload shape is new public read-model surface. Existing text logs are preserved. If consumers reject the schema, revert this PR and keep the viewer on existing text logs until a schema revision lands.
