### PR TITLE
graphics: normalize image scopes so ingested wiki art renders

### DIFF
--- a/servers/engine/tests/test_wiki_images.py
+++ b/servers/engine/tests/test_wiki_images.py
@@ -301,6 +301,27 @@ class TestViewerIngestedDescriptor(unittest.TestCase):
         result = _viewer._ingested_descriptor("portrait:shadowheart")
         self.assertIsNotNone(result)
 
+    def test_scope_key_normalizes_prefix_and_separator(self):
+        sk = _viewer._scope_key
+        self.assertEqual(sk("portrait-npc-shadowheart"), "shadowheart")
+        self.assertEqual(sk("portrait:shadowheart"), "shadowheart")
+        self.assertEqual(sk("portrait-shadowheart"), "shadowheart")
+        self.assertEqual(sk("loc-elfsong-tavern"), "elfsong-tavern")
+        self.assertEqual(sk("scene:elfsong-tavern"), "elfsong-tavern")
+        self.assertEqual(sk("npc-the-emperor"), "the-emperor")
+        self.assertEqual(sk(""), "")
+
+    def test_ingested_descriptor_normalized_match(self):
+        # ingested under the manifest slug; the UI fetches the ENGINE-ID scope — must resolve
+        self._write_ingested("baldurs-gate", "portrait:shadowheart")
+        self.assertIsNotNone(_viewer._ingested_descriptor("portrait-npc-shadowheart"))
+        self.assertIsNotNone(_viewer._ingested_descriptor("portrait-shadowheart"))
+        # a scene ingested as scene:<slug>; the UI fetches the location id
+        self._write_ingested("baldurs-gate", "scene:elfsong-tavern")
+        self.assertIsNotNone(_viewer._ingested_descriptor("loc-elfsong-tavern"))
+        # an unrelated scope still misses (no false positives)
+        self.assertIsNone(_viewer._ingested_descriptor("portrait-npc-gibberish"))
+
     def test_empty_scope_returns_none(self):
         self.assertIsNone(_viewer._ingested_descriptor(""))
         self.assertIsNone(_viewer._ingested_descriptor(None))

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -188,6 +188,24 @@ def _ingested_images_root() -> Path:
     return _REPO_ROOT / "content" / "worlds" / "_private"
 
 
+_SCOPE_PREFIXES = {"portrait", "scene", "item", "map", "npc", "char", "pc", "loc", "location", "region", "scope"}
+
+
+def _scope_key(scope: Optional[str]) -> str:
+    """Normalize a scope to a separator/prefix-agnostic NAME key so the UI's engine-id
+    scopes match the ingest manifest's readable slugs (the W2 integration seam): the screens
+    fetch ``portrait-<character_id>`` / ``<location_id>`` while ingested art is keyed
+    ``portrait:<slug>`` / ``scene:<slug>``. Lowercase; unify ``:`` / ``_`` / space to ``-``;
+    drop LEADING kind/entity prefix tokens. e.g. ``portrait-npc-shadowheart`` and
+    ``portrait:shadowheart`` both -> ``shadowheart``; ``loc-elfsong-tavern`` and
+    ``scene:elfsong-tavern`` both -> ``elfsong-tavern``."""
+    s = str(scope or "").lower().replace(":", "-").replace("_", "-").replace(" ", "-")
+    toks = [t for t in s.split("-") if t]
+    while toks and toks[0] in _SCOPE_PREFIXES:
+        toks.pop(0)
+    return "-".join(toks)
+
+
 def _ingested_descriptor(scope: Optional[str]) -> Optional[dict]:
     """Look up a wiki_ingest.json descriptor for scope across ALL world _private dirs.
 
@@ -219,6 +237,30 @@ def _ingested_descriptor(scope: Optional[str]) -> Optional[dict]:
             continue
         if isinstance(d, dict):
             return d
+    # Normalized-key fallback (W2 integration): the UI fetches engine-id scopes
+    # (portrait-<character_id>, <location_id>) while ingested assets are keyed by manifest
+    # slugs (portrait:<slug>, scene:<slug>). When the exact safe-scope dir misses, match by
+    # normalized name-key so wiki art resolves regardless of separator/prefix. Same path
+    # containment guard. This is what makes the render bridge SHOW the ingested portraits.
+    want = _scope_key(scope)
+    if not want:
+        return None
+    for world_dir in root.iterdir():
+        images_dir = world_dir / "images"
+        if not images_dir.is_dir():
+            continue
+        for sub in images_dir.iterdir():
+            desc_path = sub / "wiki_ingest.json"
+            if not desc_path.exists():
+                continue
+            try:
+                if root.resolve() not in desc_path.resolve().parents:
+                    continue
+                d = json.loads(desc_path.read_text(encoding="utf-8"))
+            except (ValueError, OSError):
+                continue
+            if isinstance(d, dict) and _scope_key(d.get("scope")) == want:
+                return d
     return None
 
 


### PR DESCRIPTION
## Summary
The W2 graphics sprint shipped two halves built by separate agents that didn't quite meet:
- The **render bridge** (`<Img scope=…>`) fetches **engine-id scopes** — `portrait-<character_id>`, `<location_id>`.
- The **wiki-image ingest** (`tools/ingest/wiki_images.py` + `manifest_images.json`) keys assets by **manifest slug** — `portrait:<slug>`, `scene:<slug>`.

So ingested portraits/scenes never matched and always fell through to the `<Placeholder>`. This PR is the integration seam that makes ingested wiki art actually show.

- Add `_scope_key()` to `viewer/server.py`: lowercase; unify `:`/`_`/space → `-`; drop leading kind/entity prefix tokens (`portrait`, `npc`, `loc`, `scene`, …). So `portrait-npc-shadowheart` and `portrait:shadowheart` both → `shadowheart`; `loc-elfsong-tavern` and `scene:elfsong-tavern` both → `elfsong-tavern`.
- Add a normalized-key fallback in `_ingested_descriptor()`: after the exact safe-scope dir misses, scan `_private/<world>/images/*/wiki_ingest.json` and match on the normalized name. Same path-containment guard preserved.

## Test plan
- [x] `pytest tests/test_wiki_images.py` — 29 passed (2 new: `_scope_key` unit + normalized-match integration)
- [x] viewer suite — 87 passed
- [x] `scripts/license_check.py` — green (no `_private`/copyrighted assets committed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced scope normalization for ingested images, allowing flexible scope formats (colon vs dash separators, various prefixes) to correctly resolve to portrait and scene assets.

* **Tests**
  * Added comprehensive test coverage for scope key normalization and descriptor lookup with various scope format variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->