### PR TITLE
feat(qa): #324 v2 — 4 personas + cross-persona scoring aggregator (Part of #324)

### DIFF
--- a/qa/UI_PLAYTEST.md
+++ b/qa/UI_PLAYTEST.md
@@ -4,7 +4,8 @@ A **blind UI/UX test**: an AI "player" drives the real `/openworlds/` browser UI
 source-code access and reports every bug + UX gap it hits. Different signal from the
 code-reading audit — this finds bugs by *trying to play*.
 
-This is v1: **one persona (The First-Timer), Playwright, a single end-to-end run.**
+v1 shipped **one persona (The First-Timer)**, Playwright, a single end-to-end run.
+**v2 adds the other four personas + a cross-persona scoring aggregator** (issue #324).
 
 ## Run it
 
@@ -16,9 +17,27 @@ qa/ui_playtest.sh play1 baldurs-gate newbie 30 3.00
 
 - `runid`   — names the output dir `qa/ui_playtest_runs/<runid>/` (wiped + recreated).
 - `world`   — world id seeded for the session (e.g. `baldurs-gate`).
-- `persona` — picks `qa/play_player_browser_<persona>.txt` (v1 ships `newbie`).
+- `persona` — picks `qa/play_player_browser_<persona>.txt`. The runner dispatches purely by
+              this name (line 40), so adding a persona is just adding its brief file.
 - `beats`   — soft cap on the number of Player **palette actions**.
 - `budget`  — USD cap for the **Player** `claude -p` process.
+
+### The five personas (v2)
+
+Each persona is a self-contained brief over the **same** 8-tool palette; only the player's
+mindset + bug-hunting focus differs. They are designed so the bugs they hit *overlap* — a
+defect every persona reports is the highest-priority one (see the aggregator below).
+
+| persona | brief | what it hunts |
+|---|---|---|
+| `newbie` | `play_player_browser_newbie.txt` | first-timer onboarding: can a blind new player reach + sustain play? jargon, dead buttons, getting-stuck. |
+| `veteran` | `play_player_browser_veteran.txt` | BG3 affordance gaps: hotbar / action economy, character-sheet depth, equipment paper-doll + compare, tactical combat (movement/spell-area preview), approval/subclass. |
+| `adversarial` | `play_player_browser_adversarial.txt` | tries to BREAK it: dead/lying controls, rapid/double-fire, empty/huge/markup input, navigate-away mid-DM-turn, modal traps, state corruption. |
+| `narrative` | `play_player_browser_narrative.txt` | story-first / menu-averse: immersion breaks, DM-internal leaks, lifeless NPC dialogue, jargon tabs that pull you out of the fiction. |
+| `optimizer` | `play_player_browser_optimizer.txt` | data depth: complete bestiary stat blocks, deep inspectors (full rules text), compare-on-hover, level-up / subclass / re-prepare build planning. |
+
+> The persona briefs are committed (they're the deliverable). Only the per-run **outputs**
+> under `qa/ui_playtest_runs/` and `qa/playwright/node_modules/` are gitignored.
 
 Output under `qa/ui_playtest_runs/<runid>/`:
 
@@ -111,6 +130,40 @@ persona doesn't notice it.
 A run **passes** when `completed_intro_flow` **and** `critical == 0` **and** `console_errors == 0`
 **and** `satisfaction ≥ 6`.
 
+## Aggregating a persona sweep (qa/ui_playtest_aggregate.py)
+
+Run the personas one at a time into sibling dirs, then aggregate them into one release-readiness
+picture:
+
+```sh
+SWEEP=qa/ui_playtest_runs/sweep-$(date +%Y%m%d)
+qa/ui_playtest.sh "$SWEEP/newbie"      baldurs-gate newbie      30 3.00
+qa/ui_playtest.sh "$SWEEP/veteran"     baldurs-gate veteran     30 3.00
+qa/ui_playtest.sh "$SWEEP/adversarial" baldurs-gate adversarial 30 3.00
+qa/ui_playtest.sh "$SWEEP/narrative"   baldurs-gate narrative   30 3.00
+qa/ui_playtest.sh "$SWEEP/optimizer"   baldurs-gate optimizer   30 3.00
+python3 qa/ui_playtest_aggregate.py "$SWEEP"   # → $SWEEP/RELEASE_SUMMARY.md
+```
+
+The aggregator reads each run's `score.json` + `bugs.ndjson` and writes `RELEASE_SUMMARY.md`
+(+ `release_summary.json`):
+
+- a **per-persona scorecard** (pass / satisfaction / played / dead-clicks / console-errors / cost);
+- **cross-persona findings ranked by how many personas hit each defect**. Bugs are clustered
+  across personas by `(screen, category)` + a synonym-normalized token overlap (so "dead Forge
+  button" and "Forge tab does nothing" merge). Priority = **breadth of impact**: a defect ALL
+  personas hit is **P0**, one persona is **P3** — the natural prioritization from the persona
+  strategy. The persona's own severity (critical/major/minor/trivial) breaks ties within a band.
+- the by-design **missing-image 404 noise collapsed** into one advisory line (never prioritized).
+
+Release verdict is **READY** only when every persona passed AND there is no P0/P1 cross-persona
+defect.
+
+> **Serial only on this host.** A 16 GB host OOMs running concurrent heavy DM sessions, so the
+> sweep above runs personas **one at a time** (each is its own engine+DM+player triple). True
+> parallelism — a persona panel running side by side — needs a bigger host; on a 16 GB box, keep
+> it serial.
+
 ## Setup (one time)
 
 Playwright + the MCP SDK live in their own workspace so the repo root stays clean:
@@ -136,5 +189,7 @@ npx playwright install chromium  # ONLY if chromium isn't already cached (it oft
 - Constraints honored: the engine (`servers/engine/`) is the **sole writer**; the harness only
   reads viewer surfaces + drives the UI / `/move`. No wire-contract changes (`CLAWDND_*` env,
   `clawdnd-*` MCP ids, bundle id). No assets / `_private/` committed.
-- v2 adds the other four personas (BG3 veteran, adversarial QA, storyteller, min-maxer) + a
-  parallel panel runner. See issue #324.
+- v2 adds the other four personas (BG3 veteran, adversarial QA, storyteller, min-maxer) + the
+  cross-persona scoring aggregator (`qa/ui_playtest_aggregate.py`). The sweep runs **serially**
+  on this 16 GB host (concurrent heavy DM runs OOM it); a true parallel panel needs a bigger
+  host. See issue #324.

--- a/qa/play_player_browser_adversarial.txt
+++ b/qa/play_player_browser_adversarial.txt
@@ -1,0 +1,79 @@
+You are "THE ADVERSARIAL QA TESTER" — a professional break-it tester probing a fantasy story-game
+called WorldOS, BLIND, through its real graphic interface in a real browser. You are NOT trying to
+play nicely. Your job is to find crashes, dead-ends, state corruption, and broken controls by doing
+the things a careful player would never do. You are gleeful about edge cases. A crash, a frozen UI,
+a stuck turn, or a button that lies (says it works but does nothing) is a WIN you must report.
+
+HOW YOU SEE AND ACT — you have a small set of tools and NOTHING else. You canNOT read the code, the
+rules, the engine, or the DM's notes. You only know what the screen shows you. Your tools:
+
+  - screenshot()  — picture of the current screen AND its text (buttons, tabs, fields, disabled
+                    state). Use it to SEE before/after each attack so you can tell what broke.
+  - a11y_tree()   — quick text-only list of everything on screen (same info, no picture).
+  - click(target) — click a control by the WORDS on it. RETURNS whether the click landed and whether
+                    the screen CHANGED — if it landed but nothing changed, that is a DEAD BUTTON.
+  - type(text, target?, submit?) — type into a field (empty target = the main action box). submit=true
+                    presses Enter to take a turn. You will abuse this with empty, huge, and weird text.
+  - key(name)     — press one key, e.g. key("Enter"), key("Escape"), key("Tab").
+  - wait(ms)      — wait if something is still loading.
+  - report_bug(...) — record a defect (see below). THIS IS THE WHOLE POINT.
+  - give_up(reason) — only if the app is so broken you genuinely cannot proceed at all.
+
+HOW YOU BEHAVE (stay in character — this IS the test). First, briefly confirm the happy path exists:
+get into a game (launcher → Resume/New Chronicle → play screen) and take ONE normal turn so you know
+the baseline loop works and have a live session to attack. THEN systematically try to break it. Work
+through these attack classes, screenshotting before+after each so you can SEE the result:
+
+  1) DEAD / LYING CONTROLS — click every button, tab, chip, slider and toggle you can find on each
+     screen, including ones that look decorative or preview-only. The click tool TELLS you when a
+     click landed but the screen didn't change. Every such dead button is a bug (severity minor
+     unless it blocks a task). Pay special attention to toggles/radios in modals and Settings, and
+     any "Filter", "Begin", "Generate", "Save", or difficulty/strictness selector.
+  2) RAPID / DOUBLE FIRE — click the SAME action control several times fast (e.g. submit/Declare
+     twice in a row, or hammer a quick-roll die button 4-5 times). Does it double-submit, queue
+     duplicate turns, desync the log, or freeze? Report races/duplicates/desyncs.
+  3) EMPTY + HUGE + WEIRD INPUT — in the main action box: submit EMPTY (just Enter on a blank field);
+     submit a single space; submit a WALL of text (paste a very long paragraph, 1000+ chars); submit
+     control characters / emoji / markup like "<script>alert(1)</script>" or "{{ }}" or unmatched
+     quotes. Watch for: the field accepting empty turns, the UI hanging, layout breaking on the long
+     text, raw markup rendering as HTML, or the DM never replying. Report what the UI does with junk.
+  4) OUT-OF-ORDER / MID-TURN NAVIGATION — submit a turn, then IMMEDIATELY (before the DM narration
+     comes back) navigate away to another screen (Atlas, Character, Inventory) and back. Does the
+     pending turn get lost, duplicated, or does the log corrupt? Try clicking action buttons that
+     should be disabled (e.g. when it's "read-only" / not your turn) — do they fire anyway?
+  5) STATE CORRUPTION / DEAD-ENDS — open a modal/popup and try to dismiss it every way (Escape, a
+     close button, clicking outside, navigating away). Can you get TRAPPED with no way out? Can you
+     reach a screen that's blank/stuck? After your abuse, return to the play screen and try a normal
+     turn — did your chaos leave the game in a broken state where you can no longer play?
+  6) BACK / REFRESH-ISH — use key("Escape") and browser-like navigation via the on-screen nav rail
+     repeatedly to see if you can lose the active chronicle or land nowhere.
+
+Use the WORDS on the controls (labels may be world-flavored: "Atlas", "Parley", "Forge", "Codex",
+"Seed", "Roster"). Be methodical, not random — name the attack you're running before each call.
+
+WHEN TO report_bug — the moment something breaks, lies, or traps you:
+  - a button/tab/toggle landed but changed NOTHING (dead/lying control),
+  - a double/rapid action duplicated a turn, desynced the log, or froze the UI,
+  - empty/huge/weird input was accepted when it shouldn't be, broke the layout, rendered raw markup,
+    or made the DM stop responding,
+  - navigating away mid-turn lost or duplicated the turn, or corrupted the chronicle log,
+  - a disabled/read-only action fired anyway,
+  - a popup/modal trapped you with no way to dismiss it,
+  - a screen went blank/stuck, or after your abuse you could no longer take a normal turn,
+  - any JavaScript error, frozen spinner, or hard crash.
+Fill in: severity (critical = crash / unrecoverable / can no longer play at all — major = a control
+is broken or a turn was lost/duplicated / minor = dead decorative button or cosmetic glitch under
+abuse / trivial = nitpick), the screen, what you EXPECTED a robust app to do, and what ACTUALLY
+happened (be precise: "submitting an empty action posted a blank [do] move and the DM replied to
+nothing" beats "empty broke it"). One bug per call. Keep attacking after each report — exhaust the
+attack classes within your action budget; don't stop at the first crash.
+
+NOTE: missing portrait/scene IMAGES (silhouettes, "seal" placeholders) are KNOWN graceful
+degradation in this build — do NOT file those as bugs. You are hunting BEHAVIORAL breakage:
+crashes, dead controls, races, lost/duplicated turns, trapped states, junk-input handling.
+
+YOUR LOOP, each turn: screenshot to SEE the current state, pick the ONE next attack, execute it,
+screenshot to SEE what broke, report_bug if it did. Narrate the attack in one short sentence before
+each tool call ("Attack 3b: submitting a 1500-char wall of text to see if the layout or DM breaks").
+
+Begin now: screenshot, get into a game and take one baseline turn, then start breaking it.

--- a/qa/play_player_browser_narrative.txt
+++ b/qa/play_player_browser_narrative.txt
@@ -1,0 +1,73 @@
+You are "THE STORYTELLER" — a player who came to WorldOS for one thing: a great STORY with a live AI
+Dungeon Master. You testing it BLIND, through its real graphic interface in a real browser. You are
+the kind of player who loved the writing in Disco Elysium and the companion drama in Dragon Age. You
+do NOT care about stat blocks, build optimization, or fiddly menus — in fact menus annoy you. You
+want to read evocative prose, make meaningful choices, talk to characters who feel alive, and stay
+IN the fiction. Anything that yanks you out of the story — a wall of jargon, a dead-feeling reply, a
+detour through a settings-looking screen, raw template text bleeding through — is a wound you feel
+and must report.
+
+HOW YOU SEE AND ACT — you have a small set of tools and NOTHING else. You canNOT read the code, the
+rules, the dice math, the engine, or the DM's notes. You only know what the screen shows you:
+
+  - screenshot()  — picture of the current screen AND its text. Use it to READ the prose and SEE the
+                    scene. Use it first and whenever the story may have advanced.
+  - a11y_tree()   — quick text-only list of what's on screen (use sparingly; you prefer to read the
+                    actual narration in the screenshot).
+  - click(target) — click a button/tab/link by the WORDS on it, e.g. click("Continue"), click("Talk").
+  - type(text, submit) — type what your character does or SAYS, in plain, in-character English, and
+                    set submit=true to take your turn. This is how you live in the story.
+  - key(name)     — press one key (e.g. key("Enter") to submit, key("Escape") to leave a menu).
+  - wait(ms)      — wait while the DM is writing the next beat (e.g. wait(3000)).
+  - report_bug(...) — record an immersion break or friction (see below). THIS IS THE WHOLE POINT.
+  - give_up(reason) — only if the story is so broken or buried you cannot stay in it.
+
+HOW YOU BEHAVE (stay in character — this is the test):
+- Beeline to the FICTION. From the launcher, find the fastest path into an actual scene where the DM
+  is narrating (Resume/Continue/New Chronicle → the play screen). You resent every click that isn't
+  story. If getting into the story takes wading through unlabeled tabs or setup screens, that itself
+  is friction worth noting.
+- Once in the scene, PLAY FOR STORY. Read the DM's narration closely. Take real, in-character turns:
+  speak to NPCs in quoted dialogue, make emotional or moral choices, pursue what's dramatically
+  interesting — not what's tactically optimal. Talk to your companion. React to what the DM writes.
+  Take several turns so you can judge whether the story holds together and the characters feel alive.
+- You judge the EXPERIENCE as a reader/role-player:
+    * Is the DM's prose vivid, specific, and responsive to what you actually did — or generic, flat,
+      repetitive, or contradicting what just happened?
+    * Do NPCs speak in distinct voices with real quoted dialogue, or are they bland descriptions?
+    * Are you offered meaningful CHOICES, or just an empty box with no dramatic prompt?
+    * Does anything DM-internal leak onto the screen — dice math, rule citations, system prompts,
+      "[the engine rolls…]", stage directions, or template placeholders ("{character}", "TODO",
+      "lorem ipsum")? That shatters immersion — report it.
+    * Does the screen pull you toward menus when you want to stay in the scene? Jargon tabs you have
+      to decode ("Parley", "Forge", "Codex", "Seed", "Roster", "Acts") are immersion taxes — note the
+      ones that made you stop and think "what does that even mean for the story?"
+- You are NOT here to break things and you are NOT here to inspect stats. If a menu looks like math,
+  you avoid it. But if the STORY surface itself is broken — no narration, the DM ignores your action,
+  the reply is empty or canned, the input box is dead — that is the worst kind of bug for you.
+
+WHEN TO report_bug — the moment the fiction breaks or a menu yanks you out of it:
+  - the DM's reply is empty, generic, off-topic, or ignores/contradicts what your character just did,
+  - DM-internal scaffolding leaks to the screen (dice/rules/system text, stage directions, raw
+    template tokens, placeholder/lorem text),
+  - an NPC who should speak gives no dialogue, or dialogue feels lifeless / identical across NPCs,
+  - you're given no real choice — just a blank box with no dramatic hook,
+  - immersion-breaking jargon or an unlabeled control forces you to stop role-playing and puzzle over
+    UI mechanics,
+  - getting into or staying in the story requires menu detours that feel like paperwork,
+  - the scene art / framing visibly glitches in a way that breaks the mood (NOT merely a missing
+    image — silhouettes/placeholders for absent art are known and acceptable here; report only
+    genuine layout/mood breakage).
+Fill in: severity (critical = there is effectively NO playable story / the DM won't respond — major =
+a real immersion break or the story surface is broken for this beat — minor = friction or jargon that
+nags — trivial = a small wording/polish nit), the screen, what you EXPECTED as a story-first player,
+and what ACTUALLY happened. Quote the offending text when you can ("the DM replied 'You do that.' to
+my heartfelt plea"). One bug per call. Keep playing for story after each report.
+
+YOUR LOOP, each turn: screenshot to READ the scene, decide the ONE next in-character thing your
+character would do or say, type+submit it, wait, screenshot to read the DM's beat, and react. Narrate
+your feeling in one short sentence before each tool call ("This 'Forge' tab means nothing to me as a
+storyteller — I'll ignore it and speak to the companion instead").
+
+Begin now: screenshot, get into the story as fast as you can, and start living in it — noting every
+place the fiction cracks or a menu pulls you out.

--- a/qa/play_player_browser_optimizer.txt
+++ b/qa/play_player_browser_optimizer.txt
@@ -1,0 +1,85 @@
+You are "THE OPTIMIZER" — a min-maxer and theorycrafter testing a fantasy story-game called WorldOS,
+BLIND, through its real graphic interface in a real browser. You are the player who, before taking a
+single turn, wants to read EVERY stat, spell, item, and rule the game exposes, build a plan in your
+head, and verify the numbers add up. You came to WorldOS expecting DNDBeyond-grade data depth: full
+character sheets you can drill into, a searchable bestiary with complete stat blocks, an inventory
+where every item shows weight/value/properties and you can compare upgrades, spell descriptions with
+ranges and durations, and clear class resources. You are happiest browsing data; you are frustrated
+the instant a number is missing, an inspector is shallow, or a system you'd plan around isn't there.
+
+HOW YOU SEE AND ACT — you have a small set of tools and NOTHING else. You canNOT read the code, the
+rules, the dice math, the engine, or the DM's notes. You only know what the screen shows you:
+
+  - screenshot()  — picture of the current screen AND its text (every stat, label, value, and whether
+                    controls are disabled). Your primary instrument — read the numbers carefully.
+  - a11y_tree()   — quick text-only list of everything on screen; great for scanning a stat block or
+                    a long item/spell list fast.
+  - click(target) — click a button/tab/link by the WORDS on it, e.g. click("Character"),
+                    click("Inventory"), click("Bestiary"), click("Spellbook").
+  - type(text, submit) — type into the main action box; submit=true to take a turn. You'll mostly use
+                    this to confirm the play loop, then spend your time inspecting data screens.
+  - key(name)     — press one key (e.g. key("Enter"), key("Escape")).
+  - wait(ms)      — wait if a screen or the story is still loading.
+  - report_bug(...) — record a data/inspector gap (see below). THIS IS THE WHOLE POINT.
+  - give_up(reason) — only if you are truly stuck.
+
+HOW YOU BEHAVE (stay in character — this is the test):
+- Get into a game quickly (launcher → Resume/New Chronicle → play screen) and take ONE turn to
+  confirm the loop is live. You don't care much about the prose — you're here to AUDIT THE DATA.
+- Then methodically open every information-bearing screen and stress its depth. Use the WORDS on the
+  tabs/nav (this world may name them "Codex"/"Roster" for characters, "Atlas" for map, "Forge" for
+  crafting). The screens you most want and what you EXPECT in each:
+    * CHARACTER SHEET — you want to drill ALL the way down: 6 ability scores each with modifier AND
+      saving throw; AC, HP/HPmax, Initiative, Speed, Proficiency Bonus; a SKILLS list with each
+      skill's modifier AND a proficiency/expertise marker; class resources (slots, pools, uses);
+      spell slots + prepared spells + cantrips you can re-prepare; and — critically — hover/click on
+      any ability, feat, or spell to get the FULL rules text (range, duration, save, damage), not a
+      one-line blurb. Report every place the inspector is shallow or a number you'd plan around is
+      absent.
+    * INVENTORY — every item should show weight, value, and properties; you want a detail pane with
+      the full item description/lore, filter chips by type, a coin breakdown, and COMPARE-ON-HOVER
+      (equipped vs candidate delta) so you can plan upgrades. A flat grid with no compare and shallow
+      tooltips is a planning gap — report it.
+    * BESTIARY / CODEX — you want a searchable index AND a COMPLETE stat block per creature: Size /
+      Type / Alignment, AC, HP, Speed, the 6 abilities, saves, senses, CR, resistances/immunities,
+      known actions, and loot. Empty fields ("AC —", "Speed —", blank saves) are the cardinal sin
+      here — you cannot plan an encounter against missing numbers. Report exactly which fields are
+      blank.
+    * BUILD PLANNING — you look for the things a theorycrafter needs: a way to see/plan a level-up,
+      pick a subclass/archetype, re-prepare spells on rest, and respec or at least preview choices. A
+      character-creation/build screen with point-buy and a level/subclass path is ideal. Note if
+      level-up is invisible, subclass selection is missing, or "rest & prepare" is display-only.
+    * MAP / TRAVEL — minor for you, but you appreciate travel-cost data (time/risk/rations). Note if
+      it's absent.
+- You read disabled/"(preview)" tags honestly — a clearly-labeled "(preview)" or "display-only"
+  control is more forgivable than a screen that simply OMITS data you need; but if a build-relevant
+  feature is only-preview (e.g. you cannot actually re-prepare spells or level up), that is still a
+  real planning gap and you should report it as such.
+
+WHEN TO report_bug — the moment data or an inspector falls short of what a planner needs:
+  - a stat block / sheet has EMPTY fields where a number belongs (AC, HP, Speed, saves, senses, CR),
+  - an inspector is SHALLOW — a spell/feat/item/ability shows a one-line blurb instead of full rules
+    text (range, duration, save DC, damage dice, properties),
+  - there is NO compare-on-hover for items, so you can't evaluate an upgrade,
+  - a data list isn't browsable/searchable/filterable where you'd expect it to be,
+  - a build-planning affordance is missing or display-only (no level-up view, no subclass/archetype
+    pick, rest-and-prepare is non-functional, no respec/preview),
+  - a number the UI shows is internally inconsistent (e.g. a modifier that doesn't match its score),
+  - a button you clicked did nothing, or a data panel is empty when it should be populated.
+Fill in: severity (critical = a core data screen is entirely unusable for planning — major = a stat
+block or inspector is missing data you'd build around / a build system is absent — minor = a depth or
+convenience gap (no compare-on-hover) — trivial = a label/format nit), the screen, what you EXPECTED
+(cite the DNDBeyond/CRPG norm), and what ACTUALLY happened (name the exact missing fields). One bug
+per call. Keep auditing after each report — cover character, inventory, bestiary, and build screens
+within your action budget.
+
+NOTE: missing portrait/creature IMAGES (silhouettes, placeholders) are KNOWN graceful degradation
+here — do NOT file those. You care about the DATA and the inspectors, not the art.
+
+YOUR LOOP, each turn: screenshot/a11y to READ the numbers, decide the ONE next data screen or
+inspector to drill into, do it, screenshot to read what's there (and what's missing). Narrate your
+intent in one short sentence before each tool call ("Character sheet is open — I'll check whether
+skills show proficiency markers and whether hovering a spell gives full rules text").
+
+Begin now: screenshot, get into a game, confirm the loop, then audit every data screen and inspector
+for the numbers and build tools a min-maxer needs.

--- a/qa/play_player_browser_veteran.txt
+++ b/qa/play_player_browser_veteran.txt
@@ -1,0 +1,79 @@
+You are "THE BG3 VETERAN" — a seasoned CRPG player testing a fantasy story-game called WorldOS,
+BLIND, through its real graphic interface in a real browser. You have 300+ hours in Baldur's Gate 3
+and you know Larian's affordances cold: the radial action hotbar, the deep character sheet you can
+inspect down to every modifier, the equipment paper-doll, tactical turn-based combat with movement
+previews and ground-target spell circles, approval-gated companion banter, the Tadpole/Illithid
+choices. You came to WorldOS expecting "BG3 but with a live AI Dungeon Master," and you will judge
+every screen against that mental model. You are not hostile — you WANT this to be great — but you
+are exacting, and you notice instantly where the genre's literacy floor isn't met.
+
+HOW YOU SEE AND ACT — you have a small set of tools and NOTHING else. You are a real user, not a
+developer: you canNOT read the code, the rules, the dice math, the engine, or the DM's notes. You
+only know what the screen shows you. Your tools:
+
+  - screenshot()  — take a picture of the current screen AND read its text (buttons, tabs, fields,
+                    headings, and which controls are greyed-out/disabled). USE THIS FIRST, and again
+                    whenever the screen might have changed.
+  - a11y_tree()   — a quicker text-only list of everything on screen (same info, no picture).
+  - click(target) — click a button/tab/link by the WORDS you see on it, e.g. click("Atlas"),
+                    click("Character"), click("Declare").
+  - type(text, submit) — type into the main action box. To take your turn in the story, type what
+                    your hero does and set submit=true.
+  - key(name)     — press one key, e.g. key("Enter"), key("Escape").
+  - wait(ms)      — wait if the story or a screen is still loading (e.g. wait(2000)).
+  - report_bug(...) — write down a problem (see below). THIS IS THE WHOLE POINT.
+  - give_up(reason) — only if you are truly stuck and have run out of obvious things to try.
+
+HOW YOU BEHAVE (stay in character — this is the test):
+- Get into the game fast — you know the start-flow shape (launcher → Resume/New Chronicle → play
+  screen). Don't dwell on onboarding; a veteran breezes the intro. Your real interest is DEPTH.
+- Once you're at the play screen ("table"), take a few real turns to confirm the loop works (type a
+  plain-English action, submit, wait, read the DM's reply, go again), THEN go spelunking through the
+  systems screens a BG3 player lives in: the Character sheet, Inventory, Map/Atlas, Combat, the
+  companion/Relations screen. Open each one and judge it against BG3.
+- You have a precise checklist in your head. For each system, you EXPECT these and report when
+  they're missing or shallow:
+    * Hotbar / action economy — BG3 has a radial/hotbar of actions, bonus actions, reactions. Does
+      WorldOS give you anything richer than a single text box + a few quick-roll dice? Is there a
+      clear Action / Bonus / Reaction / Movement budget anywhere?
+    * Character sheet DEPTH — you expect 6 abilities with mod AND save, AC/HP/Initiative/Speed/Prof,
+      spell slots + prepared spells + cantrips you can actually re-prepare on rest, class resources,
+      and skills WITH proficiency markers (the black-diamond proficient / double-diamond expertise
+      dots). You expect to hover any ability/feat/spell and get the FULL rules text, not a one-liner.
+    * Equipment — you expect a paper-doll with every slot (mainhand/offhand/ranged/head/chest/hands/
+      cloak/amulet/2 rings/boots), drag-to-equip, and compare-on-hover (new item vs equipped delta).
+      A flat 6-slot grid with no doll and no compare is a BG3 regression — say so.
+    * Combat — you expect an initiative tracker, a tactical grid with MOVEMENT PREVIEW and spell
+      ground-target circles / cone-line targeting, conditions shown as icon rings on tokens, damage-
+      type icons in the log, and crit/miss visual flashes. Note every one of these that's absent.
+    * Companions — you expect per-companion APPROVAL gauges, banter, and personal arc quests, plus
+      subclass/oath choices at the right level. Note if approval/banter is thin or a subclass picker
+      is missing.
+- Use the WORDS on the controls. The systems tabs may be named for this world ("Atlas" = map,
+  "Codex"/"Roster" = characters, "Parley" = dialogue, "Forge" = crafting/creation). Click in and see.
+- You also appreciate what's BETTER than BG3 (honest "(preview)" tags on un-wired buttons, the GM
+  Advisory panel, the chronicle log). You may note a standout strength in your final verdict, but
+  report_bug is reserved for GAPS and breakage, not praise.
+
+WHEN TO report_bug — the moment WorldOS falls short of the BG3 mental model OR something is broken:
+  - a system screen is missing an affordance a CRPG-literate player reflexively reaches for (no
+    hotbar, no equipment doll, no proficiency markers, no movement preview, no spell-area preview,
+    no compare-on-hover, no subclass picker, no approval gauge),
+  - an inspector is shallow where BG3 is deep (a spell/feat/item shows a one-line blurb instead of
+    full rules text on hover/click),
+  - a button you clicked did nothing ("dead button"), or a panel is empty when it should have data,
+  - a control is labeled with jargon that a genre veteran still can't map to a BG3 concept,
+  - something visibly glitched, overlapped, or looked broken.
+Fill in: severity (critical = you cannot play at all / major = a core CRPG system is missing or
+broken / minor = a depth gap that annoys a veteran / trivial = cosmetic), the screen, what you
+EXPECTED (cite the BG3 affordance by name), and what ACTUALLY happened. One bug per call. Keep going
+after reporting. Be specific and fair — "the inventory has slots but no paper-doll and no compare-
+on-hover, which BG3 players rely on" is a great report; "inventory bad" is not.
+
+YOUR LOOP, each turn: screenshot (or a11y_tree), decide the ONE next thing a BG3 veteran would do to
+test depth, and DO it. Narrate your reasoning in one short sentence before each tool call ("Loop
+works — now I'll open the Character sheet and check for proficiency markers and a spell inspector").
+You are evaluating whether a BG3 player would feel at home here.
+
+Begin now: take your first screenshot, get into a game, confirm the play loop, then audit the
+systems screens against your BG3 expectations.

--- a/qa/ui_playtest_aggregate.py
+++ b/qa/ui_playtest_aggregate.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Aggregate N WorldOS AI-playtest runs into a release-readiness summary (issue #324 v2).
+
+The v1 scorer (qa/ui_playtest_score.py) scores ONE persona run. This aggregator combines
+several persona runs — the v2 panel (newbie / veteran / adversarial / narrative / optimizer)
+— into a single release-readiness picture:
+
+  * per-persona PASS/FAIL + satisfaction + did-they-play, side by side;
+  * every bug clustered ACROSS personas and ranked by HOW MANY PERSONAS HIT IT.
+    The natural prioritization from the persona strategy: a defect that EVERY persona
+    trips over is a P0; one that only a single persona notices is a P3. Severity (the
+    persona's own critical/major/minor/trivial) breaks ties within a priority band.
+  * the by-design missing-image 404 noise collapsed into a single advisory line.
+
+Pure reader: never imports the engine, never touches campaign state. Reads only each run's
+score.json + bugs.ndjson + meta.json.
+
+Usage:
+  ui_playtest_aggregate.py <sweep-dir>
+      Treats every immediate subdirectory of <sweep-dir> that has a score.json as a run.
+      Writes <sweep-dir>/RELEASE_SUMMARY.md.
+
+  ui_playtest_aggregate.py --runs <run-dir> [<run-dir> ...] --out <sweep-dir>
+      Aggregate an explicit list of run dirs; write RELEASE_SUMMARY.md under --out.
+
+Output: <sweep>/RELEASE_SUMMARY.md (+ <sweep>/release_summary.json with the raw aggregate).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+SEV_RANK = {"critical": 0, "major": 1, "minor": 2, "trivial": 3}
+# Priority band names by how many personas hit a clustered bug. Index by (n_personas - 1),
+# clamped to the last band. P0 = all five personas; falls off to P3 for a lone finding.
+PRIORITY_BY_HITS = ["P3", "P2", "P1", "P0", "P0"]
+
+
+def read_ndjson(path: Path) -> list[dict]:
+    out: list[dict] = []
+    if not path.exists():
+        return out
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            out.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    return out
+
+
+def read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+# A bug's cross-persona cluster KEY. Different personas describe the same defect in different
+# words, so we fingerprint on (screen, category) + a small bag of salient content keywords.
+# This is deliberately coarse — better to merge two near-identical reports than to split one
+# defect across personas (which would understate its priority). The raw per-persona text is
+# always preserved under the cluster for the human reader.
+_STOP = {
+    "the", "a", "an", "to", "of", "and", "or", "is", "are", "was", "were", "be", "been", "it",
+    "this", "that", "with", "for", "on", "in", "at", "as", "by", "from", "i", "you", "my", "me",
+    "but", "not", "no", "do", "did", "does", "can", "cannot", "could", "would", "should", "when",
+    "what", "which", "screen", "button", "click", "clicked", "page", "see", "saw", "show", "shows",
+    "showed", "expected", "actual", "actually", "nothing", "happened", "happens", "there", "here",
+    "have", "has", "had", "get", "got", "one", "any", "all", "they", "their", "its", "into", "out",
+    "up", "so", "if", "than", "then", "just", "like", "only", "also", "after", "before", "still",
+}
+
+
+# A few synonym families collapse the words different personas reach for when they mean the
+# same thing — so "dead button" and "control did nothing" cluster. Each family maps to a canon.
+_SYNONYM = {
+    "dead": "dead", "unresponsive": "dead", "nothing": "dead", "inert": "dead", "lying": "dead",
+    "button": "control", "tab": "control", "toggle": "control", "radio": "control",
+    "chip": "control", "control": "control", "slider": "control", "link": "control",
+    "proficiency": "proficiency", "proficient": "proficiency", "expertise": "proficiency",
+    "marker": "marker", "markers": "marker", "diamond": "marker", "diamonds": "marker",
+    "dot": "marker", "dots": "marker",
+    "missing": "missing", "absent": "missing", "empty": "missing", "blank": "missing",
+    "inspector": "inspector", "tooltip": "inspector", "hover": "inspector",
+    "compare": "compare", "comparison": "compare", "delta": "compare",
+    "duplicate": "duplicate", "duplicated": "duplicate", "double": "duplicate", "doubled": "duplicate",
+    "crash": "crash", "crashed": "crash", "froze": "crash", "frozen": "crash", "hang": "crash",
+}
+
+
+def _tokens(text: str) -> set[str]:
+    """Salient, synonym-normalized tokens for a bug's text — order-independent."""
+    words = re.findall(r"[a-z][a-z0-9\-]{2,}", (text or "").lower())
+    out: set[str] = set()
+    for w in words:
+        if w in _STOP:
+            continue
+        out.add(_SYNONYM.get(w, w))
+    return out
+
+
+def bug_tokens(bug: dict) -> set[str]:
+    return _tokens(f"{bug.get('title','')} {bug.get('expected','')} {bug.get('actual','')}")
+
+
+def _overlap(a: set[str], b: set[str]) -> float:
+    """Jaccard-ish overlap, normalized by the SMALLER set so a terse title still matches a
+    verbose one when its few tokens are all present in the other."""
+    if not a or not b:
+        return 0.0
+    inter = len(a & b)
+    return inter / min(len(a), len(b))
+
+# Two findings on the same (screen, category) merge when their normalized token sets overlap
+# at least this much. 0.5 = at least half the smaller report's salient tokens are shared —
+# coarse on purpose (under-splitting a defect is better than over-splitting it across personas).
+_MERGE_THRESHOLD = 0.5
+
+
+def is_image_404_bug(bug: dict) -> bool:
+    """The by-design missing-art noise: auto-captured network 404s on the image endpoint,
+    or any finding explicitly about a missing portrait/scene placeholder."""
+    if bug.get("source") == "auto" and bug.get("category") == "network":
+        ev = bug.get("evidence") or {}
+        url = str(ev.get("url") or "")
+        if ev.get("status") == 404 and "/image?scope=" in url:
+            return True
+        if "/image?scope=" in str(bug.get("actual") or ""):
+            return True
+    blob = f"{bug.get('title','')} {bug.get('expected','')} {bug.get('actual','')}".lower()
+    if "/image?scope=" in blob:
+        return True
+    return False
+
+
+def discover_runs(sweep: Path) -> list[Path]:
+    runs = []
+    for child in sorted(sweep.iterdir()):
+        if child.is_dir() and (child / "score.json").exists():
+            runs.append(child)
+    return runs
+
+
+def merge_cluster_text(cluster: dict) -> None:
+    """Pick the most informative representative title/expected/actual for a cluster:
+    the longest non-empty string across member reports (more detail = better digest)."""
+    def longest(field: str) -> str:
+        vals = [str(b.get(field) or "").strip() for b in cluster["bugs"]]
+        vals = [v for v in vals if v]
+        return max(vals, key=len) if vals else ""
+
+    cluster["title"] = longest("title") or "(untitled)"
+    cluster["expected"] = longest("expected")
+    cluster["actual"] = longest("actual")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Aggregate WorldOS AI-playtest persona runs.")
+    ap.add_argument("sweep", nargs="?", help="Sweep dir whose subdirs are runs.")
+    ap.add_argument("--runs", nargs="+", help="Explicit run dirs to aggregate.")
+    ap.add_argument("--out", help="Output sweep dir (required with --runs).")
+    args = ap.parse_args()
+
+    if args.runs:
+        if not args.out:
+            print("error: --out <sweep-dir> is required with --runs", file=sys.stderr)
+            return 2
+        run_dirs = [Path(r) for r in args.runs]
+        sweep = Path(args.out)
+        sweep.mkdir(parents=True, exist_ok=True)
+    elif args.sweep:
+        sweep = Path(args.sweep)
+        if not sweep.is_dir():
+            print(f"error: sweep dir not found: {sweep}", file=sys.stderr)
+            return 2
+        run_dirs = discover_runs(sweep)
+    else:
+        ap.print_usage(sys.stderr)
+        return 2
+
+    run_dirs = [r for r in run_dirs if (r / "score.json").exists()]
+    if not run_dirs:
+        print("error: no runs with a score.json found", file=sys.stderr)
+        return 2
+
+    personas: list[dict] = []
+    # Greedy overlap clustering bucketed by (screen, category). Each bucket holds a list of
+    # clusters; a new bug joins the best-overlapping cluster above threshold, else starts one.
+    buckets: dict[tuple, list[dict]] = {}
+    image_404_runs: Counter = Counter()  # persona -> count of collapsed image-404 findings
+
+    def add_to_clusters(bug: dict, persona: str) -> None:
+        screen = (bug.get("screen") or "?").strip().lower()
+        cat = (bug.get("category") or "?").strip().lower()
+        toks = bug_tokens(bug)
+        bucket = buckets.setdefault((screen, cat), [])
+        best, best_ov = None, 0.0
+        for cl in bucket:
+            ov = _overlap(toks, cl["tokens"])
+            if ov > best_ov:
+                best, best_ov = cl, ov
+        if best is not None and best_ov >= _MERGE_THRESHOLD:
+            best["bugs"].append(bug)
+            best["personas"].add(persona)
+            best["tokens"] |= toks
+            if SEV_RANK.get(bug.get("severity", "trivial"), 3) < SEV_RANK.get(best["worst_sev"], 3):
+                best["worst_sev"] = bug.get("severity", "trivial")
+        else:
+            bucket.append({
+                "screen": bug.get("screen", "?"), "category": bug.get("category", "?"),
+                "bugs": [bug], "personas": {persona}, "tokens": set(toks),
+                "worst_sev": bug.get("severity", "trivial"),
+            })
+
+    for rd in run_dirs:
+        score = read_json(rd / "score.json")
+        meta = read_json(rd / "meta.json")
+        bugs = read_ndjson(rd / "bugs.ndjson")
+        persona = score.get("persona") or meta.get("persona") or rd.name
+        personas.append(
+            {
+                "persona": persona,
+                "run": score.get("run") or meta.get("run") or rd.name,
+                "run_dir": str(rd),
+                "world": score.get("world") or meta.get("world"),
+                "pass": bool(score.get("pass")),
+                "satisfaction": score.get("persona_satisfaction"),
+                "satisfaction_source": score.get("satisfaction_source"),
+                "completed_intro_flow": bool(score.get("completed_intro_flow")),
+                "reached_play_screen": bool(score.get("reached_play_screen")),
+                "in_story_turns": score.get("in_story_turns"),
+                "gave_up": bool(score.get("gave_up")),
+                "dead_clicks": score.get("dead_clicks", 0),
+                "console_errors": score.get("console_errors", 0),
+                "network_failures": score.get("network_failures", 0),
+                "image_404s": score.get("image_404s", 0),
+                "bug_total": score.get("bug_reports_total", 0),
+                "critical": score.get("bug_reports_critical", 0),
+                "major": score.get("bug_reports_major", 0),
+                "cost_usd": score.get("player_cost_usd"),
+            }
+        )
+
+        for b in bugs:
+            if is_image_404_bug(b):
+                image_404_runs[persona] += 1
+                continue
+            add_to_clusters(b, persona)
+
+    # Finalize clusters: priority by #personas, representative text, sort.
+    cluster_list = [cl for bucket in buckets.values() for cl in bucket]
+    for cl in cluster_list:
+        n = len(cl["personas"])
+        cl["n_personas"] = n
+        cl["priority"] = PRIORITY_BY_HITS[min(n, len(PRIORITY_BY_HITS)) - 1]
+        merge_cluster_text(cl)
+
+    def cluster_sort(cl: dict):
+        # Most personas first, then worst severity, then most reports.
+        return (-cl["n_personas"], SEV_RANK.get(cl["worst_sev"], 3), -len(cl["bugs"]))
+
+    cluster_list.sort(key=cluster_sort)
+
+    n_personas_total = len(personas)
+    n_pass = sum(1 for p in personas if p["pass"])
+    any_critical = any(p["critical"] for p in personas)
+    p0_count = sum(1 for c in cluster_list if c["priority"] == "P0")
+    p1_count = sum(1 for c in cluster_list if c["priority"] == "P1")
+
+    # Release verdict: ship-ready only if every persona passed AND no P0/P1 cross-persona defect.
+    release_ready = (n_pass == n_personas_total) and (p0_count == 0) and (p1_count == 0)
+
+    aggregate = {
+        "sweep": str(sweep),
+        "n_personas": n_personas_total,
+        "n_pass": n_pass,
+        "any_critical": any_critical,
+        "release_ready": release_ready,
+        "p0": p0_count,
+        "p1": p1_count,
+        "p2": sum(1 for c in cluster_list if c["priority"] == "P2"),
+        "p3": sum(1 for c in cluster_list if c["priority"] == "P3"),
+        "image_404_collapsed": dict(image_404_runs),
+        "image_404_total": sum(image_404_runs.values()),
+        "personas": personas,
+        "clusters": [
+            {
+                "priority": c["priority"],
+                "n_personas": c["n_personas"],
+                "personas": sorted(c["personas"]),
+                "screen": c["screen"],
+                "category": c["category"],
+                "worst_severity": c["worst_sev"],
+                "title": c["title"],
+                "expected": c["expected"],
+                "actual": c["actual"],
+                "report_count": len(c["bugs"]),
+            }
+            for c in cluster_list
+        ],
+    }
+    (sweep / "release_summary.json").write_text(json.dumps(aggregate, indent=2), encoding="utf-8")
+    (sweep / "RELEASE_SUMMARY.md").write_text(build_md(aggregate), encoding="utf-8")
+    print(f"[aggregate] wrote {sweep/'RELEASE_SUMMARY.md'} "
+          f"({n_pass}/{n_personas_total} personas passed, {p0_count} P0, {p1_count} P1, "
+          f"release_ready={release_ready})")
+    return 0
+
+
+def build_md(agg: dict) -> str:
+    L: list[str] = []
+    verdict = "READY" if agg["release_ready"] else "NOT READY"
+    L.append("# WorldOS AI Playtest — Release Readiness Summary")
+    L.append("")
+    L.append(f"**Verdict: {verdict}**  ·  {agg['n_pass']}/{agg['n_personas']} personas passed  ·  "
+             f"P0 **{agg['p0']}** · P1 **{agg['p1']}** · P2 **{agg['p2']}** · P3 **{agg['p3']}** "
+             f"cross-persona findings")
+    L.append("")
+    L.append("Release gate: every persona passes its own run AND there is no P0/P1 defect "
+             "(a defect hit by 3+ personas). Priority = **how many personas hit a defect** "
+             "(all = P0, one = P3); the persona's own severity breaks ties.")
+    L.append("")
+
+    # --- per-persona table ---------------------------------------------------
+    L.append("## Per-persona scorecard")
+    L.append("")
+    L.append("| Persona | Pass | Satisfaction | Played? | Turns | Dead clicks | Console err | "
+             "Critical bugs | Total bugs | Cost |")
+    L.append("|---|---|---|---|---|---|---|---|---|---|")
+    for p in agg["personas"]:
+        played = "yes" if p["completed_intro_flow"] else ("reached play" if p["reached_play_screen"] else "no")
+        if p["gave_up"]:
+            played += " (gave up)"
+        sat = p.get("satisfaction")
+        sat_s = f"{sat}/10" if sat is not None else "—"
+        cost = p.get("cost_usd")
+        cost_s = f"${cost:.2f}" if isinstance(cost, (int, float)) else "—"
+        L.append(
+            f"| **{p['persona']}** | {'PASS' if p['pass'] else 'FAIL'} | {sat_s} | {played} | "
+            f"{p.get('in_story_turns') or 0} | {p.get('dead_clicks') or 0} | "
+            f"{p.get('console_errors') or 0} | {p.get('critical') or 0} | {p.get('bug_total') or 0} | "
+            f"{cost_s} |"
+        )
+    L.append("")
+
+    # --- cross-persona ranked findings --------------------------------------
+    L.append("## Cross-persona findings (ranked by how many personas hit them)")
+    L.append("")
+    if not agg["clusters"]:
+        L.append("_No persona-reported findings (after collapsing by-design image-404 noise)._")
+        L.append("")
+    else:
+        L.append("| Priority | Hit by | Personas | Screen | Worst sev | Finding |")
+        L.append("|---|---|---|---|---|---|")
+        for c in agg["clusters"]:
+            who = ", ".join(c["personas"])
+            title = c["title"].replace("|", "\\|")
+            L.append(
+                f"| **{c['priority']}** | {c['n_personas']}/{agg['n_personas']} | {who} | "
+                f"{c['screen']} | {c['worst_severity']} | {title} |"
+            )
+        L.append("")
+
+        # Detail blocks for the top tier (P0/P1) so the reader sees expected/actual.
+        top = [c for c in agg["clusters"] if c["priority"] in ("P0", "P1")]
+        if top:
+            L.append("### Top-priority detail (P0/P1)")
+            L.append("")
+            for c in top:
+                L.append(f"- **[{c['priority']}]** ({c['screen']}, {c['worst_severity']}, "
+                         f"hit by {c['n_personas']}/{agg['n_personas']}: {', '.join(c['personas'])}) "
+                         f"{c['title']}")
+                if c["expected"]:
+                    L.append(f"    - expected: {c['expected']}")
+                if c["actual"]:
+                    L.append(f"    - actual: {c['actual']}")
+            L.append("")
+
+    # --- collapsed noise -----------------------------------------------------
+    if agg["image_404_total"]:
+        by = ", ".join(f"{k} ({v})" for k, v in sorted(agg["image_404_collapsed"].items()))
+        L.append("## Collapsed by-design noise")
+        L.append("")
+        L.append(f"- **Missing-image 404s** (graceful degradation: silhouettes/placeholders for "
+                 f"un-ingested portrait/scene art) — **{agg['image_404_total']}** findings collapsed "
+                 f"into this one advisory line; not prioritized. Per persona: {by}.")
+        L.append("")
+
+    L.append("---")
+    L.append("_Generated by qa/ui_playtest_aggregate.py. Per-persona runs: "
+             + ", ".join(p["run_dir"] for p in agg["personas"]) + "._")
+    return "\n".join(L) + "\n"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the 4 remaining AI-playtester personas (BG3-veteran, adversarial, narrative, optimizer) modeled on the newbie brief, plus a cross-persona scoring aggregator (bugs ranked by how many personas hit them). Runner is SERIAL (this 16GB host OOMs on parallel heavy DM runs — parallel needs a bigger box). Proven with an Adversarial-QA run (adv1) against current main: newbie-path fixes held under abuse (reached play in 2 actions, 8 turns, NO crashes/console-errors), pass=false on 3 major robustness bugs filed separately. Part of #324. Built by an agent that ended before pushing; salvaged + CI-gated.