### PR TITLE
fix(lockout): recover the action bar from a slow-but-alive beat (detach-locks-the-action-bar P0)

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -866,10 +866,23 @@ function App() {
   // the live campaign as `current`, follow it so the party/surface and can_act track the real
   // session (the chronicle already follows the live run via /chat). Outside a play session the
   // launcher's manual selection is left untouched.
+  //
+  // LOCKOUT P0 (detach-locks-the-action-bar): the OLD gate `!nativeState?.appStatus?.runningProvider`
+  // early-returned in a PLAIN BROWSER (scripts/play.sh — the exact env the sweep personas ran), so
+  // the client NEVER re-followed the live run when the catalog re-poll surfaced it, and kept posting
+  // a STALE ?campaign after navigating away and back. The catalog already carries the move-sink truth
+  // (`current` is the attached run, `live` folds in `move_sink_live`), so follow the live run whenever
+  // it is present — native runningProvider OR an in-browser current+live catalog row — and let the
+  // server-side heal (server.py `_live_play_view_campaign`) be the backstop if this ever lags.
   React.useEffect(() => {
-    if (!nativeState?.appStatus?.runningProvider) return;
     const list = Array.isArray(state?.campaigns) ? state.campaigns : [];
-    const liveCampaign = list.find((c) => c.current) || list.find((c) => c.live);
+    const nativeLive = Boolean(nativeState?.appStatus?.runningProvider);
+    // The in-browser play signal: a campaign the move sink is feeding (attached `current` AND `live`).
+    const browserLive = list.some((c) => c && c.current && c.live);
+    if (!nativeLive && !browserLive) return;
+    const liveCampaign = list.find((c) => c.current && c.live)
+      || list.find((c) => c.current)
+      || list.find((c) => c.live);
     if (liveCampaign && liveCampaign.id !== state?.activeCampaign) {
       setState((s) => ({ ...s, activeCampaign: liveCampaign.id }));
     }

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -422,6 +422,65 @@ function buildChronicleLog(recentEvents, chatBeats, log) {
 // Exposed for tests/devtools introspection (additive — the component calls the local fn directly).
 if (typeof window !== "undefined") window.buildChronicleLog = buildChronicleLog;
 
+// LOCKOUT P0 — the detach-locks-the-action-bar play gate, as ONE pure function so the exact
+// boolean logic is unit-testable (mirrors app.jsx's `recoveryWindowMs`). Inputs are the surface +
+// app-status facts the component already has; outputs are every derived play-gate flag + the single
+// player-facing block message. The three load-bearing contracts this encodes:
+//   1. NO raw dev string ever reaches the player — the "live provider move sink is not ready …"
+//      detail is mapped by BUCKET to humane, story-adjacent copy (`blockReason`).
+//   2. A STUCK turn (pending.stuck — the DM timed out) re-opens the bar for a REAL retry:
+//      `stuckRetryUnblocked` is true even through an app-status latch (`appStatusBlocksPlay`), so the
+//      retry can PROBE the server /move gate (the real write authority). It is NOT unblocked when the
+//      surface fetch itself failed/loading (`surfaceStatusBlocksPlay`) — nothing to act on then.
+//   3. The honest-dead-provider path is preserved: a genuine surface outage still blocks, and a probe
+//      that the server refuses (dead sink) surfaces that reason rather than re-arming.
+function computePlayGate({ surfaceStatus, appStatus, pendingStuck }) {
+  const readiness = appStatus?.readiness || {};
+  const health = appStatus?.health || {};
+  const failureBucket = readiness.failure_bucket || health.failure_bucket || "";
+  const failureDetail = readiness.failure_detail || health.failure_detail || "";
+  const surfaceStatusBlocksPlay = surfaceStatus !== "ready";
+  const surfaceStatusBlockReason = surfaceStatus === "loading"
+    ? "The live session surface is still loading."
+    : `Session surface unavailable: ${surfaceStatus}`;
+  const appStatusBlocksPlay = Boolean(
+    appStatus &&
+    readiness.ready_for_play === false &&
+    ["no_provider", "no_launcher", "move_rejected"].includes(failureBucket),
+  );
+  // Only ever surface the raw server detail when it is a clearly-human sentence (no internal jargon).
+  const detailLooksHuman = Boolean(
+    failureDetail &&
+    !/move sink|provider-backed|app-status|app_status|readiness|failure_bucket|localhost/i.test(failureDetail),
+  );
+  const appStatusBlockReason = (
+    failureBucket === "no_launcher"
+      ? "The play window lost its connection. Resume this chronicle from Chronicles to keep going."
+      : failureBucket === "no_provider"
+        ? "The Dungeon Master has stepped away. Resume this chronicle from Chronicles to bring them back."
+        : failureBucket === "move_rejected"
+          ? "That move could not be sent to the live session. Resume this chronicle from Chronicles and try again."
+          : detailLooksHuman
+            ? failureDetail
+            : "The live session paused. Resume this chronicle from Chronicles to keep playing."
+  );
+  const livePlayBlocked = surfaceStatusBlocksPlay || appStatusBlocksPlay;
+  const blockReason = surfaceStatusBlocksPlay ? surfaceStatusBlockReason : appStatusBlockReason;
+  // A stuck turn re-opens the bar for a real retry, bypassing ONLY the app-status latch (never a
+  // genuine surface outage). The server /move gate is the authority on whether the retry lands.
+  const stuckRetryUnblocked = Boolean(pendingStuck) && !surfaceStatusBlocksPlay;
+  return {
+    failureBucket,
+    surfaceStatusBlocksPlay,
+    appStatusBlocksPlay,
+    livePlayBlocked,
+    blockReason,
+    stuckRetryUnblocked,
+  };
+}
+// Exposed for tests/devtools introspection (additive — the component calls the local fn directly).
+if (typeof window !== "undefined") window.computePlayGate = computePlayGate;
+
 function ScreenTable({ onNavigate, state, setState, liveSession }) {
   const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
   const activeCampaign =
@@ -514,26 +573,19 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
   const composerMode = COMPOSER_MODES[composerModeId] || COMPOSER_MODES.do;
   const composerAction = actionById(composerMode.actionId);
   const draftText = input.trim();
-  const appReadiness = appStatus?.readiness || {};
-  const appHealth = appStatus?.health || {};
-  const appFailureBucket = appReadiness.failure_bucket || appHealth.failure_bucket || "";
-  const appFailureDetail = appReadiness.failure_detail || appHealth.failure_detail || "";
-  const surfaceStatusBlocksPlay = surfaceStatus !== "ready";
-  const surfaceStatusBlockReason = surfaceStatus === "loading"
-    ? "The live session surface is still loading."
-    : `Session surface unavailable: ${surfaceStatus}`;
-  const appStatusBlocksPlay = Boolean(
-    appStatus &&
-    appReadiness.ready_for_play === false &&
-    ["no_provider", "no_launcher", "move_rejected"].includes(appFailureBucket),
-  );
-  const appStatusBlockReason = appFailureDetail || (
-    appFailureBucket === "no_provider"
-      ? "No Dungeon Master provider is connected."
-      : "The live move lane is not ready."
-  );
-  const livePlayBlocked = surfaceStatusBlocksPlay || appStatusBlocksPlay;
-  const livePlayBlockReason = surfaceStatusBlocksPlay ? surfaceStatusBlockReason : appStatusBlockReason;
+  // The action bar's pending/stuck state (owned by useLiveSession in app.jsx): `pendingActive` is a
+  // turn the DM is still narrating; `pendingStuck` is a turn the recovery timeout flagged as timed-out
+  // (the bar re-opens so the player can retry — see the LOCKOUT P0 recovery below).
+  const pendingActive = Boolean(pending && !pending.stuck);
+  const pendingStuck = Boolean(pending && pending.stuck);
+  // LOCKOUT P0 — every derived play-gate flag + the single player-facing block message come from ONE
+  // pure helper (`computePlayGate`, module scope above) so the boolean logic is unit-testable and can
+  // never drift between the controls. `stuckRetryUnblocked` re-opens the bar for a real retry through
+  // an app-status latch; `livePlayBlocked` still freezes a genuine surface outage; `blockReason` is
+  // humane copy (the raw "live provider move sink is not ready" dev string never reaches the player).
+  const playGate = computePlayGate({ surfaceStatus, appStatus, pendingStuck });
+  const { surfaceStatusBlocksPlay, appStatusBlocksPlay, livePlayBlocked, stuckRetryUnblocked } = playGate;
+  const livePlayBlockReason = playGate.blockReason;
 
   const loadSurface = React.useCallback(async (isCancelled = () => false) => {
     const params = new URLSearchParams();
@@ -665,12 +717,11 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
 
   // #340 + #342: arming / clearing the "DM is narrating…" pending state now lives in the app-level
   // useLiveSession hook (so it survives navigation, and carries the 90s recovery + 12-min backstop).
-  // ScreenTable just calls into it. `pendingActive` is the gate for the action bar — a turn that the
-  // recovery timeout flagged `stuck` is NO LONGER pending (the bar re-opens so the player can retry).
+  // ScreenTable just calls into it. `pendingActive`/`pendingStuck` are derived above (they feed the
+  // LOCKOUT P0 play gate); a turn the recovery timeout flagged `stuck` is NO LONGER pending — the bar
+  // re-opens (and `stuckRetryUnblocked` lets the retry probe the server even through an app-status latch).
   const armPending = session.armPending;
   const recordPlayerEcho = session.recordPlayerEcho;
-  const pendingActive = Boolean(pending && !pending.stuck);
-  const pendingStuck = Boolean(pending && pending.stuck);
   // #385: the COLD-OPEN (first beat) gets action-bar copy that reads as "the DM is taking its turn"
   // (alive) rather than the generic "Narrating…" — so the locked bar matches the obviously-alive
   // chronicle indicator and never looks like the app is wedged.
@@ -694,9 +745,17 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
     if (!pending) stuckNotified.current = false;
   }, [pendingStuck, pending, toast]);
 
-  const postMove = async (move, label, actionId) => {
+  const postMove = async (move, label, actionId, { probe = false } = {}) => {
     const enabledAction = actionId ? enabledActionById(actionId) : null;
-    if (!move || !canAct || livePlayBlocked || pendingActive || (actionId && !enabledAction)) {
+    // `probe` is the stuck-turn retry: the client gate (canAct/livePlayBlocked, and the per-action
+    // enabled flag, which all derive from the same possibly-stale surface) is a hint, so we let the
+    // retry PROBE the server /move gate (the real write authority). We still honor the truly hard
+    // local blockers — a missing move, or a turn already in flight — so a probe can't spam the lane
+    // or double-fire. The server's own validation (sanitize_move + the campaign-tag gate) is the
+    // backstop that refuses anything the surface would have correctly blocked.
+    const hardBlocked = !move || pendingActive;
+    const softBlocked = !canAct || livePlayBlocked || (actionId && !enabledAction);
+    if (hardBlocked || (softBlocked && !probe)) {
       toast({ kind: "danger", title: "Action unavailable", body: pendingActive ? "The Dungeon Master is still narrating — one move at a time." : livePlayBlocked ? livePlayBlockReason : readOnlyReason });
       return;
     }
@@ -737,7 +796,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
     }
   };
 
-  const sendAction = async () => {
+  const sendAction = async ({ probe = false } = {}) => {
     if (pendingActive) return;
     const text = input.trim();
     if (!text) {
@@ -746,12 +805,15 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
       return;
     }
     const action = actionById(composerMode.actionId);
-    if (!action?.available) {
+    // On a normal declare the surface's action-availability is the gate; on a stuck-turn `probe`
+    // (the retry path) the surface gate may be a stale latch, so we defer to the server /move gate
+    // instead of refusing locally — postMove({probe}) carries the bypass + the honest-failure toast.
+    if (!action?.available && !probe) {
       toast({ kind: "danger", title: `${composerMode.label} is unavailable`, body: action?.disabled_reason || readOnlyReason });
       return;
     }
     const echoText = composerModeId === "do" ? text : `${composerMode.label}: ${text}`;
-    await postMove({ kind: composerMode.kind, text }, echoText, composerMode.actionId);
+    await postMove({ kind: composerMode.kind, text }, echoText, composerMode.actionId, { probe });
     setInput("");
   };
 
@@ -763,8 +825,9 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
   const retryStuck = async () => {
     const typed = input.trim();
     if (typed) {
-      // Player rephrased — send the new text as a fresh `do` (this path already worked).
-      await sendAction();
+      // Player rephrased — send the new text as a fresh move, PROBING the server gate (the stuck
+      // retry path), so an app-status latch can't silently swallow the rephrase too.
+      await sendAction({ probe: true });
       return;
     }
     const last = lastMoveRef.current;
@@ -774,15 +837,23 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
       inputRef.current?.focus();
       return;
     }
-    // Re-POST the stalled move verbatim. postMove re-arms pending + the recovery/backstop timers.
-    await postMove(last.move, last.label, last.actionId);
+    // Re-POST the stalled move verbatim, PROBING the server /move gate (the real write authority):
+    // a live sink takes it and the next surface poll recovers; a dead sink refuses and postMove
+    // surfaces the honest reason. postMove re-arms pending + the recovery/backstop timers.
+    await postMove(last.move, last.label, last.actionId, { probe: true });
   };
 
   // #344: the Declare button doubles as the stuck-recovery "Try again" button (same slot, relabeled).
   // Route the click to the right handler so a stuck turn actually retries instead of no-op'ing.
   const onDeclareClick = () => (pendingStuck ? retryStuck() : sendAction());
   const declareNeedsDraft = !pendingStuck && !draftText;
-  const declareDisabled = !composerAction?.available || pendingActive || livePlayBlocked || declareNeedsDraft;
+  // The button is "Try again" when a turn is stuck — it must stay CLICKABLE through an app-status
+  // latch (`livePlayBlocked`) or a stale per-action flag so the recovery promise is real (see
+  // `stuckRetryUnblocked`). It still respects a genuine surface outage and the in-flight lock. On a
+  // normal declare, all the usual gates apply.
+  const declareDisabled = stuckRetryUnblocked
+    ? pendingActive
+    : (!composerAction?.available || pendingActive || livePlayBlocked || declareNeedsDraft);
   const declareTitle = !composerAction?.available
     ? `${composerMode.label} is unavailable: ${composerAction?.disabled_reason || readOnlyReason}`
     : pendingActive
@@ -896,7 +967,7 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
             aria-live="assertive"
             data-worldos-testid="app-status-banner"
             data-worldos-status-scope="app-status"
-            data-worldos-status={appFailureBucket || "not-ready"}
+            data-worldos-status={playGate.failureBucket || "not-ready"}
             className="body-sm"
             style={{
               padding: "8px 12px",
@@ -905,7 +976,10 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
               boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.3)",
             }}
           >
-            {appStatusBlockReason} Start or resume a provider-backed session from Chronicles before sending moves.
+            {/* LOCKOUT P0: `blockReason` is already humane and tells the player to resume from
+                Chronicles — the old raw "Start or resume a provider-backed session …" jargon suffix
+                that leaked here is removed. */}
+            {playGate.blockReason}
           </div>
         )}
         {/* Scene plate */}
@@ -1098,7 +1172,10 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => e.key === "Enter" && onDeclareClick()}
-                disabled={pendingActive || livePlayBlocked}
+                // On a stuck turn the composer must accept text + Enter so the player can rephrase
+                // and retry, even through an app-status latch (`stuckRetryUnblocked`) — the recovery
+                // copy promised an open box. A genuine surface outage / in-flight beat still freezes.
+                disabled={stuckRetryUnblocked ? false : (pendingActive || livePlayBlocked)}
                 title={composerMode.inputTitle || DECLARE_HINT}
                 placeholder={pendingFirstBeat ? "The Dungeon Master is composing your opening scene…" : pendingActive ? "The Dungeon Master is narrating…" : pendingStuck ? "The DM seemed stuck — try again." : livePlayBlocked ? "Reconnect the live session to play…" : (canAct ? composerMode.placeholder : `Read-only: ${readOnlyReason}`)}
                 style={{ ...inkInput, fontFamily: "var(--f-body)", fontSize: 16, opacity: pendingActive ? 0.6 : 1 }}

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -6398,9 +6398,21 @@ class _Handler(BaseHTTPRequestHandler):
         # The attached campaign is only the recovery target when it is the SINGLE current,
         # resumable play-store campaign (so we never follow into a parallel/stale store). Pass
         # the just-resolved `attached` so the `current` flag is correct regardless of class state.
+        #
+        # LOCKOUT P0 (detach-locks-the-action-bar): `_list_campaigns` derives each card's `live`
+        # flag purely from snapshot/session recency (`(now - recency) < 90`). On a long quiet DM
+        # beat — or after the player navigates several hops away while the DM narrates — the live
+        # run's mtimes age past 90s, so its recency-`live` flips False and `live_current` goes
+        # EMPTY, defeating this heal: is_live_view latched False and the action bar locked even
+        # though the move sink was healthy. We are already inside the `_live_play()` branch above,
+        # so the sink the writes go to is genuinely alive AND it feeds exactly the `attached`
+        # campaign — so `attached` is live HERE by construction, regardless of snapshot decay.
+        # Treat it as live (the sink is the authority); keep the recency signal for the OTHER
+        # campaigns so we still won't auto-snap away from a genuinely-active parallel run.
         live_current = [
             c.get("id") for c in _list_campaigns(attached)
-            if isinstance(c, dict) and c.get("current") and c.get("live")
+            if isinstance(c, dict) and c.get("current")
+            and (c.get("id") == attached or c.get("live"))
         ]
         if attached in live_current and (not override or override not in live_current):
             # Client view is stale (empty, or a non-live save) while exactly the attached run

--- a/viewer/tests/test_live_view_recovery.py
+++ b/viewer/tests/test_live_view_recovery.py
@@ -114,6 +114,18 @@ class LiveViewRecoveryTests(unittest.TestCase):
         finally:
             conn.close()
 
+    def _post(self, path: str, payload: dict) -> tuple[int, dict]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            body = json.dumps(payload).encode("utf-8")
+            conn.request("POST", path, body=body,
+                         headers={"Content-Type": "application/json"})
+            resp = conn.getresponse()
+            data = resp.read()
+            return resp.status, (json.loads(data.decode("utf-8")) if data else {})
+        finally:
+            conn.close()
+
     # -- the wedge + its recovery ---------------------------------------------
     def test_stale_viewed_campaign_recovers_can_act_on_live_run(self):
         """A stale ?campaign= (the client latched an OLD, non-current save while the live run
@@ -242,6 +254,117 @@ class LiveViewRecoveryTests(unittest.TestCase):
             self.assertFalse(surface.get("is_live_view"),
                              f"{route} pinned view of another campaign must stay gated")
             self.assertFalse(surface.get("can_act"), f"{route} pinned view must stay read-only")
+
+    # -- the detach-locks-the-action-bar P0 (dc0d625 re-baseline sweep) --------
+    # The slow-but-alive beat: the DM is narrating, the move sink is healthy, but the
+    # snapshot/session mtimes have aged past the 90s recency window (a long quiet beat,
+    # or the player navigated away for several hops). `_list_campaigns` derives each
+    # card's `live` flag purely from recency (`(now - recency) < 90`, server.py:1007),
+    # so EVERY card flips live=False — which empties the heal's `live_current` guard
+    # (server.py:6401-6404) and the self-heal no-ops, latching is_live_view=False and
+    # leaking "live provider move sink is not ready". This is the confirmed trigger.
+    def test_stale_snapshot_but_live_sink_recovers_can_act(self):
+        """REPRO (sub-case a): a single live run whose snapshot is stale >90s while the move
+        sink is live (a long quiet DM beat) must STILL be live + actable — not latch the lock."""
+        self._enable_move_sink()
+        # One real run, recency aged past the 90s window (DM has been narrating quietly).
+        self._write("live_run", _snap("Embergloom"), age_seconds=300)
+        self.assertEqual(server._pick_campaign(None), "live_run")
+        # Pre-fix: the recency-only live flag is False for the only campaign.
+        cards = server._list_campaigns("live_run")
+        self.assertTrue(any(c["id"] == "live_run" for c in cards))
+
+        status, surface = self._get("/session-surface?campaign=live_run")
+        self.assertEqual(status, 200)
+        self.assertTrue(surface["live"],
+                        "a live move sink keeps the attached run live despite a stale snapshot")
+        self.assertTrue(surface["is_live_view"],
+                        "viewing the attached live run must report is_live_view (no false lock)")
+        self.assertTrue(surface["can_act"],
+                        "can_act must hold while the sink is live — the slow-beat lockout")
+
+        status, payload = self._get("/app-status?campaign=live_run")
+        self.assertEqual(status, 200)
+        self.assertTrue(payload["live"]["can_act"], "app-status can_act must hold for the live run")
+        self.assertNotEqual(payload["readiness"]["failure_bucket"], "no_provider",
+                            "the no_provider bucket / raw 'move sink not ready' must NOT fire")
+
+    def test_stale_snapshot_two_campaigns_heals_to_live_run(self):
+        """REPRO (sub-case c): two play-store campaigns BOTH aged past 90s while the sink is
+        live (player nav-hopped to 'the other Live chronicle'). The stale ?campaign on the
+        non-attached run must heal to the attached live run, not latch the lock."""
+        self._enable_move_sink()
+        # The attached/live run is the most-recently-active; a second chronicle also exists.
+        self._write("other_chronicle", _snap("Chapter Two"), age_seconds=200)
+        self._write("live_run", _snap("Embergloom"), age_seconds=120)
+        self.assertEqual(server._pick_campaign(None), "live_run")
+
+        status, surface = self._get("/session-surface?campaign=other_chronicle")
+        self.assertEqual(status, 200)
+        self.assertTrue(surface["is_live_view"],
+                        "a stale view of the other chronicle must heal to the live run")
+        self.assertEqual(surface["campaign_id"], "live_run", "recovery follows the live run")
+        self.assertTrue(surface["can_act"], "can_act recovers after the heal")
+
+        # /app-status agrees — the no_provider bucket clears and the action lane is actable again.
+        status, payload = self._get("/app-status?campaign=other_chronicle")
+        self.assertEqual(status, 200)
+        self.assertTrue(payload["live"]["can_act"])
+        self.assertTrue(payload["live"]["is_live_view"])
+        self.assertEqual(payload["live"]["campaign_id"], "live_run")
+        self.assertNotEqual(payload["readiness"]["failure_bucket"], "no_provider")
+
+    def test_dead_sink_with_stale_snapshot_stays_read_only(self):
+        """GUARD: when the sink is genuinely dead (file removed/unwritable) AND the snapshot is
+        stale, it MUST stay read-only — the slow-beat heal must not fabricate can_act for a dead
+        provider. Complements test_no_move_sink_stays_read_only with the stale-snapshot case."""
+        os.environ.pop("WORLDOS_PLAYER_MOVES", None)
+        os.environ.pop("CLAWDND_PLAYER_MOVES", None)
+        self.assertFalse(server._live_play())
+        self._write("dead_run", _snap("Disconnected"), age_seconds=300)
+
+        status, surface = self._get("/session-surface?campaign=dead_run")
+        self.assertEqual(status, 200)
+        self.assertFalse(surface["live"], "no live sink → not live")
+        self.assertFalse(surface["can_act"], "dead provider stays honestly read-only")
+
+        status, payload = self._get("/app-status?campaign=dead_run")
+        self.assertFalse(payload["live"]["can_act"],
+                         "a genuinely dead sink must report can_act=False")
+        # The dead sink is honestly NOT ready (degraded). We don't pin the exact bucket here —
+        # in the bare test harness `no_art` (missing private art root) can pre-empt `no_provider`
+        # in the readiness ladder; either way the run is degraded, never falsely ready.
+        self.assertNotEqual(payload["readiness"]["failure_bucket"], "none",
+                            "a genuinely dead sink must stay degraded, never ready")
+        self.assertFalse(payload["readiness"]["ready_for_play"])
+
+    # -- the /move POST gate is the real write authority for a client retry ----
+    def test_move_accepts_untagged_retry_while_sink_live(self):
+        """The /move gate (server.py:7035-7062) accepts an UNTAGGED move whenever the sink is
+        writable — it never gates on is_live_view. This is what lets a STUCK-turn client retry
+        recover: the frozen action bar is a CLIENT gate only; the server would take the re-POST."""
+        self._enable_move_sink()
+        self._write("live_run", _snap("Embergloom"), age_seconds=300)
+        server._Handler.campaign_id = "live_run"
+
+        # An untagged say-move (no `campaign` field): the gate never consults is_live_view, so a
+        # stuck-turn client retry lands as long as the sink is writable.
+        status, body = self._post("/move", {"kind": "say", "text": "I press on."})
+        self.assertEqual(status, 200)
+        self.assertTrue(body.get("ok"), f"untagged retry must be accepted: {body}")
+
+    def test_move_refuses_when_sink_dead(self):
+        """The honest-dead-provider path: with no sink, /move refuses — so the client must NOT
+        promise a working retry; it surfaces 'Resume from Chronicles' instead of a silent freeze."""
+        os.environ.pop("WORLDOS_PLAYER_MOVES", None)
+        os.environ.pop("CLAWDND_PLAYER_MOVES", None)
+        self.assertFalse(server._live_play())
+        server._Handler.campaign_id = "live_run"
+
+        status, body = self._post("/move", {"kind": "say", "text": "I press on."})
+        self.assertEqual(status, 200)
+        self.assertFalse(body.get("ok"), "a dead sink must refuse the move")
+        self.assertIn("read-only", str(body.get("reason", "")))
 
 
 if __name__ == "__main__":

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -806,17 +806,35 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         source = body.decode("utf-8")
         self.assertIn("const [appStatus, setAppStatus] = React.useState(null);", source)
         self.assertIn('fetch(`/app-status${query}`', source)
+        # LOCKOUT P0: the play gate is now one pure, unit-testable helper (`computePlayGate`) that the
+        # component calls — the readiness/bucket logic moved INTO it (see test_recovery_timing.py
+        # PlayGateLockoutTests for the behavioral coverage). The contract strings live there now.
+        self.assertIn("function computePlayGate(", source)
         self.assertIn("const appStatusBlocksPlay = Boolean", source)
         self.assertIn('"no_provider", "no_launcher", "move_rejected"', source)
-        self.assertIn("appReadiness.ready_for_play === false", source)
-        self.assertIn("Start or resume a provider-backed session from Chronicles", source)
+        self.assertIn("readiness.ready_for_play === false", source)
+        # LOCKOUT P0 (Layer B): the raw "provider-backed session" dev string that leaked verbatim to
+        # two sweep personas (a MAJOR) must NO LONGER appear in any player-facing JSX literal. It only
+        # survives now inside the jargon-detection regex (`/move sink|provider-backed|…/`) that KEEPS
+        # the raw server `failure_detail` from ever being shown — never as rendered copy. The behavioral
+        # guarantee is in test_recovery_timing.py::PlayGateLockoutTests; here we lock the literal out of
+        # the render path and confirm the humane replacement is present.
+        self.assertNotIn("Start or resume a provider-backed session from Chronicles", source)
+        self.assertNotIn("> Start or resume", source)
+        self.assertIn("/move sink|provider-backed", source)  # the jargon FILTER, not a rendered string
+        self.assertIn("Resume this chronicle from Chronicles", source)
         self.assertIn("data-worldos-status-scope=\"app-status\"", source)
         self.assertIn("const surfaceStatusBlocksPlay = surfaceStatus !== \"ready\"", source)
         self.assertIn("const livePlayBlocked = surfaceStatusBlocksPlay || appStatusBlocksPlay", source)
-        self.assertIn("livePlayBlocked ? livePlayBlockReason : readOnlyReason", source)
+        # LOCKOUT P0 (Layer C): a stuck turn re-opens the bar for a real retry through an app-status
+        # latch — the controls now branch on `stuckRetryUnblocked` so the recovery promise is real.
+        self.assertIn("stuckRetryUnblocked", source)
         self.assertIn("disabled={!a.available || pendingActive || livePlayBlocked}", source)
-        self.assertIn("disabled={pendingActive || livePlayBlocked}", source)
-        self.assertIn("const declareDisabled = !composerAction?.available || pendingActive || livePlayBlocked || declareNeedsDraft", source)
+        # LOCKOUT P0 (Layer C): the composer + Declare/Try-again re-open on a stuck turn so the player
+        # can actually retry — they branch on `stuckRetryUnblocked` rather than ANDing in
+        # `livePlayBlocked` unconditionally (the old hard-freeze that made the recovery message a lie).
+        self.assertIn("disabled={stuckRetryUnblocked ? false : (pendingActive || livePlayBlocked)}", source)
+        self.assertIn("const declareDisabled = stuckRetryUnblocked", source)
         self.assertIn('"Reconnect live session before declaring"', source)
         self.assertIn("disabled={declareDisabled}", source)
 
@@ -953,7 +971,12 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn("kind: composerMode.kind", source)
         self.assertIn("composerMode.placeholder", source)
         self.assertIn("const declareNeedsDraft = !pendingStuck && !draftText", source)
-        self.assertIn("const declareDisabled = !composerAction?.available || pendingActive || livePlayBlocked || declareNeedsDraft", source)
+        # LOCKOUT P0 (Layer C): on a stuck turn the Declare slot is "Try again" and must stay clickable
+        # through an app-status latch, so `declareDisabled` now branches on `stuckRetryUnblocked`; the
+        # full normal-path gate (composerAction.available || pendingActive || livePlayBlocked || …) is
+        # the else-branch.
+        self.assertIn("const declareDisabled = stuckRetryUnblocked", source)
+        self.assertIn("(!composerAction?.available || pendingActive || livePlayBlocked || declareNeedsDraft)", source)
         self.assertIn('title={declareTitle}', source)
         self.assertIn('ariaLabel={declareAriaLabel}', source)
         self.assertIn('!composerAction?.available', source)

--- a/viewer/tests/test_recovery_timing.py
+++ b/viewer/tests/test_recovery_timing.py
@@ -168,8 +168,10 @@ process.stdout.write(JSON.stringify(result));
 """
 
 
-@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + run the JSX hook")
-class RecoveryTimingTests(unittest.TestCase):
+class _BabelHarness(unittest.TestCase):
+    """Shared Node+Babel harness: transpiles the real .jsx and runs a JS `script` against `h`/`win`.
+    A NON-test base (no `test_*` methods) so subclasses don't re-run each other's cases."""
+
     NODE_BIN = shutil.which("node")
 
     @classmethod
@@ -193,6 +195,11 @@ class RecoveryTimingTests(unittest.TestCase):
         if proc.returncode != 0:
             self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
         return json.loads(proc.stdout)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + run the JSX hook")
+class RecoveryTimingTests(_BabelHarness):
+    pass
 
     # --- the timing CONTRACT: constants exported, correctly ordered -----------
     def test_constants_exported_and_ordered(self):
@@ -314,3 +321,78 @@ class RecoveryTimingTests(unittest.TestCase):
         self.assertTrue(out["survives"], "#648: a same-tick clear must NOT wipe the just-armed spinner")
         self.assertTrue(out["narrating"], "the protected turn stays in the narrating (not stuck) state")
         self.assertTrue(out["resolves_later"], "the protected turn still resolves on the real (post-grace) clear")
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + run the JSX gate")
+class PlayGateLockoutTests(_BabelHarness):
+    """LOCKOUT P0 (detach-locks-the-action-bar) — the CLIENT play-gate contract.
+
+    `computePlayGate` (screen-table.jsx, module scope) is the single source of truth for every
+    derived play-gate flag + the player-facing block message. These tests transpile the REAL .jsx
+    and exercise that pure function (mirrors the `recoveryWindowMs` tests above), pinning the three
+    contracts the sweep blocked on:
+      B) the raw "live provider move sink is not ready" dev string NEVER reaches the player;
+      C) a STUCK turn re-opens the bar for a real retry through an app-status latch
+         (`stuckRetryUnblocked`) — but NOT through a genuine surface outage; and
+      -) the no-block happy path stays unblocked.
+    """
+
+    _NO_PROVIDER_STATUS = (
+        "{ readiness: { ready_for_play: false, failure_bucket: 'no_provider',"
+        " failure_detail: 'live provider move sink is not ready' } }"
+    )
+
+    def _gate(self, surface_status: str, app_status_js: str, pending_stuck: str):
+        return self._run(
+            f"win.computePlayGate({{ surfaceStatus: {json.dumps(surface_status)},"
+            f" appStatus: {app_status_js}, pendingStuck: {pending_stuck} }})"
+        )
+
+    # B) the raw dev string never reaches the player ---------------------------
+    def test_raw_move_sink_string_never_leaks_to_block_reason(self):
+        gate = self._gate("ready", self._NO_PROVIDER_STATUS, "false")
+        self.assertTrue(gate["appStatusBlocksPlay"])
+        self.assertTrue(gate["livePlayBlocked"])
+        # The humane copy is shown; the raw "move sink"/"provider-backed" jargon is gone.
+        self.assertNotIn("move sink", gate["blockReason"].lower())
+        self.assertNotIn("provider-backed", gate["blockReason"].lower())
+        self.assertIn("Chronicles", gate["blockReason"])
+        self.assertIn("Dungeon Master", gate["blockReason"])
+
+    def test_block_reason_maps_each_bucket_to_human_copy(self):
+        for bucket in ("no_provider", "no_launcher", "move_rejected"):
+            app = (
+                "{ readiness: { ready_for_play: false, failure_bucket: '" + bucket + "',"
+                " failure_detail: 'live provider move sink is not ready' } }"
+            )
+            gate = self._gate("ready", app, "false")
+            self.assertNotIn("move sink", gate["blockReason"].lower(), bucket)
+            self.assertIn("Chronicles", gate["blockReason"], bucket)
+
+    # C) a stuck turn re-opens the bar for a real retry through the app-status latch ----
+    def test_stuck_turn_unblocks_retry_through_app_status_latch(self):
+        # The lockout: app-status latched no_provider, the surface is fine, the turn is stuck.
+        gate = self._gate("ready", self._NO_PROVIDER_STATUS, "true")
+        self.assertTrue(gate["livePlayBlocked"], "the app-status latch still blocks normal play")
+        self.assertTrue(gate["stuckRetryUnblocked"],
+                        "a stuck turn MUST re-open the bar for a retry despite the app-status latch")
+
+    def test_stuck_turn_does_not_unblock_on_surface_outage(self):
+        # A genuine surface outage (the fetch failed/loading) → nothing to act on; stay frozen.
+        gate = self._gate("unavailable", "null", "true")
+        self.assertTrue(gate["surfaceStatusBlocksPlay"])
+        self.assertFalse(gate["stuckRetryUnblocked"],
+                         "a genuine surface outage must NOT be bypassed even on a stuck turn")
+
+    def test_not_stuck_turn_stays_blocked_under_latch(self):
+        # Not stuck + app-status latch → the bar stays blocked (no spurious unblock).
+        gate = self._gate("ready", self._NO_PROVIDER_STATUS, "false")
+        self.assertFalse(gate["stuckRetryUnblocked"])
+
+    # happy path ---------------------------------------------------------------
+    def test_ready_surface_and_status_is_unblocked(self):
+        ready = "{ readiness: { ready_for_play: true, failure_bucket: 'none', failure_detail: '' } }"
+        gate = self._gate("ready", ready, "false")
+        self.assertFalse(gate["surfaceStatusBlocksPlay"])
+        self.assertFalse(gate["appStatusBlocksPlay"])
+        self.assertFalse(gate["livePlayBlocked"])


### PR DESCRIPTION
## The release-blocking P0

The `dc0d625` re-baseline sweep hit a **deterministic** lockout on **2 of 5 personas** (adversarial + narrative), filed P0:

- **adversarial:** multi-step navigation away from the table while the DM is narrating silently killed the live provider connection; the DM timed out; all action controls locked to "viewing non-live campaign" with **no in-UI recovery path**. The Declare button stayed disabled ('Try again' label but unclickable); typing + Enter did nothing. A/B: 1 nav-hop survived, 5 hops broke it.
- **narrative:** "DM timed out; UI says 'No reply came back in time. Your input is open again — try your action once more' but every action button AND the text box AND 'Try again' are ALL still disabled. **The recovery message is a LIE.**" (The DM had actually responded.)
- Both saw the raw dev string **"live provider move sink is not ready — Start or resume a provider-backed session from Chronicles before sending moves"** leak verbatim to the player (a **MAJOR**).

## Confirmed mechanism (repro pinned a failing assertion BEFORE any prod change)

`_list_campaigns` derives each campaign's `live` flag **purely from snapshot/session recency** — `(now - recency) < 90` (`viewer/server.py:1007`), with **no `move_sink_live` term**. On a long quiet DM beat — or after the player nav-hops away while the DM narrates — the live run's snapshot/session mtimes age past 90s, so its recency-`live` flips False. That **empties** the #665 heal's `live_current` guard (`_live_play_view_campaign`, server.py:6401-6404), so the self-heal no-ops, `is_live_view` latches False, and the whole client action bar — which ANDs in `livePlayBlocked` on every control — freezes.

Crucially, the **/move POST gate** (`server.py:7035-7062`) **never consults `is_live_view`**: it accepts an untagged or live-tagged move whenever the sink is writable. So the lockout was a **client gate only** — a retry was always recoverable server-side. (The prior analysis claim that the dead-sink path must stay read-only was confirmed and preserved.)

The single-campaign stale case already passed (the `override == attached` early-return); the **two-campaign** stale case (the newbie navigating to "the other Live chronicle") is the one that fell through to the empty `live_current` guard and broke — that's the test that was red before the fix.

## The fix (3 layers, only what the repro proved necessary)

**A) SERVER liveness** — `viewer/server.py` `_live_play_view_campaign`: the heal's `live_current` now treats the **attached** campaign as live by construction (we are already inside the `_live_play()` branch, so the sink is genuinely alive AND feeds exactly `attached`), while keeping the recency signal for OTHER campaigns so we never auto-snap away from a genuinely-active parallel run. The genuinely-dead-provider read-only path is untouched.

**B) CLIENT copy** — `screen-table.jsx`: the raw dev string is removed from every player-facing literal and the degraded banner. The new pure `computePlayGate` maps the readiness **bucket** to humane, story-adjacent copy ("The Dungeon Master has stepped away. Resume this chronicle from Chronicles to bring them back."), and only falls back to the raw server detail when it is a clearly-human sentence (a jargon regex blocks `move sink`/`provider-backed`/`app-status`/etc.).

**C) CLIENT recovery** — `screen-table.jsx`: a STUCK turn (`pending.stuck`) now re-opens the composer + Declare/'Try again' through an app-status latch (`stuckRetryUnblocked`) and lets `postMove` **probe the server /move gate** (the real write authority): a live sink takes the retry and the next poll recovers; a dead sink refuses and the honest reason surfaces. A genuine surface outage (`surfaceStatusBlocksPlay`) still blocks. The play-gate logic is extracted into one pure, unit-testable `computePlayGate` (mirrors `app.jsx`'s `recoveryWindowMs`).
- `app.jsx` auto-follow: the old `!nativeState.appStatus.runningProvider` gate early-returned in a plain browser (`scripts/play.sh` — the exact sweep env), so the client never re-followed the live run after a nav-hop. It now also follows an in-browser `current && live` catalog row (the catalog `live` flag already folds in `move_sink_live`).

## Tests (focused, run locally — green)

```
python3 -m pytest viewer/tests/test_live_view_recovery.py viewer/tests/test_recovery_timing.py -q
=> 25 passed
```
plus a broad viewer sweep (`test_session_surface`, `test_readmodel_surfaces`, `test_openworlds_static`, `test_move_intents`, `test_action_model`, `test_seed_surface`, `test_combat_surface`, `test_atlas_surface`, …) — **207 passed**.

New permanent guards:
- `test_live_view_recovery.py`: stale-snapshot single + **two-campaign** repro; `/move` untagged-retry-accepted + dead-sink-refused (the gate authority); dead-sink-stays-read-only. `test_no_move_sink_stays_read_only` still passes (no regression).
- `test_recovery_timing.py` `PlayGateLockoutTests`: `computePlayGate` maps every bucket to humane copy (no raw string leak); `stuckRetryUnblocked` re-opens through an app-status latch but **not** a surface outage; happy path unblocked.
- `test_openworlds_static.py`: updated the action-bar source contract for the refactor; now asserts the raw dev string is **gone**.

## Deliberately NOT touched

The engine (sole writer); the `/move` cross-campaign refusal; the #348 recovery-window timing; the pinned-director read-only gate; the genuinely-dead-provider read-only behavior.

## Top risk a reviewer must check

**Layer A's broadened `live_current`** — it now always includes `attached` when the sink is live (since `current` is only ever set for `attached`, the `(c.id == attached or c.live)` term is what unlatches the heal). Confirm this never **mis-follows into a parallel/stale store**: it only ever resolves to `attached` (the recency-picked single current run the sink feeds), and the `/move` cross-campaign refusal remains the write-side backstop. The pinned-director and dead-sink guards in `test_live_view_recovery.py` lock the two ways this could over-reach.