### PR TITLE
fix: untrack qa/playwright/node_modules symlink (broke VM checkout)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@
 # (qa/ui_playtest.sh), palette MCP server (qa/playwright/palette_server.js + package.json),
 # persona briefs, and scorer ARE committed; only the run outputs + node_modules are ignored.
 /qa/ui_playtest_runs/
-/qa/playwright/node_modules/
+/qa/playwright/node_modules
 /qa/playwright/_*.js
 # The on-demand findings ledger (qa/collect_findings.py output) — a regenerable digest of
 # local QA run scores, derived from the ignored qa/transcripts/. The collector script IS

--- a/qa/playwright/node_modules
+++ b/qa/playwright/node_modules
@@ -1,1 +1,0 @@
-/Users/lume/ClawDnD-val/qa/playwright/node_modules


### PR DESCRIPTION
git add -A tracked a local node_modules symlink → dangling on the VM (playwright MISSING for the part-B proxy). Untrack + tighten the ignore pattern (no trailing slash catches the symlink name). Per-host npm install provisions it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git ignore patterns to exclude build dependencies, ensuring cleaner repository management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->