### PR TITLE
docs: clarify app-proof SHA after docs-only tips

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -10,8 +10,8 @@
 >
 > Takeover routing, 2026-06-01: `/Users/lume/ClawDnD-val` is the synced local app/private-art checkout
 > and the default place to build/run/test the GUI and native app. The latest same-SHA app proof is
-> `9545383` after #508; the app handoff gate was rerun on current `main` and passed 100/100.
-> Verify `origin/main` before acting.
+> `9545383` after #508; later docs-only commits may sit above that proof without becoming new product
+> proof. Verify `origin/main` before acting, and rerun the handoff gate before pairing newer persona artifacts.
 > Lexar is for evidence/snapshots/logs, not the default runtime tree, because macOS permission prompts
 > can break AI/browser tests when assets live on the external drive. For tracked GUI edits, prefer a
 > same-disk local worktree; use Lexar worktrees only for non-GUI slices that will not launch against art.

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -5,13 +5,13 @@
      Post-compaction agents: this 6-line block is ground truth. Do NOT reconstruct
      state from scattered docs or old plans; trust this, verify the sha, then act.
      ──────────────────────────────────────────────────────────────────────────
-     AS OF:        2026-06-01T17:07:00+07:00 #508 support-VM preflight merged; current handoff build is 9545383
+     AS OF:        2026-06-01T17:24:00+07:00 docs wording pass; latest handoff build remains 9545383
      MAIN BASELINE:
-                   Current `origin/main` / canonical checkout is `9545383` (PR #508 merged the
-                   repo-owned support-VM preflight artifact gate). Product behavior was reproved on
-                   this exact SHA by the app handoff gate below. Earlier product-code baseline
-                   `fd9dba5` remains preserved as historical proof, but is no longer the latest
-                   same-SHA target for #466.
+                   Latest same-SHA app-proof target is `9545383` (PR #508 merged the repo-owned
+                   support-VM preflight artifact gate, and the app handoff gate was rerun on that
+                   exact SHA). Current `origin/main` may contain docs-only commits above that proof;
+                   do not treat docs-only tips as new product proof. Earlier product-code baseline
+                   `fd9dba5` remains preserved as historical proof.
      CANONICAL:    /Users/lume/ClawDnD-val is now the synced local app/private-art checkout and
                    the default place to build/run/test the Mac app. Keep GUI/runtime tests on this
                    local disk so macOS does not prompt on Lexar-hosted assets.
@@ -227,7 +227,7 @@ verifier; can revert the goal to "fix" anytime.
 
 ---
 
-## 9. CURRENT STATUS (2026-06-01T17:07:00+07:00 — #508 preflight merged; latest app proof is 9545383)
+## 9. CURRENT STATUS (2026-06-01T17:24:00+07:00 — latest same-SHA app proof is 9545383)
 
 - Repo truth stabilization merged in PR #465, UX-first doc sync merged in PR #468, first-minute
   click/title chrome proof merged in PR #470, local/Lexar/support-VM routing merged in PR #471,
@@ -301,7 +301,7 @@ verifier; can revert the goal to "fix" anytime.
   gaps across all three manifests, and Codex trace `failed_or_error_count=0` with `line_count=177`.
   `qa.release_readiness.validate_handoff_json(..., "fd9dba5")` returned `valid=True` and `gaps=0`.
 - The post-#508 handoff gate `handoff-20260601T100304Z-9545383` then reproved the same fast GUI
-  velocity loop on current `main`: web-scripted smoke 5 moves, built-app scripted smoke 5 moves,
+  velocity loop on product build `9545383`: web-scripted smoke 5 moves, built-app scripted smoke 5 moves,
   built-app Codex playtest 1 move, private art present, active player, five enabled actions, zero evidence
   gaps across all three manifests, and Codex trace `failed_or_error_count=0` with `line_count=80`.
   `qa.release_readiness.validate_handoff_json(..., "9545383")` returned `valid=True` and `gaps=0`.

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -27,7 +27,7 @@
 > If an operator hands you local session notes or decision records, treat them as
 > private working artifacts unless they are intentionally promoted into tracked docs.
 >
-> Last updated: 2026-06-01T17:07:00+07:00 (`9545383` is the latest same-SHA app-proof build; release notes below are historical context).
+> Last updated: 2026-06-01T17:24:00+07:00 (`9545383` is the latest same-SHA app-proof build; docs-only tips may sit above it, and release notes below are historical context).
 >
 > **Graphics & game-types roadmap (canonical):** the long-term plan for the kinds of games
 > WorldOS can produce (GT0 narrative dashboard → GT1 SNES pixel → GT2 Pillars/BG isometric)
@@ -319,7 +319,8 @@ preflight artifact gate.
 The local app/private-art checkout should stay fast-forwarded to `origin/main`; the only current gate
 truth lives in `WorldOS-OPERATING-GOAL.md` + `WorldOS-GUI-RUNBOOK.md` + `qa/SCORECARD.md`. Do not use
 this section to decide release state. The next sprint is UX-first (#467):
-fast handoff play is proven diagnostically on `9545383`, including private art, Codex DM, an active player,
+fast handoff play is proven diagnostically on `9545383` rather than automatically on later docs-only tips,
+including private art, Codex DM, an active player,
 five enabled actions, one accepted/resolved `/move`, no evidence-manifest gaps, zero failed/error provider
 trace events, and a post-merge `handoff_score=100`. With #479 proven and #504/#505 merged, run #466 only after
 support-VM routing/auth/config preflight is explicit; this session's read-only check found the local


### PR DESCRIPTION
## Summary\n- Clarifies that 9545383 is the latest same-SHA app-proof target, not necessarily the latest docs-only main tip.\n- Updates the Operating Goal, GUI Runbook, and main Runbook so future #466 work either pins support-VM persona artifacts to 9545383 or reruns Mac handoff on a newer SHA.\n- Prevents recursive docs-only commits from being misread as new product proof.\n\n## Tests\n- git diff --check\n- python3 -m pytest qa/test_release_readiness.py qa/test_support_vm_preflight.py -q\n- validate_handoff_json('/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260601T100304Z-9545383/handoff.json', '9545383') -> valid=True, gaps=0, score=100\n\n## Licensing / CLA\n- [x] I have the right to submit this contribution under the project license.\n- [x] No private art, credentials, raw evidence bundles, or restricted material are committed.\n\n## Release note\n- Docs-only truth clarification. This is not a release verdict; #466 still requires the full non-partial five-persona RRI.\n