### PR TITLE
docs(openworlds): add fidelity and asset contract

### DIFF
--- a/docs/OPENWORLDS_DESIGN_ASSET_POLICY.md
+++ b/docs/OPENWORLDS_DESIGN_ASSET_POLICY.md
@@ -7,39 +7,52 @@ third-party game UI material.
 
 ## Source Buckets
 
+Source artifact:
+
+- `OpenWorlds.zip`
+  - SHA256: `8e9e2b885764fd3492b74b2d02eda5db9827eb087121054e8ca52e9ace10fd0a`
+  - Acquisition date: 2026-05-25 UTC
+  - Local extraction label: `openworlds-design-2026-05-25`
+  - License/provenance status: internal design handoff; not a blanket asset
+    license
+
 Primary visual/reference contract:
 
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/Open Worlds.html`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/styles.css`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/app.jsx`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/chrome.jsx`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/screen-*.jsx`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/camp-sidebar.jsx`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/toast.jsx`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/tooltip.jsx`
+- `openworlds/Open Worlds.html`
+- `openworlds/styles.css`
+- `openworlds/app.jsx`
+- `openworlds/chrome.jsx`
+- `openworlds/screen-*.jsx`
+- `openworlds/camp-sidebar.jsx`
+- `openworlds/toast.jsx`
+- `openworlds/tooltip.jsx`
 
 Prototype/demo data requiring rewrite:
 
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/data.js`
+- `openworlds/data.js`
 
 Open Design or tweak-host code to remove from production routes:
 
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/tweaks-panel.jsx`
+- `openworlds/tweaks-panel.jsx`
 
 Secondary reference only:
 
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/uploads/dndforever/index.html`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/uploads/dndforever/DESIGN-HANDOFF.md`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/uploads/dndforever/DESIGN-MANIFEST.json`
+- `uploads/dndforever/index.html`
+- `uploads/dndforever/DESIGN-HANDOFF.md`
+- `uploads/dndforever/DESIGN-MANIFEST.json`
 
 Reference-only assets:
 
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/screenshots/*`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/uploads/*.png`
-- `/Users/lume/Downloads/OpenWorlds.zip`
+- `openworlds/screenshots/*`
+- `uploads/*.png`
+- `OpenWorlds.zip`
 
 The reference-only assets must not be committed unless a follow-up PR documents
 clear provenance and licensing.
+
+When a later PR copies any source file into the repo, its PR body must map the
+source artifact entry to the new repo-relative path and list the relevant
+license/provenance note.
 
 ## Allowed In Repo
 

--- a/docs/OPENWORLDS_DESIGN_ASSET_POLICY.md
+++ b/docs/OPENWORLDS_DESIGN_ASSET_POLICY.md
@@ -1,0 +1,99 @@
+# OpenWorlds Design Asset Policy
+
+This policy governs any ClawDnD work derived from the local OpenWorlds design
+bundle. It exists to preserve visual fidelity without accidentally committing
+uncleared reference art, prototype-only dependencies, private content, or
+third-party game UI material.
+
+## Source Buckets
+
+Primary visual/reference contract:
+
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/Open Worlds.html`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/styles.css`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/app.jsx`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/chrome.jsx`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/screen-*.jsx`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/camp-sidebar.jsx`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/toast.jsx`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/tooltip.jsx`
+
+Prototype/demo data requiring rewrite:
+
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/data.js`
+
+Open Design or tweak-host code to remove from production routes:
+
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/tweaks-panel.jsx`
+
+Secondary reference only:
+
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/uploads/dndforever/index.html`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/uploads/dndforever/DESIGN-HANDOFF.md`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/uploads/dndforever/DESIGN-MANIFEST.json`
+
+Reference-only assets:
+
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/screenshots/*`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/uploads/*.png`
+- `/Users/lume/Downloads/OpenWorlds.zip`
+
+The reference-only assets must not be committed unless a follow-up PR documents
+clear provenance and licensing.
+
+## Allowed In Repo
+
+- Audited and cleaned HTML/CSS/JS implementation code from the primary
+  OpenWorlds export only after the PR documents provenance, dependency notices,
+  and copied source files.
+- Abstract design tokens, layout structure, component behavior, and interaction
+  patterns ported from the primary export.
+- Locally vendored runtime libraries for the first exact-fidelity sprint, when
+  their license notices are included and no network CDN calls remain.
+- ClawDnD-authored docs that describe source buckets, fidelity requirements,
+  and asset handling.
+
+## Not Allowed In Repo
+
+- `OpenWorlds.zip`.
+- Pasted Owlcat/BG/reference screenshots.
+- Any image from `uploads/*.png` or `openworlds/screenshots/*` without explicit
+  provenance.
+- Open Design sandbox, preview, snapshot, or tweak-host chrome.
+- Live CDN dependencies in the packaged app.
+- Private world seeds, QA transcripts, play-state, secrets, or local runtime
+  artifacts.
+- Browser-side code that directly mutates campaign state.
+
+## Prototype Dependency Policy
+
+The OpenWorlds prototype currently references Google Fonts, React, ReactDOM, and
+Babel through network CDNs. Production ClawDnD builds must not depend on those
+network calls.
+
+The first exact-fidelity PR may use locally vendored React, ReactDOM, and Babel
+to preserve the export quickly. A release-hardening PR must replace runtime
+Babel with a proper bundled build before beta distribution or notarization.
+
+Fonts must be self-hosted with license notices, replaced by system fallbacks with
+explicit visual acceptance, or separately cleared before shipping.
+
+## PR Checklist For Visual Work
+
+Every OpenWorlds visual PR must state:
+
+- Whether any binary/image assets were copied.
+- Whether any third-party or reference assets were copied.
+- Which source files from the primary export were ported.
+- Whether live network dependencies remain.
+- Which screenshot viewports were checked.
+- Whether the browser surface still treats the engine as the sole game-state
+  writer.
+
+The default acceptable statement is:
+
+> No third-party/reference image assets copied. OpenWorlds implementation code
+> was audited against the local primary export before porting. Runtime
+> dependencies are local and documented. Prototype data was rewritten or clearly
+> kept as non-canonical demo data. Engine state remains read-only from the
+> browser except for existing `/move` player-intent posts.

--- a/docs/OPENWORLDS_FIDELITY_PLAN.md
+++ b/docs/OPENWORLDS_FIDELITY_PLAN.md
@@ -11,17 +11,18 @@ local services and host the product surface in `WKWebView`; it should not
 recreate the OpenWorlds UI in SwiftUI unless a future native component can meet
 screenshot-level parity.
 
-Primary visual/reference source files:
+Primary visual/reference source files inside source artifact `OpenWorlds.zip`
+SHA256 `8e9e2b885764fd3492b74b2d02eda5db9827eb087121054e8ca52e9ace10fd0a`:
 
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/Open Worlds.html`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/styles.css`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/app.jsx`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/chrome.jsx`
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/screen-*.jsx`
+- `openworlds/Open Worlds.html`
+- `openworlds/styles.css`
+- `openworlds/app.jsx`
+- `openworlds/chrome.jsx`
+- `openworlds/screen-*.jsx`
 
 Prototype/demo data requiring rewrite or explicit non-canonical labeling:
 
-- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/data.js`
+- `openworlds/data.js`
 
 ## Architecture
 
@@ -81,8 +82,8 @@ Prototype/demo data requiring rewrite or explicit non-canonical labeling:
 ## PR #123 Disposition
 
 PR #123 must remain unmerged. After this plan lands, add a final PR comment on
-#123 linking to the fidelity contract PR and close #123 as superseded once the
-first viewer-hosted OpenWorlds surface PR is open.
+issue/PR `#123` linking to the fidelity contract PR and close `#123` as
+superseded once the first viewer-hosted OpenWorlds surface PR is open.
 
 If the viewer-hosted web-surface path fails, reopen the architecture decision in
 a new issue or PR. Do not revive the SwiftUI repaint unless it includes

--- a/docs/OPENWORLDS_FIDELITY_PLAN.md
+++ b/docs/OPENWORLDS_FIDELITY_PLAN.md
@@ -1,0 +1,122 @@
+# OpenWorlds Fidelity Rollout Plan
+
+This document supersedes the SwiftUI repaint direction explored in PR #123.
+OpenWorlds should be integrated as an exact web surface first, then wired to
+ClawDnD read models screen by screen.
+
+## Decision
+
+The OpenWorlds export is the visual contract. The macOS app should supervise
+local services and host the product surface in `WKWebView`; it should not
+recreate the OpenWorlds UI in SwiftUI unless a future native component can meet
+screenshot-level parity.
+
+Primary visual/reference source files:
+
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/Open Worlds.html`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/styles.css`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/app.jsx`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/chrome.jsx`
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/screen-*.jsx`
+
+Prototype/demo data requiring rewrite or explicit non-canonical labeling:
+
+- `/Volumes/LEXAR/Codex/openworlds-design-2026-05-25/openworlds/data.js`
+
+## Architecture
+
+- SwiftUI owns native process supervision, provider launch/status, settings,
+  logs, dependency checks, diagnostics, and packaging.
+- `viewer/server.py` serves the exact OpenWorlds web surface under
+  `/openworlds/` so the UI and viewer APIs are same-origin.
+- `/dashboard` remains a fallback/debug route until the OpenWorlds surface is
+  stable.
+- The browser may read viewer APIs and post player intent to `/move`.
+- The browser must never write `snapshot.json`, `play-state`, `qa/state`,
+  inventory, quests, XP, world clocks, companion state, or private notes.
+
+## Rollout
+
+1. Fidelity and asset contract.
+   - Add this plan and the asset policy.
+   - Keep PR #123 draft and mark it superseded.
+   - Confirm no reference images or private content are staged.
+
+2. Viewer-hosted exact OpenWorlds surface.
+   - Create a cleaned, audited `viewer/openworlds/` bundle from the primary
+     export.
+   - Normalize `Open Worlds.html` to `index.html`.
+   - Use locally vendored React/ReactDOM/Babel for the first exact-fidelity
+     sprint, with notices.
+   - Remove live CDN calls and Open Design host chrome.
+   - Rewrite or label prototype `data.js` content as non-canonical demo data.
+   - The PR body must list copied source files, dependency license notices,
+     removed CDN calls, removed sandbox/tweak code, and any rewritten prototype
+     copy or data.
+   - Serve `/openworlds/`, `/openworlds/<asset>`, and
+     `/openworlds/config.json`.
+
+3. Native app opens OpenWorlds.
+   - Have the Play surface start the viewer and load `/openworlds/`.
+   - Keep SwiftUI diagnostics and settings available.
+   - Abandon the SwiftUI OpenWorlds repaint from PR #123.
+
+4. Chronicles launcher data binding.
+   - Replace prototype campaign rows with read-only campaign summaries.
+   - Show live/stale status, world, day, location, and provider/run metadata
+     where available.
+
+5. Session/Table read model.
+   - Add filtered `/session-surface`.
+   - Feed the Table screen with scene, party, conditions, quests, recent events,
+     and available actions.
+   - Exclude hidden fields such as `notes`, `dm_notes`, sealed companion agenda,
+     and private lore.
+
+6. Gameplay surfaces.
+   - Combat board, atlas, relations/camp, inventory/merchant/forge, acts, and
+     bestiary/codex proceed as read-model surfaces before adding backed player
+     actions.
+
+## PR #123 Disposition
+
+PR #123 must remain unmerged. After this plan lands, add a final PR comment on
+#123 linking to the fidelity contract PR and close #123 as superseded once the
+first viewer-hosted OpenWorlds surface PR is open.
+
+If the viewer-hosted web-surface path fails, reopen the architecture decision in
+a new issue or PR. Do not revive the SwiftUI repaint unless it includes
+screenshot-level parity evidence against the exported OpenWorlds reference.
+
+## Visual Gates
+
+Before a visual PR is marked ready:
+
+- Capture exported reference and ClawDnD candidate screenshots at `1366x768`,
+  `1440x900`, and `1920x1080`.
+- Add `1024x768` and mobile-like widths when the PR claims responsive web
+  parity; otherwise record those viewports as deferred.
+- Confirm the candidate preserves the OpenWorlds window frame, nav rail,
+  parchment surface, typography, spacing, hover/active affordances, and screen
+  routing.
+- Reject obvious SwiftUI repaint drift.
+
+## Validation
+
+Focused local checks:
+
+```bash
+cd <repo-root>
+pwd
+python3 -m py_compile viewer/server.py
+python3 -m unittest discover -s viewer/tests -q
+swift build --package-path macos/ClawDnDApp
+./script/build_and_run.sh --verify
+python3 scripts/license_check.py
+git diff --check
+```
+
+Use GitHub CI for broad engine, rules, voice, and license validation. Docs-only
+PRs are expected to run the normal CI and license-check jobs; the macOS Swift
+workflow only runs for macOS, script, or workflow changes unless manually
+dispatched. Use CodeRabbit and read-only adversarial agents before merge.


### PR DESCRIPTION
## Summary

Adds the fidelity-first contract for integrating the OpenWorlds design into ClawDnD after PR #123 proved that a hand SwiftUI repaint is the wrong path.

This PR is intentionally docs-only. It defines:

- the primary OpenWorlds visual/reference source files
- which screenshots/uploads are reference-only and must not be committed
- which prototype files require rewrite or removal before production use
- the viewer-hosted `/openworlds/` architecture and engine-state boundary
- the PR sequence for exact surface, native host, launcher binding, and later gameplay surfaces
- visual validation gates and docs-only CI expectations

Refs #113.
Refs #122.
Supersedes the implementation direction in #123, but does not close it yet. #123 should remain draft/unmerged until the viewer-hosted OpenWorlds replacement is open.

## Why

The OpenWorlds export depends on the actual web implementation for its fidelity: CSS texture layers, parchment/walnut/brass treatment, typography, SVG ornaments, dense layout, and interaction states. Recreating that by hand in SwiftUI lost the design. This contract locks the safer direction before code/assets move into the repo.

## Boundaries

- No engine, rules, voice, content, or QA narrative changes.
- No OpenWorlds screenshots, uploaded reference images, private state, transcripts, or zip bundles committed.
- Browser surfaces remain read-only except for the existing `/move` player-intent path.
- Live CDN dependencies are banned for packaged app work; local vendored runtime is allowed only for the first exact-fidelity sprint with notices.

## Validation

Local validation run from `/Volumes/LEXAR/repos/ClawDnD-openworlds-contract`:

```bash
git diff --check
python3 -m py_compile viewer/server.py
python3 -m unittest discover -s viewer/tests -q
python3 scripts/license_check.py
```

Results:

- `viewer/server.py` py_compile passed
- viewer tests passed: 14 tests
- license check passed
- diff check passed

Adversarial review:

- Architecture/state-authority reviewer approved after confirming engine sole-writer and `/move` boundaries.
- Asset/license reviewer found overbroad copy language; fixed by requiring audited cleaned bundles, provenance, notices, and explicit prototype data handling.
- Test/CI reviewer found docs-only Swift CI overclaim and imprecise #123 disposition; fixed in the fidelity plan.

## Next PR

PR B should create a cleaned, audited `viewer/openworlds/` bundle served by `viewer/server.py` under `/openworlds/`, with local runtime dependencies and no reference images.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a design asset policy covering provenance, allowed/blocked asset types, and guidelines for prototype vs production usage.
  * Added an implementation fidelity plan describing the staged rollout, responsibilities between native and web surfaces, constraints on browser-side data mutations, and required validation/checklist steps before release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->