### PR TITLE
fix(qa): pipe scorer prompt via stdin (E2BIG) + fail loudly on 0-byte/API-error scorecards

### DIFF
--- a/qa/score.sh
+++ b/qa/score.sh
@@ -15,25 +15,54 @@ MD="$1"; STATE="$2"; RUBRIC="$3"; SCHEMA="$4"; OUT="$5"; BUDGET="${6:-1.50}"
 INPUT="$(printf '%s\n\n# ===== OUTPUT FORMAT =====\nRespond with ONLY a single JSON object conforming to this schema — no prose, no markdown, no code fences:\n%s\n\n# ===== DISTILLED TRANSCRIPT =====\n%s\n\n# ===== FINAL ENGINE STATE (ground truth) =====\n%s\n' \
   "$(cat "$RUBRIC")" "$(cat "$SCHEMA")" "$(cat "$MD")" "$(cat "$STATE")")"
 
+ERR="${OUT%.json}.err"
+RAW="${OUT%.json}.raw.json"   # raw claude --output-format json envelope (kept for the guard)
+
 attempt=0
 while [ "$attempt" -lt 3 ]; do
   attempt=$((attempt + 1))
+  # The rubric+schema+transcript+state prompt is ~100-200KB. Passing it as a single
+  # argv (`claude -p "$INPUT"`) is what `execve` carries, and macOS counts the WHOLE
+  # argv + the full environment against ARG_MAX (1 MB). Under the parallel QA swarm the
+  # inherited env is fat (plugin/MCP/state vars), so prompt + env crosses 1 MB →
+  # `Argument list too long` (E2BIG) → claude never runs → a 0-byte $OUT that the old
+  # retry loop MISREAD as a transient auth/rate blip. Pipe via STDIN instead: `claude -p`
+  # with no positional prompt reads the prompt from stdin (the documented pipe path), so
+  # the prompt never touches the argv budget. Model, flags, and output schema unchanged.
+  #
   # --json-schema was found to suppress the result text in this CLI; we rely on the
   # JSON-only instruction in the prompt and strip any stray code fences.
-  claude -p "$INPUT" \
+  printf '%s' "$INPUT" | claude -p \
     --model sonnet --permission-mode bypassPermissions \
     --max-budget-usd "$BUDGET" \
-    --output-format json 2> "${OUT%.json}.err" \
-    | jq -r '.result // empty' 2>/dev/null \
-    | sed -E '/^```/d' > "$OUT" 2>/dev/null
+    --output-format json > "$RAW" 2> "$ERR"
+
+  # The scorecard text lives at .result; strip any stray code fences.
+  jq -r '.result // empty' "$RAW" 2>/dev/null | sed -E '/^```/d' > "$OUT" 2>/dev/null
 
   # A valid scorecard parses as JSON AND carries a .scores object.
   if jq -e '.scores' "$OUT" >/dev/null 2>&1; then
+    rm -f "$RAW"
     exit 0
   fi
-  echo "[score] attempt $attempt: no valid scorecard for $(basename "$OUT") (transient auth/rate?); retrying…" >&2
+
+  # GUARD: distinguish a genuine API error / E2BIG / dead process from a transient blip,
+  # and FAIL LOUDLY in the non-transient cases instead of silently calling it "auth/rate".
+  api_err="$(jq -r 'select(.is_error == true) | .api_error_status // .subtype // "error"' "$RAW" 2>/dev/null)"
+  if [ ! -s "$RAW" ]; then
+    # No envelope at all → claude itself never produced output (E2BIG, killed, exec fail).
+    echo "[score] attempt $attempt: EMPTY output for $(basename "$OUT") — claude wrote NOTHING to stdout. This is NOT a rate blip (likely E2BIG / killed process). stderr tail:" >&2
+    tail -n 20 "$ERR" >&2 2>/dev/null || echo "[score]   (no stderr captured at $ERR)" >&2
+  elif [ -n "$api_err" ]; then
+    # A real API-error envelope (e.g. 401 auth, 400, overload). Surface it — don't bury it.
+    echo "[score] attempt $attempt: API ERROR ($api_err) for $(basename "$OUT"): $(jq -r '.result // "<no message>"' "$RAW" 2>/dev/null | head -1)" >&2
+  else
+    echo "[score] attempt $attempt: unparseable scorecard / missing .scores for $(basename "$OUT") (possibly transient); retrying…" >&2
+  fi
   sleep 5
 done
 
-echo "[score] FAILED after $attempt attempts: $OUT" >&2
+echo "[score] FAILED after $attempt attempts: $OUT — last stderr tail:" >&2
+tail -n 20 "$ERR" >&2 2>/dev/null || echo "[score]   (no stderr captured at $ERR)" >&2
+rm -f "$RAW"
 exit 1

--- a/qa/score_openclaw.sh
+++ b/qa/score_openclaw.sh
@@ -78,7 +78,12 @@ if m:
 " 2>/dev/null)"
 
   if [ -z "$STRIPPED" ]; then
-    echo "[score_openclaw] attempt $attempt: empty reply for $(basename "$OUT") (transient gateway/rate?); retrying…" >&2
+    # GUARD: an empty reply is NOT automatically a rate blip. The gateway may have
+    # rejected the call outright (e.g. the ~100-200KB prompt + a fat environment
+    # crossing the execve ARG_MAX budget when passed via --message, or an auth
+    # failure). Surface the real stderr tail instead of silently calling it transient.
+    echo "[score_openclaw] attempt $attempt: EMPTY reply for $(basename "$OUT") — gateway returned no payload text. This may be E2BIG (prompt too large for --message argv), auth, or rate. stderr tail:" >&2
+    tail -n 20 "${OUT%.json}.oc.err" >&2 2>/dev/null || echo "[score_openclaw]   (no stderr captured at ${OUT%.json}.oc.err)" >&2
     sleep 5
     continue
   fi
@@ -94,5 +99,6 @@ if m:
   sleep 5
 done
 
-echo "[score_openclaw] FAILED after $attempt attempts: $OUT" >&2
+echo "[score_openclaw] FAILED after $attempt attempts: $OUT — last stderr tail:" >&2
+tail -n 20 "${OUT%.json}.oc.err" >&2 2>/dev/null || echo "[score_openclaw]   (no stderr captured at ${OUT%.json}.oc.err)" >&2
 exit 1


### PR DESCRIPTION
## Root cause: E2BIG, misdiagnosed as "auth/rate"

`qa/score.sh` builds a **~100–200KB** rubric + schema + distilled-transcript + final-engine-state prompt (`$INPUT`) and passed it as a **single argv**:

```sh
claude -p "$INPUT" --output-format json
```

macOS counts the **whole `argv` + the inherited environment** against `ARG_MAX` (verified on host: `getconf ARG_MAX` = **1048576**; a single arg E2BIGs only once total crosses ~1 MB). Under the parallel QA swarm (`run_parallel.sh` / `release_gate.sh`) the inherited environment is fat (plugin/MCP/state/CI vars), so **prompt + env crosses 1 MB → `execve` fails with `Argument list too long` (E2BIG)**. `claude` never runs → `$OUT` is **0 bytes**.

The old retry loop then printed `no valid scorecard … (transient auth/rate?)`, burned all 3 attempts, and failed with **no usable signal** — the failure was silently reclassified as a rate blip every time.

## Fix

**1. Deliver the prompt via STDIN** (removes it from the `execve` argv budget entirely):

```sh
printf '%s' "$INPUT" | claude -p \
  --model sonnet --permission-mode bypassPermissions \
  --max-budget-usd "$BUDGET" \
  --output-format json > "$RAW" 2> "$ERR"
```

`claude -p` with **no positional prompt** reads the prompt from stdin (documented pipe path; confirmed against the installed CLI). The scorer **model (sonnet), flags, rubric/schema inputs, and the `.result → jq → sed → .scores` output pipeline are byte-for-byte unchanged** — only prompt *delivery* changed.

**2. Loud guard** — capture the raw `claude` JSON envelope; when the `.scores` gate fails, branch instead of blanket-retrying:
- **empty stdout** (E2BIG / killed / exec fail) → `EMPTY output … NOT a rate blip` + **stderr tail**
- **`is_error` envelope** (401 auth / 400 / overload) → `API ERROR (<status>): <message>`
- otherwise → possibly-transient retry

Final failure also dumps the stderr tail. No real failure is silently called "auth/rate" again.

**3. `qa/score_openclaw.sh`** (the gpt-5.4 gateway scorer — same prompt-assembly pattern) uses `openclaw agent --message`, which has **no stdin/file input flag**, so its prompt delivery is unchanged. But its empty-reply and final-failure paths now surface the **real stderr tail** and name E2BIG as a candidate (it still passes ~184KB via `--message`, so it carries the same residual argv-budget risk on its own CLI — flagged in-comment).

## Scope

- The other `claude -p "$msg"` calls (`run_qa.sh`, `run_duo.sh`, `run_party.sh`, `run_combat_sprint.sh`, `ui_playtest*.sh`, `play_human.sh`) are **DM/player PLAY turns** (short per-turn messages), **not** the giant scorer blob — not E2BIG candidates, left untouched.
- `*.raw.json` temp lives under `qa/transcripts/` (gitignored) and is deleted on success and final failure; it matches none of the findings-collector suffixes.

## Verification

- `bash -n` clean on both scripts; **shellcheck clean** on `score.sh` (the substantively changed file). `score_openclaw.sh` has one **pre-existing** `SC2034` (`BUDGET` intentionally unused — API parity).
- **End-to-end run** of the real `score.sh` with tiny fixtures confirms: prompt assembly → stdin pipe → `claude` runs and emits a JSON envelope → `.scores` gate → all three guard branches (exercised the **API-ERROR (401)** branch via the host's stale-OAuth credentials).
- **Not done (honest):** no full scoring pass (expensive); **no successful live score** — this host's claude.ai OAuth returns 401 on live calls, so the happy-path `exit 0` was not exercised against a real key. The stdin mechanics, post-pipeline, and guard are all proven.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and diagnostics in QA scoring infrastructure with enhanced logging for failure scenarios.

* **Chores**
  * Enhanced resilience of QA tooling to handle system resource constraints and provide better post-failure diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->