### PR TITLE
Expose engine build planner in viewer

### DIFF
--- a/viewer/dashboard.html
+++ b/viewer/dashboard.html
@@ -903,6 +903,7 @@ let evCursor = 0, actCursor = 0, chatCursor = 0, pcName = "";
 let lastFeedCampaign = undefined;  // the campaign the feed cursors belong to (reset on a switch)
 let lastChatRole = null;           // role of the newest chat line → drives the "DM is narrating…" bubble
 let lastState = null, activeView = "play";   // S2 player-sheet tabs
+const buildPlannerCache = new Map();          // campaign+character+snapshot signature -> planner response
 // Ring buffer of recent story beats captured off the SAME /chat or /events feed the
 // Play view polls, so the Memories journal (parity 6.1) can show logged beats without
 // re-fetching. Capped so a long session can't grow it unbounded.
@@ -2041,6 +2042,106 @@ function renderSpellbook(c, wrap) {
 }
 
 // ---- 4. PROGRESSION ---------------------------------------------------------
+function plannerCampaignId() {
+  return (lastState && lastState.id) || selectedCampaignId || "";
+}
+function plannerSignature(c) {
+  const classes = (c.classes||[]).map(cl => [cl.name||"", cl.level||0, cl.subclass||""]);
+  return JSON.stringify({
+    campaign: plannerCampaignId(),
+    character: c.id || "",
+    updated: lastState && lastState.updated_at,
+    xp: c.xp || 0,
+    level: totalLevel(c),
+    classes,
+  });
+}
+function requestBuildPlanner(c) {
+  const campaign = plannerCampaignId();
+  const character = c && c.id;
+  if (!campaign || !character) {
+    return { ok:false, code:"missing_scope", errors:["campaign or character id is missing"] };
+  }
+  const key = plannerSignature(c);
+  const hit = buildPlannerCache.get(key);
+  if (hit) return hit;
+  const pending = { pending:true, ok:false, code:"loading", errors:[] };
+  buildPlannerCache.set(key, pending);
+  fetch(`/build-options?campaign=${encodeURIComponent(campaign)}&character=${encodeURIComponent(character)}`)
+    .then(r => r.ok ? r.json() : { ok:false, code:"http_error", errors:[`planner HTTP ${r.status}`] })
+    .then(data => { buildPlannerCache.set(key, data); if (activeView === "progression") renderSheet(); })
+    .catch(err => {
+      buildPlannerCache.set(key, { ok:false, code:"network_error", errors:[err && err.message ? err.message : String(err)] });
+      if (activeView === "progression") renderSheet();
+    });
+  return pending;
+}
+function deltaTags(deltas, prefix) {
+  const rows = [];
+  Object.entries(deltas || {}).forEach(([id, d]) => {
+    const delta = Number(d && d.delta);
+    if (!Number.isFinite(delta) || delta === 0) return;
+    const label = prefix === "slot" ? `slot L${id}` : titleCase(id);
+    const recharge = d && d.recharge ? ` ${d.recharge}` : "";
+    rows.push(`<span class="tag">${esc(label)} ${signed(delta)}${esc(recharge)}</span>`);
+  });
+  return rows.join("");
+}
+function featureTags(features) {
+  const rows = (features || []).map(f => typeof f === "string" ? f : (f && f.name) || "").filter(Boolean);
+  return rows.length
+    ? rows.slice(0, 6).map(f => `<span class="tag">${esc(f)}</span>`).join("")
+    : `<span class="tag">no new features</span>`;
+}
+function optionChoiceTags(option) {
+  const choices = option.choices || {};
+  const tags = [];
+  if (choices.asi_required) tags.push(`<span class="tag cond">ASI required</span>`);
+  if (choices.asi_required && choices.feat_allowed) tags.push(`<span class="tag">Feat available</span>`);
+  if (choices.asi_required && choices.feat_allowed === false) tags.push(`<span class="tag warn">Feat blocked</span>`);
+  if (option.multiclass) tags.push(`<span class="tag">multiclass</span>`);
+  return tags.join("");
+}
+function buildPlannerHTML(response) {
+  if (!response || response.pending) {
+    return `<div class="scard" style="grid-column:1/-1"><h3>Engine build planner</h3>
+      <div class="empty">Loading planner preview…</div></div>`;
+  }
+  if (!response.ok) {
+    const code = response.code || "planner_error";
+    const errors = (response.errors || ["planner unavailable"]).map(e => `<li>${esc(e)}</li>`).join("");
+    return `<div class="scard" style="grid-column:1/-1"><h3>Engine build planner <span class="h3n">${esc(code)}</span></h3>
+      <ul class="obj-list">${errors}</ul></div>`;
+  }
+  const planner = response.planner || {};
+  const options = planner.options || [];
+  const blocked = planner.blocked_options || [];
+  const optionHTML = options.length ? options.map(option => {
+    const title = titleCase(option.class_name || (option.to && option.to.class) || "class");
+    const to = option.to || {};
+    const hp = option.hp_gain == null ? "" : `<span class="tag cond">+${esc(option.hp_gain)} HP</span>`;
+    const slots = deltaTags(option.spell_slots_delta || option.spell_slot_deltas, "slot");
+    const resources = deltaTags(option.resources_delta || option.resource_deltas, "resource");
+    const choices = optionChoiceTags(option);
+    return `<div class="pitem" style="align-items:flex-start;gap:10px">
+      <span class="p-nm"><b>${esc(title)}</b><br><span style="color:var(--dim)">level ${esc(to.level || "")}</span>
+        <div class="kv-tags" style="margin-top:7px">${hp}${choices}${slots}${resources}</div>
+        <div class="kv-tags" style="margin-top:7px">${featureTags(option.features_gained)}</div>
+      </span>
+      <span class="p-bonus" title="Engine-owned preview only">preview</span>
+    </div>`;
+  }).join("") : `<div class="empty">No legal build options returned.</div>`;
+  const blockedHTML = blocked.length
+    ? `<div class="kv-line" style="margin-top:10px;color:var(--dim)">Blocked</div>
+      <div class="plist">${blocked.slice(0, 8).map(option => {
+        const errors = (option.errors || ["blocked by engine planner"]).join("; ");
+        return `<div class="pitem"><span class="p-nm">${esc(titleCase(option.class_name || "class"))}<br>
+          <span style="color:var(--faint)">${esc(errors)}</span></span><span class="p-bonus">blocked</span></div>`;
+      }).join("")}</div>`
+    : "";
+  return `<div class="scard" style="grid-column:1/-1"><h3>Engine build planner <span class="h3n">${esc(response.source||"")}</span></h3>
+    <div class="plist">${optionHTML}</div>${blockedHTML}</div>`;
+}
 function renderProgression(c, wrap) {
   const lvl = totalLevel(c), xp = c.xp ?? 0;
   // Bracket the current XP within the 5e thresholds, anchored on the character's
@@ -2087,7 +2188,8 @@ function renderProgression(c, wrap) {
       `<div class="pitem"><span class="p-nm">${esc(cl.name)}${cl.subclass?` — ${esc(cl.subclass)}`:""}</span><span class="p-bonus">${cl.level}</span></div>`).join("")}</div>`
     : `<div class="empty">Unclassed.</div>`}</div>`;
 
-  const body = `<div class="sgrid cols2">${xpCard}${hdCard}${clsCard}</div>`;
+  const plannerCard = buildPlannerHTML(requestBuildPlanner(c));
+  const body = `<div class="sgrid cols2">${xpCard}${hdCard}${clsCard}${plannerCard}</div>`;
   wrap.innerHTML = sheetShell((c.name?c.name+"'s ":"")+"Progression", identityLine(c), body);
 }
 

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -5,7 +5,9 @@ Run it for the PLAYER to *see* the adventure while they play through Claude Code
 the current location/map, party vitals, who's in the scene (with voices), the
 quest log, and a live roll/event feed. The AI never reads this — it reads the
 same state via the engine's MCP tools. This server is a **pure downstream
-reader**: stdlib only (no deps, runs anywhere). It has exactly two side effects,
+reader**. It starts with stdlib only; the optional `/build-options` endpoint
+imports the engine planner lazily and degrades to JSON errors if unavailable.
+It has exactly two side effects,
 both opt-in and local:
 - `POST /move` appends a player *move intent* (NOT campaign state) to the
   append-only log at $CLAWDND_PLAYER_MOVES — inert (refuses, writes nothing)
@@ -20,6 +22,8 @@ It reads the engine's on-disk truth directly:
   a whole, valid file — no lock needed.
 - the active session's `sessions/<id>.jsonl` is append-only; we tolerate a
   half-written trailing line (skip it; it completes on the next poll).
+- `GET /build-options` validates campaign/character scope and calls the
+  engine-owned read-only build planner; it never calls level_up or saves.
 
 Usage:  python3 viewer/server.py [campaign_id] [port]
         (CLAWDND_STATE_DIR is honored, mirroring the engine's store.state_dir())
@@ -29,11 +33,13 @@ from __future__ import annotations
 
 import base64
 import binascii
+import importlib.util
 import json
 import os
 import subprocess
 import sys
 import time
+import types
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Optional
@@ -239,6 +245,159 @@ def _safe_campaign_id(campaign_id: Optional[str]) -> Optional[str]:
     except OSError:
         return None
     return None
+
+
+_ENGINE_SERVER = None
+_ENGINE_IMPORT_ERROR = ""
+
+
+def _install_fastmcp_shim() -> None:
+    """Let the plain-stdlib viewer import engine/server.py for direct function calls.
+
+    The dashboard command runs with system python, not the engine's MCP dependency
+    environment. engine.server only needs FastMCP at import time to decorate tools;
+    for this read-only bridge a no-op decorator is enough and keeps the planner code
+    itself engine-owned.
+    """
+    if "mcp.server.fastmcp" in sys.modules:
+        return
+
+    class FastMCP:  # noqa: D401 - tiny import shim, not the real MCP server.
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def tool(self, *args, **_kwargs):
+            if args and callable(args[0]):
+                return args[0]
+            return lambda fn: fn
+
+    mcp_mod = sys.modules.get("mcp") or types.ModuleType("mcp")
+    server_mod = sys.modules.get("mcp.server") or types.ModuleType("mcp.server")
+    fastmcp_mod = types.ModuleType("mcp.server.fastmcp")
+    fastmcp_mod.FastMCP = FastMCP
+    mcp_mod.server = server_mod
+    server_mod.fastmcp = fastmcp_mod
+    sys.modules["mcp"] = mcp_mod
+    sys.modules["mcp.server"] = server_mod
+    sys.modules["mcp.server.fastmcp"] = fastmcp_mod
+
+
+def _load_engine_server():
+    global _ENGINE_SERVER, _ENGINE_IMPORT_ERROR
+    if _ENGINE_SERVER is not None:
+        return _ENGINE_SERVER
+    engine_dir = (_HERE.parent / "servers" / "engine").resolve()
+    try:
+        try:
+            from mcp.server.fastmcp import FastMCP as _FastMCP  # noqa: F401
+        except ModuleNotFoundError:
+            _install_fastmcp_shim()
+        if str(engine_dir) not in sys.path:
+            sys.path.insert(0, str(engine_dir))
+        spec = importlib.util.spec_from_file_location("_clawdnd_engine_server_for_viewer", engine_dir / "server.py")
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load engine server module")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        _ENGINE_SERVER = module
+        _ENGINE_IMPORT_ERROR = ""
+        return module
+    except Exception as exc:  # import/dependency failures become explicit JSON degradation
+        _ENGINE_IMPORT_ERROR = str(exc)
+        return None
+
+
+def _engine_server():
+    """Test-visible accessor for the engine-owned planner module."""
+    return _load_engine_server()
+
+
+def _clean_character_id(character_id: Optional[str]) -> Optional[str]:
+    if not isinstance(character_id, str):
+        return None
+    cid = character_id.strip()
+    if not cid or len(cid) > 160 or "\x00" in cid:
+        return None
+    return cid
+
+
+def _progression_error(code: str, message: str, *, campaign_id: str = "", character_id: str = "") -> dict:
+    return {
+        "ok": False,
+        "code": code,
+        "campaign_id": campaign_id,
+        "character_id": character_id,
+        "source": "engine.build_options",
+        "planner": None,
+        "errors": [message],
+    }
+
+
+def build_options_response(campaign_id: Optional[str], character_id: Optional[str]) -> dict:
+    """GET /build-options read model.
+
+    The viewer validates the campaign path and character id, then calls the
+    engine-owned read-only build_options planner. It never writes a snapshot and
+    does not expose the mutating level_up path.
+    """
+    safe_campaign = _safe_campaign_id(campaign_id)
+    if not safe_campaign:
+        return _progression_error("invalid_campaign", "missing or unsafe campaign id")
+
+    safe_character = _clean_character_id(character_id)
+    if not safe_character:
+        return _progression_error(
+            "invalid_character",
+            "missing or unsafe character id",
+            campaign_id=safe_campaign,
+        )
+
+    snapshot = _read_snapshot(safe_campaign)
+    if not snapshot:
+        return _progression_error(
+            "state_unavailable",
+            "campaign snapshot is unavailable",
+            campaign_id=safe_campaign,
+            character_id=safe_character,
+        )
+    chars = snapshot.get("characters")
+    if not isinstance(chars, dict) or safe_character not in chars:
+        return _progression_error(
+            "invalid_character",
+            "character is not present in this campaign snapshot",
+            campaign_id=safe_campaign,
+            character_id=safe_character,
+        )
+
+    engine = _load_engine_server()
+    if engine is None or not hasattr(engine, "build_options"):
+        detail = _ENGINE_IMPORT_ERROR or "engine build_options is unavailable"
+        return _progression_error(
+            "engine_unavailable",
+            f"engine build planner unavailable: {detail}",
+            campaign_id=safe_campaign,
+            character_id=safe_character,
+        )
+
+    try:
+        planner = engine.build_options(safe_campaign, safe_character)
+    except Exception as exc:
+        return _progression_error(
+            "engine_error",
+            str(exc),
+            campaign_id=safe_campaign,
+            character_id=safe_character,
+        )
+    return {
+        "ok": True,
+        "code": "ok",
+        "campaign_id": safe_campaign,
+        "character_id": safe_character,
+        "source": "engine.build_options",
+        "planner": planner,
+        "errors": [],
+    }
 
 
 def _display_location(snapshot: dict) -> str:
@@ -1366,6 +1525,14 @@ class _Handler(BaseHTTPRequestHandler):
             # newest-active first, with the attached one marked `current`. Lets the
             # dashboard offer a picker instead of silently auto-following recency.
             self._json({"campaigns": _list_campaigns()})
+        elif route == "/build-options":
+            # Read-only progression planner bridge: path-safe campaign scope +
+            # character id, then engine.build_options. It returns disabled/error
+            # data for the dashboard to render and never exposes level_up.
+            qs = parse_qs(parsed.query)
+            cid = (qs.get("campaign") or [""])[0] or self._view_campaign(qs)
+            character_id = (qs.get("character") or [""])[0]
+            self._json(build_options_response(cid, character_id))
         elif route in ("/monitor", "/monitor.html"):
             # The MULTI-CAMPAIGN monitor: one live page showing EVERY campaign across the play
             # store + all parallel QA runs (watch the stress tests + any live game in one place).

--- a/viewer/tests/test_build_options_bridge.py
+++ b/viewer/tests/test_build_options_bridge.py
@@ -1,0 +1,64 @@
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(server)
+
+
+class BuildOptionsBridgeTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+
+    def tearDown(self):
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def test_build_options_response_uses_engine_planner_without_mutating_snapshot(self):
+        engine = server._engine_server()
+        campaign_id = engine.create_campaign("Planner")["id"]
+        character_id = engine.create_character(
+            campaign_id,
+            "Ren",
+            kind="player",
+            class_name="Fighter",
+            level=3,
+            apply_srd_defaults=True,
+            abilities={"strength": 16, "dexterity": 14, "constitution": 12},
+        )["id"]
+        snapshot_path = self._tmp / "campaigns" / campaign_id / "snapshot.json"
+        before = json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+        response = server.build_options_response(campaign_id, character_id)
+        after = json.loads(snapshot_path.read_text(encoding="utf-8"))
+
+        self.assertTrue(response["ok"])
+        self.assertEqual(response["source"], "engine.build_options")
+        self.assertEqual(response["campaign_id"], campaign_id)
+        self.assertEqual(response["planner"]["character_id"], character_id)
+        fighter = next(o for o in response["planner"]["options"] if o["class_name"] == "fighter")
+        self.assertEqual(fighter["to"], {"level": 4, "class": "fighter"})
+        self.assertTrue(fighter["choices"]["asi_required"])
+        self.assertEqual(after, before)
+
+    def test_build_options_response_rejects_unsafe_or_missing_campaign_id(self):
+        response = server.build_options_response("../secret", "pc")
+
+        self.assertFalse(response["ok"])
+        self.assertEqual(response["code"], "invalid_campaign")
+        self.assertIn("campaign", response["errors"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_progression_planner_dashboard.py
+++ b/viewer/tests/test_progression_planner_dashboard.py
@@ -1,0 +1,92 @@
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+_DASHBOARD_PATH = Path(__file__).resolve().parents[1] / "dashboard.html"
+
+
+def _planner_source() -> str:
+    html = _DASHBOARD_PATH.read_text(encoding="utf-8")
+    start = html.index("const esc =")
+    helper_start = html.index("function buildPlannerHTML", start)
+    end = html.index("function renderProgression", helper_start)
+    return html[start:helper_start] + html[helper_start:end]
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required for dashboard renderer fixture tests")
+class ProgressionPlannerDashboardTests(unittest.TestCase):
+    NODE_BIN = shutil.which("node")
+
+    def _render(self, planner_response):
+        program = (
+            _planner_source()
+            + "\nconst response = "
+            + json.dumps(planner_response)
+            + ";\nconsole.log(buildPlannerHTML(response));\n"
+        )
+        proc = subprocess.run(
+            [self.NODE_BIN],
+            input=program,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return proc.stdout
+
+    def test_build_planner_html_renders_engine_options_and_blockers(self):
+        html = self._render({
+            "ok": True,
+            "source": "engine.build_options",
+            "planner": {
+                "choices": {"asi_required": True, "feat_allowed": False, "multiclass_allowed": False},
+                "options": [
+                    {
+                        "class_name": "fighter",
+                        "legal": True,
+                        "to": {"level": 4, "class": "fighter"},
+                        "hp_gain": 7,
+                        "features_gained": [{"name": "Ability Score Improvement"}],
+                        "spell_slots_delta": {"2": {"from_max": 0, "to_max": 2, "delta": 2}},
+                        "resources_delta": {"ki": {"from_max": 0, "to_max": 2, "delta": 2, "recharge": "short"}},
+                        "choices": {"asi_required": True, "feat_allowed": False},
+                        "errors": [],
+                    }
+                ],
+                "blocked_options": [
+                    {
+                        "class_name": "wizard",
+                        "to": {"level": 4, "class": "wizard"},
+                        "errors": ["multiclassing is disabled by campaign house rules"],
+                    }
+                ],
+            },
+        })
+
+        self.assertIn("Engine build planner", html)
+        self.assertIn("Fighter", html)
+        self.assertIn("+7 HP", html)
+        self.assertIn("Ability Score Improvement", html)
+        self.assertIn("slot L2 +2", html)
+        self.assertIn("Ki +2", html)
+        self.assertIn("ASI required", html)
+        self.assertIn("Feat blocked", html)
+        self.assertIn("Wizard", html)
+        self.assertIn("multiclassing is disabled", html)
+        self.assertNotIn("level_up", html)
+
+    def test_build_planner_html_renders_explicit_degraded_errors(self):
+        html = self._render({
+            "ok": False,
+            "code": "engine_unavailable",
+            "errors": ["engine build planner unavailable: missing dependency"],
+        })
+
+        self.assertIn("engine_unavailable", html)
+        self.assertIn("missing dependency", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Scope

Sprint 2 viewer/dashboard slice for ClawDnD issue #81: consume the engine-owned build planner from the Progression sheet without giving the browser or viewer a campaign-state writer.

Refs #81

## Architecture Invariant

- The engine remains the sole writer and source of truth.
- The new viewer endpoint is read-only: it validates campaign and character scope, calls engine `build_options`, and returns planner JSON.
- The dashboard only renders returned planner data. It does not compute D&D build legality in browser JS and does not call `level_up` or any mutating progression path.
- Passive dashboard refreshes may request `/build-options`, but that endpoint never calls `save_campaign`, never appends a move, and never levels a character.

## Files And Functions Changed

- `viewer/server.py`
  - Added `GET /build-options?campaign=<id>&character=<id>`.
  - Added `build_options_response(...)` with campaign path validation, character validation against the snapshot, explicit degraded JSON errors, and engine `build_options` delegation.
  - Added a tiny lazy FastMCP import shim so the plain `python3 viewer/server.py` dashboard process can import engine planner functions even when it is not running inside the engine MCP dependency environment.
- `viewer/dashboard.html`
  - Extended `renderProgression` to show engine planner data.
  - Added cached `/build-options` fetch keyed by campaign, character, snapshot update, XP, level, and classes.
  - Added render-only cards for legal options, blocked options/errors, ASI/feat requirements, HP gain, features, resource deltas, and spell-slot deltas.
- `viewer/tests/test_build_options_bridge.py`
  - Covers engine planner delegation and proves the snapshot is unchanged.
  - Covers unsafe campaign id rejection.
- `viewer/tests/test_progression_planner_dashboard.py`
  - Covers dashboard rendering for legal options, blocked options, deltas, and degraded errors.
  - Guards against rendering a `level_up` action.

## Validation

Local, focused validation only from the Lexar-backed worktree:

- `pwd && python3 -m py_compile viewer/server.py`
  - exit 0 from `/Volumes/LEXAR/repos/ClawDnD-build-planner-viewer`
- `pwd && python3 -m unittest discover -s viewer/tests`
  - 11 tests passed in 0.282s from `/Volumes/LEXAR/repos/ClawDnD-build-planner-viewer`
- `pwd && uv run pytest tests/test_progression.py`
  - 31 tests passed in 0.29s from `/Volumes/LEXAR/repos/ClawDnD-build-planner-viewer/servers/engine`
- `pwd && git diff --check`
  - exit 0 from `/Volumes/LEXAR/repos/ClawDnD-build-planner-viewer`
- Local HTTP smoke:
  - seeded a temporary campaign under `/Volumes/LEXAR/Codex/clawdnd-build-planner-smoke`
  - `GET /build-options?campaign=<id>&character=<id>` returned `ok: true`, `source: engine.build_options`, legal fighter option, ASI requirement, and `+7 HP`
  - `GET /dashboard` returned the dashboard HTML

No live Claude/Codex story QA was run.

## Risks And Limitations

- The viewer imports engine planner code lazily. If the engine module or its non-MCP dependencies are unavailable, `/build-options` returns `ok: false` with `code: engine_unavailable` instead of faking legal choices.
- The dashboard currently displays preview-only planner options and blocked reasons. It intentionally does not submit level-up commits.
- This is issue #81 dashboard consumption, not the full closure of every remaining #81 acceptance item.

## Rollback Notes

Reverting this PR removes the `/build-options` endpoint, the Progression planner card, and the focused viewer tests. Existing `/state`, `/move`, `/events`, and dashboard progression XP/classes/hit-dice rendering return to their previous behavior.
