### PR TITLE
docs: add agent QA navigation map

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -4,8 +4,9 @@
 > Born from the 2026-05-31 reorientation: the prior loop scored a HEADLESS PROXY served from
 > WORKTREES WITH NO ART, so every visible defect (no palette, no images, no map, unformatted
 > chronicle, phantom companion) sailed past. This runbook makes that impossible to repeat.
-> Companions: `WorldOS-OPERATING-GOAL.md` (the gate), `qa/GUI_WORKBOOK.md` (the live punch-list),
-> `qa/release_readiness.py` (the RRI scorer), `qa/SCORECARD.md` (the ledger).
+> Companions: `WorldOS-OPERATING-GOAL.md` (current truth), `qa/QA_TOOLS.md` (QA command index),
+> `docs/AGENT_GRADE_APP_TESTABILITY.md` (app-status/evidence contract), `qa/GUI_WORKBOOK.md`
+> (historical punch-list), `qa/release_readiness.py` (the RRI scorer), `qa/SCORECARD.md` (the ledger).
 >
 > Takeover routing, 2026-06-01: `/Users/lume/ClawDnD-val` is the synced local app/private-art checkout
 > and the default place to build/run/test the GUI and native app. The latest product-code app proof is
@@ -14,6 +15,50 @@
 > Lexar is for evidence/snapshots/logs, not the default runtime tree, because macOS permission prompts
 > can break AI/browser tests when assets live on the external drive. For tracked GUI edits, prefer a
 > same-disk local worktree; use Lexar worktrees only for non-GUI slices that will not launch against art.
+
+## Fresh GUI Agent Quick Start
+
+Before a main implementation agent spends time on long persona runs, run the hybrid handoff gate on
+the current commit. It catches stale tabs, dead launchers, missing private art, missing actor/actions,
+failed `/move`, no narration, console/network errors, provider trace failures, and evidence gaps.
+
+```bash
+cd /Users/lume/ClawDnD-val
+python3 qa/app_handoff_gate.py \
+  --web-beats 5 \
+  --built-beats 5 \
+  --codex-moves 1 \
+  --art-root /Users/lume/ClawDnD-val \
+  --scripted-budget 1.00 \
+  --codex-budget 3.00 \
+  --timeout 90 \
+  --codex-timeout 240
+```
+
+The run writes `/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/<run-id>/`. Review
+`handoff.json` first, then each gate's `app-evidence/manifest.json`, `app-status.*.json`,
+`session-surface.*.json`, screenshots, moves, console/network/action logs, and provider trace summary.
+`handoff_score=100` means the GUI wiring loop is trustworthy for implementation velocity. It is not
+release-ready evidence by itself.
+
+| Command | Use it for | Do not treat it as |
+|---|---|---|
+| `scripts/play.sh ... 8799` | Fast local LOOK loop on the canonical repo with private art | Built-app proof |
+| `qa/app_handoff_gate.py` | Fast web + built-app scripted smoke + short built-app Codex provider playtest | Full release verdict |
+| `qa/ui_playtest_app.sh` | Lower-level native app harness, native Part A+B evidence, failure buckets | Complete five-persona sweep by itself |
+| `qa/ui_playtest.sh` | Blind browser persona diagnostics for #324 | Built-app product proof |
+| `qa/release_readiness.py --handoff-json ...` | RRI rollup and release verdict when paired with complete persona evidence | A substitute for missing persona artifacts |
+
+| Port / route | Meaning | Guardrail |
+|---|---|---|
+| `8799 /openworlds/` | Canonical fast iteration surface from `/Users/lume/ClawDnD-val` | Use for LOOK, then rebuild/prove the app |
+| `8899 /openworlds/` | Scripted/dev harness default | Valid only when same-port `/app-status` is live |
+| `8765` or dynamic app ports | Native app spawned viewer | Read `run.json` or `/app-status.viewer.port`; do not guess |
+| `8990-8999` | Browser persona harness range | Diagnostic browser evidence unless paired with app proof |
+
+Handoff requires five enabled actions today because scripted/Codex smoke proves the main play loop.
+Release RRI's palette-live gate is stricter: it still requires at least six enabled actions on a
+`can_act:true` surface with disk-backed evidence.
 
 ## The two surfaces (never confuse them again)
 - **ITERATE — visible, playable, fast:** the OpenWorlds viewer served **from the local canonical repo**

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -72,6 +72,28 @@
 > Read order on resume: the STATE-OF-TRUTH block above → this file → `WorldOS-GUI-RUNBOOK.md` →
 > `WorldOS-RUNBOOK.md` → `qa/SCORECARD.md`. (NORTH-STAR is the long-game ceiling, not needed to act.)
 
+## Agent Navigation / Current TOC
+
+Use this map before opening older audit docs. It is meant for a fresh agent that needs to know
+which file answers which question.
+
+| Need | Read / run |
+|---|---|
+| Current release truth, last proof, next action | This file, especially the state block above |
+| Fast GUI/native app loop | `WorldOS-GUI-RUNBOOK.md` |
+| Repo architecture, invariants, broader dev loop | `WorldOS-RUNBOOK.md` and `docs/ARCHITECTURE.md` |
+| QA command index | `qa/QA_TOOLS.md` |
+| App-status, handoff, evidence contract | `docs/AGENT_GRADE_APP_TESTABILITY.md` |
+| Evidence ledger | `qa/SCORECARD.md` |
+| Historical GUI punch-list | `qa/GUI_WORKBOOK.md` |
+| Blind browser persona harness | `qa/UI_PLAYTEST.md` |
+| Old page-by-page audits and native roadmaps | `docs/OPENWORLDS_UI_AUDIT.md`, `docs/OPENWORLDS_NATIVE_APP_ROADMAP.md`, `docs/ui-audit/` |
+
+Incoming-agent rule: if the goal is to catch broken wiring, stale browser tabs, dead controls,
+missing art, missing actor/actions, failed moves, console/network errors, or evidence gaps before
+spending budget on long playtests, start with `qa/app_handoff_gate.py` from the GUI runbook. It is
+the handoff/velocity gate only. Full non-partial RRI remains the release verdict.
+
 ---
 
 ## 0. FIRST PRINCIPLES — what are we actually trying to do?

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -6,8 +6,9 @@
 > agent notes such as `CLAUDE.md` are intentionally local-only and gitignored.
 >
 > **Takeover routing, 2026-06-01:** current release/gate state lives in
-> `WorldOS-OPERATING-GOAL.md` first, then `WorldOS-GUI-RUNBOOK.md`, then `qa/SCORECARD.md`.
-> The work queue later in this file is historical unless it agrees with those sources.
+> `WorldOS-OPERATING-GOAL.md` first, then `WorldOS-GUI-RUNBOOK.md`, `qa/QA_TOOLS.md`, and
+> `qa/SCORECARD.md`. The work queue later in this file is historical unless it agrees with those
+> sources.
 > **Local/VM routing, 2026-06-01:** `/Users/lume/ClawDnD-val` is the synced local app/private-art
 > checkout and should be used for GUI/native-app testing. Use `/Volumes/LEXAR/Codex` for evidence,
 > snapshots, and logs; do not make Lexar the default GUI runtime tree because external-drive

--- a/docs/AGENT_GRADE_APP_TESTABILITY.md
+++ b/docs/AGENT_GRADE_APP_TESTABILITY.md
@@ -10,6 +10,9 @@ not change the game architecture: the engine remains the sole writer, the native
 app/OpenWorlds viewer remains a thin reader plus `/move` intent submitter, and
 the built app remains release truth.
 
+Current command routing lives in `qa/QA_TOOLS.md` and `WorldOS-GUI-RUNBOOK.md`. This file defines
+the contract those tools must satisfy.
+
 ## Related Work
 
 - [#324](https://github.com/electricsheephq/WorldOS/issues/324): AI playtester harness with five personas.
@@ -239,6 +242,21 @@ score.
 `qa/app_handoff_gate.py` is the fast hybrid gate for Codex-led GUI work. It is
 the command a main implementation agent should run before spending budget on
 longer exploratory/persona playtests.
+
+Default local invocation:
+
+```bash
+cd /Users/lume/ClawDnD-val
+python3 qa/app_handoff_gate.py \
+  --web-beats 5 \
+  --built-beats 5 \
+  --codex-moves 1 \
+  --art-root /Users/lume/ClawDnD-val \
+  --scripted-budget 1.00 \
+  --codex-budget 3.00 \
+  --timeout 90 \
+  --codex-timeout 240
+```
 
 The handoff gate writes
 `/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/<run-id>/handoff.json`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,8 @@
 # WorldOS — Architecture
 
+> Architecture map only. For current agent routing, GUI/native app proof, and QA commands, start with
+> `WorldOS-OPERATING-GOAL.md`, `WorldOS-GUI-RUNBOOK.md`, and `qa/QA_TOOLS.md`.
+
 WorldOS is a Claude Code plugin: an **AI Dungeon Master + voiced AI companion** that
 plays D&D 5e. Its center of gravity is a **living-world engine** — the DM *generates*
 an epic, mature story live inside a persistent, canon-anchored world, with deterministic

--- a/docs/OPENWORLDS_FIDELITY_PLAN.md
+++ b/docs/OPENWORLDS_FIDELITY_PLAN.md
@@ -1,5 +1,9 @@
 # OpenWorlds Fidelity Rollout Plan
 
+> Historical rollout plan for the OpenWorlds integration. Current agent routing, app proof commands,
+> and release gating live in `WorldOS-OPERATING-GOAL.md`, `WorldOS-GUI-RUNBOOK.md`, `qa/QA_TOOLS.md`,
+> and `qa/SCORECARD.md`.
+
 This document supersedes the SwiftUI repaint direction explored in PR #123.
 OpenWorlds should be integrated as an exact web surface first, then wired to
 WorldOS read models screen by screen.

--- a/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
+++ b/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
@@ -1,5 +1,10 @@
 # OpenWorlds Native App Roadmap
 
+> Historical roadmap. Use this for architecture intent and old sprint context, not as the current
+> validation path. Current GUI/native app proof starts from `/Users/lume/ClawDnD-val`, uses
+> `qa/app_handoff_gate.py` or `qa/ui_playtest_app.sh` for app evidence, and uses
+> `qa/release_readiness.py` for release verdicts. See `WorldOS-GUI-RUNBOOK.md` and `qa/QA_TOOLS.md`.
+
 Date: 2026-05-26
 
 ## Correction

--- a/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
+++ b/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
@@ -1,7 +1,7 @@
 # OpenWorlds Native App Roadmap
 
 > Historical roadmap. Use this for architecture intent and old sprint context, not as the current
-> validation path. Current GUI/native app proof starts from `/Users/lume/ClawDnD-val`, uses
+> validation path. Current GUI/native app proof starts from the canonical local app/private-art checkout, uses
 > `qa/app_handoff_gate.py` or `qa/ui_playtest_app.sh` for app evidence, and uses
 > `qa/release_readiness.py` for release verdicts. See `WorldOS-GUI-RUNBOOK.md` and `qa/QA_TOOLS.md`.
 

--- a/docs/OPENWORLDS_UI_AUDIT.md
+++ b/docs/OPENWORLDS_UI_AUDIT.md
@@ -1,5 +1,10 @@
 # OpenWorlds App — Page-by-Page UI/UX Audit (2026-05-27)
 
+> Historical snapshot. This audit predates the built-app `/move` wiring, app-status/handoff harness,
+> scripted provider, and stable agent hooks. It is still useful as UX backlog context, but current app
+> proof and release routing live in `WorldOS-OPERATING-GOAL.md`, `WorldOS-GUI-RUNBOOK.md`,
+> `qa/QA_TOOLS.md`, and `qa/SCORECARD.md`.
+
 **Method:** live walkthrough of every screen via the preview server (`127.0.0.1:8799/openworlds/`).
 **This is the same UI the desktop app ("WorldOS") shows** — the app launches `viewer/server.py` and loads `/openworlds/`. (`/dashboard` is the *old* `dashboard.html`, the `play.sh` surface — not this UI.) So fixes here land in the app on rebuild/restart.
 **Scope of this doc:** audit + scored backlog ONLY. No product code changed. We prioritize/sequence together before fixing.

--- a/docs/RELEASE_1.0_CHECKLIST.md
+++ b/docs/RELEASE_1.0_CHECKLIST.md
@@ -1,5 +1,10 @@
 # WorldOS 1.0.0 — Release Checklist
 
+> Historical checklist. Do not execute this as the current release path. Current release truth requires
+> the hardened non-partial RRI in `qa/release_readiness.py`, with same-SHA built-app proof and complete
+> persona evidence recorded in `qa/SCORECARD.md`. Start from `WorldOS-OPERATING-GOAL.md`,
+> `WorldOS-GUI-RUNBOOK.md`, and `qa/QA_TOOLS.md`.
+
 **Scope:** local/personal 1.0 build. The bundled `baldurs-gate` world ships as-is for
 personal use (Wizards Fan Content Policy). Public distribution and notarization are
 deferred to 1.0.1 (see `macos/WorldOSApp/RELEASE_CHECKLIST.md` for the signing state).

--- a/docs/ui-audit/MASTER_TRACKER.md
+++ b/docs/ui-audit/MASTER_TRACKER.md
@@ -1,7 +1,9 @@
 # OpenWorlds UI/UX — Master Tracker (Phase 5 deep audit, 2026-05-29)
 
-> **Source-of-truth index** for the page-by-page UI/UX audit landed under `docs/ui-audit/`.
-> Updated by the implementation agent as issues land. Mirror of `#242` Phase 5 status.
+> Historical index for the page-by-page UI/UX audit landed under `docs/ui-audit/`.
+> Use this for backlog context only. Current GUI/native app proof and QA routing live in
+> `WorldOS-OPERATING-GOAL.md`, `WorldOS-GUI-RUNBOOK.md`, `qa/QA_TOOLS.md`, and `qa/SCORECARD.md`.
+> Mirror of `#242` Phase 5 status.
 >
 > **Audit method:** live walkthrough of every screen at `127.0.0.1:8799/openworlds/`, viewports
 > 1440×900 and 1512×982; sources read for every `viewer/openworlds/screen-*.jsx`; findings anchored
@@ -265,7 +267,7 @@ The Wave-1 cross-cutting items are partially done; Wave 2-4 per-screen criticals
 
 ### Wave 4 — per-screen minors + trivials
 
-18. Implementation agent files individual tickets per per-screen audit doc Minor/Trivial rows as work is picked up. The audit docs hold the source of truth — don't pre-file 60+ Minor tickets.
+18. Implementation agent files individual tickets per per-screen audit doc Minor/Trivial rows as work is picked up. The audit docs hold historical finding detail; current routing and gate truth live in the top-level runbooks.
 
 ### Wave 5 — Camp (Loop 2 lane)
 

--- a/macos/WorldOSApp/RELEASE_CHECKLIST.md
+++ b/macos/WorldOSApp/RELEASE_CHECKLIST.md
@@ -1,5 +1,9 @@
 # WorldOS Native macOS Release Checklist
 
+> Native packaging checklist only. For current GUI/native app proof, use
+> `WorldOS-GUI-RUNBOOK.md` and `qa/QA_TOOLS.md`; for release truth, use the non-partial RRI path in
+> `WorldOS-OPERATING-GOAL.md` and `qa/release_readiness.py`.
+
 The v0.3 macOS lane starts with a locally signed development app. Notarization is
 release-trust work after the local shell, provider bridge, and dashboard hosting
 are stable.

--- a/qa/GUI_WORKBOOK.md
+++ b/qa/GUI_WORKBOOK.md
@@ -1,10 +1,14 @@
-# WorldOS GUI Workbook — the living punch-list (verified on the REAL surface)
+# WorldOS GUI Workbook — historical GUI punch-list (verified findings)
 
-> Single source of truth for the GUI test→fix→look loop. Each row: defect, VERIFIED root cause
-> (file:line), fix, status, proof. "Verified" = observed on the live playable surface
-> (8799 from CANONICAL — has _private art) or read from canonical source. NOT a proxy guess.
-> Iteration surface: `http://127.0.0.1:8799/openworlds/` (`scripts/play.sh` from canonical).
-> Gate surface: built `dist/WorldOS.app` via `qa/ui_playtest_app.sh`. See `WorldOS-GUI-RUNBOOK.md`.
+> This file preserves verified GUI findings and punch-list rows. Current operating truth lives in
+> `WorldOS-OPERATING-GOAL.md`, `WorldOS-GUI-RUNBOOK.md`, `qa/QA_TOOLS.md`, and `qa/SCORECARD.md`.
+> Historical rows may mention old SHAs or pre-handoff routing. Use them for context, not for deciding
+> current release state. "Verified" means observed on the live playable surface or read from canonical
+> source at the time recorded, not a proxy guess.
+>
+> Current routing: iteration surface `http://127.0.0.1:8799/openworlds/` from `/Users/lume/ClawDnD-val`;
+> gate surface built `dist/WorldOS.app`; fast handoff command `qa/app_handoff_gate.py`; release verdict
+> `qa/release_readiness.py`.
 
 ## ★ HEADLINE (historical canonical f5500ac, verified 2026-05-31, 3 clean reads on live canonical 8799)
 **Most of what the owner saw broken was a STALE-BUILD / WORKTREE-WITHOUT-ART artifact, not broken canonical code.** Served correctly from canonical:
@@ -13,11 +17,12 @@
 - DM cold-open narration = 4842 chars with **27 paragraph breaks** (the prose IS well-formed).
 ⇒ The fix for "no images / no map / no palette" is **serve/build WITH `_private` art present** (infra), not 3 code PRs. The real *code* bugs are layout prominence + render formatting + the silent companion.
 
-Post-#465/#468 note: the code baseline for the next clean RRI is `b15ad3c` or newer, and the current
-doc-sync baseline is `e4078c7`. RRI release scoring requires a disk-backed `palette_live` proof with
-**≥6 enabled actions** on a `can_act:true` surface. The 5-action canonical read above remains useful
-orientation, but it is not release proof; issue #466 must either prove the built app now meets the live
-palette gate or fail with an actionable artifact path.
+Post-#504/#505 note: the latest product-code fast handoff proof is `fd9dba5`
+(`handoff-20260601T085319Z-fd9dba5`), which passed web scripted smoke, built-app scripted smoke, and a
+short built-app Codex-provider playtest with zero evidence gaps. That 5-action handoff is an
+implementation-velocity gate, not release proof. RRI release scoring still requires a disk-backed
+`palette_live` proof with **>=6 enabled actions** on a `can_act:true` surface plus complete same-SHA
+persona evidence. Issue #466 must either produce that clean RRI or fail with actionable artifact paths.
 
 ## Phase 0 — infra (DONE)
 - ✅ `launch.json` repointed off the deprecated LEXAR copy → canonical/8799/`/openworlds/`/live state.

--- a/qa/GUI_WORKBOOK.md
+++ b/qa/GUI_WORKBOOK.md
@@ -18,7 +18,7 @@
 ⇒ The fix for "no images / no map / no palette" is **serve/build WITH `_private` art present** (infra), not 3 code PRs. The real *code* bugs are layout prominence + render formatting + the silent companion.
 
 Post-#504/#505 note: the latest product-code fast handoff proof is `fd9dba5`
-(`handoff-20260601T085319Z-fd9dba5`), which passed web scripted smoke, built-app scripted smoke, and a
+(`handoff-20260601T085319Z-fd9dba5`), which passed web-scripted smoke, built-app scripted smoke, and a
 short built-app Codex-provider playtest with zero evidence gaps. That 5-action handoff is an
 implementation-velocity gate, not release proof. RRI release scoring still requires a disk-backed
 `palette_live` proof with **>=6 enabled actions** on a `can_act:true` surface plus complete same-SHA

--- a/qa/QA_TOOLS.md
+++ b/qa/QA_TOOLS.md
@@ -1,0 +1,90 @@
+# WorldOS QA Tools Index
+
+This is the command map for agents. It does not replace the release truth in
+`WorldOS-OPERATING-GOAL.md`, the GUI loop in `WorldOS-GUI-RUNBOOK.md`, or the evidence ledger in
+`qa/SCORECARD.md`.
+
+Default local paths:
+
+- App/private-art checkout: `/Users/lume/ClawDnD-val`.
+- Evidence root: `/Volumes/LEXAR/Codex`.
+- Heavy persona/backend sweeps: GitHub CI or the owner-provided support VM after explicit preflight.
+
+## Fast GUI And Native App Gates
+
+| Tool | Use it for | Writes / reads | Do not use when |
+|---|---|---|---|
+| `qa/app_handoff_gate.py` | The current fastest handoff gate: web scripted smoke, built `dist/WorldOS.app` scripted smoke, short built-app Codex playtest, and bounded hook checks on one SHA | `/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/<run-id>/handoff.json` plus gate evidence bundles | You need the final release verdict; run RRI instead |
+| `qa/app_smoke_scripted.py` | Deterministic multi-beat scripted smoke against the web/viewer harness | Screenshots, app-status snapshots, moves, `smoke.json` | You need real-provider behavior or native shell proof |
+| `qa/ui_playtest_app.sh` | Built-app/native harness with native Part A+B evidence and stable failure buckets | Native app run dir, app-status snapshots, screenshots, move/chat artifacts | You only need a quick static or web smoke |
+| `qa/export_app_evidence.py` | Normalize a live app or run dir into a reviewable evidence bundle | `manifest.json`, status/session snapshots, screenshots, traces, logs | You are trying to prove behavior without first running a gate |
+| `qa/app_failure_buckets.py` | Classify harness failures into the stable app bucket list | Bucket JSON / shell-readable output | You need product fixes; this only labels failures |
+| `qa/app_handoff_hooks.js` | Static/same-port hook probe for core agent-driving controls | Hook-check JSON inside handoff evidence | You need human exploratory testing; this is a bounded locator check |
+
+Copy-paste fast handoff command:
+
+```bash
+cd /Users/lume/ClawDnD-val
+python3 qa/app_handoff_gate.py \
+  --web-beats 5 \
+  --built-beats 5 \
+  --codex-moves 1 \
+  --art-root /Users/lume/ClawDnD-val \
+  --scripted-budget 1.00 \
+  --codex-budget 3.00 \
+  --timeout 90 \
+  --codex-timeout 240
+```
+
+Read `handoff.json` first. A `handoff_score` of `100` means the GUI implementation agent has a
+trustworthy fast loop for wiring and core controls. It does not mean release-ready.
+
+Stable app failure buckets are:
+`no_app`, `no_launcher`, `no_provider`, `no_art`, `no_actor`, `no_actions`, `move_rejected`,
+`no_narration`, `console_error`, and `permission_prompt`.
+
+## Release And RRI
+
+| Tool | Use it for | Required evidence | Do not use when |
+|---|---|---|---|
+| `qa/release_readiness.py` | The Release Readiness Index rollup and only release verdict | Complete same-SHA app/persona evidence, including optional `--handoff-json` Mac proof | You only need fast GUI wiring confidence |
+| `qa/release_gate.sh` | Orchestrate the release sweep over the canonical persona set | Built app, persona runs, behavior/UI/image/palette evidence | The support VM or Mac proof preflight is incomplete |
+
+RRI requires a non-partial five-persona result on one build SHA. A handoff gate can feed the native
+app proof through `--handoff-json`, but it cannot fill in missing persona artifacts.
+
+## Browser And Persona Diagnostics
+
+| Tool | Use it for | Writes | Do not treat it as |
+|---|---|---|---|
+| `qa/ui_playtest.sh` | Blind browser persona playtest for #324 | `qa/ui_playtest_runs/<runid>/` | Built-app proof |
+| `qa/ui_playtest_aggregate.py` | Combine browser persona findings | Aggregate report/score | Release verdict |
+| `qa/ui_playtest_score.py` | Score a browser UI playtest run | `score.json` | Proof that the native shell works |
+
+Use these when you want empirical UX friction from a browser-driven player. They are valuable for
+finding broken buttons and confusing flows, but the product is still `dist/WorldOS.app`.
+
+## Story, Mechanics, And Engine Quality
+
+| Tool | Use it for | Notes |
+|---|---|---|
+| `qa/run_duo.sh` | AI player + DM duo for story/mechanical quality | Heavy local run; prefer narrow or remote execution |
+| `qa/run_combat_sprint.sh` | Fast bug-finder for combat fidelity | Good for finding engine/adherence issues, not broad story score |
+| `qa/run_party.sh` | Player + companion agents + DM ensemble | Exercises companion and betrayal lanes |
+| `qa/score.sh` | Primary story/mechanical/5e scoring | Uses the repo rubrics and schemas |
+| `qa/score_openclaw.sh` | Stricter gpt-5.4 cross-check | Cross-check only, not the primary score baseline |
+
+## Evidence Reading Order
+
+For any app run, review in this order:
+
+1. `handoff.json`, `RRI.json`, or gate verdict JSON.
+2. `manifest.json` and its `review_entrypoint`.
+3. `app-status.initial.json` / `app-status.final.json`.
+4. `session-surface.initial.json` / `session-surface.final.json`.
+5. Screenshots and accessibility snapshots.
+6. `moves.ndjson`, `actions.ndjson`, `console.ndjson`, `network.ndjson`.
+7. Provider trace summary and raw trace snippets.
+
+If a screenshot shows a playable page but same-port `/app-status` is missing, classify it as
+`no_launcher`. Stale rendered browser tabs are not evidence.

--- a/qa/SCORECARD.md
+++ b/qa/SCORECARD.md
@@ -5,6 +5,16 @@
 > `*` = RED-capped (gate failed → scores forced ≤ 2.5; not a real quality reading).
 > Scorer: claude `score.sh` unless noted `[oc]` (gpt-5.4, grades ~1.5 harsher).
 
+## Current Evidence Index
+
+| Question | Current answer |
+|---|---|
+| Latest fast GUI handoff proof | `handoff-20260601T085319Z-fd9dba5` under `/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/` |
+| Latest release verdict | None after RRI hardening |
+| Latest RRI attempt | `gate-f5500ac-partial` is partial / harness-contaminated, not release evidence |
+| Fast GUI gate command | `python3 qa/app_handoff_gate.py --web-beats 5 --built-beats 5 --codex-moves 1 --art-root /Users/lume/ClawDnD-val --scripted-budget 1.00 --codex-budget 3.00 --timeout 90 --codex-timeout 240` |
+| Next release action | #466 clean non-partial RRI on one SHA, pairing same-SHA Mac handoff proof with complete persona/backend artifacts |
+
 ## Built-app gameplay proof ledger
 
 > Diagnostic product evidence from the shipped Mac surface. These rows prove built-app behavior but do not

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -2,6 +2,8 @@
 
 > Source of truth for HOW we measure a playtest. Current as of 2026-05-26.
 > The running results ledger is `qa/SCORECARD.md`.
+> For the current app/native handoff tools and RRI routing, start with `qa/QA_TOOLS.md` and
+> `WorldOS-GUI-RUNBOOK.md`; this file describes the story/mechanical scoring model.
 
 The fitness function = **1 hard behavioral gate** (deterministic pass/fail) + **3 LLM
 lenses** (each 1–5). The gate is the honest floor; the lenses grade quality above it.

--- a/qa/UI_PLAYTEST.md
+++ b/qa/UI_PLAYTEST.md
@@ -1,5 +1,10 @@
 # AI Playtester harness (issue #324)
 
+> Current routing note: this is the blind browser persona diagnostic harness. It is valuable for
+> empirical UX friction, but it is not the built-app product gate. For the fast built-app handoff
+> gate run `qa/app_handoff_gate.py`; for lower-level native app evidence use `qa/ui_playtest_app.sh`;
+> for release truth use the non-partial RRI path in `qa/release_readiness.py`.
+
 A **blind UI/UX test**: an AI "player" drives the real `/openworlds/` browser UI with no
 source-code access and reports every bug + UX gap it hits. Different signal from the
 code-reading audit — this finds bugs by *trying to play*.


### PR DESCRIPTION
## Summary
- add a central agent navigation/current TOC to `WorldOS-OPERATING-GOAL.md`
- add a fresh GUI agent quick start, command table, and port truth table to `WorldOS-GUI-RUNBOOK.md`
- add `qa/QA_TOOLS.md` as the QA command index for handoff, built-app smoke, browser persona diagnostics, RRI, and story/mechanics lanes
- mark older audit/checklist/roadmap docs as historical so they do not override current handoff/RRI truth

## Licensing / CLA

- [x] I have read `CLA.md` and submit this contribution under the WorldOS Contributor License Agreement.
- [x] I have not included confidential information, private customer data, private imported content, or third-party-restricted material.
- [x] Any third-party material in this PR is clearly identified with source and license. (No third-party material added.)

## Validation
- `git diff --check`
- reference-existence check for all newly linked docs and QA tools
- navigation-pointer check for handoff and RRI docs

## Notes
Docs-only. No app build, handoff gate, RRI, or heavy local suite was run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized runbooks and guides with improved cross-references for better discoverability
  * Clearly marked historical documents to prevent reliance on outdated procedures
  * Created new comprehensive QA tools reference guide with workflow routing
  * Added clarified instructions for validation and testing procedures
  * Updated evidence tracking and release-related documentation for current workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->