### PR TITLE
fix(#624): default subclass at creation — no blank build (optimizer stops bailing)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1048,6 +1048,18 @@ def _class_level_hp(class_name: str, level: int, con_mod: int) -> "int | None":
     return max(1, die + con_mod + (lvl - 1) * per_level_after_first)
 
 
+# #624: iconic SRD default subclass per class — fills an UNSET subclass at/above the class's
+# subclass-selection level so a created character never shows a BLANK build choice (a level-3
+# Wizard with no Arcane Tradition reads as an unfinished build and a min-maxer bails). The
+# interactive picker is #397; this is the honest default until then. An explicit subclass wins.
+_DEFAULT_SUBCLASS = {
+    "barbarian": "Path of the Berserker", "bard": "College of Lore", "cleric": "Life Domain",
+    "druid": "Circle of the Land", "fighter": "Champion", "monk": "Way of the Open Hand",
+    "paladin": "Oath of Devotion", "ranger": "Hunter", "rogue": "Thief",
+    "sorcerer": "Draconic Bloodline", "warlock": "The Fiend", "wizard": "School of Evocation",
+}
+
+
 def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool) -> None:
     """Fill SRD class defaults onto a character in place: saving-throw proficiencies,
     hit dice, level-1 HP (max die + CON), proficiency bonus, class base AC (when
@@ -1101,6 +1113,14 @@ def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool
                 explicit = [s for s in pool if s != "any" and s in SKILL_ABILITIES]
                 pool = explicit + [s for s in SKILL_ABILITIES if s not in explicit]
             ch.skill_proficiencies = pool[: int(sk.get("count", 0))]
+        # #624: at/above the class's subclass-selection level (3, warlock 6), a blank subclass
+        # reads as an unfinished build — the optimizer bailed at turn 2 on "unresolved build
+        # choices". Fill the iconic SRD default when the caller chose none (explicit always wins).
+        _sub_at = 6 if cname == "warlock" else 3
+        if level >= _sub_at and ch.classes and not str(ch.classes[0].subclass or "").strip():
+            _def_sub = _DEFAULT_SUBCLASS.get(cname)
+            if _def_sub:
+                ch.classes[0].subclass = _def_sub
         _recompute_spellcasting(ch)
         _seed_starting_spells(ch, cname, level)
         _recompute_class_resources(ch)

--- a/servers/engine/tests/test_adversarial_release.py
+++ b/servers/engine/tests/test_adversarial_release.py
@@ -230,3 +230,23 @@ def test_any_skill_class_resolves_to_concrete_skills():
     assert skills, "Bard should have default skill proficiencies, not an empty sheet"
     assert "any" not in skills, f"unresolved 'any' placeholder persisted: {skills}"
     assert len(skills) == 3, f"Bard should get 3 concrete skills, got {skills}"
+
+
+def test_subclass_filled_at_subclass_level_when_unset():
+    # #624: a character created at/above its subclass level with no subclass must get the iconic
+    # SRD default (not a BLANK build) — the optimizer bailed at turn 2 on "unresolved build
+    # choices". The interactive picker is #397; this is the honest interim default. Explicit wins.
+    cid = _campaign()
+    wiz = server.create_character(cid, "Gale", kind="player", class_name="Wizard",
+                                  level=3, apply_srd_defaults=True)["id"]
+    wclasses = server.get_character(cid, wiz).get("classes") or []
+    assert wclasses and (wclasses[0].get("subclass") or "").strip(), "L3 wizard must carry a subclass"
+    assert "Evocation" in wclasses[0]["subclass"], wclasses[0]["subclass"]
+    # below the subclass level → still unset (no premature subclass)
+    f1 = server.create_character(cid, "Recruit", kind="player", class_name="Fighter",
+                                 level=1, apply_srd_defaults=True)["id"]
+    assert not ((server.get_character(cid, f1).get("classes") or [{}])[0].get("subclass") or "").strip()
+    # an explicit subclass is preserved (the default never overwrites a choice)
+    rg = server.create_character(cid, "Sneak", kind="player", class_name="Rogue", level=3,
+                                 subclass="Arcane Trickster", apply_srd_defaults=True)["id"]
+    assert (server.get_character(cid, rg).get("classes") or [{}])[0].get("subclass") == "Arcane Trickster"


### PR DESCRIPTION
Targets the binding G3-sat lever (optimizer 5). **sweep_v9:** the optimizer bailed at turn 2 on a character sheet with BLANK build choices ('subclass, ASI, Expertise — no pickers'). A level-3 Wizard with no Arcane Tradition reads as unfinished. **Fix** (proven Bard-skills creation-hook pattern): fill the iconic SRD default subclass at/above the class's subclass level when the caller chose none; explicit always wins; below the level stays unset. The interactive picker remains #397 — this is the honest interim that stops the bail so the optimizer explores the depth already shipped. **Guard:** test_subclass_filled_at_subclass_level_when_unset. Expected: optimizer stops bailing turn-2 → explores → lifts off 5 → avg over 7 on the next sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Characters now automatically receive a default subclass when reaching the required level, preventing blank subclass selections.

* **Tests**
  * Added regression test to verify automatic subclass assignment at the appropriate character level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->