### PR TITLE
feat(quest-arc): Event/Parley decisionals — Layer 3 (completes the build-now trio)

### DIFF
--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -25,6 +25,7 @@ from models import (
     CompanionDossier,
     Character,
     DowntimeProject,
+    Event,
     Faction,
     FactionAsset,
     Location,
@@ -673,6 +674,15 @@ def _apply_ending_overlay(c: Campaign, overlay: dict) -> None:
             if dossier is not None:
                 ch.companion_dossier = dossier
 
+    # ADDITIVE (Quest & Arc engine, Layer 3): the chosen ending may ALSO seed stumble-into
+    # Events — so the post-state shapes which decisionals stumble into the party (Raphael's
+    # bribe under one ending, the Flaming Fist's offer under another). Folded onto whatever the
+    # base world already seeded; a malformed entry degrades (skip-one), like companion_seeds.
+    # No `events` key in the overlay is a no-op. Runs here so a `reputation_at` trigger can be
+    # ref-checked against the (already-seeded) factions.
+    ov_id = overlay.get("id", overlay.get("name", "?"))
+    _seed_events_block(c, overlay.get("events"), where=f"ending overlay {ov_id!r}")
+
 
 def _seed_strategic_state(c: Campaign, world: dict) -> None:
     """Seed optional strategic board data from world.json.
@@ -781,6 +791,63 @@ def _seed_strategic_state(c: Campaign, world: dict) -> None:
         c.strategic_state.projects[project.id] = project
 
     c.strategic_state.last_tick_day = c.day
+
+
+def _seed_events_block(c: Campaign, raw, *, where: str) -> int:
+    """Fold an OPTIONAL authored `events` block onto the campaign (Quest & Arc engine, Layer 3).
+    Mutates `c.events`; returns the count seeded.
+
+    The block is a list of Event objects OR a dict mapping id -> Event object. Each entry is
+    validated into an `Event`; a present-but-MALFORMED entry (wrong shape, a `reputation_at`
+    trigger naming a missing faction, a forbidden extra key) is SKIPPED with a diagnostic —
+    DEGRADE-not-abort, exactly the companion_seeds / world_state / strategic contract — never
+    aborting start_world. A missing/None/non-collection block is a no-op (today's behavior).
+
+    A `reputation_at` trigger whose `trigger_faction_id` isn't a seeded faction is skipped (the
+    trigger could never satisfy and signals an authoring typo). Other triggers reference only
+    flags/day, which are open by design, so they aren't ref-checked. An explicit id collision
+    (two events with the same id) keeps the first and skips the rest, logged."""
+    if raw is None:
+        return 0
+    if isinstance(raw, dict):
+        entries = list(raw.values())
+    elif isinstance(raw, list):
+        entries = raw
+    else:
+        print(f"[content] skipping malformed events block in {where} (not a list or object)")
+        return 0
+    seeded = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            print(f"[content] skipping events entry in {where} (not an object)")
+            continue
+        try:
+            event = Event.model_validate(entry)
+        except (ValidationError, ValueError, TypeError):
+            print(f"[content] skipping malformed event in {where}")
+            continue
+        # A reputation_at trigger naming a faction not in this world can never fire — almost
+        # always an authoring typo. Skip it (degrade) so the board stays clean.
+        if event.trigger == "reputation_at" and event.trigger_faction_id not in c.factions:
+            print(
+                f"[content] skipping event {event.id!r} in {where}: "
+                f"reputation_at trigger names unknown faction {event.trigger_faction_id!r}"
+            )
+            continue
+        if event.id in c.events:
+            print(f"[content] skipping event {event.id!r} in {where}: duplicate event id (keeping the first)")
+            continue
+        c.events[event.id] = event
+        seeded += 1
+    return seeded
+
+
+def _seed_events(c: Campaign, world: dict) -> None:
+    """Seed authored stumble-into Events from `world['events']` (Quest & Arc engine, Layer 3).
+
+    Runs AFTER factions are seeded (so a `reputation_at` trigger can be ref-checked). Additive
+    + degrade-not-abort: a world with no `events` key seeds nothing (today's behavior)."""
+    _seed_events_block(c, world.get("events"), where="world events block")
 
 
 def _seed_campaign_backlog(c: Campaign, world: dict) -> None:
@@ -1095,6 +1162,11 @@ def seed_world(world: dict, start_at: str = "", ending: str = "") -> Campaign:
         c.factions[faction.id] = faction
 
     _seed_strategic_state(c, world)
+
+    # Authored stumble-into Events (Quest & Arc engine, Layer 3). Runs after factions so a
+    # `reputation_at` trigger can be ref-checked. Additive: a world with no `events` key is a
+    # no-op (today's behavior). The ending overlay may add MORE events (see _apply_ending_overlay).
+    _seed_events(c, world)
 
     # Roster NPCs exist in state (recallable, voiced) but are not party members — the
     # DM pulls them in or invents freely. Each NPC's hook is stored as a memory fact.

--- a/servers/engine/events.py
+++ b/servers/engine/events.py
@@ -1,0 +1,176 @@
+"""First-class stumble-into Events (Quest & Arc engine, Layer 3) — pure module.
+
+The Kingmaker "stumble-into" decisional, made a real engine fact: a content-authored
+``Event`` whose ``ParleyOption``s each carry a DETERMINISTIC ``Outcome``. Picking an option
+ripples through the EXISTING engine vocabulary and can STAGE the already-merged Layer-2
+companion flip — Layer 3 sets a ``decision_flag``; Layer 2 (shipped) reads it. They meet at
+``Campaign.flags``, the contract-safe engine-mutated store.
+
+A THIN wrapper over machinery that already ships — no new resolver, no new state machine:
+
+- ``present`` returns the unresolved Events whose contract-safe ``trigger`` holds NOW (reads
+  ONLY flags / faction reputation / day — never fiction, the questgen.py:7-19 discipline).
+  Idempotent: a ``resolved`` Event is skipped, exactly like ``consequences.due`` skips a fired
+  Consequence. The Director surfaces these as a soft nudge.
+- ``resolve`` applies the chosen option's ``Outcome``: the shared keys via
+  ``worldsim._apply_structured_effect`` (byte-for-byte the backlog/strategic ripple path), then
+  the three thin extension keys inline (``decision_flag`` -> ``flags``; ``schedule_in_days`` /
+  ``schedule_text`` -> ``consequences.schedule``), then marks the Event ``resolved``. IDEMPOTENT:
+  re-resolving a ``resolved`` Event is a pure no-op (applies NOTHING).
+
+Pure module (no MCP, no I/O), like ``worldsim.py`` / ``consequences.py`` / ``companion_arc.py``:
+the functions mutate the in-memory ``Campaign`` in place; the engine stays the sole writer — the
+MCP tool layer (``present_events`` / ``resolve_event``) persists under ``campaign_lock`` +
+``save_campaign``.
+"""
+
+from __future__ import annotations
+
+import consequences as consequences_mod
+import worldsim
+from models import Campaign, Event, ParleyOption
+
+
+def trigger_holds(event: Event, campaign: Campaign) -> bool:
+    """Whether ``event``'s trigger is satisfied NOW (contract-safe: reads ONLY engine-mutated
+    flags / faction reputation / day — never fiction).
+
+    - ``manual``: always available (the DM/content drops it; the stumble-into default).
+    - ``flag_set``: ``campaign.flags.get(event.trigger_value)`` is True.
+    - ``day_reached``: ``campaign.day >= event.trigger_threshold``.
+    - ``reputation_at``: the named faction's reputation has reached ``trigger_threshold`` — the
+      SIGN of the threshold picks the direction (>= for a non-negative target, <= for a negative
+      one), so a negative target arms when reputation has fallen TO/BELOW it. A faction that no
+      longer exists never satisfies the trigger (degrade, never raise).
+
+    An unknown/garbage trigger is treated as unavailable (never raises) — a malformed seeded
+    Event degrades to "never surfaces" rather than breaking the read."""
+    trig = event.trigger
+    if trig == "manual":
+        return True
+    if trig == "flag_set":
+        return bool(event.trigger_value) and bool(campaign.flags.get(event.trigger_value))
+    if trig == "day_reached":
+        return campaign.day >= event.trigger_threshold
+    if trig == "reputation_at":
+        fac = campaign.factions.get(event.trigger_faction_id)
+        if fac is None:
+            return False
+        target = event.trigger_threshold
+        # Sign of the target picks the direction: a negative target arms on a FALL to/below it
+        # (reputation <= target); a non-negative target arms on a RISE to/above it.
+        return fac.reputation <= target if target < 0 else fac.reputation >= target
+    return False
+
+
+def present(campaign: Campaign) -> list[Event]:
+    """Return the UNRESOLVED Events whose trigger holds now (read-only; does NOT mutate).
+
+    Skips ``resolved`` Events (idempotent — a fired Event never re-presents, like
+    ``consequences.due``). Deterministic order (by event id) so the surface is reproducible
+    regardless of dict insertion order."""
+    return [
+        ev
+        for ev in sorted(campaign.events.values(), key=lambda e: e.id)
+        if not ev.resolved and trigger_holds(ev, campaign)
+    ]
+
+
+def _outcome_shared_effect(option: ParleyOption) -> dict:
+    """Project the chosen option's Outcome onto the dict ``worldsim._apply_structured_effect``
+    consumes — the keys it shares with the backlog/strategic ripple path, byte-for-byte. The
+    three extension keys (decision_flag / schedule_* / narrate) are handled separately in
+    ``resolve`` and are deliberately NOT in this dict (unknown keys are harmless there, but we
+    keep the contract crisp)."""
+    o = option.outcome
+    return {
+        "flag": o.flag,
+        "faction_id": o.faction_id,
+        "reputation_delta": o.reputation_delta,
+        "controller_id": o.controller_id,
+        "location_id": o.location_id,
+        "npc_name": o.npc_name,
+    }
+
+
+def find_option(event: Event, option_label: str) -> ParleyOption | None:
+    """The ParleyOption whose ``label`` matches (case-insensitive, trimmed), or None.
+
+    Picks the FIRST match in author order so a content author's option ordering is honored."""
+    want = (option_label or "").strip().casefold()
+    for opt in event.options:
+        if opt.label.strip().casefold() == want:
+            return opt
+    return None
+
+
+def resolve(campaign: Campaign, event: Event, option: ParleyOption) -> dict:
+    """Apply ``option``'s deterministic Outcome to ``campaign`` (mutates) and mark ``event``
+    resolved. Returns a DM-facing summary of what moved. DETERMINISTIC — no LLM, no roll here.
+
+    Order: the shared ripple via ``worldsim._apply_structured_effect`` (flag / reputation /
+    control / arrival), then the three extension keys inline:
+      * ``decision_flag`` -> ``campaign.flags[decision_flag] = True`` (the L2<->L3 seam — arms a
+        matching ``attitude_below`` CompanionAgenda, identical to ``record_decision(sets_flag=)``).
+      * ``schedule_in_days`` / ``schedule_text`` -> ``consequences.schedule`` (the rule-of-three
+        echo) — only when BOTH a positive day count and text are present.
+    Finally ``event.resolved = True`` (idempotency latch).
+
+    NOTE: this assumes the caller has already short-circuited a re-resolve of a ``resolved``
+    Event (see ``resolve_event`` in server.py) — it does not re-check ``resolved`` itself, so the
+    pure function stays a single deterministic application step."""
+    o = option.outcome
+
+    # The shared ripple — the exact path the backlog/strategic board uses. `narrate` is the
+    # DM-facing fallback line.
+    narrated = worldsim._apply_structured_effect(
+        campaign, _outcome_shared_effect(option), fallback=o.narrate
+    )
+
+    flags_set: list[str] = []
+    if o.flag:
+        flags_set.append(o.flag)
+
+    rep_shift: dict | None = None
+    if o.faction_id and o.faction_id in campaign.factions:
+        # Report the post-shift reputation the effect just applied (clamped by the effect path).
+        rep_shift = {
+            "faction_id": o.faction_id,
+            "reputation_delta": o.reputation_delta,
+            "reputation": campaign.factions[o.faction_id].reputation,
+        }
+
+    # Extension key 1 — the L2<->L3 seam: set the content-defined decision flag (same store as
+    # record_decision(sets_flag=)). Arms any attitude_below agenda whose decision_flag matches.
+    decision_flag = (o.decision_flag or "").strip()
+    if decision_flag:
+        campaign.flags[decision_flag] = True
+        if decision_flag not in flags_set:
+            flags_set.append(decision_flag)
+
+    # Extension key 2 — the rule-of-three echo: schedule a follow-on Consequence so the choice
+    # lingers/returns. Requires BOTH a positive day count and text (a malformed half-spec is a
+    # no-op, never a 0-day phantom consequence).
+    scheduled: dict | None = None
+    if o.schedule_in_days > 0 and o.schedule_text.strip():
+        conseq = consequences_mod.schedule(
+            campaign,
+            o.schedule_in_days,
+            o.schedule_text.strip(),
+            note=f"event:{event.id}",
+        )
+        scheduled = {"trigger_day": conseq.trigger_day, "text": conseq.text}
+
+    # Idempotency latch — a fired Event never re-presents or re-applies.
+    event.resolved = True
+
+    return {
+        "event_id": event.id,
+        "option_label": option.label,
+        "narrated_line": narrated,
+        "flags_set": flags_set,
+        "rep_shift": rep_shift,
+        "scheduled": scheduled,
+        "decision_flag": decision_flag,
+        "resolved": True,
+    }

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -310,6 +310,103 @@ class CompanionQuestArc(_StrictModel):
         return self
 
 
+# --- Quest & Arc engine, Layer 3: first-class Event / ParleyOption / Outcome ----------------
+# The Kingmaker "stumble-into" decisional: a content-authored choice point whose options carry a
+# DETERMINISTIC ripple (set a flag, shift faction reputation, schedule a Consequence) AND can STAGE
+# the already-merged Layer-2 companion flip by setting a `decision_flag`. A THIN first-class wrapper
+# over machinery that already ships — no new resolver, no new state machine:
+#   * the ripple reuses worldsim._apply_structured_effect byte-for-byte;
+#   * the L2 flip reuses CompanionAgenda.decision_flag (Layer 2) — they meet at Campaign.flags;
+#   * the schedule echo reuses consequences.schedule (Layer 1's rule-of-three pattern).
+# ADDITIVE: a campaign with no events behaves exactly as today; old snapshots round-trip.
+
+# A contract-safe trigger reads ONLY engine-MUTATED values (flags / faction reputation / day) —
+# never near-constant fiction (the questgen.py:7-19 discipline). Mirrors the CompanionAgenda
+# trigger vocabulary so there is one mental model for "when does an arc beat become available".
+EventTrigger = Literal["manual", "flag_set", "day_reached", "reputation_at"]
+
+
+class Outcome(_StrictModel):
+    """The DETERMINISTIC ripple a chosen ParleyOption applies (Quest & Arc engine, Layer 3).
+
+    The payload reuses worldsim._apply_structured_effect's keys BYTE-FOR-BYTE (so a picked
+    option ripples through the exact same engine path a backlog item / strategic project does),
+    plus three thin extension keys the resolver handles inline:
+
+      * the shared keys (applied via _apply_structured_effect): ``flag`` -> campaign.flags[flag]
+        = True; ``faction_id`` + ``reputation_delta`` -> clamped reputation shift;
+        ``controller_id`` + ``location_id`` -> a ``control:loc=fac`` flag; ``npc_name`` -> an
+        ``arrival:`` stub flag.
+      * ``decision_flag`` (NEW — the L2<->L3 seam): sets ``campaign.flags[decision_flag] = True``,
+        identical to ``record_decision(sets_flag=...)``. This ARMS any ``attitude_below``
+        CompanionAgenda whose ``decision_flag`` matches — the owner's "take the bribe -> the
+        knight-companion turns". Layer 3 sets the flag; the already-merged Layer 2 reads it.
+      * ``schedule_in_days`` + ``schedule_text`` (NEW): schedules a follow-on Consequence via
+        consequences.schedule (the rule-of-three echo) so the choice lingers/returns later.
+      * ``narrate`` (NEW): a DM-facing one-liner — the human-readable summary of the ripple
+        (passed as the `fallback` to _apply_structured_effect).
+
+    EVERY value is CONTENT-defined; the engine never invents a flag name or a reputation delta.
+    An empty Outcome is a pure no-op (the engine still records the pick; nothing else moves).
+    Setting-agnostic: no engine-coded taxonomy, same discipline as the merged L1/L2."""
+
+    # --- keys shared with worldsim._apply_structured_effect (applied verbatim through it) ---
+    flag: str = ""  # -> campaign.flags[flag] = True
+    faction_id: str = ""  # paired with reputation_delta -> clamped -100..100 shift
+    reputation_delta: int = 0
+    controller_id: str = ""  # paired with location_id -> a `control:loc=fac` flag
+    location_id: str = ""
+    npc_name: str = ""  # -> an `arrival:<name>` stub flag
+    # --- the three thin extension keys the resolver handles inline ---
+    decision_flag: str = ""  # NEW: campaign.flags[decision_flag]=True — arms a matching L2 agenda
+    schedule_in_days: int = 0  # NEW: with schedule_text -> consequences.schedule (rule-of-three echo)
+    schedule_text: str = ""
+    narrate: str = ""  # DM-facing one-liner (the _apply_structured_effect `fallback`)
+
+
+class ParleyOption(_StrictModel):
+    """One tagged choice in an Event's parley menu (Quest & Arc engine, Layer 3).
+
+    Mirrors the slot shape `generate_parley_options` supplies (an alignment/skill `tag`, an
+    optional `skill`+`dc` the DM may gate the pick behind) but ADDS a deterministic `outcome`:
+    where today the DM hand-routes a freeform pick to skill_check / social_check / record_decision,
+    a ParleyOption already KNOWS its ripple. The engine never authors the prose — the `label` is a
+    short tagged choice the DM voices; resolution is the `outcome`."""
+
+    label: str  # the short tagged choice the player picks ("Take the bribe — CN")
+    tag: str = ""  # an alignment/skill hint (mirrors generate_parley_options' tagging guidance)
+    skill: str = ""  # optional gated check the DM may run before applying the outcome (routes to skill_check)
+    dc: int = 0
+    outcome: "Outcome" = Field(default_factory=lambda: Outcome())
+
+
+class Event(_StrictModel):
+    """A first-class stumble-into decisional (Quest & Arc engine, Layer 3).
+
+    A content-authored choice point: when its contract-safe ``trigger`` holds (flags / faction
+    reputation / day — never fiction), ``present_events`` surfaces it as a soft nudge; the DM
+    voices the ``prompt`` and the ``options`` (relayed to the player via the #141 parley surface),
+    and ``resolve_event`` applies the chosen option's deterministic Outcome. IDEMPOTENT: a fired
+    Event sets ``resolved=True`` and never re-presents / re-applies (like a fired Consequence)."""
+
+    id: str = Field(default_factory=lambda: _new_id("event"))
+    trigger: EventTrigger = "manual"  # how the Event becomes available (default: DM/content surfaces it)
+    # The predicate operands the trigger reads (engine-mutated values only):
+    #   flag_set     -> trigger_value is the flag name; available when campaign.flags[name] is True.
+    #   day_reached  -> trigger_threshold is the day; available when campaign.day >= threshold.
+    #   reputation_at-> trigger_faction_id + trigger_threshold; available when that faction's
+    #                   reputation >= threshold (or <= threshold when threshold is negative — the
+    #                   sign picks the direction, mirroring the design's `reputation_delta` sign use).
+    #   manual       -> always available until resolved (the DM/content drops it; the default).
+    trigger_value: str = ""  # flag name for `flag_set`
+    trigger_faction_id: str = ""  # faction id for `reputation_at`
+    trigger_threshold: int = 0  # day for `day_reached`; reputation level for `reputation_at`
+    prompt: str = ""  # the situation the DM voices
+    options: list["ParleyOption"] = Field(default_factory=list)  # the tagged choices; freeform is ALWAYS also allowed (#141)
+    anchor_npc_id: str = ""  # optional canon-NPC binding (the owner's priority — bind to a roster NPC)
+    resolved: bool = False  # idempotency: a fired Event never re-presents or re-applies
+
+
 class CompanionDossier(_StrictModel):
     """A companion's structured identity — the OPERATIONAL state the engine's living-world
     systems act on (camp scheduling, banter selection, approval causes, companion quest
@@ -1102,6 +1199,14 @@ class Campaign(_StrictModel):
     # tracked Quest objects; explicit server APIs advance them and optionally project status
     # into linked Quests. Empty == old snapshots load unchanged.
     companion_quest_arcs: dict[str, CompanionQuestArc] = Field(default_factory=dict)
+    # First-class stumble-into Events (Quest & Arc engine, Layer 3). Content-authored decisionals
+    # whose options carry a deterministic Outcome (a world ripple + optionally a Layer-2
+    # decision_flag that arms a companion flip). Surfaced read-only by present_events when their
+    # contract-safe trigger holds; applied by resolve_event. Empty == today's behavior byte-for-
+    # byte; old snapshots lacking the key round-trip to this empty default. Mirrors
+    # companion_quest_arcs; seeded from a world/ending `events` block (content.py). Engine
+    # sole-writer (resolve_event under campaign_lock + save_campaign).
+    events: dict[str, "Event"] = Field(default_factory=dict)
 
     characters: dict[str, Character] = Field(default_factory=dict)  # id -> Character (PCs, companion, NPCs)
     party: list[str] = Field(default_factory=list)  # character ids that are PCs / companions

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -26,6 +26,7 @@ import consequences as consequences_mod
 import content as content_mod
 import dice as dice_mod
 import encounter
+import events as events_mod
 import generator
 import imagegen
 import inventory
@@ -4893,6 +4894,7 @@ def generate_parley_options(
     difficulty: str = "medium",
     skills: Optional[list[str]] = None,
     include_alignment: bool = True,
+    event_id: str = "",
 ) -> dict:
     """Call this BEFORE narrating a social encounter or any choice point: it lays out the
     PLAYER'S available options with sheet-correct DCs so you author a real Parley menu
@@ -4915,7 +4917,16 @@ def generate_parley_options(
     a chosen skill option -> ``skill_check(actor, skill, dc)``; a social option vs a tracked
     NPC -> ``social_check`` (or ``target_name`` for a scene extra); a combat option ->
     ``start_combat``; a free-form/alignment beat you adjudicate, then ``record_decision``
-    (and optional ``adjust_reputation``). Read-only."""
+    (and optional ``adjust_reputation``). Read-only.
+
+    Quest & Arc engine, Layer 3 — `event_id` (OPTIONAL): when a first-class stumble-into Event
+    is live (from ``present_events``), pass its id to attach the Event's AUTHORED options to the
+    surface as ``event: {id, prompt, options:[{label, tag, skill, dc}]}``. The Event's options
+    are the menu slots; the free-form path is STILL always present (never a closed set). A picked
+    Event option routes to ``resolve_event(campaign_id, event_id, option_label)`` (the engine
+    applies its deterministic ripple) — not to skill_check/record_decision. An unknown
+    `event_id` or one that is already resolved simply omits the block (degrades to today's
+    freeform parley)."""
     c = _require(campaign_id)
     aid = actor_id or _lead_pc_id(c)
     if not aid:
@@ -4955,6 +4966,22 @@ def generate_parley_options(
     }
     if include_alignment:
         out["alignment"] = actor.alignment
+    # Quest & Arc engine, Layer 3: when a live Event is named, attach its authored options as
+    # the menu slots (the free-form path above stays). A resolved/unknown Event omits the block,
+    # degrading to today's freeform parley. resolve_event applies a picked option's ripple.
+    if event_id:
+        ev = c.events.get(event_id)
+        if ev is not None and not ev.resolved:
+            out["event"] = {
+                "id": ev.id,
+                "prompt": ev.prompt,
+                "anchor_npc_id": ev.anchor_npc_id,
+                "options": [
+                    {"label": opt.label, "tag": opt.tag, "skill": opt.skill, "dc": opt.dc}
+                    for opt in ev.options
+                ],
+                "resolve_with": "resolve_event",
+            }
     return out
 
 
@@ -6108,6 +6135,86 @@ def record_decision(
         if flag:
             out["flag"] = flag
         return out
+
+
+@mcp.tool()
+def present_events(campaign_id: str) -> dict:
+    """Surface the first-class stumble-into EVENTS that are available right now (Quest & Arc
+    engine, Layer 3) — the Kingmaker-style decisionals whose moment has arrived. Call it each
+    beat like `check_consequences` / `check_companion_arc`: it returns the unresolved Events
+    whose CONTRACT-SAFE trigger holds (a set flag, a faction's reputation reaching a level, or a
+    reached day — never fiction), so you can drop a soft nudge ("a man in Flaming-Fist colors
+    falls into step beside you...") and lay out its tagged options.
+
+    Each returned Event carries its `prompt` (the situation you voice), its `options` (tagged
+    choices the player picks — relay them via the parley surface; a free-form path is ALWAYS
+    also allowed), and any `anchor_npc_id` (bind the scene to that canon NPC). READ-ONLY: it
+    never fires or mutates anything; resolved Events are skipped (idempotent). When the player
+    picks an option, call `resolve_event(campaign_id, event_id, option_label)` to apply its
+    deterministic ripple — that is the engine resolution; you narrate the result."""
+    c = _require(campaign_id)
+    available = events_mod.present(c)
+    return {
+        "events": [
+            {
+                "id": ev.id,
+                "prompt": ev.prompt,
+                "trigger": ev.trigger,
+                "anchor_npc_id": ev.anchor_npc_id,
+                "options": [
+                    {"label": opt.label, "tag": opt.tag, "skill": opt.skill, "dc": opt.dc}
+                    for opt in ev.options
+                ],
+            }
+            for ev in available
+        ],
+        "free_form": True,  # the player may ALWAYS act outside the menu (#141 — never a closed set)
+    }
+
+
+@mcp.tool()
+def resolve_event(campaign_id: str, event_id: str, option_label: str) -> dict:
+    """Resolve a stumble-into EVENT by applying the chosen option's DETERMINISTIC outcome
+    (Quest & Arc engine, Layer 3) — the engine ripples; you narrate. Call this AFTER the player
+    picks one of the options `present_events` laid out (a free-form pick the player invents is
+    NOT an Event option — adjudicate that yourself, then record_decision / adjust_reputation as
+    usual).
+
+    Looks up the Event by `event_id` and the chosen `option_label` (case-insensitive), then
+    applies that option's `Outcome` through the SAME engine path the living world uses: a set
+    `flag`, a clamped faction `reputation_delta`, a `control:`/`arrival:` marker, an optional
+    follow-on Consequence scheduled `schedule_in_days` out (the thread lingers), and — the
+    decision-gated flip — an optional `decision_flag` set True in `Campaign.flags`, which ARMS a
+    matching `attitude_below` companion agenda (the owner's "take the bribe -> the knight turns";
+    same store as `record_decision(sets_flag=...)`). Then marks the Event resolved.
+
+    IDEMPOTENT: re-resolving an already-resolved Event is a no-op (applies nothing) — calling it
+    twice is safe. Returns the narrated line + what moved (`flags_set`, `rep_shift`, `scheduled`,
+    `decision_flag`) for you to weave. If you set a `decision_flag`, follow up with
+    `check_companion_arc` to see whether the spiked betrayal fires."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        event = c.events.get(event_id)
+        if event is None:
+            raise ValueError(f"no event {event_id!r} in campaign")
+        if event.resolved:
+            # Idempotency: a fired Event applies NOTHING on a re-resolve. No save needed (no
+            # mutation), so a double-call can never double-ripple.
+            return {
+                "event_id": event.id,
+                "resolved": True,
+                "noop": True,
+                "note": "event already resolved — no effect applied",
+            }
+        option = events_mod.find_option(event, option_label)
+        if option is None:
+            labels = [opt.label for opt in event.options]
+            raise ValueError(
+                f"event {event_id!r} has no option labelled {option_label!r}; options are {labels}"
+            )
+        result = events_mod.resolve(c, event, option)
+        save_campaign(c)
+        return result
 
 
 @mcp.tool()

--- a/servers/engine/tests/test_event_parley_layer3.py
+++ b/servers/engine/tests/test_event_parley_layer3.py
@@ -1,0 +1,653 @@
+"""Tests for the Quest & Arc engine, Layer 3 — first-class Event / ParleyOption / Outcome.
+
+The Kingmaker stumble-into decisional made a real engine fact: a content-authored ``Event``
+whose ``ParleyOption``s carry a DETERMINISTIC ``Outcome`` that ripples through the EXISTING
+engine vocabulary (``worldsim._apply_structured_effect`` + ``consequences.schedule``) AND can
+STAGE the already-merged Layer-2 companion flip by setting a ``decision_flag``.
+
+Coverage (per the verification plan):
+  * ``present_events`` surfaces a trigger-met Event and hides a trigger-unmet / resolved one.
+  * ``resolve_event`` applies each Outcome kind (flag set, faction reputation_delta, scheduled
+    Consequence, narrate) and is IDEMPOTENT on re-resolve (a no-op).
+  * the L2<->L3 SEAM: an option whose Outcome sets a ``decision_flag`` makes the matching
+    ``attitude_below`` companion agenda's betrayal probability spike (reuses the L2 pattern).
+  * ADDITIVE: no events == today's behavior, byte-for-byte; old snapshots round-trip.
+  * the parley surface EXTENSION (engine generate_parley_options(event_id=) — reused, not new).
+  * content seeding via ``seed_world`` / the ending overlay (degrade-not-abort).
+
+Pure-module functions (events.py) are exercised directly (like test_companion_arc.py); the
+MCP tools (server.py) are exercised against a real persisted campaign (like test_parley.py).
+Single-process only (the host OOMs on parallel pytest).
+"""
+
+import random
+
+import pytest
+
+import companion_arc
+import content as content_mod
+import events as events_mod
+import server
+import store
+from models import (
+    Campaign,
+    Character,
+    CompanionAgenda,
+    CompanionArc,
+    Event,
+    Faction,
+    Outcome,
+    ParleyOption,
+)
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _event(eid="event_x", trigger="manual", options=None, **kw) -> Event:
+    return Event(
+        id=eid,
+        trigger=trigger,
+        prompt=kw.pop("prompt", "A figure falls into step beside you."),
+        options=options if options is not None else [ParleyOption(label="Listen")],
+        **kw,
+    )
+
+
+def _campaign_with_events(*evs: Event, day: int = 1, flags=None, factions=None) -> Campaign:
+    c = Campaign(title="L3")
+    c.day = day
+    if flags:
+        c.flags.update(flags)
+    for f in factions or []:
+        c.factions[f.id] = f
+    for ev in evs:
+        c.events[ev.id] = ev
+    return c
+
+
+# =========================================================================
+# ADDITIVE DEFAULT + round-trip (empty == today, old snapshots load)
+# =========================================================================
+
+
+def test_campaign_events_defaults_empty():
+    assert Campaign(title="T").events == {}
+
+
+def test_old_campaign_snapshot_without_events_deserializes_unchanged():
+    """A snapshot authored before Layer 3 has no `events` key — it must load with events={}
+    and round-trip identically (the additive-default contract)."""
+    c = Campaign(title="Pre-L3")
+    data = c.model_dump(mode="json")
+    old = {k: v for k, v in data.items() if k != "events"}
+    assert "events" not in old
+    reloaded = Campaign.model_validate(old)
+    assert reloaded.events == {}
+    # a full round-trip stays stable
+    assert Campaign.model_validate(reloaded.model_dump(mode="json")).events == {}
+
+
+def test_event_models_default_shapes():
+    o = Outcome()
+    assert o.flag == "" and o.decision_flag == "" and o.reputation_delta == 0
+    assert o.schedule_in_days == 0 and o.schedule_text == "" and o.narrate == ""
+    po = ParleyOption(label="Take the bribe")
+    assert po.tag == "" and po.skill == "" and po.dc == 0
+    assert isinstance(po.outcome, Outcome) and po.outcome.flag == ""
+    ev = Event(prompt="p")
+    assert ev.trigger == "manual" and ev.resolved is False and ev.options == []
+    assert ev.id.startswith("event_")
+
+
+def test_event_round_trips_with_full_outcome():
+    ev = _event(options=[ParleyOption(
+        label="Take the bribe", tag="CN", skill="deception", dc=15,
+        outcome=Outcome(flag="took_money", faction_id="fac-x", reputation_delta=-10,
+                        decision_flag="took_bribe", schedule_in_days=7, schedule_text="debt called",
+                        narrate="You pocket the gold."),
+    )])
+    reloaded = Event.model_validate(ev.model_dump(mode="json"))
+    assert reloaded == ev
+
+
+# =========================================================================
+# TRIGGERS (contract-safe: flags / reputation / day only) — events.trigger_holds + present
+# =========================================================================
+
+
+def test_manual_trigger_always_available_until_resolved():
+    ev = _event(eid="event_m", trigger="manual")
+    c = _campaign_with_events(ev)
+    assert [e.id for e in events_mod.present(c)] == ["event_m"]
+    ev.resolved = True
+    assert events_mod.present(c) == []  # resolved -> hidden (idempotent)
+
+
+def test_flag_set_trigger_gates_on_flag():
+    ev = _event(eid="event_f", trigger="flag_set", trigger_value="door_open")
+    c = _campaign_with_events(ev)
+    assert events_mod.present(c) == []  # flag absent
+    c.flags["door_open"] = True
+    assert [e.id for e in events_mod.present(c)] == ["event_f"]
+    c.flags["door_open"] = False
+    assert events_mod.present(c) == []  # present but False -> not available
+
+
+def test_day_reached_trigger_gates_on_day():
+    ev = _event(eid="event_d", trigger="day_reached", trigger_threshold=5)
+    c = _campaign_with_events(ev, day=4)
+    assert events_mod.present(c) == []
+    c.day = 5
+    assert [e.id for e in events_mod.present(c)] == ["event_d"]
+
+
+def test_reputation_at_positive_target_arms_on_rise():
+    fac = Faction(id="fac-fist", name="Flaming Fist", reputation=0)
+    ev = _event(eid="event_r", trigger="reputation_at", trigger_faction_id="fac-fist", trigger_threshold=10)
+    c = _campaign_with_events(ev, factions=[fac])
+    assert events_mod.present(c) == []  # rep 0 < 10
+    fac.reputation = 10
+    assert [e.id for e in events_mod.present(c)] == ["event_r"]
+
+
+def test_reputation_at_negative_target_arms_on_fall():
+    """A negative threshold arms when reputation has fallen TO/BELOW it (the sign picks
+    direction) — 'when they hate you enough'."""
+    fac = Faction(id="fac-fist", name="Flaming Fist", reputation=0)
+    ev = _event(eid="event_rn", trigger="reputation_at", trigger_faction_id="fac-fist", trigger_threshold=-10)
+    c = _campaign_with_events(ev, factions=[fac])
+    assert events_mod.present(c) == []  # rep 0 not <= -10
+    fac.reputation = -10
+    assert [e.id for e in events_mod.present(c)] == ["event_rn"]
+
+
+def test_reputation_at_unknown_faction_never_available():
+    ev = _event(eid="event_ru", trigger="reputation_at", trigger_faction_id="nope", trigger_threshold=5)
+    c = _campaign_with_events(ev)  # no such faction
+    assert events_mod.present(c) == []
+
+
+def test_present_skips_resolved_and_is_id_ordered():
+    a = _event(eid="event_a", trigger="manual")
+    b = _event(eid="event_b", trigger="manual")
+    z = _event(eid="event_z", trigger="manual", prompt="resolved one")
+    z.resolved = True
+    c = _campaign_with_events(z, b, a)
+    assert [e.id for e in events_mod.present(c)] == ["event_a", "event_b"]  # sorted, z skipped
+
+
+def test_unknown_trigger_degrades_to_unavailable():
+    ev = _event(eid="event_bad", trigger="manual")
+    # force an out-of-vocabulary trigger past validation by mutating the instance
+    object.__setattr__(ev, "trigger", "garbage")
+    c = _campaign_with_events(ev)
+    assert events_mod.trigger_holds(ev, c) is False  # never raises
+
+
+# =========================================================================
+# RESOLVE — each Outcome kind applies; idempotent on re-resolve (pure module)
+# =========================================================================
+
+
+def test_resolve_sets_flag():
+    ev = _event(options=[ParleyOption(label="Open it", outcome=Outcome(flag="vault_open", narrate="It swings wide."))])
+    c = _campaign_with_events(ev)
+    res = events_mod.resolve(c, ev, events_mod.find_option(ev, "Open it"))
+    assert c.flags.get("vault_open") is True
+    assert res["flags_set"] == ["vault_open"]
+    assert res["narrated_line"] == "It swings wide."
+    assert ev.resolved is True
+
+
+def test_resolve_shifts_faction_reputation_clamped():
+    fac = Faction(id="fac-x", name="X", reputation=95)
+    ev = _event(options=[ParleyOption(label="Help them", outcome=Outcome(faction_id="fac-x", reputation_delta=20))])
+    c = _campaign_with_events(ev, factions=[fac])
+    res = events_mod.resolve(c, ev, events_mod.find_option(ev, "Help them"))
+    assert c.factions["fac-x"].reputation == 100  # clamped to +100
+    assert res["rep_shift"] == {"faction_id": "fac-x", "reputation_delta": 20, "reputation": 100}
+
+
+def test_resolve_schedules_consequence():
+    ev = _event(options=[ParleyOption(
+        label="Take the bribe",
+        outcome=Outcome(schedule_in_days=7, schedule_text="Raphael calls in the debt"),
+    )])
+    c = _campaign_with_events(ev, day=3)
+    res = events_mod.resolve(c, ev, events_mod.find_option(ev, "Take the bribe"))
+    due = [co for co in c.consequences if co.text == "Raphael calls in the debt"]
+    assert len(due) == 1
+    assert due[0].trigger_day == 3 + 7  # scheduled relative to today
+    assert due[0].note == f"event:{ev.id}"
+    assert res["scheduled"] == {"trigger_day": 10, "text": "Raphael calls in the debt"}
+
+
+def test_resolve_half_specified_schedule_is_noop():
+    """A schedule needs BOTH a positive day count and text — a half-spec never creates a
+    0-day phantom consequence."""
+    ev = _event(options=[
+        ParleyOption(label="days only", outcome=Outcome(schedule_in_days=5)),  # no text
+        ParleyOption(label="text only", outcome=Outcome(schedule_text="something")),  # no days
+    ])
+    c = _campaign_with_events(ev)
+    res = events_mod.resolve(c, ev, events_mod.find_option(ev, "days only"))
+    assert c.consequences == []
+    assert res["scheduled"] is None
+
+
+def test_resolve_narrate_only_is_pure_no_ripple():
+    ev = _event(options=[ParleyOption(label="Walk away", outcome=Outcome(narrate="You turn your back."))])
+    c = _campaign_with_events(ev)
+    before = c.model_dump(mode="json")
+    res = events_mod.resolve(c, ev, events_mod.find_option(ev, "Walk away"))
+    assert res["narrated_line"] == "You turn your back."
+    assert res["flags_set"] == [] and res["rep_shift"] is None and res["scheduled"] is None
+    # the ONLY change is the resolved latch and (nothing else moved)
+    after = c.model_dump(mode="json")
+    before["events"][ev.id]["resolved"] = True
+    assert after == before
+
+
+def test_resolve_empty_outcome_is_pure_noop_except_latch():
+    ev = _event(options=[ParleyOption(label="Shrug")])  # default empty Outcome
+    c = _campaign_with_events(ev)
+    res = events_mod.resolve(c, ev, events_mod.find_option(ev, "Shrug"))
+    assert c.flags == {} and c.consequences == []
+    assert res["flags_set"] == [] and res["decision_flag"] == ""
+    assert ev.resolved is True
+
+
+def test_resolve_applies_all_outcome_kinds_together():
+    fac = Faction(id="fac-x", name="X", reputation=0)
+    ev = _event(options=[ParleyOption(label="Take the bribe", outcome=Outcome(
+        flag="took_money", faction_id="fac-x", reputation_delta=-15,
+        decision_flag="took_bribe", schedule_in_days=7, schedule_text="debt called in",
+        narrate="You pocket the gold.",
+    ))])
+    c = _campaign_with_events(ev, factions=[fac])
+    res = events_mod.resolve(c, ev, events_mod.find_option(ev, "Take the bribe"))
+    assert c.flags.get("took_money") is True
+    assert c.flags.get("took_bribe") is True  # the L2 decision flag
+    assert c.factions["fac-x"].reputation == -15
+    assert any(co.text == "debt called in" for co in c.consequences)
+    assert set(res["flags_set"]) == {"took_money", "took_bribe"}
+    assert res["decision_flag"] == "took_bribe"
+    assert res["narrated_line"] == "You pocket the gold."
+
+
+def test_find_option_case_insensitive_and_first_match():
+    ev = _event(options=[ParleyOption(label="Take the Bribe"), ParleyOption(label="Refuse")])
+    assert events_mod.find_option(ev, "take the bribe").label == "Take the Bribe"
+    assert events_mod.find_option(ev, "  REFUSE  ").label == "Refuse"
+    assert events_mod.find_option(ev, "nope") is None
+
+
+# =========================================================================
+# THE TOOLS (server.py) against a real persisted campaign — incl. idempotency
+# =========================================================================
+
+
+@pytest.fixture
+def l3_campaign(tmp_path, monkeypatch):
+    """A persisted campaign with a lead PC, a companion, and a faction. Returns (cid, pc, comp)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Layer 3 Test")["id"]
+    pc = server.create_character(cid, "Vanya", kind="player", class_name="bard", level=3)["id"]
+    comp = server.create_character(cid, "Dorn", kind="companion", class_name="fighter", level=3)["id"]
+    c = store.load_campaign(cid)
+    c.factions["fac-fist"] = Faction(id="fac-fist", name="Flaming Fist", reputation=0)
+    store.save_campaign(c)
+    return cid, pc, comp
+
+
+def _inject_event(cid: str, ev: Event) -> None:
+    c = store.load_campaign(cid)
+    c.events[ev.id] = ev
+    store.save_campaign(c)
+
+
+def test_present_events_tool_surfaces_trigger_met_hides_unmet(l3_campaign):
+    cid, _pc, _comp = l3_campaign
+    met = _event(eid="event_met", trigger="manual",
+                 options=[ParleyOption(label="Take the bribe", tag="CN", skill="deception", dc=15)])
+    unmet = _event(eid="event_unmet", trigger="flag_set", trigger_value="never_set")
+    _inject_event(cid, met)
+    _inject_event(cid, unmet)
+    out = server.present_events(cid)
+    ids = [e["id"] for e in out["events"]]
+    assert ids == ["event_met"]
+    assert out["free_form"] is True  # the #141 guard: never a closed set
+    surfaced = out["events"][0]
+    assert surfaced["prompt"]
+    assert surfaced["options"] == [{"label": "Take the bribe", "tag": "CN", "skill": "deception", "dc": 15}]
+
+
+def test_present_events_tool_hides_resolved(l3_campaign):
+    cid, _pc, _comp = l3_campaign
+    ev = _event(eid="event_done", trigger="manual")
+    ev.resolved = True
+    _inject_event(cid, ev)
+    assert server.present_events(cid)["events"] == []
+
+
+def test_present_events_tool_is_read_only(l3_campaign):
+    cid, _pc, _comp = l3_campaign
+    _inject_event(cid, _event(eid="event_ro", trigger="manual"))
+    before = store.load_campaign(cid).model_dump(mode="json")
+    server.present_events(cid)
+    after = store.load_campaign(cid).model_dump(mode="json")
+    assert before == after
+
+
+def test_resolve_event_tool_applies_outcome_and_persists(l3_campaign):
+    cid, _pc, _comp = l3_campaign
+    ev = _event(eid="event_bribe", trigger="manual", options=[ParleyOption(
+        label="Take the bribe",
+        outcome=Outcome(flag="took_money", faction_id="fac-fist", reputation_delta=-20,
+                        decision_flag="took_bribe", narrate="You pocket the gold."),
+    )])
+    _inject_event(cid, ev)
+    res = server.resolve_event(cid, "event_bribe", "take the bribe")  # case-insensitive label
+    assert res["resolved"] is True and res.get("noop") is None
+    assert res["decision_flag"] == "took_bribe"
+    # persisted
+    c = store.load_campaign(cid)
+    assert c.flags.get("took_money") is True
+    assert c.flags.get("took_bribe") is True
+    assert c.factions["fac-fist"].reputation == -20
+    assert c.events["event_bribe"].resolved is True
+
+
+def test_resolve_event_tool_idempotent_on_re_resolve(l3_campaign):
+    """Re-resolving a resolved Event is a NO-OP — applies nothing, can't double-ripple."""
+    cid, _pc, _comp = l3_campaign
+    ev = _event(eid="event_once", trigger="manual", options=[ParleyOption(
+        label="Help", outcome=Outcome(faction_id="fac-fist", reputation_delta=10),
+    )])
+    _inject_event(cid, ev)
+    first = server.resolve_event(cid, "event_once", "Help")
+    assert first["rep_shift"]["reputation"] == 10
+    # second call: no-op, reputation does NOT move again
+    second = server.resolve_event(cid, "event_once", "Help")
+    assert second["noop"] is True and second["resolved"] is True
+    assert store.load_campaign(cid).factions["fac-fist"].reputation == 10  # still 10, not 20
+
+
+def test_resolve_event_tool_unknown_event_raises(l3_campaign):
+    cid, _pc, _comp = l3_campaign
+    with pytest.raises(ValueError):
+        server.resolve_event(cid, "event_nope", "anything")
+
+
+def test_resolve_event_tool_unknown_option_raises(l3_campaign):
+    cid, _pc, _comp = l3_campaign
+    _inject_event(cid, _event(eid="event_o", trigger="manual", options=[ParleyOption(label="Yes")]))
+    with pytest.raises(ValueError):
+        server.resolve_event(cid, "event_o", "Maybe")
+
+
+# =========================================================================
+# THE L2<->L3 SEAM — resolve_event arming a decision_flag spikes the betrayal
+# =========================================================================
+
+
+def _knight_with_agenda(decision_flag: str, attitude: int = -30, threshold: int = 0) -> Character:
+    agenda = CompanionAgenda(trigger="attitude_below", value=threshold, decision_flag=decision_flag)
+    return Character(name="Knight", kind="companion", attitude_value=attitude, arc=CompanionArc(agenda=agenda))
+
+
+def test_l2_l3_seam_resolve_arms_matching_agenda():
+    """The whole integration: an Event option whose Outcome sets `decision_flag` flips the same
+    flag a matching attitude_below agenda reads (Layer 2). They meet at Campaign.flags."""
+    knight = _knight_with_agenda("took_bribe")
+    c = Campaign(title="seam")
+    c.characters[knight.id] = knight
+    c.party.append(knight.id)
+    ev = _event(eid="event_seam", trigger="manual", options=[ParleyOption(
+        label="Take the bribe", outcome=Outcome(decision_flag="took_bribe"),
+    )])
+    c.events[ev.id] = ev
+
+    agenda = knight.arc.agenda
+    # before: the flag isn't set, the boost is NOT active
+    assert companion_arc._decision_flag_active(agenda, c) is False
+    p_off = companion_arc._attitude_below_snap_p(
+        knight.attitude_value, agenda.value, vulnerable=False, decision_flag_active=False
+    )
+
+    # resolve the event -> sets the flag (identical to record_decision(sets_flag="took_bribe"))
+    events_mod.resolve(c, ev, events_mod.find_option(ev, "Take the bribe"))
+    assert c.flags.get("took_bribe") is True
+
+    # after: the SAME agenda now reads the flag as active and the snap probability SPIKES
+    assert companion_arc._decision_flag_active(agenda, c) is True
+    p_on = companion_arc._attitude_below_snap_p(
+        knight.attitude_value, agenda.value, vulnerable=False, decision_flag_active=True
+    )
+    assert p_on > p_off
+    assert p_on == pytest.approx(p_off + companion_arc.ATTITUDE_SNAP_DECISION_BONUS)
+
+
+def test_l2_l3_seam_fire_rate_spikes_through_resolve_event_tool(l3_campaign, monkeypatch):
+    """End-to-end through the TOOLS: resolve_event arms the flag, then check_companion_arc
+    fires the betrayal at a NOTABLY higher rate than the same agenda with no Event resolved.
+    Mirrors the L2 statistical gate (test_companion_arc.test_decision_flag_fires_at_...)."""
+    cid, _pc, _comp = l3_campaign
+
+    # attach a knight with an attitude_below agenda gated on "took_bribe", below threshold
+    c = store.load_campaign(cid)
+    knight = _knight_with_agenda("took_bribe", attitude=-30, threshold=0)
+    c.characters[knight.id] = knight
+    c.party.append(knight.id)
+    c.events["event_bribe"] = _event(eid="event_bribe", trigger="manual", options=[ParleyOption(
+        label="Take the bribe", outcome=Outcome(decision_flag="took_bribe"),
+    )])
+    store.save_campaign(c)
+
+    # a seeded rng makes evaluate deterministic; sample the fire rate with the flag OFF
+    def fire_rate(seed: int) -> float:
+        rng = random.Random(seed)
+        hits = 0
+        trials = 400
+        for _ in range(trials):
+            cc = store.load_campaign(cid)
+            k = next(ch for ch in cc.characters.values() if ch.name == "Knight")
+            k.arc.agenda.fired = False
+            if companion_arc.evaluate(k, cc, rng=rng)["agenda_fired"]:
+                hits += 1
+        return hits / trials
+
+    rate_off = fire_rate(seed=7)
+
+    # now resolve the Event through the TOOL -> arms took_bribe
+    server.resolve_event(cid, "event_bribe", "Take the bribe")
+    assert store.load_campaign(cid).flags.get("took_bribe") is True
+
+    rate_on = fire_rate(seed=8)
+
+    # base ≈ 0.30, boosted ≈ 0.60 — demand a clearly higher rate (wide margin for variance)
+    assert rate_on > rate_off + 0.15, f"on={rate_on:.3f} should be notably > off={rate_off:.3f}"
+
+
+def test_l2_l3_seam_no_decision_flag_is_pure_world_ripple():
+    """An Outcome with NO decision_flag is just a world ripple — it never arms a companion
+    flip (fully additive)."""
+    knight = _knight_with_agenda("took_bribe")
+    c = Campaign(title="ripple")
+    c.characters[knight.id] = knight
+    c.party.append(knight.id)
+    c.factions["fac-x"] = Faction(id="fac-x", name="X", reputation=0)
+    ev = _event(eid="event_world", trigger="manual", options=[ParleyOption(
+        label="Donate", outcome=Outcome(faction_id="fac-x", reputation_delta=10),  # no decision_flag
+    )])
+    c.events[ev.id] = ev
+    events_mod.resolve(c, ev, events_mod.find_option(ev, "Donate"))
+    assert c.factions["fac-x"].reputation == 10
+    assert c.flags.get("took_bribe") is None  # the knight's flag was never touched
+    assert companion_arc._decision_flag_active(knight.arc.agenda, c) is False
+
+
+# =========================================================================
+# PARLEY SURFACE EXTENSION — generate_parley_options(event_id=) (reused, not new)
+# =========================================================================
+
+
+def test_parley_surface_without_event_id_is_unchanged(l3_campaign):
+    """No event_id -> no `event` block: today's freeform parley, byte-for-byte."""
+    cid, _pc, _comp = l3_campaign
+    out = server.generate_parley_options(cid)
+    assert "event" not in out
+    assert out["free_form"] is True
+    assert out["skills"]  # still supplies the DC-tagged slots
+
+
+def test_parley_surface_attaches_live_event_block(l3_campaign):
+    cid, _pc, _comp = l3_campaign
+    ev = _event(eid="event_live", trigger="manual", options=[
+        ParleyOption(label="Take the bribe", tag="CN", skill="deception", dc=15),
+        ParleyOption(label="Refuse", tag="LG"),
+    ])
+    _inject_event(cid, ev)
+    out = server.generate_parley_options(cid, event_id="event_live")
+    assert out["free_form"] is True  # free-form path STAYS (never a closed set)
+    assert "event" in out
+    block = out["event"]
+    assert block["id"] == "event_live"
+    assert block["resolve_with"] == "resolve_event"
+    assert block["options"] == [
+        {"label": "Take the bribe", "tag": "CN", "skill": "deception", "dc": 15},
+        {"label": "Refuse", "tag": "LG", "skill": "", "dc": 0},
+    ]
+
+
+def test_parley_surface_omits_resolved_or_unknown_event(l3_campaign):
+    cid, _pc, _comp = l3_campaign
+    done = _event(eid="event_resolved", trigger="manual")
+    done.resolved = True
+    _inject_event(cid, done)
+    assert "event" not in server.generate_parley_options(cid, event_id="event_resolved")
+    assert "event" not in server.generate_parley_options(cid, event_id="event_missing")
+
+
+def test_parley_surface_event_block_is_read_only(l3_campaign):
+    cid, _pc, _comp = l3_campaign
+    _inject_event(cid, _event(eid="event_ro2", trigger="manual"))
+    before = store.load_campaign(cid).model_dump(mode="json")
+    server.generate_parley_options(cid, event_id="event_ro2")
+    after = store.load_campaign(cid).model_dump(mode="json")
+    assert before == after
+
+
+# =========================================================================
+# CONTENT SEEDING — seed_world / ending overlay (degrade-not-abort)
+# =========================================================================
+
+
+def _world_with_events(events_block) -> dict:
+    return {
+        "id": "testworld",
+        "name": "Test World",
+        "premise": "a place",
+        "regions": [{"id": "loc-start", "name": "Start"}],
+        "factions": [{"id": "fac-fist", "name": "Flaming Fist", "reputation": 0}],
+        "events": events_block,
+    }
+
+
+def test_seed_world_seeds_events():
+    world = _world_with_events([
+        {
+            "id": "event_raphael",
+            "trigger": "manual",
+            "prompt": "Raphael offers a deal.",
+            "options": [
+                {"label": "Take the bribe", "tag": "CN", "outcome": {"decision_flag": "took_bribe"}},
+                {"label": "Refuse", "tag": "LG"},
+            ],
+        }
+    ])
+    c = content_mod.seed_world(world)
+    assert "event_raphael" in c.events
+    ev = c.events["event_raphael"]
+    assert ev.prompt == "Raphael offers a deal."
+    assert ev.options[0].outcome.decision_flag == "took_bribe"
+    # and it surfaces via present (manual trigger)
+    assert any(e.id == "event_raphael" for e in events_mod.present(c))
+
+
+def test_seed_world_no_events_key_is_noop():
+    world = {"id": "w", "name": "W", "regions": [{"id": "loc-a", "name": "A"}]}
+    c = content_mod.seed_world(world)
+    assert c.events == {}
+
+
+def test_seed_world_degrades_on_malformed_event(capsys):
+    """A malformed event entry is skipped (degrade-not-abort); valid siblings still seed."""
+    world = _world_with_events([
+        {"id": "event_good", "trigger": "manual", "prompt": "ok", "options": [{"label": "A"}]},
+        {"id": "event_bad", "trigger": "manual", "bogus_key": True},  # forbidden extra -> skip
+        "not even an object",  # skip
+    ])
+    c = content_mod.seed_world(world)
+    assert "event_good" in c.events
+    assert "event_bad" not in c.events
+    assert "[content] skipping malformed event" in capsys.readouterr().out
+
+
+def test_seed_world_skips_reputation_at_with_unknown_faction(capsys):
+    world = _world_with_events([
+        {"id": "event_rep", "trigger": "reputation_at", "trigger_faction_id": "ghost",
+         "trigger_threshold": 5, "prompt": "p", "options": [{"label": "A"}]},
+    ])
+    c = content_mod.seed_world(world)
+    assert "event_rep" not in c.events
+    assert "unknown faction" in capsys.readouterr().out
+
+
+def test_seed_world_events_block_accepts_dict_mapping():
+    """The events block may be a dict id->event (like Campaign.events) OR a list."""
+    world = _world_with_events({
+        "event_a": {"id": "event_a", "trigger": "manual", "prompt": "p", "options": [{"label": "A"}]},
+    })
+    c = content_mod.seed_world(world)
+    assert "event_a" in c.events
+
+
+def test_ending_overlay_seeds_events_on_top_of_base():
+    """An ending overlay may ALSO seed Events — the post-state shapes which decisionals stumble
+    into the party. Folded onto whatever the base world already seeded."""
+    c = Campaign(title="W")
+    c.factions["fac-fist"] = Faction(id="fac-fist", name="Flaming Fist", reputation=0)
+    c.events["event_base"] = _event(eid="event_base", trigger="manual")  # a pre-existing base event
+    overlay = {
+        "id": "tyranny", "name": "Tyranny",
+        "events": [
+            {"id": "event_overlay", "trigger": "manual", "prompt": "The Fist demands tribute.",
+             "options": [{"label": "Pay", "outcome": {"decision_flag": "paid_tribute"}}]},
+        ],
+    }
+    content_mod._apply_ending_overlay(c, overlay)  # must NOT raise
+    assert "event_base" in c.events  # base survives
+    assert "event_overlay" in c.events  # overlay folds on top
+    assert c.events["event_overlay"].options[0].outcome.decision_flag == "paid_tribute"
+
+
+def test_ending_overlay_events_degrade_not_abort():
+    """A malformed overlay event is skipped; a valid sibling still applies; no `events` key is
+    a no-op (today's behavior)."""
+    c = Campaign(title="W")
+    overlay = {
+        "id": "ov", "name": "Ov",
+        "events": [
+            {"id": "event_ok", "trigger": "manual", "prompt": "ok", "options": [{"label": "A"}]},
+            {"id": "event_bad", "trigger": "manual", "forbidden": True},  # extra key -> skip
+        ],
+    }
+    content_mod._apply_ending_overlay(c, overlay)  # must NOT raise
+    assert "event_ok" in c.events and "event_bad" not in c.events
+
+    # no events key -> nothing touched
+    c2 = Campaign(title="W2")
+    content_mod._apply_ending_overlay(c2, {"id": "ov2", "name": "Ov2"})
+    assert c2.events == {}

--- a/servers/engine/tests/test_parley.py
+++ b/servers/engine/tests/test_parley.py
@@ -341,12 +341,15 @@ def test_both_tools_registered():
 
 
 def test_no_model_change_old_snapshot_round_trips():
-    # Phases 1-2 add no fields; a minimal legacy snapshot still validates unchanged
-    # (the additive-round-trip contract, trivially satisfied since the model is untouched).
+    # The Event+Parley SCAFFOLD (Phases 1-2) added no model fields; a minimal legacy snapshot
+    # still validates unchanged (the additive-round-trip contract). NOTE: the Quest & Arc engine
+    # Layer 3 later added `Campaign.events` (a dict, mirroring companion_quest_arcs) — still
+    # additive, so a legacy snapshot deserializes with events == {} (see
+    # test_event_parley_layer3.test_old_campaign_snapshot_without_events_deserializes_unchanged).
     payload = {"title": "Legacy", "house_rules": {"difficulty": "standard"}}
     c = Campaign.model_validate(payload)
     assert c.title == "Legacy"
-    assert c.events == [] if hasattr(c, "events") else True  # no events field added in P1-2
+    assert c.events == {}  # Layer 3's events dict defaults empty for a pre-L3 snapshot
 
 
 # =========================================================================

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -2458,6 +2458,74 @@ def _suggested_parley_dc(difficulty: str, house_difficulty: str) -> int:
     return base + shift
 
 
+def _parley_event_trigger_holds(event: dict, snapshot: dict) -> bool:
+    """Snapshot-side mirror of engine `events.trigger_holds` (Quest & Arc engine, Layer 3) —
+    reads ONLY the engine-mutated flags / faction reputation / day already in the snapshot
+    (contract-safe; no fiction). Kept in lock-step with servers/engine/events.py so the viewer
+    surfaces exactly the Events the engine's `present_events` would. An unknown trigger or a
+    malformed operand degrades to "not available" (never raises)."""
+    trig = event.get("trigger") or "manual"
+    if trig == "manual":
+        return True
+    flags = snapshot.get("flags") if isinstance(snapshot.get("flags"), dict) else {}
+    if trig == "flag_set":
+        name = str(event.get("trigger_value") or "")
+        return bool(name) and bool(flags.get(name))
+    if trig == "day_reached":
+        try:
+            day = int(snapshot.get("day", 1))
+            return day >= int(event.get("trigger_threshold", 0))
+        except (TypeError, ValueError):
+            return False
+    if trig == "reputation_at":
+        factions = snapshot.get("factions") if isinstance(snapshot.get("factions"), dict) else {}
+        fac = factions.get(str(event.get("trigger_faction_id") or ""))
+        if not isinstance(fac, dict):
+            return False
+        try:
+            rep = int(fac.get("reputation", 0))
+            target = int(event.get("trigger_threshold", 0))
+        except (TypeError, ValueError):
+            return False
+        return rep <= target if target < 0 else rep >= target
+    return False
+
+
+def _live_parley_event(snapshot: dict) -> dict | None:
+    """The first UNRESOLVED, trigger-met Event in the snapshot (by id, stable), projected to the
+    surface shape ``{id, prompt, anchor_npc_id, options:[{label, tag, skill, dc}], resolve_with}``
+    — or None when no Event is live. Mirrors engine `events.present` (deterministic id order,
+    skips resolved). Read-only; the viewer never resolves — a picked option relays via /move and
+    the DM agent calls `resolve_event`."""
+    raw_events = snapshot.get("events")
+    if not isinstance(raw_events, dict):
+        return None
+    for _eid, ev in sorted(raw_events.items(), key=lambda kv: kv[0]):
+        if not isinstance(ev, dict) or ev.get("resolved"):
+            continue
+        if not _parley_event_trigger_holds(ev, snapshot):
+            continue
+        raw_opts = ev.get("options") if isinstance(ev.get("options"), list) else []
+        options = [
+            {
+                "label": _text(o.get("label")),
+                "tag": _text(o.get("tag")),
+                "skill": _text(o.get("skill")),
+                "dc": int(o.get("dc", 0)) if isinstance(o.get("dc"), (int, float)) else 0,
+            }
+            for o in raw_opts
+            if isinstance(o, dict)
+        ]
+        return {
+            "id": _text(ev.get("id")),
+            "prompt": _text(ev.get("prompt")),
+            "anchor_npc_id": _text(ev.get("anchor_npc_id")),
+            "options": options,
+            "resolve_with": "resolve_event",
+        }
+    return None
+
+
 def build_parley_surface(
     snapshot: dict,
     *,
@@ -2469,7 +2537,14 @@ def build_parley_surface(
     """Project a parley menu for the lead PC: actor + per-skill {skill, modifier,
     suggested_dc} + alignment + free_form. Prefers the engine's own
     generate_parley_options (loaded via models.Campaign) for sheet-correct modifiers;
-    degrades to a snapshot-only computation mirroring it. Closes the UI side of #141."""
+    degrades to a snapshot-only computation mirroring it. Closes the UI side of #141.
+
+    Quest & Arc engine, Layer 3: when a first-class stumble-into Event is live (unresolved +
+    its contract-safe trigger holds in the snapshot), an optional ``event`` block is added —
+    ``{id, prompt, anchor_npc_id, options:[{label, tag, skill, dc}], resolve_with}`` — so the
+    authored Event options surface as the menu slots. The free-form path STAYS (never a closed
+    set, #141 guard); a picked option still relays via /move and the DM agent calls
+    `resolve_event`. No live Event -> no block (today's freeform parley, byte-for-byte)."""
     snapshot = snapshot if isinstance(snapshot, dict) else {}
     actor_id, actor = _lead_pc(snapshot)
     base = {
@@ -2493,6 +2568,12 @@ def build_parley_surface(
         "state_authority": "engine",
         "write_lane": "/move",
     }
+    # Quest & Arc engine, Layer 3: surface a live stumble-into Event's authored options as the
+    # menu slots when one is available. Independent of the actor's sheet (a stumble-into is about
+    # the situation), so it attaches even on the empty/no-actor path. The free-form path stays.
+    live_event = _live_parley_event(snapshot)
+    if live_event is not None:
+        base["event"] = live_event
     if not actor_id or not actor:
         base["source"] = "empty"
         return base

--- a/viewer/tests/test_readmodel_surfaces.py
+++ b/viewer/tests/test_readmodel_surfaces.py
@@ -316,6 +316,65 @@ class ReadModelSurfaceTests(unittest.TestCase):
         self.assertEqual(surface["skills"], [])
         self.assertTrue(surface["free_form"])
 
+    # ── parley: Layer 3 stumble-into Event block ───────────────────────────────
+
+    def test_parley_surface_omits_event_block_without_live_event(self):
+        # the base snapshot has no `events` key -> no event block (today's freeform parley)
+        self._write("camp_marches", _SNAPSHOT)
+        _status, surface = self._get_json("/parley-surface?campaign=camp_marches")
+        self.assertNotIn("event", surface)
+        self.assertTrue(surface["free_form"])
+
+    def test_parley_surface_attaches_live_event_options(self):
+        # a manual-trigger, unresolved Event surfaces its authored options as the menu slots
+        snap = dict(_SNAPSHOT)
+        snap["events"] = {
+            "event_bribe": {
+                "id": "event_bribe", "trigger": "manual", "prompt": "Raphael offers a deal.",
+                "anchor_npc_id": "olwen",
+                "options": [
+                    {"label": "Take the bribe", "tag": "CN", "skill": "deception", "dc": 15},
+                    {"label": "Refuse", "tag": "LG"},
+                ],
+            }
+        }
+        self._write("camp_marches", snap)
+        _status, surface = self._get_json("/parley-surface?campaign=camp_marches")
+        self.assertTrue(surface["free_form"])  # free-form path STAYS (never a closed set)
+        self.assertIn("event", surface)
+        block = surface["event"]
+        self.assertEqual(block["id"], "event_bribe")
+        self.assertEqual(block["prompt"], "Raphael offers a deal.")
+        self.assertEqual(block["resolve_with"], "resolve_event")
+        self.assertEqual(block["options"][0], {"label": "Take the bribe", "tag": "CN", "skill": "deception", "dc": 15})
+        self.assertEqual(block["options"][1], {"label": "Refuse", "tag": "LG", "skill": "", "dc": 0})
+        self.assert_no_private_keys(surface)
+
+    def test_parley_surface_hides_resolved_and_trigger_unmet_events(self):
+        snap = dict(_SNAPSHOT)
+        snap["day"] = 4
+        snap["events"] = {
+            "event_done": {"id": "event_done", "trigger": "manual", "resolved": True,
+                            "prompt": "spent", "options": [{"label": "X"}]},
+            "event_future": {"id": "event_future", "trigger": "day_reached", "trigger_threshold": 99,
+                              "prompt": "not yet", "options": [{"label": "Y"}]},
+        }
+        self._write("camp_marches", snap)
+        _status, surface = self._get_json("/parley-surface?campaign=camp_marches")
+        self.assertNotIn("event", surface)  # nothing live
+
+    def test_parley_surface_event_trigger_reads_snapshot_flag(self):
+        snap = dict(_SNAPSHOT)
+        snap["flags"] = {"met_raphael": True}
+        snap["events"] = {
+            "event_gated": {"id": "event_gated", "trigger": "flag_set", "trigger_value": "met_raphael",
+                             "prompt": "He returns.", "options": [{"label": "Greet"}]},
+        }
+        self._write("camp_marches", snap)
+        _status, surface = self._get_json("/parley-surface?campaign=camp_marches")
+        self.assertIn("event", surface)
+        self.assertEqual(surface["event"]["id"], "event_gated")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Quest & Arc engine Layer 3 (decision-quest-arc-engine.md + the L3 design). First-class Event/ParleyOption/Outcome: present_events (read, gated only on flags/rep/day) + resolve_event (write, applies the chosen Outcome via the existing _apply_structured_effect + 3 extension keys incl. decision_flag; idempotent noop on re-resolve) over a new pure events.py (mirrors consequences/worldsim/companion_arc). Content events seed at seed_world (degrade-not-abort). Parley surface EXTENDED (generate_parley_options event_id + viewer event block) — reuses the #141 free-form relay, no new write route. **L2↔L3 seam verified**: an Outcome.decision_flag flips Campaign.flags → the L2 agenda boosts the betrayal roll (0.30→0.60). Additive (empty events == today; old snapshots round-trip). 41 new + 5 viewer tests; FULL engine suite 1210 + viewer 55 passing single-process. Local-gated.