### PR TITLE
feat(#397 inc1): pendingSubclass read-model flag

### DIFF
--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3581,6 +3581,12 @@ def _character_sheet(cid: str, ch: dict) -> dict:
         "race": _text(ch.get("race")),
         "class": klass,
         "archetype": _text((ch.get("classes") or [{}])[0].get("subclass") if isinstance(ch.get("classes"), list) and ch.get("classes") else "") or _text(ch.get("background")),
+        # #397 (read-model increment 1): flag a PENDING subclass choice — at/above the class's
+        # subclass-selection level (3; warlock 6) with no subclass set — so the character screen can
+        # offer the build-choice PICKER. Detect, do NOT auto-fill (#624's auto-fill pre-empts the
+        # choice the optimizer wants; CI's build_options test confirmed the subclass must stay choosable).
+        "pendingSubclass": bool((level or 1) >= (6 if klass.lower() == "warlock" else 3)
+                                and not str((ch.get("classes") or [{}])[0].get("subclass") or "").strip()),
         "alignment": _text(ch.get("alignment"), "Unaligned"),
         "level": level or 1,
         "xp": int(_num(ch.get("xp")) or 0),

--- a/viewer/tests/test_charsheet_depth.py
+++ b/viewer/tests/test_charsheet_depth.py
@@ -224,6 +224,22 @@ class CharsheetDepthTests(unittest.TestCase):
         elara = self._party(surface)["elara"]
         self.assertEqual(elara["classFeatures"], [])
 
+    def test_surface_flags_pending_subclass_choice(self):
+        # #397 (read-model increment 1): a character at/above its subclass-selection level (3;
+        # warlock 6) with NO subclass set must flag pendingSubclass=True so the character screen
+        # can offer the build-choice picker. Detect, not auto-fill (#624 proved auto-fill pre-empts
+        # the choice). With a subclass set, or below the level, it's False.
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["characters"]["elara"]["classes"][0]["subclass"] = None  # L3 wizard, no Arcane Tradition
+        self._write("camp_pend", snap)
+        _s, surface = self._get_json("/character-surface?campaign=camp_pend")
+        self.assertTrue(self._party(surface)["elara"]["pendingSubclass"])
+        # the default snapshot: elara has "School of Evocation", thornwick (L4 fighter) has "Champion"
+        self._write("camp_set", copy.deepcopy(_SNAPSHOT))
+        _s2, surface2 = self._get_json("/character-surface?campaign=camp_set")
+        self.assertFalse(self._party(surface2)["elara"]["pendingSubclass"])
+        self.assertFalse(self._party(surface2)["thornwick"]["pendingSubclass"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#397 (the binding G3-sat lever), increment 1 of 4 per the ADR. Adds `pendingSubclass` to /character-surface (at/above the class's subclass level with no subclass set) — the detection the build-choice picker keys off. Detect, not auto-fill (#624 abandoned: CI proved the subclass must stay choosable). Guard: test_surface_flags_pending_subclass_choice. Next increments: /build-options route → level_up move-kind → picker UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Character sheets now properly track pending subclass selections, enabling the character screen to display the subclass selection interface when needed.

* **Tests**
  * Added end-to-end tests to verify correct handling of subclass selection status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->