### PR TITLE
[codex] Reduce Codex DM setup tool noise

### DIFF
--- a/scripts/play_codex_dm.sh
+++ b/scripts/play_codex_dm.sh
@@ -359,6 +359,8 @@ codex_dm_turn() {
 
 LOG_EVENT_TOOL_RULE="Tool argument rule: for log_event narration, omit the speaker argument entirely. For dialogue, pass a real non-empty character id or name. Never pass JSON null for speaker or any optional string field."
 STATE_DISCOVERY_RULE="State discovery rule: after reading skills/dungeon-master/SKILL.md, use clawdnd-engine/clawdnd-rules MCP tools for live game state. Do not use shell commands, rg, find, or filesystem reads to discover campaign state."
+STARTUP_MUTATION_RULE="Startup mutation rule: before the first player-facing narration, do not call create_character, recruit_companion, or load any non-player canon character. The only allowed character/roster mutation during startup is seating the one player when the native app has not already seated one. Introduce scene NPCs in narration first; create or load a tracked NPC only after the player engages them."
+SOCIAL_CHECK_TARGET_RULE="Social check target rule: before calling social_check, decide whether the target is tracked. For a named, factioned, recurring, or specifically addressed NPC, use scene_context state plus find_npcs or create_character to get a real npc_id, then pass that id. Use npc_id=\"\" with target_name only for a clearly throwaway scene-local extra."
 if [ -n "${CLAWDND_PLAY_COMPANIONS//[[:space:]]/}" ]; then
   COMPANION_TOOL_RULE="Companion rule: only add companions named by CLAWDND_PLAY_COMPANIONS (${CLAWDND_PLAY_COMPANIONS}). Do not add any other companion to the party."
 else
@@ -400,6 +402,8 @@ Before acting, read skills/dungeon-master/SKILL.md and follow its live-world con
 
 $LOG_EVENT_TOOL_RULE
 $STATE_DISCOVERY_RULE
+$STARTUP_MUTATION_RULE
+$SOCIAL_CHECK_TARGET_RULE
 $COMPANION_TOOL_RULE
 
 Native-selected canon hero already seated:
@@ -422,6 +426,8 @@ Before acting, read skills/dungeon-master/SKILL.md and follow its live-world con
 
 $LOG_EVENT_TOOL_RULE
 $STATE_DISCOVERY_RULE
+$STARTUP_MUTATION_RULE
+$SOCIAL_CHECK_TARGET_RULE
 $COMPANION_TOOL_RULE
 
 Start a live solo session:
@@ -461,6 +467,7 @@ while true; do
 $LOG_EVENT_TOOL_RULE
 $STATE_DISCOVERY_RULE
 $CAMPAIGN_TOOL_HINT
+$SOCIAL_CHECK_TARGET_RULE
 $COMPANION_TOOL_RULE
 
 Player move:

--- a/servers/engine/tests/test_codex_provider_wrapper.py
+++ b/servers/engine/tests/test_codex_provider_wrapper.py
@@ -206,6 +206,26 @@ def test_codex_dm_wrapper_forbids_unconfigured_solo_companions():
     assert "only add companions named by CLAWDND_PLAY_COMPANIONS" in source
 
 
+def test_codex_dm_wrapper_constrains_startup_roster_mutation():
+    source = DM_SCRIPT.read_text(encoding="utf-8")
+
+    assert "STARTUP_MUTATION_RULE" in source
+    assert "before the first player-facing narration" in source
+    assert "do not call create_character" in source
+    assert "only allowed character/roster mutation during startup is seating the one player" in source
+    assert source.count("$STARTUP_MUTATION_RULE") == 2
+
+
+def test_codex_dm_wrapper_requires_tracked_social_targets():
+    source = DM_SCRIPT.read_text(encoding="utf-8")
+
+    assert "SOCIAL_CHECK_TARGET_RULE" in source
+    assert "before calling social_check" in source
+    assert "use scene_context state plus find_npcs or create_character" in source
+    assert 'Use npc_id=\\"\\" with target_name only for a clearly throwaway scene-local extra' in source
+    assert source.count("$SOCIAL_CHECK_TARGET_RULE") == 3
+
+
 def test_codex_dm_wrapper_run_allows_unset_model_with_fake_codex(tmp_path):
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()


### PR DESCRIPTION
## Summary
- add startup guidance that prevents the Codex DM from mutating the roster before first player-facing narration
- require tracked NPC IDs for named/factioned/recurring social-check targets, while allowing target_name-only checks for clearly throwaway extras
- add focused wrapper contract tests for both prompt rules

## Why
This is the follow-up for #479. The final built-app Codex-DM proof on #475 was playable, but provider traces still showed safety-cancelled setup/social tool calls that inflated first-turn latency and would distort #466 RRI playability evidence.

## Validation
- `pwd && bash -n scripts/play_codex_dm.sh`
- `pwd && uv run --directory servers/engine python -m pytest tests/test_codex_provider_wrapper.py -q -p no:xdist` (`19 passed`)

## Notes
Stacked on #475 because the Codex DM wrapper is introduced there. Retarget to `main` after #475 merges.

Refs #479, #475, #466, #480.