### PR TITLE
content(baldurs-gate): 7 navigable area-detail files (BG enrichment)

### DIFF
--- a/content/worlds/baldurs-gate/areas/counting-house.json
+++ b/content/worlds/baldurs-gate/areas/counting-house.json
@@ -1,0 +1,19 @@
+{
+  "id": "loc-counting-house",
+  "name": "the Counting House",
+  "description": "A basalt-faced hall that straddles the boundary between the Upper and Lower cities, its vaulted interior always smelling of ink, candle-wax, and old money. Above ground the patriars' coin-clerks argue over ledgers behind iron grilles; below ground the Guild has long kept its own set of books. The Absolute crisis scarcely touched the facade — the sums still balance, the fees are still collected — but the personnel have changed, and the trapdoor to the lower vaults opens a fraction more freely than it used to.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "Baldur's Gate — Upper City",
+    "Baldur's Gate — Lower City"
+  ],
+  "tags": [
+    "finance",
+    "city",
+    "underworld",
+    "intrigue"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/content/worlds/baldurs-gate/areas/elfsong-tavern.json
+++ b/content/worlds/baldurs-gate/areas/elfsong-tavern.json
@@ -1,0 +1,19 @@
+{
+  "id": "loc-elfsong-tavern",
+  "name": "the Elfsong Tavern",
+  "description": "A sprawling, smoke-dark inn on the Lower City's main drag, its common room permanently lit by tallow candles and the glow of argument. Three floors of creaking galleries look down on a bar where Flaming Fist veterans drink beside tiefling refugees and tadpole-survivors who have nowhere quieter to go. The tavern owes its name to a ghostly elven voice that rises, unbidden, between the second and third bell — mournful, wordless, beautiful in the way a wound is beautiful. The barkeep does not comment on it. Neither does anyone who stays more than a night.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "Baldur's Gate — Lower City",
+    "Bloomridge Market"
+  ],
+  "tags": [
+    "tavern",
+    "city",
+    "hub",
+    "haunt"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/content/worlds/baldurs-gate/areas/heapside-warrens.json
+++ b/content/worlds/baldurs-gate/areas/heapside-warrens.json
@@ -1,0 +1,19 @@
+{
+  "id": "loc-heapside-warrens",
+  "name": "the Heapside Warrens",
+  "description": "The oldest and lowest district of the Lower City, heaped against the original harbor wall and rebuilt so many times that no two buildings share a right angle. The streets are shoulder-width, the tenements lean into one another for structural support, and the alleys beneath them are a permanent dusk. Heapside was already the Gate's poorest quarter before the crisis; after, it swallowed the overflow — families from the Netherbrain's scar, discharged Fist soldiers without pensions, tadpole-survivors who could not go home. A dozen unofficial 'ward bosses' keep an uneasy order the watch no longer attempts, and their negotiations are conducted in the language of debt.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "Baldur's Gate — Lower City",
+    "the Siltwharf Steps",
+    "the Undercity Sewers"
+  ],
+  "tags": [
+    "slums",
+    "city",
+    "underworld"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/content/worlds/baldurs-gate/areas/little-calimshan.json
+++ b/content/worlds/baldurs-gate/areas/little-calimshan.json
@@ -1,0 +1,19 @@
+{
+  "id": "loc-little-calimshan",
+  "name": "Little Calimshan",
+  "description": "A tight neighborhood pressed against the Outer City's southern wall, its flat-roofed tenements and tiled arches as out of place on the Chionthar as a desert wind. The community that built it came north generations ago from the Calim Empire and stayed; their tea-stalls, silk-vendors, and an old Calishite wayshrine to Tymora line a quarter-mile of alley that smells of cardamom and tallow. Since the crisis an influx of Outer City refugees has doubled the quarter's population, and the original residents navigate the crowding with a wary, proprietary hospitality. The Guild collects quietly here, and the guild-runners are always from the neighborhood.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "The Outer City & Rivington",
+    "the Siltwharf Steps"
+  ],
+  "tags": [
+    "district",
+    "culture",
+    "underworld",
+    "city"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/content/worlds/baldurs-gate/areas/sorcerous-sundries.json
+++ b/content/worlds/baldurs-gate/areas/sorcerous-sundries.json
@@ -1,0 +1,18 @@
+{
+  "id": "loc-sorcerous-sundries",
+  "name": "Sorcerous Sundries",
+  "description": "The Gate's foremost emporium of the arcane, a tall merchant-house whose shelves run floor to ceiling with bottled lights, catalogued spell-scrolls, and curiosities with price-tags that do not explain what they do. Since the crisis the management has added a locked rear counter for tadpole-related 'consultations' — a polite term for frightened people asking whether they are going to change. The answer is usually hedged, costs three gold, and does not comfort. A driftglobe above the door still flickers when certain names are spoken nearby; no one on staff has managed to make it stop.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "Baldur's Gate — Lower City",
+    "the Elfsong Tavern"
+  ],
+  "tags": [
+    "magic",
+    "shop",
+    "city"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/content/worlds/baldurs-gate/areas/undercity-sewers.json
+++ b/content/worlds/baldurs-gate/areas/undercity-sewers.json
@@ -1,0 +1,20 @@
+{
+  "id": "loc-undercity-sewers",
+  "name": "the Undercity Sewers",
+  "description": "A vast network of vaulted brick tunnels threading beneath the Lower City, older than the walls above and more honestly built. Torchlight carries six feet before the dark closes in; the trickle of water is constant and the smell is everything you expect. The Absolute crisis cracked the deeper chambers — a section near the harbor still runs with something that is not quite water and does not quite dry — and Bhaalist murder-shrines left in the rock-cut alcoves have not all been found. The Guild moves freely here; so, it is increasingly suspected, does something else. Street-access grates are everywhere and the stairs that lead up to the Elfsong's cellar are an open secret.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "Baldur's Gate — Lower City",
+    "Little Calimshan",
+    "the Elfsong Tavern"
+  ],
+  "tags": [
+    "underworld",
+    "sewers",
+    "dungeon",
+    "city"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/content/worlds/baldurs-gate/areas/wyrms-rock.json
+++ b/content/worlds/baldurs-gate/areas/wyrms-rock.json
@@ -1,0 +1,19 @@
+{
+  "id": "loc-wyrms-rock",
+  "name": "Wyrm's Rock Fortress",
+  "description": "The great drum-towered fortress on the promontory above the Chionthar, named for the legendary sea-beast Balduran slew when he first sailed this shore. The Steel Watch foundry beneath it is wrecked and silent — the assembly-hall floors still carpeted in burst-open construct casings — but the fortress itself was only bruised by the battle. The Flaming Fist holds it now, more by habit than by any duke's order, and the walls look down on a city nobody yet governs. The Archduke's receiving-rooms stand empty and exactly as Gortash left them, which suits the Fist just fine and the patriars not at all.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "Baldur's Gate — Upper City",
+    "the Counting House"
+  ],
+  "tags": [
+    "fortress",
+    "power",
+    "city",
+    "ruins"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/servers/engine/tests/test_content.py
+++ b/servers/engine/tests/test_content.py
@@ -1108,16 +1108,17 @@ def test_load_world_areas_absent_dir_is_empty():
 
 
 def test_seed_world_seeds_areas_additively_with_resolved_connections():
-    # ADDITIVE: after the 7 authored regions, the 2 example areas are seeded as Locations.
+    # ADDITIVE: after the authored regions, all area files are seeded as Locations.
     w = content.load_world_data("baldurs-gate")
     base_regions = len(w["regions"])
+    n_areas = len(content.load_world_areas("baldurs-gate"))
     c = content.seed_world(w)
     by_name = {loc.name: loc for loc in c.locations.values()}
     # the authored regions are all still present, plus the ingested areas
     assert "Baldur's Gate — Lower City" in by_name      # an authored region
     assert "Bloomridge Market" in by_name               # an ingested area
     assert "the Siltwharf Steps" in by_name
-    assert len(c.locations) == base_regions + 2
+    assert len(c.locations) == base_regions + n_areas
 
     bm = by_name["Bloomridge Market"]
     # ingested-area fields carried through (region, tags→notes)
@@ -1145,8 +1146,9 @@ def test_seed_world_areas_do_not_double_seed_or_change_start():
     # explicit dedup probe: a region whose NAME an injected area reuses is not re-seeded
     w2 = content.load_world_data("baldurs-gate")
     before = len(content.seed_world(w2).locations)
-    # (the example areas have unique names, so the count is the regions + 2 areas)
-    assert before == len(w2["regions"]) + 2
+    # (all areas have unique names, so the count is the regions + number of area files)
+    n_areas = len(content.load_world_areas("baldurs-gate"))
+    assert before == len(w2["regions"]) + n_areas
 
 
 def test_seed_world_without_areas_is_unchanged(tmp_path, monkeypatch):


### PR DESCRIPTION
## What
Baldur's Gate has a rich 253-page lore corpus but only **2** navigable area-detail files. This adds **7** canonical, lore-grounded areas with original atmospheric prose (post-crisis BG tone):

the Elfsong Tavern · Sorcerous Sundries · the Counting House · Wyrm's Rock Fortress · Little Calimshan · the Undercity Sewers · the Heapside Warrens

## Why
Per the owner steer: BG is THE world — enrich it (areas/maps), not Sundered Reach. Areas give the DM grounded look_around / scene detail + extend the navigable map.

## Safety / reachability
- All 7 cross-link into the navigable graph via connections to existing seed regions + the 2 prior areas + each other — **no orphans** (the lower-city underworld cluster reaches both the Lower City region and the Siltwharf Steps).
- License + attribution strings copied verbatim from the templates (CC-BY-SA Fan Content; original prose, no copied wiki text).
- Also de-fragilized the area-count test to derive the count dynamically via load_world_areas (so it never breaks as areas grow).
- 9 areas load cleanly; **1016 tests pass**; license_check passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seven new areas to Baldur's Gate: Counting House, Elfsong Tavern, Heapside Warrens, Little Calimshan, Sorcerous Sundries, Undercity Sewers, and Wyrm's Rock Fortress, each with detailed descriptions, regional classifications, and interconnections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->