### PR TITLE
fix(#674-nit): render the bestiary public-reference action mechanics

### DIFF
--- a/viewer/openworlds/screen-bestiary.jsx
+++ b/viewer/openworlds/screen-bestiary.jsx
@@ -103,6 +103,15 @@ function liveBestiaryEntry(item) {
     stats: (item?.abilities && typeof item.abilities === "object") ? item.abilities : undefined,
     tactics: item?.tactics ? String(item.tactics) : "",
     knownActions: Array.isArray(item?.known_actions) ? item.known_actions.filter((a) => String(a).trim()) : [],
+    // #674: the structured reference actions — name + desc carrying the to-hit/damage MECHANICS (e.g.
+    // "Scimitar. Melee Attack Roll: +4 … 5 (1d6+2) Slashing damage."). The 'Browse all' public reference
+    // projection (bestiary.public_reference_projection) supplies these; the theorycrafter optimizer needs
+    // the mechanics, not just the names in knownActions. Hidden when none.
+    actions: Array.isArray(item?.actions)
+      ? item.actions
+          .filter((a) => a && (String(a.name || "").trim() || String(a.desc || "").trim()))
+          .map((a) => ({ name: String(a.name || "").trim(), desc: String(a.desc || "").trim() }))
+      : [],
     // #depth: tier-3 (slain) defenses — the most tactically load-bearing facts (the engine now
     // passes these through intel_projection). Each row hidden when blank.
     resistances: Array.isArray(item?.damage_resistances) ? item.damage_resistances.filter((x) => String(x).trim()) : [],
@@ -409,6 +418,21 @@ function BestiaryEntry({ entry, tab }) {
               <div className="tag-row" style={{ marginTop: 6 }}>
                 {entry.knownActions.map((a) => <Pill key={a}>{a}</Pill>)}
               </div>
+            </>
+          )}
+
+          {/* #674: full Actions — name + the to-hit/damage mechanics (desc) from the 'Browse all' public
+              reference projection, for the theorycrafter who needs the numbers, not just names. Hidden when none. */}
+          {Array.isArray(entry.actions) && entry.actions.length > 0 && (
+            <>
+              <Divider />
+              <SectionTitle>Actions</SectionTitle>
+              {entry.actions.map((a, i) => (
+                <div key={`act-${i}-${a.name}`} style={{ marginTop: 6 }}>
+                  {a.name && <span className="eyebrow" style={{ marginRight: 6 }}>{a.name}</span>}
+                  {a.desc && <span style={{ fontSize: 13, opacity: 0.9 }}>{a.desc}</span>}
+                </div>
+              ))}
             </>
           )}
 

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -239,6 +239,19 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn('.catch((e) => toast({ kind: "danger"', source)
         self.assertIn('title: "Move not sent"', source)
 
+    def test_bestiary_renders_reference_action_mechanics(self):
+        # #674: the 'Browse all' public reference projection (bestiary.public_reference_projection) ships
+        # a structured actions[] (name + desc carrying the to-hit/damage MECHANICS, e.g. "Scimitar … +4 …
+        # 1d6+2"). The theorycrafter optimizer needs the numbers, not just the names in knownActions — and
+        # the projection data was previously shipped but the screen never rendered it. Guard the wire-up.
+        status, ctype, body = self._get("/openworlds/screen-bestiary.jsx")
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        self.assertIn("item?.actions", source)                         # entry builder maps the structured actions
+        self.assertIn("<SectionTitle>Actions</SectionTitle>", source)  # the render section exists
+        self.assertIn("entry.actions.map", source)                     # each action's name + desc (mechanics) rendered
+
     def test_journal_detail_matches_selected_tab_not_first_rumor(self):
         status, ctype, body = self._get("/openworlds/screen-journal.jsx")
 


### PR DESCRIPTION
The merged #674 public_reference_projection ships a structured actions[] (name + desc
carrying the to-hit/damage mechanics, e.g. 'Scimitar … +4 … 1d6+2'), but screen-bestiary.jsx
rendered only known_actions (names). The theorycrafter optimizer (sweep sat 3→5 from the
core #674 fix) needs the numbers — so wire the structured actions into the Codex 'Browse all'
stat block: map item.actions in the entry builder + render an Actions section (name + desc),
mirroring the existing Known-abilities / Defenses sections. Guard: test_openworlds_static
asserts the screen reads item.actions + renders the Actions section. Closes the #674 nit.
