### PR TITLE
Let Codex provider model env default to CLI

### DIFF
--- a/qa/test_macos_app_static.py
+++ b/qa/test_macos_app_static.py
@@ -89,13 +89,14 @@ class MacOSAppStaticContractTests(unittest.TestCase):
         self.assertIn("player_agent", harness)
         self.assertIn("provider", harness)
 
-    def test_codex_provider_wrappers_pin_supported_default_model(self):
+    def test_codex_provider_wrappers_omit_model_arg_when_env_unset(self):
         dm = self.read("scripts/play_codex_dm.sh")
         actor = self.read("scripts/play_codex_actor.sh")
 
         for script in (dm, actor):
             self.assertIn("WORLDOS_CODEX_MODEL", script)
-            self.assertIn('CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-gpt-5.5}}"', script)
+            self.assertIn('CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-}}"', script)
+            self.assertNotIn('CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-gpt-5.5}}"', script)
             self.assertIn('MODEL_ARGS=(--model "$CODEX_MODEL")', script)
             self.assertIn("--ignore-user-config", script)
 

--- a/scripts/play_codex_actor.sh
+++ b/scripts/play_codex_actor.sh
@@ -198,9 +198,9 @@ if [ "$MODE" != "run" ]; then
 fi
 
 # codex exec intentionally ignores user config so app/provider proofs do not
-# inherit local prompts or sandbox policy. Pin a ChatGPT-account-supported model
-# unless the operator explicitly selects another one.
-CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-gpt-5.5}}"
+# inherit local prompts or sandbox policy. Let Codex CLI choose its account
+# default unless the operator explicitly pins a provider model.
+CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-}}"
 MODEL_ARGS=()
 if [ -n "${CODEX_MODEL//[[:space:]]/}" ]; then
   MODEL_ARGS=(--model "$CODEX_MODEL")

--- a/scripts/play_codex_dm.sh
+++ b/scripts/play_codex_dm.sh
@@ -239,9 +239,9 @@ if [ "$MODE" != "run" ]; then
 fi
 
 # codex exec intentionally ignores user config so app/provider proofs do not
-# inherit local prompts or sandbox policy. Pin a ChatGPT-account-supported model
-# unless the operator explicitly selects another one.
-CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-gpt-5.5}}"
+# inherit local prompts or sandbox policy. Let Codex CLI choose its account
+# default unless the operator explicitly pins a provider model.
+CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-}}"
 MODEL_ARGS=()
 if [ -n "${CODEX_MODEL//[[:space:]]/}" ]; then
   MODEL_ARGS=(--model "$CODEX_MODEL")


### PR DESCRIPTION
## Summary
- Stop defaulting Codex provider wrappers to an explicit model when model env vars are unset.
- Let Codex CLI choose its account default unless `WORLDOS_CODEX_MODEL` or `CLAWDND_CODEX_MODEL` is explicitly provided.
- Apply the same behavior to the DM and actor wrappers.
- Update the static macOS/provider contract to match the new no-hardcoded-model behavior.

## Verification
- `uv run --directory servers/engine --group dev pytest tests/test_codex_provider_wrapper.py::test_codex_dm_wrapper_run_allows_unset_model_with_fake_codex -q`
- `uv run --directory servers/engine --group dev pytest tests/test_codex_provider_wrapper.py -q`
- `python3 -m pytest qa/test_macos_app_static.py -q`
- `bash -n scripts/play_codex_dm.sh`
- `bash -n scripts/play_codex_actor.sh`
- `git diff --check`

## Notes
- This fixes the broad CI failure hit by the current GUI product PRs once GitHub runners recovered.
- Provider behavior remains explicitly pinnable through env vars.