### PR TITLE
fix(engine): reconcile spawn_monster id so end_combat sees no living-hostile duplicate

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1863,8 +1863,41 @@ def spawn_monster(campaign_id: str, name: str = "", count: int = 1,
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         spawned = []
+        # ID-reconcile (combat seam): re-staging a creature already standing pristine on the
+        # table — a second spawn_monster("Ogre") for "the ogre" the DM just described — must
+        # NOT mint a fresh duplicate id. A duplicate the DM never targets stays in the
+        # initiative order at full HP, so end_combat reports a live hostile after the REAL
+        # foe is killed, the behavioral gate goes RED, and a clean fight is judged broken
+        # (dc0d625 sweep: end_combat fired with a living Ogre while the duo had actually won).
+        # Reuse pristine, in-scene copies of this TYPE — alive, undamaged, no conditions, NOT
+        # already in the active combat order (so two foes the DM is genuinely fighting are
+        # never collapsed) — before minting any new record. Deterministic (sorted by id).
+        in_combat_ids = {cb.character_id for cb in c.combat.order}
+        reusable = sorted(
+            (
+                ch for ch in c.characters.values()
+                if ch.kind == "monster"
+                and getattr(ch, "creature_slug", "") == slug
+                and slug != ""
+                and not ch.dead
+                and ch.current_hp == ch.max_hp
+                and ch.current_hp > 0
+                and ch.temp_hp == 0
+                and not ch.conditions
+                and ch.xp_value == sb["xp"]
+                and ch.id not in in_combat_ids
+            ),
+            key=lambda ch: ch.id,
+        )
         for i in range(n):
             label = f"{sb['name']} {i + 1}" if n > 1 else sb["name"]
+            if reusable:
+                # Reconcile onto the existing record: reuse its id (the DM's "the ogre"),
+                # refresh the label so numbering stays consistent, and report reused=True.
+                ch = reusable.pop(0)
+                ch.name = label
+                spawned.append({"id": ch.id, "name": ch.name, "reused": True})
+                continue
             ch = Character(
                 name=label,
                 kind="monster",

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -2119,3 +2119,46 @@ def test_parry_does_not_fire_when_it_cannot_flip_or_on_a_crit_or_ranged(tmp_path
     monkeypatch.setattr(server.dice_mod, "roll", _attack_roll_stub(16))
     rr = server.attack(cid3, hr, cap3, attack_bonus=0, damage_dice="1d6+1", damage_type="piercing", is_ranged=True)
     assert rr["hit"] is True and rr["parry"] is None
+
+
+# --- combat ID-reconcile seam (dc0d625): re-staging a pristine foe must not leave a duplicate ---
+def test_respawn_pristine_monster_reconciles_id_so_end_combat_is_clean(tmp_path, monkeypatch):
+    """ROOT (dc0d625 sweep): a second spawn_monster for a creature already standing pristine on
+    the table used to mint a NEW combatant id. The DM kills the foe it tracked; the duplicate
+    (different id, never targeted) stays in the order at full HP, so end_combat reports a LIVING
+    hostile after a clean win and the behavioral gate goes RED — capping a real fight's score.
+
+    The reconcile: the re-spawn reuses the existing pristine record's id (reused=True) instead
+    of minting a duplicate. Deterministic — no dice; the assertion is on ids + HP state."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("ReconcileSeam")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30, armor_class=12)["id"]
+
+    # The DM stages the ogre, narrates, then re-stages "the ogre" — the QA-observed mistake.
+    s1 = server.spawn_monster(cid, "Ogre")
+    ogre = s1["spawned"][0]["id"]
+    s2 = server.spawn_monster(cid, "Ogre")
+
+    # Reconcile: the re-spawn reuses the same id and flags reused — NOT a fresh duplicate.
+    assert s2["spawned"][0]["id"] == ogre, "re-spawn of a pristine foe must reuse the existing id"
+    assert s2["spawned"][0].get("reused") is True
+    monsters = [ch for ch in store.load_campaign(cid).characters.values() if ch.kind == "monster"]
+    assert len(monsters) == 1, "no duplicate monster record may exist after the reconcile"
+
+    # The real fight: start combat, drop the (single) ogre to 0 HP, end combat.
+    server.start_combat(cid, [hero, ogre])
+    out = server.apply_damage(cid, ogre, 999)  # overkill -> 0 HP, dead
+    assert out["current_hp"] == 0
+
+    res = server.end_combat(cid)
+    # The behavioral gate keys on warning_live_hostiles: it MUST be absent on a clean win.
+    assert "warning_live_hostiles" not in res, (
+        f"end_combat saw a living hostile after a clean kill: {res.get('warning_live_hostiles')!r}"
+    )
+    survivors = [
+        ch for ch in store.load_campaign(cid).characters.values()
+        if ch.kind == "monster" and ch.current_hp > 0 and not ch.dead
+    ]
+    assert survivors == [], f"no living-hostile duplicate may remain: {[s.name for s in survivors]}"


### PR DESCRIPTION
## Root cause (dc0d625 sweep triage — CONFIRMED in source + reproduced)

`end_combat` fired with a LIVING hostile because `spawn_monster` minted a **new** combatant id every call. A second `spawn_monster(\"Ogre\")` for \"the ogre\" the DM had just described created a **second** `Character` record with a different id and the identical name. The DM then killed the foe it tracked (`ogre1`); the duplicate (`ogre2`, never targeted) stayed in the initiative order at full HP. `end_combat`'s live-hostile check iterates `c.combat.order` and flags any `kind==\"monster\"` at `>0 HP`, so it reported `warning_live_hostiles` after a clean win → behavioral gate RED → the duo's real fight (3–4 rounds vs Ogres, Karlach died) judged broken → story/mech **GATE-CAPPED to 2.5**.

Reproduced before the fix (two `spawn_monster(\"Ogre\")` → `start_combat` → kill the first → `end_combat`): `warning_live_hostiles: {count: 1, ...}` with the duplicate Ogre at 68/68.

## Fix (minimal, additive — `servers/engine/server.py`, `spawn_monster`)

Before minting, reconcile onto an existing **pristine, in-scene** record of the same creature TYPE (`creature_slug`). A record is reusable only when it is:
- alive (`not dead`), undamaged (`current_hp == max_hp > 0`), no `temp_hp`, no `conditions`, full `xp_value`, **and**
- **NOT already in the active combat order** — so two foes the DM is genuinely fighting are never collapsed.

Reuse is deterministic (sorted by id), reports `reused: True`, and `count>1` reuses the available pristine copies and mints only the shortfall. When there is no reusable copy the path is **byte-identical** to before.

## Guard test (deterministic, no dice)

`tests/test_combat.py::test_respawn_pristine_monster_reconciles_id_so_end_combat_is_clean`:
spawn → re-spawn (asserts same id, `reused=True`, **one** monster record) → `start_combat` → `apply_damage` to 0 HP → asserts `end_combat` has **no** `warning_live_hostiles` and **zero** living-hostile survivors.

## Verification (focused, local)

- `tests/test_combat.py` — **124 passed**
- all `spawn_monster`-using suites (`test_bestiary`, `test_xp_kill_time`, `test_spatial_xp`, `test_qa_gate`, `test_qa_fixes`, `test_parley`, `test_bestiary_intel`, `test_beat_roundtrip`, `test_tool_arg_aliases_sweep`) — **242 passed**

## Risk

Low. Additive; the no-reusable-copy path is unchanged. The in-combat exclusion guarantees distinct foes already in a fight are never merged.