### PR TITLE
fix(openworlds): wire lineage-correct portraits for 5 empty races (#379)

### DIFF
--- a/viewer/openworlds/screen-create.jsx
+++ b/viewer/openworlds/screen-create.jsx
@@ -50,6 +50,21 @@ const PORTRAIT_GALLERY = [
   { slug: "halsin", name: "Halsin", race: "elf", alive: true },
   { slug: "minthara", name: "Minthara", race: "drow", alive: true },
   { slug: "dame-aylin", name: "Dame Aylin", race: "aasimar", alive: true },
+  // #379: five selectable lineages (dwarf, halfling, gnome, dragonborn, half-orc) had ZERO
+  // canon faces, so StepPortrait fell back to the lineage-mismatched living gallery for them.
+  // These are wire-ups of art ALREADY ingested under `_private/.../portrait_<slug>/` — each is a
+  // recognizable, LIVING, non-hostile BG3 NPC whose canon race (verified against bg3.wiki) maps to
+  // a RACES key below. Appended (never reordered) so existing hero.portrait indices stay stable.
+  { slug: "baelen-bonecloak", name: "Baelen Bonecloak", race: "dwarf", alive: true },
+  { slug: "thokki", name: "Thokki", race: "dwarf", alive: true },
+  { slug: "cora-highberry", name: "Cora Highberry", race: "halfling", alive: true },
+  { slug: "roger-highberry", name: "Roger Highberry", race: "halfling", alive: true },
+  { slug: "barcus-wroot", name: "Barcus Wroot", race: "gnome", alive: true },
+  { slug: "wulbren-bongle", name: "Wulbren Bongle", race: "gnome", alive: true },
+  { slug: "medrash", name: "Medrash", race: "dragonborn", alive: true },
+  { slug: "lyrux-goldthroat", name: "Lyrux Goldthroat", race: "dragonborn", alive: true },
+  { slug: "jord", name: "Jord", race: "half-orc", alive: true },
+  { slug: "gronch", name: "Gronch", race: "half-orc", alive: true },
 ];
 function portraitScope(i) {
   const p = PORTRAIT_GALLERY[i];

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -1634,6 +1634,50 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIsNotNone(aylin_match, "Dame Aylin gallery row not found")
         self.assertIn(aylin_match.group(1), race_keys)
 
+    def test_openworlds_create_every_selectable_race_has_a_living_gallery_face(self):
+        # #379: the race-aware StepPortrait filter (p.race === hero.race && p.alive !== false)
+        # left dwarf/halfling/gnome/dragonborn/half-orc with ZERO lineage-correct faces, so those
+        # five lineages silently fell back to a mismatched gallery. Guard that EVERY selectable
+        # RACES key now has >= 1 LIVING (alive !== false) PORTRAIT_GALLERY face of its own lineage,
+        # so the curated grid is lineage-correct for all races (not just the fallback grid).
+        status, ctype, body = self._get("/openworlds/screen-create.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+
+        # RACES keys the player can actually pick (StepRace renders Object.entries(RACES)).
+        races_match = re.search(r"const RACES = \{(.*?)\n\};", source, re.S)
+        self.assertIsNotNone(races_match, "RACES object not found in screen-create.jsx")
+        race_keys = {
+            quoted or bare
+            for quoted, bare in re.findall(
+                r'^\s{2}(?:"([a-z-]+)"|([a-z-]+)):\s*\{', races_match.group(1), re.M
+            )
+        }
+        self.assertIn("human", race_keys)  # sanity: parser found real keys
+
+        # Parse PORTRAIT_GALLERY rows into (race, alive) pairs.
+        gallery_match = re.search(r"const PORTRAIT_GALLERY = \[(.*?)\n\];", source, re.S)
+        self.assertIsNotNone(gallery_match, "PORTRAIT_GALLERY array not found")
+        rows = re.findall(
+            r'\{\s*slug:\s*"[a-z0-9-]+",\s*name:[^,]+,\s*race:\s*"([a-z-]+)",\s*alive:\s*(true|false)',
+            gallery_match.group(1),
+        )
+        self.assertTrue(rows, "no PORTRAIT_GALLERY rows parsed")
+        living_races = {race for race, alive in rows if alive == "true"}
+
+        missing = sorted(race_keys - living_races)
+        self.assertEqual(
+            missing,
+            [],
+            f"selectable races with no LIVING lineage-correct gallery face (#379): {missing}",
+        )
+
+        # Pin the five lineages this issue fixed so a future trim can't silently reopen the gap.
+        for race in ("dwarf", "halfling", "gnome", "dragonborn", "half-orc"):
+            self.assertIn(race, living_races, f"#379 regression: {race} lost its gallery face")
+
     def _write_snapshot(self, campaign_dir: Path, payload: dict) -> None:
         campaign_dir.mkdir(parents=True)
         (campaign_dir / "snapshot.json").write_text(json.dumps(payload), encoding="utf-8")


### PR DESCRIPTION
Closes #379.

## Problem

StepPortrait's race-aware gallery filter (`p.race === hero.race && p.alive !== false`) left **5 of 11 selectable lineages — dwarf, halfling, gnome, dragonborn, half-orc — with ZERO lineage-correct faces**. Those races silently fell back to the lineage-mismatched living gallery (the `portraitChoicesForRace` fallback), so a dwarf was still offered human/elf faces.

This is the issue's **preferred primary fix (acceptance criterion 1)**: curate ≥1 (target ≥2) lineage-correct face per affected race from the **already-ingested** pool under `content/worlds/_private/baldurs-gate/images/portrait_<slug>/`. Wire-up, not ingest.

## What changed

`viewer/openworlds/screen-create.jsx` — appended 10 entries to `PORTRAIT_GALLERY` (2 per affected race). Each is a recognizable, **living**, non-hostile BG3 NPC whose canon race was **verified against bg3.wiki**, whose `race` maps to an existing `RACES` key, and whose slug resolves to a real `portrait_<slug>/image.*` face (verified present):

| race | entries |
|------|---------|
| dwarf | Baelen Bonecloak, Thokki |
| halfling | Cora Highberry, Roger Highberry |
| gnome | Barcus Wroot, Wulbren Bongle (deep gnomes) |
| dragonborn | Medrash, Lyrux Goldthroat |
| half-orc | Jord, Gronch |

- Entries are **appended, never reordered** → existing `hero.portrait` indices stay stable (criterion 5). `PORTRAIT_GALLERY.indexOf(p)` round-trips selection state unchanged.
- Dead-figure exclusion (`alive !== false`) preserved.

`viewer/tests/test_openworlds_static.py` — new guard `test_openworlds_create_every_selectable_race_has_a_living_gallery_face`: asserts **every** selectable `RACES` key now has ≥1 *living, lineage-correct* `PORTRAIT_GALLERY` face, and pins the five fixed lineages so a future trim can't silently reopen the gap (criterion 4: `gallery_per_race >= 1`).

## Already-resolved items (no change needed)

- **Criterion 2 (Dame Aylin / aasimar):** an `aasimar` key already exists in `RACES`, so her `race: "aasimar"` entry is already reachable (guarded by the existing `..._races_are_valid_races_keys` test).
- **Criterion 3 (empty-grid fallback):** `portraitChoicesForRace` + the `portrait-gallery-fallback` empty-state already exist and remain as a safety net for any future un-curated lineage.

## Validation

- JSX validated through `viewer/openworlds/vendor/babel-standalone-7.29.0.min.js` via node+vm — parses clean (no build step; served as `text/babel`).
- All 10 new slugs confirmed to have a real `image.*` face under `_private/.../portrait_<slug>/`.
- `viewer/tests/test_portrait_art.py` + `viewer/tests/test_openworlds_static.py`: **64 passed**.

## Findings skipped (out of scope per the issue)

- Subrace handling, class-aware variant filtering, gallery expansion for already-covered races, and the separate `--ui-gate gallery_per_race` harness assertion — all explicitly out of scope in #379.

Render-only / additive change. Does not touch the combat surface, lockout area, or parity lane.