### PR TITLE
qa: cold-open-specific DM-turn timeout (max-effort world-build ~280-400s exceeds the 200s default)

### DIFF
--- a/qa/dryrun_coldopen_timeout_proof.sh
+++ b/qa/dryrun_coldopen_timeout_proof.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# DRY-RUN PROOF (no model call): shows that the DM-turn `timeout` deadline is now TIERED off the
+# cold-open `first` signal via the SHARED helper clawdnd_dm_timeout (qa/lib_beat_driver.sh), the
+# sibling of clawdnd_dm_effort_arg. The cold open's --effort max world-build runs ~280–400s, so the
+# routine 200s deadline was KILLING it; the cold open now gets WORLDOS_COLDOPEN_TIMEOUT (default
+# 400s) while continuing/routine beats keep CLAWDND_BEAT_TIMEOUT (default 200s, unchanged).
+#
+# It sources the REAL qa/lib_beat_driver.sh and reproduces BOTH product cold-open paths' DM-turn
+# `timeout` wrapper VERBATIM — scripts/play.sh dm_turn AND scripts/play_party.sh turn() — plus the
+# player / companion facade turn (which is NEVER wrapped in a per-beat timeout), with a stub
+# `timeout`+`claude` that just prints the argv they would have run. We assert:
+#   (1) the COLD-OPEN DM argv is `timeout 400 claude …`  (default cold-open deadline);
+#   (2) a ROUTINE/continuing DM argv is `timeout 200 claude …`  (routine deadline, unchanged);
+#   (3) the env override works:  WORLDOS_COLDOPEN_TIMEOUT bumps the cold open, CLAWDND_BEAT_TIMEOUT
+#       bumps the routine tier, independently;
+#   (4) the PLAYER / COMPANION turn argv has NO `timeout` wrapper at all (player turn unaffected);
+#   (5) the SAME resolved deadline (not the stale global) is echoed in the retry log line.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/qa/lib_beat_driver.sh"
+
+DSID="DSID-fixed-0000"; PSID="PSID-fixed-0000"; CSID="CSID-fixed-0000"
+CAMPAIGN_ID="camp-abc123"
+CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
+DM_CFG="/tmp/dm.mcp.json"; PLAYER_CFG="/tmp/player.mcp.json"; COMP_CFG="/tmp/companion_0.mcp.json"
+CLAWDND_DM_MODEL="sonnet"; CLAWDND_ACTOR_MODEL="sonnet"; BUDGET="1.50"
+
+# Stub `claude`: print the exact argv (each arg in «»). Stub `timeout`: print TIMEOUT-WRAP <secs>
+# then exec-through to the stubbed claude with the REST of the argv — so the proof shows the
+# deadline AND the wrapped command exactly as the real `timeout <secs> claude …` would run.
+claude() { printf 'CLAUDE-ARGV-BEGIN\n'; local a; for a in "$@"; do printf '  «%s»\n' "$a"; done; printf 'CLAUDE-ARGV-END\n'; }
+timeout() { printf 'TIMEOUT-WRAP «%s»\n' "$1"; shift; "$@"; }
+
+# ---- VERBATIM: scripts/play.sh dm_turn() argv assembly (the timeout-wrapped invoke) -----------
+# Mirrors dm_turn: lean args -> effort arg -> beat_timeout via the shared helper -> the
+# `timeout "$beat_timeout" claude -p …` wrapper. Sinks (> "$out", retry, jq) dropped. $1=first $2=msg
+play_dm_turn_argv() {
+  local first="$1" msg="$2" campaign_id="${CAMPAIGN_ID:-}" resume=() extra=() beat_timeout
+  clawdnd_dm_lean_args "$first" "$campaign_id" "$CLAWDND_LEAN_TAIL"
+  if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
+    resume=("${CLAWDND_DM_LEAN_SESSION[@]}"); extra=("${CLAWDND_DM_LEAN_EXTRA[@]}")
+  elif [ "$first" = "0" ]; then resume=(--resume "$DSID"); else resume=(--session-id "$DSID"); fi
+  clawdnd_dm_effort_arg "$first"
+  beat_timeout="$(clawdnd_dm_timeout "$first")"
+  timeout "$beat_timeout" \
+    claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+      --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+      --output-format stream-json --verbose
+  # Prove the retry log line uses the resolved $beat_timeout, not the stale global.
+  printf 'RETRY-LOG-LINE: [play] DM turn rc=124 (timeout=%ss) — retrying once with a fresh session\n' "$beat_timeout"
+}
+
+# ---- VERBATIM: scripts/play_party.sh turn() DM-branch argv assembly (newly timeout-wrapped) ----
+# $1=first $2=msg ; companion branch ($kind=actor) is NEVER timeout-wrapped (player untouched).
+party_turn_argv() {
+  local kind="$1" first="$2" msg="$3" sid="$4" cfg="${5:-}" resume=() extra=() beat_timeout
+  [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
+  if [ "$kind" = "dm" ]; then
+    clawdnd_dm_lean_args "$first" "${CAMPAIGN_ID:-}" "$CLAWDND_LEAN_TAIL"
+    if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
+      resume=("${CLAWDND_DM_LEAN_SESSION[@]}"); extra=("${CLAWDND_DM_LEAN_EXTRA[@]}")
+    fi
+    clawdnd_dm_effort_arg "$first"
+    beat_timeout="$(clawdnd_dm_timeout "$first")"
+    timeout "$beat_timeout" \
+      claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+        --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+        --output-format stream-json --verbose
+  else
+    # Companion facade: NO timeout wrapper — exactly as today.
+    claude -p "$msg" "${resume[@]}" --mcp-config "$cfg" --strict-mcp-config \
+      --model "$CLAWDND_ACTOR_MODEL" --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+      --output-format stream-json --verbose
+  fi
+}
+
+hr() { printf '\n========== %s ==========\n' "$1"; }
+
+hr "S1 play.sh COLD OPEN (first=1), no env -> timeout 400"
+out1="$(play_dm_turn_argv 1 'Begin the session.')"; printf '%s\n' "$out1"
+hr "S2 play.sh ROUTINE beat (first=0), no env -> timeout 200"
+out2="$(play_dm_turn_argv 0 'The player does: opens the door.')"; printf '%s\n' "$out2"
+hr "S3 play.sh COLD OPEN + WORLDOS_COLDOPEN_TIMEOUT=600 -> timeout 600"
+out3="$(WORLDOS_COLDOPEN_TIMEOUT=600 play_dm_turn_argv 1 'Begin the session.')"; printf '%s\n' "$out3"
+hr "S4 play.sh ROUTINE + CLAWDND_BEAT_TIMEOUT=150 -> timeout 150 (cold open unaffected)"
+out4="$(CLAWDND_BEAT_TIMEOUT=150 play_dm_turn_argv 0 'The player does: opens the door.')"; printf '%s\n' "$out4"
+hr "S5 play_party.sh COLD OPEN DM (first=1) -> timeout 400"
+out5="$(party_turn_argv dm 1 'You are the Dungeon Master. Begin.' "$DSID")"; printf '%s\n' "$out5"
+hr "S6 play_party.sh ROUTINE DM beat (first=0) -> timeout 200"
+out6="$(party_turn_argv dm 0 'This beat, the party acts.' "$DSID")"; printf '%s\n' "$out6"
+hr "S7 play_party.sh COMPANION facade turn -> NO timeout wrapper (player turn unaffected)"
+out7="$(party_turn_argv actor 0 'Take your action through your tools.' "$CSID" "$COMP_CFG")"; printf '%s\n' "$out7"
+
+# ---- Assertions -------------------------------------------------------------------
+hr "ASSERTIONS"
+fail=0
+chk() { if eval "$2"; then echo "PASS: $1"; else echo "FAIL: $1"; fail=1; fi; }
+
+# (1) cold open -> 400; (2) routine -> 200; and the cold open is NOT 200 (the bug it fixes).
+chk "S1 play.sh cold open wraps timeout 400"     'printf "%s" "$out1" | grep -q -- "TIMEOUT-WRAP «400»"'
+chk "S1 play.sh cold open is NOT timeout 200"     '! printf "%s" "$out1" | grep -q -- "TIMEOUT-WRAP «200»"'
+chk "S1 play.sh cold open still has --effort max" 'printf "%s" "$out1" | grep -A1 -- "«--effort»" | grep -q -- "«max»"'
+chk "S2 play.sh routine wraps timeout 200"       'printf "%s" "$out2" | grep -q -- "TIMEOUT-WRAP «200»"'
+chk "S2 play.sh routine still --effort medium"    'printf "%s" "$out2" | grep -A1 -- "«--effort»" | grep -q -- "«medium»"'
+# (3) env overrides, independent per tier.
+chk "S3 WORLDOS_COLDOPEN_TIMEOUT=600 -> timeout 600" 'printf "%s" "$out3" | grep -q -- "TIMEOUT-WRAP «600»"'
+chk "S4 CLAWDND_BEAT_TIMEOUT=150 -> routine timeout 150" 'printf "%s" "$out4" | grep -q -- "TIMEOUT-WRAP «150»"'
+# (5) retry log line uses the RESOLVED deadline (400 on the cold open, 200 on routine) — not stale.
+chk "S1 retry log line says timeout=400s"        'printf "%s" "$out1" | grep -q -- "timeout=400s"'
+chk "S2 retry log line says timeout=200s"        'printf "%s" "$out2" | grep -q -- "timeout=200s"'
+# play_party parity.
+chk "S5 play_party cold open wraps timeout 400"  'printf "%s" "$out5" | grep -q -- "TIMEOUT-WRAP «400»"'
+chk "S6 play_party routine wraps timeout 200"    'printf "%s" "$out6" | grep -q -- "TIMEOUT-WRAP «200»"'
+# (4) the player / companion facade turn is NEVER timeout-wrapped (player turn unaffected).
+chk "S7 companion turn has NO timeout wrapper"   '! printf "%s" "$out7" | grep -q -- "TIMEOUT-WRAP"'
+chk "S7 companion turn still runs claude"        'printf "%s" "$out7" | grep -q -- "CLAUDE-ARGV-BEGIN"'
+
+hr "RESULT"
+[ "$fail" = 0 ] && echo "ALL ASSERTIONS PASSED" || echo "SOME ASSERTIONS FAILED"
+exit "$fail"

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -182,6 +182,40 @@ clawdnd_dm_effort_arg() {
   CLAWDND_DM_EFFORT=(--effort "$level")
 }
 
+# DM-TURN TIMEOUT TIER (the ONE shared implementation of the cold-open-vs-routine timeout split).
+#
+# Both play loops wrap the DM's `claude -p` in `timeout <secs>` + ONE retry, so a wedged turn
+# recovers instead of hanging the session. But the two kinds of beat need very different deadlines,
+# for the SAME reason the effort tier splits them (clawdnd_dm_effort_arg, keyed off `first`):
+#   • the COLD OPEN (first != 0) is the one-time, --effort max, full world-build — generate the
+#     world, scene, PC, opening NPCs + portraits. That MAX-EFFORT cold open routinely runs ~280–400s;
+#     the routine 200s deadline KILLS it mid-build (the masked "cold-open reproducibly broken" mode),
+#     so the cold open gets a generous deadline: WORLDOS_COLDOPEN_TIMEOUT (default 400s).
+#   • CONTINUING / routine beats (first = 0) are --effort medium and resolve one move against
+#     established canon — fast — so they keep the existing per-beat deadline CLAWDND_BEAT_TIMEOUT
+#     (default 200s), unchanged. (Routine behavior is byte-identical to today.)
+# Keyed off the SAME `first` signal as the effort + lean levers, so cold-open=full+max+400s and the
+# long tail=lean+medium+200s stay in lock-step. Applies ONLY to the DM turn (player/companion turns
+# are never wrapped in a per-beat timeout at all).
+#
+# Both knobs resolve through the same WORLDOS_/CLAWDND_ fallback as everything else (worldos_env):
+#   WORLDOS_COLDOPEN_TIMEOUT (default 400) — the cold open's deadline, in seconds.
+#   CLAWDND_BEAT_TIMEOUT     (default 200) — every continuing beat's deadline (today's knob, kept).
+# Note: CLAWDND_BEAT_TIMEOUT keeps its CLAWDND_ name (it predates the WorldOS rename and is the
+# documented routine knob); only the NEW cold-open knob takes the WORLDOS_ name. worldos_env still
+# honors a WORLDOS_BEAT_TIMEOUT override of the routine tier for forward-compat.
+#
+# Unlike the effort/lean helpers (which populate an array spliced into argv), this just ECHOES the
+# resolved seconds — the caller uses it as the scalar `timeout <secs>` argument. $1 = first?(1/0)
+clawdnd_dm_timeout() {
+  local first="$1"
+  if [ "$first" != "0" ]; then
+    worldos_env COLDOPEN_TIMEOUT 400
+  else
+    worldos_env BEAT_TIMEOUT 200
+  fi
+}
+
 # RE-MINT SESSION ON RETRY (the ONE shared implementation of "never reuse a CONSUMED session id").
 # A `claude -p` attempt that fails AFTER startup STILL registered its --session-id on disk
 # (~/.claude/projects/<proj>/<uuid>.jsonl), so a retry that re-passes that SAME --session-id dies

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -67,8 +67,13 @@ DM_TURNS=0
 # path (byte-identical to the pre-lean behavior) — still fully reversible per-run. A/B harness:
 # qa/lib/lean_beats_check.sh.
 CLAWDND_LEAN_BEATS="${CLAWDND_LEAN_BEATS:-1}"
-# Per-beat backend timeout (seconds) + ONE retry, so a wedged DM turn recovers instead of
-# hanging the session. Applies in BOTH modes (it only wraps the existing claude -p call).
+# Per-beat backend timeout (seconds) + ONE retry, so a wedged DM turn recovers instead of hanging
+# the session. The deadline is TIERED off the cold-open `first` signal (clawdnd_dm_timeout in
+# qa/lib_beat_driver.sh, the sibling of the effort tier): the cold open's --effort max world-build
+# runs ~280–400s so it gets WORLDOS_COLDOPEN_TIMEOUT (default 400s); continuing/routine beats keep
+# CLAWDND_BEAT_TIMEOUT (default 200s, unchanged). Both knobs are read inside dm_turn via the helper;
+# this line documents the routine default. Applies in BOTH lean/legacy modes (it only wraps the
+# existing claude -p call) and ONLY to the DM turn.
 CLAWDND_BEAT_TIMEOUT="${CLAWDND_BEAT_TIMEOUT:-200}"
 # Recent player-facing narration tail the lean re-ground asks scene_context for (generous by
 # default so continuity survives the lean boundary — named NPCs, prior choices, the scene).
@@ -213,11 +218,14 @@ fi
 #     narration tail) and honor every established fact/name/voice as canon it already
 #     authored. $3 (campaign_id) lets the directive name the exact id to pass to
 #     scene_context; on beat 1, or when $3 is empty, lean is a no-op (we mint/resume $DSID).
-# A per-beat timeout (CLAWDND_BEAT_TIMEOUT) wraps the claude -p in BOTH modes; ONE retry on
-# timeout/failure, then the caller's #357 fallback recovers any prose the DM streamed live.
-# Echoes the DM's final text.
+# A per-beat timeout wraps the claude -p in BOTH modes; ONE retry on timeout/failure, then the
+# caller's #357 fallback recovers any prose the DM streamed live. The deadline is TIERED off the
+# SAME `first` cold-open signal as the effort tier (clawdnd_dm_timeout, qa/lib_beat_driver.sh): the
+# cold open (first=1) is the --effort max world-build that runs ~280–400s, so it gets a generous
+# WORLDOS_COLDOPEN_TIMEOUT (default 400s) instead of the 200s that was KILLING it; continuing beats
+# keep CLAWDND_BEAT_TIMEOUT (default 200s). Echoes the DM's final text.
 dm_turn() {
-  local first="$1" msg="$2" campaign_id="${3:-}" out resume=() extra=() rc
+  local first="$1" msg="$2" campaign_id="${3:-}" out resume=() extra=() rc beat_timeout
   # The lean-beat path (fresh session + re-ground directive) is the ONE shared implementation
   # in qa/lib_beat_driver.sh — qa/run_duo.sh drives the SAME helper, so the two harnesses can't
   # drift. It populates CLAWDND_DM_LEAN_{SESSION,EXTRA} when this is a continuing beat AND
@@ -236,9 +244,13 @@ dm_turn() {
   # one-time world-build), --effort medium on continuing beats (the bulk — cuts thinking-latency).
   # Keyed off the SAME `first` signal as lean. DM turn ONLY (the player facade never gets --effort).
   clawdnd_dm_effort_arg "$first"
+  # TIMEOUT TIER (shared helper, qa/lib_beat_driver.sh): the cold open's max-effort world-build runs
+  # ~280–400s, so it gets WORLDOS_COLDOPEN_TIMEOUT (default 400s); continuing beats keep
+  # CLAWDND_BEAT_TIMEOUT (default 200s). Keyed off the SAME `first` signal as the effort tier above.
+  beat_timeout="$(clawdnd_dm_timeout "$first")"
   out="$DM_LOG.$(date +%s%N).jsonl"
   _dm_invoke() {
-    timeout "$CLAWDND_BEAT_TIMEOUT" \
+    timeout "$beat_timeout" \
       claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
         --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
         --output-format stream-json --verbose > "$out" 2>> "$DM_LOG.err"
@@ -253,7 +265,7 @@ dm_turn() {
     # in use." → 0-byte → empty narration. A lean beat re-mints via clawdnd_dm_lean_args; the
     # cold-open / legacy --resume path re-mints via clawdnd_dm_remint_session_on_retry. (The
     # re-ground directive $extra is unchanged — we only refresh the session id.)
-    echo "[play] DM turn rc=$rc (timeout=${CLAWDND_BEAT_TIMEOUT}s) — retrying once with a fresh session" >&2
+    echo "[play] DM turn rc=$rc (timeout=${beat_timeout}s) — retrying once with a fresh session" >&2
     clawdnd_dm_lean_args "$first" "$campaign_id" "$CLAWDND_LEAN_TAIL"
     if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
       resume=("${CLAWDND_DM_LEAN_SESSION[@]}")

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -258,14 +258,24 @@ turn() {
     # (the bulk — cuts thinking-latency). Keyed off the SAME `first` signal as lean. DM turn ONLY —
     # the companion facade branch below never gets --effort (nor the lean re-ground).
     clawdnd_dm_effort_arg "$first"
+    # TIMEOUT TIER (shared helper, qa/lib_beat_driver.sh) — SAME implementation scripts/play.sh's
+    # dm_turn uses: the cold open's --effort max world-build runs ~280–400s, so it gets
+    # WORLDOS_COLDOPEN_TIMEOUT (default 400s); continuing beats get CLAWDND_BEAT_TIMEOUT (default
+    # 200s). Keyed off the SAME `first` signal as the effort tier above. This wraps the DM turn in
+    # `timeout` (parity with play.sh dm_turn — play_party is the native app's entry point and
+    # previously had NO per-beat deadline, so a wedged DM turn could hang the session indefinitely;
+    # the one-retry below recovers a transient timeout). DM turn ONLY — the companion facade never
+    # gets a per-beat timeout.
+    local beat_timeout; beat_timeout="$(clawdnd_dm_timeout "$first")"
     out="$DM_LOG.$(date +%s%N).jsonl"
     # DM turn with ONE retry (parity with scripts/play.sh dm_turn — play_party is the native app's
     # entry point and previously had NO DM retry, so a transient cold-open failure was permanent).
     local rc
     _dm_invoke() {
-      claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
-        --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
-        --output-format stream-json --verbose > "$out" 2>> "$DM_LOG.err"
+      timeout "$beat_timeout" \
+        claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+          --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+          --output-format stream-json --verbose > "$out" 2>> "$DM_LOG.err"
     }
     _dm_invoke; rc=$?
     if [ "$rc" -ne 0 ]; then
@@ -273,7 +283,7 @@ turn() {
       # consumed --session-id ("Session ID … is already in use."). Lean re-mints itself; the
       # cold-open / --resume path re-mints via the shared helper. ($extra is unchanged.)
       clawdnd_report_attempt_failure "$out" "$rc"
-      echo "[play-party] DM turn rc=$rc — retrying once with a fresh session" >&2
+      echo "[play-party] DM turn rc=$rc (timeout=${beat_timeout}s) — retrying once with a fresh session" >&2
       clawdnd_dm_lean_args "$first" "${CAMPAIGN_ID:-}" "$CLAWDND_LEAN_TAIL"
       if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
         resume=("${CLAWDND_DM_LEAN_SESSION[@]}")


### PR DESCRIPTION
## Problem

The DM turn wraps `claude -p` in `timeout <secs>` so a wedged turn recovers instead of hanging the session (`scripts/play.sh` ~L72/L244). But ONE flat deadline — `CLAWDND_BEAT_TIMEOUT` (default **200s**) — was applied to **every** beat, including the **cold open** (beat 1, `--effort max`, the full world-build). That max-effort cold open routinely runs **~280–400s**, so the 200s deadline KILLED it mid-build (one of the masked "cold-open reproducibly broken" modes). Routine medium-effort beats are fast — 200s is fine for them.

## Fix

Tier the deadline off the **same `first` cold-open signal** the effort + lean levers already key on, via a tiny **shared helper** so the play loops can't drift — mirroring the existing `clawdnd_dm_effort_arg` pattern.

- **`qa/lib_beat_driver.sh`** — new `clawdnd_dm_timeout "$first"` (sibling of `clawdnd_dm_effort_arg`): echoes `WORLDOS_COLDOPEN_TIMEOUT` (**default 400**) on the cold open, `CLAWDND_BEAT_TIMEOUT` (**default 200**, unchanged) on continuing beats. Resolves via the same `worldos_env` `WORLDOS_`/`CLAWDND_` fallback as everything else.
- **`scripts/play.sh` `dm_turn`** — resolve `beat_timeout` via the helper, use it in the `timeout` wrapper + the retry log line (was the stale global).
- **`scripts/play_party.sh` `turn()` DM branch** — same helper + `timeout` wrapper.

### Behavior knobs

| beat | env knob | default |
|------|----------|---------|
| cold open (`first=1`) | `WORLDOS_COLDOPEN_TIMEOUT` | **400s** |
| continuing/routine (`first=0`) | `CLAWDND_BEAT_TIMEOUT` | **200s** (unchanged) |

### Scope notes
- Routine behavior is otherwise unchanged; the **player/companion facade turn is never wrapped** in a per-beat timeout. The **retry logic** (re-mints the session id) is untouched.
- **`play_party.sh` delta:** its DM turn previously had **NO per-beat timeout at all**, so this **adds** one (cold open 400s, routine 200s). Net a safety improvement (an unbounded DM turn could hang the session) and brings play_party to parity with `play.sh`'s `dm_turn`. Reviewer should confirm 200s is comfortable for play_party's routine beats — they're lean+medium-effort (fast) and the one-retry recovers a transient timeout, but it's a new deadline where there was none.
- `qa/run_duo.sh` / `qa/run_party.sh` are unchanged (no timeout wrapper today; out of scope — QA loops, not the product cold-open path).

## Verification

- `bash -n` passes on all edited scripts + the new proof.
- New **`qa/dryrun_coldopen_timeout_proof.sh`** (no model call) reproduces both product cold-open paths' `timeout` wrapper *verbatim* with a stub `timeout`+`claude` and asserts: cold-open→`timeout 400`, routine→`timeout 200`, env overrides (`WORLDOS_COLDOPEN_TIMEOUT=600`→600; `CLAWDND_BEAT_TIMEOUT=150`→routine 150, cold open untouched), the retry log uses the resolved deadline, and the companion turn has no wrapper. **13/13 PASS.**
- The existing lean proofs (`dryrun_lean_proof.sh`, `dryrun_lean_proof_play_party.sh`) still pass — no regression from editing the shared lib.

⚠️ Not verified with a live clean-host cold open (no model call in CI / this run). The ~280–400s figure is from the issue context; the fix gives the cold open a 400s ceiling vs the 200s that was killing it, but the real end-to-end timing needs the clean-host cold-open run to confirm.

**Do not merge** — needs review + the clean-host cold-open to confirm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added QA tests validating timeout behavior for DM turns in cold-open vs continuing beat scenarios.

* **Bug Fixes**
  * Implemented tiered timeout limits for DM turn execution: 400-second limit for cold-open beats, 200-second limit for continuing beats. Timeout values configurable via environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->