### PR TITLE
fix(skills): normalize skill-name case — optimizer crit '0 proficient' on a canon L5 Wizard

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -762,6 +762,19 @@ class Character(_StrictModel):
             res.used = max(0, min(res.used, res.max))
         return self
 
+    @model_validator(mode="after")
+    def _normalize_skill_case(self) -> "Character":
+        # Skill names are compared case-sensitively everywhere (skill_bonus below, social_check,
+        # the viewer's Skills tab) against the lowercase-underscore SKILL_ABILITIES keys. Canon
+        # character records and DM `patch={"skills":["Arcana",...]}` aliases introduce CAPITALIZED
+        # (or space-separated) names, which then silently match nothing -> "0 proficient" + skill
+        # checks missing the proficiency bonus (QA 2026-06-03: optimizer crit on a L5 Wizard/Sage
+        # whose Arcana/History showed +3 not +6). load_canon_character runs this via model_validate,
+        # so normalizing at the model boundary fixes every seat/patch path and the saved snapshot.
+        self.skill_proficiencies = [str(s).strip().lower().replace(" ", "_") for s in self.skill_proficiencies if str(s).strip()]
+        self.skill_expertise = [str(s).strip().lower().replace(" ", "_") for s in self.skill_expertise if str(s).strip()]
+        return self
+
     @property
     def total_level(self) -> int:
         return sum(c.level for c in self.classes) or 1

--- a/servers/engine/tests/test_character_skill_normalization.py
+++ b/servers/engine/tests/test_character_skill_normalization.py
@@ -1,0 +1,46 @@
+"""Character skill-name case normalization (QA 2026-06-03 — optimizer crit).
+
+A canon-character record (or a DM `patch={"skills":["Arcana",...]}` alias) can introduce skill
+names that are Capitalized or space-separated. Skill names are compared case-sensitively everywhere
+(Character.skill_bonus, social_check, the viewer Skills tab) against the lowercase-underscore
+SKILL_ABILITIES keys, so an un-normalized capitalized list silently matches nothing → "0 proficient"
+and skill checks that miss the proficiency bonus (a L5 Wizard/Sage showed Arcana +3 instead of +6).
+Character._normalize_skill_case normalizes at the model boundary; load_canon_character runs it via
+model_validate, so the seat path + saved snapshot end up correct.
+"""
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location("wos_models", Path(__file__).resolve().parents[1] / "models.py")
+models = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(models)
+
+
+def test_skill_names_normalized_to_lowercase_underscore():
+    ch = models.Character.model_validate({
+        "id": "rolan", "name": "Rolan",
+        "classes": [{"name": "Wizard", "level": 5}],
+        "abilities": {"intelligence": 17},
+        "proficiency_bonus": 3,
+        "skill_proficiencies": ["Arcana", "History", "Animal Handling"],
+        "skill_expertise": ["Sleight Of Hand"],
+    })
+    assert ch.skill_proficiencies == ["arcana", "history", "animal_handling"]
+    assert ch.skill_expertise == ["sleight_of_hand"]
+
+
+def test_skill_bonus_finds_proficiency_after_normalization():
+    """The whole point: skill_bonus must add the proficiency bonus for a (formerly capitalized)
+    proficient skill — Arcana = INT mod + proficiency_bonus, not the bare INT mod."""
+    ch = models.Character.model_validate({
+        "id": "rolan", "name": "Rolan",
+        "classes": [{"name": "Wizard", "level": 5}],
+        "abilities": {"intelligence": 17},  # +3
+        "proficiency_bonus": 3,
+        "skill_proficiencies": ["Arcana"],
+    })
+    int_mod = ch.ability_modifier(models.SKILL_ABILITIES["arcana"])
+    assert ch.skill_bonus("arcana") == int_mod + 3
+    # a non-proficient skill stays at the bare ability modifier
+    assert ch.skill_bonus("nature") == ch.ability_modifier(models.SKILL_ABILITIES["nature"])

--- a/servers/engine/tests/test_character_skill_normalization.py
+++ b/servers/engine/tests/test_character_skill_normalization.py
@@ -8,17 +8,12 @@ and skill checks that miss the proficiency bonus (a L5 Wizard/Sage showed Arcana
 Character._normalize_skill_case normalizes at the model boundary; load_canon_character runs it via
 model_validate, so the seat path + saved snapshot end up correct.
 """
-import importlib.util
-from pathlib import Path
-
-_SPEC = importlib.util.spec_from_file_location("wos_models", Path(__file__).resolve().parents[1] / "models.py")
-models = importlib.util.module_from_spec(_SPEC)
-assert _SPEC.loader is not None
-_SPEC.loader.exec_module(models)
+import server  # noqa: F401 — importing the engine resolves Character's forward refs (model_rebuild)
+from models import Character, SKILL_ABILITIES
 
 
 def test_skill_names_normalized_to_lowercase_underscore():
-    ch = models.Character.model_validate({
+    ch = Character.model_validate({
         "id": "rolan", "name": "Rolan",
         "classes": [{"name": "Wizard", "level": 5}],
         "abilities": {"intelligence": 17},
@@ -33,14 +28,14 @@ def test_skill_names_normalized_to_lowercase_underscore():
 def test_skill_bonus_finds_proficiency_after_normalization():
     """The whole point: skill_bonus must add the proficiency bonus for a (formerly capitalized)
     proficient skill — Arcana = INT mod + proficiency_bonus, not the bare INT mod."""
-    ch = models.Character.model_validate({
+    ch = Character.model_validate({
         "id": "rolan", "name": "Rolan",
         "classes": [{"name": "Wizard", "level": 5}],
         "abilities": {"intelligence": 17},  # +3
         "proficiency_bonus": 3,
         "skill_proficiencies": ["Arcana"],
     })
-    int_mod = ch.ability_modifier(models.SKILL_ABILITIES["arcana"])
+    int_mod = ch.ability_modifier(SKILL_ABILITIES["arcana"])
     assert ch.skill_bonus("arcana") == int_mod + 3
     # a non-proficient skill stays at the bare ability modifier
-    assert ch.skill_bonus("nature") == ch.ability_modifier(models.SKILL_ABILITIES["nature"])
+    assert ch.skill_bonus("nature") == ch.ability_modifier(SKILL_ABILITIES["nature"])

--- a/servers/engine/tests/test_qa_fixes.py
+++ b/servers/engine/tests/test_qa_fixes.py
@@ -158,8 +158,12 @@ def test_update_character_skills_alias_maps_to_proficiencies(tmp_path, monkeypat
     pc = server.create_character(cid, "Hero", kind="player", max_hp=10)["id"]
     out = server.update_character(
         cid, pc, {"skills": ["Arcana", "History"], "expertise": ["Arcana"]})
-    assert out["skill_proficiencies"] == ["Arcana", "History"]
-    assert out["skill_expertise"] == ["Arcana"]
+    # Normalized to the lowercase-underscore SKILL_ABILITIES keys (Character._normalize_skill_case,
+    # 2026-06-03): a DM passing the natural Capitalized names must STILL produce proficiencies that
+    # match everywhere (skill_bonus / the viewer Skills tab) — capitalized values silently matched
+    # nothing and rendered "0 proficient" (optimizer crit).
+    assert out["skill_proficiencies"] == ["arcana", "history"]
+    assert out["skill_expertise"] == ["arcana"]
     with pytest.raises(Exception):
         server.update_character(cid, pc, {"skilz": ["Stealth"]})
 

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3326,6 +3326,16 @@ def _ability_mod(score: object) -> int:
     return ((int(s) - 10) // 2) if s is not None else 0
 
 
+def _norm_skills(v: object) -> list:
+    """Normalize a snapshot skill list to the lowercase-underscore keys the projection compares
+    against (mirrors models.Character._normalize_skill_case). Stale snapshots seated before that
+    engine normalizer can carry CAPITALIZED canon names (e.g. ['Arcana','History']) — without this
+    the case mismatch renders '0 proficient' and drops the proficiency bonus (QA 2026-06-03)."""
+    if not isinstance(v, list):
+        return []
+    return [str(s).strip().lower().replace(" ", "_") for s in v if str(s).strip()]
+
+
 def _skill_bonus_from_sheet(ch: dict, skill: str) -> int:
     """Mirror Character.skill_bonus off raw snapshot fields: ability modifier of the
     skill's governing ability + proficiency (doubled on expertise)."""
@@ -3336,8 +3346,8 @@ def _skill_bonus_from_sheet(ch: dict, skill: str) -> int:
     bonus = _ability_mod(abilities.get(ability))
     prof = _num(ch.get("proficiency_bonus"))
     prof = int(prof) if prof is not None else 2
-    expertise = ch.get("skill_expertise") if isinstance(ch.get("skill_expertise"), list) else []
-    proficiencies = ch.get("skill_proficiencies") if isinstance(ch.get("skill_proficiencies"), list) else []
+    expertise = _norm_skills(ch.get("skill_expertise"))
+    proficiencies = _norm_skills(ch.get("skill_proficiencies"))
     if skill in expertise:
         bonus += 2 * prof
     elif skill in proficiencies:
@@ -3476,8 +3486,10 @@ def _character_sheet(cid: str, ch: dict) -> dict:
     })
 
     # Skills: project the SRD skill list with sheet-correct bonuses (proficient first).
-    proficiencies = ch.get("skill_proficiencies") if isinstance(ch.get("skill_proficiencies"), list) else []
-    expertise = ch.get("skill_expertise") if isinstance(ch.get("skill_expertise"), list) else []
+    # Normalize case so capitalized canon names (['Arcana',...]) on a stale snapshot still match
+    # the lowercase SKILL_ABILITIES keys — else the Skills tab shows "0 proficient" (QA 2026-06-03).
+    proficiencies = _norm_skills(ch.get("skill_proficiencies"))
+    expertise = _norm_skills(ch.get("skill_expertise"))
     skill_ids = list(dict.fromkeys([*proficiencies, *expertise, *_SKILL_ABILITIES.keys()]))
     skills = [
         {"name": sk.replace("_", " ").title(), "mod": _skill_bonus_from_sheet(ch, sk),

--- a/viewer/tests/test_charsheet_depth.py
+++ b/viewer/tests/test_charsheet_depth.py
@@ -240,6 +240,23 @@ class CharsheetDepthTests(unittest.TestCase):
         self.assertFalse(self._party(surface2)["elara"]["pendingSubclass"])
         self.assertFalse(self._party(surface2)["thornwick"]["pendingSubclass"])
 
+    def test_capitalized_skill_proficiencies_still_project(self):
+        """QA 2026-06-03 (optimizer crit, sat=4): a canon-seated character can carry CAPITALIZED
+        skill names on a stale snapshot (['Arcana','History',...]). The Skills tab must still mark
+        them proficient WITH the proficiency bonus, not '0 proficient' — a case mismatch against the
+        lowercase SKILL_ABILITIES keys. Mirrors the engine Character._normalize_skill_case."""
+        ch = copy.deepcopy(_SNAPSHOT["characters"]["elara"])  # INT 16 (+3), proficiency_bonus 2
+        ch["skill_proficiencies"] = ["Arcana", "History", "Investigation", "Perception"]
+        ch["skill_expertise"] = []
+        sheet = server._character_sheet("elara", ch)
+        by_name = {s["name"]: s for s in sheet["skills"]}
+        proficient = [s for s in sheet["skills"] if s["proficient"]]
+        self.assertEqual(len(proficient), 4, "all 4 capitalized proficiencies must project as proficient")
+        self.assertTrue(by_name["Arcana"]["proficient"])
+        # Arcana (INT) = INT mod (+3) + proficiency (+2) = +5, NOT the raw +3 of the case-broken bug.
+        self.assertEqual(by_name["Arcana"]["mod"], 5)
+        self.assertFalse(by_name["Acrobatics"]["proficient"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Found by the 2026-06-03 VM 5-persona sweep on the picker build** (optimizer sat=4, lowest, critical bug).

The optimizer (a min-maxer) opened Party → Heroes → Skills and saw **'0 proficient'** for a Level-5 Wizard/Sage — every skill showed the raw ability mod (Arcana +3, not +6). Root cause: the seated canon character (Rolan) carries **CAPITALIZED** `skill_proficiencies` `['Arcana','History','Investigation','Perception']`, but every consumer compares case-sensitively against the lowercase `SKILL_ABILITIES` keys (`Character.skill_bonus`, `social_check`, the viewer Skills tab) → matches nothing → 0 proficient **and skill checks miss the proficiency bonus**.

**Fix (root + robustness):**
- **Engine:** `Character._normalize_skill_case` (model_validator) lowercases+underscores `skill_proficiencies`/`skill_expertise` at the model boundary. `load_canon_character` runs it via `model_validate`, so the seat path AND the saved snapshot are normalized → `skill_bonus` works.
- **Viewer:** `_norm_skills()` makes `_skill_bonus_from_sheet` + the Skills projection case-insensitive, so even a STALE capitalized snapshot renders correctly (the .app reads the viewer live).

**Validated on the VM against the optimizer's REAL snapshot:** proficient 0 → **4** (Arcana +6, History +6, Investigation +6, Perception +4). Guards: `test_character_skill_normalization` (engine, 2) + `test_capitalized_skill_proficiencies_still_project` (viewer). Closes the Skills-tab critical; the optimizer's broader 'data-layer pass' (gear/spell-prep/subclass-feature preview) + the Parley state-corruption crit are tracked separately.