### PR TITLE
fix(openworlds): server-relations — #286 #311

### DIFF
--- a/viewer/openworlds/screen-relations.jsx
+++ b/viewer/openworlds/screen-relations.jsx
@@ -262,7 +262,7 @@ function FactionDetail({ f }) {
         }}>{(f.motto && f.motto.trim()) ? f.motto : f.name}</div>
         {/* Sigil */}
         <div style={{
-          position: "absolute", top: -10, right: 10,
+          position: "absolute", top: 8, right: 10,
           width: 36, height: 36, borderRadius: "50%",
           background: "radial-gradient(circle at 30% 30%, var(--b-200), var(--b-500))",
           boxShadow: "inset 0 0 0 1px var(--b-600), 0 2px 4px rgba(0,0,0,0.4)",

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3380,7 +3380,19 @@ def _character_sheet(cid: str, ch: dict) -> dict:
 
     conditions = [str(c).replace("_", " ").title() for c in (ch.get("conditions") or []) if str(c)]
     death = ch.get("death_saves") if isinstance(ch.get("death_saves"), dict) else {}
+    # The engine's `features` list holds CLASS/SUBCLASS features only (models.Character.features
+    # is populated from srd_tables.features_through/features_at). Chosen FEATS are recorded
+    # separately as "| feat: <Name>" markers in ch.notes (engine level_up path). Surface those
+    # two distinct sources so the sheet's Feats tab and Class Features list are not identical
+    # duplicates (#286): classFeatures <- features, feats <- notes feat-markers (empty when none).
     features = [_text(f) for f in (ch.get("features") or []) if _text(f)]
+    feat_names: list[str] = []
+    for seg in _text(ch.get("notes")).split("|"):
+        seg = seg.strip()
+        if seg.lower().startswith("feat:"):
+            fname = seg.split(":", 1)[1].strip()
+            if fname and fname not in feat_names:
+                feat_names.append(fname)
     equipped = [
         {"slot": _text(it.get("slot"), "Worn"), "name": _text(it.get("name")), "glyph": _text(it.get("name"), "item").lower()}
         for it in (ch.get("inventory") or []) if isinstance(it, dict) and bool(it.get("equipped")) and _text(it.get("name"))
@@ -3415,7 +3427,7 @@ def _character_sheet(cid: str, ch: dict) -> dict:
         "dead": bool(ch.get("dead")),
         "stable": bool(ch.get("stable")),
         "equipped": equipped,
-        "feats": [{"name": f, "glyph": "feat", "detail": ""} for f in features],
+        "feats": [{"name": f, "glyph": "feat", "detail": ""} for f in feat_names],
         "abilities": [],
         "proficiencies": features,
         "classFeatures": [{"name": f, "detail": ""} for f in features],
@@ -3669,6 +3681,32 @@ def _standing_label(rep: int) -> str:
     return "Welcome"
 
 
+# Leading articles/qualifiers stripped before deriving a faction sigil so
+# "The Flaming Fist" reads as "FF" (not "T") and "Order of the Gauntlet" as "G".
+_FACTION_SIGIL_PREFIXES = ("the ", "order of the ", "order of ", "cult of the ",
+                           "cult of ", "house of ", "house ", "clan ", "guild of ",
+                           "guild ", "company of the ", "company of ")
+
+
+def _faction_sigil(name: str) -> str:
+    """Derive a 1-2 letter sigil for a faction medallion. Strips a leading article/
+    qualifier ("The ", "Order of ", "Cult of ", ...) then takes the initials of the
+    first one or two remaining words, so "The Flaming Fist" -> "FF" and a single-word
+    faction -> its first letter."""
+    base = _text(name).strip()
+    low = base.lower()
+    for pre in _FACTION_SIGIL_PREFIXES:
+        if low.startswith(pre) and len(low) > len(pre):
+            base = base[len(pre):].strip()
+            break
+    words = [w for w in base.replace("-", " ").split() if w]
+    if not words:
+        return "✦"
+    if len(words) == 1:
+        return words[0][:1].upper()
+    return (words[0][:1] + words[1][:1]).upper()
+
+
 def _relations_factions(snapshot: dict) -> list[dict]:
     factions = snapshot.get("factions")
     out: list[dict] = []
@@ -3687,7 +3725,7 @@ def _relations_factions(snapshot: dict) -> list[dict]:
             "short": _text(row.get("description"))[:48] or "a standing power",
             "kind": "Faction",
             "color": _FACTION_COLORS[i % len(_FACTION_COLORS)],
-            "sigil": name[:1].upper() or "✦",
+            "sigil": _faction_sigil(name),
             "motto": tags[0].title() if tags else "",
             "seat": "",
             "rep": _reputation_to_bar(rep),


### PR DESCRIPTION
## Summary

Two WorldOS OpenWorlds UI fixes in the relations/character surface. Touches only `viewer/server.py` and `viewer/openworlds/screen-relations.jsx`.

### #286 — Feats tab and Class Features list showed identical content

**Root cause:** In `_character_sheet` (`viewer/server.py`), both the `feats` and `classFeatures` payload fields were built from the same `ch.features` list, so the sheet's Feats tab and Class Features list rendered the exact same entries.

The engine model is clear that these are two distinct things: `Character.features` (`servers/engine/models.py`) is documented as "class/subclass features gained" and is populated only from `srd_tables.features_through` / `features_at` (`servers/engine/server.py`). Chosen **feats** are not stored there at all — the `level_up` path records them as `| feat: <Name>` markers in `ch.notes`. So feeding both UI fields from `features` was double-wrong: it duplicated the list *and* mislabeled class features as feats.

**What changed:**
- `classFeatures` continues to come from `features` (correct — that list *is* the class/subclass features).
- `feats` is now parsed from the engine's authoritative source: the `| feat: <Name>` markers in `ch.notes`. When a character has taken no feats, `feats` is an honest empty list (the Feats tab already renders a "No feats taken yet" empty state), never a duplicate of `classFeatures`.

The two lists are now guaranteed disjoint.

### #311 — Faction sigil derivation and clipping

**(a) Sigil initial (`viewer/server.py`).** The medallion initial was `name[:1].upper()`, so "The Flaming Fist" became "T" and "Order of the Gauntlet" became "O". Added a small `_faction_sigil(name)` helper that strips a leading article/qualifier ("The ", "Order of ", "Cult of ", "House ", "Clan ", "Guild of ", "Company of the ", ...) and then takes the initials of the first one or two remaining words: "The Flaming Fist" -> "FF", "Order of the Gauntlet" -> "G", "Zhentarim" -> "Z". The "no usable name" fallback to "✦" is preserved.

**(b) Sigil position (`viewer/openworlds/screen-relations.jsx`).** The 36px sigil medallion sat at `top: -10` inside the `position: relative`, `height: 90` banner, so its top edge clipped above the banner. Changed to `top: 8` to keep the whole medallion inside the banner.

## Verification

Imported the edited `viewer/server.py` and exercised the changed functions directly:
- `_faction_sigil`: "The Flaming Fist" -> "FF", "Order of the Gauntlet" -> "G", "Cult of the Absolute" -> "A", "Zhentarim" -> "Z", "House Baenre" -> "B", "" -> "✦".
- `_character_sheet`: with feats in notes, `feats` = `[Alert, Magic Initiate]` and `classFeatures` = `[Sneak Attack, Cunning Action, Evasion]` (disjoint); with no feat markers, `feats` = `[]` (not a duplicate). `python3 -m py_compile` clean.

Addresses #286, #311

Do NOT close on merge — verify on the next build's playtest.
