### PR TITLE
fix(audit): #268 Browse-spellbook CTA + #271 inventory paper-doll

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -826,10 +826,26 @@ function SpellsTab({ hero }) {
   const groups = (Array.isArray(hero.spells) ? hero.spells : []).filter((g) => g && Array.isArray(g.list) && g.list.length);
   const slots = Array.isArray(hero.spellSlots) ? hero.spellSlots : [];
   const isCaster = slots.length > 0 || groups.length > 0;
+  // #268: every caster gets a working "Browse spellbook" path — a read-only inspector over
+  // the hero's known + prepared spells (the surface's hero.spells groups). The empty state
+  // INVITES the browse instead of dead-ending; preparation stays in the Rest & Prepare modal.
+  const [browsing, setBrowsing] = React.useState(false);
+  const spellCount = groups.reduce((n, g) => n + g.list.length, 0);
+
+  const browseCta = isCaster ? (
+    <BrassButton
+      tone="dark"
+      size="sm"
+      onClick={() => setBrowsing(true)}
+      title="Inspect this hero's known & prepared spells (read-only)"
+    >
+      Browse spellbook{spellCount ? ` (${spellCount})` : ""}
+    </BrassButton>
+  ) : null;
 
   return (
     <div>
-      <SectionTitle ordinal="·">Spellbook</SectionTitle>
+      <SectionTitle ordinal="·" right={browseCta}>Spellbook</SectionTitle>
       <SpellSlotTrack slots={slots} />
       {groups.length ? (
         groups.map((group) => (
@@ -854,13 +870,100 @@ function SpellsTab({ hero }) {
             </div>
           </div>
         ))
+      ) : isCaster ? (
+        // Caster with open slots but no spell NAMES bound yet — invite the browse path
+        // (and the Rest & Prepare flow) instead of dead-ending on a flat message (#268).
+        <div style={{
+          marginTop: slots.length ? 16 : 8,
+          padding: "16px 18px", textAlign: "center",
+          background: "rgba(176,141,87,0.06)",
+          boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)",
+        }}>
+          <div className="hand muted" style={{ fontSize: 13 }}>
+            This hero holds open spell slots but has bound no spells to the page.
+          </div>
+          <div style={{ marginTop: 10 }}>
+            <BrassButton
+              tone="dark"
+              size="sm"
+              onClick={() => setBrowsing(true)}
+              title="Open this hero's spellbook (read-only)"
+            >
+              Browse spellbook
+            </BrassButton>
+          </div>
+        </div>
       ) : (
         <div className="muted body-sm" style={{ marginTop: slots.length ? 16 : 8 }}>
-          {isCaster
-            ? "No spells prepared yet — this hero holds open slots but has bound no spells to the page."
-            : "This hero prepares no spells."}
+          This hero prepares no spells.
         </div>
       )}
+
+      {browsing && <SpellbookBrowser hero={hero} groups={groups} onClose={() => setBrowsing(false)} />}
+    </div>
+  );
+}
+
+function SpellbookBrowser({ hero, groups, onClose }) {
+  // Read-only spellbook inspector (#268). Surfaces the hero's known + prepared spells from
+  // the /character-surface read-model — no preparation here (the Rest & Prepare modal owns
+  // that write-flow). When the engine carries no spell NAMES, we say so honestly rather than
+  // fabricate an SRD list, and point the player at Rest & Prepare.
+  const list = (Array.isArray(groups) ? groups : []).filter((g) => g && Array.isArray(g.list) && g.list.length);
+  return (
+    <div style={{
+      position: "fixed", inset: 0, zIndex: 200,
+      background: "rgba(15, 8, 2, 0.7)",
+      display: "grid", placeItems: "center",
+      backdropFilter: "blur(2px)",
+    }} onClick={onClose}>
+      <div onClick={(e) => e.stopPropagation()} style={{ width: 640, maxWidth: "92vw", maxHeight: "88vh", overflow: "auto" }}>
+        <Panel framed>
+          <div className="eyebrow" style={{ color: "var(--crimson)" }}>The Spellbook</div>
+          <h2 className="h1" style={{ fontSize: 24 }}>{hero.name}'s Spells</h2>
+          <p className="hand muted" style={{ fontSize: 13, marginTop: 2 }}>
+            Read-only. Prepare or change today's spells from <em>Rest &amp; Prepare</em>.
+          </p>
+          <Divider />
+
+          {list.length ? (
+            list.map((group) => (
+              <div key={group.level} style={{ marginTop: 16 }}>
+                <SectionTitle right={<span className="muted body-sm">{group.list.length}</span>}>
+                  {spellGroupLabel(group.level)}
+                </SectionTitle>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+                  {group.list.map((sp) => (
+                    <div key={sp.name} style={{
+                      display: "flex", gap: 10, alignItems: "center", padding: 10,
+                      background: "rgba(176,141,87,0.08)",
+                      boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)",
+                    }}>
+                      <Placeholder label={sp.glyph} w={36} h={36} framed />
+                      <div style={{ minWidth: 0 }}>
+                        <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.08em", color: "var(--ink-900)" }}>
+                          {sp.name}
+                        </div>
+                        <div className="body-sm muted">{spellMeta(sp)}</div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))
+          ) : (
+            <p className="body muted" style={{ marginTop: 0 }}>
+              No spells are inscribed in this hero's book yet. Open <em>Rest &amp; Prepare</em>
+              {" "}to bind spells to the day.
+            </p>
+          )}
+
+          <Divider />
+          <div style={{ display: "flex", justifyContent: "flex-end" }}>
+            <BrassButton tone="ghost" onClick={onClose}>Close book</BrassButton>
+          </div>
+        </Panel>
+      </div>
     </div>
   );
 }
@@ -886,4 +989,4 @@ function FeatsTab({ hero }) {
   );
 }
 
-Object.assign(window, { ScreenCharacter, AbilityScore, StatLine, ResourcesStatus, AbilitiesTab, SkillsTab, SpellsTab, SpellSlotTrack, LineagePanel, FeatsTab, AbilityCard, FeatRow, RestPrepareModal, RestCard, ProficiencyDot, portraitScope, spellMeta });
+Object.assign(window, { ScreenCharacter, AbilityScore, StatLine, ResourcesStatus, AbilitiesTab, SkillsTab, SpellsTab, SpellbookBrowser, SpellSlotTrack, LineagePanel, FeatsTab, AbilityCard, FeatRow, RestPrepareModal, RestCard, ProficiencyDot, portraitScope, spellMeta });

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -151,27 +151,8 @@ function ScreenInventory({ onNavigate, state, setState }) {
           </div>
         )}
 
-        {/* Hero portrait + slots */}
-        <div style={{ position: "relative", marginTop: 16, padding: "0 8px" }}>
-          <Img scope={heroPortraitScope(hero)} label={`${hero.name} · full art`} h={220} framed style={{ width: "100%" }} />
-
-          {/* Equipment slots ringing portrait */}
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(6, 1fr)", gap: 6, marginTop: 10 }}>
-            {EQUIP_SLOTS.map((s) => {
-              const equipped = hero.equipped.find((e) => e.slot === s.label);
-              return (
-                <div key={s.label} style={{ textAlign: "center" }}>
-                  {equipped
-                    ? <Img scope={"item-" + slug(equipped.name)} label={equipped.name} w="100%" h={44} framed />
-                    : <Placeholder label={s.label} w="100%" h={44} framed />}
-                  <div style={{ fontFamily: "var(--f-mono)", fontSize: 8, marginTop: 2, color: "var(--ink-600)" }}>
-                    {s.label}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </div>
+        {/* Hero paper-doll: portrait flanked by the canonical equipment slots (#271). */}
+        <PaperDoll hero={hero} />
 
         <Divider />
 
@@ -305,10 +286,132 @@ function ScreenInventory({ onNavigate, state, setState }) {
   );
 }
 
+// #271: the canonical D&D/BG3 equipment slot set, laid out as a paper-doll (two columns
+// flanking the portrait + a weapons row beneath). Each slot has a stable `id` (used for
+// item→slot assignment), a short `label`, and a `col` (left/right/arms) placing it in the
+// doll. Ring 1 / Ring 2 and Main / Off-Hand are distinct so a hero can wear two of each.
 const EQUIP_SLOTS = [
-  { label: "Head" }, { label: "Neck" }, { label: "Body" },
-  { label: "Hands" }, { label: "Ring" }, { label: "Boots" },
+  { id: "head",    label: "Head",    col: "left"  },
+  { id: "cloak",   label: "Cloak",   col: "left"  },
+  { id: "body",    label: "Body",    col: "left"  },
+  { id: "hands",   label: "Hands",   col: "left"  },
+  { id: "belt",    label: "Belt",    col: "left"  },
+  { id: "amulet",  label: "Amulet",  col: "right" },
+  { id: "ring1",   label: "Ring I",  col: "right" },
+  { id: "ring2",   label: "Ring II", col: "right" },
+  { id: "boots",   label: "Boots",   col: "right" },
+  { id: "mainhand", label: "Main Hand", col: "arms" },
+  { id: "offhand",  label: "Off-Hand",  col: "arms" },
+  { id: "ranged",   label: "Ranged",    col: "arms" },
 ];
+
+// Name→slot inference. The engine carries no per-item slot (the Item model has no `slot`
+// field, so the surface emits slot:"Worn" for everything), so we infer the doll cell from
+// the item NAME — exactly as the surface infers item TYPE from the name. Forward-compatible:
+// if the surface ever emits a real canonical slot id, assignEquipSlots prefers it.
+const _SLOT_NAME_HINTS = [
+  ["head",   ["helm", "helmet", "circlet", "crown", "hat", "hood", "cap", "coif", "mask", "diadem"]],
+  ["cloak",  ["cloak", "cape", "mantle", "shawl"]],
+  ["amulet", ["amulet", "necklace", "pendant", "talisman", "torc", "locket", "periapt", "medallion", "brooch"]],
+  ["body",   ["robe", "armor", "armour", "mail", "plate", "cuirass", "breastplate", "leather", "hide", "vest", "tunic", "garb", "raiment", "padded", "scale", "brigandine", "chain shirt", "half plate"]],
+  ["hands",  ["gauntlet", "glove", "bracer", "vambrace", "handwrap", "gloves"]],
+  ["belt",   ["belt", "girdle", "sash", "cord"]],
+  ["boots",  ["boot", "boots", "greave", "sabaton", "shoe", "sandal", "footwrap", "slipper"]],
+  ["ring",   ["ring", "band", "signet"]],
+  // Off-hand / ranged are detected before generic main-hand weapons.
+  ["offhand", ["shield", "buckler", "off-hand", "offhand"]],
+  ["ranged",  ["bow", "crossbow", "sling", "dart", "javelin", "arrows", "bolts", "ammunition", "quiver"]],
+  ["mainhand", ["sword", "axe", "dagger", "mace", "spear", "rapier", "blade", "hammer", "staff", "club", "flail", "scimitar", "glaive", "halberd", "warhammer", "maul", "trident", "whip", "wand", "scepter", "morningstar", "pike", "lance", "greatsword", "longsword", "shortsword"]],
+];
+
+function inferEquipSlotId(name) {
+  const low = (name || "").toLowerCase();
+  for (const [slot, needles] of _SLOT_NAME_HINTS) {
+    if (needles.some((n) => low.includes(n))) return slot;
+  }
+  return ""; // unrecognized — placed into the first free generic cell by assignEquipSlots
+}
+
+// Build a { slotId: equippedItem } map from hero.equipped. Rings and weapons spill from
+// their primary cell to the secondary (ring1→ring2, mainhand→offhand) so a hero wearing two
+// rings or dual-wielding shows both. Anything unrecognized lands in the first open cell so
+// no equipped item is ever silently dropped from the doll.
+function assignEquipSlots(equipped) {
+  const byId = {};
+  const order = EQUIP_SLOTS.map((s) => s.id);
+  const place = (item, preferred) => {
+    // honor a real canonical slot id from the surface if present
+    const fromSurface = order.includes(item.slot) ? item.slot : "";
+    const chain = fromSurface
+      ? [fromSurface]
+      : preferred === "ring" ? ["ring1", "ring2"]
+      : preferred === "mainhand" ? ["mainhand", "offhand"]
+      : preferred ? [preferred]
+      : [];
+    for (const id of chain) {
+      if (!byId[id]) { byId[id] = item; return true; }
+    }
+    return false;
+  };
+  const leftovers = [];
+  for (const it of (Array.isArray(equipped) ? equipped : [])) {
+    if (!it || !it.name) continue;
+    const placed = place(it, inferEquipSlotId(it.name));
+    if (!placed) leftovers.push(it);
+  }
+  // Drop any still-unplaced equipped items into the first open cell (never lose worn gear).
+  for (const it of leftovers) {
+    const open = order.find((id) => !byId[id]);
+    if (open) byId[open] = it;
+  }
+  return byId;
+}
+
+function EquipSlotCell({ slot, item }) {
+  return (
+    <div style={{ textAlign: "center" }}>
+      {item
+        ? (
+          <window.Tooltip content={<window.InfoTooltip kind="Equipped" title={item.name} body={`Worn in the ${slot.label} slot.`} />} side="top">
+            <div>
+              <Img scope={"item-" + slug(item.name)} label={`${item.name} · ${slot.label}`} w="100%" h={44} framed />
+            </div>
+          </window.Tooltip>
+        )
+        : <Placeholder label={slot.label} w="100%" h={44} framed />}
+      <div style={{ fontFamily: "var(--f-mono)", fontSize: 8, marginTop: 2, color: item ? "var(--ink-700)" : "var(--ink-600)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+        {item ? item.name : slot.label}
+      </div>
+    </div>
+  );
+}
+
+function PaperDoll({ hero }) {
+  // Paper-doll equip layout (#271): portrait centered, equipment slots flanking it in two
+  // columns (left + right), with the weapons row (Main / Off-Hand / Ranged) beneath. Each
+  // cell shows the equipped item's name-slug icon, or an honest empty slot with its label.
+  const assigned = assignEquipSlots(hero.equipped);
+  const col = (name) => EQUIP_SLOTS.filter((s) => s.col === name);
+  return (
+    <div style={{ marginTop: 16 }}>
+      <div className="eyebrow" style={{ marginBottom: 8 }}>Equipped</div>
+      {/* doll: left slots | portrait | right slots */}
+      <div style={{ display: "grid", gridTemplateColumns: "52px 1fr 52px", gap: 8, alignItems: "start" }}>
+        <div style={{ display: "grid", gap: 6 }}>
+          {col("left").map((s) => <EquipSlotCell key={s.id} slot={s} item={assigned[s.id]} />)}
+        </div>
+        <Img scope={heroPortraitScope(hero)} label={`${hero.name} · full art`} h={258} framed style={{ width: "100%" }} />
+        <div style={{ display: "grid", gap: 6 }}>
+          {col("right").map((s) => <EquipSlotCell key={s.id} slot={s} item={assigned[s.id]} />)}
+        </div>
+      </div>
+      {/* weapons row under the doll */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 6, marginTop: 8 }}>
+        {col("arms").map((s) => <EquipSlotCell key={s.id} slot={s} item={assigned[s.id]} />)}
+      </div>
+    </div>
+  );
+}
 
 function CoinSlot({ tone, label, val }) {
   return (
@@ -460,4 +563,4 @@ const ITEM_TYPES = {
 
 function toRoman(n) { return ["", "I", "II", "III", "IV", "V"][n] || n; }
 
-Object.assign(window, { ScreenInventory, CoinSlot, ItemSlot, ItemDetail, EQUIP_SLOTS, ITEM_TYPES, toRoman, slug, itemScope });
+Object.assign(window, { ScreenInventory, CoinSlot, ItemSlot, ItemDetail, EQUIP_SLOTS, PaperDoll, EquipSlotCell, inferEquipSlotId, assignEquipSlots, ITEM_TYPES, toRoman, slug, itemScope });


### PR DESCRIPTION
Closes #268. Closes #271. Part of the OpenWorlds audit (#242). #268: SpellsTab gets a 'Browse spellbook (N)' CTA + read-only SpellbookBrowser modal (was a dead-end empty state). #271: 6 flat equip slots → a 12-slot canonical paper-doll (Head/Cloak/Body/Hands/Belt/Amulet/Ring×2/Boots/Main/Off/Ranged), slot placement name-inferred (engine Item has no slot field — flagged as optional engine enhancement). Verified live: engine 1504, viewer 146, axe 0/17, license clean, 0 console errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Browse spellbook" functionality for casters to explore known and prepared spells in a read-only modal.
  * Redesigned equipment display with an improved paper-doll interface showing character equipment slots organized in an intuitive layout with portrait and weapons row.
  * Enhanced spell slot handling to distinguish between casters with open slots versus those with no spells prepared.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->