### PR TITLE
Fix OpenWorlds first-minute click chrome

### DIFF
--- a/qa/ui_audit_health.sh
+++ b/qa/ui_audit_health.sh
@@ -372,13 +372,22 @@ with open(sys.argv[1]) as f:
                 emit("FAIL", f"ui-gate art_present {s} @ {vp}: " + "; ".join(why))
                 total_fail += 1
             # 13c. title_bar_clearance — #260 / #306
-            if not v.get("titleNavOverlap", False):
-                emit("PASS", f"ui-gate title_bar_clearance {s} @ {vp}: no title/nav-rail collision")
+            title_ok = (
+                not v.get("titleNavOverlap", False)
+                and not v.get("titleEndOverlap", False)
+                and (v.get("titleLineCount") in (None, 0, 1))
+                and (v.get("titleDayReadable") in (None, True))
+            )
+            if title_ok:
+                emit("PASS",
+                    f"ui-gate title_bar_clearance {s} @ {vp}: title one-line, no nav/day collision, day readable")
             else:
-                tr = v.get("titleRect"); nr = v.get("navRect")
+                tr = v.get("titleRect"); nr = v.get("navRect"); er = v.get("titleEndRect"); dr = v.get("titleDayRect")
                 emit("FAIL",
-                    f"ui-gate title_bar_clearance {s} @ {vp}: title-text rect overlaps nav-rail "
-                    f"(title={tr} nav={nr}) — #260 regression")
+                    f"ui-gate title_bar_clearance {s} @ {vp}: navOverlap={v.get('titleNavOverlap')} "
+                    f"endOverlap={v.get('titleEndOverlap')} lines={v.get('titleLineCount')} "
+                    f"dayReadable={v.get('titleDayReadable')} "
+                    f"(title={tr} nav={nr} end={er} day={dr}) — #306 regression")
                 total_fail += 1
             # 13d. play_reachable (launcher only)
             cta = v.get("launcherCta")
@@ -392,6 +401,23 @@ with open(sys.argv[1]) as f:
                 total_fail += 1
             else:
                 emit("PASS", f"ui-gate play_reachable {s} @ {vp}: '{cta.get('text')}' enabled")
+            # 13e. representative hit-target proof — #309
+            hit = v.get("hitTargets")
+            if hit is not None:
+                missing = [
+                    key for key in (
+                        "tabPaddingClickFired",
+                        "tabKeyboardFired",
+                        "navPaddingClickFired",
+                        "navKeyboardFired",
+                    )
+                    if not hit.get(key)
+                ]
+                if not missing:
+                    emit("PASS", f"ui-gate hit_targets {s} @ {vp}: tab/nav padding clicks + keyboard activation work")
+                else:
+                    emit("FAIL", f"ui-gate hit_targets {s} @ {vp}: failed {missing} details={hit}")
+                    total_fail += 1
 print(f"__TOTAL_FAIL__:{total_fail}")
 PY
       # Replay the python report through pass/fail/warn so the overall summary

--- a/qa/ui_gate_probe.js
+++ b/qa/ui_gate_probe.js
@@ -1,8 +1,9 @@
 // qa/ui_gate_probe.js
 // Headless Playwright probe behind `qa/ui_audit_health.sh --ui-gate`.
 //
-// Drives one or more OpenWorlds screens at two viewport widths (1366 + 1512 —
-// the "narrow desktop" + "MBP 13-inch" pair the Loop-9 audit measured against)
+// Drives one or more OpenWorlds screens at viewport widths from
+// WORLDOS_UI_GATE_VIEWPORTS (default: 1366 + 1512 — the "narrow desktop" +
+// "MBP 13-inch" pair the Loop-9 audit measured against)
 // and emits a structured JSON line per screen so the shell wrapper can pass/fail
 // per-check.
 //
@@ -19,7 +20,11 @@
 //         "imgsTotal": 0,
 //         "imgsBroken": 0,
 //         "titleNavOverlap": true,         // collision check (#260 / #306)
-//         "launcherCta": { "text": "Resume → play", "disabled": false }
+//         "titleEndOverlap": false,
+//         "titleLineCount": 1,
+//         "titleDayReadable": true,
+//         "launcherCta": { "text": "Resume → play", "disabled": false },
+//         "hitTargets": null               // populated for representative clickability screens
 //       },
 //       "1512": { ... }
 //     }
@@ -57,7 +62,73 @@ if (!screens.length) {
   process.exit(2);
 }
 
-const VIEWPORTS = [1366, 1512];
+const VIEWPORTS = (process.env.WORLDOS_UI_GATE_VIEWPORTS || '1366,1512')
+  .split(',')
+  .map((v) => Number(v.trim()))
+  .filter((v) => Number.isFinite(v) && v > 0);
+
+async function clickButtonPadding(page, selector, label) {
+  const locator = page.locator(selector).filter({ hasText: label }).first();
+  try {
+    await locator.waitFor({ state: 'visible', timeout: 5000 });
+  } catch {
+    return { ok: false, reason: `missing ${selector} ${label}` };
+  }
+  const box = await locator.boundingBox();
+  if (!box) return { ok: false, reason: `no bounding box for ${selector} ${label}` };
+  await page.mouse.click(
+    box.x + Math.min(6, Math.max(2, box.width * 0.12)),
+    box.y + box.height / 2,
+  );
+  return { ok: true };
+}
+
+async function focusButtonAndPress(page, selector, label, key = 'Enter') {
+  const locator = page.locator(selector).filter({ hasText: label }).first();
+  try {
+    await locator.waitFor({ state: 'visible', timeout: 5000 });
+  } catch {
+    return { ok: false, reason: `missing ${selector} ${label}` };
+  }
+  await locator.focus();
+  await page.keyboard.press(key);
+  return { ok: true };
+}
+
+async function activeTabLabel(page) {
+  return await page.evaluate(() => (document.querySelector('.tab-button.active')?.textContent || '').trim());
+}
+
+async function activeNavLabel(page) {
+  return await page.evaluate(() => (document.querySelector('.nav-item.active .tip')?.textContent || '').trim());
+}
+
+async function runHitTargetChecks(page, screen) {
+  if (screen !== 'character') return null;
+  const checks = {};
+
+  const tabClick = await clickButtonPadding(page, '.tab-button', 'Stash');
+  await page.waitForTimeout(250);
+  checks.tabPaddingClickFired = tabClick.ok && await activeTabLabel(page) === 'Stash';
+  if (!tabClick.ok) checks.tabPaddingClickReason = tabClick.reason;
+
+  const tabKeyboard = await focusButtonAndPress(page, '.tab-button', 'Forge');
+  await page.waitForTimeout(250);
+  checks.tabKeyboardFired = tabKeyboard.ok && await activeTabLabel(page) === 'Forge';
+  if (!tabKeyboard.ok) checks.tabKeyboardReason = tabKeyboard.reason;
+
+  const navClick = await clickButtonPadding(page, '.nav-item', 'Map');
+  await page.waitForTimeout(250);
+  checks.navPaddingClickFired = navClick.ok && await activeNavLabel(page) === 'Map';
+  if (!navClick.ok) checks.navPaddingClickReason = navClick.reason;
+
+  const navKeyboard = await focusButtonAndPress(page, '.nav-item', 'Journal');
+  await page.waitForTimeout(250);
+  checks.navKeyboardFired = navKeyboard.ok && await activeNavLabel(page) === 'Journal';
+  if (!navKeyboard.ok) checks.navKeyboardReason = navKeyboard.reason;
+
+  return checks;
+}
 
 async function probeScreen(browser, screen) {
   const out = { screen, viewports: {} };
@@ -96,14 +167,32 @@ async function probeScreen(browser, screen) {
       // BOUNDING RECTS — when title text wraps, its bottom extends down past
       // the nav-rail's top, producing a true visual collision.
       const t = document.querySelector('.title-text');
+      const e = document.querySelector('.title-end');
+      const day = document.querySelector('.title-end > span:last-child');
       const n = document.querySelector('.nav-rail');
       const rect = (el) => (el ? el.getBoundingClientRect() : null);
       const tr = rect(t);
+      const er = rect(e);
+      const dr = rect(day);
       const nr = rect(n);
-      const overlap = tr && nr
+      const navOverlap = tr && nr
         ? (tr.left < nr.right && tr.right > nr.left)
           && (tr.top < nr.bottom && tr.bottom > nr.top)
         : false;
+      const titleEndOverlap = tr && er
+        ? (tr.left < er.right && tr.right > er.left)
+          && (tr.top < er.bottom && tr.bottom > er.top)
+        : false;
+      let titleLineCount = null;
+      if (t) {
+        const range = document.createRange();
+        range.selectNodeContents(t);
+        const tops = Array.from(range.getClientRects())
+          .filter((r) => r.width > 0 && r.height > 0)
+          .map((r) => Math.round(r.top));
+        titleLineCount = new Set(tops).size || 0;
+        range.detach();
+      }
       const placeholders = document.querySelectorAll('.placeholder').length;
       const imgEls = Array.from(document.querySelectorAll('img'));
       const imgsBroken = imgEls.filter((i) => i.complete && i.naturalWidth === 0).length;
@@ -121,8 +210,13 @@ async function probeScreen(browser, screen) {
           : { missing: true };
       }
       return {
-        titleNavOverlap: overlap,
+        titleNavOverlap: navOverlap,
+        titleEndOverlap,
+        titleLineCount,
+        titleDayReadable: dr ? dr.height >= 12 && dr.width >= 24 : null,
         titleRect: tr ? { left: tr.left, right: tr.right, top: tr.top, bottom: tr.bottom } : null,
+        titleEndRect: er ? { left: er.left, right: er.right, top: er.top, bottom: er.bottom } : null,
+        titleDayRect: dr ? { left: dr.left, right: dr.right, top: dr.top, bottom: dr.bottom, height: dr.height } : null,
         navRect: nr ? { left: nr.left, right: nr.right, top: nr.top, bottom: nr.bottom } : null,
         placeholders,
         imgsTotal: imgEls.length,
@@ -143,6 +237,7 @@ async function probeScreen(browser, screen) {
     }
     out.viewports[String(width)] = {
       ...measured,
+      hitTargets: await runHitTargetChecks(page, screen),
       consoleErrors: errs.length,
       consoleErrorSamples: errs.slice(0, 3),
     };

--- a/viewer/openworlds/chrome.jsx
+++ b/viewer/openworlds/chrome.jsx
@@ -385,6 +385,7 @@ function TabBar({ current, onNavigate }) {
         <button
           type="button"
           key={tab.id}
+          className={`tab-button ${current === tab.id ? "active" : ""}`}
           onClick={() => onNavigate(tab.id)}
           style={{
             position: "relative",

--- a/viewer/openworlds/styles.css
+++ b/viewer/openworlds/styles.css
@@ -121,8 +121,22 @@ body {
 }
 
 button, input, select, textarea { font: inherit; color: inherit; }
-button { background: none; border: 0; padding: 0; cursor: pointer; }
+button {
+  background: none;
+  border: 0;
+  padding: 0;
+  cursor: pointer;
+  box-sizing: border-box;
+  touch-action: manipulation;
+}
 a { color: inherit; text-decoration: none; cursor: pointer; }
+
+/* #309: buttons own the whole visible hit target. Decorative text/icon wrappers
+   should not become the click target or leave only the letters feeling live. */
+button > :where(span, svg, img, .ow-icon, .ow-icon-fallback),
+button > :where(span, svg, img, .ow-icon, .ow-icon-fallback) * {
+  pointer-events: none;
+}
 
 .ow-icon,
 .ow-icon-fallback {
@@ -405,6 +419,14 @@ a { color: inherit; text-decoration: none; cursor: pointer; }
   height: 1px;
   background: linear-gradient(90deg, transparent, var(--b-500), transparent);
   margin: 4px 0;
+}
+
+.tab-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  box-sizing: border-box;
 }
 
 /* ===== Stage ===== */

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -216,6 +216,55 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn("image/svg+xml", ctype)
         self.assertIn(b"<svg", body)
 
+    def test_openworlds_shared_buttons_own_their_visible_hit_targets(self):
+        # #309: first-minute playability depends on the visible button chrome being clickable,
+        # not only the letters/icons inside it. The shared chrome keeps handlers on outer
+        # buttons, gives the TabBar button a real flex box, and makes decorative children
+        # transparent to pointer targeting so clicks land on the button.
+        chrome = (server._OPENWORLDS_DIR / "chrome.jsx").read_text(encoding="utf-8")
+        styles = (server._OPENWORLDS_DIR / "styles.css").read_text(encoding="utf-8")
+
+        self.assertRegex(
+            chrome,
+            r"<button\s+[^>]*type=\"button\"[^>]*key=\{tab\.id\}[^>]*className=\{`tab-button",
+        )
+        self.assertIn("onClick={() => onNavigate(tab.id)}", chrome)
+        self.assertIn(".tab-button", styles)
+        tab_button_rule = re.search(r"\.tab-button\s*\{([^}]+)\}", styles, re.S)
+        self.assertIsNotNone(tab_button_rule)
+        self.assertIn("display: inline-flex", tab_button_rule.group(1))
+        self.assertIn("min-height: 34px", tab_button_rule.group(1))
+        self.assertIn("button > :where(span, svg, img, .ow-icon, .ow-icon-fallback)", styles)
+        self.assertIn("pointer-events: none", styles)
+
+        self.assertIn('className={`nav-item ${currentGroup?.id === g.id ? "active" : ""}`}', chrome)
+        self.assertIn("onClick={() => onNavigate(getDefaultScreen(g.id))}", chrome)
+
+    def test_openworlds_title_bar_keeps_title_and_day_pill_apart(self):
+        # #306: long campaign titles must never wrap under the nav rail or collide with the
+        # day/capability band. The structural fix is intentionally static so the built-app
+        # visual proof can focus on real rendering instead of rediscovering this regression.
+        chrome = (server._OPENWORLDS_DIR / "chrome.jsx").read_text(encoding="utf-8")
+        styles = (server._OPENWORLDS_DIR / "styles.css").read_text(encoding="utf-8")
+
+        self.assertIn("grid-template-columns: 1fr 240px", styles)
+        self.assertIn("paddingLeft: nativeStatus?.bridge ? 76 : 78", chrome)
+        self.assertNotIn("paddingLeft: nativeStatus?.bridge ? 76 : 0", chrome)
+
+        title_text_rule = re.search(r"\.title-text\s*\{([^}]+)\}", styles, re.S)
+        self.assertIsNotNone(title_text_rule)
+        title_text_css = title_text_rule.group(1)
+        self.assertIn("white-space: nowrap", title_text_css)
+        self.assertIn("overflow: hidden", title_text_css)
+        self.assertIn("text-overflow: ellipsis", title_text_css)
+        self.assertIn("max-width: calc(100% - 240px)", title_text_css)
+
+        title_end_rule = re.search(r"\.title-end\s*\{([^}]+)\}", styles, re.S)
+        self.assertIsNotNone(title_end_rule)
+        title_end_css = title_end_rule.group(1)
+        self.assertIn("font-size: 13px", title_end_css)
+        self.assertIn("min-width: 240px", title_end_css)
+
     def test_openworlds_combat_screen_binds_viewer_combat_surface(self):
         status, ctype, body = self._get("/openworlds/screen-combat.jsx")
 


### PR DESCRIPTION
## Summary
- Make shared OpenWorlds tabs/buttons own the full visible hit target, so players do not have to click the letters directly.
- Extend the UI gate probe with browser-measured title/day geometry and representative padding-click + keyboard activation checks.
- Lock #306 title/day layout and #309 shared click-target behavior with focused static tests.

## UX Evidence
- Live browser proof saved at `/Volumes/LEXAR/Codex/worldos-ui-gate-character-20260531T222414.ndjson`.
- Probe command: `WORLDOS_UI_GATE_VIEWPORTS=1280,1366,1440,1512,1920 node qa/ui_gate_probe.js 8815 character`.
- Result at all five widths: `titleNavOverlap=false`, `titleEndOverlap=false`, `titleLineCount=1`, `titleDayReadable=true`, `consoleErrors=0`, `tabPaddingClickFired=true`, `tabKeyboardFired=true`, `navPaddingClickFired=true`, `navKeyboardFired=true`.

## Tests
- `node -c qa/ui_gate_probe.js`
- `bash -n qa/ui_audit_health.sh`
- `python3 -m pytest viewer/tests/test_openworlds_static.py qa/test_release_gate_static.py -q` — 44 passed, 4 subtests passed
- `git diff --check`

## Notes
- Addresses shared chrome evidence for #309 and browser geometry evidence for #306.
- Does not claim final closure of #309/#306 until broader built-app/playtest proof is recorded.
- No engine authority change: GUI remains read-only plus `/move`; engine remains sole writer.

Refs #309
Refs #306
Refs #467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation testing for interactive UI elements and navigation interactions across multiple viewport widths.
  * Added verification tests for clickable button targets and title layout consistency.

* **Bug Fixes**
  * Strengthened title bar clearance validation with multi-field checking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->