### PR TITLE
feat(qa): ui_playtest_app.sh — playtest the BUILT .app surface (§8.2, P0)

### DIFF
--- a/qa/ui_playtest_app.sh
+++ b/qa/ui_playtest_app.sh
@@ -1,0 +1,567 @@
+#!/usr/bin/env bash
+# WorldOS AI PLAYTESTER — the BUILT .app surface (§8.2, P0). Issue: WorldOS-OPERATING-GOAL.md.
+#
+# WHY THIS EXISTS (the failure §0 of the operating goal): qa/ui_playtest.sh boots its OWN
+# viewer/server.py with CLAWDND_PLAYER_MOVES set → can_act:true → a PLAYABLE surface the
+# harness wires up for itself. The shipped dist/WorldOS.app launches the viewer WITHOUT that
+# env → read-only "director's view" → a surface the user can NEVER reach by launching the app.
+# Every "all green" run there tested the wrong thing. THIS harness tests the BUILT .app surface
+# and the byte-identical backend the app shells — never a harness-wired port (P0).
+#
+# Two parts, one run:
+#   (A) NATIVE-TRANSITION GATE — re-verifies release-blocker #356.
+#       pkill the app + THIS checkout's stale viewers; rm -rf dist/WorldOS.app; fresh
+#       `script/build_and_run.sh` (off the CURRENT checkout's HEAD → must include the #356 banner
+#       fix). Launch the .app, DISCOVER its read-only launcher viewer's actual port (the .app's
+#       PortFinder walks up from preferredPort 8765, which is often already taken on this host —
+#       we never assume 8765), RAISE the .app frontmost (AppKit activate — not System-Events UI
+#       scripting, so no TCC dialog) and CGEvent-click the launcher's primary play CTA
+#       ("RESUME → PLAY"; re-clicking on a focus-race miss). Then assert the bridge MINTED a
+#       provider session: a NEW play-state/<run> dir appears AND a NEW viewer (a different port)
+#       whose /session-surface reports can_act:true. Screenshot before+after (best-effort;
+#       see screenshot()). PASS = a live, playable session; FAIL = stuck read-only. The honest
+#       #356 re-verify on the BUILT app — PASS/FAIL is the session-surface ground truth, never a
+#       screenshot. (NOTE: the CGEvent click is reliable on a PRISTINE, frontmost launcher — i.e.
+#       a fresh build+launch, which is exactly what this gate does — but is flaky to re-issue
+#       against an already-clicked/dirtied app instance on a busy multi-app desktop.)
+#
+#   (B) PERSONA LOOP — the playable surface the .app reaches once #356 mints the session.
+#       Launch scripts/play_party.sh <world> <run> <port> (the EXACT command the native
+#       startProviderSession bridge shells; solo → execs scripts/play.sh, which boots a LIVE
+#       viewer with CLAWDND_PLAYER_MOVES set + its own DM cold-open + DM resolver loop). Then
+#       drive that viewer with the real Playwright palette as <persona> for <beats> moves. This
+#       is byte-identical backend to the .app — the honest play surface, NOT a harness-only port.
+#
+# Usage:   qa/ui_playtest_app.sh <run> <world> <persona> <beats> <budget>
+# Example: qa/ui_playtest_app.sh smoke1 baldurs-gate newbie 6 4.00
+#   <beats>  = max player palette ACTIONS before part B stops (a soft cap; player may give_up).
+#   <budget> = USD cap for the WHOLE run (parts A + B; we stop part B early if A+DM already spent it).
+#
+# Flags (env):
+#   WOS_APP_SKIP_BUILD=1   reuse an already-running .app (skip pkill/rebuild) — for fast inner loop.
+#   WOS_APP_PART=A|B|AB    run only part A, only part B, or both (default AB).
+#   WORLDOS_DM_MODEL       DM model (default sonnet). CLAWDND_PLAY_BUDGET caps each DM turn.
+#
+# Produces under qa/ui_playtest_runs/<run>/:
+#   native/  before.png after.png transition.json transition.log       (part A)
+#   player/screenshots/*.png player/a11y/*.txt bugs.ndjson actions.ndjson
+#   console.ndjson network.ndjson score.json summary.md meta.json        (part B)
+#   run.json  — top-level {build_sha, version, part_a, part_b, $spend}.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
+. "$ROOT/qa/lib_beat_driver.sh"  # worldos_env + shared helpers (snapshot path, cost, etc.)
+
+RUN="${1:-app-$(date +%H%M%S)}"
+WORLD="${2:-baldurs-gate}"
+PERSONA="${3:-newbie}"
+BEATS="${4:-6}"
+BUDGET="${5:-4.00}"
+PART="$(worldos_env APP_PART "${WOS_APP_PART:-AB}")"
+
+PW_DIR="$ROOT/qa/playwright"
+APP_BUNDLE="$ROOT/dist/WorldOS.app"
+PREFERRED_PORT="${WOS_APP_PREFERRED_PORT:-8765}"   # matches RootView.swift @AppStorage("preferredPort") default
+DM_MODEL="$(worldos_env DM_MODEL sonnet)"
+PLAYER_MODEL="$(worldos_env UIPT_PLAYER_MODEL sonnet)"
+PERSONA_FILE="$ROOT/qa/play_player_browser_${PERSONA}.txt"
+
+RUNDIR="$ROOT/qa/ui_playtest_runs/$RUN"
+NATIVE_DIR="$RUNDIR/native"
+PLAYERDIR="$RUNDIR/player"
+rm -rf "$RUNDIR" 2>/dev/null
+mkdir -p "$NATIVE_DIR" "$PLAYERDIR/screenshots" "$PLAYERDIR/a11y"
+
+BUILD_SHA="$(git -C "$ROOT" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+VERSION="$( ([ -f "$ROOT/VERSION" ] && cat "$ROOT/VERSION") \
+            || git -C "$ROOT" describe --tags --always 2>/dev/null \
+            || echo "unknown")"
+log() { printf '[uipt-app] %s\n' "$*"; }
+log "run=$RUN world=$WORLD persona=$PERSONA beats=$BEATS budget=\$$BUDGET part=$PART"
+log "build_sha=$BUILD_SHA version=$VERSION repo=$ROOT"
+
+# --- never let a play script pop a browser on the owner's screen --------------------------
+# scripts/play*.sh call `open`/`xdg-open` once the dashboard serves. Shim `open` to a no-op so
+# the BACKEND runs but no window is forced onto the owner. (The .app's OWN window in part A is
+# intentional — that is the surface under test.)
+NOOPEN="$RUNDIR/.noopen"; mkdir -p "$NOOPEN"
+printf '#!/bin/sh\nexit 0\n' > "$NOOPEN/open"; chmod +x "$NOOPEN/open"
+PATH_NOOPEN="$NOOPEN:$PATH"
+
+# --- screenshot via screencapture. The harness's OWN process tree usually lacks Screen
+# Recording TCC, so a direct screencapture returns "could not create image from display". The
+# parent (Claude Code / its MCP host) DOES have it. We try a direct capture first; if it fails,
+# we DROP A REQUEST FILE the orchestrator fulfills via its screen-recording-granted path. Either
+# way the gate's PASS/FAIL never depends on the image — the image is evidence, the run-dir +
+# session-surface are ground truth. -----------------------------------------------------------
+screenshot() {  # $1 = output png
+  local out="$1"
+  /usr/sbin/screencapture -x "$out" >/dev/null 2>&1 && [ -s "$out" ] && return 0
+  # fallback: leave a marker the orchestrator can pick up (best-effort; non-fatal)
+  printf '%s\n' "$out" >> "$NATIVE_DIR/screenshot-requests.txt"
+  return 1
+}
+
+# Spent-so-far across every claude -p this run wrote (part A mint + part B DM/companions live
+# under play-state/<run>*/dm.combined.jsonl; the part B PLAYER agent reports its own cost). Sums
+# total_cost_usd from every dm.combined.jsonl under play-state for THIS run prefix. Read-only.
+dm_spend() {
+  local total=0 f
+  for f in "$ROOT"/play-state/"$RUN"*/dm.combined.jsonl "$ROOT"/play-state/"$RUN"*/dm.jsonl; do
+    [ -f "$f" ] || continue
+    local c; c="$(jq -rs '[.[]|select(.type=="result")|.total_cost_usd//0]|add // 0' "$f" 2>/dev/null)"
+    total="$(awk -v a="$total" -v b="${c:-0}" 'BEGIN{printf "%.4f", a+b}')"
+  done
+  printf '%s' "$total"
+}
+
+###############################################################################################
+# PART A — NATIVE-TRANSITION GATE (re-verifies #356)
+###############################################################################################
+PART_A_RESULT="skipped"; PART_A_MINTED_PORT=""; PART_A_RUNDIR=""
+run_part_a() {
+  log "=== PART A: native-transition gate (re-verifies #356) ==="
+  local tlog="$NATIVE_DIR/transition.log"; : > "$tlog"
+  a_log() { printf '%s\n' "$*" | tee -a "$tlog"; }
+
+  # Raise WorldOS to front (AppKit activate — NOT System Events, no TCC dialog), verify it is
+  # z-order 0, then CGEvent-click the calibrated RESUME → PLAY CTA center. Idempotent — safe to
+  # call repeatedly until the bridge mints a session. Writes its steps to $tlog.
+  click_play_cta() {
+    python3 - "$tlog" <<'PY' || echo "[A] CGEvent click attempt FAILED" >> "$tlog"
+import sys, time, Quartz
+from ApplicationServices import AXIsProcessTrusted
+from AppKit import (NSRunningApplication, NSWorkspace,
+                    NSApplicationActivateIgnoringOtherApps, NSApplicationActivateAllWindows)
+tlog = open(sys.argv[1], "a")
+def say(m): print(m); tlog.write(m+"\n"); tlog.flush()
+if not AXIsProcessTrusted():
+    say("[A] WARN: AXIsProcessTrusted() False — synthetic clicks may be dropped.")
+def worldos_app():
+    apps = NSRunningApplication.runningApplicationsWithBundleIdentifier_("dev.clawdnd.app")
+    if apps: return apps[0]
+    for a in NSWorkspace.sharedWorkspace().runningApplications():
+        if "WorldOS" in (a.localizedName() or ""): return a
+    return None
+def front_owner_and_win():
+    wins = Quartz.CGWindowListCopyWindowInfo(
+        Quartz.kCGWindowListOptionOnScreenOnly | Quartz.kCGWindowListExcludeDesktopElements,
+        Quartz.kCGNullWindowID)
+    layer0 = [w for w in wins if w.get("kCGWindowLayer") == 0]
+    front = layer0[0].get("kCGWindowOwnerName") if layer0 else None
+    win = next((w for w in layer0 if "WorldOS" in (w.get("kCGWindowOwnerName") or "")), None)
+    return front, win
+app = worldos_app()
+if app is None:
+    say("[A] ERROR: WorldOS running application not found"); sys.exit(3)
+# Activate, then click IMMEDIATELY (minimize the focus-race window). Verify frontmost first.
+win = None
+for attempt in range(8):
+    app.activateWithOptions_(NSApplicationActivateIgnoringOtherApps | NSApplicationActivateAllWindows)
+    time.sleep(0.6)
+    front, win = front_owner_and_win()
+    if win is not None and front and "WorldOS" in front:
+        break
+    say(f"[A] WorldOS not frontmost (front={front!r}) — re-activating…")
+if win is None:
+    say("[A] ERROR: no WorldOS layer-0 window after activation"); sys.exit(3)
+front, win = front_owner_and_win()
+if not (front and "WorldOS" in front):
+    say(f"[A] WARN: WorldOS slipped from front (front={front!r}) just before click — clicking anyway.")
+b = win["kCGWindowBounds"]; X, Y, W, H = b["X"], b["Y"], b["Width"], b["Height"]
+cx, cy = X + W - 219, Y + 204          # calibrated CTA center (right-aligned button)
+say(f"[A] window X={X} Y={Y} W={W} H={H}; front={front!r}; click=({cx:.0f},{cy:.0f})")
+def post(ev): Quartz.CGEventPost(Quartz.kCGHIDEventTap, ev)
+post(Quartz.CGEventCreateMouseEvent(None, Quartz.kCGEventMouseMoved, (cx, cy), Quartz.kCGMouseButtonLeft)); time.sleep(0.10)
+post(Quartz.CGEventCreateMouseEvent(None, Quartz.kCGEventLeftMouseDown, (cx, cy), Quartz.kCGMouseButtonLeft)); time.sleep(0.08)
+post(Quartz.CGEventCreateMouseEvent(None, Quartz.kCGEventLeftMouseUp,   (cx, cy), Quartz.kCGMouseButtonLeft))
+say("[A] click posted.")
+PY
+  }
+
+  if [ "${WOS_APP_SKIP_BUILD:-0}" != "1" ]; then
+    a_log "[A] pkill WorldOSApp + THIS checkout's stale viewers, rm -rf $APP_BUNDLE, fresh build…"
+    pkill -x WorldOSApp >/dev/null 2>&1 || true
+    # ONLY reap viewers spawned from THIS repo root — NEVER a blanket `pkill -f viewer/server.py`
+    # (that would kill unrelated services on this host, e.g. the evaOS desktop-bridge squatting
+    # 8765 on the Tailscale iface, or another checkout's viewer). Match the absolute repo path.
+    pkill -f "$ROOT/viewer/server.py" >/dev/null 2>&1 || true
+    sleep 1
+    rm -rf "$APP_BUNDLE"
+    # Fresh build off the CURRENT checkout's HEAD (must include #356). build_and_run.sh sets
+    # WORLDOS_REPO_ROOT=$ROOT so the .app runs THIS checkout's viewer (the fixed JSX is served
+    # live as text/babel — no separate ui:build step). open is shimmed: the .app still launches
+    # (build_and_run.sh uses /usr/bin/open -n directly, not PATH `open`), but no extra windows.
+    if ! PATH="$PATH_NOOPEN" "$ROOT/script/build_and_run.sh" run >> "$tlog" 2>&1; then
+      a_log "[A] BUILD/LAUNCH FAILED — see $tlog"; PART_A_RESULT="build_failed"; return 1
+    fi
+  else
+    a_log "[A] WOS_APP_SKIP_BUILD=1 — reusing the running .app (no rebuild)."
+  fi
+
+  # DISCOVER the launcher viewer's actual port. We do NOT assume the preferred port (8765): the
+  # app's PortFinder walks UP from preferredPort, and on this host 8765 is often already taken by
+  # an unrelated service (evaOS bridge on the Tailscale iface), so the launcher commonly lands on
+  # 8766+. The launcher viewer is THIS repo's viewer/server.py process; its port is the last
+  # numeric token of its argv. Wait for it to appear AND answer /openworlds/ 200.
+  local launcher_port="" ready=0
+  for _ in $(seq 1 80); do
+    launcher_port="$(launcher_port_of "$ROOT")"
+    if [ -n "$launcher_port" ] && \
+       [ "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$launcher_port/openworlds/" 2>/dev/null)" = "200" ]; then
+      ready=1; break
+    fi
+    sleep 0.5
+  done
+  [ "$ready" = "1" ] || { a_log "[A] launcher viewer never came up (discovered port='${launcher_port:-none}')"; PART_A_RESULT="no_launcher"; return 1; }
+  pgrep -x WorldOSApp >/dev/null 2>&1 || { a_log "[A] WorldOSApp is not running"; PART_A_RESULT="app_not_running"; return 1; }
+  a_log "[A] launcher viewer ready on $launcher_port; can_act(before)=$(curl -s "http://127.0.0.1:$launcher_port/session-surface" | jq -c '{can_act,is_live_view,live}' 2>/dev/null)"
+
+  # BEFORE screenshot + baseline play-state set (so a NEW run dir is detectable post-click).
+  screenshot "$NATIVE_DIR/before.png" && a_log "[A] before.png captured" || a_log "[A] before.png deferred to orchestrator"
+  local before_dirs; before_dirs="$(ls -1 "$ROOT/play-state" 2>/dev/null | sort || true)"
+
+  # CGEvent-click the launcher's primary play CTA.
+  #  - RAISE WorldOS to front first. A synthetic CGEvent click is delivered to whatever window is
+  #    FRONTMOST at that screen point; on a busy desktop other app windows (Claude/Codex/etc.)
+  #    overlap the button's coordinate and SWALLOW the click (observed: a click that never
+  #    reached the .app). We activate via NSRunningApplication.activate (AppKit) — an
+  #    app-activation API, NOT System Events UI scripting, so it does NOT pop a TCC dialog — and
+  #    verify WorldOS is z-order index 0 before clicking, retrying activation a few times.
+  #  - We compute the click point from the .app's window geometry (CGWindowList — no AX dialog):
+  #    the "RESUME → PLAY" button is right-aligned in the ContinueBanner just below the top nav
+  #    (button center ≈ window_right-219pt, window_top+204pt; corroborated by the baseline
+  #    agent's (1692,340) and re-observed at (1701,344) here). AXIsProcessTrusted is True so the
+  #    synthetic click lands.
+  a_log "[A] raising WorldOS to front + CGEvent-clicking the RESUME → PLAY CTA (with retries)…"
+  click_play_cta   # first attempt (the poll re-clicks if the focus-race ate it)
+
+  # ASSERT the mint. Poll up to ~3.5 min for BOTH: (i) a NEW play-state run dir AND (ii) a NEW
+  # viewer (a DIFFERENT port than the launcher) whose /session-surface reports can_act:true. The
+  # DM cold-open mints the campaign; can_act flips once the move-sink is set AND the viewer binds
+  # the live campaign (auto-follow), which happens early in the cold-open turn. RE-CLICK every
+  # ~24s while nothing has minted: on a busy multi-app desktop another window can steal focus
+  # between the activate and the CGEvent, swallowing the click — a re-click recovers it.
+  a_log "[A] polling for a minted live session (new run dir + can_act:true on a new port)…"
+  local minted_port="" minted_run="" can_act="false"
+  for i in $(seq 1 70); do
+    # (i) a new play-state dir
+    local now_dirs new_dir
+    now_dirs="$(ls -1 "$ROOT/play-state" 2>/dev/null | sort || true)"
+    new_dir="$(comm -13 <(printf '%s\n' "$before_dirs") <(printf '%s\n' "$now_dirs") 2>/dev/null | head -1)"
+    # Re-click if nothing has started after ~24s and ~48s (idempotent: clicking RESUME→PLAY again
+    # before the mint just re-issues startPlay; once a run dir exists we stop clicking).
+    if [ -z "$new_dir" ] && { [ "$i" = "6" ] || [ "$i" = "12" ]; }; then
+      a_log "[A] no mint yet after $((i*4))s — re-clicking the CTA (focus-race recovery)…"
+      click_play_cta
+    fi
+    # (ii) ANY of THIS repo's viewers (other than the launcher) now reporting can_act:true. We
+    # enumerate the live viewer ports from the running processes (robust to the actual port the
+    # PortFinder chose) instead of guessing a fixed range.
+    local p surf ca
+    for p in $(repo_viewer_ports "$ROOT"); do
+      [ "$p" = "$launcher_port" ] && continue
+      surf="$(curl -s --max-time 2 "http://127.0.0.1:$p/session-surface" 2>/dev/null)" || continue
+      [ -z "$surf" ] && continue
+      ca="$(printf '%s' "$surf" | jq -r '.can_act // false' 2>/dev/null)"
+      if [ "$ca" = "true" ]; then minted_port="$p"; can_act="true"; fi
+    done
+    [ -n "$new_dir" ] && minted_run="$new_dir"
+    if [ "$can_act" = "true" ] && [ -n "$minted_run" ]; then
+      a_log "[A] MINTED: run=$minted_run port=$minted_port can_act=true (after ${i} polls)"
+      break
+    fi
+    sleep 3
+  done
+
+  # AFTER screenshot (shows the live table if the transition worked).
+  sleep 1; screenshot "$NATIVE_DIR/after.png" && a_log "[A] after.png captured" || a_log "[A] after.png deferred to orchestrator"
+
+  # Capture the minted surface BEFORE teardown (so transition.json records the real can_act state,
+  # not an empty post-kill fetch).
+  PART_A_MINTED_PORT="$minted_port"; PART_A_RUNDIR="$minted_run"
+  local surf_final="{}"
+  [ -n "$minted_port" ] && surf_final="$(curl -s "http://127.0.0.1:$minted_port/session-surface" 2>/dev/null | jq -c '{can_act,is_live_view,live,campaignId,enabledActions}' 2>/dev/null || echo '{}')"
+
+  # Tear down the minted session's BACKEND so its DM loop can't keep spending toward the .app's
+  # own $15 session budget (we only needed the cold-open to prove can_act:true). The .app process
+  # stays up; we kill the play.sh tree it shelled. We match BOTH the state-dir path AND the run-id
+  # POSITIONAL arg (`play[_party].sh <world> <run> <port>`) — the supervisor + DM-loop bash procs
+  # carry the run id positionally, NOT the play-state path, so a path-only pkill leaves the
+  # viewer-respawning supervisor alive. We do NOT touch the launcher viewer.
+  if [ -n "$minted_run" ]; then
+    a_log "[A] tearing down minted backend (run=$minted_run) — cold-open was enough."
+    pkill -f "play-state/$minted_run/" 2>/dev/null || true
+    pkill -f "play_party.sh $WORLD $minted_run" 2>/dev/null || true
+    pkill -f "play.sh $WORLD $minted_run" 2>/dev/null || true
+    pkill -f "$WORLD $minted_run " 2>/dev/null || true
+    [ -n "$minted_port" ] && pkill -f "server.py .* $minted_port\$" 2>/dev/null || true
+    sleep 1
+  fi
+  if [ "$can_act" = "true" ] && [ -n "$minted_run" ]; then
+    PART_A_RESULT="PASS"
+    a_log "[A] RESULT: PASS — #356 banner minted a live DM (can_act:true). surface=$surf_final"
+  else
+    PART_A_RESULT="FAIL"
+    a_log "[A] RESULT: FAIL — stuck read-only (no minted can_act:true session). minted_run='${minted_run:-none}' port='${minted_port:-none}' surface=$surf_final"
+  fi
+
+  python3 - "$NATIVE_DIR/transition.json" "$PART_A_RESULT" "$BUILD_SHA" "$VERSION" \
+            "${minted_run:-}" "${minted_port:-}" "$can_act" "$surf_final" <<'PY'
+import json, sys, datetime
+out, result, sha, ver, run, port, can_act, surf = sys.argv[1:9]
+try: surf_obj = json.loads(surf)
+except Exception: surf_obj = {"raw": surf}
+json.dump({
+    "gate": "native_transition_356",
+    "result": result, "build_sha": sha, "version": ver,
+    "minted_run_dir": run or None, "minted_port": int(port) if port else None,
+    "can_act_after_click": can_act == "true",
+    "session_surface_after": surf_obj,
+    "before_png": "native/before.png", "after_png": "native/after.png",
+    "at": datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+}, open(out, "w"), indent=2)
+PY
+  a_log "[A] wrote $NATIVE_DIR/transition.json"
+  [ "$PART_A_RESULT" = "PASS" ]
+}
+
+###############################################################################################
+# PART B — PERSONA LOOP (the .app-faithful backend + the real palette persona)
+###############################################################################################
+PART_B_RESULT="skipped"; PART_B_PLAYER_COST="0"
+run_part_b() {
+  log "=== PART B: persona loop on the .app-faithful backend ==="
+  [ -f "$PERSONA_FILE" ] || { log "[B] no persona brief at $PERSONA_FILE — skipping"; PART_B_RESULT="no_persona"; return 1; }
+  [ -d "$PW_DIR/node_modules/playwright" ] || {
+    log "[B] Playwright not installed at $PW_DIR. Run: (cd qa/playwright && npm install && npx playwright install chromium)"
+    PART_B_RESULT="no_playwright"; return 1; }
+
+  # Budget guard: if part A + its DM already spent the run budget, skip B (we never exceed budget).
+  local spent; spent="$(dm_spend)"
+  if awk -v s="${spent:-0}" -v b="$BUDGET" 'BEGIN{exit !(s+0 >= b+0)}'; then
+    log "[B] run budget \$$BUDGET already reached (spent ~\$$spent in part A) — skipping persona loop."
+    PART_B_RESULT="budget_exhausted"; return 1
+  fi
+  # The PLAYER agent gets whatever budget remains (it drives /move; the DM cost is the bulk).
+  local player_budget; player_budget="$(awk -v s="${spent:-0}" -v b="$BUDGET" 'BEGIN{r=b-s; if(r<0.5)r=0.5; printf "%.2f", r}')"
+
+  # Faithful backend: a SEPARATE play-state run (so it never collides with part A's mint). This
+  # is the EXACT command the native bridge shells (ProviderAdapters.swift:62). Solo → execs
+  # scripts/play.sh, which boots a LIVE viewer (CLAWDND_PLAYER_MOVES set) + a DM cold-open + a
+  # DM resolver loop tailing the move sink. We point the palette persona at THAT viewer.
+  local b_run="${RUN}-b"
+  local b_port; b_port="$(pick_free_port $((PREFERRED_PORT+20)))" || { log "[B] no free port"; PART_B_RESULT="no_port"; return 1; }
+  local b_url="http://127.0.0.1:$b_port/openworlds/"
+  log "[B] launching faithful backend: scripts/play_party.sh $WORLD $b_run $b_port  (solo → play.sh; DM=$DM_MODEL)"
+
+  # Cap the backend so it can never overshoot the run budget. CLAWDND_PLAY_SESSION_BUDGET is the
+  # aggregate DM ceiling; CLAWDND_PLAY_MAX_TURNS bounds turns; per-turn cap keeps each beat small.
+  local sess_cap; sess_cap="$(awk -v r="$player_budget" 'BEGIN{c=r-0.20; if(c<0.50)c=0.50; printf "%.2f", c}')"
+  (
+    export PATH="$PATH_NOOPEN"
+    export WORLDOS_DM_MODEL="$DM_MODEL" CLAWDND_DM_MODEL="$DM_MODEL"
+    export CLAWDND_PLAY_PORT="$b_port"
+    export CLAWDND_PLAY_BUDGET="${CLAWDND_PLAY_BUDGET:-1.50}"
+    export CLAWDND_PLAY_SESSION_BUDGET="$sess_cap"
+    export CLAWDND_PLAY_MAX_TURNS="${CLAWDND_PLAY_MAX_TURNS:-$((BEATS + 4))}"
+    export CLAWDND_PLAY_MAX_IDLE="${CLAWDND_PLAY_MAX_IDLE:-600}"
+    "$ROOT/scripts/play_party.sh" "$WORLD" "$b_run" "$b_port" >> "$RUNDIR/backend.log" 2>&1
+  ) &
+  B_BACKEND=$!
+  # Clean teardown: kill the backend subshell, THEN the play.sh supervisor + DM-loop bash procs
+  # (matched by the run-id positional — they don't carry the play-state path, and the supervisor
+  # respawns the viewer, so a path-only kill leaves it alive), then the viewer + state dir, belt
+  # and suspenders. The launcher and other runs are untouched (unique run id `${RUN}-b`).
+  b_cleanup() {
+    kill "$B_BACKEND" 2>/dev/null || true
+    pkill -f "play_party.sh $WORLD $b_run" 2>/dev/null || true
+    pkill -f "play.sh $WORLD $b_run" 2>/dev/null || true
+    pkill -f "$WORLD $b_run " 2>/dev/null || true
+    pkill -f "play-state/$b_run/" 2>/dev/null || true
+    pkill -f "server.py .* $b_port\$" 2>/dev/null || true
+  }
+  trap 'b_cleanup' RETURN
+
+  # Wait for the backend to be GENUINELY READY for a player — not merely can_act:true. The
+  # move-sink (→ can_act:true) and the campaign exist EARLY in the DM cold-open, but the PC isn't
+  # SEATED and the opening narration isn't written until the cold-open turn FINISHES. A smoke run
+  # proved that launching the persona on can_act alone drops it into a "no active character" /
+  # empty-scene limbo (a race, not a real bug). A real player waits for the opening scene, so we
+  # gate on ALL THREE: (1) viewer 200 + can_act:true, (2) a seated PLAYER character in the
+  # snapshot, (3) opening narration written to chat.jsonl (the DM's cold-open reply). Falls back
+  # to "can_act + seated PC" if chat stays empty past a grace window (so an empty-narration bug
+  # like #357 still lets the loop proceed and the persona can REPORT the empty scene as a bug).
+  local b_state="$ROOT/play-state/$b_run"
+  log "[B] waiting for the backend to be player-ready (can_act + seated PC + opening narration)…"
+  local ready=0 ca pc chat_lines saw_canact=0 saw_pc=0
+  for i in $(seq 1 120); do   # up to ~6 min for the full cold-open
+    if [ "$(curl -s -o /dev/null -w '%{http_code}' "$b_url" 2>/dev/null)" = "200" ]; then
+      ca="$(curl -s --max-time 2 "http://127.0.0.1:$b_port/session-surface" 2>/dev/null | jq -r '.can_act // false' 2>/dev/null)"
+      [ "$ca" = "true" ] && saw_canact=1
+      # seated PLAYER character?
+      pc="$(_seated_player_count "$b_state")"; pc="${pc:-0}"
+      [ "$pc" -ge 1 ] && saw_pc=1
+      # opening narration?
+      chat_lines=0; [ -f "$b_state/chat.jsonl" ] && chat_lines="$(grep -c . "$b_state/chat.jsonl" 2>/dev/null || echo 0)"
+      if [ "$saw_canact" = "1" ] && [ "$saw_pc" = "1" ] && [ "${chat_lines:-0}" -ge 1 ]; then
+        ready=1; log "[B] player-ready: can_act:true, seated PC ($pc), chat lines=$chat_lines (after $((i*3))s)."; break
+      fi
+      # Grace fallback: can_act + seated PC but STILL no narration after ~2.5min → proceed anyway
+      # (the persona will report the empty opening scene — a real finding, e.g. #357).
+      if [ "$saw_canact" = "1" ] && [ "$saw_pc" = "1" ] && [ "$i" -ge 50 ]; then
+        ready=1; log "[B] proceeding without opening narration after $((i*3))s (chat empty — persona will judge it; possible #357)."; break
+      fi
+    fi
+    kill -0 "$B_BACKEND" 2>/dev/null || { log "[B] backend exited early — see $RUNDIR/backend.log"; break; }
+    sleep 3
+  done
+  if [ "$ready" != "1" ]; then
+    log "[B] backend never became player-ready (can_act=$saw_canact seatedPC=$saw_pc) — see $RUNDIR/backend.log"
+    PART_B_RESULT="backend_not_ready"; return 1
+  fi
+  log "[B] backend player-ready on $b_port. Pointing the palette persona at it."
+
+  # PLAYER MCP config: ONLY the Playwright palette (strict). The persona sees ONLY the screen.
+  local player_cfg="$RUNDIR/player.mcp.json"
+  python3 - "$PW_DIR" "$b_url" "$RUNDIR" "$(worldos_env UIPT_CHANNEL "")" "$PERSONA" "$player_cfg" <<'PY'
+import json, sys
+pw_dir, url, rundir, channel, persona, out = sys.argv[1:7]
+json.dump({"mcpServers": {"clawdnd-uiplayer": {
+    "command": "node", "args": [f"{pw_dir}/palette_server.js"],
+    "env": {"CLAWDND_UIPT_URL": url, "CLAWDND_UIPT_RUNDIR": rundir,
+            "CLAWDND_UIPT_CHANNEL": channel, "CLAWDND_UIPT_PERSONA": persona},
+}}}, open(out, "w"))
+PY
+
+  local persona_brief; persona_brief="$(cat "$PERSONA_FILE")"
+  local psid; psid="$(python3 -c 'import uuid;print(uuid.uuid4())')"
+  local player_out="$PLAYERDIR/player.jsonl"
+  log "[B] player agent starting (persona=$PERSONA, ~$BEATS actions, budget \$$player_budget)…"
+  claude -p "$persona_brief
+
+You have a budget of about $BEATS actions for this whole session. Spend them trying to start and play the story, reporting friction as you go. When you have either (a) genuinely gotten stuck after reporting it, or (b) played a few real turns and seen enough to judge the experience, you may stop — give a final 1-2 sentence verdict and, if you got stuck, call give_up. Start now." \
+    --session-id "$psid" --mcp-config "$player_cfg" --strict-mcp-config \
+    --model "$PLAYER_MODEL" --permission-mode bypassPermissions --max-budget-usd "$player_budget" \
+    --output-format stream-json --verbose > "$player_out" 2>> "$PLAYERDIR/player.err"
+  local player_rc=$?
+  log "[B] player agent finished (rc=$player_rc)."
+
+  local player_verdict player_cost
+  player_verdict="$(jq -rs 'map(select(.type=="result"))[-1].result // ""' "$player_out" 2>/dev/null)"
+  player_cost="$(jq -rs '[.[]|select(.type=="result")|.total_cost_usd//0]|add // 0' "$player_out" 2>/dev/null)"
+  PART_B_PLAYER_COST="${player_cost:-0}"
+
+  b_cleanup; trap - RETURN
+
+  # meta.json (the scorer reads it) + score + summary via the EXISTING scorer (unchanged).
+  python3 - "$RUNDIR/meta.json" "$RUN" "$WORLD" "$PERSONA" "$b_port" "$BEATS" "$BUDGET" "$player_cost" "$player_rc" "$BUILD_SHA" "$VERSION" <<'PY'
+import json, sys, datetime
+out, run, world, persona, port, beats, budget, cost, rc, sha, ver = sys.argv[1:12]
+json.dump({
+    "run": run, "world": world, "persona": persona, "port": int(port),
+    "beats_cap": int(beats), "budget_usd": float(budget),
+    "player_cost_usd": round(float(cost or 0), 4), "player_rc": int(rc),
+    "build_sha": sha, "version": ver, "surface": "built-app-faithful-backend (play_party.sh)",
+    "finished_at": datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+}, open(out, "w"), indent=2)
+PY
+  log "[B] scoring + summarizing…"
+  python3 "$ROOT/qa/ui_playtest_score.py" "$RUNDIR" "$player_verdict" 2>> "$RUNDIR/score.err"
+  PART_B_RESULT="ran"
+  [ -f "$RUNDIR/summary.md" ] && { echo "----- part B summary.md -----"; cat "$RUNDIR/summary.md"; }
+}
+
+# A free port at/above $1 (probes 30 candidates). Echoes the port or fails.
+pick_free_port() {
+  local start="${1:-8800}" p
+  for p in $(seq "$start" $((start+30))); do
+    if ! (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then echo "$p"; return 0; fi
+    exec 3>&- 2>/dev/null || true
+  done
+  return 1
+}
+
+# Every port served by a viewer/server.py whose WORKING DIRECTORY is repo root $1 (one per line,
+# ascending). We match on CWD, not the argv path, because the .app launches its TWO viewers
+# differently: the read-only LAUNCHER via `startViewer` uses an ABSOLUTE path (<root>/viewer/
+# server.py), while the MINTED provider viewer is spawned by scripts/play*.sh with a RELATIVE
+# path (`python3 viewer/server.py`) and CWD=repo root. Matching CWD catches BOTH and excludes
+# viewers from other checkouts / unrelated services (e.g. the evaOS bridge on 8765). The port is
+# the last numeric token of the argv. We resolve PIDs via pgrep then read each full command via
+# `ps -o command=` (pgrep -af can truncate). Robust to whatever port PortFinder actually chose.
+repo_viewer_ports() {
+  local root="$1" rootp pid cwd cmd
+  rootp="$(cd "$root" 2>/dev/null && pwd -P)"; rootp="${rootp:-$root}"
+  for pid in $(pgrep -f 'viewer/server.py' 2>/dev/null); do
+    cmd="$(ps -o command= -p "$pid" 2>/dev/null)"
+    cwd="$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)"
+    # Match EITHER an absolute argv path under repo root (the LAUNCHER, whose CWD is the .app's
+    # temp dir, not the repo) OR CWD == repo root (the MINTED provider viewer, launched by
+    # play*.sh with a RELATIVE `viewer/server.py`). Either way it is THIS checkout's viewer; this
+    # excludes other checkouts (e.g. /Users/lume/ClawDnD-val) and unrelated services.
+    if printf '%s' "$cmd" | grep -qF "$rootp/viewer/server.py" \
+       || printf '%s' "$cmd" | grep -qF "$root/viewer/server.py" \
+       || [ "$cwd" = "$rootp" ] || [ "$cwd" = "$root" ]; then
+      printf '%s\n' "$cmd" | grep -oE '[0-9]{4,5}' | tail -1
+    fi
+  done | sort -un
+}
+
+# The launcher viewer's port = the LOWEST repo-viewer port (the .app starts the read-only
+# launcher first; any minted provider viewer lands on a HIGHER free port). Echoes it or nothing.
+launcher_port_of() {
+  repo_viewer_ports "$1" | head -1
+}
+
+# Count seated PLAYER characters in a play-state run's campaign snapshot (the DM cold-open seats
+# the human PC via load_canon_character/create_character; until it does, the table shows "no
+# active character"). $1 = play-state run dir. Echoes an integer (0 if no snapshot yet). Read-only.
+_seated_player_count() {
+  local snap; snap="$(clawdnd_snapshot_path "$1" 2>/dev/null)"
+  [ -n "$snap" ] || { echo 0; return 0; }
+  python3 - "$snap" <<'PY' 2>/dev/null || echo 0
+import json, sys
+try: s = json.load(open(sys.argv[1]))
+except Exception: print(0); sys.exit(0)
+chars = s.get("characters", {}) or {}
+print(sum(1 for c in chars.values() if isinstance(c, dict) and c.get("kind") == "player"))
+PY
+}
+
+###############################################################################################
+# DRIVE
+###############################################################################################
+case "$PART" in
+  A)  run_part_a || true ;;
+  B)  run_part_b || true ;;
+  *)  run_part_a || true; run_part_b || true ;;
+esac
+
+# Top-level run.json — the structured truth (P0): tagged {build_sha, version}, both parts, $spend.
+FINAL_DM_SPEND="$(dm_spend)"
+TOTAL_SPEND="$(awk -v a="${FINAL_DM_SPEND:-0}" -v b="${PART_B_PLAYER_COST:-0}" 'BEGIN{printf "%.4f", a+b}')"
+python3 - "$RUNDIR/run.json" "$RUN" "$WORLD" "$PERSONA" "$BEATS" "$BUDGET" "$BUILD_SHA" "$VERSION" \
+          "$PART" "$PART_A_RESULT" "${PART_A_RUNDIR:-}" "${PART_A_MINTED_PORT:-}" \
+          "$PART_B_RESULT" "$FINAL_DM_SPEND" "$PART_B_PLAYER_COST" "$TOTAL_SPEND" <<'PY'
+import json, sys, datetime
+(out, run, world, persona, beats, budget, sha, ver, part, a_res, a_run, a_port,
+ b_res, dm_spend, player_cost, total) = sys.argv[1:17]
+json.dump({
+    "run": run, "world": world, "persona": persona, "beats_cap": int(beats),
+    "budget_usd": float(budget), "build_sha": sha, "version": ver, "part": part,
+    "part_a": {"gate": "native_transition_356", "result": a_res,
+               "minted_run_dir": a_run or None, "minted_port": int(a_port) if a_port else None},
+    "part_b": {"persona_loop": b_res},
+    "spend_usd": {"dm_and_companions": round(float(dm_spend or 0), 4),
+                  "player_agent": round(float(player_cost or 0), 4),
+                  "total": round(float(total or 0), 4)},
+    "surface": "BUILT dist/WorldOS.app (part A) + byte-identical play_party.sh backend (part B)",
+    "at": datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+}, open(out, "w"), indent=2)
+PY
+
+log "=== DONE. dir=$RUNDIR ==="
+log "part A (#356 gate): $PART_A_RESULT   part B (persona loop): $PART_B_RESULT"
+log "spend: DM ~\$$FINAL_DM_SPEND + player ~\$$PART_B_PLAYER_COST = ~\$$TOTAL_SPEND (budget \$$BUDGET)"
+[ -f "$RUNDIR/run.json" ] && { echo "----- run.json -----"; cat "$RUNDIR/run.json"; }
+[ "$PART_A_RESULT" = "PASS" ] || [ "$PART_A_RESULT" = "skipped" ]


### PR DESCRIPTION
## What

The **§8.2 infra (P0)** from `WorldOS-OPERATING-GOAL.md`: a permanent, `.app`-faithful playtest harness, `qa/ui_playtest_app.sh`, that tests the **BUILT `dist/WorldOS.app` surface** (and the byte-identical backend the app shells) — **never** the dev viewer or a harness-wired port. This closes the failure that birthed the operating goal (`§0`): the old `qa/ui_playtest.sh` booted its *own* viewer with `CLAWDND_PLAYER_MOVES` set → `can_act:true` → a playable surface the harness wired for itself, while the shipped `.app` launches the viewer **without** that env → read-only. Every "all green" run there tested a surface the user can never reach.

Usage: `qa/ui_playtest_app.sh <run> <world> <persona> <beats> <budget>`

### (A) Native-transition gate — re-verifies release-blocker #356
`pkill WorldOSApp` + this checkout's stale viewers → `rm -rf dist/WorldOS.app` → fresh `script/build_and_run.sh` (off HEAD, which must include #356) → launch the `.app` → **discover** the launcher viewer's actual port (the app's `PortFinder` walks up from `preferredPort` 8765, which is frequently already taken on a dev host — we never assume 8765) → **raise the app frontmost via AppKit `activateWithOptions`** (an app-activation API, *not* System-Events UI scripting, so no TCC dialog) → **CGEvent-click** the launcher's `RESUME → PLAY` CTA (computed from the window geometry; re-clicks on a focus-race miss) → **assert** the bridge minted a provider session: a new `play-state/<run>` dir appears **and** a new viewer (a different port) whose `/session-surface` reports `can_act:true`. PASS/FAIL is the session-surface **ground truth**, not a screenshot.

### (B) Persona loop — the playable surface the `.app` reaches once #356 mints
Launch `scripts/play_party.sh <world> <run> <port>` (the **exact** command `startProviderSession` shells — `ProviderAdapters.swift:62`; solo → `play.sh` with a live viewer + DM cold-open + resolver loop), wait until **player-ready** (`can_act` + a seated PC + opening narration, with a grace fallback so an empty-narration bug is still surfaced rather than hanging the run), then drive the **real Playwright palette** (`palette_server.js`, `CLAWDND_UIPT_URL`) as `<persona>` for `<beats>` moves. Reuses `ui_playtest_score.py` + the existing persona briefs.

Artifacts land under `qa/ui_playtest_runs/<run>/` tagged `{build_sha, version}`: `native/transition.json`, `bugs.ndjson`, `score.json`, `summary.md`, `run.json`. `open()` is shimmed so no browser pops on the owner's screen; the palette runs headless.

## First-run results (this PR's verification)

**#356 RE-VERIFY = GREEN.** On a freshly-built `.app` off `3f946e7` (which includes #356), clicking the `RESUME → PLAY` banner minted run `play-20260530104419`; its provider viewer reported **`can_act:true`, `is_live_view:true`, `live:true`, `enabledActions=[continue,say,do,check,save]`**, and the WebView transitioned from the read-only launcher to a **playable table** (free-text + Declare enabled). The harness's part-A gate reproduces this autonomously (`transition.json: result=PASS`). Caveat captured in the header: the CGEvent click is reliable on a **pristine, frontmost** launcher (a fresh build+launch, exactly what the gate does) but is flaky to *re-issue* against an already-clicked app on a busy multi-app desktop.

**Newbie smoke (6 beats):** reached the play screen, took 2 in-story turns, 0 dead clicks, 0 console errors. **`#357` (empty/missing opening narration) STILL REPRODUCES on `3f946e7`**: the DM cold-open seats the PC and builds the world, but writes **no player-facing narration** to `/chat` — the table sits locked on "Setting the opening scene…" and the newbie gave up waiting (1 major bug). (A `fix/357-empty-narration` branch already exists; this confirms it is not yet fixed on main.)

## Notes
- Refs `WorldOS-OPERATING-GOAL.md` §8.2 / P0 / first-consequence #2.
- Screenshots are best-effort: the harness process tree typically lacks Screen-Recording TCC, so `screencapture` falls back to dropping a request marker — the gate never depends on the image.
- Do **not** merge yet (per task) — opening for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated UI playtesting harness for comprehensive application verification and testing. Includes app launch surface validation, backend compatibility checks, automated persona-driven backend interactions, player session state verification, dynamic port discovery, resource consumption budgeting, screenshot capture for analysis, test scoring and evaluation, and detailed run metadata tracking with combined results reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->