### PR TITLE
run_duo now honors CLAWDND_LEAN_BEATS — the duo harness was bypassing the lean path; mirrors play.sh

### DIFF
--- a/qa/dryrun_lean_proof.sh
+++ b/qa/dryrun_lean_proof.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# DRY-RUN PROOF (no model call): shows that qa/run_duo.sh's DM turn now honors
+# CLAWDND_LEAN_BEATS via the SHARED clawdnd_dm_lean_args helper. It sources the REAL
+# qa/lib_beat_driver.sh and reproduces run_duo.sh's DM-branch argv assembly VERBATIM,
+# with a stub `claude` that just prints the argv it would have run. We assert that:
+#   (1) lean ON + continuing beat + known campaign  -> fresh --session-id + LEAN RE-GROUND
+#       --append-system-prompt, and NO --resume;
+#   (2) lean ON + cold open (first=1)               -> normal --session-id $DSID, no lean;
+#   (3) lean OFF + continuing beat                  -> --resume $DSID, no lean (unchanged).
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/qa/lib_beat_driver.sh"
+
+DSID="DSID-fixed-0000"
+CAMPAIGN_ID="camp-abc123"
+CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
+DM_CFG="/tmp/dm.mcp.json"; BUDGET="0.80"; CLAWDND_DM_MODEL="sonnet"
+
+# Stub `claude`: print the exact argv (NUL-joined, then shown one-per-line) and return.
+claude() {
+  printf 'CLAUDE-ARGV-BEGIN\n'
+  local a; for a in "$@"; do printf '  «%s»\n' "$a"; done
+  printf 'CLAUDE-ARGV-END\n'
+}
+
+# VERBATIM copy of run_duo.sh turn()'s DM branch argv assembly (the code under test).
+dm_turn_argv() {            # $1=first(1/0)  $2=msg
+  local first="$1" msg="$2" sid="$DSID" resume=() extra=()
+  [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
+  clawdnd_dm_lean_args "$first" "${CAMPAIGN_ID:-}" "$CLAWDND_LEAN_TAIL"
+  if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
+    resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
+    extra=("${CLAWDND_DM_LEAN_EXTRA[@]}")
+  fi
+  claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+    --model "$CLAWDND_DM_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+    --output-format stream-json --verbose
+}
+
+hr() { printf '\n========== %s ==========\n' "$1"; }
+
+hr "SCENARIO 1 — CLAWDND_LEAN_BEATS=1, continuing beat (first=0), campaign known"
+out1="$(CLAWDND_LEAN_BEATS=1 dm_turn_argv 0 'The player does: opens the door.')"
+printf '%s\n' "$out1"
+
+hr "SCENARIO 2 — CLAWDND_LEAN_BEATS=1, COLD OPEN (first=1) -> lean must NOT fire"
+out2="$(CLAWDND_LEAN_BEATS=1 dm_turn_argv 1 'Begin the session.')"
+printf '%s\n' "$out2"
+
+hr "SCENARIO 3 — CLAWDND_LEAN_BEATS=0, continuing beat (first=0) -> UNCHANGED"
+out3="$(CLAWDND_LEAN_BEATS=0 dm_turn_argv 0 'The player does: opens the door.')"
+printf '%s\n' "$out3"
+
+# ---- Assertions -------------------------------------------------------------------
+hr "ASSERTIONS"
+fail=0
+chk() { if eval "$2"; then echo "PASS: $1"; else echo "FAIL: $1"; fail=1; fi; }
+
+# S1: lean ON, continuing -> fresh --session-id (a UUID, NOT $DSID), LEAN RE-GROUND present, NO --resume.
+chk "S1 has --session-id"                       'printf "%s" "$out1" | grep -q -- "--session-id"'
+chk "S1 fresh session id is a UUID (not \$DSID)" 'printf "%s" "$out1" | grep -Eq "«[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}»"'
+chk "S1 NOT $DSID"                               '! printf "%s" "$out1" | grep -q -- "«DSID-fixed-0000»"'
+chk "S1 has --append-system-prompt"             'printf "%s" "$out1" | grep -q -- "--append-system-prompt"'
+chk "S1 directive says LEAN RE-GROUND"          'printf "%s" "$out1" | grep -q "LEAN RE-GROUND"'
+chk "S1 directive names scene_context+campaign" 'printf "%s" "$out1" | grep -q "scene_context(campaign_id=\\\"camp-abc123\\\""'
+chk "S1 directive honors recent_narration tail" 'printf "%s" "$out1" | grep -q "recent_narration=8"'
+chk "S1 has NO --resume"                         '! printf "%s" "$out1" | grep -q -- "--resume"'
+
+# S2: lean ON but cold open -> normal --session-id $DSID, no lean.
+chk "S2 uses --session-id \$DSID (cold open)"   'printf "%s" "$out2" | grep -q -- "«DSID-fixed-0000»"'
+chk "S2 has NO --append-system-prompt"           '! printf "%s" "$out2" | grep -q -- "--append-system-prompt"'
+chk "S2 has NO --resume"                          '! printf "%s" "$out2" | grep -q -- "--resume"'
+
+# S3: lean OFF, continuing -> --resume $DSID, no lean (byte-identical to today).
+chk "S3 uses --resume \$DSID"                    'printf "%s" "$out3" | grep -q -- "--resume" && printf "%s" "$out3" | grep -q -- "«DSID-fixed-0000»"'
+chk "S3 has NO --append-system-prompt"           '! printf "%s" "$out3" | grep -q -- "--append-system-prompt"'
+chk "S3 has NO fresh --session-id"               '! printf "%s" "$out3" | grep -q -- "--session-id"'
+
+hr "RESULT"
+[ "$fail" = 0 ] && echo "ALL ASSERTIONS PASSED" || echo "SOME ASSERTIONS FAILED"
+exit "$fail"

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -93,6 +93,59 @@ clawdnd_dm_narration_or_fallback() {
   fi
 }
 
+# LEAN-BEAT DM-TURN ARGS (the ONE shared implementation of the CLAWDND_LEAN_BEATS path).
+#
+# Both play loops (scripts/play.sh AND qa/run_duo.sh) drive a DM turn through `claude -p`,
+# normally `--resume`-ing the DM's growing session every beat (which REPLAYS the whole
+# transcript → prefill grows ~6–10K tok/beat → the late-session slowdown a narrative persona
+# quit over). With CLAWDND_LEAN_BEATS=1, continuing beats (NOT the cold open) instead start a
+# FRESH session — a new --session-id, NO transcript carried — plus an --append-system-prompt
+# re-ground directive telling the DM to re-ground from the engine's persisted truth via
+# scene_context (which bundles state/threads/arcs + the recent player-facing narration TAIL)
+# rather than from the fat transcript.
+#
+# This used to live INLINE in scripts/play.sh's dm_turn only, so qa/run_duo.sh's DM turn
+# silently ignored the flag and the duo QA harness could never exercise lean. Factored here so
+# the lean SESSION-ARG decision + the (long, drift-prone) re-ground directive prose live in
+# EXACTLY ONE place and the two harnesses can't drift again (the file's stated intent).
+#
+# Bash 3.2 (the macOS system bash both harnesses run under) has NO namerefs, so this CANNOT
+# return arrays by reference. Instead it POPULATES two well-known GLOBAL arrays the caller
+# splices into its claude -p invocation:
+#   CLAWDND_DM_LEAN_SESSION  — () when NOT lean (caller keeps its own --resume/--session-id),
+#                              else (--session-id <fresh-uuid>) for a transcript-free turn.
+#   CLAWDND_DM_LEAN_EXTRA    — () when NOT lean, else (--append-system-prompt "<directive>").
+# Lean fires ONLY when: first = 0 (a CONTINUING beat)  AND  $CLAWDND_LEAN_BEATS = 1  AND
+# campaign_id is non-empty. The cold open (first != 0) or an unknown campaign id falls through
+# to the caller's normal resume path — byte-identical to today when the flag is off.
+# CONVENTION (both harnesses): first=1 ⇒ the cold open that mints the session; first=0 ⇒ a
+# continuing beat that would otherwise --resume it. Lean replaces that --resume on continuing
+# beats with a fresh transcript-free session — so the firing condition is first=0, NOT first!=0.
+# (scripts/play.sh's old inline lean used `first != 0`, which — combined with campaign_id only
+# being known on continuing beats — meant its lean branch NEVER actually fired; this shared
+# helper restores the documented intent: lean on beats 2+, full cold open. See PR notes.)
+# $CLAWDND_LEAN_TAIL ($3, default 8) is the recent-narration depth the re-ground asks for.
+# $1 = first?(1/0)  $2 = campaign_id (may be empty)  $3 = lean_tail (optional; default 8)
+clawdnd_dm_lean_args() {
+  local first="$1" campaign_id="${2:-}" lean_tail="${3:-8}"
+  CLAWDND_DM_LEAN_SESSION=()
+  CLAWDND_DM_LEAN_EXTRA=()
+  # The cold open (first != 0), flag off, or no campaign to re-ground against → no-op (caller's
+  # existing --resume/--session-id path is used unchanged). Lean fires on CONTINUING beats only.
+  if [ "$first" != "0" ] || [ "${CLAWDND_LEAN_BEATS:-0}" != "1" ] || [ -z "$campaign_id" ]; then
+    return 0
+  fi
+  # LEAN beat: fresh session, no transcript replay. Re-ground from persisted truth.
+  CLAWDND_DM_LEAN_SESSION=(--session-id "$(uuidgen 2>/dev/null || python3 -c 'import uuid;print(uuid.uuid4())')")
+  CLAWDND_DM_LEAN_EXTRA=(--append-system-prompt "LEAN RE-GROUND (this turn has NO prior conversation transcript — by design, to keep your turn fast). You are mid-campaign, NOT starting over. Your FIRST action this turn MUST be clawdnd-engine scene_context(campaign_id=\"$campaign_id\", recent_narration=$lean_tail). That one call returns the campaign's CANON, and it is your whole memory for this beat — HONOR all of it as canon YOU already authored:
+  • durable — the standing threads that persist across the campaign: open_quests (each with its still-open objectives = what the party still OWES), npc_relationships (every NPC the party has MET, with their attitude_value + attitude + relationship tags), companions (each companion's standing bond — attitude_value, has_arc, has_betrayal_agenda), factions (reputation + standing gauges), and the set flags.
+  • director — the top structural debts the campaign owes right now (advisory; pay the top one as fiction, never recite it).
+  • events / companion_arcs — any decisional that fired this beat, and any bond that just turned or betrayal_warning to foreshadow.
+  • recent_narration — the last $lean_tail player-facing beats' prose (the immediate story-so-far).
+  • state — the volatile current scene, party vitals, day/time, active quests, combat, pacing_mode, seed_params.
+Do NOT contradict any of it, re-introduce an already-met NPC, reset the clock, or forget a prior choice. CRUCIAL — LOSSLESS RULE: this compact bundle is the always-pinned SPINE, not the whole world. For ANYTHING the moment reaches back to that is NOT in this bundle (a fact, NPC, place, event, or lore detail from earlier), you MUST retrieve it BEFORE you narrate — the entire world/lore/history is searchable on disk: call recall(campaign_id=\"$campaign_id\", query=\"…\") for past events/decisions/facts, lookup_lore(campaign_id=\"$campaign_id\", query=\"…\") for world/setting lore, or recall_npc(campaign_id=\"$campaign_id\", npc_id=\"…\") before voicing a returning NPC. NEVER guess and NEVER invent a detail that contradicts established canon — retrieve first. (You may also pass recall_query=\"…\" to scene_context to fold a recall into the same first call.) Then resolve the move and narrate, seamlessly continuing the established story.")
+}
+
 # Read the run's progression facts from the snapshot in ONE python pass. Echoes a single
 # TAB-separated line:  day <TAB> time_of_day <TAB> visited_count <TAB> npcs_met <TAB>
 # current_location_id <TAB> current_location_visited(0/1) <TAB> combat_active(0/1)

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -32,6 +32,20 @@ CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
 # The player facade is a near-free no-tool agent; its model is a separate knob (default sonnet,
 # so behavior is unchanged) kept consistent with the party harness's WORLDOS_ACTOR_MODEL.
 CLAWDND_ACTOR_MODEL="$(worldos_env ACTOR_MODEL sonnet)"
+
+# --- Lean-per-beat context (PERF, default OFF → byte-identical to today). --------------
+# MIRRORS scripts/play.sh exactly (and shares its ONE implementation via the
+# clawdnd_dm_lean_args helper in qa/lib_beat_driver.sh). With CLAWDND_LEAN_BEATS=1, the DM's
+# CONTINUING beats (beats 1..N below — NOT the cold open D1) start a FRESH claude session (a
+# new --session-id, NO transcript replay) seeded with a re-ground directive: the DM re-grounds
+# from the engine's persisted truth via scene_context (state/director/events/companion_arcs +
+# the recent player-facing narration TAIL) instead of from the growing transcript. This is the
+# whole point of the flag — and the duo QA harness USED to ignore it (its DM turn always
+# `--resume`d the full transcript), so the lean path could never be validated through the duo
+# runner that qa/release_gate.sh uses. DEFAULT 0 ⇒ the --resume path is untouched, fully
+# reversible. The recent-narration tail depth mirrors play.sh's CLAWDND_LEAN_TAIL (default 8).
+CLAWDND_LEAN_BEATS="${CLAWDND_LEAN_BEATS:-0}"
+CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
 T="qa/transcripts"; STATE_DIR="$ROOT/qa/state/$RUN"
 mkdir -p "$T" "$STATE_DIR"; rm -rf "$STATE_DIR/campaigns" 2>/dev/null
 
@@ -79,6 +93,11 @@ PY
 
 DSID="$(python3 -c 'import uuid;print(uuid.uuid4())')"
 PSID="$(python3 -c 'import uuid;print(uuid.uuid4())')"
+# The DM's campaign id (for the lean re-ground). Resolved AFTER the cold-open D1 mints the
+# world (start_world writes $STATE_DIR/campaigns/<id>/). Declared here (empty) so the DM
+# turn()'s lean branch can reference it safely under `set -u` even during the cold open —
+# when it's empty, clawdnd_dm_lean_args no-ops and the normal --resume path is used.
+CAMPAIGN_ID=""
 DM_BRIEF="$(cat qa/play_dm_duo.txt)"; PLAYER_BRIEF="$(cat "$PLAYER_PROMPT_FILE")"
 COMBINED="$T/$RUN.jsonl"; : > "$COMBINED"
 # A clean two-sided conversation log (the player agent's turns AND the DM's), so the
@@ -90,11 +109,24 @@ echo "[duo] run=$RUN world=$WORLD beats=$BEATS dm=$DSID player=$PSID"
 
 # $1=role(player|dm) $2=session-id $3=first?(1/0) $4=message ; echoes the agent's reply text
 turn() {
-  local role="$1" sid="$2" first="$3" msg="$4" out resume=()
+  local role="$1" sid="$2" first="$3" msg="$4" out resume=() extra=()
   [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
   if [ "$role" = "dm" ]; then
+    # LEAN beats (CLAWDND_LEAN_BEATS=1): a continuing DM beat starts a FRESH session + a
+    # re-ground directive instead of --resume-ing the full transcript — the SAME implementation
+    # scripts/play.sh uses, via the shared clawdnd_dm_lean_args helper (qa/lib_beat_driver.sh),
+    # so the two harnesses can't drift. CAMPAIGN_ID is resolved after the opening beat (it's
+    # empty during the cold open D1, so lean correctly no-ops there); the helper ALSO only fires
+    # on a continuing beat (first=0) and no-ops on the cold open (first!=0). When lean doesn't
+    # fire (flag off / cold open / unknown id) the helper leaves both arrays empty and we keep
+    # the --resume/--session-id behavior set above unchanged.
+    clawdnd_dm_lean_args "$first" "${CAMPAIGN_ID:-}" "$CLAWDND_LEAN_TAIL"
+    if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
+      resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
+      extra=("${CLAWDND_DM_LEAN_EXTRA[@]}")
+    fi
     out="$T/$RUN.dm.$(date +%s%N).jsonl"
-    claude -p "$msg" "${resume[@]}" --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+    claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
       --model "$CLAWDND_DM_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
       --output-format stream-json --verbose > "$out" 2>> "$T/$RUN.dm.err"
     cat "$out" >> "$COMBINED"
@@ -164,6 +196,27 @@ DMSG="$(clawdnd_dm_narration_or_fallback "$DMSG" "$STATE_DIR")"
 echo "[duo] DM opened: ${DMSG:0:120}…"
 [ -z "$DMSG" ] && { echo "[duo] DM produced no opening — aborting (see $COMBINED)" >&2; exit 1; }
 chatlog dm "$DMSG"
+
+# Resolve the campaign id the cold open just minted (for the lean re-ground; harmless when
+# CLAWDND_LEAN_BEATS=0). D1's start_world wrote the snapshot to
+# $STATE_DIR/campaigns/<id>/snapshot.json — read the id back from that dir. Mirrors
+# scripts/play.sh:347-363. The run wipes $STATE_DIR/campaigns at setup, so there is exactly
+# one campaign here; prefer the largest non-empty snapshot's parent (via the shared helper,
+# robust against a lock-only orphan dir), falling back to the sole campaign subdir. Empty ⇒
+# the DM turn's lean branch no-ops and the normal --resume path is used.
+CAMPAIGN_SNAP="$(clawdnd_snapshot_path "$STATE_DIR")"
+if [ -n "$CAMPAIGN_SNAP" ]; then
+  CAMPAIGN_ID="$(basename "$(dirname "$CAMPAIGN_SNAP")")"
+elif [ -d "$STATE_DIR/campaigns" ]; then
+  CAMPAIGN_ID="$(find "$STATE_DIR/campaigns" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | head -n1)"
+fi
+if [ "$CLAWDND_LEAN_BEATS" = "1" ]; then
+  if [ -n "$CAMPAIGN_ID" ]; then
+    echo "[duo] lean-beats ON — beats 2+ re-ground via scene_context (campaign=$CAMPAIGN_ID), no transcript replay"
+  else
+    echo "[duo] lean-beats ON but campaign id not found under $STATE_DIR/campaigns — beats use the normal resume path" >&2
+  fi
+fi
 
 # Alternate player <-> DM for BEATS rounds. Each beat is now BEAT-AWARE (decision §A):
 # read the clock + location at the START of the beat, pick the ONE moment-specific runbook

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -217,16 +217,15 @@ fi
 # Echoes the DM's final text.
 dm_turn() {
   local first="$1" msg="$2" campaign_id="${3:-}" out resume=() extra=() rc
-  if [ "$first" != "0" ] && [ "$CLAWDND_LEAN_BEATS" = "1" ] && [ -n "$campaign_id" ]; then
-    # LEAN beat: fresh session, no transcript replay. Re-ground from persisted truth.
-    resume=(--session-id "$(uuidgen 2>/dev/null || python3 -c 'import uuid;print(uuid.uuid4())')")
-    extra=(--append-system-prompt "LEAN RE-GROUND (this turn has NO prior conversation transcript — by design, to keep your turn fast). You are mid-campaign, NOT starting over. Your FIRST action this turn MUST be clawdnd-engine scene_context(campaign_id=\"$campaign_id\", recent_narration=$CLAWDND_LEAN_TAIL). That one call returns the campaign's CANON, and it is your whole memory for this beat — HONOR all of it as canon YOU already authored:
-  • durable — the standing threads that persist across the campaign: open_quests (each with its still-open objectives = what the party still OWES), npc_relationships (every NPC the party has MET, with their attitude_value + attitude + relationship tags), companions (each companion's standing bond — attitude_value, has_arc, has_betrayal_agenda), factions (reputation + standing gauges), and the set flags.
-  • director — the top structural debts the campaign owes right now (advisory; pay the top one as fiction, never recite it).
-  • events / companion_arcs — any decisional that fired this beat, and any bond that just turned or betrayal_warning to foreshadow.
-  • recent_narration — the last $CLAWDND_LEAN_TAIL player-facing beats' prose (the immediate story-so-far).
-  • state — the volatile current scene, party vitals, day/time, active quests, combat, pacing_mode, seed_params.
-Do NOT contradict any of it, re-introduce an already-met NPC, reset the clock, or forget a prior choice. CRUCIAL — LOSSLESS RULE: this compact bundle is the always-pinned SPINE, not the whole world. For ANYTHING the moment reaches back to that is NOT in this bundle (a fact, NPC, place, event, or lore detail from earlier), you MUST retrieve it BEFORE you narrate — the entire world/lore/history is searchable on disk: call recall(campaign_id=\"$campaign_id\", query=\"…\") for past events/decisions/facts, lookup_lore(campaign_id=\"$campaign_id\", query=\"…\") for world/setting lore, or recall_npc(campaign_id=\"$campaign_id\", npc_id=\"…\") before voicing a returning NPC. NEVER guess and NEVER invent a detail that contradicts established canon — retrieve first. (You may also pass recall_query=\"…\" to scene_context to fold a recall into the same first call.) Then resolve the move and narrate, seamlessly continuing the established story.")
+  # The lean-beat path (fresh session + re-ground directive) is the ONE shared implementation
+  # in qa/lib_beat_driver.sh — qa/run_duo.sh drives the SAME helper, so the two harnesses can't
+  # drift. It populates CLAWDND_DM_LEAN_{SESSION,EXTRA} when this is a continuing beat AND
+  # CLAWDND_LEAN_BEATS=1 AND campaign_id is known; otherwise both stay empty and we use the
+  # normal resume path below (byte-identical to the flag-off behavior).
+  clawdnd_dm_lean_args "$first" "$campaign_id" "$CLAWDND_LEAN_TAIL"
+  if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
+    resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
+    extra=("${CLAWDND_DM_LEAN_EXTRA[@]}")
   elif [ "$first" = "0" ]; then
     resume=(--resume "$DSID")
   else
@@ -244,9 +243,11 @@ Do NOT contradict any of it, re-introduce an already-met NPC, reset the clock, o
     # timeout(1) exits 124 on the deadline; any nonzero gets ONE retry. A retried lean beat
     # mints a NEW fresh session id (never replay a half-written transcript).
     echo "[play] DM turn rc=$rc (timeout=${CLAWDND_BEAT_TIMEOUT}s) — retrying once" >&2
-    if [ "$first" != "0" ] && [ "$CLAWDND_LEAN_BEATS" = "1" ] && [ -n "$campaign_id" ]; then
-      resume=(--session-id "$(uuidgen 2>/dev/null || python3 -c 'import uuid;print(uuid.uuid4())')")
-    fi
+    # A retried lean beat mints a NEW fresh session id (never replay a half-written transcript);
+    # re-call the shared helper so the re-mint stays in lock-step with the lean path above. The
+    # re-ground directive ($extra) is unchanged, so we only refresh the session id here.
+    clawdnd_dm_lean_args "$first" "$campaign_id" "$CLAWDND_LEAN_TAIL"
+    [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ] && resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
     out="$DM_LOG.$(date +%s%N).jsonl"
     _dm_invoke; rc=$?
     [ "$rc" -ne 0 ] && echo "[play] DM turn retry also rc=$rc — relying on engine-logged narration" >&2


### PR DESCRIPTION
## Problem

The duo QA harness **`qa/run_duo.sh` IGNORED `CLAWDND_LEAN_BEATS`**, so the lean compact-context path could not be validated through it. Its DM turn always `--resume`d the full growing transcript regardless of the flag. Only `scripts/play.sh` had a lean branch.

This is load-bearing because **`qa/release_gate.sh --lean` exports `CLAWDND_LEAN_BEATS=1` and then runs `qa/run_duo.sh`** (release_gate.sh:179 + :236). So the "lean" measured runs through the duo runner were not actually exercising lean — e.g. the `leanval` row in `qa/scores_ledger.md` claims a "61-69% context drop" via `engine-duo`, which the duo runner could not have produced before this fix.

## Fix

Factored the lean DM-turn path into **one shared helper** — `clawdnd_dm_lean_args` in `qa/lib_beat_driver.sh` — and call it from **both** `play.sh` and `run_duo.sh`, so the two harnesses share ONE implementation and can't drift again (the file's stated intent). The helper:
- decides fresh-session vs. resume, and
- emits the `LEAN RE-GROUND` `--append-system-prompt` directive (verbatim the prose that previously lived inline in play.sh: first action MUST be `scene_context(campaign_id=…, recent_narration=$CLAWDND_LEAN_TAIL)`; honor durable + recent_narration as canon; retrieve via `recall`/`lookup_lore`/`recall_npc` for anything beyond the bundle).

bash 3.2 (the macOS system bash both harnesses run under) has no namerefs, so the helper returns via two globals: `CLAWDND_DM_LEAN_SESSION` / `CLAWDND_DM_LEAN_EXTRA`.

**`run_duo.sh`** now:
1. resolves `CAMPAIGN_ID` after the cold open (reads it back from `$STATE_DIR/campaigns/<id>/`, mirroring play.sh:347-363);
2. on a **continuing beat** with the flag on, starts a fresh `--session-id` (no `--resume`) + the re-ground directive. The cold open (D1) stays full;
3. defaults `CLAWDND_LEAN_BEATS=0` and `CLAWDND_LEAN_TAIL=8` — with the flag off the `--resume` path is byte-identical to today.

## Also fixes a latent bug in play.sh's lean (it was dead code)

play.sh gated lean on `first != 0`, but **`first=0` is the continuing beat** (`first=1` is the cold open, in both harnesses). Combined with `campaign_id` only being known on continuing beats, **play.sh's lean branch never actually fired.** The shared helper uses the correct `first=0` gate, restoring the documented intent (lean on beats 2+, full cold open) in BOTH harnesses. This is the only behavior change to play.sh; the flag-OFF path stays byte-identical.

## Verification (cheap, no live run)

- `bash -n` clean on `qa/lib_beat_driver.sh`, `qa/run_duo.sh`, `scripts/play.sh`, and the proof.
- **`qa/dryrun_lean_proof.sh`** (gateway-free, no model): sources the real lib and reproduces run_duo's DM-branch argv assembly with a stub `claude` that prints argv. 14/14 assertions pass:
  - **lean ON + continuing beat** → fresh `--session-id <uuid>` (not `$DSID`) + `--append-system-prompt` "LEAN RE-GROUND" naming `scene_context(campaign_id=…, recent_narration=8)`, and **NO `--resume`**;
  - **lean ON + cold open** → normal `--session-id $DSID`, no lean directive;
  - **lean OFF + continuing beat** → `--resume $DSID`, no lean (unchanged).
- `qa/test_release_gate_static.py` passes (the static test that reads `play.sh`/`release_gate.sh` text).

**Not done:** no live duo run (model + budget). The proof verifies the exact `claude` argv the duo DM turn now builds; it does not exercise the model end-to-end. Wire contracts / scoring / the player agent are untouched.