### PR TITLE
docs: route app testing through local checkout

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -7,27 +7,29 @@
 > Companions: `WorldOS-OPERATING-GOAL.md` (the gate), `qa/GUI_WORKBOOK.md` (the live punch-list),
 > `qa/release_readiness.py` (the RRI scorer), `qa/SCORECARD.md` (the ledger).
 >
-> Takeover note, 2026-05-31: `/Users/lume/ClawDnD-val` is currently the private-art/live-app checkout,
-> not the place for tracked takeover edits. Use Lexar worktrees for changes; intentionally fast-forward
-> canonical only when the owner chooses to move the live app/art checkout.
+> Takeover routing, 2026-05-31: `/Users/lume/ClawDnD-val` is the synced local app/private-art checkout
+> (`36d8ac3 == origin/main` after #470) and the default place to build/run/test the GUI and native app.
+> Lexar is for evidence/snapshots/logs, not the default runtime tree, because macOS permission prompts
+> can break AI/browser tests when assets live on the external drive. For tracked GUI edits, prefer a
+> same-disk local worktree; use Lexar worktrees only for non-GUI slices that will not launch against art.
 
 ## The two surfaces (never confuse them again)
-- **ITERATE — visible, playable, fast:** the OpenWorlds viewer served **from the canonical repo**
+- **ITERATE — visible, playable, fast:** the OpenWorlds viewer served **from the local canonical repo**
   `/Users/lume/ClawDnD-val` (which HAS the 2.9 GB `content/worlds/_private` art) as a LIVE PLAYABLE
   session on **fixed port 8799**. This is where you fix one thing at a time and LOOK.
 - **GATE — truth:** the built `dist/WorldOS.app` via `qa/ui_playtest_app.sh` (part A native #356 +
   part B persona loop). Release is judged here. Same viewer code; adds the native shell.
-- **Why both:** identical viewer. 8799-from-canonical skips the build + guarantees art is present, so
-  it's the honest fast loop. The `.app` is the shipped artifact. A Lexar worktree may serve private art
-  only when `WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val` points at the canonical private-art checkout.
+- **Why both:** identical viewer. 8799-from-local skips the build + guarantees art is present, so
+  it's the honest fast loop. The `.app` is the shipped artifact. A non-local worktree may serve private art
+  only when `WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val` points at the local private-art checkout, but
+  use that as a fallback rather than the default because external-drive file prompts have broken local AI tests.
   The native app has a separate Private art repo path setting, and `script/build_and_run.sh` also writes
   the art root into `Info.plist` as `WorldOSArtRepoRoot` so LaunchServices env loss cannot hide missing art.
 
 ## Stand up the iteration surface (8799, playable, from canonical)
 ```bash
 cd /Users/lume/ClawDnD-val
-# Do not auto-pull during takeover; this checkout holds private art and the live app.
-# Verify intentionally before moving it:
+# This is the intended local app checkout. Verify it is synced before testing:
 git rev-parse --short HEAD && git rev-parse --short origin/main
 pkill -f 'viewer/server.py'; pkill -f 'scripts/play.sh'; pkill -f 'play_party.sh'   # NOT node:18789 (Eva gateway)
 CLAWDND_PLAY_PORT=8799 nohup bash scripts/play.sh baldurs-gate preview-$(git rev-parse --short HEAD) 8799 > /tmp/wos-8799.log 2>&1 &
@@ -54,13 +56,14 @@ streams mid-turn (`/events` count climbs during the turn) · a SOLO session has 
 ## Fix one thing → PR → merge → rebuild → LOOK (the loop)
 1. Confirm the symptom on 8799 with ≥2 clean reads. If it doesn't reproduce, it's a stale/corrupt
    read — do NOT fix it (log to GUI_WORKBOOK "evaporated").
-2. Builder agent in a **worktree off origin/main** (never branch-op canonical):
-   `git -C /Users/lume/ClawDnD-val worktree add -B codex/<slug> /Volumes/LEXAR/repos/wos-<slug> origin/main`
+2. Builder agent in a **same-disk local worktree off origin/main** when GUI/app tests need art:
+   `git -C /Users/lume/ClawDnD-val worktree add -B codex/<slug> /Users/lume/WorldOS-worktrees/wos-<slug> origin/main`
+   Lexar worktrees remain fine for docs/backend/non-GUI slices that do not launch the viewer/app.
 3. PR → CI green (incl. `viewer-tests`) → admin-squash-merge → delete branch → prune worktree.
    **Builder PRs sometimes fail to push silently** (happened twice this session) — always
    `gh pr view <n>` / `git ls-remote origin <branch>` to confirm the branch+PR EXIST before relying
    on them; if lost, redo the (usually small) change yourself in a clean worktree.
-4. `git pull --ff-only` canonical → restart 8799 → LOOK → tick GUI_WORKBOOK with the proof.
+4. `git pull --ff-only` local canonical → restart 8799 → LOOK → tick GUI_WORKBOOK with the proof.
 
 ## The gate sweep (Phase 3 — judged on the built .app)
 ```bash
@@ -83,8 +86,17 @@ WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val \
 WORLDOS_PREFER_LAUNCH_ROOTS=1 \
 script/build_and_run.sh --verify
 ```
-This proves the worktree-built bundle launches without killing the canonical app. It is only a smoke:
+This proves the local/worktree-built bundle launches without killing an existing app. It is only a smoke:
 release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI sweep.
+
+## Support VM lane (heavy sweeps, not Mac-only app truth)
+
+- Target: owner-provided **32GB support VM** (`support-vm-1`); connection/auth details live in local
+  operator-only runbooks/evidence, not tracked repo docs.
+- Do not assume it is ready for Codex runs until credentials/config are intentionally installed and verified.
+- Use it for heavy backend/persona release sweeps and parallel QA once configured.
+- Do **not** use it as proof for Mac-only surfaces: `WorldOS.app` build/launch, native #356, and built-app
+  UI play evidence stay on this Mac or macOS CI.
 
 ## Release (when RRI = 10/10 on a fresh .app build)
 Bump `.claude-plugin/plugin.json` → 1.0.4, tag `v1.0.4`, GitHub release + CHANGELOG. Then MAINTAIN:
@@ -95,9 +107,9 @@ reverts the goal to "fix" and outranks new work.
 ## Hard rules (carried from CLAUDE.md + this session's lessons)
 - Engine (`servers/engine`) = SOLE writer of campaign state. Don't touch wire contracts
   (`clawdnd-*`/`CLAWDND_*` MCP ids, `dev.clawdnd.app`); you MAY read `WORLDOS_ART_REPO_ROOT`.
-- `_private/` (the 2.9 GB art) is **never committed**. Building/serving from canonical is how the
-  art is present; Lexar worktrees can read it via `WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val`.
-- 16 GB host: tests on **GitHub CI / 32GB VM**, never heavy local suites. Parallel read-only agents are
+- `_private/` (the 2.9 GB art) is **never committed**. Building/serving from the local checkout is how the
+  art is present; worktrees can read it via `WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val` when needed.
+- 16 GB Mac: tests on **GitHub CI / 32GB support VM** for heavyweight sweeps, never heavy local suites. Parallel read-only agents are
   fine; do not launch multiple heavyweight persona sweeps locally.
 - **Verify, don't trust:** ≥2 clean reads for any claim; the RRI scorer reads disk, not the live
   channel; confirm builder PRs actually pushed.

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -5,14 +5,20 @@
      Post-compaction agents: this 6-line block is ground truth. Do NOT reconstruct
      state from scattered docs or old plans; trust this, verify the sha, then act.
      ──────────────────────────────────────────────────────────────────────────
-     AS OF:        2026-05-31 post-takeover UX sprint sync
+     AS OF:        2026-05-31 local-checkout sync
      MAIN BASELINE:
-                   e4078c7 (PR #468 merged; verified by git fetch on 2026-05-31).
-                   Re-verify current `origin/main` before acting; use this as the doc-sync baseline.
-     CANONICAL:    /Users/lume/ClawDnD-val is the private-art/live-app checkout; observed at f5500ac
-                   and behind origin/main by 3 commits before takeover. Do not fast-forward it
-                   until the owner intentionally chooses to move the private-art checkout.
-     WORKTREE:     tracked takeover edits happen from a Lexar worktree off refreshed origin/main.
+                   36d8ac3 (PR #470 merged; verified in /Users/lume/ClawDnD-val on 2026-05-31).
+                   Re-verify current `origin/main` before acting.
+     CANONICAL:    /Users/lume/ClawDnD-val is now the synced local app/private-art checkout and
+                   the default place to build/run/test the Mac app. Keep GUI/runtime tests on this
+                   local disk so macOS does not prompt on Lexar-hosted assets.
+     WORKTREES:    For tracked edits, prefer same-disk local worktrees when GUI/app tests need assets.
+                   Use /Volumes/LEXAR/Codex for evidence/snapshots and Lexar worktrees only for
+                   non-GUI/doc/backend slices that do not launch the app against private art.
+     SUPPORT VM:   32GB owner-provided support VM (`support-vm-1`). Connection/auth details live
+                   in local operator-only evidence/runbooks, not tracked repo docs. Use it for
+                   heavy backend/persona sweeps only after Codex/config/credentials are intentionally
+                   installed. Mac-built `.app` smoke/play proof stays on this Mac or macOS CI.
      LAST MEASURED GATE BUILD:
                    f5500ac produced qa/RRI.json = 2.7/10, but this is PARTIAL /
                    HARNESS-CONTAMINATED evidence: only newbie wrote score.json; the other
@@ -21,9 +27,10 @@
      LAST VALID RELEASE GATE:
                    none after the RRI contract hardening. A release verdict requires expected
                    persona count, disk-backed palette/image/behavioral evidence, and built .app play.
-     NEXT ACTION:  Run the clean post-hardening gate (#466) to get a trustworthy failure list, but
-                   plan the next sprint UX-first (#467): first-turn playability, clickability/chrome, launcher
-                   clarity, live-response feel, and CRPG depth before more hardening/proxy/security work.
+     NEXT ACTION:  From the synced local checkout, prove first-turn built-app play and run #466 for a
+                   trustworthy clean RRI failure list/result. Keep sprint work UX-first (#467):
+                   first-turn playability, clickability/chrome, launcher clarity, live-response feel,
+                   and CRPG depth before more hardening/proxy/security work.
      DISCIPLINE:   ≥2 clean reads before any fix (channel fabricates under host load); ONE heavy claude -p stream;
                    never probe-kill; test the BUILT .app, never a proxy; honest scores; never "100% confidence".
      ════════════════════════════════════════════════════════════════════════════ -->
@@ -120,8 +127,9 @@ by an average). **RRI 10/10 = every gate holds on one fresh build:**
 
 ## 5. THE ITERATE LOOP (while the gate fails)
 
-`git fetch` → create/update a **Lexar worktree off origin/main** (never branch-op the private-art
-checkout) → `rm -rf dist/WorldOS.app` in the intended app checkout → `qa/ui_playtest_app.sh` × 5 personas against the built `.app` → **score** (5-persona
+`git fetch` → create/update a **same-disk local worktree off origin/main** for tracked edits
+when GUI/app tests need assets (Lexar is evidence/scratch, not the default runtime tree) →
+`rm -rf dist/WorldOS.app` in the local app checkout → `qa/ui_playtest_app.sh` × 5 personas against the built `.app` → **score** (5-persona
 satisfaction + 3 lenses + behavioral + axe) → **file GitHub issues** tied to `{build_sha, version_tag}`
 with `file:line` + acceptance criteria → **delegate code to builder subagents** (worktree → PR →
 CI-green incl. `viewer-tests` → squash-merge) → **rebuild → re-playtest.**
@@ -153,32 +161,35 @@ verifier; can revert the goal to "fix" anytime.
 - **Never** claim "100% confidence" / "audit complete." A merged PR is a hypothesis; a non-reproducing
   NEXT build is the evidence. Close issues only on next-build non-reproduction. **Honest scores only.**
 - Engine (`servers/engine`) = **SOLE writer** of campaign state. Don't touch wire contracts
-  (`clawdnd-*` / `CLAWDND_*` / `dev.clawdnd.app`). Build/edit from **Lexar worktrees off origin/main**.
-  Treat `/Users/lume/ClawDnD-val` as the canonical private-art/live-app checkout until intentionally
-  moved. 16GB host → **GitHub CI / 32GB VM** for heavy tests, never local heavy workers. `_private/`
-  never committed.
+  (`clawdnd-*` / `CLAWDND_*` / `dev.clawdnd.app`). Build/run/test the Mac app from
+  `/Users/lume/ClawDnD-val` so private art stays on the local disk and macOS does not prompt on Lexar
+  files. Use **same-disk local worktrees** for GUI-affecting tracked edits, Lexar for evidence/snapshots,
+  and the 32GB support VM / GitHub CI for heavy tests. `_private/` never committed.
 
 ---
 
-## 9. CURRENT STATUS (2026-05-31 — post-#465, NOT a release verdict)
+## 9. CURRENT STATUS (2026-05-31 — local checkout synced, NOT a release verdict)
 
-- Repo truth stabilization merged in PR #465, and the UX-first doc sync merged in PR #468. The current
-  doc-sync baseline is `e4078c7`; re-verify `origin/main` before acting. The private-art checkout at
-  `/Users/lume/ClawDnD-val` was observed at `f5500ac` before takeover. Keep it intact until the owner
-  intentionally fast-forwards the live app/private-art checkout.
+- Repo truth stabilization merged in PR #465, UX-first doc sync merged in PR #468, and first-minute
+  click/title chrome proof merged in PR #470. The local app/private-art checkout
+  `/Users/lume/ClawDnD-val` is synced to `36d8ac3 == origin/main` as of 2026-05-31.
+- The stale local pre-sync artifacts were preserved before the fast-forward at
+  `/Volumes/LEXAR/Codex/worldos-local-checkout-snapshot-20260531T223923` and in `stash@{0}`
+  (`pre-sync local takeover docs 2026-05-31`). Treat those as evidence, not current release truth.
 - The `f5500ac` RRI (`2.7/10`) is preserved as partial evidence only. It proves the gate/harness was
   not trustworthy enough for release scoring: one persona completed, others lacked `score.json`, and
   image/palette/behavioral/UI audit sources were either missing or harness-contaminated.
-- The next evidence step is issue #466: run a clean non-partial five-persona RRI from the post-#465 code
-  baseline (`b15ad3c`) or newer on the 32GB VM for backend/personas, plus the Mac/macOS CI built-app
-  playtest. The expected outcome is either a trustworthy blocker list or a real 11/11 release result.
+- The next evidence step is issue #466: run a clean non-partial five-persona RRI from `36d8ac3` or newer.
+  Heavy backend/persona sweeps belong on the owner-provided 32GB support VM (`support-vm-1`) once
+  auth/config are intentionally installed there; connection details are kept outside tracked docs.
+  Mac-only built-app launch/play proof stays on this Mac or macOS CI.
 - Product direction is now UX-first (#467). Do not turn the next sprint into more gate hardening, proxy adapters,
   transport/security work, UGC/legal, or renderer branches unless #466 proves they block the player-facing
   session. The game must feel launchable, clickable, responsive, and deep before it needs more machinery.
-- Highest-confidence UX risks to verify/fix next: first-turn built-app play; global click hit areas (#309);
-  title/chrome truth (#306); launcher clarity/stale campaigns (#358); per-beat latency/live response (#393);
-  portrait/gallery blockers (#379); and CRPG depth on Heroes/Battle/Inventory (#308/#318/#310,
-  with #462/#463 folded into Battle readability as presentation containment).
+- Highest-confidence UX risks to verify/fix next: first-turn built-app play; broader click hit areas (#309)
+  after #470's shared-chrome proof; built-app title/chrome truth (#306); launcher clarity/stale campaigns
+  (#358); per-beat latency/live response (#393); portrait/gallery blockers (#379); and CRPG depth on
+  Heroes/Battle/Inventory (#308/#318/#310, with #462/#463 folded into Battle readability as presentation containment).
 
 ---
 

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -8,6 +8,12 @@
 > **Takeover routing, 2026-05-31:** current release/gate state lives in
 > `WorldOS-OPERATING-GOAL.md` first, then `WorldOS-GUI-RUNBOOK.md`, then `qa/SCORECARD.md`.
 > The work queue later in this file is historical unless it agrees with those sources.
+> **Local/VM routing, 2026-05-31:** `/Users/lume/ClawDnD-val` is the synced local app/private-art
+> checkout and should be used for GUI/native-app testing. Use `/Volumes/LEXAR/Codex` for evidence,
+> snapshots, and logs; do not make Lexar the default GUI runtime tree because external-drive
+> permissions can break local AI/browser tests. Heavy backend/persona sweeps belong on GitHub CI or
+> the owner-provided 32GB support VM (`support-vm-1`) after SSH/Codex credentials are installed and
+> verified; connection details are kept outside tracked docs. Mac-only built-app proof remains local/macOS CI.
 
 > **This is the compaction-resilience doc.** If you are an agent resuming this project
 > after a context reset, read this top-to-bottom before doing anything. It captures the
@@ -144,8 +150,10 @@ change must respect them.
 > development, run focused tests first and keep Python test runs single-process unless
 > you have explicitly verified your machine can handle parallel workers.
 
-1. **Branch off main in a fresh worktree** (keeps lanes disjoint from the sibling desktop
-   work). Implement **additively** (honor every invariant above).
+1. **Branch off main in a fresh worktree** (keeps lanes disjoint from the app-testing checkout).
+   For GUI/native-app work, prefer same-disk local worktrees under `/Users/lume/WorldOS-worktrees`
+   so private-art reads stay on the local disk. Lexar worktrees are fine for docs/backend/non-GUI
+   slices that do not launch the app against art. Implement **additively** (honor every invariant above).
 2. **Run focused local tests single-process:**
    ```bash
    uv run --directory servers/engine python -m pytest <relpath> -q -p no:xdist
@@ -295,11 +303,11 @@ out freely. Only **`claude -p` QA is host-heavy** (the duo/sprint spin up engine
 ## CURRENT STATE + WORK QUEUE
 
 **Historical snapshot, not current authority:** this queue was written around `ea815fc`
-(2026-05-27 cont.3). During the 2026-05-31 takeover, the gate-truth stabilization merged as PR #465
-and the UX-first doc sync merged as PR #468; the doc-sync baseline is `e4078c7`, the canonical
-private-art checkout was observed at `f5500ac`, and the only current gate truth lives in
-`WorldOS-OPERATING-GOAL.md` + `WorldOS-GUI-RUNBOOK.md` + `qa/SCORECARD.md`. Do not use this section
-to decide release state. The next sprint is UX-first (#467):
+(2026-05-27 cont.3). During the 2026-05-31 takeover, the gate-truth stabilization merged as PR #465,
+the UX-first doc sync merged as PR #468, and first-minute click/title chrome proof merged as PR #470.
+The local app/private-art checkout is now synced at `36d8ac3 == origin/main`; the only current gate
+truth lives in `WorldOS-OPERATING-GOAL.md` + `WorldOS-GUI-RUNBOOK.md` + `qa/SCORECARD.md`. Do not use
+this section to decide release state. The next sprint is UX-first (#467):
 prove first-turn built-app play via #466, then prioritize clickability/chrome, launcher clarity,
 live-response feel, and CRPG depth before more hardening/proxy/security work.
 


### PR DESCRIPTION
## Summary
- Update takeover routing so `/Users/lume/ClawDnD-val` is the synced local app/private-art checkout and default GUI/native-app test tree.
- Clarify Lexar is for evidence/snapshots/logs, not the default GUI runtime tree, because external-drive permissions can interrupt local AI/browser testing.
- Document the owner-provided 32GB support VM lane by stable alias (`support-vm-1`) without publishing connection/auth details.

## Support VM Details
- Target: owner-provided 32GB support VM (`support-vm-1`).
- Connection/auth details live in local operator-only evidence/runbooks, not tracked repo docs or public PR text.
- Intended use: heavy backend/persona sweeps after Codex/config/credentials are intentionally installed and verified.
- Not a substitute for Mac-only `WorldOS.app` launch/play proof, which stays local or macOS CI.

## Local Checkout Evidence
- `/Users/lume/ClawDnD-val` fast-forwarded from `f5500ac` to `36d8ac3 == origin/main`.
- Dirty pre-sync local artifacts preserved at `/Volumes/LEXAR/Codex/worldos-local-checkout-snapshot-20260531T223923` and in `stash@{0}`.
- Local `.agents/` retained but hidden via `.git/info/exclude` so repo status stays clean.

## Tests
- `git diff --check`
- `git diff --cached --check`
- Sensitive VM connection-string scan across the three edited docs - no matches
- `bash -n qa/release_gate.sh qa/ui_audit_health.sh qa/ui_playtest_app.sh script/build_and_run.sh scripts/play.sh scripts/play_party.sh`
- `python3 -m pytest qa/test_release_gate_static.py qa/test_release_readiness.py viewer/tests/test_openworlds_static.py -q` - 57 passed, 4 subtests passed
- `qa/release_gate.sh --preflight-only --port 8785` - preflight OK from `/Users/lume/ClawDnD-val`; private art present, 2360 scopes; on origin/main tip `36d8ac3`; port free; tools present

## CLA / Licensing / Confidentiality
- [x] I have authority to submit this documentation-only change.
- [x] No third-party code, assets, or private art are introduced.
- [x] No secrets, credentials, support VM connection details, or private asset files are committed.
- [x] Machine-specific connection details remain in operator-only local evidence/runbooks.

Refs #466
Refs #467