### PR TITLE
Fix Heroes screen party portrait rendering

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -10,7 +10,7 @@
    A loaded PC/companion, however, carries a random instance id ("char_40c15af4c9fc") that
    matches no art — so we derive the scope from slug(name), which resolves real faces for
    canon heroes and degrades to the silhouette (via Img's onError) for portrait-less ones. */
-function portraitScope(p) {
+function characterPortraitScope(p) {
   const s = (p && p.name && window.slug) ? window.slug(p.name) : "";
   if (s) return "portrait-" + s;
   return (p && p.id) ? "portrait-" + p.id : "";
@@ -93,7 +93,7 @@ function ScreenCharacter({ onNavigate, state, setState }) {
               : "inset 0 0 0 1px rgba(140,100,60,0.2)",
             textAlign: "left",
           }}>
-            <Img scope={portraitScope(p)} label={p.name} w={36} h={44} framed />
+            <Img scope={characterPortraitScope(p)} label={p.name} w={36} h={44} framed />
             <div>
               <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.08em", color: "var(--ink-900)" }}>
                 {p.name}
@@ -131,7 +131,7 @@ function ScreenCharacter({ onNavigate, state, setState }) {
         {/* Hero header card */}
         <Panel framed style={{ padding: 22 }}>
           <div style={{ display: "grid", gridTemplateColumns: "140px 1fr auto", gap: 22, alignItems: "start" }}>
-            <Img scope={portraitScope(hero)} label={`${hero.name} · portrait`} w={140} h={170} framed />
+            <Img scope={characterPortraitScope(hero)} label={`${hero.name} · portrait`} w={140} h={170} framed />
             <div>
               <div className="eyebrow" style={{ color: "var(--crimson)" }}>{hero.alignment}</div>
               <h1 className="h1" style={{ marginTop: 2 }}>{hero.name}</h1>
@@ -1201,4 +1201,4 @@ function FeatsTab({ hero }) {
   );
 }
 
-Object.assign(window, { ScreenCharacter, AbilityScore, StatLine, ResourcesStatus, HeroEquipDoll, equippedStat, AbilitiesTab, SkillsTab, SpellsTab, SpellbookBrowser, SpellSlotTrack, SpellRules, SpellRuleChip, hasSpellRules, LineagePanel, FeatsTab, AbilityCard, FeatRow, RestPrepareModal, RestCard, ProficiencyDot, ProficiencyBadge, portraitScope, spellMeta });
+Object.assign(window, { ScreenCharacter, AbilityScore, StatLine, ResourcesStatus, HeroEquipDoll, equippedStat, AbilitiesTab, SkillsTab, SpellsTab, SpellbookBrowser, SpellSlotTrack, SpellRules, SpellRuleChip, hasSpellRules, LineagePanel, FeatsTab, AbilityCard, FeatRow, RestPrepareModal, RestCard, ProficiencyDot, ProficiencyBadge, characterPortraitScope, spellMeta });

--- a/viewer/tests/test_portrait_art.py
+++ b/viewer/tests/test_portrait_art.py
@@ -70,6 +70,20 @@ class PortraitArtRouteTests(unittest.TestCase):
         self.assertIn("Img scope=", source)
         self.assertIn("portrait-", source)
 
+    def test_screen_character_portrait_scope_does_not_collide_with_create_gallery_scope(self):
+        # screen-create.jsx owns a gallery helper named portraitScope(index). The character
+        # sheet must not use the same global helper name for party members, or the later-loaded
+        # create screen overwrites it and Heroes falls back to portrait placeholders.
+        status, ctype, body = self._get("/openworlds/screen-character.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        self.assertIn("function characterPortraitScope(p)", source)
+        self.assertIn("scope={characterPortraitScope(p)}", source)
+        self.assertIn("scope={characterPortraitScope(hero)}", source)
+        self.assertNotIn("function portraitScope(p)", source)
+
     def test_screen_table_uses_img_render_bridge_for_party_portraits(self):
         # screen-table.jsx must use <Img scope="portrait-…"> in the PartyRow component
         # for each PC in the party list / turn order panel.


### PR DESCRIPTION
## Summary
- Fixes the Party / Heroes screen rendering actor portraits as placeholders while the same portrait loads on Table and Parley.
- Renames the character-sheet portrait helper to avoid a global collision with the later-loaded create-flow gallery helper.
- Adds a regression test so the character sheet cannot reintroduce the global `portraitScope(p)` collision.

## Product Evidence
- Browser-first local proof on the patched viewer: Heroes renders two loaded Abby images from `/image?scope=portrait-abby` and zero portrait placeholders.
- Browser console errors: 0.
- Private browser screenshots/status snapshots are retained under the local Lexar evidence root and are not committed.

## Test Plan
- `python3 -m pytest viewer/tests/test_portrait_art.py -q`
- `python3 -m pytest viewer/tests/test_openworlds_static.py viewer/tests/test_portrait_art.py -q`

## Invariants
- Viewer-only change.
- Engine remains the sole campaign-state writer.
- GUI remains a read-model consumer plus `/move` intent submitter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hero portrait rendering to properly identify and display character images using character names instead of internal identifiers. Canonical hero portraits now load correctly in roster views and character headers with improved fallback support.

* **Tests**
  * Added validation test to ensure portrait display logic functions correctly and prevents naming conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->