### PR TITLE
feat(macos): surface provider diagnostics

### DIFF
--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Models/ProviderModels.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Models/ProviderModels.swift
@@ -68,6 +68,29 @@ struct ProviderLaunchRequest {
     let message: String
 }
 
+struct ProviderLaunchMetadata: Equatable {
+    let kind: ProviderKind
+    let processName: String
+    let executable: String
+    let arguments: [String]
+    let workingDirectory: URL
+    let environment: [String: String]
+    let world: String
+    let runId: String
+    let port: Int
+    let statePath: String?
+    let message: String
+    var processID: Int32?
+    var launchedAt: Date?
+    var exitedAt: Date?
+    var exitStatus: Int32?
+    var lastError: String?
+
+    var commandLine: String {
+        ([executable] + arguments).joined(separator: " ")
+    }
+}
+
 enum ProviderError: LocalizedError {
     case missingDependency(String)
     case configuration(String)

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
@@ -9,6 +9,7 @@ final class AppProcessService: ObservableObject {
     @Published var supervisorLog: String = ""
     @Published var providerLog: String = ""
     @Published var lastError: String?
+    @Published var providerLaunchMetadata: ProviderLaunchMetadata?
 
     private var viewerProcess: ManagedProcess?
     private var providerProcess: ManagedProcess?
@@ -23,6 +24,11 @@ final class AppProcessService: ObservableObject {
         Active campaign: \(activeCampaignID ?? "none")
         Running provider: \(runningProvider?.rawValue ?? "none")
         Last error: \(lastError ?? "none")
+
+        \(Diagnostics.providerLaunchSummary(providerLaunchMetadata))
+
+        Provider last log lines:
+        \(Diagnostics.lastLines(providerLog))
 
         Dependencies:
         \(dependencies.map { "\($0.command): \($0.path ?? "missing")" }.joined(separator: "\n"))
@@ -105,6 +111,7 @@ final class AppProcessService: ObservableObject {
         runId: String,
         preferredPort: Int,
         companions: String,
+        stateDir: String,
         preferences: ProviderPreferences
     ) throws -> URL {
         let repoURL = URL(fileURLWithPath: repoPath)
@@ -116,26 +123,49 @@ final class AppProcessService: ObservableObject {
             try throwAndRecord("Could not find a free provider viewer port near \(preferredPort).")
         }
         let adapter = registry.adapter(for: kind)
-        let request = try adapter.startSession(
-            world: world,
-            runId: runId,
-            port: port,
-            companions: companions,
-            repoPath: repoURL,
-            preferences: preferences
-        )
+        let request: ProviderLaunchRequest
+        do {
+            request = try adapter.startSession(
+                world: world,
+                runId: runId,
+                port: port,
+                companions: companions,
+                repoPath: repoURL,
+                preferences: preferences
+            )
+        } catch {
+            let message = error.localizedDescription
+            lastError = message
+            append(message, stream: .provider)
+            throw error
+        }
 
         providerProcess?.terminate()
         providerProcess = nil
         runningProvider = nil
+        providerLaunchMetadata = nil
         providerLog = ""
+        let metadata = ProviderLaunchMetadata(
+            kind: kind,
+            processName: request.name,
+            executable: request.executable,
+            arguments: request.arguments,
+            workingDirectory: request.workingDirectory,
+            environment: request.environment,
+            world: world,
+            runId: runId,
+            port: port,
+            statePath: expandedPathIfPresent(stateDir),
+            message: request.message
+        )
         let managed = try launchManagedProcess(
             name: request.name,
             executable: request.executable,
             arguments: request.arguments,
             workingDirectory: request.workingDirectory,
             environment: request.environment,
-            stream: .provider
+            stream: .provider,
+            providerMetadata: metadata
         )
         providerProcess = managed
         runningProvider = kind
@@ -155,6 +185,10 @@ final class AppProcessService: ObservableObject {
         providerProcess?.terminate()
         providerProcess = nil
         runningProvider = nil
+        if var metadata = providerLaunchMetadata, metadata.exitStatus == nil {
+            metadata.exitedAt = Date()
+            providerLaunchMetadata = metadata
+        }
         stopProviderViewerEndpointIfNeeded()
     }
 
@@ -164,7 +198,8 @@ final class AppProcessService: ObservableObject {
         arguments: [String],
         workingDirectory: URL,
         environment: [String: String],
-        stream: LogStream
+        stream: LogStream,
+        providerMetadata: ProviderLaunchMetadata? = nil
     ) throws -> ManagedProcess {
         var mergedEnvironment = ProcessInfo.processInfo.environment
         environment.forEach { key, value in mergedEnvironment[key] = value }
@@ -194,6 +229,7 @@ final class AppProcessService: ObservableObject {
                 managed?.close()
                 self?.append("\(name) exited with status \(process.terminationStatus)", stream: stream)
                 if stream == .provider {
+                    self?.recordProviderExit(status: process.terminationStatus)
                     if self?.providerProcess === managed {
                         self?.providerProcess = nil
                         self?.runningProvider = nil
@@ -211,10 +247,21 @@ final class AppProcessService: ObservableObject {
 
         do {
             try process.run()
+            if var providerMetadata {
+                providerMetadata.processID = process.processIdentifier
+                providerMetadata.launchedAt = Date()
+                providerLaunchMetadata = providerMetadata
+                append(Diagnostics.providerLaunchSummary(providerMetadata), stream: .provider)
+            }
             return managed
         } catch {
             let message = "\(name) failed to launch: \(error.localizedDescription)"
             lastError = message
+            if var providerMetadata {
+                providerMetadata.lastError = message
+                providerLaunchMetadata = providerMetadata
+                append(Diagnostics.providerLaunchSummary(providerMetadata), stream: stream)
+            }
             append(message, stream: stream)
             throw error
         }
@@ -247,6 +294,24 @@ final class AppProcessService: ObservableObject {
         guard var endpoint = viewerEndpoint, endpoint.name == "Provider viewer" else { return }
         endpoint.status = .stopped
         viewerEndpoint = endpoint
+    }
+
+    private func recordProviderExit(status: Int32) {
+        guard var metadata = providerLaunchMetadata else { return }
+        metadata.exitStatus = status
+        metadata.exitedAt = Date()
+        if status != 0 {
+            let message = "\(metadata.processName) exited with status \(status)"
+            metadata.lastError = message
+            lastError = message
+        }
+        providerLaunchMetadata = metadata
+    }
+
+    private func expandedPathIfPresent(_ path: String) -> String? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return (trimmed as NSString).expandingTildeInPath
     }
 
     private func throwAndRecord(_ message: String) throws -> Never {

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
@@ -13,6 +13,7 @@ final class AppProcessService: ObservableObject {
 
     private var viewerProcess: ManagedProcess?
     private var providerProcess: ManagedProcess?
+    private var intentionallyStoppingProviderPIDs: Set<Int32> = []
     private let registry = ProviderRegistry()
     private let maxLogCharacters = 120_000
 
@@ -123,6 +124,9 @@ final class AppProcessService: ObservableObject {
             try throwAndRecord("Could not find a free provider viewer port near \(preferredPort).")
         }
         let adapter = registry.adapter(for: kind)
+        if providerProcess == nil {
+            providerLaunchMetadata = nil
+        }
         let request: ProviderLaunchRequest
         do {
             request = try adapter.startSession(
@@ -140,7 +144,10 @@ final class AppProcessService: ObservableObject {
             throw error
         }
 
-        providerProcess?.terminate()
+        if let providerProcess {
+            intentionallyStoppingProviderPIDs.insert(providerProcess.pid)
+            providerProcess.terminate()
+        }
         providerProcess = nil
         runningProvider = nil
         providerLaunchMetadata = nil
@@ -182,11 +189,15 @@ final class AppProcessService: ObservableObject {
     }
 
     func stopProvider() {
-        providerProcess?.terminate()
+        if let providerProcess {
+            intentionallyStoppingProviderPIDs.insert(providerProcess.pid)
+            providerProcess.terminate()
+        }
         providerProcess = nil
         runningProvider = nil
         if var metadata = providerLaunchMetadata, metadata.exitStatus == nil {
             metadata.exitedAt = Date()
+            metadata.lastError = nil
             providerLaunchMetadata = metadata
         }
         stopProviderViewerEndpointIfNeeded()
@@ -229,7 +240,9 @@ final class AppProcessService: ObservableObject {
                 managed?.close()
                 self?.append("\(name) exited with status \(process.terminationStatus)", stream: stream)
                 if stream == .provider {
-                    self?.recordProviderExit(status: process.terminationStatus)
+                    let processID = process.processIdentifier
+                    let stoppedByUser = self?.intentionallyStoppingProviderPIDs.remove(processID) != nil
+                    self?.recordProviderExit(status: process.terminationStatus, stoppedByUser: stoppedByUser, processID: processID)
                     if self?.providerProcess === managed {
                         self?.providerProcess = nil
                         self?.runningProvider = nil
@@ -268,7 +281,8 @@ final class AppProcessService: ObservableObject {
     }
 
     private func append(_ text: String, stream: LogStream, prefix: String? = nil) {
-        let line = prefix.map { "[\($0)] \(text)" } ?? text
+        let safeText = stream == .provider ? Diagnostics.redactedText(text) : text
+        let line = prefix.map { "[\($0)] \(safeText)" } ?? safeText
         switch stream {
         case .supervisor:
             supervisorLog += line.hasSuffix("\n") ? line : line + "\n"
@@ -296,11 +310,14 @@ final class AppProcessService: ObservableObject {
         viewerEndpoint = endpoint
     }
 
-    private func recordProviderExit(status: Int32) {
+    private func recordProviderExit(status: Int32, stoppedByUser: Bool, processID: Int32) {
         guard var metadata = providerLaunchMetadata else { return }
+        guard metadata.processID == processID else { return }
         metadata.exitStatus = status
         metadata.exitedAt = Date()
-        if status != 0 {
+        if stoppedByUser {
+            metadata.lastError = nil
+        } else if status != 0 {
             let message = "\(metadata.processName) exited with status \(status)"
             metadata.lastError = message
             lastError = message

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/Diagnostics.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/Diagnostics.swift
@@ -3,6 +3,16 @@ import Foundation
 
 enum Diagnostics {
     static let sensitiveKeyFragments = ["KEY", "TOKEN", "SECRET", "PASSWORD", "AUTH", "COOKIE"]
+    private static let sensitiveFlags = [
+        "--api-key",
+        "--apikey",
+        "--auth",
+        "--authorization",
+        "--cookie",
+        "--password",
+        "--secret",
+        "--token"
+    ]
 
     @MainActor
     static func copy(processService: AppProcessService) {
@@ -20,6 +30,22 @@ enum Diagnostics {
                 "\(key)=\(redactedValue(forKey: key, value: environment[key] ?? ""))"
             }
             .joined(separator: "\n")
+    }
+
+    static func redactedText(_ text: String) -> String {
+        var redacted = text
+        let replacements = [
+            (#"(?i)\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|AUTH|COOKIE)[A-Z0-9_]*)=(?:"[^"]*"|'[^']*'|[^\s'"]+)"#, "$1=<redacted>"),
+            (#"(?i)(--(?:api[-_]?key|auth(?:orization)?|cookie|password|secret|token)(?:=|\s+))(?:"[^"]*"|'[^']*'|[^\s'"]+)"#, "$1<redacted>"),
+            (#"(?i)\b(bearer)\s+[A-Za-z0-9._~+/=-]+"#, "$1 <redacted>"),
+            (#"\b(sk-[A-Za-z0-9_-]{8,})\b"#, "<redacted>"),
+            (#"\b(gh[pousr]_[A-Za-z0-9_]{20,})\b"#, "<redacted>"),
+            (#"\b(xox[baprs]-[A-Za-z0-9-]{10,})\b"#, "<redacted>")
+        ]
+        for (pattern, template) in replacements {
+            redacted = replacing(pattern: pattern, in: redacted, with: template)
+        }
+        return redacted
     }
 
     static func providerLaunchSummary(_ metadata: ProviderLaunchMetadata?) -> String {
@@ -43,8 +69,8 @@ enum Diagnostics {
         Repo path: \(metadata.workingDirectory.path)
         State path: \(statePath)
         Executable: \(metadata.executable)
-        Arguments: \(metadata.arguments.joined(separator: " "))
-        Command: \(metadata.commandLine)
+        Arguments: \(redactedArguments(metadata.arguments).joined(separator: " "))
+        Command: \(redactedCommandLine(executable: metadata.executable, arguments: metadata.arguments))
         Environment overrides:
         \(redactedEnvironmentSummary(metadata.environment))
         Launched at: \(launchedAt)
@@ -66,7 +92,34 @@ enum Diagnostics {
         if sensitiveKeyFragments.contains(where: { uppercasedKey.contains($0) }) {
             return "<redacted>"
         }
-        return value
+        return redactedText(value)
+    }
+
+    private static func redactedArguments(_ arguments: [String]) -> [String] {
+        var shouldRedactNext = false
+        return arguments.map { argument in
+            if shouldRedactNext {
+                shouldRedactNext = false
+                return "<redacted>"
+            }
+            if sensitiveFlags.contains(argument.lowercased()) {
+                shouldRedactNext = true
+                return argument
+            }
+            return redactedText(argument)
+        }
+    }
+
+    private static func redactedCommandLine(executable: String, arguments: [String]) -> String {
+        ([executable] + redactedArguments(arguments)).joined(separator: " ")
+    }
+
+    private static func replacing(pattern: String, in text: String, with template: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return text
+        }
+        let range = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.stringByReplacingMatches(in: text, range: range, withTemplate: template)
     }
 
     private static func normalizedOptional(_ value: String?) -> String {

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/Diagnostics.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/Diagnostics.swift
@@ -2,10 +2,83 @@ import AppKit
 import Foundation
 
 enum Diagnostics {
+    static let sensitiveKeyFragments = ["KEY", "TOKEN", "SECRET", "PASSWORD", "AUTH", "COOKIE"]
+
     @MainActor
     static func copy(processService: AppProcessService) {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(processService.diagnostics, forType: .string)
+    }
+
+    static func redactedEnvironmentSummary(_ environment: [String: String]) -> String {
+        guard !environment.isEmpty else { return "none" }
+        return environment
+            .keys
+            .sorted()
+            .map { key in
+                "\(key)=\(redactedValue(forKey: key, value: environment[key] ?? ""))"
+            }
+            .joined(separator: "\n")
+    }
+
+    static func providerLaunchSummary(_ metadata: ProviderLaunchMetadata?) -> String {
+        guard let metadata else {
+            return "Provider launch: none"
+        }
+
+        let launchedAt = metadata.launchedAt.map(Self.formatDate) ?? "not launched"
+        let exitedAt = metadata.exitedAt.map(Self.formatDate) ?? "not exited"
+        let exitStatus = metadata.exitStatus.map(String.init) ?? "running or unknown"
+        let statePath = normalizedOptional(metadata.statePath)
+
+        return """
+        Provider launch:
+        Kind: \(metadata.kind.rawValue)
+        Process: \(metadata.processName)
+        PID: \(metadata.processID.map(String.init) ?? "none")
+        Run ID: \(metadata.runId)
+        World: \(metadata.world)
+        Port: \(metadata.port)
+        Repo path: \(metadata.workingDirectory.path)
+        State path: \(statePath)
+        Executable: \(metadata.executable)
+        Arguments: \(metadata.arguments.joined(separator: " "))
+        Command: \(metadata.commandLine)
+        Environment overrides:
+        \(redactedEnvironmentSummary(metadata.environment))
+        Launched at: \(launchedAt)
+        Exited at: \(exitedAt)
+        Exit status: \(exitStatus)
+        Last error: \(metadata.lastError ?? "none")
+        Message: \(metadata.message)
+        """
+    }
+
+    static func lastLines(_ text: String, limit: Int = 40) -> String {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false)
+        guard !lines.isEmpty else { return "none" }
+        return lines.suffix(limit).joined(separator: "\n")
+    }
+
+    private static func redactedValue(forKey key: String, value: String) -> String {
+        let uppercasedKey = key.uppercased()
+        if sensitiveKeyFragments.contains(where: { uppercasedKey.contains($0) }) {
+            return "<redacted>"
+        }
+        return value
+    }
+
+    private static func normalizedOptional(_ value: String?) -> String {
+        guard let value,
+              !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return "none"
+        }
+        return value
+    }
+
+    private static func formatDate(_ date: Date) -> String {
+        ISO8601DateFormatter().string(from: date)
     }
 }

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/Diagnostics.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/Diagnostics.swift
@@ -39,6 +39,7 @@ enum Diagnostics {
             (#"(?i)(--[A-Za-z0-9_-]*(?:api[-_]?key|auth(?:orization)?|cookie|password|secret|token)[A-Za-z0-9_-]*(?:=|\s+))(?:"[^"]*"|'[^']*'|[^\s'"]+)"#, "$1<redacted>"),
             (#"(?i)\b(bearer)\s+[A-Za-z0-9._~+/=-]+"#, "$1 <redacted>"),
             (#"\b(sk-[A-Za-z0-9_-]{8,})\b"#, "<redacted>"),
+            (#"\b(github_pat_[A-Za-z0-9_]{20,})\b"#, "<redacted>"),
             (#"\b(gh[pousr]_[A-Za-z0-9_]{20,})\b"#, "<redacted>"),
             (#"\b(xox[baprs]-[A-Za-z0-9-]{10,})\b"#, "<redacted>")
         ]

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/Diagnostics.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/Diagnostics.swift
@@ -36,7 +36,7 @@ enum Diagnostics {
         var redacted = text
         let replacements = [
             (#"(?i)\b([A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|AUTH|COOKIE)[A-Z0-9_]*)=(?:"[^"]*"|'[^']*'|[^\s'"]+)"#, "$1=<redacted>"),
-            (#"(?i)(--(?:api[-_]?key|auth(?:orization)?|cookie|password|secret|token)(?:=|\s+))(?:"[^"]*"|'[^']*'|[^\s'"]+)"#, "$1<redacted>"),
+            (#"(?i)(--[A-Za-z0-9_-]*(?:api[-_]?key|auth(?:orization)?|cookie|password|secret|token)[A-Za-z0-9_-]*(?:=|\s+))(?:"[^"]*"|'[^']*'|[^\s'"]+)"#, "$1<redacted>"),
             (#"(?i)\b(bearer)\s+[A-Za-z0-9._~+/=-]+"#, "$1 <redacted>"),
             (#"\b(sk-[A-Za-z0-9_-]{8,})\b"#, "<redacted>"),
             (#"\b(gh[pousr]_[A-Za-z0-9_]{20,})\b"#, "<redacted>"),
@@ -97,10 +97,19 @@ enum Diagnostics {
 
     private static func redactedArguments(_ arguments: [String]) -> [String] {
         var shouldRedactNext = false
+        var shouldRedactShellCommand = false
         return arguments.map { argument in
+            if shouldRedactShellCommand {
+                shouldRedactShellCommand = false
+                return "<configured command redacted>"
+            }
             if shouldRedactNext {
                 shouldRedactNext = false
                 return "<redacted>"
+            }
+            if argument == "-c" || argument == "-lc" {
+                shouldRedactShellCommand = true
+                return argument
             }
             if sensitiveFlags.contains(argument.lowercased()) {
                 shouldRedactNext = true

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/LogsView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/LogsView.swift
@@ -26,6 +26,11 @@ struct LogsView: View {
                     .tabItem { Text("Viewer") }
                 LogText(title: "Provider", text: processService.providerLog)
                     .tabItem { Text("Provider") }
+                LogText(
+                    title: "Provider Diagnostics",
+                    text: Diagnostics.providerLaunchSummary(processService.providerLaunchMetadata)
+                )
+                .tabItem { Text("Provider Diagnostics") }
                 LogText(title: "Diagnostics", text: processService.diagnostics)
                     .tabItem { Text("Diagnostics") }
             }

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/PlayView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/PlayView.swift
@@ -151,6 +151,7 @@ struct PlayView: View {
                 runId: cleanRunID.isEmpty ? Self.newRunID() : cleanRunID,
                 preferredPort: preferredPort,
                 companions: companions,
+                stateDir: stateDir,
                 preferences: providerPreferences
             )
         } catch {

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/ProvidersView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/ProvidersView.swift
@@ -37,6 +37,13 @@ struct ProvidersView: View {
                         ProviderCard(status: status)
                     }
 
+                    GroupBox("Current provider diagnostics") {
+                        Text(Diagnostics.providerLaunchSummary(processService.providerLaunchMetadata))
+                            .font(.caption.monospaced())
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .textSelection(.enabled)
+                    }
+
                     GroupBox("Configured provider commands") {
                         VStack(alignment: .leading, spacing: 10) {
                             TextField("Codex launch command", text: $codexProviderCommand)


### PR DESCRIPTION
## Summary

Surfaces provider launch diagnostics in the native macOS shell so users and agents can see what command/environment contract was attempted when a provider session starts or fails.

Refs #97
Refs #82

## Architecture commitments

- Diagnostics are observer/control-plane metadata, not campaign state.
- The app remains an orchestrator and read surface; providers still speak through existing move/state contracts.
- Sensitive environment values, common token patterns, bearer tokens, and secret-like argument fragments are redacted before display, logs, or copied diagnostics.
- Configured shell commands launched via `-c`/`-lc` are never displayed; the command argument is replaced wholesale with `<configured command redacted>`.
- Intentional provider stops are not recorded as failures, and old process exits cannot overwrite newer provider metadata.
- No engine, rules, voice, QA story lane, or DM skill changes are included.

## Files changed

- `macos/ClawDnDApp/Sources/ClawDnDApp/Models/ProviderModels.swift`
  - adds provider launch metadata model.
- `macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift`
  - records provider command, env overrides, lifecycle timestamps, pid, exit status, and launch errors.
  - redacts app-captured provider log text, tracks intentional provider termination, and avoids stale process-exit metadata writes.
- `macos/ClawDnDApp/Sources/ClawDnDApp/Services/Diagnostics.swift`
  - formats redacted provider diagnostics and recent logs.
  - redacts env values by key name plus freeform command text patterns such as `OPENAI_API_KEY=...`, `--api-key ...`, `--client-secret ...`, `Bearer ...`, `sk-...`, GitHub tokens, and Slack tokens.
  - hides configured shell-command bodies following `-c` or `-lc`.
- `macos/ClawDnDApp/Sources/ClawDnDApp/Views/LogsView.swift`
- `macos/ClawDnDApp/Sources/ClawDnDApp/Views/PlayView.swift`
- `macos/ClawDnDApp/Sources/ClawDnDApp/Views/ProvidersView.swift`
  - display launch diagnostics in native UI surfaces.

## Validation

Local, from `/Volumes/LEXAR/repos/ClawDnD-provider-diagnostics`:

- `swift build --package-path macos/ClawDnDApp`
- `swift build --package-path macos/ClawDnDApp --scratch-path /Volumes/LEXAR/Codex/clawdnd-pr101-swift-build`
- `./script/build_and_run.sh --verify`
- app process stopped after verify
- `git diff --check`

GitHub:

- CI `test`
- CI `license-check`
- CodeRabbit review/status.
- Independent adversarial review found the command-redaction blocker; follow-up commits `88b5cdc` and `f292756` fix it and the lifecycle concerns.

## Risk and rollback

Risk is mostly UI/diagnostic exposure. Provider command text is intentionally visible only as launch metadata after redaction; configured shell commands are hidden entirely. Revert if this diagnostic surface proves too chatty or needs a different audit model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Provider Diagnostics" tab in logs view displaying detailed provider launch lifecycle information, including startup details, exit status, environment variables, and command arguments
  * Added "Current provider diagnostics" section in providers view showing live provider diagnostic data with automatic redaction of sensitive information
  * Enhanced provider process error tracking and lifecycle recording capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->