### PR TITLE
docs(qa): RRI evidence-path contract + lean-ON-is-broken learnings

### DIFF
--- a/.claude/skills/worldos-dev/SKILL.md
+++ b/.claude/skills/worldos-dev/SKILL.md
@@ -63,6 +63,35 @@ handoff.json) at the **SAME SHA**; `qa/release_readiness.py --handoff-json <mac.
 combines them. Mixed-SHA / missing `run.json`/`score.json`/`network.ndjson` ⇒ `partial`/`harness_contaminated`
 (never a clean release). Copy VM `results/` back under `/Volumes/LEXAR/Codex/...` for the rollup + ledger.
 
+### RRI evidence-path contract (don't false-mask the gate)
+**`release_readiness.py` requires EVIDENCE-PATH flags, not just value flags** — a gate that has the
+*value* but not a *path that EXISTS* is an `evidence_gap`, which RED-caps the gate and **understates the
+RRI**. A VM part-B-only sweep that passes only value flags reads a FALSE-LOW number (real 2026-06-05: an
+honest **~4.5/11** masked as **1.8/11**). Each gate needs BOTH halves (see `release_readiness.py` ~709–731):
+- **behavioral:** `--behavioral GREEN` **AND** `--behavioral-path <file-that-exists>`.
+- **ui_audit:** `--ui-audit PASS` **AND** `--ui-audit-log <file-that-exists>`.
+- **palette_live:** `--palette-live true` **AND** `--palette-source <file-or-label>` (a label is fine;
+  only a path-looking value is existence-checked).
+- **native_gate:** needs `--handoff-json <mac-handoff>` (the Mac Part-A) — **structurally absent on a
+  VM-only sweep**, so that gate is *expected* to be a gap until the Mac part-A rolls in at the same SHA.
+  Don't read its absence as a regression; read it as "Part-A not yet joined."
+
+**The other half of the same bug — behavioral read the WRONG path → false RED.** The sweep computed
+behavioral from `$DCOMB=qa/transcripts/vm2-duo.combined.jsonl`, which doesn't exist (empty ⇒ defaulted
+RED) — even though `run_duo.sh` runs `assert_behavioral.py` itself and **prints `behavioral=GREEN` in its
+own log**. **Fix (in `qa/vm/sweep_v2.sh`): read behavioral from the duo-log verdict, and pass the three
+evidence-path flags:**
+```bash
+behav=RED; grep -q 'behavioral=GREEN' "$RES/duo.log" && behav=GREEN   # NOT the nonexistent combined.jsonl
+python3 qa/release_readiness.py --runs … --story … --mech … \
+  --behavioral $behav     --behavioral-path "$RES/duo.log" \
+  --ui-audit  $audit      --ui-audit-log    "$RES/ui_audit.log" \
+  --palette-live true     --palette-source  "$RES/ui_audit.log" \
+  --build-sha "$SHA" --out "$RES/RRI.json" --scorecard-row
+```
+That single change took the VM sweep's RRI from **1.8 → 4.5** with no behavior/score change — it was
+pure harness-evidence plumbing. The corrected reference harness is checked in at `qa/vm/sweep_v2.sh`.
+
 ## Load-bearing INVARIANTS (never violate)
 1. **Engine = SOLE WRITER.** State is `snapshot.json` written under `campaign_lock` via
    atomic temp-file + `os.replace` (`servers/engine/store.py`). The player facade

--- a/.claude/skills/worldos-latency-forensics/SKILL.md
+++ b/.claude/skills/worldos-latency-forensics/SKILL.md
@@ -41,7 +41,9 @@ between tool calls" read — same conclusion, correct metric.)
   wall-clock but stops give-ups on the wait.
 - **Compact `scene_context` digest** — re-ground each beat from a small digest (durable threads +
   recent-narration tail) off the snapshot+session-log, NOT the ~690K transcript (~10–27× context drop;
-  lossless because the engine's FTS5 retrieves on demand).
+  lossless because the engine's FTS5 retrieves on demand). **⚠ NOT to be confused with LEAN-ON** —
+  the `CLAWDND_LEAN_BEATS` lean path that *replaces* the transcript with a scene_context re-ground is
+  BROKEN today (cross-chronicle contamination + dropped beats); see REFUTED below.
 - **Prose-trim** — cap narration length.
 
 **TRADING (quality cost — the OWNER's call, A/B first):**
@@ -52,6 +54,20 @@ between tool calls" read — same conclusion, correct metric.)
   speed) is an open owner decision — see `docs/MODEL-TIERING-STRATEGY.md`; do not assume it.
 
 ## REFUTED — do NOT re-chase
+- **lean-ON (`CLAWDND_LEAN_BEATS`) is BROKEN — do NOT enable it as a latency lever** (contradicts the
+  "lean is neutral" assumption above; the assumption was wrong). A/B on the **same build** with the ONLY
+  variable = `CLAWDND_LEAN_BEATS` (2026-06-05): lean-ON **regressed** — it introduced TWO new criticals
+  that the clean lean-OFF run did NOT have:
+  - **Cross-chronicle contamination** (100% reproducible): every DM beat appended a *different* save's
+    opening scene (e.g. Basilisk Gate with the wrong HP/day) — the lean continuing-beat re-grounds from
+    `scene_context` and pulls **wrong / parallel-campaign** content.
+  - **Dropped beats**: the spinner cleared and time advanced but **ZERO narration text** came back.
+
+  Same root as **#640** (multi-campaign divergence): `scripts/play_party.sh` mints a campaign per launch
+  with only a ~30-min reuse guard (L201), so the lean re-ground can latch onto a parallel campaign.
+  **lean stays OFF until the #640 re-ground root is fixed.** Address the 3–5 min latency via the
+  **effort / streaming / `scene_context`-digest** levers (above) — **NOT** lean. (The corrected VM
+  `qa/vm/sweep_v2.sh` runs with lean intentionally OFF and says so in its header.)
 - **A small/Haiku "research-packet" helper to prefetch for the DM** — touches ≤5% of the beat
   (generation-bound). Refuted.
 - **A headless `--fast` flag** — doesn't exist; use `--effort`.

--- a/docs/qa/FAST_GATE.md
+++ b/docs/qa/FAST_GATE.md
@@ -82,6 +82,14 @@ compute the **correlation** between the fast-gate verdict and the full-RRI verdi
 "~80% signal" is *measured*, not asserted. Never write `pass=1` to `scores.db` from a fast run, and
 label every fast verdict **"INNER-LOOP — not a release verdict."**
 
+> **⚠ Tier-2 RRI evidence-path contract — don't false-mask the number.** When you roll the sweep up to
+> an RRI, `qa/release_readiness.py` requires *evidence-path* flags, not just value flags: each of
+> behavioral / ui_audit / palette_live needs BOTH the value AND a path that EXISTS (and `native_gate`
+> needs the Mac `--handoff-json`), or the gate is RED-capped as an `evidence_gap` and the RRI reads
+> **falsely low** (a real ~4.5/11 once masked as 1.8/11). The exact flag list + the behavioral-from-duo-log
+> fix live in the `worldos-dev` skill (§ "RRI evidence-path contract"); the corrected VM harness is
+> `qa/vm/sweep_v2.sh`.
+
 ---
 
 ## What the fast loop intentionally DEFERS to the milestone sweep (the honest ~20%)

--- a/qa/vm/sweep_v2.sh
+++ b/qa/vm/sweep_v2.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# REFERENCE COPY - the support-VM heavy gate-sweep harness (part-B 5-persona).
+#
+# This is a checked-in snapshot of the script that lives on the evaos-support VM
+# at /root/worldos-qa/sweep_v2.sh (the canonical runnable copy). It runs the heavy
+# 5-persona OpenWorlds-browser sweep + duo + ui_audit and rolls up an RRI via
+# qa/release_readiness.py. Paths/ports below are VM-internal (/root/worldos-qa/...)
+# and are intentionally left as-is for reference; this copy is NOT meant to run on
+# the Mac. See the `worldos-dev` skill (sec. "VM GATE SWEEP" and sec. "RRI evidence-path
+# contract") and WorldOS-GUI-RUNBOOK.md sec. "Support VM lane".
+#
+# TWO load-bearing things this version gets right (cost a real diagnosis):
+#   1. RRI evidence-path contract - it passes the *evidence-path* flags
+#      (--behavioral-path / --ui-audit-log / --palette-source), not just value
+#      flags. Without them release_readiness.py records an `evidence_gap` and
+#      RED-caps the gate -> the RRI reads FALSELY LOW (a real ~4.5/11 once masked
+#      as 1.8/11). native_gate's --handoff-json is the Mac Part-A and is
+#      *structurally absent* on a VM-only sweep (joined at the same SHA later).
+#   2. behavioral-from-duo-log - it reads `behavioral=GREEN` from run_duo.sh's own
+#      log (run_duo runs assert_behavioral.py itself), NOT the nonexistent
+#      qa/transcripts/vm2-duo.combined.jsonl, which defaulted RED. These two fixes
+#      took the sweep's RRI from 1.8 -> 4.5 with no behavior/score change.
+#
+# LEAN IS INTENTIONALLY OFF. Do not enable CLAWDND_LEAN_BEATS here: lean-ON
+# re-grounds the continuing beat from scene_context and CONTAMINATES the chronicle
+# (pulls a parallel save's content) + drops beats (proven 2026-06-05 A/B; same
+# root as #640). Address the 3-5 min latency via effort / streaming, NOT lean.
+# See the `worldos-latency-forensics` skill (sec. REFUTED).
+# -----------------------------------------------------------------------------
+# v2 VM gate sweep: canary-first, then PARALLEL personas (the 30GB/16vCPU advantage).
+# lean stays OFF: the lean-ON re-ground from scene_context CONTAMINATES the chronicle (pulls a parallel saves content) + drops beats (proven 2026-06-05 A/B). Address latency via effort/streaming, NOT lean.
+# no set -e (one persona failing must not abort the batch). Explicit PATH + IS_SANDBOX.
+export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.local/bin:$PATH
+export IS_SANDBOX=1
+cd /root/worldos-qa/WorldOS || { echo "NO REPO"; exit 1; }
+RES=/root/worldos-qa/results; mkdir -p "$RES"
+SHA="$(git rev-parse --short HEAD)"; LOG="$RES/sweep2.log"; : > "$LOG"
+note(){ echo "[$(date +%H:%M:%S)] $*" | tee -a "$LOG"; }
+rm -f "$RES/DONE" "$RES/CANARY_FAIL" 2>/dev/null
+
+# 0) kill the stuck v1 orchestrator + any stray vm- play procs; free ports
+note "killing v1 orchestrator + stray procs..."
+pkill -f gate_sweep.sh 2>/dev/null
+pkill -f 'lean_beats_check' 2>/dev/null
+pkill -f 'play.sh baldurs-gate vm-' 2>/dev/null; pkill -f 'play_party.sh baldurs-gate vm-' 2>/dev/null
+pkill -f 'play.sh baldurs-gate leanchk' 2>/dev/null
+for p in $(seq 8810 8830) 8884 8885; do lsof -ti:$p 2>/dev/null | xargs kill -9 2>/dev/null; done
+sleep 4
+note "start build=$SHA (parallel mode, lean OFF for the sweep - direct G3 measure)"
+
+run_persona(){  # $1=persona $2=port  -> writes results/score-$1.json
+  local persona="$1" port="$2"
+  WOS_APP_PART=B WOS_APP_SKIP_BUILD=1 WOS_APP_PREFERRED_PORT=$port \
+    timeout 1500 bash qa/ui_playtest_app.sh "vm2-$persona" baldurs-gate "$persona" 40 12.00 \
+    > "$RES/vm2-$persona.log" 2>&1
+  local rc=$?
+  lsof -ti:$port 2>/dev/null | xargs kill -9 2>/dev/null
+  pkill -f "play.sh baldurs-gate vm2-$persona" 2>/dev/null
+  pkill -f "play_party.sh baldurs-gate vm2-$persona" 2>/dev/null
+  local sc="qa/ui_playtest_runs/vm2-$persona/score.json"
+  if [ -f "$sc" ]; then
+    cp "$sc" "$RES/score-$persona.json"
+    note "  $persona rc=$rc $(python3 -c "import json;d=json.load(open('$sc'));print('sat=%s gaveup=%s crit=%s arc=%s turns=%s'%(d.get('persona_satisfaction'),d.get('gave_up'),d.get('bug_reports_critical'),d.get('completed_intro_flow'),d.get('in_story_turns')))" 2>/dev/null)"
+  else
+    note "  $persona rc=$rc - NO SCORE (see vm2-$persona.log)"
+  fi
+}
+
+# 1) CANARY: newbie alone. Verify scoring works before spending on the batch.
+note "CANARY: newbie (verifying part-B produces a score on the VM)..."
+run_persona newbie 8810
+if [ ! -f "$RES/score-newbie.json" ]; then
+  note "CANARY FAILED - no score-newbie.json. Aborting batch; see vm2-newbie.log for the cause."
+  note "  --- vm2-newbie.log tail ---"; tail -25 "$RES/vm2-newbie.log" >> "$LOG" 2>/dev/null
+  touch "$RES/CANARY_FAIL"; touch "$RES/DONE"; exit 0
+fi
+note "CANARY OK - scoring works. Launching the other 4 personas IN PARALLEL (staggered 30s)..."
+
+# 2) Parallel batch: veteran/adversarial/narrative/optimizer, staggered starts
+i=0
+for pp in "veteran 8812" "adversarial 8814" "narrative 8816" "optimizer 8818"; do
+  set -- $pp
+  run_persona "$1" "$2" &
+  i=$((i+1)); sleep 30
+done
+wait
+note "all 5 personas done."
+
+# 3) duo (story/mech) + behavioral + audit - run after personas (sequential, cheap-ish)
+note "3-lens duo..."
+timeout 2700 bash qa/run_duo.sh vm2-duo baldurs-gate veteran 8 2.00 > "$RES/duo.log" 2>&1
+for f in tolkien angrydm; do s="qa/transcripts/vm2-duo.$f.json"; [ -f "$s" ] && cp "$s" "$RES/duo-$f.json" && note "  $f overall=$(python3 -c "import json;print(json.load(open('$s')).get('overall'))" 2>/dev/null)"; done
+DCOMB="qa/transcripts/vm2-duo.combined.jsonl"; DSTATE="qa/transcripts/vm2-duo.state.json"
+[ -f "$DCOMB" ] && { python3 qa/assert_behavioral.py "$DCOMB" "$DSTATE" > "$RES/behavioral.log" 2>&1; echo "rc=$?" >> "$RES/behavioral.log"; note "behavioral rc=$(tail -1 "$RES/behavioral.log")"; }
+aport=8861; lsof -ti:$aport 2>/dev/null | xargs kill -9 2>/dev/null
+( WORLDOS_STATE_DIR=/root/worldos-qa/auditstate python3 viewer/server.py '' $aport >/dev/null 2>&1 & echo $! >"$RES/av.pid" )
+sleep 6
+timeout 600 bash qa/ui_audit_health.sh --port $aport --quick --axe --ui-gate > "$RES/ui_audit.log" 2>&1
+note "ui_audit rc=$?"; [ -f "$RES/av.pid" ] && kill "$(cat "$RES/av.pid")" 2>/dev/null
+
+# 4) RRI
+behav=RED; grep -q 'behavioral=GREEN' "$RES/duo.log" 2>/dev/null && behav=GREEN   # run_duo.sh runs assert_behavioral itself + prints the verdict; the old $DCOMB path was wrong -> false RED in the RRI
+audit=FAIL; grep -qiE 'all checks pass|0 regress|PASS' "$RES/ui_audit.log" 2>/dev/null && audit=PASS
+python3 qa/release_readiness.py \
+  --runs $(ls -d qa/ui_playtest_runs/vm2-* 2>/dev/null | grep -v duo | paste -sd, -) \
+  --story "$RES/duo-tolkien.json" --mech "$RES/duo-angrydm.json" \
+  --behavioral $behav --behavioral-path "$RES/duo.log" \
+  --ui-audit $audit --ui-audit-log "$RES/ui_audit.log" \
+  --palette-live true --palette-source "$RES/ui_audit.log" \
+  --build-sha "$SHA" \
+  --out "$RES/RRI.json" --scorecard-row > "$RES/rri.txt" 2>&1
+note "=== RRI ==="; cat "$RES/rri.txt" | tee -a "$LOG"
+note "=== SWEEP COMPLETE -> $RES ==="
+touch "$RES/DONE"
+
+touch /root/worldos-qa/results/DONE


### PR DESCRIPTION
Documents two hard-won QA learnings so they can't be re-learned the hard way. **Additive docs only — no behavior change** (the script in `qa/vm/sweep_v2.sh` is a checked-in *reference* of the already-corrected support-VM harness; it is not wired into any CI/Mac path).

## Learning 1 — the RRI was falsely masking (a harness-evidence plumbing bug)
A VM part-B-only 5-persona sweep read a false **1.8/11** when the honest number was **~4.5/11**. Root cause is `qa/release_readiness.py` (~709–731): it requires **evidence-PATH** flags, not just value flags. Each gate needs BOTH the value AND a path that EXISTS:
- `--behavioral GREEN` **AND** `--behavioral-path <file>`
- `--ui-audit PASS` **AND** `--ui-audit-log <file>`
- `--palette-live true` **AND** `--palette-source <file-or-label>`
- `native_gate` needs `--handoff-json <mac-handoff>` (the Mac Part-A) — structurally absent on a VM-only sweep, so it's an *expected* gap until Part-A joins at the same SHA, not a regression.

Additionally the VM sweep read behavioral from a **wrong/nonexistent** path (`qa/transcripts/vm2-duo.combined.jsonl`) → empty → defaulted RED, even though `run_duo.sh` runs `assert_behavioral.py` itself and prints `behavioral=GREEN` in its own log. Fix: read behavioral from the duo-log verdict and pass the three evidence-path flags. Result: **RRI 1.8 → 4.5**, no score change.

Documented in:
- `.claude/skills/worldos-dev/SKILL.md` — new "RRI evidence-path contract (don't false-mask the gate)" subsection near the VM GATE SWEEP / RRI rollup.
- `docs/qa/FAST_GATE.md` — cross-reference note in the Tier-2 section.
- `qa/vm/sweep_v2.sh` — checked-in reference of the corrected support-VM harness (VM-internal paths/ports kept as-is; header notes the two fixes + lean OFF).

## Learning 2 — lean-ON is BROKEN (do NOT re-chase it as a latency lever)
Contradicts the latency-forensics skill's prior "lean is neutral" assumption. Same-build A/B (only variable = `CLAWDND_LEAN_BEATS`, 2026-06-05): lean-ON **regressed** — it introduced TWO new criticals the clean lean-OFF run did NOT have:
1. **Cross-chronicle contamination** (100% reproducible) — every DM beat appended a *different* save's opening scene (wrong HP/day); the lean continuing-beat re-grounds from `scene_context` and pulls wrong/parallel-campaign content.
2. **Dropped beats** — spinner cleared and time advanced, but ZERO narration text.

Same root as **#640** (multi-campaign divergence; `scripts/play_party.sh` mints a campaign per launch with only a ~30-min reuse guard at L201). **lean stays OFF** until the #640 re-ground root is fixed; address the 3–5 min latency via effort / streaming / `scene_context`-digest levers, NOT lean.

Documented in:
- `.claude/skills/worldos-latency-forensics/SKILL.md` — REFUTED entry + a "not the same as the scene_context-digest neutral lever" caveat.

No secrets. No engine/runtime behavior touched.