### PR TITLE
feat(viewer): add OpenWorlds combat surface

### DIFF
--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -1,169 +1,233 @@
-/* Screen: Combat Encounter — tactical grid, initiative, action bar */
+/* Screen: Combat Encounter - engine-owned tactical projection */
 
-function ScreenCombat({ onNavigate, state, setState }) {
-  const [tokens, setTokens] = React.useState(() => TOKENS.map((token) => ({ ...token })));
-  const [selectedToken, setSelectedToken] = React.useState("cassian");
-  const [activeAction, setActiveAction] = React.useState(null);
-  const [round, setRound] = React.useState(2);
-  const [ap, setAp] = React.useState({ standardUsed: false, moveUsed: false, swiftUsed: false });
+function combatSurfaceFromCampaign(activeCampaign, state) {
+  const campaignId = activeCampaign?.campaign_id || state?.activeCampaign || activeCampaign?.id || "";
+  const params = new URLSearchParams();
+  if (campaignId) params.set("campaign", campaignId);
+  if (activeCampaign?.source) params.set("source", activeCampaign.source);
+  if (activeCampaign?.runId) params.set("run", activeCampaign.runId);
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+function ScreenCombat({ onNavigate, state }) {
+  const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
+  const activeCampaign =
+    campaigns.find((c) => c.id === state?.activeCampaign) ||
+    campaigns[0] ||
+    {};
+  const surfaceQuery = window.combatSurfaceFromCampaign(activeCampaign, state);
+  const campaignId = activeCampaign?.campaign_id || state?.activeCampaign || activeCampaign?.id || "";
+  const [surface, setSurface] = React.useState(null);
+  const [surfaceStatus, setSurfaceStatus] = React.useState("loading");
+  const [selectedToken, setSelectedToken] = React.useState("");
+  const [localLog, setLocalLog] = React.useState([]);
+  const [busyAction, setBusyAction] = React.useState("");
   const toast = window.useToast ? window.useToast() : (() => {});
-  const [log, setLog] = React.useState([
-    { t: "round", text: "Round 1 — initiative." },
-    { t: "act", who: "Mira", text: "moves to G4 and looses a crossbow bolt at the south bandit." },
-    { t: "roll", text: "Attack roll: d20+5 = 19. Hit." },
-    { t: "dmg", text: "1d8+2 piercing = 6. Bandit south staggered." },
-    { t: "act", who: "Cassian", text: "casts shocking grasp, charges the courtyard." },
-    { t: "roll", text: "Concentration check: 18. Spell held." },
-    { t: "round", text: "Round 2 — initiative continues." },
-    { t: "act", who: "Bandit North", text: "advances. Shortbow at Vell. Misses (13 vs AC 18)." },
-  ]);
 
-  const selected = tokens.find((t) => t.id === selectedToken) || tokens[0];
+  const loadSurface = React.useCallback(async (isCancelled = () => false) => {
+    try {
+      const response = await fetch("/combat-surface" + surfaceQuery, { cache: "no-store" });
+      if (!response.ok) throw new Error(`combat surface ${response.status}`);
+      const payload = await response.json();
+      if (isCancelled()) return;
+      setSurface(payload);
+      setSurfaceStatus("ready");
+    } catch (error) {
+      if (isCancelled()) return;
+      setSurfaceStatus(error?.message || "unavailable");
+    }
+  }, [surfaceQuery]);
 
-  const onMove = (gx, gy) => {
-    if (!selected || activeAction !== "move") return;
-    setTokens((current) =>
-      current.map((token) => token.id === selected.id ? { ...token, x: gx, y: gy } : token)
-    );
-    setLog((l) => [...l, { t: "act", who: selected.name, text: `moves to ${String.fromCharCode(64 + gx)}${gy}.` }]);
-    setAp({ ...ap, moveUsed: true });
-    setActiveAction(null);
-    toast({ kind: "rest", eyebrow: "Action", title: selected.name + " moves", body: `to ${String.fromCharCode(64 + gx)}${gy}` });
+  React.useEffect(() => {
+    let cancelled = false;
+    let timer = null;
+    const guardedLoad = async () => {
+      if (cancelled) return;
+      await loadSurface(() => cancelled);
+    };
+    const stopPolling = () => {
+      if (timer !== null) {
+        window.clearInterval(timer);
+        timer = null;
+      }
+    };
+    const startPolling = () => {
+      if (timer === null) timer = window.setInterval(guardedLoad, 5000);
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        guardedLoad();
+        startPolling();
+      } else {
+        stopPolling();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    handleVisibility();
+    return () => {
+      cancelled = true;
+      stopPolling();
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [loadSurface]);
+
+  const tokens = Array.isArray(surface?.tokens) ? surface.tokens : [];
+  const initiative = Array.isArray(surface?.initiative) ? surface.initiative : [];
+  const actions = Array.isArray(surface?.actionBar) ? surface.actionBar : [];
+  const zones = Array.isArray(surface?.zones) ? surface.zones : [];
+  const battleLog = Array.isArray(surface?.battleLog) ? surface.battleLog : [];
+  const encounter = surface?.encounter || { active: false, name: "No active encounter" };
+  const economy = surface?.actionEconomy || {};
+  const canAct = Boolean(surface?.can_act);
+  const selected =
+    tokens.find((t) => t.id === selectedToken) ||
+    tokens.find((t) => t.id === surface?.selectedTokenId) ||
+    tokens[0] ||
+    null;
+  const visibleLog = [...battleLog, ...localLog];
+
+  React.useEffect(() => {
+    if (!selectedToken || !tokens.some((t) => t.id === selectedToken)) {
+      setSelectedToken(surface?.selectedTokenId || tokens[0]?.id || "");
+    }
+  }, [surface?.selectedTokenId, selectedToken, tokens]);
+
+  const actionById = (id) => actions.find((a) => a.id === id) || {};
+  const actionHint = (action) => {
+    if (!action) return "unavailable";
+    if (action.disabled_reason) return action.disabled_reason;
+    if (action.move?.name) return action.move.name;
+    if (action.move?.kind) return action.move.kind;
+    return action.available ? "ready" : "unavailable";
   };
 
-  const endTurn = () => {
-    setRound(round + 1);
-    setAp({ standardUsed: false, moveUsed: false, swiftUsed: false });
-    setActiveAction(null);
-    toast({ eyebrow: "Round", title: "Round " + (round + 1) + " begins" });
+  const postMove = async (action) => {
+    if (!action?.available || !action?.move || !canAct) {
+      toast({
+        kind: "danger",
+        eyebrow: "Combat",
+        title: action?.label ? `${action.label} unavailable` : "Action unavailable",
+        body: action?.disabled_reason || "This surface is read-only.",
+      });
+      return;
+    }
+    setBusyAction(action.id);
+    try {
+      const response = await fetch("/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...action.move, campaign: surface?.campaign_id || campaignId }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.reason || `move ${response.status}`);
+      }
+      setLocalLog((rows) => [
+        ...rows,
+        {
+          event: "player-intent",
+          title: "Player intent sent",
+          text: action.label || action.move.name || action.move.kind,
+          meta: [{ label: "lane", value: "/move" }],
+        },
+      ]);
+      await loadSurface();
+    } catch (error) {
+      toast({ kind: "danger", title: "Move not sent", body: error?.message || "The viewer could not reach /move." });
+    } finally {
+      setBusyAction("");
+    }
+  };
+
+  const actionTile = (id, fallbackIcon, fallbackLabel) => {
+    const action = actionById(id);
+    return (
+      <ActionTile
+        key={id}
+        icon={action.icon || fallbackIcon}
+        label={action.label || fallbackLabel}
+        hint={actionHint(action)}
+        active={busyAction === id}
+        disabled={!action.available || !action.move || !canAct || Boolean(busyAction)}
+        onClick={() => postMove(action)}
+      />
+    );
   };
 
   return (
-    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "1fr 280px", gap: 14, padding: 14 }}>
+    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "minmax(0, 1fr) 280px", gap: 14, padding: 14 }}>
 
       <div style={{ display: "flex", flexDirection: "column", gap: 14, minHeight: 0 }}>
-        {/* Battle map */}
         <Panel framed style={{ padding: 18, position: "relative", flex: "1 1 auto", minHeight: 0, overflow: "hidden" }}>
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 10 }}>
-            <div>
-              <div className="eyebrow" style={{ color: "var(--crimson)" }}>Encounter · Round {round}</div>
-              <h2 className="h1" style={{ fontSize: 22 }}>Lanternrest Courtyard</h2>
-            </div>
-            <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
-              <Pill tone="emerald" dot>Surprise broken</Pill>
-              <Pill dot>Cover: light</Pill>
-              <BrassButton size="sm" tone="ghost">↩ Undo</BrassButton>
-              <BrassButton size="sm" onClick={() => onNavigate("table")}>End encounter</BrassButton>
-            </div>
-          </div>
-
-          <CombatMap tokens={tokens} selected={selectedToken} onSelect={setSelectedToken} activeAction={activeAction} onMove={onMove} />
-        </Panel>
-
-        {/* Action bar */}
-        <Panel framed style={{ padding: 14, flex: "0 0 auto" }}>
-          <div style={{ display: "grid", gridTemplateColumns: "200px 1fr", gap: 16, alignItems: "center" }}>
-            <div style={{
-              display: "flex", gap: 10, alignItems: "center",
-              padding: "8px 12px",
-              background: "linear-gradient(180deg, var(--p-100), var(--p-200))",
-              boxShadow: "inset 0 0 0 1px var(--b-500), inset 0 0 0 3px var(--p-100), inset 0 0 0 4px var(--b-400)",
-            }}>
-              <Placeholder label={selected.short || "token"} w={40} h={48} framed />
-              <div>
-                <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.08em", color: "var(--ink-900)" }}>
-                  {selected.name}
-                </div>
-                <div style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-700)", marginTop: 2 }}>
-                  HP {selected.hp}/{selected.hpMax} · AC {selected.ac}
-                </div>
-                <div style={{ marginTop: 4, display: "flex", gap: 6 }}>
-                  <ApBadge used={ap.standardUsed} label="Std" />
-                  <ApBadge used={ap.moveUsed} label="Move" />
-                  <ApBadge used={ap.swiftUsed} label="Sw" />
-                </div>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 10, gap: 12 }}>
+            <div style={{ minWidth: 0 }}>
+              <div className="eyebrow" style={{ color: "var(--crimson)" }}>
+                Encounter {encounter.round ? `- Round ${encounter.round}` : ""}
+              </div>
+              <h2 className="h1" style={{ fontSize: 22, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {encounter.name || "No active encounter"}
+              </h2>
+              <div className="body-sm" style={{ color: "var(--ink-700)", marginTop: 4 }}>
+                {encounter.summary || surfaceStatus}
               </div>
             </div>
-
-            <div style={{ display: "grid", gridTemplateColumns: "repeat(7, 1fr)", gap: 6 }}>
-              <ActionTile icon="↗" label="Move" hint={ap.moveUsed ? "spent" : "6 squares"} onClick={() => !ap.moveUsed && setActiveAction("move")} active={activeAction === "move"} spent={ap.moveUsed} />
-              <ActionTile icon="⚔" label="Attack" hint={ap.standardUsed ? "spent" : "d20+5 · 1d8+2"} onClick={() => !ap.standardUsed && (setActiveAction("attack"), setAp({ ...ap, standardUsed: true }), toast({ eyebrow: "Attack", title: selected.name + " attacks", body: "d20+5 vs AC 15: 18 — hit. 7 piercing." }))} active={activeAction === "attack"} spent={ap.standardUsed} />
-              <ActionTile icon="✦" label="Cast" hint={ap.standardUsed ? "spent" : "Shocking Grasp"} onClick={() => !ap.standardUsed && (setActiveAction("cast"), setAp({ ...ap, standardUsed: true }), toast({ kind: "item", eyebrow: "Spell", title: selected.name + " casts Shocking Grasp", body: "Held in the off hand. Touch attack next." }))} active={activeAction === "cast"} spent={ap.standardUsed} />
-              <ActionTile icon="◈" label="Defend" hint="+4 AC, end turn" onClick={() => { toast({ eyebrow: "Stance", title: selected.name + " defends", body: "+4 AC until next turn." }); endTurn(); }} />
-              <ActionTile icon="◊" label="Item" hint="3 in belt" />
-              <ActionTile icon="✺" label="Dodge" hint={ap.swiftUsed ? "spent" : "opt-out reactions"} onClick={() => !ap.swiftUsed && setAp({ ...ap, swiftUsed: true })} spent={ap.swiftUsed} />
-              <ActionTile icon="⊘" label="End turn" hint="advance order" onClick={endTurn} />
+            <div style={{ display: "flex", gap: 6, alignItems: "center", flexWrap: "wrap", justifyContent: "flex-end" }}>
+              <Pill tone={canAct ? "emerald" : "crimson"} dot>{canAct ? "Live" : "Read-only"}</Pill>
+              <Pill dot>{surface?.grid?.mode === "grid" ? "Grid" : "Zones"}</Pill>
+              <BrassButton size="sm" tone="ghost" onClick={() => loadSurface()}>Refresh</BrassButton>
+              <BrassButton size="sm" onClick={() => onNavigate("table")}>Back to table</BrassButton>
             </div>
           </div>
 
-          {activeAction === "move" && (
-            <div className="hand" style={{ marginTop: 10, fontSize: 14, color: "var(--crimson)" }}>
-              Pick a tile within 6 squares. Yellow = within reach. Esc to cancel.
-            </div>
+          {encounter.active ? (
+            <CombatMap tokens={tokens} zones={zones} selected={selected?.id} onSelect={setSelectedToken} />
+          ) : (
+            <CombatEmptyState status={surfaceStatus} onNavigate={onNavigate} />
           )}
+        </Panel>
+
+        <Panel framed style={{ padding: 14, flex: "0 0 auto" }}>
+          <div style={{ display: "grid", gridTemplateColumns: "minmax(180px, 220px) 1fr", gap: 16, alignItems: "center" }}>
+            <CombatantSummary token={selected} economy={economy} />
+            <div style={{ display: "grid", gridTemplateColumns: "repeat(7, minmax(0, 1fr))", gap: 6 }}>
+              {actionTile("move", "↗", "Move")}
+              {actionTile("attack", "⚔", "Attack")}
+              {actionTile("cast", "✦", "Cast")}
+              {actionTile("bonus-action", "◈", "Bonus")}
+              {actionTile("item", "◊", "Item")}
+              {actionTile("reaction", "✺", "Reaction")}
+              {actionTile("end-turn", "⊘", "End turn")}
+            </div>
+          </div>
         </Panel>
       </div>
 
-      {/* RIGHT — initiative + log */}
       <div style={{ display: "flex", flexDirection: "column", gap: 14, minHeight: 0 }}>
         <Panel framed style={{ padding: 18 }}>
           <SectionTitle>Initiative</SectionTitle>
           <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
-            {INITIATIVE.map((t) => {
-              const tok = tokens.find((x) => x.id === t.id) || t;
-              const isFoe = tok.team === "foe";
-              const isActive = t.active;
-              const hpRatio = tok.hp ? tok.hp / tok.hpMax : 1;
+            {initiative.length ? initiative.map((row) => {
+              const tok = tokens.find((x) => x.id === row.id) || row;
               return (
-                <button key={t.id} onClick={() => setSelectedToken(t.id)} style={{
-                  display: "grid", gridTemplateColumns: "28px 36px 1fr auto", gap: 8, alignItems: "center",
-                  padding: "6px 10px",
-                  background: isActive
-                    ? "linear-gradient(180deg, var(--p-100), var(--p-200))"
-                    : selectedToken === t.id ? "rgba(176,141,87,0.18)" : "transparent",
-                  boxShadow: isActive
-                    ? "inset 0 0 0 1px var(--b-500), 0 0 16px -6px var(--gold-glow)"
-                    : "inset 0 -1px 0 rgba(140,100,60,0.2)",
-                  cursor: "pointer",
-                  textAlign: "left",
-                }}>
-                  <span style={{
-                    fontFamily: "var(--f-display)",
-                    fontSize: 14,
-                    color: isFoe ? "var(--crimson)" : "var(--ink-900)",
-                    fontWeight: 600,
-                  }}>{t.init}</span>
-                  <Placeholder label={tok.short || "?"} w={36} h={36} framed />
-                  <div style={{ minWidth: 0 }}>
-                    <div style={{
-                      fontFamily: "var(--f-display)",
-                      fontSize: 11,
-                      letterSpacing: "0.06em",
-                      color: isFoe ? "var(--crimson)" : "var(--ink-900)",
-                      fontStyle: isFoe ? "italic" : "normal",
-                      overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
-                    }}>{tok.name}</div>
-                    <div style={{ display: "flex", gap: 4, alignItems: "center", marginTop: 3 }}>
-                      <div style={{ flex: 1, height: 4, background: "rgba(0,0,0,0.15)", position: "relative", boxShadow: "inset 0 0 0 1px rgba(80,50,20,0.3)" }}>
-                        <div style={{
-                          position: "absolute", inset: 0, right: `${(1 - hpRatio) * 100}%`,
-                          background: isFoe ? "linear-gradient(180deg, var(--crimson), #4a1010)" :
-                            (hpRatio > 0.5 ? "linear-gradient(180deg, #5a8a3a, #3a6020)" : "linear-gradient(180deg, var(--crimson), #4a1010)"),
-                        }} />
-                      </div>
-                    </div>
-                  </div>
-                  {isActive && <span style={{ color: "var(--crimson)", fontFamily: "var(--f-display)", fontSize: 14 }}>▶</span>}
-                </button>
+                <InitiativeRow
+                  key={row.id}
+                  row={row}
+                  token={tok}
+                  selected={selected?.id === row.id}
+                  onClick={() => setSelectedToken(row.id)}
+                />
               );
-            })}
+            }) : <div className="body-sm" style={{ color: "var(--ink-600)" }}>No initiative order.</div>}
           </div>
         </Panel>
 
         <Panel framed style={{ padding: 18, flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
           <SectionTitle>Battle Log</SectionTitle>
-          <div style={{ flex: 1, overflow: "auto", display: "flex", flexDirection: "column", gap: 4 }}>
-            {log.map((l, i) => <BattleLogLine key={i} l={l} />)}
+          <div style={{ flex: 1, overflow: "auto", display: "flex", flexDirection: "column", gap: 6 }}>
+            {visibleLog.length
+              ? visibleLog.map((row, i) => <BattleLogLine key={`${row.event || "log"}-${i}`} l={row} />)
+              : <div className="body-sm" style={{ color: "var(--ink-600)" }}>Combat events will appear here.</div>}
           </div>
         </Panel>
       </div>
@@ -171,18 +235,68 @@ function ScreenCombat({ onNavigate, state, setState }) {
   );
 }
 
-function CombatMap({ tokens, selected, onSelect, activeAction, onMove }) {
-  const COLS = 16, ROWS = 10;
-  const selectedToken = tokens.find((t) => t.id === selected);
+function CombatantSummary({ token, economy }) {
+  if (!token) {
+    return (
+      <div style={{ padding: "8px 12px", background: "rgba(176,141,87,0.08)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.3)" }}>
+        <div style={{ fontFamily: "var(--f-display)", fontSize: 12, color: "var(--ink-800)" }}>No token selected</div>
+        <div style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-600)", marginTop: 2 }}>Open a live combat to act.</div>
+      </div>
+    );
+  }
+  const hpText = token.hpKnown ? `HP ${token.hp}/${token.hpMax}` : token.health || "unknown";
+  const acText = token.ac ? ` · AC ${token.ac}` : "";
+  return (
+    <div style={{
+      display: "flex", gap: 10, alignItems: "center",
+      padding: "8px 12px",
+      background: "linear-gradient(180deg, var(--p-100), var(--p-200))",
+      boxShadow: "inset 0 0 0 1px var(--b-500), inset 0 0 0 3px var(--p-100), inset 0 0 0 4px var(--b-400)",
+    }}>
+      <Placeholder label={token.short || token.initial || "token"} w={40} h={48} framed />
+      <div style={{ minWidth: 0 }}>
+        <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.08em", color: "var(--ink-900)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {token.name}
+        </div>
+        <div style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-700)", marginTop: 2 }}>
+          {hpText}{acText}
+        </div>
+        <div style={{ marginTop: 4, display: "flex", gap: 6 }}>
+          <ApBadge used={economy.action_available === false} label="Act" />
+          <ApBadge used={economy.bonus_available === false} label="Bonus" />
+          <ApBadge used={economy.reaction_available === false} label="React" />
+        </div>
+      </div>
+    </div>
+  );
+}
 
-  // Determine which tiles are within reach (movement = 6 squares)
-  const inRange = (gx, gy) => {
-    if (!selectedToken || activeAction !== "move") return false;
-    const dx = Math.abs(gx - selectedToken.x);
-    const dy = Math.abs(gy - selectedToken.y);
-    return Math.max(dx, dy) <= 6 && Math.max(dx, dy) > 0;
-  };
+function CombatEmptyState({ status, onNavigate }) {
+  return (
+    <div style={{
+      height: "calc(100% - 50px)",
+      display: "grid",
+      placeItems: "center",
+      background: "linear-gradient(135deg, rgba(58,36,24,0.55), rgba(37,22,14,0.65))",
+      boxShadow: "inset 0 0 0 1px var(--w-500), inset 0 0 60px rgba(0,0,0,0.45)",
+    }}>
+      <div style={{ textAlign: "center", maxWidth: 360 }}>
+        <div className="eyebrow" style={{ color: "var(--crimson)" }}>No active initiative</div>
+        <h3 className="h1" style={{ fontSize: 22, marginTop: 6 }}>Return to the table</h3>
+        <p className="body-sm" style={{ color: "var(--ink-700)", marginTop: 8 }}>{status === "ready" ? "The engine has no active combat board for this campaign." : status}</p>
+        <div style={{ marginTop: 14 }}>
+          <BrassButton size="sm" onClick={() => onNavigate("table")}>Open table</BrassButton>
+        </div>
+      </div>
+    </div>
+  );
+}
 
+function CombatMap({ tokens, zones, selected, onSelect }) {
+  const cols = 16, rows = 10;
+  const terrain = zones.length
+    ? zones.map((z) => z.name).filter(Boolean).join(" · ")
+    : "tactical field";
   return (
     <div style={{
       position: "relative",
@@ -193,66 +307,53 @@ function CombatMap({ tokens, selected, onSelect, activeAction, onMove }) {
       boxShadow: "inset 0 0 0 1px var(--w-500), inset 0 0 60px rgba(0,0,0,0.6)",
       overflow: "hidden",
     }}>
-      {/* Painted scene backdrop */}
       <div style={{ position: "absolute", inset: 12 }}>
-        <Placeholder label="terrain · courtyard · packed earth · stable wall north · gate south" h="100%" style={{ width: "100%", height: "100%", opacity: 0.5 }} />
+        <Placeholder label={terrain} h="100%" style={{ width: "100%", height: "100%", opacity: 0.5 }} />
       </div>
 
-      {/* Grid overlay */}
       <svg style={{ position: "absolute", inset: 0, width: "100%", height: "100%", pointerEvents: "none" }}>
         <defs>
-          <pattern id="gridPattern" x="0" y="0" width={`${100 / COLS}%`} height={`${100 / ROWS}%`} patternUnits="userSpaceOnUse">
+          <pattern id="openworldsCombatGrid" x="0" y="0" width={`${100 / cols}%`} height={`${100 / rows}%`} patternUnits="userSpaceOnUse">
             <rect width="100%" height="100%" fill="none" stroke="rgba(176, 141, 87, 0.18)" strokeWidth="1" />
           </pattern>
         </defs>
-        <rect width="100%" height="100%" fill="url(#gridPattern)" />
-
-        {/* Column labels */}
-        {Array.from({ length: COLS }).map((_, i) => (
-          <text key={`c${i}`} x={`${(i + 0.5) * (100 / COLS)}%`} y="12" textAnchor="middle"
+        <rect width="100%" height="100%" fill="url(#openworldsCombatGrid)" />
+        {Array.from({ length: cols }).map((_, i) => (
+          <text key={`c${i}`} x={`${(i + 0.5) * (100 / cols)}%`} y="12" textAnchor="middle"
             fontFamily="Cinzel" fontSize="9" fill="rgba(212, 185, 122, 0.4)" letterSpacing="1">
             {String.fromCharCode(65 + i)}
           </text>
         ))}
-        {/* Row labels */}
-        {Array.from({ length: ROWS }).map((_, i) => (
-          <text key={`r${i}`} x="6" y={`${(i + 0.5) * (100 / ROWS) + 3}%`}
+        {Array.from({ length: rows }).map((_, i) => (
+          <text key={`r${i}`} x="6" y={`${(i + 0.5) * (100 / rows) + 3}%`}
             fontFamily="Cinzel" fontSize="9" fill="rgba(212, 185, 122, 0.4)">{i + 1}</text>
         ))}
       </svg>
 
-      {/* Tile click overlay */}
-      <div style={{
-        position: "absolute", inset: 0,
-        display: "grid",
-        gridTemplateColumns: `repeat(${COLS}, 1fr)`,
-        gridTemplateRows: `repeat(${ROWS}, 1fr)`,
-      }}>
-        {Array.from({ length: COLS * ROWS }).map((_, idx) => {
-          const gx = (idx % COLS) + 1;
-          const gy = Math.floor(idx / COLS) + 1;
-          const reach = inRange(gx, gy);
-          return (
-            <div
-              key={idx}
-              onClick={() => reach && onMove(gx, gy)}
-              style={{
-                background: reach ? "rgba(244, 210, 123, 0.16)" : "transparent",
-                boxShadow: reach ? "inset 0 0 0 1px rgba(244, 210, 123, 0.4)" : "none",
-                cursor: reach ? "pointer" : "default",
-                transition: "background 100ms",
-              }}
-            />
-          );
-        })}
-      </div>
+      {zones.map((z, i) => (
+        <div key={z.name || i} style={{
+          position: "absolute",
+          left: `${4 + (i % 4) * 24}%`,
+          top: `${8 + Math.floor(i / 4) * 28}%`,
+          padding: "4px 7px",
+          fontFamily: "var(--f-display)",
+          fontSize: 9,
+          letterSpacing: "0.12em",
+          textTransform: "uppercase",
+          color: "rgba(244, 210, 123, 0.68)",
+          background: "rgba(30,18,10,0.32)",
+          boxShadow: "inset 0 0 0 1px rgba(176,141,87,0.18)",
+        }}>
+          {z.name}
+        </div>
+      ))}
 
-      {/* Tokens */}
       {tokens.map((t) => (
         <CombatToken
           key={t.id}
           t={t}
-          cols={COLS} rows={ROWS}
+          cols={cols}
+          rows={rows}
           selected={selected === t.id}
           onClick={() => onSelect(t.id)}
         />
@@ -261,10 +362,21 @@ function CombatMap({ tokens, selected, onSelect, activeAction, onMove }) {
   );
 }
 
+function healthRatio(t) {
+  if (t.hpKnown && Number.isFinite(Number(t.hp)) && Number.isFinite(Number(t.hpMax)) && Number(t.hpMax) > 0) {
+    return Math.max(0, Math.min(1, Number(t.hp) / Number(t.hpMax)));
+  }
+  if (t.health === "down") return 0.08;
+  if (t.health === "bloodied") return 0.38;
+  if (t.health === "wounded") return 0.68;
+  return 1;
+}
+
 function CombatToken({ t, cols, rows, selected, onClick }) {
-  const xPct = ((t.x - 0.5) / cols) * 100;
-  const yPct = ((t.y - 0.5) / rows) * 100;
+  const xPct = (((Number(t.x) || 1) - 0.5) / cols) * 100;
+  const yPct = (((Number(t.y) || 1) - 0.5) / rows) * 100;
   const isFoe = t.team === "foe";
+  const hpRatio = healthRatio(t);
   return (
     <button onClick={onClick} style={{
       position: "absolute",
@@ -293,7 +405,6 @@ function CombatToken({ t, cols, rows, selected, onClick }) {
       }}>
         {t.initial}
       </div>
-      {/* Floating HP bar */}
       <div style={{
         position: "absolute", left: "50%", bottom: -10, transform: "translateX(-50%)",
         width: 44, height: 4,
@@ -302,11 +413,10 @@ function CombatToken({ t, cols, rows, selected, onClick }) {
       }}>
         <div style={{
           position: "absolute", left: 0, top: 0, bottom: 0,
-          width: `${(t.hp / t.hpMax) * 100}%`,
+          width: `${hpRatio * 100}%`,
           background: isFoe ? "linear-gradient(180deg, #d63a3a, #8a1a1a)" : "linear-gradient(180deg, #5cd56a, #2a8c39)",
         }} />
       </div>
-      {/* Name label */}
       <div style={{
         position: "absolute", left: "50%", top: -16, transform: "translateX(-50%)",
         fontFamily: "var(--f-display)", fontSize: 8, letterSpacing: "0.15em",
@@ -318,27 +428,73 @@ function CombatToken({ t, cols, rows, selected, onClick }) {
   );
 }
 
-function ActionTile({ icon, label, hint, onClick, active, spent }) {
+function InitiativeRow({ row, token, selected, onClick }) {
+  const isFoe = row.team === "foe";
+  const hpRatio = healthRatio(token);
   return (
-    <button onClick={onClick} disabled={spent} style={{
+    <button onClick={onClick} style={{
+      display: "grid", gridTemplateColumns: "28px 36px 1fr auto", gap: 8, alignItems: "center",
+      padding: "6px 10px",
+      background: row.active
+        ? "linear-gradient(180deg, var(--p-100), var(--p-200))"
+        : selected ? "rgba(176,141,87,0.18)" : "transparent",
+      boxShadow: row.active
+        ? "inset 0 0 0 1px var(--b-500), 0 0 16px -6px var(--gold-glow)"
+        : "inset 0 -1px 0 rgba(140,100,60,0.2)",
+      cursor: "pointer",
+      textAlign: "left",
+    }}>
+      <span style={{
+        fontFamily: "var(--f-display)",
+        fontSize: 14,
+        color: isFoe ? "var(--crimson)" : "var(--ink-900)",
+        fontWeight: 600,
+      }}>{row.init ?? "-"}</span>
+      <Placeholder label={token.short || "?"} w={36} h={36} framed />
+      <div style={{ minWidth: 0 }}>
+        <div style={{
+          fontFamily: "var(--f-display)",
+          fontSize: 11,
+          letterSpacing: "0.06em",
+          color: isFoe ? "var(--crimson)" : "var(--ink-900)",
+          fontStyle: isFoe ? "italic" : "normal",
+          overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+        }}>{row.name}</div>
+        <div style={{ display: "flex", gap: 4, alignItems: "center", marginTop: 3 }}>
+          <div style={{ flex: 1, height: 4, background: "rgba(0,0,0,0.15)", position: "relative", boxShadow: "inset 0 0 0 1px rgba(80,50,20,0.3)" }}>
+            <div style={{
+              position: "absolute", left: 0, top: 0, bottom: 0, width: `${hpRatio * 100}%`,
+              background: isFoe ? "linear-gradient(180deg, var(--crimson), #4a1010)" :
+                (hpRatio > 0.5 ? "linear-gradient(180deg, #5a8a3a, #3a6020)" : "linear-gradient(180deg, var(--crimson), #4a1010)"),
+            }} />
+          </div>
+        </div>
+      </div>
+      {row.active && <span style={{ color: "var(--crimson)", fontFamily: "var(--f-display)", fontSize: 14 }}>▶</span>}
+    </button>
+  );
+}
+
+function ActionTile({ icon, label, hint, onClick, active, disabled }) {
+  return (
+    <button onClick={onClick} disabled={disabled} title={hint || label} style={{
       padding: "10px 8px",
       textAlign: "center",
       background: active
         ? "linear-gradient(180deg, var(--b-200), var(--b-400))"
-        : spent ? "rgba(0,0,0,0.18)" : "rgba(176,141,87,0.08)",
-      color: active ? "var(--w-300)" : spent ? "var(--ink-500)" : "var(--ink-800)",
+        : disabled ? "rgba(0,0,0,0.18)" : "rgba(176,141,87,0.08)",
+      color: active ? "var(--w-300)" : disabled ? "var(--ink-500)" : "var(--ink-800)",
       boxShadow: active
         ? "inset 0 0 0 1px var(--b-600), inset 0 1px 0 rgba(255,250,220,0.6), 0 0 16px -4px var(--gold-glow)"
         : "inset 0 0 0 1px rgba(140,100,60,0.3)",
-      cursor: spent ? "not-allowed" : "pointer",
+      cursor: disabled ? "not-allowed" : "pointer",
       transition: "all 140ms",
-      opacity: spent ? 0.5 : 1,
-    }}
-    onMouseEnter={(e) => { if (!active && !spent) e.currentTarget.style.background = "rgba(176,141,87,0.18)"; }}
-    onMouseLeave={(e) => { if (!active && !spent) e.currentTarget.style.background = "rgba(176,141,87,0.08)"; }}>
+      opacity: disabled ? 0.55 : 1,
+      minWidth: 0,
+    }}>
       <div style={{ fontSize: 18, lineHeight: 1, marginBottom: 4 }}>{icon}</div>
-      <div style={{ fontFamily: "var(--f-display)", fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase" }}>{label}</div>
-      {hint && <div style={{ fontFamily: "var(--f-mono)", fontSize: 8, color: active ? "var(--w-300)" : "var(--ink-600)", marginTop: 2 }}>{hint}</div>}
+      <div style={{ fontFamily: "var(--f-display)", fontSize: 9, letterSpacing: "0.12em", textTransform: "uppercase", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{label}</div>
+      {hint && <div style={{ fontFamily: "var(--f-mono)", fontSize: 8, color: active ? "var(--w-300)" : "var(--ink-600)", marginTop: 2, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{hint}</div>}
     </button>
   );
 }
@@ -357,48 +513,39 @@ function ApBadge({ used, label }) {
 }
 
 function BattleLogLine({ l }) {
-  if (l.t === "round") return (
-    <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 0", margin: "6px 0", borderTop: "1px solid rgba(140,100,60,0.3)", borderBottom: "1px solid rgba(140,100,60,0.3)" }}>
-      <span style={{ fontFamily: "var(--f-display)", fontSize: 11, letterSpacing: "0.2em", textTransform: "uppercase", color: "var(--crimson)" }}>{l.text}</span>
+  const meta = Array.isArray(l.meta) ? l.meta : [];
+  return (
+    <div style={{ padding: "5px 0", borderBottom: "1px solid rgba(140,100,60,0.16)" }}>
+      <div style={{ display: "flex", gap: 6, alignItems: "baseline" }}>
+        <span style={{ fontFamily: "var(--f-display)", fontSize: 10, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--ink-900)" }}>
+          {l.title || l.event || "Combat"}
+        </span>
+        <span className="body-sm" style={{ color: "var(--ink-700)" }}>{l.text}</span>
+      </div>
+      {meta.length > 0 && (
+        <div style={{ display: "flex", gap: 5, flexWrap: "wrap", marginTop: 4 }}>
+          {meta.map((m, i) => (
+            <span key={`${m.label}-${i}`} style={{
+              fontFamily: "var(--f-mono)",
+              fontSize: 10,
+              color: "var(--ink-600)",
+              padding: "1px 5px",
+              background: "rgba(176,141,87,0.12)",
+              boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.18)",
+            }}>{m.label}: {m.value}</span>
+          ))}
+        </div>
+      )}
     </div>
   );
-  if (l.t === "act") return (
-    <div style={{ padding: "4px 0", fontSize: 13 }}>
-      <span style={{ fontFamily: "var(--f-display)", fontSize: 10, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--ink-900)", marginRight: 6 }}>
-        {l.who}
-      </span>
-      <span className="body-sm" style={{ color: "var(--ink-700)" }}>{l.text}</span>
-    </div>
-  );
-  if (l.t === "roll") return (
-    <div style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--ink-600)", padding: "2px 12px" }}>
-      ▷ {l.text}
-    </div>
-  );
-  if (l.t === "dmg") return (
-    <div style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--crimson)", padding: "2px 12px" }}>
-      ▷ {l.text}
-    </div>
-  );
-  return null;
 }
 
-const TOKENS = [
-  { id: "cassian", name: "Cassian", initial: "C", short: "C·portrait", team: "ally", x: 5, y: 7, hp: 22, hpMax: 24, ac: 17, standardUsed: false, moveUsed: false, swiftUsed: false },
-  { id: "mira", name: "Mira", initial: "M", short: "M·portrait", team: "ally", x: 7, y: 8, hp: 18, hpMax: 22, ac: 15 },
-  { id: "vell", name: "Vell", initial: "V", short: "V·portrait", team: "ally", x: 4, y: 8, hp: 28, hpMax: 30, ac: 18 },
-  { id: "bandit-n", name: "Bandit N", initial: "♠", team: "foe", x: 11, y: 3, hp: 14, hpMax: 16, ac: 15 },
-  { id: "bandit-s", name: "Bandit S", initial: "♠", team: "foe", x: 13, y: 6, hp: 8, hpMax: 16, ac: 15 },
-  { id: "bandit-e", name: "Sgt.", initial: "♣", team: "foe", x: 13, y: 4, hp: 22, hpMax: 22, ac: 16 },
-];
-
-const INITIATIVE = [
-  { id: "mira", init: 19 },
-  { id: "cassian", init: 14, active: true },
-  { id: "bandit-e", init: 12 },
-  { id: "bandit-n", init: 11 },
-  { id: "vell", init: 9 },
-  { id: "bandit-s", init: 4 },
-];
-
-Object.assign(window, { ScreenCombat, CombatMap, CombatToken, ActionTile, ApBadge, BattleLogLine, TOKENS, INITIATIVE });
+Object.assign(window, {
+  ScreenCombat,
+  CombatMap,
+  CombatToken,
+  ActionTile,
+  ApBadge,
+  BattleLogLine,
+  combatSurfaceFromCampaign,
+});

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1032,6 +1032,342 @@ def build_session_surface(
     }
 
 
+def _combat_team(kind: object) -> str:
+    value = _text(kind).lower()
+    if value in {"monster", "enemy", "foe", "hostile"}:
+        return "foe"
+    return "ally"
+
+
+def _combat_initial(name: str, fallback: str = "?") -> str:
+    for part in name.replace("-", " ").split():
+        if part:
+            return part[0].upper()
+    return fallback[:1].upper() if fallback else "?"
+
+
+def _combat_health_label(cur_hp: object, max_hp: object) -> str:
+    cur = _num(cur_hp)
+    maxv = _num(max_hp)
+    if cur is None or maxv is None or maxv <= 0:
+        return "unknown"
+    if cur <= 0:
+        return "down"
+    ratio = cur / maxv
+    if ratio <= 0.5:
+        return "bloodied"
+    if ratio < 1:
+        return "wounded"
+    return "steady"
+
+
+def _combat_public_stat(ch: dict, *names: str) -> bool:
+    return any(bool(ch.get(name)) for name in names)
+
+
+def _combat_row_positions(snapshot: dict) -> dict[str, dict]:
+    combat = snapshot.get("combat") if isinstance(snapshot, dict) else None
+    order = combat.get("order") if isinstance(combat, dict) else None
+    if not isinstance(order, list):
+        return {}
+    out: dict[str, dict] = {}
+    for row in order:
+        if not isinstance(row, dict):
+            continue
+        cid = row.get("character_id")
+        if isinstance(cid, str) and cid.strip():
+            out[cid.strip()] = row
+    return out
+
+
+def _combat_display_position(
+    row: dict,
+    *,
+    idx: int,
+    zones: list[dict],
+    zone_offsets: dict[str, int],
+) -> tuple[int, int, str]:
+    x = _num(row.get("x") or row.get("col") or row.get("grid_x"))
+    y = _num(row.get("y") or row.get("row") or row.get("grid_y"))
+    if x is not None and y is not None:
+        return max(1, min(16, int(x))), max(1, min(10, int(y))), "grid"
+    zone_name = _text(row.get("zone"))
+    zone_index = next((i for i, z in enumerate(zones) if z.get("name") == zone_name), idx)
+    offset = zone_offsets.get(zone_name, 0)
+    zone_offsets[zone_name] = offset + 1
+    base_x = 3 + (zone_index % 4) * 4
+    base_y = 3 + (zone_index // 4) * 3
+    return max(1, min(16, base_x + offset)), max(1, min(10, base_y + (offset % 2))), "zone"
+
+
+def _combat_tokens(snapshot: dict, combat_view: dict) -> tuple[list[dict], list[dict], list[dict], str, str]:
+    chars = snapshot.get("characters") if isinstance(snapshot, dict) else {}
+    chars = chars if isinstance(chars, dict) else {}
+    raw_rows = _combat_row_positions(snapshot)
+    zones = [dict(z) for z in combat_view.get("zones", []) if isinstance(z, dict)]
+    zone_occupants: dict[str, list[str]] = {z.get("name", ""): [] for z in zones}
+    zone_offsets: dict[str, int] = {}
+    tokens: list[dict] = []
+    initiative: list[dict] = []
+    position_sources: set[str] = set()
+
+    for idx, row in enumerate(combat_view.get("order", [])):
+        if not isinstance(row, dict):
+            continue
+        cid = _text(row.get("id"))
+        raw = raw_rows.get(cid, {})
+        name = _text(row.get("name"), cid or "Unknown")
+        kind = _text(row.get("kind"))
+        team = _combat_team(kind)
+        token = {
+            "id": cid,
+            "name": name,
+            "initial": _combat_initial(name, cid),
+            "short": f"{_combat_initial(name, cid)} portrait",
+            "team": team,
+            "initiative": row.get("initiative"),
+            "isCurrent": bool(row.get("is_current")),
+            "reactionAvailable": bool(row.get("reaction_available")),
+            "conditions": [str(c) for c in row.get("conditions", []) if str(c)]
+            if isinstance(row.get("conditions"), list)
+            else [],
+        }
+        zone = _text(row.get("zone"))
+        if zone:
+            token["zone"] = zone
+            if zone in zone_occupants:
+                zone_occupants[zone].append(cid)
+        x, y, source = _combat_display_position(raw, idx=idx, zones=zones, zone_offsets=zone_offsets)
+        token["x"] = x
+        token["y"] = y
+        position_sources.add(source)
+
+        ch = chars.get(cid)
+        ch = ch if isinstance(ch, dict) else {}
+        hp = row.get("hp") if isinstance(row.get("hp"), dict) else {}
+        cur_hp = hp.get("current") if isinstance(hp, dict) else None
+        max_hp = hp.get("max") if isinstance(hp, dict) else None
+        hp_known = team != "foe" or _combat_public_stat(ch, "hp_known", "known_hp", "player_known_hp")
+        token["hpKnown"] = bool(hp_known)
+        token["health"] = _combat_health_label(cur_hp, max_hp)
+        if hp_known:
+            token["hp"] = cur_hp if cur_hp is not None else 1
+            token["hpMax"] = max_hp if max_hp not in (None, 0) else token["hp"] or 1
+        ac = row.get("ac")
+        if team != "foe" or _combat_public_stat(ch, "ac_known", "known_ac", "player_known_ac"):
+            if ac is not None:
+                token["ac"] = ac
+        tokens.append(token)
+        initiative.append({
+            "id": cid,
+            "name": name,
+            "init": row.get("initiative"),
+            "active": bool(row.get("is_current")),
+            "team": team,
+            "health": token["health"],
+            "reactionAvailable": token["reactionAvailable"],
+        })
+
+    for zone in zones:
+        name = _text(zone.get("name"))
+        zone["occupants"] = zone_occupants.get(name, [])
+    mode = "grid" if "grid" in position_sources else "zones"
+    selected = next((t["id"] for t in tokens if t.get("isCurrent")), tokens[0]["id"] if tokens else "")
+    return tokens, initiative, zones, selected, mode
+
+
+def _combat_action_bar(action_model: dict, combat_active: bool) -> list[dict]:
+    by_id = {a["id"]: a for a in _session_available_actions(action_model) if a.get("id")}
+    live = bool(action_model.get("live"))
+    is_live_view = bool(action_model.get("is_live_view"))
+    actor = action_model.get("actor")
+    combat = action_model.get("combat") if isinstance(action_model.get("combat"), dict) else {}
+
+    def base_reason() -> str | None:
+        if not combat_active:
+            return "not in combat"
+        if actor is None:
+            return "no active character"
+        if not live:
+            return "no live move sink"
+        if not is_live_view:
+            return "viewing non-live campaign"
+        if not combat.get("is_current_turn"):
+            return "not current turn"
+        return None
+
+    def from_model(action_id: str, label: str, icon: str, fallback_reason: str | None = None) -> dict:
+        item = dict(by_id.get(action_id) or {
+            "id": action_id,
+            "label": label,
+            "available": False,
+            "disabled_reason": fallback_reason or base_reason() or "not engine-backed yet",
+        })
+        item.setdefault("id", action_id)
+        item.setdefault("label", label)
+        item["icon"] = icon
+        item.setdefault("available", False)
+        item.setdefault("disabled_reason", None if item.get("available") else fallback_reason or base_reason())
+        return item
+
+    end_reason = base_reason()
+    end_turn = {
+        "id": "end-turn",
+        "label": "End turn",
+        "icon": "⊘",
+        "available": end_reason is None,
+        "disabled_reason": end_reason,
+    }
+    if end_reason is None:
+        end_turn["move"] = {"kind": "combat", "name": "End Turn"}
+
+    return [
+        {
+            "id": "move",
+            "label": "Move",
+            "icon": "↗",
+            "available": False,
+            "disabled_reason": "movement destinations not projected yet",
+        },
+        from_model("attack", "Attack", "⚔", base_reason()),
+        {
+            "id": "cast",
+            "label": "Cast",
+            "icon": "✦",
+            "available": False,
+            "disabled_reason": "spell choices not projected yet",
+        },
+        from_model("bonus-action", "Bonus", "◈", base_reason()),
+        {
+            "id": "item",
+            "label": "Item",
+            "icon": "◊",
+            "available": False,
+            "disabled_reason": "inventory combat actions not projected yet",
+        },
+        from_model("reaction", "Reaction", "✺", base_reason()),
+        end_turn,
+    ]
+
+
+def _combat_ref(value: object) -> dict | None:
+    if not isinstance(value, dict):
+        return None
+    rid = _text(value.get("id"))
+    name = _text(value.get("name"), rid)
+    if not rid and not name:
+        return None
+    out = {"name": name}
+    if rid:
+        out["id"] = rid
+    return out
+
+
+def _combat_log_meta(label: str, value: object) -> dict | None:
+    if value in (None, ""):
+        return None
+    return {"label": label, "value": value}
+
+
+def _combat_battle_log(raw_events: list[dict] | None) -> list[dict]:
+    out: list[dict] = []
+    for row in raw_events or []:
+        if not isinstance(row, dict):
+            continue
+        payload = row.get("payload")
+        text = _text(row.get("text") or row.get("detail") or row.get("summary"))
+        item = {"event": _text(row.get("kind") or row.get("type"), "combat"), "text": text[:1000]}
+        if isinstance(payload, dict) and payload.get("schema") == "clawdnd.combat_event.v1":
+            event = _text(payload.get("event"), "combat")
+            actor = _combat_ref(payload.get("actor"))
+            target = _combat_ref(payload.get("target"))
+            title = "Combat"
+            if actor and target:
+                title = f"{actor['name']} -> {target['name']}"
+            elif actor or target:
+                title = (actor or target or {}).get("name", "Combat")
+            meta: list[dict] = []
+            roll = payload.get("roll")
+            if isinstance(roll, dict):
+                meta.extend(x for x in [
+                    _combat_log_meta("d20", roll.get("natural")),
+                    _combat_log_meta("roll", roll.get("total")),
+                ] if x)
+            damage = payload.get("damage")
+            if isinstance(damage, dict):
+                dmg = damage.get("total")
+                dtype = _text(damage.get("type"))
+                meta.append({"label": "Damage", "value": f"{dmg}{' ' + dtype if dtype else ''}"})
+            item = {
+                "event": event,
+                "title": title,
+                "text": text[:1000] if text else title,
+                "actor": actor,
+                "target": target,
+                "meta": meta[:5],
+            }
+        if item.get("text") or item.get("title"):
+            out.append(item)
+        if len(out) >= 12:
+            break
+    return out
+
+
+def build_combat_surface(
+    snapshot: dict,
+    *,
+    campaign_id: str,
+    live: bool,
+    is_live_view: bool,
+    recent_events: list[dict] | None = None,
+) -> dict:
+    """Project a browser-safe OpenWorlds combat board from engine-owned state."""
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    location = _session_location(snapshot)
+    combat_view = build_combat_view(snapshot)
+    action_model = build_action_model(snapshot, live=live, is_live_view=is_live_view)
+    combat_active = bool(combat_view.get("active"))
+    tokens, initiative, zones, selected, mode = _combat_tokens(snapshot, combat_view)
+    action_bar = _combat_action_bar(action_model, combat_active)
+    can_act = bool(live and is_live_view and combat_active)
+    battle_log = _combat_battle_log(recent_events)
+    summary = _text(snapshot.get("summary"))
+    if not summary:
+        summary = (
+            f"Combat round {combat_view.get('round')}"
+            if combat_active and combat_view.get("round") else
+            _text(location.get("description"), "No active combat.")
+        )
+
+    return {
+        "campaign_id": campaign_id,
+        "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
+        "world": _text(snapshot.get("world_id"), "unknown"),
+        "dayLabel": _openworlds_day_label(snapshot),
+        "location": location,
+        "encounter": {
+            "active": combat_active,
+            "name": location["name"] if combat_active else "No active encounter",
+            "summary": summary,
+            "round": combat_view.get("round") if combat_active else None,
+            "warnings": combat_view.get("warnings", []),
+        },
+        "grid": {"mode": mode, "cols": 16, "rows": 10},
+        "tokens": tokens,
+        "initiative": initiative,
+        "zones": zones,
+        "selectedTokenId": selected,
+        "actionEconomy": (combat_view.get("actions") if combat_active else {}) or {},
+        "actionBar": action_bar,
+        "battleLog": battle_log,
+        "live": bool(live),
+        "is_live_view": bool(is_live_view),
+        "can_act": can_act,
+        "state_authority": "engine",
+        "write_lane": "/move",
+    }
+
+
 def _relative_time_label(ts: float, *, now: float) -> str:
     if ts <= 0:
         return "unknown"
@@ -2148,6 +2484,8 @@ def _openworlds_config() -> dict:
         "mode": "viewer-read-model",
         "api_base": "",
         "campaign_catalog": "/openworlds/campaigns.json",
+        "session_surface": "/session-surface",
+        "combat_surface": "/combat-surface",
         "state_authority": "engine",
         "write_lane": "/move",
         "demo_data": False,
@@ -2323,6 +2661,34 @@ class _Handler(BaseHTTPRequestHandler):
             if not isinstance(raw_snap, dict):
                 raw_snap = {}
             self._json(build_session_surface(
+                raw_snap,
+                campaign_id=cid,
+                live=live,
+                is_live_view=live and cid == self.campaign_id,
+                recent_events=_session_event_tail(cid),
+            ))
+        elif route == "/combat-surface":
+            qs = parse_qs(parsed.query)
+            live = _live_play()
+            catalog_ref = _session_surface_catalog_ref(qs)
+            if catalog_ref is not None:
+                cid, raw_snap, campaign_dir, root_is_current = catalog_ref
+                self._json(build_combat_surface(
+                    raw_snap,
+                    campaign_id=cid,
+                    live=live,
+                    is_live_view=bool(live and root_is_current and cid == self.campaign_id),
+                    recent_events=_session_event_tail_from_dir(campaign_dir, raw_snap),
+                ))
+                return
+            cid = self._view_campaign(qs)
+            if not cid:
+                self._json(build_combat_surface({}, campaign_id="", live=live, is_live_view=False))
+                return
+            raw_snap = _read_snapshot(cid)
+            if not isinstance(raw_snap, dict):
+                raw_snap = {}
+            self._json(build_combat_surface(
                 raw_snap,
                 campaign_id=cid,
                 live=live,

--- a/viewer/tests/test_combat_surface.py
+++ b/viewer/tests/test_combat_surface.py
@@ -1,0 +1,214 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+def _find_action(surface: dict, action_id: str) -> dict:
+    found = next((a for a in surface["actionBar"] if a["id"] == action_id), None)
+    if found is None:
+        available = [a.get("id") for a in surface["actionBar"] if isinstance(a, dict)]
+        raise AssertionError(f"action {action_id!r} not found in actionBar: {available}")
+    return found
+
+
+class CombatSurfaceTests(unittest.TestCase):
+    def test_combat_surface_projects_engine_owned_board_without_private_fields(self):
+        snapshot = {
+            "id": "camp_combat",
+            "title": "Ambush at the Gate",
+            "summary": "Steel rings under the Basilisk Gate.",
+            "world_id": "baldurs-gate",
+            "current_location_id": "gate",
+            "locations": {
+                "gate": {
+                    "name": "Basilisk Gate",
+                    "description": "A rain-slick gatehouse with overturned carts.",
+                    "notes": "private route through the guard tower",
+                },
+            },
+            "party": ["hero"],
+            "characters": {
+                "hero": {
+                    "id": "hero",
+                    "name": "Tav",
+                    "kind": "player",
+                    "current_hp": 18,
+                    "max_hp": 24,
+                    "armor_class": 17,
+                    "conditions": ["blessed"],
+                    "notes": "private player note",
+                },
+                "gob": {
+                    "id": "gob",
+                    "name": "Goblin Sapper",
+                    "kind": "monster",
+                    "current_hp": 3,
+                    "max_hp": 7,
+                    "armor_class": 13,
+                    "conditions": ["prone"],
+                    "notes": "secret satchel weakness",
+                },
+            },
+            "combat": {
+                "active": True,
+                "round": 2,
+                "turn_index": 0,
+                "action_used": False,
+                "bonus_action_used": True,
+                "zones": [
+                    {"name": "gate", "description": "broken carts and torchlight", "adjacent": ["road"]},
+                    {"name": "road", "description": "muddy road", "adjacent": ["gate"]},
+                ],
+                "order": [
+                    {"character_id": "hero", "initiative": 18, "reaction_used": False, "zone": "gate"},
+                    {"character_id": "gob", "initiative": 9, "reaction_used": True, "zone": "road"},
+                ],
+            },
+            "dm_notes": "private combat agenda",
+        }
+        recent_events = [
+            {
+                "kind": "combat",
+                "text": "Tav strikes the sapper.",
+                "payload": {
+                    "schema": "clawdnd.combat_event.v1",
+                    "event": "attack",
+                    "actor": {"id": "hero", "name": "Tav", "notes": "private actor note"},
+                    "target": {"id": "gob", "name": "Goblin Sapper", "ac": 13, "notes": "private target note"},
+                    "roll": {"natural": 13, "total": 18},
+                    "damage": {"total": 6, "type": "slashing"},
+                    "secret": "private payload strategy",
+                },
+            }
+        ]
+
+        surface = server.build_combat_surface(
+            snapshot,
+            campaign_id="camp_combat",
+            live=True,
+            is_live_view=True,
+            recent_events=recent_events,
+        )
+
+        self.assertEqual(surface["campaign_id"], "camp_combat")
+        self.assertEqual(surface["state_authority"], "engine")
+        self.assertEqual(surface["write_lane"], "/move")
+        self.assertTrue(surface["can_act"])
+        self.assertEqual(surface["encounter"]["name"], "Basilisk Gate")
+        self.assertEqual(surface["encounter"]["round"], 2)
+        self.assertEqual(surface["selectedTokenId"], "hero")
+        self.assertEqual(surface["grid"], {"mode": "zones", "cols": 16, "rows": 10})
+        self.assertEqual([t["id"] for t in surface["tokens"]], ["hero", "gob"])
+        self.assertEqual(surface["tokens"][0]["ac"], 17)
+        self.assertEqual(surface["tokens"][0]["hp"], 18)
+        self.assertEqual(surface["tokens"][0]["conditions"], ["blessed"])
+        self.assertEqual(surface["tokens"][1]["team"], "foe")
+        self.assertNotIn("ac", surface["tokens"][1])
+        self.assertFalse(surface["tokens"][1]["hpKnown"])
+        self.assertEqual(surface["tokens"][1]["health"], "bloodied")
+        self.assertEqual(surface["initiative"][0]["name"], "Tav")
+        self.assertTrue(surface["initiative"][0]["active"])
+        self.assertEqual(surface["zones"][0]["occupants"], ["hero"])
+        self.assertEqual(surface["zones"][1]["occupants"], ["gob"])
+        self.assertEqual(_find_action(surface, "attack")["move"], {"kind": "attack", "name": "Attack"})
+        self.assertFalse(_find_action(surface, "bonus-action")["available"])
+        self.assertEqual(_find_action(surface, "bonus-action")["disabled_reason"], "bonus action spent")
+        self.assertEqual(surface["battleLog"][0]["event"], "attack")
+        self.assertEqual(surface["battleLog"][0]["title"], "Tav -> Goblin Sapper")
+        self.assertEqual(surface["battleLog"][0]["meta"][0], {"label": "d20", "value": 13})
+        self.assertNotIn("combatView", surface)
+        self.assertNotIn("actionModel", surface)
+
+        encoded = json.dumps(surface)
+        for forbidden in (
+            "notes",
+            "dm_notes",
+            "secret",
+            "private",
+            "payload strategy",
+            "guard tower",
+            "satchel weakness",
+        ):
+            self.assertNotIn(forbidden, encoded)
+        self.assert_no_private_keys(surface)
+
+    def test_combat_surface_fails_closed_when_not_live_or_not_current_turn(self):
+        snapshot = {
+            "party": ["hero"],
+            "characters": {
+                "hero": {"id": "hero", "name": "Tav", "kind": "player"},
+                "gob": {"id": "gob", "name": "Goblin", "kind": "monster"},
+            },
+            "combat": {
+                "active": True,
+                "round": 1,
+                "turn_index": 1,
+                "order": [
+                    {"character_id": "hero", "initiative": 18},
+                    {"character_id": "gob", "initiative": 9},
+                ],
+            },
+        }
+
+        surface = server.build_combat_surface(
+            snapshot,
+            campaign_id="camp_readonly",
+            live=False,
+            is_live_view=False,
+        )
+
+        self.assertFalse(surface["can_act"])
+        self.assertEqual(_find_action(surface, "attack")["disabled_reason"], "no live move sink")
+        self.assertEqual(_find_action(surface, "end-turn")["disabled_reason"], "no live move sink")
+        self.assertEqual(surface["selectedTokenId"], "gob")
+        self.assertEqual(surface["tokens"][0]["team"], "ally")
+        self.assertEqual(surface["tokens"][1]["team"], "foe")
+
+    def test_combat_surface_degrades_to_empty_state_without_active_combat(self):
+        surface = server.build_combat_surface(
+            {"title": "Quiet Camp"},
+            campaign_id="camp_empty",
+            live=True,
+            is_live_view=True,
+        )
+
+        self.assertFalse(surface["encounter"]["active"])
+        self.assertEqual(surface["tokens"], [])
+        self.assertEqual(surface["initiative"], [])
+        self.assertFalse(surface["can_act"])
+        self.assertEqual(_find_action(surface, "attack")["disabled_reason"], "not in combat")
+
+    def assert_no_private_keys(self, value) -> None:
+        private_keys = {
+            "notes",
+            "dm_notes",
+            "scenes",
+            "lore",
+            "memory",
+            "personality",
+            "backstory",
+            "companion_dossier",
+            "sealed_agenda",
+            "agenda",
+            "secret",
+        }
+        if isinstance(value, dict):
+            for key, child in value.items():
+                self.assertNotIn(key, private_keys)
+                self.assert_no_private_keys(child)
+        elif isinstance(value, list):
+            for child in value:
+                self.assert_no_private_keys(child)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -93,6 +93,18 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn(b"fonts/", body)
         self.assertNotIn(b"https://", body)
 
+    def test_openworlds_combat_screen_binds_viewer_combat_surface(self):
+        status, ctype, body = self._get("/openworlds/screen-combat.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        self.assertIn('fetch("/combat-surface', source)
+        self.assertIn('fetch("/move"', source)
+        self.assertIn("window.combatSurfaceFromCampaign", source)
+        self.assertNotIn("TOKENS.map", source)
+        self.assertNotIn("setTokens", source)
+
     def test_openworlds_rejects_path_traversal(self):
         self.assertEqual(self._status("/openworlds/../server.py"), 404)
         self.assertEqual(self._status("/openworlds/%2e%2e/server.py"), 404)
@@ -290,6 +302,117 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertEqual(surface["title"], "QA Table Save")
         self.assertEqual(surface["location"]["name"], "QA Location")
         self.assertEqual(surface["party"][0]["name"], "QA Tav")
+        self.assertFalse(surface["can_act"])
+        self.assertFalse(surface["is_live_view"])
+
+    def test_combat_surface_route_projects_selected_campaign_safely(self):
+        campaign_dir = self._tmp / "campaigns" / "camp_combat"
+        self._write_snapshot(
+            campaign_dir,
+            {
+                "id": "camp_combat",
+                "title": "Combat Save",
+                "summary": "A fight at the gate.",
+                "current_location_id": "gate",
+                "locations": {
+                    "gate": {"name": "Basilisk Gate", "notes": "private map bypass"},
+                },
+                "party": ["hero"],
+                "characters": {
+                    "hero": {
+                        "id": "hero",
+                        "name": "Tav",
+                        "kind": "player",
+                        "current_hp": 12,
+                        "max_hp": 20,
+                        "armor_class": 16,
+                    },
+                    "gob": {
+                        "id": "gob",
+                        "name": "Goblin",
+                        "kind": "monster",
+                        "armor_class": 13,
+                        "notes": "private monster note",
+                    },
+                },
+                "combat": {
+                    "active": True,
+                    "round": 2,
+                    "turn_index": 0,
+                    "order": [
+                        {"character_id": "hero", "initiative": 18},
+                        {"character_id": "gob", "initiative": 9},
+                    ],
+                },
+                "dm_notes": "private route agenda",
+            },
+        )
+
+        status, ctype, body = self._get("/combat-surface?campaign=camp_combat")
+
+        self.assertEqual(status, 200)
+        self.assertIn("application/json", ctype)
+        surface = json.loads(body.decode("utf-8"))
+        self.assertEqual(surface["campaign_id"], "camp_combat")
+        self.assertEqual(surface["state_authority"], "engine")
+        self.assertEqual(surface["write_lane"], "/move")
+        self.assertEqual(surface["encounter"]["name"], "Basilisk Gate")
+        self.assertTrue(surface["encounter"]["active"])
+        self.assertEqual([t["id"] for t in surface["tokens"]], ["hero", "gob"])
+        self.assertNotIn("ac", surface["tokens"][1])
+        encoded = json.dumps(surface)
+        self.assertNotIn("private map", encoded)
+        self.assertNotIn("private monster", encoded)
+        self.assertNotIn("private route", encoded)
+        self.assert_no_private_keys(surface)
+
+    def test_combat_surface_route_projects_catalog_run_read_only(self):
+        repo_root = self._tmp / "repo"
+        (repo_root / "viewer").mkdir(parents=True)
+        server._HERE = repo_root / "viewer"
+        qa_campaign = repo_root / "qa" / "state" / "wave3-red" / "campaigns" / "camp_qa"
+        self._write_snapshot(
+            qa_campaign,
+            {
+                "id": "camp_qa",
+                "title": "QA Combat Save",
+                "current_location_id": "qa-arena",
+                "locations": {"qa-arena": {"name": "QA Arena"}},
+                "party": ["hero"],
+                "characters": {
+                    "hero": {"id": "hero", "name": "QA Tav", "kind": "player"},
+                    "gob": {"id": "gob", "name": "QA Goblin", "kind": "monster"},
+                },
+                "combat": {
+                    "active": True,
+                    "round": 4,
+                    "turn_index": 1,
+                    "order": [
+                        {"character_id": "hero", "initiative": 18},
+                        {"character_id": "gob", "initiative": 9},
+                    ],
+                },
+            },
+        )
+        self._write_snapshot(
+            self._tmp / "campaigns" / "camp_live",
+            {
+                "id": "camp_live",
+                "title": "Live Combat Save",
+                "party": [],
+                "characters": {},
+            },
+        )
+        _QuietHandler.campaign_id = "camp_live"
+
+        status, _ctype, body = self._get("/combat-surface?source=qa&run=wave3-red&campaign=camp_qa")
+
+        self.assertEqual(status, 200)
+        surface = json.loads(body.decode("utf-8"))
+        self.assertEqual(surface["campaign_id"], "camp_qa")
+        self.assertEqual(surface["title"], "QA Combat Save")
+        self.assertEqual(surface["encounter"]["round"], 4)
+        self.assertEqual(surface["selectedTokenId"], "gob")
         self.assertFalse(surface["can_act"])
         self.assertFalse(surface["is_live_view"])
 


### PR DESCRIPTION
## Summary

Refs #116.

Adds the next OpenWorlds fidelity rollout slice: a viewer-hosted, engine-owned combat board read model plus a bound OpenWorlds Battle screen.

- Adds `GET /combat-surface` beside `/session-surface`.
- Projects active combat into a browser-safe `CombatSurface`: encounter header, tokens, initiative, zones, action economy, action bar, and structured battle log.
- Binds `viewer/openworlds/screen-combat.jsx` to `/combat-surface` instead of locally mutating prototype token state.
- Keeps all state-changing combat controls on the existing `POST /move` lane.
- Fails closed for unavailable actions: movement, spell choice, and item combat actions remain disabled until the engine/action model supplies backed destinations or choices.
- Hides raw combat/action internals from the combat API so exact monster AC/HP and private snapshot fields do not leak through nested payloads.

## Architecture Notes

The viewer remains a read/adaptation layer:

- `build_combat_surface(...)` derives from engine-owned snapshot state via existing `build_combat_view(...)` and `build_action_model(...)`.
- Browser code never decides hits, damage, movement legality, spell legality, initiative, action spend, death saves, concentration, or state persistence.
- Enabled actions carry only existing `/move` payloads such as `{ kind: "attack", name: "Attack" }` or `{ kind: "combat", name: "End Turn" }`.
- Disabled actions render with explicit reasons rather than inventing browser-side mechanics.
- The public token model reveals exact ally HP/AC, but foe exact HP/AC only when explicit known-stat flags exist; otherwise foes show coarse health labels.
- Structured combat log cards whitelist event fields and do not expose raw payloads.

## Files To Review

- `viewer/server.py`
  - `build_combat_surface`
  - `_combat_tokens`
  - `_combat_action_bar`
  - `_combat_battle_log`
  - `/combat-surface` route
- `viewer/openworlds/screen-combat.jsx`
  - `combatSurfaceFromCampaign`
  - `ScreenCombat`
  - `/move` submission path
- `viewer/tests/test_combat_surface.py`
- `viewer/tests/test_openworlds_static.py`

## Validation

Local validation from `/Volumes/LEXAR/repos/ClawDnD-openworlds-combat-board`:

```bash
python3 -m py_compile viewer/server.py
python3 -m unittest discover -s viewer/tests -q
python3 scripts/license_check.py
git diff --check
```

Rendered smoke:

```bash
CLAWDND_STATE_DIR=/Volumes/LEXAR/Codex/clawdnd-combat-surface-smoke python3 viewer/server.py camp_combat 18766
```

Then Chrome/Playwright against `http://127.0.0.1:18766/openworlds/`, keyboard shortcut `x`:

- `Basilisk Gate`, `Tav`, and `Goblin Sapper` rendered.
- Battle log rendered `Tav -> Goblin Sapper` / attack text.
- Private strings were absent from page text.
- No page errors.
- Only known development warnings appeared: React DevTools info and Babel standalone production warning.

Screenshot artifact:

- `/Volumes/LEXAR/Codex/clawdnd-combat-surface-smoke/openworlds-combat-1440x900.png`

## Rollback Notes

This PR is viewer-only. It does not change engine/rules/voice APIs or campaign persistence. Reverting it removes `/combat-surface` and restores the prototype Battle screen behavior without touching saved campaign state.
