### PR TITLE
docs: consolidate canonical WorldOS planning docs (STAGED — do not merge yet)

### DIFF
--- a/WorldOS-NORTH-STAR.md
+++ b/WorldOS-NORTH-STAR.md
@@ -5,9 +5,13 @@
 > When a decision is ambiguous, when the score and your gut disagree, when you're about to add a
 > feature: come back here. The North Star is **more than a score.** The score is a proxy for it.
 >
-> Read order on resume during takeover: `WorldOS-OPERATING-GOAL.md` → `WorldOS-GUI-RUNBOOK.md` →
-> `WorldOS-RUNBOOK.md` → `qa/SCORECARD.md` → this file. The North Star tells you what "great"
-> means; it does not decide whether the current build is releasable.
+> Read order on resume: `WorldOS-OPERATING-GOAL.md` → `WorldOS-RUNBOOK.md` (the merged HOW-TO + GUI
+> loop) → `qa/SCORECARD.md` → this file. The North Star tells you what "great" means; it does not decide
+> whether the current build is releasable.
+>
+> The long-game graphics/game-types ceiling is the committed roadmap
+> [`docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md`](docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md) — the single
+> source of truth (GT0 narrative → GT1 SNES pixel → GT2 isometric; capabilities C1–C10).
 >
 > Voice: confident, opinionated, builder's. Last north-star content update 2026-05-28;
 > takeover freshness note added 2026-05-31.

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -1,82 +1,33 @@
-# WorldOS — OPERATING GOAL (v1 — re-authored from first principles 2026-05-31)
+# WorldOS — OPERATING GOAL (v1 — re-authored from first principles 2026-05-31; consolidated 2026-06-02)
 
 <!-- ════════════════════════════════════════════════════════════════════════════
      ★ STATE OF TRUTH — READ THIS FIRST, ACT ON THIS ONLY (update every session)
-     Post-compaction agents: this 6-line block is ground truth. Do NOT reconstruct
-     state from scattered docs or old plans; trust this, verify the sha, then act.
+     Post-compaction agents: this block is ground truth. Do NOT reconstruct state
+     from scattered docs or old plans; trust this, verify the SHA, then act. Keep
+     it to ~10 lines — the PR-narrative lives in docs/archive/OPERATING-GOAL-PR-LOG.md.
      ──────────────────────────────────────────────────────────────────────────
-     AS OF:        2026-06-01T18:02:45+07:00 repo Codex persona-lane patch; latest handoff build remains 9545383
-     MAIN BASELINE:
-                   Latest same-SHA app-proof target is `9545383` (PR #508 merged the repo-owned
-                   support-VM preflight artifact gate, and the app handoff gate was rerun on that
-                   exact SHA). Current `origin/main` may contain docs-only commits above that proof;
-                   do not treat docs-only tips as new product proof. Earlier product-code baseline
-                   `fd9dba5` remains preserved as historical proof.
-     CANONICAL:    /Users/lume/ClawDnD-val is now the synced local app/private-art checkout and
-                   the default place to build/run/test the Mac app. Keep GUI/runtime tests on this
-                   local disk so macOS does not prompt on Lexar-hosted assets.
-     WORKTREES:    For tracked edits, prefer same-disk local worktrees when GUI/app tests need assets.
-                   Use /Volumes/LEXAR/Codex for evidence/snapshots and Lexar worktrees only for
-                   non-GUI/doc/backend slices that do not launch the app against private art.
-     SUPPORT VM:   32GB owner-provided support VM (`support-vm-1`). Connection/auth details live
-                   in local operator-only evidence/runbooks, not tracked repo docs. Use it for
-                   heavy backend/persona sweeps only after Codex/config/credentials are intentionally
-                   installed. The default VM persona lane is Codex DM plus Codex UI player and requires
-                   Codex CLI `>=0.120.0`; Claude is only required when deliberately selected. Mac-built
-                   `.app` smoke/play proof stays on this Mac or macOS CI.
-                   Current local preflight note: a read-only operator-endpoint scout reached
-                   `evaos-support` (~32 GB RAM, 16 CPUs) with WorldOS at `/root/worldos-qa/WorldOS`,
-                   but that checkout was stale (`4524b3e`) and behind the `9545383` app-proof baseline.
-                   GitHub origin query/sync failed in batch mode (`could not read Username for
-                   'https://github.com'`), Codex auth/config was not proven, and artifact return needs
-                   remote staging plus copy-back to Lexar. Do not run #466 there until an operator
-                   approves repo sync/auth setup and the preflight passes.
-     LAST MEASURED GATE BUILD:
-                   f5500ac produced qa/RRI.json = 2.7/10, but this is PARTIAL /
-                   HARNESS-CONTAMINATED evidence: only newbie wrote score.json; the other
-                   personas failed around port/backend harness setup; behavioral/UI/palette/image
-                   evidence was not a valid five-persona release verdict.
-     LAST BUILT-APP PLAY PROOF:
-                   Last built-app handoff proof is `9545383`
-                   (`/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/handoff-20260601T100304Z-9545383/`):
-                   `qa/app_handoff_gate.py` scored `handoff_score=100` with web-scripted smoke
-                   5 moves, built `dist/WorldOS.app` scripted smoke 5 moves, and built
-                   `dist/WorldOS.app` Codex-provider playtest 1 move. Private BG art was present,
-                   visible narration and five enabled actions were present, `/move` resolved, all
-                   three manifests had zero evidence gaps, and the Codex provider trace reported
-                   `trace_exists=true`, `line_count=80`, and
-                   `failed_or_error_count=0`.
-                   The prior `fd9dba5` and `4a0efe1` 100/100 handoffs remain preserved but are
-                   superseded as latest merged-main app proof by this `9545383` post-#508 run.
-                   Prior trace-clean real-provider built-app proof on merged main is `f7ab6d7`
-                   (`codex-main-f7ab6d7-proof-20260601T010058Z`); it remains useful diagnostic
-                   #479 evidence but is superseded as the latest merged-main app proof by the
-                   `9545383` handoff gate.
-     LAST VALID RELEASE GATE:
-                   none after the RRI contract hardening. A release verdict requires expected
-                   persona count, disk-backed palette/image/behavioral evidence, and built .app play.
-     NEXT ACTION:  #479 is closed; #504 gives a fast GUI velocity gate; #505 lets RRI consume
-                   Mac handoff proof through `--handoff-json`.
-                   Do not claim release. Run #466 for a trustworthy clean RRI failure list/result.
-                   For same-SHA RRI, sync the support VM checkout to `9545383`, run
-                   `python3 qa/support_vm_preflight.py --expected-sha 9545383 --provider codex --player-agent codex ...`,
-                   and pair
-                   the VM persona artifacts with the `9545383` Mac handoff JSON above. If a
-                   newer release-candidate SHA is used instead, rerun the Mac handoff on that
-                   same SHA before rollup. The 32GB support VM runs heavy backend/persona sweeps
-                   only after the preflight writes a redacted ready-for-RRI artifact, including a
-                   successful `origin/main` query from the VM.
-                   If the VM route is still unavailable, record that as the blocker and
-                   file/fix repo-side RRI harness gaps only if found. #481/#482/#483/#484/#485/#486
-                   are closed; #466 remains the release-gate issue and #467 remains the UX-first sprint.
-                   Keep sprint work UX-first (#467): first-turn playability, clickability/chrome,
-                   launcher clarity, live-response feel, and CRPG depth before more hardening/proxy/security work.
-     DISCIPLINE:   ≥2 clean reads before any fix (channel fabricates under host load); ONE heavy claude -p stream;
-                   never probe-kill; test the BUILT .app, never a proxy; honest scores; never "100% confidence".
+     CURRENT SHA:   <TODO: fill from the measured A/B run — `git -C /Users/lume/ClawDnD-val rev-parse --short origin/main`>
+                    Note (verified 2026-06-02): commits ABOVE the old `9545383` app-proof are NOT all
+                    docs-only — they include product/QA code (#528 viewer screen-create, the RRI scorer
+                    qa/release_readiness.py, ui_playtest_app.sh). So re-prove the app on the CURRENT SHA;
+                    do not carry `9545383` forward as if main were docs-only on top of it.
+     LAST REAL SCORE: <TODO: fill from the A/B + ledger — the last NON-partial, non-contaminated RRI row,
+                    with its build SHA. As of consolidation there is NONE; see qa/SCORECARD.md "RRI
+                    reconciliation" for why the 1.8 / ~6.0 / 2.7 numbers are all partial/unmeasured.>
+     CANONICAL:     /Users/lume/ClawDnD-val is the synced local app/private-art checkout — build/run/test
+                    the Mac app here so macOS does not prompt on Lexar-hosted assets.
+     NEXT ACTION:   Do not claim release. Run #466 for a trustworthy clean five-persona RRI on ONE explicit
+                    SHA. Pair a same-SHA Mac handoff (`qa/app_handoff_gate.py` → `--handoff-json`) with
+                    support-VM persona artifacts, gated by `qa/support_vm_preflight.py` (operator must
+                    approve VM repo-sync/auth first; the scouted VM checkout was stale + auth unproven).
+                    Keep sprint work UX-first (#467) — see docs/archive/OPERATING-GOAL-PR-LOG.md §10.
+     DISCIPLINE:    ≥2 clean reads before any fix (channel fabricates under host load); ONE heavy claude -p
+                    stream; never probe-kill; test the BUILT .app, never a proxy; honest scores; never "100% confidence".
      ════════════════════════════════════════════════════════════════════════════ -->
 
-> Read order on resume: the STATE-OF-TRUTH block above → this file → `WorldOS-GUI-RUNBOOK.md` →
-> `WorldOS-RUNBOOK.md` → `qa/SCORECARD.md`. (NORTH-STAR is the long-game ceiling, not needed to act.)
+> Read order on resume: the STATE-OF-TRUTH block above → this file → `WorldOS-RUNBOOK.md` (the merged
+> HOW-TO + GUI loop) → `qa/SCORECARD.md` (the human score ledger). (NORTH-STAR is the long-game ceiling,
+> not needed to act.) Historical PR-narrative + sprint order: `docs/archive/OPERATING-GOAL-PR-LOG.md`.
 
 ## Agent Navigation / Current TOC
 
@@ -86,12 +37,12 @@ which file answers which question.
 | Need | Read / run |
 |---|---|
 | Current release truth, last proof, next action | This file, especially the state block above |
-| Fast GUI/native app loop | `WorldOS-GUI-RUNBOOK.md` |
-| Repo architecture, invariants, broader dev loop | `WorldOS-RUNBOOK.md` and `docs/ARCHITECTURE.md` |
+| Fast GUI/native app loop + repo architecture, invariants, dev loop | `WorldOS-RUNBOOK.md` (GUI runbook merged in) and `docs/ARCHITECTURE.md` |
 | QA command index | `qa/QA_TOOLS.md` |
 | App-status, handoff, evidence contract | `docs/AGENT_GRADE_APP_TESTABILITY.md` |
-| Evidence ledger | `qa/SCORECARD.md` |
-| Historical GUI punch-list | `qa/GUI_WORKBOOK.md` |
+| Score ledger (human narrative) | `qa/SCORECARD.md` (points at the machine-readable `qa/scores.db` once it lands) |
+| Historical GUI punch-list | `docs/archive/GUI_WORKBOOK.md` |
+| Historical PR-narrative + UX sprint order | `docs/archive/OPERATING-GOAL-PR-LOG.md` |
 | Blind browser persona harness | `qa/UI_PLAYTEST.md` |
 | Old page-by-page audits and native roadmaps | `docs/OPENWORLDS_UI_AUDIT.md`, `docs/OPENWORLDS_NATIVE_APP_ROADMAP.md`, `docs/ui-audit/` |
 
@@ -231,132 +182,13 @@ verifier; can revert the goal to "fix" anytime.
 
 ---
 
-## 9. CURRENT STATUS (2026-06-01T17:49:00+07:00 — latest same-SHA app proof is 9545383)
+## 9. CURRENT STATUS + UX-FIRST SPRINT ORDER
 
-- Repo truth stabilization merged in PR #465, UX-first doc sync merged in PR #468, first-minute
-  click/title chrome proof merged in PR #470, local/Lexar/support-VM routing merged in PR #471,
-  native provider selection merged in PR #472, and takeover docs synced in PR #473.
-  The takeover foundation then merged: PR #475 added the Codex-DM built-app provider path,
-  `/app-status`, evidence export baseline, and docs; PR #494 added the dev-gated scripted provider;
-  PR #495 added stable OpenWorlds accessibility / `data-worldos-testid` hooks; PR #496 added app
-  playtest failure buckets plus RRI gate-split metadata. PR #498 synced takeover docs after those
-  merges. PR #499 then recorded the current-main built-app proof, PR #500 fixed the Codex-DM
-  provider trace cancellations, PR #501 recorded that proof in the runbooks/scorecard, and PR #504
-  added the hybrid 100/100 app handoff gate. PR #505 then hardened the RRI bridge so Mac handoff
-  evidence can be supplied with `--handoff-json` while support-VM persona artifacts supply the heavy
-  sweep. PR #506 then synced these docs to the `fd9dba5` proof without changing product code. PR #508 added the
-  support-VM preflight artifact gate. The local app/private-art checkout `/Users/lume/ClawDnD-val` was
-  fast-forwarded to `9545383`, and the Mac app handoff was rerun on that exact SHA.
-- The stale local pre-sync artifacts were preserved before the fast-forward at
-  `/Volumes/LEXAR/Codex/worldos-local-checkout-snapshot-20260531T223923` and in `stash@{0}`
-  (`pre-sync local takeover docs 2026-05-31`). Treat those as evidence, not current release truth.
-- The `f5500ac` RRI (`2.7/10`) is preserved as partial evidence only. It proves the gate/harness was
-  not trustworthy enough for release scoring: one persona completed, others lacked `score.json`, and
-  image/palette/behavioral/UI audit sources were either missing or harness-contaminated.
-- Built-app launch smoke on `cad2e00` rendered OpenWorlds with private art, but the first Resume/Play
-  click still forced Claude and failed on Claude auth. PR #472 fixed that web/native selection bug.
-  PR #475 then added a separate Codex DM wrapper and points the native Codex adapter at it,
-  while keeping the older Codex actor wrapper as a constrained player/move-facade helper.
-- Early Codex-DM local built-app evidence is preserved: private BG art loaded,
-  Alfira seated as `player`, visible DM narration, enabled actions, a real player move appended to
-  `player_moves.jsonl`, and a post-move DM response with `can_act:true` in `/session-surface`.
-  Evidence is in `/Volumes/LEXAR/Codex/worldos-built-app-proof/`:
-  `session-surface-racefix-after-dm-response-20260601T012410.json`,
-  `worldos-racefix-first-turn-20260601T012110.png`, and
-  `worldos-racefix-dm-response-dismissed-permission-20260601T012516.png`.
-- A Photos/Music permission prompt seen during this proof was traced through unified logs to
-  macOS TCC attribution contamination: `responsible=dev.clawdnd.app`, but the actual accessor was
-  `/usr/bin/find` launched by the test/diagnostic environment. Treat that screenshot prompt as harness
-  contamination unless a clean run shows `WorldOSApp`/WebKit itself accessing a protected library path.
-- The next gate evidence step is issue #466: a clean non-partial five-persona RRI from one explicit SHA.
-  The easiest current path is a support-VM sweep pinned to `9545383`, gated first by
-  `qa/support_vm_preflight.py --expected-sha 9545383`, and paired with the `9545383` handoff JSON. If the
-  sweep runs on a newer `origin/main` tip, rerun the Mac handoff on that same SHA first.
-  Heavy backend/persona sweeps belong on the owner-provided 32GB support VM (`support-vm-1`) once auth/config
-  are intentionally installed there; connection details are kept outside tracked docs. In this Codex Desktop
-  session a read-only operator-endpoint scout reached the VM and confirmed `evaos-support` has ~32 GB RAM,
-  16 CPUs, `git`, `python3`, `uv`, Node/npm, Codex CLI, Playwright, and private art, but its WorldOS checkout
-  is `4524b3e` and behind the `9545383` proof baseline; GitHub origin query/sync failed in batch mode; Codex
-  auth/config was not proven. Get operator approval for VM repo sync/auth setup, verify `origin/main` is
-  queryable from the VM, and define artifact return before the heavy sweep. Mac-only built-app launch/play
-  proof stays on this Mac or macOS CI.
-- Built-app diagnostic evidence exists, but release truth is still absent. The PR #475 pre-merge app-code
-  proof `8bd833f` (`codex-app-headproof-20260601T043909`) was trace-clean. The post-merge main proof
-  `32ca561` (`post475-main-app-proof-20260601T051230`) was playable with private art, Alfira, five enabled
-  actions, and a resolved `/move`, but provider trace noise persisted. The current-main `19c3fd0` proof
-  (`codex-current-main-proof-20260531T234242Z`) repeated the product pass on the actual built app:
-  private art root present, Codex provider, live campaign/run, writable `/move`, Alfira active, five enabled
-  actions, visible narration, one accepted player move, chat roles `dm, player, dm`, and
-  `/session-surface` still live/actionable. Its provider trace still recorded 3 failed/cancelled tool calls
-  (`log_event`, `log_event`, `persist_beat`). The follow-up #479 branch proof `b081092`
-  (`codex-479-traceclean-nodup-proof-20260601T003002Z`) reran the built `WorldOS.app` with private art,
-  accepted and resolved a real `/move`, kept `/session-surface` live/actionable, exported
-  `app-evidence/manifest.json` with no gaps, and produced a provider trace summary with zero parse errors
-  and zero failed/error tool calls. Native accessibility review also showed the chronicle rendered the opening
-  and follow-up once each after suppressing engine-logged `/chat` duplicates. PR #500 merged that fix, and the
-  merged-main proof `f7ab6d7` (`codex-main-f7ab6d7-proof-20260601T010058Z`) repeated the built-app run:
-  private BG art present, Codex provider, Alfira active, five enabled actions, writable `/move`, one accepted
-  player move, chat roles `dm, player, dm`, `/session-surface` still live/actionable, native after-move
-  screenshot archived, `app-evidence/manifest.json` with no gaps, and `provider-errors.after-move.json`
-  reporting zero parse errors plus zero failed/error tool calls. This is sufficient to close #479 as a
-  merged-main diagnostic; it is still not an RRI release verdict.
-- The post-#505 product-code handoff gate `handoff-20260601T085319Z-fd9dba5` then reproved the fast GUI
-  velocity loop: web-scripted smoke 5 moves, built-app scripted smoke 5 moves,
-  built-app Codex playtest 1 move, private art present, active player, five enabled actions, zero evidence
-  gaps across all three manifests, and Codex trace `failed_or_error_count=0` with `line_count=177`.
-  `qa.release_readiness.validate_handoff_json(..., "fd9dba5")` returned `valid=True` and `gaps=0`.
-- The post-#508 handoff gate `handoff-20260601T100304Z-9545383` then reproved the same fast GUI
-  velocity loop on product build `9545383`: web-scripted smoke 5 moves, built-app scripted smoke 5 moves,
-  built-app Codex playtest 1 move, private art present, active player, five enabled actions, zero evidence
-  gaps across all three manifests, and Codex trace `failed_or_error_count=0` with `line_count=80`.
-  `qa.release_readiness.validate_handoff_json(..., "9545383")` returned `valid=True` and `gaps=0`.
-  This supersedes the `fd9dba5` handoff as current app-wiring proof. It remains diagnostic and cannot
-  replace the full five-persona RRI.
-- The agent-grade testability layer now has real code merged: `GET /app-status` exposes the live run,
-  campaign, provider, private-art presence, move sink, actor, enabled actions, readiness, and failure buckets
-  without mutating state; the scripted provider can prove wiring behind a dev/test gate; and stable a11y/DOM
-  hooks make the UI more driveable. A current-session `:8899` probe briefly showed `080497e`, scripted
-  provider, private art root at `/Users/lume/ClawDnD-val`, `can_act:true`, five enabled actions,
-  `ready_for_smoke:true`, and no reported console/network failures; a later read found the port already
-  down. Browser-based checks should use the live port discovered from `run.json` or `/app-status`, and if
-  a browser session cannot reach local URLs, fall back to `/app-status`, `/session-surface`, app screenshots,
-  and exported evidence. Treat fixed ad-hoc ports as transient harness/observability evidence only, never
-  built `.app` proof.
-- Product direction is now UX-first (#467). Do not turn the next sprint into more gate hardening, proxy adapters,
-  transport/security work, UGC/legal, or renderer branches unless #466 proves they block the player-facing
-  session. The game must feel launchable, clickable, responsive, and deep before it needs more machinery.
-- Highest-confidence UX risks to verify/fix next: broader click hit areas (#309) after #470's
-  shared-chrome proof; built-app title/chrome truth (#306); launcher clarity/stale campaigns (#358);
-  per-beat latency/live response (#393); portrait/gallery blockers (#379); and CRPG depth on
-  Heroes/Battle/Inventory (#308/#318/#310, with #462/#463 folded into Battle readability as presentation containment).
+> Moved out of this file during the 2026-06-02 consolidation to keep the operating goal short.
+> The live state is the STATE-OF-TRUTH block at the top of this file; the running score ledger is
+> `qa/SCORECARD.md`. The historical PR-by-PR narrative (former §9) and the UX-first sprint order
+> (former §10) now live in **`docs/archive/OPERATING-GOAL-PR-LOG.md`** for provenance.
 
----
-
-## 10. UX-FIRST SPRINT ORDER (after takeover stabilization)
-
-Use the gate as evidence, not as the roadmap. The next sprint should optimize the felt session:
-
-1. **Stretch first-turn proof into a short built-app playtest.** PARTIAL. PR #475, #500, and follow-up proofs show
-   a fresh player can launch,
-   choose/start/resume, reach the Table, submit multiple `/move`s, and see narration resolve without
-   critical console/runtime errors. Current main now has trace-clean real-provider evidence for #479.
-   Evidence must be built-app
-   screenshots plus `/app-status`,
-   `/session-surface`, move/chat/provider artifacts, not a proxy preview.
-2. **Fix the "this is not clickable" feeling.** Close #309 only when clicking any visible tab/button
-   background works with mouse and keyboard. Pair with visual truth for #306 so the title/day/chrome no
-   longer look broken at common widths.
-3. **Make the launcher feel like a real game shelf.** Remove stale/scratch campaign noise (#358), make
-   bridge/no-bridge state honest, and ensure each chronicle looks distinct enough to choose.
-4. **Make slow turns feel alive.** Verify #393/#394-style streaming in a real built-app run; if text does
-   not appear within the first 15-30 seconds of a turn, prioritize streaming/proof-of-life UX over more
-   backend hardening.
-5. **Add CRPG depth where players look for it.** Heroes spellbook/manage-spells (#308), Battle readability
-   (#318, including #462/#463 token containment/alignment as presentation truth), Inventory/paper-doll
-   feel (#310), and portrait/race gallery continuity (#379) beat proxy/security work until the session
-   feels like a game.
-
----
 
 *The mechanics are the floor. The launchable, playable, felt prestige session in the built app is the
 product. Build toward the North-Star ceiling; use THIS loop to keep the floor under the user's feet

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -5,10 +5,12 @@
 > legacy. This runbook is the public project map + read order. Machine-specific
 > agent notes such as `CLAUDE.md` are intentionally local-only and gitignored.
 >
-> **Takeover routing, 2026-06-01:** current release/gate state lives in
-> `WorldOS-OPERATING-GOAL.md` first, then `WorldOS-GUI-RUNBOOK.md`, `qa/QA_TOOLS.md`, and
-> `qa/SCORECARD.md`. The work queue later in this file is historical unless it agrees with those
-> sources.
+> **Routing (consolidated 2026-06-02):** current release/gate state lives in
+> `WorldOS-OPERATING-GOAL.md` first (its STATE-OF-TRUTH block), then this file, `qa/QA_TOOLS.md`, and
+> `qa/SCORECARD.md` (the human score ledger). The former `WorldOS-GUI-RUNBOOK.md` is now merged into
+> this file (see "THE GUI / NATIVE-APP LOOP" below); the original is preserved at
+> `docs/archive/WorldOS-GUI-RUNBOOK.md`. The detailed historical work-queue that used to live at the
+> bottom of this file is now at `docs/archive/RUNBOOK-WORK-QUEUE.md`.
 > **Local/VM routing, 2026-06-01:** `/Users/lume/ClawDnD-val` is the synced local app/private-art
 > checkout and should be used for GUI/native-app testing. Use `/Volumes/LEXAR/Codex` for evidence,
 > snapshots, and logs; do not make Lexar the default GUI runtime tree because external-drive
@@ -27,7 +29,9 @@
 > If an operator hands you local session notes or decision records, treat them as
 > private working artifacts unless they are intentionally promoted into tracked docs.
 >
-> Last updated: 2026-06-01T17:24:00+07:00 (`9545383` is the latest same-SHA app-proof build; docs-only tips may sit above it, and release notes below are historical context).
+> Last updated: 2026-06-02 (consolidation). The last fast handoff proof was on `9545383`, but **code/QA
+> commits have since landed above it on `origin/main`** (verified 2026-06-02 — NOT docs-only), so that SHA
+> is stale as a "current" baseline; re-prove on the current SHA. Release notes are historical context.
 >
 > **Graphics & game-types roadmap (canonical):** the long-term plan for the kinds of games
 > WorldOS can produce (GT0 narrative dashboard → GT1 SNES pixel → GT2 Pillars/BG isometric)
@@ -242,6 +246,160 @@ critical/high** adversarial defects.
 
 ---
 
+## THE GUI / NATIVE-APP LOOP (merged from the former GUI runbook)
+
+> How to test→fix→LOOK the WorldOS GUI on the REAL surface and drive it to a 10/10 release. Born from
+> the 2026-05-31 reorientation: the prior loop scored a HEADLESS PROXY served from worktrees WITH NO ART,
+> so every visible defect (no palette, no images, no map, unformatted chronicle, phantom companion)
+> sailed past. This loop makes that impossible to repeat. The product is the **launchable, played `.app`**;
+> a green score on any other surface is a measurement bug, not progress.
+
+### The two surfaces (never confuse them)
+- **ITERATE — visible, playable, fast:** the OpenWorlds viewer served **from the local canonical repo**
+  `/Users/lume/ClawDnD-val` (which HAS the ~2.9 GB `content/worlds/_private` art) as a LIVE PLAYABLE
+  session on **fixed port 8799**. Fix one thing at a time and LOOK here.
+- **GATE — truth:** the built `dist/WorldOS.app` via `qa/ui_playtest_app.sh` (part A native #356 +
+  part B persona loop). Release is judged here. Same viewer code; adds the native shell. A non-local
+  worktree may serve art only via `WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val`, but prefer the local
+  checkout because external-drive file prompts have broken local AI tests.
+
+### Fresh-GUI-agent quick start — the hybrid handoff gate
+Before spending budget on long persona runs, run the handoff gate on the current commit. It catches
+stale tabs, dead launchers, missing private art, missing actor/actions, failed `/move`, no narration,
+console/network errors, provider trace failures, and evidence gaps.
+```bash
+cd /Users/lume/ClawDnD-val
+python3 qa/app_handoff_gate.py --web-beats 5 --built-beats 5 --codex-moves 1 \
+  --art-root /Users/lume/ClawDnD-val --scripted-budget 1.00 --codex-budget 3.00 \
+  --timeout 90 --codex-timeout 240
+```
+Writes `/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/<run-id>/`. Review `handoff.json`
+first, then each gate's `app-evidence/manifest.json`, `app-status.*.json`, `session-surface.*.json`,
+screenshots, moves, console/network/action logs, provider trace. `handoff_score=100` means the GUI
+wiring loop is trustworthy **for implementation velocity** — it is NOT release-ready evidence by itself.
+
+| Command | Use it for | Do not treat it as |
+|---|---|---|
+| `scripts/play.sh ... 8799` | Fast local LOOK loop on canonical repo with private art | Built-app proof |
+| `qa/app_handoff_gate.py` | Fast web + built-app scripted smoke + short Codex playtest | Full release verdict |
+| `qa/ui_playtest_app.sh` | Native app harness, native Part A+B evidence, failure buckets | Five-persona sweep by itself |
+| `qa/ui_playtest.sh` | Blind browser persona diagnostics (#324) | Built-app product proof |
+| `qa/release_readiness.py --handoff-json ...` | RRI rollup + verdict when paired with complete persona evidence | A substitute for missing persona artifacts |
+
+Ports: `8799 /openworlds/` = canonical fast-iteration; `8899` = scripted/dev harness (valid only when
+same-port `/app-status` is live); native app uses a dynamic port — read `run.json` or
+`/app-status.viewer.port`, never guess. The handoff gate accepts five enabled actions; the RRI
+palette-live gate is stricter (≥6 enabled actions on a `can_act:true`, disk-backed surface).
+
+### Stand up the iteration surface (8799, playable, from canonical)
+```bash
+cd /Users/lume/ClawDnD-val
+git rev-parse --short HEAD && git rev-parse --short origin/main   # confirm synced
+pkill -f 'viewer/server.py'; pkill -f 'scripts/play.sh'; pkill -f 'play_party.sh'   # NOT the Eva gateway
+CLAWDND_PLAY_PORT=8799 nohup bash scripts/play.sh baldurs-gate preview-$(git rev-parse --short HEAD) 8799 > /tmp/wos-8799.log 2>&1 &
+```
+Open `http://127.0.0.1:8799/openworlds/`. The DM cold-open takes ~30–90s; **wait for a SEATED PC**
+(party non-empty), not just `can_act:true` — `can_act` can flip true before the PC is seated.
+
+### LOOK (verify by curl + screenshot — NEVER a single Read; the channel fabricates)
+The tool channel intermittently returns fabricated/empty/doubled reads (it has invented a palette-disabled
+bug and a scene-404 that were both false). **Ground every load-bearing claim in ≥2 clean reads + an HTTP
+code/checksum.**
+```bash
+curl -s http://127.0.0.1:8799/session-surface | python3 -c 'import json,sys;d=json.load(sys.stdin); \
+  print("party",[(p["name"],p.get("kind")) for p in d.get("party",[])]); \
+  print("palette",[a["id"] for a in d.get("availableActions",[]) if a.get("available")]); \
+  print("can_act",d.get("can_act"))'
+# images: curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:8799/image?scope=location:loc-lower-city"
+```
+Per-fix visual checklist: palette buttons present + enabled in the MAIN column · a click resolves a turn ·
+portraits/scene/map images 200 · a multi-paragraph DM beat renders as paragraphs · prose streams mid-turn
+(`/events` count climbs) · a SOLO session has the PC alone.
+
+### Fix one thing → PR → merge → rebuild → LOOK
+1. Confirm the symptom on 8799 with ≥2 clean reads. If it doesn't reproduce, it's a stale/corrupt read —
+   do NOT fix it.
+2. Builder agent in a **same-disk local worktree off origin/main** when GUI/app tests need art:
+   `git -C /Users/lume/ClawDnD-val worktree add -B codex/<slug> /Users/lume/WorldOS-worktrees/wos-<slug> origin/main`.
+   Lexar worktrees remain fine for docs/backend/non-GUI slices that do not launch the viewer/app.
+3. PR → CI green (incl. `viewer-tests`) → admin-squash-merge → delete branch → prune worktree.
+   **Builder PRs sometimes fail to push silently** — always `gh pr view <n>` / `git ls-remote origin <branch>`
+   to confirm the branch+PR EXIST before relying on them.
+4. `git pull --ff-only` local canonical → restart 8799 → LOOK → record the proof in `qa/SCORECARD.md`.
+
+### Agent-facing app contract
+- `GET /app-status` and `GET /__worldos/app-status.json` are **read-only** probes for agents/harnesses:
+  build/version, viewer port, state root, provider, private-art-root presence, live campaign/run, move
+  sink, active actor, enabled actions, canonical endpoints. They must not mutate state.
+- Use `/app-status` before screenshots when diagnosing the built app. A built-app proof that cannot
+  produce this status object is a harness/observability failure. `qa/ui_playtest_app.sh` captures launcher
+  and minted-provider `app-status` JSON into the native evidence folder. See
+  `docs/AGENT_GRADE_APP_TESTABILITY.md` for the full contract.
+- Native provider reality check: OpenWorlds native-start honors the macOS app's selected provider (#472);
+  if the web UI hasn't loaded app-status it omits `provider` and Swift's `selectedProviderRaw` decides.
+  The Codex path has two wrappers — `scripts/play_codex_dm.sh` (the selected provider's DM loop) and
+  `scripts/play_codex_actor.sh` (constrained player/companion actor). Do not swap them. A wrapper run is
+  not release proof by itself.
+
+### The gate sweep (judged on the built `.app`)
+```bash
+WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val \
+qa/release_gate.sh --personas newbie,veteran,adversarial,narrative,optimizer --budget 12 --port 8785
+```
+RRI 10/10 = all 11 gates (OPERATING-GOAL §4) hold on ONE build across the five canonical personas. The
+scorer must record required/expected/completed/missing personas + explicit evidence gaps, disk-backed
+behavioral, UI-audit, image denominator/source, palette-live evidence, per-run Part B pass status, and
+same-build SHA. Append every `--scorecard-row` to `qa/SCORECARD.md`. Only a non-partial,
+non-harness-contaminated 10/10 row with no evidence gaps counts as release evidence.
+
+### Support VM lane (heavy sweeps, not Mac-only app truth)
+- Target: owner-provided **32GB support VM** (`support-vm-1`); connection/auth details live in local
+  operator-only runbooks/evidence, **not** tracked repo docs. Do not assume it is ready for Codex runs
+  until credentials/config are intentionally installed and verified.
+- Default VM persona lane is Codex DM + Codex UI player (Claude only when explicitly selected). The Codex
+  lane needs Codex CLI `>=0.120.0` (per-invocation `codex exec -c mcp_servers.*` overrides).
+- Do **not** use it as proof for Mac-only surfaces (`WorldOS.app` build/launch, native #356, built-app UI
+  play). Those stay on this Mac or macOS CI.
+- VM preflight before any RRI sweep, via the repo-owned writer:
+  ```bash
+  python3 qa/support_vm_preflight.py --repo /root/worldos-qa/WorldOS --expected-sha <SHA> \
+    --provider codex --player-agent codex --art-root /root/worldos-qa/WorldOS \
+    --private-art-mode required --artifact-dir /tmp/worldos-support-vm-preflight-<SHA> \
+    --artifact-return-target /Volumes/LEXAR/Codex/worldos-support-vm-rri/<SHA>-preflight
+  ```
+  It is read-only w.r.t. WorldOS state, writes `support_vm_preflight.{json,md}`, redacts secrets, and
+  exits non-zero if same-SHA/origin/tool/auth/private-art blockers would make the sweep untrustworthy.
+  [UNVERIFIED, carried from the prior runbook] A read-only scout reached `evaos-support` (~32 GB RAM, 16
+  CPUs, `uv`/Node/`codex-cli 0.120.0`/Playwright/private art) but its checkout was stale (`4524b3e`),
+  batch-mode `git` could not query the HTTPS origin, Codex auth was unproven, and `/Volumes/LEXAR/Codex`
+  did not exist on the VM. Approve/sync the VM, prove Codex auth, make `origin/main` queryable, and define
+  artifact return before #466.
+- Split Mac/VM rollup: pass the Mac proof as
+  `--handoff-json /Volumes/LEXAR/Codex/worldos-agent-grade-app-testability/<handoff>/handoff.json`
+  alongside VM persona dirs from the **same** SHA. RRI satisfies the native gate from the Mac handoff only
+  if all required gates+manifests are same-SHA, clean, private-art-present, gap-free. Mixed-SHA/missing
+  artifacts stay `partial` / `harness_contaminated`.
+
+### macOS privacy-prompt triage
+A macOS Photos/Music prompt during local proof can be a **test-process attribution artifact**: TCC may
+name the frontmost WorldOS app as `responsible` while the actual `accessing` process is a diagnostic
+command (`/usr/bin/find`, `codex`). Before filing as a product blocker, inspect:
+```bash
+/usr/bin/log show --style compact --last 10m \
+  --predicate 'eventMessage CONTAINS[c] "dev.clawdnd" OR eventMessage CONTAINS[c] "kTCCServicePhotos" OR eventMessage CONTAINS[c] "kTCCServiceMediaLibrary"'
+```
+If `AUTHREQ_ATTRIBUTION` shows `accessing=/usr/bin/find` or `=codex`, classify as harness contamination
+and rerun without broad filesystem scans while the app is frontmost. If `WorldOSApp`/a WebKit child
+directly accesses a protected path, treat it as a release-blocking bug.
+
+### Release (when RRI = 10/10 on a fresh `.app` build)
+Bump `.claude-plugin/plugin.json` (current `1.0.3` → `1.0.4`), tag `v1.0.4`, GitHub release + CHANGELOG.
+Then MAINTAIN: every PR touching `viewer/ | macos/ | skills/ | servers/engine/` → rebuild + RRI sweep +
+SCORECARD row; any regression (a critical bug, a sub-7 persona, sub-threshold score, image <95%, dead
+palette) reverts the goal to "fix" and outranks new work.
+
+---
+
 ## AGENT DELEGATION
 
 Orchestrate via subagents; verify from the top.
@@ -305,131 +463,11 @@ out freely. Only **`claude -p` QA is host-heavy** (the duo/sprint spin up engine
 
 ## CURRENT STATE + WORK QUEUE
 
-**Historical snapshot, not current authority:** this queue was written around `ea815fc`
-(2026-05-27 cont.3). During the 2026-05-31 takeover, the gate-truth stabilization merged as PR #465,
-the UX-first doc sync merged as PR #468, and first-minute click/title chrome proof merged as PR #470.
-Local routing sync merged as PR #471, native provider-selection sync merged as PR #472, takeover
-state docs synced as PR #473, Codex-DM app observability merged as PR #475, scripted smoke provider merged
-as PR #494, stable agent UI hooks merged as PR #495, failure-bucket/RRI split metadata merged as PR #496,
-and takeover truth sync merged as PR #498, followed by PR #499 recording current-main built-app proof
-PR #500 fixing Codex-DM provider trace cancellations, PR #501 recording that proof in docs, and
-PR #504 adding the 100/100 hybrid app handoff gate, PR #505 adding the RRI `--handoff-json`
-bridge for Mac app proof, PR #506 syncing docs to that proof, and PR #508 adding the support-VM
-preflight artifact gate.
-The local app/private-art checkout should stay fast-forwarded to `origin/main`; the only current gate
-truth lives in `WorldOS-OPERATING-GOAL.md` + `WorldOS-GUI-RUNBOOK.md` + `qa/SCORECARD.md`. Do not use
-this section to decide release state. The next sprint is UX-first (#467):
-fast handoff play is proven diagnostically on `9545383` rather than automatically on later docs-only tips,
-including private art, Codex DM, an active player,
-five enabled actions, one accepted/resolved `/move`, no evidence-manifest gaps, zero failed/error provider
-trace events, and a post-merge `handoff_score=100`. With #479 proven and #504/#505 merged, run #466 only after
-support-VM routing/auth/config preflight is explicit; this session's read-only check found the local
-`support-vm-1` SSH alias did not resolve and the operator-endpoint VM checkout was stale at `4524b3e`.
-Then prioritize clickability/chrome, launcher clarity,
-live-response feel, and CRPG depth before more hardening/proxy/security work.
-
-**LATEST (2026-05-27 cont.3) — the Quest & Arc engine is COMPLETE + WIRED, all combat
-defects closed, and the sibling's draft-PR backlog is fully landed.** Since the queue
-below was written: L3 events (#196), faction arcs (#205), the DM-wiring (#203), the North
-Star doc (#206), the full combat-fidelity wave (#207/#209/#210/#211/#213→**#215** maneuver
-die — all 6 flagged combat defects CLOSED), canon content-fill (**#216** — 4 stumble-into
-Events + 2 faction arcs + 2 decision-gated agendas), and **all 10 sibling roadmap-squeeze
-PRs** (#190/#192/#199/#191/#197 engine + #204/#201/#202/#198/#187 viewer) merged after a
-2-agent read-only triage. **Combat-sprint at a new high: angry-dm 3.7** (combat core "clean
-— every number traces to a tool call"); residual is DM adherence (monster reactions #218)
-+ narration nits (#219), not engine. distill now surfaces auto-fired repeat-saves +
-maneuver damage (#217). IN FLIGHT: a post-content-fill story-lift duo (does story clear
-4.3?) + the **2nd-seed generativity spike** (the North Star deliverable-B gate — a thin
-ORIGINAL non-BG world, zero engine changes; branch `spike/second-seed-generativity`).
-The detailed queue below is now mostly HISTORICAL — read `implementation-notes.html` +
-`qa/SCORECARD.md` for the live state.
-
-### Quest & Arc engine (the living-story skeleton — `decision-quest-arc-engine.md`)
-- **L1 — rule-of-three** (`Quest.evolves_to` + `callback_in_days`; `complete_quest`
-  schedules the follow-on via `consequences.schedule`) — **MERGED #185**.
-- **L2 — decision-gated flips** (`CompanionAgenda.decision_flag` adds +0.30 to the
-  attitude-gated betrayal roll; the breaking-point guard is checked FIRST so it never fires
-  above threshold; warning bands telegraph) — **MERGED #189**.
-- **L3 — Event / ParleyOption / Outcome** (the first-class Kingmaker decisional; thin
-  wrapper over `_apply_structured_effect`; converges with the parley research; an Event
-  Outcome sets a decision_flag → the L2↔L3 seam) — **BUILDING** (design in flight).
-- **BUILD-NEXT — faction-growth arcs** (the Skyrim/Kingmaker join→grow→lead): additive
-  `Faction` fields (`rank`, `standing`, `joined`, `questline_arc_id`) + generalize the
-  companion stage-machine into a faction-owned `Arc` gated on `Faction.reputation`.
-  **QUEUED.** (Closes the "rep is tracked but reads nothing" gap.)
-- **DM-skill WIRING + canon content-fill** (author Raphael / Flaming-Fist into agendas +
-  quest `evolves_to` chains) — **QUEUED**, per wave.
-- **DEFER** — kingdom/guild-building continuation (tick the inert `RegionControl`/
-  `FactionAsset` primitives). Far-future.
-
-### Other engine / QA threads
-- **Campaign Director (#72)** — `director.py` + `scene_debt.py` + 3 advisory tools.
-  **MERGED + integrated** (DM consults `get_campaign_director` each beat → `add_quest` gap
-  closed in play). #71 (path-compiler) + #73 (predicates) deferred until a world authors an
-  `adventure_path`.
-- **Combat-fidelity fixes** — Multiattack economy (#181), Round-1 turn-skip ENGINE block
-  (#183), Guiding-Bolt-on-hit (#188) all **MERGED**. Residual: broader DM-adherence /
-  class-feature coverage (issue **#166**) — push via the reach-for pattern + a richer sprint
-  seed, not engine force.
-- **Observability (#184)** — snapshot version-stamp (`schema_version` + `engine_sha`) +
-  centralized QA findings collector (`qa/collect_findings.py`) — **MERGED**. Possible next
-  slice: a real-play event log.
-- **#143 variant matrices** — foundation ~90% shipped; remaining = (a) doc the weight
-  convention in `content/worlds/README.md` (common 11 / uncommon 6 / rare 2 / very_rare 1
-  on a ~20 base), (b) author canon variant CONTENT (free-rollable slots first), (c) ONE
-  engine bit: generalize the companion agenda-roll to rare non-companion NPC flips (cap
-  ~0.07, 3–7%/scene). **GATED on an owner glance** at the quest-idea boundary before a big
-  content push.
-- **#141 Parley → AI-player relay** — reopened; the relay was never built. Pairs with
-  L3 / the social encounter type.
-- **Party-ensemble betrayal validation** — `run_party.sh` not exercised since L2 shipped;
-  restore it to validate the decision-flip in play.
-
-### NATIVE DESKTOP APP — the play path (IN SCOPE; was the sibling lane)
-The macOS/OpenWorlds Swift shell is now part of this lane (the old "another agent owns it,
-stay out" note is retired; those PRs #150/#182/#187/#190-192 are merged). The app
-(`macos/WorldOSApp/`, built by `script/build_and_run.sh run` → `dist/WorldOS.app`) is a
-WKWebView loading the **live worktree** viewer at `/openworlds/` — so a **viewer/JS change
-lands on app relaunch with NO Swift rebuild** (the swift build is a ~0.1s no-op).
-
-**How in-app PLAY works (2026-05-27 cont.26 — the read-only→functional fix):**
-- The OpenWorlds launcher Play buttons call the native bridge
-  `OpenWorldsNative.request("startProviderSession",{provider?,world,runId,companions})`
-  (`screen-launcher.jsx`). `provider` is optional: when the web surface has not loaded app status yet,
-  Swift `RootView.startProviderFromBridge` falls back to the macOS app's `selectedProviderRaw` setting.
-  Swift then asks `AppProcessService.startProviderSession` to launch the selected provider on a fresh
-  port and returns `{url}`; the JS then `window.location.assign(reply.url)` — drive the reload from
-  **JS**, not the Swift `webURL` @State (which didn't repoint reliably across the async hop).
-- The Claude provider still shells **`scripts/play.sh`** / `scripts/play_party.sh`. `play.sh` IS the play loop:
-  it binds a viewer with `CLAWDND_PLAYER_MOVES` +
-  `CLAWDND_VIEWER_CHAT` set (→ `_live_play()` true) and runs a `claude -p` DM watching the
-  move sink. `POST /move` → sink; `/chat?since=` → DM narration the Session tails.
-- The checked-in Codex provider now defaults to `scripts/play_codex_dm.sh`, a DM wrapper that owns
-  the live viewer, the engine/rules/voice MCP contract, `chat.jsonl`, and `player_moves.jsonl`.
-  Keep `scripts/play_codex_actor.sh` as the constrained player/companion actor helper through
-  `player_server.py`; it is not the native provider's DM loop. OpenClaw still requires an explicit
-  configured command before it can be treated as a startable provider.
-- Agents and app harnesses should read `GET /app-status` before trying to infer state from pixels or
-  process lists. It is a read-only contract for the live OpenWorlds surface: provider, run/state roots,
-  private-art presence, active campaign/session, move sink, actor, enabled actions, and canonical endpoints.
-  The built-app harness captures launcher and minted-provider app-status JSON as release evidence.
-- **`can_act = _live_play() AND is_live_view`**, and `is_live_view` requires
-  `cid == self.campaign_id`. The viewer launches with an EMPTY campaign id; `_resolve_campaign`
-  lazily sets `self.campaign_id` to the **current** campaign (`_pick_campaign`). So the
-  ★gotcha★: the SPA must VIEW the live/current campaign — `app.jsx` auto-routes launcher→table
-  when `runningProvider` is set, **re-polls `campaigns.json` (4s), and auto-follows the
-  `current` campaign** so the surface binds to the DM-minted run, not a stale save the
-  one-shot catalog pick had selected. Verify playable: `curl /session-surface` → `can_act:true`.
-- **Footguns (all fixed cont.26, watch for regressions):** (1) a Finder/Dock GUI launch gets
-  launchd's minimal PATH → `claude`/`uv` not found; `launch_common.sh:clawdnd_augment_path`
-  prepends `~/.local/bin`+Homebrew. (2) `play.sh`/`play_party.sh` traps must SEPARATE EXIT
-  (cleanup) from INT/TERM (cleanup+`exit`) or SIGTERM resumes the loop (wedged orphan). (3)
-  `AppProcessService` does NOT kill its viewer child on app SIGTERM → orphaned viewers accrue
-  across relaunches (still open — terminate-on-quit TODO). (4) `play.sh` always starts a
-  FRESH campaign (true resume-by-id is a later enhancement).
-- **Critical files:** `RootView.swift` (startProviderSession bridge), `ProviderAdapters.swift`
-  (shells play.sh, ClaudeProvider.detect), `AppProcessService.swift` (PortFinder), `WebView.swift`
-  (bridge user-script `window.ClawDnDNative`), `screen-launcher.jsx` + `app.jsx`, `scripts/play.sh`.
+> Moved to `docs/archive/RUNBOOK-WORK-QUEUE.md` during the 2026-06-02 consolidation (it was already
+> self-labeled "Historical snapshot, not current authority"). For the live release state read the
+> STATE-OF-TRUTH block in `WorldOS-OPERATING-GOAL.md`; for the running score ledger read
+> `qa/SCORECARD.md`; for open GitHub work run `gh issue list` / `gh pr list`. Most Quest-Arc and
+> combat-fidelity items in that archive are MERGED and closed — it is kept for provenance only.
 
 ---
 

--- a/docs/AGENT_GRADE_APP_TESTABILITY.md
+++ b/docs/AGENT_GRADE_APP_TESTABILITY.md
@@ -10,7 +10,7 @@ not change the game architecture: the engine remains the sole writer, the native
 app/OpenWorlds viewer remains a thin reader plus `/move` intent submitter, and
 the built app remains release truth.
 
-Current command routing lives in `qa/QA_TOOLS.md` and `WorldOS-GUI-RUNBOOK.md`. This file defines
+Current command routing lives in `qa/QA_TOOLS.md` and `WorldOS-RUNBOOK.md`. This file defines
 the contract those tools must satisfy.
 
 ## Related Work

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # WorldOS — Architecture
 
 > Architecture map only. For current agent routing, GUI/native app proof, and QA commands, start with
-> `WorldOS-OPERATING-GOAL.md`, `WorldOS-GUI-RUNBOOK.md`, and `qa/QA_TOOLS.md`.
+> `WorldOS-OPERATING-GOAL.md`, `WorldOS-RUNBOOK.md`, and `qa/QA_TOOLS.md`.
 
 WorldOS is a Claude Code plugin: an **AI Dungeon Master + voiced AI companion** that
 plays D&D 5e. Its center of gravity is a **living-world engine** — the DM *generates*

--- a/docs/OPENWORLDS_FIDELITY_PLAN.md
+++ b/docs/OPENWORLDS_FIDELITY_PLAN.md
@@ -1,7 +1,7 @@
 # OpenWorlds Fidelity Rollout Plan
 
 > Historical rollout plan for the OpenWorlds integration. Current agent routing, app proof commands,
-> and release gating live in `WorldOS-OPERATING-GOAL.md`, `WorldOS-GUI-RUNBOOK.md`, `qa/QA_TOOLS.md`,
+> and release gating live in `WorldOS-OPERATING-GOAL.md`, `WorldOS-RUNBOOK.md`, `qa/QA_TOOLS.md`,
 > and `qa/SCORECARD.md`.
 
 This document supersedes the SwiftUI repaint direction explored in PR #123.

--- a/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
+++ b/docs/OPENWORLDS_NATIVE_APP_ROADMAP.md
@@ -3,7 +3,7 @@
 > Historical roadmap. Use this for architecture intent and old sprint context, not as the current
 > validation path. Current GUI/native app proof starts from the canonical local app/private-art checkout, uses
 > `qa/app_handoff_gate.py` or `qa/ui_playtest_app.sh` for app evidence, and uses
-> `qa/release_readiness.py` for release verdicts. See `WorldOS-GUI-RUNBOOK.md` and `qa/QA_TOOLS.md`.
+> `qa/release_readiness.py` for release verdicts. See `WorldOS-RUNBOOK.md` and `qa/QA_TOOLS.md`.
 
 Date: 2026-05-26
 

--- a/docs/OPENWORLDS_UI_AUDIT.md
+++ b/docs/OPENWORLDS_UI_AUDIT.md
@@ -2,7 +2,7 @@
 
 > Historical snapshot. This audit predates the built-app `/move` wiring, app-status/handoff harness,
 > scripted provider, and stable agent hooks. It is still useful as UX backlog context, but current app
-> proof and release routing live in `WorldOS-OPERATING-GOAL.md`, `WorldOS-GUI-RUNBOOK.md`,
+> proof and release routing live in `WorldOS-OPERATING-GOAL.md`, `WorldOS-RUNBOOK.md`,
 > `qa/QA_TOOLS.md`, and `qa/SCORECARD.md`.
 
 **Method:** live walkthrough of every screen via the preview server (`127.0.0.1:8799/openworlds/`).

--- a/docs/RELEASE_1.0_CHECKLIST.md
+++ b/docs/RELEASE_1.0_CHECKLIST.md
@@ -3,7 +3,7 @@
 > Historical checklist. Do not execute this as the current release path. Current release truth requires
 > the hardened non-partial RRI in `qa/release_readiness.py`, with same-SHA built-app proof and complete
 > persona evidence recorded in `qa/SCORECARD.md`. Start from `WorldOS-OPERATING-GOAL.md`,
-> `WorldOS-GUI-RUNBOOK.md`, and `qa/QA_TOOLS.md`.
+> `WorldOS-RUNBOOK.md`, and `qa/QA_TOOLS.md`.
 
 **Scope:** local/personal 1.0 build. The bundled `baldurs-gate` world ships as-is for
 personal use (Wizards Fan Content Policy). Public distribution and notarization are

--- a/docs/archive/GUI_WORKBOOK.md
+++ b/docs/archive/GUI_WORKBOOK.md
@@ -1,7 +1,12 @@
 # WorldOS GUI Workbook — historical GUI punch-list (verified findings)
 
+> **ARCHIVED 2026-06-02** — moved from `qa/GUI_WORKBOOK.md` to `docs/archive/` during the canonical-doc
+> consolidation. Historical reference only. For current operating truth see
+> `WorldOS-OPERATING-GOAL.md`; for the human score ledger see `qa/SCORECARD.md`. The GUI runbook was
+> merged into `WorldOS-RUNBOOK.md`.
+>
 > This file preserves verified GUI findings and punch-list rows. Current operating truth lives in
-> `WorldOS-OPERATING-GOAL.md`, `WorldOS-GUI-RUNBOOK.md`, `qa/QA_TOOLS.md`, and `qa/SCORECARD.md`.
+> `WorldOS-OPERATING-GOAL.md`, `WorldOS-RUNBOOK.md`, `qa/QA_TOOLS.md`, and `qa/SCORECARD.md`.
 > Historical rows may mention old SHAs or pre-handoff routing. Use them for context, not for deciding
 > current release state. "Verified" means observed on the live playable surface or read from canonical
 > source at the time recorded, not a proxy guess.

--- a/docs/archive/OPERATING-GOAL-PR-LOG.md
+++ b/docs/archive/OPERATING-GOAL-PR-LOG.md
@@ -1,0 +1,139 @@
+# WorldOS — OPERATING-GOAL archived PR-log + sprint order (§9/§10)
+
+> **ARCHIVED 2026-06-02** during the canonical-doc consolidation. This is the rambling §9 "CURRENT
+> STATUS" PR narrative and §10 "UX-FIRST SPRINT ORDER" that previously lived at the bottom of
+> `WorldOS-OPERATING-GOAL.md`. It was moved out so the operating goal stays a short GOAL + RRI gate +
+> a single STATE block.
+>
+> **Historical context only — does NOT override current truth.** For the live release state, read the
+> STATE block in `WorldOS-OPERATING-GOAL.md`. For the score ledger read `qa/SCORECARD.md`. SHAs below
+> were current as of 2026-06-01; many code/QA commits have since landed on `origin/main` above the
+> `9545383` proof (verified 2026-06-02: the post-`9545383` tips are NOT all docs-only — see the
+> consolidation note in the PR description).
+
+---
+
+## 9. CURRENT STATUS (2026-06-01T17:49:00+07:00 — latest same-SHA app proof was 9545383)
+
+- Repo truth stabilization merged in PR #465, UX-first doc sync merged in PR #468, first-minute
+  click/title chrome proof merged in PR #470, local/Lexar/support-VM routing merged in PR #471,
+  native provider selection merged in PR #472, and takeover docs synced in PR #473.
+  The takeover foundation then merged: PR #475 added the Codex-DM built-app provider path,
+  `/app-status`, evidence export baseline, and docs; PR #494 added the dev-gated scripted provider;
+  PR #495 added stable OpenWorlds accessibility / `data-worldos-testid` hooks; PR #496 added app
+  playtest failure buckets plus RRI gate-split metadata. PR #498 synced takeover docs after those
+  merges. PR #499 then recorded the current-main built-app proof, PR #500 fixed the Codex-DM
+  provider trace cancellations, PR #501 recorded that proof in the runbooks/scorecard, and PR #504
+  added the hybrid 100/100 app handoff gate. PR #505 then hardened the RRI bridge so Mac handoff
+  evidence can be supplied with `--handoff-json` while support-VM persona artifacts supply the heavy
+  sweep. PR #506 then synced these docs to the `fd9dba5` proof without changing product code. PR #508 added the
+  support-VM preflight artifact gate. The local app/private-art checkout `/Users/lume/ClawDnD-val` was
+  fast-forwarded to `9545383`, and the Mac app handoff was rerun on that exact SHA.
+- The stale local pre-sync artifacts were preserved before the fast-forward at
+  `/Volumes/LEXAR/Codex/worldos-local-checkout-snapshot-20260531T223923` and in `stash@{0}`
+  (`pre-sync local takeover docs 2026-05-31`). Treat those as evidence, not current release truth.
+- The `f5500ac` RRI (`2.7/10`) is preserved as partial evidence only. It proves the gate/harness was
+  not trustworthy enough for release scoring: one persona completed, others lacked `score.json`, and
+  image/palette/behavioral/UI audit sources were either missing or harness-contaminated.
+- Built-app launch smoke on `cad2e00` rendered OpenWorlds with private art, but the first Resume/Play
+  click still forced Claude and failed on Claude auth. PR #472 fixed that web/native selection bug.
+  PR #475 then added a separate Codex DM wrapper and points the native Codex adapter at it,
+  while keeping the older Codex actor wrapper as a constrained player/move-facade helper.
+- Early Codex-DM local built-app evidence is preserved: private BG art loaded,
+  Alfira seated as `player`, visible DM narration, enabled actions, a real player move appended to
+  `player_moves.jsonl`, and a post-move DM response with `can_act:true` in `/session-surface`.
+  Evidence is in `/Volumes/LEXAR/Codex/worldos-built-app-proof/`:
+  `session-surface-racefix-after-dm-response-20260601T012410.json`,
+  `worldos-racefix-first-turn-20260601T012110.png`, and
+  `worldos-racefix-dm-response-dismissed-permission-20260601T012516.png`.
+- A Photos/Music permission prompt seen during this proof was traced through unified logs to
+  macOS TCC attribution contamination: `responsible=dev.clawdnd.app`, but the actual accessor was
+  `/usr/bin/find` launched by the test/diagnostic environment. Treat that screenshot prompt as harness
+  contamination unless a clean run shows `WorldOSApp`/WebKit itself accessing a protected library path.
+- The next gate evidence step is issue #466: a clean non-partial five-persona RRI from one explicit SHA.
+  The easiest current path is a support-VM sweep pinned to a release-candidate SHA, gated first by
+  `qa/support_vm_preflight.py`, and paired with the same-SHA handoff JSON. If the
+  sweep runs on a newer `origin/main` tip, rerun the Mac handoff on that same SHA first.
+  Heavy backend/persona sweeps belong on the owner-provided 32GB support VM (`support-vm-1`) once auth/config
+  are intentionally installed there; connection details are kept outside tracked docs. In an earlier Codex Desktop
+  session a read-only operator-endpoint scout reached the VM and confirmed `evaos-support` has ~32 GB RAM,
+  16 CPUs, `git`, `python3`, `uv`, Node/npm, Codex CLI, Playwright, and private art, but its WorldOS checkout
+  was `4524b3e` and behind the `9545383` proof baseline; GitHub origin query/sync failed in batch mode; Codex
+  auth/config was not proven. Get operator approval for VM repo sync/auth setup, verify `origin/main` is
+  queryable from the VM, and define artifact return before the heavy sweep. Mac-only built-app launch/play
+  proof stays on this Mac or macOS CI.
+- Built-app diagnostic evidence exists, but release truth is still absent. The PR #475 pre-merge app-code
+  proof `8bd833f` (`codex-app-headproof-20260601T043909`) was trace-clean. The post-merge main proof
+  `32ca561` (`post475-main-app-proof-20260601T051230`) was playable with private art, Alfira, five enabled
+  actions, and a resolved `/move`, but provider trace noise persisted. The current-main `19c3fd0` proof
+  (`codex-current-main-proof-20260531T234242Z`) repeated the product pass on the actual built app:
+  private art root present, Codex provider, live campaign/run, writable `/move`, Alfira active, five enabled
+  actions, visible narration, one accepted player move, chat roles `dm, player, dm`, and
+  `/session-surface` still live/actionable. Its provider trace still recorded 3 failed/cancelled tool calls
+  (`log_event`, `log_event`, `persist_beat`). The follow-up #479 branch proof `b081092`
+  (`codex-479-traceclean-nodup-proof-20260601T003002Z`) reran the built `WorldOS.app` with private art,
+  accepted and resolved a real `/move`, kept `/session-surface` live/actionable, exported
+  `app-evidence/manifest.json` with no gaps, and produced a provider trace summary with zero parse errors
+  and zero failed/error tool calls. Native accessibility review also showed the chronicle rendered the opening
+  and follow-up once each after suppressing engine-logged `/chat` duplicates. PR #500 merged that fix, and the
+  merged-main proof `f7ab6d7` (`codex-main-f7ab6d7-proof-20260601T010058Z`) repeated the built-app run:
+  private BG art present, Codex provider, Alfira active, five enabled actions, writable `/move`, one accepted
+  player move, chat roles `dm, player, dm`, `/session-surface` still live/actionable, native after-move
+  screenshot archived, `app-evidence/manifest.json` with no gaps, and `provider-errors.after-move.json`
+  reporting zero parse errors plus zero failed/error tool calls. This is sufficient to close #479 as a
+  merged-main diagnostic; it is still not an RRI release verdict.
+- The post-#505 product-code handoff gate `handoff-20260601T085319Z-fd9dba5` then reproved the fast GUI
+  velocity loop: web-scripted smoke 5 moves, built-app scripted smoke 5 moves,
+  built-app Codex playtest 1 move, private art present, active player, five enabled actions, zero evidence
+  gaps across all three manifests, and Codex trace `failed_or_error_count=0` with `line_count=177`.
+  `qa.release_readiness.validate_handoff_json(..., "fd9dba5")` returned `valid=True` and `gaps=0`.
+- The post-#508 handoff gate `handoff-20260601T100304Z-9545383` then reproved the same fast GUI
+  velocity loop on product build `9545383`: web-scripted smoke 5 moves, built-app scripted smoke 5 moves,
+  built-app Codex playtest 1 move, private art present, active player, five enabled actions, zero evidence
+  gaps across all three manifests, and Codex trace `failed_or_error_count=0` with `line_count=80`.
+  `qa.release_readiness.validate_handoff_json(..., "9545383")` returned `valid=True` and `gaps=0`.
+  This superseded the `fd9dba5` handoff as app-wiring proof. It remained diagnostic and cannot
+  replace the full five-persona RRI.
+- The agent-grade testability layer now has real code merged: `GET /app-status` exposes the live run,
+  campaign, provider, private-art presence, move sink, actor, enabled actions, readiness, and failure buckets
+  without mutating state; the scripted provider can prove wiring behind a dev/test gate; and stable a11y/DOM
+  hooks make the UI more driveable. A current-session `:8899` probe briefly showed `080497e`, scripted
+  provider, private art root at `/Users/lume/ClawDnD-val`, `can_act:true`, five enabled actions,
+  `ready_for_smoke:true`, and no reported console/network failures; a later read found the port already
+  down. Browser-based checks should use the live port discovered from `run.json` or `/app-status`, and if
+  a browser session cannot reach local URLs, fall back to `/app-status`, `/session-surface`, app screenshots,
+  and exported evidence. Treat fixed ad-hoc ports as transient harness/observability evidence only, never
+  built `.app` proof.
+- Product direction is now UX-first (#467). Do not turn the next sprint into more gate hardening, proxy adapters,
+  transport/security work, UGC/legal, or renderer branches unless #466 proves they block the player-facing
+  session. The game must feel launchable, clickable, responsive, and deep before it needs more machinery.
+- Highest-confidence UX risks to verify/fix next: broader click hit areas (#309) after #470's
+  shared-chrome proof; built-app title/chrome truth (#306); launcher clarity/stale campaigns (#358);
+  per-beat latency/live response (#393); portrait/gallery blockers (#379); and CRPG depth on
+  Heroes/Battle/Inventory (#308/#318/#310, with #462/#463 folded into Battle readability as presentation containment).
+
+---
+
+## 10. UX-FIRST SPRINT ORDER (after takeover stabilization)
+
+Use the gate as evidence, not as the roadmap. The next sprint should optimize the felt session:
+
+1. **Stretch first-turn proof into a short built-app playtest.** PARTIAL. PR #475, #500, and follow-up proofs show
+   a fresh player can launch,
+   choose/start/resume, reach the Table, submit multiple `/move`s, and see narration resolve without
+   critical console/runtime errors. Current main now has trace-clean real-provider evidence for #479.
+   Evidence must be built-app
+   screenshots plus `/app-status`,
+   `/session-surface`, move/chat/provider artifacts, not a proxy preview.
+2. **Fix the "this is not clickable" feeling.** Close #309 only when clicking any visible tab/button
+   background works with mouse and keyboard. Pair with visual truth for #306 so the title/day/chrome no
+   longer look broken at common widths.
+3. **Make the launcher feel like a real game shelf.** Remove stale/scratch campaign noise (#358), make
+   bridge/no-bridge state honest, and ensure each chronicle looks distinct enough to choose.
+4. **Make slow turns feel alive.** Verify #393/#394-style streaming in a real built-app run; if text does
+   not appear within the first 15-30 seconds of a turn, prioritize streaming/proof-of-life UX over more
+   backend hardening.
+5. **Add CRPG depth where players look for it.** Heroes spellbook/manage-spells (#308), Battle readability
+   (#318, including #462/#463 token containment/alignment as presentation truth), Inventory/paper-doll
+   feel (#310), and portrait/race gallery continuity (#379) beat proxy/security work until the session
+   feels like a game.

--- a/docs/archive/RUNBOOK-WORK-QUEUE.md
+++ b/docs/archive/RUNBOOK-WORK-QUEUE.md
@@ -1,0 +1,139 @@
+# WorldOS — RUNBOOK archived "CURRENT STATE + WORK QUEUE"
+
+> **ARCHIVED 2026-06-02** during the canonical-doc consolidation. This is the historical
+> "CURRENT STATE + WORK QUEUE" section that previously lived near the bottom of
+> `WorldOS-RUNBOOK.md`. It was self-labeled "Historical snapshot, not current authority" and is moved
+> here so the runbook stays a clean HOW-TO (architecture + invariants + dev/QA loops + lessons).
+>
+> **Historical context only — does NOT override current truth.** For the live release state read the
+> STATE block in `WorldOS-OPERATING-GOAL.md`; for the score ledger read `qa/SCORECARD.md`. Most of the
+> Quest-Arc / combat-fidelity items below are MERGED and closed; they are kept for provenance.
+
+---
+
+## CURRENT STATE + WORK QUEUE (historical)
+
+**Historical snapshot, not current authority:** this queue was written around `ea815fc`
+(2026-05-27 cont.3). During the 2026-05-31 takeover, the gate-truth stabilization merged as PR #465,
+the UX-first doc sync merged as PR #468, and first-minute click/title chrome proof merged as PR #470.
+Local routing sync merged as PR #471, native provider-selection sync merged as PR #472, takeover
+state docs synced as PR #473, Codex-DM app observability merged as PR #475, scripted smoke provider merged
+as PR #494, stable agent UI hooks merged as PR #495, failure-bucket/RRI split metadata merged as PR #496,
+and takeover truth sync merged as PR #498, followed by PR #499 recording current-main built-app proof
+PR #500 fixing Codex-DM provider trace cancellations, PR #501 recording that proof in docs, and
+PR #504 adding the 100/100 hybrid app handoff gate, PR #505 adding the RRI `--handoff-json`
+bridge for Mac app proof, PR #506 syncing docs to that proof, and PR #508 adding the support-VM
+preflight artifact gate.
+The local app/private-art checkout should stay fast-forwarded to `origin/main`; current gate truth lives in
+`WorldOS-OPERATING-GOAL.md` + `qa/SCORECARD.md`. Do not use this section to decide release state.
+The next sprint is UX-first (#467):
+fast handoff play is proven diagnostically on `9545383` rather than automatically on later docs-only tips,
+including private art, Codex DM, an active player,
+five enabled actions, one accepted/resolved `/move`, no evidence-manifest gaps, zero failed/error provider
+trace events, and a post-merge `handoff_score=100`. With #479 proven and #504/#505 merged, run #466 only after
+support-VM routing/auth/config preflight is explicit; an earlier read-only check found the local
+`support-vm-1` SSH alias did not resolve and the operator-endpoint VM checkout was stale at `4524b3e`.
+Then prioritize clickability/chrome, launcher clarity,
+live-response feel, and CRPG depth before more hardening/proxy/security work.
+
+**LATEST (2026-05-27 cont.3) — the Quest & Arc engine is COMPLETE + WIRED, all combat
+defects closed, and the sibling's draft-PR backlog is fully landed.** Since the queue
+below was written: L3 events (#196), faction arcs (#205), the DM-wiring (#203), the North
+Star doc (#206), the full combat-fidelity wave (#207/#209/#210/#211/#213→**#215** maneuver
+die — all 6 flagged combat defects CLOSED), canon content-fill (**#216** — 4 stumble-into
+Events + 2 faction arcs + 2 decision-gated agendas), and **all 10 sibling roadmap-squeeze
+PRs** (#190/#192/#199/#191/#197 engine + #204/#201/#202/#198/#187 viewer) merged after a
+2-agent read-only triage. **Combat-sprint at a new high: angry-dm 3.7** (combat core "clean
+— every number traces to a tool call"); residual is DM adherence (monster reactions #218)
++ narration nits (#219), not engine. distill now surfaces auto-fired repeat-saves +
+maneuver damage (#217). IN FLIGHT: a post-content-fill story-lift duo (does story clear
+4.3?) + the **2nd-seed generativity spike** (the North Star deliverable-B gate — a thin
+ORIGINAL non-BG world, zero engine changes; branch `spike/second-seed-generativity`).
+The detailed queue below is now mostly HISTORICAL — read `qa/SCORECARD.md` for the live state.
+
+### Quest & Arc engine (the living-story skeleton — `decision-quest-arc-engine.md`)
+- **L1 — rule-of-three** (`Quest.evolves_to` + `callback_in_days`; `complete_quest`
+  schedules the follow-on via `consequences.schedule`) — **MERGED #185**.
+- **L2 — decision-gated flips** (`CompanionAgenda.decision_flag` adds +0.30 to the
+  attitude-gated betrayal roll; the breaking-point guard is checked FIRST so it never fires
+  above threshold; warning bands telegraph) — **MERGED #189**.
+- **L3 — Event / ParleyOption / Outcome** (the first-class Kingmaker decisional; thin
+  wrapper over `_apply_structured_effect`; converges with the parley research; an Event
+  Outcome sets a decision_flag → the L2↔L3 seam) — **MERGED #196**.
+- **BUILD-NEXT — faction-growth arcs** (the Skyrim/Kingmaker join→grow→lead): additive
+  `Faction` fields (`rank`, `standing`, `joined`, `questline_arc_id`) + generalize the
+  companion stage-machine into a faction-owned `Arc` gated on `Faction.reputation`.
+  **MERGED #205.** (Closes the "rep is tracked but reads nothing" gap.)
+- **DM-skill WIRING + canon content-fill** (author Raphael / Flaming-Fist into agendas +
+  quest `evolves_to` chains) — **MERGED #203/#216**.
+- **DEFER** — kingdom/guild-building continuation (tick the inert `RegionControl`/
+  `FactionAsset` primitives). Far-future.
+
+### Other engine / QA threads
+- **Campaign Director (#72)** — `director.py` + `scene_debt.py` + 3 advisory tools.
+  **MERGED + integrated** (DM consults `get_campaign_director` each beat → `add_quest` gap
+  closed in play). #71 (path-compiler) + #73 (predicates) deferred until a world authors an
+  `adventure_path`.
+- **Combat-fidelity fixes** — Multiattack economy (#181), Round-1 turn-skip ENGINE block
+  (#183), Guiding-Bolt-on-hit (#188) all **MERGED**. Residual: broader DM-adherence /
+  class-feature coverage (issue **#166**) — push via the reach-for pattern + a richer sprint
+  seed, not engine force.
+- **Observability (#184)** — snapshot version-stamp (`schema_version` + `engine_sha`) +
+  centralized QA findings collector (`qa/collect_findings.py`) — **MERGED**. Possible next
+  slice: a real-play event log.
+- **#143 variant matrices** — foundation ~90% shipped; remaining = (a) doc the weight
+  convention in `content/worlds/README.md` (common 11 / uncommon 6 / rare 2 / very_rare 1
+  on a ~20 base), (b) author canon variant CONTENT (free-rollable slots first), (c) ONE
+  engine bit: generalize the companion agenda-roll to rare non-companion NPC flips (cap
+  ~0.07, 3–7%/scene). **GATED on an owner glance** at the quest-idea boundary before a big
+  content push.
+- **#141 Parley → AI-player relay** — reopened; the relay was never built. Pairs with
+  L3 / the social encounter type.
+- **Party-ensemble betrayal validation** — `run_party.sh` not exercised since L2 shipped;
+  restore it to validate the decision-flip in play.
+
+### NATIVE DESKTOP APP — the play path (IN SCOPE; was the sibling lane)
+The macOS/OpenWorlds Swift shell is now part of this lane (the old "another agent owns it,
+stay out" note is retired; those PRs #150/#182/#187/#190-192 are merged). The app
+(`macos/WorldOSApp/`, built by `script/build_and_run.sh run` → `dist/WorldOS.app`) is a
+WKWebView loading the **live worktree** viewer at `/openworlds/` — so a **viewer/JS change
+lands on app relaunch with NO Swift rebuild** (the swift build is a ~0.1s no-op).
+
+**How in-app PLAY works (2026-05-27 cont.26 — the read-only→functional fix):**
+- The OpenWorlds launcher Play buttons call the native bridge
+  `OpenWorldsNative.request("startProviderSession",{provider?,world,runId,companions})`
+  (`screen-launcher.jsx`). `provider` is optional: when the web surface has not loaded app status yet,
+  Swift `RootView.startProviderFromBridge` falls back to the macOS app's `selectedProviderRaw` setting.
+  Swift then asks `AppProcessService.startProviderSession` to launch the selected provider on a fresh
+  port and returns `{url}`; the JS then `window.location.assign(reply.url)` — drive the reload from
+  **JS**, not the Swift `webURL` @State (which didn't repoint reliably across the async hop).
+- The Claude provider still shells **`scripts/play.sh`** / `scripts/play_party.sh`. `play.sh` IS the play loop:
+  it binds a viewer with `CLAWDND_PLAYER_MOVES` +
+  `CLAWDND_VIEWER_CHAT` set (→ `_live_play()` true) and runs a `claude -p` DM watching the
+  move sink. `POST /move` → sink; `/chat?since=` → DM narration the Session tails.
+- The checked-in Codex provider now defaults to `scripts/play_codex_dm.sh`, a DM wrapper that owns
+  the live viewer, the engine/rules/voice MCP contract, `chat.jsonl`, and `player_moves.jsonl`.
+  Keep `scripts/play_codex_actor.sh` as the constrained player/companion actor helper through
+  `player_server.py`; it is not the native provider's DM loop. OpenClaw still requires an explicit
+  configured command before it can be treated as a startable provider.
+- Agents and app harnesses should read `GET /app-status` before trying to infer state from pixels or
+  process lists. It is a read-only contract for the live OpenWorlds surface: provider, run/state roots,
+  private-art presence, active campaign/session, move sink, actor, enabled actions, and canonical endpoints.
+  The built-app harness captures launcher and minted-provider app-status JSON as release evidence.
+- **`can_act = _live_play() AND is_live_view`**, and `is_live_view` requires
+  `cid == self.campaign_id`. The viewer launches with an EMPTY campaign id; `_resolve_campaign`
+  lazily sets `self.campaign_id` to the **current** campaign (`_pick_campaign`). So the
+  ★gotcha★: the SPA must VIEW the live/current campaign — `app.jsx` auto-routes launcher→table
+  when `runningProvider` is set, **re-polls `campaigns.json` (4s), and auto-follows the
+  `current` campaign** so the surface binds to the DM-minted run, not a stale save the
+  one-shot catalog pick had selected. Verify playable: `curl /session-surface` → `can_act:true`.
+- **Footguns (all fixed cont.26, watch for regressions):** (1) a Finder/Dock GUI launch gets
+  launchd's minimal PATH → `claude`/`uv` not found; `launch_common.sh:clawdnd_augment_path`
+  prepends `~/.local/bin`+Homebrew. (2) `play.sh`/`play_party.sh` traps must SEPARATE EXIT
+  (cleanup) from INT/TERM (cleanup+`exit`) or SIGTERM resumes the loop (wedged orphan). (3)
+  `AppProcessService` does NOT kill its viewer child on app SIGTERM → orphaned viewers accrue
+  across relaunches (still open — terminate-on-quit TODO). (4) `play.sh` always starts a
+  FRESH campaign (true resume-by-id is a later enhancement).
+- **Critical files:** `RootView.swift` (startProviderSession bridge), `ProviderAdapters.swift`
+  (shells play.sh, ClaudeProvider.detect), `AppProcessService.swift` (PortFinder), `WebView.swift`
+  (bridge user-script `window.ClawDnDNative`), `screen-launcher.jsx` + `app.jsx`, `scripts/play.sh`.

--- a/docs/archive/WorldOS-GUI-RUNBOOK.md
+++ b/docs/archive/WorldOS-GUI-RUNBOOK.md
@@ -1,5 +1,11 @@
 # WorldOS GUI Runbook — the look-and-wire release loop
 
+> **ARCHIVED / SUPERSEDED 2026-06-02** — this runbook was merged into `WorldOS-RUNBOOK.md` (section
+> "THE GUI / NATIVE-APP LOOP") during the canonical-doc consolidation (two runbooks were the sprawl
+> being fought). This copy is kept for provenance only; act on `WorldOS-RUNBOOK.md`. Some proof
+> narrative below cites SHA `9545383` as "latest app proof" — that is stale: code/QA commits have since
+> landed above it on `origin/main` (re-prove on the current SHA).
+>
 > How to test→fix→LOOK the WorldOS GUI on the REAL surface and drive it to a 10/10 release.
 > Born from the 2026-05-31 reorientation: the prior loop scored a HEADLESS PROXY served from
 > WORKTREES WITH NO ART, so every visible defect (no palette, no images, no map, unformatted

--- a/docs/ui-audit/MASTER_TRACKER.md
+++ b/docs/ui-audit/MASTER_TRACKER.md
@@ -2,7 +2,7 @@
 
 > Historical index for the page-by-page UI/UX audit landed under `docs/ui-audit/`.
 > Use this for backlog context only. Current GUI/native app proof and QA routing live in
-> `WorldOS-OPERATING-GOAL.md`, `WorldOS-GUI-RUNBOOK.md`, `qa/QA_TOOLS.md`, and `qa/SCORECARD.md`.
+> `WorldOS-OPERATING-GOAL.md`, `WorldOS-RUNBOOK.md`, `qa/QA_TOOLS.md`, and `qa/SCORECARD.md`.
 > Mirror of `#242` Phase 5 status.
 >
 > **Audit method:** live walkthrough of every screen at `127.0.0.1:8799/openworlds/`, viewports

--- a/qa/QA_TOOLS.md
+++ b/qa/QA_TOOLS.md
@@ -1,7 +1,7 @@
 # WorldOS QA Tools Index
 
 This is the command map for agents. It does not replace the release truth in
-`WorldOS-OPERATING-GOAL.md`, the GUI loop in `WorldOS-GUI-RUNBOOK.md`, or the evidence ledger in
+`WorldOS-OPERATING-GOAL.md`, the GUI loop in `WorldOS-RUNBOOK.md`, or the evidence ledger in
 `qa/SCORECARD.md`.
 
 Default local paths:

--- a/qa/SCORECARD.md
+++ b/qa/SCORECARD.md
@@ -127,7 +127,29 @@
 > One row per attempted gate sweep on a BUILT `.app`. RRI = gates_passed/11 × 10. Release requires a **non-partial**
 > 10/10 row with all 11 gate denominators and evidence paths. Rows marked partial, pre-hardening, pending, or
 > unmeasured are diagnostic evidence only.
-> See `WorldOS-OPERATING-GOAL.md` §4 for the gates, `WorldOS-GUI-RUNBOOK.md` for the sweep procedure.
+> See `WorldOS-OPERATING-GOAL.md` §4 for the gates, `WorldOS-RUNBOOK.md` ("THE GUI / NATIVE-APP LOOP") for the sweep procedure.
+>
+> **This SCORECARD is the SOLE home for per-run score rows** (the operating goal and runbook no longer
+> duplicate them). It is the **human narrative ledger**. A sibling lane is building `qa/scores.db` (the
+> machine-readable ledger) + `qa/scores_ledger.md`; once those land, this file cross-links to them and
+> does not duplicate their rows. [UNVERIFIED 2026-06-02: `qa/scores.db` / `qa/scores_ledger.md` do not
+> exist in the repo yet — this is a forward cross-link, not a present file.]
+
+### ★ RRI reconciliation — why the number whiplashed (1.8 → ~6.0 → 2.7 → none)
+
+A resuming agent will see several different "RRI" figures across old notes. They are NOT a regressing
+score — they are **different partial measurements on different builds, none a valid release verdict**:
+
+| Figure | Where it came from | Build | Why it is not a verdict |
+|---|---|---|---|
+| **1.8/10** | LEXAR session-notes (archived) `…/session-notes/2026-05-31/_archive/worldos-gate-status-HANDOFF.md` / `worldos-VELOCITY-DIAGNOSIS.md` | provisional | "Provisional" — behavioral/axe/image-render were UNMEASURED inputs counted as fails. |
+| **~6.0** | `sweep1` row below | `c6480a3` | INCOMPLETE / pre-hardening: behavioral/UI/image/console denominators incomplete; 1 persona gave up. |
+| **2.7** | `gate-f5500ac-partial` row below + (gitignored) `qa/RRI.json` | `f5500ac` | PARTIAL / harness-contaminated: only `newbie` wrote `score.json`; other personas failed at harness setup. |
+| **none** | current "LAST VALID RELEASE GATE" | — | Correct: no clean, non-partial five-persona sweep has ever completed. The RRI contract was later hardened so partial/mixed-SHA evidence can never silently produce a release-ready result. |
+
+**Bottom line: there is no valid RRI yet.** The next real number comes from #466 — one clean,
+non-partial five-persona sweep on a single explicit SHA. Until then, treat every figure above as
+diagnostic only.
 
 | Sweep | Date | build_sha | RRI | Native | Arc | Sat (avg/no-giveup) | Crit/Console | Story | Mech | Behav | Axe | Img% | Palette | Failed gates / notes |
 |---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -3,7 +3,7 @@
 > Source of truth for HOW we measure a playtest. Current as of 2026-05-26.
 > The running results ledger is `qa/SCORECARD.md`.
 > For the current app/native handoff tools and RRI routing, start with `qa/QA_TOOLS.md` and
-> `WorldOS-GUI-RUNBOOK.md`; this file describes the story/mechanical scoring model.
+> `WorldOS-RUNBOOK.md`; this file describes the story/mechanical scoring model.
 
 The fitness function = **1 hard behavioral gate** (deterministic pass/fail) + **3 LLM
 lenses** (each 1–5). The gate is the honest floor; the lenses grade quality above it.


### PR DESCRIPTION
## What & why
A 95%-confidence consolidation of the WorldOS planning docs so a resuming agent reads **1–2 docs** and knows exactly where things stand. Planning docs had drifted across many compaction cycles (stale SHAs, a dead VM-SSH plan, two conflicting fix-queues, RRI numbers whiplashing 1.8/~6.0/2.7/none).

**STAGED ONLY — please do NOT merge yet.** The owner wants the measured A/B run to land first as a reference point. The STATE block's "current SHA" and "last real score" are left as clearly-marked `<TODO …>` placeholders to fill from the A/B + ledger results (no numbers invented).

**Docs only, no code.** Branch is a worktree off `origin/main` (`ae27602`).

## Final canonical set — what each owns
| Doc | Owns |
|---|---|
| `WorldOS-OPERATING-GOAL.md` | GOAL + the RRI gate + a single ~10-line STATE block. §9 PR-log + §10 sprint order moved out. |
| `WorldOS-RUNBOOK.md` | HOW-TO: architecture + invariants + dev/QA loops + lessons. **`WorldOS-GUI-RUNBOOK.md` merged in** as "THE GUI / NATIVE-APP LOOP". Historical work-queue moved out. |
| `qa/SCORECARD.md` | **Sole home for per-run score rows.** New "RRI reconciliation" table + forward cross-link to the sibling `qa/scores.db` / `qa/scores_ledger.md` ledger (not duplicated). |
| `WorldOS-NORTH-STAR.md` | Vision/ceiling — left stable; roadmap cross-link added. |

## Archived (moved, not deleted)
- `docs/archive/OPERATING-GOAL-PR-LOG.md` — former §9 PR-narrative + §10 sprint order.
- `docs/archive/RUNBOOK-WORK-QUEUE.md` — former runbook "CURRENT STATE + WORK QUEUE" (was self-labeled historical).
- `docs/archive/WorldOS-GUI-RUNBOOK.md` — original GUI runbook (now merged), banner added.
- `docs/archive/GUI_WORKBOOK.md` — moved from `qa/` (self-labeled historical), banner added.
- **LEXAR** (`/Volumes/LEXAR/Codex/session-notes/2026-05-31/_archive/`, not this repo): `worldos-gate-status-HANDOFF.md`, `worldos-TRAJECTORY-ANALYSIS.md`, `worldos-VELOCITY-DIAGNOSIS.md` + a README pointer.
- **Dead VM-SSH plan** `/Users/lume/.claude/plans/twinkly-meandering-pizza.md` — 1-line `SUPERSEDED` pointer prepended.

## Stale/conflicting claims corrected (with evidence they were wrong)
1. **"`origin/main` may contain only DOCS-ONLY commits above `9545383`"** (asserted in OPERATING-GOAL STATE block, RUNBOOK header, GUI-RUNBOOK) — **FALSE.** `git log 9545383..origin/main` is **17 commits**, several are product/QA **code**: `#528` (`viewer/openworlds/screen-create.jsx`), `bd93b84`/`7a373cf`/`9fa1cd4` (`qa/release_readiness.py` — the RRI scorer itself), `6d107d6` (`qa/ui_playtest_app.sh` + persona lane), `#520`/`#522`/`#523`. So `9545383` is genuinely **stale** as a "current" baseline. Corrected in the STATE block + RUNBOOK header; the archived copies carry a stale-SHA banner.
2. **RRI whiplash 1.8 → ~6.0 → 2.7 → none** — these were read as a regressing score. They are **different partial measurements on different builds, none a valid verdict**. Reconciled in one table in `qa/SCORECARD.md`: 1.8 = LEXAR provisional handoff (unmeasured inputs counted as fails); ~6.0 = `sweep1` (`c6480a3`, incomplete/pre-hardening); 2.7 = `gate-f5500ac-partial` (`f5500ac`, harness-contaminated, = gitignored `qa/RRI.json`); none = current (no clean sweep ever finished — correct).

## Could NOT verify to 95% (left as [UNVERIFIED])
- **`qa/scores.db` / `qa/scores_ledger.md`** — the sibling agent's machine-readable ledger does **not exist in the repo yet**. Cross-linked as forthcoming and explicitly marked `[UNVERIFIED]` in SCORECARD, not asserted present.
- **Support-VM scout findings** (capacity/stale-checkout/auth-unproven) carried into the RUNBOOK GUI section are tagged `[UNVERIFIED, carried from the prior runbook]` — they were a prior session's read-only scout, not re-verified here.

## Note on mtime deception (per the discipline)
`qa/GUI_WORKBOOK.md` was touched recently (2026-06-01) but is self-labeled historical → recency ≠ currency. `WorldOS-NORTH-STAR.md` is older but is the stable vision doc → old ≠ wrong. Staleness was judged by cross-checking claims against `git log`/origin-main + code + SCORECARD, not by mtime.