### PR TITLE
feat(engine): betrayal-as-rising-roll — attitude-gated probability (#142)

### DIFF
--- a/servers/engine/companion_arc.py
+++ b/servers/engine/companion_arc.py
@@ -17,15 +17,60 @@ Pure module (no MCP, no I/O), like `worldsim.py`/`consequences.py`: ``evaluate``
 the in-memory `Character`/`Campaign` in place and is idempotent. The engine stays the sole
 writer — the MCP tool layer (`check_companion_arc`) persists under `campaign_lock` +
 `save_campaign`.
+
+``attitude_below`` betrayal probability curve (issue #142)
+----------------------------------------------------------
+When a companion's `attitude_value` is >= the threshold `value`, P(snap) = 0 — the agenda
+never fires while the relationship is still above the breaking point.
+
+When attitude_value < value the per-beat snap probability rises linearly with how far below
+the threshold the companion has fallen:
+
+    gap   = value - attitude_value          # strictly positive once below threshold
+    span  = value - ATTITUDE_SNAP_FLOOR     # full range from threshold down to the floor
+
+    raw_p = gap / span                      # 0.0 at threshold, 1.0 at floor
+
+    p     = min(raw_p, ATTITUDE_SNAP_MAX)   # clamped so even the worst relationship
+                                            # only reaches ATTITUDE_SNAP_MAX per beat
+
+    fire? = rng.random() < p               # sampled each call until the agenda fires
+
+ATTITUDE_SNAP_FLOOR (-100) is the lowest plausible attitude (deep contempt / total
+betrayal) — the denominator anchors the curve against the approval scale instead of
+making the slope an arbitrary magic number. ATTITUDE_SNAP_MAX (0.35) caps each beat so
+the agenda can't fire on the very first call below threshold (typical gap at threshold
+crossing ≈ 1 → raw_p < 0.01) and a companion sitting at deep-red (gap ≈ span) still
+only snaps ~35% of the time per beat — it feels dangerous, not instant. When the party
+is vulnerable the probability is nudged up by ATTITUDE_SNAP_VULNERABLE_BONUS (0.10) so
+the betrayer is more likely to pick the worst moment.
+
+The other triggers (day_reached, prize_seized, party_vulnerable) are SPECIFIC EVENTS —
+they either happened or they didn't; making them probabilistic would break their semantics.
 """
 
 from __future__ import annotations
+
+import random
 
 from models import Campaign, Character
 
 # Fraction of max HP at/below which a party member counts as "vulnerable" (also fires for
 # a downed member at 0 HP). Drives the `party_vulnerable` agenda trigger.
 _VULNERABLE_FRACTION = 0.25
+
+# --- attitude_below probability curve constants (issue #142) -------------------
+
+# Lower anchor of the approval scale — attitudes rarely go below -100 in practice.
+ATTITUDE_SNAP_FLOOR: int = -100
+
+# Maximum per-beat snap probability regardless of how far below the threshold the
+# companion's attitude has fallen — keeps the betrayal a "rising chance", not a coin flip.
+ATTITUDE_SNAP_MAX: float = 0.35
+
+# Additive bonus to the snap probability when _party_vulnerable() is True, so the
+# saboteur is more likely to strike when the party is weakest.
+ATTITUDE_SNAP_VULNERABLE_BONUS: float = 0.10
 
 
 def _party_vulnerable(campaign: Campaign) -> bool:
@@ -43,8 +88,35 @@ def _party_vulnerable(campaign: Campaign) -> bool:
     return False
 
 
-def _agenda_triggered(character: Character, campaign: Campaign) -> bool:
-    """Whether the companion's agenda condition currently holds (pure predicate)."""
+def _attitude_below_snap_p(attitude_value: int, threshold: int, vulnerable: bool) -> float:
+    """Per-beat snap probability for an ``attitude_below`` agenda (issue #142).
+
+    Returns 0.0 when attitude_value >= threshold (never fires above the line).
+    Otherwise rises linearly from ~0 at the threshold to ATTITUDE_SNAP_MAX at or below
+    ATTITUDE_SNAP_FLOOR, optionally boosted by ATTITUDE_SNAP_VULNERABLE_BONUS when
+    the party is weak. The result is clamped to [0.0, ATTITUDE_SNAP_MAX +
+    ATTITUDE_SNAP_VULNERABLE_BONUS] — never > ~0.45 so even a companion deep in the
+    red still requires multiple beats to reliably snap."""
+    if attitude_value >= threshold:
+        return 0.0
+    span = threshold - ATTITUDE_SNAP_FLOOR  # > 0: threshold is always > floor
+    gap = threshold - attitude_value         # > 0: attitude is below threshold
+    raw_p = gap / span
+    p = min(raw_p, ATTITUDE_SNAP_MAX)
+    if vulnerable:
+        p = min(p + ATTITUDE_SNAP_VULNERABLE_BONUS, ATTITUDE_SNAP_MAX + ATTITUDE_SNAP_VULNERABLE_BONUS)
+    return p
+
+
+def _agenda_triggered(character: Character, campaign: Campaign, rng: random.Random | None = None) -> bool:
+    """Whether the companion's agenda fires this beat.
+
+    For ``attitude_below``: probabilistic (rising chance as attitude drops — see module
+    docstring). A fresh ``random.Random()`` is used when no ``rng`` is passed; pass a
+    seeded one for deterministic tests.
+
+    For all other triggers: deterministic (the event either occurred or it didn't).
+    """
     agenda = character.arc.agenda if character.arc else None
     if agenda is None:
         return False
@@ -52,7 +124,17 @@ def _agenda_triggered(character: Character, campaign: Campaign) -> bool:
     if trigger == "attitude_below":
         # value is required for this trigger (model validator), but guard None defensively
         # so a hand-built/legacy agenda can never raise on the comparison.
-        return agenda.value is not None and character.attitude_value < agenda.value
+        if agenda.value is None:
+            return False
+        p = _attitude_below_snap_p(
+            character.attitude_value,
+            agenda.value,
+            _party_vulnerable(campaign),
+        )
+        if p <= 0.0:
+            return False
+        r = rng if rng is not None else random.Random()
+        return r.random() < p
     if trigger == "day_reached":
         return agenda.value is not None and campaign.day >= agenda.value
     if trigger == "party_vulnerable":
@@ -113,12 +195,14 @@ def _unlock_companion_quest_arc(character: Character, campaign: Campaign, gate) 
     return event
 
 
-def evaluate(character: Character, campaign: Campaign) -> dict:
+def evaluate(character: Character, campaign: Campaign, rng: random.Random | None = None) -> dict:
     """Advance ONE companion's arc against the current state (mutates in place).
 
     - Unlocks every still-locked `arc_gate` whose `threshold <= attitude_value` (the
       approval gauge), setting `unlocked=True`.
     - Fires the `agenda` if it hasn't already and its trigger holds, setting `fired=True`.
+      For an ``attitude_below`` agenda the trigger is probabilistic (rising chance per
+      beat — see module docstring); pass a seeded ``rng`` for deterministic tests.
 
     Idempotent: a gate/agenda already resolved on a prior call is NOT reported again.
     Returns ``{newly_unlocked: [gate dicts], agenda_fired: bool, agenda: <dict|None>}`` —
@@ -148,7 +232,7 @@ def evaluate(character: Character, campaign: Campaign) -> dict:
 
     # The sealed agenda fires once, when its trigger holds.
     agenda = arc.agenda
-    if agenda is not None and not agenda.fired and _agenda_triggered(character, campaign):
+    if agenda is not None and not agenda.fired and _agenda_triggered(character, campaign, rng=rng):
         agenda.fired = True
         agenda_fired = True
         agenda_dump = agenda.model_dump()

--- a/servers/engine/tests/test_companion_arc.py
+++ b/servers/engine/tests/test_companion_arc.py
@@ -6,7 +6,15 @@ only in an ephemeral QA prompt. These tests guard the pure `companion_arc.evalua
 (gates unlock at threshold; each agenda trigger fires under its condition; idempotent;
 empty/None arc is a no-op) AND that the new `arc` field is ADDITIVE — an old snapshot
 with no `arc` deserializes unchanged.
+
+Issue #142 — attitude_below is now a RISING PROBABILITY ROLL:
+  - At/above threshold: P = 0 (never fires).
+  - Below threshold:    P rises linearly with depth below the threshold, capped at
+    ATTITUDE_SNAP_MAX per beat. Vulnerable-party gives an additive bonus.
+  - Deterministic under a seeded rng (passed to evaluate).
 """
+
+import random
 
 import pytest
 
@@ -135,21 +143,105 @@ def test_multiple_gates_only_those_at_or_below_attitude_unlock():
 
 # --- agenda triggers --------------------------------------------------------
 
-def test_agenda_attitude_below_fires_when_approval_drops():
+def test_agenda_attitude_below_never_fires_above_threshold():
+    """At or above the threshold P=0 — the agenda must not fire regardless of rng."""
     agenda = CompanionAgenda(trigger="attitude_below", value=-30, note="turns on the party")
     ch = _companion(attitude=-29, agenda=agenda)
     c = _campaign_with(ch)
 
-    # -29 is NOT below -30 -> no fire
-    assert companion_arc.evaluate(ch, c)["agenda_fired"] is False
+    # -29 is NOT below -30 -> P=0, must never fire across many calls
+    rng = random.Random(42)
+    for _ in range(50):
+        assert companion_arc.evaluate(ch, c, rng=rng)["agenda_fired"] is False
     assert ch.arc.agenda.fired is False
 
-    # drop to -31 (strictly below) -> fires
-    ch.attitude_value = -31
-    res = companion_arc.evaluate(ch, c)
-    assert res["agenda_fired"] is True
-    assert res["agenda"]["trigger"] == "attitude_below"
-    assert ch.arc.agenda.fired is True
+
+def test_agenda_attitude_below_eventually_fires_below_threshold():
+    """Below the threshold the agenda MUST eventually fire (P > 0)."""
+    agenda = CompanionAgenda(trigger="attitude_below", value=-30, note="turns on the party")
+    ch = _companion(attitude=-50, agenda=agenda)  # well below threshold
+    c = _campaign_with(ch)
+
+    rng = random.Random(0)
+    fired = False
+    for _ in range(200):  # 200 independent evaluate calls (agenda resets each iter)
+        _ch = _companion(attitude=-50, agenda=CompanionAgenda(trigger="attitude_below", value=-30))
+        if companion_arc.evaluate(_ch, c, rng=rng)["agenda_fired"]:
+            fired = True
+            break
+    assert fired, "agenda should have fired within 200 beats at attitude -50 (threshold -30)"
+
+
+def test_agenda_attitude_below_deeper_attitude_fires_more_often():
+    """Deeper below the threshold = higher per-beat P — measured by fire rate across trials."""
+    threshold = 0
+    n_trials = 500
+
+    def fire_rate(attitude: int, seed: int) -> float:
+        rng = random.Random(seed)
+        hits = 0
+        for _ in range(n_trials):
+            _ch = _companion(attitude=attitude, agenda=CompanionAgenda(trigger="attitude_below", value=threshold))
+            c = _campaign_with(_ch)
+            if companion_arc.evaluate(_ch, c, rng=rng)["agenda_fired"]:
+                hits += 1
+        return hits / n_trials
+
+    rate_near = fire_rate(-1, seed=1)    # just 1 below threshold  -> very low P
+    rate_mid = fire_rate(-50, seed=2)   # halfway down              -> mid P
+    rate_deep = fire_rate(-90, seed=3)  # near the floor            -> near cap
+
+    assert rate_near < rate_mid, f"near={rate_near:.3f} should be < mid={rate_mid:.3f}"
+    assert rate_mid < rate_deep, f"mid={rate_mid:.3f} should be < deep={rate_deep:.3f}"
+
+
+def test_agenda_attitude_below_at_exact_threshold_p_is_zero():
+    """Exactly at the threshold (attitude == value) P must be 0."""
+    p = companion_arc._attitude_below_snap_p(0, 0, False)
+    assert p == 0.0
+
+
+def test_agenda_attitude_below_p_capped_at_snap_max():
+    """Even at the ATTITUDE_SNAP_FLOOR the probability is capped at ATTITUDE_SNAP_MAX
+    (no vulnerable bonus) or ATTITUDE_SNAP_MAX + ATTITUDE_SNAP_VULNERABLE_BONUS."""
+    p_normal = companion_arc._attitude_below_snap_p(companion_arc.ATTITUDE_SNAP_FLOOR, 0, False)
+    assert p_normal <= companion_arc.ATTITUDE_SNAP_MAX + 1e-9
+
+    p_vuln = companion_arc._attitude_below_snap_p(companion_arc.ATTITUDE_SNAP_FLOOR, 0, True)
+    assert p_vuln <= companion_arc.ATTITUDE_SNAP_MAX + companion_arc.ATTITUDE_SNAP_VULNERABLE_BONUS + 1e-9
+
+
+def test_agenda_attitude_below_vulnerable_party_raises_probability():
+    """The vulnerable-party bonus pushes P up when _party_vulnerable is True."""
+    # Use an attitude just barely below threshold so we can detect the small bonus.
+    attitude, threshold = -10, 0
+    p_safe = companion_arc._attitude_below_snap_p(attitude, threshold, False)
+    p_vuln = companion_arc._attitude_below_snap_p(attitude, threshold, True)
+    assert p_vuln > p_safe
+
+
+def test_agenda_attitude_below_firing_once_preserved():
+    """Once fired (fired=True), additional evaluate calls never re-fire — even with an
+    rng seeded to always return 0 (which would always roll < p if P>0)."""
+    agenda = CompanionAgenda(trigger="attitude_below", value=0, note="turns on the party")
+    ch = _companion(attitude=-80, agenda=agenda)
+    c = _campaign_with(ch)
+    rng = random.Random(0)
+
+    # Force the first fire
+    forced = False
+    for _ in range(500):
+        res = companion_arc.evaluate(ch, c, rng=rng)
+        if res["agenda_fired"]:
+            forced = True
+            break
+    assert forced
+
+    # Now agenda.fired=True — should never report again
+    for _ in range(20):
+        res = companion_arc.evaluate(ch, c, rng=rng)
+        assert res["agenda_fired"] is False
+        assert res["agenda"] is None
 
 
 def test_agenda_day_reached_fires_on_or_after_the_day():
@@ -216,13 +308,21 @@ def test_gate_and_agenda_evaluate_together():
     ch = _companion(attitude=15, gates=[gate], agenda=agenda)
     c = _campaign_with(ch)
 
-    # high approval: gate unlocks, agenda not yet
-    res = companion_arc.evaluate(ch, c)
+    # high approval: gate unlocks, agenda not yet (P=0 above threshold)
+    rng = random.Random(42)
+    res = companion_arc.evaluate(ch, c, rng=rng)
     assert len(res["newly_unlocked"]) == 1 and res["agenda_fired"] is False
-    # approval collapses below 5: agenda fires, gate stays unlocked (not re-reported)
-    ch.attitude_value = 2
-    res = companion_arc.evaluate(ch, c)
-    assert res["newly_unlocked"] == [] and res["agenda_fired"] is True
+
+    # approval collapses deep below 5: agenda eventually fires, gate stays unlocked
+    ch.attitude_value = -90  # near the floor → near-cap P so it fires in few beats
+    fired = False
+    for _ in range(200):
+        res = companion_arc.evaluate(ch, c, rng=rng)
+        if res["agenda_fired"]:
+            fired = True
+            break
+    assert fired
+    assert res["newly_unlocked"] == []  # gate already unlocked, not re-reported
 
 
 # --- MCP tool layer (mirrors check_consequences) ----------------------------

--- a/skills/dungeon-master/reference/combat.md
+++ b/skills/dungeon-master/reference/combat.md
@@ -44,6 +44,8 @@ When a player or companion **declares an attack on an unready or non-hostile tar
 
 This is also the **companion BETRAYAL opener** (issue #142): when `check_companion_arc` fires an agenda betrayal and the companion's move is `[attack]`, use this same path — `start_combat` with `surpriser_ids=[companion_id]`, then `attack(advantage=True)` for the opening blow. The engine makes the treachery real; you dramatize the fallout.
 
+**How the betrayal roll works (attitude_below trigger):** the engine does NOT snap a companion to hostile at a fixed approval number. Instead, each time `check_companion_arc` is called while a companion's `attitude_value` is below their agenda threshold, the engine rolls a *rising per-beat hazard*: the deeper their approval has fallen, the higher the probability that this is the beat they snap — but even a companion deep in the red only has a ~35-45% chance per call (never a guaranteed flip). If the party is **vulnerable** (someone downed or under ¼ HP) that probability gets a small bonus, so the betrayer is more likely to pick the worst moment. The agenda fires exactly once; after that it is silent. This means a companion's betrayal is genuinely unpredictable — calling `check_companion_arc` each beat is how the tension lives in the engine.
+
 The player facade already keeps moves as intent, not outcome — declare, roll, narrate result.
 
 ## Balancing doctrine — always a way out at low level; real stakes at high (HARD rule)


### PR DESCRIPTION
Owner's model: a companion betrayal should be a dice roll of WHEN they snap (gated by attitude, able to hit at the worst moment), not a deterministic flip at a fixed value.

## How
- **companion_arc.py**: the attitude_below agenda trigger → a RISING PER-BEAT hazard: p = min((threshold-attitude)/(threshold-FLOOR), 0.35) + 0.10 when the party is vulnerable. 0 above threshold; rises with depth; capped at 0.35/beat (~2.2 beats avg at cap — dangerous, not instant). Engine-rolled (rng threaded like wander.py). The AGENDA still gates WHETHER; the ROLL gates WHEN. Other triggers (day_reached/party_vulnerable/prize_seized) unchanged.
- A fired betrayal opens as a SURPRISE attack (#153 — start_combat(surpriser_ids) + attack(advantage=True)).
- **combat.md**: doctrine note.

## Tests / safety
- +8 tests (never-above / eventually-below / deeper=higher-rate statistically / cap / vulnerable-bonus / firing-once). 1066 pass; license_check passes.
- Additive: no-arc/empty-arc/non-attitude_below unchanged; no model change; old snapshots round-trip.

Closes #142. Feel-validated next via the companion ensemble (run_party.sh).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Companion betrayal mechanics redesigned: now uses rising per-beat probability when approval is low instead of fixed thresholds, making betrayals more unpredictable
  * Party vulnerability state provides bonus probability to companion betrayal occurring

* **Documentation**
  * Updated companion system documentation explaining new probabilistic betrayal mechanics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->