### PR TITLE
fix(openworlds): wire the stuck-recovery 'Try again' to actually retry (Closes #344)

### DIFF
--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -215,6 +215,13 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
   const recordPlayerEcho = session.recordPlayerEcho;
   const pendingActive = Boolean(pending && !pending.stuck);
   const pendingStuck = Boolean(pending && pending.stuck);
+  // #344: remember the move that is currently in flight so the "Try again" recovery (shown when a
+  // turn goes `stuck`) can actually RE-POST it. The first submit clears the input box (setInput("")),
+  // so by the time the bar re-opens stuck the box is empty — without the original move stored, the
+  // old "Try again" path (sendAction → input.trim() → empty → early-return) was a silent no-op. We
+  // keep the canonical move object + its label here, set on every postMove, so a retry resends the
+  // exact stalled turn (free-text, roll, or structured action alike).
+  const lastMoveRef = React.useRef(null);
 
   // #342: surface the recovery exactly once when a turn goes `stuck` so the player knows the bar
   // re-opened on purpose (the DM stalled) rather than silently.
@@ -241,6 +248,9 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
       : move;
     const rawLabel = label || cleanMove.text || cleanMove.name || "declares an action";
     const text = window.neutralizeMarkup(String(rawLabel)) || "declares an action";
+    // #344: capture the (already-neutralized) move + label + actionId so a later "Try again"
+    // recovery can re-POST this exact turn if the DM stalls on it.
+    lastMoveRef.current = { move: cleanMove, label: text, actionId };
     try {
       const response = await fetch(writeLane.endpoint || "/move", {
         method: "POST",
@@ -271,6 +281,33 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
     await postMove({ kind: "do", text }, text, "do");
     setInput("");
   };
+
+  // #344: the recovery action for a `stuck` turn. The old "Try again" reused sendAction, which reads
+  // the (now-empty) input box and early-returned — a dead button. This handler resends the stalled
+  // turn: if the player typed something new into the re-opened box we send THAT (a rephrase, the
+  // toast's other option); otherwise we re-POST the exact move that stalled. Either way the bar
+  // re-arms via postMove → armPending, so the turn goes back to "narrating" and the recovery clears.
+  const retryStuck = async () => {
+    const typed = input.trim();
+    if (typed) {
+      // Player rephrased — send the new text as a fresh `do` (this path already worked).
+      await sendAction();
+      return;
+    }
+    const last = lastMoveRef.current;
+    if (!last || !last.move) {
+      // Nothing captured to retry (shouldn't happen for a stuck turn) — nudge the player to type.
+      toast({ kind: "danger", title: "Nothing to retry", body: "Type your action again, then press Try again." });
+      inputRef.current?.focus();
+      return;
+    }
+    // Re-POST the stalled move verbatim. postMove re-arms pending + the recovery/backstop timers.
+    await postMove(last.move, last.label, last.actionId);
+  };
+
+  // #344: the Declare button doubles as the stuck-recovery "Try again" button (same slot, relabeled).
+  // Route the click to the right handler so a stuck turn actually retries instead of no-op'ing.
+  const onDeclareClick = () => (pendingStuck ? retryStuck() : sendAction());
 
   const requestRoll = (sides = 20) => {
     const action = actionById("check");
@@ -406,13 +443,13 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
                 ref={inputRef}
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && sendAction()}
+                onKeyDown={(e) => e.key === "Enter" && onDeclareClick()}
                 disabled={pendingActive}
                 title={DECLARE_HINT}
                 placeholder={pendingActive ? "The Dungeon Master is narrating…" : pendingStuck ? "The DM seemed stuck — try again." : (canAct ? "Describe what your hero does..." : `Read-only: ${readOnlyReason}`)}
                 style={{ ...inkInput, fontFamily: "var(--f-body)", fontSize: 16, opacity: pendingActive ? 0.6 : 1 }}
               />
-              <BrassButton onClick={sendAction} title={DECLARE_HINT} disabled={!actionById("do")?.available || pendingActive}>{pendingActive ? "Narrating…" : pendingStuck ? "Try again" : "Declare"}</BrassButton>
+              <BrassButton onClick={onDeclareClick} title={pendingStuck ? "Re-send your last action to the Dungeon Master, or type a new one first." : DECLARE_HINT} disabled={!actionById("do")?.available || pendingActive}>{pendingActive ? "Narrating…" : pendingStuck ? "Try again" : "Declare"}</BrassButton>
             </div>
           </div>
         </Panel>


### PR DESCRIPTION
Closes #344

Validates the two #324-v2 veteran (vet1) findings filed against current main (post-#343), then fixes the one that genuinely reproduces. **Viewer-only; engine stays the sole writer — no `/move` or wire-contract change.** One file: `viewer/openworlds/screen-table.jsx` (+39/−2).

---

### Finding 1 — the "Try again" recovery button is DEAD → **REAL, fixed**

**Repro (headless CDP against the real JSX, no engine):** drive a live surface → type a `do`, click Declare (fires `/move`, input clears + disables, narrating beat shown, 90s+12min timers armed) → fire the 90s recovery → bar re-opens `stuck`, Declare relabels to **"Try again"**, input is enabled but **empty** → click "Try again".

| | move count before "Try again" | after |
|---|---|---|
| **Before fix** | 1 | **1 — no retry fired (dead button)** |
| **After fix** | 1 | **2 — the stalled turn is re-POSTed** |

**Root cause:** #343 relabels the Declare button to "Try again" when a turn goes `stuck`, but it stayed wired to `sendAction`, which does `const text = input.trim(); if (!text) return;`. The first submit clears the box (`setInput("")`), so by the time the bar re-opens stuck the box is empty → `sendAction` early-returns → the click is a silent no-op. (#343's own evidence missed this because that repro left/re-typed text in the box; the veteran's real turn-1 box was empty.)

**Fix:**
- Capture the in-flight move (already-neutralized `move` object + `label` + `actionId`) in a `lastMoveRef` on every `postMove`.
- New `retryStuck()`: if the player typed **new** text into the re-opened box, send that (the "or rephrase" path — already worked); otherwise **re-POST the exact stalled move**. Either way `postMove → armPending` re-arms the narrating state + the 90s recovery / 12-min backstop.
- Declare button + Enter route through `onDeclareClick = pendingStuck ? retryStuck() : sendAction()`, so non-stuck behavior is byte-for-byte unchanged.

Both branches verified: empty-box "Try again" → re-sends the stalled move; new-text "Try again" → sends the new text (last move = the rephrase).

### Finding 2 — Table nav still blocked from Map/Journal during narration → **NOT reproducible**

**Repro (headless CDP, real JSX):** arm an active pending turn on Table (`input.disabled=true`, placeholder "The Dungeon Master is narrating…"), then exercise the nav rail.

- All 6 nav-rail buttons during pending: `disabled:false`, `pointer-events:auto`, hit-test **uncovered** (the button is the topmost element at its center).
- `Table → Map → Table`: returns to Table, **in-flight turn preserved** (`input.disabled` still true on return — #340's lifted state working).
- `Table → Journal → Table`: same clean round-trip.

This matches #341: the nav rail / tab bar live at the App level and are pending-agnostic; the one churn hazard (the narrating dots' `transform: scale`) is already opacity-only. The veteran's nav complaint was most likely that now-fixed continuous-motion actionability artifact. **No nav change made.**

---

### Validation
- `qa/ui_audit_health.sh --quick --axe` → **axe total: 0 violations** across all 17 screens; health summary PASS.
- Both edited/affected JSX files transpile cleanly via the vendored in-browser Babel (`babel-standalone-7.29.0`).
- Targeted headless CDP repros (zero-dependency Node `WebSocket` driver over the real JSX) confirm before→after for finding 1 and not-repro for finding 2.

### Evidence
Verbatim CDP repro snapshots (real JSX, the patched build) — the load-bearing evidence is the `/move` call count, which a screenshot can't show:

```
# after first Declare (turn in flight)
declareBtn={"text":"Narrating…","disabled":true}  input={"disabled":true,"ph":"The Dungeon Master is narrating…"}  moves=[{"kind":"do","text":"I search the room for traps"}]
# after the 90s recovery fires (stuck)
declareBtn={"text":"Try again","disabled":false}  input={"value":"","disabled":false,"ph":"The DM seemed stuck — try again."}  stuckBeat=true  moves=[ …1 move… ]
# after clicking "Try again" (empty box) — PATCHED
declareBtn={"text":"Narrating…","disabled":true}  moves=[ …, {"kind":"do","text":"I search the room for traps"} ]   ← 2 moves: the stalled turn was re-POSTed
>>> VERDICT: moves 1 → 2  (before fix: 1 → 1, dead button)
```

Rephrase branch (type new text, then "Try again"): `moves = [ {"text":"I sneak past the guard"}, {"text":"I bribe the guard instead"} ]` — the new text is sent.

A local screenshot of the stuck state (toast "The Dungeon Master seems stuck" + the stuck beat in the chronicle + the re-enabled bar with the **"Try again"** button) was also captured during the repro.

Please admin-merge on green — do not auto-merge.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when the system becomes unresponsive: players can now retry their last action or submit a new one to recover from a stuck state.

* **UI/UX**
  * Unified the Declare button behavior to handle both new submissions and retry attempts through a consistent interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/346?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->