### PR TITLE
Add single-flight lock so a 2nd play_party.sh cold-open is cleanly rejected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
         run: uv run --directory servers/rules --group dev pytest -q
       - name: Voice tests (torch-free; null backend + static metadata)
         run: uv run --directory servers/voice --group dev pytest -q
+      - name: Single-flight launch-guard test (scripts/launch_common.sh lock)
+        # Pure bash + POSIX mkdir/kill -0/rm — no uv/claude/viewer. Proves a second concurrent
+        # play_party.sh cold-open is cleanly rejected and the lock self-heals (release / dead holder).
+        run: bash qa/test_play_party_single_flight.sh
 
   viewer-tests:
     # The viewer is where most recent regressions landed, but its suite was not in

--- a/qa/test_play_party_single_flight.sh
+++ b/qa/test_play_party_single_flight.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# BEHAVIORAL TEST (no model call): proves scripts/launch_common.sh's single-flight launch lock
+# rejects a SECOND concurrent ensemble cold-open and self-heals across release / a dead holder.
+# This is the lock that play_party.sh acquires before the DM cold-open so two launches can't
+# collide on session ids / the viewer port (observed under memory pressure as
+# "Session ID already in use").
+#
+# It sources the REAL helpers and drives them against a throwaway $ROOT under mktemp — NO claude,
+# NO viewer, NO pytest workers, so it is safe to run anywhere (macOS dev box AND ubuntu CI; the
+# lock is mkdir/kill -0/rm, which behave identically on both). Mirrors qa/dryrun_lean_proof_*.sh:
+# a `chk` assertion helper, PASS/FAIL lines, exit = number of failures.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/scripts/launch_common.sh"
+
+holder=""
+TMP="$(mktemp -d)"
+trap 'kill "${holder:-}" 2>/dev/null; rm -rf "$TMP"' EXIT
+LOCK="$TMP/play-state/.launch.lock"
+
+fail=0
+chk() { if eval "$2"; then echo "PASS: $1"; else echo "FAIL: $1"; fail=1; fi; }
+
+# (1) First acquire on a free checkout succeeds and records OUR pid.
+CLAWDND_LAUNCH_LOCK_WAIT=0 clawdnd_acquire_launch_lock "$TMP"; rc=$?
+chk "first acquire succeeds (rc=0)"            '[ "$rc" = 0 ]'
+chk "lock dir + pid file created"              '[ -f "$LOCK/pid" ]'
+chk "pid file records our pid"                 '[ "$(cat "$LOCK/pid")" = "$$" ]'
+
+# (2) A LIVE holder makes a second acquire reject within the bounded wait — and must NOT be stolen.
+sleep 60 & holder=$!
+printf '%s\n' "$holder" > "$LOCK/pid"          # pretend a different live cold-open (pid=$holder) owns it
+start=$SECONDS
+CLAWDND_LAUNCH_LOCK_WAIT=1 clawdnd_acquire_launch_lock "$TMP" 2>"$TMP/err"; rc=$?
+elapsed=$((SECONDS - start))
+chk "live holder → second acquire rejected (rc!=0)"  '[ "$rc" != 0 ]'
+chk "rejection message names the running cold-open"  'grep -q "already running" "$TMP/err"'
+chk "rejection is bounded (<=4s for WAIT=1)"         '[ "$elapsed" -le 4 ]'
+chk "live holder lock NOT stolen (pid unchanged)"    '[ "$(cat "$LOCK/pid")" = "$holder" ]'
+
+# (3) The holder dies WITHOUT releasing (the OOM scenario: SIGKILL skips the cleanup trap). The
+#     stale lock must be reclaimed so the next launch is not blocked forever.
+kill "$holder" 2>/dev/null; wait "$holder" 2>/dev/null   # holder now definitively dead
+chk "precondition: dead holder pid is gone"          '! kill -0 "$holder" 2>/dev/null'
+chk "stale lock left behind (holder never released)" '[ "$(cat "$LOCK/pid" 2>/dev/null)" = "$holder" ]'
+CLAWDND_LAUNCH_LOCK_WAIT=1 clawdnd_acquire_launch_lock "$TMP" 2>"$TMP/err2"; rc=$?
+chk "stale (dead-holder) lock reclaimed → acquire ok" '[ "$rc" = 0 ]'
+chk "reclaimed lock now records our pid"              '[ "$(cat "$LOCK/pid")" = "$$" ]'
+
+# (4) Release frees the lock for the OWNER, is a NO-OP for a non-owner, and re-acquire then works.
+clawdnd_release_launch_lock "$TMP"
+chk "owner release removes the lock"                 '[ ! -e "$LOCK" ]'
+mkdir -p "$LOCK"; printf '%s\n' "424242" > "$LOCK/pid"   # a lock owned by someone else
+clawdnd_release_launch_lock "$TMP"
+chk "non-owner release is a no-op (lock survives)"   '[ "$(cat "$LOCK/pid" 2>/dev/null)" = "424242" ]'
+rm -rf "$LOCK"
+CLAWDND_LAUNCH_LOCK_WAIT=0 clawdnd_acquire_launch_lock "$TMP"; rc=$?
+chk "acquire succeeds again after a clean release"   '[ "$rc" = 0 ]'
+
+[ "$fail" = 0 ] && echo "ALL ASSERTIONS PASSED" || echo "SOME ASSERTIONS FAILED"
+exit "$fail"

--- a/scripts/launch_common.sh
+++ b/scripts/launch_common.sh
@@ -95,3 +95,60 @@ clawdnd_choose_port() {
   echo "Close an existing viewer/monitor, or pass a port explicitly." >&2
   return 1
 }
+
+# --- Single-flight launch lock --------------------------------------------------------------
+# Refuse a SECOND concurrent ensemble cold-open from this checkout, so two play_party.sh runs
+# can't collide on session ids / the viewer port. (Observed under memory pressure: launching a
+# second cold-open while one was already running failed with "Session ID already in use".)
+#
+# Mechanism: an atomic `mkdir` lock dir holding the owner's PID, with PID-liveness staleness.
+# Deliberately portable and flock-FREE — stock macOS has no flock(1) (the collision was seen on a
+# Mac), and more decisively, the viewer supervisor in play_party.sh is an orphan-surviving respawn
+# loop: a flock fd inherited by it would stay held FOREVER if the main process is OOM-killed
+# (SIGKILL skips the cleanup trap). Recording the MAIN pid instead lets the next launch notice the
+# owner is gone (`kill -0` fails) and reclaim the lock. `mkdir`/`kill -0`/`rm` behave identically
+# on macOS and Linux, so there is one code path and the behavioral test runs everywhere.
+#
+# Knob: CLAWDND_LAUNCH_LOCK_WAIT = seconds to wait for a LIVE holder before rejecting (default 5;
+# 0 = reject immediately). The short wait lets the native app's "restart" (terminate-old then
+# start-new) succeed — the old run releases on SIGTERM and the new one acquires within the window.
+clawdnd_acquire_launch_lock() {
+  local root="$1" lock="$1/play-state/.launch.lock" waited=0 held_pid
+  local wait="${CLAWDND_LAUNCH_LOCK_WAIT:-5}"
+  case "$wait" in ''|*[!0-9]*) wait=5 ;; esac   # tolerate a bad value → default
+  mkdir -p "$root/play-state" 2>/dev/null
+  while :; do
+    if mkdir "$lock" 2>/dev/null; then
+      printf '%s\n' "$$" > "$lock/pid"          # won the atomic create → we own it
+      return 0
+    fi
+    held_pid="$(cat "$lock/pid" 2>/dev/null || true)"
+    if [ -n "$held_pid" ] && kill -0 "$held_pid" 2>/dev/null; then
+      :                                         # a LIVE cold-open holds it → wait, then reject
+    elif [ -z "$held_pid" ] && [ "$waited" -lt "$wait" ]; then
+      :                                         # owner mid-acquire (mkdir done, pid not yet written)
+                                                # → wait a beat and re-read; do NOT reclaim (race-safe)
+    else
+      # dead owner (gone, e.g. OOM-killed before cleanup), or a lock that never recorded a pid
+      echo "[play-party] clearing a stale launch lock (previous holder pid ${held_pid:-none} is gone)." >&2
+      rm -rf "$lock" 2>/dev/null
+      continue
+    fi
+    if [ "$waited" -ge "$wait" ]; then
+      echo "[play-party] another WorldOS cold-open is already running (pid ${held_pid:-?}) — refusing to start a second so they can't collide. Stop it first, or wait for it to finish." >&2
+      return 1
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+}
+
+# Release the launch lock, but ONLY if we are the recorded owner — a rejected second launch must
+# never delete the winner's lock. Safe to call unconditionally from cleanup. $1 = repo ROOT.
+clawdnd_release_launch_lock() {
+  local lock="$1/play-state/.launch.lock"
+  if [ "$(cat "$lock/pid" 2>/dev/null || true)" = "$$" ]; then
+    rm -rf "$lock" 2>/dev/null
+  fi
+  return 0
+}

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -108,6 +108,14 @@ MAX_TURNS="${CLAWDND_PLAY_MAX_TURNS:-40}"               # hard cap on agent turn
 if declare -F clawdnd_choose_port >/dev/null 2>&1; then
   PORT="$(clawdnd_choose_port "$PORT" "$PORT_EXPLICIT")" || exit 1
 fi
+# Single-flight: refuse a SECOND concurrent ensemble cold-open (two collide under memory pressure —
+# "Session ID already in use"). Acquired here, before any heavy work (companion pre-seed, the viewer
+# supervisor, the DSID mint, the DM cold-open); released in _party_cleanup below. A rejected launch
+# exits here BEFORE the EXIT/INT/TERM traps are armed, so it runs no cleanup and never touches the
+# holder's lock. (set -uo pipefail has no -e, so the explicit `exit 1` is required.)
+if declare -F clawdnd_acquire_launch_lock >/dev/null 2>&1; then
+  clawdnd_acquire_launch_lock "$ROOT" || exit 1
+fi
 AGENT_TURNS=0
 
 # Product play state under play-state/ (git-ignored), same layout as play.sh.
@@ -340,7 +348,7 @@ viewer_supervisor &  SUP=$!
 # main loop, so `kill`/closing the window couldn't stop a wedged run (it took kill -9, and a
 # dry-run with no human spun a sleep-loop for 8.5h). Separate the EXIT trap (cleanup) from the
 # signal traps (cleanup + exit) so a normal `kill` actually stops it.
-_party_cleanup() { kill "$SUP" 2>/dev/null; [ -f "$VPID_FILE" ] && kill "$(cat "$VPID_FILE" 2>/dev/null)" 2>/dev/null; }
+_party_cleanup() { declare -F clawdnd_release_launch_lock >/dev/null 2>&1 && clawdnd_release_launch_lock "$ROOT"; kill "$SUP" 2>/dev/null; [ -f "$VPID_FILE" ] && kill "$(cat "$VPID_FILE" 2>/dev/null)" 2>/dev/null; }
 trap _party_cleanup EXIT
 trap '_party_cleanup; exit 130' INT TERM
 


### PR DESCRIPTION
## Problem

The WorldOS `.app` (and the double-clickable `worldos-play.command`) cold-opens a
DM+player+companion game by shelling `scripts/play_party.sh`. The script is correct in isolation —
it mints a fresh DSID and runs `claude -p --session-id $DSID` exactly once for the cold-open, and
the VM cold-open is clean. The gap is the **absence of a single-flight guard**: nothing stops a
*second* cold-open from starting while one is already running. Under memory pressure (a Mac with a
concurrent QA session + ~10.5 GB swap) two `play_party.sh` processes collided and produced a
`Session ID already in use` failure. The project's own discipline is already "one heavy `claude -p`
run at a time," so rejecting a second concurrent cold-open enforces an invariant we already want.

## Change (additive, in the engine/content/QA lane only)

- **`scripts/launch_common.sh`** — new `clawdnd_acquire_launch_lock` / `clawdnd_release_launch_lock`
  helpers (mirroring `clawdnd_choose_port`): an **atomic `mkdir` lock dir keyed by the owner PID,
  with PID-liveness staleness**. A bounded wait (`CLAWDND_LAUNCH_LOCK_WAIT`, default `5`s, `0` =
  reject immediately) then a clean `[play-party] … already running` rejection (exit 1).
- **`scripts/play_party.sh`** — acquire in the ensemble path *before any heavy work* (companion
  pre-seed, viewer supervisor, DSID mint, DM cold-open) with `|| exit 1`; release by prepending to
  the existing `_party_cleanup()` so the **existing `EXIT` + `INT/TERM` traps free it** (no new
  traps). A rejected launch exits before the traps arm, so it never touches the holder's lock.
- **`qa/test_play_party_single_flight.sh`** — behavioral test (pure `mkdir`/`kill -0`/`rm`; no
  `claude`/viewer/pytest): first-acquire, live-holder reject (bounded + message + not-stolen),
  dead-holder reclaim, ownership-checked release. **Wired into the ubuntu CI `test` job.**

## Why `mkdir` + PID-liveness rather than `flock`

`flock(1)` is **OOM-unsafe here specifically**: the viewer supervisor (`play_party.sh`) is a
`while :` respawn loop, so if the main process is **OOM-killed** (SIGKILL — uncatchable, the exact
"memory pressure" trigger) it is **orphaned and keeps running**, holding any inherited `flock` fd
**forever** → a permanent lock that blocks all future launches. Recording the *main* PID lets the
next launch see the owner is gone (`kill -0` fails) and reclaim. PID-liveness is therefore required
regardless. `mkdir`/`kill -0`/`rm` are POSIX and identical on macOS (stock macOS has **no
`flock(1)`** — and the failure was seen on a Mac) and Linux, so there is **one portable code path**
and the test runs everywhere.

The bounded wait (vs pure non-blocking) is deliberate: it lets the native app's
terminate-old-then-start-new **"restart"** succeed (the old run releases on SIGTERM and the new one
acquires within the window) while still rejecting a genuinely-concurrent second game.

## Scope / non-goals

- Guard lives **only in `play_party.sh`** — the single chokepoint all callers funnel through;
  `worldos-play.command` already surfaces a non-zero exit with a user-facing message.
- The macOS/OpenWorlds **Swift `.app` layer is untouched** (sibling lane; it already single-flights
  at the AppKit layer).
- **Per-checkout** lock (`$ROOT/play-state/.launch.lock`, gitignored). The solo path (`exec
  play.sh`) is out of scope; adding the same one-line guard there later is trivial (shared helper).
- No engine/state/model changes.

## Verification

- Local (LEXAR; pure bash, no disk strain): `bash -n` on all edited scripts (incl. the exact
  `macos-swift.yml` `find scripts -name '*.sh' | bash -n` gate) ✅; the behavioral test prints
  **14/14 `PASS:` and exits 0** ✅.
- CI: the new **"Single-flight launch-guard test"** step runs on `ubuntu-latest`; **macOS Swift**
  triggers (this touches `scripts/*.sh`) and `bash -n`-syntax-checks the edited scripts on macOS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added launch conflict prevention to ensure only one concurrent play session runs from the same checkout, eliminating resource collisions and conflicts.

* **Tests**
  * Added comprehensive test suite validating launch lock behavior, conflict detection, and stale lock resolution.

* **Chores**
  * Updated CI workflow to include launch lock validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->