### PR TITLE
feat(viewer): PC/companion portraits via the render bridge (W2d)

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -75,7 +75,7 @@ function ScreenCharacter({ onNavigate, state, setState }) {
               : "inset 0 0 0 1px rgba(140,100,60,0.2)",
             textAlign: "left",
           }}>
-            <Placeholder label={p.short} w={36} h={44} framed />
+            <Img scope={p.id ? "portrait-" + p.id : ""} label={p.short} w={36} h={44} framed />
             <div>
               <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.08em", color: "var(--ink-900)" }}>
                 {p.name}
@@ -113,7 +113,7 @@ function ScreenCharacter({ onNavigate, state, setState }) {
         {/* Hero header card */}
         <Panel framed style={{ padding: 22 }}>
           <div style={{ display: "grid", gridTemplateColumns: "140px 1fr auto", gap: 22, alignItems: "start" }}>
-            <Placeholder label={`${hero.short} · portrait`} w={140} h={170} framed />
+            <Img scope={hero.id ? "portrait-" + hero.id : ""} label={`${hero.short} · portrait`} w={140} h={170} framed />
             <div>
               <div className="eyebrow" style={{ color: "var(--crimson)" }}>{hero.alignment}</div>
               <h1 className="h1" style={{ marginTop: 2 }}>{hero.name}</h1>

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -405,7 +405,7 @@ function PartyRow({ p, active, onClick }) {
       cursor: "pointer",
       transition: "all 140ms",
     }}>
-      <Placeholder label={p.short} w={44} h={56} framed />
+      <Img scope={p.id ? "portrait-" + p.id : ""} label={p.short} w={44} h={56} framed />
       <div>
         <div style={{ fontFamily: "var(--f-display)", fontSize: 13, letterSpacing: "0.08em", color: "var(--ink-900)" }}>
           {p.name}

--- a/viewer/tests/test_portrait_art.py
+++ b/viewer/tests/test_portrait_art.py
@@ -1,0 +1,86 @@
+"""W2d: PC/companion portrait render-bridge tests.
+
+Assert that screen-character.jsx and screen-table.jsx wire the <Img> render-bridge
+component for PC portraits using scope="portrait-<character_id>", mirroring the
+pattern already present in screen-relations.jsx (W2a).
+"""
+
+import http.client
+import importlib.util
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+class _QuietHandler(server._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:  # noqa: D401
+        return
+
+
+class PortraitArtRouteTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _get(self, path: str) -> tuple[int, str, bytes]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            response = conn.getresponse()
+            return response.status, response.headers.get("Content-Type", ""), response.read()
+        finally:
+            conn.close()
+
+    def test_screen_character_uses_img_render_bridge_for_pc_portraits(self):
+        # screen-character.jsx must use <Img scope="portrait-…"> in the party rail
+        # (roster thumbnails) and in the hero header card — not bare <Placeholder>.
+        status, ctype, body = self._get("/openworlds/screen-character.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        self.assertIn("Img scope=", source)
+        self.assertIn("portrait-", source)
+
+    def test_screen_table_uses_img_render_bridge_for_party_portraits(self):
+        # screen-table.jsx must use <Img scope="portrait-…"> in the PartyRow component
+        # for each PC in the party list / turn order panel.
+        status, ctype, body = self._get("/openworlds/screen-table.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        self.assertIn("Img scope=", source)
+        self.assertIn("portrait-", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Wires `<Img scope="portrait-<id>">` into the character screen (party rail + hero header) and the table party panel — portraits render the moment art is cached, graceful placeholder otherwise. New test_portrait_art.py; viewer 74 passed.