### PR TITLE
[codex] Add dev-gated scripted smoke provider

### DIFF
--- a/macos/WorldOSApp/Sources/WorldOSApp/Models/ProviderModels.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Models/ProviderModels.swift
@@ -4,6 +4,19 @@ enum ProviderKind: String, CaseIterable, Identifiable {
     case claude
     case codex
     case openclaw
+    case scripted
+
+    static var allCases: [ProviderKind] {
+        var cases: [ProviderKind] = [.claude, .codex, .openclaw]
+        if scriptedProviderEnabled {
+            cases.append(.scripted)
+        }
+        return cases
+    }
+
+    static var scriptedProviderEnabled: Bool {
+        ProcessInfo.processInfo.environment["WORLDOS_ENABLE_SCRIPTED_PROVIDER"] == "1"
+    }
 
     var id: String { rawValue }
 
@@ -12,6 +25,7 @@ enum ProviderKind: String, CaseIterable, Identifiable {
         case .claude: "Claude"
         case .codex: "Codex"
         case .openclaw: "OpenClaw"
+        case .scripted: "Scripted"
         }
     }
 
@@ -20,7 +34,12 @@ enum ProviderKind: String, CaseIterable, Identifiable {
         case .claude: "sparkles"
         case .codex: "terminal"
         case .openclaw: "link"
+        case .scripted: "scroll"
         }
+    }
+
+    var isLaunchEnabled: Bool {
+        self != .scripted || Self.scriptedProviderEnabled
     }
 }
 

--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/ProviderAdapters.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/ProviderAdapters.swift
@@ -255,11 +255,90 @@ struct OpenClawProvider: ProviderAdapter {
     }
 }
 
+struct ScriptedProvider: ProviderAdapter {
+    let kind: ProviderKind = .scripted
+
+    func detect(repoPath: URL, preferences: ProviderPreferences) -> ProviderStatus {
+        guard ProviderKind.scriptedProviderEnabled else {
+            return ProviderStatus(
+                kind: kind,
+                availability: .missing,
+                detail: "Hidden. Set WORLDOS_ENABLE_SCRIPTED_PROVIDER=1 to expose deterministic smoke.",
+                detectedPath: nil
+            )
+        }
+        let script = repoPath.appendingPathComponent("scripts/play_scripted_dm.sh")
+        guard FileManager.default.fileExists(atPath: script.path) else {
+            return ProviderStatus(
+                kind: kind,
+                availability: .error,
+                detail: "Scripted provider helper is missing: scripts/play_scripted_dm.sh",
+                detectedPath: nil
+            )
+        }
+        guard Shell.which("python3") != nil || Shell.which("python") != nil else {
+            return ProviderStatus(
+                kind: kind,
+                availability: .missing,
+                detail: "python3 is required for deterministic scripted smoke.",
+                detectedPath: script.path
+            )
+        }
+        return ProviderStatus(
+            kind: kind,
+            availability: .configured,
+            detail: "Ready. Dev/test-only deterministic smoke provider; no Claude, Codex, or OpenClaw required.",
+            detectedPath: script.path
+        )
+    }
+
+    func startSession(
+        world: String,
+        runId: String,
+        port: Int,
+        companions: String,
+        hero: String,
+        repoPath: URL,
+        preferences: ProviderPreferences
+    ) throws -> ProviderLaunchRequest {
+        guard ProviderKind.scriptedProviderEnabled else {
+            throw ProviderError.configuration("Scripted provider is disabled. Set WORLDOS_ENABLE_SCRIPTED_PROVIDER=1 for dev/test smoke.")
+        }
+        let script = repoPath.appendingPathComponent("scripts/play_scripted_dm.sh")
+        guard FileManager.default.fileExists(atPath: script.path) else {
+            throw ProviderError.configuration("Scripted provider helper is missing: scripts/play_scripted_dm.sh")
+        }
+        return ProviderLaunchRequest(
+            name: "Scripted smoke game",
+            executable: "/bin/zsh",
+            arguments: ["-lc", "scripts/play_scripted_dm.sh"],
+            environment: providerEnvironment(
+                kind: kind,
+                world: world,
+                runId: runId,
+                port: port,
+                companions: companions,
+                hero: hero,
+                preferences: preferences
+            ),
+            workingDirectory: repoPath,
+            message: "Scripted smoke provider launched on port \(port)."
+        )
+    }
+
+    func stop(runId: String) {}
+
+    func tailLogs(runId: String) -> String {
+        "Scripted provider output is captured in play-state/<run-id>/scripted-provider/."
+    }
+}
+
 struct ProviderRegistry {
     private let adapters: [ProviderKind: ProviderAdapter] = [
         .claude: ClaudeProvider(),
         .codex: CodexProvider(),
-        .openclaw: OpenClawProvider()
+        .openclaw: OpenClawProvider(),
+        .scripted: ScriptedProvider()
     ]
 
     func adapter(for kind: ProviderKind) -> ProviderAdapter {

--- a/macos/WorldOSApp/Sources/WorldOSApp/Views/PlayView.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Views/PlayView.swift
@@ -145,6 +145,9 @@ struct PlayView: View {
         do {
             webViewErrorMessage = nil
             let provider = ProviderKind(rawValue: selectedProviderRaw) ?? .claude
+            guard provider.isLaunchEnabled else {
+                throw ProviderError.configuration("Scripted provider is disabled. Set WORLDOS_ENABLE_SCRIPTED_PROVIDER=1 for dev/test smoke.")
+            }
             let cleanRunID = runID.trimmingCharacters(in: .whitespacesAndNewlines)
             webURL = try processService.startProviderSession(
                 kind: provider,

--- a/macos/WorldOSApp/Sources/WorldOSApp/Views/RootView.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Views/RootView.swift
@@ -244,6 +244,9 @@ struct RootView: View {
     private func startProviderFromBridge(_ payload: [String: Any]) async throws -> [String: Any] {
         let providerRaw = stringPayload(payload, "provider") ?? selectedProviderRaw
         let provider = ProviderKind(rawValue: providerRaw) ?? .claude
+        guard provider.isLaunchEnabled else {
+            throw ProviderError.configuration("Scripted provider is disabled. Set WORLDOS_ENABLE_SCRIPTED_PROVIDER=1 for dev/test smoke.")
+        }
         let world = stringPayload(payload, "world") ?? defaultWorld
         let runId = stringPayload(payload, "runId").flatMap { $0.isEmpty ? nil : $0 } ?? Self.newRunID()
         let companions = stringPayload(payload, "companions") ?? ""

--- a/qa/test_macos_app_static.py
+++ b/qa/test_macos_app_static.py
@@ -71,6 +71,38 @@ class MacOSAppStaticContractTests(unittest.TestCase):
         self.assertNotIn('play_party.sh $WORLD $minted_run', harness)
         self.assertNotIn('play.sh $WORLD $minted_run', harness)
 
+    def test_scripted_provider_is_dev_gated_and_model_free(self):
+        models = self.read("macos/WorldOSApp/Sources/WorldOSApp/Models/ProviderModels.swift")
+        providers = self.read("macos/WorldOSApp/Sources/WorldOSApp/Services/ProviderAdapters.swift")
+        root_view = self.read("macos/WorldOSApp/Sources/WorldOSApp/Views/RootView.swift")
+        play_view = self.read("macos/WorldOSApp/Sources/WorldOSApp/Views/PlayView.swift")
+        script = self.read("scripts/play_scripted_dm.sh")
+
+        self.assertIn("case scripted", models)
+        self.assertIn("WORLDOS_ENABLE_SCRIPTED_PROVIDER", models)
+        self.assertIn("static var allCases", models)
+        self.assertIn("cases.append(.scripted)", models)
+        self.assertIn("var isLaunchEnabled", models)
+
+        self.assertIn("struct ScriptedProvider", providers)
+        self.assertIn("ProviderKind.scriptedProviderEnabled", providers)
+        self.assertIn("scripts/play_scripted_dm.sh", providers)
+        self.assertIn(".scripted: ScriptedProvider()", providers)
+        self.assertIn("no Claude, Codex, or OpenClaw required", providers)
+
+        self.assertIn("guard provider.isLaunchEnabled", root_view)
+        self.assertIn("guard provider.isLaunchEnabled", play_view)
+
+        self.assertIn("WORLDOS_ENABLE_SCRIPTED_PROVIDER=1 is required", script)
+        self.assertIn('uv run --directory "$ROOT/servers/engine"', script)
+        self.assertIn("server.start_world", script)
+        self.assertIn("server.load_canon_character", script)
+        self.assertIn("server.log_event", script)
+        self.assertIn("python3 viewer/server.py", script)
+        self.assertIn("WORLDOS_PLAYER_MOVES", script)
+        self.assertNotIn("claude -p", script)
+        self.assertNotIn("codex -p", script)
+
     def test_provider_viewer_stays_attached_during_native_restarts(self):
         root_view = self.read("macos/WorldOSApp/Sources/WorldOSApp/Views/RootView.swift")
         app_process = self.read("macos/WorldOSApp/Sources/WorldOSApp/Services/AppProcessService.swift")

--- a/scripts/play_scripted_dm.sh
+++ b/scripts/play_scripted_dm.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Deterministic built-app smoke provider.
+#
+# This is a dev/test-only provider path for proving app/viewer wiring without
+# Claude, Codex, OpenClaw, network calls, or model auth. It still seeds campaign
+# state through the engine's Python API; the viewer remains a reader plus /move.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ "${1:-}" = "--dry-run" ]; then
+  printf 'scripted provider dry-run: requires no Claude, Codex, or OpenClaw\n'
+  printf 'gate=%s world=%s run=%s port=%s\n' \
+    "${WORLDOS_ENABLE_SCRIPTED_PROVIDER:-0}" \
+    "${CLAWDND_WORLD:-baldurs-gate}" \
+    "${CLAWDND_RUN_ID:-scripted-smoke}" \
+    "${CLAWDND_PLAY_PORT:-8765}"
+  exit 0
+fi
+
+if [ "${WORLDOS_ENABLE_SCRIPTED_PROVIDER:-0}" != "1" ]; then
+  printf '[scripted-provider] WORLDOS_ENABLE_SCRIPTED_PROVIDER=1 is required.\n' >&2
+  exit 64
+fi
+
+WORLD="${CLAWDND_WORLD:-baldurs-gate}"
+RUN="${CLAWDND_RUN_ID:-scripted-smoke-$(date +%H%M%S)}"
+PORT="${CLAWDND_PLAY_PORT:-8765}"
+STATE_DIR="$ROOT/play-state/$RUN"
+TRACE_DIR="$STATE_DIR/scripted-provider"
+MOVES="$STATE_DIR/player_moves.jsonl"
+CHAT="$STATE_DIR/chat.jsonl"
+VIEWER_LOG="$STATE_DIR/viewer.log"
+TRACE="$TRACE_DIR/trace.ndjson"
+VPID_FILE="$STATE_DIR/.viewer.pid"
+
+mkdir -p "$TRACE_DIR"
+: > "$MOVES"
+: > "$CHAT"
+: > "$TRACE"
+
+json_append() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import json, sys, time
+path, role, text = sys.argv[1:4]
+with open(path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps({"role": role, "text": text, "at": time.time()}) + "\n")
+PY
+}
+
+trace() {
+  python3 - "$TRACE" "$1" "$2" <<'PY'
+import json, sys, time
+path, event, detail = sys.argv[1:4]
+with open(path, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps({"event": event, "detail": detail, "at": time.time()}) + "\n")
+PY
+}
+
+BOOTSTRAP_JSON="$(
+  CLAWDND_STATE_DIR="$STATE_DIR" uv run --directory "$ROOT/servers/engine" python - "$WORLD" <<'PY'
+import json, sys
+import server
+
+world = sys.argv[1]
+campaign_id = server.start_world(world)["campaign_id"]
+server.start_session(campaign_id, title="Scripted smoke")
+available = server.list_canon_characters(campaign_id, playable_only=True).get("available", [])
+name = (available[0] or {}).get("name") if available else "Charming Latham"
+pc = server.load_canon_character(campaign_id, name, kind="player", add_to_party=True)
+if not isinstance(pc, dict) or pc.get("error"):
+    pc = server.load_canon_character(campaign_id, "Charming Latham", kind="player", add_to_party=True)
+if not isinstance(pc, dict) or pc.get("error"):
+    raise SystemExit("could not seat a scripted player")
+opening = (
+    f"You are {pc.get('name') or name}, standing under a steady lantern at the edge of the road. "
+    "The smoke provider is awake, the table is listening, and the next move is yours."
+)
+server.log_event(campaign_id, "narration", opening)
+print(json.dumps({"campaign_id": campaign_id, "player": pc, "opening": opening}))
+PY
+)"
+
+CAMPAIGN_ID="$(python3 -c 'import json,sys;print(json.loads(sys.stdin.read())["campaign_id"])' <<<"$BOOTSTRAP_JSON")"
+OPENING="$(python3 -c 'import json,sys;print(json.loads(sys.stdin.read())["opening"])' <<<"$BOOTSTRAP_JSON")"
+PLAYER_NAME="$(python3 -c 'import json,sys;print((json.loads(sys.stdin.read())["player"].get("name") or "Hero"))' <<<"$BOOTSTRAP_JSON")"
+json_append "$CHAT" "dm" "$OPENING"
+trace "bootstrap" "campaign=$CAMPAIGN_ID player=$PLAYER_NAME"
+
+viewer_supervisor() {
+  while :; do
+    WORLDOS_STATE_DIR="$STATE_DIR" CLAWDND_STATE_DIR="$STATE_DIR" \
+    WORLDOS_VIEWER_CHAT="$CHAT" CLAWDND_VIEWER_CHAT="$CHAT" \
+    WORLDOS_PLAYER_MOVES="$MOVES" CLAWDND_PLAYER_MOVES="$MOVES" \
+      python3 viewer/server.py "" "$PORT" >> "$VIEWER_LOG" 2>&1 &
+    local vp=$!
+    echo "$vp" > "$VPID_FILE"
+    wait "$vp" 2>/dev/null || true
+    sleep 1
+  done
+}
+
+viewer_supervisor &
+SUP=$!
+cleanup() {
+  kill "$SUP" 2>/dev/null || true
+  [ -f "$VPID_FILE" ] && kill "$(cat "$VPID_FILE" 2>/dev/null)" 2>/dev/null || true
+}
+trap cleanup EXIT
+trap 'cleanup; exit 0' INT TERM
+
+trace "viewer_started" "port=$PORT"
+processed=0
+
+while :; do
+  count="$(grep -c . "$MOVES" 2>/dev/null || true)"
+  if [ "${count:-0}" -gt "$processed" ]; then
+    line="$(tail -n 1 "$MOVES")"
+    reply="$(
+      CLAWDND_STATE_DIR="$STATE_DIR" uv run --directory "$ROOT/servers/engine" python - "$CAMPAIGN_ID" "$line" <<'PY'
+import json, sys
+import server
+
+campaign_id, raw = sys.argv[1], sys.argv[2]
+try:
+    move = json.loads(raw)
+except json.JSONDecodeError:
+    move = {"text": raw}
+text = str(move.get("text") or move.get("label") or move.get("name") or "continue").strip()
+reply = (
+    f"The table accepts your move: {text}. "
+    "The lantern brightens once, confirming the scripted smoke loop handled /move deterministically."
+)
+server.log_event(campaign_id, "narration", reply)
+print(reply)
+PY
+)"
+    json_append "$CHAT" "player" "$line"
+    json_append "$CHAT" "dm" "$reply"
+    trace "move_resolved" "$line"
+    processed="$count"
+  fi
+  sleep 1
+done


### PR DESCRIPTION
## Summary
- add hidden `scripted` provider kind gated by `WORLDOS_ENABLE_SCRIPTED_PROVIDER=1`
- register a fail-closed native ScriptedProvider adapter that launches `scripts/play_scripted_dm.sh` without Claude, Codex, or OpenClaw
- add deterministic scripted smoke driver that seeds through engine APIs, starts the real viewer path, exposes `/move`, and writes fixed narration/follow-up
- add static Mac contract coverage for the gate and script

Refs #482, #480.

## Test Plan
- `bash -n scripts/play_scripted_dm.sh`
- `WORLDOS_ENABLE_SCRIPTED_PROVIDER=0 CLAWDND_WORLD=baldurs-gate CLAWDND_RUN_ID=test-scripted CLAWDND_PLAY_PORT=9876 scripts/play_scripted_dm.sh --dry-run`
- `python3 -m pytest qa/test_macos_app_static.py -q`
- `swift build --package-path macos/WorldOSApp`
- `git diff --check`

Draft until #488 lands or the stack is ready for review.