### PR TITLE
fix(openworlds): character — #308 #288 (#287 already fixed on main)

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -181,7 +181,7 @@ function ScreenCharacter({ onNavigate, state, setState }) {
         </Panel>
 
         {/* Lower split: stats blocks + tab content */}
-        <div style={{ display: "grid", gridTemplateColumns: "1.05fr 1.7fr 1fr", gap: 14, minHeight: 0 }}>
+        <div className="stack-on-narrow" style={{ display: "grid", gridTemplateColumns: "1.05fr 1.7fr 1fr", gap: 14, minHeight: 0 }}>
 
           {/* Combat block */}
           <Panel framed style={{ padding: 22, overflow: "auto" }}>
@@ -749,6 +749,9 @@ function spellMeta(sp) {
 }
 
 function LineagePanel({ hero }) {
+  // A dead hero's sheet drops the lineage panel entirely (#308) — the living-world surface
+  // stops projecting lineage flavor for the fallen, so render nothing rather than a stale block.
+  if (hero.dead) return null;
   // Surface the engine's authoritative lineage: race (+ subrace) as the heading, the
   // racial traits the snapshot carries, and any backstory/personality flavor note. Honest
   // empty-state only when the snapshot truly records no race and no flavor — never invent.


### PR DESCRIPTION
## Summary

Two scoped fixes to the OpenWorlds Character screen (`viewer/openworlds/screen-character.jsx`), plus an honest note on a third issue that turned out to already be fixed on `main`.

### #308 — Lineage panel renders for a dead hero
**Root cause:** `LineagePanel` projected the hero's race / subrace / racial-traits / flavor note with no `hero.dead` check, so a fallen party member's sheet still showed a full lineage block. `hero.dead` is an existing field on the `/character-surface` read-model (already consumed by `ResourcesStatus` for the "dying" gate), so the panel had the signal available — it just never checked it.
**Change:** added `if (hero.dead) return null;` as the first guard in `LineagePanel`'s render. A dead hero now drops the lineage block entirely. Per the issue, **icon rendering is deferred and left untouched** here.

### #288 / #284 — 3-column character split crowds below 1200px
**Root cause:** the `.stack-on-narrow` responsive helper (`styles.css:906`, `grid-template-columns: 1fr !important` under `@media (max-width: 1200px)`) was defined but **never applied** in any screen JSX (#284). On the Character screen the lower split (Combat / tab content / Lineage, `gridTemplateColumns: '1.05fr 1.7fr 1fr'`) therefore stayed 3-wide and crowded at the 1366×768 laptop floor (#288).
**Change:** appended `className="stack-on-narrow"` to that nested grid div. No new CSS — this is the existing rule's first use. The grid now collapses to a single column under 1200px.

### #287 — NOT changed (already fixed on `main`)
The issue describes the **Special Abilities** header and **Lineage > traits** rendering without gating, leaving empty panes. Both were already fixed on `main`:
- commit `f6be4de` added inline empty-states to `AbilitiesTab` (`abilities.length > 0 ? cards : "No active abilities recorded — this hero's edge is in their feats and class features."`, plus the analogous Feats empty-state) and gated the right-column **Traits** section (`hero.traits.length > 0 ? … : "No distinguishing traits recorded."`);
- commit `8dd17f8` introduced `LineagePanel` with its racial-traits list already gated on `{traits.length > 0 && …}`.

Applying the proposed `{abilities.length > 0 && …}` wrap now would **regress** the screen by deleting that intentional empty-state line (Astarion, who ships `abilities: []` but has feats, would lose the "Special Abilities" header *and* its explanatory line). The `LineagePanel` race heading is correctly gated on `race` (not on traits) — a hero with a race but no enumerated traits should still show its race. So #287 is intentionally left as-is.

## Scope
Touches only `viewer/openworlds/screen-character.jsx` (4 insertions, 1 deletion). No engine, surface, or CSS changes.

Addresses #287, #308, #288

**Do NOT close on merge — verify on the next build's playtest.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed character detail panel visibility for deceased characters.

* **Style**
  * Improved responsive layout for narrow screen displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->