### PR TITLE
fix(openworlds): table-chrome — #274 #306 #320

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -102,6 +102,19 @@ const PENDING_BACKSTOP_MS = 12 * 60 * 1000;       // …with the original hard b
 function recoveryWindowMs(firstBeat) {
   return firstBeat ? PENDING_RECOVERY_FIRST_MS : PENDING_RECOVERY_MS;
 }
+
+// #274: a monotonic, client-side sequence stamped on every chronicle entry created here (player
+// echoes + each ingested chat beat) as `.at`. The session log in screen-table.jsx concatenates
+// three sources (recentEvents → chatBeats → log); because the player's optimistic echo (`log`) and
+// the DM's narration (`chatBeats`) live in SEPARATE arrays, a plain concat put a just-typed action
+// ABOVE the older DM prose it was responding to. A shared ever-increasing counter records true
+// creation order across BOTH arrays, so a stable sort by `.at` interleaves them correctly. It is a
+// counter, not a wall-clock — two entries can never tie, and it survives across runs harmlessly
+// (it only needs to be monotonic, not absolute). recentEvents (server history, no `.at`) stay the
+// oldest band; that ordering is handled where visibleLog is assembled.
+let __logSeq = 0;
+function nextLogSeq() { __logSeq += 1; return __logSeq; }
+
 function useLiveSession(state) {
   const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
   const activeCampaign =
@@ -151,7 +164,7 @@ function useLiveSession(state) {
   }, [clearTimers]);
 
   const recordPlayerEcho = React.useCallback((who, text) => {
-    setLog((l) => [...l, { kind: "action", who, text }]);
+    setLog((l) => [...l, { kind: "action", who, text, at: nextLogSeq() }]);  // #274: creation-order stamp
   }, []);
 
   React.useEffect(() => clearTimers, [clearTimers]);
@@ -186,9 +199,11 @@ function useLiveSession(state) {
         if (!cancelled && items.length) {
           const beats = items
             .map((it) => {
-              if (it.role === "player") return { kind: "dialog", who: "You", text: it.text };
+              // #274: stamp each beat with the shared monotonic counter at ingest time so it
+              // time-merges correctly against local player echoes (which share the same counter).
+              if (it.role === "player") return { kind: "dialog", who: "You", text: it.text, at: nextLogSeq() };
               const clean = sanitize(it.text);
-              return clean ? { kind: "narration", text: clean } : null;
+              return clean ? { kind: "narration", text: clean, at: nextLogSeq() } : null;
             })
             .filter(Boolean);
           if (beats.length) setChatBeats((prev) => [...prev, ...beats]);

--- a/viewer/openworlds/chrome.jsx
+++ b/viewer/openworlds/chrome.jsx
@@ -430,18 +430,23 @@ function CapabilityBadge({ capability, nativeStatus }) {
 function TitleBar({ campaign, location, day, capability, nativeStatus }) {
   return (
     <div className="title-bar">
-      {/* Platform-aware (#260): the macOS native window floats the REAL traffic lights
-          (RootView.swift) at top-left over this transparent bar, so reserve 76px to clear them —
-          but ONLY in the native app (nativeStatus.bridge true). A plain browser has no traffic
-          lights, so the padding is 0 there and the title text is no longer shoved off its mark /
-          over the nav rail. The Loop-4 ask was this fork; it had been hardcoded to 76. */}
-      <div className="title-text" style={{ paddingLeft: nativeStatus?.bridge ? 76 : 0 }}>
+      {/* Platform-aware (#260, finished in #306): the macOS native window floats the REAL traffic
+          lights (RootView.swift) at top-left over this transparent bar, so reserve 76px to clear
+          them in the native app (nativeStatus.bridge true). #306: the browser branch was 0, which
+          let a long campaign title's left edge run UNDER the 78px nav-rail below it (the rail starts
+          at x=0 in the column beneath this bar) — so reserve ~78px there too. paddingLeft stays
+          inline because it's the only nativeStatus-conditional bit; the nowrap + ellipsis + maxWidth
+          clamp that keeps a long title on ONE line (clear of the day/capability pills) lives in
+          styles.css (.title-text). */}
+      <div className="title-text" style={{ paddingLeft: nativeStatus?.bridge ? 76 : 78 }}>
         <span>Open Worlds</span><em>·</em><span>{campaign || "Open Worlds"}</span>
         {location && (<><em>·</em><span>{location}</span></>)}
       </div>
+      {/* #306: the right band (minWidth + larger font) now lives in styles.css (.title-end); the day
+          pill keeps a slightly larger size so "DAY 1 · MORNING" reads against the campaign title. */}
       <div className="title-end">
         <CapabilityBadge capability={capability} nativeStatus={nativeStatus} />
-        {day && <span>{day}</span>}
+        {day && <span style={{ fontSize: 13, letterSpacing: "0.06em" }}>{day}</span>}
       </div>
     </div>
   );

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -219,7 +219,16 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
   const visibleQuests = quests.filter((q) => !q.status || q.status === "active" || q.status === "open");
   const canAct = Boolean(surface?.can_act);
   const readOnlyReason = blockedActions.find((a) => a.disabled_reason)?.disabled_reason || "read-only surface";
-  const visibleLog = surface ? [...recentEvents, ...chatBeats, ...log] : [...demoLog, ...log];
+  // #274: the chronicle merges three sources — recentEvents (engine history), chatBeats (the live
+  // DM/player tail) and log (local optimistic player echoes). A plain concat let a just-typed action
+  // (in `log`) sort ABOVE the older DM prose it answered (in `chatBeats`), because the two live in
+  // separate arrays appended at different times. chatBeats + log carry a shared monotonic `.at`
+  // (stamped client-side in app.jsx at creation/ingest), so a STABLE sort by `.at` restores true
+  // chronological order across both. recentEvents have no `.at` (server history with no client
+  // sequence) and are always the oldest, so they keep their leading position and relative order.
+  // Array.prototype.sort is stable (ES2019+); ties are impossible anyway since the counter is unique.
+  const mergedTail = [...chatBeats, ...log].sort((a, b) => (a?.at || 0) - (b?.at || 0));
+  const visibleLog = surface ? [...recentEvents, ...mergedTail] : [...demoLog, ...log];
   const actionById = (id) => actions.find((a) => a.id === id);
   const enabledActionById = (id) => enabledActions.find((a) => a.id === id);
 
@@ -435,7 +444,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
 
       {/* LEFT — Party roster */}
       <div style={{ display: "flex", flexDirection: "column", gap: 10, minHeight: 0 }}>
-        <Panel framed style={{ padding: 18, flex: "0 0 auto" }}>
+        <Panel framed style={{ padding: "14px 18px", flex: "0 0 auto" }}>{/* #320: tighter panel padding */}
           <div className="eyebrow" style={{ color: "var(--crimson)" }}>{encounter.active ? encounter.summary : "Session"}</div>
           <SectionTitle>The Party</SectionTitle>
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
@@ -450,7 +459,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
           </div>
         </Panel>
 
-        <Panel framed style={{ padding: 18, flex: "1 1 auto", minHeight: 0, overflow: "auto" }}>
+        <Panel framed style={{ padding: "14px 18px", flex: "1 1 auto", minHeight: 0, overflow: "auto" }}>{/* #320: tighter panel padding */}
           <SectionTitle>Conditions</SectionTitle>
           <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
             {conditions.length ? conditions.map((c) => (
@@ -504,8 +513,10 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
         </div>
 
         {/* Log */}
-        <Panel framed style={{ flex: "1 1 auto", display: "flex", flexDirection: "column", minHeight: 0, padding: 22 }}>
-          <SectionTitle ordinal="·">The Tabletop Chronicle</SectionTitle>
+        <Panel framed style={{ flex: "1 1 auto", display: "flex", flexDirection: "column", minHeight: 0, padding: "14px 18px" }}>{/* #320: tighter panel padding */}
+          {/* #320: trimmed "The Tabletop Chronicle" → "Chronicle" and dropped the "·" lead dot
+              (read as visual noise on a busy screen). */}
+          <SectionTitle>Chronicle</SectionTitle>
           <div ref={logRef} tabIndex={0} style={{ flex: "1 1 auto", overflow: "auto", paddingRight: 12 }}>
             {visibleLog.length ? visibleLog.map((entry, i) => (
               <LogEntry key={entry.id || `${entry.kind || "n"}-${i}`} entry={entry} />
@@ -552,7 +563,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
       {/* RIGHT — Quests + Quick stash + GM tools */}
       <div style={{ display: "flex", flexDirection: "column", gap: 10, minHeight: 0 }}>
         {advisory && Array.isArray(advisory.debts) && advisory.debts.length > 0 && (
-          <Panel framed style={{ padding: 18 }}>
+          <Panel framed style={{ padding: "14px 18px" }}>{/* #320: tighter panel padding */}
             <SectionTitle right={advisory.total_debts ? <Pill tone="crimson">{advisory.total_debts}</Pill> : null}>GM Advisory</SectionTitle>
             <div className="body-sm muted" style={{ marginBottom: 8 }}>What the campaign owes the story.</div>
             <div style={{
@@ -574,8 +585,8 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
           </Panel>
         )}
 
-        <Panel framed style={{ padding: 18 }}>
-          <SectionTitle>Active Quests</SectionTitle>
+        <Panel framed style={{ padding: "14px 18px" }}>{/* #320: tighter panel padding */}
+          <SectionTitle>Quests</SectionTitle>{/* #320: "Active Quests" → "Quests" */}
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
             {visibleQuests.map((q) => (
               <button key={q.id} onClick={() => onNavigate("journal")} style={{
@@ -598,7 +609,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
           </div>
         </Panel>
 
-        <Panel framed style={{ padding: 18 }}>
+        <Panel framed style={{ padding: "14px 18px" }}>{/* #320: tighter panel padding */}
           <SectionTitle right={<button className="btn ghost sm" onClick={() => onNavigate("inventory")}>Open</button>}>Quick Stash</SectionTitle>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 6 }}>
             {stash.slice(0, 8).map((it) => (
@@ -611,7 +622,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
           </div>
         </Panel>
 
-        <Panel framed style={{ padding: 18, flex: 1, minHeight: 0, overflow: "auto" }}>
+        <Panel framed style={{ padding: "14px 18px", flex: 1, minHeight: 0, overflow: "auto" }}>{/* #320: tighter panel padding */}
           <SectionTitle>Encounter</SectionTitle>
           <div className="body-sm muted" style={{ marginBottom: 10 }}>
             {encounter.summary || scene.summary || "Choose what to risk."}

--- a/viewer/openworlds/styles.css
+++ b/viewer/openworlds/styles.css
@@ -212,7 +212,11 @@ a { color: inherit; text-decoration: none; cursor: pointer; }
   position: relative;
   z-index: 5;
   display: grid;
-  grid-template-columns: 130px 1fr 130px;
+  /* #306: two real children only (.title-text + .title-end — the traffic lights are drawn by the
+     native RootView, not DOM). The old empty 130px left spacer is gone; the title spans the left
+     and clears the rail via its own paddingLeft, and a fixed 240px band on the right holds the day +
+     capability pills so they never collide with a long title. */
+  grid-template-columns: 1fr 240px;
   align-items: center;
   height: 38px;
   padding: 0 16px;
@@ -246,6 +250,13 @@ a { color: inherit; text-decoration: none; cursor: pointer; }
   text-transform: uppercase;
   color: var(--b-200);
   text-shadow: 0 1px 0 rgba(0,0,0,0.6);
+  /* #306: a long campaign name used to wrap to 3 lines and run under the nav-rail / over the day
+     pill. Keep it on ONE line, ellipsize the overflow, and cap its width so the 240px right band is
+     always free. (paddingLeft, which clears the rail / native traffic lights, stays inline.) */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: calc(100% - 240px);
 }
 .title-text em {
   font-style: normal;
@@ -256,11 +267,14 @@ a { color: inherit; text-decoration: none; cursor: pointer; }
 .title-end {
   display: flex; justify-content: flex-end; gap: 12px;
   font-family: var(--f-display);
-  font-size: 10px;
+  /* #306: the day pill ("DAY 1 · MORNING") read far too small next to the campaign title — bump the
+     base size and reserve a real right band so it never gets squeezed under the title. */
+  font-size: 13px;
   letter-spacing: 0.2em;
   text-transform: uppercase;
   color: var(--b-300);
   align-items: center;
+  min-width: 240px;
 }
 
 .capability-badge {


### PR DESCRIPTION
## WorldOS / OpenWorlds — table + title-bar chrome fixes

Conflict-free group touching only the OpenWorlds viewer: `viewer/openworlds/{app.jsx, screen-table.jsx, chrome.jsx, styles.css}`.

Addresses #274, #306, #320.

---

### #274 — Session log: concatenate vs time-merge (player action shows in wrong order)

**Root cause.** `ScreenTable` built the chronicle as a plain concat `visibleLog = [...recentEvents, ...chatBeats, ...log]`. The player's optimistic echo (`log`) and the DM's narration tail (`chatBeats`) live in **separate arrays** that are appended at different times, so a player who typed mid-poll saw their just-declared action render **above** the older DM prose it was actually responding to.

**What changed.**
- `app.jsx`: added a module-level monotonic client counter (`nextLogSeq()`) and stamped an `.at` sequence on every chronicle entry created client-side — the player echo in `recordPlayerEcho`, and each ingested chat beat (player dialog + DM narration) in the `/chat` poll map. A shared ever-increasing counter records true creation order **across both arrays** (it's a counter, not a wall-clock, so two entries can never tie).
- `screen-table.jsx`: `visibleLog` now stable-sorts the combined `chatBeats + log` tail by `.at` before render. `recentEvents` (engine history, no client `.at`) keep their leading position as the oldest band; the live tail interleaves correctly beneath it. `Array.prototype.sort` is stable (ES2019+), and ties are impossible since the counter is unique.

Result: declaring an action mid-narration now lands **after** the narration that prompted it, not above it.

Note: per the conflict-free scope this fix is viewer-only. `recentEvents` come from the server (`viewer/server.py`, untouched here) without an `.at`; they remain the leading history band, which is correct because they are always the oldest. A future server-side `recentEvents[i].at` (engine seq#) could fold them into the same sort if ever needed, but is out of scope for this group.

### #306 — Title-bar still broken (P0): title overlaps nav-rail, wraps 3 lines, day pill tiny

**Root cause.** The Loop-7 fix set the browser `paddingLeft` to `0`. With a long campaign name the title-text had no left clearance (its left edge ran under the 78px nav-rail column below the bar), no `white-space: nowrap` (so it wrapped to ~3 lines), and no width cap or reserved right band (so it collided with the day / capability pills on the right). The day pill itself was only 10px and read far too small.

**What changed.**
- `chrome.jsx`: browser `paddingLeft` `0 → 78` to clear the 78px nav-rail column (native keeps `76` for the real traffic lights — that branch is unchanged). The day-pill span gets a slightly larger size so "DAY 1 · MORNING" reads.
- `styles.css`:
  - `.title-text` — `white-space: nowrap`, `overflow: hidden`, `text-overflow: ellipsis`, `max-width: calc(100% - 240px)` so a long title stays on **one line**, ellipsizes, and never crosses into the right band.
  - `.title-end` — `font-size: 10px → 13px` and `min-width: 240px` so the day + capability pills always have a reserved, readable right band.
  - `.title-bar` grid `130px 1fr 130px → 1fr 240px`. The bar has only two real DOM children (`.title-text` + `.title-end`); the macOS traffic lights are drawn by the native RootView, not as DOM nodes, so the old empty 130px left spacer column served no purpose. The new `1fr 240px` matches the title's `max-width` clamp and the end band's `min-width`.

Faithful to the issue's acceptance criteria. (The issue's sample used `64`/`56px`-rail numbers from an older layout; the current rail is `78px`, so `78` is the correct clearance here.)

### #320 — Session/Table: too much chrome (trim headers, padding, lead dots)

**Root cause.** The Table screen carried verbose panel headers, a decorative "·" lead dot on the Chronicle title, and generous panel padding (18/22), crowding an increasingly content-rich screen.

**What changed (`screen-table.jsx`).**
- "The Tabletop Chronicle" → "Chronicle"; "Active Quests" → "Quests".
- Dropped the `ordinal="·"` lead dot on the Chronicle section title (the only section title that carried one).
- Tightened every Table panel's padding `18`/`22 → "14px 18px"`.

Empty-state copy was **already** one-line muted text ("No active party conditions.", "No active quests", "Inventory empty", "No active combat round.", etc.), so criterion #4's "1-line empty state" is already satisfied at the copy level; I did not add conditional panel-collapse logic for the flex-grow panels (Conditions / Encounter), as that risks layout regressions and goes beyond a chrome trim. I left the global `.section-title::after` rule alone — it's shared by every screen, and trimming it would have broad cross-screen impact beyond this Table-focused issue.

---

### Verification
- All three modified `.jsx` files transform cleanly with the project's in-browser Babel (`vendor/babel-standalone-7.29.0.min.js`, `preset: react`).
- `styles.css` braces balanced; all edited selectors/declarations confirmed present.
- No files outside the four viewer targets were touched.

**Do NOT close on merge — verify on the next build's playtest.**
