### PR TITLE
feat(openworlds): inspector depth — proficiency markers, paper-doll, spell rules-text, item properties (optimizer/veteran)

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -218,43 +218,7 @@ function ScreenCharacter({ onNavigate, state, setState }) {
             <Divider />
 
             <div className="eyebrow">Equipped</div>
-            {(!Array.isArray(hero.equipped) || hero.equipped.length === 0) ? (
-              <div style={{
-                marginTop: 8, padding: "12px 14px", textAlign: "center",
-                background: "rgba(176,141,87,0.06)",
-                boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)",
-              }}>
-                <div className="hand muted" style={{ fontSize: 12 }}>No gear equipped.</div>
-                {onNavigate && (
-                  <BrassButton tone="ghost" size="sm" style={{ marginTop: 8 }} onClick={() => onNavigate("inventory")}>
-                    Open the stash
-                  </BrassButton>
-                )}
-              </div>
-            ) : (
-            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginTop: 8 }}>
-              {hero.equipped.map((it, i) => (
-                <div key={`${it.slot}-${it.name || i}`} style={{
-                  display: "flex", gap: 8, alignItems: "center",
-                  padding: 8,
-                  background: "rgba(176,141,87,0.08)",
-                  boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)",
-                }}>
-                  {/* Equipped item art — mirror screen-inventory's `item-<slug(name)>` scope
-                      (the engine keys ingested item icons by a name-slug; the surface emits
-                      it.name on each equipped entry). <Img> falls back to a Placeholder on a
-                      404, so a missing icon degrades gracefully. */}
-                  <Img scope={it.name ? "item-" + (window.slug ? window.slug(it.name) : "") : ""} label={it.name || it.glyph} w={32} h={32} fit="contain" framed />
-                  <div style={{ minWidth: 0 }}>
-                    <div className="eyebrow" style={{ fontSize: 9 }}>{it.slot}</div>
-                    <div style={{ fontFamily: "var(--f-display)", fontSize: 11, color: "var(--ink-900)", letterSpacing: "0.05em", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
-                      {it.name}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-            )}
+            <HeroEquipDoll hero={hero} onNavigate={onNavigate} />
           </Panel>
 
           {/* Center tab content */}
@@ -568,6 +532,88 @@ function StatLine({ k, v }) {
   );
 }
 
+// A short stat line for an equipped item's tooltip / slot caption from the read-model's
+// REAL catalog stats — "1d8 slashing" for a weapon, "AC 18" for armor — or "" when the
+// item is a catalog-miss (then we show just its name; never a fabricated stat).
+function equippedStat(it) {
+  if (!it) return "";
+  if (it.damage) return [it.damage, it.damageType].filter(Boolean).join(" ");
+  if (typeof it.ac === "number") return `AC ${it.ac}`;
+  return "";
+}
+
+function HeroEquipDoll({ hero, onNavigate }) {
+  // Slotted paper-doll for the combat column (#271 brought to the hero sheet). Reuses the
+  // SAME canonical slot set + name→slot assignment that the inventory screen's PaperDoll uses
+  // (window.EQUIP_SLOTS / window.assignEquipSlots) so a hero's gear lands in Head/Body/Main-Hand/
+  // etc. instead of a flat "Worn" list. Each filled cell shows the item's real catalog stat
+  // (damage dice / AC) from the read-model; empty cells render an honest labeled slot.
+  const equipped = Array.isArray(hero.equipped) ? hero.equipped : [];
+  const SLOTS = Array.isArray(window.EQUIP_SLOTS) ? window.EQUIP_SLOTS : [];
+  const assign = typeof window.assignEquipSlots === "function" ? window.assignEquipSlots : null;
+  const slug = window.slug || ((n) => (n || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, ""));
+
+  if (equipped.length === 0) {
+    return (
+      <div style={{
+        marginTop: 8, padding: "12px 14px", textAlign: "center",
+        background: "rgba(176,141,87,0.06)",
+        boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)",
+      }}>
+        <div className="hand muted" style={{ fontSize: 12 }}>No gear equipped.</div>
+        {onNavigate && (
+          <BrassButton tone="ghost" size="sm" style={{ marginTop: 8 }} onClick={() => onNavigate("inventory")}>
+            Open the stash
+          </BrassButton>
+        )}
+      </div>
+    );
+  }
+
+  // Build the {slotId: item} map (preferring the shared inventory helper). If that helper
+  // isn't loaded, fall back to listing each equipped item under its recorded slot — no crash.
+  const assigned = assign ? assign(equipped) : null;
+  const cells = (assigned && SLOTS.length)
+    ? SLOTS.map((s) => ({ slot: s, item: assigned[s.id] })).filter((c) => c.item)
+    : equipped.map((it, i) => ({ slot: { id: `e${i}`, label: it.slot || "Worn" }, item: it }));
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8, marginTop: 8 }}>
+      {cells.map(({ slot, item }) => {
+        const stat = equippedStat(item);
+        return (
+          <window.Tooltip
+            key={slot.id}
+            content={<window.InfoTooltip kind={slot.label} title={item.name} body={[stat, item.rarity && item.rarity !== "common" ? item.rarity : "", item.attunement ? "Requires attunement" : ""].filter(Boolean).join(" · ") || `Worn in the ${slot.label} slot.`} />}
+            side="top"
+          >
+            <div style={{
+              display: "flex", gap: 8, alignItems: "center",
+              padding: 8,
+              background: "rgba(176,141,87,0.08)",
+              boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)",
+              cursor: "help",
+            }}>
+              {/* Equipped item art — mirror screen-inventory's `item-<slug(name)>` scope (the
+                  engine keys ingested item icons by a name-slug; the surface emits it.name on
+                  each equipped entry). <Img> falls back to a Placeholder on a 404. */}
+              <Img scope={item.name ? "item-" + slug(item.name) : ""} label={item.name || item.glyph} w={32} h={32} fit="contain" framed />
+              <div style={{ minWidth: 0 }}>
+                <div className="eyebrow" style={{ fontSize: 9 }}>{slot.label}</div>
+                <div style={{ fontFamily: "var(--f-display)", fontSize: 11, color: "var(--ink-900)", letterSpacing: "0.05em", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+                  {item.name}
+                </div>
+                {/* Real stat (damage dice / AC) when the catalog resolved it — never faked. */}
+                {stat && <div className="hand muted" style={{ fontSize: 10, lineHeight: 1.1 }}>{stat}</div>}
+              </div>
+            </div>
+          </window.Tooltip>
+        );
+      })}
+    </div>
+  );
+}
+
 function ResourcesStatus({ hero }) {
   // Pull only what the surface actually carries; every value is gated so an absent
   // or zero field renders nothing (no hardcoded fakes).
@@ -704,25 +750,72 @@ function ProficiencyDot({ proficient, expertise }) {
   );
 }
 
+// A small text badge naming a skill's training, paired with the proficiency dots so the
+// marker is unmissable (the bare 7px dot read as decoration to power players). "Expertise"
+// = double proficiency, "Prof" = proficient, nothing for untrained. Values come straight
+// from the read-model's per-skill proficient/expertise flags — never inferred from the mod.
+function ProficiencyBadge({ proficient, expertise }) {
+  if (!proficient && !expertise) return null;
+  const label = expertise ? "Expertise" : "Prof";
+  return (
+    <span className="eyebrow" style={{
+      fontSize: 8, letterSpacing: "0.12em", padding: "1px 5px", flexShrink: 0,
+      color: expertise ? "var(--w-300)" : "var(--ink-800)",
+      background: expertise
+        ? "linear-gradient(180deg, var(--b-300), var(--b-500))"
+        : "rgba(176,141,87,0.22)",
+      boxShadow: expertise
+        ? "inset 0 0 0 1px var(--b-600), 0 0 8px -3px var(--gold-glow)"
+        : "inset 0 0 0 1px rgba(140,100,60,0.45)",
+    }}>{label}</span>
+  );
+}
+
 function SkillsTab({ hero }) {
+  const skills = Array.isArray(hero.skills) ? hero.skills : [];
+  const proficientCount = skills.filter((s) => s.proficient || s.expertise).length;
+  const expertiseCount = skills.filter((s) => s.expertise).length;
   return (
     <div>
-      <SectionTitle ordinal="·">Skills</SectionTitle>
+      <SectionTitle ordinal="·" right={
+        <span className="muted body-sm">
+          {proficientCount} proficient{expertiseCount ? ` · ${expertiseCount} expertise` : ""}
+        </span>
+      }>Skills</SectionTitle>
+      {/* Legend so the marker convention is self-explanatory at a glance. */}
+      <div style={{ display: "flex", gap: 14, alignItems: "center", marginBottom: 8, flexWrap: "wrap" }}>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+          <ProficiencyDot proficient expertise={false} />
+          <span className="muted" style={{ fontSize: 10 }}>Proficient</span>
+        </span>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+          <ProficiencyDot proficient expertise />
+          <span className="muted" style={{ fontSize: 10 }}>Expertise (×2 prof)</span>
+        </span>
+        <span style={{ display: "inline-flex", alignItems: "center", gap: 5 }}>
+          <ProficiencyDot proficient={false} expertise={false} />
+          <span className="muted" style={{ fontSize: 10 }}>Untrained</span>
+        </span>
+      </div>
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 4 }}>
-        {hero.skills.map((s) => (
-          <div key={s.name} style={{
-            display: "flex", justifyContent: "space-between", alignItems: "baseline",
-            padding: "6px 12px",
-            background: (s.proficient || s.mod > 0) ? "rgba(176,141,87,0.1)" : "transparent",
+        {skills.map((s) => (
+          <div key={s.name} title={s.expertise ? "Expertise — double proficiency bonus" : s.proficient ? "Proficient" : "Not proficient"} style={{
+            display: "flex", justifyContent: "space-between", alignItems: "center",
+            padding: "6px 10px 6px 8px",
+            background: (s.proficient || s.expertise) ? "rgba(176,141,87,0.12)" : "transparent",
+            // A gold left-accent bar on trained skills — the second, unmissable cue.
+            borderLeft: s.expertise ? "3px solid var(--b-400)" : s.proficient ? "3px solid rgba(176,141,87,0.7)" : "3px solid transparent",
             boxShadow: "inset 0 -1px 0 rgba(140,100,60,0.15)",
           }}>
-            <span style={{ display: "inline-flex", alignItems: "baseline", gap: 7, minWidth: 0 }}>
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 7, minWidth: 0 }}>
               {/* Proficiency marker (DNDBeyond/BG3 convention): filled gold dot = proficient,
-                  two dots = expertise (double proficiency), hollow = untrained. */}
+                  two dots = expertise (double proficiency), hollow = untrained — paired with a
+                  text badge so power players don't miss it. */}
               <ProficiencyDot proficient={s.proficient} expertise={s.expertise} />
-              <span className="body-sm" style={{ color: s.proficient ? "var(--ink-900)" : "var(--ink-700)" }}>{s.name}</span>
+              <span className="body-sm" style={{ color: (s.proficient || s.expertise) ? "var(--ink-900)" : "var(--ink-700)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{s.name}</span>
+              <ProficiencyBadge proficient={s.proficient} expertise={s.expertise} />
             </span>
-            <span style={{ fontFamily: "var(--f-display)", fontSize: 14, color: s.mod >= 0 ? "var(--ink-900)" : "var(--crimson)" }}>
+            <span style={{ fontFamily: "var(--f-display)", fontSize: 14, color: s.mod >= 0 ? "var(--ink-900)" : "var(--crimson)", flexShrink: 0 }}>
               {s.mod >= 0 ? "+" : ""}{s.mod}
             </span>
           </div>
@@ -740,12 +833,80 @@ function spellGroupLabel(level) {
   return (typeof level === "number" || /^\d+$/.test(String(level))) ? `Level ${level}` : String(level);
 }
 
-// Compose a spell's "school · casting-time" subline, dropping any em-dash / blank placeholder
-// the read-model emits when the school isn't projected (the engine stores spell names, not
-// full SRD blocks) — so we never render the bare "— · prepared".
+// Compose a spell's compact subline. Prefer the REAL SRD level/school the read-model now
+// projects ("Cantrip · Evocation" / "Level 3 · Evocation"); fall back to the prepared/known
+// grouping only when the SRD lookup missed. Drops any em-dash / blank placeholder so we never
+// render the bare "— · prepared".
 function spellMeta(sp) {
   const clean = (v) => { const s = String(v ?? "").trim(); return (s && s !== "—" && s !== "-") ? s : ""; };
+  const lvl = clean(sp.levelLabel);
+  const school = clean(sp.school);
+  if (lvl || school) return [lvl, school].filter(Boolean).join(" · ");
   return [clean(sp.school), clean(sp.time)].filter(Boolean).join(" · ");
+}
+
+// True when the read-model resolved this spell's SRD rules block (so we have something richer
+// than the bare name to show). A catalog-miss spell carries only name + grouping.
+function hasSpellRules(sp) {
+  return Boolean(sp && (sp.range || sp.duration || sp.castingTime || sp.damage || sp.save || sp.desc));
+}
+
+// One labeled rules chip ("Range · 150 feet"). Hidden when the value is blank so a spell that
+// carries only some fields (e.g. a self-buff with no save) never shows empty rows.
+function SpellRuleChip({ label, value }) {
+  const v = String(value ?? "").trim();
+  if (!v || v === "—") return null;
+  return (
+    <div style={{
+      padding: "4px 8px",
+      background: "rgba(176,141,87,0.06)",
+      boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.2)",
+    }}>
+      <span className="eyebrow" style={{ fontSize: 8 }}>{label}</span>
+      <div style={{ fontFamily: "var(--f-display)", fontSize: 12, color: "var(--ink-900)", marginTop: 1 }}>{v}</div>
+    </div>
+  );
+}
+
+// The per-spell rules block: range / casting time / duration / save (with the caster's DC) /
+// damage / components, plus Concentration / Ritual badges and the upcast + description prose.
+// EVERY field is sourced from the engine's real srd524 record via the read-model — a spell the
+// SRD doesn't carry shows nothing here (just its name above). `compact` trims to the headline
+// stat chips for the in-tab card; the full block (with desc + upcast) shows in the browser.
+function SpellRules({ sp, compact }) {
+  if (!hasSpellRules(sp)) return null;
+  const dc = sp.save && (sp.saveDc !== null && sp.saveDc !== undefined)
+    ? `DC ${sp.saveDc} ${String(sp.save).slice(0, 3).toUpperCase()}`
+    : (sp.save ? `${String(sp.save).slice(0, 3).toUpperCase()} save` : "");
+  const dmg = sp.damage ? [sp.damage, sp.damageType].filter(Boolean).join(" ") + (sp.attack ? " (spell attack)" : "") : "";
+  return (
+    <div style={{ marginTop: 6 }}>
+      <div style={{ display: "flex", gap: 6, flexWrap: "wrap", marginBottom: dc || dmg ? 6 : 0 }}>
+        {sp.concentration && <Pill tone="royal" dot>Concentration</Pill>}
+        {sp.ritual && <Pill tone="emerald">Ritual</Pill>}
+      </div>
+      <div style={{ display: "grid", gridTemplateColumns: compact ? "1fr 1fr" : "1fr 1fr 1fr", gap: 4 }}>
+        <SpellRuleChip label="Range" value={sp.range} />
+        <SpellRuleChip label="Cast" value={sp.castingTime} />
+        <SpellRuleChip label="Duration" value={sp.duration} />
+        {dc && <SpellRuleChip label="Save" value={dc} />}
+        {dmg && <SpellRuleChip label="Effect" value={dmg} />}
+        {!compact && <SpellRuleChip label="Components" value={sp.components} />}
+      </div>
+      {!compact && sp.material && (
+        <div className="hand muted" style={{ fontSize: 11, marginTop: 4 }}>Material: {sp.material}</div>
+      )}
+      {!compact && sp.desc && (
+        <p className="body-sm" style={{ marginTop: 8, marginBottom: 0, color: "var(--ink-700)", lineHeight: 1.45 }}>{sp.desc}</p>
+      )}
+      {!compact && sp.higherLevel && (
+        <p className="body-sm muted" style={{ marginTop: 6, marginBottom: 0, lineHeight: 1.4 }}>
+          <span className="eyebrow" style={{ fontSize: 8 }}>At higher levels</span><br />
+          {sp.higherLevel}
+        </p>
+      )}
+    </div>
+  );
 }
 
 function LineagePanel({ hero }) {
@@ -857,17 +1018,22 @@ function SpellsTab({ hero }) {
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
               {group.list.map((sp) => (
                 <div key={sp.name} style={{
-                  display: "flex", gap: 10, padding: 10,
+                  padding: 10,
                   background: "rgba(176,141,87,0.08)",
                   boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)",
                 }}>
-                  <Placeholder label={sp.glyph} w={36} h={36} framed />
-                  <div style={{ minWidth: 0 }}>
-                    <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.08em", color: "var(--ink-900)" }}>
-                      {sp.name}
+                  <div style={{ display: "flex", gap: 10, minWidth: 0 }}>
+                    <Placeholder label={sp.glyph} w={36} h={36} framed />
+                    <div style={{ minWidth: 0 }}>
+                      <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.08em", color: "var(--ink-900)" }}>
+                        {sp.name}
+                      </div>
+                      <div className="body-sm muted">{spellMeta(sp)}</div>
                     </div>
-                    <div className="body-sm muted">{spellMeta(sp)}</div>
                   </div>
+                  {/* Real SRD rules (range / duration / save DC / damage) from the read-model.
+                      Renders nothing for a spell the SRD doesn't carry — never fabricated. */}
+                  <SpellRules sp={sp} compact />
                 </div>
               ))}
             </div>
@@ -935,20 +1101,25 @@ function SpellbookBrowser({ hero, groups, onClose }) {
                 <SectionTitle right={<span className="muted body-sm">{group.list.length}</span>}>
                   {spellGroupLabel(group.level)}
                 </SectionTitle>
-                <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+                <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: 8 }}>
                   {group.list.map((sp) => (
                     <div key={sp.name} style={{
-                      display: "flex", gap: 10, alignItems: "center", padding: 10,
+                      padding: 12,
                       background: "rgba(176,141,87,0.08)",
                       boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)",
                     }}>
-                      <Placeholder label={sp.glyph} w={36} h={36} framed />
-                      <div style={{ minWidth: 0 }}>
-                        <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.08em", color: "var(--ink-900)" }}>
-                          {sp.name}
+                      <div style={{ display: "flex", gap: 10, alignItems: "center", minWidth: 0 }}>
+                        <Placeholder label={sp.glyph} w={36} h={36} framed />
+                        <div style={{ minWidth: 0 }}>
+                          <div style={{ fontFamily: "var(--f-display)", fontSize: 13, letterSpacing: "0.08em", color: "var(--ink-900)" }}>
+                            {sp.name}
+                          </div>
+                          <div className="body-sm muted">{spellMeta(sp)}</div>
                         </div>
-                        <div className="body-sm muted">{spellMeta(sp)}</div>
                       </div>
+                      {/* Full SRD rules block (range / save DC / damage / components / description /
+                          upcast) — all from the engine's real srd524 record via the read-model. */}
+                      <SpellRules sp={sp} />
                     </div>
                   ))}
                 </div>
@@ -992,4 +1163,4 @@ function FeatsTab({ hero }) {
   );
 }
 
-Object.assign(window, { ScreenCharacter, AbilityScore, StatLine, ResourcesStatus, AbilitiesTab, SkillsTab, SpellsTab, SpellbookBrowser, SpellSlotTrack, LineagePanel, FeatsTab, AbilityCard, FeatRow, RestPrepareModal, RestCard, ProficiencyDot, portraitScope, spellMeta });
+Object.assign(window, { ScreenCharacter, AbilityScore, StatLine, ResourcesStatus, HeroEquipDoll, equippedStat, AbilitiesTab, SkillsTab, SpellsTab, SpellbookBrowser, SpellSlotTrack, SpellRules, SpellRuleChip, hasSpellRules, LineagePanel, FeatsTab, AbilityCard, FeatRow, RestPrepareModal, RestCard, ProficiencyDot, ProficiencyBadge, portraitScope, spellMeta });

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -480,14 +480,20 @@ function ItemDetail({ item, hero, toast, canAct, postInvMove }) {
     <div>
       <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
         <Img scope={itemScope(item)} label={item.name} w={72} h={72} framed />
-        <div>
+        <div style={{ minWidth: 0 }}>
           <div className="eyebrow" style={{ color:
             item.type === "rare" ? "var(--royal)" :
             item.type === "quest" ? "var(--crimson)" :
             "var(--ink-600)" }}>
-            {ITEM_TYPES[item.type] || item.type}
+            {/* Prefer the SRD catalog's own classification ("Martial Weapon", "Wondrous") when
+                the read-model resolved it; fall back to the coarse grid type. */}
+            {itemCategory(item)}
           </div>
           <h2 className="h1" style={{ fontSize: 20, lineHeight: 1.1, marginTop: 2 }}>{item.name}</h2>
+          {/* Rarity sits under the name when it is anything beyond the default "common". */}
+          {item.rarity && item.rarity.toLowerCase() !== "common" && (
+            <div className="hand" style={{ fontSize: 13, color: "var(--royal)", marginTop: 2, textTransform: "capitalize" }}>{item.rarity}</div>
+          )}
         </div>
       </div>
 
@@ -497,18 +503,24 @@ function ItemDetail({ item, hero, toast, canAct, postInvMove }) {
         {item.desc}
       </p>
 
+      {/* Stat block — Weight/Value always (catalog-backfilled), plus the REAL combat stats the
+          read-model now surfaces from the SRD item catalog: damage dice + type for weapons, base
+          AC for armor/shields. A field absent from the catalog record is simply not rendered —
+          never a fabricated number (e.g. a free-text "Longsword +1" the catalog can't resolve
+          shows weight/value only, exactly today's behavior). */}
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginTop: 14 }}>
         <StatLine k="Weight" v={item.weight || "—"} />
         <StatLine k="Value" v={item.value || "—"} />
-        <StatLine k="Slot" v={item.slot || "—"} />
-        <StatLine k="Origin" v={item.origin || "Unknown"} />
+        {item.damage && <StatLine k="Damage" v={[item.damage, item.damageType].filter(Boolean).join(" ")} />}
+        {typeof item.ac === "number" && <StatLine k="Armor Class" v={`${item.ac}`} />}
+        {item.attunement && <StatLine k="Attunement" v="Required" />}
       </div>
 
-      {item.properties && (
+      {Array.isArray(item.properties) && item.properties.length > 0 && (
         <>
           <Divider />
           <div className="eyebrow">Properties</div>
-          <div className="tag-row" style={{ marginTop: 6 }}>
+          <div className="tag-row" style={{ marginTop: 6, display: "flex", gap: 6, flexWrap: "wrap" }}>
             {item.properties.map((p) => <Pill key={p}>{p}</Pill>)}
           </div>
         </>
@@ -561,6 +573,21 @@ const ITEM_TYPES = {
   common: "Sundry",
 };
 
+// The SRD catalog `kind` slug -> a readable category label for the item header. When the
+// read-model resolved a catalog record we prefer its real classification (so a relic reads
+// "Wondrous Item", a blade "Weapon"); otherwise we fall back to the coarse grid type label.
+const ITEM_KINDS = {
+  weapon: "Weapon", armor: "Armor", shield: "Shield", wondrous: "Wondrous Item",
+  ring: "Ring", rod: "Rod", staff: "Staff", wand: "Wand", scroll: "Scroll",
+  potion: "Potion", gear: "Adventuring Gear", ammunition: "Ammunition",
+};
+
+function itemCategory(item) {
+  const kind = (item && item.kind ? String(item.kind) : "").toLowerCase();
+  if (kind) return ITEM_KINDS[kind] || (kind.charAt(0).toUpperCase() + kind.slice(1));
+  return ITEM_TYPES[item && item.type] || (item && item.type) || "Item";
+}
+
 function toRoman(n) { return ["", "I", "II", "III", "IV", "V"][n] || n; }
 
-Object.assign(window, { ScreenInventory, CoinSlot, ItemSlot, ItemDetail, EQUIP_SLOTS, PaperDoll, EquipSlotCell, inferEquipSlotId, assignEquipSlots, ITEM_TYPES, toRoman, slug, itemScope });
+Object.assign(window, { ScreenInventory, CoinSlot, ItemSlot, ItemDetail, EQUIP_SLOTS, PaperDoll, EquipSlotCell, inferEquipSlotId, assignEquipSlots, ITEM_TYPES, ITEM_KINDS, itemCategory, toRoman, slug, itemScope });

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3250,6 +3250,39 @@ _SKILL_ABILITIES = {
 _ABILITY_KEYS = ("strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma")
 
 
+def _equipped_items(ch: dict) -> list[dict]:
+    """Projected list of a character's EQUIPPED gear for the heroes-screen paper-doll +
+    the inventory equip slots. Each entry carries name/slot/glyph plus the item's REAL SRD
+    combat stats (kind / damage / damageType / ac / rarity / attunement) when the catalog
+    resolves the name — so the doll's slot tooltip can read "Main Hand · 1d8 slashing"
+    honestly, and stays just the name when the catalog has no record. The engine carries no
+    canonical slot on the Item model, so `slot` is whatever the snapshot recorded (else "Worn");
+    the screen's name->slot inference places it in the doll cell (forward-compatible if the
+    engine ever emits a real slot id)."""
+    out: list[dict] = []
+    for it in (ch.get("inventory") or []):
+        if not isinstance(it, dict) or not bool(it.get("equipped")):
+            continue
+        name = _text(it.get("name"))
+        if not name:
+            continue
+        meta = _catalog_meta(name)
+        damage = _text(meta.get("damage")) if meta else ""
+        ac_raw = meta.get("ac") if meta else None
+        out.append({
+            "slot": _text(it.get("slot"), "Worn"),
+            "name": name,
+            "glyph": name.lower(),
+            "kind": _text(meta.get("kind")) if meta else "",
+            "damage": damage,
+            "damageType": _text(meta.get("damage_type")) if (meta and damage) else "",
+            "ac": int(ac_raw) if isinstance(ac_raw, (int, float)) else None,
+            "rarity": (_text(it.get("rarity")) or (_text(meta.get("rarity")) if meta else "")) or "",
+            "attunement": bool(it.get("requires_attunement") or (meta.get("requires_attunement") if meta else False)),
+        })
+    return out
+
+
 def _character_sheet(cid: str, ch: dict) -> dict:
     """One party character's full sheet for the heroes screen, mapping 5e snapshot fields
     into the shape screen-character.jsx renders (stats block, skills, spells, class
@@ -3304,32 +3337,29 @@ def _character_sheet(cid: str, ch: dict) -> dict:
         for sk in skill_ids if sk in _SKILL_ABILITIES
     ]
 
-    # Spells: the snapshot stores spell NAMES only (no per-spell level/school blocks), so
-    # we render the names the engine actually carries — never fabricating. Prepared spells
-    # are the union of spells_prepared and spells_known marked prepared; we surface the full
-    # known/prepared list grouped under "Prepared" / "Known" so a caster with spells SHOWS
-    # them and a caster with none shows an honest empty list (the SpellsTab fallback).
+    # Spells: the snapshot stores spell NAMES only, but the engine bundles the full srd524
+    # spell dump — so for each known/prepared spell we look up its REAL rules block (level,
+    # school, range, casting time, duration, concentration, save ability, damage, components,
+    # upcast, desc) via `_spell_card`. A spell the SRD doesn't carry degrades to just its name
+    # (today's behavior). The per-spell save DC is the caster's computed DC (None for a non-
+    # caster class), surfaced only for save-forcing spells. We group under "Prepared"/"Known"
+    # so the distinction stays honest; a caster with none shows an honest empty list.
     spells_known = [s for s in (ch.get("spells_known") or []) if isinstance(s, str)]
     prepared_list = [s for s in (ch.get("spells_prepared") or []) if isinstance(s, str)]
     spells_prepared = set(prepared_list)
+    save_dc = _spell_save_dc(ch)
     spells = []
     if prepared_list:
         spells.append({
             "level": "Prepared",
-            "list": [
-                {"name": s, "school": "—", "time": "prepared", "glyph": "spell"}
-                for s in prepared_list
-            ],
+            "list": [_spell_card(s, "prepared", save_dc) for s in prepared_list],
         })
     # Known-but-not-prepared spells get their own group so the distinction stays honest.
     known_only = [s for s in spells_known if s not in spells_prepared]
     if known_only:
         spells.append({
             "level": "Known",
-            "list": [
-                {"name": s, "school": "—", "time": "known", "glyph": "spell"}
-                for s in known_only
-            ],
+            "list": [_spell_card(s, "known", save_dc) for s in known_only],
         })
 
     # Spell slots: the engine owns ch.spell_slots {level: {maximum, used}}. Surface the
@@ -3393,10 +3423,7 @@ def _character_sheet(cid: str, ch: dict) -> dict:
             fname = seg.split(":", 1)[1].strip()
             if fname and fname not in feat_names:
                 feat_names.append(fname)
-    equipped = [
-        {"slot": _text(it.get("slot"), "Worn"), "name": _text(it.get("name")), "glyph": _text(it.get("name"), "item").lower()}
-        for it in (ch.get("inventory") or []) if isinstance(it, dict) and bool(it.get("equipped")) and _text(it.get("name"))
-    ]
+    equipped = _equipped_items(ch)
 
     return {
         "id": cid,
@@ -3522,6 +3549,124 @@ def _infer_item_type(name: str, item: dict) -> str:
 
 _ITEMCATALOG = None
 _ITEMCATALOG_TRIED = False
+_SPELLS_MOD = None
+_SPELLS_TRIED = False
+
+
+def _engine_module(modname: str):
+    """Lazily import a pure engine helper module (itemcatalog / spells) so the viewer can
+    enrich the read-model with the engine's REAL bundled SRD data. Returns the module or
+    None; on None the surface degrades to today's behavior (the viewer stays a pure reader,
+    never fabricating). Adds servers/engine to sys.path once (same pattern as _catalog_meta)."""
+    try:
+        engine_dir = (_HERE.parent / "servers" / "engine").resolve()
+        if str(engine_dir) not in sys.path:
+            sys.path.insert(0, str(engine_dir))
+        return __import__(modname)
+    except Exception:
+        return None
+
+
+def _spell_meta(name: str) -> dict:
+    """Lazily resolve a spell's structured SRD record (level / school / range / duration /
+    concentration / ritual / save ability / damage / components / upcast / desc) from the
+    engine's bundled srd524 dump via ``spells.srd_spell``. Returns {} when the spell isn't
+    in the SRD (an honest miss -> the screen shows just the name, today's behavior). The
+    viewer never invents spell rules text — it only surfaces what the engine already owns."""
+    global _SPELLS_MOD, _SPELLS_TRIED
+    if not name:
+        return {}
+    if _SPELLS_MOD is None and not _SPELLS_TRIED:
+        _SPELLS_TRIED = True
+        _SPELLS_MOD = _engine_module("spells")
+    if _SPELLS_MOD is None:
+        return {}
+    try:
+        return _SPELLS_MOD.srd_spell(name) or {}
+    except Exception:
+        return {}
+
+
+# Casting ability per SRD class (mirror of srd_tables._CASTING_ABILITY). A character's spell
+# save DC / attack bonus key off their FIRST caster class's ability mod (engine _casting_mod).
+# Non-caster classes (Fighter/Rogue/etc.) are absent -> no DC is computed (we never fabricate
+# one; the per-spell `save` still names which save the TARGET rolls, which is class-independent).
+_CASTING_ABILITY = {
+    "bard": "charisma", "cleric": "wisdom", "druid": "wisdom", "paladin": "charisma",
+    "ranger": "wisdom", "sorcerer": "charisma", "warlock": "charisma", "wizard": "intelligence",
+}
+
+
+def _spell_save_dc(ch: dict) -> int | None:
+    """A caster's spell save DC = 8 + proficiency + casting-ability modifier, mirroring
+    engine ``server.spell_save_dc`` read-only from the snapshot. Returns None when the
+    character has no SRD caster class (a Fighter with stray spell names, an NPC) — we then
+    omit the DC rather than invent one. Honest: reads only engine-set abilities/prof."""
+    classes = ch.get("classes") if isinstance(ch.get("classes"), list) else []
+    ability = None
+    for cl in classes:
+        if isinstance(cl, dict):
+            a = _CASTING_ABILITY.get(_text(cl.get("name")).lower())
+            if a:
+                ability = a
+                break
+    if ability is None:
+        return None
+    abilities = ch.get("abilities") if isinstance(ch.get("abilities"), dict) else {}
+    prof = _num(ch.get("proficiency_bonus"))
+    prof = int(prof) if prof is not None else 2
+    return 8 + prof + _ability_mod(abilities.get(ability))
+
+
+def _spell_card(name: str, time_label: str, save_dc: int | None) -> dict:
+    """One spell's render card for the heroes screen: the name plus the engine's REAL SRD
+    rules fields (level / school / range / casting time / duration / components / save / damage)
+    when the spell resolves in srd524, and just the name (today's behavior) when it doesn't.
+
+    `time_label` is the engine-derived prepared/known grouping. `save_dc` is the caster's
+    computed DC (None for non-casters) — surfaced ONLY for spells that force a save, so the
+    inspector can show "DC 15 DEX" honestly. Never fabricates a field the SRD record lacks."""
+    meta = _spell_meta(name)
+    card = {"name": name, "school": "—", "time": time_label, "glyph": "spell"}
+    if not meta:
+        return card
+    school = _text(meta.get("school"))
+    level_raw = meta.get("level")
+    level = int(level_raw) if isinstance(level_raw, (int, float)) else None
+    rng = _text(meta.get("range_text"))
+    casting_time = _text(meta.get("casting_time"))
+    duration = _text(meta.get("duration"))
+    concentration = bool(meta.get("concentration"))
+    ritual = bool(meta.get("ritual"))
+    save_ability = _text(meta.get("saving_throw_ability"))
+    attack_roll = bool(meta.get("attack_roll"))
+    damage = _text(meta.get("damage_roll"))
+    dtypes = [_text(t) for t in (meta.get("damage_types") or []) if _text(t)]
+    # Components V/S/M -> a compact "V, S, M" string (only the ones present).
+    comp = [c for c, on in (("V", meta.get("verbal")), ("S", meta.get("somatic")), ("M", meta.get("material"))) if on]
+    card.update({
+        "school": school.title() if school else "—",
+        "level": level,
+        # "Cantrip" reads better than "Level 0" for a 0-level spell.
+        "levelLabel": "Cantrip" if level == 0 else (f"Level {level}" if level is not None else ""),
+        "range": rng,
+        "castingTime": casting_time,
+        "duration": duration,
+        "concentration": concentration,
+        "ritual": ritual,
+        "components": ", ".join(comp),
+        "material": _text(meta.get("material_specified")),
+        # save: which ability the TARGET rolls (class-independent SRD fact). saveDc: the
+        # caster's DC (omitted when the character isn't a caster, or the spell forces no save).
+        "save": save_ability,
+        "saveDc": save_dc if (save_ability and save_dc is not None) else None,
+        "attack": attack_roll,
+        "damage": damage,
+        "damageType": ", ".join(dtypes),
+        "higherLevel": _text(meta.get("higher_level")),
+        "desc": _text(meta.get("desc")),
+    })
+    return card
 
 
 def _catalog_meta(name: str) -> dict:
@@ -3533,20 +3678,34 @@ def _catalog_meta(name: str) -> dict:
         return {}
     if _ITEMCATALOG is None and not _ITEMCATALOG_TRIED:
         _ITEMCATALOG_TRIED = True
-        try:
-            engine_dir = (_HERE.parent / "servers" / "engine").resolve()
-            if str(engine_dir) not in sys.path:
-                sys.path.insert(0, str(engine_dir))
-            import itemcatalog as _ic  # type: ignore
-            _ITEMCATALOG = _ic
-        except Exception:
-            _ITEMCATALOG = None
+        _ITEMCATALOG = _engine_module("itemcatalog")
     if _ITEMCATALOG is None:
         return {}
     try:
         return _ITEMCATALOG.resolve(name) or {}
     except Exception:
         return {}
+
+
+# Weapon-property slugs the SRD catalog stamps on a Weapon record (`is_simple` ->
+# "simple", `is_improvised` -> "improvised") and the attunement clause it stamps on a
+# MagicItem ("attune:<detail>"). Rendered verbatim as pills; the leading "attune:" is
+# stripped at display so the chip reads "Requires attunement (...)" cleanly.
+def _catalog_property_chips(meta: dict) -> list[str]:
+    """Human-readable property chips for an item from its SRD catalog record. Surfaces
+    ONLY the real, item-specific data the catalog carries (weapon simple/improvised flags,
+    the attunement clause). Never invents a property the catalog didn't stamp."""
+    chips: list[str] = []
+    for p in (meta.get("properties") or []):
+        s = _text(p)
+        if not s:
+            continue
+        if s.startswith("attune:"):
+            detail = s.split(":", 1)[1].strip()
+            chips.append(f"Attunement: {detail}" if detail else "Requires attunement")
+        else:
+            chips.append(s.replace("-", " "))
+    return chips
 
 
 def _inventory_items(cid: str, ch: dict) -> list[dict]:
@@ -3564,32 +3723,59 @@ def _inventory_items(cid: str, ch: dict) -> list[dict]:
         weight = _num(item.get("weight"))
         cost = _num(item.get("cost"))
         rarity = _text(item.get("rarity"))
-        # Backfill weight/value/rarity from the SRD catalog when the granted item omits them
-        # (engine stays the source of truth; this is display-only enrichment for the reader).
-        if (weight is None or weight <= 0) or (cost is None or cost <= 0) or not rarity:
-            meta = _catalog_meta(name)
-            if meta:
-                if weight is None or weight <= 0:
-                    weight = _num(meta.get("weight"))
-                if cost is None or cost <= 0:
-                    cost = _num(meta.get("cost"))
-                if not rarity:
-                    rarity = _text(meta.get("rarity"))
+        # Resolve the SRD catalog record ONCE. It is the source of the item's stat block
+        # (damage dice / damage type / base AC / weapon properties / attunement clause) and
+        # also backfills weight/value/rarity the granted item omits. The engine stays the
+        # source of truth — a granted item's own value always wins; the catalog only fills
+        # gaps and supplies combat stats the Item model has no field for. A name the catalog
+        # can't resolve (e.g. "Longsword +1", "Healing Potion") yields {} -> the stat fields
+        # stay empty exactly as today (HONEST: never fabricate a number the engine lacks).
+        meta = _catalog_meta(name)
+        if meta:
+            if weight is None or weight <= 0:
+                weight = _num(meta.get("weight"))
+            if cost is None or cost <= 0:
+                cost = _num(meta.get("cost"))
+            if not rarity:
+                rarity = _text(meta.get("rarity"))
+        # Damage / AC: real catalog stats. Damage type is only meaningful with a dice expr.
+        damage = _text(meta.get("damage")) if meta else ""
+        damage_type = _text(meta.get("damage_type")) if (meta and damage) else ""
+        ac_raw = meta.get("ac") if meta else None
+        ac = int(ac_raw) if isinstance(ac_raw, (int, float)) else None
+        # Catalog `kind` ("weapon"/"armor"/"wondrous"/"potion"/"ring"/…) is the SRD's own
+        # classification; carry it through as the item's category alongside the coarse `type`
+        # the grid filters on (so the detail can read "Martial Weapon" / "Wondrous Item").
+        kind = _text(meta.get("kind")) if meta else ""
+        attunement = bool(item.get("requires_attunement") or (meta.get("requires_attunement") if meta else False))
+        # Property chips: the granted item's recorded "attuned" state first, then the catalog's
+        # real per-item properties (weapon simple/improvised, attunement clause). De-duped, no fab.
+        properties = ["Attuned"] if item.get("attuned") else []
+        for chip in (_catalog_property_chips(meta) if meta else []):
+            if chip not in properties:
+                properties.append(chip)
         out.append({
             "id": f"{cid}:{idx}:{name}",
             "owner": cid,
             "name": name,
             "qty": int(qty) if qty is not None else 1,
             "type": _infer_item_type(name, item),
+            "kind": kind,
             "glyph": _text(item.get("glyph"), name.lower()),
             "equipped": bool(item.get("equipped")),
             "weight": f"{weight:g} lb" if weight is not None and weight > 0 else "—",
             "value": f"{cost:g} gp" if cost is not None and cost > 0 else "—",
             "rarity": rarity or "common",
             "desc": _text(item.get("description"), "No description recorded."),
-            "attunement": bool(item.get("requires_attunement")),
+            # Combat stat block (empty string / None when the catalog has no such datum —
+            # the screen hides each row that is blank). damage e.g. "1d8", damageType "slashing",
+            # ac e.g. 18 (base AC for armor / shields).
+            "damage": damage,
+            "damageType": damage_type,
+            "ac": ac,
+            "attunement": attunement,
             "attuned": bool(item.get("attuned")),
-            "properties": [p for p in (["attuned"] if item.get("attuned") else []) ],
+            "properties": properties,
         })
     return out
 
@@ -3621,10 +3807,7 @@ def _inventory_party(snapshot: dict) -> list[dict]:
             "level": level or 1,
             "alignment": _text(ch.get("alignment"), "Unaligned"),
             "currency": _currency_for(ch),
-            "equipped": [
-                {"slot": _text(it.get("slot"), "Worn"), "name": _text(it.get("name")), "glyph": _text(it.get("name"), "item").lower()}
-                for it in (ch.get("inventory") or []) if isinstance(it, dict) and bool(it.get("equipped")) and _text(it.get("name"))
-            ],
+            "equipped": _equipped_items(ch),
             "items": items,
         })
     return out

--- a/viewer/tests/test_readmodel_surfaces.py
+++ b/viewer/tests/test_readmodel_surfaces.py
@@ -381,6 +381,97 @@ class ReadModelSurfaceTests(unittest.TestCase):
         self.assertTrue(any(r["id"] == "second_wind" for r in hero["classResources"]))
         self.assert_no_private_keys(surface)
 
+    def test_character_surface_marks_skill_proficiency_expertise_and_untrained(self):
+        # Inspector-depth (optimizer/veteran): every skill carries explicit proficient/expertise
+        # flags so the Skills tab can mark trained vs untrained — not just a raw modifier.
+        self._write("camp_marches", _SNAPSHOT)
+        _status, surface = self._get_json("/character-surface?campaign=camp_marches")
+        hero = {c["id"]: c for c in surface["party"]}["cassian"]
+        skills = {s["name"]: s for s in hero["skills"]}
+        # expertise (persuasion): both flags true, double-proficiency mod
+        self.assertTrue(skills["Persuasion"]["proficient"])
+        self.assertTrue(skills["Persuasion"]["expertise"])
+        # proficient-only (athletics): STR +3 mod + 2 prof = +5, expertise false
+        self.assertTrue(skills["Athletics"]["proficient"])
+        self.assertFalse(skills["Athletics"]["expertise"])
+        self.assertEqual(skills["Athletics"]["mod"], 5)
+        # untrained (stealth): neither flag; DEX +1 mod, no proficiency
+        self.assertFalse(skills["Stealth"]["proficient"])
+        self.assertFalse(skills["Stealth"]["expertise"])
+        self.assertEqual(skills["Stealth"]["mod"], 1)
+
+    def test_character_surface_spell_rules_text_for_a_real_caster(self):
+        # Inspector-depth bug #3: each known/prepared spell carries its REAL srd524 rules block
+        # (level/school/range/duration/concentration/save/damage), and the caster's spell save DC
+        # is computed (8 + prof + casting mod) for save-forcing spells. A Wizard (INT caster).
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["party"].append("elara")
+        snap["characters"]["elara"] = {
+            "id": "elara", "name": "Elara", "kind": "player", "race": "Elf",
+            "classes": [{"name": "Wizard", "level": 5}],
+            "abilities": {"intelligence": 18, "dexterity": 14, "constitution": 12},
+            "proficiency_bonus": 3, "armor_class": 12, "max_hp": 22, "current_hp": 22,
+            "spells_known": ["Fire Bolt", "Magic Missile"], "spells_prepared": ["Fireball"],
+            "spell_slots": {"3": {"maximum": 2, "used": 0}},
+        }
+        self._write("camp_caster", snap)
+        _status, surface = self._get_json("/character-surface?campaign=camp_caster")
+        elara = {c["id"]: c for c in surface["party"]}["elara"]
+        by_name = {sp["name"]: sp for grp in elara["spells"] for sp in grp["list"]}
+        # Fireball: L3 evocation, 150-foot range, DEX save, 8d6, DC = 8 + 3 prof + 4 INT = 15
+        fb = by_name["Fireball"]
+        self.assertEqual(fb["level"], 3)
+        self.assertEqual(fb["school"], "Evocation")
+        self.assertEqual(fb["range"], "150 feet")
+        self.assertEqual(fb["save"], "dexterity")
+        self.assertEqual(fb["saveDc"], 15)
+        self.assertEqual(fb["damage"], "8d6")
+        self.assertIn("fire", fb["damageType"])
+        # Fire Bolt: a cantrip (level 0) with an attack roll, no save -> saveDc omitted (None)
+        fbolt = by_name["Fire Bolt"]
+        self.assertEqual(fbolt["level"], 0)
+        self.assertEqual(fbolt["levelLabel"], "Cantrip")
+        self.assertTrue(fbolt["attack"])
+        self.assertIsNone(fbolt["saveDc"])
+        self.assert_no_private_keys(surface)
+
+    def test_character_surface_omits_spell_dc_for_non_caster_but_keeps_rules(self):
+        # HONEST data: Cassian is a Fighter (no SRD caster class), so no spell save DC is
+        # fabricated — but the spell's own rules text (school/range/duration) still resolves,
+        # since those are class-independent SRD facts. Bless (a buff) forces no save anyway.
+        self._write("camp_marches", _SNAPSHOT)
+        _status, surface = self._get_json("/character-surface?campaign=camp_marches")
+        hero = {c["id"]: c for c in surface["party"]}["cassian"]
+        by_name = {sp["name"]: sp for grp in hero["spells"] for sp in grp["list"]}
+        self.assertEqual(by_name["Bless"]["school"], "Enchantment")
+        self.assertEqual(by_name["Bless"]["range"], "30 feet")
+        self.assertTrue(by_name["Bless"]["concentration"])
+        self.assertIsNone(by_name["Bless"]["saveDc"])  # Fighter -> no DC, not fabricated
+        self.assertEqual(by_name["Shield"]["school"], "Abjuration")
+
+    def test_character_surface_unknown_spell_degrades_to_name_only(self):
+        # A spell name the SRD doesn't carry surfaces as just its name (today's behavior) —
+        # the read-model never invents rules text it doesn't have.
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["characters"]["cassian"]["spells_prepared"] = ["Totally Made Up Spell"]
+        self._write("camp_unknown", snap)
+        _status, surface = self._get_json("/character-surface?campaign=camp_unknown")
+        hero = {c["id"]: c for c in surface["party"]}["cassian"]
+        sp = next(s for grp in hero["spells"] for s in grp["list"] if s["name"] == "Totally Made Up Spell")
+        self.assertEqual(sp["school"], "—")
+        self.assertNotIn("range", sp)  # no SRD block was merged in
+
+    def test_character_surface_equipped_carries_real_catalog_stats(self):
+        # Inspector-depth bug #2 backing: the heroes-screen paper-doll gets each equipped item's
+        # real catalog stats (kind / damage / ac) so a slot tooltip can read "1d8 piercing".
+        self._write("camp_marches", _SNAPSHOT)
+        _status, surface = self._get_json("/character-surface?campaign=camp_marches")
+        mira = {c["id"]: c for c in surface["party"]}["mira"]
+        rapier = next(e for e in mira["equipped"] if e["name"] == "Rapier")
+        self.assertEqual(rapier["kind"], "weapon")
+        self.assertEqual(rapier["damage"], "1d8")
+        self.assertEqual(rapier["damageType"], "piercing")
+
     # ── inventory ───────────────────────────────────────────────────────────────
 
     def test_inventory_surface_projects_packs_and_currency(self):
@@ -399,6 +490,49 @@ class ReadModelSurfaceTests(unittest.TestCase):
         # the flat shared-stash view spans every party member's items
         self.assertTrue(len(surface["stash"]) >= len(cassian["items"]))
         self.assert_no_private_keys(surface)
+
+    def test_inventory_surface_surfaces_real_item_stats_from_catalog(self):
+        # Inspector-depth bug #4: an item the SRD catalog resolves carries its real stat block
+        # (damage dice / type for a weapon, base AC for armor). Mira's Rapier resolves to 1d8
+        # piercing; a Plate Armor resolves to AC 18 — straight from the engine's item catalog.
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["characters"]["mira"]["inventory"].append(
+            {"name": "Plate Armor", "quantity": 1, "equipped": False})
+        self._write("camp_marches", snap)
+        _status, surface = self._get_json("/inventory-surface?campaign=camp_marches")
+        mira = {m["id"]: m for m in surface["party"]}["mira"]
+        items = {i["name"]: i for i in mira["items"]}
+        self.assertEqual(items["Rapier"]["damage"], "1d8")
+        self.assertEqual(items["Rapier"]["damageType"], "piercing")
+        self.assertEqual(items["Rapier"]["kind"], "weapon")
+        self.assertEqual(items["Plate Armor"]["ac"], 18)
+        self.assertEqual(items["Plate Armor"]["kind"], "armor")
+
+    def test_inventory_surface_unresolved_item_keeps_empty_stats(self):
+        # HONEST data: a free-text item the catalog can't resolve ("Longsword +1", "Healing
+        # Potion") surfaces NO fabricated damage/ac — empty stat fields, exactly today's
+        # behavior. We never invent a number the engine didn't produce.
+        self._write("camp_marches", _SNAPSHOT)
+        _status, surface = self._get_json("/inventory-surface?campaign=camp_marches")
+        cassian = {m["id"]: m for m in surface["party"]}["cassian"]
+        items = {i["name"]: i for i in cassian["items"]}
+        self.assertEqual(items["Longsword +1"]["damage"], "")
+        self.assertIsNone(items["Longsword +1"]["ac"])
+        self.assertEqual(items["Healing Potion"]["damage"], "")
+        self.assertIsNone(items["Healing Potion"]["ac"])
+
+    def test_inventory_surface_item_properties_include_attunement(self):
+        # An attuned magic item surfaces an "Attuned" property chip; a catalog item that
+        # requires attunement carries the attunement flag for the detail's stat block.
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["characters"]["cassian"]["inventory"].append(
+            {"name": "Cloak of Protection", "quantity": 1, "requires_attunement": True, "attuned": True})
+        self._write("camp_attune", snap)
+        _status, surface = self._get_json("/inventory-surface?campaign=camp_attune")
+        cassian = {m["id"]: m for m in surface["party"]}["cassian"]
+        cloak = {i["name"]: i for i in cassian["items"]}["Cloak of Protection"]
+        self.assertTrue(cloak["attunement"])
+        self.assertIn("Attuned", cloak["properties"])
 
     # ── relations ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Why
The 5-persona built-app sweep capped the two power personas — **optimizer 5/10, veteran 6/10** (both completed the session, no give-up, just rated low) — on **data depth**: the inspector UI didn't *show* the real data the engine already has. This PR surfaces and displays that real data.

**Principle: HONEST data only.** Every field is sourced from the engine's bundled SRD data (proficiencies on the character sheet, `servers/engine/itemcatalog.py` for items, `data/srd/srd524/Spell.json` via `spells.srd_spell` for spells). A catalog/SRD miss degrades to today's behavior (empty/name-only) — **no fabricated numbers**. Additive throughout (empty/missing data == current behavior).

Files touched (only these): `viewer/server.py`, `viewer/openworlds/screen-character.jsx`, `viewer/openworlds/screen-inventory.jsx`, plus additive tests in `viewer/tests/test_readmodel_surfaces.py`.

## The 4 bugs — what was surfaced + displayed

### 1. Skills tab had no proficiency/expertise markers (optimizer + veteran)
- **Read-model:** already emitted `proficient` / `expertise` per skill — **no change needed** (the data was already exposed).
- **Display (`screen-character.jsx` SkillsTab):** the existing 7px proficiency dot was being missed by power players. Made the marker **unmissable** — dot **+** a text badge (`Prof` / `Expertise`) + a gold left-accent bar on trained skills + a legend + a "N proficient · M expertise" count. Untrained skills read plainly.

### 2. No equipment paper-doll (veteran)
- The **inventory** screen already had a full slotted paper-doll (#271); the **character** screen's "Equipped" block was a flat `Worn` list.
- **Read-model:** added a shared `_equipped_items` helper carrying each equipped item's real catalog stats (kind / damage / damageType / AC / rarity / attunement).
- **Display (`screen-character.jsx`):** replaced the flat list with a **slotted paper-doll** (`HeroEquipDoll`) that *reuses the inventory screen's canonical slot set + assignment* (`window.EQUIP_SLOTS` / `window.assignEquipSlots` — no second mechanism), with each cell showing the item's real stat (e.g. `1d8 piercing`, `AC 18`) in caption + tooltip.

### 3. Spell inspector was a flat name-list — no rules text (optimizer)
- **Read-model (extended):** the snapshot stores spell *names* only — so each known/prepared spell now resolves its **real srd524 rules block** via `spells.srd_spell`: level, school, range, casting time, duration, concentration, ritual, save ability, **caster's computed save DC** (`8 + prof + casting-mod`, mirroring engine `spell_save_dc`; **omitted — not faked — for a non-caster class**), attack flag, damage dice/type, V/S/M components, material, upcast text, description.
- **Display:** `SpellsTab` cards show a compact rules block (range / cast / duration / save DC / damage); the Spellbook browser shows the **full** block + description + "at higher levels". An SRD-miss spell shows just its name (today's behavior).

### 4. Item Properties field was blank (optimizer)
- **Read-model (extended):** `_inventory_items` now surfaces the real `itemcatalog.resolve` stat block it was previously dropping — **damage dice + type** (weapons), **base AC** (armor/shields), SRD `kind`/category, attunement, and weapon/attunement **property chips** — alongside the existing weight/value/rarity backfill.
- **Display (`screen-inventory.jsx` ItemDetail):** Properties is no longer blank — renders Damage, Armor Class, attunement, SRD category, rarity, and property chips. (Removed the always-"Unknown" Origin / "—" Slot noise rows.) A free-text item the catalog can't resolve (e.g. `Longsword +1`, `Healing Potion`) shows weight/value only — honest, no fabricated damage.

## Read-model vs display, per bug (honest accounting)
| Bug | Data already exposed? | Action |
|---|---|---|
| 1 — skills proficiency | **Yes** (`proficient`/`expertise` already emitted) | Display only — made the marker unmissable |
| 2 — paper-doll | Partly (equipped names emitted) | Extended read-model (per-item catalog stats) + new slotted doll on the character screen |
| 3 — spell rules | **No** | Extended read-model (full srd524 block + computed DC) + display |
| 4 — item properties | **No** (catalog damage/AC/properties were dropped) | Extended read-model (surface the dropped stats) + display |

This matches the #272 triage note: the viewer read-models had the *access* but weren't *emitting* item damage/properties or spell rules.

## Tests
+8 additive cases in `viewer/tests/test_readmodel_surfaces.py`:
- spell rules + computed DC for a real caster (Wizard → Fireball DC 15 DEX, 8d6 fire);
- DC **omitted** for a non-caster (Fighter with stray spells) while rules text still resolves;
- unknown spell → name-only degrade;
- skill proficient / expertise / untrained flags;
- equipped items carry real catalog stats;
- item damage / AC / attunement surfaced; unresolved item → empty stats (no fabrication).

Existing surface tests stay green (30 pass in `test_readmodel_surfaces.py`; the full viewer suite is green locally except one pre-existing `test_portrait_gen` case that needs `pydantic`, unrelated to this change). Both JSX files transpile clean (Babel React preset). **Heavy local tests deferred to CI in the cloud.**

## Deferred
The **5th** sweep finding — **no level-up / ASI / subclass-choice screen** — is a larger new interactive flow (needs an engine write-lane + multi-step modal), so it is **filed as a follow-up, not built here: #397**.

---
**Do NOT close on merge — verify on the next 5-persona sweep (optimizer/veteran ≥7).**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual paper-doll equipment layout displaying items by slot with combat stats and tooltips.
  * Skills tab now shows proficiency and expertise badges with counts in the header.
  * Spells display comprehensive SRD rules details with optional compact and full views.

* **Improvements**
  * Item display improved with catalog-driven categorization and combat-relevant stats (damage, AC, attunement).
  * Spell cards redesigned to single-column layout with integrated rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->