### PR TITLE
content(tidal-commonwealth): deepen into a playable 2nd world — lore corpus + 2 endings

### DIFF
--- a/content/worlds/tidal-commonwealth/endings/mechanism-destroyed.json
+++ b/content/worlds/tidal-commonwealth/endings/mechanism-destroyed.json
@@ -1,0 +1,92 @@
+{
+  "id": "mechanism-destroyed",
+  "name": "The Mechanism Destroyed — The Commonwealth Holds",
+  "schema_version": 1,
+  "supersedes": [
+    "something old is cycling back toward activation",
+    "the mechanism is still active",
+    "the clock runs three years closer to completion",
+    "approximately three years from now",
+    "eighty-seven years through a ninety-year cycle",
+    "the mechanism is cyclic",
+    "what is currently rising from the deep rim",
+    "something is rising from the deep rim",
+    "something has begun to rise from it",
+    "the compact is sixty days from a crisis"
+  ],
+  "world_state": {
+    "world_tenor": "hopeful",
+    "facts": {
+      "the_mechanism": "destroyed",
+      "the_compact": "renewed",
+      "the_gray_basin": "stilling",
+      "vethis_bloc": "integrated",
+      "tide_readers": "vindicated"
+    }
+  },
+  "era": "The Forty-Third Year of the Interregnum, in its final days — or the first year of whatever comes after. The mechanism beneath the Deep Rim was found and destroyed before the cycle completed; the Gray Basin is stilling, the luminescence fading for the first time in living memory. The Compact was renewed under the pressure of the crisis and came out harder and more honest than it went in. The Commonwealth did not drown. What it cost to get here is another matter.",
+  "premise_suffix": " In this telling, the mechanism was reached and undone before the second Tide began. The Tide-Readers were vindicated. The Vethis Bloc, forced to put its intelligence on the table by the scale of the crisis, lost its leverage and kept its seat — and Kessal Vor negotiated from a weaker position than he had planned. The Gray Basin's water is slowly becoming ordinary water again, and the deep-divers who know what ordinary water looks like in those depths find the change unsettling in its own right: something vast is no longer there, and the absence has a shape. The Commonwealth survived. Into its first hopeful, diminished morning, the player steps — the crisis resolved, the factions rearranging themselves around a world where the threat is gone and the debts are not.",
+  "standing_threads": [
+    "The Tide-Readers vindicated: Mira Scroll's evidence is now a matter of public record, the Council has formally acknowledged the mechanism's existence and destruction, and the sect that was called fringe scholarship for three generations is the closest thing the Commonwealth has to institutional heroes — which means every city-state is now trying to absorb them, hire them, or quietly take credit for having always supported them.",
+    "Rebuilding the Compact: the crisis forced transparency the Compact had never managed before — Vethis's hidden intelligence, the League's depth-logs, the Warden's private negotiations — and the renewed Compact is a tougher document, with real reporting requirements and a mutual-defense clause that cost Saltmere, Vethis, and the Ironhull League a piece each of what they most wanted to keep.",
+    "The Basin's strange silence: the Deep Rim mechanism is gone, but what it left behind is not nothing — the basin floor is marked, the ruins are different than they were, and at least three dive-crews have reported something that might be a secondary structure, or might be the aftermath of the destruction, or might be neither of those things."
+  ],
+  "history_append": [
+    "The mechanism found: after the COLD LAMP's discovery and the crisis that followed, a joint League-Tide-Reader-Compact expedition reached the Deep Rim's architecture and confirmed both its existence and its purpose; what they found in the central chamber has been classified by the Council and described, in the public record, only as a machine of pre-imperial construction whose function was water management on a continental scale.",
+    "The mechanism destroyed: the decision to destroy rather than study it was contested; the argument for destruction won by two votes in a Council session that lasted fourteen hours and ended with three city representatives not speaking to each other. The mechanism was destroyed. The Basin began to still.",
+    "The Vethis Bloc's accounting: Kessal Vor was forced to disclose his intelligence to the full Council, months after he should have done it voluntarily; the disclosure was not a confession but was received as one, and Vethis's political position in the renewed Compact is weaker than it was, its military credibility intact, its moral credibility reduced."
+  ],
+  "story_seeds_append": [
+    "The classified chamber report: what the expedition found in the Deep Rim's central structure, before they destroyed it, is not in the public record — three surviving expedition members know what they saw, and at least one of them is not sleeping.",
+    "The secondary structure: dive-crews working the newly stilled shallows have logged a change in the basin floor near the old rim edge — something that wasn't there before the mechanism was destroyed, or that the mechanism was obscuring. The League has not yet decided whether to report it.",
+    "Vor's second act: Kessal Vor survived the political accounting and remains on the Vethis council; a person who almost let the world drown for political leverage, and who is now rebuilding his position in a Commonwealth that knows exactly what he did, is either a cautionary figure or a warning that the incentives haven't changed."
+  ],
+  "fates": {
+    "npc-warden-estris": {
+      "status": "alive, exhausted, at the desk",
+      "where": "the Compact Council records room at Ironhull Station",
+      "note": "Spent the crisis as the fulcrum between what the Compact allowed and what survival required; the renewed Compact is partly her drafting. She will not accept a formal title for this. She has already started preparing the next crisis's paperwork."
+    },
+    "npc-captain-drev": {
+      "status": "alive, the Basin known",
+      "where": "the COLD LAMP at anchor, between dives",
+      "note": "What he saw at the Deep Rim six years ago has now been confirmed by two hundred other people and destroyed by a Council vote. He does not feel vindicated. He feels the same way he felt on the dive — that he was looking at something that noticed being looked at — except that thing is now gone, and he does not know if gone is the right word for what happened to it."
+    },
+    "npc-mira-scroll": {
+      "status": "alive, vindicated, and tired of being thanked",
+      "where": "the Tide-Readers' archive at Saltmere",
+      "note": "Spent two years being told her evidence was fringe scholarship; spent the crisis being told her evidence was essential; is now being asked to sit on four advisory councils simultaneously. She has declined all four. She has a great deal more work to do."
+    },
+    "npc-tribune-kessal": {
+      "status": "alive, diminished",
+      "where": "Vethis Isle council chambers",
+      "note": "His intelligence about the Deep Rim, held too long for leverage, nearly cost everyone everything; he knows this, the Council knows this, and the knowledge has not made him different — it has made him more careful, which is not the same thing and everyone can tell."
+    }
+  },
+  "companion_seeds": {
+    "npc-captain-drev": {
+      "arc": {
+        "arc_gates": [
+          {
+            "kind": "loyalty",
+            "threshold": 30,
+            "note": "The Basin confirmed and the mechanism destroyed, Drev allows himself something he withheld for six years: that the dive was real, and that you were the person who made following the evidence possible rather than burying it again. He does not call this trust. He calls it knowing which side of a thing someone stands on. He is on yours."
+          },
+          {
+            "kind": "personal_quest",
+            "threshold": 45,
+            "note": "The Deep Rim expedition — his six-year wound finally opened and closed. Drev asks to be on the team that goes down to the mechanism's chamber. Not for the Council, not for the League. Because he saw it first, alone, and he needs to see it again with someone he trusts, before it stops existing. His personal quest is the expedition itself: confirmation, grief, and whatever comes after finally knowing."
+          }
+        ],
+        "agenda": {
+          "trigger": "attitude_below",
+          "value": -25,
+          "decision_flag": "left_drev_exposed",
+          "note": "In the ending where the mechanism is destroyed, Drev's break carries the same weight with a different wound: if you spent the crisis gambling other people's lives while claiming to protect what he found, and left him exposed at the moments that counted, he reaches the expedition decision and does not bring you. He files his own report with the Tide-Readers, cuts the formal relationship, and is civil at the dock — the cold civility of a man who has decided you are not someone he will spend his last dive near."
+        }
+      }
+    }
+  },
+  "license": "Original ClawDnD world content. CC-BY-4.0.",
+  "attribution": "Original work. The Tidal Commonwealth is a clean-room original setting — no WotC / Larian / Forgotten Realms / Baldur's Gate IP. CC-BY-4.0 © ClawDnD contributors."
+}

--- a/content/worlds/tidal-commonwealth/endings/second-tide-rising.json
+++ b/content/worlds/tidal-commonwealth/endings/second-tide-rising.json
@@ -1,0 +1,92 @@
+{
+  "id": "second-tide-rising",
+  "name": "The Second Tide — A Faction Seizes the Mechanism",
+  "schema_version": 1,
+  "supersedes": [
+    "the compact is forty years old and the generation that signed it is nearly gone",
+    "no single power should ever get large enough to drown again",
+    "the compact has held",
+    "the compact survived",
+    "the mechanism is still active",
+    "the mechanism is cyclic",
+    "what is currently rising from the deep rim",
+    "something is rising from the deep rim",
+    "something has begun to rise from it",
+    "the compact is sixty days from a crisis"
+  ],
+  "world_state": {
+    "world_tenor": "grim",
+    "facts": {
+      "the_mechanism": "seized",
+      "the_compact": "broken",
+      "the_gray_basin": "destabilizing",
+      "vethis_bloc": "ascendant",
+      "tide_readers": "suppressed"
+    }
+  },
+  "era": "The Forty-Third Year of the Interregnum — and possibly its last. The mechanism beneath the Deep Rim was reached before the crisis became public, but the party that reached it did not destroy it. The Vethis Bloc holds the mechanism now: not the knowledge of it, not a political advantage from knowing about it — the actual architecture, occupied and held by Vethis divers at the Deep Rim's central structure. The Compact is broken. The Gray Basin's water is wrong in new ways. The Commonwealth has sixty days, perhaps less, before the Bloc demonstrates what it can do with what it holds.",
+  "premise_suffix": " In this telling, the mechanism was found and taken rather than destroyed — and the party that took it is not the party that would use it wisely. The Vethis Bloc's seizure of the Deep Rim structure has broken the Compact irrevocably: the other cities cannot pretend the non-aggression clause survives a threat of continental flooding. The Tide-Readers are being suppressed — Mira Scroll's research has been classified by the Bloc as a security matter — and the Salvagers' League is being pressured to redact its depth-logs. The Commonwealth is sixty days from a demonstration that changes what it means to be a city-state on the Basin's edge. Into a world that is deciding whether to resist or accommodate the new order, the player steps: the crisis not resolved but metastasized, and every faction calculating how much of themselves they can preserve.",
+  "standing_threads": [
+    "The Bloc's ultimatum: Kessal Vor has not yet made a public demand — the announcement is scheduled, the Compact cities have been warned privately, and the diplomatic window is still open, which is why the League and the Compact remnant are moving now rather than after the demonstration.",
+    "The suppressed evidence: Mira Scroll's full research has been classified; she managed to get copies out before the Bloc's agents arrived, and those copies are somewhere in the Commonwealth's remaining free cities — whoever finds them has the technical knowledge to understand what the mechanism can and cannot actually do, which is not what the Bloc is claiming it can do.",
+    "The League's fracture: the Salvagers' League has been told to sign a new licensing agreement that cedes control of all Deep Rim survey rights to the Vethis Bloc; the League's senior factors are split — some are willing to sign, some are not, and the split is happening in real time, in the dockside offices of Ironhull Station, which Vethis forces have not yet occupied."
+  ],
+  "history_append": [
+    "The seizure: a Vethis dive-team, acting on Tribune Kessal Vor's private intelligence, reached the Deep Rim's central structure ahead of the joint expedition the Compact Council had authorized; they occupied it, changed the access codes on the architecture's control points, and reported back to Vor that the site was secure before the Compact's team launched.",
+    "The Compact breaks: the Saltmere and Ironhull League representatives walked out of the emergency Council session when Vor refused to either vacate the structure or share its access with the full Council; the Compact has no enforcement mechanism, and Vor knows it; the document that held the Commonwealth together for forty years is now a historical artifact.",
+    "The Tide-Readers silenced: Mira Scroll's public statement about the mechanism's capabilities was classified as a security threat within forty-eight hours of the seizure; the Bloc's position is that her research constitutes a military secret, and two of her research colleagues have been detained as material witnesses."
+  ],
+  "story_seeds_append": [
+    "The copies: Mira Scroll got her research out in pieces, through three different couriers, before the classification order; the pieces are in Saltmere, the Ironhull Station, and one location she will only name to the right person under the right conditions — and together they explain exactly how the mechanism works and exactly what it cannot do, which the Bloc does not want the Commonwealth to know.",
+    "The League's deciding vote: the senior factors' vote on the new licensing agreement is forty-eight hours away; the vote is tied; the deciding factor is a woman named Calla Bryne who has not been seen at her usual berth since yesterday morning, and three separate factions need to know where she is and what she is going to decide.",
+    "Drev's position: the COLD LAMP is the League's most credible active vessel and Drev is the League's most credible living witness to the Deep Rim's actual conditions — which makes him an asset the Bloc wants neutralized and the resistance needs operational, and which puts him in exactly the position he spent six years trying to avoid."
+  ],
+  "fates": {
+    "npc-warden-estris": {
+      "status": "alive, operating without authority",
+      "where": "a safe address in Saltmere's upper city that is not the Compact records room",
+      "note": "The Compact is broken, which means her official position is dissolved; she is operating anyway, because someone has to coordinate the cities that have not yet chosen the Bloc's terms, and she is the only person who knows where every lever is. She is sixty-three and has three weeks of supplies and a very clear understanding of what happens if Saltmere signs the licensing agreement."
+    },
+    "npc-captain-drev": {
+      "status": "alive, under pressure",
+      "where": "the COLD LAMP at Ironhull Station, possibly for the last time",
+      "note": "The Bloc wants his depth-logs classified and his League vote guaranteed; the resistance needs his Basin knowledge and his credibility with the other captains; he has been told, by a Vethis envoy, that the COLD LAMP's survey license will not be renewed if he votes against the agreement. He is thinking about this with the same care he uses for equipment checks, which is to say: methodically, slowly, and already knowing the answer."
+    },
+    "npc-mira-scroll": {
+      "status": "alive, in hiding",
+      "where": "unknown — she is not where the Bloc thinks she is",
+      "note": "Her public statement cost her her laboratory and her colleagues' safety; she sent the research copies out, she said what she knew, and she is now somewhere in the Commonwealth's free cities with the rest of what she knows and a very strong opinion about what should be done with it. She will surface when she decides the right person has arrived."
+    },
+    "npc-tribune-kessal": {
+      "status": "ascendant, uneasy",
+      "where": "Vethis Isle, the council chambers",
+      "note": "Got exactly what he spent two years positioning for, and the having of it is not what the wanting was. He controls a mechanism that can end a civilization. He is a city-state tribune with fifteen years of political experience and no training for what he is holding, and three of his own council members are arguing about the demonstration date, and he has begun to understand that the thing he seized may not be as controllable as the Tide-Readers' suppressed research implied."
+    }
+  },
+  "companion_seeds": {
+    "npc-captain-drev": {
+      "arc": {
+        "arc_gates": [
+          {
+            "kind": "loyalty",
+            "threshold": 30,
+            "note": "Drev has been told the COLD LAMP's license won't survive a no-vote. The calculation he is running — crew safety versus the Basin's future versus whether the Bloc's claim about the mechanism is even accurate — is the same calculation he ran six years ago, and he ran it wrong. He names the crew member he lost on the Deep Rim dive only after you reach this depth, as the evidence for a conclusion he needs you to help him reach: that the Bloc is not going to use the mechanism carefully, and that the right kind of loss is the one you choose."
+          },
+          {
+            "kind": "personal_quest",
+            "threshold": 45,
+            "note": "The dive he can no longer avoid: the only way to know if the Bloc's technical claims about the mechanism are accurate — or if Mira Scroll's suppressed research is right that the mechanism's control is far more conditional than Vor is claiming — is to go back to the Deep Rim and look. Drev has not been back in six years. His personal arc is the mission that requires him to return to the place that scarred him, with someone he has decided to trust, to find out if the world can still be saved or only survived."
+          }
+        ],
+        "agenda": {
+          "trigger": "attitude_below",
+          "value": -25,
+          "decision_flag": "left_drev_exposed",
+          "note": "Under the second-tide ending, Drev's break is cold and specific: if you gambled lives he was responsible for and left him exposed when it counted, he signs the League licensing agreement — not because he believes in the Bloc, but because you were the alternative and the alternative proved unreliable. He files the paperwork, notifies the Bloc's envoy, and is at his usual berth the next morning. He does not explain. He has made a decision from evidence, the way he always does."
+        }
+      }
+    }
+  },
+  "license": "Original ClawDnD world content. CC-BY-4.0.",
+  "attribution": "Original work. The Tidal Commonwealth is a clean-room original setting — no WotC / Larian / Forgotten Realms / Baldur's Gate IP. CC-BY-4.0 © ClawDnD contributors."
+}

--- a/content/worlds/tidal-commonwealth/lore/captain-drev-ossian.md
+++ b/content/worlds/tidal-commonwealth/lore/captain-drev-ossian.md
@@ -1,0 +1,19 @@
+# Captain Drev Ossian
+
+*Era: The Forty-Third Year of the Interregnum. Captain of the COLD LAMP, twentieth year in the Basin.*
+
+Drev Ossian has dived the Gray Basin for twenty years, and the first thing any League factor will tell you about him is that he is careful. He runs a full equipment check before every dive. He does not exceed his planned depths. He has never lost a crew member to equipment failure. He has lost one crew member to something that was not equipment failure, on a dive six years ago at the Deep Rim's inner edge, and he does not discuss that dive.
+
+The scar runs from his jawline to his collarbone on the left side, a smooth pale line that tells the story of something sharp and cold and fast. The dive record from that trip is in the League's archives, amended and re-amended, stripped of its original depth-logs and submitted late. League factors who have seen both the original and the amended version have not compared them publicly, because the original version describes something that would require everyone who reads it to decide what to do about it, and most people in the League would prefer not to decide.
+
+He is a half-elf, which means he has probably been diving since before some of the Commonwealth's current city councils were constituted, and he will probably be diving after their successors are gone. He does not emphasize this. He does not emphasize much. He argues from evidence, falls silent rather than speculate, and has built a reputation over two decades for being the most reliably honest captain in the League — not because honesty is easy, but because he has concluded that a lie which saves you one problem creates three others, and he is bad at keeping track of three problems.
+
+The decision that defines him, the one he has to live with, was not the dive itself. It was what he did afterward: he went back to Ironhull Station, filed an amended record, put his crew on medical leave without explanation, and spent three days at anchor in the shallows doing what he described to anyone who asked as routine maintenance. He did not report what he had seen. He did not report it because he could not be certain — the water at the rim affects perception, the light is wrong, a person alone at depth for too long will see things — and because the thing he had seen, if he reported it accurately, would require the Commonwealth to make a decision he was not sure the Commonwealth would make correctly.
+
+He has been waiting six years for more evidence. More evidence has been arriving.
+
+The COLD LAMP's most recent survey — the one that brought back a crate locked from the inside and two crew short — was the first time the evidence came to him rather than the other way around.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*

--- a/content/worlds/tidal-commonwealth/lore/the-compact.md
+++ b/content/worlds/tidal-commonwealth/lore/the-compact.md
@@ -1,0 +1,17 @@
+# The Compact
+
+*Era: The Forty-Third Year of the Interregnum. The Compact is forty years old.*
+
+The document that holds the Commonwealth together is thirty-one articles on tanned leather, stored in a fireproof chest in the Ironhull Station records room and witnessed by a seal from every signatory city. It has survived two attempts to formally dissolve it, one fire (the fireproof chest worked), and forty years of bad faith from parties who signed it in good faith and then had children who signed nothing.
+
+The Compact's core rule is simple: no signatory city may make war on another signatory city, acquire land that borders a signatory city's territory without consent, or maintain a fleet above the capped tonnage limit outside its home harbor. Everything else — trade disputes, fishing rights, treaty arbitration, mutual defense — is handled by the rotating Compact Council, a body of city representatives with barely enough authority to issue binding guidance and nowhere near enough authority to enforce it.
+
+It was signed forty years ago after the Three-City War, which had left Saltmere, the Ironhull League, and Vethis Isle all diminished and all unwilling to admit they had fought for nothing. The negotiators who hammered it out were practical people with fresh memories of what a short war between starving survivors looked like, and they made the rules simple enough that no one could claim later to have misunderstood them.
+
+The generation that signed it is nearly gone. **Warden Estris Vane** is among the last people alive who was present at the negotiations — she was a young records clerk who copied the final document by hand — and she has spent thirty years watching the Compact survive by being the one thing everyone agrees they need until the moment they decide they don't. The current crisis is different, she believes, because this time the Vethis Bloc is not posturing. Tribune Kessal Vor has actual intelligence about the Deep Rim, and he is choosing to use it as leverage rather than sounding the alarm, which means he has already decided the Compact is less useful to him than the alternatives.
+
+The Compact can survive cities that want more than it allows. It cannot survive cities that believe the alternative is survivable.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*

--- a/content/worlds/tidal-commonwealth/lore/the-drowning-tide.md
+++ b/content/worlds/tidal-commonwealth/lore/the-drowning-tide.md
@@ -1,0 +1,19 @@
+# The Drowning Tide
+
+*Era: The Forty-Third Year of the Interregnum. Three generations after the Drowning Tide.*
+
+The Drowning Tide was not a storm. It was not a quake. Survivors described it afterward — those few who survived and were later believed — as a single surging exhalation, as if the sea had exhaled from below. The water moved in one direction, with one purpose, for three days, and when it stopped the Varentine Empire's heartland was sixty fathoms under saltwater.
+
+The plateau city of Varent drowned in hours. Its towers, its granaries, its great records-archive, its palace of six domes — all of it is somewhere beneath what is now called the Gray Basin. The coastal cities survived only because the surge had spent itself on the highlands; by the time the water reached the eastern harbors, it had slowed to a brown surge of wreckage and sediment rather than a kill-wave. They received the water and they received the refugees, and those two things defined the next century.
+
+No one has ever established the cause. Three generations of scholars, sect theorists, and drowned-coast engineers have produced three competing explanations: a natural seismic disruption of unprecedented scale, a deliberate act of sabotage by persons or forces now dead, or — the answer the Tide-Readers hold — something that was built inside the plateau's deepest geology, something that activated. The first explanation is accepted by the Council of Four. The second is debated by academics who are careful about which academics they debate it with. The third is officially considered fringe scholarship, except when the Tide-Readers bring evidence, at which point it becomes evidence that cannot be published.
+
+What is known without dispute: the Tide acted on the water from below. Coastal tide-stations recorded not a surge moving from ocean inward, but a movement originating from the interior — from the plateau — and pushing outward in all directions simultaneously. The ocean did not invade the highlands. The highlands generated something, and the water obeyed it.
+
+Survivors of the first days remembered that the water at the plateau's edge was wrong before the surge. Too still. Too dark. And at certain tides, faintly luminescent.
+
+The Tide-Readers have compared those accounts to what their survey boats are recording now at the Deep Rim. The comparison is why Mira Scroll has been trying to get an audience with the Compact Council for six months.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*

--- a/content/worlds/tidal-commonwealth/lore/the-gray-basin-and-deep-rim.md
+++ b/content/worlds/tidal-commonwealth/lore/the-gray-basin-and-deep-rim.md
@@ -1,0 +1,21 @@
+# The Gray Basin and the Deep Rim
+
+*Era: The Forty-Third Year of the Interregnum. Active survey season.*
+
+The Gray Basin is the inland sea that covers what was once the Varentine Empire's central plateau. It is roughly circular, three hundred kilometers across, and — in its navigable outer shallows — between twenty and forty meters deep, where the salvage rigs work the drowned-edge ruins. Its center is another matter.
+
+The **Gray Basin Shallows** are the working waters of the Commonwealth's salvage economy. For three generations, divers have brought up carved stone, corroded ironwork, sealed jars of plateau grain, and the occasional intact building-corner from the old empire's cities. The floor of the shallows is charted, argued over, and divided into licensed survey blocks by the Salvagers' League. It is the closest thing the Commonwealth has to a stable extractive industry, and like all such industries it has produced a community of people who know more about what the Basin contains than anyone in the city councils would find comfortable.
+
+The **Deep Rim** begins where the drowned plateau drops away from the outer shelf into depths no line has ever bottomed. The outer edge of the rim is navigable water; the inner edge is where the water changes. Too still. Too dark. When the conditions are right — calm night, no moon, and a patience for watching — the water at the rim is faintly luminescent: a dim blue-gray pulse that Tide-Reader journals have documented for sixty years and that every senior salvager knows about and almost none discuss in front of League factors, because an honest account of what the Deep Rim water looks like at night would require an explanation, and no one has an explanation that ends well.
+
+The floor of the Deep Rim is unknown. The deepest successful dive on record was conducted by a Tide-Reader survey team eleven years ago; they reached forty-two fathoms below the shelf edge and described, in a report that has been circulated privately for a decade, structural forms that were not natural rock formations. They did not describe them as ruins. The word they used, in a carefully bureaucratic sentence in the middle of a longer technical document, was: *architecture*.
+
+What is surfacing from the Deep Rim now is not, primarily, artifacts — though artifacts are being recovered. What is surfacing is change. The bottom of the shallows closest to the rim is measurably higher than it was three survey seasons ago. Not by much. Four to seven centimeters in the deepest-mapped zones. The Salvagers' League's senior depth-loggers know this. They have not yet reported it to the Compact Council, partly because there is no agreed protocol for reporting it, and partly because the captain who first noticed it — **Drev Ossian** of the COLD LAMP — made a quiet suggestion at the last League factors' meeting that they confirm it across multiple rigs before they put it in a document that would then have to go to every city simultaneously.
+
+The Deep Rim's water does not move the way water should. It resists current. It responds to the tides on a calendar that is six minutes behind the tidal clock everywhere else in the Commonwealth's waters. The Tide-Readers believe this is because the mechanism that created the Drowning Tide is cyclic, and the six-minute offset is the measure of how far through the cycle it has progressed since activation.
+
+They believe it is eighty-seven years through a ninety-year cycle.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*

--- a/content/worlds/tidal-commonwealth/lore/the-salvagers-league.md
+++ b/content/worlds/tidal-commonwealth/lore/the-salvagers-league.md
@@ -1,0 +1,17 @@
+# The Salvagers' League
+
+*Era: The Forty-Third Year of the Interregnum. Active survey season.*
+
+The Salvagers' League is not a city and not a government, which is precisely what makes it powerful. It is a guild-network of professional wreck-divers, survey crews, artifact traders, equipment manufacturers, and the lawyers who negotiate between all of them — a federation of interests that operates across every Commonwealth city-state and owes loyalty to none of them. Its only rule, the one carved into the lintel of every League dock office, reads: *What comes up belongs to whoever brought it up, and who brought it up is whoever has the papers.*
+
+The papers are the League's product. A licensed survey block, a dive-record, a provenance chain for recovered artifacts — these documents are the currency of the Basin economy, and the League is the bank that issues them and the court that adjudicates disputes about them. Every city tries to regulate the League's work within its harbors. None has yet managed to regulate what happens in the water itself.
+
+The League is organized around **factors** — senior members with a vote on what goes to auction, what gets held back, and who gets access to which survey blocks. Factors are elected from below, by the dive-crews who bring them finds, in a process so informal and reputation-dependent that it would be invisible to anyone not already inside the League's working culture. An outsider earns a factor's hearing by producing results the League considers worth hearing about; the League considers results worth hearing about when they come from someone who has already gone down and come back with something useful.
+
+The League's intelligence advantage over every Commonwealth city is not technological — it is positional. League divers are the only people who regularly visit the Gray Basin's floor. They know, collectively, exactly where the bottom is changing, exactly which ruins are rising, and exactly what the Deep Rim looks like up close. Some of this knowledge is in League records. Most of it is in the private journals of individual dive-crews, in the unrecorded conversations between captains at the Ironhull Station dock, in the things that do not go into manifests because the things that go into manifests end up in the hands of city factors and then in front of city councils and then in a political argument that has nothing to do with the Basin and everything to do with who gets to tax which harbor.
+
+**Captain Drev Ossian** is the League's most respected active captain, though he would deny this. He has dived the Basin for twenty years on the COLD LAMP, logged more survey blocks than any three other crews combined, and has a scar on his jaw and neck that he has never explained. He is also the person who, in the last factors' meeting, suggested quietly that the League confirm the rising-floor data across multiple rigs before anyone puts it in writing. The other factors present understood that this suggestion was not about confirmation. It was about deciding, before the document exists, who the document should reach.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*

--- a/content/worlds/tidal-commonwealth/lore/the-tide-readers.md
+++ b/content/worlds/tidal-commonwealth/lore/the-tide-readers.md
@@ -1,0 +1,21 @@
+# The Tide-Readers
+
+*Era: The Forty-Third Year of the Interregnum. Third generation of the sect.*
+
+The Tide-Readers were founded in the years immediately after the Drowning Tide by survivors who refused to accept that what had happened was a natural disaster. They were not, originally, a unified sect — they were a loose network of coastal engineers, imperial records-keepers, and a few deep-water divers who were separately bothered by the same fact: the tidal station records from the days before the Tide did not look like a storm. They looked like a controlled release.
+
+The sect's formal founding is dated to the moment its first three independent investigators compared notes and found that they had each reached the same conclusion by different routes. The Tide was not a surge that originated from the ocean. The Tide originated from beneath the plateau's interior, moved outward in all directions simultaneously, and stopped when the interior source stopped producing it. This meant either a geological event of a kind that had never been recorded before and showed no precursor signs in the Varentine Empire's century of seismic monitoring — or something deliberate.
+
+The Tide-Readers chose deliberate, and spent three generations trying to prove it.
+
+They are mistrusted by every city-state, not because their evidence is weak — it has grown stronger with each decade — but because the conclusion it implies is deeply uncomfortable. If the Drowning Tide was a mechanism, then it can potentially be activated again. If it can be activated again, every city-state in the Commonwealth is built beside a weapon of continental destruction that is still active. The Compact Council has never formally acknowledged this possibility, and the Tide-Readers have never been invited to present their full evidence to the Council's joint session. Individual cities commission the Tide-Readers' environmental survey work when they need depth charts; none of them want to be the city that formally acknowledged what the depth charts are finding.
+
+**Mira Scroll** is the Tide-Readers' current lead theorist. She is the third generation of the sect's inner circle, trained by the person who was trained by the founders, and she has spent twelve years synthesizing what the previous two generations found into a unified model of what the mechanism is and how it works. Her conclusion — reached carefully, revised six times, and shared with three independent analysts before she committed to it in writing — is that the mechanism is located in the Deep Rim, that it is cyclic, and that the current cycle's completion date is approximately three years from now.
+
+She is not uncertain about this. Her data is very good. She has been trying to get a meeting with the Compact Council for six months, and has been told, three times, that the Council's schedule is full. The fourth message came back with a suggested date eighteen months out.
+
+The Tide-Readers are not armed. They are not powerful. What they have is right, and being right about something this large and this unwelcome is its own kind of danger.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*

--- a/content/worlds/tidal-commonwealth/lore/the-vethis-bloc.md
+++ b/content/worlds/tidal-commonwealth/lore/the-vethis-bloc.md
@@ -1,0 +1,17 @@
+# The Vethis Bloc
+
+*Era: The Forty-Third Year of the Interregnum. Tribune Kessal Vor in his second term.*
+
+Vethis Isle sits on volcanic rock that makes it nearly impossible to siege and absolutely impossible to flood. This has shaped its politics for three generations: while other Commonwealth cities rebuilt their harbors on drowned coasts and spent their political energy managing refugee populations and competing for salvage blocks, Vethis rebuilt its walls, expanded its harbor fortifications, and produced a council culture that views military preparedness as the only honest answer to living in a world where the sea can kill you in three days.
+
+The Vethis Bloc is Vethis Isle and the two smaller city-states in its orbit — Keth's Crossing and Aldmere — which share Vethis's militarist political alignment and benefit from its naval protection. Together they represent the Commonwealth's most significant military force: not the largest fleet, but the best-maintained fleet, crewed by professionals rather than the mix of militia and hired sailors that most cities rely on. This is a source of genuine Commonwealth security, and Vethis reminds the Council of this at every session.
+
+It is also the source of Vethis's central political argument, which **Tribune Kessal Vor** has refined over two Council terms into something approaching a manifesto: the Compact's non-aggression clause has made the Commonwealth comfortable with weakness, and comfortable weakness is precisely what a second Drowning Tide would require. Vethis is defending everyone. Vethis should have the authority that goes with that responsibility. The Compact, as currently structured, prevents that authority from being formalized — and the Compact, as currently structured, is forty years old and was written for a world without what is currently rising from the Deep Rim.
+
+Vor is not wrong about the military situation. This is what makes him difficult. The Tide-Readers' warning about the Deep Rim mechanism — which Vethis's own divers reported independently six months ago — is, in the right framing, exactly the kind of crisis that would require a unified Commonwealth military command. In the wrong framing, it is the kind of crisis that would require someone to have the authority to act unilaterally, and unilateral authority in the Vethis Bloc's hands looks, to the other cities, very much like conquest with better publicity.
+
+Vor has chosen to hold the Deep Rim intelligence rather than share it, which means he has already run that political calculus and decided the moment to deploy it has not yet arrived. He is waiting for the right crisis, or the right weakness in the Council's position, or the right counter-offer from a party with something worth trading. The fact that what he is sitting on could be the most important piece of information in the Commonwealth's history, and that every day it sits in a Vethis archive the clock runs three years closer to completion, is something Vor understands. He has made a choice about how to weigh it.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*

--- a/content/worlds/tidal-commonwealth/lore/warden-estris-vane.md
+++ b/content/worlds/tidal-commonwealth/lore/warden-estris-vane.md
@@ -1,0 +1,17 @@
+# Warden Estris Vane
+
+*Era: The Forty-Third Year of the Interregnum. Thirty-ninth year of the Compact.*
+
+Estris Vane has been the Compact Council's Secretary-Warden for twenty-three years, a position that, in theory, makes her a senior administrator and keeper of records. In practice, it makes her the person who has outlasted seven Compact Chairs, twelve city representatives, one formal dissolution attempt, and an arson attempt on the records room — and who understands the Compact's machinery well enough to have kept it running through all of those things.
+
+She is sixty-three. She has a reputation for being polite, invisible, and very good at her job. What her job actually requires, and what she does not describe to people who have not earned the description, is: knowing which Compact rules have been quietly violated by which city, in what order, and to what degree, so that the threat of documentation can be deployed before the violation becomes a crisis. The Compact has no enforcement mechanism. Estris Vane is the enforcement mechanism.
+
+She was nineteen when the Compact was negotiated, a records clerk copied by hand the document she would spend the next four decades protecting. She remembers the negotiators — not as names from history, but as specific tired people arguing through the night in the Ironhull records room, shouting about tonnage limits and fishing boundaries, not yet knowing if the thing they were building would survive the week. It survived forty years. She considers this a moderate success, in the same way a ship that has not yet sunk is a moderate success.
+
+The current crisis is, in her private assessment, different from every previous crisis. Previous crises involved cities wanting more than the Compact allowed — more tonnage, more territory, more votes on the Council. This crisis involves a city (the Vethis Bloc) possessing intelligence about a potential civilizational threat (the Deep Rim mechanism) and choosing to use that intelligence as political leverage rather than sharing it. Estris has seen bad faith before. She has not seen bad faith that could theoretically get everyone killed in three years.
+
+She is looking, carefully and without obvious urgency, for people with no obvious city allegiance who might be able to move in the gap between what the Compact allows and what the crisis requires. She has brought in outsiders before — on three salvage contracts, most recently, where the outsider was Captain Drev Ossian of the Salvagers' League. She knows the limits of what the Compact can do, and she has spent thirty years knowing them, and the limit she is approaching now is the first one she does not know how to work around from inside the system.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*

--- a/content/worlds/tidal-commonwealth/world.json
+++ b/content/worlds/tidal-commonwealth/world.json
@@ -188,9 +188,92 @@
           }
         }
       ]
+    },
+    {
+      "id": "event-warden-summons",
+      "trigger": "manual",
+      "anchor_npc_id": "npc-warden-estris",
+      "prompt": "A letter arrives sealed with the Compact Council's administrative mark — not the official seal, which would require a formal summons and a logged record, but the Secretary-Warden's private mark, which means whoever sent it did not want a record of the sending. The note inside is three sentences: the date, a location in Ironhull Station's lower records room, and the words 'I am aware that the Compact has no authority to ask you to attend. I am asking anyway. —E.V.' The location is accessible at the time given, the Compact's official business is scheduled elsewhere, and whatever the Secretary-Warden wants, she has been careful to make it deniable.",
+      "options": [
+        {
+          "label": "Go — if the woman who keeps the Compact alive is asking privately, there's a reason",
+          "tag": "pragmatic / engaged",
+          "outcome": {
+            "flag": "warden_meeting_attended",
+            "faction_id": "fac-compact",
+            "reputation_delta": 5,
+            "schedule_in_days": 5,
+            "schedule_text": "Whatever the Warden shared in the records room is already moving — a courier was sent from Ironhull Station the morning after, and Tribune Kessal Vor's faction has noticed the Warden's schedule has an unlogged gap. Someone is asking questions about who she met with.",
+            "narrate": "She is already at the table when you arrive, two cups of salt-tea and a folder of unmarked documents in front of her. She does not waste time on framing. 'I have sixty days before a vote that will either renew the Compact or end it, a city that is sitting on intelligence it should have shared three months ago, and no legal mechanism to compel them to share it. I am looking for a different kind of mechanism.' She sets the folder on the table between you. 'I have looked at your record. You are the kind of person who understands that some problems require unofficial solutions. I need to know if you are the kind of person who can execute one.'"
+          }
+        },
+        {
+          "label": "Send a reply asking what this is about before committing to anything",
+          "tag": "cautious / professional",
+          "outcome": {
+            "flag": "warden_meeting_deferred",
+            "faction_id": "fac-compact",
+            "reputation_delta": 2,
+            "schedule_in_days": 10,
+            "schedule_text": "A second letter arrives, this one shorter: a time and location, and a single added sentence — 'The situation is not one I can describe in writing. You will understand why when you hear it.' The Secretary-Warden is still asking. She is running out of days.",
+            "narrate": "The reply comes back in a day — delivered by a courier who does not wait for a response and does not identify who sent them. The note is brief. She does not explain herself. She gives you another date and adds: 'The matter involves the Deep Rim. I trust this is sufficient.' You have been warned."
+          }
+        },
+        {
+          "label": "Ignore it — unofficial requests from powerful people come with unofficial obligations",
+          "tag": "independent / wary",
+          "outcome": {
+            "flag": "warden_meeting_declined",
+            "narrate": "The time passes. No follow-up arrives. Three days later you see the Warden at a distance, in the Ironhull Station main hall, speaking to someone whose face you do not recognize — quiet, precise, the same economy of motion she brings to everything. She notices you noticing, and her expression does not change. Whatever she needed, she is finding another way to get it."
+          }
+        }
+      ]
     }
   ],
   "faction_arcs": [
+    {
+      "id": "arc-tide-readers-evidence",
+      "faction_id": "fac-tide-readers",
+      "title": "What the Water Remembers",
+      "requires_joined": false,
+      "note": "The Tide-Readers do not recruit — they accumulate people who have seen what the Basin contains and decided to understand it rather than ignore it. Stage 1 gates on faction reputation and gives the party access to Mira Scroll's current research (the part she will share). Stage 2 (standing gate) requires the party to have contributed something real — a depth-log, a structural observation, confirmation data from the rim — not just listened. The finale is the moment the evidence becomes undeniable, the full mechanism cycle confirmed, and the party is the one person or group Mira trusts to decide what to do with it: publish and force the Council's hand, or bring it to the one faction that can move fast enough to matter.",
+      "stages": [
+        {
+          "id": "stage-tide-readers-access",
+          "title": "An audience with the evidence",
+          "unlock_at": 8,
+          "gauge": "reputation",
+          "note": "Once the Tide-Readers have seen the party take the Basin seriously — not as a salvage opportunity but as a problem — Mira Scroll makes herself available for a real conversation. She shows the party the last three seasons of survey data and the tidal offset graph. She does not ask for anything. She is watching to see what they do with the information. Use advance_faction_arc to mark this stage resolved once the party has responded to the data with something that demonstrates they understand what it means.",
+          "location_id": "loc-gray-basin-shallows"
+        },
+        {
+          "id": "stage-tide-readers-contribution",
+          "title": "Evidence from below",
+          "unlock_at": 15,
+          "gauge": "standing",
+          "note": "Standing with the Tide-Readers is earned by contributing to the evidence base — a dive that returns usable depth-data, confirmation of the architectural structures, measurement of the luminescence's current phase. Use grant_standing as the party contributes real observations. When standing reaches 15, Mira Scroll makes the private comparison explicit: the pre-Tide station records and the current rim readings, side by side. The six-minute offset. The cycle calculation. She says: 'Three years. Possibly less. I have been saying this for six months and no one has scheduled a meeting.'",
+          "location_id": "loc-the-deep-rim"
+        },
+        {
+          "id": "stage-tide-readers-reckoning",
+          "title": "The reckoning",
+          "unlock_at": 30,
+          "gauge": "standing",
+          "note": "The world-changing decision: with the cycle confirmed and the Council still stalling, Mira Scroll's complete research is ready — the mechanism, its location, its activation timeline, and a set of options for what can be done about it. She has decided to trust the party with the choice of who this goes to. The finale forces the party to choose a path — the Council (slow, formal, potentially captured by the Bloc), the League (fast, pragmatic, potentially mercenary), or a direct approach to the Deep Rim itself. Call advance_faction_arc(stage_status='resolved', rank=5) once the choice is made.",
+          "location_id": "loc-ironhull-station",
+          "finale_effect": {
+            "flag": "tide_readers_evidence_released",
+            "faction_id": "fac-tide-readers",
+            "reputation_delta": 20,
+            "controller_id": "fac-tide-readers",
+            "location_id": "loc-the-deep-rim",
+            "narrate": "The evidence is out: mechanism, location, cycle, timeline — in Mira Scroll's careful, specific, unanswerable language, addressed to whoever you decided could be trusted with it. What happens next depends on whose hands it landed in and how much time the cycle has left. The Tide-Readers have done their work. The work is not over.",
+            "schedule_in_days": 7,
+            "schedule_text": "Mira Scroll's research has reached its recipient. The response is not what anyone expected, and the question is now whether the party is ahead of the Vethis Bloc's awareness of what has been released — or behind it."
+          }
+        }
+      ]
+    },
     {
       "id": "arc-salvagers-rise",
       "faction_id": "fac-salvagers-league",

--- a/servers/engine/tests/test_second_seed.py
+++ b/servers/engine/tests/test_second_seed.py
@@ -314,3 +314,142 @@ def test_base_world_companion_arc_arms_without_an_ending():
     # the relationship gates (loyalty + personal-quest) seeded too — a full companion, not just a flip
     gate_kinds = {g.kind for g in drev.arc.arc_gates}
     assert {"loyalty", "personal_quest"} <= gate_kinds
+
+
+# ---------------------------------------------------------------------------
+# 10. Tidal Commonwealth endings: zero-skip seeding + companion_seeds + world_state
+# ---------------------------------------------------------------------------
+
+
+ENDING_MECHANISM_DESTROYED = "mechanism-destroyed"
+ENDING_SECOND_TIDE = "second-tide-rising"
+
+
+def test_ending_mechanism_destroyed_seeds_clean():
+    """mechanism-destroyed ending must seed with ZERO skip-diagnostics, set world_tenor=hopeful,
+    and apply Drev's ending-tied companion arc (loyalty + personal_quest gates, agenda)."""
+    world = _load_world()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        c = content_mod.seed_world(world, ending=ENDING_MECHANISM_DESTROYED)
+    skip_lines = [ln for ln in buf.getvalue().splitlines() if "[content] skipping" in ln]
+    assert skip_lines == [], f"mechanism-destroyed ending emitted skips:\n" + "\n".join(skip_lines)
+    assert c.ending_id == ENDING_MECHANISM_DESTROYED
+    assert c.world_state is not None
+    assert c.world_state.world_tenor == "hopeful"
+    assert c.world_state.facts.get("the_mechanism") == "destroyed"
+    # Drev's ending-tied companion arc applied correctly
+    drev = c.characters[NPC_COMPANION_ID]
+    assert drev.arc is not None, "Drev must have an arc in this ending"
+    assert drev.arc.agenda is not None
+    assert drev.arc.agenda.trigger == "attitude_below"
+    gate_kinds = {g.kind for g in drev.arc.arc_gates}
+    assert {"loyalty", "personal_quest"} <= gate_kinds, (
+        f"mechanism-destroyed ending must seed loyalty + personal_quest gates; got {gate_kinds}"
+    )
+
+
+def test_ending_second_tide_seeds_clean():
+    """second-tide-rising ending must seed with ZERO skip-diagnostics, set world_tenor=grim,
+    and arm Drev's resistance-context companion arc with his flip intact."""
+    world = _load_world()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        c = content_mod.seed_world(world, ending=ENDING_SECOND_TIDE)
+    skip_lines = [ln for ln in buf.getvalue().splitlines() if "[content] skipping" in ln]
+    assert skip_lines == [], f"second-tide-rising ending emitted skips:\n" + "\n".join(skip_lines)
+    assert c.ending_id == ENDING_SECOND_TIDE
+    assert c.world_state is not None
+    assert c.world_state.world_tenor == "grim"
+    assert c.world_state.facts.get("the_mechanism") == "seized"
+    assert c.world_state.facts.get("the_compact") == "broken"
+    # Drev's ending-tied companion arc applied correctly
+    drev = c.characters[NPC_COMPANION_ID]
+    assert drev.arc is not None, "Drev must have an arc in this ending"
+    assert drev.arc.agenda is not None
+    gate_kinds = {g.kind for g in drev.arc.arc_gates}
+    assert {"loyalty", "personal_quest"} <= gate_kinds
+
+
+def test_both_endings_round_trip():
+    """Both Tidal Commonwealth endings must survive a model_dump / model_validate round-trip."""
+    world = _load_world()
+    from models import Campaign
+    for eid in (ENDING_MECHANISM_DESTROYED, ENDING_SECOND_TIDE):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            c = content_mod.seed_world(world, ending=eid)
+        data = c.model_dump(mode="json")
+        reloaded = Campaign.model_validate(data)
+        assert reloaded.ending_id == eid, f"round-trip lost ending_id for {eid!r}"
+        assert reloaded.world_state is not None, f"round-trip lost world_state for {eid!r}"
+
+
+def test_ending_fates_applied():
+    """Both endings must land fates on the authored NPC roster."""
+    world = _load_world()
+    for eid, expected_npc, expected_substr in [
+        (ENDING_MECHANISM_DESTROYED, "npc-warden-estris", "desk"),
+        (ENDING_SECOND_TIDE, "npc-mira-scroll", "hiding"),
+    ]:
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            c = content_mod.seed_world(world, ending=eid)
+        npc = c.characters.get(expected_npc)
+        assert npc is not None, f"{eid}: {expected_npc!r} not found in characters"
+        # fate note should be on the NPC's lore or notes field
+        npc_text = " ".join([
+            npc.notes or "",
+            npc.lore or "" if hasattr(npc, "lore") else "",
+            str(npc.model_dump(mode="json")),
+        ]).lower()
+        assert expected_substr in npc_text, (
+            f"{eid}: fate for {expected_npc!r} missing expected text {expected_substr!r}"
+        )
+
+
+def test_second_event_seeded():
+    """The second authored event (event-warden-summons) must seed correctly."""
+    world = _load_world()
+    c, stdout = _seed_world(world)
+    assert "event-warden-summons" in c.events, "event-warden-summons not seeded"
+    ev = c.events["event-warden-summons"]
+    assert ev.anchor_npc_id == "npc-warden-estris"
+    assert len(ev.options) >= 2
+
+
+def test_tide_readers_faction_arc_seeded():
+    """The Tide-Readers faction arc must seed with 3 stages and correct gauges."""
+    world = _load_world()
+    c, _ = _seed_world(world)
+    assert "arc-tide-readers-evidence" in c.faction_arcs, "Tide-Readers arc not seeded"
+    arc = c.faction_arcs["arc-tide-readers-evidence"]
+    assert len(arc.stages) == 3
+    assert arc.stages[0].gauge == "reputation"
+    assert arc.stages[1].gauge == "standing"
+    assert arc.stages[2].gauge == "standing"
+
+
+def test_lorebook_tidal_commonwealth_corpus():
+    """The Tidal Commonwealth lore corpus must have >= 7 pages and return hits for key topics."""
+    import lorebook
+    count = lorebook.page_count("tidal-commonwealth")
+    assert count >= 7, f"expected at least 7 lore pages, got {count}"
+    # each major topic must surface
+    topics = [
+        ("Drowning Tide catastrophe", "drowning-tide"),
+        ("Compact Warden", "compact"),
+        ("Gray Basin Deep Rim", "gray-basin"),
+        ("Salvagers League captain", "salvagers"),
+        ("Tide-Readers mechanism", "tide-readers"),
+        ("Vethis Bloc Tribune", "vethis"),
+        ("Warden Estris Vane", "warden"),
+        ("Captain Drev Ossian scar", "captain"),
+    ]
+    for query, expected_slug in topics:
+        hits = lorebook.lookup_lore("tidal-commonwealth", query, 3)
+        assert hits, f"lookup_lore({query!r}) returned no hits"
+        assert any(expected_slug in h["source"] for h in hits), (
+            f"lookup_lore({query!r}) did not surface expected page matching {expected_slug!r}; "
+            f"got: {[h['source'] for h in hits]}"
+        )


### PR DESCRIPTION
## Summary
Deepens the project's second original world (The Tidal Commonwealth, #220) from proof-of-concept into **playable-world depth** — all original CC-BY-4.0 prose, **zero engine `.py` changes** (pure content + tests), reinforcing deliverable B.

- **8 lore pages** (`lore/*.md`, lorebook-format, surfaced via `lookup_lore`): the Drowning Tide, the Compact, the Gray Basin & Deep Rim, the four factions, Warden Estris Vane, Captain Drev Ossian.
- **2 ending overlays**: `mechanism-destroyed` (hopeful — Compact renewed, Tide-Readers vindicated) and `second-tide-rising` (grim — Vethis seizes the mechanism, Compact broken), each with a **Drev `companion_seeds` arc that resolves differently per ending** (the last dive vs the resistance dive).
- **+1 event** (`event-warden-summons`, anchor Warden Estris) and **+1 faction arc** (`arc-tide-readers-evidence`, join→grow→reckoning).

## Validation
- Full engine suite **1352 passed** (+7 tests in `test_second_seed.py`, 18 total).
- `license_check.py` green (authored `lore/*.md` are exempt from the ingested-attribution gate; each carries a CC-BY footer anyway).
- `lookup_lore` smoke: 8 pages indexed, all topic queries return the right page top-3, era fields parse.
- `seed_world` **zero skip-diagnostics** for the base world AND both endings (mechanism-destroyed→`hopeful`, second-tide-rising→`grim`).
- **Zero engine `.py` changes** — every surface (2 endings, per-ending companion_seeds, world_state, fates, 2nd faction arc, 2nd event) ran on existing machinery.

## Remaining (follow-up, not blocking)
Geographic texture — location lore for Saltmere / Ironhull Station / Vethis Isle as *places* (2–3 more pages).