### PR TITLE
qa: require preflight evidence for split RRI

### DIFF
--- a/qa/release_readiness.py
+++ b/qa/release_readiness.py
@@ -253,7 +253,8 @@ def validate_support_preflight_json(preflight_json: str, expected_sha: str) -> t
         gaps.append(support_preflight_gap(str(preflight_path), "support preflight repo was dirty or unproven clean"))
     if repo.get("expected_sha_match") is not True:
         gaps.append(support_preflight_gap(str(preflight_path), "support preflight repo expected_sha_match was not true"))
-    if not (repo.get("origin_main_query") or {}).get("ok"):
+    origin_main_query = repo.get("origin_main_query") if isinstance(repo.get("origin_main_query"), dict) else {}
+    if origin_main_query.get("ok") is not True:
         gaps.append(support_preflight_gap(str(preflight_path), "support preflight origin/main query was not proven"))
     if expected_sha:
         preflight_sha = str(readiness.get("expected_sha") or repo.get("expected_sha") or repo.get("head_short") or "")
@@ -657,8 +658,6 @@ def main() -> int:
             })
         else:
             evidence_gaps.extend(support_preflight_gaps)
-    elif args.support_preflight_json:
-        evidence_gaps.extend(support_preflight_gaps)
     for failure in part_a_failures:
         evidence_gaps.append({
             "gate": "native_gate",
@@ -710,7 +709,9 @@ def main() -> int:
     elif looks_like_path(args.palette_source) and not Path(args.palette_source).exists():
         evidence_gaps.append({"gate": "palette_live", "missing": args.palette_source, "detail": "palette-live evidence source missing"})
     evidence_gap_gates = {gap["gate"] for gap in evidence_gaps}
-    native_evidence_gap_gates = {"native_gate", "support_preflight"}
+    native_evidence_gap_gates = {"native_gate"}
+    if split_vm_handoff_evidence:
+        native_evidence_gap_gates.add("support_preflight")
     native_gate_detail = f"source={native_source or 'n/a'} {native_detail or 'part_a=' + (native or 'n/a')}".strip()
 
     # ---- the 11 gates (each contributes to RRI; all must hold for 10/10) ----

--- a/qa/release_readiness.py
+++ b/qa/release_readiness.py
@@ -13,6 +13,8 @@ Pure reader of on-disk artifacts (never the live HTTP channel, which can corrupt
   - --ui-audit PASS|FAIL      (ui_audit_health.sh exit)
   - --palette-live true|false (a clean /session-surface read done by the CALLER, not here)
   - --handoff-json handoff.json (optional Mac-built app proof from qa/app_handoff_gate.py)
+  - --support-preflight-json support_vm_preflight.json (required when VM persona evidence
+    relies on --handoff-json for Mac-built app proof)
 
 The two NEW signals the plan calls for — image-render-rate and palette-live — are computed
 here (image rate from score.json/network.ndjson) and passed in (palette-live), so this stays
@@ -23,6 +25,7 @@ Usage:
       [--story story.json] [--mech mech.json] \
       [--behavioral GREEN|RED] [--ui-audit PASS|FAIL] [--palette-live true|false] \
       [--build-sha SHA] [--expected-personas newbie,veteran,...] [--handoff-json handoff.json]
+      [--support-preflight-json support_vm_preflight.json]
       [--out qa/RRI.json] [--scorecard-row]
 
 Targets for 10/10 (each dimension is a gate; all must hold on ONE build):
@@ -187,6 +190,104 @@ def handoff_gap(missing: str, detail: str) -> dict:
     return {"gate": "native_gate", "missing": missing, "detail": detail}
 
 
+def support_preflight_gap(missing: str, detail: str) -> dict:
+    return {"gate": "support_preflight", "missing": missing, "detail": detail}
+
+
+def validate_support_preflight_json(preflight_json: str, expected_sha: str) -> tuple[dict, list[dict]]:
+    proof = {
+        "path": preflight_json or "",
+        "valid": False,
+        "schema": "",
+        "verdict": "",
+        "ready_for_rri": False,
+        "release_verdict": False,
+        "readiness": {},
+    }
+    if not preflight_json:
+        return proof, []
+
+    preflight_path = Path(preflight_json)
+    payload, error = read_json_with_error(preflight_path)
+    if error:
+        return proof, [support_preflight_gap(preflight_json, f"support preflight JSON {error}")]
+
+    readiness = payload.get("readiness") if isinstance(payload.get("readiness"), dict) else {}
+    repo = payload.get("repo") if isinstance(payload.get("repo"), dict) else {}
+    gaps: list[dict] = []
+    proof.update(
+        {
+            "schema": payload.get("schema") or "",
+            "verdict": payload.get("verdict") or "",
+            "ready_for_rri": payload.get("ready_for_rri") is True,
+            "release_verdict": bool(payload.get("release_verdict")),
+            "readiness": {
+                "safe_to_run_personas": readiness.get("safe_to_run_personas") is True,
+                "same_sha_ready": readiness.get("same_sha_ready") is True,
+                "provider": readiness.get("provider") or "",
+                "player_agent": readiness.get("player_agent") or "",
+                "provider_auth_ready": readiness.get("provider_auth_ready") is True,
+                "player_agent_auth_ready": readiness.get("player_agent_auth_ready") is True,
+                "required_tools_ready": readiness.get("required_tools_ready") is True,
+                "persona_briefs_ready": readiness.get("persona_briefs_ready") is True,
+                "private_art_ready": readiness.get("private_art_ready") is True,
+                "artifact_return_ready": readiness.get("artifact_return_ready") is True,
+                "host_capacity_ready": readiness.get("host_capacity_ready") is True,
+                "mac_handoff_required": readiness.get("mac_handoff_required") is True,
+                "blocking_categories": readiness.get("blocking_categories") if isinstance(readiness.get("blocking_categories"), list) else [],
+                "expected_sha": readiness.get("expected_sha") or "",
+                "repo_head_short": readiness.get("repo_head_short") or repo.get("head_short") or "",
+                "min_memory_gb": readiness.get("min_memory_gb"),
+            },
+        }
+    )
+    if payload.get("schema") != "worldos.support-vm-preflight.v1":
+        gaps.append(support_preflight_gap(str(preflight_path), "support preflight schema is missing or wrong"))
+    if payload.get("verdict") != "passed":
+        gaps.append(support_preflight_gap(str(preflight_path), f"support preflight verdict is {payload.get('verdict') or 'missing'}"))
+    if payload.get("ready_for_rri") is not True:
+        gaps.append(support_preflight_gap(str(preflight_path), "support preflight ready_for_rri was not true"))
+    if payload.get("release_verdict") is not False:
+        gaps.append(support_preflight_gap(str(preflight_path), "support preflight must not claim a release verdict"))
+    if repo.get("dirty") is not False:
+        gaps.append(support_preflight_gap(str(preflight_path), "support preflight repo was dirty or unproven clean"))
+    if repo.get("expected_sha_match") is not True:
+        gaps.append(support_preflight_gap(str(preflight_path), "support preflight repo expected_sha_match was not true"))
+    if not (repo.get("origin_main_query") or {}).get("ok"):
+        gaps.append(support_preflight_gap(str(preflight_path), "support preflight origin/main query was not proven"))
+    if expected_sha:
+        preflight_sha = str(readiness.get("expected_sha") or repo.get("expected_sha") or repo.get("head_short") or "")
+        repo_head = str(readiness.get("repo_head_short") or repo.get("head_short") or "")
+        if not build_sha_matches(preflight_sha, expected_sha):
+            gaps.append(support_preflight_gap(str(preflight_path), f"support preflight expected_sha {preflight_sha or 'missing'} does not match --build-sha {expected_sha}"))
+        if not build_sha_matches(repo_head, expected_sha):
+            gaps.append(support_preflight_gap(str(preflight_path), f"support preflight repo_head {repo_head or 'missing'} does not match --build-sha {expected_sha}"))
+    required_readiness = [
+        "safe_to_run_personas",
+        "same_sha_ready",
+        "provider_auth_ready",
+        "player_agent_auth_ready",
+        "required_tools_ready",
+        "persona_briefs_ready",
+        "private_art_ready",
+        "artifact_return_ready",
+        "host_capacity_ready",
+        "mac_handoff_required",
+    ]
+    for field in required_readiness:
+        if readiness.get(field) is not True:
+            gaps.append(support_preflight_gap(str(preflight_path), f"support preflight readiness.{field} was not true"))
+    if readiness.get("blocking_categories"):
+        gaps.append(
+            support_preflight_gap(
+                str(preflight_path),
+                "support preflight blocking_categories is not empty: " + ", ".join(str(v) for v in readiness.get("blocking_categories")),
+            )
+        )
+    proof["valid"] = not gaps
+    return proof, gaps
+
+
 def validate_handoff_json(handoff_json: str, expected_sha: str) -> tuple[dict, list[dict]]:
     proof = {
         "path": handoff_json or "",
@@ -349,6 +450,7 @@ def main() -> int:
     ap.add_argument("--ui-audit-log", default="", help="path to the UI audit evidence source")
     ap.add_argument("--palette-source", default="", help="path or label for the palette-live evidence source")
     ap.add_argument("--handoff-json", default="", help="Mac app handoff gate JSON proving built-app smoke/play evidence")
+    ap.add_argument("--support-preflight-json", default="", help="Support VM preflight JSON proving same-SHA heavy-lane readiness")
     ap.add_argument("--build-sha", dest="build_sha", default="")
     ap.add_argument("--out", default="qa/RRI.json")
     ap.add_argument("--scorecard-row", action="store_true")
@@ -357,6 +459,7 @@ def main() -> int:
     run_dirs = [Path(p) for p in split_csv(args.runs)]
     expected_personas = split_csv(args.expected_personas)
     handoff_proof, handoff_evidence_gaps = validate_handoff_json(args.handoff_json, args.build_sha)
+    support_preflight_proof, support_preflight_gaps = validate_support_preflight_json(args.support_preflight_json, args.build_sha)
     persona_scores = []
     harness_failures = []
     completed_personas: list[str] = []
@@ -482,6 +585,7 @@ def main() -> int:
         native = "PASS"
         native_source = args.handoff_json
         native_detail = f"handoff_json={args.handoff_json} gates={','.join(REQUIRED_HANDOFF_GATES)}"
+    split_vm_handoff_evidence = bool(persona_scores and native_source == args.handoff_json and args.handoff_json)
 
     evidence_gaps = []
     build_shas = sorted({str(p["run_build_sha"]) for p in persona_scores if p.get("run_build_sha")})
@@ -544,6 +648,17 @@ def main() -> int:
             "detail": f"persona={p.get('persona') or 'unknown'} part_b={p.get('part_b_result')} score_pass={p.get('part_b_score_pass')} failure_bucket={bucket} failure_detail={detail}".strip(),
         })
     evidence_gaps.extend(handoff_evidence_gaps)
+    if split_vm_handoff_evidence:
+        if not args.support_preflight_json:
+            evidence_gaps.append({
+                "gate": "support_preflight",
+                "missing": "--support-preflight-json",
+                "detail": "VM/persona artifacts that rely on --handoff-json for Mac proof require a same-SHA support preflight artifact",
+            })
+        else:
+            evidence_gaps.extend(support_preflight_gaps)
+    elif args.support_preflight_json:
+        evidence_gaps.extend(support_preflight_gaps)
     for failure in part_a_failures:
         evidence_gaps.append({
             "gate": "native_gate",
@@ -595,11 +710,12 @@ def main() -> int:
     elif looks_like_path(args.palette_source) and not Path(args.palette_source).exists():
         evidence_gaps.append({"gate": "palette_live", "missing": args.palette_source, "detail": "palette-live evidence source missing"})
     evidence_gap_gates = {gap["gate"] for gap in evidence_gaps}
+    native_evidence_gap_gates = {"native_gate", "support_preflight"}
     native_gate_detail = f"source={native_source or 'n/a'} {native_detail or 'part_a=' + (native or 'n/a')}".strip()
 
     # ---- the 11 gates (each contributes to RRI; all must hold for 10/10) ----
     gates = {
-        "native_gate":        (native == "PASS" and "native_gate" not in evidence_gap_gates,
+        "native_gate":        (native == "PASS" and not (evidence_gap_gates & native_evidence_gap_gates),
                                native_gate_detail),
         "arc_completed":      (any_completed and "arc_completed" not in evidence_gap_gates,
                                f"completed_intro_flow on >=1 persona"),
@@ -653,6 +769,10 @@ def main() -> int:
             **handoff_proof,
             "evidence_gaps": handoff_evidence_gaps,
         },
+        "support_preflight_evidence": {
+            **support_preflight_proof,
+            "evidence_gaps": support_preflight_gaps,
+        },
         "gates_passed": passed,
         "gates_total": total_gates,
         "failed_gates": failed,
@@ -664,6 +784,7 @@ def main() -> int:
             "story": args.story or "",
             "mechanical": args.mech or "",
             "handoff_json": args.handoff_json or "",
+            "support_preflight_json": args.support_preflight_json or "",
             "runs": [str(p) for p in run_dirs],
             "images": sorted({p["image_source"] for p in persona_scores if p.get("image_source")}),
         },
@@ -671,6 +792,7 @@ def main() -> int:
             "native_gate": native,
             "native_gate_source": native_source,
             "handoff_proof": handoff_proof,
+            "support_preflight": support_preflight_proof,
             "arc_completed": any_completed,
             "cross_persona_satisfaction": round(avg_sat, 1),
             "score_pass_failed_personas": score_pass_failed_personas,

--- a/qa/test_release_readiness.py
+++ b/qa/test_release_readiness.py
@@ -1359,6 +1359,96 @@ class ReleaseReadinessContractTests(unittest.TestCase):
             self.assertTrue(support_gaps)
             self.assertIn("badcafe", " ".join(gap["detail"] for gap in support_gaps))
 
+    def test_direct_native_evidence_ignores_optional_stale_support_preflight(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [self.write_persona_run(tmp, persona) for persona in personas]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            support_preflight = self.write_support_preflight(tmp, sha="badcafe")
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(payload["release_ready"])
+            self.assertNotIn("support_preflight", {gap["gate"] for gap in payload["evidence_gaps"]})
+            self.assertNotIn("native_gate", payload["failed_gates"])
+            self.assertFalse(payload["support_preflight_evidence"]["valid"])
+
+    def test_support_preflight_origin_main_query_must_be_object(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [self.write_persona_run(tmp, persona, include_part_a=False) for persona in personas]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            handoff = self.write_handoff_bundle(tmp)
+            support_preflight = self.write_support_preflight(tmp)
+            payload = json.loads(support_preflight.read_text(encoding="utf-8"))
+            payload["repo"]["origin_main_query"] = "not-a-dict"
+            support_preflight.write_text(json.dumps(payload), encoding="utf-8")
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--handoff-json",
+                str(handoff),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertFalse(payload["support_preflight_evidence"]["valid"])
+            self.assertIn("support_preflight", {gap["gate"] for gap in payload["evidence_gaps"]})
+            self.assertIn("origin/main query", " ".join(gap["detail"] for gap in payload["evidence_gaps"]))
+
     def test_handoff_json_must_prove_engine_state_authority(self):
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)

--- a/qa/test_release_readiness.py
+++ b/qa/test_release_readiness.py
@@ -128,6 +128,56 @@ class ReleaseReadinessContractTests(unittest.TestCase):
         )
         return handoff
 
+    def write_support_preflight(
+        self,
+        tmp: Path,
+        *,
+        sha: str = "deadbee",
+        ready: bool = True,
+        blocking_categories: list[str] | None = None,
+    ) -> Path:
+        preflight = tmp / "support_vm_preflight.json"
+        blocking_categories = blocking_categories or []
+        preflight.write_text(
+            json.dumps(
+                {
+                    "schema": "worldos.support-vm-preflight.v1",
+                    "verdict": "passed" if ready else "blocked",
+                    "ready_for_rri": ready,
+                    "release_verdict": False,
+                    "blockers": [] if ready else ["host memory below required capacity"],
+                    "repo": {
+                        "head_short": sha,
+                        "expected_sha": sha,
+                        "expected_sha_match": True,
+                        "dirty": False,
+                        "origin_main_query": {"ok": True, "head_short": sha},
+                    },
+                    "readiness": {
+                        "safe_to_run_personas": ready,
+                        "release_verdict": False,
+                        "expected_sha": sha,
+                        "repo_head_short": sha,
+                        "same_sha_ready": ready,
+                        "provider": "codex",
+                        "player_agent": "codex",
+                        "provider_auth_ready": ready,
+                        "player_agent_auth_ready": ready,
+                        "required_tools_ready": ready,
+                        "persona_briefs_ready": ready,
+                        "private_art_ready": ready,
+                        "artifact_return_ready": ready,
+                        "host_capacity_ready": ready,
+                        "min_memory_gb": 24,
+                        "mac_handoff_required": True,
+                        "blocking_categories": blocking_categories,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        return preflight
+
     def write_release_inputs(self, tmp: Path) -> tuple[Path, Path, Path, Path, Path]:
         story = tmp / "story.json"
         mech = tmp / "mech.json"
@@ -1122,6 +1172,65 @@ class ReleaseReadinessContractTests(unittest.TestCase):
             runs = [self.write_persona_run(tmp, persona, include_part_a=False) for persona in personas]
             story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
             handoff = self.write_handoff_bundle(tmp)
+            support_preflight = self.write_support_preflight(tmp)
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--handoff-json",
+                str(handoff),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(payload["release_ready"])
+            self.assertEqual(payload["signals"]["native_gate"], "PASS")
+            self.assertEqual(payload["signals"]["native_gate_source"], str(handoff))
+            self.assertEqual(payload["artifact_sources"]["handoff_json"], str(handoff))
+            self.assertTrue(payload["signals"]["handoff_proof"]["valid"])
+            self.assertEqual(payload["artifact_sources"]["support_preflight_json"], str(support_preflight))
+            self.assertTrue(payload["signals"]["support_preflight"]["valid"])
+            self.assertTrue(payload["support_preflight_evidence"]["valid"])
+            self.assertEqual(payload["support_preflight_evidence"]["evidence_gaps"], [])
+            self.assertEqual(payload["handoff_evidence"]["path"], str(handoff))
+            self.assertTrue(payload["handoff_evidence"]["valid"])
+            self.assertEqual(payload["handoff_evidence"]["evidence_gaps"], [])
+            self.assertEqual(
+                sorted(payload["handoff_evidence"]["gates"]),
+                ["built_app_codex_playtest", "built_app_scripted_smoke", "web_scripted_smoke"],
+            )
+            self.assertEqual(payload["handoff_evidence"]["gates"]["built_app_codex_playtest"]["manifest_verdict"], "passed")
+            self.assertIn("handoff_json=", payload["gate_detail"]["native_gate"])
+
+    def test_split_vm_persona_evidence_requires_support_preflight(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [self.write_persona_run(tmp, persona, include_part_a=False) for persona in personas]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            handoff = self.write_handoff_bundle(tmp)
 
             rc, _text, payload = self.run_rri(
                 tmp,
@@ -1151,21 +1260,104 @@ class ReleaseReadinessContractTests(unittest.TestCase):
                 "deadbee",
             )
 
-            self.assertEqual(rc, 0)
-            self.assertTrue(payload["release_ready"])
-            self.assertEqual(payload["signals"]["native_gate"], "PASS")
-            self.assertEqual(payload["signals"]["native_gate_source"], str(handoff))
-            self.assertEqual(payload["artifact_sources"]["handoff_json"], str(handoff))
-            self.assertTrue(payload["signals"]["handoff_proof"]["valid"])
-            self.assertEqual(payload["handoff_evidence"]["path"], str(handoff))
-            self.assertTrue(payload["handoff_evidence"]["valid"])
-            self.assertEqual(payload["handoff_evidence"]["evidence_gaps"], [])
-            self.assertEqual(
-                sorted(payload["handoff_evidence"]["gates"]),
-                ["built_app_codex_playtest", "built_app_scripted_smoke", "web_scripted_smoke"],
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertIn("native_gate", payload["failed_gates"])
+            self.assertIn("support_preflight", {gap["gate"] for gap in payload["evidence_gaps"]})
+            self.assertIn("--support-preflight-json", {gap["missing"] for gap in payload["evidence_gaps"]})
+
+    def test_blocked_support_preflight_blocks_split_vm_release_ready(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [self.write_persona_run(tmp, persona, include_part_a=False) for persona in personas]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            handoff = self.write_handoff_bundle(tmp)
+            support_preflight = self.write_support_preflight(tmp, ready=False, blocking_categories=["host_capacity"])
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--handoff-json",
+                str(handoff),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
             )
-            self.assertEqual(payload["handoff_evidence"]["gates"]["built_app_codex_playtest"]["manifest_verdict"], "passed")
-            self.assertIn("handoff_json=", payload["gate_detail"]["native_gate"])
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertIn("native_gate", payload["failed_gates"])
+            self.assertFalse(payload["support_preflight_evidence"]["valid"])
+            self.assertIn("host_capacity", payload["support_preflight_evidence"]["readiness"]["blocking_categories"])
+            self.assertIn("support_preflight", {gap["gate"] for gap in payload["evidence_gaps"]})
+
+    def test_stale_support_preflight_blocks_split_vm_release_ready(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [self.write_persona_run(tmp, persona, include_part_a=False) for persona in personas]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            handoff = self.write_handoff_bundle(tmp)
+            support_preflight = self.write_support_preflight(tmp, sha="badcafe")
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--handoff-json",
+                str(handoff),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertIn("native_gate", payload["failed_gates"])
+            self.assertFalse(payload["support_preflight_evidence"]["valid"])
+            support_gaps = [gap for gap in payload["evidence_gaps"] if gap["gate"] == "support_preflight"]
+            self.assertTrue(support_gaps)
+            self.assertIn("badcafe", " ".join(gap["detail"] for gap in support_gaps))
 
     def test_handoff_json_must_prove_engine_state_authority(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
- add `--support-preflight-json` to the RRI rollup
- validate same-SHA heavy-lane readiness artifacts before split Mac/app + persona evidence can count
- fail the native evidence gate when split evidence is missing, blocked, stale, dirty, or not origin-queryable
- expose structured `support_preflight_evidence`, `signals.support_preflight`, and `artifact_sources.support_preflight_json`

## Validation
- `python3 -m pytest qa/test_release_readiness.py -q`
- `python3 -m pytest qa/test_support_vm_preflight.py -q`
- `python3 -m py_compile qa/release_readiness.py qa/test_release_readiness.py`
- `git diff --check`

## Safety
- no private artifacts or operator topology committed
- handoff-only diagnostics remain partial without requiring support preflight until scored persona evidence exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `--support-preflight-json` argument to validate support VM preflight artifacts against schema and verdict requirements.
  * Support preflight evidence is now included in release readiness output with SHA consistency checks.
  * Release readiness conditionally requires support preflight artifact for split-VM configurations.
  * Refined native gate logic to separately handle support preflight evidence gaps.

* **Tests**
  * Added comprehensive test coverage for support preflight validation scenarios (missing, blocked, and stale artifacts).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->