### PR TITLE
fix(viewer): building-universe overlay can never wedge — escape hatch + streaming polish (#405, #406)

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -161,6 +161,14 @@ function useLiveSession(state) {
   const chatCursor = React.useRef(0);
   const eventsCursor = React.useRef(0);                // #393: per-file cursor for the live /events tail
   const dmBeatCountRef = React.useRef(0);
+  // #406: the count of turns that have RESOLVED on /chat (the turn-END signal), bumped ONLY in the
+  // /chat poll — NOT by streamed /events paragraphs. `firstBeat` (the generous cold-open recovery
+  // window) keys off THIS, not dmBeatCountRef: the cold-open is still "the first beat" until its
+  // turn actually resolves, so a player who hits "Try again" after one paragraph streamed keeps the
+  // 4-min window instead of being dropped to the 180s later-beat window (the #348 false-stuck trap
+  // re-introduced for the still-opening cold open). dmBeatCountRef stays the per-paragraph counter
+  // (it gates streaming dedup/order), but it no longer decides the recovery window.
+  const resolvedTurnsRef = React.useRef(0);
   // #393/#405: dedup key sets across BOTH narration sources. There are TWO key spaces and the
   // distinction is the whole fix:
   //   • `seenSeq` — the STABLE session-log line index (`seq`) the server now stamps on every /events
@@ -176,6 +184,10 @@ function useLiveSession(state) {
   // its turn-END reply — or /chat carrying the whole beat as one blob while /events carried N
   // paragraphs — defeated the dedup and the chronicle showed each beat 3-4× and out of order.
   const seenSeq = React.useRef(new Set());
+  // #406: seenText is RESET per turn (when a /chat DM line resolves a turn, below) — it only needs to
+  // span one turn's /events→/chat gap, so a run-long text set is wrong: it would permanently suppress
+  // a legitimately-repeated short line (a catchphrase, a repeated "Yes.") on a /chat-only path. seenSeq
+  // stays run-long (stable ids never collide and must absorb re-ingests).
   const seenText = React.useRef(new Set());
   // #405: did the CURRENT in-flight turn stream any narration via the canonical /events source? When
   // true, the turn-END /chat DM line is a pure turn-RESOLUTION signal (it clears the pending
@@ -216,10 +228,16 @@ function useLiveSession(state) {
     return true;
   }, []);
 
-  const clearTimers = React.useCallback(() => {
+  // Clear ONLY the adaptive 'stuck' recovery timer (the one notePendingProgress re-arms each
+  // streamed beat). Kept separate from the absolute backstop so a streaming turn can reset 'stuck'
+  // WITHOUT pushing the hard 12-min cap forward (see notePendingProgress / #406).
+  const clearRecoveryTimer = React.useCallback(() => {
     if (recoveryTimer.current) { window.clearTimeout(recoveryTimer.current); recoveryTimer.current = null; }
-    if (backstopTimer.current) { window.clearTimeout(backstopTimer.current); backstopTimer.current = null; }
   }, []);
+  const clearTimers = React.useCallback(() => {
+    clearRecoveryTimer();
+    if (backstopTimer.current) { window.clearTimeout(backstopTimer.current); backstopTimer.current = null; }
+  }, [clearRecoveryTimer]);
 
   // #393: a ref mirror of `pending` so a poll callback (whose effect deps deliberately EXCLUDE
   // `pending`, to avoid re-subscribing the 3s interval every turn) can read the CURRENT turn state
@@ -247,7 +265,10 @@ function useLiveSession(state) {
   // real narration beat regardless of this flag).
   const armPending = React.useCallback((text) => {
     clearTimers();
-    const firstBeat = dmBeatCountRef.current === 0;
+    // #406: "first beat?" = no turn has RESOLVED on /chat yet (resolvedTurnsRef), NOT "no paragraph
+    // has streamed" (dmBeatCountRef). So a retried cold-open — one paragraph streamed, then "Try
+    // again" before the turn resolved — still gets the generous PENDING_RECOVERY_FIRST_MS window.
+    const firstBeat = resolvedTurnsRef.current === 0;
     const recoveryMs = recoveryWindowMs(firstBeat);
     setPendingState({ text, since: Date.now(), stuck: false, firstBeat });
     recoveryTimer.current = window.setTimeout(() => {
@@ -268,15 +289,20 @@ function useLiveSession(state) {
     // StrictMode's double-invoked updaters.
     const p = pendingRef.current;
     if (!p) return;
-    clearTimers();
+    // #406: re-arm ONLY the adaptive 'stuck' recovery timer — NOT the absolute backstop. The
+    // backstop is a hard wall-clock cap from submit (armed once in armPending); re-arming it on
+    // every streamed beat let a turn that streams a paragraph every few seconds but never resolves
+    // on /chat defer the 12-min cap FOREVER (so neither 'stuck' nor the backstop ever fired). Now a
+    // long-but-healthy streaming turn keeps resetting 'stuck' (it's plainly alive) while the
+    // absolute cap still fires at its original deadline.
+    clearRecoveryTimer();
     const recoveryMs = recoveryWindowMs(Boolean(p.firstBeat));
     recoveryTimer.current = window.setTimeout(() => {
       setPendingState((q) => (q ? { ...q, stuck: true } : q));
     }, recoveryMs);
-    backstopTimer.current = window.setTimeout(() => setPendingState(null), PENDING_BACKSTOP_MS);
     // Clear any prior 'stuck' flag — fresh prose just arrived, so the turn is plainly not stuck.
     if (p.stuck) setPendingState((q) => (q ? { ...q, stuck: false } : q));
-  }, [clearTimers, setPendingState]);
+  }, [clearRecoveryTimer, setPendingState]);
 
   // #399: idempotent player echo. The #344 'Try again' recovery re-POSTs the EXACT stalled move
   // (postMove → recordPlayerEcho again), which used to append a SECOND identical action row — the
@@ -305,6 +331,7 @@ function useLiveSession(state) {
     chatCursor.current = 0;
     eventsCursor.current = 0;          // #393: reset the live /events tail per run
     dmBeatCountRef.current = 0;
+    resolvedTurnsRef.current = 0;       // #406: a fresh run has resolved no turns yet (cold-open window)
     seenSeq.current = new Set();        // #405: a fresh run shares no seq dedup keys with the last
     seenText.current = new Set();       // #405: …nor any text-key fallback keys
     eventsStreamedThisTurnRef.current = false;  // #405: no /events narration streamed for any turn yet
@@ -364,11 +391,24 @@ function useLiveSession(state) {
           // Player echoes alone never resolve a turn.
           if (dmLineArrived) {
             dmBeatCountRef.current += beats.filter((b) => b.kind === "narration").length;
+            // #406: a /chat DM line is the turn-RESOLUTION signal — count it so the NEXT turn is no
+            // longer treated as the cold-open 'firstBeat'. This is the ONLY place the count bumps
+            // (the /events stream bumps dmBeatCountRef, not this), so a retried cold-open whose first
+            // turn never resolved keeps its generous recovery window.
+            resolvedTurnsRef.current += 1;
             clearPending();
             // #405: the turn is over → reset the per-turn "/events streamed" flag so the NEXT turn is
             // judged on ITS OWN streaming. Without this, a streamed turn would wrongly suppress a
             // later TERSE turn's /chat-only prose (the flag would stay stuck true for the whole run).
             eventsStreamedThisTurnRef.current = false;
+            // #406: scope the TEXT-key dedup to the turn (the seq-keyed /events path is the canonical,
+            // run-long dedup; #407). seenText only needs to span ONE turn's /events→/chat gap, so a
+            // run-long text set would PERMANENTLY suppress a legitimately-repeated short line on a
+            // /chat-only path (an NPC catchphrase, a repeated "Yes." / "The door is locked." on a
+            // later turn) — the turn resolves but shows no new prose ("the DM said nothing"). Reset
+            // it once the turn resolves so the next turn's identical line renders. (seenSeq is NOT
+            // reset — stable ids never collide, and it must stay run-long to absorb re-ingests.)
+            seenText.current = new Set();
           }
         }
         if (!cancelled && typeof payload.next === "number") chatCursor.current = payload.next;
@@ -504,9 +544,16 @@ function App() {
   // cold-open. It hands off (clears) when the first DM narration beat lands in liveSession.chatBeats
   // (the same real milestone the in-table cold-open clears on). Falls back gracefully if the
   // bundle/hook is absent.
+  // #405: a cold-open / session error reported on the native bridge (appStatus.lastError, mirrored
+  // into nativeState.error) means no narration will ever arrive — feed it to the hook so the overlay
+  // DISMISSES immediately (yielding to the table, which surfaces the error + a retry) rather than
+  // wedging a full-screen cover over the recovery. Pre-RELOAD mint failures are already torn down by
+  // screen-launcher / screen-create (they call OpenWorldsBuilding.clear()); this catches the
+  // POST-reload cold-open error, where the overlay is up and only the bridge status can flag it.
+  const coldOpenError = (nativeState && (nativeState.appStatus?.lastError || nativeState.error)) || "";
   const building = (typeof window.useBuildingUniverse === "function")
-    ? window.useBuildingUniverse(liveSession)
-    : { active: false, record: null, handoff: false, dismiss: () => {} };
+    ? window.useBuildingUniverse(liveSession, coldOpenError)
+    : { active: false, record: null, handoff: false, escapable: false, dismiss: () => {} };
 
   React.useEffect(() => {
     document.documentElement.setAttribute("data-palette", t.palette || "warm");
@@ -796,9 +843,16 @@ function App() {
 
       {/* The full-screen "building your universe" loading overlay. position:fixed (styles.css), so
           it covers the whole app — title bar, rail, stage — while the table boots underneath and
-          the app-level /chat poll keeps running. Clears itself when the first DM narration lands. */}
+          the app-level /chat poll keeps running. Clears itself when the first DM narration lands —
+          or, #405, on a cold-open error, a ~120s stall ceiling, or the manual "Enter anyway →"
+          (onEnterAnyway → dismiss), so it can never wedge over the table's own recovery. */}
       {building.active && window.BuildingUniverse && (
-        <window.BuildingUniverse record={building.record} handoff={building.handoff} />
+        <window.BuildingUniverse
+          record={building.record}
+          handoff={building.handoff}
+          escapable={building.escapable}
+          onEnterAnyway={building.dismiss}
+        />
       )}
     </React.Fragment>
   );

--- a/viewer/openworlds/building-universe.jsx
+++ b/viewer/openworlds/building-universe.jsx
@@ -25,8 +25,18 @@
  * liveSession.chatBeats gaining a { kind: "narration" } entry (app.jsx's /chat poll). When that
  * lands, the universe is built: we show a one-beat "Your story begins…" flourish, then clear the
  * flag and let App route to the table where that very first beat is already in the chronicle.
- * A 12-min hard backstop (matching the cold-open's PENDING_BACKSTOP_MS) guarantees the overlay can
- * never wedge forever even if no beat ever comes.
+ *
+ * HOW IT CAN NEVER WEDGE (#405). The overlay is only a COVER for the slow cold-open — it must YIELD
+ * to the table (which has the real recovery: live streaming narration, a 180s "DM is narrating…"
+ * timeout, and a "Try again" affordance). So dismiss() — wired in App — fires on ANY of three exits,
+ * not just the handoff: (1) a HARD ERROR (a cold-open / session error reported on the native bridge)
+ * dismisses immediately; (2) a ~120s STALL CEILING (a FIXED deadline from the build's start, NOT a
+ * 12-min one and NOT re-armed per beat) dismisses so the table's own handling takes over; and (3) a
+ * manual "Enter anyway →" affordance (after ~15s) lets an impatient player skip to the table anytime.
+ * After any dismiss the table is fully reachable (the z-9000 cover is unmounted) and usable — on a
+ * cold-open the action bar is enabled, so the player can act and the table's own narrating/stuck-
+ * recovery engages. The 12-min sessionStorage self-heal in read() is a SEPARATE net for the reload
+ * path only (a stale flag can't re-enter the overlay), not the live overlay's ceiling.
  *
  * The bar of honesty (per the owner): animated "composing your opening…" + rotating lore flavor +
  * a live elapsed readout. No fake progress bar we can't back.
@@ -37,11 +47,34 @@
 // the click — before startProviderSession — by both the launcher (startPlay) and the Forge
 // (bindHero), so the overlay is up instantly, before the async bridge hop and the reload.
 const OW_BUILDING_KEY = "openworlds.building";
-// A floor on how long the overlay lingers once "begun", so a fast-failing bridge call (no reload,
-// instant reject) still shows the intent for a readable moment rather than a flash — but mostly
-// this exists so begin()→immediate-error in a browser preview doesn't blink. The real lifetime is
-// governed by the first-narration handoff and the hard backstop below.
-const OW_BUILDING_BACKSTOP_MS = 12 * 60 * 1000; // mirrors app.jsx PENDING_BACKSTOP_MS (the cold-open ceiling)
+// #405: the LIVE dismiss ceiling. The overlay is only a COVER for the legitimately-slow cold-open
+// (the engine spends ~55s building the world + composing the opening). It is NOT the recovery
+// surface — the table is (live streaming narration, a 180s "DM is narrating…" timeout, and a
+// "Try again" recovery). So if no first-narration handoff arrives within this ceiling we DISMISS
+// the overlay and let the table's own handling take over, rather than wedging the player on a
+// full-screen cover. ~120s comfortably covers the real cold-open + margin without the old
+// 12-minute dead-end. This is a FIXED deadline measured from the build's startedAt — it does NOT
+// re-arm on streamed beats (the overlay's handoff is the first-narration milestone, not "any beat").
+const OW_BUILDING_CEILING_MS = 120 * 1000;
+// #405: a manual escape. After this long with no handoff, surface an "Enter anyway →" affordance so
+// an impatient player can skip straight to the table at any time (the table is fully usable — its
+// own narrating/stuck-recovery takes over). Well below the ceiling so the player is never trapped.
+const OW_BUILDING_ESCAPE_MS = 15 * 1000;
+// #405: a short grace before an ERROR signal is honored as a dismiss. The error comes from the
+// native bridge's lastError, which can carry a STALE error from a PRIOR failed attempt at the
+// instant a fresh build begins (the same-page launcher window, before the reload re-inits native
+// state). Ignoring the error for the first few seconds of a build prevents a just-clicked Play from
+// being nuked by a leftover error; a genuine cold-open failure is observed on a later bridge poll
+// (well past this grace), so real errors still dismiss promptly. Far below the manual-escape time,
+// so the player is never stuck waiting on it.
+const OW_BUILDING_ERROR_GRACE_MS = 3 * 1000;
+// The cross-RELOAD stale-flag net (NOT a min-display floor — no such floor exists; on a fast bridge
+// failure both screen-launcher and screen-create call clear() immediately, so the overlay flashes
+// away). A persisted record older than this is stale — e.g. a tab left on the overlay, then a fresh
+// load — so read() drops it rather than re-entering the overlay. Kept generous (12 min) because it
+// only guards the reload path; the LIVE overlay's lifetime is governed by the handoff + the ~120s
+// ceiling above + the error/manual dismiss wired in App, none of which depend on this.
+const OW_BUILDING_BACKSTOP_MS = 12 * 60 * 1000;
 
 window.OpenWorldsBuilding = window.OpenWorldsBuilding || {
   // Stamp the intent + announce it so a still-mounted App shows the overlay this tick (pre-reload).
@@ -78,6 +111,9 @@ window.OpenWorldsBuilding = window.OpenWorldsBuilding || {
     try { window.sessionStorage.removeItem(OW_BUILDING_KEY); } catch (_e) {}
   },
   backstopMs: OW_BUILDING_BACKSTOP_MS,
+  ceilingMs: OW_BUILDING_CEILING_MS,   // #405: the live dismiss ceiling (yield to the table)
+  escapeMs: OW_BUILDING_ESCAPE_MS,     // #405: when the "Enter anyway" affordance appears
+  errorGraceMs: OW_BUILDING_ERROR_GRACE_MS,  // #405: grace before a (possibly stale) error dismisses
 };
 
 // ---- rotating lore flavor (honest "the world is being assembled" cues) -----------------------
@@ -100,6 +136,22 @@ const BUILDING_FLAVOR = [
   "The ink is still drying on your first page…",
 ];
 
+// #406 (5): the LATE-phase pool. The early pool plays through in ~40s, but a real cold-open can run
+// well past that (a blind newbie run saw minutes). Rather than recycle the bright early lines —
+// which reads as "stuck on a loop" — shift past ~42s to a calmer, patient register that owns the
+// length of the wait honestly ("a rich opening is worth it"). Still rotates so renders/snapshots
+// differ (the #385 proof-of-life lesson), and is intentionally a different length from the early
+// pool so the two phases don't lock-step.
+const BUILDING_FLAVOR_LATE = [
+  "Still composing — a rich opening is worth the wait…",
+  "The Dungeon Master is weaving the finer details…",
+  "Setting the final pieces of your opening scene…",
+  "A great tale takes a moment longer to begin…",
+  "Almost there — the first page is nearly written…",
+  "Holding the curtain a beat longer, for a worthy entrance…",
+  "The world is taking shape around your hero…",
+];
+
 // A short, calm sub-line that rotates more slowly — sets the expectation honestly.
 const BUILDING_SUBLINE = [
   "Your world is being built. This first moment can take up to a minute.",
@@ -111,84 +163,138 @@ const BUILDING_SUBLINE = [
 // Owns the overlay's lifecycle. Reads the persisted intent on mount (so a reloaded page shows the
 // overlay immediately), listens for begin() (the pre-reload, same-page case), and HANDS OFF when
 // the first DM narration beat lands in liveSession.chatBeats — the same real milestone the
-// in-table cold-open clears on. Returns { active, record, dismiss }.
-function useBuildingUniverse(liveSession) {
+// in-table cold-open clears on. #405: it ALSO dismisses (yields to the table) on a hard cold-open
+// error, on a ~120s stall ceiling, and via a manual "Enter anyway →" affordance — so the cover can
+// never wedge full-screen over the table's own recovery.
+//   `sessionError` (optional): a truthy cold-open/session error reported on the native bridge. When
+//   set, the overlay dismisses immediately so the player isn't stranded on a full-screen cover while
+//   the table (which surfaces the error + a retry) sits unreachable beneath it.
+// Returns { active, record, handoff, escapable, dismiss }.
+function useBuildingUniverse(liveSession, sessionError) {
   const [record, setRecord] = React.useState(() => window.OpenWorldsBuilding.read());
   // "handoff" is the brief flourish phase after the first beat lands but before we unmount — so the
   // table doesn't pop in with a jarring cut; the player reads "Your story begins…" for a beat.
   const [handoff, setHandoff] = React.useState(false);
+  // #405: once the build has been up past OW_BUILDING_ESCAPE_MS with no handoff, expose the manual
+  // "Enter anyway →" affordance. Drives only the affordance's visibility; dismiss() does the work.
+  const [escapable, setEscapable] = React.useState(false);
   const handoffTimer = React.useRef(null);
-  const backstopTimer = React.useRef(null);
+  const ceilingTimer = React.useRef(null);
+  const escapeTimer = React.useRef(null);
+  const errorTimer = React.useRef(null);
+
+  // The one true exit. Clears the persisted flag + unmounts the overlay (App then routes to the
+  // table). Used by the handoff flourish, the error dismiss, the stall ceiling, AND the manual
+  // "Enter anyway" button — every path that reveals the table funnels through here.
+  const dismiss = React.useCallback(() => {
+    window.OpenWorldsBuilding.clear();
+    setRecord(null);
+    setHandoff(false);
+    setEscapable(false);
+  }, []);
 
   // begin() fired on THIS page (no reload yet — the launcher/forge click) → show immediately.
   React.useEffect(() => {
     const onBegin = (e) => {
       setHandoff(false);
+      setEscapable(false);
       setRecord((e && e.detail) || window.OpenWorldsBuilding.read());
     };
     window.addEventListener("clawdnd:building-begin", onBegin);
     return () => window.removeEventListener("clawdnd:building-begin", onBegin);
   }, []);
 
-  // Hard backstop: never let the overlay wedge forever. If no first beat arrives within the
-  // ceiling, clear the flag and dismiss (the table's own cold-open/stuck handling takes over).
+  // #405 (1) HARD ERROR → dismiss. A cold-open / session error means no narration will ever arrive;
+  // the table surfaces the error + a retry, so get off the cover rather than making the player wait
+  // out a ceiling on a doomed build. Honored only after a short grace from the build's start, so a
+  // STALE bridge error at the click instant can't nuke a just-begun build (see the grace const);
+  // a genuine cold-open failure is seen on a later poll, well past the grace, so it still dismisses.
   React.useEffect(() => {
     if (!record || handoff) return undefined;
-    const elapsed = Date.now() - (record.startedAt || Date.now());
-    const remaining = Math.max(0, OW_BUILDING_BACKSTOP_MS - elapsed);
-    backstopTimer.current = window.setTimeout(() => {
-      window.OpenWorldsBuilding.clear();
-      setRecord(null);
-    }, remaining);
+    if (!sessionError) return undefined;
+    const sinceStart = Date.now() - (record.startedAt || Date.now());
+    if (sinceStart >= OW_BUILDING_ERROR_GRACE_MS) { dismiss(); return undefined; }
+    // Within the grace window — re-check once it elapses (the error may be a stale leftover that a
+    // fresh build will clear; if it's still set past the grace, dismiss then).
+    errorTimer.current = window.setTimeout(dismiss, OW_BUILDING_ERROR_GRACE_MS - sinceStart);
     return () => {
-      if (backstopTimer.current) { window.clearTimeout(backstopTimer.current); backstopTimer.current = null; }
+      if (errorTimer.current) { window.clearTimeout(errorTimer.current); errorTimer.current = null; }
     };
-  }, [record, handoff]);
+  }, [record, handoff, sessionError, dismiss]);
+
+  // #405 (2) STALL CEILING — a FIXED ~120s deadline from the build's start (NOT re-armed per beat,
+  // NOT the old 12-min wall). If no first-narration handoff lands within it, dismiss so the table's
+  // own cold-open/stuck recovery (its 180s "DM is narrating…" timeout + "Try again") takes over.
+  // The cover exists only to mask the slow cold-open; once that's plausibly overrun, the table is
+  // the better surface. Also arms the ~15s manual-escape affordance off the SAME fixed clock.
+  React.useEffect(() => {
+    if (!record || handoff) return undefined;
+    const start = record.startedAt || Date.now();
+    const ceilingRemaining = Math.max(0, OW_BUILDING_CEILING_MS - (Date.now() - start));
+    const escapeRemaining = Math.max(0, OW_BUILDING_ESCAPE_MS - (Date.now() - start));
+    ceilingTimer.current = window.setTimeout(dismiss, ceilingRemaining);
+    // Surface the manual escape once past the threshold (immediately if a reload already overran it).
+    if (escapeRemaining <= 0) setEscapable(true);
+    else escapeTimer.current = window.setTimeout(() => setEscapable(true), escapeRemaining);
+    return () => {
+      if (ceilingTimer.current) { window.clearTimeout(ceilingTimer.current); ceilingTimer.current = null; }
+      if (escapeTimer.current) { window.clearTimeout(escapeTimer.current); escapeTimer.current = null; }
+    };
+  }, [record, handoff, dismiss]);
 
   // THE HANDOFF. The first DM narration beat = the universe is built. Detect it off the live
-  // chat tail (the exact signal the cold-open pending clears on). Run the short flourish, then
-  // clear the flag + unmount so App routes to the table (where this beat is already in the log).
+  // chat tail (the exact signal the cold-open pending clears on). FLIP into the flourish phase —
+  // but do NOT arm the dismiss timer here: this effect's deps include `handoff`, so flipping it
+  // re-runs the effect and its cleanup, which would CANCEL a timer armed in the same run before it
+  // could fire (the latent bug the un-effect'd unit tests could never catch — #406). The dismiss
+  // timer is armed in a SEPARATE effect keyed on `handoff`, below, whose cleanup only fires on
+  // unmount/record-change — so the flourish reliably ends in a dismiss.
   const hasFirstNarration =
     Array.isArray(liveSession && liveSession.chatBeats) &&
     liveSession.chatBeats.some((b) => b && b.kind === "narration");
 
   React.useEffect(() => {
-    if (!record || handoff) return undefined;
-    if (!hasFirstNarration) return undefined;
+    if (!record || handoff) return;
+    if (!hasFirstNarration) return;
     setHandoff(true);
+    setEscapable(false);
+  }, [record, handoff, hasFirstNarration]);
+
+  // Arm the 1400ms flourish→dismiss timer ONCE we're in the handoff phase. Separate effect so the
+  // timer outlives the render that set `handoff` (see above). Cleanup only on unmount/record swap.
+  React.useEffect(() => {
+    if (!handoff) return undefined;
     handoffTimer.current = window.setTimeout(() => {
-      window.OpenWorldsBuilding.clear();
-      setRecord(null);
-      setHandoff(false);
+      dismiss();
     }, 1400);
     return () => {
       if (handoffTimer.current) { window.clearTimeout(handoffTimer.current); handoffTimer.current = null; }
     };
-  }, [record, handoff, hasFirstNarration]);
+  }, [handoff, dismiss]);
 
   React.useEffect(() => () => {
     if (handoffTimer.current) window.clearTimeout(handoffTimer.current);
-    if (backstopTimer.current) window.clearTimeout(backstopTimer.current);
+    if (ceilingTimer.current) window.clearTimeout(ceilingTimer.current);
+    if (escapeTimer.current) window.clearTimeout(escapeTimer.current);
+    if (errorTimer.current) window.clearTimeout(errorTimer.current);
   }, []);
 
-  const dismiss = React.useCallback(() => {
-    window.OpenWorldsBuilding.clear();
-    setRecord(null);
-    setHandoff(false);
-  }, []);
-
-  return { active: Boolean(record), record, handoff, dismiss };
+  return { active: Boolean(record), record, handoff, escapable, dismiss };
 }
 window.useBuildingUniverse = useBuildingUniverse;
 
 // ---- the full-screen overlay ----------------------------------------------------------------
 // On-brand (parchment + brass + candleglow), animated (a rotating brass seal + an etched
 // "assembling" progress sweep that is HONEST — it loops, it does not claim a percentage), a live
-// elapsed readout, and rotating lore flavor. a11y: a single stable role="status" announces the
-// wait ONCE (it never re-fires per tick); the ticking elapsed + rotating headline are visible and
-// in the a11y tree (so a screenshot AND the accessibility snapshot both see motion — the #385
-// frozen-app lesson) but live OUTSIDE the announced region so a screen reader isn't spammed.
-function BuildingUniverse({ record, handoff }) {
+// elapsed readout, and rotating lore flavor. a11y (#406): this is a LOADING STATE, not a dialog —
+// it does NOT trap focus, inert the app, or handle Escape, so it must NOT claim role="dialog"
+// aria-modal (a false-modal that leaves the covered app in the tab order). We use role="status" +
+// aria-busy on the root and a single stable polite announcement; the ticking elapsed + rotating
+// headline are visible and in the a11y tree (so a screenshot AND the accessibility snapshot both
+// see motion — the #385 frozen-app lesson) but live OUTSIDE the announced region so a screen reader
+// isn't spammed per tick. #405: when `escapable`, a real focusable "Enter anyway →" button lets a
+// keyboard/screen-reader user leave the cover for the table at any time.
+function BuildingUniverse({ record, handoff, escapable, onEnterAnyway }) {
   const start = (record && typeof record.startedAt === "number") ? record.startedAt : Date.now();
   const [now, setNow] = React.useState(() => Date.now());
   React.useEffect(() => {
@@ -200,10 +306,15 @@ function BuildingUniverse({ record, handoff }) {
   const ss = String(secs % 60).padStart(2, "0");
   const elapsedLabel = `${mm}:${ss}`;
 
-  // Rotate the headline every ~3.5s and the subline every ~9s so both visibly change over the wait.
+  // Rotate the headline + subline for the FULL overlay lifetime (#406 item 5). The early pool plays
+  // through ~40s; past that, switch to a calmer "still composing — a rich opening is worth the wait"
+  // register (BUILDING_FLAVOR_LATE) rather than recycling the bright early lines — so a long
+  // cold-open (a blind newbie run saw minutes) keeps copy that tracks the real arc of the wait
+  // instead of looping. Both phases still ROTATE so consecutive renders/snapshots differ.
+  const lateHeadlines = secs >= 42 ? BUILDING_FLAVOR_LATE : BUILDING_FLAVOR;
   const headline = handoff
     ? "Your story begins…"
-    : BUILDING_FLAVOR[Math.floor(secs / 3.5) % BUILDING_FLAVOR.length];
+    : lateHeadlines[Math.floor(secs / 3.5) % lateHeadlines.length];
   const subline = handoff
     ? "Stepping into the scene the Dungeon Master has set for you."
     : BUILDING_SUBLINE[Math.floor(secs / 9) % BUILDING_SUBLINE.length];
@@ -213,8 +324,12 @@ function BuildingUniverse({ record, handoff }) {
     : (record && record.kind === "forge" ? "Binding your hero" : "Building your universe");
 
   return (
-    <div className={`building-universe ${handoff ? "is-handoff" : ""}`} role="dialog" aria-modal="true" aria-label="Building your universe">
-      {/* Announced ONCE — stable text, so the polite region does not re-fire every second. */}
+    <div className={`building-universe ${handoff ? "is-handoff" : ""}`} aria-busy={!handoff} aria-label="Building your universe">
+      {/* Announced ONCE via a dedicated stable role="status" region — stable text, so the polite
+          region does not re-fire every second. The ROOT is NOT role="status" (it wraps the ticking
+          elapsed/headline, which would spam the announcement); it is a plain labeled, aria-busy
+          container — NOT a role="dialog" aria-modal (#406: no focus trap exists, so claiming modal
+          would be a false attribute that leaves the covered app in the tab order). */}
       <span className="visually-hidden" role="status" aria-live="polite">
         {handoff
           ? "Your story is ready. Entering the table."
@@ -266,6 +381,17 @@ function BuildingUniverse({ record, handoff }) {
           </span>
           <span className="bu-elapsed">{handoff ? "ready" : `composing · ${elapsedLabel}`}</span>
         </div>
+
+        {/* #405: the manual escape. Appears after ~15s (escapable) so an impatient player — or a
+            keyboard/screen-reader user — can skip straight to the table at any time. The table is
+            fully usable on a cold-open (its action bar is enabled, and its own narrating/stuck
+            recovery engages on the first move), so this never strands the player. Hidden during the
+            handoff flourish (we're already entering the table). */}
+        {escapable && !handoff && (
+          <button type="button" className="bu-escape" onClick={onEnterAnyway}>
+            Enter anyway →
+          </button>
+        )}
       </div>
     </div>
   );
@@ -275,4 +401,5 @@ window.BuildingUniverse = BuildingUniverse;
 // Expose the flavor pools for tests / devtools introspection (purely additive — the component
 // closes over the consts directly; nothing in the running app reads these off window).
 window.BUILDING_FLAVOR = BUILDING_FLAVOR;
+window.BUILDING_FLAVOR_LATE = BUILDING_FLAVOR_LATE;
 window.BUILDING_SUBLINE = BUILDING_SUBLINE;

--- a/viewer/openworlds/styles.css
+++ b/viewer/openworlds/styles.css
@@ -1097,6 +1097,35 @@ a { color: inherit; text-decoration: none; cursor: pointer; }
   font-variant-numeric: tabular-nums;
 }
 
+/* #405: the manual "Enter anyway →" escape, shown after ~15s. Deliberately SECONDARY (a quiet ghost
+   link, not a brass primary) so it reads as "skip if you're impatient", not "the build failed" —
+   but a real, focusable <button> so keyboard + screen-reader users can leave the cover. Fades in so
+   it doesn't jump the layout when it appears. */
+.building-universe .bu-escape {
+  margin-top: 26px;
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--b-500);
+  border-radius: 2px;
+  padding: 7px 16px;
+  font-family: var(--f-display);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  color: var(--ink-700);
+  cursor: pointer;
+  transition: background 160ms ease, color 160ms ease, border-color 160ms ease;
+  animation: bu-fade-in 420ms ease both;
+}
+.building-universe .bu-escape:hover {
+  background: rgba(120, 90, 50, 0.12);
+  color: var(--ink-900);
+  border-color: var(--b-400);
+}
+.building-universe .bu-escape:focus-visible {
+  outline: 2px solid var(--gold-glow);
+  outline-offset: 2px;
+}
+
 /* The brief "Your story begins…" flourish as the first beat lands and we hand off to the table. */
 .building-universe.is-handoff { animation: bu-fade-in 320ms ease both; }
 .building-universe.is-handoff .bu-headline { color: var(--crimson); }
@@ -1136,6 +1165,7 @@ a { color: inherit; text-decoration: none; cursor: pointer; }
 [data-reduced-motion="on"] .building-universe .bu-candleglow,
 [data-reduced-motion="on"] .building-universe .bu-dots span,
 [data-reduced-motion="on"] .building-universe .bu-sweep-fill,
+[data-reduced-motion="on"] .building-universe .bu-escape,
 [data-reduced-motion="on"] .building-universe.is-handoff,
 [data-reduced-motion="on"] .building-universe {
   animation: none !important;
@@ -1151,6 +1181,7 @@ a { color: inherit; text-decoration: none; cursor: pointer; }
   .building-universe .bu-core,
   .building-universe .bu-candleglow,
   .building-universe .bu-dots span,
+  .building-universe .bu-escape,
   .building-universe { animation: none !important; }
   .building-universe .bu-sweep { background: rgba(120, 90, 50, 0.3); }
   .building-universe .bu-sweep-fill { display: none !important; }

--- a/viewer/tests/test_building_universe.py
+++ b/viewer/tests/test_building_universe.py
@@ -126,6 +126,34 @@ function countStatus(node) {
   return n;
 }
 
+// Find the overlay ROOT (the .building-universe element) and report its a11y-relevant attrs, so a
+// test can assert the #406 fix: NOT role="dialog" aria-modal (a false modal with no focus trap).
+function rootAttrs(node) {
+  if (node == null || typeof node !== 'object') return null;
+  if (Array.isArray(node)) { for (const c of node) { const r = rootAttrs(c); if (r) return r; } return null; }
+  const props = node.props || {};
+  if (typeof props.className === 'string' && props.className.indexOf('building-universe') !== -1) {
+    return { role: props.role || null, ariaModal: props['aria-modal'] || null, ariaBusy: props['aria-busy'], ariaLabel: props['aria-label'] || null };
+  }
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [props.children] : []));
+  for (const c of kids) { const r = rootAttrs(c); if (r) return r; }
+  return null;
+}
+// Locate the "Enter anyway" escape button (className bu-escape) and confirm it's a real, wired button.
+function escapeButton(node) {
+  if (node == null || typeof node !== 'object') return null;
+  if (Array.isArray(node)) { for (const c of node) { const r = escapeButton(c); if (r) return r; } return null; }
+  const props = node.props || {};
+  if (props.className === 'bu-escape') {
+    const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [props.children] : []));
+    return { tag: node.type, type: props.type || null, wired: typeof props.onClick === 'function',
+             text: collectText(kids, false, false).join(' ').trim() };
+  }
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [props.children] : []));
+  for (const c of kids) { const r = escapeButton(c); if (r) return r; }
+  return null;
+}
+
 function report(props) {
   const tree = BuildingUniverse(props);
   return {
@@ -133,6 +161,8 @@ function report(props) {
     accessibleText: collectText(tree, true, false).join(' ␟ '),
     statusRegions: countStatus(tree),
     statusText: statusText(tree, false).join(' '),
+    root: rootAttrs(tree),
+    escape: escapeButton(tree),
   };
 }
 
@@ -272,6 +302,370 @@ class BuildingUniverseTests(unittest.TestCase):
         forge = self._run("h.render(5, { record: { startedAt: 1000000 - 5000, kind: 'forge' } })")
         self.assertIn("universe", play["allText"].lower())
         self.assertIn("hero", forge["allText"].lower(), "the forge flow should name the hero binding")
+
+    # --- #406 (1): the overlay root is NOT a false aria-modal dialog (no focus trap exists) -------
+    def test_root_is_not_a_false_aria_modal_dialog(self):
+        out = self._run("h.render(20, {})")
+        root = out["root"]
+        self.assertIsNotNone(root, "the overlay root (.building-universe) must be found")
+        self.assertNotEqual(root["role"], "dialog",
+                            "the overlay must NOT claim role=dialog — it has no focus trap (#406)")
+        self.assertIsNone(root["ariaModal"],
+                          "the overlay must NOT claim aria-modal=true (a false modal leaves the covered app in the tab order)")
+        self.assertTrue(root["ariaBusy"], "as a loading state the root should be aria-busy while building")
+        self.assertTrue(root["ariaLabel"], "the overlay keeps an aria-label")
+        # the dedicated role=status announcement region is still present (the correct a11y model).
+        self.assertGreaterEqual(out["statusRegions"], 1, "a dedicated role=status region still announces the wait")
+
+    # --- #405: the manual 'Enter anyway' escape renders as a real wired button when escapable ----
+    def test_enter_anyway_escape_button_renders_and_is_wired(self):
+        # onEnterAnyway is a function prop (App passes building.dismiss) — supply one so the harness
+        # can confirm the button is actually wired to it.
+        with_escape = self._run("h.render(20, { escapable: true, onEnterAnyway: function(){} })")
+        no_escape = self._run("h.render(5, { escapable: false, onEnterAnyway: function(){} })")
+        self.assertIsNone(no_escape["escape"], "the escape button must NOT show before it's escapable")
+        esc = with_escape["escape"]
+        self.assertIsNotNone(esc, "when escapable, the 'Enter anyway' button must render")
+        self.assertEqual(esc["tag"], "button", "it must be a real <button> (focusable for keyboard/screen-reader)")
+        self.assertEqual(esc["type"], "button")
+        self.assertTrue(esc["wired"], "the escape button must be wired to an onClick (onEnterAnyway → dismiss)")
+        self.assertIn("anyway", esc["text"].lower(), "the escape reads as 'Enter anyway'")
+        # and during the handoff flourish the escape is suppressed (we're already entering the table).
+        handoff = self._run("h.render(20, { escapable: true, handoff: true, onEnterAnyway: function(){} })")
+        self.assertIsNone(handoff["escape"], "the escape is hidden during the handoff flourish")
+
+
+# ---------------------------------------------------------------------------------------------
+# #405/#406: the OVERLAY LIFECYCLE — handoff / dismiss-on-error / dismiss-on-ceiling / manual
+# "Enter anyway". The suite above stubs useEffect to a no-op, so the lifecycle (the whole reason
+# the overlay can wedge) was UNTESTED — that is exactly why the dead-end shipped green. This harness
+# runs a minimal but REAL React: useState with a working setter that re-renders, useEffect that runs
+# after commit + re-runs on dep change + cleans up, useRef/useCallback with stable identity, plus a
+# controllable Date.now()/setTimeout so we can advance time and fire the ceiling/escape timers. We
+# drive the actual useBuildingUniverse(liveSession, sessionError) hook from building-universe.jsx
+# (not a reimplementation) and assert the real exits.
+_LIFECYCLE_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+// ---- controllable clock + timers ----
+let NOW = 1000000;
+let _timerId = 1;
+let _timers = [];  // { id, at, fn }
+function setTimeoutImpl(fn, ms) { const id = _timerId++; _timers.push({ id, at: NOW + (ms || 0), fn }); return id; }
+function clearTimeoutImpl(id) { _timers = _timers.filter((t) => t.id !== id); }
+function advance(ms) {
+  const target = NOW + ms;
+  // fire timers in due order, allowing newly-scheduled ones within the window to also fire.
+  for (;;) {
+    const due = _timers.filter((t) => t.at <= target).sort((a, b) => a.at - b.at)[0];
+    if (!due) break;
+    _timers = _timers.filter((t) => t !== due);
+    NOW = due.at;
+    due.fn();
+  }
+  NOW = target;
+}
+
+// ---- a tiny single-component React with WORKING hooks ----
+// State + ref + callback-memo slots are positional (hooks rules: same order every render). After a
+// render we run effects whose deps changed (and their cleanups), then re-render if any setState ran,
+// to a fixed point — mirroring React's commit→effect→re-render loop closely enough for this hook.
+function makeRuntime(renderFn) {
+  let hooks = [];          // positional hook cells
+  let cursor = 0;
+  let dirty = false;       // a setState ran → another render pass is needed
+  let lastTree = null;
+
+  function useState(init) {
+    const i = cursor++;
+    if (!hooks[i]) hooks[i] = { type: 'state', value: (typeof init === 'function') ? init() : init };
+    const cell = hooks[i];
+    const set = (next) => {
+      const v = (typeof next === 'function') ? next(cell.value) : next;
+      if (!Object.is(v, cell.value)) { cell.value = v; dirty = true; }
+    };
+    return [cell.value, set];
+  }
+  function useRef(init) {
+    const i = cursor++;
+    if (!hooks[i]) hooks[i] = { type: 'ref', ref: { current: init } };
+    return hooks[i].ref;
+  }
+  function depsEqual(a, b) {
+    if (!a || !b || a.length !== b.length) return false;
+    for (let k = 0; k < a.length; k++) if (!Object.is(a[k], b[k])) return false;
+    return true;
+  }
+  function useCallback(fn, deps) {
+    const i = cursor++;
+    if (!hooks[i] || !depsEqual(hooks[i].deps, deps)) hooks[i] = { type: 'cb', fn, deps };
+    return hooks[i].fn;
+  }
+  // effects are collected during render and run after commit (post-render).
+  let pendingEffects = [];
+  function useEffect(fn, deps) {
+    const i = cursor++;
+    const prev = hooks[i];
+    if (!prev) { hooks[i] = { type: 'effect', deps, cleanup: null }; pendingEffects.push(i); }
+    else if (!depsEqual(prev.deps, deps)) { prev.deps = deps; pendingEffects.push(i); }
+    // store the fn so the post-commit pass can run exactly this render's closure.
+    hooks[i].fn = fn;
+  }
+
+  const React = { useState, useRef, useCallback, useEffect,
+    createElement: (type, props) => ({ type, props: props || {} }), Fragment: 'F' };
+
+  function commitEffects() {
+    const toRun = pendingEffects.slice();
+    pendingEffects = [];
+    for (const i of toRun) {
+      const cell = hooks[i];
+      if (typeof cell.cleanup === 'function') { try { cell.cleanup(); } catch (_e) {} }
+      const ret = cell.fn();
+      cell.cleanup = (typeof ret === 'function') ? ret : null;
+    }
+  }
+  function renderOnce() { cursor = 0; dirty = false; lastTree = renderFn(React); commitEffects(); }
+  function renderToFixedPoint(maxPasses) {
+    let n = 0;
+    do { renderOnce(); n++; } while (dirty && n < (maxPasses || 50));
+    return lastTree;
+  }
+  function unmount() { for (const c of hooks) if (c && typeof c.cleanup === 'function') { try { c.cleanup(); } catch (_e) {} } }
+  return { React, render: renderToFixedPoint };
+}
+
+const _store = {};
+const sessionStorage = {
+  getItem: (k) => (k in _store ? _store[k] : null),
+  setItem: (k, v) => { _store[k] = String(v); },
+  removeItem: (k) => { delete _store[k]; },
+};
+const _events = {};
+const sandbox = {
+  ReactDOM: { createRoot: () => ({ render() {} }) },
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible', getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
+  sessionStorage,
+  CustomEvent: function (type, opts) { this.type = type; this.detail = (opts || {}).detail; },
+  setInterval: () => 0, clearInterval: () => {},
+  setTimeout: setTimeoutImpl, clearTimeout: clearTimeoutImpl,
+  console,
+};
+sandbox.window = sandbox;
+sandbox.window.addEventListener = (t, fn) => { (_events[t] = _events[t] || []).push(fn); };
+sandbox.window.removeEventListener = () => {};
+sandbox.window.dispatchEvent = (e) => { (_events[e.type] || []).forEach((fn) => fn(e)); return true; };
+sandbox.Date = { now: () => NOW };
+// React is needed at module-eval time (the file calls React.useState etc only inside fns, but the
+// component bodies reference React); inject a placeholder that the per-test runtime overwrites.
+sandbox.React = { createElement: (type, props) => ({ type, props: props || {} }), Fragment: 'F' };
+vm.createContext(sandbox);
+
+function load(p) {
+  const src = fs.readFileSync(p, 'utf8');
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+load(%(building)s);
+
+const useBuildingUniverse = sandbox.window.useBuildingUniverse;
+if (typeof useBuildingUniverse !== 'function') throw new Error('useBuildingUniverse not exported');
+const B = sandbox.window.OpenWorldsBuilding;
+
+// A driver: holds mutable inputs (liveSession.chatBeats, sessionError), renders the hook to a fixed
+// point against the CURRENT inputs, and exposes the latest hook result. `h.*` mutators change inputs
+// then re-render so a test reads the post-effect state.
+function makeDriver() {
+  const inputs = { chatBeats: [], sessionError: '' };
+  let result = null;
+  const rt = makeRuntime((React) => {
+    sandbox.React = React;  // the component body closes over `React` from the sandbox global
+    result = useBuildingUniverse({ chatBeats: inputs.chatBeats.slice() }, inputs.sessionError);
+    return null;
+  });
+  return {
+    render: () => { rt.render(); return snap(); },
+    addNarration: () => { inputs.chatBeats = inputs.chatBeats.concat([{ kind: 'narration', text: 'A door creaks open.' }]); rt.render(); return snap(); },
+    setError: (msg) => { inputs.sessionError = msg; rt.render(); return snap(); },
+    advance: (ms) => { advance(ms); rt.render(); return snap(); },
+    callDismiss: () => { result.dismiss(); rt.render(); return snap(); },
+    snap,
+  };
+  function snap() {
+    return {
+      active: !!(result && result.active),
+      handoff: !!(result && result.handoff),
+      escapable: !!(result && result.escapable),
+      hasKey: ('openworlds.building' in _store),
+      now: NOW,
+      ceilingMs: B.ceilingMs,
+      escapeMs: B.escapeMs,
+      errorGraceMs: B.errorGraceMs,
+    };
+  }
+}
+
+const h = {
+  begin: (meta) => B.begin(meta || { world: 'baldurs-gate', kind: 'play' }),
+  driver: () => makeDriver(),
+  setNow: (n) => { NOW = n; },
+};
+
+const script = %(script)s;
+const result = (function () { return eval(script); })();
+process.stdout.write(JSON.stringify(result));
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + render the JSX")
+class BuildingUniverseLifecycleTests(unittest.TestCase):
+    """The REAL effect-driven lifecycle (the suite above stubs useEffect, so these paths — the
+    handoff, the #405 escape hatches — were entirely uncovered)."""
+
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_BUILDING, _BABEL):
+            assert p.exists(), f"missing {p}"
+
+    def _run(self, script: str):
+        program = _LIFECYCLE_HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "building": json.dumps(str(_BUILDING)),
+            "script": json.dumps(script),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program,
+            text=True,
+            capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+    # --- sanity: the harness actually runs effects (the begin() flag → active overlay) ----------
+    def test_harness_runs_effects_and_overlay_is_active_while_building(self):
+        out = self._run(
+            "(function(){ h.begin(); var d = h.driver(); var s = d.render();"
+            " return { active: s.active, handoff: s.handoff }; })()"
+        )
+        self.assertTrue(out["active"], "with a building flag set, the overlay must be active (effects run)")
+        self.assertFalse(out["handoff"])
+
+    # --- HANDOFF: the first narration beat flips active→false (after the flourish) --------------
+    def test_first_narration_beat_hands_off_and_clears(self):
+        out = self._run(
+            "(function(){ h.begin(); var d = h.driver(); d.render();"
+            " var afterBeat = d.addNarration();"            # narration lands → handoff flourish begins
+            " var afterFlourish = d.advance(1500);"          # past the 1400ms flourish → clear
+            " return { handoffWhileFlourishing: afterBeat.handoff, activeAfter: afterFlourish.active,"
+            "          keyAfter: afterFlourish.hasKey }; })()"
+        )
+        self.assertTrue(out["handoffWhileFlourishing"], "the first narration beat should enter the handoff flourish")
+        self.assertFalse(out["activeAfter"], "after the flourish the overlay must clear (hand off to the table)")
+        self.assertFalse(out["keyAfter"], "the persisted building flag must be cleared on handoff")
+
+    # --- #405 (1) DISMISS ON ERROR: a cold-open/session error past the grace clears the overlay ----
+    def test_session_error_dismisses_after_grace(self):
+        out = self._run(
+            "(function(){ h.begin(); var d = h.driver(); var s0 = d.render();"
+            " var pastGrace = d.advance(s0.errorGraceMs + 500);"   # build is now seconds in (the real cold-open phase)
+            " var after = d.setError('cold-open failed: provider error');"
+            " return { errorGraceMs: s0.errorGraceMs, activeBefore: pastGrace.active,"
+            "          activeAfter: after.active, keyAfter: after.hasKey }; })()"
+        )
+        self.assertLess(out["errorGraceMs"], 10 * 1000, "the error grace must be short (a few seconds)")
+        self.assertTrue(out["activeBefore"], "overlay is up while building (no error yet)")
+        self.assertFalse(out["activeAfter"], "a cold-open/session error must dismiss the overlay (yield to the table)")
+        self.assertFalse(out["keyAfter"], "the building flag must be cleared on a hard error")
+
+    # --- #405 (1) the grace guard: a STALE error at the click instant must NOT nuke a fresh build ---
+    # The bridge lastError can carry a leftover error from a prior failed attempt at the instant a new
+    # build begins (pre-reload). It must be ignored within the grace; if a fresh build clears it, the
+    # overlay survives — but if it persists past the grace it IS a real failure and dismisses.
+    def test_stale_error_within_grace_does_not_dismiss_but_persisting_error_does(self):
+        out = self._run(
+            "(function(){ h.begin(); var d = h.driver();"
+            " var withStaleErr = d.setError('stale leftover from a prior attempt');"   # error present from t=0
+            " var withinGrace = d.snap();"                  # still within grace → must remain active
+            " var cleared = d.setError('');"                # a fresh build clears the leftover error
+            " var afterClear = d.advance(5000);"            # past the grace, now error-free
+            " return { activeWithinGrace: withinGrace.active, activeAfterClear: afterClear.active }; })()"
+        )
+        self.assertTrue(out["activeWithinGrace"],
+                        "a stale error within the grace must NOT immediately dismiss a just-begun build")
+        self.assertTrue(out["activeAfterClear"],
+                        "if a fresh build clears the leftover error, the overlay survives (no false dismiss)")
+
+    def test_error_persisting_through_grace_dismisses(self):
+        out = self._run(
+            "(function(){ h.begin(); var d = h.driver();"
+            " d.setError('cold-open failed at t=0');"       # error present from the start
+            " var early = d.snap();"                         # within grace → still up
+            " var late = d.advance(d.snap().errorGraceMs + 1000);"  # error never cleared → dismiss at grace
+            " return { activeEarly: early.active, activeLate: late.active }; })()"
+        )
+        self.assertTrue(out["activeEarly"], "within the grace the overlay holds (the error may be stale)")
+        self.assertFalse(out["activeLate"], "an error that persists through the grace IS real → dismiss")
+
+    # --- #405 (2) DISMISS ON CEILING: ~120s with no narration auto-dismisses (NOT 12 min) --------
+    def test_stall_ceiling_dismisses_well_before_twelve_minutes(self):
+        out = self._run(
+            "(function(){ h.begin(); var d = h.driver(); var s0 = d.render();"
+            " var justBefore = d.advance(s0.ceilingMs - 2000);"   # 2s shy of the ceiling — still up
+            " var atCeiling = d.advance(3000);"                    # cross the ceiling → dismiss
+            " return { ceilingMs: s0.ceilingMs, activeJustBefore: justBefore.active,"
+            "          activeAtCeiling: atCeiling.active }; })()"
+        )
+        self.assertLessEqual(out["ceilingMs"], 180 * 1000,
+                             "the stall ceiling must be well under the old 12-min dead-end (~120s)")
+        self.assertTrue(out["activeJustBefore"], "the overlay should still cover just before the ceiling")
+        self.assertFalse(out["activeAtCeiling"], "at the stall ceiling the overlay must dismiss (table takes over)")
+
+    def test_ceiling_does_not_rearm_on_streamed_progress(self):
+        # #406 (2): a build that keeps re-rendering (e.g. streamed beats / a ticking clock) must NOT
+        # push the ceiling forward — it is a FIXED deadline from start. Render repeatedly across the
+        # window, then cross the ceiling and confirm it still fires.
+        out = self._run(
+            "(function(){ h.begin(); var d = h.driver(); var s0 = d.render();"
+            " for (var i=0;i<5;i++){ d.advance(20000); }"   # 100s of re-renders within the window
+            " var nearCeiling = d.snap();"
+            " var past = d.advance(25000);"                  # now well past 120s
+            " return { activeNear: nearCeiling.active, activePast: past.active }; })()"
+        )
+        self.assertTrue(out["activeNear"], "still covering within the fixed window")
+        self.assertFalse(out["activePast"], "the ceiling is a fixed deadline — re-renders must not defer it")
+
+    # --- #405 (3) MANUAL ESCAPE: 'escapable' arms after ~15s; dismiss() clears + table reachable --
+    def test_manual_escape_arms_after_threshold_and_dismiss_reveals_table(self):
+        out = self._run(
+            "(function(){ h.begin(); var d = h.driver(); var s0 = d.render();"
+            " var early = d.advance(s0.escapeMs - 2000);"   # before the escape threshold
+            " var armed = d.advance(3000);"                  # past ~15s → 'Enter anyway' affordance
+            " var afterClick = d.callDismiss();"             # the player clicks Enter anyway
+            " return { escapeMs: s0.escapeMs, escapableEarly: early.escapable, escapableArmed: armed.escapable,"
+            "          activeAfterClick: afterClick.active, keyAfterClick: afterClick.hasKey }; })()"
+        )
+        self.assertLess(out["escapeMs"], 60 * 1000, "the manual escape must appear early (~15s), not minutes in")
+        self.assertFalse(out["escapableEarly"], "the manual escape must NOT show before its threshold")
+        self.assertTrue(out["escapableArmed"], "after ~15s the manual 'Enter anyway' affordance must appear")
+        self.assertFalse(out["activeAfterClick"], "clicking 'Enter anyway' (dismiss) must clear the overlay")
+        self.assertFalse(out["keyAfterClick"], "the building flag must be cleared so the overlay can't re-enter")
+
+    # --- NEGATIVE DISCLOSURE: no narration + within the ceiling STAYS active (documents the cover)
+    def test_no_narration_within_ceiling_stays_active(self):
+        out = self._run(
+            "(function(){ h.begin(); var d = h.driver(); d.render();"
+            " var mid = d.advance(40000);"   # 40s in, no beat, no error — still legitimately covering
+            " return { active: mid.active, handoff: mid.handoff }; })()"
+        )
+        self.assertTrue(out["active"],
+                        "with no beat, no error, and within the ceiling the cover legitimately stays up")
+        self.assertFalse(out["handoff"])
 
 
 if __name__ == "__main__":

--- a/viewer/tests/test_live_narration_stream.py
+++ b/viewer/tests/test_live_narration_stream.py
@@ -661,6 +661,58 @@ class LiveNarrationStreamTests(unittest.TestCase):
             "recentEvents rows sharing a live seq must be dropped (immune to prose); the older un-twinned line is kept, leading, in order (#405)",
         )
 
+    # --- #406 (3): a legitimately-REPEATED /chat-only line on a LATER turn must still render -------
+    # The seq-keyed dedup (#407) is the canonical run-long path; the TEXT-key fallback (used only for
+    # a /chat-only beat: a terse turn, or the human/native path) must be scoped to the TURN, not the
+    # run. A run-long text set permanently suppressed a repeated short line (a catchphrase, a repeated
+    # "Yes." / "The door is locked." across two attempts) on its second genuine occurrence — the turn
+    # resolved but showed no new prose ("the DM said nothing"). seenText now resets when a turn
+    # resolves, so the same line on a later turn renders again.
+    def test_repeated_chat_only_line_renders_on_a_later_turn(self):
+        out = self._run(
+            # Turn 1 (terse, /chat-only): "The door is locked." — rendered.
+            "h.arm('try the door');"
+            "h.enqueue('/chat', { items: [{ role: 'dm', text: 'The door is locked.' }], next: 1 });"
+            "await h.tick();"
+            "var afterTurn1 = h.narrationTexts();"
+            # Turn 2 (terse, /chat-only): the SAME line on a fresh attempt — must NOT be suppressed.
+            "h.arm('try the door again');"
+            "h.enqueue('/chat', { items: [{ role: 'dm', text: 'The door is locked.' }], next: 2 });"
+            "await h.tick();"
+            "return ({ afterTurn1: afterTurn1, afterTurn2: h.narrationTexts() });"
+        )
+        self.assertEqual(out["afterTurn1"], ["The door is locked."])
+        self.assertEqual(
+            out["afterTurn2"], ["The door is locked.", "The door is locked."],
+            "a legitimately-repeated /chat-only line on a later turn must render again (text-key dedup is per-turn, not per-run — #406)",
+        )
+
+    # --- #406 (4): a STREAMED-but-UNRESOLVED cold-open keeps the generous first-beat window --------
+    # `firstBeat` (the 4-min cold-open recovery window) must key off "has a turn RESOLVED on /chat",
+    # NOT "has a paragraph streamed". The /events poll bumps the per-paragraph counter, so before the
+    # fix a retried cold-open (one paragraph streamed via /events, then the player hits 'Try again'
+    # before the turn resolved) was wrongly treated as a LATER beat → dropped to the 180s window
+    # (the #348 false-stuck trap, re-introduced for the still-opening cold open). It must stay
+    # firstBeat=true until a /chat line actually resolves the opening turn.
+    def test_streamed_but_unresolved_cold_open_keeps_first_beat_window(self):
+        out = self._run(
+            # Cold-open turn 1: a paragraph STREAMS via /events (bumps dmBeatCountRef), but the turn
+            # has NOT resolved on /chat yet.
+            "h.arm('begin');"
+            "h.enqueue('/events', { entries: [{ kind: 'narration', text: 'You wake in a cold cell.', seq: 0 }], next: 1 });"
+            "await h.tick();"
+            "var midStream = h.pending();"  # still firstBeat (the opening hasn't resolved)
+            # The player hits 'Try again' (re-arm) before any /chat resolution.
+            "h.arm('begin');"
+            "var retried = h.pending();"
+            "return ({ midStream_firstBeat: !!(midStream && midStream.firstBeat),"
+            "          retried_firstBeat: !!(retried && retried.firstBeat) });"
+        )
+        self.assertTrue(out["midStream_firstBeat"],
+                        "while the cold-open streams but hasn't resolved, it is still the first beat")
+        self.assertTrue(out["retried_firstBeat"],
+                        "a retried cold-open (streamed, never resolved on /chat) must KEEP the 4-min first-beat window, not drop to 180s (#406)")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #405. Addresses #406.

> **Do NOT close on merge — verify on the next full-arc playtest.**

## #405 (CRITICAL) — the overlay could wedge full-screen for 12 minutes

The "building your universe" cover (`z-index: 9000`) only cleared via the first-narration handoff or a 12-minute backstop, and its `dismiss()` callback had **zero call sites**. On a DM cold-open that errors or stalls (no narration ever arrives), the cover sat over everything — including the table's own "Try again" recovery — for up to 12 minutes. A blind playtester quits.

### Product decision implemented
The overlay is only a **cover** for the legitimately-slow cold-open (~55s). The table already has robust handling (live streaming narration, a 180s "DM is narrating…" timeout, a "Try again" recovery), so the cover now **yields to the table** on ANY of:

1. **Hard error** — a cold-open / session error reported on the native bridge (`appStatus.lastError`, mirrored to `nativeState.error`) dismisses the overlay. Honored after a **3s grace** so a *stale* leftover error at a fresh build's click instant (pre-reload) can't nuke a just-started build; a genuine failure (seen on a later poll, past the grace) still dismisses promptly. (Pre-reload mint failures were already torn down by `screen-launcher`/`screen-create`; this covers the **post-reload** cold-open error.)
2. **Stall ceiling** — replaced the 12-min backstop with a **FIXED ~120s ceiling** measured from the build's start (covers the real ~55s cold-open + margin). On hit → dismiss → the table's 180s narrating + Try-again take over.
3. **Manual escape** — an **"Enter anyway →"** button appears after ~15s, wired to `dismiss()` (App passes `onEnterAnyway={building.dismiss}`).

After any dismiss the table is reachable (the z-9000 cover unmounts) and usable — on a cold-open the table arms no `pending`, so its action bar is **enabled** and the player can act (their move then arms the table's own narrating/stuck-recovery).

The 12-min `sessionStorage` self-heal in `read()` is kept as a **separate** net for the reload path only (a stale flag can't re-enter the overlay) — it no longer governs the live overlay.

### Latent handoff bug found + fixed (by the new tests)
The handoff flourish armed its 1400ms `dismiss()` timer in the **same effect** that flipped `handoff` — an effect whose deps include `handoff` and whose cleanup clears the timer. React re-runs the effect when `handoff` flips → cleanup cancels the just-armed timer → the re-run early-returns → **the dismiss never fired**. So even the canonical exit (first narration) never auto-dismissed the cover; it relied on nothing. This shipped green only because the unit tests stub `useEffect` to a no-op. Fixed by splitting into (a) flip `handoff` on first narration and (b) a separate `handoff`-keyed effect that arms the dismiss timer (cleanup only on unmount/record swap). Confirmed empirically: `test_first_narration_beat_hands_off_and_clears` FAILS on the single-effect version, PASSES after.

## #406 — streaming/overlay polish bundle

| # | Item | Disposition |
|---|------|-------------|
| 1 | False `aria-modal` w/ no focus management | **Fixed** — dropped `role=dialog`/`aria-modal` (no focus trap exists); root is now an `aria-busy` labeled container; the dedicated `role=status` announcement is kept. |
| 2 | 12-min backstop re-arms on every streamed beat | **Fixed** — `notePendingProgress` re-arms only the adaptive `stuck` recovery timer (split out `clearRecoveryTimer`); the absolute backstop is armed once in `armPending`, so a streaming-but-unresolved turn can't defer the 12-min cap forever. |
| 3 | Narration-dedup scope | **#407 resolved the canonical path; a residual remained → fixed.** The seq-keyed `/events` dedup (#407) does NOT suppress legitimately-repeated lines (different `seq`). But the TEXT-key fallback (`seenText`, used only for `/chat`-only beats) was run-long, so a repeated short line on a later `/chat`-only turn (a catchphrase, a repeated "Yes.") was permanently suppressed. `seenText` now resets when a turn resolves (the gap it must span is one turn's `/events`→`/chat`). |
| 4 | Retried cold-open drops 4min → 180s | **Fixed** — `firstBeat` now keys off a new `resolvedTurnsRef` (bumped only on `/chat` turn-resolution), not `dmBeatCountRef` (bumped per streamed paragraph). A retried cold-open whose first turn never resolved keeps the generous 4-min window. |
| 5 | Headline freezes after 38.5s | **Fixed** — added `BUILDING_FLAVOR_LATE`, a calmer "still composing — a rich opening is worth the wait" pool used past ~42s, so the headline keeps fresh, on-arc copy for the full overlay lifetime (still rotates → proof-of-life). |
| 6 | Untested lifecycle + wrong comment | **Fixed** — added an effect-running test harness + the lifecycle tests below; rewrote the misleading "min-display floor" comment (no such floor exists). |

## How I verified the wedge is gone

- **New effect-running lifecycle harness** (`test_building_universe.py`) drives the **real** `useBuildingUniverse` hook with a minimal working React (real `useState`/`useEffect`+cleanup/`useRef`/`useCallback`) + a controllable clock/timers. Asserts: handoff-on-narration clears the cover; **dismiss-on-error** (after grace) clears it; a **stale error within grace** does NOT dismiss (and a persisting one does); the **~120s ceiling** dismisses (and does NOT re-arm on re-renders); the **"Enter anyway"** affordance arms after ~15s and `dismiss()` clears the flag; and a negative-disclosure test that no-beat-within-ceiling legitimately stays up.
- **Component render tests** confirm the root is no longer a false `aria-modal` dialog and the escape renders as a real wired `<button>`.
- **Streaming-hook regression guards** (`test_live_narration_stream.py`): a repeated `/chat`-only line renders on a later turn (#406.3); a streamed-but-unresolved cold-open keeps the first-beat window (#406.4). Both were confirmed to **FAIL on pre-fix behavior** and pass after.
- Booted the viewer (`viewer/server.py "" 8884`) and confirmed it serves the changed bundle. (Browser-eyeball wasn't possible this session — the Preview tool kept binding to a different local checkout and Claude-in-Chrome was disconnected — so the lifecycle harness is the behavioral proof.)

## Scope
Viewer-only: `viewer/openworlds/{building-universe,app}.jsx`, `styles.css`, + the two test files. No DM skill / `--resume` / `persist_beat` / engine / wire-contract changes.

CI runs the viewer suite (`viewer-tests` job, `pytest viewer/tests -q -p no:xdist`); the new lifecycle tests run there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Enter anyway" escape button to the loading overlay, allowing manual dismissal after a brief wait period.
  * Enhanced loading overlay with better error handling and accessibility improvements.

* **Bug Fixes**
  * Improved stability and recovery behavior for live sessions.
  * Added automatic timeout protection for the loading overlay to prevent indefinite hangs.

* **Tests**
  * Expanded test coverage for overlay lifecycle, error handling, and narration behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->