### PR TITLE
fix(G5/#466): duo P0 intro = retry-safe plain-text capture (unblocks the duo harness)

### DIFF
--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -194,14 +194,22 @@ player_move() {
   [ -n "$new" ] && printf '%s' "$new" | jq -rs 'map("[\(.kind)] \(.text)") | join("  ")' 2>/dev/null
 }
 
-# P0: the player introduces their character with a SINGLE say() — who they are + what
-# they're after. They do NOT act yet: the world isn't built and the scene isn't set, so
-# "firing off" actions into a void reads as the PLAYER authoring the story (owner live-QA:
-# "the player just starts making up story; there's no intro"). The DM opens the scene next
-# (D1); the player's first real action comes at beat 1.
-PMSG="$(player_move 1 "$PLAYER_BRIEF
+# P0: the player introduces their character in PLAIN TEXT — who they are + what they're after.
+# They do NOT act yet: the world isn't built and the scene isn't set, so "firing off" actions into
+# a void reads as the PLAYER authoring the story (owner live-QA: "the player just starts making up
+# story; there's no intro"). The DM opens the scene next (D1); the player's first real action comes
+# at beat 1.
+#
+# WHY PLAIN TEXT (not a say() tool call): at P0 there is no campaign/session yet, so a say() move has
+# nothing to write into — the move-intent never lands in $MOVES, and player_move (which extracts from
+# $MOVES) returns empty → "player produced no intro — aborting". A one/two-sentence text intro is all
+# the DM needs to open around the player's concept, and it carries no pre-world tool dependency. We
+# capture the agent's text via turn_retry (returns `.result`, and re-mints a fresh session id on an
+# empty cold-open attempt) so a transient blank doesn't abort the whole run — the same retry safety
+# D1 already had, which P0's bare player_move lacked.
+PMSG="$(turn_retry player "$PSID" 1 "$PLAYER_BRIEF
 
-This is the very start — the world isn't built and the scene isn't set yet. Introduce your character with a SINGLE say(\"…\"): who they are and what they want. Do NOT do()/attack/cast yet — wait for the DM to open the scene. One say(), nothing else.")"
+This is the very start — the world isn't built and the scene isn't set yet. Introduce your character in ONE OR TWO SENTENCES of plain text: who they are and what they want. Reply with prose only — do NOT call say()/do()/attack/cast yet (there is no scene to act in). The DM opens the scene next; your first action comes after.")"
 echo "[duo] player intro: ${PMSG:0:120}…"
 [ -z "$PMSG" ] && { echo "[duo] player produced no intro — aborting" >&2; exit 1; }
 chatlog player "$PMSG"

--- a/servers/engine/tests/test_dm_session_remint.py
+++ b/servers/engine/tests/test_dm_session_remint.py
@@ -122,3 +122,21 @@ def test_play_party_dm_has_live_progress_rule():
     assert "Live progress rule" in party and "log_event" in party and "narration" in party
     # parity: the codex DM path already carried this intent.
     assert "LIVE_PROGRESS_LOG_RULE" in _src("scripts/play_codex_dm.sh")
+
+
+def test_run_duo_p0_intro_is_robust_plain_text():
+    """G5: the duo's opening player intro (P0) must be a retry-safe PLAIN-TEXT capture, not a
+    pre-world say() tool call. The world/session does not exist yet at P0, so a say() move never
+    lands in $MOVES and the old bare-player_move path returned empty -> 'player produced no intro
+    -- aborting', killing every duo run before beat 1 (the G5 story/mechanical scores could never
+    be measured). The fix: capture the agent's `.result` via turn_retry (which re-mints a fresh
+    session on an empty cold-open attempt, the retry safety D1 already had and P0 lacked), and ask
+    for prose rather than a tool call. Guards against regressing to the brittle say()-into-void."""
+    duo = _src("qa/run_duo.sh")
+    # P0 routes through turn_retry (retry-safe), NOT a bare player_move that can silently abort.
+    assert 'PMSG="$(turn_retry player "$PSID" 1' in duo, "P0 intro must use turn_retry, not bare player_move"
+    # the P0 prompt asks for plain-text prose, never a mandatory pre-world say() tool call.
+    assert "ONE OR TWO SENTENCES of plain text" in duo
+    assert "do NOT call say()" in duo
+    # the abort guard stays (an intro is still required) — we made it reachable, not removed it.
+    assert "player produced no intro — aborting" in duo


### PR DESCRIPTION
## Problem

Every duo run aborted at the opening beat with `player produced no intro — aborting` (sweep_v9's duo died exactly here), so **G5 story/mechanical scores could never be measured**.

Root cause (static): P0 hard-required the player to land a `say()` **tool call** in `$MOVES`. But at P0 there is no campaign/session yet — the pre-world `say()` move has nothing to write into, so `$MOVES` stays empty and bare `player_move` returns "". P0 also uniquely used `player_move` (no cold-open retry) where D1 uses `turn_retry` — the asymmetric retry.

## Fix

- P0 now captures the agent's `.result` **plain text** via `turn_retry` (re-mints a fresh session on an empty cold-open attempt — the retry safety D1 had and P0 lacked).
- The prompt asks for a **one/two-sentence prose intro**, not a pre-world tool call.
- Design-consistent: the player still does **not** act before the scene is set; the first **tool** action is beat 1. The "intro required" abort guard stays — we made it *reachable*, not removed it.
- Strictly more robust than what it replaces (the old path always aborted).

## Guard

`test_run_duo_p0_intro_is_robust_plain_text` pins: P0 routes through `turn_retry` (not bare `player_move`), asks for plain text, and keeps the intro-required guard. `bash -n` clean; all 7 harness structural tests pass.

## Honest validation note

The **runtime** proof — does a full duo now run start-to-finish, and what are the story/mechanical scores — is a **VM-lane duo run** (the 16GB Mac OOMs on the heavy QA path; the support-VM lane exists for exactly this). This PR lands the harness fix so that G5 measurement session opens cleanly instead of aborting at beat 0. Part of #466 (release-readiness).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Character introductions now accept plain text input only (1–2 sentences); tool/action calls are no longer supported during the character introduction phase.
  * Improved session initialization handling for character intros.

* **Tests**
  * Added regression test to ensure character introduction phase stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->