### PR TITLE
Refresh provider status after DM moves

### DIFF
--- a/qa/test_macos_app_static.py
+++ b/qa/test_macos_app_static.py
@@ -166,6 +166,12 @@ class MacOSAppStaticContractTests(unittest.TestCase):
         self.assertIn('tmp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")', script)
         self.assertIn("os.fsync(handle.fileno())", script)
         self.assertIn("tmp_path.replace(path)", script)
+        move_turn_increment = 'DM_TURNS=$((DM_TURNS + 1))'
+        self.assertIn(move_turn_increment, script)
+        self.assertLess(
+            script.index(move_turn_increment),
+            script.index('write_provider_status "running" "active"', script.index(move_turn_increment)),
+        )
 
         self.assertIn("def _provider_status_summary() -> dict:", server)
         self.assertIn('"provider_status": provider_status', server)

--- a/scripts/play_codex_dm.sh
+++ b/scripts/play_codex_dm.sh
@@ -650,6 +650,7 @@ $PMSG")"; then
     fi
     record_dm_reply "$ACTIVE_CAMPAIGN_ID" "$REPLY" "move"
     DM_TURNS=$((DM_TURNS + 1))
+    write_provider_status "running" "active" "Codex DM provider is running."
   else
     sleep 2
   fi


### PR DESCRIPTION
## Summary
- Refresh `provider_status.json` after each resolved Codex DM move, not only after startup and turn-cap stop.
- Keeps `/app-status` provider lifecycle truth aligned with the live session after player moves.

## Product Evidence
- During a current-main browser playtest, the app returned to a playable state after `Look` and `d20` moves, but `/app-status.viewer.provider_status.dm_turns` stayed at the opening-turn value.
- This PR fixes that stale status so agents/harnesses can trust the provider turn counter while the app remains playable.

## Validation
- Red test first: `python3 -m pytest qa/test_macos_app_static.py::MacOSAppStaticContractTests::test_codex_dm_provider_publishes_turn_cap_stop_status -q` failed before the script change.
- `bash -n scripts/play_codex_dm.sh`
- `git diff --check`
- `python3 -m pytest qa/test_macos_app_static.py::MacOSAppStaticContractTests::test_codex_dm_provider_publishes_turn_cap_stop_status -q`
- `python3 -m pytest servers/engine/tests/test_codex_provider_wrapper.py::test_codex_dm_wrapper_run_pins_supported_default_model_with_fake_codex servers/engine/tests/test_codex_provider_wrapper.py::test_codex_dm_wrapper_can_delegate_to_cli_default_with_fake_codex servers/engine/tests/test_codex_provider_wrapper.py::test_codex_dm_wrapper_processes_moves_submitted_during_opening -q`
- `python3 -m pytest servers/engine/tests/test_codex_provider_wrapper.py qa/test_macos_app_static.py -q` -> 35 passed

## Invariants
- Engine remains the sole campaign-state writer.
- GUI/app remains a live reader plus `/move` intent submitter.
- `/app-status` remains read-only.