### PR TITLE
[settlements] Add settlement pressure read model skeleton

### DIFF
--- a/docs/SETTLEMENT_PRESSURE.md
+++ b/docs/SETTLEMENT_PRESSURE.md
@@ -1,0 +1,31 @@
+# Settlement Pressure Skeleton
+
+This first slice adds a clean-room settlement pressure read model for living worlds.
+It is intentionally small: content may seed public civic pressure for a Location,
+optionally naming public faction ids, establishments, and public NPC pressure.
+
+The engine stores settlement rows under `Campaign.strategic_state.settlements`.
+Rows are keyed by `location_id`, so they stay anchored to the existing Location map
+instead of becoming a second travel graph or faction authority.
+
+Seeded fields are:
+
+- `location_id`
+- `settlement_type`
+- `governance`
+- `public_safety`
+- `economy`
+- `unrest`
+- `public_faction_ids`
+- `establishments`
+- `public_npcs`
+- `notes`
+
+`notes` is engine-side DM context only. Atlas projects only player-safe metadata:
+settlement type, governance, public safety, economy, unrest, public faction names,
+establishments, and public NPC pressure. The viewer remains read-only and continues
+to expose `/move` as its only player intent lane.
+
+Malformed settlement rows and rows with unknown location, faction, or NPC references
+are skipped with diagnostics. Existing saves load unchanged because the settlements
+map defaults to empty.

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -32,6 +32,7 @@ from models import (
     Location,
     Quest,
     RegionControl,
+    SettlementPressure,
     StrategicClock,
     WorldGraph,
     WorldGraphEdge,
@@ -999,6 +1000,42 @@ def _seed_world_graph(c: Campaign, world: dict) -> None:
     c.world_graph = graph
 
 
+def _seed_settlement_pressure(c: Campaign, world: dict) -> None:
+    """Seed optional settlement/NPC/faction pressure from world.json.
+
+    Settlement pressure is additive read-model state anchored to existing locations.
+    Unknown references or malformed rows are skipped with diagnostics so an authored
+    block cannot partially bind to the wrong civic surface.
+    """
+    for entry in _as_list_lenient(world, "settlements"):
+        if not isinstance(entry, dict):
+            print("[content] skipping settlement (not an object)")
+            continue
+        try:
+            settlement = SettlementPressure.model_validate(entry)
+        except (ValidationError, ValueError, TypeError):
+            print("[content] skipping malformed settlement")
+            continue
+
+        missing_locations = [settlement.location_id] if settlement.location_id not in c.locations else []
+        missing_factions = [fid for fid in settlement.public_faction_ids if fid and fid not in c.factions]
+        missing_npcs = [npc.npc_id for npc in settlement.public_npcs if npc.npc_id and npc.npc_id not in c.characters]
+        if missing_locations or missing_factions or missing_npcs:
+            print(
+                "[content] skipping settlement "
+                f"{settlement.location_id!r}: unknown refs "
+                f"locations={missing_locations} factions={missing_factions} npcs={missing_npcs}"
+            )
+            continue
+        if settlement.location_id in c.strategic_state.settlements:
+            print(f"[content] skipping settlement {settlement.location_id!r}: duplicate location_id")
+            continue
+
+        settlement.public_faction_ids = _dedupe_strs(fid for fid in settlement.public_faction_ids if fid)
+        settlement.establishments = _dedupe_strs(str(x).strip() for x in settlement.establishments if str(x).strip())
+        c.strategic_state.settlements[settlement.location_id] = settlement
+
+
 def _seed_campaign_backlog(c: Campaign, world: dict) -> None:
     """Seed the PROACTIVE living-world backlog (P0) — the world's own off-screen to-do, so the
     campaign advances when in-fiction time passes (P1 tick_backlog) instead of only reacting to
@@ -1358,6 +1395,8 @@ def seed_world(world: dict, start_at: str = "", ending: str = "") -> Campaign:
         if dossier is not None:
             ch.companion_dossier = dossier
         c.characters[ch.id] = ch
+
+    _seed_settlement_pressure(c, world)
 
     # World facts the DM recalls to stay consistent (indexed into the ledger as lore).
     c.lore = [str(x) for x in (_as_list(world, "history") + _as_list(world, "standing_threads")) if str(x).strip()]

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1193,6 +1193,36 @@ class DowntimeProject(_StrictModel):
         return self
 
 
+class SettlementNpcPressure(_StrictModel):
+    """Player-safe NPC pressure visible at a settlement.
+
+    This is a public signal, not private motivation or scripted dialogue."""
+
+    npc_id: str = ""  # optional ref into Campaign.characters
+    role: str = ""
+    pressure: str = ""
+
+
+class SettlementPressure(_StrictModel):
+    """Clean-room settlement texture anchored to one Location.
+
+    The row stores public-facing civic pressure only. Private notes may be retained for
+    DM tools, but viewer projections must not expose them."""
+
+    location_id: str
+    settlement_type: Literal[
+        "hamlet", "village", "town", "city", "district", "port", "fort", "camp", "outpost", "other"
+    ] = "town"
+    governance: str = ""
+    public_safety: str = ""
+    economy: str = ""
+    unrest: int = Field(0, ge=0, le=100)
+    public_faction_ids: list[str] = Field(default_factory=list)
+    establishments: list[str] = Field(default_factory=list)
+    public_npcs: list[SettlementNpcPressure] = Field(default_factory=list)
+    notes: str = ""
+
+
 class StrategicState(_StrictModel):
     """The campaign's optional strategic board.
 
@@ -1204,6 +1234,7 @@ class StrategicState(_StrictModel):
     assets: dict[str, FactionAsset] = Field(default_factory=dict)  # asset id -> asset
     clocks: dict[str, StrategicClock] = Field(default_factory=dict)  # clock id -> clock
     projects: dict[str, DowntimeProject] = Field(default_factory=dict)  # project id -> project
+    settlements: dict[str, SettlementPressure] = Field(default_factory=dict)  # location_id -> settlement pressure
     last_tick_day: int = 0
 
 

--- a/servers/engine/tests/test_content.py
+++ b/servers/engine/tests/test_content.py
@@ -275,6 +275,93 @@ def test_seed_world_seeds_world_graph_metadata_without_authorizing_travel(capsys
     assert "unknown location" in out
 
 
+def test_seed_world_seeds_settlement_pressure_additively(capsys):
+    world = {
+        "id": "settlement-test",
+        "name": "Settlement Test",
+        "premise": "A compact settlement fixture.",
+        "era": "now",
+        "regions": [
+            {"id": "loc-harbor", "name": "Harbor", "description": "docks", "connections": []},
+            {"id": "loc-hill", "name": "Hill", "description": "watchpost", "connections": []},
+        ],
+        "factions": [
+            {"id": "fac-civic", "name": "Civic League", "description": "wardens", "reputation": 3},
+            {"id": "fac-rivals", "name": "Rival Compact", "description": "claimants", "reputation": -2},
+        ],
+        "npc_roster": [
+            {"id": "npc-reeve", "name": "Harbor Reeve", "role": "magistrate"},
+        ],
+        "history": [],
+        "standing_threads": [],
+        "starting_options": [{"location_id": "loc-harbor", "framing": "Start at the harbor."}],
+        "settlements": [
+            {
+                "location_id": "loc-harbor",
+                "settlement_type": "port",
+                "governance": "council",
+                "public_safety": "strained",
+                "economy": "busy",
+                "unrest": 24,
+                "public_faction_ids": ["fac-civic", "fac-rivals"],
+                "establishments": ["Harbor hall", "Lamp market"],
+                "public_npcs": [
+                    {"npc_id": "npc-reeve", "role": "hears petitions", "pressure": "Backlog of disputes"},
+                ],
+                "notes": "private compromise route",
+            },
+            {
+                "location_id": "loc-missing",
+                "settlement_type": "village",
+            },
+            {
+                "location_id": "loc-hill",
+                "settlement_type": "fort",
+                "public_faction_ids": ["fac-missing"],
+            },
+            {
+                "location_id": "loc-hill",
+                "settlement_type": "fort",
+                "public_npcs": [{"npc_id": "npc-missing", "role": "watch captain"}],
+            },
+            {"location_id": "loc-hill", "settlement_type": "moonbase"},
+        ],
+    }
+
+    c = content.seed_world(world)
+
+    assert set(c.strategic_state.settlements) == {"loc-harbor"}
+    settlement = c.strategic_state.settlements["loc-harbor"]
+    assert settlement.settlement_type == "port"
+    assert settlement.location_id == "loc-harbor"
+    assert settlement.public_faction_ids == ["fac-civic", "fac-rivals"]
+    assert settlement.establishments == ["Harbor hall", "Lamp market"]
+    assert settlement.public_npcs[0].npc_id == "npc-reeve"
+    assert settlement.notes == "private compromise route"
+
+    out = capsys.readouterr().out
+    assert "skipping settlement" in out
+
+
+def test_legacy_strategic_state_loads_without_settlements():
+    c = Campaign.model_validate(
+        {
+            "id": "camp-old",
+            "title": "Old Strategic Save",
+            "strategic_state": {
+                "regions": {},
+                "assets": {},
+                "clocks": {},
+                "projects": {},
+                "last_tick_day": 4,
+            },
+        }
+    )
+
+    assert c.strategic_state.settlements == {}
+    assert c.strategic_state.last_tick_day == 4
+
+
 def test_seed_world_rejects_unknown_start(tmp_path, monkeypatch):
     w = content.load_world_data("sundered-reach")
     with pytest.raises(ValueError, match="not a region"):

--- a/servers/engine/tests/test_engine.py
+++ b/servers/engine/tests/test_engine.py
@@ -29,6 +29,7 @@ def test_campaign_roundtrips_with_empty_strategic_state():
         "assets": {},
         "clocks": {},
         "projects": {},
+        "settlements": {},
         "last_tick_day": 0,
     }
 

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1977,6 +1977,54 @@ def _atlas_strategic(snapshot: dict, visible_ids: set[str]) -> tuple[list[dict],
     return clocks[:12], projects[:12], regions[:12], last_tick_day
 
 
+def _atlas_settlements(snapshot: dict, visible_ids: set[str]) -> list[dict]:
+    st = snapshot.get("strategic_state")
+    if not isinstance(st, dict):
+        return []
+    raw = st.get("settlements")
+    if not isinstance(raw, dict):
+        return []
+
+    out: list[dict] = []
+    for sid, row in raw.items():
+        if not isinstance(row, dict):
+            continue
+        loc_id = _text(row.get("location_id"), _text(sid))
+        if loc_id not in visible_ids:
+            continue
+        faction_ids = row.get("public_faction_ids")
+        faction_ids = faction_ids if isinstance(faction_ids, list) else []
+        establishments = row.get("establishments")
+        establishments = establishments if isinstance(establishments, list) else []
+        public_npcs = row.get("public_npcs")
+        public_npcs = public_npcs if isinstance(public_npcs, list) else []
+        out.append({
+            "location_id": loc_id,
+            "settlement_type": _text(row.get("settlement_type"), "town"),
+            "governance": _text(row.get("governance")),
+            "public_safety": _text(row.get("public_safety")),
+            "economy": _text(row.get("economy")),
+            "unrest": int(_num(row.get("unrest")) or 0),
+            "public_factions": [
+                _atlas_faction_name(snapshot, _text(fid))
+                for fid in faction_ids
+                if _text(fid)
+            ],
+            "establishments": [_text(name) for name in establishments if _text(name)][:8],
+            "public_npcs": [
+                {
+                    "npc_id": _text(npc.get("npc_id")),
+                    "role": _text(npc.get("role")),
+                    "pressure": _text(npc.get("pressure")),
+                }
+                for npc in public_npcs
+                if isinstance(npc, dict) and (_text(npc.get("role")) or _text(npc.get("pressure")))
+            ][:8],
+        })
+    out.sort(key=lambda s: (s["location_id"], s["settlement_type"]))
+    return out[:12]
+
+
 def build_atlas_surface(
     snapshot: dict,
     *,
@@ -1992,6 +2040,7 @@ def build_atlas_surface(
     current = next((loc for loc in locations if loc["id"] == current_id), None)
     travel_options = _atlas_travel_options(snapshot, locations, live=live, is_live_view=is_live_view)
     clocks, projects, regions, last_tick_day = _atlas_strategic(snapshot, visible_ids)
+    settlements = _atlas_settlements(snapshot, visible_ids)
     current_tags = set(current.get("tags", [])) if current else set()
     camp_available = bool(current and current_tags.intersection({"rest", "town", "safe", "camp"}))
     return {
@@ -2007,6 +2056,7 @@ def build_atlas_surface(
         "strategic_clocks": clocks,
         "downtime_projects": projects,
         "region_control": regions,
+        "settlements": settlements,
         "camp_available": camp_available,
         "last_world_tick": last_tick_day,
         "live": bool(live),

--- a/viewer/tests/test_atlas_surface.py
+++ b/viewer/tests/test_atlas_surface.py
@@ -69,6 +69,27 @@ class AtlasSurfaceTests(unittest.TestCase):
             },
             "strategic_state": {
                 "last_tick_day": 11,
+                "settlements": {
+                    "gate": {
+                        "location_id": "gate",
+                        "settlement_type": "district",
+                        "governance": "watch council",
+                        "public_safety": "tense",
+                        "economy": "market day",
+                        "unrest": 18,
+                        "public_faction_ids": ["harpers"],
+                        "establishments": ["Lantern Hall"],
+                        "public_npcs": [
+                            {"npc_id": "reeve", "role": "gate reeve", "pressure": "Petitions are delayed"}
+                        ],
+                        "notes": "private settlement agenda",
+                    },
+                    "hidden-crypt": {
+                        "location_id": "hidden-crypt",
+                        "settlement_type": "hideout",
+                        "notes": "private hidden settlement",
+                    },
+                },
                 "regions": {
                     "gate": {
                         "location_id": "gate",
@@ -130,6 +151,11 @@ class AtlasSurfaceTests(unittest.TestCase):
         self.assertTrue(surface["strategic_clocks"][0]["urgent"])
         self.assertEqual(surface["downtime_projects"][0]["title"], "Repair Gate Winch")
         self.assertEqual(surface["region_control"][0]["controller"], "Harpers")
+        self.assertEqual(surface["settlements"][0]["location_id"], "gate")
+        self.assertEqual(surface["settlements"][0]["settlement_type"], "district")
+        self.assertEqual(surface["settlements"][0]["public_factions"], ["Harpers"])
+        self.assertEqual(surface["settlements"][0]["establishments"], ["Lantern Hall"])
+        self.assertEqual(surface["settlements"][0]["public_npcs"][0]["role"], "gate reeve")
 
         encoded = json.dumps(surface)
         for forbidden in (
@@ -143,6 +169,8 @@ class AtlasSurfaceTests(unittest.TestCase):
             "clock note",
             "project note",
             "region note",
+            "settlement agenda",
+            "hideout",
         ):
             self.assertNotIn(forbidden, encoded)
         self.assert_no_private_keys(surface)


### PR DESCRIPTION
# Draft: settlement pressure skeleton for Atlas

Refs #178.

## Summary

This draft adds a minimal, clean-room settlement pressure skeleton tied to the existing Location, Faction, Character, and StrategicState surfaces.

- adds `SettlementPressure` and `SettlementNpcPressure` as additive StrategicState children
- seeds optional top-level `settlements` blocks from world data after factions and roster NPCs exist
- skips malformed settlement rows and unknown location/faction/NPC references with diagnostics
- projects only player-safe settlement metadata into Atlas
- documents the state-authority boundary for this first settlement slice

## State Authority

Settlement pressure is engine-owned state. The viewer only reads the Atlas projection and still exposes `/move` as the only player intent lane. It does not write settlement state, faction influence, unrest, NPC pressure, or strategic clocks.

## Clean-Room Boundary

This PR does not import Eigengrau/OpenDnD prose, names, tables, generator code, or runtime dependencies. The model uses generic civic dimensions only: settlement type, governance, public safety, economy, unrest, public faction ids, establishments, and public NPC pressure.

## Player-Safe Projection

Atlas receives:

- settlement type
- governance
- public safety
- economy
- unrest
- public faction names
- establishments
- public NPC pressure rows

Atlas intentionally omits `notes`, DM/private fields, hidden locations, private agendas, and source/provenance data.

## Validation

Ran locally from `/Volumes/LEXAR/repos/ClawDnD-settlement-texture`:

```bash
uv run --directory servers/engine --group dev pytest -q tests/test_engine.py::test_campaign_roundtrips_with_empty_strategic_state tests/test_content.py::test_seed_world_seeds_settlement_pressure_additively tests/test_content.py::test_legacy_strategic_state_loads_without_settlements
python3 -m unittest viewer.tests.test_atlas_surface -q
python3 -m py_compile viewer/server.py
uv run --directory servers/engine python -m py_compile models.py content.py
python3 scripts/license_check.py
git diff --check
```

All passed before opening the draft PR.

## Follow-Ups Intentionally Not In This Draft

- worldsim/tick advancement of settlement pressure
- generated defaults from location tags
- Relations/Codex settlement projections
- richer local faction influence mechanics
