### PR TITLE
ci: run viewer/tests in CI (close the viewer-coverage gap)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,42 @@ jobs:
       - name: Voice tests (torch-free; null backend + static metadata)
         run: uv run --directory servers/voice --group dev pytest -q
 
+  viewer-tests:
+    # The viewer is where most recent regressions landed, but its suite was not in
+    # CI (three viewer PRs each had to caveat "verified locally"). This job runs the
+    # whole viewer/tests/ suite, single-process, on push + PR so viewer regressions
+    # are caught in CI like the engine/rules/voice suites.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Install Node (for the JSX behaviour harness)
+        # A subset of viewer tests transpile the real .jsx through the VENDORED
+        # babel-standalone (viewer/openworlds/vendor/) and run it under node's `vm`.
+        # Babel is vendored and the harness only requires node built-ins (fs, vm), so
+        # NO `npm install` is needed — just a node binary on PATH. Without node these
+        # tests `skipIf` themselves; we install it so they actually RUN in CI.
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Create + activate a venv with the viewer test deps
+        # Most viewer tests import viewer/server.py (stdlib-only at import time) and need
+        # no third-party deps. The exception is test_portrait_gen's real-subprocess test,
+        # which shells the engine via `uv run --directory servers/engine --no-project`
+        # (a bare interpreter) to prove the null image provider opens no socket. That
+        # child resolves the ACTIVE venv, so installing pydantic (the engine's runtime
+        # dep, declared in servers/engine/pyproject.toml) here lets the engine subprocess
+        # import `store`/`imagegen` and the test runs instead of erroring on import.
+        run: |
+          uv venv .venv-viewer --python 3.12
+          echo "VIRTUAL_ENV=$PWD/.venv-viewer" >> "$GITHUB_ENV"
+          echo "$PWD/.venv-viewer/bin" >> "$GITHUB_PATH"
+          uv pip install --python .venv-viewer pydantic pytest
+      - name: Viewer tests (single-process; JSX harness via node + vendored babel)
+        # -p no:xdist keeps this single-process (no parallel workers) — lean by design.
+        run: python -m pytest viewer/tests -q -p no:xdist
+
   license-check:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Why

The viewer is where most recent regressions landed, yet `viewer/tests/` was **not run by CI**. CI ran only `servers/engine` + `servers/rules` + `servers/voice` pytest + `scripts/license_check.py`. Three recent viewer PRs each had to caveat *"viewer tests not in CI — verified locally"* (e.g. #402), so viewer regressions could slip through. This closes that gap.

## What this adds

A new **`viewer-tests`** job in `.github/workflows/ci.yml` that runs the **entire `viewer/tests/` suite on push + PR, single-process**. CI-config + env only — **no engine/viewer/skill source touched, no wire contracts touched.**

The setup mirrors the existing `test` job (`actions/checkout` + `astral-sh/setup-uv`) and adds exactly what the viewer suite genuinely needs:

- **`actions/setup-node@v4`** — a subset of viewer tests (`test_recovery_timing`, `test_live_narration_stream`, `test_combat_event_cards`) are a **real-JSX behaviour harness**: they transpile the actual `.jsx` through the **vendored** `viewer/openworlds/vendor/babel-standalone-7.29.0.min.js` and run it under node's `vm`. Babel is vendored and the harness only `require()`s node built-ins (`fs`, `vm`), so **no `npm install` is needed** — just a `node` binary. Without node these tests `@unittest.skipIf` themselves; installing node makes them **actually run** in CI.
- **A venv with `pydantic` + `pytest`** — see below.

Invocation is single-process: `python -m pytest viewer/tests -q -p no:xdist` (no parallel workers — lean by design).

## How `test_portrait_gen` / deps are handled (the one known local failure)

`viewer/tests/test_portrait_gen.py::PortraitGenRealSubprocessTests::test_null_default_returns_placeholder_no_network` is the test that fails locally on a bare box with `ModuleNotFoundError: No module named 'pydantic'`. Root cause (verified, not guessed):

- The test calls `server._portrait_gen(...)`, which shells the engine via `uv run --directory servers/engine --no-project python -c <snippet>`. `--no-project` deliberately gives a **bare interpreter** (so a wedged gateway can't tie up the viewer thread).
- That snippet does `import imagegen` → `import store` → `from pydantic import ValidationError`. With `--no-project`, pydantic is absent unless it's in the **active** environment. That's the env gap — **not a real defect** (the test's purpose is proving the null image provider opens no socket; the engine side already proves the same in `servers/engine/tests/test_imagegen.py`).

**Fix (no source change, no weakened assertion):** the job creates a venv, exports `VIRTUAL_ENV` + PATH so subsequent steps (and the `uv run --no-project` child) inherit it, and installs `pydantic` — the engine's **declared** runtime dep (`servers/engine/pyproject.toml`: `pydantic>=2.6`). I verified locally that `uv run --no-project` resolves the active venv, so the engine subprocess imports `store`/`imagegen` and the test **runs and passes** rather than erroring on import. No assertion was relaxed; the test does real work.

## Green CI evidence (reproduced locally, single-process)

Baseline on `origin/main` (bare env): `201 ran, 1 failed (test_portrait_gen → ModuleNotFoundError: pydantic), 1 skipped` — matches the caveat in the three viewer PRs.

With this job's setup (node + active venv w/ pydantic), from repo root:
```
$ python -m pytest viewer/tests -q -p no:xdist
200 passed, 1 skipped, 17 subtests passed in ~63s
```

- The JSX/babel-harness tests **run** (node present) and pass.
- `test_portrait_gen` (all 13, incl. the real-subprocess one) **runs and passes** (pydantic present).
- The **1 remaining skip** is `test_roster_surface::test_known_canon_pick_resolves_its_ingested_portrait`, which `skipTest`s when there's *"no ingested `_private` portrait for hartlebury in this checkout."* `_private/` is never committed, so this is correctly skipped in CI too — it's gated on private art, not an env gap, and forcing it to run is out of scope (no public fixture exists).

## Which viewer tests now run in CI vs. remain uncovered

- **Now covered in CI:** the full `viewer/tests/` suite — all 25 test files, including the Python server-route/read-model tests **and** the node/babel JSX-behaviour tests **and** `test_portrait_gen`'s real-engine-subprocess test.
- **Still skipped (by design, not a gap):** the single `test_roster_surface` canon-portrait assertion that requires an ingested `_private` portrait (private content, never committed).

## Notes for the reviewer

- The job runs the suite as `unittest`-style tests under pytest (the suite is `unittest.TestCase` classes); both `python -m unittest discover -s viewer/tests` and `pytest viewer/tests` agree it's green. I used pytest to match the existing `test` job's convention.
- `.venv-viewer` is created only on the CI runner and discarded with the job — nothing is committed.

**Do NOT close on merge — verify on next CI run.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration testing infrastructure with additional automated viewer test suite validation on code pushes and pull requests to improve code quality assurance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->