### PR TITLE
feat(qa): fast-gate Tier 0 — a 2-second/$0 inner loop (stop using the 90-min sweep to iterate)

### DIFF
--- a/docs/qa/FAST_GATE.md
+++ b/docs/qa/FAST_GATE.md
@@ -1,0 +1,91 @@
+# Fast QA Gate — iterate in minutes, not 90-minute sweeps
+
+**Problem.** We were using the *milestone* gate (the full 5-persona `.app` sweep) as the *iteration*
+loop. That sweep is ~60–90 min and ~$8–12, and most of its cost is wasted re-work per iteration:
+a `--effort max` cold-open world-build **five times**, 5 full free-play personas, an 8-beat duo —
+when the thing we changed only needs a small, targeted signal. It's also single-run-noisy (±2 on
+satisfaction, ±0.3–0.5 on the LLM lenses), so one sweep can't even tell signal from noise.
+
+**Goal (the owner's bar):** ~80% of the sweep's signal at ~90% less time, so we can iterate 5–6×
+faster and reserve the sweep for milestone validation.
+
+This design was produced by three parallel agents (a cost/signal map, a design, and an **adversarial
+critique**). The critique is why this doc exists — it caught that the *obvious* fast design is a
+false-confidence trap.
+
+---
+
+## The trap: naive "seed everything from a mid-arc snapshot" is WORSE than useless
+
+The intuitive cheap design — pre-build mid-arc snapshot fixtures and probe from them — **removes
+exactly the surfaces where our real bugs live.** Grounded, code-cited failures it would have
+GREEN-lit:
+
+1. **The skill-case crit** (optimizer, 2026-06-03: Arcana +3 not +6). `_normalize_skill_case`
+   (`models.py`) runs *before* the snapshot is written, so a mid-arc fixture bakes in the **fixed**
+   state. Seed the optimizer from it and it reads +6 and passes — while a real **seat-path**
+   regression ships. The "optimizer catches skill-case" justification is **inverted**.
+2. **Combat reachability** (the actual G1 fail). `run_combat_sprint.sh` seeds a fight already standing
+   in the room and sets `CLAWDND_GATE_COMBAT_SPRINT=1`, which *turns off* the travel/rest progression
+   floor (`assert_behavioral.py`). It proves the engine *resolves* a fight; it says nothing about
+   whether a free-play persona ever *reaches* one — which was the real 0-combat failure.
+3. **Cross-persona variance** (the actual G3 fail). Real sweeps fail on the **veteran (sat=5)** or the
+   adversarial (Enter-submit move-sink), not the optimizer — which "takes one turn to confirm the loop
+   and doesn't care about prose." One fixed persona samples the wrong order statistic (G3 is the
+   *minimum* across personas, not the mean).
+4. **A 4-beat duo falls below `MIN_BEATS=6`** → silently disarms 5 FATAL behavioral floors
+   (`world_advanced_time`, `party_traveled`, `combat_not_left_active`, `xp_awarded`, `player_probed`).
+5. **Cold-open setup integrity** (the #356 native-transition gate; the stochastic no-PC seating bug in
+   `play_party.sh`) — a snapshot pre-seats past all of it.
+
+Honest signal of the naive design: **~55–65%**, not 80% — and the missing 35–45% is concentrated in
+the bug classes that have actually shipped.
+
+---
+
+## The corrected 3-tier design
+
+| Tier | What | Cost | Owns |
+|---|---|---|---|
+| **0 — Deterministic (CI/pytest, $0, ~60s)** | seat-path skill correctness · rest-restores · travel-moves · combat-through-engine · model normalizers | **~60s, $0** | the structural + **seat-path** + engine-transition classes — *including the skill-case crit* |
+| **1 — Fast LLM loop (~13 min, ~$2.5)** | **rotated** persona `[iter % 5]` from a **short cold-open** (catches seating + free-play reachability + variance over 5 loops) · **≥6-beat** duo (floors stay armed) · a "free-play *reached* combat" check distinct from the sprint | **~13 min** | the satisfaction/quality *iteration* signal (honestly, not a verdict) |
+| **2 — Milestone sweep (unchanged)** | full 5-persona `.app` + RRI + native part-A, **+ correlation tracking** | ~90 min | the release verdict |
+
+**The biggest lever isn't a new harness — it's moving deterministic signal into pytest/CI.** The
+seat-path skill test alone (Tier 0) would have caught the optimizer's #1 crit in CI for $0, with zero
+sweeps.
+
+### Tier 0 — built now (`qa/fast_gate.sh`)
+Runs a curated subset of the existing deterministic engine tests + the new end-to-end seat-path skill
+test (`test_canon_wizard_seat_yields_proficient_skill_bonus` in `tests/test_canon_abilities.py`).
+Covers: G1 combat (`test_combat`), G1 rest (`test_rests`), G1 travel (`test_travel`), G2 seat-path
+data (`test_canon_abilities` + `test_character_skill_normalization`). `$0`, ~60s, no LLM, no cold-open.
+Run it on every change before deciding whether a heavier probe is even warranted.
+
+### Tier 1 — the fast LLM loop (next, with the critique's mitigations baked in)
+Not yet built — it needs a small harness change (skip the cold-open splice when handed a seeded
+snapshot, in `run_duo.sh` and `ui_playtest.sh`). The **non-negotiable corrections** from the critique:
+- **Rotate the persona** by iteration index `personas[iter % 5]` — same per-loop cost, full variance
+  over 5 loops. Record which persona ran so the ledger shows coverage-over-time.
+- **Keep the duo ≥6 beats** so `assert_behavioral.py`'s progression floors stay armed.
+- **Run *some* persona from a real cold open each loop** (not only a snapshot seed) so seating +
+  free-play reachability stay covered; add a `seed_canon_fixture.py` seat-path assertion every loop
+  (zero-LLM) to keep skill-case/seating coverage even when a probe snapshot-seeds.
+- **Add a "free-play *reached* combat/travel/rest" check** distinct from the seeded sprint — never let
+  the sprint's green imply reachability.
+- **Story/mech on a short seeded duo is a regression *tripwire*, not the 4.3/4.5 verdict** (those bars
+  were calibrated on 8-beat cold-opened duos). Defer the precise judgment to the sweep.
+
+### Tier 2 — keep honest via measured correlation
+Every K iterations / before merge, run the full sweep and write the row to `qa/scores.db`. Then
+compute the **correlation** between the fast-gate verdict and the full-RRI verdict over history — so
+"~80% signal" is *measured*, not asserted. Never write `pass=1` to `scores.db` from a fast run, and
+label every fast verdict **"INNER-LOOP — not a release verdict."**
+
+---
+
+## What the fast loop intentionally DEFERS to the milestone sweep (the honest ~20%)
+Cross-persona breadth in a single run; the cold-open / max-effort world-build itself; the #356 native
+`.app` transition (macOS Part-A); full-arc long-horizon coherence; the authoritative 4.3/4.5 story/mech
+bar; and the RRI rollup. The fast gate answers *"did this change break the core loops / seat path /
+single-persona satisfaction — worth spending 90 min on the sweep?"* — not *"is this releasable?"*

--- a/qa/fast_gate.sh
+++ b/qa/fast_gate.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# WorldOS FAST-GATE — Tier 0 (deterministic, $0, ~30-60s).
+#
+# The cheap inner-loop substitute for the ~90-min / ~$10 five-persona milestone sweep. It catches the
+# STRUCTURAL + SEAT-PATH + ENGINE-TRANSITION regression classes (G1 combat/rest/travel, G2 seat-path
+# data correctness) in CI for FREE — the classes that do NOT need an LLM to detect. Most regressions
+# we actually shipped (the skill-case +3-not-+6 crit, frozen-clock, combat-unresolved, version-skew)
+# are in this tier; catching them here means we never burn a 90-minute sweep to discover a $0 bug.
+#
+# PASS here  => the core engine loops + seat path are intact; safe to keep iterating, and the change
+#               is WORTH a heavier LLM probe / milestone sweep.
+# ITERATE    => fix this now; do NOT spend the sweep.
+#
+# This is an ITERATION signal, NOT a release verdict. G3 (cross-persona satisfaction) and G5 quality
+# scores are irreducibly LLM-judged + noisy and stay in the LLM probe / milestone sweep. The honest
+# 3-tier design + the ~75-80% signal accounting (and why naive mid-arc snapshot seeding is a
+# false-confidence trap) is in docs/qa/FAST_GATE.md.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 2
+LOG="${TMPDIR:-/tmp}/wos_fastgate_t0.log"
+
+echo "── FAST-GATE Tier 0 — deterministic engine + seat-path + rest/travel + combat ($0) ──"
+# Per the QA cost/signal map, these gate signals are FREE + INSTANT (no LLM, no cold-open world build):
+#   - test_canon_abilities  : SEAT-PATH skill correctness (the optimizer skill-case crit) + ability derivation (G2 data)
+#   - test_character_skill_normalization : the model-boundary skill-name normalizer (G2)
+#   - test_rests            : rest-that-restores HP/slots + advances the clock (G1 rest limb)
+#   - test_travel           : travel-that-moves location + clock (G1 travel limb)
+#   - test_combat           : combat resolved THROUGH the engine — start_combat/attack/rounds (G1 combat limb)
+TESTS="tests/test_canon_abilities.py tests/test_character_skill_normalization.py tests/test_rests.py tests/test_travel.py tests/test_combat.py"
+
+if uv run --directory servers/engine python -m pytest -q -p no:xdist $TESTS >"$LOG" 2>&1; then
+  echo "  ✓ deterministic engine tier: $(grep -oE '[0-9]+ passed' "$LOG" | tail -1)"
+else
+  echo "❌ FAST-GATE T0: ITERATE — deterministic engine tier failed (G1 combat/rest/travel · G2 seat-path):"
+  grep -E "FAILED|Error|assert|[0-9]+ failed" "$LOG" | head -15
+  echo "   full log: $LOG"
+  exit 1
+fi
+
+echo "✅ FAST-GATE T0 PASS — core engine loops + seat path intact (\$0, deterministic)."
+echo "   When iterating on DM-craft / UX, run the LLM probe next (rotated persona + ≥6-beat duo, ~13 min / ~\$2.5)."
+echo "   Before merge/release, run the milestone 5-persona sweep + RRI. See docs/qa/FAST_GATE.md."

--- a/servers/engine/tests/test_canon_abilities.py
+++ b/servers/engine/tests/test_canon_abilities.py
@@ -94,6 +94,29 @@ def test_canon_wizard_loads_with_derived_int_not_flat_ten(tmp_path, monkeypatch)
     assert res["warnings"] == []
 
 
+def test_canon_wizard_seat_yields_proficient_skill_bonus(tmp_path, monkeypatch):
+    """SEAT-PATH skill correctness — the deterministic ($0, CI) substitute for an expensive optimizer
+    playtest sweep. The 2026-06-03 optimizer crit was a SEATED canon caster showing Arcana +3 not +6:
+    skill_proficiencies that didn't match the lowercase SKILL_ABILITIES keys, so skill_bonus dropped
+    the proficiency. This exercises load_canon_character END-TO-END (the seat path AND the model's
+    _normalize_skill_case), asserting the seated PC's proficiencies are normalized and each skill_bonus
+    actually ADDS the proficiency bonus. Would have caught the crit in CI with zero LLM / zero sweep —
+    the fast-gate Tier-0 deterministic catch (see docs/qa/FAST_GATE.md)."""
+    from models import SKILL_ABILITIES
+    c = _seed(tmp_path, monkeypatch)
+    res = server.load_canon_character(c.id, "Charming Latham", kind="player", add_to_party=True)
+    assert "error" not in res
+    ch = server._require(c.id).characters[res["id"]]
+    assert ch.skill_proficiencies, "a seated canon Wizard must have skill proficiencies (SRD defaults if none in canon)"
+    for sk in ch.skill_proficiencies:
+        # normalized to the lowercase-underscore SKILL_ABILITIES keys (no capitalized canon names)
+        assert sk == sk.lower().replace(" ", "_"), f"un-normalized skill proficiency: {sk!r}"
+        assert sk in SKILL_ABILITIES, f"skill {sk!r} is not a valid SKILL_ABILITIES key"
+        # the bonus ADDS the proficiency (ability mod + proficiency_bonus), not the bare ability mod
+        assert ch.skill_bonus(sk) == ch.ability_modifier(SKILL_ABILITIES[sk]) + ch.proficiency_bonus, \
+            f"{sk}: skill_bonus must include the proficiency bonus (the +3-not-+6 crit)"
+
+
 def test_explicit_canon_abilities_are_preserved_unchanged(tmp_path, monkeypatch):
     # The Withers-style case: a canon record that DOES carry an `abilities` block must keep it
     # verbatim (a hand-authored sheet wins over derivation). No record ships one today, so inject


### PR DESCRIPTION
**The problem you flagged:** we were using the *milestone* gate (the full 5-persona `.app` sweep, ~90 min / ~$10, single-run-noisy) as the *iteration* loop. Backwards — and slow.

**What I did:** ran three parallel agents (a QA cost/signal map, a fast-gate design, and an **adversarial critique**) to design a faster loop honestly. The critique earned its keep — it proved the *obvious* cheap design (seed everything from mid-arc snapshots) is a **false-confidence trap**: it bakes in the post-fix state and skips the exact surfaces where our real bugs live (the skill-case `+3-not-+6` crit normalizes *before* the snapshot; `combat_sprint` proves *resolution* not *reachability* and turns off the progression floor; one optimizer persona misses the veteran/adversarial variance that actually fails G3; a 4-beat duo falls below `MIN_BEATS=6` and disarms 5 FATAL floors). Naive design ≈ 55–65% signal, not 80%.

**This PR lands Tier 0** of the corrected 3-tier design (full writeup: `docs/qa/FAST_GATE.md`):

- `qa/fast_gate.sh` — deterministic, **$0, ~2s** (measured on the VM: **186 passed in 2s**). Runs the curated deterministic engine tests for G1 (combat-through-engine / rest-restores / travel-moves) + G2 (seat-path data) — the regression classes that **don't need an LLM**.
- A new **end-to-end seat-path skill test** (`test_canon_wizard_seat_yields_proficient_skill_bonus`) that seats a canon Wizard via `load_canon_character` and asserts each proficiency is normalized and `skill_bonus` adds the proficiency — **it would have caught the optimizer's skill-case crit in CI for $0, with zero sweeps.**

**The insight:** the biggest lever isn't a new harness — it's moving deterministic gate signal into pytest/CI. Most regressions we shipped live in this tier.

**Next (scoped in the doc, not this PR):** Tier 1 — the fast LLM loop (~13 min / ~$2.5) with the critique's mandatory mitigations baked in (rotate the persona by iteration so variance is swept over 5 loops; keep the duo ≥6 beats; run *some* persona from a real cold-open each loop for seating/free-play coverage; a "free-play *reached* combat" check distinct from the sprint). Tier 2 — measured fast-vs-full correlation in `scores.db` so "~80% signal" is proven, not asserted; never report a fast verdict as a release verdict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive QA gate process documentation outlining a faster iterative testing approach with tiered validation levels.

* **Tests**
  * Implemented rapid deterministic test checks to catch regressions quickly.
  * Added character ability skill handling test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->