### PR TITLE
Clarify doc-only tip versus handoff proof

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -8,7 +8,9 @@
 > `qa/release_readiness.py` (the RRI scorer), `qa/SCORECARD.md` (the ledger).
 >
 > Takeover routing, 2026-06-01: `/Users/lume/ClawDnD-val` is the synced local app/private-art checkout
-> (`fd9dba5 == origin/main` after #475/#494/#495/#496/#498/#499/#500/#501/#504/#505) and the default place to build/run/test the GUI and native app.
+> and the default place to build/run/test the GUI and native app. The latest product-code app proof is
+> `fd9dba5` after #475/#494/#495/#496/#498/#499/#500/#501/#504/#505; #506 and later doc-only commits may sit
+> above that SHA on `origin/main` without invalidating the proof. Verify `origin/main` before acting.
 > Lexar is for evidence/snapshots/logs, not the default runtime tree, because macOS permission prompts
 > can break AI/browser tests when assets live on the external drive. For tracked GUI edits, prefer a
 > same-disk local worktree; use Lexar worktrees only for non-GUI slices that will not launch against art.
@@ -64,7 +66,7 @@
   accessibility review showed the chronicle with one opening narration row and one follow-up narration row,
   not duplicate chat/event prose. This closes the #479 diagnostic blocker, but release still requires #466's
   full non-partial RRI gate.
-- The post-#505 current-main handoff gate
+- The post-#505 product-code handoff gate
   (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260601T085319Z-fd9dba5/`, build
   `fd9dba5`) is the current fastest GUI trust proof. It scored `handoff_score=100` with web-scripted smoke
   5 moves, built `dist/WorldOS.app` scripted smoke 5 moves, and built `dist/WorldOS.app` Codex-provider
@@ -72,8 +74,9 @@
   app-status/session-surface snapshots, move logs, provider trace, console/network/action logs, and failure
   bucket fields. The Codex trace summary reported `trace_exists=true`, `line_count=177`, and
   `failed_or_error_count=0`. `validate_handoff_json(..., "fd9dba5")` returned `valid=True`, `gaps=0`.
-  This supersedes the `4a0efe1` handoff as current proof. It is the fast GUI velocity gate, not the
-  release verdict.
+  This supersedes the `4a0efe1` handoff as current proof. Docs-only commits may sit above this SHA; if #466
+  persona artifacts are produced from a newer SHA, rerun the Mac handoff on that same SHA before RRI rollup.
+  It is the fast GUI velocity gate, not the release verdict.
 
 ## Agent-facing app contract
 
@@ -203,7 +206,7 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
   the endpoint. Capacity/tooling look suitable for heavy sweeps: ~32 GB RAM, 16 CPUs, ~537 GB free disk, `git`,
   `python3`, `uv 0.11.17`, Node `v22.22.1`, npm `10.9.4`, `codex-cli 0.120.0`, Playwright modules, and private
   art. The VM WorldOS checkout at `/root/worldos-qa/WorldOS` is clean but stale at `4524b3e` and behind
-  current `main@fd9dba5`; Codex auth/config is not proven; `/Volumes/LEXAR/Codex` does not exist on the VM.
+  the `fd9dba5` proof baseline; Codex auth/config is not proven; `/Volumes/LEXAR/Codex` does not exist on the VM.
   Before #466, approve/sync the VM checkout, prove Codex auth, set a remote staging path, and copy artifacts
   back to local Lexar.
 - RRI rollup rule: Mac/local evidence supplies native Part A and built-app screenshots; VM artifacts can supply
@@ -212,8 +215,10 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
   must remain `partial` / `harness_contaminated`.
 - Split Mac/VM rollup command shape: pass the Mac proof into RRI as
   `--handoff-json /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260601T085319Z-fd9dba5/handoff.json`
-  alongside the VM persona run dirs. RRI should then satisfy the native gate from the Mac handoff bundle
-  only if all required handoff gates and manifests are same-SHA, clean, private-art-present, and gap-free.
+  alongside VM persona run dirs from the same `fd9dba5` SHA. RRI should satisfy the native gate from the
+  Mac handoff bundle only if all required handoff gates and manifests are same-SHA, clean,
+  private-art-present, and gap-free. If the VM runs a newer SHA, rerun `qa/app_handoff_gate.py` on that
+  newer SHA first.
 
 ## Release (when RRI = 10/10 on a fresh .app build)
 Bump `.claude-plugin/plugin.json` → 1.0.4, tag `v1.0.4`, GitHub release + CHANGELOG. Then MAINTAIN:

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -5,11 +5,13 @@
      Post-compaction agents: this 6-line block is ground truth. Do NOT reconstruct
      state from scattered docs or old plans; trust this, verify the sha, then act.
      ──────────────────────────────────────────────────────────────────────────
-     AS OF:        2026-06-01T16:00:00+07:00 #505 RRI bridge merged + current-SHA handoff gate passed
+     AS OF:        2026-06-01T16:18:00+07:00 #506 docs sync merged; product handoff build remains fd9dba5
      MAIN BASELINE:
-                   fd9dba5 (PRs #475, #494, #495, #496, #498, #499, #500, #501, #504,
-                   and #505 merged; verified `/Users/lume/ClawDnD-val` was fast-forwarded after #505).
-                   Re-verify current `origin/main` before acting.
+                   Product-code / last app-proof baseline is `fd9dba5` (PRs #475, #494, #495,
+                   #496, #498, #499, #500, #501, #504, and #505 merged; verified
+                   `/Users/lume/ClawDnD-val` was fast-forwarded after #505). PR #506 merged as
+                   docs-only commit `38cc3a6` above that proof. Future docs-only commits may sit
+                   above the last product-proof SHA; re-verify current `origin/main` before acting.
      CANONICAL:    /Users/lume/ClawDnD-val is now the synced local app/private-art checkout and
                    the default place to build/run/test the Mac app. Keep GUI/runtime tests on this
                    local disk so macOS does not prompt on Lexar-hosted assets.
@@ -24,7 +26,7 @@
                    `ssh -o BatchMode=yes support-vm-1 ...` could not resolve the hostname in this
                    Codex Desktop session. A read-only operator-endpoint scout reached `evaos-support`
                    (~32 GB RAM, 16 CPUs) with WorldOS at `/root/worldos-qa/WorldOS`, but that checkout
-                   was stale (`4524b3e`) and now behind `fd9dba5`; Codex auth/config was not
+                   was stale (`4524b3e`) and behind the `fd9dba5` product-proof baseline; Codex auth/config was not
                    proven. Restore/verify operator routing, fast-forward the VM repo, verify Codex auth,
                    and define artifact return before running #466 there.
      LAST MEASURED GATE BUILD:
@@ -33,7 +35,7 @@
                    personas failed around port/backend harness setup; behavioral/UI/palette/image
                    evidence was not a valid five-persona release verdict.
      LAST BUILT-APP PLAY PROOF:
-                   Last merged-main handoff proof is `fd9dba5`
+                   Last product-code handoff proof is `fd9dba5`
                    (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260601T085319Z-fd9dba5/`):
                    `qa/app_handoff_gate.py` scored `handoff_score=100` with web-scripted smoke
                    5 moves, built `dist/WorldOS.app` scripted smoke 5 moves, and built
@@ -53,10 +55,12 @@
                    persona count, disk-backed palette/image/behavioral evidence, and built .app play.
      NEXT ACTION:  #479 is closed; #504 gives a fast GUI velocity gate; #505 lets RRI consume
                    Mac handoff proof through `--handoff-json`.
-                   Do not claim release. Run #466 for a trustworthy clean RRI failure list/result:
-                   use the `fd9dba5` handoff JSON for Mac/local built `.app` proof while the 32GB support VM
-                   runs heavy backend/persona sweeps after explicit VM routing/auth/config
-                   preflight. If the VM route is still unavailable, record that as the blocker and
+                   Do not claim release. Run #466 for a trustworthy clean RRI failure list/result.
+                   For same-SHA RRI, either run the support-VM persona sweep pinned to `fd9dba5`
+                   and pair it with the `fd9dba5` handoff JSON, or rerun the Mac handoff on a newer
+                   release-candidate SHA before rollup. The 32GB support VM runs heavy
+                   backend/persona sweeps only after explicit VM routing/auth/config preflight.
+                   If the VM route is still unavailable, record that as the blocker and
                    file/fix repo-side RRI harness gaps only if found. Continue #485/#486 for
                    evidence export and gate split follow-through; #481/#482/#483/#484 are closed.
                    Keep sprint work UX-first (#467): first-turn playability, clickability/chrome,
@@ -199,7 +203,7 @@ verifier; can revert the goal to "fix" anytime.
 
 ---
 
-## 9. CURRENT STATUS (2026-06-01T16:00:00+07:00 — #505 RRI bridge merged + current-SHA handoff gate passed)
+## 9. CURRENT STATUS (2026-06-01T16:18:00+07:00 — #506 docs sync merged; latest product proof is fd9dba5)
 
 - Repo truth stabilization merged in PR #465, UX-first doc sync merged in PR #468, first-minute
   click/title chrome proof merged in PR #470, local/Lexar/support-VM routing merged in PR #471,
@@ -212,8 +216,9 @@ verifier; can revert the goal to "fix" anytime.
   provider trace cancellations, PR #501 recorded that proof in the runbooks/scorecard, and PR #504
   added the hybrid 100/100 app handoff gate. PR #505 then hardened the RRI bridge so Mac handoff
   evidence can be supplied with `--handoff-json` while support-VM persona artifacts supply the heavy
-  sweep. The local app/private-art checkout `/Users/lume/ClawDnD-val` was fast-forwarded to
-  `fd9dba5 == origin/main` after #505.
+  sweep. PR #506 then synced these docs to the `fd9dba5` proof without changing product code. The local
+  app/private-art checkout `/Users/lume/ClawDnD-val` should be kept fast-forwarded to `origin/main`,
+  but the latest app-proof SHA remains `fd9dba5`.
 - The stale local pre-sync artifacts were preserved before the fast-forward at
   `/Volumes/LEXAR/Codex/worldos-local-checkout-snapshot-20260531T223923` and in `stash@{0}`
   (`pre-sync local takeover docs 2026-05-31`). Treat those as evidence, not current release truth.
@@ -235,12 +240,14 @@ verifier; can revert the goal to "fix" anytime.
   macOS TCC attribution contamination: `responsible=dev.clawdnd.app`, but the actual accessor was
   `/usr/bin/find` launched by the test/diagnostic environment. Treat that screenshot prompt as harness
   contamination unless a clean run shows `WorldOSApp`/WebKit itself accessing a protected library path.
-- The next gate evidence step is issue #466: a clean non-partial five-persona RRI from `fd9dba5` or newer.
+- The next gate evidence step is issue #466: a clean non-partial five-persona RRI from one explicit SHA.
+  The easiest current path is a support-VM sweep pinned to `fd9dba5` and paired with the `fd9dba5`
+  handoff JSON. If the sweep runs on a newer `origin/main` tip, rerun the Mac handoff on that same SHA first.
   Heavy backend/persona sweeps belong on the owner-provided 32GB support VM (`support-vm-1`) once auth/config
   are intentionally installed there; connection details are kept outside tracked docs. In this Codex Desktop
   session the local SSH alias for `support-vm-1` did not resolve; a read-only operator-endpoint scout reached
   the VM and confirmed `evaos-support` has ~32 GB RAM, 16 CPUs, `git`, `python3`, `uv`, Node/npm, Codex CLI,
-  Playwright, and private art, but its WorldOS checkout is `4524b3e` and now behind `fd9dba5`; Codex
+  Playwright, and private art, but its WorldOS checkout is `4524b3e` and behind the `fd9dba5` proof baseline; Codex
   auth/config was not proven. Restore/verify VM routing, fast-forward the VM checkout, verify auth, and define
   artifact return before the heavy sweep. Mac-only built-app launch/play proof stays on this Mac or macOS CI.
 - Built-app diagnostic evidence exists, but release truth is still absent. The PR #475 pre-merge app-code
@@ -263,12 +270,13 @@ verifier; can revert the goal to "fix" anytime.
   screenshot archived, `app-evidence/manifest.json` with no gaps, and `provider-errors.after-move.json`
   reporting zero parse errors plus zero failed/error tool calls. This is sufficient to close #479 as a
   merged-main diagnostic; it is still not an RRI release verdict.
-- The post-#505 current-main handoff gate `handoff-20260601T085319Z-fd9dba5` then reproved the fast GUI
-  velocity loop on the current `main`: web-scripted smoke 5 moves, built-app scripted smoke 5 moves,
+- The post-#505 product-code handoff gate `handoff-20260601T085319Z-fd9dba5` then reproved the fast GUI
+  velocity loop: web-scripted smoke 5 moves, built-app scripted smoke 5 moves,
   built-app Codex playtest 1 move, private art present, active player, five enabled actions, zero evidence
   gaps across all three manifests, and Codex trace `failed_or_error_count=0` with `line_count=177`.
   `qa.release_readiness.validate_handoff_json(..., "fd9dba5")` returned `valid=True` and `gaps=0`.
-  This supersedes the `4a0efe1` handoff as current app-wiring proof, but it remains diagnostic and cannot
+  This supersedes the `4a0efe1` handoff as current app-wiring proof. Docs-only commits may now sit above
+  it on `origin/main`; it remains diagnostic and cannot
   replace the full five-persona RRI.
 - The agent-grade testability layer now has real code merged: `GET /app-status` exposes the live run,
   campaign, provider, private-art presence, move sink, actor, enabled actions, readiness, and failure buckets

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -15,7 +15,7 @@
 > the owner-provided 32GB support VM (`support-vm-1`) after remote access and Codex config are
 > intentionally installed and verified; connection details are kept outside tracked docs. A read-only
 > scout reached the operator endpoint and found `evaos-support` suitable but stale (`4524b3e`, behind
-> current `fd9dba5`) with Codex auth/config unproven. Mac-only built-app proof remains local/macOS CI.
+> the `fd9dba5` proof baseline) with Codex auth/config unproven. Mac-only built-app proof remains local/macOS CI.
 
 > **This is the compaction-resilience doc.** If you are an agent resuming this project
 > after a context reset, read this top-to-bottom before doing anything. It captures the
@@ -26,7 +26,7 @@
 > If an operator hands you local session notes or decision records, treat them as
 > private working artifacts unless they are intentionally promoted into tracked docs.
 >
-> Last updated: 2026-06-01T16:00:00+07:00 (`main@fd9dba5`; #475/#494/#495/#496/#498/#499/#500/#501/#504/#505 merged; #505 RRI bridge merged; fd9dba5 100/100 handoff gate passed; release notes below are historical context).
+> Last updated: 2026-06-01T16:18:00+07:00 (`fd9dba5` remains the latest product-code app-proof build; #506 merged docs-only above it; release notes below are historical context).
 >
 > **Graphics & game-types roadmap (canonical):** the long-term plan for the kinds of games
 > WorldOS can produce (GT0 narrative dashboard → GT1 SNES pixel → GT2 Pillars/BG isometric)
@@ -312,13 +312,13 @@ state docs synced as PR #473, Codex-DM app observability merged as PR #475, scri
 as PR #494, stable agent UI hooks merged as PR #495, failure-bucket/RRI split metadata merged as PR #496,
 and takeover truth sync merged as PR #498, followed by PR #499 recording current-main built-app proof
 PR #500 fixing Codex-DM provider trace cancellations, PR #501 recording that proof in docs, and
-PR #504 adding the 100/100 hybrid app handoff gate, then PR #505 adding the RRI `--handoff-json`
-bridge for Mac app proof.
-The local app/private-art checkout is now synced at
-`fd9dba5 == origin/main`; the only current gate
+PR #504 adding the 100/100 hybrid app handoff gate, PR #505 adding the RRI `--handoff-json`
+bridge for Mac app proof, and PR #506 syncing docs to that proof. Docs-only commits may sit above
+the latest product-proof SHA on `origin/main`.
+The local app/private-art checkout should stay fast-forwarded to `origin/main`; the only current gate
 truth lives in `WorldOS-OPERATING-GOAL.md` + `WorldOS-GUI-RUNBOOK.md` + `qa/SCORECARD.md`. Do not use
 this section to decide release state. The next sprint is UX-first (#467):
-current-main fast handoff play is proven diagnostically on `fd9dba5`, including private art, Codex DM, an active player,
+product-code fast handoff play is proven diagnostically on `fd9dba5`, including private art, Codex DM, an active player,
 five enabled actions, one accepted/resolved `/move`, no evidence-manifest gaps, zero failed/error provider
 trace events, and a post-merge `handoff_score=100`. With #479 proven and #504/#505 merged, run #466 only after
 support-VM routing/auth/config preflight is explicit; this session's read-only check found the local


### PR DESCRIPTION
## Summary
- clarifies that `fd9dba5` is the latest product-code app-proof build, while #506 is a docs-only commit above it
- prevents #466 from accidentally mixing VM artifacts from a newer docs-only SHA with the `fd9dba5` Mac handoff JSON
- documents the two valid same-SHA paths: pin VM persona sweep to `fd9dba5`, or rerun the Mac handoff on a newer release-candidate SHA before RRI rollup

## Validation
- `git diff --check`
- `python3 -m pytest qa/test_release_readiness.py -q` -> 21 passed
- `validate_handoff_json(..., "fd9dba5")` -> `valid=True`, `gaps=0`

No product code changes. This is release-truth clarification only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated operational runbooks and release guidance with clarified verification steps and baseline references
  * Refined gate naming and VM handoff procedures for improved process clarity
  * Updated status narratives and evidence tracking in operational documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->