### PR TITLE
docs+qa: ui-audit Loop 9 — harness prep (dual-DM fix, beat recorder, --ui-gate)

### DIFF
--- a/docs/ui-audit/DUAL_DM_FIX.md
+++ b/docs/ui-audit/DUAL_DM_FIX.md
@@ -1,0 +1,426 @@
+# Dual-DM Fix: `qa/ui_playtest.sh` ↔ `scripts/play_party.sh`
+
+**Loop-9, gotcha #1.** This document captures the architecture problem and the
+exact patch needed to fix it.
+
+## TL;DR
+
+`qa/ui_playtest.sh` and `scripts/play_party.sh` (via its solo fallback into
+`scripts/play.sh`) **both** spawn a DM agent (`claude -p`) wired to the **same
+viewer move sink** (`$MOVES = $STATE_DIR/player_moves.jsonl`). If a user ever
+runs them side by side over the same state dir — or if a future composition
+ever chains them — the two DMs race on the same move tail, double-resolve
+every move, and corrupt narration. Worse: the DMs hold two **separate** Claude
+sessions on the same campaign, so the engine sees writes from two voices that
+never coordinate.
+
+The fix is to **separate roles by ownership**:
+
+- `play_party.sh` (or `play.sh` underneath) **owns the viewer + the DM agent**.
+- `ui_playtest.sh` **strips down to just the Playwright Player** that drives
+  the *already-running* viewer.
+
+When the two scripts compose, there is exactly one DM resolving moves from
+exactly one sink.
+
+---
+
+## Current architecture (file:line)
+
+### `qa/ui_playtest.sh` — owns viewer + DM + Player (THREE roles)
+
+| Role | Lines | Notes |
+|------|-------|-------|
+| Viewer (engine + `/move` + `/chat`) | `qa/ui_playtest.sh:114-130` | `python3 viewer/server.py "" "$PORT"` wired with `CLAWDND_VIEWER_CHAT=$CHAT` + `CLAWDND_PLAYER_MOVES=$MOVES`. Port picked from 8990–8999. |
+| **DM agent (`claude -p`, full plugin)** | `qa/ui_playtest.sh:71-90, 132-145, 152-157` | Builds `$DM_CFG` rooted at `$ROOT/servers/*` + engine state dir = `$STATE_DIR`. `dm_turn()` runs `claude -p ... --plugin-dir "$ROOT" --mcp-config "$DM_CFG"`. The "opening" turn at L153 seats a PC + companion. |
+| **DM-resolver background loop** | `qa/ui_playtest.sh:159-183` | A `( ... ) &` subshell tailing `$MOVES`. Each new line → `dm_turn 0 "The player does: ..."` → `chatlog dm ...` → writes back to `$CHAT`. PID held in `$DMLOOP`. |
+| Playwright Player (`claude -p` with palette MCP only) | `qa/ui_playtest.sh:92-109, 185-201` | The `$PLAYER_CFG` MCP server (`palette_server.js`) is the agent's *only* tool surface. URL handed in via env (`CLAWDND_UIPT_URL`). |
+
+The two **DM**-shaped artifacts to remove from `ui_playtest.sh` are:
+
+1. The DM MCP-config build (`L71-90`).
+2. The `dm_turn` helper and DM-resolver loop (`L132-183`), including the DM
+   "opening turn" at `L152-157` that seats the PC + companion.
+
+(The DM scratch dir at `$RUNDIR/dm/` and the `mkdir -p ... "$RUNDIR/dm"` at
+`L52`, `MOVES` + `CHAT` + `COMBINED` files at `L53-55`, and the `DM_BUDGET`
+env knob at `L39` all go with them.)
+
+### `scripts/play_party.sh` — owns viewer + DM + companions (the "right side")
+
+| Role | Lines | Notes |
+|------|-------|-------|
+| Solo fallback (delegates to `scripts/play.sh`) | `scripts/play_party.sh:69-85` | When no companion-spec is given, `exec scripts/play.sh "${ARGS[@]}"`. **The solo path IS just `play.sh`** — same DM, same viewer, same move sink. |
+| Viewer supervisor | `scripts/play_party.sh:291-311` (party) and `scripts/play.sh:208-229` (solo) | Long-running supervised viewer at port 8765 (or `$CLAWDND_PLAY_PORT`, or `clawdnd_choose_port`). Same `CLAWDND_PLAYER_MOVES=$MOVES` + `CLAWDND_VIEWER_CHAT=$CHAT` wiring. PID file: `$STATE_DIR/.viewer.pid`. |
+| DM agent (full plugin) | `scripts/play_party.sh:113-128` (config), `215-233` (turn), `331-340` (opening) — and `scripts/play.sh:70-85, 183-192, 251-273` for solo. | Same `--plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config --model "$CLAWDND_DM_MODEL"` invocation. The opening turn seats a PC + companion live. |
+| Human-paced beat loop | `scripts/play_party.sh:393-450` (party), `scripts/play.sh:286-326` (solo) | Tails `$MOVES`. New line → companion turns (party only) → `turn dm ... "The player does: ..."` → narrates back to `$CHAT`. |
+| Idle ceiling | `scripts/play_party.sh:399-403, 444-447` (party only — solo `play.sh` has none, see L286-326) | Party loop stops after `CLAWDND_PLAY_MAX_IDLE` (default 1800s) with no human move; solo loop spins on `sleep 2` forever until Ctrl-C. |
+
+### The collision
+
+If both scripts run against the same campaign:
+
+1. **Two viewers compete for the port** — `play_party.sh` picks 8765,
+   `ui_playtest.sh` picks 8990; if a user manually points them at the same
+   state dir, both viewers serve different ports but **the same `MOVES` file**.
+2. **Two DMs race on `$MOVES`** — both have a `MCURSOR` tailing the same JSONL
+   file, both run `dm_turn 0 "The player does: ..."`. The first one to read
+   `$MOVES` past its `MCURSOR` wins; the loser silently double-resolves the
+   same move with stale narration.
+3. **Two Claude sessions on one campaign** — each DM has its own `$DSID`
+   (`uuidgen`). They write engine state via the same `clawdnd-engine` MCP but
+   never see each other's `--resume` tape, so the engine gets contradictory
+   `apply_check` / `apply_attack` / scene-narration calls.
+4. **Twice the cost** — both DMs bill against budgets the user thought was
+   one ceiling.
+
+This isn't a theoretical race. It's the **intended** flow of `ui_playtest.sh`
+*today* — the harness is self-contained — and the user has explicitly asked
+for `play_party.sh` to be the play surface a playtester drives. The two
+collide because each owns the DM independently.
+
+---
+
+## Proposed architecture
+
+```
+scripts/play_party.sh   (or play.sh underneath)
+   └── owns:
+        • viewer (supervised) on a chosen $PORT
+        • DM agent (one claude -p, one session id, one $DSID)
+        • $MOVES + $CHAT sinks under play-state/$RUN/
+        • the human-paced beat loop tailing $MOVES
+        • a "rundir handshake" file: play-state/$RUN/.handshake.json
+          { "port": 8765, "url": "http://127.0.0.1:8765/openworlds/",
+            "state_dir": "...", "moves": "...", "chat": "...",
+            "campaign_id": "...", "dm_session_id": "..." }
+
+qa/ui_playtest.sh
+   └── owns:
+        • the Playwright Player agent ONLY
+        • bugs.ndjson, screenshots/, a11y/, console/network logs
+        • scoring + summary
+
+   └── reads (does NOT spawn):
+        • the URL from --attach-to <rundir>/.handshake.json
+        • the PORT/CHAT for friction signals only
+```
+
+The Player agent uses the **same** palette MCP server, but its
+`CLAWDND_UIPT_URL` env var is sourced from the handshake JSON written by
+`play_party.sh` (or `play.sh`) — not from a port `ui_playtest.sh` picked
+itself.
+
+### Why a handshake JSON (not a fixed env var)?
+
+Two reasons:
+
+1. **Per-run isolation.** `play_party.sh` already builds per-run state dirs
+   under `play-state/$RUN/`. A handshake JSON dropped there means a
+   playtester can attach to a *specific* live game without stomping on
+   another one (the persona sweep at `qa/UI_PLAYTEST.md:139-145` runs five
+   personas sequentially — each Player attaches to *its own* live game).
+2. **Survives a viewer respawn.** `play_party.sh`'s supervisor restarts the
+   viewer if it dies (`L294-302`). A handshake JSON written ONCE by the
+   parent script (not the supervisor) tells the Player which port the parent
+   chose, even if the underlying viewer process changed PID.
+
+The handshake JSON is the **only** new contract surface.
+
+---
+
+## The exact patch
+
+### 1. `scripts/play_party.sh` + `scripts/play.sh` — emit the handshake
+
+After the port is chosen and the campaign is pre-seeded, write the handshake
+JSON. This is additive — the existing flows do not read it; only the new
+detached Player path will.
+
+**Add to `scripts/play.sh` after `L43` (port chosen) and before `L57`
+(state dir created):**
+
+```bash
+# --- attachment handshake -----------------------------------------------------
+# After the port is chosen and STATE_DIR exists, drop a handshake JSON that an
+# external Player (qa/ui_playtest.sh --attach-to) can read to attach to THIS
+# live game without spawning its own viewer or DM. Written once; the viewer
+# supervisor (L208-229) does not touch it.
+write_handshake() {
+  python3 - "$STATE_DIR/.handshake.json" "$PORT" "$STATE_DIR" "$MOVES" "$CHAT" "$DSID" <<'PY'
+import json, sys
+out, port, state, moves, chat, dsid = sys.argv[1:7]
+json.dump({
+    "schema": "clawdnd.play.handshake.v1",
+    "port": int(port),
+    "url": f"http://127.0.0.1:{port}/openworlds/",
+    "state_dir": state,
+    "moves": moves,
+    "chat": chat,
+    "dm_session_id": dsid,
+    "campaign_id": None,  # filled by viewer once campaign exists
+}, open(out, "w"), indent=2)
+PY
+}
+# (Called after $DSID is generated; see below.)
+```
+
+Then call `write_handshake` right after `DSID="$(uuidgen ...)"` at `L87`:
+
+```bash
+DSID="$(uuidgen 2>/dev/null || python3 -c 'import uuid;print(uuid.uuid4())')"
+write_handshake
+```
+
+And **mirror this in `scripts/play_party.sh`**:
+- Insert the same `write_handshake` helper after `L102` (state dir created)
+  but reading `STATE_DIR`, `PORT`, `MOVES`, `CHAT`, `DSID`.
+- Call `write_handshake` right after `DSID="$(uuidgen ...)"` at `L206`.
+
+The handshake JSON is dropped under `play-state/$RUN/.handshake.json`. (It is
+gitignored — `play-state/` already is.)
+
+### 2. `qa/ui_playtest.sh` — add `--attach-to` and strip the DM
+
+**Add a new flag** (default OFF — keeps existing standalone behavior
+during migration):
+
+```bash
+ATTACH_RUNDIR="${UIPT_ATTACH_TO:-}"   # path to play-state/$RUN/ with .handshake.json
+# Allow CLI override: qa/ui_playtest.sh --attach-to play-state/play-1234 newbie newbie 30 3.00
+if [ "${1:-}" = "--attach-to" ]; then
+  ATTACH_RUNDIR="$2"; shift 2
+fi
+```
+
+**When `$ATTACH_RUNDIR` is set, skip ALL DM scaffolding:**
+
+```bash
+if [ -n "$ATTACH_RUNDIR" ]; then
+  # Attach mode: read PORT + URL from the running parent's handshake.
+  HANDSHAKE="$ATTACH_RUNDIR/.handshake.json"
+  [ -f "$HANDSHAKE" ] || { echo "[uipt] --attach-to dir has no .handshake.json: $HANDSHAKE" >&2; exit 5; }
+  # Wait up to 60s for the handshake to be readable AND the URL to answer 200.
+  for _ in $(seq 1 60); do
+    PORT="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("port",""))' "$HANDSHAKE" 2>/dev/null)"
+    [ -n "$PORT" ] && [ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/openworlds/" 2>/dev/null)" = "200" ] && break
+    sleep 1
+  done
+  URL="http://127.0.0.1:$PORT/openworlds/"
+  # No viewer to spawn, no DM, no resolver loop, no $DSID, no $DM_CFG.
+  echo "[uipt] attach mode: parent run=$ATTACH_RUNDIR port=$PORT"
+else
+  # ... existing standalone path: pick_port, spawn viewer, build DM_CFG, run dm_turn, spawn DM loop ...
+fi
+```
+
+**Remove (in attach mode) the lines:**
+
+- `L52` `mkdir -p ... "$RUNDIR/dm"` — no DM scratch dir needed.
+- `L53-55` `MOVES` / `CHAT` / `COMBINED` file init — these belong to the
+  parent now.
+- `L56` `DM_CFG=` — no DM config.
+- `L60-68` `pick_port` + `PORT=$(pick_port)` — the parent picked the port.
+- `L71-90` DM MCP config builder — gone.
+- `L114-130` viewer spawn + ready loop — replaced with the handshake wait above.
+- `L132-145` `dm_turn()` — gone.
+- `L147-157` DM opening turn — gone. (The parent's DM already opened the
+  scene; the Player discovers the live game via the launcher.)
+- `L159-183` DM-resolver loop subshell + `DMLOOP=$!` — gone. The parent's
+  beat loop resolves moves.
+- `L207-209` `kill "$DMLOOP"`/`kill "$VIEWER"` — gone.
+- `cleanup()` at `L119` — collapses to a no-op in attach mode.
+
+**Keep unchanged:**
+
+- The Player MCP config build (`L92-109`).
+- The Player agent invocation (`L185-201`).
+- The verdict + cost extraction (`L203-205`).
+- `meta.json` + scoring (`L211-225`).
+
+### 3. Optional: scrape the parent's `chat.jsonl` for the Player verdict
+
+Today the harness scores `console_errors` + `network_failures` purely from
+the palette-captured logs. In attach mode the Player still sees the same
+screen, so this works unchanged. If the scorer needs DM-side narration
+context (e.g., for `completed_intro_flow`), point it at the parent's chat:
+
+```bash
+[ -n "$ATTACH_RUNDIR" ] && CHAT_FOR_SCORE="$ATTACH_RUNDIR/chat.jsonl" \
+                       || CHAT_FOR_SCORE="$CHAT"
+python3 "$ROOT/qa/ui_playtest_score.py" "$RUNDIR" "$PLAYER_VERDICT" "$CHAT_FOR_SCORE"
+```
+
+(Today's scorer signature is `(rundir, verdict)`. Adding the chat path is a
+follow-up to land in `ui_playtest_score.py` — out of scope for this fix
+unless the score needs it.)
+
+### 4. Optional: smoke-test convenience script
+
+Add `qa/ui_playtest_attached.sh` (one-shot composition):
+
+```bash
+#!/usr/bin/env bash
+# Launch play_party.sh in background, wait for its handshake, then run
+# ui_playtest.sh --attach-to <that dir>. One DM, one viewer, one Player.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUN="${1:-play-$(date +%H%M%S)}"
+PARENT="$ROOT/play-state/$RUN"
+mkdir -p "$PARENT"
+CLAWDND_PLAY_MAX_TURNS=40 CLAWDND_PLAY_MAX_IDLE=300 \
+  "$ROOT/scripts/play_party.sh" "${2:-baldurs-gate}" "$RUN" &
+PARENT_PID=$!
+trap 'kill $PARENT_PID 2>/dev/null' EXIT
+# Wait for handshake (max 60s).
+for _ in $(seq 1 60); do [ -f "$PARENT/.handshake.json" ] && break; sleep 1; done
+[ -f "$PARENT/.handshake.json" ] || { echo "[smoke] parent never wrote handshake" >&2; exit 1; }
+exec "$ROOT/qa/ui_playtest.sh" --attach-to "$PARENT" "${3:-attached-$RUN}" \
+                               "${4:-baldurs-gate}" "${5:-newbie}" "${6:-30}" "${7:-3.00}"
+```
+
+This is a developer convenience, not a contract.
+
+---
+
+## Acceptance criteria
+
+A smoke test that proves **no dual DM** is running at any time:
+
+```bash
+# Run the composed flow.
+qa/ui_playtest_attached.sh smoke-1 baldurs-gate newbie 10 1.00 &
+SMOKE=$!
+
+# Sample every 2s for the lifetime of the run. Count concurrent DM processes.
+MAX_DMS=0
+while kill -0 "$SMOKE" 2>/dev/null; do
+  # A DM process = claude -p with --plugin-dir AND --mcp-config dm.mcp.json.
+  N=$(pgrep -f 'claude -p.*--plugin-dir.*--mcp-config.*dm\.mcp\.json' | wc -l | tr -d ' ')
+  [ "$N" -gt "$MAX_DMS" ] && MAX_DMS=$N
+  sleep 2
+done
+echo "[smoke] max concurrent DM processes: $MAX_DMS (expected ≤ 1)"
+[ "$MAX_DMS" -le 1 ] || { echo "DUAL DM DETECTED" >&2; exit 1; }
+```
+
+**Pass criteria:**
+
+1. `MAX_DMS ≤ 1` for the full duration of the run.
+2. Exactly **one** `.handshake.json` exists under `play-state/`.
+3. The Player's `$RUNDIR/bugs.ndjson` records at least one screenshot and at
+   least one click (proves the Player actually drove the live game).
+4. The parent `play-state/$RUN/chat.jsonl` shows DM narration entries with
+   strictly increasing `\n`-separated timestamps in the embedded JSON — no
+   duplicate "DM" lines for the same player move (which would prove the
+   double-resolve race didn't happen).
+5. Neither the parent nor the Player exits with code ≠ 0 caused by the
+   handshake path (handshake-readable: 0 is the only correct outcome).
+
+Manual smoke (a 5-minute check):
+
+```bash
+# Term 1
+scripts/play_party.sh baldurs-gate manual-1 8765
+
+# Term 2 (after Term 1 says "DM opened the scene")
+qa/ui_playtest.sh --attach-to play-state/manual-1 manual-1 baldurs-gate newbie 10 1.00
+
+# Verify:
+#   1. ONE viewer process: pgrep -f 'viewer/server.py' | wc -l   → 1
+#   2. ONE DM process:     pgrep -f 'claude -p.*dm\.mcp\.json' | wc -l → 1
+#   3. The Player's bugs.ndjson and screenshots/ are populated
+#   4. The DM in Term 1 narrates results of the Player's clicks
+```
+
+---
+
+## Migration plan
+
+Backwards-compatible rollout in three steps:
+
+### Phase 1 (this PR) — additive
+
+- Add `--attach-to` flag and the attach-mode branch to `qa/ui_playtest.sh`.
+- Add `write_handshake` to `scripts/play.sh` + `scripts/play_party.sh`.
+- **Existing standalone `ui_playtest.sh` invocations continue to work
+  unchanged** — every script that calls it today (the sweep at
+  `qa/UI_PLAYTEST.md:139-145`, any user habit) is untouched.
+- Land `qa/ui_playtest_attached.sh` as the documented composition.
+
+### Phase 2 (next PR) — flip the default in the sweep
+
+- Update the persona sweep in `qa/UI_PLAYTEST.md:139-145` and any orchestrator
+  (`qa/ui_playtest_aggregate.py`?) to launch ONE `play_party.sh` per sweep
+  and have all five personas attach to it via `--attach-to`. Five Players,
+  one DM, one viewer — five times the data for one-fifth the DM cost.
+- Add a deprecation banner to standalone mode: when `ui_playtest.sh` runs
+  without `--attach-to`, print `[uipt] WARN: standalone mode will be removed
+  in a future release; pass --attach-to <rundir>`.
+
+### Phase 3 (cleanup) — remove standalone
+
+- After two releases with the deprecation banner, delete the
+  standalone DM scaffolding from `ui_playtest.sh` (L52-55, L71-90, L114-130,
+  L132-183, L207-209). `--attach-to` becomes mandatory.
+- This is the patch that physically removes the dual-DM code path.
+
+### Migration safety
+
+- The handshake file is JSON with a `schema` field
+  (`clawdnd.play.handshake.v1`). Future versions bump the schema; the
+  attach-mode Player refuses to attach to an unknown schema.
+- The Player's wait-for-handshake loop has a 60s ceiling — if the parent
+  never wrote one (old `play.sh` from before phase 1), the Player exits
+  cleanly with `exit 5` (new exit code, distinct from today's `2/3/4`).
+- A user who runs `ui_playtest.sh` standalone (no `--attach-to`) during
+  phase 1 gets today's behavior, byte-for-byte. There is **no flag day**.
+
+---
+
+## Out of scope (intentionally)
+
+- **Per-persona Player isolation in attach mode.** Five Players attaching to
+  one viewer-DM each drive the same browser session sequentially in the
+  current sweep. Running them concurrently against one DM means five Players
+  POSTing `/move` simultaneously — the parent's beat loop would interleave
+  them. That's a future change to the parent's loop (batched-resolve), not
+  this fix.
+- **Replacing the harness's pre-mint of a PC/companion.** Today
+  `ui_playtest.sh:152-157` runs a DM "opening turn" so the launcher's
+  Chronicles shelf has a Resume option. In attach mode, the parent's DM has
+  already done this (and seated a PC the parent's user / wizard authored).
+  The Player discovers the game via the launcher just as before — but it's
+  the parent's PC, not one the harness minted. This is a *better* signal
+  (it's the real flow), but if a Player needs a guaranteed-canonical seed PC
+  for #305, the parent must be told what to seat. That's a parent-side
+  contract, not part of this fix.
+- **Multiple parents on one machine.** Two parallel `play_party.sh` runs
+  with distinct `$RUN` names get distinct `play-state/$RUN/.handshake.json`
+  files; the Player chooses one by passing `--attach-to`. If a user runs two
+  parents on the same port (e.g., both default 8765 and the second hits
+  `clawdnd_choose_port`'s fallback), the second's handshake correctly
+  records its actual chosen port. No new code needed.
+
+---
+
+## Open questions for the main agent
+
+1. **Should attach-mode `ui_playtest.sh` re-write `meta.json` to record the
+   parent's `$RUN` id?** Probably yes — the persona sweep aggregator should
+   know the Player attached to a shared parent. Suggest adding
+   `"attached_to": "<parent-run-id>"` to `meta.json` when `ATTACH_RUNDIR` is
+   set.
+2. **The current scoring rubric expects `console_errors` from the same
+   browser the DM "knows about"** — in attach mode the parent's
+   `chat.jsonl` is the DM's narration record. Is that the right source for
+   `completed_intro_flow`? If yes, plumb `--chat-source <parent-chat>` into
+   `ui_playtest_score.py`. (Today the score doesn't read the chat, so this
+   may be a no-op.)
+3. **Does the Eva / wizard authored-hero flow at `play.sh:100-180` interact
+   with attach-mode?** I assumed yes: if `CLAWDND_PLAY_HERO` is set, the
+   parent pre-seeds an authored PC, and the Player discovers + plays it.
+   No code change needed — but worth a one-line note in the handshake JSON
+   (`"hero_authored": true`) so the Player's persona brief can adapt
+   ("you're playing this author's hero" vs "you're picking from
+   Chronicles").

--- a/qa/playwright/screenshot_helper.js
+++ b/qa/playwright/screenshot_helper.js
@@ -1,0 +1,406 @@
+/*
+ * BeatRecorder — the screenshot-per-beat contract.
+ *
+ * KILLER RULE (the owner's, 2026-05-30): "every UI playtest saves a PNG per beat;
+ * every UI fix renders before/after. No blind UI edits."
+ *
+ * This module is that rule, in code. Any UI action that goes through `beat()` is
+ * sandwiched by a before.png + an after.png with no way for the caller to skip
+ * either one — the action runs INSIDE the recorder, not next to it. Skipping a
+ * screenshot would require not calling beat() at all (which is auditable via the
+ * actions.ndjson sequence: missing seq numbers == off-the-books actions).
+ *
+ * CONTRACT
+ * --------
+ *   - No UI action runs without a before+after PNG. The caller passes the action
+ *     as a callback; the recorder captures, runs, captures again, then logs.
+ *   - Every PNG is named `beat-NNN-{before,after}-{label}.png` (seq zero-padded
+ *     to 3 digits; label slugged to [a-z0-9-]). One-shot state captures via
+ *     `snapshot()` are `beat-NNN-state-{label}.png`.
+ *   - `actions.ndjson` is the contract between the Player agent and the QA review
+ *     pass: one JSON line per beat with {seq, kind, label, ts, before, after,
+ *     console_errors_since_last, network_failures_since_last, duration_ms,
+ *     error?}. The reviewer agent reads these to know what was done and which
+ *     PNG to look at — never just the PNGs alone.
+ *   - `summary.json` (written by `finalize()`) is the run-level deliverable:
+ *     totals + first/last beat + console/network counts. The QA scorer reads it
+ *     to know whether the recording was even complete.
+ *
+ * DESIGN NOTES
+ * ------------
+ *   - Listeners (console / pageerror / requestfailed / response>=400) are
+ *     attached LAZILY on first beat for a given page, and per-beat counters
+ *     are zeroed at the START of each beat. So the recorded
+ *     `console_errors_since_last` is "what happened during this beat's action +
+ *     anything emitted in the gap between beats" — i.e. errors are always
+ *     attributed forward to the next beat. This is intentional: if you click
+ *     X and an error appears, you want the error pinned to the X beat.
+ *   - We DO NOT swallow action errors. The action callback's throw is captured
+ *     into the ndjson row (`error` field), the after.png is still taken (so you
+ *     can see the broken state), and the throw is re-raised so the caller's
+ *     control flow stays honest.
+ *   - We are intentionally NOT an MCP server, NOT a bug-reporter, and NOT a
+ *     scorer — those live in palette_server.js and ui_playtest_score.py. This
+ *     module is just the evidence-collector. It does one thing well so callers
+ *     (palette_server, ad-hoc fix-verifier scripts, the before/after differ for
+ *     a one-line CSS change) can all share the same on-disk format.
+ *   - All file I/O is synchronous-append on the hot path (matches palette_server)
+ *     so a crash mid-run still leaves a valid prefix of ndjson on disk.
+ */
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+
+const SHOT_TIMEOUT_MS = 8000; // screenshot() should never block the recorder
+const ACTION_TIMEOUT_DEFAULT_MS = 30000; // soft cap on a single beat's action
+
+function nowIso() {
+  return new Date().toISOString().replace(/\.\d+Z$/, "Z");
+}
+
+function slug(s) {
+  return String(s || "step")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 60) || "step";
+}
+
+function appendLine(file, obj) {
+  try {
+    fs.appendFileSync(file, JSON.stringify(obj) + "\n");
+  } catch (_e) {
+    /* never let a logging failure break a tool call */
+  }
+}
+
+/**
+ * BeatRecorder — records screenshot pairs around UI actions.
+ *
+ * Usage:
+ *   const rec = new BeatRecorder("/path/to/run", { logger: console.log });
+ *   await rec.beat(page, "open-launcher", async () => {
+ *     await page.goto("http://127.0.0.1:8799/openworlds/");
+ *   });
+ *   await rec.snapshot(page, "after-load");
+ *   await rec.finalize();
+ */
+class BeatRecorder {
+  /**
+   * @param {string} runDir - run root; we write `screenshots/` and `actions.ndjson` under it
+   * @param {object} [opts]
+   * @param {(line: string) => void} [opts.logger] - optional sink for human-readable events
+   * @param {number} [opts.actionTimeoutMs] - per-beat soft cap (default 30s)
+   * @param {boolean} [opts.fullPage] - pass-through to page.screenshot fullPage flag
+   */
+  constructor(runDir, opts = {}) {
+    if (!runDir || typeof runDir !== "string") {
+      throw new Error("BeatRecorder: runDir is required (string)");
+    }
+    this.runDir = runDir;
+    this.shotsDir = path.join(runDir, "screenshots");
+    this.actionsFile = path.join(runDir, "actions.ndjson");
+    this.summaryFile = path.join(runDir, "summary.json");
+    this.logger = typeof opts.logger === "function" ? opts.logger : () => {};
+    this.actionTimeoutMs = Number(opts.actionTimeoutMs) > 0 ? Number(opts.actionTimeoutMs) : ACTION_TIMEOUT_DEFAULT_MS;
+    this.fullPage = !!opts.fullPage;
+
+    fs.mkdirSync(this.runDir, { recursive: true });
+    fs.mkdirSync(this.shotsDir, { recursive: true });
+
+    this.seq = 0;
+    this.totalBeats = 0;
+    this.totalSnapshots = 0;
+    this.totalScreenshots = 0;
+    this.totalConsoleErrors = 0;
+    this.totalNetworkFailures = 0;
+    this.firstBeatTs = null;
+    this.lastBeatTs = null;
+    this.failedBeats = 0;
+
+    // Per-page state: which pages we've already hooked, plus the rolling buffers
+    // of console errors + network failures since the last beat-boundary.
+    // WeakMap so closed pages get GC'd without us leaking handlers.
+    this._pageState = new WeakMap();
+    this._finalized = false;
+  }
+
+  /**
+   * Lazily attach console + network listeners to a page. Idempotent.
+   * @private
+   */
+  _ensureHooked(page) {
+    let state = this._pageState.get(page);
+    if (state) return state;
+
+    state = {
+      consoleErrors: [], // [{ts, type, text}] since last beat boundary
+      networkFailures: [], // [{ts, url, method, status?, error?}] since last beat
+    };
+
+    const onConsole = (msg) => {
+      const type = msg.type();
+      if (type !== "error" && type !== "warning") return;
+      const text = msg.text();
+      // Mirror palette_server's noise filter — React-devtools nag + per-resource 404 echo
+      if (/Download the React DevTools|Each child in a list should have a unique/.test(text)) return;
+      // The "Failed to load resource" line is the browser's echo of a 4xx/5xx — we'll
+      // record the response below; don't double-count it here.
+      if (/Failed to load resource/i.test(text)) return;
+      if (type === "error") {
+        state.consoleErrors.push({ ts: nowIso(), type, text: text.slice(0, 600) });
+      }
+    };
+
+    const onPageError = (err) => {
+      const text = String(err && err.message ? err.message : err);
+      state.consoleErrors.push({ ts: nowIso(), type: "pageerror", text: text.slice(0, 600) });
+    };
+
+    const onRequestFailed = (req) => {
+      const failure = req.failure();
+      const errText = failure ? failure.errorText : "failed";
+      // Aborted navigations are user-driven; not a failure to report.
+      if (/net::ERR_ABORTED/.test(errText)) return;
+      state.networkFailures.push({
+        ts: nowIso(),
+        url: req.url(),
+        method: req.method(),
+        error: errText,
+      });
+    };
+
+    const onResponse = (resp) => {
+      const status = resp.status();
+      if (status < 400) return;
+      state.networkFailures.push({
+        ts: nowIso(),
+        url: resp.url(),
+        method: resp.request().method(),
+        status,
+      });
+    };
+
+    page.on("console", onConsole);
+    page.on("pageerror", onPageError);
+    page.on("requestfailed", onRequestFailed);
+    page.on("response", onResponse);
+
+    this._pageState.set(page, state);
+    return state;
+  }
+
+  /**
+   * Drain the per-page rolling buffers and return what accumulated since the
+   * last beat (or page-hook). Mutates state by clearing the arrays.
+   * @private
+   */
+  _drainSince(page) {
+    const state = this._ensureHooked(page);
+    const consoleErrors = state.consoleErrors.splice(0);
+    const networkFailures = state.networkFailures.splice(0);
+    this.totalConsoleErrors += consoleErrors.length;
+    this.totalNetworkFailures += networkFailures.length;
+    return { consoleErrors, networkFailures };
+  }
+
+  /**
+   * Take a screenshot. Returns the path RELATIVE to `runDir` (so callers can
+   * embed it in summary.md / bug records without leaking absolute paths) and
+   * the absolute path (so the caller can read it back).
+   * @private
+   */
+  async _screenshot(page, filename) {
+    const absPath = path.join(this.shotsDir, filename);
+    const relPath = path.relative(this.runDir, absPath);
+    try {
+      // Race the screenshot against a hard cap — a hung page must NOT pin the
+      // recorder. If we hit the cap, write a sentinel and continue.
+      await Promise.race([
+        page.screenshot({ path: absPath, fullPage: this.fullPage, timeout: SHOT_TIMEOUT_MS }),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("screenshot timeout")), SHOT_TIMEOUT_MS + 1500)),
+      ]);
+      this.totalScreenshots += 1;
+      return { abs: absPath, rel: relPath, ok: true };
+    } catch (e) {
+      this.logger("BeatRecorder: screenshot failed for " + filename + ": " + (e && e.message ? e.message : e));
+      return { abs: absPath, rel: relPath, ok: false, error: String(e && e.message ? e.message : e) };
+    }
+  }
+
+  /**
+   * Record one beat: before-screenshot, run the action, after-screenshot, log.
+   *
+   * @param {import('playwright').Page} page
+   * @param {string} label - short slug-able description ("click-start", "open-roster")
+   * @param {() => Promise<any>} action - the UI action; awaited inside the beat
+   * @returns {Promise<object>} the ndjson row that was written
+   *
+   * If the action throws, we still take the after.png (so the broken state is
+   * captured) and re-throw after writing the row. The row will have `ok:false`
+   * and an `error` field.
+   */
+  async beat(page, label, action) {
+    if (this._finalized) throw new Error("BeatRecorder: beat() called after finalize()");
+    if (!page) throw new Error("BeatRecorder.beat: page is required");
+    if (typeof action !== "function") throw new Error("BeatRecorder.beat: action callback is required");
+
+    this._ensureHooked(page);
+    // Drain anything that accumulated since the last beat boundary BEFORE the
+    // before.png; that way the per-beat counters describe "errors during THIS
+    // beat" (plus any leak from the gap, which is the conservative choice).
+    this._drainSince(page);
+
+    this.seq += 1;
+    const seqStr = String(this.seq).padStart(3, "0");
+    const safeLabel = slug(label);
+    const startTs = nowIso();
+    if (this.firstBeatTs === null) this.firstBeatTs = startTs;
+
+    const beforeName = "beat-" + seqStr + "-before-" + safeLabel + ".png";
+    const afterName = "beat-" + seqStr + "-after-" + safeLabel + ".png";
+
+    this.logger("[beat " + seqStr + "] " + safeLabel + " — capturing before");
+    const before = await this._screenshot(page, beforeName);
+
+    let actionError = null;
+    const t0 = Date.now();
+    try {
+      await Promise.race([
+        Promise.resolve().then(() => action()),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("beat action timeout (" + this.actionTimeoutMs + "ms)")), this.actionTimeoutMs)
+        ),
+      ]);
+    } catch (e) {
+      actionError = e;
+      this.logger("[beat " + seqStr + "] action threw: " + (e && e.message ? e.message : e));
+    }
+    const durationMs = Date.now() - t0;
+
+    this.logger("[beat " + seqStr + "] " + safeLabel + " — capturing after");
+    const after = await this._screenshot(page, afterName);
+
+    const { consoleErrors, networkFailures } = this._drainSince(page);
+
+    const row = {
+      ts: startTs,
+      seq: this.seq,
+      kind: "beat",
+      label: safeLabel,
+      label_raw: String(label || ""),
+      duration_ms: durationMs,
+      before: before.rel,
+      after: after.rel,
+      before_ok: before.ok,
+      after_ok: after.ok,
+      console_errors_since_last: consoleErrors,
+      network_failures_since_last: networkFailures,
+      ok: actionError === null,
+    };
+    if (actionError) {
+      row.error = String(actionError && actionError.message ? actionError.message : actionError);
+    }
+    appendLine(this.actionsFile, row);
+    this.lastBeatTs = nowIso();
+    this.totalBeats += 1;
+    if (actionError) {
+      this.failedBeats += 1;
+      // Re-throw so the caller's control flow is honest. The row is already on disk.
+      throw actionError;
+    }
+    return row;
+  }
+
+  /**
+   * Single screenshot + ndjson row, no before/after pairing. Use for a
+   * baseline / final "this is the state" capture that is not bracketing a UI
+   * action. Counted in summary.json under `snapshots`, NOT `beats`.
+   *
+   * @param {import('playwright').Page} page
+   * @param {string} label
+   * @returns {Promise<object>} the ndjson row that was written
+   */
+  async snapshot(page, label) {
+    if (this._finalized) throw new Error("BeatRecorder: snapshot() called after finalize()");
+    if (!page) throw new Error("BeatRecorder.snapshot: page is required");
+
+    this._ensureHooked(page);
+    // Drain so the counters are accurate for "since last beat or snapshot".
+    const drainedPre = this._drainSince(page);
+
+    this.seq += 1;
+    const seqStr = String(this.seq).padStart(3, "0");
+    const safeLabel = slug(label);
+    const ts = nowIso();
+    if (this.firstBeatTs === null) this.firstBeatTs = ts;
+
+    const stateName = "beat-" + seqStr + "-state-" + safeLabel + ".png";
+    this.logger("[beat " + seqStr + "] " + safeLabel + " — state snapshot");
+    const shot = await this._screenshot(page, stateName);
+
+    const row = {
+      ts,
+      seq: this.seq,
+      kind: "snapshot",
+      label: safeLabel,
+      label_raw: String(label || ""),
+      screenshot: shot.rel,
+      screenshot_ok: shot.ok,
+      console_errors_since_last: drainedPre.consoleErrors,
+      network_failures_since_last: drainedPre.networkFailures,
+      ok: shot.ok,
+    };
+    appendLine(this.actionsFile, row);
+    this.lastBeatTs = ts;
+    this.totalSnapshots += 1;
+    return row;
+  }
+
+  /**
+   * Write summary.json. Safe to call multiple times — only the LAST call is
+   * authoritative. After finalize(), beat/snapshot will throw.
+   *
+   * @returns {Promise<object>} the summary object written
+   */
+  async finalize() {
+    const summary = {
+      schema: "screenshot-helper.v1",
+      generated_at: nowIso(),
+      run_dir: this.runDir,
+      total_beats: this.totalBeats,
+      total_snapshots: this.totalSnapshots,
+      total_screenshots: this.totalScreenshots,
+      failed_beats: this.failedBeats,
+      total_console_errors: this.totalConsoleErrors,
+      total_network_failures: this.totalNetworkFailures,
+      first_beat_ts: this.firstBeatTs,
+      last_beat_ts: this.lastBeatTs,
+      actions_ndjson: path.relative(this.runDir, this.actionsFile),
+      screenshots_dir: path.relative(this.runDir, this.shotsDir),
+    };
+    try {
+      fs.writeFileSync(this.summaryFile, JSON.stringify(summary, null, 2) + "\n");
+    } catch (e) {
+      this.logger("BeatRecorder.finalize: failed to write summary.json: " + (e && e.message ? e.message : e));
+    }
+    this._finalized = true;
+    this.logger(
+      "BeatRecorder finalized — " +
+        this.totalBeats +
+        " beats, " +
+        this.totalSnapshots +
+        " snapshots, " +
+        this.totalScreenshots +
+        " PNGs, " +
+        this.totalConsoleErrors +
+        " console errors, " +
+        this.totalNetworkFailures +
+        " network failures"
+    );
+    return summary;
+  }
+}
+
+module.exports = { BeatRecorder, slug };

--- a/qa/playwright/screenshot_helper.test.js
+++ b/qa/playwright/screenshot_helper.test.js
@@ -1,0 +1,182 @@
+/*
+ * Smoke test for BeatRecorder.
+ *
+ * Launches a headless Chromium, navigates to https://example.com, runs two
+ * beats + one snapshot through the recorder, finalizes, and asserts that:
+ *   1. The before/after PNGs exist for each beat (and are non-empty).
+ *   2. The state PNG exists for the snapshot.
+ *   3. actions.ndjson has exactly the rows we expect, in order, with the
+ *      right shape (seq, label, kind, before/after fields).
+ *   4. summary.json reports the right totals.
+ *   5. Calling beat() after finalize() throws.
+ *
+ * Run it directly:
+ *   cd qa/playwright && node screenshot_helper.test.js
+ *
+ * Exit code is 0 on success, non-zero on the first failed assertion. Output
+ * is plain text so it's tail-friendly under `gh run watch` and the playtest
+ * harness's run log.
+ *
+ * NOTE: this test makes one real network request to https://example.com — it
+ * is deliberately the same target the W3C / IETF / Playwright docs use as a
+ * stable smoke endpoint. If that's offline, the test will fail the navigation
+ * (which is itself a fine signal that the recorder still wrote a row with
+ * `ok:false` and the after.png for the broken state).
+ */
+"use strict";
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const assert = require("assert");
+
+const { BeatRecorder, slug } = require("./screenshot_helper.js");
+
+const TEST_URL = process.env.SCREENSHOT_HELPER_TEST_URL || "https://example.com";
+
+function readNdjson(file) {
+  const raw = fs.readFileSync(file, "utf8");
+  return raw
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l));
+}
+
+async function main() {
+  // 1. Slug helper sanity (no Playwright needed)
+  assert.strictEqual(slug("Open Launcher!"), "open-launcher", "slug should lowercase + dash");
+  assert.strictEqual(slug(""), "step", "slug empty -> fallback");
+  assert.strictEqual(slug("a/b/c"), "a-b-c", "slug should replace slashes");
+  console.log("[ok] slug helper");
+
+  // 2. Set up a run dir under the OS tempdir so the test is self-cleaning-ish
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), "beatrec-smoke-"));
+  console.log("[info] runDir = " + runDir);
+
+  // 3. Capture logger output so we can assert it isn't silent
+  const loggedLines = [];
+  const rec = new BeatRecorder(runDir, { logger: (s) => loggedLines.push(s) });
+
+  // 4. Launch Playwright. Resolve the local install path (sub-agent 1 installs
+  // playwright at qa/playwright/node_modules) so this test works both from the
+  // qa/playwright dir and elsewhere.
+  let chromium;
+  try {
+    ({ chromium } = require("playwright"));
+  } catch (e) {
+    console.error("[fail] playwright not installed; install it first via `npm i` in qa/playwright/");
+    console.error("       (" + (e && e.message ? e.message : e) + ")");
+    process.exit(2);
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  let exitCode = 0;
+  try {
+    const ctx = await browser.newContext({ viewport: { width: 1024, height: 768 } });
+    const page = await ctx.newPage();
+
+    // Beat 1 — navigate. This is the canonical first beat in any UI playtest.
+    const row1 = await rec.beat(page, "Goto example", async () => {
+      await page.goto(TEST_URL, { waitUntil: "domcontentloaded", timeout: 20000 });
+    });
+    assert.strictEqual(row1.seq, 1, "first beat seq is 1");
+    assert.strictEqual(row1.kind, "beat", "kind is beat");
+    assert.strictEqual(row1.label, "goto-example", "label slugged");
+    assert.strictEqual(row1.ok, true, "first beat ok");
+    assert.ok(row1.before && row1.after, "before+after recorded");
+    assert.ok(row1.before.startsWith("screenshots/"), "before path is run-relative");
+    assert.ok(Array.isArray(row1.console_errors_since_last), "console-errors array present");
+    console.log("[ok] beat 1 — goto");
+
+    // Beat 2 — read the page title (a no-op for the DOM, but exercises the
+    // before/after contract on a second call so we can assert seq advances).
+    const row2 = await rec.beat(page, "Read title", async () => {
+      const t = await page.title();
+      assert.ok(t.length > 0, "page has a title");
+    });
+    assert.strictEqual(row2.seq, 2, "second beat seq is 2");
+    console.log("[ok] beat 2 — read title");
+
+    // Snapshot — single screenshot, no action.
+    const row3 = await rec.snapshot(page, "final state");
+    assert.strictEqual(row3.seq, 3, "snapshot uses next seq");
+    assert.strictEqual(row3.kind, "snapshot", "kind is snapshot");
+    assert.ok(row3.screenshot.startsWith("screenshots/"), "snapshot screenshot path");
+    console.log("[ok] snapshot");
+
+    // Assert files on disk
+    const shotsDir = path.join(runDir, "screenshots");
+    const expectedFiles = [
+      "beat-001-before-goto-example.png",
+      "beat-001-after-goto-example.png",
+      "beat-002-before-read-title.png",
+      "beat-002-after-read-title.png",
+      "beat-003-state-final-state.png",
+    ];
+    for (const f of expectedFiles) {
+      const p = path.join(shotsDir, f);
+      assert.ok(fs.existsSync(p), "expected screenshot exists: " + f);
+      const stat = fs.statSync(p);
+      assert.ok(stat.size > 200, "screenshot non-trivial size (>200b): " + f + " (got " + stat.size + ")");
+    }
+    console.log("[ok] all 5 expected PNGs exist + non-trivial");
+
+    // Assert ndjson contents
+    const actionsFile = path.join(runDir, "actions.ndjson");
+    assert.ok(fs.existsSync(actionsFile), "actions.ndjson exists");
+    const rows = readNdjson(actionsFile);
+    assert.strictEqual(rows.length, 3, "ndjson has 3 rows");
+    assert.deepStrictEqual(
+      rows.map((r) => r.seq),
+      [1, 2, 3],
+      "ndjson seq is 1,2,3 in order"
+    );
+    assert.deepStrictEqual(
+      rows.map((r) => r.kind),
+      ["beat", "beat", "snapshot"],
+      "ndjson kinds beat/beat/snapshot"
+    );
+    console.log("[ok] actions.ndjson well-formed");
+
+    // Finalize + summary.json
+    const summary = await rec.finalize();
+    assert.strictEqual(summary.total_beats, 2, "summary total_beats");
+    assert.strictEqual(summary.total_snapshots, 1, "summary total_snapshots");
+    assert.strictEqual(summary.total_screenshots, 5, "summary total_screenshots");
+    assert.strictEqual(summary.failed_beats, 0, "summary failed_beats");
+    assert.ok(summary.first_beat_ts && summary.last_beat_ts, "summary has timestamps");
+
+    const summaryFile = path.join(runDir, "summary.json");
+    assert.ok(fs.existsSync(summaryFile), "summary.json on disk");
+    const summaryOnDisk = JSON.parse(fs.readFileSync(summaryFile, "utf8"));
+    assert.strictEqual(summaryOnDisk.schema, "screenshot-helper.v1", "schema label");
+    console.log("[ok] summary.json");
+
+    // Calling beat() after finalize must throw
+    let threw = false;
+    try {
+      await rec.beat(page, "post-final", async () => {});
+    } catch (_e) {
+      threw = true;
+    }
+    assert.ok(threw, "beat() after finalize() throws");
+    console.log("[ok] post-finalize beat() throws");
+
+    // Logger received output
+    assert.ok(loggedLines.length > 0, "logger received lines");
+    console.log("[ok] logger received " + loggedLines.length + " lines");
+
+    console.log("\n[PASS] screenshot_helper smoke OK — runDir kept for inspection: " + runDir);
+  } catch (e) {
+    exitCode = 1;
+    console.error("[FAIL] " + (e && e.stack ? e.stack : e));
+  } finally {
+    await browser.close().catch(() => {});
+  }
+  process.exit(exitCode);
+}
+
+main().catch((e) => {
+  console.error("[FAIL] unhandled: " + (e && e.stack ? e.stack : e));
+  process.exit(1);
+});

--- a/qa/ui_audit_health.sh
+++ b/qa/ui_audit_health.sh
@@ -6,6 +6,12 @@
 #   qa/ui_audit_health.sh              # full sweep, port 8799
 #   qa/ui_audit_health.sh --port 8895  # custom port
 #   qa/ui_audit_health.sh --quick      # skip screenshot capture (fastest)
+#   qa/ui_audit_health.sh --axe        # add the axe-core a11y sweep (slower)
+#   qa/ui_audit_health.sh --ui-gate    # add the "UI gate with teeth" probe (Loop-9):
+#                                      #   per-screen Playwright check for console
+#                                      #   errors, placeholder explosion, broken
+#                                      #   imgs, title-bar/nav-rail collision (#260),
+#                                      #   and the launcher Resume/Continue CTA.
 #
 # Output: structured PASS/FAIL lines to stdout, exit 0 if all PASS, 1 otherwise.
 #
@@ -23,9 +29,27 @@
 #      (no rename / refactor accidentally dropped a route).
 #   9. styles.css responsive breakpoints + a11y rules still defined.
 #  10. _private/baldurs-gate/images/ still has ≥ 2000 dirs (asset catalog intact).
-#  11. (optional) Re-capture screenshots at 1366 + 1512 to /tmp/ow-health/ —
+#  11. (optional, --quick=0) Re-capture screenshots at 1366 + 1512 to /tmp/ow-health/ —
 #      compare against the audit baseline (visual diff is manual; this just
 #      checks the capture pipeline works).
+#  12. (optional, --axe) axe-core a11y sweep across every screen. Baseline = 0.
+#  13. (optional, --ui-gate) "UI gate with teeth", driven by qa/ui_gate_probe.js
+#      (headless Playwright). For each screen, at viewports 1366 + 1512:
+#       13a. renders_clean: 0 JS console errors and 0 page-level exceptions
+#            (404 resource warns from un-ingested art are dropped — those are
+#            tracked by check #10 + check 13b).
+#       13b. art_present: total `.placeholder` count ≤ per-screen Loop-9 baseline
+#            + 2 slack (launcher 26, character 9, bestiary 20, inventory 13,
+#            forge 1, all others 0). Broken-img count (resolved + naturalWidth
+#            == 0) must be 0.
+#       13c. title_bar_clearance: `.title-text` and `.nav-rail` bounding rects
+#            do NOT overlap (this catches the #260 / #306 regression where the
+#            title text wraps and falls behind the nav rail at narrow widths).
+#       13d. play_reachable: on #launcher, a "Continue → play" or "Resume → play"
+#            button is present and not disabled.
+#      If a running viewer isn't reachable on the configured port the probe
+#      WARNs instead of FAILing, so the gate stays opt-in for CI lanes that
+#      don't stand up a viewer.
 #
 # Exit codes:
 #   0 — all PASS, audit findings still valid as filed.
@@ -35,11 +59,13 @@ set -u
 PORT=8799
 QUICK=0
 AXE=0
+UI_GATE=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --port) PORT="$2"; shift 2 ;;
     --quick) QUICK=1; shift ;;
     --axe) AXE=1; shift ;;
+    --ui-gate) UI_GATE=1; shift ;;
     *) echo "unknown arg: $1" >&2; exit 2 ;;
   esac
 done
@@ -266,6 +292,119 @@ if [ "$AXE" -eq 1 ]; then
       else
         fail "axe total: $TOTAL violations (baseline = 0; a11y regression detected)"
       fi
+    fi
+  fi
+fi
+
+# 13. Optional: "UI gate with teeth" — per-screen Playwright probe (Loop-9).
+# Off by default. Drives qa/ui_gate_probe.js at 1366 + 1512 viewports against
+# the configured viewer; checks: renders_clean, art_present, title_bar_clearance,
+# play_reachable. Baselines were measured 2026-05-30 against viewer/server.py
+# on the full _private asset catalog (≥2359 dirs). If the viewer isn't reachable
+# this whole block WARNs rather than FAILs — the gate is opt-in for lanes that
+# stand up a viewer first.
+if [ "$UI_GATE" -eq 1 ]; then
+  if ! command -v node >/dev/null 2>&1; then
+    warn "node not on PATH; skipping --ui-gate"
+  elif [ ! -f qa/playwright/node_modules/playwright/package.json ]; then
+    warn "qa/playwright/node_modules/playwright not installed; run (cd qa/playwright && npm install)"
+  elif [ ! -f qa/ui_gate_probe.js ]; then
+    warn "qa/ui_gate_probe.js missing; --ui-gate skipped"
+  else
+    # Per-screen placeholder ceilings (Loop-9 baseline + 2 slack) — kept inline
+    # in the python report block below (macOS ships bash 3.2 which has no
+    # associative arrays; rather than gate the script on bash 4, we let python
+    # carry the table).
+    SCREENS_UI=(launcher table combat character map relations dialogue bestiary \
+                inventory journal acts merchant forge create seed settings roster)
+    UI_OUT=/tmp/ow-ui-gate.ndjson
+    : > "$UI_OUT"
+    if ! node qa/ui_gate_probe.js "$PORT" "${SCREENS_UI[@]}" > "$UI_OUT" 2>/tmp/ow-ui-gate.err; then
+      warn "ui_gate_probe exited non-zero — see /tmp/ow-ui-gate.err"
+      warn "(skipping per-screen checks)"
+    else
+      # Parse NDJSON via python for portability (jq isn't a hard dep here).
+      # Emit one PASS/FAIL per screen × check, then a roll-up.
+      python3 - "$UI_OUT" <<'PY' > /tmp/ow-ui-gate.report
+import json, sys
+PH_CAP = {
+    "launcher": 28, "table": 2, "combat": 2, "character": 11, "map": 2,
+    "relations": 2, "dialogue": 2, "bestiary": 22, "inventory": 15,
+    "journal": 2, "acts": 2, "merchant": 2, "forge": 3, "create": 2,
+    "seed": 2, "settings": 2, "roster": 2,
+}
+def emit(verdict, line): print(f"{verdict}  {line}")
+total_fail = 0
+with open(sys.argv[1]) as f:
+    for raw in f:
+        raw = raw.strip()
+        if not raw.startswith("{"): continue
+        try:
+            d = json.loads(raw)
+        except Exception as e:
+            emit("FAIL", f"ui-gate parse error: {e}")
+            total_fail += 1
+            continue
+        s = d["screen"]
+        cap = PH_CAP.get(s, 2)
+        # Aggregate across the two viewports — both must pass for a green light.
+        vps = d.get("viewports", {})
+        if not vps:
+            emit("WARN", f"ui-gate {s}: no viewport data (viewer reachable?)")
+            continue
+        for vp, v in vps.items():
+            # 13a. renders_clean
+            if v.get("consoleErrors", 0) == 0:
+                emit("PASS", f"ui-gate renders_clean {s} @ {vp}: 0 console errors")
+            else:
+                samples = v.get("consoleErrorSamples") or []
+                emit("FAIL", f"ui-gate renders_clean {s} @ {vp}: {v['consoleErrors']} err — {samples[:1]}")
+                total_fail += 1
+            # 13b. art_present (placeholder ceiling + no broken imgs)
+            ph = v.get("placeholders", 0)
+            broken = v.get("imgsBroken", 0)
+            if ph <= cap and broken == 0:
+                emit("PASS", f"ui-gate art_present {s} @ {vp}: placeholders={ph}/cap{cap} broken=0/{v.get('imgsTotal',0)}")
+            else:
+                why = []
+                if ph > cap: why.append(f"placeholders={ph} > cap {cap}")
+                if broken > 0: why.append(f"broken imgs={broken}/{v.get('imgsTotal',0)}")
+                emit("FAIL", f"ui-gate art_present {s} @ {vp}: " + "; ".join(why))
+                total_fail += 1
+            # 13c. title_bar_clearance — #260 / #306
+            if not v.get("titleNavOverlap", False):
+                emit("PASS", f"ui-gate title_bar_clearance {s} @ {vp}: no title/nav-rail collision")
+            else:
+                tr = v.get("titleRect"); nr = v.get("navRect")
+                emit("FAIL",
+                    f"ui-gate title_bar_clearance {s} @ {vp}: title-text rect overlaps nav-rail "
+                    f"(title={tr} nav={nr}) — #260 regression")
+                total_fail += 1
+            # 13d. play_reachable (launcher only)
+            cta = v.get("launcherCta")
+            if cta is None:
+                pass  # non-launcher screens skip this check
+            elif cta.get("missing"):
+                emit("FAIL", f"ui-gate play_reachable {s} @ {vp}: no Resume/Continue CTA found on launcher")
+                total_fail += 1
+            elif cta.get("disabled"):
+                emit("FAIL", f"ui-gate play_reachable {s} @ {vp}: CTA '{cta.get('text')}' is disabled")
+                total_fail += 1
+            else:
+                emit("PASS", f"ui-gate play_reachable {s} @ {vp}: '{cta.get('text')}' enabled")
+print(f"__TOTAL_FAIL__:{total_fail}")
+PY
+      # Replay the python report through pass/fail/warn so the overall summary
+      # picks up failures via the shell's FAIL variable.
+      while IFS= read -r line; do
+        case "$line" in
+          PASS*) pass "${line#PASS  }" ;;
+          FAIL*) fail "${line#FAIL  }" ;;
+          WARN*) warn "${line#WARN  }" ;;
+          __TOTAL_FAIL__:*) ;;  # rollup only
+          *) echo "$line" ;;
+        esac
+      done < /tmp/ow-ui-gate.report
     fi
   fi
 fi

--- a/qa/ui_gate_probe.js
+++ b/qa/ui_gate_probe.js
@@ -1,0 +1,168 @@
+// qa/ui_gate_probe.js
+// Headless Playwright probe behind `qa/ui_audit_health.sh --ui-gate`.
+//
+// Drives one or more OpenWorlds screens at two viewport widths (1366 + 1512 —
+// the "narrow desktop" + "MBP 13-inch" pair the Loop-9 audit measured against)
+// and emits a structured JSON line per screen so the shell wrapper can pass/fail
+// per-check.
+//
+// Usage:
+//   node qa/ui_gate_probe.js <port> <screen-hash> [screen-hash ...]
+//
+// Output: NDJSON, one JSON object per screen, like:
+//   {
+//     "screen": "launcher",
+//     "viewports": {
+//       "1366": {
+//         "consoleErrors": 0,
+//         "placeholders": 6,
+//         "imgsTotal": 0,
+//         "imgsBroken": 0,
+//         "titleNavOverlap": true,         // collision check (#260 / #306)
+//         "launcherCta": { "text": "Resume → play", "disabled": false }
+//       },
+//       "1512": { ... }
+//     }
+//   }
+//
+// Why two widths: #260 (title-bar text overlaps nav-rail) reproduces below
+// ~1380px. Measuring at both 1366 (under) and 1512 (over) catches regressions
+// that introduce new clipping AND verifies the fix actually clears both bands.
+//
+// Console-error filter: we drop `Failed to load resource … 404` lines on
+// purpose — those come from un-ingested art-scope tiles and are already tracked
+// by the "art_present" check + the existing _private asset-catalog gate. We
+// only surface JavaScript runtime errors (TypeError, ReferenceError, React
+// "uncaught" boundaries, page-level exceptions) — the kind that would render
+// a screen *broken*, not just art-poor.
+
+const path = require('path');
+
+// Resolve playwright via the local install — works whether the script is
+// invoked from the repo root, /tmp, or CI's checkout dir.
+const playwrightPath = path.join(__dirname, 'playwright', 'node_modules', 'playwright');
+let chromium;
+try {
+  ({ chromium } = require(playwrightPath));
+} catch (e) {
+  console.error(`ui_gate_probe: playwright not available at ${playwrightPath}`);
+  console.error('Install with: (cd qa/playwright && npm install)');
+  process.exit(2);
+}
+
+const port = process.argv[2] || '8765';
+const screens = process.argv.slice(3);
+if (!screens.length) {
+  console.error('usage: node qa/ui_gate_probe.js <port> <screen> [<screen> ...]');
+  process.exit(2);
+}
+
+const VIEWPORTS = [1366, 1512];
+
+async function probeScreen(browser, screen) {
+  const out = { screen, viewports: {} };
+  for (const width of VIEWPORTS) {
+    const ctx = await browser.newContext({ viewport: { width, height: 900 } });
+    const page = await ctx.newPage();
+    const errs = [];
+    page.on('console', (m) => {
+      if (m.type() !== 'error') return;
+      const t = m.text();
+      // Filter the noisy asset-404 stream — those are tracked by art_present, not renders_clean.
+      if (/Failed to load resource.*(404|net::ERR_)/.test(t)) return;
+      errs.push(t.slice(0, 240));
+    });
+    page.on('pageerror', (e) => errs.push('PAGEERROR ' + String(e).slice(0, 240)));
+    try {
+      await page.goto(`http://127.0.0.1:${port}/openworlds/#${screen}`, {
+        waitUntil: 'domcontentloaded',
+        timeout: 15000,
+      });
+      // Babel-standalone transpiles JSX on first paint; wait for the React tree to
+      // mount and lazy effects (Img resolution, route-bound data) to settle. We
+      // poll `document.querySelector('.title-bar')` rather than `networkidle`
+      // because the dev server's hot-reload pings keep the network busy.
+      await page.waitForFunction(() => !!document.querySelector('.title-bar'), { timeout: 10000 });
+      await page.waitForTimeout(1200);
+    } catch (e) {
+      errs.push('NAV ' + String(e).slice(0, 220));
+    }
+    // Babel-standalone can fire a late re-eval that destroys the V8 context
+     // while we're mid-evaluate. Retry once on context-destroyed.
+    const evalOnce = async () => await page.evaluate(() => {
+      // title-bar / nav-rail collision (#260 / #306). The actual bug is text
+      // overflowing the title-text grid cell and being occluded by the nav-rail
+      // at narrow widths. We check both horizontal AND vertical overlap of the
+      // BOUNDING RECTS — when title text wraps, its bottom extends down past
+      // the nav-rail's top, producing a true visual collision.
+      const t = document.querySelector('.title-text');
+      const n = document.querySelector('.nav-rail');
+      const rect = (el) => (el ? el.getBoundingClientRect() : null);
+      const tr = rect(t);
+      const nr = rect(n);
+      const overlap = tr && nr
+        ? (tr.left < nr.right && tr.right > nr.left)
+          && (tr.top < nr.bottom && tr.bottom > nr.top)
+        : false;
+      const placeholders = document.querySelectorAll('.placeholder').length;
+      const imgEls = Array.from(document.querySelectorAll('img'));
+      const imgsBroken = imgEls.filter((i) => i.complete && i.naturalWidth === 0).length;
+      // Launcher CTA — the primary Continue / Resume → play button. Other
+      // screens leave this null.
+      let launcherCta = null;
+      if ((location.hash === '#launcher' || location.hash === '' || location.hash === '#')) {
+        const btns = Array.from(document.querySelectorAll('button'));
+        const cta = btns.find((b) => /continue|resume/i.test((b.textContent || '')));
+        launcherCta = cta
+          ? {
+              text: (cta.textContent || '').trim().slice(0, 80),
+              disabled: cta.disabled || cta.getAttribute('aria-disabled') === 'true',
+            }
+          : { missing: true };
+      }
+      return {
+        titleNavOverlap: overlap,
+        titleRect: tr ? { left: tr.left, right: tr.right, top: tr.top, bottom: tr.bottom } : null,
+        navRect: nr ? { left: nr.left, right: nr.right, top: nr.top, bottom: nr.bottom } : null,
+        placeholders,
+        imgsTotal: imgEls.length,
+        imgsBroken,
+        launcherCta,
+      };
+    });
+    let measured;
+    try {
+      measured = await evalOnce();
+    } catch (e) {
+      if (/Execution context was destroyed/.test(String(e))) {
+        await page.waitForTimeout(800);
+        measured = await evalOnce();
+      } else {
+        throw e;
+      }
+    }
+    out.viewports[String(width)] = {
+      ...measured,
+      consoleErrors: errs.length,
+      consoleErrorSamples: errs.slice(0, 3),
+    };
+    await ctx.close();
+  }
+  return out;
+}
+
+(async () => {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    for (const s of screens) {
+      const row = await probeScreen(browser, s);
+      // NDJSON so the shell can stream and parse incrementally.
+      console.log(JSON.stringify(row));
+    }
+  } finally {
+    await browser.close();
+  }
+})().catch((e) => {
+  console.error('ui_gate_probe fatal: ' + (e?.stack || e));
+  process.exit(3);
+});


### PR DESCRIPTION
## TL;DR

Audit-thread harness prep so the AI playtester's next loop actually drives the rendered UI instead of silently HTTP-polling. Three new artifacts + one opt-in extension to `qa/ui_audit_health.sh`. **No implementation changes.** Pure prep for the main agent.

## What this lands

| Artifact | Purpose | Closes gotcha |
|---|---|---|
| `docs/ui-audit/DUAL_DM_FIX.md` (426 lines) | Architectural patch + file:line surgery plan for the `qa/ui_playtest.sh` ↔ `scripts/play_party.sh` dual-DM race | Gotcha #1 (dual-DM fight on `$MOVES`) |
| `qa/playwright/screenshot_helper.js` + `.test.js` | `BeatRecorder` — the owner's killer rule in code: "every UI action saves before+after PNG; every UI fix renders before/after" | Killer rule (no blind UI edits) |
| `qa/ui_gate_probe.js` + `qa/ui_audit_health.sh --ui-gate` | Per-screen Playwright probe at 1366 + 1512: `renders_clean` / `art_present` / `title_bar_clearance` / `play_reachable` | UI gate with teeth |

## Why now

Owner playtest of `dist/ClawDnD.app` on 2026-05-30 scored GUI **2/10** with a 2-day-stale build (cause: no UI gate enforcing what shipped). Subsequent pivot established the AI playtester must drive a *real* browser against the *real* play-started viewer with a *screenshot per beat*. None of those three are enforced today. This PR closes the harness gap so the next loop's evidence is actually evidence.

## What this is NOT

- ❌ No edit to `qa/ui_playtest.sh` — the dual-DM strip is *designed* in `DUAL_DM_FIX.md`; the patch is the main agent's to apply (with the `--use-play-party` migration flag I propose in §"Migration plan").
- ❌ No viewer / engine / Swift app changes.
- ❌ Does NOT close #260 / #306 / #286 / #309 / #277 / #283 / #284. It makes those regressions *detectable* (the `--ui-gate` probe will FAIL on #260 if title-text rect overlaps nav-rail), not fixed.

## DO NOT MERGE yet

Hold for the main agent to review the dual-DM design and confirm the strip-playtest-to-Player approach is the one they want. The other 3 artifacts are no-risk additions (new files + opt-in flag) and could merge independently if it'd help; I'll defer to the main agent's preference.

## Collision audit (done before commit)

| Risk vector | Status |
|---|---|
| Main agent's 6 open PRs #361–369 (all `fix/ui-*` branches) | All target `viewer/openworlds/screen-*.jsx` — **zero overlap** with `docs/` + `qa/` surfaces in this PR |
| Origin commits `#359` and `#360` (the 2 I was behind) | Touched `qa/dm_narration_fallback.py`, `qa/lib_beat_driver.sh`, `qa/run_duo.sh`, `qa/run_party.sh`, `scripts/play*.sh`, `screen-launcher.jsx`, dungeon-master skill — **zero overlap** |
| `qa/ui_audit_health.sh` | Last touched by audit thread (`842dc16`); main agent not in this file. Mod here is opt-in `--ui-gate` flag only — default behavior unchanged |
| `qa/playwright/package.json` + `package-lock.json` | Sub-agent 1's `npm install` produced byte-identical content to upstream; **not included in this PR** (regenerable, owned by impl track) |

## Next steps for the main agent

1. Read `DUAL_DM_FIX.md` § "The patch" + § "Migration plan"; sign off (or push back) on the `--use-play-party` flag approach.
2. Once Playwright is installed locally (`cd qa/playwright && npm install`), wire `BeatRecorder` into the Player driver — replaces today's ad-hoc `page.screenshot()` calls with the `beat()` contract.
3. Run `qa/ui_audit_health.sh --ui-gate --port 8765` against a fresh viewer to capture today's baseline for `placeholders` / `consoleErrors` / `titleNavOverlap`. CI can gate on regressions after that.

Refs: Loop 9 plan in `docs/ui-audit/MAINTAIN.md` + `STRATEGY.md`.
