### PR TITLE
qa/engine: lean default ON + DM effort-tiering (max cold-open / medium routine)

### DIFF
--- a/qa/dryrun_lean_proof.sh
+++ b/qa/dryrun_lean_proof.sh
@@ -1,30 +1,36 @@
 #!/usr/bin/env bash
 # DRY-RUN PROOF (no model call): shows that qa/run_duo.sh's DM turn now honors
-# CLAWDND_LEAN_BEATS via the SHARED clawdnd_dm_lean_args helper. It sources the REAL
-# qa/lib_beat_driver.sh and reproduces run_duo.sh's DM-branch argv assembly VERBATIM,
-# with a stub `claude` that just prints the argv it would have run. We assert that:
-#   (1) lean ON + continuing beat + known campaign  -> fresh --session-id + LEAN RE-GROUND
-#       --append-system-prompt, and NO --resume;
-#   (2) lean ON + cold open (first=1)               -> normal --session-id $DSID, no lean;
-#   (3) lean OFF + continuing beat                  -> --resume $DSID, no lean (unchanged).
+# CLAWDND_LEAN_BEATS AND the DM effort-tier — both via the SHARED helpers in
+# qa/lib_beat_driver.sh (clawdnd_dm_lean_args + clawdnd_dm_effort_arg). It sources the REAL
+# qa/lib_beat_driver.sh and reproduces run_duo.sh's DM-branch AND player-branch argv assembly
+# VERBATIM, with a stub `claude` that just prints the argv it would have run. We assert that:
+#   (1) CLAWDND_LEAN_BEATS now DEFAULTS to 1 (lean is standard — no env set → lean fires);
+#   (2) the COLD-OPEN DM argv includes --effort max;
+#   (3) a ROUTINE/continuing DM argv includes --effort medium;
+#   (4) the PLAYER turn argv has NO --effort;
+#   (5) the flag override still works: CLAWDND_LEAN_BEATS=0 forces the legacy --resume path;
+# plus the original lean-fires/no-fires behavior (fresh --session-id + LEAN RE-GROUND on a
+# continuing beat; normal --session-id on the cold open).
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "$ROOT/qa/lib_beat_driver.sh"
 
-DSID="DSID-fixed-0000"
+DSID="DSID-fixed-0000"; PSID="PSID-fixed-0000"
 CAMPAIGN_ID="camp-abc123"
 CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
-DM_CFG="/tmp/dm.mcp.json"; BUDGET="0.80"; CLAWDND_DM_MODEL="sonnet"
+DM_CFG="/tmp/dm.mcp.json"; PLAYER_CFG="/tmp/player.mcp.json"; BUDGET="0.80"
+CLAWDND_DM_MODEL="sonnet"; CLAWDND_ACTOR_MODEL="sonnet"
 
-# Stub `claude`: print the exact argv (NUL-joined, then shown one-per-line) and return.
+# Stub `claude`: print the exact argv (each arg on its own line in «»), then return.
 claude() {
   printf 'CLAUDE-ARGV-BEGIN\n'
   local a; for a in "$@"; do printf '  «%s»\n' "$a"; done
   printf 'CLAUDE-ARGV-END\n'
 }
 
-# VERBATIM copy of run_duo.sh turn()'s DM branch argv assembly (the code under test).
-dm_turn_argv() {            # $1=first(1/0)  $2=msg
+# VERBATIM copy of run_duo.sh turn()'s DM branch argv assembly (the code under test) —
+# including the shared effort-tier splice. $1=first(1/0)  $2=msg
+dm_turn_argv() {
   local first="$1" msg="$2" sid="$DSID" resume=() extra=()
   [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
   clawdnd_dm_lean_args "$first" "${CAMPAIGN_ID:-}" "$CLAWDND_LEAN_TAIL"
@@ -32,49 +38,73 @@ dm_turn_argv() {            # $1=first(1/0)  $2=msg
     resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
     extra=("${CLAWDND_DM_LEAN_EXTRA[@]}")
   fi
+  clawdnd_dm_effort_arg "$first"
   claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
-    --model "$CLAWDND_DM_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+    --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
     --output-format stream-json --verbose
+}
+
+# VERBATIM copy of run_duo.sh turn()'s PLAYER branch argv assembly — proves the player facade
+# gets NO --effort (and no lean/effort helper is ever called for it). $1=first(1/0)  $2=msg
+player_turn_argv() {
+  local first="$1" msg="$2" sid="$PSID" resume=()
+  [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
+  claude -p "$msg" "${resume[@]}" --mcp-config "$PLAYER_CFG" --strict-mcp-config \
+    --model "$CLAWDND_ACTOR_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+    --output-format json
 }
 
 hr() { printf '\n========== %s ==========\n' "$1"; }
 
-hr "SCENARIO 1 — CLAWDND_LEAN_BEATS=1, continuing beat (first=0), campaign known"
-out1="$(CLAWDND_LEAN_BEATS=1 dm_turn_argv 0 'The player does: opens the door.')"
+hr "SCENARIO 1 — DEFAULT (no CLAWDND_LEAN_BEATS set), continuing beat (first=0) -> lean fires + effort medium"
+out1="$(unset CLAWDND_LEAN_BEATS; dm_turn_argv 0 'The player does: opens the door.')"
 printf '%s\n' "$out1"
 
-hr "SCENARIO 2 — CLAWDND_LEAN_BEATS=1, COLD OPEN (first=1) -> lean must NOT fire"
-out2="$(CLAWDND_LEAN_BEATS=1 dm_turn_argv 1 'Begin the session.')"
+hr "SCENARIO 2 — DEFAULT (no CLAWDND_LEAN_BEATS set), COLD OPEN (first=1) -> no lean + effort max"
+out2="$(unset CLAWDND_LEAN_BEATS; dm_turn_argv 1 'Begin the session.')"
 printf '%s\n' "$out2"
 
-hr "SCENARIO 3 — CLAWDND_LEAN_BEATS=0, continuing beat (first=0) -> UNCHANGED"
+hr "SCENARIO 3 — OVERRIDE CLAWDND_LEAN_BEATS=0, continuing beat (first=0) -> legacy --resume (lean off), effort still medium"
 out3="$(CLAWDND_LEAN_BEATS=0 dm_turn_argv 0 'The player does: opens the door.')"
 printf '%s\n' "$out3"
+
+hr "SCENARIO 4 — PLAYER turn (continuing beat) -> NO --effort, NO lean"
+out4="$(unset CLAWDND_LEAN_BEATS; player_turn_argv 0 'I draw my sword and advance.')"
+printf '%s\n' "$out4"
 
 # ---- Assertions -------------------------------------------------------------------
 hr "ASSERTIONS"
 fail=0
 chk() { if eval "$2"; then echo "PASS: $1"; else echo "FAIL: $1"; fail=1; fi; }
 
-# S1: lean ON, continuing -> fresh --session-id (a UUID, NOT $DSID), LEAN RE-GROUND present, NO --resume.
-chk "S1 has --session-id"                       'printf "%s" "$out1" | grep -q -- "--session-id"'
-chk "S1 fresh session id is a UUID (not \$DSID)" 'printf "%s" "$out1" | grep -Eq "«[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}»"'
-chk "S1 NOT $DSID"                               '! printf "%s" "$out1" | grep -q -- "«DSID-fixed-0000»"'
-chk "S1 has --append-system-prompt"             'printf "%s" "$out1" | grep -q -- "--append-system-prompt"'
-chk "S1 directive says LEAN RE-GROUND"          'printf "%s" "$out1" | grep -q "LEAN RE-GROUND"'
-chk "S1 directive names scene_context+campaign" 'printf "%s" "$out1" | grep -q "scene_context(campaign_id=\\\"camp-abc123\\\""'
-chk "S1 directive honors recent_narration tail" 'printf "%s" "$out1" | grep -q "recent_narration=8"'
-chk "S1 has NO --resume"                         '! printf "%s" "$out1" | grep -q -- "--resume"'
+# (1) DEFAULT lean=1: S1 (no env) on a continuing beat must FIRE lean -> fresh UUID session,
+#     LEAN RE-GROUND directive, NO --resume. This proves the default flipped to 1.
+chk "S1 DEFAULT fires lean: has --session-id"        'printf "%s" "$out1" | grep -q -- "--session-id"'
+chk "S1 DEFAULT lean: fresh UUID (not \$DSID)"        'printf "%s" "$out1" | grep -Eq "«[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}»"'
+chk "S1 DEFAULT lean: NOT \$DSID"                     '! printf "%s" "$out1" | grep -q -- "«DSID-fixed-0000»"'
+chk "S1 DEFAULT lean: has --append-system-prompt"    'printf "%s" "$out1" | grep -q -- "--append-system-prompt"'
+chk "S1 DEFAULT lean: directive says LEAN RE-GROUND" 'printf "%s" "$out1" | grep -q "LEAN RE-GROUND"'
+chk "S1 DEFAULT lean: NO --resume"                   '! printf "%s" "$out1" | grep -q -- "--resume"'
+# (3) routine effort = medium (continuing beat).
+chk "S1 routine DM argv has --effort medium"         'printf "%s" "$out1" | grep -A1 -- "«--effort»" | grep -q -- "«medium»"'
 
-# S2: lean ON but cold open -> normal --session-id $DSID, no lean.
-chk "S2 uses --session-id \$DSID (cold open)"   'printf "%s" "$out2" | grep -q -- "«DSID-fixed-0000»"'
-chk "S2 has NO --append-system-prompt"           '! printf "%s" "$out2" | grep -q -- "--append-system-prompt"'
-chk "S2 has NO --resume"                          '! printf "%s" "$out2" | grep -q -- "--resume"'
+# (2) cold-open effort = max; cold open does NOT fire lean (normal --session-id \$DSID, no lean).
+chk "S2 cold-open DM argv has --effort max"          'printf "%s" "$out2" | grep -A1 -- "«--effort»" | grep -q -- "«max»"'
+chk "S2 cold open uses --session-id \$DSID"          'printf "%s" "$out2" | grep -q -- "«DSID-fixed-0000»"'
+chk "S2 cold open has NO --append-system-prompt"     '! printf "%s" "$out2" | grep -q -- "--append-system-prompt"'
+chk "S2 cold open has NO --resume"                   '! printf "%s" "$out2" | grep -q -- "--resume"'
+chk "S2 cold open does NOT use --effort medium"      '! { printf "%s" "$out2" | grep -A1 -- "«--effort»" | grep -q -- "«medium»"; }'
 
-# S3: lean OFF, continuing -> --resume $DSID, no lean (byte-identical to today).
-chk "S3 uses --resume \$DSID"                    'printf "%s" "$out3" | grep -q -- "--resume" && printf "%s" "$out3" | grep -q -- "«DSID-fixed-0000»"'
-chk "S3 has NO --append-system-prompt"           '! printf "%s" "$out3" | grep -q -- "--append-system-prompt"'
-chk "S3 has NO fresh --session-id"               '! printf "%s" "$out3" | grep -q -- "--session-id"'
+# (5) override LEAN=0 forces the legacy --resume path (no lean) — still fully reversible per-run.
+chk "S3 override LEAN=0 uses --resume \$DSID"         'printf "%s" "$out3" | grep -q -- "--resume" && printf "%s" "$out3" | grep -q -- "«DSID-fixed-0000»"'
+chk "S3 override LEAN=0 has NO --append-system-prompt" '! printf "%s" "$out3" | grep -q -- "--append-system-prompt"'
+chk "S3 override LEAN=0 has NO fresh --session-id"    '! printf "%s" "$out3" | grep -q -- "--session-id"'
+# effort tier is independent of lean: a continuing beat is still medium even with lean forced off.
+chk "S3 routine DM argv still --effort medium"        'printf "%s" "$out3" | grep -A1 -- "«--effort»" | grep -q -- "«medium»"'
+
+# (4) the PLAYER turn never gets --effort (effort applies ONLY to the DM turn).
+chk "S4 player turn has NO --effort"                  '! printf "%s" "$out4" | grep -q -- "--effort"'
+chk "S4 player turn has NO --append-system-prompt"    '! printf "%s" "$out4" | grep -q -- "--append-system-prompt"'
 
 hr "RESULT"
 [ "$fail" = 0 ] && echo "ALL ASSERTIONS PASSED" || echo "SOME ASSERTIONS FAILED"

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -130,9 +130,11 @@ clawdnd_dm_lean_args() {
   local first="$1" campaign_id="${2:-}" lean_tail="${3:-8}"
   CLAWDND_DM_LEAN_SESSION=()
   CLAWDND_DM_LEAN_EXTRA=()
-  # The cold open (first != 0), flag off, or no campaign to re-ground against → no-op (caller's
-  # existing --resume/--session-id path is used unchanged). Lean fires on CONTINUING beats only.
-  if [ "$first" != "0" ] || [ "${CLAWDND_LEAN_BEATS:-0}" != "1" ] || [ -z "$campaign_id" ]; then
+  # The cold open (first != 0), flag explicitly off (CLAWDND_LEAN_BEATS=0), or no campaign to
+  # re-ground against → no-op (caller's existing --resume/--session-id path is used unchanged).
+  # Lean fires on CONTINUING beats only. DEFAULT is now lean-ON (:-1): lean is standard, and
+  # CLAWDND_LEAN_BEATS=0 is the explicit opt-out (matches the default flipped in both harnesses).
+  if [ "$first" != "0" ] || [ "${CLAWDND_LEAN_BEATS:-1}" != "1" ] || [ -z "$campaign_id" ]; then
     return 0
   fi
   # LEAN beat: fresh session, no transcript replay. Re-ground from persisted truth.
@@ -144,6 +146,40 @@ clawdnd_dm_lean_args() {
   • recent_narration — the last $lean_tail player-facing beats' prose (the immediate story-so-far).
   • state — the volatile current scene, party vitals, day/time, active quests, combat, pacing_mode, seed_params.
 Do NOT contradict any of it, re-introduce an already-met NPC, reset the clock, or forget a prior choice. CRUCIAL — LOSSLESS RULE: this compact bundle is the always-pinned SPINE, not the whole world. For ANYTHING the moment reaches back to that is NOT in this bundle (a fact, NPC, place, event, or lore detail from earlier), you MUST retrieve it BEFORE you narrate — the entire world/lore/history is searchable on disk: call recall(campaign_id=\"$campaign_id\", query=\"…\") for past events/decisions/facts, lookup_lore(campaign_id=\"$campaign_id\", query=\"…\") for world/setting lore, or recall_npc(campaign_id=\"$campaign_id\", npc_id=\"…\") before voicing a returning NPC. NEVER guess and NEVER invent a detail that contradicts established canon — retrieve first. (You may also pass recall_query=\"…\" to scene_context to fold a recall into the same first call.) Then resolve the move and narrate, seamlessly continuing the established story.")
+}
+
+# DM-TURN EFFORT TIER (the ONE shared implementation of the cold-open-vs-routine effort split).
+#
+# Both play loops drive the DM through `claude -p --model …`. Opus (and the other thinking
+# models) default to effort=high — i.e. maximum thinking budget every turn — which is the single
+# biggest per-turn LATENCY cost. But the two kinds of beat want different budgets:
+#   • the COLD OPEN (first != 0) is the one-time, do-it-right world-build — generate the world,
+#     scene, PC, opening NPCs — so it earns the richest thinking: --effort max.
+#   • CONTINUING / routine beats (first = 0) are the BULK of a session and mostly resolve one
+#     move against already-established canon — so a medium thinking budget keeps quality while
+#     cutting the thinking-latency that dominates each turn: --effort medium.
+# This is keyed off the SAME `first` signal the lean branch uses (clawdnd_dm_lean_args), so the
+# cold open is always full+max and the long tail is lean+medium — the two levers stay in lock-step.
+#
+# Levels are env-overridable (e.g. bump the routine tier back to high for a quality A/B, or drop
+# the cold open to high to save cost) via the same WORLDOS_/CLAWDND_ resolution as everything else:
+#   WORLDOS_DM_EFFORT_COLDOPEN (default max)    — the cold open's effort
+#   WORLDOS_DM_EFFORT_ROUTINE  (default medium) — every continuing beat's effort
+# Valid claude levels: low|medium|high|xhigh|max (a bad override is passed through verbatim and the
+# CLI validates it). Applies ONLY to the DM turn — the player/actor facade never gets --effort.
+#
+# Like the lean helper, bash 3.2 has no namerefs, so this POPULATES a well-known GLOBAL array the
+# caller splices into its claude -p invocation (never empty — every DM turn gets an explicit tier):
+#   CLAWDND_DM_EFFORT — (--effort max) on the cold open, (--effort medium) on continuing beats.
+# $1 = first?(1/0)
+clawdnd_dm_effort_arg() {
+  local first="$1" level
+  if [ "$first" != "0" ]; then
+    level="$(worldos_env DM_EFFORT_COLDOPEN max)"
+  else
+    level="$(worldos_env DM_EFFORT_ROUTINE medium)"
+  fi
+  CLAWDND_DM_EFFORT=(--effort "$level")
 }
 
 # Read the run's progression facts from the snapshot in ONE python pass. Echoes a single

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -42,9 +42,11 @@ CLAWDND_ACTOR_MODEL="$(worldos_env ACTOR_MODEL sonnet)"
 # the recent player-facing narration TAIL) instead of from the growing transcript. This is the
 # whole point of the flag — and the duo QA harness USED to ignore it (its DM turn always
 # `--resume`d the full transcript), so the lean path could never be validated through the duo
-# runner that qa/release_gate.sh uses. DEFAULT 0 ⇒ the --resume path is untouched, fully
-# reversible. The recent-narration tail depth mirrors play.sh's CLAWDND_LEAN_TAIL (default 8).
-CLAWDND_LEAN_BEATS="${CLAWDND_LEAN_BEATS:-0}"
+# runner that qa/release_gate.sh uses. DEFAULT 1 (lean is now STANDARD — validated: ~10–27×
+# context drop, story quality held at 4.4); set CLAWDND_LEAN_BEATS=0 to force the legacy
+# --resume path (byte-identical to pre-lean). The recent-narration tail depth mirrors
+# play.sh's CLAWDND_LEAN_TAIL (default 8).
+CLAWDND_LEAN_BEATS="${CLAWDND_LEAN_BEATS:-1}"
 CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
 T="qa/transcripts"; STATE_DIR="$ROOT/qa/state/$RUN"
 mkdir -p "$T" "$STATE_DIR"; rm -rf "$STATE_DIR/campaigns" 2>/dev/null
@@ -125,9 +127,14 @@ turn() {
       resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
       extra=("${CLAWDND_DM_LEAN_EXTRA[@]}")
     fi
+    # EFFORT TIER (shared helper, qa/lib_beat_driver.sh) — SAME implementation play.sh uses, so the
+    # two harnesses can't drift: --effort max on the cold open (one-time world-build), --effort
+    # medium on continuing beats (the bulk — cuts thinking-latency). Keyed off the SAME `first`
+    # signal as lean. DM turn ONLY — the player branch below never gets --effort.
+    clawdnd_dm_effort_arg "$first"
     out="$T/$RUN.dm.$(date +%s%N).jsonl"
     claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
-      --model "$CLAWDND_DM_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+      --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
       --output-format stream-json --verbose > "$out" 2>> "$T/$RUN.dm.err"
     cat "$out" >> "$COMBINED"
     jq -rs 'map(select(.type=="result"))[-1].result // ""' "$out" 2>/dev/null

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -62,10 +62,11 @@ DM_TURNS=0
 # re-grounds from the engine's persisted truth via scene_context (which already bundles
 # state/director/events/companion_arcs + the recent player-facing narration TAIL) rather
 # than from the fat transcript. Beat 1 (the cold open) is ALWAYS full — it establishes and
-# persists the world/scene/PC. DEFAULT 0 ⇒ the resume path below is untouched, so this is
-# fully reversible and a regression can't ship by accident. A/B harness:
+# persists the world/scene/PC. DEFAULT 1 (lean is now STANDARD — validated: ~10–27× context
+# drop, story quality held at 4.4). Set CLAWDND_LEAN_BEATS=0 to force the legacy full-resume
+# path (byte-identical to the pre-lean behavior) — still fully reversible per-run. A/B harness:
 # qa/lib/lean_beats_check.sh.
-CLAWDND_LEAN_BEATS="${CLAWDND_LEAN_BEATS:-0}"
+CLAWDND_LEAN_BEATS="${CLAWDND_LEAN_BEATS:-1}"
 # Per-beat backend timeout (seconds) + ONE retry, so a wedged DM turn recovers instead of
 # hanging the session. Applies in BOTH modes (it only wraps the existing claude -p call).
 CLAWDND_BEAT_TIMEOUT="${CLAWDND_BEAT_TIMEOUT:-200}"
@@ -231,11 +232,15 @@ dm_turn() {
   else
     resume=(--session-id "$DSID")
   fi
+  # EFFORT TIER (shared helper, qa/lib_beat_driver.sh): --effort max on the cold open (rich,
+  # one-time world-build), --effort medium on continuing beats (the bulk — cuts thinking-latency).
+  # Keyed off the SAME `first` signal as lean. DM turn ONLY (the player facade never gets --effort).
+  clawdnd_dm_effort_arg "$first"
   out="$DM_LOG.$(date +%s%N).jsonl"
   _dm_invoke() {
     timeout "$CLAWDND_BEAT_TIMEOUT" \
       claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
-        --model "$CLAWDND_DM_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+        --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
         --output-format stream-json --verbose > "$out" 2>> "$DM_LOG.err"
   }
   _dm_invoke; rc=$?


### PR DESCRIPTION
WorldOS's target fast-DM config: make **lean the default** and add **effort-tiering** (max cold-open / medium routine). Lean is already validated (reallean: ~10–27× context drop, story quality held at 4.4); #550 fixed the arg-naming that previously caused the RED gate.

## (A) Flip lean default ON
`CLAWDND_LEAN_BEATS` default flipped `:-0` → `:-1` at every site so lean is standard:
- `scripts/play.sh` (the var default)
- `qa/run_duo.sh` (the var default)
- `qa/lib_beat_driver.sh` — the firing-guard fallback inside the shared `clawdnd_dm_lean_args` helper (`${CLAWDND_LEAN_BEATS:-1}`)

Still fully overridable: **`CLAWDND_LEAN_BEATS=0` forces the legacy full `--resume` path** (byte-identical to pre-lean). The cold open (beat 1) is unaffected — it is always the full `--session-id`; lean only ever applied to *continuing* beats, and that logic is unchanged.

## (B) DM effort-tiering
Opus defaults to `effort=high` every turn (max thinking ≈ the biggest per-turn latency cost). New shared helper **`clawdnd_dm_effort_arg`** in `qa/lib_beat_driver.sh` (alongside `clawdnd_dm_lean_args`) so `play.sh` + `run_duo.sh` share it and can't drift. Keyed off the **same** cold-open-vs-continuing `first` signal as lean:
- **COLD-OPEN** beat → `--effort max` (rich, one-time world-build)
- **CONTINUING/routine** beats → `--effort medium` (the bulk; cuts thinking-latency)

Overridable: `WORLDOS_DM_EFFORT_COLDOPEN` (default `max`), `WORLDOS_DM_EFFORT_ROUTINE` (default `medium`); legacy `CLAWDND_DM_EFFORT_*` names also resolve via `worldos_env`. Applied **only to the DM turn** — the player/actor facade gets no `--effort`. `--effort` is a valid top-level `claude` flag (`low|medium|high|xhigh|max`), passed per-call.

## Verify (CI billing-locked — no model calls were made)
- `bash -n` clean on all four edited scripts.
- `qa/dryrun_lean_proof.sh` extended with a stub `claude` (no model call). **18/18 assertions PASS**:
  1. `CLAWDND_LEAN_BEATS` defaults to 1 (no env set → lean fires: fresh UUID + LEAN RE-GROUND, no `--resume`)
  2. cold-open DM argv includes `--effort max`
  3. routine DM argv includes `--effort medium`
  4. player turn argv has **no** `--effort`
  5. `CLAWDND_LEAN_BEATS=0` override forces the legacy `--resume` (non-lean) path

**Not yet live-validated:** no real model run here (CI billing-locked). The owner will A/B this config on the VM (lean + effort-medium) before `--admin`-merging. Other DM-driving runners (`run_party.sh`, `play_party.sh`, `run_combat_sprint.sh`, `run_duo_openclaw.sh`) source the shared lib but were intentionally left out of scope — a follow-up can adopt `clawdnd_dm_effort_arg` there.

**Do not merge** — pending VM validation.