### PR TITLE
fix(openworlds): add aasimar lineage to RACES (Closes #375)

### DIFF
--- a/viewer/openworlds/screen-create.jsx
+++ b/viewer/openworlds/screen-create.jsx
@@ -863,6 +863,19 @@ const RACES = {
     body: "Strong enough to end the argument and stubborn enough to outlast it. Refuses to fall when a lesser frame would, and rises angrier.",
     bonus: { str: 2, con: 1 },
   },
+  // Aasimar — added Loop-10 to make Dame Aylin's PORTRAIT_GALLERY entry
+  // (race: "aasimar") validate. Per 5e canon (Protector tradition): CHA +2,
+  // WIS +1. Closes #375 (the race-tag drift the --ui-gate `gallery_per_race`
+  // probe flags as `unknownRaces: ["aasimar"]`). Subraces (Protector / Scourge /
+  // Fallen) deferred to #377.
+  aasimar: {
+    name: "Aasimar",
+    size: "Medium",
+    life: "160 years",
+    glyph: "aasimar",
+    body: "Touched by something brighter once. Bears a heritage older than empires, and the unsettling habit of catching candle-light at the wrong angles. Born to the Upper Planes' echo; walks the world unsure whether to atone or to lead.",
+    bonus: { cha: 2, wis: 1 },
+  },
 };
 
 const CLASSES = {


### PR DESCRIPTION
## TL;DR

Adds `aasimar` as a first-class lineage in `RACES` (CHA +2, WIS +1 per 5e canon Protector tradition), retroactively validating Dame Aylin's existing `PORTRAIT_GALLERY` entry (`race: "aasimar"`). Closes the race-tag drift the `--ui-gate gallery_per_race` probe (PR #386) flags as `unknownRaces: ["aasimar"]`.

## Closes / addresses

- **Closes #375** (Trivial — Dame Aylin tagged with invalid RACES key)
- Pairs with **PR #386** (`gallery_per_race ≥ 1` gate that detects this class of drift)
- Surfaced during **Loop 10 verification** of PR #369

## What this lands

One additive entry at `viewer/openworlds/screen-create.jsx:866`:

```jsx
aasimar: {
  name: "Aasimar",
  size: "Medium",
  life: "160 years",
  glyph: "aasimar",
  body: "Touched by something brighter once. Bears a heritage older than empires, and the unsettling habit of catching candle-light at the wrong angles. Born to the Upper Planes' echo; walks the world unsure whether to atone or to lead.",
  bonus: { cha: 2, wis: 1 },
},
```

## Why option (1), not option (2)

#375 offered two paths:
1. **Add aasimar to RACES** (lineage-positive)
2. Re-tag Dame Aylin → human (drift-patching)

Picked (1). Aasimar IS a canonical 5e lineage (PHB-adjacent, Volo's Guide) AND a canonical BG3 lore lineage (planetouched). Re-tagging Aylin would patch the drift but cost real CRPG-canon fidelity. Players coming from D&D Beyond / Kingmaker / BG3 will expect Aasimar on a character-creation screen.

## 5e canon mapping

| Field | Value | Rationale |
|---|---|---|
| Size | Medium | Volo's Guide |
| Life | ~160 years | "live longer than humans" |
| ASI | CHA +2, WIS +1 | Protector tradition (most common in BG3 lore, closest fit for the existing flat-RACES bonus style) |

Subraces (Protector / Scourge / Fallen) and full trait set (Celestial Resistance, Healing Hands, Light cantrip) deferred — same pattern as the other 11 races, which don't yet expose subraces or full trait sets either.

## Smoke test (post-fix, regex from #386 against patched file)

```
Counts per race (after this PR):
   human        4
   halfling     0  ← still empty (#379 — next PR with empty-state)
   dwarf        0  ← still empty
   elf          2
   half         2
   tiefling     1
   dragonborn   0  ← still empty
   drow         1
   githyanki    1
   gnome        0  ← still empty
   half-orc     0  ← still empty
   aasimar      1  ← Dame Aylin now reachable ✓
Unknown race tags: []  ← drift CLOSED ✓
```

## Acceptance criteria (per #375)

- ☑ Option (1) chosen: aasimar added to RACES with proper ability bonuses (CHA +2, WIS +1)
- ☑ Closest lore fit (Protector Aasimar tradition)
- ☑ Lore-line body copy matches existing prose style (mythopoetic, present-tense, character-not-encyclopedia)
- ☑ Dame Aylin's PORTRAIT_GALLERY entry now validates (verified via regex smoke)
- ☑ `--ui-gate gallery_per_race` `unknownRaces` set is now empty (verified)

## Out of scope (intentionally)

- Empty galleries for dwarf / halfling / gnome / dragonborn / half-orc — **separate #379 fix coming next** with empty-state fallback
- Full subrace handling — #377
- Aasimar racial trait set beyond ability bonuses — deferred until the other 11 races get full trait sets too (consistency)
- Updating `CREATE_RACE_IDS` in `qa/ui_gate_probe.js` — that lives on PR #386 (unmerged); will rebase #386 to include `'aasimar'` once this lands

## Collision audit

- `viewer/openworlds/screen-create.jsx` last touched on main by PR #369 (`fix(openworlds): create — #277 #281 #315`). Adding a single RACES entry at the end of the table doesn't conflict with any open PR's surface.
- Main agent's open #388 is `fix(dm,viewer): cold-open delivers a real 2nd-person opening` — DM/cold-open territory, zero overlap.
- This PR is additive: removes nothing, modifies no existing entry.

## DO NOT MERGE yet

Per owner direction. Ready for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added Aasimar as a playable race option in character creation with +2 Charisma and +1 Wisdom stat bonuses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->