### PR TITLE
Expose active actor on session surface

### DIFF
--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1651,6 +1651,7 @@ def build_session_surface(
     location = _session_location(snapshot)
     party = _session_party_cards(snapshot)
     action_model = build_action_model(snapshot, live=live, is_live_view=is_live_view)
+    actor = action_model.get("actor") if isinstance(action_model.get("actor"), dict) else None
     combat_view = build_combat_view(snapshot)
     actions = _session_available_actions(action_model)
     enabled_actions, blocked_actions = _session_action_buckets(actions)
@@ -1676,6 +1677,7 @@ def build_session_surface(
             "caption": location["name"],
             "imageScope": f"location:{location['id']}" if location["id"] else "",
         },
+        "actor": actor,
         "party": party,
         "conditions": _session_conditions(party),
         "activeQuests": active_quests,

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -936,6 +936,7 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertEqual(surface["write_lane"], "/move")
         self.assertEqual(surface["title"], "Table Save")
         self.assertEqual(surface["location"]["name"], "Lower City")
+        self.assertEqual(surface["actor"], {"id": "hero", "name": "Tav", "kind": "player"})
         self.assertEqual(surface["party"][0]["name"], "Tav")
         encoded = json.dumps(surface)
         self.assertNotIn("private route", encoded)

--- a/viewer/tests/test_session_surface.py
+++ b/viewer/tests/test_session_surface.py
@@ -121,6 +121,7 @@ class SessionSurfaceTests(unittest.TestCase):
         self.assertEqual(surface["location"]["name"], "Lower City")
         self.assertEqual(surface["location"]["region"], "Baldur's Gate")
         self.assertEqual(surface["scene"]["summary"], "The party studies the sealed gate as dusk gathers.")
+        self.assertEqual(surface["actor"], {"id": "tav", "name": "Tav", "kind": "player"})
         self.assertEqual([p["name"] for p in surface["party"]], ["Tav", "Jaheira"])
         self.assertEqual(surface["party"][0]["class"], "Fighter")
         self.assertEqual(surface["party"][0]["level"], 5)
@@ -162,6 +163,7 @@ class SessionSurfaceTests(unittest.TestCase):
         surface = server.build_session_surface(snapshot, campaign_id="camp_live", live=True, is_live_view=True)
 
         self.assertTrue(surface["can_act"])
+        self.assertEqual(surface["actor"], {"id": "pc", "name": "Vela", "kind": "player"})
         self.assertEqual(surface["write_lane"], "/move")
         continue_action = _find_action(surface, "continue")
         look_action = _find_action(surface, "look")


### PR DESCRIPTION
## Summary
- Expose the safe active player actor at top-level `/session-surface.actor`.
- Keep the actor sourced from the existing read-only `actionModel.actor`, so `/session-surface` and `/app-status` agree on who can act.
- Preserve the invariant: engine remains the only campaign-state writer; the viewer only projects state and submits `/move` intents.

## Evidence
- Focused validation: `git diff --check`.
- Focused tests: `python3 -m pytest viewer/tests/test_session_surface.py viewer/tests/test_openworlds_static.py -q` -> `54 passed, 6 subtests passed`.
- Browser/read-model proof on patched worktree port `8802`: `/app-status.live.actor` and `/session-surface.actor` both identify Abby; `can_act=true`; six enabled actions; visible table shows Abby, Do mode selected, Declare enabled, and two loaded images.
- Evidence bundle: `/Volumes/LEXAR/Codex/worldos-product-slices/session-surface-actor-7580755-20260601T222443Z/`.

## Notes
- This is product read-model consistency work, not a release verdict.
- No private art or evidence files are committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The `/session-surface` endpoint now exposes actor information at the top level of the response, including the actor's ID, name, and kind. This allows direct access to details about the active party character without requiring additional API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->