### PR TITLE
Draft: authored monster metadata and bestiary projection skeleton

### DIFF
--- a/docs/MONSTER_AUTHORING.md
+++ b/docs/MONSTER_AUTHORING.md
@@ -1,0 +1,31 @@
+# Monster Authoring Skeleton
+
+ClawDnD keeps bundled SRD creatures canonical. Native authored monster packs are
+additive only: they can introduce net-new monster names, but they cannot override
+or shadow an SRD creature.
+
+Future authored packs live under `data/bestiary/authored/<pack-id>/pack.json`.
+Each pack manifest carries:
+
+- `id`
+- `title`
+- `license`
+- `source`
+- `provenance`
+- `monsters`
+
+Each monster record must also carry its own explicit `license`, `source`, and
+`provenance` metadata. Pack-level metadata is not enough for a committed monster
+record, because records may later be copied, projected, reviewed, or exported
+independently.
+
+The initial skeleton intentionally commits no private, OGL-only, trade-dress, or
+unreviewed monster records. Tests use temporary authored packs to prove the
+contract:
+
+- missing record metadata excludes the monster from the runtime index
+- a same-name authored record cannot replace an SRD creature
+- the player bestiary projection exposes only safe preview fields plus metadata
+
+The player-safe projection is read-only and omits HP, AC, ability scores, action
+descriptions, tactical notes, and private authoring fields.

--- a/scripts/license_check.py
+++ b/scripts/license_check.py
@@ -66,6 +66,26 @@ def _check_ingested_attribution(tracked: list[str]) -> list[str]:
     return errors
 
 
+def _check_authored_bestiary() -> list[str]:
+    """Validate native authored monster packs without importing or committing content."""
+    authored_root = ROOT / "data" / "bestiary" / "authored"
+    if not authored_root.exists():
+        return []
+    engine_dir = ROOT / "servers" / "engine"
+    sys.path.insert(0, str(engine_dir))
+    try:
+        import bestiary  # type: ignore
+    except Exception as exc:
+        return [f"authored bestiary validation unavailable: {exc}"]
+    try:
+        bestiary._authored_entries.cache_clear()
+        bestiary._index.cache_clear()
+        return [f"authored bestiary: {e}" for e in bestiary.authored_validation_errors()]
+    finally:
+        bestiary._authored_entries.cache_clear()
+        bestiary._index.cache_clear()
+
+
 def tracked_files() -> list[str]:
     out = subprocess.run(
         ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True
@@ -97,6 +117,7 @@ def main() -> int:
 
     # Ingested (wiki-derived) records/pages must each carry per-source attribution.
     errors.extend(_check_ingested_attribution(tracked))
+    errors.extend(_check_authored_bestiary())
 
     if errors:
         print("LICENSE CHECK FAILED:")

--- a/servers/engine/bestiary.py
+++ b/servers/engine/bestiary.py
@@ -25,8 +25,11 @@ import encounter
 
 _ROOT = Path(__file__).resolve().parents[2] / "data" / "srd"
 _PRIMARY = _ROOT / "srd524"  # canonical SRD 5.2 — always wins a name collision
+_AUTHORED_ROOT = Path(__file__).resolve().parents[2] / "data" / "bestiary" / "authored"
 
 _ABILITIES = ("strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma")
+_ABILITY_SHORTS = ("str", "dex", "con", "int", "wis", "cha")
+_CONTENT_METADATA = ("license", "source", "provenance")
 
 
 def _dirs() -> list:
@@ -74,8 +77,142 @@ def _index() -> dict[str, dict]:
             if name:
                 key = name.lower()
                 if key not in out:  # FIRST-WINS — earlier dir (srd524) takes precedence
-                    out[key] = {"src": d.name, "row": c}
+                    out[key] = {"src": d.name, "row": c, "content_origin": "srd"}
+    for key, entry in _authored_entries()[0].items():
+        if key not in out:  # authored monsters fill gaps, never shadow SRD names
+            out[key] = entry
     return out
+
+
+def _authored_pack_dirs() -> list[Path]:
+    """Native authored monster pack dirs.
+
+    These are intentionally separate from ``data/srd`` fixture packs: authored records
+    need explicit license/source/provenance metadata and never participate in SRD
+    fixture precedence. A pack is a directory with one ``pack.json`` manifest.
+    """
+    if not _AUTHORED_ROOT.is_dir():
+        return []
+    return sorted(p for p in _AUTHORED_ROOT.iterdir() if p.is_dir() and (p / "pack.json").exists())
+
+
+def _read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _metadata_errors(obj: dict, label: str) -> list[str]:
+    errors: list[str] = []
+    for field in _CONTENT_METADATA:
+        value = obj.get(field)
+        if not isinstance(value, dict) or not any(str(v).strip() for v in value.values()):
+            errors.append(f"{label} missing explicit {field} metadata")
+    return errors
+
+
+def _authored_abilities(raw: object) -> dict[str, int]:
+    data = raw if isinstance(raw, dict) else {}
+    out: dict[str, int] = {}
+    for short, full in zip(_ABILITY_SHORTS, _ABILITIES):
+        out[short] = int(data.get(short, data.get(full, 10)) or 10)
+    return out
+
+
+def _authored_actions(raw: object) -> list[dict]:
+    if not isinstance(raw, list):
+        return []
+    out: list[dict] = []
+    for row in raw:
+        if not isinstance(row, dict):
+            continue
+        name = str(row.get("name", "")).strip()
+        desc = str(row.get("desc", row.get("description", ""))).strip()
+        if name:
+            out.append({"name": name, "desc": desc, "action_type": str(row.get("action_type", "ACTION"))})
+    return out
+
+
+@functools.lru_cache(maxsize=None)
+def _authored_entries() -> tuple[dict[str, dict], tuple[str, ...]]:
+    """Load valid native authored monsters and collect validation errors.
+
+    The loader is intentionally strict about metadata and conservative about name
+    collisions. Invalid records are excluded from the runtime index; collisions against
+    SRD names are reported and skipped so authored packs cannot silently replace a
+    canonical SRD creature.
+    """
+    entries: dict[str, dict] = {}
+    errors: list[str] = []
+    srd_names = {
+        c.get("fields", {}).get("name", "").strip().lower()
+        for d in _dirs()
+        for c in _read_json(d / "Creature.json")
+        if c.get("fields", {}).get("name")
+    }
+    for pack_dir in _authored_pack_dirs():
+        pack_path = pack_dir / "pack.json"
+        try:
+            pack = _read_json(pack_path)
+        except (OSError, json.JSONDecodeError) as exc:
+            errors.append(f"{pack_path}: unreadable authored monster pack: {exc}")
+            continue
+        if not isinstance(pack, dict):
+            errors.append(f"{pack_path}: authored monster pack must be a JSON object")
+            continue
+        pack_label = f"pack {pack.get('id') or pack_dir.name}"
+        errors.extend(_metadata_errors(pack, pack_label))
+        monsters = pack.get("monsters")
+        if not isinstance(monsters, list):
+            errors.append(f"{pack_label} missing monsters list")
+            continue
+        for row in monsters:
+            if not isinstance(row, dict):
+                errors.append(f"{pack_label} has non-object monster record")
+                continue
+            name = str(row.get("name", "")).strip()
+            record_label = f"{pack_label} monster {name or '<unnamed>'}"
+            record_errors = _metadata_errors(row, record_label)
+            if not name:
+                record_errors.append(f"{record_label} missing name")
+            key = name.lower()
+            if key in srd_names:
+                record_errors.append(f"{record_label} overrides SRD creature {name!r}; authored packs may only add net-new names")
+            if key in entries:
+                record_errors.append(f"{record_label} duplicates authored creature {name!r}")
+            if record_errors:
+                errors.extend(record_errors)
+                continue
+            fields = {
+                "name": name,
+                "size": str(row.get("size", "")),
+                "type": str(row.get("type", "")),
+                "armor_class": int(row.get("armor_class", row.get("ac", 10)) or 10),
+                "hit_points": int(row.get("hit_points", row.get("hp", 1)) or 1),
+                "hit_dice": str(row.get("hit_dice", "")),
+                "abilities": _authored_abilities(row.get("abilities")),
+                "challenge_rating": _norm_cr(row.get("challenge_rating", row.get("cr", "0"))),
+                "experience_points": int(row.get("experience_points", row.get("xp", 0)) or 0),
+                "proficiency_bonus": int(row.get("proficiency_bonus", 2) or 2),
+                "initiative_bonus": int(row.get("initiative_bonus", 0) or 0),
+                "damage_resistances": _as_list(row.get("damage_resistances")),
+                "damage_immunities": _as_list(row.get("damage_immunities")),
+                "damage_vulnerabilities": _as_list(row.get("damage_vulnerabilities")),
+                "condition_immunities": _as_list(row.get("condition_immunities")),
+                "actions": _authored_actions(row.get("actions")),
+            }
+            repo_root = Path(__file__).resolve().parents[2]
+            try:
+                src = str(pack_path.relative_to(repo_root))
+            except ValueError:
+                src = str(pack_path)
+            entries[key] = {
+                "src": src,
+                "content_origin": "authored",
+                "fields": fields,
+                "license": row["license"],
+                "source": row["source"],
+                "provenance": row["provenance"],
+            }
+    return entries, tuple(errors)
 
 
 def _norm_cr(cr) -> str:
@@ -102,6 +239,49 @@ def _as_list(value) -> list[str]:
     return [p.strip() for p in str(value).replace(";", ",").split(",") if p.strip()]
 
 
+def authored_validation_errors() -> list[str]:
+    """Validation errors for committed/native authored monster packs.
+
+    Read-only helper for CI, PR review, and future authoring UI work. Invalid authored
+    records are excluded from the bestiary index, so this can be surfaced without
+    mutating combat state or allowing unsafe content through.
+    """
+    return list(_authored_entries()[1])
+
+
+def _stat_block_from_authored(entry: dict, fallback_name: str) -> dict:
+    f = entry["fields"]
+    cr = _norm_cr(f.get("challenge_rating"))
+    xp = int(f.get("experience_points") or 0)
+    if xp == 0:
+        try:
+            xp = encounter.xp_for_cr(cr)
+        except ValueError:
+            xp = 0
+    return {
+        "name": f.get("name", fallback_name),
+        "size": f.get("size", ""),
+        "type": f.get("type", ""),
+        "ac": int(f.get("armor_class") or 10),
+        "hp": int(f.get("hit_points") or 1),
+        "hit_dice": f.get("hit_dice", ""),
+        "abilities": dict(f.get("abilities") or {}),
+        "cr": cr,
+        "xp": xp,
+        "proficiency_bonus": int(f.get("proficiency_bonus") or 2),
+        "initiative_bonus": int(f.get("initiative_bonus") or 0),
+        "damage_resistances": _as_list(f.get("damage_resistances")),
+        "damage_immunities": _as_list(f.get("damage_immunities")),
+        "damage_vulnerabilities": _as_list(f.get("damage_vulnerabilities")),
+        "condition_immunities": _as_list(f.get("condition_immunities")),
+        "actions": list(f.get("actions") or []),
+        "content_origin": "authored",
+        "license": entry["license"],
+        "source": entry["source"],
+        "provenance": entry["provenance"],
+    }
+
+
 def stat_block(name: str) -> Optional[dict]:
     """A flat, engine-shaped stat block for a creature by (case-insensitive) name,
     or None if unknown. Includes abilities, AC, HP, CR/XP, the damage
@@ -110,6 +290,8 @@ def stat_block(name: str) -> Optional[dict]:
     entry = _index().get(name.strip().lower())
     if entry is None:
         return None
+    if entry.get("content_origin") == "authored":
+        return _stat_block_from_authored(entry, name)
     row = entry["row"]
     f = row["fields"]
     abilities = {
@@ -141,14 +323,56 @@ def stat_block(name: str) -> Optional[dict]:
         "damage_vulnerabilities": _as_list(f.get("damage_vulnerabilities")),
         "condition_immunities": _as_list(f.get("condition_immunities")),
         "actions": _actions_by_source_parent().get((entry["src"], row.get("pk")), []),
+        "content_origin": "srd",
     }
+
+
+def player_bestiary_preview(name: str) -> Optional[dict]:
+    """Player-safe codex preview for a known creature.
+
+    This is deliberately narrower than ``stat_block``: no HP, AC, ability scores,
+    tactical notes, or action text. It is safe for viewer/browser projection and is
+    read-only over the bestiary index.
+    """
+    sb = stat_block(name)
+    if sb is None:
+        return None
+    preview = {
+        "name": sb["name"],
+        "size": sb.get("size", ""),
+        "type": sb.get("type", ""),
+        "cr": sb.get("cr", "0"),
+        "content_origin": sb.get("content_origin", "srd"),
+        "known_actions": [str(a.get("name", "")).strip() for a in sb.get("actions", []) if a.get("name")][:5],
+    }
+    if sb.get("content_origin") == "authored":
+        preview["source"] = sb["source"]
+        preview["license"] = sb["license"]
+        preview["provenance"] = sb["provenance"]
+    return preview
+
+
+def player_bestiary(query: str = "", limit: int = 20) -> dict:
+    """Read-only player-facing bestiary/codex projection."""
+    n = max(1, min(int(limit), 50))
+    names = find(query, n)
+    return {
+        "items": [p for name in names if (p := player_bestiary_preview(name)) is not None],
+        "validation_errors": authored_validation_errors(),
+    }
+
+
+def _entry_name(entry: dict) -> str:
+    if entry.get("content_origin") == "authored":
+        return entry["fields"]["name"]
+    return entry["row"]["fields"]["name"]
 
 
 def find(query: str, limit: int = 10) -> list[str]:
     """Creature names matching `query` (substring, case-insensitive), sorted. Deduped
     against the index (first-wins), so a pack's same-named creature never appears twice."""
     q = query.strip().lower()
-    names = sorted(e["row"]["fields"]["name"] for e in _index().values())
+    names = sorted(_entry_name(e) for e in _index().values())
     if not q:
         return names[:limit]
     return [n for n in names if q in n.lower()][:limit]
@@ -164,7 +388,7 @@ def _token_prefix_matches(name: str) -> list[str]:
         return []
     out = set()
     for e in _index().values():
-        cand = e["row"]["fields"]["name"]
+        cand = _entry_name(e)
         c_tokens = cand.lower().split()
         used = [False] * len(c_tokens)
         ok = True
@@ -201,13 +425,13 @@ def resolve(name: str) -> Optional[str]:
     key = name.strip().lower()
     idx = _index()
     if key in idx:
-        return idx[key]["row"]["fields"]["name"]
+        return _entry_name(idx[key])
     alias = _ALIASES.get(key)
     if alias and alias.strip().lower() in idx:
-        return idx[alias.strip().lower()]["row"]["fields"]["name"]
+        return _entry_name(idx[alias.strip().lower()])
     warrior = f"{key} warrior"
     if warrior in idx:
-        return idx[warrior]["row"]["fields"]["name"]
+        return _entry_name(idx[warrior])
     matches = find(name)
     if len(matches) == 1:
         return matches[0]

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1635,6 +1635,25 @@ def spawn_monster(campaign_id: str, name: str, count: int = 1) -> dict:
     }
 
 
+@mcp.tool()
+def list_bestiary(query: str = "", limit: int = 20, player_safe: bool = True) -> dict:
+    """Read-only bestiary/codex lookup.
+
+    Defaults to the player-safe projection: identity, type/size/CR, action names,
+    and authored-content license/source/provenance metadata only. It never mutates
+    bestiary packs, campaign state, or combat state. Pass ``player_safe=False`` only
+    for a DM-side preview that may include mechanical stat blocks.
+    """
+    n = max(1, min(int(limit), 50))
+    if player_safe:
+        return bestiary.player_bestiary(query, n)
+    names = bestiary.find(query, n)
+    return {
+        "items": [sb for name in names if (sb := bestiary.stat_block(name)) is not None],
+        "validation_errors": bestiary.authored_validation_errors(),
+    }
+
+
 def _spawn_creature_chars(c: Campaign, canonical: str, count: int, location_id) -> list[dict]:
     """Add `count` combat-ready monster Characters for a canonical bestiary name to the
     campaign (mutates; caller holds the lock + saves). Mirrors `spawn_monster`'s

--- a/servers/engine/tests/test_bestiary.py
+++ b/servers/engine/tests/test_bestiary.py
@@ -68,6 +68,135 @@ def test_pack_precedence_srd_wins_and_pack_adds(tmp_path, monkeypatch):
         bestiary._actions_by_source_parent.cache_clear()
 
 
+def _authored_pack(tmp_path, monsters):
+    import json as _json
+
+    pack = tmp_path / "mythic-workshop"
+    pack.mkdir()
+    (pack / "pack.json").write_text(_json.dumps({
+        "id": "mythic-workshop",
+        "title": "Mythic Workshop Test Pack",
+        "license": {"name": "CC-BY-4.0"},
+        "source": {"title": "Unit test fixture"},
+        "provenance": {"author": "ClawDnD tests", "method": "hand-authored"},
+        "monsters": monsters,
+    }))
+    return tmp_path
+
+
+def test_authored_monster_pack_requires_record_metadata(tmp_path, monkeypatch):
+    root = _authored_pack(tmp_path, [{
+        "name": "Lantern Mireling",
+        "armor_class": 13,
+        "hit_points": 19,
+        "abilities": {"str": 8, "dex": 14, "con": 12, "int": 10, "wis": 13, "cha": 9},
+        "license": {"name": "CC-BY-4.0"},
+        "source": {"title": "Unit test fixture"},
+        # missing provenance on the record: pack metadata alone is not enough
+    }])
+    monkeypatch.setattr(bestiary, "_AUTHORED_ROOT", root)
+    bestiary._authored_entries.cache_clear()
+    try:
+        errors = bestiary.authored_validation_errors()
+        assert any("Lantern Mireling" in e and "provenance" in e for e in errors)
+        assert bestiary.stat_block("Lantern Mireling") is None
+    finally:
+        bestiary._authored_entries.cache_clear()
+        bestiary._index.cache_clear()
+
+
+def test_authored_monster_pack_adds_metadata_but_never_overrides_srd(tmp_path, monkeypatch):
+    root = _authored_pack(tmp_path, [
+        {
+            "name": "Wolf",
+            "armor_class": 99,
+            "hit_points": 999,
+            "abilities": {"str": 10, "dex": 10, "con": 10, "int": 10, "wis": 10, "cha": 10},
+            "license": {"name": "CC-BY-4.0"},
+            "source": {"title": "Unit test fixture"},
+            "provenance": {"author": "ClawDnD tests", "method": "hand-authored"},
+        },
+        {
+            "name": "Lantern Mireling",
+            "size": "Small",
+            "type": "fey",
+            "armor_class": 13,
+            "hit_points": 19,
+            "hit_dice": "3d6+9",
+            "challenge_rating": "1/2",
+            "experience_points": 100,
+            "abilities": {"str": 8, "dex": 14, "con": 12, "int": 10, "wis": 13, "cha": 9},
+            "actions": [{"name": "Glimmer Claw", "desc": "A player-safe action summary."}],
+            "license": {"name": "CC-BY-4.0"},
+            "source": {"title": "Unit test fixture"},
+            "provenance": {"author": "ClawDnD tests", "method": "hand-authored"},
+        },
+    ])
+    monkeypatch.setattr(bestiary, "_AUTHORED_ROOT", root)
+    bestiary._authored_entries.cache_clear()
+    bestiary._index.cache_clear()
+    try:
+        assert bestiary.stat_block("Wolf")["hp"] == 11
+        errors = bestiary.authored_validation_errors()
+        assert any("Wolf" in e and "overrides SRD" in e for e in errors)
+
+        mireling = bestiary.stat_block("Lantern Mireling")
+        assert mireling["content_origin"] == "authored"
+        assert mireling["license"]["name"] == "CC-BY-4.0"
+        assert mireling["source"]["title"] == "Unit test fixture"
+        assert mireling["provenance"]["method"] == "hand-authored"
+        assert "Lantern Mireling" in bestiary.find("mire")
+    finally:
+        bestiary._authored_entries.cache_clear()
+        bestiary._index.cache_clear()
+
+
+def test_player_bestiary_projection_is_safe_and_read_only(tmp_path, monkeypatch):
+    root = _authored_pack(tmp_path, [{
+        "name": "Lantern Mireling",
+        "size": "Small",
+        "type": "fey",
+        "armor_class": 13,
+        "hit_points": 19,
+        "challenge_rating": "1/2",
+        "abilities": {"str": 8, "dex": 14, "con": 12, "int": 10, "wis": 13, "cha": 9},
+        "actions": [{"name": "Glimmer Claw", "desc": "Private tactics stay out of projection."}],
+        "private_notes": "ambushes wounded PCs",
+        "license": {"name": "CC-BY-4.0"},
+        "source": {"title": "Unit test fixture"},
+        "provenance": {"author": "ClawDnD tests", "method": "hand-authored"},
+    }])
+    monkeypatch.setattr(bestiary, "_AUTHORED_ROOT", root)
+    bestiary._authored_entries.cache_clear()
+    bestiary._index.cache_clear()
+    try:
+        preview = bestiary.player_bestiary_preview("Lantern Mireling")
+        assert preview == {
+            "name": "Lantern Mireling",
+            "size": "Small",
+            "type": "fey",
+            "cr": "1/2",
+            "content_origin": "authored",
+            "source": {"title": "Unit test fixture"},
+            "license": {"name": "CC-BY-4.0"},
+            "provenance": {"author": "ClawDnD tests", "method": "hand-authored"},
+            "known_actions": ["Glimmer Claw"],
+        }
+        assert "hp" not in preview and "ac" not in preview
+        assert "private" not in repr(preview).lower()
+    finally:
+        bestiary._authored_entries.cache_clear()
+        bestiary._index.cache_clear()
+
+
+def test_server_list_bestiary_defaults_to_player_safe_projection():
+    out = server.list_bestiary("wolf", limit=20)
+    wolf = next(item for item in out["items"] if item["name"] == "Wolf")
+    assert wolf["content_origin"] == "srd"
+    assert "known_actions" in wolf
+    assert "hp" not in wolf and "ac" not in wolf and "abilities" not in wolf
+
+
 # --- damage resistance / immunity / vulnerability --------------------------
 
 

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -412,6 +412,22 @@ def build_options_response(campaign_id: Optional[str], character_id: Optional[st
     }
 
 
+def build_bestiary_response(query: str = "", limit: int = 20) -> dict:
+    """GET /bestiary-surface read model.
+
+    Bridges to the engine-owned player-safe bestiary projection. It exposes no write
+    path and does not import or call any campaign/combat mutation helper.
+    """
+    engine = _load_engine_server()
+    if engine is None:
+        return {
+            "items": [],
+            "validation_errors": [],
+            "error": f"engine import failed: {_ENGINE_IMPORT_ERROR}",
+        }
+    return engine.bestiary.player_bestiary(query, limit)
+
+
 def _display_location(snapshot: dict) -> str:
     loc_id = snapshot.get("current_location_id")
     locs = snapshot.get("locations")
@@ -3967,6 +3983,17 @@ class _Handler(BaseHTTPRequestHandler):
             cid = (qs.get("campaign") or [""])[0] or self._view_campaign(qs)
             character_id = (qs.get("character") or [""])[0]
             self._json(build_options_response(cid, character_id))
+        elif route == "/bestiary-surface":
+            # Read-only player-safe bestiary/codex projection. No campaign or combat
+            # mutation route is exposed here; the engine returns only public preview fields.
+            qs = parse_qs(parsed.query)
+            query = (qs.get("q") or qs.get("query") or [""])[0]
+            raw_limit = (qs.get("limit") or ["20"])[0]
+            try:
+                limit = int(raw_limit)
+            except (TypeError, ValueError):
+                limit = 20
+            self._json(build_bestiary_response(query, limit))
         elif route in ("/monitor", "/monitor.html"):
             # The MULTI-CAMPAIGN monitor: one live page showing EVERY campaign across the play
             # store + all parallel QA runs (watch the stress tests + any live game in one place).


### PR DESCRIPTION
# Draft: monster authoring metadata and bestiary projection skeleton

Refs #177.

## Summary

This draft opens the first native authored-monster lane without importing a full
monster-maker app or any monster data.

- adds a native `data/bestiary/authored/<pack-id>/pack.json` loader skeleton
- requires explicit `license`, `source`, and `provenance` metadata on each pack
  and each monster record
- keeps SRD creatures canonical: authored records with same-name SRD collisions
  are validation errors and are excluded from the runtime index
- adds a player-safe bestiary/codex projection that omits HP, AC, ability scores,
  action descriptions, tactics, and private fields
- exposes a read-only engine `list_bestiary` helper and viewer
  `/bestiary-surface` JSON bridge
- wires the license/content gate to fail future committed authored packs with
  missing metadata or SRD override attempts
- documents the authoring contract in `docs/MONSTER_AUTHORING.md`

## Clean-Room Boundary

This PR commits no private monsters, OGL/private content, trade-dress assets,
LaTeX templates, 5e-monster-maker runtime, or unreviewed monster records. Tests
use temporary pack fixtures only.

## State Authority

Authored packs are engine-side read-model content. The viewer endpoint is
read-only and only projects public preview fields; it does not mutate bestiary
packs, campaign snapshots, combat state, XP, or encounters.

## Validation

Ran locally from `/Volumes/LEXAR/repos/ClawDnD-monster-authoring`:

```bash
uv run --directory servers/engine --group dev pytest -q tests/test_bestiary.py
python3 -m py_compile servers/engine/bestiary.py servers/engine/server.py viewer/server.py scripts/license_check.py
python3 scripts/license_check.py
git diff --check
```

All passed before opening the draft PR.

## Follow-Ups Intentionally Not In This Draft

- authored monster save/edit UI
- `.5emm.json` import or `.tex` export
- CR estimation
- spawn integration for authored monsters beyond bestiary stat-block availability
- OpenWorlds visual bestiary screen
- committed original monster packs
