### PR TITLE
Hide system bookkeeping from player chronicle

### DIFF
--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -203,12 +203,15 @@ const CHRONICLE_RENDER_CAP = 50;
 //     live tail can never interleave out of chronological order; fall back to the client-side ingest
 //     counter `.at` for rows with no seq (player echoes, a chat-only beat). Array.prototype.sort is
 //     stable (ES2019+), so equal-key rows keep insertion order.
+//   • FILTER engine `system` bookkeeping rows out of the player-facing Chronicle. Roll/combat rows
+//     stay visible because they are gameplay facts; session-start/internal system rows belong in
+//     evidence/logs, not the fresh player's story scroll.
 //   • DEDUP recentEvents (the server's trailing window of the SAME session log the live /events
 //     stream reads) against the live tail so a paragraph never shows in BOTH bands. Prefer the
 //     stable `seq` (a row in both bands shares it → the match is immune to the prose AND to a
 //     windowing re-mount); fall back to a normalized TEXT key only for rows lacking a seq (legacy
 //     server / a chat-only beat), keyed identically to app.jsx's text fallback. Non-narration
-//     history rows (rolls/system/combat) are always kept.
+//     gameplay rows (rolls/combat) are always kept.
 // recentEvents are usually the leading history band, but a player row replayed from /chat can sit
 // BETWEEN two engine-owned recentEvents rows (opening narration → player move → DM reply). When rows
 // carry eventAt, sort the combined de-duped chronicle by that real event time; legacy rows without a
@@ -244,7 +247,8 @@ function buildChronicleLog(recentEvents, chatBeats, log) {
   );
   const dedupedRecent = recent.filter((row) => {
     const kind = (row && (row.kind || row.type)) || "narration";
-    if (kind !== "narration" && kind !== "dialogue") return true;  // mechanics rows always kept
+    if (kind === "system") return false; // engine bookkeeping; never player-facing
+    if (kind !== "narration" && kind !== "dialogue") return true;  // gameplay mechanic rows kept
     const seq = row && row.seq;
     if (typeof seq === "number") return !liveSeqs.has(seq);  // stable-id match (prose-independent)
     const key = narrationKey(row && (row.text || row.detail));
@@ -770,7 +774,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
             </div>
             {/* #337: one-line hint under the action bar so a first-timer knows free-text + Declare is the core loop, distinct from the quick-action buttons. */}
             <div className="body-xs muted" style={{ marginBottom: 6 }}>
-              Type freely and press <strong>Declare</strong>, or use the <strong>Actions</strong> above (hover each for what it does).
+              Choose an <strong>Action</strong>, or write your own move and press <strong>Declare</strong>.
             </div>
             <div style={{ display: "flex", gap: 10 }}>
               <input

--- a/viewer/tests/test_live_narration_stream.py
+++ b/viewer/tests/test_live_narration_stream.py
@@ -662,6 +662,8 @@ class LiveNarrationStreamTests(unittest.TestCase):
         )
 
     # --- #503: a player row replayed from /chat belongs BETWEEN recentEvents rows by event time ---
+    # System bookkeeping can share the same recentEvents band; it must not leak into the player-facing
+    # Chronicle while the player/DM ordering still holds.
     # After a reload/surface poll, the engine-owned history band can already contain opening
     # narration + the DM reply, while the player's move is replayed from /chat. A plain
     # recentEvents-before-tail concat rendered reply → YOU. eventAt restores the actual turn order.
@@ -681,12 +683,11 @@ class LiveNarrationStreamTests(unittest.TestCase):
         self.assertEqual(
             out["chronicle"],
             [
-                {"kind": "system", "text": "Session began."},
                 {"kind": "narration", "text": "The lantern steadies."},
                 {"kind": "dialog", "text": "Ask what changed tonight.", "who": "You"},
                 {"kind": "narration", "text": "A nearby voice answers."},
             ],
-            "the player move must render before the DM reply when /chat timestamps place it there (#503)",
+            "system bookkeeping stays hidden and the player move renders before the DM reply when /chat timestamps place it there (#503)",
         )
 
     # --- #479: provider wrappers may write the final DM reply to /chat only as a turn-resolution


### PR DESCRIPTION
## Summary
- hide engine `system` bookkeeping rows from the player-facing OpenWorlds Chronicle
- keep roll/combat mechanic rows visible while preserving recent-event/chat ordering
- replace the tester-ish hover helper with player-facing move copy

## Product Evidence
- Patched browser surface: same SHA `f226cba`, private art present, `can_act:true`, six enabled actions, Look move resolved, no system-session leak in the Chronicle.
- Evidence bundle: `/Volumes/LEXAR/Codex/worldos-product-slices/hide-system-chronicle-f226cba-20260602T2150/`

## Tests
- `python3 -m pytest viewer/tests/test_live_narration_stream.py viewer/tests/test_openworlds_static.py -q` -> 70 passed, 6 subtests passed
- `git diff --check`