### PR TITLE
feat(dm): default the DM model to Opus (owner decision — story 3.6→4.0)

### DIFF
--- a/docs/MODEL-TIERING-STRATEGY.md
+++ b/docs/MODEL-TIERING-STRATEGY.md
@@ -1,8 +1,8 @@
 # WorldOS Model & Effort Strategy
 
-Status: **MEASURED (2026-06-02)** for the latency/effort mechanics; the **model choice itself remains an
-open owner decision** (see below). Supersedes the 2026-05-31 "proposal/to-test" whiteboard. Companion:
-the `worldos-latency-forensics` skill (the measurement method + full lever taxonomy).
+Status: **DECIDED (2026-06-06): the DM runs Opus** (owner's call, below) — flipped the default sonnet→opus
+across production + gate + QA; latency mitigation in progress. The latency/effort mechanics were **MEASURED
+(2026-06-02)**. Companion: the `worldos-latency-forensics` skill (the measurement method + full lever taxonomy).
 
 ## What was measured (not recollection)
 - **The DM is generation-bound.** Per-beat `claude -p` time is ~90–100% `duration_api_ms` (model thinking +
@@ -25,11 +25,24 @@ the `worldos-latency-forensics` skill (the measurement method + full lever taxon
    digest (durable threads + recent-narration tail) off the snapshot+session-log, NOT the ~690K transcript.
 4. **`alwaysLoad` the engine MCP tools** (un-defer) — neutral latency win on the cold-open, cache-stable.
 
-## The OPEN decision (owner's call — do not assume)
-**Which model the DM runs is not settled.** The measured trade: **Opus = higher story (4.4–4.5)**;
-**Sonnet = faster + cheaper + already the default** and its story (4.2) is near the 4.3 bar. Pick ONE and
-hold it for the campaign; expose it as `WORLDOS_DM_MODEL` (option, not a hardcode). Do NOT unilaterally flip
-the default to Opus — that would create a config mismatch the codebase doesn't currently have.
+## The DECISION (made 2026-06-06 by the owner — Opus)
+**The DM runs Opus.** A fresh same-build A/B (lean-OFF craft duo, veteran, current scorer) confirmed the lift:
+**story-craft 3.6 → 4.0** with EVERY weak dimension lifted 3→4 (scene_craft / character_depth /
+dramatic_momentum / thematic_resonance), and the duo mech (angry-dm) 3.4 → 3.9 — same direction as the prior
+4.2→4.4 read. The dungeon-master prompts were already MAXIMAL (the NPC-speak-back non-negotiable + the per-beat
+gate), so **Sonnet was the ceiling, not the prompt.** Owner decision: **"Full Opus + attack latency"** — flip
+the default to Opus everywhere (production `play.sh` / `play_party.sh`, the gate `ui_playtest_app.sh`, the QA
+duos/sprints), keep the **player facade on Sonnet** (near-free no-tool agent), and **mitigate latency rather
+than trade the model**. Cheap iteration can still opt out via `WORLDOS_DM_MODEL=sonnet`.
+
+**Latency mitigation** (Opus = slower beats; the narrative already failed the latency gate at Sonnet):
+(1) `alwaysLoad` the engine tools — ON. (2) **streaming** — the live-progress rule + `log_event` narration-first
+make the scene appear *as it composes* (a slow Opus beat is *felt-OK* if the prose streams). (3) the **#679
+recovery** — a stuck beat no longer bricks the bar. (4) **THE KEY ENABLER: fix the #640 lean re-ground root**
+so lean-ON is safe again (it currently CONTAMINATES — see latency-forensics "lean is broken"), restoring
+invariant #3's compact `scene_context` re-ground = fast Opus beats instead of the full-transcript replay
+lean-OFF forces. Until #640 lands, Opus runs lean-OFF (correct but slow); the re-measure gate is a same-SHA
+Opus sweep confirming story ≥4.3 AND no latency give-up.
 
 ## REFUTED — do not re-chase
 - **A Haiku (or any small-model) "research-packet" helper to prefetch for the DM** — the beat is
@@ -43,6 +56,7 @@ digest-correctness (1 engine call, no LLM) → cache-stability (1 two-beat run) 
 VM part-B sweep; see the Support VM lane). Hold the scorer constant during any A/B.
 
 ## Still open
-- The exact Opus model id valid in the current CLI/runtime.
-- Whether a lower routine effort holds story ≥ 4.3 (needs the quality A/B).
+- **The #640 lean re-ground root** — the key Opus-latency enabler (re-enable lean safely; repro-first).
+- The exact Opus model id valid in the current CLI/runtime (confirm `claude --model opus` resolves on the gate path).
+- The same-SHA Opus re-measure sweep: does Opus + streaming hold story ≥4.3 AND keep cross-persona sat ≥7 (no latency give-up)?
 - Scorer-to-Opus re-baseline as a later one-time calibration.

--- a/qa/UI_PLAYTEST.md
+++ b/qa/UI_PLAYTEST.md
@@ -184,7 +184,7 @@ npx playwright install chromium  # ONLY if chromium isn't already cached (it oft
 ### Env knobs (optional)
 
 - `WORLDOS_UIPT_CHANNEL=chrome` — reuse system Chrome instead of bundled Chromium.
-- `WORLDOS_DM_MODEL` / `WORLDOS_UIPT_PLAYER_MODEL` — model per agent (default `sonnet`).
+- `WORLDOS_DM_MODEL` / `WORLDOS_UIPT_PLAYER_MODEL` — model per agent (DM default `opus`; player `sonnet`).
 - `WORLDOS_UIPT_DM_BUDGET` — USD per DM turn (default `1.50`).
 
 ## Scope notes

--- a/qa/run_combat_sprint.sh
+++ b/qa/run_combat_sprint.sh
@@ -16,7 +16,7 @@ cd "$ROOT" || exit 1
 . "$ROOT/qa/lib_beat_driver.sh"
 
 RUN="${1:-cs-$(date +%H%M%S)}"
-CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
+CLAWDND_DM_MODEL="$(worldos_env DM_MODEL opus)"
 T="$ROOT/qa/transcripts"
 STATE_DIR="$ROOT/qa/state/$RUN"
 mkdir -p "$T" "$STATE_DIR"

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -40,8 +40,8 @@ if [ "$(id -u)" = "0" ] && [ -z "${IS_SANDBOX:-}" ]; then
 fi
 
 # The DM model is an env var so A/B-testing Opus vs sonnet for structural adherence is a
-# one-flag flip (decision-dm-driver.md §3 "model choice as an orthogonal lever"). Default sonnet.
-CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
+# one-flag flip (decision-dm-driver.md §3 "model choice as an orthogonal lever"). Default opus (DECIDED 2026-06-06).
+CLAWDND_DM_MODEL="$(worldos_env DM_MODEL opus)"
 # The player facade is a near-free no-tool agent; its model is a separate knob (default sonnet,
 # so behavior is unchanged) kept consistent with the party harness's WORLDOS_ACTOR_MODEL.
 CLAWDND_ACTOR_MODEL="$(worldos_env ACTOR_MODEL sonnet)"

--- a/qa/run_party.sh
+++ b/qa/run_party.sh
@@ -55,7 +55,7 @@ SESSION_BUDGET="${CLAWDND_PARTY_SESSION_BUDGET:-30.00}"  # aggregate ceiling for
 MAX_TURNS="${CLAWDND_PARTY_MAX_TURNS:-60}"               # hard agent-turn cap (safety net)
 # Model knobs (default sonnet, so behavior is unchanged): the DM model is the structural-
 # adherence lever (decision §3); the actor model drives the player/companion facade agents.
-CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
+CLAWDND_DM_MODEL="$(worldos_env DM_MODEL opus)"
 CLAWDND_ACTOR_MODEL="$(worldos_env ACTOR_MODEL sonnet)"
 T="qa/transcripts"; STATE_DIR="$ROOT/qa/state/$RUN"
 mkdir -p "$T" "$STATE_DIR"; rm -rf "$STATE_DIR/campaigns" 2>/dev/null

--- a/qa/run_qa.sh
+++ b/qa/run_qa.sh
@@ -27,7 +27,7 @@ BUDGET="${2:-3.00}"
 PROMPT_FILE="${3:-qa/play_prompt.txt}"
 RUBRIC_FILE="${4:-qa/rubric.md}"
 # DM model knob (default sonnet → unchanged); a one-flag flip for Opus structural-adherence tests.
-CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
+CLAWDND_DM_MODEL="$(worldos_env DM_MODEL opus)"
 T="qa/transcripts"
 STATE_DIR="$ROOT/qa/state/$RUN"          # per-run isolation -> parallel-safe
 MCP_CONFIG="$STATE_DIR/qa.mcp.json"

--- a/qa/ui_playtest.sh
+++ b/qa/ui_playtest.sh
@@ -34,7 +34,7 @@ BEATS="${4:-30}"          # max player palette actions (soft cap)
 BUDGET="${5:-3.00}"       # USD cap for the PLAYER agent
 PW_DIR="$ROOT/qa/playwright"
 PW_CHANNEL="$(worldos_env UIPT_CHANNEL "")"   # "" = bundled chromium; "chrome" = system Chrome
-DM_MODEL="$(worldos_env DM_MODEL sonnet)"
+DM_MODEL="$(worldos_env DM_MODEL opus)"
 PLAYER_MODEL="$(worldos_env UIPT_PLAYER_MODEL sonnet)"
 DM_BUDGET="$(worldos_env UIPT_DM_BUDGET 1.50)"        # per DM turn
 PERSONA_FILE="$ROOT/qa/play_player_browser_${PERSONA}.txt"

--- a/qa/ui_playtest_app.sh
+++ b/qa/ui_playtest_app.sh
@@ -50,7 +50,7 @@
 #                               an operator can continue a short built-app gameplay playtest.
 #                               Also waits for first-turn readiness: seated actor, enabled actions,
 #                               and visible narration/chat, not merely can_act:true.
-#   WORLDOS_DM_MODEL           DM model (default sonnet). CLAWDND_PLAY_BUDGET caps each DM turn.
+#   WORLDOS_DM_MODEL           DM model (default opus — DECIDED 2026-06-06, see docs/MODEL-TIERING-STRATEGY.md). CLAWDND_PLAY_BUDGET caps each DM turn.
 #
 # Produces under qa/ui_playtest_runs/<run>/:
 #   native/  before.png after.png transition.json transition.log       (part A)
@@ -84,7 +84,7 @@ fi
 PW_DIR="$ROOT/qa/playwright"
 APP_BUNDLE="$ROOT/dist/WorldOS.app"
 PREFERRED_PORT="${WOS_APP_PREFERRED_PORT:-8765}"   # matches RootView.swift @AppStorage("preferredPort") default
-DM_MODEL="$(worldos_env DM_MODEL sonnet)"
+DM_MODEL="$(worldos_env DM_MODEL opus)"
 PLAYER_MODEL="$(worldos_env UIPT_PLAYER_MODEL sonnet)"
 PERSONA_FILE="$ROOT/qa/play_player_browser_${PERSONA}.txt"
 

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -49,7 +49,7 @@ SESSION_BUDGET="${CLAWDND_PLAY_SESSION_BUDGET:-15.00}"  # aggregate ceiling for 
 MAX_TURNS="${CLAWDND_PLAY_MAX_TURNS:-40}"              # hard turn cap (worst case = MAX_TURNS×BUDGET)
 # The DM model is an env var (default sonnet) so Opus-vs-sonnet structural-adherence testing
 # is a one-flag flip — mirrors qa/run_duo.sh (decision-dm-driver.md §3).
-CLAWDND_DM_MODEL="$(worldos_env DM_MODEL sonnet)"
+CLAWDND_DM_MODEL="$(worldos_env DM_MODEL opus)"
 DM_TURNS=0
 
 # --- Lean-per-beat context (PERF, default OFF → byte-identical to today). --------------

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -71,7 +71,7 @@ COMPANION_SPEC="${4:-${CLAWDND_PLAY_COMPANIONS:-}}"
 # Model knobs (default sonnet → unchanged behavior). The DM model is the structural-adherence
 # lever (decision §3); the actor model drives the companion facade agents. The solo path below
 # delegates to play.sh, which honors CLAWDND_DM_MODEL on its own (the env var carries through).
-CLAWDND_DM_MODEL="${CLAWDND_DM_MODEL:-sonnet}"
+CLAWDND_DM_MODEL="${CLAWDND_DM_MODEL:-opus}"
 CLAWDND_ACTOR_MODEL="${CLAWDND_ACTOR_MODEL:-sonnet}"
 # Lean-beat re-ground depth: how many recent player-facing beats the LEAN RE-GROUND directive
 # asks scene_context to fold in (default 8 — SAME as scripts/play.sh + qa/run_duo.sh). Used by


### PR DESCRIPTION
## Decision
Owner chose **Full Opus + attack latency** after a same-build A/B: Opus story-craft **3.6→4.0** (every weak dim 3→4: scene_craft/character_depth/dramatic_momentum/thematic_resonance), duo mech 3.4→3.9. The DM prompts were already maximal, so **Sonnet was the ceiling**.

## Change
Flip the `WORLDOS_DM_MODEL` default `sonnet→opus` across production (`play.sh`, `play_party.sh`), the gate (`ui_playtest_app.sh`), and the QA duos/sprints. **Player facade stays Sonnet.** Latency-proof `dryrun_*` scripts keep pinned sonnet. Cheap iteration opts out via `WORLDOS_DM_MODEL=sonnet`. Decision record updated.

## Latency mitigation (Opus is slower; this is the tradeoff)
- `alwaysLoad` engine tools — already ON · streaming (live-progress rule) — already prompted · #679 recovery — merged.
- **Key enabler (separate PR): the #640 lean re-ground root** — re-enable lean safely → fast Opus beats instead of full-transcript replay. Until then Opus runs lean-OFF (correct but slow).
- **Re-measure gate:** a same-SHA Opus sweep must hold story ≥4.3 AND cross-persona sat ≥7 (no latency give-up) before this counts toward the release RRI.