### PR TITLE
fix(combat): auto-enforce repeat-save conditions (Hold Person/Monster self-resolve) — #209

### DIFF
--- a/servers/engine/combat.py
+++ b/servers/engine/combat.py
@@ -194,6 +194,18 @@ def is_incapacitated(ch: Character) -> bool:
 SAVE_AUTOFAIL = {Condition.PARALYZED, Condition.PETRIFIED, Condition.STUNNED, Condition.UNCONSCIOUS}
 
 
+def save_modifiers(ch: Character, ability: Ability) -> tuple[bool, bool]:
+    """The SRD condition rules that bend a saving throw, as (auto_fail, disadvantage) —
+    pure, no roll, no mutation. paralyzed/petrified/stunned/unconscious AUTO-FAIL STR & DEX
+    saves; restrained gives DISADVANTAGE on DEX saves. Factored out so every save site
+    (`saving_throw`, the grapple/shove saves, the #209 end-of-turn repeat save in
+    `next_turn`) applies one identical rule set instead of re-deriving it."""
+    conds = set(ch.conditions)
+    auto_fail = ability in (Ability.STR, Ability.DEX) and bool(conds & SAVE_AUTOFAIL)
+    disadvantage = ability == Ability.DEX and Condition.RESTRAINED in conds
+    return auto_fail, disadvantage
+
+
 # A melee hit within 5 ft of an Unconscious or Paralyzed creature is automatically
 # a Critical Hit (SRD). We have no distance model, so a non-ranged attack is
 # treated as being within 5 ft.
@@ -477,6 +489,13 @@ def tick_round_effects(ch: Character) -> list[str]:
     expired: list[ActiveEffect] = []
     surviving: list[ActiveEffect] = []
     for eff in ch.active_effects:
+        # A repeat-save marker (#209: Hold Person → paralyzed) is a CONDITION tracker, not a
+        # round-timed buff — its lifetime is the recurring end-of-turn save (next_turn) + the
+        # caster's concentration, NOT a round counter. So it's exempt from the round-tick
+        # decrement (it carries no meaningful rounds_remaining and must not expire on a tick).
+        if eff.repeat_save is not None:
+            surviving.append(eff)
+            continue
         if eff.scale in ("rounds", "minutes"):
             eff.rounds_remaining -= 1
             if eff.rounds_remaining <= 0:
@@ -544,6 +563,19 @@ def expire_concentration_effects(ch: Character) -> list[str]:
     if expired:
         ch.active_effects = [eff for eff in ch.active_effects if not eff.concentration]
     return expired
+
+
+def end_repeat_save_effect(ch: Character, eff: ActiveEffect) -> None:
+    """Remove a save-ends effect from its holder after a successful end-of-turn repeat
+    save (#209), and clear the condition it imposed so the holder is genuinely freed
+    (Hold Person's effect leaves AND the `paralyzed` condition lifts — one source of
+    truth). Mutates ONLY the holder `ch`. The CASTER's concentration twin (held on a
+    different Character) is ended by the server layer, which has both characters in hand.
+    A no-op-safe identity removal: the exact effect object is dropped by identity, and the
+    imposed condition removed if present."""
+    ch.active_effects = [e for e in ch.active_effects if e is not eff]
+    if eff.imposes_condition is not None:
+        ch.conditions = [cn for cn in ch.conditions if cn != eff.imposes_condition]
 
 
 # --- Grapple / Shove (SRD 5.2 / 2024 Unarmed Strike options) ---------------

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -445,6 +445,30 @@ class CompanionDossier(_StrictModel):
     relationships: dict[str, str] = Field(default_factory=dict)
 
 
+class RepeatSave(_StrictModel):
+    """An END-OF-TURN repeat saving throw that the ENGINE rolls for the holder of an
+    ActiveEffect, so a "save-ends" spell (Hold Person → paralyzed: "the target repeats
+    the save at the end of each of its turns, ending the effect on a success") doesn't
+    leave its victim locked forever because the DM forgot to prompt the save (#209).
+
+    Carried on the TARGET-side ActiveEffect (the one whose holder owes the save).
+    `next_turn` rolls `saving_throw_bonus(ability)` vs `dc` for the combatant whose turn
+    is ENDING; on a SUCCESS the engine removes the effect (and, when `ends_effect`, the
+    condition it imposed + the caster's concentration twin); on a FAILURE the effect
+    persists for another round. The DM narrates the surfaced result — no prompt needed.
+
+    ADDITIVE: optional on ActiveEffect (None == today's behavior — no end-of-turn save),
+    so every existing snapshot round-trips unchanged and only a save-ends effect sets it."""
+
+    ability: Ability  # which save the holder rolls (Hold Person → WIS)
+    dc: int  # the caster's spell save DC (fixed at cast)
+    # On a successful save, end the effect (the 5e "ending the effect on a success" clause).
+    # The few save-ends effects that DON'T end on a single success (e.g. a recurring poison
+    # tick) can carry ends_effect=False — the save still rolls + is reported, but the marker
+    # stays. Defaults True (the Hold Person / paralysis case).
+    ends_effect: bool = True
+
+
 class ActiveEffect(_StrictModel):
     """A timed spell effect the ENGINE tracks so it auto-expires instead of relying
     on the DM to remember (Bless for 10 rounds, Hex for 1 hour, Mage Armor for 8
@@ -495,6 +519,17 @@ class ActiveEffect(_StrictModel):
     # attack resolves (one-shot). Defaults False, so every existing effect (Bless, Hex, Mage
     # Armor) and every old snapshot is untouched — only an advantage-granting rider sets it.
     grants_advantage: bool = False
+    # END-OF-TURN repeat save (#209): a "save-ends" spell (Hold Person, Hypnotic Pattern,
+    # a monster's hold) carries this so `next_turn` rolls the holder's recurring save and
+    # frees them on a success instead of locking them indefinitely. None == no repeat save
+    # (every existing effect / old snapshot). See RepeatSave.
+    repeat_save: Optional[RepeatSave] = None
+    # The condition this effect IMPOSED on its holder (Hold Person → "paralyzed"), so that
+    # when a repeat save ENDS the effect the engine can also clear that condition (one source
+    # of truth — the marker and the condition came together, they leave together). Empty ==
+    # the effect imposes no engine-tracked condition (a pure buff like Bless). Mainly read
+    # alongside repeat_save; only a condition-imposing effect sets it.
+    imposes_condition: Optional[Condition] = None
 
 
 class PendingOnHitRider(_StrictModel):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -72,6 +72,7 @@ from models import (
     Location,
     PendingOnHitRider,
     Quest,
+    RepeatSave,
     SceneDebt,
     SessionLogEntry,
     SpellSlotLevel,
@@ -86,11 +87,22 @@ _AB3_TO_FULL = {
     "wis": "wisdom",
     "cha": "charisma",
 }
+# Reverse: accept either the 3-letter code (the Ability enum value) or the full word
+# (how the SRD records spell saving_throw_ability, e.g. "wisdom") and resolve to an Ability.
+_FULL_TO_AB3 = {full: ab3 for ab3, full in _AB3_TO_FULL.items()}
 from store import append_log, campaign_lock, campaigns_for_world
 from store import list_campaigns as _list_campaigns
 from store import load_campaign, save_campaign
 
 mcp = FastMCP("clawdnd-engine")
+
+
+def _parse_ability(value: str) -> Ability:
+    """Resolve an ability name to the Ability enum, accepting BOTH the 3-letter code
+    ('wis') and the full word ('wisdom') — the latter is how SRD records spell their
+    saving_throw_ability, so a rider DC threaded from cast_spell stays usable verbatim."""
+    v = (value or "").strip().lower()
+    return Ability(_FULL_TO_AB3.get(v, v))
 
 
 def _require(campaign_id: str) -> Campaign:
@@ -1959,12 +1971,32 @@ def update_character(campaign_id: str, character_id: str, patch: dict) -> dict:
 
 
 @mcp.tool()
-def add_condition(campaign_id: str, character_id: str, condition: str) -> dict:
+def add_condition(
+    campaign_id: str,
+    character_id: str,
+    condition: str,
+    repeat_save_ability: str = "",
+    repeat_save_dc: int = 0,
+    source_id: str = "",
+    spell_name: str = "",
+) -> dict:
     """Add a 5e condition to a character (idempotent). Prefer this over patching
     the whole conditions list. Valid values: blinded, charmed, deafened,
     frightened, grappled, incapacitated, invisible, paralyzed, petrified,
-    poisoned, prone, restrained, stunned, unconscious."""
+    poisoned, prone, restrained, stunned, unconscious.
+
+    SAVE-ENDS conditions (#209): for a "the target repeats the save at the end of
+    each of its turns" effect (Hold Person → paralyzed, Hold Monster, a monster's
+    hold), pass `repeat_save_ability` (str/dex/con/int/wis/cha) + `repeat_save_dc`
+    (the caster's spell save DC) so the ENGINE rolls that recurring save in next_turn
+    and frees the target on a success — instead of the target staying locked because
+    the DM forgot to prompt the save. `source_id` (the caster) + `spell_name` link the
+    effect to its concentration so a successful escape also ends the caster's
+    concentration. ADDITIVE: omit these and the condition behaves exactly as before
+    (no end-of-turn save — the DM resolves any save by hand). cast_spell surfaces the
+    `condition_rider` hint telling you exactly which values to pass here."""
     cond = Condition(condition.lower())
+    rs_ability = _parse_ability(repeat_save_ability) if repeat_save_ability else None
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _char(c, character_id)
@@ -1978,6 +2010,41 @@ def add_condition(campaign_id: str, character_id: str, condition: str) -> dict:
         if cond in combat.INCAPACITATING:
             ch.concentration = None  # SRD: incapacitation breaks concentration
             combat.expire_concentration_effects(ch)  # ...and its engine-tracked effect
+        # Save-ends linkage (#209): record a TARGET-side ActiveEffect carrying the recurring
+        # end-of-turn save + the condition it imposed, so next_turn self-enforces the escape.
+        # The marker is NOT a concentration twin (concentration=False) — the caster's twin
+        # lives on the caster; this only remembers "what to roll, what to clear on success".
+        # Re-applying the same save-ends spell/condition refreshes (doesn't stack) the marker.
+        if rs_ability is not None and repeat_save_dc > 0:
+            eff_name = spell_name or f"{cond.value} (save ends)"
+            # Keep source_id as a CONCENTRATION link only when the source spell actually
+            # concentrates (Hold Person does). Then it precisely signals "this marker is the
+            # twin of source_id's concentration" so next_turn frees the target if that
+            # concentration ends. A non-concentration save-ends source (a monster's innate
+            # hold) still self-enforces its end-of-turn save, but carries no concentration link
+            # (source_id dropped) — so the inverse reconciliation never wrongly sweeps it.
+            concentrates = False
+            if spell_name:
+                rec = spells.srd_spell(spell_name)
+                try:
+                    cur_rec = spells.spell_data(spell_name)
+                except ValueError:
+                    cur_rec = None
+                concentrates = bool(
+                    (cur_rec.get("concentration") if cur_rec else None)
+                    or (rec.get("concentration") if rec else None)
+                )
+            ch.active_effects = [e for e in ch.active_effects if e.name != eff_name]
+            ch.active_effects.append(
+                ActiveEffect(
+                    name=eff_name,
+                    source_id=source_id if concentrates else "",
+                    imposes_condition=cond,
+                    repeat_save=RepeatSave(
+                        ability=rs_ability, dc=repeat_save_dc, ends_effect=True
+                    ),
+                )
+            )
         save_campaign(c)
         return {**ch.model_dump(mode="json"), "immune": False, "added": added}
 
@@ -2522,7 +2589,15 @@ def next_turn(campaign_id: str) -> dict:
     dead or removed combatants are skipped). Returns whose turn it is, whether
     they owe a death save (downed and unstable), and a ``turn_brief`` with their
     authoritative attack line + available limited resources so the DM never drifts
-    from the sheet numbers mid-combat (#166)."""
+    from the sheet numbers mid-combat (#166).
+
+    Also self-enforces SAVE-ENDS effects (#209): the OUTGOING combatant (whose turn
+    just ended) automatically rolls any repeat-save it carries (Hold Person → a WIS
+    save to shake off paralysis), reported in ``repeat_saves`` — a success frees it
+    (clearing the condition + the caster's concentration); a failure keeps the lock.
+    A paralyzed target whose caster loses concentration is freed here too (the inverse
+    link), surfaced in ``expired_effects``. So nothing stays locked because the DM
+    forgot to prompt the save."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         order = c.combat.order
@@ -2553,6 +2628,68 @@ def next_turn(campaign_id: str) -> dict:
                     f"(attack / cast_spell / use_action) or declare a pass via "
                     f"use_action(kind='skip') before advancing."
                 )
+        # --- End-of-turn REPEAT SAVES (#209): engine-rolls-and-tells ----------------
+        # A save-ends effect (Hold Person → paralyzed: "the target repeats the save at
+        # the END of each of its turns, ending the effect on a success") must get that
+        # save automatically, or its victim stays locked forever when the DM forgets to
+        # prompt it. So for the OUTGOING combatant (whose turn is ending — same anchor as
+        # the PC-skip guard above), roll each repeat-save-bearing active_effect's save via
+        # the shared resolver and free them on a success. The engine resolves it; results
+        # are surfaced in the return so the DM narrates the escape (or the continued hold).
+        repeat_save_results: list[dict] = []
+        if previous is not None:
+            # Snapshot the list — end_repeat_save_effect mutates previous.active_effects.
+            for eff in list(previous.active_effects):
+                rs = eff.repeat_save
+                if rs is None:
+                    continue
+                auto_fail, disadvantage = combat.save_modifiers(previous, rs.ability)
+                r = dice_mod.roll(
+                    f"1d20+{previous.saving_throw_bonus(rs.ability)}",
+                    disadvantage=disadvantage,
+                )
+                success = (not auto_fail) and r.total >= rs.dc
+                entry = {
+                    "character_id": previous.id,
+                    "name": eff.name,
+                    "ability": rs.ability.value,
+                    "dc": rs.dc,
+                    "roll": r.total,
+                    "natural": r.natural,
+                    "success": success,
+                    "ended": False,
+                }
+                if auto_fail:
+                    forcing = ", ".join(
+                        cn.value for cn in previous.conditions if cn in combat.SAVE_AUTOFAIL
+                    )
+                    entry["reason"] = (
+                        f"condition auto-fail: {previous.name} is {forcing} — "
+                        f"STR/DEX saves automatically fail"
+                    )
+                if disadvantage:
+                    entry["disadvantage"] = True
+                if success and rs.ends_effect:
+                    ended_condition = eff.imposes_condition
+                    # End the CASTER's concentration twin if this effect came from a
+                    # concentration spell (the twin lives on the caster, not on this
+                    # target-side marker). One source of truth: the spell is over, so the
+                    # caster's concentration field + its flagged effect both clear.
+                    caster = c.characters.get(eff.source_id) if eff.source_id else None
+                    if (
+                        caster is not None
+                        and caster is not previous
+                        and caster.concentration == eff.name
+                    ):
+                        caster.concentration = None
+                        combat.expire_concentration_effects(caster)
+                        entry["concentration_ended_for"] = caster.id
+                    # Remove the effect from the target + clear the condition it imposed.
+                    combat.end_repeat_save_effect(previous, eff)
+                    entry["ended"] = True
+                    if ended_condition is not None:
+                        entry["cleared_condition"] = ended_condition.value
+                repeat_save_results.append(entry)
         n = len(order)
         cur = None
         new_round = False
@@ -2593,10 +2730,37 @@ def next_turn(campaign_id: str) -> dict:
                     continue
                 for name in combat.tick_round_effects(holder):
                     expired.append({"character_id": holder.id, "name": name})
+        # CONCENTRATION-LINK reconciliation (#209, the inverse direction): a repeat-save
+        # marker (Hold Person → paralyzed) is the TARGET-side twin of the CASTER's
+        # concentration. If that concentration has ended for ANY reason — its duration just
+        # ticked out above, or it broke earlier (failed save / incapacitation / 0 HP / a
+        # recast) — the spell is over, so the target must be freed here rather than staying
+        # paralyzed indefinitely. Sweep every combatant's markers: when the source caster no
+        # longer concentrates on that spell, drop the marker + clear the condition it imposed.
+        for cb in order:
+            holder = c.characters.get(cb.character_id)
+            if holder is None:
+                continue
+            for eff in list(holder.active_effects):
+                if eff.repeat_save is None or not eff.source_id:
+                    continue
+                caster = c.characters.get(eff.source_id)
+                # Marker is orphaned when the caster is gone, or no longer concentrating on
+                # this spell (concentration twin broken/expired). A non-concentration save-ends
+                # source (caster never concentrated) is left alone — nothing ties it to a twin.
+                caster_concentrating = caster is not None and caster.concentration == eff.name
+                if caster is not None and not caster_concentrating:
+                    combat.end_repeat_save_effect(holder, eff)
+                    expired.append({"character_id": holder.id, "name": eff.name})
         view = _combat_view(c)
         view["current_name"] = cur.name if cur else None
         view["death_save_due"] = bool(cur and cur.current_hp == 0 and not cur.dead and not cur.stable)
         view["expired_effects"] = expired
+        # End-of-turn repeat saves the engine just rolled for the OUTGOING combatant (#209):
+        # each carries success + whether the effect/condition ended, so the DM narrates the
+        # escape ("the paralysis loosens its grip") or the continued hold. Empty == none owed.
+        if repeat_save_results:
+            view["repeat_saves"] = repeat_save_results
         # Surface per-turn authoritative attack line + available resources so the DM
         # has the sheet numbers AT THE TRIGGER POINT — not just at start_combat (#166).
         # Only when combat is active and there's a living current combatant.
@@ -2622,6 +2786,7 @@ def next_turn(campaign_id: str) -> dict:
                 "turn_index": c.combat.turn_index,
                 "death_save_due": view["death_save_due"],
                 "expired_effects": expired,
+                "repeat_saves": repeat_save_results,
             },
             speaker=cur.name if cur else "",
         )
@@ -3961,6 +4126,35 @@ def cast_spell(
                 "spell_save_dc) then apply_damage(base_damage, damage_types, "
                 "half=<save succeeded>); healing via apply_healing."
             )
+            # SAVE-ENDS rider hint (#209): for a "repeats the save at the end of each of
+            # its turns, ending on a success" condition spell (Hold Person → paralyzed,
+            # Hold Monster), tell the DM exactly which self-enforcing add_condition call to
+            # make on a FAILED initial save. Passing repeat_save_ability/dc/source/spell to
+            # add_condition wires the ENGINE to roll the recurring save in next_turn and free
+            # the target on a success — no manual end-of-turn prompting. Only the unambiguous
+            # single-condition pattern surfaces this (spells.repeat_save_rider is conservative).
+            rider = spells.repeat_save_rider(srd)
+            if rider is not None and target_id and target_id != character_id:
+                save_dc = 8 + prof + mod
+                # Normalize the ability to the canonical 3-letter code (the Ability enum value
+                # next_turn reports + saving_throw expects) — SRD records carry the full word.
+                rs_ab = _parse_ability(rider["ability"]).value
+                result["condition_rider"] = {
+                    "condition": rider["condition"],
+                    "repeat_save_ability": rs_ab,
+                    "repeat_save_dc": save_dc,
+                    "source_id": character_id,
+                    "spell_name": canonical,
+                    "target_id": target_id,
+                    "note": (
+                        f"On a FAILED initial {rs_ab} save, apply via "
+                        f"add_condition(character_id='{target_id}', condition='{rider['condition']}', "
+                        f"repeat_save_ability='{rs_ab}', repeat_save_dc={save_dc}, "
+                        f"source_id='{character_id}', spell_name='{canonical}'). The engine then "
+                        f"rolls the end-of-turn repeat save in next_turn and frees the target on a "
+                        f"success (ending this concentration) — no manual prompting."
+                    ),
+                }
         # Zone-aware range for a TOUCH/melee spell (S2.7): same rule as a melee
         # attack — advisory, never blocks, inert without declared zones. Position
         # lives on the Combatant records.
@@ -3987,9 +4181,7 @@ def saving_throw(campaign_id: str, character_id: str, ability: str, dc: int) -> 
     c = _require(campaign_id)
     ch = _char(c, character_id)
     ab = Ability(ability.lower())
-    conds = set(ch.conditions)
-    auto_fail = ab in (Ability.STR, Ability.DEX) and bool(conds & combat.SAVE_AUTOFAIL)
-    disadvantage = ab == Ability.DEX and Condition.RESTRAINED in conds
+    auto_fail, disadvantage = combat.save_modifiers(ch, ab)
     r = dice_mod.roll(f"1d20+{ch.saving_throw_bonus(ab)}", disadvantage=disadvantage)
     out = {"ability": ab.value, "roll": r.total, "natural": r.natural, "dc": dc,
            "success": (not auto_fail) and r.total >= dc}

--- a/servers/engine/spells.py
+++ b/servers/engine/spells.py
@@ -192,3 +192,48 @@ def parse_duration(duration: Optional[str]) -> Optional[dict]:
     if unit in ("day",):
         return {"scale": "days", "rounds": 0, "hours": 0, "days": n}
     return None
+
+
+# 5e condition names the engine tracks (mirrors models.Condition); used to spot which
+# condition a save-ends spell imposes. Kept here (not imported) so spells.py stays a
+# pure, I/O-light data helper with no model dependency.
+_TRACKED_CONDITIONS = (
+    "blinded", "charmed", "deafened", "frightened", "grappled", "incapacitated",
+    "invisible", "paralyzed", "petrified", "poisoned", "prone", "restrained",
+    "stunned", "unconscious",
+)
+# The canonical "at the END OF EACH OF ITS TURNS the target repeats the save, ending the
+# spell on a single success" clause shared by Hold Person / Hold Monster (and any future
+# spell worded identically). Deliberately anchored on the END-OF-TURN trigger: a spell whose
+# recurring save fires on a DIFFERENT trigger (Dominate Person/Beast/Monster: "whenever the
+# target takes damage") must NOT match — the engine only owns the END-OF-TURN save, so
+# auto-imposing it on a damage-triggered spell would roll a save 5e doesn't grant. Likewise
+# multi-success (Contagion) and detached-clause (Weird) wordings don't match.
+_REPEAT_SAVE_RE = re.compile(
+    r"at the end of each of its turns,\s*the target repeats the save,\s*"
+    r"ending the spell on itself on a success",
+    re.IGNORECASE,
+)
+
+
+def repeat_save_rider(srd_record: Optional[dict]) -> Optional[dict]:
+    """For a save-ends condition spell whose victim "repeats the save at the end of each
+    of its turns, ending the spell on itself on a success" (Hold Person, Hold Monster),
+    return ``{ability, condition}`` — the recurring save's ability and the single condition
+    it imposes — so cast_spell can tell the DM exactly how to apply it self-enforcingly
+    (#209). Returns None for any other spell.
+
+    GENERAL, not Hold-Person-special: it keys off the canonical SRD wording + a single
+    tracked condition, so it fires for Hold Monster too and would fire for a new spell
+    worded the same way. Intentionally conservative — a spell with multi-condition or
+    multi-success recurring-save semantics returns None (the engine won't guess wrong)."""
+    if not srd_record:
+        return None
+    ability = (srd_record.get("saving_throw_ability") or "").strip().lower()
+    desc = (srd_record.get("desc") or "").lower()
+    if not ability or not _REPEAT_SAVE_RE.search(desc):
+        return None
+    found = [cn for cn in _TRACKED_CONDITIONS if re.search(rf"\b{cn}\b", desc)]
+    if len(found) != 1:
+        return None  # only the unambiguous single-condition case self-enforces
+    return {"ability": ability, "condition": found[0]}

--- a/servers/engine/tests/test_effect_durations.py
+++ b/servers/engine/tests/test_effect_durations.py
@@ -416,6 +416,250 @@ def test_self_buff_attack_spell_not_deferred_unchanged():
     assert [e["name"] for e in _effects(cid, w)] == ["Mirror Image"]  # applied at cast, as before
 
 
+# --- End-of-turn REPEAT SAVES (#209): Hold Person → paralyzed self-enforces ----------
+# A save-ends spell ("the target repeats the save at the end of each of its turns, ending
+# the spell on a success") must get that recurring save automatically in next_turn, or its
+# victim stays locked forever when the DM forgets to prompt it. The engine rolls the save
+# for the OUTGOING combatant, frees them on a success (clearing the condition + the caster's
+# concentration), and surfaces the result so the DM narrates it.
+
+import models  # noqa: E402  (RepeatSave / ActiveEffect direct construction)
+
+
+def _hold_caster(cid, name="Pious", wis=16):
+    """A cleric who knows + has Hold Person prepared, with a 2nd-level slot to cast it."""
+    c = _cleric(cid, name, wisdom=wis)
+    server.level_up(cid, c, "Cleric")
+    server.level_up(cid, c, "Cleric")  # level 3 -> a 2nd-level slot
+    server.learn_spells(cid, c, ["Hold Person"])
+    server.prepare_spells(cid, c, ["Hold Person"])
+    return c
+
+
+def _humanoid(cid, name="Cultist", wis=8, hp=30):
+    return server.create_character(
+        cid, name, kind="monster", max_hp=hp, armor_class=12,
+        abilities={"wisdom": wis},
+    )["id"]
+
+
+def _lock_foe_with_hold_person(cid, caster, foe, monkeypatch):
+    """Set up combat, cast Hold Person on the caster's turn, apply the self-enforcing
+    paralyzed marker to the foe, and advance until the FOE is the current combatant (so the
+    next `next_turn` rolls the foe's end-of-turn repeat save). Returns the spell save DC.
+    Leaves a neutral d20 stub patched — each test re-patches the save roll it wants."""
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(10))  # ties -> input order [caster, foe]
+    server.start_combat(cid, [caster, foe])
+    _advance_to(cid, caster)  # caster acts first -> the cast is an on-turn action
+    out = server.cast_spell(cid, caster, "Hold Person", target_id=foe)
+    server.add_condition(cid, foe, "paralyzed", **{
+        k: out["condition_rider"][k]
+        for k in ("repeat_save_ability", "repeat_save_dc", "source_id", "spell_name")
+    })
+    _advance_to(cid, foe)  # foe is paralyzed (can't act) but its turn still ends on next_turn
+    return out["spell_save_dc"]
+
+
+def test_cast_hold_person_surfaces_condition_rider_hint():
+    """cast(Hold Person at a foe) is un-automated but surfaces a `condition_rider` hint
+    telling the DM the exact self-enforcing add_condition call (WIS save vs the spell DC)."""
+    cid = server.create_campaign("S")["id"]
+    caster = _hold_caster(cid, wis=16)
+    foe = _humanoid(cid)
+    out = server.cast_spell(cid, caster, "Hold Person", target_id=foe)
+    assert out["automated"] is False and out["concentration"] == "Hold Person"
+    rider = out["condition_rider"]
+    # Ability is normalized to the canonical 3-letter code (Ability.WIS.value), not the SRD
+    # full word — so it's directly usable as add_condition's repeat_save_ability.
+    assert rider["condition"] == "paralyzed" and rider["repeat_save_ability"] == "wis"
+    assert rider["repeat_save_dc"] == out["spell_save_dc"]  # the caster's spell save DC
+    assert rider["source_id"] == caster and rider["spell_name"] == "Hold Person"
+    assert rider["target_id"] == foe
+
+
+def test_add_condition_with_repeat_save_writes_self_enforcing_marker():
+    """add_condition with the repeat-save params writes a TARGET-side ActiveEffect carrying
+    the recurring save + the imposed condition (the general save-ends wiring, #209)."""
+    cid = server.create_campaign("S")["id"]
+    caster = _hold_caster(cid)
+    foe = _humanoid(cid)
+    server.add_condition(cid, foe, "paralyzed", repeat_save_ability="wis",
+                         repeat_save_dc=14, source_id=caster, spell_name="Hold Person")
+    eff = _effects(cid, foe)
+    assert [e["name"] for e in eff] == ["Hold Person"]
+    rs = eff[0]["repeat_save"]
+    assert rs["ability"] == "wis" and rs["dc"] == 14 and rs["ends_effect"] is True
+    assert eff[0]["imposes_condition"] == "paralyzed" and eff[0]["source_id"] == caster
+    assert eff[0]["concentration"] is False  # the marker is NOT the caster's twin
+    assert "paralyzed" in server.get_character(cid, foe)["conditions"]
+
+
+def test_paralyzed_foe_gets_end_of_turn_wis_save_and_a_failure_keeps_the_lock(monkeypatch):
+    """THE BUG (#209): a foe paralyzed by Hold Person gets a WIS save when ITS turn ends in
+    next_turn — and a FAILED save keeps the paralysis + the effect (no indefinite lock-free)."""
+    cid = server.create_campaign("S")["id"]
+    caster = _hold_caster(cid)
+    foe = _humanoid(cid, wis=8)  # WIS mod -1
+    dc = _lock_foe_with_hold_person(cid, caster, foe, monkeypatch)
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(3))  # natural 3 -1 = 2, well under DC -> FAIL
+    v = server.next_turn(cid)  # foe is the OUTGOING combatant -> rolls its end-of-turn save
+    rs = v["repeat_saves"]
+    assert len(rs) == 1 and rs[0]["character_id"] == foe and rs[0]["name"] == "Hold Person"
+    assert rs[0]["ability"] == "wis" and rs[0]["dc"] == dc
+    assert rs[0]["success"] is False and rs[0]["ended"] is False
+    # The lock holds: effect + paralyzed condition both persist; caster still concentrating.
+    assert [e["name"] for e in _effects(cid, foe)] == ["Hold Person"]
+    assert "paralyzed" in server.get_character(cid, foe)["conditions"]
+    assert server.get_character(cid, caster)["concentration"] == "Hold Person"
+
+
+def test_successful_end_of_turn_save_frees_target_and_ends_concentration(monkeypatch):
+    """A SUCCESSFUL end-of-turn save removes the effect AND the paralyzed condition, and ends
+    the CASTER's concentration twin (one source of truth) — the target is genuinely freed."""
+    cid = server.create_campaign("S")["id"]
+    caster = _hold_caster(cid)
+    foe = _humanoid(cid, wis=8)
+    _lock_foe_with_hold_person(cid, caster, foe, monkeypatch)
+    assert server.get_character(cid, caster)["concentration"] == "Hold Person"
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(20))  # natural 20 -> clears any DC
+    v = server.next_turn(cid)
+    rs = v["repeat_saves"][0]
+    assert rs["success"] is True and rs["ended"] is True
+    assert rs["cleared_condition"] == "paralyzed" and rs["concentration_ended_for"] == caster
+    # Freed: no effect, no paralyzed condition, and the caster's concentration ended.
+    assert _effects(cid, foe) == []
+    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]
+    assert server.get_character(cid, caster)["concentration"] is None
+
+
+def test_non_repeat_save_effect_is_untouched_by_next_turn(monkeypatch):
+    """REGRESSION: an ordinary timed effect with NO repeat_save (Bless) is never given an
+    end-of-turn save — next_turn surfaces no `repeat_saves` and leaves the effect alone."""
+    cid = server.create_campaign("S")["id"]
+    caster = _cleric(cid)
+    foe = _humanoid(cid)
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(1))  # ties -> input order; would FAIL a save
+    server.start_combat(cid, [caster, foe])
+    _advance_to(cid, caster)  # reach the caster's turn so the cast is an on-turn action
+    server.cast_spell(cid, caster, "Bless")  # self-buff, concentration, no repeat_save
+    v = server.next_turn(cid)  # caster is outgoing -> Bless must NOT trigger a save
+    assert "repeat_saves" not in v
+    assert [e["name"] for e in _effects(cid, caster)] == ["Bless"]  # untouched
+    assert server.get_character(cid, caster)["concentration"] == "Bless"
+
+
+def test_next_turn_with_no_repeat_save_effects_is_byte_identical(monkeypatch):
+    """ADDITIVE: with no repeat_save anywhere, next_turn behaves exactly as today — no
+    `repeat_saves` key at all (the new path is fully inert)."""
+    cid = server.create_campaign("S")["id"]
+    a = _cleric(cid, "A")
+    foe = _humanoid(cid)
+    server.start_combat(cid, [a, foe])
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(10))
+    v = _advance_turn(cid)
+    assert "repeat_saves" not in v  # inert: no save-ends effect in play
+
+
+def test_repeat_save_only_for_the_outgoing_combatant(monkeypatch):
+    """The save fires for the combatant whose turn is ENDING — not for a still-locked foe
+    who isn't the outgoing one. A paralyzed foe gets its save only when ITS OWN turn ends."""
+    cid = server.create_campaign("S")["id"]
+    caster = _hold_caster(cid)
+    foe = _humanoid(cid, wis=8)
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(20))  # ties -> input order [caster, foe]
+    server.start_combat(cid, [caster, foe])
+    _advance_to(cid, caster)  # caster acts first
+    out = server.cast_spell(cid, caster, "Hold Person", target_id=foe)
+    server.add_condition(cid, foe, "paralyzed", **{
+        k: out["condition_rider"][k]
+        for k in ("repeat_save_ability", "repeat_save_dc", "source_id", "spell_name")
+    })
+    # Advancing past the CASTER (whose turn just ended) must NOT roll the FOE's save —
+    # the foe carries the marker, not the caster (the save is the OUTGOING combatant's).
+    v = server.next_turn(cid)  # caster outgoing -> no repeat_saves (caster has no marker)
+    assert "repeat_saves" not in v
+    assert [e["name"] for e in _effects(cid, foe)] == ["Hold Person"]  # foe still locked
+
+
+def test_paralyzed_does_not_autofail_the_wis_repeat_save(monkeypatch):
+    """SRD nuance: paralysis auto-fails STR/DEX saves, but Hold Person's repeat save is WIS —
+    so it rolls normally. A high WIS roll frees the target despite being paralyzed."""
+    cid = server.create_campaign("S")["id"]
+    caster = _hold_caster(cid)
+    foe = _humanoid(cid, wis=8)
+    _lock_foe_with_hold_person(cid, caster, foe, monkeypatch)
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(20))
+    rs = server.next_turn(cid)["repeat_saves"][0]
+    assert rs["ability"] == "wis" and rs["success"] is True and "reason" not in rs  # no auto-fail
+
+
+def test_caster_losing_concentration_frees_the_paralyzed_target(monkeypatch):
+    """INVERSE direction (#209): if the CASTER's concentration ends (here: incapacitated),
+    Hold Person is over — so next_turn frees the target (drops the marker + the paralyzed
+    condition) instead of leaving it locked indefinitely. One source of truth, both ways."""
+    cid = server.create_campaign("S")["id"]
+    caster = _hold_caster(cid)
+    foe = _humanoid(cid, wis=8)
+    _lock_foe_with_hold_person(cid, caster, foe, monkeypatch)
+    assert "paralyzed" in server.get_character(cid, foe)["conditions"]
+    # Break the caster's concentration directly (stun it) — its twin effect drops immediately,
+    # but the TARGET's marker + paralyzed persist until the reconciliation pass in next_turn.
+    server.add_condition(cid, caster, "stunned")
+    assert server.get_character(cid, caster)["concentration"] is None  # concentration broke
+    assert "paralyzed" in server.get_character(cid, foe)["conditions"]  # not yet reconciled
+    # A FAILED foe save would normally KEEP the lock — but the caster no longer concentrates,
+    # so the reconciliation frees the foe regardless of the (irrelevant) save roll.
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(1))
+    v = server.next_turn(cid)
+    assert {"character_id": foe, "name": "Hold Person"} in v["expired_effects"]
+    assert _effects(cid, foe) == []
+    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]  # freed via the link
+
+
+def test_non_concentration_save_ends_source_is_not_concentration_swept(monkeypatch):
+    """A save-ends marker from a NON-concentration source (no concentration twin) self-enforces
+    its end-of-turn save but is NEVER swept by the concentration reconciliation — a FAILED save
+    keeps it (it only ends on a successful save), regardless of any caster's concentration."""
+    cid = server.create_campaign("S")["id"]
+    caster = _cleric(cid)
+    foe = _humanoid(cid, wis=8)
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(10))
+    server.start_combat(cid, [caster, foe])
+    # A non-concentration source (Bless concentrates, but we don't pass it as spell_name) — use
+    # a generic save-ends marker with no spell linkage: source_id is dropped (not concentration).
+    server.add_condition(cid, foe, "restrained", repeat_save_ability="str", repeat_save_dc=14,
+                         source_id=caster)  # no spell_name -> not a concentration link
+    eff = _effects(cid, foe)
+    assert eff[0]["source_id"] == ""  # concentration link NOT kept (no concentrating spell)
+    assert eff[0]["repeat_save"]["ability"] == "str"
+    _advance_to(cid, foe)
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(1))  # FAIL the end-of-turn save
+    v = server.next_turn(cid)
+    assert v["repeat_saves"][0]["success"] is False and v["repeat_saves"][0]["ended"] is False
+    assert [e["name"] for e in _effects(cid, foe)] == ["restrained (save ends)"]  # still held
+    assert "restrained" in server.get_character(cid, foe)["conditions"]
+
+
+def test_repeat_save_marker_roundtrips_old_snapshot():
+    """ADDITIVE: a snapshot with NO repeat_save/imposes_condition keys loads unchanged (the
+    fields default to None), so existing campaigns deserialize exactly as before."""
+    snap = {"title": "T", "characters": {"c1": {
+        "name": "X",
+        "active_effects": [{"name": "Bless", "scale": "rounds", "rounds_remaining": 5}],
+    }}}
+    c = models.Campaign.model_validate(snap)
+    eff = c.characters["c1"].active_effects[0]
+    assert eff.repeat_save is None and eff.imposes_condition is None
+    # And a marker round-trips through JSON intact.
+    ae = models.ActiveEffect(
+        name="Hold Person", imposes_condition=models.Condition.PARALYZED,
+        repeat_save=models.RepeatSave(ability=models.Ability.WIS, dc=15),
+    )
+    back = models.ActiveEffect.model_validate(json.loads(ae.model_dump_json()))
+    assert back.repeat_save.ability == models.Ability.WIS and back.repeat_save.dc == 15
+    assert back.imposes_condition == models.Condition.PARALYZED
+
+
 # --- decrement + auto-expire in combat ---------------------------------------
 def test_next_turn_decrements_and_expires_bless():
     cid = server.create_campaign("S")["id"]


### PR DESCRIPTION
Closes #209 (sprint-enriched1's worst-seam). Repeat-save conditions (Hold Person: target repeats the WIS save at END of each of its turns) now SELF-ENFORCE — no DM prompt. New RepeatSave model + ActiveEffect.repeat_save + imposes_condition (additive). next_turn (after the #183 skip-guard anchor) rolls the end-of-turn save for the outgoing combatant via a new shared combat.save_modifiers resolver (extracted from saving_throw → one source of truth; honors paralysis auto-fail/restrained-disadvantage); on success removes the effect + clears the condition + ends the caster's concentration; surfaced in the return. GENERAL: add_condition gained repeat_save params; cast_spell surfaces a condition_rider hint via spells.repeat_save_rider (fires for Hold Person + Hold Monster; excludes Dominate/Blindness-Deafness/Contagion/Weird). BONUS: closed the inverse lock (caster loses concentration → target freed) via a next_turn reconciliation sweep. Additive (no repeat_save == today; old snapshots round-trip). 10 new tests + FULL suite 1273 single-process. Follow-up: combat.md still documents the old manual flow (docs-only). Local-gated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for end-of-turn saving throws on save-ending spell conditions, allowing targets to break free after successful rolls.
  * Spells now provide targeting hints to ensure save-ending effects are correctly applied with proper saving throw abilities and difficulty classes.
  * Improved concentration tracking integration for spell effects that end on successful saving throws.

* **Bug Fixes**
  * Corrected behavior when concentration is lost on save-ending spell effects to properly free targets and clear conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->