### PR TITLE
fix(duo): revert P0 to say()-tagged intro + root IS_SANDBOX guard (the real beat-0 fix)

### DIFF
--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -26,6 +26,19 @@ WORLD="${2:-baldurs-gate}"
 PLAYER_PROMPT_FILE="${3:-qa/play_player_duo.txt}"
 BEATS="${4:-6}"
 BUDGET="${5:-0.80}"
+
+# ── Root + IS_SANDBOX preflight (the real beat-0 blocker, 2026-06-03) ─────────────────
+# claude refuses `--dangerously-skip-permissions` (which `--permission-mode bypassPermissions`
+# maps to) when running as root, UNLESS IS_SANDBOX=1. On a root QA host (the 32GB support VM) every
+# claude turn would otherwise return an empty `.result` and the run aborts with a confusing
+# "player produced no intro — aborting". Fail LOUDLY with the fix instead of silently. sweep_v2.sh
+# exports IS_SANDBOX=1 itself; a STANDALONE duo on the VM needs `IS_SANDBOX=1 bash qa/run_duo.sh …`.
+if [ "$(id -u)" = "0" ] && [ -z "${IS_SANDBOX:-}" ]; then
+  echo "[duo] FATAL: running as root without IS_SANDBOX=1 — claude refuses --dangerously-skip-permissions as root." >&2
+  echo "[duo]        re-run as: IS_SANDBOX=1 bash qa/run_duo.sh $*" >&2
+  exit 2
+fi
+
 # The DM model is an env var so A/B-testing Opus vs sonnet for structural adherence is a
 # one-flag flip (decision-dm-driver.md §3 "model choice as an orthogonal lever"). Default sonnet.
 CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
@@ -194,22 +207,21 @@ player_move() {
   [ -n "$new" ] && printf '%s' "$new" | jq -rs 'map("[\(.kind)] \(.text)") | join("  ")' 2>/dev/null
 }
 
-# P0: the player introduces their character in PLAIN TEXT — who they are + what they're after.
-# They do NOT act yet: the world isn't built and the scene isn't set, so "firing off" actions into
-# a void reads as the PLAYER authoring the story (owner live-QA: "the player just starts making up
+# P0: the player introduces their character with a SINGLE say() — who they are + what they're after.
+# They do NOT act yet: the world isn't built and the scene isn't set, so "firing off" actions into a
+# void reads as the PLAYER authoring the story (owner live-QA: "the player just starts making up
 # story; there's no intro"). The DM opens the scene next (D1); the player's first real action comes
 # at beat 1.
 #
-# WHY PLAIN TEXT (not a say() tool call): at P0 there is no campaign/session yet, so a say() move has
-# nothing to write into — the move-intent never lands in $MOVES, and player_move (which extracts from
-# $MOVES) returns empty → "player produced no intro — aborting". A one/two-sentence text intro is all
-# the DM needs to open around the player's concept, and it carries no pre-world tool dependency. We
-# capture the agent's text via turn_retry (returns `.result`, and re-mints a fresh session id on an
-# empty cold-open attempt) so a transient blank doesn't abort the whole run — the same retry safety
-# D1 already had, which P0's bare player_move lacked.
-PMSG="$(turn_retry player "$PSID" 1 "$PLAYER_BRIEF
+# The intro goes through say() (a TAGGED [say] move via player_move), NOT raw prose: the behavioral
+# gate `player_turns_structured` requires every player turn to be a facade move, and a raw-text intro
+# trips it RED (which caps all G5 lenses ≤2.5). An earlier "plain-text intro" experiment (#636) did
+# exactly that — it ALSO mis-diagnosed the real beat-0 blocker, which is `IS_SANDBOX=1`: on a root QA
+# host claude refuses `--dangerously-skip-permissions` → empty turn → "player produced no intro". The
+# root guard above enforces that, so the say()-based intro lands cleanly and stays a tagged move.
+PMSG="$(player_move 1 "$PLAYER_BRIEF
 
-This is the very start — the world isn't built and the scene isn't set yet. Introduce your character in ONE OR TWO SENTENCES of plain text: who they are and what they want. Reply with prose only — do NOT call say()/do()/attack/cast yet (there is no scene to act in). The DM opens the scene next; your first action comes after.")"
+This is the very start — the world isn't built and the scene isn't set yet. Introduce your character with a SINGLE say(\"…\"): who they are and what they want. Do NOT do()/attack/cast yet — wait for the DM to open the scene. One say(), nothing else.")"
 echo "[duo] player intro: ${PMSG:0:120}…"
 [ -z "$PMSG" ] && { echo "[duo] player produced no intro — aborting" >&2; exit 1; }
 chatlog player "$PMSG"

--- a/servers/engine/tests/test_dm_session_remint.py
+++ b/servers/engine/tests/test_dm_session_remint.py
@@ -124,19 +124,24 @@ def test_play_party_dm_has_live_progress_rule():
     assert "LIVE_PROGRESS_LOG_RULE" in _src("scripts/play_codex_dm.sh")
 
 
-def test_run_duo_p0_intro_is_robust_plain_text():
-    """G5: the duo's opening player intro (P0) must be a retry-safe PLAIN-TEXT capture, not a
-    pre-world say() tool call. The world/session does not exist yet at P0, so a say() move never
-    lands in $MOVES and the old bare-player_move path returned empty -> 'player produced no intro
-    -- aborting', killing every duo run before beat 1 (the G5 story/mechanical scores could never
-    be measured). The fix: capture the agent's `.result` via turn_retry (which re-mints a fresh
-    session on an empty cold-open attempt, the retry safety D1 already had and P0 lacked), and ask
-    for prose rather than a tool call. Guards against regressing to the brittle say()-into-void."""
+def test_run_duo_p0_intro_is_a_tagged_say_move():
+    """G5/behavioral: the duo's opening player intro (P0) must be a `say()` TAGGED move (via
+    player_move), NOT raw prose. The behavioral gate `player_turns_structured` requires every player
+    turn to be a facade move; a raw-text intro trips it RED and caps all G5 lenses ≤2.5 (measured on
+    the VM 2026-06-03 — the #636 plain-text intro produced exactly that). So P0 goes through
+    player_move with a 'SINGLE say()' prompt, keeping the intro a tagged [say] move."""
     duo = _src("qa/run_duo.sh")
-    # P0 routes through turn_retry (retry-safe), NOT a bare player_move that can silently abort.
-    assert 'PMSG="$(turn_retry player "$PSID" 1' in duo, "P0 intro must use turn_retry, not bare player_move"
-    # the P0 prompt asks for plain-text prose, never a mandatory pre-world say() tool call.
-    assert "ONE OR TWO SENTENCES of plain text" in duo
-    assert "do NOT call say()" in duo
-    # the abort guard stays (an intro is still required) — we made it reachable, not removed it.
+    assert 'PMSG="$(player_move 1 ' in duo, "P0 intro must go through player_move (a tagged say move)"
+    assert "SINGLE say(" in duo, "P0 prompt must ask for a say(), so the intro is a tagged move"
+    assert "ONE OR TWO SENTENCES of plain text" not in duo, "the raw-text intro (behavioral RED) must be reverted"
+    # the abort guard stays (an intro is still required).
     assert "player produced no intro — aborting" in duo
+
+
+def test_run_duo_has_root_is_sandbox_guard():
+    """The REAL beat-0 blocker on the root QA VM: claude refuses --dangerously-skip-permissions as
+    root unless IS_SANDBOX=1, so every turn returns empty and the run silently aborts. run_duo.sh
+    must fail LOUDLY (with the fix) instead of the confusing 'no intro' abort."""
+    duo = _src("qa/run_duo.sh")
+    assert '[ "$(id -u)" = "0" ] && [ -z "${IS_SANDBOX:-}" ]' in duo, "must detect root + missing IS_SANDBOX"
+    assert "IS_SANDBOX=1 bash qa/run_duo.sh" in duo, "must tell the user the exact fix"


### PR DESCRIPTION
VM measurement (2026-06-03) showed PR #636's plain-text P0 intro was wrong on two counts:

1. **Mis-diagnosed the blocker.** The real beat-0 cause on the root QA VM is **`IS_SANDBOX=1`**: claude refuses `--dangerously-skip-permissions` as root → empty `.result` → "player produced no intro — aborting". Adds a **loud root+no-IS_SANDBOX preflight guard** (fails with the exact fix, not a silent abort). `sweep_v2.sh` already exports it; a standalone duo needs `IS_SANDBOX=1 bash qa/run_duo.sh …`.
2. **Behavioral RED.** A raw-text intro trips `player_turns_structured` (1 player turn bypassed the facade) → behavioral RED → caps all G5 lenses ≤2.5. Reverts P0 to the **`say()`-based player_move** so the intro is a tagged `[say]` move → behavioral GREEN. With IS_SANDBOX set, the say() intro lands cleanly (verified: smoke ran past P0, DM canon-substituted, engine rolled, clock advanced).

Guards: `test_run_duo_p0_intro_is_a_tagged_say_move` + `test_run_duo_has_root_is_sandbox_guard`. bash -n clean. Net effect of #636 kept: none of the plain-text change; the genuine improvement (a clear root-guard) is added here instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added root permission guard to prevent empty output failures; script now requires `IS_SANDBOX=1` when executed as root.

* **Refactor**
  * Player character introductions now use structured tool-based input, ensuring consistent character setup before the game begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->