### PR TITLE
[dice] Record parser dependency decision

### DIFF
--- a/docs/DICE_PARSER_DECISION.md
+++ b/docs/DICE_PARSER_DECISION.md
@@ -1,0 +1,68 @@
+# Dice Parser Decision
+
+Date: 2026-05-26
+
+## Decision
+
+Keep the ClawDnD engine on its native internal dice roller for now. Treat Avrae/d20
+as reference material only, not as a runtime dependency.
+
+The current engine dice contract is small but load-bearing:
+
+- `DiceRoll` is the public result shape used by engine callers and MCP tools.
+- `seed` must keep rolls deterministic for tests, replay, and audit trails.
+- Advantage and disadvantage must follow the D&D 5e cancellation rule.
+- Crit/fumble state belongs to the first single d20 test die only.
+- Parser bounds must reject pathological public-tool input before it can allocate
+  large roll lists or spend unbounded time parsing.
+
+Avrae/d20 remains useful as a comparison point for notation ideas, but adopting it
+would require proving that deterministic seeded behavior, result shape, first-d20
+semantics, and denial-of-service bounds all survive unchanged. Until that proof
+exists, adding the dependency increases integration risk without solving a current
+engine bug.
+
+## Current Boundaries
+
+The internal parser supports:
+
+- constants, such as `5`
+- standard dice terms, such as `1d20`, `2d6`, and `d%`
+- signed modifiers and multiple terms, such as `2d6+1d4+2`
+- keep-highest/keep-lowest suffixes, such as `4d6kh3`
+- advantage/disadvantage on the first single d20 term
+
+The parser intentionally rejects:
+
+- empty expressions
+- zero dice
+- keeping more dice than were rolled
+- more than 1000 dice in one term
+- die sides outside `1..1000`
+- normalized expressions longer than 4096 characters
+
+These bounds are intentionally above normal D&D use. They are not game-balance
+limits; they protect the public `roll` lane from pathological inputs.
+
+## Validation Evidence
+
+Focused regression coverage lives in `servers/engine/tests/test_dice.py` and locks:
+
+- deterministic seeding
+- advantage/disadvantage cancellation
+- first-d20 crit/fumble behavior
+- percentile shorthand
+- count, side, keep, and expression-length bounds
+
+This lane did not add Avrae/d20 or any other dice dependency.
+
+## Revisit Criteria
+
+Revisit a third-party dice parser only if it can be wrapped behind the existing
+`DiceRoll` contract and proven with focused tests to preserve:
+
+- deterministic seeded output
+- compatible roll, drop, modifier, detail, crit, and fumble fields
+- current first-d20 semantics
+- bounded expression length, dice count, and die sides
+- no broad dependency/runtime cost for the engine MCP server

--- a/servers/engine/dice.py
+++ b/servers/engine/dice.py
@@ -20,6 +20,7 @@ _TERM = re.compile(r"(\d*)d(\d+)(kh\d+|kl\d+)?$")
 # allocating a giant list and hanging the engine via the public `roll` MCP tool.
 _MAX_DICE = 1000
 _MAX_SIDES = 1000
+_MAX_EXPRESSION_CHARS = 4096
 
 
 @dataclass
@@ -51,6 +52,8 @@ def roll(
     expr = expression.replace(" ", "").lower().replace("d%", "d100")
     if not expr:
         raise ValueError("empty dice expression")
+    if len(expr) > _MAX_EXPRESSION_CHARS:
+        raise ValueError(f"dice expression must be <= {_MAX_EXPRESSION_CHARS} characters")
 
     terms = re.findall(r"[+-]?[^+-]+", expr)
     total = 0

--- a/servers/engine/tests/test_dice.py
+++ b/servers/engine/tests/test_dice.py
@@ -132,6 +132,15 @@ def test_roll_rejects_pathological_dice():
             raise AssertionError(f"expected ValueError for {expr!r}")
 
 
+def test_roll_rejects_pathologically_long_expression():
+    expr = "+".join(["1d6"] * 2000)
+    try:
+        dice.roll(expr)
+    except ValueError:
+        return
+    raise AssertionError("expected ValueError for pathologically long expression")
+
+
 def test_legit_rolls_unaffected_by_bounds():
     # Real D&D rolls stay well under the bounds and are unchanged.
     assert dice.roll("20d6+5", seed=1).total > 0          # high-level fireball


### PR DESCRIPTION
## Summary

Records the ClawDnD dice parser dependency decision and locks the missing parser
length bound with a focused regression test.

Refs roadmap squeeze dice lane.

## What Changed

- Added `docs/DICE_PARSER_DECISION.md` documenting why Avrae/d20 stays
  reference-only for this lane.
- Kept the engine on the native `servers/engine/dice.py` roller so the public
  `DiceRoll` contract and seeded deterministic behavior remain unchanged.
- Added a normalized expression-length guard for pathological public-tool input.
- Added focused dice regression coverage for pathologically long expressions.

## Decision Notes

Avrae/d20 is useful reference material, but it is not adopted as a dependency here.
Before any third-party parser can replace or wrap the internal roller, it must prove
that it preserves:

- deterministic seeded rolls
- the existing `DiceRoll` shape
- first-single-d20 advantage/crit/fumble semantics
- parser bounds for expression length, dice count, and die sides

The current ClawDnD-native parser remains the safer engine default because it is
small, auditable, deterministic, and already covered by focused tests.

## Validation

Run from `/Volumes/LEXAR/repos/ClawDnD-dice-parser-spike`:

```bash
uv run --directory servers/engine --group dev pytest -q tests/test_dice.py
python3 -m py_compile servers/engine/dice.py
git diff --check
```

## Rollback Plan

Revert this PR to remove the decision doc and the expression-length guard. No save
schema, runtime dependency, or non-dice surface is affected.
