### PR TITLE
fix(#640): single-flight the cold-open campaign — the #1 G3 blocker (is_live_view lockout)

### DIFF
--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -174,14 +174,40 @@ PY
 # (the persona/agenda NEVER does). Prints JSON: {campaign_id, companions:[{id,name,persona}]}.
 # Run under `uv` from the engine dir (its venv has mcp/pydantic; bare python3 lacks them).
 SEED_JSON="$(CLAWDND_STATE_DIR="$STATE_DIR" uv run --directory "$ROOT/servers/engine" python - "$WORLD" "$COMPANION_SPEC" <<'PY'
-import json, sys
+import json, sys, os, glob, time
 world, spec = sys.argv[1], sys.argv[2]
 import server  # engine tools as plain functions (state dir from CLAWDND_STATE_DIR; cwd is the engine dir)
 
-# A new campaign in this world, with an active session. If the world returns existing
-# campaigns we still start a fresh one (start_world mints a new campaign id).
-camp = server.start_world(world)["campaign_id"]
-server.start_session(camp, title="Dashboard party")
+# Single-flight (#640): REUSE a RECENT, fully-seeded campaign in this state dir rather than minting a
+# parallel one. The .app's native RESUME and the part-B harness each run this pre-seed; minting a
+# fresh campaign each launch creates DIVERGENT campaigns, so the viewer's is_live_view (= viewed ==
+# attached) latches False → frozen chronicle + "viewing non-live campaign" read-only lockout (the #1
+# cross-persona G3 blocker, measured 2026-06-03). The 30-min window scopes reuse to THIS run, so a
+# stale cross-run campaign in the same state dir is never resurrected.
+camp = None
+companions = []
+_camps_dir = os.path.join(os.environ.get("CLAWDND_STATE_DIR", ""), "campaigns")
+for _snap in sorted(glob.glob(os.path.join(_camps_dir, "camp_*", "snapshot.json")), key=os.path.getmtime, reverse=True):
+    if time.time() - os.path.getmtime(_snap) > 1800:
+        break  # newest-first list; once we pass the window, all the rest are older too
+    try:
+        _d = json.load(open(_snap))
+    except Exception:
+        continue
+    if _d.get("world_id") != world:
+        continue
+    _comps = [{"id": _cid, "name": _c.get("name"), "persona": "qa/play_companion.txt"}
+              for _cid, _c in (_d.get("characters") or {}).items() if _c.get("kind") == "companion"]
+    if _comps:  # a prior launch already seeded this world here → reuse it (no parallel campaign)
+        camp = _d.get("campaign_id") or os.path.basename(os.path.dirname(_snap))
+        companions = _comps
+        break
+
+_minted = camp is None
+if _minted:
+    # A new campaign in this world, with an active session (first launch / no recent campaign).
+    camp = server.start_world(world)["campaign_id"]
+    server.start_session(camp, title="Dashboard party")
 
 # Each companion: a fresh kind="companion" with an SRD sheet, added to the party. The
 # player PC is intentionally NOT created here (the DM creates the human PC live). Spec
@@ -191,8 +217,7 @@ server.start_session(camp, title="Dashboard party")
 # sealed agenda (that lives solely in the persona PROMPT, read later by the shell).
 # Companions are COMMA-separated (so a spell field can contain spaces like "Cure Wounds");
 # fields within a token are ":"-separated; spells "|"-separated.
-companions = []
-for tok in (t for t in spec.split(",") if t.strip()):
+for tok in (t for t in (spec.split(",") if _minted else []) if t.strip()):
     parts = tok.strip().split(":")
     name = parts[0].strip()
     cls = parts[1] if len(parts) > 1 and parts[1] else "fighter"

--- a/servers/engine/tests/test_dm_session_remint.py
+++ b/servers/engine/tests/test_dm_session_remint.py
@@ -145,3 +145,15 @@ def test_run_duo_has_root_is_sandbox_guard():
     duo = _src("qa/run_duo.sh")
     assert '[ "$(id -u)" = "0" ] && [ -z "${IS_SANDBOX:-}" ]' in duo, "must detect root + missing IS_SANDBOX"
     assert "IS_SANDBOX=1 bash qa/run_duo.sh" in duo, "must tell the user the exact fix"
+
+
+def test_play_party_single_flights_the_cold_open_campaign():
+    """#640 (the #1 cross-persona G3 blocker): play_party.sh must REUSE a recent seeded campaign in
+    its state dir rather than start_world-minting a fresh one on every launch. The .app native RESUME
+    and the part-B harness each run the pre-seed; parallel campaigns made the viewer's is_live_view
+    (= viewed == attached) latch False → frozen chronicle + 'viewing non-live campaign' read-only
+    lockout (newbie/narrative/adversarial, 2026-06-03). Verified on the VM: 3 launches → 1 campaign."""
+    party = _src("scripts/play_party.sh")
+    assert "Single-flight (#640)" in party, "play_party.sh lost the single-flight reuse"
+    assert "_minted = camp is None" in party, "must only mint when no recent campaign was reused"
+    assert "time.time() - os.path.getmtime" in party, "reuse must be scoped by a recency window (this run only)"


### PR DESCRIPTION
Closes the #1 cross-persona G3 blocker from the 2026-06-03 sweep: the chronicle-freeze + "viewing non-live campaign" read-only lockout that hit newbie/narrative/adversarial (3/5).

## Root cause
`is_live_view = (live AND viewed_campaign == attached_campaign)` (viewer/server.py:5717,6419). It latched **False** because the run accumulated **multiple campaigns**: `play_party.sh` mints a fresh one every launch (`start_world`), and the .app native RESUME + the part-B harness each run the pre-seed → divergent campaigns; the viewer attaches by recency to the wrong one and the self-healing refuses the parallel store. (Evidence: vm2-newbie-b had 4 campaigns.)

## Fix
`play_party.sh` pre-seed now **reuses a RECENT (30-min window = this run only), fully-seeded campaign** in its state dir instead of minting a parallel one; it mints fresh only when none exists. A stale cross-run campaign is never resurrected (outside the window).

## Validated on the VM (the real engine + the actual pre-seed)
**3 launches → 1 campaign** (`camp_24d82d7e52d3` reused all 3); companions correctly surfaced on reuse; the mint path (1st launch) still seeds normally. Guard: `test_play_party_single_flights_the_cold_open_campaign` + the existing structural suite. bash -n clean.

## Acceptance (next sweep)
A fresh `ui_playtest_app.sh` run produces **exactly one** play-store campaign; `/session-surface` reports `is_live_view=true`/`can_act=true` throughout; no lockout; chronicles advance every beat. Verified on the NEXT built-.app sweep (non-reproduction).