### PR TITLE
content(bg): 5 navigable post-BG3 areas

### DIFF
--- a/content/worlds/baldurs-gate/areas/basilisk-gate.json
+++ b/content/worlds/baldurs-gate/areas/basilisk-gate.json
@@ -1,0 +1,20 @@
+{
+  "id": "loc-basilisk-gate",
+  "name": "the Basilisk Gate",
+  "description": "The great south-facing arch that divides the Upper City's marble composure from the Lower City's noise: a tunnel of ancient grey stone wide enough to drive three wagons abreast, its vault carved with the petrified basilisk the Flaming Fist killed here to prove a point about law. In ordinary years the passage is a toll-post and a social membrane — the gate-watch decides, with practised prejudice, who reads as Upper City and who does not. Since the Absolute's fall ordinary has left the building. The checkpoint has quintupled; Flaming Fist sergeants with hollow eyes run papers nobody printed against lists nobody agrees on, while tadpole-survivors — visibly, unmistakably — are turned away at the arch that once admitted them without remark. A camp of the refused has grown against the Lower City face of the wall: cloaks, cookfires, and a very specific quality of patience from people who have nowhere else to argue their case. The gate itself is undamaged, which the patriars consider evidence that the structure of authority held; the people camped in its shadow consider evidence that it chose sides.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "Baldur's Gate — Upper City",
+    "Baldur's Gate — Lower City",
+    "Bloomridge Market"
+  ],
+  "tags": [
+    "gate",
+    "city",
+    "power",
+    "intrigue"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/content/worlds/baldurs-gate/areas/gray-harbor.json
+++ b/content/worlds/baldurs-gate/areas/gray-harbor.json
@@ -1,0 +1,21 @@
+{
+  "id": "loc-gray-harbor",
+  "name": "the Gray Harbor",
+  "description": "The Gate's oldest working harbor, where the Chionthar broadens toward the Sea of Swords and the smell of salt overtakes the smell of the city. In ordinary commerce the Gray Harbor is a perpetual controlled chaos of merchant vessels, wherries, net-menders, and the gulls that own the air above the breakwater. In this first post-Absolute winter it is half that, and the half that remains is strange. The nearest quay to where the Netherbrain breached the harbor floor still heaves underfoot when the tide runs wrong — stone that should be cold runs warm, and the rivermen who know the water say the bottom changed. Two deep-water berths at the far end have been claimed, without permission anyone can cite, by a consortium of Calishite traders who are not from Little Calimshan and who arrived the week after the battle, which is fast, and whose cargo manifests are sealed, which is suspicious. The harbormaster's office still charges its fees; it no longer asks its questions.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "Baldur's Gate — Lower City",
+    "the Siltwharf Steps",
+    "the Heapside Warrens",
+    "Wyrm's Crossing & the Risen Road"
+  ],
+  "tags": [
+    "waterfront",
+    "harbor",
+    "city",
+    "underworld"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/content/worlds/baldurs-gate/areas/patriars-walk.json
+++ b/content/worlds/baldurs-gate/areas/patriars-walk.json
@@ -1,0 +1,20 @@
+{
+  "id": "loc-patriars-walk",
+  "name": "the Patriars' Walk",
+  "description": "The long marble-flagged promenade that winds through the Upper City's residential heart, flanked by the walled estates of families who have owned this view since before Gortash's grandfather was born. In warmer seasons the Walk is where the Parliament of Peers does the real business of governance — in gloved hands, over garden walls, during the kind of conversation that has no record. In this first winter after the Absolute it is strange, and the strangeness is visible: shuttered windows on three of the oldest estates, a Ravengard steward quietly negotiating the price of debt with a Zhentarim coin-factor in a doorway that used to be a tradesman's entrance, two houses whose owners died without heirs in the crisis and whose sealed doors the Council cannot agree on. The Walk itself is impeccable — someone is still paying the lamplighters and the stone-cleaners — but the marble is cold and the usual social traffic has thinned to a careful few. Patriars who were close to Gortash are not seen here anymore, or anywhere.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "Baldur's Gate — Upper City",
+    "the Basilisk Gate",
+    "Wyrm's Rock Fortress"
+  ],
+  "tags": [
+    "district",
+    "power",
+    "intrigue",
+    "city"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/content/worlds/baldurs-gate/areas/rivington-crossroads.json
+++ b/content/worlds/baldurs-gate/areas/rivington-crossroads.json
@@ -1,0 +1,20 @@
+{
+  "id": "loc-rivington-crossroads",
+  "name": "Rivington & the Crossroads",
+  "description": "The first neighborhood outside the walls on the Risen Road: technically the Outer City, practically its own small town, with a mill, a circus-ground-turned-refugee-settlement, a Flaming Fist checkpoint that was supposed to be temporary six months ago, and the residual smell of carnival. Rivington is where you end up if you cannot get into the Gate or will not pay what the gate-watch demands; it is also where you start if you are coming up the Risen Road from the south. The tiefling community that came north from the western wilds made this its home, and signs of that are everywhere — painted doorframes, small shrines to gods the Lower City does not stock, the sound of a different music from the windows. The Gur caravans camp at the crossroads' edge: horse-lines, cookfires, and an industry of quiet monster-hunting that the neighborhood finds useful and the city watch officially pretends not to know about. Since Cazador fell his vampire spawn have been drifting outward, and some of them drift this far.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "The Outer City & Rivington",
+    "Wyrm's Crossing & the Risen Road",
+    "Little Calimshan"
+  ],
+  "tags": [
+    "district",
+    "slums",
+    "city",
+    "crossroads"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}

--- a/content/worlds/baldurs-gate/areas/steel-watch-foundry-ruins.json
+++ b/content/worlds/baldurs-gate/areas/steel-watch-foundry-ruins.json
@@ -1,0 +1,20 @@
+{
+  "id": "loc-steel-watch-foundry-ruins",
+  "name": "the Steel Watch Foundry Ruins",
+  "description": "The assembly halls beneath Wyrm's Rock that built the construct army Gortash used to police the city — and which the battle detonated. Access is down a broad freight-ramp off the fortress's inner courtyard, through blast-bent doors that never quite closed again. Inside: vaulted chambers reeking of burnt forge-oil and ozone, assembly-cradles still holding the half-finished husks of war-constructs that never got their command-runes, and a floor carpeted in the burst casings of those that finished badly. The Flaming Fist posted a nominal guard at the ramp's top in the first week; the guard rotation has since become a matter of active negotiation between sergeants who dislike going down there and officers who don't want to admit why. Scavengers have been through, and so has someone more careful — control-cores have been removed from a selective set of husks and the missing slots are clean, not looted-rough. The Gondian artificers who were enslaved here, now free, come back on their own time to reclaim their tools, mourn their dead, and argue in Gnomish about what, if anything, should be rebuilt.",
+  "region": "Baldur's Gate",
+  "connections": [
+    "Wyrm's Rock Fortress",
+    "the Counting House",
+    "the Undercity Sewers"
+  ],
+  "tags": [
+    "ruins",
+    "dungeon",
+    "city",
+    "industrial"
+  ],
+  "source_url": "",
+  "license": "Original prose by the ClawDnD authors, released under CC-BY-SA 4.0. Setting (Baldur's Gate, the Sword Coast) is unofficial Fan Content under the Wizards Fan Content Policy; see LICENSE.md in this world folder.",
+  "attribution": "Original example area written for ClawDnD (CC-BY-SA 4.0). Unofficial, non-commercial Fan Content; place-names are property of Wizards of the Coast LLC."
+}


### PR DESCRIPTION
Closes #167. 5 BG areas, schema-matched, navigable connections, license-clean. Gate: license_check green, load smoke (14 areas, no dupes). Local-gated (Actions degraded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added five new areas to the Baldur's Gate world: the Basilisk Gate, Gray Harbor, the Patriars' Walk, Rivington & the Crossroads, and the Steel Watch Foundry Ruins. Each location includes detailed descriptions, connections to neighboring areas, and relevant tags.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->