### PR TITLE
docs: integrate the tiered QA loop as the standard process (skill + operating-goal + runbook)

### DIFF
--- a/.claude/skills/worldos-dev/SKILL.md
+++ b/.claude/skills/worldos-dev/SKILL.md
@@ -110,6 +110,25 @@ Keep Python tests single-process unless the lane explicitly supports parallel ex
    git worktree remove --force <worktree> && git branch -D <branch> && git worktree prune
    ```
 
+## QA STRATEGY — pick the TIER (don't run the 90-min sweep to iterate)
+**Match the test to the change + your confidence — run a MIX, not all-or-nothing.** The full 5-persona
+sweep is the MILESTONE verdict, not the inner loop. Design + the honest signal accounting (the
+adversarial critique that proved naive mid-arc-snapshot seeding is a false-confidence trap — it bakes
+in the post-fix state and skips the seat-path/cold-open/free-play surfaces our bugs live in):
+`docs/qa/FAST_GATE.md`.
+
+| Tier | Run | Cost | When |
+|---|---|---|---|
+| **0 — deterministic** | `qa/fast_gate.sh` | **$0, ~2s** | EVERY engine/content/data/viewer change (and in CI). 186 engine tests + the end-to-end seat-path skill guard → the structural / seat-path / rest / travel / combat-resolution regression classes, caught free + instant. |
+| **1 — fast LLM loop** | `qa/fast_probe.sh [persona]` | ~$2–3, ~20 min | DM-craft / UX / satisfaction changes. ONE persona ROTATED by iteration (`newbie→…→optimizer`) + a 6-beat duo (≥6 keeps the behavioral floors armed). Iteration signal ONLY. |
+| **2 — milestone sweep** | the `## VM GATE SWEEP` procedure above (VM part-B + Mac part-A) | ~$10, ~90 min | ONLY when 0+1 pass + before a version bump → RRI → #466. Also the periodic recalibration of the cheap tiers vs the full RRI. |
+
+Rules: Tier 0 on **every** change (free + instant — most regressions we ship live here, e.g. the
+skill-case +3-not-+6 crit). Tier 1 when you touched DM/UX and need a satisfaction/quality read —
+**rotate the persona** so variance sweeps over 5 loops (one fixed optimizer misses the veteran/
+adversarial fails). Tier 2 sparingly. **NEVER report a Tier-0/1 result as a release verdict.** After
+any tier, log the outcome (tier, build SHA, result, delta) to the ledger so progress is observable.
+
 ## THE QA LOOP
 Spec: `qa/SCORING.md`. **The ledger is `qa/scores_db.py` (SQLite `scores.db`) → rendered to
 `qa/scores_ledger.md` (`add_run(...)` / `--render`); `qa/SCORECARD.md` is LEGACY narrative.** Append

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -188,14 +188,31 @@ by an average). **RRI 10/10 = every gate holds on one fresh build:**
 
 ---
 
-## 5. THE ITERATE LOOP (while the gate fails)
+## 5. THE ITERATE LOOP (while the gate fails) — TIERED, not all-or-nothing
 
-`git fetch` → create/update a **same-disk local worktree off origin/main** for tracked edits
-when GUI/app tests need assets (Lexar is evidence/scratch, not the default runtime tree) →
-`rm -rf dist/WorldOS.app` in the local app checkout → `qa/ui_playtest_app.sh` × 5 personas against the built `.app` → **score** (5-persona
-satisfaction + 3 lenses + behavioral + axe) → **file GitHub issues** tied to `{build_sha, version_tag}`
-with `file:line` + acceptance criteria → **delegate code to builder subagents** (worktree → PR →
-CI-green incl. `viewer-tests` → squash-merge) → **rebuild → re-playtest.**
+Iterate with the test **tier matched to the change + current confidence** — do NOT run the ~90-min
+5-persona sweep for every edit (that is the milestone *verdict*, not the inner loop; running it as the
+loop is what made progress crawl). Full design + the adversarial-validated honest-signal accounting
+(why naive mid-arc-snapshot seeding is a false-confidence trap): `docs/qa/FAST_GATE.md`.
+
+- **Tier 0 — deterministic, $0, ~2s (`qa/fast_gate.sh`):** run on EVERY engine/content/data/viewer
+  change (it is also in CI). 186 engine tests + the end-to-end seat-path skill guard catch the
+  structural / seat-path / rest / travel / combat-resolution regression classes — most of what we
+  actually ship (e.g. the skill-case +3-not-+6 crit) — free + instant.
+- **Tier 1 — fast LLM loop, ~$2–3, ~20 min (`qa/fast_probe.sh`):** run on any DM-craft / UX /
+  satisfaction change. ONE persona ROTATED by iteration (`newbie→…→optimizer`, so cross-persona
+  variance is swept over 5 loops at one-persona cost) + a 6-beat duo. An ITERATION signal, never a
+  release verdict.
+- **Tier 2 — milestone sweep, ~$10, ~90 min:** ONLY when Tier 0+1 pass + before a version bump.
+  `git fetch` → same-disk worktree off `origin/main` → `rm -rf dist/WorldOS.app` → `qa/ui_playtest_app.sh`
+  × 5 personas against the built `.app` → 5-persona satisfaction + 3 lenses + behavioral + axe → RRI
+  rollup (VM part-B + Mac part-A, same SHA) → #466. Also the periodic recalibration that keeps the
+  cheap tiers' "~80% signal" *measured* against the full RRI, not assumed.
+
+Then, regardless of tier: **file GitHub issues** tied to `{build_sha, version_tag}` with `file:line` +
+acceptance criteria → **delegate code to builder subagents** (worktree → PR → CI-green incl.
+`viewer-tests` → squash-merge) → re-run the matched tier. **Document the outcome** (tier, build SHA,
+result, delta) to the ledger / session scratchpad so progress is observable.
 **An issue closes ONLY when the NEXT build's playtest no longer reproduces it.**
 
 ---

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -194,8 +194,16 @@ push → `gh pr create` (no `tail` in an `&&` chain) → merge after checks pass
 
 ## THE QA LOOP
 
+**Pick the TIER — don't run the 90-min sweep to iterate.** Tier 0 `qa/fast_gate.sh` ($0 / ~2s, every
+change) → Tier 1 `qa/fast_probe.sh` (~$2–3 / ~20 min, DM-craft/UX/satisfaction) → Tier 2 the milestone
+5-persona `.app` sweep (~$10 / ~90 min, only before a version bump). Strategy + the adversarial-validated
+signal accounting: `docs/qa/FAST_GATE.md` and the `worldos-dev` skill's "QA STRATEGY" table. The runners
+below are what each tier composes.
+
 The fitness function = **1 hard behavioral gate** + **3 LLM lenses**. Spec: `qa/SCORING.md`.
-**Log every run to `qa/SCORECARD.md`** (the ledger that survives compaction).
+**Log every scored run to the ledger: `qa/scores_db.py` → SQLite `scores.db` → rendered to
+`qa/scores_ledger.md` (`add_run(...)` / `--render`)** — the compaction-surviving ledger. (`qa/SCORECARD.md`
+is LEGACY narrative; don't hand-edit it.)
 
 **Runners:**
 - `qa/run_duo.sh <run> <world> <persona> [beats] [budget]` — AI player + DM duo via


### PR DESCRIPTION
Makes the 3-tier fast-QA (PRs #661/#662) the **documented iteration process** — a mix matched to the change, not all-or-nothing.

- **worldos-dev skill** — `QA STRATEGY — pick the TIER` table before the QA loop: Tier 0 `fast_gate.sh` ($0/~2s, every change) · Tier 1 `fast_probe.sh` (~$2-3/~20min, DM-craft/UX, rotated persona) · Tier 2 the milestone sweep (~$10/~90min, before a version bump). Cross-refs `docs/qa/FAST_GATE.md`.
- **OPERATING-GOAL §5 THE ITERATE LOOP** — rewritten tiered. Previously it literally said `ui_playtest_app.sh × 5 personas` *every* iteration (the all-or-nothing problem). Now Tier 0/1 are the inner loop; Tier 2 is the milestone verdict + recalibration.
- **RUNBOOK THE QA LOOP** — tier pointer + fixed a doc-drift the memory observer flagged: the runbook called `SCORECARD.md` the active ledger while the skill marks it LEGACY → aligned both to `scores_db.py`/`scores_ledger.md`.

Docs only.