### PR TITLE
fix(play): bash-3.2-safe empty-array expansion in dm_turn — unblocks every playtest (#420)

### DIFF
--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -229,7 +229,7 @@ dm_turn() {
   out="$DM_LOG.$(date +%s%N).jsonl"
   _dm_invoke() {
     timeout "$CLAWDND_BEAT_TIMEOUT" \
-      claude -p "$msg" "${resume[@]}" "${extra[@]}" --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+      claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
         --model "$CLAWDND_DM_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
         --output-format stream-json --verbose > "$out" 2>> "$DM_LOG.err"
   }


### PR DESCRIPTION
Closes #420 (bug CONFIRMED + reproduced + fixed on this host).

## Root cause (verified on bash 3.2.57, the macOS host default)
`dm_turn()` (scripts/play.sh) builds `resume=()` + `extra=()` then expands `"${resume[@]}" "${extra[@]}"` in the `claude -p` call (L232). On the **non-lean default beat path** `extra` stays EMPTY, and under `set -uo pipefail` bash 3.2.57 throws `extra[@]: unbound variable` at L231 → play.sh dies **before seating the PC** → backend never becomes player-ready → **every playtest/gate on main produces zero scores (dead on arrival)**. Regression from #417 (lean-beats merge added the `extra=()` array).

## Evidence
- Live: `backend.log: line 231: extra[@]: unbound variable`; smoke on flag-OFF path → `can_act:false`, empty party.
- Unit repro: `bash -c 'set -u; extra=(); printf "%s" "${extra[@]}"'` → throws; with the `+` guard → exit 0.
- Same error present in `qa/ui_playtest_runs/gate-96c0401-newbie/backend.log`.

## Fix (one line)
Guard both expansions: `${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"}` — expands to nothing (no throw) when empty on bash 3.2+.

## After fix (verified)
flag-OFF smoke: **0 unbound errors**, backend proceeds to cold-open (was: died at L231). `bash -n` clean.

## Correction to #420
The issue's secondary claim of a 'triplicated 4× extra= block / stray line-27' is NOT accurate — there is exactly 1 `claude -p` call, 1 `extra[@]` site, a clean if/elif/else. The real cause is the empty-array expansion (above); nothing to de-duplicate. The bug, the bash-3.2 mechanism, and the `+`-guard remedy are all correct.

**Do NOT close on merge — verify the next gate run produces persona scores.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal script argument handling for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->