### PR TITLE
feat(content): The Tidal Commonwealth — 2nd original world (generativity spike proves deliverable B)

### DIFF
--- a/content/worlds/tidal-commonwealth/LICENSE.md
+++ b/content/worlds/tidal-commonwealth/LICENSE.md
@@ -1,0 +1,12 @@
+# The Tidal Commonwealth — Licensing & Attribution
+
+**Original ClawDnD world content — free and open.**
+
+- **World content** (setting, regions, factions, NPCs, lore in `world.json`):
+  original work, licensed **Creative Commons Attribution 4.0 (CC-BY-4.0)**.
+- **Game rules**: System Reference Document 5.2, ©Wizards of the Coast,
+  **CC-BY-4.0** (see `data/srd/ATTRIBUTION.md`).
+
+This is clean-room original content — no Wizards of the Coast / Larian / Forgotten
+Realms / Baldur's Gate IP. ClawDnD's code is MIT (separate `LICENSE`); this world's
+prose is CC-BY-4.0.

--- a/content/worlds/tidal-commonwealth/world.json
+++ b/content/worlds/tidal-commonwealth/world.json
@@ -1,0 +1,272 @@
+{
+  "id": "tidal-commonwealth",
+  "schema_version": 1,
+  "name": "The Tidal Commonwealth",
+  "ruleset": "SRD 5.2",
+  "license": "CC-BY-4.0",
+  "attribution": "Original ClawDnD world. Built on SRD 5.2 (CC-BY-4.0). No Wizards of the Coast / Larian / Forgotten Realms / Baldur's Gate IP — clean-room original.",
+  "map_kind": "none",
+  "era": "The Forty-Third Year of the Interregnum. Three generations have passed since the Drowning Tide swallowed the old Empire's heartland — the great plateau is gone, the imperial capital is sixty fathoms under saltwater, and what remains is a scatter of island-cities and reef-holds arguing over who inherits the wreckage. No one has yet managed to crown anything.",
+  "tone": "Heroic but grim, mature (18+), morally grey — the Baldur's Gate register. The ocean won and the world rebuilt itself around the absence; every faction has a point, every alliance has a price, and the most dangerous thing in the world is a good person who has stopped believing the right thing is possible. Generate prestige maritime fantasy, never a quest board.",
+  "premise": "Three generations ago, the Drowning Tide — a catastrophic surge of still-unknown origin — swallowed the central plateau of the old Varentine Empire, submerging its capital and richest provinces under a new inland sea called the Gray Basin. What survived became the Tidal Commonwealth: a loose, fractious coalition of island-cities, reef-holds, and drowned-coast fishing towns that mostly agrees on one thing — no single power should ever get large enough to drown again. The Compact that holds the Commonwealth together is forty years old, crumbling at its edges, and fiercely defended by the people who remember what came before it. Into this world the player steps: the sea holds secrets, the factions sharpen their knives, and something old is stirring in the basin's depths.",
+  "history": [
+    "The Varentine Empire (ended ~100 years ago): a centralized imperial state built on the highland plateau, its capital Varent the largest city of its age. Its reach extended to the coasts but its heart was inland — which made it vulnerable to what came.",
+    "The Drowning Tide (~100 years ago): a single catastrophic surge — not a storm, not a quake, but something that acted on the water from below — swallowed the plateau in three days. Varent drowned in hours. The coastal cities survived only because the wave had exhausted itself on the highlands; refugees poured into them for a decade.",
+    "The Interregnum (last ~100 years): no successor state has managed to unify the survivors. Dozens of city-states and island councils rose and fell; the drowned coast is dotted with the ruins of brief kingdoms.",
+    "The Compact (~40 years ago): the surviving coastal powers hammered out a mutual non-conquest agreement after the Three-City War left all of them diminished. It has held — barely — because the alternative is remembered.",
+    "The Gray Basin: the inland sea that covers the drowned plateau. Its surface is calm, its depths unexplored. Salvagers dive the outer rim. Nothing returns from the deep center, and the water at its heart is wrong — it doesn't move the way water should.",
+    "The Tide-Readers: a small, old-knowledge sect who claim to know why the Drowning Tide happened. They are not trusted. They have been right before.",
+    "The present: trade disputes between the cities are sharpening into something harder; a new thing has begun to surface from the Gray Basin — artifacts, ruins, and something that isn't either of those."
+  ],
+  "standing_threads": [
+    "Something is surfacing from the Gray Basin's deep center — artifacts, structural ruins, and at least one thing that moved — and no one in the Commonwealth wants to be the first to say it aloud.",
+    "The Compact is forty years old and the generation that signed it is nearly gone; its successors inherit the letter but not the terror that made it, and two cities are close to a breaking point.",
+    "The Tide-Readers' founder-sect believes the Drowning Tide was deliberate — a mechanism, not a natural disaster — and their evidence is growing harder to dismiss."
+  ],
+  "regions": [
+    {
+      "id": "loc-saltmere",
+      "name": "Saltmere",
+      "description": "The Commonwealth's busiest free port — a tiered city built into a drowned-coast cliff, its lower districts half-flooded at high tide, its upper warrens loud with merchant arguments and Compact-politics. The default hub: traders, diplomats, salvagers, refugees, and the occasional Tide-Reader all pass through. The Saltmere Council has the largest vote under the Compact and uses it.",
+      "connections": ["loc-gray-basin-shallows", "loc-ironhull-station"],
+      "tags": ["hub", "city", "port"]
+    },
+    {
+      "id": "loc-ironhull-station",
+      "name": "Ironhull Station",
+      "description": "A fortified reef-platform — an old imperial signal-tower converted into a trading post and light-house, equidistant between Saltmere and the League cities. It is the Compact's only neutral ground, the place where deals are brokered and arguments kept off the ships. Permanently crowded, always watching.",
+      "connections": ["loc-saltmere", "loc-gray-basin-shallows", "loc-vethis-isle"],
+      "tags": ["crossroads", "neutral-ground", "intrigue"]
+    },
+    {
+      "id": "loc-vethis-isle",
+      "name": "Vethis Isle",
+      "description": "A League city-state on an island whose volcanic rock makes it almost impossible to siege — Vethis is proud, militant, and convinced the rest of the Commonwealth is coasting on its willingness to defend them. Its council is the youngest and the most aggressive, and it is the city closest to breaking the Compact.",
+      "connections": ["loc-ironhull-station", "loc-gray-basin-shallows"],
+      "tags": ["city", "military", "tension"]
+    },
+    {
+      "id": "loc-gray-basin-shallows",
+      "name": "The Gray Basin Shallows",
+      "description": "The navigable outer ring of the inland sea — shallow enough for salvage diving, deep enough to hide what the tide left. Salvage rigs, marker-buoys, and the occasional Tide-Reader survey boat share these waters. The bottom changes. Salvagers notice, and mostly say nothing, because the alternative is explaining what they saw.",
+      "connections": ["loc-saltmere", "loc-ironhull-station", "loc-vethis-isle", "loc-the-deep-rim"],
+      "tags": ["sea", "salvage", "mystery"]
+    },
+    {
+      "id": "loc-the-deep-rim",
+      "name": "The Deep Rim",
+      "description": "The inner edge of the Gray Basin where the drowned plateau drops away into depths no line has bottomed. The water here is wrong: too still, too dark, and at certain tides faintly luminescent. Salvagers don't dive past the rim. Tide-Readers study it. Something has begun to rise from it.",
+      "connections": ["loc-gray-basin-shallows"],
+      "tags": ["sea", "dangerous", "mystery", "ruin"]
+    }
+  ],
+  "factions": [
+    {
+      "id": "fac-compact",
+      "name": "The Compact Council",
+      "description": "The Tidal Commonwealth's governing body — a rotating council of city representatives with barely enough authority to maintain the mutual non-conquest agreement. Honorable in intent, paralyzed in practice; the faction everyone claims to support and quietly undermines.",
+      "reputation": 0
+    },
+    {
+      "id": "fac-salvagers-league",
+      "name": "The Salvagers' League",
+      "description": "The guild-network of professional wreck-divers and artifact traders who work the Gray Basin's shallows. Pragmatic, well-armed, well-connected, and the only faction with real intelligence on what the Basin contains. They sell to everyone and owe loyalty to no city — which is precisely what makes them dangerous when they find something they don't put up for auction.",
+      "reputation": 0
+    },
+    {
+      "id": "fac-tide-readers",
+      "name": "The Tide-Readers",
+      "description": "A sect of archivists, divers, and theorists who have dedicated three generations to understanding what caused the Drowning Tide. Mistrusted by every city (no one wants the answer) and occasionally right in ways that get people killed. They believe the Tide was deliberate — built — and the evidence is mounting.",
+      "reputation": -1
+    },
+    {
+      "id": "fac-vethis-bloc",
+      "name": "The Vethis Bloc",
+      "description": "Vethis Isle and the two smaller militarist city-states in its orbit, who believe the Compact's non-aggression clause has made the Commonwealth weak and that someone — preferably them — needs to lead the defense of the Basin's edge before what's surfacing becomes ungovernable. Aggressive, genuinely afraid, and not entirely wrong.",
+      "reputation": -1
+    }
+  ],
+  "npc_roster": [
+    {
+      "id": "npc-warden-estris",
+      "name": "Warden Estris Vane",
+      "voice_id": "npc-elder",
+      "role": "Compact Council secretary — de facto keeper of the peace",
+      "personality": "A sharp-minded woman in her sixties who has watched the Compact survive thirty-nine years by being the person no one notices is in the room. She does not raise her voice. She remembers everything. She has buried two colleagues who underestimated how much a secretary can choose to forget.",
+      "hook": "Knows the Compact is sixty days from a crisis she cannot resolve alone, and is quietly looking for people with no obvious city allegiance who might help before it becomes public."
+    },
+    {
+      "id": "npc-captain-drev",
+      "name": "Captain Drev Ossian",
+      "voice_id": "companion-default",
+      "role": "Salvagers' League captain — candidate COMPANION",
+      "personality": "A weathered half-elf who has dived the Gray Basin for twenty years and does not discuss what he saw on the dive that gave him his scar. Blunt, practical, loyal to crew above all else; argues from evidence and falls silent rather than speculate. The scar runs from his jaw to his collarbone, and he flinches at the sound of stillwater.",
+      "hook": "Available as the player's companion; whatever he found on that dive is tied to what is surfacing now, and he knows it.",
+      "dossier": {
+        "wound": "saw something in the Deep Rim that he cannot explain and will not name",
+        "wants": ["to protect his crew", "to understand what he saw before it finds him"],
+        "fears": ["being responsible for another crew going down", "the thing in the deep being exactly what he thinks it is"],
+        "values": ["evidence over belief", "crew loyalty", "honest risk-taking"],
+        "approval_likes": ["making decisions on evidence", "standing between danger and bystanders"],
+        "approval_dislikes": ["taking the Tide-Readers' claims on faith without evidence", "gambling other people's lives"],
+        "banter_tags": ["the_scar", "what_the_basin_holds", "crew_over_cause"],
+        "camp_prompts": ["sits facing the water and doesn't notice you've arrived", "traces the scar with two fingers when he thinks he's alone"],
+        "relationships": {
+          "npc-warden-estris": "old working relationship — she brought him in on three salvage contracts",
+          "npc-mira-scroll": "knows her by reputation and is wary of her"
+        }
+      }
+    },
+    {
+      "id": "npc-mira-scroll",
+      "name": "Mira Scroll",
+      "voice_id": "npc-female-1",
+      "role": "Tide-Readers' lead theorist — warmth first, then horror",
+      "personality": "A young-seeming woman of indeterminate age who talks about the Drowning Tide the way a naturalist talks about a particularly elegant predator — with genuine wonder and no apparent horror. Her diagrams are meticulous, her conclusions alarming, and her certainty that the mechanism is still active is the thing the Commonwealth Council refuses to put in writing. She means every word she says. That is the problem.",
+      "hook": "Has proof that the Drowning Tide was a mechanism, not a disaster — and proof that something in the Deep Rim is cycling toward a second activation. She is trying to decide who to trust with it."
+    },
+    {
+      "id": "npc-tribune-kessal",
+      "name": "Tribune Kessal Vor",
+      "voice_id": "npc-male-1",
+      "role": "Vethis Bloc spokesman — right for the wrong reasons",
+      "personality": "A Vethis council tribune with the gift for making invasion sound like mutual defense. Genuinely believes the Commonwealth will collapse without a strong center — and genuinely believes Vethis should be that center. Charming, impatient, not as clever as he thinks, and carrying intelligence about the Basin that he's chosen not to share.",
+      "hook": "Knows something is rising from the Deep Rim — his divers reported it six months ago — and is using that knowledge as leverage rather than sounding the alarm."
+    }
+  ],
+  "events": [
+    {
+      "id": "event-league-cache",
+      "trigger": "manual",
+      "anchor_npc_id": "npc-captain-drev",
+      "prompt": "The salvage rig COLD LAMP was supposed to run a routine outer-shallows survey. It came back three days late, two crew short, and with its cargo hold locked from the inside. Captain Drev Ossian intercepts you at the Ironhull docks before the League inspectors arrive: the crew found something at the rim that isn't in any of the Basin charts, something the League factors will auction to the highest bidder the moment they see it — and two cities are already watching the dock. 'I need it in different hands before the inspectors open that hold,' he says. He does not specify what different hands means, or what COLD LAMP found.",
+      "options": [
+        {
+          "label": "Help him move it — trust the captain's judgment",
+          "tag": "loyal / pragmatic",
+          "outcome": {
+            "flag": "cold_lamp_cache_secured",
+            "decision_flag": "trust_over_procedure",
+            "faction_id": "fac-salvagers-league",
+            "reputation_delta": -6,
+            "schedule_in_days": 8,
+            "schedule_text": "The League factors know something came off COLD LAMP before inspection. They don't know what or where — but they are asking, and the asking has a price attached. Whatever trust was bought by helping Drev, the League is about to invoice it.",
+            "narrate": "The crate moves before the inspectors reach the gangplank. You don't open it. You don't ask what's inside. Drev gives you a nod that carries more weight than he'd let on, and the inspection turns up an unremarkable manifest. For now."
+          }
+        },
+        {
+          "label": "Tell him to let the League inspect it — the Compact procedure exists for a reason",
+          "tag": "principled / lawful",
+          "outcome": {
+            "flag": "cold_lamp_cache_inspected",
+            "faction_id": "fac-compact",
+            "reputation_delta": 7,
+            "schedule_in_days": 6,
+            "schedule_text": "The League inspection logs go directly to the Compact Council summary — and the Vethis Bloc's factor was on the dock when the crate opened. Whatever COLD LAMP found, Vethis now knows it exists. Tribune Kessal Vor has been asking for a meeting.",
+            "narrate": "The inspectors open the hold by the book. You watch Drev's jaw tighten when the League factor reaches for the manifest clipboard. Whatever is in there — it's on the record now, and the record goes to every Compact city-state by morning. The captain doesn't speak to you for the rest of the afternoon."
+          }
+        },
+        {
+          "label": "Stay out of it — not your rig, not your cargo",
+          "tag": "detached / wary",
+          "outcome": {
+            "flag": "cold_lamp_cache_bystander",
+            "narrate": "You step back from the gangplank and let it play out. The inspectors arrive; Drev makes a decision you don't see; the dock moves on. Whatever came up from the shallows is out of your hands, one way or another — and something in the captain's expression, when he passes you later, suggests he noticed you weren't there when it counted."
+          }
+        }
+      ]
+    }
+  ],
+  "faction_arcs": [
+    {
+      "id": "arc-salvagers-rise",
+      "faction_id": "fac-salvagers-league",
+      "title": "Depth and Tenure",
+      "requires_joined": true,
+      "note": "The join->grow->lead questline for the Salvagers' League. The League trusts earned knowledge, not credentials — you join by demonstrating you can dive and keep your mouth shut; you rise by accumulating the kind of clout that comes from knowing what's down there and being careful about what you sell. Stage 1 (the proving dive) gates on reputation; stages 2-3 gate on the monotonic standing gauge (depth-clout earned through successful jobs — use grant_standing as the party completes League contracts). The finale ripples a world-changing effect: the party takes the League's council seat, and the Commonwealth's intelligence on the Gray Basin falls under their discretion.",
+      "stages": [
+        {
+          "id": "stage-league-proving",
+          "title": "The proving dive",
+          "unlock_at": 12,
+          "gauge": "reputation",
+          "note": "Available once the League has seen enough of you to risk a test. A gray-haired dive-master meets you at the equipment racks before dawn: 'The League doesn't take referrals. We take people who've already gone down and come back with something useful. You want in? There's a site at chart-mark seven-nine-blue that nobody's touched. Come back with a record of the depth and whatever you find at the bottom, and we'll talk.' Run the dive, then call advance_faction_arc to resolve it; grant_standing as the party banks clean work.",
+          "location_id": "loc-gray-basin-shallows"
+        },
+        {
+          "id": "stage-league-factor",
+          "title": "Earn a factor's berth",
+          "unlock_at": 20,
+          "gauge": "standing",
+          "note": "Available once the party's depth-clout (standing, earned via grant_standing on completed League contracts) marks them as a factor — someone other divers bring their finds to before the inspectors arrive. The recognition comes sideways, the way it does in the League: 'Three rigs have asked for you specifically on their next survey. That means something. Hang your marker at dock seven — that's a factor's berth, and it comes with a vote on what we bring to auction and what we sit on.' Set rank on advance_faction_arc (rank=3).",
+          "location_id": "loc-ironhull-station"
+        },
+        {
+          "id": "stage-league-council",
+          "title": "The council chair",
+          "unlock_at": 45,
+          "gauge": "standing",
+          "note": "The world-changing finale. With the League's old council chair retired and the Basin producing things that can't go to auction without a Commonwealth crisis, the League's senior factors put the chair in the party's hands — the decision-maker for what the Commonwealth knows about its own drowned heartland. Play it as the moment the party stops working for the League and becomes the authority on the Basin. Call advance_faction_arc(stage_status='resolved', rank=5).",
+          "finale_effect": {
+            "flag": "league_council_chair_held",
+            "faction_id": "fac-salvagers-league",
+            "reputation_delta": 25,
+            "controller_id": "fac-salvagers-league",
+            "location_id": "loc-gray-basin-shallows",
+            "narrate": "There is no ceremony — the League does things by handshake and logged charter — but the senior factors sign the document one by one, and when the last one adds her mark the Basin's intelligence belongs to you: what surfaces, what stays down, what goes to auction and what gets buried. The Commonwealth thinks it governs the Gray Basin. The League has always known better. Now so do you.",
+            "schedule_in_days": 12,
+            "schedule_text": "What comes with the chair: a courier arrives with a sealed League report the previous chair locked away — a dive record from six years ago that describes something at the Deep Rim in terms no one wanted to put into the general archive. Now it's your problem."
+          }
+        }
+      ]
+    }
+  ],
+  "quest_variants": [
+    {
+      "id": "the-first-surfacing",
+      "name": "What COLD LAMP Found",
+      "outcomes": [
+        {
+          "id": "cache-under-study",
+          "when": {"world_tenor": "hopeful"},
+          "lore": "The artifact COLD LAMP recovered from the Gray Basin rim has been placed under joint Tide-Reader and Compact Council study — an uneasy alliance, but one that is actually producing answers. The early findings are alarming and have not yet been published.",
+          "hook": "One of the study's researchers has gone missing; the last message she sent described a pattern in the artifact's surface that she said 'moved when you weren't looking at it.'"
+        },
+        {
+          "id": "cache-in-vethis-hands",
+          "random": 2,
+          "lore": "The COLD LAMP artifact was acquired by the Vethis Bloc before the Compact Council could impound it. Tribune Kessal Vor has announced it is being studied for 'defensive applications' and declined to share the findings.",
+          "hook": "A Compact inspector who was supposed to document the artifact before handover never filed her report. She has asked to meet, at night, at a location that is not her office."
+        },
+        {
+          "id": "cache-lost-overboard",
+          "random": 1,
+          "lore": "The COLD LAMP artifact went overboard during a League dock dispute — whether deliberately or by accident, no one is saying on the record. It is somewhere in the Saltmere harbor shallows, and at least three separate parties have divers looking for it.",
+          "hook": "A night-dive retrieval job is circulating through the Salvagers' League, paying three times the standard rate, with a very specific instruction: bring it to a specific address in Saltmere's upper city, no manifests."
+        }
+      ]
+    }
+  ],
+  "story_seeds": [
+    "Something is rising from the Deep Rim — prove what it is, and decide who can be trusted with that knowledge (the slow main thread).",
+    "The Compact is sixty days from a vote that will either renew it or break it into a war; the Vethis Bloc is already drafting military plans they haven't filed with the Council.",
+    "The Tide-Readers' founding evidence — the proof the Drowning Tide was a mechanism — is hidden somewhere in the Gray Basin's sunken ruins, and three factions are looking for it.",
+    "Captain Drev Ossian's lost dive record describes something at the Deep Rim that he has never told the League. He remembers it every time it storms.",
+    "A Saltmere fishing town on the Basin's edge has stopped answering courier ships. The last message out was three days ago and read only: 'the bottom is closer than it was.'"
+  ],
+  "starting_options": [
+    {
+      "location_id": "loc-saltmere",
+      "framing": "Default. The player arrives in the Commonwealth's busiest free port — traders, diplomats, salvagers, and the occasional Tide-Reader all pass through. The threads find you here."
+    },
+    {
+      "location_id": "loc-ironhull-station",
+      "framing": "The player is on the Compact's neutral ground — already in the middle of a deal, a dispute, or something that has gone wrong between cities."
+    },
+    {
+      "location_id": "loc-gray-basin-shallows",
+      "framing": "The player is already working the Basin's salvage circuit — lower, wetter, and closer to what's coming up from the deep."
+    }
+  ],
+  "dm_guidance": "Run this as a LIVING SANDBOX, not a fixed plot. On start_world: seed the regions as locations, the factions, and the standing threads/history into memory (so recall keeps the world consistent). Drop the player at a starting_option, then GENERATE the specific scene/town/NPC on arrival and PERSIST it (add_location, create_character, remember, add_quest) so the world grows and is never forgotten. The three standing threads (the Deep Rim surfacing, the Compact crisis, the Tide-Readers' evidence) move whether or not the party is watching. Pull from the npc_roster, but invent freely — every reef-hold has a harbor-master, every salvage rig has a dive-crew, every Compact session has a functionary who knows too much. The main gravity is the Basin: something old is cycling back toward activation, and the Commonwealth doesn't have a word for it yet. Hold the craft bar of the dungeon-master skill: felt menace, a wounded companion (Drev is ready, his scar is the door), show-don't-tell, the unforgettable beat. GRANDEUR is the dimension to push — don't let a session live in one tavern. Move the party through at least two locations and make the Basin's wrongness PRESS ON THE ROOM as physical things, not lore recited: a tide-chart that is six minutes off, a depth-line that bottoms before it should and comes back smelling of something that isn't saltwater, a fish brought up from the shallows that is perfectly preserved but not recently dead, the faint luminescence you only see if you've been watching for fifteen minutes. Something vast is cycling beneath the human-scale politics. Show one edge of it."
+}

--- a/servers/engine/tests/test_second_seed.py
+++ b/servers/engine/tests/test_second_seed.py
@@ -1,0 +1,283 @@
+"""Generativity spike — deliverable B: The Tidal Commonwealth.
+
+Proves that a SECOND original world seed (content/worlds/tidal-commonwealth/world.json)
+seeds and runs with ZERO engine code changes: all living-story surfaces (events,
+faction_arcs, quest_variants, world_graph, settlements, npc_roster / dossier) exercise
+the existing engine byte-for-byte, no new machinery required.
+
+Assertions:
+  1. seed_world returns a Campaign with NO skip-diagnostics ([content] skipping ...).
+  2. present_events surfaces the authored event (manual trigger).
+  3. Resolving an Outcome sets the decision_flag, shifts faction reputation, and schedules
+     a follow-on Consequence.
+  4. The authored faction arc gates (stage locked below unlock_at, available at/above).
+  5. The quest_variant resolves (at least one outcome stored in c.quest_outcomes).
+  6. NPC roster + companion dossier seeded correctly (4 NPCs, dossier on the companion).
+
+Single-process only (the host OOMs on parallel pytest; never -n / xdist).
+"""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+
+import pytest
+
+import content as content_mod
+import events as events_mod
+import faction_arc as fa
+from models import Campaign, Faction, FactionArc, FactionArcStage
+
+# ---------------------------------------------------------------------------
+# constants — world + authored ids live in CONTENT, not engine code
+# ---------------------------------------------------------------------------
+
+WORLD_ID = "tidal-commonwealth"
+EVENT_ID = "event-league-cache"
+FACTION_ARC_ID = "arc-salvagers-rise"
+FACTION_ID = "fac-salvagers-league"
+QUEST_VARIANT_ID = "the-first-surfacing"
+NPC_COMPANION_ID = "npc-captain-drev"
+COMPACT_FACTION_ID = "fac-compact"
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_world() -> dict:
+    """Load the world dict; skip cleanly if content dir isn't reachable."""
+    try:
+        return content_mod.load_world_data(WORLD_ID)
+    except (ValueError, FileNotFoundError, OSError):  # pragma: no cover
+        pytest.skip(f"{WORLD_ID!r} world content not reachable from test cwd")
+
+
+def _seed_world(world: dict) -> tuple[Campaign, str]:
+    """Seed the world, capturing stdout to detect [content] skipping lines."""
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        c = content_mod.seed_world(world)
+    return c, buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# 1. zero skip-diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_seed_world_zero_skip_diagnostics():
+    """seed_world must return a Campaign with NO [content] skipping lines.
+
+    A skip-line means a dangling ref or malformed block — the author's first
+    indicator that their world.json has an authoring error to fix.
+    """
+    world = _load_world()
+    c, stdout = _seed_world(world)
+    skip_lines = [ln for ln in stdout.splitlines() if "[content] skipping" in ln]
+    assert skip_lines == [], (
+        "seed_world emitted skip-diagnostics — dangling refs or malformed blocks:\n"
+        + "\n".join(skip_lines)
+    )
+    assert isinstance(c, Campaign)
+    assert c.world_id == WORLD_ID
+
+
+# ---------------------------------------------------------------------------
+# 2. events: present_events surfaces the authored event
+# ---------------------------------------------------------------------------
+
+
+def test_event_surfaces_via_present_events():
+    """The authored manual-trigger event must surface via events_mod.present."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+    assert EVENT_ID in c.events, f"event {EVENT_ID!r} not seeded"
+    ev = c.events[EVENT_ID]
+    present_ids = [e.id for e in events_mod.present(c)]
+    assert EVENT_ID in present_ids, (
+        f"{EVENT_ID!r} not in present_events; present={present_ids}"
+    )
+    assert ev.anchor_npc_id == NPC_COMPANION_ID
+
+
+def test_event_has_three_options_including_refuse_path():
+    """The authored event must carry >= 2 options including a clean 'not your problem' path."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+    ev = c.events[EVENT_ID]
+    assert len(ev.options) >= 2
+    # at least one option has no faction_id or reputation_delta (the refuse/walk-away path)
+    no_ripple = [o for o in ev.options if not o.outcome.faction_id and o.outcome.reputation_delta == 0]
+    assert no_ripple, "event must have at least one option with no faction ripple (the refuse path)"
+
+
+# ---------------------------------------------------------------------------
+# 3. resolve_event: flag + reputation + consequence schedule
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_event_sets_flag_shifts_faction_schedules_consequence():
+    """Resolving the 'help the captain' option sets the decision_flag, shifts
+    fac-salvagers-league reputation, and schedules a follow-on consequence.
+    Mirrors test_event_parley_layer3.py assertions."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+    ev = c.events[EVENT_ID]
+
+    # pick the 'help' option — the first option (trust_over_procedure)
+    # find_option is exact case-insensitive; the full label includes the em-dash clause
+    help_option = next(
+        (o for o in ev.options if o.label.casefold().startswith("help him move it")),
+        None,
+    )
+    assert help_option is not None, (
+        "could not find the 'Help him move it' option; labels="
+        + str([o.label for o in ev.options])
+    )
+
+    pre_rep = c.factions[FACTION_ID].reputation
+    res = events_mod.resolve(c, ev, help_option)
+
+    # flag set
+    assert c.flags.get("trust_over_procedure") is True, "decision_flag not set"
+    # faction reputation shifted
+    post_rep = c.factions[FACTION_ID].reputation
+    assert post_rep < pre_rep, f"expected reputation to fall; pre={pre_rep} post={post_rep}"
+    # consequence scheduled
+    followups = [co for co in c.consequences if "League" in co.text or "invoice" in co.text.lower() or "factors" in co.text.lower()]
+    assert followups, "follow-on consequence not scheduled"
+    # event marked resolved → idempotent (the pure module sets the latch)
+    assert ev.resolved is True
+
+
+# ---------------------------------------------------------------------------
+# 4. faction arc gates
+# ---------------------------------------------------------------------------
+
+
+def test_faction_arc_seeded_and_gates_correctly():
+    """The authored faction arc for fac-salvagers-league must seed and gate:
+    - stage 1 (reputation gate at 12) is locked below 12 and available at 12.
+    - stage 2 (standing gate at 20) is locked when standing < 20.
+    Mirrors test_faction_arcs.py gate assertions."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+
+    assert FACTION_ARC_ID in c.faction_arcs, f"arc {FACTION_ARC_ID!r} not seeded"
+    arc = c.faction_arcs[FACTION_ARC_ID]
+    fac = c.factions[FACTION_ID]
+
+    # The faction must link back to its arc
+    assert fac.questline_arc_id == FACTION_ARC_ID
+
+    # Stage 1: reputation gate at 12
+    stage1 = arc.stages[0]
+    assert stage1.gauge == "reputation"
+    assert stage1.unlock_at == 12
+
+    fac.reputation = 11
+    assert fa.stage_gate_holds(stage1, fac) is False, "reputation 11 < 12: should be locked"
+    fac.reputation = 12
+    assert fa.stage_gate_holds(stage1, fac) is True, "reputation 12 >= 12: should be available"
+
+    # Stage 2: standing gate — locked when standing < 20 even at max reputation
+    stage2 = arc.stages[1]
+    assert stage2.gauge == "standing"
+    assert stage2.unlock_at == 20
+
+    fac.reputation = 100  # reputation high
+    fac.standing = 19
+    assert fa.stage_gate_holds(stage2, fac) is False, "standing 19 < 20: should be locked"
+    fac.standing = 20
+    assert fa.stage_gate_holds(stage2, fac) is True, "standing 20 >= 20: should be available"
+
+
+def test_faction_arc_requires_join_before_advancing():
+    """The requires_joined arc must not advance before join_faction."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+    arc = c.faction_arcs[FACTION_ARC_ID]
+    fac = c.factions[FACTION_ID]
+
+    # give plenty of reputation but don't join
+    fac.reputation = 100
+    fac.joined = False
+    res = fa.evaluate(arc, c)
+    assert res["newly_available"] == [], "arc must stay locked until faction is joined"
+
+
+# ---------------------------------------------------------------------------
+# 5. quest_variants: at least one outcome is resolved
+# ---------------------------------------------------------------------------
+
+
+def test_quest_variant_resolves():
+    """The quest_variant 'the-first-surfacing' must resolve to one of its authored outcomes."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+    assert QUEST_VARIANT_ID in c.quest_outcomes, (
+        f"quest_variant {QUEST_VARIANT_ID!r} not resolved; quest_outcomes={c.quest_outcomes}"
+    )
+    outcome_id = c.quest_outcomes[QUEST_VARIANT_ID]
+    valid_ids = {"cache-under-study", "cache-in-vethis-hands", "cache-lost-overboard"}
+    assert outcome_id in valid_ids, f"unexpected outcome id {outcome_id!r}"
+
+
+# ---------------------------------------------------------------------------
+# 6. NPC roster + companion dossier seeded correctly
+# ---------------------------------------------------------------------------
+
+
+def test_npc_roster_seeded_with_dossier():
+    """All 4 authored roster NPCs must be seeded; the companion (npc-captain-drev) must carry
+    its companion_dossier (wound, wants, fears, values, banter_tags, camp_prompts, relationships)."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+
+    roster_ids = ["npc-warden-estris", "npc-captain-drev", "npc-mira-scroll", "npc-tribune-kessal"]
+    for nid in roster_ids:
+        assert nid in c.characters, f"roster NPC {nid!r} not seeded"
+
+    companion = c.characters[NPC_COMPANION_ID]
+    assert companion.companion_dossier is not None, "companion dossier not seeded"
+    d = companion.companion_dossier
+    assert d.wound, "dossier wound must not be empty"
+    assert d.wants, "dossier wants must not be empty"
+    assert d.fears, "dossier fears must not be empty"
+    assert d.values, "dossier values must not be empty"
+    assert d.banter_tags, "dossier banter_tags must not be empty"
+    assert d.camp_prompts, "dossier camp_prompts must not be empty"
+    assert d.relationships, "dossier relationships must not be empty"
+
+
+# ---------------------------------------------------------------------------
+# 7. starting_options respected (current_location_id is the first starting option)
+# ---------------------------------------------------------------------------
+
+
+def test_starting_location_set():
+    """The world's first starting_option (loc-saltmere) must be the current_location_id."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+    assert c.current_location_id == "loc-saltmere"
+    assert c.locations["loc-saltmere"].visited is True
+
+
+# ---------------------------------------------------------------------------
+# 8. ADDITIVE: no engine changes (belt-and-suspenders round-trip)
+# ---------------------------------------------------------------------------
+
+
+def test_campaign_round_trips_after_second_seed():
+    """A campaign seeded from the second world must survive a model_dump / model_validate
+    round-trip — proving the additive-default contract (no new required fields)."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+    data = c.model_dump(mode="json")
+    reloaded = Campaign.model_validate(data)
+    assert reloaded.world_id == WORLD_ID
+    assert EVENT_ID in reloaded.events
+    assert FACTION_ARC_ID in reloaded.faction_arcs


### PR DESCRIPTION
## Summary
The North Star's falsifiable **deliverable-B gate**: can a brand-new universe be added as *content alone, with ZERO engine changes*? **Yes.** This adds "The Tidal Commonwealth" — a clean-room original (CC-BY-4.0, no WotC/Larian/FR IP) drowned-empire maritime world — that seeds clean and exercises every living-story surface from a `world.json` alone.

Diff is **3 files, 567 insertions, zero engine `.py` changes**: the world seed, its LICENSE.md, and a permanent generativity test.

## What it proves
- `content.seed_world(tidal_commonwealth)` → **zero skip-diagnostics**: 5 regions, 4 factions, 4 NPCs (incl. a companion-ready captain with a full dossier), 1 stumble-into Event (decision_flag + faction-rep + scheduled callback + clean refuse path), 1 join→grow→lead faction arc (reputation-gated stage 1, standing-gated stages 2–3, world-changing finale), 1 quest variant (ending-tied + random outcomes).
- `events` / `faction_arcs` / `quest_variants` / `npc_roster`+dossier / `standing_threads`+`history` all seed + fire from the seed.

## Generativity boundary found (the valuable part)
A **`CompanionAgenda`** (sealed betrayal/flip) can currently only be armed via an **ending overlay's `companion_seeds`** — there's no base-`world.json` surface for it. Companion *dossiers* seed fine; only the sealed *agenda* needs an ending file. Documented for the self-serve-ingestor docs, plus the authoring gotchas (faction_id must match exactly; `reputation_at` triggers need the faction seeded first; quest-variant outcomes need an `id`).

## Test plan
- [x] `tests/test_second_seed.py` — 10 tests (seed clean / event surfaces+resolves / arc gates / quest variants / legacy-load) — **10 passed**
- [x] Full engine suite **1344 passed** (zero engine changes → no regressions)
- [x] `scripts/license_check.py` green (CC-BY-4.0 LICENSE.md present)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the "Tidal Commonwealth," a fully realized tabletop world featuring a detailed premise and history, distinct regions with interconnections, multiple factions with reputation systems, an authored cast of NPCs, dynamic scripted events with branching outcomes, faction story arcs, quest variants, and narrative seeds. The world is designed as a living sandbox for immersive gameplay.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/220?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->