### PR TITLE
feat(#397 inc4): build-choice picker UI (LevelUpModal) — the optimizer's keystone

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -323,6 +323,10 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
   const [subclassName, setSubclassName] = React.useState("");
   const [asiNote, setAsiNote] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
+  // #robustness: synchronous in-flight lock (mirrors screen-table.jsx). The `submitting` STATE
+  // only updates on re-render, so a rapid double-click would otherwise relay TWO level-up intents
+  // and double-level the character. The ref blocks the second call within the same tick.
+  const submittingRef = React.useRef(false);
   const cap = (s) => (s || "").replace(/^./, (ch) => ch.toUpperCase());
 
   React.useEffect(() => {
@@ -361,7 +365,8 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
   const toLevel = (option && option.to && option.to.level) || (Number(hero.level) + 1);
 
   const confirm = async () => {
-    if (submitting) return;
+    if (submittingRef.current) return;
+    submittingRef.current = true;
     setSubmitting(true);
     const cls = cap((option && option.class_name) || hero.class || "my class");
     const parts = ["I advance " + (hero.name || "my character") + " to level " + toLevel + " as a " + cls];
@@ -392,6 +397,7 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
         title: "Level-up not sent",
         body: (e && e.message) || "The viewer could not reach /move.",
       });
+      submittingRef.current = false;
       setSubmitting(false);
     }
   };

--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -32,6 +32,7 @@ function ScreenCharacter({ onNavigate, state, setState }) {
   const [active, setActive] = React.useState("");
   const [tab, setTab] = React.useState("abilities");
   const [restOpen, setRestOpen] = React.useState(false);
+  const [levelUpOpen, setLevelUpOpen] = React.useState(false);
   const toast = window.useToast ? window.useToast() : (() => {});
 
   const loadSurface = React.useCallback(async (isCancelled = () => false) => {
@@ -124,6 +125,15 @@ function ScreenCharacter({ onNavigate, state, setState }) {
         <BrassButton tone="dark" size="sm" onClick={() => setRestOpen(true)} style={{ width: "100%" }}>
           Rest & Prepare
         </BrassButton>
+        {/* #397: the build-choice affordance. Shown ONLY when the engine read-model says a choice
+            is actually due — a pending subclass (pendingSubclass, even from creation above the
+            choose-level) or enough XP for the next level. Never a faked "always available" button. */}
+        {(hero.pendingSubclass || (Number(hero.xp) >= Number(hero.xpMax) && Number(hero.xpMax) > 0)) && (
+          <BrassButton size="sm" onClick={() => setLevelUpOpen(true)} style={{ width: "100%", marginTop: 8 }}
+            testId="level-up-open" ariaLabel={hero.pendingSubclass ? "Choose your subclass" : "Level up"}>
+            {hero.pendingSubclass ? "Choose Subclass" : "Level Up"}
+          </BrassButton>
+        )}
       </Panel>
 
       {/* RIGHT: sheet */}
@@ -286,6 +296,220 @@ function ScreenCharacter({ onNavigate, state, setState }) {
       </div>
 
       {restOpen && <RestPrepareModal hero={hero} party={party} onClose={() => setRestOpen(false)} toast={toast} setState={setState} />}
+      {levelUpOpen && (
+        <LevelUpModal
+          hero={hero}
+          campaignId={surface?.campaign_id || state?.activeCampaign || ""}
+          onClose={() => setLevelUpOpen(false)}
+          onDone={() => { setLevelUpOpen(false); loadSurface(); }}
+          toast={toast}
+        />
+      )}
+    </div>
+  );
+}
+
+// #397 — the build-choice PICKER. Unlike RestPrepareModal (display-only), this writes for real:
+// it reads the engine-owned legal level-up preview from /build-options (HP/features/slots — never
+// faked), and on confirm relays a `do` move-intent to the DM, who resolves it through the engine
+// level_up tool (sole writer) exactly as camp-sidebar.jsx relays "make camp". The subclass is NOT
+// a hardcoded dropdown — the engine does not enumerate world-canon subclasses (class_data has no
+// subclass list); the player NAMES it and the DM, which knows the world's options, finalizes it.
+function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
+  const [planner, setPlanner] = React.useState(null);
+  const [error, setError] = React.useState("");
+  const [loading, setLoading] = React.useState(true);
+  const [chosenClass, setChosenClass] = React.useState((hero.class || "").toLowerCase());
+  const [subclassName, setSubclassName] = React.useState("");
+  const [asiNote, setAsiNote] = React.useState("");
+  const [submitting, setSubmitting] = React.useState(false);
+  const cap = (s) => (s || "").replace(/^./, (ch) => ch.toUpperCase());
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const url = "/build-options?campaign=" + encodeURIComponent(campaignId || "") +
+                    "&character=" + encodeURIComponent(hero.id || "");
+        const response = await fetch(url, { cache: "no-store" });
+        const payload = await response.json();
+        if (cancelled) return;
+        if (payload && payload.ok && payload.planner) {
+          setPlanner(payload.planner);
+        } else {
+          setError((payload && Array.isArray(payload.errors) && payload.errors[0]) || "The build planner is unavailable.");
+        }
+      } catch (e) {
+        if (!cancelled) setError("Could not reach the build planner.");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [campaignId, hero.id]);
+
+  const options = (planner && Array.isArray(planner.options)) ? planner.options : [];
+  // The option for the chosen class (default: continue the current class), else the first legal path.
+  const option = options.find((o) => (o.class_name || "").toLowerCase() === chosenClass) || options[0] || null;
+  const featuresGained = (option && Array.isArray(option.features_gained)) ? option.features_gained : [];
+  // Subclass is DUE if the engine grants a "<X> Subclass" feature at this level, or the read-model
+  // already flagged one pending (created above the choose-level). Either way the player names it.
+  const subclassDue = !!hero.pendingSubclass ||
+    featuresGained.some((f) => /subclass/i.test((f && f.name) || ""));
+  const asiRequired = !!(option && option.choices && option.choices.asi_required);
+  const featAllowed = !!(option && option.choices && option.choices.feat_allowed);
+  const toLevel = (option && option.to && option.to.level) || (Number(hero.level) + 1);
+
+  const confirm = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    const cls = cap((option && option.class_name) || hero.class || "my class");
+    const parts = ["I advance " + (hero.name || "my character") + " to level " + toLevel + " as a " + cls];
+    if (subclassDue && subclassName.trim()) parts.push("choosing the " + subclassName.trim() + " subclass");
+    if (asiRequired) {
+      parts.push("and for my ability score improvement" + (featAllowed ? " (or feat)" : "") + ": " +
+                 (asiNote.trim() || "ask me which to take"));
+    }
+    const text = parts.join(", ") + ".";
+    try {
+      const response = await fetch("/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "do", text, campaign: campaignId }),
+      });
+      if (!response.ok) throw new Error("move " + response.status);
+      toast({
+        kind: "rest",
+        eyebrow: "Advancement",
+        title: "Level-up relayed to the DM",
+        body: "Move relayed — the engine resolves the level-up and refreshes the sheet.",
+      });
+      if (onDone) onDone(); else onClose();
+    } catch (e) {
+      toast({
+        kind: "danger",
+        eyebrow: "Advancement",
+        title: "Level-up not sent",
+        body: (e && e.message) || "The viewer could not reach /move.",
+      });
+      setSubmitting(false);
+    }
+  };
+
+  // Confirm is blocked ONLY while submitting or when a subclass is required but unnamed — it is
+  // never permanently disabled (that is the RestPrepareModal display-only stub; the picker writes).
+  const confirmDisabled = submitting || (subclassDue && !subclassName.trim());
+
+  return (
+    <div style={{
+      position: "fixed", inset: 0, zIndex: 200,
+      background: "rgba(15, 8, 2, 0.7)",
+      display: "grid", placeItems: "center",
+      backdropFilter: "blur(2px)",
+    }} onClick={onClose} role="dialog" aria-modal="true" aria-label="Level up" data-worldos-testid="level-up-modal">
+      <div onClick={(e) => e.stopPropagation()} style={{ width: 640, maxWidth: "92vw", maxHeight: "88vh", overflow: "auto" }}>
+        <Panel framed>
+          <div className="eyebrow" style={{ color: "var(--crimson)" }}>Advancement</div>
+          <h2 className="h1" style={{ fontSize: 26 }}>Level Up — {hero.name}</h2>
+          <Divider />
+
+          {loading ? (
+            <p className="body muted">Consulting the build planner…</p>
+          ) : error ? (
+            <p className="body" style={{ color: "var(--crimson)" }} data-worldos-testid="levelup-error">{error}</p>
+          ) : (
+            <>
+              <p className="body" style={{ marginTop: 0 }}>
+                {hero.name} has earned the next rung. The engine planner shows what this level grants —
+                confirm to relay the advancement to the Dungeon Master, who records it.
+              </p>
+
+              {options.length > 1 && (
+                <div style={{ marginTop: 12 }}>
+                  <SectionTitle>Advance as</SectionTitle>
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                    {options.map((o) => {
+                      const cn = (o.class_name || "").toLowerCase();
+                      return (
+                        <button key={cn} onClick={() => setChosenClass(cn)}
+                          data-worldos-testid={"levelup-class-" + cn}
+                          style={{
+                            padding: "6px 12px", cursor: "pointer",
+                            background: chosenClass === cn ? "linear-gradient(180deg, var(--b-200), var(--b-400))" : "transparent",
+                            boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.3)",
+                            color: chosenClass === cn ? "var(--w-300)" : "var(--ink-800)",
+                            fontFamily: "var(--f-display)", fontSize: 12,
+                          }}>
+                          {cap(o.class_name)}{o.multiclass ? " · multiclass" : ""}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {option && (
+                <div style={{ marginTop: 16 }}>
+                  <div style={{ display: "flex", gap: 10, flexWrap: "wrap", alignItems: "center" }}>
+                    <Pill tone="emerald" dot>Level {(option.from && option.from.level) || hero.level} → {toLevel}</Pill>
+                    {typeof option.hp_gain === "number" && <Pill tone="crimson" dot>+{option.hp_gain} HP</Pill>}
+                    <Pill>{cap(option.class_name)}</Pill>
+                  </div>
+                  {featuresGained.length > 0 && (
+                    <div style={{ marginTop: 12 }}>
+                      <SectionTitle>Features gained</SectionTitle>
+                      <ul style={{ margin: 0, paddingLeft: 18 }}>
+                        {featuresGained.map((f, i) => (
+                          <li key={i} className="body-sm" style={{ color: "var(--ink-800)" }}>{(f && f.name) || String(f)}</li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {subclassDue && (
+                <div style={{ marginTop: 16 }}>
+                  <SectionTitle>Choose your subclass</SectionTitle>
+                  <p className="body-sm muted" style={{ marginTop: 0 }}>
+                    This level grants a subclass. Name the one your character takes — the DM confirms it against the world's options.
+                  </p>
+                  <input type="text" value={subclassName} onChange={(e) => setSubclassName(e.target.value)}
+                    placeholder="e.g. School of Evocation"
+                    data-worldos-testid="levelup-subclass-input"
+                    style={{
+                      width: "100%", padding: "8px 10px", boxSizing: "border-box",
+                      boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.4)",
+                      background: "rgba(255,250,235,0.5)", fontFamily: "var(--f-body)", fontSize: 14,
+                    }} />
+                </div>
+              )}
+
+              {asiRequired && (
+                <div style={{ marginTop: 16 }}>
+                  <SectionTitle>Ability Score Improvement{featAllowed ? " or feat" : ""}</SectionTitle>
+                  <input type="text" value={asiNote} onChange={(e) => setAsiNote(e.target.value)}
+                    placeholder={featAllowed ? "e.g. +2 STR — or a feat like Great Weapon Master" : "e.g. +2 STR, or +1 STR / +1 CON"}
+                    data-worldos-testid="levelup-asi-input"
+                    style={{
+                      width: "100%", padding: "8px 10px", boxSizing: "border-box",
+                      boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.4)",
+                      background: "rgba(255,250,235,0.5)", fontFamily: "var(--f-body)", fontSize: 14,
+                    }} />
+                </div>
+              )}
+
+              <div style={{ display: "flex", gap: 10, marginTop: 24, justifyContent: "flex-end" }}>
+                <BrassButton tone="ghost" onClick={onClose} testId="modal-close" ariaLabel="Close level up modal">Not yet</BrassButton>
+                <BrassButton onClick={confirm} disabled={confirmDisabled} testId="levelup-confirm"
+                  ariaLabel="Confirm level up and relay to the Dungeon Master">
+                  {submitting ? "Relaying…" : "Confirm advancement"}
+                </BrassButton>
+              </div>
+            </>
+          )}
+        </Panel>
+      </div>
     </div>
   );
 }

--- a/viewer/tests/test_levelup_picker.py
+++ b/viewer/tests/test_levelup_picker.py
@@ -70,6 +70,14 @@ class LevelUpPickerGuard(unittest.TestCase):
         self.assertIn("disabled={confirmDisabled}", self.modal)
         self.assertNotIn("not saved to the engine", self.modal)
 
+    def test_confirm_is_guarded_against_double_submit(self):
+        """A rapid double-click must not relay two level-up intents (which would double-level the
+        character). The state-based `submitting` only updates on re-render, so the guard MUST be a
+        synchronous ref lock (the established screen-table.jsx pattern), checked + set before await."""
+        self.assertIn("submittingRef", self.modal)
+        self.assertIn("if (submittingRef.current) return;", self.modal)
+        self.assertIn("submittingRef.current = true;", self.modal)
+
     def test_subclass_is_named_input_not_a_fabricated_dropdown(self):
         """The engine does not enumerate world-canon subclasses, so the picker must take a NAMED
         subclass (player types it, DM finalizes) — never a hardcoded list the engine doesn't assert."""

--- a/viewer/tests/test_levelup_picker.py
+++ b/viewer/tests/test_levelup_picker.py
@@ -1,0 +1,83 @@
+"""#397 — the build-choice PICKER (LevelUpModal) regression guard.
+
+The optimizer persona bails when it cannot make build choices (level-up / subclass). The picker
+closes that: a character-screen affordance that surfaces a DUE choice, shows the engine-owned legal
+preview from /build-options, and on confirm relays a `do` move-intent to the DM (sole writer) — the
+SAME write pattern camp-sidebar.jsx uses for "make camp".
+
+This guard is a static-content test (no server needed). It pins the load-bearing invariants so the
+picker can never silently regress into a display-only stub (the trap RestPrepareModal sits in) or
+start fabricating data the engine does not assert:
+
+  1. the affordance exists AND is gated on a real read-model signal (pendingSubclass / XP), never
+     an always-on button;
+  2. the modal reads the engine planner (/build-options) — real HP/features, nothing faked;
+  3. the confirm WRITES for real (POST /move kind:"do") and is never permanently disabled;
+  4. the subclass is a NAMED input the DM finalizes — NOT a hardcoded dropdown (the engine does not
+     enumerate world-canon subclasses).
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+_SCREEN = Path(__file__).resolve().parents[1] / "openworlds" / "screen-character.jsx"
+
+
+def _modal_block(src: str) -> str:
+    """Return just the LevelUpModal function body, so write-path assertions are scoped to the
+    picker and can't be satisfied by some unrelated POST elsewhere in the screen."""
+    start = src.index("function LevelUpModal")
+    # the next top-level `function ` after it bounds the block
+    nxt = src.index("\nfunction ", start + 1)
+    return src[start:nxt]
+
+
+class LevelUpPickerGuard(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.src = _SCREEN.read_text(encoding="utf-8")
+        cls.modal = _modal_block(cls.src)
+
+    def test_affordance_exists_and_is_read_model_gated(self):
+        """The Level Up / Choose Subclass button exists and only renders when a choice is actually
+        due — gated on pendingSubclass or enough XP — never an always-visible button."""
+        self.assertIn('testId="level-up-open"', self.src)
+        self.assertIn("Choose Subclass", self.src)
+        # the gate must reference the read-model signals (inc1 pendingSubclass + xp threshold)
+        self.assertRegex(
+            self.src,
+            r"hero\.pendingSubclass[^\n]*Number\(hero\.xp\)\s*>=\s*Number\(hero\.xpMax\)",
+            "the affordance must be gated on pendingSubclass / XP, not always shown",
+        )
+
+    def test_modal_reads_engine_planner_not_faked_data(self):
+        """The modal fetches the engine-owned /build-options planner (real HP/features/slots)."""
+        self.assertIn("function LevelUpModal", self.src)
+        self.assertIn('data-worldos-testid="level-up-modal"', self.modal)
+        self.assertIn("/build-options?campaign=", self.modal)
+        # it renders the planner's real features, not an invented list
+        self.assertIn("features_gained", self.modal)
+
+    def test_confirm_writes_a_real_do_intent_and_is_not_display_only(self):
+        """Unlike RestPrepareModal (display-only, permanently disabled), the picker confirm POSTs a
+        real `do` move-intent to /move — the DM resolves it through the engine level_up."""
+        self.assertIn('fetch("/move"', self.modal)
+        self.assertIn('kind: "do"', self.modal)
+        self.assertIn('testId="levelup-confirm"', self.modal)
+        # the confirm's disabled state is DYNAMIC (submitting / unnamed-subclass), never a hardcoded
+        # `disabled` with a display-only title like the rest modal carries.
+        self.assertIn("disabled={confirmDisabled}", self.modal)
+        self.assertNotIn("not saved to the engine", self.modal)
+
+    def test_subclass_is_named_input_not_a_fabricated_dropdown(self):
+        """The engine does not enumerate world-canon subclasses, so the picker must take a NAMED
+        subclass (player types it, DM finalizes) — never a hardcoded list the engine doesn't assert."""
+        self.assertIn('data-worldos-testid="levelup-subclass-input"', self.modal)
+        self.assertIn("subclassDue", self.modal)
+        # confirm is blocked until a due subclass is named (honest required-field, not silent default)
+        self.assertIn("subclassDue && !subclassName.trim()", self.modal)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

The character screen now offers a **build-choice picker** — the keystone of #397 (the binding G3-satisfaction lever; the optimizer persona bails when it can't make level-up / subclass choices).

- A left-rail affordance ("Level Up" / "Choose Subclass") that renders **only when a choice is actually due** — `pendingSubclass` (inc1's read-model flag, even from creation above the choose-level) or enough XP for the next level. Never an always-on button.
- A modal that reads the **engine-owned legal preview** from `/build-options` (inc2): real HP gain, features gained (incl. the `<X> Subclass` marker), spell-slot deltas — nothing faked.
- On confirm it relays a `do` **move-intent** to the DM, who resolves it through the engine `level_up` tool (sole writer) — the **same write pattern** `camp-sidebar.jsx` uses for "make camp".

## Design decision (inc3 dropped)

Fast-path, precedent-grounded (first-principles skill, Step 1.5 — ran the actual system):

- The move-intent allowlist `_MOVE_FIELDS` is **load-bearing**, and the architecture deliberately avoids widening it (graphical intents reuse `target`). `camp-sidebar.jsx` **proves** a viewer affordance can drive an engine mutation via a `do`-intent with **zero new move-kind** and zero new security surface. So a dedicated structured `level_up` move-kind (the summary's inc3) is **unnecessary** and is dropped. If a re-sweep ever shows the DM mis-parsing the intent, the dedicated kind is an additive follow-up.
- The subclass is a **named input the DM finalizes**, not a hardcoded dropdown: the engine does **not** enumerate world-canon subclasses (`class_data` carries no subclass list; subclasses are world/wiki canon). Fabricating a list would assert knowledge the engine doesn't have.

## Guard

`viewer/tests/test_levelup_picker.py` pins four invariants so the picker can't silently regress into a display-only stub (the trap `RestPrepareModal` sits in) or fabricate data:
1. affordance is read-model-gated (pendingSubclass / XP), not always-on;
2. modal reads the engine planner (`/build-options`) — real features;
3. confirm **writes** for real (`POST /move` `kind:"do"`) and is never permanently disabled;
4. subclass is a named input (no fabricated dropdown).

JSX verified through the runtime `babel-standalone-7.29.0`. Targeted suite green (18 tests: picker guard + charsheet read-model + build-options bridge + planner dashboard).

## Build order (#397)

inc1 read-model flag ✅ (#634) · inc2 `/build-options` route ✅ (44dd0c5, already shipped) · inc3 **dropped** (do-intent reuse) · inc4 picker UI ✅ (this PR).

**Honest note:** this lands the affordance; the G3-sat lift is confirmed by a **re-sweep** showing the optimizer reaching the picker and not bailing — not claimed here. That's the next step.

Closes the UI half of #397.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive "Choose Subclass / Level Up" button appears when a character is ready to advance.
  * Guided Level Up modal shows next-level details (progression, HP, granted features) and lets players pick subclass, ASI/feat text, and confirm advancement.
  * Confirmation disabled until required inputs are provided; prevents double-submit and shows success/error feedback.

* **Tests**
  * Added regression tests to verify gating, modal behavior, input validation, and submit guarding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->