### PR TITLE
fix(#253): journal — All-caught-up advisory pill (J-06) + non-letter drop-cap guard (J-08)

### DIFF
--- a/viewer/openworlds/screen-journal.jsx
+++ b/viewer/openworlds/screen-journal.jsx
@@ -22,6 +22,14 @@ function jNpcScope(n) {
   return (n && n.id) ? "portrait-" + n.id : "";
 }
 
+// Drop-cap guard (J-08): the .dropcap class floats a giant ::first-letter, which looks
+// broken when the entry opens on a digit or punctuation (e.g. a quote or "3 days ago…").
+// Only opt into the drop-cap when the first non-space character is an actual letter.
+function journalDropcap(entry) {
+  const ch = String(entry == null ? "" : entry).trim().charAt(0);
+  return /\p{L}/u.test(ch) ? "body dropcap" : "body";
+}
+
 function journalQuestInTab(q, tab) {
   if (tab === "active") return q.status === "active";
   if (tab === "complete") return q.status === "complete";
@@ -194,6 +202,27 @@ function ScreenJournal({ onNavigate, state, setState }) {
             </div>
           </div>
         )}
+
+        {/* "All caught up" pill (J-06) — when the campaign owes nothing structural, show a
+            small emerald reassurance instead of an empty rail. Gated on a real advisory
+            (source !== "empty"): never fabricated on the no-snapshot / demo fallback, where
+            an honest journal has nothing to say about debts. */}
+        {advisory.source && advisory.source !== "empty" && advisory.total_debts === 0 &&
+          !(Array.isArray(advisory.debts) && advisory.debts.length > 0) && (
+          <div style={{ marginTop: 12, paddingTop: 12, borderTop: "1px dashed rgba(80,50,20,0.3)" }}>
+            <div className="eyebrow" style={{ color: "var(--crimson)", marginBottom: 6 }}>GM Advisory</div>
+            <div style={{
+              display: "inline-flex", alignItems: "center", gap: 6,
+              padding: "5px 10px",
+              background: "rgba(60,140,90,0.12)",
+              boxShadow: "inset 0 0 0 1px var(--emerald)",
+              color: "var(--emerald)",
+            }}>
+              <span aria-hidden="true">✓</span>
+              <span className="eyebrow" style={{ fontSize: 9 }}>All caught up</span>
+            </div>
+          </div>
+        )}
       </Panel>
 
       {/* RIGHT — Two-page spread */}
@@ -254,7 +283,7 @@ function ScreenJournal({ onNavigate, state, setState }) {
 
             <Divider />
 
-            <p className="body dropcap" style={{ marginTop: 0 }}>
+            <p className={journalDropcap(quest.entry)} style={{ marginTop: 0 }}>
               {quest.entry}
             </p>
 

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -252,6 +252,29 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn("title: \"No active quests\"", source)
         self.assertNotIn("|| quests[0] ||", source)
 
+    def test_journal_all_caught_up_pill_is_gated_on_real_advisory(self):
+        """J-06: a clean campaign shows an 'All caught up' pill, but only when the advisory
+        came from a real snapshot (source != 'empty') — never fabricated on the demo
+        fallback."""
+        status, ctype, body = self._get("/openworlds/screen-journal.jsx")
+        self.assertEqual(status, 200)
+        source = body.decode("utf-8")
+        self.assertIn("All caught up", source)
+        # The pill must be gated: a real source AND zero debts.
+        self.assertIn('advisory.source !== "empty"', source)
+        self.assertIn("advisory.total_debts === 0", source)
+
+    def test_journal_dropcap_skips_non_letter_entries(self):
+        """J-08: the floated drop-cap is only applied when the entry opens on a letter, so a
+        quest entry starting with a digit or punctuation does not get a broken cap."""
+        status, ctype, body = self._get("/openworlds/screen-journal.jsx")
+        self.assertEqual(status, 200)
+        source = body.decode("utf-8")
+        self.assertIn("function journalDropcap(entry)", source)
+        # The dropcap class is applied via the helper, not hardcoded on the <p>.
+        self.assertIn("className={journalDropcap(quest.entry)}", source)
+        self.assertNotIn('<p className="body dropcap"', source)
+
     def test_app_status_route_exposes_agent_probe_contract(self):
         campaign_dir = self._tmp / "campaigns" / "camp_live"
         self._write_snapshot(


### PR DESCRIPTION
Implements the remaining open findings on the **Quest Journal** screen audit (#253). Most J-findings already landed in prior journal passes (#239, #362, the name-slug portrait commit); this PR closes the two minor render-only ones that were still open, plus confirms the rest are resolved.

## Implemented
- **J-06 (Minor) — GM Advisory "All caught up" pill.** When the Campaign Director advisory has `total_debts === 0` AND the advisory came from a real snapshot (`source !== "empty"`), the left rail now shows a small emerald "All caught up" pill instead of rendering nothing. Gated so the no-snapshot / demo fallback never fabricates a green reassurance. Uses only fields already emitted by `build_journal_surface` → `_director_advisory` (`total_debts`, `source`). `screen-journal.jsx`.
- **J-08 (Minor) — Drop-cap on non-letter entries.** Added a `journalDropcap(entry)` helper that only applies the floated `.dropcap` (`::first-letter`) when the quest entry opens on a letter (Unicode `\p{L}`). Entries starting with a digit or punctuation now render plain instead of a broken giant cap. `screen-journal.jsx`.

## Already resolved in source (no change needed)
- **J-02 (Major)** — "Names mentioned" NPC roster already uses `<Img scope={jNpcScope(n)} …>` (line ~339), not `<Placeholder>`.
- **J-03 (Major)** — Bookmark button is fully wired (localStorage `ow.journal.bookmarks`, list marker, toggle).
- **J-04 (Major)** — Quest sketch is gated on `quest.sketch && (…)`.
- **J-05 (Minor)** — Objectives panel already renders an honest "No objectives recorded yet" empty-state.
- **J-09 (Trivial)** — The hardcoded "OPEN WORLDS" wax-seal flourish was already removed (#313).

## Skipped (out of scope)
- **J-07 (Minor, epic:atlas)** — "Show on map" centering requires changing the `app.jsx` navigate signature and the Atlas/map screen to consume a focus target. That crosses into other screens, so it is intentionally not done here.
- **J-01 (Critical)** — cross-cutting title-bar overlap lives in `chrome.jsx`, tracked under the per-page-polish / L-01 lane; not a journal-screen change.

## Validation
- `screen-journal.jsx` transforms cleanly through `vendor/babel-standalone-7.29.0.min.js` (node+vm), and the compiled output parses.
- Added two static-route guards in `viewer/tests/test_openworlds_static.py` (J-06 gating + J-08 helper). Full `test_openworlds_static.py` module green (59 passed).

Changes are additive and render-only; the engine remains the sole writer and no read-model fields were invented.

Refs #253.
