### PR TITLE
fix(openworlds): cold-open waiting state is clearly alive, not frozen (Addresses #385)

### DIFF
--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -318,6 +318,10 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
   const recordPlayerEcho = session.recordPlayerEcho;
   const pendingActive = Boolean(pending && !pending.stuck);
   const pendingStuck = Boolean(pending && pending.stuck);
+  // #385: the COLD-OPEN (first beat) gets action-bar copy that reads as "the DM is taking its turn"
+  // (alive) rather than the generic "Narrating…" — so the locked bar matches the obviously-alive
+  // chronicle indicator and never looks like the app is wedged.
+  const pendingFirstBeat = Boolean(pendingActive && pending.firstBeat);
   // #344: remember the move that is currently in flight so the "Try again" recovery (shown when a
   // turn goes `stuck`) can actually RE-POST it. The first submit clears the input box (setInput("")),
   // so by the time the bar re-opens stuck the box is empty — without the original move stored, the
@@ -551,10 +555,10 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
                 onKeyDown={(e) => e.key === "Enter" && onDeclareClick()}
                 disabled={pendingActive}
                 title={DECLARE_HINT}
-                placeholder={pendingActive ? "The Dungeon Master is narrating…" : pendingStuck ? "The DM seemed stuck — try again." : (canAct ? "Describe what your hero does..." : `Read-only: ${readOnlyReason}`)}
+                placeholder={pendingFirstBeat ? "The Dungeon Master is composing your opening scene…" : pendingActive ? "The Dungeon Master is narrating…" : pendingStuck ? "The DM seemed stuck — try again." : (canAct ? "Describe what your hero does..." : `Read-only: ${readOnlyReason}`)}
                 style={{ ...inkInput, fontFamily: "var(--f-body)", fontSize: 16, opacity: pendingActive ? 0.6 : 1 }}
               />
-              <BrassButton onClick={onDeclareClick} title={pendingStuck ? "Re-send your last action to the Dungeon Master, or type a new one first." : DECLARE_HINT} disabled={!actionById("do")?.available || pendingActive}>{pendingActive ? "Narrating…" : pendingStuck ? "Try again" : "Declare"}</BrassButton>
+              <BrassButton onClick={onDeclareClick} title={pendingStuck ? "Re-send your last action to the Dungeon Master, or type a new one first." : DECLARE_HINT} disabled={!actionById("do")?.available || pendingActive}>{pendingFirstBeat ? "Composing…" : pendingActive ? "Narrating…" : pendingStuck ? "Try again" : "Declare"}</BrassButton>
             </div>
           </div>
         </Panel>
@@ -814,6 +818,23 @@ function LogEntry({ entry }) {
 // takes several minutes. Telling a first-timer "up to a minute" then re-opening the bar at 90s was
 // the #348 false-stuck trap. For the opening we say "a few minutes"; later beats keep "up to a
 // minute" (they really are ~35–60s). This copy mirrors the adaptive recovery window in app.jsx.
+// #385: the rotating "the world is being made" flavor lines for the COLD-OPEN only. The first beat
+// legitimately takes minutes (the engine builds the world + sets the scene; no streaming), and the
+// old single static line ("Setting the opening scene — …") read as FROZEN: it never changed, the
+// pulsing dots / shimmer / elapsed were all decorative-and-aria-hidden, so to the accessibility tree
+// AND to a single screenshot the whole affordance collapsed to two unchanging strings. A fresh
+// player (and the §8.2 a11y-snapshot harness) saw nothing move and gave up. These lines ROTATE every
+// few seconds so consecutive renders/snapshots DIFFER — visible, honest progress (it's the DM
+// composing, not fake percent-progress) — and they're announced via the live region below.
+const DM_COLD_OPEN_FLAVOR = [
+  "The Dungeon Master is composing your opening scene…",
+  "Lighting the candles and unrolling the map…",
+  "Gathering the threads of your story…",
+  "Setting the stage and casting the first players…",
+  "Sketching the world around you…",
+  "The ink is still drying on your opening…",
+];
+
 function DmNarratingBeat({ since, firstBeat }) {
   const start = typeof since === "number" ? since : Date.now();
   const [now, setNow] = React.useState(() => Date.now());
@@ -825,15 +846,64 @@ function DmNarratingBeat({ since, firstBeat }) {
   const mm = Math.floor(secs / 60);
   const ss = String(secs % 60).padStart(2, "0");
   const elapsedLabel = `${mm}:${ss}`;
+  // #385: the headline reads as an ACTIVE process, not a passive status. The cold-open rotates a
+  // flavor line every ~4s (so the text itself visibly changes); later beats keep the steady label.
+  const label = firstBeat
+    ? DM_COLD_OPEN_FLAVOR[Math.floor(secs / 4) % DM_COLD_OPEN_FLAVOR.length]
+    : "The Dungeon Master is narrating";
   const waitHint = firstBeat
-    ? "Setting the opening scene — the first beat of a session can take a few minutes."
+    ? "The first beat of a session can take a few minutes — hang tight, your story is on its way."
     : "Weaving the next beat — this can take up to a minute.";
+  // #385: a11y model for the cold-open. The frozen-app illusion came from the live region being the
+  // ONLY accessible text AND it never changing (the dots/shimmer/elapsed were all aria-hidden). Fix:
+  //   • The visible label + elapsed are NO LONGER aria-hidden for the first beat, so they appear in
+  //     the accessibility tree / ariaSnapshot AND visibly change between renders — the proof-of-life
+  //     the §8.2 snapshot harness and a real screen reader can actually perceive.
+  //   • But they live OUTSIDE the aria-live region (the outer div is a plain container here): a
+  //     polite region re-announces its whole text on every change, so leaving the per-second elapsed
+  //     inside it would spam a screen reader every tick — the exact noise #336 avoided by hiding it.
+  //   • A SEPARATE visually-hidden role="status" announces the reassurance ONCE on mount (it never
+  //     changes → announced once, not per tick). Later beats keep the original single-region behavior.
+  if (firstBeat) {
+    return (
+      <div style={{ margin: "14px 0", display: "flex", gap: 12, opacity: 0.92 }}>
+        <div style={{ width: 4, alignSelf: "stretch", background: "linear-gradient(180deg, var(--crimson), transparent)" }} />
+        <div className="body" style={{ flex: 1 }}>
+          {/* announced ONCE — stable text, so a polite region doesn't re-fire every second */}
+          <span role="status" aria-live="polite" style={{
+            position: "absolute", width: 1, height: 1, padding: 0, margin: -1,
+            overflow: "hidden", clip: "rect(0 0 0 0)", whiteSpace: "nowrap", border: 0,
+          }}>
+            The Dungeon Master is composing your opening scene. {waitHint}
+          </span>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+            {/* visible + in the a11y tree (NOT aria-hidden) so the rotating text + elapsed prove life */}
+            <span className="dm-narrating-label eyebrow" style={{ color: "var(--crimson)" }}>{label}</span>
+            <span className="dm-narrating-dots" aria-hidden="true" style={{ display: "inline-flex", gap: 4 }}>
+              {[0, 1, 2].map((i) => (
+                <span key={i} style={{
+                  width: 6, height: 6, borderRadius: "50%", background: "var(--b-400)",
+                  animation: "dmNarratePulse 1200ms ease-in-out infinite", animationDelay: `${i * 200}ms`,
+                }} />
+              ))}
+            </span>
+            <span style={{ fontFamily: "var(--f-mono)", fontSize: 12, color: "var(--ink-600)", fontVariantNumeric: "tabular-nums" }}>
+              {`composing · ${elapsedLabel}`}
+            </span>
+          </div>
+          <div className="hand muted" style={{ fontSize: 12, marginTop: 4 }}>
+            {waitHint}
+          </div>
+        </div>
+      </div>
+    );
+  }
   return (
     <div role="status" aria-live="polite" style={{ margin: "14px 0", display: "flex", gap: 12, opacity: 0.92 }}>
       <div style={{ width: 4, alignSelf: "stretch", background: "linear-gradient(180deg, var(--crimson), transparent)" }} />
       <div className="body" style={{ flex: 1 }}>
         <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-          <span className="dm-narrating-label eyebrow" style={{ color: "var(--crimson)" }}>The Dungeon Master is narrating</span>
+          <span className="dm-narrating-label eyebrow" style={{ color: "var(--crimson)" }}>{label}</span>
           <span className="dm-narrating-dots" aria-hidden="true" style={{ display: "inline-flex", gap: 4 }}>
             {[0, 1, 2].map((i) => (
               <span key={i} style={{
@@ -897,6 +967,9 @@ function DmStuckBeat() {
 }
 
 Object.assign(window, { ScreenTable, PartyRow, ConditionRow, LogEntry, DmNarratingBeat, DmStuckBeat, sanitizeNarration });
+// #385: expose the cold-open flavor pool for tests/devtools introspection (purely additive —
+// nothing in the running app reads it off window; DmNarratingBeat closes over the const directly).
+window.DM_COLD_OPEN_FLAVOR = DM_COLD_OPEN_FLAVOR;
 
 function EncounterButton({ icon, label, detail, tone, onClick, disabled, hint }) {
   const iconNode = window.OpenWorldsIcon?.has?.(icon)

--- a/viewer/tests/test_cold_open_progress.py
+++ b/viewer/tests/test_cold_open_progress.py
@@ -1,0 +1,278 @@
+"""Behavior tests for the #385 cold-open "obviously-alive" waiting state.
+
+The first DM beat of a session (the cold-open / Act-opening) legitimately takes minutes
+(the engine builds the world + sets the scene; the /chat tail carries no streaming). The
+shipped `DmNarratingBeat` (viewer/openworlds/screen-table.jsx) DID animate — pulsing dots,
+a shimmer label, a live elapsed counter — but every one of those aliveness cues was either
+decorative-and-`aria-hidden` (the dots, the shimmer) or `aria-hidden` (the elapsed counter)
+AND the visible label never changed. So to the accessibility tree (what the §8.2 newbie
+harness reads via `ariaSnapshot`) AND to a single static screenshot, the whole affordance
+collapsed to two unchanging strings — it read as a FROZEN app, and a fresh player gave up
+(satisfaction 4/10, gave_up:true). #385.
+
+The fix makes the FIRST-BEAT branch obviously alive on the surfaces that matter:
+  • a ROTATING flavor headline ("The Dungeon Master is composing your opening scene…",
+    "Lighting the candles…", …) that changes every ~4s — so consecutive renders / aria
+    snapshots DIFFER;
+  • the elapsed counter is NO LONGER aria-hidden for the cold-open (it's in the a11y tree
+    and visibly ticks) — the strongest "still alive" cue a screen reader / snapshot can see;
+  • the per-second-changing text lives OUTSIDE the aria-live region (a separate
+    visually-hidden role="status" announces a STABLE reassurance ONCE) so a screen reader
+    isn't spammed every tick.
+Later beats (the ~35–60s norm) keep the original #336 treatment unchanged.
+
+These tests exercise the REAL component by transpiling the actual `screen-table.jsx` with the
+SAME bundled Babel-standalone the browser uses and rendering `DmNarratingBeat` under a tiny
+`createElement`-capturing React stub at controllable elapsed times — so the test tracks the
+shipped JSX, not a reimplementation (mirrors test_recovery_timing.py / test_sanitize_narration.py).
+"""
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+_OPENWORLDS = Path(__file__).resolve().parents[1] / "openworlds"
+_SCREEN_TABLE = _OPENWORLDS / "screen-table.jsx"
+_BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+
+# A self-contained Node harness. React.createElement is captured into a plain node tree
+# ({type, props, children}); hooks are stubbed (useState seeds its initial value, useEffect
+# is a no-op — we drive elapsed via the injected `Date.now`, not the 1s interval). We render
+# DmNarratingBeat at a chosen elapsed time and walk the tree to collect: every visible text
+# string, every text string that is NOT under an aria-hidden subtree (the "accessible" text a
+# screen reader / ariaSnapshot would see), and whether a role="status" live region exists.
+_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+let NOW = 1000000;
+
+// ---- a createElement-capturing React: enough to render a pure component to a node tree ----
+function makeReact() {
+  function useState(init) {
+    const v = (typeof init === 'function') ? init() : init;
+    return [v, function () {}];               // first-render value; setState is a no-op here
+  }
+  function useEffect() {}                       // the 1s interval is irrelevant — we set NOW directly
+  function useRef(init) { return { current: init }; }
+  function useCallback(fn) { return fn; }
+  function createElement(type, props) {
+    const children = Array.prototype.slice.call(arguments, 2);
+    return { type, props: props || {}, children };
+  }
+  return { useState, useEffect, useRef, useCallback, createElement, Fragment: 'F' };
+}
+
+const React = makeReact();
+const sandbox = {
+  React,
+  ReactDOM: { createRoot: () => ({ render() {} }) },
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible', getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
+  setInterval: () => 0, clearInterval: () => {}, setTimeout: () => 0, clearTimeout: () => {},
+  fetch: () => Promise.resolve({ ok: false, json: () => Promise.resolve({}) }),
+  console,
+};
+sandbox.window = sandbox;
+sandbox.Date = { now: () => NOW };
+vm.createContext(sandbox);
+
+function load(p) {
+  const src = fs.readFileSync(p, 'utf8');
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+load(%(screen_table)s);
+
+const DmNarratingBeat = sandbox.window.DmNarratingBeat;
+if (typeof DmNarratingBeat !== 'function') throw new Error('DmNarratingBeat not exported');
+
+// Render the component (a function component) by invoking it and getting its element tree.
+function renderBeat(props) { return DmNarratingBeat(props); }
+
+// Walk a node tree, collecting strings. `accessibleOnly` skips any subtree whose props carry
+// aria-hidden truthy (mirrors how ariaSnapshot / a screen reader drops aria-hidden content).
+function collectText(node, accessibleOnly, hiddenAncestor) {
+  let out = [];
+  if (node == null || node === false) return out;
+  if (typeof node === 'string' || typeof node === 'number') {
+    if (!(accessibleOnly && hiddenAncestor)) out.push(String(node));
+    return out;
+  }
+  if (Array.isArray(node)) {
+    for (const c of node) out = out.concat(collectText(c, accessibleOnly, hiddenAncestor));
+    return out;
+  }
+  const props = node.props || {};
+  const hidden = hiddenAncestor || props['aria-hidden'] === 'true' || props['aria-hidden'] === true;
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [props.children] : []));
+  for (const c of kids) out = out.concat(collectText(c, accessibleOnly, hidden));
+  return out;
+}
+
+// Does the tree contain an element with role="status" (a live region)? Return how many.
+function countStatusRegions(node) {
+  let n = 0;
+  if (node == null || typeof node !== 'object') return 0;
+  if (Array.isArray(node)) { for (const c of node) n += countStatusRegions(c); return n; }
+  const props = node.props || {};
+  if (props.role === 'status') n += 1;
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [props.children] : []));
+  for (const c of kids) n += countStatusRegions(c);
+  return n;
+}
+
+// Collect the text inside every role="status" subtree (what a polite region would announce).
+function statusText(node, inStatus) {
+  let out = [];
+  if (node == null || typeof node !== 'object') {
+    return out;
+  }
+  if (Array.isArray(node)) { for (const c of node) out = out.concat(statusText(c, inStatus)); return out; }
+  const props = node.props || {};
+  const here = inStatus || props.role === 'status';
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [props.children] : []));
+  for (const c of kids) {
+    if (typeof c === 'string' || typeof c === 'number') { if (here) out.push(String(c)); }
+    else out = out.concat(statusText(c, here));
+  }
+  return out;
+}
+
+function report(props) {
+  const tree = renderBeat(props);
+  return {
+    allText: collectText(tree, false, false).join(' ␟ '),
+    accessibleText: collectText(tree, true, false).join(' ␟ '),
+    statusRegions: countStatusRegions(tree),
+    statusText: statusText(tree, false).join(' '),
+  };
+}
+
+const h = {
+  setNow: (n) => { NOW = n; },
+  // render at `elapsedSec` seconds in (since = NOW - elapsedSec*1000) for the given firstBeat flag.
+  render: (elapsedSec, firstBeat) => report({ since: NOW - elapsedSec * 1000, firstBeat }),
+  flavor: () => sandbox.window.DM_COLD_OPEN_FLAVOR,
+};
+
+const script = %(script)s;
+const result = (function () { return eval(script); })();
+process.stdout.write(JSON.stringify(result));
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + render the JSX")
+class ColdOpenProgressTests(unittest.TestCase):
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_SCREEN_TABLE, _BABEL):
+            assert p.exists(), f"missing {p}"
+
+    def _run(self, script: str):
+        program = _HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "screen_table": json.dumps(str(_SCREEN_TABLE)),
+            "script": json.dumps(script),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program,
+            text=True,
+            capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+    # --- the flavor pool exists and is non-trivial ---------------------------
+    def test_flavor_pool_is_exported_and_rotatable(self):
+        flavor = self._run("h.flavor()")
+        self.assertIsInstance(flavor, list)
+        self.assertGreaterEqual(len(flavor), 4, "need several lines so the headline visibly rotates")
+        self.assertTrue(all(isinstance(s, str) and s.strip() for s in flavor))
+
+    # --- #385 CORE: the cold-open ACCESSIBLE text CHANGES over time ----------
+    # This is the exact failure: the §8.2 harness reads ariaSnapshot (accessible text only) and a
+    # static screenshot. If the accessible text is identical at t=2s and t=30s, it reads as frozen.
+    def test_cold_open_accessible_text_changes_over_time(self):
+        out = self._run(
+            "({ early: h.render(2, true), mid: h.render(30, true), late: h.render(120, true) })"
+        )
+        a_early = out["early"]["accessibleText"]
+        a_mid = out["mid"]["accessibleText"]
+        a_late = out["late"]["accessibleText"]
+        self.assertNotEqual(a_early, a_mid, "cold-open accessible text must change (not frozen) as time passes")
+        self.assertNotEqual(a_mid, a_late, "cold-open accessible text must keep changing deeper into the wait")
+        # the live elapsed readout is part of the ACCESSIBLE text (not aria-hidden) for the cold-open
+        self.assertIn("0:02", a_early)
+        self.assertIn("0:30", a_mid)
+        self.assertIn("2:00", a_late)
+
+    # --- the headline rotates through the flavor pool ------------------------
+    def test_cold_open_headline_rotates_through_flavor(self):
+        flavor = self._run("h.flavor()")
+        # sample a few 4s buckets; collect the headline (accessible) text seen
+        out = self._run(
+            "[0,4,8,12,20].map(function(s){ return h.render(s, true).accessibleText; })"
+        )
+        seen = set()
+        for txt in out:
+            for line in flavor:
+                if line in txt:
+                    seen.add(line)
+        self.assertGreaterEqual(len(seen), 3, "the cold-open headline should rotate through several flavor lines")
+
+    # --- the cold-open headline is composing-voiced, NOT the static old copy --
+    def test_cold_open_drops_the_static_setting_the_scene_label(self):
+        text = self._run("h.render(1, true).allText")
+        self.assertIn("composing", text.lower(), "cold-open should read as the DM actively composing")
+        # The old dead-end phrasing must be gone from the cold-open.
+        self.assertNotIn("Setting the opening scene — the first beat", text)
+
+    # --- the per-second-changing text is NOT inside the announced live region -
+    # A polite role="status" re-announces its whole text on every change; the ticking elapsed must
+    # live OUTSIDE it so a screen reader isn't spammed every second. The live region announces a
+    # STABLE reassurance that does NOT contain the elapsed clock.
+    def test_cold_open_live_region_is_stable_not_per_second(self):
+        out = self._run("({ a: h.render(7, true), b: h.render(8, true) })")
+        # there IS a status region (so the wait is announced at all)
+        self.assertGreaterEqual(out["a"]["statusRegions"], 1, "cold-open must still announce the wait via a status region")
+        # the announced (status) text must NOT carry the per-second clock → identical across a 1s step
+        self.assertEqual(
+            out["a"]["statusText"], out["b"]["statusText"],
+            "the announced live-region text must be stable second-to-second (no per-tick screen-reader spam)",
+        )
+        # …and concretely it must not contain an m:ss clock token (a digit-colon-digit pattern)
+        import re as _re
+        self.assertIsNone(
+            _re.search(r"\d:\d\d", out["a"]["statusText"]),
+            "the announced live-region text must not contain a ticking m:ss clock",
+        )
+
+    # --- LATER beats keep the original #336 treatment (regression guard) ------
+    # The fix is first-beat-scoped: a later beat keeps the steady "narrating" label and its elapsed
+    # stays aria-hidden (short waits → no per-second announcement). So its ACCESSIBLE text does NOT
+    # carry the ticking clock and is stable across a 1s step.
+    def test_later_beat_treatment_is_unchanged(self):
+        out = self._run("({ a: h.render(7, false), b: h.render(8, false) })")
+        self.assertIn("The Dungeon Master is narrating", out["a"]["allText"])
+        self.assertNotIn("composing", out["a"]["allText"].lower())
+        # later-beat elapsed is aria-hidden → not in accessible text → accessible text stable 1s apart
+        self.assertEqual(
+            out["a"]["accessibleText"], out["b"]["accessibleText"],
+            "later-beat accessible text should be unchanged second-to-second (elapsed stays aria-hidden)",
+        )
+        # and the visible elapsed still ticks in the full text (the #336 visual cue is intact)
+        self.assertIn("0:07", out["a"]["allText"])
+        self.assertIn("0:08", out["b"]["allText"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses #385 (P0/CRITICAL). **Do NOT close on merge — verify on next build's newbie playtest.**

## Root cause

The cold-open (first-beat) waiting state renders through `DmNarratingBeat` (`viewer/openworlds/screen-table.jsx`). It *did* have animation — pulsing dots, a shimmer label, and a live elapsed counter — but **every one of those aliveness cues was either decorative-and-`aria-hidden` (dots, shimmer) or `aria-hidden` (the elapsed counter), and the visible headline never changed.**

The §8.2 newbie harness "sees" the screen via Playwright `ariaSnapshot` / `ariaText` (screen-reader semantics) plus a single static PNG screenshot (`qa/playwright/palette_server.js`). To that surface — and to a real screen-reader user, and to anyone glancing at a still frame — the entire affordance collapsed to **two unchanging strings**: "The Dungeon Master is narrating" + "Setting the opening scene — the first beat of a session can take a few minutes." Nothing in the accessibility tree ever changed, so it read as a **frozen/crashed app**. The newbie waited ~11s, saw nothing move, and gave up (satisfaction 4/10, `gave_up:true`).

So #336's animation and #348's adaptive recovery window *were* wired to the cold-open (`pending.firstBeat` threads through from `armPending` in `app.jsx`), but the proof-of-life was invisible on the surfaces that actually decide "is this alive?".

## What changed (`screen-table.jsx` only — additive, first-beat-scoped)

- **Rotating flavor headline** for the cold-open: "The Dungeon Master is composing your opening scene…", "Lighting the candles and unrolling the map…", etc., rotating every ~4s — so consecutive renders / aria snapshots **differ** (visible, honest progress; not fake percentages).
- **Elapsed counter is no longer `aria-hidden` for the cold-open** ("composing · 0:42") — it's in the accessibility tree and visibly ticks. A live readout that changes every second is the strongest "still alive" cue a screen reader / snapshot can perceive.
- **No screen-reader spam:** the per-second-changing text lives *outside* the `aria-live` region. A separate visually-hidden `role="status"` announces a **stable** reassurance once on mount (a polite region re-announces its whole text on every change, so the ticking clock stays out of it — the exact noise #336 avoided by hiding elapsed). 
- **Action bar reads as "the DM is taking its turn" (alive), not broken:** for the first beat the input placeholder is "The Dungeon Master is composing your opening scene…" and the button reads "Composing…". Disabled state preserved.
- **Later beats (~35–60s norm) are byte-identical to before** — the `firstBeat` early-return leaves the original #336/#341/#348 path untouched (only the inline label string became a `label` var that evaluates to the same string for later beats).

## Tests

New `viewer/tests/test_cold_open_progress.py` (6 tests) transpiles the real `screen-table.jsx` with the shipped Babel and renders `DmNarratingBeat` under a `createElement`-capturing React stub (same architecture as `test_recovery_timing.py`). It asserts:
- the cold-open **accessible** text changes at t=2s / 30s / 120s (the exact frozen-app failure);
- the headline rotates through several flavor lines;
- the announced live-region text is **stable** second-to-second (no per-tick spam, no m:ss in it);
- the old static "Setting the opening scene — the first beat" copy is gone from the cold-open;
- **later-beat treatment is unchanged** (regression guard).

Full viewer suite: **162 passed, 1 skipped, 17 subtests** (single-process). `test_recovery_timing.py` (#348) still green. `license_check` clean. JSX transpiles under the bundled Babel.

## Scope notes
- Touched **only** `viewer/openworlds/screen-table.jsx` (+ the new test). **No `app.jsx` change needed** — `pending.firstBeat` was already threaded through; the bug was purely in the render, not the hook/state plumbing.
- **`styles.css` NOT touched** (the existing `dm-narrate-style` keyframes already cover the dots/shimmer; reduced-motion still stills them; the elapsed/flavor are information, not decoration).
- Honest "composing…" + elapsed timer — no faked progress.

## Follow-up (separate, tracked in #385)
The first-beat **latency itself** ("a few minutes", no streaming) is a distinct quality concern; this PR only makes the wait obviously-alive so a first-timer waits instead of bouncing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Opening scene composition now displays distinct UI with "Composing…" text instead of generic narration copy.
  * Added rotating flavor labels and improved timer display for the first beat.

* **Improvements**
  * Enhanced accessibility for cold-open progress with better live-region announcements and stable status updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->