### PR TITLE
qa: standardize scoring system (SCORING.md) + scorecard ledger (SCORECARD.md)

### DIFF
--- a/qa/SCORECARD.md
+++ b/qa/SCORECARD.md
@@ -1,0 +1,29 @@
+# ClawDnD QA Scorecard — running ledger
+
+> The "what did each run score, and what change was under test" log. Updated per QA run.
+> System reference: `qa/SCORING.md`. Targets: **story ≥ 4.3, mechanical ≥ 4.5, gate GREEN, 0 critical/high.**
+> `*` = RED-capped (gate failed → scores forced ≤ 2.5; not a real quality reading).
+> Scorer: claude `score.sh` unless noted `[oc]` (gpt-5.4, grades ~1.5 harsher).
+
+| Run | Date | World | Persona | Model | Beats | Gate | Story | Mech | AngryDM | Change under test / notes |
+|---|---|---|---|---|---|---|---|---|---|---|
+| newmain-rogue2 | ~2026-05-25 | baldurs-gate | rogue (social) | sonnet | — | GREEN | 4.1 | 3.0 | 2.0 | 85-commit merge validation. Low mech/angry = social run, little combat exercised (coverage artifact, not engine defect). |
+| ocwiz-claude | ~2026-05-26 | baldurs-gate | wizard | gpt-5.4 [oc] | — | RED | 2.5* | 2.5* | 2.4* | RED-capped (gate failed). gpt-5.4 OpenClaw-path shakedown. |
+| duo-typed1 | 2026-05-26 | baldurs-gate | wayfarer | sonnet | 12 | GREEN | 4.0 | 4.0 | 3.3 | DM reframed travel→urban political thriller (verdict: "prestige-tier"). **add_quest=0 (reach-for gap CONFIRMED)**; 0 wander encounters fired (urban, few travel triggers → variety not exercised in play). angry-dm 3.3 = combat-light coverage artifact. |
+| duo-caster1 | 2026-05-26 | baldurs-gate | battlemage | sonnet | 10 | GREEN | 4.0 | 3.8 | 2.6 | **add_quest=3** (contract framing prompts quest-tracking ✓). But player made 11 say/6 do/3 check, **0 cast_spell/0 attack** — DM built an infiltration+moral-dilemma scene; the AI player engaged via roleplay, not combat → no formal fight → angry-dm 2.6 is a **combat-coverage artifact, NOT an engine defect**. |
+
+## Change log (run ↔ engine delta)
+- **#137** wandering-encounter system (travel/camp combat risk) — merged.
+- **#138** Parley scaffold + encounter_outlook + balancing doctrine — merged.
+- **#139** GPT-5.4 / OpenClaw QA path (infra) — merged.
+- **#140** typed multi-resolution encounters (combat/skill/social/hazard/boon; 60% non-combat) — merged. Engine variety validated in vivo (pick_typed_encounter distribution: generic 40% combat, road 20%, undead ruin 61%).
+
+## World scope (owner steer 2026-05-26)
+- **Baldur's Gate is THE world.** All content + QA target BG. Sundered Reach was a side-option — **deprioritized** (existing SR content stays in place, no further investment). Enrich BG instead (area-detail files, BG-flavored mid-tier monsters, map depth). Perfect the whole system on BG; a 2nd world becomes near-free via the universe seed later.
+
+## Open quality threads (drive the loop)
+- **angry-dm / 5e-fidelity stuck ~2.6–3.3 = AI-player NARRATIVE DRIFT, not an engine defect.** duo-caster1 proved it: even a combat-seeking battlemage made 0 cast_spell/0 attack (11 say/6 do/3 check) — both AI player and DM gravitate to roleplay/social/puzzle, so combat (the richest 5e surface) is rarely *formally run*. A human player would fight. FIX = a **forced-combat QA lane** (a scenario that guarantees an engine-run fight) to read real 5e-fidelity — NOT an engine change. (The engine combat is validated by the audit + the combat-torture test.)
+- **add_quest reach-for — CONFIRMED + nuanced.** duo-typed1 (emergent thriller) = 0; duo-caster1 (explicit contract) = 3. The DM tracks quests when the goal is explicit, not in emergent play. STRUCTURAL fix = the **Campaign Director** (#72) surfacing "untracked active hook → add_quest" each beat (anchored on #72).
+- **Story ~4.0 (vs 4.3 target)** — close. The Campaign Director (#71–73) is the lever (scene-debt: setup-without-payoff, no-reversal, NPC-introduced-but-silent).
+- **Companion-agent surface under-tested** — recent QA = player+DM duos only; restore `run_party.sh` (1 AI companion + DM-voiced others) to the cadence (exercises companion clarify/tactics + the betrayal path, #142).
+- **must_offer_out (set-piece path)** — DONE: the `start_combat` outlook fold-in (#146) now auto-surfaces it for any over-matched fight, not just wander.

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -1,0 +1,63 @@
+# ClawDnD QA Scoring System — standardized reference
+
+> Source of truth for HOW we measure a playtest. Current as of 2026-05-26.
+> The running results ledger is `qa/SCORECARD.md`.
+
+The fitness function = **1 hard behavioral gate** (deterministic pass/fail) + **3 LLM
+lenses** (each 1–5). The gate is the honest floor; the lenses grade quality above it.
+
+## 1. Behavioral gate — HARD pass/fail (`qa/assert_behavioral.py`)
+LLM scorers grade prose and can't be trusted to flip RED on a structurally broken run,
+so this deterministic gate does. Exit 0 = GREEN (warnings allowed), 1 = RED. FATAL checks:
+- DM turns > 0 **and** player turns > 0; ≥ 1 dice roll.
+- **World-progression floor** (runs ≥ 6 beats): the clock advanced **and** the party
+  visited ≥ 2 locations. (+ WARN if no new named NPC entered.)
+- Player did **not** narrate the world / assert outcomes (the facade over-write heuristic, H4).
+- **Structural story-craft floor**: if a companion is present, it speaks (no "log, not a scene").
+- **Mechanical resolution**: a player `[cast]`/`[attack]`/`[check]`/`[save]` move MUST be
+  resolved by the DM (`cast_spell`/`attack`/`saving_throw`/`roll`) — an unresolved
+  declaration is FATAL.
+- **State integrity**: combat not left active at end-of-run; no stray monsters at a location;
+  no lingering conditions left dangling.
+- WARN (soft, not fatal): player asked **0 questions + 0 checks** across the run →
+  "passive plot-passenger" — this is where `clarify` / `request_check` usage is tracked.
+
+### RED-cap (anti-loophole)
+If the gate is RED, all three LLM scorecards are **capped to ≤ 2.5 / INVALID** and
+annotated with the failed checks (`clawdnd_cap_score_red`). A dead/non-progressing scene
+can never display as 4.1 again. On a GREEN run, scores pass through untouched.
+
+## 2. The three LLM lenses (1–5 each; run concurrently)
+Scored by `qa/score.sh` (claude -p) or `qa/score_openclaw.sh` (gpt-5.4, off the claude quota).
+
+| Lens | Rubric / schema | Scores what | Dimensions |
+|---|---|---|---|
+| **Mechanical** | `rubric.md` / `score_schema.json` | DM tool-stream (`$RUN.md`) | tool_sourced, rules_correctness, state_integrity, companion_agency, player_agency, exploration, narrative_pacing, robustness |
+| **Story-craft** ("The Loremaster's Eye" / Tolkien) | `rubric_tolkien.md` / `score_schema_tolkien.json` | two-sided play (`$RUN.play.md`) | scene_craft, grandeur, character_depth, prose_atmosphere, dramatic_momentum, thematic_resonance, memorability (+ scope / progressed / per-act breakdown) |
+| **5e rules-fidelity** ("The Angry DM") | `rubric_angry_dm.md` / `score_schema_angry_dm.json` | DM tool-stream vs SRD 5.2.1 bench card | rules_as_written, mechanical_completeness, tool_fidelity, action_economy, combat_resolution, conditions_and_effects (+ coverage) |
+
+- **Story-craft is STINGY + ACT-RELATIVE**: BG3-calibrated, detects scope (an 8-beat slice
+  is ~Act 1, NOT docked for lacking a climax); judges grandeur/stakes relative to act position.
+- **Mechanical**: hallucinated mechanics are the worst defect; `tool_sourced` + `rules_correctness` weighted heaviest.
+- **Angry DM**: adversarial; walks an exhaustive 5e checklist (d20 tests, ~15 action types, all 14 conditions).
+
+## 3. North-Star targets (the loop's exit bar)
+- **Story-craft ≥ 4.3**, **Mechanical ≥ 4.5**, **gate GREEN**, **zero critical/high** adversarial defects.
+- **GPT-5.4 grades ~1.5 pts HARSHER than claude.** Claude (`score.sh`) is the PRIMARY baseline;
+  gpt-5.4 (`score_openclaw.sh`) is a stricter cross-check, not the headline number.
+
+## 4. Runners
+| Script | What it runs |
+|---|---|
+| `run_duo.sh <run> <world> <persona> [beats] [budget]` | AI player + DM duo (claude -p); 3 lenses + gate |
+| `run_duo_openclaw.sh <run> <world> <persona> [beats]` | same, via gpt-5.4 (OpenClaw gateway; off the claude quota) |
+| `run_party.sh` | AI player + N companion AGENTS + DM (multi-agent ensemble; the betrayal path) |
+| `run_parallel.sh` | 2–3 isolated concurrent runs (the velocity model) |
+| `run_qa.sh` | single-agent full-plugin playtest |
+
+Default DM/player model = `sonnet` (`CLAWDND_DM_MODEL` / `CLAWDND_ACTOR_MODEL` env override; Opus for key structural-adherence runs).
+
+## 5. Reading a result line
+`[duo] done. story-craft=X mechanical=Y angry-dm=Z behavioral=GREEN|RED`
+- **RED** ⇒ X/Y/Z are RED-capped; read `$RUN.gate.txt` for the failed checks.
+- **GREEN** ⇒ real scores; compare against the North-Star targets and log to `SCORECARD.md`.

--- a/qa/play_player_wayfarer.txt
+++ b/qa/play_player_wayfarer.txt
@@ -1,0 +1,17 @@
+You are the PLAYER — a single protagonist at a D&D table, NOT the Dungeon Master. You control ONE character, acting ONLY through your tools (the "clawdnd-player" MCP). You cannot narrate the world, voice NPCs, or decide outcomes — the DM and the dice do that.
+
+YOUR CHARACTER: Wren Calloway — a level-3 half-elf ranger-scout who carries messages and small goods between the settlements of a dangerous region. You know the roads, the weather, and the things that hunt the dark between towns. You are competent and curious, neither a coward nor a hothead: you fight when a fight finds you, but you would rather read a stranger, find the safe ford, or talk a wary patrol down. You have a delivery to make and a long way to go.
+
+HOW YOU PLAY — YOU ARE ON A JOURNEY:
+- KEEP MOVING. Your through-line is travel: you are crossing the region to reach the next settlement and deliver your charge. In most beats, PUSH ONWARD — do("I press on up the road toward the next waypoint") / do("I make for the river crossing before dark") / say() your intent to travel. Ask the DM what lies along the route (clarify) and MOVE.
+- MAKE CAMP when the day runs long — do("I find defensible ground and make camp for the night"). Travel and camp are where the road comes alive.
+- MEET WHAT THE ROAD BRINGS, in kind:
+  * A person on the road (a wary patrol, a desperate pilgrim, a toll-bravo): TALK first — say() a line, request_check("Insight")/("Persuasion") to read or sway them. Don't open with steel.
+  * An obstacle (a washed-out ford, a rockfall, a sealed barrow-door): SOLVE it — request_check("Athletics")/("Survival")/("Acrobatics") as fits.
+  * A hazard (a sucking bog, a crumbling cliff path): brave it carefully — request_check or a saving throw as the DM calls.
+  * A real threat that means you harm: THEN fight — attack / cast_spell / do("I loose an arrow at the lead wolf").
+- If the DM hands you a set of options (a "parley" or a list of choices), you may pick one — OR do anything else you like. The options are a menu, not a cage.
+- Declare INTENT, never results: request_check("Survival") to find the path — don't assume you found it. attack("the charging boar") — don't assume it died. The DM + dice resolve everything.
+- END EVERY TURN WITH AT LEAST ONE MOVE (do / say / request_check / attack / cast_spell / use_item / clarify). look()/my_sheet() are read-only and don't count — still take a move in the same turn. At the very START, call my_sheet() once to learn your real skills/gear, then act.
+
+Make your move(s) now. You have a road to walk and a delivery to make. Set out.


### PR DESCRIPTION
Re-establishes the QA measure as durable, committed artifacts (it was living in working context and got lost across compactions).

- **qa/SCORING.md** — the fitness-function reference: the hard behavioral gate (assert_behavioral.py) + RED-cap; the 3 LLM lenses (mechanical / Tolkien story-craft / Angry-DM 5e-fidelity) with dimensions; North-Star targets (story >=4.3, mech >=4.5, gate GREEN); the runners.
- **qa/SCORECARD.md** — the running results ledger (run / gate / 3 scores / change-under-test), seeded with the recent real runs, plus open quality threads and the BG-only world scope.
- **qa/play_player_wayfarer.txt** — a travel-heavy persona for exercising wandering-encounter variety.

Docs + a QA persona only; zero runtime impact on the plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added player gameplay guide with character information and turn-based play rules
  * Established QA scoring framework and validation standards documentation
  * Updated test run tracking with latest quality metrics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->