### PR TITLE
feat(macos): add beta distribution lane

### DIFF
--- a/docs/OPENWORLDS_APP_SURFACE_MAP.md
+++ b/docs/OPENWORLDS_APP_SURFACE_MAP.md
@@ -1,0 +1,74 @@
+# OpenWorlds App Surface Map
+
+Date: 2026-05-26
+
+This document is the app-side handoff map for the OpenWorlds macOS shell. It
+describes what is wired today, what is display-only, and which GitHub issue owns
+the next implementation. The native app remains a supervisor and read/action
+surface; the engine/viewer remain the game-state authority.
+
+## Capability Legend
+
+- **Wired**: usable against current viewer/native bridge APIs.
+- **Read-only**: backed by real data, but no mutation path yet.
+- **Partial**: some real backing exists, but the screen still contains local or
+  prototype-only behavior.
+- **Display-only**: retained for design fidelity and roadmap shape, not backed
+  by ClawDnD data yet.
+- **Engine-needed**: needs a new engine/viewer read model or engine-owned action.
+- **Bridge-needed**: needs native supervisor bridge work.
+
+## Product Shell
+
+| Area | Current state | Evidence | Owner issue | Next action |
+| --- | --- | --- | --- | --- |
+| Native app host | Wired | `RootView` launches viewer and hosts `/openworlds/` in `WKWebView` | #82, #113 | Keep as product shell; leave old SwiftUI shell as debug only |
+| Bundled OpenWorlds assets | Wired | App packages `viewer/openworlds` and sets `CLAWDND_OPENWORLDS_DIR` | #134 | Keep UI assets app-bundled; engine/viewer stay repo-backed |
+| Sparkle local beta | Partial | `UpdaterService`, `checkForUpdates`, local appcast | #134 | Manual update smoke; notarization remains separate |
+| Window controls | Partial | OpenWorlds traffic buttons call `windowCommand`; AppKit drag strip exists | #136 | Manual close/minimize/zoom/drag smoke; tune drag hit box if needed |
+| Native settings/provider/log bridge | Partial | Settings screen calls `appStatus`, provider actions, diagnostics, Sparkle | #132, #133 | Move remaining Swift debug-only controls into OpenWorlds or mark unavailable |
+
+## OpenWorlds Screens
+
+| Screen | Current state | Backing today | Owner issue | Handoff notes |
+| --- | --- | --- | --- | --- |
+| Chronicles / launcher | Partial | `/openworlds/campaigns.json`; local selected campaign state | #114 | Resume/view navigates to Table. New chronicle modal currently creates local-only demo rows and must be replaced with native/provider start flow before treating it as real. |
+| Session / table | Wired/partial | `/session-surface`; enabled actions post `/move` | #115 | Best real gameplay surface today. Continue enriching read model fields rather than writing local state. |
+| Battle / combat | Wired/partial | `/combat-surface`; action bar posts `/move` | #116 | Tactical board is engine-owned projection. Improve legality, event cards, targeting, and refresh behavior through viewer read models. |
+| Atlas / map | Wired/partial | `/atlas-surface`; available travel posts `/move` | #117 | Strategic map is partially real. Camp/rest UI is still mostly informational until rest/camp actions are engine-owned. |
+| Settings / native app | Partial | Native bridge app status, dependencies, providers, Sparkle | #132, #134 | `ClawDnD` section is real. Audio/display/gameplay/controls/accessibility/saves are display-only until preferences are bridged. |
+| Quest journal | Display-only/read-model-needed | `state.quests` demo/store fallback only | #120 or new journal projection issue | Should consume player-known quest projection from viewer, not static seed data. |
+| Character / heroes | Display-only/engine-needed | `state.party` only | #80/#81 if build planner, or new character projection issue | Needs character sheet projection, level-up/build planner actions, rest-prep through engine. |
+| Inventory / stash | Display-only/engine-needed | `state.stash` only; equip/use/drop are local toasts | #119 | Replace local interactions with engine-owned item action model. |
+| Merchant / market | Display-only/engine-needed | static `MERCHANTS`, local cart/coins | #119 | Needs economy/merchant read models and buy/sell/haggle player-intent actions. |
+| Forge | Display-only/engine-needed | static recipe list and local random roll | #119 | Must not keep local crafting resolution; needs engine-owned craft preview/action. |
+| Relations / camp | Display-only/engine-needed | static factions/NPCs | #118 | Needs companion/camp/faction/NPC disposition projection and player-known filtering. |
+| Bestiary / codex | Display-only/engine-needed | static `BESTIARY`, `PEOPLE`, `LORE` | #121 | Must consume player-known lore only; never expose hidden/private lore. |
+| Acts | Display-only/engine-needed | static `ACTS` | #120 | Needs campaign-director projection and player-visible chronology/payoff markers. |
+| Dialogue / parley | Display-only/provider-needed | static `DIALOGUE`; local choice tree | #118 or provider dialogue issue | Needs provider/engine dialogue read model; choices should post player intent, not mutate local branch only. |
+| Creation Plane | Display-only/engine-needed | local character-creation wizard | #79/#81 or new onboarding issue | Can remain design reference until character creation/start-game contract exists. |
+| World Seed | Display-only/engine-needed | local seed settings and toasts | #114/#79 | Needs read-only campaign seed projection first; destructive reseed must be unavailable until engine-owned. |
+
+## Highest-Value App Follow-Ups
+
+1. **Finish manual beta smoke for PR #150**: verify OpenWorlds loads inside the
+   packaged app, Sparkle reads the local appcast, traffic buttons control the
+   real native window, and the drag strip behaves well.
+2. **Replace local-only launcher creation**: `NewCampaignModal` must call the
+   native/provider start flow or be marked `Display-only`.
+3. **Bridge Settings preferences**: persist real native prefs for repo path,
+   port, state dir, provider commands, budgets, voice backend, and update state.
+4. **Complete Session/Combat/Atlas before new surfaces**: these already have
+   viewer read models and `/move` lanes, so they compound fastest.
+5. **Keep all inventory/crafting/merchant actions disabled until engine-owned**:
+   the current UI is visually useful but must not resolve item/economy state in
+   browser-local code.
+6. **Add notarization as a separate release-trust issue**: current beta is
+   Developer ID signed but intentionally not notarized.
+
+## Non-Negotiable Boundary
+
+The macOS app and OpenWorlds browser code may supervise, display, and submit
+player intent. They must not directly write `snapshot.json`, `play-state`,
+`qa/state`, inventory, quests, XP, clocks, companion state, or private lore.
+

--- a/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
+++ b/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
@@ -60,16 +60,27 @@ Every OpenWorlds screen should expose one of these labels:
 5. Sprint 4: make Chronicles the real app home with live/stale run state.
 6. Sprint 5+: finish gameplay surfaces in impact order: table, combat, atlas,
    relations/camp, inventory/economy, acts, bestiary/codex.
-7. Release trust: add a Sparkle-backed update channel (#134) after the local `.app`,
-   signing, and bundle identity are stable. This should let owners update the
-   native app without repeated manual rebuild/download cycles, while keeping the
-   viewer/engine state directories outside the app bundle.
+7. Release trust: add a Sparkle-backed local beta channel (#134) after the local
+   `.app`, signing, and bundle identity are stable. This lets owners update the
+   native app and bundled OpenWorlds UI without repeated manual rebuild/download
+   cycles, while keeping the viewer/engine state directories outside the app
+   bundle.
 
 ## Sparkle Update Lane
 
-Sparkle is intentionally out of the correction PR's runtime scope. Track it as a
-release-trust feature in #134 after the OpenWorlds host and native bridge are
-stable.
+Sparkle is the beta distribution lane for #134. The local beta channel writes to
+`/Volumes/LEXAR/Codex/clawdnd-beta-channel` and uses:
+
+- app bundle: `/Volumes/LEXAR/Codex/clawdnd-beta-channel/ClawDnD.app`
+- update feed: `file:///Volumes/LEXAR/Codex/clawdnd-beta-channel/appcast.xml`
+- release script: `script/package_macos_beta.sh`
+- bundle id: `dev.clawdnd.app`
+- version/build: `0.3.0` / `2026052601` for `0.3.0-beta.1`
+- signing identity: `Developer ID Application: Andrew Ryan (TC6MS3T6NN)`
+
+The Sparkle private key lives only under
+`/Volumes/LEXAR/Codex/clawdnd-release-secrets/`. The repo stores only the public
+key in `macos/ClawDnDApp/SparklePublicKey.txt`.
 
 Implementation goals:
 
@@ -82,6 +93,9 @@ Implementation goals:
   bridge, not through a second visible SwiftUI settings shell.
 - Keep local dev builds working without Sparkle so contributors can still use
   `./script/build_and_run.sh --verify`.
+- Package `viewer/openworlds/` into `ClawDnD.app/Contents/Resources/openworlds`
+  and launch the repo-backed Python viewer with `CLAWDND_OPENWORLDS_DIR` pointing
+  at those bundled assets when available.
 
 ## Window Chrome Lane
 
@@ -114,6 +128,9 @@ Supported request types:
 - `stopProvider`
 - `diagnostics`
 - `copyDiagnostics`
+- `updaterStatus`
+- `checkForUpdates`
+- `windowCommand`
 - `openFallbackDashboard`
 
 Native replies:

--- a/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
+++ b/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
@@ -68,8 +68,12 @@ Every OpenWorlds screen should expose one of these labels:
 
 ## Sparkle Update Lane
 
-Sparkle is the beta distribution lane for #134. The local beta channel writes to
-`/Volumes/LEXAR/Codex/clawdnd-beta-channel` and uses:
+Sparkle is the beta distribution lane for #134. Maintainers currently use a
+Lexar-backed local channel at `/Volumes/LEXAR/Codex/clawdnd-beta-channel`.
+Contributors can use a different local channel by setting `BETA_OUTPUT_DIR` and,
+when needed, `CLAWDND_FEED_URL` before running the packaging script.
+
+Local maintainer setup:
 
 - app bundle: `/Volumes/LEXAR/Codex/clawdnd-beta-channel/ClawDnD.app`
 - update feed: `file:///Volumes/LEXAR/Codex/clawdnd-beta-channel/appcast.xml`
@@ -77,6 +81,14 @@ Sparkle is the beta distribution lane for #134. The local beta channel writes to
 - bundle id: `dev.clawdnd.app`
 - version/build: `0.3.0` / `2026052601` for `0.3.0-beta.1`
 - signing identity: `Developer ID Application: Andrew Ryan (TC6MS3T6NN)`
+
+Contributor override example:
+
+```bash
+BETA_OUTPUT_DIR="$HOME/ClawDnD-beta-channel" \
+CLAWDND_FEED_URL="file://$HOME/ClawDnD-beta-channel/appcast.xml" \
+./script/package_macos_beta.sh --version 0.3.0 --build 2026052601 --channel local-beta
+```
 
 The Sparkle private key lives only under
 `/Volumes/LEXAR/Codex/clawdnd-release-secrets/`. The repo stores only the public
@@ -132,6 +144,28 @@ Supported request types:
 - `checkForUpdates`
 - `windowCommand`
 - `openFallbackDashboard`
+
+Update and window request payloads:
+
+```json
+{ "type": "updaterStatus", "payload": {} }
+```
+
+Returns `{ "updater": { "version": "0.3.0", "build": "2026052601", "feedURL": "...", "channel": "local-beta", "canCheckForUpdates": true, "status": "ready", "lastError": "" } }`.
+
+```json
+{ "type": "checkForUpdates", "payload": {} }
+```
+
+Triggers Sparkle's user-facing update check and returns the same updater status
+shape.
+
+```json
+{ "type": "windowCommand", "payload": { "command": "close" } }
+```
+
+`command` must be one of `close`, `minimize`, or `zoom`; the native reply
+includes `{ "command": "...", "performed": true }`.
 
 Native replies:
 

--- a/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
+++ b/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
@@ -89,10 +89,13 @@ Local maintainer setup:
 Contributor override example:
 
 ```bash
-BETA_OUTPUT_DIR="$HOME/ClawDnD-beta-channel" \
+BETA_OUTPUT_DIR="/Volumes/LEXAR/Codex/my-clawdnd-beta-channel" \
 CLAWDND_FEED_URL="http://127.0.0.1:8765/appcast.xml" \
 ./script/package_macos_beta.sh --version 0.3.0 --build 2026052601 --channel local-beta
 ```
+
+The beta packaging script intentionally rejects output paths outside
+`/Volumes/LEXAR/Codex` and release identifiers containing path separators.
 
 The Sparkle private key lives only under
 `/Volumes/LEXAR/Codex/clawdnd-release-secrets/`. The repo stores only the public

--- a/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
+++ b/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
@@ -71,12 +71,16 @@ Every OpenWorlds screen should expose one of these labels:
 Sparkle is the beta distribution lane for #134. Maintainers currently use a
 Lexar-backed local channel at `/Volumes/LEXAR/Codex/clawdnd-beta-channel`.
 Contributors can use a different local channel by setting `BETA_OUTPUT_DIR` and,
-when needed, `CLAWDND_FEED_URL` before running the packaging script.
+when needed, `CLAWDND_FEED_URL` before running the packaging script. Sparkle
+must fetch appcasts over HTTP(S), so the app points Sparkle at the running
+loopback viewer, and the viewer serves the local channel artifacts without
+moving game state into the app bundle.
 
 Local maintainer setup:
 
 - app bundle: `/Volumes/LEXAR/Codex/clawdnd-beta-channel/ClawDnD.app`
-- update feed: `file:///Volumes/LEXAR/Codex/clawdnd-beta-channel/appcast.xml`
+- update feed: `http://127.0.0.1:<viewer-port>/appcast.xml`
+- local channel files: `/Volumes/LEXAR/Codex/clawdnd-beta-channel/appcast.xml`
 - release script: `script/package_macos_beta.sh`
 - bundle id: `dev.clawdnd.app`
 - version/build: `0.3.0` / `2026052601` for `0.3.0-beta.1`
@@ -86,7 +90,7 @@ Contributor override example:
 
 ```bash
 BETA_OUTPUT_DIR="$HOME/ClawDnD-beta-channel" \
-CLAWDND_FEED_URL="file://$HOME/ClawDnD-beta-channel/appcast.xml" \
+CLAWDND_FEED_URL="http://127.0.0.1:8765/appcast.xml" \
 ./script/package_macos_beta.sh --version 0.3.0 --build 2026052601 --channel local-beta
 ```
 
@@ -108,6 +112,9 @@ Implementation goals:
 - Package `viewer/openworlds/` into `ClawDnD.app/Contents/Resources/openworlds`
   and launch the repo-backed Python viewer with `CLAWDND_OPENWORLDS_DIR` pointing
   at those bundled assets when available.
+- Launch the viewer with `CLAWDND_BETA_CHANNEL_DIR` when a local beta channel is
+  configured, so `/appcast.xml` and `ClawDnD-*` artifacts are served from the
+  same loopback host/port as the OpenWorlds shell.
 
 ## Window Chrome Lane
 

--- a/macos/ClawDnDApp/Package.resolved
+++ b/macos/ClawDnDApp/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "6276ba2b404829d139c45ff98427cf90e2efc59b",
+        "version" : "2.9.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/macos/ClawDnDApp/Package.swift
+++ b/macos/ClawDnDApp/Package.swift
@@ -10,7 +10,15 @@ let package = Package(
     products: [
         .executable(name: "ClawDnDApp", targets: ["ClawDnDApp"])
     ],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.2")
+    ],
     targets: [
-        .executableTarget(name: "ClawDnDApp")
+        .executableTarget(
+            name: "ClawDnDApp",
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle")
+            ]
+        )
     ]
 )

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/App/ClawDnDApp.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/App/ClawDnDApp.swift
@@ -7,18 +7,21 @@ struct ClawDnDApp: App {
     @Environment(\.openWindow) private var openWindow
     @StateObject private var processService = AppProcessService()
     @StateObject private var campaignStore = CampaignStore()
+    @StateObject private var updaterService = UpdaterService()
 
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environmentObject(processService)
                 .environmentObject(campaignStore)
+                .environmentObject(updaterService)
                 .frame(minWidth: 1120, minHeight: 720)
         }
         WindowGroup("Debug Control Center", id: "debug-control-center") {
             DebugControlCenterView()
                 .environmentObject(processService)
                 .environmentObject(campaignStore)
+                .environmentObject(updaterService)
                 .frame(minWidth: 1120, minHeight: 720)
         }
         .commands {

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Models/LocalEndpoint.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Models/LocalEndpoint.swift
@@ -28,6 +28,10 @@ struct LocalEndpoint: Identifiable, Equatable {
         return components?.url ?? url.appendingPathComponent("openworlds/")
     }
 
+    var appcastURL: URL {
+        url.appendingPathComponent("appcast.xml")
+    }
+
     var monitorURL: URL {
         url.appendingPathComponent("monitor")
     }

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
@@ -62,6 +62,11 @@ final class AppProcessService: ObservableObject {
         guard RepositoryLocator.looksLikeRepo(repoURL) else {
             try throwAndRecord("Repo path is not a ClawDnD checkout: \(repoPath)")
         }
+        guard RepositoryLocator.supportsOpenWorldsViewer(repoURL) else {
+            try throwAndRecord(
+                "Repo checkout is missing OpenWorlds viewer routes. Update the checkout or choose an OpenWorlds-capable ClawDnD worktree: \(repoPath)"
+            )
+        }
         guard Shell.which("python3") != nil else {
             try throwAndRecord("python3 is missing. Install Python 3 before launching the viewer.")
         }
@@ -121,6 +126,11 @@ final class AppProcessService: ObservableObject {
         let repoURL = URL(fileURLWithPath: repoPath)
         guard RepositoryLocator.looksLikeRepo(repoURL) else {
             try throwAndRecord("Repo path is not a ClawDnD checkout: \(repoPath)")
+        }
+        guard RepositoryLocator.supportsOpenWorldsViewer(repoURL) else {
+            try throwAndRecord(
+                "Repo checkout is missing OpenWorlds viewer routes. Update the checkout or choose an OpenWorlds-capable ClawDnD worktree: \(repoPath)"
+            )
         }
 
         guard let port = PortFinder.firstFreePort(startingAt: preferredPort) else {

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
@@ -10,6 +10,7 @@ final class AppProcessService: ObservableObject {
     @Published var providerLog: String = ""
     @Published var lastError: String?
     @Published var providerLaunchMetadata: ProviderLaunchMetadata?
+    @Published var openWorldsAssetsPath: String?
 
     private var viewerProcess: ManagedProcess?
     private var providerProcess: ManagedProcess?
@@ -22,6 +23,7 @@ final class AppProcessService: ObservableObject {
         ClawDnD Native App Diagnostics
         Viewer: \(viewerEndpoint?.url.absoluteString ?? "stopped")
         Viewer status: \(viewerEndpoint?.status.rawValue ?? "stopped")
+        OpenWorlds assets: \(openWorldsAssetsPath ?? "repo default")
         Active campaign: \(activeCampaignID ?? "none")
         Running provider: \(runningProvider?.rawValue ?? "none")
         Last error: \(lastError ?? "none")
@@ -74,6 +76,7 @@ final class AppProcessService: ObservableObject {
         if !stateDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             env["CLAWDND_STATE_DIR"] = (stateDir as NSString).expandingTildeInPath
         }
+        attachBundledOpenWorldsAssets(to: &env)
         let args = ["python3", "viewer/server.py", campaignID ?? "", String(port)]
         let managed = try launchManagedProcess(
             name: "viewer",
@@ -152,13 +155,15 @@ final class AppProcessService: ObservableObject {
         runningProvider = nil
         providerLaunchMetadata = nil
         providerLog = ""
+        var providerEnvironment = request.environment
+        attachBundledOpenWorldsAssets(to: &providerEnvironment)
         let metadata = ProviderLaunchMetadata(
             kind: kind,
             processName: request.name,
             executable: request.executable,
             arguments: request.arguments,
             workingDirectory: request.workingDirectory,
-            environment: request.environment,
+            environment: providerEnvironment,
             world: world,
             runId: runId,
             port: port,
@@ -170,7 +175,7 @@ final class AppProcessService: ObservableObject {
             executable: request.executable,
             arguments: request.arguments,
             workingDirectory: request.workingDirectory,
-            environment: request.environment,
+            environment: providerEnvironment,
             stream: .provider,
             providerMetadata: metadata
         )
@@ -329,6 +334,23 @@ final class AppProcessService: ObservableObject {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         return (trimmed as NSString).expandingTildeInPath
+    }
+
+    private func attachBundledOpenWorldsAssets(to environment: inout [String: String]) {
+        guard let bundledAssets = bundledOpenWorldsAssets() else {
+            openWorldsAssetsPath = nil
+            return
+        }
+        environment["CLAWDND_OPENWORLDS_DIR"] = bundledAssets.path
+        openWorldsAssetsPath = bundledAssets.path
+    }
+
+    private func bundledOpenWorldsAssets() -> URL? {
+        guard let resourceURL = Bundle.main.resourceURL else { return nil }
+        let assetsURL = resourceURL.appendingPathComponent("openworlds", isDirectory: true)
+        let indexURL = assetsURL.appendingPathComponent("index.html")
+        guard FileManager.default.fileExists(atPath: indexURL.path) else { return nil }
+        return assetsURL
     }
 
     private func throwAndRecord(_ message: String) throws -> Never {

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/AppProcessService.swift
@@ -11,6 +11,7 @@ final class AppProcessService: ObservableObject {
     @Published var lastError: String?
     @Published var providerLaunchMetadata: ProviderLaunchMetadata?
     @Published var openWorldsAssetsPath: String?
+    @Published var localBetaChannelPath: String?
 
     private var viewerProcess: ManagedProcess?
     private var providerProcess: ManagedProcess?
@@ -24,6 +25,7 @@ final class AppProcessService: ObservableObject {
         Viewer: \(viewerEndpoint?.url.absoluteString ?? "stopped")
         Viewer status: \(viewerEndpoint?.status.rawValue ?? "stopped")
         OpenWorlds assets: \(openWorldsAssetsPath ?? "repo default")
+        Local beta channel: \(localBetaChannelPath ?? "not configured")
         Active campaign: \(activeCampaignID ?? "none")
         Running provider: \(runningProvider?.rawValue ?? "none")
         Last error: \(lastError ?? "none")
@@ -82,6 +84,7 @@ final class AppProcessService: ObservableObject {
             env["CLAWDND_STATE_DIR"] = (stateDir as NSString).expandingTildeInPath
         }
         attachBundledOpenWorldsAssets(to: &env)
+        attachLocalBetaChannel(to: &env)
         let args = ["python3", "viewer/server.py", campaignID ?? "", String(port)]
         let managed = try launchManagedProcess(
             name: "viewer",
@@ -167,6 +170,7 @@ final class AppProcessService: ObservableObject {
         providerLog = ""
         var providerEnvironment = request.environment
         attachBundledOpenWorldsAssets(to: &providerEnvironment)
+        attachLocalBetaChannel(to: &providerEnvironment)
         let metadata = ProviderLaunchMetadata(
             kind: kind,
             processName: request.name,
@@ -361,6 +365,32 @@ final class AppProcessService: ObservableObject {
         let indexURL = assetsURL.appendingPathComponent("index.html")
         guard FileManager.default.fileExists(atPath: indexURL.path) else { return nil }
         return assetsURL
+    }
+
+    private func attachLocalBetaChannel(to environment: inout [String: String]) {
+        guard let channelURL = localBetaChannel() else {
+            localBetaChannelPath = nil
+            return
+        }
+        environment["CLAWDND_BETA_CHANNEL_DIR"] = channelURL.path
+        localBetaChannelPath = channelURL.path
+    }
+
+    private func localBetaChannel() -> URL? {
+        let fileManager = FileManager.default
+        if let rawPath = Bundle.main.object(forInfoDictionaryKey: "ClawDnDLocalBetaChannelPath") as? String {
+            let url = URL(fileURLWithPath: (rawPath as NSString).expandingTildeInPath, isDirectory: true)
+            if fileManager.fileExists(atPath: url.appendingPathComponent("appcast.xml").path) {
+                return url
+            }
+        }
+
+        let appDirectory = Bundle.main.bundleURL.deletingLastPathComponent()
+        if fileManager.fileExists(atPath: appDirectory.appendingPathComponent("appcast.xml").path) {
+            return appDirectory
+        }
+
+        return nil
     }
 
     private func throwAndRecord(_ message: String) throws -> Never {

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/RepositoryLocator.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/RepositoryLocator.swift
@@ -2,34 +2,87 @@ import Foundation
 
 enum RepositoryLocator {
     static func defaultRepoPath() -> String? {
-        if let env = ProcessInfo.processInfo.environment["CLAWDND_REPO_ROOT"] {
-            let expanded = (env as NSString).expandingTildeInPath
-            if looksLikeRepo(URL(fileURLWithPath: expanded)) {
-                return expanded
+        if let openWorldsRepo = defaultOpenWorldsRepoPath() {
+            return openWorldsRepo
+        }
+
+        for candidate in candidateURLs() where looksLikeRepo(candidate) {
+            return candidate.standardizedFileURL.path
+        }
+
+        return nil
+    }
+
+    static func defaultOpenWorldsRepoPath() -> String? {
+        for candidate in candidateURLs() where supportsOpenWorldsViewer(candidate) {
+            if looksLikeRepo(candidate) {
+                return candidate.standardizedFileURL.path
             }
+        }
+        return nil
+    }
+
+    static func validRepoPath(_ rawPath: String) -> String? {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded)
+        return looksLikeRepo(url) ? url.standardizedFileURL.path : nil
+    }
+
+    static func openWorldsRepoPath(_ rawPath: String) -> String? {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let expanded = (trimmed as NSString).expandingTildeInPath
+        let url = URL(fileURLWithPath: expanded)
+        return looksLikeRepo(url) && supportsOpenWorldsViewer(url) ? url.standardizedFileURL.path : nil
+    }
+
+    private static func candidateURLs() -> [URL] {
+        var candidates: [URL] = []
+
+        func append(_ url: URL?) {
+            guard let url else { return }
+            let standardized = url.standardizedFileURL
+            guard !candidates.contains(standardized) else { return }
+            candidates.append(standardized)
+        }
+
+        if let env = ProcessInfo.processInfo.environment["CLAWDND_REPO_ROOT"],
+           let valid = validRepoPath(env) {
+            append(URL(fileURLWithPath: valid))
         }
 
         let bundleURL = Bundle.main.bundleURL
         var cursor = bundleURL.deletingLastPathComponent()
         for _ in 0..<8 {
-            if looksLikeRepo(cursor) {
-                return cursor.path
-            }
+            append(cursor)
             cursor.deleteLastPathComponent()
         }
 
-        let homeRepo = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent("repos/ClawDnD")
-        if looksLikeRepo(homeRepo) {
-            return homeRepo.path
+        append(FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("repos/ClawDnD"))
+        append(URL(fileURLWithPath: "/Volumes/LEXAR/repos/ClawDnD"))
+
+        let lexarRepos = URL(fileURLWithPath: "/Volumes/LEXAR/repos", isDirectory: true)
+        if let children = try? FileManager.default.contentsOfDirectory(
+            at: lexarRepos,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) {
+            let clawRepos = children
+                .filter { $0.lastPathComponent.localizedCaseInsensitiveContains("ClawDnD") }
+                .sorted { lhs, rhs in
+                    if lhs.lastPathComponent == "ClawDnD" { return true }
+                    if rhs.lastPathComponent == "ClawDnD" { return false }
+                    return lhs.lastPathComponent < rhs.lastPathComponent
+                }
+            clawRepos.forEach { append($0) }
         }
 
         let cwd = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        if looksLikeRepo(cwd) {
-            return cwd.path
-        }
+        append(cwd)
 
-        return nil
+        return candidates
     }
 
     static func looksLikeRepo(_ url: URL) -> Bool {
@@ -37,5 +90,14 @@ enum RepositoryLocator {
         let plugin = url.appendingPathComponent(".claude-plugin/plugin.json").path
         return FileManager.default.fileExists(atPath: viewer)
             && FileManager.default.fileExists(atPath: plugin)
+    }
+
+    static func supportsOpenWorldsViewer(_ url: URL) -> Bool {
+        let serverURL = url.appendingPathComponent("viewer/server.py")
+        guard let source = try? String(contentsOf: serverURL, encoding: .utf8) else {
+            return false
+        }
+        return source.contains("CLAWDND_OPENWORLDS_DIR")
+            && source.contains("/openworlds/config.json")
     }
 }

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/RepositoryLocator.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/RepositoryLocator.swift
@@ -14,10 +14,8 @@ enum RepositoryLocator {
     }
 
     static func defaultOpenWorldsRepoPath() -> String? {
-        for candidate in candidateURLs() where supportsOpenWorldsViewer(candidate) {
-            if looksLikeRepo(candidate) {
-                return candidate.standardizedFileURL.path
-            }
+        for candidate in candidateURLs() where looksLikeRepo(candidate) && supportsOpenWorldsViewer(candidate) {
+            return candidate.standardizedFileURL.path
         }
         return nil
     }
@@ -61,7 +59,6 @@ enum RepositoryLocator {
         }
 
         append(FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("repos/ClawDnD"))
-        append(URL(fileURLWithPath: "/Volumes/LEXAR/repos/ClawDnD"))
 
         let lexarRepos = URL(fileURLWithPath: "/Volumes/LEXAR/repos", isDirectory: true)
         if let children = try? FileManager.default.contentsOfDirectory(
@@ -93,11 +90,7 @@ enum RepositoryLocator {
     }
 
     static func supportsOpenWorldsViewer(_ url: URL) -> Bool {
-        let serverURL = url.appendingPathComponent("viewer/server.py")
-        guard let source = try? String(contentsOf: serverURL, encoding: .utf8) else {
-            return false
-        }
-        return source.contains("CLAWDND_OPENWORLDS_DIR")
-            && source.contains("/openworlds/config.json")
+        let index = url.appendingPathComponent("viewer/openworlds/index.html").path
+        return FileManager.default.fileExists(atPath: index)
     }
 }

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/UpdaterService.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/UpdaterService.swift
@@ -8,6 +8,7 @@ final class UpdaterService: NSObject, ObservableObject, SPUUpdaterDelegate {
 
     private var updaterController: SPUStandardUpdaterController?
     private var overrideFeedURL: URL?
+    private var feedAvailable = false
 
     override init() {
         super.init()
@@ -19,11 +20,14 @@ final class UpdaterService: NSObject, ObservableObject, SPUUpdaterDelegate {
 
         if feedURL.isEmpty {
             updaterController = nil
+            feedAvailable = false
             lastError = "Sparkle feed URL is missing or empty in Info.plist."
         } else if publicKey.isEmpty {
             updaterController = nil
+            feedAvailable = false
             lastError = "Sparkle public key is missing or empty in Info.plist."
         } else {
+            feedAvailable = true
             updaterController = SPUStandardUpdaterController(
                 startingUpdater: true,
                 updaterDelegate: self,
@@ -32,9 +36,10 @@ final class UpdaterService: NSObject, ObservableObject, SPUUpdaterDelegate {
         }
     }
 
-    func setFeedURL(_ feedURL: URL?) {
+    func setFeedURL(_ feedURL: URL?, available: Bool = false) {
         overrideFeedURL = feedURL
-        lastError = nil
+        feedAvailable = available
+        lastError = available ? nil : "Local beta appcast is unavailable."
     }
 
     var statusPayload: [String: Any] {
@@ -44,10 +49,12 @@ final class UpdaterService: NSObject, ObservableObject, SPUUpdaterDelegate {
             "build": info["CFBundleVersion"] as? String ?? "0",
             "bundleIdentifier": info["CFBundleIdentifier"] as? String ?? "",
             "feedURL": currentFeedURLString,
+            "feedAvailable": feedAvailable,
             "channel": info["ClawDnDUpdateChannel"] as? String ?? "local-beta",
-            "canCheckForUpdates": updaterController?.updater.canCheckForUpdates ?? false,
-            "publicKeyConfigured": (info["SUPublicEDKey"] as? String)?.isEmpty == false,
-            "status": updaterController == nil ? "unavailable" : "ready",
+            "canCheckForUpdates": feedAvailable && (updaterController?.updater.canCheckForUpdates ?? false),
+            "publicKeyConfigured": ((info["SUPublicEDKey"] as? String)?
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false),
+            "status": updaterController == nil || !feedAvailable ? "unavailable" : "ready",
             "lastError": lastError ?? "",
         ]
         if let lastCheckRequestedAt {
@@ -59,6 +66,10 @@ final class UpdaterService: NSObject, ObservableObject, SPUUpdaterDelegate {
     func checkForUpdates() throws -> [String: Any] {
         guard let updaterController else {
             throw ProviderError.configuration(lastError ?? "Sparkle updater is unavailable.")
+        }
+        guard feedAvailable else {
+            lastError = "Local beta appcast is unavailable. Start the viewer from a packaged beta channel."
+            throw ProviderError.configuration(lastError ?? "Local beta appcast is unavailable.")
         }
         guard updaterController.updater.canCheckForUpdates else {
             throw ProviderError.configuration("Sparkle updater is not ready to check for updates yet.")

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/UpdaterService.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/UpdaterService.swift
@@ -9,12 +9,17 @@ final class UpdaterService: ObservableObject {
     private let updaterController: SPUStandardUpdaterController?
 
     init() {
-        if Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String == nil {
+        let feedURL = (Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let publicKey = (Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        if feedURL.isEmpty {
             updaterController = nil
-            lastError = "Sparkle feed URL is missing from Info.plist."
-        } else if Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String == nil {
+            lastError = "Sparkle feed URL is missing or empty in Info.plist."
+        } else if publicKey.isEmpty {
             updaterController = nil
-            lastError = "Sparkle public key is missing from Info.plist."
+            lastError = "Sparkle public key is missing or empty in Info.plist."
         } else {
             updaterController = SPUStandardUpdaterController(
                 startingUpdater: true,

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/UpdaterService.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/UpdaterService.swift
@@ -2,13 +2,16 @@ import Foundation
 import Sparkle
 
 @MainActor
-final class UpdaterService: ObservableObject {
+final class UpdaterService: NSObject, ObservableObject, SPUUpdaterDelegate {
     @Published private(set) var lastCheckRequestedAt: Date?
     @Published private(set) var lastError: String?
 
-    private let updaterController: SPUStandardUpdaterController?
+    private var updaterController: SPUStandardUpdaterController?
+    private var overrideFeedURL: URL?
 
-    init() {
+    override init() {
+        super.init()
+
         let feedURL = (Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let publicKey = (Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String)?
@@ -23,10 +26,15 @@ final class UpdaterService: ObservableObject {
         } else {
             updaterController = SPUStandardUpdaterController(
                 startingUpdater: true,
-                updaterDelegate: nil,
+                updaterDelegate: self,
                 userDriverDelegate: nil
             )
         }
+    }
+
+    func setFeedURL(_ feedURL: URL?) {
+        overrideFeedURL = feedURL
+        lastError = nil
     }
 
     var statusPayload: [String: Any] {
@@ -35,7 +43,7 @@ final class UpdaterService: ObservableObject {
             "version": info["CFBundleShortVersionString"] as? String ?? "0.0.0",
             "build": info["CFBundleVersion"] as? String ?? "0",
             "bundleIdentifier": info["CFBundleIdentifier"] as? String ?? "",
-            "feedURL": info["SUFeedURL"] as? String ?? "",
+            "feedURL": currentFeedURLString,
             "channel": info["ClawDnDUpdateChannel"] as? String ?? "local-beta",
             "canCheckForUpdates": updaterController?.updater.canCheckForUpdates ?? false,
             "publicKeyConfigured": (info["SUPublicEDKey"] as? String)?.isEmpty == false,
@@ -55,10 +63,42 @@ final class UpdaterService: ObservableObject {
         guard updaterController.updater.canCheckForUpdates else {
             throw ProviderError.configuration("Sparkle updater is not ready to check for updates yet.")
         }
+        guard let feedURL = currentFeedURL, ["http", "https"].contains(feedURL.scheme?.lowercased() ?? "") else {
+            lastError = "Sparkle feed is not reachable over HTTP yet. Start the viewer first."
+            throw ProviderError.configuration(lastError ?? "Sparkle feed is not reachable over HTTP yet.")
+        }
         lastCheckRequestedAt = Date()
         lastError = nil
         updaterController.checkForUpdates(nil)
         return statusPayload
+    }
+
+    @objc(feedURLStringForUpdater:)
+    func feedURLString(for updater: SPUUpdater) -> String? {
+        overrideFeedURL?.absoluteString
+    }
+
+    @objc(updater:didAbortWithError:)
+    func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+        lastError = error.localizedDescription
+    }
+
+    @objc(updater:didFinishUpdateCycleForUpdateCheck:error:)
+    func updater(
+        _ updater: SPUUpdater,
+        didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+        error: Error?
+    ) {
+        lastError = error?.localizedDescription
+    }
+
+    private var currentFeedURLString: String {
+        overrideFeedURL?.absoluteString
+            ?? (Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String ?? "")
+    }
+
+    private var currentFeedURL: URL? {
+        URL(string: currentFeedURLString.trimmingCharacters(in: .whitespacesAndNewlines))
     }
 
     private static let isoDateFormatter = ISO8601DateFormatter()

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Services/UpdaterService.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Services/UpdaterService.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Sparkle
+
+@MainActor
+final class UpdaterService: ObservableObject {
+    @Published private(set) var lastCheckRequestedAt: Date?
+    @Published private(set) var lastError: String?
+
+    private let updaterController: SPUStandardUpdaterController?
+
+    init() {
+        if Bundle.main.object(forInfoDictionaryKey: "SUFeedURL") as? String == nil {
+            updaterController = nil
+            lastError = "Sparkle feed URL is missing from Info.plist."
+        } else if Bundle.main.object(forInfoDictionaryKey: "SUPublicEDKey") as? String == nil {
+            updaterController = nil
+            lastError = "Sparkle public key is missing from Info.plist."
+        } else {
+            updaterController = SPUStandardUpdaterController(
+                startingUpdater: true,
+                updaterDelegate: nil,
+                userDriverDelegate: nil
+            )
+        }
+    }
+
+    var statusPayload: [String: Any] {
+        let info = Bundle.main.infoDictionary ?? [:]
+        var payload: [String: Any] = [
+            "version": info["CFBundleShortVersionString"] as? String ?? "0.0.0",
+            "build": info["CFBundleVersion"] as? String ?? "0",
+            "bundleIdentifier": info["CFBundleIdentifier"] as? String ?? "",
+            "feedURL": info["SUFeedURL"] as? String ?? "",
+            "channel": info["ClawDnDUpdateChannel"] as? String ?? "local-beta",
+            "canCheckForUpdates": updaterController?.updater.canCheckForUpdates ?? false,
+            "publicKeyConfigured": (info["SUPublicEDKey"] as? String)?.isEmpty == false,
+            "status": updaterController == nil ? "unavailable" : "ready",
+            "lastError": lastError ?? "",
+        ]
+        if let lastCheckRequestedAt {
+            payload["lastCheckRequestedAt"] = Self.isoDateFormatter.string(from: lastCheckRequestedAt)
+        }
+        return payload
+    }
+
+    func checkForUpdates() throws -> [String: Any] {
+        guard let updaterController else {
+            throw ProviderError.configuration(lastError ?? "Sparkle updater is unavailable.")
+        }
+        guard updaterController.updater.canCheckForUpdates else {
+            throw ProviderError.configuration("Sparkle updater is not ready to check for updates yet.")
+        }
+        lastCheckRequestedAt = Date()
+        lastError = nil
+        updaterController.checkForUpdates(nil)
+        return statusPayload
+    }
+
+    private static let isoDateFormatter = ISO8601DateFormatter()
+}

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/RootView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/RootView.swift
@@ -150,16 +150,16 @@ struct RootView: View {
         throw ProviderError.configuration("Viewer did not become ready at \(url.absoluteString): \(lastError)")
     }
 
-    private func handleNativeRequest(_ request: NativeBridgeRequest) async -> NativeBridgeReply {
+    private func handleNativeRequest(_ request: NativeBridgeRequest, sourceWindow: NSWindow?) async -> NativeBridgeReply {
         do {
-            let payload = try await nativePayload(for: request)
+            let payload = try await nativePayload(for: request, sourceWindow: sourceWindow)
             return .success(request: request, payload: payload)
         } catch {
             return .failure(request: request, error: error.localizedDescription)
         }
     }
 
-    private func nativePayload(for request: NativeBridgeRequest) async throws -> [String: Any] {
+    private func nativePayload(for request: NativeBridgeRequest, sourceWindow: NSWindow?) async throws -> [String: Any] {
         switch request.type {
         case "appStatus":
             return appStatusPayload()
@@ -191,7 +191,7 @@ struct RootView: View {
         case "checkForUpdates":
             return ["updater": try updaterService.checkForUpdates()]
         case "windowCommand":
-            return try performWindowCommand(request.payload)
+            return try performWindowCommand(request.payload, sourceWindow: sourceWindow)
         case "openFallbackDashboard":
             let dashboardURL = try await ensureDashboardURL()
             NSWorkspace.shared.open(dashboardURL)
@@ -256,7 +256,8 @@ struct RootView: View {
     }
 
     private func updateAppcastFeedURL() {
-        updaterService.setFeedURL(processService.viewerEndpoint?.appcastURL)
+        let appcastURL = processService.localBetaChannelPath == nil ? nil : processService.viewerEndpoint?.appcastURL
+        updaterService.setFeedURL(appcastURL, available: appcastURL != nil)
     }
 
     private func appStatusPayload(extra: [String: Any] = [:]) -> [String: Any] {
@@ -293,12 +294,12 @@ struct RootView: View {
         return payload
     }
 
-    private func performWindowCommand(_ payload: [String: Any]) throws -> [String: Any] {
+    private func performWindowCommand(_ payload: [String: Any], sourceWindow: NSWindow?) throws -> [String: Any] {
         guard let rawCommand = stringPayload(payload, "command")?.lowercased(), !rawCommand.isEmpty else {
             throw ProviderError.configuration("windowCommand requires a command.")
         }
-        guard let window = NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
-            throw ProviderError.configuration("No active app window is available.")
+        guard let window = sourceWindow, window.isVisible else {
+            throw ProviderError.configuration("No OpenWorlds app window is available.")
         }
         switch rawCommand {
         case "close":

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/RootView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/RootView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct RootView: View {
     @EnvironmentObject private var processService: AppProcessService
     @EnvironmentObject private var campaignStore: CampaignStore
+    @EnvironmentObject private var updaterService: UpdaterService
 
     @AppStorage("repoPath") private var repoPath: String = RepositoryLocator.defaultRepoPath() ?? ""
     @AppStorage("preferredPort") private var preferredPort: Int = 8765
@@ -52,6 +53,11 @@ struct RootView: View {
                 }
                 .background(.black.opacity(0.82))
             }
+        }
+        .overlay(alignment: .top) {
+            OpenWorldsDragStrip()
+                .frame(width: 560, height: 36)
+                .accessibilityHidden(true)
         }
         .onAppear {
             refresh()
@@ -171,6 +177,12 @@ struct RootView: View {
         case "copyDiagnostics":
             Diagnostics.copy(processService: processService)
             return ["copied": true]
+        case "updaterStatus":
+            return ["updater": updaterService.statusPayload]
+        case "checkForUpdates":
+            return ["updater": try updaterService.checkForUpdates()]
+        case "windowCommand":
+            return try performWindowCommand(request.payload)
         case "openFallbackDashboard":
             let dashboardURL = try await ensureDashboardURL()
             NSWorkspace.shared.open(dashboardURL)
@@ -254,9 +266,31 @@ struct RootView: View {
             "providers": providerStatusesPayload(),
             "dependencies": dependencyPayload(),
             "providerDiagnostics": Diagnostics.providerLaunchSummary(processService.providerLaunchMetadata),
+            "openWorldsAssetsPath": processService.openWorldsAssetsPath ?? "",
+            "updater": updaterService.statusPayload,
         ]
         extra.forEach { payload[$0.key] = $0.value }
         return payload
+    }
+
+    private func performWindowCommand(_ payload: [String: Any]) throws -> [String: Any] {
+        guard let rawCommand = stringPayload(payload, "command")?.lowercased(), !rawCommand.isEmpty else {
+            throw ProviderError.configuration("windowCommand requires a command.")
+        }
+        guard let window = NSApp.keyWindow ?? NSApp.mainWindow ?? NSApp.windows.first(where: { $0.isVisible }) else {
+            throw ProviderError.configuration("No active app window is available.")
+        }
+        switch rawCommand {
+        case "close":
+            DispatchQueue.main.async { window.performClose(nil) }
+        case "minimize":
+            DispatchQueue.main.async { window.miniaturize(nil) }
+        case "zoom":
+            DispatchQueue.main.async { window.zoom(nil) }
+        default:
+            throw ProviderError.configuration("Unsupported window command: \(rawCommand)")
+        }
+        return ["command": rawCommand, "performed": true]
     }
 
     private func endpointPayload(_ endpoint: LocalEndpoint?) -> [String: Any] {
@@ -367,6 +401,22 @@ private final class OpenWorldsChromeHostView: NSView {
                 window.standardWindowButton(button)?.isHidden = true
             }
         }
+    }
+}
+
+private struct OpenWorldsDragStrip: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        OpenWorldsDragStripView(frame: .zero)
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {}
+}
+
+private final class OpenWorldsDragStripView: NSView {
+    override var acceptsFirstResponder: Bool { false }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.performDrag(with: event)
     }
 }
 

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/RootView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/RootView.swift
@@ -36,6 +36,7 @@ struct RootView: View {
                     navigationError: $webViewErrorMessage,
                     nativeRequestHandler: handleNativeRequest
                 )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .ignoresSafeArea()
             } else {
                 OpenWorldsLaunchOverlay(
@@ -97,6 +98,7 @@ struct RootView: View {
                     preferredPort: preferredPort,
                     stateDir: stateDir
                 )
+                updateAppcastFeedURL()
                 launchMessage = "Waiting for OpenWorlds"
                 try await waitForOpenWorlds(url)
                 guard !Task.isCancelled else { return }
@@ -170,12 +172,14 @@ struct RootView: View {
             return try await startViewerFromBridge(request.payload)
         case "stopViewer":
             processService.stopViewer()
+            updaterService.setFeedURL(nil)
             webURL = nil
             return appStatusPayload()
         case "startProviderSession":
             return try await startProviderFromBridge(request.payload)
         case "stopProvider":
             processService.stopProvider()
+            updaterService.setFeedURL(nil)
             return appStatusPayload()
         case "diagnostics":
             return ["diagnostics": processService.diagnostics]
@@ -206,6 +210,7 @@ struct RootView: View {
             stateDir: stateDir,
             campaignID: campaignID
         )
+        updateAppcastFeedURL()
         try await waitForOpenWorlds(url)
         webURL = url
         return appStatusPayload(extra: ["url": url.absoluteString])
@@ -228,6 +233,7 @@ struct RootView: View {
             stateDir: stateDir,
             preferences: providerPreferences
         )
+        updateAppcastFeedURL()
         try await waitForOpenWorlds(url)
         webURL = url
         return appStatusPayload(extra: ["url": url.absoluteString, "runId": runId])
@@ -243,9 +249,14 @@ struct RootView: View {
             preferredPort: preferredPort,
             stateDir: stateDir
         )
+        updateAppcastFeedURL()
         try await waitForOpenWorlds(url)
         webURL = url
         return processService.viewerEndpoint?.dashboardURL ?? url
+    }
+
+    private func updateAppcastFeedURL() {
+        updaterService.setFeedURL(processService.viewerEndpoint?.appcastURL)
     }
 
     private func appStatusPayload(extra: [String: Any] = [:]) -> [String: Any] {
@@ -423,7 +434,7 @@ private final class OpenWorldsChromeHostView: NSView {
             window.titleVisibility = .hidden
             window.titlebarAppearsTransparent = true
             window.styleMask.insert(.fullSizeContentView)
-            window.styleMask.remove(.titled)
+            window.styleMask.insert(.titled)
             window.styleMask.insert(.resizable)
             window.toolbar = nil
             window.backgroundColor = .black

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/RootView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/RootView.swift
@@ -75,7 +75,7 @@ struct RootView: View {
 
     private func refresh() {
         processService.refreshDependencies()
-        if let resolved = resolvedRepoPath(persist: true) {
+        if let resolved = resolveAndPersistRepoPath() {
             campaignStore.reload(repoPath: resolved)
         } else {
             campaignStore.reload(repoPath: repoPath)
@@ -249,7 +249,7 @@ struct RootView: View {
     }
 
     private func appStatusPayload(extra: [String: Any] = [:]) -> [String: Any] {
-        let currentRepoPath = resolvedRepoPath(persist: false) ?? repoPath
+        let currentRepoPath = resolvedRepoPath() ?? repoPath
         var payload: [String: Any] = [
             "repoPath": currentRepoPath,
             "stateDir": stateDir.isEmpty ? "default" : stateDir,
@@ -330,7 +330,7 @@ struct RootView: View {
     }
 
     private func providerStatusesPayload() -> [[String: Any]] {
-        let currentRepoPath = resolvedRepoPath(persist: false) ?? repoPath
+        let currentRepoPath = resolvedRepoPath() ?? repoPath
         return processService.providerStatuses(repoPath: currentRepoPath, preferences: providerPreferences).map {
             [
                 "kind": $0.kind.rawValue,
@@ -344,7 +344,7 @@ struct RootView: View {
     }
 
     private func requireRepoPath() throws -> String {
-        if let resolved = resolvedRepoPath(persist: true) {
+        if let resolved = resolveAndPersistRepoPath() {
             return resolved
         }
         throw ProviderError.configuration(
@@ -352,17 +352,19 @@ struct RootView: View {
         )
     }
 
-    private func resolvedRepoPath(persist: Bool) -> String? {
+    private func resolveAndPersistRepoPath() -> String? {
+        guard let resolved = resolvedRepoPath() else { return nil }
+        if resolved != repoPath {
+            repoPath = resolved
+        }
+        return resolved
+    }
+
+    private func resolvedRepoPath() -> String? {
         if let compatible = RepositoryLocator.openWorldsRepoPath(repoPath) {
-            if persist, compatible != repoPath {
-                repoPath = compatible
-            }
             return compatible
         }
         if let discovered = RepositoryLocator.defaultOpenWorldsRepoPath() {
-            if persist, discovered != repoPath {
-                repoPath = discovered
-            }
             return discovered
         }
         return nil

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/RootView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/RootView.swift
@@ -75,7 +75,11 @@ struct RootView: View {
 
     private func refresh() {
         processService.refreshDependencies()
-        campaignStore.reload(repoPath: repoPath)
+        if let resolved = resolvedRepoPath(persist: true) {
+            campaignStore.reload(repoPath: resolved)
+        } else {
+            campaignStore.reload(repoPath: repoPath)
+        }
     }
 
     private func startOpenWorlds() {
@@ -87,8 +91,9 @@ struct RootView: View {
             webURL = nil
             launchMessage = "Starting the local viewer"
             do {
+                let resolvedRepoPath = try requireRepoPath()
                 let url = try processService.startViewer(
-                    repoPath: repoPath,
+                    repoPath: resolvedRepoPath,
                     preferredPort: preferredPort,
                     stateDir: stateDir
                 )
@@ -194,8 +199,9 @@ struct RootView: View {
 
     private func startViewerFromBridge(_ payload: [String: Any]) async throws -> [String: Any] {
         let campaignID = stringPayload(payload, "campaignID").flatMap { $0.isEmpty ? nil : $0 }
+        let resolvedRepoPath = try requireRepoPath()
         let url = try processService.startViewer(
-            repoPath: repoPath,
+            repoPath: resolvedRepoPath,
             preferredPort: preferredPort,
             stateDir: stateDir,
             campaignID: campaignID
@@ -211,9 +217,10 @@ struct RootView: View {
         let world = stringPayload(payload, "world") ?? defaultWorld
         let runId = stringPayload(payload, "runId").flatMap { $0.isEmpty ? nil : $0 } ?? Self.newRunID()
         let companions = stringPayload(payload, "companions") ?? ""
+        let resolvedRepoPath = try requireRepoPath()
         let url = try processService.startProviderSession(
             kind: provider,
-            repoPath: repoPath,
+            repoPath: resolvedRepoPath,
             world: world,
             runId: runId,
             preferredPort: preferredPort,
@@ -230,8 +237,9 @@ struct RootView: View {
         if let endpoint = processService.viewerEndpoint {
             return endpoint.dashboardURL
         }
+        let resolvedRepoPath = try requireRepoPath()
         let url = try processService.startViewer(
-            repoPath: repoPath,
+            repoPath: resolvedRepoPath,
             preferredPort: preferredPort,
             stateDir: stateDir
         )
@@ -241,8 +249,9 @@ struct RootView: View {
     }
 
     private func appStatusPayload(extra: [String: Any] = [:]) -> [String: Any] {
+        let currentRepoPath = resolvedRepoPath(persist: false) ?? repoPath
         var payload: [String: Any] = [
-            "repoPath": repoPath,
+            "repoPath": currentRepoPath,
             "stateDir": stateDir.isEmpty ? "default" : stateDir,
             "preferredPort": preferredPort,
             "defaultWorld": defaultWorld,
@@ -253,7 +262,7 @@ struct RootView: View {
             "runningProvider": processService.runningProvider?.rawValue ?? "",
             "lastError": processService.lastError ?? "",
             "preferences": [
-                "repoPath": repoPath,
+                "repoPath": currentRepoPath,
                 "preferredPort": preferredPort,
                 "stateDir": stateDir,
                 "selectedProvider": selectedProviderRaw,
@@ -321,7 +330,8 @@ struct RootView: View {
     }
 
     private func providerStatusesPayload() -> [[String: Any]] {
-        processService.providerStatuses(repoPath: repoPath, preferences: providerPreferences).map {
+        let currentRepoPath = resolvedRepoPath(persist: false) ?? repoPath
+        return processService.providerStatuses(repoPath: currentRepoPath, preferences: providerPreferences).map {
             [
                 "kind": $0.kind.rawValue,
                 "displayName": $0.kind.displayName,
@@ -331,6 +341,31 @@ struct RootView: View {
                 "launchable": $0.isLaunchable,
             ]
         }
+    }
+
+    private func requireRepoPath() throws -> String {
+        if let resolved = resolvedRepoPath(persist: true) {
+            return resolved
+        }
+        throw ProviderError.configuration(
+            "Repo path is not a ClawDnD checkout. Choose a checkout in Settings or set CLAWDND_REPO_ROOT."
+        )
+    }
+
+    private func resolvedRepoPath(persist: Bool) -> String? {
+        if let compatible = RepositoryLocator.openWorldsRepoPath(repoPath) {
+            if persist, compatible != repoPath {
+                repoPath = compatible
+            }
+            return compatible
+        }
+        if let discovered = RepositoryLocator.defaultOpenWorldsRepoPath() {
+            if persist, discovered != repoPath {
+                repoPath = discovered
+            }
+            return discovered
+        }
+        return nil
     }
 
     private var providerPreferences: ProviderPreferences {

--- a/macos/ClawDnDApp/Sources/ClawDnDApp/Views/WebView.swift
+++ b/macos/ClawDnDApp/Sources/ClawDnDApp/Views/WebView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftUI
 import WebKit
@@ -54,7 +55,7 @@ struct NativeBridgeReply {
 }
 
 struct WebView: NSViewRepresentable {
-    typealias NativeRequestHandler = @MainActor (NativeBridgeRequest) async -> NativeBridgeReply
+    typealias NativeRequestHandler = @MainActor (NativeBridgeRequest, NSWindow?) async -> NativeBridgeReply
 
     let url: URL?
     @Binding var navigationError: String?
@@ -179,8 +180,9 @@ struct WebView: NSViewRepresentable {
                 send(.failure(request: request, error: "Native bridge is unavailable."))
                 return
             }
+            let sourceWindow = webView?.window
             Task { @MainActor in
-                let reply = await nativeRequestHandler(request)
+                let reply = await nativeRequestHandler(request, sourceWindow)
                 self.send(reply)
             }
         }

--- a/macos/ClawDnDApp/SparklePublicKey.txt
+++ b/macos/ClawDnDApp/SparklePublicKey.txt
@@ -1,0 +1,1 @@
+nEtnlcHYwAug72XlWg6Li9poAbUzN2CwFy94WmJ23E0=

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -13,6 +13,8 @@ DIST_DIR="$ROOT_DIR/dist"
 APP_BUNDLE="$DIST_DIR/$DISPLAY_NAME.app"
 APP_CONTENTS="$APP_BUNDLE/Contents"
 APP_MACOS="$APP_CONTENTS/MacOS"
+APP_FRAMEWORKS="$APP_CONTENTS/Frameworks"
+APP_RESOURCES="$APP_CONTENTS/Resources"
 APP_BINARY="$APP_MACOS/$APP_NAME"
 INFO_PLIST="$APP_CONTENTS/Info.plist"
 
@@ -30,9 +32,12 @@ build_bundle() {
   bin_path="$(swift build --package-path "$PACKAGE_DIR" --show-bin-path)/$APP_NAME"
 
   rm -rf "$APP_BUNDLE"
-  mkdir -p "$APP_MACOS"
+  mkdir -p "$APP_MACOS" "$APP_FRAMEWORKS" "$APP_RESOURCES"
   cp "$bin_path" "$APP_BINARY"
   chmod +x "$APP_BINARY"
+  copy_sparkle_framework
+  copy_openworlds_resources
+  add_app_framework_rpath
 
   cat >"$INFO_PLIST" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -64,6 +69,29 @@ PLIST
 
   if command -v codesign >/dev/null 2>&1; then
     codesign --force --sign - "$APP_BUNDLE" >/dev/null 2>&1 || true
+  fi
+}
+
+copy_sparkle_framework() {
+  local sparkle_framework
+  sparkle_framework="$(find "$PACKAGE_DIR/.build/artifacts" -path '*/Sparkle.framework' -type d -print -quit 2>/dev/null || true)"
+  if [[ -z "$sparkle_framework" ]]; then
+    sparkle_framework="$(find "$PACKAGE_DIR/.build" -path '*/Sparkle.framework' -type d -print -quit 2>/dev/null || true)"
+  fi
+  if [[ -n "$sparkle_framework" ]]; then
+    ditto "$sparkle_framework" "$APP_FRAMEWORKS/Sparkle.framework"
+  fi
+}
+
+copy_openworlds_resources() {
+  if [[ -d "$ROOT_DIR/viewer/openworlds" ]]; then
+    ditto "$ROOT_DIR/viewer/openworlds" "$APP_RESOURCES/openworlds"
+  fi
+}
+
+add_app_framework_rpath() {
+  if command -v install_name_tool >/dev/null 2>&1 && ! otool -l "$APP_BINARY" | grep -q '@executable_path/../Frameworks'; then
+    install_name_tool -add_rpath '@executable_path/../Frameworks' "$APP_BINARY"
   fi
 }
 

--- a/script/package_macos_beta.sh
+++ b/script/package_macos_beta.sh
@@ -1,0 +1,357 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build and package the ClawDnD macOS beta channel.
+#
+# This script intentionally keeps every generated artifact under
+# /Volumes/LEXAR/Codex/clawdnd-beta-channel and reads release signing material
+# from /Volumes/LEXAR/Codex/clawdnd-release-secrets. It never prints key
+# contents and does not mutate source files.
+
+DEFAULT_VERSION="0.3.0"
+DEFAULT_BUILD="2026052601"
+DEFAULT_CHANNEL="local-beta"
+
+APP_NAME="ClawDnD"
+EXECUTABLE_NAME="ClawDnDApp"
+BUNDLE_ID="dev.clawdnd.app"
+SIGNING_IDENTITY="Developer ID Application: Andrew Ryan (TC6MS3T6NN)"
+
+OUTPUT_ROOT="/Volumes/LEXAR/Codex/clawdnd-beta-channel"
+SECRETS_DIR="/Volumes/LEXAR/Codex/clawdnd-release-secrets"
+PRIVATE_KEY_FILE="${SECRETS_DIR}/sparkle-ed25519-private-key.base64"
+
+usage() {
+  cat <<'USAGE'
+Usage: script/package_macos_beta.sh [--version VERSION] [--build BUILD] [--channel CHANNEL]
+
+Defaults:
+  --version  0.3.0
+  --build    2026052601
+  --channel  local-beta
+
+Environment:
+  CLAWDND_FEED_URL              Sparkle feed URL written into Info.plist.
+                                Defaults to file:///Volumes/LEXAR/Codex/clawdnd-beta-channel/appcast.xml
+  CLAWDND_DOWNLOAD_URL_PREFIX   Optional URL prefix passed to Sparkle generate_appcast.
+USAGE
+}
+
+log() {
+  printf '[package_macos_beta] %s\n' "$*"
+}
+
+fail() {
+  printf '[package_macos_beta] error: %s\n' "$*" >&2
+  exit 1
+}
+
+require_file() {
+  local path="$1"
+  local label="$2"
+  [[ -f "$path" ]] || fail "missing ${label}: ${path}"
+}
+
+require_dir() {
+  local path="$1"
+  local label="$2"
+  [[ -d "$path" ]] || fail "missing ${label}: ${path}"
+}
+
+require_command() {
+  command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+xml_escape() {
+  local value="$1"
+  value="${value//&/&amp;}"
+  value="${value//</&lt;}"
+  value="${value//>/&gt;}"
+  value="${value//\"/&quot;}"
+  value="${value//\'/&apos;}"
+  printf '%s' "$value"
+}
+
+copy_sparkle_framework() {
+  local package_dir="$1"
+  local frameworks_dir="$2"
+  local sparkle_framework=""
+
+  sparkle_framework="$(find "${package_dir}/.build/artifacts" -path '*/Sparkle.framework' -type d -print -quit 2>/dev/null || true)"
+  [[ -n "$sparkle_framework" ]] || fail "Sparkle.framework was not found under SwiftPM artifacts; run SwiftPM resolution/build first"
+
+  mkdir -p "$frameworks_dir"
+  ditto "$sparkle_framework" "${frameworks_dir}/Sparkle.framework"
+}
+
+find_swiftpm_executable() {
+  local package_dir="$1"
+  local executable_path=""
+
+  if [[ -x "${package_dir}/.build/release/${EXECUTABLE_NAME}" ]]; then
+    executable_path="${package_dir}/.build/release/${EXECUTABLE_NAME}"
+  fi
+
+  if [[ -z "$executable_path" ]]; then
+    executable_path="$(find "${package_dir}/.build" -type f -path "*/release/${EXECUTABLE_NAME}" -perm -111 -print 2>/dev/null | head -n 1 || true)"
+  fi
+
+  [[ -n "$executable_path" ]] || fail "release executable was not found in ${package_dir}/.build"
+  printf '%s' "$executable_path"
+}
+
+find_generate_appcast() {
+  local package_dir="$1"
+  local tool_path=""
+
+  tool_path="$(find "${package_dir}/.build/artifacts" -type f -path '*/bin/generate_appcast' -perm -111 -print -quit 2>/dev/null || true)"
+  if [[ -z "$tool_path" ]]; then
+    tool_path="$(find "${package_dir}/.build/checkouts" -type f -name generate_appcast -perm -111 -print -quit 2>/dev/null || true)"
+  fi
+
+  [[ -n "$tool_path" ]] || fail "Sparkle generate_appcast was not found in SwiftPM build artifacts"
+  printf '%s' "$tool_path"
+}
+
+write_info_plist() {
+  local plist_path="$1"
+  local version="$2"
+  local build="$3"
+  local channel="$4"
+  local public_key="$5"
+  local feed_url="$6"
+
+  cat >"$plist_path" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key>
+  <string>en</string>
+  <key>CFBundleDisplayName</key>
+  <string>${APP_NAME}</string>
+  <key>CFBundleExecutable</key>
+  <string>${EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>${BUNDLE_ID}</string>
+  <key>CFBundleInfoDictionaryVersion</key>
+  <string>6.0</string>
+  <key>CFBundleName</key>
+  <string>${APP_NAME}</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>$(xml_escape "$version")</string>
+  <key>CFBundleVersion</key>
+  <string>$(xml_escape "$build")</string>
+  <key>ClawDnDUpdateChannel</key>
+  <string>$(xml_escape "$channel")</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>13.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSSupportsAutomaticGraphicsSwitching</key>
+  <true/>
+  <key>SUEnableInstallerLauncherService</key>
+  <true/>
+  <key>SUFeedURL</key>
+  <string>$(xml_escape "$feed_url")</string>
+  <key>SUPublicEDKey</key>
+  <string>$(xml_escape "$public_key")</string>
+</dict>
+</plist>
+PLIST
+}
+
+sign_bundle_contents() {
+  local app_path="$1"
+
+  log "Signing nested Sparkle helpers, framework, executable, and app bundle"
+  while IFS= read -r nested; do
+    codesign --force --timestamp --options runtime --sign "$SIGNING_IDENTITY" "$nested"
+  done < <(find "${app_path}/Contents/Frameworks/Sparkle.framework" \
+    \( -name '*.xpc' -o -name '*.app' -o -name '*.dylib' -o -name Autoupdate \) -print 2>/dev/null | sort)
+
+  codesign --force --timestamp --options runtime --sign "$SIGNING_IDENTITY" \
+    "${app_path}/Contents/Frameworks/Sparkle.framework"
+  codesign --force --timestamp --options runtime --sign "$SIGNING_IDENTITY" \
+    "${app_path}/Contents/MacOS/${EXECUTABLE_NAME}"
+  codesign --force --timestamp --options runtime --sign "$SIGNING_IDENTITY" "$app_path"
+}
+
+write_release_notes() {
+  local notes_path="$1"
+  local version="$2"
+  local build="$3"
+  local channel="$4"
+
+  cat >"$notes_path" <<NOTES
+# ClawDnD ${version} (${build})
+
+Channel: ${channel}
+
+- Beta macOS package assembled from the SwiftPM release build.
+- Includes the bundled OpenWorlds viewer resources.
+- Signed with Developer ID Application and Sparkle EdDSA appcast metadata.
+NOTES
+}
+
+write_checksums() {
+  local checksums_path="$1"
+  shift
+
+  : >"$checksums_path"
+  for artifact in "$@"; do
+    shasum -a 256 "$artifact" >>"$checksums_path"
+  done
+}
+
+write_validation_report() {
+  local report_path="$1"
+  local app_path="$2"
+  local zip_path="$3"
+  local dmg_path="$4"
+  local appcast_path="$5"
+  local version="$6"
+  local build="$7"
+  local channel="$8"
+
+  {
+    printf '# ClawDnD Beta Packaging Validation\n\n'
+    printf -- '- Version: `%s`\n' "$version"
+    printf -- '- Build: `%s`\n' "$build"
+    printf -- '- Channel: `%s`\n' "$channel"
+    printf -- '- App bundle: `%s`\n' "$app_path"
+    printf -- '- ZIP: `%s`\n' "$zip_path"
+    printf -- '- DMG: `%s`\n' "$dmg_path"
+    printf -- '- Appcast: `%s`\n\n' "$appcast_path"
+    printf '## Checks\n\n'
+    printf '```text\n'
+    codesign --verify --deep --strict --verbose=2 "$app_path" 2>&1
+    spctl --assess --type execute --verbose=2 "$app_path" 2>&1 || true
+    printf '```\n'
+  } >"$report_path"
+}
+
+main() {
+  local version="$DEFAULT_VERSION"
+  local build="$DEFAULT_BUILD"
+  local channel="$DEFAULT_CHANNEL"
+
+  while (($#)); do
+    case "$1" in
+      --version)
+        [[ $# -ge 2 ]] || fail "--version requires a value"
+        version="$2"
+        shift 2
+        ;;
+      --build)
+        [[ $# -ge 2 ]] || fail "--build requires a value"
+        build="$2"
+        shift 2
+        ;;
+      --channel)
+        [[ $# -ge 2 ]] || fail "--channel requires a value"
+        channel="$2"
+        shift 2
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        fail "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  require_command swift
+  require_command ditto
+  require_command codesign
+  require_command hdiutil
+  require_command shasum
+  require_command spctl
+
+  local script_dir repo_root package_dir public_key_file feed_url
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  repo_root="$(cd "${script_dir}/.." && pwd)"
+  package_dir="${repo_root}/macos/ClawDnDApp"
+  public_key_file="${package_dir}/SparklePublicKey.txt"
+  feed_url="${CLAWDND_FEED_URL:-file://${OUTPUT_ROOT}/appcast.xml}"
+
+  [[ "$repo_root" == /Volumes/LEXAR/repos/* ]] || fail "repo must be under /Volumes/LEXAR/repos; found ${repo_root}"
+  [[ "$OUTPUT_ROOT" == /Volumes/LEXAR/Codex/* ]] || fail "output root must be under /Volumes/LEXAR/Codex"
+
+  require_dir "$package_dir" "SwiftPM package"
+  require_dir "${repo_root}/viewer/openworlds" "OpenWorlds viewer resources"
+  require_file "$public_key_file" "Sparkle public key"
+  require_file "$PRIVATE_KEY_FILE" "Sparkle private key file"
+
+  local public_key
+  public_key="$(tr -d '\r\n[:space:]' <"$public_key_file")"
+  [[ -n "$public_key" ]] || fail "Sparkle public key file is empty"
+
+  log "Building SwiftPM release package at ${package_dir}"
+  swift build -c release --package-path "$package_dir"
+
+  local executable_path generate_appcast_path
+  executable_path="$(find_swiftpm_executable "$package_dir")"
+  generate_appcast_path="$(find_generate_appcast "$package_dir")"
+
+  local staging_dir app_path channel_app_path zip_path dmg_path dmg_src appcast_src release_notes_path
+  local appcast_path checksums_path validation_report_path artifact_stem
+  staging_dir="${OUTPUT_ROOT}/staging"
+  app_path="${staging_dir}/${APP_NAME}.app"
+  channel_app_path="${OUTPUT_ROOT}/${APP_NAME}.app"
+  artifact_stem="${APP_NAME}-${version}-beta.1"
+  zip_path="${OUTPUT_ROOT}/${artifact_stem}.zip"
+  dmg_path="${OUTPUT_ROOT}/${artifact_stem}.dmg"
+  dmg_src="${staging_dir}/dmg"
+  appcast_src="${staging_dir}/appcast"
+  release_notes_path="${OUTPUT_ROOT}/RELEASE_NOTES.md"
+  appcast_path="${OUTPUT_ROOT}/appcast.xml"
+  checksums_path="${OUTPUT_ROOT}/CHECKSUMS.txt"
+  validation_report_path="${OUTPUT_ROOT}/validation-report.md"
+
+  log "Assembling ${app_path}"
+  rm -rf "$staging_dir"
+  mkdir -p "${app_path}/Contents/MacOS" "${app_path}/Contents/Resources" "${app_path}/Contents/Frameworks"
+  install -m 755 "$executable_path" "${app_path}/Contents/MacOS/${EXECUTABLE_NAME}"
+  write_info_plist "${app_path}/Contents/Info.plist" "$version" "$build" "$channel" "$public_key" "$feed_url"
+  plutil -lint "${app_path}/Contents/Info.plist" >/dev/null
+  copy_sparkle_framework "$package_dir" "${app_path}/Contents/Frameworks"
+  ditto "${repo_root}/viewer/openworlds" "${app_path}/Contents/Resources/openworlds"
+
+  sign_bundle_contents "$app_path"
+  rm -rf "$channel_app_path"
+  ditto "$app_path" "$channel_app_path"
+
+  log "Writing ZIP, DMG, release notes, appcast, checksums, and validation report"
+  rm -f "$zip_path" "$dmg_path" "$release_notes_path" "${zip_path%.zip}.md" "${dmg_path%.dmg}.md" "$appcast_path" "$checksums_path" "$validation_report_path"
+  ditto -c -k --keepParent "$app_path" "$zip_path"
+
+  mkdir -p "$dmg_src"
+  ditto "$app_path" "${dmg_src}/${APP_NAME}.app"
+  hdiutil create -volname "${APP_NAME} ${version}" -srcfolder "$dmg_src" -ov -format UDZO "$dmg_path" >/dev/null
+
+  write_release_notes "$release_notes_path" "$version" "$build" "$channel"
+  cp "$release_notes_path" "${zip_path%.zip}.md"
+  cp "$release_notes_path" "${dmg_path%.dmg}.md"
+  mkdir -p "$appcast_src"
+  cp "$zip_path" "$appcast_src/"
+  cp "${zip_path%.zip}.md" "$appcast_src/"
+
+  local appcast_args=("$generate_appcast_path" --ed-key-file "$PRIVATE_KEY_FILE" -o "$appcast_path")
+  if [[ -n "${CLAWDND_DOWNLOAD_URL_PREFIX:-}" ]]; then
+    appcast_args+=(--download-url-prefix "$CLAWDND_DOWNLOAD_URL_PREFIX")
+  fi
+  appcast_args+=("$appcast_src")
+  "${appcast_args[@]}" >/dev/null
+
+  write_checksums "$checksums_path" "$zip_path" "$dmg_path" "$appcast_path" "$release_notes_path"
+  write_validation_report "$validation_report_path" "$channel_app_path" "$zip_path" "$dmg_path" "$appcast_path" "$version" "$build" "$channel"
+
+  log "Done: ${OUTPUT_ROOT}"
+}
+
+main "$@"

--- a/script/package_macos_beta.sh
+++ b/script/package_macos_beta.sh
@@ -36,8 +36,9 @@ Environment:
   BETA_OUTPUT_DIR               Output directory for the local beta channel.
                                 Defaults to /Volumes/LEXAR/Codex/clawdnd-beta-channel
   CLAWDND_FEED_URL              Sparkle feed URL written into Info.plist.
-                                Defaults to file://${BETA_OUTPUT_DIR:-/Volumes/LEXAR/Codex/clawdnd-beta-channel}/appcast.xml
+                                Defaults to http://127.0.0.1:8765/appcast.xml
   CLAWDND_DOWNLOAD_URL_PREFIX   Optional URL prefix passed to Sparkle generate_appcast.
+                                Defaults to http://127.0.0.1:8765/
 USAGE
 }
 
@@ -132,6 +133,7 @@ write_info_plist() {
   local channel="$4"
   local public_key="$5"
   local feed_url="$6"
+  local beta_channel_root="$7"
 
   cat >"$plist_path" <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
@@ -158,6 +160,8 @@ write_info_plist() {
   <string>$(xml_escape "$build")</string>
   <key>ClawDnDUpdateChannel</key>
   <string>$(xml_escape "$channel")</string>
+  <key>ClawDnDLocalBetaChannelPath</key>
+  <string>$(xml_escape "$beta_channel_root")</string>
   <key>LSMinimumSystemVersion</key>
   <string>13.0</string>
   <key>NSHighResolutionCapable</key>
@@ -294,12 +298,13 @@ main() {
   prerelease="$(printf '%s' "$prerelease" | tr -d '[:space:]')"
   [[ -n "$prerelease" ]] || fail "pre-release suffix must not be empty"
 
-  local script_dir repo_root package_dir public_key_file feed_url
+  local script_dir repo_root package_dir public_key_file feed_url download_url_prefix
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
   repo_root="$(cd "${script_dir}/.." && pwd)"
   package_dir="${repo_root}/macos/ClawDnDApp"
   public_key_file="${package_dir}/SparklePublicKey.txt"
-  feed_url="${CLAWDND_FEED_URL:-file://${OUTPUT_ROOT}/appcast.xml}"
+  download_url_prefix="${CLAWDND_DOWNLOAD_URL_PREFIX:-http://127.0.0.1:8765/}"
+  feed_url="${CLAWDND_FEED_URL:-${download_url_prefix%/}/appcast.xml}"
 
   [[ "$repo_root" == /Volumes/LEXAR/repos/* ]] || fail "repo must be under /Volumes/LEXAR/repos; found ${repo_root}"
   [[ "$OUTPUT_ROOT" == /Volumes/LEXAR/Codex/* ]] || fail "output root must be under /Volumes/LEXAR/Codex"
@@ -339,7 +344,7 @@ main() {
   rm -rf "$staging_dir"
   mkdir -p "${app_path}/Contents/MacOS" "${app_path}/Contents/Resources" "${app_path}/Contents/Frameworks"
   install -m 755 "$executable_path" "${app_path}/Contents/MacOS/${EXECUTABLE_NAME}"
-  write_info_plist "${app_path}/Contents/Info.plist" "$version" "$build" "$channel" "$public_key" "$feed_url"
+  write_info_plist "${app_path}/Contents/Info.plist" "$version" "$build" "$channel" "$public_key" "$feed_url" "$OUTPUT_ROOT"
   plutil -lint "${app_path}/Contents/Info.plist" >/dev/null
   copy_sparkle_framework "$package_dir" "${app_path}/Contents/Frameworks"
   ditto "${repo_root}/viewer/openworlds" "${app_path}/Contents/Resources/openworlds"
@@ -365,9 +370,7 @@ main() {
   cp "${zip_path%.zip}.md" "$appcast_src/"
 
   local appcast_args=("$generate_appcast_path" --ed-key-file "$PRIVATE_KEY_FILE" -o "$appcast_path")
-  if [[ -n "${CLAWDND_DOWNLOAD_URL_PREFIX:-}" ]]; then
-    appcast_args+=(--download-url-prefix "$CLAWDND_DOWNLOAD_URL_PREFIX")
-  fi
+  appcast_args+=(--download-url-prefix "$download_url_prefix")
   appcast_args+=("$appcast_src")
   "${appcast_args[@]}" >/dev/null
 

--- a/script/package_macos_beta.sh
+++ b/script/package_macos_beta.sh
@@ -32,9 +32,10 @@ Defaults:
   --channel  local-beta
   --prerelease beta.1
 
-Environment:
+ Environment:
   BETA_OUTPUT_DIR               Output directory for the local beta channel.
                                 Defaults to /Volumes/LEXAR/Codex/clawdnd-beta-channel
+                                Must resolve under /Volumes/LEXAR/Codex.
   CLAWDND_FEED_URL              Sparkle feed URL written into Info.plist.
                                 Defaults to http://127.0.0.1:8765/appcast.xml
   CLAWDND_DOWNLOAD_URL_PREFIX   Optional URL prefix passed to Sparkle generate_appcast.
@@ -65,6 +66,29 @@ require_dir() {
 
 require_command() {
   command -v "$1" >/dev/null 2>&1 || fail "required command not found: $1"
+}
+
+realpath_compat() {
+  python3 -c 'import os, sys; print(os.path.realpath(os.path.expanduser(sys.argv[1])))' "$1"
+}
+
+validate_release_token() {
+  local label="$1"
+  local value="$2"
+  [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]] || \
+    fail "${label} must be non-empty and may contain only letters, numbers, dot, underscore, and dash"
+}
+
+assert_under_root() {
+  local root="$1"
+  local path="$2"
+  local label="$3"
+  local resolved
+  resolved="$(realpath_compat "$path")"
+  case "$resolved" in
+    "$root"|"$root"/*) ;;
+    *) fail "${label} must stay under ${root}; ${path} resolves to ${resolved}" ;;
+  esac
 }
 
 xml_escape() {
@@ -293,10 +317,18 @@ main() {
   require_command hdiutil
   require_command install_name_tool
   require_command otool
+  require_command python3
   require_command shasum
   require_command spctl
   prerelease="$(printf '%s' "$prerelease" | tr -d '[:space:]')"
-  [[ -n "$prerelease" ]] || fail "pre-release suffix must not be empty"
+  validate_release_token "version" "$version"
+  validate_release_token "build" "$build"
+  validate_release_token "channel" "$channel"
+  validate_release_token "pre-release suffix" "$prerelease"
+
+  OUTPUT_ROOT="$(realpath_compat "$OUTPUT_ROOT")"
+  [[ "$OUTPUT_ROOT" == /Volumes/LEXAR/Codex/* ]] || fail "output root must resolve under /Volumes/LEXAR/Codex; found ${OUTPUT_ROOT}"
+  mkdir -p "$OUTPUT_ROOT"
 
   local script_dir repo_root package_dir public_key_file feed_url download_url_prefix
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -307,7 +339,6 @@ main() {
   feed_url="${CLAWDND_FEED_URL:-${download_url_prefix%/}/appcast.xml}"
 
   [[ "$repo_root" == /Volumes/LEXAR/repos/* ]] || fail "repo must be under /Volumes/LEXAR/repos; found ${repo_root}"
-  [[ "$OUTPUT_ROOT" == /Volumes/LEXAR/Codex/* ]] || fail "output root must be under /Volumes/LEXAR/Codex"
 
   require_dir "$package_dir" "SwiftPM package"
   require_dir "${repo_root}/viewer/openworlds" "OpenWorlds viewer resources"
@@ -339,6 +370,17 @@ main() {
   appcast_path="${OUTPUT_ROOT}/appcast.xml"
   checksums_path="${OUTPUT_ROOT}/CHECKSUMS.txt"
   validation_report_path="${OUTPUT_ROOT}/validation-report.md"
+
+  assert_under_root "$OUTPUT_ROOT" "$staging_dir" "staging directory"
+  assert_under_root "$OUTPUT_ROOT" "$channel_app_path" "channel app bundle"
+  assert_under_root "$OUTPUT_ROOT" "$zip_path" "zip artifact"
+  assert_under_root "$OUTPUT_ROOT" "$dmg_path" "dmg artifact"
+  assert_under_root "$OUTPUT_ROOT" "$dmg_src" "dmg staging directory"
+  assert_under_root "$OUTPUT_ROOT" "$appcast_src" "appcast staging directory"
+  assert_under_root "$OUTPUT_ROOT" "$release_notes_path" "release notes"
+  assert_under_root "$OUTPUT_ROOT" "$appcast_path" "appcast"
+  assert_under_root "$OUTPUT_ROOT" "$checksums_path" "checksums"
+  assert_under_root "$OUTPUT_ROOT" "$validation_report_path" "validation report"
 
   log "Assembling ${app_path}"
   rm -rf "$staging_dir"

--- a/script/package_macos_beta.sh
+++ b/script/package_macos_beta.sh
@@ -11,28 +11,32 @@ set -euo pipefail
 DEFAULT_VERSION="0.3.0"
 DEFAULT_BUILD="2026052601"
 DEFAULT_CHANNEL="local-beta"
+DEFAULT_PRERELEASE="beta.1"
 
 APP_NAME="ClawDnD"
 EXECUTABLE_NAME="ClawDnDApp"
 BUNDLE_ID="dev.clawdnd.app"
 SIGNING_IDENTITY="Developer ID Application: Andrew Ryan (TC6MS3T6NN)"
 
-OUTPUT_ROOT="/Volumes/LEXAR/Codex/clawdnd-beta-channel"
+OUTPUT_ROOT="${BETA_OUTPUT_DIR:-/Volumes/LEXAR/Codex/clawdnd-beta-channel}"
 SECRETS_DIR="/Volumes/LEXAR/Codex/clawdnd-release-secrets"
 PRIVATE_KEY_FILE="${SECRETS_DIR}/sparkle-ed25519-private-key.base64"
 
 usage() {
   cat <<'USAGE'
-Usage: script/package_macos_beta.sh [--version VERSION] [--build BUILD] [--channel CHANNEL]
+Usage: script/package_macos_beta.sh [--version VERSION] [--build BUILD] [--channel CHANNEL] [--prerelease SUFFIX]
 
 Defaults:
   --version  0.3.0
   --build    2026052601
   --channel  local-beta
+  --prerelease beta.1
 
 Environment:
+  BETA_OUTPUT_DIR               Output directory for the local beta channel.
+                                Defaults to /Volumes/LEXAR/Codex/clawdnd-beta-channel
   CLAWDND_FEED_URL              Sparkle feed URL written into Info.plist.
-                                Defaults to file:///Volumes/LEXAR/Codex/clawdnd-beta-channel/appcast.xml
+                                Defaults to file://${BETA_OUTPUT_DIR:-/Volumes/LEXAR/Codex/clawdnd-beta-channel}/appcast.xml
   CLAWDND_DOWNLOAD_URL_PREFIX   Optional URL prefix passed to Sparkle generate_appcast.
 USAGE
 }
@@ -245,6 +249,7 @@ main() {
   local version="$DEFAULT_VERSION"
   local build="$DEFAULT_BUILD"
   local channel="$DEFAULT_CHANNEL"
+  local prerelease="${PRERELEASE:-$DEFAULT_PRERELEASE}"
 
   while (($#)); do
     case "$1" in
@@ -261,6 +266,11 @@ main() {
       --channel)
         [[ $# -ge 2 ]] || fail "--channel requires a value"
         channel="$2"
+        shift 2
+        ;;
+      --prerelease)
+        [[ $# -ge 2 ]] || fail "--prerelease requires a value"
+        prerelease="$2"
         shift 2
         ;;
       -h|--help)
@@ -281,6 +291,8 @@ main() {
   require_command otool
   require_command shasum
   require_command spctl
+  prerelease="$(printf '%s' "$prerelease" | tr -d '[:space:]')"
+  [[ -n "$prerelease" ]] || fail "pre-release suffix must not be empty"
 
   local script_dir repo_root package_dir public_key_file feed_url
   script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -313,7 +325,7 @@ main() {
   staging_dir="${OUTPUT_ROOT}/staging"
   app_path="${staging_dir}/${APP_NAME}.app"
   channel_app_path="${OUTPUT_ROOT}/${APP_NAME}.app"
-  artifact_stem="${APP_NAME}-${version}-beta.1"
+  artifact_stem="${APP_NAME}-${version}-${prerelease}"
   zip_path="${OUTPUT_ROOT}/${artifact_stem}.zip"
   dmg_path="${OUTPUT_ROOT}/${artifact_stem}.dmg"
   dmg_src="${staging_dir}/dmg"

--- a/script/package_macos_beta.sh
+++ b/script/package_macos_beta.sh
@@ -84,6 +84,14 @@ copy_sparkle_framework() {
   ditto "$sparkle_framework" "${frameworks_dir}/Sparkle.framework"
 }
 
+add_app_framework_rpath() {
+  local binary_path="$1"
+  if otool -l "$binary_path" | grep -q '@executable_path/../Frameworks'; then
+    return
+  fi
+  install_name_tool -add_rpath '@executable_path/../Frameworks' "$binary_path"
+}
+
 find_swiftpm_executable() {
   local package_dir="$1"
   local executable_path=""
@@ -269,6 +277,8 @@ main() {
   require_command ditto
   require_command codesign
   require_command hdiutil
+  require_command install_name_tool
+  require_command otool
   require_command shasum
   require_command spctl
 
@@ -321,6 +331,7 @@ main() {
   plutil -lint "${app_path}/Contents/Info.plist" >/dev/null
   copy_sparkle_framework "$package_dir" "${app_path}/Contents/Frameworks"
   ditto "${repo_root}/viewer/openworlds" "${app_path}/Contents/Resources/openworlds"
+  add_app_framework_rpath "${app_path}/Contents/MacOS/${EXECUTABLE_NAME}"
 
   sign_bundle_contents "$app_path"
   rm -rf "$channel_app_path"

--- a/viewer/openworlds/chrome.jsx
+++ b/viewer/openworlds/chrome.jsx
@@ -366,12 +366,50 @@ function CapabilityBadge({ capability, nativeStatus }) {
 }
 
 function TitleBar({ campaign, location, day, capability, nativeStatus }) {
+  const bridgeReady = Boolean(nativeStatus?.bridge && window.OpenWorldsNative?.hasBridge?.());
+  const commandWindow = (command) => {
+    if (!bridgeReady) return;
+    window.OpenWorldsNative.request("windowCommand", { command }).catch((error) => {
+      window.dispatchEvent(new CustomEvent("openworlds:toast", {
+        detail: {
+          kind: "danger",
+          title: "Window command failed",
+          body: error?.message || String(error),
+        },
+      }));
+    });
+  };
+  const controlTitle = bridgeReady
+    ? "Native window control"
+    : "Unavailable outside the ClawDnD macOS app";
+
   return (
     <div className="title-bar">
-      <div className="traffic-lights" aria-hidden="true">
-        <span className="traffic-light close" />
-        <span className="traffic-light min" />
-        <span className="traffic-light zoom" />
+      <div className="traffic-lights" aria-label="Window controls">
+        <button
+          type="button"
+          className="traffic-light close"
+          onClick={() => commandWindow("close")}
+          disabled={!bridgeReady}
+          title={`${controlTitle}: close`}
+          aria-label="Close window"
+        />
+        <button
+          type="button"
+          className="traffic-light min"
+          onClick={() => commandWindow("minimize")}
+          disabled={!bridgeReady}
+          title={`${controlTitle}: minimize`}
+          aria-label="Minimize window"
+        />
+        <button
+          type="button"
+          className="traffic-light zoom"
+          onClick={() => commandWindow("zoom")}
+          disabled={!bridgeReady}
+          title={`${controlTitle}: zoom`}
+          aria-label="Zoom window"
+        />
       </div>
       <div className="title-text">
         <span>Open Worlds</span><em>·</em><span>{campaign || "The Long Road to Odrun"}</span>

--- a/viewer/openworlds/screen-settings.jsx
+++ b/viewer/openworlds/screen-settings.jsx
@@ -225,6 +225,7 @@ function NativeAppSection({ nativeState, refreshNative }) {
   const providers = Array.isArray(nativeState?.providers) ? nativeState.providers : [];
   const dependencies = Array.isArray(nativeState?.dependencies) ? nativeState.dependencies : [];
   const bridgeReady = Boolean(nativeState?.bridge);
+  const hasNativeBridge = Boolean(window.OpenWorldsNative?.hasBridge?.());
 
   const nativeAction = async (type, payload = {}) => {
     if (!window.OpenWorldsNative?.hasBridge?.()) {
@@ -307,7 +308,7 @@ function NativeAppSection({ nativeState, refreshNative }) {
           <BrassButton
             size="sm"
             onClick={() => nativeAction("checkForUpdates")}
-            disabled={!bridgeReady || !updater.canCheckForUpdates}
+            disabled={!bridgeReady || !hasNativeBridge || !updater.canCheckForUpdates}
           >
             Check for Updates
           </BrassButton>

--- a/viewer/openworlds/screen-settings.jsx
+++ b/viewer/openworlds/screen-settings.jsx
@@ -313,7 +313,7 @@ function NativeAppSection({ nativeState, refreshNative }) {
             Check for Updates
           </BrassButton>
           <p className="body-sm muted" style={{ marginTop: 12 }}>
-            Local beta updates use the file-based appcast in the Lexar release channel. Campaign state remains in the configured repo/state directory.
+            Local beta updates are served from the Lexar release channel through this viewer's loopback feed. Campaign state remains in the configured repo/state directory.
           </p>
         </Panel>
       </div>

--- a/viewer/openworlds/screen-settings.jsx
+++ b/viewer/openworlds/screen-settings.jsx
@@ -221,6 +221,7 @@ function NativeAppSection({ nativeState, refreshNative }) {
   const toast = window.useToast ? window.useToast() : (() => {});
   const app = nativeState?.appStatus || {};
   const viewer = app.viewer || {};
+  const updater = app.updater || {};
   const providers = Array.isArray(nativeState?.providers) ? nativeState.providers : [];
   const dependencies = Array.isArray(nativeState?.dependencies) ? nativeState.dependencies : [];
   const bridgeReady = Boolean(nativeState?.bridge);
@@ -281,6 +282,37 @@ function NativeAppSection({ nativeState, refreshNative }) {
           </div>
           <p className="body-sm muted" style={{ marginTop: 12 }}>
             Native actions supervise local processes only. Game intent still travels through the existing engine/player move lane.
+          </p>
+        </Panel>
+      </div>
+
+      <Divider />
+      <SectionTitle>Updates</SectionTitle>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <Panel framed style={{ padding: 18 }}>
+          <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
+            <Pill tone={updater.status === "ready" ? "emerald" : "crimson"}>
+              Sparkle {updater.status || "unavailable"}
+            </Pill>
+            <Pill tone="royal">{updater.channel || "local-beta"}</Pill>
+          </div>
+          <StatLine k="Version" v={updater.version || "0.0.0"} />
+          <StatLine k="Build" v={updater.build || "0"} />
+          <StatLine k="Feed" v={updater.feedURL || "not configured"} />
+          <StatLine k="Last check" v={updater.lastCheckRequestedAt || "not checked"} />
+          <StatLine k="Update error" v={updater.lastError || "none"} />
+        </Panel>
+        <Panel framed style={{ padding: 18 }}>
+          <SectionTitle>Update Actions</SectionTitle>
+          <BrassButton
+            size="sm"
+            onClick={() => nativeAction("checkForUpdates")}
+            disabled={!bridgeReady || !updater.canCheckForUpdates}
+          >
+            Check for Updates
+          </BrassButton>
+          <p className="body-sm muted" style={{ marginTop: 12 }}>
+            Local beta updates use the file-based appcast in the Lexar release channel. Campaign state remains in the configured repo/state directory.
           </p>
         </Panel>
       </div>

--- a/viewer/openworlds/styles.css
+++ b/viewer/openworlds/styles.css
@@ -197,14 +197,26 @@ a { color: inherit; text-decoration: none; cursor: pointer; }
   align-items: center;
 }
 .traffic-light {
+  display: block;
+  padding: 0;
   width: 13px; height: 13px;
   border-radius: 50%;
+  border: 0;
   box-shadow:
     inset 0 1px 1px rgba(255,255,255,0.5),
     inset 0 -1px 1px rgba(0,0,0,0.3),
     0 0 0 1px rgba(0,0,0,0.45);
   cursor: pointer;
   -webkit-app-region: no-drag;
+}
+.traffic-light:disabled {
+  cursor: not-allowed;
+  filter: saturate(0.35) brightness(0.72);
+  opacity: 0.7;
+}
+.traffic-light:focus-visible {
+  outline: 1px solid var(--b-100);
+  outline-offset: 3px;
 }
 .traffic-light.close { background: radial-gradient(circle at 30% 30%, #ff6b5a, #b73d2f); }
 .traffic-light.min { background: radial-gradient(circle at 30% 30%, #ffce58, #b8862a); }

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -2848,8 +2848,13 @@ def _beta_channel_asset(route: str) -> Path | None:
 
 
 def _loopback_base_url(handler: BaseHTTPRequestHandler) -> str:
-    host = handler.headers.get("Host", "").strip() or "127.0.0.1"
-    return f"http://{host}"
+    port = getattr(handler.server, "server_port", None)
+    if not port:
+        try:
+            port = handler.server.server_address[1]
+        except (AttributeError, IndexError, TypeError):
+            port = 0
+    return f"http://127.0.0.1:{port}"
 
 
 def _rewritten_appcast(handler: BaseHTTPRequestHandler, appcast: Path) -> bytes:

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -37,6 +37,7 @@ import importlib.util
 import json
 import mimetypes
 import os
+import re
 import subprocess
 import sys
 import time
@@ -50,6 +51,7 @@ _HERE = Path(__file__).resolve().parent
 # servers/voice lives two levels up from viewer/ (repo root / servers / voice).
 _VOICE_DIR = _HERE.parent / "servers" / "voice"
 _OPENWORLDS_DIR_ENV = "CLAWDND_OPENWORLDS_DIR"
+_BETA_CHANNEL_DIR_ENV = "CLAWDND_BETA_CHANNEL_DIR"
 _OPENWORLDS_ROUTE = "/openworlds"
 _OPENWORLDS_MIME_TYPES = {
     ".html": "text/html; charset=utf-8",
@@ -70,6 +72,15 @@ def _openworlds_dir() -> Path:
     """
     override = os.environ.get(_OPENWORLDS_DIR_ENV, "").strip()
     return Path(override).expanduser() if override else _HERE / "openworlds"
+
+
+def _beta_channel_dir() -> Path | None:
+    """Optional local Sparkle channel root exposed through loopback HTTP."""
+    override = os.environ.get(_BETA_CHANNEL_DIR_ENV, "").strip()
+    if not override:
+        return None
+    root = Path(override).expanduser()
+    return root if root.is_dir() else None
 
 # The constrained move palette — the SAME lane the engine facade enforces. A human
 # acting via the dashboard must not be able to POST DM-side narration ("the dragon
@@ -2814,6 +2825,49 @@ def _openworlds_asset(route: str) -> Path | None:
     return target if target.is_file() else None
 
 
+def _beta_channel_asset(route: str) -> Path | None:
+    """Resolve a local-beta Sparkle artifact path under the configured channel root."""
+    root = _beta_channel_dir()
+    if root is None:
+        return None
+    if route == "/appcast.xml":
+        target_name = "appcast.xml"
+    else:
+        target_name = unquote(route.lstrip("/"))
+    if "/" in target_name or target_name.startswith("."):
+        return None
+    if target_name != "appcast.xml" and not target_name.startswith("ClawDnD-"):
+        return None
+    try:
+        root_resolved = root.resolve()
+        target = (root_resolved / target_name).resolve()
+        target.relative_to(root_resolved)
+    except (OSError, ValueError):
+        return None
+    return target if target.is_file() else None
+
+
+def _loopback_base_url(handler: BaseHTTPRequestHandler) -> str:
+    host = handler.headers.get("Host", "").strip() or "127.0.0.1"
+    return f"http://{host}"
+
+
+def _rewritten_appcast(handler: BaseHTTPRequestHandler, appcast: Path) -> bytes:
+    """Serve the local appcast with artifact links rewritten to this viewer's port."""
+    text = appcast.read_text(encoding="utf-8")
+    base = _loopback_base_url(handler).rstrip("/") + "/"
+    root = _beta_channel_dir()
+    if root is not None:
+        for candidate in (root, root.resolve()):
+            try:
+                text = text.replace(candidate.as_uri().rstrip("/") + "/", base)
+            except ValueError:
+                continue
+    text = re.sub(r"http://127\.0\.0\.1:\d+/", base, text)
+    text = re.sub(r"http://localhost:\d+/", base, text)
+    return text.encode("utf-8")
+
+
 class _Handler(BaseHTTPRequestHandler):
     campaign_id = ""  # set on the class before serving
     transcript_path = ""  # optional agent-transcript .jsonl to tail for /activity
@@ -2936,6 +2990,18 @@ class _Handler(BaseHTTPRequestHandler):
         elif route in ("/dashboard", "/dashboard.html"):
             html = (_HERE / "dashboard.html").read_bytes()
             self._send(200, html, "text/html; charset=utf-8")
+        elif route == "/appcast.xml":
+            appcast = _beta_channel_asset(route)
+            if appcast is None:
+                self._send(404, b"not found", "text/plain")
+            else:
+                self._send(200, _rewritten_appcast(self, appcast), "application/xml; charset=utf-8")
+        elif route.startswith("/ClawDnD-"):
+            asset = _beta_channel_asset(route)
+            if asset is None:
+                self._send(404, b"not found", "text/plain")
+            else:
+                self._send(200, asset.read_bytes(), _openworlds_mime(asset))
         elif route == "/openworlds/config.json":
             self._json(_openworlds_config())
         elif route == "/openworlds/campaigns.json":

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -49,7 +49,7 @@ from urllib.parse import parse_qs, quote, unquote, urlparse
 _HERE = Path(__file__).resolve().parent
 # servers/voice lives two levels up from viewer/ (repo root / servers / voice).
 _VOICE_DIR = _HERE.parent / "servers" / "voice"
-_OPENWORLDS_DIR = _HERE / "openworlds"
+_OPENWORLDS_DIR_ENV = "CLAWDND_OPENWORLDS_DIR"
 _OPENWORLDS_ROUTE = "/openworlds"
 _OPENWORLDS_MIME_TYPES = {
     ".html": "text/html; charset=utf-8",
@@ -60,6 +60,16 @@ _OPENWORLDS_MIME_TYPES = {
     ".md": "text/markdown; charset=utf-8",
     ".ttf": "font/ttf",
 }
+
+
+def _openworlds_dir() -> Path:
+    """OpenWorlds asset root.
+
+    The native app can ship a bundled copy of the UI and point the repo-backed
+    viewer at it. Engine/viewer data still comes from the configured checkout.
+    """
+    override = os.environ.get(_OPENWORLDS_DIR_ENV, "").strip()
+    return Path(override).expanduser() if override else _HERE / "openworlds"
 
 # The constrained move palette — the SAME lane the engine facade enforces. A human
 # acting via the dashboard must not be able to POST DM-side narration ("the dragon
@@ -2786,8 +2796,9 @@ def _openworlds_mime(path: Path) -> str:
 
 def _openworlds_asset(route: str) -> Path | None:
     """Resolve a /openworlds asset path without allowing traversal outside the bundle."""
+    openworlds_dir = _openworlds_dir()
     if route in (_OPENWORLDS_ROUTE, f"{_OPENWORLDS_ROUTE}/"):
-        index = _OPENWORLDS_DIR / "index.html"
+        index = openworlds_dir / "index.html"
         return index if index.is_file() else None
     if not route.startswith(f"{_OPENWORLDS_ROUTE}/"):
         return None
@@ -2795,7 +2806,7 @@ def _openworlds_asset(route: str) -> Path | None:
     if not rel or rel.endswith("/"):
         rel = f"{rel}index.html"
     try:
-        root = _OPENWORLDS_DIR.resolve()
+        root = openworlds_dir.resolve()
         target = (root / rel).resolve()
         target.relative_to(root)
     except (OSError, ValueError):

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -58,14 +58,18 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
             os.environ["CLAWDND_BETA_CHANNEL_DIR"] = self._old_beta_channel
         server._HERE = self._old_here
 
-    def _get(self, path: str) -> tuple[int, str, bytes]:
-        status, headers, body = self._get_with_headers(path)
+    def _get(self, path: str, headers: dict[str, str] | None = None) -> tuple[int, str, bytes]:
+        status, headers, body = self._get_with_headers(path, headers=headers)
         return status, headers.get("Content-Type", ""), body
 
-    def _get_with_headers(self, path: str) -> tuple[int, http.client.HTTPMessage, bytes]:
+    def _get_with_headers(
+        self,
+        path: str,
+        headers: dict[str, str] | None = None,
+    ) -> tuple[int, http.client.HTTPMessage, bytes]:
         conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
         try:
-            conn.request("GET", path)
+            conn.request("GET", path, headers=headers or {})
             response = conn.getresponse()
             return response.status, response.headers, response.read()
         finally:
@@ -137,6 +141,23 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn(f"{expected_base}ClawDnD-0.3.0-beta.1.md", source)
         self.assertNotIn("file://", source)
         self.assertNotIn("http://127.0.0.1:8765/", source)
+
+    def test_local_beta_appcast_ignores_request_host_header(self):
+        beta = self._tmp / "beta-channel"
+        beta.mkdir()
+        (beta / "ClawDnD-0.3.0-beta.1.zip").write_bytes(b"zip")
+        (beta / "appcast.xml").write_text(
+            f'<rss><channel><item><enclosure url="{beta.as_uri()}/ClawDnD-0.3.0-beta.1.zip" /></item></channel></rss>',
+            encoding="utf-8",
+        )
+        os.environ["CLAWDND_BETA_CHANNEL_DIR"] = str(beta)
+
+        status, _ctype, body = self._get("/appcast.xml", headers={"Host": "updates.example.test"})
+
+        self.assertEqual(status, 200)
+        source = body.decode("utf-8")
+        self.assertIn(f"http://127.0.0.1:{self._port}/ClawDnD-0.3.0-beta.1.zip", source)
+        self.assertNotIn("updates.example.test", source)
 
     def test_local_beta_artifacts_are_path_guarded(self):
         beta = self._tmp / "beta-channel"

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -26,9 +26,11 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
         self._old_state = os.environ.get("CLAWDND_STATE_DIR")
         self._old_openworlds = os.environ.get("CLAWDND_OPENWORLDS_DIR")
+        self._old_beta_channel = os.environ.get("CLAWDND_BETA_CHANNEL_DIR")
         self._old_here = server._HERE
         os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
         os.environ.pop("CLAWDND_OPENWORLDS_DIR", None)
+        os.environ.pop("CLAWDND_BETA_CHANNEL_DIR", None)
         _QuietHandler.campaign_id = ""
         _QuietHandler.transcript_path = ""
         _QuietHandler.chat_path = ""
@@ -50,6 +52,10 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
             os.environ.pop("CLAWDND_OPENWORLDS_DIR", None)
         else:
             os.environ["CLAWDND_OPENWORLDS_DIR"] = self._old_openworlds
+        if self._old_beta_channel is None:
+            os.environ.pop("CLAWDND_BETA_CHANNEL_DIR", None)
+        else:
+            os.environ["CLAWDND_BETA_CHANNEL_DIR"] = self._old_beta_channel
         server._HERE = self._old_here
 
     def _get(self, path: str) -> tuple[int, str, bytes]:
@@ -100,6 +106,51 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertEqual(status, 200)
         self.assertIn("text/html", ctype)
         self.assertEqual(body, b"bundled openworlds beta")
+
+    def test_local_beta_appcast_is_served_over_loopback_http(self):
+        beta = self._tmp / "beta-channel"
+        beta.mkdir()
+        (beta / "ClawDnD-0.3.0-beta.1.zip").write_bytes(b"zip")
+        (beta / "ClawDnD-0.3.0-beta.1.md").write_text("notes", encoding="utf-8")
+        (beta / "appcast.xml").write_text(
+            f"""
+            <rss>
+              <channel>
+                <item>
+                  <sparkle:releaseNotesLink>{beta.as_uri()}/ClawDnD-0.3.0-beta.1.md</sparkle:releaseNotesLink>
+                  <enclosure url="http://127.0.0.1:8765/ClawDnD-0.3.0-beta.1.zip" />
+                </item>
+              </channel>
+            </rss>
+            """,
+            encoding="utf-8",
+        )
+        os.environ["CLAWDND_BETA_CHANNEL_DIR"] = str(beta)
+
+        status, ctype, body = self._get("/appcast.xml")
+
+        self.assertEqual(status, 200)
+        self.assertIn("application/xml", ctype)
+        source = body.decode("utf-8")
+        expected_base = f"http://{self._host}:{self._port}/"
+        self.assertIn(f"{expected_base}ClawDnD-0.3.0-beta.1.zip", source)
+        self.assertIn(f"{expected_base}ClawDnD-0.3.0-beta.1.md", source)
+        self.assertNotIn("file://", source)
+        self.assertNotIn("http://127.0.0.1:8765/", source)
+
+    def test_local_beta_artifacts_are_path_guarded(self):
+        beta = self._tmp / "beta-channel"
+        beta.mkdir()
+        (beta / "ClawDnD-0.3.0-beta.1.zip").write_bytes(b"zip")
+        os.environ["CLAWDND_BETA_CHANNEL_DIR"] = str(beta)
+
+        status, ctype, body = self._get("/ClawDnD-0.3.0-beta.1.zip")
+
+        self.assertEqual(status, 200)
+        self.assertIn("zip", ctype)
+        self.assertEqual(body, b"zip")
+        self.assertEqual(self._status("/../ClawDnD-0.3.0-beta.1.zip"), 404)
+        self.assertEqual(self._status("/not-clawdnd.zip"), 404)
 
     def test_openworlds_config_is_browser_safe_metadata(self):
         status, ctype, body = self._get("/openworlds/config.json")

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -25,8 +25,10 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
     def setUp(self):
         self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
         self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        self._old_openworlds = os.environ.get("CLAWDND_OPENWORLDS_DIR")
         self._old_here = server._HERE
         os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        os.environ.pop("CLAWDND_OPENWORLDS_DIR", None)
         _QuietHandler.campaign_id = ""
         _QuietHandler.transcript_path = ""
         _QuietHandler.chat_path = ""
@@ -44,6 +46,10 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
             os.environ.pop("CLAWDND_STATE_DIR", None)
         else:
             os.environ["CLAWDND_STATE_DIR"] = self._old_state
+        if self._old_openworlds is None:
+            os.environ.pop("CLAWDND_OPENWORLDS_DIR", None)
+        else:
+            os.environ["CLAWDND_OPENWORLDS_DIR"] = self._old_openworlds
         server._HERE = self._old_here
 
     def _get(self, path: str) -> tuple[int, str, bytes]:
@@ -82,6 +88,18 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertNotIn(b"https://unpkg.com", body)
         self.assertNotIn(b"https://fonts.googleapis.com", body)
         self.assertNotIn(b"tweaks-panel.jsx", body)
+
+    def test_openworlds_static_assets_can_be_served_from_bundled_override(self):
+        bundled = self._tmp / "bundled-openworlds"
+        bundled.mkdir()
+        (bundled / "index.html").write_text("bundled openworlds beta", encoding="utf-8")
+        os.environ["CLAWDND_OPENWORLDS_DIR"] = str(bundled)
+
+        status, ctype, body = self._get("/openworlds/")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/html", ctype)
+        self.assertEqual(body, b"bundled openworlds beta")
 
     def test_openworlds_config_is_browser_safe_metadata(self):
         status, ctype, body = self._get("/openworlds/config.json")


### PR DESCRIPTION
## Summary

Adds the local beta distribution lane for the OpenWorlds-first ClawDnD macOS app.

- Adds Sparkle 2.9.2 to the SwiftPM macOS app.
- Adds native `UpdaterService` plus OpenWorlds bridge requests for `updaterStatus`, `checkForUpdates`, and `windowCommand`.
- Packages `viewer/openworlds/` into `ClawDnD.app/Contents/Resources/openworlds` and launches the repo-backed Python viewer with `CLAWDND_OPENWORLDS_DIR` pointing at bundled UI assets.
- Serves the local Sparkle appcast and ZIP payload through the viewer loopback route, not raw `file://`, so Sparkle can check local beta updates safely.
- Converts OpenWorlds traffic lights into bridge-backed native close/minimize/zoom controls and adds an AppKit drag strip over the title region.
- Adds `script/package_macos_beta.sh` to build, sign, zip, DMG, appcast, checksums, release notes, and validation output under `/Volumes/LEXAR/Codex/clawdnd-beta-channel`.
- Updates the OpenWorlds native app roadmap and surface map with the beta channel, signing/update boundaries, and display/read/write surface ownership.

## State Authority

This keeps the app in the supervisor/read-surface lane:

- The `.app` can update the Swift shell and bundled OpenWorlds UI assets.
- The Python viewer, engine, state directories, play-state, QA state, and campaign truth remain repo/state backed.
- Browser actions still go through existing viewer/player intent lanes; this PR does not move game-state writes into the app.

## Local Beta Output

Generated locally by:

```bash
./script/package_macos_beta.sh --version 0.3.0 --build 2026052601 --channel local-beta
```

Expected local channel:

```text
/Volumes/LEXAR/Codex/clawdnd-beta-channel/ClawDnD.app
/Volumes/LEXAR/Codex/clawdnd-beta-channel/ClawDnD-0.3.0-beta.1.zip
/Volumes/LEXAR/Codex/clawdnd-beta-channel/ClawDnD-0.3.0-beta.1.dmg
/Volumes/LEXAR/Codex/clawdnd-beta-channel/appcast.xml
/Volumes/LEXAR/Codex/clawdnd-beta-channel/RELEASE_NOTES.md
/Volumes/LEXAR/Codex/clawdnd-beta-channel/CHECKSUMS.txt
/Volumes/LEXAR/Codex/clawdnd-beta-channel/validation-report.md
```

Runtime Sparkle feed in the packaged app:

```text
http://127.0.0.1:<viewer-port>/appcast.xml
```

The packaged app stores the local channel path in `Info.plist`; the Swift supervisor passes `CLAWDND_BETA_CHANNEL_DIR` to the viewer, and the viewer rewrites appcast URLs to the live loopback port.

## Adversarial Review Fixes

After CodeRabbit approval, four read-only adversarial slice agents reviewed the PR. Verified findings fixed in commit `3b85fca`:

- **P1:** update checks could be enabled when no local beta appcast was actually served. Fixed by tracking `feedAvailable`, only overriding Sparkle to loopback when `localBetaChannelPath` exists, and failing closed before invoking Sparkle.
- **P1:** packaging paths could escape the intended beta channel via non-canonical `BETA_OUTPUT_DIR` or slash-bearing release tokens. Fixed by canonicalizing `OUTPUT_ROOT`, validating version/build/channel/prerelease tokens, and asserting generated artifacts stay under the resolved channel root.
- **P2:** appcast rewriting trusted the request `Host` header. Fixed by deriving appcast artifact URLs from the bound loopback server port and adding a spoofed-Host regression test.
- **P2:** `windowCommand` could target the wrong macOS window if another window was key. Fixed by passing the source `WKWebView` window through the native bridge and applying close/minimize/zoom only to that window.
- **P3:** docs/help implied an arbitrary `BETA_OUTPUT_DIR`; updated docs/help to state the Lexar-backed local beta constraint.

Review clearances included: no private Sparkle key committed, Sparkle framework/resources are bundled, appcast targets ZIP not DMG, notarization is correctly deferred to #151, and state authority remains outside the app bundle.

## Validation

Ran from `/Volumes/LEXAR/repos/ClawDnD-macos-beta-distribution`:

```bash
bash -n script/package_macos_beta.sh script/build_and_run.sh
python3 -m unittest viewer.tests.test_openworlds_static -q
python3 -m py_compile viewer/server.py
swift build --package-path macos/ClawDnDApp
python3 scripts/license_check.py
git diff --check
./script/package_macos_beta.sh --version 0.3.0 --build 2026052601 --channel local-beta
codesign --verify --deep --strict /Volumes/LEXAR/Codex/clawdnd-beta-channel/ClawDnD.app
plutil -lint /Volumes/LEXAR/Codex/clawdnd-beta-channel/ClawDnD.app/Contents/Info.plist
hdiutil verify /Volumes/LEXAR/Codex/clawdnd-beta-channel/ClawDnD-0.3.0-beta.1.dmg
```

Focused negative checks:

```bash
./script/package_macos_beta.sh --version 'x/../../escape' --build 2026052601 --channel local-beta
BETA_OUTPUT_DIR='/Volumes/LEXAR/Codex/../../../Users/lume/clawdnd-beta-escape' ./script/package_macos_beta.sh --version 0.3.0 --build 2026052601 --channel local-beta
```

Results:

- OpenWorlds static route tests: 19 passing.
- Swift/Sparkle build: passing.
- Package script and local beta generation: passing.
- Invalid release token and escaping output root: rejected before packaging.
- `codesign --verify --deep --strict`: passing.
- Info.plist lint: passing.
- DMG checksum verification: passing.
- License check: passing.
- `spctl`: rejected as `Unnotarized Developer ID`, expected because notarization is tracked separately in #151.

## Current External Gate

GitHub Actions are failing before repo code runs because GitHub checkout/action download is returning external auth/codeload errors (`403`, `Your account is suspended`, and setup-uv codeload download failures). Local focused validation is clean; these CI failures should be retried after the GitHub account/action-fetch issue clears.

## Follow-Up

- Rebase only if required by merge queue/reviewer, since `main` is moving.
- Keep this branch unsquashed until final merge so the review-fix trail remains easy to inspect.
- Manual visual smoke remains useful for titlebar controls and drag strip behavior after the next installed-app handoff.
- Notarization remains a later release-trust task in #151.

Refs #134
Refs #136
Refs #151


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sparkle-backed automatic updates with updater status, last-check info, and a "Check for Updates" action in the UI.
  * Interactive macOS-style window controls (close, minimize, zoom) in the embedded viewer.
  * Viewer can use bundled OpenWorlds UI assets and serve local beta release artifacts via a local beta channel.

* **Documentation**
  * Roadmap and app surface docs updated with updater distribution details and expanded native bridge API.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->