### PR TITLE
play_party.sh honors lean + effort-tiering — the .app DM now runs the fast config

### DIFF
--- a/qa/dryrun_lean_proof_play_party.sh
+++ b/qa/dryrun_lean_proof_play_party.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# DRY-RUN PROOF (no model call): shows that scripts/play_party.sh's DM turn now honors
+# CLAWDND_LEAN_BEATS AND the DM effort-tier — both via the SHARED helpers in
+# qa/lib_beat_driver.sh (clawdnd_dm_lean_args + clawdnd_dm_effort_arg). This matters because the
+# BUILT dist/WorldOS.app shells scripts/play_party.sh for its DM (see
+# macos/.../ProviderAdapters.swift ClaudeProvider), so the .app's DM must run the fast
+# lean+effort config or the G1-G5 gate would run the slow non-lean path and likely fail G3 on
+# latency. This is the play_party sibling of qa/dryrun_lean_proof.sh (which proves run_duo).
+#
+# It sources the REAL qa/lib_beat_driver.sh and reproduces play_party.sh's turn() DM branch AND
+# companion (facade) branch argv assembly VERBATIM, with a stub `claude` that just prints the argv
+# it would have run. We assert that:
+#   (1) CLAWDND_LEAN_BEATS now DEFAULTS to 1 (lean is standard — no env set → lean fires);
+#   (2) the COLD-OPEN DM argv includes --effort max (no lean: normal --session-id);
+#   (3) a ROUTINE/continuing DM argv includes --effort medium + fresh --session-id + LEAN RE-GROUND;
+#   (4) the COMPANION turn argv has NO --effort and NO lean re-ground (player/companion untouched);
+#   (5) the flag override still works: CLAWDND_LEAN_BEATS=0 forces the legacy --resume path.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/qa/lib_beat_driver.sh"
+
+# play_party's DM session id, a companion session id, and the campaign id play_party resolves
+# UP FRONT from the pre-seed (so lean re-grounds against the real campaign on continuing beats).
+DSID="DSID-fixed-0000"; CSID="CSID-fixed-0000"
+CAMPAIGN_ID="camp-abc123"
+CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
+DM_CFG="/tmp/dm.mcp.json"; COMP_CFG="/tmp/companion_0.mcp.json"; COMBINED="/tmp/combined.jsonl"
+DM_LOG="/tmp/dm"; STATE_DIR="/tmp/state"; BUDGET="1.50"
+CLAWDND_DM_MODEL="sonnet"; CLAWDND_ACTOR_MODEL="sonnet"
+
+# Stub `claude`: print the exact argv (each arg on its own line in «»), then return. We also stub
+# the I/O sinks (cat/jq/date) so the VERBATIM turn() body runs without touching real files/models.
+claude() {
+  printf 'CLAUDE-ARGV-BEGIN\n'
+  local a; for a in "$@"; do printf '  «%s»\n' "$a"; done
+  printf 'CLAUDE-ARGV-END\n'
+}
+
+# VERBATIM copy of scripts/play_party.sh turn()'s body (the code under test), including the shared
+# lean + effort-tier splice. Sinks (> "$out", cat >> COMBINED, the jq result-extract) are dropped
+# so this prints ONLY the argv. Signature mirrors play_party: $1=kind $2=sid $3=first $4=msg $5=cfg.
+turn_argv() {
+  local kind="$1" sid="$2" first="$3" msg="$4" cfg="${5:-}" out resume=() extra=()
+  [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
+  if [ "$kind" = "dm" ]; then
+    clawdnd_dm_lean_args "$first" "${CAMPAIGN_ID:-}" "$CLAWDND_LEAN_TAIL"
+    if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
+      resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
+      extra=("${CLAWDND_DM_LEAN_EXTRA[@]}")
+    fi
+    clawdnd_dm_effort_arg "$first"
+    claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+      --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+      --output-format stream-json --verbose
+  else
+    claude -p "$msg" "${resume[@]}" --mcp-config "$cfg" --strict-mcp-config \
+      --model "$CLAWDND_ACTOR_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+      --output-format stream-json --verbose
+  fi
+}
+
+hr() { printf '\n========== %s ==========\n' "$1"; }
+
+hr "SCENARIO 1 — DEFAULT (no CLAWDND_LEAN_BEATS set), continuing DM beat (first=0) -> lean fires + effort medium"
+out1="$(unset CLAWDND_LEAN_BEATS; turn_argv dm "$DSID" 0 'This beat, the party acts: opens the door.')"
+printf '%s\n' "$out1"
+
+hr "SCENARIO 2 — DEFAULT (no CLAWDND_LEAN_BEATS set), COLD OPEN DM beat (first=1) -> no lean + effort max"
+out2="$(unset CLAWDND_LEAN_BEATS; turn_argv dm "$DSID" 1 'You are the Dungeon Master. Begin the session.')"
+printf '%s\n' "$out2"
+
+hr "SCENARIO 3 — OVERRIDE CLAWDND_LEAN_BEATS=0, continuing DM beat (first=0) -> legacy --resume (lean off), effort still medium"
+out3="$(CLAWDND_LEAN_BEATS=0 turn_argv dm "$DSID" 0 'This beat, the party acts: opens the door.')"
+printf '%s\n' "$out3"
+
+hr "SCENARIO 4 — COMPANION turn (facade, continuing beat) -> NO --effort, NO lean re-ground"
+out4="$(unset CLAWDND_LEAN_BEATS; turn_argv actor "$CSID" 0 'Take your next action through your tools.' "$COMP_CFG")"
+printf '%s\n' "$out4"
+
+# ---- Assertions -------------------------------------------------------------------
+hr "ASSERTIONS"
+fail=0
+chk() { if eval "$2"; then echo "PASS: $1"; else echo "FAIL: $1"; fail=1; fi; }
+
+# (1)+(3) DEFAULT lean=1: S1 (no env) on a continuing DM beat must FIRE lean -> fresh UUID session,
+#         LEAN RE-GROUND directive, NO --resume, AND --effort medium. Proves the default is 1.
+chk "S1 DEFAULT fires lean: has --session-id"        'printf "%s" "$out1" | grep -q -- "--session-id"'
+chk "S1 DEFAULT lean: fresh UUID (not \$DSID)"        'printf "%s" "$out1" | grep -Eq "«[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}»"'
+chk "S1 DEFAULT lean: NOT \$DSID"                     '! printf "%s" "$out1" | grep -q -- "«DSID-fixed-0000»"'
+chk "S1 DEFAULT lean: has --append-system-prompt"    'printf "%s" "$out1" | grep -q -- "--append-system-prompt"'
+chk "S1 DEFAULT lean: directive says LEAN RE-GROUND" 'printf "%s" "$out1" | grep -q "LEAN RE-GROUND"'
+chk "S1 DEFAULT lean: re-grounds THIS campaign id"   'printf "%s" "$out1" | grep -q "camp-abc123"'
+chk "S1 DEFAULT lean: NO --resume"                   '! printf "%s" "$out1" | grep -q -- "--resume"'
+chk "S1 routine DM argv has --effort medium"         'printf "%s" "$out1" | grep -A1 -- "«--effort»" | grep -q -- "«medium»"'
+
+# (2) cold-open effort = max; cold open does NOT fire lean (normal --session-id \$DSID, no lean).
+chk "S2 cold-open DM argv has --effort max"          'printf "%s" "$out2" | grep -A1 -- "«--effort»" | grep -q -- "«max»"'
+chk "S2 cold open uses --session-id \$DSID"          'printf "%s" "$out2" | grep -q -- "«DSID-fixed-0000»"'
+chk "S2 cold open has NO --append-system-prompt"     '! printf "%s" "$out2" | grep -q -- "--append-system-prompt"'
+chk "S2 cold open has NO --resume"                   '! printf "%s" "$out2" | grep -q -- "--resume"'
+chk "S2 cold open does NOT use --effort medium"      '! { printf "%s" "$out2" | grep -A1 -- "«--effort»" | grep -q -- "«medium»"; }'
+
+# (5) override LEAN=0 forces the legacy --resume path (no lean) — still fully reversible per-run.
+chk "S3 override LEAN=0 uses --resume \$DSID"         'printf "%s" "$out3" | grep -q -- "--resume" && printf "%s" "$out3" | grep -q -- "«DSID-fixed-0000»"'
+chk "S3 override LEAN=0 has NO --append-system-prompt" '! printf "%s" "$out3" | grep -q -- "--append-system-prompt"'
+chk "S3 override LEAN=0 has NO fresh --session-id"    '! printf "%s" "$out3" | grep -q -- "--session-id"'
+chk "S3 routine DM argv still --effort medium"        'printf "%s" "$out3" | grep -A1 -- "«--effort»" | grep -q -- "«medium»"'
+
+# (4) the COMPANION facade turn never gets --effort or a lean re-ground (effort/lean = DM only).
+chk "S4 companion turn has NO --effort"               '! printf "%s" "$out4" | grep -q -- "--effort"'
+chk "S4 companion turn has NO --append-system-prompt" '! printf "%s" "$out4" | grep -q -- "--append-system-prompt"'
+chk "S4 companion turn has NO LEAN RE-GROUND"         '! printf "%s" "$out4" | grep -q "LEAN RE-GROUND"'
+chk "S4 companion turn uses --resume \$CSID"          'printf "%s" "$out4" | grep -q -- "--resume" && printf "%s" "$out4" | grep -q -- "«CSID-fixed-0000»"'
+
+hr "RESULT"
+[ "$fail" = 0 ] && echo "ALL ASSERTIONS PASSED" || echo "SOME ASSERTIONS FAILED"
+exit "$fail"

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -52,9 +52,11 @@ if [ -f "$COMMON" ]; then
   . "$COMMON"
 fi
 # Shared beat-driver helpers (the SAME ones play.sh + the QA duo source) — for the #357
-# empty-narration fallback (clawdnd_dm_narration_or_fallback). The solo path execs play.sh
-# (which sources this itself) before reaching the ensemble code below, so this only engages
-# the ensemble loop; pure function defs, safe to source unconditionally.
+# empty-narration fallback (clawdnd_dm_narration_or_fallback) AND the DM-turn lean + effort
+# levers (clawdnd_dm_lean_args + clawdnd_dm_effort_arg), so the ensemble DM runs the SAME fast
+# lean+effort config play.sh/run_duo do (the .app shells THIS script for its DM). The solo path
+# execs play.sh (which sources this itself) before reaching the ensemble code below, so this only
+# engages the ensemble loop; pure function defs, safe to source unconditionally.
 # shellcheck source=../qa/lib_beat_driver.sh
 . "$ROOT/qa/lib_beat_driver.sh"
 if declare -F clawdnd_missing_commands >/dev/null 2>&1; then
@@ -71,6 +73,10 @@ COMPANION_SPEC="${4:-${CLAWDND_PLAY_COMPANIONS:-}}"
 # delegates to play.sh, which honors CLAWDND_DM_MODEL on its own (the env var carries through).
 CLAWDND_DM_MODEL="${CLAWDND_DM_MODEL:-sonnet}"
 CLAWDND_ACTOR_MODEL="${CLAWDND_ACTOR_MODEL:-sonnet}"
+# Lean-beat re-ground depth: how many recent player-facing beats the LEAN RE-GROUND directive
+# asks scene_context to fold in (default 8 — SAME as scripts/play.sh + qa/run_duo.sh). Used by
+# the DM turn's clawdnd_dm_lean_args call below; the helper also defaults to 8 if unset.
+CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
 
 # --- NO companions specified → today's solo human-play, byte-for-byte. -----------------
 # Delegate to scripts/play.sh with the SAME positional args (it ignores any 4th). exec
@@ -217,14 +223,36 @@ echo "[play-party] run=$RUN world=$WORLD port=$PORT companions=$NUM_COMP dm=$DSI
 # DM gets the plugin + stream-json (tool calls land in COMBINED). A companion gets ONLY its
 # facade config (--strict-mcp-config) + json output. Both carry --max-budget-usd (per call)
 # and append their stream to COMBINED so companion tool-call cost counts toward the ceiling.
+# The DM turn ALSO honors the shared lean + effort-tiering levers (clawdnd_dm_lean_args +
+# clawdnd_dm_effort_arg from qa/lib_beat_driver.sh) — the SAME path scripts/play.sh + qa/run_duo.sh
+# drive, so the .app's DM (which shells THIS script) runs the fast lean+effort config: continuing
+# beats re-ground from a fresh transcript-free session at --effort medium, the cold open keeps the
+# full session at --effort max. The companion facade branch gets NEITHER (player turns untouched).
 # $1=kind(dm|actor) $2=session-id $3=first?(1/0) $4=message $5=mcp-cfg(actor only); echoes reply.
 turn() {
-  local kind="$1" sid="$2" first="$3" msg="$4" cfg="${5:-}" out resume=()
+  local kind="$1" sid="$2" first="$3" msg="$4" cfg="${5:-}" out resume=() extra=()
   [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
   if [ "$kind" = "dm" ]; then
+    # LEAN beats (CLAWDND_LEAN_BEATS=1, now the default): a CONTINUING DM beat (first=0) starts a
+    # FRESH session + a re-ground directive instead of --resume-ing the fat transcript — the SAME
+    # shared implementation scripts/play.sh + qa/run_duo.sh use (clawdnd_dm_lean_args in
+    # qa/lib_beat_driver.sh), so the three harnesses can't drift. play_party already knows the
+    # campaign id ($CAMPAIGN_ID, resolved up front from the pre-seed), so lean re-grounds against
+    # the real campaign on beats 2+; on the cold open (first!=0) or with CLAWDND_LEAN_BEATS=0 the
+    # helper leaves both arrays empty and we keep the --resume/--session-id path set above unchanged.
+    clawdnd_dm_lean_args "$first" "${CAMPAIGN_ID:-}" "$CLAWDND_LEAN_TAIL"
+    if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
+      resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
+      extra=("${CLAWDND_DM_LEAN_EXTRA[@]}")
+    fi
+    # EFFORT TIER (shared helper, qa/lib_beat_driver.sh) — SAME implementation play.sh + run_duo.sh
+    # use: --effort max on the cold open (one-time world-build), --effort medium on continuing beats
+    # (the bulk — cuts thinking-latency). Keyed off the SAME `first` signal as lean. DM turn ONLY —
+    # the companion facade branch below never gets --effort (nor the lean re-ground).
+    clawdnd_dm_effort_arg "$first"
     out="$DM_LOG.$(date +%s%N).jsonl"
-    claude -p "$msg" "${resume[@]}" --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
-      --model "$CLAWDND_DM_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+    claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+      --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
       --output-format stream-json --verbose > "$out" 2>> "$DM_LOG.err"
     cat "$out" >> "$COMBINED"
     jq -rs 'map(select(.type=="result"))[-1].result // ""' "$out" 2>/dev/null


### PR DESCRIPTION
## Why

The built **`dist/WorldOS.app`** shells **`scripts/play_party.sh`** for its DM — confirmed in `macos/WorldOSApp/Sources/WorldOSApp/Services/ProviderAdapters.swift`, `ClaudeProvider`:

```swift
var args = ["scripts/play_party.sh", world, runId, String(port)]
```
(and its status detail: *"Uses scripts/play_party.sh and the existing Claude plugin path."*)

Until now, `play_party.sh`'s DM `turn()` `--resume`'d the growing transcript every beat at the model's default effort (high/max) — the **slow, non-lean path**. So the `.app`'s G1–G5 gate would run that path and likely **fail G3 on latency**, even though `scripts/play.sh` + `qa/run_duo.sh` already run the fast **lean + effort-tiered** config via the shared helpers from #551.

## What

Wire `play_party.sh`'s **DM turn** to the SAME shared helpers in `qa/lib_beat_driver.sh`, so all three harnesses can't drift:

- **`clawdnd_dm_lean_args "$first" "$CAMPAIGN_ID" "$CLAWDND_LEAN_TAIL"`** — a CONTINUING beat (`first=0`) starts a **fresh transcript-free `--session-id`** + a **LEAN RE-GROUND `--append-system-prompt`** that re-grounds from `scene_context`; the cold open (`first=1`) keeps the full `--session-id`. `play_party` already resolves the campaign id up front from the pre-seed, so lean re-grounds the **real** campaign on beats 2+.
- **`clawdnd_dm_effort_arg "$first"`** — `--effort max` on the cold open (one-time world-build), `--effort medium` on continuing beats (the bulk — cuts the thinking-latency that dominates each turn).

So `play_party` now honors **`CLAWDND_LEAN_BEATS`** (default `1`) + effort-tiering. `CLAWDND_LEAN_BEATS=0` still **forces the legacy `--resume` path**. The **companion facade branch is untouched** (no `--effort`, no lean re-ground); **player turns unchanged**.

## Proof (CI billing-locked → dry-run, no model call)

- `bash -n scripts/play_party.sh` ✅ clean
- New **`qa/dryrun_lean_proof_play_party.sh`** (sibling of `qa/dryrun_lean_proof.sh`) sources the real `qa/lib_beat_driver.sh` and reproduces `play_party`'s `turn()` DM + companion argv **verbatim** with a stub `claude` — **21/21 assertions pass**:

| Scenario | DM/companion argv |
|---|---|
| Continuing DM beat (default) | fresh `--session-id` (UUID, not `$DSID`) + LEAN RE-GROUND (re-grounds the real campaign id) + `--effort medium`, **no** `--resume` |
| Cold open | `--session-id $DSID` (no lean) + `--effort max` |
| `CLAWDND_LEAN_BEATS=0` | legacy `--resume $DSID`, no lean (effort still medium) |
| Companion (facade) | **no** `--effort`, **no** LEAN RE-GROUND, plain `--resume` |

Run: `bash qa/dryrun_lean_proof_play_party.sh`

## Scope

`scripts/play_party.sh`: +34 / −6 (mostly doc comments + the lean/effort splice in the DM branch of `turn()`). The `else` (companion) branch is byte-for-byte unchanged. New file: `qa/dryrun_lean_proof_play_party.sh`.