### PR TITLE
feat(content): base-world companion arcs — a companion who turns, in any world (#221)

### DIFF
--- a/content/worlds/tidal-commonwealth/world.json
+++ b/content/worlds/tidal-commonwealth/world.json
@@ -115,6 +115,18 @@
           "npc-warden-estris": "old working relationship — she brought him in on three salvage contracts",
           "npc-mira-scroll": "knows her by reputation and is wary of her"
         }
+      },
+      "arc": {
+        "arc_gates": [
+          {"kind": "loyalty", "threshold": 30, "note": "Drev stops talking around you and starts talking to you — he names the crew he lost on the dive that scarred him, one at a time, and what he should have done differently. The trust is earned, not given; play it as a man who has decided you are worth the risk of caring about."},
+          {"kind": "personal_quest", "threshold": 45, "note": "The Deep Rim wound — the door the world points at. Drev finally describes what COLD LAMP's predecessor found at the rim six years ago: not a creature, a STRUCTURE, and it was aware of being looked at. He needs to go back and confirm it before it confirms him. His personal arc is the first hard evidence of what's cycling beneath the Commonwealth's politics."}
+        ],
+        "agenda": {
+          "trigger": "attitude_below",
+          "value": -25,
+          "decision_flag": "left_drev_exposed",
+          "note": "Drev does NOT turn for gold or power — he is crew-first to the bone. His break is the slow, cold kind: if you have repeatedly gambled lives he was responsible for and left him exposed when it counted, he stops trusting you with his people, pulls his crew and his Basin-knowledge out from under you, and — if pushed past the breaking point — actively moves to stop the next dive you would spend lives on. Telegraph it (he goes quiet, he stops bringing you finds, he starts checking your math) long before it lands. The turn is a withdrawal that becomes opposition, never a sudden knife — a good man who has stopped believing you'll do the right thing."
+        }
       }
     },
     {
@@ -171,6 +183,7 @@
           "tag": "detached / wary",
           "outcome": {
             "flag": "cold_lamp_cache_bystander",
+            "decision_flag": "left_drev_exposed",
             "narrate": "You step back from the gangplank and let it play out. The inspectors arrive; Drev makes a decision you don't see; the dock moves on. Whatever came up from the shallows is out of your hands, one way or another — and something in the captain's expression, when he passes you later, suggests he noticed you weren't there when it counted."
           }
         }

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -1402,6 +1402,22 @@ def seed_world(world: dict, start_at: str = "", ending: str = "") -> Campaign:
         )
         if dossier is not None:
             ch.companion_dossier = dossier
+        # ADDITIVE (#221, the generativity boundary the 2nd-seed spike surfaced): a roster
+        # entry may ALSO carry an OPTIONAL companion `arc` — the relationship gauge + arc
+        # gates + the sealed `agenda` that flips the companion on a decision/attitude break.
+        # In Baldur's Gate this is seeded per-ENDING (companion_seeds in the overlay), so the
+        # SAME companion turns differently under different endings; but a world WITHOUT endings
+        # (a fresh universe like the Tidal Commonwealth) had NO surface to arm a companion flip
+        # at all. Loading `arc` here from the base roster closes that gap — any world can author
+        # a companion who turns, right where the companion is defined. A malformed arc DEGRADES
+        # (the NPC gets no arc), never aborting the seed; no `arc` key -> arc stays None (today's
+        # behavior). An ending overlay's companion_seeds runs LATER (`_apply_ending_overlay`,
+        # after this loop) so an ending still OVERRIDES the base arc — endings keep the last word.
+        if isinstance(npc.get("arc"), dict):
+            try:
+                ch.arc = CompanionArc.model_validate(npc["arc"])
+            except (ValidationError, ValueError, TypeError):
+                print(f"[content] skipping malformed arc in npc_roster entry {ch.name!r}")
         c.characters[ch.id] = ch
 
     _seed_settlement_pressure(c, world)

--- a/servers/engine/tests/test_second_seed.py
+++ b/servers/engine/tests/test_second_seed.py
@@ -281,3 +281,36 @@ def test_campaign_round_trips_after_second_seed():
     assert reloaded.world_id == WORLD_ID
     assert EVENT_ID in reloaded.events
     assert FACTION_ARC_ID in reloaded.faction_arcs
+
+
+# ---------------------------------------------------------------------------
+# 9. #221: a companion arc/agenda arms from the BASE world.json (no ending overlay)
+# ---------------------------------------------------------------------------
+
+
+def test_base_world_companion_arc_arms_without_an_ending():
+    """The generativity boundary the spike surfaced: a CompanionAgenda (the sealed flip)
+    used to require an ending overlay's companion_seeds. #221 lets the base npc_roster carry
+    an `arc`, so a world with NO endings can still have a companion who turns. The Tidal
+    Commonwealth's Captain Drev must arm his decision-gated flip from the seed alone."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+    drev = c.characters[NPC_COMPANION_ID]
+    assert drev.arc is not None, "base-world npc_roster `arc` did not seed onto the companion"
+    ag = drev.arc.agenda
+    assert ag is not None and ag.trigger == "attitude_below"
+    assert ag.value == -25, "breaking point must sit inside the [-40,-20] warn band so it telegraphs"
+    # the L3->L2 seam: the agenda is decision-gated, and the gating flag is set by an event option
+    assert ag.decision_flag == "left_drev_exposed"
+    flag_setters = [
+        o.outcome.decision_flag
+        for ev in c.events.values()
+        for o in ev.options
+        if o.outcome.decision_flag
+    ]
+    assert "left_drev_exposed" in flag_setters, (
+        "the agenda's decision_flag must be reachable from an authored event option (the L3->L2 seam)"
+    )
+    # the relationship gates (loyalty + personal-quest) seeded too — a full companion, not just a flip
+    gate_kinds = {g.kind for g in drev.arc.arc_gates}
+    assert {"loyalty", "personal_quest"} <= gate_kinds


### PR DESCRIPTION
## Summary
Closes the **generativity boundary** the 2nd-seed spike (#220) surfaced: a `CompanionAgenda` (the sealed betrayal/flip) could only be armed via an **ending overlay's** `companion_seeds`, so a brand-new universe with no endings had no way to author a companion who turns on a choice — the owner's "companions that turn on a choice, in any world."

Now an `npc_roster` entry may carry an optional **`arc`** (relationship gauge + arc gates + the sealed agenda), loaded in the seed loop right beside the dossier. Additive, degrade-not-abort, and an **ending overlay still overrides it** (`_apply_ending_overlay` runs after the roster loop — endings keep the last word).

## Demonstrated on the Tidal Commonwealth's Captain Drev
- An **in-character** decision-gated flip: `attitude_below -25` (inside the [-40,-20] warn band so `betrayal_warning` telegraphs), gated on `left_drev_exposed` — a flag set by the `event-league-cache` "stay out of it" option (the **L3→L2 seam**, exactly like BG's took_bribe→Minsc). Drev doesn't betray for gold; he's crew-first — his break is a slow withdrawal that becomes opposition if you gamble lives he's responsible for.
- Plus **loyalty** + **personal-quest** relationship gates (his Deep-Rim wound — the first hard evidence of what's cycling beneath the politics).

## Test plan
- [x] `test_second_seed.py::test_base_world_companion_arc_arms_without_an_ending` — Drev's arc/agenda arms from the base seed, decision_flag reachable from an event option, both gates present
- [x] Full engine suite **1345 passed** (additive change; `test_companion_arc.py` still green)
- [x] Seed smoke: tidal-commonwealth still **zero skip-diagnostics**
- [x] `license_check.py` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Companion characters now feature dynamic story arcs that respond to player decisions. Captain Drev's loyalty and personal growth arcs will evolve based on how you handle key encounters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->