### PR TITLE
feat(time): add campaign calendar display projection

### DIFF
--- a/servers/engine/campaign_calendar.py
+++ b/servers/engine/campaign_calendar.py
@@ -1,0 +1,105 @@
+"""Display-only campaign calendar projection.
+
+The canonical engine clock is still ``Campaign.day``. This module maps that
+integer into authored calendar labels for viewer/OpenWorlds read models without
+introducing a second mutable time authority.
+"""
+
+from __future__ import annotations
+
+from models import CampaignCalendar
+
+
+def _month_cursor(calendar: CampaignCalendar, elapsed_days: int) -> tuple[int, int, int]:
+    months = calendar.months
+    if not months:
+        return calendar.epoch_year, 0, calendar.epoch_day + elapsed_days
+
+    month_index = min(max(calendar.epoch_month - 1, 0), len(months) - 1)
+    day_of_month = min(max(calendar.epoch_day, 1), months[month_index].days)
+    year = calendar.epoch_year
+    remaining = max(elapsed_days, 0)
+
+    while remaining:
+        days_left_in_month = months[month_index].days - day_of_month
+        if remaining <= days_left_in_month:
+            day_of_month += remaining
+            remaining = 0
+        else:
+            remaining -= days_left_in_month + 1
+            day_of_month = 1
+            month_index += 1
+            if month_index >= len(months):
+                month_index = 0
+                year += 1
+
+    return year, month_index, day_of_month
+
+
+def _moon_phase(age: int, phase_names: list[str], cycle_days: int) -> str:
+    names = [str(name).strip() for name in phase_names if str(name).strip()]
+    if not names:
+        names = ["new", "waxing", "full", "waning"]
+    index = min(len(names) - 1, (age * len(names)) // max(cycle_days, 1))
+    return names[index]
+
+
+def project_calendar_date(day: int, time_of_day: str, calendar: CampaignCalendar) -> dict:
+    """Return a JSON-safe calendar projection for a campaign day.
+
+    ``canonical_day`` is echoed so consumers never treat the rendered date as the
+    authority for ticks, rests, consequences, or strategic advancement.
+    """
+
+    canonical_day = day if isinstance(day, int) and day > 0 else 1
+    if not calendar.months:
+        phase = str(time_of_day).strip()
+        return {
+            "available": False,
+            "canonical_day": canonical_day,
+            "label": f"Day {canonical_day}" + (f" · {phase}" if phase else ""),
+        }
+
+    elapsed_days = canonical_day - 1
+    year, month_index, day_of_month = _month_cursor(calendar, elapsed_days)
+    month = calendar.months[month_index] if calendar.months else None
+    month_name = month.name if month else "Day"
+    season = month.season if month else ""
+
+    weekday = ""
+    weekdays = [str(name).strip() for name in calendar.weekdays if str(name).strip()]
+    if weekdays:
+        weekday = weekdays[(calendar.week_start_index + elapsed_days) % len(weekdays)]
+
+    era = f" {calendar.era_suffix.strip()}" if calendar.era_suffix.strip() else ""
+    date_core = f"{day_of_month} {month_name} {year}{era}"
+    date_label = f"{weekday}, {date_core}" if weekday else date_core
+    phase = str(time_of_day).strip()
+    label = date_label + (f" · {phase}" if phase else "")
+
+    moons = []
+    for moon in calendar.moons:
+        cycle = max(moon.cycle_days, 1)
+        age = (moon.epoch_phase_day + elapsed_days) % cycle
+        moons.append(
+            {
+                "name": moon.name,
+                "age": age,
+                "cycle_days": cycle,
+                "phase": _moon_phase(age, moon.phase_names, cycle),
+            }
+        )
+
+    return {
+        "available": True,
+        "calendar": calendar.name,
+        "canonical_day": canonical_day,
+        "year": year,
+        "month": month_name,
+        "day_of_month": day_of_month,
+        "weekday": weekday,
+        "season": season,
+        "date_label": date_label,
+        "label": label,
+        "moons": moons,
+    }

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -20,6 +20,7 @@ import worldsim
 from models import (
     BacklogItem,
     Campaign,
+    CampaignCalendar,
     CampaignBacklog,
     CompanionArc,
     CompanionDossier,
@@ -1242,6 +1243,13 @@ def seed_world(world: dict, start_at: str = "", ending: str = "") -> Campaign:
     c = Campaign(title=world.get("name", "Untitled World"), summary=world.get("premise", ""))
     c.world_id = str(world.get("id", ""))  # enables lookup_lore over this world's corpus
     c.era = str(world.get("era") or world.get("current_year") or "")  # chronology guardrail
+    if isinstance(world.get("calendar"), dict):
+        try:
+            calendar = CampaignCalendar.model_validate(world["calendar"])
+            if calendar.months:
+                c.calendar = calendar
+        except (ValidationError, ValueError, TypeError):
+            c.calendar = None
 
     first_loc = None
     for reg in _as_list(world, "regions"):

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1118,6 +1118,46 @@ class WorldState(_StrictModel):
         )
 
 
+class CalendarMonth(_StrictModel):
+    """One authored month in a campaign calendar.
+
+    This is display metadata only. The engine's authoritative clock remains
+    ``Campaign.day`` plus the tactical ``time_of_day`` phase.
+    """
+
+    name: str
+    days: int = Field(..., ge=1, le=1000)
+    season: str = ""
+
+
+class CalendarMoon(_StrictModel):
+    """A deterministic moon phase track derived from ``Campaign.day``."""
+
+    name: str
+    cycle_days: int = Field(..., ge=1, le=10000)
+    epoch_phase_day: int = Field(0, ge=0)
+    phase_names: list[str] = Field(default_factory=lambda: ["new", "waxing", "full", "waning"])
+
+
+class CampaignCalendar(_StrictModel):
+    """Clean-room, setting-agnostic calendar display metadata.
+
+    Day 1 of the campaign maps to ``epoch_year``/``epoch_month``/``epoch_day``.
+    The model deliberately stores no mutable cursor; every rendered date is a
+    pure projection from ``Campaign.day``.
+    """
+
+    name: str
+    era_suffix: str = ""
+    epoch_year: int = 1
+    epoch_month: int = Field(1, ge=1)
+    epoch_day: int = Field(1, ge=1)
+    weekdays: list[str] = Field(default_factory=list)
+    week_start_index: int = Field(0, ge=0)
+    months: list[CalendarMonth] = Field(default_factory=list)
+    moons: list[CalendarMoon] = Field(default_factory=list)
+
+
 class StrategicClock(_StrictModel):
     """A setting-agnostic strategic pressure clock.
 
@@ -1400,6 +1440,7 @@ class Campaign(_StrictModel):
     current_location_id: Optional[str] = None
     day: int = 1  # in-world day counter
     time_of_day: str = "morning"
+    calendar: Optional[CampaignCalendar] = None
     map_kind: Literal["hex", "none"] = "none"  # how the play-view renders the map
     # World-state boolean flags the DM/engine set to gate events — e.g. "prize_seized"
     # drives a companion's prize_seized agenda (S4). Additive: empty == today's behavior.

--- a/servers/engine/tests/test_campaign_calendar.py
+++ b/servers/engine/tests/test_campaign_calendar.py
@@ -1,0 +1,112 @@
+from campaign_calendar import project_calendar_date
+from content import seed_world
+from models import CampaignCalendar, CalendarMonth, CalendarMoon
+
+
+def _fixture_calendar() -> CampaignCalendar:
+    return CampaignCalendar(
+        name="Dale Reckoning",
+        era_suffix="DR",
+        epoch_year=1492,
+        epoch_month=1,
+        epoch_day=1,
+        weekdays=["Firstday", "Secondday", "Thirdday", "Fourthday", "Fifthday"],
+        months=[
+            CalendarMonth(name="Hammer", days=30, season="Deepwinter"),
+            CalendarMonth(name="Alturiak", days=30, season="The Claw of Winter"),
+            CalendarMonth(name="Ches", days=30, season="Springrise"),
+        ],
+        moons=[
+            CalendarMoon(
+                name="Selune",
+                cycle_days=8,
+                phase_names=["new", "waxing", "full", "waning"],
+            )
+        ],
+    )
+
+
+def test_project_calendar_date_keeps_day_counter_canonical_and_renders_label():
+    projection = project_calendar_date(32, "dusk", _fixture_calendar())
+
+    assert projection["available"] is True
+    assert projection["canonical_day"] == 32
+    assert projection["year"] == 1492
+    assert projection["month"] == "Alturiak"
+    assert projection["day_of_month"] == 2
+    assert projection["weekday"] == "Secondday"
+    assert projection["season"] == "The Claw of Winter"
+    assert projection["date_label"] == "Secondday, 2 Alturiak 1492 DR"
+    assert projection["label"] == "Secondday, 2 Alturiak 1492 DR · dusk"
+    assert projection["moons"] == [
+        {
+            "name": "Selune",
+            "age": 7,
+            "cycle_days": 8,
+            "phase": "waning",
+        }
+    ]
+
+
+def test_project_calendar_date_degrades_empty_calendar_to_legacy_day_label():
+    projection = project_calendar_date(5, "night", CampaignCalendar(name="Empty Calendar"))
+
+    assert projection == {
+        "available": False,
+        "canonical_day": 5,
+        "label": "Day 5 · night",
+    }
+
+
+def test_seed_world_preserves_optional_calendar_metadata_without_advancing_time():
+    campaign = seed_world(
+        {
+            "id": "calendar-test",
+            "name": "Calendar Test",
+            "premise": "A compact calendar fixture.",
+            "era": "1492 DR",
+            "calendar": _fixture_calendar().model_dump(mode="json"),
+            "regions": [
+                {"id": "loc-gate", "name": "Gate", "description": "A city gate.", "connections": []}
+            ],
+            "factions": [],
+            "npc_roster": [],
+            "history": [],
+            "standing_threads": [],
+            "starting_options": [{"location_id": "loc-gate", "framing": "Start at the gate."}],
+        }
+    )
+
+    assert campaign.day == 1
+    assert campaign.time_of_day == "morning"
+    assert campaign.calendar is not None
+    assert campaign.calendar.name == "Dale Reckoning"
+    assert project_calendar_date(campaign.day, campaign.time_of_day, campaign.calendar)["label"] == (
+        "Firstday, 1 Hammer 1492 DR · morning"
+    )
+
+
+def test_seed_world_ignores_malformed_optional_calendar_metadata():
+    campaign = seed_world(
+        {
+            "id": "calendar-broken",
+            "name": "Broken Calendar Test",
+            "premise": "A fixture with bad optional calendar metadata.",
+            "era": "1492 DR",
+            "calendar": {
+                "name": "Broken Reckoning",
+                "months": [{"name": "Impossible", "days": 0}],
+            },
+            "regions": [
+                {"id": "loc-gate", "name": "Gate", "description": "A city gate.", "connections": []}
+            ],
+            "factions": [],
+            "npc_roster": [],
+            "history": [],
+            "standing_threads": [],
+            "starting_options": [{"location_id": "loc-gate", "framing": "Start at the gate."}],
+        }
+    )
+
+    assert campaign.day == 1
+    assert campaign.calendar is None

--- a/viewer/openworlds/screen-map.jsx
+++ b/viewer/openworlds/screen-map.jsx
@@ -146,6 +146,9 @@ function ScreenMap({ onNavigate, state, campMode, setCampMode }) {
   const locationClocks = selected ? clocks.filter((c) => !c.location_id || c.location_id === selected.id) : clocks;
   const locationProjects = selected ? projects.filter((p) => !p.location_id || p.location_id === selected.id) : projects;
   const locationControl = selected ? controls.find((c) => c.location_id === selected.id) : null;
+  const calendar = surface?.calendar?.available ? surface.calendar : null;
+  const calendarMoon = Array.isArray(calendar?.moons) ? calendar.moons[0] : null;
+  const calendarDetail = calendar ? [calendar.season, calendarMoon ? `${calendarMoon.name}: ${calendarMoon.phase}` : ""].filter(Boolean).join(" · ") : "";
 
   return (
     <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "minmax(0, 1fr) 340px", gap: 14, padding: 14 }}>
@@ -159,6 +162,7 @@ function ScreenMap({ onNavigate, state, campMode, setCampMode }) {
             <div className="body-sm" style={{ color: "var(--ink-700)", marginTop: 3 }}>
               {surface?.dayLabel || surfaceStatus}
             </div>
+            {calendarDetail && <div className="body-xs" style={{ color: "var(--b-700)", marginTop: 3 }}>{calendarDetail}</div>}
           </div>
           <div style={{ display: "flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
             {!campMode && ["dawn", "day", "dusk", "night"].map((t) => (

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -31,6 +31,9 @@ function ScreenTable({ onNavigate, state, setState }) {
   const roundOrder = Array.isArray(surface?.roundOrder) ? surface.roundOrder : [];
   const scene = surface?.scene || {};
   const encounter = surface?.encounter || {};
+  const calendar = surface?.calendar?.available ? surface.calendar : null;
+  const calendarMoon = Array.isArray(calendar?.moons) ? calendar.moons[0] : null;
+  const calendarDetail = calendar ? [calendar.season, calendarMoon ? `${calendarMoon.name}: ${calendarMoon.phase}` : ""].filter(Boolean).join(" · ") : "";
   const [activeHero, setActiveHero] = React.useState(() => party[0]?.id || "");
   const hero = party.find((p) => p.id === activeHero) || party[0] || { id: "", name: "Hero", short: "Hero", level: 1, class: "Adventurer", hp: 1, hpMax: 1 };
   const visibleQuests = quests.filter((q) => !q.status || q.status === "active" || q.status === "open");
@@ -219,8 +222,9 @@ function ScreenTable({ onNavigate, state, setState }) {
             display: "flex", justifyContent: "space-between", alignItems: "flex-end",
             pointerEvents: "none",
           }}>
-            <div>
+            <div style={{ minWidth: 0, maxWidth: "min(620px, 62%)" }}>
               <Pill tone="royal" dot>{surface?.dayLabel || activeCampaign.day || "Unknown time"}</Pill>
+              {calendarDetail && <div className="body-xs" title={calendarDetail} style={{ marginTop: 4, color: "var(--p-150)", textShadow: "0 1px 2px rgba(0,0,0,0.75)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{calendarDetail}</div>}
               <div className="hand" style={{ marginTop: 6, color: "var(--p-100)", fontSize: 16, textShadow: "0 1px 2px rgba(0,0,0,0.8)" }}>
                 {scene.summary || activeCampaign.recap || "The table is waiting for a campaign snapshot."}
               </div>

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -623,12 +623,113 @@ def _text(value: object, default: str = "") -> str:
     return s if s else default
 
 
-def _openworlds_day_label(snapshot: dict) -> str:
+def _positive_int(value: object, default: int = 1) -> int:
+    return value if isinstance(value, int) and value > 0 else default
+
+
+def _openworlds_calendar_projection(snapshot: dict) -> dict:
+    calendar = snapshot.get("calendar") if isinstance(snapshot, dict) else None
+    day = _positive_int(snapshot.get("day") if isinstance(snapshot, dict) else None)
+    fallback = {
+        "available": False,
+        "canonical_day": day,
+        "label": _openworlds_legacy_day_label(snapshot),
+    }
+    if not isinstance(calendar, dict):
+        return fallback
+
+    months_raw = calendar.get("months")
+    months = [m for m in months_raw if isinstance(m, dict)] if isinstance(months_raw, list) else []
+    if not months:
+        return fallback
+
+    elapsed = day - 1
+    month_index = min(max(_positive_int(calendar.get("epoch_month"), 1) - 1, 0), len(months) - 1)
+    day_of_month = _positive_int(calendar.get("epoch_day"), 1)
+    first_days = _positive_int(months[month_index].get("days"), 1)
+    day_of_month = min(day_of_month, first_days)
+    year = calendar.get("epoch_year") if isinstance(calendar.get("epoch_year"), int) else 1
+    remaining = elapsed
+    while remaining:
+        month_days = _positive_int(months[month_index].get("days"), 1)
+        days_left = month_days - day_of_month
+        if remaining <= days_left:
+            day_of_month += remaining
+            remaining = 0
+        else:
+            remaining -= days_left + 1
+            day_of_month = 1
+            month_index += 1
+            if month_index >= len(months):
+                month_index = 0
+                year += 1
+
+    month = months[month_index]
+    weekdays_raw = calendar.get("weekdays")
+    weekdays = [_text(w) for w in weekdays_raw if _text(w)] if isinstance(weekdays_raw, list) else []
+    week_start = calendar.get("week_start_index") if isinstance(calendar.get("week_start_index"), int) else 0
+    weekday = weekdays[(week_start + elapsed) % len(weekdays)] if weekdays else ""
+    era = _text(calendar.get("era_suffix"))
+    era_suffix = f" {era}" if era else ""
+    month_name = _text(month.get("name"), "Month")
+    date_core = f"{day_of_month} {month_name} {year}{era_suffix}"
+    date_label = f"{weekday}, {date_core}" if weekday else date_core
+    time_of_day = _text(snapshot.get("time_of_day"))
+    label = date_label + (f" · {time_of_day}" if time_of_day else "")
+
+    moons = []
+    moons_raw = calendar.get("moons")
+    if isinstance(moons_raw, list):
+        for moon in moons_raw:
+            if not isinstance(moon, dict):
+                continue
+            cycle = _positive_int(moon.get("cycle_days"), 1)
+            epoch_phase = moon.get("epoch_phase_day") if isinstance(moon.get("epoch_phase_day"), int) else 0
+            age = (max(epoch_phase, 0) + elapsed) % cycle
+            phases_raw = moon.get("phase_names")
+            phases = [_text(p) for p in phases_raw if _text(p)] if isinstance(phases_raw, list) else []
+            if not phases:
+                phases = ["new", "waxing", "full", "waning"]
+            phase_index = min(len(phases) - 1, (age * len(phases)) // cycle)
+            moons.append(
+                {
+                    "name": _text(moon.get("name"), "Moon"),
+                    "age": age,
+                    "cycle_days": cycle,
+                    "phase": phases[phase_index],
+                }
+            )
+
+    return {
+        "available": True,
+        "calendar": _text(calendar.get("name"), "Calendar"),
+        "canonical_day": day,
+        "year": year,
+        "month": month_name,
+        "day_of_month": day_of_month,
+        "weekday": weekday,
+        "season": _text(month.get("season")),
+        "date_label": date_label,
+        "label": label,
+        "moons": moons,
+    }
+
+
+def _openworlds_legacy_day_label(snapshot: dict) -> str:
     day = snapshot.get("day")
     time_of_day = _text(snapshot.get("time_of_day"))
     if isinstance(day, int):
         return f"Day {day}" + (f" · {time_of_day}" if time_of_day else "")
     return time_of_day or "Unknown time"
+
+
+def _openworlds_day_label(snapshot: dict) -> str:
+    calendar = _openworlds_calendar_projection(snapshot)
+    return _text(calendar.get("label")) if calendar.get("available") else _openworlds_legacy_day_label(snapshot)
+
+
+def _openworlds_calendar(snapshot: dict) -> dict:
+    return _openworlds_calendar_projection(snapshot)
 
 
 def _party_cards(snapshot: dict) -> list[dict]:
@@ -1094,6 +1195,7 @@ def build_session_surface(
         "day": snapshot.get("day") if isinstance(snapshot.get("day"), int) else None,
         "time_of_day": _text(snapshot.get("time_of_day")),
         "dayLabel": _openworlds_day_label(snapshot),
+        "calendar": _openworlds_calendar(snapshot),
         "location": location,
         "scene": {
             "summary": summary,
@@ -2048,6 +2150,7 @@ def build_atlas_surface(
         "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
         "world": _text(snapshot.get("world_id"), "unknown"),
         "dayLabel": _openworlds_day_label(snapshot),
+        "calendar": _openworlds_calendar(snapshot),
         "current_location": current or {"id": "", "name": "Unknown location", "tags": []},
         "known_locations": locations,
         "edges": _atlas_edges(locations, snapshot),

--- a/viewer/tests/test_atlas_surface.py
+++ b/viewer/tests/test_atlas_surface.py
@@ -329,6 +329,45 @@ class AtlasSurfaceTests(unittest.TestCase):
         self.assertNotIn("Sealed Grove", encoded)
         self.assertNotIn("sealed", encoded)
 
+    def test_atlas_surface_includes_calendar_projection_for_strategic_display(self):
+        snapshot = {
+            "title": "Calendar Map",
+            "world_id": "calendar-test",
+            "day": 32,
+            "time_of_day": "dusk",
+            "current_location_id": "gate",
+            "calendar": {
+                "name": "Dale Reckoning",
+                "era_suffix": "DR",
+                "epoch_year": 1492,
+                "epoch_month": 1,
+                "epoch_day": 1,
+                "weekdays": ["Firstday", "Secondday", "Thirdday", "Fourthday", "Fifthday"],
+                "months": [
+                    {"name": "Hammer", "days": 30, "season": "Deepwinter"},
+                    {"name": "Alturiak", "days": 30, "season": "The Claw of Winter"},
+                ],
+                "moons": [
+                    {
+                        "name": "Selune",
+                        "cycle_days": 8,
+                        "phase_names": ["new", "waxing", "full", "waning"],
+                    }
+                ],
+            },
+            "locations": {
+                "gate": {"id": "gate", "name": "Gate", "visited": True, "tags": ["town"]},
+            },
+        }
+
+        surface = server.build_atlas_surface(snapshot, campaign_id="camp_calendar", live=True, is_live_view=True)
+
+        self.assertEqual(surface["dayLabel"], "Secondday, 2 Alturiak 1492 DR · dusk")
+        self.assertEqual(surface["calendar"]["date_label"], "Secondday, 2 Alturiak 1492 DR")
+        self.assertEqual(surface["calendar"]["season"], "The Claw of Winter")
+        self.assertEqual(surface["calendar"]["moons"][0]["phase"], "waning")
+        self.assertTrue(surface["camp_available"])
+
     def assert_no_private_keys(self, value) -> None:
         private_keys = {
             "notes",

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -151,6 +151,18 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn("window.combatSurfaceFromCampaign", source)
         self.assertIn("emptyState", source)
 
+    def test_openworlds_table_and_map_render_calendar_metadata(self):
+        for path in ("/openworlds/screen-table.jsx", "/openworlds/screen-map.jsx"):
+            with self.subTest(path=path):
+                status, ctype, body = self._get(path)
+
+                self.assertEqual(status, 200)
+                self.assertIn("text/babel", ctype)
+                source = body.decode("utf-8")
+                self.assertIn("surface?.calendar?.available", source)
+                self.assertIn("calendarMoon", source)
+                self.assertIn("calendarDetail", source)
+
     def test_openworlds_rejects_path_traversal(self):
         self.assertEqual(self._status("/openworlds/../server.py"), 404)
         self.assertEqual(self._status("/openworlds/%2e%2e/server.py"), 404)

--- a/viewer/tests/test_session_surface.py
+++ b/viewer/tests/test_session_surface.py
@@ -154,6 +154,60 @@ class SessionSurfaceTests(unittest.TestCase):
         self.assertEqual(say_action["ui"], "focus-say")
         self.assertNotIn("snapshot", json.dumps(surface))
 
+    def test_session_surface_projects_calendar_display_without_state_authority(self):
+        snapshot = {
+            "title": "Calendar Save",
+            "world_id": "calendar-test",
+            "day": 32,
+            "time_of_day": "dusk",
+            "calendar": {
+                "name": "Dale Reckoning",
+                "era_suffix": "DR",
+                "epoch_year": 1492,
+                "epoch_month": 1,
+                "epoch_day": 1,
+                "weekdays": ["Firstday", "Secondday", "Thirdday", "Fourthday", "Fifthday"],
+                "months": [
+                    {"name": "Hammer", "days": 30, "season": "Deepwinter"},
+                    {"name": "Alturiak", "days": 30, "season": "The Claw of Winter"},
+                ],
+                "moons": [
+                    {
+                        "name": "Selune",
+                        "cycle_days": 8,
+                        "phase_names": ["new", "waxing", "full", "waning"],
+                    }
+                ],
+            },
+            "party": ["pc"],
+            "characters": {"pc": {"id": "pc", "name": "Vela", "kind": "player"}},
+        }
+
+        surface = server.build_session_surface(snapshot, campaign_id="camp_calendar", live=True, is_live_view=True)
+
+        self.assertEqual(surface["day"], 32)
+        self.assertEqual(surface["time_of_day"], "dusk")
+        self.assertEqual(surface["dayLabel"], "Secondday, 2 Alturiak 1492 DR · dusk")
+        self.assertEqual(
+            surface["calendar"],
+            {
+                "available": True,
+                "calendar": "Dale Reckoning",
+                "canonical_day": 32,
+                "year": 1492,
+                "month": "Alturiak",
+                "day_of_month": 2,
+                "weekday": "Secondday",
+                "season": "The Claw of Winter",
+                "date_label": "Secondday, 2 Alturiak 1492 DR",
+                "label": "Secondday, 2 Alturiak 1492 DR · dusk",
+                "moons": [{"name": "Selune", "age": 7, "cycle_days": 8, "phase": "waning"}],
+            },
+        )
+        self.assertEqual(surface["state_authority"], "engine")
+        self.assertEqual(surface["write_lane"], "/move")
+        self.assertNotIn("calendar_write", json.dumps(surface))
+
     def test_session_surface_includes_combat_order_and_disabled_reasons(self):
         snapshot = {
             "party": ["pc"],


### PR DESCRIPTION
## Summary

Adds a clean-room campaign calendar display layer for OpenWorlds Table and Atlas surfaces.

This is intentionally display-only:

- `Campaign.day` remains the canonical in-world day counter.
- `Campaign.time_of_day` remains the tactical phase.
- Optional `Campaign.calendar` metadata can describe months, weekdays, seasons, and moon cycles.
- Viewer/OpenWorlds projects a browser-safe `calendar` read model and keeps `/move` as the only player-intent write lane.

Refs #176.

## What Changed

- Added strict but optional engine calendar metadata models:
  - `CampaignCalendar`
  - `CalendarMonth`
  - `CalendarMoon`
- Added `servers/engine/campaign_calendar.py`, a pure projection helper that maps `Campaign.day` plus `time_of_day` into a human date label, season, and moon phase.
- `seed_world()` now accepts optional `world.calendar` metadata, but ignores malformed or empty calendar blocks so a decorative calendar can never block world startup.
- `/session-surface` and `/atlas-surface` now include:
  - `dayLabel`
  - `calendar.available`
  - `calendar.canonical_day`
  - date, season, and first moon phase metadata
- OpenWorlds Table and Atlas render calendar details when available and retain legacy `Day N` behavior otherwise.

## Architecture Notes

This PR deliberately does not add calendar controls, time mutation APIs, event scheduling, real-time ticking, or browser-side state writes.

The date label is a projection, not authority. Consequences, travel, rests, strategic ticks, and campaign persistence continue to key off the engine-owned day counter. The viewer duplicates a small JSON-dict projection because it is a stdlib downstream reader and must not import the engine package at runtime.

## External Research

Fantasy Calendar was evaluated as reference-only. Its useful concepts are static calendar metadata, date rendering, and deterministic moon phases. This PR does not vendor or port Fantasy Calendar code and does not add a runtime dependency.

## Review Findings Squashed

- Fixed optional `world.calendar` validation so malformed calendar metadata degrades instead of aborting `seed_world()`.
- Fixed engine projection fallback for schema-valid but unusable empty calendars so it agrees with viewer legacy `Day N` behavior.
- Guarded the OpenWorlds Table calendar detail line with width and ellipsis so long season/moon names do not collide with action buttons.

## Validation

Run from `/Volumes/LEXAR/repos/ClawDnD-calendar-display`:

```bash
uv run --directory servers/engine --group dev pytest -q tests/test_campaign_calendar.py tests/test_content.py::test_seed_world_seeds_strategic_state_additively tests/test_store.py
python3 -m unittest viewer.tests.test_session_surface viewer.tests.test_atlas_surface viewer.tests.test_openworlds_static -q
python3 -m py_compile viewer/server.py scripts/license_check.py
uv run --directory servers/engine python -m py_compile campaign_calendar.py content.py models.py
python3 scripts/license_check.py
git diff --check
```

Additional JSX smoke:

```bash
node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const babelPath = 'viewer/openworlds/vendor/babel-standalone-7.29.0.min.js';
const ctx = { window: {}, self: {}, console };
ctx.window = ctx;
ctx.self = ctx;
vm.createContext(ctx);
vm.runInContext(fs.readFileSync(babelPath, 'utf8'), ctx, { filename: babelPath });
const Babel = ctx.Babel;
for (const file of ['viewer/openworlds/screen-table.jsx', 'viewer/openworlds/screen-map.jsx']) {
  Babel.transform(fs.readFileSync(file, 'utf8'), { presets: ['react'] });
  console.log(`transformed ${file}`);
}
NODE
```

## Rollback Plan

Revert this PR to remove the optional calendar metadata and viewer projection. Existing saves without `calendar` are unaffected because all fields are additive and the old `Day N` fallback remains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added campaign calendar system supporting custom date epochs, months with seasons, and moon phase tracking.
  * Calendar projections now display on both strategic and tactical views with computed weekdays, seasons, and moon phases.
  * Moon cycles calculate deterministic phase information based on elapsed days.

* **Tests**
  * Added comprehensive calendar projection, seeding, and UI rendering tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/187?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->