### PR TITLE
feat(quest): rule-of-three evolution (Quest.evolves_to + callback) — Quest&Arc Layer 1

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -533,6 +533,14 @@ class Quest(_StrictModel):
     completed_objectives: list[str] = Field(default_factory=list)
     giver_id: Optional[str] = None  # the NPC who gave the quest
     location_id: Optional[str] = None  # where it's anchored
+    # Rule-of-three evolution (Quest & Arc engine, Layer 1) — ADDITIVE: empty ==
+    # today's behavior exactly, old snapshots round-trip. When a quest resolves
+    # (status -> completed) AND `evolves_to` is set, the engine SCHEDULES a
+    # follow-on Consequence so the thread lingers/echoes instead of being
+    # one-and-done. The DM weaves the resulting prompt; the engine never
+    # auto-acts on the fiction.
+    evolves_to: str = ""  # a follow-on hook/quest id or a free seed tag the DM weaves on callback
+    callback_in_days: int = 0  # in-world days from resolution before the evolution surfaces (0 = immediately due)
 
 
 class Location(_StrictModel):
@@ -930,7 +938,7 @@ class SceneDebt(_StrictModel):
     Old snapshots without this field deserialise unchanged.
 
     kind values:
-        hook_untracked, quest_stalled, choice_without_outcome,
+        hook_untracked, quest_stalled, thread_no_payoff, choice_without_outcome,
         due_consequence, thread_pressure, npc_introduced_silent
     severity: low | med | high
     """

--- a/servers/engine/scene_debt.py
+++ b/servers/engine/scene_debt.py
@@ -103,7 +103,30 @@ def _quest_has_decision_callback(c: Campaign, quest_id: str, quest_title: str, w
     return False
 
 
-# ── 6 structural detectors ───────────────────────────────────────────────────
+def _quest_has_followon(c: Campaign, quest_id: str, quest_title: str) -> bool:
+    """Return True if a resolved quest already has SOME payoff/echo wired: a
+    scheduled Consequence that grew from it (the rule-of-three ``evolves_from:<id>``
+    note, or any consequence whose text/note references the quest id/title), or a
+    quest_hook that arcs back to it (by id reference in its fields). Used to tell a
+    resolved-but-echoing thread from a resolved-and-forgotten one."""
+    title_lower = (quest_title or "").lower()
+    evolves_note = f"evolves_from:{quest_id}"
+    for con in c.consequences:
+        if con.note == evolves_note:
+            return True
+        blob = (con.text + " " + con.note).lower()
+        if quest_id in blob or (title_lower and title_lower in blob):
+            return True
+    for h in c.quest_hooks:
+        blob = (h.title + " " + h.arc_back + " " + h.note).lower()
+        if quest_id in blob or (title_lower and title_lower in blob):
+            return True
+        if quest_id in h.prereq:
+            return True
+    return False
+
+
+# ── structural detectors ──────────────────────────────────────────────────────
 
 
 def _detect_hook_untracked(c: Campaign) -> list[SceneDebt]:
@@ -154,6 +177,37 @@ def _detect_quest_stalled(c: Campaign) -> list[SceneDebt]:
                 ),
                 severity="med",
                 evidence={"quest_id": q.id, "quest_title": q.title, "campaign_day": c.day},
+            )
+        )
+    return debts
+
+
+def _detect_quest_no_followon(c: Campaign) -> list[SceneDebt]:
+    """thread_no_payoff — a RESOLVED Quest (status == 'completed') with NO follow-on:
+    empty ``evolves_to`` AND no consequence/hook referencing it. The rule-of-three
+    nudge: every thread should echo. ADVISORY only (severity low) — the Director
+    surfaces it so the DM can set ``evolves_to`` / schedule a callback; the engine
+    NEVER auto-acts. A quest that already evolves (``evolves_to`` set) or already has
+    a payoff wired is NOT flagged."""
+    debts: list[SceneDebt] = []
+    for q in c.quests.values():
+        if q.status != "completed":
+            continue  # only resolved threads can lack a payoff
+        if (q.evolves_to or "").strip():
+            continue  # already evolves -> not a debt
+        if _quest_has_followon(c, q.id, q.title):
+            continue  # already echoed via a consequence/hook
+        debts.append(
+            SceneDebt(
+                id=_debt_id("thread_no_payoff", q.id),
+                kind="thread_no_payoff",
+                subject=q.id,
+                detail=(
+                    f"Resolved thread '{q.title}' has no payoff/echo — consider a "
+                    f"callback (set evolves_to) so it lingers instead of ending one-and-done."
+                ),
+                severity="low",
+                evidence={"quest_id": q.id, "quest_title": q.title, "status": q.status},
             )
         )
     return debts
@@ -315,9 +369,10 @@ def detect(c: Campaign) -> list[SceneDebt]:
     (today's behavior). Old snapshots without ``scene_debts`` round-trip
     unchanged — this function reads state, never mutates it.
 
-    The six debt kinds detected:
+    The debt kinds detected:
     - ``hook_untracked``: an engaged quest_hook with no tracked Quest.
     - ``quest_stalled``: an active Quest with no story beat in ≥ QUEST_STALL_DAYS.
+    - ``thread_no_payoff``: a resolved Quest with no follow-on (rule-of-three nudge).
     - ``choice_without_outcome``: a Decision offered (options present) but chosen=''.
     - ``due_consequence``: a non-thread Consequence past trigger_day, not fired.
     - ``thread_pressure``: a worldsim thread-beat overdue (world_tick not called).
@@ -326,6 +381,7 @@ def detect(c: Campaign) -> list[SceneDebt]:
     debts: list[SceneDebt] = []
     debts.extend(_detect_hook_untracked(c))
     debts.extend(_detect_quest_stalled(c))
+    debts.extend(_detect_quest_no_followon(c))
     debts.extend(_detect_choice_without_outcome(c))
     debts.extend(_detect_due_consequence(c))
     debts.extend(_detect_thread_pressure(c))

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -60,6 +60,7 @@ from models import (
     CompanionDossier,
     CompanionQuestArc,
     Condition,
+    Consequence,
     DeathSaves,
     Decision,
     Faction,
@@ -5706,9 +5707,58 @@ def add_quest(
         return {"id": q.id, "title": q.title, "status": q.status}
 
 
+def _evolution_note(quest_id: str) -> str:
+    """The deterministic `Consequence.note` tag that links a scheduled evolution
+    back to the quest it grew from. Used both to author the link and to guard
+    against double-scheduling on a re-resolve. Format: ``evolves_from:<quest_id>``."""
+    return f"evolves_from:{quest_id}"
+
+
+def _maybe_schedule_quest_evolution(c: Campaign, q: Quest) -> Optional[Consequence]:
+    """Rule-of-three evolution (Quest & Arc engine, Layer 1). When a quest reaches
+    a RESOLVED terminal state (status == "completed") AND carries an ``evolves_to``
+    hook/seed, SCHEDULE a follow-on ``Consequence`` so the thread lingers and
+    surfaces later via the existing ``check_consequences`` path (immediately if
+    ``callback_in_days`` is 0, or on a later return). The DM weaves the prompt; the
+    engine never auto-acts on the fiction.
+
+    ADDITIVE + idempotent: empty ``evolves_to`` schedules nothing (today's behavior).
+    The guard is the deterministic ``evolves_from:<quest_id>`` note — if an evolution
+    consequence for this quest already exists, re-resolving does NOT double-schedule.
+    Caller MUST hold the campaign lock (engine is the sole writer). Returns the new
+    Consequence, or None if nothing was scheduled.
+
+    NOTE on traceability: the link back to the quest is carried in ``note``
+    (``evolves_from:<quest_id>``), NOT in ``Consequence.thread_id`` — a non-empty
+    ``thread_id`` marks a worldsim background beat that ``consequences.due()`` /
+    ``check_consequences`` deliberately SKIP (those surface only via ``world_tick``).
+    Using ``thread_id`` here would silently hide the evolution from the DM, so the
+    quest id rides in ``note`` instead, which preserves both surfacing and trace-back."""
+    if q.status != "completed":
+        return None
+    if not (q.evolves_to or "").strip():
+        return None
+    note = _evolution_note(q.id)
+    # Idempotency: never double-schedule if this quest already spawned an evolution.
+    if any(con.note == note for con in c.consequences):
+        return None
+    in_days = max(0, int(q.callback_in_days))
+    text = (
+        f"Bring back / evolve the resolved thread '{q.title}' -> {q.evolves_to}: "
+        f"weave a follow-on beat that pays off this quest."
+    )
+    return consequences_mod.schedule(c, in_days=in_days, text=text, note=note)
+
+
 @mcp.tool()
 def complete_quest(campaign_id: str, quest_id: str, status: str = "completed") -> dict:
-    """Resolve a quest. status: completed | failed | active."""
+    """Resolve a quest. status: completed | failed | active.
+
+    Rule-of-three evolution (Quest & Arc engine, Layer 1): if the quest resolves
+    (status -> completed) and carries an ``evolves_to`` follow-on, the engine
+    schedules a Consequence so the thread echoes later (surfaced via
+    check_consequences). Additive + idempotent: empty ``evolves_to`` == today's
+    behavior; re-resolving never double-schedules."""
     if status not in ("completed", "failed", "active"):
         raise ValueError("status must be completed | failed | active")
     with campaign_lock(campaign_id):
@@ -5717,8 +5767,16 @@ def complete_quest(campaign_id: str, quest_id: str, status: str = "completed") -
         if q is None:
             raise ValueError(f"no quest {quest_id!r}")
         q.status = status  # type: ignore[assignment]
+        evolution = _maybe_schedule_quest_evolution(c, q)
         save_campaign(c)
-        return {"id": q.id, "title": q.title, "status": q.status}
+        out = {"id": q.id, "title": q.title, "status": q.status}
+        if evolution is not None:
+            out["evolution_scheduled"] = {
+                "consequence_id": evolution.id,
+                "trigger_day": evolution.trigger_day,
+                "evolves_to": q.evolves_to,
+            }
+        return out
 
 
 @mcp.tool()

--- a/servers/engine/tests/test_dashboard.py
+++ b/servers/engine/tests/test_dashboard.py
@@ -3,6 +3,7 @@
 import pytest
 
 import server
+import store
 
 
 @pytest.fixture
@@ -24,6 +25,101 @@ def test_complete_quest_rejects_bad_status(cid):
     q = server.add_quest(cid, "X")
     with pytest.raises(Exception):
         server.complete_quest(cid, q["id"], "ludicrous")
+
+
+# ── Rule-of-three evolution (Quest & Arc engine, Layer 1) ─────────────────────
+
+
+def _set_evolution(cid: str, quest_id: str, evolves_to: str, callback_in_days: int) -> None:
+    """Plant the rule-of-three fields on a tracked quest (content/questgen would set
+    these; add_quest deliberately keeps them DM/content-authored)."""
+    with store.campaign_lock(cid):
+        c = store.load_campaign(cid)
+        q = c.quests[quest_id]
+        q.evolves_to = evolves_to
+        q.callback_in_days = callback_in_days
+        store.save_campaign(c)
+
+
+def test_resolving_quest_with_evolution_schedules_consequence(cid):
+    """(a) Resolving a quest with evolves_to + callback_in_days=N schedules a
+    Consequence at day+N that references the quest (via the evolves_from note)."""
+    qid = server.add_quest(cid, "Recover the Sunblade")["id"]
+    _set_evolution(cid, qid, evolves_to="hook_shadow_returns", callback_in_days=3)
+
+    before = store.load_campaign(cid)
+    start_day = before.day
+    assert before.consequences == []  # nothing scheduled yet
+
+    out = server.complete_quest(cid, qid, "completed")
+    assert out["status"] == "completed"
+    assert out["evolution_scheduled"]["evolves_to"] == "hook_shadow_returns"
+    assert out["evolution_scheduled"]["trigger_day"] == start_day + 3
+
+    c = store.load_campaign(cid)
+    evo = [con for con in c.consequences if con.note == f"evolves_from:{qid}"]
+    assert len(evo) == 1
+    assert evo[0].trigger_day == start_day + 3
+    assert "hook_shadow_returns" in evo[0].text
+    assert "Recover the Sunblade" in evo[0].text
+    # Trace-back rides in `note`, NOT thread_id (so check_consequences surfaces it).
+    assert evo[0].thread_id == ""
+
+
+def test_resolving_quest_evolution_surfaces_via_check_consequences(cid):
+    """The scheduled evolution surfaces through the existing check_consequences path
+    (immediately when callback_in_days == 0)."""
+    qid = server.add_quest(cid, "Break the Siege")["id"]
+    _set_evolution(cid, qid, evolves_to="seed_warlord_regroups", callback_in_days=0)
+
+    server.complete_quest(cid, qid, "completed")
+    res = server.check_consequences(cid)
+    due_texts = [d["text"] for d in res["due"]]
+    assert any("seed_warlord_regroups" in t and "Break the Siege" in t for t in due_texts)
+
+
+def test_resolving_quest_without_evolution_schedules_nothing(cid):
+    """(b) evolves_to='' / callback=0 -> NO schedule (today's behavior exactly)."""
+    qid = server.add_quest(cid, "Plain Errand")["id"]  # no evolves_to set
+
+    out = server.complete_quest(cid, qid, "completed")
+    assert "evolution_scheduled" not in out
+
+    c = store.load_campaign(cid)
+    assert c.consequences == []
+
+
+def test_failed_quest_with_evolution_does_not_schedule(cid):
+    """A quest that resolves to 'failed' (not 'completed') does NOT schedule the
+    evolution — only the completed terminal state grows the rule-of-three follow-on."""
+    qid = server.add_quest(cid, "Doomed Errand")["id"]
+    _set_evolution(cid, qid, evolves_to="hook_consequences_of_failure", callback_in_days=2)
+
+    out = server.complete_quest(cid, qid, "failed")
+    assert "evolution_scheduled" not in out
+
+    c = store.load_campaign(cid)
+    assert [con for con in c.consequences if con.note == f"evolves_from:{qid}"] == []
+
+
+def test_re_resolving_quest_does_not_double_schedule(cid):
+    """(c) Re-resolving an already-resolved quest does NOT double-schedule the
+    evolution (idempotent on the evolves_from:<quest_id> note)."""
+    qid = server.add_quest(cid, "Ring the Old Bell")["id"]
+    _set_evolution(cid, qid, evolves_to="hook_bell_echoes", callback_in_days=1)
+
+    first = server.complete_quest(cid, qid, "completed")
+    assert "evolution_scheduled" in first
+    first_conseq_id = first["evolution_scheduled"]["consequence_id"]
+
+    # Re-resolve (e.g. status toggled back to active by the DM, then completed again).
+    server.complete_quest(cid, qid, "active")
+    second = server.complete_quest(cid, qid, "completed")
+    assert "evolution_scheduled" not in second  # guard held
+
+    c = store.load_campaign(cid)
+    evo = [con for con in c.consequences if con.note == f"evolves_from:{qid}"]
+    assert len(evo) == 1 and evo[0].id == first_conseq_id  # still exactly one
 
 
 def test_dashboard_rollup_resolves_links(cid):

--- a/servers/engine/tests/test_scene_debt.py
+++ b/servers/engine/tests/test_scene_debt.py
@@ -148,6 +148,67 @@ class TestQuestStalled:
         assert debts == []
 
 
+# ── thread_no_payoff (rule-of-three) ──────────────────────────────────────────
+
+class TestQuestNoFollowon:
+    def test_resolved_quest_no_followon_detected(self):
+        c = _camp()
+        q = Quest(title="Slay the Bandit King", status="completed")  # no evolves_to, no echo
+        c.quests[q.id] = q
+        debts = scene_debt.detect(c)
+        assert any(d.kind == "thread_no_payoff" and d.subject == q.id for d in debts)
+
+    def test_resolved_quest_with_evolves_to_clean(self):
+        c = _camp()
+        q = Quest(title="Slay the Bandit King", status="completed", evolves_to="hook_lieutenant")
+        c.quests[q.id] = q
+        debts = [d for d in scene_debt.detect(c) if d.kind == "thread_no_payoff"]
+        assert debts == []
+
+    def test_active_quest_not_flagged(self):
+        c = _camp()
+        q = Quest(title="In Progress", status="active")  # not resolved yet
+        c.quests[q.id] = q
+        debts = [d for d in scene_debt.detect(c) if d.kind == "thread_no_payoff"]
+        assert debts == []
+
+    def test_resolved_quest_with_scheduled_evolution_clean(self):
+        c = _camp()
+        q = Quest(title="Echoing Deed", status="completed")  # evolves_to empty...
+        c.quests[q.id] = q
+        # ...but a follow-on Consequence already grew from it (the engine scheduled one)
+        c.consequences.append(
+            Consequence(trigger_day=5, text="The deed echoes.", note=f"evolves_from:{q.id}")
+        )
+        debts = [d for d in scene_debt.detect(c) if d.kind == "thread_no_payoff"]
+        assert debts == []
+
+    def test_resolved_quest_referenced_by_hook_clean(self):
+        c = _camp()
+        q = Quest(title="The Stolen Crown", status="completed")
+        c.quests[q.id] = q
+        # A hook arcs back to this resolved quest by id -> it already echoes
+        h = _hook(title="Aftermath", status="open")
+        h.arc_back = f"follows from {q.id}"
+        c.quest_hooks.append(h)
+        debts = [d for d in scene_debt.detect(c) if d.kind == "thread_no_payoff"]
+        assert debts == []
+
+    def test_advisory_severity_is_low(self):
+        c = _camp()
+        q = Quest(title="One And Done", status="completed")
+        c.quests[q.id] = q
+        debts = [d for d in scene_debt.detect(c) if d.kind == "thread_no_payoff"]
+        assert debts and debts[0].severity == "low"
+
+    def test_failed_quest_not_flagged(self):
+        c = _camp()
+        q = Quest(title="Botched Job", status="failed")  # only 'completed' is a resolved payoff candidate
+        c.quests[q.id] = q
+        debts = [d for d in scene_debt.detect(c) if d.kind == "thread_no_payoff"]
+        assert debts == []
+
+
 # ── choice_without_outcome ────────────────────────────────────────────────────
 
 class TestChoiceWithoutOutcome:
@@ -318,8 +379,9 @@ class TestCleanCampaign:
         # A resolved hook
         h = _hook(title="Done Hook", status="resolved")
         c.quest_hooks.append(h)
-        # A completed quest
-        q = Quest(title="Finished Quest", status="completed")
+        # A completed quest that already echoes (rule-of-three): evolves_to set, so
+        # the thread_no_payoff nudge does NOT fire — a fully-tidy campaign.
+        q = Quest(title="Finished Quest", status="completed", evolves_to="hook_followup")
         c.quests[q.id] = q
         # A decision with a chosen
         c.decisions.append(_decision("We chose wisely", options=["a", "b"], chosen="a"))


### PR DESCRIPTION
Quest & Arc engine Layer 1. Additive Quest.evolves_to + callback_in_days; complete_quest schedules the follow-on via consequences.schedule (note evolves_from:<id>, idempotent) so a resolved thread surfaces a callback later (kills the Tolkien 'nothing lingers' defect) + a scene_debt thread_no_payoff advisory. Kept thread_id empty (would hide it from check_consequences). Tests 60+125 single-process. Local-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Quests now support follow-on evolution with configurable delays triggered upon completion.
  * Quest completion responses now include evolution scheduling details for traceability.

* **Bug Fixes**
  * Added detection for completed quests lacking follow-on content to prevent narrative dead-ends.

* **Tests**
  * Comprehensive test coverage for quest evolution scheduling and scene debt detection scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->