### PR TITLE
qa: expose structured RRI handoff evidence

### DIFF
--- a/qa/release_readiness.py
+++ b/qa/release_readiness.py
@@ -649,6 +649,10 @@ def main() -> int:
         "missing_release_personas": missing_release_personas,
         "harness_failures": harness_failures,
         "evidence_gaps": evidence_gaps,
+        "handoff_evidence": {
+            **handoff_proof,
+            "evidence_gaps": handoff_evidence_gaps,
+        },
         "gates_passed": passed,
         "gates_total": total_gates,
         "failed_gates": failed,

--- a/qa/test_release_readiness.py
+++ b/qa/test_release_readiness.py
@@ -1157,6 +1157,14 @@ class ReleaseReadinessContractTests(unittest.TestCase):
             self.assertEqual(payload["signals"]["native_gate_source"], str(handoff))
             self.assertEqual(payload["artifact_sources"]["handoff_json"], str(handoff))
             self.assertTrue(payload["signals"]["handoff_proof"]["valid"])
+            self.assertEqual(payload["handoff_evidence"]["path"], str(handoff))
+            self.assertTrue(payload["handoff_evidence"]["valid"])
+            self.assertEqual(payload["handoff_evidence"]["evidence_gaps"], [])
+            self.assertEqual(
+                sorted(payload["handoff_evidence"]["gates"]),
+                ["built_app_codex_playtest", "built_app_scripted_smoke", "web_scripted_smoke"],
+            )
+            self.assertEqual(payload["handoff_evidence"]["gates"]["built_app_codex_playtest"]["manifest_verdict"], "passed")
             self.assertIn("handoff_json=", payload["gate_detail"]["native_gate"])
 
     def test_handoff_json_must_prove_engine_state_authority(self):


### PR DESCRIPTION
## Summary
- add a top-level `handoff_evidence` object to RRI JSON output when `--handoff-json` is used
- include the validated handoff proof plus any handoff evidence gaps in a stable machine-readable field
- extend the release-readiness contract test so split Mac-app proof remains auditable without parsing `gate_detail`

## Test Plan
- `python3 -m pytest qa/test_release_readiness.py -q -k split_vm_persona_evidence_uses_handoff_json_for_native_gate`
- `python3 -m pytest qa/test_release_readiness.py -q`
- `python3 -m pytest qa/test_release_readiness.py qa/test_app_handoff_gate.py qa/test_export_app_evidence.py -q`
- `python3 -m py_compile qa/release_readiness.py`
- `git diff --check`

## Licensing / CLA
- [x] I agree to contribute this change under the repository license.
- [x] This PR does not include confidential information, private artifacts, or private operator details.

## Notes
- This is release-evidence schema hardening only; it is not a release verdict.