### PR TITLE
feat(viewer): item icons in inventory via the render bridge (W2c)

### DIFF
--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -4,6 +4,18 @@
    data until the first fetch. The per-hero coin purse comes from the live currency.
    Layout/design unchanged from the prototype. */
 
+/* W2c: item-icon scope helper — lowercase, non-alphanumeric → "-". Used as a fallback
+   when item.id is absent (it is always present in the live surface, but kept for safety). */
+function slug(name) {
+  return (name || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+/* Resolve the /image scope for an inventory item: prefer the engine id (always present as
+   "{character_id}:{idx}:{name}"); fall back to a slug of the item name. */
+function itemScope(item) {
+  return "item-" + (item.id ? item.id : slug(item.name));
+}
+
 function ScreenInventory({ onNavigate, state, setState }) {
   const surfaceQuery = window.combatSurfaceFromCampaign
     ? window.combatSurfaceFromCampaign(
@@ -108,7 +120,9 @@ function ScreenInventory({ onNavigate, state, setState }) {
               const equipped = hero.equipped.find((e) => e.slot === s.label);
               return (
                 <div key={s.label} style={{ textAlign: "center" }}>
-                  <Placeholder label={equipped ? equipped.glyph : s.label} w="100%" h={44} framed />
+                  {equipped
+                    ? <Img scope={"item-" + slug(equipped.name)} label={equipped.name} w="100%" h={44} framed />
+                    : <Placeholder label={s.label} w="100%" h={44} framed />}
                   <div style={{ fontFamily: "var(--f-mono)", fontSize: 8, marginTop: 2, color: "var(--ink-600)" }}>
                     {s.label}
                   </div>
@@ -291,13 +305,14 @@ function ItemSlot({ item, selected, onClick, onContextMenu }) {
       display: "flex", alignItems: "center", justifyContent: "center",
       transition: "all 120ms",
     }}>
-      <span style={{
-        fontFamily: "var(--f-mono)", fontSize: 8.5,
-        color: "var(--ink-700)",
-        textAlign: "center",
-        padding: 2,
-        lineHeight: 1.15,
-      }}>{item.glyph}</span>
+      <Img
+        scope={itemScope(item)}
+        label={item.name}
+        w={44}
+        h={44}
+        fit="contain"
+        style={{ pointerEvents: "none" }}
+      />
       {item.qty > 1 && (
         <span style={{
           position: "absolute", bottom: 2, right: 4,
@@ -315,7 +330,7 @@ function ItemDetail({ item, hero, toast }) {
   return (
     <div>
       <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
-        <Placeholder label={item.glyph} w={72} h={72} framed />
+        <Img scope={itemScope(item)} label={item.name} w={72} h={72} framed />
         <div>
           <div className="eyebrow" style={{ color:
             item.type === "rare" ? "var(--royal)" :
@@ -385,4 +400,4 @@ const ITEM_TYPES = {
 
 function toRoman(n) { return ["", "I", "II", "III", "IV", "V"][n] || n; }
 
-Object.assign(window, { ScreenInventory, CoinSlot, ItemSlot, ItemDetail, EQUIP_SLOTS, ITEM_TYPES, toRoman });
+Object.assign(window, { ScreenInventory, CoinSlot, ItemSlot, ItemDetail, EQUIP_SLOTS, ITEM_TYPES, toRoman, slug, itemScope });

--- a/viewer/tests/test_item_icons.py
+++ b/viewer/tests/test_item_icons.py
@@ -1,0 +1,109 @@
+"""W2c: item-icon render-bridge tests.
+
+Asserts that screen-inventory.jsx uses the <Img scope=…> component with
+the "item-" scope convention, mirroring test_openworlds_static.py style.
+"""
+
+import http.client
+import importlib.util
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server_item_icons", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+class _QuietHandler(server._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+
+class ItemIconTests(unittest.TestCase):
+    """screen-inventory.jsx must wire <Img scope=…> for item art (W2c)."""
+
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _get(self, path: str) -> tuple[int, str, bytes]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            response = conn.getresponse()
+            return response.status, response.headers.get("Content-Type", ""), response.read()
+        finally:
+            conn.close()
+
+    def test_inventory_screen_uses_img_component(self):
+        """screen-inventory.jsx must reference the <Img …> render-bridge component."""
+        status, ctype, body = self._get("/openworlds/screen-inventory.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        src = body.decode("utf-8")
+        self.assertIn("Img scope=", src)
+
+    def test_inventory_screen_uses_item_scope_prefix(self):
+        """Every item icon scope must start with 'item-' per the engine convention."""
+        _status, _ctype, body = self._get("/openworlds/screen-inventory.jsx")
+        src = body.decode("utf-8")
+        self.assertIn("item-", src)
+
+    def test_inventory_screen_has_item_scope_helper(self):
+        """itemScope() helper must be present and delegate to the 'item-' prefix."""
+        _status, _ctype, body = self._get("/openworlds/screen-inventory.jsx")
+        src = body.decode("utf-8")
+        # The helper function that assembles the scope string must exist.
+        self.assertIn("itemScope", src)
+        self.assertIn("item-", src)
+
+    def test_inventory_screen_has_slug_helper(self):
+        """slug() name-normaliser must be present for fallback scopes."""
+        _status, _ctype, body = self._get("/openworlds/screen-inventory.jsx")
+        src = body.decode("utf-8")
+        self.assertIn("function slug(", src)
+
+    def test_inventory_screen_img_has_framed_detail_icon(self):
+        """ItemDetail must render a framed <Img> (72×72) for the selected item."""
+        _status, _ctype, body = self._get("/openworlds/screen-inventory.jsx")
+        src = body.decode("utf-8")
+        # Both the Img call and the framed prop must appear in the detail section context.
+        self.assertIn("itemScope(item)", src)
+        self.assertIn("framed", src)
+
+    def test_inventory_screen_img_used_in_item_slot(self):
+        """ItemSlot grid cells must use <Img scope={itemScope(item)} …> for item art."""
+        _status, _ctype, body = self._get("/openworlds/screen-inventory.jsx")
+        src = body.decode("utf-8")
+        # ItemSlot now renders Img, not only a glyph span.
+        self.assertIn("scope={itemScope(item)}", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Wires item icons (`<Img scope="item-<id>">`, slug fallback) into the inventory stash grid, item detail, and equipped slots. Surface already exposes item ids. New test_item_icons.py (6); viewer 80 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved inventory item icon rendering across equipment slots, stash items, and item detail displays.

* **Tests**
  * Added comprehensive unit tests validating item icon rendering behavior and scope naming conventions in inventory UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/229?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->