### PR TITLE
feat(viewer): add OpenWorlds session surface

### DIFF
--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -1,42 +1,136 @@
 /* Screen: Campaign Table — live session: scene art + party + GM narration + actions */
 
 function ScreenTable({ onNavigate, state, setState }) {
-  const party = Array.isArray(state?.party) ? state.party : [];
-  const quests = Array.isArray(state?.quests) ? state.quests : [];
-  const stash = Array.isArray(state?.stash) ? state.stash : [];
-  const [log, setLog] = React.useState(Array.isArray(state?.tableLog) ? state.tableLog : []);
+  const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
+  const activeCampaign =
+    campaigns.find((c) => c.id === state?.activeCampaign) ||
+    campaigns[0] ||
+    {};
+  const campaignId = activeCampaign.campaign_id || state?.activeCampaign || activeCampaign.id || "";
+  const [surface, setSurface] = React.useState(null);
+  const [surfaceStatus, setSurfaceStatus] = React.useState("loading");
+  const demoLog = Array.isArray(state?.tableLog) ? state.tableLog : [];
+  const [log, setLog] = React.useState([]);
   const [input, setInput] = React.useState("");
-  const [activeHero, setActiveHero] = React.useState(() => party[0]?.id || "");
   const logRef = React.useRef(null);
+  const inputRef = React.useRef(null);
   const toast = window.useToast ? window.useToast() : (() => {});
+  const fallbackParty = Array.isArray(state?.party) ? state.party : [];
+  const party = Array.isArray(surface?.party) && surface.party.length ? surface.party : fallbackParty;
+  const quests = Array.isArray(surface?.activeQuests) ? surface.activeQuests : (Array.isArray(state?.quests) ? state.quests : []);
+  const stash = Array.isArray(surface?.quickInventory) ? surface.quickInventory : (Array.isArray(state?.stash) ? state.stash : []);
+  const conditions = Array.isArray(surface?.conditions) ? surface.conditions : [];
+  const recentEvents = Array.isArray(surface?.recentEvents) ? surface.recentEvents : [];
+  const actions = Array.isArray(surface?.availableActions) ? surface.availableActions : [];
+  const roundOrder = Array.isArray(surface?.roundOrder) ? surface.roundOrder : [];
+  const scene = surface?.scene || {};
+  const encounter = surface?.encounter || {};
+  const [activeHero, setActiveHero] = React.useState(() => party[0]?.id || "");
   const hero = party.find((p) => p.id === activeHero) || party[0] || { id: "", name: "Hero", short: "Hero", level: 1, class: "Adventurer", hp: 1, hpMax: 1 };
+  const canAct = Boolean(surface?.can_act);
+  const readOnlyReason = actions.find((a) => a.disabled_reason)?.disabled_reason || "read-only surface";
+  const visibleLog = surface ? [...recentEvents, ...log] : [...demoLog, ...log];
+  const actionById = (id) => actions.find((a) => a.id === id);
+
+  const loadSurface = React.useCallback(async (isCancelled = () => false) => {
+    const params = new URLSearchParams();
+    if (campaignId) params.set("campaign", campaignId);
+    if (activeCampaign.source) params.set("source", activeCampaign.source);
+    if (activeCampaign.runId) params.set("run", activeCampaign.runId);
+    const query = params.toString() ? `?${params.toString()}` : "";
+    try {
+      const response = await fetch(`/session-surface${query}`, { cache: "no-store" });
+      if (!response.ok) throw new Error(`session surface ${response.status}`);
+      const payload = await response.json();
+      if (isCancelled()) return;
+      setSurface(payload);
+      setSurfaceStatus("ready");
+    } catch (error) {
+      if (isCancelled()) return;
+      setSurfaceStatus(error?.message || "unavailable");
+    }
+  }, [campaignId, activeCampaign.source, activeCampaign.runId]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const guardedLoad = async () => {
+      if (cancelled) return;
+      await loadSurface(() => cancelled);
+    };
+    guardedLoad();
+    const timer = window.setInterval(guardedLoad, 5000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(timer);
+    };
+  }, [loadSurface]);
+
+  React.useEffect(() => {
+    if (!party.some((p) => p.id === activeHero)) {
+      setActiveHero(party[0]?.id || "");
+    }
+  }, [party, activeHero]);
 
   React.useEffect(() => {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
-  }, [log]);
+  }, [visibleLog]);
 
-  const sendAction = () => {
-    if (!input.trim()) return;
-    setLog((l) => [
-      ...l,
-      { kind: "action", who: hero.name, text: input },
-      { kind: "narration", text: synthNarration(input, hero) },
-    ]);
+  const postMove = async (move, label) => {
+    if (!move || !canAct) {
+      toast({ kind: "danger", title: "Action unavailable", body: readOnlyReason });
+      return;
+    }
+    const text = label || move.text || move.name || "declares an action";
+    try {
+      const response = await fetch("/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...move, campaign: surface?.campaign_id || campaignId }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.reason || `move ${response.status}`);
+      }
+      setLog((l) => [...l, { kind: "action", who: hero.name, text }]);
+      loadSurface();
+    } catch (error) {
+      toast({ kind: "danger", title: "Move not sent", body: error?.message || "The viewer could not reach /move." });
+    }
+  };
+
+  const sendAction = async () => {
+    const text = input.trim();
+    if (!text) return;
+    const action = actionById("do");
+    if (!action?.available) {
+      toast({ kind: "danger", title: "Declare is unavailable", body: action?.disabled_reason || readOnlyReason });
+      return;
+    }
+    await postMove({ kind: "do", text }, text);
     setInput("");
   };
 
-  const roll = (sides = 20) => {
-    const r = 1 + Math.floor(Math.random() * sides);
-    setLog((l) => [
-      ...l,
-      { kind: "roll", who: hero.name, sides, text: `rolls d${sides}: ${r}${r === sides ? " — natural!" : ""}` },
-    ]);
-    toast({
-      eyebrow: `d${sides}`,
-      title: hero.name + " rolls " + r,
-      body: r === sides ? "A natural — the chronicle leans forward." : r === 1 ? "A one. The chronicle leans the other way." : null,
-      kind: r === sides ? "level" : r === 1 ? "danger" : undefined,
-    });
+  const requestRoll = (sides = 20) => {
+    const action = actionById("check");
+    if (!action?.available) {
+      toast({ kind: "danger", title: `d${sides} unavailable`, body: action?.disabled_reason || readOnlyReason });
+      return;
+    }
+    postMove({ kind: "check", name: `d${sides}`, text: `roll d${sides}` }, `requests a d${sides} roll`);
+  };
+
+  const invokeAction = (action) => {
+    if (!action?.available) {
+      toast({ kind: "danger", title: action?.label || "Action unavailable", body: action?.disabled_reason || readOnlyReason });
+      return;
+    }
+    if (action.ui) {
+      inputRef.current?.focus();
+      return;
+    }
+    if (action.move) {
+      postMove(action.move, action.label);
+    }
   };
 
   return (
@@ -45,26 +139,26 @@ function ScreenTable({ onNavigate, state, setState }) {
       {/* LEFT — Party roster */}
       <div style={{ display: "flex", flexDirection: "column", gap: 10, minHeight: 0 }}>
         <Panel framed style={{ padding: 18, flex: "0 0 auto" }}>
-          <div className="eyebrow" style={{ color: "var(--crimson)" }}>Round IV · Initiative</div>
+          <div className="eyebrow" style={{ color: "var(--crimson)" }}>{encounter.active ? encounter.summary : "Session"}</div>
           <SectionTitle>The Party</SectionTitle>
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-            {party.map((p) => (
+            {party.length ? party.map((p) => (
               <PartyRow
                 key={p.id}
                 p={p}
                 active={activeHero === p.id}
                 onClick={() => setActiveHero(p.id)}
               />
-            ))}
+            )) : <div className="body-sm muted">No party members in the current read model.</div>}
           </div>
         </Panel>
 
         <Panel framed style={{ padding: 18, flex: "1 1 auto", minHeight: 0, overflow: "auto" }}>
           <SectionTitle>Conditions</SectionTitle>
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-            <ConditionRow icon="✦" name="Blessed" who="Cassian" detail="+1 attacks · 3 rounds" />
-            <ConditionRow icon="◆" name="Shaken" who="Mira" detail="-2 saves · until camp" tone="crimson" />
-            <ConditionRow icon="◈" name="Inspired" who="Vell" detail="re-roll one d20" tone="royal" />
+            {conditions.length ? conditions.map((c) => (
+              <ConditionRow key={c.id || `${c.name}:${c.who}`} icon={c.icon || "◆"} name={c.name} who={c.who} detail={c.detail} tone={c.tone} />
+            )) : <div className="body-sm muted">No active party conditions.</div>}
           </div>
         </Panel>
       </div>
@@ -74,7 +168,7 @@ function ScreenTable({ onNavigate, state, setState }) {
         {/* Scene plate */}
         <div style={{ position: "relative", flex: "0 0 auto" }}>
           <Placeholder
-            label="scene · isometric · Lanternrest courtyard · dusk · 7 figures"
+            label={`scene · ${scene.caption || surface?.location?.name || activeCampaign.title || "Open Worlds"}`}
             h={260}
             framed
             style={{ width: "100%" }}
@@ -87,9 +181,9 @@ function ScreenTable({ onNavigate, state, setState }) {
             pointerEvents: "none",
           }}>
             <div>
-              <Pill tone="royal" dot>Day 12 · Dusk</Pill>
+              <Pill tone="royal" dot>{surface?.dayLabel || activeCampaign.day || "Unknown time"}</Pill>
               <div className="hand" style={{ marginTop: 6, color: "var(--p-100)", fontSize: 16, textShadow: "0 1px 2px rgba(0,0,0,0.8)" }}>
-                The Lanternrest stands silent. A crow sits the gable, watching.
+                {scene.summary || activeCampaign.recap || "The table is waiting for a campaign snapshot."}
               </div>
             </div>
             <div style={{ display: "flex", gap: 6, pointerEvents: "auto" }}>
@@ -102,11 +196,11 @@ function ScreenTable({ onNavigate, state, setState }) {
 
         {/* Log */}
         <Panel framed style={{ flex: "1 1 auto", display: "flex", flexDirection: "column", minHeight: 0, padding: 22 }}>
-          <SectionTitle ordinal="·" right={<Pill>AI GM · Listening</Pill>}>The Tabletop Chronicle</SectionTitle>
+          <SectionTitle ordinal="·" right={<Pill>{canAct ? "AI GM · Listening" : surfaceStatus === "ready" ? "Read Only" : "Loading"}</Pill>}>The Tabletop Chronicle</SectionTitle>
           <div ref={logRef} style={{ flex: "1 1 auto", overflow: "auto", paddingRight: 12 }}>
-            {log.map((entry, i) => (
+            {visibleLog.length ? visibleLog.map((entry, i) => (
               <LogEntry key={i} entry={entry} />
-            ))}
+            )) : <div className="body-sm muted">No recent table events have been written yet.</div>}
           </div>
 
           {/* Action bar */}
@@ -117,20 +211,21 @@ function ScreenTable({ onNavigate, state, setState }) {
                 {hero.name}
               </strong>
               <div style={{ flex: 1 }} />
-              <button onClick={() => roll(20)} className="btn ghost sm">d20</button>
-              <button onClick={() => roll(12)} className="btn ghost sm">d12</button>
-              <button onClick={() => roll(8)} className="btn ghost sm">d8</button>
-              <button onClick={() => roll(6)} className="btn ghost sm">d6</button>
+              <button onClick={() => requestRoll(20)} className="btn ghost sm" disabled={!actionById("check")?.available}>d20</button>
+              <button onClick={() => requestRoll(12)} className="btn ghost sm" disabled={!actionById("check")?.available}>d12</button>
+              <button onClick={() => requestRoll(8)} className="btn ghost sm" disabled={!actionById("check")?.available}>d8</button>
+              <button onClick={() => requestRoll(6)} className="btn ghost sm" disabled={!actionById("check")?.available}>d6</button>
             </div>
             <div style={{ display: "flex", gap: 10 }}>
               <input
+                ref={inputRef}
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && sendAction()}
-                placeholder="Describe what your hero does…"
+                placeholder={canAct ? "Describe what your hero does..." : `Read-only: ${readOnlyReason}`}
                 style={{ ...inkInput, fontFamily: "var(--f-body)", fontSize: 16 }}
               />
-              <BrassButton onClick={sendAction}>Declare</BrassButton>
+              <BrassButton onClick={sendAction} disabled={!actionById("do")?.available}>Declare</BrassButton>
             </div>
           </div>
         </Panel>
@@ -141,7 +236,7 @@ function ScreenTable({ onNavigate, state, setState }) {
         <Panel framed style={{ padding: 18 }}>
           <SectionTitle>Active Quests</SectionTitle>
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-            {quests.filter((q) => q.status === "active").map((q) => (
+            {quests.filter((q) => !q.status || q.status === "active" || q.status === "open").map((q) => (
               <button key={q.id} onClick={() => onNavigate("journal")} style={{
                 textAlign: "left",
                 padding: "10px 12px",
@@ -158,6 +253,7 @@ function ScreenTable({ onNavigate, state, setState }) {
                 <div className="hand" style={{ fontSize: 13, color: "var(--ink-600)", marginTop: 2 }}>{q.objective}</div>
               </button>
             ))}
+            {!quests.length && <div className="body-sm muted">No active quests in the current read model.</div>}
           </div>
         </Panel>
 
@@ -167,27 +263,32 @@ function ScreenTable({ onNavigate, state, setState }) {
             {stash.slice(0, 8).map((it) => (
               <IconPlate key={it.id} size={48} label={it.glyph} framed />
             ))}
+            {!stash.length && <div className="body-sm muted" style={{ gridColumn: "1 / -1" }}>No quick inventory items.</div>}
           </div>
           <div style={{ marginTop: 12, display: "flex", justifyContent: "space-between" }}>
-            <Stat label="Coin" value="232 gp" />
-            <Stat label="Fate" value="3" />
+            <Stat label="Items" value={stash.length} />
+            <Stat label="Live" value={canAct ? "yes" : "no"} />
           </div>
         </Panel>
 
         <Panel framed style={{ padding: 18, flex: 1, minHeight: 0, overflow: "auto" }}>
           <SectionTitle>Encounter</SectionTitle>
           <div className="body-sm muted" style={{ marginBottom: 10 }}>
-            The Lanternrest waits. Choose what to risk.
+            {encounter.summary || scene.summary || "Choose what to risk."}
           </div>
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-            <EncounterButton icon="◈" label="Approach the door" detail="Mira leads · Stealth DC 14" tone=""
-              onClick={() => toast({ kind: "quest", title: "Mira approaches the door", body: "Stealth check: 18 — silent." })} />
-            <EncounterButton icon="✦" label="Light the lantern" detail="Cassian, 1 ritual" tone="royal"
-              onClick={() => toast({ kind: "item", title: "The lantern is lit", body: "For the first time in seven years. Something inside the inn registers it." })} />
-            <EncounterButton icon="◆" label="Speak aloud" detail="Persuasion · invites response" tone=""
-              onClick={() => toast({ title: "You call out", body: "Silence answers. Then a single floorboard." })} />
-            <EncounterButton icon="▲" label="Force the door" detail="Vell · loud · -1 reputation" tone="crimson"
-              onClick={() => toast({ kind: "danger", title: "Vell hits the door", body: "It opens. -1 with the Road Wardens of Restov." })} />
+            {actions.slice(0, 6).map((a) => (
+              <EncounterButton
+                key={`${a.group}:${a.id}`}
+                icon={a.available ? "◈" : "◆"}
+                label={a.label}
+                detail={a.available ? a.groupLabel : a.disabled_reason}
+                tone={a.available ? (a.group === "combat" ? "royal" : "") : "crimson"}
+                disabled={!a.available}
+                onClick={() => invokeAction(a)}
+              />
+            ))}
+            {!actions.length && <div className="body-sm muted">No actions are available until a campaign snapshot loads.</div>}
           </div>
 
           <div className="divider" style={{ margin: "14px 0" }}>
@@ -196,14 +297,8 @@ function ScreenTable({ onNavigate, state, setState }) {
 
           <SectionTitle>Round Order</SectionTitle>
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-            {[
-              { name: "Mira", init: 19, active: true },
-              { name: "Cassian", init: 14 },
-              { name: "The Crow", init: 11, foe: true },
-              { name: "Vell", init: 9 },
-              { name: "Linzi", init: 6 },
-            ].map((t) => (
-              <div key={t.name} style={{
+            {roundOrder.length ? roundOrder.map((t) => (
+              <div key={t.id || t.name} style={{
                 display: "flex", alignItems: "center", justifyContent: "space-between",
                 padding: "6px 10px",
                 background: t.active ? "linear-gradient(180deg, var(--p-100), var(--p-200))" : "transparent",
@@ -217,7 +312,7 @@ function ScreenTable({ onNavigate, state, setState }) {
                 </div>
                 <span style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--ink-600)" }}>{t.init}</span>
               </div>
-            ))}
+            )) : <div className="body-sm muted">No active combat round.</div>}
           </div>
         </Panel>
       </div>
@@ -226,7 +321,9 @@ function ScreenTable({ onNavigate, state, setState }) {
 }
 
 function PartyRow({ p, active, onClick }) {
-  const hpRatio = p.hp / p.hpMax;
+  const hp = Number.isFinite(Number(p.hp)) ? Number(p.hp) : 1;
+  const hpMax = Number.isFinite(Number(p.hpMax)) && Number(p.hpMax) > 0 ? Number(p.hpMax) : 1;
+  const hpRatio = Math.max(0, Math.min(1, hp / hpMax));
   return (
     <button onClick={onClick} style={{
       display: "grid", gridTemplateColumns: "44px 1fr", gap: 10, alignItems: "center",
@@ -254,7 +351,7 @@ function PartyRow({ p, active, onClick }) {
               background: hpRatio > 0.5 ? "linear-gradient(180deg, #5a8a3a, #3a6020)" : "linear-gradient(180deg, var(--crimson), #4a1010)",
             }} />
           </div>
-          <span style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-700)" }}>{p.hp}/{p.hpMax}</span>
+          <span style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-700)" }}>{hp}/{hpMax}</span>
         </div>
       </div>
     </button>
@@ -281,6 +378,7 @@ function ConditionRow({ icon, name, who, detail, tone }) {
 }
 
 function LogEntry({ entry }) {
+  const kind = entry.kind || "narration";
   if (entry.kind === "narration") {
     return (
       <div style={{ margin: "14px 0", display: "flex", gap: 12 }}>
@@ -326,22 +424,19 @@ function LogEntry({ entry }) {
       </div>
     );
   }
-  return null;
+  return (
+    <div style={{ margin: "8px 0" }}>
+      <span style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--ink-700)" }}>
+        {entry.label || kind}
+      </span>
+      <span className="body" style={{ marginLeft: 8, color: "var(--ink-800)" }}>{entry.text || entry.detail}</span>
+    </div>
+  );
 }
 
-function synthNarration(action, hero) {
-  const lines = [
-    `${hero.name} steps forward; the dust pauses where their boot lands. The world holds its breath for the length of a stanza.`,
-    `A floorboard answers somewhere within the Lanternrest. The crow does not move. A faint smell of beeswax and old iron crosses the threshold.`,
-    `The chronicle records: ${action.toLowerCase()}. A success — but the room is now aware of you.`,
-    `Roll persuasion, or let silence keep its grip on the door a moment longer.`,
-  ];
-  return lines[Math.floor(Math.random() * lines.length)];
-}
+Object.assign(window, { ScreenTable, PartyRow, ConditionRow, LogEntry });
 
-Object.assign(window, { ScreenTable, PartyRow, ConditionRow, LogEntry, synthNarration });
-
-function EncounterButton({ icon, label, detail, tone, onClick }) {
+function EncounterButton({ icon, label, detail, tone, onClick, disabled }) {
   return (
     <button onClick={onClick} style={{
       display: "grid", gridTemplateColumns: "24px 1fr", gap: 8, alignItems: "center",
@@ -349,14 +444,18 @@ function EncounterButton({ icon, label, detail, tone, onClick }) {
       padding: "8px 10px",
       background: "rgba(176,141,87,0.08)",
       boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.3)",
-      cursor: "pointer",
+      cursor: disabled ? "not-allowed" : "pointer",
+      opacity: disabled ? 0.62 : 1,
       transition: "all 140ms",
     }}
+    disabled={disabled}
     onMouseEnter={(e) => {
+      if (disabled) return;
       e.currentTarget.style.background = "linear-gradient(180deg, var(--p-100), var(--p-200))";
       e.currentTarget.style.boxShadow = "inset 0 0 0 1px var(--b-500), 0 0 16px -6px var(--gold-glow)";
     }}
     onMouseLeave={(e) => {
+      if (disabled) return;
       e.currentTarget.style.background = "rgba(176,141,87,0.08)";
       e.currentTarget.style.boxShadow = "inset 0 0 0 1px rgba(140,100,60,0.3)";
     }}>

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -27,6 +27,7 @@ function ScreenTable({ onNavigate, state, setState }) {
   const encounter = surface?.encounter || {};
   const [activeHero, setActiveHero] = React.useState(() => party[0]?.id || "");
   const hero = party.find((p) => p.id === activeHero) || party[0] || { id: "", name: "Hero", short: "Hero", level: 1, class: "Adventurer", hp: 1, hpMax: 1 };
+  const visibleQuests = quests.filter((q) => !q.status || q.status === "active" || q.status === "open");
   const canAct = Boolean(surface?.can_act);
   const readOnlyReason = actions.find((a) => a.disabled_reason)?.disabled_reason || "read-only surface";
   const visibleLog = surface ? [...recentEvents, ...log] : [...demoLog, ...log];
@@ -53,15 +54,36 @@ function ScreenTable({ onNavigate, state, setState }) {
 
   React.useEffect(() => {
     let cancelled = false;
+    let timer = null;
     const guardedLoad = async () => {
       if (cancelled) return;
       await loadSurface(() => cancelled);
     };
-    guardedLoad();
-    const timer = window.setInterval(guardedLoad, 5000);
+    const stopPolling = () => {
+      if (timer !== null) {
+        window.clearInterval(timer);
+        timer = null;
+      }
+    };
+    const startPolling = () => {
+      if (timer === null) {
+        timer = window.setInterval(guardedLoad, 5000);
+      }
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        guardedLoad();
+        startPolling();
+      } else {
+        stopPolling();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    handleVisibility();
     return () => {
       cancelled = true;
-      window.clearInterval(timer);
+      stopPolling();
+      document.removeEventListener("visibilitychange", handleVisibility);
     };
   }, [loadSurface]);
 
@@ -236,7 +258,7 @@ function ScreenTable({ onNavigate, state, setState }) {
         <Panel framed style={{ padding: 18 }}>
           <SectionTitle>Active Quests</SectionTitle>
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-            {quests.filter((q) => !q.status || q.status === "active" || q.status === "open").map((q) => (
+            {visibleQuests.map((q) => (
               <button key={q.id} onClick={() => onNavigate("journal")} style={{
                 textAlign: "left",
                 padding: "10px 12px",
@@ -253,7 +275,7 @@ function ScreenTable({ onNavigate, state, setState }) {
                 <div className="hand" style={{ fontSize: 13, color: "var(--ink-600)", marginTop: 2 }}>{q.objective}</div>
               </button>
             ))}
-            {!quests.length && <div className="body-sm muted">No active quests in the current read model.</div>}
+            {!visibleQuests.length && <div className="body-sm muted">No active quests in the current read model.</div>}
           </div>
         </Panel>
 
@@ -297,8 +319,8 @@ function ScreenTable({ onNavigate, state, setState }) {
 
           <SectionTitle>Round Order</SectionTitle>
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-            {roundOrder.length ? roundOrder.map((t) => (
-              <div key={t.id || t.name} style={{
+            {roundOrder.length ? roundOrder.map((t, i) => (
+              <div key={t.id || t.name || `round-${i}`} style={{
                 display: "flex", alignItems: "center", justifyContent: "space-between",
                 padding: "6px 10px",
                 background: t.active ? "linear-gradient(180deg, var(--p-100), var(--p-200))" : "transparent",

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -644,6 +644,362 @@ def _party_cards(snapshot: dict) -> list[dict]:
     return out
 
 
+def _class_summary(ch: dict) -> tuple[str, int | None]:
+    classes = ch.get("classes")
+    if isinstance(classes, list) and classes:
+        names: list[str] = []
+        levels: list[int] = []
+        for row in classes:
+            if not isinstance(row, dict):
+                continue
+            name = _text(row.get("name") or row.get("class_name"))
+            if name:
+                names.append(name)
+            level = row.get("level")
+            if isinstance(level, int) and not isinstance(level, bool):
+                levels.append(level)
+        if names:
+            return " / ".join(names), sum(levels) if levels else None
+    klass = _text(ch.get("class") or ch.get("klass"), "Adventurer")
+    level = ch.get("level")
+    return klass, level if isinstance(level, int) and not isinstance(level, bool) else None
+
+
+def _session_location(snapshot: dict) -> dict:
+    loc_id = _text(snapshot.get("current_location_id"))
+    locs = snapshot.get("locations")
+    loc = locs.get(loc_id) if isinstance(locs, dict) and loc_id else None
+    loc = loc if isinstance(loc, dict) else {}
+    name = _text(loc.get("name"), loc_id or "Unknown location")
+    return {
+        "id": loc_id,
+        "name": name,
+        "region": _text(loc.get("region"), name),
+        "description": _text(loc.get("description")),
+    }
+
+
+def _session_party_cards(snapshot: dict) -> list[dict]:
+    chars = snapshot.get("characters")
+    party = snapshot.get("party")
+    if not isinstance(chars, dict) or not isinstance(party, list):
+        return []
+    out: list[dict] = []
+    for cid in party:
+        if not isinstance(cid, str):
+            continue
+        ch = chars.get(cid)
+        if not isinstance(ch, dict):
+            continue
+        klass, level = _class_summary(ch)
+        cur_hp = _num(ch.get("current_hp"))
+        max_hp = _num(ch.get("max_hp"))
+        hp = cur_hp if cur_hp is not None else (max_hp if max_hp is not None else 1)
+        hp_max = max_hp if max_hp is not None else (cur_hp if cur_hp is not None else 1)
+        card = {
+            "id": cid,
+            "name": _text(ch.get("name"), cid),
+            "short": "portrait",
+            "level": level or 1,
+            "class": klass,
+            "hp": hp,
+            "hpMax": hp_max if hp_max else 1,
+            "kind": _text(ch.get("kind")),
+            "conditions": [str(c) for c in ch.get("conditions", []) if str(c)]
+            if isinstance(ch.get("conditions"), list)
+            else [],
+        }
+        ac = _num(ch.get("armor_class"))
+        if ac is not None:
+            card["ac"] = ac
+        if bool(ch.get("dead")):
+            card["dead"] = True
+        out.append(card)
+    return out
+
+
+def _session_conditions(party: list[dict]) -> list[dict]:
+    out: list[dict] = []
+    for card in party:
+        for condition in card.get("conditions", []):
+            name = _text(condition).replace("_", " ").title()
+            if not name:
+                continue
+            out.append({
+                "id": f"{card.get('id', '')}:{name.lower().replace(' ', '-')}",
+                "icon": "◆",
+                "name": name,
+                "who": _text(card.get("name"), "Unknown"),
+                "detail": "Active condition",
+                "tone": "royal" if name.lower() in {"blessed", "inspired"} else "",
+            })
+    return out
+
+
+def _session_active_quests(snapshot: dict) -> list[dict]:
+    quests = snapshot.get("quests")
+    locs = snapshot.get("locations")
+    out: list[dict] = []
+    if not isinstance(quests, dict):
+        return out
+    for qid, row in quests.items():
+        if not isinstance(row, dict):
+            continue
+        status = _text(row.get("status"), "active").lower()
+        if status in {"completed", "complete", "resolved", "failed", "closed"}:
+            continue
+        objectives = row.get("objectives")
+        completed = row.get("completed_objectives")
+        completed_set = {str(o) for o in completed} if isinstance(completed, list) else set()
+        objective = ""
+        if isinstance(objectives, list):
+            for item in objectives:
+                item_text = _text(item)
+                if item_text and item_text not in completed_set:
+                    objective = item_text
+                    break
+        if not objective:
+            objective = _text(row.get("description"), "Continue the investigation.")
+        location_id = _text(row.get("location_id"))
+        location = ""
+        if isinstance(locs, dict) and location_id:
+            loc = locs.get(location_id)
+            if isinstance(loc, dict):
+                location = _text(loc.get("name"), location_id)
+        out.append({
+            "id": _text(qid),
+            "title": _text(row.get("title"), _text(qid, "Quest")),
+            "label": status.title() if status else "Active",
+            "objective": objective,
+            "status": status or "active",
+            "tone": "royal",
+            "location": location,
+        })
+    return out[:8]
+
+
+def _session_quick_inventory(snapshot: dict) -> list[dict]:
+    chars = snapshot.get("characters")
+    party = snapshot.get("party")
+    if not isinstance(chars, dict) or not isinstance(party, list):
+        return []
+    out: list[dict] = []
+    for cid in party:
+        if not isinstance(cid, str):
+            continue
+        ch = chars.get(cid)
+        if not isinstance(ch, dict):
+            continue
+        inventory = ch.get("inventory")
+        if not isinstance(inventory, list):
+            continue
+        for idx, item in enumerate(inventory):
+            if not isinstance(item, dict):
+                continue
+            name = _text(item.get("name"))
+            if not name:
+                continue
+            qty = item.get("quantity", item.get("qty", item.get("count", 1)))
+            qty = qty if isinstance(qty, int) and not isinstance(qty, bool) else 1
+            out.append({
+                "id": f"{cid}:{idx}:{name}",
+                "name": name,
+                "glyph": _text(item.get("glyph"), "item"),
+                "qty": qty,
+                "type": _text(item.get("type"), "item"),
+            })
+            if len(out) >= 12:
+                return out
+    return out
+
+
+def _session_available_actions(action_model: dict) -> list[dict]:
+    out: list[dict] = []
+    groups = action_model.get("groups")
+    if not isinstance(groups, list):
+        return out
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        group_id = _text(group.get("id"))
+        group_label = _text(group.get("label"))
+        actions = group.get("actions")
+        if not isinstance(actions, list):
+            continue
+        for action in actions:
+            if not isinstance(action, dict):
+                continue
+            item = {
+                "id": _text(action.get("id")),
+                "label": _text(action.get("label")),
+                "group": group_id,
+                "groupLabel": group_label,
+                "available": bool(action.get("available")),
+                "disabled_reason": action.get("disabled_reason") if isinstance(action.get("disabled_reason"), str) else None,
+            }
+            move = action.get("move")
+            if isinstance(move, dict):
+                item["move"] = {
+                    k: v for k, v in move.items()
+                    if k in _MOVE_FIELDS or k == "kind"
+                    if isinstance(v, (str, int, float)) and not isinstance(v, bool)
+                }
+            ui = action.get("ui")
+            if isinstance(ui, str) and ui.strip():
+                item["ui"] = ui.strip()
+            out.append(item)
+    return out
+
+
+def _session_recent_events(raw_events: list[dict] | None) -> list[dict]:
+    out: list[dict] = []
+    for row in raw_events or []:
+        if not isinstance(row, dict):
+            continue
+        kind = _text(row.get("kind") or row.get("type"), "narration")
+        label = _text(row.get("label") or row.get("who") or row.get("source"))
+        text = _text(row.get("text") or row.get("detail") or row.get("summary"))
+        if not text:
+            continue
+        item = {"kind": kind, "text": text[:1000]}
+        if label:
+            item["label"] = label[:120]
+        out.append(item)
+        if len(out) >= 12:
+            break
+    return out
+
+
+def _session_event_tail_from_dir(campaign_dir: Path, snapshot: dict, limit: int = 12) -> list[dict]:
+    sid = snapshot.get("active_session_id")
+    if not sid:
+        session_ids = snapshot.get("session_ids")
+        if isinstance(session_ids, list) and session_ids:
+            sid = session_ids[-1]
+    if not isinstance(sid, str) or not sid.strip():
+        return []
+    log = campaign_dir / "sessions" / f"{sid}.jsonl"
+    if not log.exists():
+        return []
+    try:
+        lines = log.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    out: list[dict] = []
+    for raw in lines[-limit:]:
+        try:
+            row = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            out.append(row)
+    return out
+
+
+def _session_event_tail(campaign_id: str, limit: int = 12) -> list[dict]:
+    snapshot = _read_snapshot(campaign_id)
+    return _session_event_tail_from_dir(_campaign_dir(campaign_id), snapshot, limit)
+
+
+def _session_surface_catalog_ref(query: dict) -> tuple[str, dict, Path, bool] | None:
+    source = _text((query.get("source") or [""])[0])
+    run_id = _text((query.get("run") or [""])[0])
+    campaign_id = _text((query.get("campaign") or [""])[0])
+    if not source or not run_id or not campaign_id:
+        return None
+    for root in _campaign_catalog_roots():
+        if str(root.get("source")) != source or str(root.get("run_id")) != run_id:
+            continue
+        cdir = root.get("campaigns_dir")
+        if not isinstance(cdir, Path) or not cdir.is_dir():
+            return None
+        try:
+            campaign_dir = (cdir / campaign_id).resolve()
+            if not campaign_dir.is_dir() or campaign_dir.parent != cdir.resolve():
+                return None
+            snap = campaign_dir / "snapshot.json"
+            data = json.loads(snap.read_text(encoding="utf-8"))
+        except (OSError, ValueError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        root_is_current = bool(root.get("current_state")) and _resolved(cdir) == _resolved(_campaigns_dir())
+        return campaign_dir.name, data, campaign_dir, root_is_current
+    return None
+
+
+def build_session_surface(
+    snapshot: dict,
+    *,
+    campaign_id: str,
+    live: bool,
+    is_live_view: bool,
+    recent_events: list[dict] | None = None,
+) -> dict:
+    """Project a browser-safe OpenWorlds table surface from engine-owned state.
+
+    This read model intentionally copies only player-facing fields into a stable
+    shape for the OpenWorlds session screen. The browser may render it and submit
+    enabled player intents to `/move`; it must never infer or write campaign
+    state directly.
+    """
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    location = _session_location(snapshot)
+    party = _session_party_cards(snapshot)
+    action_model = build_action_model(snapshot, live=live, is_live_view=is_live_view)
+    combat_view = build_combat_view(snapshot)
+    actions = _session_available_actions(action_model)
+    combat_active = bool(combat_view.get("active"))
+    round_no = combat_view.get("round")
+    summary = _text(snapshot.get("summary"))
+    if not summary:
+        summary = _text(location.get("description"), f"The party is gathered near {location['name']}.")
+
+    return {
+        "campaign_id": campaign_id,
+        "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
+        "world": _text(snapshot.get("world_id"), "unknown"),
+        "day": snapshot.get("day") if isinstance(snapshot.get("day"), int) else None,
+        "time_of_day": _text(snapshot.get("time_of_day")),
+        "dayLabel": _openworlds_day_label(snapshot),
+        "location": location,
+        "scene": {
+            "summary": summary,
+            "caption": location["name"],
+            "imageScope": f"location:{location['id']}" if location["id"] else "",
+        },
+        "party": party,
+        "conditions": _session_conditions(party),
+        "activeQuests": _session_active_quests(snapshot),
+        "quickInventory": _session_quick_inventory(snapshot),
+        "encounter": {
+            "active": combat_active,
+            "summary": f"Combat round {round_no}" if combat_active and round_no else ("Combat" if combat_active else summary),
+            "actions": actions[:8],
+        },
+        "roundOrder": [
+            {
+                "id": _text(row.get("id")),
+                "name": _text(row.get("name"), "Unknown"),
+                "init": row.get("initiative"),
+                "active": bool(row.get("is_current")),
+                "foe": _text(row.get("kind")).lower() in {"monster", "enemy", "foe"},
+            }
+            for row in combat_view.get("order", [])
+            if isinstance(row, dict)
+        ],
+        "availableActions": actions,
+        "recentEvents": _session_recent_events(recent_events),
+        "actionModel": action_model,
+        "combatView": combat_view,
+        "live": bool(live),
+        "is_live_view": bool(is_live_view),
+        "can_act": bool(live and is_live_view),
+        "state_authority": "engine",
+        "write_lane": "/move",
+    }
+
+
 def _relative_time_label(ts: float, *, now: float) -> str:
     if ts <= 0:
         return "unknown"
@@ -1913,6 +2269,34 @@ class _Handler(BaseHTTPRequestHandler):
             self._json(_openworlds_config())
         elif route == "/openworlds/campaigns.json":
             self._json(_openworlds_campaigns(self.campaign_id))
+        elif route == "/session-surface":
+            qs = parse_qs(parsed.query)
+            live = _live_play()
+            catalog_ref = _session_surface_catalog_ref(qs)
+            if catalog_ref is not None:
+                cid, raw_snap, campaign_dir, root_is_current = catalog_ref
+                self._json(build_session_surface(
+                    raw_snap,
+                    campaign_id=cid,
+                    live=live,
+                    is_live_view=bool(live and root_is_current and cid == self.campaign_id),
+                    recent_events=_session_event_tail_from_dir(campaign_dir, raw_snap),
+                ))
+                return
+            cid = self._view_campaign(qs)
+            if not cid:
+                self._json(build_session_surface({}, campaign_id="", live=live, is_live_view=False))
+                return
+            raw_snap = _read_snapshot(cid)
+            if not isinstance(raw_snap, dict):
+                raw_snap = {}
+            self._json(build_session_surface(
+                raw_snap,
+                campaign_id=cid,
+                live=live,
+                is_live_view=live and cid == self.campaign_id,
+                recent_events=_session_event_tail(cid),
+            ))
         elif route == _OPENWORLDS_ROUTE or route.startswith(f"{_OPENWORLDS_ROUTE}/"):
             asset = _openworlds_asset(route)
             if asset is None:

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -870,23 +870,55 @@ def _session_recent_events(raw_events: list[dict] | None) -> list[dict]:
     return out
 
 
+def _safe_session_id(session_id: object) -> str:
+    if not isinstance(session_id, str):
+        return ""
+    sid = session_id.strip()
+    if not sid or "/" in sid or "\\" in sid or ".." in sid:
+        return ""
+    if Path(sid).name != sid:
+        return ""
+    if not all(ch.isalnum() or ch in "._-" for ch in sid):
+        return ""
+    return sid
+
+
+def _tail_text_lines(path: Path, limit: int, chunk_size: int = 8192) -> list[str]:
+    if limit <= 0:
+        return []
+    try:
+        with path.open("rb") as f:
+            f.seek(0, os.SEEK_END)
+            pos = f.tell()
+            data = b""
+            while pos > 0 and data.count(b"\n") <= limit:
+                size = min(chunk_size, pos)
+                pos -= size
+                f.seek(pos)
+                data = f.read(size) + data
+    except OSError:
+        return []
+    return data.decode("utf-8", errors="replace").splitlines()[-limit:]
+
+
 def _session_event_tail_from_dir(campaign_dir: Path, snapshot: dict, limit: int = 12) -> list[dict]:
     sid = snapshot.get("active_session_id")
     if not sid:
         session_ids = snapshot.get("session_ids")
         if isinstance(session_ids, list) and session_ids:
             sid = session_ids[-1]
-    if not isinstance(sid, str) or not sid.strip():
-        return []
-    log = campaign_dir / "sessions" / f"{sid}.jsonl"
-    if not log.exists():
+    sid = _safe_session_id(sid)
+    if not sid:
         return []
     try:
-        lines = log.read_text(encoding="utf-8").splitlines()
+        sessions_dir = (campaign_dir / "sessions").resolve()
+        log = (sessions_dir / f"{sid}.jsonl").resolve()
     except OSError:
         return []
+    if log.parent != sessions_dir or not log.is_file():
+        return []
     out: list[dict] = []
-    for raw in lines[-limit:]:
+    for raw in _tail_text_lines(log, limit):
         try:
             row = json.loads(raw)
         except json.JSONDecodeError:

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -204,6 +204,95 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertFalse(by_id["qa:wave3-red:camp_qa"]["canResume"])
         self.assertEqual(by_id["qa:wave3-red:camp_qa"]["monitorUrl"], "/monitor")
 
+    def test_session_surface_route_projects_selected_campaign_safely(self):
+        campaign_dir = self._tmp / "campaigns" / "camp_table"
+        self._write_snapshot(
+            campaign_dir,
+            {
+                "id": "camp_table",
+                "title": "Table Save",
+                "summary": "A quiet table scene.",
+                "world_id": "baldurs-gate",
+                "current_location_id": "lower-city",
+                "locations": {
+                    "lower-city": {
+                        "name": "Lower City",
+                        "description": "Cobbles shine after rain.",
+                        "notes": "private route note",
+                    },
+                },
+                "party": ["hero"],
+                "characters": {
+                    "hero": {
+                        "id": "hero",
+                        "name": "Tav",
+                        "kind": "player",
+                        "current_hp": 12,
+                        "max_hp": 20,
+                        "notes": "private character note",
+                    },
+                },
+                "dm_notes": "hidden route agenda",
+            },
+        )
+
+        status, ctype, body = self._get("/session-surface?campaign=camp_table")
+
+        self.assertEqual(status, 200)
+        self.assertIn("application/json", ctype)
+        surface = json.loads(body.decode("utf-8"))
+        self.assertEqual(surface["campaign_id"], "camp_table")
+        self.assertEqual(surface["state_authority"], "engine")
+        self.assertEqual(surface["write_lane"], "/move")
+        self.assertEqual(surface["title"], "Table Save")
+        self.assertEqual(surface["location"]["name"], "Lower City")
+        self.assertEqual(surface["party"][0]["name"], "Tav")
+        encoded = json.dumps(surface)
+        self.assertNotIn("private route", encoded)
+        self.assertNotIn("private character", encoded)
+        self.assertNotIn("hidden route", encoded)
+        self.assert_no_private_keys(surface)
+
+    def test_session_surface_route_projects_catalog_run_read_only(self):
+        repo_root = self._tmp / "repo"
+        (repo_root / "viewer").mkdir(parents=True)
+        server._HERE = repo_root / "viewer"
+        qa_campaign = repo_root / "qa" / "state" / "wave3-red" / "campaigns" / "camp_qa"
+        self._write_snapshot(
+            qa_campaign,
+            {
+                "id": "camp_qa",
+                "title": "QA Table Save",
+                "summary": "A QA-only session surface.",
+                "world_id": "baldurs-gate",
+                "current_location_id": "qa-location",
+                "locations": {"qa-location": {"name": "QA Location"}},
+                "party": ["hero"],
+                "characters": {"hero": {"id": "hero", "name": "QA Tav", "kind": "player"}},
+            },
+        )
+        self._write_snapshot(
+            self._tmp / "campaigns" / "camp_live",
+            {
+                "id": "camp_live",
+                "title": "Live Table Save",
+                "party": [],
+                "characters": {},
+            },
+        )
+        _QuietHandler.campaign_id = "camp_live"
+
+        status, _ctype, body = self._get("/session-surface?source=qa&run=wave3-red&campaign=camp_qa")
+
+        self.assertEqual(status, 200)
+        surface = json.loads(body.decode("utf-8"))
+        self.assertEqual(surface["campaign_id"], "camp_qa")
+        self.assertEqual(surface["title"], "QA Table Save")
+        self.assertEqual(surface["location"]["name"], "QA Location")
+        self.assertEqual(surface["party"][0]["name"], "QA Tav")
+        self.assertFalse(surface["can_act"])
+        self.assertFalse(surface["is_live_view"])
+
     def _write_snapshot(self, campaign_dir: Path, payload: dict) -> None:
         campaign_dir.mkdir(parents=True)
         (campaign_dir / "snapshot.json").write_text(json.dumps(payload), encoding="utf-8")

--- a/viewer/tests/test_session_surface.py
+++ b/viewer/tests/test_session_surface.py
@@ -14,7 +14,11 @@ _SPEC.loader.exec_module(server)
 
 
 def _find_action(surface: dict, action_id: str) -> dict:
-    return next(a for a in surface["availableActions"] if a["id"] == action_id)
+    found = next((a for a in surface["availableActions"] if a["id"] == action_id), None)
+    if found is None:
+        available = [a.get("id") for a in surface["availableActions"] if isinstance(a, dict)]
+        raise AssertionError(f"action {action_id!r} not found in availableActions: {available}")
+    return found
 
 
 class SessionSurfaceTests(unittest.TestCase):
@@ -202,10 +206,21 @@ class SessionSurfaceTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-        unsafe = server._session_event_tail_from_dir(campaign_dir, {"active_session_id": "../evil"})
+        unsafe_values = [
+            "../evil",
+            "../../evil",
+            "sessions/../evil",
+            "/etc/passwd",
+            "evil\x00sid",
+            "evil/界",
+        ]
+        unsafe = [
+            server._session_event_tail_from_dir(campaign_dir, {"active_session_id": sid})
+            for sid in unsafe_values
+        ]
         safe_tail = server._session_event_tail_from_dir(campaign_dir, {"active_session_id": "sess_1"}, limit=3)
 
-        self.assertEqual(unsafe, [])
+        self.assertEqual(unsafe, [[] for _ in unsafe_values])
         self.assertEqual([row["detail"] for row in safe_tail], ["event 17", "event 18", "event 19"])
 
     def test_session_surface_rejects_unsafe_active_session_id(self):

--- a/viewer/tests/test_session_surface.py
+++ b/viewer/tests/test_session_surface.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -184,6 +185,28 @@ class SessionSurfaceTests(unittest.TestCase):
         self.assertTrue(surface["roundOrder"][0]["active"])
         self.assertEqual(_find_action(surface, "attack")["disabled_reason"], "action spent")
         self.assertEqual(_find_action(surface, "reaction")["disabled_reason"], "reaction spent")
+
+    def test_session_event_tail_rejects_unsafe_active_session_id(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        campaign_dir = root / "campaigns" / "camp_safe"
+        (campaign_dir / "sessions").mkdir(parents=True)
+        (campaign_dir / "evil.jsonl").write_text(
+            json.dumps({"kind": "narration", "detail": "private traversal event"}) + "\n",
+            encoding="utf-8",
+        )
+        (campaign_dir / "sessions" / "sess_1.jsonl").write_text(
+            "".join(
+                json.dumps({"kind": "narration", "detail": f"event {i}"}) + "\n"
+                for i in range(20)
+            ),
+            encoding="utf-8",
+        )
+
+        unsafe = server._session_event_tail_from_dir(campaign_dir, {"active_session_id": "../evil"})
+        safe_tail = server._session_event_tail_from_dir(campaign_dir, {"active_session_id": "sess_1"}, limit=3)
+
+        self.assertEqual(unsafe, [])
+        self.assertEqual([row["detail"] for row in safe_tail], ["event 17", "event 18", "event 19"])
 
     def assert_no_private_keys(self, value) -> None:
         private_keys = {

--- a/viewer/tests/test_session_surface.py
+++ b/viewer/tests/test_session_surface.py
@@ -1,0 +1,211 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+def _find_action(surface: dict, action_id: str) -> dict:
+    return next(a for a in surface["availableActions"] if a["id"] == action_id)
+
+
+class SessionSurfaceTests(unittest.TestCase):
+    def test_session_surface_projects_safe_read_model_without_private_fields(self):
+        snapshot = {
+            "id": "camp_safe",
+            "title": "Smoke at the Gate",
+            "summary": "The party studies the sealed gate as dusk gathers.",
+            "world_id": "baldurs-gate",
+            "day": 12,
+            "time_of_day": "dusk",
+            "current_location_id": "lower-city",
+            "locations": {
+                "lower-city": {
+                    "name": "Lower City",
+                    "region": "Baldur's Gate",
+                    "description": "Rain gathers along the cobbles outside the Basilisk Gate.",
+                    "notes": "secret Zhentarim cache under the third stone",
+                },
+            },
+            "party": ["tav", "jaheira"],
+            "characters": {
+                "tav": {
+                    "id": "tav",
+                    "name": "Tav",
+                    "kind": "player",
+                    "classes": [{"name": "Fighter", "level": 5}],
+                    "current_hp": 31,
+                    "max_hp": 42,
+                    "armor_class": 18,
+                    "conditions": ["blessed"],
+                    "inventory": [
+                        {"name": "Torch", "quantity": 2, "type": "gear", "notes": "private stash marker"},
+                        {"name": "Potion of Healing", "qty": 1},
+                    ],
+                    "notes": "secret player note",
+                    "personality": "private personality seed",
+                    "backstory": "private backstory seed",
+                    "companion_dossier": {"sealed_agenda": "private agenda"},
+                },
+                "jaheira": {
+                    "id": "jaheira",
+                    "name": "Jaheira",
+                    "kind": "companion",
+                    "classes": [{"name": "Druid", "level": 5}],
+                    "current_hp": 38,
+                    "max_hp": 38,
+                    "armor_class": 16,
+                    "conditions": [],
+                },
+            },
+            "quests": {
+                "q_gate": {
+                    "title": "Ashes at the Gate",
+                    "description": "Find who sealed the Basilisk Gate after moonrise.",
+                    "status": "active",
+                    "objectives": ["Speak to Harper Tull", "Inspect the ash circle"],
+                    "completed_objectives": ["Inspect the ash circle"],
+                    "location_id": "lower-city",
+                    "notes": "secret quest solution",
+                },
+                "q_done": {"title": "Closed Door", "status": "completed"},
+            },
+            "scenes": [{"dm_notes": "hidden agenda"}],
+            "lore": ["private canon recall input"],
+            "dm_notes": "private dm note",
+        }
+
+        surface = server.build_session_surface(
+            snapshot,
+            campaign_id="camp_safe",
+            live=False,
+            is_live_view=False,
+            recent_events=[{"kind": "narration", "detail": "A bell rings once beyond the gate."}],
+        )
+
+        self.assertEqual(surface["campaign_id"], "camp_safe")
+        self.assertEqual(surface["state_authority"], "engine")
+        self.assertEqual(surface["write_lane"], "/move")
+        self.assertFalse(surface["can_act"])
+        self.assertEqual(surface["title"], "Smoke at the Gate")
+        self.assertEqual(surface["world"], "baldurs-gate")
+        self.assertEqual(surface["dayLabel"], "Day 12 · dusk")
+        self.assertEqual(surface["location"]["name"], "Lower City")
+        self.assertEqual(surface["location"]["region"], "Baldur's Gate")
+        self.assertEqual(surface["scene"]["summary"], "The party studies the sealed gate as dusk gathers.")
+        self.assertEqual([p["name"] for p in surface["party"]], ["Tav", "Jaheira"])
+        self.assertEqual(surface["party"][0]["class"], "Fighter")
+        self.assertEqual(surface["party"][0]["level"], 5)
+        self.assertEqual(surface["party"][0]["hp"], 31)
+        self.assertEqual(surface["party"][0]["hpMax"], 42)
+        self.assertEqual(surface["party"][0]["ac"], 18)
+        self.assertEqual(surface["conditions"][0]["name"], "Blessed")
+        self.assertEqual(surface["conditions"][0]["who"], "Tav")
+        self.assertEqual(surface["activeQuests"][0]["title"], "Ashes at the Gate")
+        self.assertEqual(surface["activeQuests"][0]["objective"], "Speak to Harper Tull")
+        self.assertEqual([i["name"] for i in surface["quickInventory"]], ["Torch", "Potion of Healing"])
+        self.assertEqual(surface["recentEvents"][0]["text"], "A bell rings once beyond the gate.")
+
+        encoded = json.dumps(surface)
+        for forbidden in (
+            "notes",
+            "dm_notes",
+            "scenes",
+            "personality",
+            "backstory",
+            "companion_dossier",
+            "sealed_agenda",
+            "private canon",
+            "secret",
+            "private",
+            "hidden agenda",
+        ):
+            self.assertNotIn(forbidden, encoded)
+        self.assert_no_private_keys(surface)
+
+    def test_session_surface_routes_enabled_actions_through_move_contract(self):
+        snapshot = {
+            "title": "Live Save",
+            "party": ["pc"],
+            "characters": {"pc": {"id": "pc", "name": "Vela", "kind": "player"}},
+        }
+
+        surface = server.build_session_surface(snapshot, campaign_id="camp_live", live=True, is_live_view=True)
+
+        self.assertTrue(surface["can_act"])
+        self.assertEqual(surface["write_lane"], "/move")
+        continue_action = _find_action(surface, "continue")
+        say_action = _find_action(surface, "say")
+        self.assertTrue(continue_action["available"])
+        self.assertEqual(continue_action["move"], {"kind": "do", "text": "continue"})
+        self.assertTrue(say_action["available"])
+        self.assertEqual(say_action["ui"], "focus-say")
+        self.assertNotIn("snapshot", json.dumps(surface))
+
+    def test_session_surface_includes_combat_order_and_disabled_reasons(self):
+        snapshot = {
+            "party": ["pc"],
+            "characters": {
+                "pc": {
+                    "id": "pc",
+                    "name": "Vela",
+                    "kind": "player",
+                    "current_hp": 12,
+                    "max_hp": 20,
+                    "armor_class": 15,
+                },
+                "gob": {"id": "gob", "name": "Goblin", "kind": "monster", "current_hp": 7, "max_hp": 7},
+            },
+            "combat": {
+                "active": True,
+                "round": 3,
+                "turn_index": 0,
+                "action_used": True,
+                "bonus_action_used": False,
+                "order": [
+                    {"character_id": "pc", "initiative": 18, "reaction_used": True},
+                    {"character_id": "gob", "initiative": 9},
+                ],
+            },
+        }
+
+        surface = server.build_session_surface(snapshot, campaign_id="camp_combat", live=True, is_live_view=True)
+
+        self.assertTrue(surface["encounter"]["active"])
+        self.assertEqual(surface["encounter"]["summary"], "Combat round 3")
+        self.assertEqual([row["name"] for row in surface["roundOrder"]], ["Vela", "Goblin"])
+        self.assertTrue(surface["roundOrder"][0]["active"])
+        self.assertEqual(_find_action(surface, "attack")["disabled_reason"], "action spent")
+        self.assertEqual(_find_action(surface, "reaction")["disabled_reason"], "reaction spent")
+
+    def assert_no_private_keys(self, value) -> None:
+        private_keys = {
+            "notes",
+            "dm_notes",
+            "scenes",
+            "lore",
+            "memory",
+            "personality",
+            "backstory",
+            "companion_dossier",
+            "sealed_agenda",
+            "agenda",
+        }
+        if isinstance(value, dict):
+            for key, child in value.items():
+                self.assertNotIn(key, private_keys)
+                self.assert_no_private_keys(child)
+        elif isinstance(value, list):
+            for child in value:
+                self.assert_no_private_keys(child)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_session_surface.py
+++ b/viewer/tests/test_session_surface.py
@@ -208,6 +208,33 @@ class SessionSurfaceTests(unittest.TestCase):
         self.assertEqual(unsafe, [])
         self.assertEqual([row["detail"] for row in safe_tail], ["event 17", "event 18", "event 19"])
 
+    def test_session_surface_rejects_unsafe_active_session_id(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        campaign_dir = root / "campaigns" / "camp_surface"
+        (campaign_dir / "sessions").mkdir(parents=True)
+        (campaign_dir / "evil.jsonl").write_text(
+            json.dumps({"kind": "narration", "detail": "private traversal event"}) + "\n",
+            encoding="utf-8",
+        )
+        snapshot = {
+            "title": "Unsafe Session",
+            "active_session_id": "../evil",
+            "party": ["pc"],
+            "characters": {"pc": {"id": "pc", "name": "Vela", "kind": "player"}},
+        }
+        recent_events = server._session_event_tail_from_dir(campaign_dir, snapshot)
+
+        surface = server.build_session_surface(
+            snapshot,
+            campaign_id="camp_surface",
+            live=False,
+            is_live_view=False,
+            recent_events=recent_events,
+        )
+
+        self.assertEqual(surface["recentEvents"], [])
+        self.assertEqual(surface["title"], "Unsafe Session")
+
     def assert_no_private_keys(self, value) -> None:
         private_keys = {
             "notes",


### PR DESCRIPTION
## Summary

Adds the first engine-derived OpenWorlds session/table surface for issue #115.

- Introduces `GET /session-surface` as a browser-safe, read-only projection for the OpenWorlds table screen.
- Projects campaign title/world/day/location, scene summary, party cards, conditions, active quests, quick inventory, recent events, encounter state, round order, and contextual actions.
- Keeps the engine/viewer as the state authority: the browser only renders read models and can submit player intent through the existing sanitized `POST /move` lane.
- Wires `viewer/openworlds/screen-table.jsx` to poll `/session-surface`, removes synthetic Lanternrest/Odrun table logs once real data is present, and disables unsupported actions with explicit reasons.
- Supports active state campaigns and read-only catalog roots (`play-state/*`, `qa/state/*`) via `source/run/campaign` query routing, so selecting a QA/save row cannot silently display the wrong live campaign.

Refs #115.

## Architecture Notes

### State authority

This PR does not add any browser or macOS-app write authority. The new surface is derived from `snapshot.json` and existing viewer helpers:

- `build_action_model(...)` remains the source for action availability and disabled reasons.
- `build_combat_view(...)` remains the source for round order and combat state.
- `POST /move` remains the only player-intent write lane exposed to the OpenWorlds table.
- The OpenWorlds browser code never writes snapshots, `play-state`, `qa/state`, inventory, quests, XP, world clocks, or companion state.

### Privacy boundary

The projection intentionally copies only player-facing fields. Tests cover that the output excludes private keys/content such as `notes`, `dm_notes`, `scenes`, `lore`, `personality`, `backstory`, `companion_dossier`, and sealed agenda data. Location `description`, quest title/objective/description, party vitals, and public inventory names are allowed because they are visible player-facing state.

### Catalog roots

The table surface accepts optional catalog identifiers:

```text
/session-surface?source=qa&run=wave3-red&campaign=camp_qa
/session-surface?source=play&run=play-20260525&campaign=camp_play
```

Those are resolved by iterating known catalog roots rather than by trusting caller-provided paths. Non-current roots are always read-only and set `can_act=false` / `is_live_view=false`.

## Files Changed

- `viewer/server.py`
  - Adds session-surface projection helpers.
  - Adds catalog-root lookup for read-only save/QA session surfaces.
  - Adds `GET /session-surface`.
- `viewer/openworlds/screen-table.jsx`
  - Polls `/session-surface` for selected campaign data.
  - Renders real party/conditions/scene/quests/inventory/events/actions/round order.
  - Sends enabled player intents through `/move` only.
  - Removes prototype table narration when real surface data is loaded.
- `viewer/tests/test_session_surface.py`
  - Covers safe projection, action contract, combat order, and disabled reasons.
- `viewer/tests/test_openworlds_static.py`
  - Covers the HTTP route for active campaigns and read-only catalog roots.

## Validation

Local validation was run from `/Volumes/LEXAR/repos/ClawDnD-openworlds-session-surface`:

```bash
python3 -m py_compile viewer/server.py
python3 -m unittest discover -s viewer/tests -q
python3 scripts/license_check.py
git diff --check
```

Rendered smoke validation used the in-app browser against a throwaway state dir at `http://127.0.0.1:18765/openworlds/`:

- OpenWorlds loaded.
- Navigated to Table.
- Real session data rendered: `Smoke at the Gate`, `Lower City`, `Tav`, `Jaheira`, `Ashes at the Gate`, and recent event text.
- Prototype `Lanternrest`/`Odrun` table log text was absent after the fix.
- Private scratch strings were absent.
- No runtime errors were observed. The only browser warning was the known local Babel runtime warning from the fidelity-first OpenWorlds prototype path.

## Review Notes

The main thing to inspect is whether the viewer-side projection is the right first step before moving more of this model into the engine. For this PR, rules legality is not recomputed in JavaScript; actions are rendered from the existing viewer action model and disabled when the move sink/view context is not live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabletop view now uses a server-backed session read model with periodic updates, header readiness states, snapshot-driven scene captions, and server-backed dice/Declare actions that update the view.

* **Bug Fixes**
  * Party HP display normalizes non-numeric values.
  * Action buttons honor disabled state and styling; UI panels show improved empty-state messages and visibility-aware polling.

* **Tests**
  * Added integration and unit tests for session read-model, live vs read-only behavior, combat/order handling, and safe event-tail handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->