### PR TITLE
fix(openworlds): Resume→play banner mints a DM in the native app (Addresses #356)

### DIFF
--- a/viewer/openworlds/screen-launcher.jsx
+++ b/viewer/openworlds/screen-launcher.jsx
@@ -88,6 +88,14 @@ function ScreenLauncher({ onNavigate, state, setState }) {
     const target = c || playableCampaign;
     if (!target) return;
     setState((s) => ({ ...s, activeCampaign: target.id }));
+    // #356: in the native app a canResume-but-not-yet-live campaign has NO attached DM, so navigating
+    // straight to the table lands in the read-only director's view. Mint a provider session via the
+    // bridge (the startPlay path, exactly as onResume does). Only drop straight into the table when the
+    // session is ALREADY live (an in-browser already-live run, or a browser preview with no bridge).
+    if (window.OpenWorldsNative?.hasBridge?.() && !target.live) {
+      startPlay(target.world);
+      return;
+    }
     onNavigate("table");
   };
 


### PR DESCRIPTION
## Release-blocker #356 — a fresh player cannot start play in the built app

Found by the first honest baseline against the BUILT `dist/WorldOS.app` (build_sha 4267247, v1.0.3). The launcher's prominent "RESUME → PLAY" ContinueBanner called `enterPlayable`, which only did `setState + onNavigate("table")` — it never minted a DM. On a `canResume:true, live:false` save in the native app there is no DM → the read-only director's view (`can_act:false`). This is the owner's exact complaint.

## Fix
`enterPlayable` now routes through `startPlay(target.world)` (the existing `startProviderSession` bridge path that `onResume` uses) when a native bridge exists AND the campaign isn't already live. The already-live and browser-preview cases still drop straight into the table.

## Verification (per the operating loop)
**Do NOT close on merge.** Close only when the NEXT build's `.app` baseline confirms a fresh newbie clicks Resume→play and reaches a live, `can_act:true` session (completes the intro flow). I will re-run the baseline after this merges.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed campaign resumption on native apps when campaigns are not yet marked as live. The application now properly initializes the session before navigating to gameplay.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->