### PR TITLE
fix(app): Claude lane spawns move-sink viewer with PROVIDER env — unlock play controls (no_provider false-negative)

### DIFF
--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/ProviderAdapters.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/ProviderAdapters.swift
@@ -73,6 +73,18 @@ struct ClaudeProvider: ProviderAdapter {
             environment["CLAWDND_PLAY_HERO"] = trimmedHero
         }
 
+        // Tell the move-sink viewer which provider is driving the run. The viewer's
+        // /app-status readiness gates ALL play controls on a non-empty PROVIDER that is in
+        // {codex, claude, openclaw, scripted} (viewer/server.py: provider_ready + ready_for_play);
+        // without it, /session-surface reports can_act:true but /app-status reports
+        // no_provider, so every action button stays locked ("live provider move sink is not
+        // ready"). The Codex/OpenClaw/scripted lanes set this via providerEnvironment(); the
+        // Claude lane builds its own environment, so set it directly here. We set both the
+        // canonical WORLDOS_ name and the legacy CLAWDND_ name the viewer's env_var() falls
+        // back to, mirroring how the other lanes (and budgetEnvironment) carry both prefixes.
+        environment["WORLDOS_PROVIDER"] = kind.rawValue
+        environment["CLAWDND_PROVIDER"] = kind.rawValue
+
         return ProviderLaunchRequest(
             name: "Claude game",
             executable: "/usr/bin/env",

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -78,6 +78,13 @@ CLAWDND_BEAT_TIMEOUT="${CLAWDND_BEAT_TIMEOUT:-200}"
 # Recent player-facing narration tail the lean re-ground asks scene_context for (generous by
 # default so continuity survives the lean boundary — named NPCs, prior choices, the scene).
 CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
+# Which provider drives this run. The viewer's /app-status readiness gates ALL play controls
+# on a non-empty PROVIDER in {codex,claude,openclaw,scripted} (viewer/server.py: provider_ready
+# + ready_for_play). play.sh IS the Claude play path, so default to "claude" and export it into
+# the viewer launch below; without it /app-status reports no_provider and every action button
+# stays locked even though /session-surface reports can_act:true. Resolves through the same
+# WORLDOS_/CLAWDND_ fallback as everything else, so an explicit env override still wins.
+PROVIDER="$(worldos_env PROVIDER claude)"
 
 # Product play state lives under the repo's play-state/ (git-ignored), one dir per game,
 # so saves, the chat log, and the move sink stay together and out of the QA sandbox.
@@ -301,6 +308,7 @@ viewer_supervisor() {
     WORLDOS_STATE_DIR="$STATE_DIR" CLAWDND_STATE_DIR="$STATE_DIR" \
     WORLDOS_VIEWER_CHAT="$CHAT" CLAWDND_VIEWER_CHAT="$CHAT" \
     WORLDOS_PLAYER_MOVES="$MOVES" CLAWDND_PLAYER_MOVES="$MOVES" \
+    WORLDOS_PROVIDER="$PROVIDER" CLAWDND_PROVIDER="$PROVIDER" \
       python3 viewer/server.py "" "$PORT" >> "$VIEWER_LOG" 2>&1 &
     local vp=$!; echo "$vp" > "$VPID_FILE"
     wait "$vp" 2>/dev/null   # blocks until the viewer exits (and reaps it)

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -77,6 +77,13 @@ CLAWDND_ACTOR_MODEL="${CLAWDND_ACTOR_MODEL:-sonnet}"
 # asks scene_context to fold in (default 8 — SAME as scripts/play.sh + qa/run_duo.sh). Used by
 # the DM turn's clawdnd_dm_lean_args call below; the helper also defaults to 8 if unset.
 CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
+# Which provider drives this run. The viewer's /app-status readiness gates ALL play controls on
+# a non-empty PROVIDER in {codex,claude,openclaw,scripted} (viewer/server.py: provider_ready +
+# ready_for_play). play_party.sh IS the Claude party play path, so default to "claude" and export
+# it into the viewer launch below; without it /app-status reports no_provider and every action
+# button stays locked even though /session-surface reports can_act:true. Resolves through the same
+# WORLDOS_/CLAWDND_ fallback as everything else (worldos_env), so an explicit env override wins.
+PROVIDER="$(worldos_env PROVIDER claude)"
 
 # --- NO companions specified → today's solo human-play, byte-for-byte. -----------------
 # Delegate to scripts/play.sh with the SAME positional args (it ignores any 4th). exec
@@ -368,6 +375,7 @@ VPID_FILE="$STATE_DIR/.viewer.pid"
 viewer_supervisor() {
   while :; do
     CLAWDND_STATE_DIR="$STATE_DIR" CLAWDND_VIEWER_CHAT="$CHAT" CLAWDND_PLAYER_MOVES="$MOVES" \
+    WORLDOS_PROVIDER="$PROVIDER" CLAWDND_PROVIDER="$PROVIDER" \
       python3 viewer/server.py "" "$PORT" >> "$VIEWER_LOG" 2>&1 &
     local vp=$!; echo "$vp" > "$VPID_FILE"
     wait "$vp" 2>/dev/null   # blocks until the viewer exits (and reaps it)


### PR DESCRIPTION
## The dead-end (root cause confirmed by trace)

The .app play screen gates **every action button** on `/app-status` readiness (`ready_for_play`). The viewer that backs the play screen is spawned by the .app's **Claude** adapter (and by `scripts/play.sh` / `scripts/play_party.sh`) **with** `CLAWDND_PLAYER_MOVES` (so `/session-surface` → `can_act:true`) but **without any PROVIDER env**. Result:

- `/session-surface` → `can_act:true`
- `/app-status` → `no_provider` bucket → `ready_for_play=false` → **all controls locked** ("live provider move sink is not ready")

The Codex/OpenClaw/scripted lanes already set the provider env via `providerEnvironment()` (`ProviderAdapters.swift`); the **Claude lane builds its own `environment` and never set it**. A real user on the Claude provider hits this — it's a product bug, not just a test-harness gap.

## Server-side contract (the load-bearing detail this fix matches)

`viewer/server.py`:
- L5552: `provider = env_var("PROVIDER", "") or ""`
- L5459: `provider_ready = bool(live and provider.strip())`
- L5481–5483: empty provider → `no_provider`
- L5501: `ready_for_play = ready_for_smoke and provider.strip().lower() in {"codex","claude","openclaw","scripted"}`

`viewer/_env.py` `env_var("PROVIDER")` resolves **`WORLDOS_PROVIDER`** first, then falls back to legacy **`CLAWDND_PROVIDER`** (one-time deprecation warning). So setting the provider to `claude` makes `provider_ready` true **and** passes the whitelist.

## Fix (additive only — readiness logic untouched)

1. **`ProviderAdapters.swift`** (`ClaudeProvider.startSession`): set `environment["WORLDOS_PROVIDER"]` and `["CLAWDND_PROVIDER"] = kind.rawValue` (`"claude"`) on the spawned viewer, mirroring `providerEnvironment()`.
2. **`scripts/play.sh`**: default `PROVIDER="$(worldos_env PROVIDER claude)"` near the other env defaults + export `WORLDOS_PROVIDER`/`CLAWDND_PROVIDER` into the viewer launch.
3. **`scripts/play_party.sh`**: same (party path; `play.sh` covers the solo `exec` path).

Both names are set because the server prefers `WORLDOS_` and falls back to `CLAWDND_` (setting both avoids the deprecation warning when `WORLDOS_` is present), matching how the other lanes and `budgetEnvironment` carry both prefixes.

## Verification

- `bash -n scripts/play.sh` and `bash -n scripts/play_party.sh`: **pass**.
- Server-side env name confirmed by reading `viewer/server.py:5552` + `viewer/_env.py` (`WORLDOS_PROVIDER` → `CLAWDND_PROVIDER`); the fix sets both with value `claude`.
- `ProviderKind: String` with `case claude` ⇒ `kind.rawValue == "claude"` (matches the whitelist).
- Swift compiles via CI (SwiftPM). Local `swift build` skipped — cold full build is not cheap on this disk-constrained host; relying on CI per the diagnostic plan.

## Still to confirm (do not merge yet)

A live 1-persona re-run must confirm the controls actually **unlock** and a move **reaches the engine** end-to-end. Static + contract analysis is strong but the runtime behavior is the real gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed viewer action buttons remaining disabled when provider configuration was available; buttons now properly unlock when a provider is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->