### PR TITLE
qa(combat-sprint): enrich the seed (subclasses + save-spells + save-enemy + run-to-kill) — #195

### DIFF
--- a/qa/play_prompt_combat_sprint.txt
+++ b/qa/play_prompt_combat_sprint.txt
@@ -14,21 +14,21 @@ PROCEDURE — follow exactly, no deviation:
 4. Run 3 FULL combat rounds. In each round:
    a. Call next_turn(campaign_id) to advance the initiative tracker.
    b. For each combatant whose turn it is, resolve their action with a real engine call:
-      - Aldric (fighter): attack(campaign_id, attacker_id=player_id, target_id=<a bandit or captain>, weapon="longsword")
-      - Maren (cleric): alternate between cast_spell(campaign_id, caster_id=companion_id, spell_name="Guiding Bolt", target_id=<a hostile>) and apply_healing(campaign_id, target_id=player_id, amount=<roll result>) after Cure Wounds — use saving_throw(campaign_id, character_id=<target>, dc=<Maren's spell save DC>, ability="constitution") for save-or-half spells.
-      - Monsters: attack(campaign_id, attacker_id=<monster_id>, target_id=<player_id or companion_id>, weapon=<their weapon name from notes>)
+      - Aldric (Battle Master fighter): attack(campaign_id, attacker_id=player_id, target_id=<a hostile>, attack_bonus=6, damage_dice="1d8+4", damage_type="slashing") (longsword: STR +4 & proficiency +2 = +6; the engine rolls vs AC and applies damage). Aldric has Superiority Dice — at least once, spend one on a maneuver: call use_resource(campaign_id, character_id=player_id, resource="superiority_dice") for the die, then resolve the maneuver's rider as SEPARATE calls (Trip Attack -> saving_throw(..., ability="str") and on a fail add_condition(..., condition="prone"); Menacing -> a WIS save then condition="frightened").
+      - Maren (War Domain cleric): rotate her spells so BOTH families are exercised. First read her DC once via spell_save_dc(campaign_id, character_id=companion_id) — never invent it. At least once cast a SAVE-spell: cast_spell(campaign_id, character_id=companion_id, spell_name="Hold Person", target_id=<the Bandit Captain>) (or "Bane"), then roll the target's save with saving_throw(campaign_id, character_id=<target>, dc=<that DC>, ability="wis") (Hold Person = WIS save; Bane = "cha"), and on a FAILED save call add_condition(campaign_id, character_id=<target>, condition="paralyzed") for Hold Person. Otherwise alternate cast_spell(character_id=companion_id, spell_name="Guiding Bolt"/"Sacred Flame", target_id=<hostile>) and apply_healing(campaign_id, target_id=player_id, amount=<roll result>) after Cure Wounds.
+      - Monsters: attack(campaign_id, attacker_id=<monster_id>, target_id=<player_id or companion_id>, attack_bonus=<from the monster's notes>, damage_dice=<from notes>, damage_type=<from notes>). The GHOUL: on a Claw HIT, resolve its paralysis RIDER as a SEPARATE call — saving_throw(campaign_id, character_id=<the target>, dc=10, ability="con"); on a FAILED save call add_condition(campaign_id, character_id=<the target>, condition="paralyzed"). Run the rider even if the hit would not have killed. (Ability codes are 3-letter: str/dex/con/int/wis/cha.)
    c. Every number (to-hit, damage, save DC) comes from a tool call — never invent dice.
-   d. If a combatant drops to 0 HP, call remove_combatant(campaign_id, character_id=<id>) and one sentence of narration.
+   d. If a combatant drops to 0 HP, call remove_combatant(campaign_id, character_id=<id>) and one sentence of narration. (The lone Bandit should fall fast — that validates the kill/XP path.)
    e. One sentence of narration per round (vivid, present-tense). No more.
 
 5. After round 3 (or when all hostiles are removed), call end_combat(campaign_id).
 
-6. Call end_session(campaign_id, summary="Combat sprint — 3 rounds vs Bandits + Bandit Captain.").
+6. Call end_session(campaign_id, summary="Combat sprint — 3 rounds vs a Bandit, a Bandit Captain, and a Ghoul.").
 
 7. STOP. Do not add epilogue, do not call any other tools.
 
 RULES:
 - Every mechanical outcome must come from a tool call, not prose invention.
-- No hand-waving ("they defeat the bandits") — each attack, save, and damage value is a real roll.
+- No hand-waving ("they defeat the bandits") — each attack, save, damage value, and rider (the Ghoul's paralysis, a maneuver's effect, a save-spell's condition) is a real, separate tool call.
 - One sentence of narration per round maximum; keep it present-tense and punchy.
 - If a tool errors, log the error text and continue with the next combatant — do not abort.

--- a/qa/pre_seed_combat.py
+++ b/qa/pre_seed_combat.py
@@ -10,7 +10,25 @@ the entire Baldur's Gate lore corpus (~330 locations, all wiki pages) — severa
 seconds of I/O that is irrelevant to the Angry-DM rubric (get_state / attack /
 next_turn never touch world_id). The minimal path is ~50 ms and gives the rubric
 everything it needs: a real location, a fighter PC, a cleric companion (caster
-coverage so the rubric doesn't self-penalise), and 4 hostiles.
+coverage so the rubric doesn't self-penalise), and a hostile encounter.
+
+Enrichment (#195) — the seed deliberately spans the FULL 5e combat surface so the
+combat-sprint stops being a coverage-capped weapon-swing and starts surfacing the
+next batch of real engine/adherence gaps. The Angry-DM rubric's section 8 docks a
+"level-3 Battle Master who never has/uses Superiority Dice" and its section 5 names
+"a ghoul's paralysis" rider; this seed populates exactly those hooks:
+  - Aldric is a **Battle Master** Fighter; Superiority Dice are seeded with
+    set_class_resource (the SRD tables only auto-derive BASE-class pools — a Battle
+    Master's dice are invisible to the engine until registered), so maneuvers
+    (Riposte / Trip Attack / Precision) are exercisable.
+  - Maren is a **War Domain** Cleric; her Channel Divinity pool is auto-seeded by
+    apply_srd_defaults (Cleric CD from L2), and her prepared list carries SAVE-
+    requiring spells (Bane, Hold Person) so the cast_spell -> spell_save_dc ->
+    saving_throw -> add_condition pipeline can fire.
+  - The encounter includes a **Ghoul**, whose Claw forces a CON save or Paralyzed —
+    so saves are forced on the party REGARDLESS of the casters' spell choices.
+  - The mook count is tuned so the fight CAN run to at least one enemy at 0 HP in
+    ~3-5 rounds (the XP-award path validates) while staying non-trivial.
 
 Usage (from repo root):
     CLAWDND_STATE_DIR=<dir> uv run --directory servers/engine python qa/pre_seed_combat.py <state_dir>
@@ -64,9 +82,14 @@ def main() -> None:
     # ── 2. Start a session ───────────────────────────────────────────────────
     server.start_session(campaign_id, title="Combat Sprint")
 
-    # ── 3. Fighter PC (L4) ───────────────────────────────────────────────────
+    # ── 3. Fighter PC (L4 Battle Master) ─────────────────────────────────────
     # apply_srd_defaults=True: sets proficiency bonus, HP (Fighter d10 + CON),
-    # saving throws, and AC via chain mail so the rubric sees a real AC value.
+    # saving throws, base-class pools (Second Wind, Action Surge), and AC via chain
+    # mail so the rubric sees a real AC value.
+    # subclass="Battle Master": the Martial Archetype Aldric took at L3. The SRD
+    # tables auto-derive only BASE-class pools, so the subclass's Superiority Dice
+    # are seeded explicitly below (set_class_resource) — without that a Battle
+    # Master has no dice to spend and the rubric flags the missing feature exercise.
     fighter = server.create_character(
         campaign_id=campaign_id,
         name="Aldric",
@@ -83,14 +106,31 @@ def main() -> None:
             "charisma": 10,
         },
         background="soldier",
+        subclass="Battle Master",
         apply_srd_defaults=True,
         skills=["athletics", "perception", "intimidation", "history"],
     )
     player_id = fighter["id"]
 
-    # ── 4. Cleric companion (L4, caster coverage) ────────────────────────────
+    # Seed the Battle Master's Superiority Dice (SRD 5.2: 4 dice at L3-6, each a d8
+    # until L10; short-rest recharge). Now Riposte / Trip Attack / Precision Attack /
+    # Menacing Attack have a real pool to spend against during the sprint.
+    server.set_class_resource(
+        campaign_id=campaign_id,
+        character_id=player_id,
+        resource="superiority_dice",
+        max=4,
+        recharge="short",
+        size="d8",
+    )
+
+    # ── 4. Cleric companion (L4 War Domain, caster coverage) ──────────────────
     # The Angry-DM rubric docks points when a session has no caster; the cleric
     # companion ensures cast_spell / saving_throw paths are exercised.
+    # subclass="War Domain": a domain Cleric whose Channel Divinity (Guided Strike /
+    # War God's Blessing) is auto-seeded by apply_srd_defaults (Cleric CD from L2 ->
+    # 2 uses at L4), so a subclass feature pool is populated + testable without any
+    # extra set_class_resource call.
     cleric = server.create_character(
         campaign_id=campaign_id,
         name="Maren",
@@ -107,29 +147,57 @@ def main() -> None:
             "charisma": 14,
         },
         background="acolyte",
+        subclass="War Domain",
         apply_srd_defaults=True,
         skills=["medicine", "religion", "insight", "persuasion"],
     )
     companion_id = cleric["id"]
 
-    # Give Maren her spells (replaces the list — signatures: campaign_id, character_id, spells_list)
-    server.learn_spells(campaign_id, companion_id, [
+    # Maren's spellbook — known + prepared (clerics PREPARE from the full list; the
+    # engine reads spells_known | spells_prepared when validating a cast).
+    # Rotation deliberately mixes the families the rubric tracks:
+    #   - SAVE-requiring control: Bane (CHA save, debuff) + Hold Person (WIS save ->
+    #     Paralyzed) — these drive cast_spell -> spell_save_dc -> saving_throw ->
+    #     add_condition, the pipeline the vanilla seed never exercised.
+    #   - Attack-roll / radiant: Guiding Bolt, Sacred Flame, Spiritual Weapon.
+    #   - Healing: Cure Wounds, Healing Word (apply_healing path).
+    spell_list = [
+        "Bane",
+        "Hold Person",
         "Cure Wounds",
+        "Healing Word",
         "Guiding Bolt",
         "Sacred Flame",
         "Spiritual Weapon",
-        "Healing Word",
-    ])
+    ]
+    # learn_spells sets spells_known; prepare_spells sets spells_prepared (clerics
+    # prepare). Seed BOTH so the cast-validation never rejects a save-spell as unknown.
+    server.learn_spells(campaign_id, companion_id, spell_list)
+    server.prepare_spells(campaign_id, companion_id, spell_list)
 
-    # ── 5. Hostile encounter: 3 Bandits + 1 Bandit Captain ───────────────────
-    # Balanced-deadly for a L4 party of 2: CR 1/8 × 3 + CR 2 × 1 ≈ 850 XP
-    # (deadly threshold for a 2-person L4 party is ~700 XP — tight but fair).
-    bandits = server.spawn_monster(campaign_id, "Bandit", count=3)
+    # ── 5. Hostile encounter: 1 Bandit + 1 Bandit Captain + 1 Ghoul ──────────
+    # Tuned so the fight CAN finish (run-to-kill -> XP-award path validates) while
+    # staying non-trivial, AND so a SAVE is forced regardless of the casters' choices:
+    #   - Bandit       CR 1/8, 11 HP, AC 12  — the soft mook: a single longsword hit
+    #                  or Guiding Bolt drops it, so at least one enemy reaches 0 HP in
+    #                  round 1-2 and end_combat auto-awards XP.
+    #   - Bandit Captain CR 2, 52 HP, AC 15  — the durable "boss" the party grinds; a
+    #                  real threat (Multiattack + a parry reaction) that keeps the
+    #                  3-5 round fight honest rather than a walkover.
+    #   - Ghoul        CR 1, 22 HP, AC 12    — its Claw forces a DC 10 CON save or the
+    #                  target is Paralyzed (a SEPARATE saving_throw + add_condition
+    #                  rider). This guarantees the save -> condition pipeline fires on
+    #                  the PARTY even if Maren only ever casts attack-roll/heal spells.
+    # Raw XP 25 + 450 + 200 = 675; deadly-band for a 2× L4 party but very survivable
+    # because two of the three foes are low-HP and fall fast.
+    bandits = server.spawn_monster(campaign_id, "Bandit", count=1)
     captain = server.spawn_monster(campaign_id, "Bandit Captain", count=1)
+    ghoul = server.spawn_monster(campaign_id, "Ghoul", count=1)
 
     bandit_ids = [s["id"] for s in bandits["spawned"]]
     captain_ids = [s["id"] for s in captain["spawned"]]
-    monster_ids = bandit_ids + captain_ids
+    ghoul_ids = [s["id"] for s in ghoul["spawned"]]
+    monster_ids = bandit_ids + captain_ids + ghoul_ids
 
     all_combatant_ids = [player_id, companion_id] + monster_ids
 
@@ -138,6 +206,11 @@ def main() -> None:
         "player_id": player_id,
         "companion_id": companion_id,
         "monster_ids": monster_ids,
+        # Named ids so the DM prompt can route the save-enemy + save-spells precisely
+        # (the Ghoul's paralysis rider, Hold Person on the Captain, etc.).
+        "bandit_ids": bandit_ids,
+        "captain_id": captain_ids[0] if captain_ids else None,
+        "ghoul_id": ghoul_ids[0] if ghoul_ids else None,
         "all_combatant_ids": all_combatant_ids,
     }
     print(json.dumps(result))

--- a/qa/smoke_pre_seed_combat.py
+++ b/qa/smoke_pre_seed_combat.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Cheap zero-LLM smoke for the enriched combat-sprint seed (#195).
+
+Runs qa/pre_seed_combat.py exactly the way run_combat_sprint.sh does (same
+subprocess + state dir), then re-opens the persisted campaign and asserts — and
+PRINTS — the enrichment the seed is supposed to carry:
+
+  1. Both PCs have an explicit SUBCLASS (Aldric = Battle Master, Maren = War Domain).
+  2. A subclass-resource pool is SEEDED and NON-ZERO for each (Aldric's Superiority
+     Dice via set_class_resource; Maren's Channel Divinity via apply_srd_defaults).
+  3. Maren's prepared rotation contains at least one SAVE-requiring spell
+     (Bane / Hold Person / Inflict Wounds).
+  4. A SAVE-inducing enemy (a Ghoul) is present in the encounter.
+
+This is NOT the full claude -p combat-sprint (that heavy run measures the coverage
+lift after merge). It only proves the seed populates the hooks the Angry-DM lens
+needs, so the follow-up run can actually exercise them.
+
+Run from the repo root with the engine venv (pass an ABSOLUTE path — `uv run
+--directory` cd's into servers/engine, so a relative `qa/...` won't resolve):
+    uv run --directory servers/engine python "$(pwd)/qa/smoke_pre_seed_combat.py"
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[1]
+_ENGINE = _ROOT / "servers" / "engine"
+_SEED = _ROOT / "qa" / "pre_seed_combat.py"
+
+# Save-requiring spells the rubric asks the caster to be able to throw (#195).
+_SAVE_SPELLS = {"bane", "hold person", "inflict wounds"}
+# Enemies whose stat block carries a save-or-condition rider.
+_SAVE_ENEMIES = {"ghoul", "ghast"}
+
+
+def _fail(msg: str) -> None:
+    print(f"  FAIL: {msg}")
+
+
+def main() -> int:
+    state_dir = tempfile.mkdtemp(prefix="clawdnd-smoke-")
+    env = dict(os.environ, CLAWDND_STATE_DIR=state_dir)
+
+    # ── Run the real seed entrypoint (subprocess, exactly like the harness) ──
+    proc = subprocess.run(
+        ["python", str(_SEED), state_dir],
+        cwd=str(_ENGINE),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0 or not proc.stdout.strip():
+        print("SEED FAILED to produce output:")
+        print(proc.stderr or "(no stderr)")
+        return 1
+    seed = json.loads(proc.stdout.strip().splitlines()[-1])
+
+    # ── Re-open the persisted campaign via the engine API ────────────────────
+    sys.path.insert(0, str(_ENGINE))
+    os.environ["CLAWDND_STATE_DIR"] = state_dir
+    import server  # noqa: PLC0415
+
+    cid = seed["campaign_id"]
+    aldric = server.get_character(cid, seed["player_id"])
+    maren = server.get_character(cid, seed["companion_id"])
+
+    ok = True
+    print("=== combat-sprint seed smoke (#195) ===")
+    print(f"campaign_id: {cid}")
+    print(f"state_dir:   {state_dir}")
+
+    # 1+2. Subclasses + seeded, non-zero subclass-resource pools ──────────────
+    def _subclass(sheet: dict) -> str:
+        classes = sheet.get("classes") or [{}]
+        return (classes[0].get("subclass") or "").strip()
+
+    def _resources(sheet: dict) -> dict:
+        return sheet.get("class_resources") or {}
+
+    print("\n-- PCs: subclass + class resources --")
+    for sheet, want_sub, want_pool in (
+        (aldric, "Battle Master", "superiority_dice"),
+        (maren, "War Domain", "channel_divinity"),
+    ):
+        name = sheet.get("name")
+        sub = _subclass(sheet)
+        res = _resources(sheet)
+        # Render every pool as id=used/max(size) so the seeded values are visible.
+        rendered = ", ".join(
+            f"{rid}={v.get('max', 0) - v.get('used', 0)}/{v.get('max', 0)}"
+            + (f"({v.get('size')})" if v.get("size") else "")
+            for rid, v in res.items()
+        ) or "(none)"
+        print(f"  {name}: subclass={sub!r} | resources: {rendered}")
+        if not sub:
+            ok = False
+            _fail(f"{name} has no subclass set")
+        elif sub.lower() != want_sub.lower():
+            ok = False
+            _fail(f"{name} subclass is {sub!r}, expected {want_sub!r}")
+        pool = res.get(want_pool)
+        if not pool:
+            ok = False
+            _fail(f"{name} is missing the {want_pool!r} pool")
+        elif int(pool.get("max", 0)) <= 0:
+            ok = False
+            _fail(f"{name} {want_pool!r} pool has max={pool.get('max')} (expected > 0)")
+
+    # 3. Maren carries at least one save-requiring spell ──────────────────────
+    print("\n-- Maren: save-requiring spell present --")
+    known = {s.lower() for s in (maren.get("spells_known") or [])}
+    prepared = {s.lower() for s in (maren.get("spells_prepared") or [])}
+    available = known | prepared
+    save_hits = sorted(_SAVE_SPELLS & available)
+    dc = server.spell_save_dc(cid, seed["companion_id"]).get("spell_save_dc")
+    print(f"  prepared: {sorted(maren.get('spells_prepared') or [])}")
+    print(f"  save-spells present: {save_hits or '(none)'} | spell_save_dc={dc}")
+    if not save_hits:
+        ok = False
+        _fail("Maren has no save-requiring spell (Bane / Hold Person / Inflict Wounds)")
+
+    # 4. A save-inducing enemy is in the encounter ────────────────────────────
+    print("\n-- Encounter: save-inducing enemy present --")
+    monsters = [server.get_character(cid, mid) for mid in seed.get("monster_ids", [])]
+    roster = [m.get("name", "") for m in monsters]
+    save_enemy = [m for m in monsters if any(tag in m.get("name", "").lower() for tag in _SAVE_ENEMIES)]
+    print(f"  monsters: {roster}")
+    if save_enemy:
+        g = save_enemy[0]
+        # Surface the rider text from notes so the save trigger is human-verifiable.
+        print(f"  save-inducing enemy: {g.get('name')} (notes mention a save: "
+              f"{'yes' if 'saving throw' in (g.get('notes') or '').lower() else 'check actions'})")
+    else:
+        ok = False
+        _fail("no save-inducing enemy (Ghoul / Ghast) in the encounter")
+
+    print("\n=== SMOKE: " + ("PASS" if ok else "FAIL") + " ===")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #195. The combat-sprint now exercises the full 5e surface (was coverage-capped ~3). Aldric=Battle Master (superiority_dice seeded), Maren=War Domain (Channel Divinity); Bane + Hold Person save-spells; a Ghoul forces a CON-save-or-paralyzed; run-to-kill roster validates XP. Also fixed pre-existing prompt signature bugs. Smoke PASS + pipeline check. Local-gated.