### PR TITLE
fix(#640): pin lean re-ground to the engine-authoritative LIVE campaign (stop cross-chronicle contamination)

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -50,10 +50,43 @@ worldos_env() {
 # the LARGEST non-empty snapshot under <state_dir>/campaigns (never a blind head -1, which a
 # fat-fingered campaign_id could point at a lock-only orphan dir). Echoes the path or nothing.
 # $1 = STATE_DIR
+#
+# CAUTION (issue #640): "largest snapshot" is a SCORING-state heuristic (find the fattest save
+# to grade) — it is the WRONG selector for the LEAN RE-GROUND campaign id. When two campaigns
+# coexist in one state dir (a cold-open start_world retry, or a stale leftover), the largest may
+# be the STALE/PARALLEL one, and pointing a transcript-free lean beat at it folds a DIFFERENT
+# save's opening scene into the re-ground (cross-chronicle contamination). For the LEAN id, use
+# clawdnd_live_campaign_id below (the engine's authoritative most-recently-played save), NOT this.
 clawdnd_snapshot_path() {
   local state_dir="$1"
   find "$state_dir/campaigns" -mindepth 2 -maxdepth 2 -name snapshot.json -size +1c \
     -exec ls -S {} + 2>/dev/null | head -1
+}
+
+# Resolve the LIVE campaign id for the lean re-ground — the ENGINE-authoritative answer to
+# "which save is being played right now", so a fast/transcript-free beat re-grounds against the
+# RIGHT campaign and can never fold a parallel save's opening scene into scene_context (#640).
+#
+# The engine is the sole source of truth for which campaign is live; it returns the
+# MOST-RECENTLY-UPDATED campaign (the one the harness is actively writing each beat), optionally
+# scoped to the launched world so a stale save from another world can't shadow it. This REPLACES
+# the old per-harness guesses (clawdnd_snapshot_path = largest, or `find … | head -1` = first dir)
+# that the #640 A/B proved could select the wrong campaign. Read-only (active_campaign never
+# mutates). Echoes the campaign id, or NOTHING when no campaign exists / the engine errors — in
+# which case the caller's lean branch no-ops (clawdnd_dm_lean_args returns 0 on an empty id) and
+# the normal --resume path is used (no regression). $1 = ROOT (repo root)  $2 = STATE_DIR
+# $3 = world_id (optional; scopes the resolution to the launched world)
+clawdnd_live_campaign_id() {
+  local root="$1" state_dir="$2" world="${3:-}"
+  [ -d "$state_dir/campaigns" ] || return 0
+  WORLDOS_STATE_DIR="$state_dir" CLAWDND_STATE_DIR="$state_dir" \
+    uv run --directory "$root/servers/engine" python - "$world" 2>/dev/null <<'PY'
+import sys
+import store
+cid = store.active_campaign_id(sys.argv[1] if len(sys.argv) > 1 else "")
+if cid:
+    print(cid)
+PY
 }
 
 # EMPTY-NARRATION FALLBACK (issue #357). The play/QA loops record the DM turn's FINAL reply

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -243,16 +243,23 @@ chatlog dm "$DMSG"
 
 # Resolve the campaign id the cold open just minted (for the lean re-ground; harmless when
 # CLAWDND_LEAN_BEATS=0). D1's start_world wrote the snapshot to
-# $STATE_DIR/campaigns/<id>/snapshot.json — read the id back from that dir. Mirrors
-# scripts/play.sh:347-363. The run wipes $STATE_DIR/campaigns at setup, so there is exactly
-# one campaign here; prefer the largest non-empty snapshot's parent (via the shared helper,
-# robust against a lock-only orphan dir), falling back to the sole campaign subdir. Empty ⇒
-# the DM turn's lean branch no-ops and the normal --resume path is used.
-CAMPAIGN_SNAP="$(clawdnd_snapshot_path "$STATE_DIR")"
-if [ -n "$CAMPAIGN_SNAP" ]; then
-  CAMPAIGN_ID="$(basename "$(dirname "$CAMPAIGN_SNAP")")"
-elif [ -d "$STATE_DIR/campaigns" ]; then
-  CAMPAIGN_ID="$(find "$STATE_DIR/campaigns" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | head -n1)"
+# $STATE_DIR/campaigns/<id>/snapshot.json. The run wipes $STATE_DIR/campaigns at setup, so one
+# campaign is EXPECTED — but a cold-open start_world RETRY (or the DM mistakenly re-calling
+# start_world) can mint a SECOND, PARALLEL campaign in the same state dir. The old largest-
+# snapshot / first-dir heuristics could then select the WRONG one, and a transcript-free lean
+# beat re-grounding against it folds a DIFFERENT save's opening scene into scene_context — the
+# #640 cross-chronicle contamination. So pin the LEAN id to the ENGINE-authoritative LIVE save
+# (the most-recently-played campaign in this world), not a file-size/dir-order guess. Empty ⇒
+# the DM turn's lean branch no-ops and the normal --resume path is used (no regression).
+CAMPAIGN_ID="$(clawdnd_live_campaign_id "$ROOT" "$STATE_DIR" "$WORLD")"
+if [ -z "$CAMPAIGN_ID" ]; then
+  # Defensive fallback (engine unreachable / no world_id match): the sole campaign subdir.
+  CAMPAIGN_SNAP="$(clawdnd_snapshot_path "$STATE_DIR")"
+  if [ -n "$CAMPAIGN_SNAP" ]; then
+    CAMPAIGN_ID="$(basename "$(dirname "$CAMPAIGN_SNAP")")"
+  elif [ -d "$STATE_DIR/campaigns" ]; then
+    CAMPAIGN_ID="$(find "$STATE_DIR/campaigns" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | head -n1)"
+  fi
 fi
 if [ "$CLAWDND_LEAN_BEATS" = "1" ]; then
   if [ -n "$CAMPAIGN_ID" ]; then

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -391,7 +391,13 @@ chatlog dm "$DMSG"; DM_TURNS=1
 # normal --resume path (dm_turn no-ops lean when the id is unknown).
 CAMPAIGN_ID="$HERO_CAMP"
 if [ -z "$CAMPAIGN_ID" ] && [ -d "$STATE_DIR/campaigns" ]; then
-  CAMPAIGN_ID="$(find "$STATE_DIR/campaigns" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | head -n1)"
+  # No pre-seeded hero → ask the ENGINE which save is live (the most-recently-played
+  # campaign in this world), NOT a blind first-dir pick — so a parallel campaign (a
+  # cold-open start_world retry) can't mis-point the lean re-ground at a DIFFERENT save's
+  # opening scene (#640 cross-chronicle contamination). Falls back to the first subdir only
+  # if the engine can't answer (unreachable / no world match) — no regression vs today.
+  CAMPAIGN_ID="$(clawdnd_live_campaign_id "$ROOT" "$STATE_DIR" "$WORLD")"
+  [ -z "$CAMPAIGN_ID" ] && CAMPAIGN_ID="$(find "$STATE_DIR/campaigns" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | head -n1)"
 fi
 if [ "$CLAWDND_LEAN_BEATS" = "1" ]; then
   if [ -n "$CAMPAIGN_ID" ]; then

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -94,6 +94,7 @@ _AB3_TO_FULL = {
 # (how the SRD records spell saving_throw_ability, e.g. "wisdom") and resolve to an Ability.
 _FULL_TO_AB3 = {full: ab3 for ab3, full in _AB3_TO_FULL.items()}
 from store import append_log, campaign_lock, campaigns_for_world, read_log_all
+from store import active_campaign_id as _active_campaign_id
 from store import list_campaigns as _list_campaigns
 from store import list_slots as _list_slots
 from store import load_campaign, save_campaign
@@ -403,6 +404,24 @@ def create_campaign(title: str, summary: str = "") -> dict:
 def list_campaigns() -> list[dict]:
     """List all saved campaigns (id, title, last-updated time)."""
     return _list_campaigns()
+
+
+@mcp.tool()
+def active_campaign(world_id: str = "") -> dict:
+    """The LIVE campaign in this state dir — the one a harness must re-ground a
+    lean/fast beat against (issue #640). Resolved deterministically by the engine
+    (the sole source of truth for which save is live) as the MOST-RECENTLY-UPDATED
+    campaign, optionally scoped to ``world_id``.
+
+    Harnesses previously picked the lean re-ground ``campaign_id`` by the LARGEST
+    snapshot on disk; when a parallel campaign coexists in the state dir (a cold-open
+    ``start_world`` retry, or a stale prior save) that can be the WRONG campaign, and
+    because ``scene_context`` is strictly campaign-pure it then faithfully folds a
+    DIFFERENT save's opening scene into the fast re-ground (cross-chronicle
+    contamination). Ask the engine which save is live instead of guessing from file
+    sizes. Read-only. Returns ``{"campaign_id": <id> | None}`` (None when no matching
+    campaign exists yet)."""
+    return {"campaign_id": _active_campaign_id(world_id)}
 
 
 @mcp.tool()

--- a/servers/engine/store.py
+++ b/servers/engine/store.py
@@ -277,6 +277,54 @@ def campaigns_for_world(world_id: str) -> list[dict]:
     return out
 
 
+def active_campaign_id(world_id: str = "") -> Optional[str]:
+    """The campaign a harness should re-ground a LEAN beat against — the LIVE save,
+    resolved deterministically as the MOST-RECENTLY-UPDATED campaign (largest
+    ``updated_at``), optionally scoped to ``world_id``.
+
+    Why this exists (issue #640 — lean re-ground cross-chronicle contamination):
+    the play/QA harnesses used to pick the lean re-ground ``campaign_id`` by the
+    LARGEST snapshot on disk (``qa/lib_beat_driver.sh:clawdnd_snapshot_path`` ->
+    ``ls -S | head -1``). When TWO campaigns coexist in one state dir — a cold-open
+    ``start_world`` retry minting a parallel campaign, or a stale prior save — the
+    largest snapshot can be the WRONG (parallel) campaign. The engine's
+    ``scene_context`` is strictly campaign-pure (it only ever reads
+    ``campaigns/<id>/…`` for the id it is GIVEN), so pointing a fast/transcript-free
+    lean beat at the wrong id faithfully folds a DIFFERENT save's opening scene
+    (wrong HP, wrong day, wrong scene art) into the re-ground — the A/B-proven
+    contamination. "Largest" is a fiction-volume proxy; "live" is **who wrote last**.
+
+    The engine is the SOLE source of truth for which campaign is live, so the
+    resolver lives here (the writer) and the harness asks the engine rather than
+    guessing from file sizes. Read-only; returns the campaign id, or ``None`` when no
+    matching campaign exists. Ties (equal ``updated_at``) break on the id for
+    determinism. ``world_id`` filters to one world seed (the harness always knows the
+    world it launched), so a stale save from a DIFFERENT world can never be selected.
+    """
+    root = state_dir() / "campaigns"
+    if not root.exists():
+        return None
+    best_id: Optional[str] = None
+    best_updated: float = float("-inf")
+    for d in sorted(root.iterdir()):
+        snap = d / "snapshot.json"
+        if not snap.exists():
+            continue
+        try:
+            c = Campaign.model_validate_json(snap.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        if world_id and c.world_id != world_id:
+            continue
+        updated = c.updated_at or 0.0
+        # Strict > keeps the FIRST seen on a tie; sorted(iterdir()) makes that the
+        # lexicographically-smallest id, so the choice is fully deterministic.
+        if updated > best_updated:
+            best_updated = updated
+            best_id = c.id
+    return best_id
+
+
 def append_log(campaign_id: str, session_id: str, entry: SessionLogEntry) -> None:
     path = _campaign_dir(campaign_id) / "sessions" / f"{session_id}.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/servers/engine/tests/test_lean_reground_contamination.py
+++ b/servers/engine/tests/test_lean_reground_contamination.py
@@ -1,0 +1,214 @@
+"""Regression: lean re-ground cross-chronicle contamination (issue #640).
+
+THE BUG (A/B-proven, 100% reproducible with CLAWDND_LEAN_BEATS=1): a continuing
+lean beat starts a FRESH transcript-free session and re-grounds from the engine's
+``scene_context(campaign_id=…)``. The play/QA harnesses resolved that
+``campaign_id`` by the LARGEST snapshot on disk
+(``qa/lib_beat_driver.sh:clawdnd_snapshot_path`` -> ``ls -S | head -1``). When TWO
+campaigns coexist in ONE state dir — a cold-open ``start_world`` retry minting a
+parallel campaign, or a stale prior save — the largest snapshot can be the WRONG
+(parallel) campaign. ``scene_context`` is strictly campaign-pure, so it then
+faithfully folds a DIFFERENT save's opening scene (wrong HP, wrong day, wrong scene
+art) into the fast re-ground tail — the observed contamination.
+
+This file pins BOTH halves of the diagnosis:
+
+  1. SOURCE-OF-TRUTH PROOF — ``scene_context``/``recent_narration`` is campaign-PURE
+     for the id it is given (two campaigns in one state dir never bleed). So the
+     engine is the right source of truth; the contamination is a WRONG-ID selection,
+     not an engine bleed.
+
+  2. THE BUG + THE FIX — the harness's "largest snapshot" heuristic mis-selects the
+     stale/parallel campaign, while the engine's new authoritative resolver
+     ``active_campaign(world_id)`` (``store.active_campaign_id``) pins the LIVE
+     (most-recently-updated) save. The lean re-ground, pointed at the live id,
+     returns ONLY the live campaign's prose.
+"""
+
+import json
+
+import pytest
+
+import server
+import store
+
+
+@pytest.fixture
+def state(tmp_path, monkeypatch):
+    """A clean state dir, like the harness's freshly-wiped campaigns/ tree."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _seed_campaign(narration: list[str], world_id: str = "baldurs-gate") -> str:
+    """Mint a campaign, stamp its world seed (so the world-scoped resolver has a real
+    world_id to filter on — bundled adventures leave world_id empty), and log a
+    distinct player-facing narration tail. Returns its id."""
+    cid = server.start_adventure("cellar-rats")["campaign_id"]
+    if world_id:
+        c = store.load_campaign(cid)
+        c.world_id = world_id
+        store.save_campaign(c)
+    server.start_session(cid, title="play")
+    for line in narration:
+        server.log_event(cid, kind="narration", text=line)
+    return cid
+
+
+def _set_updated_at(cid: str, when: float) -> None:
+    """Force a campaign's ``updated_at`` ON DISK, bypassing save_campaign's re-stamp.
+
+    save_campaign() overwrites ``updated_at`` with time.time() on EVERY write (the
+    sole-writer stamp), so two campaigns saved back-to-back can tie on the wall clock
+    to microsecond resolution — which would make a recency test flaky. The resolver's
+    job is "newest updated_at wins", so the test pins explicit, well-separated
+    timestamps directly in the snapshot JSON to exercise that selection
+    deterministically (mirrors a real play session, where the LIVE save is written
+    many seconds after any stale leftover)."""
+    snap = store._campaign_dir(cid) / "snapshot.json"
+    data = json.loads(snap.read_text(encoding="utf-8"))
+    data["updated_at"] = when
+    snap.write_text(json.dumps(data), encoding="utf-8")
+
+
+# ── 1) SOURCE-OF-TRUTH: the engine re-ground is campaign-PURE for a given id ──────
+
+
+def test_scene_context_recent_narration_is_campaign_pure(state):
+    """Two campaigns in ONE state dir. scene_context(campaign_id=LIVE) must return
+    ONLY the LIVE campaign's narration tail — never a line from the parallel one.
+    (Proves the contamination is a wrong-id selection upstream, NOT an engine bleed.)"""
+    live = _seed_campaign(["LIVE: you stand in the cellar, rats stirring."])
+    other = _seed_campaign(
+        ["OTHER: a Basilisk Gate refugee scene — wrong day, wrong HP 16/20."]
+    )
+    assert live != other
+
+    rn_live = server.scene_context(live, recent_narration=8)["recent_narration"]
+    texts_live = " ".join(e["text"] for e in rn_live)
+    assert "LIVE:" in texts_live
+    assert "Basilisk Gate" not in texts_live  # the parallel save NEVER bleeds in
+
+    # …and symmetrically the other id only sees the other prose.
+    rn_other = server.scene_context(other, recent_narration=8)["recent_narration"]
+    texts_other = " ".join(e["text"] for e in rn_other)
+    assert "Basilisk Gate" in texts_other
+    assert "LIVE:" not in texts_other
+
+
+def test_scene_context_state_is_campaign_pure(state):
+    """The volatile `state` block (day/title/party) is likewise scoped to the id —
+    a re-ground against the LIVE id can't read the parallel campaign's clock."""
+    live = _seed_campaign(["LIVE: cellar."])
+    other = _seed_campaign(["OTHER: refugees."])
+    # Diverge the parallel campaign's clock so a bleed would be visible as a day jump.
+    server.advance_time(other, phases=3, note="parallel save drifts forward")
+
+    st_live = server.scene_context(live, recent_narration=4)["state"]
+    st_other = server.scene_context(other, recent_narration=4)["state"]
+    assert st_live["id"] == live
+    assert st_other["id"] == other
+    # The live re-ground's day is the live campaign's, NOT the drifted parallel one.
+    assert st_live["day"] == server.get_state(live)["day"]
+
+
+# ── 2) THE BUG: "largest snapshot" mis-selects; the engine resolver pins LIVE ─────
+
+
+def _largest_snapshot_campaign_id(state_dir) -> str:
+    """Reproduce the harness's clawdnd_snapshot_path selection: the parent of the
+    LARGEST non-empty snapshot.json under campaigns/ (ls -S | head -1)."""
+    snaps = list((state_dir / "campaigns").glob("*/snapshot.json"))
+    biggest = max(snaps, key=lambda p: p.stat().st_size)
+    return biggest.parent.name
+
+
+def _fatten_snapshot(cid: str, npcs: int = 12) -> None:
+    """Grow a campaign's SNAPSHOT (not just session logs) so it is reliably the
+    largest on disk — narration lives in sessions/*.jsonl, so snapshot size is driven
+    by campaign STATE (characters/locations/quests). A stale parallel save that ran
+    longer has more of these. Creates NPCs with biographies to bloat the snapshot,
+    matching the cold-open-retry leftover that out-massed the fresh live save."""
+    for i in range(npcs):
+        server.create_character(
+            cid,
+            name=f"Refugee {i}",
+            kind="npc",
+            add_to_party=False,
+            biography="A Basilisk Gate refugee. " * 40,
+        )
+
+
+def test_largest_snapshot_heuristic_picks_the_WRONG_campaign(state):
+    """The harness's OLD selection. A STALE parallel save (a cold-open-retry leftover)
+    was written FIRST and accumulated a fat snapshot; the LIVE save is seeded after
+    and is small/fresh. "Largest snapshot" then resolves to the PARALLEL campaign —
+    the wrong id that, fed to the lean re-ground, produced the contamination.
+
+    Realism note: the engine stamps ``updated_at`` on EVERY save (sole-writer), so
+    "most-recently-updated" == "most-recently-written" — and the LIVE campaign is the
+    one the harness is actively playing each beat, so it is genuinely the last writer.
+    We pin explicit, well-separated timestamps (``_set_updated_at``) so the recency
+    selection is exercised DETERMINISTICALLY, not via back-to-back wall-clock writes
+    that can tie to microsecond resolution."""
+    # The stale parallel save is born first and is FAT (a roster of NPCs bloats its
+    # SNAPSHOT — narration lives in session logs, so snapshot size is driven by state).
+    stale = _seed_campaign(["OTHER: Basilisk Gate refugees."])
+    _fatten_snapshot(stale)
+    # The live save is seeded after and stays small; it is the one being played, so it
+    # is the most-recently-updated (a play session writes it many seconds later).
+    live = _seed_campaign(["LIVE: you stand in the cellar."])
+    _set_updated_at(stale, 1_000.0)
+    _set_updated_at(live, 2_000.0)  # the live save was written later (it is being played)
+
+    # The OLD heuristic picks the fat stale save → the contamination source.
+    assert _largest_snapshot_campaign_id(state) == stale  # FAILS to find the live save
+
+    # The FIX: the engine's authoritative resolver pins the LIVE (most-recent-writer) save.
+    assert store.active_campaign_id() == live
+    assert store.active_campaign_id("baldurs-gate") == live
+
+
+def test_active_campaign_resolver_feeds_a_clean_lean_reground(state):
+    """End-to-end: resolve the lean re-ground id via the FIX, then call the exact
+    lean re-ground (scene_context with a narration tail). The result is the LIVE
+    campaign's prose only — the contamination cannot occur."""
+    # Stale parallel save first (fat snapshot), then the live save that keeps playing.
+    stale = _seed_campaign(["OTHER: Basilisk Gate, the refugee at the gate."])
+    _fatten_snapshot(stale)
+    live = _seed_campaign(["LIVE: rats stir in the cellar dark."])
+    _set_updated_at(stale, 1_000.0)
+    _set_updated_at(live, 2_000.0)  # the live save is most-recently-updated
+    assert _largest_snapshot_campaign_id(state) == stale  # the bug's wrong selection
+
+    pinned = server.active_campaign("baldurs-gate")["campaign_id"]
+    assert pinned == live  # NOT the larger stale save
+
+    rn = server.scene_context(pinned, recent_narration=8)["recent_narration"]
+    joined = " ".join(e["text"] for e in rn)
+    assert "LIVE:" in joined
+    assert "Basilisk Gate" not in joined  # no cross-chronicle bleed
+
+
+def test_active_campaign_scopes_to_world(state):
+    """world_id scoping: a newer save from a DIFFERENT world never shadows the live
+    one (the harness always knows which world it launched)."""
+    live = _seed_campaign(["LIVE: cellar."])
+    # A different-world campaign that is NEWER overall but must be ignored when we
+    # scope to this run's world seed (the harness always knows which world it launched).
+    other_world = store.load_campaign(live).model_copy(deep=True)
+    other_world.id = "camp_otherworld"
+    other_world.world_id = "some-other-world"
+    store.save_campaign(other_world)
+    _set_updated_at(live, 1_000.0)
+    _set_updated_at("camp_otherworld", 2_000.0)  # newer, but wrong world
+
+    # Unscoped, the newer other-world save wins; scoped to this world, the live save.
+    assert store.active_campaign_id() == "camp_otherworld"
+    assert store.active_campaign_id("baldurs-gate") == live
+
+
+def test_active_campaign_none_when_empty(state):
+    """No campaigns yet → None (the harness then no-ops lean, today's behavior)."""
+    assert store.active_campaign_id() is None
+    assert server.active_campaign()["campaign_id"] is None


### PR DESCRIPTION
## The bug (A/B-proven, 100% reproducible)

With `CLAWDND_LEAN_BEATS=1`, a same-build A/B vs lean-OFF showed lean-ON introduced two criticals lean-OFF did not have:

- **Cross-chronicle contamination** — every DM beat appended the FULL text of a *different* save's opening scene (a Basilisk Gate refugee scene: wrong HP, wrong day) after the correct narration; the scene art switched and the timestamp jumped. 100% reproducible across actions.
- **Dropped beats** — spinner clears + time advances but zero narration text.

lean is currently reverted OFF (the safe config). This makes it safe to turn back ON — the enabler for the Opus DM re-grounding from a compact digest instead of replaying the full transcript.

## Confirmed mechanism (verified in source + a deterministic repro)

A continuing **lean** beat starts a FRESH, transcript-free `claude -p` session and re-grounds from `scene_context(campaign_id=…)` instead of `--resume`-ing the fat transcript (`qa/lib_beat_driver.sh:clawdnd_dm_lean_args`).

The contamination is **NOT** an engine bleed. I verified the whole engine read path is strictly campaign-scoped for the id it is *given*:
- `scene_context` → `_scene_recent_narration` → `store.read_log_all(c.id)` → globs only `campaigns/<id>/sessions/*.jsonl`.
- `get_state` / `_require` → `load_campaign` → `_campaign_dir(campaign_id)`. No cache, no fuzzy match, no "fall back to most recent".
- `recall` / `lookup_lore` / `recall_npc` → ledger db at `campaigns/<id>/ledger.db`.

The bleed is a **wrong `campaign_id` selection in the harness**. The play/QA harnesses resolved the lean re-ground id by the **LARGEST snapshot on disk** (`clawdnd_snapshot_path` → `ls -S | head -1`, in `run_duo.sh`) or the **first campaign subdir** (`play.sh`). When TWO campaigns coexist in one state dir — a cold-open `start_world` RETRY minting a parallel campaign, or a stale prior save — that heuristic can select the WRONG (parallel) campaign. `scene_context` then faithfully returns that parallel save's `recent_narration` + `state` → the correct narration (from the live move) followed by a *different* save's opening scene, with its day/HP/art. That is exactly the observed signature. "Largest" is a fiction-volume proxy; the right answer is **who wrote last** (the save being actively played).

## The fix (minimal, additive, repro-backed)

The engine is the sole source of truth for which save is live, so ask it.

- `servers/engine/store.py` — new `active_campaign_id(world_id="")`: the MOST-RECENTLY-UPDATED campaign (largest `updated_at`), optionally scoped to the launched world; deterministic tie-break on id; read-only.
- `servers/engine/server.py` — new `active_campaign(world_id="")` MCP tool wrapping it.
- `qa/lib_beat_driver.sh` — new shared `clawdnd_live_campaign_id ROOT STATE_DIR [world]` that calls the engine; documents that `clawdnd_snapshot_path` (largest) is a *scoring* selector and must NOT be used for the lean id.
- `qa/run_duo.sh` + `scripts/play.sh` — resolve the lean `CAMPAIGN_ID` through the live resolver. The old largest/first-dir picks remain only as a **defensive fallback** when the engine can't answer (so an empty id still no-ops lean to `--resume` — no regression).

Lean's latency win is preserved: it still re-grounds from the compact `scene_context` digest, never the full transcript. **lean-OFF is byte-identical** to today (the lean branch is the only thing touched and it no-ops when off).

`play_party.sh` was already correct — it pins `CAMPAIGN_ID` from its deterministic reuse-or-mint pre-seed (the 30-min reuse guard, prior #640 partial), so it is not changed.

## The repro / guard — `servers/engine/tests/test_lean_reground_contamination.py`

1. **Source-of-truth proof** (3 tests): two campaigns in one state dir; `scene_context(campaign_id=live)` returns ONLY the live campaign's `recent_narration` + `state` — never the parallel save's prose or clock. Proves the engine is pure and the bug is upstream wrong-id selection.
2. **The bug + the fix** (3 tests): a fat stale parallel campaign + a small fresh live one; the old largest-snapshot heuristic mis-selects the stale campaign, while `active_campaign(world_id)` pins the live one and yields a contamination-free re-ground; plus world-scoping and the empty-state no-op.

Fails without the resolver (3/6), passes with it (6/6), **stable over 10 consecutive runs** (timestamp-tie determinism handled).

## Test results

- `tests/test_lean_reground_contamination.py` — 6 passed (×10 stable)
- `tests/test_beat_roundtrip.py` (scene_context suite) — 19 passed
- `tests/test_store.py` + `tests/test_content.py` — 89 passed
- targeted campaign/store/scene_context/content/lean slice — 217 passed
- `qa/fast_gate.sh` (Tier-0) — 187 passed
- `scripts/license_check.py` — passed
- `bash -n` clean on all three shell files; no new shellcheck warnings

## Is lean-ON safe to re-enable?

Yes for the harness wrong-id contamination — the lean re-ground is now pinned to the engine-authoritative live campaign in `run_duo.sh` and `play.sh`, so a parallel/stale campaign can no longer fold a different save's scene into the digest. Recommend re-running the lean A/B (and the `play_party.sh` / `.app` path) to confirm the dropped-beat symptom is also gone before flipping the default back on in a sweep.

## NOT touched (verified, deliberately out of scope)

`scene_context` / `read_log_all` / `load_campaign` / `_require` (already strictly campaign-scoped — confirmed, not the bleed point); `play_party.sh` (already pins from its deterministic pre-seed). Engine sole-writer invariant intact (the new resolver is read-only).