### PR TITLE
fix(viewer): show art for common market items

### DIFF
--- a/viewer/openworlds/chrome.jsx
+++ b/viewer/openworlds/chrome.jsx
@@ -9,6 +9,26 @@ window.slug = function slug(name) {
   return (name || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 };
 
+// Shared item art aliases. Player-facing item names often carry table qualifiers
+// ("Travel rations", "Iron lantern", "Wax candle (x6)") while the ingested art cache
+// stores the reusable base prop ("item-rations", "item-lantern", "item-candle").
+// Keep this in the viewer read layer so engine item identity stays unchanged.
+const ITEM_ART_ALIASES = {
+  "travel-ration": "rations",
+  "travel-rations": "rations",
+  "iron-lantern": "lantern",
+  "wax-candle-6": "candle",
+  "wax-candles-6": "candle",
+  "candles": "candle",
+};
+
+window.itemArtScope = function itemArtScope(itemOrName) {
+  const name = typeof itemOrName === "string" ? itemOrName : itemOrName?.name;
+  const s = window.slug(name);
+  const aliased = ITEM_ART_ALIASES[s] || s;
+  return aliased ? "item-" + aliased : "";
+};
+
 const NAV_GROUPS = [
   {
     id: "g_table", label: "Table", glyph: "dice",

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -17,6 +17,7 @@ function slug(name) {
    The engine item.id is a composite "{character_id}:{idx}:{name}" which normalises to a unique
    per-instance key that never matches the shared art, so it must NOT be used for the scope. */
 function itemScope(item) {
+  if (window.itemArtScope) return window.itemArtScope(item);
   const s = slug(item && item.name);
   return s ? "item-" + s : "";
 }

--- a/viewer/openworlds/screen-merchant.jsx
+++ b/viewer/openworlds/screen-merchant.jsx
@@ -5,6 +5,7 @@
    the same key. Build the scope from a slug of the item NAME so wiki icons resolve, with a
    graceful 404 → <Placeholder> fallback inside <Img>. */
 function mItemScope(item) {
+  if (window.itemArtScope) return window.itemArtScope(item);
   const s = (window.slug ? window.slug(item && item.name) : "");
   return s ? "item-" + s : "";
 }

--- a/viewer/tests/test_item_icons.py
+++ b/viewer/tests/test_item_icons.py
@@ -104,6 +104,22 @@ class ItemIconTests(unittest.TestCase):
         # ItemSlot now renders Img, not only a glyph span.
         self.assertIn("scope={itemScope(item)}", src)
 
+    def test_shared_item_art_alias_helper_exists(self):
+        """Shared itemArtScope aliases table-qualified item names to reusable art."""
+        _status, _ctype, body = self._get("/openworlds/chrome.jsx")
+        src = body.decode("utf-8")
+        self.assertIn("window.itemArtScope", src)
+        self.assertIn('"travel-rations": "rations"', src)
+        self.assertIn('"iron-lantern": "lantern"', src)
+        self.assertIn('"wax-candle-6": "candle"', src)
+
+    def test_merchant_uses_shared_item_art_scope(self):
+        """Merchant item icons must use the shared alias helper before falling back."""
+        _status, _ctype, body = self._get("/openworlds/screen-merchant.jsx")
+        src = body.decode("utf-8")
+        self.assertIn("window.itemArtScope", src)
+        self.assertIn("return window.itemArtScope(item)", src)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add a shared viewer-side item art scope helper for table-qualified item names
- map common market labels like Travel rations and Iron lantern to existing private art scopes
- route Merchant and Inventory item art through the shared helper without changing engine item identity or state writes

## Product Evidence
- Browser proof on worktree SHA 980c0e9 + patch, port 8802, private art root `/Users/lume/ClawDnD-val`
- Evidence: `/Volumes/LEXAR/Codex/worldos-product-slices/market-item-art-aliases-980c0e9-20260601T224906Z/`
- `market-render.json`: visible broken completed images = 0; Travel rations resolves to `item-rations`; Iron lantern resolves to `item-lantern`
- `image-http.txt`: `item-rations 200 2296`, `item-lantern 200 21580`

## Tests
- `python3 -m pytest viewer/tests/test_item_icons.py -q` -> 8 passed
- `python3 -m pytest viewer/tests/test_openworlds_static.py viewer/tests/test_item_icons.py -q` -> 53 passed, 6 subtests passed

## Invariant Check
- Engine remains sole campaign-state writer.
- This change is viewer/read-model only: it changes item image scope resolution and does not add a write path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed item icon display for common items like rations, lanterns, and candles by implementing a unified artwork aliasing system that properly resolves cached item artwork.

* **Tests**
  * Added tests to verify item icon aliasing and merchant item scope functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->