### PR TITLE
Add support VM preflight artifact gate

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -195,9 +195,21 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
 - Do **not** use it as proof for Mac-only surfaces: `WorldOS.app` build/launch, native #356, and built-app
   UI play evidence stay on this Mac or macOS CI.
 - VM preflight before any RRI sweep: record VM identity, repo checkout path, branch/SHA, Codex CLI version,
-  auth/profile status, `uv`, Node/npm/Playwright availability, private-art availability or explicit
+  auth/profile status, `uv`, Node/npm/Playwright/Chromium availability, private-art availability or explicit
   backend-only/no-art classification, env vars, budget/concurrency cap, teardown commands, and the artifact
-  return path under `/Volumes/LEXAR/Codex`.
+  return path under `/Volumes/LEXAR/Codex`. Use the repo-owned preflight artifact writer before #466:
+  ```bash
+  python3 qa/support_vm_preflight.py \
+    --repo /root/worldos-qa/WorldOS \
+    --expected-sha fd9dba5 \
+    --art-root /root/worldos-qa/WorldOS \
+    --private-art-mode required \
+    --artifact-dir /tmp/worldos-support-vm-preflight-fd9dba5 \
+    --artifact-return-target /Volumes/LEXAR/Codex/worldos-support-vm-rri/fd9dba5-preflight
+  ```
+  The script is read-only with respect to WorldOS state; it writes `support_vm_preflight.json` and
+  `support_vm_preflight.md`, redacts secrets, and exits non-zero if same-SHA/tool/auth/private-art blockers
+  would make the RRI sweep untrustworthy.
 - Current preflight status (2026-06-01): this local Codex Desktop session can parse an SSH alias for
   `support-vm-1`, but `ssh -o BatchMode=yes support-vm-1 ...` failed DNS resolution (`nodename nor servname
   provided`). Do not start #466 there until operator routing is restored and the preflight fields above are

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -59,7 +59,8 @@
                    For same-SHA RRI, either run the support-VM persona sweep pinned to `fd9dba5`
                    and pair it with the `fd9dba5` handoff JSON, or rerun the Mac handoff on a newer
                    release-candidate SHA before rollup. The 32GB support VM runs heavy
-                   backend/persona sweeps only after explicit VM routing/auth/config preflight.
+                   backend/persona sweeps only after `python3 qa/support_vm_preflight.py`
+                   writes a redacted ready-for-RRI artifact for that VM checkout/SHA.
                    If the VM route is still unavailable, record that as the blocker and
                    file/fix repo-side RRI harness gaps only if found. Continue #485/#486 for
                    evidence export and gate split follow-through; #481/#482/#483/#484 are closed.

--- a/docs/AGENT_GRADE_APP_TESTABILITY.md
+++ b/docs/AGENT_GRADE_APP_TESTABILITY.md
@@ -311,6 +311,15 @@ Pass requires #466 conditions:
   session-surface evidence.
 - RRI returns non-partial release-ready status.
 
+Before using the 32GB support VM for this gate, run
+`python3 qa/support_vm_preflight.py` on that VM checkout with the exact target
+SHA. The preflight artifact must prove the VM repo SHA, Codex CLI/auth status,
+`uv`, Node/npm/Playwright/Chromium availability, private-art classification,
+env-var redaction, budget/concurrency cap, teardown commands, and artifact return path.
+It is a readiness check, not release evidence; the release verdict still comes
+only from `qa/release_readiness.py` over complete same-SHA artifacts plus the
+Mac built-app handoff proof.
+
 This is the only release gate. The UX-first roadmap in #467 should use its
 failures as product evidence, not as a reason to build more proxy machinery.
 

--- a/qa/support_vm_preflight.py
+++ b/qa/support_vm_preflight.py
@@ -1,0 +1,690 @@
+#!/usr/bin/env python3
+"""Read-only support-VM preflight for WorldOS five-persona RRI sweeps.
+
+This script does not launch the app, mutate campaign state, run persona sweeps,
+or print secrets. It writes a redacted artifact that answers the question:
+"Is this host ready to produce same-SHA VM evidence for #466?"
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import getpass
+import json
+import os
+import platform
+import re
+import shlex
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+SCHEMA = "worldos.support-vm-preflight.v1"
+CANONICAL_PERSONAS = ["newbie", "veteran", "adversarial", "narrative", "optimizer"]
+MIN_SHA_MATCH_CHARS = 7
+REQUIRED_TOOLS = [
+    "git",
+    "python3",
+    "uv",
+    "node",
+    "npm",
+    "npx",
+    "codex",
+    "claude",
+    "jq",
+    "curl",
+    "lsof",
+    "timeout",
+    "pkill",
+    "pgrep",
+    "ps",
+]
+INTERESTING_ENV_PREFIXES = ("WORLDOS_", "CLAWDND_", "CODEX_", "OPENAI_", "ANTHROPIC_")
+SAFE_PATH_ENV_NAMES = {
+    "WORLDOS_ART_REPO_ROOT",
+    "CLAWDND_ART_REPO_ROOT",
+    "WORLDOS_REPO_ROOT",
+    "CLAWDND_REPO_ROOT",
+    "CODEX_HOME",
+}
+
+
+CommandRunner = Callable[[Sequence[str], Path | None, int], dict]
+WhichFn = Callable[[str], str | None]
+
+
+@dataclass
+class PreflightConfig:
+    repo: Path
+    expected_sha: str
+    artifact_dir: Path
+    artifact_return_target: str
+    art_root: Path
+    private_art_mode: str
+    personas: list[str]
+    budget: str
+    concurrency: int
+    port: int
+
+
+def utc_timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def compact_timestamp() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def redact(value: str) -> str:
+    if not value:
+        return value
+    redacted = str(value)
+    redacted = re.sub(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{8,}\b", "sk-[REDACTED]", redacted)
+    redacted = re.sub(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]{8,}", r"\1[REDACTED]", redacted)
+    redacted = re.sub(
+        r"(?i)\b([A-Z0-9_]*(?:API[_-]?KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z0-9_]*\s*[=:]\s*)([\"']?)[^\"'\s,;]+",
+        r"\1\2[REDACTED]",
+        redacted,
+    )
+    return redacted
+
+
+def redacted_remote_url(value: str) -> str:
+    value = redact(value or "")
+    return re.sub(r"(https?://)[^/@\s]+@", r"\1[REDACTED]@", value)
+
+
+def is_secret_env_key(key: str) -> bool:
+    upper = key.upper()
+    return any(marker in upper for marker in ("API_KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL"))
+
+
+def looks_like_path(value: str) -> bool:
+    return value.startswith(("/", "~", "./", "../")) or "/" in value
+
+
+def env_snapshot(env: dict[str, str]) -> dict:
+    out: dict[str, dict] = {}
+    for key in sorted(env):
+        if not key.startswith(INTERESTING_ENV_PREFIXES):
+            continue
+        value = env.get(key, "")
+        entry = {"present": bool(value)}
+        if not value:
+            entry["value"] = ""
+            entry["value_policy"] = "empty"
+        elif is_secret_env_key(key):
+            entry["value"] = "[REDACTED]"
+            entry["value_policy"] = "secret-redacted"
+        elif key in SAFE_PATH_ENV_NAMES or (key.endswith(("_ROOT", "_DIR", "_HOME")) and looks_like_path(value)):
+            entry["value"] = redact(value)
+            entry["value_policy"] = "safe-path"
+        else:
+            entry["value"] = "[REDACTED]"
+            entry["value_policy"] = "presence-only"
+        out[key] = entry
+    return out
+
+
+def build_sha_matches(reported: str, expected: str) -> bool:
+    reported = (reported or "").strip()
+    expected = (expected or "").strip()
+    if len(reported) < MIN_SHA_MATCH_CHARS or len(expected) < MIN_SHA_MATCH_CHARS:
+        return False
+    return reported == expected or reported.startswith(expected) or expected.startswith(reported)
+
+
+def has_auth_marker(text: str, markers: Sequence[str]) -> bool:
+    return any(re.search(rf"\b{re.escape(marker)}\b", text) for marker in markers)
+
+
+def run_command(cmd: Sequence[str], cwd: Path | None = None, timeout: int = 8) -> dict:
+    try:
+        proc = subprocess.run(
+            list(cmd),
+            cwd=str(cwd) if cwd else None,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+        return {
+            "ok": proc.returncode == 0,
+            "exit_code": proc.returncode,
+            "stdout": redact(proc.stdout.strip()),
+            "stderr": redact(proc.stderr.strip()),
+            "timed_out": False,
+        }
+    except FileNotFoundError:
+        return {"ok": False, "exit_code": None, "stdout": "", "stderr": "command not found", "timed_out": False}
+    except subprocess.TimeoutExpired as exc:
+        return {
+            "ok": False,
+            "exit_code": None,
+            "stdout": redact((exc.stdout or "").strip() if isinstance(exc.stdout, str) else ""),
+            "stderr": "command timed out",
+            "timed_out": True,
+        }
+
+
+def git_text(repo: Path, args: Sequence[str], runner: CommandRunner) -> str:
+    result = runner(["git", *args], repo, 8)
+    return (result.get("stdout") or "").strip() if result.get("ok") else ""
+
+
+def inspect_repo(repo: Path, expected_sha: str, runner: CommandRunner) -> tuple[dict, list[str], list[str]]:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    info = {
+        "path": str(repo),
+        "exists": repo.exists(),
+        "is_dir": repo.is_dir(),
+        "branch": "",
+        "head": "",
+        "head_short": "",
+        "origin_main": "",
+        "dirty": None,
+        "expected_sha": expected_sha or "",
+        "expected_sha_match": None,
+        "remote_origin": "",
+    }
+
+    if not repo.exists() or not repo.is_dir():
+        blockers.append(f"repo path is not a directory: {repo}")
+        return info, blockers, warnings
+
+    git_root = git_text(repo, ["rev-parse", "--show-toplevel"], runner)
+    if not git_root:
+        blockers.append(f"repo path is not a git checkout: {repo}")
+        return info, blockers, warnings
+
+    info["git_root"] = git_root
+    info["branch"] = git_text(repo, ["rev-parse", "--abbrev-ref", "HEAD"], runner)
+    info["head"] = git_text(repo, ["rev-parse", "HEAD"], runner)
+    info["head_short"] = git_text(repo, ["rev-parse", "--short", "HEAD"], runner)
+    info["origin_main"] = git_text(repo, ["rev-parse", "origin/main"], runner)
+    info["remote_origin"] = redacted_remote_url(git_text(repo, ["remote", "get-url", "origin"], runner))
+    status = git_text(repo, ["status", "--short"], runner)
+    info["dirty"] = bool(status)
+    if status:
+        info["status_short_redacted"] = redact(status)
+        blockers.append("repo checkout is dirty; do not run release evidence from uncommitted state")
+
+    if expected_sha:
+        info["expected_sha_match"] = build_sha_matches(info["head"], expected_sha)
+        if not info["expected_sha_match"]:
+            blockers.append(
+                f"repo HEAD {info['head_short'] or info['head'] or 'unknown'} does not match expected SHA {expected_sha}"
+            )
+    else:
+        blockers.append("expected SHA is required for support-VM RRI readiness")
+
+    if info["origin_main"] and info["head"] and info["origin_main"] != info["head"]:
+        warnings.append(
+            f"HEAD {info['head_short'] or info['head']} differs from origin/main {info['origin_main'][:7]}"
+        )
+
+    return info, blockers, warnings
+
+
+def sysctl_int(name: str) -> int | None:
+    try:
+        proc = subprocess.run(["sysctl", "-n", name], text=True, capture_output=True, timeout=3, check=False)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        return int(proc.stdout.strip())
+    except ValueError:
+        return None
+
+
+def memory_total_bytes() -> int | None:
+    meminfo = Path("/proc/meminfo")
+    if meminfo.exists():
+        for line in meminfo.read_text(encoding="utf-8", errors="ignore").splitlines():
+            if line.startswith("MemTotal:"):
+                parts = line.split()
+                if len(parts) >= 2 and parts[1].isdigit():
+                    return int(parts[1]) * 1024
+    return sysctl_int("hw.memsize")
+
+
+def disk_summary(path: Path) -> dict:
+    target = path if path.exists() else path.parent
+    try:
+        usage = shutil.disk_usage(target)
+        return {
+            "path": str(target),
+            "total_bytes": usage.total,
+            "free_bytes": usage.free,
+            "free_gb": round(usage.free / (1024**3), 2),
+        }
+    except OSError as exc:
+        return {"path": str(target), "error": str(exc)}
+
+
+def inspect_host(repo: Path, artifact_dir: Path) -> dict:
+    mem_bytes = memory_total_bytes()
+    return {
+        "hostname": socket.gethostname(),
+        "user": getpass.getuser(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "python": sys.version.split()[0],
+        "cwd": os.getcwd(),
+        "cpu_count": os.cpu_count(),
+        "memory_total_bytes": mem_bytes,
+        "memory_total_gb": round(mem_bytes / (1024**3), 2) if mem_bytes else None,
+        "repo_disk": disk_summary(repo),
+        "artifact_disk": disk_summary(artifact_dir),
+    }
+
+
+def inspect_tool(
+    name: str,
+    executable: str,
+    version_args: Sequence[str],
+    repo: Path,
+    runner: CommandRunner,
+    which: WhichFn,
+) -> dict:
+    path = which(executable)
+    info = {"available": bool(path), "path": path or "", "version": "", "exit_code": None, "timed_out": False}
+    if not path:
+        return info
+    result = runner([path, *version_args], repo, 8)
+    info.update(
+        {
+            "version": " ".join(p for p in (result.get("stdout"), result.get("stderr")) if p).strip()[:300],
+            "exit_code": result.get("exit_code"),
+            "timed_out": bool(result.get("timed_out")),
+        }
+    )
+    return info
+
+
+def inspect_tools(repo: Path, runner: CommandRunner, which: WhichFn) -> tuple[dict, list[str], list[str]]:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    tool_specs = {
+        "git": ("git", ["--version"]),
+        "python3": ("python3", ["--version"]),
+        "uv": ("uv", ["--version"]),
+        "node": ("node", ["--version"]),
+        "npm": ("npm", ["--version"]),
+        "npx": ("npx", ["--version"]),
+        "codex": ("codex", ["--version"]),
+        "claude": ("claude", ["--version"]),
+        "jq": ("jq", ["--version"]),
+        "curl": ("curl", ["--version"]),
+        "lsof": ("lsof", ["-v"]),
+        "timeout": ("timeout", ["--version"]),
+        "pkill": ("pkill", ["-V"]),
+        "pgrep": ("pgrep", ["-V"]),
+        "ps": ("ps", ["--version"]),
+    }
+    tools = {name: inspect_tool(name, exe, args, repo, runner, which) for name, (exe, args) in tool_specs.items()}
+    for name in REQUIRED_TOOLS:
+        if not tools.get(name, {}).get("available"):
+            blockers.append(f"required VM tool missing: {name}")
+
+    node_path = tools.get("node", {}).get("path") or which("node")
+    playwright_dir = repo / "qa" / "playwright" / "node_modules" / "playwright"
+    playwright = {"available": False, "path": "", "exit_code": None, "timed_out": False}
+    if playwright_dir.is_dir():
+        playwright.update({"available": True, "path": str(playwright_dir), "source": "qa/playwright/node_modules"})
+    elif node_path:
+        playwright_cwd = repo / "qa" / "playwright" if (repo / "qa" / "playwright").is_dir() else repo
+        result = runner([node_path, "-e", "process.stdout.write(require.resolve('playwright'))"], playwright_cwd, 8)
+        playwright.update(
+            {
+                "available": bool(result.get("ok")),
+                "path": (result.get("stdout") or "")[:300],
+                "exit_code": result.get("exit_code"),
+                "timed_out": bool(result.get("timed_out")),
+                "source": "node_require_resolve",
+            }
+        )
+    if not playwright["available"]:
+        blockers.append("Playwright node module is not resolvable from the repo checkout")
+    tools["playwright_node_module"] = playwright
+
+    chromium = {"available": False, "path": "", "exit_code": None, "timed_out": False}
+    if playwright["available"] and node_path:
+        playwright_cwd = repo / "qa" / "playwright" if (repo / "qa" / "playwright").is_dir() else repo
+        result = runner(
+            [
+                node_path,
+                "-e",
+                "const { chromium } = require('playwright'); process.stdout.write(chromium.executablePath())",
+            ],
+            playwright_cwd,
+            8,
+        )
+        chromium_path = (result.get("stdout") or "").strip()
+        chromium.update(
+            {
+                "available": bool(result.get("ok")) and bool(chromium_path) and Path(chromium_path).exists(),
+                "path": chromium_path[:300],
+                "exit_code": result.get("exit_code"),
+                "timed_out": bool(result.get("timed_out")),
+            }
+        )
+    if not chromium["available"]:
+        blockers.append("Playwright Chromium executable is not installed; run (cd qa/playwright && npx playwright install chromium)")
+    tools["playwright_chromium"] = chromium
+
+    codex = {"available": bool(tools.get("codex", {}).get("available")), "auth_status": "not_proven"}
+    codex_path = tools.get("codex", {}).get("path")
+    if codex_path:
+        result = runner([codex_path, "auth", "status"], repo, 10)
+        combined = f"{result.get('stdout') or ''}\n{result.get('stderr') or ''}".strip()
+        lower = combined.lower()
+        codex.update(
+            {
+                "auth_probe_exit_code": result.get("exit_code"),
+                "auth_probe_timed_out": bool(result.get("timed_out")),
+            }
+        )
+        negative_auth = ("not authenticated", "unauthenticated", "not logged in", "signed out", "inactive")
+        positive_auth = ("authenticated", "logged in", "signed in")
+        if has_auth_marker(lower, negative_auth):
+            codex["auth_status"] = "not_proven"
+            blockers.append("Codex CLI auth/profile status is not proven")
+        elif result.get("ok") and has_auth_marker(lower, positive_auth):
+            codex["auth_status"] = "proven"
+        elif result.get("ok"):
+            codex["auth_status"] = "command_ok_unclassified"
+            blockers.append("Codex CLI auth/profile status is not proven")
+        else:
+            blockers.append("Codex CLI auth/profile status is not proven")
+    tools["codex_auth"] = codex
+    return tools, blockers, warnings
+
+
+def inspect_private_art(art_root: Path, mode: str) -> tuple[dict, list[str], list[str]]:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    images_root = art_root / "content" / "worlds" / "_private" / "baldurs-gate" / "images"
+    scope_count = 0
+    image_png_count = 0
+    if images_root.is_dir():
+        try:
+            for entry in images_root.iterdir():
+                if entry.is_dir():
+                    scope_count += 1
+                    if (entry / "image.png").is_file():
+                        image_png_count += 1
+        except OSError as exc:
+            warnings.append(f"private art directory could not be fully scanned: {exc}")
+    present = images_root.is_dir() and image_png_count > 0
+    info = {
+        "mode": mode,
+        "art_root": str(art_root),
+        "private_images_root": str(images_root),
+        "private_root_present": present,
+        "scope_dir_count": scope_count,
+        "image_png_count": image_png_count,
+        "contents_listed": False,
+    }
+    if not present and mode == "required":
+        blockers.append(f"private art required but not proven at {images_root}")
+    elif not present and mode == "optional":
+        warnings.append(f"private art not proven at {images_root}; classify resulting VM evidence as no-art/backend-only")
+    return info, blockers, warnings
+
+
+def inspect_required_repo_files(repo: Path, personas: list[str]) -> tuple[dict, list[str], list[str]]:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    required = [
+        "qa/ui_playtest_app.sh",
+        "qa/run_duo.sh",
+        "qa/assert_behavioral.py",
+        "qa/ui_audit_health.sh",
+        "qa/release_readiness.py",
+        "qa/play_player_duo.txt",
+        "qa/playwright/palette_server.js",
+        "scripts/play.sh",
+        "scripts/play_party.sh",
+    ]
+    required.extend(f"qa/play_player_browser_{persona}.txt" for persona in personas)
+    files = {}
+    for rel in required:
+        path = repo / rel
+        present = path.is_file()
+        files[rel] = {"present": present}
+        if not present:
+            blockers.append(f"required release artifact tool/brief missing: {rel}")
+    return {"required_files": files}, blockers, warnings
+
+
+def teardown_commands(repo: Path, port: int, expected_sha: str) -> list[str]:
+    run_prefix = f"gate-{(expected_sha or 'SHA')[:7]}"
+    repo_path = q(repo)
+    return [
+        f"pkill -f {q('play_party.sh .* ' + run_prefix)} || true",
+        f"pkill -f {q('play.sh .* ' + run_prefix)} || true",
+        f"pkill -f {q('play-state/' + run_prefix)} || true",
+        f"pkill -f {q('qa/playwright/palette_server.js.*' + run_prefix)} || true",
+        (
+            f"repo={repo_path}; "
+            f"for pid in $(lsof -nP -tiTCP:{port} -sTCP:LISTEN 2>/dev/null); do "
+            "cwd=$(lsof -a -p \"$pid\" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1); "
+            '[ "$cwd" = "$repo" ] && kill "$pid" || true; '
+            "done"
+        ),
+    ]
+
+
+def q(value: object) -> str:
+    return shlex.quote(str(value))
+
+
+def build_vm_persona_commands(config: PreflightConfig) -> list[str]:
+    run_prefix = f"gate-{(config.expected_sha or 'SHA')[:7]}"
+    commands: list[str] = []
+    for persona in config.personas:
+        commands.append(
+            " ".join(
+                [
+                    f"WORLDOS_ART_REPO_ROOT={q(config.art_root)}",
+                    "WOS_APP_PART=B",
+                    "WOS_APP_SKIP_BUILD=1",
+                    "WOS_APP_NO_GLOBAL_KILL=1",
+                    f"WOS_APP_PREFERRED_PORT={q(config.port)}",
+                    "qa/ui_playtest_app.sh",
+                    q(f"{run_prefix}-{persona}"),
+                    "baldurs-gate",
+                    q(persona),
+                    "40",
+                    q(config.budget),
+                ]
+            )
+        )
+    return commands
+
+
+def build_report(
+    config: PreflightConfig,
+    *,
+    runner: CommandRunner = run_command,
+    which: WhichFn = shutil.which,
+    env: dict[str, str] | None = None,
+) -> dict:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    config.artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    repo, repo_blockers, repo_warnings = inspect_repo(config.repo, config.expected_sha, runner)
+    tools, tool_blockers, tool_warnings = inspect_tools(config.repo, runner, which)
+    art, art_blockers, art_warnings = inspect_private_art(config.art_root, config.private_art_mode)
+    repo_files, file_blockers, file_warnings = inspect_required_repo_files(config.repo, config.personas)
+    blockers.extend(repo_blockers + tool_blockers + art_blockers + file_blockers)
+    warnings.extend(repo_warnings + tool_warnings + art_warnings + file_warnings)
+
+    # #466 release-RRI readiness needs private art evidence; optional/no-art modes
+    # are allowed for diagnostics but must not produce a green readiness artifact.
+    if config.private_art_mode != "required":
+        blockers.append("private art mode must be 'required' for #466 release-RRI readiness")
+
+    if config.concurrency > 1:
+        warnings.append("concurrency > 1 requested; verify support VM headroom before increasing persona parallelism")
+
+    ready = not blockers
+    report = {
+        "schema": SCHEMA,
+        "generated_at": utc_timestamp(),
+        "verdict": "passed" if ready else "blocked",
+        "ready_for_rri": ready,
+        "release_verdict": False,
+        "blockers": blockers,
+        "warnings": warnings,
+        "host": inspect_host(config.repo, config.artifact_dir),
+        "repo": repo,
+        "tools": tools,
+        "repo_files": repo_files,
+        "private_art": art,
+        "environment": env_snapshot(env or dict(os.environ)),
+        "rri_plan": {
+            "expected_personas": config.personas,
+            "canonical_personas": CANONICAL_PERSONAS,
+            "budget": config.budget,
+            "concurrency_cap": config.concurrency,
+            "port": config.port,
+            "same_sha_required": True,
+            "expected_sha": config.expected_sha,
+            "support_vm_scope": "backend/persona artifacts only; Mac built-app/native handoff evidence is supplied separately",
+            "do_not_run_on_support_vm": "qa/release_gate.sh includes Mac built-app/native proof and is not the support-VM sweep command",
+            "vm_persona_sweep_commands": build_vm_persona_commands(config),
+            "rollup_requires": [
+                "VM persona run dirs with run.json, score.json, network/image evidence, session_surface.final.json, and matching build_sha",
+                "VM story/mechanical scorer JSON, behavioral output, UI audit log, palette-live source, and image denominator evidence",
+                "Mac qa/app_handoff_gate.py handoff.json from the same SHA",
+                "qa/release_readiness.py rollup with --handoff-json and --build-sha",
+            ],
+            "mac_handoff_required": True,
+            "notes": [
+                "This preflight is not release evidence.",
+                "Pair VM persona artifacts with a Mac built-app handoff JSON from the same SHA.",
+                "If any persona score.json or build SHA is missing, RRI must remain partial/harness-contaminated.",
+            ],
+        },
+        "artifact_return": {
+            "local_artifact_dir": str(config.artifact_dir),
+            "return_target": config.artifact_return_target,
+            "lexar_note": "/Volumes/LEXAR/Codex may not exist on the VM; stage remotely and copy back to local Lexar.",
+        },
+        "teardown": {"commands": teardown_commands(config.repo, config.port, config.expected_sha), "executed": False},
+    }
+    return report
+
+
+def markdown_report(report: dict) -> str:
+    lines = [
+        "# WorldOS Support VM Preflight",
+        "",
+        f"- Schema: `{report['schema']}`",
+        f"- Generated: `{report['generated_at']}`",
+        f"- Verdict: `{report['verdict']}`",
+        f"- Ready for RRI: `{str(report['ready_for_rri']).lower()}`",
+        f"- Release verdict: `{str(report['release_verdict']).lower()}`",
+        "",
+        "## Repository",
+        "",
+        f"- Path: `{report['repo'].get('path', '')}`",
+        f"- HEAD: `{report['repo'].get('head_short') or report['repo'].get('head') or 'unknown'}`",
+        f"- Expected SHA: `{report['repo'].get('expected_sha') or 'not supplied'}`",
+        f"- Expected SHA match: `{report['repo'].get('expected_sha_match')}`",
+        f"- Dirty: `{report['repo'].get('dirty')}`",
+        "",
+        "## Blockers",
+        "",
+    ]
+    blockers = report.get("blockers") or []
+    lines.extend([f"- {item}" for item in blockers] if blockers else ["- none"])
+    lines.extend(["", "## Warnings", ""])
+    warnings = report.get("warnings") or []
+    lines.extend([f"- {item}" for item in warnings] if warnings else ["- none"])
+    lines.extend(
+        [
+            "",
+            "## RRI Plan",
+            "",
+            f"- Personas: `{','.join(report['rri_plan']['expected_personas'])}`",
+            f"- Budget: `{report['rri_plan']['budget']}`",
+            f"- Port: `{report['rri_plan']['port']}`",
+            f"- Support VM scope: `{report['rri_plan']['support_vm_scope']}`",
+            f"- Do not run on support VM: `{report['rri_plan']['do_not_run_on_support_vm']}`",
+            f"- First persona command: `{(report['rri_plan'].get('vm_persona_sweep_commands') or [''])[0]}`",
+            "",
+            "## Teardown",
+            "",
+        ]
+    )
+    lines.extend([f"- `{cmd}`" for cmd in report["teardown"]["commands"]])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    default_artifact = Path(tempfile.gettempdir()) / f"worldos-support-vm-preflight-{compact_timestamp()}"
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=os.getcwd(), help="WorldOS checkout to inspect")
+    parser.add_argument("--expected-sha", default="", help="SHA that VM evidence must match")
+    parser.add_argument("--artifact-dir", default=str(default_artifact), help="Directory for preflight artifacts")
+    parser.add_argument(
+        "--artifact-return-target",
+        default=f"/Volumes/LEXAR/Codex/worldos-support-vm-rri/preflight-{compact_timestamp()}",
+        help="Local Lexar target or operator return path to record in the report",
+    )
+    parser.add_argument("--art-root", default=os.environ.get("WORLDOS_ART_REPO_ROOT") or os.environ.get("CLAWDND_ART_REPO_ROOT") or os.getcwd())
+    parser.add_argument("--private-art-mode", choices=("required", "optional", "none"), default="required")
+    parser.add_argument("--personas", default=",".join(CANONICAL_PERSONAS))
+    parser.add_argument("--budget", default="12.00")
+    parser.add_argument("--concurrency", type=int, default=1)
+    parser.add_argument("--port", type=int, default=8785)
+    parser.add_argument("--no-fail", action="store_true", help="Write the report and exit 0 even if blockers exist")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    personas = [p.strip() for p in args.personas.split(",") if p.strip()]
+    config = PreflightConfig(
+        repo=Path(args.repo).expanduser().resolve(),
+        expected_sha=args.expected_sha.strip(),
+        artifact_dir=Path(args.artifact_dir).expanduser().resolve(),
+        artifact_return_target=args.artifact_return_target,
+        art_root=Path(args.art_root).expanduser().resolve(),
+        private_art_mode=args.private_art_mode,
+        personas=personas,
+        budget=args.budget,
+        concurrency=args.concurrency,
+        port=args.port,
+    )
+    report = build_report(config)
+    json_path = config.artifact_dir / "support_vm_preflight.json"
+    md_path = config.artifact_dir / "support_vm_preflight.md"
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    md_path.write_text(markdown_report(report), encoding="utf-8")
+
+    print(f"wrote {json_path}")
+    print(f"wrote {md_path}")
+    if report["blockers"]:
+        print("blockers:")
+        for blocker in report["blockers"]:
+            print(f"- {blocker}")
+    return 0 if args.no_fail or report["ready_for_rri"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/test_release_gate_static.py
+++ b/qa/test_release_gate_static.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from pathlib import Path
 
@@ -92,7 +93,10 @@ class ReleaseGateStaticContractTests(unittest.TestCase):
         source = (ROOT / "qa" / "ui_playtest_app.sh").read_text(encoding="utf-8")
 
         self.assertIn('PART_B_SCORE_PASS="false"', source)
-        self.assertIn('"part_b": {"persona_loop": b_res, "score_pass": b_score_pass == "true"}', source)
+        self.assertRegex(
+            source,
+            re.compile(r'"part_b": \{"persona_loop": b_res,\s+"score_pass": b_score_pass == "true"', re.MULTILINE),
+        )
         self.assertIn('[ "$player_rc" -eq 0 ] && [ -f "$RUNDIR/score.json" ]', source)
         self.assertIn('case "$PART" in', source)
         self.assertIn('[ "$PART_A_RESULT" = "PASS" ] || EXIT_OK=0', source)

--- a/qa/test_support_vm_preflight.py
+++ b/qa/test_support_vm_preflight.py
@@ -1,0 +1,334 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import qa.support_vm_preflight as preflight
+
+
+class FakeRunner:
+    def __init__(
+        self,
+        repo: Path,
+        *,
+        head: str = "deadbeefcafebabe1234567890",
+        status: str = "",
+        codex_auth_output: str = "Authenticated as codex-test",
+        chromium_path: Path | None = None,
+        create_chromium: bool = True,
+    ):
+        self.repo = repo
+        self.head = head
+        self.status = status
+        self.codex_auth_output = codex_auth_output
+        self.chromium_path = chromium_path or repo / ".fake-chromium"
+        if create_chromium:
+            self.chromium_path.parent.mkdir(parents=True, exist_ok=True)
+            self.chromium_path.write_text("fake browser", encoding="utf-8")
+
+    def __call__(self, cmd, cwd=None, timeout=8):
+        base = Path(cmd[0]).name
+        args = tuple(cmd[1:])
+        if base == "git":
+            if args == ("rev-parse", "--show-toplevel"):
+                return ok(str(self.repo))
+            if args == ("rev-parse", "--abbrev-ref", "HEAD"):
+                return ok("main")
+            if args == ("rev-parse", "HEAD"):
+                return ok(self.head)
+            if args == ("rev-parse", "--short", "HEAD"):
+                return ok(self.head[:7])
+            if args == ("rev-parse", "origin/main"):
+                return ok(self.head)
+            if args == ("status", "--short"):
+                return ok(self.status)
+            if args == ("remote", "get-url", "origin"):
+                return ok("https://github.com/electricsheephq/WorldOS.git")
+            if args == ("--version",):
+                return ok("git version 2.50.0")
+        if args == ("--version",):
+            versions = {
+                "python3": "Python 3.13.0",
+                "uv": "uv 0.11.17",
+                "node": "v22.22.1",
+                "npm": "10.9.4",
+                "npx": "10.9.4",
+                "codex": "codex-cli 0.120.0",
+                "claude": "claude 0.0.0-test",
+                "jq": "jq-1.7",
+                "curl": "curl 8.0.0",
+                "lsof": "lsof test",
+                "timeout": "timeout test",
+                "pkill": "pkill test",
+                "pgrep": "pgrep test",
+                "ps": "ps test",
+            }
+            return ok(versions.get(base, f"{base} test-version"))
+        if base == "node" and args[:1] == ("-e",) and "chromium.executablePath" in args[1]:
+            return ok(str(self.chromium_path))
+        if base == "node" and args[:1] == ("-e",):
+            return ok("/fake/node_modules/playwright/index.js")
+        if base == "codex" and args == ("auth", "status"):
+            return ok(self.codex_auth_output)
+        return fail("unexpected command")
+
+
+def ok(stdout=""):
+    return {"ok": True, "exit_code": 0, "stdout": stdout, "stderr": "", "timed_out": False}
+
+
+def fail(stderr="failed"):
+    return {"ok": False, "exit_code": 1, "stdout": "", "stderr": stderr, "timed_out": False}
+
+
+def fake_which(name: str) -> str | None:
+    return f"/fake/{name}"
+
+
+def make_art_root(tmp: Path) -> Path:
+    images = tmp / "content" / "worlds" / "_private" / "baldurs-gate" / "images"
+    for scope in ("portrait_alfira", "scene_camp"):
+        scope_dir = images / scope
+        scope_dir.mkdir(parents=True, exist_ok=True)
+        (scope_dir / "image.png").write_text("fake", encoding="utf-8")
+    return tmp
+
+
+def make_config(tmp: Path, *, expected_sha: str = "deadbee") -> preflight.PreflightConfig:
+    repo = tmp / "WorldOS"
+    repo.mkdir()
+    for rel in (
+        "qa/ui_playtest_app.sh",
+        "qa/run_duo.sh",
+        "qa/assert_behavioral.py",
+        "qa/ui_audit_health.sh",
+        "qa/release_readiness.py",
+        "qa/play_player_duo.txt",
+        "qa/playwright/palette_server.js",
+        "scripts/play.sh",
+        "scripts/play_party.sh",
+        "qa/play_player_browser_newbie.txt",
+        "qa/play_player_browser_veteran.txt",
+        "qa/play_player_browser_adversarial.txt",
+        "qa/play_player_browser_narrative.txt",
+        "qa/play_player_browser_optimizer.txt",
+    ):
+        path = repo / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("test", encoding="utf-8")
+    art_root = make_art_root(tmp / "art")
+    return preflight.PreflightConfig(
+        repo=repo,
+        expected_sha=expected_sha,
+        artifact_dir=tmp / "artifacts",
+        artifact_return_target="/Volumes/LEXAR/Codex/worldos-support-vm-rri/test",
+        art_root=art_root,
+        private_art_mode="required",
+        personas=list(preflight.CANONICAL_PERSONAS),
+        budget="12.00",
+        concurrency=1,
+        port=8785,
+    )
+
+
+class SupportVMPreflightTests(unittest.TestCase):
+    def test_redaction_scrubs_common_secret_forms(self):
+        raw = (
+            "OPENAI_API_KEY=sk-proj-abc123456789 "
+            "ANTHROPIC_API_KEY=anthropic-secret-value "
+            "Bearer live-token-123456789"
+        )
+        redacted = preflight.redact(raw)
+        self.assertNotIn("abc123456789", redacted)
+        self.assertNotIn("anthropic-secret-value", redacted)
+        self.assertNotIn("live-token-123456789", redacted)
+        self.assertIn("[REDACTED]", redacted)
+
+    def test_build_sha_matches_requires_seven_characters(self):
+        self.assertFalse(preflight.build_sha_matches("deadbe", "deadbeef"))
+        self.assertFalse(preflight.build_sha_matches("deadbeef", "deadbe"))
+        self.assertTrue(preflight.build_sha_matches("deadbeefcafebabe", "deadbee"))
+        self.assertTrue(preflight.build_sha_matches("deadbee", "deadbeefcafebabe"))
+
+    def test_private_art_required_blocks_and_optional_warns(self):
+        with tempfile.TemporaryDirectory() as td:
+            missing_root = Path(td) / "missing-art"
+            info, blockers, warnings = preflight.inspect_private_art(missing_root, "required")
+            self.assertFalse(info["private_root_present"])
+            self.assertTrue(blockers)
+            self.assertFalse(warnings)
+
+            info, blockers, warnings = preflight.inspect_private_art(missing_root, "optional")
+            self.assertFalse(info["private_root_present"])
+            self.assertFalse(blockers)
+            self.assertTrue(warnings)
+
+            art_root = make_art_root(Path(td) / "art")
+            info, blockers, warnings = preflight.inspect_private_art(art_root, "required")
+            self.assertTrue(info["private_root_present"])
+            self.assertGreaterEqual(info["image_png_count"], 2)
+            self.assertFalse(blockers)
+
+    def test_cli_defaults_require_private_art(self):
+        args = preflight.parse_args([])
+        self.assertEqual(args.private_art_mode, "required")
+
+    def test_env_snapshot_redacts_secret_values_but_keeps_safe_paths(self):
+        snapshot = preflight.env_snapshot(
+            {
+                "OPENAI_API_KEY": "sk-proj-supersecret123456",
+                "ANTHROPIC_API_KEY": "anthropic-supersecret",
+                "CODEX_TOKEN": "codex-token-secret",
+                "WORLDOS_ART_REPO_ROOT": "/Users/lume/ClawDnD-val",
+                "UNRELATED_SECRET": "not-inspected",
+            }
+        )
+        blob = json.dumps(snapshot)
+        self.assertNotIn("supersecret123456", blob)
+        self.assertNotIn("anthropic-supersecret", blob)
+        self.assertNotIn("codex-token-secret", blob)
+        self.assertNotIn("not-inspected", blob)
+        self.assertEqual(snapshot["WORLDOS_ART_REPO_ROOT"]["value"], "/Users/lume/ClawDnD-val")
+
+    def test_teardown_commands_are_record_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            commands = preflight.teardown_commands(Path(td) / "worldos", 8785, "deadbee")
+            self.assertTrue(commands)
+            self.assertTrue(any("8785" in command for command in commands))
+            self.assertFalse(any(command == "pkill -f 'viewer/server.py' || true" for command in commands))
+            config = make_config(Path(td))
+            report = preflight.build_report(config, runner=FakeRunner(config.repo), which=fake_which, env={})
+            self.assertFalse(report["teardown"]["executed"])
+
+    def test_report_contains_required_sections_with_canonical_personas(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+            report = preflight.build_report(
+                config,
+                runner=FakeRunner(config.repo),
+                which=fake_which,
+                env={"WORLDOS_ART_REPO_ROOT": str(config.art_root)},
+            )
+            self.assertTrue(report["ready_for_rri"])
+            self.assertFalse(report["release_verdict"])
+            for section in (
+                "host",
+                "repo",
+                "tools",
+                "repo_files",
+                "private_art",
+                "environment",
+                "rri_plan",
+                "artifact_return",
+                "teardown",
+            ):
+                self.assertIn(section, report)
+            self.assertEqual(report["rri_plan"]["expected_personas"], preflight.CANONICAL_PERSONAS)
+            self.assertEqual(report["blockers"], [])
+
+    def test_report_flags_dirty_repo_and_expected_sha_mismatch(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td), expected_sha="1234567")
+            report = preflight.build_report(
+                config,
+                runner=FakeRunner(config.repo, head="deadbeefcafebabe", status=" M viewer/app.js"),
+                which=fake_which,
+                env={},
+            )
+            self.assertFalse(report["ready_for_rri"])
+            blocker_text = "\n".join(report["blockers"])
+            self.assertIn("dirty", blocker_text)
+            self.assertIn("does not match expected SHA", blocker_text)
+
+    def test_missing_expected_sha_blocks_rri_readiness(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td), expected_sha="")
+            report = preflight.build_report(config, runner=FakeRunner(config.repo), which=fake_which, env={})
+            self.assertFalse(report["ready_for_rri"])
+            self.assertIn("expected SHA is required", "\n".join(report["blockers"]))
+
+    def test_optional_private_art_mode_blocks_release_rri_readiness(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+            config.private_art_mode = "optional"
+            report = preflight.build_report(config, runner=FakeRunner(config.repo), which=fake_which, env={})
+            self.assertFalse(report["ready_for_rri"])
+            self.assertIn("private art mode must be 'required'", "\n".join(report["blockers"]))
+
+    def test_vm_plan_does_not_suggest_mac_release_gate_command(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+            report = preflight.build_report(config, runner=FakeRunner(config.repo), which=fake_which, env={})
+            plan_blob = json.dumps(report["rri_plan"])
+            self.assertIn("qa/ui_playtest_app.sh", plan_blob)
+            self.assertIn("WOS_APP_PART=B", plan_blob)
+            self.assertNotIn("qa/release_gate.sh --personas", plan_blob)
+            self.assertTrue(report["rri_plan"]["mac_handoff_required"])
+
+    def test_missing_persona_lane_tool_blocks_readiness(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+
+            def which_without_claude(name: str) -> str | None:
+                return None if name == "claude" else f"/fake/{name}"
+
+            report = preflight.build_report(config, runner=FakeRunner(config.repo), which=which_without_claude, env={})
+            self.assertFalse(report["ready_for_rri"])
+            self.assertIn("required VM tool missing: claude", report["blockers"])
+
+    def test_missing_playwright_chromium_blocks_readiness(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+            missing_browser = Path(td) / "missing-chromium"
+            report = preflight.build_report(
+                config,
+                runner=FakeRunner(config.repo, chromium_path=missing_browser, create_chromium=False),
+                which=fake_which,
+                env={},
+            )
+            self.assertFalse(report["ready_for_rri"])
+            self.assertIn("Playwright Chromium executable is not installed", "\n".join(report["blockers"]))
+
+    def test_missing_persona_brief_blocks_readiness(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+            (config.repo / "qa" / "play_player_browser_optimizer.txt").unlink()
+            report = preflight.build_report(config, runner=FakeRunner(config.repo), which=fake_which, env={})
+            self.assertFalse(report["ready_for_rri"])
+            self.assertIn("qa/play_player_browser_optimizer.txt", "\n".join(report["blockers"]))
+
+    def test_codex_not_authenticated_output_does_not_false_green(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+            report = preflight.build_report(
+                config,
+                runner=FakeRunner(config.repo, codex_auth_output="Not authenticated as user@example.com"),
+                which=fake_which,
+                env={},
+            )
+            self.assertFalse(report["ready_for_rri"])
+            self.assertEqual(report["tools"]["codex_auth"]["auth_status"], "not_proven")
+            self.assertIn("Codex CLI auth/profile status is not proven", report["blockers"])
+            self.assertNotIn("auth_probe_excerpt", report["tools"]["codex_auth"])
+            self.assertNotIn("user@example.com", json.dumps(report))
+
+    def test_codex_auth_classifier_uses_word_boundaries(self):
+        self.assertFalse(preflight.has_auth_marker("inactive", ("active",)))
+        self.assertFalse(preflight.has_auth_marker("notauthenticated", ("authenticated",)))
+        self.assertTrue(preflight.has_auth_marker("authenticated as codex", ("authenticated",)))
+
+    def test_codex_active_alone_does_not_prove_auth(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+            report = preflight.build_report(
+                config,
+                runner=FakeRunner(config.repo, codex_auth_output="profile active"),
+                which=fake_which,
+                env={},
+            )
+            self.assertFalse(report["ready_for_rri"])
+            self.assertEqual(report["tools"]["codex_auth"]["auth_status"], "command_ok_unclassified")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a read-only support-VM preflight artifact writer for #466 same-SHA RRI readiness
- record host/repo/tool/Codex-auth/private-art/repo-file/env/RRI-plan/teardown fields without making a release verdict
- tighten docs so the 32GB VM sweep is gated by a redacted preflight artifact before heavy persona work

## Safety / invariants
- does not launch the app, mutate engine state, run persona sweeps, or commit evidence/private art
- keeps Mac built-app handoff proof separate from support-VM persona artifacts
- refuses ready-for-RRI on missing expected SHA, dirty checkout, missing required tools/scripts/briefs, missing required private art, missing Playwright Chromium, or unproven Codex auth

## Verification
- python3 -m pytest qa/test_support_vm_preflight.py -q
- python3 -m pytest qa/test_release_gate_static.py qa/test_release_readiness.py qa/test_support_vm_preflight.py -q
- python3 -m py_compile qa/support_vm_preflight.py
- git diff --check
- local dry run wrote /Volumes/LEXAR/Codex/worldos-support-vm-preflight/local-dryrun-20260601-support-vm-preflight-v5/support_vm_preflight.json and correctly blocked readiness for local SHA/auth mismatch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced preflight checklist with explicit verification fields for support VM testing workflows
  * Updated release readiness operating guidelines to require preflight validation before sweeps

* **New Features**
  * Added support VM readiness verification tooling with comprehensive environment and dependency checks

* **Tests**
  * Added comprehensive test coverage for readiness verification workflows
  * Updated existing test assertions for improved validation accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->