### PR TITLE
fix(a11y): Escape closes character-screen modals (WCAG 2.1.2 keyboard trap)

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -360,6 +360,13 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
     return () => { cancelled = true; };
   }, [campaignId, hero.id]);
 
+  // a11y (WCAG 2.1.2 — no keyboard trap): Escape dismisses the dialog, mirroring toast.jsx.
+  React.useEffect(() => {
+    const esc = (e) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onClose]);
+
   const options = (planner && Array.isArray(planner.options)) ? planner.options : [];
   // The option for the chosen class (default: continue the current class), else the first legal path.
   const option = options.find((o) => (o.class_name || "").toLowerCase() === chosenClass) || options[0] || null;
@@ -534,6 +541,13 @@ function RestPrepareModal({ hero, party, onClose, toast, setState }) {
   const [prepared, setPrepared] = React.useState({});
   // Watch order is drawn from the LIVE party (first names), never the hardcoded demo trio.
   const watchOrder = (Array.isArray(party) ? party : []).map((p) => (p.name || "").split(" ")[0]).filter(Boolean);
+
+  // a11y (WCAG 2.1.2 — no keyboard trap): Escape dismisses the dialog, mirroring toast.jsx.
+  React.useEffect(() => {
+    const esc = (e) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onClose]);
 
   const availableSpells = hero.spells || [];
   // Data-driven from the live hero. The /character-surface read-model does not project
@@ -1400,6 +1414,12 @@ function SpellbookBrowser({ hero, groups, onClose }) {
   // that write-flow). When the engine carries no spell NAMES, we say so honestly rather than
   // fabricate an SRD list, and point the player at Rest & Prepare.
   const list = (Array.isArray(groups) ? groups : []).filter((g) => g && Array.isArray(g.list) && g.list.length);
+  // a11y (WCAG 2.1.2 — no keyboard trap): Escape dismisses the dialog, mirroring toast.jsx.
+  React.useEffect(() => {
+    const esc = (e) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onClose]);
   return (
     <div style={{
       position: "fixed", inset: 0, zIndex: 200,

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -710,6 +710,28 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn('testId="modal-close"', launcher + character)
         self.assertIn('data-worldos-testid="modal-close"', camp)
 
+    def test_character_modals_close_on_escape_key(self):
+        # WCAG 2.1.2 (No Keyboard Trap): every role="dialog" modal on the character
+        # screen (Level Up, Rest & Prepare, Spellbook) must dismiss on Escape, mirroring
+        # the toast.jsx pattern (keydown effect: e.key === "Escape" && onClose()).
+        character = (server._OPENWORLDS_DIR / "screen-character.jsx").read_text(encoding="utf-8")
+        toast = (server._OPENWORLDS_DIR / "toast.jsx").read_text(encoding="utf-8")
+
+        # Sanity-check the canonical pattern still lives in toast.jsx (the source of truth).
+        self.assertIn('e.key === "Escape" && onClose()', toast)
+
+        dialog_count = character.count('role="dialog"')
+        escape_count = character.count('e.key === "Escape" && onClose()')
+        # Guards against a new modal shipping without an Escape handler (the regression
+        # this test exists to catch): one handler per dialog, no fewer.
+        self.assertEqual(3, dialog_count)
+        self.assertEqual(
+            dialog_count,
+            escape_count,
+            "every role=\"dialog\" modal in screen-character.jsx must wire an "
+            "Escape->onClose keydown handler (WCAG 2.1.2)",
+        )
+
     def test_launcher_shelf_filters_non_resumable_scratch_runs(self):
         launcher = (server._OPENWORLDS_DIR / "screen-launcher.jsx").read_text(encoding="utf-8")
         app = (server._OPENWORLDS_DIR / "app.jsx").read_text(encoding="utf-8")


### PR DESCRIPTION
## Problem

The three `role="dialog"` modals on the character screen in `viewer/openworlds/screen-character.jsx` — **Level Up**, **Rest & Prepare**, and **Spellbook** — had no Escape-key handler. That is a **WCAG 2.1.2 (No Keyboard Trap)** violation: a keyboard or screen-reader user who opened one of these dialogs could only dismiss it by clicking the backdrop scrim or the close button (a mouse action). There was no keyboard path out.

Found during the dc0d625 sweep adversarial pass, confirmed in source.

## Fix

Add an `Escape -> onClose` keydown effect to each of the three dialogs, mirroring the canonical pattern already established in `toast.jsx` (`ContextMenu`, line 85):

```js
React.useEffect(() => {
  const esc = (e) => e.key === "Escape" && onClose();
  window.addEventListener("keydown", esc);
  return () => window.removeEventListener("keydown", esc);
}, [onClose]);
```

Minimal, consistent, and properly cleaned up on unmount. No behavior change beyond the new keyboard affordance — the existing scrim-click and close-button paths are untouched.

## Guard test

Extends `viewer/tests/test_openworlds_static.py` with `test_character_modals_close_on_escape_key`, which asserts there is exactly one Escape->onClose handler per `role="dialog"` in the file (3 dialogs, 3 handlers). Verified it **fails without the fix** (`3 != 0`) and passes with it — so a future modal that ships without an Escape handler trips the gate.

## Test result

```
test_character_modals_close_on_escape_key ... ok
test_openworlds_agent_driving_hooks_are_stable ... ok
Ran 2 tests in 1.009s — OK
```
(Focused local run; full suite via CI.)

## Risk

Very low. Additive keydown listeners on three modals, each scoped to its own `onClose` and cleaned up on unmount. No write paths, no state changes, no rendering changes.