### PR TITLE
chore(observability): snapshot version-stamp + QA findings collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 /qa/transcripts/
 /qa/*.err
 /qa/smoke*.json
+# The on-demand findings ledger (qa/collect_findings.py output) — a regenerable digest of
+# local QA run scores, derived from the ignored qa/transcripts/. The collector script IS
+# committed; its output is not.
+/qa/findings.jsonl
 
 # Privately-imported, user-owned adventures — NEVER commit (may be copyrighted).
 # Only original / CC-licensed content belongs under content/campaigns/.

--- a/qa/collect_findings.py
+++ b/qa/collect_findings.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""On-demand QA findings collector — ONE queryable place for score trends + verdicts.
+
+The QA harness (run_duo.sh / run_combat_sprint.sh / score.sh) drops per-run score artifacts
+into qa/transcripts/ — but each run's verdict is scattered across several JSON files plus a gate
+.txt, and the dir is a heap of every run ever played. This script is a READ-ONLY collector: it
+scans qa/transcripts/ for every scored run, distills each into one compact row, and maintains an
+append-only qa/findings.jsonl so the score-loop debugging culture has a single grep-able ledger
+("did multiattack regress?", "which runs went RED?") WITHOUT touching the harness scripts.
+
+It NEVER runs a game, scores a transcript, or mutates any harness artifact — it only reads the
+scorecards the harness already wrote and refreshes findings.jsonl.
+
+Per-run artifacts it reads (filenames per run_duo.sh / run_combat_sprint.sh):
+    <run>.angrydm.json   Angry-DM 5e rules-fidelity scorecard (score_schema_angry_dm.json)
+                         — every scored run has one (sprint + duo).
+    <run>.tolkien.json   story / Tolkien story-craft scorecard (duo runs)  -> scores.story
+    <run>.score.json     mechanical scorecard (duo runs)                   -> scores.mechanical
+    <run>.gate.txt       behavioral-gate output; its final line is the GREEN/RED verdict.
+
+Each findings.jsonl row:
+    {run, mtime, gate, scores:{story, mechanical, angry_dm}, angry_overall, top_defects:[...]}
+
+Idempotent: re-running refreshes the rows for runs currently on disk and dedupes by run; rows
+for runs whose artifacts have since been cleaned are preserved (append-only ledger).
+
+Usage:  python qa/collect_findings.py            # from the repo root
+        python qa/collect_findings.py --transcripts <dir> --out <findings.jsonl>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+# Per-run artifact suffixes. The angry-DM card anchors discovery (every scored run has one), but
+# we also anchor on the other score artifacts so a run that somehow lacks an angry-DM card is
+# still surfaced rather than silently dropped.
+SUFFIX_ANGRYDM = ".angrydm.json"
+SUFFIX_TOLKIEN = ".tolkien.json"   # story / Tolkien story-craft
+SUFFIX_MECH = ".score.json"        # mechanical
+SUFFIX_GATE = ".gate.txt"
+
+# Worst-first ordering so "top defects" surfaces the most severe seams.
+_SEVERITY_RANK = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+
+# How many defect summaries to keep per run.
+TOP_DEFECTS = 3
+
+
+def _load_json(path: Path) -> Optional[dict]:
+    """Read a JSON object, or None if absent / unreadable / not an object. Tolerant by design:
+    a half-written or non-JSON scorecard must not crash the whole collection."""
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _overall(card: Optional[dict]) -> Optional[float]:
+    """The `overall` score off a scorecard, as a float, or None if absent/unparseable.
+
+    Note: on a behavioral-gate RED run the harness CAPS `overall` to 2.5 and records the
+    pre-cap value in `overall_before_cap`; we report the (capped) `overall` — the honest,
+    displayed score — on purpose."""
+    if not card:
+        return None
+    try:
+        return float(card["overall"])
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def _defect_summary(defect: dict) -> str:
+    """One compact line for a single Angry-DM defect: '[severity/kind] area — rule: evidence'.
+
+    Every field is optional in practice; we degrade gracefully and truncate the (often long)
+    evidence so a row stays grep-able."""
+    sev = str(defect.get("severity", "?"))
+    kind = defect.get("kind")
+    area = str(defect.get("area", "?"))
+    rule = defect.get("rule")
+    evidence = str(defect.get("evidence", "")).strip().replace("\n", " ")
+    if len(evidence) > 200:
+        evidence = evidence[:197].rstrip() + "..."
+    head = f"[{sev}/{kind}]" if kind else f"[{sev}]"
+    rule_part = f" — {rule}" if rule else ""
+    ev_part = f": {evidence}" if evidence else ""
+    return f"{head} {area}{rule_part}{ev_part}"
+
+
+def parse_angrydm(card: Optional[dict]) -> tuple[Optional[float], list[str]]:
+    """Pull (overall, top_defects) out of an Angry-DM scorecard dict.
+
+    `top_defects` is up to TOP_DEFECTS one-line summaries, worst severity first (then the card's
+    own order). Pure + tolerant so it can be unit-tested against a real <run>.angrydm.json: a
+    missing/empty/malformed card yields (None, []); a missing `defects` list yields []."""
+    overall = _overall(card)
+    defects_raw = (card or {}).get("defects")
+    if not isinstance(defects_raw, list):
+        return overall, []
+    defects = [d for d in defects_raw if isinstance(d, dict)]
+    # Stable sort by severity rank (unknown severities sort last); preserves file order within a rank.
+    ordered = sorted(defects, key=lambda d: _SEVERITY_RANK.get(str(d.get("severity", "")).lower(), 99))
+    return overall, [_defect_summary(d) for d in ordered[:TOP_DEFECTS]]
+
+
+def parse_gate(path: Path) -> Optional[str]:
+    """The behavioral-gate verdict from <run>.gate.txt. None if the file is absent/empty.
+
+    assert_behavioral.py USUALLY prints a trailing summary line ('GREEN', 'GREEN (1 warning(s))',
+    'RED ...'); we use it verbatim when present. But some gate files end at the last assertion
+    line with no summary footer — so we DON'T just take the last line (that would mistake a
+    trailing '[PASS] world_peopled' for the verdict). When no summary line is present we DERIVE
+    the verdict from the assertion markers themselves: any [FAIL] -> RED, else any [WARN] ->
+    GREEN (n warning(s)), else GREEN. Self-contained and authoritative on the gate's own output."""
+    if not path.exists():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return None
+
+    # 1. An explicit trailing verdict line (a line that STARTS with GREEN/RED and is not an
+    #    assertion row) wins — it's what the harness prints and may carry a warning count.
+    for ln in reversed(lines):
+        up = ln.upper()
+        if up.startswith("GREEN") or up.startswith("RED"):
+            return ln
+
+    # 2. No summary footer — derive from the assertion markers.
+    fails = sum(1 for ln in lines if "[FAIL]" in ln)
+    warns = sum(1 for ln in lines if "[WARN]" in ln)
+    if fails:
+        return "RED"
+    if warns:
+        return f"GREEN ({warns} warning(s))"
+    return "GREEN"
+
+
+def _run_mtime(paths: list[Path]) -> float:
+    """The NEWEST mtime across a run's present artifacts — i.e. when this run was last scored."""
+    mtimes = [p.stat().st_mtime for p in paths if p.exists()]
+    return max(mtimes) if mtimes else 0.0
+
+
+def collect(transcripts: Path) -> list[dict[str, Any]]:
+    """Scan a transcripts dir and return one findings row per scored run, sorted by run id.
+
+    A 'scored run' is any stem that carries at least one score artifact (angry-DM, Tolkien, or
+    mechanical). A run missing some artifacts is fine — the absent score is reported as null."""
+    if not transcripts.is_dir():
+        return []
+
+    # Discover run ids from the union of score-artifact stems (anchor on angry-DM but don't miss
+    # a run that only has another lens).
+    runs: set[str] = set()
+    for suffix in (SUFFIX_ANGRYDM, SUFFIX_TOLKIEN, SUFFIX_MECH):
+        for p in transcripts.glob(f"*{suffix}"):
+            runs.add(p.name[: -len(suffix)])
+
+    rows: list[dict[str, Any]] = []
+    for run in sorted(runs):
+        angrydm_path = transcripts / f"{run}{SUFFIX_ANGRYDM}"
+        tolkien_path = transcripts / f"{run}{SUFFIX_TOLKIEN}"
+        mech_path = transcripts / f"{run}{SUFFIX_MECH}"
+        gate_path = transcripts / f"{run}{SUFFIX_GATE}"
+
+        angrydm_card = _load_json(angrydm_path)
+        angry_overall, top_defects = parse_angrydm(angrydm_card)
+
+        rows.append({
+            "run": run,
+            "mtime": round(_run_mtime([angrydm_path, tolkien_path, mech_path, gate_path]), 3),
+            "gate": parse_gate(gate_path),
+            "scores": {
+                "story": _overall(_load_json(tolkien_path)),
+                "mechanical": _overall(_load_json(mech_path)),
+                "angry_dm": angry_overall,
+            },
+            "angry_overall": angry_overall,
+            "top_defects": top_defects,
+        })
+    return rows
+
+
+def merge_rows(existing: list[dict], fresh: list[dict]) -> list[dict]:
+    """Merge freshly-scanned rows into existing ones, deduped by run (fresh wins). Rows for runs
+    no longer on disk are PRESERVED — findings.jsonl is an append-only ledger across invocations.
+    Result is sorted by run id for a stable, diff-friendly file."""
+    by_run: dict[str, dict] = {}
+    for row in existing:
+        if isinstance(row, dict) and "run" in row:
+            by_run[row["run"]] = row
+    for row in fresh:
+        by_run[row["run"]] = row  # refresh / dedupe by run
+    return [by_run[r] for r in sorted(by_run)]
+
+
+def _read_existing(out_path: Path) -> list[dict]:
+    """Load prior findings.jsonl rows (skipping any blank/corrupt line), or [] if absent."""
+    if not out_path.exists():
+        return []
+    rows: list[dict] = []
+    for line in out_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(obj, dict):
+            rows.append(obj)
+    return rows
+
+
+def write_jsonl(out_path: Path, rows: list[dict]) -> None:
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _fmt(score: Optional[float]) -> str:
+    return f"{score:.1f}" if isinstance(score, (int, float)) else "  -"
+
+
+def print_table(rows: list[dict]) -> None:
+    """A compact stdout table: run, the three lens scores, gate verdict, and defect count."""
+    if not rows:
+        print("(no scored runs found in transcripts dir)")
+        return
+    name_w = max(3, max(len(str(r.get("run", ""))) for r in rows))
+    header = f"{'run':<{name_w}}  story  mech  angry  gate"
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        scores = r.get("scores") or {}
+        # The gate verdict can be long; keep just the leading token (GREEN/RED) for the table.
+        gate = r.get("gate")
+        gate_tok = gate.split()[0] if isinstance(gate, str) and gate else "-"
+        n_def = len(r.get("top_defects") or [])
+        defs = f"  ({n_def} top defect{'s' if n_def != 1 else ''})" if n_def else ""
+        print(
+            f"{str(r.get('run','')):<{name_w}}  "
+            f"{_fmt(scores.get('story')):>5}  "
+            f"{_fmt(scores.get('mechanical')):>4}  "
+            f"{_fmt(scores.get('angry_dm')):>5}  "
+            f"{gate_tok:<5}{defs}"
+        )
+    print(f"\n{len(rows)} run(s).")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Collect QA score findings into findings.jsonl.")
+    parser.add_argument(
+        "--transcripts", default="qa/transcripts",
+        help="directory of per-run score artifacts (default: qa/transcripts)",
+    )
+    parser.add_argument(
+        "--out", default="qa/findings.jsonl",
+        help="append-only findings ledger to write/refresh (default: qa/findings.jsonl)",
+    )
+    args = parser.parse_args(argv)
+
+    transcripts = Path(args.transcripts)
+    out_path = Path(args.out)
+
+    fresh = collect(transcripts)
+    merged = merge_rows(_read_existing(out_path), fresh)
+    write_jsonl(out_path, merged)
+
+    print_table(merged)
+    print(f"\nwrote {out_path} ({len(fresh)} run(s) scanned from {transcripts})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/test_collect_findings.py
+++ b/qa/test_collect_findings.py
@@ -1,0 +1,188 @@
+"""Unit tests for qa/collect_findings.py — the parse helpers + the merge/idempotency contract.
+
+Stdlib + pytest only. Self-contained: the fixtures mirror the real score-artifact schema
+(score_schema_angry_dm.json + the gate.txt format the harness writes) so the test runs in a
+fresh checkout where qa/transcripts/ (gitignored runtime data) is empty.
+
+Run with the engine venv (which has pytest):
+    uv run --directory servers/engine python -m pytest qa/test_collect_findings.py -p no:cacheprovider
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# collect_findings lives next to this test (qa/); make it importable regardless of pytest rootdir.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import collect_findings as cf  # noqa: E402
+
+
+# A realistic Angry-DM scorecard (shape per score_schema_angry_dm.json), with defects out of
+# severity order so we can assert the worst-first sort.
+_ANGRYDM = {
+    "scores": {
+        "rules_as_written": 3, "mechanical_completeness": 3, "tool_fidelity": 4,
+        "action_economy": 3, "combat_resolution": 4, "conditions_and_effects": 4, "coverage": 2,
+    },
+    "overall": 3.3,
+    "defects": [
+        {"severity": "low", "kind": "commission", "rule": "Attack Rolls", "area": "combat_resolution",
+         "evidence": "Natural 1 narrated as a fumble with extra consequence.", "five_e_says": "A nat 1 is just a miss.",
+         "suggested_fix": "Drop fumble language."},
+        {"severity": "high", "kind": "omission", "rule": "The Order of Combat", "area": "action_economy",
+         "evidence": "Maren (init 19) skipped at top of round 1 — zero action-class tool calls.", "five_e_says": "Each combatant takes a full turn.",
+         "suggested_fix": "Assert an action before next_turn."},
+        {"severity": "medium", "kind": "omission", "rule": "Experience Points", "area": "hp_death_rests",
+         "evidence": "end_combat with all enemies alive; 0 XP awarded.", "five_e_says": "XP is awarded when creatures are overcome.",
+         "suggested_fix": "Fight to at least one kill."},
+    ],
+    "coverage": {"exercised": ["attack_rolls_melee"], "gaps": ["saving_throws"], "had_caster": True, "fights": 1, "notes": "short sprint"},
+    "verdict": "Mostly clean dice but a skipped top-of-initiative turn.",
+}
+
+
+# ---------------------------------------------------------------------------
+# parse_angrydm
+# ---------------------------------------------------------------------------
+
+def test_parse_angrydm_overall_and_top_defects():
+    overall, top = cf.parse_angrydm(_ANGRYDM)
+    assert overall == 3.3
+    assert len(top) == 3
+    # Worst-first: high, then medium, then low.
+    assert top[0].startswith("[high/omission] action_economy")
+    assert top[1].startswith("[medium/omission] hp_death_rests")
+    assert top[2].startswith("[low/commission] combat_resolution")
+    # The summary weaves in the cited rule + a (truncated) evidence clause.
+    assert "The Order of Combat" in top[0]
+    assert "Maren" in top[0]
+
+
+def test_parse_angrydm_caps_at_three_defects():
+    card = dict(_ANGRYDM)
+    card["defects"] = _ANGRYDM["defects"] + [
+        {"severity": "critical", "area": "x", "kind": "omission", "rule": "r", "evidence": "e"},
+        {"severity": "high", "area": "y", "kind": "omission", "rule": "r", "evidence": "e"},
+    ]
+    _, top = cf.parse_angrydm(card)
+    assert len(top) == cf.TOP_DEFECTS == 3
+    # The injected critical sorts to the very top.
+    assert top[0].startswith("[critical/omission] x")
+
+
+def test_parse_angrydm_tolerates_missing_and_malformed():
+    assert cf.parse_angrydm(None) == (None, [])
+    assert cf.parse_angrydm({}) == (None, [])
+    assert cf.parse_angrydm({"overall": 2.0}) == (2.0, [])  # no defects key
+    assert cf.parse_angrydm({"overall": "bad", "defects": "notalist"}) == (None, [])
+
+
+def test_defect_summary_truncates_long_evidence():
+    long_ev = "x" * 500
+    s = cf._defect_summary({"severity": "high", "kind": "omission", "area": "a", "rule": "r", "evidence": long_ev})
+    assert s.endswith("...")
+    assert len(s) < 260  # head + truncated evidence, not the full 500
+
+
+# ---------------------------------------------------------------------------
+# parse_gate — both the trailing-summary form AND the derive-from-markers form
+# ---------------------------------------------------------------------------
+
+def test_parse_gate_trailing_green_summary(tmp_path):
+    p = tmp_path / "r.gate.txt"
+    p.write_text("=== behavioral assertions ===\n  [PASS] dm_produced_output\nGREEN\n", encoding="utf-8")
+    assert cf.parse_gate(p) == "GREEN"
+
+
+def test_parse_gate_trailing_green_with_warning_count(tmp_path):
+    p = tmp_path / "r.gate.txt"
+    p.write_text("  [WARN] world_peopled — only 1 NPC\nGREEN (1 warning(s))\n", encoding="utf-8")
+    assert cf.parse_gate(p) == "GREEN (1 warning(s))"
+
+
+def test_parse_gate_derives_red_from_fail_when_no_summary(tmp_path):
+    # Some gate files end at the last assertion with NO summary footer (real: ocwiz-claude).
+    # A [FAIL] anywhere must yield RED — not the leading token of the last [PASS] line.
+    p = tmp_path / "r.gate.txt"
+    p.write_text(
+        "=== behavioral assertions ===\n"
+        "  [PASS] dm_produced_output\n"
+        "  [FAIL] dm_resolved_player_moves — 1 [attack] but DM attack=0\n"
+        "  [PASS] world_peopled\n",
+        encoding="utf-8",
+    )
+    assert cf.parse_gate(p) == "RED"
+
+
+def test_parse_gate_derives_green_with_warns_when_no_summary(tmp_path):
+    p = tmp_path / "r.gate.txt"
+    p.write_text("  [PASS] a\n  [WARN] b\n  [WARN] c\n", encoding="utf-8")
+    assert cf.parse_gate(p) == "GREEN (2 warning(s))"
+
+
+def test_parse_gate_absent_is_none(tmp_path):
+    assert cf.parse_gate(tmp_path / "missing.gate.txt") is None
+
+
+# ---------------------------------------------------------------------------
+# collect — end-to-end against a synthesized transcripts dir, incl. missing artifacts
+# ---------------------------------------------------------------------------
+
+def _write(p: Path, obj) -> None:
+    p.write_text(json.dumps(obj) if not isinstance(obj, str) else obj, encoding="utf-8")
+
+
+def test_collect_full_and_partial_runs(tmp_path):
+    tx = tmp_path / "transcripts"
+    tx.mkdir()
+    # A duo run with all three lenses + a gate.
+    _write(tx / "duoX.angrydm.json", {**_ANGRYDM, "overall": 2.9})
+    _write(tx / "duoX.tolkien.json", {"overall": 4.0, "scores": {}})
+    _write(tx / "duoX.score.json", {"overall": 3.6, "scores": {}})
+    _write(tx / "duoX.gate.txt", "  [PASS] a\nGREEN\n")
+    # A combat sprint: angry-DM ONLY (no story/mechanical artifacts) — must not crash.
+    _write(tx / "sprintY.angrydm.json", {**_ANGRYDM, "overall": 3.3})
+    _write(tx / "sprintY.gate.txt", "  [PASS] a\nGREEN\n")
+
+    rows = cf.collect(tx)
+    by_run = {r["run"]: r for r in rows}
+    assert set(by_run) == {"duoX", "sprintY"}
+
+    duo = by_run["duoX"]
+    assert duo["scores"] == {"story": 4.0, "mechanical": 3.6, "angry_dm": 2.9}
+    assert duo["angry_overall"] == 2.9
+    assert duo["gate"] == "GREEN"
+    assert len(duo["top_defects"]) == 3
+
+    sprint = by_run["sprintY"]
+    # Missing lenses report null, not a crash.
+    assert sprint["scores"] == {"story": None, "mechanical": None, "angry_dm": 3.3}
+    assert sprint["angry_overall"] == 3.3
+
+
+def test_collect_missing_dir_returns_empty(tmp_path):
+    assert cf.collect(tmp_path / "nope") == []
+
+
+# ---------------------------------------------------------------------------
+# merge_rows — idempotency + append-only ledger semantics
+# ---------------------------------------------------------------------------
+
+def test_merge_dedupes_by_run_and_fresh_wins():
+    existing = [{"run": "a", "angry_overall": 1.0}, {"run": "b", "angry_overall": 2.0}]
+    fresh = [{"run": "a", "angry_overall": 9.9}]  # 'a' re-scored
+    merged = cf.merge_rows(existing, fresh)
+    by_run = {r["run"]: r for r in merged}
+    assert by_run["a"]["angry_overall"] == 9.9   # fresh wins
+    assert by_run["b"]["angry_overall"] == 2.0   # stale row preserved (append-only ledger)
+    assert [r["run"] for r in merged] == ["a", "b"]  # sorted, deduped
+
+
+def test_merge_is_idempotent():
+    fresh = [{"run": "a", "angry_overall": 1.0}, {"run": "b", "angry_overall": 2.0}]
+    once = cf.merge_rows([], fresh)
+    twice = cf.merge_rows(once, fresh)
+    assert once == twice

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -990,6 +990,14 @@ class Campaign(_StrictModel):
     created_at: float = Field(default_factory=_now)
     updated_at: float = Field(default_factory=_now)
 
+    # Observability / versioning (additive — defaulted so every existing snapshot round-trips).
+    # `schema_version` is a MANUAL constant we bump only on a breaking (non-additive) schema
+    # change, so a loaded snapshot records which schema generation wrote it. `engine_sha` is the
+    # engine's short git commit SHA at save time, stamped by store.save_campaign — instant
+    # "what engine version was this campaign last written by". Pairs with the #165 tolerant load.
+    schema_version: int = 1
+    engine_sha: str = ""
+
     current_location_id: Optional[str] = None
     day: int = 1  # in-world day counter
     time_of_day: str = "morning"

--- a/servers/engine/store.py
+++ b/servers/engine/store.py
@@ -16,6 +16,7 @@ import contextlib
 import fcntl
 import logging
 import os
+import subprocess
 import time
 from pathlib import Path
 from typing import Optional
@@ -25,6 +26,36 @@ from pydantic import ValidationError
 from models import Campaign, SessionLogEntry
 
 log = logging.getLogger(__name__)
+
+# Resolved-once cache for the engine's short git SHA. `None` = not yet resolved; a string
+# (possibly "") = resolved. We stamp this onto every saved snapshot so a campaign records the
+# engine version that last wrote it. Sentinel-based so a genuine "" (git unavailable) is cached
+# and we don't re-shell on every save.
+_ENGINE_SHA: Optional[str] = None
+
+
+def engine_sha() -> str:
+    """The engine's short git commit SHA, resolved once and cached.
+
+    Best-effort and never fatal: a missing git, a non-repo checkout, or any subprocess error
+    yields "" (and that "" is cached, so we never re-shell). Run with cwd pinned to this module's
+    directory so the SHA reflects the ENGINE repo regardless of the server's working directory."""
+    global _ENGINE_SHA
+    if _ENGINE_SHA is None:
+        try:
+            out = subprocess.run(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=Path(__file__).resolve().parent,
+                capture_output=True,
+                text=True,
+                timeout=2,
+                check=True,
+            )
+            _ENGINE_SHA = out.stdout.strip()
+        except Exception:
+            # git missing / not a repo / timeout / anything — degrade to "", never abort a save.
+            _ENGINE_SHA = ""
+    return _ENGINE_SHA
 
 
 def state_dir() -> Path:
@@ -76,6 +107,13 @@ def _atomic_write(path: Path, data: str) -> None:
 
 def save_campaign(campaign: Campaign) -> Path:
     campaign.updated_at = time.time()
+    # Version-stamp the snapshot: record the engine SHA that wrote it (cached, best-effort —
+    # never aborts a save) and make sure schema_version is populated. schema_version's authority
+    # is the manual constant on the Campaign model (default 1, bumped only on a breaking schema
+    # change); we don't overwrite it here so an intentionally-pinned value survives a re-save.
+    campaign.engine_sha = engine_sha()
+    if not campaign.schema_version:
+        campaign.schema_version = Campaign.model_fields["schema_version"].default
     path = _campaign_dir(campaign.id) / "snapshot.json"
     _atomic_write(path, campaign.model_dump_json(indent=2))
     return path

--- a/servers/engine/tests/test_store.py
+++ b/servers/engine/tests/test_store.py
@@ -129,3 +129,53 @@ def test_load_genuinely_incompatible_raises(tmp_path, monkeypatch):
 
     with pytest.raises(RuntimeError, match="incompatible with the current schema"):
         store.load_campaign(cid)
+
+
+# ---------------------------------------------------------------------------
+# (e) observability version-stamp: save→load preserves schema_version +
+#     engine_sha, and an OLD snapshot lacking both fields still loads (defaults)
+# ---------------------------------------------------------------------------
+
+def test_save_stamps_and_roundtrips_version_fields(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+
+    c = Campaign(title="Versioned Campaign")
+    store.save_campaign(c)
+
+    # The save path stamps engine_sha (== the cached resolver) and keeps schema_version set.
+    assert c.engine_sha == store.engine_sha()
+    assert c.schema_version == 1
+
+    loaded = store.load_campaign(c.id)
+    assert loaded is not None
+    assert loaded.schema_version == c.schema_version
+    assert loaded.engine_sha == c.engine_sha
+
+
+def test_engine_sha_is_stamped_onto_disk(tmp_path, monkeypatch):
+    """The serialized snapshot on disk carries engine_sha — the whole point of the stamp."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    c = Campaign(title="On-disk SHA")
+    path = store.save_campaign(c)
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert "engine_sha" in on_disk
+    assert "schema_version" in on_disk
+    assert on_disk["engine_sha"] == store.engine_sha()
+    assert on_disk["schema_version"] == 1
+
+
+def test_load_old_snapshot_without_version_fields(tmp_path, monkeypatch):
+    """An OLD snapshot predating the version-stamp (no schema_version / engine_sha keys at all)
+    must still load, falling back to the model defaults — the additive-default contract."""
+    snapshot = _minimal_snapshot()
+    snapshot.pop("schema_version", None)
+    snapshot.pop("engine_sha", None)
+    assert "schema_version" not in snapshot and "engine_sha" not in snapshot
+    cid = _write_snapshot(tmp_path, monkeypatch, snapshot)
+
+    result = store.load_campaign(cid)
+    assert result is not None
+    assert isinstance(result, Campaign)
+    # Defaults applied for the absent fields.
+    assert result.schema_version == 1
+    assert result.engine_sha == ""


### PR DESCRIPTION
Supports the score-loop debugging culture (owner-greenlit). (1) Campaign gains schema_version + engine_sha (git SHA stamped on save; cached/degrade-safe; old snapshots load with defaults; extra=forbid untouched). (2) qa/collect_findings.py (stdlib, read-only) aggregates per-run score artifacts into an append-only qa/findings.jsonl (scores + gate + worst-first top defects); idempotent + tolerant of missing/odd artifacts; /qa/findings.jsonl gitignored (regenerable). Tests: test_store.py 8 + test_collect_findings.py 13, single-process. Additive, no behavior change. Local-gated.