### PR TITLE
fix(openworlds): settings — #317

### DIFF
--- a/viewer/openworlds/screen-settings.jsx
+++ b/viewer/openworlds/screen-settings.jsx
@@ -135,7 +135,7 @@ function ScreenSettings({ onNavigate, state, setState, nativeState, refreshNativ
   ];
 
   return (
-    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "220px 1fr", gap: 14, padding: 14 }}>
+    <div className="screen stack-on-narrow" style={{ height: "100%", display: "grid", gridTemplateColumns: "220px 1fr", gap: 14, padding: 14 }}>
 
       {/* LEFT — section list */}
       <Panel framed style={{ padding: 22, overflow: "auto" }}>
@@ -196,6 +196,10 @@ function ScreenSettings({ onNavigate, state, setState, nativeState, refreshNativ
           <SettingsSection title="What the Eye Sees" eyebrow="Lantern & ink" ordinal="II.">
             {/* GENUINELY FUNCTIONAL: drives --ui-scale on <html> (styles.css zooms .window). */}
             <Slider label="UI scale" value={a11y.uiScale} onChange={(v) => applyA11y({ uiScale: v })} min={75} max={150} unit="%" />
+
+            <Divider />
+            <SectionTitle>Not yet wired</SectionTitle>
+            <PreviewBanner>Display-only — the controls below have no backing yet. UI scale above is live and persists across reloads.</PreviewBanner>
             <Slider preview label="Contrast" value={display.contrast} onChange={(v) => setDisplay({ ...display, contrast: v })} />
 
             <Divider />
@@ -349,9 +353,14 @@ function ScreenSettings({ onNavigate, state, setState, nativeState, refreshNativ
                 </ul>
                 <Divider />
                 <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
-                  <BrassButton size="sm" tone="ghost">Patch notes</BrassButton>
-                  <BrassButton size="sm" tone="ghost">Licenses</BrassButton>
-                  <BrassButton size="sm" tone="ghost">Report a bug</BrassButton>
+                  {/* The CHANGELOG.md / THIRD_PARTY_NOTICES.md docs live at the repo root, which the
+                      viewer's HTTP server does NOT serve (only /openworlds/* assets are reachable,
+                      and traversal outside the bundle is blocked — see server.py _openworlds_asset).
+                      Pointing at /CHANGELOG.md would 404, so to stay honest we open the canonical
+                      source on GitHub in a new tab rather than wiring a dead local link. */}
+                  <BrassButton size="sm" tone="ghost" title="Open the changelog on GitHub" onClick={() => window.open("https://github.com/electricsheephq/WorldOS/blob/HEAD/CHANGELOG.md", "_blank", "noopener,noreferrer")}>Patch notes</BrassButton>
+                  <BrassButton size="sm" tone="ghost" title="Open the third-party licenses on GitHub" onClick={() => window.open("https://github.com/electricsheephq/WorldOS/blob/HEAD/THIRD_PARTY_NOTICES.md", "_blank", "noopener,noreferrer")}>Licenses</BrassButton>
+                  <BrassButton size="sm" tone="ghost" title="Report a bug on GitHub" onClick={() => window.open("https://github.com/electricsheephq/WorldOS/issues/new", "_blank", "noopener,noreferrer")}>Report a bug</BrassButton>
                 </div>
               </div>
             </div>
@@ -417,12 +426,12 @@ function NativeAppSection({ nativeState, refreshNative }) {
         <Panel framed style={{ padding: 18 }}>
           <SectionTitle>Native Actions</SectionTitle>
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-            <BrassButton size="sm" onClick={() => nativeAction("startViewer")}>Start Viewer</BrassButton>
-            <BrassButton size="sm" tone="ghost" onClick={() => nativeAction("stopViewer")}>Stop Viewer</BrassButton>
-            <BrassButton size="sm" onClick={startProvider}>Start Provider</BrassButton>
-            <BrassButton size="sm" tone="ghost" onClick={() => nativeAction("stopProvider")}>Stop Provider</BrassButton>
-            <BrassButton size="sm" tone="ghost" onClick={() => nativeAction("copyDiagnostics")}>Copy Diagnostics</BrassButton>
-            <BrassButton size="sm" tone="ghost" onClick={() => nativeAction("openFallbackDashboard")}>Debug Dashboard</BrassButton>
+            <BrassButton size="sm" title="Start the local viewer process that serves this UI" onClick={() => nativeAction("startViewer")}>Start Viewer</BrassButton>
+            <BrassButton size="sm" tone="ghost" title="Stop the local viewer process serving this UI" onClick={() => nativeAction("stopViewer")}>Stop Viewer</BrassButton>
+            <BrassButton size="sm" title="Launch a provider session for the default world (e.g. Claude)" onClick={startProvider}>Start Provider</BrassButton>
+            <BrassButton size="sm" tone="ghost" title="Stop the running provider session" onClick={() => nativeAction("stopProvider")}>Stop Provider</BrassButton>
+            <BrassButton size="sm" tone="ghost" title="Copy app status and recent diagnostics to the clipboard" onClick={() => nativeAction("copyDiagnostics")}>Copy Diagnostics</BrassButton>
+            <BrassButton size="sm" tone="ghost" title="Open the fallback debug dashboard in your browser" onClick={() => nativeAction("openFallbackDashboard")}>Debug Dashboard</BrassButton>
           </div>
           <p className="body-sm muted" style={{ marginTop: 12 }}>
             Native actions supervise local processes only. Game intent still travels through the existing engine/player move lane.


### PR DESCRIPTION
## Summary

Fixes a cluster of polish/wiring bugs in the **Settings** screen (`viewer/openworlds/screen-settings.jsx`). All changes are additive, scoped to that single file, and reuse patterns already present in it (`PreviewBanner`, `SectionTitle`, `BrassButton` `title`/`onClick`).

Addresses #317.

## Root cause + what changed, per issue

**#317 (1) — Native Actions buttons had no tooltips.**
The six buttons in the "Native Actions" panel (Start/Stop Viewer, Start/Stop Provider, Copy Diagnostics, Debug Dashboard) supervise local processes but gave no hint of what they do on hover. `BrassButton` already forwards an optional `title` (used elsewhere for action-bar hints), so each button now carries a concise descriptive `title=`.

**#317 (2) — Display section was missing the honest-UI PreviewBanner.**
Every other prototype section (Sound, Gameplay, Controls) shows a `<PreviewBanner>` so players know the controls are decorative. Display was missing one. Display is a *mixed* section: **UI scale is genuinely functional** (it drives `--ui-scale` on `<html>`, backed by real CSS and persisted via `OpenWorldsA11y`), while Contrast/Atmosphere/Window are previews. To avoid falsely labelling the live control as dead, I mirrored the **Accessibility** section's pattern: the live UI-scale slider stays at the top, then a `Divider` + `Not yet wired` `SectionTitle` + `PreviewBanner` precede the preview controls, with banner copy that explicitly notes UI scale above is live.

**#317 (3) — About buttons (Patch notes / Licenses / Report a bug) were unwired.**
All three were dead `<BrassButton>`s with no `onClick`. They now open in a new tab via `window.open(..., "_blank", "noopener,noreferrer")`:
- **Report a bug** → `https://github.com/electricsheephq/WorldOS/issues/new` (as specified).
- **Patch notes** → the canonical `CHANGELOG.md` **on GitHub**.
- **Licenses** → the canonical `THIRD_PARTY_NOTICES.md` **on GitHub**.

> **Intentional deviation from the brief (please review):** the task asked these two to point at `/CHANGELOG.md` and `/THIRD_PARTY_NOTICES.md`. I verified the viewer's HTTP server (`viewer/server.py`) does **not** serve repo-root docs — only `/openworlds/*` assets are reachable, and `_openworlds_asset()` blocks traversal outside the bundle via `target.relative_to(root)`. A local `/CHANGELOG.md` link would therefore **404**, i.e. a control that looks wired but dead-ends — exactly the "silently lying" UI this screen is built to avoid. Both docs *are* tracked at the repo root on the default branch, so I wired the buttons to their canonical GitHub source instead. This keeps the change inside the single permitted file (no new server route, no copying docs into the served bundle). If you'd rather serve the docs locally, that's a separate (multi-file) change — happy to follow up.

**Plus:** appended `stack-on-narrow` to the top-level grid `className` (the existing `.stack-on-narrow` rule in `styles.css` collapses the 220px + 1fr grid to a single column on narrow viewports).

## Testing

No heavy local tests run (per repo policy, CI runs in the cloud). Verified locally: the diff is additive and scoped to one file; delimiters balance; every new construct (`PreviewBanner`, `SectionTitle`, `Divider`, `BrassButton` with `title`/`onClick`, `window.open`) already exists in this file. CI's babel transform + viewer static tests will exercise the JSX on this PR.

## Merge note

**Do NOT close on merge — verify on the next build's playtest.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Changelog, Licenses, and Bug Report links to properly open GitHub pages

* **Style**
  * Clarified which Display settings (e.g., Contrast controls) are not yet functional with "Not yet wired" notices
  * Improved descriptive labels for Native Actions panel buttons

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->