### PR TITLE
Fix Codex login probe in support VM preflight

### DIFF
--- a/qa/support_vm_preflight.py
+++ b/qa/support_vm_preflight.py
@@ -462,7 +462,8 @@ def inspect_tools(
         )
     if codex_path:
         codex["auth_status"] = "not_proven"
-        result = runner([codex_path, "auth", "status"], repo, 10)
+        codex["auth_probe_command"] = "codex login status"
+        result = runner([codex_path, "login", "status"], repo, 10)
         combined = f"{result.get('stdout') or ''}\n{result.get('stderr') or ''}".strip()
         lower = combined.lower()
         codex.update(

--- a/qa/test_support_vm_preflight.py
+++ b/qa/test_support_vm_preflight.py
@@ -30,11 +30,13 @@ class FakeRunner:
         self.remote_query_ok = remote_query_ok
         self.remote_query_head = remote_query_head or head
         self.remote_query_stderr = remote_query_stderr
+        self.commands = []
         if create_chromium:
             self.chromium_path.parent.mkdir(parents=True, exist_ok=True)
             self.chromium_path.write_text("fake browser", encoding="utf-8")
 
     def __call__(self, cmd, cwd=None, timeout=8):
+        self.commands.append(tuple(cmd))
         base = Path(cmd[0]).name
         args = tuple(cmd[1:])
         if base == "git":
@@ -80,7 +82,7 @@ class FakeRunner:
             return ok(str(self.chromium_path))
         if base == "node" and args[:1] == ("-e",):
             return ok("/fake/node_modules/playwright/index.js")
-        if base == "codex" and args == ("auth", "status"):
+        if base == "codex" and args == ("login", "status"):
             return ok(self.codex_auth_output)
         return fail("unexpected command")
 
@@ -407,6 +409,16 @@ class SupportVMPreflightTests(unittest.TestCase):
             self.assertFalse(report["ready_for_rri"])
             self.assertEqual(report["tools"]["codex_auth"]["auth_status"], "not_proven")
             self.assertIn("Codex CLI auth/profile status is not proven", report["blockers"])
+
+    def test_codex_auth_probe_uses_supported_login_status(self):
+        with tempfile.TemporaryDirectory() as td:
+            config = make_config(Path(td))
+            runner = FakeRunner(config.repo)
+            report = preflight.build_report(config, runner=runner, which=fake_which, env={})
+            self.assertTrue(report["ready_for_rri"])
+            self.assertEqual(report["tools"]["codex_auth"]["auth_probe_command"], "codex login status")
+            self.assertTrue(any(tuple(command[1:]) == ("login", "status") for command in runner.commands))
+            self.assertFalse(any(tuple(command[1:]) == ("auth", "status") for command in runner.commands))
 
     def test_codex_auth_classifier_uses_word_boundaries(self):
         self.assertFalse(preflight.has_auth_marker("inactive", ("active",)))


### PR DESCRIPTION
## Summary
- replace the unsupported `codex auth status` readiness probe with the current `codex login status` command
- record the auth probe command in `support_vm_preflight.json` for operator review
- add a regression test proving the preflight uses `login status` and never calls the stale `auth status` path

## Why
#466 depends on a trustworthy support-VM preflight before any heavy persona sweep. Current Codex CLI builds expose `codex login status`; `codex auth status` exits with an unrecognized-subcommand error, so the preflight would falsely block Codex readiness even when auth is configured.

## Tests
- `python3 -m pytest qa/test_support_vm_preflight.py -q`
- `python3 -m pytest qa/test_support_vm_preflight.py qa/test_release_readiness.py -q`
- `python3 -m py_compile qa/support_vm_preflight.py`
- `git diff --check`
- local diagnostic preflight artifact: `/Volumes/LEXAR/Codex/worldos-support-vm-preflight/local-codex-login-probe-6d107d6/support_vm_preflight.json` proved `codex_auth.auth_status=proven` via `codex login status` while correctly remaining non-ready for unrelated local-worktree blockers

## Licensing / CLA
- [x] I have submitted or will submit the required CLA if applicable.
- [x] This PR does not add third-party code or assets requiring new license review.
- [x] This PR does not include private art, secrets, credentials, or evidence bundles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication verification to use the current supported command method for Codex status checks.

* **Tests**
  * Added test coverage to verify authentication probe functionality and command usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->