### PR TITLE
openworlds: wave-2 adversarial-review nits (LOW cosmetic)

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -543,7 +543,7 @@ function ResourcesStatus({ hero }) {
 
       {resources.length > 0 && (
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 4, marginTop: hasStatusPills ? 8 : 0 }}>
-          {resources.map((r) => {
+          {resources.filter((r) => Number(r.max) > 0).map((r) => {
             const remaining = (r.remaining !== null && r.remaining !== undefined) ? r.remaining : Math.max(0, (r.max || 0) - (r.used || 0));
             return <StatLine key={r.id || r.name} k={r.name} v={`${remaining} / ${r.max}`} />;
           })}

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -16,7 +16,8 @@ function slug(name) {
    The engine item.id is a composite "{character_id}:{idx}:{name}" which normalises to a unique
    per-instance key that never matches the shared art, so it must NOT be used for the scope. */
 function itemScope(item) {
-  return "item-" + slug(item && item.name);
+  const s = slug(item && item.name);
+  return s ? "item-" + s : "";
 }
 
 function ScreenInventory({ onNavigate, state, setState }) {

--- a/viewer/openworlds/screen-relations.jsx
+++ b/viewer/openworlds/screen-relations.jsx
@@ -254,11 +254,11 @@ function FactionDetail({ f }) {
       {/* Seat — hide when the surface leaves it blank (a live faction has no seat field). */}
       {f.seat && <div className="hand" style={{ fontSize: 14, color: "var(--ink-700)" }}>{f.seat}</div>}
 
-      <Divider />
+      {f.seat && <Divider />}
 
       <p className="body dropcap" style={{ marginTop: 0, fontSize: 14 }}>{f.body}</p>
 
-      <Divider />
+      {(f.standing || f.lastContact || (f.events && f.events.length) || (f.offers && f.offers.length)) && <Divider />}
 
       {/* Standing/last-contact grid — only render a StatLine whose value is present; the live
           surface emits standing but leaves lastContact blank. */}


### PR DESCRIPTION
The wave-2 adversarial review returned a SHIP verdict (no CRITICAL/HIGH); these clear the 4 LOW cosmetic findings: relations dangling dividers, inventory empty itemScope (wasted 404), character zero-max resource row. Viewer suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resources section now displays only entries with measurable quantities.
  * Improved handling for inventory items lacking names.
  * Faction details dividers now appear contextually based on available information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->