### PR TITLE
openworlds: Bestiary badge → Wired (binds /bestiary-surface)

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -297,7 +297,7 @@ function capabilityForScreen(screen, nativeState) {
       ? { label: "Wired", tone: "emerald", detail: "Native bridge ready" }
       : { label: "Unavailable", tone: "crimson", detail: "Native bridge missing" };
   }
-  if (["launcher", "table", "combat", "map", "journal", "character", "inventory", "relations", "acts"].includes(screen)) {
+  if (["launcher", "table", "combat", "map", "journal", "character", "inventory", "relations", "acts", "bestiary"].includes(screen)) {
     return { label: "Wired", tone: "emerald", detail: "Backed by viewer read models" };
   }
   if (screen === "dialogue") {


### PR DESCRIPTION
Bestiary now fetches the live /bestiary-surface (wired in wave-2 #239) but capabilityForScreen still flagged it Display-only — stale badge. Add 'bestiary' to the wired list. Verified live: pressing 'b' opens Codex and it fetches /bestiary-surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The bestiary screen now supports interactive functionality previously unavailable, bringing it to feature parity with other screens in the viewer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->