### PR TITLE
fix(dice): clamp dice count/sides (DoS guard) — GA P1-1

### DIFF
--- a/servers/engine/dice.py
+++ b/servers/engine/dice.py
@@ -14,6 +14,13 @@ from dataclasses import dataclass, field
 
 _TERM = re.compile(r"(\d*)d(\d+)(kh\d+|kl\d+)?$")
 
+# Bounds on a single dice term. Real D&D never needs more (a high-level fireball is
+# ~20d6; d100 is the largest standard die), so these never affect legitimate rolls —
+# they exist purely to stop a pathological expression (e.g. "100000000d20") from
+# allocating a giant list and hanging the engine via the public `roll` MCP tool.
+_MAX_DICE = 1000
+_MAX_SIDES = 1000
+
 
 @dataclass
 class DiceRoll:
@@ -65,6 +72,10 @@ def roll(
             keep = m.group(3)
             if n == 0:
                 raise ValueError(f"die count must be >= 1: {term!r}")
+            if n > _MAX_DICE:
+                raise ValueError(f"die count must be <= {_MAX_DICE}: {term!r}")
+            if sides < 1 or sides > _MAX_SIDES:
+                raise ValueError(f"die sides must be 1..{_MAX_SIDES}: {term!r}")
             faces = [rng.randint(1, sides) for _ in range(n)]
             kept = faces
 

--- a/servers/engine/tests/test_dice.py
+++ b/servers/engine/tests/test_dice.py
@@ -118,3 +118,22 @@ def test_keep_more_than_rolled_raises():
     except ValueError:
         return
     raise AssertionError("expected ValueError when keeping more dice than rolled")
+
+
+def test_roll_rejects_pathological_dice():
+    # A pathological count/sides must raise (not hang allocating a giant list) — the
+    # `roll` MCP tool is publicly reachable, so this guards against a DoS.
+    for expr in ("100000000d20", "1d100000000"):
+        try:
+            dice.roll(expr)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"expected ValueError for {expr!r}")
+
+
+def test_legit_rolls_unaffected_by_bounds():
+    # Real D&D rolls stay well under the bounds and are unchanged.
+    assert dice.roll("20d6+5", seed=1).total > 0          # high-level fireball
+    assert 1 <= dice.roll("1d100", seed=1).total <= 100   # percentile die
+    assert 1 <= dice.roll("1d20", seed=1).total <= 20


### PR DESCRIPTION
Closes #164. dice.roll() was unbounded; a pathological expression hung the engine via the public roll tool. Adds 1000-cap bounds (raise ValueError above); legit rolls unaffected. 19/19 dice tests pass single-process; guard smoke: 100000000d20 raises instantly. Local-gated (Actions degraded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to dice rolling to reject excessively large dice expressions that could cause system strain. The roll parser now enforces reasonable upper bounds on dice counts and sides.

* **Tests**
  * Comprehensive test coverage added to ensure pathological dice expressions are properly rejected while standard rolls like 20d6+5 and 1d20 continue to function correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/169?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->