### PR TITLE
Classify Codex safety monitor warnings

### DIFF
--- a/qa/app_handoff_gate.py
+++ b/qa/app_handoff_gate.py
@@ -158,11 +158,15 @@ def provider_trace_summary(play_state: Path, provider: str) -> dict[str, Any]:
         if payload:
             payload.setdefault("provider", provider)
             payload.setdefault("failed_or_error_count", 0)
+            payload.setdefault("provider_infra_warning_count", 0)
+            payload.setdefault("provider_infra_samples", [])
             return payload
 
     failed = 0
+    infra_warnings = 0
     parsed = 0
     samples: list[str] = []
+    infra_samples: list[str] = []
     patterns = ("*stdout*.jsonl", "*stderr*.log", "*.ndjson", "*.jsonl", "*.log", "*.txt")
     seen: set[Path] = set()
     for pattern in patterns:
@@ -198,6 +202,12 @@ def provider_trace_summary(play_state: Path, provider: str) -> dict[str, Any]:
                             samples.append(line[:300])
                     continue
                 lower = line.lower()
+                is_infra_warning = "codex_core::arc_monitor" in lower and "safety monitor returned non-success status" in lower
+                if is_infra_warning:
+                    infra_warnings += 1
+                    if len(infra_samples) < 5:
+                        infra_samples.append(line[:300])
+                    continue
                 is_bad = any(marker in lower for marker in (
                     '"is_error":true',
                     "extra_forbidden",
@@ -219,7 +229,9 @@ def provider_trace_summary(play_state: Path, provider: str) -> dict[str, Any]:
         "trace_exists": provider_dir.is_dir(),
         "line_count": parsed,
         "failed_or_error_count": failed,
+        "provider_infra_warning_count": infra_warnings,
         "samples": samples,
+        "provider_infra_samples": infra_samples,
     }
 
 

--- a/qa/test_app_handoff_gate.py
+++ b/qa/test_app_handoff_gate.py
@@ -115,6 +115,22 @@ class AppHandoffGateTests(unittest.TestCase):
         self.assertEqual(summary["failed_or_error_count"], 0)
         self.assertEqual(summary["trace_exists"], True)
 
+    def test_codex_provider_trace_classifies_safety_monitor_500_as_infra_warning(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            provider = root / "codex-provider"
+            provider.mkdir()
+            (provider / "codex-dm.stderr.log").write_text(
+                '2026-06-01T13:39:07.247084Z  WARN codex_core::arc_monitor: safety monitor returned non-success status status=500 Internal Server Error url=https://chatgpt.com/backend-api/codex/safety/arc response_text="{\\"detail\\":\\"safety_monitor_failed\\"}"\n',
+                encoding="utf-8",
+            )
+
+            summary = gate.provider_trace_summary(root, "codex")
+
+        self.assertEqual(summary["failed_or_error_count"], 0)
+        self.assertEqual(summary["provider_infra_warning_count"], 1)
+        self.assertIn("safety monitor returned non-success", summary["provider_infra_samples"][0])
+
     def test_codex_provider_trace_missing_is_explicit(self):
         with tempfile.TemporaryDirectory() as td:
             summary = gate.provider_trace_summary(Path(td), "codex")


### PR DESCRIPTION
## Summary
- Split Codex provider infrastructure warnings from real provider/tool failures in the app handoff gate trace summary.
- Classify the Codex safety-monitor 500 warning as `provider_infra_warning_count` instead of incrementing `failed_or_error_count`.
- Keep genuine failed MCP/tool calls and validation/cancellation errors red.

## Why
The 7a373cf built-app handoff rerun reached a playable built-app state, but failed because a remote Codex safety-monitor service warning was counted as a provider failure. That obscures the difference between product/provider tool failures and transient provider-infrastructure warnings.

## Validation
- `python3 -m pytest qa/test_app_handoff_gate.py -q`
- `python3 -m pytest qa/test_app_handoff_gate.py qa/test_release_readiness.py qa/test_export_app_evidence.py -q`
- `python3 -m py_compile qa/app_handoff_gate.py`
- `git diff --check`
- Reclassified saved 7a373cf traces: the safety-monitor 500 run now reports `failed_or_error_count=0`, `provider_infra_warning_count=1`; the real failed MCP tool-call run still reports `failed_or_error_count=1`.

## Release note
This is handoff-gate classification hardening only. It is not a release verdict.
