### PR TITLE
feat(qa): fast combat-sprint lane + scoped-B gate (#152)

### DIFF
--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -19,6 +19,7 @@ Exit 0 = GREEN (warnings allowed), 1 = RED (a fatal gate failed), 2 = usage.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from collections import Counter
@@ -266,10 +267,19 @@ def main() -> int:
         f"roll={tools.get('roll', 0)} attack={tools.get('attack', 0)} save={tools.get('saving_throw', 0)} "
         f"social={tools.get('social_check', 0)} skill_check={tools.get('skill_check', 0)}")
 
-    # 5) if combat started, attacks/monsters actually happened
+    # 5) if combat started, real combat mechanics fired — attack, cast_spell, or saving_throw.
+    # Tightened from "attack + spawn_monster > 0": spawn_monster alone means monsters appeared
+    # but no dice were rolled to resolve the fight (a caster-only session legitimately has
+    # attack=0, resolving via cast_spell/saving_throw). The new gate requires at least ONE of
+    # the resolution mechanics; spawn_monster alone no longer satisfies it. FATAL.
     if tools.get("start_combat", 0) > 0:
-        chk("combat_resolved", tools.get("attack", 0) + tools.get("spawn_monster", 0) > 0,
-            f"start_combat={tools['start_combat']} attack={tools.get('attack', 0)} spawn={tools.get('spawn_monster', 0)}")
+        combat_dice = (tools.get("attack", 0)
+                       + tools.get("cast_spell", 0)
+                       + tools.get("saving_throw", 0))
+        chk("combat_resolved", combat_dice > 0,
+            f"start_combat={tools['start_combat']} attack={tools.get('attack', 0)} "
+            f"cast_spell={tools.get('cast_spell', 0)} saving_throw={tools.get('saving_throw', 0)} "
+            f"(spawn_monster={tools.get('spawn_monster', 0)} alone does not satisfy this check)")
         # M6/M7) a combat that never ENDS, or never grants XP, is a smell — but a run cut
         # off "out of time" mid-fight legitimately may not end_combat/award_xp, so WARN.
         chk("combat_ended", tools.get("end_combat", 0) > 0,
@@ -338,7 +348,11 @@ def main() -> int:
         session_beats = len(mv)
     else:
         session_beats = dm_text
-    if session_beats >= MIN_BEATS:
+    # The combat-sprint lane (run_combat_sprint.sh) is a single pre-seeded FIGHT in one place — it
+    # legitimately never advances days or travels, so it sets CLAWDND_GATE_COMBAT_SPRINT=1 to skip
+    # the world-progression floor (which would else false-RED a 40+-beat fight on a 1-location run).
+    # Story / duo runs (no env var) keep the floor — it's the honest anti-frozen-scene gate.
+    if session_beats >= MIN_BEATS and not os.environ.get("CLAWDND_GATE_COMBAT_SPRINT"):
         day = state.get("day") or 1
         tod = (state.get("time_of_day") or "").strip().lower()
         # Campaigns start at day 1, "morning"; a full session still parked there never aged.

--- a/qa/play_prompt_combat_sprint.txt
+++ b/qa/play_prompt_combat_sprint.txt
@@ -1,0 +1,34 @@
+You are a D&D 5e Dungeon Master running a COMBAT-ONLY sprint. The campaign has already been seeded — do NOT call start_world, start_session, or create_character.
+
+SEEDED IDs (injected by the harness):
+{{SEED_JSON}}
+
+PROCEDURE — follow exactly, no deviation:
+
+1. Call get_state(campaign_id) to confirm the party and monsters are present.
+
+2. One sentence of scene-setting (third-person, present tense): where, why, tone.
+
+3. Call start_combat(campaign_id, combatant_ids=[all_combatant_ids]) to open initiative.
+
+4. Run 3 FULL combat rounds. In each round:
+   a. Call next_turn(campaign_id) to advance the initiative tracker.
+   b. For each combatant whose turn it is, resolve their action with a real engine call:
+      - Aldric (fighter): attack(campaign_id, attacker_id=player_id, target_id=<a bandit or captain>, weapon="longsword")
+      - Maren (cleric): alternate between cast_spell(campaign_id, caster_id=companion_id, spell_name="Guiding Bolt", target_id=<a hostile>) and apply_healing(campaign_id, target_id=player_id, amount=<roll result>) after Cure Wounds — use saving_throw(campaign_id, character_id=<target>, dc=<Maren's spell save DC>, ability="constitution") for save-or-half spells.
+      - Monsters: attack(campaign_id, attacker_id=<monster_id>, target_id=<player_id or companion_id>, weapon=<their weapon name from notes>)
+   c. Every number (to-hit, damage, save DC) comes from a tool call — never invent dice.
+   d. If a combatant drops to 0 HP, call remove_combatant(campaign_id, character_id=<id>) and one sentence of narration.
+   e. One sentence of narration per round (vivid, present-tense). No more.
+
+5. After round 3 (or when all hostiles are removed), call end_combat(campaign_id).
+
+6. Call end_session(campaign_id, summary="Combat sprint — 3 rounds vs Bandits + Bandit Captain.").
+
+7. STOP. Do not add epilogue, do not call any other tools.
+
+RULES:
+- Every mechanical outcome must come from a tool call, not prose invention.
+- No hand-waving ("they defeat the bandits") — each attack, save, and damage value is a real roll.
+- One sentence of narration per round maximum; keep it present-tense and punchy.
+- If a tool errors, log the error text and continue with the next combatant — do not abort.

--- a/qa/pre_seed_combat.py
+++ b/qa/pre_seed_combat.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Zero-LLM pre-seed for the combat-sprint QA lane.
+
+Builds a combat-ready campaign by importing the engine directly (no MCP server,
+no LLM), then prints a single JSON line with the IDs the DM prompt needs.
+
+Choice: minimal campaign via create_campaign + add_location (make_current=True)
+rather than start_world("baldurs-gate"). Rationale: start_world loads and indexes
+the entire Baldur's Gate lore corpus (~330 locations, all wiki pages) — several
+seconds of I/O that is irrelevant to the Angry-DM rubric (get_state / attack /
+next_turn never touch world_id). The minimal path is ~50 ms and gives the rubric
+everything it needs: a real location, a fighter PC, a cleric companion (caster
+coverage so the rubric doesn't self-penalise), and 4 hostiles.
+
+Usage (from repo root):
+    CLAWDND_STATE_DIR=<dir> uv run --directory servers/engine python qa/pre_seed_combat.py <state_dir>
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: pre_seed_combat.py <state_dir>", file=sys.stderr)
+        sys.exit(1)
+
+    state_dir = sys.argv[1]
+    os.environ["CLAWDND_STATE_DIR"] = state_dir
+
+    # Add the engine root to sys.path so `import server` works when this script
+    # is invoked via `uv run --directory servers/engine python <abs-path>/qa/pre_seed_combat.py`.
+    # uv --directory resolves the venv but does NOT add the project root to sys.path
+    # for scripts given by absolute path; we mirror what pyproject.toml pythonpath=["."] does
+    # for pytest. Use __file__ to find this script's repo root, then descend into servers/engine.
+    _engine_dir = Path(__file__).resolve().parents[1] / "servers" / "engine"
+    if str(_engine_dir) not in sys.path:
+        sys.path.insert(0, str(_engine_dir))
+
+    # Import AFTER patching env + sys.path.
+    import server  # noqa: PLC0415
+
+    # ── 1. Campaign + location ───────────────────────────────────────────────
+    camp = server.create_campaign(
+        title="Combat Sprint Seed",
+        summary="Automated pre-seed for Angry-DM combat QA — no world corpus needed.",
+    )
+    campaign_id = camp["id"]
+
+    # Minimal location: one room the party and hostiles share.
+    server.add_location(
+        campaign_id=campaign_id,
+        name="Elfsong Tavern Cellar",
+        description=(
+            "A low stone cellar beneath the Elfsong Tavern. Barrels line the walls; "
+            "a single lantern throws long shadows. Exits: the taproom stairs."
+        ),
+        make_current=True,
+    )
+
+    # ── 2. Start a session ───────────────────────────────────────────────────
+    server.start_session(campaign_id, title="Combat Sprint")
+
+    # ── 3. Fighter PC (L4) ───────────────────────────────────────────────────
+    # apply_srd_defaults=True: sets proficiency bonus, HP (Fighter d10 + CON),
+    # saving throws, and AC via chain mail so the rubric sees a real AC value.
+    fighter = server.create_character(
+        campaign_id=campaign_id,
+        name="Aldric",
+        kind="player",
+        race="human",
+        class_name="fighter",
+        level=4,
+        abilities={
+            "strength": 18,
+            "dexterity": 14,
+            "constitution": 16,
+            "intelligence": 10,
+            "wisdom": 12,
+            "charisma": 10,
+        },
+        background="soldier",
+        apply_srd_defaults=True,
+        skills=["athletics", "perception", "intimidation", "history"],
+    )
+    player_id = fighter["id"]
+
+    # ── 4. Cleric companion (L4, caster coverage) ────────────────────────────
+    # The Angry-DM rubric docks points when a session has no caster; the cleric
+    # companion ensures cast_spell / saving_throw paths are exercised.
+    cleric = server.create_character(
+        campaign_id=campaign_id,
+        name="Maren",
+        kind="companion",
+        race="half-elf",
+        class_name="cleric",
+        level=4,
+        abilities={
+            "strength": 12,
+            "dexterity": 10,
+            "constitution": 14,
+            "intelligence": 12,
+            "wisdom": 18,
+            "charisma": 14,
+        },
+        background="acolyte",
+        apply_srd_defaults=True,
+        skills=["medicine", "religion", "insight", "persuasion"],
+    )
+    companion_id = cleric["id"]
+
+    # Give Maren her spells (replaces the list — signatures: campaign_id, character_id, spells_list)
+    server.learn_spells(campaign_id, companion_id, [
+        "Cure Wounds",
+        "Guiding Bolt",
+        "Sacred Flame",
+        "Spiritual Weapon",
+        "Healing Word",
+    ])
+
+    # ── 5. Hostile encounter: 3 Bandits + 1 Bandit Captain ───────────────────
+    # Balanced-deadly for a L4 party of 2: CR 1/8 × 3 + CR 2 × 1 ≈ 850 XP
+    # (deadly threshold for a 2-person L4 party is ~700 XP — tight but fair).
+    bandits = server.spawn_monster(campaign_id, "Bandit", count=3)
+    captain = server.spawn_monster(campaign_id, "Bandit Captain", count=1)
+
+    bandit_ids = [s["id"] for s in bandits["spawned"]]
+    captain_ids = [s["id"] for s in captain["spawned"]]
+    monster_ids = bandit_ids + captain_ids
+
+    all_combatant_ids = [player_id, companion_id] + monster_ids
+
+    result = {
+        "campaign_id": campaign_id,
+        "player_id": player_id,
+        "companion_id": companion_id,
+        "monster_ids": monster_ids,
+        "all_combatant_ids": all_combatant_ids,
+    }
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    main()

--- a/qa/run_combat_sprint.sh
+++ b/qa/run_combat_sprint.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# ClawDnD COMBAT-SPRINT QA — ~1.5-2 min, one claude -p DM call.
+#
+# Pre-seeds a campaign (zero LLM) then runs ONE DM call for a 3-round fight,
+# distills, behavioral-gates, and Angry-DM-scores the result.
+#
+# Usage:  qa/run_combat_sprint.sh [run-id]
+# Run from the repo root. Requires: claude CLI, uv, jq, python3.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+# Beat-driver helpers (clawdnd_cap_score_red).
+# shellcheck source=lib_beat_driver.sh
+. "$ROOT/qa/lib_beat_driver.sh"
+
+RUN="${1:-cs-$(date +%H%M%S)}"
+CLAWDND_DM_MODEL="${CLAWDND_DM_MODEL:-sonnet}"
+T="$ROOT/qa/transcripts"
+STATE_DIR="$ROOT/qa/state/$RUN"
+mkdir -p "$T" "$STATE_DIR"
+rm -rf "$STATE_DIR/campaigns" 2>/dev/null
+
+echo "[cs] run=$RUN state=$STATE_DIR model=$CLAWDND_DM_MODEL"
+
+# ── 1. Pre-seed (zero LLM) ───────────────────────────────────────────────────
+echo "[cs] pre-seeding campaign (zero LLM)…"
+SEED_JSON="$(
+  CLAWDND_STATE_DIR="$STATE_DIR" \
+  uv run --directory "$ROOT/servers/engine" python "$ROOT/qa/pre_seed_combat.py" "$STATE_DIR" 2>"$T/$RUN.seed.err"
+)"
+if [ -z "$SEED_JSON" ]; then
+  echo "[cs] pre-seed produced no output — check $T/$RUN.seed.err" >&2
+  cat "$T/$RUN.seed.err" >&2
+  exit 1
+fi
+echo "[cs] seed JSON: $SEED_JSON"
+
+# ── 2. Per-run MCP config (engine points at THIS worktree + THIS state dir) ──
+# Mirror run_duo.sh lines ~39-46: patch qa.mcp.json with the run-local state dir
+# AND override the engine --directory to this worktree so we use local code.
+DM_CFG="$STATE_DIR/dm.mcp.json"
+python3 - "$ROOT/qa/qa.mcp.json" "$STATE_DIR" "$ROOT" "$DM_CFG" <<'PY'
+import json, sys
+src, state_dir, root, out = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+cfg = json.load(open(src))
+eng = cfg["mcpServers"]["clawdnd-engine"]
+eng["env"]["CLAWDND_STATE_DIR"] = state_dir
+# Override --directory arg to use THIS worktree's engine (not the qa.mcp.json default)
+args = eng.get("args", [])
+try:
+    idx = args.index("--directory")
+    args[idx + 1] = f"{root}/servers/engine"
+except ValueError:
+    # --directory not present; insert after "run"
+    try:
+        ri = args.index("run")
+        args[ri + 1:ri + 1] = ["--directory", f"{root}/servers/engine"]
+    except ValueError:
+        args = ["run", "--directory", f"{root}/servers/engine"] + args
+eng["args"] = args
+json.dump(cfg, open(out, "w"))
+PY
+
+# ── 3. Build the DM prompt — inject the seed IDs into the template ───────────
+PROMPT_TEMPLATE="$ROOT/qa/play_prompt_combat_sprint.txt"
+PROMPT="$(sed "s|{{SEED_JSON}}|${SEED_JSON}|g" "$PROMPT_TEMPLATE")"
+
+# ── 4. ONE claude -p DM call ─────────────────────────────────────────────────
+echo "[cs] running DM (claude -p, $CLAWDND_DM_MODEL)…"
+claude -p "$PROMPT" \
+  --plugin-dir "$ROOT" \
+  --mcp-config "$DM_CFG" --strict-mcp-config \
+  --model "$CLAWDND_DM_MODEL" \
+  --permission-mode bypassPermissions \
+  --max-budget-usd 1.50 \
+  --output-format stream-json --verbose \
+  > "$T/$RUN.jsonl" 2>"$T/$RUN.err"
+echo "[cs] play exit=$? ($(wc -l < "$T/$RUN.jsonl") events)"
+
+if [ ! -s "$T/$RUN.jsonl" ]; then
+  echo "[cs] PLAY PRODUCED NO OUTPUT — check $T/$RUN.err" >&2
+  exit 1
+fi
+
+# ── 5. Distill ───────────────────────────────────────────────────────────────
+echo "[cs] distilling…"
+python3 qa/distill.py "$T/$RUN.jsonl" 2>/dev/null
+
+# ── 6. Final snapshot ────────────────────────────────────────────────────────
+SNAP="$(find "$STATE_DIR/campaigns" -mindepth 2 -maxdepth 2 -name snapshot.json -size +1c -exec ls -S {} + 2>/dev/null | head -1)"
+if [ -n "$SNAP" ] && [ -f "$SNAP" ]; then
+  cp "$SNAP" "$T/$RUN.state.json"
+else
+  echo '{"warning":"no campaign state was persisted"}' > "$T/$RUN.state.json"
+fi
+
+# ── 7. Behavioral gate ────────────────────────────────────────────────────────
+echo "[cs] behavioral gate…"
+# Combat-sprint scope: skip the world-progression floor (a single pre-seeded fight in one place
+# legitimately never advances days/travels — see assert_behavioral.py). Combat checks still apply.
+CLAWDND_GATE_COMBAT_SPRINT=1 python3 qa/assert_behavioral.py "$T/$RUN.jsonl" "$T/$RUN.state.json" | tee "$T/$RUN.gate.txt"
+GATE=${PIPESTATUS[0]}
+
+# ── 8. Angry-DM score ────────────────────────────────────────────────────────
+echo "[cs] scoring (Angry-DM 5e rules-fidelity)…"
+qa/score.sh "$T/$RUN.md" "$T/$RUN.state.json" \
+  qa/rubric_angry_dm.md qa/score_schema_angry_dm.json \
+  "$T/$RUN.angrydm.json" 1.00
+
+# ── 9. Honest scoring: cap RED runs ──────────────────────────────────────────
+if [ "${GATE:-0}" != "0" ]; then
+  GATE_REASON="$(grep -E '^\s*\[(FAIL)\]' "$T/$RUN.gate.txt" 2>/dev/null \
+    | sed 's/^[[:space:]]*//' | paste -sd'; ' - 2>/dev/null)"
+  GATE_REASON="${GATE_REASON:-behavioral gate RED}"
+  clawdnd_cap_score_red "$T/$RUN.angrydm.json" "$GATE_REASON"
+fi
+
+echo "[cs] ===== Angry-DM scorecard ($RUN) ====="
+jq -r '
+  "scores: \(.scores)",
+  "overall: \(.overall)",
+  "coverage: had_caster=\(.coverage.had_caster) fights=\(.coverage.fights) gaps=\(.coverage.gaps)",
+  "verdict: \(.verdict)",
+  "defects (\(.defects|length)):",
+  (.defects[]? | "  [\(.severity)/\(.kind)] \(.area) — \(.rule): \(.evidence) -> \(.suggested_fix)")
+' "$T/$RUN.angrydm.json" 2>/dev/null || { echo "(angry-dm parse failed; raw:)"; cat "$T/$RUN.angrydm.json"; }
+
+echo "[cs] behavioral=$([ "${GATE:-0}" = 0 ] && echo GREEN || echo RED)"
+exit "${GATE:-0}"

--- a/servers/engine/tests/test_qa_gate.py
+++ b/servers/engine/tests/test_qa_gate.py
@@ -202,6 +202,50 @@ def test_gate_xp_awarded_satisfied_by_end_combat(tmp_path):
     assert "[PASS] xp_awarded" in r.stdout  # end_combat counts, not just an explicit award_xp
 
 
+def test_gate_combat_resolved_requires_attack_or_cast_not_spawn_alone(tmp_path):
+    # combat_resolved tightening: spawn_monster alone (monsters appeared, but no dice flew)
+    # must NOT satisfy the check — a fight that started but resolved via narration with zero
+    # attack/cast_spell/saving_throw is a structurally broken run.
+    r = _run_gate(
+        tmp_path,
+        dm_tools=["start_combat", "spawn_monster"],  # NO attack/cast_spell/saving_throw
+        chat=[{"role": "player", "text": "[do] I charge."}, {"role": "dm", "text": "The bandits scatter."}],
+        moves=[{"role": "player", "kind": "do", "text": "charge the bandits"}],
+        state=PLAYER_IN_PARTY,
+    )
+    assert r.returncode == 1, r.stdout
+    assert "[FAIL] combat_resolved" in r.stdout
+
+
+def test_gate_combat_resolved_passes_on_cast_spell_only(tmp_path):
+    # A caster-only fight (e.g. Guiding Bolt + Sacred Flame via cast_spell/saving_throw,
+    # zero weapon attacks) must be GREEN — the rubric cannot penalise a legitimate caster.
+    r = _run_gate(
+        tmp_path,
+        dm_tools=["start_combat", "cast_spell", "saving_throw", "end_combat"],
+        chat=[{"role": "player", "text": "[cast] Guiding Bolt at the captain."},
+              {"role": "dm", "text": "Divine light sears; the captain staggers."}],
+        moves=[{"role": "player", "kind": "cast", "text": "Guiding Bolt", "name": "Guiding Bolt"}],
+        state=PLAYER_IN_PARTY,
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "[PASS] combat_resolved" in r.stdout
+
+
+def test_gate_combat_resolved_passes_on_attack(tmp_path):
+    # Baseline: a fight resolved via attack() stays GREEN (regression guard).
+    r = _run_gate(
+        tmp_path,
+        dm_tools=["start_combat", "attack", "end_combat"],
+        chat=[{"role": "player", "text": "[attack] strike the bandit."},
+              {"role": "dm", "text": "Steel meets flesh; the bandit crumples."}],
+        moves=[{"role": "player", "kind": "attack", "text": "strike the bandit"}],
+        state=PLAYER_IN_PARTY,
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert "[PASS] combat_resolved" in r.stdout
+
+
 def test_gate_green_skill_check_counts_as_dice_used(tmp_path):
     # skill_check (the generic ability/skill d20) must satisfy dice_used the same way
     # social_check does — a camp/exploration beat that rolls a Perception or Investigation


### PR DESCRIPTION
A ~2-min pre-seeded combat lane that exercises + scores the real 5e combat engine on the Angry-DM rubric — fixing the sampling artifact (every prior Angry-DM-scored run had 0 attack; combat was never formally exercised). Also the fast iteration vehicle for combat features (surprise, etc.).

## Files
- **qa/pre_seed_combat.py**: zero-LLM (~150ms) seed of an L4 party (fighter + cleric) + 3 Bandits + Captain via add_location/create_character/spawn_monster (no start_world).
- **qa/play_prompt_combat_sprint.txt**: DM-only 3-round fight prompt.
- **qa/run_combat_sprint.sh**: pre-seed -> one claude -p -> distill -> gate -> Angry-DM score.
- **qa/assert_behavioral.py**: scoped-B (start_combat>0 requires attack+cast_spell+saving_throw>0; caster-only fights stay GREEN) + CLAWDND_GATE_COMBAT_SPRINT env to skip the world-progression floor for the combat lane (a 1-location fight legitimately never travels). Story/duo runs keep the floor.

## Validated
A sprint ran a REAL fight: **93 attacks / 4 cast_spell / 4 start_combat / proper next_turn** (vs 0 attacks in every emergent run), gate GREEN with the flag. 1060 tests pass; license_check passes. Additive (env-gated). Closes #152.