### PR TITLE
fix(#640): symmetric is_live_view heal — close the Parley/combat/atlas read-only lockout

### DIFF
--- a/viewer/server.py
+++ b/viewer/server.py
@@ -6408,7 +6408,7 @@ class _Handler(BaseHTTPRequestHandler):
             return attached
         return override or attached
 
-    def _serve_simple_surface(self, qs: dict, builder) -> None:
+    def _serve_simple_surface(self, qs: dict, builder, *, heal: bool = False) -> None:
         """Dispatch a snapshot-only read-model surface (journal/character/inventory/
         relations/parley). Mirrors the /atlas-surface handler exactly: a catalog ?source/
         ?run ref wins (a QA/parallel run), else the per-request ?campaign view override,
@@ -6425,7 +6425,11 @@ class _Handler(BaseHTTPRequestHandler):
                 is_live_view=bool(live and root_is_current and cid == self.campaign_id),
             ))
             return
-        cid = self._view_campaign(qs)
+        # Symmetric heal (#640): a play surface (parley/character) opts into the SAME self-healing
+        # the /session-surface gate uses, so a drifted client ?campaign re-aligns to the live run
+        # instead of latching is_live_view=False ("viewing non-live campaign" read-only). Pure
+        # read-only views (journal/seed/acts/inventory/relations) keep the literal ?campaign view.
+        cid = self._live_play_view_campaign(qs) if heal else self._view_campaign(qs)
         if not cid:
             self._json(builder({}, campaign_id="", live=live, is_live_view=False))
             return
@@ -6452,7 +6456,9 @@ class _Handler(BaseHTTPRequestHandler):
             is_live = bool(live and root_is_current and cid == self.campaign_id)
             recent = _session_event_tail_from_dir(campaign_dir, raw_snap)
         else:
-            cid = self._view_campaign(qs)
+            # Symmetric heal (#640): match the GET combat/atlas surfaces (and /session-surface) so
+            # the SSE render mirror re-aligns to the live run too — keeps SSE consistent with polled.
+            cid = self._live_play_view_campaign(qs)
             raw_snap = _read_snapshot(cid) if cid else {}
             if not isinstance(raw_snap, dict):
                 raw_snap = {}
@@ -6706,7 +6712,9 @@ class _Handler(BaseHTTPRequestHandler):
                     recent_events=_session_event_tail_from_dir(campaign_dir, raw_snap),
                 ))
                 return
-            cid = self._view_campaign(qs)
+            # Symmetric heal (#640): mirror /session-surface — re-align to the live run instead of
+            # latching is_live_view=False (the read-only lockout) when the client's ?campaign drifts.
+            cid = self._live_play_view_campaign(qs)
             if not cid:
                 self._json(build_combat_surface({}, campaign_id="", live=live, is_live_view=False))
                 return
@@ -6733,7 +6741,9 @@ class _Handler(BaseHTTPRequestHandler):
                     is_live_view=bool(live and root_is_current and cid == self.campaign_id),
                 ))
                 return
-            cid = self._view_campaign(qs)
+            # Symmetric heal (#640): mirror /session-surface — re-align to the live run instead of
+            # latching is_live_view=False (the read-only lockout) when the client's ?campaign drifts.
+            cid = self._live_play_view_campaign(qs)
             if not cid:
                 self._json(build_atlas_surface({}, campaign_id="", live=live, is_live_view=False))
                 return
@@ -6791,7 +6801,7 @@ class _Handler(BaseHTTPRequestHandler):
         elif route == "/character-surface":
             # The party's full character sheets (classes/skills/spells/resources/AC/death
             # saves) projected from the engine snapshot into the heroes screen shape.
-            self._serve_simple_surface(parse_qs(parsed.query), build_character_surface)
+            self._serve_simple_surface(parse_qs(parsed.query), build_character_surface, heal=True)
         elif route == "/inventory-surface":
             # Each party member's pack (name/qty/type/glyph/equipped) + currency.
             self._serve_simple_surface(parse_qs(parsed.query), build_inventory_surface)
@@ -6807,6 +6817,7 @@ class _Handler(BaseHTTPRequestHandler):
             self._serve_simple_surface(
                 qs,
                 lambda snap, **kw: build_parley_surface(snap, difficulty=difficulty, **kw),
+                heal=True,
             )
         elif route == _OPENWORLDS_ROUTE:
             suffix = f"?{parsed.query}" if parsed.query else ""

--- a/viewer/tests/test_live_view_recovery.py
+++ b/viewer/tests/test_live_view_recovery.py
@@ -198,6 +198,51 @@ class LiveViewRecoveryTests(unittest.TestCase):
         self.assertFalse(surface["live"])
         self.assertFalse(surface["can_act"], "no live sink → must stay read-only")
 
+    # -- symmetric heal across the OTHER play surfaces (the #640 Parley lockout) ----
+    def test_play_surfaces_heal_symmetrically_with_session(self):
+        """The Parley-tab read-only lockout: /combat-, /atlas-, /parley-, /character-surface must
+        self-heal a stale ?campaign to the live run EXACTLY like /session-surface. Before the fix
+        they resolved via the non-healing ``_view_campaign`` and latched ``is_live_view=False``
+        ("viewing non-live campaign"), so navigating to Parley/Combat during live play stranded the
+        player read-only with every social/combat button disabled even though the sink was healthy."""
+        self._enable_move_sink()
+        self._write("old_save", _snap("Old Save"), age_seconds=600)
+        self._write("live_run", _snap("Embergloom"), age_seconds=0)
+        self.assertEqual(server._pick_campaign(None), "live_run")
+
+        for route in ("/combat-surface", "/atlas-surface",
+                      "/parley-surface", "/character-surface"):
+            status, surface = self._get(f"{route}?campaign=old_save")
+            self.assertEqual(status, 200, route)
+            self.assertTrue(surface.get("is_live_view"),
+                            f"{route} must self-heal is_live_view to the live run (not latch False)")
+            self.assertEqual(surface.get("campaign_id"), "live_run",
+                             f"{route} recovery must follow the live run")
+            # atlas/parley/character gate can_act purely on (live AND is_live_view) → it unlocks
+            # with the heal. combat additionally needs an active fight, so its recovery is the
+            # is_live_view assertion above (a stale view would have latched it False).
+            if route != "/combat-surface":
+                self.assertTrue(surface.get("can_act"),
+                                f"{route} can_act must recover once is_live_view heals")
+
+    def test_play_surfaces_pinned_view_stays_gated(self):
+        """The heal must preserve legitimate read-only gating on the other play surfaces too: a
+        PINNED director's view of a different campaign stays honestly gated (no auto-snap)."""
+        self._enable_move_sink()
+        self._write("the_pinned_run", _snap("Pinned"))
+        self._write("a_different_save", _snap("Other"))
+        _QuietHandler.pinned = True
+        _QuietHandler.campaign_id = "the_pinned_run"
+
+        for route in ("/combat-surface", "/atlas-surface",
+                      "/parley-surface", "/character-surface"):
+            status, surface = self._get(f"{route}?campaign=a_different_save")
+            self.assertEqual(status, 200, route)
+            self.assertEqual(surface.get("campaign_id"), "a_different_save", route)
+            self.assertFalse(surface.get("is_live_view"),
+                             f"{route} pinned view of another campaign must stay gated")
+            self.assertFalse(surface.get("can_act"), f"{route} pinned view must stay read-only")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The bug (G2 release blocker)
Navigating to **Parley** or **Combat** during live play stranded the player **read-only** ("viewing non-live campaign", every social/combat button disabled) even though the move sink was healthy. The adversarial persona hit this in the sweep.

## Root cause
Only `/session-surface` (+ `/app-status`) resolved the viewed campaign through the **self-healing** `_live_play_view_campaign`, which re-aligns a drifted client `?campaign` back to the live run. `/combat-surface`, `/atlas-surface`, `/parley-surface` and the SSE render bundle used the **non-healing** `_view_campaign`, so when the client's sticky `?campaign` drifted from the recency-attached id (catalog poll briefly drops `current`, native auto-follow stops after the provider exits, or a second save out-ranks the live run on recency during a quiet ~150s beat), `is_live_view` latched **False with no recovery** — while `/session-surface` recovered fine. So a player on Parley/Combat got stuck.

All four surfaces gate `can_act` on `is_live_view` (`combat:2258`, `atlas:2703`, `parley:4551`, `character`), so the heal flows straight to the action bar.

## Fix
Route the play-action surfaces (combat/atlas/parley) + the read-only character surface + the SSE render mirror through the **same** `_live_play_view_campaign` heal `/session-surface` already uses. The heal stays conservative:
- **PINNED** director's views, **non-live** stores, and already-correct views are untouched.
- The `POST /move` cross-campaign refusal is unchanged (engine remains sole writer).
- Pure read-only views (journal/seed/acts/inventory/relations) keep the literal `?campaign` view via an opt-in `heal` flag on `_serve_simple_surface` — nothing bounces off an explicitly-chosen non-live save.

## Guard
`test_live_view_recovery.py` gains two tests:
1. `/combat-`, `/atlas-`, `/parley-`, `/character-surface` self-heal a stale `?campaign` to the live run **exactly like** `/session-surface`.
2. A pinned director's view stays honestly gated on all four.

**394 viewer tests pass locally.**

Addresses the Parley/combat/atlas read-only residual of #640 (the parallel-store double-live case is handled separately by the QA single-flight harness fix, next in the reliability spine).