### PR TITLE
fix(openworlds): in-browser play-entry + DM-narrating affordance (#326, #327)

### DIFF
--- a/viewer/openworlds/screen-launcher.jsx
+++ b/viewer/openworlds/screen-launcher.jsx
@@ -8,6 +8,17 @@ function ScreenLauncher({ onNavigate, state, setState }) {
   const [summonError, setSummonError] = React.useState("");
   const toast = window.useToast ? window.useToast() : (() => {});
   const active = campaigns.find((c) => c.id === selected) || campaigns[0] || null;
+  const hasBridge = Boolean(window.OpenWorldsNative?.hasBridge?.());
+  // #326: the in-browser play-entry. The catalog marks a session the engine can take moves for as
+  // `live` (its move sink is writable) and `canResume` (it is the attached, current run). When such
+  // a session exists — the #324 harness pre-mints exactly this, and a resumable save is the same —
+  // the player can step straight into the live table and play; the table's own /move + /chat loop
+  // carries it from there. We surface that as an unmistakable primary so a newbie is never left
+  // hunting (the old launcher led with "Begin a new chronicle", which dead-ends without the app).
+  const playableCampaign =
+    campaigns.find((c) => c.live && c.canResume) ||
+    campaigns.find((c) => c.canResume) ||
+    null;
 
   React.useEffect(() => {
     if (campaigns.some((c) => c.id === selected)) return;
@@ -69,8 +80,30 @@ function ScreenLauncher({ onNavigate, state, setState }) {
     startPlay(c?.world);
   };
 
+  // #326: drop straight into the live table for an already-playable session. Unlike startPlay
+  // (which, in the native app, mints a NEW provider session), this binds the table to an EXISTING
+  // live/resumable chronicle and navigates there — the only step a browser player needs, since the
+  // session and its DM already exist. Used by the in-browser "Continue / Resume → play" primary.
+  const enterPlayable = (c) => {
+    const target = c || playableCampaign;
+    if (!target) return;
+    setState((s) => ({ ...s, activeCampaign: target.id }));
+    onNavigate("table");
+  };
+
   return (
     <div className="screen" style={{ padding: "32px 40px 48px", minHeight: "100%" }}>
+      {/* #326: a can't-miss in-browser play-entry. When a live/resumable session exists, this is
+          the FIRST thing the player sees — clicking it drops straight into the live table (no app,
+          no bridge needed; the session + DM already exist). This is the affordance the #324 newbie
+          was missing when they instead clicked "Begin a new chronicle" and hit the app-only wall. */}
+      {playableCampaign && (
+        <ContinueBanner
+          campaign={playableCampaign}
+          onEnter={() => enterPlayable(playableCampaign)}
+        />
+      )}
+
       <div style={{ display: "grid", gridTemplateColumns: "1.15fr 1fr", gap: 36, alignItems: "start" }}>
 
         {/* LEFT: Hero with title plate */}
@@ -168,6 +201,19 @@ function ScreenLauncher({ onNavigate, state, setState }) {
                 <span style={{ fontSize: 22, color: "var(--crimson)", lineHeight: 1 }}>✦</span>
                 <span>Begin a new chronicle</span>
               </button>
+              {/* #326: be honest, not silent. Starting a BRAND-NEW chronicle mints a fresh DM
+                  provider session — only the desktop app can do that (it has the supervisor
+                  bridge). In a plain browser there is no DM to attach, so picking a hero through
+                  here can't begin play (the roster says so too). Say it up-front rather than
+                  letting a newbie walk into the dead-end. (If a live/resumable session exists,
+                  the Continue banner above is their way in.) */}
+              {!hasBridge && (
+                <div className="hand muted" style={{ fontSize: 12, lineHeight: 1.4, padding: "0 4px" }}>
+                  {playableCampaign
+                    ? "Browsing heroes here is fine — to actually start a NEW chronicle you'll need the WorldOS desktop app. To keep playing now, use Continue above."
+                    : "Starting a new chronicle needs the WorldOS desktop app (it spins up the Dungeon Master). You can still browse the roster here."}
+                </div>
+              )}
             </div>
           </div>
         </div>
@@ -272,18 +318,32 @@ function ScreenLauncher({ onNavigate, state, setState }) {
                     </p>
                   </div>
 
-                  {/* CTA bar */}
-                  <div style={{
-                    marginTop: 24, paddingTop: 16,
-                    borderTop: "1px solid rgba(140,100,60,0.3)",
-                    display: "flex", gap: 8,
-                  }}>
-                    <BrassButton onClick={onResume} size="lg" style={{ flex: 1 }} disabled={summoning}>
-                      {summoning ? "Summoning the Dungeon Master…" : (c.canResume ? "Resume Chronicle" : "View Chronicle")}
-                    </BrassButton>
-                    <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("character")}>Roster</BrassButton>
-                    <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("journal")}>Journal</BrassButton>
-                  </div>
+                  {/* CTA bar. #326: in a plain browser a resumable session is played by entering
+                      the live table directly (enterPlayable) — no provider to "summon", so don't
+                      mislabel it. In the native app, Resume mints/attaches a provider via the
+                      bridge (onResume → startProviderSession). A non-resumable card is read-only. */}
+                  {(() => {
+                    const browserPlayable = !hasBridge && c.canResume && c.live;
+                    const onCta = browserPlayable ? () => enterPlayable(c) : onResume;
+                    const label = summoning
+                      ? "Summoning the Dungeon Master…"
+                      : browserPlayable
+                        ? "Continue Chronicle"
+                        : (c.canResume ? "Resume Chronicle" : "View Chronicle");
+                    return (
+                      <div style={{
+                        marginTop: 24, paddingTop: 16,
+                        borderTop: "1px solid rgba(140,100,60,0.3)",
+                        display: "flex", gap: 8,
+                      }}>
+                        <BrassButton onClick={onCta} size="lg" style={{ flex: 1 }} disabled={summoning}>
+                          {label}
+                        </BrassButton>
+                        <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("character")}>Roster</BrassButton>
+                        <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("journal")}>Journal</BrassButton>
+                      </div>
+                    );
+                  })()}
                   {summonError && (
                     <div className="hand" style={{ color: "var(--crimson)", fontSize: 13, marginTop: 10 }}>
                       {summonError}
@@ -301,6 +361,43 @@ function ScreenLauncher({ onNavigate, state, setState }) {
         setShowNew(false);
         startPlay(c.world);
       }} />}
+    </div>
+  );
+}
+
+// #326: the unmistakable in-browser "Continue / Resume → play" primary. Shown at the very top of
+// the launcher whenever a live/resumable session exists (the #324 harness, or any resumable save).
+// Clicking it binds the table to this chronicle and drops the player straight into the live loop —
+// the single click the browser player needs, since the session + DM already exist. A live session
+// gets the brighter "Continue" treatment; a resumable-but-idle save says "Resume".
+function ContinueBanner({ campaign, onEnter }) {
+  const isLive = Boolean(campaign?.live);
+  const region = campaignRegion(campaign);
+  return (
+    <div
+      style={{
+        display: "flex", alignItems: "center", gap: 20,
+        padding: "18px 24px", marginBottom: 28,
+        background: "linear-gradient(180deg, var(--p-100), var(--p-300))",
+        boxShadow: "inset 0 0 0 1px var(--b-500), inset 0 0 0 4px var(--p-100), inset 0 0 0 5px var(--b-400), 0 8px 18px rgba(0,0,0,0.35)",
+      }}
+    >
+      <Img scope={campaign?.imageScope || ""} label={`scene · ${region.toLowerCase()}`} w={92} h={64} framed fit="cover" />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div className="eyebrow" style={{ color: "var(--crimson)", display: "flex", alignItems: "center", gap: 8 }}>
+          <Pill tone={isLive ? "emerald" : "royal"} dot={isLive}>{isLive ? "Live now" : "Ready to resume"}</Pill>
+          <span>Your chronicle awaits</span>
+        </div>
+        <div style={{ fontFamily: "var(--f-display)", fontSize: 22, color: "var(--ink-900)", letterSpacing: "0.04em", marginTop: 4, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+          {campaign?.title || "Open Worlds"}
+        </div>
+        <div className="hand" style={{ fontSize: 14, color: "var(--ink-700)", marginTop: 2 }}>
+          {campaign?.subtitle || region}
+        </div>
+      </div>
+      <BrassButton onClick={onEnter} size="lg">
+        {isLive ? "Continue → play" : "Resume → play"}
+      </BrassButton>
     </div>
   );
 }
@@ -514,4 +611,4 @@ function SegRadio({ value, onChange, options }) {
   );
 }
 
-Object.assign(window, { ScreenLauncher, Stat, CampaignRow, PartyPortrait, NewCampaignModal, FormField, SegRadio, inkInput });
+Object.assign(window, { ScreenLauncher, ContinueBanner, Stat, CampaignRow, PartyPortrait, NewCampaignModal, FormField, SegRadio, inkInput });

--- a/viewer/openworlds/screen-roster.jsx
+++ b/viewer/openworlds/screen-roster.jsx
@@ -140,6 +140,14 @@ function ScreenRoster({ onNavigate, state, setState }) {
   const campaignId = campaigns.some((c) => c.id === state?.activeCampaign)
     ? state.activeCampaign
     : (campaigns[0]?.id || "");
+  const hasBridge = Boolean(window.OpenWorldsNative?.hasBridge?.());
+  // #326: an already-playable session (live + resumable) the browser player can enter directly,
+  // mirroring the launcher. Without the desktop bridge a NEW hero bind can't mint a DM session,
+  // so if such a session exists we redirect the player to CONTINUE it rather than dead-ending.
+  const playableCampaign =
+    campaigns.find((c) => c.live && c.canResume) ||
+    campaigns.find((c) => c.canResume) ||
+    null;
 
   const [race, setRace] = React.useState("");
   const [klass, setKlass] = React.useState("");
@@ -204,14 +212,23 @@ function ScreenRoster({ onNavigate, state, setState }) {
   const playAs = async (npc) => {
     if (summoningName) return;
     setBindNote("");
-    if (!window.OpenWorldsNative?.hasBridge?.()) {
-      // FOLLOW-UP (flagged): a browser-only preview has no supervisor to mint the session. The
-      // native path is the supported bind; here we surface the chosen hero so the flow is honest.
+    if (!hasBridge) {
+      // #326: a browser-only preview has no supervisor to mint a NEW session for a freshly-picked
+      // hero. Don't dead-end. If a live/resumable chronicle already exists (the #324 harness case),
+      // send the player there to actually PLAY; otherwise be honest that a new chronicle needs the
+      // desktop app — never a silent nothing.
+      if (playableCampaign) {
+        setState((s) => ({ ...s, activeCampaign: playableCampaign.id }));
+        toast({ kind: "info", title: "Continuing your live chronicle", body: "A session is already in progress — dropping you into the table." });
+        onNavigate("table");
+        return;
+      }
       setBindNote(
-        `Selected ${npc.name} as your hero. Live play starts from the WorldOS app — ` +
-        `open this world there to begin the chronicle as ${npc.name}.`
+        `Picking ${npc.name} as a brand-new hero starts a fresh chronicle, which needs the ` +
+        `WorldOS desktop app (it spins up the Dungeon Master). In this browser preview you can ` +
+        `browse the roster, but you can't begin a new chronicle here.`
       );
-      toast({ kind: "info", title: `Chosen: ${npc.name}`, body: "Start live play from the WorldOS app to embody this hero." });
+      toast({ kind: "info", title: `Chosen: ${npc.name}`, body: "Starting a new chronicle needs the WorldOS desktop app." });
       return;
     }
     setSummoningName(npc.name);

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -15,6 +15,14 @@ function ScreenTable({ onNavigate, state, setState }) {
   const [chatBeats, setChatBeats] = React.useState([]);
   const chatCursor = React.useRef(0);
   const [input, setInput] = React.useState("");
+  // #327: a visible "DM is narrating…" affordance. The unchanged DM's opening / resolving turn
+  // can take many minutes; without this the play loop reads as frozen the moment a move is sent.
+  // `pending` holds the submitted line + when it was sent; it is set the instant /move succeeds
+  // and cleared when a NEW DM narration beat lands via /chat (tracked by dmBeatCount below) — or
+  // by a long safety timeout so a dropped beat can never wedge the bar shut forever.
+  const [pending, setPending] = React.useState(null);
+  const dmBeatCountRef = React.useRef(0);
+  const pendingTimer = React.useRef(null);
   const logRef = React.useRef(null);
   const inputRef = React.useRef(null);
   const toast = window.useToast ? window.useToast() : (() => {});
@@ -86,6 +94,13 @@ function ScreenTable({ onNavigate, state, setState }) {
             ? { kind: "dialog", who: "You", text: it.text }
             : { kind: "narration", text: it.text });
           setChatBeats((prev) => [...prev, ...beats]);
+          // #327: a fresh DM narration beat means the turn resolved — clear the pending indicator
+          // so the action bar re-opens and the spinner stops. (Player echoes don't count.)
+          const dmArrived = beats.some((b) => b.kind === "narration");
+          if (dmArrived) {
+            dmBeatCountRef.current += beats.filter((b) => b.kind === "narration").length;
+            setPending(null);
+          }
         }
         if (!isCancelled() && typeof cPayload.next === "number") chatCursor.current = cPayload.next;
       }
@@ -137,10 +152,20 @@ function ScreenTable({ onNavigate, state, setState }) {
     if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
   }, [visibleLog]);
 
+  // #327: arm the "DM is narrating…" pending state when a move is accepted, and a safety
+  // auto-clear so a missed /chat beat can't lock the bar forever (the DM turn is long but
+  // bounded). The /chat poll clears `pending` the instant a new DM narration beat arrives.
+  const armPending = (text) => {
+    setPending({ text, since: Date.now() });
+    if (pendingTimer.current) window.clearTimeout(pendingTimer.current);
+    pendingTimer.current = window.setTimeout(() => setPending(null), 12 * 60 * 1000);
+  };
+  React.useEffect(() => () => { if (pendingTimer.current) window.clearTimeout(pendingTimer.current); }, []);
+
   const postMove = async (move, label, actionId) => {
     const enabledAction = actionId ? enabledActionById(actionId) : null;
-    if (!move || !canAct || (actionId && !enabledAction)) {
-      toast({ kind: "danger", title: "Action unavailable", body: readOnlyReason });
+    if (!move || !canAct || pending || (actionId && !enabledAction)) {
+      toast({ kind: "danger", title: "Action unavailable", body: pending ? "The Dungeon Master is still narrating — one move at a time." : readOnlyReason });
       return;
     }
     const text = label || move.text || move.name || "declares an action";
@@ -155,6 +180,7 @@ function ScreenTable({ onNavigate, state, setState }) {
         throw new Error(payload.reason || `move ${response.status}`);
       }
       setLog((l) => [...l, { kind: "action", who: hero.name, text }]);
+      armPending(text);
       loadSurface();
     } catch (error) {
       toast({ kind: "danger", title: "Move not sent", body: error?.message || `The viewer could not reach ${writeLane.endpoint || "/move"}.` });
@@ -162,6 +188,7 @@ function ScreenTable({ onNavigate, state, setState }) {
   };
 
   const sendAction = async () => {
+    if (pending) return;
     const text = input.trim();
     if (!text) return;
     const action = actionById("do");
@@ -183,6 +210,10 @@ function ScreenTable({ onNavigate, state, setState }) {
   };
 
   const invokeAction = (action) => {
+    if (pending) {
+      toast({ kind: "danger", title: "Action unavailable", body: "The Dungeon Master is still narrating — one move at a time." });
+      return;
+    }
     if (!action?.available) {
       toast({ kind: "danger", title: action?.label || "Action unavailable", body: action?.disabled_reason || readOnlyReason });
       return;
@@ -276,6 +307,7 @@ function ScreenTable({ onNavigate, state, setState }) {
             {visibleLog.length ? visibleLog.map((entry, i) => (
               <LogEntry key={entry.id || `${entry.kind || "n"}-${i}`} entry={entry} />
             )) : <div className="body-sm muted">No moves yet</div>}
+            {pending && <DmNarratingBeat />}
           </div>
 
           {/* Action bar */}
@@ -286,10 +318,10 @@ function ScreenTable({ onNavigate, state, setState }) {
                 {hero.name}
               </strong>
               <div style={{ flex: 1 }} />
-              <button onClick={() => requestRoll(20)} className="btn ghost sm" disabled={!actionById("check")?.available}>{window.OpenWorldsIcon?.has?.("dice.d20") && <window.OpenWorldsIcon id="dice.d20" size={13} />} d20</button>
-              <button onClick={() => requestRoll(12)} className="btn ghost sm" disabled={!actionById("check")?.available}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d12</button>
-              <button onClick={() => requestRoll(8)} className="btn ghost sm" disabled={!actionById("check")?.available}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d8</button>
-              <button onClick={() => requestRoll(6)} className="btn ghost sm" disabled={!actionById("check")?.available}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d6</button>
+              <button onClick={() => requestRoll(20)} className="btn ghost sm" disabled={!actionById("check")?.available || Boolean(pending)}>{window.OpenWorldsIcon?.has?.("dice.d20") && <window.OpenWorldsIcon id="dice.d20" size={13} />} d20</button>
+              <button onClick={() => requestRoll(12)} className="btn ghost sm" disabled={!actionById("check")?.available || Boolean(pending)}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d12</button>
+              <button onClick={() => requestRoll(8)} className="btn ghost sm" disabled={!actionById("check")?.available || Boolean(pending)}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d8</button>
+              <button onClick={() => requestRoll(6)} className="btn ghost sm" disabled={!actionById("check")?.available || Boolean(pending)}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d6</button>
             </div>
             <div style={{ display: "flex", gap: 10 }}>
               <input
@@ -297,10 +329,11 @@ function ScreenTable({ onNavigate, state, setState }) {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && sendAction()}
-                placeholder={canAct ? "Describe what your hero does..." : `Read-only: ${readOnlyReason}`}
-                style={{ ...inkInput, fontFamily: "var(--f-body)", fontSize: 16 }}
+                disabled={Boolean(pending)}
+                placeholder={pending ? "The Dungeon Master is narrating…" : (canAct ? "Describe what your hero does..." : `Read-only: ${readOnlyReason}`)}
+                style={{ ...inkInput, fontFamily: "var(--f-body)", fontSize: 16, opacity: pending ? 0.6 : 1 }}
               />
-              <BrassButton onClick={sendAction} disabled={!actionById("do")?.available}>Declare</BrassButton>
+              <BrassButton onClick={sendAction} disabled={!actionById("do")?.available || Boolean(pending)}>{pending ? "Narrating…" : "Declare"}</BrassButton>
             </div>
           </div>
         </Panel>
@@ -384,7 +417,7 @@ function ScreenTable({ onNavigate, state, setState }) {
                 label={a.label}
                 detail={a.available ? a.groupLabel : a.disabled_reason}
                 tone={a.available ? (a.group === "combat" ? "royal" : "") : "crimson"}
-                disabled={!a.available}
+                disabled={!a.available || Boolean(pending)}
                 onClick={() => invokeAction(a)}
               />
             ))}
@@ -537,7 +570,43 @@ function LogEntry({ entry }) {
   );
 }
 
-Object.assign(window, { ScreenTable, PartyRow, ConditionRow, LogEntry });
+// #327: the persistent "DM is narrating…" beat shown in the chronicle while a submitted move is
+// being resolved. The DM's turn is long (minutes), so this is the difference between "the world
+// is thinking" and "the app froze". Mirrors the narration LogEntry's gilt-rule styling, with a
+// gentle pulsing trio of dots (honored only when reduced-motion is off). aria-live so a screen
+// reader announces the wait too.
+function DmNarratingBeat() {
+  return (
+    <div role="status" aria-live="polite" style={{ margin: "14px 0", display: "flex", gap: 12, opacity: 0.92 }}>
+      <div style={{ width: 4, alignSelf: "stretch", background: "linear-gradient(180deg, var(--crimson), transparent)" }} />
+      <div className="body" style={{ flex: 1, display: "flex", alignItems: "center", gap: 10 }}>
+        <span className="eyebrow" style={{ color: "var(--crimson)" }}>The Dungeon Master is narrating</span>
+        <span className="dm-narrating-dots" aria-hidden="true" style={{ display: "inline-flex", gap: 4 }}>
+          {[0, 1, 2].map((i) => (
+            <span key={i} style={{
+              width: 6, height: 6, borderRadius: "50%", background: "var(--b-400)",
+              animation: "dmNarratePulse 1200ms ease-in-out infinite", animationDelay: `${i * 200}ms`,
+            }} />
+          ))}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// Keyframes + reduced-motion fallback, injected once (the OpenWorlds bundle is in-browser Babel,
+// so a tiny self-contained <style> keeps this affordance from needing a styles.css round-trip).
+(function ensureDmNarrateStyle() {
+  if (typeof document === "undefined" || document.getElementById("dm-narrate-style")) return;
+  const el = document.createElement("style");
+  el.id = "dm-narrate-style";
+  el.textContent =
+    "@keyframes dmNarratePulse{0%,80%,100%{opacity:0.25;transform:scale(0.8)}40%{opacity:1;transform:scale(1)}}" +
+    "html[data-reduced-motion='on'] .dm-narrating-dots span{animation:none!important;opacity:0.7}";
+  document.head.appendChild(el);
+})();
+
+Object.assign(window, { ScreenTable, PartyRow, ConditionRow, LogEntry, DmNarratingBeat });
 
 function EncounterButton({ icon, label, detail, tone, onClick, disabled }) {
   const iconNode = window.OpenWorldsIcon?.has?.(icon)


### PR DESCRIPTION
Closes #326
Closes #327

Two P0 play-loop **entrance** blockers surfaced by the #324 AI playtester (run `play1`, newbie persona). Built on `origin/main` @ `abe5035` (the #324/#325 harness merge).

Both bugs are in the OpenWorlds **viewer UI** (`viewer/openworlds/*.jsx`). I validated up-front that the engine + browser wiring is already correct — so these are honest UI fixes, not contract changes.

---

## #326 — in-browser "Begin a new chronicle" dead-ends

### Confirmed root cause
- The launcher's prominent left-column entries are **"Forge a new hero"** and **"Begin a new chronicle"**. "Begin a new chronicle" → `onNavigate("roster")` → pick a hero → `playAs()`. In a plain browser (`!hasBridge`), `playAs`'s no-bridge branch only set a note — *"Live play starts from the WorldOS app"* — and returned. **That is the silent dead-end the newbie hit, then `give_up`'d.** (`screen-roster.jsx` L204-216)
- **"Resume Chronicle" already worked in-browser** — `onResume → startPlay`, whose no-bridge path is `onNavigate("table")` — but it's a small secondary CTA on the right detail panel that the newbie never discovered, and it only renders when `canResume`.
- **The engine/browser path is correct** (validated empirically against a harness-style seeded session): a pre-minted/resumable session reports `live:true, canResume:true, current:true` in `campaigns.json`; `/session-surface` returns `can_act:true` (the viewer auto-follows the attached campaign, `pinned=false`); `do/say/check` actions are `available`; and **`POST /move` returns `{ok:true}` + lands in the move sink** while `/chat` returns DM narration with `live:true`. So a browser player CAN reach and drive the loop — they just had no obvious way in.

### Fix (smallest correct + honest)
- **`ContinueBanner`** (new) — when a playable session exists (`live && canResume`, or any resumable save as fallback), the launcher now **leads** with an unmistakable full-width primary: *"Live now · Your chronicle awaits · **Continue → play**"*. Clicking it binds the table to that chronicle (`enterPlayable`) and drops the player straight into the live loop. This is the affordance the harness/newbie was missing.
- **Right-panel CTA** — in-browser, a playable card routes through `enterPlayable` and reads **"Continue Chronicle"** (no misleading *"Summoning the Dungeon Master…"*; there's no provider to summon — the session already exists). The native app keeps the `startProviderSession` mint path.
- **Roster no-bridge branch** — instead of dead-ending, if a live/resumable chronicle exists it **redirects into the live table**; otherwise it states plainly that *starting a NEW chronicle needs the WorldOS desktop app*. Never a silent nothing.
- **"Begin a new chronicle"** now carries an honest sub-label when there's no bridge (new chronicles need the desktop app; you can still browse the roster / use Continue).

> Verdict on "is new-chronicle intentionally app-only?": **yes** — minting a fresh DM provider session requires the desktop supervisor bridge. The genuine gap was the missing in-browser **Continue/Resume** entry + the silent dead-end, which is what this fixes. Engine stays the sole writer; the viewer only reads surfaces + POSTs `/move`.

---

## #327 — after submitting an action, the loop looks frozen

### Confirmed root cause
- `screen-table.jsx` `postMove()` POSTed the move and appended the player's **own** line, then polled — but there was **no pending/loading affordance anywhere** (confirmed: no "narrating" indicator existed in any OpenWorlds `.jsx`). The unchanged DM's Act-1 turn takes ~5–8 min, so the UI read as frozen.
- The open questions from the issue, answered: **(a)** there was no loading affordance; **(b)** browser-submitted moves *do* reach the DM and the reply *does* render via `/chat` — so the only defect was the missing indicator.

### Fix
- A persistent **"The Dungeon Master is narrating…"** beat (gilt-rule styling + gently pulsing dots, `role="status"`/`aria-live`, reduced-motion aware) shown in the chronicle the instant a move posts.
- The action bar is **disabled while pending**: input shows the narrating placeholder, **Declare → "Narrating…"**, and the dice + encounter-action buttons all disable — so a newbie can't spam moves at a busy DM.
- Pending **clears the moment a new DM narration beat lands** via `/chat`, with a **12-min safety auto-clear** so a dropped beat can never wedge the bar shut.

---

## Validation (host-aware — no full engine pytest locally, per repo policy → CI)

Headless **Playwright** against `viewer/server.py` on an isolated port, seeded harness-style (`CLAWDND_PLAYER_MOVES` + `CLAWDND_VIEWER_CHAT` set, a canon fixture campaign, a DM opening beat in the chat log). Did **not** run the full `play2` DM loop (5–8 min/turn, host moderately loaded) — used a targeted repro that drives the exact UI ↔ engine ↔ chat seam instead.

Empirically confirmed:
- `campaigns.json` → `live:true, canResume:true`; `/session-surface` → `can_act:true`; `POST /move` → `{ok:true}` + appended to the move sink; `/chat` → opening beat with `live:true`.
- **Launcher** shows the **Continue → play** banner; clicking it lands on **The Session** (table) with a live action bar.
- **Submit** → player line echoed, **"The Dungeon Master is narrating…"** beat shown, input **disabled** ("…is narrating…" placeholder), **Declare→"Narrating…"** + all dice **disabled**.
- **DM responds** (narration beat appended to `/chat`) → narrating beat **clears**, DM prose renders, action bar **re-enables** for the next turn.
- **Roster** "Play as <hero>" (no bridge, live session present) → **redirects into the live table** (old "Live play starts from the WorldOS app" dead-end gone).

All three changed `.jsx` files transpile cleanly under the vendored in-browser Babel.

### Scope / constraints honored
- 3 files touched: `screen-launcher.jsx`, `screen-roster.jsx`, `screen-table.jsx`. Viewer stays a pure reader (reads surfaces, POSTs `/move`); engine remains the sole writer.
- No wire-contract changes (`CLAWDND_*` env, `clawdnd-*` MCP ids, bundle id). No assets / nothing under `_private/`. Run artifacts live outside the repo (`/tmp`), and `/qa/ui_playtest_runs/` + `/qa/playwright/node_modules/` are already gitignored.

Please admin-merge on green CI (not merging here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser players can now continue or resume existing campaigns directly in-app
  * Added visual "DM is narrating" indicator with blocked action submission during DM narration

* **Improvements**
  * Clearer messaging when starting new campaigns requires the desktop app
  * Action buttons disabled while waiting for DM narration to prevent conflicting submissions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->