### PR TITLE
feat(engine): compact scene_context — durable-threads pin + recent_narration (lean re-ground)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -93,7 +93,7 @@ _AB3_TO_FULL = {
 # Reverse: accept either the 3-letter code (the Ability enum value) or the full word
 # (how the SRD records spell saving_throw_ability, e.g. "wisdom") and resolve to an Ability.
 _FULL_TO_AB3 = {full: ab3 for ab3, full in _AB3_TO_FULL.items()}
-from store import append_log, campaign_lock, campaigns_for_world
+from store import append_log, campaign_lock, campaigns_for_world, read_log
 from store import list_campaigns as _list_campaigns
 from store import list_slots as _list_slots
 from store import load_campaign, save_campaign
@@ -8354,16 +8354,153 @@ def set_seed_param(campaign_id: str, param: str, value, force: bool = False) -> 
 # byte-identical to before (an unused combined tool ships nothing).
 
 
+def _scene_durable_threads(c: Campaign) -> dict:
+    """Derive the compact, continuity-CRITICAL durable threads a transcript-free
+    re-ground must not lose (#compact-scene-context).
+
+    READ-ONLY + pure derivation — never mutates state (scene_context's sole-writer
+    invariant). These are the *standing* threads (not this-beat deltas) that the
+    bundle's other sections under-surface:
+
+      - ``open_quests``        — every non-completed/non-failed Quest with its OPEN
+                                 objectives. get_state's ``active_quests`` carries
+                                 only ``{id,title}``; the unresolved objectives are
+                                 the actual continuity (what the party still OWES).
+      - ``npc_relationships``  — each NPC the party has actually MET, with its
+                                 approval gauge (``attitude_value``) + free-text
+                                 ``attitude`` + any authored ``relationships`` tags.
+                                 get_state surfaces only ``npc_count``; who the party
+                                 stands with (and how) is otherwise transcript-only.
+      - ``companions``         — each companion's STANDING bond state: approval
+                                 gauge, whether an arc / a sealed betrayal agenda is
+                                 attached. (``companion_arcs`` reports only what just
+                                 *turned* this beat; this is the durable baseline.)
+      - ``factions``           — each faction's ``reputation`` (bidirectional trust)
+                                 + ``standing`` (monotonic membership) — the engine-
+                                 mutated gauges that gate faction events.
+      - ``flags``              — the set world-state flags (gates already armed).
+
+    Everything is a thin projection; empty collections == today's behavior. The
+    DM's `recall`/`get_character`/`get_faction` reach the full record on demand —
+    this is the always-pinned spine, not the whole world.
+    """
+    chars = list(c.characters.values())
+
+    # OPEN quests (status not completed/failed) with their still-open objectives.
+    open_quests = [
+        {
+            "id": q.id,
+            "title": q.title,
+            "status": q.status,
+            "open_objectives": [
+                o for o in q.objectives if o not in q.completed_objectives
+            ],
+        }
+        for q in c.quests.values()
+        if q.status not in ("completed", "failed")
+    ]
+
+    # NPC relationships the party has a standing with: only NPCs actually met
+    # (a world seed pre-populates strangers; `met` gates them out — same rule the
+    # dashboard's Relationships view uses).
+    npc_relationships = [
+        {
+            "id": ch.id,
+            "name": ch.name,
+            "attitude_value": ch.attitude_value,
+            **({"attitude": ch.attitude} if ch.attitude else {}),
+            **({"relationships": ch.relationships} if ch.relationships else {}),
+        }
+        for ch in chars
+        if ch.kind == "npc" and ch.met
+    ]
+
+    # Companions' STANDING bond state (loyalty gauge + whether a sealed
+    # betrayal agenda is attached) — the durable baseline check_companion_arc's
+    # delta report assumes you already know.
+    companions = [
+        {
+            "id": ch.id,
+            "name": ch.name,
+            "attitude_value": ch.attitude_value,
+            "has_arc": ch.arc is not None,
+            "has_betrayal_agenda": bool(
+                ch.arc is not None
+                and ch.arc.agenda is not None
+                and ch.arc.agenda.trigger == "attitude_below"
+            ),
+        }
+        for ch in chars
+        if ch.kind == "companion"
+    ]
+
+    # Faction gauges (engine-mutated; these gate events — invariant #3).
+    factions = [
+        {
+            "id": f.id,
+            "name": f.name,
+            "reputation": f.reputation,
+            "standing": f.standing,
+        }
+        for f in c.factions.values()
+    ]
+
+    return {
+        "open_quests": open_quests,
+        "npc_relationships": npc_relationships,
+        "companions": companions,
+        "factions": factions,
+        "flags": sorted(k for k, v in c.flags.items() if v),
+    }
+
+
+def _scene_recent_narration(c: Campaign, limit: int) -> list[dict]:
+    """The last ``limit`` PLAYER-FACING beats (kind in narration|dialogue) from the
+    current session log, in CHRONOLOGICAL order — the prose tail a transcript-free
+    (lean) beat needs as its short-term memory of the story so far.
+
+    READ-ONLY: reads the session jsonl via read_log (never writes). Resolves
+    the current session the same way session_recap does (active, else the most
+    recent). Rolls / system / combat-log rows are bookkeeping noise and are
+    dropped (mirrors recap's _STORY_KINDS, minus combat: this is the spoken story).
+    """
+    if limit <= 0:
+        return []
+    sid = c.active_session_id or (c.session_ids[-1] if c.session_ids else None)
+    if not sid:
+        return []
+    entries = read_log(c.id, sid)
+    facing = [e for e in entries if e.kind in ("narration", "dialogue")]
+    return [
+        {"text": e.text, **({"speaker": e.speaker} if e.speaker else {})}
+        for e in facing[-limit:]
+    ]
+
+
 @mcp.tool()
-def scene_context(campaign_id: str, recall_query: str = "", recall_limit: int = 6) -> dict:
+def scene_context(
+    campaign_id: str,
+    recall_query: str = "",
+    recall_limit: int = 6,
+    recent_narration: int = 0,
+) -> dict:
     """ONE-CALL beat re-ground — the whole start-of-beat read cluster in a single
     round-trip (latency collapse; additive — the individual tools all still exist).
 
     Returns, in one payload, exactly what the DM reads at the top of every beat
-    (SKILL.md step 1) so it makes 1 call instead of 3–4:
+    (SKILL.md step 1) so it makes 1 call instead of 3–4. Field ordering is STABLE
+    and durable-first (the threads that persist across the campaign come before the
+    volatile clock/HP in ``state``) so a re-grounding DM — and prompt caches — see
+    the unchanging spine first:
 
-      - ``state``     — get_state(campaign_id): scene, party vitals, day/time,
-                        active quests, combat status, pacing_mode, seed_params.
+      - ``durable``   — the continuity-CRITICAL standing threads pinned so a
+                        transcript-free (lean) re-ground loses NOTHING: every
+                        ``open_quests`` (+ its still-open objectives),
+                        ``npc_relationships`` the party has MET (approval +
+                        relationship tags), each companion's standing bond
+                        (``companions``: approval / arc / sealed betrayal agenda),
+                        ``factions`` (reputation + standing gauges), and the set
+                        ``flags``. Always present; empty collections == today.
       - ``director``  — get_campaign_director(campaign_id): the top structural
                         debts the campaign OWES right now (advisory, read-only).
       - ``events``    — present_events(campaign_id): stumble-into decisionals whose
@@ -8372,31 +8509,51 @@ def scene_context(campaign_id: str, recall_query: str = "", recall_limit: int = 
                         turned / a ``betrayal_warning`` to foreshadow. (This is the
                         one sub-call that persists arc progress — same effect as
                         calling the tool directly; idempotent across beats.)
+      - ``recent_narration`` — present ONLY when ``recent_narration`` (the param)
+                        is > 0: the last N player-facing beats (narration/dialogue)
+                        from the current session log, chronological, each
+                        ``{text, speaker?}``. This is the lean-beat memory: in
+                        fast-turn mode the beat runs with NO prior transcript, so
+                        this prose tail (plus ``durable``) IS the story-so-far.
+                        Default 0 = omitted (no log read, today's behavior).
       - ``recall``    — present ONLY when ``recall_query`` is non-empty: the same
                         fuzzy memory search recall(query, limit) returns. Pass it
                         when the moment touches the past ("have we met this NPC?",
                         "what did we decide about the cult?"); leave it blank
                         otherwise and no recall is run (no wasted work).
+      - ``state``     — get_state(campaign_id): scene, party vitals, day/time,
+                        active quests, combat status, pacing_mode, seed_params.
+                        LAST because it carries the volatile values (clock, HP).
 
     Read-mostly: it runs the SAME code paths as the individual tools (so behavior
     and side effects are identical — including check_companion_arc's arc-progress
-    save), just bundled. Use this every beat in place of the separate
-    get_state / get_campaign_director / present_events / check_companion_arc
-    calls. For a returning NPC you still want recall_npc(npc_id) / get_scene on
-    arrival — those stay their own calls (situational, not every beat).
+    save), just bundled. ``durable`` + ``recent_narration`` are pure READS/derivations
+    over committed state — scene_context NEVER writes campaign state itself. Use this
+    every beat in place of the separate get_state / get_campaign_director /
+    present_events / check_companion_arc calls. For a returning NPC you still want
+    recall_npc(npc_id) / get_scene on arrival — those stay their own calls.
     """
     # Each delegate takes (and fully releases) the per-campaign flock before the
     # next runs — sequential, never nested — so this is deadlock-free even though
     # check_companion_arc acquires the lock. (Nesting campaign_lock in one process
-    # WOULD deadlock: flock is not reentrant across fds.)
-    out = {
-        "state": get_state(campaign_id),
+    # WOULD deadlock: flock is not reentrant across fds.) The durable/recent reads
+    # are lock-free snapshot reads via _require / read_log.
+    #
+    # Built durable-first so the dict preserves the stable, cache-friendly order
+    # (durable threads → advisory → this-beat deltas → … → volatile state last).
+    out: dict = {
+        "durable": _scene_durable_threads(_require(campaign_id)),
         "director": get_campaign_director(campaign_id),
         "events": present_events(campaign_id),
         "companion_arcs": check_companion_arc(campaign_id),
     }
+    if recent_narration and recent_narration > 0:
+        out["recent_narration"] = _scene_recent_narration(
+            _require(campaign_id), recent_narration
+        )
     if recall_query and recall_query.strip():
         out["recall"] = recall(campaign_id, recall_query.strip(), limit=recall_limit)
+    out["state"] = get_state(campaign_id)
     return out
 
 

--- a/servers/engine/tests/test_beat_roundtrip.py
+++ b/servers/engine/tests/test_beat_roundtrip.py
@@ -28,18 +28,45 @@ def _a_char(cid: str) -> str:
 # ── scene_context: the start-of-beat read cluster in one call ────────────────
 
 
-def test_scene_context_bundles_the_four_beat_reads(cid):
-    """scene_context returns get_state + get_campaign_director + present_events +
-    check_companion_arc, and each section equals the individual tool's output."""
+def test_scene_context_bundles_the_beat_reads(cid):
+    """scene_context returns the durable-threads pin + get_campaign_director +
+    present_events + check_companion_arc + get_state, and each delegated section
+    equals the individual tool's output (the additions never regress the bundle)."""
     sc = server.scene_context(cid)
-    assert set(sc) == {"state", "director", "events", "companion_arcs"}
-    # Each bundled section is byte-equal to calling the tool directly (state can
+    assert set(sc) == {"durable", "director", "events", "companion_arcs", "state"}
+    # Each DELEGATED section is byte-equal to calling the tool directly (state can
     # carry no time-varying fields here, so a direct compare is safe).
     assert sc["state"] == server.get_state(cid)
     assert sc["director"] == server.get_campaign_director(cid)
     assert sc["events"] == server.present_events(cid)
     # companion_arc is idempotent across beats, so a second call matches too.
     assert sc["companion_arcs"] == server.check_companion_arc(cid)
+
+
+def test_scene_context_is_durable_first_then_volatile_state(cid):
+    """STABLE, cache-friendly field order: the durable threads come first and the
+    volatile clock/HP (`state`) comes last."""
+    keys = list(server.scene_context(cid))
+    assert keys[0] == "durable"
+    assert keys[-1] == "state"
+
+
+def test_scene_context_durable_and_recent_reads_do_not_mutate_state(cid):
+    """Sole-writer invariant: the NEW durable-threads + recent_narration paths only
+    READ/derive — they must not change campaign state. (check_companion_arc, a
+    pre-existing delegate, idempotently re-saves and bumps `updated_at`; that's the
+    documented exception, so we compare substantive state with that churn excluded.)
+    """
+    server.log_event(cid, kind="narration", text="A quiet beat passes.")
+
+    def _substantive(campaign_id):
+        d = store.load_campaign(campaign_id).model_dump()
+        d.pop("updated_at", None)  # the only field check_companion_arc's save touches
+        return d
+
+    before = _substantive(cid)
+    server.scene_context(cid, recent_narration=5, recall_query="rats")
+    assert _substantive(cid) == before
 
 
 def test_scene_context_recall_is_opt_in(cid):
@@ -51,6 +78,100 @@ def test_scene_context_recall_is_opt_in(cid):
     sc = server.scene_context(cid, recall_query="rats", recall_limit=4)
     assert "recall" in sc
     assert sc["recall"] == server.recall(cid, "rats", limit=4)
+
+
+# ── scene_context: recent_narration (the lean-beat prose tail) ───────────────
+
+
+def test_scene_context_recent_narration_default_off(cid):
+    """recent_narration defaults to 0 → no `recent_narration` key and no log read
+    (exactly today's behavior)."""
+    assert "recent_narration" not in server.scene_context(cid)
+    assert "recent_narration" not in server.scene_context(cid, recent_narration=0)
+
+
+def test_scene_context_recent_narration_returns_last_n_in_order(cid):
+    """recent_narration=N → the last N PLAYER-FACING beats (narration|dialogue),
+    in chronological order, each {text, speaker?}; bookkeeping kinds are dropped."""
+    server.log_event(cid, kind="narration", text="The cellar reeks of damp.")
+    server.log_event(cid, kind="roll", text="Perception 14")  # bookkeeping → dropped
+    server.log_event(cid, kind="dialogue", text="Stay close.", speaker="Vesper")
+    server.log_event(cid, kind="system", text="Session note")  # bookkeeping → dropped
+    server.log_event(cid, kind="narration", text="A rat skitters past.")
+
+    sc = server.scene_context(cid, recent_narration=2)
+    rn = sc["recent_narration"]
+    # Only the last 2 player-facing beats, chronological, rolls/system excluded.
+    assert [e["text"] for e in rn] == ["Stay close.", "A rat skitters past."]
+    # speaker is present only when set.
+    assert rn[0]["speaker"] == "Vesper"
+    assert "speaker" not in rn[1]
+
+
+def test_scene_context_recent_narration_capped_by_available(cid):
+    """Asking for more than exist returns all player-facing beats (no padding)."""
+    server.log_event(cid, kind="narration", text="One.")
+    server.log_event(cid, kind="dialogue", text="Two.", speaker="Vesper")
+    rn = server.scene_context(cid, recent_narration=99)["recent_narration"]
+    assert [e["text"] for e in rn] == ["One.", "Two."]
+
+
+# ── scene_context: the pinned durable continuity threads ─────────────────────
+
+
+def test_scene_context_durable_threads_present(cid):
+    """The durable pin carries the continuity-critical standing threads with stable
+    shapes (open_quests + objectives, met-NPC relationships, companion bonds,
+    faction gauges, set flags) so a transcript-free re-ground loses nothing."""
+    dur = server.scene_context(cid)["durable"]
+    assert set(dur) == {
+        "open_quests",
+        "npc_relationships",
+        "companions",
+        "factions",
+        "flags",
+    }
+
+    # open_quests: every non-completed/failed quest with its still-open objectives;
+    # mirrors get_state's active_quests ids but adds the objective continuity.
+    c = store.load_campaign(cid)
+    open_ids = {q.id for q in c.quests.values() if q.status not in ("completed", "failed")}
+    assert {q["id"] for q in dur["open_quests"]} == open_ids
+    for q in dur["open_quests"]:
+        assert set(q) == {"id", "title", "status", "open_objectives"}
+
+    # companions: standing bond shape (gauge + arc/betrayal flags), one row per companion.
+    comp_ids = {ch.id for ch in c.characters.values() if ch.kind == "companion"}
+    assert {x["id"] for x in dur["companions"]} == comp_ids
+    for x in dur["companions"]:
+        assert set(x) == {"id", "name", "attitude_value", "has_arc", "has_betrayal_agenda"}
+
+    # factions: both engine-mutated gauges surfaced.
+    for f in dur["factions"]:
+        assert set(f) == {"id", "name", "reputation", "standing"}
+
+    # npc_relationships: only NPCs the party has actually MET (not seeded strangers).
+    met_npc_ids = {ch.id for ch in c.characters.values() if ch.kind == "npc" and ch.met}
+    assert {n["id"] for n in dur["npc_relationships"]} == met_npc_ids
+
+
+def test_scene_context_durable_open_quests_drops_completed_and_objectives(cid):
+    """A completed quest leaves open_quests; a completed objective leaves
+    open_objectives — the pin reflects only what's still unresolved."""
+    # Author a quest with two objectives, then complete one of them.
+    qid = server.add_quest(
+        cid, title="Clear the cellar", objectives=["find the nest", "burn it"]
+    )["id"]
+    server.complete_objective(cid, qid, "find the nest")
+
+    dur = server.scene_context(cid)["durable"]
+    row = next(x for x in dur["open_quests"] if x["id"] == qid)
+    assert row["open_objectives"] == ["burn it"]  # the completed objective is gone
+
+    # Mark the whole quest complete → it drops out of open_quests entirely.
+    server.complete_quest(cid, qid, status="completed")
+    dur2 = server.scene_context(cid)["durable"]
+    assert qid not in {x["id"] for x in dur2["open_quests"]}
 
 
 def test_scene_context_does_not_deadlock(cid):


### PR DESCRIPTION
## Compact `scene_context` (compact-context plan)

Lets a routine DM beat **re-ground from a compact, continuity-complete bundle** instead of replaying a ~690K-token transcript — **losslessly** (everything stays on disk + FTS5-searchable via `recall`; this bundle is the always-pinned *spine*, not a replacement for the ledger).

**Also fixes the LEAN bug:** `scripts/play.sh:223` already calls `scene_context(campaign_id="…", recent_narration=$CLAWDND_LEAN_TAIL)` — a param that did not exist. This change makes that call valid.

### What changed in `scene_context`
- **New param `recent_narration: int = 0`.** When `>0`, reads the last *N* player-facing beats (`kind in {narration, dialogue}`) from the current session log via `read_log` and returns a `recent_narration` field: a list of `{text, speaker?}` in **chronological** order. **Default `0` = omitted (no log read) = exactly today's behavior.**
- **New always-present `durable` pin** so a transcript-free re-ground loses nothing:
  - `open_quests` — every non-completed/failed Quest **+ its still-open objectives**
  - `npc_relationships` — NPCs the party has **met** + `attitude_value`/`attitude`/`relationships`
  - `companions` — each companion's **standing** bond: `attitude_value`, `has_arc`, `has_betrayal_agenda`
  - `factions` — `reputation` + `standing` gauges (the event-gating values)
  - `flags` — the set world-state flags
- **Stable, cache-friendly field order** — durable-first → `director` → `events` → `companion_arcs` → `recent_narration?` → `recall?` → **`state` last** (volatile clock/HP).

### Durable threads: already present vs. added
| Thread | Status |
|---|---|
| Director's top debt | **already present** (`director` section) |
| Clock / party vitals / location / in-combat | **already present** (`state` = `get_state`) |
| Active quest **ids/titles** | already present (`state.active_quests`) |
| Open quests **+ open objectives** | **ADDED** (`durable.open_quests` — `get_state` had only `{id,title}`) |
| NPC relationships (met + approval + tags) | **ADDED** (`get_state` surfaced only `npc_count`) |
| Companion **standing** bond (loyalty gauge + arc/betrayal) | **ADDED** (`companion_arcs` reports only this-beat *deltas*) |
| Faction reputation + standing | **ADDED** (`durable.factions`) |
| Set world-state flags | **ADDED** (`durable.flags`) |

### Invariants
- **Sole-writer:** `scene_context` only **reads + derives** — the new `durable`/`recent_narration` paths never write state. (`check_companion_arc`, a pre-existing delegate, keeps its documented idempotent arc-progress save; a test asserts the new paths leave substantive state unchanged.)
- **Additive (#2):** empty == today; old snapshots round-trip; each addition independently removable.
- **Wire contracts untouched** (`clawdnd-*` / `CLAWDND_*` ids unchanged).
- Delegated sections (`director`/`events`/`companion_arcs`/`state`) stay **byte-equal** to the individual tools (regression guard in the tests).

### Tests (`servers/engine/tests/test_beat_roundtrip.py`)
- `recent_narration` default-off (unchanged) / `=N` (order, `{text,speaker?}` shape, bookkeeping kinds dropped) / cap when fewer exist.
- `durable`-threads-present (key set + per-row shapes; met-NPC and completed-quest/objective filtering).
- Durable-first / volatile-state-last ordering.
- Sole-writer no-mutation.

### CI
Validated locally with `python -c` AST checks + an in-process functional smoke against the `cellar-rats` fixture (all new behavior asserted). **Per repo policy the heavy local suite was NOT run — relying on GitHub CI** to verify the full engine suite.