### PR TITLE
fix(store): tolerant snapshot load (old saves survive schema change) — GA P1-2

### DIFF
--- a/servers/engine/store.py
+++ b/servers/engine/store.py
@@ -14,12 +14,17 @@ from __future__ import annotations
 
 import contextlib
 import fcntl
+import logging
 import os
 import time
 from pathlib import Path
 from typing import Optional
 
+from pydantic import ValidationError
+
 from models import Campaign, SessionLogEntry
+
+log = logging.getLogger(__name__)
 
 
 def state_dir() -> Path:
@@ -80,7 +85,41 @@ def load_campaign(campaign_id: str) -> Optional[Campaign]:
     path = _campaign_dir(campaign_id) / "snapshot.json"
     if not path.exists():
         return None
-    return Campaign.model_validate_json(path.read_text(encoding="utf-8"))
+    raw = path.read_text(encoding="utf-8")
+    try:
+        return Campaign.model_validate_json(raw)
+    except ValidationError:
+        pass
+
+    # Tolerant fallback: drop any top-level keys the current schema doesn't know
+    # about (removed/renamed fields from an older or newer snapshot).  We only
+    # attempt this at the TOP level of Campaign — sub-model strictness is
+    # intentionally preserved.  Per-rename migrations (old-key → new-key) are
+    # added here per-release as needed; this generic net only handles field
+    # removal / unknown keys.
+    import json
+    data: dict = json.loads(raw)
+    known = set(Campaign.model_fields)
+    dropped = [k for k in list(data) if k not in known]
+    if dropped:
+        log.warning(
+            "load_campaign(%s): dropping unrecognised top-level key(s) %s "
+            "— snapshot may be from a different schema version; "
+            "data in those fields is lost for this load.",
+            campaign_id,
+            dropped,
+        )
+        for k in dropped:
+            del data[k]
+
+    try:
+        return Campaign.model_validate(data)
+    except ValidationError as exc:
+        raise RuntimeError(
+            f"load_campaign({campaign_id!r}): snapshot is incompatible with the "
+            f"current schema and cannot be loaded even after stripping unknown "
+            f"top-level keys.  Validation error: {exc}"
+        ) from exc
 
 
 def list_campaigns() -> list[dict]:

--- a/servers/engine/tests/test_store.py
+++ b/servers/engine/tests/test_store.py
@@ -1,0 +1,131 @@
+"""Tests for store.py — specifically the tolerant load_campaign path (#165).
+
+GA-readiness: an old snapshot with an unrecognised top-level key (removed or
+renamed field) must load successfully (with a WARNING) rather than hard-failing.
+Sub-model strictness and normal round-trips must be unaffected.
+"""
+
+import json
+import logging
+
+import pytest
+
+import store
+from models import Campaign
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _write_snapshot(tmp_path, monkeypatch, data: dict) -> str:
+    """Write a raw snapshot dict to disk under a temp state dir and return the campaign id."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = data["id"]
+    snap_dir = tmp_path / "campaigns" / cid
+    snap_dir.mkdir(parents=True)
+    (snap_dir / "snapshot.json").write_text(json.dumps(data), encoding="utf-8")
+    return cid
+
+
+def _minimal_snapshot(extra: dict | None = None) -> dict:
+    """Return a dict that looks like a valid Campaign snapshot, with optional extras."""
+    c = Campaign(title="Test Campaign")
+    base = json.loads(c.model_dump_json())
+    if extra:
+        base.update(extra)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# (a) snapshot with an unknown extra top-level key loads without raising,
+#     and the warning is emitted
+# ---------------------------------------------------------------------------
+
+def test_load_with_unknown_top_level_key_succeeds(tmp_path, monkeypatch, caplog):
+    snapshot = _minimal_snapshot(extra={"removed_field_from_old_schema": "some_value"})
+    cid = _write_snapshot(tmp_path, monkeypatch, snapshot)
+
+    with caplog.at_level(logging.WARNING, logger="store"):
+        result = store.load_campaign(cid)
+
+    assert result is not None, "load_campaign should return a Campaign, not None"
+    assert isinstance(result, Campaign)
+    assert result.title == "Test Campaign"
+
+    # The warning must name the dropped key
+    warning_text = caplog.text
+    assert "removed_field_from_old_schema" in warning_text, (
+        f"Expected dropped key name in warning; got: {warning_text!r}"
+    )
+
+
+def test_load_with_multiple_unknown_keys_succeeds(tmp_path, monkeypatch, caplog):
+    snapshot = _minimal_snapshot(extra={
+        "old_field_one": 42,
+        "legacy_debug_mode": True,
+    })
+    cid = _write_snapshot(tmp_path, monkeypatch, snapshot)
+
+    with caplog.at_level(logging.WARNING, logger="store"):
+        result = store.load_campaign(cid)
+
+    assert result is not None
+    assert isinstance(result, Campaign)
+    warning_text = caplog.text
+    assert "old_field_one" in warning_text
+    assert "legacy_debug_mode" in warning_text
+
+
+# ---------------------------------------------------------------------------
+# (b) normal save→load round-trip works unchanged (no warning)
+# ---------------------------------------------------------------------------
+
+def test_normal_roundtrip(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+
+    c = Campaign(title="Round-trip Campaign")
+    store.save_campaign(c)
+
+    with caplog.at_level(logging.WARNING, logger="store"):
+        loaded = store.load_campaign(c.id)
+
+    assert loaded is not None
+    assert loaded.id == c.id
+    assert loaded.title == "Round-trip Campaign"
+    # No warning should be emitted for a clean round-trip
+    assert caplog.text == "", f"Unexpected warning on clean round-trip: {caplog.text!r}"
+
+
+# ---------------------------------------------------------------------------
+# (c) snapshot missing an optional field still loads (it has a default)
+# ---------------------------------------------------------------------------
+
+def test_load_missing_optional_field(tmp_path, monkeypatch):
+    snapshot = _minimal_snapshot()
+    # Remove an optional field that has a default (e.g. summary, which defaults to "")
+    snapshot.pop("summary", None)
+    snapshot.pop("era", None)
+    cid = _write_snapshot(tmp_path, monkeypatch, snapshot)
+
+    result = store.load_campaign(cid)
+    assert result is not None
+    assert isinstance(result, Campaign)
+    assert result.summary == ""
+    assert result.era == ""
+
+
+# ---------------------------------------------------------------------------
+# (d) a snapshot that is GENUINELY incompatible (missing a required field
+#     even after unknown-key stripping) re-raises with a clear message
+# ---------------------------------------------------------------------------
+
+def test_load_genuinely_incompatible_raises(tmp_path, monkeypatch):
+    snapshot = _minimal_snapshot()
+    # "title" is a required field with no default — removing it makes the parse
+    # fail even after the unknown-key strip.
+    del snapshot["title"]
+    cid = _write_snapshot(tmp_path, monkeypatch, snapshot)
+
+    with pytest.raises(RuntimeError, match="incompatible with the current schema"):
+        store.load_campaign(cid)


### PR DESCRIPTION
Closes #165. load_campaign now catches ValidationError and degrades: drop unknown top-level keys (with a WARNING) + retry, re-raise a clear RuntimeError only on genuinely-incompatible saves. Sub-model strictness (extra=forbid) untouched; happy path unchanged. +5 tests (test_store.py), single-process green. Local-gated (Actions degraded).