### PR TITLE
feat(openworlds): seed BG world_graph edges with route_kind (Closes #381)

### DIFF
--- a/content/worlds/baldurs-gate/world.json
+++ b/content/worlds/baldurs-gate/world.json
@@ -50,6 +50,18 @@
     {"id": "loc-reithwin", "name": "Reithwin & the Lifting Shadow", "description": "The Shadow-Cursed Lands around Moonrise Towers, where Ketheric Thorm's curse of Shar is slowly lifting since his fall — Last Light Inn rekindles, the dead grow quieter, and survivors return to a poisoned country to see what crawled out of the dark.", "connections": ["loc-wyrms-crossing"], "tags": ["wilds", "shadow", "ruins"]},
     {"id": "loc-candlekeep", "name": "Candlekeep", "description": "The great fortress-library on the Sword Coast, hoarding the world's knowledge behind a one-book toll. If the truth about the Crown of Karsus, the Emperor's past, or a loose illithid is written anywhere, it is here — guarded by Avowed who do not love visitors.", "connections": ["loc-wyrms-crossing"], "tags": ["lore", "library", "secrets"]}
   ],
+  "world_graph": {
+    "seed": "baldurs-gate-loop-10-route-kinds",
+    "provenance": "authored",
+    "edges": [
+      {"from_id": "loc-lower-city",      "to_id": "loc-upper-city",      "route_kind": "street", "minutes":    8, "difficulty": "easy",   "danger": 1, "tags": ["urban", "uphill", "fist-checkpoint"]},
+      {"from_id": "loc-lower-city",      "to_id": "loc-outer-city",      "route_kind": "street", "minutes":   12, "difficulty": "easy",   "danger": 2, "tags": ["urban", "basilisk-gate", "slums-edge"]},
+      {"from_id": "loc-outer-city",      "to_id": "loc-wyrms-crossing",  "route_kind": "bridge", "minutes":   18, "difficulty": "easy",   "danger": 2, "tags": ["chionthar", "fist-toll", "wyrms-rock"]},
+      {"from_id": "loc-wyrms-crossing",  "to_id": "loc-elturel",         "route_kind": "road",   "minutes": 1440, "difficulty": "normal", "danger": 3, "tags": ["risen-road", "south", "hellrider-patrol"]},
+      {"from_id": "loc-wyrms-crossing",  "to_id": "loc-reithwin",        "route_kind": "road",   "minutes": 2160, "difficulty": "hard",   "danger": 5, "tags": ["shadow-cursed", "north", "lifting"]},
+      {"from_id": "loc-wyrms-crossing",  "to_id": "loc-candlekeep",      "route_kind": "road",   "minutes": 5760, "difficulty": "normal", "danger": 2, "tags": ["coast-road", "west", "avowed-watch"]}
+    ]
+  },
   "factions": [
     {"id": "fac-flaming-fist", "name": "The Flaming Fist", "description": "The Gate's mercenary army and de facto police, overstretched and leaderless-feeling with the Steel Watch gone and the dukedom contested. Honorable in the ranks, political at the top.", "reputation": 1},
     {"id": "fac-guild", "name": "The Guild", "description": "Baldur's Gate's vast thieves' network — smuggling, protection, information. Pragmatic, everywhere, and the ones who actually know what moves in the dark.", "reputation": 0},

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -858,7 +858,14 @@ class WorldGraphEdge(_StrictModel):
 
     from_id: str
     to_id: str
-    route_kind: Literal["street", "road", "trail", "sea", "river", "passage", "portal"] = "road"
+    # Loop-10 #381: added "ferry" (was already a dead branch in screen-map.jsx
+    # edgeStyle), "bridge" (Wyrm's Crossing — the BG canon load-bearing crossing
+    # over the Chionthar), "underground" (Underdark passages — coming with #380
+    # when the Underdark / Bhaal Temple POIs land).
+    route_kind: Literal[
+        "street", "road", "trail", "sea", "river", "passage", "portal",
+        "ferry", "bridge", "underground",
+    ] = "road"
     minutes: Optional[int] = Field(None, ge=1)
     distance: Optional[float] = Field(None, ge=0)
     difficulty: Literal["easy", "normal", "hard", "hazardous"] = "normal"

--- a/viewer/openworlds/screen-map.jsx
+++ b/viewer/openworlds/screen-map.jsx
@@ -427,9 +427,27 @@ function computeAtlasLayout(locations, edges) {
 function edgeStyle(edge) {
   const kind = (edge.route_kind || "").toLowerCase();
   const danger = typeof edge.danger === "number" ? edge.danger : 0;
+  // High-danger routes dominate the style: dark red dashed, regardless of kind.
   if (danger >= 6) return { stroke: "rgba(120,32,32,0.62)", width: 0.7, dash: "1.4 1" };
+  // Urban + extramural surface routes — solid brown.
   if (kind === "street" || kind === "road") return { stroke: "rgba(60,30,10,0.6)", width: 0.85, dash: "" };
+  // Water + crossing — solid blue. "ferry" is now a valid Literal member (#381).
   if (kind === "river" || kind === "ferry" || kind === "sea") return { stroke: "rgba(40,90,120,0.6)", width: 0.7, dash: "" };
+  // Bridge — slightly thicker amber-brown to mark a load-bearing crossing
+  // (Wyrm's Crossing over the Chionthar, etc.) as distinct from a regular road.
+  // Added Loop-10 / #381.
+  if (kind === "bridge") return { stroke: "rgba(110,75,30,0.72)", width: 1.05, dash: "" };
+  // Underground — Underdark passages, Bhaal Temple stairs, sewers. Tight dotted
+  // dash reads as "you go down, not across." Added Loop-10 / #381 ahead of the
+  // #380 Underdark POIs.
+  if (kind === "underground" || kind === "passage") return { stroke: "rgba(40,25,10,0.66)", width: 0.7, dash: "0.7 1.8" };
+  // Portal — extraplanar / arcane (Avernus gate, Astral, etc.). A subtle violet
+  // tint flags the route as "not walking distance" even when the connection is
+  // visually short.
+  if (kind === "portal") return { stroke: "rgba(95,55,135,0.62)", width: 0.7, dash: "1.2 1.2" };
+  // Trail — wilds-grade path. Lighter and looser-dashed than the default to
+  // read as "you'll get there, just not quickly."
+  if (kind === "trail") return { stroke: "rgba(85,60,30,0.5)", width: 0.6, dash: "1.4 1.6" };
   return { stroke: "rgba(60,30,10,0.46)", width: 0.5, dash: "1.6 1.2" };
 }
 


### PR DESCRIPTION
## TL;DR

Loop-10 verification of #261 found the atlas/world_graph pipeline already carries `route_kind` end-to-end — model, loader, viewer projection, viewer branching all exist — but the `baldurs-gate` world has **zero `world_graph` edges**, so every BG inter-district connection projects as the same untyped default stroke. This PR delivers the content, plus the two adjacent gaps the Loop-10 sub-agent flagged.

## Closes

- **#381** — `feat(openworlds): seed BG world_graph edges with route_kind metadata (#261 AC follow-up)`
- Pairs with parent **#261** (PR #371 closed the discovered-tier strand)

## What this lands

### 1. `servers/engine/models.py` — `WorldGraphEdge.route_kind` Literal

Extended by 3 members. The existing 7 kinds + default `"road"` are unchanged (zero behavior change for any existing authored content).

| New kind | Why |
|---|---|
| `ferry` | Was already a dead branch in `screen-map.jsx` `edgeStyle` — viewer styled it, model rejected it on author. Now authorable. |
| `bridge` | Wyrm's Crossing over the Chionthar is canonically a bridge, not a road. First-class kind so styling can mark it. |
| `underground` | Underdark passages, sewers, Bhaal Temple stairs. Lands ahead of **#380** so the data surface is ready for those POIs. |

### 2. `content/worlds/baldurs-gate/world.json` — NEW `world_graph` block

Six directed edges, one per canonical region-pair:

| From → To | Kind | Minutes | Difficulty | Danger | Lore tags |
|---|---|---|---|---|---|
| Lower City → Upper City | street | 8m | easy | 1 | urban, uphill, fist-checkpoint |
| Lower City → Outer City | street | 12m | easy | 2 | urban, basilisk-gate, slums-edge |
| Outer City → Wyrm's Crossing | **bridge** | 18m | easy | 2 | chionthar, fist-toll, wyrms-rock |
| Wyrm's Crossing → Elturel | road | 24h | normal | 3 | risen-road, south, hellrider-patrol |
| Wyrm's Crossing → Reithwin | road | 36h | **hard** | **5** | shadow-cursed, north, lifting |
| Wyrm's Crossing → Candlekeep | road | 96h | normal | 2 | coast-road, west, avowed-watch |

All 6 verified against canonical `Location.connections` — the `_seed_world_graph` loader's "edge must reference an existing connection in either direction" guard passes for every edge (validated standalone via the loader's exact predicate).

### 3. `viewer/openworlds/screen-map.jsx` — `edgeStyle` extension

Existing styled 3 kind-buckets (street/road, river/ferry/sea, default). The Literal now supports 10. Added branches:

| Kind | Style | Reads as |
|---|---|---|
| `bridge` | Thicker amber-brown solid (width 1.05) | Load-bearing crossing |
| `underground` / `passage` | Tight-dotted dark brown | "You go down, not across" |
| `portal` | Violet dashed | Extraplanar / arcane |
| `trail` | Lighter brown, looser-dashed | "You'll get there, just not quickly" |

The pre-existing high-danger override (`danger >= 6`) still wins regardless of kind — that's the right precedence (player should see "dangerous" before "what kind of road").

## Why grouped, not 3 PRs

The 3 changes form one logical unit:
- The **Literal** opens what authors can write
- The **world.json** exercises that authorship  
- The **edgeStyle** makes the new kinds visually distinguishable

Shipping any 1 or 2 leaves the surface incomplete. Authoring `bridge` without a distinct style means the player can't tell the bridge from a road; styling `bridge` without authoring leaves the new branch dead.

## Verification

| File | Check | Result |
|---|---|---|
| `world.json` | `json.load()` parses | ✅ 26 top-level keys (was 25), 6 edges |
| `world.json` | All edges satisfy loader's connection guard | ✅ 6/6 |
| `models.py` | `ast.parse()` | ✅ |
| `screen-map.jsx` | Brace + paren balance | ✅ 450/450, 601/601 |

## Acceptance criteria (per #381)

- ☑ `world_graph` block authored for the BG world (zero before, 6 now)
- ☑ `route_kind` values match the AC's intended palette (street, road, bridge — plus ferry/sea/river already supported; underground/portal/trail ready for #380)
- ☑ Literal extended to include `ferry` (closing the existing dead branch), `bridge`, `underground`
- ☑ `edgeStyle` extended to give each kind a distinct visual signal
- ☑ Edges validated against canonical `Location.connections` — zero drift

## Out of scope

- New POIs / regions — #380 (required for `portal` + `underground` edges to actually appear; this PR makes the Literal ready, the seed waits for POI work)
- Edge metadata for non-BG worlds — pure content work per world
- Symmetric-edges convention — today 6 directed edges; the viewer renders fine either way and the loader is lenient on direction

## Collision audit

- `servers/engine/models.py` last touched on `main` by PR #355 (`fix(engine): derive class+level max_hp for seated canon characters (#352)`). The diff adds 3 strings to an existing Literal — no overlap with PR #355's surface.
- `content/worlds/baldurs-gate/world.json` last touched on `main` by PR #371 (`fix(openworlds): atlas-seed (Addresses #261)`). This PR adds a new top-level key (`world_graph`) — additive only.
- `viewer/openworlds/screen-map.jsx` last touched on `main` by PR #366 (`fix(openworlds): map (Addresses #307)`). The diff extends `edgeStyle` with new branches — additive only.
- Main agent's open #388 is `fix(dm,viewer): cold-open delivers a real 2nd-person opening` — DM/cold-open territory, zero overlap.

## DO NOT MERGE yet

Per owner direction. Ready for review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added world graph connectivity for Baldur's Gate, defining travel routes between regions (lower city, upper city, outer city, Wyrm's Crossing, Elturel, Reithwin, Candlekeep) with route metadata including travel time and difficulty.
  * Introduced new route types (ferry, bridge, underground) with distinct visual styling on the map interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->