### PR TITLE
Advance strategic clocks and downtime projects

### DIFF
--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -780,6 +780,8 @@ def _seed_strategic_state(c: Campaign, world: dict) -> None:
             continue
         c.strategic_state.projects[project.id] = project
 
+    c.strategic_state.last_tick_day = c.day
+
 
 def _seed_campaign_backlog(c: Campaign, world: dict) -> None:
     """Seed the PROACTIVE living-world backlog (P0) — the world's own off-screen to-do, so the

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -648,8 +648,9 @@ class WorldState(_StrictModel):
 class StrategicClock(_StrictModel):
     """A setting-agnostic strategic pressure clock.
 
-    Inert in this slice: content may seed it and snapshots persist it, but no engine
-    tick/advancement logic consumes it yet (#75 owns advancement)."""
+    Advanced by the engine's explicit strategic tick paths. ``tick_every_days`` is
+    evaluated against ``StrategicState.last_tick_day`` so repeated calls on the same
+    in-world day never double-progress it."""
 
     id: str = Field(default_factory=lambda: _new_id("clock"))
     title: str
@@ -699,7 +700,8 @@ class RegionControl(_StrictModel):
 class DowntimeProject(_StrictModel):
     """A strategic downtime project record.
 
-    This slice persists authored projects only; project advancement is out of scope."""
+    Active projects advance on strategic day ticks. A completed project's authored
+    ``effect`` is applied exactly once when status transitions to ``complete``."""
 
     id: str = Field(default_factory=lambda: _new_id("proj"))
     title: str
@@ -709,6 +711,7 @@ class DowntimeProject(_StrictModel):
     progress_days: int = Field(0, ge=0)
     duration_days: int = Field(1, ge=1)
     status: Literal["planned", "active", "paused", "complete", "failed"] = "planned"
+    effect: dict[str, str] = Field(default_factory=dict)
     note: str = ""
 
     @model_validator(mode="after")
@@ -721,12 +724,14 @@ class StrategicState(_StrictModel):
     """The campaign's optional strategic board.
 
     Empty defaults are additive: old snapshots that lack this field deserialize with an
-    empty board, and worlds without a `strategic` block seed unchanged."""
+    empty board, and worlds without a `strategic` block seed unchanged. ``last_tick_day``
+    is the day cursor for engine-owned strategic advancement."""
 
     regions: dict[str, RegionControl] = Field(default_factory=dict)  # location_id -> control
     assets: dict[str, FactionAsset] = Field(default_factory=dict)  # asset id -> asset
     clocks: dict[str, StrategicClock] = Field(default_factory=dict)  # clock id -> clock
     projects: dict[str, DowntimeProject] = Field(default_factory=dict)  # project id -> project
+    last_tick_day: int = 0
 
 
 class BacklogItem(_StrictModel):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -862,9 +862,7 @@ def travel_to(campaign_id: str, destination_id: str, advance_time: bool = False)
             dev = worldsim.tick_backlog(c, max_events=1)
             if dev:
                 result["world_developments"] = [_backlog_line(d) for d in dev]
-            strategic = worldsim.tick_strategic(c) if c.day > before_day else []
-            if strategic:
-                result["strategic_events"] = strategic
+            result["strategic_events"] = worldsim.tick_strategic(c) if c.day > before_day else []
             # A phase elapsed (overland travel): expire timed spell effects whose
             # duration ran out (minute/round-scale die on any phase advance).
             result["expired_effects"] = _expire_clock_effects_all(c)

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -845,6 +845,7 @@ def travel_to(campaign_id: str, destination_id: str, advance_time: bool = False)
     """
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
+        before_day = c.day
         result = travel.travel_to(c, destination_id, advance_time=advance_time)
         # The PARTY travels together: co-locate every party member (PC + companions) with
         # the new location so companions don't carry a stale location_id (QA state_integrity
@@ -861,6 +862,9 @@ def travel_to(campaign_id: str, destination_id: str, advance_time: bool = False)
             dev = worldsim.tick_backlog(c, max_events=1)
             if dev:
                 result["world_developments"] = [_backlog_line(d) for d in dev]
+            strategic = worldsim.tick_strategic(c) if c.day > before_day else []
+            if strategic:
+                result["strategic_events"] = strategic
             # A phase elapsed (overland travel): expire timed spell effects whose
             # duration ran out (minute/round-scale die on any phase advance).
             result["expired_effects"] = _expire_clock_effects_all(c)
@@ -4265,6 +4269,7 @@ def world_tick(campaign_id: str) -> dict:
         c = _require(campaign_id)
         beats = worldsim.tick(c)
         dev = worldsim.tick_backlog(c)
+        strategic = worldsim.tick_strategic(c)
         save_campaign(c)
         return {
             "current_day": c.day,
@@ -4277,6 +4282,7 @@ def world_tick(campaign_id: str) -> dict:
                 {"id": p.id, "kind": p.kind, "goal_ref": p.goal_ref, "trigger_day": p.trigger_day}
                 for p in worldsim.pending_backlog(c)
             ],
+            "strategic_events": strategic,
         }
 
 
@@ -4458,6 +4464,7 @@ def downtime(campaign_id: str, days: int, note: str = "") -> dict:
         due = consequences_mod.due(c)
         beats = worldsim.tick(c, max_beats=2)  # a long span → a couple of threads stirred
         dev = worldsim.tick_backlog(c, max_events=2)  # ...and the backlog advances over the span
+        strategic = worldsim.tick_strategic(c) if elapsed > 0 else []
         # The clock jumped forward days — expire timed effects like every sibling time-seam
         # (advance_time/travel_to/long_rest/short_rest). A multi-day downtime clears hour/day-scale
         # buffs (Mage Armor) and any sub-hour leftover; this was the only seam that omitted it.
@@ -4470,6 +4477,7 @@ def downtime(campaign_id: str, days: int, note: str = "") -> dict:
             "due_consequences": [{"text": x.text, "note": x.note} for x in due],
             "world_beats": [b.text for b in beats],
             "world_developments": [_backlog_line(d) for d in dev],
+            "strategic_events": strategic,
             "expired_effects": expired,
         }
 

--- a/servers/engine/tests/test_engine.py
+++ b/servers/engine/tests/test_engine.py
@@ -29,6 +29,7 @@ def test_campaign_roundtrips_with_empty_strategic_state():
         "assets": {},
         "clocks": {},
         "projects": {},
+        "last_tick_day": 0,
     }
 
     store.save_campaign(c)

--- a/servers/engine/tests/test_strategic_tick.py
+++ b/servers/engine/tests/test_strategic_tick.py
@@ -1,0 +1,149 @@
+"""Strategic clocks + downtime projects advance only through engine ticks (#75)."""
+
+import server
+import store
+import worldsim
+from models import Campaign, Consequence, DowntimeProject, Faction, Location, StrategicClock
+
+
+def _camp(day: int = 1) -> Campaign:
+    return Campaign(title="Strategy", day=day)
+
+
+def test_tick_strategic_advances_due_clocks_and_active_projects_once_per_day():
+    c = _camp(day=1)
+    c.strategic_state.last_tick_day = 1
+    c.strategic_state.clocks["clock-threat"] = StrategicClock(
+        id="clock-threat",
+        title="Rivals gather leverage",
+        kind="threat",
+        progress=1,
+        target=3,
+        tick_every_days=1,
+    )
+    c.strategic_state.projects["proj-quay"] = DowntimeProject(
+        id="proj-quay",
+        title="Repair the quay",
+        kind="construction",
+        status="active",
+        progress_days=0,
+        duration_days=2,
+        effect={"flag": "quay_repaired"},
+    )
+
+    c.day = 2
+    first = worldsim.tick_strategic(c)
+    assert {e["type"] for e in first} == {"clock_advanced", "project_advanced"}
+    assert c.strategic_state.clocks["clock-threat"].progress == 2
+    assert c.strategic_state.projects["proj-quay"].progress_days == 1
+
+    # Same in-world day: no double-progress and no duplicate event spam.
+    assert worldsim.tick_strategic(c) == []
+    assert c.strategic_state.clocks["clock-threat"].progress == 2
+    assert c.strategic_state.projects["proj-quay"].progress_days == 1
+
+    c.day = 3
+    second = worldsim.tick_strategic(c)
+    assert any(e["type"] == "clock_due" and e["id"] == "clock-threat" for e in second)
+    assert any(e["type"] == "project_complete" and e["id"] == "proj-quay" for e in second)
+    assert c.strategic_state.clocks["clock-threat"].progress == 3
+    assert c.strategic_state.projects["proj-quay"].status == "complete"
+    assert c.flags["quay_repaired"] is True
+
+
+def test_strategic_clock_cadence_survives_daily_ticks():
+    c = _camp(day=1)
+    c.strategic_state.last_tick_day = 1
+    c.strategic_state.clocks["clock-slow"] = StrategicClock(
+        id="clock-slow",
+        title="A slow threat",
+        tick_every_days=3,
+        target=4,
+    )
+
+    for day in (2, 3):
+        c.day = day
+        assert worldsim.tick_strategic(c) == []
+        assert c.strategic_state.clocks["clock-slow"].progress == 0
+
+    c.day = 4
+    events = worldsim.tick_strategic(c)
+    assert events and events[0]["type"] == "clock_advanced"
+    assert c.strategic_state.clocks["clock-slow"].progress == 1
+
+
+def test_world_tick_surfaces_strategic_events_without_firing_narrative_consequences(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    c = _camp(day=2)
+    c.strategic_state.last_tick_day = 1
+    c.strategic_state.clocks["clock-threat"] = StrategicClock(
+        id="clock-threat",
+        title="Rivals gather leverage",
+        progress=0,
+        target=1,
+        tick_every_days=1,
+    )
+    c.consequences.append(Consequence(trigger_day=99, text="A narrative beat remains pending."))
+    store.save_campaign(c)
+
+    out = server.world_tick(c.id)
+    assert any(e["type"] == "clock_due" for e in out["strategic_events"])
+    reloaded = store.load_campaign(c.id)
+    assert len(reloaded.consequences) == 1
+    assert reloaded.consequences[0].fired is False
+
+
+def test_downtime_completes_active_project_and_applies_structured_effect_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    c = _camp(day=1)
+    c.factions["fac-civic"] = Faction(id="fac-civic", name="Civic League", reputation=10)
+    c.strategic_state.last_tick_day = 1
+    c.strategic_state.projects["proj-envoys"] = DowntimeProject(
+        id="proj-envoys",
+        title="Host the envoys",
+        kind="diplomacy",
+        status="active",
+        progress_days=0,
+        duration_days=2,
+        effect={"flag": "envoys_hosted", "faction_id": "fac-civic", "reputation_delta": "5"},
+    )
+    store.save_campaign(c)
+
+    out = server.downtime(c.id, 2)
+    assert any(e["type"] == "project_complete" for e in out["strategic_events"])
+    after = store.load_campaign(c.id)
+    assert after.strategic_state.projects["proj-envoys"].status == "complete"
+    assert after.flags["envoys_hosted"] is True
+    assert after.factions["fac-civic"].reputation == 15
+
+    # Repeated explicit ticks on the same day do not re-apply the completion effect.
+    assert server.world_tick(c.id)["strategic_events"] == []
+    again = store.load_campaign(c.id)
+    assert again.factions["fac-civic"].reputation == 15
+    assert server.downtime(c.id, 1)["strategic_events"] == []
+    later = store.load_campaign(c.id)
+    assert later.factions["fac-civic"].reputation == 15
+
+
+def test_day_rolling_travel_to_advances_strategic_projects(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    c = _camp(day=1)
+    c.time_of_day = "night"
+    c.current_location_id = "loc-a"
+    c.locations = {
+        "loc-a": Location(id="loc-a", name="A", connections=["loc-b"], visited=True),
+        "loc-b": Location(id="loc-b", name="B", connections=["loc-a"]),
+    }
+    c.strategic_state.last_tick_day = 1
+    c.strategic_state.projects["proj-watch"] = DowntimeProject(
+        id="proj-watch",
+        title="Raise the watch",
+        status="active",
+        duration_days=1,
+    )
+    store.save_campaign(c)
+
+    out = server.travel_to(c.id, "loc-b", advance_time=True)
+    assert out["day"] == 2
+    assert any(e["type"] == "project_complete" for e in out["strategic_events"])
+    assert store.load_campaign(c.id).strategic_state.projects["proj-watch"].status == "complete"

--- a/servers/engine/tests/test_strategic_tick.py
+++ b/servers/engine/tests/test_strategic_tick.py
@@ -72,6 +72,39 @@ def test_strategic_clock_cadence_survives_daily_ticks():
     assert c.strategic_state.clocks["clock-slow"].progress == 1
 
 
+def test_legacy_strategic_board_initializes_tick_cursor_without_catchup():
+    c = _camp(day=10)
+    c.strategic_state.clocks["clock-threat"] = StrategicClock(
+        id="clock-threat",
+        title="Rivals gather leverage",
+        progress=0,
+        target=3,
+        tick_every_days=1,
+    )
+    c.strategic_state.projects["proj-quay"] = DowntimeProject(
+        id="proj-quay",
+        title="Repair the quay",
+        kind="construction",
+        status="active",
+        progress_days=0,
+        duration_days=2,
+        effect={"flag": "quay_repaired"},
+    )
+
+    assert c.strategic_state.last_tick_day == 0
+    assert worldsim.tick_strategic(c) == []
+    assert c.strategic_state.last_tick_day == 10
+    assert c.strategic_state.clocks["clock-threat"].progress == 0
+    assert c.strategic_state.projects["proj-quay"].progress_days == 0
+    assert "quay_repaired" not in c.flags
+
+    c.day = 11
+    events = worldsim.tick_strategic(c)
+    assert {e["type"] for e in events} == {"clock_advanced", "project_advanced"}
+    assert c.strategic_state.clocks["clock-threat"].progress == 1
+    assert c.strategic_state.projects["proj-quay"].progress_days == 1
+
+
 def test_world_tick_surfaces_strategic_events_without_firing_narrative_consequences(tmp_path, monkeypatch):
     monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
     c = _camp(day=2)

--- a/servers/engine/tests/test_strategic_tick.py
+++ b/servers/engine/tests/test_strategic_tick.py
@@ -180,3 +180,19 @@ def test_day_rolling_travel_to_advances_strategic_projects(tmp_path, monkeypatch
     assert out["day"] == 2
     assert any(e["type"] == "project_complete" for e in out["strategic_events"])
     assert store.load_campaign(c.id).strategic_state.projects["proj-watch"].status == "complete"
+
+
+def test_day_rolling_travel_to_returns_empty_strategic_events_when_none_fire(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    c = _camp(day=1)
+    c.time_of_day = "night"
+    c.current_location_id = "loc-a"
+    c.locations = {
+        "loc-a": Location(id="loc-a", name="A", connections=["loc-b"], visited=True),
+        "loc-b": Location(id="loc-b", name="B", connections=["loc-a"]),
+    }
+    store.save_campaign(c)
+
+    out = server.travel_to(c.id, "loc-b", advance_time=True)
+    assert out["day"] == 2
+    assert out["strategic_events"] == []

--- a/servers/engine/worldsim.py
+++ b/servers/engine/worldsim.py
@@ -75,14 +75,12 @@ def pending_threads(campaign: Campaign) -> list[Consequence]:
 # consequences.due). Mirrors the tick/pending shape of the thread helpers; pure (no I/O).
 
 
-def _apply_backlog_effect(campaign: Campaign, item: BacklogItem) -> str:
-    """Apply a DETERMINISTIC backlog item's structured `effect` to the campaign (mutates) and
-    return the one-line `summary` of what changed, for the DM to weave. A number, flag, or stub
-    only — NEVER prose generation (that's the later DM/agent for needs_llm items). Setting-
-    agnostic: every key/value comes from CONTENT (the seeded `effect` dict), never engine code.
-    Unknown/empty effect keys fall through to a generic marker so a malformed effect degrades to
-    a no-op development rather than raising — the engine stays the unbreakable, always-on tick."""
-    eff = item.effect or {}
+def _apply_structured_effect(campaign: Campaign, effect: dict, *, fallback: str) -> str:
+    """Apply a deterministic strategic/backlog effect (mutates) and return a DM-facing line.
+
+    The payload is intentionally tiny and setting-agnostic: flags, faction reputation,
+    faction control markers, and NPC-arrival stubs. Unknown keys are harmless no-ops."""
+    eff = effect or {}
 
     # A campaign flag the DM/engine gates events on (e.g. {"flag": "concord_split"}).
     flag = str(eff.get("flag") or "").strip()
@@ -116,12 +114,24 @@ def _apply_backlog_effect(campaign: Campaign, item: BacklogItem) -> str:
         where = f" at {loc_id}" if loc_id else ""
         campaign.flags[f"arrival:{npc_name}{where}"] = True
 
+    return fallback.strip() or "A structured world-state effect resolved."
+
+
+def _apply_backlog_effect(campaign: Campaign, item: BacklogItem) -> str:
+    """Apply a DETERMINISTIC backlog item's structured `effect` to the campaign (mutates) and
+    return the one-line `summary` of what changed, for the DM to weave. A number, flag, or stub
+    only — NEVER prose generation (that's the later DM/agent for needs_llm items). Setting-
+    agnostic: every key/value comes from CONTENT (the seeded `effect` dict), never engine code.
+    Unknown/empty effect keys fall through to a generic marker so a malformed effect degrades to
+    a no-op development rather than raising — the engine stays the unbreakable, always-on tick."""
     # The DM-facing one-liner: prefer an authored summary, else a terse template of what moved.
     if item.summary.strip():
-        return item.summary.strip()
-    if item.title.strip():
-        return item.title.strip()
-    return f"An off-screen development ({item.kind}) advanced the world."
+        fallback = item.summary.strip()
+    elif item.title.strip():
+        fallback = item.title.strip()
+    else:
+        fallback = f"An off-screen development ({item.kind}) advanced the world."
+    return _apply_structured_effect(campaign, item.effect, fallback=fallback)
 
 
 def tick_backlog(campaign: Campaign, max_events: int = 2) -> list[BacklogItem]:
@@ -195,3 +205,85 @@ def pending_backlog(campaign: Campaign) -> list[BacklogItem]:
         (i for i in bl.items.values() if i.status == "pending" and i.trigger_day > campaign.day),
         key=lambda i: (i.trigger_day, i.id),
     )
+
+
+# --- Typed strategic board advancement (#75) --------------------------------------------------
+
+
+def _cadence_ticks(last_day: int, current_day: int, cadence_days: int) -> int:
+    """How many cadence boundaries were crossed between two campaign days."""
+    cadence = max(0, int(cadence_days))
+    if cadence <= 0 or current_day <= last_day:
+        return 0
+    # Day 1 with cadence 3 ticks after three elapsed days: on day 4, then 7, 10, ...
+    return max(0, (current_day - 1) // cadence - (last_day - 1) // cadence)
+
+
+def tick_strategic(campaign: Campaign) -> list[dict]:
+    """Advance typed strategic clocks and active downtime projects for elapsed days.
+
+    This mutates only ``campaign.strategic_state`` and deterministic campaign fields named by
+    project effects. The guard is day-based: if ``campaign.day <= last_tick_day`` it is a no-op,
+    so repeated ``world_tick`` calls on the same day never double-progress or spam events.
+    Narrative ``Consequence`` records are deliberately untouched."""
+    st = campaign.strategic_state
+    last_day = st.last_tick_day
+    elapsed = campaign.day - last_day
+    if elapsed <= 0:
+        return []
+
+    events: list[dict] = []
+
+    for clock in sorted(st.clocks.values(), key=lambda x: x.id):
+        if clock.progress >= clock.target:
+            continue
+        delta = _cadence_ticks(last_day, campaign.day, clock.tick_every_days)
+        if delta <= 0:
+            continue
+        before = clock.progress
+        clock.progress = min(clock.target, clock.progress + delta)
+        due = before < clock.target and clock.progress >= clock.target
+        events.append(
+            {
+                "type": "clock_due" if due else "clock_advanced",
+                "id": clock.id,
+                "title": clock.title,
+                "kind": clock.kind,
+                "scope": clock.scope,
+                "progress": clock.progress,
+                "target": clock.target,
+                "delta": clock.progress - before,
+                "due": due,
+                "line": clock.note or clock.title,
+            }
+        )
+
+    for project in sorted(st.projects.values(), key=lambda x: x.id):
+        if project.status != "active":
+            continue
+        before = project.progress_days
+        project.progress_days = min(project.duration_days, project.progress_days + elapsed)
+        if project.progress_days <= before:
+            continue
+        complete = before < project.duration_days and project.progress_days >= project.duration_days
+        event_type = "project_complete" if complete else "project_advanced"
+        line = project.note or project.title
+        if complete:
+            project.status = "complete"
+            line = _apply_structured_effect(campaign, project.effect, fallback=line)
+        events.append(
+            {
+                "type": event_type,
+                "id": project.id,
+                "title": project.title,
+                "kind": project.kind,
+                "progress_days": project.progress_days,
+                "duration_days": project.duration_days,
+                "delta": project.progress_days - before,
+                "complete": complete,
+                "line": line,
+            }
+        )
+
+    st.last_tick_day = campaign.day
+    return events

--- a/servers/engine/worldsim.py
+++ b/servers/engine/worldsim.py
@@ -225,9 +225,15 @@ def tick_strategic(campaign: Campaign) -> list[dict]:
     This mutates only ``campaign.strategic_state`` and deterministic campaign fields named by
     project effects. The guard is day-based: if ``campaign.day <= last_tick_day`` it is a no-op,
     so repeated ``world_tick`` calls on the same day never double-progress or spam events.
-    Narrative ``Consequence`` records are deliberately untouched."""
+    Narrative ``Consequence`` records are deliberately untouched. Legacy/manual snapshots
+    may deserialize strategic boards without a cursor; initialize those on first tick rather
+    than retroactively advancing from day 0."""
     st = campaign.strategic_state
     last_day = st.last_tick_day
+    if last_day <= 0:
+        st.last_tick_day = campaign.day
+        return []
+
     elapsed = campaign.day - last_day
     if elapsed <= 0:
         return []


### PR DESCRIPTION
## Summary

Refs #75.

Implements typed strategic advancement inside the engine:

- adds `StrategicState.last_tick_day` as the day-based idempotency guard
- advances scheduled `StrategicClock` records by cadence and emits `clock_advanced` / `clock_due` strategic events
- advances only active `DowntimeProject` records by elapsed days and emits `project_advanced` / `project_complete` events
- applies a completed project's configured structured `effect` exactly once when the project transitions to `complete`
- surfaces `strategic_events` from `world_tick`, `downtime`, and day-rolling `travel_to`

No viewer/dashboard files are touched. The engine remains the sole writer/source of truth.

## Architecture Invariant

Strategic advancement is only wired through explicit engine mutation paths:

- `world_tick`: explicit strategic tick
- `downtime`: strategic tick only when downtime actually advances at least one day
- `travel_to`: strategic tick only when `advance_time=True` rolls the campaign into a new day

Viewer polling still cannot advance strategic state. The guard is `StrategicState.last_tick_day`, so repeated calls on the same campaign day do not double-progress clocks/projects or repeat completion events.

Strategic events are a separate output lane. They do not append or mark narrative `Consequence` records as fired.

## Files / Functions

- `servers/engine/models.py`
  - `StrategicState.last_tick_day`
  - `DowntimeProject.effect`
  - updated strategic model docs
- `servers/engine/worldsim.py`
  - `_apply_structured_effect`
  - `_cadence_ticks`
  - `tick_strategic`
- `servers/engine/server.py`
  - wires `tick_strategic` into `world_tick`
  - wires it into `downtime`
  - wires it into day-rolling `travel_to`
- `servers/engine/content.py`
  - initializes seeded strategic boards with `last_tick_day = c.day`
- `servers/engine/tests/test_strategic_tick.py`
  - focused coverage for idempotency, cadence, project completion effects, output surfacing, and day-rolling travel

## Validation

Working directory: `/Volumes/LEXAR/repos/ClawDnD-strategy-tick-projects`

Local focused validation:

```bash
pwd && uv run --directory servers/engine --group dev pytest -q tests/test_strategic_tick.py
pwd && uv run --directory servers/engine --group dev pytest -q tests/test_strategic_tick.py tests/test_engine.py::test_campaign_roundtrips_with_empty_strategic_state tests/test_content.py::test_seed_world_seeds_strategic_state_additively tests/test_worldsim.py tests/test_dashboard.py tests/test_travel.py tests/test_campaign_backlog.py
pwd && python3 -m py_compile servers/engine/worldsim.py servers/engine/server.py servers/engine/models.py servers/engine/content.py
git diff --check
```

Results:

- `tests/test_strategic_tick.py`: 5 passed
- focused adjacent suite: 78 passed
- `py_compile`: passed
- `git diff --check`: passed

Per the local-resource policy, I did not run full local suites or live Claude/Codex story QA.

## Risks

- Project effects intentionally reuse the existing deterministic effect vocabulary: `flag`, `faction_id` + `reputation_delta`, `controller_id` + `location_id`, and `npc_name`.
- Seeded strategic projects remain `planned` unless content or an engine caller marks them `active`; this matches the acceptance scope that active projects advance.
- `advance_time` is not wired for this issue because the requested scope names `downtime`, day-rolling `travel_to`, and explicit `world_tick`.

## Rollback

Revert this PR to restore strategic clocks/projects to inert persisted state. Existing snapshots remain additive: missing `last_tick_day` / `effect` fields fall back to defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Strategic events are now properly generated and surfaced during travel, world ticks, and downtime actions.
  * Downtime projects now support structured effects that trigger exactly once upon completion.

* **Bug Fixes**
  * Strategic clock advancement is now deterministic and prevents duplicate progress when advanced on the same in-game day.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/109?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->