### PR TITLE
ui-audit(seed/#258): drop false chrome-palette promise from Tone notes (S-06)

### DIFF
--- a/viewer/openworlds/screen-seed.jsx
+++ b/viewer/openworlds/screen-seed.jsx
@@ -9,11 +9,16 @@
 // Option tables: each control shows a human LABEL but submits the engine VALUE the
 // /seed-surface params bind to (e.g. narration "florid", chronicle_voice "first_person_plural").
 const SEED_OPTIONS = {
+  // Notes describe the NARRATIVE register each tone sows (what the engine actually shapes via
+  // the chronicle), NOT a chrome palette. The chrome palette is the user's own theme tweak
+  // (app.jsx `data-palette`: warm/cool/dark) and is decoupled from the seed tone — the old copy
+  // ("Gold, royal blue, candlelight" / "Crimson and walnut" / "Brass and oxblood") promised a
+  // visual shift that selecting a tone never produces (S-06). Honest copy, render-only.
   tone: [
-    { value: "Heroic", label: "Heroic", note: "Gold, royal blue, candlelight. Players are who they say they are." },
-    { value: "Grim", label: "Grim", note: "Crimson and walnut. Successes are uncomfortable. Most are." },
+    { value: "Heroic", label: "Heroic", note: "Players are who they say they are. Valour reads as valour." },
+    { value: "Grim", label: "Grim", note: "Successes are uncomfortable. Most are." },
     { value: "Picaresque", label: "Picaresque", note: "The party will lie. The chronicle will pretend not to notice." },
-    { value: "Mythic", label: "Mythic", note: "Brass and oxblood. The land is older than the law and is winning." },
+    { value: "Mythic", label: "Mythic", note: "The land is older than the law, and is winning." },
   ],
   difficulty: [
     { value: "easy", label: "Story", note: "Combat is forgiving. The chronicle is the point." },


### PR DESCRIPTION
Implements the one remaining concrete, in-scope finding from the **World Seed** audit (#258 / `docs/ui-audit/screens/seed.md`). The screen was already rewritten to the live `/seed-surface` read model + `/seed-param` write lane (#266, commit `50b2f4e`), which resolved the bulk of the audit. This PR closes the last screen-local honesty gap.

## Implemented

**S-06 (Major) — Tone decoupled from chrome, but copy promised a palette shift.**
The Tone selector notes asserted a chrome palette ("Gold, royal blue, candlelight" / "Crimson and walnut" / "Brass and oxblood"), but selecting a tone changes nothing visual — `data-palette` (warm/cool/dark) is the user's own theme tweak in `app.jsx` (lines 700–701) and is fully decoupled from the seed `tone` param. The audit acceptance offers two options:
- (a) link Tone to `data-palette`, OR
- (b) **drop the visual implication from the copy.**

This PR takes **(b)** — the scoped, render-only fix. Option (a) would require the viewer to drive global chrome from one screen, invent a tone→palette mapping the read model does not emit, and fight the user's theme tweak — out of scope and a violation of "never fabricate engine state." The Tone notes now describe the **narrative register** each tone actually shapes (what the engine does via the chronicle), with no false visual promise.

## Already resolved upstream (verified in source — not re-implemented)

| Finding | Status | Evidence |
|---|---|---|
| S-02 — display-only / no write lane | **Resolved** | `writeParam` POSTs to `/seed-param`; `mutability`/`can_act`/`session_started` gate it (`screen-seed.jsx:124-160`, `server.py:build_seed_surface`). |
| S-03 — hardcoded quote/date/by/pattern/engine | **Resolved** | `_seed_identity` de-fakes every StatLine from real campaign fields; empty-state added (`server.py:3056-3080`, `screen-seed.jsx:163-175,244-252`). |
| S-07 — toggles local-state only | **Resolved** | `SeedToggle` calls `writeParam(...)` for permadeath/fate_dice/item_destruction/anachronism (`screen-seed.jsx:345-371`). |
| S-08 — chronicler's notes uncontrolled `defaultValue` | **Resolved** | `SeedNotes` is controlled and commits on blur via `writeParam` (`screen-seed.jsx:376-381,390-420`). |
| S-09 — generic quote attribution | **Resolved** | Quote is now an on-theme, world-neutral epigraph with a documenting comment (`screen-seed.jsx:192-210`). |
| S-10 — "Pattern" reads as random hex | **Resolved** | `_seed_pattern` derives a stable sha1 fingerprint from the campaign id (`server.py:3046-3053`). |

## Out of scope for this screen (not implemented — by design)

- **S-01** (title-bar overlap) — cross-cutting `chrome.jsx`, explicitly "See L-01"; not screen-seed.
- **S-04** (Reseed 2-step confirm) — there is no destructive reseed write lane in the engine. The button honestly toasts "not yet wired"; building a type-to-confirm modal that leads nowhere, or fabricating an engine reseed lane, would be worse. Deferred.
- **S-05** (consolidate with launcher's `NewCampaignModal`) — cross-file change in `screen-launcher.jsx`; out of scope (do-not-touch other screens).

## Validation
- JSX transformed cleanly through `viewer/openworlds/vendor/babel-standalone-7.29.0.min.js` (node + vm).
- `pytest viewer/tests/test_seed_surface.py viewer/tests/test_openworlds_static.py` → **80 passed** (the static guard re-transforms every JSX through babel). No test referenced the old copy.

Closes part of #258 (S-06). Read model untouched; additive, render-only.
