### PR TITLE
[codex] Add stable OpenWorlds agent UI hooks

### DIFF
--- a/viewer/openworlds/camp-sidebar.jsx
+++ b/viewer/openworlds/camp-sidebar.jsx
@@ -627,7 +627,7 @@ function TalkPanel({ hero, onClose }) {
             With {hero.name.split(" ")[0]}
           </div>
         </div>
-        <button onClick={onClose} className="icon-btn" style={{ width: 22, height: 22, color: "var(--b-200)" }}>×</button>
+        <button type="button" onClick={onClose} className="icon-btn" aria-label="Close camp chat" data-worldos-testid="modal-close" style={{ width: 22, height: 22, color: "var(--b-200)" }}>×</button>
       </div>
 
       <div style={{

--- a/viewer/openworlds/chrome.jsx
+++ b/viewer/openworlds/chrome.jsx
@@ -266,7 +266,7 @@ function Img({ scope, label, w, h, framed, style, className, fit = "cover" }) {
   );
 }
 
-function IconPlate({ size = 56, label, framed = true, glyph, tone, children, onClick, active, style }) {
+function IconPlate({ size = 56, label, framed = true, glyph, tone, children, onClick, active, style, testId, ...buttonProps }) {
   return (
     <button
       type="button"
@@ -279,6 +279,9 @@ function IconPlate({ size = 56, label, framed = true, glyph, tone, children, onC
         ...(style || {}),
       }}
       title={label}
+      aria-label={buttonProps["aria-label"] || label || undefined}
+      data-worldos-testid={testId || undefined}
+      {...buttonProps}
     >
       {children || (glyph && window.OpenWorldsIcon?.has?.(glyph) ? (
         <window.OpenWorldsIcon id={glyph} size={Math.max(18, size * 0.46)} label={label} />
@@ -289,12 +292,22 @@ function IconPlate({ size = 56, label, framed = true, glyph, tone, children, onC
   );
 }
 
-function BrassButton({ children, onClick, tone, size, disabled, style, type = "button", title }) {
+function BrassButton({ children, onClick, tone, size, disabled, style, type = "button", title, ariaLabel, testId, ...buttonProps }) {
   const cls = ["btn", tone, size, disabled ? "disabled" : ""].filter(Boolean).join(" ");
   // `title` is optional — forwarded so callers can attach a hover/affordance tooltip
   // (e.g. the #337 action-bar hints) without giving every BrassButton one.
   return (
-    <button className={cls} onClick={onClick} disabled={disabled} type={type} style={style} title={title || undefined}>
+    <button
+      className={cls}
+      onClick={onClick}
+      disabled={disabled}
+      type={type}
+      style={style}
+      title={title || undefined}
+      aria-label={ariaLabel || undefined}
+      data-worldos-testid={testId || undefined}
+      {...buttonProps}
+    >
       {children}
     </button>
   );
@@ -324,7 +337,7 @@ function Panel({ children, framed, dark, className, style, ornaments = true }) {
 function NavRail({ current, onNavigate }) {
   const currentGroup = getGroupForScreen(current);
   return (
-    <nav className="nav-rail" aria-label="Codex">
+    <nav className="nav-rail" aria-label="Codex" data-worldos-testid="primary-navigation">
       {NAV_GROUPS.map((g) => (
         <button
           type="button"
@@ -332,6 +345,9 @@ function NavRail({ current, onNavigate }) {
           className={`nav-item ${currentGroup?.id === g.id ? "active" : ""}`}
           onClick={() => onNavigate(getDefaultScreen(g.id))}
           aria-current={currentGroup?.id === g.id ? "page" : undefined}
+          aria-label={g.label}
+          data-worldos-testid="primary-nav-item"
+          data-worldos-nav-id={g.id}
         >
           <span className="glyph"><Glyph kind={g.glyph} /></span>
           <span className="tip">{g.label}</span>
@@ -344,6 +360,9 @@ function NavRail({ current, onNavigate }) {
         className={`nav-item ${currentGroup?.id === NAV_BOTTOM.id ? "active" : ""}`}
         onClick={() => onNavigate(getDefaultScreen(NAV_BOTTOM.id))}
         aria-current={currentGroup?.id === NAV_BOTTOM.id ? "page" : undefined}
+        aria-label={NAV_BOTTOM.label}
+        data-worldos-testid="primary-nav-item"
+        data-worldos-nav-id={NAV_BOTTOM.id}
       >
         <span className="glyph"><Glyph kind={NAV_BOTTOM.glyph} size={20} /></span>
         <span className="tip">{NAV_BOTTOM.label}</span>
@@ -356,7 +375,7 @@ function TabBar({ current, onNavigate }) {
   const group = getGroupForScreen(current);
   if (!group || group.tabs.length < 2) return null;
   return (
-    <div style={{
+    <div role="tablist" aria-label={`${group.label} screens`} data-worldos-testid="screen-tabs" style={{
       display: "flex",
       alignItems: "center",
       gap: 0,
@@ -385,6 +404,10 @@ function TabBar({ current, onNavigate }) {
         <button
           type="button"
           key={tab.id}
+          role="tab"
+          aria-selected={current === tab.id}
+          data-worldos-testid="screen-tab"
+          data-worldos-tab-id={tab.id}
           className={`tab-button ${current === tab.id ? "active" : ""}`}
           onClick={() => onNavigate(tab.id)}
           style={{

--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -335,7 +335,7 @@ function RestPrepareModal({ hero, party, onClose, toast, setState }) {
       background: "rgba(15, 8, 2, 0.7)",
       display: "grid", placeItems: "center",
       backdropFilter: "blur(2px)",
-    }} onClick={onClose}>
+    }} onClick={onClose} role="dialog" aria-modal="true" aria-label="Rest and prepare" data-worldos-testid="rest-prepare-modal">
       <div onClick={(e) => e.stopPropagation()} style={{ width: 720, maxWidth: "92vw", maxHeight: "88vh", overflow: "auto" }}>
         <Panel framed>
           {step === "rest" ? (
@@ -388,7 +388,7 @@ function RestPrepareModal({ hero, party, onClose, toast, setState }) {
               )}
 
               <div style={{ display: "flex", gap: 10, marginTop: 24, justifyContent: "flex-end" }}>
-                <BrassButton tone="ghost" onClick={onClose}>Not yet</BrassButton>
+                <BrassButton tone="ghost" onClick={onClose} testId="modal-close" ariaLabel="Close rest and prepare modal">Not yet</BrassButton>
                 <BrassButton onClick={completeRest} disabled title="Display-only — rest is not saved to the engine">
                   Make camp <span style={{ fontSize: 9, opacity: 0.7 }}>(preview)</span>
                 </BrassButton>
@@ -462,7 +462,7 @@ function RestPrepareModal({ hero, party, onClose, toast, setState }) {
                   {Object.values(prepared).reduce((s, l) => s + l.length, 0)} bound to the day.
                 </span>
                 <div style={{ display: "flex", gap: 10 }}>
-                  <BrassButton tone="ghost" onClick={onClose}>Close book</BrassButton>
+                  <BrassButton tone="ghost" onClick={onClose} testId="modal-close" ariaLabel="Close rest and prepare modal">Close book</BrassButton>
                   <BrassButton onClick={completePrep} disabled title="Display-only — spell preparation is not saved to the engine">
                     Seal the choices <span style={{ fontSize: 9, opacity: 0.7 }}>(preview)</span>
                   </BrassButton>
@@ -1123,7 +1123,7 @@ function SpellbookBrowser({ hero, groups, onClose }) {
       background: "rgba(15, 8, 2, 0.7)",
       display: "grid", placeItems: "center",
       backdropFilter: "blur(2px)",
-    }} onClick={onClose}>
+    }} onClick={onClose} role="dialog" aria-modal="true" aria-label="Spellbook" data-worldos-testid="spellbook-modal">
       <div onClick={(e) => e.stopPropagation()} style={{ width: 640, maxWidth: "92vw", maxHeight: "88vh", overflow: "auto" }}>
         <Panel framed>
           <div className="eyebrow" style={{ color: "var(--crimson)" }}>The Spellbook</div>
@@ -1172,7 +1172,7 @@ function SpellbookBrowser({ hero, groups, onClose }) {
 
           <Divider />
           <div style={{ display: "flex", justifyContent: "flex-end" }}>
-            <BrassButton tone="ghost" onClick={onClose}>Close book</BrassButton>
+            <BrassButton tone="ghost" onClick={onClose} testId="modal-close" ariaLabel="Close spellbook modal">Close book</BrassButton>
           </div>
         </Panel>
       </div>

--- a/viewer/openworlds/screen-launcher.jsx
+++ b/viewer/openworlds/screen-launcher.jsx
@@ -110,7 +110,7 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
   };
 
   return (
-    <div className="screen" style={{ padding: "32px 40px 48px", minHeight: "100%" }}>
+    <div className="screen" id="worldos-screen-launcher" data-worldos-testid="worldos-launcher" style={{ padding: "32px 40px 48px", minHeight: "100%" }}>
       {/* #326: a can't-miss in-browser play-entry. When a live/resumable session exists, this is
           the FIRST thing the player sees — clicking it drops straight into the live table (no app,
           no bridge needed; the session + DM already exist). This is the affordance the #324 newbie
@@ -174,6 +174,8 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
                 <CampaignRow key={c.id} c={c} selected={selected === c.id} onSelect={() => setSelected(c.id)} />
               ))}
               <button
+                type="button"
+                data-worldos-testid="chronicle-create-hero"
                 onClick={() => onNavigate("create")}
                 style={{
                   display: "flex", alignItems: "center", gap: 14,
@@ -199,6 +201,8 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
                   never an invented, portrait-less PC, never a BG3 origin. (The freeform
                   NewCampaignModal is retained below but no longer the primary new-game entry.) */}
               <button
+                type="button"
+                data-worldos-testid="chronicle-start"
                 onClick={() => onNavigate("roster")}
                 style={{
                   display: "flex", alignItems: "center", gap: 14,
@@ -354,16 +358,16 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
                         borderTop: "1px solid rgba(140,100,60,0.3)",
                         display: "flex", gap: 8,
                       }}>
-                        <BrassButton onClick={onCta} size="lg" style={{ flex: 1 }} disabled={summoning}>
+                        <BrassButton onClick={onCta} size="lg" style={{ flex: 1 }} disabled={summoning} testId="chronicle-resume" ariaLabel={label}>
                           {label}
                         </BrassButton>
-                        <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("character")}>Roster</BrassButton>
-                        <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("journal")}>Journal</BrassButton>
+                        <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("character")} testId="chronicle-roster">Roster</BrassButton>
+                        <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("journal")} testId="chronicle-journal">Journal</BrassButton>
                       </div>
                     );
                   })()}
                   {summonError && (
-                    <div className="hand" style={{ color: "var(--crimson)", fontSize: 13, marginTop: 10 }}>
+                    <div role="alert" data-worldos-testid="error-banner" className="hand" style={{ color: "var(--crimson)", fontSize: 13, marginTop: 10 }}>
                       {summonError}
                     </div>
                   )}
@@ -393,6 +397,7 @@ function ContinueBanner({ campaign, onEnter }) {
   const region = campaignRegion(campaign);
   return (
     <div
+      data-worldos-testid="continue-banner"
       style={{
         display: "flex", alignItems: "center", gap: 20,
         padding: "18px 24px", marginBottom: 28,
@@ -413,7 +418,7 @@ function ContinueBanner({ campaign, onEnter }) {
           {campaign?.subtitle || region}
         </div>
       </div>
-      <BrassButton onClick={onEnter} size="lg">
+      <BrassButton onClick={onEnter} size="lg" testId="chronicle-resume" ariaLabel={isLive ? "Continue chronicle and play" : "Resume chronicle and play"}>
         {isLive ? "Continue → play" : "Resume → play"}
       </BrassButton>
     </div>
@@ -469,6 +474,10 @@ function CampaignRow({ c, selected, onSelect }) {
   const status = c?.live ? "Live" : (c?.sourceLabel || "Saved");
   return (
     <button
+      type="button"
+      data-worldos-testid="campaign-row"
+      data-worldos-campaign-id={c.id || undefined}
+      aria-pressed={selected}
       onClick={onSelect}
       style={{
         textAlign: "left",
@@ -540,7 +549,7 @@ function NewCampaignModal({ onClose, onCreate }) {
       background: "rgba(15, 8, 2, 0.6)",
       display: "grid", placeItems: "center",
       backdropFilter: "blur(2px)",
-    }} onClick={onClose}>
+    }} onClick={onClose} role="dialog" aria-modal="true" aria-label="Begin a new chronicle" data-worldos-testid="new-campaign-modal">
       <div onClick={(e) => e.stopPropagation()} style={{ width: 640, maxWidth: "90vw" }}>
         <Panel framed>
           <div className="eyebrow" style={{ color: "var(--crimson)" }}>The First Page</div>
@@ -570,8 +579,8 @@ function NewCampaignModal({ onClose, onCreate }) {
           </FormField>
 
           <div style={{ display: "flex", gap: 10, marginTop: 24, justifyContent: "flex-end" }}>
-            <BrassButton tone="ghost" onClick={onClose}>Cancel</BrassButton>
-            <BrassButton onClick={create}>Light the lantern</BrassButton>
+            <BrassButton tone="ghost" onClick={onClose} testId="modal-close" ariaLabel="Close new campaign modal">Cancel</BrassButton>
+            <BrassButton onClick={create} testId="chronicle-start">Light the lantern</BrassButton>
           </div>
         </Panel>
       </div>

--- a/viewer/openworlds/screen-settings.jsx
+++ b/viewer/openworlds/screen-settings.jsx
@@ -135,16 +135,16 @@ function ScreenSettings({ onNavigate, state, setState, nativeState, refreshNativ
   ];
 
   return (
-    <div className="screen stack-on-narrow" style={{ height: "100%", display: "grid", gridTemplateColumns: "220px 1fr", gap: 14, padding: 14 }}>
+    <div className="screen stack-on-narrow" id="worldos-screen-settings" data-worldos-testid="settings-root" style={{ height: "100%", display: "grid", gridTemplateColumns: "220px 1fr", gap: 14, padding: 14 }}>
 
       {/* LEFT — section list */}
       <Panel framed style={{ padding: 22, overflow: "auto" }}>
         <div className="eyebrow" style={{ color: "var(--crimson)" }}>Codex of</div>
         <h2 className="h1" style={{ fontSize: 22 }}>Setting</h2>
         <Divider />
-        <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+        <div role="tablist" aria-label="Settings sections" style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           {SECTIONS.map((s) => (
-            <button key={s.id} onClick={() => setSection(s.id)} style={{
+            <button key={s.id} type="button" onClick={() => setSection(s.id)} role="tab" aria-selected={section === s.id} data-worldos-testid="settings-tab" data-worldos-tab-id={s.id} style={{
               textAlign: "left",
               padding: "10px 12px",
               fontFamily: "var(--f-display)",
@@ -409,7 +409,7 @@ function NativeAppSection({ nativeState, refreshNative }) {
 
   return (
     <SettingsSection title="WorldOS Native App" eyebrow="Supervisor bridge" ordinal="I.">
-      <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 16 }}>
+      <div role="status" aria-live="polite" data-worldos-testid="provider-status" style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 16 }}>
         <Pill tone={bridgeReady ? "emerald" : "crimson"}>{bridgeReady ? "Wired" : "Unavailable"}</Pill>
         <Pill tone={viewer.status === "running" ? "emerald" : "royal"}>Viewer {viewer.status || "stopped"}</Pill>
         {app.runningProvider && <Pill tone="royal">Provider {app.runningProvider}</Pill>}
@@ -427,13 +427,13 @@ function NativeAppSection({ nativeState, refreshNative }) {
 
         <Panel framed style={{ padding: 18 }}>
           <SectionTitle>Native Actions</SectionTitle>
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
-            <BrassButton size="sm" title="Start the local viewer process that serves this UI" onClick={() => nativeAction("startViewer")}>Start Viewer</BrassButton>
-            <BrassButton size="sm" tone="ghost" title="Stop the local viewer process serving this UI" onClick={() => nativeAction("stopViewer")}>Stop Viewer</BrassButton>
-            <BrassButton size="sm" title="Launch a provider session for the default world (e.g. Claude)" onClick={startProvider}>Start Provider</BrassButton>
-            <BrassButton size="sm" tone="ghost" title="Stop the running provider session" onClick={() => nativeAction("stopProvider")}>Stop Provider</BrassButton>
-            <BrassButton size="sm" tone="ghost" title="Copy app status and recent diagnostics to the clipboard" onClick={() => nativeAction("copyDiagnostics")}>Copy Diagnostics</BrassButton>
-            <BrassButton size="sm" tone="ghost" title="Open the fallback debug dashboard in your browser" onClick={() => nativeAction("openFallbackDashboard")}>Debug Dashboard</BrassButton>
+          <div data-worldos-testid="provider-controls" style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 8 }}>
+            <BrassButton size="sm" title="Start the local viewer process that serves this UI" onClick={() => nativeAction("startViewer")} testId="native-start-viewer">Start Viewer</BrassButton>
+            <BrassButton size="sm" tone="ghost" title="Stop the local viewer process serving this UI" onClick={() => nativeAction("stopViewer")} testId="native-stop-viewer">Stop Viewer</BrassButton>
+            <BrassButton size="sm" title="Launch a provider session for the default world (e.g. Claude)" onClick={startProvider} testId="provider-start">Start Provider</BrassButton>
+            <BrassButton size="sm" tone="ghost" title="Stop the running provider session" onClick={() => nativeAction("stopProvider")} testId="provider-stop">Stop Provider</BrassButton>
+            <BrassButton size="sm" tone="ghost" title="Copy app status and recent diagnostics to the clipboard" onClick={() => nativeAction("copyDiagnostics")} testId="native-copy-diagnostics">Copy Diagnostics</BrassButton>
+            <BrassButton size="sm" tone="ghost" title="Open the fallback debug dashboard in your browser" onClick={() => nativeAction("openFallbackDashboard")} testId="native-debug-dashboard">Debug Dashboard</BrassButton>
           </div>
           <p className="body-sm muted" style={{ marginTop: 12 }}>
             Native actions supervise local processes only. Game intent still travels through the existing engine/player move lane.
@@ -445,10 +445,12 @@ function NativeAppSection({ nativeState, refreshNative }) {
       <SectionTitle>Providers</SectionTitle>
       <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 10 }}>
         {providers.map((p) => (
-          <Panel key={p.kind} framed style={{ padding: 16 }}>
+          <Panel key={p.kind} framed style={{ padding: 16 }} className="provider-card">
+            <div data-worldos-testid="provider-card" data-worldos-provider-id={p.kind || undefined}>
             <div className="eyebrow" style={{ color: "var(--crimson)" }}>{p.displayName || p.kind}</div>
             <h3 style={{ margin: "4px 0 8px", fontFamily: "var(--f-display)", letterSpacing: "0.08em" }}>{p.availability}</h3>
             <div className="body-sm muted">{p.detail}</div>
+            </div>
           </Panel>
         ))}
         {!providers.length && (

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -559,7 +559,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
   };
 
   return (
-    <div className="screen" style={{ height: "100%", display: "grid", gridTemplateColumns: "260px 1fr 280px", gap: 14, padding: 14 }}>
+    <div className="screen" id="worldos-screen-table" data-worldos-testid="openworlds-root" style={{ height: "100%", display: "grid", gridTemplateColumns: "260px 1fr 280px", gap: 14, padding: 14 }}>
 
       {/* LEFT — Party roster */}
       <div style={{ display: "flex", flexDirection: "column", gap: 10, minHeight: 0 }}>
@@ -590,6 +590,23 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
 
       {/* CENTER — Scene + log */}
       <div style={{ display: "flex", flexDirection: "column", gap: 14, minHeight: 0 }}>
+        {surfaceStatus !== "ready" && (
+          <div
+            role={surfaceStatus === "loading" ? "status" : "alert"}
+            aria-live="polite"
+            data-worldos-testid="app-status-banner"
+            data-worldos-status={surfaceStatus}
+            className="body-sm"
+            style={{
+              padding: "8px 12px",
+              color: surfaceStatus === "loading" ? "var(--ink-700)" : "var(--crimson)",
+              background: "rgba(176,141,87,0.08)",
+              boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.3)",
+            }}
+          >
+            {surfaceStatus === "loading" ? "Loading session surface." : `Session surface unavailable: ${surfaceStatus}`}
+          </div>
+        )}
         {/* Scene plate */}
         <div style={{ position: "relative", flex: "0 0 auto" }}>
           <Img
@@ -646,6 +663,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
             tabIndex={0}
             role="log"
             aria-label="Chronicle — most recent narration at the bottom"
+            data-worldos-testid="narration-log"
             onScroll={onLogScroll}
             style={{ flex: "1 1 auto", overflow: "auto", paddingRight: 12 }}
           >
@@ -673,7 +691,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
               combat verbs (Attack/Bonus/Reaction) in an "In Combat" group when in combat. Reuses the
               EncounterButton component + invokeAction + ACTION_HINTS — the click path is unchanged.
               flex 0 0 auto so it stays anchored/visible no matter how long the chronicle grows. */}
-          <div style={{ flex: "0 0 auto", marginTop: 14 }}>
+          <div data-worldos-testid="action-palette" style={{ flex: "0 0 auto", marginTop: 14 }}>
             <SectionTitle>Actions</SectionTitle>
             {!actions.length && (
               <div className="body-sm muted" style={{ marginTop: 4 }}>
@@ -689,6 +707,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
                     label={a.label}
                     detail={a.available ? a.groupLabel : a.disabled_reason}
                     hint={ACTION_HINTS[a.id]}
+                    actionId={a.id}
                     tone={a.available ? "" : "crimson"}
                     disabled={!a.available || pendingActive}
                     onClick={() => invokeAction(a)}
@@ -709,6 +728,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
                       label={a.label}
                       detail={a.available ? a.groupLabel : a.disabled_reason}
                       hint={ACTION_HINTS[a.id]}
+                      actionId={a.id}
                       tone={a.available ? "royal" : "crimson"}
                       disabled={!a.available || pendingActive}
                       onClick={() => invokeAction(a)}
@@ -722,18 +742,18 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
           {/* DECLARE: free-text action box — the other primary input, paired with the palette above.
               Action bar — #402: flex 0 0 auto so it is ALWAYS anchored at the bottom of the panel and
               never pushed out of view by an ever-growing chronicle above it. */}
-          <div style={{ flex: "0 0 auto", marginTop: 14, padding: 12, background: "rgba(80,50,20,0.06)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.35)" }}>
+          <div data-worldos-testid="move-composer" style={{ flex: "0 0 auto", marginTop: 14, padding: 12, background: "rgba(80,50,20,0.06)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.35)" }}>
             <div style={{ display: "flex", gap: 10, alignItems: "center", marginBottom: 8 }}>
               <span className="eyebrow">Active</span>
-              <strong style={{ fontFamily: "var(--f-display)", color: "var(--ink-900)", letterSpacing: "0.1em" }}>
+              <strong data-worldos-testid="active-player" data-worldos-actor-id={hero.id || undefined} style={{ fontFamily: "var(--f-display)", color: "var(--ink-900)", letterSpacing: "0.1em" }}>
                 {hero.name}
               </strong>
               <div style={{ flex: 1 }} />
               {/* #337: dice buttons explain themselves on hover — a newbie didn't know d20/d12/d8/d6 ask the DM for a check. */}
-              <button onClick={() => requestRoll(20)} title={DICE_HINT(20)} className="btn ghost sm" disabled={!actionById("check")?.available || pendingActive}>{window.OpenWorldsIcon?.has?.("dice.d20") && <window.OpenWorldsIcon id="dice.d20" size={13} />} d20</button>
-              <button onClick={() => requestRoll(12)} title={DICE_HINT(12)} className="btn ghost sm" disabled={!actionById("check")?.available || pendingActive}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d12</button>
-              <button onClick={() => requestRoll(8)} title={DICE_HINT(8)} className="btn ghost sm" disabled={!actionById("check")?.available || pendingActive}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d8</button>
-              <button onClick={() => requestRoll(6)} title={DICE_HINT(6)} className="btn ghost sm" disabled={!actionById("check")?.available || pendingActive}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d6</button>
+              <button type="button" data-worldos-testid="dice-button" data-worldos-die="20" aria-label="Roll d20" onClick={() => requestRoll(20)} title={DICE_HINT(20)} className="btn ghost sm" disabled={!actionById("check")?.available || pendingActive}>{window.OpenWorldsIcon?.has?.("dice.d20") && <window.OpenWorldsIcon id="dice.d20" size={13} />} d20</button>
+              <button type="button" data-worldos-testid="dice-button" data-worldos-die="12" aria-label="Roll d12" onClick={() => requestRoll(12)} title={DICE_HINT(12)} className="btn ghost sm" disabled={!actionById("check")?.available || pendingActive}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d12</button>
+              <button type="button" data-worldos-testid="dice-button" data-worldos-die="8" aria-label="Roll d8" onClick={() => requestRoll(8)} title={DICE_HINT(8)} className="btn ghost sm" disabled={!actionById("check")?.available || pendingActive}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d8</button>
+              <button type="button" data-worldos-testid="dice-button" data-worldos-die="6" aria-label="Roll d6" onClick={() => requestRoll(6)} title={DICE_HINT(6)} className="btn ghost sm" disabled={!actionById("check")?.available || pendingActive}>{window.OpenWorldsIcon?.has?.("dice.roll") && <window.OpenWorldsIcon id="dice.roll" size={13} />} d6</button>
             </div>
             {/* #337: one-line hint under the action bar so a first-timer knows free-text + Declare is the core loop, distinct from the quick-action buttons. */}
             <div className="body-xs muted" style={{ marginBottom: 6 }}>
@@ -742,6 +762,8 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
             <div style={{ display: "flex", gap: 10 }}>
               <input
                 ref={inputRef}
+                aria-label="Describe your move"
+                data-worldos-testid="move-input"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && onDeclareClick()}
@@ -750,7 +772,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
                 placeholder={pendingFirstBeat ? "The Dungeon Master is composing your opening scene…" : pendingActive ? "The Dungeon Master is narrating…" : pendingStuck ? "The DM seemed stuck — try again." : (canAct ? "Describe what your hero does..." : `Read-only: ${readOnlyReason}`)}
                 style={{ ...inkInput, fontFamily: "var(--f-body)", fontSize: 16, opacity: pendingActive ? 0.6 : 1 }}
               />
-              <BrassButton onClick={onDeclareClick} title={pendingStuck ? "Re-send your last action to the Dungeon Master, or type a new one first." : DECLARE_HINT} disabled={!actionById("do")?.available || pendingActive}>{pendingFirstBeat ? "Composing…" : pendingActive ? "Narrating…" : pendingStuck ? "Try again" : "Declare"}</BrassButton>
+              <BrassButton onClick={onDeclareClick} title={pendingStuck ? "Re-send your last action to the Dungeon Master, or type a new one first." : DECLARE_HINT} disabled={!actionById("do")?.available || pendingActive} testId="move-submit" ariaLabel={pendingStuck ? "Try action again" : "Declare move"}>{pendingFirstBeat ? "Composing…" : pendingActive ? "Narrating…" : pendingStuck ? "Try again" : "Declare"}</BrassButton>
             </div>
           </div>
         </Panel>
@@ -1148,14 +1170,21 @@ Object.assign(window, { ScreenTable, PartyRow, ConditionRow, LogEntry, DmNarrati
 // nothing in the running app reads it off window; DmNarratingBeat closes over the const directly).
 window.DM_COLD_OPEN_FLAVOR = DM_COLD_OPEN_FLAVOR;
 
-function EncounterButton({ icon, label, detail, tone, onClick, disabled, hint }) {
+function EncounterButton({ icon, label, detail, tone, onClick, disabled, hint, actionId }) {
   const iconNode = window.OpenWorldsIcon?.has?.(icon)
     ? <window.OpenWorldsIcon id={icon} size={17} label={label} />
     : icon;
   return (
     // #337: `title` surfaces the one-line affordance on hover (and as a screen-reader
     // description) without changing the visible label that remains the accessible name.
-    <button onClick={onClick} title={hint || undefined} style={{
+    <button
+      type="button"
+      onClick={onClick}
+      title={hint || undefined}
+      aria-label={hint || label}
+      data-worldos-testid="action-button"
+      data-worldos-action-id={actionId || undefined}
+      style={{
       display: "grid", gridTemplateColumns: "24px 1fr", gap: 8, alignItems: "center",
       textAlign: "left",
       padding: "8px 10px",

--- a/viewer/openworlds/toast.jsx
+++ b/viewer/openworlds/toast.jsx
@@ -21,7 +21,7 @@ function ToastProvider({ children }) {
         display: "flex", flexDirection: "column", gap: 10,
         pointerEvents: "none",
         maxWidth: 360,
-      }}>
+      }} aria-live="polite" aria-label="Notifications" data-worldos-testid="toast-region">
         {toasts.map((t) => <Toast key={t.id} toast={t} />)}
       </div>
     </ToastCtx.Provider>
@@ -38,7 +38,10 @@ function Toast({ toast }) {
     { ribbon: "var(--b-400)", icon: "·" };
 
   return (
-    <div style={{
+    <div
+      role={toast.kind === "danger" ? "alert" : "status"}
+      data-worldos-testid={toast.kind === "danger" ? "error-banner" : "toast"}
+      style={{
       display: "grid",
       gridTemplateColumns: "auto 1fr",
       gap: 0,

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -318,6 +318,65 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn('className={`nav-item ${currentGroup?.id === g.id ? "active" : ""}`}', chrome)
         self.assertIn("onClick={() => onNavigate(getDefaultScreen(g.id))}", chrome)
 
+    def test_openworlds_agent_driving_hooks_are_stable(self):
+        chrome = (server._OPENWORLDS_DIR / "chrome.jsx").read_text(encoding="utf-8")
+        launcher = (server._OPENWORLDS_DIR / "screen-launcher.jsx").read_text(encoding="utf-8")
+        table = (server._OPENWORLDS_DIR / "screen-table.jsx").read_text(encoding="utf-8")
+        settings = (server._OPENWORLDS_DIR / "screen-settings.jsx").read_text(encoding="utf-8")
+        toast = (server._OPENWORLDS_DIR / "toast.jsx").read_text(encoding="utf-8")
+        character = (server._OPENWORLDS_DIR / "screen-character.jsx").read_text(encoding="utf-8")
+        camp = (server._OPENWORLDS_DIR / "camp-sidebar.jsx").read_text(encoding="utf-8")
+
+        for hook in (
+            'data-worldos-testid="primary-navigation"',
+            'data-worldos-testid="screen-tabs"',
+            'data-worldos-testid="screen-tab"',
+        ):
+            self.assertIn(hook, chrome)
+        self.assertIn('role="tablist"', chrome)
+        self.assertIn('role="tab"', chrome)
+        self.assertIn("aria-selected={current === tab.id}", chrome)
+
+        for hook in (
+            'data-worldos-testid="worldos-launcher"',
+            'data-worldos-testid="chronicle-start"',
+            'data-worldos-testid="campaign-row"',
+            'data-worldos-testid="error-banner"',
+        ):
+            self.assertIn(hook, launcher)
+        self.assertIn('testId="chronicle-resume"', launcher)
+        self.assertIn('role="alert"', launcher)
+
+        for hook in (
+            'data-worldos-testid="openworlds-root"',
+            'data-worldos-testid="app-status-banner"',
+            'data-worldos-testid="narration-log"',
+            'data-worldos-testid="active-player"',
+            'data-worldos-testid="action-palette"',
+            'data-worldos-testid="action-button"',
+            'data-worldos-action-id={actionId || undefined}',
+            'data-worldos-testid="move-composer"',
+            'data-worldos-testid="move-input"',
+        ):
+            self.assertIn(hook, table)
+        self.assertIn('testId="move-submit"', table)
+        self.assertIn('aria-label="Describe your move"', table)
+
+        for hook in (
+            'data-worldos-testid="provider-status"',
+            'data-worldos-testid="provider-controls"',
+            'data-worldos-testid="provider-card"',
+        ):
+            self.assertIn(hook, settings)
+        self.assertIn('testId="provider-start"', settings)
+        self.assertIn('role="status"', settings)
+
+        self.assertIn('data-worldos-testid="toast-region"', toast)
+        self.assertIn('role={toast.kind === "danger" ? "alert" : "status"}', toast)
+        self.assertIn('data-worldos-testid={toast.kind === "danger" ? "error-banner" : "toast"}', toast)
+        self.assertIn('testId="modal-close"', launcher + character)
+        self.assertIn('data-worldos-testid="modal-close"', camp)
+
     def test_openworlds_title_bar_keeps_title_and_day_pill_apart(self):
         # #306: long campaign titles must never wrap under the nav rail or collide with the
         # day/capability band. The structural fix is intentionally static so the built-app


### PR DESCRIPTION
## Summary
- add stable `data-worldos-testid` hooks and ARIA roles/labels for primary navigation, tabs, launcher start/resume, campaign rows, table actions, active player, move composer, provider controls, toasts, and modal close buttons
- plumb testId/ariaLabel through shared button primitives
- add a static contract test for the agent-driving surface

Refs #484, #480.

## Test Plan
- `python3 -m pytest viewer/tests/test_openworlds_static.py -q`
- `git diff --check`

Draft until #488 lands or the stack is ready for review.