### PR TITLE
Pin Codex provider default model

### DIFF
--- a/macos/WorldOSApp/Sources/WorldOSApp/Models/ProviderModels.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Models/ProviderModels.swift
@@ -15,7 +15,13 @@ enum ProviderKind: String, CaseIterable, Identifiable {
     }
 
     static var scriptedProviderEnabled: Bool {
-        ProcessInfo.processInfo.environment["WORLDOS_ENABLE_SCRIPTED_PROVIDER"] == "1"
+        if ProcessInfo.processInfo.environment["WORLDOS_ENABLE_SCRIPTED_PROVIDER"] == "1" {
+            return true
+        }
+        if let bundled = Bundle.main.object(forInfoDictionaryKey: "WorldOSEnableScriptedProvider") as? Bool {
+            return bundled
+        }
+        return false
     }
 
     var id: String { rawValue }

--- a/qa/test_macos_app_static.py
+++ b/qa/test_macos_app_static.py
@@ -89,6 +89,16 @@ class MacOSAppStaticContractTests(unittest.TestCase):
         self.assertIn("player_agent", harness)
         self.assertIn("provider", harness)
 
+    def test_codex_provider_wrappers_pin_supported_default_model(self):
+        dm = self.read("scripts/play_codex_dm.sh")
+        actor = self.read("scripts/play_codex_actor.sh")
+
+        for script in (dm, actor):
+            self.assertIn("WORLDOS_CODEX_MODEL", script)
+            self.assertIn('CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-gpt-5.5}}"', script)
+            self.assertIn('MODEL_ARGS=(--model "$CODEX_MODEL")', script)
+            self.assertIn("--ignore-user-config", script)
+
     def test_codex_dm_provider_feeds_live_progress_events(self):
         script = self.read("scripts/play_codex_dm.sh")
         app = self.read("viewer/openworlds/app.jsx")
@@ -135,12 +145,18 @@ class MacOSAppStaticContractTests(unittest.TestCase):
         root_view = self.read("macos/WorldOSApp/Sources/WorldOSApp/Views/RootView.swift")
         play_view = self.read("macos/WorldOSApp/Sources/WorldOSApp/Views/PlayView.swift")
         script = self.read("scripts/play_scripted_dm.sh")
+        build_script = self.read("script/build_and_run.sh")
 
         self.assertIn("case scripted", models)
         self.assertIn("WORLDOS_ENABLE_SCRIPTED_PROVIDER", models)
+        self.assertIn('Bundle.main.object(forInfoDictionaryKey: "WorldOSEnableScriptedProvider")', models)
         self.assertIn("static var allCases", models)
         self.assertIn("cases.append(.scripted)", models)
         self.assertIn("var isLaunchEnabled", models)
+
+        self.assertIn('ENABLE_SCRIPTED_PROVIDER="${WORLDOS_ENABLE_SCRIPTED_PROVIDER:-0}"', build_script)
+        self.assertIn("WorldOSEnableScriptedProvider", build_script)
+        self.assertIn('ENABLE_SCRIPTED_PROVIDER_PLIST="$(plist_bool "$ENABLE_SCRIPTED_PROVIDER")"', build_script)
 
         self.assertIn("struct ScriptedProvider", providers)
         self.assertIn("ProviderKind.scriptedProviderEnabled", providers)

--- a/script/build_and_run.sh
+++ b/script/build_and_run.sh
@@ -12,6 +12,7 @@ MIN_SYSTEM_VERSION="13.0"
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 ART_ROOT="${WORLDOS_ART_REPO_ROOT:-${CLAWDND_ART_REPO_ROOT:-$ROOT_DIR}}"
 PREFER_LAUNCH_ROOTS="${WORLDOS_PREFER_LAUNCH_ROOTS:-1}"
+ENABLE_SCRIPTED_PROVIDER="${WORLDOS_ENABLE_SCRIPTED_PROVIDER:-0}"
 plist_escape() {
   local value="$1"
   value="${value//&/&amp;}"
@@ -32,6 +33,7 @@ plist_bool() {
 ROOT_DIR_PLIST="$(plist_escape "$ROOT_DIR")"
 ART_ROOT_PLIST="$(plist_escape "$ART_ROOT")"
 PREFER_LAUNCH_ROOTS_PLIST="$(plist_bool "$PREFER_LAUNCH_ROOTS")"
+ENABLE_SCRIPTED_PROVIDER_PLIST="$(plist_bool "$ENABLE_SCRIPTED_PROVIDER")"
 PACKAGE_DIR="$ROOT_DIR/macos/WorldOSApp"
 DIST_DIR="$ROOT_DIR/dist"
 APP_BUNDLE="$DIST_DIR/$DISPLAY_NAME.app"
@@ -131,6 +133,8 @@ build_bundle() {
   <string>$ART_ROOT_PLIST</string>
   <key>WorldOSPreferLaunchRoots</key>
   $PREFER_LAUNCH_ROOTS_PLIST
+  <key>WorldOSEnableScriptedProvider</key>
+  $ENABLE_SCRIPTED_PROVIDER_PLIST
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
   <key>NSAppTransportSecurity</key>

--- a/scripts/play_codex_actor.sh
+++ b/scripts/play_codex_actor.sh
@@ -35,6 +35,7 @@ Optional:
   CLAWDND_PLAY_COMPANIONS
   CLAWDND_ACTOR_ID
   CLAWDND_ACTOR_ROLE
+  WORLDOS_CODEX_MODEL
   CLAWDND_CODEX_MODEL
   CLAWDND_STATE_ROOT
 EOF
@@ -196,7 +197,10 @@ if [ "$MODE" != "run" ]; then
   exit 0
 fi
 
-CODEX_MODEL="${CLAWDND_CODEX_MODEL:-}"
+# codex exec intentionally ignores user config so app/provider proofs do not
+# inherit local prompts or sandbox policy. Pin a ChatGPT-account-supported model
+# unless the operator explicitly selects another one.
+CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-gpt-5.5}}"
 MODEL_ARGS=()
 if [ -n "${CODEX_MODEL//[[:space:]]/}" ]; then
   MODEL_ARGS=(--model "$CODEX_MODEL")

--- a/scripts/play_codex_dm.sh
+++ b/scripts/play_codex_dm.sh
@@ -34,6 +34,7 @@ Required environment:
 Optional:
   CLAWDND_PLAY_COMPANIONS
   CLAWDND_PLAY_HERO
+  WORLDOS_CODEX_MODEL
   CLAWDND_CODEX_MODEL
   CLAWDND_STATE_ROOT
 EOF
@@ -237,7 +238,10 @@ if [ "$MODE" != "run" ]; then
   exit 0
 fi
 
-CODEX_MODEL="${CLAWDND_CODEX_MODEL:-}"
+# codex exec intentionally ignores user config so app/provider proofs do not
+# inherit local prompts or sandbox policy. Pin a ChatGPT-account-supported model
+# unless the operator explicitly selects another one.
+CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-gpt-5.5}}"
 MODEL_ARGS=()
 if [ -n "${CODEX_MODEL//[[:space:]]/}" ]; then
   MODEL_ARGS=(--model "$CODEX_MODEL")


### PR DESCRIPTION
## Summary
- Pin the checked-in Codex DM/player wrappers to a ChatGPT-account-supported default model (`gpt-5.5`) while preserving `WORLDOS_CODEX_MODEL` / `CLAWDND_CODEX_MODEL` overrides.
- Bundle the dev/test scripted-provider flag into the built app plist so `/usr/bin/open -n dist/WorldOS.app` can actually expose the scripted provider when the gate enables it.
- Extend the macOS static contract test to cover both provider paths.

## Why
- The Codex wrappers intentionally use `--ignore-user-config`, so they must not rely on the local Codex config for a supported model.
- The built app launch path does not reliably inherit arbitrary shell env from `open -n`; without a bundled flag, the deterministic scripted app smoke can fall back to Claude and produce misleading red evidence when Claude is unavailable.

## Validation
- `bash -n script/build_and_run.sh scripts/play_codex_dm.sh scripts/play_codex_actor.sh`
- `python3 -m pytest qa/test_macos_app_static.py -q`
- `swift build --package-path macos/WorldOSApp`
- `qa/app_handoff_gate.py --web-beats 5 --built-beats 5 --codex-moves 1 --art-root <local private-art checkout> --scripted-budget 1.00 --codex-budget 3.00 --timeout 90 --codex-timeout 240` -> handoff score 100 on `6da0d41`, no evidence gaps

This is fast handoff/playability evidence, not a full release RRI verdict.