### PR TITLE
Fail fast on non-contention mkdir errors in the launch lock

### DIFF
--- a/qa/test_play_party_single_flight.sh
+++ b/qa/test_play_party_single_flight.sh
@@ -57,5 +57,29 @@ rm -rf "$LOCK"
 CLAWDND_LAUNCH_LOCK_WAIT=0 clawdnd_acquire_launch_lock "$TMP"; rc=$?
 chk "acquire succeeds again after a clean release"   '[ "$rc" = 0 ]'
 
+# (5) Non-contention mkdir failures fail FAST — must never spin forever (CodeRabbit on #564).
+#  (a) play-state cannot be created (ROOT is a regular file) → up-front guard rejects, no hang.
+notdir="$TMP/iam-a-file"; : > "$notdir"
+CLAWDND_LAUNCH_LOCK_WAIT=0 clawdnd_acquire_launch_lock "$notdir" 2>"$TMP/err5a"; rc=$?
+chk "uncreatable play-state → acquire fails (rc!=0)"  '[ "$rc" != 0 ]'
+chk "...with a clear 'could not create' message"      'grep -q "could not create" "$TMP/err5a"'
+#  (b) play-state exists but the lock dir is uncreatable (read-only) → in-loop guard rejects fast
+#      instead of spinning. Run in the background with a watchdog so a regression FAILS, not hangs.
+#      Needs non-root (root bypasses directory permissions), so skip there.
+if [ "$(id -u)" != 0 ]; then
+  ro="$TMP/ro"; mkdir -p "$ro/play-state"; chmod 555 "$ro/play-state"
+  ( CLAWDND_LAUNCH_LOCK_WAIT=0 clawdnd_acquire_launch_lock "$ro" >/dev/null 2>>"$TMP/err5b"; echo "$?" > "$TMP/rc5b" ) &
+  bpid=$!
+  for _ in $(seq 1 50); do kill -0 "$bpid" 2>/dev/null || break; sleep 0.1; done
+  if kill -0 "$bpid" 2>/dev/null; then
+    kill "$bpid" 2>/dev/null; echo "FAIL: read-only lock dir made acquire SPIN (did not return)"; fail=1
+  else
+    chk "read-only lock dir → acquire fails fast (rc!=0)" '[ "$(cat "$TMP/rc5b" 2>/dev/null)" != 0 ]'
+  fi
+  chmod 755 "$ro/play-state" 2>/dev/null
+else
+  echo "PASS: read-only-dir spin guard (skipped — running as root bypasses dir perms)"
+fi
+
 [ "$fail" = 0 ] && echo "ALL ASSERTIONS PASSED" || echo "SOME ASSERTIONS FAILED"
 exit "$fail"

--- a/scripts/launch_common.sh
+++ b/scripts/launch_common.sh
@@ -116,11 +116,20 @@ clawdnd_acquire_launch_lock() {
   local root="$1" lock="$1/play-state/.launch.lock" waited=0 held_pid
   local wait="${CLAWDND_LAUNCH_LOCK_WAIT:-5}"
   case "$wait" in ''|*[!0-9]*) wait=5 ;; esac   # tolerate a bad value → default
-  mkdir -p "$root/play-state" 2>/dev/null
+  if ! mkdir -p "$root/play-state" 2>/dev/null; then
+    echo "[play-party] could not create $root/play-state for the launch lock." >&2
+    return 1
+  fi
   while :; do
     if mkdir "$lock" 2>/dev/null; then
       printf '%s\n' "$$" > "$lock/pid"          # won the atomic create → we own it
       return 0
+    fi
+    if [ ! -d "$lock" ]; then
+      # mkdir failed but the lock dir does NOT exist → this is NOT contention (read-only checkout,
+      # missing parent, disk full). Fail fast with a clear message instead of spinning forever.
+      echo "[play-party] could not create the launch lock at $lock — check permissions/disk space." >&2
+      return 1
     fi
     held_pid="$(cat "$lock/pid" 2>/dev/null || true)"
     if [ -n "$held_pid" ] && kill -0 "$held_pid" 2>/dev/null; then


### PR DESCRIPTION
Follow-up to #564, addressing the CodeRabbit review on that PR.

## Bug

`clawdnd_acquire_launch_lock` (added in #564) treated **every** failed `mkdir "$lock"` as
contention. If `play-state` cannot be created or the lock dir is otherwise uncreatable — a
**read-only checkout, a missing parent, or a full disk** (all plausible under the very
memory/disk pressure this guard targets) — `$lock` never exists, `held_pid` stays empty, and the
loop's `else → continue` path (no `sleep`, never returns) **spins forever** instead of failing
cleanly. CodeRabbit flagged this as a Major issue; confirmed by trace.

## Fix (minimal, matches the suggested diff)

- Make the up-front `mkdir -p "$root/play-state"` failure **fatal** (clear message + `return 1`).
- After a failed `mkdir "$lock"`, if the lock dir **does not exist** it is **not contention**
  (filesystem error) → emit a clear `could not create the launch lock` message and `return 1`,
  instead of looping. Genuine contention (dir exists) keeps the existing race-safe wait/reclaim.

## Test

`qa/test_play_party_single_flight.sh` gains two cases (now 17 assertions, all green locally):
- **(a)** uncreatable `play-state` (ROOT is a regular file) → acquire fails with `could not create`.
- **(b)** read-only `play-state` (lock dir uncreatable) → acquire **fails fast**, run under a
  background watchdog so a regression *fails the test* rather than hanging it. Skipped as root
  (root bypasses directory permissions); CI's `runner` user is non-root so it runs in CI.

## Verification

- Local (LEXAR, pure bash): `bash -n` clean; the test prints **17/17 `PASS:`** and exits 0.
- CI: the **Single-flight launch-guard test** step (ubuntu) now exercises the new cases; **macOS
  Swift** `bash -n` re-checks the edited `scripts/*.sh` on macOS.