### PR TITLE
docs(roadmap): canonical graphics & game-types roadmap + M0 thin-client spike

### DIFF
--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -16,6 +16,13 @@
 >
 > Last updated: 2026-05-28 (post-v1.0.1).
 >
+> **Graphics & game-types roadmap (canonical):** the long-term plan for the kinds of games
+> WorldOS can produce (GT0 narrative dashboard → GT1 SNES pixel → GT2 Pillars/BG isometric)
+> and the capabilities (C1–C10) that mature Branch A → Branch B lives in
+> [`docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md`](docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md) —
+> the single source of truth, executed via GitHub Milestones + Issues. Invariant: the
+> renderer is always a thin client; the engine stays the sole writer of state.
+>
 > **v1.0.1 ([Release](https://github.com/electricsheephq/WorldOS/releases/tag/v1.0.1)):** Phase-4 action lanes complete — Merchant BUY and Forge Craft now relay structured `/move` intents during live play (Create was already wired to the bridge). The seven BG3 origin heroes carry full `companion_dossier` blocks (wound / wants / fears / values / approval / banter / camp prompts). Native-app reliability: build script prefers stable Developer ID signing when keychain ACL allows; `script/unblock_native_app.sh` is a one-shot helper for security-scanner re-evaluation hangs. `docs/SPARKLE_SETUP.md` is the 7-step path to auto-update on top of Developer ID. Engine **1385/1385 ✓**, viewer **90/90 ✓**, license-check clean. **Open gap (owner-only):** first-run Keychain "Always Allow" click on a Developer-ID-signed app to end "popup every rebuild" — or run `script/unblock_native_app.sh` once.
 
 ---

--- a/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
+++ b/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
@@ -1,0 +1,165 @@
+# WorldOS Graphics & Game-Types Roadmap (canonical)
+
+> **Single source of truth.** This document is the canonical roadmap for WorldOS's graphics
+> layer and the kinds of games it can produce. It lives in the repo (`docs/roadmap/`),
+> ties to the runbook, and is executed via GitHub Milestones + Issues. Any other view
+> (Notion, slides) is a **read-only downstream mirror** of this file + GitHub — never a
+> second writer. This mirrors WorldOS's core architecture: the engine is the sole
+> authority; everything downstream is a projection.
+>
+> Status: **DRAFT — local, not yet filed.** Confidence on direction ≥95% (first-principles
+> decision 2026-05-31; full record in LEXAR session-notes `worldos-graphics-roadmap/`).
+> Supersedes `roadmap-v2-FINAL.md` by absorbing it into the capability framing below.
+
+---
+
+## 0. The two organizing axes
+
+WorldOS games are described by two axes. The roadmap is the plan for filling in the grid.
+
+- **Axis 1 — GAME TYPES** (`GT*`): the kinds of games WorldOS can produce. A game type is a
+  *presentation family* over the one shared engine — NOT a separate engine.
+- **Axis 2 — CAPABILITIES** (`C*`): the settings / abilities / configurations a game can use
+  (rendering, movement, combat presentation, assets, input, UGC, AI-autonomy…). Each
+  capability has **maturity levels**; **Branch A** = the level we ship first, **Branch B** =
+  the level we grow into later.
+
+A milestone is then defined as *"these capabilities reach these levels for these game types."*
+Capabilities evolve gradually; that gradual evolution **is** the roadmap.
+
+### The one invariant under everything (non-negotiable)
+**The Python engine is the sole writer of game state.** Every game type and every capability
+is a *renderer/presentation* concern consuming the read-model surfaces (`/atlas-surface`,
+`/character-surface`, `/combat-surface`, `/chat`, `/events`) + the single `POST /move` intent
+lane. No renderer, no AI loop, no UGC tool ever becomes a second source of truth.
+
+---
+
+## 1. Game-type taxonomy (Axis 1)
+
+| ID | Game type | Status | Engine for it | Notes |
+|----|-----------|--------|---------------|-------|
+| **GT0** | **Narrative dashboard** (the current OpenWorlds web UI) | **SHIPS TODAY** | React/JSX in WKWebView | The living-world DM + companion RPG; text/portrait-first. The proof that engine-as-authority + thin-client works. |
+| **GT1** | **SNES-style pixel turn-based** (JRPG / RPG-Maker-like feel) | Planned (MVP tier 1) | Phaser 3 (MIT), in the existing shell | Tilemap + sprite actors + 16-bit UI; zone-mode turn combat. |
+| **GT2** | **Pillars / BG1-2 isometric party cRPG** | Planned (MVP tier 2) | Phaser 3 (MVP look) → Godot 4 (premium native, optional) | Painted backdrop + token actors. **Branch A = the LOOK; Branch B = measured tactics (evidence-gated).** |
+| GT3+ | (future families — e.g. tactical-grid SRPG, top-down action) | Not scoped | TBD | Added only when a capability set + audience justify it. |
+
+**Rejected engines (recorded so they're not re-litigated):**
+- **RPG Maker MZ** — EULA refutes multi-tenant UGC (Authorized-User-only; RTP welded to its
+  editor; corporate use excluded). At most a deferred, asset-clean, exploration-only BYOL
+  export for GT1. NOT a T2/isometric option (orthogonal-tile-locked).
+- **Unity** — no macOS Unity-as-a-Library (can't embed in the WKWebView shell → separate
+  binary); cRPG toolkits assume Unity owns the rules (conflicts with engine-authority);
+  weakest AI-buildability (35/100); licensing drag for UGC vs MIT.
+- **GemRB** — GPL-2.0 (viral), C++ native, IE-data-bound. Reference for the look only.
+- **Custom WebGL/WebGPU engine** — reject for the foreseeable roadmap.
+
+---
+
+## 2. Capability model (Axis 2) — Branch A → Branch B maturity
+
+Each capability is a dial. Branch A is the first shippable level; Branch B is the growth level.
+"Configs/settings/abilities" the user referenced = these dials, exposed per game.
+
+| ID | Capability | Branch A (ship first) | Branch B (grow into) | Engine impact |
+|----|-----------|----------------------|----------------------|---------------|
+| **C1** | **Positioning model** | `theater` / `zone` (named regions; engine already has this) | `grid` (authoritative coords + measured range/LoS/AoE, **turn-based**, NO real-time) — **evidence-gated** | A = none; B = additive engine STATE (own first-principles pass) |
+| **C2** | **Scene presentation** | tilemap (GT1) · painted backdrop (GT2) | dynamic normal-map lighting (the PoE glow) | renderer-owned |
+| **C3** | **Combat presentation** | zone-band tokens, pure replay of engine `/events` | measured-grid tactics view (pairs with C1-B) | A = none; B = with C1-B |
+| **C4** | **Movement / travel** | menu travel · click-to-zone · walkmask click-to-move (renderer-owned mask) | measured per-turn movement budget (with C1-B) | A = none; B = with C1-B |
+| **C5** | **Asset pipeline** | portraits (exists) · AI pixel sprites · tilesets · painted backdrops · audio | curated per-race/scene sets; user uploads | renderer/content; AI-disclosure metadata mandatory |
+| **C6** | **Input intents** (`/move` palette) | `say/do/check/save/combat/attack/cast/use_item/clarify` (today) **+ `travel`, `inspect`, `move_to_zone`** | drag-to-zone gestures; ability-bar verbs (Shove/Dash/Hide) | **contract change — freeze in M0**, roll across viewer+DM+facade together |
+| **C7** | **Lighting** | flat-lit backdrops | normal-map dynamic lights (Godot-native; Phaser custom) | renderer-owned |
+| **C8** | **Transport** | 3s poll (today) | WebSocket/SSE push (same payload shapes) | additive engine surface (anytime after M0) |
+| **C9** | **AI build-loop autonomy** | manual scaffold + human review | gated unattended scaffold (~70-80%) w/ screenshot-critic + blind-playtester gates | tooling; loop never mutates the contract |
+| **C10** | **UGC** | none → author scenes | author whole games → ship/sell (MIT-clean stack) | per-user games persist as engine-owned data |
+
+**Branch A vs Branch B in one line:** Branch A = *every capability at its first shippable level
+for GT0/GT1/GT2*; Branch B = *the growth levels (measured tactics, dynamic lighting, full
+autonomy, ship/sell UGC)* layered on as the long-term plan proves out.
+
+---
+
+## 3. The capability × game-type matrix (target at end of MVP / Branch A)
+
+| Capability | GT0 dashboard | GT1 pixel | GT2 isometric |
+|-----------|---------------|-----------|---------------|
+| C1 positioning | zone | zone | zone (Branch A) → grid (Branch B, gated) |
+| C2 scene | (text/portrait) | tilemap | painted backdrop |
+| C3 combat | log/cards | zone-band | zone-band → measured (B) |
+| C4 movement | menu | click-to-zone | walkmask click-to-move |
+| C5 assets | portraits | sprites+tilesets | backdrops+tokens |
+| C6 input | full palette+travel | +target/move_to_zone | +target/move_to_zone |
+| C7 lighting | n/a | flat | flat → normal-map (B, Godot) |
+| C8 transport | poll → ws | poll → ws | poll → ws |
+| C9 autonomy | manual | gated loop | gated loop |
+| C10 UGC | none | author→ship (B) | author→ship (B) |
+
+---
+
+## 4. Architecture decisions (locked; confidence ≥95% on direction)
+
+1. **Renderer = thin client; engine = sole writer.** (The invariant.)
+2. **Phaser 3 (MIT) + PixiJS v8 (MIT) for the MVP, BOTH tiers**, in the existing React/WKWebView
+   shell. One renderer, two render profiles (tilemap / backdrop). Godot 4 reserved for an
+   optional *premium native desktop/Steam* GT2 client later (separate binary; MIT). Unity rejected.
+3. **Contract is LAYERED: core + per-renderer profiles.** Core (renderer-agnostic, all fields
+   defaultable for the AI generator): `schema_version`, `scene_kind`, `positioning`, named
+   `zones` (NOT x,y), engine FK ids, scope-key art, AI-disclosure. Optional blocks: `phaser{}`,
+   `rpgmaker{}` (reserved). Core-only conformance test gates it.
+4. **Positions are presentation derived from engine zones** — already the shipped pattern
+   (`viewer/server.py:_combat_row_positions`). Token x,y is an ephemeral render-hint, never state.
+5. **M0 freezes THREE contracts together:** render-profile · graphical move-intent vocabulary
+   (`_MOVE_KINDS` extension) · surface-read guarantees (stable-actor-id test, authoritative-vs-
+   derived fields, `/events` ordering). The move-vocabulary is the most likely breaking-change
+   source if not frozen first.
+6. **RTwP (real-time + party-AI) is REJECTED permanently.** BG3 dropped it; it's incompatible
+   with an LLM-DM (an LLM narrates turn-by-turn, can't drive a real-time tick); it would rebuild
+   the engine (B1) or break sole-writer (B2). The genre identity lives in the LOOK + turn-based
+   positioning, not RTwP.
+7. **C1-B (measured-grid turn-based tactics) is the ONLY future engine spatial work worth doing,
+   and it's EVIDENCE-GATED** (owner 2026-05-31: "decide after a playtest"). Triggered only if a
+   real GT2 playtest shows zone-theater feels too abstract. Own first-principles pass.
+
+---
+
+## 5. Milestones → Epics → Issues
+
+> Each milestone advances specific capabilities to specific levels for specific game types.
+> Issue bodies are drafted in the companion `roadmap-v2-FINAL.md`; titles below are file-ready.
+
+### M0 — Contract freeze + thin-client spike  *(advances C6 freeze, C1=zone, C8 groundwork; GT-agnostic)*
+- **R0.1 Render-profile contract** (core + per-renderer blocks; zones-not-xy; core-only conformance test in CI)
+- **R0.2 Graphical move-intent vocabulary** (extend `_MOVE_KINDS`: travel/inspect/move_to_zone; doc; reject-unknown test; cross-component freeze)
+- **R0.3 Surface-read guarantees + spike** (stable-actor-id test [BLOCKING]; namespace the derived position hint; Phaser thin-client spike rendering one location)
+
+### M1 — GT1: SNES pixel turn-based MVP  *(C2=tilemap, C3=zone-band, C4=click-to-zone, C5=sprites, C9=manual)*
+- **R1.1 T1 render profile + tilemaps** · **R1.2 T1 combat + character UI (zone-mode)** · **R1.3 T1 QA gates** (reuse screenshot-recorder + UI-gate + blind-playtester; add "no VTT grid chrome in zone mode" check)
+
+### M2 — GT2: Pillars/BG1-2 backdrop-isometric MVP (Branch A = the LOOK)  *(C2=backdrop, C3=zone-band, C4=walkmask, C7=flat)*
+- **R2.1 Backdrop render profile + occlusion** (walkmask renderer-owned; destinations resolve to engine zones/locations) · **R2.2 T2 combat + polish** (pure replay; normal-map lighting deferred) · **R2.3 T2 QA gates**
+
+### M3 — Gated AI build-loop + UGC  *(C9=gated autonomy, C10=author→ship, C5 disclosure)*
+- **R3.1 Gated AI build-loop** (generate render-profile core from lore; resolve art; emit Phaser glue; gate each iter; human-gate queue for taste/story/contract) · **R3.2 UGC platform + licensing/compliance** (per-user ownership; AI-disclosure end-to-end [EU 2026-08-02, Steam survey]; MIT redistribution story) · **R3.3 Transport upgrade** (C8: websocket/SSE; swap behind SurfaceClient interface)
+
+### M5 — *(optional, post-M2)* GT2 premium: Godot desktop/Steam client (Branch B look: C7 normal-map lighting)
+- Godot thin client over the surfaces (HTTPRequest/WebSocketPeer; Light2D; NavigationRegion2D); consumes the `core` contract; GDScript headless-codegen harness (compile-error feedback + `.tscn` gen + `godot-mcp`).
+
+### M6 — *(optional, post-M1)* GT1 BYOL RPG Maker exploration export
+- Asset-clean (no RTP), exploration/dialogue only (battle-system mismatch is fatal), contract-taker; RTP legal guardrails + counsel review.
+
+### Future — *(EVIDENCE-GATED)* C1-B measured-grid turn-based tactics
+- Trigger: GT2 playtest shows zone-theater too abstract. Own first-principles pass. Additive engine state (coords + measured range/LoS/AoE), turn-based, NO real-time/party-AI. RTwP stays rejected.
+
+---
+
+## 6. Ties to the runbook + single-source-of-truth mechanics
+- **Canonical:** this file (`docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md`) + GitHub Milestones/Issues + the WorldOS runbook (engine invariants, dev loop, QA gates).
+- **Execution:** each epic → a GitHub milestone; each issue → a GitHub issue with the `graphics` + `epic:*` + game-type (`gt0/gt1/gt2`) + capability (`cap:c1…c10`) labels, so the matrix is queryable.
+- **Mirror (optional):** a read-only Notion roadmap view generated FROM this file + GitHub — never edited directly. Canonical stays GitHub.
+- **Maintenance:** this file is updated as capabilities advance levels; the decision log (LEXAR `worldos-graphics-roadmap/`) records *why* each level moved.
+
+## 7. Open decisions deferred to owner (genuinely need you)
+1. Self-hosted open image model vs commercially-indemnified API for UGC assets (affects M3).
+2. GT2 MVP: flat-lit backdrops first (recommended) — confirmed; normal-map lighting = Branch B / Godot.
+3. Does the AI build-loop become a user-facing surface ("watch it build") or an internal authoring tool? (shapes M3 UX.)

--- a/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
+++ b/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
@@ -7,9 +7,11 @@
 > second writer. This mirrors WorldOS's core architecture: the engine is the sole
 > authority; everything downstream is a projection.
 >
-> Status: **DRAFT — local, not yet filed.** Confidence on direction ≥95% (first-principles
-> decision 2026-05-31; full record in LEXAR session-notes `worldos-graphics-roadmap/`).
-> Supersedes `roadmap-v2-FINAL.md` by absorbing it into the capability framing below.
+> Status: **FILED** — PR #424; milestones M0–M6 + Future-gated; issues #425–#461. Confidence
+> on direction ≥95% (first-principles decision 2026-05-31). The full decision records
+> (research report, architecture decision, T2-engine addendum) are operator-local
+> session-notes and are intentionally not committed; this document is the in-repo canonical
+> distillation of them.
 
 ---
 

--- a/spikes/m0-phaser-thin-client/README.md
+++ b/spikes/m0-phaser-thin-client/README.md
@@ -1,0 +1,51 @@
+# M0 spike — Phaser thin-client (renderer-as-client proof)
+
+> **The pixels are not the point.** This spike exists to validate the renderer-integration
+> **contract** and surface the gaps the engine team must close in M0. The Phaser scene is
+> throwaway. Decision record: `/tmp/decision-worldos-render-contract.md`; roadmap:
+> `roadmap-v2-FINAL.md` (LEXAR session-notes 2026-05-31).
+
+## Run it
+```
+cd spikes/m0-phaser-thin-client
+python3 -m http.server 8088
+# open http://127.0.0.1:8088/  (renders standalone on bundled fixtures)
+# live:  http://127.0.0.1:8088/?campaign=<id>&base=http://127.0.0.1:8765
+```
+
+## What it PROVES (the architecture decision, made visible)
+1. **Renderer owns no state.** `surface-client.js` only GETs the read-models and POSTs an intent. Re-fetch every poll; the engine is sole writer. The websocket/SSE upgrade (M3) slots behind the same `SurfaceClient` interface — callers unchanged.
+2. **Positions are presentation derived from engine zones (D1).** The scene draws **zone bands** and groups tokens by `zone`, re-deriving x,y itself — it deliberately **ignores** the surface's `position.x/y` to prove that field is an ephemeral hint, not state. This mirrors what `viewer/server.py:_combat_row_positions` already does server-side.
+3. **Zone-mode renders bands, NOT a VTT grid.** No cells, no rulers, no measurement — the honest rendering the contract requires (so the engine's gridless zone combat is never misrepresented as coordinate-tactical).
+4. **One contract, layered.** `render-profile.example.json` is the concrete core + per-renderer-block schema. The `rpgmaker` block is reserved/spec-only (BYOL exploration export, deferred post-M2).
+5. **Turn/initiative HUD + party panel** come straight from the already-shipped `/combat-surface` (#412) and `/character-surface` — zero client rules.
+
+## CONTRACT GAPS this spike SURFACES (the M0 freeze — engine-team priority)
+
+These are the three contracts to freeze in M0, *before* T1/T2 build. The spike hits each concretely:
+
+### GAP 1 — graphical move-intent vocabulary (BLOCKING, engine-side)
+The spike POSTs `{kind:"travel", target:"loc-..."}` on a travel click. The current engine **rejects** it: `_MOVE_KINDS` (viewer/server.py:84) is a closed allowlist `{say,do,check,save,combat,attack,cast,use_item,clarify}` with no `travel`. `sanitize_move` returns `"unknown move kind 'travel'"`.
+- **Why blocking:** if T1 ships click-to-travel as `do "go to the harbor"` (free text) and M2 later adds `{kind:travel}`, every M1 game + AI-loop glue emits the old shape → breaking change.
+- **Freeze now:** add structured graphical intents — `travel`(target=location_id), `inspect`/`examine`(target), `move_to_zone`(zone) — to `_MOVE_KINDS` + `_MOVE_FIELDS` + `sanitize_move`, designed once. Additive at the facade, but semantic for every consumer.
+
+### GAP 2 — surface-read guarantees (engine-side)
+The spike tweens/keys tokens by actor `id` and treats `zone` as authoritative, `position.x/y` as a hint. Three guarantees must be documented + tested:
+- **Stable actor id across snapshots** (BLOCKING test): tweening pops/respawns tokens if ids churn on re-seed/regeneration. Assert ids persist for the same logical entity.
+- **Authoritative-vs-derived fields:** mark `_combat_row_positions` x,y as ephemeral (suggest renaming to `_render_hint_position`) so no renderer/AI-loop persists it as state (it would become a second source of truth the engine silently overwrites).
+- **`/events` ordering/replay semantics:** the renderer replays engine-decided combat as animation; needs ordered, replayable events.
+
+### GAP 3 — render-profile contract shape (cross-cutting)
+`render-profile.example.json` here is the proposed freeze: layered **core** (scene_kind, named zones, engine FK ids, scope-key art, ai_disclosure — all defaultable for the AI generator) + optional per-renderer blocks. Needs: a JSON Schema, a **core-only conformance test** (a renderer using core + its block renders every M0 scene — extends the viewer-tests CI lane #403), and `schema_version` + capability negotiation so authored UGC profiles survive evolution.
+
+### Also confirmed (NOT gaps — additive/renderer-owned)
+- **Walkmask (T2)** is renderer-owned presentation (engine knows location adjacency, not walkable pixels) — no engine change; pathfinding *destinations* still resolve to engine zones/locations.
+- **Turn/initiative surface** already exists (#412) — not a new surface.
+- **`grid` mode** is explicitly OUT of v1 (a future engine-state epic), so no coordinate/movement/LoS engine work is in M0–M3.
+
+## Files
+- `render-profile.example.json` — the contract, concretized (core + per-renderer blocks)
+- `surface-client.js` — the swappable thin-client transport (poll now; ws later)
+- `spike.js` — the Phaser zone-mode scene
+- `index.html` — entry (Phaser 3 from CDN)
+- `fixtures/*.json` — surface payloads mirroring the real builder shapes (run standalone)

--- a/spikes/m0-phaser-thin-client/fixtures/atlas-surface.json
+++ b/spikes/m0-phaser-thin-client/fixtures/atlas-surface.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Fixture mirroring the REAL /atlas-surface shape (derived from viewer/server.py _atlas_known_locations + _atlas_edges + the PR #391 world_graph route_kind work). Lets the spike render standalone (no live game). The spike's SurfaceClient prefers a live ?campaign= endpoint and falls back to this.",
+  "campaign_id": "bg-absolute-remnants",
+  "current_location": { "id": "loc-lower-city", "name": "Baldur's Gate — Lower City" },
+  "current_location_id": "loc-lower-city",
+  "known_locations": [
+    { "id": "loc-lower-city", "name": "Baldur's Gate — Lower City", "tags": ["hub", "city"], "discovered": true, "visited": true },
+    { "id": "loc-upper-city", "name": "Baldur's Gate — Upper City", "tags": ["city", "intrigue"], "discovered": true, "visited": false },
+    { "id": "loc-outer-city", "name": "The Outer City & Rivington", "tags": ["slums", "crime"], "discovered": true, "visited": false },
+    { "id": "loc-wyrms-crossing", "name": "Wyrm's Crossing & the Risen Road", "tags": ["road", "crossroads"], "discovered": true, "visited": false }
+  ],
+  "edges": [
+    { "from": "loc-lower-city", "to": "loc-upper-city", "route_kind": "street", "danger": 1 },
+    { "from": "loc-lower-city", "to": "loc-outer-city", "route_kind": "street", "danger": 2 },
+    { "from": "loc-outer-city", "to": "loc-wyrms-crossing", "route_kind": "bridge", "danger": 2 }
+  ],
+  "travel_options": [
+    { "to": "loc-upper-city", "name": "Baldur's Gate — Upper City", "available": true, "move": { "kind": "travel", "target": "loc-upper-city" } },
+    { "to": "loc-outer-city", "name": "The Outer City & Rivington", "available": true, "move": { "kind": "travel", "target": "loc-outer-city" } }
+  ],
+  "can_act": true
+}

--- a/spikes/m0-phaser-thin-client/fixtures/character-surface.json
+++ b/spikes/m0-phaser-thin-client/fixtures/character-surface.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Fixture mirroring the REAL /character-surface (viewer/server.py build_character_surface). The spike's party panel reads ONLY these fields; zero client-side rules.",
+  "party": [
+    { "id": "char-aubree", "name": "Aubree", "race": "Human", "class": "Ranger", "hp": 24, "hpMax": 30, "stats": { "ac": 15 }, "level": 4 },
+    { "id": "char-companion-1", "name": "Shadowheart", "race": "Half-Elf", "class": "Cleric", "hp": 18, "hpMax": 22, "stats": { "ac": 18 }, "level": 4 }
+  ]
+}

--- a/spikes/m0-phaser-thin-client/fixtures/combat-surface.json
+++ b/spikes/m0-phaser-thin-client/fixtures/combat-surface.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "Fixture mirroring the REAL /combat-surface (viewer/server.py build_combat_surface + _combat_row_positions). NOTE the `position` x,y are DERIVED from zone (x=0.18+col*0.32, y=0.25+row*0.28) — they are an ephemeral RENDER HINT, never authoritative state. The spike treats `zone` as truth and re-derives x,y itself to prove the 'renderer owns layout' contract.",
+  "active": true,
+  "round": 2,
+  "turn_index": 0,
+  "current_id": "char-aubree",
+  "zones": [
+    { "name": "the market row" },
+    { "name": "the alley mouth" },
+    { "name": "the gate approach" }
+  ],
+  "initiative": [
+    { "id": "char-aubree", "name": "Aubree", "initiative": 18, "is_current": true, "hp_current": 24, "hp_max": 30, "conditions": [], "zone": "the market row", "position": { "x": 0.18, "y": 0.25, "zone": "the market row" } },
+    { "id": "mon-cultist-1", "name": "Cultist", "initiative": 14, "is_current": false, "hp_current": 9, "hp_max": 11, "conditions": [], "zone": "the alley mouth", "position": { "x": 0.5, "y": 0.25, "zone": "the alley mouth" } },
+    { "id": "char-companion-1", "name": "Shadowheart", "initiative": 12, "is_current": false, "hp_current": 18, "hp_max": 22, "conditions": [], "zone": "the market row", "position": { "x": 0.18, "y": 0.25, "zone": "the market row" } },
+    { "id": "mon-cultist-2", "name": "Cultist", "initiative": 7, "is_current": false, "hp_current": 11, "hp_max": 11, "conditions": ["prone"], "zone": "the gate approach", "position": { "x": 0.82, "y": 0.25, "zone": "the gate approach" } }
+  ]
+}

--- a/spikes/m0-phaser-thin-client/index.html
+++ b/spikes/m0-phaser-thin-client/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>WorldOS M0 spike — Phaser thin-client</title>
+  <!-- Phaser 3 (MIT) from CDN. The spike is throwaway; a real build would vendor it
+       like the viewer vendors babel-standalone. -->
+  <script src="https://cdn.jsdelivr.net/npm/phaser@3.80.1/dist/phaser.min.js"></script>
+  <style>
+    body { margin: 0; background: #0c0a06; color: #cbb890; font-family: -apple-system, system-ui, sans-serif; }
+    #wrap { max-width: 980px; margin: 1.2em auto; padding: 0 1em; }
+    #game { width: 960px; height: 600px; box-shadow: 0 0 0 1px rgba(140,100,60,.4); }
+    h1 { font-size: 1.1em; } .meta { color: #897; font-size: .85em; line-height: 1.5; }
+    code { background: #1c180e; padding: 1px 5px; border-radius: 3px; }
+  </style>
+</head>
+<body>
+  <div id="wrap">
+    <h1>WorldOS M0 spike — renderer-as-thin-client (Phaser 3)</h1>
+    <p class="meta">
+      Proves the architecture decision live: a Phaser renderer that owns <strong>no game state</strong> —
+      it reads <code>/atlas-surface</code>, <code>/combat-surface</code>, <code>/character-surface</code> and writes only an
+      <strong>intent</strong> via <code>POST /move</code>. Tokens are placed by engine <strong>zone</strong> (zone bands, not a VTT grid),
+      re-derived client-side to prove the renderer owns layout. Runs <strong>standalone on bundled fixtures</strong>;
+      add <code>?campaign=&lt;id&gt;</code> (and optional <code>?base=http://127.0.0.1:8765</code>) to point at a live viewer.
+    </p>
+    <div id="game"></div>
+    <p class="meta">
+      Serve locally: <code>python3 -m http.server</code> from this dir, open <code>/index.html</code>.
+      See <code>README.md</code> for what it validates + the <strong>contract gaps</strong> it surfaces.
+    </p>
+  </div>
+  <script src="./surface-client.js"></script>
+  <script src="./spike.js"></script>
+</body>
+</html>

--- a/spikes/m0-phaser-thin-client/render-profile.example.json
+++ b/spikes/m0-phaser-thin-client/render-profile.example.json
@@ -1,0 +1,53 @@
+{
+  "_comment": "M0 render-profile CONTRACT — concrete example (the load-bearing artifact this spike exists to validate). LAYERED: a renderer-agnostic `core` every renderer honors + optional per-renderer blocks. Decision: /tmp/decision-worldos-render-contract.md. Engine stays sole writer; this profile is presentation that JOINS to engine state by id.",
+  "schema_version": 1,
+  "game_id": "bg-absolute-remnants",
+  "title": "Baldur's Gate — Absolute Remnants",
+
+  "core": {
+    "_comment": "Renderer-agnostic. Every field defaultable so the AI build-loop can emit a partial-but-valid profile. Carries NAMED ZONES, never x,y — each renderer derives its own coordinate space from zones (this is how _combat_row_positions already works server-side).",
+    "scene_kind": "tilemap",
+    "positioning": "zone",
+    "_positioning_note": "v1 modes = theater | zone ONLY. `grid` (drag-to-move / measured range / AoE templates) is OUT — it needs the engine to own coordinates (future engine epic, capability-flagged). zone mode renders zone BANDS, not VTT cells.",
+    "locations": [
+      {
+        "engine_location_id": "loc-lower-city",
+        "_join": "FK to /atlas-surface known_locations[].id — the engine owns the location; this only declares how to draw it.",
+        "art": { "scope_key": "scene-lower-city" },
+        "zones": ["the gate approach", "the market row", "the alley mouth"]
+      },
+      {
+        "engine_location_id": "loc-wyrms-crossing",
+        "art": { "scope_key": "scene-wyrms-crossing" },
+        "zones": ["the bridge span", "the toll house", "the far bank"]
+      }
+    ],
+    "actors": [
+      { "engine_actor_id": "char-aubree", "art": { "scope_key": "portrait-aubree" } },
+      { "engine_actor_id": "char-companion-1", "art": { "scope_key": "portrait-shadowheart" } },
+      { "engine_actor_id": "mon-cultist-1", "art": { "scope_key": "creature-cultist" } },
+      { "engine_actor_id": "mon-cultist-2", "art": { "scope_key": "creature-cultist" } }
+    ],
+    "ai_disclosure": {
+      "generated_by": "worldos-ai-build-loop",
+      "model": "example",
+      "date": "2026-05-31",
+      "_note": "EU machine-readable AI-disclosure (2026-08-02) + Steam AI survey are sourced from here."
+    }
+  },
+
+  "renderer_profiles": {
+    "_comment": "OPTIONAL per-renderer blocks. A renderer reads core + its OWN block; ignores others. The core-only conformance test asserts every M0 scene renders from core + block.",
+    "phaser": {
+      "tileset_scope_key": "tileset-bg-stone",
+      "tile_size": 32,
+      "ui_skin": "16bit",
+      "backdrop_layout": null,
+      "walkmask_ref": null,
+      "_note": "T1 tilemap fields. For T2 (scene_kind=backdrop) this block carries backdrop_layout + walkmask_ref + depth_bands + normal_map_ref instead. walkmask is RENDERER-OWNED presentation (engine knows location adjacency, not walkable pixels)."
+    },
+    "rpgmaker": {
+      "_status": "RESERVED / spec-only. BYOL exploration-export tier, deferred post-M2. tilemap-only; never populated for scene_kind=backdrop. Consumes this frozen contract, never shapes it."
+    }
+  }
+}

--- a/spikes/m0-phaser-thin-client/spike.js
+++ b/spikes/m0-phaser-thin-client/spike.js
@@ -1,0 +1,168 @@
+/*
+ * M0 spike — Phaser thin-client scene.
+ *
+ * PROVES (visibly): a Phaser renderer that is a pure CLIENT of the WorldOS
+ * surfaces. It (1) reads /atlas-surface + /combat-surface + /character-surface,
+ * (2) renders a ZONE-MODE scene — zone BANDS with tokens grouped inside, NOT a
+ * VTT grid (the D1 contract: positions are presentation derived from engine
+ * zones), (3) re-derives token x,y from `zone` itself (proving the renderer owns
+ * layout, not the engine), (4) posts a `travel` INTENT to /move on click.
+ *
+ * This is throwaway spike quality. Its REAL output is the contract validation +
+ * the gaps in README.md, not the pixels.
+ */
+"use strict";
+
+const W = 960, H = 600;
+const ZONE_COLORS = [0x3a4a6a, 0x6a4a3a, 0x3a6a4a, 0x5a3a6a]; // band tints, cycled
+
+class SpikeScene extends Phaser.Scene {
+  constructor() { super("spike"); }
+
+  preload() {
+    this.load.json("profile", "./render-profile.example.json");
+  }
+
+  async create() {
+    this.profile = this.cache.json.get("profile");
+    this.add.text(16, 12, "WorldOS M0 spike — Phaser thin-client", { font: "18px monospace", color: "#e8d8b0" });
+    this.modeText = this.add.text(16, 36, "transport: connecting…", { font: "12px monospace", color: "#9ab" });
+    this.add.text(16, H - 22, "zone-mode render: zone BANDS, not VTT cells · tokens grouped by engine zone · click a travel chip → POST /move {kind:travel}",
+      { font: "11px monospace", color: "#778" });
+
+    this.zoneLayer = this.add.container(0, 0);
+    this.tokenLayer = this.add.container(0, 0);
+    this.hudLayer = this.add.container(0, 0);
+
+    this.client = new window.SurfaceClient({
+      baseUrl: new URLSearchParams(location.search).get("base") || "",
+      campaign: new URLSearchParams(location.search).get("campaign") || "",
+      onMode: (m) => {
+        this.modeText.setText(`transport: ${m.toUpperCase()}${m === "fixture" ? " (no live game — bundled fixtures)" : " (real engine surfaces)"}`);
+        this.modeText.setColor(m === "live" ? "#8c8" : "#caa");
+      },
+    });
+
+    this.client.startPolling((snap) => this.render(snap));
+  }
+
+  // ---- render the whole frame from a surface snapshot (renderer owns NO state) ----
+  render({ atlas, combat, character }) {
+    this.zoneLayer.removeAll(true);
+    this.tokenLayer.removeAll(true);
+    this.hudLayer.removeAll(true);
+
+    const locName = atlas?.current_location?.name || "—";
+    this.add.existing(this._txt(this.hudLayer, 16, 60, `location: ${locName}`, "#e8d8b0", 14));
+
+    const zones = (combat?.zones || []).map(z => (typeof z === "string" ? z : z.name)).filter(Boolean);
+    const combatants = combat?.initiative || [];
+
+    // ZONE BANDS — discrete regions, NOT a measurement grid. This is the honest
+    // zone-mode rendering the contract requires.
+    const bandTop = 90, bandH = 150, bandGap = 12;
+    const usableW = W - 32;
+    const zoneRects = {};
+    if (zones.length) {
+      const bw = (usableW - bandGap * (zones.length - 1)) / zones.length;
+      zones.forEach((zname, i) => {
+        const x = 16 + i * (bw + bandGap);
+        const g = this.add.graphics();
+        g.fillStyle(ZONE_COLORS[i % ZONE_COLORS.length], 0.35);
+        g.fillRoundedRect(x, bandTop, bw, bandH, 8);
+        g.lineStyle(1, 0xffffff, 0.12); g.strokeRoundedRect(x, bandTop, bw, bandH, 8);
+        this.zoneLayer.add(g);
+        this.zoneLayer.add(this._txt(null, x + 8, bandTop + 6, zname, "#bcd", 11));
+        zoneRects[zname] = { x, y: bandTop, w: bw, h: bandH };
+      });
+    } else {
+      this.zoneLayer.add(this._txt(null, 16, bandTop, "theater-of-the-mind (no declared zones) — party left / foes right", "#9ab", 12));
+    }
+
+    // TOKENS — placed by ZONE (renderer re-derives layout; ignores surface x,y to
+    // prove the contract: zone is authoritative-join, x,y is an ephemeral hint).
+    const perZoneCount = {};
+    combatants.forEach((c) => {
+      const isFoe = /^mon-/.test(c.id) || /cultist|foe|enemy/i.test(c.name || "");
+      let cx, cy;
+      const zr = zoneRects[c.zone];
+      if (zr) {
+        const n = (perZoneCount[c.zone] = (perZoneCount[c.zone] || 0) + 1);
+        cx = zr.x + 30 + ((n - 1) % 3) * 40;
+        cy = zr.y + 50 + Math.floor((n - 1) / 3) * 44;
+      } else {
+        // theater fallback mirrors _combat_row_positions: party left, foes right
+        const k = (perZoneCount[isFoe ? "_foe" : "_party"] = (perZoneCount[isFoe ? "_foe" : "_party"] || 0) + 1);
+        cx = (isFoe ? 0.72 : 0.25) * W;
+        cy = 110 + (k - 1) * 50;
+      }
+      const tk = this.add.container(cx, cy);
+      const dot = this.add.graphics();
+      const color = c.is_current ? 0xf4d27b : (isFoe ? 0xb05050 : 0x5a8ac0);
+      dot.fillStyle(color, 1); dot.fillCircle(0, 0, 16);
+      if (c.is_current) { dot.lineStyle(3, 0xf4d27b, 0.9); dot.strokeCircle(0, 0, 21); }
+      tk.add(dot);
+      tk.add(this._txt(null, -16, 18, c.name || c.id, "#eee", 10));
+      const hp = (c.hp_current != null) ? `${c.hp_current}/${c.hp_max}` : "";
+      if (hp) tk.add(this._txt(null, -16, 30, hp, "#c99", 9));
+      (c.conditions || []).length && tk.add(this._txt(null, -16, -30, (c.conditions).join(","), "#fb8", 9));
+      this.tokenLayer.add(tk);
+    });
+
+    // INITIATIVE HUD (from the already-shipped /combat-surface, #412)
+    const hudY = bandTop + bandH + 18;
+    this.hudLayer.add(this._txt(null, 16, hudY, combat?.active ? `COMBAT · round ${combat.round} · turn: ${this._curName(combat)}` : "exploration (no combat)", "#e8d8b0", 13));
+    combatants.forEach((c, i) => {
+      const t = this._txt(null, 16 + (i % 4) * 230, hudY + 22 + Math.floor(i / 4) * 18,
+        `${c.is_current ? "▸ " : "  "}${c.initiative ?? "?"}  ${c.name}`, c.is_current ? "#f4d27b" : "#abc", 11);
+      this.hudLayer.add(t);
+    });
+
+    // PARTY PANEL (from /character-surface — zero client rules)
+    const party = character?.party || [];
+    const pY = hudY + 70;
+    this.hudLayer.add(this._txt(null, 16, pY, "PARTY", "#e8d8b0", 12));
+    party.forEach((p, i) => {
+      this.hudLayer.add(this._txt(null, 16, pY + 18 + i * 16,
+        `${p.name}  ${p.race} ${p.class} L${p.level}  HP ${p.hp}/${p.hpMax}  AC ${p.stats?.ac}`, "#bcd", 11));
+    });
+
+    // TRAVEL CHIPS — the renderer's only WRITE path: a constrained intent.
+    const opts = atlas?.travel_options || [];
+    const tX = 560;
+    this.hudLayer.add(this._txt(null, tX, pY, "TRAVEL → POST /move {kind:travel}", "#e8d8b0", 12));
+    opts.forEach((o, i) => {
+      const y = pY + 20 + i * 30;
+      const g = this.add.graphics();
+      g.fillStyle(0x2a3a2a, 0.8); g.fillRoundedRect(tX, y, 360, 24, 6);
+      g.lineStyle(1, 0x6a8a6a, 0.6); g.strokeRoundedRect(tX, y, 360, 24, 6);
+      this.hudLayer.add(g);
+      const label = this._txt(null, tX + 8, y + 5, `→ ${o.name}`, "#cec", 11);
+      this.hudLayer.add(label);
+      const zone = this.add.zone(tX, y, 360, 24).setOrigin(0, 0).setInteractive();
+      zone.on("pointerdown", async () => {
+        const res = await this.client.move(o.move || { kind: "travel", target: o.to });
+        label.setText(`→ ${o.name}   [intent sent: ${JSON.stringify(o.move || { kind: "travel", target: o.to })}]`);
+        label.setColor(res && res.ok === false ? "#f88" : "#8f8");
+      });
+      this.hudLayer.add(zone);
+    });
+  }
+
+  _curName(combat) {
+    const c = (combat?.initiative || []).find(x => x.is_current);
+    return c ? c.name : "—";
+  }
+  _txt(parent, x, y, s, color, size) {
+    const t = this.add.text(x, y, s, { font: `${size || 12}px monospace`, color: color || "#ccc" });
+    if (parent) parent.add(t);
+    return t;
+  }
+}
+
+window.addEventListener("load", () => {
+  new Phaser.Game({
+    type: Phaser.AUTO, width: W, height: H, parent: "game",
+    backgroundColor: "#14110a", scene: [SpikeScene],
+  });
+});

--- a/spikes/m0-phaser-thin-client/surface-client.js
+++ b/spikes/m0-phaser-thin-client/surface-client.js
@@ -1,0 +1,92 @@
+/*
+ * SurfaceClient — the thin-client transport for the M0 spike.
+ *
+ * CONTRACT ROLE: this is the ONLY thing that talks to the engine. It proves the
+ * "renderer is a thin client; engine is sole writer" model:
+ *   - READ:  GET the read-model surfaces (/atlas-surface, /combat-surface,
+ *            /character-surface). Renderer owns NO game state — it re-fetches.
+ *   - WRITE: the renderer's ONLY write is an INTENT via POST /move. It never
+ *            mutates state; it asks the engine to.
+ *
+ * SWAPPABLE TRANSPORT: polls today (~3s). The M3 websocket/SSE upgrade slots in
+ * behind this same interface with identical payload shapes — callers don't change.
+ *
+ * FIXTURE FALLBACK: if no live ?campaign= viewer is reachable, it loads the
+ * bundled fixtures so the spike renders standalone. A banner shows which mode.
+ */
+"use strict";
+
+class SurfaceClient {
+  constructor({ baseUrl = "", campaign = "", pollMs = 3000, onMode = () => {} } = {}) {
+    this.baseUrl = baseUrl;            // "" = same origin (live viewer); else fixtures
+    this.campaign = campaign;
+    this.pollMs = pollMs;
+    this.onMode = onMode;
+    this.mode = "unknown";             // "live" | "fixture"
+    this._timer = null;
+  }
+
+  _q() { return this.campaign ? `?campaign=${encodeURIComponent(this.campaign)}` : ""; }
+
+  // Try the live surface; on any failure fall back to the bundled fixture.
+  async _get(surface) {
+    if (this.mode !== "fixture") {
+      try {
+        const r = await fetch(`${this.baseUrl}/${surface}${this._q()}`, { cache: "no-store" });
+        if (r.ok) {
+          if (this.mode !== "live") { this.mode = "live"; this.onMode("live"); }
+          return await r.json();
+        }
+      } catch (_e) { /* fall through to fixture */ }
+    }
+    if (this.mode !== "fixture") { this.mode = "fixture"; this.onMode("fixture"); }
+    const fr = await fetch(`./fixtures/${surface}.json`, { cache: "no-store" });
+    return await fr.json();
+  }
+
+  atlas() { return this._get("atlas-surface"); }
+  combat() { return this._get("combat-surface"); }
+  character() { return this._get("character-surface"); }
+
+  // The renderer's ONLY write. A constrained INTENT — never a world-assertion.
+  // CONTRACT-GAP DEMO: kind:"travel" is NOT yet in the engine's _MOVE_KINDS
+  // allowlist (viewer/server.py:84) — a live engine REJECTS it today with
+  // "unknown move kind". That rejection is the point: it proves the M0
+  // move-vocabulary freeze must land before a graphical client ships.
+  async move(intent) {
+    if (this.mode === "fixture") {
+      console.log("[fixture] would POST /move:", intent);
+      return { ok: true, fixture: true };
+    }
+    try {
+      const r = await fetch(`${this.baseUrl}/move`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...intent, campaign: this.campaign }),
+      });
+      const body = await r.json().catch(() => ({}));
+      if (!r.ok || body.ok === false) {
+        console.warn("[live] /move rejected:", body.reason || r.status,
+          "(expected for kind:travel until the M0 move-vocab freeze lands)");
+      }
+      return body;
+    } catch (e) {
+      console.warn("[live] /move failed:", e);
+      return { ok: false };
+    }
+  }
+
+  startPolling(onTick) {
+    const tick = async () => {
+      try {
+        const [atlas, combat, character] = await Promise.all([this.atlas(), this.combat(), this.character()]);
+        onTick({ atlas, combat, character });
+      } catch (e) { console.warn("poll failed", e); }
+    };
+    tick();
+    this._timer = setInterval(tick, this.pollMs);
+    return () => { if (this._timer) clearInterval(this._timer); };
+  }
+}
+
+window.SurfaceClient = SurfaceClient;


### PR DESCRIPTION
## TL;DR

The **canonical single source of truth** for WorldOS's graphics layer and the kinds of games it can produce. Output of a first-principles architectural decision: a 12-agent research workflow + a 4-agent adversarial debate (2026-05-31). Docs + a throwaway reference spike only — **no engine/product code, nothing to merge into the running app.**

## What this lands

| Path | What |
|---|---|
| `docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md` | The canonical roadmap — **game types (GT0–GT2) × capabilities (C1–C10)** maturing **Branch A → Branch B**, mapped to milestones M0–M6 + an evidence-gated grid epic |
| `WorldOS-RUNBOOK.md` | A pointer to the roadmap from the project front door |
| `spikes/m0-phaser-thin-client/` | A **throwaway, reference-only** Phaser thin client: renders a zone-mode scene from fixture surfaces, posts a `travel` intent, and documents the exact contract gaps M0 must freeze. Runs standalone (`python3 -m http.server`) |

## The roadmap shape

**Game types** (presentation families over the *one* shared engine):
- **GT0** narrative dashboard (ships today) → **GT1** SNES pixel turn-based → **GT2** Pillars/BG1-2 isometric

**Capabilities** (the "settings/abilities/configs", each a Branch A→B dial): positioning · scene · combat presentation · movement · assets · input intents · lighting · transport · AI-autonomy · UGC.

**Branch A** = every capability at its first shippable level (the painted LOOK over turn-based zone combat). **Branch B** = the growth levels (measured-grid tactics, dynamic lighting, gated autonomy, ship/sell UGC), layered on as the long-term plan proves out.

## Decisions locked (confidence ≥95% on direction)

- **Renderer = thin client; Python engine = SOLE writer of state.** The invariant under everything.
- **Phaser 3 + PixiJS v8 (both MIT), both tiers**, in the existing React/WKWebView shell. **Godot 4** reserved for an *optional premium native desktop/Steam* GT2 client.
- **Rejected (recorded so they're not re-litigated):** Unity (no macOS Unity-as-a-Library → can't embed in the WKWebView shell; cRPG toolkits assume Unity owns the rules; weakest AI-buildability; UGC licensing drag). RPG Maker (orthogonal-tile-locked → not a T2 option; at most a deferred asset-clean BYOL exploration export for GT1, EULA-refuted for centrally-hosted UGC). GemRB (GPL-2.0/native/IE-data-bound). Custom engine.
- **Contract is LAYERED:** renderer-agnostic core + per-renderer profiles. **Positions are presentation derived from engine named zones** — already the shipped pattern (`viewer/server.py:_combat_row_positions`); token x,y is an ephemeral render-hint, never state.
- **M0 freezes THREE contracts together:** render-profile · graphical move-intent vocabulary (`_MOVE_KINDS` extension) · surface-read guarantees (stable-actor-id test, authoritative-vs-derived fields, `/events` ordering).
- **RTwP (real-time + party-AI) REJECTED permanently** — BG3 dropped it; it's incompatible with an LLM-DM (an LLM narrates turn-by-turn, can't drive a real-time tick); it would rebuild the engine or break sole-writer. The genre identity lives in the LOOK + turn-based positioning.
- **C1-B measured-grid turn-based tactics is the only future engine spatial work worth doing, and it's EVIDENCE-GATED** (owner 2026-05-31: "decide after a playtest").

## Process integrity note

The adversarial debate caught an error in my own draft: an earlier architecture doc cited a `CombatState{no_grid, range_band, …}` schema at `models.py:521` that **does not exist on main**. A verifier agent grep-confirmed the real model is `Combatant.zone: str` + `Zone{name, description, adjacent[]}` (`models.py:978–997`) — even more purely gridless. Corrected; conclusion strengthened. (This is the methodology working as intended.)

## Single source of truth

Canonical = this doc + GitHub Milestones/Issues + the runbook. Per owner decision (2026-05-31), **GitHub only — no Notion mirror** (one system, zero desync, consistent with engine-as-authority). Issues + milestones + labels (`gt0/gt1/gt2`, `cap:c1`–`c10`, `branch:a/b`, `epic:*`) filed separately so the capability × game-type matrix is queryable.

## Collision audit

- Pure-additive: a new `docs/roadmap/` file, a new `spikes/` dir, and a doc-pointer block in the runbook. Touches no engine, viewer, or app code.
- The implementation agent's active release work (#404–#423) is untouched; this is planning scaffolding alongside it.
- `spikes/.../index.html` was force-added (the repo's broad `*.html` ignore is for generated reports; this is a source entry point).

## DO NOT MERGE yet

For owner review. Decision records in LEXAR session-notes `worldos-graphics-roadmap/` (research report, architecture decision, T2-engine addendum, roadmap-v2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a canonical graphics & game-type roadmap documenting GT0–GT3+, capability levels (C1–C10), milestones, and locked architecture decisions.
  * Added runbook guidance and a comprehensive M0 spike README describing thin-client renderer validation and contract gaps.

* **Spikes**
  * Added an M0 Phaser thin-client renderer spike (proof-of-concept) demonstrating surface-driven rendering and travel intent.
  * Included example render-profile schema and multiple fixtures to exercise atlas, character, and combat surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->