### PR TITLE
release: bump to 1.0.0 (local/source 1.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "clawdnd",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "source": "./",
       "description": "Adventure inside living, AI-generated D&D 5e worlds with a voiced AI companion — an AI DM generates epic stories live within persistent, canon-anchored worlds."
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clawdnd",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Adventure inside living, AI-generated D&D 5e worlds with a voiced AI companion — an AI DM generates epic stories live within persistent, canon-anchored worlds; deterministic 5e rules, searchable memory, fully voice-acted.",
   "author": {
     "name": "100yenadmin"


### PR DESCRIPTION
## Summary
Version bump to **1.0.0** (`.claude-plugin/plugin.json` + `marketplace.json`), per the release checklist Step 1. The local/source 1.0:
- Living-world D&D 5e engine — **1385 tests green**, engine = sole writer.
- OpenWorlds visual layer — wiki-sourced portraits/scenes/item icons rendering across Session (scene plate), Relations (portraits + dossier), Character (correct 5e sheet), Battle (tactical board). **89 viewer tests green.**
- Honest capability surface (preview/display-only badges accurate).
- `scripts/license_check.py` green; no `_private`/copyrighted assets committed.

Tag `v1.0.0` + GitHub release follow once this merges.

## Test plan
- [x] engine: 1385 passed (single-process)
- [x] viewer: 89 passed; license check green
- [x] visual layer proven live (Claude_Preview screenshots: Session/Relations/Character/Battle)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released clawdnd plugin version 1.0.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/237?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->