### PR TITLE
Sync takeover docs after provider selection

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -8,7 +8,7 @@
 > `qa/release_readiness.py` (the RRI scorer), `qa/SCORECARD.md` (the ledger).
 >
 > Takeover routing, 2026-05-31: `/Users/lume/ClawDnD-val` is the synced local app/private-art checkout
-> (`36d8ac3 == origin/main` after #470) and the default place to build/run/test the GUI and native app.
+> (`5dd1391 == origin/main` after #472) and the default place to build/run/test the GUI and native app.
 > Lexar is for evidence/snapshots/logs, not the default runtime tree, because macOS permission prompts
 > can break AI/browser tests when assets live on the external drive. For tracked GUI edits, prefer a
 > same-disk local worktree; use Lexar worktrees only for non-GUI slices that will not launch against art.
@@ -25,6 +25,16 @@
   use that as a fallback rather than the default because external-drive file prompts have broken local AI tests.
   The native app has a separate Private art repo path setting, and `script/build_and_run.sh` also writes
   the art root into `Info.plist` as `WorldOSArtRepoRoot` so LaunchServices env loss cannot hide missing art.
+
+## Native provider reality check
+
+- OpenWorlds native-start surfaces now honor the macOS app's selected provider (#472). If the web UI has
+  not loaded app status yet, it omits `provider` and lets Swift's `selectedProviderRaw` setting decide.
+- Do not treat that as a Claude-free release proof. The default Codex wrapper
+  (`scripts/play_codex_actor.sh`) is a constrained **player actor** using the player facade; it is not yet
+  a Dungeon Master loop. OpenClaw is also not launchable until a valid provider command is configured.
+- Before running #466, prove first-turn built-app play with a provider that actually mints the world,
+  writes DM narration, and leaves `/session-surface` with `can_act:true` for the live/current campaign.
 
 ## Stand up the iteration surface (8799, playable, from canonical)
 ```bash

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -5,9 +5,9 @@
      Post-compaction agents: this 6-line block is ground truth. Do NOT reconstruct
      state from scattered docs or old plans; trust this, verify the sha, then act.
      ──────────────────────────────────────────────────────────────────────────
-     AS OF:        2026-05-31 local-checkout sync
+     AS OF:        2026-05-31 post-PR #472 local provider-selection sync
      MAIN BASELINE:
-                   36d8ac3 (PR #470 merged; verified in /Users/lume/ClawDnD-val on 2026-05-31).
+                   5dd1391 (PRs #470, #471, #472 merged; verified in /Users/lume/ClawDnD-val on 2026-05-31).
                    Re-verify current `origin/main` before acting.
      CANONICAL:    /Users/lume/ClawDnD-val is now the synced local app/private-art checkout and
                    the default place to build/run/test the Mac app. Keep GUI/runtime tests on this
@@ -27,10 +27,10 @@
      LAST VALID RELEASE GATE:
                    none after the RRI contract hardening. A release verdict requires expected
                    persona count, disk-backed palette/image/behavioral evidence, and built .app play.
-     NEXT ACTION:  From the synced local checkout, prove first-turn built-app play and run #466 for a
-                   trustworthy clean RRI failure list/result. Keep sprint work UX-first (#467):
-                   first-turn playability, clickability/chrome, launcher clarity, live-response feel,
-                   and CRPG depth before more hardening/proxy/security work.
+     NEXT ACTION:  From the synced local checkout, prove first-turn built-app play with an actual
+                   DM-capable provider, then run #466 for a trustworthy clean RRI failure list/result.
+                   Keep sprint work UX-first (#467): first-turn playability, clickability/chrome,
+                   launcher clarity, live-response feel, and CRPG depth before more hardening/proxy/security work.
      DISCIPLINE:   ≥2 clean reads before any fix (channel fabricates under host load); ONE heavy claude -p stream;
                    never probe-kill; test the BUILT .app, never a proxy; honest scores; never "100% confidence".
      ════════════════════════════════════════════════════════════════════════════ -->
@@ -171,18 +171,25 @@ verifier; can revert the goal to "fix" anytime.
 ## 9. CURRENT STATUS (2026-05-31 — local checkout synced, NOT a release verdict)
 
 - Repo truth stabilization merged in PR #465, UX-first doc sync merged in PR #468, and first-minute
-  click/title chrome proof merged in PR #470. The local app/private-art checkout
-  `/Users/lume/ClawDnD-val` is synced to `36d8ac3 == origin/main` as of 2026-05-31.
+  click/title chrome proof merged in PR #470. Local/Lexar/support-VM routing merged in PR #471.
+  Native OpenWorlds starts now honor the macOS app's selected provider instead of forcing Claude
+  from the web surface in PR #472. The local app/private-art checkout `/Users/lume/ClawDnD-val`
+  is synced to `5dd1391 == origin/main` as of 2026-05-31.
 - The stale local pre-sync artifacts were preserved before the fast-forward at
   `/Volumes/LEXAR/Codex/worldos-local-checkout-snapshot-20260531T223923` and in `stash@{0}`
   (`pre-sync local takeover docs 2026-05-31`). Treat those as evidence, not current release truth.
 - The `f5500ac` RRI (`2.7/10`) is preserved as partial evidence only. It proves the gate/harness was
   not trustworthy enough for release scoring: one persona completed, others lacked `score.json`, and
   image/palette/behavioral/UI audit sources were either missing or harness-contaminated.
-- The next evidence step is issue #466: run a clean non-partial five-persona RRI from `36d8ac3` or newer.
-  Heavy backend/persona sweeps belong on the owner-provided 32GB support VM (`support-vm-1`) once
-  auth/config are intentionally installed there; connection details are kept outside tracked docs.
-  Mac-only built-app launch/play proof stays on this Mac or macOS CI.
+- Built-app launch smoke on `cad2e00` rendered OpenWorlds with private art, but the first Resume/Play
+  click still forced Claude and failed on Claude auth. PR #472 fixed that web/native selection bug.
+  It does **not** prove a Claude-free release path yet: the checked-in Codex wrapper is a constrained
+  player actor/move-facade, and OpenClaw requires an intentionally configured provider command.
+- The next evidence step is issue #466 after the first-turn provider path is DM-capable: run a clean
+  non-partial five-persona RRI from `5dd1391` or newer. Heavy backend/persona sweeps belong on the
+  owner-provided 32GB support VM (`support-vm-1`) once auth/config are intentionally installed there;
+  connection details are kept outside tracked docs. Mac-only built-app launch/play proof stays on this
+  Mac or macOS CI.
 - Product direction is now UX-first (#467). Do not turn the next sprint into more gate hardening, proxy adapters,
   transport/security work, UGC/legal, or renderer branches unless #466 proves they block the player-facing
   session. The game must feel launchable, clickable, responsive, and deep before it needs more machinery.

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -12,8 +12,9 @@
 > checkout and should be used for GUI/native-app testing. Use `/Volumes/LEXAR/Codex` for evidence,
 > snapshots, and logs; do not make Lexar the default GUI runtime tree because external-drive
 > permissions can break local AI/browser tests. Heavy backend/persona sweeps belong on GitHub CI or
-> the owner-provided 32GB support VM (`support-vm-1`) after SSH/Codex credentials are installed and
-> verified; connection details are kept outside tracked docs. Mac-only built-app proof remains local/macOS CI.
+> the owner-provided 32GB support VM (`support-vm-1`) after remote access and Codex config are
+> intentionally installed and verified; connection details are kept outside tracked docs. Mac-only
+> built-app proof remains local/macOS CI.
 
 > **This is the compaction-resilience doc.** If you are an agent resuming this project
 > after a context reset, read this top-to-bottom before doing anything. It captures the
@@ -305,7 +306,8 @@ out freely. Only **`claude -p` QA is host-heavy** (the duo/sprint spin up engine
 **Historical snapshot, not current authority:** this queue was written around `ea815fc`
 (2026-05-27 cont.3). During the 2026-05-31 takeover, the gate-truth stabilization merged as PR #465,
 the UX-first doc sync merged as PR #468, and first-minute click/title chrome proof merged as PR #470.
-The local app/private-art checkout is now synced at `36d8ac3 == origin/main`; the only current gate
+Local routing sync merged as PR #471, and native provider-selection sync merged as PR #472. The local
+app/private-art checkout is now synced at `5dd1391 == origin/main`; the only current gate
 truth lives in `WorldOS-OPERATING-GOAL.md` + `WorldOS-GUI-RUNBOOK.md` + `qa/SCORECARD.md`. Do not use
 this section to decide release state. The next sprint is UX-first (#467):
 prove first-turn built-app play via #466, then prioritize clickability/chrome, launcher clarity,
@@ -377,14 +379,20 @@ lands on app relaunch with NO Swift rebuild** (the swift build is a ~0.1s no-op)
 
 **How in-app PLAY works (2026-05-27 cont.26 — the read-only→functional fix):**
 - The OpenWorlds launcher Play buttons call the native bridge
-  `OpenWorldsNative.request("startProviderSession",{provider,world,runId,companions})`
-  (`screen-launcher.jsx`). Swift `RootView.startProviderFromBridge` →
-  `AppProcessService.startProviderSession` shells **`scripts/play.sh`** on a fresh port and
-  returns `{url}`; the JS then `window.location.assign(reply.url)` — drive the reload from
+  `OpenWorldsNative.request("startProviderSession",{provider?,world,runId,companions})`
+  (`screen-launcher.jsx`). `provider` is optional: when the web surface has not loaded app status yet,
+  Swift `RootView.startProviderFromBridge` falls back to the macOS app's `selectedProviderRaw` setting.
+  Swift then asks `AppProcessService.startProviderSession` to launch the selected provider on a fresh
+  port and returns `{url}`; the JS then `window.location.assign(reply.url)` — drive the reload from
   **JS**, not the Swift `webURL` @State (which didn't repoint reliably across the async hop).
-- `play.sh` IS the play loop: it binds a viewer with `CLAWDND_PLAYER_MOVES` +
+- The Claude provider still shells **`scripts/play.sh`** / `scripts/play_party.sh`. `play.sh` IS the play loop:
+  it binds a viewer with `CLAWDND_PLAYER_MOVES` +
   `CLAWDND_VIEWER_CHAT` set (→ `_live_play()` true) and runs a `claude -p` DM watching the
   move sink. `POST /move` → sink; `/chat?since=` → DM narration the Session tails.
+- The checked-in Codex provider wrapper is **not** a DM substitute yet: `scripts/play_codex_actor.sh`
+  runs Codex as a constrained player actor through `player_server.py`. It can validate the provider
+  environment and move-facade contract, but it does not mint the world or write DM narration. OpenClaw
+  requires an explicit configured command before it can be treated as a startable provider.
 - **`can_act = _live_play() AND is_live_view`**, and `is_live_view` requires
   `cid == self.campaign_id`. The viewer launches with an EMPTY campaign id; `_resolve_campaign`
   lazily sets `self.campaign_id` to the **current** campaign (`_pick_campaign`). So the


### PR DESCRIPTION
## Summary
- update takeover truth blocks from the post-#470 baseline to the current post-#472 main baseline (`5dd1391`)
- document that OpenWorlds now honors the native selected provider, but that this is not yet Claude-free release proof
- clarify the Codex wrapper is currently a player actor/move-facade, while support VM details remain operator-only

## Tests
- git diff --check
- rg -n "36d8ac3|178\.|104\.123|Permission denied|publickey|TCP/22|SSH|auth posture|endpoint" WorldOS-OPERATING-GOAL.md WorldOS-GUI-RUNBOOK.md WorldOS-RUNBOOK.md || true

## Notes
- Docs-only. No code path or release gate behavior changed.
- This keeps #466 gated on a DM-capable first-turn provider path rather than treating the existing Codex actor wrapper as a Dungeon Master replacement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational guides for system setup, provider configuration, and app routing procedures.
  * Clarified how native provider selection works and configuration requirements needed for full functionality.
  * Refreshed system baseline references and next operational action steps.
  * Enhanced documentation of app play routing, session management, and provider integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->