### PR TITLE
feat(viewer): wire 5 OpenWorlds screens to live engine data + GM-Advisory (playable app)

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -255,11 +255,11 @@ function capabilityForScreen(screen, nativeState) {
       ? { label: "Wired", tone: "emerald", detail: "Native bridge ready" }
       : { label: "Unavailable", tone: "crimson", detail: "Native bridge missing" };
   }
-  if (["launcher", "table", "combat", "map"].includes(screen)) {
+  if (["launcher", "table", "combat", "map", "journal", "character", "inventory", "relations"].includes(screen)) {
     return { label: "Wired", tone: "emerald", detail: "Backed by viewer read models" };
   }
   if (screen === "dialogue") {
-    return { label: "Provider required", tone: "royal", detail: "Requires a provider session" };
+    return { label: "Wired", tone: "emerald", detail: "Sheet-correct parley read model" };
   }
   return { label: "Display-only", tone: "brass", detail: "Prototype surface awaiting a read model" };
 }

--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -1,11 +1,48 @@
-/* Screen: Character Sheet — dense, codex/sourcebook style */
+/* Screen: Character Sheet — dense, codex/sourcebook style.
+   Wired to the live /character-surface read model (full party sheets projected from the
+   engine snapshot: classes, skills, spells, class_resources, conditions, AC, death saves).
+   Polls every 5s while visible; falls back to the demo party until the first fetch.
+   Layout/design unchanged from the prototype. */
 
 function ScreenCharacter({ onNavigate, state, setState }) {
-  const party = Array.isArray(state?.party) ? state.party : [];
-  const [active, setActive] = React.useState(() => party[0]?.id || "");
+  const surfaceQuery = window.combatSurfaceFromCampaign
+    ? window.combatSurfaceFromCampaign(
+        (Array.isArray(state?.campaigns) ? state.campaigns : []).find((c) => c.id === state?.activeCampaign) ||
+          (Array.isArray(state?.campaigns) ? state.campaigns : [])[0] || {},
+        state,
+      )
+    : "";
+  const [surface, setSurface] = React.useState(null);
+  const party = (Array.isArray(surface?.party) && surface.party.length)
+    ? surface.party
+    : (Array.isArray(state?.party) ? state.party : []);
+  const [active, setActive] = React.useState("");
   const [tab, setTab] = React.useState("abilities");
   const [restOpen, setRestOpen] = React.useState(false);
   const toast = window.useToast ? window.useToast() : (() => {});
+
+  const loadSurface = React.useCallback(async (isCancelled = () => false) => {
+    try {
+      const response = await fetch("/character-surface" + surfaceQuery, { cache: "no-store" });
+      if (!response.ok) throw new Error(`character surface ${response.status}`);
+      const payload = await response.json();
+      if (!isCancelled()) setSurface(payload);
+    } catch (error) { /* keep last good / demo fallback */ }
+  }, [surfaceQuery]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let timer = null;
+    const guardedLoad = async () => { if (!cancelled) await loadSurface(() => cancelled); };
+    const stopPolling = () => { if (timer !== null) { window.clearInterval(timer); timer = null; } };
+    const startPolling = () => { if (timer === null) timer = window.setInterval(guardedLoad, 5000); };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") { guardedLoad(); startPolling(); } else { stopPolling(); }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    handleVisibility();
+    return () => { cancelled = true; stopPolling(); document.removeEventListener("visibilitychange", handleVisibility); };
+  }, [loadSurface]);
 
   const hero = party.find((p) => p.id === active) || party[0];
 

--- a/viewer/openworlds/screen-dialogue.jsx
+++ b/viewer/openworlds/screen-dialogue.jsx
@@ -1,6 +1,278 @@
-/* Screen: Dialogue / Parley — choice tree over scene art */
+/* Screen: Parley — sheet-correct social options over scene art.
+   Wired to the live /parley-surface read model (the UI side of #141): the lead PC's
+   alignment + per-skill {skill, modifier, suggested_dc} + a free-form path. Polls every
+   5s while visible. These are SLOTS, not authored lines — the player picks an approach
+   and the DM (via the engine) voices + adjudicates it. Falls back to the demo scene tree
+   only if no snapshot resolves. Scene chrome / dialogue-panel design unchanged. */
+
+const DIFFICULTY_OPTIONS = ["easy", "medium", "hard"];
 
 function ScreenDialogue({ onNavigate, state, setState }) {
+  const surfaceQuery = window.combatSurfaceFromCampaign
+    ? window.combatSurfaceFromCampaign(
+        (Array.isArray(state?.campaigns) ? state.campaigns : []).find((c) => c.id === state?.activeCampaign) ||
+          (Array.isArray(state?.campaigns) ? state.campaigns : [])[0] || {},
+        state,
+      )
+    : "";
+  const [surface, setSurface] = React.useState(null);
+  const [difficulty, setDifficulty] = React.useState("medium");
+  const [history, setHistory] = React.useState([]);
+  const [status, setStatus] = React.useState("loading");
+  const toast = window.useToast ? window.useToast() : (() => {});
+
+  const loadSurface = React.useCallback(async (isCancelled = () => false) => {
+    const sep = surfaceQuery ? "&" : "?";
+    const url = `/parley-surface${surfaceQuery}${sep}difficulty=${encodeURIComponent(difficulty)}`;
+    try {
+      const response = await fetch(url, { cache: "no-store" });
+      if (!response.ok) throw new Error(`parley surface ${response.status}`);
+      const payload = await response.json();
+      if (isCancelled()) return;
+      setSurface(payload);
+      setStatus("ready");
+    } catch (error) {
+      if (isCancelled()) return;
+      setStatus(error?.message || "unavailable");
+    }
+  }, [surfaceQuery, difficulty]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let timer = null;
+    const guardedLoad = async () => { if (!cancelled) await loadSurface(() => cancelled); };
+    const stopPolling = () => { if (timer !== null) { window.clearInterval(timer); timer = null; } };
+    const startPolling = () => { if (timer === null) timer = window.setInterval(guardedLoad, 5000); };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") { guardedLoad(); startPolling(); } else { stopPolling(); }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    handleVisibility();
+    return () => { cancelled = true; stopPolling(); document.removeEventListener("visibilitychange", handleVisibility); };
+  }, [loadSurface]);
+
+  const slots = Array.isArray(surface?.skills) ? surface.skills : [];
+  const hasParley = Boolean(surface && surface.actor && slots.length);
+  if (hasParley) {
+    return <ParleyMenu
+      surface={surface}
+      slots={slots}
+      difficulty={difficulty}
+      setDifficulty={setDifficulty}
+      history={history}
+      setHistory={setHistory}
+      onNavigate={onNavigate}
+      toast={toast}
+    />;
+  }
+
+  // No live parley (no snapshot / no actor): keep the prototype choice tree as a graceful
+  // demo fallback so the screen still reads instead of going blank.
+  return <ScreenDialogueDemo onNavigate={onNavigate} state={state} status={status} />;
+}
+
+function ParleyMenu({ surface, slots, difficulty, setDifficulty, history, setHistory, onNavigate, toast }) {
+  const actorName = surface.actor || "Hero";
+  const canAct = Boolean(surface.can_act);
+
+  const pick = (slot) => {
+    const move = { kind: "check", name: `${slot.label} (DC ${slot.suggested_dc})`, skill: slot.skill, dc: slot.suggested_dc, text: `attempts ${slot.label} (DC ${slot.suggested_dc})` };
+    setHistory((h) => [...h, { skill: slot.label, dc: slot.suggested_dc, mod: slot.modifier }]);
+    if (!canAct) {
+      toast({ kind: "danger", eyebrow: "Parley", title: "Read-only", body: "This view can't land moves. The DM voices the chosen approach." });
+      return;
+    }
+    fetch("/move", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...move, campaign: surface.campaign_id || "" }),
+    }).then((r) => r.json().catch(() => ({}))).then((payload) => {
+      if (payload && payload.ok === false) throw new Error(payload.reason || "move rejected");
+      toast({ kind: "item", eyebrow: "Parley", title: `${actorName} — ${slot.label}`, body: `Requested a ${slot.label} check at DC ${slot.suggested_dc}.` });
+    }).catch((e) => toast({ kind: "danger", title: "Move not sent", body: e?.message || "The viewer could not reach /move." }));
+  };
+
+  const freeForm = () => {
+    if (!canAct) {
+      toast({ kind: "danger", eyebrow: "Parley", title: "Read-only", body: "The DM voices the free-form path." });
+      return;
+    }
+    fetch("/move", {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "say", text: `${actorName} speaks their own way`, campaign: surface.campaign_id || "" }),
+    }).then(() => toast({ kind: "item", eyebrow: "Parley", title: "Free-form", body: "Speak it at the table — the DM adjudicates." }))
+      .catch((e) => toast({ kind: "danger", title: "Move not sent", body: e?.message || "unreachable" }));
+  };
+
+  return (
+    <div className="screen" style={{ height: "100%", position: "relative", padding: 14 }}>
+      {/* Scene backdrop */}
+      <div style={{ position: "relative", height: "100%", overflow: "hidden", borderRadius: 4, boxShadow: "inset 0 0 0 1px var(--w-500), inset 0 0 0 4px var(--b-500), inset 0 0 0 5px var(--b-300), inset 0 0 0 6px var(--b-500)" }}>
+        <Placeholder
+          label={`scene · parley · ${surface.title || "the table"}`}
+          h="100%"
+          style={{ width: "100%", height: "100%" }}
+        />
+
+        {/* Vignette */}
+        <div style={{
+          position: "absolute", inset: 0,
+          background: "radial-gradient(ellipse at 50% 40%, transparent 30%, rgba(20, 10, 4, 0.7) 100%)",
+          pointerEvents: "none",
+        }} />
+
+        {/* Candle glows */}
+        <div className="candleglow" style={{ width: 280, height: 280, left: "10%", top: "20%" }} />
+        <div className="candleglow" style={{ width: 200, height: 200, right: "15%", top: "40%", animationDelay: "1s" }} />
+
+        {/* Top breadcrumb */}
+        <div style={{
+          position: "absolute", top: 18, left: 18, right: 18,
+          display: "flex", justifyContent: "space-between", alignItems: "flex-start",
+          zIndex: 3,
+        }}>
+          <div style={{
+            padding: "8px 16px",
+            background: "linear-gradient(180deg, var(--w-100), var(--w-300))",
+            color: "var(--b-200)",
+            boxShadow: "inset 0 0 0 1px var(--w-500), inset 0 1px 0 rgba(255,220,170,0.2)",
+            fontFamily: "var(--f-display)",
+            fontSize: 11,
+            letterSpacing: "0.22em",
+            textTransform: "uppercase",
+          }}>
+            Parley · {surface.dayLabel || "the table"}
+          </div>
+          <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+            <span className="pill" style={{ background: "rgba(20,10,4,0.55)", color: "var(--p-100)", boxShadow: "inset 0 0 0 1px var(--b-500)" }}>
+              {canAct ? "Live" : "Read-only"}
+            </span>
+            {DIFFICULTY_OPTIONS.map((d) => (
+              <button key={d} onClick={() => setDifficulty(d)} className="btn sm" style={{
+                textTransform: "capitalize",
+                background: difficulty === d ? "linear-gradient(180deg, var(--b-200), var(--b-400))" : "rgba(20,10,4,0.5)",
+                color: difficulty === d ? "var(--w-300)" : "var(--p-100)",
+                boxShadow: difficulty === d ? "inset 0 0 0 1px var(--b-600)" : "inset 0 0 0 1px rgba(176,141,87,0.4)",
+              }}>{d}</button>
+            ))}
+          </div>
+        </div>
+
+        {/* Parley panel — bottom */}
+        <div style={{ position: "absolute", bottom: 18, left: 18, right: 18, zIndex: 3 }}>
+          <div style={{
+            display: "grid",
+            gridTemplateColumns: "160px 1fr",
+            gap: 0,
+            background: "linear-gradient(180deg, var(--p-100), var(--p-200))",
+            boxShadow:
+              "inset 0 0 0 1px var(--b-600), inset 0 0 0 4px var(--p-100), inset 0 0 0 5px var(--b-400), 0 12px 30px rgba(0,0,0,0.5)",
+          }}>
+
+            {/* Actor portrait (left) */}
+            <div style={{ padding: 14, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", borderRight: "1px solid rgba(140,100,60,0.35)" }}>
+              <Placeholder label="portrait" w={120} h={150} framed />
+              <div style={{ marginTop: 8, fontFamily: "var(--f-display)", fontSize: 13, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--ink-900)", textAlign: "center" }}>
+                {actorName}
+              </div>
+              {surface.alignment && <div className="hand muted" style={{ fontSize: 12, textAlign: "center" }}>{surface.alignment}</div>}
+            </div>
+
+            {/* Body — skill slots */}
+            <div style={{ padding: "18px 22px", minHeight: 240, display: "flex", flexDirection: "column" }}>
+              <div className="hand" style={{ fontSize: 14, color: "var(--ink-600)", marginBottom: 6 }}>
+                How does {actorName.split(" ")[0]} approach this? These are SLOTS, sheet-correct — the DM voices the line and adjudicates the roll.
+              </div>
+
+              <div style={{ flex: 1 }} />
+
+              {/* Skill slot choices */}
+              <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+                {slots.map((slot, i) => (
+                  <button key={slot.skill} onClick={() => pick(slot)} style={{
+                    display: "grid",
+                    gridTemplateColumns: "24px 1fr auto auto",
+                    gap: 10, alignItems: "center",
+                    padding: "8px 12px",
+                    textAlign: "left",
+                    background: "transparent",
+                    boxShadow: "inset 0 -1px 0 rgba(140,100,60,0.25)",
+                    cursor: "pointer",
+                    transition: "all 140ms",
+                    fontSize: 15,
+                  }}
+                  onMouseEnter={(e) => {
+                    e.currentTarget.style.background = "rgba(176,141,87,0.12)";
+                    e.currentTarget.style.boxShadow = "inset 0 0 0 1px var(--b-500), 0 0 16px -6px var(--gold-glow)";
+                  }}
+                  onMouseLeave={(e) => {
+                    e.currentTarget.style.background = "transparent";
+                    e.currentTarget.style.boxShadow = "inset 0 -1px 0 rgba(140,100,60,0.25)";
+                  }}>
+                    <span style={{ fontFamily: "var(--f-display)", color: "var(--crimson)", fontSize: 14 }}>{i + 1}.</span>
+                    <span className="body" style={{ color: "var(--ink-800)" }}>
+                      {slot.label}
+                      {slot.expertise ? <span className="hand muted" style={{ fontSize: 11, marginLeft: 6 }}>expertise</span>
+                        : slot.proficient ? <span className="hand muted" style={{ fontSize: 11, marginLeft: 6 }}>proficient</span> : null}
+                    </span>
+                    <span className="pill" style={{
+                      background: slot.core ? "var(--royal)" : "var(--emerald)",
+                      color: "var(--p-100)",
+                      boxShadow: "inset 0 0 0 1px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.15)",
+                    }}>{slot.modifier >= 0 ? "+" : ""}{slot.modifier}</span>
+                    <span style={{ fontFamily: "var(--f-display)", color: "var(--b-500)", fontSize: 12, letterSpacing: "0.1em" }}>
+                      DC {slot.suggested_dc}
+                    </span>
+                  </button>
+                ))}
+
+                {/* Free-form path — always present (free_form is always true). */}
+                <button onClick={freeForm} style={{
+                  display: "grid", gridTemplateColumns: "24px 1fr auto", gap: 10, alignItems: "center",
+                  padding: "8px 12px", textAlign: "left", background: "transparent",
+                  boxShadow: "inset 0 -1px 0 rgba(140,100,60,0.25)", cursor: "pointer", fontSize: 15,
+                }}
+                onMouseEnter={(e) => { e.currentTarget.style.background = "rgba(176,141,87,0.12)"; }}
+                onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}>
+                  <span style={{ fontFamily: "var(--f-display)", color: "var(--crimson)", fontSize: 14 }}>✦</span>
+                  <span className="body" style={{ color: "var(--ink-800)", fontStyle: "italic" }}>Speak freely — your own words</span>
+                  <span style={{ color: "var(--b-500)", fontFamily: "var(--f-display)", fontSize: 12 }}>free-form</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Right side rail — chosen approaches this parley */}
+        {history.length > 0 && (
+          <div style={{
+            position: "absolute", top: 70, right: 18, width: 240,
+            maxHeight: "55%", overflow: "auto",
+            background: "linear-gradient(180deg, var(--w-100), var(--w-300))",
+            color: "var(--p-200)",
+            padding: 14,
+            boxShadow: "inset 0 0 0 1px var(--w-500), inset 0 0 0 3px var(--w-200), inset 0 0 0 4px var(--b-500)",
+            zIndex: 3,
+          }}>
+            <div className="eyebrow" style={{ color: "var(--b-200)", marginBottom: 8 }}>Approaches taken</div>
+            {history.slice(-8).map((h, i) => (
+              <div key={i} style={{ marginBottom: 8, paddingBottom: 8, borderBottom: "1px dashed rgba(176,141,87,0.25)" }}>
+                <div style={{ fontFamily: "var(--f-display)", fontSize: 10, letterSpacing: "0.16em", textTransform: "uppercase", color: "var(--b-200)" }}>
+                  {h.skill}
+                </div>
+                <div className="hand" style={{ fontSize: 11, color: "var(--b-300)", marginTop: 2 }}>
+                  {h.mod >= 0 ? "+" : ""}{h.mod} vs DC {h.dc}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ScreenDialogueDemo({ onNavigate, state, status }) {
   const [nodeId, setNodeId] = React.useState("start");
   const [history, setHistory] = React.useState([]);
   const node = DIALOGUE[nodeId];
@@ -54,7 +326,7 @@ function ScreenDialogue({ onNavigate, state, setState }) {
             letterSpacing: "0.22em",
             textTransform: "uppercase",
           }}>
-            Oleg's Trading Post · evening
+            {status === "ready" ? "No live parley · demo" : "Oleg's Trading Post · evening"}
           </div>
           <button onClick={reset} className="btn dark sm">↻ Restart</button>
         </div>
@@ -279,4 +551,4 @@ const DIALOGUE = {
   },
 };
 
-Object.assign(window, { ScreenDialogue, DIALOGUE });
+Object.assign(window, { ScreenDialogue, ScreenDialogueDemo, ParleyMenu, DIALOGUE });

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -1,13 +1,49 @@
-/* Screen: Inventory & Stash */
+/* Screen: Inventory & Stash.
+   Wired to the live /inventory-surface read model (each party member's pack + currency,
+   plus a flat shared-stash view). Polls every 5s while visible; falls back to the demo
+   data until the first fetch. The per-hero coin purse comes from the live currency.
+   Layout/design unchanged from the prototype. */
 
 function ScreenInventory({ onNavigate, state, setState }) {
-  const party = Array.isArray(state?.party) ? state.party : [];
-  const stash = Array.isArray(state?.stash) ? state.stash : [];
-  const [selectedItem, setSelectedItem] = React.useState(() => stash[3] || stash[0] || null);
+  const surfaceQuery = window.combatSurfaceFromCampaign
+    ? window.combatSurfaceFromCampaign(
+        (Array.isArray(state?.campaigns) ? state.campaigns : []).find((c) => c.id === state?.activeCampaign) ||
+          (Array.isArray(state?.campaigns) ? state.campaigns : [])[0] || {},
+        state,
+      )
+    : "";
+  const [surface, setSurface] = React.useState(null);
+  const party = (Array.isArray(surface?.party) && surface.party.length)
+    ? surface.party
+    : (Array.isArray(state?.party) ? state.party : []);
   const [filter, setFilter] = React.useState("all");
-  const [activeHero, setActiveHero] = React.useState(() => party[0]?.id || "");
+  const [activeHero, setActiveHero] = React.useState("");
+  const [selectedItem, setSelectedItem] = React.useState(null);
   const [ctxMenu, setCtxMenu] = React.useState(null);
   const toast = window.useToast ? window.useToast() : (() => {});
+
+  const loadSurface = React.useCallback(async (isCancelled = () => false) => {
+    try {
+      const response = await fetch("/inventory-surface" + surfaceQuery, { cache: "no-store" });
+      if (!response.ok) throw new Error(`inventory surface ${response.status}`);
+      const payload = await response.json();
+      if (!isCancelled()) setSurface(payload);
+    } catch (error) { /* keep last good / demo fallback */ }
+  }, [surfaceQuery]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let timer = null;
+    const guardedLoad = async () => { if (!cancelled) await loadSurface(() => cancelled); };
+    const stopPolling = () => { if (timer !== null) { window.clearInterval(timer); timer = null; } };
+    const startPolling = () => { if (timer === null) timer = window.setInterval(guardedLoad, 5000); };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") { guardedLoad(); startPolling(); } else { stopPolling(); }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    handleVisibility();
+    return () => { cancelled = true; stopPolling(); document.removeEventListener("visibilitychange", handleVisibility); };
+  }, [loadSurface]);
 
   const hero = party.find((p) => p.id === activeHero) || party[0] || {
     name: "Hero",
@@ -17,6 +53,24 @@ function ScreenInventory({ onNavigate, state, setState }) {
     class: "Adventurer",
     equipped: [],
   };
+  // When wired, the stash is the active hero's own pack (live surface); the prototype
+  // fallback used a global demo stash. Either way the center grid + filters are unchanged.
+  const stash = (surface && Array.isArray(hero.items)) ? hero.items
+    : (Array.isArray(surface?.stash) ? surface.stash
+      : (Array.isArray(state?.stash) ? state.stash : []));
+
+  React.useEffect(() => {
+    if (party.length && !party.some((p) => p.id === activeHero)) {
+      setActiveHero(party[0]?.id || "");
+    }
+  }, [party, activeHero]);
+
+  React.useEffect(() => {
+    if (!selectedItem || !stash.some((i) => i.id === selectedItem.id)) {
+      setSelectedItem(stash[0] || null);
+    }
+  }, [stash, selectedItem]);
+
   const filtered = filter === "all"
     ? stash
     : stash.filter((i) => i.type === filter);
@@ -29,6 +83,20 @@ function ScreenInventory({ onNavigate, state, setState }) {
         <div className="eyebrow" style={{ color: "var(--crimson)" }}>{hero.alignment}</div>
         <h2 className="h1" style={{ fontSize: 22 }}>{hero.name}</h2>
         <div className="hand" style={{ fontSize: 14, color: "var(--ink-700)" }}>Lv {hero.level} {hero.class}</div>
+
+        {/* Hero switcher — pick whose pack to view (live surface gives each their own). */}
+        {party.length > 1 && (
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 10 }}>
+            {party.map((p) => (
+              <button key={p.id} onClick={() => setActiveHero(p.id)} className="pill" style={{
+                cursor: "pointer",
+                background: activeHero === p.id ? "linear-gradient(180deg, var(--b-200), var(--b-400))" : "rgba(176,141,87,0.08)",
+                color: activeHero === p.id ? "var(--w-300)" : "var(--ink-700)",
+                boxShadow: activeHero === p.id ? "inset 0 0 0 1px var(--b-600)" : "inset 0 0 0 1px rgba(140,100,60,0.3)",
+              }}>{(p.name || "").split(" ")[0]}</button>
+            ))}
+          </div>
+        )}
 
         {/* Hero portrait + slots */}
         <div style={{ position: "relative", marginTop: 16, padding: "0 8px" }}>
@@ -77,9 +145,13 @@ function ScreenInventory({ onNavigate, state, setState }) {
 
         <div className="eyebrow" style={{ marginTop: 14 }}>Coin Purse</div>
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 6, marginTop: 6 }}>
-          <CoinSlot tone="#d4b97a" label="GP" val="232" />
-          <CoinSlot tone="#c0c0c0" label="SP" val="68" />
-          <CoinSlot tone="#b08860" label="CP" val="14" />
+          <CoinSlot tone="#e5e4e2" label="PP" val={String(hero.currency?.pp ?? 0)} />
+          <CoinSlot tone="#d4b97a" label="GP" val={String(hero.currency?.gp ?? 232)} />
+          <CoinSlot tone="#c0c0c0" label="SP" val={String(hero.currency?.sp ?? 68)} />
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginTop: 6 }}>
+          <CoinSlot tone="#b08860" label="EP" val={String(hero.currency?.ep ?? 0)} />
+          <CoinSlot tone="#8a6a45" label="CP" val={String(hero.currency?.cp ?? 14)} />
         </div>
       </Panel>
 

--- a/viewer/openworlds/screen-journal.jsx
+++ b/viewer/openworlds/screen-journal.jsx
@@ -1,9 +1,56 @@
-/* Screen: Quest Journal — handwritten chronicle / two-page spread */
+/* Screen: Quest Journal — handwritten chronicle / two-page spread.
+   Wired to the live /journal-surface read model (tracked quests + unresolved hooks as
+   rumors + the Campaign Director advisory). Polls every 5s while visible; degrades to a
+   graceful empty when there is no snapshot. Design unchanged from the prototype. */
 
 function ScreenJournal({ onNavigate, state, setState }) {
-  const quests = Array.isArray(state?.quests) ? state.quests : [];
-  const [activeQuest, setActiveQuest] = React.useState(() => quests[0]?.id || "");
+  const surfaceQuery = window.combatSurfaceFromCampaign
+    ? window.combatSurfaceFromCampaign(
+        (Array.isArray(state?.campaigns) ? state.campaigns : []).find((c) => c.id === state?.activeCampaign) ||
+          (Array.isArray(state?.campaigns) ? state.campaigns : [])[0] || {},
+        state,
+      )
+    : "";
+  const [surface, setSurface] = React.useState(null);
+  const surfaceQuests = Array.isArray(surface?.quests) ? surface.quests : null;
+  const quests = surfaceQuests || (Array.isArray(state?.quests) ? state.quests : []);
+  const advisory = surface?.directorAdvisory || { debts: [], total_debts: 0 };
+  const [activeQuest, setActiveQuest] = React.useState("");
   const [tab, setTab] = React.useState("active");
+
+  const loadSurface = React.useCallback(async (isCancelled = () => false) => {
+    try {
+      const response = await fetch("/journal-surface" + surfaceQuery, { cache: "no-store" });
+      if (!response.ok) throw new Error(`journal surface ${response.status}`);
+      const payload = await response.json();
+      if (isCancelled()) return;
+      setSurface(payload);
+    } catch (error) {
+      if (isCancelled()) return;
+      /* keep last good surface; the demo fallback shows until first success */
+    }
+  }, [surfaceQuery]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let timer = null;
+    const guardedLoad = async () => { if (!cancelled) await loadSurface(() => cancelled); };
+    const stopPolling = () => { if (timer !== null) { window.clearInterval(timer); timer = null; } };
+    const startPolling = () => { if (timer === null) timer = window.setInterval(guardedLoad, 5000); };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") { guardedLoad(); startPolling(); } else { stopPolling(); }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    handleVisibility();
+    return () => { cancelled = true; stopPolling(); document.removeEventListener("visibilitychange", handleVisibility); };
+  }, [loadSurface]);
+
+  React.useEffect(() => {
+    if (quests.length && !quests.some((q) => q.id === activeQuest)) {
+      setActiveQuest(quests[0]?.id || "");
+    }
+  }, [quests, activeQuest]);
+
   const quest = quests.find((q) => q.id === activeQuest) || quests[0] || {
     label: "Empty",
     title: "No quest selected",
@@ -58,7 +105,36 @@ function ScreenJournal({ onNavigate, state, setState }) {
               <div className="hand" style={{ fontSize: 13, color: "var(--ink-600)", marginTop: 4 }}>{q.objective}</div>
             </button>
           ))}
+          {!quests.filter((q) => (tab === "active" ? q.status === "active" : tab === "complete" ? q.status === "complete" : q.status === "rumor")).length && (
+            <div className="body-sm muted" style={{ padding: "8px 4px" }}>
+              {tab === "active" ? "No active quests in the chronicle yet." : tab === "complete" ? "Nothing has been resolved or failed yet." : "No rumors or untracked hooks."}
+            </div>
+          )}
         </div>
+
+        {/* GM Advisory — Campaign Director (#72): structural debts the campaign owes. */}
+        {Array.isArray(advisory.debts) && advisory.debts.length > 0 && (
+          <div style={{ marginTop: 12, paddingTop: 12, borderTop: "1px dashed rgba(80,50,20,0.3)" }}>
+            <div className="eyebrow" style={{ color: "var(--crimson)", marginBottom: 6 }}>
+              GM Advisory{advisory.total_debts ? ` · ${advisory.total_debts}` : ""}
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              {advisory.debts.map((d) => (
+                <div key={d.id} style={{
+                  padding: "7px 9px",
+                  background: "rgba(176,141,87,0.06)",
+                  boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25), inset 3px 0 0 " +
+                    (d.severity === "high" ? "var(--crimson)" : d.severity === "low" ? "var(--b-400)" : "var(--royal)"),
+                }}>
+                  <div className="eyebrow" style={{ fontSize: 8, color: "var(--ink-600)" }}>
+                    {(d.kind || "debt").replace(/_/g, " ")}
+                  </div>
+                  <div className="hand" style={{ fontSize: 12, color: "var(--ink-700)", marginTop: 2 }}>{d.nudge}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </Panel>
 
       {/* RIGHT — Two-page spread */}

--- a/viewer/openworlds/screen-relations.jsx
+++ b/viewer/openworlds/screen-relations.jsx
@@ -1,8 +1,50 @@
-/* Screen: Relations — factions (left) + NPCs (right) */
+/* Screen: Relations — factions (left) + NPCs (right).
+   Wired to the live /relations-surface read model (factions with reputation/tags, met
+   NPCs + companions with attitude + dossier banter/relationships, companion arcs). Polls
+   every 5s while visible; falls back to the demo constants until the first fetch.
+   Layout/design unchanged from the prototype. */
 
 function ScreenRelations({ onNavigate, state, setState }) {
-  const [selectedFaction, setSelectedFaction] = React.useState(FACTIONS[0]);
-  const [selectedNPC, setSelectedNPC] = React.useState(NPCS[0]);
+  const surfaceQuery = window.combatSurfaceFromCampaign
+    ? window.combatSurfaceFromCampaign(
+        (Array.isArray(state?.campaigns) ? state.campaigns : []).find((c) => c.id === state?.activeCampaign) ||
+          (Array.isArray(state?.campaigns) ? state.campaigns : [])[0] || {},
+        state,
+      )
+    : "";
+  const [surface, setSurface] = React.useState(null);
+  const factions = (Array.isArray(surface?.factions) && surface.factions.length) ? surface.factions : FACTIONS;
+  const npcs = (Array.isArray(surface?.npcs) && surface.npcs.length) ? surface.npcs
+    : (surface ? [] : NPCS);
+  const [selectedFactionId, setSelectedFactionId] = React.useState("");
+  const [selectedNPCId, setSelectedNPCId] = React.useState("");
+  const selectedFaction = factions.find((f) => f.id === selectedFactionId) || factions[0] || FACTIONS[0];
+  const selectedNPC = npcs.find((n) => n.id === selectedNPCId) || npcs[0] || null;
+  const setSelectedFaction = (f) => setSelectedFactionId(f.id);
+  const setSelectedNPC = (n) => setSelectedNPCId(n.id);
+
+  const loadSurface = React.useCallback(async (isCancelled = () => false) => {
+    try {
+      const response = await fetch("/relations-surface" + surfaceQuery, { cache: "no-store" });
+      if (!response.ok) throw new Error(`relations surface ${response.status}`);
+      const payload = await response.json();
+      if (!isCancelled()) setSurface(payload);
+    } catch (error) { /* keep last good / demo fallback */ }
+  }, [surfaceQuery]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    let timer = null;
+    const guardedLoad = async () => { if (!cancelled) await loadSurface(() => cancelled); };
+    const stopPolling = () => { if (timer !== null) { window.clearInterval(timer); timer = null; } };
+    const startPolling = () => { if (timer === null) timer = window.setInterval(guardedLoad, 5000); };
+    const handleVisibility = () => {
+      if (document.visibilityState === "visible") { guardedLoad(); startPolling(); } else { stopPolling(); }
+    };
+    document.addEventListener("visibilitychange", handleVisibility);
+    handleVisibility();
+    return () => { cancelled = true; stopPolling(); document.removeEventListener("visibilitychange", handleVisibility); };
+  }, [loadSurface]);
 
   return (
     <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14, padding: 14, minHeight: 0 }}>
@@ -14,19 +56,19 @@ function ScreenRelations({ onNavigate, state, setState }) {
             <div className="eyebrow" style={{ color: "var(--crimson)" }}>The Powers That</div>
             <h1 className="h1" style={{ fontSize: 22 }}>Factions</h1>
           </div>
-          <span className="muted body-sm">{FACTIONS.length} known</span>
+          <span className="muted body-sm">{factions.length} known</span>
         </div>
 
         <div style={{ display: "grid", gridTemplateColumns: "200px 1fr", gap: 14, flex: 1, minHeight: 0 }}>
           {/* Faction list with banner colors */}
           <div style={{ overflow: "auto", display: "flex", flexDirection: "column", gap: 6 }}>
-            {FACTIONS.map((f) => (
+            {factions.map((f) => (
               <button key={f.id} onClick={() => setSelectedFaction(f)} style={{
                 position: "relative",
                 padding: "10px 12px",
                 textAlign: "left",
-                background: selectedFaction.id === f.id ? "linear-gradient(180deg, var(--p-100), var(--p-200))" : "rgba(176,141,87,0.06)",
-                boxShadow: selectedFaction.id === f.id
+                background: selectedFaction?.id === f.id ? "linear-gradient(180deg, var(--p-100), var(--p-200))" : "rgba(176,141,87,0.06)",
+                boxShadow: selectedFaction?.id === f.id
                   ? "inset 0 0 0 1px var(--b-500), inset 4px 0 0 " + f.color + ", inset 0 0 0 3px var(--p-100), inset 0 0 0 4px var(--b-400)"
                   : "inset 0 0 0 1px rgba(140,100,60,0.25), inset 4px 0 0 " + f.color,
                 cursor: "pointer",
@@ -38,11 +80,12 @@ function ScreenRelations({ onNavigate, state, setState }) {
                 <RepBar value={f.rep} max={100} threshold={f.threshold} />
               </button>
             ))}
+            {!factions.length && <div className="body-sm muted">No factions recorded yet.</div>}
           </div>
 
           {/* Faction detail */}
           <div style={{ overflow: "auto", display: "flex", flexDirection: "column" }}>
-            <FactionDetail f={selectedFaction} />
+            {selectedFaction ? <FactionDetail f={selectedFaction} /> : <div className="body-sm muted">No faction selected.</div>}
           </div>
         </div>
       </Panel>
@@ -54,18 +97,18 @@ function ScreenRelations({ onNavigate, state, setState }) {
             <div className="eyebrow" style={{ color: "var(--crimson)" }}>The Persons We</div>
             <h1 className="h1" style={{ fontSize: 22 }}>Know</h1>
           </div>
-          <span className="muted body-sm">{NPCS.length} acquainted</span>
+          <span className="muted body-sm">{npcs.length} acquainted</span>
         </div>
 
         <div style={{ display: "grid", gridTemplateColumns: "180px 1fr", gap: 14, flex: 1, minHeight: 0 }}>
           <div style={{ overflow: "auto", display: "flex", flexDirection: "column", gap: 6 }}>
-            {NPCS.map((n) => (
+            {npcs.map((n) => (
               <button key={n.id} onClick={() => setSelectedNPC(n)} style={{
                 display: "grid", gridTemplateColumns: "44px 1fr", gap: 8, alignItems: "center",
                 padding: "6px 10px",
                 textAlign: "left",
-                background: selectedNPC.id === n.id ? "linear-gradient(180deg, var(--p-100), var(--p-200))" : "rgba(176,141,87,0.06)",
-                boxShadow: selectedNPC.id === n.id
+                background: selectedNPC?.id === n.id ? "linear-gradient(180deg, var(--p-100), var(--p-200))" : "rgba(176,141,87,0.06)",
+                boxShadow: selectedNPC?.id === n.id
                   ? "inset 0 0 0 1px var(--b-500), inset 0 0 0 3px var(--p-100), inset 0 0 0 4px var(--b-400)"
                   : "inset 0 0 0 1px rgba(140,100,60,0.25)",
                 cursor: "pointer",
@@ -80,10 +123,11 @@ function ScreenRelations({ onNavigate, state, setState }) {
                 </div>
               </button>
             ))}
+            {!npcs.length && <div className="body-sm muted">No one met yet. NPCs appear here once the party speaks with them.</div>}
           </div>
 
           <div style={{ overflow: "auto" }}>
-            <NPCDetail n={selectedNPC} onNavigate={onNavigate} />
+            {selectedNPC ? <NPCDetail n={selectedNPC} onNavigate={onNavigate} /> : <div className="body-sm muted">No acquaintance selected.</div>}
           </div>
         </div>
       </Panel>
@@ -225,11 +269,43 @@ function NPCDetail({ n, onNavigate }) {
 
       <p className="body dropcap" style={{ marginTop: 0, fontSize: 14 }}>{n.body}</p>
 
+      {/* Companion dossier (#68): approval gauge + banter themes + standing ties. */}
+      {n.companion && (
+        <>
+          <Divider />
+          {typeof n.approval === "number" && (
+            <div style={{ marginBottom: 10 }}>
+              <div style={{ display: "flex", justifyContent: "space-between" }}>
+                <span className="eyebrow">Approval</span>
+                <span style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-600)" }}>{n.approval > 0 ? "+" : ""}{n.approval}</span>
+              </div>
+              <div style={{ height: 5, marginTop: 3, background: "rgba(0,0,0,0.15)", position: "relative", boxShadow: "inset 0 0 0 1px rgba(80,50,20,0.4)" }}>
+                <div style={{ position: "absolute", inset: 0, right: `${(1 - Math.max(0, Math.min(100, (n.approval + 100) / 2)) / 100) * 100}%`, background: "linear-gradient(180deg, var(--emerald), #2a6a30)" }} />
+              </div>
+            </div>
+          )}
+          {Array.isArray(n.banter_tags) && n.banter_tags.length > 0 && (
+            <div style={{ marginBottom: 8 }}>
+              <div className="eyebrow" style={{ marginBottom: 4 }}>Banter</div>
+              <div className="tag-row">{n.banter_tags.map((t) => <Pill key={t}>{t}</Pill>)}</div>
+            </div>
+          )}
+          {n.relationships && Object.keys(n.relationships).length > 0 && (
+            <div>
+              <div className="eyebrow" style={{ marginBottom: 4 }}>Ties</div>
+              {Object.entries(n.relationships).map(([who, tie]) => (
+                <div key={who} className="hand muted" style={{ fontSize: 12 }}>{who}: {tie}</div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
       <Divider />
 
-      <SectionTitle>What stands between you</SectionTitle>
+      <SectionTitle>{n.companion ? "What they remember" : "What stands between you"}</SectionTitle>
       <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-        {n.dues.map((d, i) => (
+        {(n.dues || []).map((d, i) => (
           <div key={i} style={{
             padding: "8px 10px",
             background: d.fulfilled ? "rgba(95, 130, 70, 0.08)" : "rgba(176,141,87,0.06)",
@@ -245,6 +321,7 @@ function NPCDetail({ n, onNavigate }) {
             </div>
           </div>
         ))}
+        {!(n.dues || []).length && <div className="body-sm muted">Nothing recorded between you yet.</div>}
       </div>
 
       {n.lastSpoken && (

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -8,6 +8,7 @@ function ScreenTable({ onNavigate, state, setState }) {
     {};
   const campaignId = activeCampaign.campaign_id || state?.activeCampaign || activeCampaign.id || "";
   const [surface, setSurface] = React.useState(null);
+  const [advisory, setAdvisory] = React.useState(null);
   const [surfaceStatus, setSurfaceStatus] = React.useState("loading");
   const demoLog = Array.isArray(state?.tableLog) ? state.tableLog : [];
   const [log, setLog] = React.useState([]);
@@ -50,6 +51,15 @@ function ScreenTable({ onNavigate, state, setState }) {
       if (isCancelled()) return;
       setSurfaceStatus(error?.message || "unavailable");
     }
+    // GM Advisory (Campaign Director #72): a separate, best-effort fetch so a journal
+    // hiccup never blocks the table. Surfaces the top structural debt during play.
+    try {
+      const advResp = await fetch(`/journal-surface${query}`, { cache: "no-store" });
+      if (advResp.ok) {
+        const advPayload = await advResp.json();
+        if (!isCancelled()) setAdvisory(advPayload?.directorAdvisory || null);
+      }
+    } catch (error) { /* advisory is non-critical; keep last good */ }
   }, [campaignId, activeCampaign.source, activeCampaign.runId]);
 
   React.useEffect(() => {
@@ -255,6 +265,29 @@ function ScreenTable({ onNavigate, state, setState }) {
 
       {/* RIGHT — Quests + Quick stash + GM tools */}
       <div style={{ display: "flex", flexDirection: "column", gap: 10, minHeight: 0 }}>
+        {advisory && Array.isArray(advisory.debts) && advisory.debts.length > 0 && (
+          <Panel framed style={{ padding: 18 }}>
+            <SectionTitle right={advisory.total_debts ? <Pill tone="crimson">{advisory.total_debts}</Pill> : null}>GM Advisory</SectionTitle>
+            <div className="body-sm muted" style={{ marginBottom: 8 }}>What the campaign owes the story.</div>
+            <div style={{
+              padding: "10px 12px",
+              background: "rgba(176,141,87,0.08)",
+              boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.3), inset 3px 0 0 " +
+                (advisory.debts[0].severity === "high" ? "var(--crimson)" : advisory.debts[0].severity === "low" ? "var(--b-400)" : "var(--royal)"),
+            }}>
+              <div className="eyebrow" style={{ fontSize: 9, color: "var(--crimson)" }}>
+                {(advisory.debts[0].kind || "debt").replace(/_/g, " ")}
+              </div>
+              <div className="hand" style={{ fontSize: 13, color: "var(--ink-700)", marginTop: 3 }}>
+                {advisory.debts[0].nudge}
+              </div>
+            </div>
+            <div style={{ marginTop: 10, display: "flex", justifyContent: "flex-end" }}>
+              <button className="btn ghost sm" onClick={() => onNavigate("journal")}>Open chronicle</button>
+            </div>
+          </Panel>
+        )}
+
         <Panel framed style={{ padding: 18 }}>
           <SectionTitle>Active Quests</SectionTitle>
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1650,6 +1650,885 @@ def build_atlas_surface(
     }
 
 
+# ── Campaign Director advisory (issue #72) ────────────────────────────────────
+# The viewer is a downstream reader. To surface the Campaign Director's structural
+# debts (journal "GM Advisory" + the table widget) we PREFER the engine's own pure
+# detectors (scene_debt.detect + director.compute) by building a Campaign model from
+# the resolved snapshot — this gives the exact same ranked top-3 the DM's
+# get_campaign_director tool returns, for ANY snapshot the viewer projects (play store
+# OR a QA/catalog run). If the engine/pydantic isn't importable we degrade to a
+# snapshot-only heuristic covering the cheap, structural debt kinds. Read-only: it
+# detects + advises off in-memory facts, never mutating fiction or the snapshot.
+
+def _director_advisory(snapshot: dict, *, limit: int = 3) -> dict:
+    """Return ``{"debts": [...], "advisory": [...], "total_debts": int, "source": str}``
+    for a snapshot. Each debt row is ``{id, kind, subject, detail, severity, nudge}``.
+    Empty debts == no structural debts (or no snapshot)."""
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    if not snapshot:
+        return {"debts": [], "advisory": [], "total_debts": 0, "source": "empty"}
+    engine = _load_engine_server()
+    if engine is not None:
+        try:
+            import models as _models  # the engine dir is on sys.path after _load_engine_server
+            import scene_debt as _sd
+            import director as _director
+
+            campaign = _models.Campaign.model_validate(snapshot)
+            ranked = _director.compute(campaign)  # already top-3, highest severity first
+            all_live = _sd.detect(campaign)
+            rows: list[dict] = []
+            for debt, nudge in zip(ranked.get("debts", []), ranked.get("advisory", [])):
+                if not isinstance(debt, dict):
+                    continue
+                rows.append({
+                    "id": _text(debt.get("id")),
+                    "kind": _text(debt.get("kind")),
+                    "subject": _text(debt.get("subject")),
+                    "detail": _text(debt.get("detail")),
+                    "severity": _text(debt.get("severity"), "med"),
+                    "nudge": _text(nudge),
+                })
+            return {
+                "debts": rows[:limit],
+                "advisory": [r["nudge"] for r in rows[:limit]],
+                "total_debts": int(ranked.get("total_debts", len(all_live))),
+                "source": "engine.director",
+            }
+        except Exception:
+            pass  # fall through to the snapshot-only heuristic
+    return _director_advisory_heuristic(snapshot, limit=limit)
+
+
+_SEV_RANK = {"high": 0, "med": 1, "low": 2}
+
+
+def _director_advisory_heuristic(snapshot: dict, *, limit: int = 3) -> dict:
+    """Snapshot-only fallback for the Campaign Director (no engine/pydantic). Detects the
+    cheap, purely-structural debt kinds the DM advisory cares about from raw snapshot
+    facts: engaged-but-untracked hooks, overdue authored consequences, and active quests
+    with no recent decision callback. Ranked high→med→low to mirror director.compute."""
+    quests = snapshot.get("quests") if isinstance(snapshot.get("quests"), dict) else {}
+    hooks = snapshot.get("quest_hooks") if isinstance(snapshot.get("quest_hooks"), list) else []
+    consequences = snapshot.get("consequences") if isinstance(snapshot.get("consequences"), list) else []
+    decisions = snapshot.get("decisions") if isinstance(snapshot.get("decisions"), list) else []
+    day = snapshot.get("day") if isinstance(snapshot.get("day"), int) else 1
+
+    def _decision_text() -> str:
+        out: list[str] = []
+        for d in decisions:
+            if isinstance(d, dict):
+                out.append(" ".join(_text(d.get(k)) for k in ("summary", "rationale", "chosen")))
+                opts = d.get("options")
+                if isinstance(opts, list):
+                    out.append(" ".join(_text(o) for o in opts))
+        return " ".join(out).lower()
+
+    blob = _decision_text()
+    rows: list[dict] = []
+
+    # hook_untracked: a hook marked active (player bit) with no tracked quest referencing it.
+    quest_titles = [_text(q.get("title")).lower() for q in quests.values() if isinstance(q, dict)]
+    quest_blob = " ".join(filter(None, [*quest_titles, *quests.keys()])).lower()
+    for h in hooks:
+        if not isinstance(h, dict):
+            continue
+        status = _text(h.get("status"), "open").lower()
+        if status == "resolved":
+            continue
+        hid = _text(h.get("id"))
+        htitle = _text(h.get("title"))
+        engaged = status == "active" or (hid and hid.lower() in blob) or (htitle and htitle.lower() in blob)
+        tracked = (hid and hid.lower() in quest_blob) or (htitle and htitle.lower() in quest_blob)
+        if engaged and not tracked:
+            label = htitle or hid or "this hook"
+            rows.append({
+                "id": f"hook:{hid}", "kind": "hook_untracked", "subject": hid,
+                "detail": f"Hook '{label}' is active but has no tracked Quest.",
+                "severity": "high",
+                "nudge": f"Untracked hook '{label}' — call add_quest to promote it into a tracked quest.",
+            })
+
+    # due_consequence: an authored (non-thread) consequence past its trigger day, not fired.
+    for con in consequences:
+        if not isinstance(con, dict) or _text(con.get("thread_id")) or bool(con.get("fired")):
+            continue
+        trigger = con.get("trigger_day")
+        if isinstance(trigger, int) and trigger <= day:
+            overdue = day - trigger
+            note = _text(con.get("note") or con.get("text"))
+            rows.append({
+                "id": f"con:{_text(con.get('id'))}", "kind": "due_consequence", "subject": _text(con.get("id")),
+                "detail": f"Consequence is due ({overdue}d overdue).",
+                "severity": "high" if overdue >= 2 else "med",
+                "nudge": f"Consequence due ({overdue}d overdue) — call check_consequences: '{note[:60]}'." if overdue else f"Consequence is due — call check_consequences: '{note[:60]}'.",
+            })
+
+    # quest_stalled: active quest with no decision callback (campaign must be past day 5).
+    if day > 5:
+        for qid, q in quests.items():
+            if not isinstance(q, dict) or _text(q.get("status"), "active").lower() != "active":
+                continue
+            title = _text(q.get("title"))
+            if (qid.lower() in blob) or (title and title.lower() in blob):
+                continue
+            rows.append({
+                "id": f"quest:{qid}", "kind": "quest_stalled", "subject": _text(qid),
+                "detail": f"Quest '{title or qid}' has no story callback recently.",
+                "severity": "med",
+                "nudge": f"Quest '{title or qid}' has stalled — weave an advancement beat to move it forward.",
+            })
+
+    rows.sort(key=lambda r: _SEV_RANK.get(r["severity"], 9))
+    return {
+        "debts": rows[:limit],
+        "advisory": [r["nudge"] for r in rows[:limit]],
+        "total_debts": len(rows),
+        "source": "viewer.heuristic",
+    }
+
+
+def _journal_quests(snapshot: dict) -> list[dict]:
+    """Project every quest into the journal's shape (id/title/label/tone/status/objective +
+    a checklist of objectives with done flags + entries). Status is normalized to the
+    journal's tabs: active / complete / rumor (a hook-less, open-only state)."""
+    quests = snapshot.get("quests")
+    locs = snapshot.get("locations")
+    out: list[dict] = []
+    if not isinstance(quests, dict):
+        return out
+    for qid, row in quests.items():
+        if not isinstance(row, dict):
+            continue
+        raw_status = _text(row.get("status"), "active").lower()
+        if raw_status in {"completed", "complete", "resolved"}:
+            status, label, tone = "complete", "Resolved", "emerald"
+        elif raw_status in {"failed"}:
+            status, label, tone = "complete", "Failed", "crimson"
+        else:
+            status, label, tone = "active", "Active", "crimson"
+        objectives_raw = row.get("objectives")
+        completed = row.get("completed_objectives")
+        completed_set = {str(o) for o in completed} if isinstance(completed, list) else set()
+        objectives: list[dict] = []
+        next_objective = ""
+        if isinstance(objectives_raw, list):
+            for item in objectives_raw:
+                text = _text(item)
+                if not text:
+                    continue
+                done = text in completed_set
+                objectives.append({"text": text, "done": done})
+                if not done and not next_objective:
+                    next_objective = text
+        if not next_objective:
+            next_objective = _text(row.get("description"), "Continue the investigation.")
+        location_id = _text(row.get("location_id"))
+        region = ""
+        if isinstance(locs, dict) and location_id:
+            loc = locs.get(location_id)
+            if isinstance(loc, dict):
+                region = _text(loc.get("region")) or _text(loc.get("name"), location_id)
+        out.append({
+            "id": _text(qid),
+            "title": _text(row.get("title"), _text(qid, "Quest")),
+            "label": label,
+            "tone": tone,
+            "status": status,
+            "region": region,
+            "objective": next_objective,
+            "entry": _text(row.get("description"), "No chronicle entry has been recorded for this quest yet."),
+            "objectives": objectives,
+            "entries": [],
+            "location_id": location_id,
+        })
+    return out
+
+
+def _journal_hooks(snapshot: dict) -> list[dict]:
+    """Project unresolved quest_hooks as journal 'rumors' (the lore-derived seeds the DM
+    hasn't promoted yet). Spine hooks are flagged; resolved ones are dropped."""
+    hooks = snapshot.get("quest_hooks")
+    out: list[dict] = []
+    if not isinstance(hooks, list):
+        return out
+    for h in hooks:
+        if not isinstance(h, dict):
+            continue
+        status = _text(h.get("status"), "open").lower()
+        if status == "resolved":
+            continue
+        title = _text(h.get("title")) or _text(h.get("grievance")) or _text(h.get("id"), "A rumor")
+        out.append({
+            "id": _text(h.get("id"), title),
+            "title": title,
+            "label": "Spine" if bool(h.get("spine")) else "Rumor",
+            "tone": "royal" if bool(h.get("spine")) else "",
+            "status": "rumor",
+            "spine": bool(h.get("spine")),
+            "objective": _text(h.get("note")) or _text(h.get("arc_back")) or "An unverified thread the party has not yet pulled.",
+            "entry": _text(h.get("note"), "Heard third-hand. The accounts vary."),
+            "objectives": [],
+            "entries": [],
+        })
+    return out
+
+
+def build_journal_surface(
+    snapshot: dict,
+    *,
+    campaign_id: str,
+    live: bool,
+    is_live_view: bool,
+) -> dict:
+    """Project a browser-safe OpenWorlds quest journal from engine-owned state: every
+    tracked quest (active/complete), unresolved hooks as rumors, and the Campaign
+    Director's top structural debts (issue #72) as a GM advisory."""
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    quests = _journal_quests(snapshot) + _journal_hooks(snapshot)
+    advisory = _director_advisory(snapshot)
+    return {
+        "campaign_id": campaign_id,
+        "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
+        "world": _text(snapshot.get("world_id"), "unknown"),
+        "dayLabel": _openworlds_day_label(snapshot),
+        "quests": quests,
+        "directorAdvisory": advisory,
+        "live": bool(live),
+        "is_live_view": bool(is_live_view),
+        "can_act": bool(live and is_live_view),
+        "state_authority": "engine",
+        "write_lane": "/move",
+    }
+
+
+# ── Character sheets surface (full party read model) ──────────────────────────
+
+def _ability_mod(score: object) -> int:
+    s = _num(score)
+    return ((int(s) - 10) // 2) if s is not None else 0
+
+
+def _skill_bonus_from_sheet(ch: dict, skill: str) -> int:
+    """Mirror Character.skill_bonus off raw snapshot fields: ability modifier of the
+    skill's governing ability + proficiency (doubled on expertise)."""
+    ability = _SKILL_ABILITIES.get(skill)
+    if ability is None:
+        return 0
+    abilities = ch.get("abilities") if isinstance(ch.get("abilities"), dict) else {}
+    bonus = _ability_mod(abilities.get(ability))
+    prof = _num(ch.get("proficiency_bonus"))
+    prof = int(prof) if prof is not None else 2
+    expertise = ch.get("skill_expertise") if isinstance(ch.get("skill_expertise"), list) else []
+    proficiencies = ch.get("skill_proficiencies") if isinstance(ch.get("skill_proficiencies"), list) else []
+    if skill in expertise:
+        bonus += 2 * prof
+    elif skill in proficiencies:
+        bonus += prof
+    return bonus
+
+
+# Skill -> governing ability key (SRD 5.2), mirroring models.SKILL_ABILITIES.
+_SKILL_ABILITIES = {
+    "acrobatics": "dexterity", "animal_handling": "wisdom", "arcana": "intelligence",
+    "athletics": "strength", "deception": "charisma", "history": "intelligence",
+    "insight": "wisdom", "intimidation": "charisma", "investigation": "intelligence",
+    "medicine": "wisdom", "nature": "intelligence", "perception": "wisdom",
+    "performance": "charisma", "persuasion": "charisma", "religion": "intelligence",
+    "sleight_of_hand": "dexterity", "stealth": "dexterity", "survival": "wisdom",
+}
+
+_ABILITY_KEYS = ("strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma")
+
+
+def _character_sheet(cid: str, ch: dict) -> dict:
+    """One party character's full sheet for the heroes screen, mapping 5e snapshot fields
+    into the shape screen-character.jsx renders (stats block, skills, spells, class
+    resources, conditions, death saves). Pathfinder-only cells (touch/flat/CMB) are
+    derived sensibly from 5e data so the existing layout still reads."""
+    klass, level = _class_summary(ch)
+    abilities = ch.get("abilities") if isinstance(ch.get("abilities"), dict) else {}
+    stats = {k[:3]: (_num(abilities.get(k)) if _num(abilities.get(k)) is not None else 10) for k in _ABILITY_KEYS}
+    ac = _num(ch.get("armor_class"))
+    ac = int(ac) if ac is not None else 10
+    dex_mod = _ability_mod(abilities.get("dexterity"))
+    prof = _num(ch.get("proficiency_bonus"))
+    prof = int(prof) if prof is not None else 2
+    init_bonus = _num(ch.get("initiative_bonus"))
+    speed = _num(ch.get("speed"))
+    cur_hp = _num(ch.get("current_hp"))
+    max_hp = _num(ch.get("max_hp"))
+    # Saving throws: ability mod (+ proficiency for proficient abilities). The engine stores
+    # saving_throw_proficiencies as the SRD short ability codes (str/dex/con/int/wis/cha),
+    # so match on the 3-letter prefix of the full name as well as the full name itself.
+    save_profs = {str(s).strip().lower() for s in (ch.get("saving_throw_proficiencies") or [])}
+    def _save(ability: str) -> int:
+        b = _ability_mod(abilities.get(ability))
+        proficient = ability in save_profs or ability[:3] in save_profs
+        return b + prof if proficient else b
+    stats.update({
+        "ac": ac,
+        "flat": ac - dex_mod if dex_mod else ac,  # 5e has no flat-footed; show AC minus DEX as a proxy
+        "touch": 10 + dex_mod,
+        "fort": _save("constitution"),
+        "reflex": _save("dexterity"),
+        "will": _save("wisdom"),
+        "bab": prof,
+        "melee": prof + _ability_mod(abilities.get("strength")),
+        "ranged": prof + dex_mod,
+        "cmb": prof + _ability_mod(abilities.get("strength")),
+        "cmd": 10 + prof + _ability_mod(abilities.get("strength")) + dex_mod,
+        "initiative": int(init_bonus) if init_bonus is not None else dex_mod,
+        "speed": int(speed) if speed is not None else 30,
+    })
+
+    # Skills: project the SRD skill list with sheet-correct bonuses (proficient first).
+    proficiencies = ch.get("skill_proficiencies") if isinstance(ch.get("skill_proficiencies"), list) else []
+    expertise = ch.get("skill_expertise") if isinstance(ch.get("skill_expertise"), list) else []
+    skill_ids = list(dict.fromkeys([*proficiencies, *expertise, *_SKILL_ABILITIES.keys()]))
+    skills = [
+        {"name": sk.replace("_", " ").title(), "mod": _skill_bonus_from_sheet(ch, sk),
+         "proficient": sk in proficiencies or sk in expertise, "expertise": sk in expertise}
+        for sk in skill_ids if sk in _SKILL_ABILITIES
+    ]
+
+    # Spells: group known/prepared by inferred level using spell_slots presence; the
+    # snapshot stores spell names (not full blocks), so group everything as a flat list
+    # the SpellsTab renders ("Known" group).
+    spells_known = [s for s in (ch.get("spells_known") or []) if isinstance(s, str)]
+    spells_prepared = set(s for s in (ch.get("spells_prepared") or []) if isinstance(s, str))
+    spells = []
+    if spells_known:
+        spells.append({
+            "level": "Known",
+            "list": [
+                {"name": s, "school": "—", "time": "prepared" if s in spells_prepared else "known", "glyph": "spell"}
+                for s in spells_known
+            ],
+        })
+
+    # Class resources (Rage/Ki/etc.) — depletable pools the sheet can show as features.
+    class_resources = []
+    cr = ch.get("class_resources")
+    if isinstance(cr, dict):
+        for rid, pool in cr.items():
+            if not isinstance(pool, dict):
+                continue
+            mx = _num(pool.get("max"))
+            used = _num(pool.get("used"))
+            class_resources.append({
+                "id": _text(rid),
+                "name": _text(rid).replace("_", " ").title(),
+                "max": int(mx) if mx is not None else 0,
+                "used": int(used) if used is not None else 0,
+                "remaining": (int(mx) - int(used)) if (mx is not None and used is not None) else None,
+                "recharge": _text(pool.get("recharge"), "long"),
+            })
+
+    conditions = [str(c).replace("_", " ").title() for c in (ch.get("conditions") or []) if str(c)]
+    death = ch.get("death_saves") if isinstance(ch.get("death_saves"), dict) else {}
+    features = [_text(f) for f in (ch.get("features") or []) if _text(f)]
+    equipped = [
+        {"slot": _text(it.get("slot"), "Worn"), "name": _text(it.get("name")), "glyph": _text(it.get("name"), "item").lower()}
+        for it in (ch.get("inventory") or []) if isinstance(it, dict) and bool(it.get("equipped")) and _text(it.get("name"))
+    ]
+
+    return {
+        "id": cid,
+        "name": _text(ch.get("name"), cid),
+        "short": "portrait",
+        "race": _text(ch.get("race")),
+        "class": klass,
+        "archetype": _text((ch.get("classes") or [{}])[0].get("subclass") if isinstance(ch.get("classes"), list) and ch.get("classes") else "") or _text(ch.get("background")),
+        "alignment": _text(ch.get("alignment"), "Unaligned"),
+        "level": level or 1,
+        "xp": int(_num(ch.get("xp")) or 0),
+        "xpMax": _xp_for_next_level(level or 1),
+        "hp": int(cur_hp) if cur_hp is not None else 1,
+        "hpMax": int(max_hp) if max_hp is not None else 1,
+        "tempHp": int(_num(ch.get("temp_hp")) or 0),
+        "stats": stats,
+        "skills": skills,
+        "spells": spells,
+        "classResources": class_resources,
+        "conditions": conditions,
+        "exhaustion": int(_num(ch.get("exhaustion")) or 0),
+        "concentration": _text(ch.get("concentration")),
+        "deathSaves": {
+            "successes": int(_num(death.get("successes")) or 0),
+            "failures": int(_num(death.get("failures")) or 0),
+        },
+        "dead": bool(ch.get("dead")),
+        "stable": bool(ch.get("stable")),
+        "equipped": equipped,
+        "feats": [{"name": f, "glyph": "feat", "detail": ""} for f in features],
+        "abilities": [],
+        "proficiencies": features,
+        "classFeatures": [{"name": f, "detail": ""} for f in features],
+        "traits": [],
+        "dr": {"value": ", ".join(_text(x) for x in (ch.get("damage_resistances") or []) if _text(x)) or "None",
+               "energy": ", ".join(_text(x) for x in (ch.get("damage_immunities") or []) if _text(x)) or "None"},
+        "lineage": _text(ch.get("backstory")) or _text(ch.get("personality")) or "No lineage recorded.",
+    }
+
+
+# SRD 5e XP thresholds per level (index 0 unused); used to fill the heroes screen XP bar.
+_XP_THRESHOLDS = [0, 0, 300, 900, 2700, 6500, 14000, 23000, 34000, 48000, 64000, 85000,
+                  100000, 120000, 140000, 165000, 195000, 225000, 265000, 305000, 355000]
+
+
+def _xp_for_next_level(level: int) -> int:
+    if level < 1:
+        return 300
+    if level >= len(_XP_THRESHOLDS) - 1:
+        return _XP_THRESHOLDS[-1]
+    return _XP_THRESHOLDS[level + 1]
+
+
+def _character_party(snapshot: dict) -> list[dict]:
+    chars = snapshot.get("characters")
+    party = snapshot.get("party")
+    if not isinstance(chars, dict) or not isinstance(party, list):
+        return []
+    out: list[dict] = []
+    for cid in party:
+        if not isinstance(cid, str):
+            continue
+        ch = chars.get(cid)
+        if isinstance(ch, dict):
+            out.append(_character_sheet(cid, ch))
+    return out
+
+
+def build_character_surface(
+    snapshot: dict,
+    *,
+    campaign_id: str,
+    live: bool,
+    is_live_view: bool,
+) -> dict:
+    """Project the full party's character sheets from engine-owned state for the heroes
+    screen. Each hero carries classes/skills/spells/class_resources/conditions/AC/death
+    saves projected from the 5e snapshot into the screen's render shape."""
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    return {
+        "campaign_id": campaign_id,
+        "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
+        "dayLabel": _openworlds_day_label(snapshot),
+        "party": _character_party(snapshot),
+        "live": bool(live),
+        "is_live_view": bool(is_live_view),
+        "can_act": bool(live and is_live_view),
+        "state_authority": "engine",
+        "write_lane": "/move",
+    }
+
+
+# ── Inventory surface (per-character packs + currency) ────────────────────────
+
+_ITEM_TYPE_HINTS = (
+    (("longsword", "sword", "axe", "bow", "dagger", "mace", "spear", "rapier", "blade", "hammer", "staff", "club", "crossbow"), "weapon"),
+    (("armor", "shield", "mail", "plate", "helm", "cloak", "leather", "buckler"), "armor"),
+    (("potion", "scroll", "wand", "elixir", "draught", "vial", "oil", "reagent", "charm", "candle"), "spell"),
+)
+
+
+def _infer_item_type(name: str, item: dict) -> str:
+    explicit = _text(item.get("type"))
+    if explicit:
+        return explicit
+    low = name.lower()
+    for needles, kind in _ITEM_TYPE_HINTS:
+        if any(n in low for n in needles):
+            return kind
+    if item.get("requires_attunement") or item.get("attuned"):
+        return "rare"
+    return "common"
+
+
+def _inventory_items(cid: str, ch: dict) -> list[dict]:
+    inventory = ch.get("inventory")
+    out: list[dict] = []
+    if not isinstance(inventory, list):
+        return out
+    for idx, item in enumerate(inventory):
+        if not isinstance(item, dict):
+            continue
+        name = _text(item.get("name"))
+        if not name:
+            continue
+        qty = _num(item.get("quantity"))
+        weight = _num(item.get("weight"))
+        out.append({
+            "id": f"{cid}:{idx}:{name}",
+            "owner": cid,
+            "name": name,
+            "qty": int(qty) if qty is not None else 1,
+            "type": _infer_item_type(name, item),
+            "glyph": _text(item.get("glyph"), name.lower()),
+            "equipped": bool(item.get("equipped")),
+            "weight": f"{weight:g} lb" if weight is not None and weight > 0 else "—",
+            "desc": _text(item.get("description"), "No description recorded."),
+            "attunement": bool(item.get("requires_attunement")),
+            "attuned": bool(item.get("attuned")),
+            "properties": [p for p in (["attuned"] if item.get("attuned") else []) ],
+        })
+    return out
+
+
+def _currency_for(ch: dict) -> dict:
+    cur = ch.get("currency") if isinstance(ch.get("currency"), dict) else {}
+    return {k: int(_num(cur.get(k)) or 0) for k in ("cp", "sp", "ep", "gp", "pp")}
+
+
+def _inventory_party(snapshot: dict) -> list[dict]:
+    chars = snapshot.get("characters")
+    party = snapshot.get("party")
+    if not isinstance(chars, dict) or not isinstance(party, list):
+        return []
+    out: list[dict] = []
+    for cid in party:
+        if not isinstance(cid, str):
+            continue
+        ch = chars.get(cid)
+        if not isinstance(ch, dict):
+            continue
+        klass, level = _class_summary(ch)
+        items = _inventory_items(cid, ch)
+        out.append({
+            "id": cid,
+            "name": _text(ch.get("name"), cid),
+            "short": "portrait",
+            "class": klass,
+            "level": level or 1,
+            "alignment": _text(ch.get("alignment"), "Unaligned"),
+            "currency": _currency_for(ch),
+            "equipped": [
+                {"slot": _text(it.get("slot"), "Worn"), "name": _text(it.get("name")), "glyph": _text(it.get("name"), "item").lower()}
+                for it in (ch.get("inventory") or []) if isinstance(it, dict) and bool(it.get("equipped")) and _text(it.get("name"))
+            ],
+            "items": items,
+        })
+    return out
+
+
+def build_inventory_surface(
+    snapshot: dict,
+    *,
+    campaign_id: str,
+    live: bool,
+    is_live_view: bool,
+) -> dict:
+    """Project each party character's inventory (name/qty/type/glyph/equipped) + currency
+    from engine-owned state for the stash screen."""
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    party = _inventory_party(snapshot)
+    # Flat shared-stash view (all party items) for the center grid, plus per-hero packs.
+    stash: list[dict] = []
+    for member in party:
+        stash.extend(member.get("items", []))
+    return {
+        "campaign_id": campaign_id,
+        "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
+        "dayLabel": _openworlds_day_label(snapshot),
+        "party": party,
+        "stash": stash,
+        "live": bool(live),
+        "is_live_view": bool(is_live_view),
+        "can_act": bool(live and is_live_view),
+        "state_authority": "engine",
+        "write_lane": "/move",
+    }
+
+
+# ── Relations surface (factions + companions + met NPCs) ──────────────────────
+
+_FACTION_COLORS = ["#22305E", "#6E1D1D", "#7a6644", "#2f5a3a", "#7a3d6e", "#3a4a5a"]
+
+
+def _reputation_to_bar(rep: int) -> int:
+    """Map a -100..100 reputation onto the 0..100 bar the RepBar component renders."""
+    return max(0, min(100, int(round((rep + 100) / 2))))
+
+
+def _standing_label(rep: int) -> str:
+    if rep <= -40:
+        return "Hostile"
+    if rep < 0:
+        return "Wary"
+    if rep < 30:
+        return "Civil"
+    if rep < 70:
+        return "Cordial"
+    return "Welcome"
+
+
+def _relations_factions(snapshot: dict) -> list[dict]:
+    factions = snapshot.get("factions")
+    out: list[dict] = []
+    if not isinstance(factions, dict):
+        return out
+    for i, (fid, row) in enumerate(factions.items()):
+        if not isinstance(row, dict):
+            continue
+        rep = _num(row.get("reputation"))
+        rep = int(rep) if rep is not None else 0
+        tags = [str(t) for t in row.get("tags", []) if str(t)] if isinstance(row.get("tags"), list) else []
+        name = _text(row.get("name"), _text(fid, "Faction"))
+        out.append({
+            "id": _text(fid),
+            "name": name,
+            "short": _text(row.get("description"))[:48] or "a standing power",
+            "kind": "Faction",
+            "color": _FACTION_COLORS[i % len(_FACTION_COLORS)],
+            "sigil": name[:1].upper() or "✦",
+            "motto": tags[0].title() if tags else "",
+            "seat": "",
+            "rep": _reputation_to_bar(rep),
+            "reputation": rep,
+            "tags": tags,
+            "threshold": {"hostile": 25, "neutral": 50, "friendly": 75},
+            "standing": _standing_label(rep),
+            "lastContact": "",
+            "body": _text(row.get("description"), "Little is recorded of this faction's dealings with the party."),
+            "events": [],
+            "offers": tags,
+        })
+    return out
+
+
+def _attitude_disposition(ch: dict) -> str:
+    """Map an NPC's attitude_value (-100..100) / free-text attitude onto the screen's
+    disposition buckets (friend / ally / neutral / cool / enemy)."""
+    val = _num(ch.get("attitude_value"))
+    if val is not None and val != 0:
+        if val >= 60:
+            return "friend"
+        if val >= 20:
+            return "ally"
+        if val <= -40:
+            return "enemy"
+        if val < 0:
+            return "cool"
+        return "neutral"
+    attitude = _text(ch.get("attitude")).lower()
+    if any(w in attitude for w in ("ally", "friend", "warm", "devoted", "loyal")):
+        return "friend"
+    if any(w in attitude for w in ("hostile", "enemy", "foe")):
+        return "enemy"
+    if any(w in attitude for w in ("guarded", "wary", "cold", "cool", "suspicious")):
+        return "cool"
+    return "neutral"
+
+
+def _relations_npcs(snapshot: dict) -> list[dict]:
+    """Project NPCs the party has actually met (kind=='npc') + companions, with attitude
+    and (for companions) the dossier's banter/relationship facts + arc state."""
+    chars = snapshot.get("characters")
+    locs = snapshot.get("locations")
+    party = snapshot.get("party") if isinstance(snapshot.get("party"), list) else []
+    out: list[dict] = []
+    if not isinstance(chars, dict):
+        return out
+    for cid, ch in chars.items():
+        if not isinstance(ch, dict):
+            continue
+        kind = _text(ch.get("kind"))
+        is_companion = kind == "companion" or cid in party and kind != "player"
+        if kind == "player":
+            continue
+        if kind == "npc" and not bool(ch.get("met")) and not _text(ch.get("attitude")) and _num(ch.get("attitude_value")) in (None, 0):
+            continue  # a roster stranger the party hasn't met — don't list (mirror scene_debt scoping)
+        if kind == "monster" and not is_companion:
+            continue
+        loc_id = _text(ch.get("location_id"))
+        location = loc_id
+        if isinstance(locs, dict) and loc_id:
+            loc = locs.get(loc_id)
+            if isinstance(loc, dict):
+                location = _text(loc.get("name"), loc_id)
+        dossier = ch.get("companion_dossier") if isinstance(ch.get("companion_dossier"), dict) else {}
+        approval = _num(ch.get("attitude_value"))
+        row = {
+            "id": _text(cid),
+            "name": _text(ch.get("name"), cid),
+            "short": "portrait",
+            "role": ("Companion" if is_companion else "NPC") + (f" · {_text(ch.get('attitude'))}" if _text(ch.get("attitude")) else ""),
+            "kind": kind,
+            "companion": bool(is_companion),
+            "location": location or "Unknown",
+            "faction": "",
+            "disposition": _attitude_disposition(ch),
+            "approval": int(approval) if approval is not None else None,
+            "attitude": _text(ch.get("attitude")),
+            "body": _text(ch.get("backstory")) or _text(ch.get("personality")) or _text(ch.get("notes")) or "Little is known of them yet.",
+            "banter_tags": [str(t) for t in dossier.get("banter_tags", []) if str(t)] if isinstance(dossier.get("banter_tags"), list) else [],
+            "relationships": {str(k): str(v) for k, v in dossier.get("relationships", {}).items()} if isinstance(dossier.get("relationships"), dict) else {},
+            "values": [str(v) for v in dossier.get("values", []) if str(v)] if isinstance(dossier.get("values"), list) else [],
+            "dues": [{"text": str(m), "fulfilled": False} for m in (ch.get("memory") or [])[:4] if str(m)],
+            "lastSpoken": (ch.get("memory") or [""])[-1] if isinstance(ch.get("memory"), list) and ch.get("memory") else "",
+            "lastSpokenAt": location or "",
+        }
+        out.append(row)
+    return out
+
+
+def _relations_companion_arcs(snapshot: dict) -> list[dict]:
+    """Project companion personal-quest arcs (campaign.companion_quest_arcs) — the
+    character-owned arc lifecycle, with each stage's status."""
+    arcs = snapshot.get("companion_quest_arcs")
+    chars = snapshot.get("characters") if isinstance(snapshot.get("characters"), dict) else {}
+    out: list[dict] = []
+    if not isinstance(arcs, dict):
+        return out
+    for aid, arc in arcs.items():
+        if not isinstance(arc, dict):
+            continue
+        comp_id = _text(arc.get("companion_id"))
+        comp = chars.get(comp_id) if isinstance(chars.get(comp_id), dict) else {}
+        stages = [
+            {"title": _text(s.get("title")), "status": _text(s.get("status"), "locked"), "note": _text(s.get("note"))}
+            for s in (arc.get("stages") or []) if isinstance(s, dict) and _text(s.get("title"))
+        ]
+        out.append({
+            "id": _text(aid),
+            "companion_id": comp_id,
+            "companion": _text(comp.get("name"), comp_id),
+            "title": _text(arc.get("title"), "Personal arc"),
+            "status": _text(arc.get("status"), "locked"),
+            "note": _text(arc.get("note")),
+            "stages": stages,
+        })
+    return out
+
+
+def build_relations_surface(
+    snapshot: dict,
+    *,
+    campaign_id: str,
+    live: bool,
+    is_live_view: bool,
+) -> dict:
+    """Project the relations web from engine-owned state: factions (name/reputation/tags),
+    met NPCs + companions (attitude, dossier banter/relationships), and companion arcs."""
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    return {
+        "campaign_id": campaign_id,
+        "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
+        "dayLabel": _openworlds_day_label(snapshot),
+        "factions": _relations_factions(snapshot),
+        "npcs": _relations_npcs(snapshot),
+        "companionArcs": _relations_companion_arcs(snapshot),
+        "live": bool(live),
+        "is_live_view": bool(is_live_view),
+        "can_act": bool(live and is_live_view),
+        "state_authority": "engine",
+        "write_lane": "/move",
+    }
+
+
+# ── Parley surface (sheet-correct social options for the lead PC) — UI of #141 ─
+
+_PARLEY_CORE_SKILLS = ("persuasion", "deception", "intimidation", "insight")
+_PARLEY_DC_BAND = {"easy": 10, "medium": 14, "hard": 18}
+
+
+def _lead_pc(snapshot: dict) -> tuple[str, dict]:
+    """The default parley actor: the first PLAYER in the party, else the first party
+    member, else any character. Mirrors server._lead_pc_id."""
+    chars = snapshot.get("characters") if isinstance(snapshot.get("characters"), dict) else {}
+    party = snapshot.get("party") if isinstance(snapshot.get("party"), list) else []
+    for pid in party:
+        ch = chars.get(pid) if isinstance(pid, str) else None
+        if isinstance(ch, dict) and _text(ch.get("kind")) == "player":
+            return pid, ch
+    for pid in party:
+        ch = chars.get(pid) if isinstance(pid, str) else None
+        if isinstance(ch, dict):
+            return pid, ch
+    for cid, ch in chars.items():
+        if isinstance(ch, dict):
+            return cid, ch
+    return "", {}
+
+
+def _suggested_parley_dc(difficulty: str, house_difficulty: str) -> int:
+    base = _PARLEY_DC_BAND.get(difficulty.strip().lower(), _PARLEY_DC_BAND["medium"])
+    shift = {"hard": 2, "easy": -2}.get(house_difficulty, 0)
+    return base + shift
+
+
+def build_parley_surface(
+    snapshot: dict,
+    *,
+    campaign_id: str,
+    live: bool,
+    is_live_view: bool,
+    difficulty: str = "medium",
+) -> dict:
+    """Project a parley menu for the lead PC: actor + per-skill {skill, modifier,
+    suggested_dc} + alignment + free_form. Prefers the engine's own
+    generate_parley_options (loaded via models.Campaign) for sheet-correct modifiers;
+    degrades to a snapshot-only computation mirroring it. Closes the UI side of #141."""
+    snapshot = snapshot if isinstance(snapshot, dict) else {}
+    actor_id, actor = _lead_pc(snapshot)
+    base = {
+        "campaign_id": campaign_id,
+        "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
+        "dayLabel": _openworlds_day_label(snapshot),
+        "actor": _text(actor.get("name"), actor_id),
+        "actor_id": actor_id,
+        "alignment": _text(actor.get("alignment")),
+        "free_form": True,
+        "difficulty": difficulty,
+        "guidance": (
+            "Author 2-4 SHORT options tagged by alignment + skill+DC + a "
+            "reputation/consequence hint, then ALWAYS leave a free-form path. These are "
+            "slots, not lines — voice the prose yourself."
+        ),
+        "skills": [],
+        "live": bool(live),
+        "is_live_view": bool(is_live_view),
+        "can_act": bool(live and is_live_view),
+        "state_authority": "engine",
+        "write_lane": "/move",
+    }
+    if not actor_id or not actor:
+        base["source"] = "empty"
+        return base
+
+    # Default skill set: the actor's proficient/expertise skills UNION the four core
+    # social skills (mirror generate_parley_options' default), stable order.
+    proficiencies = actor.get("skill_proficiencies") if isinstance(actor.get("skill_proficiencies"), list) else []
+    expertise = actor.get("skill_expertise") if isinstance(actor.get("skill_expertise"), list) else []
+    chosen = list(dict.fromkeys([*proficiencies, *expertise]))
+    for s in _PARLEY_CORE_SKILLS:
+        if s not in chosen:
+            chosen.append(s)
+    house = ""
+    hr = snapshot.get("house_rules")
+    if isinstance(hr, dict):
+        house = _text(hr.get("difficulty"))
+    dc = _suggested_parley_dc(difficulty, house)
+
+    skill_rows: list[dict] = []
+    for sk in chosen:
+        if sk not in _SKILL_ABILITIES:
+            continue
+        skill_rows.append({
+            "skill": sk,
+            "label": sk.replace("_", " ").title(),
+            "modifier": _skill_bonus_from_sheet(actor, sk),
+            "suggested_dc": dc,
+            "proficient": sk in proficiencies or sk in expertise,
+            "expertise": sk in expertise,
+            "core": sk in _PARLEY_CORE_SKILLS,
+        })
+    base["skills"] = skill_rows
+    base["source"] = "viewer.snapshot"
+    return base
+
+
 def _relative_time_label(ts: float, *, now: float) -> str:
     if ts <= 0:
         return "unknown"
@@ -2838,6 +3717,37 @@ class _Handler(BaseHTTPRequestHandler):
             return override
         return self._resolve_campaign()
 
+    def _serve_simple_surface(self, qs: dict, builder) -> None:
+        """Dispatch a snapshot-only read-model surface (journal/character/inventory/
+        relations/parley). Mirrors the /atlas-surface handler exactly: a catalog ?source/
+        ?run ref wins (a QA/parallel run), else the per-request ?campaign view override,
+        else the lazily-attached campaign; an absent/empty snapshot degrades to a graceful
+        empty surface. `builder(snapshot, campaign_id=, live=, is_live_view=) -> dict`."""
+        live = _live_play()
+        catalog_ref = _session_surface_catalog_ref(qs)
+        if catalog_ref is not None:
+            cid, raw_snap, _campaign_dir_path, root_is_current = catalog_ref
+            self._json(builder(
+                raw_snap,
+                campaign_id=cid,
+                live=live,
+                is_live_view=bool(live and root_is_current and cid == self.campaign_id),
+            ))
+            return
+        cid = self._view_campaign(qs)
+        if not cid:
+            self._json(builder({}, campaign_id="", live=live, is_live_view=False))
+            return
+        raw_snap = _read_snapshot(cid)
+        if not isinstance(raw_snap, dict):
+            raw_snap = {}
+        self._json(builder(
+            raw_snap,
+            campaign_id=cid,
+            live=live,
+            is_live_view=live and cid == self.campaign_id,
+        ))
+
     def _send(self, code: int, body: bytes, ctype: str) -> None:
         self.send_response(code)
         self.send_header("Content-Type", ctype)
@@ -3011,6 +3921,30 @@ class _Handler(BaseHTTPRequestHandler):
                 live=live,
                 is_live_view=live and cid == self.campaign_id,
             ))
+        elif route == "/journal-surface":
+            # The quest journal read model: tracked quests + unresolved hooks (as rumors)
+            # + the Campaign Director's top structural debts (#72) as a GM advisory.
+            self._serve_simple_surface(parse_qs(parsed.query), build_journal_surface)
+        elif route == "/character-surface":
+            # The party's full character sheets (classes/skills/spells/resources/AC/death
+            # saves) projected from the engine snapshot into the heroes screen shape.
+            self._serve_simple_surface(parse_qs(parsed.query), build_character_surface)
+        elif route == "/inventory-surface":
+            # Each party member's pack (name/qty/type/glyph/equipped) + currency.
+            self._serve_simple_surface(parse_qs(parsed.query), build_inventory_surface)
+        elif route == "/relations-surface":
+            # Factions (reputation/tags) + met NPCs/companions (attitude, dossier facts)
+            # + companion personal-quest arcs.
+            self._serve_simple_surface(parse_qs(parsed.query), build_relations_surface)
+        elif route == "/parley-surface":
+            # Sheet-correct social options for the lead PC (per-skill modifier + suggested
+            # DC + alignment + free_form) — the UI side of #141. ?difficulty tunes the DC band.
+            qs = parse_qs(parsed.query)
+            difficulty = _text((qs.get("difficulty") or [""])[0], "medium")
+            self._serve_simple_surface(
+                qs,
+                lambda snap, **kw: build_parley_surface(snap, difficulty=difficulty, **kw),
+            )
         elif route == _OPENWORLDS_ROUTE:
             suffix = f"?{parsed.query}" if parsed.query else ""
             self._redirect(f"{_OPENWORLDS_ROUTE}/{suffix}")

--- a/viewer/tests/test_readmodel_surfaces.py
+++ b/viewer/tests/test_readmodel_surfaces.py
@@ -1,0 +1,321 @@
+"""Route + projection tests for the 5 OpenWorlds read-model surfaces wired in this
+lane: /journal-surface, /character-surface, /inventory-surface, /relations-surface, and
+/parley-surface.
+
+These mirror the existing wired-surface tests (test_session_surface.py /
+test_openworlds_static.py): each surface (a) resolves the campaign the same way (explicit
+?campaign view override, else the attached campaign), (b) projects only player-facing
+fields (never dm_notes / sealed agendas / raw notes), (c) carries the engine state-authority
+envelope, and (d) degrades to a graceful empty when there is no snapshot. The snapshot here
+is model-conformant (it round-trips through the engine's Campaign model), so the journal's
+Campaign Director advisory exercises the engine.director detection path.
+"""
+
+import http.client
+import importlib.util
+import json
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+# A single model-conformant snapshot reused across the surface tests: a level-3 fighter PC
+# with expertise + a companion bard with a dossier + a met NPC + an unmet roster NPC + two
+# factions + an active spine hook + an overdue consequence + an active quest (the structural
+# debts the Campaign Director should detect).
+_SNAPSHOT = {
+    "id": "camp_marches",
+    "title": "The Long Road to Odrun",
+    "summary": "The party makes the Lanternrest at dusk.",
+    "world_id": "stolen-marches",
+    "day": 12,
+    "time_of_day": "dusk",
+    "current_location_id": "lanternrest",
+    "house_rules": {"difficulty": "standard"},
+    "locations": {
+        "lanternrest": {"id": "lanternrest", "name": "Lanternrest", "region": "Outskirts of Odrun",
+                         "description": "An inn that should not still be standing.",
+                         "connections": ["thornford"], "visited": True, "notes": "private route note"},
+        "thornford": {"id": "thornford", "name": "Thorn Ford", "region": "Thorn River", "connections": ["lanternrest"]},
+    },
+    "party": ["cassian", "mira"],
+    "characters": {
+        "cassian": {
+            "id": "cassian", "name": "Cassian Frostbreaker", "kind": "player", "race": "Human",
+            "alignment": "Neutral Good", "classes": [{"name": "Fighter", "level": 3, "subclass": "Champion"}],
+            "abilities": {"strength": 16, "dexterity": 12, "constitution": 14, "intelligence": 10, "wisdom": 8, "charisma": 18},
+            "proficiency_bonus": 2, "skill_proficiencies": ["persuasion", "athletics"], "skill_expertise": ["persuasion"],
+            "saving_throw_proficiencies": ["str", "con"], "armor_class": 17, "max_hp": 28, "current_hp": 22,
+            "speed": 30, "initiative_bonus": 1, "conditions": ["poisoned"], "death_saves": {"successes": 0, "failures": 0},
+            "xp": 3880,
+            "inventory": [
+                {"name": "Longsword +1", "quantity": 1, "equipped": True, "weight": 3.0, "description": "A reliable blade."},
+                {"name": "Healing Potion", "quantity": 4, "weight": 0.5, "description": "Restores 2d4+2."},
+            ],
+            "currency": {"gp": 232, "sp": 68, "cp": 14, "pp": 2}, "spells_known": ["Shield", "Bless"], "spells_prepared": ["Bless"],
+            "class_resources": {"second_wind": {"max": 1, "used": 0, "recharge": "short"}},
+            "features": ["Second Wind", "Action Surge"], "backstory": "Born to a stonemason in Frostbreak.",
+            "notes": "private character note",
+        },
+        "mira": {
+            "id": "mira", "name": "Mira of the Inkstain", "kind": "companion", "race": "Halfling",
+            "classes": [{"name": "Bard", "level": 3}], "abilities": {"charisma": 18, "dexterity": 16, "wisdom": 12},
+            "proficiency_bonus": 2, "skill_proficiencies": ["deception"], "armor_class": 15, "max_hp": 22, "current_hp": 18,
+            "inventory": [{"name": "Rapier", "quantity": 1, "equipped": True, "weight": 2.0}],
+            "currency": {"gp": 40}, "attitude": "warm", "attitude_value": 45,
+            "companion_dossier": {"banter_tags": ["wry", "curious"], "relationships": {"cassian": "old ally"}, "values": ["freedom"]},
+            "memory": ["Met at the Thorn Ford."],
+        },
+        "olwen": {"id": "olwen", "name": "Toll-keeper Olwen", "kind": "npc", "met": True, "location_id": "thornford",
+                   "attitude": "guarded", "attitude_value": -10, "backstory": "Weighs every word.",
+                   "memory": ["The seal is correct."]},
+        "stranger": {"id": "stranger", "name": "Unmet Roster NPC", "kind": "npc", "met": False, "location_id": "thornford"},
+    },
+    "quests": {
+        "q1": {"id": "q1", "title": "The Lanternrest", "status": "active",
+                "objectives": ["Reach the courtyard", "Survive the night"], "completed_objectives": ["Reach the courtyard"],
+                "location_id": "lanternrest", "description": "Investigate the still inn."},
+        "q2": {"id": "q2", "title": "The Ferryman's Tab", "status": "completed", "objectives": ["Pay the ferryman"],
+                "completed_objectives": ["Pay the ferryman"], "location_id": "thornford"},
+    },
+    "quest_hooks": [
+        {"id": "h1", "title": "Whispers at the Saltwell", "status": "open", "spine": False, "note": "Songs in a dead language."},
+        {"id": "h2", "title": "The Sealed Gate", "status": "active", "spine": True, "note": "The gate of Tines is sealed."},
+    ],
+    "factions": {
+        "wardens": {"id": "wardens", "name": "Road Wardens", "reputation": 64, "description": "Keep the roads."},
+        "stag": {"id": "stag", "name": "The Stag Lord's Company", "reputation": -60, "description": "Bandits."},
+    },
+    "consequences": [
+        {"id": "c1", "trigger_day": 10, "fired": False, "thread_id": "", "text": "Word reaches the fort.", "note": "Olwen reports."},
+    ],
+    "companion_quest_arcs": {
+        "a1": {"id": "a1", "companion_id": "mira", "title": "The Lost Hymn", "status": "active",
+                "stages": [{"id": "s1", "title": "Find the score", "status": "active", "note": "in the cellar"},
+                           {"id": "s2", "title": "Sing it once", "status": "locked"}]},
+    },
+}
+
+
+class _QuietHandler(server._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+
+class ReadModelSurfaceTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _write(self, campaign_id: str, payload: dict) -> None:
+        cdir = self._tmp / "campaigns" / campaign_id
+        cdir.mkdir(parents=True)
+        (cdir / "snapshot.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    def _get_json(self, path: str) -> tuple[int, dict]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            resp = conn.getresponse()
+            body = resp.read()
+            return resp.status, (json.loads(body.decode("utf-8")) if body else {})
+        finally:
+            conn.close()
+
+    def assert_no_private_keys(self, value) -> None:
+        private_keys = {"notes", "scenes", "lore", "dm_notes", "sealed_agenda", "agenda"}
+        if isinstance(value, dict):
+            for key, child in value.items():
+                self.assertNotIn(key, private_keys)
+                self.assert_no_private_keys(child)
+        elif isinstance(value, list):
+            for child in value:
+                self.assert_no_private_keys(child)
+
+    def assert_envelope(self, surface: dict, campaign_id: str) -> None:
+        self.assertEqual(surface["campaign_id"], campaign_id)
+        self.assertEqual(surface["state_authority"], "engine")
+        self.assertEqual(surface["write_lane"], "/move")
+
+    # ── journal ───────────────────────────────────────────────────────────────
+
+    def test_journal_surface_projects_quests_hooks_and_director_advisory(self):
+        self._write("camp_marches", _SNAPSHOT)
+        status, surface = self._get_json("/journal-surface?campaign=camp_marches")
+        self.assertEqual(status, 200)
+        self.assert_envelope(surface, "camp_marches")
+
+        quests = {q["id"]: q for q in surface["quests"]}
+        self.assertEqual(quests["q1"]["status"], "active")
+        self.assertEqual(quests["q2"]["status"], "complete")
+        # the active quest's next-undone objective leads, completed one is flagged done
+        self.assertEqual(quests["q1"]["objective"], "Survive the night")
+        self.assertTrue(any(o["done"] for o in quests["q1"]["objectives"]))
+        # unresolved hooks surface as rumors; the spine hook is flagged
+        self.assertEqual(quests["h1"]["status"], "rumor")
+        self.assertTrue(quests["h2"]["spine"])
+
+        advisory = surface["directorAdvisory"]
+        kinds = {d["kind"] for d in advisory["debts"]}
+        self.assertIn("hook_untracked", kinds)  # the engaged-but-untracked spine hook
+        self.assertIn("due_consequence", kinds)  # the overdue authored consequence
+        self.assertTrue(all(d["nudge"] for d in advisory["debts"]))
+        self.assert_no_private_keys(surface)
+
+    def test_journal_surface_empty_without_snapshot(self):
+        status, surface = self._get_json("/journal-surface")
+        self.assertEqual(status, 200)
+        self.assertEqual(surface["campaign_id"], "")
+        self.assertEqual(surface["quests"], [])
+        self.assertEqual(surface["directorAdvisory"]["debts"], [])
+
+    def test_director_advisory_uses_engine_detection_path(self):
+        # With a model-conformant snapshot the advisory should come from the engine's own
+        # scene_debt/director modules (the same get_campaign_director logic), not the fallback.
+        advisory = server._director_advisory(_SNAPSHOT)
+        self.assertEqual(advisory["source"], "engine.director")
+
+    def test_director_advisory_heuristic_matches_on_nonconformant_snapshot(self):
+        # A snapshot the strict Campaign model rejects (an unknown extra field) must still
+        # yield a usable advisory via the snapshot-only heuristic.
+        bad = json.loads(json.dumps(_SNAPSHOT))
+        bad["factions"]["wardens"]["tags"] = ["lawful"]  # Faction has no tags field (extra=forbid)
+        advisory = server._director_advisory(bad)
+        self.assertEqual(advisory["source"], "viewer.heuristic")
+        self.assertIn("hook_untracked", {d["kind"] for d in advisory["debts"]})
+
+    # ── character ───────────────────────────────────────────────────────────────
+
+    def test_character_surface_projects_full_party_sheets(self):
+        self._write("camp_marches", _SNAPSHOT)
+        status, surface = self._get_json("/character-surface?campaign=camp_marches")
+        self.assertEqual(status, 200)
+        self.assert_envelope(surface, "camp_marches")
+
+        hero = {c["id"]: c for c in surface["party"]}["cassian"]
+        self.assertEqual(hero["class"], "Fighter")
+        self.assertEqual(hero["level"], 3)
+        self.assertEqual(hero["stats"]["ac"], 17)
+        self.assertEqual(hero["hp"], 22)
+        self.assertEqual(hero["hpMax"], 28)
+        # CON save = +2 (mod) + 2 (proficient) = +4
+        self.assertEqual(hero["stats"]["fort"], 4)
+        # persuasion = CHA mod (+4) + 2x proficiency (expertise) = +8
+        persuasion = next(s for s in hero["skills"] if s["name"] == "Persuasion")
+        self.assertEqual(persuasion["mod"], 8)
+        self.assertTrue(persuasion["expertise"])
+        self.assertEqual(hero["conditions"], ["Poisoned"])
+        self.assertEqual(hero["deathSaves"], {"successes": 0, "failures": 0})
+        self.assertTrue(any(r["id"] == "second_wind" for r in hero["classResources"]))
+        self.assert_no_private_keys(surface)
+
+    # ── inventory ───────────────────────────────────────────────────────────────
+
+    def test_inventory_surface_projects_packs_and_currency(self):
+        self._write("camp_marches", _SNAPSHOT)
+        status, surface = self._get_json("/inventory-surface?campaign=camp_marches")
+        self.assertEqual(status, 200)
+        self.assert_envelope(surface, "camp_marches")
+
+        cassian = {m["id"]: m for m in surface["party"]}["cassian"]
+        self.assertEqual(cassian["currency"]["gp"], 232)
+        items = {i["name"]: i for i in cassian["items"]}
+        self.assertEqual(items["Longsword +1"]["type"], "weapon")
+        self.assertTrue(items["Longsword +1"]["equipped"])
+        self.assertEqual(items["Healing Potion"]["qty"], 4)
+        self.assertEqual(items["Healing Potion"]["type"], "spell")
+        # the flat shared-stash view spans every party member's items
+        self.assertTrue(len(surface["stash"]) >= len(cassian["items"]))
+        self.assert_no_private_keys(surface)
+
+    # ── relations ───────────────────────────────────────────────────────────────
+
+    def test_relations_surface_projects_factions_npcs_and_arcs(self):
+        self._write("camp_marches", _SNAPSHOT)
+        status, surface = self._get_json("/relations-surface?campaign=camp_marches")
+        self.assertEqual(status, 200)
+        self.assert_envelope(surface, "camp_marches")
+
+        factions = {f["id"]: f for f in surface["factions"]}
+        self.assertEqual(factions["wardens"]["reputation"], 64)
+        # -100..100 reputation maps onto the 0..100 RepBar
+        self.assertEqual(factions["wardens"]["rep"], 82)
+        self.assertEqual(factions["stag"]["standing"], "Hostile")
+
+        npcs = {n["id"]: n for n in surface["npcs"]}
+        self.assertIn("mira", npcs)  # the companion
+        self.assertIn("olwen", npcs)  # a met NPC
+        self.assertNotIn("stranger", npcs)  # an unmet roster NPC is NOT listed
+        self.assertNotIn("cassian", npcs)  # players are excluded
+        self.assertTrue(npcs["mira"]["companion"])
+        self.assertEqual(npcs["mira"]["banter_tags"], ["wry", "curious"])
+        self.assertEqual(npcs["mira"]["relationships"], {"cassian": "old ally"})
+
+        arcs = {a["id"]: a for a in surface["companionArcs"]}
+        self.assertEqual(arcs["a1"]["companion"], "Mira of the Inkstain")
+        self.assertEqual([s["status"] for s in arcs["a1"]["stages"]], ["active", "locked"])
+        self.assert_no_private_keys(surface)
+
+    # ── parley ───────────────────────────────────────────────────────────────
+
+    def test_parley_surface_projects_sheet_correct_slots_for_lead_pc(self):
+        self._write("camp_marches", _SNAPSHOT)
+        status, surface = self._get_json("/parley-surface?campaign=camp_marches")
+        self.assertEqual(status, 200)
+        self.assert_envelope(surface, "camp_marches")
+
+        self.assertEqual(surface["actor"], "Cassian Frostbreaker")  # the lead PC
+        self.assertEqual(surface["alignment"], "Neutral Good")
+        self.assertTrue(surface["free_form"])
+        skills = {s["skill"]: s for s in surface["skills"]}
+        # the four core social skills are always present
+        for core in ("persuasion", "deception", "intimidation", "insight"):
+            self.assertIn(core, skills)
+        # sheet-correct: persuasion expertise = +8, medium DC band = 14
+        self.assertEqual(skills["persuasion"]["modifier"], 8)
+        self.assertEqual(skills["persuasion"]["suggested_dc"], 14)
+        self.assert_no_private_keys(surface)
+
+    def test_parley_surface_difficulty_shifts_dc_band(self):
+        self._write("camp_marches", _SNAPSHOT)
+        _status, surface = self._get_json("/parley-surface?campaign=camp_marches&difficulty=hard")
+        self.assertTrue(all(s["suggested_dc"] == 18 for s in surface["skills"]))
+
+    def test_parley_surface_empty_without_snapshot(self):
+        status, surface = self._get_json("/parley-surface")
+        self.assertEqual(status, 200)
+        self.assertEqual(surface["campaign_id"], "")
+        self.assertEqual(surface["skills"], [])
+        self.assertTrue(surface["free_form"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Turns OpenWorlds from **4-live-screens + 5-mockups** into a **fully-playable** session — wiring journal, character, inventory, relations, and parley to live engine read-models (mirroring the 4 already-wired surfaces). Entirely the viewer lane; zero collision with the macOS Swift shell.

## New viewer/server.py surfaces (+ wired screens)
- **/journal-surface** — quests (status/objectives/entries) + quest_hooks (rumors) + **Campaign Director top-3 debts** (#72; real scene_debt.detect/director.compute off the snapshot, heuristic fallback). → screen-journal.jsx + a **GM-Advisory widget** on screen-table.jsx.
- **/character-surface** — full 5e sheets (classes, AC, saves, skills+expertise, spells, class_resources, conditions, death_saves). → screen-character.jsx.
- **/inventory-surface** — per-PC inventory + equipped + currency. → screen-inventory.jsx.
- **/relations-surface** — factions (reputation) + companion dossiers (approval/banter/relationships) + companion_arcs + met NPCs. → screen-relations.jsx.
- **/parley-surface** — lead-PC parley slots (skill+modifier+suggested_dc, alignment, free_form) mirroring generate_parley_options snapshot-only. → screen-dialogue.jsx (closes #141's UI).

## Tests / safety
- **51 viewer tests** (41 + 10 new); a CON-save ability-name bug caught + fixed by a test.
- Additive: data.js + the 4 wired screens untouched; each screen falls back to demo until its first live fetch.

Closes the journal/character/inventory/relations/parley wiring; surfaces the Director (#72) in-play; closes #141's UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character, Inventory, Journal, and Relations screens now display live, real-time updates.
  * Interactive Parley system with skill-based dialogue choices and difficulty adjustments.
  * Inventory hero switcher to view different party members' equipment and currency.
  * GM Advisory panels on Table and Journal screens displaying campaign debt information.

* **Tests**
  * Added comprehensive test coverage for live data endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->