### PR TITLE
Add persistent camp beat scheduler state

### DIFF
--- a/servers/engine/companion_banter.py
+++ b/servers/engine/companion_banter.py
@@ -1,0 +1,144 @@
+"""Deterministic camp-beat and companion-banter scheduler.
+
+Pure module: no MCP, no campaign I/O, no persistence. The engine server owns the
+load/lock/save path and records selected beats explicitly.
+"""
+
+from __future__ import annotations
+
+import re
+from itertools import combinations
+
+from models import CampBeatCandidate, Campaign, Character
+
+
+def pair_key(*companion_ids: str) -> str:
+    """Stable pair key used for cooldowns and persisted records."""
+    return "|".join(sorted(str(cid) for cid in companion_ids if str(cid).strip()))
+
+
+def _slug(value: str) -> str:
+    value = re.sub(r"[^a-z0-9]+", "-", value.strip().lower())
+    return value.strip("-")[:48] or "general"
+
+
+def _living_companions(campaign: Campaign) -> list[Character]:
+    companions = [
+        campaign.characters[pid]
+        for pid in campaign.party
+        if pid in campaign.characters
+        and campaign.characters[pid].kind == "companion"
+        and not campaign.characters[pid].dead
+        and campaign.characters[pid].current_hp > 0
+    ]
+    return sorted(companions, key=lambda ch: ch.id)
+
+
+def _last_recorded_day(campaign: Campaign) -> dict[str, int]:
+    latest: dict[str, int] = {}
+    for record in campaign.camp_beats.records:
+        keys = {record.id, record.cooldown_key}
+        if record.pair_key:
+            keys.add(f"pair:{record.pair_key}")
+        for key in keys:
+            if key:
+                latest[key] = max(latest.get(key, -1), record.day)
+    return latest
+
+
+def _is_on_cooldown(campaign: Campaign, candidate: CampBeatCandidate, latest: dict[str, int]) -> bool:
+    cooldown_days = (
+        campaign.camp_beats.pair_cooldown_days
+        if candidate.kind == "pair_banter"
+        else campaign.camp_beats.solo_cooldown_days
+    )
+    keys = [candidate.beat_id, candidate.cooldown_key]
+    if candidate.pair_key:
+        keys.append(f"pair:{candidate.pair_key}")
+    for key in keys:
+        if key in latest and campaign.day - latest[key] < cooldown_days:
+            return True
+    return False
+
+
+def _dossier_hooks(companion: Character) -> tuple[str, list[str], int]:
+    dossier = companion.companion_dossier
+    if dossier is None:
+        return ("a quiet check-in about recent events and the party's direction", [], 50)
+    if dossier.camp_prompts:
+        prompt = dossier.camp_prompts[0]
+        tags = list(dossier.banter_tags[:3])
+        return (prompt, tags, 90)
+    tags = list(dossier.banter_tags[:3] or dossier.values[:3] or dossier.wants[:3])
+    if tags:
+        return (f"a camp moment around {', '.join(tags)}", tags, 70)
+    if dossier.wound:
+        return (f"a guarded moment touching the wound: {dossier.wound}", ["wound"], 65)
+    return ("a quiet check-in about recent events and the party's direction", [], 50)
+
+
+def _solo_candidate(companion: Character) -> CampBeatCandidate:
+    hook, tags, priority = _dossier_hooks(companion)
+    anchor = _slug("|".join(tags) or hook)
+    beat_id = f"camp:solo:{companion.id}:{anchor}"
+    return CampBeatCandidate(
+        beat_id=beat_id,
+        kind="solo",
+        priority=priority,
+        companion_ids=[companion.id],
+        prompt=(
+            f"Frame a camp beat for {companion.name}: {hook}. "
+            "Give the companion a question, concern, or memory to bring forward; let the table voice the words."
+        ),
+        tags=tags,
+        cooldown_key=f"solo:{companion.id}:{anchor}",
+    )
+
+
+def _shared_pair_tags(a: Character, b: Character) -> list[str]:
+    ad = a.companion_dossier
+    bd = b.companion_dossier
+    atags = set(ad.banter_tags if ad is not None else [])
+    btags = set(bd.banter_tags if bd is not None else [])
+    shared = sorted(atags & btags)
+    if shared:
+        return shared[:3]
+    fallback = sorted((atags | btags))[:3]
+    return fallback
+
+
+def _pair_candidate(a: Character, b: Character) -> CampBeatCandidate:
+    pkey = pair_key(a.id, b.id)
+    tags = _shared_pair_tags(a, b)
+    anchor = _slug("|".join(tags) or "contrast")
+    focus = f"shared hooks: {', '.join(tags)}" if tags else "their contrasting reads on the last leg of travel"
+    return CampBeatCandidate(
+        beat_id=f"camp:pair:{pkey}:{anchor}",
+        kind="pair_banter",
+        priority=40 + len(tags),
+        companion_ids=sorted([a.id, b.id]),
+        prompt=(
+            f"Frame a brief camp banter exchange for {a.name} and {b.name} around {focus}. "
+            "Use it to reveal stance, tension, or warmth without resolving the scene for them."
+        ),
+        tags=tags,
+        cooldown_key=f"pair:{pkey}:{anchor}",
+        pair_key=pkey,
+    )
+
+
+def schedule_camp_beats(campaign: Campaign, max_beats: int = 6) -> list[CampBeatCandidate]:
+    """Return deterministic, currently-available camp beat frames.
+
+    The scheduler is a pure read of Campaign state. It excludes PCs and dead/downed
+    companions, requires two living companions for pair banter, and filters by persisted
+    camp-beat history without recording anything itself.
+    """
+    companions = _living_companions(campaign)
+    latest = _last_recorded_day(campaign)
+    candidates: list[CampBeatCandidate] = [_solo_candidate(comp) for comp in companions]
+    if len(companions) >= 2:
+        candidates.extend(_pair_candidate(a, b) for a, b in combinations(companions, 2))
+    available = [candidate for candidate in candidates if not _is_on_cooldown(campaign, candidate, latest)]
+    available.sort(key=lambda beat: (-beat.priority, beat.kind, beat.cooldown_key))
+    return available[: max(0, int(max_beats))]

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -637,11 +637,14 @@ class CampBeatState(_StrictModel):
     """Persistent camp-beat memory owned by the engine.
 
     `camp_scene` reads this to avoid recent repeats, but never mutates it. Only
-    `record_camp_beat` or another explicit record path should append records."""
+    `record_camp_beat` or another explicit record path should append records. The
+    history is compacted by cooldown key and capped so a long campaign cannot grow
+    snapshots without bound."""
 
     records: list[CampBeatRecord] = Field(default_factory=list)
     solo_cooldown_days: int = Field(2, ge=0)
     pair_cooldown_days: int = Field(3, ge=0)
+    max_records: int = Field(200, ge=1, le=1000)
 
 
 class HouseRules(_StrictModel):

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -595,6 +595,55 @@ class Decision(_StrictModel):
     actor_ids: list[str] = Field(default_factory=list)  # who weighed in / decided
 
 
+CampBeatKind = Literal["solo", "pair_banter", "arc", "decision_callback"]
+
+
+class CampBeatRecord(_StrictModel):
+    """A camp beat that actually fired at the table.
+
+    Camp prompt generation is read-only; the engine persists history only when an explicit
+    recording tool/API appends this record. Cooldown keys are deterministic so a saved campaign
+    and a reloaded campaign suppress the same recently-used beats."""
+
+    id: str
+    day: int
+    companion_ids: list[str]
+    kind: CampBeatKind
+    tags: list[str] = Field(default_factory=list)
+    resolved: bool = False
+    note: str = ""
+    cooldown_key: str = ""
+    pair_key: str = ""
+
+
+class CampBeatCandidate(_StrictModel):
+    """A deterministic frame the DM/companion agents can voice at camp.
+
+    This is a prompt/frame, not final authored dialogue. It deliberately carries only
+    player-facing hooks; sealed agendas and private DM notes stay out of this shape."""
+
+    beat_id: str
+    kind: CampBeatKind
+    priority: int = 0
+    companion_ids: list[str]
+    prompt: str
+    tags: list[str] = Field(default_factory=list)
+    cooldown_key: str
+    pair_key: str = ""
+    cooldown_reason: str = "none"
+
+
+class CampBeatState(_StrictModel):
+    """Persistent camp-beat memory owned by the engine.
+
+    `camp_scene` reads this to avoid recent repeats, but never mutates it. Only
+    `record_camp_beat` or another explicit record path should append records."""
+
+    records: list[CampBeatRecord] = Field(default_factory=list)
+    solo_cooldown_days: int = Field(2, ge=0)
+    pair_cooldown_days: int = Field(3, ge=0)
+
+
 class HouseRules(_StrictModel):
     """Campaign-level rule toggles the DM honors when adjudicating. Most are
     advisory (the DM applies them); a few may be wired into the engine over time."""
@@ -890,6 +939,9 @@ class Campaign(_StrictModel):
     # strict sibling of consequences/worldsim threads (never consumed by consequences.due).
     campaign_backlog: CampaignBacklog = Field(default_factory=CampaignBacklog)
     strategic_state: StrategicState = Field(default_factory=StrategicState)
+    # Persistent camp-beat memory (#69). Read by camp_scene/scheduler, written only by an
+    # explicit record path so prompt generation never advances campaign state by accident.
+    camp_beats: CampBeatState = Field(default_factory=CampBeatState)
 
     characters: dict[str, Character] = Field(default_factory=dict)  # id -> Character (PCs, companion, NPCs)
     party: list[str] = Field(default_factory=list)  # character ids that are PCs / companions

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4095,6 +4095,7 @@ def camp_scene(campaign_id: str, setting: str = "") -> dict:
             "records": len(c.camp_beats.records),
             "solo_cooldown_days": c.camp_beats.solo_cooldown_days,
             "pair_cooldown_days": c.camp_beats.pair_cooldown_days,
+            "max_records": c.camp_beats.max_records,
         },
         "guidance": (
             "Run a camp round: give each companion a moment IN TURN (a worry, a memory surfaced, a "
@@ -4105,6 +4106,43 @@ def camp_scene(campaign_id: str, setting: str = "") -> dict:
             "reading this scene alone does not advance beat history."
         ),
     }
+
+
+def _camp_beat_keys(record: CampBeatRecord) -> set[str]:
+    keys = {record.id, record.cooldown_key}
+    if record.pair_key:
+        keys.add(f"pair:{record.pair_key}")
+    return {key for key in keys if key}
+
+
+def _camp_beat_cooldown_days(c: Campaign, record: CampBeatRecord) -> int:
+    if record.kind == "pair_banter":
+        return c.camp_beats.pair_cooldown_days
+    return c.camp_beats.solo_cooldown_days
+
+
+def _raise_if_camp_beat_on_cooldown(c: Campaign, record: CampBeatRecord) -> None:
+    keys = _camp_beat_keys(record)
+    cooldown_days = max(0, _camp_beat_cooldown_days(c, record))
+    for existing in c.camp_beats.records:
+        if not keys.intersection(_camp_beat_keys(existing)):
+            continue
+        if existing.day == c.day:
+            raise ValueError(f"camp beat {record.id!r} was already recorded today")
+        if cooldown_days > 0 and c.day - existing.day < cooldown_days:
+            ready_day = existing.day + cooldown_days
+            raise ValueError(f"camp beat {record.id!r} is on cooldown until day {ready_day}")
+
+
+def _compact_camp_beat_records(c: Campaign) -> None:
+    latest_by_key: dict[str, tuple[int, int, CampBeatRecord]] = {}
+    for index, record in enumerate(c.camp_beats.records):
+        key = record.cooldown_key or record.id
+        current = latest_by_key.get(key)
+        if current is None or (record.day, index) >= (current[0], current[1]):
+            latest_by_key[key] = (record.day, index, record)
+    retained = sorted(latest_by_key.values(), key=lambda item: (item[0], item[1]))
+    c.camp_beats.records = [record for _, _, record in retained[-c.camp_beats.max_records :]]
 
 
 @mcp.tool()
@@ -4162,7 +4200,9 @@ def record_camp_beat(
             cooldown_key=cooldown_key,
             pair_key=pkey,
         )
+        _raise_if_camp_beat_on_cooldown(c, record)
         c.camp_beats.records.append(record)
+        _compact_camp_beat_records(c)
         save_campaign(c)
         return {"record": record.model_dump(mode="json"), "history_count": len(c.camp_beats.records)}
 

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -19,6 +19,7 @@ from mcp.server.fastmcp import FastMCP
 import bestiary
 import combat
 import companion
+import companion_banter
 import companion_arc
 import consequences as consequences_mod
 import content as content_mod
@@ -43,6 +44,8 @@ from models import (
     AbilityScores,
     ActiveEffect,
     BacklogItem,
+    CampBeatCandidate,
+    CampBeatRecord,
     Campaign,
     Character,
     ClassLevel,
@@ -4041,39 +4044,127 @@ def _camp_arc_summary(comp) -> Optional[dict]:
     return out
 
 
+def _camp_beat_view(c: Campaign, beat: CampBeatCandidate) -> dict:
+    out = beat.model_dump(mode="json")
+    participants = [c.characters[cid] for cid in beat.companion_ids if cid in c.characters]
+    out["participants"] = [
+        {"id": comp.id, "name": comp.name, "voice_id": comp.voice_id} for comp in participants
+    ]
+    if beat.kind == "solo" and participants:
+        comp = participants[0]
+        out.update(
+            {
+                "companion": comp.name,
+                "voice_id": comp.voice_id,
+                "personality": comp.personality,
+                "attitude": comp.attitude,
+                "attitude_value": comp.attitude_value,
+                "arc": _camp_arc_summary(comp),
+            }
+        )
+    return out
+
+
 @mcp.tool()
 def camp_scene(campaign_id: str, setting: str = "") -> dict:
     """Gather the party for a CAMP scene — the hub where companions breathe between adventures
-    (around the campfire, at the tavern bar, in a safe house). For EACH living companion in the
-    party it returns a beat to voice: their `voice_id`, current standing (`attitude` +
-    `attitude_value`), a memory-grounded prompt (the same frame as `companion_advise`), and a
-    read-only summary of their relationship `arc` (gates + how close the next is). Run it at a
-    long rest / downtime / on reaching a safe hub: voice each companion's moment in turn, let the
-    player talk to any of them, and play any arc beat that's ripe — then `check_companion_arc` to
-    fire/mark it. This is where loyalty, romance, grief, and grudges get their air; no companion
-    stays silent. Read-only (advice + state; it changes nothing)."""
+    (around the campfire, at the tavern bar, in a safe house). It returns deterministic
+    scheduled frames for living companions: `voice_id`/participants, current standing
+    (`attitude` + `attitude_value` for solo beats), player-facing prompts, and read-only
+    relationship `arc` summaries. Run it at a long rest / downtime / on reaching a safe hub:
+    voice the returned frames, let the player talk to any of them, and play any arc beat that's
+    ripe — then `check_companion_arc` to fire/mark it and `record_camp_beat` to persist that the
+    camp beat happened. Read-only (advice + state; it changes nothing)."""
     c = _require(campaign_id)
-    companions = [c.characters[i] for i in c.party
-                  if i in c.characters and c.characters[i].kind == "companion" and not c.characters[i].dead]
+    companions = [
+        c.characters[i]
+        for i in c.party
+        if i in c.characters
+        and c.characters[i].kind == "companion"
+        and not c.characters[i].dead
+        and c.characters[i].current_hp > 0
+    ]
     sit = setting.strip() or "an unpressured moment in camp — the day's danger behind you, the fire low"
-    beats = []
-    for comp in companions:
-        callbacks = ledger_mod.recall(campaign_id, comp.name, limit=3)  # what's remembered about them
-        frame = companion.deliberate(comp, sit, callbacks=callbacks)
-        beats.append({**frame, "attitude": comp.attitude, "attitude_value": comp.attitude_value,
-                      "arc": _camp_arc_summary(comp)})
+    scheduled = companion_banter.schedule_camp_beats(c, max_beats=len(companions))
+    beats = [_camp_beat_view(c, beat) for beat in scheduled]
     return {
         "setting": sit,
         "present": [comp.name for comp in companions],
         "beats": beats,
+        "camp_beat_history": {
+            "records": len(c.camp_beats.records),
+            "solo_cooldown_days": c.camp_beats.solo_cooldown_days,
+            "pair_cooldown_days": c.camp_beats.pair_cooldown_days,
+        },
         "guidance": (
             "Run a camp round: give each companion a moment IN TURN (a worry, a memory surfaced, a "
             "question for the player, banter with another companion), grounded in their standing + "
             "recent events. Let the player talk to any of them — this is character time, not a menu. "
             "If an arc gate is one beat from unlocking, lean toward it; play any ripe beat and then "
-            "`check_companion_arc` to fire it. No companion present stays silent."
+            "`check_companion_arc` to fire it. Record a played camp beat with `record_camp_beat`; "
+            "reading this scene alone does not advance beat history."
         ),
     }
+
+
+@mcp.tool()
+def record_camp_beat(
+    campaign_id: str,
+    beat_id: str,
+    companion_ids: Optional[list] = None,
+    kind: str = "",
+    tags: Optional[list] = None,
+    note: str = "",
+    resolved: bool = False,
+) -> dict:
+    """Persist that a camp beat actually fired.
+
+    This is the explicit write path for camp-beat history. `camp_scene` and the pure scheduler
+    are read-only; they only propose frames. For normal use, pass a `beat_id` returned by
+    `camp_scene`. The optional explicit fields support recording an externally-framed beat
+    without letting prompt generation mutate state."""
+    if not beat_id.strip():
+        raise ValueError("beat_id is required")
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        candidates = companion_banter.schedule_camp_beats(c, max_beats=100)
+        candidate = next((beat for beat in candidates if beat.beat_id == beat_id), None)
+        if candidate is not None:
+            ids = list(candidate.companion_ids)
+            record_kind = candidate.kind
+            record_tags = list(candidate.tags)
+            cooldown_key = candidate.cooldown_key
+            pkey = candidate.pair_key
+        else:
+            ids = sorted({str(cid) for cid in (companion_ids or []) if str(cid).strip()})
+            if not ids:
+                raise ValueError(f"beat_id {beat_id!r} is not currently scheduled; provide companion_ids to record explicitly")
+            for cid in ids:
+                comp = _char(c, cid)
+                if comp.kind != "companion" or comp.dead or comp.current_hp <= 0:
+                    raise ValueError(f"{cid!r} is not a living companion")
+            record_kind = kind or ("pair_banter" if len(ids) == 2 else "solo")
+            if record_kind == "pair_banter" and len(ids) != 2:
+                raise ValueError("pair_banter records require exactly two living companions")
+            if record_kind == "solo" and len(ids) != 1:
+                raise ValueError("solo records require exactly one living companion")
+            record_tags = [str(tag) for tag in (tags or []) if str(tag).strip()]
+            pkey = companion_banter.pair_key(*ids) if record_kind == "pair_banter" else ""
+            cooldown_key = f"pair:{pkey}:{beat_id}" if pkey else f"solo:{ids[0]}:{beat_id}"
+        record = CampBeatRecord(
+            id=beat_id,
+            day=c.day,
+            companion_ids=ids,
+            kind=record_kind,  # type: ignore[arg-type]
+            tags=record_tags,
+            resolved=resolved,
+            note=note,
+            cooldown_key=cooldown_key,
+            pair_key=pkey,
+        )
+        c.camp_beats.records.append(record)
+        save_campaign(c)
+        return {"record": record.model_dump(mode="json"), "history_count": len(c.camp_beats.records)}
 
 
 def _new_session_id() -> str:

--- a/servers/engine/tests/test_companion_banter.py
+++ b/servers/engine/tests/test_companion_banter.py
@@ -2,6 +2,8 @@
 
 import json
 
+import pytest
+
 import companion_banter
 import server
 import store
@@ -83,6 +85,50 @@ def test_camp_scene_is_read_only_until_explicit_record_call(tmp_path, monkeypatc
 
     cooled = server.camp_scene(cid)
     assert first_scene["beats"][0]["beat_id"] not in {beat["beat_id"] for beat in cooled["beats"]}
+
+
+def test_record_camp_beat_rejects_explicit_replay_during_cooldown(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Replay Guard")["id"]
+    server.create_character(cid, "Vesper", kind="companion")
+    beat = server.camp_scene(cid)["beats"][0]
+
+    server.record_camp_beat(cid, beat["beat_id"])
+    with pytest.raises(ValueError, match="cooldown|already recorded"):
+        server.record_camp_beat(cid, beat["beat_id"], companion_ids=beat["companion_ids"])
+
+    records = store.load_campaign(cid).camp_beats.records
+    assert len(records) == 1
+    assert records[0].id == beat["beat_id"]
+
+
+def test_record_camp_beat_compacts_latest_per_key_and_caps_history(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Compact Camp")["id"]
+    comp = server.create_character(cid, "Vesper", kind="companion")["id"]
+    c = store.load_campaign(cid)
+    c.camp_beats.max_records = 3
+    store.save_campaign(c)
+
+    beat = server.camp_scene(cid)["beats"][0]
+    server.record_camp_beat(cid, beat["beat_id"])
+    c = store.load_campaign(cid)
+    c.day += c.camp_beats.solo_cooldown_days
+    store.save_campaign(c)
+
+    second = server.record_camp_beat(cid, beat["beat_id"], companion_ids=beat["companion_ids"])
+    records = store.load_campaign(cid).camp_beats.records
+    assert second["history_count"] == 1
+    assert len(records) == 1
+    assert records[0].id == beat["beat_id"]
+    assert records[0].day == c.day
+
+    for ix in range(5):
+        server.record_camp_beat(cid, f"camp:manual:{ix}", companion_ids=[comp], kind="solo")
+
+    records = store.load_campaign(cid).camp_beats.records
+    assert len(records) == 3
+    assert [record.id for record in records] == ["camp:manual:2", "camp:manual:3", "camp:manual:4"]
 
 
 def test_recorded_pair_key_is_stable_across_save_load(tmp_path, monkeypatch):

--- a/servers/engine/tests/test_companion_banter.py
+++ b/servers/engine/tests/test_companion_banter.py
@@ -1,0 +1,120 @@
+"""#69 -- persistent camp beat state + deterministic banter scheduling."""
+
+import json
+
+import companion_banter
+import server
+import store
+from models import Campaign, Character, CompanionAgenda, CompanionArc, CompanionDossier
+
+
+def _campaign_with(*members: Character, day: int = 1) -> Campaign:
+    c = Campaign(title="Camp Beats")
+    c.day = day
+    for member in members:
+        c.characters[member.id] = member
+        c.party.append(member.id)
+    return c
+
+
+def _companion(name: str, **kw) -> Character:
+    max_hp = kw.pop("max_hp", 12)
+    current_hp = kw.pop("current_hp", max_hp)
+    return Character(name=name, kind="companion", max_hp=max_hp, current_hp=current_hp, **kw)
+
+
+def test_old_campaign_snapshot_without_camp_beat_state_loads():
+    c = _campaign_with(_companion("Vesper"))
+    raw = c.model_dump(mode="json")
+    raw.pop("camp_beats", None)
+
+    reloaded = Campaign.model_validate(raw)
+
+    assert reloaded.camp_beats.records == []
+
+
+def test_scheduler_excludes_pc_and_dead_companions_from_pair_banter():
+    pc = Character(name="Hero", kind="player")
+    alive = _companion("Vesper")
+    dead = _companion("Ash", dead=True, current_hp=0)
+    c = _campaign_with(pc, alive, dead)
+
+    beats = companion_banter.schedule_camp_beats(c, max_beats=8)
+
+    assert all(pc.id not in beat.companion_ids for beat in beats)
+    assert all(dead.id not in beat.companion_ids for beat in beats)
+    assert not any(beat.kind == "pair_banter" for beat in beats)
+
+    dead.dead = False
+    dead.current_hp = 5
+    beats = companion_banter.schedule_camp_beats(c, max_beats=8)
+    pair = next(beat for beat in beats if beat.kind == "pair_banter")
+    assert pair.companion_ids == sorted([alive.id, dead.id])
+    assert pair.pair_key == companion_banter.pair_key(alive.id, dead.id)
+
+
+def test_camp_scene_is_read_only_until_explicit_record_call(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Readonly Camp")["id"]
+    pc = server.create_character(cid, "Hero", kind="player")["id"]
+    first = server.create_character(cid, "Vesper", kind="companion")["id"]
+    second = server.create_character(cid, "Ash", kind="companion")["id"]
+    c = store.load_campaign(cid)
+    c.characters[first].companion_dossier = CompanionDossier(
+        camp_prompts=["asks what the party learned from the ruin"],
+        banter_tags=["ruin"],
+    )
+    c.characters[second].companion_dossier = CompanionDossier(banter_tags=["oath"])
+    store.save_campaign(c)
+    before = json.loads((tmp_path / "campaigns" / cid / "snapshot.json").read_text())
+
+    first_scene = server.camp_scene(cid)
+    second_scene = server.camp_scene(cid)
+    after = json.loads((tmp_path / "campaigns" / cid / "snapshot.json").read_text())
+
+    assert first_scene["beats"] == second_scene["beats"]
+    assert before == after
+    assert store.load_campaign(cid).camp_beats.records == []
+    assert all(pc not in beat["companion_ids"] for beat in first_scene["beats"])
+
+    recorded = server.record_camp_beat(cid, first_scene["beats"][0]["beat_id"])
+    assert recorded["record"]["id"] == first_scene["beats"][0]["beat_id"]
+    assert store.load_campaign(cid).camp_beats.records
+
+    cooled = server.camp_scene(cid)
+    assert first_scene["beats"][0]["beat_id"] not in {beat["beat_id"] for beat in cooled["beats"]}
+
+
+def test_recorded_pair_key_is_stable_across_save_load(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Pair Key")["id"]
+    a = server.create_character(cid, "Vesper", kind="companion")["id"]
+    b = server.create_character(cid, "Ash", kind="companion")["id"]
+    pair = next(
+        beat for beat in companion_banter.schedule_camp_beats(store.load_campaign(cid), max_beats=8)
+        if beat.kind == "pair_banter"
+    )
+
+    out = server.record_camp_beat(cid, pair.beat_id)
+    reloaded = store.load_campaign(cid)
+    record = reloaded.camp_beats.records[0]
+
+    assert out["record"]["pair_key"] == companion_banter.pair_key(a, b)
+    assert record.pair_key == companion_banter.pair_key(a, b)
+    assert Campaign.model_validate_json(reloaded.model_dump_json()).camp_beats.records[0].pair_key == record.pair_key
+
+
+def test_camp_scene_does_not_expose_sealed_agenda_notes(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Private Agenda")["id"]
+    comp = server.create_character(cid, "Vesper", kind="companion")["id"]
+    c = store.load_campaign(cid)
+    c.characters[comp].arc = CompanionArc(
+        agenda=CompanionAgenda(trigger="day_reached", value=99, note="SEALED BETRAYAL NOTE")
+    )
+    store.save_campaign(c)
+
+    scene = server.camp_scene(cid)
+
+    assert "SEALED BETRAYAL NOTE" not in json.dumps(scene)
+    assert all("final dialogue" not in beat["prompt"].lower() for beat in scene["beats"])


### PR DESCRIPTION
Refs #69

## Scope
- Adds strict `CampBeatState`, `CampBeatRecord`, and `CampBeatCandidate` engine models on `Campaign`.
- Adds `servers/engine/companion_banter.py` as a pure deterministic scheduler with stable solo/pair cooldown keys.
- Updates `camp_scene` to remain read-only while projecting scheduled player-facing beat frames.
- Adds explicit `record_camp_beat` as the persistence path for selected camp beats.
- Adds focused engine tests for additive state load, read-only scene calls, explicit persistence, cooldown suppression, pair eligibility, stable pair keys, and sealed-agenda redaction.

## Architecture Invariant
The engine remains the sole writer and source of truth. `camp_scene` does not mutate campaign snapshots; it only reads `Campaign.camp_beats` to suppress recently recorded candidates. Beat history is appended only through `record_camp_beat` or another explicit record path. The scheduler module is pure and performs no store/MCP I/O.

## Files / Functions
- `servers/engine/models.py`: `CampBeatState`, `CampBeatRecord`, `CampBeatCandidate`, `Campaign.camp_beats`.
- `servers/engine/companion_banter.py`: `schedule_camp_beats`, `pair_key`, deterministic solo/pair candidate construction and cooldown filtering.
- `servers/engine/server.py`: `_camp_beat_view`, read-only `camp_scene` integration, `record_camp_beat`.
- `servers/engine/tests/test_companion_banter.py`: focused coverage for #69 acceptance.

## Validation
Local focused validation from `/Volumes/LEXAR/repos/ClawDnD-camp-beat-scheduler`:
- `uv run --directory servers/engine --group dev pytest -q tests/test_companion_banter.py tests/test_qa_fixes.py::test_camp_scene_gathers_each_companion_with_standing_and_arc` -> 6 passed
- `uv run --directory servers/engine --group dev pytest -q tests/test_qa_fixes.py::test_long_rest_hints_camp_only_when_companions_present` -> 1 passed
- `python3 -m py_compile servers/engine/models.py servers/engine/companion_banter.py servers/engine/server.py` -> passed
- `git diff --check` -> passed

No live Claude/Codex story QA was run.

## Risks
- `camp_scene` prompts now come from deterministic camp beat frames rather than `companion.deliberate`; this is intentional for #69, but downstream consumers expecting the exact old prompt wording should treat the prompt as a frame.
- Cooldown windows are intentionally simple defaults (`solo=2`, `pair=3` days) and may need tuning after playtest.

## Rollback
Revert this PR to remove the new `camp_beats` state, pure scheduler, and `record_camp_beat` API. Existing pre-PR campaign snapshots continue to load because the new state is additive with defaults.

## Notes
- No narrative story content, DM skill prompts, QA story rubrics, BG3 world seeds, private content, viewer files, or dashboard files changed.
- Issue #69 can close once this PR merges if maintainers accept the deterministic scheduler defaults.