### PR TITLE
fix(openworlds): atlas-seed — #261

### DIFF
--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -1612,6 +1612,11 @@ def seed_world(world: dict, start_at: str = "", ending: str = "") -> Campaign:
             connections=reg.get("connections", []),
             notes=" ".join(reg.get("tags", [])),
             hex=reg.get("hex"),
+            # The world's authored regions are KNOWN day-1 — they are the shipped nav
+            # graph the player can already see in the atlas (issue #261). A world MAY
+            # opt a region OUT of day-1 visibility (fog-of-war) by declaring
+            # discovered=False; default True restores the prior all-regions-visible map.
+            discovered=bool(reg.get("discovered", True)),
         )
         if reg.get("id"):
             if reg["id"] in c.locations:
@@ -1654,6 +1659,11 @@ def seed_world(world: dict, start_at: str = "", ending: str = "") -> Campaign:
             region=str(area.get("region", "")),
             notes=" ".join(str(t) for t in (area.get("tags") or []) if str(t).strip()),
             connections=[str(x) for x in (area.get("connections") or []) if str(x).strip()],
+            # Ingested areas are equally part of the world's KNOWN day-1 nav graph, so they
+            # stay visible in the atlas exactly as before (issue #261). Marking them
+            # discovered=True keeps the projected map byte-for-byte today's behavior while
+            # making the engine the explicit writer; an area MAY opt out via discovered=False.
+            discovered=bool(area.get("discovered", True)),
         )
         if aid:
             location.id = aid

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -818,6 +818,14 @@ class Location(_StrictModel):
     connections: list[str] = Field(default_factory=list)  # location ids
     notes: str = ""
     visited: bool = False
+    # Whether this place is KNOWN on the map (atlas/nav-graph visibility) — ADDITIVE.
+    # The viewer shows a location when it is visited OR discovered; an explicitly
+    # undiscovered, unvisited place is fog-of-war. Default False is additive at the
+    # engine layer (nothing in the engine reads this flag; it only enriches the
+    # snapshot the viewer projects). seed_world flips the world's known day-1 places
+    # (authored regions + ingested areas) to True so the atlas renders the shipped
+    # nav graph from day one — see content.seed_world.
+    discovered: bool = False
     # Optional axial-hex (q, r) coords — PRESENTATION ONLY (the viewer renders them).
     # The engine's adjacency/travel is governed solely by `connections`; coords are
     # never used for movement or distance.

--- a/servers/engine/tests/test_content.py
+++ b/servers/engine/tests/test_content.py
@@ -1649,3 +1649,86 @@ def test_start_character_lia_battlemaster_template_no_spells(tmp_path, monkeypat
     assert not sheet.get("spell_slots"), "Fighter must have no spell_slots"
     assert not sheet.get("spells_known"), "lia-battlemaster must have no spells_known"
     assert not sheet.get("spells_prepared"), "lia-battlemaster must have no spells_prepared"
+
+
+# --- atlas day-1 discovery seeding (issue #261) --------------------------------------
+
+
+def _atlas_is_visible(loc) -> bool:
+    """Mirror of the viewer's known-location predicate (viewer/server.py
+    _atlas_visible_location_ids): a place shows on the atlas when it is visited OR
+    discovered; it is hidden only when explicitly undiscovered-and-unvisited (or
+    flagged hidden). Inlined here so the engine test locks the day-1 contract
+    without importing the viewer."""
+    if getattr(loc, "hidden", False):
+        return False
+    if loc.visited:
+        return True
+    return loc.discovered is True or loc.discovered is None
+
+
+def test_seed_world_marks_known_regions_discovered_day_one():
+    # Issue #261: a fresh baldurs-gate seed must mark the world's shipped nav graph as
+    # discovered so the atlas renders the known regions on day 1 (not just the single
+    # start location). The BG world ships 7 authored regions and declares none as
+    # discovered, so every one should come back discovered=True.
+    w = content.load_world_data("baldurs-gate")
+    region_ids = {str(r["id"]) for r in w["regions"]}
+    assert len(region_ids) == 7  # guards the fixture: 7 known regions ship day-1
+
+    c = content.seed_world(w)
+
+    # every authored region the world ships is KNOWN day-1
+    seeded_regions = {lid: loc for lid, loc in c.locations.items() if lid in region_ids}
+    assert seeded_regions.keys() == region_ids
+    assert all(loc.discovered is True for loc in seeded_regions.values()), (
+        "fresh seed_world must mark all known BG regions discovered (day-1 atlas)"
+    )
+
+    # the start is additionally VISITED (today's behavior, unchanged) — and is one of
+    # the now-discovered known regions, not the only visible place.
+    start = c.locations[c.current_location_id]
+    assert start.visited is True
+    assert start.discovered is True
+    assert sum(1 for loc in c.locations.values() if loc.visited) == 1
+
+    # every seeded location (regions + any ingested areas) is atlas-visible day-1, so the
+    # known nav graph shows immediately rather than collapsing to ~1 location.
+    assert all(_atlas_is_visible(loc) for loc in c.locations.values())
+    assert sum(1 for loc in c.locations.values() if _atlas_is_visible(loc)) >= 7
+
+
+def test_location_discovered_defaults_false_and_is_additive():
+    # The new field is ADDITIVE: it defaults False (an unseeded/legacy Location is
+    # exactly as before), and nothing forces it true outside seed_world's known graph.
+    from models import Location
+
+    bare = Location(name="Nowhere")
+    assert bare.discovered is False
+    # round-trips through the snapshot serialization the viewer reads
+    assert json.loads(bare.model_dump_json())["discovered"] is False
+
+
+def test_seed_world_honors_explicit_region_discovered_opt_out():
+    # A world MAY hide a region day-1 (fog-of-war) by declaring discovered=False; the
+    # engine must honor that rather than force every region visible. The other region,
+    # which omits the flag, still defaults to discovered=True (the #261 day-1 behavior).
+    world = {
+        "id": "fog-test",
+        "name": "Fog Test",
+        "premise": "discovery opt-out fixture",
+        "era": "now",
+        "regions": [
+            {"id": "loc-known", "name": "Known", "description": "open", "connections": []},
+            {"id": "loc-fog", "name": "Hidden Vale", "description": "secret", "connections": [], "discovered": False},
+        ],
+        "starting_options": [{"location_id": "loc-known", "framing": "Start in the open."}],
+    }
+
+    c = content.seed_world(world)
+
+    assert c.locations["loc-known"].discovered is True
+    assert c.locations["loc-fog"].discovered is False
+    # the opted-out, unvisited region is fog-of-war in the atlas; the known one shows
+    assert _atlas_is_visible(c.locations["loc-known"]) is True
+    assert _atlas_is_visible(c.locations["loc-fog"]) is False


### PR DESCRIPTION
## What this fixes

**Addresses #261** — a fresh `baldurs-gate` save seeds 7 known regions in `seed_world`, but only the start location was ever flagged, so the Atlas collapsed to roughly one location instead of showing the world's known day-1 nav graph.

### Root cause

The viewer's Atlas visibility predicate (`viewer/server.py :: _atlas_visible_location_ids`) is built to gate a location on a `discovered` flag: a place is shown when it is `visited` **or** `discovered`, and is fog-of-war only when it is *explicitly* undiscovered-and-unvisited. But the engine's `Location` model had **no `discovered` field at all** — the only `discovered` in the engine lived on the unrelated `WorldGraphNode` strategic-map metadata. With the field absent, `seed_world` had no way to declare the world's shipped regions as known, so the discovery-gating mechanism was effectively dead on the engine side and the map could not reliably project the day-1 known graph.

### What changed (engine — the sole writer)

- **`servers/engine/models.py`** — added an **additive** `discovered: bool = False` field to the `Location` model (placed next to `visited`). Default `False` is additive at the engine layer: nothing in the engine *reads* the flag; it only enriches the snapshot the viewer projects. Old snapshots are unchanged.
- **`servers/engine/content.py` (`seed_world`)** — the world's **known day-1 places** are now explicitly marked discovered:
  - authored `regions` → `discovered=bool(reg.get("discovered", True))`
  - ingested `areas` (the S4 `load_world_areas` loop) → `discovered=bool(area.get("discovered", True))`

  Both default to `True` so the Atlas renders the shipped nav graph from day one (the #261 fix), and both **honor an explicit `discovered=False`** so a world can opt a place into fog-of-war. For `baldurs-gate` this marks all **7 authored regions + 14 ingested areas = 21 locations** discovered; the start (`loc-lower-city`) remains the only `visited` location (today's behavior, unchanged). Marking the ingested areas `True` keeps the projected map byte-for-byte what it shows today (the viewer already treated an absent flag as visible) — no Atlas regression — while making the engine the explicit writer.
- **`servers/engine/tests/test_content.py`** — added three tests:
  - `test_seed_world_marks_known_regions_discovered_day_one` — a fresh `seed_world("baldurs-gate")` marks all 7 known regions `discovered=True`, the start is additionally `visited` (and `visited` count stays 1), and every seeded location is Atlas-visible day-1 (≥7). The visibility check inlines the viewer's exact predicate so the engine test locks the day-1 contract without importing the viewer.
  - `test_location_discovered_defaults_false_and_is_additive` — the new field defaults `False` and round-trips through `model_dump_json` (the snapshot the viewer reads).
  - `test_seed_world_honors_explicit_region_discovered_opt_out` — a region declaring `discovered=False` stays fog-of-war; a sibling that omits the flag still defaults to discovered.

### Scope / safety

- Engine-only change across `models.py` + `content.py` + a test under `servers/engine/tests/`. The engine remains the sole writer of `discovered`; the viewer is untouched.
- Purely additive: defaulted field, defaulted seeding (`.get(..., True)`), no engine code reads the flag. Verified locally by direct `seed_world` calls (the test runner's full suite needs the `mcp` dependency, which CI provides).

Addresses #261

Do NOT close on merge — verify on the next build's playtest.
