### PR TITLE
[viewer] Add save/load onboarding surface

### DIFF
--- a/servers/engine/tests/test_qa_gate.py
+++ b/servers/engine/tests/test_qa_gate.py
@@ -258,6 +258,54 @@ def test_sanitize_move_drops_unknown_fields_and_caps_length():
     assert len(long_m["text"]) <= 2000
 
 
+def test_campaign_summary_explains_resume_target_without_writes():
+    v = _viewer()
+    snap = {
+        "title": "Sundered Reach",
+        "world_id": "sundered-reach",
+        "day": 4,
+        "time_of_day": "dusk",
+        "current_location_id": "market",
+        "locations": {"market": {"name": "Lantern Market"}},
+        "characters": {
+            "pc": {"name": "Kield", "kind": "player"},
+            "ally": {"name": "Petra", "kind": "companion"},
+        },
+        "party": ["pc", "ally"],
+        "quests": {
+            "q1": {"title": "Find the bell", "status": "active"},
+            "q2": {"title": "Old debt", "status": "completed"},
+        },
+        "quest_hooks": [
+            {"title": "Smoke over the mill", "status": "open"},
+            {"title": "Spent rumor", "status": "resolved"},
+        ],
+    }
+
+    card = v.build_campaign_summary(
+        "camp_same_name_abc123",
+        snap,
+        last_played=1234.5,
+        current=True,
+        live=True,
+    )
+
+    assert card == {
+        "id": "camp_same_name_abc123",
+        "name": "Sundered Reach",
+        "world": "sundered-reach",
+        "day": 4,
+        "time_of_day": "dusk",
+        "location": "Lantern Market",
+        "party": ["Kield", "Petra"],
+        "party_count": 2,
+        "active_quest_count": 2,
+        "last_played": 1234.5,
+        "current": True,
+        "live": True,
+    }
+
+
 # --- viewer combat projection (#65) --------------------------------------------
 def test_combat_view_projects_active_combat_read_model():
     v = _viewer()

--- a/viewer/dashboard.html
+++ b/viewer/dashboard.html
@@ -66,10 +66,26 @@
     color:var(--ink); font-size:13px; }
   .sw-item:hover { background:#241a0d; }
   .sw-item.current { background:#2a1d0e; }
-  .sw-item .sw-i-name { flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--gold); }
+  .sw-item .sw-i-main { flex:1; min-width:0; display:flex; flex-direction:column; gap:2px; }
+  .sw-item .sw-i-top { display:flex; align-items:baseline; gap:7px; min-width:0; }
+  .sw-item .sw-i-name { min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--gold); }
+  .sw-id { color:#bcd4ec; border:1px solid #2e4456; background:#16222e; border-radius:7px; padding:0 5px;
+    font-size:9px; letter-spacing:.04em; flex:none; }
+  .sw-live { color:#bfe6c4; border:1px solid #2e5638; background:#14241a; border-radius:7px; padding:0 5px;
+    font-size:9px; letter-spacing:.05em; text-transform:uppercase; flex:none; }
+  .sw-item .sw-i-meta, .sw-item .sw-i-sub { color:var(--faint); font-size:10.5px; line-height:1.35; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
   .sw-item .sw-i-day { color:var(--faint); font-size:10.5px; letter-spacing:.04em; flex:none; }
   .sw-item .sw-i-tick { color:var(--gold2); font-size:11px; flex:none; width:12px; text-align:center; }
   .sw-empty { padding:8px 10px; color:var(--faint); font-size:11.5px; }
+  .empty-onboarding { max-width:560px; margin:auto; align-self:center; border:1px solid var(--card-line);
+    background:linear-gradient(180deg,#221b12,#18120c); border-radius:11px; padding:20px 22px;
+    box-shadow:0 10px 28px -16px rgba(0,0,0,.9),0 1px 0 rgba(232,201,138,.06) inset; color:var(--dim); }
+  .empty-onboarding h2 { margin:0 0 6px; color:var(--gold); font:600 18px/1.25 var(--font-display); letter-spacing:.03em; }
+  .empty-onboarding p { margin:0 0 12px; }
+  .empty-onboarding .steps { display:grid; gap:7px; margin-top:12px; }
+  .empty-onboarding .step { display:flex; gap:8px; align-items:flex-start; }
+  .empty-onboarding .num { flex:none; width:18px; height:18px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center;
+    color:#15110c; background:var(--gold2); font-size:11px; font-weight:800; }
   /* gear affordance: opens the read-only quick-settings modal. Pushed to the right edge. */
   .gear-btn { margin-left:auto; background:#1a140d; border:1px solid var(--line); color:var(--dim);
     border-radius:8px; width:30px; height:26px; font-size:14px; cursor:pointer; line-height:1;
@@ -996,6 +1012,21 @@ const shortId = (id) => {
   const tail = s.includes("_") ? s.split("_").filter(Boolean).pop() : s;
   return (tail || s).slice(-7);
 };
+const joinParts = (parts, sep = " · ") => parts.filter(v => v !== undefined && v !== null && v !== "").join(sep);
+function lastPlayedLabel(ts) {
+  const n = Number(ts || 0);
+  if (!n) return "unknown";
+  const delta = Date.now() - n * 1000;
+  if (delta < 0) return new Date(n * 1000).toLocaleString();
+  const min = Math.floor(delta / 60000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  return new Date(n * 1000).toLocaleDateString();
+}
 const statusClass = (s) => (s || "").toString().trim().toLowerCase().replace(/[^a-z0-9_-]+/g, "-") || "unknown";
 const countNames = (items, nameOf) => items.reduce((m, item) => {
   const k = (nameOf(item) || "").trim().toLowerCase();
@@ -2322,11 +2353,21 @@ function renderState(s) {
     // No campaign on disk yet (#M2): show a waiting message and keep the action layer off —
     // do NOT run the full render below, which would paint the scene/title with empty data.
     $("title").textContent = "ClawDnD";
+    $("when").textContent = "";
+    $("where").textContent = "";
     applyLiveMode(false);
     renderCombatCenter(s);
     renderActionBar(s);
     const feed = $("feed");
-    if (feed && !feed.children.length) feed.innerHTML = '<div class="empty">Waiting for the story to begin…</div>';
+    if (feed) feed.innerHTML = `<div class="empty-onboarding">
+      <h2>No saved campaign loaded</h2>
+      <p>This viewer is read-only. It attaches automatically when the engine writes a campaign snapshot.</p>
+      <div class="steps">
+        <div class="step"><span class="num">1</span><span>Resume an existing run from Claude Code or launch the dashboard command for a new adventure.</span></div>
+        <div class="step"><span class="num">2</span><span>Once a save exists, the picker above shows day, location, party, quests, and which save is live.</span></div>
+        <div class="step"><span class="num">3</span><span>Use this page to watch and choose saves; campaign creation stays in the engine flow.</span></div>
+      </div>
+    </div>`;
     return;
   }
   // Gate the action layer on whether the VIEWED campaign is the LIVE one (is_live_view) — not
@@ -2573,15 +2614,31 @@ function renderSwitcher() {
     ? _campaignList.find(c => c.id === selectedCampaignId)
     : _campaignList.find(c => c.current);
   const cur = viewing || _campaignList[0];
-  $("switcher-name").textContent = cur.name || cur.id;
-  $("switcher-day").textContent = (cur.day != null) ? ("Day " + cur.day) : "";
-  // Build the dropdown: one row per campaign (name + "Day N"), the viewed one ticked.
+  const nameCounts = countNames(_campaignList, c => c.name || c.id || "");
+  const duplicateCur = nameCount(nameCounts, cur.name || cur.id) > 1;
+  $("switcher-name").textContent = (cur.name || cur.id) + (duplicateCur ? ` #${shortId(cur.id)}` : "");
+  $("switcher-day").textContent = joinParts([cur.live && "live", cur.day != null ? ("Day " + cur.day) : ""], " · ");
+  $("switcher-btn").title = joinParts([
+    "Switch the campaign being viewed",
+    cur.location || "",
+    cur.party_count ? `${cur.party_count} party` : "",
+    cur.id ? `id ${cur.id}` : "",
+  ]);
+  // Build the dropdown: one row per campaign, with enough save metadata to disambiguate.
   $("switcher-menu").innerHTML = _campaignList.map(c => {
     const sel = c.id === cur.id;
+    const duplicate = nameCount(nameCounts, c.name || c.id) > 1;
+    const when = c.day != null ? ("Day " + c.day + (c.time_of_day ? `, ${c.time_of_day}` : "")) : "";
+    const questText = c.active_quest_count === 1 ? "1 active quest" : `${c.active_quest_count || 0} active quests`;
+    const partyText = c.party_count === 1 ? "1 party member" : `${c.party_count || 0} party members`;
+    const meta = joinParts([when, c.location || "Location unknown"]);
+    const sub = joinParts([partyText, questText, c.world || "", `last ${lastPlayedLabel(c.last_played)}`]);
     return `<div class="sw-item${sel?" current":""}" role="option" aria-selected="${sel}" data-cid="${esc(c.id)}">`
       + `<span class="sw-i-tick">${sel?"✓":""}</span>`
-      + `<span class="sw-i-name">${esc(c.name || c.id)}</span>`
-      + `<span class="sw-i-day">${c.day != null ? ("Day " + esc(c.day)) : ""}</span></div>`;
+      + `<span class="sw-i-main"><span class="sw-i-top"><span class="sw-i-name">${esc(c.name || c.id)}</span>`
+      + `${duplicate ? `<span class="sw-id">#${esc(shortId(c.id))}</span>` : ""}${c.live ? `<span class="sw-live">live</span>` : ""}</span>`
+      + `<span class="sw-i-meta">${esc(meta)}</span><span class="sw-i-sub">${esc(sub)}</span></span>`
+      + `<span class="sw-i-day">${c.current ? "current" : ""}</span></div>`;
   }).join("") || `<div class="sw-empty">No campaigns found.</div>`;
 }
 function openSwitcher() { const sw=$("switcher"); sw.classList.add("open"); $("switcher-btn").setAttribute("aria-expanded","true"); }

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -241,19 +241,104 @@ def _safe_campaign_id(campaign_id: Optional[str]) -> Optional[str]:
     return None
 
 
+def _display_location(snapshot: dict) -> str:
+    loc_id = snapshot.get("current_location_id")
+    locs = snapshot.get("locations")
+    if isinstance(locs, dict) and isinstance(loc_id, str):
+        loc = locs.get(loc_id)
+        if isinstance(loc, dict):
+            name = loc.get("name")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+        if loc_id.strip():
+            return loc_id.strip()
+    return ""
+
+
+def _party_names(snapshot: dict) -> list[str]:
+    chars = snapshot.get("characters")
+    party = snapshot.get("party")
+    if not isinstance(chars, dict) or not isinstance(party, list):
+        return []
+    out: list[str] = []
+    for cid in party:
+        if not isinstance(cid, str):
+            continue
+        ch = chars.get(cid)
+        if not isinstance(ch, dict):
+            continue
+        name = ch.get("name")
+        out.append(str(name or cid))
+    return out
+
+
+def _active_quest_count(snapshot: dict) -> int:
+    count = 0
+    quests = snapshot.get("quests")
+    if isinstance(quests, dict):
+        for q in quests.values():
+            if not isinstance(q, dict):
+                continue
+            status = str(q.get("status") or "active").strip().lower()
+            if status in ("", "active", "open"):
+                count += 1
+    hooks = snapshot.get("quest_hooks")
+    if isinstance(hooks, list):
+        for hook in hooks:
+            if not isinstance(hook, dict):
+                continue
+            status = str(hook.get("status") or "open").strip().lower()
+            if status not in ("resolved", "completed", "failed", "closed"):
+                count += 1
+    return count
+
+
+def build_campaign_summary(
+    campaign_id: str,
+    snapshot: dict,
+    *,
+    last_played: float,
+    current: bool,
+    live: bool,
+) -> dict:
+    """Read-only picker card for one save/campaign.
+
+    This is intentionally derived from snapshot facts plus file recency only: no engine imports,
+    no campaign creation, and no writer-path assumptions. The dashboard uses it to answer
+    "which save is this?" before the player resumes or starts elsewhere.
+    """
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    party = _party_names(snapshot)
+    return {
+        "id": campaign_id,
+        "name": str(snapshot.get("title") or campaign_id),
+        "world": str(snapshot.get("world_id") or ""),
+        "day": snapshot.get("day"),
+        "time_of_day": str(snapshot.get("time_of_day") or ""),
+        "location": _display_location(snapshot),
+        "party": party,
+        "party_count": len(party),
+        "active_quest_count": _active_quest_count(snapshot),
+        "last_played": last_played,
+        "current": bool(current),
+        "live": bool(live),
+    }
+
+
 def _list_campaigns() -> list[dict]:
     """All projectable campaigns under the campaigns dir, newest-active first (#H3 switcher).
 
-    One entry per campaign: {id, name, day, last_played, current}. `current` marks the
-    one currently *attached* (_Handler.campaign_id). `name` is the snapshot's world title
-    (falling back to the dir id). Empty/unparseable snapshots are skipped — the SAME guard
-    _pick_campaign uses, so a half-written/`{}` snapshot never shows as a pickable game.
-    Sorted by recency descending. Pure reader: no writes, no engine import."""
+    One entry per campaign is a read-only save card with title, day, location, party, quest
+    count, live/current flags, and last-played recency. Empty/unparseable snapshots are
+    skipped — the SAME guard _pick_campaign uses, so a half-written/`{}` snapshot never
+    shows as a pickable game. Sorted by recency descending. Pure reader: no writes, no
+    engine import."""
     cdir = _campaigns_dir()
     out: list[dict] = []
     if not cdir.is_dir():
         return out
     attached = _Handler.campaign_id
+    now = time.time()
     for snap in cdir.glob("*/snapshot.json"):
         try:
             data = json.loads(snap.read_text(encoding="utf-8"))
@@ -262,13 +347,14 @@ def _list_campaigns() -> list[dict]:
         if not isinstance(data, dict) or not data:
             continue  # empty/`{}` snapshot — nothing to show (mirror _pick_campaign)
         cid = snap.parent.name
-        out.append({
-            "id": cid,
-            "name": str(data.get("title") or cid),
-            "day": data.get("day"),
-            "last_played": _campaign_recency(snap),
-            "current": cid == attached,
-        })
+        recency = _campaign_recency(snap)
+        out.append(build_campaign_summary(
+            cid,
+            data,
+            last_played=recency,
+            current=cid == attached,
+            live=(now - recency) < 90,
+        ))
     out.sort(key=lambda c: c["last_played"], reverse=True)
     return out
 


### PR DESCRIPTION
## Summary

- Implements a focused first slice of #79 inside the read-only viewer: richer save/campaign metadata, same-name disambiguation, and clearer empty/resume onboarding.
- References #61 by keeping this within the CRPG dashboard playability surface, without build planner or engine-writer changes.
- Adds a focused regression test for the campaign picker read model.

## Architecture commitments

- Viewer remains a downstream reader: `/campaigns` derives metadata from `snapshot.json` plus session/snapshot mtimes only.
- No passive polling creates campaigns or writes campaign state.
- No engine writer paths, story content, QA rubrics, build planner, or campaign creation flows were touched.
- Campaign identity is still the filesystem campaign id; the UI only adds short-id disambiguation when visible save names collide.
- Resume/start guidance stays instructional in the viewer and points users back to the existing engine/dashboard launch flow.

## Validation

- `python3 -m py_compile viewer/server.py`
- `python3 -m pytest servers/engine/tests/test_qa_gate.py -q`
- `git diff --check HEAD~1..HEAD`
- Local HTTP smoke with temporary Lexar-backed state: `/campaigns` returned same-name saves with day/location/party/quest/live/current metadata, `/state?campaign=save_beta` rendered the non-live read model, and empty state returned `campaigns: []` plus `empty: true`.

## Risks / follow-up

- Browser automation was intentionally skipped because this worktree has no Playwright package and no Chrome/Chromium binary available; smoke coverage is HTTP-level plus focused tests.
- `live` in `/campaigns` is recency-based, matching existing monitor semantics; multiple recently touched saves can show live if their snapshots/session logs were updated within the window.
- This does not implement actual save creation/load mutation UX; it only improves the viewer onboarding/picker surface for #79.
