### PR TITLE
[ingest] Add private compendium import sidecar

### DIFF
--- a/docs/PRIVATE_COMPENDIUM_SIDECAR.md
+++ b/docs/PRIVATE_COMPENDIUM_SIDECAR.md
@@ -1,0 +1,98 @@
+# Private Compendium Sidecar
+
+ClawDnD can plan local imports from user-owned books, adventures, exports, and
+homebrew without committing or redistributing that material. The private compendium
+sidecar is a local-only directory outside the git checkout. It is for metadata,
+source files, converter output, and future normalized private content owned by the
+person running the tool.
+
+This lane is intentionally a scaffold, not a public content import. It must not add
+private books, OGL/SRD-derived private exports, paid adventure text, user exports, or
+generated corpora to the repository.
+
+## Boundaries
+
+- Keep the sidecar outside the repo. The default is
+  `/Volumes/LEXAR/Codex/clawdnd-private-compendium`.
+- Override the sidecar root with `CLAWDND_PRIVATE_COMPENDIUM_ROOT` when needed.
+- Treat `content/worlds/_private/<world-id>/...` as the only future ClawDnD output
+  namespace for private world material.
+- Do not mutate campaign state, engine state, or public `content/worlds/*` content from
+  this tool.
+- Do not make Java/Quarkus, Obsidian vaults, or converter-specific indexes runtime
+  authority for ClawDnD. They are sidecar inputs only.
+
+## Manifest
+
+Create a local sidecar manifest outside the checkout:
+
+```bash
+python3 tools/ingest/private_compendium_sidecar.py --init
+```
+
+By default this writes:
+
+```text
+/Volumes/LEXAR/Codex/clawdnd-private-compendium/private-compendium-manifest.json
+```
+
+Example manifest:
+
+```json
+{
+  "schema_version": 1,
+  "world_id": "my-private-world",
+  "owner_acknowledgement": true,
+  "sources": [
+    {
+      "id": "owned-source",
+      "title": "Owned Source",
+      "format": "markdown",
+      "path": "vault/owned-source.md",
+      "content_type": "lore"
+    }
+  ]
+}
+```
+
+`owner_acknowledgement` must be `true`. It is an explicit local assertion that the
+operator owns or is otherwise permitted to process the referenced private material.
+
+## Dry Run
+
+The current tool validates the manifest and prints planned private outputs only:
+
+```bash
+python3 tools/ingest/private_compendium_sidecar.py
+```
+
+It will reject:
+
+- sidecar roots inside the git checkout
+- path escapes such as `../outside.md`
+- missing ownership acknowledgement
+- unsupported content types
+- duplicate or path-like source identifiers
+
+For now, supported planned content is lore-only:
+
+```text
+content/worlds/_private/<world-id>/lore/compendium/<source-id>.md
+```
+
+That path is already gitignored and guarded by `scripts/license_check.py`.
+
+## Future Import Step
+
+A later importer can read this validated plan and copy or normalize owner-approved
+records into gitignored private content. That later step should remain idempotent,
+path-safe, and explicit about provenance:
+
+- `private_only: true`
+- source id and local source path
+- import run id or timestamp
+- ownership acknowledgement state
+- no public redistribution license claim
+
+Structured private monsters, items, and spells should use explicit private namespaces
+and must not silently override committed SRD names.

--- a/scripts/license_check.py
+++ b/scripts/license_check.py
@@ -27,6 +27,9 @@ FORBIDDEN_PREFIXES = (
     "content/campaigns/_imported/",
     "content/campaigns/_private/",
     "content/worlds/_private/",
+    "clawdnd-private-compendium/",
+    "private-compendium/",
+    "tools/ingest/private-compendium/",
 )
 
 

--- a/servers/engine/tests/test_private_compendium_sidecar.py
+++ b/servers/engine/tests/test_private_compendium_sidecar.py
@@ -1,0 +1,117 @@
+"""Guards the private compendium sidecar manifest validator.
+
+The sidecar is stdlib-only ingest tooling that deliberately plans local/private
+outputs instead of importing owned content into tracked ClawDnD content.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+_INGEST = Path(__file__).resolve().parents[3] / "tools" / "ingest"
+sys.path.insert(0, str(_INGEST))
+
+import private_compendium_sidecar as sidecar  # noqa: E402
+
+
+def _manifest(root: Path, **overrides):
+    data = {
+        "schema_version": 1,
+        "world_id": "my-private-world",
+        "owner_acknowledgement": True,
+        "sources": [
+            {
+                "id": "owned-book",
+                "title": "Owned Book",
+                "format": "markdown",
+                "path": "vault/owned-book.md",
+                "content_type": "lore",
+            }
+        ],
+    }
+    data.update(overrides)
+    manifest = root / "private-compendium-manifest.json"
+    manifest.write_text(json.dumps(data), encoding="utf-8")
+    (root / "vault").mkdir()
+    (root / "vault" / "owned-book.md").write_text("# owned", encoding="utf-8")
+    return manifest
+
+
+def test_manifest_validation_plans_gitignored_private_outputs(tmp_path):
+    manifest = _manifest(tmp_path)
+
+    plan = sidecar.load_plan(manifest, repo_root=Path("/repo"))
+
+    assert plan.world_id == "my-private-world"
+    assert plan.private_root == tmp_path
+    assert len(plan.sources) == 1
+    assert plan.sources[0].planned_output == Path(
+        "content/worlds/_private/my-private-world/lore/compendium/owned-book.md"
+    )
+    assert plan.sources[0].source_path == tmp_path / "vault" / "owned-book.md"
+
+
+def test_manifest_requires_owner_acknowledgement(tmp_path):
+    manifest = _manifest(tmp_path, owner_acknowledgement=False)
+
+    try:
+        sidecar.load_plan(manifest, repo_root=Path("/repo"))
+    except sidecar.ManifestError as exc:
+        assert "owner_acknowledgement" in str(exc)
+    else:
+        raise AssertionError("expected owner acknowledgement failure")
+
+
+def test_manifest_rejects_path_escape(tmp_path):
+    manifest = _manifest(
+        tmp_path,
+        sources=[{
+            "id": "escape",
+            "title": "Escape",
+            "format": "markdown",
+            "path": "../outside.md",
+            "content_type": "lore",
+        }],
+    )
+
+    try:
+        sidecar.load_plan(manifest, repo_root=Path("/repo"))
+    except sidecar.ManifestError as exc:
+        assert "outside sidecar root" in str(exc)
+    else:
+        raise AssertionError("expected path escape failure")
+
+
+def test_manifest_rejects_path_like_source_id(tmp_path):
+    manifest = _manifest(
+        tmp_path,
+        sources=[{
+            "id": "../owned-book",
+            "title": "Owned Book",
+            "format": "markdown",
+            "path": "vault/owned-book.md",
+            "content_type": "lore",
+        }],
+    )
+
+    try:
+        sidecar.load_plan(manifest, repo_root=Path("/repo"))
+    except sidecar.ManifestError as exc:
+        assert "id must be a simple slug" in str(exc)
+    else:
+        raise AssertionError("expected source id validation failure")
+
+
+def test_manifest_rejects_repo_local_sidecar_root(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    sidecar_root = repo / "sidecar"
+    sidecar_root.mkdir()
+    manifest = _manifest(sidecar_root)
+
+    try:
+        sidecar.load_plan(manifest, repo_root=repo)
+    except sidecar.ManifestError as exc:
+        assert "outside the git repository" in str(exc)
+    else:
+        raise AssertionError("expected repo-local sidecar failure")

--- a/tools/ingest/README.md
+++ b/tools/ingest/README.md
@@ -58,6 +58,21 @@ python3 tools/ingest/wiki_to_characters.py tools/ingest/manifest_characters.json
 The parser is guarded by `servers/engine/tests/test_wiki_to_characters.py` (runs in CI's
 engine pytest via a path-insert, like `test_wiki_ingest.py`).
 
+## Private compendium sidecar
+
+`private_compendium_sidecar.py` is a local-only scaffold for user-owned books,
+adventures, exports, and homebrew. It validates a manifest kept outside the git checkout
+and prints planned gitignored private outputs; it does not ingest records into public
+content or mutate engine campaign state.
+
+```bash
+python3 tools/ingest/private_compendium_sidecar.py --init
+python3 tools/ingest/private_compendium_sidecar.py
+```
+
+The default sidecar root is `/Volumes/LEXAR/Codex/clawdnd-private-compendium`, overridable
+with `CLAWDND_PRIVATE_COMPENDIUM_ROOT`. See `docs/PRIVATE_COMPENDIUM_SIDECAR.md`.
+
 ## Licensing (TEXT ONLY)
 
 Each ingested record/page carries its **source URL + a per-source license + attribution**;

--- a/tools/ingest/private_compendium_sidecar.py
+++ b/tools/ingest/private_compendium_sidecar.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Plan private compendium sidecar imports without importing private content.
+
+This is local-only ingest scaffolding for user-owned books, adventures, exports, or
+homebrew. It validates a sidecar manifest kept outside the git checkout and prints
+the private, gitignored ClawDnD outputs a later importer would write. It does not
+copy records, mutate campaign state, or write tracked content.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_SIDECAR_ROOT = Path("/Volumes/LEXAR/Codex/clawdnd-private-compendium")
+ENV_SIDECAR_ROOT = "CLAWDND_PRIVATE_COMPENDIUM_ROOT"
+MANIFEST_NAME = "private-compendium-manifest.json"
+SUPPORTED_FORMATS = {"markdown", "json", "text"}
+SUPPORTED_CONTENT_TYPES = {"lore"}
+
+_HERE = Path(__file__).resolve().parent
+_REPO = _HERE.parents[1]
+
+
+class ManifestError(ValueError):
+    """Raised when a private sidecar manifest is unsafe or malformed."""
+
+
+@dataclass(frozen=True)
+class PlannedSource:
+    source_id: str
+    title: str
+    format: str
+    content_type: str
+    source_path: Path
+    planned_output: Path
+
+
+@dataclass(frozen=True)
+class SidecarPlan:
+    manifest_path: Path
+    private_root: Path
+    world_id: str
+    sources: tuple[PlannedSource, ...]
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _source_id(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ManifestError(f"{field} must be a non-empty string")
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,79}", value.strip()):
+        raise ManifestError(f"{field} must be a simple slug, not a path")
+    return value.strip().lower()
+
+
+def _safe_world_id(value: object) -> str:
+    if not isinstance(value, str) or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,79}", value):
+        raise ManifestError("world_id must be a simple slug, not a path")
+    return value
+
+
+def _safe_source_path(raw_path: object, private_root: Path) -> Path:
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        raise ManifestError("source.path must be a non-empty string")
+    candidate = Path(raw_path)
+    if not candidate.is_absolute():
+        candidate = private_root / candidate
+    resolved = candidate.resolve(strict=False)
+    root = private_root.resolve(strict=False)
+    if not _is_relative_to(resolved, root):
+        raise ManifestError(f"source.path is outside sidecar root: {raw_path}")
+    return resolved
+
+
+def _validate_private_root(private_root: Path, repo_root: Path) -> Path:
+    root = private_root.resolve(strict=False)
+    repo = repo_root.resolve(strict=False)
+    if root == repo or _is_relative_to(root, repo):
+        raise ManifestError("private sidecar root must be outside the git repository")
+    return root
+
+
+def _planned_output(world_id: str, source_id: str, content_type: str, source_format: str) -> Path:
+    if content_type != "lore":
+        raise ManifestError(f"unsupported content_type: {content_type}")
+    ext = ".json" if source_format == "json" else ".md"
+    return Path("content") / "worlds" / "_private" / world_id / "lore" / "compendium" / f"{source_id}{ext}"
+
+
+def load_plan(manifest_path: Path, repo_root: Path = _REPO) -> SidecarPlan:
+    """Read and validate a local-only sidecar manifest, returning planned outputs."""
+    manifest_path = manifest_path.resolve(strict=False)
+    private_root = _validate_private_root(manifest_path.parent, repo_root)
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ManifestError(f"manifest not found: {manifest_path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"manifest is not valid JSON: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ManifestError("manifest must be a JSON object")
+    if data.get("schema_version") != 1:
+        raise ManifestError("schema_version must be 1")
+    if data.get("owner_acknowledgement") is not True:
+        raise ManifestError("owner_acknowledgement must be true for private/user-owned content")
+
+    world_id = _safe_world_id(data.get("world_id"))
+    sources_raw = data.get("sources")
+    if not isinstance(sources_raw, list) or not sources_raw:
+        raise ManifestError("sources must be a non-empty list")
+
+    seen: set[str] = set()
+    sources: list[PlannedSource] = []
+    for index, raw in enumerate(sources_raw, 1):
+        if not isinstance(raw, dict):
+            raise ManifestError(f"sources[{index}] must be an object")
+        source_id = _source_id(raw.get("id"), f"sources[{index}].id")
+        if source_id in seen:
+            raise ManifestError(f"duplicate source id: {source_id}")
+        seen.add(source_id)
+
+        title = raw.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise ManifestError(f"sources[{index}].title must be a non-empty string")
+        source_format = str(raw.get("format", "")).strip().lower()
+        if source_format not in SUPPORTED_FORMATS:
+            raise ManifestError(f"sources[{index}].format must be one of {sorted(SUPPORTED_FORMATS)}")
+        content_type = str(raw.get("content_type", "")).strip().lower()
+        if content_type not in SUPPORTED_CONTENT_TYPES:
+            raise ManifestError(
+                f"sources[{index}].content_type must be one of {sorted(SUPPORTED_CONTENT_TYPES)}"
+            )
+
+        source_path = _safe_source_path(raw.get("path"), private_root)
+        sources.append(
+            PlannedSource(
+                source_id=source_id,
+                title=title.strip(),
+                format=source_format,
+                content_type=content_type,
+                source_path=source_path,
+                planned_output=_planned_output(world_id, source_id, content_type, source_format),
+            )
+        )
+
+    return SidecarPlan(
+        manifest_path=manifest_path,
+        private_root=private_root,
+        world_id=world_id,
+        sources=tuple(sources),
+    )
+
+
+def _default_manifest_path() -> Path:
+    root = Path(os.environ.get(ENV_SIDECAR_ROOT, str(DEFAULT_SIDECAR_ROOT))).expanduser()
+    return root / MANIFEST_NAME
+
+
+def _write_template(manifest_path: Path) -> None:
+    if manifest_path.exists():
+        raise ManifestError(f"manifest already exists: {manifest_path}")
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    template = {
+        "schema_version": 1,
+        "world_id": "my-private-world",
+        "owner_acknowledgement": True,
+        "sources": [
+            {
+                "id": "owned-source",
+                "title": "Owned Source",
+                "format": "markdown",
+                "path": "vault/owned-source.md",
+                "content_type": "lore",
+            }
+        ],
+    }
+    manifest_path.write_text(json.dumps(template, indent=2) + "\n", encoding="utf-8")
+
+
+def _print_plan(plan: SidecarPlan) -> None:
+    print(f"[private-sidecar] manifest: {plan.manifest_path}")
+    print(f"[private-sidecar] sidecar root: {plan.private_root}")
+    print(f"[private-sidecar] world: {plan.world_id}")
+    print("[private-sidecar] planned outputs only; no content was imported")
+    for source in plan.sources:
+        exists = "exists" if source.source_path.exists() else "missing"
+        print(
+            f"  - {source.source_id}: {source.content_type}/{source.format} "
+            f"{source.source_path} ({exists}) -> {source.planned_output}"
+        )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--manifest", type=Path, default=_default_manifest_path())
+    ap.add_argument("--repo-root", type=Path, default=_REPO)
+    ap.add_argument("--init", action="store_true", help="write a safe template manifest outside the repo")
+    args = ap.parse_args()
+
+    try:
+        if args.init:
+            _write_template(args.manifest)
+            print(f"[private-sidecar] wrote template manifest: {args.manifest}")
+            return 0
+        plan = load_plan(args.manifest, repo_root=args.repo_root)
+    except ManifestError as exc:
+        print(f"PRIVATE COMPENDIUM SIDECAR ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    _print_plan(plan)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a draft private compendium sidecar lane for #179.

This is deliberately not a public content import. It creates a local-only manifest
validator and architecture doc so user-owned books, adventures, exports, and homebrew
can be planned from a sidecar outside git without committing private material or
mutating engine campaign state.

## What Changed

- Added `docs/PRIVATE_COMPENDIUM_SIDECAR.md` describing the private sidecar boundary,
  local manifest shape, dry-run behavior, and future import rules.
- Added `tools/ingest/private_compendium_sidecar.py`, a stdlib-only validator that:
  - defaults to `/Volumes/LEXAR/Codex/clawdnd-private-compendium`
  - supports `CLAWDND_PRIVATE_COMPENDIUM_ROOT`
  - requires `owner_acknowledgement: true`
  - rejects sidecar roots inside the git checkout
  - rejects path escapes outside the sidecar root
  - prints planned gitignored private lore outputs without importing content
- Added focused parser/manifest tests under `servers/engine/tests/`.
- Added `tools/ingest/README.md` guidance for the sidecar.
- Extended `scripts/license_check.py` with guard prefixes for accidentally committed
  private compendium sidecar folders.

## Architecture Boundary

The sidecar is metadata-only at this stage:

- No private compendium records are committed.
- No generated corpus is committed.
- No OGL/SRD-derived private export is committed.
- No public `content/worlds/*` data is written.
- No campaign state, engine state, or runtime state is mutated.

Future import work should write only to gitignored private namespaces such as:

```text
content/worlds/_private/<world-id>/lore/compendium/<source-id>.md
```

Structured private packs for monsters/items/spells should remain explicit private
namespaces and must not silently override SRD names.

## Validation

Run from `/Volumes/LEXAR/repos/ClawDnD-private-compendium`:

```bash
uv run --directory servers/engine --group dev pytest -q tests/test_private_compendium_sidecar.py
python3 -m py_compile tools/ingest/private_compendium_sidecar.py scripts/license_check.py
python3 scripts/license_check.py
git diff --check
```

Observed:

- Sidecar tests: 5 passed.
- `py_compile`: passed.
- `license_check`: passed.
- `git diff --check`: passed.

## Rollback Plan

Revert this PR. It is additive docs/tooling/test coverage and does not change runtime
content loading, campaign persistence, viewer behavior, or engine state authority.

Refs #179.
