### PR TITLE
feat(macos): open OpenWorlds play surface

### DIFF
--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Models/LocalEndpoint.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Models/LocalEndpoint.swift
@@ -22,6 +22,10 @@ struct LocalEndpoint: Identifiable, Equatable {
         url.appendingPathComponent("dashboard")
     }
 
+    var openWorldsURL: URL {
+        url.appendingPathComponent("openworlds")
+    }
+
     var monitorURL: URL {
         url.appendingPathComponent("monitor")
     }

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
@@ -70,7 +70,6 @@ final class AppProcessService: ObservableObject {
             try throwAndRecord("Could not find a free viewer port near \(preferredPort).")
         }
         let baseURL = URL(string: "http://127.0.0.1:\(port)")!
-        let dashboard = baseURL.appendingPathComponent("dashboard")
         var env: [String: String] = [:]
         if !stateDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             env["CLAWDND_STATE_DIR"] = (stateDir as NSString).expandingTildeInPath
@@ -86,14 +85,15 @@ final class AppProcessService: ObservableObject {
         )
         viewerProcess = managed
         activeCampaignID = campaignID
-        viewerEndpoint = LocalEndpoint(
+        let endpoint = LocalEndpoint(
             name: "Viewer",
             url: baseURL,
             healthPath: "/state",
             status: .running
         )
-        append("Started viewer pid \(managed.pid) on \(dashboard.absoluteString)", stream: .supervisor)
-        return dashboard
+        viewerEndpoint = endpoint
+        append("Started viewer pid \(managed.pid) on \(endpoint.openWorldsURL.absoluteString)", stream: .supervisor)
+        return endpoint.openWorldsURL
     }
 
     func stopViewer() {
@@ -177,15 +177,15 @@ final class AppProcessService: ObservableObject {
         providerProcess = managed
         runningProvider = kind
         let baseURL = URL(string: "http://127.0.0.1:\(port)")!
-        let dashboard = baseURL.appendingPathComponent("dashboard")
-        viewerEndpoint = LocalEndpoint(
+        let endpoint = LocalEndpoint(
             name: "Provider viewer",
             url: baseURL,
             healthPath: "/state",
             status: .starting
         )
+        viewerEndpoint = endpoint
         append("\(request.message) pid \(managed.pid)", stream: .provider)
-        return dashboard
+        return endpoint.openWorldsURL
     }
 
     func stopProvider() {

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/CampaignsView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/CampaignsView.swift
@@ -39,7 +39,7 @@ struct CampaignsView: View {
                             CampaignRow(campaign: campaign)
                                 .tag(campaign.id)
                                 .contextMenu {
-                                    Button("Open in Dashboard") {
+                                    Button("Open in Play Surface") {
                                         open(campaign)
                                     }
                                 }

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/MonitorView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/MonitorView.swift
@@ -50,13 +50,13 @@ struct MonitorView: View {
     private func openMonitor() {
         do {
             webViewErrorMessage = nil
-            let dashboard = try processService.startViewer(
+            let surface = try processService.startViewer(
                 repoPath: repoPath,
                 preferredPort: preferredPort,
                 stateDir: stateDir
             )
             webURL = processService.viewerEndpoint?.monitorURL
-                ?? dashboard.deletingLastPathComponent().appendingPathComponent("monitor")
+                ?? surface.deletingLastPathComponent().appendingPathComponent("monitor")
         } catch {
             alertMessage = error.localizedDescription
         }

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/PlayView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/PlayView.swift
@@ -64,7 +64,7 @@ struct PlayView: View {
                 Button {
                     startViewer()
                 } label: {
-                    Label("Open Dashboard", systemImage: "rectangle.on.rectangle")
+                    Label("Open Play Surface", systemImage: "rectangle.on.rectangle")
                 }
                 Button {
                     startProvider()

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/WebView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/WebView.swift
@@ -48,7 +48,7 @@ struct WebView: NSViewRepresentable {
         private func report(_ error: Error) {
             let nsError = error as NSError
             guard nsError.domain != NSURLErrorDomain || nsError.code != NSURLErrorCancelled else { return }
-            navigationError.wrappedValue = "Dashboard failed to load: \(error.localizedDescription)"
+            navigationError.wrappedValue = "Surface failed to load: \(error.localizedDescription)"
         }
     }
 }
@@ -62,7 +62,7 @@ struct WebViewErrorView: View {
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 42, weight: .regular))
                 .foregroundStyle(.orange)
-            Text("Dashboard Unavailable")
+            Text("Surface Unavailable")
                 .font(.title3.weight(.semibold))
             Text(message)
                 .font(.callout)


### PR DESCRIPTION
## Summary

This is the stacked PR C from the OpenWorlds fidelity rollout. It changes the native macOS shell to open the viewer-hosted OpenWorlds play surface in `WKWebView` instead of defaulting Play/Campaign launches to the legacy dashboard route.

- Adds `LocalEndpoint.openWorldsURL`.
- Makes `AppProcessService.startViewer(...)` return `/openworlds`.
- Makes `AppProcessService.startProviderSession(...)` return `/openworlds`.
- Keeps `LocalEndpoint.dashboardURL` available as the fallback/debug route.
- Keeps Monitor routed to `/monitor`.
- Renames visible generic dashboard error/copy in the app to “surface” so the UI is not tied to the old route.

Stacked on #125 because `/openworlds/` is introduced there. Refs #82, #113, #114.

## Architecture Boundary

SwiftUI remains the native supervisor/control center:

- starts and stops the local viewer/provider processes;
- chooses ports and records endpoint status;
- hosts the existing browser surface in `WKWebView`;
- exposes logs/errors/diagnostics.

The macOS app does not become a game-state writer. Game-state authority remains in the engine and the browser write lane remains the existing `/move` player-intent endpoint. This PR only changes which same-origin viewer route the app loads after launch.

## Route Behavior

- Play -> `startViewer(...)` -> `http://127.0.0.1:<port>/openworlds`
- Start Game/provider -> `startProviderSession(...)` -> `http://127.0.0.1:<port>/openworlds`
- Campaign Browser open -> `startViewer(... campaignID:)` -> `http://127.0.0.1:<port>/openworlds`
- Monitor -> `viewerEndpoint.monitorURL` -> `http://127.0.0.1:<port>/monitor`
- Debug/fallback dashboard remains available through `LocalEndpoint.dashboardURL`.

## Validation

Local validation from `/Volumes/LEXAR/repos/ClawDnD-openworlds-webview-route`:

- `swift build --package-path macos/ClawDnDApp`
- `./script/build_and_run.sh --verify`
- `python3 -m py_compile viewer/server.py`
- `python3 -m unittest viewer.tests.test_openworlds_static -q`
- `python3 scripts/license_check.py`
- `git diff --check`

The verify command launched `dist/ClawDnD.app`; I stopped the launched app process afterward and confirmed no `dist/` or build artifacts are staged.

## Review Notes

This PR is intentionally narrow. It does not add new SwiftUI game screens, rewrite the OpenWorlds UI, change provider contracts, or touch engine/rules/voice/story/QA lanes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a dedicated "Open Worlds" surface URL for viewer/provider flows.

* **Style**
  * Rebranded UI terminology: "Dashboard" renamed to "Play Surface" (buttons, menus, views, and error headers) for consistent user-facing language.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->