### PR TITLE
fix(engine): harden scene_context durable-block reads + campaign-wide recent_narration

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -93,7 +93,7 @@ _AB3_TO_FULL = {
 # Reverse: accept either the 3-letter code (the Ability enum value) or the full word
 # (how the SRD records spell saving_throw_ability, e.g. "wisdom") and resolve to an Ability.
 _FULL_TO_AB3 = {full: ab3 for ab3, full in _AB3_TO_FULL.items()}
-from store import append_log, campaign_lock, campaigns_for_world, read_log
+from store import append_log, campaign_lock, campaigns_for_world, read_log_all
 from store import list_campaigns as _list_campaigns
 from store import list_slots as _list_slots
 from store import load_campaign, save_campaign
@@ -8386,90 +8386,112 @@ def _scene_durable_threads(c: Campaign) -> dict:
     """
     chars = list(c.characters.values())
 
+    # EVERY attribute read below is defensive (``getattr`` with a safe default) so
+    # scene_context — the DM's primary re-ground tool — NEVER raises an
+    # ``AttributeError`` because some object is missing a field the durable block
+    # expects (e.g. a partially-built Character, an older/variant model, or a field
+    # the schema never grew). A missing attribute degrades to omit/empty for that
+    # sub-field; it must never throw the whole tool. (#compact-scene-context: the
+    # `relationships` read here threw for any Character lacking that attribute.)
+
     # OPEN quests (status not completed/failed) with their still-open objectives.
-    open_quests = [
-        {
-            "id": q.id,
-            "title": q.title,
-            "status": q.status,
-            "open_objectives": [
-                o for o in q.objectives if o not in q.completed_objectives
-            ],
-        }
-        for q in c.quests.values()
-        if q.status not in ("completed", "failed")
-    ]
+    open_quests = []
+    for q in c.quests.values():
+        status = getattr(q, "status", "active")
+        if status in ("completed", "failed"):
+            continue
+        objectives = getattr(q, "objectives", None) or []
+        completed = getattr(q, "completed_objectives", None) or []
+        open_quests.append(
+            {
+                "id": getattr(q, "id", None),
+                "title": getattr(q, "title", None),
+                "status": status,
+                "open_objectives": [o for o in objectives if o not in completed],
+            }
+        )
 
     # NPC relationships the party has a standing with: only NPCs actually met
     # (a world seed pre-populates strangers; `met` gates them out — same rule the
     # dashboard's Relationships view uses).
-    npc_relationships = [
-        {
-            "id": ch.id,
-            "name": ch.name,
-            "attitude_value": ch.attitude_value,
-            **({"attitude": ch.attitude} if ch.attitude else {}),
-            **({"relationships": ch.relationships} if ch.relationships else {}),
-        }
-        for ch in chars
-        if ch.kind == "npc" and ch.met
-    ]
+    npc_relationships = []
+    for ch in chars:
+        if getattr(ch, "kind", None) != "npc" or not getattr(ch, "met", False):
+            continue
+        attitude = getattr(ch, "attitude", None)
+        relationships = getattr(ch, "relationships", None)
+        npc_relationships.append(
+            {
+                "id": getattr(ch, "id", None),
+                "name": getattr(ch, "name", None),
+                "attitude_value": getattr(ch, "attitude_value", None),
+                **({"attitude": attitude} if attitude else {}),
+                **({"relationships": relationships} if relationships else {}),
+            }
+        )
 
     # Companions' STANDING bond state (loyalty gauge + whether a sealed
     # betrayal agenda is attached) — the durable baseline check_companion_arc's
     # delta report assumes you already know.
-    companions = [
-        {
-            "id": ch.id,
-            "name": ch.name,
-            "attitude_value": ch.attitude_value,
-            "has_arc": ch.arc is not None,
-            "has_betrayal_agenda": bool(
-                ch.arc is not None
-                and ch.arc.agenda is not None
-                and ch.arc.agenda.trigger == "attitude_below"
-            ),
-        }
-        for ch in chars
-        if ch.kind == "companion"
-    ]
+    companions = []
+    for ch in chars:
+        if getattr(ch, "kind", None) != "companion":
+            continue
+        arc = getattr(ch, "arc", None)
+        agenda = getattr(arc, "agenda", None) if arc is not None else None
+        companions.append(
+            {
+                "id": getattr(ch, "id", None),
+                "name": getattr(ch, "name", None),
+                "attitude_value": getattr(ch, "attitude_value", None),
+                "has_arc": arc is not None,
+                "has_betrayal_agenda": bool(
+                    agenda is not None
+                    and getattr(agenda, "trigger", None) == "attitude_below"
+                ),
+            }
+        )
 
     # Faction gauges (engine-mutated; these gate events — invariant #3).
     factions = [
         {
-            "id": f.id,
-            "name": f.name,
-            "reputation": f.reputation,
-            "standing": f.standing,
+            "id": getattr(f, "id", None),
+            "name": getattr(f, "name", None),
+            "reputation": getattr(f, "reputation", None),
+            "standing": getattr(f, "standing", None),
         }
         for f in c.factions.values()
     ]
 
+    flags = getattr(c, "flags", None) or {}
     return {
         "open_quests": open_quests,
         "npc_relationships": npc_relationships,
         "companions": companions,
         "factions": factions,
-        "flags": sorted(k for k, v in c.flags.items() if v),
+        "flags": sorted(k for k, v in flags.items() if v),
     }
 
 
 def _scene_recent_narration(c: Campaign, limit: int) -> list[dict]:
-    """The last ``limit`` PLAYER-FACING beats (kind in narration|dialogue) from the
-    current session log, in CHRONOLOGICAL order — the prose tail a transcript-free
-    (lean) beat needs as its short-term memory of the story so far.
+    """The last ``limit`` PLAYER-FACING beats (kind in narration|dialogue) across
+    the WHOLE campaign's session logs, in CHRONOLOGICAL order — the prose tail a
+    transcript-free (lean) beat needs as its short-term memory of the story so far.
 
-    READ-ONLY: reads the session jsonl via read_log (never writes). Resolves
-    the current session the same way session_recap does (active, else the most
-    recent). Rolls / system / combat-log rows are bookkeeping noise and are
-    dropped (mirrors recap's _STORY_KINDS, minus combat: this is the spoken story).
+    READ-ONLY: reads the session jsonl files via store.read_log_all (never writes).
+    Reads CAMPAIGN-WIDE, not just the current session: under lean / fast-turn play
+    EACH beat starts a fresh session id, so the current session log is typically
+    empty and a single-session read would deliver nothing — the prose-tail would
+    silently never arrive. read_log_all walks every ``sessions/*.jsonl`` (canonical
+    session_ids order, defensive disk tail, stable by timestamp) so the last N
+    beats surface regardless of which session wrote them.
+
+    Rolls / system / combat-log rows are bookkeeping noise and are dropped (mirrors
+    recap's _STORY_KINDS, minus combat: this is the spoken story).
     """
     if limit <= 0:
         return []
-    sid = c.active_session_id or (c.session_ids[-1] if c.session_ids else None)
-    if not sid:
-        return []
-    entries = read_log(c.id, sid)
+    entries = read_log_all(c.id, getattr(c, "session_ids", None))
     facing = [e for e in entries if e.kind in ("narration", "dialogue")]
     return [
         {"text": e.text, **({"speaker": e.speaker} if e.speaker else {})}
@@ -8511,10 +8533,12 @@ def scene_context(
                         calling the tool directly; idempotent across beats.)
       - ``recent_narration`` — present ONLY when ``recent_narration`` (the param)
                         is > 0: the last N player-facing beats (narration/dialogue)
-                        from the current session log, chronological, each
-                        ``{text, speaker?}``. This is the lean-beat memory: in
-                        fast-turn mode the beat runs with NO prior transcript, so
-                        this prose tail (plus ``durable``) IS the story-so-far.
+                        across ALL of the campaign's session logs, chronological,
+                        each ``{text, speaker?}``. This is the lean-beat memory: in
+                        fast-turn mode the beat runs with NO prior transcript AND
+                        each beat opens a fresh session, so reading campaign-wide
+                        (not just the current session) is what makes this prose
+                        tail (plus ``durable``) the actual story-so-far.
                         Default 0 = omitted (no log read, today's behavior).
       - ``recall``    — present ONLY when ``recall_query`` is non-empty: the same
                         fuzzy memory search recall(query, limit) returns. Pass it
@@ -8537,7 +8561,7 @@ def scene_context(
     # next runs — sequential, never nested — so this is deadlock-free even though
     # check_companion_arc acquires the lock. (Nesting campaign_lock in one process
     # WOULD deadlock: flock is not reentrant across fds.) The durable/recent reads
-    # are lock-free snapshot reads via _require / read_log.
+    # are lock-free snapshot reads via _require / read_log_all.
     #
     # Built durable-first so the dict preserves the stable, cache-friendly order
     # (durable threads → advisory → this-beat deltas → … → volatile state last).

--- a/servers/engine/store.py
+++ b/servers/engine/store.py
@@ -294,3 +294,52 @@ def read_log(campaign_id: str, session_id: str) -> list[SessionLogEntry]:
         if line:
             entries.append(SessionLogEntry.model_validate_json(line))
     return entries
+
+
+def read_log_all(
+    campaign_id: str, session_ids: Optional[list[str]] = None
+) -> list[SessionLogEntry]:
+    """Read EVERY session log of a campaign, concatenated in chronological order.
+
+    READ-ONLY (the sole-writer invariant): only ever opens and parses the
+    ``campaigns/<id>/sessions/*.jsonl`` files; never writes.
+
+    Under lean / fast-turn play each beat starts a FRESH session id, so the
+    CURRENT session's log can be empty even though the story-so-far lives in
+    earlier session files — a per-session ``read_log`` would miss it. This walks
+    them all so a campaign-wide tail (e.g. scene_context's ``recent_narration``)
+    sees the last beats regardless of which session wrote them.
+
+    Ordering is canonical-chronological:
+      * sessions in the order the campaign opened them (``session_ids``, which the
+        model documents as "play sessions in order") come first, in that order;
+      * any *.jsonl on disk NOT named in ``session_ids`` (defensive: an orphaned
+        or externally-added file) is appended afterwards, ordered by file mtime;
+      * within each session, entries keep their on-disk (append) order.
+    A final stable sort by each entry's timestamp ``t`` smooths any cross-file
+    interleave while preserving append order for equal/zero timestamps.
+    """
+    sessions_dir = _campaign_dir(campaign_id) / "sessions"
+    if not sessions_dir.is_dir():
+        return []
+
+    on_disk = {p.stem: p for p in sessions_dir.glob("*.jsonl") if p.is_file()}
+
+    ordered_ids: list[str] = []
+    seen: set[str] = set()
+    for sid in session_ids or []:
+        if sid in on_disk and sid not in seen:
+            ordered_ids.append(sid)
+            seen.add(sid)
+    # Defensive tail: files present on disk but not listed in session_ids.
+    leftover = [sid for sid in on_disk if sid not in seen]
+    leftover.sort(key=lambda sid: on_disk[sid].stat().st_mtime)
+    ordered_ids.extend(leftover)
+
+    entries: list[SessionLogEntry] = []
+    for sid in ordered_ids:
+        entries.extend(read_log(campaign_id, sid))
+    # Stable sort: keeps within-file append order for equal timestamps and orders
+    # across files by wall-clock when timestamps are present.
+    entries.sort(key=lambda e: e.t)
+    return entries

--- a/servers/engine/tests/test_beat_roundtrip.py
+++ b/servers/engine/tests/test_beat_roundtrip.py
@@ -116,6 +116,50 @@ def test_scene_context_recent_narration_capped_by_available(cid):
     assert [e["text"] for e in rn] == ["One.", "Two."]
 
 
+def test_scene_context_recent_narration_spans_multiple_sessions(cid):
+    """DEFECT 2 — the lean case: under fast-turn play each beat opens a FRESH
+    session, so prose lives across several session logs. recent_narration must read
+    the campaign WIDE and return the last N player-facing beats regardless of which
+    session wrote them — the prior pre-fix single-session read returned [] here
+    (the current session's log was empty).
+    """
+    # Session 1: a couple of player-facing beats.
+    server.log_event(cid, kind="narration", text="The market wakes at dawn.")
+    server.log_event(cid, kind="dialogue", text="Coin first.", speaker="Sael")
+
+    # Roll over to a FRESH session (this is what lean/fast-turn does each beat).
+    server.start_session(cid, title="next beat")
+    c = store.load_campaign(cid)
+    assert len(c.session_ids) >= 2  # we are genuinely on a new session now
+
+    # Session 2: more beats (plus bookkeeping that must be dropped).
+    server.log_event(cid, kind="roll", text="Insight 12")  # dropped
+    server.log_event(cid, kind="narration", text="A cloaked figure watches.")
+    server.log_event(cid, kind="dialogue", text="You're being followed.", speaker="Sael")
+
+    sc = server.scene_context(cid, recent_narration=3)
+    rn = sc["recent_narration"]
+    # Last 3 player-facing beats, in chronological order, SPANNING both sessions:
+    # the tail crosses the session boundary (one from session 1, two from session 2).
+    assert [e["text"] for e in rn] == [
+        "Coin first.",
+        "A cloaked figure watches.",
+        "You're being followed.",
+    ]
+    assert rn[0]["speaker"] == "Sael"  # speaker preserved across the session boundary
+    assert "speaker" not in rn[1]  # narration has no speaker
+
+    # And a wide-enough window returns ALL player-facing beats from both sessions
+    # in order (the system/roll rows from start_session + the explicit roll dropped).
+    wide = server.scene_context(cid, recent_narration=99)["recent_narration"]
+    assert [e["text"] for e in wide] == [
+        "The market wakes at dawn.",
+        "Coin first.",
+        "A cloaked figure watches.",
+        "You're being followed.",
+    ]
+
+
 # ── scene_context: the pinned durable continuity threads ─────────────────────
 
 
@@ -172,6 +216,57 @@ def test_scene_context_durable_open_quests_drops_completed_and_objectives(cid):
     server.complete_quest(cid, qid, status="completed")
     dur2 = server.scene_context(cid)["durable"]
     assert qid not in {x["id"] for x in dur2["open_quests"]}
+
+
+class _BareCharacter:
+    """A stand-in 'character' that is MISSING every durable-block attribute
+    (relationships, attitude_value, attitude, kind, met, arc, ...).
+
+    Reproduces the #compact-scene-context crash class: the durable block read
+    ``ch.relationships`` (a field the real Character never even had), so any
+    object lacking an expected attribute threw AttributeError and took the whole
+    scene_context tool down. The hardened block must getattr-default every read
+    and degrade gracefully — never raise — on such an object.
+    """
+
+
+def test_scene_durable_threads_never_throws_on_missing_attrs(cid):
+    """DEFECT 1 — scene_context must NOT throw when a character object lacks the
+    attributes the durable block expects; it degrades (omits/empties) instead.
+
+    We splice a bare object (no relationships / attitude_value / kind / met / arc)
+    into the in-memory roster and derive the durable threads directly. Pre-fix this
+    raised ``AttributeError: 'Character' object has no attribute 'relationships'``;
+    post-fix it returns normally and simply contributes nothing for that object.
+    """
+    c = store.load_campaign(cid)
+    baseline = server._scene_durable_threads(c)
+
+    c.characters["bare-1"] = _BareCharacter()  # validate_assignment is off — fine in-mem
+    dur = server._scene_durable_threads(c)  # must NOT raise
+
+    # The bare object has no kind/met/arc → it joins no durable list; the real
+    # threads are unchanged from the baseline (graceful degradation, not a crash).
+    assert set(dur) == {"open_quests", "npc_relationships", "companions", "factions", "flags"}
+    assert dur == baseline
+
+
+def test_scene_context_met_npc_without_relationships_attr(cid):
+    """DEFECT 1 (end-to-end) — a MET npc surfaces in durable.npc_relationships and
+    scene_context returns cleanly even though Character has no ``relationships``
+    attribute at all (the exact field whose non-defensive read threw). The row
+    carries the attitude that IS set and simply omits the absent relationships.
+    """
+    pc = server.create_character(cid, "Probe", kind="player", abilities={"charisma": 16})["id"]
+    npc = server.create_character(cid, "Sael", kind="npc")["id"]
+    # A successful social check flips `met` True (first-contact) and sets attitude.
+    server.social_check(cid, pc, npc, "persuasion", dc=1)
+
+    sc = server.scene_context(cid)  # must NOT raise
+    row = next(n for n in sc["durable"]["npc_relationships"] if n["id"] == npc)
+    assert row["name"] == "Sael"
+    assert "relationships" not in row  # Character has no such attribute → omitted, not a crash
+    assert "attitude" in row  # the set free-text disposition is still surfaced
 
 
 def test_scene_context_does_not_deadlock(cid):

--- a/servers/engine/tests/test_store.py
+++ b/servers/engine/tests/test_store.py
@@ -11,7 +11,7 @@ import logging
 import pytest
 
 import store
-from models import Campaign
+from models import Campaign, SessionLogEntry
 
 
 # ---------------------------------------------------------------------------
@@ -179,3 +179,65 @@ def test_load_old_snapshot_without_version_fields(tmp_path, monkeypatch):
     # Defaults applied for the absent fields.
     assert result.schema_version == 1
     assert result.engine_sha == ""
+
+
+# ---------------------------------------------------------------------------
+# (f) read_log_all: campaign-wide narration reader (the lean-beat fix, #compact-
+#     scene-context defect 2). Each lean beat opens a fresh session, so a tail of
+#     the story must concatenate ALL session logs in chronological order.
+# ---------------------------------------------------------------------------
+
+def test_read_log_all_concatenates_sessions_in_order(tmp_path, monkeypatch):
+    """read_log_all walks EVERY sessions/*.jsonl and returns them in canonical
+    session order (session_ids first), within-file append order preserved — the
+    cross-session continuity a single read_log misses under lean play."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp-wide"
+
+    store.append_log(cid, "s1", SessionLogEntry(t=1.0, kind="narration", text="a"))
+    store.append_log(cid, "s1", SessionLogEntry(t=2.0, kind="dialogue", text="b"))
+    store.append_log(cid, "s2", SessionLogEntry(t=3.0, kind="narration", text="c"))
+    store.append_log(cid, "s2", SessionLogEntry(t=4.0, kind="narration", text="d"))
+
+    # Per-session reads only see their own file (this is the lean trap: s2 read in
+    # isolation never shows s1's prose).
+    assert [e.text for e in store.read_log(cid, "s1")] == ["a", "b"]
+    assert [e.text for e in store.read_log(cid, "s2")] == ["c", "d"]
+
+    # Campaign-wide read stitches them in canonical chronological order.
+    allg = store.read_log_all(cid, ["s1", "s2"])
+    assert [e.text for e in allg] == ["a", "b", "c", "d"]
+
+
+def test_read_log_all_empty_when_no_sessions(tmp_path, monkeypatch):
+    """No sessions dir / no files → [] (never raises), so an early lean beat with
+    nothing logged yet degrades to an empty tail."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    assert store.read_log_all("no-such-campaign", None) == []
+    assert store.read_log_all("no-such-campaign", ["s1"]) == []
+
+
+def test_read_log_all_includes_files_not_in_session_ids(tmp_path, monkeypatch):
+    """A *.jsonl on disk not named in session_ids (orphan/external) is still read
+    (defensive tail), so no committed prose is silently lost."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp-orphan"
+    store.append_log(cid, "listed", SessionLogEntry(t=1.0, kind="narration", text="listed"))
+    store.append_log(cid, "orphan", SessionLogEntry(t=2.0, kind="narration", text="orphan"))
+
+    texts = [e.text for e in store.read_log_all(cid, ["listed"])]
+    assert "listed" in texts and "orphan" in texts
+
+
+def test_read_log_all_is_read_only(tmp_path, monkeypatch):
+    """Sole-writer invariant: read_log_all must not create or modify any file."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp-ro"
+    store.append_log(cid, "s1", SessionLogEntry(t=1.0, kind="narration", text="x"))
+    sessions_dir = tmp_path / "campaigns" / cid / "sessions"
+    before = {p.name: p.stat().st_mtime_ns for p in sessions_dir.glob("*.jsonl")}
+
+    store.read_log_all(cid, ["s1"])
+
+    after = {p.name: p.stat().st_mtime_ns for p in sessions_dir.glob("*.jsonl")}
+    assert before == after  # no writes, no new files


### PR DESCRIPTION
Fixes the **two leanval blockers** in the compact `scene_context` (both found by a real lean validation run; both block making lean the default).

## Defect 1 — `AttributeError` crashed `scene_context` (the DM's primary re-ground tool)
`_scene_durable_threads` read durable-block attributes **non-defensively**. In particular `ch.relationships` references a field the `Character` model never had, so it raised `'Character' object has no attribute 'relationships'` and took down the *entire* `scene_context` call for **any** character — not an edge case.

**Fix:** every durable-block read now uses `getattr(..., <safe default>)` and degrades gracefully (omit/empty that sub-field) instead of throwing. Audited the whole block, not just the reported line. Hardened reads:
- character: `relationships`, `attitude`, `attitude_value`, `kind`, `met`, `arc` → `arc.agenda` → `agenda.trigger`
- quest: `id`, `title`, `status`, `objectives`, `completed_objectives`
- faction: `id`, `name`, `reputation`, `standing`
- campaign: `flags`

`scene_context` can no longer throw because an object is missing an expected attribute.

## Defect 2 — `recent_narration` empty under lean
The param read only the **current** session log via `read_log`, but under lean each beat starts a **fresh** session id → the current log is empty → the prose tail never delivered.

**Fix:** new read-only `store.read_log_all(campaign_id, session_ids)` walks every `campaigns/<id>/sessions/*.jsonl` in canonical `session_ids` order (defensive disk tail for orphan files, stable sort by entry timestamp). `_scene_recent_narration` now reads **campaign-wide**, so the last N player-facing beats (`narration`/`dialogue`) surface regardless of which session wrote them. Sole-writer invariant preserved (read-only).

## Tests (extend `servers/engine/tests/`)
- `test_beat_roundtrip.py`:
  - `scene_context` does **not** throw when a character lacks `relationships`/other durable attrs — both a bare object spliced into the roster and a real **met NPC** (which genuinely has no `relationships` attr) returning gracefully.
  - `recent_narration` returns the last N beats spanning **multiple prior sessions** (the lean case) — crossing a `start_session` boundary.
- `test_store.py`: `read_log_all` unit tests — cross-session order, empty/missing campaign, orphan-file inclusion, read-only (no file writes/mtime changes).

## Verification
- `python -m py_compile` on all 4 changed files: OK.
- AST checks: zero non-defensive `ch.`/`q.`/`f.` reads remain in `_scene_durable_threads`; `read_log` no longer referenced in `server.py`; `_scene_recent_narration` calls `read_log_all`.
- In-process functional smoke (against real `models` + real disk; `mcp` dep unavailable in sandbox so `server` itself wasn't imported): `read_log_all` stitches narration across sessions in order, drops bookkeeping kinds, returns `[]` for a missing campaign; confirmed a real `Character` lacks `relationships` (old `ch.relationships` *does* raise) and the `getattr` path degrades cleanly.
- Full pytest suite verified by CI.

Do **not** merge — owner merges after CI.