### PR TITLE
qa: pass split evidence through release gate

### DIFF
--- a/qa/QA_TOOLS.md
+++ b/qa/QA_TOOLS.md
@@ -55,6 +55,10 @@ RRI requires a non-partial five-persona result on one build SHA. A handoff gate 
 app proof through `--handoff-json`, but it cannot fill in missing persona artifacts. The support-VM
 preflight must pass before a VM sweep can count toward #466; if `origin/main` is not queryable from
 the VM, fix the VM repo credentials/sync lane before running personas.
+When a sweep uses remote/persona artifacts plus Mac handoff proof, pass both evidence files into
+the RRI rollup path: `qa/release_gate.sh --handoff-json <handoff.json> --support-preflight-json
+<support_vm_preflight.json> ...`. Missing or stale support-preflight evidence must stay a failed
+release gate, not a warning.
 The default VM lane is Codex DM plus Codex UI player; Claude is only a readiness dependency when
 `--provider claude` or `--player-agent claude` is selected. The Codex lane requires Codex CLI
 `>=0.120.0` for per-invocation MCP server overrides.

--- a/qa/release_gate.sh
+++ b/qa/release_gate.sh
@@ -18,6 +18,7 @@
 #
 # Usage:
 #   qa/release_gate.sh [--personas a,b,c] [--lean] [--port 8765] [--budget 12]
+#                      [--handoff-json path] [--support-preflight-json path]
 #   qa/release_gate.sh --preflight-only      # just run the integrity checks, no sweep
 #
 # Host discipline: runs ONE heavy claude -p stream at a time (the host is 16GB; two
@@ -29,12 +30,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT" || exit 2
 PERSONAS="newbie,veteran,adversarial,narrative,optimizer"
 LEAN=0; PORT="${WOS_APP_PREFERRED_PORT:-8765}"; BUDGET="12.00"; PREFLIGHT_ONLY=0
+HANDOFF_JSON=""; SUPPORT_PREFLIGHT_JSON=""
 RUNID="gate-$(git rev-parse --short HEAD 2>/dev/null || echo nohead)"
 while [ $# -gt 0 ]; do case "$1" in
   --personas) PERSONAS="$2"; shift 2;;
   --lean) LEAN=1; shift;;
   --port) PORT="$2"; shift 2;;
   --budget) BUDGET="$2"; shift 2;;
+  --handoff-json) HANDOFF_JSON="$2"; shift 2;;
+  --support-preflight-json) SUPPORT_PREFLIGHT_JSON="$2"; shift 2;;
   --preflight-only) PREFLIGHT_ONLY=1; shift;;
   *) echo "unknown arg: $1"; exit 2;;
 esac; done
@@ -157,6 +161,15 @@ preflight() {
   [ -f "$ROOT/qa/playwright/node_modules/playwright/package.json" ] \
     || fail "Playwright not installed at qa/playwright/node_modules/playwright. Run: (cd qa/playwright && npm install && npx playwright install chromium)"
   ok "all orchestrated tools and command deps present"
+
+  if [ -n "$HANDOFF_JSON" ]; then
+    [ -s "$HANDOFF_JSON" ] || fail "--handoff-json does not point to a readable file"
+    ok "handoff evidence file present"
+  fi
+  if [ -n "$SUPPORT_PREFLIGHT_JSON" ]; then
+    [ -s "$SUPPORT_PREFLIGHT_JSON" ] || fail "--support-preflight-json does not point to a readable file"
+    ok "support preflight evidence file present"
+  fi
   echo "── preflight OK ──────────────────────────────────────────────────"
 }
 
@@ -266,17 +279,26 @@ except Exception:
 PY
 then PALETTE="true"; fi
 
+RRI_ARGS=(
+  --runs "$RUN_DIRS"
+  --expected-personas "$PERSONAS"
+  --behavioral "$BEHAV"
+  --ui-audit "$AUDIT"
+  --palette-live "$PALETTE"
+  --ui-audit-log "$UI_AUDIT_LOG"
+  --build-sha "$(git rev-parse --short HEAD 2>/dev/null)"
+  --out "$ROOT/qa/RRI.json"
+  --scorecard-row
+)
+[ -n "$STORY" ] && RRI_ARGS+=(--story "$STORY")
+[ -n "$MECH" ] && RRI_ARGS+=(--mech "$MECH")
+[ -n "$BEHAV_PATH" ] && RRI_ARGS+=(--behavioral-path "$BEHAV_PATH")
+[ -n "$PALETTE_SOURCE" ] && RRI_ARGS+=(--palette-source "$PALETTE_SOURCE")
+[ -n "$HANDOFF_JSON" ] && RRI_ARGS+=(--handoff-json "$HANDOFF_JSON")
+[ -n "$SUPPORT_PREFLIGHT_JSON" ] && RRI_ARGS+=(--support-preflight-json "$SUPPORT_PREFLIGHT_JSON")
+
 set +e
-python3 qa/release_readiness.py \
-  --runs "$RUN_DIRS" \
-  --expected-personas "$PERSONAS" \
-  ${STORY:+--story "$STORY"} ${MECH:+--mech "$MECH"} \
-  --behavioral "$BEHAV" --ui-audit "$AUDIT" --palette-live "$PALETTE" \
-  ${BEHAV_PATH:+--behavioral-path "$BEHAV_PATH"} \
-  --ui-audit-log "$UI_AUDIT_LOG" \
-  ${PALETTE_SOURCE:+--palette-source "$PALETTE_SOURCE"} \
-  --build-sha "$(git rev-parse --short HEAD 2>/dev/null)" \
-  --out "$ROOT/qa/RRI.json" --scorecard-row | tee "$ROOT/qa/ui_playtest_runs/${RUNID}-RRI.txt"
+python3 qa/release_readiness.py "${RRI_ARGS[@]}" | tee "$ROOT/qa/ui_playtest_runs/${RUNID}-RRI.txt"
 RRI_RC="${PIPESTATUS[0]}"
 set -e
 

--- a/qa/test_release_gate_static.py
+++ b/qa/test_release_gate_static.py
@@ -11,9 +11,19 @@ class ReleaseGateStaticContractTests(unittest.TestCase):
         source = (ROOT / "qa" / "release_gate.sh").read_text(encoding="utf-8")
 
         self.assertIn('--expected-personas "$PERSONAS"', source)
+        self.assertIn('--handoff-json) HANDOFF_JSON="$2"; shift 2;;', source)
+        self.assertIn('--support-preflight-json) SUPPORT_PREFLIGHT_JSON="$2"; shift 2;;', source)
+        self.assertIn("[ -s \"$HANDOFF_JSON\" ] || fail", source)
+        self.assertIn("[ -s \"$SUPPORT_PREFLIGHT_JSON\" ] || fail", source)
+        self.assertIn("RRI_ARGS=(", source)
+        self.assertIn('[ -n "$HANDOFF_JSON" ] && RRI_ARGS+=(--handoff-json "$HANDOFF_JSON")', source)
+        self.assertIn(
+            '[ -n "$SUPPORT_PREFLIGHT_JSON" ] && RRI_ARGS+=(--support-preflight-json "$SUPPORT_PREFLIGHT_JSON")',
+            source,
+        )
         self.assertIn("MISSING_SCORES", source)
         self.assertIn("missing persona score", source)
-        self.assertIn("set +e\npython3 qa/release_readiness.py", source)
+        self.assertIn('set +e\npython3 qa/release_readiness.py "${RRI_ARGS[@]}"', source)
         self.assertIn('RRI_RC="${PIPESTATUS[0]}"', source)
         self.assertIn('set -e\n\necho ""', source)
         self.assertIn('exit "$RRI_RC"', source)


### PR DESCRIPTION
## Summary
- Adds `--handoff-json` and `--support-preflight-json` flags to `qa/release_gate.sh`.
- Forwards those evidence files into `qa/release_readiness.py` via an argv array so split Mac/remote evidence cannot bypass the support-preflight requirement added by the RRI contract.
- Updates the QA tools index with generic, public-safe guidance for split evidence rollups.

## Public-Safety Check
- This PR does not add operator hostnames, remote checkout paths, auth-status output, private-art topology, artifact-return topology, or private evidence bundle paths.
- Diff scan was run before opening the PR.

## Tests
- `bash -n qa/release_gate.sh`
- `python3 -m pytest qa/test_release_gate_static.py -q`
- `python3 -m pytest qa/test_release_readiness.py -q`
- `git diff --check`

Not a release verdict; this only tightens the release-gate evidence path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--handoff-json` and `--support-preflight-json` CLI options to the release gate for passing Mac handoff and support VM preflight evidence.

* **Bug Fixes**
  * Release gate now validates evidence files exist and are readable before proceeding.
  * Missing or stale support-preflight evidence now causes release gate failure.

* **Documentation**
  * Updated QA instructions for Release Readiness Index rollup with remote/persona artifacts and Mac handoff proof.

* **Tests**
  * Enhanced release gate shell contract validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->