### PR TITLE
Fix launcher shelf scratch-run clutter

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -62,6 +62,10 @@ window.openWorldsRequestedCampaignFromLocation = window.openWorldsRequestedCampa
   }
 };
 
+function openWorldsPlayerChronicle(c) {
+  return Boolean(c?.canResume || c?.current);
+}
+
 // #342: neutralize markup in player free-text BEFORE it is sent to the engine or echoed into the
 // chronicle. The adversarial run (#324 v2) found that submitting "<script>…</script>", "{{ }}", or
 // "<b>…</b>" sent the raw markup straight to the DM (it stalled 35s+) and rode along in the local
@@ -605,12 +609,13 @@ function App() {
         setState((s) => {
           const requestedCampaign = requestedCampaignRef.current;
           const requestedStillExists = requestedCampaign && nextCampaigns.some((c) => c.id === requestedCampaign);
-          const activeStillExists = nextCampaigns.some((c) => c.id === s?.activeCampaign);
+          const playerCampaigns = nextCampaigns.filter(openWorldsPlayerChronicle);
+          const activeStillExists = playerCampaigns.some((c) => c.id === s?.activeCampaign);
           const preferred =
             (requestedStillExists ? requestedCampaign : "") ||
-            nextCampaigns.find((c) => c.current)?.id ||
-            nextCampaigns.find((c) => c.live)?.id ||
-            nextCampaigns[0]?.id ||
+            playerCampaigns.find((c) => c.current)?.id ||
+            playerCampaigns.find((c) => c.live && c.canResume)?.id ||
+            playerCampaigns.find((c) => c.canResume)?.id ||
             "";
           if (requestedStillExists) requestedCampaignRef.current = "";
           return {
@@ -794,9 +799,10 @@ function App() {
   };
 
   const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
+  const playerChronicles = campaigns.filter(openWorldsPlayerChronicle);
   const current =
-    campaigns.find((c) => c.id === state?.activeCampaign) ||
-    campaigns[0] ||
+    playerChronicles.find((c) => c.id === state?.activeCampaign) ||
+    playerChronicles[0] ||
     { title: "Open Worlds", day: "" };
 
   return (

--- a/viewer/openworlds/screen-launcher.jsx
+++ b/viewer/openworlds/screen-launcher.jsx
@@ -2,12 +2,13 @@
 
 function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" }) {
   const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
-  const [selected, setSelected] = React.useState(state?.activeCampaign || campaigns[0]?.id || "");
+  const playerChronicles = campaigns.filter(isPlayerChronicle);
+  const [selected, setSelected] = React.useState(state?.activeCampaign || playerChronicles[0]?.id || "");
   const [showNew, setShowNew] = React.useState(false);
   const [summoning, setSummoning] = React.useState(false);
   const [summonError, setSummonError] = React.useState("");
   const toast = window.useToast ? window.useToast() : (() => {});
-  const active = campaigns.find((c) => c.id === selected) || campaigns[0] || null;
+  const active = playerChronicles.find((c) => c.id === selected) || playerChronicles[0] || null;
   const hasBridge = Boolean(window.OpenWorldsNative?.hasBridge?.());
   // #326: the in-browser play-entry. The catalog marks a session the engine can take moves for as
   // `live` (its move sink is writable) and `canResume` (it is the attached, current run). When such
@@ -16,17 +17,17 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
   // carries it from there. We surface that as an unmistakable primary so a newbie is never left
   // hunting (the old launcher led with "Begin a new chronicle", which dead-ends without the app).
   const playableCampaign =
-    campaigns.find((c) => c.live && c.canResume) ||
-    campaigns.find((c) => c.canResume) ||
+    playerChronicles.find((c) => c.live && c.canResume) ||
+    playerChronicles.find((c) => c.canResume) ||
     null;
 
   React.useEffect(() => {
-    if (campaigns.some((c) => c.id === selected)) return;
-    const fallback = campaigns.some((c) => c.id === state?.activeCampaign)
+    if (playerChronicles.some((c) => c.id === selected)) return;
+    const fallback = playerChronicles.some((c) => c.id === state?.activeCampaign)
       ? state.activeCampaign
-      : campaigns[0]?.id || "";
+      : playerChronicles[0]?.id || "";
     setSelected(fallback);
-  }, [campaigns, selected, state?.activeCampaign]);
+  }, [playerChronicles, selected, state?.activeCampaign]);
 
   // Begin a live, playable session. Inside the native WorldOS app this asks the supervisor
   // to start the currently selected provider session. The app repoints its WebView at that
@@ -83,9 +84,9 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
   };
 
   const onResume = () => {
-    const nextCampaign = campaigns.some((c) => c.id === selected) ? selected : campaigns[0]?.id;
+    const nextCampaign = playerChronicles.some((c) => c.id === selected) ? selected : playerChronicles[0]?.id;
     if (!nextCampaign) return;
-    const c = campaigns.find((x) => x.id === nextCampaign);
+    const c = playerChronicles.find((x) => x.id === nextCampaign);
     setState((s) => ({ ...s, activeCampaign: nextCampaign }));
     startPlay(c?.world);
   };
@@ -154,7 +155,7 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
           <div style={{ marginTop: 56 }}>
             <SectionTitle ordinal="I.">Chronicles</SectionTitle>
             <div style={{ display: "grid", gap: 12 }}>
-              {campaigns.length === 0 && (
+              {playerChronicles.length === 0 && (
                 <div style={{
                   padding: "28px 22px",
                   textAlign: "center",
@@ -170,7 +171,7 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
                   </div>
                 </div>
               )}
-              {campaigns.map((c) => (
+              {playerChronicles.map((c) => (
                 <CampaignRow key={c.id} c={c} selected={selected === c.id} onSelect={() => setSelected(c.id)} />
               ))}
               <button
@@ -243,7 +244,7 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
         {/* RIGHT: Selected detail */}
         <Panel framed style={{ padding: 0, overflow: "hidden" }}>
           {(() => {
-            const c = campaigns.find((x) => x.id === selected) || campaigns[0];
+            const c = playerChronicles.find((x) => x.id === selected) || playerChronicles[0];
             if (!c) {
               return (
                 <div style={{ padding: 28 }}>
@@ -385,6 +386,10 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
       }} />}
     </div>
   );
+}
+
+function isPlayerChronicle(c) {
+  return Boolean(c?.canResume || c?.current);
 }
 
 // #326: the unmistakable in-browser "Continue / Resume → play" primary. Shown at the very top of
@@ -638,4 +643,4 @@ function SegRadio({ value, onChange, options }) {
   );
 }
 
-Object.assign(window, { ScreenLauncher, ContinueBanner, Stat, CampaignRow, PartyPortrait, NewCampaignModal, FormField, SegRadio, inkInput });
+Object.assign(window, { ScreenLauncher, isPlayerChronicle, ContinueBanner, Stat, CampaignRow, PartyPortrait, NewCampaignModal, FormField, SegRadio, inkInput });

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -435,6 +435,26 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn('testId="modal-close"', launcher + character)
         self.assertIn('data-worldos-testid="modal-close"', camp)
 
+    def test_launcher_shelf_filters_non_resumable_scratch_runs(self):
+        launcher = (server._OPENWORLDS_DIR / "screen-launcher.jsx").read_text(encoding="utf-8")
+        app = (server._OPENWORLDS_DIR / "app.jsx").read_text(encoding="utf-8")
+
+        self.assertIn("const playerChronicles = campaigns.filter(isPlayerChronicle);", launcher)
+        self.assertIn("function isPlayerChronicle(c)", launcher)
+        self.assertIn("return Boolean(c?.canResume || c?.current);", launcher)
+        self.assertIn("playerChronicles.length === 0", launcher)
+        self.assertIn("playerChronicles.map((c) =>", launcher)
+        self.assertNotIn("{campaigns.map((c) =>", launcher)
+        self.assertIn("playerChronicles.find((c) => c.live && c.canResume)", launcher)
+        self.assertIn("playerChronicles.find((c) => c.canResume)", launcher)
+        self.assertIn("function openWorldsPlayerChronicle(c)", app)
+        self.assertIn("const playerCampaigns = nextCampaigns.filter(openWorldsPlayerChronicle);", app)
+        self.assertIn("const activeStillExists = playerCampaigns.some((c) => c.id === s?.activeCampaign);", app)
+        self.assertIn("playerCampaigns.find((c) => c.current)?.id", app)
+        self.assertIn("playerCampaigns.find((c) => c.live && c.canResume)?.id", app)
+        self.assertIn("playerCampaigns.find((c) => c.canResume)?.id", app)
+        self.assertNotIn("nextCampaigns[0]?.id", app)
+
     def test_openworlds_title_bar_keeps_title_and_day_pill_apart(self):
         # #306: long campaign titles must never wrap under the nav rail or collide with the
         # day/capability band. The structural fix is intentionally static so the built-app
@@ -612,7 +632,7 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn('params.get("campaign")', source)
         self.assertIn("requestedCampaignRef", source)
         self.assertIn("requestedStillExists", source)
-        self.assertLess(source.index("requestedStillExists ? requestedCampaign"), source.index("nextCampaigns.find((c) => c.current)?.id"))
+        self.assertLess(source.index("requestedStillExists ? requestedCampaign"), source.index("playerCampaigns.find((c) => c.current)?.id"))
         self.assertIn("requestedCampaignRef.current = \"\"", source)
 
     def test_openworlds_camp_rest_gives_feedback_when_dm_is_busy(self):


### PR DESCRIPTION
## Summary
- Filters the player-facing Chronicles shelf to resumable/current player chronicles instead of rendering every diagnostic catalog row.
- Applies the same player-chronicle filter to app-level default active campaign selection so hidden scratch rows do not become the implicit active campaign.
- Preserves explicit `?campaign=` deep links and leaves `/openworlds/campaigns.json` / monitor diagnostics unchanged.

## Evidence
- `python3 -m pytest viewer/tests/test_openworlds_static.py -q` -> 43 passed, 6 subtests passed.
- Fast built-app handoff on clean SHA `f2abf98`: `/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260601T184859Z-f2abf98/handoff.json` -> status passed, handoff_score 100, no evidence gaps.
- In-app browser proof with local scratch history linked in: `/Volumes/LEXAR/Codex/worldos-product-slices/launcher-clean-shelf-f2abf98/launcher-clean-shelf.png` and `launcher-clean-shelf.json`; visible launcher rows dropped to 1 while the diagnostic catalog retained scratch history.

## Invariants
- Engine remains sole campaign-state writer.
- GUI remains read-only catalog projection plus existing `/move` intent path.
- No private art or evidence bundles committed.

## Licensing / CLA
- [x] I have rights to contribute this code.
- [x] This contribution follows the repository license terms.