### PR TITLE
Deduplicate Chronicle player echo replays

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -401,22 +401,28 @@ function useLiveSession(state) {
     if (p.stuck) setPendingState((q) => (q ? { ...q, stuck: false } : q));
   }, [clearRecoveryTimer, setPendingState]);
 
-  // #399: idempotent player echo. The #344 'Try again' recovery re-POSTs the EXACT stalled move
-  // (postMove → recordPlayerEcho again), which used to append a SECOND identical action row — the
-  // duplicated "Rolan—" the playtester saw in the chronicle. Skip the append when the last entry is
-  // already an identical action (same `who` + same trimmed text) so a retry never doubles the line.
-  // Only a back-to-back exact repeat is suppressed; a genuine "do X" then "do X again" two turns
-  // apart is separated by the DM's narration beat between them, so it is NOT deduped.
-  const recordPlayerEcho = React.useCallback((who, text) => {
+  // #399: idempotent player echo for STUCK retries only. The #344 'Try again' recovery re-POSTs
+  // the EXACT stalled move (postMove → recordPlayerEcho again), which used to append a SECOND
+  // identical action row. Suppress that duplicate only while the pending turn is explicitly stuck:
+  // a player may intentionally repeat the same words/action on a later normal turn, and the
+  // Chronicle must show that second choice.
+  const recordPlayerEcho = React.useCallback((who, text, move) => {
     setLog((l) => {
+      const route = String(move?.kind || "").trim().toLowerCase();
+      const echoText = route === "say"
+        ? window.stripRoutingTag(move?.text || text).replace(/^\s*say\s*:\s*/i, "").replace(/\s+/g, " ").trim()
+        : text;
+      const entryKind = route === "say" ? "dialog" : "action";
       const last = l[l.length - 1];
-      if (last && last.kind === "action" && last.who === who
-          && String(last.text || "").trim() === String(text || "").trim()) {
+      const retryingStuckTurn = Boolean(pendingRef.current && pendingRef.current.stuck);
+      if (retryingStuckTurn && last && last.kind === entryKind && last.who === who
+          && String(last.text || "").trim() === String(echoText || "").trim()
+          && String(last.route || "") === route) {
         return l;  // identical to the row already showing (a Try-again re-POST) — no duplicate.
       }
       // #402: bound the echo tail so a long session doesn't grow `log` (and the rendered DOM /
       // a11y tree) without limit. Keep the most-recent MAX_LIVE_ECHOES.
-      return boundTail([...l, { kind: "action", who, text, at: nextLogSeq(), eventAt: Date.now() / 1000 }], MAX_LIVE_ECHOES);  // #274: creation-order stamp
+      return boundTail([...l, { kind: entryKind, who, text: echoText, route, at: nextLogSeq(), eventAt: Date.now() / 1000 }], MAX_LIVE_ECHOES);  // #274: creation-order stamp
     });
   }, []);
 

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -289,17 +289,28 @@ function buildChronicleLog(recentEvents, chatBeats, log) {
     continue: "Continue",
     "look around": "Look",
   };
-  const playerEchoKeys = (entry) => {
-    const kind = entry && (entry.kind || entry.type);
-    const who = String(entry?.who || "").trim().toLowerCase();
-    if (entry?.route === "say" || entry?.mode === "say" || entry?.routing?.type === "say") return [];
-    if (kind !== "action" && !(kind === "dialog" && who === "you")) return [];
-    const key = String(entry?.text || "")
+  const playerEchoRoute = (entry) => String(entry?.route || entry?.mode || entry?.routing?.type || "").trim().toLowerCase();
+  const canonicalPlayerEchoKey = (raw) => {
+    let key = String(raw || "")
+      .replace(/^\s*\[(?:say|do|check|save|continue|attack|cast|use_item|clarify)\]\s*/i, "")
       .replace(/^\s*(?:say|do|check|save)\s*:\s*/i, "")
       .replace(/^[`'"“”]+|[`'"“”]+$/g, "")
       .replace(/\s+/g, " ")
       .trim()
       .toLowerCase();
+    if (!key) return "";
+    const requestedDie = key.match(/^requests?\s+a\s+d(\d+)\s+roll$/);
+    if (requestedDie) return `roll d${requestedDie[1]}`;
+    const rolledDie = key.match(/^roll\s+d(\d+)$/);
+    if (rolledDie) return `roll d${rolledDie[1]}`;
+    return key;
+  };
+  const playerEchoKeys = (entry) => {
+    const kind = entry && (entry.kind || entry.type);
+    const who = String(entry?.who || "").trim().toLowerCase();
+    const route = playerEchoRoute(entry);
+    if (kind !== "action" && !(kind === "dialog" && (who === "you" || route === "say"))) return [];
+    const key = canonicalPlayerEchoKey(entry?.text);
     if (!key) return [];
     return [key, ...(QUICK_ACTION_REPLAY_ALIASES[key] || [])];
   };
@@ -649,7 +660,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
       if (!response.ok || payload.ok === false) {
         throw new Error(payload.reason || `move ${response.status}`);
       }
-      recordPlayerEcho(hero.name, text);
+      recordPlayerEcho(hero.name, text, cleanMove);
       armPending(text);
       // #402: a new turn was just submitted — force the chronicle back to the bottom on the next
       // content change even if the player had scrolled up, so they always see their move land and

--- a/viewer/tests/test_live_narration_stream.py
+++ b/viewer/tests/test_live_narration_stream.py
@@ -226,12 +226,13 @@ const h = {
   chronicle: (recent) => sandbox.window.buildChronicleLog(recent || [], reactHost.api().chatBeats || [], reactHost.api().log || [])
     .map((e) => ({ kind: e.kind, text: e.text, who: e.who })),
   pending: () => reactHost.api().pending,
+  markStuck: () => { const p = reactHost.api().pending; if (p) p.stuck = true; },
   // arm the "DM is narrating…" indicator exactly as a posted player move does (armPending is on
   // the hook's returned api). Used to prove a streamed paragraph CLEARS it (the give-up fix).
   arm: (text) => reactHost.api().armPending(text || 'open the scene'),
   // #399: the hook's public player-echo append (the chronicle's optimistic "You: …" row). Idempotent
   // so a #344 'Try again' re-POST of the exact stalled move doesn't double the line.
-  echo: (who, text) => reactHost.api().recordPlayerEcho(who, text),
+  echo: (who, text, move) => reactHost.api().recordPlayerEcho(who, text, move),
   log: () => (reactHost.api().log || []).map((e) => ({ kind: e.kind, who: e.who, text: e.text })),
   // #399: the recovery-window selector by turn position (firstBeat ⇒ cold-open window, else later).
   recoveryWindowMs: (firstBeat) => sandbox.window.recoveryWindowMs(firstBeat),
@@ -453,15 +454,18 @@ class LiveNarrationStreamTests(unittest.TestCase):
                          "the later-beat window must be 180s so a content-rich 90–120s beat 2–4 isn't falsely declared stuck (#399)")
         self.assertEqual(out["first"], 4 * 60 * 1000, "the cold-open window is unchanged (4 min)")
 
-    # --- #399: the player echo is IDEMPOTENT (the 'Try again' re-POST doesn't duplicate) -------
+    # --- #399: the player echo is IDEMPOTENT only during stuck-turn retry ---------------------
     # The #344 stuck-recovery re-POSTs the EXACT stalled move (postMove → recordPlayerEcho again),
     # which used to append a SECOND identical action row — the duplicated "Rolan—" the playtester
-    # filed. A back-to-back identical (who, text) must NOT double the chronicle line.
+    # filed. Suppress that duplicate only when the pending turn is actually in stuck retry state;
+    # a normal later turn may intentionally repeat the same words/action.
     def test_player_echo_is_idempotent_on_retry(self):
         out = self._run(
             "await h.drain();"
             "h.echo('Rolan', 'Rolan\\u2014 hold the line');"  # original submit
             "var afterFirst = h.log();"
+            "h.arm('Rolan\\u2014 hold the line');"
+            "h.markStuck();"
             "h.echo('Rolan', 'Rolan\\u2014 hold the line');"  # 'Try again' re-POST (exact same move)
             "var afterRetry = h.log();"
             "return ({ afterFirst: afterFirst, afterRetry: afterRetry });"
@@ -470,6 +474,17 @@ class LiveNarrationStreamTests(unittest.TestCase):
         self.assertEqual(len(out["afterRetry"]), 1,
                          "a 'Try again' re-POST of the exact same move must NOT duplicate the chronicle action (#399)")
         self.assertEqual(out["afterRetry"][0]["text"], "Rolan— hold the line")
+
+    # --- #399/#503: normal repeated moves are NOT deduped ------------------------------------
+    def test_player_echo_keeps_normal_repeated_action(self):
+        out = self._run(
+            "await h.drain();"
+            "h.echo('Rolan', 'hold the line');"
+            "h.echo('Rolan', 'hold the line');"
+            "return ({ log: h.log() });"
+        )
+        self.assertEqual(len(out["log"]), 2,
+                         "a normal repeated action must appear twice; idempotence is only for stuck retry")
 
     # --- #399: a DIFFERENT action (a rephrase, or a later turn) is NOT deduped -----------------
     def test_player_echo_keeps_distinct_actions(self):
@@ -717,6 +732,32 @@ class LiveNarrationStreamTests(unittest.TestCase):
             out["chronicle"],
             [{"kind": "action", "text": "Look", "who": "Abby"}],
             "quick action payload aliases like Look/look around must not render as a second You row",
+        )
+
+    def test_say_replay_is_deduped_against_optimistic_dialog_echo(self):
+        out = self._run(
+            "h.echo('Abby', 'Say: Hi', { kind: 'say', text: 'Hi' });"
+            "h.enqueue('/chat', { items: [{ role: 'player', text: '[say] Hi', at: 20 }], next: 1 });"
+            "await h.tick();"
+            "return ({ chronicle: h.chronicle() });"
+        )
+        self.assertEqual(
+            out["chronicle"],
+            [{"kind": "dialog", "text": "Hi", "who": "Abby"}],
+            "a typed Say move should show one speech row, not an optimistic action plus a replayed You quote",
+        )
+
+    def test_dice_roll_replay_is_deduped_against_optimistic_roll_echo(self):
+        out = self._run(
+            "h.echo('Abby', 'requests a d20 roll', { kind: 'check', text: 'roll d20' });"
+            "h.enqueue('/chat', { items: [{ role: 'player', text: '[check] roll d20', at: 20 }], next: 1 });"
+            "await h.tick();"
+            "return ({ chronicle: h.chronicle() });"
+        )
+        self.assertEqual(
+            out["chronicle"],
+            [{"kind": "action", "text": "requests a d20 roll", "who": "Abby"}],
+            "a dice request should show one player row, not both the local request and replayed roll text",
         )
 
     def test_quick_action_replay_renders_as_clean_action_after_reload(self):


### PR DESCRIPTION
## Summary
- Deduplicate `/chat` player replays against the local optimistic player echo in Chronicle.
- Render optimistic Say moves as dialogue using the spoken text, so a typed speech move shows once as speech.
- Normalize dice/check replay keys so `requests a d20 roll` and replayed `roll d20` collapse to one player row.
- Keep normal repeated moves visible; exact duplicate suppression now applies only to stuck-turn retry.

## Verification
- `python3 -m pytest viewer/tests/test_live_narration_stream.py::LiveNarrationStreamTests::test_say_replay_is_deduped_against_optimistic_dialog_echo viewer/tests/test_live_narration_stream.py::LiveNarrationStreamTests::test_dice_roll_replay_is_deduped_against_optimistic_roll_echo -q`
- `python3 -m pytest viewer/tests/test_live_narration_stream.py -q` (`33 passed`)
- `python3 -m pytest viewer/tests/test_openworlds_static.py -q`
- `git diff --check`
- Browser live check: typed Say and Roll d20 each render one player row followed by the DM reply; zero console errors; zero broken visible images.

## Notes
- Display-only change. Engine remains sole campaign-state writer; GUI remains a live reader plus `/move` submitter.
- Local/private evidence is retained outside the public repository.