### PR TITLE
fix(bestiary): full public-reference projection for the "Browse all" codex

### DIFF
--- a/servers/engine/bestiary.py
+++ b/servers/engine/bestiary.py
@@ -533,23 +533,93 @@ def intel_projection(name: str, tier: int) -> Optional[dict]:
     return out
 
 
-def player_bestiary(query: str = "", limit: int = 20, intel: Optional[dict] = None) -> dict:
+def _public_actions(sb: dict) -> list[dict]:
+    """The creature's actions as structured rows for the PUBLIC reference codex — ``name`` +
+    the raw mechanics ``desc`` (to-hit / reach / range / damage) + ``action_type``. Unlike the
+    intel codex's name-only ``known_actions`` (a kill-tier reveal that withholds the numbers),
+    a reference browse is public SRD reading material, so the to-hit/damage text rides along so
+    the theorycrafter can actually evaluate the creature. Empty list when it has no actions. Pure;
+    rows with no name are skipped (an SRD action always has a name)."""
+    out: list[dict] = []
+    for a in sb.get("actions", []) or []:
+        name = str(a.get("name", "")).strip()
+        if not name:
+            continue
+        out.append({
+            "name": name,
+            "desc": str(a.get("desc", "")).strip(),
+            "action_type": str(a.get("action_type", "ACTION")).strip() or "ACTION",
+        })
+    return out
+
+
+def public_reference_projection(name: str) -> Optional[dict]:
+    """Full public-SRD reference stat block for a creature, or ``None`` if unknown.
+
+    This is the "Browse all" reference surface (optimizer root-cause dc0d625): the intel codex
+    (#263) is fog-of-war — gated on the party SLAYING creatures — so before a kill the reference
+    browse showed only HOLLOW rows (CR/size/type + action NAMES, no AC/HP/abilities/saves/action
+    mechanics), and a theorycrafter couldn't evaluate anything. SRD 5.2 creature stats are public
+    Open Game Content (CC-BY-4.0), so a *reference* browse has nothing to hide — this returns the
+    FULL public sheet: identity + CR, AC, HP/hit dice, speed, ability scores, proficient saves,
+    senses, the damage resistance/immunity/vulnerability + condition-immunity lists, and the key
+    actions WITH their to-hit/damage mechanics (``actions`` rows carry the raw SRD desc, not just
+    the name as the kill-tier ``known_actions`` does). A ``tactics`` blurb composed from the action
+    text is included too.
+
+    Built on top of ``intel_projection(name, 3)`` (the slain-tier reveal) so the field set tracks
+    a single source of truth — then the public-reference extras (structured ``actions`` with
+    mechanics) are layered on. The returned dict carries ``reference: True`` (and NO ``tier`` key)
+    so a caller can tell a reference row from an earned-intel row. Pure + READ-ONLY over the
+    bestiary index; the engine remains the sole writer.
+    """
+    proj = intel_projection(name, 3)
+    if proj is None:
+        return None
+    sb = stat_block(name)  # already known-good (intel_projection succeeded), reused for actions
+    proj.pop("tier", None)
+    proj["reference"] = True
+    if sb is not None:
+        actions = _public_actions(sb)
+        if actions:
+            proj["actions"] = actions
+    return proj
+
+
+def player_bestiary(
+    query: str = "", limit: int = 20, intel: Optional[dict] = None, reference: bool = False
+) -> dict:
     """Read-only player-facing bestiary/codex projection.
 
-    Two modes, selected by ``intel`` (kept PURE — this module never opens a campaign file;
-    the viewer loads the snapshot read-only and passes the dict in):
+    Three modes (kept PURE — this module never opens a campaign file; the viewer loads the
+    snapshot read-only and passes the dict in):
 
-    * ``intel is None`` (today's call): the global SRD browse — ``player_bestiary_preview``
-      for every match, no campaign scope, no leakage. Back-compat preserved byte-for-byte.
+    * ``reference=True`` (the "Browse all" public reference codex): the global SRD browse with
+      ``public_reference_projection`` for every match — FULL public SRD stats (AC, HP/hit dice,
+      speed, ability scores, saves, senses, resistances/immunities, and key actions WITH their
+      to-hit/damage mechanics). No campaign scope, no fog-of-war — SRD stats are public Open Game
+      Content, so a reference browse renders full stat blocks instead of the hollow preview. This
+      is the optimizer root-cause fix (dc0d625): the theorycrafter can finally evaluate creatures.
+    * ``intel is None`` and not ``reference`` (the legacy default call): the global SRD browse —
+      ``player_bestiary_preview`` for every match, no campaign scope, no leakage. Back-compat
+      preserved byte-for-byte.
     * ``intel`` set (a ``{creature_slug: max_tier}`` dict, the campaign's earned intel): the
       intel-tier codex (#263). Each match's tier is looked up by ``creature_slug(name)``;
       creatures at tier >= 1 get ``intel_projection`` (progressively more stats per tier),
       and unencountered matches (tier 0) become a REDACTED ``{id_hint, tier:0, unknown:true}``
       rumour row — the real name is withheld from the wire (only an opaque render key is sent),
       so the index can show "N known · M rumoured" without leaking unencountered creature names.
+
+    ``reference`` takes precedence over ``intel`` (a "Browse all" request bypasses earned intel);
+    the viewer never passes both, but the precedence is explicit so the surface is deterministic.
     """
     n = max(1, min(int(limit), 50))
     names = find(query, n)
+    if reference:
+        return {
+            "items": [p for name in names if (p := public_reference_projection(name)) is not None],
+            "validation_errors": authored_validation_errors(),
+        }
     if intel is None:
         return {
             "items": [p for name in names if (p := player_bestiary_preview(name)) is not None],

--- a/servers/engine/tests/test_bestiary.py
+++ b/servers/engine/tests/test_bestiary.py
@@ -408,3 +408,57 @@ def test_player_bestiary_intel_mode_tiers_and_rumours():
     rumours = [i for i in out["items"] if i.get("unknown")]
     assert rumours and all(i.get("tier") == 0 for i in rumours)
     assert all("ac" not in i and "cr" not in i for i in rumours)  # no stats leaked on a rumour
+
+
+# --- public-reference projection ("Browse all" — optimizer root-cause) ------
+
+
+def test_public_reference_projection_returns_full_public_stats():
+    """GUARD: the public-reference projection returns FULL SRD-public stats — AC, HP/hit dice,
+    speed, ability scores, proficient saves, and at least one ACTION carrying its to-hit/damage
+    MECHANICS (not just the action name). This is the optimizer root-cause: the 'Browse all'
+    reference codex previously showed hollow stat blocks (only CR/size/type + action names), so
+    the theorycrafter couldn't evaluate creatures."""
+    proj = bestiary.public_reference_projection("Goblin Warrior")
+    assert proj is not None
+    # identity + threat
+    assert proj["name"] == "Goblin Warrior" and proj.get("cr")
+    # vitals + defenses that the hollow preview withheld
+    assert isinstance(proj.get("ac"), int) and proj["ac"] > 0
+    assert isinstance(proj.get("hp"), int) and proj["hp"] > 0
+    assert str(proj.get("hit_dice", "")).strip()
+    assert proj.get("speed")  # at least a walk speed
+    # full ability scores
+    assert proj.get("abilities") and {"str", "dex", "con", "int", "wis", "cha"} <= set(proj["abilities"])
+    # an ACTION with mechanics (to-hit / damage), not merely its name
+    actions = proj.get("actions")
+    assert isinstance(actions, list) and actions, "reference projection must carry structured actions"
+    scimitar = next((a for a in actions if a.get("name") == "Scimitar"), None)
+    assert scimitar is not None
+    desc = scimitar.get("desc", "")
+    assert "+4" in desc and "damage" in desc.lower()  # to-hit bonus + damage clause present
+    # a reference row is NOT an earned-intel row
+    assert proj.get("reference") is True and "tier" not in proj
+
+
+def test_public_reference_projection_unknown_returns_none():
+    assert bestiary.public_reference_projection("nonexistent beast") is None
+
+
+def test_player_bestiary_reference_mode_renders_full_stats():
+    """End-to-end: player_bestiary(reference=True) returns full public stat blocks for every
+    match (the surface the viewer's 'Browse all' toggle drives), not the hollow preview."""
+    out = bestiary.player_bestiary("goblin", 20, reference=True)
+    by_name = {i.get("name"): i for i in out["items"]}
+    gw = by_name["Goblin Warrior"]
+    # full stats present, no fog-of-war / rumour redaction on a public reference browse
+    assert "ac" in gw and "hp" in gw and "abilities" in gw and gw.get("reference") is True
+    assert not any(i.get("unknown") for i in out["items"])  # reference mode never blurs
+
+
+def test_player_bestiary_reference_precedence_over_intel():
+    """reference=True bypasses earned intel — a 'Browse all' request renders full public stats
+    even when an intel dict is also supplied (deterministic precedence)."""
+    out = bestiary.player_bestiary("goblin", 20, intel={"goblin-warrior": 1}, reference=True)
+    gw = next(i for i in out["items"] if i.get("name") == "Goblin Warrior")
+    assert "ac" in gw and "hp" in gw and gw.get("reference") is True

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -744,10 +744,13 @@ def build_bestiary_response(query: str = "", limit: int = 20, campaign_id: str =
     authority and the sole writer; this only reads the snapshot and passes a dict in.
 
     When ``reference`` is set, the campaign intel is BYPASSED and the surface returns the global
-    SRD browse (every match → names + tier-less preview stats). This is the codex "Browse all"
-    reference mode: in real play the intel codex is perpetually fog-of-war (the party rarely
-    slays enough to reveal much), so a player needs a way to read public monster facts (identity,
-    CR, the preview stat line) without it being gated on kills. Still strictly read-only.
+    SRD browse with the engine's PUBLIC-REFERENCE projection — every match → FULL public SRD stats
+    (AC, HP/hit dice, speed, ability scores, saves, senses, resistances/immunities, and key actions
+    WITH their to-hit/damage mechanics). This is the codex "Browse all" reference mode: in real play
+    the intel codex is perpetually fog-of-war (the party rarely slays enough to reveal much), so a
+    player/theorycrafter needs a way to read PUBLIC monster facts without it being gated on kills.
+    SRD 5.2 stats are public Open Game Content, so the reference browse renders full stat blocks
+    instead of the old hollow preview (the optimizer root-cause fix). Still strictly read-only.
     """
     engine = _load_engine_server()
     if engine is None:
@@ -756,9 +759,13 @@ def build_bestiary_response(query: str = "", limit: int = 20, campaign_id: str =
             "validation_errors": [],
             "error": f"engine import failed: {_ENGINE_IMPORT_ERROR}",
         }
+    if reference:
+        # "Browse all": the engine returns the full public-SRD reference sheet per match. Campaign
+        # intel is intentionally not loaded — a reference browse is public OGC, not fog-of-war.
+        return engine.bestiary.player_bestiary(query, limit, reference=True)
     intel: Optional[dict] = None
     safe = _safe_campaign_id(campaign_id) if campaign_id else ""
-    if safe and not reference:
+    if safe:
         snap = _read_snapshot(safe)
         raw = snap.get("bestiary_intel") if isinstance(snap, dict) else None
         if isinstance(raw, dict):


### PR DESCRIPTION
## Root cause (dc0d625 sweep, optimizer sat=3 — confirmed in source)

The Codex **"Browse all"** reference mode rendered **HOLLOW** stat blocks — only CR/size/type + action **NAMES**, with no AC/HP/Speed/abilities/saves/action mechanics — so a theorycrafter couldn't evaluate creatures.

Traced it: `viewer/server.py:build_bestiary_response`'s `reference=1` path left `intel=None`, which falls through to `bestiary.player_bestiary(intel=None)` → `player_bestiary_preview` (the deliberately player-safe HOLLOW preview: name/size/type/cr + action names only). The intel codex (#263) is fog-of-war gated on the party *slaying* creatures, so before a kill the reference browse had nothing rich to show.

## Fix — additive READ projection (engine stays the sole writer)

- **`bestiary.public_reference_projection(name)`** — returns the FULL public-SRD sheet: AC, HP/hit dice, speed, ability scores, proficient saves, senses, the damage resistance/immunity/vulnerability + condition-immunity lists, and the key **actions WITH their to-hit/damage mechanics** (structured `actions` rows carrying the raw SRD `desc`, not just the name as the kill-tier `known_actions` does). Built on top of `intel_projection(name, 3)` so the field set tracks one source of truth; carries `reference: True` and **no** `tier`. SRD 5.2 creature stats are public Open Game Content (CC-BY-4.0), so a *reference* browse has no fog-of-war to gate.
- **`bestiary.player_bestiary(..., reference=True)`** — new mode mapping every match through `public_reference_projection`. The legacy `intel=None` call stays **byte-for-byte** back-compat; `reference` takes precedence over `intel`.
- **`viewer/server.py:build_bestiary_response`** — the `reference=1` path now calls `player_bestiary(reference=True)` instead of dropping to the hollow preview. Still strictly read-only — no write/mutation path touched.

The viewer's `screen-bestiary.jsx` already renders `ac`/`hp`/`hit_dice`/`speed`/`senses`/`saves`/`abilities`/`known_actions`/`tactics` + defenses (hide-when-blank), so **full stat blocks now render with no UI change** — the data was simply never being sent in reference mode.

## Guard tests (`servers/engine/tests/test_bestiary.py`)

- `test_public_reference_projection_returns_full_public_stats` — the projection returns AC/HP/hit_dice/speed/abilities and an **action-with-mechanics** (Scimitar `+4` / `1d6+2` damage) for a known creature; `reference:True`, no `tier`.
- `test_public_reference_projection_unknown_returns_none`
- `test_player_bestiary_reference_mode_renders_full_stats` — full stats, never blurs.
- `test_player_bestiary_reference_precedence_over_intel`

## Test result

Focused run, local (allowlisted repo):
```
uv run pytest tests/test_bestiary.py        -> 33 passed in 1.43s
uv run pytest tests/test_bestiary_intel.py  -> 13 passed in 0.36s  (regression check)
```

## Risk

Low. Additive read-only projection; the engine remains the sole writer (no campaign/combat mutation path touched). Legacy non-reference call paths are unchanged (back-compat asserted). The only behavioral change is the `reference=1` surface, which now returns richer public-OGC data the UI already knew how to render.