### PR TITLE
fix(a11y/G4): role=region on toast live-region (axe 17→0, G4 PASS)

### DIFF
--- a/viewer/openworlds/toast.jsx
+++ b/viewer/openworlds/toast.jsx
@@ -21,7 +21,7 @@ function ToastProvider({ children }) {
         display: "flex", flexDirection: "column", gap: 10,
         pointerEvents: "none",
         maxWidth: 360,
-      }} aria-live="polite" aria-label="Notifications" data-worldos-testid="toast-region">
+      }} role="region" aria-live="polite" aria-label="Notifications" data-worldos-testid="toast-region">
         {toasts.map((t) => <Toast key={t.id} toast={t} />)}
       </div>
     </ToastCtx.Provider>


### PR DESCRIPTION
Closes the G4 gate gap. `ui_audit_health.sh --quick --axe` reported 17 axe violations, all one root cause: the shared toast container (`<div aria-live aria-label>`, on every screen) — a generic div role prohibits `aria-label`. Adding `role=region` makes it a labeled live-region landmark. **Verified:** re-ran axe with a live viewer → **0 violations, full audit PASS**; 57 static tests green. One-line fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility of toast notifications to improve compatibility with screen readers and assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->