### PR TITLE
fix(viewer): class-aware class-feature descriptions (Spellcasting mislabel)

### DIFF
--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3405,34 +3405,81 @@ _CLASS_FEATURE_DESCS: "dict | None" = None
 
 
 def _class_feature_desc_map() -> dict:
-    """name -> SRD description for class/subclass features (data/srd/class_features.json).
+    """(class, name) -> SRD description for class/subclass features (data/srd/class_features.json).
 
     Lets the character read-model project feature DESCRIPTIONS instead of blank detail — the
     engine already authored these canon SRD entries (260 of them), the read-model was just
-    dropping them, so the Abilities/Feats tabs rendered bare name-lists. Built once and cached;
-    global across every class/level bucket so a feature resolves regardless of which bucket holds
-    it. Honest: a feature with no authored desc stays blank (never fabricated)."""
+    dropping them, so the Abilities/Feats tabs rendered bare name-lists.
+
+    CLASS-AWARE keying (the fix): a feature NAME like "Spellcasting" is SHARED across 7 caster
+    classes with 7 DISTINCT descriptions ("Cast wizard spells using Intelligence…" vs "Cast bard
+    spells using Charisma…"), and so are "Expertise"/"Fighting Style"/"Channel Divinity"/
+    "Unarmored Defense"/"Subclass Feature". Keying by name alone collapsed all of them onto
+    whichever class loaded first (bard, alphabetically), so EVERY caster's Spellcasting read out
+    the bard's text — wrong class AND wrong ability. We key by ``(class_lower, name)`` so the
+    description resolves against the character's ACTUAL class.
+
+    The cache holds two sub-maps:
+      - ``"by_class_feature"``: {(class_lower, name): desc} — the authoritative class-aware lookup.
+      - ``"shared_names"``: the set of feature names that appear with >1 distinct desc across
+        classes — i.e. names we must NEVER resolve without a class (the flat fallback skips them so
+        a name-only lookup can't mislabel a shared feature).
+
+    Built once and cached. Honest: a feature with no authored desc stays blank (never fabricated)."""
     global _CLASS_FEATURE_DESCS
     if _CLASS_FEATURE_DESCS is not None:
         return _CLASS_FEATURE_DESCS
-    out: dict = {}
+    by_class_feature: dict = {}
+    name_descs: dict = {}  # name -> set of distinct descs (to detect shared/ambiguous names)
     try:
         raw = json.loads((_REPO_ROOT / "data" / "srd" / "class_features.json").read_text(encoding="utf-8"))
         if isinstance(raw, dict):
-            for by_level in raw.values():
+            for cls, by_level in raw.items():
                 if not isinstance(by_level, dict):
                     continue
+                cls_key = str(cls or "").strip().lower()
                 for feats in by_level.values():
                     for f in (feats or []):
                         if isinstance(f, dict):
                             nm = str(f.get("name") or "").strip()
                             ds = str(f.get("desc") or "").strip()
                             if nm and ds:
-                                out.setdefault(nm, ds)
+                                by_class_feature.setdefault((cls_key, nm), ds)
+                                name_descs.setdefault(nm, set()).add(ds)
     except Exception:
-        out = {}
-    _CLASS_FEATURE_DESCS = out
-    return out
+        by_class_feature, name_descs = {}, {}
+    shared_names = {nm for nm, descs in name_descs.items() if len(descs) > 1}
+    _CLASS_FEATURE_DESCS = {
+        "by_class_feature": by_class_feature,
+        "shared_names": shared_names,
+        # Flat fallback for legacy/class-less resolution: only UNAMBIGUOUS names (one desc across
+        # all classes) so we can never mislabel a shared feature when the class is unknown.
+        "by_name": {nm: next(iter(descs)) for nm, descs in name_descs.items() if len(descs) == 1},
+    }
+    return _CLASS_FEATURE_DESCS
+
+
+def _feature_desc(class_names: "list[str]", feature_name: str) -> str:
+    """Resolve a class feature's SRD description for a character with class(es) ``class_names``.
+
+    Tries the CLASS-AWARE map ((class, name) -> desc) for each of the character's classes first —
+    so a Wizard's "Spellcasting" gets the wizard/Intelligence text and a Bard's gets the bard/
+    Charisma text. Falls back to the unambiguous flat map only for a non-shared name (a feature
+    whose description is identical across every class that has it, e.g. a uniquely-named class
+    feature). A name that's shared with conflicting descriptions but doesn't match the character's
+    class returns "" rather than guessing the wrong class — honest over fabricated."""
+    maps = _class_feature_desc_map()
+    by_cf = maps["by_class_feature"]
+    for cls in class_names:
+        ck = str(cls or "").strip().lower()
+        if ck:
+            ds = by_cf.get((ck, feature_name))
+            if ds:
+                return ds
+    # No class matched. Only fall back for an unambiguous (non-shared) name.
+    if feature_name in maps["shared_names"]:
+        return ""
+    return maps["by_name"].get(feature_name, "")
 
 
 def _character_sheet(cid: str, ch: dict) -> dict:
@@ -3576,7 +3623,21 @@ def _character_sheet(cid: str, ch: dict) -> dict:
     # two distinct sources so the sheet's Feats tab and Class Features list are not identical
     # duplicates (#286): classFeatures <- features, feats <- notes feat-markers (empty when none).
     features = [_text(f) for f in (ch.get("features") or []) if _text(f)]
-    _feat_descs = _class_feature_desc_map()  # name -> SRD desc, so classFeatures carry detail
+    # Class-aware feature descriptions: resolve each feature's SRD desc against the character's
+    # ACTUAL class(es) so a shared name like "Spellcasting" carries the right class+ability text
+    # (Wizard -> Intelligence, Bard -> Charisma), not whichever class loaded first. _class_feature_names
+    # comes from the engine-set `classes` list (and falls back to the single `class`/`klass` field).
+    _class_feature_names: list[str] = []
+    _classes_list = ch.get("classes") if isinstance(ch.get("classes"), list) else []
+    for _cl in _classes_list:
+        if isinstance(_cl, dict):
+            _cn = _text(_cl.get("name") or _cl.get("class_name"))
+            if _cn:
+                _class_feature_names.append(_cn)
+    if not _class_feature_names:
+        _fallback_cls = _text(ch.get("class") or ch.get("klass"))
+        if _fallback_cls:
+            _class_feature_names.append(_fallback_cls)
     feat_names: list[str] = []
     for seg in _text(ch.get("notes")).split("|"):
         seg = seg.strip()
@@ -3632,7 +3693,7 @@ def _character_sheet(cid: str, ch: dict) -> dict:
         "feats": [{"name": f, "glyph": "feat", "detail": ""} for f in feat_names],
         "abilities": [],
         "proficiencies": features,
-        "classFeatures": [{"name": f, "detail": _feat_descs.get(f, "")} for f in features],
+        "classFeatures": [{"name": f, "detail": _feature_desc(_class_feature_names, f)} for f in features],
         "traits": [],
         "dr": {"value": ", ".join(_text(x) for x in (ch.get("damage_resistances") or []) if _text(x)) or "None",
                "energy": ", ".join(_text(x) for x in (ch.get("damage_immunities") or []) if _text(x)) or "None"},

--- a/viewer/tests/test_charsheet_depth.py
+++ b/viewer/tests/test_charsheet_depth.py
@@ -67,8 +67,29 @@ _SNAPSHOT = {
             "proficiency_bonus": 2, "armor_class": 18, "max_hp": 36, "current_hp": 36,
             "features": ["Second Wind", "Action Surge", "Improved Critical"],
         },
+        # A second caster whose "Spellcasting" feature is the SAME NAME as the Wizard's but a
+        # DIFFERENT class+ability (Charisma/bard). Used to prove the read-model resolves the
+        # description against the character's ACTUAL class, not whichever class loaded first.
+        "lyric": {
+            "id": "lyric", "name": "Lyric Songsteel", "kind": "player", "race": "Half-Elf",
+            "alignment": "Chaotic Good",
+            "classes": [{"name": "Bard", "level": 3, "subclass": "College of Lore"}],
+            "abilities": {"strength": 9, "dexterity": 14, "constitution": 12,
+                          "intelligence": 11, "wisdom": 10, "charisma": 16},
+            "proficiency_bonus": 2, "armor_class": 13, "max_hp": 18, "current_hp": 18,
+            "spell_slots": {"1": {"maximum": 4, "used": 0}, "2": {"maximum": 2, "used": 0}},
+            # Both casters carry the shared-name "Spellcasting" class feature.
+            "features": ["Spellcasting", "Bardic Inspiration", "Expertise"],
+        },
     },
 }
+
+# Give the Wizard the same shared-name "Spellcasting" feature so the cross-class guard can
+# compare the two side by side (the engine populates it for every caster at L1).
+_SNAPSHOT["characters"]["elara"]["features"] = [
+    "Spellcasting", "Arcane Recovery", "Evocation Savant", "Sculpt Spells",
+]
+_SNAPSHOT["party"].append("lyric")
 
 
 class _QuietHandler(server._Handler):
@@ -212,6 +233,48 @@ class CharsheetDepthTests(unittest.TestCase):
         # (was blank before — the engine authored 260 descs the surface was dropping).
         arcane = next(c for c in elara["classFeatures"] if c["name"] == "Arcane Recovery")
         self.assertTrue(arcane["detail"], "Arcane Recovery should carry its SRD description")
+        self.assertIn("slot", arcane["detail"].lower())
+
+    def test_shared_feature_desc_is_class_aware(self):
+        """Cross-class feature-description bug (dc0d625 sweep): "Spellcasting" is one feature NAME
+        shared by 7 caster classes with 7 DISTINCT descriptions. Keying the SRD desc map by NAME
+        alone collapsed them onto whichever class loaded first (bard), so a Wizard's Spellcasting
+        read out the BARD's text — wrong class AND wrong ability. The read-model must resolve the
+        description against the character's ACTUAL class: a Wizard's references Intelligence/wizard,
+        a Bard's references Charisma/bard."""
+        self._write("camp_depth", _SNAPSHOT)
+        _status, surface = self._get_json("/character-surface?campaign=camp_depth")
+        party = self._party(surface)
+
+        def _spellcasting_detail(char):
+            return next(c["detail"] for c in char["classFeatures"] if c["name"] == "Spellcasting")
+
+        wiz_detail = _spellcasting_detail(party["elara"]).lower()
+        bard_detail = _spellcasting_detail(party["lyric"]).lower()
+
+        # Wizard: Intelligence + wizard list (NOT the bard's Charisma text).
+        self.assertIn("intelligence", wiz_detail)
+        self.assertIn("wizard", wiz_detail)
+        self.assertNotIn("charisma", wiz_detail)
+        self.assertNotIn("bard", wiz_detail)
+
+        # Bard: Charisma + bard list.
+        self.assertIn("charisma", bard_detail)
+        self.assertIn("bard", bard_detail)
+        self.assertNotIn("intelligence", bard_detail)
+
+        # And the two descriptions are genuinely different (proves the lookup is class-aware,
+        # not just that one class happens to match the global-first entry).
+        self.assertNotEqual(wiz_detail, bard_detail)
+
+    def test_unique_named_feature_desc_not_regressed(self):
+        """Guard against over-correction: a UNIQUELY-named class feature (one class, one desc)
+        must still carry its SRD description. The class-aware fix must not blank these out."""
+        self._write("camp_depth", _SNAPSHOT)
+        _status, surface = self._get_json("/character-surface?campaign=camp_depth")
+        elara = self._party(surface)["elara"]
+        arcane = next(c for c in elara["classFeatures"] if c["name"] == "Arcane Recovery")
+        self.assertTrue(arcane["detail"], "Arcane Recovery should still carry its SRD description")
         self.assertIn("slot", arcane["detail"].lower())
 
     def test_surface_class_features_empty_when_engine_has_none(self):


### PR DESCRIPTION
## Bug

A Wizard's **Spellcasting** feature description read *\"Cast bard spells using Charisma; learn spells and cantrips from the bard list\"* — **wrong class AND wrong ability**. Confirmed in source (the dc0d625 sweep — veteran + optimizer + adversarial all hit it).

`viewer/server.py::_class_feature_desc_map()` keyed the SRD class-feature description map by feature **NAME** only:

```python
out.setdefault(nm, ds)   # name -> desc, first-write-wins
```

But `data/srd/class_features.json` carries **\"Spellcasting\"** under **7 caster classes** with **7 distinct descriptions** (Wizard/Intelligence, Bard/Charisma, Cleric/Wisdom, …). `setdefault` + dict iteration order meant the FIRST class to load (`bard`, alphabetically) won, so EVERY caster's Spellcasting rendered the bard text. The same name collision silently mislabeled **Expertise**, **Fighting Style**, **Channel Divinity**, **Unarmored Defense**, and **Subclass Feature**.

## Fix

Make the lookup **class-aware**:

- `_class_feature_desc_map()` now keys by `(class_lower, feature_name)` and also records which names are *shared* (appear with >1 distinct desc) plus a flat fallback of only **unambiguous** (single-desc) names.
- New `_feature_desc(class_names, feature_name)` resolves a feature against the character's **actual class(es)** (from the engine-set `classes` list). Falls back to the flat map only for a non-shared name; a shared name with no class match returns `\"\"` (honest, never guesses the wrong class).
- `_character_sheet` passes the character's class names into the resolver for `classFeatures`.

Non-shared descriptions (the 260 single-class SRD entries, e.g. Arcane Recovery) are unaffected.

## Guard tests (`viewer/tests/test_charsheet_depth.py`)

- `test_shared_feature_desc_is_class_aware`: a Wizard's Spellcasting references **Intelligence/wizard** (and NOT charisma/bard); a Bard's references **Charisma/bard**; the two differ.
- `test_unique_named_feature_desc_not_regressed`: a uniquely-named feature (Arcane Recovery) still carries its SRD detail.

## Test result

```
$ python3 -m pytest viewer/tests/test_charsheet_depth.py -q
13 passed in 6.60s
$ python3 -m pytest viewer/tests/test_readmodel_surfaces.py -q
30 passed, 4 subtests passed
```