### PR TITLE
feat(quest-arc): faction-growth arcs (join→grow→lead) — Quest&Arc BUILD-NEXT

### DIFF
--- a/content/worlds/baldurs-gate/world.json
+++ b/content/worlds/baldurs-gate/world.json
@@ -89,6 +89,49 @@
     }
   ],
   "license_events": "events prose is ORIGINAL ClawDnD text (an authored stumble-into decisional staging a canon BG3 figure in our own words), released CC-BY-4.0 as fan content under the Wizards Fan Content Policy (+ Larian for BG3 elements). No in-game text is reproduced.",
+  "faction_arcs": [
+    {
+      "id": "arc-fist-rise",
+      "faction_id": "fac-flaming-fist",
+      "title": "The Banner of the Fist",
+      "requires_joined": true,
+      "note": "The join->grow->lead questline for the Flaming Fist. The Gate's mercenary army is overstretched and leaderless-feeling with the Steel Watch gone and the dukedom contested; a hard, honorable company looking for someone to follow. Stage 1 (enlist) gates on reputation (you have to be trusted to be let in); stages 2-3 gate on the monotonic `standing` gauge (rank earned through service — use grant_standing as the party completes Fist work). The finale ripples a world-changing effect via _apply_structured_effect: the party takes command, the Fist's reputation surges, and the Gate falls under the Fist's banner.",
+      "stages": [
+        {
+          "id": "stage-fist-enlist",
+          "title": "Take the oath",
+          "unlock_at": 15,
+          "gauge": "reputation",
+          "note": "Available once the Fist trusts the party enough to let them swear in. A drill-yard veteran sizes them up: 'We're short of everything but graves, and long on folk who'd rather watch the Gate burn than carry a bucket. You're not those folk — or you wouldn't be standing in my yard. Take the oath, then. The pay's poor and the hours are worse, but you'll never want for someone at your back.' Play the enlistment, then call advance_faction_arc to resolve it; grant_standing as they prove themselves on patrol."
+        },
+        {
+          "id": "stage-fist-captaincy",
+          "title": "Earn the captaincy",
+          "unlock_at": 25,
+          "gauge": "standing",
+          "note": "Available once the party's SERVICE (standing, earned via grant_standing on completed Fist work) marks them as officer material. A field-promotion in the ash of a street that didn't fall because they held it: 'On your knee. No — don't make a speech of it, none of us are good at speeches. By such authority as is left to give it, you're a captain of the Flaming Fist. The ranks already follow you; this just lets the paperwork catch up.' Set the party's new rank on advance_faction_arc (rank=3)."
+        },
+        {
+          "id": "stage-fist-command",
+          "title": "Raise the banner",
+          "unlock_at": 50,
+          "gauge": "standing",
+          "note": "The world-changing finale. With the dukedom contested and no one else willing to stand in the gap, the Fist's surviving officers put the company in the party's hands. Resolving this stage ripples the finale: the Fist's standing with the Gate surges and the city's order falls under the Fist's banner. Play it as the moment the party stops serving the Fist and becomes the Fist — then call advance_faction_arc(stage_status='resolved', rank=5).",
+          "finale_effect": {
+            "flag": "fist_under_party_banner",
+            "faction_id": "fac-flaming-fist",
+            "reputation_delta": 30,
+            "controller_id": "fac-flaming-fist",
+            "location_id": "loc-lower-city",
+            "narrate": "They do not cheer — the Fist is not a company that cheers — but every blade in the yard comes up in salute, and holds, and the silence of it is louder than any roar. The banner that has flown crooked over a leaderless army since the Steel Watch fell is hauled straight and high, and for the first time in a long winter the Gate has someone to answer for it. The watch-fires are lit by your order tonight. The streets are yours to keep.",
+            "schedule_in_days": 10,
+            "schedule_text": "The cost of command comes due: rivals who tolerated a leaderless Fist will not tolerate a led one. Someone tests the new banner — and the party learns that holding a city is harder than taking it."
+          }
+        }
+      ]
+    }
+  ],
+  "license_faction_arcs": "faction-arc prose is ORIGINAL ClawDnD text (an authored join->grow->lead questline for a canon BG3 faction in our own words), released CC-BY-4.0 as fan content under the Wizards Fan Content Policy (+ Larian for BG3 elements). No in-game text is reproduced.",
   "npc_roster": [
     {"id": "npc-jaheira", "name": "Jaheira", "voice_id": "npc-elder", "role": "High Harper, veteran of a hundred years", "personality": "A half-elf druid-warrior and Harper leader who has buried more friends than most people meet. Dry, fierce, maternal in a way that bites; she has saved the Coast before and is too tired and too stubborn to stop now. The player's likeliest mentor and door into the Harpers.", "hook": "Suspects someone is gathering the Absolute's loose ends — and that the new powers circling the dukedom are not all what they claim."},
     {"id": "npc-minsc", "name": "Minsc and Boo", "voice_id": "companion-default", "role": "ranger of legend (and his miniature giant space hamster) — candidate COMPANION", "personality": "Booming, bighearted, gloriously simple-seeming and far shrewder than he sounds; speaks to and for Boo, the 'miniature giant space hamster.' A hero of ages past, lately unfrozen and itching to 'go for the eyes.' Loyal unto death; grieves the friends time took from him.", "hook": "Available as a companion; his old griefs (Dynaheir, the centuries he lost) surface whenever loss or duty is in play.", "dossier": {"wound": "outlived the friends time took from him", "wants": ["a righteous cause to swing for", "to honor the fallen by protecting the living"], "fears": ["failing those under his guard, as he feels he once did"], "values": ["courage", "loyalty", "the small and the innocent"], "approval_likes": ["standing up for the helpless", "boldness in a good cause"], "approval_dislikes": ["preying on the weak", "cowardice dressed as caution"], "banter_tags": ["go_for_the_eyes", "grief_of_long_years", "boo_knows_best"], "camp_prompts": ["asks Boo what the stars looked like before the years he lost"], "relationships": {"npc-jaheira": "old comrade-in-arms"}}},

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -27,6 +27,7 @@ from models import (
     DowntimeProject,
     Event,
     Faction,
+    FactionArc,
     FactionAsset,
     Location,
     Quest,
@@ -683,6 +684,14 @@ def _apply_ending_overlay(c: Campaign, overlay: dict) -> None:
     ov_id = overlay.get("id", overlay.get("name", "?"))
     _seed_events_block(c, overlay.get("events"), where=f"ending overlay {ov_id!r}")
 
+    # ADDITIVE (Quest & Arc engine, faction arcs / #127): the chosen ending may ALSO seed faction
+    # questlines — so the post-state shapes which factions are joinable + what their arcs become
+    # (the Fist's rise looks different under a tyranny ending vs a liberation one). Folded onto
+    # whatever the base world already seeded; a malformed entry degrades (skip-one), like events.
+    # No `faction_arcs` key in the overlay is a no-op. Runs here so an arc's `faction_id` can be
+    # ref-checked against the (already-seeded) factions.
+    _seed_faction_arcs_block(c, overlay.get("faction_arcs"), where=f"ending overlay {ov_id!r}")
+
 
 def _seed_strategic_state(c: Campaign, world: dict) -> None:
     """Seed optional strategic board data from world.json.
@@ -848,6 +857,81 @@ def _seed_events(c: Campaign, world: dict) -> None:
     Runs AFTER factions are seeded (so a `reputation_at` trigger can be ref-checked). Additive
     + degrade-not-abort: a world with no `events` key seeds nothing (today's behavior)."""
     _seed_events_block(c, world.get("events"), where="world events block")
+
+
+def _seed_faction_arcs_block(c: Campaign, raw, *, where: str) -> int:
+    """Fold an OPTIONAL authored `faction_arcs` block onto the campaign (Quest & Arc engine,
+    faction arcs / #127). Mutates `c.faction_arcs` + links each named faction's `questline_arc_id`;
+    returns the count seeded.
+
+    This is the clean answer to "how is a faction arc seeded" given a faction is NOT a Character
+    (so the `companion_seeds` path — keyed to a roster companion — doesn't fit): faction arcs get
+    their OWN block. It mirrors `_seed_events_block` byte-for-byte — a list of FactionArc objects OR
+    a dict id->FactionArc; each validated into a `FactionArc`; a present-but-MALFORMED entry (wrong
+    shape, a `faction_id` naming a missing faction, a forbidden extra key, a stage `quest_id` with
+    no tracked Quest, a duplicate stage id) is SKIPPED with a diagnostic — DEGRADE-not-abort,
+    exactly the companion_seeds / world_state / events contract — never aborting start_world. A
+    missing/None/non-collection block is a no-op (today's behavior).
+
+    An arc naming an unknown faction is skipped (the gauge gate could never resolve — an authoring
+    typo). An explicit id collision (two arcs with the same id) keeps the first and skips the rest."""
+    if raw is None:
+        return 0
+    if isinstance(raw, dict):
+        entries = list(raw.values())
+    elif isinstance(raw, list):
+        entries = raw
+    else:
+        print(f"[content] skipping malformed faction_arcs block in {where} (not a list or object)")
+        return 0
+    seeded = 0
+    for entry in entries:
+        if not isinstance(entry, dict):
+            print(f"[content] skipping faction_arcs entry in {where} (not an object)")
+            continue
+        try:
+            arc = FactionArc.model_validate(entry)
+        except (ValidationError, ValueError, TypeError):
+            print(f"[content] skipping malformed faction arc in {where}")
+            continue
+        # An arc must name a real faction — its gauge gate reads that faction's reputation/standing;
+        # an unknown faction can never satisfy it (almost always an authoring typo). Skip (degrade).
+        if not arc.faction_id or arc.faction_id not in c.factions:
+            print(
+                f"[content] skipping faction arc {arc.id!r} in {where}: "
+                f"names unknown faction {arc.faction_id!r}"
+            )
+            continue
+        # A stage's optional tracked-Quest projection must point at an existing Quest (seeded
+        # quests are rare at world-gen, so this is usually empty). A dangling ref degrades the arc.
+        bad_quest = next((s.quest_id for s in arc.stages if s.quest_id and s.quest_id not in c.quests), None)
+        if bad_quest is not None:
+            print(
+                f"[content] skipping faction arc {arc.id!r} in {where}: "
+                f"stage references unknown tracked quest {bad_quest!r}"
+            )
+            continue
+        if arc.id in c.faction_arcs:
+            print(f"[content] skipping faction arc {arc.id!r} in {where}: duplicate arc id (keeping the first)")
+            continue
+        c.faction_arcs[arc.id] = arc
+        # Link the faction back to its questline (the runtime tools rely on questline_arc_id to
+        # find the arc on join_faction). If the faction already links a DIFFERENT arc, keep the
+        # first link (one questline per faction); the arc is still seeded + reachable by id.
+        fac = c.factions[arc.faction_id]
+        if not fac.questline_arc_id:
+            fac.questline_arc_id = arc.id
+        seeded += 1
+    return seeded
+
+
+def _seed_faction_arcs(c: Campaign, world: dict) -> None:
+    """Seed authored faction questlines from `world['faction_arcs']` (Quest & Arc engine, faction
+    arcs / #127).
+
+    Runs AFTER factions are seeded (so an arc's `faction_id` can be ref-checked). Additive +
+    degrade-not-abort: a world with no `faction_arcs` key seeds nothing (today's behavior)."""
+    _seed_faction_arcs_block(c, world.get("faction_arcs"), where="world faction_arcs block")
 
 
 def _seed_campaign_backlog(c: Campaign, world: dict) -> None:
@@ -1156,12 +1240,24 @@ def seed_world(world: dict, start_at: str = "", ending: str = "") -> Campaign:
             name=fac.get("name", "Faction"),
             description=fac.get("description", ""),
             reputation=int(fac.get("reputation", 0)),
+            # ADDITIVE faction-growth membership (faction arcs / #127). A world MAY seed a
+            # starting rank/standing/joined state, but the default leaves a faction un-joined at
+            # rank 0 / standing 0 — byte-for-byte today's behavior. `standing` floors at 0 (the
+            # monotonic gauge), so a negative seed degrades to 0 rather than aborting the world.
+            rank=int(fac.get("rank", 0)),
+            standing=max(0, int(fac.get("standing", 0))),
+            joined=bool(fac.get("joined", False)),
         )
         if fac.get("id"):
             faction.id = fac["id"]
         c.factions[faction.id] = faction
 
     _seed_strategic_state(c, world)
+
+    # Faction-growth questlines (Quest & Arc engine, faction arcs / #127). Runs AFTER factions are
+    # seeded so an arc's `faction_id` can be ref-checked. Additive: a world with no `faction_arcs`
+    # key is a no-op (today's behavior); the ending overlay may add MORE (see _apply_ending_overlay).
+    _seed_faction_arcs(c, world)
 
     # Authored stumble-into Events (Quest & Arc engine, Layer 3). Runs after factions so a
     # `reputation_at` trigger can be ref-checked. Additive: a world with no `events` key is a

--- a/servers/engine/faction_arc.py
+++ b/servers/engine/faction_arc.py
@@ -1,0 +1,198 @@
+"""Faction-growth questlines (Quest & Arc engine, faction arcs / #127) — pure module.
+
+The Skyrim/Kingmaker join->grow->lead loop, made a real engine state machine by GENERALIZING the
+proven companion stage-machine (``CompanionQuestArc``) onto a FACTION-owned reputation/standing
+gauge — NOT a parallel system. The companion arc is keyed to a companion and gates on its
+``attitude_value``; a ``FactionArc`` is keyed to a ``faction_id`` and its stages gate on that
+faction's ``reputation`` (the bidirectional trust gauge) or ``standing`` (the monotonic membership
+gauge). Both are engine-mutated, so a gate reads ONLY engine values, NEVER fiction — the
+questgen.py:7-19 discipline / invariant #3.
+
+A THIN reuse, not a rebuild — every moving part already ships:
+
+- the lifecycle enum is ``CompanionQuestStatus`` (``locked|available|active|resolved|failed``),
+  reused verbatim;
+- ``gate_value`` reads the faction gauge the same way ``events.trigger_holds`` reads it
+  (reputation/standing only);
+- ``apply_finale`` ripples a resolved stage's ``finale_effect`` through
+  ``worldsim._apply_structured_effect`` — byte-for-byte the backlog/strategic/Event ripple path —
+  with an ``effect_applied`` idempotency latch (a re-advance never double-ripples, exactly like a
+  fired Event/Consequence).
+
+Pure module (no MCP, no I/O), like ``events.py`` / ``worldsim.py`` / ``companion_arc.py``: the
+functions read or mutate the in-memory ``Campaign`` in place; the engine stays the sole writer —
+the MCP tool layer (``join_faction`` / ``advance_faction_arc`` in server.py) persists under
+``campaign_lock`` + ``save_campaign``.
+"""
+
+from __future__ import annotations
+
+import worldsim
+from models import Campaign, Faction, FactionArc, FactionArcStage
+
+
+def gauge_value(faction: Faction, gauge: str) -> int:
+    """The CURRENT value of the gauge a stage gates on (engine-mutated; never fiction).
+
+    ``"standing"`` -> the monotonic membership gauge; anything else (incl. the default
+    ``"reputation"``) -> the bidirectional trust gauge. A faction always carries both as ints, so
+    this never raises."""
+    return faction.standing if gauge == "standing" else faction.reputation
+
+
+def stage_gate_holds(stage: FactionArcStage, faction: Faction) -> bool:
+    """Whether ``stage``'s gauge gate is satisfied NOW: the faction's gauge has reached
+    ``unlock_at``.
+
+    Pure + contract-safe — reads ONLY ``reputation`` / ``standing`` (engine-mutated), the same
+    discipline as ``events.trigger_holds``. A non-negative threshold arms on a RISE to/above it
+    (``gauge >= unlock_at``); a negative threshold arms on a FALL to/below it (``gauge <=
+    unlock_at``) — the sign picks the direction, mirroring the Event ``reputation_at`` trigger.
+    (``standing`` is non-negative so its gate is always the >= direction in practice.)"""
+    val = gauge_value(faction, stage.gauge)
+    return val <= stage.unlock_at if stage.unlock_at < 0 else val >= stage.unlock_at
+
+
+def evaluate(arc: FactionArc, campaign: Campaign) -> dict:
+    """Advance ``arc``'s stages against the CURRENT faction gauge (mutates) and report what just
+    became live. The engine's deterministic, idempotent pass — mirrors ``companion_arc.evaluate``.
+
+    A ``locked`` stage whose gate now holds flips to ``available`` (the rank-up unlock) — but ONLY
+    when the arc is ARMED (the faction has ``joined`` it, unless the arc opts out via
+    ``requires_joined=False``). A stage NEVER auto-advances past ``available`` here: moving to
+    ``active``/``resolved``/``failed`` is an EXPLICIT ``advance_faction_arc`` call (the engine
+    surfaces the opportunity; the DM/player drive the choice — the advise-not-act contract). The
+    finale ripple is applied by ``apply_finale`` only on an explicit advance to ``resolved``.
+
+    Idempotent: a stage already unlocked is not re-reported; re-evaluating the same snapshot
+    yields the same result. Returns ``{"newly_available": [stage ids]}``."""
+    faction = campaign.factions.get(arc.faction_id)
+    if faction is None:
+        return {"newly_available": []}  # a dangling arc (faction removed) degrades to inert
+    armed = faction.joined or not arc.requires_joined
+    newly: list[str] = []
+    if armed and arc.status == "locked":
+        arc.status = "available"  # the arc itself opens once armed
+    for stage in arc.stages:
+        if stage.status == "locked" and armed and stage_gate_holds(stage, faction):
+            stage.status = "available"
+            newly.append(stage.id)
+    return {"newly_available": newly}
+
+
+def detect_rank_available(campaign: Campaign) -> list[dict]:
+    """ADVISORY read-only detector: for each ARMED faction arc, the stages that are ``available``
+    (a rank-up the player has earned but not yet taken) or ``active`` (a questline beat in flight).
+
+    Mirrors the scene_debt / Director contract: it DETECTS opportunity from engine state and
+    returns it; it NEVER advances an arc or mutates anything. The DM reads the nudge and chooses
+    whether to play the beat (the engine must not auto-advance a faction quest — map seam #5). Pure
+    (no mutation): unlike ``evaluate`` it does not flip ``locked->available``; it only reports
+    stages already in those states, so calling it is side-effect-free.
+
+    Returns one entry per faction arc with available/active stages, deterministically ordered by
+    arc id then stage author order."""
+    out: list[dict] = []
+    for arc in sorted(campaign.faction_arcs.values(), key=lambda a: a.id):
+        faction = campaign.factions.get(arc.faction_id)
+        if faction is None:
+            continue
+        if arc.requires_joined and not faction.joined:
+            continue  # not a member yet — no rank-up to nudge
+        available = [s.id for s in arc.stages if s.status == "available"]
+        active = [s.id for s in arc.stages if s.status == "active"]
+        if not available and not active:
+            continue
+        out.append(
+            {
+                "arc_id": arc.id,
+                "faction_id": arc.faction_id,
+                "faction_name": faction.name,
+                "title": arc.title,
+                "available_stage_ids": available,
+                "active_stage_ids": active,
+                # A terse DM-facing nudge — "rank-up available" vs "questline in flight".
+                "nudge": (
+                    f"faction questline '{arc.title}': rank-up available"
+                    if available
+                    else f"faction questline '{arc.title}': stage in flight"
+                ),
+            }
+        )
+    return out
+
+
+def apply_finale(campaign: Campaign, stage: FactionArcStage) -> dict | None:
+    """Apply a resolved stage's world-changing ``finale_effect`` ONCE (mutates) and return a
+    DM-facing summary of what moved, or ``None`` if there is nothing to apply / it already fired.
+
+    DETERMINISTIC — no LLM, no roll. The ripple goes through ``worldsim._apply_structured_effect``,
+    byte-for-byte the path the backlog / strategic board / Layer-3 Events use, so a faction finale
+    moves the world through the EXACT same vocabulary (set a flag, shift a faction's reputation, a
+    control/arrival marker). Plus the same three thin extension keys an Event ``Outcome`` carries
+    (``decision_flag`` -> ``flags``; ``schedule_in_days``/``schedule_text`` -> a follow-on
+    Consequence) so a finale can arm a companion flip or leave a lingering echo — the join->lead
+    payoff rippling outward exactly like a Kingmaker decisional.
+
+    IDEMPOTENT: guarded by ``stage.effect_applied`` — a second call (a re-advance to ``resolved``)
+    is a pure no-op, so the finale ripples at most once even if the tool is called twice."""
+    effect = stage.finale_effect
+    if effect is None or stage.effect_applied:
+        return None
+
+    # The shared ripple — the exact engine path the living world uses. `narrate` is the fallback.
+    shared = {
+        "flag": effect.flag,
+        "faction_id": effect.faction_id,
+        "reputation_delta": effect.reputation_delta,
+        "controller_id": effect.controller_id,
+        "location_id": effect.location_id,
+        "npc_name": effect.npc_name,
+    }
+    narrated = worldsim._apply_structured_effect(campaign, shared, fallback=effect.narrate)
+
+    flags_set: list[str] = []
+    if effect.flag:
+        flags_set.append(effect.flag)
+
+    rep_shift: dict | None = None
+    if effect.faction_id and effect.faction_id in campaign.factions:
+        rep_shift = {
+            "faction_id": effect.faction_id,
+            "reputation_delta": effect.reputation_delta,
+            "reputation": campaign.factions[effect.faction_id].reputation,
+        }
+
+    # Extension key 1 — the L2<->L3 seam: a finale may arm a companion flip (the same store as
+    # record_decision(sets_flag=)). E.g. seizing leadership of the Fist turns a rival-companion.
+    decision_flag = (effect.decision_flag or "").strip()
+    if decision_flag:
+        campaign.flags[decision_flag] = True
+        if decision_flag not in flags_set:
+            flags_set.append(decision_flag)
+
+    # Extension key 2 — the rule-of-three echo: a finale may leave a lingering Consequence. Both a
+    # positive day count AND text are required (a half-spec is a no-op, never a 0-day phantom).
+    scheduled: dict | None = None
+    if effect.schedule_in_days > 0 and effect.schedule_text.strip():
+        import consequences as consequences_mod
+
+        conseq = consequences_mod.schedule(
+            campaign,
+            effect.schedule_in_days,
+            effect.schedule_text.strip(),
+            note=f"faction_arc:{stage.id}",
+        )
+        scheduled = {"trigger_day": conseq.trigger_day, "text": conseq.text}
+
+    # Idempotency latch — the finale ripples at most once.
+    stage.effect_applied = True
+
+    return {
+        "stage_id": stage.id,
+        "narrated_line": narrated,
+        "flags_set": flags_set,
+        "rep_shift": rep_shift,
+        "scheduled": scheduled,
+        "decision_flag": decision_flag,
+    }

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -720,6 +720,95 @@ class Faction(_StrictModel):
     description: str = ""
     reputation: int = 0  # -100..100
 
+    # --- Faction-growth membership (Quest & Arc engine, faction arcs / #127) -----------------
+    # ADDITIVE: every field defaults to "behaves exactly like today when unset", so an old
+    # snapshot round-trips byte-for-byte and a world that authors no membership is unchanged.
+    # These give the Skyrim/Kingmaker join->grow->lead loop a gauge the engine can READ to gate
+    # a faction questline (closing the "reputation is tracked but nothing reads it" gap).
+    #
+    # `standing` is a MONOTONIC membership/progression gauge — distinct from the bidirectional
+    # `reputation`. Reputation (-100..100) is how the faction FEELS about you (it can fall, drifts
+    # via the backlog); `standing` (>=0) is how far you've RISEN inside it through service — the
+    # Skyrim "rank progress" number, only ever earned upward. A FactionArc stage may gate on
+    # EITHER gauge (see FactionArcStage.gauge); both are engine-mutated, so a gate never reads
+    # fiction (invariant #3). `rank` is the readable tier the standing/arc has unlocked (0 ==
+    # not a ranked member); `joined` is the membership latch `join_faction` sets; `questline_arc_id`
+    # links this faction to its FactionArc in Campaign.faction_arcs (empty == no questline).
+    rank: int = 0
+    standing: int = Field(default=0, ge=0)  # monotonic membership gauge — never negative
+    joined: bool = False
+    questline_arc_id: str = ""
+
+
+class FactionArcStage(_StrictModel):
+    """One engine-owned stage inside a faction questline (Quest & Arc engine, faction arcs).
+
+    Generalizes ``CompanionQuestStage`` (the proven companion machine) to a FACTION owner. The
+    same bounded lifecycle enum (``locked|available|active|resolved|failed``); the difference is
+    the UNLOCK GATE is folded directly onto the stage as a gauge threshold — a stage becomes
+    ``available`` when the owning faction's gauge has reached ``unlock_at``. This is PURE and
+    engine-evaluated: it reads ONLY ``reputation`` / ``standing`` (engine-mutated gauges), NEVER
+    fiction (the questgen.py discipline / invariant #3).
+
+    ``gauge`` picks WHICH faction gauge the threshold reads:
+      * ``"reputation"`` (default) — the bidirectional trust gauge (a trust-gated stage).
+      * ``"standing"`` — the monotonic membership/progression gauge (a service-grind stage).
+
+    A resolved stage may carry a one-shot ``finale_effect`` — an ``Outcome``-shaped world ripple
+    (the same payload ``_apply_structured_effect`` consumes) applied EXACTLY ONCE when the stage
+    transitions to ``resolved`` (the world-changing finale). Idempotent: ``effect_applied`` latches
+    so a re-advance never double-ripples (mirrors a fired Event/Consequence)."""
+
+    id: str = Field(default_factory=lambda: _new_id("fstage"))
+    title: str
+    status: CompanionQuestStatus = "locked"
+    # The gauge threshold that unlocks this stage (locked -> available). Read by the engine
+    # against `gauge`; pure, contract-safe (reputation/standing only, never fiction).
+    unlock_at: int = 0
+    gauge: Literal["reputation", "standing"] = "reputation"
+    location_id: str = ""
+    quest_id: str = ""  # optional player-facing tracked-Quest projection (one-way, like companion stages)
+    note: str = ""
+    # The world-changing ripple this stage applies ONCE on resolve (the finale). Reuses the
+    # Outcome payload so it ripples through the EXACT engine path the backlog / Events use. Empty
+    # == no ripple (a non-finale stage). The engine never authors the payload — it's content.
+    finale_effect: Optional["Outcome"] = None
+    effect_applied: bool = False  # idempotency latch — a resolved stage's finale ripples at most once
+
+
+class FactionArc(_StrictModel):
+    """A FACTION's joinable, multi-stage questline (Quest & Arc engine, faction arcs / #127).
+
+    The Skyrim/Kingmaker join->grow->lead loop, made a real engine state machine by GENERALIZING
+    ``CompanionQuestArc`` onto a faction-owned reputation/standing gauge — NOT a parallel system.
+    The companion arc is keyed to a companion; this is keyed to a ``faction_id`` and its stages
+    gate on the faction's gauge. ``join_faction`` arms it (flips the faction ``joined`` + links
+    ``questline_arc_id``); ``advance_faction_arc`` advances a stage when its gauge gate holds and
+    applies a resolved stage's ``finale_effect`` once.
+
+    ADDITIVE: a campaign with no faction arcs behaves exactly as today; old snapshots round-trip.
+    Stages are evaluated in author order; ``status`` is the arc-level lifecycle (the arc resolves
+    when its terminal stage does)."""
+
+    id: str = Field(default_factory=lambda: _new_id("farc"))
+    faction_id: str = ""
+    title: str
+    status: CompanionQuestStatus = "locked"
+    stages: list[FactionArcStage] = Field(default_factory=list)
+    # The arc only ARMS after the party joins (join_faction). A locked-but-unjoined arc never
+    # advances — the gauge gate is necessary but not sufficient; membership is the precondition.
+    requires_joined: bool = True
+    note: str = ""
+
+    @model_validator(mode="after")
+    def _unique_stage_ids(self) -> "FactionArc":
+        seen: set[str] = set()
+        for stage in self.stages:
+            if stage.id in seen:
+                raise ValueError(f"duplicate faction arc stage id {stage.id!r}")
+            seen.add(stage.id)
+        return self
+
 
 class Combatant(_StrictModel):
     character_id: str
@@ -1094,7 +1183,7 @@ class SceneDebt(_StrictModel):
 
     kind values:
         hook_untracked, quest_stalled, thread_no_payoff, choice_without_outcome,
-        due_consequence, thread_pressure, npc_introduced_silent
+        due_consequence, thread_pressure, npc_introduced_silent, faction_rank_available
     severity: low | med | high
     """
 
@@ -1199,6 +1288,14 @@ class Campaign(_StrictModel):
     # tracked Quest objects; explicit server APIs advance them and optionally project status
     # into linked Quests. Empty == old snapshots load unchanged.
     companion_quest_arcs: dict[str, CompanionQuestArc] = Field(default_factory=dict)
+    # Faction-growth questlines (Quest & Arc engine, faction arcs / #127). The Skyrim/Kingmaker
+    # join->grow->lead loop: a FactionArc generalizes the companion stage-machine onto a faction-
+    # owned reputation/standing gauge (each stage gated on stage.unlock_at). join_faction arms one;
+    # advance_faction_arc advances a stage when its gauge gate holds and ripples a resolved stage's
+    # finale ONCE. Empty == today's behavior byte-for-byte; old snapshots lacking the key round-trip
+    # to this empty default. Mirrors companion_quest_arcs/events; seeded from a world/ending
+    # `faction_arcs` block (content.py). Engine sole-writer (the tools persist under campaign_lock).
+    faction_arcs: dict[str, FactionArc] = Field(default_factory=dict)
     # First-class stumble-into Events (Quest & Arc engine, Layer 3). Content-authored decisionals
     # whose options carry a deterministic Outcome (a world ripple + optionally a Layer-2
     # decision_flag that arms a companion flip). Surfaced read-only by present_events when their

--- a/servers/engine/scene_debt.py
+++ b/servers/engine/scene_debt.py
@@ -346,6 +346,48 @@ def _detect_npc_introduced_silent(c: Campaign) -> list[SceneDebt]:
     return debts
 
 
+def _detect_faction_rank_available(c: Campaign) -> list[SceneDebt]:
+    """faction_rank_available — a JOINED faction whose questline (FactionArc) has a stage the
+    party has EARNED (status ``available``) but not yet taken. The Skyrim/Kingmaker "your
+    promotion is waiting" nudge: the gauge gate is satisfied, the rank-up is on the table, but the
+    DM hasn't played the beat. ADVISORY only (severity low) — the Director surfaces it so the DM
+    can play the rank-up and call ``advance_faction_arc``; the engine NEVER auto-advances a faction
+    quest (map seam #5). Pure / read-only: it reports stages ALREADY in ``available`` (flipped by
+    the engine's gauge eval); it never mutates an arc. A faction not yet joined, or an arc with no
+    available stage, is not flagged."""
+    debts: list[SceneDebt] = []
+    for arc in sorted(c.faction_arcs.values(), key=lambda a: a.id):
+        fac = c.factions.get(arc.faction_id)
+        if fac is None:
+            continue
+        if arc.requires_joined and not fac.joined:
+            continue  # not a member — no earned rank-up to nudge
+        available = [s for s in arc.stages if s.status == "available"]
+        if not available:
+            continue
+        titles = ", ".join(s.title for s in available)
+        debts.append(
+            SceneDebt(
+                id=_debt_id("faction_rank_available", arc.id),
+                kind="faction_rank_available",
+                subject=arc.id,
+                detail=(
+                    f"Faction questline '{arc.title}' ({fac.name}) has a rank-up the party earned "
+                    f"but hasn't taken — stage(s): {titles}. Play the promotion / next mission and "
+                    f"call advance_faction_arc."
+                ),
+                severity="low",
+                evidence={
+                    "arc_id": arc.id,
+                    "faction_id": arc.faction_id,
+                    "faction_name": fac.name,
+                    "available_stage_ids": [s.id for s in available],
+                },
+            )
+        )
+    return debts
+
+
 # ── v2 stubs (COARSE narrative proxies — not implemented in v1) ───────────────
 
 # TODO v2: setup_without_payoff — a quest_hook with status 'open' referenced in
@@ -377,6 +419,7 @@ def detect(c: Campaign) -> list[SceneDebt]:
     - ``due_consequence``: a non-thread Consequence past trigger_day, not fired.
     - ``thread_pressure``: a worldsim thread-beat overdue (world_tick not called).
     - ``npc_introduced_silent``: a met NPC at current location with no memory.
+    - ``faction_rank_available``: a joined faction's questline has an earned, untaken rank-up.
     """
     debts: list[SceneDebt] = []
     debts.extend(_detect_hook_untracked(c))
@@ -386,4 +429,5 @@ def detect(c: Campaign) -> list[SceneDebt]:
     debts.extend(_detect_due_consequence(c))
     debts.extend(_detect_thread_pressure(c))
     debts.extend(_detect_npc_introduced_silent(c))
+    debts.extend(_detect_faction_rank_available(c))
     return debts

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -27,6 +27,7 @@ import content as content_mod
 import dice as dice_mod
 import encounter
 import events as events_mod
+import faction_arc as faction_arc_mod
 import generator
 import imagegen
 import inventory
@@ -65,6 +66,7 @@ from models import (
     DeathSaves,
     Decision,
     Faction,
+    FactionArc,
     HouseRules,
     Item,
     Location,
@@ -6091,6 +6093,255 @@ def adjust_reputation(
         fac.reputation = max(-100, min(100, fac.reputation + int(delta)))
         save_campaign(c)
         return {"id": fac.id, "name": fac.name, "reputation": fac.reputation, "reason": reason}
+
+
+# --- Faction-growth questlines (Quest & Arc engine, faction arcs / #127) -----------------------
+# The Skyrim/Kingmaker join->grow->lead loop. Mirrors the companion-quest-arc tool surface
+# (set_companion_quest_arc / advance_companion_quest_arc / get_companion_quest_arcs +
+# check_companion_arc) — generalized onto a FACTION-owned reputation/standing gauge. The engine
+# advances a stage only when its gauge gate holds (pure, contract-safe) and ripples a resolved
+# stage's finale ONCE; the advisory surface (check_faction_arcs) detects-but-never-acts.
+
+
+def _faction_arc_view(c: Campaign, arc: FactionArc) -> dict:
+    """A DM-facing view of a faction arc with its faction name + the current gauge values resolved
+    (so the DM sees how close each locked stage is to unlocking without a second call)."""
+    fac = c.factions.get(arc.faction_id)
+    out = arc.model_dump()
+    out["faction_name"] = fac.name if fac else ""
+    out["reputation"] = fac.reputation if fac else None
+    out["standing"] = fac.standing if fac else None
+    out["joined"] = fac.joined if fac else False
+    out["rank"] = fac.rank if fac else 0
+    out["linked_quests"] = [
+        {"id": q.id, "title": q.title, "status": q.status}
+        for s in arc.stages
+        if s.quest_id and (q := c.quests.get(s.quest_id)) is not None
+    ]
+    return out
+
+
+def _validate_faction_arc_links(c: Campaign, arc: FactionArc) -> None:
+    """Validate a faction arc's references against campaign state (mirrors
+    _validate_companion_quest_arc_links). A faction arc must name a real faction; each stage's
+    optional tracked-Quest projection must point at an existing Quest."""
+    if not arc.faction_id or arc.faction_id not in c.factions:
+        raise ValueError(f"faction arc {arc.id!r} names unknown faction {arc.faction_id!r}")
+    for stage in arc.stages:
+        if stage.quest_id and stage.quest_id not in c.quests:
+            raise ValueError(f"no tracked quest {stage.quest_id!r} for faction arc stage {stage.id!r}")
+
+
+@mcp.tool()
+def grant_standing(campaign_id: str, faction_id: str, amount: int, reason: str = "") -> dict:
+    """Raise (or lower) a faction's MONOTONIC membership `standing` by `amount` — the Skyrim-style
+    "rank progress" gauge, distinct from `reputation` (how the faction FEELS about you). Use it
+    when the party performs SERVICE that advances them inside a faction (completing a faction
+    job, proving themselves) — standing is what unlocks the next stage of a faction questline
+    gated on `gauge="standing"`. Floored at 0 (it never goes negative — you don't un-rise through
+    service; `reputation` is the gauge that can be burned). The faction must already exist (join
+    it / earn reputation first). Returns the faction's new standing.
+
+    NOTE: this does NOT auto-advance a faction arc — call `check_faction_arcs` after to see whether
+    a stage just unlocked, then `advance_faction_arc` to take it (the advise-not-act contract)."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        fac = c.factions.get(faction_id)
+        if fac is None:
+            raise ValueError(f"no faction {faction_id!r} — join it or earn reputation first")
+        fac.standing = max(0, fac.standing + int(amount))
+        save_campaign(c)
+        return {"id": fac.id, "name": fac.name, "standing": fac.standing, "reason": reason}
+
+
+@mcp.tool()
+def set_faction_arc(campaign_id: str, arc: dict) -> dict:
+    """Create or replace an engine-owned FACTION questline (the join->grow->lead state machine).
+
+    `arc` is `{faction_id, title, stages:[{title, unlock_at, gauge?, location_id?, quest_id?,
+    note?, finale_effect?}], requires_joined?, note?}`. `gauge` is "reputation" (default) or
+    "standing" — which faction gauge a stage's `unlock_at` threshold reads. `finale_effect` is an
+    Outcome-shaped world ripple (flag / faction_id+reputation_delta / controller_id+location_id /
+    npc_name / decision_flag / schedule_in_days+schedule_text / narrate) applied ONCE when the
+    stage resolves — the world-changing finale. The faction must already exist; any stage
+    `quest_id` must point at an existing tracked Quest. LINKS the arc to its faction
+    (`questline_arc_id`). The engine evaluates the gauge gates each beat via `check_faction_arcs`;
+    `join_faction` arms the arc; `advance_faction_arc` advances a stage / applies the finale."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        parsed = FactionArc.model_validate(dict(arc or {}))
+        _validate_faction_arc_links(c, parsed)
+        c.faction_arcs[parsed.id] = parsed
+        # Link the faction back to its questline so get_state / the viewer can find it.
+        c.factions[parsed.faction_id].questline_arc_id = parsed.id
+        save_campaign(c)
+        return {"faction_arc": _faction_arc_view(c, parsed)}
+
+
+@mcp.tool()
+def join_faction(campaign_id: str, faction_id: str, rank: int = 1) -> dict:
+    """JOIN a faction — the membership latch that ARMS its questline (the Skyrim/Kingmaker
+    join->grow->lead loop). Sets the faction `joined=True` and its starting `rank` (default 1 —
+    the lowest membership tier), then ARMS any linked FactionArc: a `requires_joined` arc that was
+    `locked` opens to `available`, and any stage whose gauge gate ALREADY holds unlocks. Use it
+    when the party formally enlists with / is inducted into a group.
+
+    The faction must already exist (earn some reputation first, or it's seeded by the world).
+    Idempotent on the membership latch (re-joining just re-evaluates the arc). Returns the
+    faction's membership state + any stages that just became available. After this, grow
+    `reputation`/`standing` through service, then `advance_faction_arc` to climb the questline."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        fac = c.factions.get(faction_id)
+        if fac is None:
+            raise ValueError(f"no faction {faction_id!r} — earn reputation with it first (adjust_reputation)")
+        fac.joined = True
+        if rank > fac.rank:
+            fac.rank = int(rank)
+        newly_available: list[str] = []
+        arc = c.faction_arcs.get(fac.questline_arc_id) if fac.questline_arc_id else None
+        if arc is not None:
+            res = faction_arc_mod.evaluate(arc, c)
+            newly_available = res["newly_available"]
+        save_campaign(c)
+        return {
+            "id": fac.id,
+            "name": fac.name,
+            "joined": fac.joined,
+            "rank": fac.rank,
+            "standing": fac.standing,
+            "reputation": fac.reputation,
+            "questline_arc_id": fac.questline_arc_id,
+            "newly_available_stage_ids": newly_available,
+        }
+
+
+@mcp.tool()
+def get_faction_arcs(campaign_id: str, faction_id: str = "", status: str = "") -> dict:
+    """Read faction questlines (the join->grow->lead arcs), optionally filtered by faction and
+    lifecycle status. Read-only; does NOT evaluate gates or advance anything (use
+    `check_faction_arcs` to advance locked->available, `advance_faction_arc` to take a stage). Each
+    arc view resolves the faction's name + current reputation/standing/joined/rank so the DM can
+    see how close each locked stage sits to its `unlock_at`."""
+    c = _require(campaign_id)
+    wanted = _companion_quest_status(status, "status") if status else ""
+    arcs = list(c.faction_arcs.values())
+    if faction_id:
+        arcs = [a for a in arcs if a.faction_id == faction_id]
+    if wanted:
+        arcs = [a for a in arcs if a.status == wanted]
+    arcs.sort(key=lambda a: (a.faction_id, a.title, a.id))
+    return {"faction_arcs": [_faction_arc_view(c, a) for a in arcs], "count": len(arcs)}
+
+
+@mcp.tool()
+def check_faction_arcs(campaign_id: str, faction_id: str = "") -> dict:
+    """Advance faction questlines' gauge gates against the CURRENT state and surface the rank-ups
+    that just became live — the faction analog of `check_companion_arc`. Call it each beat: when a
+    stage UNLOCKS (the faction's reputation/standing reached its `unlock_at` and the party has
+    joined), play that "you've earned a promotion / the next mission opens" beat.
+
+    Pass `faction_id` to evaluate one faction's arc, or leave blank to evaluate ALL armed arcs. A
+    stage flips locked->available when its gauge gate holds AND the faction is joined; the engine
+    NEVER auto-advances past `available` — taking a stage (active/resolved/failed) and rippling its
+    finale is an EXPLICIT `advance_faction_arc` call (advise-not-act). Idempotent — an
+    already-unlocked stage is not re-reported. Also returns an ADVISORY `nudges` list (available /
+    in-flight questline stages) mirroring the Director's scene-debt surface; read-only, never acts."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        if faction_id and faction_id not in c.factions:
+            raise ValueError(f"no faction {faction_id!r}")
+        results = []
+        for arc in c.faction_arcs.values():
+            if faction_id and arc.faction_id != faction_id:
+                continue
+            res = faction_arc_mod.evaluate(arc, c)
+            if res["newly_available"]:
+                fac = c.factions.get(arc.faction_id)
+                results.append(
+                    {
+                        "arc_id": arc.id,
+                        "faction_id": arc.faction_id,
+                        "faction_name": fac.name if fac else "",
+                        "title": arc.title,
+                        "newly_available_stage_ids": res["newly_available"],
+                    }
+                )
+        save_campaign(c)
+        # The advisory nudge surface (read-only — runs on the just-evaluated state).
+        nudges = faction_arc_mod.detect_rank_available(c)
+        if faction_id:
+            nudges = [n for n in nudges if n["faction_id"] == faction_id]
+        return {"results": results, "nudges": nudges}
+
+
+@mcp.tool()
+def advance_faction_arc(
+    campaign_id: str,
+    arc_id: str,
+    stage_id: str = "",
+    stage_status: str = "",
+    status: str = "",
+    rank: int = 0,
+) -> dict:
+    """Explicitly advance a FACTION questline — take an available stage, resolve a finale, fail a
+    branch (the faction analog of `advance_companion_quest_arc`). The engine ripples a resolved
+    stage's world-changing finale ONCE; you narrate it.
+
+    `stage_id` + `stage_status` advances one stage (e.g. `available`->`active`->`resolved`).
+    `status` advances the arc-level lifecycle. `rank` (optional) sets the faction's new membership
+    rank (a promotion). GATE-CHECKED: a stage can only leave `locked`/`available` toward `active`
+    when its gauge gate holds (the party earned it) — advancing an un-earned stage is rejected.
+
+    When a stage moves to `resolved` AND carries a `finale_effect`, the engine applies that ripple
+    through the SAME path the living world uses (a set flag, a faction reputation shift, a
+    control/arrival marker, an optional `decision_flag` that arms a companion flip, an optional
+    follow-on Consequence). IDEMPOTENT: re-resolving an already-resolved stage applies the finale
+    NOTHING further (the `effect_applied` latch) — calling it twice is safe. Returns the updated
+    arc view + what the finale moved (`finale`)."""
+    next_stage_status = _companion_quest_status(stage_status, "stage_status") if stage_status else ""
+    next_status = _companion_quest_status(status, "status") if status else ""
+    if not any((next_stage_status, next_status, rank)):
+        raise ValueError("advance_faction_arc requires stage_status, status, or rank")
+    if next_stage_status and not stage_id:
+        raise ValueError("stage_status requires stage_id")
+
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        arc = c.faction_arcs.get(arc_id)
+        if arc is None:
+            raise ValueError(f"no faction arc {arc_id!r}")
+        fac = c.factions.get(arc.faction_id)
+        if fac is None:
+            raise ValueError(f"faction arc {arc_id!r} names unknown faction {arc.faction_id!r}")
+
+        finale: dict | None = None
+        if next_stage_status:
+            stage = next((s for s in arc.stages if s.id == stage_id), None)
+            if stage is None:
+                raise ValueError(f"no stage {stage_id!r} in faction arc {arc_id!r}")
+            # Gate enforcement: a stage may only begin (-> active) once its gauge gate holds.
+            # Moving toward active/resolved from locked without the gate is rejected (the engine
+            # enforces "earned trust", invariant #3 — a pure gauge check, never fiction).
+            advancing = next_stage_status in ("available", "active", "resolved")
+            if stage.status == "locked" and advancing and not faction_arc_mod.stage_gate_holds(stage, fac):
+                raise ValueError(
+                    f"faction arc stage {stage_id!r} is gated: {stage.gauge} "
+                    f"{faction_arc_mod.gauge_value(fac, stage.gauge)} has not reached unlock_at {stage.unlock_at}"
+                )
+            stage.status = next_stage_status
+            if next_stage_status == "resolved":
+                finale = faction_arc_mod.apply_finale(c, stage)
+        if next_status:
+            arc.status = next_status
+        if rank and rank > fac.rank:
+            fac.rank = int(rank)
+
+        save_campaign(c)
+        out = {"faction_arc": _faction_arc_view(c, arc)}
+        if finale is not None:
+            out["finale"] = finale
+        return out
 
 
 @mcp.tool()

--- a/servers/engine/tests/test_faction_arcs.py
+++ b/servers/engine/tests/test_faction_arcs.py
@@ -1,0 +1,552 @@
+"""Tests for the Quest & Arc engine, faction arcs (#127) — the Skyrim/Kingmaker join->grow->lead loop.
+
+A FactionArc GENERALIZES the proven companion stage-machine (CompanionQuestArc) onto a FACTION-owned
+reputation/standing gauge — NOT a parallel system. Coverage (per the verification plan):
+  * a stage is LOCKED below its `unlock_at` and AVAILABLE at/above (a deterministic gauge gate).
+  * the join->advance flow: an arc only arms after join_faction; advance_faction_arc climbs it.
+  * the finale ripples via worldsim._apply_structured_effect EXACTLY ONCE (idempotent re-advance).
+  * the standing-vs-reputation distinction: a stage may gate on either engine-mutated gauge.
+  * the advisory surface (check_faction_arcs nudges + the scene_debt detector) detects-not-acts.
+  * the exemplar Flaming-Fist arc loads via seed_world (degrade-not-abort on malformed).
+  * ADDITIVE: no faction arc == today's behavior byte-for-byte; old snapshots round-trip.
+
+Pure-module functions (faction_arc.py) are exercised directly (like test_companion_arc.py); the MCP
+tools (server.py) are exercised against a real persisted campaign (like test_event_parley_layer3.py).
+Single-process only (the host OOMs on parallel pytest; never -n / xdist).
+"""
+
+import pytest
+
+import content as content_mod
+import faction_arc as fa
+import scene_debt
+import server
+import store
+from models import (
+    Campaign,
+    Faction,
+    FactionArc,
+    FactionArcStage,
+    Outcome,
+)
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _stage(sid="s1", title="Stage", unlock_at=10, gauge="reputation", **kw) -> FactionArcStage:
+    return FactionArcStage(id=sid, title=title, unlock_at=unlock_at, gauge=gauge, **kw)
+
+
+def _arc(aid="arc-x", faction_id="fac-x", title="Arc", stages=None, **kw) -> FactionArc:
+    return FactionArc(id=aid, faction_id=faction_id, title=title, stages=stages or [], **kw)
+
+
+def _campaign_with_arc(arc: FactionArc, *, reputation=0, standing=0, joined=False) -> Campaign:
+    c = Campaign(title="FA")
+    c.factions[arc.faction_id] = Faction(
+        id=arc.faction_id, name="X", reputation=reputation, standing=standing, joined=joined
+    )
+    c.faction_arcs[arc.id] = arc
+    return c
+
+
+# =========================================================================
+# ADDITIVE DEFAULT + round-trip (empty == today, old snapshots load)
+# =========================================================================
+
+
+def test_campaign_faction_arcs_defaults_empty():
+    assert Campaign(title="T").faction_arcs == {}
+
+
+def test_faction_membership_fields_default_to_today():
+    """Faction's new fields default to "behaves like today when unset" — the additive contract."""
+    f = Faction(id="fac-a", name="A")
+    assert f.rank == 0 and f.standing == 0 and f.joined is False and f.questline_arc_id == ""
+
+
+def test_old_faction_snapshot_without_membership_round_trips():
+    """A faction authored before #127 has only id/name/description/reputation — it must load with
+    the membership fields at their defaults and round-trip identically."""
+    old = {"id": "fac-a", "name": "A", "description": "d", "reputation": 5}
+    f = Faction.model_validate(old)
+    assert f.standing == 0 and f.joined is False and f.rank == 0 and f.reputation == 5
+    assert Faction.model_validate(f.model_dump(mode="json")).reputation == 5
+
+
+def test_old_campaign_snapshot_without_faction_arcs_deserializes_unchanged():
+    c = Campaign(title="Pre-127")
+    data = c.model_dump(mode="json")
+    old = {k: v for k, v in data.items() if k != "faction_arcs"}
+    assert "faction_arcs" not in old
+    reloaded = Campaign.model_validate(old)
+    assert reloaded.faction_arcs == {}
+    assert Campaign.model_validate(reloaded.model_dump(mode="json")).faction_arcs == {}
+
+
+def test_standing_is_monotonic_typed():
+    """`standing` is a monotonic gauge — the model rejects a negative value (the type guard)."""
+    with pytest.raises(Exception):
+        Faction(id="z", name="Z", standing=-1)
+
+
+def test_faction_arc_models_default_shapes():
+    st = FactionArcStage(title="Finale")
+    assert st.status == "locked" and st.unlock_at == 0 and st.gauge == "reputation"
+    assert st.finale_effect is None and st.effect_applied is False
+    arc = FactionArc(faction_id="fac-x", title="Rise")
+    assert arc.status == "locked" and arc.stages == [] and arc.requires_joined is True
+    assert arc.id.startswith("farc")
+
+
+def test_faction_arc_round_trips_with_full_finale():
+    arc = _arc(stages=[_stage(
+        sid="s2", title="Lead", unlock_at=50, gauge="standing",
+        finale_effect=Outcome(flag="led", faction_id="fac-x", reputation_delta=30,
+                              decision_flag="seized_power", schedule_in_days=10,
+                              schedule_text="cost comes due", narrate="You command."),
+    )])
+    reloaded = FactionArc.model_validate(arc.model_dump(mode="json"))
+    assert reloaded == arc
+
+
+def test_duplicate_stage_id_rejected():
+    with pytest.raises(ValueError, match="duplicate faction arc stage id"):
+        FactionArc(faction_id="f", title="t", stages=[_stage(sid="dup"), _stage(sid="dup")])
+
+
+# =========================================================================
+# THE GAUGE GATE (LOCKED below unlock_at, AVAILABLE at/above) — pure module
+# =========================================================================
+
+
+def test_stage_gate_locked_below_available_at_and_above_reputation():
+    """The core deterministic gate on the bidirectional reputation gauge."""
+    fac = Faction(id="fac-x", name="X", reputation=9)
+    st = _stage(unlock_at=10, gauge="reputation")
+    assert fa.stage_gate_holds(st, fac) is False  # 9 < 10 -> locked
+    fac.reputation = 10
+    assert fa.stage_gate_holds(st, fac) is True  # at threshold -> available
+    fac.reputation = 25
+    assert fa.stage_gate_holds(st, fac) is True  # above -> available
+
+
+def test_stage_gate_on_standing_gauge():
+    """The standing-vs-reputation distinction: a stage may gate on the MONOTONIC standing gauge
+    instead — reputation at 0 doesn't satisfy a standing gate, and vice-versa."""
+    fac = Faction(id="fac-x", name="X", reputation=100, standing=5)
+    st = _stage(unlock_at=10, gauge="standing")
+    assert fa.stage_gate_holds(st, fac) is False  # standing 5 < 10 even though reputation is 100
+    fac.standing = 10
+    assert fa.stage_gate_holds(st, fac) is True
+    # a reputation-gauge stage at the same threshold reads reputation, not standing
+    rep_stage = _stage(unlock_at=10, gauge="reputation")
+    fac.reputation = 0
+    fac.standing = 99
+    assert fa.stage_gate_holds(rep_stage, fac) is False  # standing high, reputation 0 -> locked
+
+
+def test_stage_gate_negative_threshold_arms_on_fall():
+    """A negative reputation threshold arms on a FALL to/below it (the sign picks direction) —
+    a "they've come to despise you" branch unlock."""
+    fac = Faction(id="fac-x", name="X", reputation=0)
+    st = _stage(unlock_at=-10, gauge="reputation")
+    assert fa.stage_gate_holds(st, fac) is False  # 0 not <= -10
+    fac.reputation = -10
+    assert fa.stage_gate_holds(st, fac) is True
+    fac.reputation = -30
+    assert fa.stage_gate_holds(st, fac) is True
+
+
+# =========================================================================
+# evaluate(): join is the precondition; gate flips locked->available; idempotent
+# =========================================================================
+
+
+def test_evaluate_inert_until_joined():
+    """A requires_joined arc never advances until the faction is joined — the gate is necessary
+    but not sufficient (membership is the precondition)."""
+    arc = _arc(stages=[_stage(unlock_at=10)])
+    c = _campaign_with_arc(arc, reputation=50, joined=False)  # gate holds, but not joined
+    res = fa.evaluate(arc, c)
+    assert res["newly_available"] == []
+    assert arc.status == "locked" and arc.stages[0].status == "locked"
+
+
+def test_evaluate_arms_on_join_and_unlocks_held_gates():
+    arc = _arc(stages=[_stage(sid="s1", unlock_at=10), _stage(sid="s2", unlock_at=30)])
+    c = _campaign_with_arc(arc, reputation=20, joined=True)
+    res = fa.evaluate(arc, c)
+    assert arc.status == "available"  # the arc itself opens once armed
+    assert res["newly_available"] == ["s1"]  # only s1's gate (10) holds at rep 20; s2 (30) doesn't
+    assert arc.stages[0].status == "available" and arc.stages[1].status == "locked"
+
+
+def test_evaluate_is_idempotent():
+    arc = _arc(stages=[_stage(unlock_at=10)])
+    c = _campaign_with_arc(arc, reputation=20, joined=True)
+    assert fa.evaluate(arc, c)["newly_available"] == ["s1"]
+    assert fa.evaluate(arc, c)["newly_available"] == []  # already unlocked -> not re-reported
+
+
+def test_evaluate_requires_joined_false_arms_without_join():
+    """A world MAY author an arc that doesn't require joining (requires_joined=False) — it arms on
+    the gauge gate alone."""
+    arc = _arc(stages=[_stage(unlock_at=10)], requires_joined=False)
+    c = _campaign_with_arc(arc, reputation=20, joined=False)
+    res = fa.evaluate(arc, c)
+    assert arc.status == "available" and res["newly_available"] == ["s1"]
+
+
+def test_evaluate_degrades_on_dangling_faction():
+    """An arc whose faction was removed degrades to inert (never raises)."""
+    arc = _arc(stages=[_stage(unlock_at=10)])
+    c = Campaign(title="T")
+    c.faction_arcs[arc.id] = arc  # no faction seeded
+    assert fa.evaluate(arc, c) == {"newly_available": []}
+
+
+# =========================================================================
+# apply_finale(): ripples via _apply_structured_effect EXACTLY ONCE
+# =========================================================================
+
+
+def test_finale_ripples_through_structured_effect():
+    """The finale moves the world through the SAME path the backlog/Events use: flag + reputation
+    + control marker + a scheduled echo."""
+    c = Campaign(title="T")
+    c.factions["fac-x"] = Faction(id="fac-x", name="X", reputation=10)
+    c.current_location_id = None
+    st = _stage(finale_effect=Outcome(
+        flag="world_changed", faction_id="fac-x", reputation_delta=25,
+        controller_id="fac-x", location_id="loc-1",
+        schedule_in_days=5, schedule_text="the reckoning", narrate="The world tilts."))
+    res = fa.apply_finale(c, st)
+    assert res is not None
+    assert c.flags.get("world_changed") is True
+    assert c.flags.get("control:loc-1=fac-x") is True
+    assert c.factions["fac-x"].reputation == 35  # 10 + 25
+    assert res["rep_shift"]["reputation"] == 35
+    assert any(co.note == f"faction_arc:{st.id}" for co in c.consequences)  # the rule-of-three echo
+    assert st.effect_applied is True
+
+
+def test_finale_is_idempotent():
+    """A re-advance to resolved never double-ripples (the effect_applied latch)."""
+    c = Campaign(title="T")
+    c.factions["fac-x"] = Faction(id="fac-x", name="X", reputation=10)
+    st = _stage(finale_effect=Outcome(flag="f", faction_id="fac-x", reputation_delta=20, narrate="n"))
+    fa.apply_finale(c, st)
+    assert c.factions["fac-x"].reputation == 30
+    again = fa.apply_finale(c, st)  # second call
+    assert again is None
+    assert c.factions["fac-x"].reputation == 30  # unchanged — no double ripple
+    assert len(c.consequences) == 0
+
+
+def test_finale_arms_companion_flip_via_decision_flag():
+    """A finale may set a decision_flag — the L2<->L3 seam (e.g. seizing leadership turns a rival
+    companion). It lands in Campaign.flags exactly like record_decision(sets_flag=)."""
+    c = Campaign(title="T")
+    c.factions["fac-x"] = Faction(id="fac-x", name="X")
+    st = _stage(finale_effect=Outcome(decision_flag="seized_the_fist", narrate="You take command."))
+    res = fa.apply_finale(c, st)
+    assert c.flags.get("seized_the_fist") is True
+    assert "seized_the_fist" in res["flags_set"]
+
+
+def test_finale_none_is_noop():
+    c = Campaign(title="T")
+    st = _stage()  # no finale_effect
+    assert fa.apply_finale(c, st) is None
+
+
+# =========================================================================
+# THE ADVISORY SURFACE — detect_rank_available + the scene_debt detector
+# =========================================================================
+
+
+def test_detect_rank_available_reports_available_stages_read_only():
+    arc = _arc(stages=[_stage(sid="s1", unlock_at=10), _stage(sid="s2", unlock_at=30)])
+    c = _campaign_with_arc(arc, reputation=20, joined=True)
+    fa.evaluate(arc, c)  # flips s1 -> available
+    before = c.model_dump(mode="json")
+    nudges = fa.detect_rank_available(c)
+    assert len(nudges) == 1
+    assert nudges[0]["available_stage_ids"] == ["s1"]
+    assert "rank-up available" in nudges[0]["nudge"]
+    # read-only — detect_rank_available never mutates
+    assert c.model_dump(mode="json") == before
+
+
+def test_detect_rank_available_skips_unjoined_faction():
+    arc = _arc(stages=[_stage(unlock_at=10)])
+    c = _campaign_with_arc(arc, reputation=50, joined=False)
+    assert fa.detect_rank_available(c) == []  # not a member -> no rank-up to nudge
+
+
+def test_scene_debt_detector_surfaces_earned_rank_up():
+    """The Director surfaces a faction_rank_available debt for a joined faction's earned-but-
+    untaken rank-up — the established advise-not-act contract."""
+    arc = _arc(stages=[_stage(sid="s1", title="Take the oath", unlock_at=10)])
+    c = _campaign_with_arc(arc, reputation=20, joined=True)
+    fa.evaluate(arc, c)
+    debts = scene_debt.detect(c)
+    rank_debts = [d for d in debts if d.kind == "faction_rank_available"]
+    assert len(rank_debts) == 1
+    assert rank_debts[0].subject == arc.id
+    assert rank_debts[0].severity == "low"
+    assert "s1" in rank_debts[0].evidence["available_stage_ids"]
+
+
+def test_scene_debt_detector_silent_when_no_arc():
+    """No faction arc == today's behavior: the new detector adds nothing."""
+    c = Campaign(title="T")
+    assert [d for d in scene_debt.detect(c) if d.kind == "faction_rank_available"] == []
+
+
+# =========================================================================
+# THE TOOLS (server.py) against a real persisted campaign — the join->advance flow
+# =========================================================================
+
+
+@pytest.fixture
+def fa_campaign(tmp_path, monkeypatch):
+    """A persisted campaign with a PC and a seeded faction (un-joined, rep 0). Returns cid."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Faction Arc Test")["id"]
+    server.create_character(cid, "Vanya", kind="player", class_name="fighter", level=3)
+    c = store.load_campaign(cid)
+    c.factions["fac-fist"] = Faction(id="fac-fist", name="Flaming Fist", reputation=0, standing=0)
+    store.save_campaign(c)
+    return cid
+
+
+def _arm_arc(cid: str) -> str:
+    """Seed a 3-stage Flaming-Fist arc via the tool and return its id."""
+    out = server.set_faction_arc(cid, {
+        "id": "arc-fist",
+        "faction_id": "fac-fist",
+        "title": "The Banner of the Fist",
+        "stages": [
+            {"id": "st-oath", "title": "Take the oath", "unlock_at": 15, "gauge": "reputation"},
+            {"id": "st-captain", "title": "Earn the captaincy", "unlock_at": 25, "gauge": "standing"},
+            {"id": "st-command", "title": "Raise the banner", "unlock_at": 50, "gauge": "standing",
+             "finale_effect": {"flag": "fist_under_party_banner", "faction_id": "fac-fist",
+                               "reputation_delta": 30, "controller_id": "fac-fist",
+                               "location_id": "loc-1", "narrate": "The banner flies high."}},
+        ],
+    })
+    return out["faction_arc"]["id"]
+
+
+def test_set_faction_arc_links_questline_to_faction(fa_campaign):
+    cid = fa_campaign
+    arc_id = _arm_arc(cid)
+    c = store.load_campaign(cid)
+    assert arc_id in c.faction_arcs
+    assert c.factions["fac-fist"].questline_arc_id == arc_id  # the faction links its questline
+
+
+def test_set_faction_arc_rejects_unknown_faction(fa_campaign):
+    cid = fa_campaign
+    with pytest.raises(ValueError, match="unknown faction"):
+        server.set_faction_arc(cid, {"faction_id": "fac-nope", "title": "X", "stages": []})
+
+
+def test_join_faction_arms_arc_and_unlocks_held_gate(fa_campaign):
+    """join_faction sets joined + rank and unlocks any stage whose gauge gate already holds."""
+    cid = fa_campaign
+    _arm_arc(cid)
+    # raise reputation to 20 (>= the oath stage's 15) BEFORE joining
+    server.adjust_reputation(cid, "fac-fist", 20)
+    out = server.join_faction(cid, "fac-fist")
+    assert out["joined"] is True and out["rank"] == 1
+    assert out["newly_available_stage_ids"] == ["st-oath"]  # the reputation gate held
+    c = store.load_campaign(cid)
+    assert c.faction_arcs["arc-fist"].stages[0].status == "available"
+
+
+def test_join_faction_requires_existing_faction(fa_campaign):
+    cid = fa_campaign
+    with pytest.raises(ValueError, match="no faction"):
+        server.join_faction(cid, "fac-ghost")
+
+
+def test_grant_standing_is_monotonic_and_floors_at_zero(fa_campaign):
+    cid = fa_campaign
+    assert server.grant_standing(cid, "fac-fist", 10)["standing"] == 10
+    assert server.grant_standing(cid, "fac-fist", 5)["standing"] == 15
+    assert server.grant_standing(cid, "fac-fist", -100)["standing"] == 0  # floors, never negative
+
+
+def test_join_grow_advance_full_flow(fa_campaign):
+    """The whole join->grow->advance loop through the tools: join, grow standing, the
+    standing-gated stages unlock via check_faction_arcs, advance each stage."""
+    cid = fa_campaign
+    _arm_arc(cid)
+    server.adjust_reputation(cid, "fac-fist", 20)
+    server.join_faction(cid, "fac-fist")  # unlocks st-oath (reputation gate)
+    # take the oath: available -> active -> resolved
+    server.advance_faction_arc(cid, "arc-fist", stage_id="st-oath", stage_status="active")
+    server.advance_faction_arc(cid, "arc-fist", stage_id="st-oath", stage_status="resolved")
+    # grow standing through service to 50 (>= both standing gates)
+    server.grant_standing(cid, "fac-fist", 50)
+    out = server.check_faction_arcs(cid, "fac-fist")
+    avail = out["results"][0]["newly_available_stage_ids"]
+    assert set(avail) == {"st-captain", "st-command"}
+    # promote to captain
+    server.advance_faction_arc(cid, "arc-fist", stage_id="st-captain", stage_status="resolved", rank=3)
+    c = store.load_campaign(cid)
+    assert c.factions["fac-fist"].rank == 3
+
+
+def test_advance_rejects_ungated_stage(fa_campaign):
+    """The engine ENFORCES earned trust: a locked stage can't be advanced toward active while its
+    gauge gate is unmet (invariant #3 — a pure gauge check)."""
+    cid = fa_campaign
+    _arm_arc(cid)
+    server.join_faction(cid, "fac-fist")  # rep 0 < 15, so st-oath stays locked
+    with pytest.raises(ValueError, match="gated"):
+        server.advance_faction_arc(cid, "arc-fist", stage_id="st-oath", stage_status="active")
+
+
+def test_advance_finale_ripples_once_idempotent(fa_campaign):
+    """Resolving the finale stage ripples its world-changing effect ONCE; re-resolving applies
+    nothing further (the idempotency the verification plan calls out)."""
+    cid = fa_campaign
+    _arm_arc(cid)
+    server.join_faction(cid, "fac-fist")
+    server.grant_standing(cid, "fac-fist", 50)
+    server.check_faction_arcs(cid, "fac-fist")  # unlock the standing-gated stages
+    server.advance_faction_arc(cid, "arc-fist", stage_id="st-command", stage_status="active")
+    first = server.advance_faction_arc(cid, "arc-fist", stage_id="st-command", stage_status="resolved", rank=5)
+    assert first["finale"]["flags_set"] == ["fist_under_party_banner"]
+    c = store.load_campaign(cid)
+    rep_after_finale = c.factions["fac-fist"].reputation
+    assert c.flags.get("fist_under_party_banner") is True
+    assert c.flags.get("control:loc-1=fac-fist") is True
+    assert c.factions["fac-fist"].rank == 5
+    # re-resolve -> finale applies NOTHING further (no double ripple)
+    second = server.advance_faction_arc(cid, "arc-fist", stage_id="st-command", stage_status="resolved")
+    assert second.get("finale") is None
+    assert store.load_campaign(cid).factions["fac-fist"].reputation == rep_after_finale
+
+
+def test_advance_requires_an_argument(fa_campaign):
+    cid = fa_campaign
+    _arm_arc(cid)
+    with pytest.raises(ValueError, match="requires stage_status, status, or rank"):
+        server.advance_faction_arc(cid, "arc-fist")
+
+
+def test_get_faction_arcs_resolves_gauge_context(fa_campaign):
+    cid = fa_campaign
+    _arm_arc(cid)
+    server.adjust_reputation(cid, "fac-fist", 12)
+    server.grant_standing(cid, "fac-fist", 7)
+    out = server.get_faction_arcs(cid, "fac-fist")
+    assert out["count"] == 1
+    view = out["faction_arcs"][0]
+    assert view["faction_name"] == "Flaming Fist"
+    assert view["reputation"] == 12 and view["standing"] == 7  # current gauge context surfaced
+
+
+def test_check_faction_arcs_returns_advisory_nudges(fa_campaign):
+    cid = fa_campaign
+    _arm_arc(cid)
+    server.adjust_reputation(cid, "fac-fist", 20)
+    server.join_faction(cid, "fac-fist")
+    out = server.check_faction_arcs(cid, "fac-fist")
+    assert any(n["faction_id"] == "fac-fist" for n in out["nudges"])
+
+
+# =========================================================================
+# THE EXEMPLAR — the authored Flaming-Fist arc on the REAL shipped content
+# =========================================================================
+
+BG_WORLD = "baldurs-gate"
+FIST_ARC = "arc-fist-rise"
+
+
+def _seed_bg(ending: str = "") -> Campaign:
+    """Seed the real baldurs-gate world. Skips cleanly if the world bible isn't reachable."""
+    try:
+        world = content_mod.load_world_data(BG_WORLD)
+    except (ValueError, FileNotFoundError, OSError):  # pragma: no cover - content not present
+        pytest.skip("baldurs-gate world content not reachable from test cwd")
+    return content_mod.seed_world(world, ending=ending)
+
+
+def test_bg_flaming_fist_arc_seeds_and_links():
+    """The authored Flaming-Fist questline loads from world.json, links to its faction, and has
+    the 3-stage join->prove->lead shape with a world-changing finale on the terminal stage."""
+    c = _seed_bg()
+    assert FIST_ARC in c.faction_arcs, "the authored Flaming-Fist arc must seed from world.json"
+    arc = c.faction_arcs[FIST_ARC]
+    assert arc.faction_id == "fac-flaming-fist"
+    assert c.factions["fac-flaming-fist"].questline_arc_id == FIST_ARC  # linked back
+    assert len(arc.stages) == 3, "join -> prove -> lead"
+    # stage 1 gates on reputation (trust to be let in); the later stages on standing (earned rank)
+    assert arc.stages[0].gauge == "reputation"
+    assert arc.stages[1].gauge == "standing" and arc.stages[2].gauge == "standing"
+    # the terminal stage carries a world-changing finale that ripples a real effect
+    finale = arc.stages[-1].finale_effect
+    assert finale is not None
+    assert finale.flag and finale.narrate.strip()
+    assert finale.faction_id == "fac-flaming-fist" and finale.reputation_delta > 0
+    # canon-grounded: the finale puts the Fist in control of a real location in this world
+    assert finale.location_id in c.locations
+
+
+def test_bg_flaming_fist_arc_locked_at_seed():
+    """At world start the Fist isn't joined and reputation is the seed value (1) — all stages
+    locked. The additive guarantee: the exemplar changes nothing until the player engages it."""
+    c = _seed_bg()
+    arc = c.faction_arcs[FIST_ARC]
+    assert c.factions["fac-flaming-fist"].joined is False
+    fa.evaluate(arc, c)
+    assert all(s.status == "locked" for s in arc.stages)
+
+
+def test_bg_flaming_fist_arc_end_to_end_on_real_content():
+    """The whole authored loop on shipped canon: join the Fist, prove yourself (reputation),
+    rise through service (standing), then the finale ripples the Gate under the Fist's banner."""
+    c = _seed_bg()
+    arc = c.faction_arcs[FIST_ARC]
+    fac = c.factions["fac-flaming-fist"]
+    # prove yourself: reputation up to the oath threshold, then join
+    fac.reputation = arc.stages[0].unlock_at
+    fac.joined = True
+    fa.evaluate(arc, c)
+    assert arc.stages[0].status == "available"  # the oath opens
+    # rise through service: standing up to the command threshold
+    fac.standing = arc.stages[2].unlock_at
+    fa.evaluate(arc, c)
+    assert arc.stages[2].status == "available"  # the command stage opens
+    # the finale ripples the Gate under the Fist's banner, exactly once
+    rep_before = fac.reputation
+    res = fa.apply_finale(c, arc.stages[2])
+    assert res is not None
+    assert c.flags.get(arc.stages[2].finale_effect.flag) is True
+    assert fac.reputation == min(100, rep_before + arc.stages[2].finale_effect.reputation_delta)
+    assert fa.apply_finale(c, arc.stages[2]) is None  # idempotent
+
+
+def test_bg_malformed_faction_arc_degrades_not_aborts():
+    """A malformed faction arc in a world block is SKIPPED (degrade-not-abort), exactly the
+    companion_seeds / events contract — a sibling valid arc still seeds, start_world never aborts."""
+    c = Campaign(title="probe")
+    c.factions["fac-real"] = Faction(id="fac-real", name="Real")
+    seeded = content_mod._seed_faction_arcs_block(
+        c,
+        [
+            {"id": "bad", "faction_id": "fac-missing", "title": "X", "stages": []},  # unknown faction
+            {"id": "alsobad", "title": "no faction id", "stages": []},  # missing faction_id
+            {"id": "good", "faction_id": "fac-real", "title": "OK", "stages": []},  # valid
+        ],
+        where="probe block",
+    )
+    assert seeded == 1
+    assert "good" in c.faction_arcs and "bad" not in c.faction_arcs and "alsobad" not in c.faction_arcs


### PR DESCRIPTION
Closes #127. The Skyrim/Kingmaker faction questline: generalizes the companion stage-machine (locked→available→active→resolved/failed) onto a FACTION-owned gauge. Additive Faction fields (rank/standing/joined/questline_arc_id). FactionArc/FactionArcStage keyed to faction_id; unlock gate folded onto the stage (unlock_at + gauge selector); finale_effect ripples via _apply_structured_effect with an idempotency latch; new pure faction_arc.py. Tools: join_faction/advance_faction_arc/grant_standing/set_faction_arc/get_faction_arcs + check_faction_arcs (Director nudge + faction_rank_available scene_debt). standing=monotonic earned-rank vs reputation=bidirectional trust; own faction_arcs seed block (a faction isn't a Character). Exemplar: the Flaming Fist 'Banner of the Fist' (oath rep>=15 → captaincy standing>=25 → raise-the-banner standing>=50, finale puts Lower City under your banner + a 10-day cost-of-command callback). Contract-safe (gates read only rep/standing); additive (empty==today). 39 tests + FULL suite 1253 passing single-process, 0 regressions; license green. Local-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Faction questlines now available in campaigns, enabling structured progression through faction ranks
* Flaming Fist faction features "The Banner of the Fist" questline with enlistment, captaincy, and leadership stages
* Faction rank and standing mechanics track membership growth and reputation
* Dynamic stage unlocking based on reputation and standing thresholds
* Finale events with consequences and rewards upon stage completion

## Tests
* Comprehensive faction questline system test coverage added

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/205?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->