### PR TITLE
fix(openworlds): inventory — #310

### DIFF
--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -129,7 +129,7 @@ function ScreenInventory({ onNavigate, state, setState }) {
   }
 
   return (
-    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "320px 1fr 320px", gap: 14, padding: 14 }}>
+    <div className="screen stack-on-narrow" style={{ height: "100%", display: "grid", gridTemplateColumns: "320px 1fr 320px", gap: 14, padding: 14 }}>
 
       {/* LEFT — Hero & equipped */}
       <Panel framed style={{ padding: 22, overflow: "auto" }}>
@@ -396,7 +396,7 @@ function PaperDoll({ hero }) {
     <div style={{ marginTop: 16 }}>
       <div className="eyebrow" style={{ marginBottom: 8 }}>Equipped</div>
       {/* doll: left slots | portrait | right slots */}
-      <div style={{ display: "grid", gridTemplateColumns: "52px 1fr 52px", gap: 8, alignItems: "start" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "52px 280px 52px", gap: 8, alignItems: "start" }}>
         <div style={{ display: "grid", gap: 6 }}>
           {col("left").map((s) => <EquipSlotCell key={s.id} slot={s} item={assigned[s.id]} />)}
         </div>


### PR DESCRIPTION
## Summary

Fixes two layout bugs in the OpenWorlds Inventory & Stash screen (`viewer/openworlds/screen-inventory.jsx`).

### #310 (1) — Paper-doll center column expands unbounded

**Root cause:** The equipped paper-doll grid used `gridTemplateColumns: "52px 1fr 52px"`. The `1fr` center track (holding the full-art hero portrait) grew to consume all leftover space in the left panel, so the portrait — and the two 52px equip-slot rails flanking it — sprawled as the panel widened, breaking the intended compact doll layout.

**Change:** Constrained the center track to a fixed width: `"52px 280px 52px"`. The portrait now renders at a stable size and the slot rails stay pinned beside it.

### #310 (2) — Top-level 3-column grid never collapses on narrow viewports

**Root cause:** The screen's outer grid was `gridTemplateColumns: "320px 1fr 320px"` with only `className="screen"`. There is an existing responsive rule in `styles.css` (`@media (max-width: 1200px) { .stack-on-narrow { grid-template-columns: 1fr !important; } }`), but this screen never opted into it, so the three rigid columns (320px + content + 320px) overflowed below 1200px instead of stacking.

**Change:** Appended the `stack-on-narrow` utility class (`className="screen stack-on-narrow"`). Below 1200px the grid now collapses to a single column via the pre-existing CSS rule (whose `!important` correctly overrides the inline `gridTemplateColumns`). This is the first screen to wire up the utility; no CSS changes were needed.

## Scope

- Touches only `viewer/openworlds/screen-inventory.jsx` (2 lines changed).
- Purely additive / minimal; matches existing inline-style conventions.

Addresses #310

**Do NOT close on merge — verify on the next build's playtest.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for the inventory screen on narrow displays.
  * Refined equipment display proportions for better visual balance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->