### PR TITLE
fix(viewer): render chronicle narration exactly once, in order, via a stable key (#405)

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -161,25 +161,58 @@ function useLiveSession(state) {
   const chatCursor = React.useRef(0);
   const eventsCursor = React.useRef(0);                // #393: per-file cursor for the live /events tail
   const dmBeatCountRef = React.useRef(0);
-  // #393: dedup key set shared across BOTH narration sources. The session log streams a turn's
-  // narration mid-flight via /events; the duo/human runner ALSO appends the SAME prose to /chat at
-  // turn-END. Without a shared seen-set the player would see each streamed paragraph twice (once live,
-  // once when the chat line lands). Keyed by normalized narration text so whichever source surfaces a
-  // given paragraph FIRST wins and the later duplicate is dropped. Player echoes are never deduped.
-  const seenNarration = React.useRef(new Set());
+  // #393/#405: dedup key sets across BOTH narration sources. There are TWO key spaces and the
+  // distinction is the whole fix:
+  //   • `seenSeq` — the STABLE session-log line index (`seq`) the server now stamps on every /events
+  //     entry (and on the recentEvents history band). This is the engine's sole-writer per-beat
+  //     identity; it does NOT depend on the prose, so a re-ingest (windowing / a session-rotation
+  //     cursor rewind) of the same line collapses to one row, and it is the chronological sort key.
+  //   • `seenText` — a normalized-TEXT fallback, used ONLY for narration that has NO seq (a /chat-only
+  //     beat: a terse turn that streamed nothing via /events, or the human/native path where /chat is
+  //     the sole source). Text keys are fragile (a reworded reply, or a whole-turn /chat blob vs the
+  //     per-paragraph /events rows, hash differently) — which is exactly why /chat narration is now a
+  //     FALLBACK only and the canonical live source is the seq-keyed /events stream.
+  // #405 root-cause: previously a single text-keyed set reconciled both sources, so the DM rewording
+  // its turn-END reply — or /chat carrying the whole beat as one blob while /events carried N
+  // paragraphs — defeated the dedup and the chronicle showed each beat 3-4× and out of order.
+  const seenSeq = React.useRef(new Set());
+  const seenText = React.useRef(new Set());
+  // #405: did the CURRENT in-flight turn stream any narration via the canonical /events source? When
+  // true, the turn-END /chat DM line is a pure turn-RESOLUTION signal (it clears the pending
+  // indicator) and adds NO narration row — the session log already carried that beat's canonical,
+  // seq-keyed, per-paragraph prose. When the turn streamed NOTHING via /events (a terse turn that
+  // logged no narration, or the human/native path where /chat is the sole source) the /chat copy is
+  // the only source and IS rendered (text-keyed). This is reset each time a /chat DM line resolves a
+  // turn, so the decision is per-TURN, not per-run: a streamed turn 1 followed by a terse turn 2 still
+  // shows turn 2's /chat-only prose. The /events poll always lands a turn's paragraphs before its
+  // turn-END /chat blob (prose is logged DURING the turn; /chat is written only at turn-end, and
+  // /events polls faster), so this flag is reliably set by the time the resolving /chat line arrives.
+  const eventsStreamedThisTurnRef = React.useRef(false);
   const recoveryTimer = React.useRef(null);
   const backstopTimer = React.useRef(null);
 
   // sanitizeNarration lives in screen-table.jsx (loaded first); fall back to identity if absent.
   const sanitize = (txt) => (typeof window.sanitizeNarration === "function" ? window.sanitizeNarration(txt) : (txt || ""));
-  // #393: a stable dedup key for a narration paragraph — whitespace-collapsed + lowercased so the
-  // /events copy and the /chat copy of the same prose hash identically. First-seen returns true (show
-  // it + record the key); a repeat returns false (suppress). Empty/blank text is never recorded.
+  // #405: claim a narration beat by its STABLE session-log `seq` (the server-stamped absolute line
+  // index). First-seen returns true (show it + record the id); any later arrival of the same line —
+  // a windowing re-mount, a session-rotation cursor rewind, or the recentEvents history band
+  // overlapping the live tail — returns false and is suppressed. Keyed by id, so it is immune to the
+  // DM rewording the prose between its streamed copy and its reply.
+  const claimNarrationSeq = React.useCallback((seq) => {
+    if (typeof seq !== "number" || !Number.isFinite(seq)) return false;
+    if (seenSeq.current.has(seq)) return false;
+    seenSeq.current.add(seq);
+    return true;
+  }, []);
+  // #393/#405: the TEXT-key fallback for narration with no seq (a /chat-only beat). Whitespace-
+  // collapsed + lowercased. First-seen returns true; a repeat returns false. Used only when no seq is
+  // available — seq-keyed beats never consult this set, so a reworded /chat copy can't double a beat
+  // that already streamed (that path is gated by eventsStreamedThisTurnRef, below).
   const claimNarration = React.useCallback((txt) => {
     const key = String(txt || "").replace(/\s+/g, " ").trim().toLowerCase();
     if (!key) return false;
-    if (seenNarration.current.has(key)) return false;
-    seenNarration.current.add(key);
+    if (seenText.current.has(key)) return false;
+    seenText.current.add(key);
     return true;
   }, []);
 
@@ -272,7 +305,9 @@ function useLiveSession(state) {
     chatCursor.current = 0;
     eventsCursor.current = 0;          // #393: reset the live /events tail per run
     dmBeatCountRef.current = 0;
-    seenNarration.current = new Set();  // #393: a fresh run shares no dedup keys with the last
+    seenSeq.current = new Set();        // #405: a fresh run shares no seq dedup keys with the last
+    seenText.current = new Set();       // #405: …nor any text-key fallback keys
+    eventsStreamedThisTurnRef.current = false;  // #405: no /events narration streamed for any turn yet
     setChatBeats([]);
     setLog([]);
     clearPending();
@@ -307,9 +342,18 @@ function useLiveSession(state) {
               // time-merges correctly against local player echoes (which share the same counter).
               if (it.role === "player") return { kind: "dialog", who: "You", text: it.text, at: nextLogSeq() };
               dmLineArrived = true;
+              // #405: a /chat DM line is the turn-RESOLUTION signal (it clears the pending indicator
+              // below). It is NOT a second narration row when this run is streaming its prose via the
+              // canonical seq-keyed /events source: the /chat reply is the SAME beat, but as the whole
+              // turn's reply text — often a single blob, and sometimes REWORDED — so rendering it would
+              // duplicate (and mis-order) what already streamed per-paragraph. The session log is the
+              // canonical chronicle; the /chat copy is suppressed here. We ONLY render a /chat DM line
+              // as narration when nothing streamed via /events for this run (a terse turn that logged
+              // no narration, or the human/native path where /chat is the sole source) — text-keyed,
+              // since a chat-only beat has no session-log seq, and there is no /events stream to
+              // collide with in that case.
+              if (eventsStreamedThisTurnRef.current) return null;
               const clean = sanitize(it.text);
-              // #393: drop a turn-END chat beat whose prose already streamed live via /events this
-              // turn (claimNarration is false on a repeat) so the same paragraph isn't shown twice.
               return clean && claimNarration(clean) ? { kind: "narration", text: clean, at: nextLogSeq() } : null;
             })
             .filter(Boolean);
@@ -321,6 +365,10 @@ function useLiveSession(state) {
           if (dmLineArrived) {
             dmBeatCountRef.current += beats.filter((b) => b.kind === "narration").length;
             clearPending();
+            // #405: the turn is over → reset the per-turn "/events streamed" flag so the NEXT turn is
+            // judged on ITS OWN streaming. Without this, a streamed turn would wrongly suppress a
+            // later TERSE turn's /chat-only prose (the flag would stay stuck true for the whole run).
+            eventsStreamedThisTurnRef.current = false;
           }
         }
         if (!cancelled && typeof payload.next === "number") chatCursor.current = payload.next;
@@ -370,7 +418,18 @@ function useLiveSession(state) {
               const kind = (e && (e.kind || e.type)) || "narration";
               if (kind !== "narration" && kind !== "dialogue") return null;
               const clean = sanitize(e && (e.text || e.detail));
-              return clean && claimNarration(clean) ? { kind: "narration", text: clean, at: nextLogSeq() } : null;
+              if (!clean) return null;
+              // #405: dedup by the STABLE session-log `seq` the server stamps on each entry — NOT by
+              // prose. So a paragraph re-ingested by a windowing re-mount or a session-rotation cursor
+              // rewind collapses to one row, and the dedup can't be defeated by a reworded copy. A
+              // legacy entry with no seq (older server) falls back to the text key. The seq doubles as
+              // the chronological order key: `orderSeq` keeps the engine's session-log line order so
+              // live narration can never interleave out of order with the (now-removed) /chat source.
+              const seq = (e && typeof e.seq === "number") ? e.seq : null;
+              const fresh = (seq !== null) ? claimNarrationSeq(seq) : claimNarration(clean);
+              if (!fresh) return null;
+              eventsStreamedThisTurnRef.current = true;  // the current turn HAS streamed live narration
+              return { kind: "narration", text: clean, at: nextLogSeq(), orderSeq: seq };
             })
             .filter(Boolean);
           if (beats.length) {

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -195,6 +195,54 @@ const DECLARE_HINT = "Type what your hero does in your own words, then Declare t
 // Older beats are still available in full in the Quest Journal.
 const CHRONICLE_RENDER_CAP = 50;
 
+// #405: assemble the chronicle's full ordered, de-duplicated row list from its three sources. Pure
+// (no React, no DOM) so the exactly-once + chronological-order contract is unit-testable. The whole
+// narration-duplication fix lives here + in app.jsx's useLiveSession dedup:
+//   • ORDER by the STABLE session-log sequence (`orderSeq` on a live /events beat / `seq` on a
+//     recentEvents row — both = the engine's absolute session-log line index) when present, so the
+//     live tail can never interleave out of chronological order; fall back to the client-side ingest
+//     counter `.at` for rows with no seq (player echoes, a chat-only beat). Array.prototype.sort is
+//     stable (ES2019+), so equal-key rows keep insertion order.
+//   • DEDUP recentEvents (the server's trailing window of the SAME session log the live /events
+//     stream reads) against the live tail so a paragraph never shows in BOTH bands. Prefer the
+//     stable `seq` (a row in both bands shares it → the match is immune to the prose AND to a
+//     windowing re-mount); fall back to a normalized TEXT key only for rows lacking a seq (legacy
+//     server / a chat-only beat), keyed identically to app.jsx's text fallback. Non-narration
+//     history rows (rolls/system/combat) are always kept.
+// recentEvents stay the leading (oldest) band: they are the session log's trailing lines, all at or
+// before the live tail's lines, and the dedup guarantees no overlap — so a plain concat is in order.
+function buildChronicleLog(recentEvents, chatBeats, log) {
+  const recent = Array.isArray(recentEvents) ? recentEvents : [];
+  const beats = Array.isArray(chatBeats) ? chatBeats : [];
+  const echoes = Array.isArray(log) ? log : [];
+  const sanitize = (t) => (typeof window !== "undefined" && typeof window.sanitizeNarration === "function")
+    ? window.sanitizeNarration(t || "") : (t || "");
+  const narrationKey = (t) => sanitize(t || "").replace(/\s+/g, " ").trim().toLowerCase();
+  const orderOf = (e) => (e && typeof e.orderSeq === "number") ? e.orderSeq : null;
+  const mergedTail = [...beats, ...echoes].sort((a, b) => {
+    const sa = orderOf(a), sb = orderOf(b);
+    if (sa !== null && sb !== null) return sa - sb;   // both from the session log → true beat order
+    return (a?.at || 0) - (b?.at || 0);               // else fall back to client ingest order
+  });
+  const liveSeqs = new Set(
+    mergedTail.filter((b) => b && b.kind === "narration" && typeof b.orderSeq === "number").map((b) => b.orderSeq),
+  );
+  const liveNarrationKeys = new Set(
+    mergedTail.filter((b) => b && b.kind === "narration").map((b) => narrationKey(b.text)).filter(Boolean),
+  );
+  const dedupedRecent = recent.filter((row) => {
+    const kind = (row && (row.kind || row.type)) || "narration";
+    if (kind !== "narration" && kind !== "dialogue") return true;  // mechanics rows always kept
+    const seq = row && row.seq;
+    if (typeof seq === "number") return !liveSeqs.has(seq);  // stable-id match (prose-independent)
+    const key = narrationKey(row && (row.text || row.detail));
+    return !key || !liveNarrationKeys.has(key);
+  });
+  return [...dedupedRecent, ...mergedTail];
+}
+// Exposed for tests/devtools introspection (additive — the component calls the local fn directly).
+if (typeof window !== "undefined") window.buildChronicleLog = buildChronicleLog;
+
 function ScreenTable({ onNavigate, state, setState, liveSession }) {
   const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
   const activeCampaign =
@@ -247,33 +295,12 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
   const visibleQuests = quests.filter((q) => !q.status || q.status === "active" || q.status === "open");
   const canAct = Boolean(surface?.can_act);
   const readOnlyReason = blockedActions.find((a) => a.disabled_reason)?.disabled_reason || "read-only surface";
-  // #274: the chronicle merges three sources — recentEvents (engine history), chatBeats (the live
-  // DM/player tail) and log (local optimistic player echoes). A plain concat let a just-typed action
-  // (in `log`) sort ABOVE the older DM prose it answered (in `chatBeats`), because the two live in
-  // separate arrays appended at different times. chatBeats + log carry a shared monotonic `.at`
-  // (stamped client-side in app.jsx at creation/ingest), so a STABLE sort by `.at` restores true
-  // chronological order across both. recentEvents have no `.at` (server history with no client
-  // sequence) and are always the oldest, so they keep their leading position and relative order.
-  // Array.prototype.sort is stable (ES2019+); ties are impossible anyway since the counter is unique.
-  const mergedTail = [...chatBeats, ...log].sort((a, b) => (a?.at || 0) - (b?.at || 0));
-  // #393: dedup recentEvents against the live tail. recentEvents is the server's trailing window of
-  // the SAME session log that the live narration stream (chatBeats, fed by app.jsx's /events poll)
-  // now reads — so a paragraph that has already streamed into the live band would otherwise ALSO
-  // show in this leading history band (the same prose twice, adjacent). Drop any recentEvents
-  // narration row whose text already appears in the live tail; non-narration history rows and
-  // genuine pre-session prose (not in the live tail) are untouched. Keyed identically to app.jsx's
-  // claimNarration (whitespace-collapsed + lowercased) so the two projections of one paragraph match.
-  const narrationKey = (t) => sanitizeNarration(t || "").replace(/\s+/g, " ").trim().toLowerCase();
-  const liveNarrationKeys = new Set(
-    mergedTail.filter((b) => b && b.kind === "narration").map((b) => narrationKey(b.text)).filter(Boolean),
-  );
-  const dedupedRecent = recentEvents.filter((row) => {
-    const kind = (row && (row.kind || row.type)) || "narration";
-    if (kind !== "narration" && kind !== "dialogue") return true;  // mechanics rows always kept
-    const key = narrationKey(row && (row.text || row.detail));
-    return !key || !liveNarrationKeys.has(key);
-  });
-  const visibleLog = surface ? [...dedupedRecent, ...mergedTail] : [...demoLog, ...log];
+  // #274/#393/#405: the chronicle merges three sources — recentEvents (the server's trailing window
+  // of the session log), chatBeats (the live DM/player tail), and log (local optimistic player
+  // echoes) — into one ordered, de-duplicated list. The merge/dedup/order is a PURE function
+  // (buildChronicleLog, below) so the exactly-once + chronological-order contract is unit-testable
+  // without mounting the component. See its doc-comment for the stable-`seq`-keyed reconciliation.
+  const visibleLog = surface ? buildChronicleLog(recentEvents, chatBeats, log) : [...demoLog, ...log];
   // #402: BOUND what the chronicle RENDERS. Even with the live tail capped in useLiveSession, the
   // leading history band (recentEvents from the server) can be large, so the merged list could still
   // mount hundreds of rows into the DOM + the accessibility tree — the exact thing that buried the

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1488,6 +1488,13 @@ def _session_recent_events(raw_events: list[dict] | None) -> list[dict]:
         item = {"kind": kind, "text": text[:1000]}
         if label:
             item["label"] = label[:120]
+        # Carry the stable session-log line index (`seq`) through to the surface when present, so the
+        # viewer's leading history band (recentEvents) de-dups against the live /events tail by ID,
+        # not by prose. _session_event_tail_from_dir stamps it; an older snapshot/path without it
+        # simply omits the key and the viewer falls back to its text-key dedup for that row.
+        seq = row.get("seq")
+        if isinstance(seq, int) and not isinstance(seq, bool):
+            item["seq"] = seq
         out.append(item)
         if len(out) >= 12:
             break
@@ -1541,13 +1548,29 @@ def _session_event_tail_from_dir(campaign_dir: Path, snapshot: dict, limit: int 
         return []
     if log.parent != sessions_dir or not log.is_file():
         return []
+    # Compute the ABSOLUTE line index of the first tailed line so each row can carry the SAME
+    # stable `seq` key as the /events feed (both index the same session log). The tail returns only
+    # the last `limit` lines, so its base index is (total non-truncated lines − len(tail)). A line's
+    # absolute index is base+offset; this lets the leading history band (recentEvents) and the live
+    # /events tail dedup against ONE id space — a paragraph in both bands matches by seq, never by
+    # its (rewordable) prose. Best-effort: if the count read fails we fall back to no seq (the
+    # client's text-key fallback still de-dups), so this never breaks the surface.
+    tail = _tail_text_lines(log, limit)
+    base = 0
+    try:
+        with log.open("r", encoding="utf-8", errors="replace") as fh:
+            total = sum(1 for _ in fh)
+        base = max(0, total - len(tail))
+    except OSError:
+        base = 0
     out: list[dict] = []
-    for raw in _tail_text_lines(log, limit):
+    for offset, raw in enumerate(tail):
         try:
             row = json.loads(raw)
         except json.JSONDecodeError:
             continue
         if isinstance(row, dict):
+            row.setdefault("seq", base + offset)
             out.append(row)
     return out
 
@@ -5266,9 +5289,20 @@ def _read_events(campaign_id: str, since: int) -> tuple[list[dict], int]:
             consumed += 1
             continue
         try:
-            out.append(json.loads(stripped))
+            row = json.loads(stripped)
         except json.JSONDecodeError:
             break  # half-written trailing line — DON'T advance past it; re-read next poll
+        # Stamp the row with its ABSOLUTE line index in the session log as a STABLE id (`seq`).
+        # The viewer keys narration dedup + chronological order off this — NOT off the prose —
+        # so a beat the DM rewords between its streamed copy and its turn-END /chat reply can't
+        # show twice, and a re-ingest (windowing / cursor-rewind on session rotation) of the same
+        # line collapses to one row. The session log is the engine's sole-writer narration record,
+        # so a line index is a true monotonic per-beat identity. `consumed` is this line's index
+        # (it was incremented for every prior line, blank or not), and the same absolute indexing is
+        # mirrored by _session_recent_events so the leading history band shares the key space.
+        if isinstance(row, dict):
+            row.setdefault("seq", consumed)
+        out.append(row)
         consumed += 1
     return out, consumed
 

--- a/viewer/tests/test_live_narration_stream.py
+++ b/viewer/tests/test_live_narration_stream.py
@@ -217,6 +217,14 @@ const h = {
   setCampaign: (id) => { state.activeCampaign = id; state.campaigns = [{ id, campaign_id: id }]; reactHost.mount(() => useLiveSession(state)); },
   beats: () => (reactHost.api().chatBeats || []).map((b) => ({ kind: b.kind, text: b.text })),
   narrationTexts: () => (reactHost.api().chatBeats || []).filter((b) => b.kind === 'narration').map((b) => b.text),
+  // #405: the FULLY-ASSEMBLED chronicle (recentEvents history band + live tail + echoes), ordered +
+  // de-duplicated exactly as ScreenTable renders it, via the pure buildChronicleLog from screen-table.
+  // `recent` is the server's recentEvents band (default empty). Returns ordered narration text only.
+  chronicleNarration: (recent) => sandbox.window.buildChronicleLog(recent || [], reactHost.api().chatBeats || [], reactHost.api().log || [])
+    .filter((e) => e.kind === 'narration').map((e) => e.text),
+  // The full ordered chronicle rows (kind+text+who) for asserting interleaved order across sources.
+  chronicle: (recent) => sandbox.window.buildChronicleLog(recent || [], reactHost.api().chatBeats || [], reactHost.api().log || [])
+    .map((e) => ({ kind: e.kind, text: e.text, who: e.who })),
   pending: () => reactHost.api().pending,
   // arm the "DM is narrating…" indicator exactly as a posted player move does (armPending is on
   // the hook's returned api). Used to prove a streamed paragraph CLEARS it (the give-up fix).
@@ -515,6 +523,143 @@ class LiveNarrationStreamTests(unittest.TestCase):
                          "the most-recent DM narration must always survive the trim (the player's latest reply)")
         self.assertNotEqual(out["first"], "beat 0",
                          "the oldest beats must be dropped once the cap is exceeded (the tail slides forward)")
+
+    # ============================================================================================
+    # #405: the narration-DUPLICATION regression fix. The chronicle showed DM narration 3-4× and
+    # out of chronological order in a multi-beat session because the two narration sources were
+    # reconciled by TEXT. These tests reproduce the exact failure modes the text-key dedup missed
+    # and prove the stable-`seq`-keyed fix renders each beat EXACTLY ONCE, in order.
+    # ============================================================================================
+
+    # --- #405 ROOT CAUSE 1 — the DM REWORDS its turn-END /chat reply. The streamed /events copy and
+    # the /chat copy differ, so the old text-key dedup hashed them differently and showed the beat
+    # TWICE. With /events as the canonical seq-keyed source and the /chat DM line suppressed as a
+    # pure resolution signal, the beat shows exactly once regardless of the reword. -----------------
+    def test_reworded_chat_reply_does_not_duplicate_a_streamed_beat(self):
+        out = self._run(
+            "h.arm('I push open the door');"
+            # mid-turn: the canonical paragraph streams via /events WITH its stable session-log seq.
+            "h.enqueue('/events', { entries: [{ kind: 'narration', text: 'The oak door groans inward, revealing a smoke-choked hall.', seq: 0 }], next: 1 });"
+            "await h.tick();"
+            "var afterStream = h.narrationTexts();"
+            # turn-END: the DM's /chat reply is a REWORDED telling of the same beat (different prose).
+            "h.enqueue('/chat', { items: [{ role: 'dm', text: 'You shove the heavy door wide; beyond it a hall thick with smoke opens up before you.' }], next: 1 });"
+            "await h.tick();"
+            "return ({ afterStream: afterStream, narration: h.narrationTexts(), pending: h.pending() });"
+        )
+        self.assertEqual(len(out["afterStream"]), 1, "the streamed paragraph appears once mid-turn")
+        self.assertEqual(out["narration"], ["The oak door groans inward, revealing a smoke-choked hall."],
+                         "a REWORDED /chat reply must NOT add a second row — the seq-keyed streamed copy is canonical (#405)")
+        self.assertIsNone(out["pending"], "the /chat DM line still RESOLVES the turn (clears the indicator)")
+
+    # --- #405 ROOT CAUSE 2 — /events streams N PER-PARAGRAPH rows; the turn-END /chat line carries the
+    # WHOLE turn as ONE blob. Even verbatim, the blob key matches no single paragraph key, so the old
+    # dedup rendered the blob as an extra row → "opening narration appears 3 times". The whole turn
+    # must show as its per-paragraph streamed rows ONLY. --------------------------------------------
+    def test_chat_blob_does_not_duplicate_per_paragraph_stream(self):
+        out = self._run(
+            "h.arm('I enter the hall');"
+            # mid-turn: two distinct paragraphs stream as two /events rows (seq 0 and seq 1).
+            "h.enqueue('/events', { entries: ["
+            "  { kind: 'narration', text: 'The hall is vast and cold.', seq: 0 },"
+            "  { kind: 'narration', text: 'A figure waits by the hearth.', seq: 1 }"
+            "], next: 2 });"
+            "await h.tick();"
+            "var afterStream = h.narrationTexts();"
+            # turn-END: /chat carries BOTH paragraphs joined into one reply blob (the DMSG result).
+            "h.enqueue('/chat', { items: [{ role: 'dm', text: 'The hall is vast and cold. A figure waits by the hearth.' }], next: 1 });"
+            "await h.tick();"
+            "return ({ afterStream: afterStream, narration: h.narrationTexts() });"
+        )
+        self.assertEqual(out["afterStream"], ["The hall is vast and cold.", "A figure waits by the hearth."],
+                         "both paragraphs stream live as separate beats")
+        self.assertEqual(out["narration"], ["The hall is vast and cold.", "A figure waits by the hearth."],
+                         "the turn-END /chat BLOB must NOT add a third row — the per-paragraph stream is canonical (#405)")
+
+    # --- #405 ROOT CAUSE 3 — windowing / a session-rotation cursor rewind RE-INGESTS the same /events
+    # line. Keyed by the stable session-log seq, the second arrival of seq N collapses to one row even
+    # if its text differs slightly — proving the dedup is ID-keyed, not prose-keyed. ----------------
+    def test_same_seq_reingested_is_shown_once(self):
+        out = self._run(
+            "h.enqueue('/events', { entries: [{ kind: 'narration', text: 'Lightning splits the sky.', seq: 5 }], next: 6 });"
+            "await h.tick();"
+            "var first = h.narrationTexts();"
+            # the SAME session-log line (seq 5) re-arrives — e.g. a windowing re-mount re-read the tail —
+            # with cosmetically different text. A stable-id dedup must still drop it.
+            "h.enqueue('/events', { entries: [{ kind: 'narration', text: 'Lightning  splits   the sky!!', seq: 5 }], next: 6 });"
+            "await h.tick();"
+            "return ({ first: first, second: h.narrationTexts() });"
+        )
+        self.assertEqual(out["first"], ["Lightning splits the sky."])
+        self.assertEqual(out["second"], ["Lightning splits the sky."],
+                         "a re-ingested session-log line (same seq) must collapse to one row, immune to its prose (#405)")
+
+    # --- #405: CHRONOLOGICAL ORDER — beats that stream out of arrival order still render in session-log
+    # (seq) order in the assembled chronicle. -------------------------------------------------------
+    def test_chronicle_orders_by_session_log_seq(self):
+        out = self._run(
+            # Three paragraphs arrive across two polls, the later seq landing in the FIRST poll.
+            "h.enqueue('/events', { entries: ["
+            "  { kind: 'narration', text: 'THIRD beat.', seq: 2 },"
+            "  { kind: 'narration', text: 'FIRST beat.', seq: 0 }"
+            "], next: 3 });"
+            "await h.tick();"
+            "h.enqueue('/events', { entries: [{ kind: 'narration', text: 'SECOND beat.', seq: 1 }], next: 4 });"
+            "await h.tick();"
+            "return ({ ordered: h.chronicleNarration() });"
+        )
+        self.assertEqual(out["ordered"], ["FIRST beat.", "SECOND beat.", "THIRD beat."],
+                         "the assembled chronicle must render strictly in session-log seq order, not arrival order (#405)")
+
+    # --- #405: the per-TURN canonical decision. A STREAMED turn followed by a TERSE turn (which logs no
+    # /events narration, landing prose ONLY on /chat) must still show the terse turn's prose — the
+    # 'suppress /chat when /events streamed' rule is per-turn, reset when each turn resolves. ---------
+    def test_terse_turn_after_streamed_turn_still_renders(self):
+        out = self._run(
+            # Turn 1: streams a paragraph via /events, resolves on /chat (its blob is suppressed).
+            "h.arm('open the door');"
+            "h.enqueue('/events', { entries: [{ kind: 'narration', text: 'The door opens.', seq: 0 }], next: 1 });"
+            "await h.tick();"
+            "h.enqueue('/chat', { items: [{ role: 'dm', text: 'The door opens onto the hall.' }], next: 1 });"
+            "await h.tick();"
+            "var afterTurn1 = h.narrationTexts();"
+            # Turn 2 (TERSE): nothing streams via /events; the beat lands ONLY as a /chat DM line.
+            "h.arm('listen');"
+            "h.enqueue('/chat', { items: [{ role: 'dm', text: 'You hear footsteps approaching.' }], next: 2 });"
+            "await h.tick();"
+            "return ({ afterTurn1: afterTurn1, afterTurn2: h.narrationTexts() });"
+        )
+        self.assertEqual(out["afterTurn1"], ["The door opens."],
+                         "turn 1 shows its streamed paragraph once (the reworded /chat blob suppressed)")
+        self.assertEqual(out["afterTurn2"], ["The door opens.", "You hear footsteps approaching."],
+                         "a TERSE turn 2 (no /events stream) must still render its /chat-only prose — the suppression is per-turn (#405)")
+
+    # --- #405: recentEvents (the server history band) is de-duped against the live tail by the STABLE
+    # seq — a paragraph in BOTH bands shows once, immune to the prose. (Exercises buildChronicleLog,
+    # the pure ScreenTable assembler, with a recentEvents band that carries server `seq`.) -----------
+    def test_recent_events_deduped_against_live_tail_by_seq(self):
+        out = self._run(
+            # The live tail streams seq 0 + seq 1 via /events.
+            "h.enqueue('/events', { entries: ["
+            "  { kind: 'narration', text: 'A bell tolls thrice.', seq: 0 },"
+            "  { kind: 'narration', text: 'The crowd falls silent.', seq: 1 }"
+            "], next: 2 });"
+            "await h.tick();"
+            # The server's recentEvents history band carries the SAME two session-log lines (seq 0,1) —
+            # here with cosmetically different prose — PLUS one older pre-session line (seq -1, no live
+            # twin) that must survive. Assert each live beat shows ONCE and the older line is kept.
+            "var recent = ["
+            "  { kind: 'narration', text: 'An older, pre-session beat.', seq: -1 },"
+            "  { kind: 'narration', text: 'A BELL tolls thrice!', seq: 0 },"
+            "  { kind: 'narration', text: 'the crowd  falls silent', seq: 1 }"
+            "];"
+            "return ({ chronicle: h.chronicleNarration(recent) });"
+        )
+        self.assertEqual(
+            out["chronicle"],
+            ["An older, pre-session beat.", "A bell tolls thrice.", "The crowd falls silent."],
+            "recentEvents rows sharing a live seq must be dropped (immune to prose); the older un-twinned line is kept, leading, in order (#405)",
+        )
 
 
 if __name__ == "__main__":

--- a/viewer/tests/test_session_surface.py
+++ b/viewer/tests/test_session_surface.py
@@ -1,8 +1,24 @@
+import contextlib
 import importlib.util
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
+
+
+@contextlib.contextmanager
+def _env(key: str, value: str):
+    """Temporarily set an env var (restored on exit) — for pointing _state_dir() at a temp dir."""
+    old = os.environ.get(key)
+    os.environ[key] = value
+    try:
+        yield
+    finally:
+        if old is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = old
 
 
 _SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
@@ -373,6 +389,67 @@ class SessionSurfaceTests(unittest.TestCase):
 
         self.assertEqual(surface["recentEvents"], [])
         self.assertEqual(surface["title"], "Unsafe Session")
+
+    # --- #405: the session-log tail stamps each row with its ABSOLUTE line index as a stable `seq`,
+    # and that seq survives into the surface's recentEvents — so the viewer can dedup the history band
+    # against the live /events tail by ID (immune to a reworded copy), not by prose. ----------------
+    def test_session_event_tail_stamps_stable_absolute_seq(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        campaign_dir = root / "campaigns" / "camp_seq"
+        (campaign_dir / "sessions").mkdir(parents=True)
+        # 20 lines; tail of 5 → absolute indices 15..19 (NOT 0..4). This is the load-bearing property:
+        # the seq is the line's index in the WHOLE log, so it matches the /events feed's per-line id.
+        (campaign_dir / "sessions" / "sess_1.jsonl").write_text(
+            "".join(
+                json.dumps({"kind": "narration", "text": f"event {i}"}) + "\n"
+                for i in range(20)
+            ),
+            encoding="utf-8",
+        )
+        tail = server._session_event_tail_from_dir(campaign_dir, {"active_session_id": "sess_1"}, limit=5)
+        self.assertEqual([row["seq"] for row in tail], [15, 16, 17, 18, 19],
+                         "each tailed row must carry its ABSOLUTE session-log line index as `seq`")
+        self.assertEqual([row["text"] for row in tail], [f"event {i}" for i in range(15, 20)])
+
+        # And the seq propagates through the surface projection (recentEvents) for the viewer's dedup.
+        surface = server.build_session_surface(
+            {"title": "Seq Session", "active_session_id": "sess_1"},
+            campaign_id="camp_seq",
+            live=False,
+            is_live_view=False,
+            recent_events=tail,
+        )
+        seqs = [row.get("seq") for row in surface["recentEvents"]]
+        self.assertTrue(all(isinstance(s, int) for s in seqs), "recentEvents rows carry the stable seq")
+        self.assertEqual(seqs, sorted(seqs), "recentEvents seq is monotonic (session-log order)")
+
+    # --- #405: /events stamps each entry with its absolute line index, consistent ACROSS polls (the
+    # cursor advances), so the client's seq-keyed dedup has a single stable id space per session log. -
+    def test_read_events_stamps_absolute_seq_across_polls(self):
+        root = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self.enterContext(_env("WORLDOS_STATE_DIR", str(root)))
+        campaign_dir = root / "campaigns" / "camp_evt"
+        (campaign_dir / "sessions").mkdir(parents=True)
+        log = campaign_dir / "sessions" / "sess_1.jsonl"
+        (campaign_dir / "snapshot.json").write_text(
+            json.dumps({"title": "Evt", "active_session_id": "sess_1"}), encoding="utf-8"
+        )
+        # First two lines.
+        log.write_text(
+            json.dumps({"kind": "narration", "text": "line 0"}) + "\n"
+            + json.dumps({"kind": "narration", "text": "line 1"}) + "\n",
+            encoding="utf-8",
+        )
+        first, nxt = server._read_events("camp_evt", 0)
+        self.assertEqual([e["seq"] for e in first], [0, 1], "first poll stamps absolute indices 0,1")
+        self.assertEqual(nxt, 2)
+        # Append a third line; the next poll (since=cursor) must stamp it seq 2 (absolute), not 0.
+        with log.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps({"kind": "narration", "text": "line 2"}) + "\n")
+        second, nxt2 = server._read_events("camp_evt", nxt)
+        self.assertEqual([e["seq"] for e in second], [2],
+                         "the seq is the ABSOLUTE line index, stable across polls (not reset to 0)")
+        self.assertEqual(nxt2, 3)
 
     def assert_no_private_keys(self, value) -> None:
         private_keys = {


### PR DESCRIPTION
## The bug (live full-arc playtest — MAJOR)
In the OpenWorlds **Chronicle** panel, DM narration appeared **4+ times and out of chronological order** during a multi-beat session ("Opening narration appears 3 times"; "narrations 4+ times, entries out of chronological order").

## Root cause
The chronicle reconciled its **two** live narration sources **by TEXT**, which is fragile:
- **`/events`** tails the engine session log (`sessions/<sid>.jsonl`), where the DM streams each paragraph mid-turn via `log_event(kind="narration")` — one line per paragraph (the #393 give-up fix). `recentEvents` (the history band) is the same file's trailing window.
- **`/chat`** tails a *separate* file (`<run>.chat.jsonl`), one `{"role":"dm","text":RESULT}` line per turn — the DM's whole reply, often the **entire turn's prose as one blob**.

The existing dedup (`claimNarration` / `dedupedRecent`, whitespace+case-normalized text key) broke two ways:
1. **Reword** — the DM rewording its turn-END `/chat` reply hashes differently from the streamed copy, so the beat shows twice. The DM skill (`skills/dungeon-master/SKILL.md` line 66) *explicitly* warns "a reworded reply defeats the de-dup and the player sees the beat twice." We can't stop the LLM rewording (the skill is out of scope).
2. **Blob-vs-paragraph** — even verbatim, the `/chat` blob's key (the whole turn) matches no single `/events` paragraph key, so the whole turn renders **again** after its paragraphs already streamed = "opening appears 3 times".

Ordering broke because the two sources interleaved (a turn's `/chat` blob lands after a later beat's paragraphs already streamed).

## The fix — render each beat EXACTLY ONCE, in order, by a STABLE key
- **Stable key, not text.** The server now stamps every `/events` entry (and the `recentEvents` band) with its **absolute session-log line index** as `seq` — the engine's sole-writer per-beat identity, independent of the prose. Purely additive (`server.py`: `_read_events`, `_session_event_tail_from_dir`, `_session_recent_events`).
- **One canonical source per beat.** `/events` (the session log) is the **canonical live-narration source**; dedup + ordering key off `seq`. A `/chat` DM line is a turn-**resolution** signal (it still clears the "narrating…" indicator) but adds **no narration row** when the current turn streamed via `/events`. It renders narration **only as a per-turn fallback** when nothing streamed (a terse turn, or the human/native path where `/chat` is the sole source) — text-keyed, since a chat-only beat has no `seq` and there is no `/events` stream to collide with.
- **Chronological by `seq`.** Live narration now shares the session-log line order, so the two sources structurally cannot interleave out of order.
- **Re-ingest immunity.** A windowing re-mount or a session-rotation cursor rewind re-reads the same line; keyed by `seq`, it collapses to one row.
- The chronicle merge/dedup/order is extracted to a pure, exported `buildChronicleLog` so the contract is unit-testable.

### Why not a fully shared id across both files?
`/chat` is a different file written by the runner/skill (out of scope — wire contracts and the DM lane are owned elsewhere). A truly shared beat-id would need the runner to correlate both files. The "one canonical source + idempotent other" design (the task's preferred option) achieves exactly-once **without** that bigger change, so it is the right minimal fix.

## How I verified (actually exercised, not just read)
- **8 new tests, single-process** (extend the existing real-`.jsx`-via-Babel+Node harness + the server import test):
  - reword does not duplicate a streamed beat; `/chat` blob does not duplicate the per-paragraph stream; same-`seq` re-ingest shown once; chronicle orders by session-log `seq`; a terse turn after a streamed turn still renders; `recentEvents` deduped against the live tail by `seq`; `/events` + `recentEvents` carry monotonic **absolute** `seq` (stable across polls). Each duplication test is red before / green after.
- **Live server over HTTP** (booted on `:8880`, seeded session log): `/events` and `/session-surface` both carry `seq` on the wire; the cursor-advance poll returns absolute `seq` (not reset), and a freshly-appended line gets the next absolute index.
- **End-to-end render** through the real transpiled `useLiveSession` + `buildChronicleLog`: the full multi-beat scenario (3 streamed paragraphs + a mechanics row + a **reworded `/chat` blob** + a **windowing re-ingest** + the **recentEvents band**, all carrying the same beats) renders **exactly 3 narration rows, in order**, `pending` cleared, the mechanics row preserved.
- **Full viewer suite green: 208 passed, 1 skipped** (single-process, `-p no:xdist`). `license_check` clean.

## Scope / invariants
Viewer-only (`viewer/openworlds/*.jsx` + a minimal additive `seq` stamp in `viewer/server.py`). The engine stays the sole writer (`seq` is a pure read-projection of the line index it already wrote); no DM-skill / `--resume` / `persist_beat` / wire-contract changes. Windowing (≤50 rows), the bounded live tail, and auto-scroll are unchanged. `_private/` untouched.

**Do NOT close on merge — verify on the next full-arc playtest.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced stable sequence-based deduplication for narration entries across live event streams and chat responses.

* **Bug Fixes**
  * Fixed duplicate narration appearing in live session chronicles (issue `#405`).
  * Resolved inconsistent narration ordering between streamed and chat-delivered content.

* **Tests**
  * Added regression tests validating narration deduplication and chronological ordering in live sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->