### PR TITLE
fix(combat): Guiding Bolt applies its advantage rider on HIT, not on cast (#186)

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -376,6 +376,42 @@ class ActiveEffect(_StrictModel):
     until_long_rest: bool = False
 
 
+class PendingOnHitRider(_StrictModel):
+    """An attack-roll spell's ON-HIT rider effect that has NOT yet landed (#186).
+
+    5e attack-roll spells (Guiding Bolt: "on a hit ... the next attack roll against
+    it has Advantage") grant a timed effect on the TARGET *only when the spell attack
+    hits*. But the cast and the attack are two separate engine calls (`cast_spell`
+    then `attack`), so the effect must not be written to the target at cast time —
+    a missed bolt would wrongly leave the marker, and a re-cast would phantom-stack
+    a second one.
+
+    So `cast_spell` records this PENDING rider on the CASTER (one source of truth,
+    keyed by `target_id` + spell `name`) instead of writing the ActiveEffect; the
+    next `attack()` whose attacker == this caster and target == `target_id`
+    materializes the ActiveEffect on the target on a HIT, or discards this record on
+    a MISS. It carries the duration descriptor (the same `scale`/`rounds`/clock
+    fields `cast_spell` computed) so the effect rebuilt on hit is identical to the
+    one that would have been written at cast.
+
+    ADDITIVE: `Character.pending_on_hit_riders` defaults to `[]`, so every existing
+    snapshot deserializes unchanged and a campaign that never casts an attack-roll
+    rider spell behaves exactly as today. Only attack-roll spells with a timed
+    duration aimed at a SEPARATE target ever create one — save spells and self/ally
+    buffs are untouched (they write their effect at cast, as before)."""
+
+    name: str  # the spell's canonical name (the materialized effect's name)
+    source_id: str  # the caster's character id (matched against attack()'s attacker)
+    target_id: str  # who the rider lands on, on a hit (matched against attack()'s target)
+    # Duration descriptor captured at cast (mirrors ActiveEffect's timing fields) so the
+    # effect materialized on hit is byte-identical to the one cast_spell would have written.
+    scale: Literal["rounds", "minutes", "hours", "days"] = "rounds"
+    rounds_remaining: int = 0
+    expires_day: int = 0
+    expires_phase_index: int = 0
+    until_long_rest: bool = False
+
+
 class Character(_StrictModel):
     id: str = Field(default_factory=lambda: _new_id("char"))
     name: str
@@ -416,6 +452,11 @@ class Character(_StrictModel):
     # that auto-expire via next_turn / clock-advance tools instead of relying on the DM
     # to remember. Empty == today's behavior. See ActiveEffect; set by cast_spell.
     active_effects: list[ActiveEffect] = Field(default_factory=list)
+    # Attack-roll spell on-hit riders (Guiding Bolt's "advantage on the next attack")
+    # that have NOT yet landed — recorded here at cast time and materialized onto the
+    # target only when the spell attack hits (see PendingOnHitRider, #186). Empty ==
+    # today's behavior; held on the CASTER so attack() can match attacker→target.
+    pending_on_hit_riders: list[PendingOnHitRider] = Field(default_factory=list)
     death_saves: DeathSaves = Field(default_factory=DeathSaves)
     dead: bool = False
     stable: bool = False  # stabilized at 0 HP; no longer rolling death saves

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -67,6 +67,7 @@ from models import (
     HouseRules,
     Item,
     Location,
+    PendingOnHitRider,
     Quest,
     SceneDebt,
     SessionLogEntry,
@@ -2861,6 +2862,44 @@ def attack(
             kx = _award_kill_xp(c, target)
             if kx:
                 result["kill_xp"] = kx
+        # ON-HIT RIDER RESOLUTION (#186). An attack-roll spell (Guiding Bolt) recorded a
+        # PENDING rider on the caster at cast_spell time instead of writing its timed effect
+        # to the target. This attack resolves that spell attack when it's the caster striking
+        # this same target: on a HIT, materialize the rider's ActiveEffect on the target now
+        # (refresh-not-stack, identical to a cast-time write); on a MISS, discard it (no free
+        # advantage). A weapon attack with no matching pending rider is wholly unaffected.
+        riders = [
+            r for r in attacker.pending_on_hit_riders if r.target_id == target_id
+        ]
+        if riders:
+            # Drop every matched rider from the caster whatever the outcome — hit applies,
+            # miss simply discards. (Unmatched riders, e.g. a bolt aimed at a different
+            # target, stay pending.)
+            attacker.pending_on_hit_riders = [
+                r for r in attacker.pending_on_hit_riders if r.target_id != target_id
+            ]
+            if hit:
+                applied = []
+                for r in riders:
+                    eff = ActiveEffect(
+                        name=r.name,
+                        source_id=r.source_id,
+                        concentration=False,
+                        scale=r.scale,
+                        rounds_remaining=r.rounds_remaining,
+                        expires_day=r.expires_day,
+                        expires_phase_index=r.expires_phase_index,
+                        until_long_rest=r.until_long_rest,
+                    )
+                    # Refresh, don't stack (mirrors cast_spell's write).
+                    target.active_effects = [
+                        e for e in target.active_effects if e.name != r.name
+                    ]
+                    target.active_effects.append(eff)
+                    applied.append(r.name)
+                result["on_hit_effect_applied"] = applied
+            else:
+                result["on_hit_effect_discarded"] = [r.name for r in riders]
         outcome_label = "crit" if is_crit else ("hit" if hit else "miss")
         if hit and result["damage"]:
             dtype = f" {damage_type}" if damage_type else ""
@@ -3695,6 +3734,15 @@ def cast_spell(
     # The spell's timed duration (if any), normalized from whichever data source carries
     # it — both curated and srd524 records have a `duration` string (see spells.parse_duration).
     duration = spells.parse_duration(curated.get("duration") if curated else srd.get("duration"))
+    # Does this spell resolve via an ATTACK ROLL (vs a saving throw / auto-hit / buff)?
+    # SRD records carry an explicit `attack_roll` bool; a curated spell is an attack spell
+    # when its mechanics kind is "attack" (Fire Bolt — a damage cantrip). Drives the #186
+    # on-hit-rider defer below: an attack-roll spell's timed effect on a SEPARATE target
+    # is a 5e on-hit rider (Guiding Bolt) and must wait for the attack to HIT.
+    is_attack_roll_spell = bool(
+        (curated.get("mechanics", {}).get("kind") == "attack") if curated
+        else srd.get("attack_roll")
+    )
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _char(c, character_id)
@@ -3754,28 +3802,66 @@ def cast_spell(
         # CASTER (so it stays the twin of ch.concentration, one source of truth); a
         # non-concentration buff with an explicit target holds it on that target.
         effect_holder = ch
+        pending_rider = None  # set when the effect DEFERS to the spell-attack hit (#186)
         if duration is not None:
             if not concentrates and target_id and target_id != character_id:
                 tgt = c.characters.get(target_id)
                 if tgt is not None:
                     effect_holder = tgt
-            eff = ActiveEffect(
-                name=canonical,
-                source_id=character_id,
-                concentration=concentrates,
-                scale=duration["scale"],
-                rounds_remaining=duration["rounds"],
-                until_long_rest=(duration["scale"] == "hours"),
+            # ON-HIT RIDER DEFER (#186). An ATTACK-ROLL spell whose timed effect lands on a
+            # SEPARATE target is a 5e on-hit rider (Guiding Bolt: "on a hit, the next attack
+            # against it has Advantage"). The cast and the spell attack are two calls, so the
+            # effect must NOT be written to the target at cast time — a MISS would leave a
+            # phantom marker (free advantage) and a re-cast would stack a second one. Record a
+            # PENDING rider on the CASTER instead; the next attack() (attacker == caster,
+            # target == this target) materializes it on a HIT or discards it on a MISS. Save
+            # spells (attack_roll False) and self/ally buffs (holder == caster) are unaffected
+            # — they fall through to the immediate write below, exactly as before.
+            defer_on_hit = (
+                is_attack_roll_spell
+                and effect_holder is not ch
+                and not concentrates
             )
-            if duration["scale"] in ("hours", "days"):
-                eff.expires_day, eff.expires_phase_index = _effect_clock_deadline(
-                    c, duration["hours"], duration["days"]
+            if defer_on_hit:
+                rider = PendingOnHitRider(
+                    name=canonical,
+                    source_id=character_id,
+                    target_id=effect_holder.id,
+                    scale=duration["scale"],
+                    rounds_remaining=duration["rounds"],
+                    until_long_rest=(duration["scale"] == "hours"),
                 )
-            # Recasting the SAME spell on a holder refreshes (doesn't stack) it.
-            effect_holder.active_effects = [
-                e for e in effect_holder.active_effects if e.name != canonical
-            ]
-            effect_holder.active_effects.append(eff)
+                if duration["scale"] in ("hours", "days"):
+                    rider.expires_day, rider.expires_phase_index = _effect_clock_deadline(
+                        c, duration["hours"], duration["days"]
+                    )
+                # Re-casting at the SAME target replaces the pending rider for this spell —
+                # no phantom second marker (the bug). Keyed by (target_id, name).
+                ch.pending_on_hit_riders = [
+                    r for r in ch.pending_on_hit_riders
+                    if not (r.target_id == rider.target_id and r.name == canonical)
+                ]
+                ch.pending_on_hit_riders.append(rider)
+                pending_rider = rider
+                effect_holder = ch  # nothing written to the target yet; caster carries the pending record
+            else:
+                eff = ActiveEffect(
+                    name=canonical,
+                    source_id=character_id,
+                    concentration=concentrates,
+                    scale=duration["scale"],
+                    rounds_remaining=duration["rounds"],
+                    until_long_rest=(duration["scale"] == "hours"),
+                )
+                if duration["scale"] in ("hours", "days"):
+                    eff.expires_day, eff.expires_phase_index = _effect_clock_deadline(
+                        c, duration["hours"], duration["days"]
+                    )
+                # Recasting the SAME spell on a holder refreshes (doesn't stack) it.
+                effect_holder.active_effects = [
+                    e for e in effect_holder.active_effects if e.name != canonical
+                ]
+                effect_holder.active_effects.append(eff)
         mod = _casting_mod(ch)
         prof = ch.proficiency_bonus
         c.characters[character_id] = Character.model_validate(ch.model_dump(mode="json"))
@@ -3805,8 +3891,23 @@ def cast_spell(
             },
         }
         # Surface the engine-tracked timed effect (if any) so the DM knows it'll
-        # auto-expire — and on whom it's tracked.
-        if duration is not None:
+        # auto-expire — and on whom it's tracked. An ON-HIT rider (#186) is NOT on the
+        # target yet, so report it as a `pending_effect` keyed to its target: it lands
+        # only when the spell attack hits (and the DM resolves that via attack()).
+        if pending_rider is not None:
+            result["pending_effect"] = {
+                "name": canonical,
+                "target_id": pending_rider.target_id,
+                "scale": duration["scale"],
+                "rounds_remaining": duration["rounds"],
+                "on_hit": True,
+                "note": (
+                    "On-hit rider: applied to the target only when the spell attack HITS "
+                    "(resolve via attack(attacker=this caster, target=this target)); "
+                    "discarded on a miss."
+                ),
+            }
+        elif duration is not None:
             result["active_effect"] = {
                 "name": canonical,
                 "holder_id": effect_holder.id,

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -818,7 +818,13 @@ def test_next_turn_brief_monster_multiattack(tmp_path, monkeypatch):
     captain_id = res["spawned"][0]["id"]
 
     server.start_combat(cid, [pc, captain_id])
-    nt = server.next_turn(cid)  # advance past the first combatant to the second
+    # Initiative order is random; the #183 guard blocks advancing past an able PC
+    # who hasn't acted, so declare a pass for the PC if it won initiative.
+    try:
+        nt = server.next_turn(cid)  # advance past the first combatant to the second
+    except ValueError:
+        server.use_action(cid, pc, "skip")
+        nt = server.next_turn(cid)
 
     assert "turn_brief" in nt, "next_turn must always include turn_brief when combat is active"
     brief = nt["turn_brief"]

--- a/servers/engine/tests/test_effect_durations.py
+++ b/servers/engine/tests/test_effect_durations.py
@@ -138,6 +138,173 @@ def test_buff_with_target_tracks_on_target():
     assert _effects(cid, ally)[0]["source_id"] == caster  # source recorded
 
 
+# --- attack-roll spell ON-HIT riders defer until the spell attack hits (#186) ----
+# Guiding Bolt grants its "next attack has Advantage" rider ONLY on a hit. cast_spell
+# must NOT write that marker to the target at cast time (a miss would leave a phantom
+# free-advantage marker, and a re-cast would stack a second one). Instead it records a
+# PENDING rider on the caster; the next attack() materializes it on a HIT and discards
+# it on a MISS. Save spells and self/ally buffs are unaffected (the regressions below).
+
+import dice as dice_mod  # noqa: E402  (deterministic hit/miss for the attack() resolution)
+from dice import DiceRoll  # noqa: E402
+
+
+def _d20_roll(natural: int):
+    """A dice.roll stub that forces the d20 NATURAL face (so a spell attack is a
+    deterministic hit/miss) while honoring the expression's flat modifier; non-d20
+    expressions (damage) roll a fixed mid value. Used via monkeypatch on the attack."""
+    def _roll(expression: str, advantage: bool = False, disadvantage: bool = False, seed=None) -> DiceRoll:
+        if expression.startswith("1d20"):
+            mod = 0
+            if "+" in expression:
+                mod = int(expression.split("+", 1)[1])
+            elif "-" in expression.split("d", 1)[1]:
+                mod = -int(expression.rsplit("-", 1)[1])
+            return DiceRoll(
+                expression=expression, total=natural + mod, rolls=[natural], modifier=mod,
+                detail=f"{expression}[{natural}] = {natural + mod}", is_d20=True,
+                natural=natural, crit=(natural == 20), fumble=(natural == 1),
+            )
+        return DiceRoll(expression=expression, total=6, rolls=[3], detail=f"{expression}[3] = 6")
+    return _roll
+
+
+def _gb_cleric(cid, name="Pious"):
+    c = _cleric(cid, name)
+    server.learn_spells(cid, c, ["Guiding Bolt"])
+    server.prepare_spells(cid, c, ["Guiding Bolt"])
+    return c
+
+
+def _advance_to(cid, who):
+    """Pass non-`who` combatants (PCs must act/pass before next_turn, #160) until it
+    is `who`'s turn so an action attack by `who` is legal."""
+    for _ in range(12):
+        cur = server.get_state(cid).get("current_turn")
+        if cur == who:
+            return
+        ch = server.get_character(cid, cur)
+        if ch.get("kind") in ("player", "companion") and ch.get("current_hp", 1) > 0:
+            server.use_action(cid, cur, "skip")
+        server.next_turn(cid)
+    raise AssertionError(f"never reached {who}'s turn")
+
+
+def test_guiding_bolt_cast_defers_rider_does_not_touch_target():
+    """cast(Guiding Bolt at foe) must NOT write the GB marker to the target — it returns
+    a `pending_effect` (not `active_effect`) and records a pending rider on the caster."""
+    cid = server.create_campaign("S")["id"]
+    cleric = _gb_cleric(cid)
+    foe = server.create_character(cid, "Goblin", kind="monster", max_hp=30, armor_class=12)["id"]
+    out = server.cast_spell(cid, cleric, "Guiding Bolt", target_id=foe)
+    # NOT applied to the target yet — surfaced as a pending on-hit effect instead.
+    assert "active_effect" not in out
+    assert out["pending_effect"]["name"] == "Guiding Bolt"
+    assert out["pending_effect"]["target_id"] == foe and out["pending_effect"]["on_hit"] is True
+    assert _effects(cid, foe) == []  # the target carries NOTHING at cast time
+    # The pending rider lives on the CASTER, keyed to the target.
+    riders = server.get_character(cid, cleric)["pending_on_hit_riders"]
+    assert [r["name"] for r in riders] == ["Guiding Bolt"]
+    assert riders[0]["target_id"] == foe and riders[0]["source_id"] == cleric
+
+
+def test_guiding_bolt_miss_does_not_apply_rider(monkeypatch):
+    """THE BUG (#186): cast(Guiding Bolt) + attack(MISS) -> the target has NO GB marker,
+    and the pending rider is discarded (no free advantage on a missed bolt)."""
+    cid = server.create_campaign("S")["id"]
+    cleric = _gb_cleric(cid)
+    foe = server.create_character(cid, "Goblin", kind="monster", max_hp=30, armor_class=18)["id"]
+    server.cast_spell(cid, cleric, "Guiding Bolt", target_id=foe)
+    server.start_combat(cid, [cleric, foe])
+    _advance_to(cid, cleric)
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(2))  # natural 2, +bonus -> misses AC 18
+    res = server.attack(cid, cleric, foe, attack_bonus=5, damage_dice="4d6",
+                        damage_type="radiant", is_ranged=True)
+    assert res["hit"] is False
+    assert res.get("on_hit_effect_discarded") == ["Guiding Bolt"]
+    assert "on_hit_effect_applied" not in res
+    assert _effects(cid, foe) == []  # <-- the fix: NO marker on a miss
+    assert server.get_character(cid, cleric)["pending_on_hit_riders"] == []  # rider consumed
+
+
+def test_guiding_bolt_hit_applies_rider(monkeypatch):
+    """cast(Guiding Bolt) + attack(HIT) -> the GB marker IS written to the target (a
+    round-scale effect, sourced from the caster), and the pending rider is consumed."""
+    cid = server.create_campaign("S")["id"]
+    cleric = _gb_cleric(cid)
+    foe = server.create_character(cid, "Goblin", kind="monster", max_hp=30, armor_class=10)["id"]
+    server.cast_spell(cid, cleric, "Guiding Bolt", target_id=foe)
+    server.start_combat(cid, [cleric, foe])
+    _advance_to(cid, cleric)
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(15))  # natural 15, +5 -> hits AC 10
+    res = server.attack(cid, cleric, foe, attack_bonus=5, damage_dice="4d6",
+                        damage_type="radiant", is_ranged=True)
+    assert res["hit"] is True
+    assert res.get("on_hit_effect_applied") == ["Guiding Bolt"]
+    assert "on_hit_effect_discarded" not in res
+    eff = _effects(cid, foe)
+    assert [e["name"] for e in eff] == ["Guiding Bolt"]  # <-- marker written on a hit
+    assert eff[0]["scale"] == "rounds" and eff[0]["source_id"] == cleric
+    assert server.get_character(cid, cleric)["pending_on_hit_riders"] == []  # rider consumed
+
+
+def test_guiding_bolt_recast_does_not_phantom_stack_pending():
+    """Re-casting Guiding Bolt at the same target replaces the pending rider (one record),
+    so a second cast can't leave a phantom marker (the re-cast half of the bug)."""
+    cid = server.create_campaign("S")["id"]
+    cleric = _gb_cleric(cid)
+    for _ in range(2):  # a level-3 cleric has two 1st-level slots to spend
+        server.level_up(cid, cleric, "Cleric")
+    foe = server.create_character(cid, "Goblin", kind="monster", max_hp=30, armor_class=12)["id"]
+    server.cast_spell(cid, cleric, "Guiding Bolt", target_id=foe)
+    server.cast_spell(cid, cleric, "Guiding Bolt", target_id=foe)  # re-cast
+    riders = server.get_character(cid, cleric)["pending_on_hit_riders"]
+    assert len(riders) == 1 and riders[0]["target_id"] == foe  # single rider, no phantom
+    assert _effects(cid, foe) == []  # still nothing on the target
+
+
+def test_guiding_bolt_materialized_rider_auto_expires(monkeypatch):
+    """Once a hit materializes the GB rider on the target, it auto-expires like any other
+    timed effect — its 1-round duration ends a round later via next_turn."""
+    cid = server.create_campaign("S")["id"]
+    cleric = _gb_cleric(cid)
+    foe = server.create_character(cid, "Goblin", kind="monster", max_hp=60, armor_class=10)["id"]
+    server.cast_spell(cid, cleric, "Guiding Bolt", target_id=foe)
+    server.start_combat(cid, [cleric, foe])
+    _advance_to(cid, cleric)
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(15))  # hit -> GB lands on foe
+    server.attack(cid, cleric, foe, attack_bonus=5, damage_dice="4d6", is_ranged=True)
+    assert [e["name"] for e in _effects(cid, foe)] == ["Guiding Bolt"]
+    # (the d20 stub stays patched; next_turn / use_action(skip) roll no attack, so the
+    # turn advance below is unaffected — don't monkeypatch.undo(), which would also revert
+    # the autouse CLAWDND_STATE_DIR fixture and orphan the campaign.)
+    expired = None
+    for _ in range(6):
+        v = _advance_turn(cid)
+        if v["expired_effects"]:
+            expired = v["expired_effects"]
+            break
+    assert expired == [{"character_id": foe, "name": "Guiding Bolt"}]
+    assert _effects(cid, foe) == []
+
+
+def test_self_buff_attack_spell_not_deferred_unchanged():
+    """REGRESSION: a self/ally buff still writes its effect at cast even if the SRD record
+    happens to carry attack_roll (Mirror Image is a self-buff). The defer is scoped to a
+    SEPARATE target, so a no-target / self-target cast is byte-identical to before."""
+    cid = server.create_campaign("S")["id"]
+    w = server.create_character(cid, "Gale", kind="player", class_name="Wizard",
+                                apply_srd_defaults=True, abilities={"intelligence": 16})["id"]
+    server.level_up(cid, w, "Wizard")
+    server.level_up(cid, w, "Wizard")  # level 3 -> a 2nd-level slot for the level-2 spell
+    server.learn_spells(cid, w, ["Mirror Image"])
+    server.prepare_spells(cid, w, ["Mirror Image"])
+    out = server.cast_spell(cid, w, "Mirror Image")  # no target -> holder is the caster
+    assert "pending_effect" not in out
+    assert out["active_effect"]["holder_id"] == w
+    assert [e["name"] for e in _effects(cid, w)] == ["Mirror Image"]  # applied at cast, as before
+
+
 # --- decrement + auto-expire in combat ---------------------------------------
 def test_next_turn_decrements_and_expires_bless():
     cid = server.create_campaign("S")["id"]


### PR DESCRIPTION
Closes #186 (found by the combat-sprint bug-finder). An attack-roll spell's on-hit rider (Guiding Bolt: next attack vs target has advantage) was written to TARGET state at cast_spell time, persisting even on a MISS. Now cast_spell records a PendingOnHitRider on the caster (additive Character field) for attack-roll spells; attack() materializes it on HIT, discards on MISS. Save/buff spells unchanged (scoped to attack-roll spells w/ a timed effect on a separate target). Also de-flakes test_next_turn_brief_monster_multiattack (a pre-existing flake the #183 guard exposed). Tests: 48 effect-durations (7 new incl. miss/hit invariants) + 134 combat, single-process; broad regression green. Local-gated.