### PR TITLE
qa(distill): surface auto-fired repeat-saves + maneuver damage for the scorer

### DIFF
--- a/qa/distill.py
+++ b/qa/distill.py
@@ -24,6 +24,38 @@ def _short(v, n=220) -> str:
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
+def _audit_fields(res) -> list[str]:
+    """Surface engine-auto-fired mechanics that the 240-char tool_result preview truncates,
+    so the scorer can AUDIT them tool-sourced rather than only in DM prose (a recurring
+    Angry-DM finding). Currently: next_turn's ``repeat_saves`` (Hold Person/Monster
+    end-of-turn escape saves, #209) and attack/use_resource ``maneuver_damage`` (the Battle
+    Master superiority die, #213). Best-effort: a non-JSON or shape-mismatched result yields
+    nothing (the normal truncated `← …` preview line still stands)."""
+    try:
+        data = json.loads(res) if isinstance(res, str) else res
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    out: list[str] = []
+    for rs in data.get("repeat_saves", []) or []:
+        if not isinstance(rs, dict):
+            continue
+        verdict = "ENDS" if rs.get("ended") else ("saved" if rs.get("success") else "held")
+        out.append(
+            f"    `↳ repeat-save: {rs.get('name', '?')} on {rs.get('character_id', '?')} — "
+            f"{str(rs.get('ability', '?')).upper()} {rs.get('roll', '?')} (nat {rs.get('natural', '?')}) "
+            f"vs DC {rs.get('dc', '?')} → {verdict}`"
+        )
+    md = data.get("maneuver_damage")
+    if isinstance(md, dict):
+        out.append(
+            f"    `↳ maneuver-damage: {md.get('maneuver', '?')} {md.get('die', '?')}="
+            f"{md.get('rolled', '?')} applied={md.get('applied', md.get('applies_to', '?'))}`"
+        )
+    return out
+
+
 def _content_blocks(msg: dict):
     """A message's content may be a string or a list of typed blocks."""
     content = msg.get("content", [])
@@ -63,6 +95,7 @@ def distill(path: Path) -> tuple[str, Counter]:
                             x.get("text", "") for x in res if isinstance(x, dict)
                         )
                     lines_out.append(f"    `← {_short(res, 240)}`")
+                    lines_out.extend(_audit_fields(res))
         elif etype == "result":
             cost = ev.get("total_cost_usd", "?")
             turns = ev.get("num_turns", "?")

--- a/qa/test_distill.py
+++ b/qa/test_distill.py
@@ -1,0 +1,71 @@
+"""Unit tests for qa/distill.py — the _audit_fields helper that surfaces engine-auto-fired
+mechanics the 240-char tool_result preview would otherwise truncate (so the Angry-DM scorer
+can audit them tool-sourced, not only in DM prose).
+
+Stdlib + pytest only. Self-contained.
+
+Run with the engine venv (which has pytest):
+    uv run --directory servers/engine python -m pytest qa/test_distill.py -p no:cacheprovider
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+# distill lives next to this test (qa/); make it importable regardless of pytest rootdir.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import distill  # noqa: E402
+
+
+def test_audit_fields_surfaces_repeat_saves_with_roll_detail():
+    # A next_turn return carrying two Hold Person end-of-turn escape saves (#209): one held,
+    # one that frees the target. The exact roll values must survive (the scorer flagged them
+    # "irrecoverable from the truncated next_turn output").
+    res = json.dumps(
+        {
+            "round": 2,
+            "repeat_saves": [
+                {"character_id": "char_cap", "name": "Hold Person", "ability": "wis",
+                 "dc": 14, "roll": 5, "natural": 5, "success": False, "ended": False},
+                {"character_id": "char_cap", "name": "Hold Person", "ability": "wis",
+                 "dc": 14, "roll": 18, "natural": 18, "success": True, "ended": True,
+                 "cleared_condition": "paralyzed"},
+            ],
+        }
+    )
+    lines = distill._audit_fields(res)
+    assert len(lines) == 2
+    assert "Hold Person on char_cap" in lines[0]
+    assert "WIS 5 (nat 5) vs DC 14 → held" in lines[0]
+    assert "WIS 18 (nat 18) vs DC 14 → ENDS" in lines[1]
+
+
+def test_audit_fields_surfaces_maneuver_damage():
+    # An attack/use_resource return carrying the Battle Master superiority die (#213).
+    res = json.dumps(
+        {"ok": True, "maneuver_damage": {"maneuver": "Trip Attack", "die": "1d8",
+                                         "rolled": 6, "applied": True}}
+    )
+    lines = distill._audit_fields(res)
+    assert len(lines) == 1
+    assert "maneuver-damage: Trip Attack 1d8=6 applied=True" in lines[0]
+
+
+def test_audit_fields_is_safe_on_non_json_non_dict_and_irrelevant():
+    assert distill._audit_fields("not json at all") == []
+    assert distill._audit_fields(json.dumps([1, 2, 3])) == []
+    assert distill._audit_fields(json.dumps({"unrelated": "result"})) == []
+    # An empty/null repeat_saves is a no-op (the common case: most turns fire none).
+    assert distill._audit_fields(json.dumps({"repeat_saves": []})) == []
+    assert distill._audit_fields(json.dumps({"repeat_saves": None})) == []
+
+
+def test_audit_fields_tolerates_partial_repeat_save_entries():
+    # A malformed entry (missing keys, or not a dict) must not crash — it degrades to "?".
+    res = json.dumps({"repeat_saves": ["bogus", {"name": "Hold Monster"}]})
+    lines = distill._audit_fields(res)
+    assert len(lines) == 1  # the string entry is skipped; the partial dict still renders
+    assert "Hold Monster" in lines[0]


### PR DESCRIPTION
## Summary
Closes the Angry-DM MED finding from `sprint-postmaneuver`: the engine **already returns** full detail for #209 repeat-saves and #213 maneuver damage in `next_turn`/`attack` results, but `distill.py`'s 240-char tool_result preview truncated next_turn's tail — so the scorer could only see those auto-fired mechanics in DM **prose** ("the specific roll values (5 and 18) are irrecoverable from the truncated output").

This adds `_audit_fields(res)` — parses the tool_result JSON and emits dedicated `↳` audit lines for `repeat_saves` (character, ability, roll/nat vs DC, held/saved/ENDS) and `maneuver_damage` (the superiority die), so engine-auto-fired mechanics are **tool-sourced and auditable** in the distilled transcript regardless of the preview cap. Pure, best-effort (non-JSON / shape-mismatch → no-op; the normal `← …` preview still stands).

## Validation
- 4 unit tests in `qa/test_distill.py` (repeat-save roll detail, maneuver damage, non-JSON/list/irrelevant safety, partial-entry tolerance).
- Run on the **real** `sprint-postmaneuver.jsonl`: surfaces the exact `WIS 5 (nat 5) → held` / `WIS 18 (nat 18) → ENDS` saves the scorer flagged + Trip/Menacing maneuver dice.
- `qa/test_distill.py` + `qa/test_collect_findings.py`: **17 passed**.

## Test plan
- [x] `uv run --directory servers/engine python -m pytest qa/test_distill.py` green
- [x] Real-transcript end-to-end surfaces the audit lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transcript processing now captures and displays detailed audit information for specific game mechanics, with graceful handling of malformed data.

* **Tests**
  * Added comprehensive unit test coverage for audit field extraction functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/217?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->