### PR TITLE
openworlds: render-bridge art gaps + 5e fidelity + honesty fixes

### DIFF
--- a/tools/ingest/manifest_images.json
+++ b/tools/ingest/manifest_images.json
@@ -33,7 +33,7 @@
         {"title": "The Dark Urge",        "scope": "portrait:the-dark-urge",   "kind": "portrait"},
 
         {"title": "Elfsong Tavern",       "scope": "scene:elfsong-tavern",     "kind": "scene"},
-        {"title": "Lower City",           "scope": "scene:baldurs-gate",       "kind": "scene"},
+        {"title": "Lower City",           "scope": "scene:lower-city",         "kind": "scene"},
         {"title": "Moonrise Towers",      "scope": "scene:moonrise-towers",    "kind": "scene"},
         {"title": "Wyrm's Rock Fortress", "scope": "scene:wyrms-rock",         "kind": "scene"},
         {"title": "Candlekeep",           "scope": "scene:candlekeep",         "kind": "scene", "_flag": "lead image is wrong — needs explicit file. Candlekeep does not appear in BG3; the bg3.wiki page's lead is a 70px character-portrait icon, not a location still. No in-game Candlekeep scene exists on the wiki."},

--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -255,7 +255,7 @@ function capabilityForScreen(screen, nativeState) {
       ? { label: "Wired", tone: "emerald", detail: "Native bridge ready" }
       : { label: "Unavailable", tone: "crimson", detail: "Native bridge missing" };
   }
-  if (["launcher", "table", "combat", "map", "journal", "character", "inventory", "relations"].includes(screen)) {
+  if (["launcher", "table", "combat", "map", "journal", "character", "inventory", "relations", "acts"].includes(screen)) {
     return { label: "Wired", tone: "emerald", detail: "Backed by viewer read models" };
   }
   if (screen === "dialogue") {

--- a/viewer/openworlds/camp-sidebar.jsx
+++ b/viewer/openworlds/camp-sidebar.jsx
@@ -212,7 +212,7 @@ function CampSidebar({ state, onExit, onBeginRest, onTalk, talkPartner }) {
                     opacity: isDragging ? 0.4 : 1,
                   }}
                 >
-                  <Placeholder label={p.short || "portrait"} w="100%" h={56} framed />
+                  <Img scope={p.id ? "portrait-" + p.id : ""} label={p.short || "portrait"} w="100%" h={56} framed />
                 </button>
                 <div className="hand" style={{ fontSize: 10, marginTop: 2, color: "var(--ink-700)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
                   {p.name.split(" ")[0]}
@@ -347,7 +347,7 @@ function RoleSlot({ icon, label, summary, summaryValue, detail, hero, onDrop, on
       <div style={{ position: "relative" }}>
         {hero ? (
           <>
-            <Placeholder label={hero.short || "portrait"} w={56} h={68} framed />
+            <Img scope={hero.id ? "portrait-" + hero.id : ""} label={hero.short || "portrait"} w={56} h={68} framed />
             <button onClick={onClear} style={{
               position: "absolute", top: -6, right: -6,
               width: 18, height: 18, borderRadius: "50%",
@@ -410,7 +410,7 @@ function WatchSlot({ num, hero, value, onDrop, onClear, onDragOver }) {
       }}>{num}</span>
       {hero ? (
         <>
-          <Placeholder label={hero.short || "portrait"} w="100%" h={60} framed />
+          <Img scope={hero.id ? "portrait-" + hero.id : ""} label={hero.short || "portrait"} w="100%" h={60} framed />
           <div className="hand" style={{ fontSize: 11, marginTop: 4, color: "var(--ink-700)" }}>
             {hero.name.split(" ")[0]} <span style={{ color: "var(--emerald)" }}>{value}</span>
           </div>
@@ -444,7 +444,7 @@ function SpecialRoleRow({ hero, role }) {
       background: "rgba(176,141,87,0.06)",
       boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)",
     }}>
-      <Placeholder label={hero.short || "portrait"} w={44} h={54} framed />
+      <Img scope={hero.id ? "portrait-" + hero.id : ""} label={hero.short || "portrait"} w={44} h={54} framed />
       <div>
         <div className="eyebrow" style={{ color: "var(--ink-700)", fontSize: 9 }}>{hero.name.split(" ")[0]}</div>
         <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.06em", color: "var(--ink-900)", marginTop: 2 }}>
@@ -498,7 +498,7 @@ function TalkPanel({ hero, onClose }) {
       <div style={{
         display: "grid", gridTemplateColumns: "60px 1fr", gap: 10, marginBottom: 10,
       }}>
-        <Placeholder label={hero.short || "portrait"} w={60} h={72} framed />
+        <Img scope={hero.id ? "portrait-" + hero.id : ""} label={hero.short || "portrait"} w={60} h={72} framed />
         <div className="body" style={{ color: "var(--p-200)", fontSize: 14, fontStyle: "italic", lineHeight: 1.4 }}>
           <span style={{ color: "var(--crimson-bright)", fontSize: 22, fontFamily: "var(--f-display)" }}>"</span>
           {reply ? reply.heroReply : conv.openingPrompt}

--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -166,12 +166,10 @@ function ScreenCharacter({ onNavigate, state, setState }) {
 
             <div className="eyebrow" style={{ marginTop: 4 }}>Attack</div>
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 4, marginTop: 8 }}>
-              <StatLine k="Base Attack" v={`+${hero.stats.bab}`} />
-              <StatLine k="Initiative" v={`+${hero.stats.initiative}`} />
-              <StatLine k="Melee" v={`+${hero.stats.melee}`} />
-              <StatLine k="Ranged" v={`+${hero.stats.ranged}`} />
-              <StatLine k="CMB" v={`+${hero.stats.cmb}`} />
-              <StatLine k="CMD" v={hero.stats.cmd} />
+              <StatLine k="Proficiency" v={`+${hero.stats.proficiency_bonus}`} />
+              <StatLine k="Initiative" v={`${hero.stats.initiative >= 0 ? "+" : ""}${hero.stats.initiative}`} />
+              <StatLine k="Melee" v={`${hero.stats.melee >= 0 ? "+" : ""}${hero.stats.melee}`} />
+              <StatLine k="Ranged" v={`${hero.stats.ranged >= 0 ? "+" : ""}${hero.stats.ranged}`} />
             </div>
 
             <Divider />
@@ -179,11 +177,19 @@ function ScreenCharacter({ onNavigate, state, setState }) {
             <div className="eyebrow">Defense</div>
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 4, marginTop: 8 }}>
               <StatLine k="AC" v={hero.stats.ac} />
-              <StatLine k="Flat" v={hero.stats.flat} />
-              <StatLine k="Touch" v={hero.stats.touch} />
-              <StatLine k="Fort" v={`+${hero.stats.fort}`} />
-              <StatLine k="Reflex" v={`+${hero.stats.reflex}`} />
-              <StatLine k="Will" v={`+${hero.stats.will}`} />
+              <StatLine k="Speed" v={`${hero.stats.speed} ft`} />
+            </div>
+
+            <Divider />
+
+            {/* 5e saving throws: one per ability (mod + proficiency where proficient),
+                computed by the engine read-model (server _character_sheet). */}
+            <div className="eyebrow">Saving Throws</div>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 4, marginTop: 8 }}>
+              {["STR","DEX","CON","INT","WIS","CHA"].map((s) => {
+                const v = (hero.stats.saves || {})[s.toLowerCase()] ?? 0;
+                return <StatLine key={s} k={s} v={`${v >= 0 ? "+" : ""}${v}`} />;
+              })}
             </div>
 
             <Divider />

--- a/viewer/openworlds/screen-dialogue.jsx
+++ b/viewer/openworlds/screen-dialogue.jsx
@@ -169,7 +169,7 @@ function ParleyMenu({ surface, slots, difficulty, setDifficulty, history, setHis
 
             {/* Actor portrait (left) */}
             <div style={{ padding: 14, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", borderRight: "1px solid rgba(140,100,60,0.35)" }}>
-              <Placeholder label="portrait" w={120} h={150} framed />
+              <Img scope={surface.event?.anchor_npc_id ? "portrait-" + surface.event.anchor_npc_id : ""} label={actorName} w={120} h={150} framed />
               <div style={{ marginTop: 8, fontFamily: "var(--f-display)", fontSize: 13, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--ink-900)", textAlign: "center" }}>
                 {actorName}
               </div>
@@ -410,7 +410,7 @@ function ScreenDialogueDemo({ onNavigate, state, status }) {
 
             {/* Listener (right) */}
             <div style={{ padding: 14, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", borderLeft: "1px solid rgba(140,100,60,0.35)" }}>
-              <Placeholder label={listener.short} w={120} h={150} framed />
+              <Img scope={listener.id ? "portrait-" + listener.id : ""} label={listener.short} w={120} h={150} framed />
               <div style={{ marginTop: 8, fontFamily: "var(--f-display)", fontSize: 13, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--ink-900)", textAlign: "center" }}>
                 {listener.name}
               </div>

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -112,7 +112,7 @@ function ScreenInventory({ onNavigate, state, setState }) {
 
         {/* Hero portrait + slots */}
         <div style={{ position: "relative", marginTop: 16, padding: "0 8px" }}>
-          <Placeholder label={`${hero.short} · full art`} h={220} framed style={{ width: "100%" }} />
+          <Img scope={hero.id ? "portrait-" + hero.id : ""} label={`${hero.short} · full art`} h={220} framed style={{ width: "100%" }} />
 
           {/* Equipment slots ringing portrait */}
           <div style={{ display: "grid", gridTemplateColumns: "repeat(6, 1fr)", gap: 6, marginTop: 10 }}>
@@ -245,13 +245,13 @@ function ScreenInventory({ onNavigate, state, setState }) {
           onClose={() => setCtxMenu(null)}
           items={[
             { label: "Examine", icon: "◈", hint: "E", onClick: () => toast({ kind: "item", title: ctxMenu.item.name, body: ctxMenu.item.desc }) },
-            { label: "Equip", icon: "⚔", hint: "Q", disabled: !ctxMenu.item.slot, onClick: () => toast({ kind: "item", title: "Equipped: " + ctxMenu.item.name, body: hero.name + " takes it up." }) },
-            { label: "Use", icon: "✦", disabled: ctxMenu.item.type !== "spell", onClick: () => toast({ kind: "item", title: "Used: " + ctxMenu.item.name }) },
+            { label: "Equip (preview)", icon: "⚔", hint: "Q", disabled: true, title: "Display-only — not saved to the engine", onClick: () => toast({ kind: "item", title: "Equipped: " + ctxMenu.item.name, body: hero.name + " takes it up." }) },
+            { label: "Use (preview)", icon: "✦", disabled: true, title: "Display-only — not saved to the engine", onClick: () => toast({ kind: "item", title: "Used: " + ctxMenu.item.name }) },
             { divider: true },
-            { label: "Give to " + hero.name.split(" ")[0], icon: "→", onClick: () => toast({ kind: "item", title: ctxMenu.item.name + " given to " + hero.name }) },
-            { label: "Mark as trash", icon: "◌", onClick: () => toast({ title: "Marked: " + ctxMenu.item.name }) },
+            { label: "Give to " + hero.name.split(" ")[0] + " (preview)", icon: "→", disabled: true, title: "Display-only — not saved to the engine", onClick: () => toast({ kind: "item", title: ctxMenu.item.name + " given to " + hero.name }) },
+            { label: "Mark as trash (preview)", icon: "◌", disabled: true, title: "Display-only — not saved to the engine", onClick: () => toast({ title: "Marked: " + ctxMenu.item.name }) },
             { divider: true },
-            { label: "Drop", icon: "▾", tone: "crimson", onClick: () => toast({ kind: "danger", title: "Dropped: " + ctxMenu.item.name, body: "You will not get it back unless you fetch it yourself." }) },
+            { label: "Drop (preview)", icon: "▾", tone: "crimson", disabled: true, title: "Display-only — not saved to the engine", onClick: () => toast({ kind: "danger", title: "Dropped: " + ctxMenu.item.name, body: "You will not get it back unless you fetch it yourself." }) },
           ]}
         />
       )}
@@ -379,11 +379,11 @@ function ItemDetail({ item, hero, toast }) {
       )}
 
       <div style={{ display: "flex", gap: 6, marginTop: 18, flexWrap: "wrap" }}>
-        <BrassButton size="sm" onClick={() => toast && toast({ kind: "item", title: item.name + " given to " + hero.name, body: hero.name.split(" ")[0] + " stows it in their pack." })}>
-          Give to {hero.name.split(" ")[0]}
+        <BrassButton size="sm" disabled title="Display-only — not saved to the engine" onClick={() => toast && toast({ kind: "item", title: item.name + " given to " + hero.name, body: hero.name.split(" ")[0] + " stows it in their pack." })}>
+          Give to {hero.name.split(" ")[0]} (preview)
         </BrassButton>
-        <BrassButton tone="ghost" size="sm">Examine</BrassButton>
-        <BrassButton tone="ghost" size="sm">Drop</BrassButton>
+        <BrassButton tone="ghost" size="sm" onClick={() => toast && toast({ kind: "item", title: item.name, body: item.desc })}>Examine</BrassButton>
+        <BrassButton tone="ghost" size="sm" disabled title="Display-only — not saved to the engine">Drop (preview)</BrassButton>
       </div>
     </div>
   );

--- a/viewer/openworlds/screen-relations.jsx
+++ b/viewer/openworlds/screen-relations.jsx
@@ -277,7 +277,7 @@ function NPCDetail({ n, onNavigate, campBeats }) {
   return (
     <div>
       <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
-        <Placeholder label={n.short} w={120} h={148} framed />
+        <Img scope={n.id ? "portrait-" + n.id : ""} label={n.short} w={120} h={148} framed />
         <div style={{ flex: 1 }}>
           <div className="eyebrow" style={{ color: "var(--crimson)" }}>{n.role}</div>
           <h2 className="h1" style={{ fontSize: 20, marginTop: 2 }}>{n.name}</h2>

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -209,7 +209,8 @@ function ScreenTable({ onNavigate, state, setState }) {
       <div style={{ display: "flex", flexDirection: "column", gap: 14, minHeight: 0 }}>
         {/* Scene plate */}
         <div style={{ position: "relative", flex: "0 0 auto" }}>
-          <Placeholder
+          <Img
+            scope={scene.imageScope || ""}
             label={`scene · ${scene.caption || surface?.location?.name || activeCampaign.title || "Open Worlds"}`}
             h={260}
             framed

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -2747,8 +2747,8 @@ _ABILITY_KEYS = ("strength", "dexterity", "constitution", "intelligence", "wisdo
 def _character_sheet(cid: str, ch: dict) -> dict:
     """One party character's full sheet for the heroes screen, mapping 5e snapshot fields
     into the shape screen-character.jsx renders (stats block, skills, spells, class
-    resources, conditions, death saves). Pathfinder-only cells (touch/flat/CMB) are
-    derived sensibly from 5e data so the existing layout still reads."""
+    resources, conditions, death saves). All-5e: six per-ability saving throws (mod +
+    proficiency), AC, proficiency bonus, melee/ranged attack bonus, initiative, speed."""
     klass, level = _class_summary(ch)
     abilities = ch.get("abilities") if isinstance(ch.get("abilities"), dict) else {}
     stats = {k[:3]: (_num(abilities.get(k)) if _num(abilities.get(k)) is not None else 10) for k in _ABILITY_KEYS}
@@ -2771,16 +2771,19 @@ def _character_sheet(cid: str, ch: dict) -> dict:
         return b + prof if proficient else b
     stats.update({
         "ac": ac,
-        "flat": ac - dex_mod if dex_mod else ac,  # 5e has no flat-footed; show AC minus DEX as a proxy
-        "touch": 10 + dex_mod,
-        "fort": _save("constitution"),
-        "reflex": _save("dexterity"),
-        "will": _save("wisdom"),
-        "bab": prof,
+        # 5e saving throws: one per ability (mod + proficiency where proficient). No
+        # touch/flat-footed AC or CMB/CMD — those are Pathfinder/3.5, not 5e.
+        "saves": {
+            "str": _save("strength"),
+            "dex": _save("dexterity"),
+            "con": _save("constitution"),
+            "int": _save("intelligence"),
+            "wis": _save("wisdom"),
+            "cha": _save("charisma"),
+        },
+        "proficiency_bonus": prof,
         "melee": prof + _ability_mod(abilities.get("strength")),
         "ranged": prof + dex_mod,
-        "cmb": prof + _ability_mod(abilities.get("strength")),
-        "cmd": 10 + prof + _ability_mod(abilities.get("strength")) + dex_mod,
         "initiative": int(init_bonus) if init_bonus is not None else dex_mod,
         "speed": int(speed) if speed is not None else 30,
     })

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -242,6 +242,10 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         (campaign_dir / "sessions" / "sess_1.jsonl").write_text("{}", encoding="utf-8")
         _QuietHandler.campaign_id = "camp_live"
 
+        # Isolate the catalog's repo-local roots (play-state/*, qa/state/*) under tmp so
+        # a dev worktree that happens to hold local QA runs doesn't leak into the count.
+        server._HERE = self._tmp / "viewer"
+
         status, ctype, body = self._get("/openworlds/campaigns.json")
 
         self.assertEqual(status, 200)

--- a/viewer/tests/test_readmodel_surfaces.py
+++ b/viewer/tests/test_readmodel_surfaces.py
@@ -370,8 +370,8 @@ class ReadModelSurfaceTests(unittest.TestCase):
         self.assertEqual(hero["stats"]["ac"], 17)
         self.assertEqual(hero["hp"], 22)
         self.assertEqual(hero["hpMax"], 28)
-        # CON save = +2 (mod) + 2 (proficient) = +4
-        self.assertEqual(hero["stats"]["fort"], 4)
+        # 5e CON save = +2 (mod) + 2 (proficient) = +4
+        self.assertEqual(hero["stats"]["saves"]["con"], 4)
         # persuasion = CHA mod (+4) + 2x proficiency (expertise) = +8
         persuasion = next(s for s in hero["skills"] if s["name"] == "Persuasion")
         self.assertEqual(persuasion["mod"], 8)


### PR DESCRIPTION
## Summary
Polish wave driven by a read-only screen audit. Three threads:

**Render-bridge art gaps** (wire `<Img>` where scope data already exists, verified live):
- Session scene plate (`scene.imageScope` → location art), Parley live-actor + listener portraits, Relations **dossier** large portrait, Inventory hero full-art, all 5 Camp-sidebar party portraits.
- Launcher + Journal NPC thumbs **left as placeholders** — their read-models carry no entity id (honest backend limitation, not a wiring miss).
- Re-key the Lower City scene `scene:baldurs-gate` → `scene:lower-city` so it matches the engine location id `loc-lower-city` (the BG start location's scene plate now resolves).

**5e fidelity** — `_character_sheet` was emitting Pathfinder/3.5 cells (touch/flat AC, CMB/CMD, fort/reflex/will). Now emits real 5e: a six-ability `saves` dict (mod + proficiency) + `proficiency_bonus`; the character screen renders the six saves + "Proficiency". No more Pathfinder terms on a 5e sheet.

**Honesty** — Acts binds `/acts-surface` live but showed a stale "Display-only" badge (added `"acts"` to `capabilityForScreen`). Inventory Equip/Use/Give/Drop only toasted on a "Wired" screen → marked `(preview)` + disabled with a "not saved to the engine" title.

**Test hardening** — the campaigns-catalog test isolates the repo-local play-state/qa-state roots under tmp (a dev worktree with local QA runs was leaking into the count).

## Verification
- [x] viewer suite: 89 passed; `scripts/license_check.py` green
- [x] LIVE in Claude_Preview on a seeded BG campaign: Character sheet shows 6 5e saves (no Fort/CMB/Touch); Relations dossier + list render real ingested BG3 portraits (10/10 `<img>` loaded); scene/item scopes resolve via `/image`
- [x] no `_private`/copyrighted assets committed