### PR TITLE
fix(combat): next_turn blocks skipping an able PC's turn (+ use_action skip escape)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -2245,6 +2245,16 @@ def start_combat(
                 outlook = _outlook_for_xps(_party_levels(c), monster_xps)
                 if outlook.get("must_offer_out") or outlook.get("band") == "deadly":
                     view["outlook"] = outlook
+        # Surface whose turn it is at combat-start and make clear they must act BEFORE
+        # calling next_turn (the root cause of Round-1 skips: DM reads start_combat.current
+        # as already-done and immediately calls next_turn).
+        first_combatant = c.characters.get(c.combat.current_combatant_id)
+        if first_combatant is not None:
+            view["turn_instruction"] = (
+                f"It is now {first_combatant.name}'s turn (Round 1). "
+                f"Resolve their action (attack / cast_spell / use_action) BEFORE calling next_turn. "
+                f"'current' is WHO MUST ACT NOW — not a completed turn."
+            )
         save_campaign(c)
         return view
 
@@ -2514,6 +2524,30 @@ def next_turn(campaign_id: str) -> dict:
         if not c.combat.active or not order:
             raise ValueError("no active combat")
         previous = c.characters.get(c.combat.current_combatant_id)
+        # --- PC-skip guard (#160/#166): enforce that a PC/companion who CAN act has
+        # actually acted (or explicitly passed) before we advance past their turn.
+        # Rules-correct 5e: a creature takes an action or explicitly declares a pass;
+        # silent skip is never legal. Monsters/NPCs advance freely (DM runs them).
+        if previous is not None and previous.kind in ("player", "companion"):
+            outgoing_able = (
+                not combat.is_incapacitated(previous)
+                and previous.current_hp > 0
+                and not previous.dead
+                and not getattr(previous, "stable", False)  # stable/unconscious can't act anyway
+            )
+            # "Stable" PCs at 0 hp are unconscious — is_incapacitated covers most
+            # of this, but we also gate on hp>0 to be explicit.
+            outgoing_acted = (
+                c.combat.action_used
+                or c.combat.action_attacks_made > 0
+                or c.combat.bonus_action_used
+            )
+            if outgoing_able and not outgoing_acted:
+                raise ValueError(
+                    f"{previous.name} has not acted this turn — resolve their action "
+                    f"(attack / cast_spell / use_action) or declare a pass via "
+                    f"use_action(kind='skip') before advancing."
+                )
         n = len(order)
         cur = None
         new_round = False
@@ -2563,6 +2597,14 @@ def next_turn(campaign_id: str) -> dict:
         # Only when combat is active and there's a living current combatant.
         if cur is not None:
             view["turn_brief"] = _turn_brief(cur, c)
+            # Clarify to the DM that 'current' is WHO MUST ACT NOW — not a completed turn.
+            # This directly addresses the Round-1 skip pattern where the DM misread
+            # start_combat/next_turn's 'current' as the turn just finished.
+            view["turn_instruction"] = (
+                f"It is now {cur.name}'s turn (Round {c.combat.round}). "
+                f"Resolve their action (attack / cast_spell / use_action) BEFORE calling next_turn. "
+                f"'current' is WHO MUST ACT NOW — not a completed turn."
+            )
         _log_combat_event(
             c,
             f"Turn advances to {cur.name}." if cur else "Turn advances with no living combatant.",
@@ -2584,16 +2626,20 @@ def next_turn(campaign_id: str) -> dict:
 
 @mcp.tool()
 def use_action(campaign_id: str, character_id: str, kind: str = "action") -> dict:
-    """Track a combatant's action economy. kind: action | bonus | reaction | free.
+    """Track a combatant's action economy. kind: action | bonus | reaction | free | skip.
     `action`/`bonus` are legal only on the creature's OWN turn and only once each
     per turn; `reaction` is legal any time but once per round (it refreshes at the
     start of the creature's turn via next_turn); `free`/movement isn't rate-limited.
+    `skip` (a.k.a. pass) declares an intentional do-nothing turn for the current
+    combatant — sets action_used so next_turn's PC-skip guard is satisfied without
+    actually attacking or casting. Use it when a PC Dodges, Dashes, Disengages,
+    Readies, or simply passes their turn.
     Returns {ok, reason, action_available, bonus_available, reaction_available} so
     you can flag an illegal double-action. NOTE: multiattack (Extra Attack) is ONE
     action — declare a single `action`, then make several attack() calls under it."""
     kind = kind.lower()
-    if kind not in ("action", "bonus", "reaction", "free", "movement"):
-        raise ValueError("kind must be action | bonus | reaction | free")
+    if kind not in ("action", "bonus", "reaction", "free", "movement", "skip"):
+        raise ValueError("kind must be action | bonus | reaction | free | skip")
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         if not c.combat.active:
@@ -2614,6 +2660,17 @@ def use_action(campaign_id: str, character_id: str, kind: str = "action") -> dic
                 f"{', '.join(c.value for c in ch.conditions if c in combat.INCAPACITATING)}) "
                 f"and can't take an action, bonus action, or reaction"
             )
+        elif kind == "skip":
+            # Declare an intentional pass: satisfies the PC-skip guard in next_turn so
+            # the DM can advance the turn without the combatant attacking or casting.
+            # Only valid on the current combatant's turn; marks action_used so any
+            # subsequent use_action(kind='action') is properly rejected.
+            if not is_current:
+                ok, reason = False, f"it is not {ch.name}'s turn — skip must be declared on your own turn"
+            elif c.combat.action_used:
+                ok, reason = False, "action already used this turn (already acted or skipped)"
+            else:
+                c.combat.action_used = True
         elif kind in ("action", "bonus"):
             if not is_current:
                 ok, reason = False, f"it is not {ch.name}'s turn (only a reaction acts off-turn)"
@@ -3729,6 +3786,10 @@ def cast_spell(
         # is separate from the character, so the re-validation above didn't touch it).
         if cast_consumes_reaction and caster_cb is not None:
             caster_cb.reaction_used = True
+        # An on-turn cast consumes the combatant's action (mirrors attack()'s action_used
+        # bookkeeping). Required so next_turn's PC-skip guard recognises a spell as "acted".
+        elif caster_cb is not None and not cast_consumes_reaction:
+            c.combat.action_used = True
         save_campaign(c)
         updated = c.characters[character_id]
         result = {

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -226,6 +226,10 @@ def test_turn_advance_logs_structured_combat_event_payload(tmp_path, monkeypatch
     gob = server.create_character(cid, "Goblin", kind="monster", max_hp=7, armor_class=15)["id"]
 
     before = server.start_combat(cid, [hero, gob])
+    # Pass the outgoing combatant if it's the PC, then advance (#160 enforcement).
+    cur = server.get_state(cid)["current_turn"]
+    if server.get_character(cid, cur)["kind"] in ("player", "companion"):
+        server.use_action(cid, cur, "skip")
     advanced = server.next_turn(cid)
 
     camp = store.load_campaign(cid)
@@ -310,6 +314,11 @@ def test_next_turn_skips_dead(tmp_path, monkeypatch):  # H2
     server.apply_damage(cid, d, 100)  # d is dead
     seen = set()
     for _ in range(6):  # two laps
+        # PC must act or pass before next_turn advances past them (#160 enforcement).
+        cur = server.get_state(cid)["current_turn"]
+        ch = server.get_character(cid, cur)
+        if ch["kind"] in ("player", "companion"):
+            server.use_action(cid, cur, "skip")
         v = server.next_turn(cid)
         if v["current"]:
             seen.add(v["current"])
@@ -871,8 +880,10 @@ def test_next_turn_brief_monster_has_correct_multiattack_count(tmp_path, monkeyp
 
     sc = server.start_combat(cid, [pc, captain_id])
     # Captain has higher initiative → captain is turn_index=0 (first).
-    # next_turn → advances to the PC's turn.
+    # next_turn → advances to the PC's turn. Captain is outgoing (monster) → no guard.
     nt1 = server.next_turn(cid)
+    # PC is now current — must act or pass before next_turn (#160 enforcement).
+    server.use_action(cid, pc, "skip")
     # next_turn again → wraps back to the captain (new round).
     nt2 = server.next_turn(cid)
 
@@ -911,10 +922,16 @@ def test_next_turn_brief_pc_attack_numbers(tmp_path, monkeypatch):
     monster = server.create_character(cid, "Dummy", kind="monster", max_hp=5)["id"]
 
     server.start_combat(cid, [pc, monster])
-    # Call next_turn until we land on the PC.
+    # Call next_turn until we land on the PC. Pass the outgoing PC if needed (#160 enforcement).
+    cur = server.get_state(cid)["current_turn"]
+    if server.get_character(cid, cur)["kind"] in ("player", "companion"):
+        server.use_action(cid, cur, "skip")
     nt = server.next_turn(cid)
-    # If the first next_turn is the monster, advance one more.
+    # If the first next_turn is the monster, pass the monster's outgoing turn and advance once more.
     if nt.get("turn_brief", {}).get("kind") != "player":
+        cur2 = server.get_state(cid)["current_turn"]
+        if server.get_character(cid, cur2)["kind"] in ("player", "companion"):
+            server.use_action(cid, cur2, "skip")
         nt = server.next_turn(cid)
 
     brief = nt.get("turn_brief", {})
@@ -946,9 +963,15 @@ def test_next_turn_brief_pc_with_action_surge(tmp_path, monkeypatch):
     monster = server.create_character(cid, "Dummy", kind="monster", max_hp=5)["id"]
 
     server.start_combat(cid, [pc, monster])
-    # Find the PC's turn in next_turn responses
+    # Find the PC's turn in next_turn responses. Pass outgoing PCs (#160 enforcement).
+    cur = server.get_state(cid)["current_turn"]
+    if server.get_character(cid, cur)["kind"] in ("player", "companion"):
+        server.use_action(cid, cur, "skip")
     nt = server.next_turn(cid)
     if nt.get("turn_brief", {}).get("kind") != "player":
+        cur2 = server.get_state(cid)["current_turn"]
+        if server.get_character(cid, cur2)["kind"] in ("player", "companion"):
+            server.use_action(cid, cur2, "skip")
         nt = server.next_turn(cid)
 
     brief = nt.get("turn_brief", {})
@@ -1052,11 +1075,14 @@ def test_multiattack_monster_makes_two_attacks_third_rejected(tmp_path, monkeypa
     # initiative rolls are high; then next_turn places it first.
     # Simpler: start with both, then next_turn until the captain is current.
     server.start_combat(cid, [captain_id, pc])
-    # Advance turns until the Bandit Captain is current.
+    # Advance turns until the Bandit Captain is current. Pass outgoing PCs (#160).
     for _ in range(10):
         state = server.get_state(cid)
         if state["current_turn"] == captain_id:
             break
+        cur = state["current_turn"]
+        if server.get_character(cid, cur)["kind"] in ("player", "companion"):
+            server.use_action(cid, cur, "skip")
         server.next_turn(cid)
     assert server.get_state(cid)["current_turn"] == captain_id, (
         "Could not make Bandit Captain the current combatant — adjust test setup"
@@ -1153,11 +1179,14 @@ def test_multiattack_zero_path_unchanged(tmp_path, monkeypatch):
     wolf_id = res["spawned"][0]["id"]
 
     server.start_combat(cid, [wolf_id, pc])
-    # Advance until the wolf is current.
+    # Advance until the wolf is current. Pass any PC outgoing combatant first (#160).
     for _ in range(10):
         state = server.get_state(cid)
         if state["current_turn"] == wolf_id:
             break
+        cur = state["current_turn"]
+        if server.get_character(cid, cur)["kind"] in ("player", "companion"):
+            server.use_action(cid, cur, "skip")
         server.next_turn(cid)
     assert server.get_state(cid)["current_turn"] == wolf_id
 
@@ -1165,3 +1194,231 @@ def test_multiattack_zero_path_unchanged(tmp_path, monkeypatch):
     # Wolf has no Multiattack -> 2nd is rejected.
     with _pytest.raises(ValueError, match="already attacked this turn"):
         server.attack(cid, wolf_id, pc, attack_bonus=4, damage_dice="2d4+2")
+
+
+# =========================================================================
+# Issue #160/#166: Round-1 turn-skip enforcement in next_turn
+# =========================================================================
+# next_turn must BLOCK advancing past a PC/companion who can act but has not
+# acted or declared a pass this turn. Monsters/NPCs are never blocked.
+
+
+def test_next_turn_blocks_pc_who_has_not_acted(tmp_path, monkeypatch):
+    """BLOCK: next_turn raises when the outgoing PC has not acted or passed.
+
+    This is the core Round-1 skip defect — the DM calls next_turn immediately
+    after start_combat, silently skipping the highest-initiative PC's turn.
+    """
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+    import pytest as _pytest
+
+    cid = server.create_campaign("Turn Skip Block #160")["id"]
+    # Force PC to go first so the outgoing combatant on the first next_turn is the PC.
+    pc = server.create_character(cid, "Aria", kind="player", max_hp=20, armor_class=14)["id"]
+    mob = server.create_character(cid, "Goblin", kind="monster", max_hp=7, armor_class=15)["id"]
+    # Rig initiative so pc is always first.
+    import dice as dice_mod
+    _orig = dice_mod.roll
+    _call = [0]
+    def _rigged(expr, **kw):
+        r = _orig(expr, **kw)
+        if expr.startswith("1d20"):
+            _call[0] += 1
+            from dice import DiceRoll
+            total = 25 if _call[0] == 1 else 1
+            return DiceRoll(expression=expr, total=total, rolls=[total], is_d20=True, natural=total)
+        return r
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged)
+
+    server.start_combat(cid, [pc, mob])
+    assert server.get_state(cid)["current_turn"] == pc, "PC must be first for this test"
+
+    # next_turn with no action from PC must be rejected
+    with _pytest.raises(ValueError, match="has not acted this turn"):
+        server.next_turn(cid)
+
+
+def test_next_turn_allows_pc_after_attack(tmp_path, monkeypatch):
+    """ALLOW: next_turn succeeds when the outgoing PC attacked this turn."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Turn Skip After Attack #160")["id"]
+    pc = server.create_character(cid, "Aria", kind="player", max_hp=20, armor_class=14)["id"]
+    mob = server.create_character(cid, "Goblin", kind="monster", max_hp=7, armor_class=15)["id"]
+
+    # Rig PC first
+    _call = [0]
+    _orig = server.dice_mod.roll
+    def _rigged(expr, **kw):
+        r = _orig(expr, **kw)
+        if expr.startswith("1d20"):
+            _call[0] += 1
+            from dice import DiceRoll
+            total = 25 if _call[0] == 1 else 1
+            return DiceRoll(expression=expr, total=total, rolls=[total], is_d20=True, natural=total)
+        return r
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged)
+
+    server.start_combat(cid, [pc, mob])
+    assert server.get_state(cid)["current_turn"] == pc
+
+    server.attack(cid, pc, mob, attack_bonus=5, damage_dice="1d8+3")  # PC acted
+    view = server.next_turn(cid)  # must NOT raise
+    assert view["active"] is True
+
+
+def test_next_turn_allows_pc_after_use_action(tmp_path, monkeypatch):
+    """ALLOW: next_turn succeeds when the outgoing PC declared use_action(kind='action')."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Turn Skip After use_action #160")["id"]
+    pc = server.create_character(cid, "Aria", kind="player", max_hp=20, armor_class=14)["id"]
+    mob = server.create_character(cid, "Goblin", kind="monster", max_hp=7, armor_class=15)["id"]
+
+    _call = [0]
+    _orig = server.dice_mod.roll
+    def _rigged(expr, **kw):
+        r = _orig(expr, **kw)
+        if expr.startswith("1d20"):
+            _call[0] += 1
+            from dice import DiceRoll
+            total = 25 if _call[0] == 1 else 1
+            return DiceRoll(expression=expr, total=total, rolls=[total], is_d20=True, natural=total)
+        return r
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged)
+
+    server.start_combat(cid, [pc, mob])
+    assert server.get_state(cid)["current_turn"] == pc
+
+    server.use_action(cid, pc, "action")  # Dodge/Dash/Disengage/Ready/Help declared
+    view = server.next_turn(cid)  # must NOT raise
+    assert view["active"] is True
+
+
+def test_next_turn_allows_pc_after_skip(tmp_path, monkeypatch):
+    """ALLOW: use_action(kind='skip') is the pass escape — next_turn succeeds after it."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Turn Skip Pass Escape #160")["id"]
+    pc = server.create_character(cid, "Aria", kind="player", max_hp=20, armor_class=14)["id"]
+    mob = server.create_character(cid, "Goblin", kind="monster", max_hp=7, armor_class=15)["id"]
+
+    _call = [0]
+    _orig = server.dice_mod.roll
+    def _rigged(expr, **kw):
+        r = _orig(expr, **kw)
+        if expr.startswith("1d20"):
+            _call[0] += 1
+            from dice import DiceRoll
+            total = 25 if _call[0] == 1 else 1
+            return DiceRoll(expression=expr, total=total, rolls=[total], is_d20=True, natural=total)
+        return r
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged)
+
+    server.start_combat(cid, [pc, mob])
+    assert server.get_state(cid)["current_turn"] == pc
+
+    skip_result = server.use_action(cid, pc, "skip")
+    assert skip_result["ok"] is True, f"skip must be accepted; got {skip_result}"
+    view = server.next_turn(cid)  # must NOT raise after skip
+    assert view["active"] is True
+
+
+def test_next_turn_allows_incapacitated_pc(tmp_path, monkeypatch):
+    """NO BLOCK: an incapacitated (stunned/unconscious) PC is advanced without error.
+
+    A PC who CANNOT act must never trigger the skip-guard — they're already unable
+    to take an action and forcing a pass would be wrong.
+    """
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Incapacitated PC #160")["id"]
+    pc = server.create_character(cid, "Aria", kind="player", max_hp=20, armor_class=14)["id"]
+    mob = server.create_character(cid, "Goblin", kind="monster", max_hp=7, armor_class=15)["id"]
+
+    _call = [0]
+    _orig = server.dice_mod.roll
+    def _rigged(expr, **kw):
+        r = _orig(expr, **kw)
+        if expr.startswith("1d20"):
+            _call[0] += 1
+            from dice import DiceRoll
+            total = 25 if _call[0] == 1 else 1
+            return DiceRoll(expression=expr, total=total, rolls=[total], is_d20=True, natural=total)
+        return r
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged)
+
+    server.start_combat(cid, [pc, mob])
+    assert server.get_state(cid)["current_turn"] == pc
+
+    # Stun the PC — incapacitated, cannot act
+    server.add_condition(cid, pc, "stunned")
+    view = server.next_turn(cid)  # must NOT raise — incapacitated PC is not blocked
+    assert view["active"] is True
+
+
+def test_next_turn_allows_downed_pc(tmp_path, monkeypatch):
+    """NO BLOCK: a PC at 0 hp is advanced without error (they can't act, just death-save)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Downed PC #160")["id"]
+    pc = server.create_character(cid, "Aria", kind="player", max_hp=20, armor_class=14)["id"]
+    mob = server.create_character(cid, "Goblin", kind="monster", max_hp=7, armor_class=15)["id"]
+
+    _call = [0]
+    _orig = server.dice_mod.roll
+    def _rigged(expr, **kw):
+        r = _orig(expr, **kw)
+        if expr.startswith("1d20"):
+            _call[0] += 1
+            from dice import DiceRoll
+            total = 25 if _call[0] == 1 else 1
+            return DiceRoll(expression=expr, total=total, rolls=[total], is_d20=True, natural=total)
+        return r
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged)
+
+    server.start_combat(cid, [pc, mob])
+    assert server.get_state(cid)["current_turn"] == pc
+
+    # Drop the PC to 0 — they're downed, cannot take actions
+    server.apply_damage(cid, pc, 20)
+    assert server.get_character(cid, pc)["current_hp"] == 0
+    view = server.next_turn(cid)  # must NOT raise — 0-hp PC is not blocked
+    assert view["active"] is True
+
+
+def test_next_turn_monster_no_action_advances_freely(tmp_path, monkeypatch):
+    """NO BLOCK: a monster who took no action advances without error — guard is PC-only."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Monster Free Advance #160")["id"]
+    pc = server.create_character(cid, "Aria", kind="player", max_hp=20, armor_class=14)["id"]
+    mob = server.create_character(cid, "Goblin", kind="monster", max_hp=7, armor_class=15)["id"]
+
+    # Rig monster first
+    _call = [0]
+    _orig = server.dice_mod.roll
+    def _rigged(expr, **kw):
+        r = _orig(expr, **kw)
+        if expr.startswith("1d20"):
+            _call[0] += 1
+            from dice import DiceRoll
+            total = 25 if _call[0] == 1 else 1
+            return DiceRoll(expression=expr, total=total, rolls=[total], is_d20=True, natural=total)
+        return r
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged)
+
+    server.start_combat(cid, [mob, pc])
+    # mob is first (rigged higher initiative)
+    assert server.get_state(cid)["current_turn"] == mob
+
+    # Monster takes no action — next_turn must NOT raise
+    view = server.next_turn(cid)
+    assert view["active"] is True

--- a/servers/engine/tests/test_effect_durations.py
+++ b/servers/engine/tests/test_effect_durations.py
@@ -33,6 +33,17 @@ def _effects(cid, char_id):
     return server.get_character(cid, char_id)["active_effects"]
 
 
+def _advance_turn(cid):
+    """Pass the current PC/companion (if any) then call next_turn.
+    Required after #160 enforcement: a PC who can act must act or pass before next_turn."""
+    cur = server.get_state(cid).get("current_turn")
+    if cur:
+        ch = server.get_character(cid, cur)
+        if ch.get("kind") in ("player", "companion") and ch.get("current_hp", 1) > 0:
+            server.use_action(cid, cur, "skip")
+    return server.next_turn(cid)
+
+
 # --- duration parsing (pure) -------------------------------------------------
 @pytest.mark.parametrize(
     "text,scale,rounds",
@@ -137,9 +148,9 @@ def test_next_turn_decrements_and_expires_bless():
     expired = None
     last_round = 0
     # Two combatants -> 2 next_turns per round. Bless ticks once per round; the 10th
-    # decrement (start of round 11) expires it.
+    # decrement (start of round 11) expires it. Use _advance_turn to pass PCs first (#160).
     for _ in range(30):
-        v = server.next_turn(cid)
+        v = _advance_turn(cid)
         last_round = v["round"]
         if v["expired_effects"]:
             expired = v
@@ -160,9 +171,9 @@ def test_round_decrement_is_per_round_not_per_turn():
     server.cast_spell(cid, c, "Bless")
     server.start_combat(cid, [c, foe])
     before = _effects(cid, c)[0]["rounds_remaining"]
-    server.next_turn(cid)  # advance one turn (1 of 2) — no round wrap yet
+    _advance_turn(cid)  # advance one turn (1 of 2) — no round wrap yet; pass PC if needed (#160)
     assert _effects(cid, c)[0]["rounds_remaining"] == before  # unchanged mid-round
-    server.next_turn(cid)  # wrap -> round 2 -> decrement
+    _advance_turn(cid)  # wrap -> round 2 -> decrement
     assert _effects(cid, c)[0]["rounds_remaining"] == before - 1
 
 
@@ -216,8 +227,8 @@ def test_recasting_same_spell_refreshes_not_stacks():
     foe = server.create_character(cid, "Goblin", kind="monster", max_hp=30)["id"]
     server.cast_spell(cid, c, "Bless")
     server.start_combat(cid, [c, foe])
-    server.next_turn(cid)
-    server.next_turn(cid)  # round 2 -> Bless 10 -> 9
+    _advance_turn(cid)       # pass PC if needed, then advance (#160)
+    _advance_turn(cid)  # round 2 -> Bless 10 -> 9
     assert _effects(cid, c)[0]["rounds_remaining"] == 9
     server.cast_spell(cid, c, "Bless")  # recast refreshes
     eff = _effects(cid, c)
@@ -334,8 +345,8 @@ def test_mage_armor_survives_combat_but_expires_on_long_rest():
     assert out["active_effect"]["scale"] == "hours"
     foe = server.create_character(cid, "Goblin", kind="monster", max_hp=20)["id"]
     server.start_combat(cid, [w, foe])
-    for _ in range(12):  # several rounds of combat
-        server.next_turn(cid)
+    for _ in range(12):  # several rounds of combat; pass PCs before advancing (#160)
+        _advance_turn(cid)
     assert [e["name"] for e in _effects(cid, w)] == ["Mage Armor"]  # still up
     server.end_combat(cid)
     lr = server.long_rest(cid, w)  # overnight ends the 8h buff


### PR DESCRIPTION
Closes the #1 combat-fidelity residual (#160/#166): the DM next_turn's past an able PC who took no action (the recurring Round-1 skip; angry-dm capped ~3.3). next_turn now REJECTS advancing past a PC/companion who is able-to-act and took no action this turn, with a clean use_action(kind='skip') pass escape; also fixes on-turn cast_spell not marking action_used + adds a turn_instruction clarity key to start_combat/next_turn. Scoped to PC/companion (monsters unchanged), additive. 9 pre-existing tests that modeled the skip were updated to act/pass (no assertions weakened); 7 new tests; FULL suite 1121 passed single-process. Local-gated.