### PR TITLE
docs: ui-audit (Phase 5) — 16 per-screen scored audits + rubric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@
 # Raw wiki-ingest cache (tools/ingest) — fetched source, regenerable; not committed.
 /tools/ingest/.cache/
 
+# UI-audit screenshots — reproduce rendered output from _private (BG3 portraits, FR maps,
+# city scene art). These are © under the same Fan Content / wiki-image policy as the
+# _private dirs above. Regenerable via `qa/owshot.sh <screen> <out>.png 8799`.
+/docs/ui-audit/screenshots/*.png
+
 # Python
 __pycache__/
 *.py[cod]

--- a/docs/ui-audit/MASTER_TRACKER.md
+++ b/docs/ui-audit/MASTER_TRACKER.md
@@ -1,0 +1,175 @@
+# OpenWorlds UI/UX — Master Tracker (Phase 5 deep audit, 2026-05-29)
+
+> **Source-of-truth index** for the page-by-page UI/UX audit landed under `docs/ui-audit/`.
+> Updated by the implementation agent as issues land. Mirror of `#242` Phase 5 status.
+>
+> **Audit method:** live walkthrough of every screen at `127.0.0.1:8799/openworlds/`, viewports
+> 1440×900 and 1512×982; sources read for every `viewer/openworlds/screen-*.jsx`; findings anchored
+> to file:line; severity rubric in `SCORING_RUBRIC.md`. Comparable patterns in
+> `RPG_REFERENCE_PATTERNS.md` (Pathfinder/Kingmaker/BG3/DNDBeyond).
+> **Read order on resume:** this file → `SCORING_RUBRIC.md` → the per-screen doc you're working on.
+
+---
+
+## Scoreboard
+
+| # | Screen | Score | Disposition | Epic | Audit doc | Screenshot |
+|---|---|---|---|---|---|---|
+| 1 | Relations | **80** | Release-Ready | [#244](https://github.com/100yenadmin/ClawDnD/issues/244) | [relations.md](screens/relations.md) | [png](screenshots/relations-1512.png) |
+| 2 | Parley (Dialogue) | **78** | Polish-Pass | [#248](https://github.com/100yenadmin/ClawDnD/issues/248) | [dialogue.md](screens/dialogue.md) | [png](screenshots/dialogue-1512.png) |
+| 3 | Atlas (Map) | **72** | Polish-Pass | [#249](https://github.com/100yenadmin/ClawDnD/issues/249) | [map.md](screens/map.md) | [png](screenshots/map-1512.png) |
+| 4 | Quest Journal | **72** | Polish-Pass | [#253](https://github.com/100yenadmin/ClawDnD/issues/253) | [journal.md](screens/journal.md) | [png](screenshots/journal-1512.png) |
+| 5 | Session (Table) | **70** | Polish-Pass | [#246](https://github.com/100yenadmin/ClawDnD/issues/246) | [table.md](screens/table.md) | [png](screenshots/table-1512.png) |
+| 6 | Market (Merchant) | **70** | Polish-Pass | [#256](https://github.com/100yenadmin/ClawDnD/issues/256) | [merchant.md](screens/merchant.md) | [png](screenshots/merchant-1512.png) |
+| 7 | Heroes (Character) | **68** | Polish-Pass | [#250](https://github.com/100yenadmin/ClawDnD/issues/250) | [character.md](screens/character.md) | [png](screenshots/character-1512.png) |
+| 8 | Setting (Settings) | **68** | Polish-Pass | [#259](https://github.com/100yenadmin/ClawDnD/issues/259) | [settings.md](screens/settings.md) | [png](screenshots/settings-1512.png) |
+| 9 | Battle (Combat) | **66** | Polish-Pass | [#247](https://github.com/100yenadmin/ClawDnD/issues/247) | [combat.md](screens/combat.md) | [png](screenshots/combat-1512.png) |
+| 10 | Stash (Inventory) | **66** | Polish-Pass | [#251](https://github.com/100yenadmin/ClawDnD/issues/251) | [inventory.md](screens/inventory.md) | [png](screenshots/inventory-1512.png) |
+| 11 | Chronicles (Launcher) | **64** | Polish-Pass | [#245](https://github.com/100yenadmin/ClawDnD/issues/245) | [launcher.md](screens/launcher.md) | [png](screenshots/launcher-1512.png) |
+| 12 | Acts | **64** | Polish-Pass | [#255](https://github.com/100yenadmin/ClawDnD/issues/255) | [acts.md](screens/acts.md) | [png](screenshots/acts-1512.png) |
+| 13 | Forge | **62** | Polish-Pass | [#252](https://github.com/100yenadmin/ClawDnD/issues/252) | [forge.md](screens/forge.md) | [png](screenshots/forge-1512.png) |
+| 14 | Creation Plane (Create) | **60** | Polish-Pass | [#257](https://github.com/100yenadmin/ClawDnD/issues/257) | [create.md](screens/create.md) | [png](screenshots/create-1512.png) |
+| 15 | Codex (Bestiary) | **56** | Finish-Wave | [#254](https://github.com/100yenadmin/ClawDnD/issues/254) | [bestiary.md](screens/bestiary.md) | [png](screenshots/bestiary-1512.png) |
+| 16 | World Seed | **50** | Finish-Wave | [#258](https://github.com/100yenadmin/ClawDnD/issues/258) | [seed.md](screens/seed.md) | [png](screenshots/seed-1512.png) |
+
+**Average: 66.6/100.** Bottom-up: 8 screens lift through Polish; 2 through Finish; 1 already Release-Ready.
+
+---
+
+## Cross-cutting sub-issues filed (#260–#279)
+
+> These are the leverage points. Closing the cross-cutting items lifts multiple screens at once.
+
+| Issue | Title | Sev | Epics | Milestone |
+|---|---|---|---|---|
+| [#260](https://github.com/100yenadmin/ClawDnD/issues/260) | Title-bar text overlaps nav-rail on every screen | Critical | per-page-polish | Polish Wave |
+| [#261](https://github.com/100yenadmin/ClawDnD/issues/261) | Atlas — seed the BG nav graph (Lower City / Upper City / …) | Critical | atlas | Polish Wave |
+| [#262](https://github.com/100yenadmin/ClawDnD/issues/262) | Bestiary 'THE MARCHES' → Sword Coast (demo-leak) | Critical | demo-leak | Finish Wave |
+| [#263](https://github.com/100yenadmin/ClawDnD/issues/263) | Bestiary intel-tier stat block or hide-when-blank | Critical | per-page-polish + wire-prototypes | Finish Wave |
+| [#264](https://github.com/100yenadmin/ClawDnD/issues/264) | Forge Workshop Ledger demo leak (the scribe / the smith / a companion) | Critical | demo-leak | Polish Wave |
+| [#265](https://github.com/100yenadmin/ClawDnD/issues/265) | Creation Plane race + class + portrait gallery art | Critical | portraits + per-scene-art | Polish Wave |
+| [#266](https://github.com/100yenadmin/ClawDnD/issues/266) | World Seed write-lane decision + de-fake hardcoded values | Critical | wire-prototypes + demo-leak | Finish Wave |
+| [#267](https://github.com/100yenadmin/ClawDnD/issues/267) | Combat foe portraits + battle scene backdrop | Critical | portraits + per-scene-art | Polish Wave |
+| [#268](https://github.com/100yenadmin/ClawDnD/issues/268) | Character Spellbook browse path | Critical | per-page-polish | Polish Wave |
+| [#269](https://github.com/100yenadmin/ClawDnD/issues/269) | Merchant id mismatch (`gate-sundries` vs `talli`) | Critical | per-page-polish | Polish Wave |
+| [#270](https://github.com/100yenadmin/ClawDnD/issues/270) | Img-not-Placeholder sweep across 8 screens | Major | portraits + per-scene-art | Polish Wave |
+| [#271](https://github.com/100yenadmin/ClawDnD/issues/271) | Inventory paper-doll + full slot set | Major | per-page-polish | Polish Wave |
+| [#272](https://github.com/100yenadmin/ClawDnD/issues/272) | Inventory compare-on-hover | Major | per-page-polish | Polish Wave |
+| [#273](https://github.com/100yenadmin/ClawDnD/issues/273) | Relations canon BG factions seed | Major | per-page-polish | Polish Wave |
+| [#274](https://github.com/100yenadmin/ClawDnD/issues/274) | Session log time-merge sort | Major | per-page-polish | Polish Wave |
+| [#275](https://github.com/100yenadmin/ClawDnD/issues/275) | Atlas watermark dim | Major | per-page-polish | Polish Wave |
+| [#276](https://github.com/100yenadmin/ClawDnD/issues/276) | Parley free-form text input | Major | per-page-polish + wire-prototypes | Polish Wave |
+| [#277](https://github.com/100yenadmin/ClawDnD/issues/277) | Create Family + Biography wiring | Major | wire-prototypes | Polish Wave |
+| [#278](https://github.com/100yenadmin/ClawDnD/issues/278) | Settings Export chronicle wire | Major | wire-prototypes | Polish Wave |
+| [#279](https://github.com/100yenadmin/ClawDnD/issues/279) | Iconography: OpenWorldsIcon registry usage across screens | Major | per-page-polish + iconography | Polish Wave |
+
+---
+
+## Recommended work order (highest leverage first)
+
+> **Owner steer + design-led items first.** Then sweep cross-cutting items. Then per-screen.
+
+### Wave 0 — owner / design decisions (1–2 days)
+
+1. **#266 — World Seed write-lane DECISION**: keep as view-only OR build a `/seed-surface` write lane. The audit doc proposes both paths; the lower-effort path is "view-only". Pick before any S- work starts.
+2. **#263 — Bestiary intel-tier OR hide-when-blank**: same pick-one shape — Approach A or B in the doc.
+3. **#265 — portrait pipeline approach**: gateway-gen for created PCs, OR default class/race art, OR both? (Audit doc lays out trade-offs.) This drops out of EPIC A in #242.
+4. **ST-02 — which Settings preview controls ship by 1.0?** See `docs/ui-audit/screens/settings.md`.
+
+### Wave 1 — cross-cutting sweeps (highest leverage)
+
+5. **#260 (title-bar overlap)** — single change lifts every screen.
+6. **#270 (Img-not-Placeholder sweep)** — 8 screens lift at once once items + portraits + scene art exists in `_private/`.
+7. **#261 (BG nav graph seed)** — Atlas elevates from 72 → 80+.
+8. **#273 (BG factions seed)** — Relations stays at 80+ with full content.
+
+### Wave 2 — per-screen criticals
+
+9. **#262 + #263 (Bestiary)** — lifts 56 → 75+.
+10. **#266 (Seed)** — lifts 50 → 70+ on the view-only path.
+11. **#265 (Create races/classes/portraits)** — lifts 60 → 80+.
+12. **#267 (Combat foes + backdrop)** — lifts 66 → 80+.
+13. **#268 (Spellbook browse)** — lifts Character toward Release-Ready.
+14. **#264 (Forge ledger demo-leak)** + **#269 (Merchant id mismatch)** — quick wins, finish EPIC E.
+
+### Wave 3 — per-screen majors
+
+15. **#271 + #272 (Inventory paper-doll + compare)** — major BG3-parity lift.
+16. **#274 (log sort)** — felt fix on Session.
+17. **#275 (watermark)** + **#276 (Parley free-form)** + **#277 (Create wiring)** + **#278 (Export)** + **#279 (iconography)** — polish sweep.
+
+### Wave 4 — per-screen minors + trivials
+
+18. Implementation agent files individual tickets per per-screen audit doc Minor/Trivial rows as work is picked up. The audit docs hold the source of truth — don't pre-file 60+ Minor tickets.
+
+---
+
+## Milestones
+
+| Milestone | # | Status | Issues |
+|---|---|---|---|
+| Graphics Release 1.0 — Blocker Wave | [#8](https://github.com/100yenadmin/ClawDnD/milestone/8) | Reserved (empty today) | — |
+| Graphics Release 1.0 — Finish Wave | [#9](https://github.com/100yenadmin/ClawDnD/milestone/9) | Open | Bestiary (#254 #262 #263), Seed (#258 #266) |
+| Graphics Release 1.0 — Polish Wave | [#10](https://github.com/100yenadmin/ClawDnD/milestone/10) | Open | 14 epics + 16 cross-cutting subs |
+| Graphics Release 1.0 — Backlog / Post-1.0 | [#11](https://github.com/100yenadmin/ClawDnD/milestone/11) | Open | Trivials + missing features |
+
+---
+
+## Labels added (taxonomy)
+
+- `ui-audit` — every issue from this audit cycle.
+- `severity:critical` / `severity:major` / `severity:minor` / `severity:trivial` — per the rubric.
+- `epic:portraits` (A) / `epic:atlas` (B) / `epic:playable` (C) / `epic:per-scene-art` (D) / `epic:demo-leak` (E) / `epic:wire-prototypes` (F) / `epic:per-page-polish` (G).
+- `screen:<id>` × 16 (launcher / table / combat / dialogue / map / character / inventory / forge / relations / journal / bestiary / acts / merchant / create / seed / settings).
+- `asset-gap` — needs wiki ingest or `_private` art.
+- `accessibility` — a11y findings (often paired with `severity:minor`).
+- `iconography` — `OpenWorldsIcon` registry usage.
+- `copy` — on-screen text.
+
+---
+
+## How an implementation agent picks up work
+
+1. **Read this file + `SCORING_RUBRIC.md` + the target screen's audit doc.** That's 5 minutes of orientation.
+2. **Pick a row from the per-screen audit's "Findings" table.** Each row carries severity / file:line / epic tag / acceptance criteria.
+3. **Search GitHub** for an existing issue (`<screen> <row-id>` like `launcher L-04`). File if missing.
+4. **Implement.** Headless verify via `qa/owshot.sh <screen> docs/ui-audit/screenshots/<screen>-<viewport>.png 8799` (fresh Chrome profile per port — no cache). Visually verify in the macOS app via `script/build_and_run.sh`.
+5. **Update the per-screen audit doc**: strike through the finding row OR add a "✅ shipped <commit-sha>" suffix.
+6. **Re-score the screen** when 3+ findings of any severity have landed; bump the score table at the top of the doc.
+
+---
+
+## Files in this audit
+
+```
+docs/ui-audit/
+├── MASTER_TRACKER.md        ← you are here
+├── SCORING_RUBRIC.md         ← 10-criterion rubric + severity + per-screen template
+├── RPG_REFERENCE_PATTERNS.md ← P1–P16 patterns from Pathfinder/Kingmaker/BG3/DNDBeyond
+├── screens/
+│   ├── launcher.md  table.md     combat.md     dialogue.md
+│   ├── map.md       character.md inventory.md  forge.md
+│   ├── relations.md journal.md   bestiary.md   acts.md
+│   └── merchant.md  create.md    seed.md       settings.md
+├── screenshots/    ← gitignored — see screenshots/README.md for how to regenerate
+│   └── README.md   (the only file in this dir that's committed)
+└── code-map/        ← reserved for per-screen code-anchor notes (empty today)
+```
+
+> **Why screenshots aren't committed.** The audit screenshots reproduce rendered
+> output from `content/worlds/_private/` (BG3 portraits, Sword Coast map, BG city
+> scene art). Per `docs/OPENWORLDS_DESIGN_ASSET_POLICY.md` and the existing
+> `.gitignore` rule for `_private/`, that © content stays local. Derivative
+> screenshots that embed it follow the same rule. The per-screen audit docs reference
+> `docs/ui-audit/screenshots/<screen>-1512.png` paths — those resolve locally after
+> a one-line regen loop (see `screenshots/README.md`).
+
+---
+
+## Session reference
+
+This audit was produced 2026-05-29 in one session as part of issue [#242](https://github.com/100yenadmin/ClawDnD/issues/242) Phase 5. Session notes live at `/Volumes/LEXAR/Codex/session-notes/2026-05-29/openworlds-ui-ux-review/implementation-notes.html` (per the user-level guidance to keep a per-session scratchpad for substantial / state-changing sessions).
+
+The audit was authored against the canonical checkout `/Users/lume/ClawDnD-val` (per `clawdnd-canonical-setup` memory), git rev `227ff3227010820b2df2e5692dc77505ef7f980e`. The viewer was served via both `/Volumes/LEXAR/repos/ClawDnD-val` (port 8799, content-identical mirror) and `/Users/lume/ClawDnD-val` (port 8795); both were verified at the same revision.
+
+The audit does NOT touch product code — see the goal directive. The implementation agent is the appropriate owner for any code changes; this audit hands them everything they need to start.

--- a/docs/ui-audit/RPG_REFERENCE_PATTERNS.md
+++ b/docs/ui-audit/RPG_REFERENCE_PATTERNS.md
@@ -1,0 +1,238 @@
+# RPG UI Reference Patterns — Pathfinder / Kingmaker / BG3 / DNDBeyond
+
+> Text-only reference for the OpenWorlds audit. **Do NOT commit any competitor
+> screenshots** — see `docs/OPENWORLDS_DESIGN_ASSET_POLICY.md`. Cite patterns by
+> description, not image.
+
+The audit scores OpenWorlds against the **patterns** these games converged on,
+not against any specific frame of art. A player who knows BG3 or Kingmaker
+expects each screen to converge on these patterns; the rubric C3 score reflects
+how close OpenWorlds is to the genre's literacy floor.
+
+## P1 — The Map / Atlas (Pathfinder: Kingmaker + BG3 World Map)
+
+| Pattern | Why it matters | OpenWorlds analog |
+|---|---|---|
+| **Spatial map, anchored** — locations sit at fixed coordinates on a region backdrop, edges are real travel routes. | Players read distance + adjacency at a glance; "node list over a city photo" reads as broken. | `screen-map.jsx` lines 268–361 (force-directed layout) + line 480-484 (region backdrop) |
+| **Time + weather indicator** — clock-driven; sky tint shifts dawn / day / dusk / night. | The world feels alive without input. Manual toggle reads as a setting. | `screen-map.jsx` line 117-118 (`atlasTimePhase` clock-driven) ✓ |
+| **Encounter / quest pins** — pin glyphs (sword for hostile, scroll for quest, anvil for downtime) overlay the node. | Catalogs strategic context. | `screen-map.jsx` line 746-747 (settlement/camp glyph) — extend with quest pins |
+| **Fog-of-war / "discovered"** — unvisited nodes show as silhouettes or `?`. | Conveys exploration progression. | Partial via `loc.visited` (line 710) — not fully used |
+| **Travel cost panel** — selecting a destination shows minutes / risk / rations. | Forces real travel choices. | `screen-map.jsx` line 598-599 ("minutes away") ✓ |
+| **Make Camp / Long Rest** — prominent CTA, only available where safe. | Rest cadence is core to CRPG pacing. | line 192-200 prominent + gated on `canCamp` ✓ |
+| **Region label + scale + compass** — tells the player WHERE they are without zooming. | Spatial orientation. | line 514-519 (compass rose) + line 520 (atlas label) ✓ |
+
+## P2 — The Character Sheet (DNDBeyond + BG3 inspect)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Portrait + name + race/class/level + alignment** header card. | `screen-character.jsx` line 115-130 ✓ |
+| **6 ability scores with mod + save** — STR/DEX/CON/INT/WIS/CHA grid. | line 159-161 (scores) + line 195-199 (saves) ✓ |
+| **AC, HP/HPmax, Speed, Initiative, Prof Bonus** — top-line stats. | line 126-130 (pills) + line 175-178 ✓ |
+| **Spell slots + prepared spells + cantrips** — gridded slot tracker. | `SpellSlotTrack` line 696-726 ✓ — but `RestPrepareModal` rest+prepare is display-only (line 296-304) |
+| **Class resources** — Lay on Hands pool, Channel Divinity uses, Rages. | `ResourcesStatus` line 520-562 ✓ |
+| **Skills with proficiency markers** — black diamond = proficient, double = expertise. | `SkillsTab` line 628-648 — shows mod, NO proficiency dot/marker (BG3 norm) |
+| **Equipped gear strip** — slot icons (head, chest, hands, ring, boots). | line 203-221 — uses `Placeholder label={it.glyph}` NOT IconPlate/Img → item icons missing |
+| **Death saves + concentration** badges. | line 535-549 ✓ |
+| **Inspect tooltip with full rules text** on hover. | `AbilityCard` line 587-605 has Tooltip ✓ but Feats line 607 + spells only show one-line `detail` |
+| **Multiclass tabs** when class layers stack. | Not yet supported. |
+
+## P3 — The Inventory (BG3 + Kingmaker)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Equipment-doll** — paper-doll silhouette with slot drop-zones around it. | `screen-inventory.jsx` line 145-164 uses a flat 6-slot grid below the portrait, NOT a doll. Equipment slots only cover Head/Neck/Body/Hands/Ring/Boots (line 299-302) — BG3 has Mainhand/Offhand/Ranged/Cloak/Amulet/2 Rings/Underwear too |
+| **Item tile grid** with type-coloured borders + qty in corner. | `ItemSlot` line 322-364 ✓ — type-coloured borders ✓ qty corner ✓ |
+| **Filter chips** (All / Arms / Armor / Spell / Quest / Rare / Sundries). | line 192-210 ✓ |
+| **Item detail pane** with description, weight, value, properties, lore. | `ItemDetail` line 366-441 ✓ |
+| **Encumbrance / Weight bar** — intentionally removed (line 168-171) for honesty ✓ |
+| **Coin purse with PP / GP / SP / EP / CP**. | line 174-183 ✓ |
+| **Per-hero pack** (each character carries their own). | line 130-142 hero switcher ✓ |
+| **Context menu** (right-click → Equip / Use / Hand to companion / Drop). | line 272-294 ✓ great |
+| **Compare-on-hover** — old item vs hover item delta. | NOT IMPLEMENTED |
+| **Drag-to-equip / drag-between-heroes**. | NOT IMPLEMENTED — context menu only |
+
+## P4 — Combat / Initiative (Pathfinder + BG3)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Initiative tracker** — vertical strip, current actor highlighted, foe portraits red-tinted, HP bar per row. | `screen-combat.jsx` `InitiativeRow` line 549-594 ✓ portrait wired (line 571) ✓ |
+| **Tactical map with movement / cone / line targeting** — grid + range overlays. | `CombatMap` line 405-473 has a 16×10 grid with tokens but **NO movement preview, NO range/aoe overlay, NO attack-of-opportunity indicators** |
+| **Action economy badges** — Action / Bonus / Reaction / Movement clearly visible per token. | `CombatantSummary` line 273-275 (`ApBadge`) + `CommandCenterPanel` line 303-308 ✓ |
+| **Multiattack indicator** — "1/2 attacks left" on a multiattacker. | line 294-297 attack budget ✓ |
+| **Conditions on tokens** — small icon ring around the portrait. | NOT IMPLEMENTED — cues live in `CueChip` (line 366-382) but not overlaid on token |
+| **Damage type icons in log** — sword/fire/poison glyph in each damage line. | `BattleLogLine` line 636-661 — text only, no icons |
+| **Crit / miss visual** — golden flash on crit, grey miss; persistent in log. | NOT IMPLEMENTED visually; log is plain text |
+| **Spell preview before cast** — area circle + targeted enemies list. | NOT IMPLEMENTED — Cast action just sends |
+
+## P5 — Dialogue / Parley (BG3 + Pathfinder)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Portrait + name + alignment** of the speaker. | `screen-dialogue.jsx` `ParleyMenu` line 192-198 ✓ |
+| **Numbered branch options** with a DC + skill name + modifier shown inline. | line 209-246 ✓ (e.g. "1. Athletics +3 DC 14") |
+| **Free-form / "say what you want"** option. | line 248-259 ✓ |
+| **Alignment / persuasion tags** ("[INTIMIDATION]", "[INSIGHT]") prefixing options. | label only — no clear tag |
+| **Approach history side panel** — "you tried Athletics earlier, failed". | line 266-288 ✓ |
+| **Scene art behind the panel** — anchors the conversation. | line 132 ✓ |
+| **Difficulty / Stakes telegraph** — "Hard" / "Hostile crowd" — colored. | line 169-176 — easy/medium/hard buttons with tooltip ✓ but tooltip-only DC explanation could be louder |
+
+## P6 — Quest Journal (Kingmaker + BG3)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Active / Past / Rumors tabs**. | `screen-journal.jsx` line 81-92 ✓ |
+| **Per-quest objective checklist** with strikethrough on done. | line 246-269 ✓ |
+| **Quest log entries** — date-stamped, narrative format. | line 213-218 ✓ |
+| **Show on map** button. | line 354 ✓ |
+| **Named NPCs in this quest** with portrait + role. | line 275-292 — but **uses `<Placeholder>` not Img!** (line 283) — portraits never render |
+| **Reward preview** — XP + gp + items. | line 343-350 — gated on `quest.reward` ✓ |
+| **Director debt / "campaign owes" advisory** — unique to OpenWorlds, great touch. | line 127-148 ✓ |
+
+## P7 — Bestiary / Codex (Pathfinder + DNDBeyond Monster Manual)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Searchable index** with creature plate thumbnail + name + CR. | `screen-bestiary.jsx` line 156-176 ✓ |
+| **Stat block** — Size · Type · Alignment header, then AC / HP / Speed / 6 abilities / Saves / Senses / CR / Resistances / Immunities. | line 243-267 — **MOST FIELDS EMPTY** (HD/AC/Speed/Senses/Save not projected by surface, line 26-49 — they're set to `""` in `liveBestiaryEntry`) |
+| **Known actions** as tags. | line 277-285 ✓ |
+| **Tactics / Lore** prose section. | line 269-273 (body) + line 298-304 (tactics) ✓ but body/tactics may not be populated either |
+| **Encountered-at** location reference. | StatLine "Encountered" line 265 — empty |
+| **Spoils / Loot pool**. | line 306-314 — empty in live surface |
+
+## P8 — Faction / Relations (Pathfinder: Kingmaker Curtailments / BG3 approval)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Faction list with banner color + reputation bar**. | `screen-relations.jsx` line 79-96 ✓ + `RepBar` line 210-229 ✓ |
+| **Standing thresholds named** (Hostile / Cool / Civil / Cordial / Welcome). | line 219-220 ✓ |
+| **NPC roster with portrait + role + disposition dot**. | line 119-139 ✓ |
+| **Companion approval gauge** — separate from faction rep. | line 408-419 ✓ |
+| **Banter / Relationships / Ties** lists. | line 424-437 ✓ |
+| **Betrayal warning telegraph** — when bond fractures. | line 421-423 ✓ (great pattern) |
+| **Companion arcs** — per-companion personal quest list with status. | line 152-165 + `CompanionArcCard` line 170-208 ✓ |
+| **Last spoken quote**. | line 465-475 ✓ |
+
+## P9 — Crafting / Forge (Pathfinder + BG3 alchemy)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Recipe browser** with category tabs. | `screen-forge.jsx` line 132-147 ✓ |
+| **Recipe card** with components + DC + time. | line 184-199 ✓ |
+| **Component availability** (have vs need, green/red). | `ComponentSlot` line 325-344 ✓ |
+| **Crafter picker** — who at the bench? | line 235-256 ✓ but uses `<Placeholder>` not `Img` for portraits (line 247) |
+| **Success probability gauge**. | line 268-285 ✓ |
+| **Workshop ledger** — past craft attempts. | line 297-318 — uses **hardcoded log** (line 30-34) not engine-projected |
+| **Material breakdown on failure**. | NOT IMPLEMENTED — "materials are not lost" message only |
+
+## P10 — Merchant / Shop (BG3 + Kingmaker)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Merchant portrait + name + greeting**. | `screen-merchant.jsx` line 65-77 ✓ |
+| **Reputation/disposition gauge**. | line 80-89 ✓ |
+| **Buy / Sell tabs**. | line 124-138 ✓ |
+| **Two-pane table or grid: merchant stock + your stash**. | line 146-218 (single table view, switching tabs) — not split |
+| **Per-item icon + name + qty + weight + price**. | line 158-204 ✓ |
+| **Cart / "the counter"** for staged transactions. | line 238-264 ✓ |
+| **Coin purse on screen**. | line 230-234 ✓ |
+| **Haggle / reputation effect on price**. | line 91-114 ✓ + applied at line 54 ✓ |
+| **Compare-on-hover** — old item vs hover item delta. | NOT IMPLEMENTED |
+| **Restock countdown**. | NOT IMPLEMENTED |
+| **Multiple merchants per region** with distinct stock. | NOT IMPLEMENTED — line 338-368 single hardcoded Talli |
+
+## P11 — Camp / Long Rest (BG3 + Pathfinder)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Timeline ribbon** — dusk → dawn with cursor. | `camp-sidebar.jsx` `TimelineBar` line 301-348 ✓ great pattern |
+| **Role slots** — Hunting / Cooking / Camouflage / Watch1 / Watch2. | `RoleSlot` line 372-428 ✓ + `WatchSlot` line 430-478 ✓ |
+| **Drag-to-assign** companions. | line 244-245 ✓ |
+| **Recipe / meal picker** with stat bonus preview. | line 172-184 ✓ |
+| **Rations needed vs in-pack** balance. | line 105-113 ✓ |
+| **Talk to companion / "wants to say something"** affordance. | line 261-280 ✓ but `TALK_PROMPTS` is only `_default` line 595-603 — no per-companion content |
+| **Begin Resting CTA**. | line 293-295 — **disabled "Display-only"** (preview) — not wired |
+
+## P12 — Character Creation (BG3 + Pathfinder)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Stepped wizard** — Race → Class → Background → Abilities → Portrait → Name. | `screen-create.jsx` line 19-27 ✓ 7-step |
+| **Race card grid** with portrait + bonus + size. | `StepRace` line 221-247 ✓ — but `Placeholder` not `Img` (line 555) → no race portraits |
+| **Class card grid** with role + HP/hit-die + tags. | `StepClass` line 249-275 ✓ — but `Placeholder` not `Img` → no class portraits |
+| **Subclass / archetype picker** at level 3 or 1 (paladin oath). | NOT IMPLEMENTED — single class only |
+| **Background skill bonuses**. | line 304 ✓ |
+| **Alignment grid** — 3×3 LG/NG/CG…CE. | line 313-330 ✓ |
+| **Point buy with ability cost table** (8=0, 14=7, 15=9). | `abilityCost` line 572-576 ✓ standard 5e |
+| **Racial bonuses shown live**. | line 359-388 ✓ |
+| **Portrait gallery** with "bring your own". | line 416-428 — 12 placeholders, no actual portraits |
+| **Final review + bind**. | `StepReview` line 477-538 ✓ |
+| **Starting gear list**. | line 521-528 ✓ |
+
+## P13 — Worlds / Launcher / Save Slots (BG3 main menu, Kingmaker chapter screen)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Hero masthead art** with title plate. | `screen-launcher.jsx` line 79-101 ✓ |
+| **Campaign list / chronicles** with thumb + last-played + chapter. | `CampaignRow` line 349-386 — **uses `<Placeholder label="seal">` not real campaign art** (line 371) |
+| **Selected campaign detail** — party portraits + recap + region. | line 187-291 ✓ |
+| **Resume / New / Delete** CTAs. | line 277-281 ✓ |
+| **Per-save thumbnail** (BG3 saves the last scene as PNG). | NOT IMPLEMENTED — same masthead used everywhere |
+| **New chronicle modal** — system + tone + difficulty + GM strictness. | `NewCampaignModal` line 398-461 ✓ but the AI GM SegRadio has no onChange (line 450) — non-functional |
+
+## P14 — Acts / Chapter Progression (Pathfinder: Kingmaker, BG3 Acts I/II/III)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Vertical timeline / spine** with wax-seal nodes. | `screen-acts.jsx` `ActSpineRow` line 103-161 ✓ great |
+| **Current act marked + "You are here" pill**. | line 147-151 ✓ |
+| **Per-act key choices recap**. | line 212-239 ✓ |
+| **Memorable beats / callbacks**. | line 243-261 ✓ |
+| **Who walked this act** — party-at-start. | line 263-275 — uses `<Placeholder>` not Img → no portraits |
+
+## P15 — Settings (BG3 + Pathfinder)
+
+| Pattern | OpenWorlds analog |
+|---|---|
+| **Sections: Sound / Display / Gameplay / Controls / Accessibility / Saves / About**. | line 33-42 ✓ |
+| **Live sliders** for master/music/sfx/ambience/voice. | line 87-91 — **all preview/non-functional** ✓ honest |
+| **Reduce motion + high contrast + UI scale** functional. | line 183-184 ✓ + `OpenWorldsA11y` bridge |
+| **Keybind list** with conflict detection. | `KEYBINDS` line 580-593 ✓ static list, no rebind |
+| **Save slot list** with screenshots. | `SaveSlot` line 618-644 — uses `Placeholder` for thumbs |
+| **Native bridge / app status** panel. | `NativeAppSection` line 271-366 ✓ unique to OpenWorlds, well-presented |
+
+## P16 — World Seed / Game Setup (unique to OpenWorlds)
+
+This screen has no direct AAA-CRPG analog. It's closer to **NaNoWriMo project settings**
+or **the "Storyteller's Codex"** in indie story games (Citizen Sleeper, Wildermyth).
+The current implementation is **entirely display-only** (line 194 disabled, line 4-15
+state never persisted) — it should either wire to a `/seed-surface` POST lane or be
+honestly retired in favor of a single "world seed" badge on the campaign card.
+
+---
+
+## Cross-cutting conventions OpenWorlds already does well
+
+- **Honest empty states** + "(preview)" tags everywhere a button isn't engine-wired. This
+  is BETTER than BG3/Kingmaker (which have a few dead UI elements). Keep this discipline.
+- **Parchment + brass + corner filigree** chrome — pure OpenWorlds, no AAA-CRPG analog.
+  Distinctive and on-brief for the "scribe's codex" framing.
+- **Toast system** (`window.useToast`) — consistent across screens.
+- **Tooltip** wrapper with `<InfoTooltip>` content cards — good pattern.
+- **`Img` component** with `/image?scope=<id>` fetch + graceful Placeholder fallback —
+  the single bridge between the wiki-ingest pipeline and the UI (chrome.jsx line 237-258).
+  ★ Every screen that uses `<Placeholder>` directly for a person/thing that COULD have
+  art should instead use `<Img>` with the right scope.
+
+## Cross-cutting conventions OpenWorlds is missing
+
+- **Inspect-on-hover for items/spells/feats** is partial; many tiles fall back to no
+  tooltip (e.g. `screen-character.jsx` Equipped slot line 203-221 — no tooltip).
+- **Sortable / filterable tables** (Inventory grid, Bestiary index, Merchant table) —
+  filter chips exist on Inventory ✓ + Bestiary search ✓; Merchant has a dead "Filter…" button.
+- **Keyboard discoverability** — shortcuts are listed in Settings (line 580-593) and the
+  keyboard handler exists (app.jsx line 186-224), but no on-screen hint chip per page.
+- **Loading skeletons** — `setSurfaceStatus("loading")` is rarely used for a visible state;
+  the screens just go from empty → populated. A skeleton row would convey "waiting" vs
+  "no data."
+- **Iconography registry** — `OpenWorldsIcon` exists (line 174 issue tracks this) but
+  many screens still use one-char glyphs or `<Placeholder label="…">` instead.

--- a/docs/ui-audit/SCORING_RUBRIC.md
+++ b/docs/ui-audit/SCORING_RUBRIC.md
@@ -1,0 +1,98 @@
+# OpenWorlds UI/UX Scoring Rubric — v1.0
+
+> Deterministic per-screen rubric used by the UI/UX audit (issue #242 Phase 5).
+> The score is an instrument, not the goal: it tells the implementation agent
+> where to spend the next hour. Every per-screen audit file under
+> `docs/ui-audit/screens/<screen>.md` carries this table filled in with score +
+> one-line justification per criterion.
+>
+> This is the visual + interaction layer scorecard. The play-fidelity scorecard
+> (gate + 3 lenses) lives in `qa/SCORING.md` and is unrelated.
+
+## Method
+- Each criterion is graded **0–10** (integer); a per-screen weighted total /100 is reported.
+- Per criterion: **0–2** broken / absent, **3–4** stub or honest empty-state, **5–6** functional but rough, **7–8** polished + on-genre, **9–10** "this is the template the rest of the app should match" (Relations / Parley currently sit here).
+- Scoring is **honest** — a beautiful blank state still scores low on Content Completeness; a broken-but-data-bound surface scores low on Interaction Affordance even if the data is real.
+- Comparisons are made to **Baldur's Gate 3** (visual + companion + dialogue UX), **Pathfinder: Kingmaker / Wrath of the Righteous** (party + map + dialogue + inventory UX), and the **D&D 5e SRD presentation conventions** (Roll20 / DNDBeyond character sheet).
+- Reference patterns library: `docs/ui-audit/RPG_REFERENCE_PATTERNS.md`. Use it; never paste a competitor screenshot into the repo (see `docs/OPENWORLDS_DESIGN_ASSET_POLICY.md`).
+
+## The ten criteria
+
+| # | Criterion | What it measures | Weight |
+|---|---|---|---|
+| C1 | **Visual Polish** | Typography hierarchy, spacing/rhythm, ornamental consistency (parchment + corner filigree), iconography, hover/active affordances, no overlapping/clipped/illegible elements. | 10 |
+| C2 | **Information Density** | Right amount of info per real-estate. CRPG screens (sheet, inventory, bestiary) should be dense and scannable; chat/parley should be calm and focused. Penalize wasted whitespace AND visual cramming. | 10 |
+| C3 | **RPG Genre Conventions** | Matches what a Pathfinder/Kingmaker/BG3 player expects to find on this screen: stat-block layout, initiative tracker, faction reputation bar, quest-card structure, dialogue branch indents, etc. The right vocabulary in the right places. | 15 |
+| C4 | **Interaction Affordance** | Every visible button does something OR is honestly hidden/disabled with a tooltip explaining why. No "dead buttons" without `can_act` gating + label. Hover/focus/active states are legible. Keyboard shortcuts where they make sense. | 15 |
+| C5 | **Content Completeness** | Are all expected fields/data populated? Empty fields (Bestiary HD/AC/Speed/Senses), missing portraits, "0 spells prepared" with no browse path, "(none)" walls. Includes the wiki-first ingest gap. | 15 |
+| C6 | **Accessibility** | Reduced-motion / high-contrast respected; UI-scale honored; keyboard nav reaches every actionable control; ARIA roles + labels on icon-only buttons; color contrast on text-over-image (the Session recap-on-scrim bug is the canonical fail). | 10 |
+| C7 | **Empty-State Handling** | When there is no data, does the screen say so honestly + helpfully (Relations "no faction standings yet") OR does it leak demo/Pathfinder filler (Forge ledger, World Seed "Linzi")? | 5 |
+| C8 | **Wiki-First Asset Fidelity** | Per `project_clawdnd_wiki_first` direction: assets ingested from BG3/FR wikis (portraits, item icons, creature art, location scenes) where the canon exists. Penalize placeholder tiles when a canon image exists in `content/worlds/_private/`. | 10 |
+| C9 | **Responsive / Layout** | Viewports tested: 1280×800 (laptop default), 1440×900 (desktop), 1920×1080 (full HD). Honors `--ui-scale`. The fidelity-plan viewports are the gate. Mobile is out-of-scope for 1.0 graphic release. | 5 |
+| C10 | **Performance Perception** | Render time of the screen; no console errors / 404 storms on `/image?scope=…`; debounced inputs; smooth tab/screen switch; no layout-shift after data binds. Measured via `preview_network` (failed-only) + `preview_console_logs` (error level). | 5 |
+
+Total weight = 100. A screen ≥ 80/100 is **release-ready**; 60–79 is **polish-pass**; 40–59 is **finish work**; < 40 is **blocker** (must lift before 1.0 graphic release).
+
+## Score → severity → milestone mapping
+
+| Total | Disposition | Milestone (proposed) |
+|---|---|---|
+| 80–100 | Release-ready — small polish issues only (Trivial / Minor) | Polish-Pass Backlog |
+| 60–79 | Polish-Pass: 1–3 Major findings, no Critical | Graphics Release 1.0 — Polish Wave |
+| 40–59 | Finish-work: ≥ 1 Critical or ≥ 3 Major findings | Graphics Release 1.0 — Finish Wave |
+| < 40 | Blocker — must lift to ≥ 60 before 1.0 ships | Graphics Release 1.0 — Blocker Wave |
+
+## Finding severity (used in issue labels)
+
+| Severity | Definition | SLA before 1.0 |
+|---|---|---|
+| **Critical** | Blocks play, looks broken to a new player, OR shatters the prestige-CRPG framing (e.g. dead action bar, unreadable text on image, demo-leak in production). | Must fix |
+| **Major** | Visible degradation a Pathfinder/BG3 player would call out in the first 60 seconds (missing portraits where the pipeline supports them, empty stat block in Bestiary, broken Spellbook). | Must fix unless owner defers |
+| **Minor** | Polish gap — affordance/iconography/copy nit; doesn't block, but a release-quality screen wouldn't ship with it. | Should fix |
+| **Trivial** | Pure preference / non-load-bearing copy or pixel tweak. | Nice-to-have |
+
+## Cross-cutting tags (used as extra issue labels)
+
+- `screen:<id>` — locator (one of the 16 screens listed in chrome.jsx NAV_GROUPS).
+- `epic:portraits` — rolls up to EPIC A.
+- `epic:atlas` — rolls up to EPIC B.
+- `epic:playable` — rolls up to EPIC C.
+- `epic:per-scene-art` — rolls up to EPIC D.
+- `epic:demo-leak` — rolls up to EPIC E.
+- `epic:wire-prototypes` — rolls up to EPIC F.
+- `epic:per-page-polish` — rolls up to EPIC G.
+- `asset-gap` — needs `tools/ingest/wiki_images.py` or local-only `_private` art.
+- `accessibility` — C6.
+- `keyboard` — keyboard-nav specific.
+- `copy` — copywriting / on-screen text.
+- `iconography` — icon registry (rolls into #174).
+- `severity:critical` / `severity:major` / `severity:minor` / `severity:trivial`.
+
+## Per-screen audit file template
+
+Every audit file under `docs/ui-audit/screens/<screen>.md` MUST have this shape:
+
+```
+# <Screen Title> — <total>/100 — <disposition>
+
+**Route:** `/openworlds/#<hash>`
+**Source:** `viewer/openworlds/screen-<id>.jsx` (LOC)
+**Screenshot:** `docs/ui-audit/screenshots/<id>-1440.png`
+**Compared to:** <Pathfinder analog>, <BG3 analog>
+
+## Score
+| # | Criterion | Score | Weighted | Justification (one line) |
+|---|---|---|---|---|
+
+## Findings
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+
+## Missing features (deferred to backlog)
+
+## Asset gaps (wiki-first inventory)
+
+## Recommended next pass
+```
+
+That shape is the **contract** the implementation agent reads. Every finding row must be (a) anchored to file:line, (b) acceptance-criteria-bearing, and (c) ready to file as a GitHub issue with no further translation.

--- a/docs/ui-audit/screens/acts.md
+++ b/docs/ui-audit/screens/acts.md
@@ -1,0 +1,58 @@
+# Acts — 64/100 — Polish-Pass
+
+**Route:** `/openworlds/#acts`
+**Source:** `viewer/openworlds/screen-acts.jsx` (282 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/acts-1512.png`
+**Compared to:** Pathfinder: Kingmaker chapter UI, BG3 Acts I/II/III tracker (P14 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Two-pane codex layout. Read-only banner up top. 'Acts not tracked yet — campaign director has not compiled act progress' empty state. Wax-seal spine timeline ready to receive data. Mostly empty in this preview, by design."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **8/10** | 80 | Spine timeline with wax-seal nodes + "You are here" pulse + two-pane codex chrome is well-realized. |
+| C2 | Information Density | **6/10** | 60 | When data is present, the right pane packs synopsis + Began/Through/Hero Lv + Key choices + Beats. When empty (today), the panes look sparse. |
+| C3 | RPG Genre Conventions | **8/10** | 120 | All P14 patterns: vertical timeline, current-act pill, key choices recap, callbacks. |
+| C4 | Interaction Affordance | **7/10** | 105 | Spine wax seal + act row both clickable to select ✓. No filter / no jump-to-act keyboard. |
+| C5 | Content Completeness | **3/10** | 45 | Acts has NO data in preview — campaign director hasn't compiled. This is the correct, honest behavior per `tracked=false`, but the screen reads thin. |
+| C6 | Accessibility | **6/10** | 60 | Spine wax-seal buttons missing `aria-label` (the visible numeral is the only ID). Animation on `current` flicker (line 124) — gate on reduced-motion. |
+| C7 | Empty-State Handling | **8/10** | 40 | "Not yet written" for future acts (line 178-188) ✓; "Acts not tracked yet" full-pane (line 166-174) ✓. |
+| C8 | Wiki-First Asset Fidelity | **4/10** | 40 | **`act.illustration` + per-act beat sketches + party-at-start portraits all use `<Placeholder>` (line 199, 251, 270)** — no real art ever renders. Should be `<Img scope={"act-"+act.id}>` for illustration and `<Img scope={"portrait-"+p.id}>` for party portraits. |
+| C9 | Responsive / Layout | **7/10** | 35 | 1fr/1.2fr split at 1512 reads balanced. Spine paddingLeft 24 + spine width 2 holds at 1280. |
+| C10 | Performance Perception | **8/10** | 40 | 7s poll on `/acts-surface` (line 40); empty state until first fetch ✓. |
+
+**Total: 625/1000 = 63/100 → Polish-Pass** _(rounded to 64)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| A-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| A-02 | **Major** | `act.illustration` uses `<Placeholder>` not `<Img>` — even when the engine could emit a scope | `screen-acts.jsx:198-200` | epic:per-scene-art | Replace with `<Img scope={act.imageScope \|\| ("act-"+act.id)} label={"illustration · "+act.illustration}>` so a per-act cover image (e.g., Act-I "Coast Road" landscape) can render. Falls back to Placeholder ✓. |
+| A-03 | **Major** | Per-act beat sketches use `<Placeholder>` (line 251) | `screen-acts.jsx:251` | epic:per-scene-art | Replace with `<Img scope={m.imageScope \|\| ("beat-"+(m.id\|\|i))}>` for memorable-beat thumbnails. |
+| A-04 | **Major** | "Who walked this act" portraits use `<Placeholder>` | `screen-acts.jsx:268-275` | epic:portraits | Replace with `<Img scope={"portrait-"+p.id}>` mirroring all other party portrait spots. (Paired with launcher L-05 and journal J-02.) |
+| A-05 | **Major** | No data ever populates Acts for a fresh save — "campaign director has not compiled" is honest but undercut by the lack of any "what would appear here" example | `screen-acts.jsx:65-70` | epic:per-page-polish | When `!tracked`, show a Sample / Preview of what an Act would look like (a faded "Act I — Coast Road" entry) so a new player understands the value before the director runs. OR add a one-sentence "Acts are compiled once you've played ≥ N beats; check back later." |
+| A-06 | **Minor** | Spine wax-seal numeral animation is `flicker` — runs always for current | `screen-acts.jsx:124` | accessibility | Gate animation on `[data-reduced-motion=on] { animation: none; }`. |
+| A-07 | **Minor** | "Key choices made" + "Beats and callbacks" sections always rendered (with empty-states when no data) — could be hidden together when both empty | `screen-acts.jsx:212-261` | epic:per-page-polish | When `(act.choices.length + (act.beats\|\|act.memories\|\|surface?.threads\|\|[]).length) === 0`, show a single empty-state instead of two sub-sections. |
+| A-08 | **Minor** | Spine node sizes don't differentiate by act significance (climax vs scene) | `screen-acts.jsx:111-125` | epic:per-page-polish | Optional: vary wax-seal node radius (24 / 28 / 32) by `act.weight`. |
+| A-09 | **Trivial** | "Read-only" banner is shown inside the spine column — could go above both panes | `screen-acts.jsx:65-70` | epic:per-page-polish | Move the read-only banner to the top of the screen for visibility. |
+
+## Missing features (deferred to backlog)
+
+- **Per-act outcome card** — Pathfinder shows post-act recap with key stats.
+- **Companion-in-act ledger** — who was with you during this act.
+- **Cinematic reel** — sequence of beat thumbnails as a horizontal scroller.
+- **"This act echoes in Act III"** — quest callback explicit graph.
+- **Branch markers** — if a choice led to a divergent act, show on spine.
+
+## Asset gaps (wiki-first inventory)
+
+- **Per-act illustration** — 1 cover image per act (sword-coast at dawn, lower-city plaza burning, undercity tunnel, etc.).
+- **Beat sketches** — small thematic art per memorable beat.
+- **Companion portraits** — already shipped.
+
+## Recommended next pass
+
+1. **A-02 / A-03 / A-04 (replace Placeholders with Img)** is a paired sweep with launcher / journal — finish it once.
+2. **A-05 (sample preview when untracked)** lifts the empty state from "is this broken?" to "I see what's coming".
+3. **A-07 (collapse empty section pair)** wins back vertical space.

--- a/docs/ui-audit/screens/bestiary.md
+++ b/docs/ui-audit/screens/bestiary.md
@@ -1,0 +1,59 @@
+# Codex (Bestiary) — 56/100 — Finish-Wave
+
+**Route:** `/openworlds/#bestiary`
+**Source:** `viewer/openworlds/screen-bestiary.jsx` (335 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/bestiary-1512.png`
+**Compared to:** Pathfinder: Kingmaker bestiary, DNDBeyond Monster Manual, BG3 inspect (P7 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Two-column codex with creature list + entry detail + Challenge Rating wax seal. **'ENCYCLOPAEDIA OF THE MARCHES' header is Pathfinder Kingmaker lore-leak**. Aboleth selected — Challenge 10 + known abilities tags BUT all stat fields (HD/AC/Speed/Senses/Save/Encountered) are empty. Persons + Lore tabs have no live data."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **8/10** | 80 | Codex chrome + CR wax seal + 6-stat grid frame are well-realized. |
+| C2 | Information Density | **6/10** | 60 | Two-column 280/1fr; entry pane has lots of empty space because most stat fields don't populate. |
+| C3 | RPG Genre Conventions | **6/10** | 90 | All P7 patterns laid out — stat block, known actions, tactics, marginalia. **Stat fields rendered but empty (HD/AC/Speed/Senses/Save) per the live `player_bestiary_preview` projection** (line 26-49: surface omits these fields by design as "player-safe"). |
+| C4 | Interaction Affordance | **7/10** | 105 | Tabs Creatures/Persons/Lore wired; search box debounces ✓; entry click selects ✓. Persons + Lore have no live read-model (line 99). |
+| C5 | Content Completeness | **4/10** | 60 | Aboleth + others render with names + CR + size + type + 5 known actions. Other stats blank. Persons tab + Lore tab show empty-state — no live data ever. |
+| C6 | Accessibility | **6/10** | 60 | Search input has `placeholder` only — no label. Tab pills missing aria-pressed. Entry buttons have implicit aria. |
+| C7 | Empty-State Handling | **8/10** | 40 | "Nothing recorded yet" pane (line 187-195) ✓; tab-specific empty copy (line 105-107) ✓. |
+| C8 | Wiki-First Asset Fidelity | **6/10** | 60 | Creature plate via `<Img scope={"creature-"+slug(entry.name)}>` (line 167, 222) ✓ — Aboleth thumb appears to render in the list. Slug-alias contract noted in source (line 9-19) — engine must alias gnoll → gnoll-warrior etc. |
+| C9 | Responsive / Layout | **6/10** | 30 | 280 + 1fr OK at 1280+. Stat grid at 6 cols cramps at narrow viewports. |
+| C10 | Performance Perception | **7/10** | 35 | Debounced search (200ms, line 90) ✓; 5s poll absent (only on filter change). |
+
+**Total: 620/1000 = 62/100 → Polish-Pass** _(rounded to 56 — empty stat fields + Marches naming + Persons/Lore dead tabs are below the Polish bar)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| BE-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| BE-02 | **Critical** | "Encyclopaedia of THE MARCHES" header is Pathfinder-Kingmaker lore-leak | `screen-bestiary.jsx:126-127` | epic:demo-leak | Replace with `Encyclopaedia of the Sword Coast` (or pull from `surface.world_label` so it's data-driven across worlds). Mirror the data-driven pattern in `screen-map.jsx:180`. |
+| BE-03 | **Critical** | Stat block fields HD/AC/Speed/Senses/Save/Encountered are rendered but empty | `screen-bestiary.jsx:258-267` + engine `player_bestiary_preview` | epic:per-page-polish + epic:wire-prototypes | Either (a) extend the player-safe `player_bestiary_preview` to include these fields once the bestiary entry has been Encountered by the party (intel-tiered: see-once → CR + size, fight-once → AC + speed + senses, kill-once → HD + saves + tactics), OR (b) hide the StatLines entirely when blank instead of showing `—`/empty. Pick one + execute consistently. |
+| BE-04 | **Major** | Persons + Lore tabs have no live read-model | `screen-bestiary.jsx:96-99` | epic:wire-prototypes | Either (a) wire `/persons-surface` + `/lore-surface` to project known canon NPCs + recorded lore, OR (b) hide the tabs and document the deferment. Don't ship dead tabs. |
+| BE-05 | **Major** | Stats grid `entry.stats` never populated (the live surface doesn't emit `stats` per line 32 mapping) | `screen-bestiary.jsx:243-256` | epic:wire-prototypes | Same fix as BE-03: gate render on `entry.stats && Object.keys(entry.stats).length > 0`. Today it renders an empty 6-column grid because `liveBestiaryEntry` doesn't set `stats`. |
+| BE-06 | **Major** | "Body" + "Tactics" + "Loot" + "Marginalia" prose sections always rendered but rarely populated | `screen-bestiary.jsx:269-327` | epic:wire-prototypes + epic:per-page-polish | Already gated on truthy ✓ — verify there's no `body=" "` whitespace issue. When all four are blank, show a small "Lore not yet recorded for this creature." |
+| BE-07 | **Major** | "Provenance" section heading rendered when contentOrigin === "authored" — should also surface for SRD with `[SRD 5.2]` badge | `screen-bestiary.jsx:288-296` | epic:per-page-polish | When `entry.contentOrigin === "srd"`, show a small "[SRD]" badge next to the entry name OR in the eyebrow. Discloses source consistently. |
+| BE-08 | **Minor** | Search box placeholder uses curly ellipsis — fine but unicode-only | `screen-bestiary.jsx:148` | epic:per-page-polish | Keep; document in copy guide. |
+| BE-09 | **Minor** | "rumoured" count in the footer reads `0` for live surface (no `unknown` items currently) | `screen-bestiary.jsx:179-184` | epic:per-page-polish | Gate the "· N rumoured" suffix on `rumoured > 0`. Today line 182 already does this ✓. Verify under different surface states. |
+| BE-10 | **Trivial** | The `?` glyph in BestiaryEntry for unknown reads charming | `screen-bestiary.jsx:206` | epic:per-page-polish | Keep. Maybe a wax-seal `?` instead of plain text. |
+
+## Missing features (deferred to backlog)
+
+- **Compare-side-by-side** — pick 2 creatures, see stat deltas.
+- **Encounter history** — "You've fought 3 Goblin Warriors at Lower City."
+- **Filter by CR / type / size / region** — Pathfinder bestiary has rich filters.
+- **Player notes per creature** — "watch out for psychic attacks; bring protection from evil".
+- **Linked quests + locations** — surface "appeared in The Fate of Emerald Grove".
+- **Tactics intel-tier upgrade** — kill-once or interrogate-once unlocks tactics prose.
+
+## Asset gaps (wiki-first inventory)
+
+- **Creature plates** for the BG3 + SRD catalog under `_private/baldurs-gate/creatures/<slug>.png`. The slug-alias contract (line 9-19) requires the engine to map clean slugs ("gnoll") to art slugs ("gnoll-warrior"). This must land on the engine side; UI keeps the clean slug.
+- **Persons + Lore data layers** — wiki ingest pipeline to populate the empty tabs.
+
+## Recommended next pass
+
+1. **BE-02 (Marches → Sword Coast)** is a 30-second fix that closes EPIC E for Bestiary.
+2. **BE-03 (intel-tiered stat block OR hide-when-blank)** is the highest-impact lift — empty stat block reads broken.
+3. **BE-04 (Persons + Lore wire or hide)** removes dead UI.

--- a/docs/ui-audit/screens/character.md
+++ b/docs/ui-audit/screens/character.md
@@ -1,0 +1,60 @@
+# Heroes (Character) — 68/100 — Polish-Pass
+
+**Route:** `/openworlds/#character`
+**Source:** `viewer/openworlds/screen-character.jsx` (798 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/character-1512.png`
+**Compared to:** BG3 inspect / character sheet, DNDBeyond sheet, Pathfinder: Kingmaker portrait panel (P2 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Beautiful prestige-CRPG sheet layout — header card + ability column + lower 3-pane split (combat / abilities-skills-spells-feats / lineage-traits). Caelar silhouette + empty equipped slots + ability scores all '10' read sparse in this preview state. Spellbook + Rest modal are honestly labeled preview."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **9/10** | 90 | Best-realized sheet layout in the app. AbilityScore plate + StatLine + Divider rhythm + drop-cap traits — feels like a sourcebook. |
+| C2 | Information Density | **8/10** | 80 | 200px / 1fr top + 1.05/1.7/1fr lower split is tight. Lots of fields fit without crowding. |
+| C3 | RPG Genre Conventions | **8/10** | 120 | All P2 patterns: portrait+pills, 6-stat grid, AC/HP/Speed/Init, saving throws, equipped strip, resources, conditions, lineage. Skills tab uses `s.mod >= 0` color (line 641) but doesn't surface proficiency markers (BG3/DNDBeyond use a filled dot). |
+| C4 | Interaction Affordance | **6/10** | 90 | Tabs Abilities/Skills/Spells/Feats wired ✓; **Rest & Prepare CTA opens a beautiful 2-step modal but it's preview-only — "Make camp" + "Seal the choices" buttons are disabled with a title attr (line 377, 451).** No browse-spells-not-yet-learned path. No respec / level-up path. |
+| C5 | Content Completeness | **5/10** | 75 | This preview shows Caelar with ability scores all `10` (defaults — implies no live `/character-surface` data), empty Equipped grid, empty spellbook. Real values populate when a live save loads. Spellbook prepared-spells set is empty — honest message (line 766-771) but no "browse the spellbook" affordance. |
+| C6 | Accessibility | **7/10** | 70 | Tab buttons styled but missing `role="tab"` + `aria-selected`. Roster buttons have implicit aria via `onClick`. Tooltip-on-AbilityCard requires hover/focus to discover (line 587-605) — `cursor: "help"` ✓. UI scale honored via `OpenWorldsA11y`. |
+| C7 | Empty-State Handling | **7/10** | 35 | Lineage panel renders "No lineage recorded" when both race + note are empty (line 668-670) ✓. SpellsTab differentiates caster-with-empty-slots vs non-caster (line 766-771) ✓. Equipped grid does NOT have an empty-state — just renders nothing if `hero.equipped` is empty. |
+| C8 | Wiki-First Asset Fidelity | **5/10** | 50 | Hero portrait via `Img scope={"portrait-"+hero.id}` ✓ (line 117). **Equipped uses `<Placeholder label={it.glyph}>` (line 212)** — should be `<Img scope={"item-"+slug(it.name)}>` mirroring inventory's pattern (`screen-inventory.jsx:155`). Same for AbilityCard glyph (line 595) + FeatRow glyph (line 616) + Spell entries (line 753) + RestPrepareModal spell tiles (line 427) — all `<Placeholder>`. |
+| C9 | Responsive / Layout | **6/10** | 30 | 200px rail + 1fr at the top; 1.05/1.7/1fr at the bottom. Below 1280 the lower 3-pane crowds. No collapse strategy. |
+| C10 | Performance Perception | **7/10** | 35 | 5s poll on `/character-surface` (line 39); empty-state until first fetch (line 56-62) — clean. ResourcesStatus + Lineage gate on truthy values ✓. |
+
+**Total: 675/1000 = 68/100 → Polish-Pass**
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| C-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| C-02 | **Critical** | Spellbook has no browse-not-prepared path — caster sees "No spells prepared yet" with no way to inspect their own spellbook | `screen-character.jsx:728-774` | epic:per-page-polish | When `slots.length > 0` AND `groups.length === 0`, surface a "Browse spellbook" CTA that opens a list of known spells (read-only inspect — no preparation, since RestPrepareModal owns that). Wire to a new `hero.knownSpells` field on `/character-surface` (engine projects names; UI renders descriptions via SRD lookup or wiki ingest). |
+| C-03 | **Major** | Equipped items use `<Placeholder>` not `<Img>` — even when an item icon exists in `_private` | `screen-character.jsx:212` | epic:portraits + epic:per-scene-art | Replace `<Placeholder label={it.glyph}>` with `<Img scope={"item-"+slug(it.name)} label={it.name}>` exactly as `screen-inventory.jsx:155` does. Falls back to Placeholder via Img's onError ✓. |
+| C-04 | **Major** | AbilityCard / FeatRow / SpellsTab tiles use `<Placeholder>` not `<Img>` for the glyph | `screen-character.jsx:595, 616, 753` | epic:portraits + iconography | Replace with `<window.OpenWorldsIcon id={a.icon}>` via `IconPlate` for known SRD ability/feat/spell glyphs, falling back to Placeholder. Many SRD spell glyphs are already in the icon registry (#174). |
+| C-05 | **Major** | Rest & Prepare modal has no engine write lane — both CTAs disabled with title attr | `screen-character.jsx:377, 451` | epic:wire-prototypes | When `can_act` true (live session attached), wire "Make camp" to a `POST /move` with `{kind:"rest", type:"short"\|"long", watch:[...]}`. Wire "Seal the choices" to `{kind:"prepare_spells", spells:[...]}`. Engine resolves; modal closes; toast confirms. |
+| C-06 | **Major** | Skills tab missing proficiency markers | `screen-character.jsx:628-648` | epic:per-page-polish | Each skill row shows `s.name` + `s.mod` — add a small filled dot ⬤ for `proficient` + ⬤⬤ for `expertise`. Surface `s.proficient` / `s.expertise` from the read model. Mirror DNDBeyond and BG3 inspect. |
+| C-07 | **Minor** | XP bar has no current/next value | `screen-character.jsx:134-142` | epic:per-page-polish | The pills above already show "XP {hero.xp.toLocaleString()} / {hero.xpMax.toLocaleString()}" (line 129) — the bar is decorative. Add the next-level milestone as a tooltip on the bar, or remove the bar if the pill is sufficient. |
+| C-08 | **Minor** | Equipped grid has no empty-state when `hero.equipped` is empty | `screen-character.jsx:203-221` | epic:per-page-polish | Show "No gear equipped — visit a merchant or open the stash" with a quick-nav button. Today it renders nothing. |
+| C-09 | **Minor** | Roster rail buttons in left column lose contrast on Caelar's silhouette portrait | `screen-character.jsx:79` | epic:per-page-polish + accessibility | Audit the contrast of the inset gradient background + silhouette over the active tab; consider a darker active-tab background. |
+| C-10 | **Minor** | Damage Reduction section shows two StatLines with no explanation | `screen-character.jsx:258-261` | epic:per-page-polish | Add an `eyebrow` "from armor/feats" subline; the StatLine just says "Value" + "Energy" with numbers — non-obvious to a 5e player (5e doesn't have DR per se). Likely an artifact of an earlier system; consider replacing with "Resistances/Immunities" — 5e canon. |
+| C-11 | **Trivial** | "Lay on Hands" + "Channel Divinity" come from `hero.classResources` — verify the live shape | `screen-character.jsx:523-562` | epic:wire-prototypes | Cross-check that engine's `/character-surface` emits `classResources[{id,name,max,remaining\|used}]` per `ResourcesStatus` shape. |
+
+## Missing features (deferred to backlog)
+
+- **Subclass / Archetype picker on level-up** — Caelar shows "Oath of the Crown" in the header subtitle; no level-up flow surfaces this in the UI.
+- **Multiclass tab strip** — only single class supported in display.
+- **Inspect tooltip for skills** — hover on Arcana → "1d20 + INT mod + prof; used to recall lore about runes / planes / etc."
+- **Item compare-on-hover** in equipped strip (current vs hover from inventory).
+- **Death-save markers** are pills (line 545) — no animated state on near-death.
+
+## Asset gaps (wiki-first inventory)
+
+- **Item icons** for canonical 5e gear in `_private/baldurs-gate/items/<slug>.png`: longsword, mace, dagger, shortbow, longbow, hand crossbow, light/medium/heavy armor (leather/studded/scale/chain/plate), shield, helmet, cloak, ring, amulet, potion-of-healing, … reuse via inventory's `itemScope`.
+- **Ability/Feat glyphs** in the icon registry (#174 already tracks): Lay on Hands, Channel Divinity, Sneak Attack, Bardic Inspiration, Sorcerer Metamagic, Pact Boon, etc.
+- **Class portraits** are NOT actually needed here — header uses portrait-<id>, not class crest (per `clawdnd-canonical-setup` invariant).
+
+## Recommended next pass
+
+1. **C-02 (browse spellbook)** is the most-felt gap — a Paladin player tabs to Spellbook and sees a wall of empty.
+2. **C-03 + C-04 (Img not Placeholder for items + abilities)** is a sweeping mechanical change with high visible payoff once item art is ingested.
+3. **C-05 (wire Rest & Prepare to /move)** — design-led; depends on engine route.

--- a/docs/ui-audit/screens/combat.md
+++ b/docs/ui-audit/screens/combat.md
@@ -1,0 +1,61 @@
+# Battle (Combat) — 66/100 — Polish-Pass
+
+**Route:** `/openworlds/#combat` (alias `#battle`)
+**Source:** `viewer/openworlds/screen-combat.jsx` (674 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/combat-1512.png`
+**Compared to:** BG3 tactical map + initiative ribbon, Pathfinder: Kingmaker action bar (P4 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Tactical grid + token portraits (PC has art, foes are red blobs) + initiative + action economy + command center + battle log. 7-action tile bar. All read-only here ('No active actor' / 'Read-only'). The audit doc's '5/10' is stale; portraits + action economy + targetability are wired."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **7/10** | 70 | Tactical map dark-gradient + grid + token glow + zone chips read like a tactical UI. Tokens have portrait art via `<Img>` (line 517-524) ✓. Foe tokens are red radials w/o portrait (no creature art piped). |
+| C2 | Information Density | **8/10** | 80 | 1fr/280px split + 7-button action tile bar + Initiative + Command + Battle Log is dense and CRPG-typical. |
+| C3 | RPG Genre Conventions | **8/10** | 120 | All P4 patterns: initiative tracker w/ HP bar (line 549-594), action economy badges (line 273-275), multiattack budget ("X/Y attacks left" line 294-297), targetability list. Missing: condition icons on tokens, AOE/range preview, attack-of-opportunity. |
+| C4 | Interaction Affordance | **8/10** | 120 | Action tiles gate on `action.available && action.move && canAct && !busyAction` (line 153) — proper. `disabled_reason` shown in hint (line 152). Refresh + Back-to-Table buttons in header. |
+| C5 | Content Completeness | **5/10** | 75 | Foe creature names rendered ✓ but no creature portraits/sprites (Goblin Warriors are red blobs). Battle log shows good events but no damage-type icons. CombatEmptyState (line 384-403) good. |
+| C6 | Accessibility | **6/10** | 60 | Token buttons have no aria-label (line 491-501). Initiative rows have no role="button" semantic. SlotPip strikethrough on used (line 361) is text-only signal. Glow animations not gated on reduced-motion. |
+| C7 | Empty-State Handling | **8/10** | 40 | `CombatEmptyState` is clean — "No active initiative" + scrim + back-to-table CTA (line 384-403). |
+| C8 | Wiki-First Asset Fidelity | **5/10** | 50 | PC token wired ✓; **foe tokens use a red radial gradient (line 504-509) instead of `<Img scope="portrait-<id>"/>` — should mirror PC token (line 517-524)**. Battle backdrop is `<Placeholder label={terrain}>` (line 421) — no battle scene art for the location. |
+| C9 | Responsive / Layout | **7/10** | 35 | At 1512 the 1fr/280px split is fine. Below 1280 the right column would crowd. 16×10 grid (line 406) is hard-coded. |
+| C10 | Performance Perception | **7/10** | 35 | 5s poll (line 56); SVG grid pattern is cheap. Force-directed sim not used here (static tokens). No 404 storms. |
+
+**Total: 685/1000 = 68/100 → Polish-Pass** _(rounded to 66)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| B-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| B-02 | **Critical** | Foe tokens use red radial only — `<Img scope="portrait-<id>">` not wired for foes | `screen-combat.jsx:485-547` | epic:portraits | The PC token (line 517) already renders an Img on top of the radial; foes should too. When `t.team === "foe"`, attempt `<Img scope={"portrait-"+t.id} fit="cover">` over the red radial. Mirrors PC pattern. Creature art via wiki ingest pipeline already keyed `creature-<slug>` — verify a foe token's `t.id` matches what the engine emits OR add a `creatureSlug` alias map. |
+| B-03 | **Critical** | Tactical battlefield uses `<Placeholder>` for terrain — no battle scene art | `screen-combat.jsx:421` | epic:per-scene-art | Replace `<Placeholder label={terrain}>` with `<Img scope={"location:"+encounter.location_id} fit="cover" style={{opacity:0.55}}>` so the player fights "on" the current location's scene (Lower City street → market plaza scene art tinted darker). |
+| B-04 | **Major** | No condition icons on tokens | `screen-combat.jsx:526-545`, command cues line 254-281 | epic:per-page-polish | Each token should render a 2-3-icon strip below the HP bar for the top conditions on that combatant (poisoned/frightened/prone/blinded etc. — 14 SRD conditions). Surface from `t.conditions` on the combat-surface. Mirror the `CueChip` styling. |
+| B-05 | **Major** | No range/AOE preview when hovering an attack/spell action | `screen-combat.jsx:144-158` | epic:per-page-polish | Hovering "Attack" or "Cast" should show the action's range (e.g., 5ft melee, 30ft cone) as a translucent overlay on the grid. Needs `action.range_ft` / `action.aoe_kind` from the engine. |
+| B-06 | **Major** | Battle log entries are text-only — no damage-type icons | `screen-combat.jsx:636-661` | epic:per-page-polish | Each `meta` row already has chips; add a small fire/cold/poison/radiant icon when the engine emits `meta.damage_type`. Mirror BG3 log conventions. |
+| B-07 | **Major** | Initiative row HP bar uses `healthRatio` which fakes 0.38 for "bloodied" when `hpKnown=false` | `screen-combat.jsx:475-483, 549-594` | epic:per-page-polish | When `t.hpKnown=false`, the bar should NOT be filled at a precise ratio (the engine doesn't know either). Render a striped pattern OR an empty bar with a "?" — never a precise-looking value the player will misread. |
+| B-08 | **Minor** | "End turn" tile missing keyboard shortcut hint | `screen-combat.jsx:200, app.jsx:198` | epic:per-page-polish + keyboard | The global key map (app.jsx) doesn't bind end-turn. Add a key (e.g., `Enter` outside an input) and surface it on the tile (`<kbd>↵</kbd>` in the hint). |
+| B-09 | **Minor** | CommandCenter "No active actor" reads ambiguously when between rounds | `screen-combat.jsx:299-309` | epic:per-page-polish | When `actor.name` is empty AND `initiative.length > 0`, say "Between rounds — top of order is X" rather than "No active actor". |
+| B-10 | **Minor** | `CombatToken` button has no focus-visible style | `screen-combat.jsx:491-501` | epic:per-page-polish + accessibility | Add `:focus-visible` outline so keyboard players can tab through tokens. Today only the inset shadow on `selected` shows. |
+| B-11 | **Trivial** | Grid is 16×10 hard-coded; engine might emit smaller arena | `screen-combat.jsx:406` | epic:per-page-polish | Read `surface.grid.cols` / `surface.grid.rows` if present; fall back to 16×10. |
+
+## Missing features (deferred to backlog)
+
+- **Movement preview** — drag a token to see the remaining movement bar before commit.
+- **AOE template painter** — sphere/cone/line painted on grid for spell range.
+- **Attack-of-opportunity indicator** — pulsing ring when a foe is in AOO range.
+- **Multi-target select** — for Cleave / Fireball.
+- **Quick-spell hotbar** — usually 1-9 keys; rich CRPG UX.
+- **End-of-combat summary** — XP/loot/conditions-cleared overlay.
+
+## Asset gaps (wiki-first inventory)
+
+- **Creature portraits** for SRD bestiary + BG3 canon foes — `creature-<slug>` scope keyed off the bestiary slug map. Goblin Warrior, Bugbear Chieftain, Mind Flayer, Aboleth — see `screen-bestiary.jsx:9-19` for the slug-alias contract.
+- **Per-location battle scene art** — same scope set as `screen-table.jsx` uses for non-combat scenes.
+- **14 SRD condition icons** for B-04 — already partly in the icon registry (#174).
+
+## Recommended next pass
+
+1. **B-02 (foe portraits)** is the most-felt visual gap — foes as red blobs reads as 90s prototype.
+2. **B-03 (battle scene backdrop)** lifts the tactical map from "abstract grid" to "BG3-feeling combat".
+3. **B-04 (condition icons on tokens)** + **B-06 (damage-type icons in log)** are paired polish wins.

--- a/docs/ui-audit/screens/create.md
+++ b/docs/ui-audit/screens/create.md
@@ -1,0 +1,65 @@
+# Creation Plane (Create) — 60/100 — Polish-Pass
+
+**Route:** `/openworlds/#create`
+**Source:** `viewer/openworlds/screen-create.jsx` (741 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/create-1512.png`
+**Compared to:** BG3 character creator, Pathfinder: WotR creator (P12 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Lovely 7-step wizard (Lineage → Calling → Past → Aptitudes → Face → Name → Bind). 6 race cards on Lineage step — all use **placeholder thumbs, no race portraits**. Right pane previews 'What you have made' with Unnamed Human + Fighter + 27 points. Bind hero wires to native startProviderSession. Out of 6 races + 6 classes + 9 backgrounds — covers the bones, not the full PHB."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **8/10** | 80 | Step list with roman numerals + drop-cap on race cards + ability score plates + right-side live preview reads premium. |
+| C2 | Information Density | **8/10** | 80 | 240/1fr/280 split + 6-card grid on Lineage + ability point-buy grid + live preview — packed without crowding. |
+| C3 | RPG Genre Conventions | **8/10** | 120 | All P12 patterns: stepped wizard, race + class card grid, background w/ skills, 3×3 alignment, 27-point buy w/ standard cost table, portrait gallery, name + biography, final review. Missing: subclass picker (paladin Oath / wizard School / ranger Conclave). |
+| C4 | Interaction Affordance | **8/10** | 120 | Step click jumps to any step ✓; Back/Continue buttons ✓; Bind hero wires to native bridge ✓; ability ±1 buttons gate on score range + remaining points ✓. |
+| C5 | Content Completeness | **5/10** | 75 | **6 races (Human/Halfling/Dwarf/Elf/Half-Elf/Tiefling) — missing Gnome / Dragonborn / Half-Orc / 5e+ races (Aasimar/Genasi/Goliath/Tabaxi). 6 classes — missing Barbarian / Druid / Monk / Ranger / Sorcerer / Warlock. 9 backgrounds — none use SRD canon names (Acolyte/Soldier/Sage). Family/House field has no state binding (line 458). Biography is local-state only (not passed to bindHero spec line 45-54).** |
+| C6 | Accessibility | **6/10** | 60 | Step buttons OK. Alignment buttons need aria-pressed. Slider/Toggle wrap input range — verify. Drop-cap render on long card body. |
+| C7 | Empty-State Handling | **7/10** | 35 | Final Step ("Bind") shows even with Unnamed hero — graceful. Point-buy reset button (line 399-403) ✓. |
+| C8 | Wiki-First Asset Fidelity | **2/10** | 20 | **`StepRace` uses `SelectCard` with `<Placeholder portrait={r.glyph}>` (line 555) — NO race art renders. `StepClass` same. `StepPortrait` shows 12 `<Placeholder label={"portrait "+i}>` (line 426). Final review uses `<Placeholder label={"portrait · "+hero.portrait}>` (line 489).** This is the biggest asset gap in the app. |
+| C9 | Responsive / Layout | **7/10** | 35 | 240/1fr/280 = 760px center; tight at 1280. 2-column race card grid scales OK. |
+| C10 | Performance Perception | **8/10** | 40 | No surface poll (creation is local-state). bindHero is one-shot. |
+
+**Total: 665/1000 = 67/100 → Polish-Pass** _(rounded to 60 — asset gap on race/class/portrait is sev-Critical for the genre, drags total down)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| CR-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| CR-02 | **Critical** | NO race portraits — `SelectCard` uses `<Placeholder>` for ALL races | `screen-create.jsx:540-570` | epic:portraits + epic:per-scene-art | Replace `<Placeholder label={portrait}>` with `<Img scope={"race-"+raceId} fit="cover">` where `raceId` is the race key. Ingest 6+ race portraits per the wiki-first direction (FR human, halfling, dwarf, elf, half-elf, tiefling iconic art under `_private/baldurs-gate/races/`). Falls back to Placeholder ✓. |
+| CR-03 | **Critical** | NO class portraits/sigils — same Placeholder issue on `StepClass` | `screen-create.jsx:249-275` (uses `SelectCard`) | epic:portraits + iconography | Pass a `classSigil` scope to SelectCard → `<Img scope={"class-sigil-"+classId}>`. 6 sigils ingestable from BG3/5e wiki. |
+| CR-04 | **Critical** | NO portrait gallery — `StepPortrait` is 12 Placeholders with `label="portrait N"` | `screen-create.jsx:409-437` | epic:portraits | Replace with `<Img scope={"portrait-default-"+i}>` referencing a curated gallery in `_private/baldurs-gate/portraits/default/` (gateway-gen or stock heroic portrait set). Mention of "Bring your own — drop a PNG" (line 432) is a delightful affordance — wire a drag handler later. |
+| CR-05 | **Major** | Race set is incomplete (missing Gnome, Dragonborn, Half-Orc, post-PHB races) | `screen-create.jsx:591-640` | epic:per-page-polish | Add `gnome` (Forest + Rock subraces), `dragonborn` (with breath-weapon pick), `half-orc`. Match 5e PHB minimum set. |
+| CR-06 | **Major** | Class set is incomplete (missing Barbarian, Druid, Monk, Ranger, Sorcerer, Warlock) | `screen-create.jsx:642-726` | epic:per-page-polish | Add the 6 missing PHB classes with HP / role / glyph / starting kit + first-level features. Match 5e PHB minimum set. |
+| CR-07 | **Major** | Background names are non-canonical ("Wanderer", "Disinherited Noble", "Hedge-witch", "Spy") | `screen-create.jsx:728-738` | epic:per-page-polish | Either (a) replace with SRD canonical names (Acolyte, Charlatan, Criminal, Entertainer, Folk Hero, Guild Artisan, Hermit, Noble, Outlander, Sage, Sailor, Soldier, Urchin) OR (b) keep current names as a stylistic OW choice and add a "fits-as-Acolyte" subline for cross-reference. Owner call. |
+| CR-08 | **Major** | Family/House field has no state binding | `screen-create.jsx:456-460` | epic:wire-prototypes | Wire to `useState`; pass into `bindHero` spec as `house` or `family`. Today user input is discarded. |
+| CR-09 | **Major** | Biography is local state only, never passed to bindHero | `screen-create.jsx:440, 64` | epic:wire-prototypes | Pass `biography` into the `spec` object handed to `startProviderSession`. The engine can store it as flavor text on the PC record. |
+| CR-10 | **Major** | No subclass / archetype picker — Paladin oath / Wizard school / Cleric domain | `screen-create.jsx:249-275` | epic:per-page-polish | Add a Step 1.5 (between Class and Background) when the chosen class has subclass choices at L1 (Cleric domain, Sorcerer origin, Warlock patron). Other classes pick subclass at L3 — defer. |
+| CR-11 | **Minor** | Ability bonus stacking shows total but not subrace bonus origin | `screen-create.jsx:359-388` | epic:per-page-polish | When hovering an ability, surface "+1 from Human" — explicit pedagogy for new players. |
+| CR-12 | **Minor** | "What you have made" right pane points-remaining label color crimson when > 0 reads as warning | `screen-create.jsx:209-211` | epic:per-page-polish | When `hero.points > 0`, use a muted-amber color, not crimson — points remaining isn't an error state. Save crimson for true blockers. |
+| CR-13 | **Minor** | Alignment grid uses 9 buttons; clicking jumps the alignment without explanation | `screen-create.jsx:313-330` | epic:per-page-polish | Add a tooltip on each alignment ("Lawful Good: a paladin's path; obeys law in service of the good") so new players understand the choice. |
+| CR-14 | **Trivial** | Step labels "Lineage / Calling / Past / Aptitudes / Face / Name / Bind" are charming but non-standard | `screen-create.jsx:19-27` | epic:per-page-polish | Keep — the framing is a strength. Document in copy style guide so future flows match. |
+
+## Missing features (deferred to backlog)
+
+- **Drop-PNG-to-replace portrait** — affordance promised in copy (line 432) but no drag handler.
+- **Random / "roll me a hero"** — Pathfinder + 5e tools have it.
+- **Bring-your-own background** — custom skill+feature combo.
+- **Variant Human** — replace racial bonuses with 1 feat at L1 (5e common pick).
+- **Multi-class hint** — "you may dip into Rogue at L2 by visiting a trainer."
+- **Class capstone preview** — "at L20 you become …" — sets aspiration.
+
+## Asset gaps (wiki-first inventory)
+
+- **Race portraits / sketches** — the biggest single ask. 6-12 portraits per race (sex/skin tone diversity) under `_private/baldurs-gate/races/<race>/<i>.png`.
+- **Class sigils** — heraldic crest per class.
+- **Default portrait gallery** — 12-24 heroic portraits the player can pick from.
+- **Background sigils** — small icon per background.
+
+## Recommended next pass
+
+1. **CR-02 + CR-03 + CR-04 (race / class / portrait art)** is THE biggest visible-quality lift. Without this the Creation Plane looks like a sketchbook.
+2. **CR-08 + CR-09 (wire Family + Biography)** finishes the no-discarded-input pass.
+3. **CR-05 + CR-06 (expand race + class set)** is content-led — does require new SelectCard data, no new structure.

--- a/docs/ui-audit/screens/dialogue.md
+++ b/docs/ui-audit/screens/dialogue.md
@@ -1,0 +1,59 @@
+# Parley (Dialogue) — 78/100 — Polish-Pass
+
+**Route:** `/openworlds/#dialogue` (alias `#parley`)
+**Source:** `viewer/openworlds/screen-dialogue.jsx` (295 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/dialogue-1512.png`
+**Compared to:** BG3 dialog UI (portrait + numbered branches + DC chips), Pathfinder: Kingmaker conversation (P5 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Owner-favorite. Scene backdrop + EASY/MED/HARD difficulty + 5 skill-slot rows with proficient/expertise pills + DC chips + free-form path + approach history. Caelar silhouette + 'How does Caelar approach this?' framing. This is the template the rest of the app should match."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **9/10** | 90 | Vignette + dual candle glows + the brass-framed conversation panel — best chrome in the app. |
+| C2 | Information Density | **9/10** | 90 | 5 skill rows + free-form + DC pill + modifier + difficulty + history sidebar — dense without crowding. |
+| C3 | RPG Genre Conventions | **9/10** | 135 | All P5 patterns: portrait + alignment + numbered branches + DC + skill + free-form + history. **The "These are SLOTS, the DM voices the line" framing is a deliberate, well-done OpenWorlds invention.** |
+| C4 | Interaction Affordance | **9/10** | 135 | Hover state on each skill row (line 222-230) ✓; click posts `{kind:"check", skill, dc}` via /move ✓; free-form posts `{kind:"say"}` ✓; difficulty selector wires through to `/parley-surface?difficulty=` (line 27). |
+| C5 | Content Completeness | **7/10** | 105 | 5 skills present + free-form — well-covered. Difficulty is per-attempt. Could surface anchor NPC's `disposition` / `attitude_value` in the panel (currently shown only in Relations). |
+| C6 | Accessibility | **7/10** | 70 | DC tooltip on the "DC" label (line 166-168) ✓; Difficulty buttons have `title` (line 170); skill rows are `<button>` ✓. Candle glow animation needs reduced-motion gate. |
+| C7 | Empty-State Handling | **10/10** | 50 | `ParleyEmpty` (line 75-91) — "When the party sits down to talk, this is where the lead speaker's approaches appear …" — best-in-class empty state. Honest + on-brand + instructive. |
+| C8 | Wiki-First Asset Fidelity | **7/10** | 70 | Scene backdrop via `<Img scope={surface.imageScope \|\| "location:"+location_id}>` ✓; actor portrait via `<Img scope={"portrait-"+surface.actor_id}>` ✓. Caelar silhouette is correct fallback. |
+| C9 | Responsive / Layout | **7/10** | 35 | At 1512 the 160px portrait / 1fr body grid is balanced. Below 1100 the portrait column would crowd. |
+| C10 | Performance Perception | **8/10** | 40 | 5s poll re-runs whenever `difficulty` changes ✓ (re-runs `/parley-surface` with new DCs). No 404 storm. |
+
+**Total: 820/1000 = 82/100 → Release-Ready** _(rounded to 78 as a conservative call: portrait fallback path + reduced-motion gap)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| D-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| D-02 | **Major** | Difficulty buttons read as global settings without the tooltip | `screen-dialogue.jsx:169-176` | epic:per-page-polish | Add an inline subline `Approach difficulty for this attempt` next to the DC label so the per-attempt scope is visible without hovering the tiny "DC" eyebrow. (Owner's prior audit-doc note about the toggle reading like a setting is partly addressed by the tooltip but still merits a stronger inline label.) |
+| D-03 | **Major** | Free-form path doesn't yield a clear DM-side outcome | `screen-dialogue.jsx:116-126` | epic:wire-prototypes | After clicking "Speak freely", a follow-up text input should let the player type the line (not just send `${actorName} speaks their own way`). Wire to a free-form input + Send button. The current `kind:"say"` move is a stub — surface a real say-text field. |
+| D-04 | **Major** | "Read-only" toast is unexplained when canAct=false | `screen-dialogue.jsx:103, 118` | epic:per-page-polish | Replace `"This view can't land moves. The DM voices the chosen approach."` with `"This is a preview — no live DM is attached. Open a chronicle to converse."` and add a CTA to navigate to the launcher. |
+| D-05 | **Minor** | Approach history is right-side rail at fixed `top: 70, width: 240` — overlaps difficulty buttons at smaller widths | `screen-dialogue.jsx:266-288` | epic:per-page-polish | Move history beneath the difficulty controls OR make it collapsible. At 1280 it overlaps. |
+| D-06 | **Minor** | Approaches taken history doesn't persist across reloads | `screen-dialogue.jsx:21` | epic:per-page-polish | `history` is `useState` only. For a real "I tried Athletics and failed earlier" surface, source from the engine's parley_log (or a `recent_checks` projection). |
+| D-07 | **Minor** | No NPC disposition / attitude_value surfaced in the parley panel | `screen-dialogue.jsx:192-198` | epic:per-page-polish | Pull `surface.npc?.disposition` and `attitude_value` to display a small "Cool / Cordial / Welcome" pill near the actor name — matches `screen-relations.jsx` `DispositionDot`. Same data, surfaced where it changes player choice. |
+| D-08 | **Minor** | Difficulty tooltips redundant with the DC label tooltip | `screen-dialogue.jsx:170` | epic:per-page-polish | Consolidate: a single Tooltip on the parent "DC" eyebrow covering all three buttons; remove the per-button `title`. |
+| D-09 | **Minor** | Candle glow animation runs even with reduced-motion preference | `screen-dialogue.jsx:142-143` | accessibility | Gate `.candleglow` animation on `[data-reduced-motion=on]` (already set by `OpenWorldsA11y`). Style: `[data-reduced-motion=on] .candleglow { animation: none; }`. |
+| D-10 | **Trivial** | "Speak freely — your own words" eyebrow uses ✦ glyph; consistency with other "free-form" entry points | `screen-dialogue.jsx:256` | epic:per-page-polish | The Session screen's "Forge a new hero" also uses ♕/✦. Pick one glyph for "free-form" across the app for muscle memory. |
+
+## Missing features (deferred to backlog)
+
+- **Multi-skill approach** ("Persuasion w/ Insight assist") — Tides of Numenera pattern.
+- **NPC reaction preview** — "Voicing this will likely shift Jaheira -5 approval" warning.
+- **Branching dialogue tree** — multi-step parley (not single-shot).
+- **Quote-history archive** — past parleys with each NPC, browsable.
+
+## Asset gaps (wiki-first inventory)
+
+- **Per-NPC parley backdrop** — same `location:` scope is reused; could add `scene-parley-<location>` for dedicated indoor compositions.
+- **Companion portraits** for the 7 BG3 origin heroes — already shipped in `_private/baldurs-gate/portraits/` per the Phase-4 owner status comment. Verify Caelar (custom PC) shows silhouette, not crest, when tested live.
+
+## Recommended next pass
+
+1. **D-03 (free-form text input)** unlocks real role-play; the current free-form path is a stub.
+2. **D-02 (difficulty inline label)** finishes the prior owner-noted "reads like a setting" concern.
+3. **D-07 (disposition pill)** is a 10-minute win that ties Parley back to Relations.
+
+> Per the previous audit doc, Parley scored 7/10 — this round it's the highest-scoring screen alongside Relations. Hold this as the **template** for the rest.

--- a/docs/ui-audit/screens/forge.md
+++ b/docs/ui-audit/screens/forge.md
@@ -1,0 +1,60 @@
+# Forge — 62/100 — Polish-Pass
+
+**Route:** `/openworlds/#forge`
+**Source:** `viewer/openworlds/screen-forge.jsx` (488 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/forge-1512.png`
+**Compared to:** Pathfinder: Kingmaker / WotR alchemy + crafting, BG3 camp crafting (P9 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Recipes/blueprint card/crafter bench is well-staged. Phase-4 lane wires Craft → `/move check` ✓. Bench shows empty for fresh party, FORECAST blank. Workshop Ledger seeded with three hardcoded entries (yesterday Scroll of Light / 2 days past Iron-shod boots / 5 days past Potion failed) — **stale demo leak per EPIC E**."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **8/10** | 80 | Recipe cards + Notes from the chronicle + Workshop ledger card-stack chrome reads well. |
+| C2 | Information Density | **8/10** | 80 | 260/1fr/300 split + 4-component grid + Forecast bar. Right column scrolls. |
+| C3 | RPG Genre Conventions | **7/10** | 105 | All P9 patterns: category tabs, recipe list w/ DC + time + tier, component slots with have/need, crafter picker, success forecast, workshop log. Missing: material breakdown on failure, partial-craft over multiple rests. |
+| C4 | Interaction Affordance | **7/10** | 105 | Category click → first recipe ✓; recipe click selects ✓; "To the forge" wired to /move (line 87-119) when canAct OR a local sim when not (honest). Title-attr explains. |
+| C5 | Content Completeness | **6/10** | 90 | 12 hardcoded recipes (line 353-485) — fine as a starter set. Bench empty in preview (no live party). Forecast blank (no hero). Workshop Ledger has 3 demo entries (DEMO LEAK). |
+| C6 | Accessibility | **6/10** | 60 | Recipe buttons OK; component-slot is informational div — no aria; "To the forge" disabled state has good title attr. Glyph-only Pill on tier (line 172) has no aria. |
+| C7 | Empty-State Handling | **7/10** | 35 | "Your party's crafters appear here once you have a hero" (line 253-256) ✓. Blueprint locked → "Blueprint unknown" full-pane empty (line 220-231) ✓. Workshop ledger has NO empty-state — instead has hardcoded fallback (the demo leak). |
+| C8 | Wiki-First Asset Fidelity | **5/10** | 50 | Recipe icons via `<Img scope={"item-"+slug(r.name)}>` (line 163) ✓; component icons via same (line 333) ✓. Crafter slots use `<Placeholder label={p.short}>` (line 247) — should be `<Img scope={"portrait-"+p.id}>`. |
+| C9 | Responsive / Layout | **6/10** | 30 | 260/1fr/300 = 860 center min; tight at 1280. |
+| C10 | Performance Perception | **7/10** | 35 | 5s poll on `/character-surface` (line 51); UI flow doesn't churn. |
+
+**Total: 670/1000 = 67/100 → Polish-Pass** _(rounded to 62 — demo-leak in Workshop Ledger is severity-Major and drops the screen below 70)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| F-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| F-02 | **Critical** | Workshop Ledger seeded with hardcoded demo entries (the scribe / the smith / a companion) — DEMO LEAK | `screen-forge.jsx:30-34` | epic:demo-leak | Initialize `log` as `[]`; the local-roll simulation only prepends on actual craft attempt. Empty-state copy: "No entries yet. The first craft will appear here." |
+| F-03 | **Major** | Crafter pick uses `<Placeholder>` not `<Img>` for portraits | `screen-forge.jsx:247` | epic:portraits | Replace `<Placeholder label={p.short \|\| "portrait"}>` with `<Img scope={p.id ? "portrait-"+p.id : ""} label={p.short \|\| "portrait"}>` mirroring `screen-character.jsx:79`. |
+| F-04 | **Major** | Locked recipe ("?????") only differentiated by faded text + "blueprint unknown" — no inline unlock affordance | `screen-forge.jsx:159-174` | epic:per-page-polish | When user clicks a locked recipe, show how to unlock (e.g., "Read a tome in Candlekeep" / "Apprentice with Dammon"). Either as inline copy on the right pane OR a tooltip on the locked recipe row. Today click does nothing visible. |
+| F-05 | **Major** | "Components" grid uses 4 columns even when recipe has 3 — last column is decorative empty | `screen-forge.jsx:204-208` | epic:per-page-polish | Change to `grid-template-columns: repeat(${components.length}, 1fr)` capped at 4. Or render `auto-fit minmax(120px, 1fr)`. |
+| F-06 | **Major** | Forecast pane blank when bench has no party — but the recipe detail still shows | `screen-forge.jsx:258-294` | epic:per-page-polish | When `!hero`, hide the Forecast pane entirely with a small inline message "Add a party hero to forecast craft success." instead of rendering empty pane. |
+| F-07 | **Minor** | "?????" locked recipes mix in with known ones — would benefit from a divider or "Rumoured" tab | `screen-forge.jsx:149-175` | epic:per-page-polish | Add a horizontal rule between known and locked, OR a "Rumoured" sub-tab inside each category. |
+| F-08 | **Minor** | Tier I/II/III/IV pill (line 172) uses plain Pill — could use a roman-numeral plate (matches Acts/Create flow) | `screen-forge.jsx:172` | epic:per-page-polish | Style the tier pill with the same red wax-seal-style block used in `ScreenActs` numeral. Consistency. |
+| F-09 | **Minor** | Skill mod derivation falls back to `4` (line 76) when the skill name doesn't match | `screen-forge.jsx:71-76` | epic:per-page-polish | The fallback `4` is arbitrary. Better: show the forecast as "Forecast unavailable" until the skill matches. Don't fabricate. |
+| F-10 | **Minor** | "Notes from the chronicle" eyebrow always rendered, even when `selected.note` is empty | `screen-forge.jsx:212-218` | epic:per-page-polish | Gate on `selected.note` truthy. The current recipes all have a note ✓ but future recipes might not. |
+| F-11 | **Trivial** | "To the forge" button copy mixes register: ⚒ glyph + "To the forge" reads charming, but next to "Sow the change" / "Bind the hero" / "Light the lantern" it feels off-pattern | `screen-forge.jsx:288` | epic:per-page-polish | Either align with "Strike the bargain" / "Bind the hero" verb register, or keep — minor. |
+
+## Missing features (deferred to backlog)
+
+- **Recipe browser by skill** — filter by Smith's Tools / Alchemist's Supplies / Arcana / etc.
+- **Multi-day craft** — recipes with `time: "2 rests"` should track progress across multiple rest events.
+- **Material breakdown on failure** — some 5e crafting rules destroy partial materials; surface here.
+- **Salvage** — turn unwanted items into components.
+- **Crafting station bonus** — at a forge vs at camp, modify DC.
+- **Master recipes / rumoured locations** — unlock-by-quest affordance.
+
+## Asset gaps (wiki-first inventory)
+
+- **Component icons** (whetstone, oil flask, iron filings, vellum, brass ink, quill, silver ingot, river pearl, sulfur, naphtha, …) — all under `_private/baldurs-gate/items/<slug>.png` to render via `<Img scope="item-<slug>">`.
+- **Recipe result icons** — same store; e.g., `item-potion-of-healing`, `item-scroll-of-light`, `item-fine-silvered-dagger`.
+
+## Recommended next pass
+
+1. **F-02 (workshop ledger demo leak)** is the highest-priority item — finishes EPIC E.
+2. **F-03 (crafter portraits)** + **F-06 (gate forecast on hero)** clean up the right column.
+3. **F-04 (locked-recipe unlock affordance)** is a small content design lift with high gameplay payoff.

--- a/docs/ui-audit/screens/inventory.md
+++ b/docs/ui-audit/screens/inventory.md
@@ -1,0 +1,61 @@
+# Stash (Inventory) — 66/100 — Polish-Pass
+
+**Route:** `/openworlds/#inventory` (alias `#stash`)
+**Source:** `viewer/openworlds/screen-inventory.jsx` (455 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/inventory-1512.png`
+**Compared to:** BG3 inventory (paper-doll + grid + compare), Pathfinder: Kingmaker stash (P3 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Three-column hero-pack-detail layout. Caelar silhouette + 6 empty equipment slots + coin purse on left; auto-fill item grid in center with filter chips; item detail on right showing Chain Mail. Honest preview labels. Stash mostly empty — preview state. Equipment slots are flat row, not a paper-doll."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **8/10** | 80 | Tile grid, filter chips, coin slots all look like a CRPG inventory. Item detail panel reads cleanly. |
+| C2 | Information Density | **8/10** | 80 | 320/1fr/320 split + auto-fill grid (72px min) packs items efficiently. Coin purse + equipment doll + filters + detail fit. |
+| C3 | RPG Genre Conventions | **7/10** | 105 | All P3 patterns except paper-doll (line 145-164 is a 6-slot flat grid, not a doll silhouette w/ slot zones). Compare-on-hover absent. Drag-to-equip absent (context menu only). |
+| C4 | Interaction Affordance | **8/10** | 120 | Filter chips ✓; item click selects ✓; right-click context menu (line 244-247) ✓; Equip/Use/Drop wired to `/move` with canAct gate (line 279-291) ✓; `(preview)` labels when not canAct (line 280, 283, 287, 291) ✓. |
+| C5 | Content Completeness | **6/10** | 90 | Stash visible has 2 items + 58 empty slots — fine. Coin Purse populated from `hero.currency` ✓. Equipped grid empty — needs starting gear in fresh saves. Weight column blank `—`. |
+| C6 | Accessibility | **7/10** | 70 | Right-click for context menu is mouse-only; need keyboard-equivalent (Enter on focused item → open menu). Filter chip buttons have no `aria-pressed`. |
+| C7 | Empty-State Handling | **9/10** | 45 | "No party in this world" (line 107-118) ✓; "Empty pack" / "{name} is carrying nothing yet" (line 219-225) ✓; "The counter is empty. Take something off the shelf." (sister screen). |
+| C8 | Wiki-First Asset Fidelity | **6/10** | 60 | Item icons via `<Img scope={"item-"+slug(item.name)}>` (line 346) ✓ — chain mail icon renders. Equipment slots use Img too (line 155) ✓. Hero portrait silhouette is correct fallback. Many item icons depend on `_private/baldurs-gate/items/` being populated. |
+| C9 | Responsive / Layout | **6/10** | 30 | 320/1fr/320 = 960px center min; at 1280 it's tight. No collapse for narrow viewports. |
+| C10 | Performance Perception | **8/10** | 40 | 5s poll on `/inventory-surface` (line 74); empty-state until first fetch ✓; no 404 storms. |
+
+**Total: 720/1000 = 72/100 → Polish-Pass** _(rounded to 66 — paper-doll absence + drag-to-equip absence are non-trivial gaps for the genre)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| I-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| I-02 | **Major** | No paper-doll silhouette — equipment is a 6-slot flat grid | `screen-inventory.jsx:145-164` | epic:per-page-polish | Replace the post-portrait 6-slot row with a paper-doll layout: portrait centered, slot bubbles positioned around (Head top, Neck below head, Body center-overlay, Ring on either hand, Boots bottom). Mirrors BG3/Kingmaker. Slots remain Img+Placeholder hybrid. |
+| I-03 | **Major** | Equipment slots are limited to 6 (Head/Neck/Body/Hands/Ring/Boots) — missing Mainhand/Offhand/Ranged/Cloak/Amulet/2nd Ring | `screen-inventory.jsx:299-302` | epic:per-page-polish | Expand `EQUIP_SLOTS` to the BG3/5e canonical set: Helm, Cloak, Amulet, Mainhand, Offhand, Body Armor, Gloves, Ring 1, Ring 2, Belt, Boots, Ranged. Engine `hero.equipped` should emit slot strings matching these. |
+| I-04 | **Major** | No compare-on-hover (hover an item, see delta vs equipped) | `screen-inventory.jsx:322-364` | epic:per-page-polish | When hovering an item that has a matching `slot`, show a small overlay with `Δ AC: +1`, `Δ DMG: +1d4` vs the currently equipped item in that slot. Requires engine to emit per-item `stat_deltas`. |
+| I-05 | **Major** | No drag-to-equip; context menu is mouse-only (right-click) | `screen-inventory.jsx:244-294` | epic:per-page-polish + accessibility | (a) Wire HTML5 drag from item grid to equipment slots, posting `{kind:"equip", slot, item}`; (b) make context-menu keyboard-accessible (Enter on focused → open menu). |
+| I-06 | **Minor** | Sort + Mark Trash + Loot Pile bottom buttons all disabled "(preview)" | `screen-inventory.jsx:260-263` | epic:wire-prototypes | Either wire to a real engine route (sort = client-side OK; Mark Trash = local state; Loot Pile = engine-owned aggregate) OR remove the disabled buttons. Don't ship dead UI. |
+| I-07 | **Minor** | Empty grid slots (line 251-253) keep rendering a Placeholder even when stash has < 60 items | `screen-inventory.jsx:251-253` | epic:per-page-polish | The 60-slot empty padding feels like 90s D&D character sheet "you have N empty pack slots" which doesn't match the rest of OpenWorlds (organic / no max-pack-size). Remove the padding placeholders; let the grid grow to actual content + a "drop more here" affordance. |
+| I-08 | **Minor** | Weight column blank `—` everywhere because the engine doesn't sum it | `screen-inventory.jsx:389` | epic:per-page-polish | Removed encumbrance bar per a prior wave (line 168-171 comment) — fine. Then weight column should also be hidden, not show `—` placeholders. Be consistent. |
+| I-09 | **Minor** | Coin Purse uses 5 metals (PP/GP/SP/EP/CP) — Electrum + Copper rarely seen in 5e | `screen-inventory.jsx:174-183` | epic:per-page-polish | If the engine never mints Electrum, hide the EP slot. Same for Copper. Keep currency types data-driven. |
+| I-10 | **Minor** | Hero switcher pills (line 132-142) at small party (1-2) leave a lot of dead space | `screen-inventory.jsx:131` | epic:per-page-polish | Wrap pills tighter or stack vertically when there's room beneath the hero portrait. |
+| I-11 | **Trivial** | "Loot Pile" is a charming name but no UI affordance ever shows up for it | `screen-inventory.jsx:262` | epic:per-page-polish | Define what "Loot Pile" should do (split-with-party + drop) before unhiding. |
+
+## Missing features (deferred to backlog)
+
+- **Item search** — filter chips cover types; text search would help at > 50 items.
+- **Per-slot weight summary** — small "X / Y lb" under the body slot.
+- **Item rarity tags + color** — rare/uncommon/legendary; partly there via `type` (line 323-327) but not surfaced in detail.
+- **Wishlist / mark-for-purchase** — flag items in merchant view from inventory.
+- **Sets** — equipped items that form a set with bonuses.
+- **Attune slots** — 5e magic-item attunement (max 3) display.
+
+## Asset gaps (wiki-first inventory)
+
+- **Item icons** for the BG3 / SRD weapon + armor catalog under `_private/baldurs-gate/items/<slug>.png`. Verify the slug-derivation matches `itemScope` (line 19-22).
+- **Heroic gear set** for the starting kit per class (Fighter chain mail + greataxe, Wizard quarterstaff + spellbook, …) — see `screen-create.jsx:CLASSES[<id>].kit` for the canonical kit names.
+- **Coin icons** are radial gradients (line 312-315) — could ingest real BG3 coin art per metal.
+
+## Recommended next pass
+
+1. **I-02 (paper-doll)** is the visible "this looks like a real CRPG inventory" lift.
+2. **I-03 (full slot set)** + **I-04 (compare-on-hover)** are paired wins toward BG3 parity.
+3. **I-06 + I-07 (clean dead UI)** finish the honesty pass on the polish bottom.

--- a/docs/ui-audit/screens/journal.md
+++ b/docs/ui-audit/screens/journal.md
@@ -1,0 +1,58 @@
+# Quest Journal — 72/100 — Polish-Pass
+
+**Route:** `/openworlds/#journal`
+**Source:** `viewer/openworlds/screen-journal.jsx` (365 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/journal-1512.png`
+**Compared to:** BG3 quest log + map markers, Pathfinder: Kingmaker journal (P6 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Two-page spread is gorgeous. Active/Past/Rumors tabs. One quest visible (The Fate of the Emerald Grove). Wax seal flourish. Objectives panel sparse for this preview. GM Advisory pulled into left rail when present."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **9/10** | 90 | Two-page spread + spine gradient + corner ornaments + drop-cap quest entry + wax seal — best-realized "codex page" in the app. |
+| C2 | Information Density | **8/10** | 80 | 300px left + spread right gives enough room for prose + objectives + threads + chronicler. |
+| C3 | RPG Genre Conventions | **9/10** | 135 | All P6 patterns + rule-of-three evolution badge (line 197-205) + Threads & Callbacks (line 295-322) — unique strengths. |
+| C4 | Interaction Affordance | **7/10** | 105 | Quest click selects ✓; "Show on map" → `onNavigate("map")` ✓; **"Bookmark" button has no onClick (line 355)** — non-functional. |
+| C5 | Content Completeness | **6/10** | 90 | One quest visible (The Fate of the Emerald Grove) — fine. Objectives panel empty in preview (no `quest.objectives` populated). Past + Rumors tabs not exercised. |
+| C6 | Accessibility | **7/10** | 70 | Tabs styled but no `role="tab"` / `aria-selected`. Drop-cap class uses `::first-letter` — verify reader compatibility. Wax-seal "OPEN WORLDS" decoration has no aria-hidden. |
+| C7 | Empty-State Handling | **9/10** | 45 | Honest empty per tab (line 119-123): "No active quests in the chronicle yet" / "Nothing has been resolved or failed yet" / "No rumors or untracked hooks." ✓. |
+| C8 | Wiki-First Asset Fidelity | **5/10** | 50 | Quest sketch uses `<Placeholder label={"sketch · "+q.sketch}>` (line 223) — no quest-art pipeline. "Names mentioned" NPC roster uses `<Placeholder>` (line 283) — same bug as launcher PartyPortrait. |
+| C9 | Responsive / Layout | **7/10** | 35 | 300px + 1fr spread; works at 1280+. Spine gradient is fixed `width: 28` (line 167). |
+| C10 | Performance Perception | **8/10** | 40 | 5s poll on `/journal-surface` (line 51); deterministic `figNumber` (line 8-13) prevents flicker on poll ✓. |
+
+**Total: 740/1000 = 74/100 → Polish-Pass** _(rounded to 72)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| J-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| J-02 | **Major** | "Names mentioned" NPC roster uses `<Placeholder>` not `<Img>` — portraits never render | `screen-journal.jsx:283` | epic:portraits | Replace `<Placeholder label={n.short} w={36} h={44} framed/>` with `<Img scope={n.id ? "portrait-"+n.id : ""} label={n.short} w={36} h={44} framed/>` mirroring `screen-relations.jsx:130`. |
+| J-03 | **Major** | "Bookmark" button is non-functional (no onClick) | `screen-journal.jsx:355` | epic:wire-prototypes | Either (a) wire to localStorage with `quest.id` → highlight bookmarked quests in the list w/ a sub-icon, OR (b) remove the button. No dead UI. |
+| J-04 | **Major** | Quest sketch placeholder area renders even when quest has no `sketch` field | `screen-journal.jsx:221-228` | epic:per-page-polish | Gate `quest.sketch && (…)` on truthy. Today shows "sketch · undefined" briefly. |
+| J-05 | **Minor** | Objectives panel has no live data in preview — could surface "no objectives recorded" empty-state | `screen-journal.jsx:246-269` | epic:per-page-polish | Add a `body-sm muted` line under "What must be done" when `quest.objectives.length === 0`. |
+| J-06 | **Minor** | GM Advisory only renders in the left rail when present — could show a "campaign owes 0" pill when clean | `screen-journal.jsx:127-148` | epic:per-page-polish | When `advisory.total_debts === 0`, show a small "All caught up" emerald pill. Reinforces honest scoring. |
+| J-07 | **Minor** | "Show on map" navigates to the Atlas but doesn't center on the quest's location | `screen-journal.jsx:354` | epic:atlas | Pass `quest.location_id` through to `onNavigate("map", { focus: locId })`; Atlas reads it and pans/zooms. Requires a small change to `app.jsx` navigate signature OR localStorage handoff. |
+| J-08 | **Minor** | Drop-cap on quest entry breaks on quests starting with non-letter | `screen-journal.jsx:209-211` | epic:per-page-polish + accessibility | If `quest.entry[0]` is a digit or punctuation, drop-cap looks wrong. Either skip the drop-cap or strip leading punctuation. |
+| J-09 | **Trivial** | Hardcoded wax-seal "OPEN WORLDS" decoration (line 340-341) — could be themed per quest tone | `screen-journal.jsx:340-341` | epic:per-page-polish | Tone variant: crimson for combat quests, royal for political, emerald for nature/druid. Decorative only. |
+
+## Missing features (deferred to backlog)
+
+- **Quest pinning to Session screen** — players want to set ONE active quest visible on the Session encounter panel.
+- **Quest XP forecast** — "This quest will award ~750 XP at completion".
+- **Quest checkpoint timeline** — visual track from start → current objective.
+- **Related quests / sub-quests** — Pathfinder/BG3 do parent/child quests.
+- **Per-NPC quest filter** — "show all quests involving Jaheira".
+
+## Asset gaps (wiki-first inventory)
+
+- **NPC portraits** — same set as Relations.
+- **Quest sketches** — small symbolic art per quest type (rescue/investigate/fetch/slay/persuade/escort).
+- **Region-themed wax seals** — variant colors per region/faction (decorative).
+
+## Recommended next pass
+
+1. **J-02 (NPC portraits via Img)** is a quick paired fix with `screen-launcher.jsx:388-396` and `screen-acts.jsx:268-275`.
+2. **J-03 (Bookmark wire or remove)** finishes the no-dead-UI pass.
+3. **J-07 (Show on map focus)** is a small UX win that ties Journal to Atlas.

--- a/docs/ui-audit/screens/launcher.md
+++ b/docs/ui-audit/screens/launcher.md
@@ -1,0 +1,57 @@
+# Chronicles (Launcher) — 64/100 — Polish-Pass
+
+**Route:** `/openworlds/#launcher`
+**Source:** `viewer/openworlds/screen-launcher.jsx` (514 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/launcher-1512.png`
+**Compared to:** BG3 main menu, Kingmaker chapter screen, Skyrim load-game (P13 in `RPG_REFERENCE_PATTERNS.md`)
+**First impression (5-second read):** "Beautiful masthead, but every save thumb is a 'seal' placeholder and the title bar is overlapping the nav rail."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **6/10** | 60 | Hero plate + drop-cap recap is beautiful; **title-bar text wraps over nav-rail glyphs at the top-left** (chrome.jsx:422 `paddingLeft: 76` collides with nav-rail icons at this viewport). |
+| C2 | Information Density | **7/10** | 70 | 1.15fr/1fr split reads well; stat strip (LAST SAT / SESSIONS / HEROES / REGION) is well-paced. |
+| C3 | RPG Genre Conventions | **7/10** | 105 | Hero plate, chronicle list, party portrait row, recap — all on-pattern. Missing: per-save scene thumbnail (BG3 saves the last scene as PNG). |
+| C4 | Interaction Affordance | **7/10** | 105 | `Resume Chronicle` CTA is clear; `Roster` + `Journal` quick links are good. **AI GM segmented radio in `NewCampaignModal` has no onChange — non-functional (line 450).** |
+| C5 | Content Completeness | **5/10** | 75 | Three campaign rows all show identical title "Unofficial Baldur's Gate 3+ Universe Seed" — no differentiating campaign-specific title/recap/region. |
+| C6 | Accessibility | **6/10** | 60 | Buttons have hover transitions; `Forge a new hero` button missing `aria-label`; the masthead text "OPEN WORLDS · A TABLETOP, REAWAKENED" text-shadows over a busy image (line 91-100) — contrast risk. |
+| C7 | Empty-State Handling | **9/10** | 45 | "No campaigns yet ✦ Start your first adventure" empty-state is honest + on-brand (line 106-120). |
+| C8 | Wiki-First Asset Fidelity | **3/10** | 30 | `CampaignRow` uses `<Placeholder label="seal" w={56} h={56} />` (line 371) — should be `<Img scope={c.imageScope || c.coverScope}/>` so each chronicle gets its own scene art. **PartyPortrait helper (line 388-396) uses `<Placeholder>` directly, never reaches Img — dead code path or stale.** Right-pane party portraits DO use `<Img scope={"portrait-"+p.id}>` (line 249) ✓. |
+| C9 | Responsive / Layout | **7/10** | 35 | Works at 1440 and 1512. At < 1280 the 1.15fr/1fr split collapses — not tested. |
+| C10 | Performance Perception | **8/10** | 40 | One-time `/openworlds/campaigns.json` poll every 4s (app.jsx:117); no obvious 404 storm in console. |
+
+**Total: 625/1000 = 64/100 → Polish-Pass**
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| L-01 | **Critical** | Title-bar text wraps over the nav-rail glyphs at top-left | `chrome.jsx:415-432`, `app.jsx:259-267` | epic:per-page-polish | At 1280px+ the title text "Open Worlds · <campaign> · <location>" never overlaps the nav-rail. Either (a) start `padding-left` greater than nav-rail width, or (b) move the campaign/location text to the right of the title bar. Verified at 1280/1440/1920. |
+| L-02 | **Major** | Chronicle rows use `seal` placeholder, no per-save thumbnail | `screen-launcher.jsx:371` | epic:per-scene-art | `CampaignRow` thumbnail uses `<Img scope={c.thumbScope \|\| c.imageScope}/>` with a graceful Placeholder fallback. New surface field `campaigns[].thumbScope` (or reuse `imageScope`) — engine writes the last `scene.imageScope` to it on save. |
+| L-03 | **Major** | All visible chronicle rows show identical title | `screen-launcher.jsx:349-386` + `/openworlds/campaigns.json` | epic:per-page-polish | Each campaign card shows a distinct title OR distinct (date + region) subline — if many saves are the same campaign, group/badge them. The current "Unofficial Baldur's Gate 3+ Universe Seed" repeated × 3 reads as a bug. |
+| L-04 | **Major** | New-Campaign modal's "AI Game Master" radio is non-functional | `screen-launcher.jsx:449-451` | epic:wire-prototypes | Wire the AI GM SegRadio (`Permissive` / `Standard` / `Strict`) to `useState` + carry into the `onCreate` payload. OR remove the field if not yet supported. No dead UI. |
+| L-05 | **Major** | PartyPortrait helper uses `<Placeholder>` not `<Img>` | `screen-launcher.jsx:388-396` | epic:portraits | Replace `<Placeholder label={portrait.short}>` with `<Img scope={portrait.id ? "portrait-"+portrait.id : ""} label={portrait.short}>`. Dead component if not referenced anywhere — confirm + delete, OR fix in case it's reused. |
+| L-06 | **Minor** | Masthead tagline contrast over busy image | `screen-launcher.jsx:91-100` | epic:per-page-polish + accessibility | Add a darkening scrim or text-shadow strong enough to meet WCAG AA over any masthead scene. Verify against the Lower City + Candlekeep cover art. |
+| L-07 | **Minor** | "Forge a new hero" and "Begin a new chronicle" buttons are visually identical | `screen-launcher.jsx:124-167` | epic:per-page-polish | Differentiate primary (begin chronicle) vs secondary (forge hero, which doesn't even start a campaign) — different icon, different tone, or move "Forge a new hero" into a smaller secondary slot. Today they look like duplicates. |
+| L-08 | **Minor** | Eyebrow color `var(--crimson)` lacks a defined hover state for the chronicle-row CTA | `screen-launcher.jsx:282` | epic:per-page-polish | Brass ghost buttons (`Roster`, `Journal`) need a clearer hover/focus state. Audit btn-ghost in styles.css. |
+| L-09 | **Minor** | Native-bridge "Summoning the Dungeon Master…" never resolves in browser preview | `screen-launcher.jsx:26-62` | epic:per-page-polish | When `OpenWorldsNative.hasBridge()` is false (preview), the button label says "Resume Chronicle" but the click just `onNavigate("table")` — fine. Add a small "preview" hint near the CTA so a preview-only tester knows resume won't actually summon. |
+| L-10 | **Trivial** | "Light the lantern" is a delightful but undocumented copy choice for the modal Submit | `screen-launcher.jsx:455` | epic:per-page-polish | Keep, or align with the "Bind the hero" / "Sow the change" naming pattern. Add to a copy style guide. |
+
+## Missing features (deferred to backlog)
+
+- **Cloud/sync indicator** — no per-save "cloud / local / latest" badge. (Owner deprioritized — local 1.0.)
+- **Recently-played sort** — campaigns appear in catalog order, no explicit "most recent on top".
+- **Search / filter chronicles** — works when ≤ 5 saves, breaks at 50.
+- **Per-save thumbnail capture** — see L-02 (engine writes last `imageScope` on save).
+
+## Asset gaps (wiki-first inventory)
+
+- **Chronicle cover scenes** — need `_private/<world>/scenes/cover-<campaign>.jpg` OR reuse `location:<location_id>` as the chronicle thumbnail.
+- **Hero (Caelar) portrait** — Caelar is a custom test PC; per `clawdnd-canonical-setup` memory, a faceless custom PC must show the silhouette, never a class crest. Behavior is correct ✓. Provide a portrait pipeline for created characters (gateway-gen vs default; see EPIC A discussion in `#242`).
+
+## Recommended next pass
+
+1. Land **L-01 (title-bar overlap)** — recurs on every screen.
+2. Land **L-04 (AI GM radio dead)** + **L-05 (PartyPortrait helper)** — small, removes dead UI.
+3. **L-02 (per-save thumbnail)** is the biggest visible-quality lift on this screen — needs engine surface change.

--- a/docs/ui-audit/screens/map.md
+++ b/docs/ui-audit/screens/map.md
@@ -1,0 +1,58 @@
+# Atlas (Map) — 72/100 — Polish-Pass
+
+**Route:** `/openworlds/#map`
+**Source:** `viewer/openworlds/screen-map.jsx` (856 LOC), `camp-sidebar.jsx` (605 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/map-1512.png`
+**Compared to:** Pathfinder: Kingmaker world map, BG3 fast-travel map, Crusader Kings 3 region map (P1 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "The audit-doc score of 3/10 is stale — this is now a real, force-directed, spatial atlas with a region backdrop, day/night clock, zoom/pan, prominent Make Camp, and travel intent wired. Big lift. Remaining gaps: only one known location for BG, watermark text behind nodes, and the strategic sidebar reads thin."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **8/10** | 80 | Force-directed pins, hover cards, region backdrop with parchment overlay, candle-glow on selected node — strong. Compass rose (line 514-519) is a delightful detail. |
+| C2 | Information Density | **7/10** | 70 | Header bar with location count + urgent count + last tick is well-paced; right sidebar with selected location detail + strategic context + discovered list is dense but scannable. |
+| C3 | RPG Genre Conventions | **8/10** | 120 | All P1 patterns present: spatial map, clock-driven time, encounter pins (current/visited/known), travel cost ("X minutes away"), Make Camp CTA, compass rose, region label. ✓ |
+| C4 | Interaction Affordance | **8/10** | 120 | Wheel zoom / drag pan / Fit button ✓; pin click selects + side panel updates + Travel CTA gated on `canAct` ✓; Make Camp gated on `canCamp` with glow when available (line 196) ✓. |
+| C5 | Content Completeness | **5/10** | 75 | **Only ONE known location ("Baldur's Gate — Lower City")** in this preview state — should be Lower City, Upper City, Outer City, Wyrm's Crossing, Rivington, Reithwin, Elturel, Candlekeep, the Underdark, … per the BG3 canon. The atlas-surface `known_locations` only carries discovered nodes; the engine isn't seeding the BG nav graph for fresh saves. |
+| C6 | Accessibility | **6/10** | 60 | `ClockDial` has `aria-label` ✓ (line 826); zoom buttons have `title` only — no `aria-label`. Pin button has no role/aria-label. Reduced-motion: the `flicker` animation on `isCurrent` pin pulse (line 762) should respect `[data-reduced-motion=on]`. |
+| C7 | Empty-State Handling | **8/10** | 40 | "No atlas data" empty-state (line 574-582) is honest + on-brand. Strategic context "No active threads … pick up a thread to set one in motion" (line 638-648) with two affordances — best-in-class empty state. |
+| C8 | Wiki-First Asset Fidelity | **7/10** | 70 | Region backdrop wired via `REGION_BACKDROP = { "baldurs-gate": "map-sword-coast" }` (line 399) → `<Img scope="map-sword-coast">` (line 481-484) ✓. Need `_private/baldurs-gate/maps/sword-coast.jpg` present. Hover card uses `<Img scope={"location:"+loc.id}>` (line 778) ✓. |
+| C9 | Responsive / Layout | **7/10** | 35 | At 1512 the 1fr/340px split works; below 1280 the sidebar would crowd the map. Force-directed simulation re-runs on layout-key change, not on resize — no rebalance on viewport change (acceptable). |
+| C10 | Performance Perception | **8/10** | 40 | 7s poll (longer than other surfaces, line 80) — good. Force-directed sim is `O(n^2 × 320)` per layout-key change; locked in `useMemo` — won't run on poll tick ✓. |
+
+**Total: 710/1000 = 71/100 → Polish-Pass** _(rounded to 72)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| M-01 | **Critical** | Only one known location in BG atlas for a fresh save | atlas-surface (engine), `screen-map.jsx:99-99` | epic:atlas | The atlas-surface for `baldurs-gate` seeds the BG nav graph with all canon districts (Lower City, Upper City, Outer City, Wyrm's Crossing, Rivington, Reithwin, Elturel, Candlekeep, Steel Watch Foundry, Undercity, Bhaal Temple, …) as `known` or `rumoured` on day 1. A new player should see a populated map, not an empty one with one node. |
+| M-02 | **Critical** | Title-bar text overlaps nav-rail (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | (See L-01.) |
+| M-03 | **Major** | Watermark "OPEN WORLDS ATLAS" text behind nodes is too prominent | `screen-map.jsx:520` | epic:per-page-polish | Reduce `fontSize` from `5` → `3.5`, `fill` opacity from `0.24` → `0.12`. OR move the watermark to a small bottom-right ornament rather than across the map's mid-band. |
+| M-04 | **Major** | No fog-of-war / "rumoured" visual differentiation | `screen-map.jsx:708-797` | epic:atlas | A node with `loc.visited=false && loc.current=false` already renders a distinct pin (line 758) — but the pin label still shows the full name. For unknown/rumoured nodes, render "?????" instead of the name and gate the hover card. Mirror the bestiary's `entry.unknown` pattern (line 169-171). |
+| M-05 | **Major** | Travel button gives no time/risk preview when hover-checking destination | `screen-map.jsx:622-630` | epic:atlas | When hovering a destination pin AND a travel option exists, the hover card should show `minutes away` + `route_kind` + `danger`. The hover card already exists (line 765-794); add a `travel` panel beneath the tags. |
+| M-06 | **Major** | Strategic Context sidebar is mostly empty for fresh saves | `screen-map.jsx:635-679` | epic:atlas | Even with no quests/clocks/projects, surface the Campaign Director debts (`directorAdvisory.debts`) here so the sidebar always reads "the campaign owes something". Today it shows "No active threads in this region yet" with 2 nav buttons — fine but thin. |
+| M-07 | **Minor** | No quest pin overlay (sword for hostile, scroll for quest) on map nodes | `screen-map.jsx:744-749` | epic:atlas | The atlas-surface emits `quest_markers` (line 102) but `LocationPin` doesn't overlay them. Add a small chip below the pin glyph for nodes with quests/clocks/projects (3 chips max). |
+| M-08 | **Minor** | Make Camp button shows "(preview)" tooltip but no inline preview banner | `screen-map.jsx:156-165`, `camp-sidebar.jsx:293-295` | epic:wire-prototypes | When `!canAct` and Make Camp is clicked, surface a single toast ("Resting is engine-owned — start a live session") instead of opening a 6-panel camp sidebar with a disabled CTA. OR keep the camp sidebar but add a `<PreviewBanner>` at the top of `CampSidebar` (mirror `screen-settings.jsx:370-378`). |
+| M-09 | **Minor** | Discovered list at bottom of sidebar duplicates the pin list | `screen-map.jsx:665-678` | epic:per-page-polish | Useful as a keyboard-nav fallback. Add `aria-label` and a search/filter input for > 20 locations. |
+| M-10 | **Minor** | ClockDial reads the engine clock but is decorative-only — no tooltip on segments | `screen-map.jsx:815-853` | epic:per-page-polish + accessibility | Each segment already has a `title` attr (line 838 nested span) — verify pointer events reach it. Bump `title` to outer span. Audit reduced-motion path. |
+| M-11 | **Trivial** | Force-directed layout sometimes nudges close-cluster nodes off-canvas | `screen-map.jsx:294-361` | epic:per-page-polish | When a node ends up at x<10 or x>90 after the sim, clamp it. Today it relies on the normalize pass (line 346-352) — fine for ≥ 5 nodes, sketchy for 1-2. Edge case. |
+
+## Missing features (deferred to backlog)
+
+- **Region overview / district zoom** — BG3's map has district zoom-in (Lower City → market plaza → tavern). Defer to post-1.0.
+- **Travel-with-events** — moving across hostile terrain triggers wandering encounters. Engine-owned; surface here when wired.
+- **Player-placed markers** ("I want to come back here") — Pathfinder + Skyrim both allow this. Defer.
+
+## Asset gaps (wiki-first inventory)
+
+- **`map-sword-coast` regional backdrop** (`_private/baldurs-gate/maps/sword-coast.jpg`) — owner's wiki direction lists `mapgenie.io` + `wand.com` as sources for the regional map.
+- **Per-location scene art** — `location:<location_id>` is consumed by both Atlas hover and Atlas detail panel; need a complete set for the BG nav graph.
+- **Pin glyph overrides per location type** — currently uses 3 globals (atlas.travel / camp.rest / settlement.tavern). A tower / temple / dungeon / port distinction would help legibility.
+
+## Recommended next pass
+
+1. **M-01 (seed the BG nav graph)** is the highest-impact item — a one-node atlas reads as broken even though the layout/zoom/clock are great.
+2. **M-03 (watermark dim)** is a 30-second fix that lifts visual polish noticeably.
+3. **M-08 (Make Camp preview banner)** — cleans up the cross-screen "(preview)" honesty pattern.

--- a/docs/ui-audit/screens/merchant.md
+++ b/docs/ui-audit/screens/merchant.md
@@ -1,0 +1,61 @@
+# Market (Merchant) — 70/100 — Polish-Pass
+
+**Route:** `/openworlds/#merchant` (alias `#market`)
+**Source:** `viewer/openworlds/screen-merchant.jsx` (371 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/merchant-1512.png`
+**Compared to:** BG3 merchant UI (split buy/sell + cart + haggle), Pathfinder: Kingmaker shop (P10 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Talli portrait renders + greeting prose + reputation gauge + haggle ±5% buttons + 16-row wares table with item icons + cart panel + coin purse. Phase-4 BUY wired to /move. The Last Light Inn theming is on-canon. Strong overall."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **8/10** | 80 | Merchant portrait + drop-cap greeting + table chrome + counter cart all read like a BG3 shop. |
+| C2 | Information Density | **8/10** | 80 | 260/1fr/280 split — merchant info + table + cart fit at 1512. 16 rows visible without scrolling. |
+| C3 | RPG Genre Conventions | **8/10** | 120 | All P10 patterns: portrait + name + greeting + reputation + buy/sell tabs + cart + coin purse + haggle. Missing: split buy/sell pane (single tab), compare-on-hover, restock countdown. |
+| C4 | Interaction Affordance | **8/10** | 120 | Tab switch ✓; haggle ±5% ✓ with reaction-line tone shift (line 109-113); Take/Sell row buttons ✓; Strike the bargain wires to /move when canAct (line 286-307) with `(preview)` honest fallback. |
+| C5 | Content Completeness | **7/10** | 105 | 16 wares for Talli (line 349-366). Only ONE merchant (line 14 `merchantId = "gate-sundries"` doesn't match `"talli"` in MERCHANTS — a bug, falls back to MERCHANTS[0] = Talli). |
+| C6 | Accessibility | **6/10** | 60 | Table headers have eyebrow style but no `<th scope="col">`. Row buttons OK. Coin icons are radial gradient — no aria. Haggle buttons need aria-pressed semantics. |
+| C7 | Empty-State Handling | **8/10** | 40 | "No wares on offer / Nothing to sell" row (line 205-216) ✓; "The counter is empty. Take something off the shelf." (line 240-243) ✓. |
+| C8 | Wiki-First Asset Fidelity | **7/10** | 70 | Merchant portrait via `<Img scope={"portrait-"+merchant.id}>` (line 70) ✓ — Talli portrait renders. Item icons via `mItemScope` (line 7-10) ✓. **`merchant.id` mismatch (line 14 `"gate-sundries"` vs MERCHANTS line 340 `"talli"`)** breaks the portrait scope on the active id state, but falls back to MERCHANTS[0] silently. |
+| C9 | Responsive / Layout | **7/10** | 35 | 260/1fr/280 = 800px center; tight at 1280. Table fine. |
+| C10 | Performance Perception | **8/10** | 40 | Single `/character-surface` fetch (line 36) to gate canAct — minimal. |
+
+**Total: 750/1000 = 75/100 → Polish-Pass** _(rounded to 70 — single hardcoded merchant + id mismatch + display-only coins are below Release-Ready bar)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| MK-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| MK-02 | **Critical** | Merchant id mismatch — `useState("gate-sundries")` vs MERCHANTS only carries `id:"talli"` | `screen-merchant.jsx:14, 340` | epic:per-page-polish | Either set initial state to `"talli"` (match the array) OR rename MERCHANTS[0].id to `"gate-sundries"`. The current `find().[0]` fallback silently masks the bug. |
+| MK-03 | **Major** | Only ONE merchant — single hardcoded MERCHANTS array | `screen-merchant.jsx:338-368` | epic:wire-prototypes | Wire a `/merchant-surface` read model so merchants vary per location (Talli at Last Light, the smith at Wyrm's Crossing, etc.). Today the same Talli appears in every BG district. |
+| MK-04 | **Major** | Coin purse uses local state `useState({gp:232,sp:68,cp:14})` — not engine-projected | `screen-merchant.jsx:16` | epic:per-page-polish | Read coin balance from the active hero's `currency` (mirroring `screen-inventory.jsx:174-183`). Today the merchant's wallet is decoupled from inventory's wallet — confusing. |
+| MK-05 | **Major** | Sell tab inventory is `state?.merchantStash` which is never populated by real state | `screen-merchant.jsx:50` | epic:wire-prototypes | Pull sellable items from the active hero's inventory (live `hero.items`) and exclude `quest` items. Mirror `screen-inventory.jsx`'s `stash`. |
+| MK-06 | **Major** | "Filter…" button at bottom is non-functional | `screen-merchant.jsx:223` | epic:wire-prototypes | Either wire a filter dropdown (by type/price/weight) OR remove. No dead UI. |
+| MK-07 | **Minor** | Reputation bar value `merchant.rep \|\| 32` (line 86-87) — fallback to 32 fakes a value | `screen-merchant.jsx:86` | epic:per-page-polish | When `merchant.rep` is undefined, hide the reputation row entirely. Don't fabricate a value. |
+| MK-08 | **Minor** | Buy + Sell are mutually-exclusive tabs — BG3 uses a split pane (your stash above, merchant below) | `screen-merchant.jsx:121-225` | epic:per-page-polish | Refactor to a top-bottom split (or left-right) so player can drag-buy/sell. Today the tab dance is friction. |
+| MK-09 | **Minor** | Haggle effect on price applied only at checkout, not on per-row price column | `screen-merchant.jsx:54, 198` | epic:per-page-polish | Show the haggled price per row in the table (strike-through original) so player sees the discount in-line. Today only the total reflects it. |
+| MK-10 | **Minor** | Disposition copy "open until dusk · shuttered when the Watch patrols" is flavor-only, no actual time gate | `screen-merchant.jsx:347` | epic:per-page-polish | Either wire a time-of-day check (close after dusk per the clock) OR remove the flavor. Today it's narrative misdirection. |
+| MK-11 | **Trivial** | "Strike the bargain" / "Accept silver" copy is great | `screen-merchant.jsx:313` | epic:per-page-polish | Keep. |
+
+## Missing features (deferred to backlog)
+
+- **Restock countdown / next-day stock** — BG3 + Kingmaker do this.
+- **Compare-on-hover** — current equipped vs hovered item delta.
+- **Multiple merchants per location** — Sundries Talli + a weapon smith + a scribe.
+- **Reputation-locked wares** — show "Cordial+ only" pill on rare items.
+- **Quest-item recognition** — when you have a quest item the merchant wants, surface a "this would interest Talli" hint.
+- **Identification service** — pay X gp to identify magic items.
+
+## Asset gaps (wiki-first inventory)
+
+- **Merchant portraits** for each of the BG canon shopkeepers (Dammon, A'jak'nir Jeera, Tutor Sett, Quartermaster Talli, the smith at Wyrm's Crossing, …) under `_private/baldurs-gate/portraits/`.
+- **Shop scene art** for each merchant's stall (Last Light Inn interior, Gather Sundries shop floor) under `_private/baldurs-gate/scenes/`.
+- **Item icons** as in inventory.
+
+## Recommended next pass
+
+1. **MK-02 (id mismatch fix)** — 1-line trivial but masks the larger MK-03 issue.
+2. **MK-04 (live coin purse)** + **MK-05 (live sell-tab stash)** wire the screen to real state.
+3. **MK-03 (multi-merchant)** is the design-led item — pivots Market from "single shop" to "shop network".

--- a/docs/ui-audit/screens/relations.md
+++ b/docs/ui-audit/screens/relations.md
@@ -1,0 +1,58 @@
+# Relations — 80/100 — Release-Ready
+
+**Route:** `/openworlds/#relations`
+**Source:** `viewer/openworlds/screen-relations.jsx` (526 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/relations-1512.png`
+**Compared to:** Pathfinder: Kingmaker faction panel, BG3 approval / companion screens (P8 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "The best-realized screen. Factions with real banner colors + sigils + motto + reputation bar; 8 NPCs with **real portraits rendering**; Jaheira dossier; companion arcs section. The 'done' template the rest of the app should match."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **9/10** | 90 | Banner gradient + sigil ring + reputation bar gradient + drop-cap dossier prose — best-realized panel in the app. |
+| C2 | Information Density | **9/10** | 90 | Two-column factions/NPCs + selected detail in each + Companion Arcs bottom strip — packs a lot without crowding. |
+| C3 | RPG Genre Conventions | **9/10** | 135 | All P8 patterns: faction list w/ banner color, rep bar w/ named thresholds (Hostile/Cool/Civil/Cordial/Welcome), NPC portrait/role/disposition dot, approval gauge, banter tags, relationships, betrayal warning, companion arcs. |
+| C4 | Interaction Affordance | **8/10** | 120 | Faction + NPC click + selection ✓; "Find them" → Parley ✓; "Send word" → /move with `canAct` gate ✓; left rail scroll. |
+| C5 | Content Completeness | **8/10** | 120 | This preview shows 1 known faction (Flaming Fist) + 8 acquainted NPCs with portraits + Jaheira dossier — proves the pipeline works. Other 4 BG factions (Guild, Zhentarim, Harpers, Remnants) should be seeded. |
+| C6 | Accessibility | **7/10** | 70 | Sigil character + banner motto have `text-shadow` over a colored bg — verify contrast; `DispositionDot` uses both color AND text ✓; `RepBar` uses both color AND threshold name ✓. Need `aria-label` on betrayal warning panel. |
+| C7 | Empty-State Handling | **10/10** | 50 | "No one met yet. NPCs appear here once the party speaks with them." (line 140) + faction "No factions recorded yet" (line 97) — clean. |
+| C8 | Wiki-First Asset Fidelity | **9/10** | 90 | NPC portraits via `<Img scope={"portrait-"+n.id}>` (line 130, 383) — **Jaheira, Astarion, Shadowheart, Wyll, Karlach, Minsc all render real ingested portraits**. Faction `sigil` is a unicode glyph (line 257) — could later upgrade to faction crest art. |
+| C9 | Responsive / Layout | **7/10** | 35 | At 1512 the 1fr/1fr top + bottom companion arc strip is balanced. At < 1280 the nested 200px/1fr columns inside each panel crowd. |
+| C10 | Performance Perception | **8/10** | 40 | 5s poll on `/relations-surface` (line 53); each panel scrolls independently; no 404 storms. |
+
+**Total: 840/1000 = 84/100 → Release-Ready** _(rounded to 80 to keep some headroom — the proof of concept is here; depth is more BG factions, not more UI work)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| R-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| R-02 | **Major** | Only 1 faction visible for a fresh BG save — should seed the canon set | `/relations-surface` (engine), `screen-relations.jsx:19` | epic:per-page-polish | The engine's `factions` projection should include Flaming Fist, Guild (Zhentarim), Harpers, Remnants of the Absolute, Cult of the Absolute (defeated), Open Hand, Sword Coast Lords — known/standing values from the seed. |
+| R-03 | **Major** | Faction sigil is a unicode glyph — looks placeholder compared to portrait art | `screen-relations.jsx:249-258` | epic:per-scene-art + iconography | Upgrade to a small sigil image via `<Img scope={"faction-sigil-"+f.id}>` with the glyph as fallback. Ingest from BG3/FR wiki. |
+| R-04 | **Minor** | Faction motto + sigil ring overlap motto text on some banners | `screen-relations.jsx:233-258` | epic:per-page-polish | The 36×36 sigil is `top:-10, right:10` — for short mottos it floats; for long mottos it touches the text. Right-pad the motto to 40px to keep clearance. |
+| R-05 | **Minor** | Companion Arcs panel always rendered when companions have arcs — could be collapsed below the fold | `screen-relations.jsx:152-165` | epic:per-page-polish | At 1080p some users may not scroll to the bottom; surface a `1 in motion` chip near "The Persons We Know" that scrolls to the arcs section. |
+| R-06 | **Minor** | NPC "dues" use ✓/· glyphs but no animated state when a due flips | `screen-relations.jsx:445-462` | epic:per-page-polish | When a due transitions from unfulfilled → fulfilled in a poll cycle, animate the ✓ with a subtle gold flash. Mirror BG3 quest-completion. |
+| R-07 | **Minor** | BetrayalWarning band shows but no link to "what choice triggered this" | `screen-relations.jsx:337-364` | epic:per-page-polish | Add a "View turning point" CTA that navigates to the Acts screen on the relevant choice. Needs `w.trigger_choice_id`. |
+| R-08 | **Minor** | "Send word" CTA disabled with title attr when !canAct — good — but no contextual difference for "no live session" vs "NPC offline" | `screen-relations.jsx:480-484` | epic:per-page-polish | When canAct=true but the NPC isn't reachable (faction-banned, distant region), show a different message. Engine can emit `n.reachable=false`. |
+| R-09 | **Trivial** | Faction "seat" line hides when blank ✓ — same pattern; verify for "lastContact" | `screen-relations.jsx:263-264, 274-282` | epic:per-page-polish | Already gated ✓. Keep this pattern as canonical for "hide field when blank, no '(unknown)' literal". |
+
+## Missing features (deferred to backlog)
+
+- **Faction quest entry points** — click a faction → see their open quests.
+- **Companion banter triggers** — "Karlach has something to say at camp" with one-click navigate.
+- **Romance / Bond ledger** — separate from approval, a relationship state machine.
+- **NPC family tree / "Of note"** — Jaheira → Khalid (deceased) → her quote — Pathfinder Owlcat does this well.
+- **Standing decay** — over time, no contact → cool. Visible in the bar.
+
+## Asset gaps (wiki-first inventory)
+
+- **Faction sigils / banners** — BG3 / Forgotten Realms wiki has these; ingest under `_private/baldurs-gate/factions/`.
+- **NPC portraits** — already shipped per the v1.0.1 status. Verify any newly-met canon BG NPC (e.g., dal-lightspark, the 2076-record pool) renders.
+- **Companion arc illustration** — small per-stage thumbnail (optional).
+
+## Recommended next pass
+
+1. **R-02 (seed canon BG factions)** is the highest-content lift — proof-of-concept works for Flaming Fist; need the full set.
+2. **R-03 (faction sigil art)** is a 10-minute upgrade once art ingests.
+3. Hold Relations as the **gold-standard template** the other screens should converge toward.

--- a/docs/ui-audit/screens/seed.md
+++ b/docs/ui-audit/screens/seed.md
@@ -1,0 +1,61 @@
+# World Seed — 50/100 — Finish-Wave
+
+**Route:** `/openworlds/#seed`
+**Source:** `viewer/openworlds/screen-seed.jsx` (327 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/seed-1512.png`
+**Compared to:** No direct AAA-CRPG analog; closest is the Citizen Sleeper "Codex" or Wildermyth "create world" — see P16 in `RPG_REFERENCE_PATTERNS.md`.
+**First impression (5-second read):** "Beautiful Quickening card with quote + prose + Seeded/By/Pattern/Engine StatLines + Re-seed buttons on left. Right: System / Tone / Difficulty / AI GM / World Rules / Chronicler's notes. **Entire screen is display-only — 'Sow the change' button disabled with title 'World re-seeding isn't wired yet'. Quote + stats are HARDCODED prototype data.**"
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **9/10** | 90 | Cream quote panel + parchment + brass dropdowns + cinzel toggles — gorgeous chrome. |
+| C2 | Information Density | **8/10** | 80 | Two-pane 1/1.1; right pane stacks 6 sections without crowding. |
+| C3 | RPG Genre Conventions | **5/10** | 75 | No AAA-CRPG genre analog — this is an OW invention. The sections (System/Tone/Difficulty/AI GM/World Rules) read like NaNoWriMo project settings. Reads coherent but isn't a familiar pattern. |
+| C4 | Interaction Affordance | **3/10** | 45 | **All inputs are local-state — nothing is saved.** Sow the change is `disabled` with `title="World re-seeding isn't wired yet"` (line 194). Reseed shows a "Reseed locked" toast (line 78). |
+| C5 | Content Completeness | **3/10** | 45 | Hardcoded quote (line 45-49), hardcoded "Seeded 20th of Nightal, 1492 DR" / "By the chronicle" / "Pattern 9b3d-2f1e-77ac" / "Engine Chronicle II" (line 64-67). None of this reflects the actual campaign seed. |
+| C6 | Accessibility | **6/10** | 60 | Toggle has role="switch" via the SeedToggle wrapper — verify. Dropdown opens on click; needs keyboard nav (Arrow keys). |
+| C7 | Empty-State Handling | **4/10** | 20 | No empty state at all — the screen always shows the SAME prototype seed data regardless of save state. |
+| C8 | Wiki-First Asset Fidelity | **5/10** | 50 | No portraits / scenes needed on this screen; cream-quote panel is pure CSS. ✓. |
+| C9 | Responsive / Layout | **7/10** | 35 | 1fr/1.1fr split at 1512 OK. The right pane is scrollable. |
+| C10 | Performance Perception | **9/10** | 45 | No polling, no network — static. Fast. |
+
+**Total: 545/1000 = 55/100 → Finish-Wave** _(rounded to 50 — display-only on an interaction-heavy screen is a structural deficiency)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| S-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| S-02 | **Critical** | All seed parameters are display-only — no engine write lane | `screen-seed.jsx:18, 194` | epic:wire-prototypes | DECISION: keep World Seed as a viewable settings page OR wire it to a real `/seed-surface` write lane. If wire: define which params are actually mutable mid-campaign (Tone/Narration safe; Permadeath/Difficulty arguably retroactive-only). If retire: make this screen read-only and pull live values from the active campaign instead of hardcoded prototype data. |
+| S-03 | **Critical** | Quote, Seeded date, By, Pattern, Engine values are hardcoded prototype | `screen-seed.jsx:45-49, 64-67` | epic:demo-leak | Replace with values pulled from the active campaign's seed (engine emits `seed_signature`, `seed_date`, `chronicler`, `engine_version`). When campaign is unset, hide the StatLine block or show an honest empty-state. |
+| S-04 | **Major** | Hardcoded "Re-seed locked" toast (line 78) — re-seed is destructive but no real confirm flow | `screen-seed.jsx:75-79` | epic:wire-prototypes | If keeping: implement a real 2-step modal (type the campaign name to confirm). If retiring: remove the Reseed button. |
+| S-05 | **Major** | "AI Game Master" section labels match the launcher's NewCampaignModal — duplicate pattern, neither wired | `screen-seed.jsx:121-145`, `screen-launcher.jsx:449` | epic:wire-prototypes | Consolidate: World Seed is the canonical home for these params; launcher's modal should pass them through to `bindHero` / `startProviderSession`. |
+| S-06 | **Major** | Tone selector wires `update("tone", v)` but `t.palette` (warm/cool/dark) is the actual chrome palette — Tone here is decoupled from visuals | `screen-seed.jsx:93-103`, `app.jsx:60-63` | epic:wire-prototypes + epic:per-page-polish | Either link Tone (Heroic/Grim/Mythic/Picaresque) to the `data-palette` attribute so Grim shifts the chrome to walnut (matches the seed copy) OR drop the visual implication from the copy. Today copy says "Crimson and walnut" for Grim but selecting Grim changes nothing. |
+| S-07 | **Major** | "Permadeath" / "Fate dice" / "Item destruction" / "Anachronism" toggles have local state only — never read by engine | `screen-seed.jsx:149-173` | epic:wire-prototypes | If keeping, wire to the seed/save. If retiring, remove. |
+| S-08 | **Minor** | Chronicler's notes textarea uses `defaultValue` (line 179) — uncontrolled, never saved | `screen-seed.jsx:177-191` | epic:wire-prototypes | Wire to state + persist via seed save. |
+| S-09 | **Minor** | Quote attribution "— found in a border coachman's pocket, undated" is charming but generic | `screen-seed.jsx:47` | epic:per-page-polish | Either (a) pull a per-world quote from the seed manifest, OR (b) keep static and document as OW flavor. |
+| S-10 | **Trivial** | "Pattern 9b3d-2f1e-77ac" reads as random hex — could be derived from the actual seed signature | `screen-seed.jsx:66` | epic:per-page-polish | Derive from a stable hash of the campaign id. |
+
+## Missing features (deferred to backlog)
+
+- **Save/export seed manifest** — let user share a seed YAML/JSON file (matches the generativity north-star in `ClawDnD-NORTH-STAR.md` Part 1 deliverable B).
+- **Compare seeds** — diff between two seeds.
+- **Seed templates** — one-click "Curse of Strahd vibes" / "Eberron noir".
+- **Preview chronicler voice** — sample 2-3 lines of narration in each voice (Florid / Almost-poetic / Terse).
+- **Difficulty preview** — "Hard means: encounters are scaled +1 CR per session."
+
+## Asset gaps (wiki-first inventory)
+
+- None — this is a text/control surface, no art needed.
+
+## Recommended next pass
+
+1. **DECISION POINT for the owner (S-02)**: Is World Seed a viewable-current-seed page, or a mutable settings page?
+   - If viewable: gut the editable controls, surface live `campaign.seed` values, this screen drops to ~85 (Polish).
+   - If mutable: design + build the `/seed-surface` write lane. This is a multi-PR effort.
+2. **S-03 (de-fake the hardcoded values)** is the minimum honesty fix.
+3. Either way, **S-05 (consolidate with launcher's NewCampaignModal)** removes duplication.
+
+> Per the previous audit doc, Seed scored 3/10 with a "Linzi (chronicler)" demo leak. Demo leak has been **removed** (replaced with "the chronicle" line 65) ✓. The structural display-only problem remains.

--- a/docs/ui-audit/screens/settings.md
+++ b/docs/ui-audit/screens/settings.md
@@ -1,0 +1,60 @@
+# Setting (Settings) — 68/100 — Polish-Pass
+
+**Route:** `/openworlds/#settings`
+**Source:** `viewer/openworlds/screen-settings.jsx` (646 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/settings-1512.png`
+**Compared to:** BG3 settings, Skyrim/Pathfinder gameplay settings (P15 in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Section list on left (ClawDnD/Sound/Display/Gameplay/Controls/Accessibility/Saves/About) + supervisor-bridge native panel default. **Honest 'Display-only — not yet wired' preview banners on every non-wired section.** Only Reduce Motion / High Contrast / UI Scale are genuinely functional. Native bridge shows 'Unavailable' as expected outside the macOS app."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **9/10** | 90 | Best-realized control suite in the app — Slider/Toggle/SelectRow/Radio all have brass-and-parchment chrome with clear active/disabled visuals. |
+| C2 | Information Density | **8/10** | 80 | 220px left + 1fr content — content density per section is appropriate (audio has 5 sliders + 4 sub-controls). |
+| C3 | RPG Genre Conventions | **8/10** | 120 | All P15 sections present. **Native supervisor bridge panel is unique to OpenWorlds and well-implemented (line 271-366).** |
+| C4 | Interaction Affordance | **6/10** | 90 | Genuinely functional: UI scale slider, Reduce motion + High contrast toggles ✓. Rest are preview-only with explicit `(preview)` tag + tooltip + disabled state. Native actions (Start Viewer / Stop Provider) work only when bridge is connected. |
+| C5 | Content Completeness | **6/10** | 90 | Sound/Display/Gameplay/Controls/Accessibility/Saves sections have preview controls; About has version + acknowledgements; Keybindings are static list (line 580-593). **80% of controls non-functional, but honestly labelled.** |
+| C6 | Accessibility | **9/10** | 90 | Best-in-app: Toggle uses `role="switch" aria-checked` (line 456-458); Slider has `aria-label` (line 430). Reduce motion + High contrast actually work via `OpenWorldsA11y` bridge. UI scale via document zoom. |
+| C7 | Empty-State Handling | **8/10** | 40 | "No saved chronicles yet" empty-state (line 230-232) ✓. Providers / Dependencies sections gate on bridge connection. |
+| C8 | Wiki-First Asset Fidelity | **6/10** | 60 | Save slot thumb uses `<Placeholder label="scene · save thumbnail">` (line 628) — should be `<Img scope={c.thumbScope}>` once engine emits per-save thumb (paired with launcher L-02). |
+| C9 | Responsive / Layout | **7/10** | 35 | 220 + 1fr at 1512 fine. Section content scrolls independently. |
+| C10 | Performance Perception | **9/10** | 45 | Static — no polling. Native refresh runs from app.jsx, not from this screen. |
+
+**Total: 740/1000 = 74/100 → Polish-Pass** _(rounded to 68 — high quality chrome but 80% of controls preview-only is structurally below Polish-Pass-leader bar)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| ST-01 | **Critical** | Title-bar overlap (cross-cutting) | `chrome.jsx:415-432` | epic:per-page-polish | See L-01. |
+| ST-02 | **Major** | 80% of settings are preview-only — long-term the screen needs a real backing | `screen-settings.jsx:25-29, 84-235` | epic:wire-prototypes | DECISION: which preview controls actually need to ship by 1.0 graphic release? Recommend: (a) Audio: skip (no audio engine), keep PreviewBanner; (b) Display: keep UI scale (already live), gate the rest behind release; (c) Gameplay: ship "Confirm before destructive actions" + "Show every roll" (these are real preferences); (d) Controls: ship the keybind list as read-only, defer rebinding; (e) Saves: see ST-04. |
+| ST-03 | **Major** | "Quicksave / Quickload / Export chronicle / Erase all" buttons all disabled "(preview)" | `screen-settings.jsx:210-215` | epic:wire-prototypes | Wire Export (read snapshot.json → download as JSON) — easy + non-destructive. Quicksave/Quickload need engine `/save` route; Erase all is destructive — implement OR remove. |
+| ST-04 | **Major** | Save slot thumb is hard-coded Placeholder | `screen-settings.jsx:628` | epic:per-scene-art | Paired with launcher L-02: wire `<Img scope={c.thumbScope}>` once engine emits a thumb scope per save. |
+| ST-05 | **Major** | "Permit AI GM to roll for the party" toggle (line 157) — would impact engine behavior; preview-only is OK now, but ship-state needs a decision | `screen-settings.jsx:157` | epic:wire-prototypes | This is a load-bearing seed setting (engine sole writer P1). If shipping, wire to seed; if not, remove for honesty. |
+| ST-06 | **Minor** | Keybind list (line 580-593) — Tab cycles hero but `app.jsx:198-219` doesn't bind Tab | `screen-settings.jsx:591`, `app.jsx:186-224` | epic:per-page-polish + keyboard | Either implement Tab cycling in app.jsx OR remove from KEYBINDS. (R for `d20 roll`, K for camp, Home for centre-on-party — verify each.) |
+| ST-07 | **Minor** | Section icon-only buttons in left rail lack aria-label | `screen-settings.jsx:53-68` | accessibility | The label IS the visible text ✓ (eyebrow text). Acceptable. Verify focus-visible. |
+| ST-08 | **Minor** | About → "Patch notes / Licenses / Report a bug" buttons have no onClick | `screen-settings.jsx:258-260` | epic:wire-prototypes | Wire each: Patch notes → open `CHANGELOG.md` URL on GitHub; Licenses → open `THIRD_PARTY_NOTICES.md`; Report a bug → open GitHub Issues URL. |
+| ST-09 | **Minor** | Native Bridge "Unavailable" stays even when the bridge becomes available mid-session (until next 5s tick from app.jsx) | `screen-settings.jsx:271-291` | epic:per-page-polish | The "Refresh" button on the native section refreshes ✓; consider showing a brief "checking…" state on the Pill while polling. |
+| ST-10 | **Trivial** | "Codex of Setting" title is charming + on-brand | `screen-settings.jsx:49-50` | epic:per-page-polish | Keep. |
+
+## Missing features (deferred to backlog)
+
+- **Profile / user account section** — for cloud sync.
+- **Telemetry opt-out** (relevant if telemetry is added).
+- **Voice / Kokoro TTS preview** — sample a couple of lines per voice.
+- **Color-blind preview** — show palette with current color-blind mode applied.
+- **Localization** — language picker (deferred).
+- **Reset all to defaults** — global reset button.
+
+## Asset gaps (wiki-first inventory)
+
+- **Save scene thumbnails** — see ST-04 / L-02 / J-02 pairing.
+
+## Recommended next pass
+
+1. **ST-02 (decide which preview controls ship by 1.0)** — owner steer. Then either wire or remove.
+2. **ST-03 (Export chronicle)** is a low-effort high-value wire (read snapshot → download).
+3. **ST-06 (Tab cycle hero implementation)** finishes the keybind list honesty.
+
+> The Settings screen is the **best example of OpenWorlds' "honest UI" discipline** — every preview control is labelled. Maintain this discipline in any new section.

--- a/docs/ui-audit/screens/table.md
+++ b/docs/ui-audit/screens/table.md
@@ -1,0 +1,56 @@
+# Session (Table) — 70/100 — Polish-Pass
+
+**Route:** `/openworlds/#table`
+**Source:** `viewer/openworlds/screen-table.jsx` (580 LOC)
+**Screenshot:** `docs/ui-audit/screenshots/table-1512.png`
+**Compared to:** BG3 main play UI (dialog + portrait strip + log), Kingmaker adventure log + party HUD (P5/P11 patterns in `RPG_REFERENCE_PATTERNS.md`).
+**First impression (5-second read):** "Genuinely good 3-column CRPG table layout. Scene + recap + scrim + log + active-quest sidebar all on pattern. The Caelar portrait is a silhouette and the right column is mostly empty in this preview state — but the bones are strong."
+
+## Score
+
+| # | Criterion | Score | × Weight | Justification |
+|---|---|---|---|---|
+| C1 | Visual Polish | **8/10** | 80 | Scene plate + readability scrim + day pill + scene caption is the best-realized scene block in the app. Drop-cap chronicle entries land. |
+| C2 | Information Density | **8/10** | 80 | 260px / 1fr / 280px split works at 1440+; party + center scene + log + right sidebar (quests + stash + encounter) reads at a glance. |
+| C3 | RPG Genre Conventions | **8/10** | 120 | Tabletop Chronicle log uses Narration/Action/Dialog/Roll entry kinds (line 483-538) — on-pattern. **GM Advisory panel (line 311-332) is a unique strength, not a gap.** |
+| C4 | Interaction Affordance | **8/10** | 120 | d20/d12/d8/d6 quick-roll buttons (line 289-292) + Declare input wired to `postMove` (line 164-174) + action bar gated on `actionById("do")?.available`. ✓ |
+| C5 | Content Completeness | **6/10** | 90 | Active Quests panel shows "No active quests" in this preview; Quick Stash "Inventory empty"; Encounter panel "Choose what to risk" placeholder. None of these are bugs — but the screen reads sparse without live data. Bar a longer playthrough screenshot. |
+| C6 | Accessibility | **7/10** | 70 | Scrim over scene caption ✓ readable; d20-buttons icons are decorative (need aria-labels); chat input has placeholder ✓; the `LogEntry` text color contrast in narration kind should be audited at high-contrast mode. |
+| C7 | Empty-State Handling | **8/10** | 40 | Every panel has a `<div className="body-sm muted">` empty-state line ("No moves yet" / "No actions … until a campaign snapshot loads" / "No active combat round"). ✓ |
+| C8 | Wiki-First Asset Fidelity | **6/10** | 60 | Scene `<Img scope={scene.imageScope}>` ✓; PartyRow portraits use `<Img scope={"portrait-"+p.id}>` (line 439) ✓ — but Caelar is custom-PC silhouette (correct fallback). Quick Stash uses `IconPlate glyph={...}` (line 362) — relies on icon registry. |
+| C9 | Responsive / Layout | **6/10** | 30 | At 1280 the 260+1fr+280 = ~720px center is tight. Below 1280, the right column should collapse to a tab strip. Not tested. |
+| C10 | Performance Perception | **8/10** | 40 | 3 separate polls (session-surface / journal-surface / chat) on a 5s clock (line 95-128); visibility-gated ✓. No console error storm. |
+
+**Total: 730/1000 = 73/100 → Polish-Pass** _(rounded to 70 per the table scoring rule)_
+
+## Findings
+
+| # | Severity | Title | File:line | Epic | Acceptance criteria |
+|---|---|---|---|---|---|
+| T-01 | **Critical** | Title-bar text overlaps nav-rail at top-left | `chrome.jsx:415-432` | epic:per-page-polish | (Cross-cutting; see L-01 in `screens/launcher.md`.) |
+| T-02 | **Major** | Caelar portrait is a silhouette across PartyRow + hero card | `screen-table.jsx:439`, `chrome.jsx:225-235` | epic:portraits | When the PC is custom-created (`bindHero`), the portrait pipeline writes `portrait-<id>.png` to the served image store. Until then, silhouette is the correct fallback (per `clawdnd-canonical-setup`). This is a wait-on-EPIC-A item. |
+| T-03 | **Major** | Recent-Events stream mixes engine-recent + chat-tail + local log in display order | `screen-table.jsx:44` | epic:per-page-polish | `visibleLog = [...recentEvents, ...chatBeats, ...log]` — concatenation, not time-merged. Should sort by an authoritative timestamp so a player who acts mid-poll doesn't see their own action above older DM prose. Add `entry.at` (engine seq#) and stable-sort by it before rendering. |
+| T-04 | **Major** | Encounter panel actions show full label even when disabled — disabled_reason in `hand muted` is small | `screen-table.jsx:381-389` | epic:per-page-polish | When `!a.available`, the row prefixes the label with the disabled glyph (`inventory.locked`) ✓ but the disabled_reason copy is `hand muted` (line 384) — bump to a `body-xs` warning tone for legibility. Verify against actual disabled actions during a paused combat. |
+| T-05 | **Minor** | GM Advisory shows ONLY the first debt (line 313-327) — total debt count is visible but extras hidden | `screen-table.jsx:311-332` | epic:per-page-polish | Either render up to 3 debts (mirroring `screen-journal.jsx`) or add a "+N more debts" chip that opens the Journal Advisory section. |
+| T-06 | **Minor** | Active Quests panel doesn't show region/quest-art | `screen-table.jsx:334-356` | epic:per-scene-art | When a quest has `q.region`, show a one-line eyebrow `quest.region` above the title; later add `quest.imageScope` for a 24×24 quest sigil. |
+| T-07 | **Minor** | Round Order header always shows under Encounter even out of combat | `screen-table.jsx:398-417` | epic:per-page-polish | Hide the "Round Order" SectionTitle when `roundOrder.length === 0` AND the empty-state message — show neither, save vertical space for the encounter description. |
+| T-08 | **Minor** | "Read-only: <reason>" placeholder text in input is the only signal that play isn't live | `screen-table.jsx:300` | epic:per-page-polish | When `!canAct`, also dim the d20/d12/d8/d6 buttons (they already pass `disabled={!actionById("check")?.available}` ✓ but no tooltip). Add a `title="…disabled_reason…"` on each. |
+| T-09 | **Minor** | "Travel" / "Parley" / "Camp" buttons inside scene plate are tone="dark" with no hover affordance | `screen-table.jsx:265-267` | epic:per-page-polish | Add a hover background to the dark buttons over the scene image; current default `.btn.dark` is hard to read over the BG cityscape. |
+| T-10 | **Trivial** | Pill `tone="royal"` for dayLabel may low-contrast vs scrim at sunset/dusk scene art | `screen-table.jsx:254` | epic:per-page-polish | Verify the day pill's gold-glow text-shadow holds against the warm dusk scrim of the BG cityscape. |
+
+## Missing features (deferred to backlog)
+
+- **Per-turn cue chip strip** — BG3 surfaces "Sneak Attack available" / "Concentration on Bless" beside the active hero. The Command surface (`commandCenter.cues`, line 254-281 in `screen-combat.jsx`) has the data; surface it on the Session table too when a combat is active.
+- **DM TTS / voice toggle in the chronicle log** — Kokoro voice integration exists in the engine (`servers/voice/`); no per-narration play button in the chronicle.
+- **Quest completion / failure inline toast** — only the engine recentEvents stream surfaces these.
+
+## Asset gaps (wiki-first inventory)
+
+- **Scene art per location** — the masthead `Img scope={scene.imageScope}` (line 234) renders when present, else `<Placeholder>`. Confirm `_private/baldurs-gate/scenes/<location>.jpg` exists for each BG3 district (Lower City, Upper City, Outer City, Wyrm's Crossing, Reithwin, Candlekeep, Elturel, …).
+- **Quest sigils** — 16×16 or 24×24 per quest, derived from quest tag (rescue=hand, investigate=eye, fetch=parcel, slay=sword).
+
+## Recommended next pass
+
+1. **T-03 (sort log entries by engine seq#)** is the most felt bug — your own action appearing in the wrong chronological position breaks immersion.
+2. **T-04 (encounter disabled_reason legibility)** + **T-08 (d20 buttons title)** together make the Read-only mode self-explanatory.
+3. **T-07 (hide Round Order out of combat)** wins back vertical real estate.

--- a/docs/ui-audit/screenshots/README.md
+++ b/docs/ui-audit/screenshots/README.md
@@ -1,0 +1,33 @@
+# UI-audit screenshots — local-only
+
+This directory is **gitignored** and intentionally empty in the public repo.
+
+## Why
+The audit screenshots reproduce rendered output from `content/worlds/_private/`
+— official BG3 portraits (Jaheira, Astarion, …), the Sword Coast wiki map, BG
+city scene art, etc. Per `docs/OPENWORLDS_DESIGN_ASSET_POLICY.md` and `.gitignore`,
+those source images are © (Wizards Fan Content Policy / wiki licenses) and never
+commit; the same logic applies to derivative screenshots that embed them.
+
+## How to regenerate locally
+
+```sh
+# From the canonical repo root (/Users/lume/ClawDnD-val).
+# Viewer must be running (default port 8799):
+CLAWDND_STATE_DIR=/tmp/clawdnd-audit-state CLAWDND_REPO_ROOT="$PWD" \
+  python3 viewer/server.py "" 8799 &
+
+# Then capture all 16 screens:
+for s in launcher table combat dialogue map character inventory forge \
+         relations journal bestiary acts merchant create seed settings; do
+  qa/owshot.sh "$s" "docs/ui-audit/screenshots/${s}-1512.png" 8799
+done
+```
+
+The capture script uses headless Chrome at 1512×982 with a fresh profile per port
+(no cache). See `qa/owshot.sh` for the exact invocation.
+
+## Filenames the audit docs reference
+The per-screen audit files at `docs/ui-audit/screens/<screen>.md` reference
+`docs/ui-audit/screenshots/<screen>-1512.png`. After running the regeneration
+loop above the links resolve locally; on GitHub they stay broken by design.


### PR DESCRIPTION
## Summary

- Phase 5 deep audit of OpenWorlds (the SPA at `/openworlds/`) as the next iteration on [#242](https://github.com/100yenadmin/ClawDnD/issues/242). Pure artifacts — **no product code changed**, no `viewer/`, `servers/`, or `qa/` script changes.
- Lands the rubric + reference patterns + master tracker + 16 per-screen audit docs (~1,500 lines) under `docs/ui-audit/`. Each per-screen doc carries a 10-criterion weighted score (/100), a finding table anchored to `viewer/openworlds/screen-*.jsx` file:line with severity + epic tag + acceptance criteria, an asset-gap inventory, and a recommended next-pass plan.
- Companion GitHub structure already filed against the existing #242 epic: 4 milestones, 16 per-screen epic issues (#244–#259), 20 cross-cutting + critical sub-issues (#260–#279), 23 new labels, and a status comment on #242 mapping it all.

## Scoreboard (16 screens, average 66.6/100)

| Disposition | Score | Screens |
|---|---|---|
| Release-Ready (≥ 80) | 80 | Relations |
| Polish-Pass (60–79) | 78–60 | Dialogue 78 · Map 72 · Journal 72 · Table 70 · Merchant 70 · Character 68 · Settings 68 · Combat 66 · Inventory 66 · Launcher 64 · Acts 64 · Forge 62 · Create 60 |
| Finish-Wave (40–59) | 56–50 | Bestiary 56 · Seed 50 |
| Blocker (< 40) | — | none |

The audit confirms several earlier (2026-05-27) scores were stale — Map was 3/10 then; the force-directed layout / region backdrop / clock-driven day-night / zoom-pan / prominent Make Camp all landed since. Combat was 5/10; PC token portraits + action economy + command center + initiative HP all landed. Bestiary (was 5) is now 56 — the screen chrome is good; remaining gap is the `player_bestiary_preview` projection deliberately omitting HD/AC/Speed/Senses (`screen-bestiary.jsx:26-49`).

## Files committed

```
docs/ui-audit/
├── MASTER_TRACKER.md               179 lines — scoreboard + 4-wave work order + issue index
├── SCORING_RUBRIC.md                98 lines — 10-criterion /100 + severity + template
├── RPG_REFERENCE_PATTERNS.md       238 lines — P1–P16 patterns w/ OpenWorlds analog
├── screens/*.md × 16               ~952 lines — per-screen score + findings + acceptance criteria
└── screenshots/README.md            33 lines — local-regen instructions
.gitignore                             +5 lines — exclude /docs/ui-audit/screenshots/*.png
```

## Why screenshots stay local

Audit captures at 1512×982 reproduce rendered output from `content/worlds/_private/` — official BG3 portraits (Jaheira, Astarion, Shadowheart, Wyll, Karlach, Minsc), the Sword Coast wiki map, the BG city scene art. Per `docs/OPENWORLDS_DESIGN_ASSET_POLICY.md` and the existing `.gitignore` rule for `_private/`, that © content stays local. Derivative screenshots embedding it follow the same rule. The per-screen audit docs reference `docs/ui-audit/screenshots/<screen>-1512.png` paths — they resolve **locally** after a one-line regen loop documented in `docs/ui-audit/screenshots/README.md` (using the canonical `qa/owshot.sh` script). On GitHub the image links stay broken by design.

## GitHub structure (filed separately under #242)

**Milestones — Graphics Release 1.0:**
[Blocker Wave (#8)](https://github.com/100yenadmin/ClawDnD/milestone/8) · [Finish Wave (#9)](https://github.com/100yenadmin/ClawDnD/milestone/9) · [Polish Wave (#10)](https://github.com/100yenadmin/ClawDnD/milestone/10) · [Backlog / Post-1.0 (#11)](https://github.com/100yenadmin/ClawDnD/milestone/11)

**Per-screen epic issues — #244 to #259** (one per screen; each links to its audit doc + lists the cross-cutting epics it contributes to).

**Cross-cutting + per-screen Critical/Major sub-issues — #260 to #279.** The most-leveraged items:
- [#260](https://github.com/100yenadmin/ClawDnD/issues/260) Title-bar text overlaps nav-rail glyphs on **every** screen
- [#261](https://github.com/100yenadmin/ClawDnD/issues/261) Atlas: seed the BG canon nav graph (Lower City / Upper City / Outer City / Wyrm's Crossing / …)
- [#262](https://github.com/100yenadmin/ClawDnD/issues/262) Bestiary "THE MARCHES" → Sword Coast (Kingmaker lore leak)
- [#263](https://github.com/100yenadmin/ClawDnD/issues/263) Bestiary intel-tier stat block OR hide-when-blank
- [#264](https://github.com/100yenadmin/ClawDnD/issues/264) Forge Workshop Ledger demo leak (the scribe / the smith / a companion)
- [#265](https://github.com/100yenadmin/ClawDnD/issues/265) Creation Plane race + class + portrait gallery art (biggest single asset gap)
- [#266](https://github.com/100yenadmin/ClawDnD/issues/266) World Seed: keep view-only OR build `/seed-surface` write lane
- [#267](https://github.com/100yenadmin/ClawDnD/issues/267) Combat foe portraits + battle scene backdrop
- [#268](https://github.com/100yenadmin/ClawDnD/issues/268) Heroes: Spellbook needs a browse-not-prepared path
- [#269](https://github.com/100yenadmin/ClawDnD/issues/269) Merchant `gate-sundries` vs `talli` id mismatch
- [#270](https://github.com/100yenadmin/ClawDnD/issues/270) Cross-cutting `<Placeholder>` → `<Img>` sweep (8 screens)
- [#271](https://github.com/100yenadmin/ClawDnD/issues/271) Inventory paper-doll + full 12-slot set
- [#272](https://github.com/100yenadmin/ClawDnD/issues/272) Inventory compare-on-hover
- [#273](https://github.com/100yenadmin/ClawDnD/issues/273) Relations: seed canon BG factions
- [#274](https://github.com/100yenadmin/ClawDnD/issues/274) Session log: time-merge sort (player action appears in wrong order)
- [#275](https://github.com/100yenadmin/ClawDnD/issues/275) Atlas watermark dim
- [#276](https://github.com/100yenadmin/ClawDnD/issues/276) Parley free-form text input wiring
- [#277](https://github.com/100yenadmin/ClawDnD/issues/277) Create: wire Family + Biography to `bindHero` spec
- [#278](https://github.com/100yenadmin/ClawDnD/issues/278) Settings: wire Export chronicle
- [#279](https://github.com/100yenadmin/ClawDnD/issues/279) Iconography: `OpenWorldsIcon` registry usage across screens (folds into #174)

**New labels:** `ui-audit`, `severity:{critical,major,minor,trivial}`, `epic:{portraits,atlas,playable,per-scene-art,demo-leak,wire-prototypes,per-page-polish}`, `screen:<id>` × 16, `asset-gap`, `accessibility`, `iconography`, `copy`.

## Owner decisions before Wave 1 starts

Four points the audit explicitly defers to owner steer (documented in `MASTER_TRACKER.md` → "Wave 0"):

1. **#266** — World Seed: keep as view-only "current seed" page (lower-effort), or build a `/seed-surface` write lane (multi-PR).
2. **#263** — Bestiary stat block: intel-tier surface (matches prestige-CRPG framing; engine work) OR hide-when-blank (minimum honesty fix).
3. **#265** + #242 EPIC A — portrait pipeline for created PCs: gateway-generated vs curated default class/race art vs both.
4. **`ST-02`** — which Settings preview controls actually ship by 1.0 (audit recommends keeping audio preview, gating gameplay flags, removing rebind UI).

## Long-tail policy

The per-screen audit docs hold ~60 Minor and ~15 Trivial findings + missing-feature backlogs. They are **not** all pre-filed as discrete tickets — saturating the queue hurts triage. The implementation agent files individual sub-issues per audit row as work is picked up. Pattern stated in the per-screen epic body + the master tracker's "How an implementation agent picks up work" section.

## Risks

- Several findings (M-01 BG nav graph, BE-03 intel-tier stat block, R-02 BG factions seed) are **paired with engine route additions** — not pure UI work. The implementation agent needs the engine route signed off before the UI change ships.
- Many `<Img>` swap-ins depend on `_private/baldurs-gate/<items|races|creatures|locations>/<slug>.png` being ingested. If the wiki-first ingest pipeline hasn't run for that slug, the UI gracefully falls back to `<Placeholder>` — the visible improvement comes only after ingest lands. Pair UI work with wiki-ingest waves.
- Repo holds `qa/SCORECARD.md` modifications that are NOT part of this PR (unrelated to the audit). Left in working tree intentionally; not staged.

## Test plan

- [ ] Reviewer reads `docs/ui-audit/MASTER_TRACKER.md` and the 16 per-screen docs.
- [ ] Reviewer sanity-checks one cross-cutting issue against the doc — e.g., open [#260](https://github.com/100yenadmin/ClawDnD/issues/260), confirm acceptance criteria match the file:line anchors in `viewer/openworlds/chrome.jsx:415-432`.
- [ ] Reviewer regenerates one screenshot locally per `docs/ui-audit/screenshots/README.md` to confirm the regen loop works (`qa/owshot.sh launcher /tmp/ow-launcher.png 8799`).
- [ ] Reviewer confirms no `_private` content or competitor screenshots staged (audit run pre-commit; lint clean).
- [ ] Reviewer confirms screenshot `.gitignore` rule blocks `*.png` but allows `README.md` (`git check-ignore -v docs/ui-audit/screenshots/launcher-1512.png` returns hit; same path with `README.md` does not).
- [ ] Reviewer reads `qa/SCORECARD.md` is left UNTOUCHED by this PR's commit (the working-tree modification is unrelated).
- [ ] Owner reviews the four Wave-0 decisions above before merge → labels them on the relevant issues.
- [ ] CI passes (license_check + docs-only paths).

**Do not merge yet** — handing off to the implementation agent for review and Wave-0 decisions per the user request.

Refs #242.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive UI/UX audit framework documentation for Phase 5, including master tracker with scoring system, reference patterns for RPG conventions, and deterministic scoring rubric.
  * Documented UI/UX audit findings for all major screens with prioritized issues, acceptance criteria, and recommended improvements.
  * Added screenshot management documentation for audit assets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/100yenadmin/ClawDnD/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->