### PR TITLE
feat(viewer): scene + region art in atlas & dialogue (W2e)

### DIFF
--- a/viewer/openworlds/screen-dialogue.jsx
+++ b/viewer/openworlds/screen-dialogue.jsx
@@ -74,6 +74,8 @@ function ScreenDialogue({ onNavigate, state, setState }) {
 function ParleyMenu({ surface, slots, difficulty, setDifficulty, history, setHistory, onNavigate, toast }) {
   const actorName = surface.actor || "Hero";
   const canAct = Boolean(surface.can_act);
+  const sceneScope = surface.location_id ||
+    (surface.event?.anchor_npc_id ? `portrait-${surface.event.anchor_npc_id}` : null);
 
   const pick = (slot) => {
     const move = { kind: "check", name: `${slot.label} (DC ${slot.suggested_dc})`, skill: slot.skill, dc: slot.suggested_dc, text: `attempts ${slot.label} (DC ${slot.suggested_dc})` };
@@ -108,11 +110,7 @@ function ParleyMenu({ surface, slots, difficulty, setDifficulty, history, setHis
     <div className="screen" style={{ height: "100%", position: "relative", padding: 14 }}>
       {/* Scene backdrop */}
       <div style={{ position: "relative", height: "100%", overflow: "hidden", borderRadius: 4, boxShadow: "inset 0 0 0 1px var(--w-500), inset 0 0 0 4px var(--b-500), inset 0 0 0 5px var(--b-300), inset 0 0 0 6px var(--b-500)" }}>
-        <Placeholder
-          label={`scene · parley · ${surface.title || "the table"}`}
-          h="100%"
-          style={{ width: "100%", height: "100%" }}
-        />
+        <Img scope={sceneScope} label={`scene · parley · ${surface.title || "the table"}`} w="100%" h="100%" fit="cover" style={{ position: "absolute", inset: 0 }} />
 
         {/* Vignette */}
         <div style={{
@@ -293,11 +291,7 @@ function ScreenDialogueDemo({ onNavigate, state, status }) {
     <div className="screen" style={{ height: "100%", position: "relative", padding: 14 }}>
       {/* Scene backdrop */}
       <div style={{ position: "relative", height: "100%", overflow: "hidden", borderRadius: 4, boxShadow: "inset 0 0 0 1px var(--w-500), inset 0 0 0 4px var(--b-500), inset 0 0 0 5px var(--b-300), inset 0 0 0 6px var(--b-500)" }}>
-        <Placeholder
-          label="scene · oleg's trading post · interior · candlelit · 3 figures at table"
-          h="100%"
-          style={{ width: "100%", height: "100%" }}
-        />
+        <Img scope={node.locationScope || null} label="scene · oleg's trading post · interior · candlelit · 3 figures at table" w="100%" h="100%" fit="cover" style={{ position: "absolute", inset: 0 }} />
 
         {/* Vignette */}
         <div style={{

--- a/viewer/openworlds/screen-map.jsx
+++ b/viewer/openworlds/screen-map.jsx
@@ -180,6 +180,18 @@ function ScreenMap({ onNavigate, state, campMode, setCampMode }) {
           </div>
         </div>
 
+        {!campMode && selected && (
+          <Img
+            scope={selected.id}
+            label={selected.name}
+            w="100%"
+            h={90}
+            framed
+            fit="cover"
+            style={{ marginBottom: 8, flex: "0 0 auto" }}
+          />
+        )}
+
         <div style={{ position: "relative", flex: "1 1 auto", minHeight: 0 }}>
           {campMode && window.CampSidebar ? (
             <div style={{ position: "absolute", inset: 0, overflow: "auto" }}>
@@ -342,7 +354,7 @@ function AtlasSidebar({ selected, travel, currentId, busyTravel, canAct, quests,
             </div>
 
             <Divider />
-            <Placeholder label={`${selected.name} - painted location`} h={118} framed />
+            <Img scope={selected.id} label={selected.name} w="100%" h={118} framed />
             <p className="body dropcap" style={{ marginTop: 12, fontSize: 15 }}>
               {selected.description || "No public description has been recorded for this place yet."}
             </p>
@@ -488,7 +500,7 @@ function LocationPin({ loc, selected }) {
           pointerEvents: "none",
           animation: "tooltip-in 140ms ease both",
         }}>
-          <Placeholder label={`${loc.name} vignette`} h={70} framed style={{ width: "100%" }} />
+          <Img scope={loc.id} label={loc.name} w="100%" h={70} framed fit="cover" />
           <div className="eyebrow" style={{ color: "var(--crimson)", marginTop: 8, fontSize: 9 }}>
             {loc.region || "Unknown reach"}
           </div>

--- a/viewer/tests/test_scene_art.py
+++ b/viewer/tests/test_scene_art.py
@@ -1,0 +1,108 @@
+"""W2e: screen-map.jsx and screen-dialogue.jsx render scene art via the Img bridge.
+
+Mirrors test_openworlds_static.py style: spin up the viewer's HTTP server against a
+temp state dir and assert that both JSX files contain the ``Img scope=`` pattern wired
+to location-keyed scopes, confirming the render bridge is used for scene art.
+"""
+
+import http.client
+import importlib.util
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+class _QuietHandler(server._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:  # noqa: D401
+        return
+
+
+class SceneArtRenderBridgeTests(unittest.TestCase):
+    """Assert that scene art is wired via the Img render bridge in the map and parley screens."""
+
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        self._old_here = server._HERE
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+        server._HERE = self._old_here
+
+    def _get(self, path: str) -> tuple[int, str, bytes]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            response = conn.getresponse()
+            return response.status, response.headers.get("Content-Type", ""), response.read()
+        finally:
+            conn.close()
+
+    def test_map_screen_renders_scene_art_via_img_bridge(self):
+        """screen-map.jsx must use <Img scope={...}> for location scene art (W2e).
+
+        The atlas sidebar shows a painted location illustration for the selected location
+        (scope = location id from atlas surface's known_locations[].id).  A banner-style
+        Img is also shown for the current/selected location at the top of the map panel.
+        The hover tooltip vignette uses Img as well.
+        """
+        status, ctype, body = self._get("/openworlds/screen-map.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        # The Img component is used for scene art, not just a raw Placeholder
+        self.assertIn("Img scope=", source)
+        # The scope is wired to the location id (selected.id) from the atlas surface
+        self.assertIn("selected.id", source)
+        # Graceful placeholder fallback is inherited from the Img component itself
+        self.assertIn("Img", source)
+
+    def test_parley_screen_renders_scene_art_via_img_bridge(self):
+        """screen-dialogue.jsx (Parley tab) must use <Img scope={...}> as scene backdrop (W2e).
+
+        The live parley menu uses location_id from the surface when present, otherwise
+        falls back to portrait-<anchor_npc_id> from the event block so the conversation
+        always has a visual backdrop when art has been generated.
+        """
+        status, ctype, body = self._get("/openworlds/screen-dialogue.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        # The Img component is used for scene art in the parley screen
+        self.assertIn("Img scope=", source)
+        # The scope resolves location_id first, then portrait fallback
+        self.assertIn("location_id", source)
+        self.assertIn("portrait-", source)
+        # The anchor NPC fallback scope is wired to the event block
+        self.assertIn("anchor_npc_id", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Wires `<Img scope=<location_id>>` scene/region art into the atlas (location detail, map banner, pin tooltip) and the parley/dialogue backdrop (location scope, NPC-portrait fallback for live Events). New test_scene_art.py; viewer 82 passed.