### PR TITLE
Clarify composer input help by action mode

### DIFF
--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -207,6 +207,8 @@ const COMPOSER_MODES = {
     kind: "do",
     label: "Do",
     helper: "Write what your hero attempts.",
+    inputLabel: "Describe what your hero does",
+    inputTitle: DECLARE_HINT,
     placeholder: "Describe what your hero does...",
   },
   say: {
@@ -214,6 +216,8 @@ const COMPOSER_MODES = {
     kind: "say",
     label: "Say",
     helper: "Speak in character.",
+    inputLabel: "Describe what your hero says",
+    inputTitle: "Type what your hero says in character, then Declare to speak.",
     placeholder: "What do you say?",
   },
   check: {
@@ -221,6 +225,8 @@ const COMPOSER_MODES = {
     kind: "check",
     label: "Check",
     helper: "Ask the DM for a skill or ability check.",
+    inputLabel: "Describe what your hero checks",
+    inputTitle: "Describe the check you want to make and how, then Declare.",
     placeholder: "What are you checking, and how?",
   },
   save: {
@@ -228,6 +234,8 @@ const COMPOSER_MODES = {
     kind: "save",
     label: "Save",
     helper: "Resist a danger or effect.",
+    inputLabel: "Describe what your hero resists",
+    inputTitle: "Describe the danger your hero is resisting, then Declare.",
     placeholder: "What danger are you resisting?",
   },
 };
@@ -1003,13 +1011,13 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
             <div style={{ display: "flex", gap: 10 }}>
               <input
                 ref={inputRef}
-                aria-label="Describe your move"
+                aria-label={composerMode.inputLabel || "Describe your move"}
                 data-worldos-testid="move-input"
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && onDeclareClick()}
                 disabled={pendingActive || appStatusBlocksPlay}
-                title={DECLARE_HINT}
+                title={composerMode.inputTitle || DECLARE_HINT}
                 placeholder={pendingFirstBeat ? "The Dungeon Master is composing your opening scene…" : pendingActive ? "The Dungeon Master is narrating…" : pendingStuck ? "The DM seemed stuck — try again." : appStatusBlocksPlay ? "Start or resume a DM provider to play…" : (canAct ? composerMode.placeholder : `Read-only: ${readOnlyReason}`)}
                 style={{ ...inkInput, fontFamily: "var(--f-body)", fontSize: 16, opacity: pendingActive ? 0.6 : 1 }}
               />

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -495,7 +495,7 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         ):
             self.assertIn(hook, table)
         self.assertIn('testId="move-submit"', table)
-        self.assertIn('aria-label="Describe your move"', table)
+        self.assertIn('aria-label={composerMode.inputLabel || "Describe your move"}', table)
         self.assertIn('aria-live={surfaceStatus === "loading" ? "polite" : "assertive"}', table)
         self.assertIn('aria-label={label}', table)
 
@@ -775,6 +775,23 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn("sanitizeNarration(entry.text)", source)
         self.assertIn('data-worldos-testid="chronicle-narration"', source)
         self.assertNotRegex(source, r'data-worldos-testid="chronicle-narration"[\s\S]*?>Chronicle</span>')
+
+    def test_openworlds_table_composer_input_help_matches_mode(self):
+        # A fresh player selecting Say/Check/Save should not see the generic "hero does" tooltip.
+        # The placeholder already changes by mode; the accessible label and native tooltip should
+        # follow it so the Declare box teaches the selected action type.
+        status, _ctype, body = self._get("/openworlds/screen-table.jsx")
+
+        self.assertEqual(status, 200)
+        source = body.decode("utf-8")
+        self.assertIn('inputLabel: "Describe what your hero says"', source)
+        self.assertIn('inputTitle: "Type what your hero says in character, then Declare to speak."', source)
+        self.assertIn('inputLabel: "Describe what your hero checks"', source)
+        self.assertIn('inputTitle: "Describe the check you want to make and how, then Declare."', source)
+        self.assertIn('inputLabel: "Describe what your hero resists"', source)
+        self.assertIn('inputTitle: "Describe the danger your hero is resisting, then Declare."', source)
+        self.assertIn('aria-label={composerMode.inputLabel || "Describe your move"}', source)
+        self.assertIn("title={composerMode.inputTitle || DECLARE_HINT}", source)
 
     def test_openworlds_app_bounds_the_live_session_tail(self):
         # #402: the live tail (chatBeats + player echoes) is bounded in useLiveSession so a long


### PR DESCRIPTION
## Summary
- Make the OpenWorlds free-text composer teach the selected action mode through its accessible label and native tooltip.
- Align Do/Say/Check/Save input help with the existing mode-specific placeholders.
- Preserve the engine/GUI invariant: no engine authority, state writer, provider, or /move behavior changes.

## Verification
- `python3 -m pytest viewer/tests/test_openworlds_static.py::OpenWorldsStaticRouteTests::test_openworlds_table_composer_input_help_matches_mode -q`
- `python3 -m pytest viewer/tests/test_openworlds_static.py -q`
- Browser live check: Do/Say/Check/Save labels, placeholders, and titles align; zero console errors; zero broken visible images.

## Notes
- This is a focused fresh-player polish slice, not a release verdict.
- Local/private evidence is retained outside the public repository.