### PR TITLE
fix(engine): derive class+level max_hp for seated canon characters (#352)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1020,6 +1020,27 @@ def _derive_canon_abilities(class_name: str, level: int) -> "AbilityScores | Non
     return AbilityScores(**{_AB3_TO_FULL[ab]: val for ab, val in assigned.items()})
 
 
+def _class_level_hp(class_name: str, level: int, con_mod: int) -> "int | None":
+    """The SRD fixed-HP max for a single-class character of `class_name` at `level` with the
+    given CON modifier: max die + CON at L1, then average (die//2+1) + CON per level after.
+    Returns None for an unknown class (the caller can't size it). Deterministic and pure.
+
+    Extracted from _apply_srd_class_defaults so the canon-load seat path can use the SAME
+    formula to (a) compute a class+level-appropriate max_hp for a record that ships none and
+    (b) recognize a record whose explicit max_hp is BELOW the class+level floor (the #352
+    "critically-low canon max_hp" defect — a L5 Wizard seated at a flat 10 instead of ~32)."""
+    try:
+        die = srd_tables.hit_die(class_name.lower())
+    except (ValueError, AttributeError):
+        return None
+    try:
+        lvl = max(1, int(level))
+    except (TypeError, ValueError):
+        lvl = 1
+    per_level_after_first = (die // 2 + 1) + con_mod
+    return max(1, die + con_mod + (lvl - 1) * per_level_after_first)
+
+
 def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool) -> None:
     """Fill SRD class defaults onto a character in place: saving-throw proficiencies,
     hit dice, level-1 HP (max die + CON), proficiency bonus, class base AC (when
@@ -1035,8 +1056,7 @@ def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool
         if ch.max_hp <= 1:  # HP not explicitly provided -> compute for the FULL level
             # SRD fixed-HP: max die + CON at L1, then average (die//2+1) + CON per level.
             con = ch.abilities.modifier(Ability.CON)
-            per_level_after_first = (die // 2 + 1) + con
-            ch.max_hp = max(1, die + con + (level - 1) * per_level_after_first)
+            ch.max_hp = _class_level_hp(cname, level, con) or ch.max_hp
             ch.current_hp = ch.max_hp
         ch.proficiency_bonus = srd_tables.proficiency_bonus(level)
         if set_base_ac:
@@ -2229,19 +2249,40 @@ def load_canon_character(campaign_id: str, name: str, kind: str = "npc", add_to_
         if classes:
             _apply_srd_class_defaults(ch, classes[0].name, classes[0].level,
                                       set_base_ac=(ch.armor_class == 10))
-        # The Character default HP is a placeholder max_hp=1 (the model's bare default). An identity
-        # stub left at 1 HP is an INSTANT-KILL combatant: the first hit trips combat's SRD massive-
-        # damage rule (damage >= max_hp at 0 HP) and flags it dead before it's ever fleshed out
-        # (QA: a canon NPC pulled into a fight pre-recruit died in one hit, then stayed dead). Give
-        # the stub a SANE floor so a fresh canon figure can take a swing while awaiting its real
-        # sheet: honor a canon HP hint if the record carries one, else a modest default. (The full
-        # combat sheet still comes from apply_srd_defaults / recruit_companion.)
+        # MAX_HP (#352 — canon PC seated with a critically-low max_hp). The Character default is a
+        # placeholder max_hp=1, and an identity stub left at 1 HP is an INSTANT-KILL combatant: the
+        # first hit trips combat's SRD massive-damage rule (damage >= max_hp at 0 HP) and flags it
+        # dead before it's ever fleshed out (QA: a canon NPC pulled into a fight pre-recruit died in
+        # one hit). The OLD code floored every canon load to `max(canon_hp, 10)` — but for a CLASSED
+        # record that floor CLOBBERED the class+level HP _apply_srd_class_defaults just computed
+        # above (QA ow-living1: Latham, a L5 Guild Wizard with no `max_hp` field, was seated at a
+        # flat 10 instead of his class+level 32 — the angry-dm scorer's "single worst seam, must fix
+        # before combat"). Mirror the #322 ability-derivation: when the canon record lacks a SENSIBLE
+        # max_hp, DERIVE a class+level-appropriate one (hit-die + CON modifier per level, the same
+        # _class_level_hp formula the SRD defaults use) so a seated canon combatant is sized for its
+        # class+level. Precedence, deterministic + additive:
+        #   1. _apply_srd_class_defaults already set max_hp from the class+level floor (it ran on the
+        #      max_hp<=1 stub) — that is the class-appropriate value; keep it as the floor.
+        #   2. an EXPLICIT canon max_hp/hit_points that is >= that class floor is honored (a
+        #      hand-authored sheet, or a higher-than-formula canon value, always wins upward).
+        #   3. a class-less / unknown-class record (no floor) keeps the modest flat-10 stub default.
+        # An explicit canon HP BELOW the class+level floor is treated as a low placeholder and the
+        # class floor wins (the issue's "absent, OR below the class+level floor" case).
         try:
             canon_hp = int(rec.get("max_hp") or rec.get("hit_points") or 0)
         except (TypeError, ValueError):
             canon_hp = 0
-        ch.max_hp = max(canon_hp, 10)
-        ch.current_hp = ch.max_hp  # a fresh identity stub stands at full (placeholder) health
+        # The class+level floor (None for a class-less / unknown-class record). Computed off the now-
+        # seated abilities (derived/canon/placeholder), so CON is real — matches the SRD-defaults HP.
+        con_mod = ch.abilities.modifier(Ability.CON)
+        class_floor = _class_level_hp(classes[0].name, classes[0].level, con_mod) if classes else None
+        if class_floor is not None:
+            # Classed: never below the class+level floor; an explicit canon value above it wins.
+            ch.max_hp = max(class_floor, canon_hp)
+        else:
+            # Class-less / unknown class: honor an explicit canon HP, else the modest flat-10 stub.
+            ch.max_hp = max(canon_hp, 10)
+        ch.current_hp = ch.max_hp  # a fresh identity stub stands at full health
         # INVARIANT: a kind="player" character IS the party's protagonist — always in the
         # party, regardless of add_to_party. QA ow-rv1: the brief told the DM to load a canon
         # PC via load_canon_character(kind="player"), but add_to_party defaults False, so the

--- a/servers/engine/tests/test_canon_maxhp.py
+++ b/servers/engine/tests/test_canon_maxhp.py
@@ -1,0 +1,139 @@
+"""Canon max_hp derivation (#352: a seated canon PC got a critically-low max_hp — broke combat).
+
+A standalone canon character JSON ships a class + level but (across the shipped corpus) NO
+`max_hp` field. `load_canon_character` runs `_apply_srd_class_defaults`, which DOES compute the
+correct class+level HP onto the max_hp<=1 stub — but the seat path then UNCONDITIONALLY floored
+the result to `max(canon_hp, 10)`, clobbering it back down to a flat 10 for every classed canon
+figure. QA ow-living1 (living-PC duo): Charming Latham, a L5 Guild Wizard with no `max_hp`, was
+seated at max_hp 10 instead of his class+level 32 — the angry-dm scorer's "single worst seam,
+must fix before combat." (Same stat-seeding class as #322, where canon records lacked an
+`abilities` block and seated flat-10 ability scores.)
+
+These guard the engine-level fix in server.load_canon_character (and the shared _class_level_hp
+helper that both it and _apply_srd_class_defaults now use):
+  * a class-typed canon record with NO max_hp -> a class+level-appropriate value (hit-die + CON
+    per level), NOT a flat 10 (Latham, a real canon L5 Wizard -> 32);
+  * a record whose EXPLICIT max_hp is at or above the class+level floor -> that value is honored
+    (a hand-authored / higher-than-formula sheet always wins upward);
+  * a record whose EXPLICIT max_hp is BELOW the class+level floor -> the class floor wins (the
+    "critically-low canon max_hp" case — a low placeholder must not seat a fragile combatant);
+  * a class-less / unknown-class record -> the modest flat-10 stub (today's behavior), since it
+    can't be sized for a class+level.
+"""
+
+import pytest
+
+import content
+import server
+import srd_tables
+from models import Ability
+
+WORLD = "baldurs-gate"
+
+
+def _seed(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    c = content.seed_world(content.load_world_data(WORLD))
+    server.save_campaign(c)
+    return c
+
+
+# --- the _class_level_hp helper, in isolation -------------------------------
+
+def test_class_level_hp_matches_srd_fixed_hp_formula():
+    # SRD fixed-HP: max die + CON at L1, then average (die//2+1) + CON per level after.
+    # Wizard d6, CON +2, L5: 6+2 + 4*((6//2+1)+2) = 8 + 4*5 = 28? No — die+con at L1 = 8,
+    # plus (5-1) levels * (4 + 2) = 4*6 = 24 -> wait: per-level = (die//2+1)+con = 4+2 = 6.
+    # 8 + 4*6 = 32. (CON +2 from the L5 wizard's derived array.)
+    assert server._class_level_hp("wizard", 5, 2) == 32
+    # L1 of any class is just max-die + CON.
+    assert server._class_level_hp("wizard", 1, 2) == srd_tables.hit_die("wizard") + 2
+    assert server._class_level_hp("fighter", 1, 3) == srd_tables.hit_die("fighter") + 3
+    # A d8 cleric at L3, CON +2: 8+2 + 2*((8//2+1)+2) = 10 + 2*7 = 24.
+    assert server._class_level_hp("cleric", 3, 2) == 24
+    # Negative CON is allowed but the value never drops below 1.
+    assert server._class_level_hp("wizard", 1, -5) >= 1
+
+
+def test_class_level_hp_returns_none_for_unknown_class():
+    # An unknown / class-less label can't be sized -> None (the caller keeps the flat-10 stub).
+    assert server._class_level_hp("", 1, 0) is None
+    assert server._class_level_hp("townsperson", 5, 0) is None
+
+
+def test_class_level_hp_tolerates_bad_level():
+    # A non-int level coerces to L1 rather than raising (canon `level` is a string field).
+    assert server._class_level_hp("wizard", "oops", 2) == srd_tables.hit_die("wizard") + 2
+    assert server._class_level_hp("wizard", None, 2) == srd_tables.hit_die("wizard") + 2
+
+
+# --- through the load_canon_character tool ----------------------------------
+
+def test_canon_wizard_seats_with_class_level_maxhp_not_flat_ten(tmp_path, monkeypatch):
+    # THE #352 REPRO. Charming Latham (Guild) is a LIVING canon L5 Wizard shipping no `max_hp`
+    # field. He must seat at his class+level HP (d6 hit-die + CON per level = 32 with the #322-
+    # derived CON +2), NOT the old flat-10 floor that broke combat.
+    c = _seed(tmp_path, monkeypatch)
+    res = server.load_canon_character(c.id, "Charming Latham", kind="player", add_to_party=True)
+    assert "error" not in res
+    ch = server._require(c.id).characters[res["id"]]
+    con = ch.abilities.modifier(Ability.CON)
+    expected = server._class_level_hp("wizard", 5, con)
+    assert ch.max_hp == expected == 32, (ch.max_hp, expected)
+    assert ch.max_hp > 10, "must NOT be the critically-low flat-10 floor"
+    assert ch.current_hp == ch.max_hp  # seats at full health
+    assert ch.hit_dice == "5d6"
+
+
+def test_classed_canon_with_no_hp_derives_floor(tmp_path, monkeypatch):
+    # A different class+level (Cleric d8, L3) with no max_hp also seats at its class floor.
+    c = _seed(tmp_path, monkeypatch)
+    record = {"name": "Plain Cleric", "race": "Human", "class": "Cleric", "level": "3"}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: record)
+    res = server.load_canon_character(c.id, "Plain Cleric", kind="npc")
+    assert "error" not in res and not res.get("already_present")
+    ch = server._require(c.id).characters[res["id"]]
+    con = ch.abilities.modifier(Ability.CON)
+    assert ch.max_hp == server._class_level_hp("cleric", 3, con) > 10
+
+
+def test_explicit_canon_maxhp_above_floor_is_preserved(tmp_path, monkeypatch):
+    # A hand-authored / higher-than-formula canon max_hp (above the class+level floor) wins upward
+    # and is NOT lowered to the formula value. (No record ships one today; inject via the loader.)
+    c = _seed(tmp_path, monkeypatch)
+    record = {"name": "Beefy Fighter", "race": "Human", "class": "Fighter", "level": "5",
+              "max_hp": 99}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: record)
+    res = server.load_canon_character(c.id, "Beefy Fighter", kind="companion", add_to_party=True)
+    assert "error" not in res and not res.get("already_present")
+    ch = server._require(c.id).characters[res["id"]]
+    assert ch.max_hp == 99, "an explicit canon max_hp above the class floor must be honored"
+    assert ch.current_hp == 99
+
+
+def test_explicit_canon_maxhp_below_floor_uses_class_floor(tmp_path, monkeypatch):
+    # The "critically-low canon max_hp" case: an explicit value BELOW the class+level floor is a
+    # low placeholder; the class floor must win so the seated combatant isn't one-shot fragile.
+    c = _seed(tmp_path, monkeypatch)
+    record = {"name": "Underfed Wizard", "race": "Human", "class": "Wizard", "level": "5",
+              "max_hp": 4}  # absurdly low for a L5 wizard
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: record)
+    res = server.load_canon_character(c.id, "Underfed Wizard", kind="player", add_to_party=True)
+    assert "error" not in res
+    ch = server._require(c.id).characters[res["id"]]
+    con = ch.abilities.modifier(Ability.CON)
+    floor = server._class_level_hp("wizard", 5, con)
+    assert ch.max_hp == floor > 4, (ch.max_hp, floor)
+
+
+def test_classless_canon_keeps_flat_ten_stub(tmp_path, monkeypatch):
+    # A class-less / unknown-class record can't be sized for a class+level, so it keeps the modest
+    # flat-10 identity stub (today's behavior — never the instant-kill max_hp=1 default).
+    c = _seed(tmp_path, monkeypatch)
+    record = {"name": "Nameless Ghost", "race": "Human", "class": ""}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: record)
+    res = server.load_canon_character(c.id, "Nameless Ghost", kind="npc")
+    assert "error" not in res and not res.get("already_present")
+    ch = server._require(c.id).characters[res["id"]]
+    assert ch.max_hp == 10
+    assert ch.current_hp == 10

--- a/servers/engine/tests/test_companion_dossier.py
+++ b/servers/engine/tests/test_companion_dossier.py
@@ -154,18 +154,26 @@ def test_load_canon_character_populates_dossier(tmp_path, monkeypatch):
     assert "knowledge" in sheet["companion_dossier"]["values"]
 
 
-def test_load_canon_character_applies_hp_floor_through_the_tool(tmp_path, monkeypatch):
-    # The HP-floor THROUGH THE TOOL: a canon identity stub must NOT load at the model's
-    # placeholder max_hp=1 (a one-hit-kill in combat). server.load_canon_character floors it
-    # to >=10 with current_hp==max_hp (server.py ~1685). Gale ships no canon HP hint, so the
-    # floor is the sole reason his max_hp is 10 — delete the floor and this assert goes red.
+def test_load_canon_character_derives_class_level_hp_through_the_tool(tmp_path, monkeypatch):
+    # DERIVED MAX_HP THROUGH THE TOOL: a canon identity stub must NOT load at the model's
+    # placeholder max_hp=1 (a one-hit-kill in combat). #352 replaced the old arbitrary flat-10
+    # floor with a class+level-derived max_hp: server.load_canon_character runs the shared
+    # `_class_level_hp` helper (hit-die + CON per level) and seats current_hp==max_hp. Gale ships
+    # no canon HP hint and is a Wizard L1 (CON +2 from the #322-derived array), so his max_hp is
+    # d6 + CON = 8 — the sole reason it isn't the placeholder 1. Mirrors test_canon_maxhp.py.
     monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
     bg = server.start_world("baldurs-gate")["campaign_id"]
     res = server.load_canon_character(bg, "Gale")  # fresh load (Gale isn't rostered)
     assert not res.get("already_present")
     sheet = server.get_character(bg, res["id"])
-    assert sheet["max_hp"] >= 10  # floored above the placeholder 1
-    assert sheet["current_hp"] == sheet["max_hp"]  # a fresh stub stands at full (placeholder) health
+    # Derive the expected value from the seated sheet the same way the engine does: hit-die +
+    # CON per level for the char's (single) class + level. AbilityScores.modifier == (score-10)//2.
+    cls = sheet["classes"][0]
+    con = (sheet["abilities"]["constitution"] - 10) // 2
+    expected = server._class_level_hp(cls["name"], cls["level"], con)
+    assert sheet["max_hp"] == expected == 8, (sheet["max_hp"], expected)  # Wizard L1, CON +2 -> d6+2
+    assert sheet["max_hp"] > 1  # NOT the one-hit-kill placeholder the derive replaced
+    assert sheet["current_hp"] == sheet["max_hp"]  # a fresh stub stands at full health
 
 
 def test_coerce_dossier_degrades_on_malformed():


### PR DESCRIPTION
Closes #352

## Root cause
A canon character JSON carries a **class + level** but (across the entire shipped corpus) **no `max_hp` field**. In `load_canon_character` (`servers/engine/server.py`), `_apply_srd_class_defaults` DOES compute the correct class+level HP onto the `max_hp<=1` stub — but the seat path immediately after **unconditionally floored** the result:

```python
ch.max_hp = max(canon_hp, 10)   # canon_hp == 0 for a record with no HP field
```

So for **every classed canon figure** the class+level HP was clobbered back down to a flat **10**. That flat-10 floor was only meant for *class-less* identity stubs (so a bare NPC isn't an instant-kill `max_hp=1` combatant), but it wrongly applied to classed records too.

QA **ow-living1** (living-PC canon duo): **Charming Latham**, a L5 Guild Wizard with no `max_hp`, was seated at **max_hp 10** — the angry-dm scorer's *"single worst seam, must fix before combat."* This is the same stat-seeding class as **#322** (canon records lacked an `abilities` block → flat-10 ability scores, fixed by deriving at load).

## Fix
Mirror the #322 ability-derivation. When a canon record lacks a **sensible** `max_hp`, **derive a class+level-appropriate one at load**. The formula is the SRD fixed/average-HP convention already used by `_apply_srd_class_defaults` and `level_up`:

> **hit-die + CON-mod** at L1, then **(die//2 + 1) + CON-mod** per level after.

I extracted that formula into a shared helper `_class_level_hp(class_name, level, con_mod)` (single source of truth — `_apply_srd_class_defaults` now calls it too) and applied it in the canon seat path.

**Precedence (deterministic + additive):**
1. A **classed** record is never seated below its class+level floor (the value `_apply_srd_class_defaults` computed).
2. An **explicit** canon `max_hp`/`hit_points` **at or above** the floor is honored upward (a hand-authored or higher-than-formula sheet wins).
3. An explicit value **below** the floor is treated as a low placeholder and the **class floor wins** (the issue's *"absent, OR below the class+level floor"* case).
4. A **class-less / unknown-class** record can't be sized, so it keeps the modest **flat-10 stub** (today's behavior — never the instant-kill `max_hp=1`).

The CON modifier used is the now-seated one (the #322 derived/canon/explicit abilities), so the floor matches the SRD-defaults HP exactly.

## Evidence (Latham before → after)
| | max_hp |
|---|---|
| **Before** | **10** (flat `max(canon_hp=0, 10)` floor) |
| **After** | **32** (d6 hit-die + CON +2/level, with the #322-derived CON 14) |

`6 + 2` at L1, then `4 × ((6//2+1) + 2)` = `8 + 20` = **32**. Verified in vivo by seating Latham via `load_canon_character(kind="player")`.

## Invariants / scope
- **Engine = sole writer** — fix is entirely in `servers/engine/server.py`.
- **Additive** (+52 / −11 in `server.py`; the deletions are the inline-formula extraction + the old clobber). Empty/old snapshots round-trip; class-less behavior unchanged.
- **No wire contracts touched** (`CLAWDND_*`, `clawdnd-*` MCP ids, bundle id all untouched).

## Tests
Adds `servers/engine/tests/test_canon_maxhp.py`:
- `_class_level_hp` formula (incl. unknown-class → `None`, bad-level coercion);
- **the Latham repro** — real canon L5 Wizard → 32, not 10;
- classed-no-hp derivation (Cleric L3);
- explicit canon HP **above** floor → preserved (99);
- explicit canon HP **below** floor → class floor wins;
- class-less record → flat-10 stub.

Focused single-process run green locally (`test_canon_maxhp.py` + `test_canon_abilities.py` = 15 passed; `test_engine`/`test_progression`/`test_class_features`/`test_combat`/`test_playable_alive`/`test_content` = 264 passed — the `_apply_srd_class_defaults` refactor is regression-safe). Relying on CI for the full suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected character HP derivation so max HP is computed from class, level, and Constitution (SRD rules); explicit max HP values are preserved when above that floor. Class-less/unknown records retain the earlier flat-10 fallback. current HP now initializes to the resulting max HP.

* **Tests**
  * Added unit and end-to-end tests covering class/level HP calculation, unknown classes, and max/current HP behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->