### PR TITLE
docs: ClawDnD RUNBOOK + clawdnd-dev skill (compaction resilience)

### DIFF
--- a/.claude/skills/clawdnd-dev/SKILL.md
+++ b/.claude/skills/clawdnd-dev/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: clawdnd-dev
+description: Develop, test, and QA the ClawDnD plugin (the living-world D&D 5e engine). Use when implementing an engine/content/QA change, running or scoring a playtest, delegating a build to a subagent, or resuming the project after a compaction. Encodes the exact dev loop (worktree → additive change → single-process LEXAR pytest → PR → squash-admin merge → prune), the QA loop (duo / combat-sprint runners + the 3 lenses + behavioral gate), and the load-bearing engine invariants. Read ClawDnD-RUNBOOK.md first for full context.
+---
+
+# ClawDnD Dev
+
+You build and harden **ClawDnD** — a post-BG3 living-world D&D 5e Claude Code plugin. North
+star: **epic Baldur's-Gate-caliber STORY on a deterministic SRD 5.2 engine**; goal: a
+universe-system that generates worlds. FREE product, BG-only. **Read `ClawDnD-RUNBOOK.md`
+(repo root) for the full project/architecture/state.** This skill is the operational loop.
+
+## Load-bearing INVARIANTS (never violate)
+1. **Engine = SOLE WRITER.** State is `snapshot.json` written under `campaign_lock` via
+   atomic temp-file + `os.replace` (`servers/engine/store.py`). The player facade
+   (`servers/engine/player_server.py`, the `clawdnd-player` MCP) is READ-ONLY on state —
+   it only appends structured *moves* the DM resolves.
+2. **Additive-by-default.** Empty == today; old snapshots round-trip. Models are
+   `_StrictModel` (`extra="forbid"`); the tolerant load (#165) drops only unknown
+   *top-level* keys. Every new field defaults to today's behavior; each feature is
+   independently removable.
+3. **Gates/triggers read ONLY engine-mutated values** (`flags`, `reputation`,
+   `attitude_value`, `day`, `standing`) — **NEVER fiction.** The engine can't judge prose.
+   Quest CONTENT stays DM-advisory; only gauge-backed things get engine teeth.
+4. **Engine rolls; the DM is TOLD the result.** Wander/betrayal/variant rolls happen
+   in-engine, surface in the tool return; the DM narrates. "Probability proposes, DM disposes."
+5. **QA is gateway-free / null-backend, and NEVER touches Eva** (the owner's live OpenClaw
+   agent): no gateway restart/reconfigure, no `doctor --fix`, no global `mcp set`, don't
+   touch agents `main`/`operations`.
+
+## THE DEV LOOP (exact)
+Test policy: **GitHub-CI-first; local only on LEXAR; SINGLE-PROCESS** (main disk ~4.3 GB
+free — parallel workers OOM the host). This repo is on LEXAR, so local single-process is OK.
+
+1. **Worktree off main** (keeps the engine/content/QA lane disjoint from the sibling
+   macOS/OpenWorlds lane). Implement **additively** (honor every invariant).
+2. **Single-process test** (warm the venv first on a fresh worktree):
+   ```bash
+   uv run --directory servers/engine python -m pytest <relpath> -q -p no:xdist
+   ```
+   **NEVER pass `-n` / use xdist** — parallel workers OOM the host. Run focused files for
+   the change; run the full `servers/engine/tests` before merge.
+3. **Push + open the PR** with a HEREDOC body:
+   ```bash
+   gh pr create --title "…" --body "$(cat <<'EOF'
+   …
+   EOF
+   )"
+   ```
+   **DO NOT pipe `gh pr create` through `tail` inside an `&&` chain** — it masks a transient
+   failure and silently skips the merge (bit us on #185). Verify the returned PR URL.
+4. **Merge (local-gate):** `gh pr merge --squash --admin` — GitHub Actions is degraded
+   repo-wide; we gate on local single-process pytest + `license_check`, CI reconciles post-merge.
+5. **Sync + clean:**
+   ```bash
+   git pull --ff-only origin main
+   git worktree remove --force <worktree> && git branch -D <branch> && git worktree prune
+   ```
+
+## THE QA LOOP
+Spec: `qa/SCORING.md`. **Log every run to `qa/SCORECARD.md`.** Targets: **story ≥ 4.3,
+mechanical ≥ 4.5, gate GREEN, 0 critical/high.**
+
+Runners (from repo root):
+- `qa/run_duo.sh <run> <world> <persona> [beats] [budget]` — AI player + DM duo (gateway-free
+  `claude -p`; threaded `--session-id`/`--resume`, re-grounds from snapshot each beat).
+- `qa/run_combat_sprint.sh <run>` — **the fast BUG-FINDER** (~2 min, pre-seeded fight, one DM
+  call, Angry-DM-scored). Use to *find* engine defects.
+- `qa/run_party.sh` — player + companion peer agents + DM (the betrayal path / Quest-Arc L2).
+- `qa/run_duo_openclaw.sh` — gpt-5.4 path (scoped `clawdnd-qa*` agents, `--thinking low`).
+
+Scoring: **behavioral gate** (`qa/assert_behavioral.py`, deterministic; RED ⇒ all lenses
+capped ≤2.5) + **3 LLM lenses** — Mechanical (`rubric.md`), Story-craft/Tolkien
+(`rubric_tolkien.md`), 5e-fidelity/Angry-DM (`rubric_angry_dm.md`). Scorer `qa/score.sh`
+(claude, PRIMARY) or `qa/score_openclaw.sh` (gpt-5.4, grades ~1.5 harsher — cross-check only).
+
+QA truths:
+- The combat-sprint **finds bugs**; a single sprint's Angry-DM is **coverage-capped ~3**.
+  The score climbs via **broader play + a richer seed**, not re-running one short fight.
+- Low mech/Angry-DM on emergent duos is usually a **sampling artifact** (players drift to
+  roleplay), not an engine defect — force fights via wander + combat-seeking personas.
+
+## DELEGATION
+Create worktree → spawn agent with a **precise spec** + the **single-process-test guardrail**
++ **"flag-don't-force-fix if many tests break"** → **review the diff (trust BUT verify;
+confirm additive + invariant-safe + no weakened guardrail tests)** → merge via the dev loop.
+API agents (Agent tool, gpt-5.4) don't strain the host — fan out freely; only `claude -p` QA
+is host-heavy (**2 concurrent is fine**). Reap orphaned `player_server`/`server.py` procs.
+
+## DISCIPLINE (the expensive lessons)
+- **Validate before fixing** — the LLM scorer mis-attributes root cause (the "STR-18 attack
+  bug" was a FALSE alarm; engine was correct at +6). Reproduce against the engine first.
+- **Surfacing info ≠ the DM using it** — fold the value into a trigger the DM already hits
+  every turn (e.g. `turn_brief` on `next_turn`; Director at beat start), or ENFORCE in the
+  engine (Multiattack #181, turn-skip #183).
+- **First-principles for load-bearing decisions** (public contract/schema/tool API) — write
+  a decision doc, not speculative code.
+- **REUSE before rebuild** — the engine is usually ~80–90% there (Quest-Arc reused the
+  companion stage-machine; #143 reused `_resolve_quest_variants`). Find the existing primitive.
+- **Don't collide with the macOS/OpenWorlds sibling lane** (their open PRs: #150/#182/#187 +
+  drafts #190/#191/#192). Stay in the engine/content/QA lane.

--- a/ClawDnD-RUNBOOK.md
+++ b/ClawDnD-RUNBOOK.md
@@ -1,0 +1,333 @@
+# ClawDnD — RUNBOOK (READ FIRST on resume)
+
+> **This is the compaction-resilience doc.** If you are an agent resuming this project
+> after a context reset, read this top-to-bottom before doing anything. It captures the
+> project, architecture, the load-bearing invariants you must not violate, the exact dev
+> + QA loops, how to delegate, the hard-won lessons, and the current state + work queue.
+>
+> Companion artifacts (the live day-log + decision records) live at
+> `/Volumes/LEXAR/Codex/session-notes/2026-05-26/clawdnd-overnight-qa/`:
+> `implementation-notes.html` (running log — read it for the latest in-flight state),
+> `decision-quest-arc-engine.md`, `decision-143-variant-matrices.md`,
+> `decision-campaign-director.md`, `decision-event-parley.md`, `insights-encounter-balance.md`.
+> The QA results ledger is `qa/SCORECARD.md`; the scoring spec is `qa/SCORING.md`.
+>
+> Last updated: 2026-05-26.
+
+---
+
+## PROJECT
+
+**ClawDnD** — a post-Baldur's-Gate-3, **living-world D&D 5e Claude Code plugin**. You don't
+play *against* the AI; you adventure *with* it. An AI Dungeon Master narrates and voices
+every NPC; a voiced AI companion adventures alongside you with its own sheet and agency.
+
+- **North star: epic, mature, Baldur's-Gate-caliber STORY** sitting on a **deterministic
+  SRD 5.2 engine**. Dice and rules are never hallucinated; the story is generated live.
+- **Goal: a universe-system that generates worlds.** Reverse-engineer how BG3 / Skyrim /
+  Kingmaker structure story → a seed/engine that can spin up new lore-grounded worlds. A
+  2nd world is meant to be near-free once the system is perfected on the first.
+- **FREE product.** BG3 ingestion is **INTERNAL-ONLY** — we ship a **wiki-INDEX + a
+  self-serve ingestor**, and distribute **nothing copyrighted**. (Owner steer: P0
+  commercial-license question is resolved as FREE; the public `baldurs-gate/` world is
+  unofficial Fan Content, never sold.)
+- **BG-ONLY focus.** Baldur's Gate is THE world. Sundered Reach is a deprioritized
+  side-option (left in place, no investment). All content + QA target BG. Perfect the
+  whole system on BG.
+- Code is **MIT**; rules data is **CC-BY-4.0 SRD 5.2.1**; universe seeds are unofficial
+  free Fan Content with their own `LICENSE.md`.
+
+---
+
+## ARCHITECTURE + FILE MAP
+
+**Three Python MCP servers** (run with `uv`), an AI DM brain (Claude), and a viewer app.
+
+| MCP server | Dir | Role |
+|---|---|---|
+| `clawdnd-engine` | `servers/engine/` | Authoritative game state: dice, sheets, combat, conditions, XP/leveling, encounters, persistence. **Sole writer of campaign truth.** |
+| `clawdnd-rules` | `servers/rules/` | SRD 5.2.1 rules lookup (offline; `dnd5eapi.co` fallback). |
+| `clawdnd-voice` | `servers/voice/` | TTS behind a swappable `TtsBackend` (Kokoro default; null backend in QA). |
+| `clawdnd-player` | `servers/engine/player_server.py` | **The constrained move FACADE.** An actor acts ONLY through this limited, READ-ONLY-on-state surface; it can't narrate the world or assert outcomes. Parameterized by `CLAWDND_ACTOR_ID` / `CLAWDND_ACTOR_ROLE` so the same surface drives the player or any companion peer agent. |
+
+> **NOTE / spec correction:** there is **no `servers/player/` directory**. The player
+> facade is the file `servers/engine/player_server.py`, exposed as the `clawdnd-player`
+> MCP server. `.mcp.json` registers the 3 plugin servers (engine/rules/voice); the player
+> facade is wired per-run by the QA harness.
+
+### Key engine modules (`servers/engine/`)
+
+| File | What lives here |
+|---|---|
+| `models.py` | All Pydantic models. `_StrictModel` (`extra="forbid"`) base; `Character`, `Quest`, `Faction`, `CompanionArc/Agenda`, `ArcGate`, `CompanionQuestArc`, `WorldState`, `Campaign`, `SceneDebt`, `Event/ParleyOption/Outcome` (Quest-Arc L3), `PendingOnHitRider`, etc. The contract surface — **additive-only**. |
+| `server.py` | The big one (~300KB). All engine MCP tools (`start_world`, `start_combat`, `attack`, `cast_spell`, `next_turn`, `add_quest`, `get_campaign_director`, `roll`, …). |
+| `store.py` | **Sole-writer persistence.** `campaign_lock()` (fcntl), `_atomic_write` (tmp + `os.replace`), `save_campaign`, `load_campaign` (with the #165 **tolerant load**: drops unknown TOP-LEVEL keys so old/new snapshots round-trip; sub-model strictness preserved). |
+| `player_server.py` | The constrained move facade (the `clawdnd-player` MCP) — see above. |
+| `combat.py` | Action economy, attack-vs-AC, damage, conditions, the Multiattack enforcement (#181), turn-skip guard. |
+| `companion_arc.py` | The ONE engine-enforced arc system: betrayal/agenda rolls off the `attitude_value` gauge; `CompanionAgenda.decision_flag` (Quest-Arc L2). The reuse template for faction arcs. |
+| `companion.py` / `companion_banter.py` | Companion sheets, dossiers, banter. |
+| `director.py` + `scene_debt.py` | **Campaign Director (#72):** advisory layer telling the DM what the campaign OWES each beat (scene-debt taxonomy: `hook_untracked`, `quest_stalled`, `npc_introduced_silent`, `thread_no_payoff`, …). Advise-not-dictate; the engine never acts on a debt. |
+| `content.py` | World/seed loading, `_resolve_quest_variants` (ending-tied `when:{fact}` + seeded weighted-random `random:<weight>`), ending overlays. |
+| `worldsim.py` | `tick()` — standing threads move on their own; `BacklogItem.effect` + `_apply_structured_effect` ripple path. |
+| `wander.py` | Typed multi-resolution wandering encounters (combat/skill/social/hazard/boon; ~60% non-combat) staged on travel/camp; folds in `encounter_outlook`. |
+| `encounter.py` | CR→XP SIZING math + `_outlook_for_xps` (`must_offer_out` doctrine). |
+| `consequences.py` | `schedule()` — scheduled `Consequence`s (rule-of-three callbacks, #185). |
+| `questgen.py` / `generator.py` | Hook assembly at seed (deliberately one-shot, rejects re-triggering); campaign generation. |
+| `bestiary.py` / `itemcatalog.py` / `lorebook.py` / `srd_tables.py` | Auto-discovered content data layers. |
+| `dice.py` | Full notation + the `_MAX_DICE`/`_MAX_SIDES` DoS clamp (#169). |
+| `rests.py`, `inventory.py`, `npc.py`, `recap.py`, `travel.py`, `spells.py`, `ledger.py`, `imagegen.py`, `openclaw_image.py` | Supporting subsystems. |
+
+### Other surfaces
+
+- **`viewer/`** — the local dashboard/director's-view (`server.py`, `dashboard.html`,
+  `monitor.html`). **`viewer/openworlds/`** — the playable React CRPG app (28 screens:
+  `screen-map/combat/camp/dialogue/merchant/forge/bestiary/acts/relations/journal/…`,
+  `app.jsx`, `data.js`, `native-bridge.js`). Renders on **live engine read-models** (#161
+  wired). **The macOS/OpenWorlds Swift shell is the SIBLING lane — see "Don't collide".**
+- **`qa/`** — the QA harness (see THE QA LOOP).
+- **`content/worlds/baldurs-gate/`** — the world: `world.json` (regions, factions, cast,
+  history, standing threads, `quest_variants`), `areas/`, `characters/`, `endings/`,
+  `lore/`, `origins/`, `LICENSE.md`.
+- **`skills/`** (`dungeon-master`, `companion`, `campaign-author`, `world-author`),
+  **`agents/`** (`companion-agent.md`), **`commands/`** (player slash commands),
+  **`data/srd/`** (SRD 5.2.1), **`tools/ingest/`** (wiki → lore corpus).
+
+---
+
+## INVARIANTS (load-bearing — do not violate)
+
+These are the rules that keep the engine deterministic and crash-/compaction-safe. Every
+change must respect them.
+
+1. **The engine is the SOLE WRITER of campaign truth.** Campaign state lives on disk as
+   `snapshot.json`, written under `campaign_lock` via an **atomic** temp-file + `os.replace`.
+   Nothing else mutates state. The player facade (`player_server.py`) is **READ-ONLY** on
+   state — it only appends structured *moves* for the DM to resolve.
+2. **Additive-by-default.** Empty == today. Old snapshots must round-trip. Models use
+   `_StrictModel` (`extra="forbid"`); the #165 **tolerant load** drops only *unknown
+   top-level* keys (sub-model strictness intact) so a future non-additive schema change
+   can't brick old saves. Every new field defaults to "behaves like today when unset."
+   Each feature must be independently removable; low blast radius.
+3. **Gates/triggers read ONLY engine-MUTATED values — NEVER fiction.** A gate or trigger
+   may key off `flags`, `reputation`, `attitude_value`, `day`, `standing` — values the
+   engine itself sets. The engine **cannot judge prose** and must never monitor near-
+   constant fiction. (This is *the* constraint from `questgen.py`. It's why quest CONTENT
+   stays DM-advisory and only gauge-backed things get engine teeth.)
+4. **QA uses null voice / null image and NEVER the Eva / OpenClaw gateway-by-accident.**
+   The QA harness runs gateway-free `claude -p` (or a *scoped* gpt-5.4 OpenClaw path with
+   isolated `clawdnd-qa*` agents). **NEVER touch Eva** (the owner's live agent): don't
+   restart/reconfigure the gateway, don't touch agents `main`/`operations`, no
+   `doctor --fix`, no global `mcp set`.
+5. **Engine rolls the probability; the DM is TOLD the result.** Wander/betrayal/variant
+   rolls happen *in-engine* and surface in the tool return; the DM narrates + routes.
+   The DM never rolls dice in its head. "Probability proposes, DM/lore disposes."
+
+---
+
+## THE DEV LOOP (exact)
+
+> **Test-execution policy (from `~/.claude/CLAUDE.md`): GitHub-CI-first; local only on
+> LEXAR; SINGLE-PROCESS.** Main disk (`/`) has ~4.3 GB free and parallel test workers have
+> OOM-ed the host. This repo (`/Volumes/LEXAR/repos/ClawDnD*`) is on LEXAR, so local
+> single-process pytest is OK. **NEVER run with `-n` / xdist — parallel workers OOM the host.**
+
+1. **Branch off main in a fresh worktree** (keeps lanes disjoint from the sibling desktop
+   work). Implement **additively** (honor every invariant above).
+2. **Single-process test on LEXAR:**
+   ```bash
+   uv run --directory servers/engine python -m pytest <relpath> -q -p no:xdist
+   ```
+   `-p no:xdist` (or simply never passing `-n`) is mandatory. Run the focused test file(s)
+   for the change; run the full suite (`servers/engine/tests`) before merge.
+   - **Warm the venv first** on a fresh worktree (`uv sync` or a `uv run python -c pass`)
+     — a cold-start `.venv` race once produced a phantom "Extra inputs not permitted"
+     mechanical failure mid-run. The QA runners warm it; do it manually for ad-hoc tests.
+3. **Push**, then create the PR:
+   ```bash
+   gh pr create --title "…" --body "$(cat <<'EOF'
+   …
+   EOF
+   )"
+   ```
+   **DO NOT pipe `gh pr create` through `tail` inside an `&&` chain** — a transient
+   GraphQL blip gets masked, the branch ends up pushed-but-unmerged, and the merge is
+   silently skipped. (This bit us on #185.) Check the exit / the returned PR URL.
+4. **Merge (local-gate):**
+   ```bash
+   gh pr merge --squash --admin
+   ```
+   GitHub Actions went **degraded repo-wide** (~2026-05-26), so we gate on **local
+   single-process pytest + `license_check`** per the test policy; CI reconciles
+   post-merge. `--admin` is intentional here for that reason.
+5. **Sync + clean up:**
+   ```bash
+   git pull --ff-only origin main
+   git worktree remove --force <worktree>
+   git branch -D <branch>
+   git worktree prune
+   ```
+
+**The whole shape:** worktree off main → implement additive → single-process LEXAR test →
+push → `gh pr create` (no `tail` in an `&&` chain) → `gh pr merge --squash --admin` →
+`git pull --ff-only origin main` → remove worktree + delete branch + prune.
+
+---
+
+## THE QA LOOP
+
+The fitness function = **1 hard behavioral gate** + **3 LLM lenses**. Spec: `qa/SCORING.md`.
+**Log every run to `qa/SCORECARD.md`** (the ledger that survives compaction).
+
+**Runners:**
+- `qa/run_duo.sh <run> <world> <persona> [beats] [budget]` — AI player + DM duo via
+  `claude -p` (gateway-free). Threaded/cached: `--session-id` on beat 1, `--resume` after,
+  re-grounding from snapshot each beat (anti-mush). The player gets ONLY the `clawdnd-player`
+  facade; the DM gets the full engine+rules+voice (null backends) + the dungeon-master skill.
+- `qa/run_combat_sprint.sh <run>` — **the fast BUG-FINDER.** ~1.5–2 min: pre-seeds a fight
+  (zero LLM) → ONE DM call for a 3-round combat → behavioral-gate → Angry-DM score.
+- `qa/run_duo_openclaw.sh` — the same duo via **gpt-5.4** (OpenClaw gateway, off the claude
+  quota; scoped `clawdnd-qa*` agents only; needs `--thinking low`).
+- `qa/run_party.sh` — player + up to 3 companion peer AGENTS + DM (exercises recruit/banter/
+  the betrayal path; restore this to the cadence to feel-validate Quest-Arc L2).
+- `qa/run_parallel.sh` — 2–3 isolated concurrent runs (the velocity model; 2 `claude -p` is fine).
+
+**Scoring — three lenses (1–5 each) + the gate:**
+- **Behavioral gate** (`qa/assert_behavioral.py`) — deterministic pass/fail. FATAL on:
+  dead/non-progressing scene, world-progression floor (≥6-beat runs: clock advanced +
+  ≥2 locations), player narrating the world (facade over-write), silent companion,
+  unresolved player `[cast]/[attack]/[check]/[save]`, combat left active / stray monsters /
+  dangling conditions. **RED ⇒ all three lenses capped to ≤2.5 / INVALID.**
+- **Mechanical** (`rubric.md`) — DM tool-stream vs correctness; hallucinated mechanics are
+  the worst defect.
+- **Story-craft / "The Loremaster's Eye" (Tolkien)** (`rubric_tolkien.md`) — stingy +
+  act-relative; BG3-calibrated. Reads the two-sided play log.
+- **5e-fidelity / "The Angry DM"** (`rubric_angry_dm.md`) — adversarial SRD 5.2.1 checklist
+  (d20 tests, ~15 action types, all 14 conditions). Reads the DM tool-stream + a behavioral
+  scoped-B gate.
+- Scorers: `qa/score.sh` (claude — the PRIMARY baseline) or `qa/score_openclaw.sh` (gpt-5.4,
+  grades **~1.5 pts HARSHER** — a strict cross-check, NOT the headline).
+
+**Targets (the loop's exit bar):** **story ≥ 4.3, mechanical ≥ 4.5, gate GREEN, 0
+critical/high** adversarial defects.
+
+**How to read the lenses (hard-won):**
+- The **combat-sprint is a fast BUG-FINDER**, not a score-maximizer. It surfaced **real
+  engine bugs** the surfacing work had masked: monster Multiattack (#181), the Round-1
+  turn-skip (#183), Guiding-Bolt-on-cast-not-hit (#188). Use it to *find* defects.
+- **A single sprint's Angry-DM is COVERAGE-CAPPED (~3)** — one vanilla 3-round fight can't
+  exercise the whole 5e surface. The **score climbs via BROADER play + a richer seed**
+  (saves/conditions/subclasses/run-to-resolution), not by re-running one short fight.
+- **Low mech/Angry-DM on emergent duos is usually a SAMPLING artifact, not an engine
+  defect** — both AI player and DM drift to roleplay, so combat is rarely formally run.
+  The wandering-encounter system + combat-seeking personas force real fights.
+
+---
+
+## AGENT DELEGATION
+
+Orchestrate via subagents; verify from the top.
+
+1. **Create a fresh worktree** off main for the agent's lane.
+2. **Spawn an agent** (Agent tool / `claude -p`) with: a **precise spec**, the
+   **single-process-test guardrail** (`-p no:xdist`, never `-n`, LEXAR only), and the
+   directive **"flag-don't-force-fix if many tests break"** (don't let an agent weaken
+   assertions or paper over a real regression to make a suite go green).
+3. **Review the diff** — *trust BUT verify*. Read what the agent actually changed; confirm
+   it's additive, honors the invariants, and didn't weaken a guardrail test.
+4. **Merge** via the dev loop.
+
+**Host-load rule:** API-backed agents (Agent tool, gpt-5.4) **don't strain the host** — fan
+out freely. Only **`claude -p` QA is host-heavy** (the duo/sprint spin up engine processes);
+**2 concurrent `claude -p` runs is fine**, more risks OOM. Reap orphaned `player_server` /
+`server.py` processes between runs.
+
+---
+
+## DISCIPLINE / LESSONS (the expensive ones)
+
+- **Validate BEFORE fixing.** The LLM scorer mis-attributes root cause. The "STR-18 → +5
+  attack bug" was a **FALSE alarm** — engine smoke confirmed melee **+6** (mod 4 + prof 2);
+  the real issue was DM adherence, not the engine. Reproduce against the engine before you
+  "fix" anything a scorer flagged.
+- **Surfacing info ≠ the DM using it (the reach-for lesson).** Adding a tool/field the DM
+  *could* call doesn't mean it *will*. Two reliable fixes: (a) **fold the value into a
+  trigger the DM already hits every turn** (e.g. `turn_brief` on `next_turn` vs only at
+  `start_combat`; the Director consulted at beat start → `add_quest` went 0→3), or (b)
+  **ENFORCE it in the engine** (the Multiattack economy fix #181; the turn-skip block #183).
+- **The combat-sprint → engine-fix → re-measure loop WORKS.** It's how Multiattack,
+  turn-skip, and Guiding-Bolt were each isolated and the Angry-DM score moved (2.8 → 3.3
+  after #181). Use it deliberately.
+- **First-principles for load-bearing decisions.** A public contract / schema / tool API /
+  concurrency change with real trade-offs = run the research/decision loop and write a
+  decision doc (see the four in the session-notes dir), not speculative code.
+- **Don't reflexively import a gate from one code path into another** — ask "in which
+  domain is this concern real?" first (e.g. apply_damage is *legit* for traps/poison, so a
+  blanket "reject apply_damage" rule was wrong).
+- **REUSE before rebuild.** The Quest-Arc engine reused the companion stage-machine; #143
+  variants reused the shipped `_resolve_quest_variants` resolver. The engine is usually
+  ~80–90% there — find the existing primitive.
+
+---
+
+## CURRENT STATE + WORK QUEUE
+
+**`main` tip:** `c7a49d7` — Quest-Arc Layer 2 (#189). Full suite **1169 green** at last full
+run. Branch lane is the disjoint **engine / content / QA** lane.
+
+### Quest & Arc engine (the living-story skeleton — `decision-quest-arc-engine.md`)
+- **L1 — rule-of-three** (`Quest.evolves_to` + `callback_in_days`; `complete_quest`
+  schedules the follow-on via `consequences.schedule`) — **MERGED #185**.
+- **L2 — decision-gated flips** (`CompanionAgenda.decision_flag` adds +0.30 to the
+  attitude-gated betrayal roll; the breaking-point guard is checked FIRST so it never fires
+  above threshold; warning bands telegraph) — **MERGED #189**.
+- **L3 — Event / ParleyOption / Outcome** (the first-class Kingmaker decisional; thin
+  wrapper over `_apply_structured_effect`; converges with the parley research; an Event
+  Outcome sets a decision_flag → the L2↔L3 seam) — **BUILDING** (design in flight).
+- **BUILD-NEXT — faction-growth arcs** (the Skyrim/Kingmaker join→grow→lead): additive
+  `Faction` fields (`rank`, `standing`, `joined`, `questline_arc_id`) + generalize the
+  companion stage-machine into a faction-owned `Arc` gated on `Faction.reputation`.
+  **QUEUED.** (Closes the "rep is tracked but reads nothing" gap.)
+- **DM-skill WIRING + canon content-fill** (author Raphael / Flaming-Fist into agendas +
+  quest `evolves_to` chains) — **QUEUED**, per wave.
+- **DEFER** — kingdom/guild-building continuation (tick the inert `RegionControl`/
+  `FactionAsset` primitives). Far-future.
+
+### Other engine / QA threads
+- **Campaign Director (#72)** — `director.py` + `scene_debt.py` + 3 advisory tools.
+  **MERGED + integrated** (DM consults `get_campaign_director` each beat → `add_quest` gap
+  closed in play). #71 (path-compiler) + #73 (predicates) deferred until a world authors an
+  `adventure_path`.
+- **Combat-fidelity fixes** — Multiattack economy (#181), Round-1 turn-skip ENGINE block
+  (#183), Guiding-Bolt-on-hit (#188) all **MERGED**. Residual: broader DM-adherence /
+  class-feature coverage (issue **#166**) — push via the reach-for pattern + a richer sprint
+  seed, not engine force.
+- **Observability (#184)** — snapshot version-stamp (`schema_version` + `engine_sha`) +
+  centralized QA findings collector (`qa/collect_findings.py`) — **MERGED**. Possible next
+  slice: a real-play event log.
+- **#143 variant matrices** — foundation ~90% shipped; remaining = (a) doc the weight
+  convention in `content/worlds/README.md` (common 11 / uncommon 6 / rare 2 / very_rare 1
+  on a ~20 base), (b) author canon variant CONTENT (free-rollable slots first), (c) ONE
+  engine bit: generalize the companion agenda-roll to rare non-companion NPC flips (cap
+  ~0.07, 3–7%/scene). **GATED on an owner glance** at the quest-idea boundary before a big
+  content push.
+- **#141 Parley → AI-player relay** — reopened; the relay was never built. Pairs with
+  L3 / the social encounter type.
+- **Party-ensemble betrayal validation** — `run_party.sh` not exercised since L2 shipped;
+  restore it to validate the decision-flip in play.
+
+### The SIBLING DESKTOP lane — DON'T COLLIDE
+Another agent owns the **macOS / OpenWorlds Swift shell**. Stay in the engine/content/QA
+lane. Open PRs that are **theirs** (leave them): **#150** (macOS beta-distribution),
+**#182** (OpenWorlds attributed icon-registry), **#187** (campaign-calendar display), plus
+drafts **#190** (dice-parser decision), **#191** (worldgraph skeleton), **#192** (private
+compendium import sidecar). Many `viewer/openworlds-*` worktrees are 0-commits-ahead =
+already merged (the app on main is their combined result).
+
+---
+
+## RESUME CHECKLIST
+1. Read this file, then `implementation-notes.html` (latest in-flight state) + `qa/SCORECARD.md`.
+2. `cd /Volumes/LEXAR/repos/ClawDnD` (or the relevant worktree); `git log --oneline -10`.
+3. `gh pr list` + `gh issue list` to see open lanes (avoid the desktop-lane PRs above).
+4. Pick up the Quest-Arc L3 build / the queued waves; build → single-process LEXAR test →
+   PR (no `tail` in `&&`) → `--squash --admin` → sync + prune. Log every QA run to SCORECARD.


### PR DESCRIPTION
Read-first resume doc (ClawDnD-RUNBOOK.md, 333 lines) + an invokable clawdnd-dev SKILL — the project state map, file map, the 5 load-bearing invariants, the DEV LOOP + QA LOOP (verbatim), agent-delegation pattern, discipline/lessons, and the current Quest&Arc queue. So any post-compaction agent resumes seamlessly. Verified against source (corrected servers/player→player_server.py; confirmed merged PRs). Additive docs only. Local-gated.