### PR TITLE
feat(openworlds): create — bring-your-own portrait PNG/JPEG upload (#376, #315 AC4)

### DIFF
--- a/viewer/openworlds/screen-create.jsx
+++ b/viewer/openworlds/screen-create.jsx
@@ -515,6 +515,104 @@ function StepPortrait({ hero, setHero }) {
   const [genState, setGenState] = React.useState(hero.portraitMode === "gen" ? "done" : "idle");
   const toast = window.useToast ? window.useToast() : (() => {});
   const genMode = hero.portraitMode === "gen" && !!hero.portraitGenScope;
+  // #376 / #315 AC4 — "Bring your own": a drop zone + file picker that uploads a PNG/JPEG and
+  // threads it through the SAME provisional-scope seam the generated face uses (portrait-pc-<hash>
+  // -> bindHero {mode:"gen", scope} -> play.sh re-keys onto portrait-<char_id>). uploadState:
+  // "idle" | "uploading". byoPreview holds an object-URL for an instant local preview while the
+  // upload lands; it's revoked on the next pick / unmount so we don't leak blob URLs.
+  const [uploadState, setUploadState] = React.useState("idle");
+  const [byoPreview, setByoPreview] = React.useState("");
+  const fileInputRef = React.useRef(null);
+  const byoPreviewRef = React.useRef("");
+  React.useEffect(function cleanupByoPreview() {
+    return function () { if (byoPreviewRef.current) URL.revokeObjectURL(byoPreviewRef.current); };
+  }, []);
+
+  const BYO_MAX_BYTES = 5 * 1024 * 1024; // 5 MB — mirrors the server cap + the UI copy.
+  const BYO_TYPES = ["image/png", "image/jpeg"];
+
+  const clearByoPreview = () => {
+    if (byoPreviewRef.current) { URL.revokeObjectURL(byoPreviewRef.current); byoPreviewRef.current = ""; }
+    setByoPreview("");
+  };
+  const setLocalPreview = (file) => {
+    const url = URL.createObjectURL(file);
+    if (byoPreviewRef.current) URL.revokeObjectURL(byoPreviewRef.current);
+    byoPreviewRef.current = url;
+    setByoPreview(url);
+  };
+
+  // Read a File -> base64 string (no data-URL prefix) for the upload body.
+  const fileToBase64 = (file) => new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const out = String(reader.result || "");
+      const comma = out.indexOf(",");
+      resolve(comma >= 0 ? out.slice(comma + 1) : out);
+    };
+    reader.onerror = () => reject(reader.error || new Error("read failed"));
+    reader.readAsDataURL(file);
+  });
+
+  const acceptFile = async (file) => {
+    if (!file) return;
+    if (uploadState === "uploading") return; // one in-flight upload
+    // Reject non-image MIME / oversize INLINE — never a console throw, never a silent no-op (AC5).
+    if (!BYO_TYPES.includes(file.type)) {
+      toast({ kind: "danger", title: "That file isn't a portrait", body: "Bring a PNG or JPEG image." });
+      return;
+    }
+    if (file.size > BYO_MAX_BYTES) {
+      toast({ kind: "danger", title: "Image too large", body: "Keep your portrait under 5 MB." });
+      return;
+    }
+    setLocalPreview(file); // instant local preview (AC2) while the bytes land server-side.
+    setUploadState("uploading");
+    try {
+      const bytes = await fileToBase64(file);
+      const resp = await fetch("/portrait-upload", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          mime: file.type,
+          bytes,
+          race: hero.race,
+          class: hero.class,
+          name: (hero.name || "").trim(),
+        }),
+      });
+      const res = await resp.json().catch(() => ({}));
+      if (res && res.ok && res.scope) {
+        // Reuse the generated-face seam: the upload now resolves via <Img scope=…> on every
+        // surface, and bindHero carries {mode:"gen", scope} so play.sh re-keys it onto the PC.
+        setHero({ ...hero, portraitMode: "gen", portraitGenScope: res.scope });
+        setGenState("done");
+        setUploadState("idle");
+        return;
+      }
+      setUploadState("idle");
+      clearByoPreview();
+      toast({ kind: "danger", title: "Couldn't use that image", body: (res && res.reason) || "Try a different PNG or JPEG." });
+    } catch (err) {
+      setUploadState("idle");
+      clearByoPreview();
+      toast({ kind: "danger", title: "Couldn't use that image", body: "Try a different PNG or JPEG." });
+    }
+  };
+
+  const onByoDrop = (e) => {
+    e.preventDefault(); // stop the browser navigating away to the dropped file (the old broken behavior).
+    const file = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+    acceptFile(file);
+  };
+  const openFilePicker = () => { if (fileInputRef.current) fileInputRef.current.click(); };
+  const onByoKeyDown = (e) => {
+    if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+      e.preventDefault();
+      openFilePicker();
+    }
+  };
+
   const portraitChoiceState = portraitChoicesForRace(hero.race);
   const galleryChoices = portraitChoiceState.choices;
   const usingGalleryFallback = portraitChoiceState.usingFallback;
@@ -655,8 +753,76 @@ function StepPortrait({ hero, setHero }) {
       </div>
 
       <Divider />
-      <div className="hand muted">
-        Bring your own — drop a PNG onto any frame to replace it.
+
+      {/* #376 / #315 AC4 — "Bring your own": a real drop zone + file picker. Keyboard-reachable
+          (focusable, Space/Enter open the native picker; role=button + aria-label for AT). Accepts
+          PNG/JPEG up to 5 MB; anything else is rejected with an inline toast (never a console throw,
+          never a silent no-op). On a valid pick the upload lands via /portrait-upload and joins the
+          generated-face seam, so it persists through bindHero -> play.sh re-key like any unique face. */}
+      <div style={{ display: "grid", gridTemplateColumns: "200px 1fr", gap: 16, alignItems: "start" }}>
+        <div>
+          {/* Live local preview of the uploaded face (object-URL) until/after the bytes land. */}
+          {byoPreview ? (
+            <img
+              src={byoPreview}
+              alt="your uploaded portrait"
+              style={{ width: "100%", height: 150, objectFit: "cover", display: "block",
+                boxShadow: "inset 0 0 0 2px var(--b-500), 0 0 16px -2px var(--gold-glow)" }}
+            />
+          ) : (
+            <Placeholder label="your own face" w="100%" h={150} framed />
+          )}
+        </div>
+        <div>
+          <div className="eyebrow" style={{ marginBottom: 6 }}>Bring your own</div>
+          <div
+            role="button"
+            tabIndex={0}
+            aria-label="Bring your own portrait"
+            data-worldos-testid="portrait-byo-dropzone"
+            onClick={openFilePicker}
+            onKeyDown={onByoKeyDown}
+            onDrop={onByoDrop}
+            onDragOver={(e) => e.preventDefault()}
+            onDragEnter={(e) => e.preventDefault()}
+            style={{
+              padding: "18px 14px",
+              textAlign: "center",
+              cursor: uploadState === "uploading" ? "progress" : "pointer",
+              color: "var(--ink-700)",
+              background: "rgba(176,141,87,0.06)",
+              boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.4)",
+              lineHeight: 1.5,
+            }}
+          >
+            <div className="body-sm" style={{ color: "var(--ink-800)" }}>
+              {uploadState === "uploading"
+                ? "Setting your face…"
+                : "Drop a PNG or JPEG here, or choose a file."}
+            </div>
+            <div className="hand muted" style={{ fontSize: 12, marginTop: 4 }}>
+              Up to 5 MB. This face becomes your hero on every screen.
+            </div>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg"
+            data-worldos-testid="portrait-byo-input"
+            onChange={(e) => { const f = e.target.files && e.target.files[0]; e.target.value = ""; acceptFile(f); }}
+            style={{ display: "none" }}
+          />
+          <div style={{ marginTop: 12, display: "flex", gap: 10, alignItems: "center" }}>
+            <BrassButton onClick={openFilePicker} disabled={uploadState === "uploading"}>
+              {uploadState === "uploading" ? "Setting your face…" : "Choose file…"}
+            </BrassButton>
+            {byoPreview && uploadState !== "uploading" && (
+              <BrassButton tone="ghost" size="sm" onClick={() => { clearByoPreview(); setHero({ ...hero, portraitMode: "gallery" }); setGenState("idle"); }}>
+                Use a gallery face
+              </BrassButton>
+            )}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -6249,6 +6249,95 @@ def _portrait_gen(payload: dict) -> dict:
     return res
 
 
+# --- POST /portrait-upload — "Bring your own" face for a player-created PC (#376, #315 AC4).
+# The Create wizard's StepPortrait advertised "Bring your own — drop a PNG onto any frame" but
+# had no implementation behind it. This is the honest write lane: the client uploads the chosen
+# image's bytes and we land them as a derived-cache descriptor under a PROVISIONAL content-scope
+# (portrait-pc-<hash>, the SAME shape /portrait-gen mints), so:
+#   1. the wizard renders the upload immediately via <Img scope=…> (GET /image reads bytes_b64), and
+#   2. bindHero threads {mode:"gen", scope} through the seam — play.sh ALREADY re-keys any
+#      provisional portrait-pc-<hash> onto portrait-<char_id> via imagegen.copy_scope at PC-mint
+#      time, so the upload persists across save/reload exactly like a generated face.
+# This is a DERIVED-cache write only (a JSON descriptor matching imagegen's on-disk shape) — the
+# engine remains the sole writer of campaign state; snapshot.json is never touched. We write the
+# descriptor in pure stdlib so this reader still imports nothing from the engine.
+_PORTRAIT_UPLOAD_MAX_BYTES = 5 * 1024 * 1024  # 5 MB cap on the decoded image (matches the UI copy).
+# Accepted image MIME types -> the magic-byte signature we require so a renamed .txt/.exe can't
+# masquerade as an image. PNG: 89 50 4E 47; JPEG: FF D8 FF.
+_PORTRAIT_UPLOAD_SIGNATURES = {
+    "image/png": (b"\x89PNG\r\n\x1a\n",),
+    "image/jpeg": (b"\xff\xd8\xff",),
+}
+
+
+def _portrait_upload(payload: dict) -> dict:
+    """Land a user-uploaded portrait into the derived cache; return a UI-ready verdict.
+
+    Contract (always 200, never raises, mirrors _portrait_gen):
+    - a valid PNG/JPEG within the size cap -> {"ok": True, "scope": "portrait-pc-…"}
+    - oversize / wrong MIME / not-actually-an-image / bad base64 -> {"ok": False, "reason": …}
+
+    The verdict's ``scope`` is the provisional content-scope the wizard renders + threads through
+    bindHero (then play.sh re-keys it onto the real PC). Bytes are stored inline (bytes_b64) so the
+    descriptor is self-contained and survives the copy_scope re-key verbatim."""
+    mime = str(payload.get("mime") or payload.get("mime_type") or "").strip().lower()
+    if mime not in _PORTRAIT_UPLOAD_SIGNATURES:
+        return {"ok": False, "reason": "unsupported image type — use a PNG or JPEG"}
+    b64 = payload.get("bytes") or payload.get("bytes_b64")
+    if not isinstance(b64, str) or not b64.strip():
+        return {"ok": False, "reason": "no image data"}
+    # Strip an optional data-URL prefix ("data:image/png;base64,…") the browser FileReader may add.
+    if "," in b64 and b64.lstrip().lower().startswith("data:"):
+        b64 = b64.split(",", 1)[1]
+    # Bound the work BEFORE decoding: base64 inflates ~4/3, so a payload whose decoded size would
+    # exceed the cap is rejected without ever materializing the bytes.
+    if (len(b64) // 4) * 3 > _PORTRAIT_UPLOAD_MAX_BYTES + 3:
+        return {"ok": False, "reason": "image too large — keep it under 5 MB"}
+    try:
+        data = base64.b64decode(b64, validate=True)
+    except (binascii.Error, ValueError):
+        return {"ok": False, "reason": "could not read image data"}
+    if not data:
+        return {"ok": False, "reason": "no image data"}
+    if len(data) > _PORTRAIT_UPLOAD_MAX_BYTES:
+        return {"ok": False, "reason": "image too large — keep it under 5 MB"}
+    # Magic-byte guard: the bytes must actually be the image kind they claim (a renamed
+    # .txt/.exe/.psd is rejected here, never silently cached as a face).
+    if not any(data.startswith(sig) for sig in _PORTRAIT_UPLOAD_SIGNATURES[mime]):
+        return {"ok": False, "reason": "that file is not a valid image"}
+    # Provisional scope keyed by the SAME inputs /portrait-gen uses, plus a per-upload seed so two
+    # different uploads for the same hero never collide on one scope dir.
+    seed = payload.get("seed")
+    scope = _portrait_gen_scope(
+        str(payload.get("race") or ""),
+        str(payload.get("class") or payload.get("class_") or ""),
+        str(payload.get("name") or ""),
+        seed if seed not in (None, "") else hashlib.sha256(data).hexdigest()[:12],
+    )
+    # Write a descriptor matching imagegen's on-disk shape so GET /image serves it unchanged and
+    # copy_scope re-keys it verbatim. A hash over the bytes keys the file so a repeat upload of the
+    # same image is idempotent (one descriptor, not a pile).
+    digest = hashlib.sha256(data).hexdigest()
+    descriptor = {
+        "kind": "portrait",
+        "provider": "byo",  # bring-your-own — distinguishes an uploaded face from a generated one.
+        "mime_type": mime,
+        "bytes_b64": base64.b64encode(data).decode("ascii"),
+        "hash": digest,
+        "cached_at": time.time(),
+    }
+    try:
+        cache_dir = _images_dir(scope)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        tmp = cache_dir / (digest + ".json.tmp")
+        final = cache_dir / (digest + ".json")
+        tmp.write_text(json.dumps(descriptor, ensure_ascii=False, indent=2), encoding="utf-8")
+        os.replace(tmp, final)
+    except OSError as exc:
+        return {"ok": False, "reason": f"could not store image: {exc}"}
+    return {"ok": True, "scope": scope, "mime": mime, "bytes": len(data)}
+
+
 def _openworlds_config() -> dict:
     """Browser-safe metadata for the OpenWorlds shell.
 
@@ -7026,6 +7115,9 @@ class _Handler(BaseHTTPRequestHandler):
         if route == "/portrait-gen":
             self._do_portrait_gen()
             return
+        if route == "/portrait-upload":
+            self._do_portrait_upload()
+            return
         if route == "/ugc/profile":
             self._do_ugc_save()
             return
@@ -7160,6 +7252,32 @@ class _Handler(BaseHTTPRequestHandler):
             self._json({"ok": False, "reason": "bad portrait-gen payload"})
             return
         self._json(_portrait_gen(payload))
+
+    def _do_portrait_upload(self) -> None:
+        """POST /portrait-upload — "Bring your own" face for a player-created PC (#376, #315 AC4).
+
+        Reads {mime, bytes(base64), race?, class?, name?, seed?} and lands the uploaded image as a
+        derived-cache descriptor under a provisional content-scope (returned as ``scope``). Always
+        200 with a JSON verdict (stored-or-rejected); a bad/oversize/non-image upload is rejected
+        with a reason the UI surfaces as an inline toast — never a console throw, never a silent
+        no-op. This is a DERIVED-cache write only (the engine remains the sole writer of campaign
+        state; snapshot.json is never touched). The scope threads through bindHero as a
+        {mode:"gen", scope} choice, which play.sh already re-keys onto the real PC at mint time."""
+        # Refuse an over-budget body BEFORE reading it into memory. The decoded image is capped at
+        # 5 MB; the base64 envelope + JSON framing inflate ~4/3, so an 8 MB body is generous
+        # headroom and bounds a malicious Content-Length to a small read.
+        try:
+            declared = int(self.headers.get("Content-Length") or 0)
+        except (TypeError, ValueError):
+            declared = 0
+        if declared > 8 * 1024 * 1024:
+            self._json({"ok": False, "reason": "image too large — keep it under 5 MB"})
+            return
+        payload = self._read_post_json()
+        if payload is ... or not isinstance(payload, dict):
+            self._json({"ok": False, "reason": "bad portrait-upload payload"})
+            return
+        self._json(_portrait_upload(payload))
 
     def _do_slot(self, action: str) -> None:
         """POST /save-slot | /load-slot — quicksave / quickload of the live campaign.

--- a/viewer/tests/test_portrait_upload.py
+++ b/viewer/tests/test_portrait_upload.py
@@ -1,0 +1,245 @@
+"""#376 / #315 AC4: POST /portrait-upload route tests — "Bring your own" portrait.
+
+The Create wizard's StepPortrait advertised "Bring your own — drop a PNG onto any frame" with no
+implementation behind it. /portrait-upload is the honest write lane: it lands a user-uploaded
+PNG/JPEG as a derived-cache descriptor under a provisional content-scope (portrait-pc-<hash>, the
+same shape /portrait-gen mints), so the wizard renders it via <Img scope=…> and bindHero threads
+{mode:"gen", scope} through the existing seam (play.sh re-keys it onto the real PC at mint time).
+
+These tests open a loopback socket but NEVER hit any gateway or engine subprocess — the upload is a
+pure stdlib descriptor write. They assert:
+  - route plumbing: distinct from 404; bad payload -> ok:false (200, never a 500);
+  - a valid PNG / JPEG lands a descriptor that GET /image serves back byte-for-byte;
+  - oversize / wrong-MIME / not-actually-an-image are REJECTED inline (ok:false, nothing cached);
+  - the StepPortrait JSX wires the drop zone + file picker + keyboard reach + the bindHero seam.
+"""
+
+import base64
+import http.client
+import importlib.util
+import json
+import os
+import tempfile
+import threading
+import unittest
+import zlib
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+def _tiny_png() -> bytes:
+    """A minimal valid 1x1 PNG (real signature + IHDR/IDAT/IEND), built without Pillow."""
+    sig = b"\x89PNG\r\n\x1a\n"
+
+    def chunk(typ: bytes, data: bytes) -> bytes:
+        body = typ + data
+        return (len(data)).to_bytes(4, "big") + body + zlib.crc32(body).to_bytes(4, "big")
+
+    ihdr = chunk(b"IHDR", (1).to_bytes(4, "big") + (1).to_bytes(4, "big") + bytes([8, 2, 0, 0, 0]))
+    raw = b"\x00\xff\x00\x00"  # one scanline: filter byte + one RGB pixel
+    idat = chunk(b"IDAT", zlib.compress(raw))
+    iend = chunk(b"IEND", b"")
+    return sig + ihdr + idat + iend
+
+
+def _tiny_jpeg() -> bytes:
+    """Bytes that START with the JPEG SOI/marker signature (FF D8 FF) — enough for the magic-byte
+    guard; the route never decodes pixels."""
+    return b"\xff\xd8\xff\xe0" + b"\x00" * 32
+
+
+class _QuietHandler(server._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:  # noqa: D401
+        return
+
+
+class PortraitUploadRouteTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _post(self, path: str, body: object) -> tuple[int, dict]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=10)
+        try:
+            raw = body if isinstance(body, (bytes, bytearray)) else json.dumps(body).encode("utf-8")
+            conn.request("POST", path, body=raw, headers={"Content-Type": "application/json"})
+            response = conn.getresponse()
+            data = response.read()
+            try:
+                parsed = json.loads(data.decode("utf-8"))
+            except (ValueError, UnicodeDecodeError):
+                parsed = {}
+            return response.status, parsed
+        finally:
+            conn.close()
+
+    def _get(self, path: str) -> tuple[int, str, bytes]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            response = conn.getresponse()
+            return response.status, response.getheader("Content-Type") or "", response.read()
+        finally:
+            conn.close()
+
+    # --- route presence + payload validation ----------------------------------- #
+
+    def test_route_is_distinct_from_404(self):
+        status_unknown, _ = self._post("/nope-not-a-route", {})
+        self.assertEqual(status_unknown, 404)
+        status, res = self._post("/portrait-upload", {})  # empty payload still returns a verdict
+        self.assertEqual(status, 200)
+        self.assertIsInstance(res, dict)
+        self.assertFalse(res.get("ok"))
+
+    def test_bad_payload_returns_ok_false(self):
+        status, res = self._post("/portrait-upload", b"{ not json")
+        self.assertEqual(status, 200)
+        self.assertFalse(res.get("ok"))
+        self.assertIn("reason", res)
+
+    # --- happy path: a valid image lands + is servable ------------------------- #
+
+    def test_valid_png_lands_and_is_servable_by_image_route(self):
+        png = _tiny_png()
+        b64 = base64.b64encode(png).decode("ascii")
+        status, res = self._post("/portrait-upload", {
+            "mime": "image/png", "bytes": b64,
+            "race": "human", "class": "fighter", "name": "Eira",
+        })
+        self.assertEqual(status, 200)
+        self.assertTrue(res.get("ok"), res)
+        scope = res.get("scope", "")
+        self.assertTrue(scope.startswith("portrait-pc-"), res)
+        # The descriptor landed in the provisional scope's cache dir (a derived write).
+        cache_dir = self._tmp / "images" / server._safe_scope(scope)
+        self.assertTrue(any(cache_dir.glob("*.json")), "expected a cached upload descriptor")
+        # GET /image?scope=… serves the EXACT uploaded bytes back (end-to-end render path).
+        gstatus, ctype, body = self._get(f"/image?scope={scope}")
+        self.assertEqual(gstatus, 200)
+        self.assertEqual(ctype, "image/png")
+        self.assertEqual(body, png)
+
+    def test_valid_jpeg_accepted(self):
+        b64 = base64.b64encode(_tiny_jpeg()).decode("ascii")
+        status, res = self._post("/portrait-upload", {"mime": "image/jpeg", "bytes": b64})
+        self.assertEqual(status, 200)
+        self.assertTrue(res.get("ok"), res)
+
+    def test_data_url_prefix_is_stripped(self):
+        b64 = base64.b64encode(_tiny_png()).decode("ascii")
+        status, res = self._post("/portrait-upload", {
+            "mime": "image/png", "bytes": "data:image/png;base64," + b64,
+        })
+        self.assertEqual(status, 200)
+        self.assertTrue(res.get("ok"), res)
+
+    # --- rejections: nothing is cached, an inline reason is returned ----------- #
+
+    def test_unsupported_mime_rejected(self):
+        b64 = base64.b64encode(b"hello").decode("ascii")
+        status, res = self._post("/portrait-upload", {"mime": "text/plain", "bytes": b64})
+        self.assertEqual(status, 200)
+        self.assertFalse(res.get("ok"))
+        self.assertIn("reason", res)
+
+    def test_non_image_bytes_with_image_mime_rejected(self):
+        # A renamed .txt/.exe claiming image/png — the magic-byte guard must reject it.
+        b64 = base64.b64encode(b"this is definitely not a PNG").decode("ascii")
+        status, res = self._post("/portrait-upload", {"mime": "image/png", "bytes": b64})
+        self.assertEqual(status, 200)
+        self.assertFalse(res.get("ok"), res)
+
+    def test_oversize_rejected(self):
+        # 6 MB of valid PNG-prefixed bytes -> over the 5 MB cap -> rejected, nothing cached.
+        big = _tiny_png() + b"\x00" * (6 * 1024 * 1024)
+        res = server._portrait_upload({"mime": "image/png", "bytes": base64.b64encode(big).decode("ascii")})
+        self.assertFalse(res.get("ok"))
+        self.assertIn("5 MB", res.get("reason", ""))
+
+    def test_empty_bytes_rejected(self):
+        status, res = self._post("/portrait-upload", {"mime": "image/png", "bytes": ""})
+        self.assertEqual(status, 200)
+        self.assertFalse(res.get("ok"))
+
+    def test_bad_base64_rejected(self):
+        res = server._portrait_upload({"mime": "image/png", "bytes": "!!!not base64!!!"})
+        self.assertFalse(res.get("ok"))
+
+    # --- determinism + idempotence -------------------------------------------- #
+
+    def test_same_image_same_inputs_is_idempotent(self):
+        png = _tiny_png()
+        b64 = base64.b64encode(png).decode("ascii")
+        payload = {"mime": "image/png", "bytes": b64, "race": "elf", "class": "rogue", "name": "Sable"}
+        r1 = server._portrait_upload(dict(payload))
+        r2 = server._portrait_upload(dict(payload))
+        self.assertEqual(r1.get("scope"), r2.get("scope"))
+        cache_dir = self._tmp / "images" / server._safe_scope(r1["scope"])
+        self.assertEqual(len(list(cache_dir.glob("*.json"))), 1)  # one descriptor, not a pile
+
+    # --- StepPortrait UI wiring (#376) ----------------------------------------- #
+
+    def _get_source(self, path: str) -> str:
+        status, _ctype, body = self._get(path)
+        self.assertEqual(status, 200)
+        return body.decode("utf-8")
+
+    def test_screen_create_has_byo_upload_affordance(self):
+        src = self._get_source("/openworlds/screen-create.jsx")
+        # A real drop zone + file input exist and POST the dedicated upload route.
+        self.assertIn('data-worldos-testid="portrait-byo-dropzone"', src)
+        self.assertIn('type="file"', src)
+        self.assertIn('accept="image/png,image/jpeg"', src)
+        self.assertIn("/portrait-upload", src)
+        self.assertIn("Choose file", src)
+
+    def test_byo_dropzone_is_keyboard_accessible(self):
+        src = self._get_source("/openworlds/screen-create.jsx")
+        # AC4: focusable, role=button, aria-label, Space/Enter open the picker; drop is captured.
+        self.assertIn('role="button"', src)
+        self.assertIn("tabIndex={0}", src)
+        self.assertIn('aria-label="Bring your own portrait"', src)
+        self.assertIn("onByoKeyDown", src)
+        self.assertIn("onByoDrop", src)
+        self.assertIn("e.preventDefault()", src)
+
+    def test_byo_threads_through_bindhero_seam(self):
+        src = self._get_source("/openworlds/screen-create.jsx")
+        # An accepted upload joins the generated-face seam so bindHero carries it as {mode:"gen"}.
+        self.assertIn('portraitMode: "gen"', src)
+        self.assertIn("portraitGenScope: res.scope", src)
+
+    def test_broken_promise_text_removed(self):
+        src = self._get_source("/openworlds/screen-create.jsx")
+        # AC6: the old advertise-but-don't-implement hand-text must be gone now that it works.
+        self.assertNotIn("drop a PNG onto any frame to replace it", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #376 (parent #315 AC4).

## Problem
`StepPortrait` advertised the hand-text *"Bring your own — drop a PNG onto any frame to replace it."* (`screen-create.jsx:659`) but there was **no** file input, drop zone, drop handler, or `byo` portrait branch anywhere — a broken promise. A dropped PNG did nothing (or the browser navigated away to the file).

## What changed

### Server — `viewer/server.py` (roster/portrait projection only)
- New `POST /portrait-upload` + `_portrait_upload()` derived-cache write lane (sibling of `_portrait_gen`).
- Validates `image/png` / `image/jpeg` by **both** MIME and **magic bytes** (a renamed `.txt`/`.exe`/`.psd` is rejected), caps the decoded image at **5 MB** (and refuses an over-budget `Content-Length` before reading it), rejects bad base64 / empty bytes.
- Lands the bytes as a JSON descriptor (`{kind, provider:"byo", mime_type, bytes_b64, hash}`) under a **provisional content-scope** `portrait-pc-<hash>` — the exact on-disk shape `imagegen` writes and `GET /image` already serves. Pure stdlib; imports nothing from the engine. **Derived-cache write only — `snapshot.json` is never touched; the engine stays the sole writer.**
- Did **not** touch the combat/lockout/`is_live_view` area, nor `play.sh`, `screen-combat.jsx`, `screen-table.jsx`, `screen-character.jsx`, or the parity lane.

### UI — `viewer/openworlds/screen-create.jsx` (additive, render-only)
- AC1: a focusable **drop zone** + **"Choose file…"** picker below the gallery; accepts PNG/JPEG ≤ 5 MB.
- AC2: **live preview** of the picked file via `URL.createObjectURL` (revoked on re-pick / unmount — no blob leak).
- AC3: **end-to-end persistence** — an accepted upload joins the generated-face seam (`portraitMode:"gen"` + `portraitGenScope`), so `bindHero` carries `{mode:"gen", scope}` and `play.sh`'s existing `imagegen.copy_scope` re-keys it onto `portrait-<char_id>` at mint time. **No change to `play.sh` was needed** — the BYO scope reuses the gen path verbatim.
- AC4: **keyboard reachable** — `tabIndex={0}`, `role="button"`, `aria-label="Bring your own portrait"`; Space/Enter open the native picker; drop/dragover `preventDefault` so the browser no longer navigates away.
- AC5: non-image / oversize files surface an inline `toast({kind:"danger"})` — never a console throw, never a silent no-op.
- AC6: the broken-promise hand-text is **replaced** by the working affordance.

### Test — `viewer/tests/test_portrait_upload.py` (new guard)
Route plumbing (distinct-from-404, bad-payload → `ok:false`), a valid PNG **round-trips through `GET /image` byte-for-byte**, JPEG accepted, data-URL prefix stripped, oversize / wrong-MIME / non-image / bad-base64 rejected with **nothing cached**, idempotent re-upload, and the StepPortrait JSX wiring (drop zone, file input, keyboard reach, bindHero seam, removed hand-text).

## Validation
- `screen-create.jsx` transformed cleanly through `vendor/babel-standalone-7.29.0.min.js` (node+vm) — the no-build-step invariant.
- `viewer/tests/test_portrait_upload.py` — 15 passed. `test_openworlds_static.py` (transforms every JSX) — 60 passed. `test_portrait_art.py` + `test_portrait_gen.py` plumbing/wiring — pass.
- One pre-existing, unrelated failure: `test_portrait_gen.py::PortraitGenRealSubprocessTests` shells `uv run` against the engine and fails with `No module named 'pydantic'` **only in the fresh worktree's uv resolution** (passes on the canonical checkout). Not touched by this change.

## Findings skipped
None — all six ACs of #376 are implemented. Subrace handling and the larger gallery (#315 AC3/AC5) are out of scope for this issue (separate ACs / issues).