### PR TITLE
docs: make takeover baseline wording stable

### DIFF
--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -6,7 +6,9 @@
      state from scattered docs or old plans; trust this, verify the sha, then act.
      ──────────────────────────────────────────────────────────────────────────
      AS OF:        2026-05-31 post-takeover UX sprint sync
-     ORIGIN TIP:   b15ad3c (PR #465 merged; verified by git fetch on 2026-05-31)
+     MAIN BASELINE:
+                   e4078c7 (PR #468 merged; verified by git fetch on 2026-05-31).
+                   Re-verify current `origin/main` before acting; use this as the doc-sync baseline.
      CANONICAL:    /Users/lume/ClawDnD-val is the private-art/live-app checkout; observed at f5500ac
                    and behind origin/main by 3 commits before takeover. Do not fast-forward it
                    until the owner intentionally chooses to move the private-art checkout.
@@ -160,15 +162,16 @@ verifier; can revert the goal to "fix" anytime.
 
 ## 9. CURRENT STATUS (2026-05-31 — post-#465, NOT a release verdict)
 
-- Repo truth stabilization merged in PR #465. Current `origin/main` is `b15ad3c`; the private-art
-  checkout at `/Users/lume/ClawDnD-val` was observed at `f5500ac` before takeover. Keep it intact until
-  the owner intentionally fast-forwards the live app/private-art checkout.
+- Repo truth stabilization merged in PR #465, and the UX-first doc sync merged in PR #468. The current
+  doc-sync baseline is `e4078c7`; re-verify `origin/main` before acting. The private-art checkout at
+  `/Users/lume/ClawDnD-val` was observed at `f5500ac` before takeover. Keep it intact until the owner
+  intentionally fast-forwards the live app/private-art checkout.
 - The `f5500ac` RRI (`2.7/10`) is preserved as partial evidence only. It proves the gate/harness was
   not trustworthy enough for release scoring: one persona completed, others lacked `score.json`, and
   image/palette/behavioral/UI audit sources were either missing or harness-contaminated.
-- The next evidence step is issue #466: run a clean non-partial five-persona RRI from `b15ad3c` or newer
-  on the 32GB VM for backend/personas, plus the Mac/macOS CI built-app playtest. The expected outcome is
-  either a trustworthy blocker list or a real 11/11 release result.
+- The next evidence step is issue #466: run a clean non-partial five-persona RRI from the post-#465 code
+  baseline (`b15ad3c`) or newer on the 32GB VM for backend/personas, plus the Mac/macOS CI built-app
+  playtest. The expected outcome is either a trustworthy blocker list or a real 11/11 release result.
 - Product direction is now UX-first (#467). Do not turn the next sprint into more gate hardening, proxy adapters,
   transport/security work, UGC/legal, or renderer branches unless #466 proves they block the player-facing
   session. The game must feel launchable, clickable, responsive, and deep before it needs more machinery.

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -295,10 +295,11 @@ out freely. Only **`claude -p` QA is host-heavy** (the duo/sprint spin up engine
 ## CURRENT STATE + WORK QUEUE
 
 **Historical snapshot, not current authority:** this queue was written around `ea815fc`
-(2026-05-27 cont.3). During the 2026-05-31 takeover, the gate-truth stabilization merged as PR #465;
-current `origin/main` is `b15ad3c`, the canonical private-art checkout was observed at `f5500ac`, and
-the only current gate truth lives in `WorldOS-OPERATING-GOAL.md` + `WorldOS-GUI-RUNBOOK.md` +
-`qa/SCORECARD.md`. Do not use this section to decide release state. The next sprint is UX-first (#467):
+(2026-05-27 cont.3). During the 2026-05-31 takeover, the gate-truth stabilization merged as PR #465
+and the UX-first doc sync merged as PR #468; the doc-sync baseline is `e4078c7`, the canonical
+private-art checkout was observed at `f5500ac`, and the only current gate truth lives in
+`WorldOS-OPERATING-GOAL.md` + `WorldOS-GUI-RUNBOOK.md` + `qa/SCORECARD.md`. Do not use this section
+to decide release state. The next sprint is UX-first (#467):
 prove first-turn built-app play via #466, then prioritize clickability/chrome, launcher clarity,
 live-response feel, and CRPG depth before more hardening/proxy/security work.
 

--- a/qa/GUI_WORKBOOK.md
+++ b/qa/GUI_WORKBOOK.md
@@ -13,10 +13,11 @@
 - DM cold-open narration = 4842 chars with **27 paragraph breaks** (the prose IS well-formed).
 ⇒ The fix for "no images / no map / no palette" is **serve/build WITH `_private` art present** (infra), not 3 code PRs. The real *code* bugs are layout prominence + render formatting + the silent companion.
 
-Post-#465 note: `origin/main` is now `b15ad3c`, and RRI release scoring requires a
-disk-backed `palette_live` proof with **≥6 enabled actions** on a `can_act:true` surface. The 5-action
-canonical read above remains useful orientation, but it is not release proof; issue #466 must either prove
-the built app now meets the live palette gate or fail with an actionable artifact path.
+Post-#465/#468 note: the code baseline for the next clean RRI is `b15ad3c` or newer, and the current
+doc-sync baseline is `e4078c7`. RRI release scoring requires a disk-backed `palette_live` proof with
+**≥6 enabled actions** on a `can_act:true` surface. The 5-action canonical read above remains useful
+orientation, but it is not release proof; issue #466 must either prove the built app now meets the live
+palette gate or fail with an actionable artifact path.
 
 ## Phase 0 — infra (DONE)
 - ✅ `launch.json` repointed off the deprecated LEXAR copy → canonical/8799/`/openworlds/`/live state.


### PR DESCRIPTION
## Summary
- replaces self-staling `ORIGIN TIP` / `current origin/main` wording with a stable doc-sync baseline
- records PR #468 / `e4078c7` as the baseline input while still telling agents to re-verify `origin/main` before acting
- keeps #466 anchored to the post-#465 code baseline (`b15ad3c`) or newer

## Validation
- `git diff --check`
- GitHub CI: `test`, `viewer-tests`, `license-check`, and Socket checks passed on PR #469
- CodeRabbit: no actionable comments generated; status passed/skipped

## Licensing / CLA
- [x] I confirm this documentation-only change does not add restricted third-party material.
- [x] I confirm this change is authored for this repository and is compatible with the existing project license/CLA expectations.

No heavyweight local release sweep was run; this is wording-only docs cleanup.
