### PR TITLE
feat(ingest): wiki image-ingest + /image resolves ingested art (W2b)

### DIFF
--- a/servers/engine/tests/test_wiki_images.py
+++ b/servers/engine/tests/test_wiki_images.py
@@ -1,0 +1,435 @@
+"""Tests for tools/ingest/wiki_images.py (W2b: wiki image-ingest pipeline).
+
+Covers:
+  - write_descriptor: writes image bytes + provenance sidecar + viewer descriptor
+  - _safe_scope / _private_images_dir: path sanitisation
+  - _ext_for_mime: MIME → extension mapping
+  - viewer _ingested_descriptor: scope → descriptor lookup
+  - viewer _latest_descriptor: ingested-first resolution order
+  - viewer /image endpoint: serves ingested asset; 404s when absent
+
+All tests are offline (no network). A temp fixture PNG is used instead of real wiki
+images. The viewer is imported via importlib (same pattern as test_openworlds_static.py).
+"""
+
+from __future__ import annotations
+
+import http.client
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+# ---- import tools/ingest/wiki_images ----------------------------------------
+_INGEST = Path(__file__).resolve().parents[3] / "tools" / "ingest"
+sys.path.insert(0, str(_INGEST))
+import wiki_images  # noqa: E402  (path-insert must precede import)
+
+# ---- import viewer/server ---------------------------------------------------
+_SERVER_PATH = Path(__file__).resolve().parents[3] / "viewer" / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server_wi", _SERVER_PATH)
+assert _SPEC is not None
+_viewer = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_viewer)
+
+# A minimal valid 1×1 PNG (not just random bytes — keeps MIME probing honest).
+_PNG_1X1 = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x02\x00\x00\x00\x90wS\xde\x00\x00\x00\x0cIDATx\x9cc\xf8\x0f\x00"
+    b"\x00\x01\x01\x00\x05\x18\xd8N\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+
+# ---------------------------------------------------------------------------
+# wiki_images unit tests
+# ---------------------------------------------------------------------------
+
+class TestSafeScopeAndPaths(unittest.TestCase):
+    def test_safe_scope_strips_colons(self):
+        # Colons (e.g. "portrait:shadowheart") become underscores.
+        safe = wiki_images._safe_scope("portrait:shadowheart")
+        self.assertEqual(safe, "portrait_shadowheart")
+
+    def test_safe_scope_allows_alnum_dash_underscore(self):
+        self.assertEqual(wiki_images._safe_scope("scene-elfsong_1"), "scene-elfsong_1")
+
+    def test_safe_scope_empty(self):
+        self.assertEqual(wiki_images._safe_scope(""), "")
+        self.assertEqual(wiki_images._safe_scope(None), "")
+
+    def test_safe_scope_length_cap(self):
+        long_scope = "a" * 200
+        self.assertEqual(len(wiki_images._safe_scope(long_scope)), 128)
+
+    def test_private_images_dir_is_under_private(self):
+        d = wiki_images._private_images_dir("baldurs-gate", "portrait:shadowheart")
+        # Must be under content/worlds/_private/baldurs-gate/images/
+        self.assertIn("_private", str(d))
+        self.assertIn("baldurs-gate", str(d))
+        self.assertTrue(str(d).endswith("portrait_shadowheart"))
+
+
+class TestExtForMime(unittest.TestCase):
+    def test_jpeg(self):
+        self.assertEqual(wiki_images._ext_for_mime("image/jpeg", "https://x/foo.jpg"), ".jpg")
+
+    def test_png(self):
+        ext = wiki_images._ext_for_mime("image/png", "https://x/foo.png")
+        self.assertEqual(ext, ".png")
+
+    def test_fallback_from_url(self):
+        # When MIME is unknown, fall back to URL extension.
+        ext = wiki_images._ext_for_mime("application/octet-stream", "https://x/foo.webp")
+        self.assertEqual(ext, ".webp")
+
+    def test_bin_when_unknown(self):
+        ext = wiki_images._ext_for_mime("application/octet-stream", "https://x/foo")
+        self.assertEqual(ext, ".bin")
+
+
+class TestWriteDescriptor(unittest.TestCase):
+    def setUp(self):
+        self._tmp = self.enterContext(tempfile.TemporaryDirectory())
+        # Patch _REPO_ROOT in wiki_images so writes land in our tmpdir.
+        self._orig_root = wiki_images._REPO_ROOT
+        wiki_images._REPO_ROOT = Path(self._tmp)
+
+    def tearDown(self):
+        wiki_images._REPO_ROOT = self._orig_root
+
+    def test_writes_image_and_descriptor(self):
+        desc_path = wiki_images.write_descriptor(
+            "baldurs-gate",
+            "portrait:shadowheart",
+            _PNG_1X1,
+            "image/png",
+            source_url="https://bg3.wiki/w/images/Shadowheart.png",
+            page_url="https://bg3.wiki/wiki/Shadowheart",
+            license="CC BY-SA 4.0 / CC BY-NC-SA 4.0",
+            attribution="Image from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0.",
+        )
+        # Descriptor file was written.
+        self.assertTrue(desc_path.exists())
+        desc = json.loads(desc_path.read_text())
+        self.assertEqual(desc["scope"], "portrait:shadowheart")
+        self.assertIn("path", desc)
+        self.assertEqual(desc["mime_type"], "image/png")
+        self.assertIn("source_url", desc)
+        self.assertIn("license", desc)
+        self.assertIn("attribution", desc)
+
+    def test_image_bytes_written(self):
+        wiki_images.write_descriptor(
+            "baldurs-gate",
+            "portrait:astarion",
+            _PNG_1X1,
+            "image/png",
+            source_url="https://bg3.wiki/w/images/Astarion.png",
+            page_url="https://bg3.wiki/wiki/Astarion",
+            license="CC BY-SA 4.0",
+            attribution="bg3.wiki",
+        )
+        out_dir = wiki_images._private_images_dir("baldurs-gate", "portrait:astarion")
+        img_files = list(out_dir.glob("image.*"))
+        img_files = [f for f in img_files if not f.name.endswith(".provenance.json")]
+        self.assertEqual(len(img_files), 1)
+        self.assertEqual(img_files[0].read_bytes(), _PNG_1X1)
+
+    def test_provenance_sidecar_written(self):
+        wiki_images.write_descriptor(
+            "baldurs-gate",
+            "scene:elfsong",
+            _PNG_1X1,
+            "image/jpeg",
+            source_url="https://bg3.wiki/w/images/Elfsong.jpg",
+            page_url="https://bg3.wiki/wiki/Elfsong_Tavern",
+            license="CC BY-SA 4.0",
+            attribution="bg3.wiki",
+        )
+        out_dir = wiki_images._private_images_dir("baldurs-gate", "scene:elfsong")
+        prov_files = list(out_dir.glob("*.provenance.json"))
+        self.assertEqual(len(prov_files), 1)
+        prov = json.loads(prov_files[0].read_text())
+        self.assertEqual(prov["source_url"], "https://bg3.wiki/w/images/Elfsong.jpg")
+        self.assertIn("license", prov)
+        self.assertIn("attribution", prov)
+        self.assertIn("fetched_at", prov)
+
+    def test_descriptor_path_is_under_private(self):
+        desc_path = wiki_images.write_descriptor(
+            "baldurs-gate",
+            "portrait:gale",
+            _PNG_1X1,
+            "image/png",
+            source_url="https://bg3.wiki/w/images/Gale.png",
+            page_url="https://bg3.wiki/wiki/Gale",
+            license="CC BY-SA 4.0",
+            attribution="bg3.wiki",
+        )
+        # The descriptor must live under _private (containment).
+        self.assertIn("_private", str(desc_path))
+
+    def test_path_traversal_neutralised_by_safe_scope(self):
+        """Path-traversal characters in the scope are sanitised by _safe_scope.
+
+        '../../etc/passwd' becomes '__etc_passwd' — it lands inside _private and
+        never escapes. The protection is the sanitiser, not a raised exception.
+        """
+        desc_path = wiki_images.write_descriptor(
+            "baldurs-gate",
+            "../../etc/passwd",
+            _PNG_1X1,
+            "image/png",
+            source_url="x",
+            page_url="x",
+            license="",
+            attribution="",
+        )
+        # Output must be inside the _private tree.
+        self.assertIn("_private", str(desc_path))
+        # Must NOT be near /etc/.
+        self.assertNotIn("/etc/", str(desc_path))
+
+    def test_descriptor_filename_constant(self):
+        desc_path = wiki_images.write_descriptor(
+            "baldurs-gate",
+            "portrait:wyll",
+            _PNG_1X1,
+            "image/png",
+            source_url="https://bg3.wiki/w/images/Wyll.png",
+            page_url="https://bg3.wiki/wiki/Wyll",
+            license="CC BY-SA 4.0",
+            attribution="bg3.wiki",
+        )
+        self.assertEqual(desc_path.name, wiki_images._DESCRIPTOR_FILENAME)
+
+
+class TestIngestManifestDryRun(unittest.TestCase):
+    def setUp(self):
+        self._tmp = self.enterContext(tempfile.TemporaryDirectory())
+        self._orig_root = wiki_images._REPO_ROOT
+        wiki_images._REPO_ROOT = Path(self._tmp)
+
+    def tearDown(self):
+        wiki_images._REPO_ROOT = self._orig_root
+
+    def test_dry_run_does_not_write(self):
+        manifest = {
+            "world_id": "baldurs-gate",
+            "rate_delay_seconds": 0,
+            "sources": [{
+                "wiki": "bg3.wiki",
+                "script_path": "/w",
+                "license": "CC BY-SA 4.0",
+                "attribution": "bg3.wiki",
+                "images": [
+                    {"title": "Shadowheart", "scope": "portrait:shadowheart", "kind": "portrait"}
+                ],
+            }]
+        }
+        mf_path = Path(self._tmp) / "manifest_images.json"
+        mf_path.write_text(json.dumps(manifest))
+        # dry-run must return cleanly and write nothing.
+        rc = wiki_images.ingest_manifest(mf_path, max_override=None, dry_run=True)
+        self.assertEqual(rc, 0)
+        private_dir = Path(self._tmp) / "content" / "worlds" / "_private"
+        # Nothing should have been written.
+        self.assertFalse(private_dir.exists())
+
+
+# ---------------------------------------------------------------------------
+# Viewer _ingested_descriptor + _latest_descriptor integration
+# ---------------------------------------------------------------------------
+
+class _QuietHandler(_viewer._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+
+class TestViewerIngestedDescriptor(unittest.TestCase):
+    """_ingested_descriptor looks up wiki_ingest.json across _private world dirs."""
+
+    def setUp(self):
+        self._tmp = self.enterContext(tempfile.TemporaryDirectory())
+        self._old_repo_root = _viewer._REPO_ROOT
+        _viewer._REPO_ROOT = Path(self._tmp)
+
+    def tearDown(self):
+        _viewer._REPO_ROOT = self._old_repo_root
+
+    def _write_ingested(self, world_id: str, scope: str, extra: dict | None = None) -> Path:
+        """Write a minimal wiki_ingest.json descriptor for testing."""
+        safe = "".join(c if (c.isalnum() or c in "-_") else "_" for c in scope)[:128]
+        d = Path(self._tmp) / "content" / "worlds" / "_private" / world_id / "images" / safe
+        d.mkdir(parents=True, exist_ok=True)
+        img = d / "image.png"
+        img.write_bytes(_PNG_1X1)
+        desc = {
+            "scope": scope,
+            "path": str(img),
+            "mime_type": "image/png",
+            "source_url": "https://bg3.wiki/w/images/Test.png",
+            "license": "CC BY-SA 4.0",
+            "attribution": "bg3.wiki",
+        }
+        if extra:
+            desc.update(extra)
+        desc_path = d / "wiki_ingest.json"
+        desc_path.write_text(json.dumps(desc))
+        return desc_path
+
+    def test_finds_ingested_descriptor(self):
+        self._write_ingested("baldurs-gate", "portrait:shadowheart")
+        result = _viewer._ingested_descriptor("portrait:shadowheart")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["scope"], "portrait:shadowheart")
+        self.assertEqual(result["mime_type"], "image/png")
+
+    def test_returns_none_when_absent(self):
+        result = _viewer._ingested_descriptor("portrait:nonexistent")
+        self.assertIsNone(result)
+
+    def test_safe_scope_used_for_lookup(self):
+        # "portrait:shadowheart" safe-scopes to "portrait_shadowheart".
+        self._write_ingested("baldurs-gate", "portrait:shadowheart")
+        # Lookup using the original (colon) scope should still work.
+        result = _viewer._ingested_descriptor("portrait:shadowheart")
+        self.assertIsNotNone(result)
+
+    def test_empty_scope_returns_none(self):
+        self.assertIsNone(_viewer._ingested_descriptor(""))
+        self.assertIsNone(_viewer._ingested_descriptor(None))
+
+
+class TestViewerLatestDescriptorOrder(unittest.TestCase):
+    """_latest_descriptor: ingested asset wins over generated cache."""
+
+    def setUp(self):
+        self._tmp = self.enterContext(tempfile.TemporaryDirectory())
+        self._old_repo_root = _viewer._REPO_ROOT
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        _viewer._REPO_ROOT = Path(self._tmp)
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+
+    def tearDown(self):
+        _viewer._REPO_ROOT = self._old_repo_root
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _write_ingested(self, world_id: str, scope: str) -> None:
+        safe = "".join(c if (c.isalnum() or c in "-_") else "_" for c in scope)[:128]
+        d = Path(self._tmp) / "content" / "worlds" / "_private" / world_id / "images" / safe
+        d.mkdir(parents=True, exist_ok=True)
+        img = d / "image.png"
+        img.write_bytes(_PNG_1X1)
+        desc = {"scope": scope, "path": str(img), "mime_type": "image/png", "source": "ingested"}
+        (d / "wiki_ingest.json").write_text(json.dumps(desc))
+
+    def _write_generated(self, scope: str) -> None:
+        safe = "".join(c if (c.isalnum() or c in "-_") else "_" for c in scope)[:128]
+        d = Path(self._tmp) / "images" / safe
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "abc123.json").write_text(json.dumps({"scope": scope, "source": "generated"}))
+
+    def test_ingested_wins_over_generated(self):
+        self._write_ingested("baldurs-gate", "portrait:shadowheart")
+        self._write_generated("portrait:shadowheart")
+        result = _viewer._latest_descriptor("portrait:shadowheart")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get("source"), "ingested")
+
+    def test_generated_used_when_no_ingested(self):
+        self._write_generated("portrait:nobody")
+        result = _viewer._latest_descriptor("portrait:nobody")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.get("source"), "generated")
+
+    def test_returns_none_when_nothing(self):
+        result = _viewer._latest_descriptor("portrait:empty")
+        self.assertIsNone(result)
+
+
+# ---------------------------------------------------------------------------
+# Viewer /image endpoint: serves ingested asset; 404s on absent scope
+# ---------------------------------------------------------------------------
+
+class TestViewerImageEndpoint(unittest.TestCase):
+    """/image?scope=X serves ingested asset bytes; 404s when no descriptor."""
+
+    def setUp(self):
+        self._tmp = self.enterContext(tempfile.TemporaryDirectory())
+        self._old_repo_root = _viewer._REPO_ROOT
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        _viewer._REPO_ROOT = Path(self._tmp)
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = _viewer.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        _viewer._REPO_ROOT = self._old_repo_root
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _get(self, path: str) -> tuple[int, bytes]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        body = resp.read()
+        conn.close()
+        return resp.status, body
+
+    def _write_ingested(self, world_id: str, scope: str, img_bytes: bytes = _PNG_1X1) -> Path:
+        safe = "".join(c if (c.isalnum() or c in "-_") else "_" for c in scope)[:128]
+        d = Path(self._tmp) / "content" / "worlds" / "_private" / world_id / "images" / safe
+        d.mkdir(parents=True, exist_ok=True)
+        img = d / "image.png"
+        img.write_bytes(img_bytes)
+        desc = {"scope": scope, "path": str(img), "mime_type": "image/png"}
+        (d / "wiki_ingest.json").write_text(json.dumps(desc))
+        return img
+
+    def test_serves_ingested_image_bytes(self):
+        img_path = self._write_ingested("baldurs-gate", "portrait:shadowheart")
+        status, body = self._get("/image?scope=portrait:shadowheart")
+        self.assertEqual(status, 200)
+        self.assertEqual(body, _PNG_1X1)
+
+    def test_404_when_absent(self):
+        status, _ = self._get("/image?scope=portrait:nobody")
+        self.assertEqual(status, 404)
+
+    def test_404_when_empty_scope(self):
+        status, _ = self._get("/image?scope=")
+        self.assertEqual(status, 404)
+
+    def test_path_traversal_scope_does_not_escape(self):
+        # A scope with traversal characters resolves to a sanitised safe-scope
+        # and returns 404 (not a file from outside _private).
+        status, body = self._get("/image?scope=../../etc/passwd")
+        # Either 404 (scope not found) or 200 with our dummy bytes — never /etc/passwd.
+        if status == 200:
+            self.assertEqual(body, _PNG_1X1)
+        else:
+            self.assertEqual(status, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/ingest/README.md
+++ b/tools/ingest/README.md
@@ -58,6 +58,62 @@ python3 tools/ingest/wiki_to_characters.py tools/ingest/manifest_characters.json
 The parser is guarded by `servers/engine/tests/test_wiki_to_characters.py` (runs in CI's
 engine pytest via a path-insert, like `test_wiki_ingest.py`).
 
+## Image pipeline (W2b — wiki image ingest)
+
+`wiki_images.py` fetches the **lead image** for each entry in `manifest_images.json`
+via the MediaWiki API (pageimages → imageinfo fallback) and writes:
+
+1. **Image file** at `content/worlds/_private/<world_id>/images/<safe-scope>/image.<ext>`
+2. **Provenance sidecar** (`image.<ext>.provenance.json`) — `source_url`, `license`,
+   `attribution`, `fetched_at`.
+3. **Viewer descriptor** (`wiki_ingest.json`) — the shape `_latest_descriptor` in
+   `viewer/server.py` reads: `{path, mime_type, scope, source_url, license, attribution}`.
+
+**Licensing / storage discipline:** Official game/wiki art (© Larian / WotC) lands ONLY
+under the gitignored `content/worlds/_private/` tree. CC-BY-SA wiki images are kept WITH
+per-file attribution in the sidecar. The `_private/` path is covered by `.gitignore`;
+`scripts/license_check.py` enforces no committed images from that tree. NEVER commit the
+`_private/` directory.
+
+The `/image?scope=<scope>` viewer endpoint resolves descriptors in this order:
+  1. Ingested asset (`_private/<world>/images/<scope>/wiki_ingest.json`) — priority
+  2. Generated imagegen cache (`<state_dir>/images/<scope>/*.json`)
+  3. 404 / placeholder fallback
+
+```bash
+# Dry-run (preview what would be fetched, no downloads):
+python3 tools/ingest/wiki_images.py --dry-run
+
+# Fetch up to N images per source (for testing):
+python3 tools/ingest/wiki_images.py --max 3
+
+# Full ingest (all entries in manifest_images.json):
+python3 tools/ingest/wiki_images.py
+
+# Custom manifest:
+python3 tools/ingest/wiki_images.py path/to/my_manifest_images.json
+```
+
+Resumable + idempotent: scopes already written to `_private/` are skipped.
+The manifest format:
+
+```json
+{
+  "world_id": "baldurs-gate",
+  "rate_delay_seconds": 0.75,
+  "sources": [{
+    "wiki": "bg3.wiki",
+    "script_path": "/w",
+    "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual)",
+    "attribution": "Image from bg3.wiki ...",
+    "images": [
+      {"title": "Shadowheart", "scope": "portrait:shadowheart", "kind": "portrait"},
+      {"title": "Elfsong Tavern", "scope": "scene:elfsong-tavern", "kind": "scene"}
+    ]
+  }]
+}
+```
+
 ## Private compendium sidecar
 
 `private_compendium_sidecar.py` is a local-only scaffold for user-owned books,

--- a/tools/ingest/manifest_images.json
+++ b/tools/ingest/manifest_images.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "W2b image-ingest manifest for the Unofficial Baldur's Gate 3+ Universe Seed. Lead images for key characters and locations are fetched from bg3.wiki (CC BY-SA 4.0 / CC BY-NC-SA 4.0 dual-licensed, non-commercial fan use) and written ONLY to the gitignored content/worlds/_private/baldurs-gate/images/<scope>/ path. NEVER committed. Each image gets a .provenance.json sidecar with source_url, license, and attribution. To run a full ingest: python3 tools/ingest/wiki_images.py (uses this manifest). Use --max N to cap images per source during testing.",
+  "world_id": "baldurs-gate",
+  "rate_delay_seconds": 0.75,
+  "sources": [
+    {
+      "_comment": "bg3.wiki — standalone MediaWiki (API at /w/api.php). Images are dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. See https://bg3.wiki/wiki/bg3wiki:Copyrights. Non-commercial fan project; we attribute per wiki policy.",
+      "wiki": "bg3.wiki",
+      "script_path": "/w",
+      "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual; see https://bg3.wiki/wiki/bg3wiki:Copyrights — older revisions CC BY-NC-SA 4.0 only). Non-commercial fan use.",
+      "attribution": "Image from bg3.wiki, dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0. Unofficial, non-commercial fan content. Subject to Larian Studios' and Wizards of the Coast's Fan Content Policies.",
+      "images": [
+        {"title": "Shadowheart",          "scope": "portrait:shadowheart",     "kind": "portrait"},
+        {"title": "Astarion",             "scope": "portrait:astarion",        "kind": "portrait"},
+        {"title": "Gale",                 "scope": "portrait:gale",            "kind": "portrait"},
+        {"title": "Karlach",              "scope": "portrait:karlach",         "kind": "portrait"},
+        {"title": "Lae'zel",              "scope": "portrait:lazel",           "kind": "portrait"},
+        {"title": "Wyll",                 "scope": "portrait:wyll",            "kind": "portrait"},
+        {"title": "Halsin",               "scope": "portrait:halsin",          "kind": "portrait"},
+        {"title": "Minsc",                "scope": "portrait:minsc",           "kind": "portrait"},
+        {"title": "Jaheira",              "scope": "portrait:jaheira",         "kind": "portrait"},
+        {"title": "Withers",              "scope": "portrait:withers",         "kind": "portrait"},
+        {"title": "Elfsong Tavern",       "scope": "scene:elfsong-tavern",     "kind": "scene"},
+        {"title": "Baldur's Gate",        "scope": "scene:baldurs-gate",       "kind": "scene"},
+        {"title": "Moonrise Towers",      "scope": "scene:moonrise-towers",    "kind": "scene"},
+        {"title": "Wyrm's Rock Fortress", "scope": "scene:wyrms-rock",         "kind": "scene"},
+        {"title": "Candlekeep",           "scope": "scene:candlekeep",         "kind": "scene"}
+      ]
+    }
+  ]
+}

--- a/tools/ingest/wiki_images.py
+++ b/tools/ingest/wiki_images.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Stage 1 of the wiki IMAGE-ingest pipeline: fetch lead images → servable descriptors.
+
+OFFLINE content tooling (NOT an MCP tool, NOT imported by the engine). Stdlib only
+(urllib + json), so it adds no dependency and can run anywhere.
+
+Given a manifest of {title, scope, kind(portrait|item|scene|map)} entries it:
+  1. Fetches the page's lead image URL via the MediaWiki API
+     (action=query&prop=pageimages&piprop=original, or imageinfo&iiprop=url).
+  2. Downloads the image bytes.
+  3. Writes a descriptor JSON to the world's gitignored _private images dir so the
+     viewer's /image endpoint can serve it.
+
+## Licensing / storage discipline (LOAD-BEARING)
+
+Official game / wiki images (BG3 portraits, Larian/WotC item icons) are © — they are
+written ONLY to the gitignored path:
+
+    content/worlds/_private/<world_id>/images/<scope>/
+
+…which is covered by the /content/worlds/_private/ rule in .gitignore. They are NEVER
+committed. CC-BY-SA wiki images may be kept WITH per-file attribution.
+
+Each image gets a sidecar `<filename>.provenance.json` carrying:
+  - source_url  — the wiki image file URL (canon or thumbnail)
+  - page_url    — the wiki article URL the image came from
+  - license     — license string from the manifest source
+  - attribution — attribution string from the manifest source
+  - fetched_at  — unix timestamp
+
+## Manifest format
+
+```json
+{
+  "world_id": "baldurs-gate",
+  "rate_delay_seconds": 0.5,
+  "sources": [
+    {
+      "wiki": "bg3.wiki",
+      "script_path": "/w",
+      "license": "CC BY-SA 4.0 / CC BY-NC-SA 4.0 (dual, non-commercial fan use)",
+      "attribution": "Image from bg3.wiki; dual-licensed CC BY-SA 4.0 / CC BY-NC-SA 4.0.",
+      "images": [
+        {"title": "Shadowheart", "scope": "portrait:shadowheart", "kind": "portrait"},
+        {"title": "Elfsong Tavern", "scope": "scene:elfsong-tavern", "kind": "scene"}
+      ]
+    }
+  ]
+}
+```
+
+The `scope` field maps directly to the `/image?scope=` viewer parameter. The descriptor
+written is exactly what viewer/server.py `_serve_image` / `_latest_descriptor` expects:
+  {"path": "<abs>", "mime_type": "image/jpeg", "scope": "...", ...}
+
+## Usage
+
+    python3 tools/ingest/wiki_images.py [manifest_images.json] [--max N] [--dry-run]
+
+Resumable + idempotent (skips already-written scopes), polite (rate-limited + User-Agent).
+A `--dry-run` flag logs what would be fetched without downloading or writing anything.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import mimetypes
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parents[1]
+_UA = "ClawDnD-image-ingest/0.1 (private, non-commercial fan project; MediaWiki API)"
+
+# Descriptor filename written under the scope dir (single file per scope —
+# the viewer's _latest_descriptor picks newest *.json so this is stable).
+_DESCRIPTOR_FILENAME = "wiki_ingest.json"
+
+
+# --------------------------------------------------------------------------- #
+# MediaWiki API helpers
+# --------------------------------------------------------------------------- #
+
+def _api(wiki: str, params: dict, delay: float, script_path: str = "") -> dict:
+    """One polite GET against the wiki's api.php. Returns parsed JSON (or {} on error)."""
+    sp = ("/" + script_path.strip("/")) if script_path.strip("/") else ""
+    qs = urllib.parse.urlencode({**params, "format": "json", "maxlag": "5"})
+    url = f"https://{wiki}{sp}/api.php?{qs}"
+    req = urllib.request.Request(url, headers={"User-Agent": _UA})
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                time.sleep(delay)
+                return json.loads(r.read().decode("utf-8"))
+        except Exception as e:  # noqa: BLE001
+            print(f"  ! api error ({attempt + 1}/3): {e}", file=sys.stderr)
+            time.sleep(1.5 * (attempt + 1))
+    return {}
+
+
+def _fetch_lead_image_url(
+    wiki: str,
+    title: str,
+    delay: float,
+    script_path: str = "",
+) -> str | None:
+    """Fetch the lead/thumbnail image URL for a wiki page.
+
+    Strategy A — pageimages with piprop=original: fastest, returns the full-res
+    page-image (the infobox portrait for character pages). Falls through to strategy
+    B when not available (e.g. the page has no infobox image or the wiki doesn't
+    support piprop=original).
+
+    Strategy B — query imageinfo on the first image listed in the page (prop=images).
+    Slower (two round-trips) but works for any page with any image.
+
+    Returns an absolute image URL or None on failure.
+    """
+    # Strategy A: pageimages
+    data = _api(wiki, {
+        "action": "query",
+        "titles": title,
+        "prop": "pageimages",
+        "piprop": "original",
+        "redirects": "1",
+    }, delay, script_path)
+    pages = data.get("query", {}).get("pages", {})
+    for page in pages.values():
+        original = page.get("original", {})
+        url = original.get("source", "")
+        if url:
+            return url
+
+    # Strategy B: first image listed on the page → imageinfo
+    data2 = _api(wiki, {
+        "action": "query",
+        "titles": title,
+        "prop": "images",
+        "imlimit": "5",
+        "redirects": "1",
+    }, delay, script_path)
+    pages2 = data2.get("query", {}).get("pages", {})
+    img_titles: list[str] = []
+    for page in pages2.values():
+        for img in page.get("images", []):
+            t = img.get("title", "")
+            if t:
+                img_titles.append(t)
+    if not img_titles:
+        return None
+    # Fetch image info for the first candidate
+    for img_title in img_titles[:3]:
+        data3 = _api(wiki, {
+            "action": "query",
+            "titles": img_title,
+            "prop": "imageinfo",
+            "iiprop": "url",
+            "redirects": "1",
+        }, delay, script_path)
+        pages3 = data3.get("query", {}).get("pages", {})
+        for page in pages3.values():
+            for ii in page.get("imageinfo", []):
+                url = ii.get("url", "")
+                if url:
+                    return url
+    return None
+
+
+def _download_image(url: str) -> tuple[bytes, str] | None:
+    """Download image bytes + MIME type from `url`. Returns (bytes, mime) or None."""
+    req = urllib.request.Request(url, headers={"User-Agent": _UA})
+    for attempt in range(3):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as r:
+                data = r.read()
+                ctype = r.headers.get_content_type() or ""
+                return data, ctype
+        except Exception as e:  # noqa: BLE001
+            print(f"  ! download error ({attempt + 1}/3): {e}", file=sys.stderr)
+            time.sleep(1.5 * (attempt + 1))
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# Output path helpers
+# --------------------------------------------------------------------------- #
+
+def _safe_scope(scope: str | None) -> str:
+    """Reduce an arbitrary scope id to a single safe path segment (alnum, -, _).
+
+    Mirrors imagegen._safe_scope and viewer/server.py's _safe_scope: only alnum,
+    hyphen, and underscore survive; all other characters (including ':', '.', '/',
+    '\\') become underscores. Length-capped at 128. This is the path-traversal
+    guard — a scope like '../../etc/passwd' becomes '______etc_passwd'.
+    """
+    if not scope:
+        return ""
+    return "".join(c if (c.isalnum() or c in "-_") else "_" for c in str(scope))[:128]
+
+
+def _private_images_dir(world_id: str, scope: str) -> Path:
+    """Gitignored output root for one scope: content/worlds/_private/<world_id>/images/<scope>/.
+
+    The scope is sanitised via _safe_scope so a manifest entry like
+    'portrait:shadowheart' becomes 'portrait_shadowheart' (and path-traversal
+    characters can't escape the _private root). The containment check in
+    write_descriptor() is a belt-and-suspenders guard.
+    """
+    return _REPO_ROOT / "content" / "worlds" / "_private" / world_id / "images" / _safe_scope(scope)
+
+
+# Known image MIME types that mimetypes.guess_extension may not know on all platforms.
+_MIME_TO_EXT: dict[str, str] = {
+    "image/jpeg": ".jpg",
+    "image/jpg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/svg+xml": ".svg",
+    "image/avif": ".avif",
+    "image/bmp": ".bmp",
+    "image/tiff": ".tiff",
+}
+
+
+def _ext_for_mime(mime: str, url: str) -> str:
+    """Best file extension: prefer explicit table, then Content-Type, fall back to URL path."""
+    bare = mime.split(";")[0].strip().lower()
+    # 1. Explicit table (cross-platform reliable).
+    if bare in _MIME_TO_EXT:
+        return _MIME_TO_EXT[bare]
+    # 2. stdlib mimetypes (may not know webp/avif on older systems).
+    #    Skip generic fallbacks like ".bin" that don't describe the actual format.
+    ext = mimetypes.guess_extension(bare, strict=False) or ""
+    if ext in (".jpe", ".jpeg"):
+        ext = ".jpg"
+    if ext and ext not in (".bin", ".exe"):
+        return ext
+    # 3. URL path extension — more reliable for image/* when MIME is generic.
+    url_path = urllib.parse.urlparse(url).path
+    ext = Path(url_path).suffix.lower()
+    return ext or ".bin"
+
+
+def write_descriptor(
+    world_id: str,
+    scope: str,
+    image_data: bytes,
+    mime: str,
+    *,
+    source_url: str,
+    page_url: str,
+    license: str,
+    attribution: str,
+) -> Path:
+    """Write image + sidecar provenance + descriptor to the _private images dir.
+
+    Containment guarantee: the output dir must resolve under
+    content/worlds/_private/<world_id>/images/ — path-traversal safe.
+    """
+    out_dir = _private_images_dir(world_id, scope)
+    # Containment check: the resolved dir must be under the _private images root.
+    expected_root = (_REPO_ROOT / "content" / "worlds" / "_private" / world_id / "images").resolve()
+    try:
+        if expected_root not in out_dir.resolve().parents and out_dir.resolve() != expected_root:
+            raise ValueError(f"scope resolved outside _private images root: {out_dir}")
+    except OSError as exc:
+        raise ValueError(f"bad output path: {out_dir}") from exc
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    ext = _ext_for_mime(mime, source_url)
+    img_path = out_dir / f"image{ext}"
+    img_path.write_bytes(image_data)
+
+    # Provenance sidecar (per-file attribution, as promised).
+    prov = {
+        "source_url": source_url,
+        "page_url": page_url,
+        "license": license,
+        "attribution": attribution,
+        "mime_type": mime,
+        "fetched_at": time.time(),
+    }
+    prov_path = out_dir / f"image{ext}.provenance.json"
+    prov_path.write_text(json.dumps(prov, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    # Viewer descriptor (what _latest_descriptor / _serve_image reads).
+    desc = {
+        "scope": scope,
+        "path": str(img_path.resolve()),
+        "mime_type": mime,
+        "source_url": source_url,
+        "license": license,
+        "attribution": attribution,
+        "ingested_at": time.time(),
+    }
+    desc_path = out_dir / _DESCRIPTOR_FILENAME
+    desc_path.write_text(json.dumps(desc, ensure_ascii=False, indent=2), encoding="utf-8")
+    return desc_path
+
+
+# --------------------------------------------------------------------------- #
+# Pipeline entry point
+# --------------------------------------------------------------------------- #
+
+def ingest_manifest(manifest_path: Path, *, max_override: int | None, dry_run: bool) -> int:
+    """Run the image-ingest pipeline from a manifest file. Returns exit code."""
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    world_id: str = manifest["world_id"]
+    delay = float(manifest.get("rate_delay_seconds", 0.5))
+    sources: list[dict] = manifest.get("sources", [])
+
+    fetched = skipped = missing = errors = 0
+    for src in sources:
+        wiki: str = src["wiki"]
+        script_path: str = src.get("script_path", "")
+        license_str: str = src.get("license", "")
+        attribution_str: str = src.get("attribution", "")
+        images: list[dict] = src.get("images", [])
+        if max_override is not None:
+            images = images[:max_override]
+
+        print(f"[image-ingest] wiki={wiki} world={world_id} images={len(images)}")
+
+        for entry in images:
+            title: str = entry["title"]
+            scope: str = entry["scope"]
+            kind: str = entry.get("kind", "scene")
+
+            out_dir = _private_images_dir(world_id, scope)
+            desc_path = out_dir / _DESCRIPTOR_FILENAME
+
+            if desc_path.exists() and not dry_run:
+                skipped += 1
+                print(f"  [skip] {scope} (already ingested)")
+                continue
+
+            # Derive page URL for provenance.
+            sp = ("/" + script_path.strip("/")) if script_path.strip("/") else ""
+            page_url = f"https://{wiki}{sp}/wiki/{urllib.parse.quote(title.replace(' ', '_'))}"
+
+            print(f"  [fetch] {title!r} → scope={scope}")
+
+            if dry_run:
+                print(f"    dry-run: would fetch lead image from {wiki}")
+                continue
+
+            img_url = _fetch_lead_image_url(wiki, title, delay, script_path)
+            if not img_url:
+                print(f"  ! no lead image found for {title!r} on {wiki}", file=sys.stderr)
+                missing += 1
+                continue
+
+            print(f"    image url: {img_url}")
+            result = _download_image(img_url)
+            if result is None:
+                print(f"  ! download failed for {img_url}", file=sys.stderr)
+                errors += 1
+                continue
+
+            image_bytes, mime = result
+            if not mime or mime == "application/octet-stream":
+                mime = mimetypes.guess_type(img_url)[0] or "image/jpeg"
+
+            try:
+                write_descriptor(
+                    world_id,
+                    scope,
+                    image_bytes,
+                    mime,
+                    source_url=img_url,
+                    page_url=page_url,
+                    license=license_str,
+                    attribution=attribution_str,
+                )
+            except Exception as exc:  # noqa: BLE001
+                print(f"  ! write failed for {scope}: {exc}", file=sys.stderr)
+                errors += 1
+                continue
+
+            fetched += 1
+            print(f"    ok ({len(image_bytes)} bytes, {mime})")
+
+    print(
+        f"[image-ingest] done: {fetched} fetched, {skipped} cached-skip, "
+        f"{missing} missing, {errors} errors"
+    )
+    return 1 if errors else 0
+
+
+def main() -> int:
+    default_manifest = _HERE / "manifest_images.json"
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("manifest", nargs="?", default=str(default_manifest),
+                    help="path to the image manifest JSON (default: manifest_images.json)")
+    ap.add_argument("--max", type=int, default=None,
+                    help="cap the number of images per source (for dry-runs / testing)")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print what would be fetched without downloading or writing")
+    args = ap.parse_args()
+
+    manifest_path = Path(args.manifest)
+    if not manifest_path.exists():
+        print(f"manifest not found: {manifest_path}", file=sys.stderr)
+        return 1
+
+    return ingest_manifest(manifest_path, max_override=args.max, dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -147,6 +147,16 @@ def _live_play() -> bool:
 # the engine. GET /image?scope=<scope> finds the most-recent descriptor for a scope
 # and serves the pixels; absent scope/descriptor → 404 so the dashboard falls back
 # to its luxe placeholder.
+#
+# W2b — ingested asset lookup:
+# wiki_images.py writes a descriptor (wiki_ingest.json) under the gitignored path
+#   content/worlds/_private/<world_id>/images/<safe-scope>/
+# Resolution order for a scope:
+#   1. Ingested asset (_private/<world_id>/images/<scope>/wiki_ingest.json) — newest wins
+#   2. Generated imagegen cache (<state_dir>/images/<scope>/*.json)
+#   3. 404 / placeholder fallback
+# The _private root is added to the path-containment allowlist in _serve_image so file
+# serving is safe even when descriptors carry absolute paths from a different machine.
 
 def _safe_scope(scope: Optional[str]) -> str:
     """Reduce a caller-supplied scope id to a single safe path segment, mirroring
@@ -165,15 +175,55 @@ def _images_dir(scope: Optional[str]) -> Path:
     return root / seg if seg else root
 
 
-def _latest_descriptor(scope: Optional[str]) -> Optional[dict]:
-    """Most-recently-written *.json descriptor under the scope's cache dir, parsed.
-    Returns None when the scope dir is absent, holds no descriptors, or the newest
-    one won't parse (the cache is rebuildable, never load-bearing — a bad entry is
-    just a miss, exactly like imagegen.cache_read)."""
+# W2b: repo root is two levels above viewer/ (repo-root/viewer/server.py).
+_REPO_ROOT = _HERE.parent
+
+
+def _ingested_images_root() -> Path:
+    """Root of the gitignored _private images tree (world-neutral).
+
+    Returns content/worlds/_private/ inside the repo. This directory is covered by
+    /content/worlds/_private/ in .gitignore so its contents are NEVER committed.
+    """
+    return _REPO_ROOT / "content" / "worlds" / "_private"
+
+
+def _ingested_descriptor(scope: Optional[str]) -> Optional[dict]:
+    """Look up a wiki_ingest.json descriptor for scope across ALL world _private dirs.
+
+    Searches content/worlds/_private/<any-world>/images/<safe-scope>/wiki_ingest.json.
+    Returns the first readable descriptor found, or None. Path-traversal safe: scope
+    is sanitised and the result is confirmed to sit inside _ingested_images_root().
+    """
     seg = _safe_scope(scope)
     if not seg:
         return None
-    cdir = _images_dir(scope)
+    root = _ingested_images_root()
+    if not root.is_dir():
+        return None
+    for world_dir in root.iterdir():
+        if not world_dir.is_dir():
+            continue
+        desc_path = world_dir / "images" / seg / "wiki_ingest.json"
+        if not desc_path.exists():
+            continue
+        # Containment check: descriptor must resolve under _private root.
+        try:
+            if root.resolve() not in desc_path.resolve().parents:
+                continue
+        except OSError:
+            continue
+        try:
+            d = json.loads(desc_path.read_text(encoding="utf-8"))
+        except (ValueError, OSError):
+            continue
+        if isinstance(d, dict):
+            return d
+    return None
+
+
+def _newest_json_descriptor(cdir: Path) -> Optional[dict]:
+    """Most-recently-written *.json under a directory, parsed. None on miss/error."""
     if not cdir.is_dir():
         return None
     newest: Optional[Path] = None
@@ -192,6 +242,27 @@ def _latest_descriptor(scope: Optional[str]) -> Optional[dict]:
     except (ValueError, OSError):
         return None
     return d if isinstance(d, dict) else None
+
+
+def _latest_descriptor(scope: Optional[str]) -> Optional[dict]:
+    """Resolve the best image descriptor for a scope.
+
+    Resolution order (W2b):
+      1. Ingested asset — content/worlds/_private/<world>/images/<scope>/wiki_ingest.json
+      2. Generated imagegen cache — <state_dir>/images/<scope>/*.json (newest)
+      3. None → 404
+
+    The cache is rebuildable, never load-bearing — a bad entry is just a miss.
+    """
+    seg = _safe_scope(scope)
+    if not seg:
+        return None
+    # 1. Ingested asset (wiki_images.py output) — takes priority over generated cache
+    ingested = _ingested_descriptor(scope)
+    if ingested is not None:
+        return ingested
+    # 2. Generated imagegen cache (existing behaviour)
+    return _newest_json_descriptor(_images_dir(scope))
 
 
 def _campaign_recency(snap_path: Path) -> float:
@@ -4670,9 +4741,11 @@ class _Handler(BaseHTTPRequestHandler):
         ctype = desc.get("mime_type")
         ctype = ctype if isinstance(ctype, str) and ctype.strip() else "image/png"
         # 1) a real file on disk — ONLY if it's contained under an expected image root
-        # (the derived cache, or the OpenClaw gateway media dir where it writes generated
-        # images). The viewer is the documented "pure reader": a descriptor's `path` must
-        # never let /image serve an arbitrary file (e.g. /etc/passwd) even if tampered.
+        # (the derived cache, the OpenClaw gateway media dir, or the gitignored _private
+        # ingested-art tree). The viewer is the documented "pure reader": a descriptor's
+        # `path` must never let /image serve an arbitrary file (e.g. /etc/passwd) even
+        # if tampered. W2b adds the _private ingested root so wiki_images.py output is
+        # served transparently alongside generated images.
         path = desc.get("path")
         if isinstance(path, str) and path:
             _oh = os.environ.get("OPENCLAW_HOME")
@@ -4680,6 +4753,8 @@ class _Handler(BaseHTTPRequestHandler):
                 _state_dir() / "images",
                 Path(os.environ.get("CLAWDND_OPENCLAW_MEDIA_DIR")
                      or ((Path(_oh) if _oh else Path.home() / ".openclaw") / "media" / "tool-image-generation")),
+                # W2b: ingested wiki art (gitignored _private; never committed).
+                _ingested_images_root(),
             ]
             data = None
             try:


### PR DESCRIPTION
The art SOURCE for the visual layer. `tools/ingest/wiki_images.py` (stdlib, MediaWiki API, polite, --dry-run/--max) fetches item/portrait/scene/map art per a manifest into **gitignored** `content/worlds/_private/<world>/images/<scope>/` with per-file provenance sidecars; `viewer/server.py` `/image` now resolves **ingested asset → imagegen cache → none** (path-traversal-safe root allowlist extended). Official art stays in `_private` (never committed); generated art is the shippable path; `license_check` green.

**Proven end-to-end:** 3 real BG portraits fetched → served via `/image` → 200 with bytes. 27 new offline tests; engine **1383**, viewer **87**, license green. Full-ingest is a documented command the owner runs after review (not auto-run).

Note: manifest scopes (`portrait:<slug>`) need aligning to the UI's `portrait-<character_id>` fetch convention — fast follow-up so ingested portraits render in the screens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Wiki image ingest pipeline: fetch and store images from MediaWiki with licensing and provenance tracking.
  * Ingested images now prioritized in viewer's image serving with improved safety.

* **Documentation**
  * Added image pipeline guide covering configuration and CLI usage.

* **Tests**
  * New test suite for wiki image ingest and viewer image serving.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->