### PR TITLE
qa: run_party honors DM effort-tiering (max cold-open / medium routine)

### DIFF
--- a/qa/run_party.sh
+++ b/qa/run_party.sh
@@ -172,9 +172,15 @@ turn() {
   local kind="$1" sid="$2" first="$3" msg="$4" cfg="${5:-}" out resume=()
   [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
   if [ "$kind" = "dm" ]; then
+    # EFFORT TIER (shared helper, qa/lib_beat_driver.sh) — SAME implementation scripts/play.sh,
+    # qa/run_duo.sh, and scripts/play_party.sh use, so the harnesses can't drift: --effort max on
+    # the cold open (one-time world-build), --effort medium on continuing beats (the bulk — cuts
+    # thinking-latency). Keyed off the SAME `first` signal the lean branch uses elsewhere. DM
+    # turn ONLY — the actor branch below never gets --effort.
+    clawdnd_dm_effort_arg "$first"
     out="$T/$RUN.dm.$(date +%s%N).jsonl"
     claude -p "$msg" "${resume[@]}" --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
-      --model "$CLAWDND_DM_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+      --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
       --output-format stream-json --verbose > "$out" 2>> "$T/$RUN.dm.err"
     cat "$out" >> "$COMBINED"
     jq -rs 'map(select(.type=="result"))[-1].result // ""' "$out" 2>/dev/null


### PR DESCRIPTION
## Summary

Follow-up to #551 (which added the `clawdnd_dm_effort_arg` helper in `qa/lib_beat_driver.sh` and wired it into `scripts/play.sh` + `qa/run_duo.sh`) and #552 (which wired it into `scripts/play_party.sh`).

This PR extends the same effort-tier lever to **`qa/run_party.sh`**'s DM turn — mirroring the exact wiring style used in `qa/run_duo.sh`:

- `clawdnd_dm_effort_arg "$first"` is called inside the DM branch of `turn()`, immediately before the `claude -p` invocation, keyed off the same `first` cold-open-vs-continuing signal the player/actor branch ignores.
- `${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"}` is spliced into the DM argv right after `--model "$CLAWDND_DM_MODEL"`.
- Result: `--effort max` on the cold open (one-time world-build), `--effort medium` on every continuing beat (the bulk — cuts the thinking-latency that dominates each turn).
- The actor branch (`--model "$CLAWDND_ACTOR_MODEL"`) is untouched — `--effort` is DM-only.

### The other three scripts in the original wiring-gap list

| Script | Status | Why |
| --- | --- | --- |
| `scripts/play_party.sh` | already wired | done in #552 — no-op here |
| `qa/run_combat_sprint.sh` | **skipped** | one-shot script with a single DM `claude -p` call and no per-beat `first` signal in the call's scope. Per the brief ("if a given script has no clean per-turn first signal, note that and skip it rather than forcing it"), I didn't force a constant tier — the right default for the pre-seeded combat sprint isn't obviously max OR medium, and that's a follow-up call. |
| `qa/run_duo_openclaw.sh` | **skipped** | the DM turn runs through `openclaw agent` (`oc_turn` → `openclaw agent --agent clawdnd-qa-dm --model "$CLAWDND_DM_MODEL" …`), NOT `claude -p`. `--effort` is a `claude -p` flag — it would be silently dropped by `openclaw agent`. Wiring it here would be misleading. |

### Diff

Only one file touched:

```
 qa/run_party.sh | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)
```

## Test plan

- [x] `bash -n qa/run_party.sh` parses clean.
- [x] `bash -n` on `qa/lib_beat_driver.sh`, `qa/run_duo.sh`, `scripts/play_party.sh`, `qa/run_combat_sprint.sh`, `qa/run_duo_openclaw.sh` — all still parse (no collateral edits).
- [ ] Smoke-run `qa/run_party.sh` for one cold-open + one continuing beat and confirm the DM transcript shows `--effort max` on beat 1 and `--effort medium` on beat 2 (look in the `dm.*.jsonl` stream / the launched process args). Defer to maintainer — runs cost real budget.
- [ ] Confirm the actor turn's launched argv does NOT include `--effort` (regression guard on the DM-only constraint).

## Notes

- Draft — please do not merge until the smoke-run lands a confirming party transcript.
- Did not also wire `clawdnd_dm_lean_args` into `run_party.sh` (`CAMPAIGN_ID` isn't currently resolved in this harness). That's a separate change in the same spirit as #549 / #552 if/when wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal agent configuration logic to dynamically modify settings based on interaction state (first interaction vs. continuation).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->