### PR TITLE
Render structured combat event cards

### DIFF
--- a/viewer/dashboard.html
+++ b/viewer/dashboard.html
@@ -191,8 +191,12 @@
   .combat-card-main { margin-top:6px; color:#dfc5b8; font-size:13px; }
   .combat-card-meta { margin-top:6px; display:flex; flex-wrap:wrap; gap:6px; color:#bda997; font-size:11px; }
   .combat-card-meta span { border:1px solid #3d3027; background:#18110d; border-radius:7px; padding:2px 6px; }
+  .combat-card-meta span.warn { border-color:#5f4b2a; color:#e8c878; }
   .combat-card.outcome-crit { border-color:#9b5d3b; }
   .combat-card.outcome-miss { border-color:#3f3a35; }
+  .combat-card.outcome-move { border-color:#5b4c2f; }
+  .combat-card.outcome-turn { border-color:#4b5368; }
+  .combat-card.outcome-death-save { border-color:#72505f; }
   /* "The DM is narrating…" — a pending bubble while the DM's turn is in flight (the
      player has acted; the response is composing). Perception fix: turn latency read as
      "the DM isn't engaging". Three breathing dots under the DM byline. */
@@ -904,6 +908,16 @@ function hpText(state) {
   if (Number.isFinite(Number(state.current_hp))) return `${state.current_hp} HP`;
   return "";
 }
+function refName(ref, fallback = "") {
+  return ref && ref.name ? ref.name : fallback;
+}
+function combatMeta(meta, label, value, cls = "") {
+  if (value === undefined || value === null || value === "") return;
+  meta.push({ label, value, cls });
+}
+function combatList(items) {
+  return (Array.isArray(items) ? items : []).map(i => refName(i)).filter(Boolean).join(", ");
+}
 function combatEventCard(e) {
   const p = e && e.payload;
   if (!p || p.schema !== COMBAT_EVENT_SCHEMA) return "";
@@ -918,32 +932,62 @@ function combatEventCard(e) {
     const roll = p.roll || {};
     const ac = p.target && p.target.ac ? ` vs AC ${p.target.ac}` : "";
     main = `Attack ${roll.total ?? "?"}${ac}`;
-    if (roll.natural) meta.push(`d20 ${roll.natural}`);
-    if (p.damage) meta.push(`Damage ${p.damage.total ?? 0}${p.damage.type ? " " + p.damage.type : ""}`);
+    combatMeta(meta, "d20", roll.natural);
+    combatMeta(meta, "Damage", p.damage ? `${p.damage.total ?? 0}${p.damage.type ? " " + p.damage.type : ""}` : "");
     const hp = hpText(p.target_state);
-    if (hp) meta.push(`HP ${hp}`);
+    combatMeta(meta, "HP", hp);
   } else if (p.event === "damage") {
     outcome = "damage";
     main = `${target || "Target"} takes ${p.result && p.result.damage_to_hp !== undefined ? p.result.damage_to_hp : p.amount || 0}${p.damage_type ? " " + p.damage_type : ""} damage`;
     const hp = hpText(p.result);
-    if (hp) meta.push(`HP ${hp}`);
+    combatMeta(meta, "HP", hp);
   } else if (p.event === "healing") {
     outcome = "healing";
     main = `${target || "Target"} regains ${p.result && p.result.healed !== undefined ? p.result.healed : p.amount || 0} hit points`;
     const hp = hpText(p.result);
-    if (hp) meta.push(`HP ${hp}`);
+    combatMeta(meta, "HP", hp);
   } else if (p.event === "combat_start") {
     outcome = "start";
     const names = (p.combatants || []).map(c => c.name).filter(Boolean).join(", ");
     main = names ? `Initiative: ${names}` : (e.text || "Combat begins");
-    if (p.round) meta.push(`Round ${p.round}`);
+    combatMeta(meta, "Round", p.round);
   } else if (p.event === "combat_end") {
     outcome = "end";
     main = e.text || "Combat ends";
-    if (p.round) meta.push(`Ended in round ${p.round}`);
-    if (p.xp_awarded) meta.push(`${p.xp_awarded} XP`);
+    combatMeta(meta, "Ended", p.round ? `round ${p.round}` : "");
+    combatMeta(meta, "XP", p.xp_awarded);
+  } else if (p.event === "zone_movement") {
+    outcome = "move";
+    main = `${actor || "Combatant"} moves from ${p.from_zone || "an unset zone"} to ${p.to_zone || "an unset zone"}`;
+    const provokers = combatList(p.provokers);
+    combatMeta(meta, "OA", p.opportunity_attack ? (provokers || "provoked") : "none");
+    (Array.isArray(p.warnings) ? p.warnings : []).forEach(w => combatMeta(meta, "Warn", w, "warn"));
+  } else if (p.event === "turn_advanced") {
+    outcome = "turn";
+    const current = refName(p.current, "no living combatant");
+    main = `Turn advances to ${current}`;
+    combatMeta(meta, "Round", p.round);
+    combatMeta(meta, "Index", Number.isFinite(Number(p.turn_index)) ? p.turn_index : "");
+    combatMeta(meta, "New round", p.new_round ? "yes" : "");
+    combatMeta(meta, "Death save", p.death_save_due ? "due" : "");
+    const expired = combatList(p.expired_effects);
+    combatMeta(meta, "Expired", expired);
+  } else if (p.event === "death_save") {
+    outcome = "death-save";
+    const roll = p.roll || {};
+    const who = target || "Combatant";
+    const result = (p.result || "rolled").toString().replace(/_/g, " ");
+    main = `${who} rolls ${roll.total ?? "?"}: ${result}`;
+    combatMeta(meta, "d20", roll.natural);
+    combatMeta(meta, "Saves", `${p.successes ?? 0} success / ${p.failures ?? 0} fail`);
+    if (p.state) {
+      combatMeta(meta, "HP", hpText(p.state));
+      combatMeta(meta, "State", p.state.dead ? "dead" : (p.state.stable ? "stable" : (p.state.dying ? "dying" : "")));
+    }
+  } else {
+    return "";
   }
-  return `<div class="combat-card outcome-${statusClass(outcome)}"><div class="combat-card-top"><span class="combat-chip">${esc(outcome)}</span><span class="combat-title">${esc(title)}</span></div><div class="combat-card-main">${esc(main)}</div>${meta.length ? `<div class="combat-card-meta">${meta.map(m=>`<span>${esc(m)}</span>`).join("")}</div>` : ""}</div>`;
+  return `<div class="combat-card outcome-${statusClass(outcome)}"><div class="combat-card-top"><span class="combat-chip">${esc(outcome)}</span><span class="combat-title">${esc(title)}</span></div><div class="combat-card-main">${esc(main)}</div>${meta.length ? `<div class="combat-card-meta">${meta.map(m=>`<span${m.cls?` class="${esc(m.cls)}"`:""}>${esc(m.label)} ${esc(m.value)}</span>`).join("")}</div>` : ""}</div>`;
 }
 const initials = (n) => (n||"?").trim().split(/\s+/).map(w=>w[0]).slice(0,2).join("").toUpperCase();
 const shortId = (id) => {

--- a/viewer/tests/test_combat_event_cards.py
+++ b/viewer/tests/test_combat_event_cards.py
@@ -11,13 +11,16 @@ _DASHBOARD_PATH = Path(__file__).resolve().parents[1] / "dashboard.html"
 def _renderer_source() -> str:
     html = _DASHBOARD_PATH.read_text(encoding="utf-8")
     start = html.index("const esc =")
-    end = html.index("const countNames =", start)
+    status_start = html.index("const statusClass =", start)
+    end = html.index("const countNames =", status_start)
     return html[start:end]
 
 
 @unittest.skipIf(shutil.which("node") is None, "node is required for dashboard renderer fixture tests")
 class CombatEventCardTests(unittest.TestCase):
-    def _render_cards(self):
+    NODE_BIN = shutil.which("node")
+
+    def _render_cards(self) -> dict:
         fixtures = {
             "attack": {
                 "kind": "combat",
@@ -89,7 +92,7 @@ class CombatEventCardTests(unittest.TestCase):
             + ";\nconst out = Object.fromEntries(Object.entries(fixtures).map(([k, v]) => [k, combatEventCard(v)]));\nconsole.log(JSON.stringify(out));\n"
         )
         proc = subprocess.run(
-            ["node"],
+            [self.NODE_BIN],
             input=program,
             text=True,
             capture_output=True,

--- a/viewer/tests/test_combat_event_cards.py
+++ b/viewer/tests/test_combat_event_cards.py
@@ -1,0 +1,135 @@
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+_DASHBOARD_PATH = Path(__file__).resolve().parents[1] / "dashboard.html"
+
+
+def _renderer_source() -> str:
+    html = _DASHBOARD_PATH.read_text(encoding="utf-8")
+    start = html.index("const esc =")
+    end = html.index("const countNames =", start)
+    return html[start:end]
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required for dashboard renderer fixture tests")
+class CombatEventCardTests(unittest.TestCase):
+    def _render_cards(self):
+        fixtures = {
+            "attack": {
+                "kind": "combat",
+                "text": "Vela hits Goblin.",
+                "payload": {
+                    "schema": "clawdnd.combat_event.v1",
+                    "event": "attack",
+                    "outcome": "crit",
+                    "actor": {"name": 'Vela <script>alert("x")</script>'},
+                    "target": {"name": "Goblin", "ac": 13},
+                    "roll": {"total": 24, "natural": 20},
+                    "damage": {"total": 11, "type": "slashing"},
+                    "target_state": {"current_hp": 2},
+                },
+            },
+            "zone_movement": {
+                "kind": "combat",
+                "text": "Vela moves.",
+                "payload": {
+                    "schema": "clawdnd.combat_event.v1",
+                    "event": "zone_movement",
+                    "actor": {"name": "Vela"},
+                    "from_zone": "Doorway",
+                    "to_zone": "Altar <img src=x onerror=alert(1)>",
+                    "opportunity_attack": True,
+                    "provokers": [{"name": "Cultist"}],
+                    "warnings": ['"Altar" is not adjacent'],
+                },
+            },
+            "turn_advanced": {
+                "kind": "combat",
+                "text": "Turn advances.",
+                "payload": {
+                    "schema": "clawdnd.combat_event.v1",
+                    "event": "turn_advanced",
+                    "round": 3,
+                    "new_round": True,
+                    "current": {"name": "Goblin"},
+                    "turn_index": 1,
+                    "death_save_due": True,
+                    "expired_effects": [{"name": "Bless"}],
+                },
+            },
+            "death_save": {
+                "kind": "combat",
+                "text": "Vela rolls a death save.",
+                "payload": {
+                    "schema": "clawdnd.combat_event.v1",
+                    "event": "death_save",
+                    "target": {"name": "Vela"},
+                    "roll": {"total": 1, "natural": 1},
+                    "result": "dead",
+                    "successes": 0,
+                    "failures": 3,
+                    "state": {"current_hp": 0, "dead": True, "stable": False, "dying": False},
+                },
+            },
+            "unknown": {
+                "kind": "combat",
+                "text": "Plain fallback text.",
+                "payload": {"schema": "clawdnd.combat_event.v1", "event": "new_future_event"},
+            },
+            "plain": {"kind": "combat", "text": "Plain combat text."},
+        }
+        program = (
+            _renderer_source()
+            + "\nconst fixtures = "
+            + json.dumps(fixtures)
+            + ";\nconst out = Object.fromEntries(Object.entries(fixtures).map(([k, v]) => [k, combatEventCard(v)]));\nconsole.log(JSON.stringify(out));\n"
+        )
+        proc = subprocess.run(
+            ["node"],
+            input=program,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return json.loads(proc.stdout)
+
+    def test_new_combat_payloads_render_as_cards(self):
+        cards = self._render_cards()
+
+        self.assertIn("outcome-crit", cards["attack"])
+        self.assertIn("Attack 24 vs AC 13", cards["attack"])
+        self.assertIn("Damage 11 slashing", cards["attack"])
+
+        self.assertIn("outcome-move", cards["zone_movement"])
+        self.assertIn("moves from Doorway to Altar", cards["zone_movement"])
+        self.assertIn("OA Cultist", cards["zone_movement"])
+        self.assertIn("class=\"warn\"", cards["zone_movement"])
+
+        self.assertIn("outcome-turn", cards["turn_advanced"])
+        self.assertIn("Turn advances to Goblin", cards["turn_advanced"])
+        self.assertIn("Death save due", cards["turn_advanced"])
+        self.assertIn("Expired Bless", cards["turn_advanced"])
+
+        self.assertIn("outcome-death-save", cards["death_save"])
+        self.assertIn("Vela rolls 1: dead", cards["death_save"])
+        self.assertIn("Saves 0 success / 3 fail", cards["death_save"])
+        self.assertIn("State dead", cards["death_save"])
+
+    def test_cards_escape_payload_strings_and_preserve_fallbacks(self):
+        cards = self._render_cards()
+        joined = "\n".join(cards.values())
+
+        self.assertNotIn("<script>", joined)
+        self.assertNotIn("<img", joined)
+        self.assertIn("&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;", cards["attack"])
+        self.assertIn("&lt;img src=x onerror=alert(1)&gt;", cards["zone_movement"])
+        self.assertEqual(cards["unknown"], "")
+        self.assertEqual(cards["plain"], "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Completes the viewer/dashboard half of #66 under the #57 combat readability epic.

This PR teaches the dashboard feed to render the structured combat event payloads now emitted on `main` for:

- `attack`
- `zone_movement`
- `turn_advanced`
- `death_save`

It preserves the existing plain-text path for combat events without a supported structured payload, so unknown future payloads and ordinary log text continue to fall back to the generic escaped text renderer.

## Architecture Commitments

- The viewer remains a downstream projection of engine truth. No combat mutation, state derivation, or pass-through behavior was added here.
- The renderer only recognizes the stable `clawdnd.combat_event.v1` schema and known event names; unsupported payload events return an empty card string so the existing `combatCard || esc(e.text)` fallback remains authoritative.
- All card-visible strings still flow through the existing dashboard `esc()` function before landing in `innerHTML`, including actor names, zones, warnings, death-save results, and metadata labels.
- The card model stays compact: the engine payload is read directly, with small viewer-only helpers for display names, metadata chips, and list formatting.

## User-Facing Behavior

- Movement events now show from/to zones, opportunity-attack provokers, and warning chips.
- Turn advancement events now show the new actor, round/index context, new-round marker, death-save due marker, and expired effects.
- Death-save events now show the target, roll, outcome, success/failure pips as text, HP, and terminal state.
- Existing attack cards keep hit/miss/crit, roll, AC, damage, and target HP metadata while using the same safer metadata path.

## Validation

Run from `/Volumes/LEXAR/repos/ClawDnD-combat-card-renderer`:

```bash
python3 -m unittest viewer.tests.test_combat_event_cards viewer.tests.test_action_model
python3 -m py_compile viewer/server.py
git diff --check
```

I intentionally did not run live story QA, per scope.

## Residual Risks

- This is fixture/unit coverage of the dashboard renderer, not a browser smoke test; CSS layout was not visually inspected in a live dashboard.
- Unknown future structured combat events intentionally fall back to plain escaped text until they get explicit card copy.
- The viewer trusts the engine's payload field names for these known events; if the engine schema changes, the fallback remains safe but the richer card metadata may disappear.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced combat-card styling with new visual state variants for additional event outcomes (warn, move, turn, death-save).

* **Tests**
  * Added comprehensive test coverage for combat event card rendering, including HTML escaping validation and edge-case handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->