### PR TITLE
Fix portrait fallback for unrepresented lineages

### DIFF
--- a/viewer/openworlds/screen-create.jsx
+++ b/viewer/openworlds/screen-create.jsx
@@ -65,6 +65,15 @@ function heroPortraitScope(hero) {
   return portraitScope(hero.portrait);
 }
 
+function portraitChoicesForRace(race) {
+  const livingChoices = PORTRAIT_GALLERY.filter((p) => p.alive !== false);
+  const lineageChoices = livingChoices.filter((p) => !race || p.race === race);
+  return {
+    choices: lineageChoices.length ? lineageChoices : livingChoices,
+    usingFallback: !!race && lineageChoices.length === 0,
+  };
+}
+
 function ScreenCreate({ onNavigate, state, setState, preferredProvider = "" }) {
   const [step, setStep] = React.useState(0);
   const [hero, setHero] = React.useState({
@@ -506,6 +515,10 @@ function StepPortrait({ hero, setHero }) {
   const [genState, setGenState] = React.useState(hero.portraitMode === "gen" ? "done" : "idle");
   const toast = window.useToast ? window.useToast() : (() => {});
   const genMode = hero.portraitMode === "gen" && !!hero.portraitGenScope;
+  const portraitChoiceState = portraitChoicesForRace(hero.race);
+  const galleryChoices = portraitChoiceState.choices;
+  const usingGalleryFallback = portraitChoiceState.usingFallback;
+  const raceName = RACES[hero.race]?.name || "this lineage";
 
   // Picking a gallery face always returns to gallery mode (so the gallery selection wins back).
   const pickGallery = (i) => setHero({ ...hero, portrait: i, portraitMode: "gallery" });
@@ -555,10 +568,32 @@ function StepPortrait({ hero, setHero }) {
       <h1 className="h1">What will the chronicle remember of you?</h1>
       <Divider />
 
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(6, 1fr)", gap: 10 }}>
-        {/* #315: only canon faces of the hero's lineage, and never a dead figure. The original
+      {usingGalleryFallback && (
+        <div
+          role="status"
+          aria-live="polite"
+          data-worldos-testid="portrait-gallery-fallback"
+          className="body-sm"
+          style={{
+            marginBottom: 12,
+            padding: "10px 12px",
+            color: "var(--ink-800)",
+            background: "rgba(249, 238, 211, 0.58)",
+            boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.28)",
+            lineHeight: 1.4,
+          }}
+        >
+          No curated portrait exists for {raceName} yet. Choose any living gallery face below,
+          or summon a unique portrait.
+        </div>
+      )}
+
+      <div data-worldos-testid="portrait-gallery" style={{ display: "grid", gridTemplateColumns: "repeat(6, 1fr)", gap: 10 }}>
+        {/* #315: prefer canon faces of the hero's lineage, and never a dead figure. #379/#390:
+            if a selectable lineage has no curated faces yet, keep character creation playable
+            by showing the full living gallery instead of an empty grid. The original
             gallery index drives selection + scope, so map filtered entries back to it. */}
-        {PORTRAIT_GALLERY.filter(p => (!hero.race || p.race === hero.race) && p.alive !== false).map((p) => {
+        {galleryChoices.map((p) => {
           const i = PORTRAIT_GALLERY.indexOf(p);
           return (
           <button key={p.slug} onClick={() => pickGallery(i)} title={p.name} style={{
@@ -1057,4 +1092,4 @@ const BACKGROUNDS = {
   spy: { name: "Spy", brief: "Was paid for nine years to be elsewhere.", skills: ["Stealth", "Insight"] },
 };
 
-Object.assign(window, { ScreenCreate, RACES, CLASSES, BACKGROUNDS, SelectCard, abilityCost, raceScope, classScope, portraitScope, heroPortraitScope, PORTRAIT_GALLERY });
+Object.assign(window, { ScreenCreate, RACES, CLASSES, BACKGROUNDS, SelectCard, abilityCost, raceScope, classScope, portraitScope, heroPortraitScope, portraitChoicesForRace, PORTRAIT_GALLERY });

--- a/viewer/tests/test_portrait_gen.py
+++ b/viewer/tests/test_portrait_gen.py
@@ -132,6 +132,16 @@ class PortraitGenRouteTests(unittest.TestCase):
         self.assertIn("heroPortraitScope", src)
         self.assertIn("portraitGenScope", src)
 
+    def test_screen_create_keeps_portraits_available_for_unrepresented_lineages(self):
+        src = self._get_source("/openworlds/screen-create.jsx")
+        # Several selectable lineages do not yet have curated canon faces. The Face step must
+        # fall back to the full living gallery instead of rendering an empty grid.
+        self.assertIn("function portraitChoicesForRace", src)
+        self.assertIn("lineageChoices.length ? lineageChoices : livingChoices", src)
+        self.assertIn('data-worldos-testid="portrait-gallery-fallback"', src)
+        self.assertIn("No curated portrait exists for", src)
+        self.assertIn("galleryChoices.map", src)
+
 
 class PortraitGenEngineTests(unittest.TestCase):
     """Exercise the _portrait_gen plumbing with a STUBBED engine subprocess so no uv is


### PR DESCRIPTION
## Summary
- Keeps character creation playable for selectable lineages with no curated canon portrait yet.
- Adds a living-gallery fallback plus a visible status note on the Face step.
- Exposes the fallback helper/hook for static and agent-facing checks without changing engine state or write authority.

## Evidence
- Focused portrait regression: `python3 -m pytest viewer/tests/test_portrait_gen.py -k 'not null_default_returns_placeholder_no_network' -q` -> 12 passed, 1 deselected.
- OpenWorlds static suite: `python3 -m pytest viewer/tests/test_openworlds_static.py -q` -> 42 passed, 6 subtests passed.
- Built-app handoff gate on `39f7c30`: `qa/app_handoff_gate.py --web-beats 5 --built-beats 5 --codex-moves 1 ...` -> passed, handoff_score 100, zero evidence gaps.
- Manual in-app browser check: selecting Dwarf then Face shows the fallback note and 12 living portrait choices.

## Licensing / CLA
- [x] I have the right to submit this change under the repository license.
- [x] No confidential, restricted, private-art, credential, or support-VM material is included in this PR.

## Release Note
This is product UX/playability work, not a release verdict. Full five-persona RRI remains required for release.