### PR TITLE
feat(viewer): bind OpenWorlds campaigns to local state

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -18,6 +18,52 @@ function App() {
     document.documentElement.setAttribute("data-palette", t.palette || "warm");
   }, [t.palette]);
 
+  React.useEffect(() => {
+    let cancelled = false;
+
+    async function loadCampaignCatalog() {
+      try {
+        const response = await fetch("/openworlds/campaigns.json", { cache: "no-store" });
+        if (!response.ok) throw new Error(`campaign catalog ${response.status}`);
+        const payload = await response.json();
+        if (cancelled) return;
+
+        const nextCampaigns = Array.isArray(payload?.campaigns) ? payload.campaigns : [];
+        setState((s) => {
+          const activeStillExists = nextCampaigns.some((c) => c.id === s?.activeCampaign);
+          const preferred =
+            nextCampaigns.find((c) => c.current)?.id ||
+            nextCampaigns.find((c) => c.live)?.id ||
+            nextCampaigns[0]?.id ||
+            "";
+          return {
+            ...s,
+            campaigns: nextCampaigns,
+            activeCampaign: activeStillExists ? s.activeCampaign : preferred,
+            campaignCatalog: {
+              loaded: true,
+              total: payload?.total ?? nextCampaigns.length,
+              source: "viewer",
+            },
+          };
+        });
+      } catch (error) {
+        if (cancelled) return;
+        setState((s) => ({
+          ...s,
+          campaignCatalog: {
+            loaded: false,
+            source: "demo-fallback",
+            error: error?.message || "campaign catalog unavailable",
+          },
+        }));
+      }
+    }
+
+    loadCampaignCatalog();
+    return () => { cancelled = true; };
+  }, []);
+
   // Keyboard shortcuts
   React.useEffect(() => {
     const onKey = (e) => {

--- a/viewer/openworlds/screen-launcher.jsx
+++ b/viewer/openworlds/screen-launcher.jsx
@@ -5,10 +5,24 @@ function ScreenLauncher({ onNavigate, state, setState }) {
   const [selected, setSelected] = React.useState(state?.activeCampaign || campaigns[0]?.id || "");
   const [showNew, setShowNew] = React.useState(false);
 
+  React.useEffect(() => {
+    if (campaigns.some((c) => c.id === selected)) return;
+    setSelected(state?.activeCampaign || campaigns[0]?.id || "");
+  }, [campaigns, selected, state?.activeCampaign]);
+
   const onResume = () => {
     const nextCampaign = selected || campaigns[0]?.id;
     if (!nextCampaign) return;
+    const campaign = campaigns.find((c) => c.id === nextCampaign);
     setState((s) => ({ ...s, activeCampaign: nextCampaign }));
+    if (campaign?.resumeUrl) {
+      window.location.assign(campaign.resumeUrl);
+      return;
+    }
+    if (campaign?.monitorUrl) {
+      window.location.assign(campaign.monitorUrl);
+      return;
+    }
     onNavigate("table");
   };
 
@@ -105,12 +119,15 @@ function ScreenLauncher({ onNavigate, state, setState }) {
                 </div>
               );
             }
-            const party = Array.isArray(c.party) ? c.party : [];
+            const party = normalizeCampaignParty(c.party);
+            const dayBadge = campaignDayBadge(c);
+            const chapter = campaignChapter(c);
+            const region = campaignRegion(c);
             return (
               <div>
                 {/* Top vignette with overlaid label */}
                 <div style={{ position: "relative" }}>
-                  <Placeholder label={`vignette · ${c.region.toLowerCase()}`} h={140} style={{ width: "100%", boxShadow: "none" }} />
+                  <Placeholder label={`vignette · ${region.toLowerCase()}`} h={140} style={{ width: "100%", boxShadow: "none" }} />
                   <div style={{
                     position: "absolute", inset: 0,
                     background: "linear-gradient(180deg, transparent 40%, rgba(40, 25, 10, 0.85) 100%)",
@@ -121,18 +138,18 @@ function ScreenLauncher({ onNavigate, state, setState }) {
                   }}>
                     <div>
                       <div className="eyebrow" style={{ color: "var(--gold-glow)", textShadow: "0 1px 2px rgba(0,0,0,0.6)" }}>
-                        {c.system} · Chapter {c.chapter}
+                        {c.system || "D&D 5e"} · Chapter {chapter}
                       </div>
                       <div style={{ fontFamily: "var(--f-display)", fontSize: 22, color: "var(--p-100)", letterSpacing: "0.04em", marginTop: 2, textShadow: "0 1px 2px rgba(0,0,0,0.7)" }}>
                         {c.title}
                       </div>
                     </div>
-                    <Pill tone="royal">{c.day.split(" · ")[0] || c.day}</Pill>
+                    <Pill tone={c.live ? "emerald" : "royal"}>{c.live ? "Live" : dayBadge}</Pill>
                   </div>
                 </div>
 
                 <div style={{ padding: "20px 28px 28px" }}>
-                  <div className="hand" style={{ fontSize: 15, color: "var(--ink-700)" }}>{c.subtitle}</div>
+                  <div className="hand" style={{ fontSize: 15, color: "var(--ink-700)" }}>{c.subtitle || region}</div>
 
                   {/* Stat strip with vertical brass dividers */}
                   <div style={{
@@ -147,7 +164,7 @@ function ScreenLauncher({ onNavigate, state, setState }) {
                       { label: "Last sat", value: c.lastPlayed },
                       { label: "Sessions", value: c.sessions },
                       { label: "Heroes", value: party.length },
-                      { label: "Region", value: c.region },
+                      { label: "Region", value: region },
                     ].map((s, i) => (
                       <div key={s.label} style={{
                         padding: "10px 12px",
@@ -172,6 +189,11 @@ function ScreenLauncher({ onNavigate, state, setState }) {
                         <div className="hand" style={{ fontSize: 12, marginTop: 4, color: "var(--ink-700)" }}>{p.name}</div>
                       </div>
                     ))}
+                    {party.length === 0 && (
+                      <div className="hand muted" style={{ fontSize: 14, padding: "18px 8px", textAlign: "center" }}>
+                        No party recorded yet.
+                      </div>
+                    )}
                   </div>
 
                   {/* Recap with side sketch */}
@@ -181,7 +203,7 @@ function ScreenLauncher({ onNavigate, state, setState }) {
                       <Placeholder label="sketch · last scene" w={100} h={120} framed />
                     </div>
                     <p className="body dropcap" style={{ marginTop: 0, fontSize: 15 }}>
-                      {c.recap}
+                      {c.recap || "This chronicle is ready to continue."}
                     </p>
                   </div>
 
@@ -192,7 +214,7 @@ function ScreenLauncher({ onNavigate, state, setState }) {
                     display: "flex", gap: 8,
                   }}>
                     <BrassButton onClick={onResume} size="lg" style={{ flex: 1 }}>
-                      Resume Chronicle
+                      {c.canResume ? "Resume Chronicle" : "View Chronicle"}
                     </BrassButton>
                     <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("character")}>Roster</BrassButton>
                     <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("journal")}>Journal</BrassButton>
@@ -213,6 +235,34 @@ function ScreenLauncher({ onNavigate, state, setState }) {
   );
 }
 
+function normalizeCampaignParty(party) {
+  if (!Array.isArray(party)) return [];
+  return party.map((p) => {
+    if (typeof p === "string") return { name: p, short: "portrait" };
+    return {
+      name: p?.name || "Unknown",
+      short: p?.short || "portrait",
+      kind: p?.kind || "",
+      hp: p?.hp || "",
+    };
+  });
+}
+
+function campaignRegion(c) {
+  return c?.region || c?.location || c?.world || "Unknown";
+}
+
+function campaignDayBadge(c) {
+  const day = typeof c?.day === "string" ? c.day : "";
+  return day.split(" · ")[0] || day || "Stale";
+}
+
+function campaignChapter(c) {
+  const chapter = c?.chapter;
+  if (chapter === undefined || chapter === null || chapter === "") return "I";
+  return String(chapter);
+}
+
 function Stat({ label, value }) {
   return (
     <div style={{
@@ -227,6 +277,7 @@ function Stat({ label, value }) {
 }
 
 function CampaignRow({ c, selected, onSelect }) {
+  const status = c?.live ? "Live" : (c?.sourceLabel || "Saved");
   return (
     <button
       onClick={onSelect}
@@ -252,12 +303,12 @@ function CampaignRow({ c, selected, onSelect }) {
         <div style={{ fontFamily: "var(--f-display)", fontSize: 17, letterSpacing: "0.08em", color: "var(--ink-900)" }}>
           {c.title}
         </div>
-        <div className="hand" style={{ fontSize: 14, color: "var(--ink-600)" }}>{c.subtitle}</div>
+        <div className="hand" style={{ fontSize: 14, color: "var(--ink-600)" }}>{c.subtitle || campaignRegion(c)}</div>
       </div>
       <div style={{ textAlign: "right" }}>
-        <div className="eyebrow">{c.lastPlayed}</div>
+        <div className="eyebrow">{status} · {c.lastPlayed || "unknown"}</div>
         <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--ink-700)", marginTop: 4 }}>
-          Ch. {c.chapter}
+          Ch. {campaignChapter(c)}
         </div>
       </div>
     </button>

--- a/viewer/openworlds/screen-launcher.jsx
+++ b/viewer/openworlds/screen-launcher.jsx
@@ -7,11 +7,14 @@ function ScreenLauncher({ onNavigate, state, setState }) {
 
   React.useEffect(() => {
     if (campaigns.some((c) => c.id === selected)) return;
-    setSelected(state?.activeCampaign || campaigns[0]?.id || "");
+    const fallback = campaigns.some((c) => c.id === state?.activeCampaign)
+      ? state.activeCampaign
+      : campaigns[0]?.id || "";
+    setSelected(fallback);
   }, [campaigns, selected, state?.activeCampaign]);
 
   const onResume = () => {
-    const nextCampaign = selected || campaigns[0]?.id;
+    const nextCampaign = campaigns.some((c) => c.id === selected) ? selected : campaigns[0]?.id;
     if (!nextCampaign) return;
     const campaign = campaigns.find((c) => c.id === nextCampaign);
     setState((s) => ({ ...s, activeCampaign: nextCampaign }));
@@ -249,7 +252,10 @@ function normalizeCampaignParty(party) {
 }
 
 function campaignRegion(c) {
-  return c?.region || c?.location || c?.world || "Unknown";
+  const value = c?.region ?? c?.location ?? c?.world;
+  if (value === undefined || value === null) return "Unknown";
+  const trimmed = String(value).trim();
+  return trimmed || "Unknown";
 }
 
 function campaignDayBadge(c) {

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -44,7 +44,7 @@ import types
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Optional
-from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import parse_qs, quote, unquote, urlparse
 
 _HERE = Path(__file__).resolve().parent
 # servers/voice lives two levels up from viewer/ (repo root / servers / voice).
@@ -528,6 +528,268 @@ def _list_campaigns() -> list[dict]:
         ))
     out.sort(key=lambda c: c["last_played"], reverse=True)
     return out
+
+
+def _resolved(path: Path) -> str:
+    try:
+        return str(path.resolve())
+    except OSError:
+        return str(path)
+
+
+def _session_count(campaign_dir: Path) -> int:
+    sessions = campaign_dir / "sessions"
+    if not sessions.is_dir():
+        return 0
+    return sum(1 for p in sessions.glob("*.jsonl") if p.is_file())
+
+
+def _catalog_run_id(state_root: Path) -> str:
+    """Stable display id for a state root.
+
+    Product runs live under play-state/<run-id> and QA under qa/state/<run-id>.
+    A bare CLAWDND_STATE_DIR (for example ~/.clawdnd/state, or a temp dir in
+    tests) is the viewer's active state root rather than a named run, so expose it
+    as "state" instead of leaking a random local folder name into the UI.
+    """
+    if state_root.parent.name in ("play-state", "state"):
+        return state_root.name
+    return "state"
+
+
+def _campaign_catalog_roots() -> list[dict]:
+    """Read-only roots for the OpenWorlds campaign shelf.
+
+    The native app and the exact OpenWorlds surface need the same product answer:
+    "what local play or QA runs exist?"  We scan the viewer's active state dir,
+    repo-local play-state/*, and repo-local qa/state/* without importing the
+    engine and without opening any write path.
+    """
+    roots: list[dict] = []
+    seen: set[str] = set()
+
+    def add(source: str, run_id: str, state_root: Path, campaigns_dir: Path, *, current_state: bool = False) -> None:
+        key = _resolved(campaigns_dir)
+        if key in seen:
+            return
+        seen.add(key)
+        roots.append({
+            "source": source,
+            "run_id": run_id,
+            "state_root": state_root,
+            "campaigns_dir": campaigns_dir,
+            "current_state": current_state,
+        })
+
+    state_root = _state_dir()
+    add("play", _catalog_run_id(state_root), state_root, state_root / "campaigns", current_state=True)
+
+    play_state = _HERE.parent / "play-state"
+    if play_state.is_dir():
+        for run in sorted(play_state.iterdir()):
+            cdir = run / "campaigns"
+            if cdir.is_dir():
+                add("play", run.name, run, cdir)
+
+    qa_state = _HERE.parent / "qa" / "state"
+    if qa_state.is_dir():
+        for run in sorted(qa_state.iterdir()):
+            cdir = run / "campaigns"
+            if cdir.is_dir():
+                add("qa", run.name, run, cdir)
+    return roots
+
+
+def _text(value: object, default: str = "") -> str:
+    if value is None:
+        return default
+    s = str(value).strip()
+    return s if s else default
+
+
+def _openworlds_day_label(snapshot: dict) -> str:
+    day = snapshot.get("day")
+    time_of_day = _text(snapshot.get("time_of_day"))
+    if isinstance(day, int):
+        return f"Day {day}" + (f" · {time_of_day}" if time_of_day else "")
+    return time_of_day or "Unknown time"
+
+
+def _party_cards(snapshot: dict) -> list[dict]:
+    chars = snapshot.get("characters")
+    party = snapshot.get("party")
+    if not isinstance(chars, dict) or not isinstance(party, list):
+        return []
+    out: list[dict] = []
+    for cid in party:
+        if not isinstance(cid, str):
+            continue
+        ch = chars.get(cid)
+        if not isinstance(ch, dict):
+            out.append({"id": cid, "name": cid, "short": "portrait"})
+            continue
+        card = {
+            "id": cid,
+            "name": _text(ch.get("name"), cid),
+            "short": "portrait",
+            "kind": _text(ch.get("kind")),
+        }
+        hp = ch.get("current_hp")
+        hp_max = ch.get("max_hp")
+        if isinstance(hp, int) and isinstance(hp_max, int):
+            card["hp"] = f"{hp}/{hp_max}"
+        if ch.get("dead"):
+            card["dead"] = True
+        out.append(card)
+    return out
+
+
+def _relative_time_label(ts: float, *, now: float) -> str:
+    if ts <= 0:
+        return "unknown"
+    delta = max(0, now - ts)
+    if delta < 90:
+        return "just now"
+    if delta < 3600:
+        minutes = max(1, int(delta // 60))
+        return f"{minutes} min ago"
+    if delta < 86400:
+        hours = max(1, int(delta // 3600))
+        return f"{hours} hr ago"
+    if delta < 86400 * 7:
+        days = max(1, int(delta // 86400))
+        return f"{days} day{'s' if days != 1 else ''} ago"
+    return time.strftime("%Y-%m-%d", time.localtime(ts))
+
+
+def _infer_catalog_provider(state_root: Path, source: str) -> str:
+    if source == "qa":
+        return "QA"
+    if (state_root / "codex-provider").is_dir():
+        return "Codex"
+    if any(state_root.glob("companion_*.mcp.json")):
+        return "Claude party"
+    if (state_root / "dm.mcp.json").is_file():
+        return "Claude"
+    return "Local"
+
+
+def build_openworlds_campaign_summary(
+    source: str,
+    run_id: str,
+    campaign_id: str,
+    snapshot: dict,
+    *,
+    campaign_dir: Path,
+    state_root: Path,
+    last_played: float,
+    current: bool,
+    can_resume: bool,
+    now: float,
+) -> dict:
+    """Browser-safe OpenWorlds launcher row for one campaign.
+
+    This deliberately projects only player-facing fields. It never includes local
+    absolute paths, scene `dm_notes`, lore recall input, sealed agendas, or raw
+    session transcripts; follow-on surfaces can add explicit read models when they
+    need more data.
+    """
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    live = (now - last_played) < 90
+    location = _display_location(snapshot)
+    world = _text(snapshot.get("world_id"), "unknown")
+    title = _text(snapshot.get("title"), campaign_id)
+    ruleset = _text(snapshot.get("ruleset"), "D&D 5e")
+    day = _openworlds_day_label(snapshot)
+    party = _party_cards(snapshot)
+    active_quests = _active_quest_count(snapshot)
+    source_label = "QA run" if source == "qa" else "Play save"
+    where = location or world
+    subtitle = f"{source_label} · {where}" if where else source_label
+    recap = _text(snapshot.get("summary"))
+    if not recap:
+        if active_quests:
+            recap = f"{active_quests} active quest{'s' if active_quests != 1 else ''} remain in motion."
+        elif location:
+            recap = f"The party is gathered near {location}."
+        else:
+            recap = "This chronicle is ready to continue."
+
+    resume_url = f"/dashboard?campaign={quote(campaign_id)}" if can_resume else ""
+    return {
+        "id": f"{source}:{run_id}:{campaign_id}",
+        "campaign_id": campaign_id,
+        "source": source,
+        "sourceLabel": "QA" if source == "qa" else "Play",
+        "runId": run_id,
+        "title": title,
+        "subtitle": subtitle,
+        "system": ruleset,
+        "chapter": str(snapshot.get("day") or "I"),
+        "lastPlayed": _relative_time_label(last_played, now=now),
+        "last_played": last_played,
+        "sessions": _session_count(campaign_dir),
+        "region": location or world,
+        "day": day,
+        "world": world,
+        "location": location,
+        "party": party,
+        "partyCount": len(party),
+        "activeQuestCount": active_quests,
+        "provider": _infer_catalog_provider(state_root, source),
+        "live": live,
+        "liveStatus": "live" if live else "stale",
+        "current": bool(current),
+        "canResume": bool(can_resume),
+        "resumeUrl": resume_url,
+        "dashboardUrl": resume_url,
+        "monitorUrl": "/monitor",
+        "recap": recap,
+    }
+
+
+def _openworlds_campaigns(attached_campaign: str = "") -> dict:
+    now = time.time()
+    out: list[dict] = []
+    current_campaign = attached_campaign
+    current_campaigns_dir = _resolved(_campaigns_dir())
+    for root in _campaign_catalog_roots():
+        cdir = root["campaigns_dir"]
+        if not isinstance(cdir, Path) or not cdir.is_dir():
+            continue
+        for snap in cdir.glob("*/snapshot.json"):
+            try:
+                data = json.loads(snap.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            if not isinstance(data, dict) or not data:
+                continue
+            campaign_id = snap.parent.name
+            root_is_current = bool(root["current_state"]) and _resolved(cdir) == current_campaigns_dir
+            try:
+                summary = build_openworlds_campaign_summary(
+                    str(root["source"]),
+                    str(root["run_id"]),
+                    campaign_id,
+                    data,
+                    campaign_dir=snap.parent,
+                    state_root=root["state_root"],
+                    last_played=_campaign_recency(snap),
+                    current=root_is_current and campaign_id == current_campaign,
+                    can_resume=root_is_current,
+                    now=now,
+                )
+            except (OSError, TypeError, ValueError):
+                continue
+            out.append(summary)
+    out.sort(key=lambda c: (not c.get("current"), not c.get("live"), c.get("source") != "play", -c.get("last_played", 0)))
+    return {
+        "campaigns": out[:80],
+        "total": len(out),
+        "now": now,
+        "state_authority": "engine",
+        "write_lane": "/move",
+    }
 
 
 def _monitor_roots() -> list[tuple[str, Path]]:
@@ -1420,18 +1682,20 @@ def _speak(text: str, voice_id: str = "narrator-dm") -> dict:
 def _openworlds_config() -> dict:
     """Browser-safe metadata for the OpenWorlds shell.
 
-    The UI bundle is currently a local-fidelity prototype backed by demo data;
-    later PRs bind it to read-only viewer APIs. This endpoint lets the macOS
-    app/browser confirm the route contract without reading files directly.
+    The UI bundle preserves the exported OpenWorlds surface, then binds the
+    launcher to read-only viewer APIs. The remaining game screens still keep the
+    prototype seed as a fallback until their own read models land.
     """
     return {
         "surface": "openworlds",
         "source": "OpenWorlds.zip",
-        "mode": "prototype-demo-data",
+        "mode": "viewer-read-model",
         "api_base": "",
+        "campaign_catalog": "/openworlds/campaigns.json",
         "state_authority": "engine",
         "write_lane": "/move",
-        "demo_data": True,
+        "demo_data": False,
+        "demo_data_fallback": True,
     }
 
 
@@ -1579,6 +1843,8 @@ class _Handler(BaseHTTPRequestHandler):
             self._send(200, html, "text/html; charset=utf-8")
         elif route == "/openworlds/config.json":
             self._json(_openworlds_config())
+        elif route == "/openworlds/campaigns.json":
+            self._json(_openworlds_campaigns(self.campaign_id))
         elif route == _OPENWORLDS_ROUTE or route.startswith(f"{_OPENWORLDS_ROUTE}/"):
             asset = _openworlds_asset(route)
             if asset is None:

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -741,6 +741,7 @@ def build_openworlds_campaign_summary(
         "liveStatus": "live" if live else "stale",
         "current": bool(current),
         "canResume": bool(can_resume),
+        "readOnly": not bool(can_resume),
         "resumeUrl": resume_url,
         "dashboardUrl": resume_url,
         "monitorUrl": "/monitor",
@@ -748,22 +749,88 @@ def build_openworlds_campaign_summary(
     }
 
 
-def _openworlds_campaigns(attached_campaign: str = "") -> dict:
-    now = time.time()
-    out: list[dict] = []
-    current_campaign = attached_campaign
+_openworlds_catalog_cache: tuple[object, list[dict]] | None = None
+
+
+def _openworlds_catalog_index(
+    roots: list[dict],
+    attached_campaign: str,
+) -> tuple[object, list[tuple[dict, Path, float]]]:
+    """Return a small stat-based signature plus snapshots to project.
+
+    The OpenWorlds launcher fetches once today, but this endpoint is a natural
+    future poll target. Match the monitor's cache pattern: stat snapshots and
+    session logs cheaply, then only re-read JSON when mtimes change.
+    """
     current_campaigns_dir = _resolved(_campaigns_dir())
-    for root in _campaign_catalog_roots():
+    sig_entries: list[tuple] = [("attached", attached_campaign), ("current", current_campaigns_dir)]
+    snapshots: list[tuple[dict, Path, float]] = []
+    for root in roots:
         cdir = root["campaigns_dir"]
         if not isinstance(cdir, Path) or not cdir.is_dir():
             continue
         for snap in cdir.glob("*/snapshot.json"):
+            try:
+                snap_mtime = snap.stat().st_mtime
+                recency = _campaign_recency(snap)
+            except OSError:
+                continue
+            sig_entries.append((
+                str(root["source"]),
+                str(root["run_id"]),
+                _resolved(cdir),
+                snap.parent.name,
+                snap_mtime,
+                recency,
+            ))
+            snapshots.append((root, snap, recency))
+    return tuple(sig_entries), snapshots
+
+
+def _refresh_openworlds_campaign_times(cards: list[dict], *, now: float) -> list[dict]:
+    refreshed: list[dict] = []
+    for card in cards:
+        c = dict(card)
+        last_played = c.get("last_played")
+        last_played = (
+            last_played
+            if isinstance(last_played, (int, float)) and not isinstance(last_played, bool)
+            else 0
+        )
+        live = (now - last_played) < 90
+        c["live"] = live
+        c["liveStatus"] = "live" if live else "stale"
+        c["lastPlayed"] = _relative_time_label(last_played, now=now)
+        refreshed.append(c)
+    refreshed.sort(
+        key=lambda c: (
+            not c.get("current"),
+            not c.get("live"),
+            c.get("source") != "play",
+            -c.get("last_played", 0),
+        )
+    )
+    return refreshed
+
+
+def _openworlds_campaigns(attached_campaign: str = "") -> dict:
+    global _openworlds_catalog_cache
+    now = time.time()
+    roots = _campaign_catalog_roots()
+    current_campaigns_dir = _resolved(_campaigns_dir())
+    signature, snapshots = _openworlds_catalog_index(roots, attached_campaign)
+    if _openworlds_catalog_cache and _openworlds_catalog_cache[0] == signature:
+        out = _refresh_openworlds_campaign_times(_openworlds_catalog_cache[1], now=now)
+    else:
+        built: list[dict] = []
+        for root, snap, recency in snapshots:
             try:
                 data = json.loads(snap.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError):
                 continue
             if not isinstance(data, dict) or not data:
                 continue
+            cdir = root["campaigns_dir"]
             campaign_id = snap.parent.name
             root_is_current = bool(root["current_state"]) and _resolved(cdir) == current_campaigns_dir
             try:
@@ -774,15 +841,16 @@ def _openworlds_campaigns(attached_campaign: str = "") -> dict:
                     data,
                     campaign_dir=snap.parent,
                     state_root=root["state_root"],
-                    last_played=_campaign_recency(snap),
-                    current=root_is_current and campaign_id == current_campaign,
+                    last_played=recency,
+                    current=root_is_current and campaign_id == attached_campaign,
                     can_resume=root_is_current,
                     now=now,
                 )
             except (OSError, TypeError, ValueError):
                 continue
-            out.append(summary)
-    out.sort(key=lambda c: (not c.get("current"), not c.get("live"), c.get("source") != "play", -c.get("last_played", 0)))
+            built.append(summary)
+        _openworlds_catalog_cache = (signature, built)
+        out = _refresh_openworlds_campaign_times(built, now=now)
     return {
         "campaigns": out[:80],
         "total": len(out),

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -149,6 +149,7 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertEqual(campaign["sessions"], 1)
         self.assertTrue(campaign["current"])
         self.assertTrue(campaign["canResume"])
+        self.assertFalse(campaign["readOnly"])
         self.assertEqual(campaign["resumeUrl"], "/dashboard?campaign=camp_live")
         self.assertEqual([p["name"] for p in campaign["party"]], ["Tav", "Jaheira"])
         self.assertEqual(campaign["recap"], "The party reached the inn and caught its breath.")
@@ -156,6 +157,7 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertNotIn("private note", encoded)
         self.assertNotIn("hidden agenda", encoded)
         self.assertNotIn("private canon", encoded)
+        self.assert_no_private_keys(json.loads(encoded))
 
     def test_openworlds_campaigns_includes_repo_play_state_and_qa_runs_read_only(self):
         repo_root = self._tmp / "repo"
@@ -196,6 +198,8 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn("qa:wave3-red:camp_qa", by_id)
         self.assertEqual(by_id["play:play-20260525:camp_play"]["provider"], "Local")
         self.assertEqual(by_id["qa:wave3-red:camp_qa"]["provider"], "QA")
+        self.assertTrue(by_id["play:play-20260525:camp_play"]["readOnly"])
+        self.assertTrue(by_id["qa:wave3-red:camp_qa"]["readOnly"])
         self.assertFalse(by_id["play:play-20260525:camp_play"]["canResume"])
         self.assertFalse(by_id["qa:wave3-red:camp_qa"]["canResume"])
         self.assertEqual(by_id["qa:wave3-red:camp_qa"]["monitorUrl"], "/monitor")
@@ -203,6 +207,16 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
     def _write_snapshot(self, campaign_dir: Path, payload: dict) -> None:
         campaign_dir.mkdir(parents=True)
         (campaign_dir / "snapshot.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    def assert_no_private_keys(self, value) -> None:
+        private_keys = {"notes", "scenes", "lore", "dm_notes", "sealed_agenda", "agenda"}
+        if isinstance(value, dict):
+            for key, child in value.items():
+                self.assertNotIn(key, private_keys)
+                self.assert_no_private_keys(child)
+        elif isinstance(value, list):
+            for child in value:
+                self.assert_no_private_keys(child)
 
 
 if __name__ == "__main__":

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -25,6 +25,7 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
     def setUp(self):
         self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
         self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        self._old_here = server._HERE
         os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
         _QuietHandler.campaign_id = ""
         _QuietHandler.transcript_path = ""
@@ -43,6 +44,7 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
             os.environ.pop("CLAWDND_STATE_DIR", None)
         else:
             os.environ["CLAWDND_STATE_DIR"] = self._old_state
+        server._HERE = self._old_here
 
     def _get(self, path: str) -> tuple[int, str, bytes]:
         conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
@@ -78,7 +80,9 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertEqual(config["surface"], "openworlds")
         self.assertEqual(config["state_authority"], "engine")
         self.assertEqual(config["write_lane"], "/move")
-        self.assertTrue(config["demo_data"])
+        self.assertEqual(config["campaign_catalog"], "/openworlds/campaigns.json")
+        self.assertFalse(config["demo_data"])
+        self.assertTrue(config["demo_data_fallback"])
 
     def test_openworlds_static_assets_are_same_origin_and_local(self):
         status, ctype, body = self._get("/openworlds/vendor/google-fonts.css")
@@ -93,6 +97,112 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertEqual(self._status("/openworlds/../server.py"), 404)
         self.assertEqual(self._status("/openworlds/%2e%2e/server.py"), 404)
         self.assertEqual(self._status("/openworlds/vendor/../../server.py"), 404)
+
+    def test_openworlds_campaigns_projects_current_state_without_private_fields(self):
+        campaign_dir = self._tmp / "campaigns" / "camp_live"
+        self._write_snapshot(
+            campaign_dir,
+            {
+                "id": "camp_live",
+                "title": "Road After Moonrise",
+                "ruleset": "SRD 5.2",
+                "world_id": "baldurs-gate",
+                "day": 12,
+                "time_of_day": "dusk",
+                "current_location_id": "last-light",
+                "summary": "The party reached the inn and caught its breath.",
+                "locations": {"last-light": {"name": "Last Light Inn"}},
+                "party": ["hero", "jaheira"],
+                "characters": {
+                    "hero": {"name": "Tav", "kind": "player", "current_hp": 22, "max_hp": 30},
+                    "jaheira": {"name": "Jaheira", "kind": "companion", "current_hp": 34, "max_hp": 34},
+                },
+                "quests": {"q1": {"status": "active"}},
+                "notes": "private note must not leave the snapshot",
+                "scenes": [{"dm_notes": "hidden agenda"}],
+                "lore": ["private canon recall input"],
+            },
+        )
+        (campaign_dir / "sessions").mkdir()
+        (campaign_dir / "sessions" / "sess_1.jsonl").write_text("{}", encoding="utf-8")
+        _QuietHandler.campaign_id = "camp_live"
+
+        status, ctype, body = self._get("/openworlds/campaigns.json")
+
+        self.assertEqual(status, 200)
+        self.assertIn("application/json", ctype)
+        catalog = json.loads(body.decode("utf-8"))
+        self.assertEqual(catalog["state_authority"], "engine")
+        self.assertEqual(catalog["write_lane"], "/move")
+        self.assertEqual(catalog["total"], 1)
+        campaign = catalog["campaigns"][0]
+        self.assertEqual(campaign["id"], "play:state:camp_live")
+        self.assertEqual(campaign["campaign_id"], "camp_live")
+        self.assertEqual(campaign["source"], "play")
+        self.assertEqual(campaign["runId"], "state")
+        self.assertEqual(campaign["title"], "Road After Moonrise")
+        self.assertEqual(campaign["world"], "baldurs-gate")
+        self.assertEqual(campaign["day"], "Day 12 · dusk")
+        self.assertEqual(campaign["location"], "Last Light Inn")
+        self.assertEqual(campaign["region"], "Last Light Inn")
+        self.assertEqual(campaign["system"], "SRD 5.2")
+        self.assertEqual(campaign["sessions"], 1)
+        self.assertTrue(campaign["current"])
+        self.assertTrue(campaign["canResume"])
+        self.assertEqual(campaign["resumeUrl"], "/dashboard?campaign=camp_live")
+        self.assertEqual([p["name"] for p in campaign["party"]], ["Tav", "Jaheira"])
+        self.assertEqual(campaign["recap"], "The party reached the inn and caught its breath.")
+        encoded = json.dumps(campaign)
+        self.assertNotIn("private note", encoded)
+        self.assertNotIn("hidden agenda", encoded)
+        self.assertNotIn("private canon", encoded)
+
+    def test_openworlds_campaigns_includes_repo_play_state_and_qa_runs_read_only(self):
+        repo_root = self._tmp / "repo"
+        (repo_root / "viewer").mkdir(parents=True)
+        server._HERE = repo_root / "viewer"
+        play_campaign = repo_root / "play-state" / "play-20260525" / "campaigns" / "camp_play"
+        qa_campaign = repo_root / "qa" / "state" / "wave3-red" / "campaigns" / "camp_qa"
+        self._write_snapshot(
+            play_campaign,
+            {
+                "id": "camp_play",
+                "title": "Owner Save",
+                "world_id": "baldurs-gate",
+                "current_location_id": "baldurs-gate",
+                "locations": {"baldurs-gate": {"name": "Baldur's Gate"}},
+                "party": [],
+                "characters": {},
+            },
+        )
+        self._write_snapshot(
+            qa_campaign,
+            {
+                "id": "camp_qa",
+                "title": "QA Save",
+                "world_id": "baldurs-gate",
+                "day": 3,
+                "party": [],
+                "characters": {},
+            },
+        )
+
+        status, _ctype, body = self._get("/openworlds/campaigns.json")
+
+        self.assertEqual(status, 200)
+        campaigns = json.loads(body.decode("utf-8"))["campaigns"]
+        by_id = {c["id"]: c for c in campaigns}
+        self.assertIn("play:play-20260525:camp_play", by_id)
+        self.assertIn("qa:wave3-red:camp_qa", by_id)
+        self.assertEqual(by_id["play:play-20260525:camp_play"]["provider"], "Local")
+        self.assertEqual(by_id["qa:wave3-red:camp_qa"]["provider"], "QA")
+        self.assertFalse(by_id["play:play-20260525:camp_play"]["canResume"])
+        self.assertFalse(by_id["qa:wave3-red:camp_qa"]["canResume"])
+        self.assertEqual(by_id["qa:wave3-red:camp_qa"]["monitorUrl"], "/monitor")
+
+    def _write_snapshot(self, campaign_dir: Path, payload: dict) -> None:
+        campaign_dir.mkdir(parents=True)
+        (campaign_dir / "snapshot.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Binds the exact OpenWorlds Chronicles launcher to real local ClawDnD campaign state instead of prototype campaign rows.

- Adds a read-only `GET /openworlds/campaigns.json` viewer API.
- Scans the active viewer state dir, repo-local `play-state/*`, and repo-local `qa/state/*` campaign snapshots.
- Projects browser-safe campaign cards for the OpenWorlds launcher: source/run, world, day/time, location, party, provider, live/stale, current/resumable, quest count, sessions, and safe recap.
- Updates the OpenWorlds app shell to fetch the catalog on load and replace demo rows when the API succeeds.
- Keeps prototype data as a fallback only if the catalog endpoint is unavailable.
- Keeps engine/viewer authority boundaries intact: the API reads snapshots and session mtimes only; it never imports engine writers or writes campaign state.

Refs #114.

## Architecture Notes

The new viewer catalog is deliberately downstream-only:

- `viewer/server.py`
  - `_campaign_catalog_roots()` discovers read-only roots from the active `CLAWDND_STATE_DIR`, `play-state/*`, and `qa/state/*`.
  - `build_openworlds_campaign_summary(...)` projects only player-facing fields and omits local absolute paths, `dm_notes`, lore recall input, sealed agenda text, raw transcripts, and other private state.
  - `_openworlds_campaigns(...)` returns the browser contract plus `state_authority: engine` and `write_lane: /move`.
  - `canResume` is true only when the campaign is in the viewer's active state root, because `/dashboard?campaign=...` cannot switch the server to a different state dir.
- `viewer/openworlds/app.jsx`
  - Fetches `/openworlds/campaigns.json` once on load.
  - Replaces demo campaigns with the viewer catalog when successful.
  - Preserves demo fallback only on endpoint failure.
- `viewer/openworlds/screen-launcher.jsx`
  - Handles real catalog fields defensively.
  - Opens the existing dashboard for resumable active-state campaigns.
  - Sends non-resumable historical/QA entries to the existing monitor instead of pretending the prototype table is live.

## State Authority / Safety

This PR does not change engine, rules, voice, provider, or macOS public APIs.

The browser still has no direct campaign write path. The only game-intent write lane remains `POST /move`, and this PR does not add new POST routes.

## Validation

Local validation from `/Volumes/LEXAR/repos/ClawDnD-openworlds-campaigns-binding`:

```bash
python3 -m py_compile viewer/server.py
python3 -m unittest discover -s viewer/tests -q
python3 scripts/license_check.py
git diff --check
```

Result: `20` viewer tests passed; license check passed.

Rendered smoke:

- Started `viewer/server.py` against a throwaway state dir under `/Volumes/LEXAR/Codex/clawdnd-openworlds-campaign-smoke.*`.
- Verified `/openworlds/campaigns.json` returned the real campaign row.
- Used headless Chrome via CDP against `http://127.0.0.1:8876/openworlds/`.
- Confirmed visible body text includes `Smoke at the Gate` and `Lower City`, excludes the prototype `The Long Road to Odrun`, and reports no runtime exceptions.

No Swift files changed, so `swift build --package-path macos/ClawDnDApp` was intentionally not rerun for this viewer-only PR.

## Rollback

Reverting this commit returns OpenWorlds to the exact prototype-data launcher while preserving the already-merged `/openworlds/` static route and macOS WebView route.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Campaign library loads on app startup and a new /openworlds/campaigns.json catalog endpoint lists available campaigns (including provider labels and read-only/monitor links).
  * Improved campaign details: party, chapter, region, day badge, recap fallbacks, and resume CTA with optional redirect.

* **Bug Fixes**
  * Safer state updates on unmount and selection fallback when campaigns change.

* **Tests**
  * Added catalog tests and helpers to ensure no private fields and repo/QA discovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/127?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->