### PR TITLE
[codex] Harden support VM origin preflight

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -241,9 +241,10 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
 - Do **not** use it as proof for Mac-only surfaces: `WorldOS.app` build/launch, native #356, and built-app
   UI play evidence stay on this Mac or macOS CI.
 - VM preflight before any RRI sweep: record VM identity, repo checkout path, branch/SHA, Codex CLI version,
-  auth/profile status, `uv`, Node/npm/Playwright/Chromium availability, private-art availability or explicit
-  backend-only/no-art classification, env vars, budget/concurrency cap, teardown commands, and the artifact
-  return path under `/Volumes/LEXAR/Codex`. Use the repo-owned preflight artifact writer before #466:
+  GitHub `origin/main` queryability, auth/profile status, `uv`, Node/npm/Playwright/Chromium availability,
+  private-art availability or explicit backend-only/no-art classification, env vars, budget/concurrency cap,
+  teardown commands, and the artifact return path under `/Volumes/LEXAR/Codex`. Use the repo-owned preflight
+  artifact writer before #466:
   ```bash
   python3 qa/support_vm_preflight.py \
     --repo /root/worldos-qa/WorldOS \
@@ -254,19 +255,16 @@ release truth still requires `qa/ui_playtest_app.sh` Part A+B and the full RRI s
     --artifact-return-target /Volumes/LEXAR/Codex/worldos-support-vm-rri/9545383-preflight
   ```
   The script is read-only with respect to WorldOS state; it writes `support_vm_preflight.json` and
-  `support_vm_preflight.md`, redacts secrets, and exits non-zero if same-SHA/tool/auth/private-art blockers
-  would make the RRI sweep untrustworthy.
-- Current preflight status (2026-06-01): this local Codex Desktop session can parse an SSH alias for
-  `support-vm-1`, but `ssh -o BatchMode=yes support-vm-1 ...` failed DNS resolution (`nodename nor servname
-  provided`). Do not start #466 there until operator routing is restored and the preflight fields above are
-  written to Lexar evidence.
+  `support_vm_preflight.md`, redacts secrets, and exits non-zero if same-SHA/origin/tool/auth/private-art
+  blockers would make the RRI sweep untrustworthy.
 - Read-only VM scout (2026-06-01): an operator-only endpoint note can reach `evaos-support` without printing
   the endpoint. Capacity/tooling look suitable for heavy sweeps: ~32 GB RAM, 16 CPUs, ~537 GB free disk, `git`,
   `python3`, `uv 0.11.17`, Node `v22.22.1`, npm `10.9.4`, `codex-cli 0.120.0`, Playwright modules, and private
   art. The VM WorldOS checkout at `/root/worldos-qa/WorldOS` is clean but stale at `4524b3e` and behind
-  the `9545383` proof baseline; Codex auth/config is not proven; `/Volumes/LEXAR/Codex` does not exist on the VM.
-  Before #466, approve/sync the VM checkout, prove Codex auth, set a remote staging path, and copy artifacts
-  back to local Lexar.
+  the `9545383` proof baseline; `git` cannot query/sync the HTTPS origin in batch mode; Codex auth/config is
+  not proven; `/Volumes/LEXAR/Codex` does not exist on the VM. Before #466, approve/sync the VM checkout, prove
+  Codex auth, make `origin/main` queryable from the VM, set a remote staging path, and copy artifacts back to
+  local Lexar.
 - RRI rollup rule: Mac/local evidence supplies native Part A and built-app screenshots; VM artifacts can supply
   persona, behavior, image/network, palette-live, and score evidence only when `run.json`, `score.json`,
   `session_surface.final.json`, `network.ndjson`, and build SHA are present. Missing or mixed-SHA artifacts

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -5,7 +5,7 @@
      Post-compaction agents: this 6-line block is ground truth. Do NOT reconstruct
      state from scattered docs or old plans; trust this, verify the sha, then act.
      ──────────────────────────────────────────────────────────────────────────
-     AS OF:        2026-06-01T17:24:00+07:00 docs wording pass; latest handoff build remains 9545383
+     AS OF:        2026-06-01T18:10:00+07:00 support-VM origin-readiness pass; latest handoff build remains 9545383
      MAIN BASELINE:
                    Latest same-SHA app-proof target is `9545383` (PR #508 merged the repo-owned
                    support-VM preflight artifact gate, and the app handoff gate was rerun on that
@@ -22,13 +22,13 @@
                    in local operator-only evidence/runbooks, not tracked repo docs. Use it for
                    heavy backend/persona sweeps only after Codex/config/credentials are intentionally
                    installed. Mac-built `.app` smoke/play proof stays on this Mac or macOS CI.
-                   Current local preflight note: `ssh -G support-vm-1` resolves only to the alias;
-                   `ssh -o BatchMode=yes support-vm-1 ...` could not resolve the hostname in this
-                   Codex Desktop session. A read-only operator-endpoint scout reached `evaos-support`
-                   (~32 GB RAM, 16 CPUs) with WorldOS at `/root/worldos-qa/WorldOS`, but that checkout
-                   was stale (`4524b3e`) and behind the `9545383` app-proof baseline; Codex auth/config was not
-                   proven. Restore/verify operator routing, fast-forward the VM repo, verify Codex auth,
-                   and define artifact return before running #466 there.
+                   Current local preflight note: a read-only operator-endpoint scout reached
+                   `evaos-support` (~32 GB RAM, 16 CPUs) with WorldOS at `/root/worldos-qa/WorldOS`,
+                   but that checkout was stale (`4524b3e`) and behind the `9545383` app-proof baseline.
+                   GitHub origin query/sync failed in batch mode (`could not read Username for
+                   'https://github.com'`), Codex auth/config was not proven, and artifact return needs
+                   remote staging plus copy-back to Lexar. Do not run #466 there until an operator
+                   approves repo sync/auth setup and the preflight passes.
      LAST MEASURED GATE BUILD:
                    f5500ac produced qa/RRI.json = 2.7/10, but this is PARTIAL /
                    HARNESS-CONTAMINATED evidence: only newbie wrote score.json; the other
@@ -61,7 +61,8 @@
                    the VM persona artifacts with the `9545383` Mac handoff JSON above. If a
                    newer release-candidate SHA is used instead, rerun the Mac handoff on that
                    same SHA before rollup. The 32GB support VM runs heavy backend/persona sweeps
-                   only after the preflight writes a redacted ready-for-RRI artifact.
+                   only after the preflight writes a redacted ready-for-RRI artifact, including a
+                   successful `origin/main` query from the VM.
                    If the VM route is still unavailable, record that as the blocker and
                    file/fix repo-side RRI harness gaps only if found. #481/#482/#483/#484/#485/#486
                    are closed; #466 remains the release-gate issue and #467 remains the UX-first sprint.
@@ -227,7 +228,7 @@ verifier; can revert the goal to "fix" anytime.
 
 ---
 
-## 9. CURRENT STATUS (2026-06-01T17:24:00+07:00 — latest same-SHA app proof is 9545383)
+## 9. CURRENT STATUS (2026-06-01T18:10:00+07:00 — latest same-SHA app proof is 9545383)
 
 - Repo truth stabilization merged in PR #465, UX-first doc sync merged in PR #468, first-minute
   click/title chrome proof merged in PR #470, local/Lexar/support-VM routing merged in PR #471,
@@ -270,11 +271,12 @@ verifier; can revert the goal to "fix" anytime.
   sweep runs on a newer `origin/main` tip, rerun the Mac handoff on that same SHA first.
   Heavy backend/persona sweeps belong on the owner-provided 32GB support VM (`support-vm-1`) once auth/config
   are intentionally installed there; connection details are kept outside tracked docs. In this Codex Desktop
-  session the local SSH alias for `support-vm-1` did not resolve; a read-only operator-endpoint scout reached
-  the VM and confirmed `evaos-support` has ~32 GB RAM, 16 CPUs, `git`, `python3`, `uv`, Node/npm, Codex CLI,
-  Playwright, and private art, but its WorldOS checkout is `4524b3e` and behind the `9545383` proof baseline; Codex
-  auth/config was not proven. Restore/verify VM routing, fast-forward the VM checkout, verify auth, and define
-  artifact return before the heavy sweep. Mac-only built-app launch/play proof stays on this Mac or macOS CI.
+  session a read-only operator-endpoint scout reached the VM and confirmed `evaos-support` has ~32 GB RAM,
+  16 CPUs, `git`, `python3`, `uv`, Node/npm, Codex CLI, Playwright, and private art, but its WorldOS checkout
+  is `4524b3e` and behind the `9545383` proof baseline; GitHub origin query/sync failed in batch mode; Codex
+  auth/config was not proven. Get operator approval for VM repo sync/auth setup, verify `origin/main` is
+  queryable from the VM, and define artifact return before the heavy sweep. Mac-only built-app launch/play
+  proof stays on this Mac or macOS CI.
 - Built-app diagnostic evidence exists, but release truth is still absent. The PR #475 pre-merge app-code
   proof `8bd833f` (`codex-app-headproof-20260601T043909`) was trace-clean. The post-merge main proof
   `32ca561` (`post475-main-app-proof-20260601T051230`) was playable with private art, Alfira, five enabled

--- a/qa/QA_TOOLS.md
+++ b/qa/QA_TOOLS.md
@@ -49,9 +49,12 @@ Stable app failure buckets are:
 |---|---|---|---|
 | `qa/release_readiness.py` | The Release Readiness Index rollup and only release verdict | Complete same-SHA app/persona evidence, including optional `--handoff-json` Mac proof | You only need fast GUI wiring confidence |
 | `qa/release_gate.sh` | Orchestrate the release sweep over the canonical persona set | Built app, persona runs, behavior/UI/image/palette evidence | The support VM or Mac proof preflight is incomplete |
+| `qa/support_vm_preflight.py` | Read-only readiness artifact before a support-VM persona sweep | VM identity, repo SHA, `origin/main` queryability, tool/auth/art status, return path, teardown plan | You are trying to fix or sync the VM; get operator approval first |
 
 RRI requires a non-partial five-persona result on one build SHA. A handoff gate can feed the native
-app proof through `--handoff-json`, but it cannot fill in missing persona artifacts.
+app proof through `--handoff-json`, but it cannot fill in missing persona artifacts. The support-VM
+preflight must pass before a VM sweep can count toward #466; if `origin/main` is not queryable from
+the VM, fix the VM repo credentials/sync lane before running personas.
 
 ## Browser And Persona Diagnostics
 

--- a/qa/support_vm_preflight.py
+++ b/qa/support_vm_preflight.py
@@ -178,6 +178,29 @@ def git_text(repo: Path, args: Sequence[str], runner: CommandRunner) -> str:
     return (result.get("stdout") or "").strip() if result.get("ok") else ""
 
 
+def inspect_origin_main_query(repo: Path, runner: CommandRunner) -> dict:
+    result = runner(["git", "ls-remote", "origin", "refs/heads/main"], repo, 15)
+    stdout = (result.get("stdout") or "").strip()
+    remote_head = ""
+    if result.get("ok") and stdout:
+        first_field = stdout.split()[0]
+        if re.fullmatch(r"[0-9a-fA-F]{40}", first_field):
+            remote_head = first_field.lower()
+    info = {
+        "ok": bool(result.get("ok")) and bool(remote_head),
+        "exit_code": result.get("exit_code"),
+        "timed_out": bool(result.get("timed_out")),
+        "head": remote_head,
+        "head_short": remote_head[:7],
+    }
+    if not info["ok"]:
+        combined = "\n".join(
+            part for part in (result.get("stdout") or "", result.get("stderr") or "") if part
+        ).strip()
+        info["error_redacted"] = redacted_remote_url(combined)[:500]
+    return info
+
+
 def inspect_repo(repo: Path, expected_sha: str, runner: CommandRunner) -> tuple[dict, list[str], list[str]]:
     blockers: list[str] = []
     warnings: list[str] = []
@@ -193,6 +216,13 @@ def inspect_repo(repo: Path, expected_sha: str, runner: CommandRunner) -> tuple[
         "expected_sha": expected_sha or "",
         "expected_sha_match": None,
         "remote_origin": "",
+        "origin_main_query": {
+            "ok": False,
+            "exit_code": None,
+            "timed_out": False,
+            "head": "",
+            "head_short": "",
+        },
     }
 
     if not repo.exists() or not repo.is_dir():
@@ -210,6 +240,7 @@ def inspect_repo(repo: Path, expected_sha: str, runner: CommandRunner) -> tuple[
     info["head_short"] = git_text(repo, ["rev-parse", "--short", "HEAD"], runner)
     info["origin_main"] = git_text(repo, ["rev-parse", "origin/main"], runner)
     info["remote_origin"] = redacted_remote_url(git_text(repo, ["remote", "get-url", "origin"], runner))
+    info["origin_main_query"] = inspect_origin_main_query(repo, runner)
     status = git_text(repo, ["status", "--short"], runner)
     info["dirty"] = bool(status)
     if status:
@@ -229,6 +260,14 @@ def inspect_repo(repo: Path, expected_sha: str, runner: CommandRunner) -> tuple[
         warnings.append(
             f"HEAD {info['head_short'] or info['head']} differs from origin/main {info['origin_main'][:7]}"
         )
+    if not info["origin_main_query"].get("ok"):
+        blockers.append("repo origin/main is not queryable from this VM; configure approved GitHub credentials before RRI")
+    else:
+        remote_head = info["origin_main_query"].get("head")
+        if remote_head and info["origin_main"] and remote_head != info["origin_main"]:
+            warnings.append(
+                f"local origin/main {info['origin_main'][:7]} differs from queried origin/main {remote_head[:7]}"
+            )
 
     return info, blockers, warnings
 
@@ -605,6 +644,8 @@ def markdown_report(report: dict) -> str:
         f"- Expected SHA: `{report['repo'].get('expected_sha') or 'not supplied'}`",
         f"- Expected SHA match: `{report['repo'].get('expected_sha_match')}`",
         f"- Dirty: `{report['repo'].get('dirty')}`",
+        f"- Origin/main query: `{str(report['repo'].get('origin_main_query', {}).get('ok')).lower()}`",
+        f"- Queried origin/main: `{report['repo'].get('origin_main_query', {}).get('head_short') or 'unknown'}`",
         "",
         "## Blockers",
         "",

--- a/qa/test_support_vm_preflight.py
+++ b/qa/test_support_vm_preflight.py
@@ -11,17 +11,23 @@ class FakeRunner:
         self,
         repo: Path,
         *,
-        head: str = "deadbeefcafebabe1234567890",
+        head: str = "deadbeefcafebabe1234567890abcdef12345678",
         status: str = "",
         codex_auth_output: str = "Authenticated as codex-test",
         chromium_path: Path | None = None,
         create_chromium: bool = True,
+        remote_query_ok: bool = True,
+        remote_query_head: str | None = None,
+        remote_query_stderr: str = "could not read Username for 'https://github.com'",
     ):
         self.repo = repo
         self.head = head
         self.status = status
         self.codex_auth_output = codex_auth_output
         self.chromium_path = chromium_path or repo / ".fake-chromium"
+        self.remote_query_ok = remote_query_ok
+        self.remote_query_head = remote_query_head or head
+        self.remote_query_stderr = remote_query_stderr
         if create_chromium:
             self.chromium_path.parent.mkdir(parents=True, exist_ok=True)
             self.chromium_path.write_text("fake browser", encoding="utf-8")
@@ -44,6 +50,10 @@ class FakeRunner:
                 return ok(self.status)
             if args == ("remote", "get-url", "origin"):
                 return ok("https://github.com/electricsheephq/WorldOS.git")
+            if args == ("ls-remote", "origin", "refs/heads/main"):
+                if self.remote_query_ok:
+                    return ok(f"{self.remote_query_head}\trefs/heads/main")
+                return fail(self.remote_query_stderr)
             if args == ("--version",):
                 return ok("git version 2.50.0")
         if args == ("--version",):
@@ -239,6 +249,39 @@ class SupportVMPreflightTests(unittest.TestCase):
             blocker_text = "\n".join(report["blockers"])
             self.assertIn("dirty", blocker_text)
             self.assertIn("does not match expected SHA", blocker_text)
+
+    def test_origin_main_query_failure_blocks_readiness(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+            report = preflight.build_report(
+                config,
+                runner=FakeRunner(
+                    config.repo,
+                    remote_query_ok=False,
+                    remote_query_stderr="fatal: could not read Username for 'https://token@example.com'",
+                ),
+                which=fake_which,
+                env={},
+            )
+            self.assertFalse(report["ready_for_rri"])
+            self.assertFalse(report["repo"]["origin_main_query"]["ok"])
+            self.assertIn("repo origin/main is not queryable", "\n".join(report["blockers"]))
+            self.assertIn("[REDACTED]@", report["repo"]["origin_main_query"]["error_redacted"])
+            self.assertNotIn("token@example.com", json.dumps(report))
+
+    def test_origin_main_query_records_remote_head(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+            remote_head = "1111111222222233333334444444555555566666"
+            report = preflight.build_report(
+                config,
+                runner=FakeRunner(config.repo, remote_query_head=remote_head),
+                which=fake_which,
+                env={},
+            )
+            self.assertTrue(report["ready_for_rri"])
+            self.assertEqual(report["repo"]["origin_main_query"]["head"], remote_head)
+            self.assertIn("queried origin/main", "\n".join(report["warnings"]).lower())
 
     def test_missing_expected_sha_blocks_rri_readiness(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- add a read-only origin/main query probe to `qa/support_vm_preflight.py` so support-VM RRI readiness fails before stale or unauthenticated repo state can burn a persona sweep
- record the queried remote SHA in JSON/Markdown preflight artifacts and redact any credential-bearing Git error output
- update the current truth docs and QA tools index to route #466 through origin-queryable support-VM preflight evidence

## Why
A read-only support VM scout found a clean but stale checkout plus HTTPS origin auth failure. The previous preflight could catch an expected-SHA mismatch, but it could not prove the VM could query GitHub origin before a heavy five-persona RRI run.

## Validation
- `python3 -m pytest qa/test_support_vm_preflight.py -q`
- `python3 -m pytest qa/test_release_readiness.py qa/test_support_vm_preflight.py -q`
- `python3 -m py_compile qa/support_vm_preflight.py`
- `git diff --check`
- `coderabbit review --agent -t uncommitted` -> 0 issues

## Notes
This is not release evidence and does not run VM mutations. It only hardens the readiness artifact that must pass before #466 can use support-VM persona artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated support VM preflight process documentation and runbook guidance to clarify requirements and current validation gaps.

* **Chores**
  * Enhanced internal QA tooling to verify remote repository queryability as part of VM readiness checks.
  * Updated test infrastructure to support new validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->