### PR TITLE
fix(combat): Guiding Bolt advantage auto-consumed on the next attack (#194)

### DIFF
--- a/servers/engine/combat.py
+++ b/servers/engine/combat.py
@@ -38,6 +38,30 @@ _TARGET_GIVES_ADV = {
     Condition.UNCONSCIOUS,
 }
 
+# Spells whose timed effect is a "next attack roll against the target has Advantage"
+# rider (#194). When such a spell's on-hit rider materializes on the target, the
+# ActiveEffect is flagged grants_advantage=True so attack_modifiers auto-grants advantage
+# to the next attacker (and attack() consumes the marker). Keyed by canonical spell name so
+# the marker is general — any future rider spell just joins this set. Currently: Guiding
+# Bolt ("On a hit ... the next attack roll made against it ... has Advantage").
+_ADVANTAGE_GRANTING_SPELLS = frozenset({"Guiding Bolt"})
+
+
+def spell_grants_advantage(spell_name: str) -> bool:
+    """Does this spell's on-hit rider grant ADVANTAGE to the next attack against the target
+    (Guiding Bolt)? Used when materializing the rider to flag the ActiveEffect; pure."""
+    return spell_name in _ADVANTAGE_GRANTING_SPELLS
+
+
+def advantage_granting_effect(target: Character):
+    """The first active_effect on ``target`` flagged as granting advantage to the next
+    attack against it (Guiding Bolt's rider), or None. Pure — no mutation; attack() reads
+    this to surface/consume the marker. Today only one such marker can exist at a time."""
+    for eff in target.active_effects:
+        if getattr(eff, "grants_advantage", False):
+            return eff
+    return None
+
 
 def double_dice(expr: str) -> str:
     """Double the DICE count of a damage expression for a critical hit, leaving
@@ -48,9 +72,12 @@ def double_dice(expr: str) -> str:
 
 
 def attack_modifiers(attacker: Character, target: Character, is_ranged: bool = False) -> tuple[bool, bool]:
-    """(advantage, disadvantage) implied by the combatants' conditions. The caller
-    combines these with any explicit flags; dice.roll cancels adv+disadv. A prone
-    target grants advantage to melee attackers and disadvantage to ranged ones."""
+    """(advantage, disadvantage) implied by the combatants' conditions AND any
+    advantage-granting active_effect on the TARGET (Guiding Bolt's "next attack against it
+    has Advantage" rider, #194). The caller combines these with any explicit flags;
+    dice.roll cancels adv+disadv. A prone target grants advantage to melee attackers and
+    disadvantage to ranged ones. PURE — reads state only; consuming the rider is attack()'s
+    job. A target with no advantage-granting effect (the common case) is unaffected."""
     adv = disadv = False
     ac = set(attacker.conditions)
     tc = set(target.conditions)
@@ -65,6 +92,10 @@ def attack_modifiers(attacker: Character, target: Character, is_ranged: bool = F
     if Condition.PRONE in tc:
         adv = adv or (not is_ranged)
         disadv = disadv or is_ranged
+    # An advantage-granting rider on the target (Guiding Bolt) auto-grants advantage to the
+    # next attacker — deterministic, not reliant on the DM passing advantage=True (#194).
+    if advantage_granting_effect(target) is not None:
+        adv = True
     return adv, disadv
 
 

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -488,6 +488,13 @@ class ActiveEffect(_StrictModel):
     # hour-scale buffs also end on a long rest (an overnight ~8h) regardless of the
     # phase math; day-scale ones survive it.
     until_long_rest: bool = False
+    # Combat rider flag (#194): this effect grants ADVANTAGE to the NEXT attack roll made
+    # against its holder (Guiding Bolt's "the next attack roll against it has Advantage").
+    # combat.attack_modifiers reads it so the engine auto-applies advantage instead of
+    # relying on the DM to pass advantage=True; attack() consumes the effect after that one
+    # attack resolves (one-shot). Defaults False, so every existing effect (Bless, Hex, Mage
+    # Armor) and every old snapshot is untouched — only an advantage-granting rider sets it.
+    grants_advantage: bool = False
 
 
 class PendingOnHitRider(_StrictModel):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -2812,6 +2812,10 @@ def attack(
                 )
                 if not ok:
                     raise ValueError(f"{attacker.name} cannot attack: {reason}")
+        # Capture any advantage-granting rider on the target (Guiding Bolt's "next attack
+        # has advantage" marker) BEFORE the roll so we can both auto-apply its advantage
+        # (via attack_modifiers) and consume it after this one attack resolves (#194).
+        adv_marker = combat.advantage_granting_effect(target)
         cadv, cdis = combat.attack_modifiers(attacker, target, is_ranged=is_ranged)
         adv = advantage or cadv
         dis = disadvantage or cdis
@@ -2893,6 +2897,10 @@ def attack(
                         expires_day=r.expires_day,
                         expires_phase_index=r.expires_phase_index,
                         until_long_rest=r.until_long_rest,
+                        # Flag the rider as advantage-granting (Guiding Bolt) so the NEXT
+                        # attack against this target auto-gets advantage via
+                        # combat.attack_modifiers and is consumed there (#194).
+                        grants_advantage=combat.spell_grants_advantage(r.name),
                     )
                     # Refresh, don't stack (mirrors cast_spell's write).
                     target.active_effects = [
@@ -2903,6 +2911,19 @@ def attack(
                 result["on_hit_effect_applied"] = applied
             else:
                 result["on_hit_effect_discarded"] = [r.name for r in riders]
+        # CONSUME the advantage-granting rider (Guiding Bolt) that auto-granted advantage to
+        # THIS attack (#194). 5e: "the next attack roll made against it has Advantage" — the
+        # marker is spent by the next attack ROLL (hit OR miss), so it benefits exactly one
+        # attack. ``adv_marker`` was captured before the roll, so a Guiding-Bolt SPELL attack
+        # that just materialized a fresh marker on this same target (above) is not consumed
+        # here (that path had no pre-existing marker). Removed by identity so re-applied
+        # same-name effects aren't clobbered.
+        if adv_marker is not None:
+            target.active_effects = [
+                e for e in target.active_effects if e is not adv_marker
+            ]
+            result["advantage_source"] = adv_marker.name
+            result["advantage_consumed"] = True
         outcome_label = "crit" if is_crit else ("hit" if hit else "miss")
         if hit and result["damage"]:
             dtype = f" {damage_type}" if damage_type else ""

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -168,6 +168,53 @@ def test_attack_modifiers():
     assert dis2 and not adv2
 
 
+# --- advantage-granting rider on the target (Guiding Bolt, #194) ---
+def test_attack_modifiers_advantage_granting_effect_on_target():
+    """A target carrying an advantage-granting active_effect (Guiding Bolt's rider) auto-
+    grants advantage to the attacker — even with no conditions and no explicit flag."""
+    gb = ActiveEffect(name="Guiding Bolt", grants_advantage=True, scale="rounds", rounds_remaining=1)
+    adv, dis = combat.attack_modifiers(mk(), mk(active_effects=[gb]))
+    assert adv and not dis
+
+
+def test_attack_modifiers_plain_effect_does_not_grant_advantage():
+    """An ordinary timed effect (Bless) is NOT a 'next attack has advantage' rider —
+    grants_advantage defaults False, so a target carrying it is unaffected (no regression)."""
+    bless = ActiveEffect(name="Bless", scale="minutes", rounds_remaining=10)
+    adv, dis = combat.attack_modifiers(mk(), mk(active_effects=[bless]))
+    assert not adv and not dis
+    # ...and a target with no effects at all is likewise unaffected.
+    adv0, dis0 = combat.attack_modifiers(mk(), mk())
+    assert not adv0 and not dis0
+
+
+def test_attack_modifiers_marker_combines_with_disadvantage():
+    """The marker grants advantage; an attacker's own disadvantage (blinded) still applies —
+    the caller/dice.roll cancels them. The marker doesn't suppress condition-derived disadv."""
+    gb = ActiveEffect(name="Guiding Bolt", grants_advantage=True, scale="rounds", rounds_remaining=1)
+    adv, dis = combat.attack_modifiers(mk(conditions=[Condition.BLINDED]), mk(active_effects=[gb]))
+    assert adv and dis
+
+
+def test_advantage_granting_effect_helper():
+    """advantage_granting_effect returns the flagged effect (Guiding Bolt) or None — pure,
+    and it does not mutate the target."""
+    gb = ActiveEffect(name="Guiding Bolt", grants_advantage=True)
+    bless = ActiveEffect(name="Bless")
+    tgt = mk(active_effects=[bless, gb])
+    found = combat.advantage_granting_effect(tgt)
+    assert found is gb
+    assert len(tgt.active_effects) == 2  # no mutation
+    assert combat.advantage_granting_effect(mk(active_effects=[bless])) is None
+    assert combat.advantage_granting_effect(mk()) is None
+
+
+def test_spell_grants_advantage_registry():
+    assert combat.spell_grants_advantage("Guiding Bolt") is True
+    assert combat.spell_grants_advantage("Bless") is False
+    assert combat.spell_grants_advantage("Fire Bolt") is False
+
+
 # --- end-to-end through the MCP tools ---
 def test_combat_flow_end_to_end(tmp_path, monkeypatch):
     monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))

--- a/servers/engine/tests/test_effect_durations.py
+++ b/servers/engine/tests/test_effect_durations.py
@@ -11,6 +11,7 @@ import pytest
 import combat
 import spells
 import server
+import store
 from models import ActiveEffect, Campaign, Character
 
 
@@ -31,6 +32,12 @@ def _cleric(cid, name="Pious", **abil):
 
 def _effects(cid, char_id):
     return server.get_character(cid, char_id)["active_effects"]
+
+
+def _load(cid, char_id) -> Character:
+    """The real persisted Character object (for pure combat.* calls) — get_character augments
+    the dict with non-model view keys, which a strict Character would reject."""
+    return store.load_campaign(cid).characters[char_id]
 
 
 def _advance_turn(cid):
@@ -286,6 +293,110 @@ def test_guiding_bolt_materialized_rider_auto_expires(monkeypatch):
             break
     assert expired == [{"character_id": foe, "name": "Guiding Bolt"}]
     assert _effects(cid, foe) == []
+
+
+# --- the materialized GB marker auto-grants + is consumed by the NEXT attack (#194) ----
+# #186/#188 fixed the on-HIT registration; #194 is the OTHER half — the marker on the
+# target must make the next attack against it carry advantage WITHOUT the DM passing
+# advantage=True, and be consumed so it benefits exactly one attack.
+
+
+def _fighter(cid, name="Brawn", ac=10):
+    return server.create_character(
+        cid, name, kind="player", class_name="Fighter", apply_srd_defaults=True,
+        armor_class=ac, abilities={"strength": 16, "constitution": 14},
+    )["id"]
+
+
+def test_guiding_bolt_marker_auto_grants_advantage_to_next_attack_and_is_consumed(monkeypatch):
+    """cast(GB)+hit lands the marker on the foe; the NEXT attack against that foe (by a
+    DIFFERENT combatant, who passes NO advantage flag) auto-carries advantage=True, names
+    its source, and CONSUMES the marker — so it benefits exactly one attack (#194)."""
+    cid = server.create_campaign("S")["id"]
+    cleric = _gb_cleric(cid)
+    fighter = _fighter(cid)
+    foe = server.create_character(cid, "Goblin", kind="monster", max_hp=80, armor_class=10)["id"]
+    server.cast_spell(cid, cleric, "Guiding Bolt", target_id=foe)
+    # The fixed-natural-15 stub also makes initiative tie -> input order [cleric, fighter, foe],
+    # so the cleric acts first and the fighter follows in the SAME round (marker still live).
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(15))
+    server.start_combat(cid, [cleric, fighter, foe])
+    _advance_to(cid, cleric)
+    # Cleric's GB attack hits -> the "next attack has advantage" marker lands on the foe.
+    gb = server.attack(cid, cleric, foe, attack_bonus=5, damage_dice="4d6",
+                       damage_type="radiant", is_ranged=True)
+    assert gb["hit"] is True and gb.get("on_hit_effect_applied") == ["Guiding Bolt"]
+    # The GB spell attack itself must NOT have consumed any advantage (none pre-existed).
+    assert "advantage_source" not in gb
+    eff = _effects(cid, foe)
+    assert [e["name"] for e in eff] == ["Guiding Bolt"] and eff[0]["grants_advantage"] is True
+    # Advance to the fighter (still round 1) and attack the SAME foe with NO advantage flag.
+    server.next_turn(cid)
+    assert server.get_state(cid)["current_turn"] == fighter
+    res = server.attack(cid, fighter, foe, attack_bonus=4, damage_dice="1d8+3",
+                        damage_type="slashing")  # DM passes NO advantage=True
+    assert res["advantage"] is True  # <-- the fix: engine auto-granted it
+    assert res["disadvantage"] is False
+    assert res["advantage_source"] == "Guiding Bolt" and res["advantage_consumed"] is True
+    # The marker is consumed — gone from the foe, so it benefits exactly ONE attack. Because
+    # attack_modifiers derives the auto-advantage purely from this (now empty) effect list, a
+    # SECOND attack against the foe necessarily gets NO advantage from the marker.
+    assert _effects(cid, foe) == []
+    adv2, dis2 = combat.attack_modifiers(_load(cid, fighter), _load(cid, foe))
+    assert adv2 is False and dis2 is False
+
+
+def test_guiding_bolt_marker_not_consumed_for_attack_on_other_target(monkeypatch):
+    """The marker is the FOE's; an attack against a DIFFERENT (unmarked) target neither gets
+    advantage from it nor consumes it — the marker stays live for the marked foe."""
+    cid = server.create_campaign("S")["id"]
+    cleric = _gb_cleric(cid)
+    fighter = _fighter(cid)
+    foe = server.create_character(cid, "Goblin", kind="monster", max_hp=80, armor_class=10)["id"]
+    other = server.create_character(cid, "Rat", kind="monster", max_hp=80, armor_class=10)["id"]
+    server.cast_spell(cid, cleric, "Guiding Bolt", target_id=foe)
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(15))
+    server.start_combat(cid, [cleric, fighter, foe, other])
+    _advance_to(cid, cleric)
+    server.attack(cid, cleric, foe, attack_bonus=5, damage_dice="4d6", is_ranged=True)  # marker on foe
+    server.next_turn(cid)
+    assert server.get_state(cid)["current_turn"] == fighter
+    # Fighter strikes the UNMARKED 'other' -> no auto-advantage, marker untouched.
+    res = server.attack(cid, fighter, other, attack_bonus=4, damage_dice="1d8+3")
+    assert res["advantage"] is False
+    assert "advantage_source" not in res and "advantage_consumed" not in res
+    assert [e["name"] for e in _effects(cid, foe)] == ["Guiding Bolt"]  # still live on the foe
+    assert _effects(cid, other) == []
+
+
+def test_attack_on_unmarked_target_has_no_advantage_machinery(monkeypatch):
+    """A plain weapon attack against a target carrying NO advantage rider is byte-identical
+    to before — no advantage, no advantage_source/consumed keys (non-marked unaffected)."""
+    cid = server.create_campaign("S")["id"]
+    fighter = _fighter(cid)
+    foe = server.create_character(cid, "Goblin", kind="monster", max_hp=80, armor_class=10)["id"]
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(15))
+    server.start_combat(cid, [fighter, foe])
+    _advance_to(cid, fighter)
+    res = server.attack(cid, fighter, foe, attack_bonus=4, damage_dice="1d8+3")
+    assert res["advantage"] is False and res["disadvantage"] is False
+    assert "advantage_source" not in res and "advantage_consumed" not in res
+
+
+def test_condition_advantage_still_works_with_no_marker(monkeypatch):
+    """REGRESSION: condition-derived advantage (a PRONE target, melee) is unchanged by the
+    #194 marker path — it still grants advantage with no marker present and no source key."""
+    cid = server.create_campaign("S")["id"]
+    fighter = _fighter(cid)
+    foe = server.create_character(cid, "Goblin", kind="monster", max_hp=80, armor_class=10)["id"]
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(15))
+    server.start_combat(cid, [fighter, foe])
+    _advance_to(cid, fighter)
+    server.add_condition(cid, foe, "prone")  # melee attacker vs prone -> advantage
+    res = server.attack(cid, fighter, foe, attack_bonus=4, damage_dice="1d8+3")  # melee
+    assert res["advantage"] is True  # condition advantage intact
+    assert "advantage_source" not in res  # NOT from a marker
+    assert _effects(cid, foe) == []  # no spurious marker created/consumed
 
 
 def test_self_buff_attack_spell_not_deferred_unchanged():


### PR DESCRIPTION
Closes #194 (the consumption half of the Guiding-Bolt fix; #186/#188 did the on-hit registration). The advantage marker on the target now actually GRANTS advantage to the next attack, deterministically — no longer reliant on the DM passing advantage=true. General design: ActiveEffect.grants_advantage flag + a one-line _ADVANTAGE_GRANTING_SPELLS registry (the single extension point for future riders); attack_modifiers returns advantage=True when the target carries such an effect (pure); attack() consumes it by IDENTITY after the roll (hit or miss per 5e RAW 'next attack roll', so exactly one attack benefits; a refreshed same-name effect isn't clobbered). Conditions / non-marked targets / the GB cast itself verified unaffected. 10 new tests + 159 combat/effects/spellcasting + FULL suite 1223 single-process, 0 regressions. Rebased clean onto the faction-arcs main. Local-gated.