### PR TITLE
feat(viewer): add OpenWorlds atlas surface

### DIFF
--- a/viewer/openworlds/screen-map.jsx
+++ b/viewer/openworlds/screen-map.jsx
@@ -1,41 +1,166 @@
-/* Screen: World Map — hand-drawn cartography with location nodes */
+/* Screen: World Map - engine-owned atlas and strategic read model */
 
-function ScreenMap({ onNavigate, state, setState, campMode, setCampMode }) {
-  const locations = Array.isArray(state?.locations) ? state.locations : [];
-  const party = Array.isArray(state?.party) ? state.party : [];
-  const [selected, setSelected] = React.useState(() => locations.find((l) => l.current) || locations[0] || null);
+function atlasSurfaceFromCampaign(activeCampaign, state) {
+  const campaignId = activeCampaign?.campaign_id || state?.activeCampaign || activeCampaign?.id || "";
+  const params = new URLSearchParams();
+  if (campaignId) params.set("campaign", campaignId);
+  if (activeCampaign?.source) params.set("source", activeCampaign.source);
+  if (activeCampaign?.runId) params.set("run", activeCampaign.runId);
+  const query = params.toString();
+  return query ? `?${query}` : "";
+}
+
+function ScreenMap({ onNavigate, state, campMode, setCampMode }) {
+  const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
+  const activeCampaign =
+    campaigns.find((c) => c.id === state?.activeCampaign) ||
+    campaigns[0] ||
+    {};
+  const surfaceQuery = window.atlasSurfaceFromCampaign(activeCampaign, state);
+  const campaignId = activeCampaign?.campaign_id || state?.activeCampaign || activeCampaign?.id || "";
+  const [surface, setSurface] = React.useState(null);
+  const [surfaceStatus, setSurfaceStatus] = React.useState("loading");
+  const [selectedId, setSelectedId] = React.useState("");
   const [time, setTime] = React.useState("dusk");
+  const [busyTravel, setBusyTravel] = React.useState("");
   const [talkPartner, setTalkPartner] = React.useState(null);
   const toast = window.useToast ? window.useToast() : (() => {});
 
+  const loadSurface = React.useCallback(async (isCancelled = () => false) => {
+    try {
+      const response = await fetch("/atlas-surface" + surfaceQuery, { cache: "no-store" });
+      if (!response.ok) throw new Error(`atlas surface ${response.status}`);
+      const payload = await response.json();
+      if (isCancelled()) return;
+      setSurface(payload);
+      setSurfaceStatus("ready");
+      const label = (payload.dayLabel || "").toLowerCase();
+      if (label.includes("night")) setTime("night");
+      else if (label.includes("dawn") || label.includes("morning")) setTime("dawn");
+      else if (label.includes("dusk") || label.includes("evening")) setTime("dusk");
+      else if (label.includes("day") || label.includes("noon")) setTime("day");
+    } catch (error) {
+      if (isCancelled()) return;
+      setSurfaceStatus(error?.message || "unavailable");
+    }
+  }, [surfaceQuery]);
+
   React.useEffect(() => {
-    if (locations.length === 0) {
-      if (selected) setSelected(null);
+    let cancelled = false;
+    let timer = null;
+    const guardedLoad = async () => {
+      if (cancelled) return;
+      await loadSurface(() => cancelled);
+    };
+    const stopPolling = () => {
+      if (timer !== null) {
+        window.clearInterval(timer);
+        timer = null;
+      }
+    };
+    const startPolling = () => {
+      if (timer === null) timer = window.setInterval(guardedLoad, 7000);
+    };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") {
+        guardedLoad();
+        startPolling();
+      } else {
+        stopPolling();
+      }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    handleVisibility();
+    return () => {
+      cancelled = true;
+      stopPolling();
+      document.removeEventListener("visibilitychange", handleVisibility);
+    };
+  }, [loadSurface]);
+
+  const locations = Array.isArray(surface?.known_locations) ? surface.known_locations : [];
+  const edges = Array.isArray(surface?.edges) ? surface.edges : [];
+  const travelOptions = Array.isArray(surface?.travel_options) ? surface.travel_options : [];
+  const quests = Array.isArray(surface?.quest_markers) ? surface.quest_markers : [];
+  const clocks = Array.isArray(surface?.strategic_clocks) ? surface.strategic_clocks : [];
+  const projects = Array.isArray(surface?.downtime_projects) ? surface.downtime_projects : [];
+  const controls = Array.isArray(surface?.region_control) ? surface.region_control : [];
+  const currentLocation = surface?.current_location || {};
+  const selected =
+    locations.find((l) => l.id === selectedId) ||
+    locations.find((l) => l.id === currentLocation.id) ||
+    locations[0] ||
+    null;
+  const selectedTravel = selected ? travelOptions.find((t) => t.to === selected.id) : null;
+  const canCamp = Boolean(surface?.camp_available);
+  const canAct = Boolean(surface?.can_act);
+
+  React.useEffect(() => {
+    if (!selectedId || !locations.some((l) => l.id === selectedId)) {
+      setSelectedId(currentLocation.id || locations[0]?.id || "");
+    }
+  }, [currentLocation.id, locations, selectedId]);
+
+  const postTravel = async (option) => {
+    if (!option?.available || !option?.move || !canAct) {
+      toast({
+        kind: "danger",
+        eyebrow: "Travel",
+        title: option?.name ? `Cannot travel to ${option.name}` : "Travel unavailable",
+        body: option?.disabled_reason || "This atlas is read-only.",
+      });
       return;
     }
-    if (!selected || !locations.find((l) => l.id === selected.id)) {
-      setSelected(locations.find((l) => l.current) || locations[0] || null);
+    setBusyTravel(option.to);
+    try {
+      const response = await fetch("/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...option.move, campaign: surface?.campaign_id || campaignId }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.reason || `move ${response.status}`);
+      }
+      toast({ kind: "quest", title: "Travel intent sent", body: option.name || option.to });
+      onNavigate("table");
+    } catch (error) {
+      toast({ kind: "danger", title: "Move not sent", body: error?.message || "The viewer could not reach /move." });
+    } finally {
+      setBusyTravel("");
     }
-  }, [locations, selected?.id]);
-
-  const beginRest = () => {
-    toast({ kind: "rest", eyebrow: "Long rest", title: "The camp settles", body: "10 hours pass. Wounds knit. Spells return. The road is patient." });
-    setCampMode && setCampMode(false);
-    setTalkPartner(null);
-    setTimeout(() => onNavigate("character"), 600);
   };
 
-  return (
-    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "1fr 340px", gap: 14, padding: 14 }}>
+  const beginRest = () => {
+    toast({
+      kind: "rest",
+      eyebrow: "Camp",
+      title: canCamp ? "Camp is visible" : "Camp unavailable",
+      body: canCamp
+        ? "The atlas can show camp mode, but rest resolution remains engine-owned."
+        : "The current location is not marked as a camp or rest point.",
+    });
+  };
 
-      {/* MAP CANVAS */}
+  const locationQuests = selected ? quests.filter((q) => !q.location_id || q.location_id === selected.id) : quests;
+  const locationClocks = selected ? clocks.filter((c) => !c.location_id || c.location_id === selected.id) : clocks;
+  const locationProjects = selected ? projects.filter((p) => !p.location_id || p.location_id === selected.id) : projects;
+  const locationControl = selected ? controls.find((c) => c.location_id === selected.id) : null;
+
+  return (
+    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "minmax(0, 1fr) 340px", gap: 14, padding: 14 }}>
       <Panel framed style={{ padding: 18, position: "relative", display: "flex", flexDirection: "column", minHeight: 0, overflow: "hidden" }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 10, position: "relative", zIndex: 3, flex: "0 0 auto" }}>
-          <div>
-            <div className="eyebrow" style={{ color: "var(--crimson)" }}>The Stolen Marches</div>
-            <h1 className="h1" style={{ fontSize: 24 }}>{campMode ? "Camp" : "World Atlas"}</h1>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 10, position: "relative", zIndex: 3, flex: "0 0 auto", gap: 12 }}>
+          <div style={{ minWidth: 0 }}>
+            <div className="eyebrow" style={{ color: "var(--crimson)" }}>{surface?.world || "Open Worlds"}</div>
+            <h1 className="h1" style={{ fontSize: 24, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {campMode ? "Camp" : "World Atlas"}
+            </h1>
+            <div className="body-sm" style={{ color: "var(--ink-700)", marginTop: 3 }}>
+              {surface?.dayLabel || surfaceStatus}
+            </div>
           </div>
-          <div style={{ display: "flex", gap: 6 }}>
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
             {!campMode && ["dawn", "day", "dusk", "night"].map((t) => (
               <button key={t} onClick={() => setTime(t)} className="pill" style={{
                 cursor: "pointer",
@@ -44,221 +169,265 @@ function ScreenMap({ onNavigate, state, setState, campMode, setCampMode }) {
                 boxShadow: time === t ? "inset 0 0 0 1px var(--b-600), inset 0 1px 0 rgba(255,250,220,0.6)" : "inset 0 0 0 1px rgba(140,100,60,0.3)",
               }}>{t}</button>
             ))}
-            <BrassButton size="sm" tone={campMode ? "" : "ghost"} onClick={() => setCampMode && setCampMode(!campMode)}>
-              {campMode ? "✺ Camped" : "Make Camp"}
+            <BrassButton size="sm" tone={campMode ? "" : "ghost"} onClick={() => setCampMode && setCampMode(!campMode)} disabled={!canCamp}>
+              {campMode ? "Camped" : "Make Camp"}
             </BrassButton>
+            <BrassButton size="sm" tone="ghost" onClick={() => loadSurface()}>Refresh</BrassButton>
           </div>
         </div>
 
-        {/* Map surface */}
         <div style={{ position: "relative", flex: "1 1 auto", minHeight: 0 }}>
-          {/* Aged map background */}
-          <div style={{
-            position: "absolute", inset: 0,
-            background:
-              `radial-gradient(ellipse at 30% 25%, rgba(120, 80, 30, 0.25), transparent 50%),
-               radial-gradient(ellipse at 75% 70%, rgba(100, 60, 20, 0.3), transparent 55%),
-               radial-gradient(ellipse at 15% 80%, rgba(160, 110, 60, 0.18), transparent 40%),
-               linear-gradient(135deg, #c8a878 0%, #b89868 40%, #a08055 100%)`,
-            boxShadow: "inset 0 0 80px rgba(60, 30, 10, 0.6)",
-          }}>
-            {/* Terrain pattern overlay using SVG */}
-            <svg width="100%" height="100%" viewBox="0 0 1000 600" preserveAspectRatio="xMidYMid slice" style={{ position: "absolute", inset: 0, opacity: 0.6 }}>
-              <defs>
-                <pattern id="forest" x="0" y="0" width="20" height="20" patternUnits="userSpaceOnUse">
-                  <path d="M10 4 L13 14 L7 14 Z" fill="rgba(40,60,30,0.6)" />
-                </pattern>
-                <pattern id="hills" x="0" y="0" width="40" height="20" patternUnits="userSpaceOnUse">
-                  <path d="M0 18 Q 10 10 20 18 T 40 18" fill="none" stroke="rgba(90, 50, 20, 0.4)" strokeWidth="1" />
-                </pattern>
-                <pattern id="water" x="0" y="0" width="20" height="14" patternUnits="userSpaceOnUse">
-                  <path d="M0 7 Q 5 4 10 7 T 20 7" fill="none" stroke="rgba(30, 60, 90, 0.5)" strokeWidth="1" />
-                </pattern>
-                <filter id="paper">
-                  <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" />
-                  <feColorMatrix values="0 0 0 0 0.4  0 0 0 0 0.25  0 0 0 0 0.1  0 0 0 0.15 0" />
-                  <feComposite in2="SourceGraphic" operator="in" />
-                </filter>
-              </defs>
-
-              {/* Forest blobs */}
-              <path d="M80 100 Q 150 80 220 110 T 380 120 Q 420 200 360 240 T 200 280 Q 100 260 80 180 Z" fill="url(#forest)" opacity="0.7" />
-              <path d="M520 80 Q 620 60 700 100 T 880 130 Q 900 220 820 260 T 620 280 Q 540 240 520 160 Z" fill="url(#forest)" opacity="0.55" />
-              <path d="M200 380 Q 300 360 380 400 T 540 440 Q 500 500 380 510 T 200 480 Q 160 440 200 380 Z" fill="url(#forest)" opacity="0.6" />
-
-              {/* Hills */}
-              <rect x="600" y="350" width="350" height="80" fill="url(#hills)" opacity="0.5" />
-              <rect x="50" y="450" width="200" height="60" fill="url(#hills)" opacity="0.4" />
-
-              {/* River */}
-              <path d="M -20 200 Q 200 220 360 260 T 700 320 Q 850 360 1020 380" stroke="rgba(60, 100, 130, 0.7)" strokeWidth="6" fill="none" />
-              <path d="M -20 200 Q 200 220 360 260 T 700 320 Q 850 360 1020 380" fill="url(#water)" stroke="none" />
-
-              {/* Roads */}
-              <path d="M 100 540 Q 220 480 320 460 T 540 380 Q 680 320 820 280" stroke="rgba(80, 40, 10, 0.7)" strokeWidth="2" strokeDasharray="4 4" fill="none" />
-              <path d="M 540 380 Q 600 300 660 200 T 720 60" stroke="rgba(80, 40, 10, 0.7)" strokeWidth="2" strokeDasharray="4 4" fill="none" />
-
-              {/* Compass rose */}
-              <g transform="translate(900, 510)" opacity="0.85">
-                <circle r="40" fill="none" stroke="rgba(60,30,10,0.6)" strokeWidth="1" />
-                <circle r="32" fill="none" stroke="rgba(60,30,10,0.4)" strokeWidth="0.5" />
-                <path d="M 0 -38 L 4 0 L 0 38 L -4 0 Z" fill="rgba(120, 30, 30, 0.7)" />
-                <path d="M -38 0 L 0 -4 L 38 0 L 0 4 Z" fill="rgba(60,30,10,0.7)" />
-                <text y="-44" textAnchor="middle" fontFamily="Cinzel" fontSize="9" fill="rgba(60,30,10,0.9)">N</text>
-                <text y="52" textAnchor="middle" fontFamily="Cinzel" fontSize="9" fill="rgba(60,30,10,0.9)">S</text>
-                <text x="-48" y="3" textAnchor="middle" fontFamily="Cinzel" fontSize="9" fill="rgba(60,30,10,0.9)">W</text>
-                <text x="48" y="3" textAnchor="middle" fontFamily="Cinzel" fontSize="9" fill="rgba(60,30,10,0.9)">E</text>
-              </g>
-
-              {/* Region label */}
-              <text x="500" y="80" textAnchor="middle" fontFamily="Cinzel" fontSize="36" fill="rgba(60, 30, 10, 0.25)" letterSpacing="8" fontWeight="600">THE STOLEN MARCHES</text>
-              <text x="180" y="500" textAnchor="middle" fontFamily="Cinzel" fontSize="20" fill="rgba(60, 30, 10, 0.3)" letterSpacing="4">Thorn River</text>
-              <text x="800" y="450" textAnchor="middle" fontFamily="Cinzel" fontSize="18" fill="rgba(60, 30, 10, 0.3)" letterSpacing="3">Old Hills</text>
-
-              {/* Roads/connections between locations */}
-              {locations.map((loc) =>
-                loc.connections?.map((cId) => {
-                  const target = locations.find((l) => l.id === cId);
-                  if (!target) return null;
-                  return (
-                    <line key={`${loc.id}-${cId}`}
-                      x1={loc.x * 10} y1={loc.y * 6}
-                      x2={target.x * 10} y2={target.y * 6}
-                      stroke="rgba(60, 30, 10, 0.4)" strokeWidth="1.5" strokeDasharray="3 4" />
-                  );
-                })
-              )}
-            </svg>
-
-            {/* Time-of-day overlay */}
-            <div style={{
-              position: "absolute", inset: 0,
-              background: time === "night"
-                ? "linear-gradient(180deg, rgba(20, 30, 60, 0.55), rgba(20, 20, 40, 0.65))"
-                : time === "dusk"
-                ? "linear-gradient(180deg, rgba(80, 30, 20, 0.18), rgba(40, 20, 40, 0.25))"
-                : time === "dawn"
-                ? "linear-gradient(180deg, rgba(255, 200, 120, 0.18), rgba(255, 150, 80, 0.12))"
-                : "transparent",
-              pointerEvents: "none",
-              transition: "background 400ms",
-            }} />
-
-            {/* Location nodes */}
-            {locations.map((loc) => (
-              <button
-                key={loc.id}
-                onClick={() => setSelected(loc)}
-                style={{
-                  position: "absolute",
-                  left: `${loc.x}%`,
-                  top: `${loc.y}%`,
-                  transform: "translate(-50%, -100%)",
-                  background: "none",
-                  cursor: "pointer",
-                  padding: 0,
-                }}
-              >
-                <LocationPin loc={loc} selected={selected?.id === loc.id} time={time} />
-              </button>
-            ))}
-          </div>
+          {campMode && window.CampSidebar ? (
+            <div style={{ position: "absolute", inset: 0, overflow: "auto" }}>
+              <window.CampSidebar
+                state={state}
+                onExit={() => { setCampMode && setCampMode(false); setTalkPartner(null); }}
+                onBeginRest={beginRest}
+                onTalk={setTalkPartner}
+                talkPartner={talkPartner}
+              />
+            </div>
+          ) : (
+            <AtlasMap locations={locations} edges={edges} selected={selected} time={time} onSelect={setSelectedId} />
+          )}
         </div>
 
-        {/* Bottom party portraits strip — now a separate row in the flex column */}
         <div style={{
           marginTop: 10,
-          display: "flex", gap: 6,
+          display: "flex",
+          gap: 6,
           padding: 8,
           background: "linear-gradient(180deg, var(--w-100), var(--w-300))",
           boxShadow: "inset 0 0 0 1px var(--w-500), inset 0 0 0 2px var(--b-500), inset 0 0 0 3px var(--w-200)",
           zIndex: 3,
           flex: "0 0 auto",
+          alignItems: "center",
         }}>
-          {party.map((p) => (
-            <div key={p.id} style={{ width: 48, height: 48, position: "relative" }}>
-              <Placeholder label={p.short} w="100%" h="100%" framed />
-              <div style={{
-                position: "absolute", bottom: 0, left: 0, right: 0,
-                height: 3,
-                background: "linear-gradient(90deg, #2a8c39, #5cd56a)",
-                width: `${(p.hp / p.hpMax) * 100}%`,
-              }} />
-            </div>
-          ))}
+          <Pill tone={surface?.is_live_view ? "emerald" : "crimson"} dot>{surface?.is_live_view ? "Live" : "Read-only"}</Pill>
+          <Pill dot>{locations.length} known</Pill>
+          <Pill dot>{clocks.filter((c) => c.urgent).length + projects.filter((p) => p.urgent).length} urgent</Pill>
           <div style={{ flex: 1 }} />
-          <div style={{ color: "var(--b-200)", fontFamily: "var(--f-display)", fontSize: 10, letterSpacing: "0.18em", textTransform: "uppercase", alignSelf: "center", padding: "0 8px" }}>
-            Day 12 · {time} · 29 Gozran
+          <div style={{ color: "var(--b-200)", fontFamily: "var(--f-display)", fontSize: 10, letterSpacing: "0.18em", textTransform: "uppercase", padding: "0 8px" }}>
+            Last strategic tick: {surface?.last_world_tick || "none"}
           </div>
         </div>
       </Panel>
 
-      {/* SIDE — Location detail OR Camp panel */}
-      {campMode ? (
-        <window.CampSidebar
-          state={state}
-          onExit={() => { setCampMode && setCampMode(false); setTalkPartner(null); }}
-          onBeginRest={beginRest}
-          onTalk={setTalkPartner}
-          talkPartner={talkPartner}
-        />
-      ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: 14, minHeight: 0 }}>
-          <Panel framed style={{ padding: 22 }}>
-            {selected ? (
-              <>
-                <div className="eyebrow" style={{ color: "var(--crimson)" }}>{selected.region || "The Stolen Marches"}</div>
-                <h2 className="h1" style={{ fontSize: 22 }}>{selected.name}</h2>
-                <div className="hand" style={{ fontSize: 14, marginTop: 2 }}>{selected.distance} · {selected.travel}</div>
-
-                <Divider />
-
-                <Placeholder label={`${selected.short || "location vignette"} · painted`} h={120} framed />
-
-                <p className="body dropcap" style={{ marginTop: 12, fontSize: 15 }}>
-                  {selected.description}
-                </p>
-
-                <Divider />
-
-                <div className="tag-row">
-                  {selected.tags.map((t) => <Pill key={t} tone={t === "danger" ? "crimson" : t === "rest" ? "emerald" : ""}>{t}</Pill>)}
-                </div>
-
-                <div style={{ display: "flex", gap: 6, marginTop: 18 }}>
-                  <BrassButton onClick={() => {
-                    toast({ kind: "quest", title: "The party travels to " + selected.name, body: selected.travel + " · " + selected.distance });
-                    onNavigate("table");
-                  }}>Travel here</BrassButton>
-                  <BrassButton tone="ghost" size="sm" onClick={() => toast({ title: "Marked: " + selected.name, body: "Linzi makes a note." })}>Mark</BrassButton>
-                </div>
-              </>
-            ) : <div className="muted">Pick a place upon the map.</div>}
-          </Panel>
-
-          <Panel framed style={{ padding: 22, flex: 1, overflow: "auto" }}>
-            <SectionTitle>Discovered</SectionTitle>
-            <div className="body-sm" style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              {locations.filter((l) => l.discovered).map((l) => (
-                <button key={l.id} onClick={() => setSelected(l)} style={{
-                  display: "flex", justifyContent: "space-between", textAlign: "left",
-                  padding: "8px 12px", cursor: "pointer",
-                  background: selected?.id === l.id ? "rgba(176,141,87,0.18)" : "transparent",
-                  boxShadow: "inset 0 -1px 0 rgba(140,100,60,0.2)",
-                }}>
-                  <span style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.08em", color: "var(--ink-900)" }}>{l.name}</span>
-                  <span className="muted" style={{ fontFamily: "var(--f-mono)", fontSize: 10 }}>{l.distance}</span>
-                </button>
-              ))}
-            </div>
-          </Panel>
-        </div>
-      )}
+      <AtlasSidebar
+        selected={selected}
+        travel={selectedTravel}
+        currentId={currentLocation.id}
+        busyTravel={busyTravel}
+        canAct={canAct}
+        quests={locationQuests}
+        clocks={locationClocks}
+        projects={locationProjects}
+        control={locationControl}
+        allLocations={locations}
+        onSelect={setSelectedId}
+        onTravel={postTravel}
+        onMark={(loc) => toast({ title: "Local mark only", body: loc?.name ? `${loc.name} marked in this view.` : "Pick a location first." })}
+      />
     </div>
   );
 }
 
-function LocationPin({ loc, selected, time }) {
+function AtlasMap({ locations, edges, selected, time, onSelect }) {
+  return (
+    <div style={{ position: "relative", height: "100%" }}>
+      <div style={{
+        position: "absolute", inset: 0,
+        background:
+          `radial-gradient(ellipse at 30% 25%, rgba(120, 80, 30, 0.25), transparent 50%),
+           radial-gradient(ellipse at 75% 70%, rgba(100, 60, 20, 0.3), transparent 55%),
+           radial-gradient(ellipse at 15% 80%, rgba(160, 110, 60, 0.18), transparent 40%),
+           linear-gradient(135deg, #c8a878 0%, #b89868 40%, #a08055 100%)`,
+        boxShadow: "inset 0 0 80px rgba(60, 30, 10, 0.6)",
+        overflow: "hidden",
+      }}>
+        <svg width="100%" height="100%" viewBox="0 0 100 100" preserveAspectRatio="none" style={{ position: "absolute", inset: 0, opacity: 0.72 }}>
+          <defs>
+            <pattern id="atlasForest" x="0" y="0" width="4" height="4" patternUnits="userSpaceOnUse">
+              <path d="M2 .7 L2.8 2.8 L1.2 2.8 Z" fill="rgba(40,60,30,0.48)" />
+            </pattern>
+            <pattern id="atlasHills" x="0" y="0" width="8" height="4" patternUnits="userSpaceOnUse">
+              <path d="M0 3.5 Q 2 1.5 4 3.5 T 8 3.5" fill="none" stroke="rgba(90,50,20,0.35)" strokeWidth=".25" />
+            </pattern>
+          </defs>
+          <path d="M8 15 Q15 12 22 16 T38 18 Q42 32 36 40 T20 45 Q10 42 8 30 Z" fill="url(#atlasForest)" />
+          <path d="M58 12 Q68 9 76 16 T94 22 Q95 37 83 44 T64 43 Q55 37 58 22 Z" fill="url(#atlasForest)" opacity="0.78" />
+          <rect x="62" y="62" width="32" height="14" fill="url(#atlasHills)" opacity="0.72" />
+          <path d="M-2 38 Q20 40 36 46 T70 54 Q85 60 102 64" stroke="rgba(60,100,130,0.55)" strokeWidth="1.5" fill="none" />
+          {edges.map((edge, i) => {
+            const from = locations.find((l) => l.id === edge.from);
+            const to = locations.find((l) => l.id === edge.to);
+            if (!from || !to) return null;
+            return (
+              <line key={`${edge.from}-${edge.to}-${i}`}
+                x1={from.x} y1={from.y}
+                x2={to.x} y2={to.y}
+                stroke="rgba(60,30,10,0.48)" strokeWidth="0.45" strokeDasharray="1 1" />
+            );
+          })}
+          <g transform="translate(89, 86)" opacity="0.85">
+            <circle r="6" fill="none" stroke="rgba(60,30,10,0.56)" strokeWidth=".35" />
+            <path d="M0 -5.5 L.7 0 L0 5.5 L-.7 0 Z" fill="rgba(120,30,30,0.7)" />
+            <path d="M-5.5 0 L0 -.7 L5.5 0 L0 .7 Z" fill="rgba(60,30,10,0.7)" />
+            <text y="-7" textAnchor="middle" fontFamily="Cinzel" fontSize="2" fill="rgba(60,30,10,0.9)">N</text>
+          </g>
+          <text x="50" y="12" textAnchor="middle" fontFamily="Cinzel" fontSize="5" fill="rgba(60,30,10,0.24)" letterSpacing="1.5">OPEN WORLDS ATLAS</text>
+        </svg>
+
+        <div style={{
+          position: "absolute", inset: 0,
+          background: time === "night"
+            ? "linear-gradient(180deg, rgba(20, 30, 60, 0.55), rgba(20, 20, 40, 0.65))"
+            : time === "dusk"
+            ? "linear-gradient(180deg, rgba(80, 30, 20, 0.18), rgba(40, 20, 40, 0.25))"
+            : time === "dawn"
+            ? "linear-gradient(180deg, rgba(255, 200, 120, 0.18), rgba(255, 150, 80, 0.12))"
+            : "transparent",
+          pointerEvents: "none",
+          transition: "background 400ms",
+        }} />
+
+        {locations.map((loc) => (
+          <button
+            key={loc.id}
+            onClick={() => onSelect(loc.id)}
+            style={{
+              position: "absolute",
+              left: `${loc.x}%`,
+              top: `${loc.y}%`,
+              transform: "translate(-50%, -100%)",
+              background: "none",
+              cursor: "pointer",
+              padding: 0,
+            }}
+          >
+            <LocationPin loc={loc} selected={selected?.id === loc.id} />
+          </button>
+        ))}
+
+        {!locations.length && (
+          <div style={{ position: "absolute", inset: 0, display: "grid", placeItems: "center" }}>
+            <div style={{ textAlign: "center", maxWidth: 320 }}>
+              <div className="eyebrow" style={{ color: "var(--crimson)" }}>No atlas data</div>
+              <h2 className="h1" style={{ fontSize: 22, marginTop: 6 }}>The map has not been discovered</h2>
+              <p className="body-sm" style={{ color: "var(--ink-700)", marginTop: 8 }}>Known locations will appear here once the engine snapshot includes them.</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AtlasSidebar({ selected, travel, currentId, busyTravel, canAct, quests, clocks, projects, control, allLocations, onSelect, onTravel, onMark }) {
+  const travelDisabled = !travel?.available || !canAct || Boolean(busyTravel) || selected?.id === currentId;
+  const travelReason = selected?.id === currentId ? "current location" : (travel?.disabled_reason || "no engine-backed route");
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 14, minHeight: 0 }}>
+      <Panel framed style={{ padding: 22 }}>
+        {selected ? (
+          <>
+            <div className="eyebrow" style={{ color: "var(--crimson)" }}>{selected.region || "Unknown reach"}</div>
+            <h2 className="h1" style={{ fontSize: 22 }}>{selected.name}</h2>
+            <div className="hand" style={{ fontSize: 14, marginTop: 2 }}>
+              {selected.current ? "Current location" : (travel?.minutes ? `${travel.minutes} minutes away` : "Known location")}
+            </div>
+
+            <Divider />
+            <Placeholder label={`${selected.name} - painted location`} h={118} framed />
+            <p className="body dropcap" style={{ marginTop: 12, fontSize: 15 }}>
+              {selected.description || "No public description has been recorded for this place yet."}
+            </p>
+
+            <Divider />
+            <div className="tag-row">
+              {(selected.tags || []).length
+                ? selected.tags.map((t) => <Pill key={t} tone={t === "danger" ? "crimson" : t === "rest" ? "emerald" : ""}>{t}</Pill>)
+                : <Pill>known</Pill>}
+            </div>
+
+            {control && (
+              <div style={{ marginTop: 12, display: "flex", gap: 6, flexWrap: "wrap" }}>
+                <Pill tone="emerald">Control: {control.controller || "unclaimed"}</Pill>
+                <Pill>Stability {control.stability}</Pill>
+                <Pill tone={control.unrest > 50 ? "crimson" : ""}>Unrest {control.unrest}</Pill>
+              </div>
+            )}
+
+            <div style={{ display: "flex", gap: 6, marginTop: 18 }}>
+              <BrassButton disabled={travelDisabled} onClick={() => onTravel(travel)}>
+                {busyTravel === selected.id ? "Sending..." : "Travel here"}
+              </BrassButton>
+              <BrassButton tone="ghost" size="sm" onClick={() => onMark(selected)}>Mark</BrassButton>
+            </div>
+            {travelDisabled && (
+              <div className="body-sm" style={{ color: "var(--ink-600)", marginTop: 8 }}>{travelReason}</div>
+            )}
+          </>
+        ) : <div className="muted">Pick a place upon the map.</div>}
+      </Panel>
+
+      <Panel framed style={{ padding: 18, flex: 1, overflow: "auto" }}>
+        <SectionTitle>Strategic Context</SectionTitle>
+        <StrategicList label="Quests" items={quests} empty="No active quest markers here." render={(q) => (
+          <ContextRow key={q.id} title={q.title} meta={q.objective || q.status || "active"} />
+        )} />
+        <StrategicList label="Clocks" items={clocks} empty="No strategic clocks here." render={(c) => (
+          <ContextRow key={c.id} title={c.title} meta={`${c.kind} - ${c.progress}/${c.target}`} urgent={c.urgent} />
+        )} />
+        <StrategicList label="Projects" items={projects} empty="No downtime projects here." render={(p) => (
+          <ContextRow key={p.id} title={p.title} meta={`${p.status} - ${p.progress_days}/${p.duration_days} days`} urgent={p.urgent} />
+        )} />
+
+        <Divider />
+        <SectionTitle>Discovered</SectionTitle>
+        <div className="body-sm" style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {allLocations.map((loc) => (
+            <button key={loc.id} onClick={() => onSelect(loc.id)} style={{
+              display: "flex", justifyContent: "space-between", textAlign: "left",
+              padding: "8px 12px", cursor: "pointer",
+              background: selected?.id === loc.id ? "rgba(176,141,87,0.18)" : "transparent",
+              boxShadow: "inset 0 -1px 0 rgba(140,100,60,0.2)",
+            }}>
+              <span style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.08em", color: "var(--ink-900)" }}>{loc.name}</span>
+              <span className="muted" style={{ fontFamily: "var(--f-mono)", fontSize: 10 }}>{loc.current ? "here" : loc.region}</span>
+            </button>
+          ))}
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function StrategicList({ label, items, empty, render }) {
+  return (
+    <div style={{ marginTop: 12 }}>
+      <div className="eyebrow" style={{ color: "var(--ink-600)", marginBottom: 6 }}>{label}</div>
+      <div style={{ display: "flex", flexDirection: "column", gap: 5 }}>
+        {items.length ? items.map(render) : <div className="body-sm" style={{ color: "var(--ink-600)" }}>{empty}</div>}
+      </div>
+    </div>
+  );
+}
+
+function ContextRow({ title, meta, urgent }) {
+  return (
+    <div style={{
+      padding: "8px 10px",
+      background: urgent ? "rgba(120,32,32,0.12)" : "rgba(176,141,87,0.08)",
+      boxShadow: urgent ? "inset 0 0 0 1px rgba(120,32,32,0.22)" : "inset 0 0 0 1px rgba(140,100,60,0.18)",
+    }}>
+      <div style={{ fontFamily: "var(--f-display)", fontSize: 11, color: urgent ? "var(--crimson)" : "var(--ink-900)", letterSpacing: "0.08em" }}>{title}</div>
+      {meta && <div className="body-sm" style={{ color: "var(--ink-600)", marginTop: 2 }}>{meta}</div>}
+    </div>
+  );
+}
+
+function LocationPin({ loc, selected }) {
   const isCurrent = loc.current;
   const isVisited = loc.visited;
   const [hover, setHover] = React.useState(false);
@@ -269,7 +438,6 @@ function LocationPin({ loc, selected, time }) {
       onMouseLeave={() => setHover(false)}
       style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 4, position: "relative" }}
     >
-      {/* Banner label */}
       <div style={{
         position: "relative",
         padding: "4px 14px 4px",
@@ -290,7 +458,6 @@ function LocationPin({ loc, selected, time }) {
       }}>
         {loc.name}
       </div>
-      {/* Pin */}
       <div style={{
         width: 12, height: 12, borderRadius: "50%",
         background: isCurrent
@@ -304,7 +471,6 @@ function LocationPin({ loc, selected, time }) {
         animation: isCurrent ? "flicker 2.4s ease-in-out infinite" : "none",
       }} />
 
-      {/* Hover preview card */}
       {hover && !selected && (
         <div style={{
           position: "absolute",
@@ -318,7 +484,7 @@ function LocationPin({ loc, selected, time }) {
           pointerEvents: "none",
           animation: "tooltip-in 140ms ease both",
         }}>
-          <Placeholder label={loc.short || "vignette"} h={70} framed style={{ width: "100%" }} />
+          <Placeholder label={`${loc.name} vignette`} h={70} framed style={{ width: "100%" }} />
           <div className="eyebrow" style={{ color: "var(--crimson)", marginTop: 8, fontSize: 9 }}>
             {loc.region || "Unknown reach"}
           </div>
@@ -326,9 +492,9 @@ function LocationPin({ loc, selected, time }) {
             {loc.name}
           </div>
           <div className="hand" style={{ fontSize: 12, color: "var(--ink-600)", marginTop: 2 }}>
-            {loc.distance} · {loc.travel}
+            {loc.current ? "Current location" : "Known route"}
           </div>
-          {loc.tags && (
+          {loc.tags && loc.tags.length > 0 && (
             <div style={{ display: "flex", gap: 4, marginTop: 6, flexWrap: "wrap" }}>
               {loc.tags.slice(0, 3).map((t) => <Pill key={t} tone={t === "danger" ? "crimson" : t === "rest" ? "emerald" : ""}>{t}</Pill>)}
             </div>
@@ -339,4 +505,4 @@ function LocationPin({ loc, selected, time }) {
   );
 }
 
-Object.assign(window, { ScreenMap, LocationPin });
+Object.assign(window, { ScreenMap, LocationPin, atlasSurfaceFromCampaign });

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1368,6 +1368,287 @@ def build_combat_surface(
     }
 
 
+def _atlas_locations(snapshot: dict) -> dict[str, dict]:
+    locs = snapshot.get("locations") if isinstance(snapshot, dict) else None
+    return locs if isinstance(locs, dict) else {}
+
+
+def _atlas_visible_location_ids(snapshot: dict) -> list[str]:
+    locs = _atlas_locations(snapshot)
+    current_id = _text(snapshot.get("current_location_id"))
+    visible: list[str] = []
+    for loc_id, row in locs.items():
+        if not isinstance(row, dict):
+            continue
+        lid = _text(row.get("id"), _text(loc_id))
+        if not lid:
+            continue
+        if lid == current_id:
+            visible.append(lid)
+            continue
+        if bool(row.get("hidden")):
+            continue
+        discovered = row.get("discovered")
+        if discovered is False and not bool(row.get("visited")):
+            continue
+        if bool(row.get("visited")) or discovered is True or discovered is None:
+            visible.append(lid)
+    return visible
+
+
+def _atlas_hex_position(loc: dict, idx: int) -> tuple[int, int]:
+    raw = loc.get("hex")
+    q = r = None
+    if isinstance(raw, (list, tuple)) and len(raw) >= 2:
+        q, r = _num(raw[0]), _num(raw[1])
+    if q is not None and r is not None:
+        x = 50 + int(q) * 18 + int(r) * 9
+        y = 50 + int(r) * 14
+        return max(8, min(92, x)), max(10, min(88, y))
+    x = 24 + (idx % 4) * 18
+    y = 24 + (idx // 4) * 18
+    return max(8, min(92, x)), max(10, min(88, y))
+
+
+def _atlas_tags(row: dict) -> list[str]:
+    raw = row.get("tags")
+    if isinstance(raw, list):
+        return [_text(t).lower() for t in raw if _text(t)]
+    out: list[str] = []
+    for key in ("danger", "rest", "town", "camp", "safe"):
+        if bool(row.get(key)):
+            out.append(key)
+    return out
+
+
+def _atlas_known_locations(snapshot: dict) -> list[dict]:
+    locs = _atlas_locations(snapshot)
+    visible_ids = _atlas_visible_location_ids(snapshot)
+    current_id = _text(snapshot.get("current_location_id"))
+    out: list[dict] = []
+    for idx, loc_id in enumerate(visible_ids):
+        row = locs.get(loc_id)
+        if not isinstance(row, dict):
+            continue
+        x, y = _atlas_hex_position(row, idx)
+        name = _text(row.get("name"), loc_id)
+        out.append({
+            "id": loc_id,
+            "name": name,
+            "description": _text(row.get("description")),
+            "region": _text(row.get("region"), _text(snapshot.get("world_id"), "World")),
+            "visited": bool(row.get("visited")) or loc_id == current_id,
+            "current": loc_id == current_id,
+            "x": x,
+            "y": y,
+            "tags": _atlas_tags(row),
+            "connections": [
+                _text(c) for c in row.get("connections", [])
+                if isinstance(row.get("connections"), list) and _text(c) in visible_ids
+            ],
+        })
+    out.sort(key=lambda l: (not l["current"], l["name"]))
+    return out
+
+
+def _atlas_edges(locations: list[dict]) -> list[dict]:
+    known = {loc["id"] for loc in locations}
+    seen: set[tuple[str, str]] = set()
+    out: list[dict] = []
+    for loc in locations:
+        src = loc["id"]
+        for dst in loc.get("connections", []):
+            if dst not in known:
+                continue
+            key = tuple(sorted((src, dst)))
+            if key in seen or src == dst:
+                continue
+            seen.add(key)
+            out.append({"from": key[0], "to": key[1]})
+    return out
+
+
+def _atlas_move_reason(snapshot: dict, *, live: bool, is_live_view: bool) -> str | None:
+    if not _atlas_locations(snapshot):
+        return "no map data"
+    if not live:
+        return "no live move sink"
+    if not is_live_view:
+        return "viewing non-live campaign"
+    if isinstance(snapshot.get("combat"), dict) and snapshot["combat"].get("active"):
+        return "cannot travel during active combat"
+    return None
+
+
+def _atlas_travel_options(snapshot: dict, locations: list[dict], *, live: bool, is_live_view: bool) -> list[dict]:
+    locs = _atlas_locations(snapshot)
+    current_id = _text(snapshot.get("current_location_id"))
+    current = locs.get(current_id) if current_id else None
+    if not isinstance(current, dict):
+        return []
+    known = {loc["id"]: loc for loc in locations}
+    travel_times = current.get("travel_times") if isinstance(current.get("travel_times"), dict) else {}
+    disabled = _atlas_move_reason(snapshot, live=live, is_live_view=is_live_view)
+    out: list[dict] = []
+    for dst in current.get("connections", []) if isinstance(current.get("connections"), list) else []:
+        dst_id = _text(dst)
+        target = known.get(dst_id)
+        if not target:
+            continue
+        minutes = travel_times.get(dst_id)
+        minutes = minutes if isinstance(minutes, int) and not isinstance(minutes, bool) else None
+        item = {
+            "to": dst_id,
+            "name": target["name"],
+            "minutes": minutes,
+            "available": disabled is None,
+            "disabled_reason": disabled,
+        }
+        if disabled is None:
+            item["move"] = {"kind": "do", "text": f"Travel to {target['name']}"}
+        out.append(item)
+    return out
+
+
+def _atlas_faction_name(snapshot: dict, faction_id: str) -> str:
+    factions = snapshot.get("factions")
+    row = factions.get(faction_id) if isinstance(factions, dict) else None
+    return _text(row.get("name"), faction_id) if isinstance(row, dict) else faction_id
+
+
+def _atlas_quest_markers(snapshot: dict, visible_ids: set[str]) -> list[dict]:
+    quests = snapshot.get("quests")
+    if not isinstance(quests, dict):
+        return []
+    out: list[dict] = []
+    for qid, row in quests.items():
+        if not isinstance(row, dict):
+            continue
+        status = _text(row.get("status"), "active")
+        if status not in {"active", "open"}:
+            continue
+        loc_id = _text(row.get("location_id"))
+        if loc_id and loc_id not in visible_ids:
+            continue
+        objectives = row.get("objectives") if isinstance(row.get("objectives"), list) else []
+        completed = set(row.get("completed_objectives") if isinstance(row.get("completed_objectives"), list) else [])
+        objective = next((_text(o) for o in objectives if _text(o) and o not in completed), "")
+        out.append({
+            "id": _text(qid),
+            "title": _text(row.get("title"), _text(qid)),
+            "status": status,
+            "location_id": loc_id,
+            "objective": objective,
+        })
+    return out[:12]
+
+
+def _atlas_strategic(snapshot: dict, visible_ids: set[str]) -> tuple[list[dict], list[dict], list[dict], int]:
+    st = snapshot.get("strategic_state")
+    if not isinstance(st, dict):
+        return [], [], [], 0
+    clocks: list[dict] = []
+    for cid, row in (st.get("clocks") if isinstance(st.get("clocks"), dict) else {}).items():
+        if not isinstance(row, dict):
+            continue
+        loc_id = _text(row.get("region_id") or row.get("location_id"))
+        if loc_id and loc_id not in visible_ids:
+            continue
+        progress = _num(row.get("progress")) or 0
+        target = _num(row.get("target")) or 1
+        remaining = max(0, int(target) - int(progress))
+        clocks.append({
+            "id": _text(row.get("id"), _text(cid)),
+            "title": _text(row.get("title"), _text(cid)),
+            "kind": _text(row.get("kind"), "threat"),
+            "location_id": loc_id,
+            "progress": int(progress),
+            "target": int(target),
+            "remaining": remaining,
+            "urgent": remaining <= 1 or (target > 0 and progress / target >= 0.75),
+        })
+    projects: list[dict] = []
+    for pid, row in (st.get("projects") if isinstance(st.get("projects"), dict) else {}).items():
+        if not isinstance(row, dict):
+            continue
+        loc_id = _text(row.get("location_id"))
+        if loc_id and loc_id not in visible_ids:
+            continue
+        progress = _num(row.get("progress_days")) or 0
+        duration = _num(row.get("duration_days")) or 1
+        remaining = max(0, int(duration) - int(progress))
+        status = _text(row.get("status"), "planned")
+        projects.append({
+            "id": _text(row.get("id"), _text(pid)),
+            "title": _text(row.get("title"), _text(pid)),
+            "kind": _text(row.get("kind"), "other"),
+            "location_id": loc_id,
+            "status": status,
+            "progress_days": int(progress),
+            "duration_days": int(duration),
+            "remaining_days": remaining,
+            "urgent": status in {"active", "paused"} and remaining <= 2,
+        })
+    regions: list[dict] = []
+    for rid, row in (st.get("regions") if isinstance(st.get("regions"), dict) else {}).items():
+        if not isinstance(row, dict):
+            continue
+        loc_id = _text(row.get("location_id"), _text(rid))
+        if loc_id not in visible_ids:
+            continue
+        regions.append({
+            "location_id": loc_id,
+            "controller": _atlas_faction_name(snapshot, _text(row.get("controller_id"))),
+            "stability": int(_num(row.get("stability")) or 0),
+            "unrest": int(_num(row.get("unrest")) or 0),
+            "tags": [_text(t) for t in row.get("tags", []) if isinstance(row.get("tags"), list) and _text(t)],
+        })
+    last_tick_day = int(_num(st.get("last_tick_day")) or 0)
+    clocks.sort(key=lambda c: (not c["urgent"], c["remaining"], c["title"]))
+    projects.sort(key=lambda p: (not p["urgent"], p["remaining_days"], p["title"]))
+    return clocks[:12], projects[:12], regions[:12], last_tick_day
+
+
+def build_atlas_surface(
+    snapshot: dict,
+    *,
+    campaign_id: str,
+    live: bool,
+    is_live_view: bool,
+) -> dict:
+    """Project a browser-safe OpenWorlds atlas from engine-owned campaign state."""
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    locations = _atlas_known_locations(snapshot)
+    visible_ids = {loc["id"] for loc in locations}
+    current_id = _text(snapshot.get("current_location_id"))
+    current = next((loc for loc in locations if loc["id"] == current_id), None)
+    travel_options = _atlas_travel_options(snapshot, locations, live=live, is_live_view=is_live_view)
+    clocks, projects, regions, last_tick_day = _atlas_strategic(snapshot, visible_ids)
+    current_tags = set(current.get("tags", [])) if current else set()
+    camp_available = bool(current and current_tags.intersection({"rest", "town", "safe", "camp"}))
+    return {
+        "campaign_id": campaign_id,
+        "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
+        "world": _text(snapshot.get("world_id"), "unknown"),
+        "dayLabel": _openworlds_day_label(snapshot),
+        "current_location": current or {"id": "", "name": "Unknown location", "tags": []},
+        "known_locations": locations,
+        "edges": _atlas_edges(locations),
+        "travel_options": travel_options,
+        "quest_markers": _atlas_quest_markers(snapshot, visible_ids),
+        "strategic_clocks": clocks,
+        "downtime_projects": projects,
+        "region_control": regions,
+        "camp_available": camp_available,
+        "last_world_tick": last_tick_day,
+        "live": bool(live),
+        "is_live_view": bool(is_live_view),
+        "can_act": bool(live and is_live_view),
+        "state_authority": "engine",
+        "write_lane": "/move",
+    }
+
+
 def _relative_time_label(ts: float, *, now: float) -> str:
     if ts <= 0:
         return "unknown"
@@ -2486,6 +2767,7 @@ def _openworlds_config() -> dict:
         "campaign_catalog": "/openworlds/campaigns.json",
         "session_surface": "/session-surface",
         "combat_surface": "/combat-surface",
+        "atlas_surface": "/atlas-surface",
         "state_authority": "engine",
         "write_lane": "/move",
         "demo_data": False,
@@ -2694,6 +2976,32 @@ class _Handler(BaseHTTPRequestHandler):
                 live=live,
                 is_live_view=live and cid == self.campaign_id,
                 recent_events=_session_event_tail(cid),
+            ))
+        elif route == "/atlas-surface":
+            qs = parse_qs(parsed.query)
+            live = _live_play()
+            catalog_ref = _session_surface_catalog_ref(qs)
+            if catalog_ref is not None:
+                cid, raw_snap, _campaign_dir_path, root_is_current = catalog_ref
+                self._json(build_atlas_surface(
+                    raw_snap,
+                    campaign_id=cid,
+                    live=live,
+                    is_live_view=bool(live and root_is_current and cid == self.campaign_id),
+                ))
+                return
+            cid = self._view_campaign(qs)
+            if not cid:
+                self._json(build_atlas_surface({}, campaign_id="", live=live, is_live_view=False))
+                return
+            raw_snap = _read_snapshot(cid)
+            if not isinstance(raw_snap, dict):
+                raw_snap = {}
+            self._json(build_atlas_surface(
+                raw_snap,
+                campaign_id=cid,
+                live=live,
+                is_live_view=live and cid == self.campaign_id,
             ))
         elif route == _OPENWORLDS_ROUTE or route.startswith(f"{_OPENWORLDS_ROUTE}/"):
             asset = _openworlds_asset(route)

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1432,6 +1432,8 @@ def _atlas_known_locations(snapshot: dict) -> list[dict]:
             continue
         x, y = _atlas_hex_position(row, idx)
         name = _text(row.get("name"), loc_id)
+        connections = row.get("connections")
+        connections = connections if isinstance(connections, list) else []
         out.append({
             "id": loc_id,
             "name": name,
@@ -1442,12 +1444,9 @@ def _atlas_known_locations(snapshot: dict) -> list[dict]:
             "x": x,
             "y": y,
             "tags": _atlas_tags(row),
-            "connections": [
-                _text(c) for c in row.get("connections", [])
-                if isinstance(row.get("connections"), list) and _text(c) in visible_ids
-            ],
+            "connections": [_text(c) for c in connections if _text(c) in visible_ids],
         })
-    out.sort(key=lambda l: (not l["current"], l["name"]))
+    out.sort(key=lambda loc: (not loc["current"], loc["name"]))
     return out
 
 
@@ -1596,12 +1595,14 @@ def _atlas_strategic(snapshot: dict, visible_ids: set[str]) -> tuple[list[dict],
         loc_id = _text(row.get("location_id"), _text(rid))
         if loc_id not in visible_ids:
             continue
+        tags = row.get("tags")
+        tags = tags if isinstance(tags, list) else []
         regions.append({
             "location_id": loc_id,
             "controller": _atlas_faction_name(snapshot, _text(row.get("controller_id"))),
             "stability": int(_num(row.get("stability")) or 0),
             "unrest": int(_num(row.get("unrest")) or 0),
-            "tags": [_text(t) for t in row.get("tags", []) if isinstance(row.get("tags"), list) and _text(t)],
+            "tags": [_text(t) for t in tags if _text(t)],
         })
     last_tick_day = int(_num(st.get("last_tick_day")) or 0)
     clocks.sort(key=lambda c: (not c["urgent"], c["remaining"], c["title"]))

--- a/viewer/tests/test_atlas_surface.py
+++ b/viewer/tests/test_atlas_surface.py
@@ -1,0 +1,206 @@
+import importlib.util
+import json
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+class AtlasSurfaceTests(unittest.TestCase):
+    def test_atlas_surface_projects_known_map_without_private_fields(self):
+        snapshot = {
+            "id": "camp_map",
+            "title": "Roads of the Gate",
+            "world_id": "baldurs-gate",
+            "day": 12,
+            "time_of_day": "dusk",
+            "current_location_id": "gate",
+            "locations": {
+                "gate": {
+                    "id": "gate",
+                    "name": "Basilisk Gate",
+                    "description": "A guarded gatehouse.",
+                    "connections": ["market", "hidden-crypt"],
+                    "visited": True,
+                    "hex": [0, 0],
+                    "region": "Lower City",
+                    "travel_times": {"market": 20, "hidden-crypt": 5},
+                    "tags": ["town", "rest"],
+                    "notes": "private gate bypass",
+                },
+                "market": {
+                    "id": "market",
+                    "name": "Rain Market",
+                    "description": "Canvas stalls bright with rain.",
+                    "connections": ["gate"],
+                    "visited": False,
+                    "discovered": True,
+                    "hex": [1, 0],
+                    "region": "Lower City",
+                    "tags": ["danger"],
+                },
+                "hidden-crypt": {
+                    "id": "hidden-crypt",
+                    "name": "Hidden Crypt",
+                    "description": "Spoilers.",
+                    "hidden": True,
+                    "connections": ["gate"],
+                    "notes": "private undead cache",
+                },
+            },
+            "quests": {
+                "q_market": {
+                    "title": "Find the Rain Seller",
+                    "status": "active",
+                    "location_id": "market",
+                    "objectives": ["Question the blue awning merchant"],
+                    "notes": "private quest solution",
+                },
+                "q_done": {"title": "Closed Road", "status": "completed", "location_id": "gate"},
+            },
+            "factions": {
+                "harpers": {"id": "harpers", "name": "Harpers", "notes": "private faction note"}
+            },
+            "strategic_state": {
+                "last_tick_day": 11,
+                "regions": {
+                    "gate": {
+                        "location_id": "gate",
+                        "controller_id": "harpers",
+                        "stability": 62,
+                        "unrest": 12,
+                        "tags": ["watched"],
+                        "note": "private region note",
+                    }
+                },
+                "clocks": {
+                    "c1": {
+                        "id": "c1",
+                        "title": "Sapper Cell Regroups",
+                        "kind": "threat",
+                        "scope": "region",
+                        "region_id": "market",
+                        "progress": 5,
+                        "target": 6,
+                        "note": "private clock note",
+                    }
+                },
+                "projects": {
+                    "p1": {
+                        "id": "p1",
+                        "title": "Repair Gate Winch",
+                        "kind": "construction",
+                        "location_id": "gate",
+                        "progress_days": 2,
+                        "duration_days": 5,
+                        "status": "active",
+                        "note": "private project note",
+                    }
+                },
+            },
+            "dm_notes": "private map agenda",
+        }
+
+        surface = server.build_atlas_surface(
+            snapshot,
+            campaign_id="camp_map",
+            live=True,
+            is_live_view=True,
+        )
+
+        self.assertEqual(surface["campaign_id"], "camp_map")
+        self.assertEqual(surface["state_authority"], "engine")
+        self.assertEqual(surface["write_lane"], "/move")
+        self.assertEqual(surface["current_location"]["id"], "gate")
+        self.assertEqual([loc["id"] for loc in surface["known_locations"]], ["gate", "market"])
+        self.assertEqual(surface["known_locations"][0]["tags"], ["town", "rest"])
+        self.assertEqual(surface["edges"], [{"from": "gate", "to": "market"}])
+        self.assertEqual(surface["travel_options"][0]["to"], "market")
+        self.assertEqual(surface["travel_options"][0]["minutes"], 20)
+        self.assertEqual(surface["travel_options"][0]["move"], {"kind": "do", "text": "Travel to Rain Market"})
+        self.assertTrue(surface["camp_available"])
+        self.assertEqual(surface["quest_markers"][0]["title"], "Find the Rain Seller")
+        self.assertEqual(surface["strategic_clocks"][0]["title"], "Sapper Cell Regroups")
+        self.assertTrue(surface["strategic_clocks"][0]["urgent"])
+        self.assertEqual(surface["downtime_projects"][0]["title"], "Repair Gate Winch")
+        self.assertEqual(surface["region_control"][0]["controller"], "Harpers")
+
+        encoded = json.dumps(surface)
+        for forbidden in (
+            "Hidden Crypt",
+            "hidden-crypt",
+            "notes",
+            "dm_notes",
+            "private",
+            "undead cache",
+            "quest solution",
+            "clock note",
+            "project note",
+            "region note",
+        ):
+            self.assertNotIn(forbidden, encoded)
+        self.assert_no_private_keys(surface)
+
+    def test_atlas_surface_fails_closed_when_not_live(self):
+        snapshot = {
+            "current_location_id": "gate",
+            "locations": {
+                "gate": {"name": "Gate", "connections": ["market"], "visited": True},
+                "market": {"name": "Market", "visited": True},
+            },
+        }
+
+        surface = server.build_atlas_surface(
+            snapshot,
+            campaign_id="camp_readonly",
+            live=False,
+            is_live_view=False,
+        )
+
+        self.assertFalse(surface["can_act"])
+        self.assertEqual(surface["travel_options"][0]["disabled_reason"], "no live move sink")
+        self.assertNotIn("move", surface["travel_options"][0])
+
+    def test_atlas_surface_degrades_for_legacy_saves(self):
+        surface = server.build_atlas_surface(
+            {"title": "Old Save"},
+            campaign_id="camp_old",
+            live=True,
+            is_live_view=True,
+        )
+
+        self.assertEqual(surface["title"], "Old Save")
+        self.assertEqual(surface["known_locations"], [])
+        self.assertEqual(surface["edges"], [])
+        self.assertEqual(surface["travel_options"], [])
+        self.assertFalse(surface["camp_available"])
+
+    def assert_no_private_keys(self, value) -> None:
+        private_keys = {
+            "notes",
+            "dm_notes",
+            "scenes",
+            "lore",
+            "memory",
+            "secret",
+            "agenda",
+            "note",
+            "effect",
+        }
+        if isinstance(value, dict):
+            for key, child in value.items():
+                self.assertNotIn(key, private_keys)
+                self.assert_no_private_keys(child)
+        elif isinstance(value, list):
+            for child in value:
+                self.assert_no_private_keys(child)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_atlas_surface.py
+++ b/viewer/tests/test_atlas_surface.py
@@ -181,6 +181,36 @@ class AtlasSurfaceTests(unittest.TestCase):
         self.assertEqual(surface["travel_options"], [])
         self.assertFalse(surface["camp_available"])
 
+    def test_atlas_surface_tolerates_null_optional_lists(self):
+        snapshot = {
+            "current_location_id": "gate",
+            "locations": {
+                "gate": {
+                    "name": "Gate",
+                    "connections": None,
+                    "visited": True,
+                }
+            },
+            "strategic_state": {
+                "regions": {
+                    "gate": {
+                        "location_id": "gate",
+                        "tags": None,
+                    }
+                }
+            },
+        }
+
+        surface = server.build_atlas_surface(
+            snapshot,
+            campaign_id="camp_nulls",
+            live=True,
+            is_live_view=True,
+        )
+
+        self.assertEqual(surface["known_locations"][0]["connections"], [])
+        self.assertEqual(surface["region_control"][0]["tags"], [])
+
     def assert_no_private_keys(self, value) -> None:
         private_keys = {
             "notes",

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -105,6 +105,17 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertNotIn("TOKENS.map", source)
         self.assertNotIn("setTokens", source)
 
+    def test_openworlds_map_screen_binds_viewer_atlas_surface(self):
+        status, ctype, body = self._get("/openworlds/screen-map.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        self.assertIn('fetch("/atlas-surface', source)
+        self.assertIn('fetch("/move"', source)
+        self.assertIn("window.atlasSurfaceFromCampaign", source)
+        self.assertNotIn("state?.locations", source)
+
     def test_openworlds_rejects_path_traversal(self):
         self.assertEqual(self._status("/openworlds/../server.py"), 404)
         self.assertEqual(self._status("/openworlds/%2e%2e/server.py"), 404)
@@ -413,6 +424,91 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertEqual(surface["title"], "QA Combat Save")
         self.assertEqual(surface["encounter"]["round"], 4)
         self.assertEqual(surface["selectedTokenId"], "gob")
+        self.assertFalse(surface["can_act"])
+        self.assertFalse(surface["is_live_view"])
+
+    def test_atlas_surface_route_projects_selected_campaign_safely(self):
+        campaign_dir = self._tmp / "campaigns" / "camp_map"
+        self._write_snapshot(
+            campaign_dir,
+            {
+                "id": "camp_map",
+                "title": "Atlas Save",
+                "world_id": "baldurs-gate",
+                "current_location_id": "gate",
+                "locations": {
+                    "gate": {
+                        "name": "Basilisk Gate",
+                        "connections": ["market", "hidden"],
+                        "visited": True,
+                        "tags": ["town", "rest"],
+                        "notes": "private gate note",
+                    },
+                    "market": {
+                        "name": "Rain Market",
+                        "connections": ["gate"],
+                        "discovered": True,
+                    },
+                    "hidden": {
+                        "name": "Hidden Crypt",
+                        "hidden": True,
+                        "notes": "private crypt note",
+                    },
+                },
+                "quests": {
+                    "q1": {"title": "Find the Seller", "status": "active", "location_id": "market"},
+                },
+                "dm_notes": "private atlas agenda",
+            },
+        )
+
+        status, ctype, body = self._get("/atlas-surface?campaign=camp_map")
+
+        self.assertEqual(status, 200)
+        self.assertIn("application/json", ctype)
+        surface = json.loads(body.decode("utf-8"))
+        self.assertEqual(surface["campaign_id"], "camp_map")
+        self.assertEqual(surface["state_authority"], "engine")
+        self.assertEqual(surface["write_lane"], "/move")
+        self.assertEqual(surface["current_location"]["name"], "Basilisk Gate")
+        self.assertEqual([loc["id"] for loc in surface["known_locations"]], ["gate", "market"])
+        self.assertEqual(surface["edges"], [{"from": "gate", "to": "market"}])
+        self.assertTrue(surface["camp_available"])
+        encoded = json.dumps(surface)
+        self.assertNotIn("Hidden Crypt", encoded)
+        self.assertNotIn("private", encoded)
+        self.assert_no_private_keys(surface)
+
+    def test_atlas_surface_route_projects_catalog_run_read_only(self):
+        repo_root = self._tmp / "repo"
+        (repo_root / "viewer").mkdir(parents=True)
+        server._HERE = repo_root / "viewer"
+        qa_campaign = repo_root / "qa" / "state" / "wave3-red" / "campaigns" / "camp_qa"
+        self._write_snapshot(
+            qa_campaign,
+            {
+                "id": "camp_qa",
+                "title": "QA Atlas Save",
+                "current_location_id": "qa-gate",
+                "locations": {
+                    "qa-gate": {"name": "QA Gate", "connections": ["qa-market"], "visited": True},
+                    "qa-market": {"name": "QA Market", "visited": True},
+                },
+            },
+        )
+        self._write_snapshot(
+            self._tmp / "campaigns" / "camp_live",
+            {"id": "camp_live", "title": "Live Atlas Save", "party": [], "characters": {}},
+        )
+        _QuietHandler.campaign_id = "camp_live"
+
+        status, _ctype, body = self._get("/atlas-surface?source=qa&run=wave3-red&campaign=camp_qa")
+
+        self.assertEqual(status, 200)
+        surface = json.loads(body.decode("utf-8"))
+        self.assertEqual(surface["campaign_id"], "camp_qa")
+        self.assertEqual(surface["title"], "QA Atlas Save")
+        self.assertEqual(surface["current_location"]["name"], "QA Gate")
         self.assertFalse(surface["can_act"])
         self.assertFalse(surface["is_live_view"])
 


### PR DESCRIPTION
## Summary

Refs #117.

Adds the OpenWorlds atlas/map rollout slice as a viewer-owned read model bound to the exported Map screen.

- Adds `GET /atlas-surface`.
- Projects known locations, current location, route edges, travel options, quest markers, strategic clocks, downtime projects, region control, camp availability, and last strategic tick.
- Binds `viewer/openworlds/screen-map.jsx` to `/atlas-surface` instead of prototype `state.locations`.
- Keeps travel as a player intent through existing `POST /move`.
- Keeps camp/rest display read-only until an engine-backed rest action is explicitly wired.
- Filters hidden locations and private snapshot fields from the browser payload.

## Architecture Notes

The atlas remains a read/adaptation layer:

- `build_atlas_surface(...)` derives from the engine-owned campaign snapshot.
- Browser clicks only select locations locally; they do not mutate travel state.
- Travel buttons submit existing `/move` payloads such as `{ kind: "do", text: "Travel to Rain Market" }`.
- Hidden locations are omitted unless they are the current location.
- Strategic clocks/projects/region control are read-only projections. The browser does not advance clocks, projects, world ticks, quest state, or location state.
- Marking a location is local UI only and is labelled that way.

## Files To Review

- `viewer/server.py`
  - `build_atlas_surface`
  - `_atlas_known_locations`
  - `_atlas_travel_options`
  - `_atlas_strategic`
  - `/atlas-surface` route
- `viewer/openworlds/screen-map.jsx`
  - `atlasSurfaceFromCampaign`
  - `ScreenMap`
  - `AtlasSidebar`
  - `/move` travel submission path
- `viewer/tests/test_atlas_surface.py`
- `viewer/tests/test_openworlds_static.py`

## Validation

Local validation from `/Volumes/LEXAR/repos/ClawDnD-openworlds-map-surface`:

```bash
python3 -m py_compile viewer/server.py
python3 -m unittest discover -s viewer/tests -q
python3 scripts/license_check.py
git diff --check
```

Rendered smoke:

```bash
CLAWDND_STATE_DIR=/Volumes/LEXAR/Codex/clawdnd-atlas-surface-smoke python3 viewer/server.py camp_map 18767
```

Then Chrome/Playwright against `http://127.0.0.1:18767/openworlds/`, keyboard shortcut `m`:

- `Basilisk Gate` and `Rain Market` rendered.
- Hidden `Hidden Crypt` did not render.
- Private strings did not render.
- Selecting `Rain Market` rendered `Find the Rain Seller` and `Sapper Cell Regroups`.
- No page errors.
- Only known development warnings appeared: React DevTools info and Babel standalone production warning.

Screenshot artifacts:

- `/Volumes/LEXAR/Codex/clawdnd-atlas-surface-smoke/openworlds-atlas-1440x900.png`
- `/Volumes/LEXAR/Codex/clawdnd-atlas-surface-smoke/openworlds-atlas-rain-market-1440x900.png`

## Rollback Notes

This PR is viewer-only. It does not change engine/rules/voice APIs or campaign persistence. Reverting it removes `/atlas-surface` and restores the previous prototype map behavior without touching saved campaign state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * World map now syncs live atlas data from the engine and auto-refreshes while visible; manual Refresh available
  * Added Make Camp / Camped toggle (disabled when unavailable) and reduced rest to a toast notification
  * Travel actions show immediate success/failure toasts and indicate busy state
  * Sidebar added: travel controls, quests/clocks/projects, and discovered locations
  * Simplified location pin hover previews showing current location and known routes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->