### PR TITLE
engine: alias intuitive DM tool arg names + social_check companion targets — stop spurious release_gate RED

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -5885,9 +5885,13 @@ def set_pacing(campaign_id: str, mode: str) -> dict:
 
 
 @mcp.tool()
-def remember(campaign_id: str, character_id: str, fact: str) -> dict:
+def remember(campaign_id: str, character_id: str, fact: str = "", text: str = "") -> dict:
     """Append a fact to a character's (usually an NPC's) persistent memory, so it
-    is recalled in later sessions."""
+    is recalled in later sessions. Pass the fact as ``fact`` (canonical) or ``text``
+    (alias) — they are equivalent; ``fact`` wins if both are given."""
+    fact = fact if fact else text  # `text` is an accepted alias for the canonical `fact`
+    if not fact:
+        raise ValueError("remember needs a fact (pass `fact` or its alias `text`)")
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _char(c, character_id)
@@ -5939,15 +5943,21 @@ _ON_FAILURE_DIRECTIVE = {
 @mcp.tool()
 def social_check(campaign_id: str, actor_id: str, npc_id: str, skill: str, dc: int,
                  target_name: str = "") -> dict:
-    """An actor's skill check against an NPC, with read-vs-influence semantics.
+    """An actor's skill check against a tracked NPC, monster, or COMPANION, with
+    read-vs-influence semantics.
+
+    The target (``npc_id``) may be an NPC, a monster, or a COMPANION — a party member is
+    a legitimate social target (persuade/intimidate/read a companion); it moves the SAME
+    attitude/approval track an NPC uses (the gauge companion arcs evaluate). Only a PLAYER
+    character cannot be the target.
 
     INFLUENCE skills (persuasion / deception / intimidation / …) try to move the
-    NPC: on success the attitude improves one step on the track (hostile -> wary ->
+    target: on success the attitude improves one step on the track (hostile -> wary ->
     indifferent -> friendly -> helpful), on failure it worsens one step.
 
-    READ skills (insight / perception / investigation) only PERCEIVE the NPC and
+    READ skills (insight / perception / investigation) only PERCEIVE the target and
     NEVER change its attitude — reading or misreading someone is observer clarity,
-    not influence. A read returns a `read` block (an accurate sense of the NPC's
+    not influence. A read returns a `read` block (an accurate sense of the target's
     stance on success; a deliberately uncertain, almost-grasped impression on a
     miss) for the DM to narrate — never a flat attitude penalty for a failed read.
 
@@ -5993,8 +6003,12 @@ def social_check(campaign_id: str, actor_id: str, npc_id: str, skill: str, dc: i
         if actor_id == npc_id:
             raise ValueError("actor and npc must be different characters")
         the_npc = _char(c, npc_id)
-        if the_npc.kind not in ("npc", "monster"):
-            raise ValueError("social_check target must be an NPC or monster")
+        # A companion IS a valid social target: persuading/intimidating/reading a party
+        # member moves the SAME attitude/attitude_value track an NPC uses (it's the approval
+        # gauge companion arcs already evaluate), so the influence/read logic below applies
+        # unchanged. Only a PLAYER (the actor's own party-of-one PCs) is not a social target.
+        if the_npc.kind not in ("npc", "monster", "companion"):
+            raise ValueError("social_check target must be an NPC, monster, or companion")
         r = dice_mod.roll(f"1d20+{actor.skill_bonus(sk)}")
         success = r.total >= dc
         old = the_npc.attitude
@@ -6056,8 +6070,9 @@ def social_check(campaign_id: str, actor_id: str, npc_id: str, skill: str, dc: i
 
 
 @mcp.tool()
-def skill_check(campaign_id: str, character_id: str, skill: str, dc: int = 0,
-                advantage: bool = False, disadvantage: bool = False) -> dict:
+def skill_check(campaign_id: str, character_id: str, skill: str = "", dc: int = 0,
+                advantage: bool = False, disadvantage: bool = False,
+                ability: str = "", skill_name: str = "", check: str = "") -> dict:
     """Roll a skill check for a character with the CORRECT modifier derived from their sheet
     (ability modifier + proficiency if proficient, doubled where they have expertise) — so you
     NEVER hand-compute a bonus, the most common mechanical error. Use this for any non-social
@@ -6065,7 +6080,13 @@ def skill_check(campaign_id: str, character_id: str, skill: str, dc: int = 0,
     the roll (``dc=0`` -> roll only, no pass/fail). For a check that targets an NPC's attitude
     (persuade / intimidate / read someone), use ``social_check`` instead. 5e RAW: a skill check
     does NOT auto-succeed on a natural 20 — success is total vs DC; the natural is reported so you
-    can flavor a 20/1. Read-only (a check is a roll, not a state change)."""
+    can flavor a 20/1. Read-only (a check is a roll, not a state change).
+
+    Name the skill via ``skill`` (canonical) or any of the aliases ``ability`` / ``skill_name`` /
+    ``check`` — they are equivalent; the canonical ``skill`` wins if more than one is given."""
+    skill = skill or ability or skill_name or check  # accept intuitive aliases; `skill` is canonical
+    if not skill:
+        raise ValueError("skill_check needs a skill (pass `skill` or an alias: `ability`/`skill_name`/`check`)")
     sk = skill.strip().lower().replace(" ", "_")
     if sk not in SKILL_ABILITIES:
         raise ValueError(f"unknown skill {skill!r}")
@@ -6968,13 +6989,22 @@ def check_companion_arc(campaign_id: str, companion_id: str = "") -> dict:
 
 
 @mcp.tool()
-def set_companion_arc(campaign_id: str, companion_id: str, arc: dict) -> dict:
+def set_companion_arc(campaign_id: str, companion_id: str = "", arc: dict = None,
+                      companion: str = "", character_id: str = "") -> dict:
     """Attach (or REPLACE) a companion's relationship arc + sealed agenda, so the DM —
     or the ending-seed loader — can author what a bond grows into and what a saboteur is
     planning. `arc` is `{arc_gates: [{kind, threshold, note?}], agenda: {trigger, value?,
     note?}}` where gate `kind` is personal_quest|romance|loyalty|betrayal and agenda
     `trigger` is attitude_below|day_reached|party_vulnerable|prize_seized. The companion
-    must exist and be a companion. `check_companion_arc` then evaluates it each beat."""
+    must exist and be a companion. `check_companion_arc` then evaluates it each beat.
+
+    Identify the companion via ``companion_id`` (canonical) or the aliases ``companion`` /
+    ``character_id`` — equivalent; canonical ``companion_id`` wins if more than one is given."""
+    companion_id = companion_id or companion or character_id  # accept intuitive aliases
+    if not companion_id:
+        raise ValueError("set_companion_arc needs a companion id (pass `companion_id` or an alias: `companion`/`character_id`)")
+    if arc is None:
+        raise ValueError("set_companion_arc needs an `arc` object")
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _require_companion(c, companion_id)
@@ -7760,17 +7790,19 @@ def advance_faction_arc(
 @mcp.tool()
 def record_decision(
     campaign_id: str,
-    summary: str,
+    summary: str = "",
     options: Optional[list] = None,
     chosen: str = "",
     rationale: str = "",
     actor_ids: Optional[list] = None,
     sets_flag: str = "",
+    decision: str = "",
 ) -> dict:
     """Record a party decision so the DM and companions can call back to it later
     ('last time we trusted Grett...'). Capture the choice after a deliberation:
-    `summary` (the decision), `options` (what was on the table), `chosen`, why
-    (`rationale`), and who weighed in (`actor_ids`). Returns the decision id.
+    `summary` (the decision; pass it as `summary` (canonical) or `decision` (alias) —
+    equivalent, `summary` wins if both given), `options` (what was on the table),
+    `chosen`, why (`rationale`), and who weighed in (`actor_ids`). Returns the decision id.
 
     `sets_flag` (optional, Quest & Arc engine Layer 2) ties this CHOICE to a CONTENT-
     defined campaign flag it raises — the one-step path for the owner's model ("let the
@@ -7780,6 +7812,9 @@ def record_decision(
     spikes). The flag NAME is yours (e.g. "let_daughter_die", "took_bribe") — never
     engine-coded. Equivalent to a `set_flag` call alongside the record; omit it (or use
     plain `set_flag`) when no agenda is gated on the choice. Returns the flag in `flag`."""
+    summary = summary if summary else decision  # `decision` is an accepted alias for `summary`
+    if not summary:
+        raise ValueError("record_decision needs a summary (pass `summary` or its alias `decision`)")
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         d = Decision(

--- a/servers/engine/tests/test_tool_arg_aliases.py
+++ b/servers/engine/tests/test_tool_arg_aliases.py
@@ -1,0 +1,196 @@
+"""Tool-arg-name robustness: the DM (Opus) calls engine tools with intuitive arg
+names the strict MCP schema used to reject with a "Field required" validation error,
+which flips the release_gate's `no_rejected_tool_calls` FATAL check RED even on an
+otherwise-healthy run.
+
+Each tool now accepts BOTH the canonical name AND an intuitive alias; the canonical
+stays primary (wins if both are given) and behavior is IDENTICAL to using the
+canonical name. social_check additionally treats a COMPANION as a legitimate social
+target (it was a capability gap, not just naming — the guard rejected kind=companion
+and produced WARNs in the run).
+
+These are targeted unit tests (run with `-k alias` / `-k companion_social`), not the
+full suite. They prove: alias == canonical for remember/record_decision/skill_check/
+set_companion_arc, and that social_check succeeds against a companion (influence AND
+read) while STILL rejecting a player.
+"""
+
+import pytest
+
+import server
+from models import CompanionArc
+
+
+@pytest.fixture
+def campaign(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    return server.create_campaign("Alias")["id"]
+
+
+# --- 1. remember: canonical `fact`, alias `text` --------------------------------
+
+def test_remember_text_alias_equals_fact(campaign):
+    npc = server.create_character(campaign, "Brakka", kind="npc")["id"]
+    # canonical
+    out_fact = server.remember(campaign, npc, fact="bought a round")
+    assert "bought a round" in out_fact["memory"]
+    # alias produces the identical effect (and de-dupes, like canonical would)
+    out_text = server.remember(campaign, npc, text="owes the party a favor")
+    assert "owes the party a favor" in out_text["memory"]
+    # same return shape / same character
+    assert set(out_fact) == set(out_text) == {"id", "name", "memory"}
+    assert out_text["id"] == npc
+
+
+def test_remember_canonical_wins_when_both_given(campaign):
+    npc = server.create_character(campaign, "Brakka", kind="npc")["id"]
+    out = server.remember(campaign, npc, fact="canonical fact", text="alias text")
+    assert "canonical fact" in out["memory"]
+    assert "alias text" not in out["memory"]
+
+
+def test_remember_missing_both_raises_clear_error(campaign):
+    npc = server.create_character(campaign, "Brakka", kind="npc")["id"]
+    with pytest.raises(ValueError, match="fact"):
+        server.remember(campaign, npc)
+
+
+# --- 2. record_decision: canonical `summary`, alias `decision` ------------------
+
+def test_record_decision_decision_alias_equals_summary(campaign):
+    out_canon = server.record_decision(campaign, summary="spared the cultist")
+    out_alias = server.record_decision(campaign, decision="spared the cultist")
+    assert out_canon["summary"] == out_alias["summary"] == "spared the cultist"
+    # identical return shape
+    assert set(out_canon) == set(out_alias)
+    # the alias call actually persisted a decision with that summary
+    c = server._require(campaign)
+    assert any(d.summary == "spared the cultist" for d in c.decisions)
+
+
+def test_record_decision_canonical_wins_when_both_given(campaign):
+    out = server.record_decision(campaign, summary="canonical", decision="alias")
+    assert out["summary"] == "canonical"
+
+
+def test_record_decision_missing_both_raises(campaign):
+    with pytest.raises(ValueError, match="summary"):
+        server.record_decision(campaign)
+
+
+# --- 3. skill_check: canonical `skill`, aliases ability/skill_name/check --------
+
+def test_skill_check_skill_aliases_equal_canonical(campaign):
+    pc = server.create_character(
+        campaign, "Scout", kind="player", abilities={"wisdom": 16}
+    )["id"]
+    canon = server.skill_check(campaign, pc, skill="perception", dc=0)
+    for kw in ("ability", "skill_name", "check"):
+        alias = server.skill_check(campaign, pc, **{kw: "perception"}, dc=0)
+        # same resolved skill + same modifier (the load-bearing equality: alias maps
+        # to the exact same sheet-derived bonus, not a hand-computed one)
+        assert alias["skill"] == canon["skill"] == "perception"
+        assert alias["modifier"] == canon["modifier"]
+        assert set(alias) == set(canon)
+
+
+def test_skill_check_canonical_wins_when_both_given(campaign):
+    pc = server.create_character(campaign, "Scout", kind="player")["id"]
+    out = server.skill_check(campaign, pc, skill="perception", ability="athletics")
+    assert out["skill"] == "perception"
+
+
+def test_skill_check_missing_all_names_raises(campaign):
+    pc = server.create_character(campaign, "Scout", kind="player")["id"]
+    with pytest.raises(ValueError, match="skill"):
+        server.skill_check(campaign, pc)
+
+
+# --- 4. set_companion_arc: canonical `companion_id`, aliases companion/character_id
+
+def _arc_dict():
+    return {
+        "arc_gates": [{"kind": "loyalty", "threshold": 50}],
+        "agenda": {"trigger": "day_reached", "value": 99},
+    }
+
+
+def test_set_companion_arc_aliases_equal_canonical(campaign):
+    comp_a = server.create_character(campaign, "Aerie", kind="companion")["id"]
+    comp_b = server.create_character(campaign, "Boo", kind="companion")["id"]
+    comp_c = server.create_character(campaign, "Cael", kind="companion")["id"]
+
+    canon = server.set_companion_arc(campaign, companion_id=comp_a, arc=_arc_dict())
+    via_companion = server.set_companion_arc(campaign, companion=comp_b, arc=_arc_dict())
+    via_charid = server.set_companion_arc(campaign, character_id=comp_c, arc=_arc_dict())
+
+    # identical return shape and identical MEANINGFUL arc content (the gate `id` is
+    # auto-generated per call, so compare the structural fields, not the random id)
+    assert set(canon) == set(via_companion) == set(via_charid)
+
+    def _shape(res):
+        gate = res["arc"]["arc_gates"][0]
+        return (gate["kind"], gate["threshold"], res["arc"]["agenda"]["trigger"],
+                res["arc"]["agenda"]["value"])
+
+    assert _shape(canon) == _shape(via_companion) == _shape(via_charid) == ("loyalty", 50, "day_reached", 99)
+    # the alias calls actually attached the arc to the RIGHT companion
+    assert server._require(campaign).characters[comp_b].arc is not None
+    assert server._require(campaign).characters[comp_c].arc is not None
+    assert via_companion["id"] == comp_b and via_charid["id"] == comp_c
+
+
+def test_set_companion_arc_canonical_wins_when_both_given(campaign):
+    comp = server.create_character(campaign, "Aerie", kind="companion")["id"]
+    other = server.create_character(campaign, "Other", kind="companion")["id"]
+    out = server.set_companion_arc(campaign, companion_id=comp, companion=other, arc=_arc_dict())
+    assert out["id"] == comp  # canonical target won; the alias did not redirect
+
+
+def test_set_companion_arc_missing_id_raises(campaign):
+    with pytest.raises(ValueError, match="companion"):
+        server.set_companion_arc(campaign, arc=_arc_dict())
+
+
+# --- 5. social_check: a COMPANION is a valid social target ----------------------
+
+def test_social_check_succeeds_against_companion_influence(campaign):
+    pc = server.create_character(
+        campaign, "Bard", kind="player", abilities={"charisma": 16}
+    )["id"]
+    comp = server.create_character(campaign, "Jaheira", kind="companion")["id"]
+
+    # influence: persuading a companion moves the SAME attitude/approval track an NPC
+    # uses (the gauge companion arcs evaluate) — no exception, real state change.
+    win = server.social_check(campaign, pc, comp, "persuasion", dc=1)  # always succeeds
+    assert win["success"] is True
+    assert win["kind"] == "influence"
+    assert win["new_attitude_value"] == 15  # +15, like an NPC
+    assert server.get_character(campaign, comp)["attitude_value"] == 15
+
+    loss = server.social_check(campaign, pc, comp, "persuasion", dc=100)  # always fails
+    assert loss["success"] is False
+    assert loss["new_attitude_value"] == 5  # -10 from 15, clamped scale
+    assert "on_failure" in loss  # failed influence still hands the turn back
+
+
+def test_social_check_read_against_companion_does_not_shift_attitude(campaign):
+    pc = server.create_character(
+        campaign, "Watcher", kind="player", abilities={"wisdom": 16}
+    )["id"]
+    comp = server.create_character(campaign, "Minsc", kind="companion")["id"]
+    server.set_attitude(campaign, comp, "friendly")
+
+    ok = server.social_check(campaign, pc, comp, "insight", dc=1)  # clear read
+    assert ok["kind"] == "read" and ok["success"] is True
+    # a read PERCEIVES, never influences — attitude (text + number) untouched
+    assert ok["old_attitude"] == ok["new_attitude"] == "friendly"
+    assert server.get_character(campaign, comp)["attitude_value"] == 0  # read didn't nudge
+
+
+def test_social_check_still_rejects_a_player_target(campaign):
+    # the relaxation only added companions; a PLAYER is still not a social target
+    pc = server.create_character(campaign, "Bard", kind="player")["id"]
+    pc2 = server.create_character(campaign, "Fighter", kind="player")["id"]
+    with pytest.raises(ValueError):
+        server.social_check(campaign, pc, pc2, "persuasion", dc=10)


### PR DESCRIPTION
## Why

The validated lean run is one gate away from a GREEN `release_gate`: it fails the FATAL `no_rejected_tool_calls` check because Opus (the DM) calls engine tools with the arg names it intuitively reaches for, which the strict MCP schema rejects with a **"Field required"** validation error (`assert_behavioral.py` flags any error whose text contains `"validation error"` as FATAL). The DM's intent silently doesn't take effect.

Separately, `social_check` against a `kind=companion` target was **rejected** by the guard (`social_check target must be an NPC or monster`) — a plain `ValueError`, so it landed as the recoverable `engine_guards_hit` **WARN** (the 3 WARNs in the run), not the FATAL. But a companion *is* a legitimate social target, so this is a real capability gap.

## What

Each tool now accepts **both** the canonical name and an intuitive alias. The canonical stays primary (wins if both are passed); the alias just coalesces to it. Because the params are now keyword args on the function, the FastMCP schema exposes both names, so either works from the DM side.

| tool | canonical | alias(es) added |
|---|---|---|
| `remember` | `fact` | `text` |
| `record_decision` | `summary` | `decision` |
| `skill_check` | `skill` | `ability`, `skill_name`, `check` |
| `set_companion_arc` | `companion_id` | `companion`, `character_id` |

> Note: for `skill_check` and `set_companion_arc`, the DM's intuitive names (`skill`, `companion_id`) were **already** the canonical params — those calls were not the source of the "Field required" FATAL (that's `remember`/`record_decision`). The extra aliases are added for robustness per the task, and equality-to-canonical is proven by tests.

**`social_check` now treats a COMPANION as a valid social target.** The guard is relaxed from `("npc", "monster")` to `("npc", "monster", "companion")`. A companion carries the same `attitude` / `attitude_value` fields an NPC does (it's the approval gauge companion arcs already evaluate), so the existing influence/read logic applies **unchanged** — persuade/intimidate moves the track ±, a read perceives without shifting. **Only a PLAYER is still rejected.**

## Invariants

- Behavior is **identical** when canonical names are used — aliases only coalesce.
- **No** return-shape or wire-contract changes.
- Sole-writer invariant (`campaign_lock` + `save_campaign`) untouched.
- When a required value is omitted under *all* accepted names, the tool now raises a **clear `ValueError`** naming the canonical + alias (instead of an opaque schema "Field required").

## Tests

Adds `servers/engine/tests/test_tool_arg_aliases.py` (15 targeted tests): each alias == canonical (same effect, same return shape, canonical-wins-when-both), the missing-value error path, and `social_check` succeeding against a companion (influence **and** read) while still rejecting a player.

**All 15 pass locally** (mcp resolved from uv cache; `Python 3.12`). Targeted regression on the touched tools also green: `test_npc.py` + `test_companion_arc.py` (81) and `test_factions_decisions.py` + `test_beat_roundtrip.py` + `test_qa_fixes.py` + `test_ledger.py` (97) — **0 failures, no contract break**. `python -m py_compile servers/engine/server.py` passes.

Ran **only** the targeted `-k`/per-file tests, not the full suite (host disk policy). Full suite + the lean run will confirm on CI / the VM once billing is restored.

Do not merge yet — owner will `--admin-merge` after review (CI billing-locked).