### PR TITLE
fix(#623): claude/.app DM logs early /events progress beat (kills perceived drop/hang)

### DIFF
--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -135,6 +135,15 @@ DM_LOG="$STATE_DIR/dm"          # per-turn stream-json files: $DM_LOG.<ts>.jsonl
 COMBINED="$STATE_DIR/dm.combined.jsonl"; : > "$COMBINED"  # every agent turn's stream (cost accounting)
 VIEWER_LOG="$STATE_DIR/viewer.log"
 
+# #623: the live-progress rule (parity with scripts/play_codex_dm.sh's LIVE_PROGRESS_LOG_RULE).
+# Without it the claude/plugin DM emits NOTHING to /events until the full 85-157s beat completes,
+# so the viewer shows blank and the player (and a persona playtester) perceives a "dropped"/"hung"
+# beat — the single biggest story-persona satisfaction drag (sweep_v8 forensics: healthy beats,
+# zero streaming refs). Instructing the DM to log ONE early narration progress-beat makes /events
+# show visible story progress while the turn is still composing (the #571 streaming lever, which
+# play_party.sh — the .app's AND the VM sweep's DM path — was missing while play_codex_dm.sh had it).
+CLAWDND_LIVE_PROGRESS_RULE="Live progress rule: after you know the live campaign and scene, call log_event(kind=\"narration\", text=\"...\") ONCE with a short, non-duplicate, player-facing progress beat BEFORE any longer resolution work. This is how /events shows visible story progress while your turn is still running. Keep the final reply as the full 2nd-person scene; do not copy this progress beat verbatim, because the wrapper records the final reply through the engine after the turn."
+
 # --- DM config: the three plugin MCP servers, engine pointed at this game's state dir,
 # silent voice backend — IDENTICAL wiring to play.sh (the DM runs the full plugin). -----
 python3 - "$ROOT" "$STATE_DIR" "$DM_CFG" <<'PY'
@@ -248,6 +257,9 @@ turn() {
   local kind="$1" sid="$2" first="$3" msg="$4" cfg="${5:-}" out resume=() extra=()
   [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
   if [ "$kind" = "dm" ]; then
+    # #623: prepend the live-progress rule so the DM logs an early /events narration beat (parity
+    # with play_codex_dm.sh) — without it the long beat shows blank → the perceived drop/hang.
+    msg="$CLAWDND_LIVE_PROGRESS_RULE"$'\n\n'"$msg"
     # LEAN beats (CLAWDND_LEAN_BEATS=1, now the default): a CONTINUING DM beat (first=0) starts a
     # FRESH session + a re-ground directive instead of --resume-ing the fat transcript — the SAME
     # shared implementation scripts/play.sh + qa/run_duo.sh use (clawdnd_dm_lean_args in

--- a/servers/engine/tests/test_dm_session_remint.py
+++ b/servers/engine/tests/test_dm_session_remint.py
@@ -107,3 +107,18 @@ def test_all_three_harnesses_remint_on_retry():
     # run_duo.sh's cold-open ($3=1) retry mints a fresh id rather than reusing $2.
     assert 'if [ "${3:-}" = "1" ]; then' in duo
     assert 'turn "$1" "$_fresh" "$3" "${@:4}"' in duo
+
+
+def test_play_party_dm_has_live_progress_rule():
+    """#623: play_party.sh (the .app + VM-sweep claude DM path) must apply a live-progress rule so
+    the DM logs an EARLY /events narration beat — parity with play_codex_dm.sh's
+    LIVE_PROGRESS_LOG_RULE. Without it the DM emits nothing to /events until the full 85-157s beat
+    completes, so the viewer shows blank and a player/persona perceives a 'dropped'/'hung' beat
+    (sweep_v8 forensics: healthy beats, zero streaming refs). Guards against the rule being lost or
+    the three harnesses drifting."""
+    party = _src("scripts/play_party.sh")
+    assert "CLAWDND_LIVE_PROGRESS_RULE=" in party, "play_party.sh lost the live-progress rule definition"
+    assert 'msg="$CLAWDND_LIVE_PROGRESS_RULE"' in party, "the rule must be applied to the DM turn message"
+    assert "Live progress rule" in party and "log_event" in party and "narration" in party
+    # parity: the codex DM path already carried this intent.
+    assert "LIVE_PROGRESS_LOG_RULE" in _src("scripts/play_codex_dm.sh")


### PR DESCRIPTION
Closes the root cause of #623 (the biggest story-persona satisfaction lever). **Forensics (measure-first, sweep_v8):** the DM beats ran clean (85-157s, ttft 2-5s, all recorded, zero errors) but `viewer.log` streaming-refs=0 — `play_party.sh` (the .app + claude-lane sweep DM path) lacked the `LIVE_PROGRESS_LOG_RULE` that `play_codex_dm.sh` has, so the claude DM emitted nothing to /events until the full beat finished → blank viewer → perceived drop/hang. **Fix:** prepend the live-progress rule to every DM turn message in play_party.sh (parity). Lands in BOTH the shipped .app and the VM sweeps. **Guard:** test_play_party_dm_has_live_progress_rule. Expected effect: the next VM sweep should show streaming refs > 0 and lift the narrative/newbie scores (8+ writing no longer dragged to 6 by the false drop/hang).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing event streaming during extended narration sequences, ensuring real-time gameplay updates flow continuously to players.

* **Tests**
  * Added regression test to verify and maintain event streaming consistency during game narrative beats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->