### PR TITLE
feat(openworlds): seed BG world_graph edges with route_kind (Closes #391, #381)

### DIFF
--- a/content/worlds/baldurs-gate/world.json
+++ b/content/worlds/baldurs-gate/world.json
@@ -50,6 +50,18 @@
     {"id": "loc-reithwin", "name": "Reithwin & the Lifting Shadow", "description": "The Shadow-Cursed Lands around Moonrise Towers, where Ketheric Thorm's curse of Shar is slowly lifting since his fall — Last Light Inn rekindles, the dead grow quieter, and survivors return to a poisoned country to see what crawled out of the dark.", "connections": ["loc-wyrms-crossing"], "tags": ["wilds", "shadow", "ruins"]},
     {"id": "loc-candlekeep", "name": "Candlekeep", "description": "The great fortress-library on the Sword Coast, hoarding the world's knowledge behind a one-book toll. If the truth about the Crown of Karsus, the Emperor's past, or a loose illithid is written anywhere, it is here — guarded by Avowed who do not love visitors.", "connections": ["loc-wyrms-crossing"], "tags": ["lore", "library", "secrets"]}
   ],
+  "world_graph": {
+    "seed": "baldurs-gate-loop-10-route-kinds",
+    "provenance": "authored",
+    "edges": [
+      {"from_id": "loc-lower-city",      "to_id": "loc-upper-city",      "route_kind": "street", "minutes":    8, "difficulty": "easy",   "danger": 1, "tags": ["urban", "uphill", "fist-checkpoint"]},
+      {"from_id": "loc-lower-city",      "to_id": "loc-outer-city",      "route_kind": "street", "minutes":   12, "difficulty": "easy",   "danger": 2, "tags": ["urban", "basilisk-gate", "slums-edge"]},
+      {"from_id": "loc-outer-city",      "to_id": "loc-wyrms-crossing",  "route_kind": "bridge", "minutes":   18, "difficulty": "easy",   "danger": 2, "tags": ["chionthar", "fist-toll", "wyrms-rock"]},
+      {"from_id": "loc-wyrms-crossing",  "to_id": "loc-elturel",         "route_kind": "road",   "minutes": 1440, "difficulty": "normal", "danger": 3, "tags": ["risen-road", "south", "hellrider-patrol"]},
+      {"from_id": "loc-wyrms-crossing",  "to_id": "loc-reithwin",        "route_kind": "road",   "minutes": 2160, "difficulty": "hard",   "danger": 5, "tags": ["shadow-cursed", "north", "lifting"]},
+      {"from_id": "loc-wyrms-crossing",  "to_id": "loc-candlekeep",      "route_kind": "road",   "minutes": 5760, "difficulty": "normal", "danger": 2, "tags": ["coast-road", "west", "avowed-watch"]}
+    ]
+  },
   "factions": [
     {"id": "fac-flaming-fist", "name": "The Flaming Fist", "description": "The Gate's mercenary army and de facto police, overstretched and leaderless-feeling with the Steel Watch gone and the dukedom contested. Honorable in the ranks, political at the top.", "reputation": 1},
     {"id": "fac-guild", "name": "The Guild", "description": "Baldur's Gate's vast thieves' network — smuggling, protection, information. Pragmatic, everywhere, and the ones who actually know what moves in the dark.", "reputation": 0},

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -871,7 +871,18 @@ class WorldGraphEdge(_StrictModel):
 
     from_id: str
     to_id: str
-    route_kind: Literal["street", "road", "trail", "sea", "river", "passage", "portal"] = "road"
+    # #381 (Loop-10): additive route-kind members. The original 7 kinds + the
+    # default "road" are unchanged (zero behavior change for existing content):
+    #   - "ferry": was already a styled branch in screen-map.jsx edgeStyle but
+    #     the model rejected it on author; now authorable.
+    #   - "bridge": Wyrm's Crossing over the Chionthar is canonically a bridge,
+    #     not a road — a first-class kind so styling can mark the crossing.
+    #   - "underground": Underdark passages, sewers, Bhaal Temple stairs (lands
+    #     ahead of #380 so the data surface is ready for those POIs).
+    route_kind: Literal[
+        "street", "road", "trail", "sea", "river", "passage", "portal",
+        "ferry", "bridge", "underground",
+    ] = "road"
     minutes: Optional[int] = Field(None, ge=1)
     distance: Optional[float] = Field(None, ge=0)
     difficulty: Literal["easy", "normal", "hard", "hazardous"] = "normal"

--- a/servers/engine/tests/test_content.py
+++ b/servers/engine/tests/test_content.py
@@ -275,6 +275,51 @@ def test_seed_world_seeds_world_graph_metadata_without_authorizing_travel(capsys
     assert "unknown location" in out
 
 
+def test_baldurs_gate_ships_route_kind_world_graph_edges(capsys):
+    # Regression guard for #381: the shipped baldurs-gate world must seed its
+    # full 6-edge world_graph with route_kind metadata. This breaks if (a) the
+    # world.json world_graph block is dropped, (b) any edge stops matching a
+    # canonical Location.connection, or (c) the WorldGraphEdge.route_kind Literal
+    # loses one of the kinds used here ("street"/"bridge"/"road") — in which case
+    # the loader silently drops that edge and the count/kinds assertions fail.
+    w = content.load_world_data("baldurs-gate")
+    c = content.seed_world(w)
+
+    edges = c.world_graph.edges
+    pairs = {(e.from_id, e.to_id): e for e in edges}
+    expected = {
+        ("loc-lower-city", "loc-upper-city"): "street",
+        ("loc-lower-city", "loc-outer-city"): "street",
+        ("loc-outer-city", "loc-wyrms-crossing"): "bridge",
+        ("loc-wyrms-crossing", "loc-elturel"): "road",
+        ("loc-wyrms-crossing", "loc-reithwin"): "road",
+        ("loc-wyrms-crossing", "loc-candlekeep"): "road",
+    }
+    # Exactly these 6 edges land (no edge silently dropped, none spuriously added).
+    assert set(pairs) == set(expected)
+    assert len(edges) == 6
+    for pair, kind in expected.items():
+        assert pairs[pair].route_kind == kind, (pair, pairs[pair].route_kind)
+
+    # The "bridge" kind is the canonical Wyrm's Crossing over the Chionthar and
+    # MUST survive the additive-Literal change specifically (it is the load-bearing
+    # new member exercised by shipped content).
+    crossing = pairs[("loc-outer-city", "loc-wyrms-crossing")]
+    assert crossing.route_kind == "bridge"
+    assert "chionthar" in crossing.tags
+
+    # Every seeded edge references a canonical Location.connection in at least one
+    # direction (the loader's own guard); proven here against the shipped content.
+    for e in edges:
+        src = c.locations[e.from_id]
+        dst = c.locations[e.to_id]
+        assert e.to_id in src.connections or e.from_id in dst.connections
+
+    # No "skipping ... edge" diagnostics for the shipped BG graph — all 6 are clean.
+    out = capsys.readouterr().out
+    assert "skipping world_graph edge" not in out
+
+
 def test_seed_world_seeds_settlement_pressure_additively(capsys):
     world = {
         "id": "settlement-test",

--- a/viewer/openworlds/screen-map.jsx
+++ b/viewer/openworlds/screen-map.jsx
@@ -436,9 +436,27 @@ function computeAtlasLayout(locations, edges) {
 function edgeStyle(edge) {
   const kind = (edge.route_kind || "").toLowerCase();
   const danger = typeof edge.danger === "number" ? edge.danger : 0;
+  // High-danger routes dominate the style: dark red dashed, regardless of kind.
   if (danger >= 6) return { stroke: "rgba(120,32,32,0.62)", width: 0.7, dash: "1.4 1" };
+  // Urban + extramural surface routes — solid brown.
   if (kind === "street" || kind === "road") return { stroke: "rgba(60,30,10,0.6)", width: 0.85, dash: "" };
+  // Water + crossing — solid blue. "ferry" is now a valid Literal member (#381).
   if (kind === "river" || kind === "ferry" || kind === "sea") return { stroke: "rgba(40,90,120,0.6)", width: 0.7, dash: "" };
+  // Bridge — slightly thicker amber-brown to mark a load-bearing crossing
+  // (Wyrm's Crossing over the Chionthar, etc.) as distinct from a regular road.
+  // Added Loop-10 / #381.
+  if (kind === "bridge") return { stroke: "rgba(110,75,30,0.72)", width: 1.05, dash: "" };
+  // Underground — Underdark passages, Bhaal Temple stairs, sewers. Tight dotted
+  // dash reads as "you go down, not across." Added Loop-10 / #381 ahead of the
+  // #380 Underdark POIs.
+  if (kind === "underground" || kind === "passage") return { stroke: "rgba(40,25,10,0.66)", width: 0.7, dash: "0.7 1.8" };
+  // Portal — extraplanar / arcane (Avernus gate, Astral, etc.). A subtle violet
+  // tint flags the route as "not walking distance" even when the connection is
+  // visually short.
+  if (kind === "portal") return { stroke: "rgba(95,55,135,0.62)", width: 0.7, dash: "1.2 1.2" };
+  // Trail — wilds-grade path. Lighter and looser-dashed than the default to
+  // read as "you'll get there, just not quickly."
+  if (kind === "trail") return { stroke: "rgba(85,60,30,0.5)", width: 0.6, dash: "1.4 1.6" };
   return { stroke: "rgba(60,30,10,0.46)", width: 0.5, dash: "1.6 1.2" };
 }
 


### PR DESCRIPTION
## TL;DR

Revives **PR #391** (verified ABSENT from current main). The atlas/world_graph pipeline already carries `route_kind` end-to-end — model, loader, atlas projection, viewer styling — but the `baldurs-gate` world shipped **zero `world_graph` edges**, so every BG inter-district connection projected as the same untyped default stroke. This delivers the content + the two adjacent gaps.

## Closes

- **#391** (revive) / **#381** — seed BG world_graph edges with route_kind metadata
- Serves parent **#261** and pairs ahead of **#380** (Underdark POIs)

## What this lands (additive + isolated)

### 1. `content/worlds/baldurs-gate/world.json` — NEW `world_graph` block
Six directed edges, one per canonical region-pair. Every edge references an existing `Location.connection` in at least one direction, so the `_seed_world_graph` loader's canonical-connection guard accepts all 6.

| From → To | Kind | Minutes | Difficulty | Danger |
|---|---|---|---|---|
| Lower City → Upper City | street | 8m | easy | 1 |
| Lower City → Outer City | street | 12m | easy | 2 |
| Outer City → Wyrm's Crossing | **bridge** | 18m | easy | 2 |
| Wyrm's Crossing → Elturel | road | 24h | normal | 3 |
| Wyrm's Crossing → Reithwin | road | 36h | **hard** | **5** |
| Wyrm's Crossing → Candlekeep | road | 96h | normal | 2 |

### 2. `servers/engine/models.py` — `WorldGraphEdge.route_kind` Literal
Additive: `ferry`, `bridge`, `underground`. The original 7 kinds + default `road` are unchanged (zero behavior change for existing content). `bridge` is load-bearing for the shipped content (Wyrm's Crossing over the Chionthar); `ferry` was already a dead branch in `edgeStyle`.

### 3. `viewer/openworlds/screen-map.jsx` — `edgeStyle` extension
Additive branches for `bridge` / `underground` / `portal` / `trail`. **Validated** by transforming the JSX through `vendor/babel-standalone-7.29.0.min.js` (parses clean).

### 4. `servers/engine/tests/test_content.py` — regression guard
`test_baldurs_gate_ships_route_kind_world_graph_edges` loads the shipped BG world and asserts exactly its 6 route-kind edges land. Fails if (a) the content block is dropped, (b) an edge stops matching a canonical connection, or (c) the Literal loses the `street`/`bridge`/`road` members the content uses (loader would silently drop the edge).

## Verification
- `uv run pytest servers/engine/tests/test_content.py` → **75 passed**
- world_graph + atlas engine tests → pass; `viewer/tests/test_atlas_surface.py` → **7 passed**
- JSON parses; JSX transforms clean through babel-standalone

## Invariants honored
- Engine remains sole state writer; schema change is **additive-only** (Literal members added, none repurposed).
- `_MOVE_FIELDS` allowlist untouched; `is_live_view`/combat-surface lockout untouched.
- No parity-lane / screen-combat / screen-table / play_party / run_duo files touched.