### PR TITLE
docs(skills): latency-forensics skill + ledger/model/flag/finish capture (last-few-days skillify)

### DIFF
--- a/.claude/skills/worldos-dev/SKILL.md
+++ b/.claude/skills/worldos-dev/SKILL.md
@@ -10,6 +10,16 @@ star: **epic Baldur's-Gate-caliber STORY on a deterministic SRD 5.2 engine**; go
 universe-system that generates worlds. Source-available commercial product, BG-focused. **Read `WorldOS-RUNBOOK.md`
 (repo root) for the full project/architecture/state.** This skill is the operational loop.
 
+> **⚠ HEAVY QA SWEEPS (5-persona / RRI) → USE THE SUPPORT VM, NOT LOCAL.** The 16 GB Mac OOMs mid-sweep
+> (proven 2026-06-02: cratered to 147 M free, personas 2–5 backends never minted, shipped a junk PARTIAL RRI 2.7).
+> Documented lane: **`WorldOS-GUI-RUNBOOK.md` § "Support VM lane (heavy sweeps)"** + memory note
+> `project_worldos_vm_sweep_lane.md`. The Mac runs the **macOS-only** native Part-A (#356 `.app` launcher +
+> built-app screenshots); the **32 GB evaos-support VM** (`root@178.104.123.213`, repo `/root/worldos-qa/WorldOS`,
+> harness `sweep_v2.sh`) runs the heavy **part-B** 5-persona sweep against the **real OpenWorlds browser GUI**
+> (server.py + playwright/chromium — NOT a degraded proxy). RRI rolls up Mac `--handoff-json` + same-SHA VM dirs.
+> **On resume after a compaction, re-read that runbook section FIRST** — do not rebuild the QA plan from memory
+> or fight local RAM. For per-beat DM latency, see the `worldos-latency-forensics` skill.
+
 ## Load-bearing INVARIANTS (never violate)
 1. **Engine = SOLE WRITER.** State is `snapshot.json` written under `campaign_lock` via
    atomic temp-file + `os.replace` (`servers/engine/store.py`). The player facade
@@ -58,8 +68,13 @@ Keep Python tests single-process unless the lane explicitly supports parallel ex
    ```
 
 ## THE QA LOOP
-Spec: `qa/SCORING.md`. **Log every run to `qa/SCORECARD.md`.** Targets: **story ≥ 4.3,
-mechanical ≥ 4.5, gate GREEN, 0 critical/high.**
+Spec: `qa/SCORING.md`. **The ledger is `qa/scores_db.py` (SQLite `scores.db`) → rendered to
+`qa/scores_ledger.md` (`add_run(...)` / `--render`); `qa/SCORECARD.md` is LEGACY narrative.** Append
+every scored run via `add_run(...)` — NEVER hand-edit `scores_ledger.md`. Load-bearing columns:
+**surface** (engine-duo / GUI-built-app / GUI-headless-proxy / smoke-only) + **dm_model** + **actor_model**
++ **scorer** — this is what prevents cross-surface/cross-model score confusion; mark contaminated rows
+(RED-capped / PARTIAL / harness) with `*` so an RRI-2.7-class number is never cited as a clean quality score.
+Targets: **story ≥ 4.3, mechanical ≥ 4.5, gate GREEN, 0 critical/high.**
 
 **Story/mechanical runners** (from repo root):
 - `qa/run_duo.sh <run> <world> <persona> [beats] [budget]` — AI player + DM duo (gateway-free
@@ -102,9 +117,13 @@ with ONLY the Playwright palette MCP — a blind persona; sees only screenshot/a
 the palette). The Player drives the browser → clicks POST `/move` → the DM resolves → narration
 flows back onto the screen; the loop is validated **because the player could play it**.
 
-The restricted **8-tool palette** (`qa/playwright/palette_server.js`, an MCP server backing a
+The restricted **9-tool palette** (`qa/playwright/palette_server.js`, an MCP server backing a
 Chromium browser — mirrors the engine's role-enforced `player_server.py` facade; NO source/engine/
-filesystem access): `screenshot · a11y_tree · click · type · key · wait · report_bug · give_up`.
+filesystem access): `screenshot · a11y_tree · click · type · key · wait · report_bug · give_up · finish`.
+**`finish(satisfaction, verdict)` = a SATISFIED end** → `gave_up=false` + a self-reported 1–10 score (the
+scorer PREFERS `status.satisfaction` over the brittle verdict-regex); **`give_up` = a genuine BLOCK** (dead
+control / error / DM stalled). Don't collapse them — #574: a satisfied player who just stopped was mis-scored
+`gave_up=true` + a derived low sat (7→2). Goal-gate G3 = sat ≥ 7 self-reported AND `gave_up=false`.
 (Use `locator.ariaSnapshot()` — `page.accessibility.snapshot()` was removed in Playwright ≥1.5x.)
 It **passively** auto-emits console errors + 4xx/5xx as `source:"auto"` bugs.
 
@@ -164,6 +183,17 @@ an unattended loop.
 - **Surfacing info ≠ the DM using it** — fold the value into a trigger the DM already hits
   every turn (e.g. `turn_brief` on `next_turn`; Director at beat start), or ENFORCE in the
   engine (Multiattack #181, turn-skip #183).
+- **QA must EXERCISE the flag before you trust an A/B** — `qa/run_duo.sh` once `--resume`d the full
+  transcript and IGNORED `CLAWDND_LEAN_BEATS`, so every prior "lean" A/B was a non-lean artifact (a
+  short run just has a smaller transcript that reads as "context dropped"). Before trusting a flag A/B
+  (lean / effort / `alwaysLoad`), READ the runner you invoked and confirm its DM turn actually consumes
+  the flag. A flag BUILT but never exercised by QA is DEAD CODE — expect latent bugs the moment it runs
+  for real (#538 recent_narration + #543 scene_context AttributeError surfaced only after #549 wired lean).
+- **DM-beat latency is model REASONING, not the GUI/harness** — measured ~100–126s/beat at `--effort
+  medium` ≈ original Opus-high; it's `duration_api_ms` (surface-independent), not the viewer/Playwright.
+  Don't chase a harness perf bug. Levers + the SDK measurement method are in the `worldos-latency-forensics`
+  skill: `alwaysLoad` un-defers engine tools (cold-open 248→176s, neutral), effort is the trading lever
+  (owner's quality call, A/B first), model choice is OPEN (see `docs/MODEL-TIERING-STRATEGY.md`).
 - **First-principles for load-bearing decisions** (public contract/schema/tool API) — write
   a decision doc, not speculative code.
 - **REUSE before rebuild** — the engine is usually ~80–90% there (Quest-Arc reused the

--- a/.claude/skills/worldos-latency-forensics/SKILL.md
+++ b/.claude/skills/worldos-latency-forensics/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: worldos-latency-forensics
+description: Root-cause and fix per-beat claude -p DM latency in WorldOS (the living-world D&D 5e engine). Use when a slow DM beat is the binding release blocker (beats trip the gate / a persona gives up on the wait), when choosing a latency lever (effort / lean / alwaysLoad / streaming / scene_context), or when someone proposes a "speed" change (a helper model, a --fast flag, a model switch) you need to validate or refute. Encodes the SDK-instrumented measurement method, the quality-cost lever taxonomy, and the hypotheses already REFUTED so they are not re-chased. Companion to worldos-dev.
+---
+
+# WorldOS DM Latency Forensics
+
+The DM is a `claude -p` agent, one invocation per beat (`scripts/play.sh`, `scripts/play_party.sh`,
+`qa/run_duo.sh`). When a beat is slow, **MEASURE before you guess** — most "make it faster" ideas
+attack the wrong thing, and an expensive 5-persona gate is the worst place to discover that.
+
+## MEASURE FIRST — the authoritative method
+Every `claude -p --output-format stream-json --verbose` emits a final `result` event. Parse it:
+- **GENERATION time = `duration_api_ms`** — the model thinking + emitting, summed across ALL turns
+  of the beat. This is the real cost.
+- **TOOL + ORCHESTRATION = `duration_ms` − `duration_api_ms`** — engine round-trips, scheduling, retries.
+- Cross-check `tool_result` event timestamps: a real engine round-trip is ≤~3s; any larger gap is
+  GENERATION between tool calls, not tool-wait.
+
+**PITFALL (load-bearing):** a naive transcript-walk that bills every "gap between a `tool_result` and
+the next `tool_use`" as *tool wait* OVER-counts — it attributes generation-between-tools to tool
+latency and fabricates a "tool-heavy" figure. The SDK `duration_api_ms` is authoritative; **true
+engine tool-exec is ~1–4% of the beat.** (This is the precise version of the earlier "≈100% thinking
+between tool calls" read — same conclusion, correct metric.)
+
+## THE VERDICT (measured 2026-06-02, Sonnet + Opus, baldurs-gate)
+- Routine beats are **~90–100% generation-bound** (Opus *more* so — more extended-thinking). Cold-open
+  (max-effort world-build) ~280–400s; routine ~100–126s at `--effort medium` ≈ the original Opus-high latency.
+- ⇒ **Attack the INPUT token mass + per-turn thinking, NOT tool round-trips.**
+- It is **NOT the GUI/harness**: `duration_api_ms` is surface-independent (same headless, in the .app,
+  or on the VM). The "5-minute feel" in a playtest is the QA *player-agent's own* between-turn
+  deliberation — a real human doesn't incur it.
+
+## LEVER TAXONOMY — choose by quality-cost
+**NEUTRAL (no quality cost — just take them):**
+- **`alwaysLoad` / un-defer MCP tools** — pins the engine tools so the DM stops burning ~2 `ToolSearch`
+  round-trips/beat re-discovering them. The win is the **cold-open** (248→176s, ToolSearch 4→0);
+  routine ~unchanged (it's thinking-bound). Cache-stable. `CLAWDND_ENGINE_ALWAYSLOAD` (default on);
+  `"alwaysLoad": true` per-server in the generated `dm.mcp.json` + `.mcp.json`.
+- **Stream mid-turn narration** (#571) — perceived-latency win + nav-during-compose; doesn't cut
+  wall-clock but stops give-ups on the wait.
+- **Compact `scene_context` digest** — re-ground each beat from a small digest (durable threads +
+  recent-narration tail) off the snapshot+session-log, NOT the ~690K transcript (~10–27× context drop;
+  lossless because the engine's FTS5 retrieves on demand).
+- **Prose-trim** — cap narration length.
+
+**TRADING (quality cost — the OWNER's call, A/B first):**
+- **`--effort` (max cold-open / medium routine / low only behind a gate)** — the single biggest
+  wall-clock lever, but lower effort can lower story quality. Medium ≈ original good latency; do NOT
+  drop below medium without a quality A/B. **NEVER switch *model* mid-campaign** — a model switch
+  invalidates the prompt cache (effort changes are cache-safe). Model choice (Opus story vs Sonnet
+  speed) is an open owner decision — see `docs/MODEL-TIERING-STRATEGY.md`; do not assume it.
+
+## REFUTED — do NOT re-chase
+- **A small/Haiku "research-packet" helper to prefetch for the DM** — touches ≤5% of the beat
+  (generation-bound). Refuted.
+- **A headless `--fast` flag** — doesn't exist; use `--effort`.
+- **`--tools` / `--allowedTools` to stop MCP deferral** — WRONG mechanism (those are built-in /
+  permission lists, not deferral controls). The real levers are `alwaysLoad` / `ENABLE_TOOL_SEARCH`
+  (verified by binary-safe `grep -a` of the `claude` binary for `alwaysLoad`/`ENABLE_TOOL_SEARCH`/
+  `shouldDefer` — real in 2.1.160). Lesson: a subagent's confident config claim is a HYPOTHESIS —
+  verify against the binary/source before building on it.
+
+## SEQUENCE — cheap → expensive (never skip ahead)
+1. **2-beat engine probe** → measure `duration_api_ms`, num_turns, ToolSearch count.
+2. **Cache-stability** (one 2-beat run) → confirm the prefix cache holds across beats.
+3. **Effort/flag-wiring probe** → confirm the runner ACTUALLY consumes the flag (see worldos-dev's
+   "QA must exercise the flag" — a harness that ignores `CLAWDND_LEAN_BEATS`/effort fakes the A/B).
+4. **Short duo A/B on the VM** (engine-duo, gateway-free) → quality + latency deltas, same SHA + seed,
+   one credit window (throttling confounds wall-clock).
+5. **ONLY THEN** the 5-persona `.app` gate (heavy — use the Support VM lane; see worldos-dev).
+Record latency columns (s/beat, cold-open-s, turns/beat) to `qa/scores_db.py` on every run.
+
+Cross-refs: `worldos-dev` (dev/QA loops + VM lane), `first-principles-architectural-decision`
+(the lever decision), `docs/MODEL-TIERING-STRATEGY.md` (model/effort decision record).

--- a/docs/MODEL-TIERING-STRATEGY.md
+++ b/docs/MODEL-TIERING-STRATEGY.md
@@ -1,56 +1,48 @@
-# WorldOS Model Tiering Strategy
+# WorldOS Model & Effort Strategy
 
-Status: proposal / to-test. This document captures a takeover whiteboard from 2026-05-31. It does
-not change runtime behavior and must not be treated as release evidence.
+Status: **MEASURED (2026-06-02)** for the latency/effort mechanics; the **model choice itself remains an
+open owner decision** (see below). Supersedes the 2026-05-31 "proposal/to-test" whiteboard. Companion:
+the `worldos-latency-forensics` skill (the measurement method + full lever taxonomy).
 
-## Why This Exists
+## What was measured (not recollection)
+- **The DM is generation-bound.** Per-beat `claude -p` time is ~90–100% `duration_api_ms` (model thinking +
+  emitting); true engine tool-exec is ~1–4%. So latency is driven by **input-token mass + per-turn thinking
+  (effort)**, NOT by tool round-trips, and NOT by the GUI/harness (`duration_api_ms` is surface-independent).
+- **Effort is the big wall-clock lever.** Routine beats ~100–126s at `--effort medium` ≈ the original
+  Opus-high feel; cold-open (max-effort world-build) ~280–400s. Dropping below medium is faster but trades
+  story quality.
+- **Story A/B (engine-duo, same week, same Sonnet scorer):** Opus story 4.4–4.5 vs Sonnet 4.2; Sonnet is
+  faster/cheaper. Both surfaces (engine harnesses AND the `.app`) currently **default Sonnet** — there is no
+  tracked artifact where Opus was "decided." Models are **options we offer, never bolted on.**
 
-The recent low story/mechanical scores raised a plausible model-routing question: should the DM use a
-stronger model for the parts of play where quality is felt, while cheaper/faster models handle test
-drivers or research helpers?
+## Invariants (do these regardless of model)
+1. **ONE model end-to-end per campaign.** **NEVER switch model mid-campaign** — a model switch invalidates the
+   Anthropic prompt cache; **effort changes are cache-safe.** (This retires the old "Opus cold-open / Sonnet
+   routine" model-tiering proposal — tier the EFFORT, not the model.)
+2. **Effort tier:** `--effort max` cold-open (one-time world-build), `--effort medium` routine. Drop to a lower
+   routine effort ONLY behind a default-off flag AND a quality A/B that holds story ≥ 4.3.
+3. **Build-the-world-once-expensive → live-in-it-cheap:** re-ground each beat from the compact `scene_context`
+   digest (durable threads + recent-narration tail) off the snapshot+session-log, NOT the ~690K transcript.
+4. **`alwaysLoad` the engine MCP tools** (un-defer) — neutral latency win on the cold-open, cache-stable.
 
-Owner recollection says earlier DM runs used Opus and later runs defaulted to Sonnet. Treat that as
-owner recollection until backed by tracked repo history or release artifacts. The tracked scripts do
-verify the current default:
+## The OPEN decision (owner's call — do not assume)
+**Which model the DM runs is not settled.** The measured trade: **Opus = higher story (4.4–4.5)**;
+**Sonnet = faster + cheaper + already the default** and its story (4.2) is near the 4.3 bar. Pick ONE and
+hold it for the campaign; expose it as `WORLDOS_DM_MODEL` (option, not a hardcode). Do NOT unilaterally flip
+the default to Opus — that would create a config mismatch the codebase doesn't currently have.
 
-| Role | Job | Current default | Evidence |
-|---|---|---|---|
-| DM | product story, rulings, combat staging | `sonnet`, overridable by `WORLDOS_DM_MODEL` / `CLAWDND_DM_MODEL` | `scripts/play.sh`, `scripts/play_party.sh`, `qa/run_duo.sh` |
-| AI playtest persona | test driver, not product output | `sonnet` / actor model envs | `qa/ui_playtest_app.sh`, `qa/run_duo.sh` |
-| Scorer | story/mechanical judge | `sonnet` today | `qa/score.sh` |
+## REFUTED — do not re-chase
+- **A Haiku (or any small-model) "research-packet" helper to prefetch for the DM** — the beat is
+  generation-bound, so a prefetch helper touches ≤5% of the wall-clock. Refuted by the latency forensics.
+- **A headless `--fast` mode** — doesn't exist for `claude -p`; use `--effort`.
 
-The f5500ac RRI must not be used as proof that model choice is the root cause. That run was partial
-and harness-contaminated.
+## Validation ladder (cheap → expensive; before any model/effort spend)
+digest-correctness (1 engine call, no LLM) → cache-stability (1 two-beat run) → effort/flag-wiring probe
+(confirm the runner consumes the flag — see worldos-dev "QA must exercise the flag") → short duo A/B on the
+32 GB VM (same SHA + seed, one credit window) → ONLY THEN the 5-persona `.app` gate (Mac native Part-A + the
+VM part-B sweep; see the Support VM lane). Hold the scorer constant during any A/B.
 
-## Proposal
-
-Use the best model where the player feels quality, and keep the test harness stable:
-
-1. Cold open / universe setup: test Opus DM.
-2. Combat or high-stakes rulings: test Opus DM.
-3. Routine continuation beats: test Sonnet, or a later tiered mode only after a clean baseline.
-4. Scorer: hold constant during A/B runs, so the ruler does not move while the DM changes.
-
-The Haiku idea is not “make Haiku the DM.” The stronger proposal is to prototype Haiku as a helper
-lane for lore/rules/state research packets, so the DM spends fewer serial tool round-trips and keeps
-premium context focused on judgment and prose.
-
-## Test Sequence
-
-Run this only after gate trust is restored:
-
-1. Sonnet baseline: fixed orchestrator, lean off, scorer constant.
-2. Opus-DM arm: same scenario and scorer, `WORLDOS_DM_MODEL=opus` or the confirmed current Opus id.
-3. Optional tiered arm: cold-open/combat Opus, routine beats Sonnet, behind a default-off flag.
-4. Optional helper prototype: Haiku research packet helper for lore/rules/state gathering.
-
-Run backend/persona sweeps on the 32GB VM. Keep the Mac-only built `.app` launch/play smoke on this
-Mac or macOS CI.
-
-## Open Questions
-
-- Which exact Opus model id is valid in the current CLI/runtime?
-- Is Claude fast mode reachable from headless `claude -p`, or only interactive Claude Code?
-- Should the scorer be promoted to Opus later as a one-time re-baseline after the DM A/B?
-- Should helper agents route through Codex subagents first, or through OpenClaw/Codex provider
-  adapters after the release gate is trustworthy?
+## Still open
+- The exact Opus model id valid in the current CLI/runtime.
+- Whether a lower routine effort holds story ≥ 4.3 (needs the quality A/B).
+- Scorer-to-Opus re-baseline as a later one-time calibration.

--- a/qa/QA_TOOLS.md
+++ b/qa/QA_TOOLS.md
@@ -1,8 +1,7 @@
 # WorldOS QA Tools Index
 
 This is the command map for agents. It does not replace the release truth in
-`WorldOS-OPERATING-GOAL.md`, the GUI loop in `WorldOS-GUI-RUNBOOK.md`, or the evidence ledger in
-`qa/SCORECARD.md`.
+`WorldOS-OPERATING-GOAL.md`, the GUI loop in `WorldOS-GUI-RUNBOOK.md`, or the evidence ledger `qa/scores_ledger.md` (rendered from `qa/scores_db.py`; `qa/SCORECARD.md` is legacy).
 
 Default local paths:
 

--- a/qa/SCORECARD.md
+++ b/qa/SCORECARD.md
@@ -1,4 +1,9 @@
-# WorldOS QA Scorecard — running ledger
+# WorldOS QA Scorecard — running ledger (LEGACY)
+
+> **⚠ THE LEDGER MOVED.** The canonical scores ledger is now `qa/scores_db.py` (SQLite `scores.db`) → rendered to
+> `qa/scores_ledger.md` via `add_run(...)` / `--render`. Append NEW runs there (it carries the load-bearing
+> **surface / dm_model / actor_model / scorer** columns that prevent cross-surface/cross-model score confusion).
+> This file is kept as narrative history only — do NOT add new rows here, and do NOT hand-edit `scores_ledger.md`.
 
 > The "what did each run score, and what change was under test" log. Updated per QA run.
 > System reference: `qa/SCORING.md`. Targets: **story ≥ 4.3, mechanical ≥ 4.5, gate GREEN, 0 critical/high.**

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -1,7 +1,7 @@
 # WorldOS QA Scoring System — standardized reference
 
 > Source of truth for HOW we measure a playtest. Current as of 2026-05-26.
-> The running results ledger is `qa/SCORECARD.md`.
+> The running results ledger is `qa/scores_db.py` (SQLite) → `qa/scores_ledger.md` (`add_run()` / `--render`); `qa/SCORECARD.md` is LEGACY narrative.
 > For the current app/native handoff tools and RRI routing, start with `qa/QA_TOOLS.md` and
 > `WorldOS-GUI-RUNBOOK.md`; this file describes the story/mechanical scoring model.
 
@@ -62,4 +62,4 @@ Default DM/player model = `sonnet` (`CLAWDND_DM_MODEL` / `CLAWDND_ACTOR_MODEL` e
 ## 5. Reading a result line
 `[duo] done. story-craft=X mechanical=Y angry-dm=Z behavioral=GREEN|RED`
 - **RED** ⇒ X/Y/Z are RED-capped; read `$RUN.gate.txt` for the failed checks.
-- **GREEN** ⇒ real scores; compare against the North-Star targets and log to `SCORECARD.md`.
+- **GREEN** ⇒ real scores; compare against the North-Star targets and append via `qa/scores_db.py` `add_run(...)` (→ `scores_ledger.md`; `SCORECARD.md` is legacy).


### PR DESCRIPTION
Captures the last-few-days workflows so a post-compaction agent finds them. 1 new skill (worldos-latency-forensics) + worldos-dev callout/ledger/palette/discipline updates + MODEL-TIERING measured-state rewrite (model choice left OPEN) + SCORECARD/SCORING/QA_TOOLS ledger-drift fixes. Doc-only; from the gap-checked skillify-discovery workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated QA operational guidance with enhanced HEAVY QA SWEEPS procedures and refined scoring/ledger specifications.
  * Added latency measurement methodology for WorldOS performance analysis.
  * Updated model tiering strategy to clarify campaign consistency rules, effort mechanics, and validation approach.
  * Restructured scoring ledger system from legacy narrative format to SQLite-backed database with rendered output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->