### PR TITLE
fix(engine): encounter audit hardening + start_combat over-match outlook

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -2064,6 +2064,24 @@ def start_combat(campaign_id: str, combatant_ids: list[str]) -> dict:
             f"Combat begins: {names}.",
             {"event": "combat_start", "round": c.combat.round, "combatants": ordered},
         )
+        # Fold in over-match outlook for DM-staged set-pieces (not just wander encounters):
+        # any time monsters are in the fight the DM may have forgotten to call
+        # encounter_outlook, so we auto-surface `must_offer_out` here.  We only attach
+        # `outlook` when the fight is over-matched (must_offer_out OR deadly) so a
+        # fair fight's view stays UNCHANGED (purely additive).
+        monster_ids_in_combat = [
+            cid for cid in combatant_ids
+            if c.characters.get(cid) is not None and c.characters[cid].kind == "monster"
+        ]
+        if monster_ids_in_combat and _party_levels(c):
+            try:
+                monster_xps = _resolve_monster_xps(c, None, monster_ids_in_combat)
+            except ValueError:
+                monster_xps = []
+            if monster_xps:
+                outlook = _outlook_for_xps(_party_levels(c), monster_xps)
+                if outlook.get("must_offer_out") or outlook.get("band") == "deadly":
+                    view["outlook"] = outlook
         save_campaign(c)
         return view
 
@@ -4357,6 +4375,8 @@ def encounter_outlook(
     may kill. Read-only."""
     c = _require(campaign_id)
     xps = _resolve_monster_xps(c, monster_xps, monster_ids)
+    if not xps:
+        raise ValueError("pass monster_xps or monster_ids — no XP to evaluate")
     levels = _party_levels(c)
     return _outlook_for_xps(levels, xps)
 
@@ -4370,6 +4390,7 @@ def _outlook_for_xps(party_levels: list[int], monster_xps: list[int]) -> dict:
     Returns ``{band, overmatch_ratio, avg_party_level, must_offer_out, guidance}``.
     `overmatch_ratio = adjusted_xp / deadly_threshold`; `must_offer_out =
     avg_party_level <= 5 and overmatch_ratio >= 2.0` (the troll/dragon boundary)."""
+    assert party_levels, "party_levels must be non-empty"
     avg_party_level = sum(party_levels) / len(party_levels)
     deadly = encounter.xp_thresholds(party_levels)["deadly"]
     adjusted = encounter.adjusted_xp(monster_xps)

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -591,3 +591,55 @@ def test_action_surge_by_non_current_combatant_does_not_unlock_current_turns_sec
     server.attack(cid, cur, target, attack_bonus=5, damage_dice="1d6")
     with pytest.raises(ValueError, match="already attacked this turn"):
         server.attack(cid, cur, target, attack_bonus=5, damage_dice="1d6")
+
+
+# =========================================================================
+# Change 2: start_combat outlook fold-in
+# =========================================================================
+
+
+def test_start_combat_outlook_present_for_overmatch(tmp_path, monkeypatch):
+    """L3 party vs dragon-tier foe → start_combat view has 'outlook' with must_offer_out true.
+
+    Uses spawn_monster("Troll") — CR 5, 1800 XP — and two copies to hit the 2x+ overmatch
+    threshold for a level-3 party (deadly budget ~1600 XP, adjusted_xp for 2 trolls with
+    x1.5 multiplier = 5400, ratio ~3.375 > 2.0).  Must_offer_out fires for avg_level <= 5."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Outlook Fold-in Test")["id"]
+    # 4x level-3 player characters
+    pc_ids = [
+        server.create_character(cid, f"PC{i}", kind="player",
+                                class_name="fighter", level=3)["id"]
+        for i in range(4)
+    ]
+    # Spawn 2 Trolls — the spawn path sets xp_value on the Character automatically
+    spawned = server.spawn_monster(cid, "Troll", count=2)
+    troll_ids = [s["id"] for s in spawned["spawned"]]
+
+    view = server.start_combat(cid, pc_ids + troll_ids)
+    assert "outlook" in view, "over-matched fight must surface 'outlook' in start_combat view"
+    assert view["outlook"]["must_offer_out"] is True
+
+
+def test_start_combat_no_outlook_for_fair_fight(tmp_path, monkeypatch):
+    """A balanced fight (L5 party vs a single Bandit) must NOT add 'outlook' to the view.
+
+    Bandit = CR 1/8, 25 XP — trivially below even the easy budget for 4x L5 PCs.
+    The view must be UNCHANGED (no 'outlook' key added for a non-deadly fight)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Fair Fight Test")["id"]
+    pc_ids = [
+        server.create_character(cid, f"PC{i}", kind="player",
+                                class_name="fighter", level=5)["id"]
+        for i in range(4)
+    ]
+    # Spawn a Bandit (CR 1/8, 25 XP) — fair for 4x L5
+    spawned = server.spawn_monster(cid, "Bandit", count=1)
+    bandit_id = spawned["spawned"][0]["id"]
+
+    view = server.start_combat(cid, pc_ids + [bandit_id])
+    assert "outlook" not in view, "a fair/easy fight must NOT add 'outlook' to start_combat view"

--- a/servers/engine/tests/test_parley.py
+++ b/servers/engine/tests/test_parley.py
@@ -347,3 +347,16 @@ def test_no_model_change_old_snapshot_round_trips():
     c = Campaign.model_validate(payload)
     assert c.title == "Legacy"
     assert c.events == [] if hasattr(c, "events") else True  # no events field added in P1-2
+
+
+# =========================================================================
+# M2: encounter_outlook raises when no XP can be resolved (silent all-clear fix)
+# =========================================================================
+
+
+def test_encounter_outlook_raises_when_no_xps_passed(outlook_campaign):
+    """encounter_outlook with neither monster_xps nor monster_ids must raise ValueError
+    rather than silently returning a misleading all-clear outlook."""
+    cid = outlook_campaign
+    with pytest.raises(ValueError, match="no XP to evaluate"):
+        server.encounter_outlook(cid)

--- a/servers/engine/tests/test_wander.py
+++ b/servers/engine/tests/test_wander.py
@@ -166,6 +166,34 @@ def test_region_creature_pools_all_resolve_in_bestiary():
 
 
 # =========================================================================
+# M1: compound-region keyword priority (danger-adjective before terrain noun)
+# =========================================================================
+
+
+@pytest.mark.parametrize(
+    "region,expected_tier,expected_rate_key",
+    [
+        ("The Haunted Wood", "undead", "haunted"),
+        ("Shadow Forest", "undead", "shadow"),
+        ("Cursed Mountain Pass", "undead", "cursed"),
+        ("Dread Swamp", "undead", "dread"),
+    ],
+)
+def test_compound_region_danger_adjective_wins(region, expected_tier, expected_rate_key):
+    """Danger-adjective keywords must match BEFORE terrain nouns in both REGION_RATES
+    and _REGION_TIER, so 'The Haunted Wood' → undead (not forest), etc."""
+    # _REGION_TIER resolution
+    assert wander._region_tier(region) == expected_tier, (
+        f"{region!r} resolved to {wander._region_tier(region)!r}, expected {expected_tier!r}"
+    )
+    # REGION_RATES resolution — the danger keyword's rate, not the terrain noun's rate
+    assert wander.encounter_chance(region) == wander.REGION_RATES[expected_rate_key], (
+        f"{region!r} encounter_chance is {wander.encounter_chance(region)}, "
+        f"expected REGION_RATES[{expected_rate_key!r}]={wander.REGION_RATES[expected_rate_key]}"
+    )
+
+
+# =========================================================================
 # INTEGRATION: engine seams stage real monster Characters + the payload
 # =========================================================================
 

--- a/servers/engine/wander.py
+++ b/servers/engine/wander.py
@@ -39,6 +39,18 @@ BASE_RATE = 0.30
 # forest" reads as haunted (the more dangerous tag) before forest. Values are the
 # raw per-roll chance BEFORE modifiers.
 REGION_RATES: dict[str, float] = {
+    # overtly hostile — danger-adjective keywords FIRST so compound names like
+    # "The Haunted Wood" or "Cursed Mountain Pass" resolve to the right tier before
+    # any terrain noun (e.g. "wood", "mountain") can match first.
+    "dungeon": 0.50,
+    "ruin": 0.45,
+    "haunted": 0.50,
+    "cursed": 0.55,
+    "shadow": 0.50,
+    "blight": 0.50,
+    "dread": 0.55,
+    "deathly": 0.55,
+    "underdark": 0.55,
     # tame / civilized — patrolled, low risk
     "town": 0.08,
     "city": 0.08,
@@ -48,16 +60,6 @@ REGION_RATES: dict[str, float] = {
     "safe": 0.05,
     "haven": 0.05,
     "sanctuary": 0.05,
-    # ordinary wilderness — the default-ish overland danger
-    "hill": 0.30,
-    "forest": 0.32,
-    "wood": 0.32,
-    "fell": 0.32,
-    "moor": 0.32,
-    "coast": 0.28,
-    "river": 0.28,
-    "plain": 0.25,
-    "field": 0.25,
     # rough country — more likely to bite
     "marsh": 0.40,
     "swamp": 0.40,
@@ -68,22 +70,28 @@ REGION_RATES: dict[str, float] = {
     "frontier": 0.38,
     "wild": 0.40,
     "border": 0.36,
-    # overtly hostile — something is almost always out there
-    "dungeon": 0.50,
-    "ruin": 0.45,
-    "haunted": 0.50,
-    "cursed": 0.55,
-    "shadow": 0.50,
-    "underdark": 0.55,
-    "blight": 0.50,
-    "dread": 0.55,
-    "deathly": 0.55,
+    # ordinary wilderness — the default-ish overland danger
+    "hill": 0.30,
+    "forest": 0.32,
+    "wood": 0.32,
+    "fell": 0.32,
+    "moor": 0.32,
+    "coast": 0.28,
+    "river": 0.28,
+    "plain": 0.25,
+    "field": 0.25,
 }
 
 # A coarse danger TIER for each region keyword, used only to bias *which* creatures
 # get drawn (see REGION_CREATURES / _region_pool). Independent of REGION_RATES so a
 # region's frequency and its flavor can be tuned separately.
 _REGION_TIER: dict[str, str] = {
+    # danger-adjective keywords FIRST (same ordering discipline as REGION_RATES) so
+    # compound names like "The Haunted Wood" → undead, not forest.
+    "ruin": "undead", "haunted": "undead", "cursed": "undead",
+    "shadow": "undead", "blight": "undead", "dread": "undead",
+    "deathly": "undead", "dungeon": "undead",
+    "underdark": "underdark",
     "town": "civilized", "city": "civilized", "village": "civilized",
     "keep": "civilized", "road": "civilized", "safe": "civilized",
     "haven": "civilized", "sanctuary": "civilized",
@@ -91,11 +99,11 @@ _REGION_TIER: dict[str, str] = {
     "coast": "coast",
     "mountain": "mountain", "hill": "mountain", "waste": "mountain",
     "badland": "mountain",
+    "frontier": "mountain",  # frontier → mountain tier (rough country, elevated risk)
     "forest": "forest", "wood": "forest", "fell": "forest", "moor": "forest",
-    "ruin": "undead", "haunted": "undead", "cursed": "undead",
-    "shadow": "undead", "blight": "undead", "dread": "undead",
-    "deathly": "undead", "dungeon": "undead",
-    "underdark": "underdark",
+    "wild": "forest",  # wild → forest tier (untamed country)
+    "border": "civilized",  # border → civilized tier (contested but still a boundary region)
+    # plain/field intentionally absent: they fall through to BASE_RATE / "wilderness" tier
 }
 
 # Creature pools by flavor tier, in ROUGHLY ascending CR within each list. Every


### PR DESCRIPTION
Post-merge adversarial-audit fixes for #137/#138/#140, plus extending the must_offer_out balance signal to ANY over-matched fight.

## Audit fixes
- **M1** (region keyword priority): danger adjectives (haunted, cursed, shadow, blight, dread, deathly, dungeon, ruin, underdark) now sort BEFORE terrain nouns in both REGION_RATES and _REGION_TIER. Fixes compound-name mis-resolution — "The Haunted Wood" was resolving to forest + low danger rate; now resolves to the undead tier + danger rate. All keys/values preserved (35 rates / 33 tiers); order only.
- **L1**: added _REGION_TIER entries frontier→mountain, wild→forest, border→civilized (plain/field intentionally fall through to wilderness, commented).
- **M2**: encounter_outlook now raises ValueError on empty XP input (was a silent "trivial/all-clear" — a footgun for the balance doctrine).
- **L2**: _outlook_for_xps asserts party_levels is non-empty (latent ZeroDivisionError guard).

## start_combat over-match fold-in
Any DM-staged fight with monster combatants now auto-computes the over-match outlook (the SAME _outlook_for_xps as encounter_outlook) and attaches it to the combat view ONLY when over-matched (must_offer_out OR deadly). So a set-piece dragon surfaces the offer-an-out signal automatically — the DM no longer has to remember to call encounter_outlook (the reach-for lesson). Purely additive: fair fights unchanged; an unresolvable monster id degrades to no-outlook.

## Tests / safety
- 1010 passed (+7: M1 compound-region parametrized, M2 raise, 2 start_combat cases). license_check passes.
- Additive: no new persisted model field (outlook lives only in the runtime combat view); old snapshots round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Combat view now automatically includes encounter difficulty indicators for overmatched party encounters.

* **Bug Fixes**
  * Fixed region name parsing to correctly prioritize danger keywords in compound region names (e.g., "Haunted Wood" now resolves as undead-themed).
  * Improved error handling when evaluating encounters with incomplete monster data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->