### PR TITLE
fix(openworlds): add aasimar lineage to RACES + regression guard (Closes #375)

### DIFF
--- a/viewer/openworlds/screen-create.jsx
+++ b/viewer/openworlds/screen-create.jsx
@@ -908,6 +908,18 @@ const RACES = {
     body: "Strong enough to end the argument and stubborn enough to outlast it. Refuses to fall when a lesser frame would, and rises angrier.",
     bonus: { str: 2, con: 1 },
   },
+  // Aasimar — added to make Dame Aylin's PORTRAIT_GALLERY entry
+  // (race: "aasimar") validate. Per 5e canon (Protector tradition): CHA +2,
+  // WIS +1. Closes #375 (the race-tag drift where the gallery filter never
+  // matches because no RACES key equals "aasimar"). Subraces deferred.
+  aasimar: {
+    name: "Aasimar",
+    size: "Medium",
+    life: "160 years",
+    glyph: "aasimar",
+    body: "Touched by something brighter once. Bears a heritage older than empires, and the unsettling habit of catching candle-light at the wrong angles. Born to the Upper Planes' echo; walks the world unsure whether to atone or to lead.",
+    bonus: { cha: 2, wis: 1 },
+  },
 };
 
 const CLASSES = {

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -1576,6 +1576,41 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertFalse(surface["can_act"])
         self.assertFalse(surface["is_live_view"])
 
+    def test_openworlds_create_portrait_gallery_races_are_valid_races_keys(self):
+        # #375: PORTRAIT_GALLERY tags each face with a `race`, and the portrait filter
+        # (`p.race === hero.race`) can only ever match a race the player can actually pick —
+        # i.e. a key in RACES (StepRace renders Object.entries(RACES)). Dame Aylin was tagged
+        # race:"aasimar" with no matching RACES key, so she was unreachable from the picker.
+        # This guard keeps every gallery race tag resolvable to a RACES key (drift would make a
+        # canon face silently un-selectable for any lineage) and pins aasimar as a real key.
+        status, ctype, body = self._get("/openworlds/screen-create.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+
+        # Extract the RACES object body and collect its top-level keys (bare ident or "quoted").
+        races_match = re.search(r"const RACES = \{(.*?)\n\};", source, re.S)
+        self.assertIsNotNone(races_match, "RACES object not found in screen-create.jsx")
+        races_body = races_match.group(1)
+        race_keys = set(
+            re.findall(r'^\s{2}(?:"([a-z-]+)"|([a-z-]+)):\s*\{', races_body, re.M)
+        )
+        race_keys = {quoted or bare for quoted, bare in race_keys}
+        self.assertIn("human", race_keys)  # sanity: parser found real keys
+        self.assertIn("aasimar", race_keys, "aasimar must be a RACES key (closes #375)")
+
+        # Every PORTRAIT_GALLERY race tag must be a key the player can actually select.
+        gallery_races = set(re.findall(r'race:\s*"([a-z-]+)"', source))
+        self.assertIn("aasimar", gallery_races)  # sanity: Dame Aylin's tag is present
+        unknown = sorted(gallery_races - race_keys)
+        self.assertEqual(unknown, [], f"PORTRAIT_GALLERY race tags missing from RACES: {unknown}")
+
+        # Dame Aylin specifically is now reachable: her tag resolves to a real RACES key.
+        aylin_match = re.search(r'slug:\s*"dame-aylin"[^}]*?race:\s*"([a-z-]+)"', source)
+        self.assertIsNotNone(aylin_match, "Dame Aylin gallery row not found")
+        self.assertIn(aylin_match.group(1), race_keys)
+
     def _write_snapshot(self, campaign_dir: Path, payload: dict) -> None:
         campaign_dir.mkdir(parents=True)
         (campaign_dir / "snapshot.json").write_text(json.dumps(payload), encoding="utf-8")


### PR DESCRIPTION
## TL;DR

Adds `aasimar` as a first-class lineage in `RACES` (CHA +2, WIS +1 per 5e canon Protector tradition), retroactively validating Dame Aylin's existing `PORTRAIT_GALLERY` entry (`race: "aasimar"`). **Revives PR #389**, rebased onto current main, and adds the regression guard #389 lacked.

## The bug (#375)

`PORTRAIT_GALLERY` tags Dame Aylin with `race: "aasimar"`, but `aasimar` was not a key in `RACES`. Because `StepRace` renders `Object.entries(RACES)`, no selectable `hero.race` could ever equal `"aasimar"`, so the portrait filter (`p.race === hero.race`) never matched — Dame Aylin was unreachable from the picker for every lineage.

## What this lands

Two files, **additive only** (47 insertions, 0 deletions):

1. `viewer/openworlds/screen-create.jsx` — one new `aasimar` entry appended to the `RACES` table:
```jsx
aasimar: {
  name: "Aasimar",
  size: "Medium",
  life: "160 years",
  glyph: "aasimar",
  body: "Touched by something brighter once. …",
  bonus: { cha: 2, wis: 1 },
},
```

2. `viewer/tests/test_openworlds_static.py` — **regression guard** `test_openworlds_create_portrait_gallery_races_are_valid_races_keys`. It parses the `RACES` keys + every `PORTRAIT_GALLERY` race tag out of the served `screen-create.jsx` and asserts every gallery race tag resolves to a real `RACES` key (with `aasimar` pinned + Dame Aylin's tag specifically resolved). This is the test the issue explicitly asked for ("assert every PORTRAIT_GALLERY[i].race is a key in RACES") and the piece PR #389 was missing.

## Verification

- **JSX validated** through `viewer/openworlds/vendor/babel-standalone-7.29.0.min.js` (node+vm) — the file is served as `text/babel` with no build step, so it must parse. Transforms cleanly (52,830 bytes output).
- **Guard verified RED→GREEN**: fails (`'aasimar' not found in {...}`) with the `RACES` entry removed; passes with the fix in place.
- Related static create-screen tests still pass.

## Why option (1), not re-tagging Aylin

#375 offered: (1) add aasimar to RACES, or (2) re-tag Dame Aylin → human. Picked (1). Aasimar is a canonical 5e lineage (Volo's Guide) and a canonical BG3 planetouched lineage — players from D&D Beyond / BG3 expect it on a creation screen. Re-tagging would patch the drift at the cost of CRPG-canon fidelity.

## Scope / invariants

- Engine untouched (no state-writer change); schema untouched; `_MOVE_FIELDS` allowlist untouched.
- Subraces (Protector / Scourge / Fallen) and the full racial trait set are deferred — consistent with the other 11 races, none of which expose subraces or full trait sets yet.

Closes #375.