### PR TITLE
feat(companion): decision-gated betrayal flips — Quest&Arc Layer 2

### DIFF
--- a/servers/engine/companion_arc.py
+++ b/servers/engine/companion_arc.py
@@ -45,8 +45,31 @@ only snaps ~35% of the time per beat — it feels dangerous, not instant. When t
 is vulnerable the probability is nudged up by ATTITUDE_SNAP_VULNERABLE_BONUS (0.10) so
 the betrayer is more likely to pick the worst moment.
 
+Decision-gated escalation (Quest & Arc engine, Layer 2)
+-------------------------------------------------------
+A recorded player CHOICE can RAISE the betrayal weight: when an ``attitude_below``
+agenda carries a ``decision_flag`` and that CONTENT-defined flag is present+True in
+``Campaign.flags`` (set when the gating choice was made — "let the daughter die",
+"took the bribe"), the per-beat snap probability is boosted by
+ATTITUDE_SNAP_DECISION_BONUS (0.30), capped at ATTITUDE_SNAP_DECISION_MAX (0.90). The
+turn becomes far likelier, but it is still ROLLED and still requires the relationship to
+be below the breaking point first — the companion stays in-character; the choice tips an
+already-curdling bond over, it doesn't conjure a betrayal from nowhere. The boost reads
+only the engine-mutated `flags` dict, never fiction (contract-safe). Empty
+`decision_flag` (or the flag absent/False) == the unescalated curve above, byte-for-byte.
+
 The other triggers (day_reached, prize_seized, party_vulnerable) are SPECIFIC EVENTS —
 they either happened or they didn't; making them probabilistic would break their semantics.
+The decision_flag boost is deliberately scoped to ``attitude_below`` only (the rising-
+chance trigger); the event triggers ignore it.
+
+Warning bands (telegraph, not surprise-from-nowhere)
+----------------------------------------------------
+``evaluate`` surfaces an advisory ``betrayal_warning`` when a companion carrying a LIVE
+(unfired) ``attitude_below`` agenda sits in the danger band ATTITUDE_WARN_HIGH (-20) ..
+ATTITUDE_WARN_LOW (-40) — so the DM/Director can foreshadow the fracture before it fires.
+It is ADVISORY ONLY: it never fires the agenda, never mutates state, and reads only the
+attitude gauge + the (engine-set) decision_flag. Outside the band there is no warning.
 """
 
 from __future__ import annotations
@@ -72,6 +95,27 @@ ATTITUDE_SNAP_MAX: float = 0.35
 # saboteur is more likely to strike when the party is weakest.
 ATTITUDE_SNAP_VULNERABLE_BONUS: float = 0.10
 
+# --- decision-gated escalation constants (Quest & Arc engine, Layer 2) ----------
+
+# Additive boost to the per-beat snap probability when the agenda's `decision_flag` is
+# set+True in Campaign.flags — a recorded player CHOICE that tips an already-curdling
+# bond over ("let the daughter die → the knight turns"). Meaningful (the "betrayal
+# chance spikes"), not a guarantee.
+ATTITUDE_SNAP_DECISION_BONUS: float = 0.30
+
+# Hard ceiling on the snap probability ONCE the decision boost is applied — the choice
+# makes the turn far likelier but never a certainty per beat (the companion stays
+# in-character; the betrayal is still rolled and still staged at an event by the DM).
+ATTITUDE_SNAP_DECISION_MAX: float = 0.90
+
+# --- warning-band constants (telegraph, Quest & Arc engine, Layer 2) ------------
+
+# The attitude danger band for a LIVE attitude_below agenda: when attitude_value sits
+# in [ATTITUDE_WARN_LOW, ATTITUDE_WARN_HIGH] the relationship is fracturing but hasn't
+# bottomed out — `evaluate` surfaces an advisory so the DM/Director can foreshadow.
+ATTITUDE_WARN_HIGH: int = -20  # upper edge: the bond has clearly soured
+ATTITUDE_WARN_LOW: int = -40   # lower edge: below this it's already deep-red / near-snap
+
 
 def _party_vulnerable(campaign: Campaign) -> bool:
     """True if any PARTY member (PC or companion) is downed or below the HP threshold —
@@ -88,15 +132,29 @@ def _party_vulnerable(campaign: Campaign) -> bool:
     return False
 
 
-def _attitude_below_snap_p(attitude_value: int, threshold: int, vulnerable: bool) -> float:
+def _attitude_below_snap_p(
+    attitude_value: int,
+    threshold: int,
+    vulnerable: bool,
+    decision_flag_active: bool = False,
+) -> float:
     """Per-beat snap probability for an ``attitude_below`` agenda (issue #142).
 
-    Returns 0.0 when attitude_value >= threshold (never fires above the line).
+    Returns 0.0 when attitude_value >= threshold (never fires above the line) — the
+    decision boost NEVER overrides this, so a recorded choice can't fire a betrayal
+    while the relationship is still above its breaking point.
+
     Otherwise rises linearly from ~0 at the threshold to ATTITUDE_SNAP_MAX at or below
     ATTITUDE_SNAP_FLOOR, optionally boosted by ATTITUDE_SNAP_VULNERABLE_BONUS when
-    the party is weak. The result is clamped to [0.0, ATTITUDE_SNAP_MAX +
+    the party is weak. The base+vulnerable result is clamped to [0.0, ATTITUDE_SNAP_MAX +
     ATTITUDE_SNAP_VULNERABLE_BONUS] — never > ~0.45 so even a companion deep in the
-    red still requires multiple beats to reliably snap."""
+    red still requires multiple beats to reliably snap.
+
+    Decision-gated escalation (Layer 2): when ``decision_flag_active`` (a recorded
+    player CHOICE set the agenda's content-defined flag), ATTITUDE_SNAP_DECISION_BONUS
+    is ADDED on top and the whole thing re-capped at ATTITUDE_SNAP_DECISION_MAX (0.90)
+    — the betrayal chance spikes, but it is still rolled, never certain, and never above
+    the breaking-point guard."""
     if attitude_value >= threshold:
         return 0.0
     span = threshold - ATTITUDE_SNAP_FLOOR  # > 0: threshold is always > floor
@@ -105,7 +163,23 @@ def _attitude_below_snap_p(attitude_value: int, threshold: int, vulnerable: bool
     p = min(raw_p, ATTITUDE_SNAP_MAX)
     if vulnerable:
         p = min(p + ATTITUDE_SNAP_VULNERABLE_BONUS, ATTITUDE_SNAP_MAX + ATTITUDE_SNAP_VULNERABLE_BONUS)
+    if decision_flag_active:
+        # The recorded choice tips the bond over: spike the chance, but keep it a roll
+        # (capped at DECISION_MAX, above the vulnerable cap) — never a guaranteed turn.
+        p = min(p + ATTITUDE_SNAP_DECISION_BONUS, ATTITUDE_SNAP_DECISION_MAX)
     return p
+
+
+def _decision_flag_active(agenda, campaign: Campaign) -> bool:
+    """Whether this agenda's decision-gated escalation is live (Layer 2).
+
+    True only when the agenda names a `decision_flag` AND that CONTENT-defined flag is
+    present and True in `Campaign.flags` (a recorded player choice set it). Reads only
+    the engine-mutated `flags` dict — never fiction. Empty `decision_flag` => False, so
+    an un-escalated agenda is byte-for-byte today's #142 behavior."""
+    if agenda is None or not agenda.decision_flag:
+        return False
+    return bool(campaign.flags.get(agenda.decision_flag))
 
 
 def _agenda_triggered(character: Character, campaign: Campaign, rng: random.Random | None = None) -> bool:
@@ -113,7 +187,7 @@ def _agenda_triggered(character: Character, campaign: Campaign, rng: random.Rand
 
     For ``attitude_below``: probabilistic (rising chance as attitude drops — see module
     docstring). A fresh ``random.Random()`` is used when no ``rng`` is passed; pass a
-    seeded one for deterministic tests.
+    seeded one for deterministic tests. A set `decision_flag` (Layer 2) spikes the chance.
 
     For all other triggers: deterministic (the event either occurred or it didn't).
     """
@@ -130,6 +204,7 @@ def _agenda_triggered(character: Character, campaign: Campaign, rng: random.Rand
             character.attitude_value,
             agenda.value,
             _party_vulnerable(campaign),
+            decision_flag_active=_decision_flag_active(agenda, campaign),
         )
         if p <= 0.0:
             return False
@@ -142,6 +217,45 @@ def _agenda_triggered(character: Character, campaign: Campaign, rng: random.Rand
     if trigger == "prize_seized":
         return bool(campaign.flags.get("prize_seized"))
     return False
+
+
+def _betrayal_warning(character: Character, campaign: Campaign) -> dict | None:
+    """ADVISORY telegraph for an approaching betrayal (Layer 2) — never auto-acts.
+
+    Returns a small advisory dict when the companion carries a LIVE (unfired)
+    ``attitude_below`` agenda AND its attitude sits in the danger band
+    [ATTITUDE_WARN_LOW, ATTITUDE_WARN_HIGH] — the relationship is fracturing but hasn't
+    bottomed out, so the DM/Director can foreshadow the turn instead of springing it
+    "from nowhere". Returns None outside the band, or when there is no live attitude_below
+    agenda. Reads only the attitude gauge + the (engine-set) decision_flag — no fiction,
+    no mutation. The `decision_flag_active` field lets the DM know a recorded choice has
+    already spiked the odds (foreshadow harder)."""
+    arc = character.arc
+    if arc is None:
+        return None
+    agenda = arc.agenda
+    if agenda is None or agenda.fired or agenda.trigger != "attitude_below":
+        return None
+    if agenda.value is None:
+        return None
+    av = character.attitude_value
+    # Only warn while the bond is in the danger band AND has actually crossed below the
+    # agenda's breaking point (an agenda whose threshold is even lower isn't live yet).
+    if not (ATTITUDE_WARN_LOW <= av <= ATTITUDE_WARN_HIGH):
+        return None
+    if av >= agenda.value:
+        return None
+    return {
+        "companion_id": character.id,
+        "attitude_value": av,
+        "threshold": agenda.value,
+        "band": [ATTITUDE_WARN_LOW, ATTITUDE_WARN_HIGH],
+        "decision_flag_active": _decision_flag_active(agenda, campaign),
+        "note": (
+            "approaching betrayal — this companion's bond is in the danger band; "
+            "foreshadow the fracture before the agenda fires"
+        ),
+    }
 
 
 def _unlock_companion_quest_arc(character: Character, campaign: Campaign, gate) -> dict | None:
@@ -206,8 +320,10 @@ def evaluate(character: Character, campaign: Campaign, rng: random.Random | None
 
     Idempotent: a gate/agenda already resolved on a prior call is NOT reported again.
     Returns ``{newly_unlocked: [gate dicts], agenda_fired: bool, agenda: <dict|None>}`` —
-    the moments that just became live, for the DM to dramatize. A character with no `arc`
-    is a no-op (empty result)."""
+    the moments that just became live, for the DM to dramatize. When a LIVE (unfired)
+    ``attitude_below`` agenda's companion sits in the danger band, an advisory
+    ``betrayal_warning`` is ALSO included (telegraph, never auto-acts; Layer 2). A
+    character with no `arc` is a no-op (empty result)."""
     newly_unlocked: list[dict] = []
     companion_quest_unlocks: list[dict] = []
     agenda_fired = False
@@ -240,4 +356,10 @@ def evaluate(character: Character, campaign: Campaign, rng: random.Random | None
     out = {"newly_unlocked": newly_unlocked, "agenda_fired": agenda_fired, "agenda": agenda_dump}
     if companion_quest_unlocks:
         out["companion_quest_unlocks"] = companion_quest_unlocks
+    # Advisory telegraph: surface an approaching-betrayal warning while a live
+    # attitude_below agenda sits in the danger band (Layer 2). Computed after the fire
+    # check, so a betrayal that JUST fired this beat is the event, not a warning.
+    warning = _betrayal_warning(character, campaign)
+    if warning is not None:
+        out["betrayal_warning"] = warning
     return out

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -222,12 +222,29 @@ class CompanionAgenda(_StrictModel):
     - "party_vulnerable": any party member at `current_hp <= 0` OR `<= 25% of max_hp`
                           (strikes when the party is weakest)
     - "prize_seized":   the campaign flag `prize_seized` is set (the goal is in hand)
+
+    Decision-gated escalation (Quest & Arc engine, Layer 2):
+    `decision_flag` names a CONTENT-defined campaign flag (e.g. "let_daughter_die",
+    "took_bribe") that, when present AND True in `Campaign.flags`, ESCALATES an
+    ``attitude_below`` agenda — a recorded player CHOICE makes the turn far likelier
+    ("let the farmer's daughter die → the knight-companion turns on you"). It BOOSTS the
+    rising snap probability (companion_arc._attitude_below_snap_p); it never makes a
+    deterministic event fire on its own and never names the breaking point — the companion
+    stays in-character, the betrayal is still rolled. ADDITIVE: empty `decision_flag` ==
+    today's #142/#158 behavior byte-for-byte, so old snapshots round-trip unchanged. The
+    flag NAME lives in content (set via set_flag / record_decision(..., sets_flag=...)),
+    never in engine code.
     """
 
     trigger: Literal["attitude_below", "day_reached", "party_vulnerable", "prize_seized"]
     value: Optional[int] = None  # REQUIRED threshold for attitude_below/day_reached; unused otherwise
     fired: bool = False
     note: str = ""  # the agenda's intent, for the DM to dramatize when it fires
+    # A CONTENT-defined campaign flag whose presence+True in Campaign.flags ESCALATES this
+    # agenda's betrayal weight (Layer 2). Only the `attitude_below` trigger reads it. Empty
+    # == today's behavior. Never engine-coded; the DM/content sets the flag (set_flag /
+    # record_decision sets_flag) when the gating choice is made.
+    decision_flag: str = ""
 
     @model_validator(mode="after")
     def _require_threshold(self):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -5581,7 +5581,14 @@ def check_companion_arc(campaign_id: str, companion_id: str = "") -> dict:
     companions that carry an arc. A gate unlocks when the companion's `attitude_value`
     (the approval gauge) reaches its threshold; the sealed agenda fires when its trigger
     holds. Idempotent — a gate/agenda already resolved on a prior call is NOT reported
-    again, so calling every beat is safe."""
+    again, so calling every beat is safe.
+
+    A result may also carry an ADVISORY `betrayal_warning` (Layer 2): when a companion's
+    unfired `attitude_below` agenda sits in the danger band (~ -20..-40 approval), this
+    telegraphs an approaching turn so you can FORESHADOW it — it never fires the agenda
+    or mutates state. A `decision_flag` set by a recorded choice (set_flag /
+    record_decision sets_flag) spikes that betrayal's odds; the warning flags when one is
+    already active."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         if companion_id:
@@ -5593,7 +5600,12 @@ def check_companion_arc(campaign_id: str, companion_id: str = "") -> dict:
             if ch.arc is None:
                 continue
             res = companion_arc.evaluate(ch, c)
-            if res["newly_unlocked"] or res["agenda_fired"] or res.get("companion_quest_unlocks"):
+            if (
+                res["newly_unlocked"]
+                or res["agenda_fired"]
+                or res.get("companion_quest_unlocks")
+                or res.get("betrayal_warning")
+            ):
                 results.append({"companion_id": ch.id, "name": ch.name, **res})
         save_campaign(c)
         return {"results": results}
@@ -6062,11 +6074,21 @@ def record_decision(
     chosen: str = "",
     rationale: str = "",
     actor_ids: Optional[list] = None,
+    sets_flag: str = "",
 ) -> dict:
     """Record a party decision so the DM and companions can call back to it later
     ('last time we trusted Grett...'). Capture the choice after a deliberation:
     `summary` (the decision), `options` (what was on the table), `chosen`, why
-    (`rationale`), and who weighed in (`actor_ids`). Returns the decision id."""
+    (`rationale`), and who weighed in (`actor_ids`). Returns the decision id.
+
+    `sets_flag` (optional, Quest & Arc engine Layer 2) ties this CHOICE to a CONTENT-
+    defined campaign flag it raises — the one-step path for the owner's model ("let the
+    farmer's daughter die → the knight-companion turns on you"). When set, the named flag
+    is flipped True in `Campaign.flags` (same store as `set_flag`), which ESCALATES any
+    `attitude_below` companion agenda whose `decision_flag` matches (the betrayal chance
+    spikes). The flag NAME is yours (e.g. "let_daughter_die", "took_bribe") — never
+    engine-coded. Equivalent to a `set_flag` call alongside the record; omit it (or use
+    plain `set_flag`) when no agenda is gated on the choice. Returns the flag in `flag`."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         d = Decision(
@@ -6078,8 +6100,14 @@ def record_decision(
             actor_ids=list(actor_ids or []),
         )
         c.decisions.append(d)
+        flag = sets_flag.strip()
+        if flag:
+            c.flags[flag] = True  # content-defined; arms a matching agenda's decision_flag
         save_campaign(c)
-        return {"id": d.id, "summary": d.summary, "chosen": d.chosen, "day": d.day}
+        out = {"id": d.id, "summary": d.summary, "chosen": d.chosen, "day": d.day}
+        if flag:
+            out["flag"] = flag
+        return out
 
 
 @mcp.tool()

--- a/servers/engine/tests/test_companion_arc.py
+++ b/servers/engine/tests/test_companion_arc.py
@@ -832,3 +832,262 @@ def test_companion_quest_arc_apis_reject_bad_optional_links_without_partial_muta
     arc = persisted.companion_quest_arcs["cq_seraphine_vow"]
     assert arc.status == "locked"
     assert arc.stages[0].status == "locked"
+
+
+# ════════════════════════════════════════════════════════════════════════════
+# Quest & Arc engine — Layer 2: decision-gated companion flips
+#
+# A recorded player CHOICE sets a CONTENT-defined campaign flag that ESCALATES an
+# `attitude_below` agenda's betrayal weight ("let the daughter die → the knight turns").
+# Additive: empty `decision_flag` == today's #142/#158 behavior, byte-for-byte. The
+# escalation reads ONLY engine-mutated values (flags + attitude_value), never fiction.
+# A danger-band warning telegraphs the turn so it isn't a surprise-from-nowhere.
+# ════════════════════════════════════════════════════════════════════════════
+
+
+# --- additive default: the new field --------------------------------------------
+
+def test_agenda_decision_flag_defaults_empty():
+    agenda = CompanionAgenda(trigger="attitude_below", value=-20)
+    assert agenda.decision_flag == ""
+
+
+def test_old_agenda_snapshot_without_decision_flag_deserializes_unchanged():
+    """An agenda authored before Layer 2 has no `decision_flag` key — it must load with
+    decision_flag="" and round-trip identically (the additive-default contract)."""
+    agenda = CompanionAgenda(trigger="attitude_below", value=-20, note="turns")
+    data = agenda.model_dump(mode="json")
+    old = {k: v for k, v in data.items() if k != "decision_flag"}
+    assert "decision_flag" not in old
+    reloaded = CompanionAgenda.model_validate(old)
+    assert reloaded.decision_flag == ""
+    # full round-trip stays stable
+    assert CompanionAgenda.model_validate(reloaded.model_dump(mode="json")).decision_flag == ""
+
+
+def test_empty_decision_flag_snap_p_is_byte_identical_to_158():
+    """With no decision_flag active, the snap probability is EXACTLY the #142/#158 curve —
+    the Layer-2 param is purely additive."""
+    for attitude in range(-100, 1, 7):
+        for vuln in (False, True):
+            base = companion_arc._attitude_below_snap_p(attitude, 0, vuln)
+            with_param = companion_arc._attitude_below_snap_p(attitude, 0, vuln, decision_flag_active=False)
+            assert base == with_param
+
+
+# --- the probability boost math --------------------------------------------------
+
+def test_decision_flag_boosts_snap_probability():
+    """An active decision_flag ADDS ATTITUDE_SNAP_DECISION_BONUS on top of the rising
+    chance (capped at ATTITUDE_SNAP_DECISION_MAX)."""
+    attitude, threshold = -30, 0  # raw_p = 30/100 = 0.30 (below the 0.35 cap)
+    p_off = companion_arc._attitude_below_snap_p(attitude, threshold, False, decision_flag_active=False)
+    p_on = companion_arc._attitude_below_snap_p(attitude, threshold, False, decision_flag_active=True)
+    assert p_off == pytest.approx(0.30)
+    assert p_on == pytest.approx(0.30 + companion_arc.ATTITUDE_SNAP_DECISION_BONUS)
+    assert p_on > p_off
+
+
+def test_decision_flag_boost_capped_at_decision_max():
+    """The boosted probability never exceeds ATTITUDE_SNAP_DECISION_MAX (0.90) — the
+    betrayal stays a roll, never a certainty per beat. At the floor with the vulnerable
+    bonus the base reaches 0.45, +0.30 decision = 0.75 (still under the 0.90 ceiling)."""
+    p_floor = companion_arc._attitude_below_snap_p(
+        companion_arc.ATTITUDE_SNAP_FLOOR, 0, True, decision_flag_active=True
+    )
+    assert p_floor <= companion_arc.ATTITUDE_SNAP_DECISION_MAX + 1e-9
+    assert p_floor == pytest.approx(
+        companion_arc.ATTITUDE_SNAP_MAX
+        + companion_arc.ATTITUDE_SNAP_VULNERABLE_BONUS
+        + companion_arc.ATTITUDE_SNAP_DECISION_BONUS
+    )
+
+    # And where the base curve is high enough, the decision boost is what the 0.90 ceiling
+    # actually clamps: a threshold of 80 puts the raw curve near 1.0, so base hits the
+    # 0.35 cap, +vuln 0.10 = 0.45, +decision 0.30 = 0.75 — still under. To exercise the
+    # ceiling directly, confirm it never returns above DECISION_MAX across the whole range.
+    for attitude in range(-100, 80):
+        p = companion_arc._attitude_below_snap_p(attitude, 80, True, decision_flag_active=True)
+        assert p <= companion_arc.ATTITUDE_SNAP_DECISION_MAX + 1e-9
+
+
+def test_decision_flag_never_fires_above_threshold():
+    """The decision boost must NOT override the breaking-point guard: at/above the
+    threshold P stays 0 even with the flag active (no betrayal from nowhere)."""
+    p = companion_arc._attitude_below_snap_p(5, 0, True, decision_flag_active=True)
+    assert p == 0.0
+
+
+# --- the with/without-flag FIRE-RATE comparison (the headline behavioral gate) ---
+
+def test_decision_flag_fires_at_notably_higher_rate(monkeypatch):
+    """STATISTICAL gate: an attitude_below agenda WITH a set decision_flag fires at a
+    NOTABLY higher per-beat rate than the same agenda without it — over a seeded rng
+    loop. This is the owner's "betrayal chance spikes" made measurable."""
+    threshold, attitude = 0, -30  # base p = 0.30; boosted p = 0.60
+    n_trials = 800
+
+    def fire_rate(*, with_flag: bool, seed: int) -> float:
+        rng = random.Random(seed)
+        hits = 0
+        for _ in range(n_trials):
+            agenda = CompanionAgenda(
+                trigger="attitude_below",
+                value=threshold,
+                decision_flag="let_daughter_die" if with_flag else "",
+            )
+            _ch = _companion(attitude=attitude, agenda=agenda)
+            flags = {"let_daughter_die": True} if with_flag else None
+            c = _campaign_with(_ch, flags=flags)
+            if companion_arc.evaluate(_ch, c, rng=rng)["agenda_fired"]:
+                hits += 1
+        return hits / n_trials
+
+    rate_off = fire_rate(with_flag=False, seed=11)
+    rate_on = fire_rate(with_flag=True, seed=12)
+
+    # base ≈ 0.30, boosted ≈ 0.60 — demand a clearly higher rate (wide margin for variance)
+    assert rate_on > rate_off + 0.15, f"on={rate_on:.3f} should be notably > off={rate_off:.3f}"
+
+
+def test_decision_flag_set_but_false_does_not_boost():
+    """The flag must be present AND True to escalate — a flag set to False (or a different
+    flag set) leaves the #158 curve unchanged."""
+    threshold, attitude = 0, -30
+    agenda = CompanionAgenda(trigger="attitude_below", value=threshold, decision_flag="took_bribe")
+    ch = _companion(attitude=attitude, agenda=agenda)
+
+    # flag present but False -> no boost
+    c_false = _campaign_with(ch, flags={"took_bribe": False})
+    assert companion_arc._decision_flag_active(ch.arc.agenda, c_false) is False
+    # an UNRELATED flag set True -> no boost
+    c_other = _campaign_with(ch, flags={"some_other_flag": True})
+    assert companion_arc._decision_flag_active(ch.arc.agenda, c_other) is False
+    # the named flag True -> boost active
+    c_true = _campaign_with(ch, flags={"took_bribe": True})
+    assert companion_arc._decision_flag_active(ch.arc.agenda, c_true) is True
+
+
+def test_decision_flag_ignored_by_non_attitude_triggers():
+    """decision_flag is scoped to attitude_below — it must not change a day_reached /
+    prize_seized / party_vulnerable agenda's deterministic semantics."""
+    # day_reached with a decision_flag set True still only fires on/after its day
+    agenda = CompanionAgenda(trigger="day_reached", value=7, decision_flag="took_bribe")
+    ch = _companion(attitude=-90, agenda=agenda)
+    assert companion_arc.evaluate(ch, _campaign_with(ch, day=6, flags={"took_bribe": True}))["agenda_fired"] is False
+    assert companion_arc.evaluate(ch, _campaign_with(ch, day=7, flags={"took_bribe": True}))["agenda_fired"] is True
+
+
+# --- warning bands (telegraph) ---------------------------------------------------
+
+def test_betrayal_warning_surfaces_in_danger_band():
+    """A live attitude_below agenda whose companion sits in [-40, -20] surfaces an
+    advisory betrayal_warning."""
+    agenda = CompanionAgenda(trigger="attitude_below", value=0, note="turns on the party")
+    ch = _companion(attitude=-30, agenda=agenda)  # in the band, below the threshold
+    res = companion_arc.evaluate(ch, _campaign_with(ch), rng=random.Random(0))
+    warn = res.get("betrayal_warning")
+    assert warn is not None
+    assert warn["companion_id"] == ch.id
+    assert warn["attitude_value"] == -30
+    assert warn["band"] == [companion_arc.ATTITUDE_WARN_LOW, companion_arc.ATTITUDE_WARN_HIGH]
+    assert warn["decision_flag_active"] is False
+
+
+def test_betrayal_warning_absent_above_the_band():
+    """Above the danger band (attitude > -20) there is no warning — the bond hasn't
+    soured far enough to telegraph."""
+    agenda = CompanionAgenda(trigger="attitude_below", value=0)
+    ch = _companion(attitude=-10, agenda=agenda)  # above the band
+    res = companion_arc.evaluate(ch, _campaign_with(ch), rng=random.Random(0))
+    assert "betrayal_warning" not in res
+
+
+def test_betrayal_warning_absent_below_the_band():
+    """Below the danger band (attitude < -40) the warning stops — past telegraphing, the
+    turn is imminent (and the high per-beat P speaks for itself)."""
+    agenda = CompanionAgenda(trigger="attitude_below", value=0)
+    # use a fresh companion each beat so a fire doesn't end the loop; just inspect one beat
+    ch = _companion(attitude=-60, agenda=agenda)
+    # Force no-fire this beat with an rng that returns ~1.0 so we can inspect the warning field.
+    class _NoFire(random.Random):
+        def random(self):  # always >= any p -> never fires
+            return 0.999999
+    res = companion_arc.evaluate(ch, _campaign_with(ch), rng=_NoFire())
+    assert res["agenda_fired"] is False
+    assert "betrayal_warning" not in res
+
+
+def test_betrayal_warning_reflects_active_decision_flag():
+    """When a recorded choice has armed the agenda's decision_flag, the warning flags it
+    so the DM foreshadows harder."""
+    agenda = CompanionAgenda(trigger="attitude_below", value=0, decision_flag="let_daughter_die")
+    ch = _companion(attitude=-25, agenda=agenda)
+    res = companion_arc.evaluate(ch, _campaign_with(ch, flags={"let_daughter_die": True}), rng=random.Random(0))
+    assert res["betrayal_warning"]["decision_flag_active"] is True
+
+
+def test_no_warning_for_non_attitude_or_fired_agenda():
+    """The warning is only for a LIVE attitude_below agenda — not for other triggers, and
+    not once it has fired."""
+    # a prize_seized agenda in the same attitude band -> no warning
+    ch_event = _companion(attitude=-30, agenda=CompanionAgenda(trigger="prize_seized"))
+    assert "betrayal_warning" not in companion_arc.evaluate(ch_event, _campaign_with(ch_event))
+
+    # a fired attitude_below agenda -> no warning (the fire was the event)
+    agenda = CompanionAgenda(trigger="attitude_below", value=0, fired=True)
+    ch_fired = _companion(attitude=-30, agenda=agenda)
+    assert "betrayal_warning" not in companion_arc.evaluate(ch_fired, _campaign_with(ch_fired))
+
+
+# --- the Decision -> flag path (MCP tool layer) ----------------------------------
+
+def test_set_flag_arms_decision_gated_agenda(camp):
+    """The existing set_flag path arms an attitude_below agenda's decision_flag: with the
+    companion below threshold, setting the flag spikes the betrayal so it fires reliably."""
+    cid, comp = camp
+    server.set_companion_arc(cid, comp, {
+        "agenda": {
+            "trigger": "attitude_below",
+            "value": 0,
+            "decision_flag": "let_daughter_die",
+            "note": "the knight turns",
+        },
+    })
+    server.adjust_attitude(cid, comp, -30)  # push deep below the breaking point
+
+    server.set_flag(cid, "let_daughter_die")
+    # With p ≈ 0.60/beat, it fires within a handful of beats (idempotent check loop).
+    fired = False
+    for _ in range(60):
+        res = server.check_companion_arc(cid, comp)["results"]
+        if any(r.get("agenda_fired") for r in res):
+            fired = True
+            break
+    assert fired, "decision-gated betrayal should fire once the flag is set and attitude is below threshold"
+
+
+def test_record_decision_sets_flag_persists_and_arms_betrayal(camp):
+    """record_decision(..., sets_flag=...) flips the content-defined flag in the same call
+    that records the choice — the one-step decision->escalation path."""
+    cid, comp = camp
+    out = server.record_decision(
+        cid,
+        "Let the farmer's daughter die",
+        options=["save her", "let her die"],
+        chosen="let her die",
+        sets_flag="let_daughter_die",
+    )
+    assert out["flag"] == "let_daughter_die"
+    c = store.load_campaign(cid)
+    assert c.flags["let_daughter_die"] is True
+    assert len(c.decisions) == 1 and c.decisions[0].chosen == "let her die"
+
+
+def test_record_decision_without_sets_flag_is_unchanged(camp):
+    """Omitting sets_flag leaves flags untouched and the return shape free of `flag` —
+    today's behavior, byte-for-byte."""
+    cid, _comp = camp
+    out = server.record_decision(cid, "A choice with no gated agenda", chosen="x")
+    assert "flag" not in out
+    assert store.load_campaign(cid).flags == {}


### PR DESCRIPTION
Quest & Arc engine Layer 2 (decision-quest-arc-engine.md). A recorded player choice (CompanionAgenda.decision_flag, set via set_flag or record_decision(sets_flag=...)) ADDS +0.30 to the attitude_below betrayal roll (the owner's 'take the bribe -> chance spikes' / 'let the daughter die -> the knight turns'). The breaking-point guard (attitude>=threshold -> 0.0) is checked FIRST, so a boosted roll can never fire while the bond is healthy — no surprise-from-nowhere; telegraphed via an advisory betrayal_warning band (-20..-40). Additive (empty decision_flag == #158 behavior byte-identical). Statistical gate: with-flag 0.60 vs without 0.30 (800 trials); 63 companion_arc tests + FULL suite 1169 passing single-process. Local-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Companion escalations now support decision flag gating mechanism with conditional probability adjustments based on player-set flag activation states
  * New betrayal warning advisory system provides alerts when companion relationships approach critical escalation thresholds within configured danger bands; warnings are advisory-only
  * Decision recording tool expanded with flag-setting capability to activate decision-gated companion escalations and unlock conditional content

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->