### PR TITLE
feat(companion): add companion quest arcs

### DIFF
--- a/servers/engine/companion_arc.py
+++ b/servers/engine/companion_arc.py
@@ -73,7 +73,7 @@ def _unlock_companion_quest_arc(character: Character, campaign: Campaign, gate) 
     event = {
         "quest_arc_id": gate.quest_arc_id,
         "stage_id": gate.stage_id,
-        "status": "available",
+        "status": "",
     }
     arc = campaign.companion_quest_arcs.get(gate.quest_arc_id)
     if arc is None:
@@ -93,10 +93,21 @@ def _unlock_companion_quest_arc(character: Character, campaign: Campaign, gate) 
             event["error"] = f"no stage {gate.stage_id!r} in companion quest arc {gate.quest_arc_id!r}"
             return event
 
+    changed: list[str] = []
     if arc.status == "locked":
         arc.status = "available"
+        changed.append("arc")
     if stage is not None and stage.status == "locked":
         stage.status = "available"
+        changed.append("stage")
+    if not changed:
+        event["status"] = arc.status
+        if stage is not None:
+            event["stage_status"] = stage.status
+        event["no_transition"] = True
+        return event
+    event["status"] = "available"
+    event["changed"] = changed
     return event
 
 
@@ -124,9 +135,12 @@ def evaluate(character: Character, campaign: Campaign) -> dict:
     # call that flips it (already-unlocked gates stay silent).
     for gate in arc.arc_gates:
         if not gate.unlocked and gate.threshold <= character.attitude_value:
+            quest_unlock = _unlock_companion_quest_arc(character, campaign, gate)
+            if quest_unlock is not None and quest_unlock.get("error"):
+                companion_quest_unlocks.append(quest_unlock)
+                continue
             gate.unlocked = True
             newly_unlocked.append(gate.model_dump())
-            quest_unlock = _unlock_companion_quest_arc(character, campaign, gate)
             if quest_unlock is not None:
                 companion_quest_unlocks.append(quest_unlock)
 

--- a/servers/engine/companion_arc.py
+++ b/servers/engine/companion_arc.py
@@ -106,7 +106,9 @@ def _unlock_companion_quest_arc(character: Character, campaign: Campaign, gate) 
             event["stage_status"] = stage.status
         event["no_transition"] = True
         return event
-    event["status"] = "available"
+    event["status"] = arc.status
+    if stage is not None:
+        event["stage_status"] = stage.status
     event["changed"] = changed
     return event
 

--- a/servers/engine/companion_arc.py
+++ b/servers/engine/companion_arc.py
@@ -62,6 +62,44 @@ def _agenda_triggered(character: Character, campaign: Campaign) -> bool:
     return False
 
 
+def _unlock_companion_quest_arc(character: Character, campaign: Campaign, gate) -> dict | None:
+    """Mark a linked companion quest arc/stage available for a personal_quest gate.
+
+    This is deliberately narrow: the relationship gate can surface availability once,
+    but success/failure stays behind the explicit companion quest advancement API."""
+    if gate.kind != "personal_quest" or not gate.quest_arc_id:
+        return None
+
+    event = {
+        "quest_arc_id": gate.quest_arc_id,
+        "stage_id": gate.stage_id,
+        "status": "available",
+    }
+    arc = campaign.companion_quest_arcs.get(gate.quest_arc_id)
+    if arc is None:
+        event["error"] = f"no companion quest arc {gate.quest_arc_id!r}"
+        return event
+    if arc.companion_id and arc.companion_id != character.id:
+        event["error"] = (
+            f"companion quest arc {gate.quest_arc_id!r} belongs to "
+            f"{arc.companion_id!r}, not {character.id!r}"
+        )
+        return event
+
+    stage = None
+    if gate.stage_id:
+        stage = next((s for s in arc.stages if s.id == gate.stage_id), None)
+        if stage is None:
+            event["error"] = f"no stage {gate.stage_id!r} in companion quest arc {gate.quest_arc_id!r}"
+            return event
+
+    if arc.status == "locked":
+        arc.status = "available"
+    if stage is not None and stage.status == "locked":
+        stage.status = "available"
+    return event
+
+
 def evaluate(character: Character, campaign: Campaign) -> dict:
     """Advance ONE companion's arc against the current state (mutates in place).
 
@@ -74,6 +112,7 @@ def evaluate(character: Character, campaign: Campaign) -> dict:
     the moments that just became live, for the DM to dramatize. A character with no `arc`
     is a no-op (empty result)."""
     newly_unlocked: list[dict] = []
+    companion_quest_unlocks: list[dict] = []
     agenda_fired = False
     agenda_dump = None
 
@@ -87,6 +126,9 @@ def evaluate(character: Character, campaign: Campaign) -> dict:
         if not gate.unlocked and gate.threshold <= character.attitude_value:
             gate.unlocked = True
             newly_unlocked.append(gate.model_dump())
+            quest_unlock = _unlock_companion_quest_arc(character, campaign, gate)
+            if quest_unlock is not None:
+                companion_quest_unlocks.append(quest_unlock)
 
     # The sealed agenda fires once, when its trigger holds.
     agenda = arc.agenda
@@ -95,4 +137,7 @@ def evaluate(character: Character, campaign: Campaign) -> dict:
         agenda_fired = True
         agenda_dump = agenda.model_dump()
 
-    return {"newly_unlocked": newly_unlocked, "agenda_fired": agenda_fired, "agenda": agenda_dump}
+    out = {"newly_unlocked": newly_unlocked, "agenda_fired": agenda_fired, "agenda": agenda_dump}
+    if companion_quest_unlocks:
+        out["companion_quest_unlocks"] = companion_quest_unlocks
+    return out

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -84,6 +84,7 @@ class Condition(str, Enum):
 
 
 CharacterKind = Literal["player", "companion", "npc", "monster"]
+CompanionQuestStatus = Literal["locked", "available", "active", "resolved", "failed"]
 
 
 class _StrictModel(BaseModel):
@@ -202,6 +203,10 @@ class ArcGate(_StrictModel):
     threshold: int  # the attitude_value at/above which this gate unlocks
     unlocked: bool = False
     note: str = ""  # what the unlock means, for the DM to play
+    # Optional link into first-class companion quest arcs (#70). A personal_quest gate may
+    # make the linked arc/stage available once; it never decides success or failure.
+    quest_arc_id: str = ""
+    stage_id: str = ""
 
 
 class CompanionAgenda(_StrictModel):
@@ -243,6 +248,49 @@ class CompanionArc(_StrictModel):
 
     arc_gates: list[ArcGate] = Field(default_factory=list)
     agenda: Optional[CompanionAgenda] = None
+
+
+class CompanionQuestStage(_StrictModel):
+    """One engine-owned stage inside a companion's personal quest arc.
+
+    The status is a bounded lifecycle enum, not free prose; an optional `quest_id` points
+    at the player-facing tracked Quest projection when the DM explicitly links one."""
+
+    id: str = Field(default_factory=lambda: _new_id("cqstage"))
+    title: str
+    status: CompanionQuestStatus = "locked"
+    unlock_gate_id: str = ""
+    location_id: str = ""
+    quest_id: str = ""
+    note: str = ""
+
+
+class CompanionQuestArc(_StrictModel):
+    """First-class companion personal quest lifecycle (#70).
+
+    This is the character-owned campaign state machine. `Quest` remains the optional
+    player-facing tracker; sync is one-way from this arc when an explicit engine API says
+    to link/update a Quest."""
+
+    id: str = Field(default_factory=lambda: _new_id("cqarc"))
+    companion_id: str = ""
+    title: str
+    status: CompanionQuestStatus = "locked"
+    stages: list[CompanionQuestStage] = Field(default_factory=list)
+    quest_ids: list[str] = Field(default_factory=list)
+    note: str = ""
+
+    @model_validator(mode="after")
+    def _collect_stage_quest_ids(self) -> "CompanionQuestArc":
+        seen: list[str] = []
+        for qid in self.quest_ids:
+            if qid and qid not in seen:
+                seen.append(qid)
+        for stage in self.stages:
+            if stage.quest_id and stage.quest_id not in seen:
+                seen.append(stage.quest_id)
+        self.quest_ids = seen
+        return self
 
 
 class CompanionDossier(_StrictModel):
@@ -945,6 +993,10 @@ class Campaign(_StrictModel):
     # Persistent camp-beat memory (#69). Read by camp_scene/scheduler, written only by an
     # explicit record path so prompt generation never advances campaign state by accident.
     camp_beats: CampBeatState = Field(default_factory=CampBeatState)
+    # First-class companion personal quest arcs (#70). These complement, but do not replace,
+    # tracked Quest objects; explicit server APIs advance them and optionally project status
+    # into linked Quests. Empty == old snapshots load unchanged.
+    companion_quest_arcs: dict[str, CompanionQuestArc] = Field(default_factory=dict)
 
     characters: dict[str, Character] = Field(default_factory=dict)  # id -> Character (PCs, companion, NPCs)
     party: list[str] = Field(default_factory=list)  # character ids that are PCs / companions

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4611,6 +4611,8 @@ def advance_companion_quest_arc(
 
     derived_from = next_status or next_stage_status
     derived_quest_status = _quest_projection_status(derived_from) if derived_from else ""
+    if next_quest_status and derived_from and not derived_quest_status:
+        raise ValueError(f"quest_status cannot project from companion quest status {derived_from!r}")
     if next_status and next_stage_status:
         stage_projection = _quest_projection_status(next_stage_status)
         if stage_projection and derived_quest_status and stage_projection != derived_quest_status:

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4467,6 +4467,22 @@ def _validate_companion_quest_arc_links(c: Campaign, arc: CompanionQuestArc) -> 
             raise ValueError(f"no tracked quest {stage.quest_id!r} for companion quest stage {stage.id!r}")
 
 
+def _validate_companion_arc_quest_links(c: Campaign, companion_id: str, arc: CompanionArc) -> None:
+    for gate in arc.arc_gates:
+        if gate.kind != "personal_quest" or not gate.quest_arc_id:
+            continue
+        quest_arc = c.companion_quest_arcs.get(gate.quest_arc_id)
+        if quest_arc is None:
+            raise ValueError(f"no companion quest arc {gate.quest_arc_id!r}")
+        if quest_arc.companion_id and quest_arc.companion_id != companion_id:
+            raise ValueError(
+                f"companion quest arc {gate.quest_arc_id!r} belongs to "
+                f"{quest_arc.companion_id!r}, not {companion_id!r}"
+            )
+        if gate.stage_id and not any(stage.id == gate.stage_id for stage in quest_arc.stages):
+            raise ValueError(f"no stage {gate.stage_id!r} in companion quest arc {gate.quest_arc_id!r}")
+
+
 def _companion_quest_arc_view(c: Campaign, arc: CompanionQuestArc) -> dict:
     companion = c.characters.get(arc.companion_id)
     out = arc.model_dump()
@@ -4504,7 +4520,7 @@ def check_companion_arc(campaign_id: str, companion_id: str = "") -> dict:
             if ch.arc is None:
                 continue
             res = companion_arc.evaluate(ch, c)
-            if res["newly_unlocked"] or res["agenda_fired"]:
+            if res["newly_unlocked"] or res["agenda_fired"] or res.get("companion_quest_unlocks"):
                 results.append({"companion_id": ch.id, "name": ch.name, **res})
         save_campaign(c)
         return {"results": results}
@@ -4521,7 +4537,9 @@ def set_companion_arc(campaign_id: str, companion_id: str, arc: dict) -> dict:
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _require_companion(c, companion_id)
-        ch.arc = CompanionArc.model_validate(arc)
+        parsed = CompanionArc.model_validate(arc)
+        _validate_companion_arc_quest_links(c, companion_id, parsed)
+        ch.arc = parsed
         save_campaign(c)
         return {"id": ch.id, "name": ch.name, "arc": ch.arc.model_dump()}
 
@@ -4588,9 +4606,18 @@ def advance_companion_quest_arc(
     next_quest_status = _tracked_quest_status(quest_status) if quest_status else ""
     if not any((next_status, next_stage_status, quest_id, next_quest_status)):
         raise ValueError("advance_companion_quest_arc requires status, stage_status, quest_id, or quest_status")
+    if next_quest_status and not (next_status or next_stage_status):
+        raise ValueError("quest_status requires status or stage_status so Quest projection follows companion arc state")
 
-    derived_from = next_stage_status or next_status
+    derived_from = next_status or next_stage_status
     derived_quest_status = _quest_projection_status(derived_from) if derived_from else ""
+    if next_status and next_stage_status:
+        stage_projection = _quest_projection_status(next_stage_status)
+        if stage_projection and derived_quest_status and stage_projection != derived_quest_status:
+            raise ValueError(
+                f"status {next_status!r} and stage_status {next_stage_status!r} imply conflicting "
+                f"quest projections {derived_quest_status!r} and {stage_projection!r}"
+            )
     if next_quest_status and derived_quest_status and next_quest_status != derived_quest_status:
         raise ValueError(
             f"quest_status {next_quest_status!r} is inconsistent with companion quest status "

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -54,6 +54,7 @@ from models import (
     Combatant,
     CompanionArc,
     CompanionDossier,
+    CompanionQuestArc,
     Condition,
     DeathSaves,
     Decision,
@@ -4424,6 +4425,60 @@ def _require_companion(c: Campaign, companion_id: str) -> Character:
     return ch
 
 
+_COMPANION_QUEST_STATUSES = {"locked", "available", "active", "resolved", "failed"}
+_TRACKED_QUEST_STATUSES = {"active", "completed", "failed"}
+
+
+def _companion_quest_status(status: str, field: str) -> str:
+    s = (status or "").strip().lower()
+    if s not in _COMPANION_QUEST_STATUSES:
+        raise ValueError(f"{field} must be locked|available|active|resolved|failed, got {status!r}")
+    return s
+
+
+def _tracked_quest_status(status: str) -> str:
+    s = (status or "").strip().lower()
+    s = {"resolved": "completed", "open": "active", "available": "active"}.get(s, s)
+    if s not in _TRACKED_QUEST_STATUSES:
+        raise ValueError(f"quest_status must be active|completed|failed (or resolved), got {status!r}")
+    return s
+
+
+def _quest_projection_status(companion_status: str) -> str:
+    return {
+        "available": "active",
+        "active": "active",
+        "resolved": "completed",
+        "failed": "failed",
+    }.get(companion_status, "")
+
+
+def _validate_companion_quest_arc_links(c: Campaign, arc: CompanionQuestArc) -> None:
+    seen_stages: set[str] = set()
+    for stage in arc.stages:
+        if stage.id in seen_stages:
+            raise ValueError(f"duplicate companion quest stage id {stage.id!r}")
+        seen_stages.add(stage.id)
+    for qid in arc.quest_ids:
+        if qid not in c.quests:
+            raise ValueError(f"no tracked quest {qid!r} for companion quest arc {arc.id!r}")
+    for stage in arc.stages:
+        if stage.quest_id and stage.quest_id not in c.quests:
+            raise ValueError(f"no tracked quest {stage.quest_id!r} for companion quest stage {stage.id!r}")
+
+
+def _companion_quest_arc_view(c: Campaign, arc: CompanionQuestArc) -> dict:
+    companion = c.characters.get(arc.companion_id)
+    out = arc.model_dump()
+    out["companion_name"] = companion.name if companion else ""
+    out["linked_quests"] = [
+        {"id": q.id, "title": q.title, "status": q.status}
+        for qid in arc.quest_ids
+        if (q := c.quests.get(qid)) is not None
+    ]
+    return out
+
+
 @mcp.tool()
 def check_companion_arc(campaign_id: str, companion_id: str = "") -> dict:
     """Advance companions' relationship arcs against the CURRENT state and surface the
@@ -4469,6 +4524,140 @@ def set_companion_arc(campaign_id: str, companion_id: str, arc: dict) -> dict:
         ch.arc = CompanionArc.model_validate(arc)
         save_campaign(c)
         return {"id": ch.id, "name": ch.name, "arc": ch.arc.model_dump()}
+
+
+@mcp.tool()
+def set_companion_quest_arc(campaign_id: str, companion_id: str, arc: dict) -> dict:
+    """Create or replace an engine-owned companion personal quest arc.
+
+    CompanionQuestArc is the lifecycle owner for personal quests. Linked tracked Quests
+    remain optional player-facing projections and must already exist when referenced."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        _require_companion(c, companion_id)
+        data = dict(arc or {})
+        if data.get("companion_id") and data["companion_id"] != companion_id:
+            raise ValueError(
+                f"companion quest arc companion_id {data['companion_id']!r} does not match {companion_id!r}"
+            )
+        data["companion_id"] = companion_id
+        parsed = CompanionQuestArc.model_validate(data)
+        _validate_companion_quest_arc_links(c, parsed)
+        c.companion_quest_arcs[parsed.id] = parsed
+        save_campaign(c)
+        return {"companion_quest_arc": _companion_quest_arc_view(c, parsed)}
+
+
+@mcp.tool()
+def get_companion_quest_arcs(campaign_id: str, companion_id: str = "", status: str = "") -> dict:
+    """Read companion personal quest arcs, optionally filtered by companion and lifecycle
+    status. Read-only; does not evaluate gates or advance quests."""
+    c = _require(campaign_id)
+    if companion_id:
+        _require_companion(c, companion_id)
+    wanted_status = _companion_quest_status(status, "status") if status else ""
+    arcs = list(c.companion_quest_arcs.values())
+    if companion_id:
+        arcs = [a for a in arcs if a.companion_id == companion_id]
+    if wanted_status:
+        arcs = [a for a in arcs if a.status == wanted_status]
+    arcs.sort(key=lambda a: (a.companion_id, a.title, a.id))
+    return {"companion_quest_arcs": [_companion_quest_arc_view(c, a) for a in arcs], "count": len(arcs)}
+
+
+@mcp.tool()
+def advance_companion_quest_arc(
+    campaign_id: str,
+    arc_id: str,
+    status: str = "",
+    stage_id: str = "",
+    stage_status: str = "",
+    quest_id: str = "",
+    quest_status: str = "",
+) -> dict:
+    """Explicitly advance a companion personal quest arc and optionally project that
+    change into linked tracked Quests.
+
+    `status` updates the CompanionQuestArc. `stage_id` + `stage_status` updates one
+    stage. `quest_id` links a tracked Quest to the arc (and stage when provided).
+    If a quest is linked and no `quest_status` is given, the engine derives a one-way
+    projection from the companion status: available/active -> active, resolved ->
+    completed, failed -> failed. Prose never advances this state."""
+    next_status = _companion_quest_status(status, "status") if status else ""
+    next_stage_status = _companion_quest_status(stage_status, "stage_status") if stage_status else ""
+    next_quest_status = _tracked_quest_status(quest_status) if quest_status else ""
+    if not any((next_status, next_stage_status, quest_id, next_quest_status)):
+        raise ValueError("advance_companion_quest_arc requires status, stage_status, quest_id, or quest_status")
+
+    derived_from = next_stage_status or next_status
+    derived_quest_status = _quest_projection_status(derived_from) if derived_from else ""
+    if next_quest_status and derived_quest_status and next_quest_status != derived_quest_status:
+        raise ValueError(
+            f"quest_status {next_quest_status!r} is inconsistent with companion quest status "
+            f"{derived_from!r}; use {derived_quest_status!r}"
+        )
+    final_quest_status = next_quest_status or derived_quest_status
+
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        current = c.companion_quest_arcs.get(arc_id)
+        if current is None:
+            raise ValueError(f"no companion quest arc {arc_id!r}")
+        data = current.model_dump(mode="json")
+        if next_status:
+            data["status"] = next_status
+
+        stage_data = None
+        if stage_id:
+            for stage in data.get("stages", []):
+                if stage.get("id") == stage_id:
+                    stage_data = stage
+                    break
+            if stage_data is None:
+                raise ValueError(f"no stage {stage_id!r} in companion quest arc {arc_id!r}")
+            if next_stage_status:
+                stage_data["status"] = next_stage_status
+        elif next_stage_status:
+            raise ValueError("stage_status requires stage_id")
+
+        if quest_id:
+            if quest_id not in c.quests:
+                raise ValueError(f"no tracked quest {quest_id!r}")
+            quest_ids = list(data.get("quest_ids", []))
+            if quest_id not in quest_ids:
+                quest_ids.append(quest_id)
+            data["quest_ids"] = quest_ids
+            if stage_data is not None:
+                stage_data["quest_id"] = quest_id
+
+        next_arc = CompanionQuestArc.model_validate(data)
+        _validate_companion_quest_arc_links(c, next_arc)
+
+        quest_targets: list[str] = []
+        if final_quest_status:
+            if quest_id:
+                quest_targets = [quest_id]
+            else:
+                quest_targets = list(next_arc.quest_ids)
+            if not quest_targets:
+                raise ValueError("quest_status or projected quest status requires quest_id or an existing linked quest")
+
+        quest_updates = []
+        for qid in quest_targets:
+            q = c.quests.get(qid)
+            if q is None:
+                raise ValueError(f"no tracked quest {qid!r}")
+            if q.status != final_quest_status:
+                quest_updates.append({"quest_id": q.id, "previous_status": q.status, "status": final_quest_status})
+
+        c.companion_quest_arcs[next_arc.id] = next_arc
+        for update in quest_updates:
+            c.quests[update["quest_id"]].status = update["status"]  # type: ignore[assignment]
+        save_campaign(c)
+        return {
+            "companion_quest_arc": _companion_quest_arc_view(c, next_arc),
+            "quest_updates": quest_updates,
+        }
 
 
 @mcp.tool()

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4469,7 +4469,11 @@ def _validate_companion_quest_arc_links(c: Campaign, arc: CompanionQuestArc) -> 
 
 def _validate_companion_arc_quest_links(c: Campaign, companion_id: str, arc: CompanionArc) -> None:
     for gate in arc.arc_gates:
-        if gate.kind != "personal_quest" or not gate.quest_arc_id:
+        if gate.kind != "personal_quest":
+            continue
+        if gate.stage_id and not gate.quest_arc_id:
+            raise ValueError("personal_quest gate stage_id requires quest_arc_id")
+        if not gate.quest_arc_id:
             continue
         quest_arc = c.companion_quest_arcs.get(gate.quest_arc_id)
         if quest_arc is None:
@@ -4481,6 +4485,25 @@ def _validate_companion_arc_quest_links(c: Campaign, companion_id: str, arc: Com
             )
         if gate.stage_id and not any(stage.id == gate.stage_id for stage in quest_arc.stages):
             raise ValueError(f"no stage {gate.stage_id!r} in companion quest arc {gate.quest_arc_id!r}")
+
+
+def _validate_replacing_companion_quest_arc(c: Campaign, arc: CompanionQuestArc) -> None:
+    for ch in c.characters.values():
+        if ch.arc is None:
+            continue
+        for gate in ch.arc.arc_gates:
+            if gate.kind != "personal_quest" or gate.quest_arc_id != arc.id:
+                continue
+            if arc.companion_id and arc.companion_id != ch.id:
+                raise ValueError(
+                    f"existing personal_quest gate on {ch.id!r} references companion quest arc {arc.id!r}, "
+                    f"which would belong to {arc.companion_id!r}"
+                )
+            if gate.stage_id and not any(stage.id == gate.stage_id for stage in arc.stages):
+                raise ValueError(
+                    f"existing personal_quest gate on {ch.id!r} references missing stage {gate.stage_id!r} "
+                    f"in companion quest arc {arc.id!r}"
+                )
 
 
 def _companion_quest_arc_view(c: Campaign, arc: CompanionQuestArc) -> dict:
@@ -4561,6 +4584,7 @@ def set_companion_quest_arc(campaign_id: str, companion_id: str, arc: dict) -> d
         data["companion_id"] = companion_id
         parsed = CompanionQuestArc.model_validate(data)
         _validate_companion_quest_arc_links(c, parsed)
+        _validate_replacing_companion_quest_arc(c, parsed)
         c.companion_quest_arcs[parsed.id] = parsed
         save_campaign(c)
         return {"companion_quest_arc": _companion_quest_arc_view(c, parsed)}
@@ -4609,17 +4633,19 @@ def advance_companion_quest_arc(
     if next_quest_status and not (next_status or next_stage_status):
         raise ValueError("quest_status requires status or stage_status so Quest projection follows companion arc state")
 
-    derived_from = next_status or next_stage_status
-    derived_quest_status = _quest_projection_status(derived_from) if derived_from else ""
+    arc_projection = _quest_projection_status(next_status) if next_status else ""
+    stage_projection = _quest_projection_status(next_stage_status) if next_stage_status else ""
+    if next_status == "locked" and stage_projection:
+        raise ValueError(f"stage_status {next_stage_status!r} cannot advance while companion quest status is 'locked'")
+    if arc_projection and stage_projection and arc_projection != stage_projection:
+        raise ValueError(
+            f"status {next_status!r} and stage_status {next_stage_status!r} imply conflicting "
+            f"quest projections {arc_projection!r} and {stage_projection!r}"
+        )
+    derived_quest_status = arc_projection or stage_projection
+    derived_from = next_status if arc_projection or (next_status and not stage_projection) else next_stage_status
     if next_quest_status and derived_from and not derived_quest_status:
         raise ValueError(f"quest_status cannot project from companion quest status {derived_from!r}")
-    if next_status and next_stage_status:
-        stage_projection = _quest_projection_status(next_stage_status)
-        if stage_projection and derived_quest_status and stage_projection != derived_quest_status:
-            raise ValueError(
-                f"status {next_status!r} and stage_status {next_stage_status!r} imply conflicting "
-                f"quest projections {derived_quest_status!r} and {stage_projection!r}"
-            )
     if next_quest_status and derived_quest_status and next_quest_status != derived_quest_status:
         raise ValueError(
             f"quest_status {next_quest_status!r} is inconsistent with companion quest status "
@@ -4666,6 +4692,11 @@ def advance_companion_quest_arc(
         if final_quest_status:
             if quest_id:
                 quest_targets = [quest_id]
+            elif stage_data is not None:
+                stage_quest_id = str(stage_data.get("quest_id") or "")
+                if not stage_quest_id:
+                    raise ValueError("stage quest projection requires quest_id or a linked stage quest_id")
+                quest_targets = [stage_quest_id]
             else:
                 quest_targets = list(next_arc.quest_ids)
             if not quest_targets:

--- a/servers/engine/tests/test_companion_arc.py
+++ b/servers/engine/tests/test_companion_arc.py
@@ -372,6 +372,7 @@ def test_personal_quest_gate_makes_linked_companion_quest_arc_available_once(cam
         "quest_arc_id": "cq_seraphine_vow",
         "stage_id": "stage_oath",
         "status": "available",
+        "changed": ["arc", "stage"],
     }]
     arc = server.get_companion_quest_arcs(cid, companion_id=comp)["companion_quest_arcs"][0]
     assert arc["status"] == "available"
@@ -380,6 +381,73 @@ def test_personal_quest_gate_makes_linked_companion_quest_arc_available_once(cam
     assert server.check_companion_arc(cid, comp)["results"] == []
     persisted = store.load_campaign(cid)
     assert persisted.companion_quest_arcs["cq_seraphine_vow"].status == "available"
+
+
+def test_set_companion_arc_rejects_missing_personal_quest_link_without_mutation(camp):
+    cid, comp = camp
+
+    with pytest.raises(ValueError, match="no companion quest arc"):
+        server.set_companion_arc(cid, comp, {
+            "arc_gates": [{
+                "kind": "personal_quest",
+                "threshold": 0,
+                "quest_arc_id": "cq_missing",
+            }],
+        })
+
+    assert store.load_campaign(cid).characters[comp].arc is None
+
+
+def test_personal_quest_gate_bad_legacy_link_does_not_burn_unlock(camp):
+    cid, comp = camp
+    c = store.load_campaign(cid)
+    c.characters[comp].arc = CompanionArc(arc_gates=[ArcGate(
+        kind="personal_quest",
+        threshold=0,
+        quest_arc_id="cq_missing",
+    )])
+    store.save_campaign(c)
+
+    out = server.check_companion_arc(cid, comp)
+    unlock = out["results"][0]["companion_quest_unlocks"][0]
+    assert "error" in unlock
+    assert store.load_campaign(cid).characters[comp].arc.arc_gates[0].unlocked is False
+
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_missing",
+        "title": "Recovered Link",
+    })
+    retried = server.check_companion_arc(cid, comp)
+    assert retried["results"][0]["companion_quest_unlocks"][0]["changed"] == ["arc"]
+    persisted = store.load_campaign(cid)
+    assert persisted.characters[comp].arc.arc_gates[0].unlocked is True
+    assert persisted.companion_quest_arcs["cq_missing"].status == "available"
+
+
+def test_personal_quest_gate_reports_no_transition_for_already_resolved_arc(camp):
+    cid, comp = camp
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "status": "resolved",
+        "stages": [{"id": "stage_oath", "title": "Name the broken oath", "status": "resolved"}],
+    })
+    server.set_companion_arc(cid, comp, {
+        "arc_gates": [{
+            "kind": "personal_quest",
+            "threshold": 0,
+            "quest_arc_id": "cq_seraphine_vow",
+            "stage_id": "stage_oath",
+        }],
+    })
+
+    unlock = server.check_companion_arc(cid, comp)["results"][0]["companion_quest_unlocks"][0]
+    assert unlock["no_transition"] is True
+    assert unlock["status"] == "resolved"
+    assert unlock["stage_status"] == "resolved"
+    persisted = store.load_campaign(cid)
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].status == "resolved"
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].stages[0].status == "resolved"
 
 
 def test_advance_companion_quest_arc_links_and_repairs_tracked_quest(camp):
@@ -438,6 +506,55 @@ def test_advance_companion_quest_arc_rejects_inconsistent_quest_status_without_m
     arc = persisted.companion_quest_arcs["cq_seraphine_vow"]
     assert arc.status == "locked"
     assert arc.quest_ids == [qid]
+    assert persisted.quests[qid].status == "active"
+
+
+def test_advance_companion_quest_arc_rejects_quest_status_without_arc_transition(camp):
+    cid, comp = camp
+    qid = server.add_quest(cid, "Seraphine's Vow")["id"]
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "quest_ids": [qid],
+    })
+
+    with pytest.raises(ValueError, match="quest_status requires status or stage_status"):
+        server.advance_companion_quest_arc(
+            cid,
+            "cq_seraphine_vow",
+            quest_id=qid,
+            quest_status="completed",
+        )
+
+    persisted = store.load_campaign(cid)
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].status == "locked"
+    assert persisted.quests[qid].status == "active"
+
+
+def test_advance_companion_quest_arc_rejects_conflicting_arc_and_stage_projection(camp):
+    cid, comp = camp
+    qid = server.add_quest(cid, "Seraphine's Vow")["id"]
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "status": "active",
+        "stages": [{"id": "stage_oath", "title": "Recover the oath-name", "status": "active"}],
+        "quest_ids": [qid],
+    })
+
+    with pytest.raises(ValueError, match="conflicting quest projections"):
+        server.advance_companion_quest_arc(
+            cid,
+            "cq_seraphine_vow",
+            status="resolved",
+            stage_id="stage_oath",
+            stage_status="active",
+            quest_id=qid,
+        )
+
+    persisted = store.load_campaign(cid)
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].status == "active"
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].stages[0].status == "active"
     assert persisted.quests[qid].status == "active"
 
 

--- a/servers/engine/tests/test_companion_arc.py
+++ b/servers/engine/tests/test_companion_arc.py
@@ -531,6 +531,29 @@ def test_advance_companion_quest_arc_rejects_quest_status_without_arc_transition
     assert persisted.quests[qid].status == "active"
 
 
+def test_advance_companion_quest_arc_rejects_locked_status_quest_projection(camp):
+    cid, comp = camp
+    qid = server.add_quest(cid, "Seraphine's Vow")["id"]
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "quest_ids": [qid],
+    })
+
+    with pytest.raises(ValueError, match="cannot project"):
+        server.advance_companion_quest_arc(
+            cid,
+            "cq_seraphine_vow",
+            status="locked",
+            quest_id=qid,
+            quest_status="completed",
+        )
+
+    persisted = store.load_campaign(cid)
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].status == "locked"
+    assert persisted.quests[qid].status == "active"
+
+
 def test_advance_companion_quest_arc_rejects_conflicting_arc_and_stage_projection(camp):
     cid, comp = camp
     qid = server.add_quest(cid, "Seraphine's Vow")["id"]

--- a/servers/engine/tests/test_companion_arc.py
+++ b/servers/engine/tests/test_companion_arc.py
@@ -64,6 +64,15 @@ def test_old_campaign_snapshot_without_flags_deserializes_unchanged():
     assert Campaign.model_validate(old).flags == {}
 
 
+def test_old_campaign_snapshot_without_companion_quest_arcs_deserializes_unchanged():
+    c = Campaign(title="Pre-#70")
+    data = c.model_dump(mode="json")
+    old = {k: v for k, v in data.items() if k != "companion_quest_arcs"}
+    assert "companion_quest_arcs" not in old
+    reloaded = Campaign.model_validate(old)
+    assert reloaded.companion_quest_arcs == {}
+
+
 def test_evaluate_no_arc_is_noop():
     ch = _companion(attitude=99)  # no gates, no agenda -> arc stays None
     assert ch.arc is None
@@ -316,3 +325,146 @@ def test_threshold_agenda_requires_explicit_value():
     comp = _companion(agenda=CompanionAgenda(trigger="day_reached", value=5))
     assert companion_arc._agenda_triggered(comp, _campaign_with(comp, day=1)) is False
     assert companion_arc._agenda_triggered(comp, _campaign_with(comp, day=5)) is True
+
+
+# --- companion quest arcs (#70) ---------------------------------------------
+
+def test_set_and_get_companion_quest_arc_by_companion_and_status(camp):
+    cid, comp = camp
+    out = server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "status": "available",
+        "stages": [{"id": "stage_oath", "title": "Name the broken oath", "status": "available"}],
+    })
+    assert out["companion_quest_arc"]["id"] == "cq_seraphine_vow"
+    assert out["companion_quest_arc"]["companion_id"] == comp
+
+    by_companion = server.get_companion_quest_arcs(cid, companion_id=comp)
+    assert by_companion["count"] == 1
+    assert by_companion["companion_quest_arcs"][0]["title"] == "Seraphine's Vow"
+
+    by_status = server.get_companion_quest_arcs(cid, status="available")
+    assert [a["id"] for a in by_status["companion_quest_arcs"]] == ["cq_seraphine_vow"]
+    assert server.get_companion_quest_arcs(cid, status="resolved")["count"] == 0
+
+
+def test_personal_quest_gate_makes_linked_companion_quest_arc_available_once(camp):
+    cid, comp = camp
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "stages": [{"id": "stage_oath", "title": "Name the broken oath"}],
+    })
+    server.set_companion_arc(cid, comp, {
+        "arc_gates": [{
+            "kind": "personal_quest",
+            "threshold": 0,
+            "quest_arc_id": "cq_seraphine_vow",
+            "stage_id": "stage_oath",
+        }],
+    })
+
+    first = server.check_companion_arc(cid, comp)
+    assert len(first["results"]) == 1
+    unlocks = first["results"][0]["companion_quest_unlocks"]
+    assert unlocks == [{
+        "quest_arc_id": "cq_seraphine_vow",
+        "stage_id": "stage_oath",
+        "status": "available",
+    }]
+    arc = server.get_companion_quest_arcs(cid, companion_id=comp)["companion_quest_arcs"][0]
+    assert arc["status"] == "available"
+    assert arc["stages"][0]["status"] == "available"
+
+    assert server.check_companion_arc(cid, comp)["results"] == []
+    persisted = store.load_campaign(cid)
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].status == "available"
+
+
+def test_advance_companion_quest_arc_links_and_repairs_tracked_quest(camp):
+    cid, comp = camp
+    qid = server.add_quest(cid, "Seraphine's Vow", objectives=["Recover the oath-name"])["id"]
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "status": "active",
+        "stages": [{"id": "stage_oath", "title": "Recover the oath-name", "status": "active"}],
+        "quest_ids": [qid],
+    })
+    # Simulate a drifted tracked Quest projection. The companion arc remains the owner.
+    server.complete_quest(cid, qid, "failed")
+
+    out = server.advance_companion_quest_arc(
+        cid,
+        "cq_seraphine_vow",
+        status="resolved",
+        stage_id="stage_oath",
+        stage_status="resolved",
+        quest_id=qid,
+    )
+    assert out["companion_quest_arc"]["status"] == "resolved"
+    assert out["companion_quest_arc"]["stages"][0]["quest_id"] == qid
+    assert out["quest_updates"] == [{
+        "quest_id": qid,
+        "previous_status": "failed",
+        "status": "completed",
+    }]
+    persisted = store.load_campaign(cid)
+    assert persisted.quests[qid].status == "completed"
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].quest_ids == [qid]
+
+
+def test_advance_companion_quest_arc_rejects_inconsistent_quest_status_without_mutation(camp):
+    cid, comp = camp
+    qid = server.add_quest(cid, "Seraphine's Vow")["id"]
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "stages": [{"id": "stage_oath", "title": "Recover the oath-name"}],
+        "quest_ids": [qid],
+    })
+
+    with pytest.raises(ValueError, match="inconsistent"):
+        server.advance_companion_quest_arc(
+            cid,
+            "cq_seraphine_vow",
+            status="resolved",
+            quest_id=qid,
+            quest_status="active",
+        )
+
+    persisted = store.load_campaign(cid)
+    arc = persisted.companion_quest_arcs["cq_seraphine_vow"]
+    assert arc.status == "locked"
+    assert arc.quest_ids == [qid]
+    assert persisted.quests[qid].status == "active"
+
+
+def test_companion_quest_arc_apis_reject_bad_optional_links_without_partial_mutation(camp):
+    cid, comp = camp
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "stages": [{"id": "stage_oath", "title": "Recover the oath-name"}],
+    })
+
+    with pytest.raises(ValueError, match="no tracked quest"):
+        server.set_companion_quest_arc(cid, comp, {
+            "id": "cq_bad",
+            "title": "Bad Link",
+            "quest_ids": ["quest_missing"],
+        })
+    assert "cq_bad" not in store.load_campaign(cid).companion_quest_arcs
+
+    with pytest.raises(ValueError, match="no stage"):
+        server.advance_companion_quest_arc(
+            cid,
+            "cq_seraphine_vow",
+            stage_id="stage_missing",
+            stage_status="active",
+        )
+    persisted = store.load_campaign(cid)
+    arc = persisted.companion_quest_arcs["cq_seraphine_vow"]
+    assert arc.status == "locked"
+    assert arc.stages[0].status == "locked"

--- a/servers/engine/tests/test_companion_arc.py
+++ b/servers/engine/tests/test_companion_arc.py
@@ -372,6 +372,7 @@ def test_personal_quest_gate_makes_linked_companion_quest_arc_available_once(cam
         "quest_arc_id": "cq_seraphine_vow",
         "stage_id": "stage_oath",
         "status": "available",
+        "stage_status": "available",
         "changed": ["arc", "stage"],
     }]
     arc = server.get_companion_quest_arcs(cid, companion_id=comp)["companion_quest_arcs"][0]
@@ -381,6 +382,29 @@ def test_personal_quest_gate_makes_linked_companion_quest_arc_available_once(cam
     assert server.check_companion_arc(cid, comp)["results"] == []
     persisted = store.load_campaign(cid)
     assert persisted.companion_quest_arcs["cq_seraphine_vow"].status == "available"
+
+
+def test_personal_quest_gate_stage_unlock_reports_actual_arc_status(camp):
+    cid, comp = camp
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "status": "active",
+        "stages": [{"id": "stage_oath", "title": "Name the broken oath"}],
+    })
+    server.set_companion_arc(cid, comp, {
+        "arc_gates": [{
+            "kind": "personal_quest",
+            "threshold": 0,
+            "quest_arc_id": "cq_seraphine_vow",
+            "stage_id": "stage_oath",
+        }],
+    })
+
+    unlock = server.check_companion_arc(cid, comp)["results"][0]["companion_quest_unlocks"][0]
+    assert unlock["status"] == "active"
+    assert unlock["stage_status"] == "available"
+    assert unlock["changed"] == ["stage"]
 
 
 def test_set_companion_arc_rejects_missing_personal_quest_link_without_mutation(camp):
@@ -396,6 +420,48 @@ def test_set_companion_arc_rejects_missing_personal_quest_link_without_mutation(
         })
 
     assert store.load_campaign(cid).characters[comp].arc is None
+
+
+def test_set_companion_arc_rejects_stage_without_quest_arc(camp):
+    cid, comp = camp
+
+    with pytest.raises(ValueError, match="stage_id requires quest_arc_id"):
+        server.set_companion_arc(cid, comp, {
+            "arc_gates": [{
+                "kind": "personal_quest",
+                "threshold": 0,
+                "stage_id": "stage_oath",
+            }],
+        })
+
+    assert store.load_campaign(cid).characters[comp].arc is None
+
+
+def test_set_companion_quest_arc_rejects_replacing_referenced_stage(camp):
+    cid, comp = camp
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "stages": [{"id": "stage_oath", "title": "Name the broken oath"}],
+    })
+    server.set_companion_arc(cid, comp, {
+        "arc_gates": [{
+            "kind": "personal_quest",
+            "threshold": 0,
+            "quest_arc_id": "cq_seraphine_vow",
+            "stage_id": "stage_oath",
+        }],
+    })
+
+    with pytest.raises(ValueError, match="references missing stage"):
+        server.set_companion_quest_arc(cid, comp, {
+            "id": "cq_seraphine_vow",
+            "title": "Seraphine's Vow",
+            "stages": [{"id": "stage_other", "title": "A different stage"}],
+        })
+
+    persisted = store.load_campaign(cid)
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].stages[0].id == "stage_oath"
 
 
 def test_personal_quest_gate_bad_legacy_link_does_not_burn_unlock(camp):
@@ -554,6 +620,30 @@ def test_advance_companion_quest_arc_rejects_locked_status_quest_projection(camp
     assert persisted.quests[qid].status == "active"
 
 
+def test_advance_companion_quest_arc_rejects_locked_arc_with_available_stage(camp):
+    cid, comp = camp
+    qid = server.add_quest(cid, "Seraphine's Vow")["id"]
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "stages": [{"id": "stage_oath", "title": "Recover the oath-name", "quest_id": qid}],
+    })
+
+    with pytest.raises(ValueError, match="cannot advance while companion quest status is 'locked'"):
+        server.advance_companion_quest_arc(
+            cid,
+            "cq_seraphine_vow",
+            status="locked",
+            stage_id="stage_oath",
+            stage_status="available",
+        )
+
+    persisted = store.load_campaign(cid)
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].status == "locked"
+    assert persisted.companion_quest_arcs["cq_seraphine_vow"].stages[0].status == "locked"
+    assert persisted.quests[qid].status == "active"
+
+
 def test_advance_companion_quest_arc_rejects_conflicting_arc_and_stage_projection(camp):
     cid, comp = camp
     qid = server.add_quest(cid, "Seraphine's Vow")["id"]
@@ -579,6 +669,40 @@ def test_advance_companion_quest_arc_rejects_conflicting_arc_and_stage_projectio
     assert persisted.companion_quest_arcs["cq_seraphine_vow"].status == "active"
     assert persisted.companion_quest_arcs["cq_seraphine_vow"].stages[0].status == "active"
     assert persisted.quests[qid].status == "active"
+
+
+def test_advance_companion_quest_arc_stage_only_updates_only_linked_stage_quest(camp):
+    cid, comp = camp
+    first_qid = server.add_quest(cid, "Seraphine's First Vow")["id"]
+    second_qid = server.add_quest(cid, "Seraphine's Second Vow")["id"]
+    server.set_companion_quest_arc(cid, comp, {
+        "id": "cq_seraphine_vow",
+        "title": "Seraphine's Vow",
+        "status": "active",
+        "stages": [
+            {"id": "stage_first", "title": "First oath", "status": "active", "quest_id": first_qid},
+            {"id": "stage_second", "title": "Second oath", "status": "active", "quest_id": second_qid},
+        ],
+    })
+
+    out = server.advance_companion_quest_arc(
+        cid,
+        "cq_seraphine_vow",
+        stage_id="stage_first",
+        stage_status="resolved",
+    )
+
+    assert out["quest_updates"] == [{
+        "quest_id": first_qid,
+        "previous_status": "active",
+        "status": "completed",
+    }]
+    persisted = store.load_campaign(cid)
+    assert persisted.quests[first_qid].status == "completed"
+    assert persisted.quests[second_qid].status == "active"
+    stages = {stage.id: stage for stage in persisted.companion_quest_arcs["cq_seraphine_vow"].stages}
+    assert stages["stage_first"].status == "resolved"
+    assert stages["stage_second"].status == "active"
 
 
 def test_companion_quest_arc_apis_reject_bad_optional_links_without_partial_mutation(camp):


### PR DESCRIPTION
Refs #70

## Summary
- Adds first-class `CompanionQuestArc` / `CompanionQuestStage` campaign state with bounded lifecycle statuses and optional tracked `Quest` links.
- Adds optional `ArcGate.quest_arc_id` / `stage_id` links so a `personal_quest` gate can make a companion quest arc/stage available exactly once.
- Adds explicit MCP APIs to create/query/advance companion quest arcs, including deterministic tracked-Quest projection repair.

## Architecture / State Authority
`CompanionQuestArc` is the lifecycle owner for companion personal arcs. `Quest` remains an optional player-facing tracked quest projection, and `QuestHook` remains world-owned seed material. The engine never infers success from prose: `check_companion_arc` can only surface availability from a linked gate, while `advance_companion_quest_arc` is the explicit mutation path for active/resolved/failed progression and linked Quest status updates.

Quest projection is one-way from companion quest advancement:
- `available` / `active` -> tracked Quest `active`
- `resolved` -> tracked Quest `completed`
- `failed` -> tracked Quest `failed`

If a linked tracked Quest has drifted, an explicit companion-quest advance repairs it deterministically and reports the previous status. Inconsistent explicit inputs, missing stages, and missing tracked Quest links fail before mutation.

## API Shape
- `set_companion_quest_arc(campaign_id, companion_id, arc)` creates or replaces an engine-owned companion quest arc.
- `get_companion_quest_arcs(campaign_id, companion_id="", status="")` reads arcs filtered by companion/status.
- `advance_companion_quest_arc(campaign_id, arc_id, status="", stage_id="", stage_status="", quest_id="", quest_status="")` explicitly advances arc/stage state and optionally links/updates a tracked Quest.
- `check_companion_arc` now includes `companion_quest_unlocks` when a linked personal quest gate unlocks availability.

## Files Changed
- `servers/engine/models.py`
- `servers/engine/companion_arc.py`
- `servers/engine/server.py`
- `servers/engine/tests/test_companion_arc.py`

## Validation
- `python3 -m py_compile servers/engine/models.py servers/engine/companion_arc.py servers/engine/server.py`
- `uv run --directory servers/engine --group dev pytest -q tests/test_companion_arc.py`
- `uv run --directory servers/engine --group dev pytest -q tests/test_questgen.py tests/test_dashboard.py tests/test_qa_fixes.py::test_set_quest_status_routes_a_tracked_quest_and_extra_attack_echo`
- `uv run --directory servers/engine --group dev pytest -q tests/test_companion_arc.py tests/test_questgen.py tests/test_dashboard.py tests/test_qa_fixes.py::test_set_quest_status_routes_a_tracked_quest_and_extra_attack_echo`
- `git diff --check`

## Risks / Non-goals
- Does not seed story/world content or edit DM skill text.
- Does not add dashboard/viewer projections.
- Does not auto-complete companion quests from narration, romance/betrayal prose, or immutable world facts.
- Full repo test suite intentionally not run locally; validation stayed focused per local-resource policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Companions now have personal quest arcs that unlock automatically when companion arc gates become available
* New API endpoints to set, list, and advance companion quest arcs with optional linked quest tracking
* Companion arc evaluation reports quest unlock events alongside existing gate notifications
* Quest arc advancement can synchronize linked tracked quest statuses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->