### PR TITLE
docs: 1.0 release prep — README quickstart, CHANGELOG, release checklist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,45 +1,184 @@
 # Changelog
 
-All notable changes to ClawDnD. ClawDnD's code is MIT; world seeds are licensed
-separately (see `content/worlds/README.md`).
+All notable changes to ClawDnD are documented here.
+[Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
+ClawDnD's code is MIT; world seeds are licensed separately (see `content/worlds/README.md`).
 
-## 0.2.0 — The Living-World Generative Engine
+---
+
+## [Unreleased]
+
+Nothing queued yet.
+
+---
+
+## [1.0.0] — 2026-05-27
+
+**The Living-World Engine — release milestone.** This release rounds off the deterministic
+5e engine, completes the Quest & Arc generative layer, ships a second original CC-BY world
+(*The Tidal Commonwealth*), and makes the OpenWorlds native macOS app a playable read-model
+with image rendering. 1.0 is a local/personal build; public distribution and notarization
+are deferred to 1.0.1.
+
+### Added
+
+**Combat engine (SRD 5.2)**
+
+- Monster **Multiattack** — enforced in the attack economy; authoritative to-hit surfaced
+  at `start_combat`.
+- Monster **Parry** defensive reactions — auto-applied when the reaction flips a hit to a
+  miss; DM narrates the deflection.
+- **Grapple / shove / escape** resolver (SRD 5.2 save-based).
+- **Surprise-attack** affordance on `start_combat` + combat-init doctrine.
+- **Battle Master maneuver die** — rolled into the triggering attack's damage.
+- **Multi-component attack damage** and Multiattack composition hardened.
+- End-of-turn **repeat saves** auto-enforced so save-ends conditions never lock forever.
+- **Guiding Bolt** advantage rider auto-granted and consumed on hit (not on cast).
+- `turn_brief` surfaced on every `next_turn` call; Round-1 turn-skip guard enforced.
+- Crit narration cites the actual source, not a blanket "nat 20".
+
+**Spellcasting**
+
+- All 339 SRD spells handled by `cast_spell`; slot management, upcasting, concentration
+  binding, and save-vs-attack resolution.
+
+**Quest & Arc engine (three-layer)**
+
+- **Layer 1 — Rule-of-three quest evolution**: `Quest.evolves_to` + `callback_in_days`
+  schedules follow-on consequences so no setup is left dangling.
+- **Layer 2 — Decision-gated companion flips**: player choices accumulate weight; a
+  betrayal roll fires only above the attitude threshold, telegraphed by warning bands.
+- **Layer 3 — First-class Events**: `ParleyOption` / `Outcome` pairs carry deterministic
+  engine outcomes (flags, reputation shifts, scheduled consequences) wired to the DM's
+  beat loop.
+- **Faction-growth arcs**: the join → grow → lead loop (`faction_arc.py`).
+- Living-story trio wired into the DM skill and seeded with canon exemplar content.
+- Betrayal modelled as a **rising probability roll** gated by attitude value (not a hard
+  threshold).
+
+**Living-world layer**
+
+- `world_tick` background world-sim: standing threads advance on the day clock
+  (auto-fired by `travel_to` / `downtime`), one beat at a time.
+- `lookup_lore` FTS over per-world `lore/` corpus; authored pages (tier 0) outrank
+  ingested wiki pages (tier 1); `era` / chronology surfaced per hit.
+- `recall` / `recall_npc` / `recall_decisions` campaign-memory ledger (FTS5 over
+  snapshot + session logs); derived, rebuildable, deletable.
+- Campaign Director + Scene-Debt advisory wired into the beat loop; `add_quest` went
+  from rare to automatic.
+- Typed multi-resolution **wandering encounters** (combat / skill / social / hazard / boon).
+- **Parley scaffold** + `encounter_outlook` + balancing doctrine.
+- `record_decision` / `adjust_reputation` / `add_consequence` (time-deferred consequences).
+- `add_location` live world-building with orphan/duplicate warnings.
+- **Campaign calendar** display projection.
+- Tolerant store load — unknown top-level keys dropped so old saves survive future schema
+  changes.
+- Settlement pressure read-model skeleton; worldgraph atlas graph metadata skeleton;
+  bestiary authored monster metadata skeleton; private compendium sidecar scaffold.
+
+**Worlds shipped**
+
+- *The Sundered Reach* (original, CC-BY-4.0) — the default world, six authored lore pages.
+- *Unofficial Baldur's Gate 3+ Universe Seed* (free, unofficial Fan Content — Wizards Fan
+  Content Policy + Larian; never sold) — 248-page ingested wiki corpus, 5 navigable
+  post-BG3 areas, mid-tier monster pack, canon BG events / faction arcs / companion seams.
+- *The Tidal Commonwealth* (original, CC-BY-4.0) — a second original world as a
+  generativity spike; geographic texture (Saltmere, Ironhull, Vethis); playable depth.
+- **Base-world companion arcs** — a companion who can turn, functional in any world seed.
+
+**OpenWorlds native macOS app**
+
+- SwiftUI shell (`macos/ClawDnDApp/`) — `script/build_and_run.sh` builds and launches an
+  ad-hoc-signed app bundle.
+- **Image render bridge** (`/image` endpoint) — generated and ingested art shown in Atlas,
+  Parley, inventory (item icons), character/table portrait, and scene-art screens.
+- Five OpenWorlds screens wired to live engine read-models: map/atlas, party, quests,
+  event feed, combat command center.
+- Companion camp beat history, acts chronicle, betrayal-warning, and quest-evolution
+  callbacks surfaced in read-models.
+- CapabilityBadge preview banners on display-only screens.
+
+**Voice**
+
+- Kokoro TTS (local, free, multi-voice) default; ElevenLabs and null backends swappable
+  via `CLAWDND_TTS_BACKEND`.
+- Per-character `voice_id` mapping; reliable text-only fallback.
+- STT seam in place (`SttBackend` interface); no live backend yet — you type your turn.
+
+**Play surface**
+
+- Interactive play dashboard (`scripts/play.sh` / `clawdnd-play.command`): acts through
+  Say / Do / Continue / dice / combat buttons and click-to-travel; DM resolves each move
+  via the engine and renders the next beat live. Safety-capped (per-turn budget, session
+  ceiling, turn cap).
+- `clawdnd-dashboard.command` — read-only director's view for watching a running game.
+- Desktop shortcut installed by `scripts/install-desktop-shortcut.sh`.
+- Beat-aware DM loop with midpoint/climax runbooks scaling to the play cap.
+
+**QA**
+
+- Behavioral gate (`assert_behavioral.py`) — deterministic PASS/FAIL on structural
+  integrity (turns taken, world progressed, player didn't narrate the world, companions
+  spoke, combat closed cleanly, no dangling conditions).
+- Tolkien story-craft lens (≈ 4.1–4.2 / 5, prestige fantasy) + mechanical lens
+  (target ≥ 4.5) + 5e-fidelity Angry-DM adversarial lens.
+- Fast combat-sprint lane + scoped behavioral gate.
+- Parallel retry-hardened QA harness; GPT-5.4 cross-check scorer.
+- `qa/SCORECARD.md` running ledger; `qa/SCORING.md` rubric.
+- ~353 engine tests (pytest) green in CI; 17 QA distill tests.
+
+### Changed
+
+- DM skill upgraded to "Generating a world live" mode: beat cycle, per-turn Director
+  consultation, storytelling craft bar (antagonist warmth-first, felt menace, the
+  unforgettable beat).
+- Bestiary multi-directory first-wins layout (content-pack foundation).
+- Engine schema hardened (`extra="forbid"` on all Pydantic v2 models).
+- Quest variants resolved once at world-gen from `world.json` seed (`quest_variants`
+  weighted matrices with documented rarity bands).
+- Viewer shifted from read-only to interactive play surface.
+
+### Fixed
+
+- Multiattack enforcement: engine *refuses* the wrong move in the attack economy.
+- Battle Master maneuver die was previously omitted from attack damage.
+- Multi-component attack damage accumulation.
+- End-of-turn repeat saves for save-ends conditions (e.g. Hold Person).
+- Guiding Bolt advantage rider applied on hit, not on cast.
+- PC turn-skip guard enforced in `next_turn`.
+- Dice count/sides clamped to stop pathological rolls hanging the engine.
+- Store tolerant-load so unknown top-level keys never brick an old save.
+- Crit narration now cites the actual crit source.
+
+---
+
+## [0.2.0] — Living-World Generative Engine
 
 The pivot: the AI DM now **generates an epic story live inside a persistent,
-canon-anchored world**, rather than only running pre-authored modules. Story quality is
-scored on a "Tolkien" story-craft lens (living-world play ≈ 4.1–4.2 / 5, prestige fantasy).
+canon-anchored world**, rather than only running pre-authored modules.
 
 - **World seeds** — `start_world(world_id)` seeds a campaign from a world bible
-  (`content/worlds/<id>/world.json`: regions, factions, NPC roster, history, `era`,
-  standing threads). `resume=` continues a world instead of orphaning it.
-- **On-demand lore** — `lookup_lore` (FTS over a per-world `lore/` corpus); authored
-  canon outranks ingested wiki pages; per-page `era`/chronology surfaced.
-- **Campaign memory** — `recall` / `recall_npc` / `recall_decisions` (FTS over
-  snapshot + session logs), a derived, rebuildable index (the anti-mush guardrail).
-- **Background world-sim** — `world_tick` ticks standing threads on the day clock
-  (auto-fired by `travel_to`/`downtime`), one beat at a time.
-- **Wiki-ingestion pipeline** — `tools/ingest/` (offline, stdlib) builds lore corpora
-  from a MediaWiki/Fandom source (CC-BY-SA); ships a 248-page Baldur's Gate corpus.
-- **Authored-scene craft** — `get_scene` surfaces read_aloud/dm_notes; `add_location`
-  (live world-building with orphan/dup warnings); `record_decision`; `adjust_reputation`.
-- **Companion** — `companion_advise` + an explicit party-deliberation loop; depth
-  guidance (a wound, lingering disagreement).
-- **Read-only play-view** (`viewer/`) — map/party/quests/event feed. Hex + fallback maps.
-- **Front door** — `/world-list`, `/world-play`, `/world-new` commands + a `world-author`
-  skill + `content/worlds/README.md` schema doc.
-- **QA** — the "Tolkien" story-craft lens + a parallel, retry-hardened QA harness.
-- **Worlds shipped** — *The Sundered Reach* (original, CC-BY-4.0) and the *Unofficial
-  Baldur's Gate 3+ Universe Seed* (free, unofficial Fan Content).
-- **DM skill** — the beat cycle, a "Generating a world live" mode, and a storytelling
-  craft bar (stage the antagonist warmth-first, felt menace, the unforgettable beat).
+  (`content/worlds/<id>/world.json`).
+- **On-demand lore** — `lookup_lore` (FTS over a per-world `lore/` corpus).
+- **Campaign memory** — `recall` / `recall_npc` / `recall_decisions`.
+- **Background world-sim** — `world_tick` ticks standing threads on the day clock.
+- **Wiki-ingestion pipeline** — `tools/ingest/` builds lore corpora from MediaWiki/Fandom
+  (CC-BY-SA); ships a 248-page Baldur's Gate corpus.
+- **Authored-scene craft** — `get_scene`, `add_location`, `record_decision`,
+  `adjust_reputation`.
+- **Companion** — `companion_advise` + party-deliberation loop.
+- **Read-only play-view** (`viewer/`) — map / party / quests / event feed.
+- **Front door** — `/world-list`, `/world-play`, `/world-new` + `world-author` skill.
+- **Worlds shipped** — *The Sundered Reach* (CC-BY-4.0) and the *Unofficial BG3+ Universe
+  Seed* (free Fan Content).
+- QA harness with Tolkien story-craft lens.
 
-## 0.1.0 — Tier-1 feature-complete
+## [0.1.0] — Tier-1 Feature-Complete
 
-- Three MCP servers (engine, rules, voice). Dice (advantage/crit, roll ledger),
-  characters & leveling, combat + action economy, all-339-spell casting, rests,
-  inventory/economy, NPC memory + check-gated social, exploration/travel, encounters,
-  multi-session persistence + "Previously on…" recaps, time-deferred consequences, a
-  multi-act arc generator.
-- Bundled SRD 5.2.1 (CC-BY-4.0) + bestiary. Original adventures ("The Cellar Rats",
-  "The Embergloom Pact"). Voice (Kokoro/ElevenLabs/null) + STT seam.
-- Player slash-commands, README, MIT license + third-party notices.
+Three MCP servers (engine, rules, voice). Dice (advantage/crit, roll ledger), characters
+and leveling, combat and action economy, all-339-spell casting, rests, inventory/economy,
+NPC memory and check-gated social, exploration/travel, encounters, multi-session
+persistence and "Previously on…" recaps, time-deferred consequences, a multi-act arc
+generator. Bundled SRD 5.2.1 (CC-BY-4.0) and bestiary. Original adventures ("The Cellar
+Rats", "The Embergloom Pact"). Voice (Kokoro / ElevenLabs / null) and STT seam. Player
+slash commands, README, MIT license and third-party notices.

--- a/README.md
+++ b/README.md
@@ -110,10 +110,11 @@ git clone https://github.com/100yenadmin/ClawDnD.git
 cd ClawDnD
 ```
 
-Then inside Claude Code:
+Then inside Claude Code, register the local marketplace and install the plugin:
 
 ```
-/plugin install .
+/plugin marketplace add .
+/plugin install clawdnd@clawdnd
 ```
 
 Claude Code reads `.claude-plugin/plugin.json` and `.mcp.json`, starts the three MCP

--- a/README.md
+++ b/README.md
@@ -93,21 +93,96 @@ The DM loop is **safety-capped** so it can't run away: a per-turn budget, a whol
 
 > Not to be confused with `clawdnd-dashboard.command`, the read-only **director's view** — it *watches* a game (live or a QA run) without an action palette. `clawdnd-play.command` is the one that lets you *play*.
 
-## Requirements
+## Quick start — install, create a character, play your first session
 
-- [Claude Code](https://claude.ai/code)
-- [`uv`](https://docs.astral.sh/uv/) (manages the Python servers; auto-provisions Python 3.12)
-- macOS / Apple Silicon recommended for the local Kokoro voice (works elsewhere too)
+### 1. Requirements
 
-## Install (dev)
+- **[Claude Code](https://claude.ai/code)** (the host shell)
+- **[`uv`](https://docs.astral.sh/uv/)** — manages the three Python MCP servers; auto-provisions Python 3.12. Install with `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+- macOS / Apple Silicon recommended for Kokoro local voice (works on Linux too; Kokoro requires a one-time model download).
+
+### 2. Install the plugin
+
+Clone the repo and register it with Claude Code in a single step:
 
 ```bash
 git clone https://github.com/100yenadmin/ClawDnD.git
 cd ClawDnD
-# In Claude Code:
-/plugin marketplace add 100yenadmin/ClawDnD
-/plugin install clawdnd@clawdnd
 ```
+
+Then inside Claude Code:
+
+```
+/plugin install .
+```
+
+Claude Code reads `.claude-plugin/plugin.json` and `.mcp.json`, starts the three MCP
+servers (`clawdnd-engine`, `clawdnd-rules`, `clawdnd-voice`) via `uv`, and the plugin
+is live for the session.
+
+### 3. Create a character and begin
+
+In Claude Code, start your first living-world session:
+
+```
+/world-list          ← see the available worlds
+/world-play sundered-reach   ← drop into The Sundered Reach (original, CC-BY)
+```
+
+The DM generates your character (level 3, class and concept fitted to the world), opens
+a scene grounded in the world's canon, introduces your **voiced AI companion**, and hands
+you an open moment to act on. You type your moves; the engine resolves them
+deterministically; the DM narrates and voices every character.
+
+Other worlds:
+- `baldurs-gate` — the Unofficial BG3+ Universe Seed (free Fan Content)
+- `tidal-commonwealth` — The Tidal Commonwealth (original, CC-BY)
+
+Or start a scripted campaign: `/campaign-new [name]` then `/session-start [id]`.
+
+### 4. Play surfaces
+
+**Option A — play in Claude Code** (type your turns in chat):
+
+```
+/world-play sundered-reach
+```
+
+**Option B — play in the browser dashboard** (action palette + live DM beside it):
+
+```bash
+# Double-click the desktop shortcut (after scripts/install-desktop-shortcut.sh), or:
+./clawdnd-play.command            # default world (baldurs-gate)
+scripts/play.sh sundered-reach    # specific world
+```
+
+Your browser opens to `http://127.0.0.1:8765/dashboard`. Act through **Say**, **Do**,
+**Continue**, the dice / skill / save / combat buttons, and click-to-travel. The DM
+resolves each move through the engine and narrates the next beat live.
+
+**Option C — native macOS app** (OpenWorlds — build from source):
+
+```bash
+script/build_and_run.sh           # builds with Swift, ad-hoc signs, opens the app
+```
+
+The app (`macos/ClawDnDApp/`) hosts the same read-model screens (atlas, party, quests,
+event feed, combat, portrait art) as live engine read-models. Requires macOS 13+ and
+`swift` in your PATH (Xcode Command Line Tools).
+
+### 5. Voice
+
+Voice is on by default (Kokoro local TTS, multi-voice, free). Toggle it mid-session:
+
+```
+/voice-toggle off    ← text-only fallback
+/voice-toggle on     ← voiced narration + per-character voices
+```
+
+Kokoro runs on-device; no API key needed. ElevenLabs can drop in later via
+`CLAWDND_TTS_BACKEND=elevenlabs` without touching anything else.
+
+---
 
 ## Licensing
 

--- a/docs/RELEASE_1.0_CHECKLIST.md
+++ b/docs/RELEASE_1.0_CHECKLIST.md
@@ -1,0 +1,157 @@
+# ClawDnD 1.0.0 — Release Checklist
+
+**Scope:** local/personal 1.0 build. The bundled `baldurs-gate` world ships as-is for
+personal use (Wizards Fan Content Policy). Public distribution and notarization are
+deferred to 1.0.1 (see `macos/ClawDnDApp/RELEASE_CHECKLIST.md` for the signing state).
+
+Do NOT execute steps here until the pre-release sanity checks below are green.
+
+---
+
+## Pre-release sanity checks (run first)
+
+- [ ] **Engine tests green in CI.** Confirm the latest commit on `main` has a passing
+  GitHub Actions run. Check with:
+  ```bash
+  gh run list --branch main --limit 5
+  gh run view <run-id>
+  ```
+  The engine pytest suite currently collects ~353 tests across `servers/engine/tests/`,
+  `servers/rules/tests/`, `servers/voice/tests/`, and `qa/`.
+
+- [ ] **License check passes locally.**
+  ```bash
+  python3 scripts/license_check.py
+  ```
+  Must print `license check passed`. All three world seeds (`sundered-reach`,
+  `tidal-commonwealth`, `baldurs-gate`) must have a `LICENSE.md` beside their
+  `world.json`.
+
+- [ ] **Played session verified.** Run one living-world session end-to-end and confirm:
+  - The DM opens a world, introduces a companion, and delivers an opening scene.
+  - At least one combat encounter resolves (attack roll → damage → HP updated).
+  - `/save` writes a `state/` checkpoint; `/session-start` reloads it with a recap.
+  - Voice plays (or `/voice-toggle off` text fallback works).
+  - Dashboard play surface works: `scripts/play.sh sundered-reach` opens a browser and
+    the action palette accepts a Say / Do move.
+
+- [ ] **Native app builds.** From a clean checkout:
+  ```bash
+  script/build_and_run.sh
+  ```
+  Confirm `ClawDnD.app` launches in `dist/` and the OpenWorlds screens load.
+
+---
+
+## Step 1 — bump the plugin version to 1.0.0
+
+File: `.claude-plugin/plugin.json`
+
+Change `"version": "0.2.0"` to `"version": "1.0.0"`.
+
+```bash
+# Edit manually, then verify:
+python3 -c "import json; d=json.load(open('.claude-plugin/plugin.json')); assert d['version']=='1.0.0'"
+```
+
+Also update `.claude-plugin/marketplace.json` if it carries a version field.
+
+---
+
+## Step 2 — commit the version bump
+
+```bash
+cd /path/to/ClawDnD          # your local checkout (not a QA worktree)
+git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+git commit -m "chore: bump version to 1.0.0"
+git push origin main
+```
+
+Wait for CI to go green on that commit before tagging.
+
+---
+
+## Step 3 — tag v1.0.0
+
+```bash
+git tag -a v1.0.0 -m "ClawDnD 1.0.0 — local/personal release"
+git push origin v1.0.0
+```
+
+---
+
+## Step 4 — create the GitHub release
+
+Extract the 1.0.0 section from `CHANGELOG.md` into a temp file for the release notes,
+then publish:
+
+```bash
+gh release create v1.0.0 \
+  --title "ClawDnD 1.0.0 — Living-World Engine" \
+  --notes-file <(awk '/^\[1\.0\.0\]/{found=1} found && /^\[0\.[0-9]/{exit} found{print}' CHANGELOG.md) \
+  --draft
+```
+
+Review the draft on GitHub (`gh release view v1.0.0 --web`), then publish:
+
+```bash
+gh release edit v1.0.0 --draft=false
+```
+
+No binary artifacts are attached for this local build. If you want to ship a zip of
+`dist/ClawDnD.app` for personal archival:
+
+```bash
+script/build_and_run.sh   # builds dist/ClawDnD.app
+cd dist && zip -r ClawDnD-1.0.0-macos.zip ClawDnD.app
+gh release upload v1.0.0 ClawDnD-1.0.0-macos.zip
+```
+
+---
+
+## Step 5 — build-from-source app (final smoke)
+
+```bash
+script/build_and_run.sh            # default: build + open
+script/build_and_run.sh --verify   # build + open + confirm process alive
+script/build_and_run.sh --release-check  # build + codesign audit
+```
+
+The script lives at `script/build_and_run.sh` (Swift build → bundle → ad-hoc sign →
+open). Requires macOS 13+, Xcode Command Line Tools (`xcode-select --install`).
+
+Signing state at 1.0: ad-hoc only. Gatekeeper will warn on first launch — right-click →
+Open to bypass. Full Developer ID signing + notarization is a 1.0.1 item (see
+`macos/ClawDnDApp/RELEASE_CHECKLIST.md`).
+
+---
+
+## 1.0 scope decisions (record for 1.0.1 planning)
+
+| Item | 1.0 disposition | Deferred to |
+|---|---|---|
+| `baldurs-gate` world seed | **Ships** for personal use (Fan Content Policy) | — |
+| Public distribution / App Store | Not in scope | 1.0.1 |
+| Developer ID signing | Not in scope | 1.0.1 |
+| Notarization | Not in scope | 1.0.1 |
+| ElevenLabs TTS backend | Stub present; not default | Later |
+| STT / voice input | Seam present; no live backend | Later |
+| Tier-2 OpenClaw companion fork | Seam present; not wired | Tier-2 milestone |
+
+---
+
+## Reference paths
+
+| Artifact | Path |
+|---|---|
+| Plugin manifest | `.claude-plugin/plugin.json` |
+| Marketplace metadata | `.claude-plugin/marketplace.json` |
+| MCP server config | `.mcp.json` |
+| Engine server | `servers/engine/server.py` |
+| Build script (macOS app) | `script/build_and_run.sh` |
+| Play dashboard script | `scripts/play.sh` |
+| License check | `scripts/license_check.py` |
+| Changelog | `CHANGELOG.md` |
+| Native app package | `macos/ClawDnDApp/Package.swift` |
+| World seeds | `content/worlds/{sundered-reach,tidal-commonwealth,baldurs-gate}/` |
+| App source | `macos/ClawDnDApp/Sources/ClawDnDApp/` |


### PR DESCRIPTION
## Summary
W5 release-mechanics docs for the local 1.0:
- **README** — install → create a character → play your first session quickstart. Corrects the local-install command to the marketplace flow (`/plugin marketplace add .` + `/plugin install clawdnd@clawdnd`); `/plugin install .` is not valid since the repo ships `.claude-plugin/marketplace.json`.
- **CHANGELOG** — a dated `[1.0.0]` section documenting the living-world engine, OpenWorlds visual layer, and combat fidelity; `[Unreleased]` kept above it.
- **docs/RELEASE_1.0_CHECKLIST.md** — the runbook to actually cut 1.0.0 (bump `plugin.json` 0.2.0→1.0.0, tag, GitHub release). plugin.json stays 0.2.0 until that step.

Docs-only; no code paths touched.

## Test plan
- [x] verified install commands against `.claude-plugin/{marketplace,plugin}.json` (names: marketplace `clawdnd`, plugin `clawdnd`) and `.mcp.json` server names (`clawdnd-engine/-rules/-voice`)
- [x] rebased clean onto main @ 8363ed8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added quick-start guide covering installation, character creation, and first-session setup with voice command toggles and platform support
  * Enhanced changelog with comprehensive 1.0.0 release notes detailing features and improvements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->