### PR TITLE
Respect native selected provider in OpenWorlds starts

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -917,14 +917,20 @@ function capabilityForScreen(screen, nativeState) {
   return null;
 }
 
+function nativePreferredProvider(nativeState) {
+  const app = nativeState?.appStatus || {};
+  return app?.preferences?.selectedProvider || app?.selectedProvider || "";
+}
+
 function ScreenRouter({ screen, state, setState, onNavigate, campMode, setCampMode, nativeState, refreshNative, liveSession }) {
+  const preferredProvider = nativePreferredProvider(nativeState);
   switch (screen) {
-    case "launcher":  return <ScreenLauncher state={state} setState={setState} onNavigate={onNavigate} />;
-    case "roster":    return <ScreenRoster state={state} setState={setState} onNavigate={onNavigate} />;
+    case "launcher":  return <ScreenLauncher state={state} setState={setState} onNavigate={onNavigate} preferredProvider={preferredProvider} />;
+    case "roster":    return <ScreenRoster state={state} setState={setState} onNavigate={onNavigate} preferredProvider={preferredProvider} />;
     case "table":     return <ScreenTable state={state} setState={setState} onNavigate={onNavigate} liveSession={liveSession} />;
     case "combat":    return <ScreenCombat state={state} setState={setState} onNavigate={onNavigate} />;
     case "character": return <ScreenCharacter state={state} setState={setState} onNavigate={onNavigate} />;
-    case "create":    return <ScreenCreate state={state} setState={setState} onNavigate={onNavigate} />;
+    case "create":    return <ScreenCreate state={state} setState={setState} onNavigate={onNavigate} preferredProvider={preferredProvider} />;
     case "forge":     return <ScreenForge state={state} setState={setState} onNavigate={onNavigate} />;
     case "relations": return <ScreenRelations state={state} setState={setState} onNavigate={onNavigate} />;
     case "acts":      return <ScreenActs state={state} setState={setState} onNavigate={onNavigate} />;
@@ -936,7 +942,7 @@ function ScreenRouter({ screen, state, setState, onNavigate, campMode, setCampMo
     case "merchant":  return <ScreenMerchant state={state} setState={setState} onNavigate={onNavigate} />;
     case "dialogue":  return <ScreenDialogue state={state} setState={setState} onNavigate={onNavigate} />;
     case "settings":  return <ScreenSettings state={state} setState={setState} onNavigate={onNavigate} nativeState={nativeState} refreshNative={refreshNative} />;
-    default:          return <ScreenLauncher state={state} setState={setState} onNavigate={onNavigate} />;
+    default:          return <ScreenLauncher state={state} setState={setState} onNavigate={onNavigate} preferredProvider={preferredProvider} />;
   }
 }
 

--- a/viewer/openworlds/screen-create.jsx
+++ b/viewer/openworlds/screen-create.jsx
@@ -65,7 +65,7 @@ function heroPortraitScope(hero) {
   return portraitScope(hero.portrait);
 }
 
-function ScreenCreate({ onNavigate, state, setState }) {
+function ScreenCreate({ onNavigate, state, setState, preferredProvider = "" }) {
   const [step, setStep] = React.useState(0);
   const [hero, setHero] = React.useState({
     name: "",
@@ -141,13 +141,14 @@ function ScreenCreate({ onNavigate, state, setState }) {
     window.OpenWorldsBuilding?.begin?.({ world: "baldurs-gate", kind: "forge", title: spec.name });
     const stamp = new Date().toISOString().slice(0, 19).replace(/[-:T]/g, "");
     try {
-      const reply = await window.OpenWorldsNative.request("startProviderSession", {
-        provider: "claude",
+      const payload = {
         world: "baldurs-gate",
         runId: `play-${stamp}`,
         companions: "",
         hero: JSON.stringify(spec),
-      });
+      };
+      if (preferredProvider) payload.provider = preferredProvider;
+      const reply = await window.OpenWorldsNative.request("startProviderSession", payload);
       // Drive the reload to the live viewer from JS using the URL the bridge returns (same as
       // screen-launcher) — the live viewer boots fresh and app.jsx auto-routes into the table
       // once the provider is running.

--- a/viewer/openworlds/screen-launcher.jsx
+++ b/viewer/openworlds/screen-launcher.jsx
@@ -1,6 +1,6 @@
 /* Screen: Launcher / Worlds — campaign selection + new campaign */
 
-function ScreenLauncher({ onNavigate, state, setState }) {
+function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" }) {
   const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
   const [selected, setSelected] = React.useState(state?.activeCampaign || campaigns[0]?.id || "");
   const [showNew, setShowNew] = React.useState(false);
@@ -29,9 +29,8 @@ function ScreenLauncher({ onNavigate, state, setState }) {
   }, [campaigns, selected, state?.activeCampaign]);
 
   // Begin a live, playable session. Inside the native WorldOS app this asks the supervisor
-  // to start a provider session (scripts/play.sh: a move-sink-wired viewer + a claude -p
-  // Dungeon Master). The app repoints its WebView at that live viewer on a fresh port, so
-  // the page reloads and app.jsx auto-lands us in the table once a provider is running.
+  // to start the currently selected provider session. The app repoints its WebView at that
+  // live viewer on a fresh port, so the page reloads and app.jsx auto-lands us in the table.
   // Outside the app (a plain 8799 browser preview) there is no DM to attach — fall back to
   // the read-only table so the surface stays reachable.
   const startPlay = async (world) => {
@@ -50,12 +49,13 @@ function ScreenLauncher({ onNavigate, state, setState }) {
     window.OpenWorldsBuilding?.begin?.({ world: world || "baldurs-gate", kind: "play" });
     const stamp = new Date().toISOString().slice(0, 19).replace(/[-:T]/g, "");
     try {
-      const reply = await window.OpenWorldsNative.request("startProviderSession", {
-        provider: "claude",
+      const payload = {
         world: world || "baldurs-gate",
         runId: `play-${stamp}`,
         companions: "",
-      });
+      };
+      if (preferredProvider) payload.provider = preferredProvider;
+      const reply = await window.OpenWorldsNative.request("startProviderSession", payload);
       // Drive the reload to the live, sink-wired viewer from JS using the URL the bridge
       // returns — don't rely on the native WebView re-binding its own state across the async
       // hop. The live viewer boots fresh and app.jsx auto-routes into the table once the

--- a/viewer/openworlds/screen-roster.jsx
+++ b/viewer/openworlds/screen-roster.jsx
@@ -135,7 +135,7 @@ function RosterCard({ npc, onPlay, busy }) {
   );
 }
 
-function ScreenRoster({ onNavigate, state, setState }) {
+function ScreenRoster({ onNavigate, state, setState, preferredProvider = "" }) {
   const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
   const campaignId = campaigns.some((c) => c.id === state?.activeCampaign)
     ? state.activeCampaign
@@ -235,13 +235,14 @@ function ScreenRoster({ onNavigate, state, setState }) {
     const stamp = new Date().toISOString().slice(0, 19).replace(/[-:T]/g, "");
     const world = (campaigns.find((c) => c.id === campaignId)?.world) || surface?.world_id || "baldurs-gate";
     try {
-      const reply = await window.OpenWorldsNative.request("startProviderSession", {
-        provider: "claude",
+      const payload = {
         world,
         runId: `play-${stamp}`,
         companions: "",
         hero: JSON.stringify({ canon: true, name: npc.name }),
-      });
+      };
+      if (preferredProvider) payload.provider = preferredProvider;
+      const reply = await window.OpenWorldsNative.request("startProviderSession", payload);
       const liveUrl = reply && (reply.url || reply.viewer?.openWorldsURL);
       if (liveUrl) {
         window.location.assign(liveUrl);

--- a/viewer/openworlds/screen-settings.jsx
+++ b/viewer/openworlds/screen-settings.jsx
@@ -397,12 +397,14 @@ function NativeAppSection({ nativeState, refreshNative }) {
     const prefs = app.preferences || {};
     const now = new Date();
     const stamp = now.toISOString().slice(0, 19).replace(/[-:T]/g, "").replace(/^(\d{8})(\d{6})$/, "$1-$2");
-    nativeAction("startProviderSession", {
-      provider: prefs.selectedProvider || app.selectedProvider || "claude",
+    const payload = {
       world: prefs.defaultWorld || app.defaultWorld || "baldurs-gate",
       runId: `play-${stamp}`,
       companions: "",
-    });
+    };
+    const provider = prefs.selectedProvider || app.selectedProvider || "";
+    if (provider) payload.provider = provider;
+    nativeAction("startProviderSession", payload);
   };
 
   return (

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -538,6 +538,25 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertNotIn("private canon", encoded)
         self.assert_no_private_keys(json.loads(encoded))
 
+    def test_native_start_surfaces_use_app_selected_provider(self):
+        app = (Path(__file__).resolve().parents[1] / "openworlds" / "app.jsx").read_text(encoding="utf-8")
+        self.assertIn("function nativePreferredProvider(nativeState)", app)
+        self.assertIn('return app?.preferences?.selectedProvider || app?.selectedProvider || "";', app)
+        self.assertIn("const preferredProvider = nativePreferredProvider(nativeState);", app)
+        self.assertIn("preferredProvider={preferredProvider}", app)
+
+        for name in ("screen-launcher.jsx", "screen-create.jsx", "screen-roster.jsx"):
+            source = (Path(__file__).resolve().parents[1] / "openworlds" / name).read_text(encoding="utf-8")
+            self.assertIn('preferredProvider = ""', source, name)
+            self.assertIn("if (preferredProvider) payload.provider = preferredProvider;", source, name)
+            self.assertNotIn('provider: "claude"', source, name)
+            self.assertNotIn('preferredProvider || "claude"', source, name)
+
+        settings = (Path(__file__).resolve().parents[1] / "openworlds" / "screen-settings.jsx").read_text(encoding="utf-8")
+        self.assertIn('const provider = prefs.selectedProvider || app.selectedProvider || "";', settings)
+        self.assertIn("if (provider) payload.provider = provider;", settings)
+        self.assertNotIn('provider: prefs.selectedProvider || app.selectedProvider || "claude"', settings)
+
     def test_monitor_play_campaign_links_openworlds_not_legacy_dashboard(self):
         source = (Path(__file__).resolve().parents[1] / "monitor.html").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- route OpenWorlds launcher, roster, creation, and Settings provider starts through the macOS app selected provider instead of forcing Claude from the web surface
- omit the provider field when native app status has not loaded yet, so RootView.startProviderFromBridge falls back to selectedProviderRaw as the native source of truth
- add a static regression test covering the native-start provider contract

## Evidence
- Built-app smoke on cad2e00 launched the local app from /Users/lume/ClawDnD-val and rendered OpenWorlds with private art before this fix. First Resume/Play minted a run but forced Claude and failed with API 401, confirming this path was still tied to Claude.
- This patch removes the web-surface hardcoded provider override.

## Tests
- python3 -m pytest viewer/tests/test_openworlds_static.py -q
- python3 -m pytest qa/test_release_gate_static.py qa/test_release_readiness.py qa/test_macos_app_static.py viewer/tests/test_openworlds_static.py -q
- git diff --check
- bash -n qa/release_gate.sh qa/ui_audit_health.sh qa/ui_playtest_app.sh script/build_and_run.sh scripts/play.sh scripts/play_party.sh scripts/play_codex_actor.sh
- CLAWDND_PROVIDER=codex CLAWDND_WORLD=baldurs-gate CLAWDND_RUN_ID=codex-dry-run CLAWDND_PLAY_PORT=8799 CLAWDND_PLAY_BUDGET=1.50 CLAWDND_PLAY_SESSION_BUDGET=15.00 CLAWDND_PLAY_MAX_TURNS=40 scripts/play_codex_actor.sh --dry-run

## Release note
This does not claim the Codex provider is a full Claude-DM replacement yet; it only fixes the native/web provider-selection contract so the selected provider can be exercised honestly in the next built-app proof.

## Checklist
- [x] No endpoint/auth details added
- [x] Engine remains the sole writer; GUI only submits native start intent and /move through existing paths
- [x] Focused local tests only; no heavyweight RRI run on the 16GB Mac


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider preferences are now dynamically applied across all native game sessions and features. Users' selected provider choices are respected when launching games, creating characters, and summoning NPCs instead of being hardcoded.

* **Tests**
  * Added test coverage to verify provider preferences are properly propagated and conditionally applied in all relevant screens and settings flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->