### PR TITLE
Map visible OpenWorlds nav hashes

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -794,7 +794,20 @@ function App() {
       "forge", "relations", "journal", "bestiary", "acts", "merchant", "create",
       "seed", "settings",
     ]);
-    const ALIAS = { battle: "combat", parley: "dialogue", chronicles: "launcher", market: "merchant", stash: "inventory", heroes: "character", pick: "roster", picker: "roster", camp: "map", rest: "map" };
+    const ALIAS = {
+      battle: "combat",
+      parley: "dialogue",
+      party: "character",
+      heroes: "character",
+      chronicles: "launcher",
+      worlds: "launcher",
+      market: "merchant",
+      stash: "inventory",
+      pick: "roster",
+      picker: "roster",
+      camp: "map",
+      rest: "map",
+    };
     const fromHash = () => {
       const raw = (window.location.hash || "").replace(/^#\/?/, "").trim().toLowerCase();
       if (!raw) return null;

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -177,6 +177,20 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn('else if (id !== "map") setCampMode(false)', source)
         self.assertIn('location={screen === "map" && campMode ? "Camp"', source)
 
+    def test_openworlds_hash_aliases_match_primary_nav_labels(self):
+        # Fresh players and browser-driving agents use the visible top-nav words as hashes.
+        # Keep those deep links mapped to the canonical screen ids the nav buttons open.
+        status, ctype, body = self._get("/openworlds/app.jsx")
+        chrome = (server._OPENWORLDS_DIR / "chrome.jsx").read_text(encoding="utf-8")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        self.assertIn('id: "g_party", label: "Party"', chrome)
+        self.assertIn('id: "g_worlds", label: "Worlds"', chrome)
+        self.assertIn('party: "character"', source)
+        self.assertIn('worlds: "launcher"', source)
+
     def test_merchant_defaults_to_baldurs_gate_lower_city_vendor(self):
         status, ctype, body = self._get("/openworlds/screen-merchant.jsx")
 


### PR DESCRIPTION
## Summary
- maps visible OpenWorlds top-nav hash labels to their canonical live screen ids
- fixes `#party` routing to the Party/Heroes screen instead of falling through to the atlas
- fixes `#worlds` routing to Chronicles/launcher instead of falling through to the market

## Product impact
Fresh players and browser-driving agents often use the visible nav words as deep links. These aliases keep those labels connected to the same screens the nav buttons open, reducing route drift during local browser playtesting.

## Validation
- `python3 -m pytest viewer/tests/test_openworlds_static.py::OpenWorldsStaticRouteTests::test_openworlds_hash_aliases_match_primary_nav_labels -q` -> 1 passed
- `python3 -m pytest viewer/tests/test_openworlds_static.py -q` -> 52 passed, 6 subtests passed
- `git diff --check`

## Invariants
- engine remains the only campaign-state writer
- GUI remains a read model plus `/move` intent submitter
- no private art, evidence bundle, VM, or operator details committed