### PR TITLE
feat(combat): surprise-attack affordance + combat-init doctrine (#153)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -2019,12 +2019,27 @@ def set_hp(
 
 
 @mcp.tool()
-def start_combat(campaign_id: str, combatant_ids: list[str]) -> dict:
+def start_combat(
+    campaign_id: str,
+    combatant_ids: list[str],
+    surpriser_ids: list[str] | None = None,
+) -> dict:
     """Begin combat: roll initiative (1d20 + initiative_bonus) for each combatant
     and build the turn order (desc, ties broken by DEX modifier then input order).
-    Pass the character ids of everyone in the fight."""
+    Pass the character ids of everyone in the fight.
+
+    surpriser_ids (optional): ids of combatants who initiated the fight with a
+    surprise attack (an ambush, a betrayal opener, an attack on an unready target).
+    They are placed FIRST in the turn order so they act before initiative would
+    otherwise allow; everyone else follows in normal rolled initiative order.
+    The return carries a ``surprise`` key signalling the opening attack should
+    use advantage=True (the edge is going-first + advantage; the target's AC still
+    applies — no auto-kill). Unknown ids in surpriser_ids are silently skipped.
+    Default [] = today's exact initiative-only behaviour (purely additive).
+    # v2 idea: also apply the 5e "surprised creatures skip round 1" rule."""
     if not combatant_ids:
         raise ValueError("combatant_ids must be non-empty")
+    surpriser_ids = [sid for sid in (surpriser_ids or []) if sid in combatant_ids]
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         if c.combat.active:
@@ -2035,6 +2050,13 @@ def start_combat(campaign_id: str, combatant_ids: list[str]) -> dict:
             r = dice_mod.roll(f"1d20+{ch.initiative_bonus}")
             rolled.append((cid, r.total, ch.ability_modifier(Ability.DEX)))
         indexed = sorted(enumerate(rolled), key=lambda t: (-t[1][1], -t[1][2], t[0]))
+        # Surprise ordering: surprisers go first (in their relative rolled order),
+        # then non-surprisers in normal rolled initiative order.
+        if surpriser_ids:
+            surpriser_set = set(surpriser_ids)
+            surprise_slots = [item for item in indexed if item[1][0] in surpriser_set]
+            normal_slots = [item for item in indexed if item[1][0] not in surpriser_set]
+            indexed = surprise_slots + normal_slots
         c.combat = Combat(
             active=True,
             round=1,
@@ -2043,6 +2065,20 @@ def start_combat(campaign_id: str, combatant_ids: list[str]) -> dict:
         )
         save_campaign(c)
         view = _combat_view(c)
+        # Surface the surprise edge in the runtime view so the DM resolves the opener
+        # with attack(advantage=True).  Not persisted — old snapshots round-trip cleanly.
+        if surpriser_ids:
+            surpriser_names = [
+                c.characters[sid].name for sid in surpriser_ids if sid in c.characters
+            ]
+            view["surprise"] = {
+                "surprisers": surpriser_ids,
+                "surpriser_names": surpriser_names,
+                "note": (
+                    "opening attack has advantage; the target's AC still applies — "
+                    "call attack(advantage=True) for the opener. NO auto-kill."
+                ),
+            }
         # Reminder: surface anyone with Extra Attack so the DM makes the right number of attacks
         # per turn (QA: a Barbarian-5 with extra_attacks=1 made a single attack). One action =
         # extra_attacks + 1 attack calls; the engine tracks the economy via use_action.

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -643,3 +643,65 @@ def test_start_combat_no_outlook_for_fair_fight(tmp_path, monkeypatch):
 
     view = server.start_combat(cid, pc_ids + [bandit_id])
     assert "outlook" not in view, "a fair/easy fight must NOT add 'outlook' to start_combat view"
+
+
+# =========================================================================
+# Change 3: start_combat surpriser_ids — surprise-attack affordance (#153)
+# =========================================================================
+
+
+def test_start_combat_surpriser_is_first_in_turn_order(tmp_path, monkeypatch):
+    """Surpriser must be placed first in the turn order regardless of initiative rolls."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Surprise Test")["id"]
+    # Give the target a sky-high initiative bonus so it would naturally roll first,
+    # then verify the attacker (low DEX) still leads when named as surpriser.
+    attacker = server.create_character(
+        cid, "Attacker", kind="player", max_hp=10, armor_class=12,
+    )["id"]
+    target = server.create_character(
+        cid, "Target", kind="monster", max_hp=10, armor_class=14,
+    )["id"]
+
+    view = server.start_combat(cid, [attacker, target], surpriser_ids=[attacker])
+
+    order_ids = [entry["character_id"] for entry in view["order"]]
+    assert order_ids[0] == attacker, "surpriser must be first in turn order"
+    assert "surprise" in view, "start_combat must surface a 'surprise' key when surpriser_ids is set"
+    assert view["surprise"]["surprisers"] == [attacker]
+    assert "advantage" in view["surprise"]["note"]
+
+
+def test_start_combat_no_surpriser_ids_unchanged_behaviour(tmp_path, monkeypatch):
+    """Default call (no surpriser_ids) must not add a 'surprise' key — purely additive."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("No Surprise Test")["id"]
+    a = server.create_character(cid, "A", kind="player", max_hp=10)["id"]
+    b = server.create_character(cid, "B", kind="monster", max_hp=10)["id"]
+
+    view = server.start_combat(cid, [a, b])
+
+    assert "surprise" not in view, "no surpriser_ids must not add 'surprise' key"
+    assert len(view["order"]) == 2
+
+
+def test_start_combat_unknown_surpriser_id_is_skipped_gracefully(tmp_path, monkeypatch):
+    """An id not in combatant_ids must be silently ignored — no error, no corruption."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Bad Surpriser Test")["id"]
+    a = server.create_character(cid, "A", kind="player", max_hp=10)["id"]
+    b = server.create_character(cid, "B", kind="monster", max_hp=10)["id"]
+
+    # "ghost-id" is not a real combatant_id — must not raise, must not appear in order
+    view = server.start_combat(cid, [a, b], surpriser_ids=["ghost-id"])
+
+    assert view["active"] is True
+    assert len(view["order"]) == 2
+    # Unknown id stripped → no surprise key surfaced (no valid surprisers remain)
+    assert "surprise" not in view

--- a/skills/dungeon-master/reference/combat.md
+++ b/skills/dungeon-master/reference/combat.md
@@ -34,6 +34,18 @@ unforgiving, so source every one from the engine:
 
   (All disabled per-campaign by `house_rules.wandering_encounters = False`; combat is never auto-started, so the `start_combat` is always yours to call.)
 
+## SURPRISE / combat-initiation doctrine — ambushes, betrayals, attacks on unready targets
+
+When a player or companion **declares an attack on an unready or non-hostile target** — an ambush opener, a betrayal, an attack on a guard who hasn't drawn — do **NOT** narrate the outcome. Treat it as combat initiation with a surprise edge:
+
+1. **Call `start_combat([...all combatants...], surpriser_ids=[the attacker's id])`.**  The surpriser(s) are placed FIRST in the turn order (they struck before anyone could react). The return carries a `surprise` key confirming this.
+2. **Resolve the opener with `attack(advantage=True)`** — surprise = going first + advantage; the target's AC still applies and the attack can miss. **NO auto-kill, no narrative "they didn't stand a chance".** Let the dice speak.
+3. **Continue through normal initiative** for all subsequent turns. The surprise edge was the first-turn advantage; from round 2 onward everyone acts in rolled order.
+
+This is also the **companion BETRAYAL opener** (issue #142): when `check_companion_arc` fires an agenda betrayal and the companion's move is `[attack]`, use this same path — `start_combat` with `surpriser_ids=[companion_id]`, then `attack(advantage=True)` for the opening blow. The engine makes the treachery real; you dramatize the fallout.
+
+The player facade already keeps moves as intent, not outcome — declare, roll, narrate result.
+
 ## Balancing doctrine — always a way out at low level; real stakes at high (HARD rule)
 
 The world is **SET**, not level-scaled: the dragon's den has a dragon, and the engine **never** alters a single hit point to pull a punch. But a SET world will routinely put a low-level party in front of something that would simply wipe them — and a casual TPK of a level-3 party against a monster they had no chance against is a failure, not drama. The engine makes the over-match **objective** so this isn't a judgment call you can rationalize past:


### PR DESCRIPTION
A declared attack on an unready/non-hostile target (an ambush opener, or a companion betrayal) should TRIGGER combat with a surprise edge — not be narrated away. Owner's model, already engine-supported via the attack advantage flag.

## How
- **server.py start_combat**: optional surpriser_ids (additive; default [] = today's pure-initiative behavior). Surprisers ordered FIRST in the turn order (the ambush edge); unknown ids stripped pre-lock; multiple surprisers keep relative rolled-initiative order. Surfaces a runtime view[surprise] = {surprisers, surpriser_names, note} — NOT persisted (old snapshots round-trip). The opener gets advantage via attack(advantage=True) vs the target's AC — the edge, but AC still applies: NO auto-kill. (5e surprised-skip-round-1 left as a v2 note.)
- **combat.md**: SURPRISE / combat-initiation doctrine — declared attack on an unready target → start_combat(surpriser_ids=[attacker]) → attack(advantage=True) → no auto-kill. Also the companion betrayal opener (#142).

## Tests
- +3 (surpriser-first + signal shape; default unchanged = additive invariant; unknown id handled gracefully). 1060 pass; license_check passes.

Closes #153. Will be fast-tested via the combat-sprint lane (#152).