### PR TITLE
feat(macos): add Codex player-facade provider wrapper

### DIFF
--- a/.github/workflows/macos-swift.yml
+++ b/.github/workflows/macos-swift.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/**/*.sh"
   pull_request:
     branches:
+      - main
       - macos/native-app-shell
     paths:
       - ".github/workflows/*.yml"

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/ProviderAdapters.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/ProviderAdapters.swift
@@ -84,39 +84,33 @@ struct CodexProvider: ProviderAdapter {
 
     func detect(repoPath: URL, preferences: ProviderPreferences) -> ProviderStatus {
         let cli = Shell.which("codex")
-        let appExists = Shell.fileExists("/Applications/Codex.app")
-        let homeConfig = Shell.fileExists("~/.codex")
+        let wrapper = repoPath.appendingPathComponent("scripts/play_codex_actor.sh")
+        let configuredCommand = preferences.codexCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+        let launchCommand = configuredCommand.isEmpty ? defaultCodexCommand : configuredCommand
 
-        if preferences.codexCommand.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            if let cli {
-                return ProviderStatus(
-                    kind: kind,
-                    availability: .installed,
-                    detail: "Codex CLI found, but no ClawDnD launch command is configured yet.",
-                    detectedPath: cli
-                )
-            }
-            if appExists || homeConfig {
-                return ProviderStatus(
-                    kind: kind,
-                    availability: .installed,
-                    detail: "Codex app/config detected, but no ClawDnD launch command is configured yet.",
-                    detectedPath: appExists ? "/Applications/Codex.app" : "~/.codex"
-                )
-            }
+        guard let cli else {
             return ProviderStatus(
                 kind: kind,
                 availability: .missing,
-                detail: "Codex was not found. Install Codex or configure a provider command.",
+                detail: "Codex CLI was not found. The Codex provider fails closed until codex is available.",
                 detectedPath: nil
+            )
+        }
+
+        guard FileManager.default.fileExists(atPath: wrapper.path) else {
+            return ProviderStatus(
+                kind: kind,
+                availability: .error,
+                detail: "Codex CLI found, but scripts/play_codex_actor.sh is missing from this checkout.",
+                detectedPath: cli
             )
         }
 
         return ProviderStatus(
             kind: kind,
             availability: .configured,
-            detail: "Configured. The app will launch your command with ClawDnD provider environment variables.",
-            detectedPath: cli
+            detail: "Ready. Launches \(launchCommand) with the ClawDnD provider environment and player-facade-only Codex wrapper.",
+            detectedPath: configuredCommand.isEmpty ? wrapper.path : cli
         )
     }
 
@@ -128,10 +122,17 @@ struct CodexProvider: ProviderAdapter {
         repoPath: URL,
         preferences: ProviderPreferences
     ) throws -> ProviderLaunchRequest {
-        let command = preferences.codexCommand.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !command.isEmpty else {
-            throw ProviderError.configuration("Codex provider is detected but not launch-configured. Set a Codex provider command in Settings.")
+        guard Shell.which("codex") != nil else {
+            throw ProviderError.missingDependency("Codex CLI is missing. Install codex before starting a Codex provider session.")
         }
+
+        let wrapper = repoPath.appendingPathComponent("scripts/play_codex_actor.sh")
+        guard FileManager.default.fileExists(atPath: wrapper.path) else {
+            throw ProviderError.configuration("Codex provider wrapper is missing: scripts/play_codex_actor.sh")
+        }
+
+        let configuredCommand = preferences.codexCommand.trimmingCharacters(in: .whitespacesAndNewlines)
+        let command = configuredCommand.isEmpty ? defaultCodexCommand : configuredCommand
         return ProviderLaunchRequest(
             name: "Codex game",
             executable: "/bin/zsh",
@@ -152,7 +153,11 @@ struct CodexProvider: ProviderAdapter {
     func stop(runId: String) {}
 
     func tailLogs(runId: String) -> String {
-        "Codex provider output is captured through the app supervisor."
+        "Codex provider output is captured through the app supervisor and play-state/<run-id>/codex-provider/."
+    }
+
+    private var defaultCodexCommand: String {
+        "scripts/play_codex_actor.sh"
     }
 }
 

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/ProviderAdapters.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/ProviderAdapters.swift
@@ -86,7 +86,6 @@ struct CodexProvider: ProviderAdapter {
         let cli = Shell.which("codex")
         let wrapper = repoPath.appendingPathComponent("scripts/play_codex_actor.sh")
         let configuredCommand = preferences.codexCommand.trimmingCharacters(in: .whitespacesAndNewlines)
-        let launchCommand = configuredCommand.isEmpty ? defaultCodexCommand : configuredCommand
 
         guard let cli else {
             return ProviderStatus(
@@ -109,7 +108,9 @@ struct CodexProvider: ProviderAdapter {
         return ProviderStatus(
             kind: kind,
             availability: .configured,
-            detail: "Ready. Launches \(launchCommand) with the ClawDnD provider environment and player-facade-only Codex wrapper.",
+            detail: configuredCommand.isEmpty
+                ? "Ready. Launches the checked-in Codex wrapper with the ClawDnD provider environment and player-facade-only tool surface."
+                : "Ready. Launches your configured Codex command with the ClawDnD provider environment and player-facade-only tool surface.",
             detectedPath: configuredCommand.isEmpty ? wrapper.path : cli
         )
     }

--- a/scripts/play_codex_actor.sh
+++ b/scripts/play_codex_actor.sh
@@ -9,6 +9,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+fail() {
+  echo "[codex-provider] $*" >&2
+  exit 2
+}
+
 MODE="run"
 case "${1:-}" in
   --dry-run) MODE="dry-run"; shift ;;
@@ -35,12 +40,9 @@ Optional:
 EOF
     exit 0
     ;;
+  --*) fail "unknown option: $1" ;;
 esac
-
-fail() {
-  echo "[codex-provider] $*" >&2
-  exit 2
-}
+[ "$#" -eq 0 ] || fail "unexpected argument: $1"
 
 require_env() {
   local name="$1" value="${!1:-}"

--- a/scripts/play_codex_actor.sh
+++ b/scripts/play_codex_actor.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Run Codex as a constrained ClawDnD player actor.
+#
+# The native app launches this through the provider environment contract. This
+# wrapper never writes campaign snapshots or QA/canon content; it only creates
+# provider-local logs/config and lets Codex emit moves through player_server.py.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+MODE="run"
+case "${1:-}" in
+  --dry-run) MODE="dry-run"; shift ;;
+  --smoke) MODE="smoke"; shift ;;
+  -h|--help)
+    cat <<'EOF'
+Usage: scripts/play_codex_actor.sh [--dry-run|--smoke]
+
+Required environment:
+  CLAWDND_PROVIDER=codex
+  CLAWDND_WORLD
+  CLAWDND_RUN_ID
+  CLAWDND_PLAY_PORT
+  CLAWDND_PLAY_BUDGET
+  CLAWDND_PLAY_SESSION_BUDGET
+  CLAWDND_PLAY_MAX_TURNS
+
+Optional:
+  CLAWDND_PLAY_COMPANIONS
+  CLAWDND_ACTOR_ID
+  CLAWDND_ACTOR_ROLE
+  CLAWDND_CODEX_MODEL
+  CLAWDND_STATE_ROOT
+EOF
+    exit 0
+    ;;
+esac
+
+fail() {
+  echo "[codex-provider] $*" >&2
+  exit 2
+}
+
+require_env() {
+  local name="$1" value="${!1:-}"
+  [ -n "${value//[[:space:]]/}" ] || fail "missing required env: $name"
+}
+
+require_env CLAWDND_PROVIDER
+PROVIDER_LOWER="$(printf '%s' "$CLAWDND_PROVIDER" | tr '[:upper:]' '[:lower:]')"
+[ "$PROVIDER_LOWER" = "codex" ] || fail "CLAWDND_PROVIDER must be codex"
+require_env CLAWDND_WORLD
+require_env CLAWDND_RUN_ID
+require_env CLAWDND_PLAY_PORT
+require_env CLAWDND_PLAY_BUDGET
+require_env CLAWDND_PLAY_SESSION_BUDGET
+require_env CLAWDND_PLAY_MAX_TURNS
+
+[[ "$CLAWDND_PLAY_PORT" =~ ^[0-9]+$ ]] || fail "CLAWDND_PLAY_PORT must be an integer"
+if [ "$CLAWDND_PLAY_PORT" -lt 1 ] || [ "$CLAWDND_PLAY_PORT" -gt 65535 ]; then
+  fail "CLAWDND_PLAY_PORT out of range: $CLAWDND_PLAY_PORT"
+fi
+[[ "$CLAWDND_PLAY_MAX_TURNS" =~ ^[0-9]+$ ]] || fail "CLAWDND_PLAY_MAX_TURNS must be an integer"
+for budget_name in CLAWDND_PLAY_BUDGET CLAWDND_PLAY_SESSION_BUDGET; do
+  [[ "${!budget_name}" =~ ^[0-9]+([.][0-9]+)?$ ]] || fail "$budget_name must be a positive decimal"
+done
+[[ "$CLAWDND_RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]] || fail "CLAWDND_RUN_ID may only contain letters, numbers, '.', '_' and '-'"
+
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+command -v uv >/dev/null 2>&1 || fail "uv is required"
+if [ "$MODE" = "run" ]; then
+  command -v codex >/dev/null 2>&1 || fail "codex CLI is required for real provider runs"
+fi
+
+if [ "$MODE" = "smoke" ]; then
+  STATE_ROOT="${CLAWDND_STATE_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/clawdnd-codex-smoke.XXXXXX")}"
+else
+  STATE_ROOT="${CLAWDND_STATE_ROOT:-$ROOT/play-state}"
+fi
+STATE_ROOT="$(python3 - "$STATE_ROOT" <<'PY'
+import sys
+from pathlib import Path
+print(Path(sys.argv[1]).expanduser().resolve(strict=False))
+PY
+)"
+
+RUN_DIR="$STATE_ROOT/$CLAWDND_RUN_ID"
+PROVIDER_DIR="$RUN_DIR/codex-provider"
+MOVES="$RUN_DIR/player_moves.jsonl"
+CONFIG="$PROVIDER_DIR/codex-player.toml"
+PROMPT_FILE="$PROVIDER_DIR/prompt.md"
+STDOUT_LOG="$PROVIDER_DIR/codex.stdout.jsonl"
+STDERR_LOG="$PROVIDER_DIR/codex.stderr.log"
+LAST_MESSAGE="$PROVIDER_DIR/codex.last.txt"
+
+mkdir -p "$PROVIDER_DIR"
+touch "$MOVES"
+
+python3 - "$ROOT" "$RUN_DIR" "$MOVES" "$CONFIG" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root, state_dir, moves, out = sys.argv[1:]
+env = {
+    "CLAWDND_STATE_DIR": state_dir,
+    "CLAWDND_PLAYER_MOVES": moves,
+    "CLAWDND_ACTOR_ID": "",
+    "CLAWDND_ACTOR_ROLE": "player",
+}
+out_path = Path(out)
+out_path.write_text(
+    "\n".join(
+        [
+            "[mcp_servers.clawdnd-player]",
+            'command = "uv"',
+            "args = " + json.dumps(
+                ["run", "--directory", f"{root}/servers/engine", "python", "player_server.py"]
+            ),
+            "env = " + "{"
+            + ", ".join(f"{key} = {json.dumps(value)}" for key, value in env.items())
+            + "}",
+            "required = true",
+            "enabled_tools = "
+            + json.dumps(
+                [
+                    "say",
+                    "do",
+                    "clarify",
+                    "request_check",
+                    "cast_spell",
+                    "use_item",
+                    "attack",
+                    "look",
+                    "my_sheet",
+                ]
+            ),
+            'default_tools_approval_mode = "auto"',
+            "",
+        ]
+    ),
+    encoding="utf-8",
+)
+PY
+
+cat > "$PROMPT_FILE" <<EOF
+You are the Codex player actor for ClawDnD run "$CLAWDND_RUN_ID" in world "$CLAWDND_WORLD".
+
+Hard boundary:
+- You are a player character, not the DM, narrator, QA harness, campaign author, or engine writer.
+- Do not edit files, campaign snapshots, engine store files, QA state, content, skills, prompts, rubrics, or world canon.
+- Use only the clawdnd-player tools exposed to you.
+- Emit legal player moves only: say, do, clarify, request_check, cast_spell, use_item, attack.
+- Read-only tools like look and my_sheet are allowed for grounding.
+- If no character or scene is available, ask one concise clarify question through the facade and stop.
+
+Session caps:
+- per-turn budget: $CLAWDND_PLAY_BUDGET
+- session budget: $CLAWDND_PLAY_SESSION_BUDGET
+- max turns: $CLAWDND_PLAY_MAX_TURNS
+
+Act once through the player facade, then stop.
+EOF
+
+summary() {
+  python3 - "$MODE" "$ROOT" "$STATE_ROOT" "$CLAWDND_WORLD" "$CLAWDND_RUN_ID" "$CLAWDND_PLAY_PORT" "$CONFIG" "$MOVES" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+mode, root, state_root, world, run_id, port, config, moves = sys.argv[1:]
+print(json.dumps({
+    "ok": True,
+    "mode": mode,
+    "provider": "codex",
+    "repo": root,
+    "state_root": state_root,
+    "world": world,
+    "run_id": run_id,
+    "port": int(port),
+    "config": str(Path(config).resolve(strict=False)),
+    "moves": str(Path(moves).resolve(strict=False)),
+}, indent=2, sort_keys=True))
+PY
+}
+
+echo "[codex-provider] run=$CLAWDND_RUN_ID world=$CLAWDND_WORLD port=$CLAWDND_PLAY_PORT mode=$MODE"
+echo "[codex-provider] config=$CONFIG"
+echo "[codex-provider] moves=$MOVES"
+
+if [ "$MODE" != "run" ]; then
+  summary
+  exit 0
+fi
+
+CODEX_MODEL="${CLAWDND_CODEX_MODEL:-gpt-5.1-codex-max}"
+export CLAWDND_STATE_DIR="$RUN_DIR"
+export CLAWDND_PLAYER_MOVES="$MOVES"
+export CLAWDND_ACTOR_ID="${CLAWDND_ACTOR_ID:-}"
+export CLAWDND_ACTOR_ROLE="${CLAWDND_ACTOR_ROLE:-player}"
+
+codex exec \
+  --ignore-user-config \
+  --ignore-rules \
+  --sandbox read-only \
+  --ask-for-approval never \
+  --json \
+  --model "$CODEX_MODEL" \
+  --cd "$ROOT" \
+  --output-last-message "$LAST_MESSAGE" \
+  -c "mcp_servers.clawdnd-player.command=\"uv\"" \
+  -c "mcp_servers.clawdnd-player.args=[\"run\",\"--directory\",\"$ROOT/servers/engine\",\"python\",\"player_server.py\"]" \
+  -c "mcp_servers.clawdnd-player.env_vars=[\"CLAWDND_STATE_DIR\",\"CLAWDND_PLAYER_MOVES\",\"CLAWDND_ACTOR_ID\",\"CLAWDND_ACTOR_ROLE\"]" \
+  -c "mcp_servers.clawdnd-player.required=true" \
+  -c "mcp_servers.clawdnd-player.enabled_tools=[\"say\",\"do\",\"clarify\",\"request_check\",\"cast_spell\",\"use_item\",\"attack\",\"look\",\"my_sheet\"]" \
+  - < "$PROMPT_FILE" \
+  > >(tee -a "$STDOUT_LOG") \
+  2> >(tee -a "$STDERR_LOG" >&2)

--- a/servers/engine/tests/test_codex_provider_wrapper.py
+++ b/servers/engine/tests/test_codex_provider_wrapper.py
@@ -1,0 +1,88 @@
+"""Codex provider wrapper contract tests.
+
+The wrapper is allowed to create provider-local logs/config and a move sink. It
+must fail closed on missing launch env and its smoke mode must not start Codex or
+run narrative QA.
+"""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = ROOT / "scripts" / "play_codex_actor.sh"
+
+
+def _env(tmp_path: Path, **overrides: str) -> dict[str, str]:
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "TMPDIR": os.environ.get("TMPDIR", ""),
+        "CLAWDND_PROVIDER": "codex",
+        "CLAWDND_WORLD": "baldurs-gate",
+        "CLAWDND_RUN_ID": "codex-smoke",
+        "CLAWDND_PLAY_PORT": "8765",
+        "CLAWDND_PLAY_BUDGET": "0.05",
+        "CLAWDND_PLAY_SESSION_BUDGET": "0.25",
+        "CLAWDND_PLAY_MAX_TURNS": "1",
+        "CLAWDND_PLAY_COMPANIONS": "",
+        "CLAWDND_STATE_ROOT": str(tmp_path),
+    }
+    env.update(overrides)
+    return env
+
+
+def _run(args: list[str], env: dict[str, str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["/bin/bash", str(SCRIPT), *args],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_codex_wrapper_fails_closed_without_required_env(tmp_path):
+    result = _run(["--dry-run"], {"PATH": os.environ.get("PATH", ""), "TMPDIR": str(tmp_path)})
+
+    assert result.returncode != 0
+    assert "missing required env" in result.stderr
+
+
+def test_codex_wrapper_rejects_non_codex_provider(tmp_path):
+    result = _run(["--dry-run"], _env(tmp_path, CLAWDND_PROVIDER="openclaw"))
+
+    assert result.returncode != 0
+    assert "CLAWDND_PROVIDER must be codex" in result.stderr
+
+
+def test_codex_wrapper_smoke_generates_player_facade_config_only(tmp_path):
+    result = _run(["--smoke"], _env(tmp_path))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    summary = json.loads(result.stdout[result.stdout.index("{") :])
+    assert summary["ok"] is True
+    assert summary["mode"] == "smoke"
+    assert summary["provider"] == "codex"
+
+    config = Path(summary["config"]).read_text(encoding="utf-8")
+    assert "[mcp_servers.clawdnd-player]" in config
+    assert "player_server.py" in config
+    assert "CLAWDND_PLAYER_MOVES" in config
+    assert "servers/engine/server.py" not in config
+    assert "qa/" not in config
+
+    moves = Path(summary["moves"])
+    assert moves.exists()
+    assert moves.read_text(encoding="utf-8") == ""
+
+
+def test_codex_wrapper_dry_run_uses_play_state_layout(tmp_path):
+    result = _run(["--dry-run"], _env(tmp_path, CLAWDND_RUN_ID="layout-check"))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    summary = json.loads(result.stdout[result.stdout.index("{") :])
+    assert summary["config"].endswith("/layout-check/codex-provider/codex-player.toml")
+    assert summary["moves"].endswith("/layout-check/player_moves.jsonl")

--- a/servers/engine/tests/test_codex_provider_wrapper.py
+++ b/servers/engine/tests/test_codex_provider_wrapper.py
@@ -58,6 +58,13 @@ def test_codex_wrapper_rejects_non_codex_provider(tmp_path):
     assert "CLAWDND_PROVIDER must be codex" in result.stderr
 
 
+def test_codex_wrapper_rejects_unknown_options_before_run_mode(tmp_path):
+    result = _run(["--dryrun"], _env(tmp_path))
+
+    assert result.returncode != 0
+    assert "unknown option: --dryrun" in result.stderr
+
+
 def test_codex_wrapper_smoke_generates_player_facade_config_only(tmp_path):
     result = _run(["--smoke"], _env(tmp_path))
 


### PR DESCRIPTION
## Summary

Adds a Codex provider wrapper that routes Codex through the ClawDnD player facade instead of giving it engine-writer or repository mutation authority.

Refs #96
Refs #82

## Architecture commitments

- Engine remains the sole game-state writer.
- Codex runs as a constrained player actor, not a DM, narrator, QA harness, campaign author, or engine writer.
- The wrapper exposes only `servers/engine/player_server.py` tools through the `clawdnd-player` MCP surface.
- The wrapper writes only provider-local artifacts under `play-state/<run-id>/codex-provider/` plus the player move JSONL sink.
- No live Codex narrative/model session was run during validation.
- Unknown wrapper options fail closed before run mode, so a typo like `--dryrun` cannot accidentally start `codex exec`.
- The macOS Swift workflow now runs for PRs targeting `main`, so provider adapter changes get remote SwiftPM validation.

## Files changed

- `scripts/play_codex_actor.sh`
  - checked-in Codex actor wrapper with `run`, `--dry-run`, and `--smoke` modes.
  - validates provider env, budgets, port, run id, and required local tools.
  - generates provider-local Codex MCP config and prompt.
  - runs Codex with read-only sandbox and player-facade-only MCP tools in real mode.
- `macos/ClawDnDApp/Sources/ClawDnDApp/Services/ProviderAdapters.swift`
  - Codex adapter now fails closed when `codex` or the wrapper is missing.
  - uses the checked-in wrapper as the default Codex launch command when no custom command is configured.
  - avoids echoing configured command text in provider status details.
- `servers/engine/tests/test_codex_provider_wrapper.py`
  - covers required env, provider kind rejection, unknown option rejection, smoke config, and play-state layout.
- `.github/workflows/macos-swift.yml`
  - enables SwiftPM build validation for PRs targeting `main` when macOS app, script, or workflow files change.

## Validation

Local, from `/Volumes/LEXAR/repos/ClawDnD-codex-provider-wrapper`:

- `bash -n scripts/play_codex_actor.sh`
- wrapper `--dry-run`
- `uv run --directory servers/engine --group dev pytest -q tests/test_codex_provider_wrapper.py tests/test_player_facade.py tests/test_player_facade_actor.py`
- `swift build --package-path macos/ClawDnDApp`
- `git diff --check`

GitHub:

- CI `test`
- CI `license-check`
- macOS Swift `SwiftPM build` expected on the hardened head after workflow filter update.
- CodeRabbit status/comments checked; prior bot review was rate-limited, so independent adversarial review was used and its blockers were fixed in `a7dd636`.

## Risk and rollback

Risk is bounded to the Codex provider path, a new script, a provider-adapter branch, focused tests, and Swift CI coverage. Revert this PR if the Codex wrapper direction changes or if a future native app provider contract replaces shell-based provider launches.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Codex provider now supports a built-in default command when no custom command is configured.
  * Added a constrained Codex player actor runner with dry-run and smoke test modes for validation.

* **Tests**
  * Added comprehensive test coverage for the Codex provider wrapper to ensure reliability.

* **Chores**
  * Updated CI workflow to include the main branch in pull request triggers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->