### PR TITLE
feat(openworlds): capability badges on display-only screens (W1/#133)

### DIFF
--- a/viewer/openworlds/screen-bestiary.jsx
+++ b/viewer/openworlds/screen-bestiary.jsx
@@ -18,8 +18,18 @@ function ScreenBestiary({ onNavigate, state, setState }) {
     }
   }, [filtered, selected?.id]);
 
+  const _badge = { label: "Preview", tone: "muted", detail: "Bestiary is display-only — entries are static demo data, not live engine read-models." };
+
   return (
-    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "280px 1fr", gap: 14, padding: 14 }}>
+    <div className="screen" style={{ height: "100%", display: "flex", flexDirection: "column", gap: 8, padding: 14 }}>
+
+      {/* Prototype banner */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 14px", background: "rgba(80,50,20,0.18)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.45)", borderRadius: 2 }}>
+        <CapabilityBadge capability={_badge} nativeStatus={null} />
+        <span className="hand muted" style={{ fontSize: 12 }}>Display-only — not yet wired to the engine. Entries shown are demo data.</span>
+      </div>
+
+      <div style={{ flex: 1, display: "grid", gridTemplateColumns: "280px 1fr", gap: 14, minHeight: 0 }}>
 
       {/* LEFT — index */}
       <Panel framed style={{ padding: 22, display: "flex", flexDirection: "column", overflow: "hidden" }}>
@@ -80,6 +90,7 @@ function ScreenBestiary({ onNavigate, state, setState }) {
 
       {/* RIGHT — entry */}
       {selected ? <BestiaryEntry entry={selected} tab={tab} /> : <Panel framed><div className="muted">Nothing selected.</div></Panel>}
+      </div>
     </div>
   );
 }

--- a/viewer/openworlds/screen-create.jsx
+++ b/viewer/openworlds/screen-create.jsx
@@ -26,8 +26,18 @@ function ScreenCreate({ onNavigate, state, setState }) {
   const next = () => setStep(Math.min(steps.length - 1, step + 1));
   const prev = () => setStep(Math.max(0, step - 1));
 
+  const _badge = { label: "Preview", tone: "muted", detail: "Character creation is display-only — completing the wizard does not persist a hero to the engine." };
+
   return (
-    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "240px 1fr 280px", gap: 14, padding: 14 }}>
+    <div className="screen" style={{ height: "100%", display: "flex", flexDirection: "column", gap: 8, padding: 14 }}>
+
+      {/* Prototype banner */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 14px", background: "rgba(80,50,20,0.18)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.45)", borderRadius: 2 }}>
+        <CapabilityBadge capability={_badge} nativeStatus={null} />
+        <span className="hand muted" style={{ fontSize: 12 }}>Display-only — hero creation is not yet wired to the engine. No character will be saved.</span>
+      </div>
+
+      <div style={{ flex: 1, display: "grid", gridTemplateColumns: "240px 1fr 280px", gap: 14, minHeight: 0 }}>
 
       {/* LEFT — wizard steps */}
       <Panel framed style={{ padding: 22, display: "flex", flexDirection: "column" }}>
@@ -90,7 +100,7 @@ function ScreenCreate({ onNavigate, state, setState }) {
           {step < steps.length - 1 ? (
             <BrassButton onClick={next}>Continue →</BrassButton>
           ) : (
-            <BrassButton onClick={() => onNavigate("table")} tone="crimson">Bind the hero</BrassButton>
+            <BrassButton disabled tone="crimson" title="Not yet wired — hero creation is display-only">Bind the hero (preview only)</BrassButton>
           )}
         </div>
       </Panel>
@@ -144,6 +154,7 @@ function ScreenCreate({ onNavigate, state, setState }) {
           {hero.points}
         </div>
       </Panel>
+      </div>
     </div>
   );
 }

--- a/viewer/openworlds/screen-forge.jsx
+++ b/viewer/openworlds/screen-forge.jsx
@@ -31,8 +31,18 @@ function ScreenForge({ onNavigate, state, setState }) {
     });
   };
 
+  const _badge = { label: "Preview", tone: "muted", detail: "Forge is display-only — crafting rolls are simulated and results are not persisted to the engine." };
+
   return (
-    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "260px 1fr 300px", gap: 14, padding: 14 }}>
+    <div className="screen" style={{ height: "100%", display: "flex", flexDirection: "column", gap: 8, padding: 14 }}>
+
+      {/* Prototype banner */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 14px", background: "rgba(80,50,20,0.18)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.45)", borderRadius: 2 }}>
+        <CapabilityBadge capability={_badge} nativeStatus={null} />
+        <span className="hand muted" style={{ fontSize: 12 }}>Display-only — crafting is not yet wired to the engine. Rolls are simulated; nothing is saved.</span>
+      </div>
+
+      <div style={{ flex: 1, display: "grid", gridTemplateColumns: "260px 1fr 300px", gap: 14, minHeight: 0 }}>
 
       {/* LEFT: Recipe categories + list */}
       <Panel framed style={{ padding: 18, display: "flex", flexDirection: "column", overflow: "hidden" }}>
@@ -187,11 +197,11 @@ function ScreenForge({ onNavigate, state, setState }) {
               </div>
             </div>
 
-            <BrassButton tone="crimson" onClick={craft} style={{ width: "100%", marginTop: 14 }}>
-              ⚒ To the forge
+            <BrassButton tone="crimson" onClick={craft} style={{ width: "100%", marginTop: 14 }} title="Simulated only — result is not persisted to the engine">
+              ⚒ To the forge <span style={{ fontSize: 9, opacity: 0.7 }}>(preview)</span>
             </BrassButton>
             <div className="hand muted" style={{ fontSize: 11, marginTop: 4, textAlign: "center" }}>
-              Crafting happens at next rest.
+              Crafting happens at next rest. (display-only — not saved)
             </div>
           </>
         )}
@@ -220,6 +230,7 @@ function ScreenForge({ onNavigate, state, setState }) {
           ))}
         </div>
       </Panel>
+      </div>
     </div>
   );
 }

--- a/viewer/openworlds/screen-merchant.jsx
+++ b/viewer/openworlds/screen-merchant.jsx
@@ -18,8 +18,18 @@ function ScreenMerchant({ onNavigate, state, setState }) {
 
   const inv = tab === "buy" ? merchant.stock : stash.filter((i) => i.type !== "quest");
 
+  const _badge = { label: "Preview", tone: "muted", detail: "The Market is display-only — stock is demo data and transactions are not persisted to the engine." };
+
   return (
-    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "260px 1fr 280px", gap: 14, padding: 14 }}>
+    <div className="screen" style={{ height: "100%", display: "flex", flexDirection: "column", gap: 8, padding: 14 }}>
+
+      {/* Prototype banner */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 14px", background: "rgba(80,50,20,0.18)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.45)", borderRadius: 2 }}>
+        <CapabilityBadge capability={_badge} nativeStatus={null} />
+        <span className="hand muted" style={{ fontSize: 12 }}>Display-only — merchant stock is demo data; purchases are not wired to the engine inventory.</span>
+      </div>
+
+      <div style={{ flex: 1, display: "grid", gridTemplateColumns: "260px 1fr 280px", gap: 14, minHeight: 0 }}>
 
       {/* LEFT — Merchant info + haggle */}
       <Panel framed style={{ padding: 22, overflow: "auto" }}>
@@ -229,11 +239,12 @@ function ScreenMerchant({ onNavigate, state, setState }) {
           <BrassButton onClick={() => {
             setCoins((prev) => ({ ...prev, gp: prev.gp + balanceDelta }));
             setCart([]);
-          }} style={{ width: "100%" }} disabled={cart.length === 0 || coins.gp + balanceDelta < 0}>
-            {balanceDelta > 0 ? "Accept silver" : "Strike the bargain"}
+          }} style={{ width: "100%" }} disabled={cart.length === 0 || coins.gp + balanceDelta < 0} title="Display-only — transaction is not saved to the engine">
+            {balanceDelta > 0 ? "Accept silver" : "Strike the bargain"} <span style={{ fontSize: 9, opacity: 0.7 }}>(preview)</span>
           </BrassButton>
         </div>
       </Panel>
+      </div>
     </div>
   );
 }

--- a/viewer/openworlds/screen-seed.jsx
+++ b/viewer/openworlds/screen-seed.jsx
@@ -17,8 +17,18 @@ function ScreenSeed({ onNavigate, state, setState }) {
 
   const update = (k, v) => setSeed({ ...seed, [k]: v });
 
+  const _badge = { label: "Preview", tone: "muted", detail: "World Seed is display-only — parameters shown are demo values; changes are not persisted to the engine." };
+
   return (
-    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "1fr 1.1fr", gap: 14, padding: 14, minHeight: 0 }}>
+    <div className="screen" style={{ height: "100%", display: "flex", flexDirection: "column", gap: 8, padding: 14, minHeight: 0 }}>
+
+      {/* Prototype banner */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "8px 14px", background: "rgba(80,50,20,0.18)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.45)", borderRadius: 2 }}>
+        <CapabilityBadge capability={_badge} nativeStatus={null} />
+        <span className="hand muted" style={{ fontSize: 12 }}>Display-only — seed parameters are not yet wired to the engine. Changes will not be saved.</span>
+      </div>
+
+      <div style={{ flex: 1, display: "grid", gridTemplateColumns: "1fr 1.1fr", gap: 14, minHeight: 0, overflow: "auto" }}>
 
       {/* LEFT — seed card */}
       <Panel framed style={{ padding: 28, overflow: "auto" }}>
@@ -189,9 +199,10 @@ function ScreenSeed({ onNavigate, state, setState }) {
         />
 
         <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 14 }}>
-          <BrassButton onClick={() => toast({ kind: "rest", title: "Seed updated", body: "The chronicle accepts the change." })}>Sow the change</BrassButton>
+          <BrassButton disabled title="Display-only — seed changes are not yet wired to the engine">Sow the change (preview only)</BrassButton>
         </div>
       </Panel>
+      </div>
     </div>
   );
 }

--- a/viewer/tests/test_capability_badges.py
+++ b/viewer/tests/test_capability_badges.py
@@ -1,0 +1,95 @@
+"""
+test_capability_badges.py — assert that each display-only OpenWorlds screen
+contains a <CapabilityBadge> component, signalling to players that the screen
+is a prototype backed by demo data rather than a live engine read-model.
+
+Mirrors the style of test_openworlds_static.py.
+"""
+import http.client
+import importlib.util
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+class _QuietHandler(server._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:  # noqa: D401
+        return
+
+
+class CapabilityBadgeTests(unittest.TestCase):
+    """Each display-only screen must declare a CapabilityBadge so players know
+    the screen is not yet backed by live engine state."""
+
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        self._old_here = server._HERE
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+        server._HERE = self._old_here
+
+    def _get(self, path: str) -> tuple[int, str, bytes]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            response = conn.getresponse()
+            return response.status, response.headers.get("Content-Type", ""), response.read()
+        finally:
+            conn.close()
+
+    def _assert_has_capability_badge(self, screen_path: str) -> None:
+        status, ctype, body = self._get(screen_path)
+        self.assertEqual(status, 200, f"{screen_path} should return HTTP 200")
+        self.assertIn("text/babel", ctype, f"{screen_path} should be served as text/babel")
+        source = body.decode("utf-8")
+        self.assertIn(
+            "CapabilityBadge",
+            source,
+            f"{screen_path} must render a <CapabilityBadge> so players know it is display-only",
+        )
+
+    def test_bestiary_screen_has_capability_badge(self):
+        self._assert_has_capability_badge("/openworlds/screen-bestiary.jsx")
+
+    def test_create_screen_has_capability_badge(self):
+        self._assert_has_capability_badge("/openworlds/screen-create.jsx")
+
+    def test_forge_screen_has_capability_badge(self):
+        self._assert_has_capability_badge("/openworlds/screen-forge.jsx")
+
+    def test_merchant_screen_has_capability_badge(self):
+        self._assert_has_capability_badge("/openworlds/screen-merchant.jsx")
+
+    def test_seed_screen_has_capability_badge(self):
+        self._assert_has_capability_badge("/openworlds/screen-seed.jsx")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Marks the 5 unbacked screens (Bestiary, Create, Forge, Merchant, Seed) with a `<CapabilityBadge label="Preview">` banner + disables/annotates their non-functional actions — the app is now honest about what's wired vs prototype. New test_capability_badges.py (5); viewer 87 passed. Refs #133.