### PR TITLE
fix(play): DM-turn retry re-mints the session id — stop the masked "Session ID already in use" cold-open dead-end

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -182,6 +182,57 @@ clawdnd_dm_effort_arg() {
   CLAWDND_DM_EFFORT=(--effort "$level")
 }
 
+# RE-MINT SESSION ON RETRY (the ONE shared implementation of "never reuse a CONSUMED session id").
+# A `claude -p` attempt that fails AFTER startup STILL registered its --session-id on disk
+# (~/.claude/projects/<proj>/<uuid>.jsonl), so a retry that re-passes that SAME --session-id dies
+# "Session ID <uuid> is already in use." → 0-byte output → empty narration → the cold open never
+# completes (the masked failure mode behind the 2026-06-02 "reproducibly broken cold-open" reports:
+# attempt 1 actually 401'd, but the retry's session collision is all that reached dm.err). The LEAN
+# path already side-steps this (clawdnd_dm_lean_args mints a fresh uuid every call); the COLD-OPEN /
+# legacy --resume path passes a STABLE $DSID and so MUST be re-minted before its retry. Given the
+# resume-mode the prior attempt used (the caller's `resume` array, passed as "$@"), populate the
+# well-known global CLAWDND_DM_RETRY_SESSION:
+#   • prior mode --session-id (a CREATE) → (--session-id <fresh-uuid>)  — retry on a BRAND-NEW session.
+#   • prior mode --resume <id>           → ()  — resuming an already-created session on retry is safe;
+#                                               leave the caller's --resume untouched.
+# Caller contract: call this ONLY when the lean helper did NOT fire (lean re-mints itself), so each
+# path mints exactly once. Bash 3.2: no namerefs — inspect args by value + populate a global (mirrors
+# clawdnd_dm_lean_args / clawdnd_dm_effort_arg). $@ = the caller's current `resume` array tokens.
+clawdnd_dm_remint_session_on_retry() {
+  CLAWDND_DM_RETRY_SESSION=()
+  if [ "${1:-}" = "--session-id" ]; then
+    CLAWDND_DM_RETRY_SESSION=(--session-id "$(uuidgen 2>/dev/null || python3 -c 'import uuid;print(uuid.uuid4())')")
+  fi
+}
+
+# SURFACE A FAILED DM ATTEMPT'S REAL ERROR (stop the masking). A DM turn redirects only STDERR to
+# dm.err, but `claude -p`'s real failure (a 401 auth error, a budget stop, an MCP startup failure)
+# is a STRUCTURED event on STDOUT — in the per-attempt $out jsonl. So when attempt 1 fails and the
+# retry then collides on the session id, dm.err shows ONLY "Session ID … in use" and the TRUE cause
+# is invisible (this masked a 401 as a phantom concurrency race across ~3 runs). Parse the last
+# result event from $out and echo a clear "[dm-attempt] …" reason to stderr; a 401/403 is flagged
+# NON-retryable with an operator hint. Read-only on engine state; jq-optional (a grep fallback still
+# names an HTTP status); a missing/0-byte $out → a generic rc line (no regression).
+# $1 = the failed attempt's stream-json path  $2 = its exit code (rc)
+clawdnd_report_attempt_failure() {
+  local out="$1" rc="$2" reason status
+  reason="$(jq -rs 'map(select(.type=="result"))[-1] | if . == null then "" else "is_error=\(.is_error) subtype=\(.subtype // "?") result=\((.result // "")[0:180])" end' "$out" 2>/dev/null)"
+  status="$(grep -oE '"(api_error_status|status)":[[:space:]]*[0-9]{3}' "$out" 2>/dev/null | grep -oE '[0-9]{3}' | head -n1)"
+  if [ -z "${reason//[[:space:]]/}" ] && [ -z "$status" ]; then
+    if [ "$rc" = "124" ]; then
+      echo "[dm-attempt] DM turn timed out (rc=124; no result event written to $out)" >&2
+    else
+      echo "[dm-attempt] DM turn failed (rc=$rc; no parseable result event in $out)" >&2
+    fi
+    return 0
+  fi
+  echo "[dm-attempt] DM turn failed (rc=$rc):${status:+ HTTP $status}${reason:+ $reason}" >&2
+  case "$status" in
+    401|403) echo "[dm-attempt] -> HTTP $status is an AUTH failure and is NOT retryable: check 'claude' login / ANTHROPIC_API_KEY (apiKeySource was likely \"none\"). The retry will also fail until auth is restored." >&2 ;;
+  esac
+  return 0
+}
+
 # Read the run's progression facts from the snapshot in ONE python pass. Echoes a single
 # TAB-separated line:  day <TAB> time_of_day <TAB> visited_count <TAB> npcs_met <TAB>
 # current_location_id <TAB> current_location_visited(0/1) <TAB> combat_active(0/1)

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -150,7 +150,19 @@ turn() {
 # silently truncate a run). Echoes the reply text (possibly empty after the retry).
 turn_retry() {
   local r; r="$(turn "$@")"
-  [ -z "$r" ] && { echo "[duo] empty turn ($1) — retrying once…" >&2; r="$(turn "$@")"; }
+  if [ -z "$r" ]; then
+    echo "[duo] empty turn ($1) — retrying once…" >&2
+    # A cold-open ($3=1) retry must NOT reuse $2's already-registered --session-id (a failed but
+    # registered attempt → "Session ID … is already in use." → empty output again). Re-mint a fresh
+    # id for the retry. Continuing beats ($3=0) use --resume (safe to repeat); lean continuing beats
+    # already mint their own fresh id inside turn(), so only the cold open needs a swap here.
+    if [ "${3:-}" = "1" ]; then
+      local _fresh; _fresh="$(uuidgen 2>/dev/null || python3 -c 'import uuid;print(uuid.uuid4())')"
+      r="$(turn "$1" "$_fresh" "$3" "${@:4}")"
+    else
+      r="$(turn "$@")"
+    fi
+  fi
   printf '%s' "$r"
 }
 

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -245,14 +245,22 @@ dm_turn() {
   }
   _dm_invoke; rc=$?
   if [ "$rc" -ne 0 ]; then
-    # timeout(1) exits 124 on the deadline; any nonzero gets ONE retry. A retried lean beat
-    # mints a NEW fresh session id (never replay a half-written transcript).
-    echo "[play] DM turn rc=$rc (timeout=${CLAWDND_BEAT_TIMEOUT}s) — retrying once" >&2
-    # A retried lean beat mints a NEW fresh session id (never replay a half-written transcript);
-    # re-call the shared helper so the re-mint stays in lock-step with the lean path above. The
-    # re-ground directive ($extra) is unchanged, so we only refresh the session id here.
+    # Surface attempt 1's REAL error (it's a stdout result event in $out; only stderr reaches
+    # $DM_LOG.err, so without this the run log shows just a downstream "Session ID … in use").
+    clawdnd_report_attempt_failure "$out" "$rc"
+    # timeout(1) exits 124 on the deadline; any nonzero gets ONE retry — on a FRESH session id. A
+    # failed attempt STILL registered its --session-id, so reusing it dies "Session ID … is already
+    # in use." → 0-byte → empty narration. A lean beat re-mints via clawdnd_dm_lean_args; the
+    # cold-open / legacy --resume path re-mints via clawdnd_dm_remint_session_on_retry. (The
+    # re-ground directive $extra is unchanged — we only refresh the session id.)
+    echo "[play] DM turn rc=$rc (timeout=${CLAWDND_BEAT_TIMEOUT}s) — retrying once with a fresh session" >&2
     clawdnd_dm_lean_args "$first" "$campaign_id" "$CLAWDND_LEAN_TAIL"
-    [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ] && resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
+    if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
+      resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
+    else
+      clawdnd_dm_remint_session_on_retry ${resume[@]+"${resume[@]}"}
+      [ "${#CLAWDND_DM_RETRY_SESSION[@]}" -gt 0 ] && resume=("${CLAWDND_DM_RETRY_SESSION[@]}")
+    fi
     out="$DM_LOG.$(date +%s%N).jsonl"
     _dm_invoke; rc=$?
     [ "$rc" -ne 0 ] && echo "[play] DM turn retry also rc=$rc — relying on engine-logged narration" >&2

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -251,9 +251,31 @@ turn() {
     # the companion facade branch below never gets --effort (nor the lean re-ground).
     clawdnd_dm_effort_arg "$first"
     out="$DM_LOG.$(date +%s%N).jsonl"
-    claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
-      --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
-      --output-format stream-json --verbose > "$out" 2>> "$DM_LOG.err"
+    # DM turn with ONE retry (parity with scripts/play.sh dm_turn — play_party is the native app's
+    # entry point and previously had NO DM retry, so a transient cold-open failure was permanent).
+    local rc
+    _dm_invoke() {
+      claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+        --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+        --output-format stream-json --verbose > "$out" 2>> "$DM_LOG.err"
+    }
+    _dm_invoke; rc=$?
+    if [ "$rc" -ne 0 ]; then
+      # Surface attempt 1's real error, then retry ONCE on a FRESH session id — never reuse a
+      # consumed --session-id ("Session ID … is already in use."). Lean re-mints itself; the
+      # cold-open / --resume path re-mints via the shared helper. ($extra is unchanged.)
+      clawdnd_report_attempt_failure "$out" "$rc"
+      echo "[play-party] DM turn rc=$rc — retrying once with a fresh session" >&2
+      clawdnd_dm_lean_args "$first" "${CAMPAIGN_ID:-}" "$CLAWDND_LEAN_TAIL"
+      if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
+        resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
+      else
+        clawdnd_dm_remint_session_on_retry ${resume[@]+"${resume[@]}"}
+        [ "${#CLAWDND_DM_RETRY_SESSION[@]}" -gt 0 ] && resume=("${CLAWDND_DM_RETRY_SESSION[@]}")
+      fi
+      out="$DM_LOG.$(date +%s%N).jsonl"
+      _dm_invoke; rc=$?
+    fi
     cat "$out" >> "$COMBINED"
     jq -rs 'map(select(.type=="result"))[-1].result // ""' "$out" 2>/dev/null
   else

--- a/servers/engine/tests/test_dm_session_remint.py
+++ b/servers/engine/tests/test_dm_session_remint.py
@@ -1,0 +1,109 @@
+"""Regression: the DM-turn retry must RE-MINT the session id, never reuse a consumed one.
+
+Root cause this guards (forensics 2026-06-02, 3 reproduced runs): the cold-open ``claude -p``
+attempt 1 failed (a 401 auth error in all 3 runs) but had ALREADY registered its ``--session-id``
+on disk; the ONE retry re-passed that SAME ``--session-id``, which ``claude -p`` rejects
+("Session ID <uuid> is already in use.") -> 0-byte output -> empty DM narration -> the cold open
+never completes / ``can_act`` never flips. The fix is the shared helper
+``clawdnd_dm_remint_session_on_retry`` (qa/lib_beat_driver.sh), wired into the retry of
+scripts/play.sh + scripts/play_party.sh and qa/run_duo.sh's ``turn_retry``, plus
+``clawdnd_report_attempt_failure`` which stops the masking by surfacing attempt 1's real error.
+
+NOTE: the single-flight launch lock (a DIFFERENT, concurrent-launch concern) is owned by PR #564
+(scripts/launch_common.sh) and intentionally NOT duplicated here.
+
+These tests are gateway-free, need no live ``claude``/network/engine, and exercise the REAL bash
+helpers under ``/bin/bash`` (macOS system bash is 3.2; the helpers are 3.2-clean, so this also
+guards 3.2 compatibility). Discovered + run in CI via ``servers/engine`` pytest.
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+LIB = ROOT / "qa" / "lib_beat_driver.sh"
+
+
+def _bash(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["/bin/bash", "-c", script], capture_output=True, text=True, cwd=str(ROOT)
+    )
+
+
+def _src(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+# --- behavioral: the helper itself -----------------------------------------------------------
+
+def test_remint_returns_fresh_id_for_create_mode_and_nothing_for_resume():
+    """--session-id (a CREATE) -> a NEW --session-id; --resume -> untouched (empty)."""
+    script = (
+        f'set -u; . "{LIB}"\n'
+        'clawdnd_dm_remint_session_on_retry --session-id OLD-UUID\n'
+        'echo "create:${CLAWDND_DM_RETRY_SESSION[*]:-EMPTY}"\n'
+        'clawdnd_dm_remint_session_on_retry --resume OLD-UUID\n'
+        'echo "resume:${CLAWDND_DM_RETRY_SESSION[*]:-EMPTY}"\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    create_line = next(ln for ln in r.stdout.splitlines() if ln.startswith("create:"))
+    # create-mode re-mints a --session-id with a FRESH id that is NOT the consumed one.
+    assert create_line.startswith("create:--session-id "), r.stdout
+    assert "OLD-UUID" not in create_line, "retry must NOT reuse the consumed session id"
+    # resume-mode is left untouched (no re-mint -> empty array).
+    assert "resume:EMPTY" in r.stdout, r.stdout
+
+
+def test_remint_two_retries_yield_distinct_ids():
+    """Real uuid path (no shim): two re-mints must differ -> proves genuine uniqueness."""
+    script = (
+        f'set -u; . "{LIB}"\n'
+        'clawdnd_dm_remint_session_on_retry --session-id OLD; a="${CLAWDND_DM_RETRY_SESSION[1]}"\n'
+        'clawdnd_dm_remint_session_on_retry --session-id OLD; b="${CLAWDND_DM_RETRY_SESSION[1]}"\n'
+        'echo "a=$a"; echo "b=$b"; [ -n "$a" ] && [ "$a" != "$b" ] && echo DISTINCT || echo SAME\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    assert "DISTINCT" in r.stdout, r.stdout
+
+
+def test_report_attempt_failure_names_a_401_auth_error(tmp_path):
+    """A failed attempt's 401 must be surfaced (it was masked as a phantom session collision)."""
+    fake = tmp_path / "attempt.jsonl"
+    fake.write_text(
+        '{"type":"system","subtype":"init","apiKeySource":"none"}\n'
+        '{"type":"result","subtype":"success","is_error":true,"api_error_status":401,'
+        '"result":"Failed to authenticate. API Error: 401 Invalid authentication credentials"}\n'
+    )
+    r = _bash(f'set -u; . "{LIB}"; clawdnd_report_attempt_failure "{fake}" 1')
+    assert r.returncode == 0, r.stderr
+    # The message goes to stderr; it must name the 401 and flag it as a non-retryable AUTH failure.
+    assert "401" in r.stderr, r.stderr
+    assert "AUTH" in r.stderr.upper(), r.stderr
+
+
+# --- static contract: anti-drift across all three harnesses ----------------------------------
+
+def test_shared_helpers_exist_and_only_remint_create_mode():
+    lib = _src("qa/lib_beat_driver.sh")
+    assert "clawdnd_dm_remint_session_on_retry()" in lib
+    assert "CLAWDND_DM_RETRY_SESSION" in lib
+    assert 'if [ "${1:-}" = "--session-id" ]; then' in lib
+    assert "clawdnd_report_attempt_failure()" in lib
+
+
+def test_all_three_harnesses_remint_on_retry():
+    """The line whose ABSENCE was the bug must be present in every cold-open retry path."""
+    play, party, duo = _src("scripts/play.sh"), _src("scripts/play_party.sh"), _src("qa/run_duo.sh")
+    # play.sh + play_party.sh route their non-lean retry through the shared re-mint + error helper.
+    for name, src in (("play.sh", play), ("play_party.sh", party)):
+        assert "clawdnd_dm_remint_session_on_retry" in src, name
+        assert "CLAWDND_DM_RETRY_SESSION" in src, name
+        assert "clawdnd_report_attempt_failure" in src, name
+    # play_party.sh gained a DM retry it did not have before.
+    assert "retrying once with a fresh session" in party
+    # run_duo.sh's cold-open ($3=1) retry mints a fresh id rather than reusing $2.
+    assert 'if [ "${3:-}" = "1" ]; then' in duo
+    assert 'turn "$1" "$_fresh" "$3" "${@:4}"' in duo


### PR DESCRIPTION
## TL;DR
The DM cold-open could end with **empty narration** and `dm.err` showing only `Error: Session ID <uuid> is already in use.` — which looked like a multi-supervisor concurrency race. **It isn't.** It's a single-process bug: the cold-open retry **reuses a session id that the failed first attempt already registered**, and that collision **masks the attempt's real error**. This PR re-mints the session id on retry (in all three harnesses) and surfaces the true failure cause. Additive; happy path is byte-identical.

## Root cause (forensics — 3 reproduced runs, 2026-06-02)
Decisive artifacts: `play-state/{smoke-clean-093152, play-20260602022602, play-20260531160253}/`.

1. The cold-open `claude -p` **attempt 1 fails** — in **all 3** runs with `result.is_error=true, api_error_status=401, "Failed to authenticate"`, `apiKeySource:"none"` (i.e. `claude -p` had **no credential**).
2. That failed attempt **still registered its `--session-id`** at startup — verified on disk: `~/.claude/projects/-Users-lume-ClawDnD-val/1C741477-….jsonl` **exists**.
3. The single retry in `dm_turn` **re-passes the same `--session-id "$DSID"`** — only the lean/continuing-beat path re-minted; the cold-open path did not. `claude -p` rejects it → **"Session ID … is already in use."** → 0-byte output → empty narration → `can_act` never flips (the `#356` `no_provider` gate).
4. `dm.err` shows **only** the collision because attempt 1's real error is a **stdout** result event; stderr (→ `dm.err`) only carries the retry's line. **The retry-reuse masks the true cause.**

Why it looked like a race: `dm.combined.jsonl` is **0 bytes** (only happens with *one* `dm_turn` doing attempt+retry, since `cat "$out" >> "$COMBINED"` runs once on the reassigned 0-byte retry `$out`); and the "4× `play.sh` procs" are the normal subshell fan-out of one run (`$(dm_turn …)` + `viewer_supervisor` + browser-open). `play.sh:109` mints a unique `$DSID` per process, so two supervisors could never collide on `--session-id` anyway.

Latency note: the retry block dates to #417; `--effort max` on cold-open (#551) makes attempt-1 failure likelier in general, but here attempt 1 fails on **auth**, not effort.

## What changed (additive; only the failing-retry path differs)
- **`qa/lib_beat_driver.sh`** — two shared helpers (one implementation so the harnesses can't drift):
  - `clawdnd_dm_remint_session_on_retry` — re-mint a **fresh `--session-id`** when the prior attempt used `--session-id` (a CREATE); leave `--resume` untouched (safe to repeat).
  - `clawdnd_report_attempt_failure` — surface attempt 1's real error to the run log; flag `401/403` as a **non-retryable auth** failure with an operator hint.
- **`scripts/play.sh`** `dm_turn`, **`scripts/play_party.sh`** `turn` (which had **no DM retry at all** — and is the native app's entry point), **`qa/run_duo.sh`** `turn_retry` — retry on a **fresh** session id, never reuse a consumed one.
- **`servers/engine/tests/test_dm_session_remint.py`** — behavioral (drives the real bash helpers under `/bin/bash`) + static-contract (anti-drift across all 3 harnesses). Gateway-free, no live `claude`/network → runs in CI under `servers/engine`.

## What this does NOT do
It does **not** authenticate `claude -p`. On a no-credential host the cold open still ends empty — but now **honestly** (`HTTP 401 … check claude login / ANTHROPIC_API_KEY`) instead of the misleading session collision. **Restoring `claude` auth on the QA / clean-isolated host is the separate release-sweep unblock** (all 3 reproduced runs were 401).

## Relationship to #564
#564 adds the **concurrent-launch single-flight lock** (`scripts/launch_common.sh`, wired into `play_party.sh`) — a real, *orthogonal* defense (two supervisors on one run dir). It does **not** fix this single-process retry-reuse. The two PRs touch **different files/functions** and merge cleanly; this one is the actual root-cause fix for the reproduced "Session ID already in use" symptom.

## Testing
- `uv run --directory servers/engine --group dev python -m pytest tests/test_dm_session_remint.py -q -p no:xdist` → **5 passed**.
- `… ../../qa/test_release_gate_static.py …` (reads play.sh/play_party.sh) → **10 passed + 2 subtests** (unchanged contracts).
- `bash -n` clean on all 4 scripts; helpers source + define cleanly under bash 3.2. `SC2034 "appears unused"` on `CLAWDND_DM_RETRY_SESSION` matches the 3 pre-existing populate-a-global helpers (cross-file pattern).
- End-to-end cold-open completion needs a `claude`-authenticated host (this host is unauthenticated — the bug); not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)