### PR TITLE
fix(#251): inventory polish pass — sort, a11y, hide-empty coins, dead-UI removal

### DIFF
--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -46,6 +46,9 @@ function ScreenInventory({ onNavigate, state, setState }) {
     ? surface.party
     : [];
   const [filter, setFilter] = React.useState("all");
+  // I-06: client-side sort order for the stash grid (display-only reordering — never an engine
+  // write). "found" keeps the surface's own order (as carried). Cycles found → name → type.
+  const [sortKey, setSortKey] = React.useState("found");
   const [activeHero, setActiveHero] = React.useState("");
   const [selectedItem, setSelectedItem] = React.useState(null);
   const [ctxMenu, setCtxMenu] = React.useState(null);
@@ -108,9 +111,17 @@ function ScreenInventory({ onNavigate, state, setState }) {
     }
   }, [stash, selectedItem]);
 
-  const filtered = filter === "all"
+  const _typeFiltered = filter === "all"
     ? stash
     : stash.filter((i) => i.type === filter);
+  // I-06: apply the client-side sort as a render-only reordering. "found" preserves the
+  // surface's carried order; "name"/"type" sort a shallow copy so the source list is untouched.
+  const filtered = sortKey === "found"
+    ? _typeFiltered
+    : [..._typeFiltered].sort((a, b) =>
+        sortKey === "name"
+          ? (a.name || "").localeCompare(b.name || "")
+          : (a.type || "").localeCompare(b.type || "") || (a.name || "").localeCompare(b.name || ""));
 
   // No live hero yet (pre-fetch, fetch failed, or an empty party) — clean empty-state
   // instead of dereferencing a fabricated hero or leaking demo data.
@@ -142,7 +153,7 @@ function ScreenInventory({ onNavigate, state, setState }) {
         {party.length > 1 && (
           <div style={{ display: "flex", flexWrap: "wrap", gap: 4, marginTop: 10 }}>
             {party.map((p) => (
-              <button key={p.id} onClick={() => setActiveHero(p.id)} className="pill" style={{
+              <button key={p.id} onClick={() => setActiveHero(p.id)} aria-pressed={activeHero === p.id ? "true" : "false"} className="pill" style={{
                 cursor: "pointer",
                 background: activeHero === p.id ? "linear-gradient(180deg, var(--b-200), var(--b-400))" : "rgba(176,141,87,0.08)",
                 color: activeHero === p.id ? "var(--w-300)" : "var(--ink-700)",
@@ -164,15 +175,21 @@ function ScreenInventory({ onNavigate, state, setState }) {
             hero.equipped (live). Coin Purse below is the hero's live currency. */}
 
         <div className="eyebrow">Coin Purse</div>
+        {/* I-09: PP/GP/SP are the everyday 5e coinage — always shown. Electrum (EP) and Copper
+            (CP) are minted only rarely; the surface emits them as 0 by default, so an empty
+            EP/CP slot is dead chrome. Render those two only when the hero actually holds them
+            (data-driven, hide-when-absent) — never fabricate a metal the engine isn't tracking. */}
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 6, marginTop: 6 }}>
           <CoinSlot tone="#e5e4e2" label="PP" val={String(hero.currency?.pp ?? 0)} />
           <CoinSlot tone="#d4b97a" label="GP" val={String(hero.currency?.gp ?? 0)} />
           <CoinSlot tone="#c0c0c0" label="SP" val={String(hero.currency?.sp ?? 0)} />
         </div>
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginTop: 6 }}>
-          <CoinSlot tone="#b08860" label="EP" val={String(hero.currency?.ep ?? 0)} />
-          <CoinSlot tone="#8a6a45" label="CP" val={String(hero.currency?.cp ?? 0)} />
-        </div>
+        {((hero.currency?.ep ?? 0) > 0 || (hero.currency?.cp ?? 0) > 0) && (
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginTop: 6 }}>
+            {(hero.currency?.ep ?? 0) > 0 && <CoinSlot tone="#b08860" label="EP" val={String(hero.currency.ep)} />}
+            {(hero.currency?.cp ?? 0) > 0 && <CoinSlot tone="#8a6a45" label="CP" val={String(hero.currency.cp)} />}
+          </div>
+        )}
       </Panel>
 
       {/* CENTER — Shared Stash */}
@@ -192,7 +209,7 @@ function ScreenInventory({ onNavigate, state, setState }) {
             { id: "rare", label: "Relics" },
             { id: "common", label: "Sundries" },
           ].map((f) => (
-            <button key={f.id} onClick={() => setFilter(f.id)} className={`pill ${filter === f.id ? "" : "muted"}`} style={{
+            <button key={f.id} onClick={() => setFilter(f.id)} aria-pressed={filter === f.id ? "true" : "false"} className={`pill ${filter === f.id ? "" : "muted"}`} style={{
               cursor: "pointer",
               background: filter === f.id ? "linear-gradient(180deg, var(--b-200), var(--b-400))" : "rgba(176,141,87,0.1)",
               color: filter === f.id ? "var(--w-300)" : "var(--ink-700)",
@@ -238,6 +255,15 @@ function ScreenInventory({ onNavigate, state, setState }) {
                   setSelectedItem(it);
                   setCtxMenu({ x: e.clientX, y: e.clientY, item: it });
                 }}
+                onContextKey={(e) => {
+                  // I-05(b) / C6: keyboard equivalent of right-click — Enter or the context-menu
+                  // key on a focused item opens the same actions menu, anchored to the tile.
+                  if (e.key !== "Enter" && e.key !== "ContextMenu") return;
+                  e.preventDefault();
+                  const r = e.currentTarget.getBoundingClientRect();
+                  setSelectedItem(it);
+                  setCtxMenu({ x: Math.round(r.right - 8), y: Math.round(r.bottom - 8), item: it });
+                }}
               />
             ))}
             {/* I-07: no fixed 60-slot pack — the grid grows to actual content (OpenWorlds is
@@ -248,9 +274,18 @@ function ScreenInventory({ onNavigate, state, setState }) {
         <div style={{ marginTop: 12, display: "flex", justifyContent: "space-between", alignItems: "center" }}>
           <span className="muted body-sm">{filtered.length} items · {stash.length} total</span>
           <div style={{ display: "flex", gap: 6 }}>
-            <BrassButton tone="ghost" size="sm" disabled title="Display-only — not saved to the engine">Sort (preview)</BrassButton>
-            <BrassButton tone="ghost" size="sm" disabled title="Display-only — not saved to the engine">Mark Trash (preview)</BrassButton>
-            <BrassButton size="sm" disabled title="Display-only — not saved to the engine">Loot Pile (preview)</BrassButton>
+            {/* I-06: Sort is a real client-side reordering (no engine write needed), so it is
+                wired live rather than shipped as a disabled "(preview)" button. The two other
+                bottom buttons were removed: per the audit (I-06 / I-11) they had no engine route
+                and no defined behavior — dead UI we do not ship. */}
+            <BrassButton
+              tone="ghost"
+              size="sm"
+              onClick={() => setSortKey((k) => k === "found" ? "name" : k === "name" ? "type" : "found")}
+              title="Reorder the stash on screen (display-only — not saved to the engine)"
+            >
+              Sort: {sortKey === "found" ? "As Carried" : sortKey === "name" ? "Name" : "Type"}
+            </BrassButton>
           </div>
         </div>
       </Panel>
@@ -432,7 +467,7 @@ function CoinSlot({ tone, label, val }) {
   );
 }
 
-function ItemSlot({ item, selected, onClick, onContextMenu }) {
+function ItemSlot({ item, selected, onClick, onContextMenu, onContextKey }) {
   const tone = item.type === "rare" ? "var(--royal)" :
                item.type === "quest" ? "var(--crimson)" :
                item.type === "spell" ? "var(--royal-bright)" :
@@ -440,7 +475,13 @@ function ItemSlot({ item, selected, onClick, onContextMenu }) {
                "var(--b-500)";
   return (
     <window.Tooltip content={<window.ItemTooltip item={item} />} side="top">
-      <button onClick={onClick} onContextMenu={onContextMenu} style={{
+      <button
+        onClick={onClick}
+        onContextMenu={onContextMenu}
+        onKeyDown={onContextKey}
+        aria-haspopup="menu"
+        aria-label={item.name + (item.qty > 1 ? " ×" + item.qty : "")}
+        style={{
       position: "relative",
       padding: 0,
       height: 68,

--- a/viewer/tests/test_item_icons.py
+++ b/viewer/tests/test_item_icons.py
@@ -174,6 +174,74 @@ class ForgePolishTests(ItemIconTests):
         self.assertIn('aria-label={"Tier "', src)
         # The list row no longer renders the recipe tier via a bare <Pill>.
         self.assertNotIn("<Pill>{r.tier}</Pill>", src)
+class InventoryPolishPassTests(unittest.TestCase):
+    """Guards for the #251 inventory polish pass (I-05b / I-06 / I-09 + C6 accessibility).
+
+    These are render-only / static-source assertions in the same spirit as
+    test_openworlds_static.py: the JSX is served as text/babel with no build step, so a
+    string-level guard is the contract check that the wiring is present and the dead UI is
+    gone. No engine state is asserted (the read-model is untouched by this pass).
+    """
+
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _src(self) -> str:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", "/openworlds/screen-inventory.jsx")
+            response = conn.getresponse()
+            self.assertEqual(response.status, 200)
+            return response.read().decode("utf-8")
+        finally:
+            conn.close()
+
+    def test_filter_chips_and_hero_pills_have_aria_pressed(self):
+        """C6: filter chips + hero switcher pills expose aria-pressed for screen readers."""
+        src = self._src()
+        self.assertIn('aria-pressed={filter === f.id ? "true" : "false"}', src)
+        self.assertIn('aria-pressed={activeHero === p.id ? "true" : "false"}', src)
+
+    def test_item_slot_is_keyboard_context_accessible(self):
+        """I-05(b): a focused item opens the actions menu via keyboard (Enter / ContextMenu)."""
+        src = self._src()
+        self.assertIn("onKeyDown={onContextKey}", src)
+        self.assertIn('aria-haspopup="menu"', src)
+        self.assertIn('e.key !== "Enter" && e.key !== "ContextMenu"', src)
+
+    def test_dead_preview_buttons_removed(self):
+        """I-06 / I-11: Mark Trash + Loot Pile dead UI is gone; Sort is wired live (no preview)."""
+        src = self._src()
+        self.assertNotIn("Mark Trash", src)
+        self.assertNotIn("Loot Pile", src)
+        self.assertNotIn("Sort (preview)", src)
+        # Sort is a real client-side reordering control, not a disabled stub.
+        self.assertIn("setSortKey(", src)
+
+    def test_electrum_and_copper_hidden_when_zero(self):
+        """I-09: EP/CP coin slots render only when the hero actually holds them."""
+        src = self._src()
+        self.assertIn("(hero.currency?.ep ?? 0) > 0", src)
+        self.assertIn("(hero.currency?.cp ?? 0) > 0", src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Inventory (Stash) polish pass — audit #251

Render-only viewer changes for `viewer/openworlds/screen-inventory.jsx`. The engine read-model (`viewer/server.py /inventory-surface`) is **untouched** — no fabricated data, all changes degrade gracefully / hide-when-absent.

### Findings implemented
| # | Sev | What changed |
|---|---|---|
| **I-06 / I-11** | Minor / Trivial | **Sort** wired as a live client-side reorder (cycles As Carried → Name → Type — a render-only reordering of the already-fetched stash, never an engine write — the audit explicitly says "sort = client-side OK"). The dead **Mark Trash** + **Loot Pile** preview buttons are removed ("Don't ship dead UI"; I-11 says define Loot Pile before unhiding → removed). |
| **I-05 (b)** | Major (a11y half) | Keyboard-accessible item context menu: Enter / the ContextMenu key on a focused item tile opens the same actions menu, anchored to the tile. Added `aria-haspopup="menu"` + `aria-label` on tiles. |
| **C6** (rubric row, also named in I-05) | — | `aria-pressed` on the filter chips **and** the hero-switcher pills. |
| **I-09** | Minor | Electrum (EP) + Copper (CP) coin slots render only when the hero actually holds them (data-driven, hide-when-absent). PP/GP/SP stay always-on. The surface always emits all 5 metals as ints, so an empty EP/CP slot was dead chrome. |

### Already resolved in source (verified, no change needed)
- **I-02** paper-doll silhouette — `PaperDoll` component already present (portrait centered, slots flanking).
- **I-03** full canonical slot set — `EQUIP_SLOTS` already has the 12 BG3/5e slots.
- **I-07** empty 60-slot pack padding — already removed (grid grows to content).
- **I-10** hero switcher dead space — pills already wrap (`flexWrap`).

### Skipped (would require read-model data the engine does not emit)
- **I-04** compare-on-hover (Δ AC / Δ DMG vs equipped) — requires per-item `stat_deltas` from the engine; the `/inventory-surface` read-model emits no such field (and items carry no per-item `slot`). Implementing this in the viewer would mean fabricating deltas. **Skipped** per scope discipline (note it, don't fake it).
- **I-05 (a)** drag-to-equip posting `{kind:"equip", slot, item}` — the read-model models no per-item equip `slot` (surface emits `slot:"Worn"` for everything), so a slot-targeted drag has no contract to write to. The existing context-menu **Equip** path already relays via `/move`. **Skipped** the drag half; implemented the keyboard-accessibility half (I-05b).
- **I-01** Critical title-bar overlap — cross-cutting `chrome.jsx` concern, out of scope for this screen.
- **I-08** weight column — already consistent: `ItemDetail` shows a single Weight stat (catalog-backfilled `item.weight`, `—` only when truly absent); there is no separate per-row weight column to hide. No change needed.

### Verification
- JSX validated through the pinned `viewer/openworlds/vendor/babel-standalone-7.29.0.min.js` via node+vm (parses/transforms cleanly).
- Added `InventoryPolishPassTests` guards in `viewer/tests/test_item_icons.py` (aria-pressed, keyboard context menu, dead-UI removal, EP/CP hide-when-zero).
- `test_item_icons.py` (13), `test_readmodel_surfaces.py` + `test_openworlds_static.py` (87 + 10 subtests) all pass locally.

Refs #251.
