### PR TITLE
feat(engine): Campaign Director + Scene-Debt advisory (#72)

### DIFF
--- a/servers/engine/director.py
+++ b/servers/engine/director.py
@@ -1,0 +1,98 @@
+"""Campaign Director — advisory ranking layer (issue #72).
+
+ADVISORY ONLY. This module consumes detected scene-debts and returns a prioritised
+advisory dict the DM reads at beat-start. It NEVER acts on debts, mutates state,
+or makes narrative-quality judgments. The DM reads + chooses; resolution is always
+an EXPLICIT tool call (resolve_scene_debt), never automatic.
+
+Pure (no I/O): input is a Campaign snapshot, output is a serialisable dict.
+"""
+
+from __future__ import annotations
+
+from models import Campaign, SceneDebt
+import scene_debt as _sd
+
+# Severity order for ranking (high first)
+_SEV_RANK: dict[str, int] = {"high": 0, "med": 1, "low": 2}
+
+# How many debts to surface in the top advisory (cap keeps DM from being overwhelmed)
+_TOP_N: int = 3
+
+
+# ── One-line advisory nudges per debt kind ────────────────────────────────────
+
+def _nudge(debt: SceneDebt) -> str:
+    """Return a one-line DM-facing advisory nudge for a debt."""
+    ev = debt.evidence or {}
+
+    if debt.kind == "hook_untracked":
+        title = ev.get("hook_title") or ev.get("hook_id", "this hook")
+        return f"Untracked hook '{title}' — call add_quest to promote it into a tracked quest."
+
+    if debt.kind == "quest_stalled":
+        title = ev.get("quest_title") or ev.get("quest_id", "this quest")
+        return (
+            f"Quest '{title}' has stalled — weave an advancement beat or decision to move it forward."
+        )
+
+    if debt.kind == "choice_without_outcome":
+        summary = ev.get("summary") or debt.subject
+        return (
+            f"Decision '{summary[:60]}' was offered but never resolved — "
+            f"record the party's choice with update_decision or re-open the scene."
+        )
+
+    if debt.kind == "due_consequence":
+        days = ev.get("overdue_days", 0)
+        note = ev.get("note") or ev.get("consequence_id", "")
+        ago = f" ({days}d overdue)" if days else ""
+        return f"Consequence{ago} is due — call check_consequences to surface it: '{str(note)[:60]}'."
+
+    if debt.kind == "thread_pressure":
+        tid = ev.get("thread_id") or ev.get("consequence_id", "")
+        return (
+            f"Standing thread '{tid}' world-beat is overdue — call world_tick to fire it."
+        )
+
+    if debt.kind == "npc_introduced_silent":
+        name = ev.get("name") or debt.subject
+        return (
+            f"NPC '{name}' has been introduced but hasn't spoken — "
+            f"give them a line or record their first memory with remember."
+        )
+
+    # fallback
+    return f"{debt.kind}: {debt.detail[:80]}"
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def compute(c: Campaign) -> dict:
+    """Detect scene-debts and return a prioritised advisory for the DM.
+
+    Read-only. Returns::
+
+        {
+            "debts": [<top 3 SceneDebt dicts, highest severity first>],
+            "advisory": ["one-line nudge per debt"],
+            "total_debts": <int>,
+        }
+
+    An empty ``debts`` list means no structural debts detected — today's
+    behavior. The DM consults this at beat-start and weaves the top 1-2 nudges
+    organically; it is NOT a mandatory checklist.
+
+    Advisory contract: the engine detects + advises; the DM decides + acts.
+    Resolution is EXPLICIT via resolve_scene_debt, never automatic.
+    """
+    all_debts = _sd.detect(c)
+    # Rank: high → med → low; stable (preserves detection order within a tier)
+    ranked = sorted(all_debts, key=lambda d: (_SEV_RANK.get(d.severity, 9), 0))
+    top = ranked[:_TOP_N]
+    return {
+        "debts": [d.model_dump() for d in top],
+        "advisory": [_nudge(d) for d in top],
+        "total_debts": len(all_debts),
+    }

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -919,6 +919,32 @@ class CampaignBacklog(_StrictModel):
     last_tick_day: int = 0  # the Campaign.day the mechanical backlog tick last advanced through
 
 
+class SceneDebt(_StrictModel):
+    """A structural story debt detected by the Campaign Director (issue #72).
+
+    ADVISORY ONLY: the engine detects debts + returns them; it NEVER acts on them
+    or mutates fiction. The DM reads + chooses. Resolution is EXPLICIT (a
+    resolve_scene_debt tool call), never automatic.
+
+    Additive: empty ``scene_debts`` on Campaign == today's behavior.
+    Old snapshots without this field deserialise unchanged.
+
+    kind values:
+        hook_untracked, quest_stalled, choice_without_outcome,
+        due_consequence, thread_pressure, npc_introduced_silent
+    severity: low | med | high
+    """
+
+    id: str = Field(default_factory=lambda: _new_id("debt"))
+    kind: str  # one of the six structural debt kinds
+    subject: str  # the id of the thing that owes (quest id, hook id, decision id, …)
+    detail: str  # one-line DM-facing description of the debt
+    severity: Literal["low", "med", "high"] = "med"
+    evidence: dict[str, Any] = Field(default_factory=dict)  # structured context for resolution
+    resolved: bool = False
+    resolution_evidence: str = ""  # DM-supplied evidence when marking resolved
+
+
 class QuestHook(_StrictModel):
     """S7 — a lore-derived quest SEED the DM pulls and weaves. The engine ASSEMBLES it at
     world-gen (a dramatic SHAPE tag bound to typed lore nouns + a `grievance` — a wrong the
@@ -1034,3 +1060,10 @@ class Campaign(_StrictModel):
     # tension, momentum, encounters. "downtime": slower — let scenes breathe, lean into
     # social/shopping/recovery. Advisory (the DM reads it via get_state); never computed on.
     pacing_mode: Literal["adventure", "downtime"] = "adventure"
+    # Campaign Director scene-debts (issue #72). ADDITIVE: empty == today's behavior.
+    # Old snapshots lacking this key deserialise to the empty default, round-tripping
+    # byte-identically. The engine never auto-populates this list; debts are detected
+    # read-only by scene_debt.detect() and surfaced via get_scene_debts /
+    # get_campaign_director. Resolved debts are marked in-place (resolved=True) by
+    # resolve_scene_debt and then preserved here as an audit trail.
+    scene_debts: list[SceneDebt] = Field(default_factory=list)

--- a/servers/engine/scene_debt.py
+++ b/servers/engine/scene_debt.py
@@ -1,0 +1,333 @@
+"""Campaign Director — structural scene-debt detection (issue #72).
+
+ADVISORY ONLY: this module detects structural debts from engine STATE and returns
+them as ``SceneDebt`` objects. It NEVER acts on debts, mutates fiction, or makes
+narrative-quality judgments. The DM reads the advisory and CHOOSES what to honour.
+Resolution is always EXPLICIT via ``resolve_scene_debt``, never automatic.
+
+PURE (no I/O): the only input is a ``Campaign`` snapshot in memory. Idempotent
+and deterministic — re-detecting on the same snapshot yields the same result.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from models import Campaign, SceneDebt
+
+
+def _debt_id(kind: str, subject: str) -> str:
+    """Deterministic debt id from kind + subject — stable across re-detections
+    of the same campaign snapshot. This makes resolve_scene_debt reliable: the
+    id returned by get_scene_debts matches the id a subsequent detect() produces
+    for the same structural fact."""
+    h = hashlib.sha1(f"{kind}:{subject}".encode()).hexdigest()[:12]
+    return f"debt_{h}"
+
+# ── Thresholds (structural; tune via QA) ──────────────────────────────────────
+
+# A quest with no status-change Decision in this many campaign days is "stalled".
+# Quests have no own `day` field, so we proxy: a Decision whose summary/rationale
+# references the quest id is the resolution signal. If no such Decision exists we
+# compare quest id creation-order to the campaign day (conservative: flag only
+# when the campaign is meaningfully advanced past the quest's arrival). Because
+# Quest has no `day` field we use a simpler proxy: an active quest whose giver is
+# known but there's been no matching Decision in the last N days of campaign time.
+QUEST_STALL_DAYS: int = 5  # in-world days with no decision-callback for the quest
+
+# A thread is "overdue for a world beat" when its next scheduled beat is already
+# past, meaning it should have fired but hasn't yet (trigger_day < campaign.day
+# and not fired). Re-armed threads (worldsim) roll their trigger_day forward, so
+# only threads whose timer hasn't fired are flagged.
+THREAD_OVERDUE_DAYS: int = 0  # trigger_day strictly past (< campaign.day)
+
+# NPCs at the current location are "silent" if they were met but have no memory
+# entries yet — proxy for "introduced but hasn't spoken". We flag only NPCs whose
+# `met` flag is True (i.e. the DM introduced them) AND who have no memory entries.
+# Companions are excluded (they have their own banter system).
+
+
+# ── Detection helpers ─────────────────────────────────────────────────────────
+
+
+def _hook_has_quest(c: Campaign, hook_id: str) -> bool:
+    """Return True if any tracked Quest's description/title contains the hook id
+    OR if the hook's title matches any tracked quest's title (case-insensitive).
+    Also True when any Quest's giver_id matches the hook's giver_id (same NPC
+    quest origin = likely the same storyline)."""
+    h = next((x for x in c.quest_hooks if x.id == hook_id), None)
+    if h is None:
+        return True  # no hook → not our concern
+    for q in c.quests.values():
+        if hook_id in (q.description or "") or hook_id in (q.title or ""):
+            return True
+        if h.title and h.title.lower() in (q.title or "").lower():
+            return True
+        if h.giver_id and h.giver_id == q.giver_id:
+            return True
+    return False
+
+
+def _hook_player_engaged(c: Campaign, hook_id: str) -> bool:
+    """A hook is 'engaged' when a Decision references it OR when the hook status
+    has been advanced to 'active' (the DM manually marked it active, meaning the
+    party bit on it). Both are structural signals in the snapshot."""
+    h = next((x for x in c.quest_hooks if x.id == hook_id), None)
+    if h is None:
+        return False
+    if h.status == "active":
+        return True
+    # A decision whose summary/rationale contains the hook id or the hook title
+    hook_title_lower = (h.title or "").lower()
+    for d in c.decisions:
+        text = (d.summary + " " + d.rationale + " " + d.chosen).lower()
+        if hook_id in text:
+            return True
+        if hook_title_lower and hook_title_lower in text:
+            return True
+    return False
+
+
+def _quest_has_decision_callback(c: Campaign, quest_id: str, quest_title: str, within_days: int) -> bool:
+    """Return True if there's a Decision in the last `within_days` of campaign time
+    referencing this quest (by id or title). A Decision's `day` field tracks when
+    it was recorded."""
+    min_day = c.day - within_days
+    title_lower = quest_title.lower()
+    for d in c.decisions:
+        if d.day < min_day:
+            continue
+        text = (d.summary + " " + d.rationale + " " + d.chosen + " " + " ".join(d.options)).lower()
+        if quest_id in text or (title_lower and title_lower in text):
+            return True
+    return False
+
+
+# ── 6 structural detectors ───────────────────────────────────────────────────
+
+
+def _detect_hook_untracked(c: Campaign) -> list[SceneDebt]:
+    """hook_untracked — a quest_hook the player engaged with no matching tracked Quest.
+    THE add_quest fix: when a hook is 'active' or referenced by a Decision but no
+    Quest was created for it, the DM owes a quest record."""
+    debts: list[SceneDebt] = []
+    for h in c.quest_hooks:
+        if h.status == "resolved":
+            continue  # already resolved; not a debt
+        if not _hook_player_engaged(c, h.id):
+            continue  # player hasn't bitten; not yet a debt
+        if _hook_has_quest(c, h.id):
+            continue  # already tracked
+        debts.append(
+            SceneDebt(
+                id=_debt_id("hook_untracked", h.id),
+                kind="hook_untracked",
+                subject=h.id,
+                detail=f"Hook '{h.title or h.id}' is active but has no tracked Quest — call add_quest.",
+                severity="high",
+                evidence={"hook_id": h.id, "hook_title": h.title, "hook_status": h.status},
+            )
+        )
+    return debts
+
+
+def _detect_quest_stalled(c: Campaign) -> list[SceneDebt]:
+    """quest_stalled — an active Quest with no decision-callback in >= QUEST_STALL_DAYS.
+    Quest has no own 'day' field; we proxy via Decisions that reference it.
+    A brand-new campaign (day <= threshold) generates no debts."""
+    if c.day <= QUEST_STALL_DAYS:
+        return []
+    debts: list[SceneDebt] = []
+    for q in c.quests.values():
+        if q.status != "active":
+            continue
+        if _quest_has_decision_callback(c, q.id, q.title, QUEST_STALL_DAYS):
+            continue
+        debts.append(
+            SceneDebt(
+                id=_debt_id("quest_stalled", q.id),
+                kind="quest_stalled",
+                subject=q.id,
+                detail=(
+                    f"Quest '{q.title}' is active but has no story callback in the last "
+                    f"{QUEST_STALL_DAYS} campaign days — needs an advancement beat."
+                ),
+                severity="med",
+                evidence={"quest_id": q.id, "quest_title": q.title, "campaign_day": c.day},
+            )
+        )
+    return debts
+
+
+def _detect_choice_without_outcome(c: Campaign) -> list[SceneDebt]:
+    """choice_without_outcome — a Decision that was offered/recorded but `chosen` is
+    still empty ('pending'), meaning the party was presented a choice that was never
+    resolved in the snapshot. Detection: Decision.chosen == "" and Decision.options
+    is non-empty (a real offered choice, not a bare fact record)."""
+    debts: list[SceneDebt] = []
+    for d in c.decisions:
+        if d.options and not d.chosen.strip():
+            debts.append(
+                SceneDebt(
+                    id=_debt_id("choice_without_outcome", d.id),
+                    kind="choice_without_outcome",
+                    subject=d.id,
+                    detail=(
+                        f"Decision '{d.summary}' was offered (options: {d.options!r}) "
+                        f"but 'chosen' is empty — the party's choice was never recorded."
+                    ),
+                    severity="high",
+                    evidence={"decision_id": d.id, "summary": d.summary, "options": d.options},
+                )
+            )
+    return debts
+
+
+def _detect_due_consequence(c: Campaign) -> list[SceneDebt]:
+    """due_consequence — an authored Consequence past its trigger_day, not yet fired.
+    These are non-thread consequences (thread_id == "") that the DM hasn't surfaced.
+    Detection uses the same criteria as consequences.due() but read-only."""
+    debts: list[SceneDebt] = []
+    for con in c.consequences:
+        if con.thread_id:
+            continue  # worldsim thread-beats; handled by thread_pressure
+        if con.fired:
+            continue
+        if con.trigger_day <= c.day:
+            overdue_days = c.day - con.trigger_day
+            debts.append(
+                SceneDebt(
+                    id=_debt_id("due_consequence", con.id),
+                    kind="due_consequence",
+                    subject=con.id,
+                    detail=(
+                        f"Consequence '{con.text[:80]}' was due on day {con.trigger_day} "
+                        f"({overdue_days} day(s) ago) — call check_consequences to surface it."
+                    ),
+                    severity="high" if overdue_days >= 2 else "med",
+                    evidence={
+                        "consequence_id": con.id,
+                        "trigger_day": con.trigger_day,
+                        "campaign_day": c.day,
+                        "overdue_days": overdue_days,
+                        "note": con.note,
+                    },
+                )
+            )
+    return debts
+
+
+def _detect_thread_pressure(c: Campaign) -> list[SceneDebt]:
+    """thread_pressure — a worldsim standing thread whose next beat is already past
+    (trigger_day <= campaign.day) and hasn't re-armed (i.e. it hasn't been ticked).
+    worldsim.tick re-arms in place, so an un-ticked overdue thread means world_tick
+    hasn't been called yet this 'day'. Detection: thread_id non-empty, not fired,
+    trigger_day <= campaign.day."""
+    debts: list[SceneDebt] = []
+    for con in c.consequences:
+        if not con.thread_id:
+            continue  # authored consequences; handled by due_consequence
+        if con.fired:
+            continue
+        if con.trigger_day <= c.day:
+            debts.append(
+                SceneDebt(
+                    id=_debt_id("thread_pressure", con.id),
+                    kind="thread_pressure",
+                    subject=con.id,
+                    detail=(
+                        f"Standing thread '{con.thread_id}' beat is overdue "
+                        f"(due day {con.trigger_day}, now day {c.day}) — call world_tick."
+                    ),
+                    severity="med",
+                    evidence={
+                        "consequence_id": con.id,
+                        "thread_id": con.thread_id,
+                        "trigger_day": con.trigger_day,
+                        "campaign_day": c.day,
+                        "text": con.text[:80],
+                    },
+                )
+            )
+    return debts
+
+
+def _detect_npc_introduced_silent(c: Campaign) -> list[SceneDebt]:
+    """npc_introduced_silent — an NPC/monster at the current location, marked as `met`
+    (introduced), with no memory entries. `met=True` means the engine or DM introduced
+    them at a first-contact tool (social_check, recruit_companion, load_canon_character),
+    but no facts have been recorded about them yet — they've appeared but haven't spoken.
+    Companions are excluded (they have the banter system and are expected to be quieter
+    at first). Only checks characters at the CURRENT location to keep it scoped."""
+    if not c.current_location_id:
+        return []
+    debts: list[SceneDebt] = []
+    for ch in c.characters.values():
+        if ch.kind not in ("npc", "monster"):
+            continue
+        if ch.location_id != c.current_location_id:
+            continue
+        if not ch.met:
+            continue
+        if ch.memory:
+            continue  # has spoken / facts recorded
+        debts.append(
+            SceneDebt(
+                id=_debt_id("npc_introduced_silent", ch.id),
+                kind="npc_introduced_silent",
+                subject=ch.id,
+                detail=(
+                    f"NPC '{ch.name}' at current location has been introduced (met=True) "
+                    f"but has no memory entries — they haven't spoken yet."
+                ),
+                severity="low",
+                evidence={
+                    "character_id": ch.id,
+                    "name": ch.name,
+                    "location_id": ch.location_id,
+                    "kind": ch.kind,
+                },
+            )
+        )
+    return debts
+
+
+# ── v2 stubs (COARSE narrative proxies — not implemented in v1) ───────────────
+
+# TODO v2: setup_without_payoff — a quest_hook with status 'open' referenced in
+# the first quarter of decisions but never advanced to 'active'/'resolved', and
+# the campaign is past day N. Needs: stable creation-day on QuestHook (not yet in
+# the model) or a first-Decision-day proxy. Coarse; advisory tolerates false-pos.
+
+# TODO v2: act_structure — past the campaign midpoint (day > N/2 if there's an
+# expected arc length) with no Decision.rationale containing reversal-tagged words
+# ("betrayal", "revealed", "turned", "loss", "price"). Coarse; needs a defined
+# arc-length on Campaign (not yet in the model). Advisory tolerates false-pos.
+
+
+# ── Public API ────────────────────────────────────────────────────────────────
+
+
+def detect(c: Campaign) -> list[SceneDebt]:
+    """Detect structural scene debts from campaign state. Pure, no I/O.
+
+    Returns a list of ``SceneDebt`` objects; empty means no debts detected
+    (today's behavior). Old snapshots without ``scene_debts`` round-trip
+    unchanged — this function reads state, never mutates it.
+
+    The six debt kinds detected:
+    - ``hook_untracked``: an engaged quest_hook with no tracked Quest.
+    - ``quest_stalled``: an active Quest with no story beat in ≥ QUEST_STALL_DAYS.
+    - ``choice_without_outcome``: a Decision offered (options present) but chosen=''.
+    - ``due_consequence``: a non-thread Consequence past trigger_day, not fired.
+    - ``thread_pressure``: a worldsim thread-beat overdue (world_tick not called).
+    - ``npc_introduced_silent``: a met NPC at current location with no memory.
+    """
+    debts: list[SceneDebt] = []
+    debts.extend(_detect_hook_untracked(c))
+    debts.extend(_detect_quest_stalled(c))
+    debts.extend(_detect_choice_without_outcome(c))
+    debts.extend(_detect_due_consequence(c))
+    debts.extend(_detect_thread_pressure(c))
+    debts.extend(_detect_npc_introduced_silent(c))
+    return debts

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -37,6 +37,8 @@ import recap
 import rests
 import spells
 import srd_tables
+import director
+import scene_debt as _scene_debt_mod
 import travel
 import wander
 import worldsim
@@ -65,6 +67,7 @@ from models import (
     Item,
     Location,
     Quest,
+    SceneDebt,
     SessionLogEntry,
     SpellSlotLevel,
     Zone,
@@ -5613,6 +5616,112 @@ def set_house_rules(campaign_id: str, patch: dict) -> dict:
         c.house_rules = HouseRules.model_validate(data)
         save_campaign(c)
         return c.house_rules.model_dump()
+
+
+@mcp.tool()
+def get_campaign_director(campaign_id: str) -> dict:
+    """Campaign Director — advisory beat-start tool (issue #72).
+
+    ADVISORY ONLY. Detects structural story debts from the current campaign state
+    and returns the top 3 (by severity) with a one-line nudge each. Read-only:
+    the engine NEVER acts on debts, mutates fiction, or forces a resolution.
+
+    Call this at the start of a beat to see what the campaign structurally OWES.
+    The DM reads the advisory and CHOOSES what to honour. One nudge at a time —
+    this is not a mandatory checklist. Resolution is always explicit via
+    resolve_scene_debt.
+
+    Returns::
+
+        {
+            "debts": [<top 3 SceneDebt dicts, highest severity first>],
+            "advisory": ["one-line nudge per debt"],
+            "total_debts": <int>,
+        }
+
+    An empty ``debts`` list means no structural debts — today's behavior.
+    """
+    c = _require(campaign_id)
+    return director.compute(c)
+
+
+@mcp.tool()
+def get_scene_debts(campaign_id: str) -> dict:
+    """Campaign Director — raw scene-debt list (issue #72).
+
+    ADVISORY ONLY. Returns the full list of structural scene-debts detected from
+    the current campaign state — all kinds and severities, unranked. Use
+    get_campaign_director for the prioritised top-3 advisory instead.
+
+    Read-only: the engine NEVER acts on debts or mutates fiction.
+
+    Also includes any previously-resolved debts persisted on the campaign snapshot
+    (resolved=True) as an audit trail, accessible from Campaign.scene_debts.
+    Live-detected debts (from detect()) are merged with the resolved persisted ones
+    so the DM can see what was owed and what was cleared.
+
+    Returns::
+
+        {
+            "live_debts": [<all currently detected SceneDebt dicts>],
+            "resolved_debts": [<SceneDebt dicts with resolved=True from snapshot>],
+            "total_live": <int>,
+        }
+    """
+    c = _require(campaign_id)
+    live = _scene_debt_mod.detect(c)
+    resolved_persisted = [d for d in c.scene_debts if d.resolved]
+    return {
+        "live_debts": [d.model_dump() for d in live],
+        "resolved_debts": [d.model_dump() for d in resolved_persisted],
+        "total_live": len(live),
+    }
+
+
+@mcp.tool()
+def resolve_scene_debt(campaign_id: str, debt_id: str, evidence: str) -> dict:
+    """Campaign Director — mark a scene-debt resolved (issue #72).
+
+    EXPLICIT RESOLUTION ONLY. The DM calls this when they have addressed a debt
+    in play (e.g. called add_quest for a hook_untracked, surfaced a consequence,
+    gave an NPC a line). The engine NEVER auto-resolves debts.
+
+    ``debt_id`` must match the ``id`` field of a SceneDebt in the live-detected
+    list (from get_scene_debts). ``evidence`` is a DM-written note explaining
+    what was done (required; must be non-empty). The resolved debt is persisted
+    on the campaign snapshot (scene_debts) as an audit trail with resolved=True
+    and the provided evidence.
+
+    Returns the persisted SceneDebt record.
+    """
+    if not evidence or not evidence.strip():
+        raise ValueError("evidence is required — describe what was done to resolve this debt.")
+
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+
+        # Check if already resolved and persisted
+        existing = next((d for d in c.scene_debts if d.id == debt_id and d.resolved), None)
+        if existing:
+            return {"message": "already resolved", "debt": existing.model_dump()}
+
+        # Detect live debts to find the matching one
+        live = _scene_debt_mod.detect(c)
+        debt = next((d for d in live if d.id == debt_id), None)
+        if debt is None:
+            raise ValueError(
+                f"No live scene-debt with id {debt_id!r}. "
+                f"Use get_scene_debts to see current debt ids."
+            )
+
+        # Mark resolved and persist
+        debt.resolved = True
+        debt.resolution_evidence = evidence.strip()
+        # Append to campaign.scene_debts (additive audit trail)
+        c.scene_debts.append(debt)
+        save_campaign(c)
+
+        return {"message": "resolved", "debt": debt.model_dump()}
 
 
 if __name__ == "__main__":

--- a/servers/engine/tests/test_scene_debt.py
+++ b/servers/engine/tests/test_scene_debt.py
@@ -1,0 +1,460 @@
+"""Tests for Campaign Director scene-debt detection (issue #72).
+
+Per-debt: a campaign that triggers the debt → detect returns it;
+a clean campaign → none. Plus: resolve_scene_debt works; additive
+round-trip (old snapshot with no scene_debts loads cleanly).
+
+ADVISORY contract under test: detect() is pure (no I/O, no mutation);
+resolve is explicit (requires evidence); empty debts == today's behavior.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import scene_debt
+import server
+import store
+from models import Campaign, Character, Consequence, Decision, Quest, QuestHook, SceneDebt
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _camp(day: int = 1) -> Campaign:
+    return Campaign(title="T", day=day)
+
+
+def _hook(title: str = "The Lost Heir", status: str = "open", giver_id: str = "") -> QuestHook:
+    return QuestHook(title=title, status=status, giver_id=giver_id or "")  # type: ignore[arg-type]
+
+
+def _npc(name: str, location_id: str = "loc1", met: bool = True) -> Character:
+    return Character(name=name, kind="npc", location_id=location_id, met=met)
+
+
+def _decision(summary: str, options: list[str] = None, chosen: str = "we agreed", day: int = 1) -> Decision:
+    return Decision(
+        summary=summary,
+        options=options or [],
+        chosen=chosen,
+        day=day,
+    )
+
+
+# ── hook_untracked ────────────────────────────────────────────────────────────
+
+class TestHookUntracked:
+    def test_active_hook_no_quest_detected(self):
+        c = _camp()
+        h = _hook(title="Rescue the Baron", status="active")
+        c.quest_hooks.append(h)
+        debts = scene_debt.detect(c)
+        kinds = [d.kind for d in debts]
+        assert "hook_untracked" in kinds
+
+    def test_decision_references_hook_no_quest_detected(self):
+        c = _camp()
+        h = _hook(title="Cult Rising", status="open")
+        c.quest_hooks.append(h)
+        c.decisions.append(_decision(summary=f"investigate {h.id}", options=["yes", "no"], chosen="yes"))
+        debts = scene_debt.detect(c)
+        assert any(d.kind == "hook_untracked" and d.subject == h.id for d in debts)
+
+    def test_hook_with_matching_quest_clean(self):
+        c = _camp()
+        h = _hook(title="Baron Quest", status="active")
+        c.quest_hooks.append(h)
+        q = Quest(title="Baron Quest", description="")
+        c.quests[q.id] = q
+        debts = [d for d in scene_debt.detect(c) if d.kind == "hook_untracked"]
+        assert debts == []
+
+    def test_resolved_hook_not_flagged(self):
+        c = _camp()
+        h = _hook(title="Old Hook", status="resolved")
+        c.quest_hooks.append(h)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "hook_untracked"]
+        assert debts == []
+
+    def test_open_hook_player_not_engaged_clean(self):
+        c = _camp()
+        h = _hook(title="Dormant Hook", status="open")
+        c.quest_hooks.append(h)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "hook_untracked"]
+        assert debts == []
+
+    def test_hook_giver_id_matches_quest_giver_clean(self):
+        c = _camp()
+        h = _hook(title="Giver Quest", status="active", giver_id="npc_abc")
+        c.quest_hooks.append(h)
+        q = Quest(title="Some Quest", giver_id="npc_abc")
+        c.quests[q.id] = q
+        debts = [d for d in scene_debt.detect(c) if d.kind == "hook_untracked"]
+        assert debts == []
+
+
+# ── quest_stalled ─────────────────────────────────────────────────────────────
+
+class TestQuestStalled:
+    def test_stalled_active_quest_detected(self):
+        c = _camp(day=10)  # well past the 5-day threshold
+        q = Quest(title="Find the Sword")
+        c.quests[q.id] = q
+        # No decisions reference this quest
+        debts = scene_debt.detect(c)
+        assert any(d.kind == "quest_stalled" and d.subject == q.id for d in debts)
+
+    def test_quest_with_recent_decision_clean(self):
+        c = _camp(day=10)
+        q = Quest(title="The Heist")
+        c.quests[q.id] = q
+        # A decision on day 8 references the quest
+        c.decisions.append(_decision(
+            summary=f"planned {q.id} approach",
+            options=["stealth", "force"],
+            chosen="stealth",
+            day=8,
+        ))
+        debts = [d for d in scene_debt.detect(c) if d.kind == "quest_stalled"]
+        assert debts == []
+
+    def test_completed_quest_not_flagged(self):
+        c = _camp(day=10)
+        q = Quest(title="Done Quest", status="completed")
+        c.quests[q.id] = q
+        debts = [d for d in scene_debt.detect(c) if d.kind == "quest_stalled"]
+        assert debts == []
+
+    def test_early_campaign_not_flagged(self):
+        c = _camp(day=3)  # below the 5-day threshold
+        q = Quest(title="Fresh Quest")
+        c.quests[q.id] = q
+        debts = [d for d in scene_debt.detect(c) if d.kind == "quest_stalled"]
+        assert debts == []
+
+    def test_quest_referenced_by_title_in_decision_clean(self):
+        c = _camp(day=10)
+        q = Quest(title="Dragon Lair")
+        c.quests[q.id] = q
+        c.decisions.append(_decision(
+            summary="approached the dragon lair cautiously",
+            options=["sneak", "charge"],
+            chosen="sneak",
+            day=9,
+        ))
+        debts = [d for d in scene_debt.detect(c) if d.kind == "quest_stalled"]
+        assert debts == []
+
+
+# ── choice_without_outcome ────────────────────────────────────────────────────
+
+class TestChoiceWithoutOutcome:
+    def test_offered_decision_no_chosen_detected(self):
+        c = _camp()
+        d = Decision(summary="Spare or kill the traitor?", options=["spare", "kill"], chosen="", day=1)
+        c.decisions.append(d)
+        debts = scene_debt.detect(c)
+        assert any(d2.kind == "choice_without_outcome" and d2.subject == d.id for d2 in debts)
+
+    def test_decision_with_chosen_clean(self):
+        c = _camp()
+        d = _decision(summary="Trust the merchant?", options=["yes", "no"], chosen="yes")
+        c.decisions.append(d)
+        debts = [d2 for d2 in scene_debt.detect(c) if d2.kind == "choice_without_outcome"]
+        assert debts == []
+
+    def test_bare_fact_no_options_clean(self):
+        c = _camp()
+        # A fact record (no options, no chosen) — not a pending choice
+        d = Decision(summary="The party rested in the inn", options=[], chosen="", day=1)
+        c.decisions.append(d)
+        debts = [d2 for d2 in scene_debt.detect(c) if d2.kind == "choice_without_outcome"]
+        assert debts == []
+
+
+# ── due_consequence ───────────────────────────────────────────────────────────
+
+class TestDueConsequence:
+    def test_overdue_consequence_detected(self):
+        c = _camp(day=5)
+        con = Consequence(trigger_day=3, text="The siege begins.", fired=False)
+        c.consequences.append(con)
+        debts = scene_debt.detect(c)
+        assert any(d.kind == "due_consequence" and d.subject == con.id for d in debts)
+
+    def test_future_consequence_clean(self):
+        c = _camp(day=3)
+        con = Consequence(trigger_day=7, text="Ritual completes.", fired=False)
+        c.consequences.append(con)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "due_consequence"]
+        assert debts == []
+
+    def test_fired_consequence_clean(self):
+        c = _camp(day=5)
+        con = Consequence(trigger_day=3, text="Already surfaced.", fired=True)
+        c.consequences.append(con)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "due_consequence"]
+        assert debts == []
+
+    def test_thread_consequence_not_flagged_as_due(self):
+        c = _camp(day=5)
+        con = Consequence(trigger_day=3, text="Thread beat.", fired=False, thread_id="thread-1")
+        c.consequences.append(con)
+        # Should NOT appear as due_consequence (it's a thread, handled by thread_pressure)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "due_consequence"]
+        assert debts == []
+
+    def test_high_severity_for_2plus_days_overdue(self):
+        c = _camp(day=7)
+        con = Consequence(trigger_day=3, text="Villain strikes.", fired=False)
+        c.consequences.append(con)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "due_consequence"]
+        assert debts and debts[0].severity == "high"
+
+    def test_med_severity_for_1_day_overdue(self):
+        c = _camp(day=4)
+        con = Consequence(trigger_day=3, text="Ally leaves.", fired=False)
+        c.consequences.append(con)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "due_consequence"]
+        assert debts and debts[0].severity == "med"
+
+
+# ── thread_pressure ───────────────────────────────────────────────────────────
+
+class TestThreadPressure:
+    def test_overdue_thread_detected(self):
+        c = _camp(day=5)
+        con = Consequence(trigger_day=3, text="Cult recruits.", fired=False, thread_id="thread-1")
+        c.consequences.append(con)
+        debts = scene_debt.detect(c)
+        assert any(d.kind == "thread_pressure" and d.subject == con.id for d in debts)
+
+    def test_future_thread_clean(self):
+        c = _camp(day=3)
+        con = Consequence(trigger_day=7, text="Faction moves.", fired=False, thread_id="thread-2")
+        c.consequences.append(con)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "thread_pressure"]
+        assert debts == []
+
+    def test_fired_thread_clean(self):
+        c = _camp(day=5)
+        con = Consequence(trigger_day=3, text="Already fired.", fired=True, thread_id="thread-3")
+        c.consequences.append(con)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "thread_pressure"]
+        assert debts == []
+
+    def test_authored_consequence_not_flagged_as_thread(self):
+        c = _camp(day=5)
+        con = Consequence(trigger_day=3, text="Non-thread.", fired=False, thread_id="")
+        c.consequences.append(con)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "thread_pressure"]
+        assert debts == []
+
+
+# ── npc_introduced_silent ─────────────────────────────────────────────────────
+
+class TestNpcIntroducedSilent:
+    def test_met_npc_no_memory_at_current_location_detected(self):
+        c = _camp()
+        c.current_location_id = "loc1"
+        npc = _npc("Verath the Fence", location_id="loc1", met=True)
+        c.characters[npc.id] = npc
+        debts = scene_debt.detect(c)
+        assert any(d.kind == "npc_introduced_silent" and d.subject == npc.id for d in debts)
+
+    def test_npc_with_memory_clean(self):
+        c = _camp()
+        c.current_location_id = "loc1"
+        npc = _npc("Grett", location_id="loc1", met=True)
+        npc.memory.append("Grett warned us about the catacombs")
+        c.characters[npc.id] = npc
+        debts = [d for d in scene_debt.detect(c) if d.kind == "npc_introduced_silent"]
+        assert debts == []
+
+    def test_unmet_npc_clean(self):
+        c = _camp()
+        c.current_location_id = "loc1"
+        npc = _npc("Stranger", location_id="loc1", met=False)
+        c.characters[npc.id] = npc
+        debts = [d for d in scene_debt.detect(c) if d.kind == "npc_introduced_silent"]
+        assert debts == []
+
+    def test_npc_at_different_location_clean(self):
+        c = _camp()
+        c.current_location_id = "loc1"
+        npc = _npc("Away NPC", location_id="loc2", met=True)
+        c.characters[npc.id] = npc
+        debts = [d for d in scene_debt.detect(c) if d.kind == "npc_introduced_silent"]
+        assert debts == []
+
+    def test_no_current_location_clean(self):
+        c = _camp()
+        c.current_location_id = None
+        npc = _npc("Floating NPC", location_id="loc1", met=True)
+        c.characters[npc.id] = npc
+        debts = [d for d in scene_debt.detect(c) if d.kind == "npc_introduced_silent"]
+        assert debts == []
+
+    def test_companion_not_flagged(self):
+        c = _camp()
+        c.current_location_id = "loc1"
+        companion = Character(name="Lyra", kind="companion", location_id="loc1", met=True)
+        c.characters[companion.id] = companion
+        debts = [d for d in scene_debt.detect(c) if d.kind == "npc_introduced_silent"]
+        assert debts == []
+
+
+# ── Clean campaign → no debts ─────────────────────────────────────────────────
+
+class TestCleanCampaign:
+    def test_empty_campaign_no_debts(self):
+        c = _camp()
+        assert scene_debt.detect(c) == []
+
+    def test_campaign_with_everything_resolved_no_debts(self):
+        c = _camp(day=3)  # below stall threshold
+        # A resolved hook
+        h = _hook(title="Done Hook", status="resolved")
+        c.quest_hooks.append(h)
+        # A completed quest
+        q = Quest(title="Finished Quest", status="completed")
+        c.quests[q.id] = q
+        # A decision with a chosen
+        c.decisions.append(_decision("We chose wisely", options=["a", "b"], chosen="a"))
+        assert scene_debt.detect(c) == []
+
+
+# ── resolve_scene_debt tool ───────────────────────────────────────────────────
+
+class TestResolveSceneDebt:
+    @pytest.fixture
+    def cid(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+        return server.create_campaign("Test World")["id"]
+
+    def test_resolve_requires_evidence(self, cid):
+        with pytest.raises((ValueError, Exception)):
+            server.resolve_scene_debt(cid, "debt_xxx", "")
+
+    def test_resolve_unknown_debt_raises(self, cid):
+        with pytest.raises((ValueError, Exception)):
+            server.resolve_scene_debt(cid, "nonexistent_debt_id", "I did it")
+
+    def test_resolve_live_debt_persists(self, cid, tmp_path, monkeypatch):
+        # Plant a due consequence so there's a live debt
+        with store.campaign_lock(cid):
+            c = store.load_campaign(cid)
+            con = Consequence(trigger_day=1, text="The ritual completes.", fired=False)
+            c.consequences.append(con)
+            c.day = 5
+            store.save_campaign(c)
+
+        # Confirm it's live
+        raw = server.get_scene_debts(cid)
+        due_debts = [d for d in raw["live_debts"] if d["kind"] == "due_consequence"]
+        assert due_debts, "Expected a live due_consequence debt"
+        debt_id = due_debts[0]["id"]
+
+        # Resolve it
+        result = server.resolve_scene_debt(cid, debt_id, "Called check_consequences and surfaced it.")
+        assert result["debt"]["resolved"] is True
+        assert result["debt"]["resolution_evidence"] == "Called check_consequences and surfaced it."
+
+        # Persisted in snapshot
+        c2 = store.load_campaign(cid)
+        assert any(d.resolved and d.id == debt_id for d in c2.scene_debts)
+
+    def test_resolve_already_resolved_returns_gracefully(self, cid, tmp_path, monkeypatch):
+        # Plant and resolve a due consequence
+        with store.campaign_lock(cid):
+            c = store.load_campaign(cid)
+            con = Consequence(trigger_day=1, text="Old event.", fired=False)
+            c.consequences.append(con)
+            c.day = 5
+            store.save_campaign(c)
+
+        raw = server.get_scene_debts(cid)
+        debt_id = raw["live_debts"][0]["id"]
+        server.resolve_scene_debt(cid, debt_id, "Done once.")
+        # Re-resolving the same debt should not raise, just return "already resolved"
+        result = server.resolve_scene_debt(cid, debt_id, "Trying again.")
+        assert result["message"] == "already resolved"
+
+
+# ── Additive round-trip ───────────────────────────────────────────────────────
+
+class TestAdditiveRoundtrip:
+    def test_old_snapshot_no_scene_debts_loads(self, tmp_path):
+        """An old snapshot JSON without scene_debts deserialises cleanly."""
+        c = Campaign(title="Old Campaign", day=1)
+        raw = json.loads(c.model_dump_json())
+        assert "scene_debts" in raw  # present with default []
+        # Remove the field to simulate an old snapshot
+        del raw["scene_debts"]
+        # Pydantic should NOT raise (field has a default_factory)
+        c2 = Campaign.model_validate(raw)
+        assert c2.scene_debts == []
+
+    def test_snapshot_with_scene_debts_round_trips(self):
+        """A snapshot with resolved scene_debts serialises and deserialises."""
+        c = Campaign(title="Campaign With Debts", day=5)
+        debt = SceneDebt(
+            kind="due_consequence",
+            subject="conseq_abc",
+            detail="A consequence was overdue.",
+            severity="high",
+            resolved=True,
+            resolution_evidence="DM surfaced it.",
+        )
+        c.scene_debts.append(debt)
+        raw = c.model_dump_json()
+        c2 = Campaign.model_validate_json(raw)
+        assert len(c2.scene_debts) == 1
+        assert c2.scene_debts[0].resolved is True
+        assert c2.scene_debts[0].kind == "due_consequence"
+
+
+# ── get_campaign_director advisory ───────────────────────────────────────────
+
+class TestGetCampaignDirector:
+    @pytest.fixture
+    def cid(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+        return server.create_campaign("Director Test")["id"]
+
+    def test_clean_campaign_no_advisory(self, cid):
+        result = server.get_campaign_director(cid)
+        assert result["debts"] == []
+        assert result["advisory"] == []
+        assert result["total_debts"] == 0
+
+    def test_advisory_returns_nudges_for_debts(self, cid, tmp_path, monkeypatch):
+        # Plant an overdue consequence
+        with store.campaign_lock(cid):
+            c = store.load_campaign(cid)
+            c.day = 5
+            con = Consequence(trigger_day=2, text="The cult acts.", fired=False)
+            c.consequences.append(con)
+            store.save_campaign(c)
+
+        result = server.get_campaign_director(cid)
+        assert result["total_debts"] >= 1
+        assert len(result["advisory"]) >= 1
+        # Advisory should mention consequence or check_consequences
+        assert any("consequence" in a.lower() or "check_consequences" in a for a in result["advisory"])
+
+    def test_advisory_capped_at_three(self, cid, tmp_path, monkeypatch):
+        """At most 3 debts returned even when more are present."""
+        with store.campaign_lock(cid):
+            c = store.load_campaign(cid)
+            c.day = 10
+            c.current_location_id = "loc1"
+            # Plant 5 overdue consequences
+            for i in range(5):
+                c.consequences.append(Consequence(trigger_day=1, text=f"Event {i}.", fired=False))
+            store.save_campaign(c)
+
+        result = server.get_campaign_director(cid)
+        assert len(result["debts"]) <= 3


### PR DESCRIPTION
## What
An ADVISORY layer that tells the DM what the campaign OWES each beat — the map's #1 story lever and the structural fix for the confirmed add_quest reach-for gap (a prestige-tier QA run tracked 0 quests).

**Advise-not-dictate** (the owner guard): the engine detects debts from STATE and returns them; it never acts or mutates fiction; resolution is explicit + evidence-backed.

## How
- **scene_debt.py** — pure detect(c) for 6 STRUCTURAL debts: hook_untracked (THE add_quest fix), quest_stalled, choice_without_outcome, due_consequence, thread_pressure, npc_introduced_silent. Deterministic debt ids so resolve matches detect. (setup_without_payoff + act_structure are commented v2 stubs — need created_day / arc-length.)
- **director.py** — pure compute(c): top-3 debts by severity + a one-line nudge each.
- **models.py** — SceneDebt + Campaign.scene_debts (additive optional; empty == today).
- **server.py** — get_campaign_director (read-only), get_scene_debts (read-only + resolved audit trail), resolve_scene_debt (explicit, evidence-required, campaign_lock + save).

## Tests / safety
- **41 new tests, 1057 total pass**; license_check passes.
- Additive: no behavior change on an empty scene_debts; old snapshots round-trip.
- Structural-detection-only: NO narrative-quality judgment in the engine (that stays the scorer's job).

## Follow-up (separate PR)
Wire the DM skill + run_duo runbook to consult get_campaign_director at beat start, so the add_quest nudge fires in play (this is what closes the gap end-to-end).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Campaign Director feature for identifying and tracking structural story debts
  * Scene-debt detection identifies untracked quest hooks, stalled quests, unresolved choices, overdue consequences, thread pressure, and silently introduced NPCs
  * Advisory view displays top 3 most severe debts with actionable recommendations
  * New tools to view all detected/resolved debts and explicitly mark debts as resolved

* **Tests**
  * Added comprehensive test suite covering debt detection and resolution workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->