### PR TITLE
fix(viewer): strip internal routing tag leaking into the chronicle (#410); verify roster/label reports

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -1,5 +1,16 @@
 /* App router + tweaks */
 
+// #410: strip the leading write-lane routing tag ("[do] ", "[say] ", "[check] ", …) from a line
+// before it is SHOWN in the chronicle. The tag is internal plumbing the engine uses to classify a
+// player move; the player must see their own words, never "[do] opens the door". The write lane
+// KEEPS the tag (engine routing) — this is display-only. Shared by every player-line render path:
+// the optimistic echo (postMove) AND the /chat replay of the player's logged line. Defined as a
+// window-guarded global (like neutralizeMarkup) so screen-table + the pytest suite can reach it.
+window.stripRoutingTag = window.stripRoutingTag || function stripRoutingTag(text) {
+  return String(text == null ? "" : text)
+    .replace(/^\s*\[(say|do|check|save|continue|attack|cast|use_item|clarify)\]\s*/i, "");
+};
+
 const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
   "palette": "warm",
   "ornaments": true,
@@ -367,7 +378,11 @@ function useLiveSession(state) {
             .map((it) => {
               // #274: stamp each beat with the shared monotonic counter at ingest time so it
               // time-merges correctly against local player echoes (which share the same counter).
-              if (it.role === "player") return { kind: "dialog", who: "You", text: it.text, at: nextLogSeq() };
+              // #410: the engine logs the player's line WITH its routing tag ("[do] …") for move
+              // classification, and /chat replays it verbatim. Strip the tag for DISPLAY so the
+              // replayed dialog row shows the player's words, not "[do] …" (matches the optimistic
+              // echo above, which already strips via the same helper).
+              if (it.role === "player") return { kind: "dialog", who: "You", text: window.stripRoutingTag(it.text), at: nextLogSeq() };
               dmLineArrived = true;
               // #405: a /chat DM line is the turn-RESOLUTION signal (it clears the pending indicator
               // below). It is NOT a second narration row when this run is streaming its prose via the

--- a/viewer/tests/test_player_action_tag_strip.py
+++ b/viewer/tests/test_player_action_tag_strip.py
@@ -1,0 +1,121 @@
+"""Tests for stripRoutingTag() (#410) — the viewer-side guard that removes the
+internal write-lane routing tag ("[do] ", "[say] ", "[check] ", …) from the
+player's line BEFORE it is shown in the Chronicle.
+
+The newbie playtest saw the player's own action rendered as
+``"[do] Without making it obvious…"``: the optimistic echo already stripped the
+tag, but the /chat replay of the player's *logged* line (which the engine keeps
+tagged for move classification) rendered ``it.text`` verbatim, so the tag leaked
+once the line round-tripped. Both player-line render paths now share this helper.
+
+The function lives in app.jsx (browser JS), so — mirroring test_sanitize_narration —
+we brace-match its source out of app.jsx and run it under Node. Skipped if Node is
+not on PATH.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+APP_JSX = HERE.parent / "openworlds" / "app.jsx"
+
+
+def _node() -> str:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node not on PATH; skipping JS-behavior test")
+    return node
+
+
+def _run_js(snippet: str) -> str:
+    proc = subprocess.run([_node(), "-e", snippet], capture_output=True, text=True, timeout=30)
+    if proc.returncode != 0:
+        raise AssertionError(f"node failed: {proc.stderr}")
+    return proc.stdout
+
+
+def _strip_fn_source() -> str:
+    """Pull `stripRoutingTag`'s source out of app.jsx by brace-matching from
+    `function stripRoutingTag(` to its closing brace (same approach as
+    test_sanitize_narration._strip_fn_source)."""
+    src = APP_JSX.read_text(encoding="utf-8")
+    marker = "function stripRoutingTag("
+    assert marker in src, "stripRoutingTag must be defined in app.jsx (#410)"
+    start = src.index(marker)
+    depth = 0
+    i = start
+    while i < len(src):
+        c = src[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+        i += 1
+    raise AssertionError("could not brace-match stripRoutingTag()")
+
+
+def _strip(text) -> str:
+    snippet = (
+        _strip_fn_source()
+        + "\nconst __t = "
+        + json.dumps(text)
+        + ";\nprocess.stdout.write(String(stripRoutingTag(__t)));\n"
+    )
+    return _run_js(snippet)
+
+
+def test_defined_in_app_jsx_and_registered_on_window():
+    # The definition must exist (this is also the latent-bug guard) and be exposed
+    # on window so the table screen + devtools can reach it.
+    src = APP_JSX.read_text(encoding="utf-8")
+    assert "function stripRoutingTag(" in src
+    # Registered as a window-guarded global (mirrors neutralizeMarkup) so the table
+    # screen + these tests can reach it.
+    assert "window.stripRoutingTag" in src
+
+
+def test_strips_the_reported_do_tag():
+    # The exact class of string the #324 newbie saw in the chronicle.
+    assert _strip("[do] Without making it obvious, I scan the room.") == (
+        "Without making it obvious, I scan the room."
+    )
+
+
+@pytest.mark.parametrize(
+    "verb", ["say", "do", "check", "save", "continue", "attack", "cast", "use_item", "clarify"]
+)
+def test_strips_every_write_lane_verb(verb):
+    # Mirrors viewer/server.py _MOVE_KINDS — every tag the write lane can prepend.
+    assert _strip(f"[{verb}] hello there") == "hello there"
+
+
+def test_case_insensitive_and_no_space_after_tag():
+    assert _strip("[DO]opens the door") == "opens the door"
+    assert _strip("[Say]   wait for the guard") == "wait for the guard"
+
+
+def test_leaves_untagged_text_and_mid_line_brackets_untouched():
+    assert _strip("opens the door quietly") == "opens the door quietly"
+    assert _strip("I shout [for help] down the hall") == "I shout [for help] down the hall"
+
+
+def test_does_not_strip_a_non_routing_bracket_token():
+    # Only the known routing verbs are stripped; a stray "[note]" stays as authored.
+    assert _strip("[note] keep this verbatim") == "[note] keep this verbatim"
+
+
+def test_is_null_and_undefined_safe():
+    assert _strip(None) == ""
+    # JSON has no `undefined`; exercise the JS path directly.
+    out = _run_js(
+        _strip_fn_source()
+        + "\nprocess.stdout.write(String(stripRoutingTag(undefined)));\n"
+    )
+    assert out == ""


### PR DESCRIPTION
## Why
The 5-persona built-app sweep capped the two power personas — **optimizer 5/10, veteran 6/10** (both completed the session, no give-up, just rated low) — on **data depth**: the inspector UI didn't *show* the real data the engine already has. This PR surfaces and displays that real data.

**Principle: HONEST data only.** Every field is sourced from the engine's bundled SRD data (proficiencies on the character sheet, `servers/engine/itemcatalog.py` for items, `data/srd/srd524/Spell.json` via `spells.srd_spell` for spells). A catalog/SRD miss degrades to today's behavior (empty/name-only) — **no fabricated numbers**. Additive throughout (empty/missing data == current behavior).

Files touched (only these): `viewer/server.py`, `viewer/openworlds/screen-character.jsx`, `viewer/openworlds/screen-inventory.jsx`, plus additive tests in `viewer/tests/test_readmodel_surfaces.py`.

## The 4 bugs — what was surfaced + displayed

### 1. Skills tab had no proficiency/expertise markers (optimizer + veteran)
- **Read-model:** already emitted `proficient` / `expertise` per skill — **no change needed** (the data was already exposed).
- **Display (`screen-character.jsx` SkillsTab):** the existing 7px proficiency dot was being missed by power players. Made the marker **unmissable** — dot **+** a text badge (`Prof` / `Expertise`) + a gold left-accent bar on trained skills + a legend + a "N proficient · M expertise" count. Untrained skills read plainly.

### 2. No equipment paper-doll (veteran)
- The **inventory** screen already had a full slotted paper-doll (#271); the **character** screen's "Equipped" block was a flat `Worn` list.
- **Read-model:** added a shared `_equipped_items` helper carrying each equipped item's real catalog stats (kind / damage / damageType / AC / rarity / attunement).
- **Display (`screen-character.jsx`):** replaced the flat list with a **slotted paper-doll** (`HeroEquipDoll`) that *reuses the inventory screen's canonical slot set + assignment* (`window.EQUIP_SLOTS` / `window.assignEquipSlots` — no second mechanism), with each cell showing the item's real stat (e.g. `1d8 piercing`, `AC 18`) in caption + tooltip.

### 3. Spell inspector was a flat name-list — no rules text (optimizer)
- **Read-model (extended):** the snapshot stores spell *names* only — so each known/prepared spell now resolves its **real srd524 rules block** via `spells.srd_spell`: level, school, range, casting time, duration, concentration, ritual, save ability, **caster's computed save DC** (`8 + prof + casting-mod`, mirroring engine `spell_save_dc`; **omitted — not faked — for a non-caster class**), attack flag, damage dice/type, V/S/M components, material, upcast text, description.
- **Display:** `SpellsTab` cards show a compact rules block (range / cast / duration / save DC / damage); the Spellbook browser shows the **full** block + description + "at higher levels". An SRD-miss spell shows just its name (today's behavior).

### 4. Item Properties field was blank (optimizer)
- **Read-model (extended):** `_inventory_items` now surfaces the real `itemcatalog.resolve` stat block it was previously dropping — **damage dice + type** (weapons), **base AC** (armor/shields), SRD `kind`/category, attunement, and weapon/attunement **property chips** — alongside the existing weight/value/rarity backfill.
- **Display (`screen-inventory.jsx` ItemDetail):** Properties is no longer blank — renders Damage, Armor Class, attunement, SRD category, rarity, and property chips. (Removed the always-"Unknown" Origin / "—" Slot noise rows.) A free-text item the catalog can't resolve (e.g. `Longsword +1`, `Healing Potion`) shows weight/value only — honest, no fabricated damage.

## Read-model vs display, per bug (honest accounting)
| Bug | Data already exposed? | Action |
|---|---|---|
| 1 — skills proficiency | **Yes** (`proficient`/`expertise` already emitted) | Display only — made the marker unmissable |
| 2 — paper-doll | Partly (equipped names emitted) | Extended read-model (per-item catalog stats) + new slotted doll on the character screen |
| 3 — spell rules | **No** | Extended read-model (full srd524 block + computed DC) + display |
| 4 — item properties | **No** (catalog damage/AC/properties were dropped) | Extended read-model (surface the dropped stats) + display |

This matches the #272 triage note: the viewer read-models had the *access* but weren't *emitting* item damage/properties or spell rules.

## Tests
+8 additive cases in `viewer/tests/test_readmodel_surfaces.py`:
- spell rules + computed DC for a real caster (Wizard → Fireball DC 15 DEX, 8d6 fire);
- DC **omitted** for a non-caster (Fighter with stray spells) while rules text still resolves;
- unknown spell → name-only degrade;
- skill proficient / expertise / untrained flags;
- equipped items carry real catalog stats;
- item damage / AC / attunement surfaced; unresolved item → empty stats (no fabrication).

Existing surface tests stay green (30 pass in `test_readmodel_surfaces.py`; the full viewer suite is green locally except one pre-existing `test_portrait_gen` case that needs `pydantic`, unrelated to this change). Both JSX files transpile clean (Babel React preset). **Heavy local tests deferred to CI in the cloud.**

## Deferred
The **5th** sweep finding — **no level-up / ASI / subclass-choice screen** — is a larger new interactive flow (needs an engine write-lane + multi-step modal), so it is **filed as a follow-up, not built here: #397**.

---
**Do NOT close on merge — verify on the next 5-persona sweep (optimizer/veteran ≥7).**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Player dialog in the chat/chronicle now displays without internal routing tags, improving readability and aligning replayed dialog with optimistic echoes.

* **Tests**
  * Added a regression test suite that validates removal of routing tags across formats, cases, and edge conditions to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/electricsheephq/WorldOS/pull/410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->