### PR TITLE
feat(qa): AI playtester harness v1 — Playwright + newbie persona (Part of #324)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 # persona briefs, and scorer ARE committed; only the run outputs + node_modules are ignored.
 /qa/ui_playtest_runs/
 /qa/playwright/node_modules/
+/qa/playwright/_*.js
 # The on-demand findings ledger (qa/collect_findings.py output) — a regenerable digest of
 # local QA run scores, derived from the ignored qa/transcripts/. The collector script IS
 # committed; its output is not.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,12 @@
 /qa/*.err
 /qa/smoke*.json
 /qa/qa.mcp.json
+# AI playtester (issue #324): run artifacts (screenshots, a11y dumps, bug/console/network
+# logs, summaries) are regenerable and bulky — never committed (public repo). The harness
+# (qa/ui_playtest.sh), palette MCP server (qa/playwright/palette_server.js + package.json),
+# persona briefs, and scorer ARE committed; only the run outputs + node_modules are ignored.
+/qa/ui_playtest_runs/
+/qa/playwright/node_modules/
 # The on-demand findings ledger (qa/collect_findings.py output) — a regenerable digest of
 # local QA run scores, derived from the ignored qa/transcripts/. The collector script IS
 # committed; its output is not.

--- a/qa/UI_PLAYTEST.md
+++ b/qa/UI_PLAYTEST.md
@@ -1,0 +1,140 @@
+# AI Playtester harness (issue #324)
+
+A **blind UI/UX test**: an AI "player" drives the real `/openworlds/` browser UI with no
+source-code access and reports every bug + UX gap it hits. Different signal from the
+code-reading audit — this finds bugs by *trying to play*.
+
+This is v1: **one persona (The First-Timer), Playwright, a single end-to-end run.**
+
+## Run it
+
+```sh
+qa/ui_playtest.sh <runid> <world> <persona> <beats> <budget>
+# the canonical v1 command:
+qa/ui_playtest.sh play1 baldurs-gate newbie 30 3.00
+```
+
+- `runid`   — names the output dir `qa/ui_playtest_runs/<runid>/` (wiped + recreated).
+- `world`   — world id seeded for the session (e.g. `baldurs-gate`).
+- `persona` — picks `qa/play_player_browser_<persona>.txt` (v1 ships `newbie`).
+- `beats`   — soft cap on the number of Player **palette actions**.
+- `budget`  — USD cap for the **Player** `claude -p` process.
+
+Output under `qa/ui_playtest_runs/<runid>/`:
+
+```
+meta.json                 run params + player cost
+summary.md                human-readable digest (what they tried, where stuck, top bugs, score)
+score.json                rubric metrics + pass/fail
+bugs.ndjson               one bug per line (schema: qa/ui_playtest_bug_schema.json)
+viewer.log                engine+viewer stdout
+dm/                       DM agent: chat.jsonl (two-sided), dm.jsonl (full stream), turn.*.jsonl, dm.err
+player/
+  screenshots/            step-NNN-*.png (one per palette action)
+  a11y/                   step-NNN.txt (the screen-reader view at each look)
+  actions.ndjson          one line per palette action {seq, action, target, ok, dead, ...}
+  console.ndjson          browser console errors/warnings captured passively
+  network.ndjson          failed / 4xx / 5xx requests captured passively
+  player.jsonl            the Player agent's full stream
+  status.json             present iff the player called give_up
+```
+
+> Run artifacts are **gitignored** (`/qa/ui_playtest_runs/`) — bulky + regenerable, public repo.
+
+## Architecture (three processes, one run)
+
+```
+qa/ui_playtest.sh
+  ├─ Engine + Viewer (viewer/server.py)  → serves /openworlds/ on a free port (8990–8999),
+  │                                         wired with a move sink + a two-sided chat log.
+  │                                         Engine is the SOLE writer; viewer only reads
+  │                                         surfaces + accepts /move intents.
+  ├─ DM agent (claude -p, full plugin)   → UNCHANGED from qa/run_duo.sh / qa/play_human.sh.
+  │                                         Opens the scene, then a background loop resolves
+  │                                         each player move posted to the move sink and writes
+  │                                         narration to the chat log. The DM never knows
+  │                                         there is a UI.
+  └─ PLAYER agent (claude -p, palette only) → a blind newbie. Sees ONLY the screen
+                                              (screenshot / a11y_tree); acts ONLY via
+                                              click / type / key / wait; reports friction via
+                                              report_bug / give_up. Drives the real browser.
+```
+
+**The play loop is the magic:** the Player doesn't talk to the DM. The Player drives the UI →
+the UI POSTs `/move` → the unchanged DM resolves it → narration flows back onto the screen via
+`/chat`. The Player re-screenshots to see the result and decides the next action. The harness
+validates the whole UI ↔ engine ↔ DM loop *empirically* (it works because the player could play).
+
+Because a plain browser has no native bridge, the harness pre-mints the live game (the DM's
+opening turn seats a living canon PC + companion and opens a scene) so the launcher's
+**Chronicles** shelf offers **Resume Chronicle**. The newbie discovers and clicks into the game
+through the *real* launcher start-flow — which is exactly the flow that exercises #305 (a dead
+character must not be offered/seated as a PC; if it is, the newbie reports it).
+
+## The Player palette (the constrained tool surface)
+
+`qa/playwright/palette_server.js` is an **MCP server** that is the Player's *entire* tool surface
+— mirroring the engine's constrained `player_server.py` facade (roles enforced in code, not
+prose). Exactly **8 tools**, each backed by a Playwright (Chromium) browser the server controls:
+
+| tool | backing |
+|---|---|
+| `screenshot()` | `page.screenshot()` (saved PNG) + the a11y text |
+| `a11y_tree()` | `locator('body').ariaSnapshot()` — what a screen reader announces* |
+| `click(target)` | `getByRole`/`getByText` locator click (visible label/text), reports dead clicks |
+| `type(text, target?, submit?)` | fill a field by label/placeholder; optional Enter to take a turn |
+| `key(name)` | `keyboard.press` |
+| `wait(ms? selector?)` | `waitForTimeout` / `waitForSelector` (capped) |
+| `report_bug({severity, screen, expected, actual, …})` | appends one line to `bugs.ndjson` |
+| `give_up(reason)` | ends the run (writes `status.json`) |
+
+There is **no** source-code access, **no** engine introspection, **no** filesystem in the palette.
+
+\* The spec named `page.accessibility.snapshot()`. That API was removed in Playwright ≥ 1.5x;
+`ariaSnapshot()` is its modern successor and returns the same role/name/value/disabled tree.
+
+The harness also **passively captures** browser console errors and failed/4xx/5xx network
+requests and auto-emits them as bugs (`source: "auto"`) — so breakage is caught even when the
+persona doesn't notice it.
+
+## Scoring (qa/ui_playtest_score.py)
+
+| metric | meaning |
+|---|---|
+| `completed_intro_flow` | reached the play screen **and** took ≥1 in-story turn |
+| `actions_to_first_beat` | palette actions until the first submitted turn (newbie target ≤ 10) |
+| `dead_clicks` | clicks that landed but changed nothing on screen |
+| `console_errors` / `network_failures` | passive-capture counts |
+| `bug_reports_{critical,major,minor,trivial}` | counts by severity |
+| `persona_satisfaction` | 1–10, self-reported if the player stated one, else derived |
+
+A run **passes** when `completed_intro_flow` **and** `critical == 0` **and** `console_errors == 0`
+**and** `satisfaction ≥ 6`.
+
+## Setup (one time)
+
+Playwright + the MCP SDK live in their own workspace so the repo root stays clean:
+
+```sh
+cd qa/playwright
+npm install                      # installs playwright + @modelcontextprotocol/sdk + zod
+npx playwright install chromium  # ONLY if chromium isn't already cached (it often is)
+```
+
+`node_modules/` is gitignored; `package.json` + `package-lock.json` are committed.
+
+### Env knobs (optional)
+
+- `WORLDOS_UIPT_CHANNEL=chrome` — reuse system Chrome instead of bundled Chromium.
+- `WORLDOS_DM_MODEL` / `WORLDOS_UIPT_PLAYER_MODEL` — model per agent (default `sonnet`).
+- `WORLDOS_UIPT_DM_BUDGET` — USD per DM turn (default `1.50`).
+
+## Scope notes
+
+- The bugs this finds are **the point** — record them; do **not** fix WorldOS UI bugs from a
+  playtest run. File them as issues.
+- Constraints honored: the engine (`servers/engine/`) is the **sole writer**; the harness only
+  reads viewer surfaces + drives the UI / `/move`. No wire-contract changes (`CLAWDND_*` env,
+  `clawdnd-*` MCP ids, bundle id). No assets / `_private/` committed.
+- v2 adds the other four personas (BG3 veteran, adversarial QA, storyteller, min-maxer) + a
+  parallel panel runner. See issue #324.

--- a/qa/play_player_browser_newbie.txt
+++ b/qa/play_player_browser_newbie.txt
@@ -1,0 +1,66 @@
+You are "THE FIRST-TIMER" — a brand-new player testing a fantasy story-game called WorldOS,
+BLIND, through its real graphic interface in a real browser. You have NEVER played Dungeons &
+Dragons. You have NEVER used this app. Someone told you it is "a story game with an AI Dungeon
+Master," and you opened it hoping to just start playing.
+
+HOW YOU SEE AND ACT — you have a small set of tools and NOTHING else. You are a real user, not a
+developer: you canNOT read the code, the rules, the dice math, the engine, or the DM's notes. You
+only know what the screen shows you. Your tools:
+
+  - screenshot()  — take a picture of the current screen AND read its text (buttons, tabs,
+                    fields, headings, and which controls are greyed-out/disabled). USE THIS FIRST,
+                    and again whenever the screen might have changed, so you know what is there.
+  - a11y_tree()   — a quicker text-only list of everything on screen (same info, no picture).
+  - click(target) — click a button/tab/link by the WORDS you see on it, e.g.
+                    click("Declare"), click("Atlas"), click("New Chronicle").
+  - type(text, submit) — type into the main action box. To take your turn in the story, type what
+                    your hero does in plain English and set submit=true, e.g.
+                    type("I look around the room to see who is here.", submit=true).
+  - key(name)     — press one key, e.g. key("Enter") to submit, key("Escape") to close a popup.
+  - wait(ms)      — wait a moment if the story or a screen is still loading (e.g. wait(2000)).
+  - report_bug(...) — write down a problem (see below). THIS IS THE WHOLE POINT.
+  - give_up(reason) — only if you are truly stuck and have run out of obvious things to try.
+
+HOW YOU BEHAVE (stay in character — this is the test):
+- Try the OBVIOUS thing first. ALWAYS screenshot() before you act so you click real labels. If a
+  button looks like "Play", "Start", "Resume", "Begin", or "New Chronicle", click it. Your goal is
+  to START PLAYING: get into the actual story where the Dungeon Master describes a scene and you
+  can type what your character does.
+- The start flow is roughly: a launcher/home screen → pick an existing adventure OR forge/create a
+  new one → land in the play screen → read the DM's opening → type your first action and submit it.
+  Follow whatever the screen offers toward that goal.
+- When you reach the play screen, take a few real turns: read the DM's narration on screen, then
+  type(...) a plain-English action and submit it, wait for the reply, screenshot to read it, and
+  go again. Talk to people, look around, make a choice — like a normal player would.
+- Do NOT read documentation. Do NOT hover hunting for tooltips. Do NOT use keyboard shortcuts you
+  were not told about. You expect the UI to TEACH you what to do.
+- Get honestly confused by jargon and unlabeled icons. If a tab is named something you do not
+  understand ("Parley", "Forge", "Acts", "Codex", "Seed", "Roster"), note it. If you cannot tell
+  what a button does, note it.
+- Be honest about friction. If you click something and NOTHING changes (the tool will TELL you
+  "nothing on screen changed" — that is a dead button), that is a problem. If you cannot figure
+  out how to take your turn, that is a problem. If a screen looks empty or broken, that is a
+  problem. If the picker offers you a hero who seems wrong to start as (e.g. flagged dead/fallen),
+  that is a problem.
+
+WHEN TO report_bug — this is the gold of the test. Call report_bug the MOMENT something is broken
+or makes no sense from a real user's perspective:
+  - a button/tab you clicked did nothing ("dead button"),
+  - a screen is empty when it clearly should have content,
+  - you are stuck with no obvious next step,
+  - jargon or an unlabeled control left you lost about what to do,
+  - you cannot find how to start playing or how to take your turn,
+  - something visibly glitched, overlapped, or looked broken,
+  - the app let you pick a starting hero that seems invalid (e.g. marked dead).
+Fill in: severity (critical = you cannot play at all / major = blocks this step / minor = annoying /
+trivial = cosmetic), the screen you are on, what you EXPECTED, and what ACTUALLY happened. One bug
+per call. Keep going after reporting — report what you find AND keep trying to play.
+
+YOUR LOOP, each turn: take a screenshot (or read the a11y_tree), decide the ONE next thing a
+curious first-timer would actually do toward starting and playing the story, and DO it with a tool.
+If you hit a wall, report_bug and try a reasonable alternative. Narrate your thinking in one short
+sentence ("This 'Forge' tab is confusing, but I'll try the big 'Play' button") before each tool
+call so the log captures your reasoning. You are NOT trying to break the app on purpose — you are
+just an ordinary person trying to play, noticing every place it trips you up.
+
+Begin now: take your first screenshot and find your way into the story.

--- a/qa/playwright/package-lock.json
+++ b/qa/playwright/package-lock.json
@@ -1,0 +1,1201 @@
+{
+  "name": "worldos-ui-playtest",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "worldos-ui-playtest",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "playwright": "1.60.0",
+        "zod": "^3.23.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/qa/playwright/package.json
+++ b/qa/playwright/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "worldos-ui-playtest",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Playwright-backed player palette (MCP server) for the WorldOS AI playtester harness — issue #324. The Player agent's entire tool surface (screenshot/a11y_tree/click/type/key/wait/report_bug/give_up). Driven by qa/ui_playtest.sh.",
+  "type": "commonjs",
+  "main": "palette_server.js",
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "playwright": "1.60.0",
+    "zod": "^3.23.0"
+  }
+}

--- a/qa/playwright/palette.mcp.example.json
+++ b/qa/playwright/palette.mcp.example.json
@@ -6,7 +6,7 @@
       "args": ["qa/playwright/palette_server.js"],
       "env": {
         "CLAWDND_UIPT_URL": "http://127.0.0.1:8993/openworlds/",
-        "CLAWDND_UIPT_RUNDIR": "qa/ui_playtest_runs/play1/player",
+        "CLAWDND_UIPT_RUNDIR": "qa/ui_playtest_runs/play1",
         "CLAWDND_UIPT_CHANNEL": "",
         "CLAWDND_UIPT_PERSONA": "newbie"
       }

--- a/qa/playwright/palette.mcp.example.json
+++ b/qa/playwright/palette.mcp.example.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "The Player agent's ENTIRE MCP surface for the AI playtester (issue #324). qa/ui_playtest.sh generates the real per-run config from this shape (filling the env). The Player is launched with --strict-mcp-config + ONLY this server, so it can ONLY screenshot/a11y_tree/click/type/key/wait/report_bug/give_up against the Playwright-driven browser — no source, no engine, no filesystem.",
+  "mcpServers": {
+    "clawdnd-uiplayer": {
+      "command": "node",
+      "args": ["qa/playwright/palette_server.js"],
+      "env": {
+        "CLAWDND_UIPT_URL": "http://127.0.0.1:8993/openworlds/",
+        "CLAWDND_UIPT_RUNDIR": "qa/ui_playtest_runs/play1/player",
+        "CLAWDND_UIPT_CHANNEL": "",
+        "CLAWDND_UIPT_PERSONA": "newbie"
+      }
+    }
+  }
+}

--- a/qa/playwright/palette_server.js
+++ b/qa/playwright/palette_server.js
@@ -1,0 +1,605 @@
+#!/usr/bin/env node
+/*
+ * WorldOS AI playtester — the PLAYER PALETTE MCP server (issue #324, v1).
+ *
+ * This is the Player agent's ENTIRE tool surface. It mirrors the engine's
+ * constrained `player_server.py` facade (roles enforced in CODE, not prose): the
+ * Player sees ONLY what is on screen and may act ONLY through these eight tools.
+ * There is NO source-code access, NO engine introspection, NO filesystem here —
+ * every tool is backed by a Playwright browser this process drives. The Player is
+ * a real, blind user clicking the real `/openworlds/` UI.
+ *
+ *   screenshot()                 -> page.screenshot() (saved PNG + a11y text)
+ *   a11y_tree()                  -> ariaSnapshot() (what a screen reader announces)
+ *   click(target)                -> getByRole/getByText locator click (visible label/text)
+ *   type(target, text[, submit]) -> fill a field by its label/placeholder, optional Enter
+ *   key(name)                    -> keyboard.press (Enter / Tab / Escape / ArrowDown ...)
+ *   wait(ms | selector)          -> waitForTimeout / waitForSelector (capped)
+ *   report_bug(record)           -> append ONE JSON line to bugs.ndjson (the gold of the test)
+ *   give_up(reason)              -> end the run (the player is stuck)
+ *
+ * NOTE on the a11y tree: the spec named `page.accessibility.snapshot()`. That API was
+ * removed in Playwright >= 1.5x; its modern successor is `locator.ariaSnapshot()`, which
+ * returns the SAME "what a screen reader sees" tree (roles, names, values, placeholders,
+ * disabled state) as compact YAML. We use ariaSnapshot — same blind-user semantics.
+ *
+ * The harness (qa/ui_playtest.sh) launches the Player `claude -p` with --strict-mcp-config
+ * pointed at a generated .mcp.json that runs THIS server with these env vars:
+ *   CLAWDND_UIPT_URL     — the live viewer URL to open (e.g. http://127.0.0.1:8993/openworlds/)
+ *   CLAWDND_UIPT_RUNDIR  — the run dir; we write screenshots/, a11y/, console.ndjson,
+ *                          network.ndjson, actions.ndjson, bugs.ndjson under it
+ *   CLAWDND_UIPT_CHANNEL — "" (bundled chromium) or "chrome" (reuse system Chrome)
+ *   CLAWDND_UIPT_PERSONA — persona slug stamped on each bug
+ *
+ * Console errors and failed network requests are captured passively for EVERY page and
+ * auto-emitted as bugs (category "console"/"network") in addition to whatever the Player
+ * notices — so we catch breakage even when the persona misses it.
+ *
+ * Pure player-side surface: it NEVER imports the engine, NEVER reads campaign state,
+ * NEVER writes anything but the run-dir artifacts. The engine stays the sole writer.
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const { chromium } = require("playwright");
+const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
+const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio.js");
+const { z } = require("zod");
+
+const TARGET_URL = process.env.CLAWDND_UIPT_URL || "http://127.0.0.1:8799/openworlds/";
+const RUNDIR = process.env.CLAWDND_UIPT_RUNDIR || path.join(process.cwd(), "uipt-run");
+const CHANNEL = (process.env.CLAWDND_UIPT_CHANNEL || "").trim();
+const PERSONA = (process.env.CLAWDND_UIPT_PERSONA || "newbie").trim();
+const MAX_WAIT_MS = 8000; // hard cap on a single wait, so the player can't stall the run
+
+const SHOTS = path.join(RUNDIR, "screenshots");
+const A11Y = path.join(RUNDIR, "a11y");
+for (const d of [RUNDIR, SHOTS, A11Y]) fs.mkdirSync(d, { recursive: true });
+
+const BUGS = path.join(RUNDIR, "bugs.ndjson");
+const ACTIONS = path.join(RUNDIR, "actions.ndjson");
+const CONSOLE = path.join(RUNDIR, "console.ndjson");
+const NETWORK = path.join(RUNDIR, "network.ndjson");
+const STATUS = path.join(RUNDIR, "status.json"); // give_up / end signalling for the orchestrator
+
+let seq = 0;
+let lastScreen = "launcher"; // best-effort current-screen label, from the URL hash
+
+function appendLine(file, obj) {
+  try {
+    fs.appendFileSync(file, JSON.stringify(obj) + "\n");
+  } catch (_e) {
+    /* never let a logging failure break a tool call */
+  }
+}
+
+function nowIso() {
+  return new Date().toISOString().replace(/\.\d+Z$/, "Z");
+}
+
+// Best-effort "which screen are we on" from the URL hash (#/table) or fallback.
+function screenFromUrl(u) {
+  try {
+    const m = String(u || "").match(/#\/?([a-z-]+)/i);
+    if (m) return m[1].toLowerCase();
+  } catch (_e) {}
+  return lastScreen;
+}
+
+function shortUrl(u) {
+  try {
+    const p = new globalThis.URL(u);
+    return p.pathname + (p.search || "");
+  } catch (_e) {
+    return String(u).slice(0, 80);
+  }
+}
+
+// ---- Playwright lifecycle ---------------------------------------------------
+let browser = null;
+let page = null;
+
+async function ensurePage() {
+  if (page && !page.isClosed()) return page;
+  const launchOpts = { headless: true };
+  if (CHANNEL) launchOpts.channel = CHANNEL; // e.g. "chrome" to reuse system Chrome
+  browser = await chromium.launch(launchOpts);
+  const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+  page = await context.newPage();
+
+  // Passive capture: console errors + failed/4xx/5xx network requests -> bugs.
+  page.on("console", (msg) => {
+    const type = msg.type();
+    if (type !== "error" && type !== "warning") return;
+    const text = msg.text();
+    if (/Download the React DevTools|Each child in a list should have a unique/.test(text)) return;
+    appendLine(CONSOLE, { ts: nowIso(), type, text: text.slice(0, 600) });
+    if (type === "error") {
+      autoBug({
+        category: "console",
+        severity: "major",
+        screen: screenFromUrl(page.url()),
+        title: "Console error: " + text.slice(0, 100),
+        expected: "No JavaScript console errors during normal play.",
+        actual: text.slice(0, 400),
+        evidence: { console_error: text.slice(0, 400) },
+        blocks_progress: false,
+        source: "auto",
+      });
+    }
+  });
+  page.on("pageerror", (err) => {
+    const text = String(err && err.message ? err.message : err);
+    appendLine(CONSOLE, { ts: nowIso(), type: "pageerror", text: text.slice(0, 600) });
+    autoBug({
+      category: "console",
+      severity: "critical",
+      screen: screenFromUrl(page.url()),
+      title: "Uncaught exception: " + text.slice(0, 100),
+      expected: "No uncaught JavaScript exceptions.",
+      actual: text.slice(0, 400),
+      evidence: { pageerror: text.slice(0, 400) },
+      blocks_progress: true,
+      source: "auto",
+    });
+  });
+  page.on("requestfailed", (req) => {
+    const failure = req.failure();
+    const rec = { ts: nowIso(), url: req.url(), method: req.method(), error: failure ? failure.errorText : "failed" };
+    appendLine(NETWORK, rec);
+    if (/net::ERR_ABORTED/.test(rec.error)) return; // aborted navigations are noise
+    autoBug({
+      category: "network",
+      severity: "major",
+      screen: screenFromUrl(page.url()),
+      title: "Network request failed: " + req.method() + " " + shortUrl(req.url()),
+      expected: "The page's network requests succeed.",
+      actual: rec.error + " — " + req.url(),
+      evidence: { network_failure: rec },
+      blocks_progress: false,
+      source: "auto",
+    });
+  });
+  page.on("response", (resp) => {
+    const status = resp.status();
+    if (status < 400) return;
+    const rec = { ts: nowIso(), url: resp.url(), status, method: resp.request().method() };
+    appendLine(NETWORK, rec);
+    autoBug({
+      category: "network",
+      severity: status >= 500 ? "major" : "minor",
+      screen: screenFromUrl(page.url()),
+      title: "HTTP " + status + " on " + resp.request().method() + " " + shortUrl(resp.url()),
+      expected: "Requests the UI makes return 2xx/3xx.",
+      actual: "HTTP " + status + " for " + resp.url(),
+      evidence: { http_status: rec },
+      blocks_progress: false,
+      source: "auto",
+    });
+  });
+
+  await page.goto(TARGET_URL, { waitUntil: "domcontentloaded", timeout: 30000 }).catch(() => {});
+  // The OpenWorlds SPA mounts React asynchronously; give it a beat to render.
+  await page.waitForTimeout(1500);
+  lastScreen = screenFromUrl(page.url());
+  return page;
+}
+
+// ---- a11y snapshot ----------------------------------------------------------
+// ariaSnapshot() returns the screen-reader view as compact YAML. Cap its size so a
+// huge screen can't blow the Player's context.
+async function ariaText(pg) {
+  try {
+    const snap = await pg.locator("body").ariaSnapshot({ timeout: 4000 });
+    return String(snap).slice(0, 9000);
+  } catch (_e) {
+    return "(accessibility snapshot unavailable for this screen)";
+  }
+}
+
+// ---- bug + action logging ---------------------------------------------------
+// De-dup auto-bugs so one repeated console error doesn't flood bugs.ndjson.
+const seenAuto = new Set();
+function autoBug(rec) {
+  const dedup = (rec.category || "") + "|" + (rec.title || "");
+  if (seenAuto.has(dedup)) return;
+  seenAuto.add(dedup);
+  writeBug(rec);
+}
+
+function writeBug(rec) {
+  const out = {
+    ts: rec.ts || nowIso(),
+    action_seq: seq,
+    persona: PERSONA,
+    screen: rec.screen || lastScreen,
+    category: rec.category || "ux",
+    severity: rec.severity || "minor",
+    title: rec.title || "(untitled)",
+    expected: rec.expected || "",
+    actual: rec.actual || "",
+    screenshot: rec.screenshot || "",
+    evidence: rec.evidence || {},
+    tried_alternatives: rec.tried_alternatives || [],
+    blocks_progress: rec.blocks_progress === true,
+    source: rec.source || "player",
+  };
+  appendLine(BUGS, out);
+  return out;
+}
+
+function logAction(action, detail) {
+  seq += 1;
+  appendLine(ACTIONS, { ts: nowIso(), seq, action, ...detail, screen: lastScreen });
+  return seq;
+}
+
+// Save a screenshot for the current step; returns the relative filename.
+async function snap(pg, label) {
+  const name = "step-" + String(seq).padStart(3, "0") + (label ? "-" + label : "") + ".png";
+  const file = path.join(SHOTS, name);
+  try {
+    await pg.screenshot({ path: file, fullPage: false });
+  } catch (_e) {
+    return "";
+  }
+  return path.join("screenshots", name);
+}
+
+// ---- locator resolution -----------------------------------------------------
+// A blind user clicks by the WORDS they see. Prefer accessible role+name, fall
+// back to visible text, then a raw selector (only the orchestrator ever passes one).
+async function resolveClickable(pg, target) {
+  const t = String(target || "").trim();
+  if (!t) return null;
+  const tries = [
+    () => pg.getByRole("button", { name: t, exact: false }).first(),
+    () => pg.getByRole("tab", { name: t, exact: false }).first(),
+    () => pg.getByRole("link", { name: t, exact: false }).first(),
+    () => pg.getByRole("menuitem", { name: t, exact: false }).first(),
+    () => pg.getByText(t, { exact: false }).first(),
+  ];
+  for (const mk of tries) {
+    try {
+      const loc = mk();
+      if ((await loc.count()) > 0) return loc;
+    } catch (_e) {}
+  }
+  try {
+    const loc = pg.locator(t).first();
+    if ((await loc.count()) > 0) return loc;
+  } catch (_e) {}
+  return null;
+}
+
+function escapeRe(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function resolveField(pg, target) {
+  const t = String(target || "").trim();
+  // Empty target = "the main action input" (the table's "Describe what your hero does...").
+  if (!t) {
+    const byPh = pg.getByPlaceholder(/describe what your hero does/i).first();
+    if ((await byPh.count().catch(() => 0)) > 0) return byPh;
+    const anyTextbox = pg.getByRole("textbox").first();
+    if ((await anyTextbox.count().catch(() => 0)) > 0) return anyTextbox;
+    return null;
+  }
+  const tries = [
+    () => pg.getByPlaceholder(new RegExp(escapeRe(t), "i")).first(),
+    () => pg.getByLabel(new RegExp(escapeRe(t), "i")).first(),
+    () => pg.getByRole("textbox", { name: t, exact: false }).first(),
+  ];
+  for (const mk of tries) {
+    try {
+      const loc = mk();
+      if ((await loc.count()) > 0) return loc;
+    } catch (_e) {}
+  }
+  const tb = pg.getByRole("textbox").first();
+  if ((await tb.count().catch(() => 0)) > 0) return tb;
+  return null;
+}
+
+// ---- MCP server -------------------------------------------------------------
+const server = new McpServer({ name: "clawdnd-uiplayer", version: "1.0.0" });
+
+function textResult(obj) {
+  return { content: [{ type: "text", text: typeof obj === "string" ? obj : JSON.stringify(obj) }] };
+}
+
+server.registerTool(
+  "screenshot",
+  {
+    description:
+      "Take a screenshot of what is on screen RIGHT NOW and read the page's accessible text. " +
+      "Returns the saved PNG path plus what a screen reader sees (buttons, tabs, fields, headings, " +
+      "and whether controls are disabled). Use this to SEE before you act.",
+    inputSchema: {},
+  },
+  async () => {
+    const pg = await ensurePage();
+    lastScreen = screenFromUrl(pg.url());
+    const sc = await snap(pg, "look");
+    logAction("screenshot", { screenshot: sc });
+    const aria = await ariaText(pg);
+    appendLine(path.join(A11Y, "_index.ndjson"), { seq, screen: lastScreen });
+    try {
+      fs.writeFileSync(path.join(A11Y, "step-" + String(seq).padStart(3, "0") + ".txt"), aria);
+    } catch (_e) {}
+    return textResult({ screen: lastScreen, screenshot: sc, a11y: aria });
+  }
+);
+
+server.registerTool(
+  "a11y_tree",
+  {
+    description:
+      "Read ONLY the accessibility tree of the current screen (what a screen reader announces): " +
+      "every button, tab, link, heading, text field and its value, plus disabled state. Cheaper " +
+      "than a screenshot when you just need the list of controls and text.",
+    inputSchema: {},
+  },
+  async () => {
+    const pg = await ensurePage();
+    lastScreen = screenFromUrl(pg.url());
+    logAction("a11y_tree", {});
+    const aria = await ariaText(pg);
+    try {
+      fs.writeFileSync(path.join(A11Y, "step-" + String(seq).padStart(3, "0") + ".txt"), aria);
+    } catch (_e) {}
+    return textResult({ screen: lastScreen, a11y: aria });
+  }
+);
+
+server.registerTool(
+  "click",
+  {
+    description:
+      "Click a button, tab, link, or menu item by the WORDS you see on it (e.g. \"Declare\", " +
+      "\"Atlas\", \"New Chronicle\"). Prefer the exact visible label. Returns whether the click " +
+      "landed and whether the screen changed (so you can tell if the button was dead).",
+    inputSchema: { target: z.string().describe("The visible text/label on the control to click.") },
+  },
+  async ({ target }) => {
+    const pg = await ensurePage();
+    const before = await ariaText(pg);
+    const loc = await resolveClickable(pg, target);
+    if (!loc) {
+      const s = logAction("click", { target, ok: false, reason: "no matching control" });
+      const sc = await snap(pg, "click-miss");
+      return textResult({
+        ok: false,
+        seq: s,
+        screenshot: sc,
+        reason: 'No control found matching "' + target + '". Take a screenshot or read the a11y_tree to see the exact labels.',
+      });
+    }
+    let ok = true;
+    let reason = "";
+    try {
+      await loc.click({ timeout: 5000 });
+    } catch (e) {
+      ok = false;
+      reason = String(e && e.message ? e.message : e).slice(0, 200);
+    }
+    await pg.waitForTimeout(700);
+    lastScreen = screenFromUrl(pg.url());
+    const after = await ariaText(pg);
+    const changed = before !== after;
+    const s = logAction("click", { target, ok, changed, dead: ok && !changed, reason });
+    const sc = await snap(pg, "click");
+    return textResult({
+      ok,
+      seq: s,
+      screen: lastScreen,
+      screen_changed: changed,
+      screenshot: sc,
+      reason: ok
+        ? changed
+          ? ""
+          : "WARNING: the click landed but NOTHING on screen changed. This looks like a dead button — consider report_bug."
+        : reason,
+    });
+  }
+);
+
+server.registerTool(
+  "type",
+  {
+    description:
+      "Type text into a field. Leave target empty to type into the main action box (the " +
+      '"Describe what your hero does..." field on the play screen). Set submit=true to press ' +
+      "Enter after typing (that is how you take your turn in the story).",
+    inputSchema: {
+      text: z.string().describe("What to type, in plain English."),
+      target: z.string().optional().describe("Field label/placeholder. Empty = the main action box."),
+      submit: z.boolean().optional().describe("Press Enter after typing (default false)."),
+    },
+  },
+  async ({ text, target, submit }) => {
+    const pg = await ensurePage();
+    const loc = await resolveField(pg, target || "");
+    if (!loc) {
+      const s = logAction("type", { target: target || "", ok: false, reason: "no field" });
+      const sc = await snap(pg, "type-miss");
+      return textResult({ ok: false, seq: s, screenshot: sc, reason: "No text field found. Take a screenshot to see if a field is visible." });
+    }
+    let ok = true;
+    let reason = "";
+    try {
+      await loc.click({ timeout: 4000 }).catch(() => {});
+      await loc.fill(String(text), { timeout: 5000 });
+      if (submit) {
+        await loc.press("Enter");
+        await pg.waitForTimeout(900);
+      }
+    } catch (e) {
+      ok = false;
+      reason = String(e && e.message ? e.message : e).slice(0, 200);
+    }
+    lastScreen = screenFromUrl(pg.url());
+    const s = logAction("type", {
+      target: target || "(main action box)",
+      text: String(text).slice(0, 200),
+      submit: !!submit,
+      ok,
+      reason,
+    });
+    const sc = await snap(pg, "type");
+    return textResult({ ok, seq: s, screen: lastScreen, screenshot: sc, submitted: !!submit, reason });
+  }
+);
+
+server.registerTool(
+  "key",
+  {
+    description:
+      'Press a single keyboard key on the page (e.g. "Enter", "Escape", "Tab", "ArrowDown"). ' +
+      "Use Enter to submit the action box, or Escape to close a popup.",
+    inputSchema: { name: z.string().describe("Key name, e.g. Enter / Escape / Tab / ArrowDown.") },
+  },
+  async ({ name }) => {
+    const pg = await ensurePage();
+    let ok = true;
+    let reason = "";
+    try {
+      await pg.keyboard.press(String(name));
+      await pg.waitForTimeout(500);
+    } catch (e) {
+      ok = false;
+      reason = String(e && e.message ? e.message : e).slice(0, 200);
+    }
+    lastScreen = screenFromUrl(pg.url());
+    const s = logAction("key", { name, ok, reason });
+    const sc = await snap(pg, "key");
+    return textResult({ ok, seq: s, screen: lastScreen, screenshot: sc, reason });
+  }
+);
+
+server.registerTool(
+  "wait",
+  {
+    description:
+      "Wait for the page to settle. Pass a number of milliseconds (capped at " + MAX_WAIT_MS +
+      "ms) to wait that long, or a CSS selector to wait until that element appears. Use after an " +
+      "action when the story or a screen might still be loading.",
+    inputSchema: {
+      ms: z.number().optional().describe("Milliseconds to wait (capped)."),
+      selector: z.string().optional().describe("CSS selector to wait for instead of a fixed time."),
+    },
+  },
+  async ({ ms, selector }) => {
+    const pg = await ensurePage();
+    let ok = true;
+    let reason = "";
+    if (selector) {
+      try {
+        await pg.waitForSelector(String(selector), { timeout: MAX_WAIT_MS });
+      } catch (_e) {
+        ok = false;
+        reason = "selector did not appear within " + MAX_WAIT_MS + "ms";
+      }
+    } else {
+      const dur = Math.max(0, Math.min(Number(ms || 1000), MAX_WAIT_MS));
+      await pg.waitForTimeout(dur);
+    }
+    lastScreen = screenFromUrl(pg.url());
+    const s = logAction("wait", { ms: ms || null, selector: selector || null, ok });
+    return textResult({ ok, seq: s, screen: lastScreen, reason });
+  }
+);
+
+server.registerTool(
+  "report_bug",
+  {
+    description:
+      "Record ONE bug or UX problem you just hit. This is the POINT of the test — be specific. " +
+      "Give the severity (critical = blocks all play / major = blocks this task / minor = annoying / " +
+      "trivial = cosmetic), which screen you are on, what you EXPECTED, and what ACTUALLY happened.",
+    inputSchema: {
+      severity: z.enum(["critical", "major", "minor", "trivial"]).describe("How bad is it."),
+      screen: z.string().optional().describe("Which screen/area you are on."),
+      expected: z.string().describe("What you expected to happen."),
+      actual: z.string().describe("What actually happened."),
+      title: z.string().optional().describe("One-line summary."),
+      category: z.enum(["ux", "bug", "content", "accessibility", "performance"]).optional(),
+      blocks_progress: z.boolean().optional().describe("Did this stop you from continuing?"),
+      tried_alternatives: z.array(z.string()).optional().describe("Other things you tried first."),
+    },
+  },
+  async (rec) => {
+    const pg = await ensurePage().catch(() => null);
+    const sc = pg ? await snap(pg, "bug") : "";
+    const out = writeBug({
+      category: rec.category || "ux",
+      severity: rec.severity,
+      screen: rec.screen || lastScreen,
+      title: rec.title || rec.expected.slice(0, 80),
+      expected: rec.expected,
+      actual: rec.actual,
+      screenshot: sc,
+      tried_alternatives: rec.tried_alternatives || [],
+      blocks_progress: rec.blocks_progress === true,
+      source: "player",
+    });
+    logAction("report_bug", { severity: out.severity, title: out.title });
+    return textResult({ ok: true, recorded: out.title, severity: out.severity, screenshot: sc });
+  }
+);
+
+server.registerTool(
+  "give_up",
+  {
+    description:
+      "End the playtest because you are stuck and cannot find a way to continue. Explain WHY in " +
+      "plain words (what you tried, what blocked you). Only use this when you have genuinely " +
+      "exhausted the obvious options.",
+    inputSchema: { reason: z.string().describe("Why you are giving up.") },
+  },
+  async ({ reason }) => {
+    const pg = await ensurePage().catch(() => null);
+    const sc = pg ? await snap(pg, "giveup") : "";
+    logAction("give_up", { reason });
+    writeBug({
+      category: "ux",
+      severity: "major",
+      screen: lastScreen,
+      title: "Player gave up: " + String(reason).slice(0, 80),
+      expected: "A first-timer can keep playing without getting stuck.",
+      actual: String(reason).slice(0, 500),
+      screenshot: sc,
+      blocks_progress: true,
+      source: "give_up",
+    });
+    try {
+      fs.writeFileSync(STATUS, JSON.stringify({ ended: true, reason: "give_up", detail: String(reason).slice(0, 500), at: nowIso() }));
+    } catch (_e) {}
+    return textResult({ ok: true, ended: true, note: "Run ended. Thanks for playing." });
+  }
+);
+
+// Graceful browser teardown on exit.
+async function shutdown() {
+  try {
+    if (browser) await browser.close();
+  } catch (_e) {}
+}
+process.on("SIGTERM", async () => {
+  await shutdown();
+  process.exit(0);
+});
+process.on("SIGINT", async () => {
+  await shutdown();
+  process.exit(0);
+});
+
+(async () => {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+})().catch((e) => {
+  process.stderr.write("palette_server fatal: " + (e && e.stack ? e.stack : e) + "\n");
+  process.exit(1);
+});

--- a/qa/playwright/palette_server.js
+++ b/qa/playwright/palette_server.js
@@ -48,20 +48,24 @@ const { StdioServerTransport } = require("@modelcontextprotocol/sdk/server/stdio
 const { z } = require("zod");
 
 const TARGET_URL = process.env.CLAWDND_UIPT_URL || "http://127.0.0.1:8799/openworlds/";
+// CLAWDND_UIPT_RUNDIR is the RUN ROOT. bugs.ndjson + status.json land here (top-level
+// deliverables); the player-side artifacts (screenshots, a11y, action/console/network
+// logs) go under player/ — matching qa/ui_playtest_score.py's reader.
 const RUNDIR = process.env.CLAWDND_UIPT_RUNDIR || path.join(process.cwd(), "uipt-run");
+const PLAYERDIR = path.join(RUNDIR, "player");
 const CHANNEL = (process.env.CLAWDND_UIPT_CHANNEL || "").trim();
 const PERSONA = (process.env.CLAWDND_UIPT_PERSONA || "newbie").trim();
 const MAX_WAIT_MS = 8000; // hard cap on a single wait, so the player can't stall the run
 
-const SHOTS = path.join(RUNDIR, "screenshots");
-const A11Y = path.join(RUNDIR, "a11y");
-for (const d of [RUNDIR, SHOTS, A11Y]) fs.mkdirSync(d, { recursive: true });
+const SHOTS = path.join(PLAYERDIR, "screenshots");
+const A11Y = path.join(PLAYERDIR, "a11y");
+for (const d of [RUNDIR, PLAYERDIR, SHOTS, A11Y]) fs.mkdirSync(d, { recursive: true });
 
-const BUGS = path.join(RUNDIR, "bugs.ndjson");
-const ACTIONS = path.join(RUNDIR, "actions.ndjson");
-const CONSOLE = path.join(RUNDIR, "console.ndjson");
-const NETWORK = path.join(RUNDIR, "network.ndjson");
-const STATUS = path.join(RUNDIR, "status.json"); // give_up / end signalling for the orchestrator
+const BUGS = path.join(RUNDIR, "bugs.ndjson"); // top-level deliverable
+const ACTIONS = path.join(PLAYERDIR, "actions.ndjson");
+const CONSOLE = path.join(PLAYERDIR, "console.ndjson");
+const NETWORK = path.join(PLAYERDIR, "network.ndjson");
+const STATUS = path.join(PLAYERDIR, "status.json"); // give_up / end signal for the orchestrator
 
 let seq = 0;
 let lastScreen = "launcher"; // best-effort current-screen label, from the URL hash
@@ -96,6 +100,27 @@ function shortUrl(u) {
   }
 }
 
+// The OpenWorlds SPA navigates by React state, NOT the URL hash (app.jsx's navigate()
+// only setScreen() — it never writes location.hash), so we can't read the screen from
+// the URL. Instead infer it from screen-specific markers in the aria snapshot. Ordered
+// most-specific first. Falls back to the previous label when nothing matches.
+function screenFromAria(aria) {
+  const a = String(aria || "");
+  const has = (re) => re.test(a);
+  if (has(/describe what your hero does/i) || (has(/\bDeclare\b/) && has(/Active Quests|Encounter|Quick Stash/i))) return "table";
+  if (has(/Forge a new hero|Begin a new chronicle|A Tabletop, Reawakened|No chronicles|Resume Chronicle|View Chronicle/i)) return "launcher";
+  if (has(/Initiative|End Turn|Bonus Action|Reaction\b/i) && has(/\bAttack\b|\bCast\b/)) return "combat";
+  if (has(/Choose a hero|Roster|Bind|Seat .*hero|fallen|Slain|Deceased/i) && has(/\bHero(es)?\b/)) return "roster";
+  if (has(/Ability Scores|Proficienc|Spellbook|Armor Class|\bAC\b.*\bHP\b|Saving Throws/i)) return "character";
+  if (has(/Encumbrance|Equipped|Backpack|Stash|Carrying/i) && has(/\bItem/)) return "inventory";
+  if (has(/Region|Fast Travel|Travel to|Map of/i)) return "map";
+  if (has(/Quest Log|Chronicle Entries|Journal/i)) return "journal";
+  if (has(/Merchant|Buy|Sell|Wares|Gold\b.*\bPrice/i)) return "merchant";
+  if (has(/Forge|Creation Plane|Generate (a )?world|Seed/i)) return "forge";
+  if (has(/Settings|Voice Backend|Provider|API Key/i)) return "settings";
+  return lastScreen;
+}
+
 // ---- Playwright lifecycle ---------------------------------------------------
 let browser = null;
 let page = null;
@@ -115,6 +140,10 @@ async function ensurePage() {
     const text = msg.text();
     if (/Download the React DevTools|Each child in a list should have a unique/.test(text)) return;
     appendLine(CONSOLE, { ts: nowIso(), type, text: text.slice(0, 600) });
+    // "Failed to load resource: ... 404/403" is the browser's generic echo of a failed
+    // network fetch — already captured (and collapsed) by the response handler as a network
+    // bug. Don't double-count it as a separate console error (it's the image-404 noise).
+    if (/Failed to load resource/i.test(text)) return;
     if (type === "error") {
       autoBug({
         category: "console",
@@ -164,15 +193,29 @@ async function ensurePage() {
   page.on("response", (resp) => {
     const status = resp.status();
     if (status < 400) return;
-    const rec = { ts: nowIso(), url: resp.url(), status, method: resp.request().method() };
+    const url = resp.url();
+    const method = resp.request().method();
+    const rec = { ts: nowIso(), url, status, method };
     appendLine(NETWORK, rec);
+    // The viewer 404s a missing /image?scope=... ON PURPOSE — it's graceful degradation
+    // (the UI shows a silhouette/placeholder). On a fresh run with no cached art that fires
+    // for every roster face. Collapse the whole class into ONE low-severity informational
+    // bug ("art not generated for this run") instead of 60 near-identical majors. The raw
+    // 404s are still in network.ndjson for anyone who wants them.
+    const isImage404 = status === 404 && /\/image\?scope=/.test(url);
     autoBug({
       category: "network",
-      severity: status >= 500 ? "major" : "minor",
+      severity: isImage404 ? "trivial" : status >= 500 ? "major" : "minor",
       screen: screenFromUrl(page.url()),
-      title: "HTTP " + status + " on " + resp.request().method() + " " + shortUrl(resp.url()),
-      expected: "Requests the UI makes return 2xx/3xx.",
-      actual: "HTTP " + status + " for " + resp.url(),
+      title: isImage404
+        ? "Missing images (404 /image) — portraits/scene art not generated for this run"
+        : "HTTP " + status + " on " + method + " " + shortUrl(url),
+      expected: isImage404
+        ? "Faces/art either render or degrade silently to a placeholder."
+        : "Requests the UI makes return 2xx/3xx.",
+      actual: isImage404
+        ? "Multiple /image 404s (expected with no cached art; first: " + url + ")"
+        : "HTTP " + status + " for " + url,
       evidence: { http_status: rec },
       blocks_progress: false,
       source: "auto",
@@ -191,11 +234,23 @@ async function ensurePage() {
 // huge screen can't blow the Player's context.
 async function ariaText(pg) {
   try {
-    const snap = await pg.locator("body").ariaSnapshot({ timeout: 4000 });
-    return String(snap).slice(0, 9000);
+    const snap = String(await pg.locator("body").ariaSnapshot({ timeout: 4000 }));
+    lastScreen = screenFromAria(snap); // SPA nav is React-state, not URL — infer from content
+    return snap.slice(0, 9000);
   } catch (_e) {
     return "(accessibility snapshot unavailable for this screen)";
   }
+}
+
+// Cheap "where am I now" refresh after an action, from the rendered aria (not the URL,
+// which the SPA never updates). Updates lastScreen as a side effect; best-effort.
+async function refreshScreen(pg) {
+  try {
+    lastScreen = screenFromAria(String(await pg.locator("body").ariaSnapshot({ timeout: 2500 })));
+  } catch (_e) {
+    /* keep prior label */
+  }
+  return lastScreen;
 }
 
 // ---- bug + action logging ---------------------------------------------------
@@ -235,7 +290,8 @@ function logAction(action, detail) {
   return seq;
 }
 
-// Save a screenshot for the current step; returns the relative filename.
+// Save a screenshot for the current step; returns the path RELATIVE TO THE RUN ROOT
+// (so summary.md + bug records, which live at the run root, resolve it).
 async function snap(pg, label) {
   const name = "step-" + String(seq).padStart(3, "0") + (label ? "-" + label : "") + ".png";
   const file = path.join(SHOTS, name);
@@ -244,7 +300,7 @@ async function snap(pg, label) {
   } catch (_e) {
     return "";
   }
-  return path.join("screenshots", name);
+  return path.join("player", "screenshots", name);
 }
 
 // ---- locator resolution -----------------------------------------------------
@@ -321,7 +377,7 @@ server.registerTool(
   },
   async () => {
     const pg = await ensurePage();
-    lastScreen = screenFromUrl(pg.url());
+    await refreshScreen(pg);
     const sc = await snap(pg, "look");
     logAction("screenshot", { screenshot: sc });
     const aria = await ariaText(pg);
@@ -344,7 +400,7 @@ server.registerTool(
   },
   async () => {
     const pg = await ensurePage();
-    lastScreen = screenFromUrl(pg.url());
+    await refreshScreen(pg);
     logAction("a11y_tree", {});
     const aria = await ariaText(pg);
     try {
@@ -386,7 +442,7 @@ server.registerTool(
       reason = String(e && e.message ? e.message : e).slice(0, 200);
     }
     await pg.waitForTimeout(700);
-    lastScreen = screenFromUrl(pg.url());
+    await refreshScreen(pg);
     const after = await ariaText(pg);
     const changed = before !== after;
     const s = logAction("click", { target, ok, changed, dead: ok && !changed, reason });
@@ -440,7 +496,7 @@ server.registerTool(
       ok = false;
       reason = String(e && e.message ? e.message : e).slice(0, 200);
     }
-    lastScreen = screenFromUrl(pg.url());
+    await refreshScreen(pg);
     const s = logAction("type", {
       target: target || "(main action box)",
       text: String(text).slice(0, 200),
@@ -472,7 +528,7 @@ server.registerTool(
       ok = false;
       reason = String(e && e.message ? e.message : e).slice(0, 200);
     }
-    lastScreen = screenFromUrl(pg.url());
+    await refreshScreen(pg);
     const s = logAction("key", { name, ok, reason });
     const sc = await snap(pg, "key");
     return textResult({ ok, seq: s, screen: lastScreen, screenshot: sc, reason });
@@ -506,7 +562,7 @@ server.registerTool(
       const dur = Math.max(0, Math.min(Number(ms || 1000), MAX_WAIT_MS));
       await pg.waitForTimeout(dur);
     }
-    lastScreen = screenFromUrl(pg.url());
+    await refreshScreen(pg);
     const s = logAction("wait", { ms: ms || null, selector: selector || null, ok });
     return textResult({ ok, seq: s, screen: lastScreen, reason });
   }

--- a/qa/ui_playtest.sh
+++ b/qa/ui_playtest.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# WorldOS AI PLAYTESTER HARNESS v1 (issue #324) — a blind UI/UX test.
+#
+# Three processes, one run:
+#   - Engine + Viewer (viewer/server.py): serves the REAL /openworlds/ UI on a free
+#     port, wired with a move sink ($MOVES) + a two-sided chat log ($CHAT). Engine is
+#     the SOLE writer; the viewer only reads surfaces + accepts /move intents.
+#   - DM agent (claude -p, full plugin + dungeon-master skill + engine MCP): UNCHANGED
+#     from qa/run_duo.sh / qa/play_human.sh. It opens the scene, then a background loop
+#     resolves each player move the UI posts to $MOVES and writes narration to $CHAT,
+#     which the UI polls via /chat. The DM never knows there is a UI.
+#   - PLAYER agent (claude -p with ONLY the Playwright palette MCP — strict): a blind
+#     newbie who SEES only the screen (screenshot / a11y_tree) and ACTS only via
+#     click / type / key / wait, reporting friction via report_bug / give_up. NO source,
+#     NO engine introspection, NO filesystem. It drives the real browser; its clicks
+#     POST /move; the unchanged DM resolves; narration flows back onto the screen.
+#
+# Usage:   qa/ui_playtest.sh <runid> <world> <persona> <beats> <budget>
+# Target:  qa/ui_playtest.sh play1 baldurs-gate newbie 30 3.00
+#   <beats>  = max player palette ACTIONS before we stop the run (a soft cap; the player
+#             may also give_up earlier). <budget> = USD cap for the PLAYER agent process.
+#
+# Produces under qa/ui_playtest_runs/<runid>/:
+#   player/screenshots/*.png, player/a11y/*.txt, bugs.ndjson, actions.ndjson,
+#   console.ndjson, network.ndjson, score.json, summary.md, meta.json
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
+. "$ROOT/qa/lib_beat_driver.sh"  # worldos_env + shared helpers
+
+RUN="${1:-play-$(date +%H%M%S)}"
+WORLD="${2:-baldurs-gate}"
+PERSONA="${3:-newbie}"
+BEATS="${4:-30}"          # max player palette actions (soft cap)
+BUDGET="${5:-3.00}"       # USD cap for the PLAYER agent
+PW_DIR="$ROOT/qa/playwright"
+PW_CHANNEL="$(worldos_env UIPT_CHANNEL "")"   # "" = bundled chromium; "chrome" = system Chrome
+DM_MODEL="$(worldos_env DM_MODEL sonnet)"
+PLAYER_MODEL="$(worldos_env UIPT_PLAYER_MODEL sonnet)"
+DM_BUDGET="$(worldos_env UIPT_DM_BUDGET 1.50)"        # per DM turn
+PERSONA_FILE="$ROOT/qa/play_player_browser_${PERSONA}.txt"
+
+[ -f "$PERSONA_FILE" ] || { echo "[uipt] no persona brief at $PERSONA_FILE" >&2; exit 2; }
+[ -d "$PW_DIR/node_modules/playwright" ] || {
+  echo "[uipt] Playwright not installed. Run: (cd qa/playwright && npm install && npx playwright install chromium)" >&2
+  exit 2
+}
+
+RUNDIR="$ROOT/qa/ui_playtest_runs/$RUN"
+PLAYERDIR="$RUNDIR/player"
+STATE_DIR="$RUNDIR/state"
+rm -rf "$RUNDIR" 2>/dev/null
+mkdir -p "$PLAYERDIR/screenshots" "$PLAYERDIR/a11y" "$STATE_DIR" "$RUNDIR/dm"
+MOVES="$STATE_DIR/player_moves.jsonl"; : > "$MOVES"
+CHAT="$RUNDIR/dm/chat.jsonl"; : > "$CHAT"
+COMBINED="$RUNDIR/dm/dm.jsonl"; : > "$COMBINED"
+DM_CFG="$STATE_DIR/dm.mcp.json"
+PLAYER_CFG="$STATE_DIR/player.mcp.json"
+
+# --- free port in 8990–8999 (fail if all busy) -------------------------------
+pick_port() {
+  local p
+  for p in $(seq 8990 8999); do
+    if ! (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then echo "$p"; return 0; fi
+    exec 3>&- 2>/dev/null || true
+  done
+  return 1
+}
+PORT="$(pick_port)" || { echo "[uipt] no free port in 8990-8999 — aborting" >&2; exit 3; }
+URL="http://127.0.0.1:$PORT/openworlds/"
+
+# --- DM MCP config: re-root every server at THIS repo + scope engine to $STATE_DIR.
+# (Identical to run_duo.sh — guards the version-skew that RED-caps a run if the DM
+#  engine runs older models.py than the snapshot writer.)
+python3 - "$ROOT/qa/qa.mcp.example.json" "$STATE_DIR" "$DM_CFG" "$ROOT" <<'PY'
+import json, sys
+cfg_path, state, out, root = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+cfg = json.load(open(cfg_path))
+for name, srv in cfg.get("mcpServers", {}).items():
+    args = srv.get("args", [])
+    if "--directory" in args:
+        i = args.index("--directory"); raw = args[i + 1].rstrip("/")
+        if raw.startswith("./"): raw = raw[2:]
+        if "/servers/" in raw: pkg = raw.rsplit("/servers/", 1)[1]
+        elif raw.startswith("servers/"): pkg = raw[len("servers/"):]
+        else: pkg = raw
+        args[i + 1] = f"{root}/servers/{pkg}"
+    if name == "clawdnd-engine":
+        srv.setdefault("env", {})["CLAWDND_STATE_DIR"] = state
+json.dump(cfg, open(out, "w"))
+PY
+
+# --- PLAYER MCP config: ONLY the Playwright palette server (strict, no other tools).
+# This is the constrained surface — the player sees ONLY the screen.
+python3 - "$PW_DIR" "$URL" "$PLAYERDIR" "$PW_CHANNEL" "$PERSONA" "$PLAYER_CFG" <<'PY'
+import json, sys
+pw_dir, url, rundir, channel, persona, out = sys.argv[1:7]
+json.dump({"mcpServers": {"clawdnd-uiplayer": {
+    "command": "node",
+    "args": [f"{pw_dir}/palette_server.js"],
+    "env": {
+        "CLAWDND_UIPT_URL": url,
+        "CLAWDND_UIPT_RUNDIR": rundir,
+        "CLAWDND_UIPT_CHANNEL": channel,
+        "CLAWDND_UIPT_PERSONA": persona,
+    },
+}}}, open(out, "w"))
+PY
+
+echo "[uipt] run=$RUN world=$WORLD persona=$PERSONA port=$PORT beats=$BEATS budget=\$$BUDGET"
+echo "[uipt] url=$URL"
+
+# --- start engine + viewer (move sink + chat wired) --------------------------
+CLAWDND_STATE_DIR="$STATE_DIR" WORLDOS_STATE_DIR="$STATE_DIR" \
+CLAWDND_VIEWER_CHAT="$CHAT" CLAWDND_PLAYER_MOVES="$MOVES" \
+  python3 viewer/server.py "" "$PORT" > "$RUNDIR/viewer.log" 2>&1 &
+VIEWER=$!
+cleanup() { kill "$VIEWER" 2>/dev/null; [ -n "${DMLOOP:-}" ] && kill "$DMLOOP" 2>/dev/null; }
+trap cleanup EXIT INT TERM
+
+# Wait for the viewer to answer /openworlds/ (200).
+ready=0
+for _ in $(seq 1 40); do
+  code="$(curl -s -o /dev/null -w '%{http_code}' "$URL" 2>/dev/null)"
+  [ "$code" = "200" ] && { ready=1; break; }
+  sleep 0.5
+done
+[ "$ready" = "1" ] || { echo "[uipt] viewer never became ready at $URL (see $RUNDIR/viewer.log)" >&2; exit 4; }
+echo "[uipt] viewer ready."
+
+# --- DM turn helper (claude -p, full plugin, resumed) ------------------------
+DSID="$(python3 -c 'import uuid;print(uuid.uuid4())')"
+DM_BRIEF="$(cat "$ROOT/qa/play_dm_duo.txt")"
+chatlog() { python3 -c 'import json,sys;open(sys.argv[1],"a").write(json.dumps({"role":sys.argv[2],"text":sys.argv[3]})+"\n")' "$CHAT" "$1" "$2"; }
+dm_turn() {
+  local first="$1" msg="$2" out resume=()
+  [ "$first" = "0" ] && resume=(--resume "$DSID") || resume=(--session-id "$DSID")
+  out="$RUNDIR/dm/turn.$(date +%s%N).jsonl"
+  claude -p "$msg" "${resume[@]}" --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+    --model "$DM_MODEL" --permission-mode bypassPermissions --max-budget-usd "$DM_BUDGET" \
+    --output-format stream-json --verbose > "$out" 2>> "$RUNDIR/dm/dm.err"
+  cat "$out" >> "$COMBINED"
+  jq -rs 'map(select(.type=="result"))[-1].result // ""' "$out" 2>/dev/null
+}
+
+# --- DM opens the scene so a LIVE, playable game exists (the launcher's Chronicles
+# shelf will then offer "Resume Chronicle", and /chat carries the opening narration).
+# Mirrors play_human.sh: seat a level-3 PC + a companion, open a personal scene. We do
+# NOT hardcode a specific canon PC (so this exercises #305: a dead character must not be
+# seated/offered). The newbie will discover + click into this game via the real launcher.
+echo "[uipt] DM opening the scene…"
+DMSG="$(dm_turn 1 "$DM_BRIEF
+
+Begin a SOLO session for a brand-new human player in this world: start_world(\"$WORLD\"), start_session, seat a fitting level-3 PLAYER CHARACTER (a LIVING canon figure via load_canon_character(kind=\"player\", add_to_party=true) — NEVER a dead/fallen character; apply sensible skills/spells), and bring in ONE roster companion the player meets in the scene. Then open a human-scale, personal scene with real quoted dialogue and hand the player an open moment + a clear choice. Their actions will arrive next as tagged moves.")"
+[ -z "$DMSG" ] && echo "[uipt] WARN: DM produced no opening (see $RUNDIR/dm/dm.err) — the player may land in a thin scene." >&2
+chatlog dm "${DMSG:-The scene is set. What do you do?}"
+
+# --- background DM-resolver loop: tail $MOVES, resolve each new move, append narration
+# to $CHAT (the UI shows it via /chat). Identical shape to play_human.sh's loop. Runs
+# until the harness kills it (player done / beats hit / budget out).
+(
+  MCURSOR="$(wc -l < "$MOVES" 2>/dev/null | tr -d ' ')"; MCURSOR="${MCURSOR:-0}"
+  while true; do
+    total="$(wc -l < "$MOVES" 2>/dev/null | tr -d ' ')"; total="${total:-0}"
+    if [ "$total" -gt "$MCURSOR" ]; then
+      new="$(tail -n +"$((MCURSOR + 1))" "$MOVES" 2>/dev/null)"; MCURSOR="$total"
+      PMSG="$(printf '%s' "$new" | jq -rs 'map("[\(.kind)] \(.text // .name // "")") | join("  ")' 2>/dev/null)"
+      [ -z "$PMSG" ] && continue
+      chatlog player "$PMSG"
+      DMSG="$(dm_turn 0 "The player does:
+
+$PMSG
+
+Resolve it through the engine (roll checks, apply casts/attacks, voice NPCs) and narrate the next beat as a played scene. Hand the moment back to the player.")"
+      chatlog dm "${DMSG:-...}"
+    else
+      sleep 2
+    fi
+  done
+) &
+DMLOOP=$!
+echo "[uipt] DM resolver loop up (pid $DMLOOP)."
+
+# --- PLAYER agent: blind newbie drives the real browser via the palette MCP only.
+# A single claude -p session: the persona brief + the action budget. The palette tools
+# log every screenshot/click/bug under $PLAYERDIR. We cap the run with a turn ceiling in
+# the prompt AND the agent's own --max-budget-usd; the palette also short-circuits on
+# give_up (writes status.json).
+PERSONA_BRIEF="$(cat "$PERSONA_FILE")"
+PSID="$(python3 -c 'import uuid;print(uuid.uuid4())')"
+echo "[uipt] player agent starting (persona=$PERSONA, max ~$BEATS actions)…"
+PLAYER_OUT="$RUNDIR/player/player.jsonl"
+claude -p "$PERSONA_BRIEF
+
+You have a budget of about $BEATS actions for this whole session. Spend them trying to start and play the story, reporting friction as you go. When you have either (a) genuinely gotten stuck after reporting it, or (b) played a few real turns and seen enough to judge the experience, you may stop — give a final 1-2 sentence verdict and, if you got stuck, call give_up. Start now." \
+  --session-id "$PSID" --mcp-config "$PLAYER_CFG" --strict-mcp-config \
+  --model "$PLAYER_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+  --output-format stream-json --verbose > "$PLAYER_OUT" 2>> "$RUNDIR/player/player.err"
+PLAYER_RC=$?
+echo "[uipt] player agent finished (rc=$PLAYER_RC)."
+
+# Final reply text (the player's verdict) for the summary.
+PLAYER_VERDICT="$(jq -rs 'map(select(.type=="result"))[-1].result // ""' "$PLAYER_OUT" 2>/dev/null)"
+PLAYER_COST="$(jq -rs '[.[]|select(.type=="result")|.total_cost_usd//0]|add // 0' "$PLAYER_OUT" 2>/dev/null)"
+
+# Stop the DM loop + viewer before scoring.
+kill "$DMLOOP" 2>/dev/null; DMLOOP=""
+kill "$VIEWER" 2>/dev/null
+
+# --- meta.json ---------------------------------------------------------------
+python3 - "$RUNDIR/meta.json" "$RUN" "$WORLD" "$PERSONA" "$PORT" "$BEATS" "$BUDGET" "$PLAYER_COST" "$PLAYER_RC" <<'PY'
+import json, sys, datetime
+out, run, world, persona, port, beats, budget, cost, rc = sys.argv[1:10]
+json.dump({
+    "run": run, "world": world, "persona": persona, "port": int(port),
+    "beats_cap": int(beats), "budget_usd": float(budget),
+    "player_cost_usd": round(float(cost or 0), 4), "player_rc": int(rc),
+    "finished_at": datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+}, open(out, "w"), indent=2)
+PY
+
+# --- score + summary ---------------------------------------------------------
+echo "[uipt] scoring + summarizing…"
+python3 "$ROOT/qa/ui_playtest_score.py" "$RUNDIR" "$PLAYER_VERDICT" 2>> "$RUNDIR/score.err"
+SCORE_RC=$?
+
+echo "[uipt] done. dir=$RUNDIR"
+if [ -f "$RUNDIR/summary.md" ]; then
+  echo "----- summary.md -----"; cat "$RUNDIR/summary.md"
+fi
+exit "$SCORE_RC"

--- a/qa/ui_playtest.sh
+++ b/qa/ui_playtest.sh
@@ -90,8 +90,10 @@ json.dump(cfg, open(out, "w"))
 PY
 
 # --- PLAYER MCP config: ONLY the Playwright palette server (strict, no other tools).
-# This is the constrained surface — the player sees ONLY the screen.
-python3 - "$PW_DIR" "$URL" "$PLAYERDIR" "$PW_CHANNEL" "$PERSONA" "$PLAYER_CFG" <<'PY'
+# This is the constrained surface — the player sees ONLY the screen. The palette treats
+# CLAWDND_UIPT_RUNDIR as the RUN ROOT (bugs.ndjson + status.json land there; screenshots/
+# a11y/action/console/network logs go under player/), so pass $RUNDIR, not $PLAYERDIR.
+python3 - "$PW_DIR" "$URL" "$RUNDIR" "$PW_CHANNEL" "$PERSONA" "$PLAYER_CFG" <<'PY'
 import json, sys
 pw_dir, url, rundir, channel, persona, out = sys.argv[1:7]
 json.dump({"mcpServers": {"clawdnd-uiplayer": {
@@ -214,7 +216,7 @@ json.dump({
     "run": run, "world": world, "persona": persona, "port": int(port),
     "beats_cap": int(beats), "budget_usd": float(budget),
     "player_cost_usd": round(float(cost or 0), 4), "player_rc": int(rc),
-    "finished_at": datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+    "finished_at": datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0, tzinfo=None).isoformat() + "Z",
 }, open(out, "w"), indent=2)
 PY
 

--- a/qa/ui_playtest_bug_schema.json
+++ b/qa/ui_playtest_bug_schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://worldos/qa/ui_playtest_bug_schema.json",
+  "title": "WorldOS UI playtest bug record",
+  "description": "One bug/UX finding emitted by the AI playtester (issue #324). bugs.ndjson holds one of these objects per line. Records come from the Player persona (source=player), the harness's passive console/network capture (source=auto), or a give_up (source=give_up).",
+  "type": "object",
+  "required": ["ts", "persona", "screen", "category", "severity", "title", "expected", "actual"],
+  "additionalProperties": true,
+  "properties": {
+    "ts": {
+      "type": "string",
+      "description": "ISO-8601 UTC timestamp (seconds precision)."
+    },
+    "action_seq": {
+      "type": "integer",
+      "description": "The palette action sequence number in effect when the bug was recorded."
+    },
+    "persona": {
+      "type": "string",
+      "description": "Persona slug for the run, e.g. 'newbie'."
+    },
+    "screen": {
+      "type": "string",
+      "description": "Best-effort current screen/area, e.g. 'launcher', 'table', 'forge', 'roster', 'character'."
+    },
+    "category": {
+      "type": "string",
+      "enum": ["ux", "bug", "content", "accessibility", "performance", "console", "network"],
+      "description": "Kind of finding. 'console'/'network' are auto-captured by the harness; the rest are persona-reported."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["critical", "major", "minor", "trivial"],
+      "description": "critical = blocks all play; major = blocks the current task; minor = annoying; trivial = cosmetic."
+    },
+    "title": {
+      "type": "string",
+      "description": "One-line summary of the problem."
+    },
+    "expected": {
+      "type": "string",
+      "description": "What a real user expected to happen."
+    },
+    "actual": {
+      "type": "string",
+      "description": "What actually happened."
+    },
+    "screenshot": {
+      "type": "string",
+      "description": "Run-relative path to the evidence screenshot, e.g. 'screenshots/step-012-bug.png'. May be empty."
+    },
+    "evidence": {
+      "type": "object",
+      "description": "Structured evidence for auto-captured findings (console_error, pageerror, network_failure, http_status).",
+      "additionalProperties": true
+    },
+    "tried_alternatives": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Other things the player tried before reporting."
+    },
+    "blocks_progress": {
+      "type": "boolean",
+      "description": "Whether this stopped the player from continuing."
+    },
+    "source": {
+      "type": "string",
+      "enum": ["player", "auto", "give_up"],
+      "description": "Origin of the record: the Player persona, the harness's passive capture, or a give_up."
+    }
+  }
+}

--- a/qa/ui_playtest_score.py
+++ b/qa/ui_playtest_score.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Score + summarize a WorldOS AI-playtest run (issue #324).
+
+Reads the run dir's artifacts (bugs.ndjson, actions.ndjson, console.ndjson,
+network.ndjson, status.json, meta.json) and writes:
+  - score.json   — the rubric metrics (completed_intro_flow, dead_clicks,
+                   console_errors, network_failures, bug counts by severity,
+                   self-reported satisfaction, pass/fail)
+  - summary.md   — a human-readable digest: what the newbie tried, where they got
+                   stuck, the top bugs, and the score.
+
+Pure reader: never imports the engine, never touches campaign state.
+
+Usage: ui_playtest_score.py <run-dir> [player-verdict-text]
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def read_ndjson(path: Path) -> list[dict]:
+    out: list[dict] = []
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+# A satisfaction number the player may have written in its final verdict
+# ("satisfaction: 4/10", "I'd rate this a 3 out of 10").
+def extract_satisfaction(text: str) -> int | None:
+    if not text:
+        return None
+    m = re.search(r"satisfaction[^0-9]{0,12}(\d{1,2})\s*/\s*10", text, re.I)
+    if m:
+        return clamp10(int(m.group(1)))
+    m = re.search(r"\b(\d{1,2})\s*(?:/|out of)\s*10\b", text, re.I)
+    if m:
+        return clamp10(int(m.group(1)))
+    return None
+
+
+def clamp10(n: int) -> int:
+    return max(1, min(10, n))
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: ui_playtest_score.py <run-dir> [verdict-text]", file=sys.stderr)
+        return 2
+    rundir = Path(sys.argv[1])
+    verdict = sys.argv[2] if len(sys.argv) > 2 else ""
+    playerdir = rundir / "player"
+
+    meta = read_json(rundir / "meta.json")
+    bugs = read_ndjson(rundir / "bugs.ndjson")
+    actions = read_ndjson(playerdir / "actions.ndjson")
+    console = read_ndjson(playerdir / "console.ndjson")
+    network = read_ndjson(playerdir / "network.ndjson")
+    status = read_json(playerdir / "status.json")
+
+    # --- action breakdown ----------------------------------------------------
+    action_kinds = Counter(a.get("action", "?") for a in actions)
+    clicks = [a for a in actions if a.get("action") == "click"]
+    dead_clicks = sum(1 for a in clicks if a.get("dead") is True)
+    type_submits = sum(1 for a in actions if a.get("action") == "type" and a.get("submit"))
+
+    # --- screens visited (from action stream) --------------------------------
+    screens = []
+    for a in actions:
+        s = a.get("screen")
+        if s and (not screens or screens[-1] != s):
+            screens.append(s)
+
+    # --- bug counts ----------------------------------------------------------
+    by_sev = Counter(b.get("severity", "?") for b in bugs)
+    by_screen = Counter(b.get("screen", "?") for b in bugs)
+    by_cat = Counter(b.get("category", "?") for b in bugs)
+    player_bugs = [b for b in bugs if b.get("source") == "player"]
+    auto_bugs = [b for b in bugs if b.get("source") == "auto"]
+
+    console_errors = sum(1 for c in console if c.get("type") in ("error", "pageerror"))
+    network_failures = len(network)
+
+    # --- completed intro flow? -----------------------------------------------
+    # Heuristic (no engine peek): the player reached the play screen ("table") AND
+    # submitted at least one in-story action (a typed+submitted turn or a [do]/[say]
+    # move that the table posts). "table" appearing in the visited screens or any
+    # type-with-submit both signal they got into the actual game.
+    reached_table = "table" in screens
+    completed_intro_flow = bool(reached_table and type_submits >= 1)
+
+    # actions to first in-story turn (first type+submit), informational.
+    actions_to_first_beat = None
+    for a in actions:
+        if a.get("action") == "type" and a.get("submit"):
+            actions_to_first_beat = a.get("seq")
+            break
+
+    gave_up = status.get("reason") == "give_up"
+
+    # --- satisfaction --------------------------------------------------------
+    satisfaction = extract_satisfaction(verdict)
+    if satisfaction is None:
+        # Derive a rough satisfaction when the player didn't state one: start at 8,
+        # subtract for the friction we measured. (Informational, clearly derived.)
+        s = 8
+        if not completed_intro_flow:
+            s -= 3
+        if gave_up:
+            s -= 2
+        s -= min(3, by_sev.get("critical", 0) * 2 + by_sev.get("major", 0))
+        s -= min(2, dead_clicks)
+        if console_errors:
+            s -= 1
+        satisfaction = clamp10(s)
+        satisfaction_source = "derived"
+    else:
+        satisfaction_source = "self-reported"
+
+    critical = by_sev.get("critical", 0)
+    major = by_sev.get("major", 0)
+    passed = bool(completed_intro_flow and critical == 0 and console_errors == 0 and satisfaction >= 6)
+
+    score = {
+        "run": meta.get("run"),
+        "persona": meta.get("persona"),
+        "world": meta.get("world"),
+        "completed_intro_flow": completed_intro_flow,
+        "reached_play_screen": reached_table,
+        "actions_total": len(actions),
+        "actions_to_first_beat": actions_to_first_beat,
+        "in_story_turns": type_submits,
+        "dead_clicks": dead_clicks,
+        "console_errors": console_errors,
+        "network_failures": network_failures,
+        "bug_reports_total": len(bugs),
+        "bug_reports_player": len(player_bugs),
+        "bug_reports_auto": len(auto_bugs),
+        "bug_reports_critical": critical,
+        "bug_reports_major": major,
+        "bug_reports_minor": by_sev.get("minor", 0),
+        "bug_reports_trivial": by_sev.get("trivial", 0),
+        "bugs_by_screen": dict(by_screen),
+        "bugs_by_category": dict(by_cat),
+        "action_kinds": dict(action_kinds),
+        "screens_visited": screens,
+        "gave_up": gave_up,
+        "give_up_reason": status.get("detail", ""),
+        "persona_satisfaction": satisfaction,
+        "satisfaction_source": satisfaction_source,
+        "player_cost_usd": meta.get("player_cost_usd"),
+        "pass": passed,
+    }
+    (rundir / "score.json").write_text(json.dumps(score, indent=2), encoding="utf-8")
+
+    # --- summary.md ----------------------------------------------------------
+    md = build_summary(score, bugs, verdict, meta)
+    (rundir / "summary.md").write_text(md, encoding="utf-8")
+    return 0
+
+
+def sev_rank(b: dict) -> int:
+    order = {"critical": 0, "major": 1, "minor": 2, "trivial": 3}
+    return order.get(b.get("severity", "minor"), 4)
+
+
+def build_summary(score: dict, bugs: list[dict], verdict: str, meta: dict) -> str:
+    L: list[str] = []
+    verd = "PASS" if score["pass"] else "FAIL"
+    L.append(f"# UI Playtest — {score.get('run')} ({score.get('persona')} on {score.get('world')})")
+    L.append("")
+    L.append(f"**Verdict: {verd}**  ·  satisfaction {score['persona_satisfaction']}/10 "
+             f"({score['satisfaction_source']})  ·  {score['actions_total']} actions  ·  "
+             f"~${score.get('player_cost_usd') or 0:.2f}")
+    L.append("")
+    L.append("Pass gate: reached the play screen + took an in-story turn, zero critical bugs, "
+             "zero console errors, satisfaction ≥ 6.")
+    L.append("")
+    L.append("## Did the first-timer get into the game?")
+    L.append("")
+    L.append(f"- Reached the play screen (table): **{yn(score['reached_play_screen'])}**")
+    L.append(f"- Completed intro flow (played a turn): **{yn(score['completed_intro_flow'])}**")
+    if score["actions_to_first_beat"] is not None:
+        L.append(f"- Actions to first in-story turn: **{score['actions_to_first_beat']}** "
+                 f"(newbie target ≤ 10)")
+    L.append(f"- In-story turns taken: **{score['in_story_turns']}**")
+    L.append(f"- Screens visited: {', '.join(score['screens_visited']) or '(none recorded)'}")
+    if score["gave_up"]:
+        L.append(f"- **Gave up:** {score['give_up_reason']}")
+    L.append("")
+    L.append("## Health signals")
+    L.append("")
+    L.append(f"- Dead clicks (landed but screen didn't change): **{score['dead_clicks']}** (target 0)")
+    L.append(f"- Console errors: **{score['console_errors']}** (target 0)")
+    L.append(f"- Failed/4xx-5xx network requests: **{score['network_failures']}** (target 0)")
+    L.append("")
+    L.append("## Bugs found")
+    L.append("")
+    L.append(f"- Total: **{score['bug_reports_total']}** "
+             f"(player-reported {score['bug_reports_player']}, auto-captured {score['bug_reports_auto']})")
+    L.append(f"- By severity: critical **{score['bug_reports_critical']}**, "
+             f"major **{score['bug_reports_major']}**, minor **{score['bug_reports_minor']}**, "
+             f"trivial **{score['bug_reports_trivial']}**")
+    if score["bugs_by_screen"]:
+        parts = ", ".join(f"{k} ({v})" for k, v in sorted(score["bugs_by_screen"].items(), key=lambda kv: -kv[1]))
+        L.append(f"- By screen: {parts}")
+    if score["bugs_by_category"]:
+        parts = ", ".join(f"{k} ({v})" for k, v in sorted(score["bugs_by_category"].items(), key=lambda kv: -kv[1]))
+        L.append(f"- By category: {parts}")
+    L.append("")
+    # Top bugs (worst severity first), capped.
+    ranked = sorted(bugs, key=lambda b: (sev_rank(b), b.get("action_seq", 0)))
+    if ranked:
+        L.append("### Top findings")
+        L.append("")
+        for b in ranked[:12]:
+            sev = b.get("severity", "?").upper()
+            scr = b.get("screen", "?")
+            title = b.get("title", "(untitled)")
+            L.append(f"- **[{sev}]** ({scr}) {title}")
+            exp = (b.get("expected") or "").strip()
+            act = (b.get("actual") or "").strip()
+            if exp:
+                L.append(f"    - expected: {exp}")
+            if act:
+                L.append(f"    - actual: {act}")
+            shot = b.get("screenshot")
+            if shot:
+                L.append(f"    - evidence: `{shot}`")
+        L.append("")
+    if verdict.strip():
+        L.append("## Player's closing verdict")
+        L.append("")
+        L.append("> " + verdict.strip().replace("\n", "\n> "))
+        L.append("")
+    L.append("---")
+    L.append(f"_Generated by qa/ui_playtest_score.py from {meta.get('run')}/. "
+             "Artifacts: player/screenshots/, player/a11y/, bugs.ndjson, actions.ndjson, "
+             "console.ndjson, network.ndjson._")
+    return "\n".join(L) + "\n"
+
+
+def yn(v) -> str:
+    return "yes" if v else "no"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/ui_playtest_score.py
+++ b/qa/ui_playtest_score.py
@@ -83,7 +83,20 @@ def main() -> int:
     action_kinds = Counter(a.get("action", "?") for a in actions)
     clicks = [a for a in actions if a.get("action") == "click"]
     dead_clicks = sum(1 for a in clicks if a.get("dead") is True)
-    type_submits = sum(1 for a in actions if a.get("action") == "type" and a.get("submit"))
+
+    # An in-story TURN is submitted either by type(submit=true) OR by clicking the table's
+    # submit control after typing — the UI exposes a "Declare" button + Do/Say/Continue
+    # chips, so a click on one of those (on the play screen) posts a /move just the same.
+    SUBMIT_CLICK = re.compile(r"\b(declare|send|submit|continue|^do\b|^say\b)\b", re.I)
+
+    def is_submit_action(a: dict) -> bool:
+        if a.get("action") == "type" and a.get("submit"):
+            return True
+        if a.get("action") == "click" and a.get("ok") and a.get("screen") == "table":
+            return bool(SUBMIT_CLICK.search(str(a.get("target") or "")))
+        return False
+
+    type_submits = sum(1 for a in actions if is_submit_action(a))
 
     # --- screens visited (from action stream) --------------------------------
     screens = []
@@ -99,8 +112,22 @@ def main() -> int:
     player_bugs = [b for b in bugs if b.get("source") == "player"]
     auto_bugs = [b for b in bugs if b.get("source") == "auto"]
 
-    console_errors = sum(1 for c in console if c.get("type") in ("error", "pageerror"))
-    network_failures = len(network)
+    # "Failed to load resource" console lines are just the browser echoing a failed fetch
+    # (already counted under network); a missing /image is graceful degradation, not a JS
+    # error. Exclude both from the console-error HEALTH metric so the gate isn't tripped by
+    # expected missing-art noise. (The raw lines stay in console.ndjson / network.ndjson.)
+    def is_resource_load(c: dict) -> bool:
+        return "Failed to load resource" in (c.get("text") or "")
+
+    console_errors = sum(
+        1 for c in console if c.get("type") in ("error", "pageerror") and not is_resource_load(c)
+    )
+
+    def is_image_404(n: dict) -> bool:
+        return n.get("status") == 404 and "/image?scope=" in (n.get("url") or "")
+
+    image_404s = sum(1 for n in network if is_image_404(n))
+    network_failures = sum(1 for n in network if not is_image_404(n))
 
     # --- completed intro flow? -----------------------------------------------
     # Heuristic (no engine peek): the player reached the play screen ("table") AND
@@ -110,10 +137,10 @@ def main() -> int:
     reached_table = "table" in screens
     completed_intro_flow = bool(reached_table and type_submits >= 1)
 
-    # actions to first in-story turn (first type+submit), informational.
+    # actions to first in-story turn (first submitted move), informational.
     actions_to_first_beat = None
     for a in actions:
-        if a.get("action") == "type" and a.get("submit"):
+        if is_submit_action(a):
             actions_to_first_beat = a.get("seq")
             break
 
@@ -154,6 +181,7 @@ def main() -> int:
         "dead_clicks": dead_clicks,
         "console_errors": console_errors,
         "network_failures": network_failures,
+        "image_404s": image_404s,
         "bug_reports_total": len(bugs),
         "bug_reports_player": len(player_bugs),
         "bug_reports_auto": len(auto_bugs),
@@ -214,6 +242,9 @@ def build_summary(score: dict, bugs: list[dict], verdict: str, meta: dict) -> st
     L.append(f"- Dead clicks (landed but screen didn't change): **{score['dead_clicks']}** (target 0)")
     L.append(f"- Console errors: **{score['console_errors']}** (target 0)")
     L.append(f"- Failed/4xx-5xx network requests: **{score['network_failures']}** (target 0)")
+    if score.get("image_404s"):
+        L.append(f"- Missing-image 404s (expected graceful degradation, not counted above): "
+                 f"**{score['image_404s']}**")
     L.append("")
     L.append("## Bugs found")
     L.append("")


### PR DESCRIPTION
## What this is

**Part of #324** — v1 of the AI playtester harness: a **blind UI/UX test**. A constrained
"player" agent drives the real `/openworlds/` browser UI with **no source-code access, no engine
introspection, no filesystem** — it sees only what's on screen and reports every bug + UX gap it
hits. This finds bugs by *trying to play*, a different signal from the code-reading audit.

Builds on the existing `qa/run_duo.sh` two-agent pattern. **The DM agent is unchanged** (same
`claude -p` DM + dungeon-master skill + engine MCP). What's new is the Player half: it gets a
**Playwright-backed MCP palette of exactly 8 tools** and nothing else.

## How the Playwright palette is wired

`qa/playwright/palette_server.js` is an MCP server that is the Player's *entire* tool surface
(mirroring the engine's constrained `player_server.py` facade — roles enforced in code, not prose).
Each tool is backed by a Playwright Chromium browser the server controls:

| tool | backing |
|---|---|
| `screenshot()` | `page.screenshot()` + the accessible text |
| `a11y_tree()` | `locator('body').ariaSnapshot()` (what a screen reader announces)* |
| `click(target)` | `getByRole`/`getByText` locator click; flags dead clicks (no screen change) |
| `type(text, target?, submit?)` | fill a field by label/placeholder; optional Enter |
| `key(name)` | `keyboard.press` |
| `wait(ms? selector?)` | `waitForTimeout` / `waitForSelector` (capped) |
| `report_bug({severity, screen, expected, actual, …})` | one line to `bugs.ndjson` |
| `give_up(reason)` | ends the run (`status.json`) |

\* The spec named `page.accessibility.snapshot()`; that API was removed in Playwright ≥ 1.5x, so we
use its modern successor `ariaSnapshot()` — same role/name/value/disabled tree.

The Player drives the UI → the UI POSTs `/move` → the **unchanged DM** resolves → narration flows
back onto the screen via `/chat`. The Player re-screenshots to see the result and decides the next
action. Console errors + failed/4xx-5xx requests are also **auto-captured** as bugs.

Because a plain browser has no native bridge, the harness pre-mints the live game (the DM's opening
turn seats a **living** canon PC + companion) so the launcher's "Resume Chronicle" path works. The
newbie discovers and clicks into the game through the **real launcher start-flow** — which is
exactly the flow that exercises #305 (a dead character must not be offered as a PC).

## Entrypoint

```sh
qa/ui_playtest.sh play1 baldurs-gate newbie 30 3.00
```

Produces under `qa/ui_playtest_runs/play1/`: per-beat **screenshots** (`player/screenshots/`),
**bugs.ndjson** (one bug/line, schema `qa/ui_playtest_bug_schema.json`), **summary.md**, and
**score.json**. Run artifacts are gitignored (public repo).

## Playwright install

Clean. Pinned `playwright@1.60.0` + `@modelcontextprotocol/sdk` + `zod` in a self-contained
`qa/playwright/` workspace (`package.json` + lockfile committed, `node_modules` gitignored).
Chromium installed via `npx playwright install chromium` (chromium only — ~92 MB; no full browser
set, given the disk constraint). `node_modules` ≈ 1 GB, gitignored.

---

## v1 run evidence (`qa/ui_playtest.sh play1 baldurs-gate newbie 30 3.00`)

**Verdict: FAIL** (correctly — 2 critical bugs) · the newbie reached the play screen and took 4
in-story turns, then **gave up** because the play loop dead-ended. satisfaction 1/10 (derived) ·
27 palette actions · ~$0.65 (player). Playwright installed cleanly (chromium-only, ~92 MB).

**Headline metrics** (`score.json`): `completed_intro_flow: true`, `reached_play_screen: true`,
`actions_to_first_beat: 12`, `in_story_turns: 4`, `dead_clicks: 2`, `console_errors: 0`,
`network_failures: 0`, `image_404s: 74` (collapsed to ONE trivial bug, not 74),
`bug_reports_total: 6` (4 player + 1 auto + 1 give-up) — **critical 2, major 2, trivial 2**.

**Artifacts produced:** 22 screenshots, 8 a11y dumps, `bugs.ndjson` (6 records), `summary.md`.

### Top bugs the blind newbie found (the point of the harness — recorded, not fixed here)

| # | Severity | Screen | Finding |
|---|----------|--------|---------|
| 1 | **Critical** | roster | "Begin a new chronicle" → pick hero → dead-end ("open this world in the WorldOS app") with no button/link to actually start playing |
| 2 | **Critical** | table | DM gives no response after an action / `Do` + `Say` buttons are dead → story frozen after the opening (no loading state; the resolver turn is slow) |
| 3 | **Major** | roster | Roster dumps **2,069 characters** on a first-timer — no starter/recommended guidance; list includes dead chars ("Alexander Rainforest: already dead"), an "Addled Frog", and enemy NPCs *(adjacent to #305)* |
| 4 | **Major** | — | Player gave up: "a beautiful stage set in front of them and no way to step onto it" |
| 5 | **Trivial** | table | Encounter action labels are doubled ("Continue Continue Explore", "Do Do Explore", …) |
| 6 | **Trivial** | launcher | Missing-image 404s (expected graceful degradation; collapsed into one informational bug) |

<details><summary>Full <code>summary.md</code> from the run</summary>

```markdown
# UI Playtest — play1 (newbie on baldurs-gate)

**Verdict: FAIL**  ·  satisfaction 1/10 (derived)  ·  27 actions  ·  ~$0.65

Pass gate: reached the play screen + took an in-story turn, zero critical bugs, zero console errors, satisfaction ≥ 6.

## Did the first-timer get into the game?

- Reached the play screen (table): **yes**
- Completed intro flow (played a turn): **yes**
- Actions to first in-story turn: **12** (newbie target ≤ 10)
- In-story turns taken: **4**
- Screens visited: launcher, roster, launcher, table
- **Gave up:** The core gameplay loop is broken in the browser. I reached the play screen and the DM delivered a beautiful opening scene, but after that: (1) clicking "Declare" after typing an action appended my text to the transcript but the DM never generated any reply — even after 20+ seconds; (2) the "Continue" button in the Encounter panel submitted but also got no DM reply; (3) the "Do" and "Say" action buttons are dead and do nothing; (4) the "Begin a new chronicle" path ended at a dead-end message tell

## Health signals

- Dead clicks (landed but screen didn't change): **2** (target 0)
- Console errors: **0** (target 0)
- Failed/4xx-5xx network requests: **0** (target 0)
- Missing-image 404s (expected graceful degradation, not counted above): **74**

## Bugs found

- Total: **6** (player-reported 4, auto-captured 1)
- By severity: critical **2**, major **2**, minor **0**, trivial **2**
- By screen: launcher (1), roster / Choose Your Hero (1), roster / Choose Your Hero (after clicking "Play as Alfira") (1), Table / play screen (Session tab) (1), Table / play screen — Encounter action buttons (1), table (1)
- By category: ux (3), bug (2), network (1)

### Top findings

- **[CRITICAL]** (roster / Choose Your Hero (after clicking "Play as Alfira")) After selecting a hero for a new chronicle, app shows a dead-end message with no button/link to actually start playing
    - expected: After picking my hero, I expected to be taken into the game — a play screen where the DM describes a scene and I can type my first action.
    - actual: A small text message appeared: "Selected Alfira as your hero. Live play starts from the WorldOS app — open this world there to begin the chronicle as Alfira." There is NO button to proceed, no link to this "WorldOS app," and no way to start playing from where I am. I am completely stuck in the browser with no path forward.
    - evidence: `player/screenshots/step-006-bug.png`
- **[CRITICAL]** (Table / play screen (Session tab)) DM never generates a response after player action — story frozen after opening scene
    - expected: After I type my action and click "Declare," the AI Dungeon Master should generate a new paragraph of story narration responding to what I did. That's the whole game.
    - actual: My action was appended to the transcript ("Vesper—I look at Minsc and say…") but the DM never replied. I waited 13+ seconds and tried clicking the "Continue" button as well — that also appended "Vesper—Continue" to the transcript with no DM response. The story is completely frozen after the opening scene.
    - evidence: `player/screenshots/step-019-bug.png`
- **[MAJOR]** (roster / Choose Your Hero) Roster dumps 2,069 characters on a first-timer with no beginner recommendation or onboarding guidance
    - expected: As a brand-new player who just clicked "Begin a new chronicle," I expected to either create my own hero from scratch, OR be shown a small set of recommended starter characters with clear guidance on who's good for beginners.
    - actual: I'm immediately presented with 2,069 characters in alphabetical order, no highlighted recommendations, no "good for beginners" tag, and no obvious default. The list includes dead characters (Alexander Rainforest: "already dead"), non-humanoid options (Addled Frog), and villain/enemy NPCs. There is zero guidance on who to pick first.
    - evidence: `player/screenshots/step-003-bug.png`
- **[MAJOR]** (table) Player gave up: The core gameplay loop is broken in the browser. I reached the play screen and t
    - expected: A first-timer can keep playing without getting stuck.
    - actual: The core gameplay loop is broken in the browser. I reached the play screen and the DM delivered a beautiful opening scene, but after that: (1) clicking "Declare" after typing an action appended my text to the transcript but the DM never generated any reply — even after 20+ seconds; (2) the "Continue" button in the Encounter panel submitted but also got no DM reply; (3) the "Do" and "Say" action buttons are dead and do nothing; (4) the "Begin a new chronicle" path ended at a dead-end message tell
    - evidence: `player/screenshots/step-026-giveup.png`
- **[TRIVIAL]** (launcher) Missing images (404 /image) — portraits/scene art not generated for this run
    - expected: Faces/art either render or degrade silently to a placeholder.
    - actual: Multiple /image 404s (expected with no cached art; first: http://127.0.0.1:8990/image?scope=portrait-char_e8a39a815ddb)
- **[TRIVIAL]** (Table / play screen — Encounter action buttons) Encounter action button labels have duplicated word ("Continue Continue Explore" instead of "Continue")
    - expected: Action button labels should each read once, e.g. "Continue," "Say," "Do," "Check."
    - actual: Each button label appears to be doubled: "Continue Continue Explore," "Say Say Explore," "Do Do Explore," "Check Check Explore," "Save Save Explore." The word is repeated before "Explore."
    - evidence: `player/screenshots/step-024-bug.png`

## Player's closing verdict

> **Playtest complete. Here's my verdict as a first-timer:**
> 
> The opening experience has real craft — the DM-written cold open for Vesper is genuinely gripping fiction. But the game is fundamentally unplayable in the browser as tested:
> 
> ---
> 
> **Bugs filed (4 total):**
> 
> | # | Severity | Title |
> |---|----------|-------|
> | 1 | **Major** | Roster dumps 2,069 characters on a first-timer with no beginner guidance |
> | 2 | **Critical** | "Begin a new chronicle" → select hero → dead-end message with no way to actually start playing |
> | 3 | **Critical** | DM never responds after player actions — story frozen after the opening scene |
> | 4 | **Trivial** | Encounter action button labels duplicated ("Continue Continue Explore") |
> 
> ---
> 
> **Summary:** The launcher and roster flows sent me down a dead end (select hero → told to use a different app, no link). The resume path gets you to the play screen, but the AI DM is silent after the opening — `Declare`, `Continue`, `Do`, and `Say` all either get no DM reply or are outright dead buttons. A first-timer has a beautiful stage set in front of them and no way to step onto it.

---
_Generated by qa/ui_playtest_score.py from play1/. Artifacts: player/screenshots/, player/a11y/, bugs.ndjson, actions.ndjson, console.ndjson, network.ndjson._
```

</details>


---

**Do not merge** — lead admin-merges on green CI. The bugs found here are the point (recorded, not
fixed in this PR — they become follow-up issues). Refs #242, #305–#320, STRATEGY.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added comprehensive automated UI playtesting infrastructure including documentation, configuration, and testing harness
  * Introduced tools for blind player simulation to test the application interface
  * Added scoring and bug tracking system to evaluate playtest results
  * Updated ignore rules for generated test artifacts

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->