### PR TITLE
docs: sync takeover UX sprint roadmap

### DIFF
--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -5,8 +5,8 @@
      Post-compaction agents: this 6-line block is ground truth. Do NOT reconstruct
      state from scattered docs or old plans; trust this, verify the sha, then act.
      ──────────────────────────────────────────────────────────────────────────
-     AS OF:        2026-05-31 takeover stabilization
-     ORIGIN TIP:   82aeaf2 (verified by git fetch on 2026-05-31)
+     AS OF:        2026-05-31 post-takeover UX sprint sync
+     ORIGIN TIP:   b15ad3c (PR #465 merged; verified by git fetch on 2026-05-31)
      CANONICAL:    /Users/lume/ClawDnD-val is the private-art/live-app checkout; observed at f5500ac
                    and behind origin/main by 3 commits before takeover. Do not fast-forward it
                    until the owner intentionally chooses to move the private-art checkout.
@@ -19,8 +19,9 @@
      LAST VALID RELEASE GATE:
                    none after the RRI contract hardening. A release verdict requires expected
                    persona count, disk-backed palette/image/behavioral evidence, and built .app play.
-     NEXT ACTION:  Stabilize gate truth first → rerun a clean gate on the 32GB VM for backend/personas
-                   plus Mac/macOS CI built-app verification → then fix the trustworthy failure list.
+     NEXT ACTION:  Run the clean post-hardening gate (#466) to get a trustworthy failure list, but
+                   plan the next sprint UX-first (#467): first-turn playability, clickability/chrome, launcher
+                   clarity, live-response feel, and CRPG depth before more hardening/proxy/security work.
      DISCIPLINE:   ≥2 clean reads before any fix (channel fabricates under host load); ONE heavy claude -p stream;
                    never probe-kill; test the BUILT .app, never a proxy; honest scores; never "100% confidence".
      ════════════════════════════════════════════════════════════════════════════ -->
@@ -157,20 +158,46 @@ verifier; can revert the goal to "fix" anytime.
 
 ---
 
-## 9. CURRENT STATUS (2026-05-31 — takeover context, NOT a release verdict)
+## 9. CURRENT STATUS (2026-05-31 — post-#465, NOT a release verdict)
 
-- Repo truth is being stabilized from a Lexar worktree at `origin/main` (`82aeaf2`). The private-art
-  checkout at `/Users/lume/ClawDnD-val` was observed at `f5500ac` and behind by 3 commits; keep it
-  intact until the owner chooses to fast-forward it.
+- Repo truth stabilization merged in PR #465. Current `origin/main` is `b15ad3c`; the private-art
+  checkout at `/Users/lume/ClawDnD-val` was observed at `f5500ac` before takeover. Keep it intact until
+  the owner intentionally fast-forwards the live app/private-art checkout.
 - The `f5500ac` RRI (`2.7/10`) is preserved as partial evidence only. It proves the gate/harness was
   not trustworthy enough for release scoring: one persona completed, others lacked `score.json`, and
   image/palette/behavioral/UI audit sources were either missing or harness-contaminated.
-- The stabilization lane is: make docs and RRI output truthful → make the gate fail on missing personas
-  and record exact evidence paths → fix high-confidence playability blockers → run the full backend/persona
-  sweep on the 32GB VM and the Mac-only built-app smoke on this Mac or macOS CI.
-- Known product blockers to verify after harness trust is restored: built app playability, narration
-  stall/disabled-control behavior under real latency, image/private-art root routing, and legacy
-  `/dashboard` references that can mislead agents away from `/openworlds/`.
+- The next evidence step is issue #466: run a clean non-partial five-persona RRI from `b15ad3c` or newer
+  on the 32GB VM for backend/personas, plus the Mac/macOS CI built-app playtest. The expected outcome is
+  either a trustworthy blocker list or a real 11/11 release result.
+- Product direction is now UX-first (#467). Do not turn the next sprint into more gate hardening, proxy adapters,
+  transport/security work, UGC/legal, or renderer branches unless #466 proves they block the player-facing
+  session. The game must feel launchable, clickable, responsive, and deep before it needs more machinery.
+- Highest-confidence UX risks to verify/fix next: first-turn built-app play; global click hit areas (#309);
+  title/chrome truth (#306); launcher clarity/stale campaigns (#358); per-beat latency/live response (#393);
+  portrait/gallery blockers (#379); and CRPG depth on Heroes/Battle/Inventory (#308/#318/#310,
+  with #462/#463 folded into Battle readability as presentation containment).
+
+---
+
+## 10. UX-FIRST SPRINT ORDER (after takeover stabilization)
+
+Use the gate as evidence, not as the roadmap. The next sprint should optimize the felt session:
+
+1. **Prove first-turn play in the built app.** A fresh player can launch, choose/start/resume, reach the
+   Table, submit one `/move`, and see narration resolve without critical console/runtime errors. Evidence:
+   issue #466 artifacts, not a proxy preview.
+2. **Fix the "this is not clickable" feeling.** Close #309 only when clicking any visible tab/button
+   background works with mouse and keyboard. Pair with visual truth for #306 so the title/day/chrome no
+   longer look broken at common widths.
+3. **Make the launcher feel like a real game shelf.** Remove stale/scratch campaign noise (#358), make
+   bridge/no-bridge state honest, and ensure each chronicle looks distinct enough to choose.
+4. **Make slow turns feel alive.** Verify #393/#394-style streaming in a real built-app run; if text does
+   not appear within the first 15-30 seconds of a turn, prioritize streaming/proof-of-life UX over more
+   backend hardening.
+5. **Add CRPG depth where players look for it.** Heroes spellbook/manage-spells (#308), Battle readability
+   (#318, including #462/#463 token containment/alignment as presentation truth), Inventory/paper-doll
+   feel (#310), and portrait/race gallery continuity (#379) beat proxy/security work until the session
+   feels like a game.
 
 ---
 

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -295,10 +295,12 @@ out freely. Only **`claude -p` QA is host-heavy** (the duo/sprint spin up engine
 ## CURRENT STATE + WORK QUEUE
 
 **Historical snapshot, not current authority:** this queue was written around `ea815fc`
-(2026-05-27 cont.3). During the 2026-05-31 takeover, `origin/main` was refreshed to `82aeaf2`,
-the canonical private-art checkout was observed at `f5500ac`, and the only current gate truth lives
-in `WorldOS-OPERATING-GOAL.md` + `WorldOS-GUI-RUNBOOK.md` + `qa/SCORECARD.md`. Do not use this
-section to decide release state.
+(2026-05-27 cont.3). During the 2026-05-31 takeover, the gate-truth stabilization merged as PR #465;
+current `origin/main` is `b15ad3c`, the canonical private-art checkout was observed at `f5500ac`, and
+the only current gate truth lives in `WorldOS-OPERATING-GOAL.md` + `WorldOS-GUI-RUNBOOK.md` +
+`qa/SCORECARD.md`. Do not use this section to decide release state. The next sprint is UX-first (#467):
+prove first-turn built-app play via #466, then prioritize clickability/chrome, launcher clarity,
+live-response feel, and CRPG depth before more hardening/proxy/security work.
 
 **LATEST (2026-05-27 cont.3) — the Quest & Arc engine is COMPLETE + WIRED, all combat
 defects closed, and the sibling's draft-PR backlog is fully landed.** Since the queue

--- a/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
+++ b/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
@@ -7,7 +7,10 @@
 > second writer. This mirrors WorldOS's core architecture: the engine is the sole
 > authority; everything downstream is a projection.
 >
-> Status: **FILED** — PR #424; milestones M0–M6 + Future-gated; issues #425–#461. Confidence
+> Status: **FILED + PARTIAL M0 CONTRACTS LANDED** — PR #424 filed milestones M0–M6 +
+> Future-gated issues #425–#461. PR #464 landed the parallel-safe M0 contract slice:
+> #425/#426/#427/#431 closed; #428/#430/#433 remain open for fuller renderer/implementation proof;
+> #429/#432 were intentionally held for coordinated `viewer/server.py` edits. Confidence
 > on direction ≥95% (first-principles decision 2026-05-31). The full decision records
 > (research report, architecture decision, T2-engine addendum) are operator-local
 > session-notes and are intentionally not committed; this document is the in-repo canonical

--- a/qa/GUI_WORKBOOK.md
+++ b/qa/GUI_WORKBOOK.md
@@ -6,12 +6,17 @@
 > Iteration surface: `http://127.0.0.1:8799/openworlds/` (`scripts/play.sh` from canonical).
 > Gate surface: built `dist/WorldOS.app` via `qa/ui_playtest_app.sh`. See `WorldOS-GUI-RUNBOOK.md`.
 
-## ★ HEADLINE (verified 2026-05-31, 3 clean reads on live canonical 8799)
+## ★ HEADLINE (historical canonical f5500ac, verified 2026-05-31, 3 clean reads on live canonical 8799)
 **Most of what the owner saw broken was a STALE-BUILD / WORKTREE-WITHOUT-ART artifact, not broken canonical code.** Served correctly from canonical:
 - `can_act:true`; palette **5 exploration actions ENABLED** (continue/say/do/check/save); attack/bonus/reaction correctly disabled ("not in combat").
 - **ALL images 200**: `location:loc-lower-city`, `portrait-rolan`, `portrait-minsc`, `map_lower-city`, `region:baldurs-gate`, `scene_baldurs-gate`.
 - DM cold-open narration = 4842 chars with **27 paragraph breaks** (the prose IS well-formed).
 ⇒ The fix for "no images / no map / no palette" is **serve/build WITH `_private` art present** (infra), not 3 code PRs. The real *code* bugs are layout prominence + render formatting + the silent companion.
+
+Post-#465 note: `origin/main` is now `b15ad3c`, and RRI release scoring requires a
+disk-backed `palette_live` proof with **≥6 enabled actions** on a `can_act:true` surface. The 5-action
+canonical read above remains useful orientation, but it is not release proof; issue #466 must either prove
+the built app now meets the live palette gate or fail with an actionable artifact path.
 
 ## Phase 0 — infra (DONE)
 - ✅ `launch.json` repointed off the deprecated LEXAR copy → canonical/8799/`/openworlds/`/live state.
@@ -23,11 +28,11 @@
 
 | # | Defect | VERIFIED root cause | Fix | Status | Proof |
 |---|---|---|---|---|---|
-| G3 | Palette buried in 280px right-rail; `slice(0,6)` drops bonus-action+reaction; no center palette | screen-table.jsx action list used to live outside the main play column and cap rows | Drop slice; promote all exploration actions to main action column near Declare; group combat verbs separately | Fixed in current branch; needs live look + full gate | Static proof: `viewer/tests/test_openworlds_static.py::test_openworlds_table_renders_all_actions_without_truncation` and `test_openworlds_table_promotes_palette_to_main_column` |
-| G4 | Chronicle renders as ONE block despite well-formed prose | `LogEntry` rendered `{text}` with default `white-space`, collapsing `\n\n` paragraph breaks | Keep sanitization, render narration with `whiteSpace: "pre-line"` | Fixed in current branch; needs live look + full gate | Static proof: `viewer/tests/test_openworlds_static.py::test_openworlds_table_chronicle_preserves_paragraph_breaks` |
-| G6 | Companion (Minsc/Alfira, kind='companion') silently in solo party at cold-open, no narrated meeting | solo play.sh could prompt the DM into seating/recruiting a companion at cold-open | Solo prompt now says the player begins alone; `play_party.sh` with empty companion spec execs solo `play.sh` unchanged | Prompt guard fixed in current branch; needs live gate proof | Static proof: `qa/test_release_gate_static.py::test_solo_play_contract_does_not_silently_recruit_companion` |
-| G5 | "No streaming visible" — VERIFY (may be infra: owner watched a stale/wrong surface) | /events+useLiveSession+log_event exist; DM emits paragraph-rich prose | Confirm mid-turn log_event on live 8799; fix only if current built-app play still batches blank waits | Open, needs built-app Part A+B evidence | DM prose well-formed; streaming path exists |
-| G7 | Worktree/.app builds 404 images (no _private) | `_ingested_images_root()` (server.py:203) hardcoded to server.py's repo → worktree has no _private | Split code repo from art repo: viewer honors `WORLDOS_ART_REPO_ROOT`; native app has a Private art repo path and launch-root override for gate builds | Fixed in takeover branch; needs PR/CI + full gate | 2026-05-31 smoke: worktree `dist/WorldOS.app` pid 69755 launched without killing canonical app; spawned worktree `viewer/server.py` on 8765; `/image?scope=location:loc-lower-city` returned `200 904100`; Info.plist root=`/Volumes/LEXAR/repos/worldos-takeover-stabilization`, art=`/Users/lume/ClawDnD-val` |
+| G3 | Palette buried in 280px right-rail; `slice(0,6)` drops bonus-action+reaction; no center palette | screen-table.jsx action list used to live outside the main play column and cap rows | Drop slice; promote all exploration actions to main action column near Declare; group combat verbs separately | Merged in #465; needs built-app palette-live proof from #466 | Static proof: `viewer/tests/test_openworlds_static.py::test_openworlds_table_renders_all_actions_without_truncation` and `test_openworlds_table_promotes_palette_to_main_column` |
+| G4 | Chronicle renders as ONE block despite well-formed prose | `LogEntry` rendered `{text}` with default `white-space`, collapsing `\n\n` paragraph breaks | Keep sanitization, render narration with `whiteSpace: "pre-line"` | Merged in #465; needs built-app live look + full gate | Static proof: `viewer/tests/test_openworlds_static.py::test_openworlds_table_chronicle_preserves_paragraph_breaks` |
+| G6 | Companion (Minsc/Alfira, kind='companion') silently in solo party at cold-open, no narrated meeting | solo play.sh could prompt the DM into seating/recruiting a companion at cold-open | Solo prompt now says the player begins alone; `play_party.sh` with empty companion spec execs solo `play.sh` unchanged | Merged in #465; needs live gate proof | Static proof: `qa/test_release_gate_static.py::test_solo_play_contract_does_not_silently_recruit_companion` |
+| G5 | "No streaming visible" — VERIFY (may be infra: owner watched a stale/wrong surface) | /events+useLiveSession+log_event exist; DM emits paragraph-rich prose; PR #394 merged streaming-lite for #393 | Confirm mid-turn log_event on live 8799; fix only if current built-app play still batches blank waits | #394 merged; #393 remains open until built-app Part A+B proves no latency give-ups | DM prose well-formed; streaming path exists; proof still owed on built app |
+| G7 | Worktree/.app builds 404 images (no _private) | `_ingested_images_root()` (server.py:203) hardcoded to server.py's repo → worktree has no _private | Split code repo from art repo: viewer honors `WORLDOS_ART_REPO_ROOT`; native app has a Private art repo path and launch-root override for gate builds | Merged in #465; needs #466 full gate proof | 2026-05-31 smoke: worktree `dist/WorldOS.app` pid 69755 launched without killing canonical app; spawned worktree `viewer/server.py` on 8765; `/image?scope=location:loc-lower-city` returned `200 904100`; Info.plist root=`/Volumes/LEXAR/repos/worldos-takeover-stabilization`, art=`/Users/lume/ClawDnD-val` |
 
 ## EVAPORATED on clean re-verification (were CORRUPTED READS — do NOT chase)
 - **G1 "palette all-disabled / PC kind=pc / no active character"** — FALSE. Live PC Rolan is `kind='player'`; palette enabled. (A corrupted snapshot read invented `kind='pc'`/`npc-alfira`. Builder A killed — pushed no PR.)


### PR DESCRIPTION
## Summary
- updates the takeover state to post-PR #465 (`b15ad3c`) and keeps #466 as the clean post-hardening RRI evidence gate
- makes #467 the UX-first sprint tracker: first-turn built-app play, clickability/chrome, launcher clarity, live-response feel, and CRPG depth before more hardening/proxy/security work
- aligns GUI/roadmap docs with the #394/#393 streaming nuance, palette-live proof requirements, #462/#463 Battle readability scope, and PR #464 M0 contract status

## GitHub issue cleanup performed
- created #467 for the UX-first release-readiness sprint
- closed #425, #426, #427, and #431 as already satisfied by merged PR #464, not by this PR
- commented on #428, #429, #430, #432, and #433 to distinguish #464 groundwork/spec from still-open implementation or renderer proof

## Note on CodeRabbit linked-issue warning
#425 was closed after verifying that PR #464 had already landed the render-profile CORE schema and docs (`docs/roadmap/contracts/render-profile.schema.json` and `docs/roadmap/contracts/render-profile.md`). This PR only records that existing status in the roadmap docs; it does not claim to newly implement #425.

## Validation
- `git diff --check`
- GitHub CI: `test`, `viewer-tests`, `license-check`, and Socket checks passed on PR #468
- CodeRabbit: no actionable comments generated; status passed/skipped

No heavyweight local release sweep was run; #466 belongs on the 32GB VM plus Mac/macOS CI built-app verification.
