### PR TITLE
fix(combat): Battle Master damage maneuvers add the superiority die to the strike (#213)

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -532,6 +532,30 @@ class ActiveEffect(_StrictModel):
     imposes_condition: Optional[Condition] = None
 
 
+class PendingDamageBonus(_StrictModel):
+    """A DECLARED-but-not-yet-applied extra damage roll the NEXT attack folds in (#213).
+
+    A Battle Master damage maneuver (Trip Attack, Menacing Attack, …) reads "you add the
+    superiority die to the attack's damage roll." But declaring the maneuver and resolving
+    the strike are two engine calls (`use_resource(superiority_dice, maneuver=…)` then
+    `attack`), so — exactly like a spell's on-hit rider (PendingOnHitRider, #186) — the die
+    is ROLLED when the resource is spent and stashed HERE on the combatant; the next
+    `attack()` adds `amount` to that strike's damage and clears this record (consumed once,
+    never double-applied). One source of truth: the roll happens at spend time so the bonus
+    is real without the DM remembering, and the attack just reads the rolled total.
+
+    ADDITIVE: `Character.pending_damage_bonus` defaults to None, so every existing snapshot
+    round-trips unchanged and a `use_resource` call with NO maneuver never creates one — a
+    plain superiority-die spend (or any other pool) behaves exactly as today."""
+
+    amount: int  # the already-rolled die result added to the next attack's damage
+    source: str = ""  # the maneuver name (Trip Attack, Menacing Attack, …) for surfacing
+    resource: str = ""  # the pool it was spent from (e.g. "superiority_dice")
+    expr: str = ""  # the die expression rolled (e.g. "1d8") for the surfaced breakdown
+    detail: str = ""  # the dice-roller's human detail (e.g. "1d8[6] = 6")
+    damage_type: str = ""  # type of the added damage; "" == same type as the weapon strike
+
+
 class PendingOnHitRider(_StrictModel):
     """An attack-roll spell's ON-HIT rider effect that has NOT yet landed (#186).
 
@@ -613,6 +637,12 @@ class Character(_StrictModel):
     # target only when the spell attack hits (see PendingOnHitRider, #186). Empty ==
     # today's behavior; held on the CASTER so attack() can match attacker→target.
     pending_on_hit_riders: list[PendingOnHitRider] = Field(default_factory=list)
+    # A DECLARED-but-not-yet-applied extra damage roll the NEXT attack folds in — a Battle
+    # Master damage maneuver (Trip/Menacing Attack) rolls its superiority die at
+    # use_resource(superiority_dice, maneuver=…) time and stashes the result here; the next
+    # attack() adds it to that strike's damage and clears it (see PendingDamageBonus, #213).
+    # None == today's behavior; a maneuver-less use_resource never sets it.
+    pending_damage_bonus: Optional[PendingDamageBonus] = None
     death_saves: DeathSaves = Field(default_factory=DeathSaves)
     dead: bool = False
     stable: bool = False  # stabilized at 0 HP; no longer rolling death saves

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -70,6 +70,7 @@ from models import (
     HouseRules,
     Item,
     Location,
+    PendingDamageBonus,
     PendingOnHitRider,
     Quest,
     RepeatSave,
@@ -3127,6 +3128,16 @@ def attack(
         # has advantage" marker) BEFORE the roll so we can both auto-apply its advantage
         # (via attack_modifiers) and consume it after this one attack resolves (#194).
         adv_marker = combat.advantage_granting_effect(target)
+        # Capture + CLEAR any pending damage-maneuver bonus (Battle Master Trip/Menacing,
+        # #213) the attacker declared via use_resource(superiority_dice, maneuver=…). The
+        # superiority die was rolled at spend time; THIS attack is the one strike that
+        # consumes it. Consume it whatever the outcome (the die is already spent — it can't
+        # carry to a later swing), but fold the rolled damage into the strike only on a HIT
+        # (a miss does no damage). None == no maneuver declared (the default path). Mirrors
+        # the adv_marker / on-hit-rider consume-once discipline so it can't double-apply.
+        man_bonus = attacker.pending_damage_bonus
+        if man_bonus is not None:
+            attacker.pending_damage_bonus = None
         cadv, cdis = combat.attack_modifiers(attacker, target, is_ranged=is_ranged)
         adv = advantage or cadv
         dis = disadvantage or cdis
@@ -3172,15 +3183,32 @@ def attack(
             if warn:
                 result["range_warning"] = warn
         if hit:
-            if damage_rolls:
+            # A pending DAMAGE-maneuver bonus (#213) folds the already-rolled superiority die
+            # into THIS strike as one extra typed component. The die is NOT re-rolled and NOT
+            # crit-doubled (5e: only weapon dice double; the maneuver die is added once),
+            # which is exactly what apply_damage_components does — it takes pre-rolled amounts.
+            # Defaults to the weapon's damage_type when the maneuver didn't specify one, so the
+            # bonus shares the strike's resistance treatment unless typed otherwise.
+            man_part = None
+            if man_bonus is not None and man_bonus.amount > 0:
+                man_part = {
+                    "amount": man_bonus.amount,
+                    "type": man_bonus.damage_type or damage_type,
+                }
+            if damage_rolls or man_part is not None:
                 # MULTI-COMPONENT (#210): roll + crit-double EACH component on its own
                 # dice, then apply per-type resistance/immunity/vulnerability per
                 # component before summing. The pre-adjustment roll total per component
                 # is surfaced so the DM sees what each type contributed; the post-
-                # resistance figure lives in target_state["components"].
+                # resistance figure lives in target_state["components"]. A single-type
+                # strike carrying a maneuver bonus joins this path too (its one weapon
+                # component + the maneuver component), so the bonus lands as ONE hit.
                 comp_results: list[dict] = []
                 parts_for_apply: list[dict] = []
-                for spec in damage_rolls:
+                base_specs = damage_rolls or (
+                    [{"dice": damage_dice, "type": damage_type}] if damage_dice else []
+                )
+                for spec in base_specs:
                     cd = str(spec.get("dice", "") or "")
                     ct = str(spec.get("type", "") or "")
                     if not cd:
@@ -3192,6 +3220,16 @@ def attack(
                         {"type": ct, "total": ctotal, "expr": cexpr, "detail": cdmg.detail}
                     )
                     parts_for_apply.append({"amount": ctotal, "type": ct})
+                if man_part is not None:
+                    # The maneuver die is a flat pre-rolled add (no expr to re-roll/double).
+                    comp_results.append({
+                        "type": man_part["type"],
+                        "total": man_bonus.amount,
+                        "expr": man_bonus.expr,
+                        "detail": man_bonus.detail,
+                        "maneuver": man_bonus.source,
+                    })
+                    parts_for_apply.append(man_part)
                 outcome = combat.apply_damage_components(
                     target, parts_for_apply, crit=is_crit
                 )
@@ -3216,10 +3254,32 @@ def attack(
                 dmg = dice_mod.roll(expr)
                 outcome = combat.apply_damage(target, max(0, dmg.total), crit=is_crit, damage_type=damage_type)
                 result["damage"] = {"total": max(0, dmg.total), "type": damage_type, "expr": expr, "detail": dmg.detail}
+            if man_bonus is not None:
+                # Surface the maneuver's contribution explicitly so the DM/log sees the die
+                # that landed (and that it WAS applied), distinct from the weapon dice.
+                result["maneuver_damage"] = {
+                    "maneuver": man_bonus.source,
+                    "die": man_bonus.expr,
+                    "rolled": man_bonus.amount,
+                    "detail": man_bonus.detail,
+                    "applied": man_bonus.amount > 0,
+                }
             result["target_state"] = outcome
             kx = _award_kill_xp(c, target)
             if kx:
                 result["kill_xp"] = kx
+        elif man_bonus is not None:
+            # The strike MISSED, so the maneuver die adds no damage — but it was already spent
+            # at use_resource time (and consumed above), so report it as spent-not-applied
+            # rather than silently swallowing it. The die does NOT carry to a later attack.
+            result["maneuver_damage"] = {
+                "maneuver": man_bonus.source,
+                "die": man_bonus.expr,
+                "rolled": man_bonus.amount,
+                "detail": man_bonus.detail,
+                "applied": False,
+                "note": "attack missed — superiority die spent but no damage added",
+            }
         # ON-HIT RIDER RESOLUTION (#186). An attack-roll spell (Guiding Bolt) recorded a
         # PENDING rider on the caster at cast_spell time instead of writing its timed effect
         # to the target. This attack resolves that spell attack when it's the caster striking
@@ -4892,14 +4952,36 @@ def long_rest(campaign_id: str, character_id: str, watch: str = "") -> dict:
 
 
 @mcp.tool()
-def use_resource(campaign_id: str, character_id: str, resource: str, amount: int = 1) -> dict:
+def use_resource(
+    campaign_id: str,
+    character_id: str,
+    resource: str,
+    amount: int = 1,
+    maneuver: str = "",
+    damage_type: str = "",
+) -> dict:
     """Spend from a depletable class-resource pool (Rage, Ki, Lay on Hands, Channel
     Divinity, Bardic Inspiration, Sorcery Points, Second Wind, Action Surge, Wild
     Shape, …). Deducts `amount` (default 1; for Lay on Hands pass the hit points to
     spend). Returns ``{ok: True, remaining, max, used}`` on success; ``{ok: False,
     error, remaining, max}`` without changing state when the character lacks that
     pool or hasn't enough left, so the DM gets a clean signal instead of an
-    exception. Pools refresh via short_rest / long_rest."""
+    exception. Pools refresh via short_rest / long_rest.
+
+    DAMAGE MANEUVER (Battle Master, #213): pass ``maneuver`` (the maneuver's name, e.g.
+    "Trip Attack" / "Menacing Attack") when the spent die is a DAMAGE maneuver — "add the
+    superiority die to the attack's damage roll." The engine ROLLS the pool's die (`amount`
+    × the resource's `size`, e.g. 1d8) at spend time and stashes the rolled total as a
+    PENDING damage bonus on the character; the NEXT ``attack()`` by this character folds it
+    into that strike's damage and clears it (consumed once — never double-applied), so the
+    maneuver's damage is REAL without the DM remembering to add it. The rolled die + bonus
+    are surfaced under ``maneuver_damage``. ``damage_type`` optionally types the added
+    damage (default "" == the same type as the weapon strike). A maneuver only makes sense
+    for a die pool: spending a POINT pool (no `size`) for a maneuver is refused with a clean
+    signal and NO state change. The maneuver's save/condition (Trip → prone, Menacing →
+    frightened) stays a separate DM ``saving_throw`` call — only the DAMAGE bonus is wired
+    here. ADDITIVE: omit ``maneuver`` (the default) and a spend is byte-identical to before
+    — no pending bonus is ever set, so a non-maneuver pool behaves exactly as today."""
     if amount < 1:
         raise ValueError("amount must be >= 1")
     with campaign_lock(campaign_id):
@@ -4921,7 +5003,48 @@ def use_resource(campaign_id: str, character_id: str, resource: str, amount: int
                 "remaining": remaining,
                 "max": res.max,
             }
+        # A DAMAGE maneuver adds the spent die to the next attack's damage — so the pool MUST
+        # roll a die. Refuse a maneuver against a point pool (no `size`) up front, BEFORE
+        # spending, so the DM gets a clean signal instead of a silently-wasted point with no
+        # bonus (and no phantom pending record gets written). Inert when `maneuver` is empty.
+        man = maneuver.strip()
+        if man and not res.size.strip():
+            return {
+                "ok": False,
+                "error": (
+                    f"{resource!r} is a point pool (no die) — a damage maneuver needs a "
+                    f"die pool like Superiority Dice; nothing spent"
+                ),
+                "resource": resource,
+                "remaining": remaining,
+                "max": res.max,
+            }
         res.used += amount
+        man_damage = None
+        if man:
+            # Roll the spent die(s) NOW (engine-rolls-and-tells, like an on-hit rider): one
+            # source of truth — the result is fixed at declare time, and the next attack just
+            # reads it. `amount` × the pool's die size (1 die per maneuver in 5e RAW, so this
+            # is 1d8 for the default Superiority Die).
+            die_expr = f"{amount}{res.size.strip()}"
+            roll = dice_mod.roll(die_expr)
+            bonus = max(0, roll.total)
+            ch.pending_damage_bonus = PendingDamageBonus(
+                amount=bonus,
+                source=man,
+                resource=resource,
+                expr=die_expr,
+                detail=roll.detail,
+                damage_type=damage_type.strip(),
+            )
+            man_damage = {
+                "maneuver": man,
+                "die": die_expr,
+                "rolled": bonus,
+                "detail": roll.detail,
+                "damage_type": damage_type.strip(),
+                "applies_to": "next attack's damage",
+            }
         # Action Surge grants a fresh Action this turn — so the Attack-action economy
         # (attack()) must allow another Attack action's worth of strikes. Record it on
         # the combat when spent mid-fight by the CURRENT combatant (resets each turn in
@@ -4935,7 +5058,7 @@ def use_resource(campaign_id: str, character_id: str, resource: str, amount: int
         c.characters[character_id] = Character.model_validate(ch.model_dump(mode="json"))
         save_campaign(c)
         new = ch.class_resources[resource]
-        return {
+        out = {
             "ok": True,
             "resource": resource,
             "spent": amount,
@@ -4944,6 +5067,9 @@ def use_resource(campaign_id: str, character_id: str, resource: str, amount: int
             "used": new.used,
             "recharge": new.recharge,
         }
+        if man_damage is not None:
+            out["maneuver_damage"] = man_damage
+        return out
 
 
 @mcp.tool()

--- a/servers/engine/tests/test_class_resources.py
+++ b/servers/engine/tests/test_class_resources.py
@@ -173,6 +173,47 @@ def test_bare_character_deserializes_and_rests(cid):
     assert rests.long_rest(ch)["resources_restored"] == []
 
 
+# --- Battle Master DAMAGE maneuver (#213): use_resource rolls the die + stashes a pending bonus ---
+def test_use_resource_maneuver_rolls_die_and_stashes_pending(cid, monkeypatch):
+    fid = server.create_character(
+        cid, "Ren", kind="player", class_name="Fighter", level=3, apply_srd_defaults=True
+    )["id"]
+    server.set_class_resource(cid, fid, "superiority_dice", max=4, recharge="short", size="d8")
+    # Deterministic die: 1d8 -> 5.
+    monkeypatch.setattr(server.dice_mod, "roll", fixed_roll(5))
+    out = server.use_resource(cid, fid, "superiority_dice", maneuver="Trip Attack")
+    assert out["ok"] is True and out["remaining"] == 3
+    assert out["maneuver_damage"]["die"] == "1d8" and out["maneuver_damage"]["rolled"] == 5
+    pdb = server.get_character(cid, fid)["pending_damage_bonus"]
+    assert pdb["amount"] == 5 and pdb["source"] == "Trip Attack" and pdb["resource"] == "superiority_dice"
+
+
+def test_use_resource_no_maneuver_sets_no_pending_bonus(cid):
+    # ADDITIVE: a plain superiority-die spend (no maneuver) never creates a pending bonus.
+    fid = server.create_character(
+        cid, "Ren", kind="player", class_name="Fighter", level=3, apply_srd_defaults=True
+    )["id"]
+    server.set_class_resource(cid, fid, "superiority_dice", max=4, recharge="short", size="d8")
+    out = server.use_resource(cid, fid, "superiority_dice")  # no maneuver
+    assert out["ok"] is True and "maneuver_damage" not in out
+    assert server.get_character(cid, fid)["pending_damage_bonus"] is None
+
+
+def test_use_resource_maneuver_amount_rolls_that_many_dice(cid, monkeypatch):
+    # amount=2 rolls 2d8 (the expression passed to the roller carries the count).
+    fid = server.create_character(
+        cid, "Ren", kind="player", class_name="Fighter", level=3, apply_srd_defaults=True
+    )["id"]
+    server.set_class_resource(cid, fid, "superiority_dice", max=4, recharge="short", size="d8")
+    seen = {}
+    def _roll(expr, *a, **k):
+        seen["expr"] = expr
+        return DiceRoll(expression=expr, total=9, rolls=[9])
+    monkeypatch.setattr(server.dice_mod, "roll", _roll)
+    out = server.use_resource(cid, fid, "superiority_dice", amount=2, maneuver="Trip Attack")
+    assert seen["expr"] == "2d8" and out["remaining"] == 2 and out["maneuver_damage"]["rolled"] == 9
+
+
 def test_use_resource_preserved_across_level_up(cid):
     # Leveling up must NOT silently refill a half-spent pool (preserve `used`).
     pid = server.create_character(

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -1847,3 +1847,166 @@ def test_next_turn_monster_no_action_advances_freely(tmp_path, monkeypatch):
     # Monster takes no action — next_turn must NOT raise
     view = server.next_turn(cid)
     assert view["active"] is True
+
+
+# =========================================================================
+# Battle Master DAMAGE maneuver (#213): use_resource(superiority_dice, maneuver=…)
+# rolls the die and the NEXT attack folds it into that strike's damage.
+# =========================================================================
+
+
+def _rigged_roller(d20_total: int, fixed: dict[str, int]):
+    """A deterministic dice_mod.roll: d20 expressions return `d20_total` (hit/miss
+    control); any other expression returns a fixed total looked up by its (space-stripped)
+    text, defaulting to 0 so an unexpected expr is loud rather than silently '6'."""
+    from dice import DiceRoll
+
+    def _roll(expr, advantage=False, disadvantage=False, seed=None):
+        e = expr.replace(" ", "").lower()
+        if e.startswith("1d20"):
+            return DiceRoll(
+                expression=expr, total=d20_total, rolls=[d20_total - 5],
+                modifier=5, detail=f"{expr}={d20_total}", is_d20=True,
+                natural=max(1, min(20, d20_total - 5)),
+            )
+        total = fixed.get(e, 0)
+        return DiceRoll(expression=expr, total=total, rolls=[total], detail=f"{expr}[{total}]={total}")
+
+    return _roll
+
+
+def _bm_combat(server, monkeypatch, tmp_path, *, die_total: int, weapon_total: int, d20: int = 25):
+    """Start a Hero-vs-Goblin fight with the Hero current, a 6-die superiority pool (d8),
+    and a rigged roller: 1d8 -> `die_total`, 1d6+3 -> `weapon_total`, d20 -> `d20`."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Battle Master")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=20, armor_class=12)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=40, armor_class=10)["id"]
+    server.set_class_resource(cid, hero, "superiority_dice", max=6, recharge="short", size="d8")
+    # Hero must be the current combatant to take an action-attack; rig initiative so the
+    # higher-init Hero goes first (start_combat rolls 1d20+init for each).
+    server.start_combat(cid, [hero, gob])
+    if server.get_state(cid)["current_turn"] != hero:
+        server.next_turn(cid)  # 2-combatant order — advance to the Hero
+    assert server.get_state(cid)["current_turn"] == hero
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged_roller(d20, {"1d8": die_total, "1d6+3": weapon_total}))
+    return cid, hero, gob
+
+
+def test_damage_maneuver_die_rolled_on_spend_and_pending(tmp_path, monkeypatch):
+    # use_resource(superiority_dice, maneuver=…) ROLLS the die and stashes a pending bonus.
+    import server
+    cid, hero, gob = _bm_combat(server, monkeypatch, tmp_path, die_total=6, weapon_total=7)
+    spent = server.use_resource(cid, hero, "superiority_dice", maneuver="Trip Attack")
+    assert spent["ok"] is True
+    assert spent["remaining"] == 5  # one die spent
+    md = spent["maneuver_damage"]
+    assert md["maneuver"] == "Trip Attack" and md["die"] == "1d8" and md["rolled"] == 6
+    # The rolled bonus is now pending on the character.
+    pdb = server.get_character(cid, hero)["pending_damage_bonus"]
+    assert pdb is not None and pdb["amount"] == 6 and pdb["source"] == "Trip Attack"
+
+
+def test_damage_maneuver_adds_die_to_triggering_attack(tmp_path, monkeypatch):
+    # The core fix: after spending a die for a maneuver, the next attack's damage STRICTLY
+    # exceeds the weapon alone by the rolled die (7 weapon + 6 die = 13).
+    import server
+    cid, hero, gob = _bm_combat(server, monkeypatch, tmp_path, die_total=6, weapon_total=7)
+    server.use_resource(cid, hero, "superiority_dice", maneuver="Trip Attack")
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+    assert res["hit"] is True
+    # weapon (7) + superiority die (6) folded into ONE hit.
+    assert res["damage"]["total"] == 13
+    assert res["damage"]["applied_total"] == 13  # no resistance on the goblin
+    assert res["maneuver_damage"]["rolled"] == 6 and res["maneuver_damage"]["applied"] is True
+    # The target actually took the full 13 (40 - 13 = 27).
+    assert server.get_character(cid, gob)["current_hp"] == 27
+    # >= +1 over the weapon alone (the regression guard from the issue).
+    assert res["damage"]["total"] >= 7 + 1
+
+
+def test_damage_maneuver_strictly_exceeds_weapon_max(tmp_path, monkeypatch):
+    # Sharper form of the issue's assert: a maneuver strike must exceed even the MAX of the
+    # weapon+mod alone. Weapon 1d6+3 maxes at 9; with the die it lands at 9 + 1 = 10 (die=1).
+    import server
+    cid, hero, gob = _bm_combat(server, monkeypatch, tmp_path, die_total=1, weapon_total=9)
+    server.use_resource(cid, hero, "superiority_dice", maneuver="Menacing Attack")
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+    weapon_max = 6 + 3  # 1d6+3
+    assert res["damage"]["total"] >= weapon_max + 1
+
+
+def test_normal_attack_without_maneuver_unchanged(tmp_path, monkeypatch):
+    # ADDITIVE: a normal attack with no maneuver spent is exactly the weapon's damage — no
+    # bonus, no maneuver_damage key, the single-type path is untouched.
+    import server
+    cid, hero, gob = _bm_combat(server, monkeypatch, tmp_path, die_total=6, weapon_total=7)
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+    assert res["hit"] is True
+    assert res["damage"]["total"] == 7  # weapon only
+    assert "maneuver_damage" not in res
+    assert res["damage"].get("expr") == "1d6+3"  # stayed on the byte-identical single-type path
+    assert server.get_character(cid, gob)["current_hp"] == 33  # 40 - 7
+
+
+def test_maneuver_die_consumed_once_not_double_applied(tmp_path, monkeypatch):
+    # The pending bonus is consumed by the FIRST attack only — a second attack the same
+    # combat (e.g. via Extra Attack) gets the weapon alone, never the die again.
+    import server
+    cid, hero, gob = _bm_combat(server, monkeypatch, tmp_path, die_total=6, weapon_total=7)
+    server.update_character(cid, hero, {"extra_attacks": 1})  # two attacks this action
+    server.use_resource(cid, hero, "superiority_dice", maneuver="Trip Attack")
+    first = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+    assert first["damage"]["total"] == 13  # 7 + 6 (die applied once)
+    # Pending bonus cleared after the first strike.
+    assert server.get_character(cid, gob)["pending_damage_bonus"] is None
+    assert server.get_character(cid, hero)["pending_damage_bonus"] is None
+    second = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+    assert second["damage"]["total"] == 7  # weapon ONLY — the die is gone
+    assert "maneuver_damage" not in second
+
+
+def test_maneuver_die_on_miss_spent_but_no_damage(tmp_path, monkeypatch):
+    # A MISS consumes the declared die (it was spent at use_resource time) but adds no
+    # damage — and it does NOT carry to a later attack.
+    import server
+    cid, hero, gob = _bm_combat(server, monkeypatch, tmp_path, die_total=6, weapon_total=7, d20=2)
+    # Goblin AC bumped so the rigged low d20 misses.
+    server.update_character(cid, gob, {"armor_class": 20})
+    server.use_resource(cid, hero, "superiority_dice", maneuver="Trip Attack")
+    res = server.attack(cid, hero, gob, attack_bonus=0, damage_dice="1d6+3", damage_type="slashing")
+    assert res["hit"] is False
+    assert res["maneuver_damage"]["applied"] is False
+    assert server.get_character(cid, gob)["current_hp"] == 40  # untouched
+    # The die did not survive to the next swing.
+    assert server.get_character(cid, hero)["pending_damage_bonus"] is None
+
+
+def test_maneuver_on_point_pool_refused_no_spend(tmp_path, monkeypatch):
+    # A damage maneuver needs a DIE pool. Declaring one against a point pool (Ki, no `size`)
+    # is refused with a clean signal and NO spend / no pending bonus.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+    cid = server.create_campaign("Point pool")["id"]
+    monk = server.create_character(cid, "Monk", kind="player", max_hp=20)["id"]
+    server.set_class_resource(cid, monk, "ki", max=5, recharge="short")  # no size -> point pool
+    out = server.use_resource(cid, monk, "ki", maneuver="Trip Attack")
+    assert out["ok"] is False and "point pool" in out["error"]
+    sheet = server.get_character(cid, monk)
+    assert sheet["class_resources"]["ki"]["used"] == 0  # nothing spent
+    assert sheet["pending_damage_bonus"] is None
+
+
+def test_maneuver_die_typed_damage_respects_resistance(tmp_path, monkeypatch):
+    # A maneuver with an explicit damage_type lands as that type — and a resistant target
+    # halves only the maneuver component (the weapon's type is untouched). Trip 'Attack' with
+    # fire damage (a homebrew flourish) on a fire-resistant foe: weapon 7 slashing (full) +
+    # die 6 fire -> 3 = 10 to HP, but the rolled-sum surfaced total is 13.
+    import server
+    cid, hero, gob = _bm_combat(server, monkeypatch, tmp_path, die_total=6, weapon_total=7)
+    server.update_character(cid, gob, {"damage_resistances": ["fire"]})
+    server.use_resource(cid, hero, "superiority_dice", maneuver="Trip Attack", damage_type="fire")
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+    assert res["damage"]["total"] == 13  # pre-resistance rolled sum (7 + 6)
+    assert res["damage"]["applied_total"] == 10  # 7 slashing + 3 (6 fire halved)
+    assert server.get_character(cid, gob)["current_hp"] == 30  # 40 - 10


### PR DESCRIPTION
## Summary
Closes #213. A Battle Master damage maneuver (Trip Attack, Menacing Attack, …) now actually **adds its rolled superiority die to the triggering attack's damage** instead of just decrementing the pool — closing the QA-flagged defect where `use_resource(superiority_dice)` was followed by an `attack` whose damage never exceeded the weapon alone.

## How (declare-then-strike pending-bonus, mirrors the #186 on-hit rider)
- **`PendingDamageBonus`** model + `Character.pending_damage_bonus: Optional = None` (additive; old snapshots round-trip; a maneuver-less `use_resource` never sets it).
- **`use_resource(..., maneuver="", damage_type="")`**: when `maneuver` is set, the engine ROLLS the pool's die at spend time (`amount` × the resource `size`, e.g. `1d8`) and stashes the rolled total. A **point pool (no `size`) refuses a maneuver with a clean signal and no spend**. Surfaced under `maneuver_damage`.
- **`attack()`**: captures + clears `pending_damage_bonus` at the top (mirrors `adv_marker`), so it's consumed by exactly one strike. On a hit, the bonus folds in as **one extra typed component** through the #210 `apply_damage_components` path (single-type strikes join that path too, so the bonus lands as one hit with correct per-type resistance). 

## Correctness
- **Consume-once**: captured-and-cleared before the hit check → a second attack the same turn (Extra Attack) gets the weapon alone. (`test_maneuver_die_consumed_once_not_double_applied`)
- **Miss**: die already spent at declare time, so a miss consumes it but adds no damage (`applied: False`).
- **Crit**: the maneuver die is added **flat, not doubled** (only weapon dice double per RAW) — read from the already-rolled amount, never re-rolled. Verified: `apply_damage_components`/`_apply_total_to_hp` take pre-rolled amounts; `crit` only affects weapon-dice doubling (at roll) + downed death-save count.
- The maneuver's save/condition (Trip → prone, Menacing → frightened) stays a separate DM `saving_throw` — only the damage bonus is wired here.

## Test plan
- [x] New: 3 in `test_class_resources.py` (roll/pending/additive), 8 in `test_combat.py` (folds in, strictly exceeds weapon+mod max, no-maneuver unchanged, no double-apply, miss, point-pool refusal, typed resistance).
- [x] Full engine suite: **1315 passed** single-process (rebased onto current main).
- [x] Additive-default invariant: maneuver-less `use_resource` is byte-identical to before.