### PR TITLE
Draft: Combat Command Center read model

### DIFF
--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -78,6 +78,7 @@ function ScreenCombat({ onNavigate, state }) {
   const zones = Array.isArray(surface?.zones) ? surface.zones : [];
   const battleLog = Array.isArray(surface?.battleLog) ? surface.battleLog : [];
   const encounter = surface?.encounter || { active: false, name: "No active encounter" };
+  const commandCenter = surface?.commandCenter || {};
   const economy = surface?.actionEconomy || {};
   const canAct = Boolean(surface?.can_act);
   const selected =
@@ -189,7 +190,7 @@ function ScreenCombat({ onNavigate, state }) {
 
         <Panel framed style={{ padding: 14, flex: "0 0 auto" }}>
           <div style={{ display: "grid", gridTemplateColumns: "minmax(180px, 220px) 1fr", gap: 16, alignItems: "center" }}>
-            <CombatantSummary token={selected} economy={economy} />
+            <CombatantSummary token={selected} economy={economy} commandCenter={commandCenter} />
             <div style={{ display: "grid", gridTemplateColumns: "repeat(7, minmax(0, 1fr))", gap: 6 }}>
               {actionTile("move", "↗", "Move")}
               {actionTile("attack", "⚔", "Attack")}
@@ -222,6 +223,11 @@ function ScreenCombat({ onNavigate, state }) {
           </div>
         </Panel>
 
+        <Panel framed style={{ padding: 18 }}>
+          <SectionTitle>Command</SectionTitle>
+          <CommandCenterPanel commandCenter={commandCenter} selectedId={selected?.id} onSelect={setSelectedToken} />
+        </Panel>
+
         <Panel framed style={{ padding: 18, flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}>
           <SectionTitle>Battle Log</SectionTitle>
           <div style={{ flex: 1, overflow: "auto", display: "flex", flexDirection: "column", gap: 6 }}>
@@ -235,7 +241,7 @@ function ScreenCombat({ onNavigate, state }) {
   );
 }
 
-function CombatantSummary({ token, economy }) {
+function CombatantSummary({ token, economy, commandCenter }) {
   if (!token) {
     return (
       <div style={{ padding: "8px 12px", background: "rgba(176,141,87,0.08)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.3)" }}>
@@ -246,6 +252,9 @@ function CombatantSummary({ token, economy }) {
   }
   const hpText = token.hpKnown ? `HP ${token.hp}/${token.hpMax}` : token.health || "unknown";
   const acText = token.ac ? ` · AC ${token.ac}` : "";
+  const cues = Array.isArray(commandCenter?.cues)
+    ? commandCenter.cues.filter((cue) => cue.character_id === token.id).slice(0, 2)
+    : [];
   return (
     <div style={{
       display: "flex", gap: 10, alignItems: "center",
@@ -266,8 +275,110 @@ function CombatantSummary({ token, economy }) {
           <ApBadge used={economy.bonus_available === false} label="Bonus" />
           <ApBadge used={economy.reaction_available === false} label="React" />
         </div>
+        {cues.length > 0 && (
+          <div style={{ marginTop: 4, display: "flex", gap: 4, flexWrap: "wrap" }}>
+            {cues.map((cue, i) => <CueChip key={`${cue.type}-${i}`} cue={cue} />)}
+          </div>
+        )}
       </div>
     </div>
+  );
+}
+
+function CommandCenterPanel({ commandCenter, selectedId, onSelect }) {
+  const actor = commandCenter?.activeActor || {};
+  const slots = commandCenter?.slots || {};
+  const budget = commandCenter?.attackBudget || {};
+  const targetability = Array.isArray(commandCenter?.targetability) ? commandCenter.targetability : [];
+  const targets = targetability.filter((row) => row.id !== actor.id);
+  const cues = Array.isArray(commandCenter?.cues) ? commandCenter.cues.slice(0, 4) : [];
+  const attackLine = Number.isFinite(Number(budget.allowed))
+    ? `${budget.remaining ?? 0}/${budget.allowed} attacks left`
+    : "attack budget unavailable";
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: 6 }}>
+        <div style={{ fontFamily: "var(--f-display)", fontSize: 13, color: "var(--ink-900)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          {actor.name || "No active actor"}
+        </div>
+        <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 4 }}>
+          <SlotPip label="Act" slot={slots.action} />
+          <SlotPip label="Bonus" slot={slots.bonusAction} />
+          <SlotPip label="React" slot={slots.reaction} />
+        </div>
+        <div style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-700)" }}>{attackLine}</div>
+      </div>
+
+      {cues.length > 0 && (
+        <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+          {cues.map((cue, i) => <CueChip key={`${cue.character_id}-${cue.type}-${i}`} cue={cue} />)}
+        </div>
+      )}
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        {targets.length ? targets.map((row) => (
+          <button key={row.id} onClick={() => onSelect(row.id)} title={row.reason || "targetable"} style={{
+            display: "grid",
+            gridTemplateColumns: "1fr auto",
+            gap: 8,
+            alignItems: "center",
+            padding: "6px 8px",
+            textAlign: "left",
+            background: selectedId === row.id ? "rgba(176,141,87,0.18)" : "transparent",
+            color: row.targetable ? "var(--ink-900)" : "var(--ink-600)",
+            boxShadow: "inset 0 -1px 0 rgba(140,100,60,0.16)",
+            cursor: "pointer",
+          }}>
+            <span style={{ minWidth: 0 }}>
+              <span style={{ display: "block", fontFamily: "var(--f-display)", fontSize: 10, letterSpacing: "0.06em", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{row.name}</span>
+              <span style={{ display: "block", fontFamily: "var(--f-mono)", fontSize: 9, color: "var(--ink-600)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{row.zone || row.health || "field"}</span>
+            </span>
+            <span style={{
+              fontFamily: "var(--f-mono)",
+              fontSize: 9,
+              color: row.targetable ? "var(--crimson)" : "var(--ink-600)",
+              textTransform: "uppercase",
+            }}>{row.targetable ? "target" : row.reason}</span>
+          </button>
+        )) : <div className="body-sm" style={{ color: "var(--ink-600)" }}>No combatants projected.</div>}
+      </div>
+    </div>
+  );
+}
+
+function SlotPip({ label, slot }) {
+  const available = Boolean(slot?.available);
+  return (
+    <span title={slot?.reason || "ready"} style={{
+      fontFamily: "var(--f-display)",
+      fontSize: 8,
+      letterSpacing: "0.1em",
+      textTransform: "uppercase",
+      padding: "3px 5px",
+      textAlign: "center",
+      color: available ? "var(--ink-900)" : "var(--ink-600)",
+      background: available ? "rgba(95,75,45,0.38)" : "rgba(0,0,0,0.18)",
+      boxShadow: available ? "inset 0 0 0 1px var(--b-500)" : "inset 0 0 0 1px rgba(80,50,20,0.35)",
+      textDecoration: available ? "none" : "line-through",
+    }}>{label}</span>
+  );
+}
+
+function CueChip({ cue }) {
+  const danger = cue?.severity === "danger";
+  return (
+    <span title={cue?.text || cue?.label || ""} style={{
+      fontFamily: "var(--f-mono)",
+      fontSize: 9,
+      color: danger ? "var(--crimson)" : "var(--ink-700)",
+      padding: "2px 5px",
+      background: danger ? "rgba(166,39,39,0.1)" : "rgba(176,141,87,0.12)",
+      boxShadow: danger ? "inset 0 0 0 1px rgba(166,39,39,0.28)" : "inset 0 0 0 1px rgba(140,100,60,0.18)",
+      maxWidth: 170,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+    }}>{cue?.label || cue?.type}</span>
   );
 }
 
@@ -544,6 +655,7 @@ Object.assign(window, {
   ScreenCombat,
   CombatMap,
   CombatToken,
+  CommandCenterPanel,
   ActionTile,
   ApBadge,
   BattleLogLine,

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1329,6 +1329,192 @@ def _combat_battle_log(raw_events: list[dict] | None) -> list[dict]:
     return out
 
 
+def _combat_slot(available: object, spent_reason: str) -> dict:
+    available_bool = bool(available)
+    return {
+        "available": available_bool,
+        "spent": not available_bool,
+        "reason": "" if available_bool else spent_reason,
+    }
+
+
+def _combat_death_save_text(death_saves: object) -> str:
+    if not isinstance(death_saves, dict):
+        return "0 success / 0 fail"
+    successes = _num(death_saves.get("successes"))
+    failures = _num(death_saves.get("failures"))
+    return f"{int(successes or 0)} success / {int(failures or 0)} fail"
+
+
+def _combat_character_cues(ch: dict, token: dict) -> list[dict]:
+    cues: list[dict] = []
+    cid = _text(token.get("id"))
+    name = _text(token.get("name"), cid or "Combatant")
+    concentration = _text(ch.get("concentration"))
+    if concentration:
+        cues.append({
+            "type": "concentration",
+            "severity": "info",
+            "character_id": cid,
+            "label": f"{name} concentrating",
+            "text": concentration,
+        })
+    hp = _num(ch.get("current_hp"))
+    dead = bool(ch.get("dead"))
+    stable = bool(ch.get("stable"))
+    if dead:
+        cues.append({
+            "type": "death",
+            "severity": "danger",
+            "character_id": cid,
+            "label": f"{name} dead",
+            "text": "dead",
+        })
+    elif hp == 0 and not stable:
+        cues.append({
+            "type": "death_saves",
+            "severity": "danger",
+            "character_id": cid,
+            "label": f"{name} dying",
+            "text": _combat_death_save_text(ch.get("death_saves")),
+        })
+    elif hp == 0 and stable:
+        cues.append({
+            "type": "stable",
+            "severity": "warning",
+            "character_id": cid,
+            "label": f"{name} stable",
+            "text": "0 HP, stable",
+        })
+    return cues
+
+
+def _combat_multiattack_count(snapshot: dict, active_id: str) -> int:
+    chars = snapshot.get("characters") if isinstance(snapshot, dict) else {}
+    ch = chars.get(active_id) if isinstance(chars, dict) else None
+    if isinstance(ch, dict):
+        for key in ("multiattack", "attacks_per_turn"):
+            value = _num(ch.get(key))
+            if value is not None and value > 1:
+                return int(value)
+    combat = snapshot.get("combat") if isinstance(snapshot, dict) else None
+    turn_brief = combat.get("turn_brief") if isinstance(combat, dict) else None
+    if not isinstance(turn_brief, dict):
+        turn_brief = snapshot.get("turn_brief") if isinstance(snapshot, dict) else None
+    attack = turn_brief.get("attack") if isinstance(turn_brief, dict) else None
+    if isinstance(attack, dict):
+        value = _num(attack.get("attacks_per_turn"))
+        if value is not None and value > 1:
+            return int(value)
+    return 0
+
+
+def _combat_command_center(
+    snapshot: dict,
+    *,
+    tokens: list[dict],
+    initiative: list[dict],
+    combat_view: dict,
+    action_model: dict,
+    battle_log: list[dict],
+) -> dict:
+    """Browser-safe command-center read model derived from engine-owned combat data."""
+    combat = snapshot.get("combat") if isinstance(snapshot, dict) else {}
+    combat = combat if isinstance(combat, dict) else {}
+    chars = snapshot.get("characters") if isinstance(snapshot, dict) else {}
+    chars = chars if isinstance(chars, dict) else {}
+    active = next((t for t in tokens if t.get("isCurrent")), None)
+    actor_id = _text(active.get("id")) if isinstance(active, dict) else ""
+    actor_ch = chars.get(actor_id) if actor_id else {}
+    actor_ch = actor_ch if isinstance(actor_ch, dict) else {}
+    actions = combat_view.get("actions") if isinstance(combat_view.get("actions"), dict) else {}
+    action_model_combat = action_model.get("combat") if isinstance(action_model.get("combat"), dict) else {}
+    actor_team = _text(active.get("team")) if isinstance(active, dict) else ""
+
+    active_actor = {}
+    if isinstance(active, dict):
+        active_actor = {
+            "id": actor_id,
+            "name": _text(active.get("name"), actor_id),
+            "team": actor_team,
+            "initiative": active.get("initiative"),
+            "zone": _text(active.get("zone")),
+            "conditions": [str(c) for c in active.get("conditions", []) if str(c)]
+            if isinstance(active.get("conditions"), list)
+            else [],
+            "cues": _combat_character_cues(actor_ch, active),
+        }
+        concentration = _text(actor_ch.get("concentration"))
+        if concentration:
+            active_actor["concentration"] = concentration
+
+    made = _num(combat.get("action_attacks_made")) or 0
+    surge = _num(combat.get("surge_actions")) or 0
+    extra = _num(actor_ch.get("extra_attacks")) or 0
+    multiattack = _combat_multiattack_count(snapshot, actor_id)
+    per_action = max(int(extra) + 1 if actor_id else 0, multiattack)
+    allowed = per_action * (1 + max(0, int(surge))) if actor_id else 0
+    remaining = max(0, allowed - int(made))
+
+    cues: list[dict] = []
+    targetability: list[dict] = []
+    action_available = bool(actions.get("action_available")) and bool(action_model_combat.get("is_current_turn", True))
+    for token in tokens:
+        if not isinstance(token, dict):
+            continue
+        tid = _text(token.get("id"))
+        ch = chars.get(tid) if tid else {}
+        ch = ch if isinstance(ch, dict) else {}
+        token_cues = _combat_character_cues(ch, token)
+        cues.extend(token_cues)
+        reason = ""
+        targetable = False
+        if tid == actor_id:
+            reason = "self"
+        elif _text(token.get("team")) == actor_team:
+            reason = "ally"
+        elif bool(ch.get("dead")):
+            reason = "dead"
+        elif not action_available:
+            reason = "action unavailable"
+        else:
+            targetable = True
+        targetability.append({
+            "id": tid,
+            "name": _text(token.get("name"), tid),
+            "team": _text(token.get("team")),
+            "zone": _text(token.get("zone")),
+            "health": _text(token.get("health"), "unknown"),
+            "conditions": [str(c) for c in token.get("conditions", []) if str(c)]
+            if isinstance(token.get("conditions"), list)
+            else [],
+            "targetable": targetable,
+            "reason": reason,
+            "cues": token_cues,
+        })
+
+    return {
+        "activeActor": active_actor,
+        "initiativeLadder": initiative,
+        "slots": {
+            "action": _combat_slot(actions.get("action_available"), "action spent"),
+            "bonusAction": _combat_slot(actions.get("bonus_available"), "bonus action spent"),
+            "reaction": _combat_slot(actions.get("reaction_available"), "reaction spent"),
+        },
+        "attackBudget": {
+            "made": int(made),
+            "allowed": int(allowed),
+            "remaining": int(remaining),
+            "extraAttacks": int(extra),
+            "surgeActions": int(surge),
+            "multiattack": int(multiattack),
+        },
+        "targetability": targetability,
+        "cues": cues,
+        "eventCards": battle_log,
+    }
+
+
 def build_combat_surface(
     snapshot: dict,
     *,
@@ -1347,6 +1533,14 @@ def build_combat_surface(
     action_bar = _combat_action_bar(action_model, combat_active)
     can_act = bool(live and is_live_view and combat_active)
     battle_log = _combat_battle_log(recent_events)
+    command_center = _combat_command_center(
+        snapshot,
+        tokens=tokens,
+        initiative=initiative,
+        combat_view=combat_view,
+        action_model=action_model,
+        battle_log=battle_log,
+    )
     summary = _text(snapshot.get("summary"))
     if not summary:
         summary = (
@@ -1374,6 +1568,7 @@ def build_combat_surface(
         "zones": zones,
         "selectedTokenId": selected,
         "actionEconomy": (combat_view.get("actions") if combat_active else {}) or {},
+        "commandCenter": command_center,
         "actionBar": action_bar,
         "battleLog": battle_log,
         "live": bool(live),

--- a/viewer/tests/test_combat_surface.py
+++ b/viewer/tests/test_combat_surface.py
@@ -141,6 +141,128 @@ class CombatSurfaceTests(unittest.TestCase):
             self.assertNotIn(forbidden, encoded)
         self.assert_no_private_keys(surface)
 
+    def test_combat_command_center_projects_turn_cues_and_targetability(self):
+        snapshot = {
+            "id": "camp_center",
+            "title": "Command Center Fight",
+            "current_location_id": "crypt",
+            "locations": {"crypt": {"name": "Moon Crypt"}},
+            "party": ["hero", "cleric"],
+            "characters": {
+                "hero": {
+                    "id": "hero",
+                    "name": "Renn",
+                    "kind": "player",
+                    "current_hp": 14,
+                    "max_hp": 30,
+                    "armor_class": 16,
+                    "extra_attacks": 1,
+                    "concentration": "Bless",
+                    "conditions": ["blessed"],
+                    "notes": "private tactical note",
+                },
+                "cleric": {
+                    "id": "cleric",
+                    "name": "Vela",
+                    "kind": "companion",
+                    "current_hp": 0,
+                    "max_hp": 22,
+                    "armor_class": 18,
+                    "conditions": ["unconscious"],
+                    "death_saves": {"successes": 1, "failures": 2},
+                },
+                "gob": {
+                    "id": "gob",
+                    "name": "Goblin Sapper",
+                    "kind": "monster",
+                    "current_hp": 3,
+                    "max_hp": 7,
+                    "armor_class": 13,
+                    "conditions": ["prone"],
+                    "notes": "private fuse",
+                },
+            },
+            "combat": {
+                "active": True,
+                "round": 3,
+                "turn_index": 0,
+                "action_used": False,
+                "bonus_action_used": True,
+                "action_attacks_made": 1,
+                "surge_actions": 0,
+                "zones": [{"name": "altar"}, {"name": "stairs", "adjacent": ["altar"]}],
+                "order": [
+                    {"character_id": "hero", "initiative": 20, "reaction_used": False, "zone": "altar"},
+                    {"character_id": "cleric", "initiative": 15, "reaction_used": True, "zone": "altar"},
+                    {"character_id": "gob", "initiative": 9, "reaction_used": False, "zone": "stairs"},
+                ],
+            },
+        }
+        recent_events = [
+            {
+                "kind": "combat",
+                "text": "Renn presses the attack.",
+                "payload": {
+                    "schema": "clawdnd.combat_event.v1",
+                    "event": "attack",
+                    "actor": {"id": "hero", "name": "Renn", "notes": "private actor note"},
+                    "target": {"id": "gob", "name": "Goblin Sapper", "notes": "private target note"},
+                    "roll": {"natural": 14, "total": 21},
+                    "damage": {"total": 5, "type": "piercing"},
+                },
+            }
+        ]
+
+        surface = server.build_combat_surface(
+            snapshot,
+            campaign_id="camp_center",
+            live=True,
+            is_live_view=True,
+            recent_events=recent_events,
+        )
+
+        center = surface["commandCenter"]
+        self.assertEqual(center["activeActor"]["id"], "hero")
+        self.assertEqual(center["activeActor"]["concentration"], "Bless")
+        self.assertEqual(center["slots"]["action"], {"available": True, "spent": False, "reason": ""})
+        self.assertEqual(center["slots"]["bonusAction"]["reason"], "bonus action spent")
+        self.assertEqual(center["slots"]["reaction"], {"available": True, "spent": False, "reason": ""})
+        self.assertEqual(
+            center["attackBudget"],
+            {
+                "made": 1,
+                "allowed": 2,
+                "remaining": 1,
+                "extraAttacks": 1,
+                "surgeActions": 0,
+                "multiattack": 0,
+            },
+        )
+        by_id = {row["id"]: row for row in center["targetability"]}
+        self.assertEqual(by_id["gob"]["targetable"], True)
+        self.assertEqual(by_id["cleric"]["reason"], "ally")
+        self.assertEqual(by_id["hero"]["reason"], "self")
+        self.assertIn(
+            {"type": "concentration", "severity": "info", "character_id": "hero", "label": "Renn concentrating", "text": "Bless"},
+            center["cues"],
+        )
+        self.assertIn(
+            {
+                "type": "death_saves",
+                "severity": "danger",
+                "character_id": "cleric",
+                "label": "Vela dying",
+                "text": "1 success / 2 fail",
+            },
+            center["cues"],
+        )
+        self.assertEqual(center["eventCards"][0]["event"], "attack")
+
+        encoded = json.dumps(center)
+        self.assertNotIn("private", encoded)
+        self.assertNotIn("notes", encoded)
+        self.assert_no_private_keys(center)
+
     def test_combat_surface_fails_closed_when_not_live_or_not_current_turn(self):
         snapshot = {
             "party": ["hero"],


### PR DESCRIPTION
## Summary

Draft PR for Lane C: Combat Command Center.

Refs #57, #116, #160.

- Adds a browser-safe `commandCenter` read model to `/combat-surface`, derived only from engine-owned snapshot/event data.
- Surfaces active actor, initiative ladder, action/bonus/reaction slots, attack budget, targetability reasons, concentration/death-save cues, and sanitized event-card rows.
- Updates the OpenWorlds combat screen to consume the read model for the command panel and selected-combatant cues without changing `/move` behavior or combat resolution mechanics.
- Adds focused viewer coverage proving action economy, targetability/readability metadata, attack budget, cues, and private-field stripping.

## Notes

- No combat mechanics were changed.
- Multiattack is surfaced only when existing snapshot or turn-brief data already exposes an attack count; otherwise the read model falls back to `extra_attacks + 1`.
- The browser still posts only existing enabled actions through `/move`; it does not write campaign snapshots or invent legal actions locally.

## Validation

- `python3 -m unittest viewer.tests.test_combat_surface viewer.tests.test_combat_event_cards -q`
- `python3 -m unittest viewer.tests.test_openworlds_static -q`
- `python3 -m py_compile viewer/server.py`
- `python3 scripts/license_check.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Command Center panel to the combat interface displaying the active actor, slot availability, and attack budget status
  * Cue indicators for concentration, death saves, and other relevant conditions now appear in combat UI
  * Projected target list is now visible and selectable during combat encounters
  * Combatant summaries enhanced with tactical cue chips and condition indicators

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/204?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->