### PR TITLE
PR-3: rename ClawDnD→WorldOS (Wave 4 — WORLDOS_* env compat)

### DIFF
--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/AppProcessService.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/AppProcessService.swift
@@ -72,7 +72,11 @@ final class AppProcessService: ObservableObject {
         let baseURL = URL(string: "http://127.0.0.1:\(port)")!
         var env: [String: String] = [:]
         if !stateDir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            env["CLAWDND_STATE_DIR"] = (stateDir as NSString).expandingTildeInPath
+            // Set BOTH names; the viewer/engine prefer WORLDOS_* and keep CLAWDND_*
+            // as the v1.x warn-only fallback (issue #295, W0-E).
+            let expandedStateDir = (stateDir as NSString).expandingTildeInPath
+            env["WORLDOS_STATE_DIR"] = expandedStateDir
+            env["CLAWDND_STATE_DIR"] = expandedStateDir
         }
         // IMPORTANT: launch the viewer with an ABSOLUTE script path and an
         // internal-disk working directory — NOT a relative path with cwd=repoURL.
@@ -84,6 +88,7 @@ final class AppProcessService: ObservableObject {
         // LaunchServices with an ad-hoc signature. An absolute script path + a cwd
         // on the internal disk avoids that volume enumeration entirely; server.py
         // resolves all of its assets from __file__, so cwd is irrelevant to it.
+        env["WORLDOS_REPO_ROOT"] = repoURL.path
         env["CLAWDND_REPO_ROOT"] = repoURL.path
         let serverScript = repoURL.appendingPathComponent("viewer/server.py").path
         let safeCWD = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)

--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/RepositoryLocator.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/RepositoryLocator.swift
@@ -2,7 +2,10 @@ import Foundation
 
 enum RepositoryLocator {
     static func defaultRepoPath() -> String? {
-        if let env = ProcessInfo.processInfo.environment["CLAWDND_REPO_ROOT"] {
+        // Prefer WORLDOS_REPO_ROOT; fall back to the legacy CLAWDND_REPO_ROOT for
+        // v1.x (issue #295, W0-E). Both resolve so existing launchers keep working.
+        let environment = ProcessInfo.processInfo.environment
+        if let env = environment["WORLDOS_REPO_ROOT"] ?? environment["CLAWDND_REPO_ROOT"] {
             let expanded = (env as NSString).expandingTildeInPath
             if looksLikeRepo(URL(fileURLWithPath: expanded)) {
                 return expanded

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -20,6 +20,32 @@
 # Sourced by BOTH loops so the two harnesses can't drift. Pure bash + a tiny `uv run` python
 # shim into servers/engine (the engine's venv has the deps; bare python3 does not).
 
+# --- WorldOS rename env-compat (issue #295, W0-E) ---------------------------------
+# Resolve an env var by suffix, preferring WORLDOS_<suffix> and falling back to the
+# legacy CLAWDND_<suffix> (one-time stderr deprecation warning), else a default.
+#   worldos_env DM_MODEL sonnet   ->  $WORLDOS_DM_MODEL, else $CLAWDND_DM_MODEL, else "sonnet"
+# Mirrors servers/*/_env.py for the shell side; both names resolve for v1.x.
+# Note: worldos_env is typically called inside $(...) (a forked subshell), so an
+# in-memory "warned" flag wouldn't survive between calls. We key the once-warning off
+# a tiny per-(invocation, var) sentinel file under $TMPDIR so it stays one-time across
+# the subshells of a single script run (PPID = the script's pid from the subshell).
+worldos_env() {
+  local suffix="$1" default="${2:-}"
+  local w="WORLDOS_${suffix}" c="CLAWDND_${suffix}"
+  if [ -n "${!w:-}" ]; then
+    printf '%s' "${!w}"
+  elif [ -n "${!c:-}" ]; then
+    local sentinel="${TMPDIR:-/tmp}/worldos-envwarn.$PPID.$c"
+    if [ ! -e "$sentinel" ]; then
+      : > "$sentinel" 2>/dev/null || true
+      printf '[worldos] DEPRECATION: env var %s is renamed to %s; the old name still works for v1.x but will be removed in v2.0.\n' "$c" "$w" >&2
+    fi
+    printf '%s' "${!c}"
+  else
+    printf '%s' "$default"
+  fi
+}
+
 # Resolve the run's campaign snapshot.json the same way the harnesses pick state for scoring:
 # the LARGEST non-empty snapshot under <state_dir>/campaigns (never a blind head -1, which a
 # fat-fingered campaign_id could point at a lock-only orphan dir). Echoes the path or nothing.
@@ -97,7 +123,7 @@ clawdnd_soft_tick() {
   # transient cache error; that's non-fatal here (the NEXT beat re-reads the clock and re-ticks),
   # so we never let the tick's exit status fail the loop (the function always returns 0).
   local camp out; camp="$(basename "$(dirname "$snap")")"
-  out="$(CLAWDND_STATE_DIR="$state_dir" uv run --directory "$root/servers/engine" python - "$camp" 2>&1 <<'PY'
+  out="$(WORLDOS_STATE_DIR="$state_dir" CLAWDND_STATE_DIR="$state_dir" uv run --directory "$root/servers/engine" python - "$camp" 2>&1 <<'PY'
 import sys
 import server
 camp = sys.argv[1]
@@ -259,7 +285,7 @@ clawdnd_director_advisory() {
   snap="$(clawdnd_snapshot_path "$state_dir")"
   [ -n "$snap" ] || return 0
   camp="$(basename "$(dirname "$snap")")"
-  out="$(CLAWDND_STATE_DIR="$state_dir" uv run --directory "$root/servers/engine" python - "$camp" 2>/dev/null <<'PY'
+  out="$(WORLDOS_STATE_DIR="$state_dir" CLAWDND_STATE_DIR="$state_dir" uv run --directory "$root/servers/engine" python - "$camp" 2>/dev/null <<'PY'
 import sys
 import server
 try:
@@ -288,7 +314,7 @@ clawdnd_event_advisory() {
   snap="$(clawdnd_snapshot_path "$state_dir")"
   [ -n "$snap" ] || return 0
   camp="$(basename "$(dirname "$snap")")"
-  out="$(CLAWDND_STATE_DIR="$state_dir" uv run --directory "$root/servers/engine" python - "$camp" 2>/dev/null <<'PY'
+  out="$(WORLDOS_STATE_DIR="$state_dir" CLAWDND_STATE_DIR="$state_dir" uv run --directory "$root/servers/engine" python - "$camp" 2>/dev/null <<'PY'
 import sys
 import server
 try:

--- a/qa/preview_live.sh
+++ b/qa/preview_live.sh
@@ -24,7 +24,8 @@ STATE_DIR="$(dirname "$(dirname "$(dirname "$SNAP")")")"   # .../qa/state/<run>/
 for p in $(lsof -ti tcp:"$PORT" 2>/dev/null || true); do kill -TERM "$p" 2>/dev/null || true; done
 sleep 1
 
-CLAWDND_STATE_DIR="$STATE_DIR" CLAWDND_REPO_ROOT="$ROOT" \
+WORLDOS_STATE_DIR="$STATE_DIR" CLAWDND_STATE_DIR="$STATE_DIR" \
+WORLDOS_REPO_ROOT="$ROOT" CLAWDND_REPO_ROOT="$ROOT" \
   nohup python3 "$ROOT/viewer/server.py" "$CAMP" "$PORT" > "/tmp/preview_live_$PORT.log" 2>&1 &
 echo "preview :$PORT -> LIVE campaign $CAMP"
 echo "  state: $STATE_DIR"

--- a/qa/run_combat_sprint.sh
+++ b/qa/run_combat_sprint.sh
@@ -16,7 +16,7 @@ cd "$ROOT" || exit 1
 . "$ROOT/qa/lib_beat_driver.sh"
 
 RUN="${1:-cs-$(date +%H%M%S)}"
-CLAWDND_DM_MODEL="${CLAWDND_DM_MODEL:-sonnet}"
+CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
 T="$ROOT/qa/transcripts"
 STATE_DIR="$ROOT/qa/state/$RUN"
 mkdir -p "$T" "$STATE_DIR"

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -28,10 +28,10 @@ BEATS="${4:-6}"
 BUDGET="${5:-0.80}"
 # The DM model is an env var so A/B-testing Opus vs sonnet for structural adherence is a
 # one-flag flip (decision-dm-driver.md §3 "model choice as an orthogonal lever"). Default sonnet.
-CLAWDND_DM_MODEL="${CLAWDND_DM_MODEL:-sonnet}"
+CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
 # The player facade is a near-free no-tool agent; its model is a separate knob (default sonnet,
-# so behavior is unchanged) kept consistent with the party harness's CLAWDND_ACTOR_MODEL.
-CLAWDND_ACTOR_MODEL="${CLAWDND_ACTOR_MODEL:-sonnet}"
+# so behavior is unchanged) kept consistent with the party harness's WORLDOS_ACTOR_MODEL.
+CLAWDND_ACTOR_MODEL="$(worldos_env ACTOR_MODEL sonnet)"
 T="qa/transcripts"; STATE_DIR="$ROOT/qa/state/$RUN"
 mkdir -p "$T" "$STATE_DIR"; rm -rf "$STATE_DIR/campaigns" 2>/dev/null
 

--- a/qa/run_party.sh
+++ b/qa/run_party.sh
@@ -55,8 +55,8 @@ SESSION_BUDGET="${CLAWDND_PARTY_SESSION_BUDGET:-30.00}"  # aggregate ceiling for
 MAX_TURNS="${CLAWDND_PARTY_MAX_TURNS:-60}"               # hard agent-turn cap (safety net)
 # Model knobs (default sonnet, so behavior is unchanged): the DM model is the structural-
 # adherence lever (decision §3); the actor model drives the player/companion facade agents.
-CLAWDND_DM_MODEL="${CLAWDND_DM_MODEL:-sonnet}"
-CLAWDND_ACTOR_MODEL="${CLAWDND_ACTOR_MODEL:-sonnet}"
+CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
+CLAWDND_ACTOR_MODEL="$(worldos_env ACTOR_MODEL sonnet)"
 T="qa/transcripts"; STATE_DIR="$ROOT/qa/state/$RUN"
 mkdir -p "$T" "$STATE_DIR"; rm -rf "$STATE_DIR/campaigns" 2>/dev/null
 

--- a/qa/run_qa.sh
+++ b/qa/run_qa.sh
@@ -27,7 +27,7 @@ BUDGET="${2:-3.00}"
 PROMPT_FILE="${3:-qa/play_prompt.txt}"
 RUBRIC_FILE="${4:-qa/rubric.md}"
 # DM model knob (default sonnet → unchanged); a one-flag flip for Opus structural-adherence tests.
-CLAWDND_DM_MODEL="${CLAWDND_DM_MODEL:-sonnet}"
+CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
 T="qa/transcripts"
 STATE_DIR="$ROOT/qa/state/$RUN"          # per-run isolation -> parallel-safe
 MCP_CONFIG="$STATE_DIR/qa.mcp.json"

--- a/qa/seed_canon_fixture.py
+++ b/qa/seed_canon_fixture.py
@@ -7,8 +7,8 @@ and NEVER one of the 7 BG3 origin heroes. Then travels to a real location (so sc
 renders), recruits a canon companion, adds inventory + a quest — so every OpenWorlds screen
 has real content to render and audit.
 
-Usage:
-  CLAWDND_STATE_DIR=<dir> uv run --directory servers/engine python qa/seed_canon_fixture.py \
+Usage (WORLDOS_STATE_DIR preferred; legacy CLAWDND_STATE_DIR still works for v1.x):
+  WORLDOS_STATE_DIR=<dir> uv run --directory servers/engine python qa/seed_canon_fixture.py \
       ["Dal Lightspark"] ["Arthus"] ["loc-lower-city"]
 Prints the campaign_id on the last line.
 """

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -96,7 +96,9 @@ PLIST
 }
 
 open_app() {
-  CLAWDND_REPO_ROOT="$ROOT_DIR" /usr/bin/open -n "$APP_BUNDLE"
+  # Set BOTH names so the native app's RepositoryLocator resolves the repo root
+  # whether it reads the new WORLDOS_* name or the legacy CLAWDND_* one (#295, W0-E).
+  WORLDOS_REPO_ROOT="$ROOT_DIR" CLAWDND_REPO_ROOT="$ROOT_DIR" /usr/bin/open -n "$APP_BUNDLE"
 }
 
 release_check() {

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -49,7 +49,7 @@ SESSION_BUDGET="${CLAWDND_PLAY_SESSION_BUDGET:-15.00}"  # aggregate ceiling for 
 MAX_TURNS="${CLAWDND_PLAY_MAX_TURNS:-40}"              # hard turn cap (worst case = MAX_TURNS×BUDGET)
 # The DM model is an env var (default sonnet) so Opus-vs-sonnet structural-adherence testing
 # is a one-flag flip — mirrors qa/run_duo.sh (decision-dm-driver.md §3).
-CLAWDND_DM_MODEL="${CLAWDND_DM_MODEL:-sonnet}"
+CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
 DM_TURNS=0
 
 # Product play state lives under the repo's play-state/ (git-ignored), one dir per game,
@@ -208,7 +208,9 @@ dm_turn() {
 VPID_FILE="$STATE_DIR/.viewer.pid"
 viewer_supervisor() {
   while :; do
-    CLAWDND_STATE_DIR="$STATE_DIR" CLAWDND_VIEWER_CHAT="$CHAT" CLAWDND_PLAYER_MOVES="$MOVES" \
+    WORLDOS_STATE_DIR="$STATE_DIR" CLAWDND_STATE_DIR="$STATE_DIR" \
+    WORLDOS_VIEWER_CHAT="$CHAT" CLAWDND_VIEWER_CHAT="$CHAT" \
+    WORLDOS_PLAYER_MOVES="$MOVES" CLAWDND_PLAYER_MOVES="$MOVES" \
       python3 viewer/server.py "" "$PORT" >> "$VIEWER_LOG" 2>&1 &
     local vp=$!; echo "$vp" > "$VPID_FILE"
     wait "$vp" 2>/dev/null   # blocks until the viewer exits (and reaps it)

--- a/servers/engine/_env.py
+++ b/servers/engine/_env.py
@@ -1,0 +1,89 @@
+"""Backward-compatible env-var resolution for the WorldOS rename (issue #295, W0-E).
+
+The project was renamed ClawDnD -> WorldOS. Env vars are migrating from the
+``CLAWDND_*`` prefix to ``WORLDOS_*``. This is a NON-breaking layer: every read
+site prefers ``WORLDOS_<X>`` but still falls back to the legacy ``CLAWDND_<X>``,
+emitting a ONE-TIME stderr deprecation warning per legacy var. The legacy names
+keep working for v1.x (the running app, QA scripts, and the macOS
+``RepositoryLocator`` still set ``CLAWDND_*``); they are removed at v2.0.
+
+Stdlib-only, zero project imports, so it's safe to import from any module
+(including ones used at import time). Mirrored per server package because each
+``servers/<pkg>`` is an isolated ``uv`` workspace with ``pythonpath = ["."]``.
+
+Usage::
+
+    from _env import env_var
+    raw = env_var("STATE_DIR")                  # WORLDOS_STATE_DIR or CLAWDND_STATE_DIR
+    backend = env_var("TTS_BACKEND", "kokoro")  # with a default
+
+Or, when a call site already holds the full legacy name as a string/constant::
+
+    token = env_var_legacy("CLAWDND_OPENCLAW_GATEWAY_TOKEN", "")
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Optional, Set
+
+#: New canonical prefix.
+WORLDOS_PREFIX = "WORLDOS_"
+#: Legacy prefix (deprecated, warn-only fallback for v1.x).
+LEGACY_PREFIX = "CLAWDND_"
+
+# Legacy var names we've already warned about, so each emits its deprecation
+# notice at most once per process (avoids spamming stderr on hot read paths).
+_warned: Set[str] = set()
+
+
+def _warn_once(legacy_name: str, worldos_name: str) -> None:
+    if legacy_name in _warned:
+        return
+    _warned.add(legacy_name)
+    print(
+        f"[worldos] DEPRECATION: env var {legacy_name} is renamed to {worldos_name}; "
+        f"the old name still works for v1.x but will be removed in v2.0.",
+        file=sys.stderr,
+    )
+
+
+def env_var(suffix: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve a WorldOS env var by its suffix (the part after the prefix).
+
+    Prefers ``WORLDOS_<suffix>``; falls back to the legacy ``CLAWDND_<suffix>``
+    (warning once to stderr). Returns ``default`` when neither is set.
+
+    ``suffix`` is given WITHOUT a prefix, e.g. ``env_var("STATE_DIR")`` reads
+    ``WORLDOS_STATE_DIR`` then ``CLAWDND_STATE_DIR``.
+    """
+    worldos_name = WORLDOS_PREFIX + suffix
+    legacy_name = LEGACY_PREFIX + suffix
+    return _resolve(worldos_name, legacy_name, default)
+
+
+def env_var_legacy(legacy_name: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve from a full legacy name (e.g. an existing ``CLAWDND_*`` constant).
+
+    Derives the new name by swapping the ``CLAWDND_`` prefix for ``WORLDOS_`` and
+    then behaves exactly like :func:`env_var`. Names without the legacy prefix are
+    read as-is (no aliasing) — used for genuinely external vars like
+    ``OPENCLAW_GATEWAY_TOKEN``.
+    """
+    if legacy_name.startswith(LEGACY_PREFIX):
+        worldos_name = WORLDOS_PREFIX + legacy_name[len(LEGACY_PREFIX):]
+        return _resolve(worldos_name, legacy_name, default)
+    # Not a renamed var (e.g. OPENCLAW_*); read it straight, no alias/warn.
+    return os.environ.get(legacy_name, default)
+
+
+def _resolve(worldos_name: str, legacy_name: str, default: Optional[str]) -> Optional[str]:
+    val = os.environ.get(worldos_name)
+    if val is not None:
+        return val
+    val = os.environ.get(legacy_name)
+    if val is not None:
+        _warn_once(legacy_name, worldos_name)
+        return val
+    return default

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -9,7 +9,6 @@ hook becomes the opening quest. The DM skill then reads the scenes and runs play
 from __future__ import annotations
 
 import json
-import os
 import random
 from pathlib import Path
 
@@ -17,6 +16,7 @@ from pydantic import ValidationError
 
 import questgen
 import worldsim
+from _env import env_var
 from models import (
     BacklogItem,
     Campaign,
@@ -44,7 +44,7 @@ from store import safe_path_segment  # path-containment guard for world/adventur
 
 
 def _content_dir() -> Path:
-    raw = os.environ.get("CLAWDND_CONTENT_DIR")
+    raw = env_var("CONTENT_DIR")
     return Path(raw).expanduser() if raw else Path(__file__).resolve().parents[2] / "content"
 
 

--- a/servers/engine/imagegen.py
+++ b/servers/engine/imagegen.py
@@ -44,6 +44,7 @@ from pathlib import Path
 from typing import Optional, Protocol, runtime_checkable
 
 import store
+from _env import env_var, env_var_legacy
 
 # The image kinds the engine knows how to ask for.
 KINDS = ("map", "portrait", "scene")
@@ -222,7 +223,7 @@ class _UnconfiguredHostedProvider:
     def configured(self) -> bool:
         """True once the credential env var is set. get_provider() uses this to
         decide whether to hand back this provider or degrade to null."""
-        return bool(os.environ.get(self.api_key_env, "").strip())
+        return bool((env_var_legacy(self.api_key_env, "") or "").strip())
 
     def generate(self, kind: str, prompt: str, *, seed: Optional[int] = None) -> dict:
         raise NotImplementedError(
@@ -348,7 +349,7 @@ _HOSTED: dict[str, type] = {
 
 def provider_name() -> str:
     """The selected image provider name (env CLAWDND_IMAGE_PROVIDER, default 'null')."""
-    return os.environ.get("CLAWDND_IMAGE_PROVIDER", "null").strip().lower()
+    return (env_var("IMAGE_PROVIDER", "null") or "null").strip().lower()
 
 
 def get_provider() -> ImageProvider:

--- a/servers/engine/lorebook.py
+++ b/servers/engine/lorebook.py
@@ -22,17 +22,17 @@ code is MIT and reads it generically — it never hard-codes any setting.
 
 from __future__ import annotations
 
-import os
 import re
 import sqlite3
 from pathlib import Path
 from typing import Optional
 
+from _env import env_var
 from store import safe_path_segment  # path-containment guard for world ids
 
 
 def _content_dir() -> Path:
-    raw = os.environ.get("CLAWDND_CONTENT_DIR")
+    raw = env_var("CONTENT_DIR")
     return Path(raw).expanduser() if raw else Path(__file__).resolve().parents[2] / "content"
 
 

--- a/servers/engine/openclaw_image.py
+++ b/servers/engine/openclaw_image.py
@@ -65,13 +65,14 @@ from __future__ import annotations
 
 import base64
 import json
-import os
 import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
+
+from _env import env_var_legacy
 
 # --------------------------------------------------------------------------- #
 # Defaults / env knobs. All overridable so the selftest and tests can redirect
@@ -368,12 +369,14 @@ class OpenClawImageClient:
 # --------------------------------------------------------------------------- #
 
 def _env(name: str, default: str) -> str:
-    return os.environ.get(name, default)
+    # CLAWDND_OPENCLAW_* names resolve via the WORLDOS_* alias (warn-only legacy
+    # fallback); OPENCLAW_* names pass through unchanged. See issue #295 (W0-E).
+    return env_var_legacy(name, default) or default
 
 
 def _env_float(name: str, default: float) -> float:
     try:
-        v = os.environ.get(name)
+        v = env_var_legacy(name)
         return float(v) if v else default
     except (TypeError, ValueError):
         return default
@@ -387,10 +390,10 @@ def _resolve_media_dir() -> Path:
     `resolveMediaDir()` (config dir + "media") plus the tool's "tool-image-generation"
     subdir.
     """
-    override = os.environ.get(ENV_MEDIA_DIR)
+    override = env_var_legacy(ENV_MEDIA_DIR)
     if override:
         return Path(override)
-    home = os.environ.get(ENV_OPENCLAW_HOME)
+    home = env_var_legacy(ENV_OPENCLAW_HOME)
     config_dir = Path(home) if home else (Path.home() / ".openclaw")
     return config_dir.joinpath(*MEDIA_SUBDIR)
 

--- a/servers/engine/player_server.py
+++ b/servers/engine/player_server.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 import contextlib
 import fcntl
 import json
-import os
 from pathlib import Path
 from typing import Optional
 
@@ -44,6 +43,7 @@ from mcp.server.fastmcp import FastMCP
 
 import spells
 import store
+from _env import env_var
 from models import SKILL_ABILITIES, Character
 
 mcp = FastMCP("clawdnd-player")
@@ -66,7 +66,7 @@ def _actor_id() -> str:
     """The character this facade speaks for, or "" for default (the player PC). A
     blank/whitespace value is treated as unset — so an empty env var doesn't silently
     select 'no character'."""
-    return (os.environ.get("CLAWDND_ACTOR_ID") or "").strip()
+    return (env_var("ACTOR_ID") or "").strip()
 
 
 _ACTOR_ROLES = ("player", "companion")  # the only roles the ensemble emits
@@ -80,7 +80,7 @@ def _actor_role() -> str:
     allowlist so a typo (or an injected value) can't smuggle an arbitrary role onto
     every move the DM/dashboard then trusts — blank -> "player" (today's default),
     any unknown value -> "companion" (the safe non-narrator peer role)."""
-    raw = (os.environ.get("CLAWDND_ACTOR_ROLE") or "").strip().lower()
+    raw = (env_var("ACTOR_ROLE") or "").strip().lower()
     if not raw:
         return "player"
     return raw if raw in _ACTOR_ROLES else "companion"
@@ -151,7 +151,7 @@ def _record(kind: str, text: str, **fields) -> dict:
     aid = _actor_id()
     if aid:
         move["actor_id"] = aid
-    p = os.environ.get("CLAWDND_PLAYER_MOVES")
+    p = env_var("PLAYER_MOVES")
     if p:
         with Path(p).open("a", encoding="utf-8") as f:
             with contextlib.suppress(OSError):
@@ -171,7 +171,7 @@ def _consecutive_clarifies() -> int:
     the 'this turn' proxy that bounds the question budget. Reads the moves-file tail; a real action
     (say/do/attack/…) resets it. 0 when there's no moves file or it's unreadable (fail-open: a read
     glitch must never block a legitimate question)."""
-    p = os.environ.get("CLAWDND_PLAYER_MOVES")
+    p = env_var("PLAYER_MOVES")
     if not p or not Path(p).exists():
         return 0
     role, aid = _actor_role(), _actor_id()

--- a/servers/engine/store.py
+++ b/servers/engine/store.py
@@ -5,9 +5,10 @@ snapshot.json with an atomic temp-file + os.replace, so a crash or compaction
 never leaves a half-written campaign. A per-session append-only JSONL log
 captures the narrative beat-by-beat for recaps and post-compaction recovery.
 
-State lives outside the repo by default (~/.clawdnd/state), overridable with the
-CLAWDND_STATE_DIR env var, so it survives plugin reinstalls and is independent of
-the server's working directory.
+State lives outside the repo by default (~/.worldos/state, falling back to the
+legacy ~/.clawdnd/state), overridable with the WORLDOS_STATE_DIR env var
+(the legacy CLAWDND_STATE_DIR still works for v1.x), so it survives plugin
+reinstalls and is independent of the server's working directory.
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ from typing import Optional
 
 from pydantic import ValidationError
 
+from _env import env_var
 from models import Campaign, SessionLogEntry
 
 log = logging.getLogger(__name__)
@@ -59,8 +61,16 @@ def engine_sha() -> str:
 
 
 def state_dir() -> Path:
-    raw = os.environ.get("CLAWDND_STATE_DIR")
-    return Path(raw).expanduser() if raw else Path.home() / ".clawdnd" / "state"
+    # WORLDOS_STATE_DIR preferred; CLAWDND_STATE_DIR is the warn-only v1.x fallback.
+    raw = env_var("STATE_DIR")
+    if raw:
+        return Path(raw).expanduser()
+    # No override: prefer the new ~/.worldos home if it already exists, else fall
+    # back to the legacy ~/.clawdnd (no bulk migration — see issue #295, W0-E/4.2).
+    worldos_home = Path.home() / ".worldos" / "state"
+    if worldos_home.parent.exists():
+        return worldos_home
+    return Path.home() / ".clawdnd" / "state"
 
 
 def safe_path_segment(value: str, kind: str = "id") -> str:

--- a/servers/engine/tests/test_env_compat.py
+++ b/servers/engine/tests/test_env_compat.py
@@ -1,0 +1,100 @@
+"""Backward-compat env-var resolution for the WorldOS rename (issue #295, W0-E).
+
+Asserts the NON-breaking contract at every read site routed through _env:
+  - WORLDOS_<X> is preferred over CLAWDND_<X>
+  - CLAWDND_<X> alone still resolves AND emits exactly one stderr deprecation warning
+  - neither set -> the provided default
+  - the legacy CLAWDND_* names keep working end-to-end (store.state_dir)
+  - the new ~/.worldos home is preferred when no override is set, else ~/.clawdnd
+"""
+
+import importlib
+
+import pytest
+
+import _env
+import store
+
+
+@pytest.fixture(autouse=True)
+def _reset_warn_cache():
+    """The one-time-warn cache is module-global; clear it so each test starts clean."""
+    _env._warned.clear()
+    yield
+    _env._warned.clear()
+
+
+def test_worldos_wins_over_clawdnd(monkeypatch, capsys):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", "/tmp/new")
+    monkeypatch.setenv("CLAWDND_STATE_DIR", "/tmp/old")
+    assert _env.env_var("STATE_DIR") == "/tmp/new"
+    # The new name wins outright — no legacy hit, so NO deprecation warning.
+    assert "DEPRECATION" not in capsys.readouterr().err
+
+
+def test_clawdnd_alone_still_works_and_warns_once(monkeypatch, capsys):
+    monkeypatch.delenv("WORLDOS_STATE_DIR", raising=False)
+    monkeypatch.setenv("CLAWDND_STATE_DIR", "/tmp/legacy")
+    # Resolves the legacy value (non-breaking)...
+    assert _env.env_var("STATE_DIR") == "/tmp/legacy"
+    # ...and reading it AGAIN still resolves but does NOT re-warn (one-time).
+    assert _env.env_var("STATE_DIR") == "/tmp/legacy"
+    err = capsys.readouterr().err
+    warnings = [ln for ln in err.splitlines() if "DEPRECATION" in ln]
+    assert len(warnings) == 1
+    assert "CLAWDND_STATE_DIR" in warnings[0]
+    assert "WORLDOS_STATE_DIR" in warnings[0]
+
+
+def test_neither_set_returns_default(monkeypatch, capsys):
+    monkeypatch.delenv("WORLDOS_TTS_BACKEND", raising=False)
+    monkeypatch.delenv("CLAWDND_TTS_BACKEND", raising=False)
+    assert _env.env_var("TTS_BACKEND", "kokoro") == "kokoro"
+    assert _env.env_var("TTS_BACKEND") is None  # default default is None
+    # Nothing set -> nothing deprecated.
+    assert "DEPRECATION" not in capsys.readouterr().err
+
+
+def test_env_var_legacy_swaps_prefix(monkeypatch, capsys):
+    # A full CLAWDND_* constant resolves its WORLDOS_* alias first...
+    monkeypatch.setenv("WORLDOS_OPENCLAW_GATEWAY_TOKEN", "new-tok")
+    monkeypatch.setenv("CLAWDND_OPENCLAW_GATEWAY_TOKEN", "old-tok")
+    assert _env.env_var_legacy("CLAWDND_OPENCLAW_GATEWAY_TOKEN", "") == "new-tok"
+    assert "DEPRECATION" not in capsys.readouterr().err
+    # ...and falls back to the legacy value (with a warning) when only it is set.
+    monkeypatch.delenv("WORLDOS_OPENCLAW_GATEWAY_TOKEN", raising=False)
+    assert _env.env_var_legacy("CLAWDND_OPENCLAW_GATEWAY_TOKEN", "") == "old-tok"
+    assert "DEPRECATION" in capsys.readouterr().err
+
+
+def test_env_var_legacy_non_clawdnd_passthrough(monkeypatch, capsys):
+    # External vars (e.g. OpenClaw's own) are read straight — never aliased, never warned.
+    monkeypatch.setenv("OPENCLAW_GATEWAY_TOKEN", "oc-tok")
+    assert _env.env_var_legacy("OPENCLAW_GATEWAY_TOKEN", "") == "oc-tok"
+    assert "DEPRECATION" not in capsys.readouterr().err
+
+
+def test_store_state_dir_honors_legacy_env(monkeypatch):
+    # The load-bearing integration: store.state_dir() still respects the legacy var
+    # (the running app + QA scripts set CLAWDND_STATE_DIR), so nothing breaks.
+    monkeypatch.delenv("WORLDOS_STATE_DIR", raising=False)
+    monkeypatch.setenv("CLAWDND_STATE_DIR", "/tmp/legacy-state")
+    assert store.state_dir() == store.Path("/tmp/legacy-state")
+    # And the new name takes precedence when both are set.
+    monkeypatch.setenv("WORLDOS_STATE_DIR", "/tmp/new-state")
+    assert store.state_dir() == store.Path("/tmp/new-state")
+
+
+def test_store_state_dir_home_fallback(monkeypatch, tmp_path):
+    # No override: prefer ~/.worldos/state when that home exists, else ~/.clawdnd/state.
+    monkeypatch.delenv("WORLDOS_STATE_DIR", raising=False)
+    monkeypatch.delenv("CLAWDND_STATE_DIR", raising=False)
+    fake_home = tmp_path
+    monkeypatch.setattr(store.Path, "home", classmethod(lambda cls: fake_home))
+
+    # ~/.worldos absent -> legacy ~/.clawdnd/state.
+    assert store.state_dir() == fake_home / ".clawdnd" / "state"
+
+    # Create ~/.worldos -> now preferred.
+    (fake_home / ".worldos").mkdir()
+    assert store.state_dir() == fake_home / ".worldos" / "state"

--- a/servers/rules/_env.py
+++ b/servers/rules/_env.py
@@ -1,0 +1,89 @@
+"""Backward-compatible env-var resolution for the WorldOS rename (issue #295, W0-E).
+
+The project was renamed ClawDnD -> WorldOS. Env vars are migrating from the
+``CLAWDND_*`` prefix to ``WORLDOS_*``. This is a NON-breaking layer: every read
+site prefers ``WORLDOS_<X>`` but still falls back to the legacy ``CLAWDND_<X>``,
+emitting a ONE-TIME stderr deprecation warning per legacy var. The legacy names
+keep working for v1.x (the running app, QA scripts, and the macOS
+``RepositoryLocator`` still set ``CLAWDND_*``); they are removed at v2.0.
+
+Stdlib-only, zero project imports, so it's safe to import from any module
+(including ones used at import time). Mirrored per server package because each
+``servers/<pkg>`` is an isolated ``uv`` workspace with ``pythonpath = ["."]``.
+
+Usage::
+
+    from _env import env_var
+    raw = env_var("STATE_DIR")                  # WORLDOS_STATE_DIR or CLAWDND_STATE_DIR
+    backend = env_var("TTS_BACKEND", "kokoro")  # with a default
+
+Or, when a call site already holds the full legacy name as a string/constant::
+
+    token = env_var_legacy("CLAWDND_OPENCLAW_GATEWAY_TOKEN", "")
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Optional, Set
+
+#: New canonical prefix.
+WORLDOS_PREFIX = "WORLDOS_"
+#: Legacy prefix (deprecated, warn-only fallback for v1.x).
+LEGACY_PREFIX = "CLAWDND_"
+
+# Legacy var names we've already warned about, so each emits its deprecation
+# notice at most once per process (avoids spamming stderr on hot read paths).
+_warned: Set[str] = set()
+
+
+def _warn_once(legacy_name: str, worldos_name: str) -> None:
+    if legacy_name in _warned:
+        return
+    _warned.add(legacy_name)
+    print(
+        f"[worldos] DEPRECATION: env var {legacy_name} is renamed to {worldos_name}; "
+        f"the old name still works for v1.x but will be removed in v2.0.",
+        file=sys.stderr,
+    )
+
+
+def env_var(suffix: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve a WorldOS env var by its suffix (the part after the prefix).
+
+    Prefers ``WORLDOS_<suffix>``; falls back to the legacy ``CLAWDND_<suffix>``
+    (warning once to stderr). Returns ``default`` when neither is set.
+
+    ``suffix`` is given WITHOUT a prefix, e.g. ``env_var("STATE_DIR")`` reads
+    ``WORLDOS_STATE_DIR`` then ``CLAWDND_STATE_DIR``.
+    """
+    worldos_name = WORLDOS_PREFIX + suffix
+    legacy_name = LEGACY_PREFIX + suffix
+    return _resolve(worldos_name, legacy_name, default)
+
+
+def env_var_legacy(legacy_name: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve from a full legacy name (e.g. an existing ``CLAWDND_*`` constant).
+
+    Derives the new name by swapping the ``CLAWDND_`` prefix for ``WORLDOS_`` and
+    then behaves exactly like :func:`env_var`. Names without the legacy prefix are
+    read as-is (no aliasing) — used for genuinely external vars like
+    ``OPENCLAW_GATEWAY_TOKEN``.
+    """
+    if legacy_name.startswith(LEGACY_PREFIX):
+        worldos_name = WORLDOS_PREFIX + legacy_name[len(LEGACY_PREFIX):]
+        return _resolve(worldos_name, legacy_name, default)
+    # Not a renamed var (e.g. OPENCLAW_*); read it straight, no alias/warn.
+    return os.environ.get(legacy_name, default)
+
+
+def _resolve(worldos_name: str, legacy_name: str, default: Optional[str]) -> Optional[str]:
+    val = os.environ.get(worldos_name)
+    if val is not None:
+        return val
+    val = os.environ.get(legacy_name)
+    if val is not None:
+        _warn_once(legacy_name, worldos_name)
+        return val
+    return default

--- a/servers/rules/server.py
+++ b/servers/rules/server.py
@@ -28,7 +28,6 @@ CLAWDND_RULES_OFFLINE=1 to disable network lookups (used in CI).
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any, Optional
 
@@ -36,12 +35,14 @@ import httpx
 from mcp.server.fastmcp import FastMCP
 from rapidfuzz import fuzz, process
 
+from _env import env_var
+
 mcp = FastMCP("clawdnd-rules")
 
 _DATA_DIR = Path(
-    os.environ.get("CLAWDND_SRD_DIR", Path(__file__).resolve().parents[2] / "data" / "srd")
+    env_var("SRD_DIR") or Path(__file__).resolve().parents[2] / "data" / "srd"
 )
-_FULL_DIR = Path(os.environ.get("CLAWDND_SRD524_DIR", _DATA_DIR / "srd524"))
+_FULL_DIR = Path(env_var("SRD524_DIR") or _DATA_DIR / "srd524")
 _API_HOST = "https://www.dnd5eapi.co"
 
 
@@ -343,7 +344,7 @@ def _fuzzy_get(query: str, table: dict[str, dict]) -> Optional[dict]:
 
 
 def _api_lookup(category: str, query: str) -> Optional[dict]:
-    if os.environ.get("CLAWDND_RULES_OFFLINE"):
+    if env_var("RULES_OFFLINE"):
         return None
     try:
         r = httpx.get(f"{_API_HOST}/api/{category}", params={"name": query}, timeout=8.0)

--- a/servers/voice/_env.py
+++ b/servers/voice/_env.py
@@ -1,0 +1,89 @@
+"""Backward-compatible env-var resolution for the WorldOS rename (issue #295, W0-E).
+
+The project was renamed ClawDnD -> WorldOS. Env vars are migrating from the
+``CLAWDND_*`` prefix to ``WORLDOS_*``. This is a NON-breaking layer: every read
+site prefers ``WORLDOS_<X>`` but still falls back to the legacy ``CLAWDND_<X>``,
+emitting a ONE-TIME stderr deprecation warning per legacy var. The legacy names
+keep working for v1.x (the running app, QA scripts, and the macOS
+``RepositoryLocator`` still set ``CLAWDND_*``); they are removed at v2.0.
+
+Stdlib-only, zero project imports, so it's safe to import from any module
+(including ones used at import time). Mirrored per server package because each
+``servers/<pkg>`` is an isolated ``uv`` workspace with ``pythonpath = ["."]``.
+
+Usage::
+
+    from _env import env_var
+    raw = env_var("STATE_DIR")                  # WORLDOS_STATE_DIR or CLAWDND_STATE_DIR
+    backend = env_var("TTS_BACKEND", "kokoro")  # with a default
+
+Or, when a call site already holds the full legacy name as a string/constant::
+
+    token = env_var_legacy("CLAWDND_OPENCLAW_GATEWAY_TOKEN", "")
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Optional, Set
+
+#: New canonical prefix.
+WORLDOS_PREFIX = "WORLDOS_"
+#: Legacy prefix (deprecated, warn-only fallback for v1.x).
+LEGACY_PREFIX = "CLAWDND_"
+
+# Legacy var names we've already warned about, so each emits its deprecation
+# notice at most once per process (avoids spamming stderr on hot read paths).
+_warned: Set[str] = set()
+
+
+def _warn_once(legacy_name: str, worldos_name: str) -> None:
+    if legacy_name in _warned:
+        return
+    _warned.add(legacy_name)
+    print(
+        f"[worldos] DEPRECATION: env var {legacy_name} is renamed to {worldos_name}; "
+        f"the old name still works for v1.x but will be removed in v2.0.",
+        file=sys.stderr,
+    )
+
+
+def env_var(suffix: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve a WorldOS env var by its suffix (the part after the prefix).
+
+    Prefers ``WORLDOS_<suffix>``; falls back to the legacy ``CLAWDND_<suffix>``
+    (warning once to stderr). Returns ``default`` when neither is set.
+
+    ``suffix`` is given WITHOUT a prefix, e.g. ``env_var("STATE_DIR")`` reads
+    ``WORLDOS_STATE_DIR`` then ``CLAWDND_STATE_DIR``.
+    """
+    worldos_name = WORLDOS_PREFIX + suffix
+    legacy_name = LEGACY_PREFIX + suffix
+    return _resolve(worldos_name, legacy_name, default)
+
+
+def env_var_legacy(legacy_name: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve from a full legacy name (e.g. an existing ``CLAWDND_*`` constant).
+
+    Derives the new name by swapping the ``CLAWDND_`` prefix for ``WORLDOS_`` and
+    then behaves exactly like :func:`env_var`. Names without the legacy prefix are
+    read as-is (no aliasing) — used for genuinely external vars like
+    ``OPENCLAW_GATEWAY_TOKEN``.
+    """
+    if legacy_name.startswith(LEGACY_PREFIX):
+        worldos_name = WORLDOS_PREFIX + legacy_name[len(LEGACY_PREFIX):]
+        return _resolve(worldos_name, legacy_name, default)
+    # Not a renamed var (e.g. OPENCLAW_*); read it straight, no alias/warn.
+    return os.environ.get(legacy_name, default)
+
+
+def _resolve(worldos_name: str, legacy_name: str, default: Optional[str]) -> Optional[str]:
+    val = os.environ.get(worldos_name)
+    if val is not None:
+        return val
+    val = os.environ.get(legacy_name)
+    if val is not None:
+        _warn_once(legacy_name, worldos_name)
+        return val
+    return default

--- a/servers/voice/registry.py
+++ b/servers/voice/registry.py
@@ -9,15 +9,14 @@ character data never changes.
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Optional
 
+from _env import env_var
+
 _MAP_PATH = Path(
-    os.environ.get(
-        "CLAWDND_VOICE_MAP",
-        Path(__file__).resolve().parents[2] / "content" / "voices" / "voice-map.json",
-    )
+    env_var("VOICE_MAP")
+    or Path(__file__).resolve().parents[2] / "content" / "voices" / "voice-map.json"
 )
 
 

--- a/servers/voice/server.py
+++ b/servers/voice/server.py
@@ -15,12 +15,11 @@ STT backends: null (default, placeholder/CI), macos / whisper (stubs). See stt.p
 
 from __future__ import annotations
 
-import os
-
 from mcp.server.fastmcp import FastMCP
 
 import registry
 import stt
+from _env import env_var
 from interface import SpeakResult
 
 mcp = FastMCP("clawdnd-voice")
@@ -29,7 +28,7 @@ _stt_backend: stt.SttBackend | None = None
 
 
 def _backend_name() -> str:
-    return os.environ.get("CLAWDND_TTS_BACKEND", "kokoro").lower()
+    return (env_var("TTS_BACKEND", "kokoro") or "kokoro").lower()
 
 
 def _get_backend():

--- a/servers/voice/stt.py
+++ b/servers/voice/stt.py
@@ -17,9 +17,10 @@ Selector: `select_backend()` reads CLAWDND_STT_BACKEND (default "null").
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from typing import Protocol, runtime_checkable
+
+from _env import env_var
 
 # Returned by real backends when their optional deps or the audio input are
 # missing — keeps `transcribe()` graceful (the MCP tool surfaces this as `text`).
@@ -109,16 +110,16 @@ class WhisperSttBackend:
                 f"(needs faster-whisper; {type(exc).__name__})"
             )
         # Real transcription would go here, e.g.:
-        #   model = WhisperModel(os.environ.get("CLAWDND_WHISPER_MODEL", "base"))
+        #   model = WhisperModel(env_var("WHISPER_MODEL", "base"))
         #   segments, _ = model.transcribe(audio_path)
         #   return " ".join(s.text for s in segments).strip()
-        _model = os.environ.get("CLAWDND_WHISPER_MODEL", "base")
+        _model = env_var("WHISPER_MODEL", "base")
         return f"{NOT_CONFIGURED}: whisper transcription not implemented yet (model={_model})"
 
 
 def backend_name() -> str:
-    """The selected STT backend name (env CLAWDND_STT_BACKEND, default 'null')."""
-    return os.environ.get("CLAWDND_STT_BACKEND", "null").lower()
+    """The selected STT backend name (env WORLDOS_STT_BACKEND, default 'null')."""
+    return (env_var("STT_BACKEND", "null") or "null").lower()
 
 
 def select_backend() -> SttBackend:

--- a/tools/ingest/private_compendium_sidecar.py
+++ b/tools/ingest/private_compendium_sidecar.py
@@ -17,7 +17,11 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# WorldOS rename (issue #295, W0-E/4.2): prefer the new ~worldos~ scratch root +
+# WORLDOS_* env var; keep the legacy clawdnd ones as warn-only fallbacks for v1.x.
+WORLDOS_DEFAULT_SIDECAR_ROOT = Path("/Volumes/LEXAR/Codex/worldos-private-compendium")
 DEFAULT_SIDECAR_ROOT = Path("/Volumes/LEXAR/Codex/clawdnd-private-compendium")
+ENV_SIDECAR_ROOT_WORLDOS = "WORLDOS_PRIVATE_COMPENDIUM_ROOT"
 ENV_SIDECAR_ROOT = "CLAWDND_PRIVATE_COMPENDIUM_ROOT"
 MANIFEST_NAME = "private-compendium-manifest.json"
 SUPPORTED_FORMATS = {"markdown", "json", "text"}
@@ -164,9 +168,29 @@ def load_plan(manifest_path: Path, repo_root: Path = _REPO) -> SidecarPlan:
     )
 
 
+def _sidecar_root() -> Path:
+    """The sidecar root, preferring the WORLDOS_* name/path with a warn-only
+    fallback to the legacy CLAWDND_* name and the legacy on-disk root (#295)."""
+    env = os.environ.get(ENV_SIDECAR_ROOT_WORLDOS)
+    if env:
+        return Path(env).expanduser()
+    legacy = os.environ.get(ENV_SIDECAR_ROOT)
+    if legacy:
+        print(
+            f"[worldos] DEPRECATION: env var {ENV_SIDECAR_ROOT} is renamed to "
+            f"{ENV_SIDECAR_ROOT_WORLDOS}; the old name still works for v1.x but "
+            f"will be removed in v2.0.",
+            file=sys.stderr,
+        )
+        return Path(legacy).expanduser()
+    # No override: prefer the new worldos root unless only the legacy dir exists.
+    if not WORLDOS_DEFAULT_SIDECAR_ROOT.exists() and DEFAULT_SIDECAR_ROOT.exists():
+        return DEFAULT_SIDECAR_ROOT
+    return WORLDOS_DEFAULT_SIDECAR_ROOT
+
+
 def _default_manifest_path() -> Path:
-    root = Path(os.environ.get(ENV_SIDECAR_ROOT, str(DEFAULT_SIDECAR_ROOT))).expanduser()
-    return root / MANIFEST_NAME
+    return _sidecar_root() / MANIFEST_NAME
 
 
 def _write_template(manifest_path: Path) -> None:

--- a/viewer/_env.py
+++ b/viewer/_env.py
@@ -1,0 +1,89 @@
+"""Backward-compatible env-var resolution for the WorldOS rename (issue #295, W0-E).
+
+The project was renamed ClawDnD -> WorldOS. Env vars are migrating from the
+``CLAWDND_*`` prefix to ``WORLDOS_*``. This is a NON-breaking layer: every read
+site prefers ``WORLDOS_<X>`` but still falls back to the legacy ``CLAWDND_<X>``,
+emitting a ONE-TIME stderr deprecation warning per legacy var. The legacy names
+keep working for v1.x (the running app, QA scripts, and the macOS
+``RepositoryLocator`` still set ``CLAWDND_*``); they are removed at v2.0.
+
+Stdlib-only, zero project imports, so it's safe to import from any module
+(including ones used at import time). Mirrored per server package because each
+``servers/<pkg>`` is an isolated ``uv`` workspace with ``pythonpath = ["."]``.
+
+Usage::
+
+    from _env import env_var
+    raw = env_var("STATE_DIR")                  # WORLDOS_STATE_DIR or CLAWDND_STATE_DIR
+    backend = env_var("TTS_BACKEND", "kokoro")  # with a default
+
+Or, when a call site already holds the full legacy name as a string/constant::
+
+    token = env_var_legacy("CLAWDND_OPENCLAW_GATEWAY_TOKEN", "")
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Optional, Set
+
+#: New canonical prefix.
+WORLDOS_PREFIX = "WORLDOS_"
+#: Legacy prefix (deprecated, warn-only fallback for v1.x).
+LEGACY_PREFIX = "CLAWDND_"
+
+# Legacy var names we've already warned about, so each emits its deprecation
+# notice at most once per process (avoids spamming stderr on hot read paths).
+_warned: Set[str] = set()
+
+
+def _warn_once(legacy_name: str, worldos_name: str) -> None:
+    if legacy_name in _warned:
+        return
+    _warned.add(legacy_name)
+    print(
+        f"[worldos] DEPRECATION: env var {legacy_name} is renamed to {worldos_name}; "
+        f"the old name still works for v1.x but will be removed in v2.0.",
+        file=sys.stderr,
+    )
+
+
+def env_var(suffix: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve a WorldOS env var by its suffix (the part after the prefix).
+
+    Prefers ``WORLDOS_<suffix>``; falls back to the legacy ``CLAWDND_<suffix>``
+    (warning once to stderr). Returns ``default`` when neither is set.
+
+    ``suffix`` is given WITHOUT a prefix, e.g. ``env_var("STATE_DIR")`` reads
+    ``WORLDOS_STATE_DIR`` then ``CLAWDND_STATE_DIR``.
+    """
+    worldos_name = WORLDOS_PREFIX + suffix
+    legacy_name = LEGACY_PREFIX + suffix
+    return _resolve(worldos_name, legacy_name, default)
+
+
+def env_var_legacy(legacy_name: str, default: Optional[str] = None) -> Optional[str]:
+    """Resolve from a full legacy name (e.g. an existing ``CLAWDND_*`` constant).
+
+    Derives the new name by swapping the ``CLAWDND_`` prefix for ``WORLDOS_`` and
+    then behaves exactly like :func:`env_var`. Names without the legacy prefix are
+    read as-is (no aliasing) — used for genuinely external vars like
+    ``OPENCLAW_GATEWAY_TOKEN``.
+    """
+    if legacy_name.startswith(LEGACY_PREFIX):
+        worldos_name = WORLDOS_PREFIX + legacy_name[len(LEGACY_PREFIX):]
+        return _resolve(worldos_name, legacy_name, default)
+    # Not a renamed var (e.g. OPENCLAW_*); read it straight, no alias/warn.
+    return os.environ.get(legacy_name, default)
+
+
+def _resolve(worldos_name: str, legacy_name: str, default: Optional[str]) -> Optional[str]:
+    val = os.environ.get(worldos_name)
+    if val is not None:
+        return val
+    val = os.environ.get(legacy_name)
+    if val is not None:
+        _warn_once(legacy_name, worldos_name)
+        return val
+    return default

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -49,6 +49,13 @@ from typing import Optional
 from urllib.parse import parse_qs, quote, unquote, urlparse
 
 _HERE = Path(__file__).resolve().parent
+# Make this dir importable so `import _env` resolves whether server.py is run as a
+# script (sys.path[0] == viewer/) OR loaded via importlib.spec_from_file_location
+# in the test suite (which does NOT add viewer/ to sys.path).
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+from _env import env_var, env_var_legacy  # noqa: E402  (after the path bootstrap above)
+
 # servers/voice lives two levels up from viewer/ (repo root / servers / voice).
 _VOICE_DIR = _HERE.parent / "servers" / "voice"
 # servers/engine — shelled (never imported) by POST /portrait-gen to generate a PC
@@ -103,9 +110,16 @@ def sanitize_move(raw: object) -> tuple[Optional[dict], str]:
 
 
 def _state_dir() -> Path:
-    """Mirror servers/engine/store.state_dir(): $CLAWDND_STATE_DIR or ~/.clawdnd/state."""
-    env = os.environ.get("CLAWDND_STATE_DIR")
-    return Path(env) if env else Path.home() / ".clawdnd" / "state"
+    """Mirror servers/engine/store.state_dir(): $WORLDOS_STATE_DIR (or the legacy
+    $CLAWDND_STATE_DIR), else ~/.worldos/state if that home exists, else the legacy
+    ~/.clawdnd/state."""
+    env = env_var("STATE_DIR")
+    if env:
+        return Path(env)
+    worldos_home = Path.home() / ".worldos" / "state"
+    if worldos_home.parent.exists():
+        return worldos_home
+    return Path.home() / ".clawdnd" / "state"
 
 
 def _campaigns_dir() -> Path:
@@ -115,7 +129,7 @@ def _campaigns_dir() -> Path:
 def _moves_path() -> Path | None:
     """The single write target: $CLAWDND_PLAYER_MOVES, an append-only log of player
     *move intents* (NOT campaign state). Unset ⇒ no live game ⇒ no write path."""
-    env = os.environ.get("CLAWDND_PLAYER_MOVES")
+    env = env_var("PLAYER_MOVES")
     return Path(env) if env else None
 
 
@@ -4994,7 +5008,7 @@ def _viewer_config() -> dict:
     the voice server is present, and whether a live move sink is configured. Pure
     reader: no writes, no engine import, just env + filesystem the viewer already
     knows. Campaign settings (pacing_mode, leveling_mode) come from /state instead."""
-    backend = os.environ.get("CLAWDND_TTS_BACKEND", "kokoro").strip().lower() or "kokoro"
+    backend = (env_var("TTS_BACKEND", "kokoro") or "kokoro").strip().lower() or "kokoro"
     voice_ready = _VOICE_DIR.is_dir() and backend != "null"
     return {
         "voice": {"backend": backend, "ready": voice_ready},
@@ -5217,7 +5231,7 @@ def _speak(text: str, voice_id: str = "narrator-dm") -> dict:
         return {"ok": False, "reason": "empty text"}
     if not _VOICE_DIR.is_dir():
         return {"ok": False, "reason": "voice server not found"}
-    backend = os.environ.get("CLAWDND_TTS_BACKEND", "kokoro").strip().lower() or "kokoro"
+    backend = (env_var("TTS_BACKEND", "kokoro") or "kokoro").strip().lower() or "kokoro"
     req = json.dumps({"text": text[:_MOVE_MAXLEN], "voice_id": voice_id, "backend": backend})
     cmd = [
         "uv", "run", "--directory", str(_VOICE_DIR), "--no-project",
@@ -5358,7 +5372,12 @@ def _portrait_gen(payload: dict) -> dict:
     # Inherit env so the provider stays whatever the HOST configured (null on a normal box —
     # no network, no gateway). Add ONLY the interactive poll bound; never set the provider here.
     env = dict(os.environ)
-    env.setdefault("CLAWDND_OPENCLAW_POLL_TIMEOUT", _PORTRAIT_GEN_POLL_TIMEOUT)
+    # Set BOTH names so the engine child resolves the bound regardless of which
+    # convention it reads (the engine prefers WORLDOS_*; CLAWDND_* is the v1.x
+    # warn-only fallback). See issue #295 (W0-E).
+    if "WORLDOS_OPENCLAW_POLL_TIMEOUT" not in env and "CLAWDND_OPENCLAW_POLL_TIMEOUT" not in env:
+        env["WORLDOS_OPENCLAW_POLL_TIMEOUT"] = _PORTRAIT_GEN_POLL_TIMEOUT
+        env["CLAWDND_OPENCLAW_POLL_TIMEOUT"] = _PORTRAIT_GEN_POLL_TIMEOUT
     cmd = [
         "uv", "run", "--directory", str(_ENGINE_DIR), "--no-project",
         "python", "-c", _PORTRAIT_GEN_SNIPPET,
@@ -5587,7 +5606,7 @@ class _Handler(BaseHTTPRequestHandler):
             _oh = os.environ.get("OPENCLAW_HOME")
             roots = [
                 _state_dir() / "images",
-                Path(os.environ.get("CLAWDND_OPENCLAW_MEDIA_DIR")
+                Path(env_var_legacy("CLAWDND_OPENCLAW_MEDIA_DIR")
                      or ((Path(_oh) if _oh else Path.home() / ".openclaw") / "media" / "tool-image-generation")),
                 # W2b: ingested wiki art (gitignored _private; never committed).
                 _ingested_images_root(),
@@ -6107,11 +6126,11 @@ def main() -> int:
     _Handler.pinned = bool(arg_campaign)
     # Optional agent-transcript to tail in the "Agent activity" panel — point it at a
     # QA run's stream-json (e.g. qa/transcripts/<run>.jsonl) to WATCH the agents play.
-    _Handler.transcript_path = os.environ.get("CLAWDND_VIEWER_TRANSCRIPT") or (
+    _Handler.transcript_path = env_var("VIEWER_TRANSCRIPT") or (
         sys.argv[3] if len(sys.argv) > 3 else ""
     )
     # Optional two-sided conversation log to show the player+DM exchange in the chat.
-    _Handler.chat_path = os.environ.get("CLAWDND_VIEWER_CHAT") or ""
+    _Handler.chat_path = env_var("VIEWER_CHAT") or ""
     srv = ThreadingHTTPServer(("127.0.0.1", port), _Handler)
     if campaign_id:
         print(f"WorldOS play-view: http://127.0.0.1:{port}  (campaign: {campaign_id})")
@@ -6125,7 +6144,7 @@ def main() -> int:
         if moves
         else "Player moves: DISABLED (set CLAWDND_PLAYER_MOVES to enable POST /move)."
     )
-    tts = os.environ.get("CLAWDND_TTS_BACKEND", "kokoro")
+    tts = env_var("TTS_BACKEND", "kokoro")
     if _VOICE_DIR.is_dir():
         print(f"Voice (POST /speak): backend={tts} via {_VOICE_DIR}")
     else:


### PR DESCRIPTION
Part of #295. WORLDOS_* env aliases preferred, CLAWDND_* warn-only fallback (both resolve, v1.x). ~/.worldos preferred w/ ~/.clawdnd fallback. MCP ids + bundle id unchanged. Validation: engine 1504+ (incl alias-precedence tests), viewer 146, dual env smoke (both names work), --axe 0, license clean.