### PR TITLE
content(tidal-commonwealth): geographic texture — Saltmere, Ironhull, Vethis as places

### DIFF
--- a/content/worlds/tidal-commonwealth/lore/ironhull-station.md
+++ b/content/worlds/tidal-commonwealth/lore/ironhull-station.md
@@ -1,0 +1,15 @@
+# Ironhull Station
+
+*Era: The Forty-Third Year of the Interregnum. The Compact's only neutral ground.*
+
+Ironhull was a Varentine signal-tower — one of the chain that once relayed the Empire's messages across the coast in a single night of mirror-flashes. The Tide left it standing because it was built on a reef-shoulder of old volcanic stone, the same bones that hold up Vethis. Everything around it drowned; the tower did not. For forty years the Commonwealth has agreed, in the careful way it agrees on anything, that *because* it belongs to no city, it can belong to all of them.
+
+So Ironhull is neutral ground — the one place a League factor, a Vethis tribune, and a Compact secretary can sit at the same table without anyone's marines in the room. The lamp at the top still turns, run now on whale-oil and grievance, the only working lighthouse between Saltmere and the League cities. Ships that would never share a harbor share Ironhull's mooring rings, tied close enough to spit across, watched the whole time.
+
+The Station is permanently, deliberately crowded. Its neutrality is not kept by law — the Compact has no law it can enforce — but by **witnesses**. Everyone watches everyone; a knife drawn on Ironhull is a knife drawn in front of every faction at once, and that is the closest thing to peace the Commonwealth has built. The brokers who work the Station have made an art of the deniable conversation: the deal struck on the wind-deck where the lamp's noise covers the words, the message left folded in a mooring-log, the meeting that, if anyone asks, was about freight.
+
+What a newcomer notices: the wind, always, scoured clean and cold off the open Basin; the lamp's slow grinding turn overhead, felt in the floor; and the way conversations drop a register when a stranger passes, then resume. Ironhull is where you go to learn what the cities will not say in their own halls — and where someone is always counting who arrived with whom.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*

--- a/content/worlds/tidal-commonwealth/lore/saltmere.md
+++ b/content/worlds/tidal-commonwealth/lore/saltmere.md
@@ -1,0 +1,17 @@
+# Saltmere
+
+*Era: The Forty-Third Year of the Interregnum. The Commonwealth's busiest free port.*
+
+Saltmere was a cliff town before the Tide and a harbor city after it. When the water came it did not break Saltmere — it *raised the sea to meet it*, and the lower town that had clung to the cliff's foot drowned in an afternoon. The survivors did the only thing the drowned coast has ever known how to do: they built upward, on top of the dead districts, and kept the names. So Saltmere is a city in tiers, and the tier you live on tells anyone who matters exactly who you are.
+
+**The Understreets** flood at every high tide. Salvager crews, refugee families three generations deep, and the people who do the work no council wants minuted live here, walking plank-causeways at noon that are six feet under by dusk. The Understreets keep their own time by the water, not the bells, and they trust the bells less every year.
+
+**The Tidemarket** is the wet middle — the working harbor, the auction halls, the customs sheds where the Salvagers' League sells what the Basin gives back. It never closes. Everything the Commonwealth fights about passes across a Tidemarket table first, wrapped in oilcloth, with the manifest still being argued.
+
+**The Cresting** is the dry upper town, where the Saltmere Council sits and the patriar houses keep their gardens above the salt line. Saltmere holds the largest single vote under the Compact and the Cresting never lets the other cities forget it. The view from up here is magnificent and faces away from the water.
+
+What a newcomer notices first: the smell of brine and tar and the wet-stone cold that never quite leaves the lower air; the bell-criers calling the tide-tables because half the city's geography depends on them; and the particular Saltmere habit of finishing a sentence by glancing at the sea, as if checking it hasn't moved closer while you weren't looking. Lately, more people are checking.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*

--- a/content/worlds/tidal-commonwealth/lore/vethis-isle.md
+++ b/content/worlds/tidal-commonwealth/lore/vethis-isle.md
@@ -1,0 +1,17 @@
+# Vethis Isle
+
+*Era: The Forty-Third Year of the Interregnum. The city closest to breaking the Compact.*
+
+Vethis did not drown. That is the first thing a Vethite will tell you and the last thing they will let you forget. When the Tide came, the island's black volcanic shoulders shrugged the water off; the harbor towns at its feet were lost, but the high city held, and into it poured the refugees the lowland cities could not save. Vethis remembers being the place that *held* — and three generations later it has built an entire civic religion out of that memory.
+
+The island is, by the plain facts of geography, almost impossible to take. One deep-water approach, overlooked the whole way by basalt cliffs and the gun-galleries cut into them; a high city behind walls that were old before the Empire fell. Vethis spends accordingly: the largest standing marine force in the Commonwealth, drilled in the cliff-yards where the sound of it carries across the water to remind the neighbors.
+
+The argument Vethis makes — and it is an argument, made constantly, by people who believe it — is simple and not entirely wrong. The Compact's non-conquest clause, they say, has made the Commonwealth a confederation of cowards, forty years of agreeing to be too weak to drown each other while *something* gathers in the Basin that will not care about anyone's vote. Someone has to be strong enough to defend the Basin's edge. Vethis volunteers. Vethis always volunteers. The other cities hear "defend" and remember that the word has a way, on Vethis lips, of meaning "command."
+
+**Tribune Kessal Vor** speaks for the Bloc, and speaks well — invasion dressed as mutual defense, delivered with real warmth. What the city does not say aloud: its divers reported something rising from the Deep Rim six months ago, and the Bloc has chosen to hold that knowledge as leverage rather than sound the Commonwealth's alarm.
+
+What a newcomer notices: the drill-drums carrying off the cliffs at dawn; the civic pride that curdles, if you push it, into something colder; and the way every Vethite conversation about the future assumes, without quite saying so, that Vethis will be giving the orders.
+
+---
+
+*Original work. CC-BY-4.0 © ClawDnD contributors.*


### PR DESCRIPTION
Finishes the Tidal Commonwealth's lore corpus (the depth pass #223 flagged location texture as the one remaining gap). 3 `lookup_lore` place-pages — Saltmere (drowned tiers), Ironhull Station (witnessed neutral ground), Vethis Isle (the militant 'we held' city) — each evocative, tied to the live threads, original CC-BY-4.0. Pure content, zero engine changes. **11 lore pages now index + retrieve; license_check green.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three new lore entries to expand the Tidal Commonwealth world: Ironhull Station, a neutral meeting ground for deniable negotiations; Saltmere, a tiered harbor city with distinct social zones; and Vethis Isle, an island shaped by historical conflict and unique civic traditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/224?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->