### PR TITLE
docs: sync app-testability evidence status

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -135,9 +135,9 @@ Release RRI's palette-live gate is stricter: it still requires at least six enab
 - Agent-grade testing progress as of `9545383`: #481 app-status is closed, #482 deterministic scripted
   provider is merged, #483 failure buckets are merged, #484 stable accessibility/DOM hooks are merged,
   #504's hybrid handoff gate is merged and green on `main`, #505's RRI handoff bridge is merged, and
-  #508's support-VM preflight artifact gate is merged.
-  #485 evidence bundle completion and
-  #486 gate-split follow-through remain active. A scripted `:8899` harness surface can prove app
+  #508's support-VM preflight artifact gate is merged. #485 evidence bundle completion and #486 gate-split
+  follow-through are closed in GitHub; #466 remains the release gate and #467 remains the UX-first sprint.
+  A scripted `:8899` harness surface can prove app
   observability, but it is not built-app release proof unless it came from `dist/WorldOS.app` /
   `qa/ui_playtest_app.sh`.
 

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -63,8 +63,8 @@
                    same SHA before rollup. The 32GB support VM runs heavy backend/persona sweeps
                    only after the preflight writes a redacted ready-for-RRI artifact.
                    If the VM route is still unavailable, record that as the blocker and
-                   file/fix repo-side RRI harness gaps only if found. Continue #485/#486 for
-                   evidence export and gate split follow-through; #481/#482/#483/#484 are closed.
+                   file/fix repo-side RRI harness gaps only if found. #481/#482/#483/#484/#485/#486
+                   are closed; #466 remains the release-gate issue and #467 remains the UX-first sprint.
                    Keep sprint work UX-first (#467): first-turn playability, clickability/chrome,
                    launcher clarity, live-response feel, and CRPG depth before more hardening/proxy/security work.
      DISCIPLINE:   ≥2 clean reads before any fix (channel fabricates under host load); ONE heavy claude -p stream;

--- a/docs/AGENT_GRADE_APP_TESTABILITY.md
+++ b/docs/AGENT_GRADE_APP_TESTABILITY.md
@@ -26,6 +26,11 @@ the contract those tools must satisfy.
 - [#485](https://github.com/electricsheephq/WorldOS/issues/485): one evidence bundle per app playtest.
 - [#486](https://github.com/electricsheephq/WorldOS/issues/486): split smoke, provider playtest, and RRI gates.
 
+As of the `9545383` handoff-proof baseline, #481 through #486 are closed in
+GitHub and implemented in the fast app-testability lane. #466 remains open for
+the clean non-partial five-persona RRI, and #467 remains open for UX-first
+release-readiness polish.
+
 ## App-Status v1
 
 `app-status` v1 is a read-only behavior contract for the live OpenWorlds

--- a/qa/SCORECARD.md
+++ b/qa/SCORECARD.md
@@ -9,7 +9,7 @@
 
 | Question | Current answer |
 |---|---|
-| Latest fast GUI handoff proof | `handoff-20260601T085319Z-fd9dba5` under `/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/` |
+| Latest fast GUI handoff proof | `handoff-20260601T100304Z-9545383` under `/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/` |
 | Latest release verdict | None after RRI hardening |
 | Latest RRI attempt | `gate-f5500ac-partial` is partial / harness-contaminated, not release evidence |
 | Fast GUI gate command | `python3 qa/app_handoff_gate.py --web-beats 5 --built-beats 5 --codex-moves 1 --art-root /Users/lume/ClawDnD-val --scripted-budget 1.00 --codex-budget 3.00 --timeout 90 --codex-timeout 240` |


### PR DESCRIPTION
## Summary\n- Updates the Scorecard current evidence index to the latest fast GUI handoff proof, handoff-20260601T100304Z-9545383.\n- Corrects runbook/testability status now that #485 and #486 are closed in GitHub.\n- Keeps #466 as the active release gate and #467 as the UX-first sprint lane.\n\n## Tests\n- git diff --check\n- python3 -m pytest qa/test_release_readiness.py qa/test_support_vm_preflight.py -q\n- validate_handoff_json('/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260601T100304Z-9545383/handoff.json', '9545383') -> valid=True, gaps=0, score=100\n\n## Licensing / CLA\n- [x] I have the right to submit this contribution under the project license.\n- [x] No private art, credentials, raw evidence bundles, or restricted material are committed.\n\n## Release note\n- Docs-only truth correction. This is not a release verdict; #466 still requires the full non-partial five-persona RRI.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal project documentation to reflect current milestone and sprint status, including latest handoff evidence references and outstanding work item tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->