### PR TITLE
Fix launcher live state for current playable run

### DIFF
--- a/viewer/openworlds/screen-launcher.jsx
+++ b/viewer/openworlds/screen-launcher.jsx
@@ -316,11 +316,11 @@ function ScreenLauncher({ onNavigate, state, setState, preferredProvider = "" })
 
                   {/* Party row */}
                   <SectionTitle>The Party</SectionTitle>
-                  <div style={{ display: "grid", gridTemplateColumns: `repeat(${Math.max(party.length, 1)}, 1fr)`, gap: 8 }}>
+                  <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
                     {party.map((p, i) => (
-                      <div key={i} style={{ textAlign: "center" }}>
-                        <Img scope={p.id ? "portrait-" + p.id : ""} label={p.name || p.short || "portrait"} w="100%" h={70} framed fit="cover" />
-                        <div className="hand" style={{ fontSize: 12, marginTop: 4, color: "var(--ink-700)" }}>{p.name}</div>
+                      <div key={i} style={{ width: 86, textAlign: "center" }}>
+                        <Img scope={p.id ? "portrait-" + p.id : ""} label={p.name || p.short || "portrait"} w={86} h={104} framed fit="cover" />
+                        <div className="hand" style={{ fontSize: 12, marginTop: 4, color: "var(--ink-700)", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{p.name}</div>
                       </div>
                     ))}
                     {party.length === 0 && (

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -4504,6 +4504,7 @@ def build_openworlds_campaign_summary(
     last_played: float,
     current: bool,
     can_resume: bool,
+    move_sink_live: bool = False,
     now: float,
 ) -> dict:
     """Browser-safe OpenWorlds launcher row for one campaign.
@@ -4514,7 +4515,7 @@ def build_openworlds_campaign_summary(
     need more data.
     """
     snapshot = snapshot if isinstance(snapshot, dict) else {}
-    live = (now - last_played) < 90
+    live = bool(current and can_resume and move_sink_live) or (now - last_played) < 90
     location = _display_location(snapshot)
     loc_id = _text(snapshot.get("current_location_id"))
     world = _text(snapshot.get("world_id"), "unknown")
@@ -4611,7 +4612,12 @@ def _openworlds_catalog_index(
     return tuple(sig_entries), snapshots
 
 
-def _refresh_openworlds_campaign_times(cards: list[dict], *, now: float) -> list[dict]:
+def _refresh_openworlds_campaign_times(
+    cards: list[dict],
+    *,
+    now: float,
+    move_sink_live: bool = False,
+) -> list[dict]:
     refreshed: list[dict] = []
     for card in cards:
         c = dict(card)
@@ -4621,7 +4627,7 @@ def _refresh_openworlds_campaign_times(cards: list[dict], *, now: float) -> list
             if isinstance(last_played, (int, float)) and not isinstance(last_played, bool)
             else 0
         )
-        live = (now - last_played) < 90
+        live = bool(move_sink_live and c.get("current") and c.get("canResume")) or (now - last_played) < 90
         c["live"] = live
         c["liveStatus"] = "live" if live else "stale"
         c["lastPlayed"] = _relative_time_label(last_played, now=now)
@@ -4637,14 +4643,18 @@ def _refresh_openworlds_campaign_times(cards: list[dict], *, now: float) -> list
     return refreshed
 
 
-def _openworlds_campaigns(attached_campaign: str = "") -> dict:
+def _openworlds_campaigns(attached_campaign: str = "", *, move_sink_live: bool = False) -> dict:
     global _openworlds_catalog_cache
     now = time.time()
     roots = _campaign_catalog_roots()
     current_campaigns_dir = _resolved(_campaigns_dir())
     signature, snapshots = _openworlds_catalog_index(roots, attached_campaign)
     if _openworlds_catalog_cache and _openworlds_catalog_cache[0] == signature:
-        out = _refresh_openworlds_campaign_times(_openworlds_catalog_cache[1], now=now)
+        out = _refresh_openworlds_campaign_times(
+            _openworlds_catalog_cache[1],
+            now=now,
+            move_sink_live=move_sink_live,
+        )
     else:
         built: list[dict] = []
         for root, snap, recency in snapshots:
@@ -4668,13 +4678,18 @@ def _openworlds_campaigns(attached_campaign: str = "") -> dict:
                     last_played=recency,
                     current=root_is_current and campaign_id == attached_campaign,
                     can_resume=root_is_current,
+                    move_sink_live=move_sink_live,
                     now=now,
                 )
             except (OSError, TypeError, ValueError):
                 continue
             built.append(summary)
         _openworlds_catalog_cache = (signature, built)
-        out = _refresh_openworlds_campaign_times(built, now=now)
+        out = _refresh_openworlds_campaign_times(
+            built,
+            now=now,
+            move_sink_live=move_sink_live,
+        )
     return {
         "campaigns": out[:80],
         "total": len(out),
@@ -6289,7 +6304,7 @@ class _Handler(BaseHTTPRequestHandler):
                 chat_path=self.chat_path,
             ))
         elif route == "/openworlds/campaigns.json":
-            self._json(_openworlds_campaigns(self.campaign_id))
+            self._json(_openworlds_campaigns(self.campaign_id, move_sink_live=_live_play()))
         elif route == "/session-surface":
             qs = parse_qs(parsed.query)
             live = _live_play()

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -447,6 +447,9 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertNotIn("{campaigns.map((c) =>", launcher)
         self.assertIn("playerChronicles.find((c) => c.live && c.canResume)", launcher)
         self.assertIn("playerChronicles.find((c) => c.canResume)", launcher)
+        self.assertIn('display: "flex", flexWrap: "wrap", gap: 10', launcher)
+        self.assertIn('style={{ width: 86, textAlign: "center" }}', launcher)
+        self.assertIn('w={86} h={104}', launcher)
         self.assertIn("function openWorldsPlayerChronicle(c)", app)
         self.assertIn("const playerCampaigns = nextCampaigns.filter(openWorldsPlayerChronicle);", app)
         self.assertIn("const activeStillExists = playerCampaigns.some((c) => c.id === s?.activeCampaign);", app)
@@ -752,6 +755,42 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertNotIn("hidden agenda", encoded)
         self.assertNotIn("private canon", encoded)
         self.assert_no_private_keys(json.loads(encoded))
+
+    def test_openworlds_campaigns_keeps_current_move_sink_run_live_after_recency_window(self):
+        campaign_dir = self._tmp / "campaigns" / "camp_live"
+        self._write_snapshot(
+            campaign_dir,
+            {
+                "id": "camp_live",
+                "title": "Road After Moonrise",
+                "ruleset": "SRD 5.2",
+                "world_id": "baldurs-gate",
+                "day": 12,
+                "current_location_id": "last-light",
+                "locations": {"last-light": {"name": "Last Light Inn"}},
+                "party": ["hero"],
+                "characters": {
+                    "hero": {"name": "Tav", "kind": "player", "current_hp": 22, "max_hp": 30},
+                },
+            },
+        )
+        stale = 1_700_000_000
+        os.utime(campaign_dir / "snapshot.json", (stale, stale))
+        moves = self._tmp / "player_moves.jsonl"
+        os.environ["CLAWDND_PLAYER_MOVES"] = str(moves)
+        _QuietHandler.campaign_id = "camp_live"
+        server._HERE = self._tmp / "viewer"
+        server._openworlds_catalog_cache = None
+
+        status, _ctype, body = self._get("/openworlds/campaigns.json")
+
+        self.assertEqual(status, 200)
+        campaign = json.loads(body.decode("utf-8"))["campaigns"][0]
+        self.assertTrue(campaign["current"])
+        self.assertTrue(campaign["canResume"])
+        self.assertFalse(campaign["readOnly"])
+        self.assertTrue(campaign["live"])
+        self.assertEqual(campaign["liveStatus"], "live")
 
     def test_native_start_surfaces_use_app_selected_provider(self):
         app = (Path(__file__).resolve().parents[1] / "openworlds" / "app.jsx").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- keep the attached current campaign marked `live` in the launcher catalog when the same viewer has a writable `/move` sink, even if snapshot/session recency has aged out
- keep the launcher CTA truthful as `Live now` / `Continue → play` for an actually playable run
- render launcher party members as compact portrait tiles instead of stretching a solo portrait into a wide strip

## Verification
- `python3 -m pytest viewer/tests/test_openworlds_static.py -q`
- `python3 -m pytest viewer/tests/test_openworlds_static.py qa/test_macos_app_static.py -q`
- Local in-app browser proof on patched OpenWorlds: forced the current campaign snapshot/session log stale while the `/move` sink remained writable; launcher still showed `Live now` and `Continue → play`, did not show `Ready to resume`, rendered Abby as an 86x104 portrait tile, and logged zero browser console errors. Evidence archived outside the repo under the local Lexar evidence tree.

## Notes
- Engine remains the sole campaign-state writer. This only changes the read-only launcher catalog projection and launcher rendering.
- This is product/UX proof for the fast browser loop, not a release verdict or built-app proof.