### PR TITLE
Reset composer after immediate quick actions

### DIFF
--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -611,6 +611,11 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
       return;
     }
     if (action.move) {
+      // Immediate quick actions (Continue/Travel/etc.) are not the free-text composer.
+      // Reset any stale Say/Check/Save draft mode so the active composer reflects the
+      // next declarable free-form action after the move resolves.
+      setComposerModeId("do");
+      setInput("");
       postMove(action.move, action.label, action.id);
     }
   };

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -589,6 +589,22 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn("composerMode.placeholder", source)
         self.assertIn("disabled={!actionById(composerMode.actionId)?.available || pendingActive}", source)
 
+    def test_openworlds_table_immediate_actions_reset_stale_composer_mode(self):
+        # Fresh-player blocker: if Say was selected, clicking an immediate action like Continue
+        # posted the Continue move but left the composer saying Active Abby / Say. Immediate
+        # quick actions now reset the free-text composer to its default mode before posting.
+        status, ctype, body = self._get("/openworlds/screen-table.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        action_move = source.index("if (action.move)")
+        reset_mode = source.index('setComposerModeId("do");', action_move)
+        clear_input = source.index('setInput("");', action_move)
+        post_move = source.index("postMove(action.move, action.label, action.id);", action_move)
+        self.assertLess(reset_mode, post_move)
+        self.assertLess(clear_input, post_move)
+
     def test_openworlds_table_renders_all_actions_without_truncation(self):
         # #G3: the palette must not silently cap the action list. The read model emits up to 8
         # verbs (exploration: say/do/check/continue/cast/use + combat: attack/bonus/reaction);


### PR DESCRIPTION
## Summary
- Fixes a first-turn UI mismatch where selecting `Say`, then clicking an immediate action like `Continue`, posted the Continue move but left the composer in `Say` mode.
- Immediate quick actions now reset the free-text composer to the default `Do` mode and clear stale draft text before posting the move.
- Adds a regression guard for the immediate-action path.

## Product Evidence
- Browser-first proof on the patched viewer: `Say` selected -> `Continue` clicked -> DM narration returned -> composer mode is `Do`, placeholder is `Describe what your hero does...`, six actions re-enabled, zero console errors.
- Private browser screenshots/status snapshots are retained under the local Lexar evidence root and are not committed.

## Test Plan
- `python3 -m pytest viewer/tests/test_openworlds_static.py -q`

## Invariants
- Viewer-only state reset.
- Engine remains the sole campaign-state writer.
- GUI remains a read-model consumer plus `/move` intent submitter.