### PR TITLE
docs(contracts)+test: M0 render-profile schema, move-intent spec, stable-actor-id + conformance tests

### DIFF
--- a/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
+++ b/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
@@ -128,7 +128,8 @@ autonomy, ship/sell UGC)* layered on as the long-term plan proves out.
 ## 5. Milestones → Epics → Issues
 
 > Each milestone advances specific capabilities to specific levels for specific game types.
-> Issue bodies are drafted in the companion `roadmap-v2-FINAL.md`; titles below are file-ready.
+> The full, acceptance-criteria issue bodies live in the filed GitHub issues (#425–#461);
+> the titles below are the index into them.
 
 ### M0 — Contract freeze + thin-client spike  *(advances C6 freeze, C1=zone, C8 groundwork; GT-agnostic)*
 - **R0.1 Render-profile contract** (core + per-renderer blocks; zones-not-xy; core-only conformance test in CI)

--- a/docs/roadmap/contracts/move-intents.md
+++ b/docs/roadmap/contracts/move-intents.md
@@ -1,0 +1,75 @@
+# Graphical move-intent vocabulary (M0)
+
+> **Status:** M0 freeze artifact — the **specification** for issue **#429** (extend the
+> `_MOVE_KINDS` allowlist) and **#430** (document the vocabulary + reject-unknown test). This
+> doc is the design + acceptance spec; the code change to `viewer/server.py` is a separate,
+> coordinated PR (it touches a file the implementation agent shares, so it is sequenced, not
+> filed in the parallel-safe docs slice).
+
+## Why this must freeze in M0 (before any tier ships)
+
+A graphical renderer's only write is an **intent** to `POST /move`. The engine's facade
+(`viewer/server.py:sanitize_move`) validates each move against a **closed allowlist**
+`_MOVE_KINDS` and **drops unknown fields** (a deliberate anti-injection design). So a new
+kind is additive at the facade but **semantic for every consumer** — the renderer, the DM
+skill, and the AI build-loop glue all encode it.
+
+If M1 ships click-to-travel as free text (`{kind:"do", text:"go to the harbor"}`) and M2
+later introduces a structured `{kind:"travel", target:"loc-harbor"}`, then **every M1 game +
+all generated glue emits the old shape** and the change becomes breaking. Freezing the
+vocabulary now makes it additive forever.
+
+## The contract today (verified, `viewer/server.py:84-85`)
+
+```python
+_MOVE_KINDS  = {"say", "do", "check", "save", "combat", "attack", "cast", "use_item", "clarify"}
+_MOVE_FIELDS = ("text", "name", "skill", "target", "weapon", "dc")
+_MOVE_MAXLEN = 2000
+```
+
+`sanitize_move` forces `role="player"` (no impersonating dm/system), requires a known `kind`,
+length-caps text, and drops unknown keys. This stays exactly as-is for every existing kind.
+
+## The additive graphical intents (M0 freeze)
+
+| Kind | New? | Fields | Meaning | Reads back from |
+|------|------|--------|---------|-----------------|
+| `say` | existing | `text` | In-fiction speech | `/chat`, `/events` |
+| `do` | existing | `text` | Free-text action (the universal fallback) | `/chat`, `/events` |
+| `check` / `save` | existing | `skill`/`name`, `dc` | Ability check / saving throw | `/combat-surface`, `/events` |
+| `combat` / `attack` / `cast` / `use_item` | existing | `name`, `target`, `weapon` | Combat actions | `/combat-surface`, `/events` |
+| `clarify` | existing | `text` | Ask the DM a question (never a world-assertion) | `/chat` |
+| **`travel`** | **new** | `target` (= `engine_location_id`) | Move the party to a known/adjacent location | `/atlas-surface` (current_location flips) |
+| **`inspect`** (alias `examine`) | **new** | `target` (location / actor / object id) | Look closely; request detail/description | `/events`, `/chat` |
+| **`move_to_zone`** | **new** | `target` (= zone name) | Reposition within the current scene's named zones | `/combat-surface` (token zone updates) |
+
+### Field reuse
+All three new kinds reuse the existing `target` field (already in `_MOVE_FIELDS`) — so the
+only change is to `_MOVE_KINDS` (add `travel`, `inspect`, `examine`, `move_to_zone`). No new
+field is required, which keeps the anti-injection field-allowlist untouched.
+
+### Gesture → intent mapping (how renderers emit these)
+- **Click a travel chip / map exit** → `{kind:"travel", target:"<location_id>"}`
+- **Click an actor / scenery / item** → `{kind:"inspect", target:"<id>"}`
+- **Click a walkmask point / drag a token to a zone band** → `{kind:"move_to_zone", target:"<zone name>"}`
+- **Target-pick + ability bar (combat)** → existing `attack`/`cast`/`use_item` with `target`
+
+## Acceptance criteria (for the #429/#430 implementation PR)
+
+1. `_MOVE_KINDS` gains `travel`, `inspect`, `examine`, `move_to_zone`; existing kinds + the
+   `do` free-text fallback are unchanged.
+2. `sanitize_move` accepts the new kinds with a `target`, still forces `role=player`, still
+   drops unknown fields, still length-caps.
+3. **Reject-unknown-kind test:** an unknown kind (e.g. `narrate`, `teleport`) is rejected
+   with `unknown move kind`.
+4. **Round-trip test:** each new kind survives `sanitize_move` with its `target` intact.
+5. **Cross-component:** the viewer allowlist, the DM skill's intent interpretation, and the
+   engine-facade allowlist (`servers/engine/player_server.py`) all agree — landed in **one**
+   PR (not viewer-only), because they are one contract.
+6. The DM skill learns to interpret the three new kinds (travel → move the party; inspect →
+   narrate detail; move_to_zone → reposition in the scene).
+
+## Out of scope
+- Drag-to-zone *gestures* and ability-bar *verbs* beyond the kinds above (Shove/Dash/Hide as
+  first-class buttons) — Branch B; ride in `do` until then.
+- Any kind that asserts world state (only the DM/engine writes the world; players send intents).

--- a/docs/roadmap/contracts/render-profile.md
+++ b/docs/roadmap/contracts/render-profile.md
@@ -1,0 +1,86 @@
+# Render-profile contract (M0)
+
+> **Status:** M0 freeze artifact. Implements issues **#425** (core schema), **#426**
+> (per-renderer blocks), **#427** (zones-not-xy / positioning modes). Companion to the
+> canonical roadmap (`docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md`) and the JSON Schema
+> (`render-profile.schema.json` in this dir). The throwaway reference instance is
+> `spikes/m0-phaser-thin-client/render-profile.example.json`.
+
+## What it is
+
+The render-profile is the **single, versioned, layered contract** that every renderer
+(Phaser web today; an optional Godot desktop client and an optional RPG Maker exploration
+adapter later) and the AI build-loop consume to draw a WorldOS game. It is **presentation
+that joins to engine state by id** — it never holds game state.
+
+## The one invariant
+
+**The Python engine is the sole writer of game state.** A render-profile describes *how to
+draw* a game; it never decides *what is true*. It references engine state by foreign key
+(`engine_location_id`, `engine_actor_id`) and resolves art by scope key (the existing
+`Img-scope → /image` bridge). A renderer that consumes this profile owns pixels and input
+gestures — nothing else.
+
+## Layered: CORE + per-renderer PROFILES
+
+```
+render-profile
+├── schema_version            (contract major version; v1)
+├── game_id / title
+├── core                      ← renderer-AGNOSTIC; EVERY renderer honors it
+│   ├── scene_kind            tilemap | backdrop   (a capability, not an impl)
+│   ├── positioning           theater | zone       (v1 only; grid is future, #461)
+│   ├── locations[]           { engine_location_id (FK), art.scope_key, zones[] }
+│   ├── actors[]              { engine_actor_id (FK), art.scope_key }
+│   └── ai_disclosure         { generated_by, model, date }
+└── renderer_profiles         ← OPTIONAL; a renderer reads core + its OWN block
+    ├── phaser                { tileset/tile_size/ui_skin | backdrop_layout/walkmask/… }
+    └── rpgmaker              (reserved / spec-only; deferred)
+```
+
+**The seam rule (the load-bearing line):** CORE carries only what *all* renderers honor —
+FK ids, the `scene_kind` capability, named `zones`, scope-key art, and disclosure. Anything
+coordinate-, walkmask-, or sprite-sheet-layout-shaped lives in an optional per-renderer
+block. The **core-only conformance test (#428)** enforces this: a renderer using `core` +
+its own block must render every M0 scene. (The repo's existing SVG/React viewer is a free
+third "renderer" to validate that `core` stays renderer-agnostic.)
+
+## Zones, not x,y (#427)
+
+The engine adjudicates combat on **named zones + adjacency**, never coordinates —
+`Combatant.zone: str` and `Zone{name, description, adjacent[]}` (`servers/engine/models.py`),
+whose docstring states it outright: *"NOT a coordinate grid: LLM agents reason about named
+regions and their adjacency far more reliably than (x, y)."* The contract therefore carries
+**named zones**; each renderer derives its own coordinate space from them. This is not a new
+idea — `viewer/server.py:_combat_row_positions` already lays engine zones onto a coarse lane
+grid to produce display positions. Any x,y a surface emits is an **ephemeral render-hint,
+never authoritative state** (see #432).
+
+### Positioning modes (v1)
+
+| Mode | Meaning | Render rule |
+|------|---------|-------------|
+| `theater` | No positional model | Party left, foes right (mirrors the engine's empty-zone fallback) |
+| `zone` | Engine named regions | Draw zone **bands** with tokens grouped inside; **no VTT cells, no rulers, no measurement**; AoE = zone highlight + affected-token list |
+
+`grid` (authoritative coordinates + measured range / line-of-sight / geometric AoE / flanking)
+is **deliberately excluded from v1**. It would require the engine to gain coordinate authority
+— a sole-writer **state** change — and is tracked as the **evidence-gated Future milestone**
+(#461, "decide after a playtest"). RTwP (real-time + party-AI) is rejected permanently.
+
+## Versioning
+
+`schema_version` is the contract major version (v1 today). Adding optional fields is
+backward-compatible; a breaking change bumps the major and requires migrating authored UGC
+profiles. Per-renderer blocks evolve without forcing a core bump. The reversal signal: the
+core-only conformance test can't render a scene from core + a renderer block, OR a tier needs
+a `/move` kind not in the M0 move-intent freeze (`move-intents.md`).
+
+## How a renderer consumes it (the contract in one paragraph)
+
+Boot: `GET /atlas-surface` to learn locations + the current location. Look up the matching
+`core.locations[]` entry by `engine_location_id`; draw its `art.scope_key` (tilemap or
+backdrop per `scene_kind`). Place each `core.actors[]` entry by its engine `zone` (positions
+derived client-side). Poll `/combat-surface` + `/events` and **replay** engine-decided combat
+(zero client rules). The only write is a constrained **intent** to `POST /move` (see
+`move-intents.md`). The engine snapshot always overrides optimistic UI.

--- a/docs/roadmap/contracts/render-profile.schema.json
+++ b/docs/roadmap/contracts/render-profile.schema.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://worldos.dev/contracts/render-profile.schema.json",
+  "title": "WorldOS Render Profile",
+  "description": "The canonical, versioned, LAYERED contract a renderer (Phaser web, future Godot, future RPG Maker adapter) and the AI build-loop consume to draw a WorldOS game. Implements M0 issues #425 (core), #426 (per-renderer blocks), #427 (zones-not-xy / positioning modes). INVARIANT: the Python engine is the sole writer of game state; this profile is PRESENTATION that JOINS to engine state by id. It carries NAMED ZONES, never x,y coordinates — each renderer derives its own coordinate space from zones (this mirrors viewer/server.py:_combat_row_positions, which already derives token positions from engine zones). Every CORE field is defaultable so the AI build-loop can emit a partial-but-valid draft. See docs/roadmap/contracts/render-profile.md.",
+  "type": "object",
+  "required": ["schema_version", "core"],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Standard JSON Schema instance keyword — a relative or absolute reference to this schema. Permitted so instances can self-identify."
+    },
+    "schema_version": {
+      "type": "integer",
+      "const": 1,
+      "description": "Contract major version. Bumping is a breaking change requiring migration of authored UGC profiles. v1 supports positioning theater|zone only."
+    },
+    "game_id": { "type": "string", "description": "Stable id for this game/profile." },
+    "title": { "type": "string", "description": "Human-facing game title." },
+    "core": {
+      "type": "object",
+      "description": "Renderer-AGNOSTIC. Everything in here EVERY renderer must honor. No coordinate/walkmask/sheet-layout data — those live in renderer_profiles. All fields defaultable for partial AI generation.",
+      "required": ["scene_kind", "positioning", "locations", "actors"],
+      "additionalProperties": false,
+      "properties": {
+        "scene_kind": {
+          "type": "string",
+          "enum": ["tilemap", "backdrop"],
+          "description": "A CAPABILITY, not an implementation. tilemap = GT1 SNES pixel; backdrop = GT2 Pillars/BG painted isometric. A renderer maps this to its own technique."
+        },
+        "positioning": {
+          "type": "string",
+          "enum": ["theater", "zone"],
+          "description": "v1 modes ONLY. theater = no positional model (party-left/foes-right). zone = engine named regions (Combatant.zone). 'grid' (authoritative coordinates + measured range/LoS/AoE) is DELIBERATELY EXCLUDED from v1 — it requires the engine to gain coordinate authority (a sole-writer STATE change), tracked as the evidence-gated Future milestone (#461). Zone mode renders zone BANDS, never VTT cells/rulers; AoE shows as a zone highlight + affected-token list."
+        },
+        "locations": {
+          "type": "array",
+          "description": "One entry per renderable location. engine_location_id is a FOREIGN KEY into /atlas-surface known_locations[].id — the engine owns the location; this only declares how to draw it.",
+          "items": {
+            "type": "object",
+            "required": ["engine_location_id"],
+            "additionalProperties": false,
+            "properties": {
+              "engine_location_id": { "type": "string", "description": "FK to /atlas-surface known_locations[].id." },
+              "art": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "scope_key": { "type": "string", "description": "Resolves via the Img-scope -> /image bridge (e.g. 'scene-lower-city')." }
+                }
+              },
+              "zones": {
+                "type": "array",
+                "description": "Named tactical regions for this location, mirroring the engine's Zone vocabulary ('the dais', 'the rafters'). NOT coordinates.",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        },
+        "actors": {
+          "type": "array",
+          "description": "One entry per renderable actor. engine_actor_id is a FOREIGN KEY to the engine character/monster id (char_<uuid12> / mon_<...>); see the stable-actor-id guarantee (#431).",
+          "items": {
+            "type": "object",
+            "required": ["engine_actor_id"],
+            "additionalProperties": false,
+            "properties": {
+              "engine_actor_id": { "type": "string", "description": "FK to the engine actor id; guaranteed stable across snapshots (#431)." },
+              "art": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "scope_key": { "type": "string", "description": "Resolves via Img-scope -> /image (e.g. 'portrait-aubree', 'creature-cultist')." }
+                }
+              }
+            }
+          }
+        },
+        "ai_disclosure": {
+          "type": "object",
+          "description": "AI-content provenance. Source for EU machine-readable disclosure (effective 2026-08-02) + Steam's AI-content survey (#454). Required on any shippable/UGC profile; optional on internal/first-party drafts.",
+          "additionalProperties": false,
+          "properties": {
+            "generated_by": { "type": "string" },
+            "model": { "type": "string" },
+            "date": { "type": "string" }
+          }
+        }
+      }
+    },
+    "renderer_profiles": {
+      "type": "object",
+      "description": "OPTIONAL per-renderer blocks. A renderer reads CORE + its OWN block and ignores the others. Coordinate/walkmask/sheet-layout-shaped data lives ONLY here (never in core). The core-only conformance test (#428) asserts every M0 scene renders from core + the renderer's own block.",
+      "additionalProperties": false,
+      "properties": {
+        "phaser": {
+          "type": "object",
+          "description": "Phaser 3 (web, both tiers). For scene_kind=tilemap: tileset + tile grid. For scene_kind=backdrop: backdrop layout + walkmask + depth bands + optional normal-map. walkmask is RENDERER-OWNED presentation (the engine knows location adjacency, not walkable pixels); pathfinding destinations still resolve to engine zones/locations.",
+          "additionalProperties": true,
+          "properties": {
+            "tileset_scope_key": { "type": "string" },
+            "tile_size": { "type": "integer" },
+            "ui_skin": { "type": "string" },
+            "backdrop_layout": { "type": ["object", "null"] },
+            "walkmask_ref": { "type": ["string", "null"] },
+            "depth_bands": { "type": ["array", "null"], "items": { "type": "number" } },
+            "normal_map_ref": { "type": ["string", "null"] },
+            "free_positions": { "type": ["object", "null"] }
+          }
+        },
+        "rpgmaker": {
+          "type": "object",
+          "description": "RESERVED / spec-only. BYOL exploration-export tier, deferred post-M2 (#458-460). tilemap-only; never populated for scene_kind=backdrop. A contract-TAKER that consumes this frozen contract, never shapes it.",
+          "additionalProperties": true
+        }
+      }
+    }
+  }
+}

--- a/servers/engine/tests/test_stable_actor_ids.py
+++ b/servers/engine/tests/test_stable_actor_ids.py
@@ -1,0 +1,72 @@
+"""M0 #431 — stable-actor-id guarantee.
+
+A graphical renderer tweens tokens between snapshots keyed by actor id. If an actor's id
+churned across snapshot regeneration, the renderer would pop/respawn the token instead of
+moving it, and the render-profile's actors[].engine_actor_id foreign key (see
+docs/roadmap/contracts/render-profile.schema.json) would dangle.
+
+This locks the guarantee the contract depends on: an actor id is minted ONCE at creation
+(char_<uuid12>) and is stable for the actor's lifetime — across repeated reads, across the
+snapshot projection (get_state), and across unrelated mutations. Engine-only, additive,
+public-API-only (mirrors test_house_biography_persistence.py); CI runs it.
+"""
+
+from __future__ import annotations
+
+import re
+
+import server
+
+_CHAR_ID = re.compile(r"^char_[0-9a-f]{12}$")
+
+
+def _campaign() -> str:
+    return server.create_campaign("stable-actor-ids")["id"]
+
+
+def test_actor_id_format_is_the_documented_char_uuid12():
+    """The contract documents engine_actor_id as char_<uuid12>; lock the shape."""
+    cid = _campaign()
+    aid = server.create_character(cid, "Aubree", kind="player")["id"]
+    assert _CHAR_ID.match(aid), f"actor id {aid!r} is not char_<12 hex>"
+
+
+def test_actor_id_is_stable_across_repeated_reads():
+    """Reading the same actor twice returns the same id (no per-read minting)."""
+    cid = _campaign()
+    aid = server.create_character(cid, "Shadowheart", kind="companion")["id"]
+    first = server.get_character(cid, aid)["id"]
+    second = server.get_character(cid, aid)["id"]
+    assert first == aid == second
+
+
+def test_actor_id_persists_into_the_snapshot_projection():
+    """get_state (the read-model the surfaces project from) carries the SAME id, so a
+    renderer can join /character-surface + /combat-surface tokens to the render-profile by
+    this key."""
+    cid = _campaign()
+    aid = server.create_character(cid, "Karlach", kind="player")["id"]
+    snap = server.get_state(cid)
+    party_ids = {m.get("id") for m in snap.get("party", []) if isinstance(m, dict)}
+    assert aid in party_ids, f"{aid!r} not found in get_state party {party_ids}"
+
+
+def test_actor_id_unchanged_by_an_unrelated_mutation():
+    """Creating a SECOND actor must not renumber the first — ids are stable handles, not
+    positional indices. (Guards the tweening contract: adding a combatant can't make
+    existing tokens jump identity.)"""
+    cid = _campaign()
+    a1 = server.create_character(cid, "Astarion", kind="player")["id"]
+    _a2 = server.create_character(cid, "Gale", kind="companion")["id"]
+    # a1 still resolves to the same record under the same id
+    assert server.get_character(cid, a1)["id"] == a1
+    assert server.get_character(cid, a1)["name"] == "Astarion"
+
+
+def test_distinct_actors_get_distinct_ids():
+    """Two actors with the SAME name still get distinct stable ids (name is not the key)."""
+    cid = _campaign()
+    a1 = server.create_character(cid, "Cultist", kind="monster")["id"]
+    a2 = server.create_character(cid, "Cultist", kind="monster")["id"]
+    assert a1 != a2
+    assert _CHAR_ID.match(a1) and _CHAR_ID.match(a2)

--- a/spikes/m0-phaser-thin-client/render-profile.example.json
+++ b/spikes/m0-phaser-thin-client/render-profile.example.json
@@ -1,18 +1,14 @@
 {
-  "_comment": "M0 render-profile CONTRACT — concrete example (the load-bearing artifact this spike exists to validate). LAYERED: a renderer-agnostic `core` every renderer honors + optional per-renderer blocks. Decision: /tmp/decision-worldos-render-contract.md. Engine stays sole writer; this profile is presentation that JOINS to engine state by id.",
+  "$schema": "../../docs/roadmap/contracts/render-profile.schema.json",
   "schema_version": 1,
   "game_id": "bg-absolute-remnants",
   "title": "Baldur's Gate — Absolute Remnants",
-
   "core": {
-    "_comment": "Renderer-agnostic. Every field defaultable so the AI build-loop can emit a partial-but-valid profile. Carries NAMED ZONES, never x,y — each renderer derives its own coordinate space from zones (this is how _combat_row_positions already works server-side).",
     "scene_kind": "tilemap",
     "positioning": "zone",
-    "_positioning_note": "v1 modes = theater | zone ONLY. `grid` (drag-to-move / measured range / AoE templates) is OUT — it needs the engine to own coordinates (future engine epic, capability-flagged). zone mode renders zone BANDS, not VTT cells.",
     "locations": [
       {
         "engine_location_id": "loc-lower-city",
-        "_join": "FK to /atlas-surface known_locations[].id — the engine owns the location; this only declares how to draw it.",
         "art": { "scope_key": "scene-lower-city" },
         "zones": ["the gate approach", "the market row", "the alley mouth"]
       },
@@ -31,23 +27,17 @@
     "ai_disclosure": {
       "generated_by": "worldos-ai-build-loop",
       "model": "example",
-      "date": "2026-05-31",
-      "_note": "EU machine-readable AI-disclosure (2026-08-02) + Steam AI survey are sourced from here."
+      "date": "2026-05-31"
     }
   },
-
   "renderer_profiles": {
-    "_comment": "OPTIONAL per-renderer blocks. A renderer reads core + its OWN block; ignores others. The core-only conformance test asserts every M0 scene renders from core + block.",
     "phaser": {
       "tileset_scope_key": "tileset-bg-stone",
       "tile_size": 32,
       "ui_skin": "16bit",
       "backdrop_layout": null,
-      "walkmask_ref": null,
-      "_note": "T1 tilemap fields. For T2 (scene_kind=backdrop) this block carries backdrop_layout + walkmask_ref + depth_bands + normal_map_ref instead. walkmask is RENDERER-OWNED presentation (engine knows location adjacency, not walkable pixels)."
+      "walkmask_ref": null
     },
-    "rpgmaker": {
-      "_status": "RESERVED / spec-only. BYOL exploration-export tier, deferred post-M2. tilemap-only; never populated for scene_kind=backdrop. Consumes this frozen contract, never shapes it."
-    }
+    "rpgmaker": {}
   }
 }

--- a/viewer/tests/test_render_profile_contract.py
+++ b/viewer/tests/test_render_profile_contract.py
@@ -1,0 +1,89 @@
+"""M0 #428 (groundwork) — render-profile core-only conformance, dependency-free.
+
+Validates the spike's example render-profile against the formal schema
+(docs/roadmap/contracts/render-profile.schema.json) so the contract has CI teeth from day
+one. Deliberately uses NO third-party validator (jsonschema may be absent in the viewer-tests
+lane): it performs the strict checks that matter for the layered contract —
+additionalProperties:false at the load-bearing objects, required fields, enums, and the
+zones-not-xy / FK rules. If jsonschema IS installed, it additionally runs a full validate.
+
+This is the seed of the full core-only conformance test (#428): once a real renderer exists,
+extend it to assert the renderer can draw every scene from CORE + its own block.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_SCHEMA = _REPO / "docs" / "roadmap" / "contracts" / "render-profile.schema.json"
+_EXAMPLE = _REPO / "spikes" / "m0-phaser-thin-client" / "render-profile.example.json"
+
+
+def _load(p: Path) -> dict:
+    if not p.exists():
+        pytest.skip(f"{p} not present in this checkout")
+    return json.loads(p.read_text())
+
+
+def test_schema_and_example_are_valid_json():
+    schema = _load(_SCHEMA)
+    ex = _load(_EXAMPLE)
+    assert schema.get("$id", "").endswith("render-profile.schema.json")
+    assert ex.get("schema_version") == 1
+
+
+def test_example_has_no_disallowed_keys_at_strict_objects():
+    """The layered contract's value comes from strictness: a typo'd or drifted key must be
+    caught. Enforce additionalProperties:false manually at top-level + core + the nested
+    location/actor objects (the objects the schema marks strict)."""
+    schema = _load(_SCHEMA)
+    ex = _load(_EXAMPLE)
+
+    top_allowed = set(schema["properties"])
+    assert set(ex) - top_allowed == set(), f"disallowed top-level keys: {set(ex) - top_allowed}"
+
+    core_schema = schema["properties"]["core"]
+    core_allowed = set(core_schema["properties"])
+    assert set(ex["core"]) - core_allowed == set(), f"disallowed core keys: {set(ex['core']) - core_allowed}"
+
+    loc_allowed = set(core_schema["properties"]["locations"]["items"]["properties"])
+    for loc in ex["core"]["locations"]:
+        assert set(loc) - loc_allowed == set(), f"disallowed location keys: {set(loc) - loc_allowed}"
+
+    act_allowed = set(core_schema["properties"]["actors"]["items"]["properties"])
+    for act in ex["core"]["actors"]:
+        assert set(act) - act_allowed == set(), f"disallowed actor keys: {set(act) - act_allowed}"
+
+
+def test_example_honors_core_required_fields_and_enums():
+    ex = _load(_EXAMPLE)
+    core = ex["core"]
+    assert core["scene_kind"] in ("tilemap", "backdrop")
+    # v1 positioning is theater|zone ONLY — grid is the evidence-gated future epic (#461).
+    assert core["positioning"] in ("theater", "zone"), "v1 must not use grid positioning"
+    assert core["locations"] and all("engine_location_id" in l for l in core["locations"])
+    assert core["actors"] and all("engine_actor_id" in a for a in core["actors"])
+
+
+def test_zones_are_named_strings_not_coordinates():
+    """The contract carries NAMED zones, never x,y. Lock it: every zone is a non-empty
+    string, and no location entry smuggles a coordinate field."""
+    ex = _load(_EXAMPLE)
+    forbidden = {"x", "y", "col", "row", "grid_x", "grid_y", "coords", "position"}
+    for loc in ex["core"]["locations"]:
+        assert forbidden.isdisjoint(loc), f"coordinate field leaked into a location: {loc}"
+        for z in loc.get("zones", []):
+            assert isinstance(z, str) and z.strip(), f"zone is not a named string: {z!r}"
+
+
+def test_full_jsonschema_validation_when_available():
+    """If jsonschema is installed, run a full strict validate as a bonus. Skips cleanly when
+    the dep is absent so the lane stays green dependency-free."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = _load(_SCHEMA)
+    ex = _load(_EXAMPLE)
+    jsonschema.validate(ex, schema)


### PR DESCRIPTION
## TL;DR

The **parallel-safe slice of M0 (Contract freeze)** — the load-bearing render-profile JSON Schema + the move-intent spec + the stable-actor-id and conformance tests. All net-new contract artifacts and tests; **no engine/viewer logic changes.** Builds on the merged roadmap (#424) and advances issues **#425/#426/#427/#428/#430/#431/#433**.

**Held for a separate coordinated PR:** the two `viewer/server.py` code edits — **#429** (extend `_MOVE_KINDS`) and **#432** (namespace the derived position hint) — because they touch a file the implementation agent actively shares. This PR specs them; it doesn't edit that file.

## What this lands

| File | Issue | What |
|---|---|---|
| `docs/roadmap/contracts/render-profile.schema.json` | #425/426/427 | Formal JSON Schema for the **layered** render-profile: renderer-agnostic `core` + optional per-renderer blocks; **zones-not-xy**; `positioning` enum `theater\|zone` (grid excluded from v1); `additionalProperties:false` strictness |
| `docs/roadmap/contracts/render-profile.md` | #425/426/427 | Human contract doc — seam rule, zones-not-xy, positioning modes, versioning, how a renderer consumes it |
| `docs/roadmap/contracts/move-intents.md` | #429/#430 (spec) | The move-intent vocabulary spec: existing palette + additive `travel`/`inspect`/`move_to_zone`, gesture→intent mapping, acceptance criteria. **Spec only** — the code edit (#429) is the held coordinated PR |
| `servers/engine/tests/test_stable_actor_ids.py` | #431 | Locks the stable-actor-id guarantee (`char_<uuid12>`, stable across reads / snapshot projection / unrelated mutations). Public-API-only |
| `viewer/tests/test_render_profile_contract.py` | #428 (groundwork) | Dependency-free conformance test: validates the example against the schema (additionalProperties strictness, required fields, enums, **no coordinate leak**), + a full `jsonschema` validate when the dep is present |
| `spikes/m0-phaser-thin-client/render-profile.example.json` | #433 (groundwork) | Rewritten as a **clean, schema-valid** instance (`$schema` pointer; drops annotation keys + the prior `/tmp` decision-doc reference) |
| `docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md` | — | Replaces the stale `roadmap-v2-FINAL.md` reference (an operator-local file not in the repo) with a pointer to the filed issues — completing the CodeRabbit fix that #424's squash only partially applied |

## Verification

- Schema + example are valid JSON; the example passes **strict** `jsonschema` validation.
- Both new test files `ast`-parse; logic passes standalone; engine + viewer suites verify in CI (viewer-tests lane added in #403 runs `test_render_profile_contract.py`).
- The conformance test is **dependency-free** and upgrades to a full validate when `jsonschema` is present.
- All issue references audited against the live issue list (real range **#425–#461**); no stale `roadmap-v2-FINAL.md` references remain.

## Parallel-safe

Every file is net-new except the roadmap ref-fix and the spike example rewrite — both in `docs/roadmap/` + `spikes/`, not the implementation agent's lane (`viewer/openworlds/*`, `servers/engine/*.py` logic, `qa/*`, `scripts/*`). New test filenames in shared dirs don't collide. The implementation agent's open PRs are untouched.
