### PR TITLE
fix: make the Opus DM default work end-to-end (per-turn budget + cold-open latency)

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -208,7 +208,13 @@ Do NOT contradict any of it, re-introduce an already-met NPC, reset the clock, o
 clawdnd_dm_effort_arg() {
   local first="$1" level
   if [ "$first" != "0" ]; then
-    level="$(worldos_env DM_EFFORT_COLDOPEN max)"
+    # Cold-open effort is model-aware. Opus's max-effort world-build is generation-bound and overruns
+    # the cold-open timeout (measured 2026-06-06: Opus --effort max never finishes <400s; --effort HIGH
+    # finishes ~300s WITH a full, BG-caliber opening). Opus-high ≈ Sonnet-max world-build quality but
+    # lands in time, so Opus defaults to high; Sonnet keeps max (it finishes in ~280–400s at max).
+    local _co_default=max
+    case "${CLAWDND_DM_MODEL:-}" in *opus*) _co_default=high ;; esac
+    level="$(worldos_env DM_EFFORT_COLDOPEN "$_co_default")"
   else
     level="$(worldos_env DM_EFFORT_ROUTINE medium)"
   fi
@@ -243,7 +249,11 @@ clawdnd_dm_effort_arg() {
 clawdnd_dm_timeout() {
   local first="$1"
   if [ "$first" != "0" ]; then
-    worldos_env COLDOPEN_TIMEOUT 400
+    # Cold-open deadline is model-aware. Opus-high cold-open measured ~300s; give it margin (500s) for
+    # per-world/per-run variance so it is never killed mid-build. Sonnet keeps 400s (max runs ~280–400s).
+    local _co_timeout=400
+    case "${CLAWDND_DM_MODEL:-}" in *opus*) _co_timeout=500 ;; esac
+    worldos_env COLDOPEN_TIMEOUT "$_co_timeout"
   else
     worldos_env BEAT_TIMEOUT 200
   fi

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -45,6 +45,13 @@ CLAWDND_DM_MODEL="$(worldos_env DM_MODEL opus)"
 # The player facade is a near-free no-tool agent; its model is a separate knob (default sonnet,
 # so behavior is unchanged) kept consistent with the party harness's WORLDOS_ACTOR_MODEL.
 CLAWDND_ACTOR_MODEL="$(worldos_env ACTOR_MODEL sonnet)"
+# Opus's high-effort cold-open world-build costs ~$2.4 on its first turn (measured 2026-06-06); a low
+# caller per-turn budget (sweep $2.00, fast_probe $0.80) would trip error_max_budget_usd on the duo
+# cold-open the same way the .app backend did. Floor the per-turn cap for an Opus DM so the cold-open
+# always lands. A CAP, not a spend — routine duo turns spend far less.
+case "$CLAWDND_DM_MODEL" in
+  *opus*) if awk "BEGIN{exit !($BUDGET < 4.0)}"; then echo "[duo] opus: flooring per-turn budget \$$BUDGET -> \$4.00 (cold-open headroom)"; BUDGET=4.00; fi ;;
+esac
 
 # --- Lean-per-beat context (PERF, default OFF → byte-identical to today). --------------
 # MIRRORS scripts/play.sh exactly (and shares its ONE implementation via the

--- a/qa/ui_playtest_app.sh
+++ b/qa/ui_playtest_app.sh
@@ -559,7 +559,11 @@ run_part_b() {
         export PATH="$PATH_NOOPEN"
         export WORLDOS_DM_MODEL="$DM_MODEL" CLAWDND_DM_MODEL="$DM_MODEL"
         export CLAWDND_PLAY_PORT="$b_port"
-        export CLAWDND_PLAY_BUDGET="${CLAWDND_PLAY_BUDGET:-1.50}"
+        # Per-turn cap scales to the DM model: the Opus max-effort cold-open world-build needs ~$12;
+        # the Sonnet-tuned $1.50 cap trips error_max_budget_usd on the Opus cold-open → no PC seated.
+        # CAP, not spend — routine beats spend far less; sess_cap still bounds total DM spend.
+        case "$DM_MODEL" in *opus*) : "${CLAWDND_PLAY_BUDGET:=12.00}" ;; *) : "${CLAWDND_PLAY_BUDGET:=1.50}" ;; esac
+        export CLAWDND_PLAY_BUDGET
         export CLAWDND_PLAY_SESSION_BUDGET="$sess_cap"
         export CLAWDND_PLAY_MAX_TURNS="${CLAWDND_PLAY_MAX_TURNS:-$((BEATS + 4))}"
         export CLAWDND_PLAY_MAX_IDLE="${CLAWDND_PLAY_MAX_IDLE:-600}"

--- a/qa/ui_playtest_app.sh
+++ b/qa/ui_playtest_app.sh
@@ -613,7 +613,13 @@ run_part_b() {
   local b_state="$ROOT/play-state/$b_run"
   log "[B] waiting for the backend to be player-ready (can_act + seated PC + opening narration)…"
   local ready=0 ca pc chat_lines saw_canact=0 saw_pc=0
-  for i in $(seq 1 120); do   # up to ~6 min for the full cold-open
+  # Slow DMs (e.g. an Opus max-effort cold-open) seat the PC well before the opening narration
+  # finishes — so the wait + the no-narration grace are env-configurable. Defaults preserve the
+  # historic ~6min cap / ~2.5min grace; raise them for an Opus cold-open so the harness waits for
+  # the narration instead of grace-proceeding into an empty scene (3s per poll).
+  local ready_polls="${WOS_APP_PLAYER_READY_POLLS:-120}"
+  local grace_polls="${WOS_APP_NARRATION_GRACE_POLLS:-50}"
+  for i in $(seq 1 "$ready_polls"); do   # up to ~ready_polls*3s for the full cold-open
     if [ "$(curl -s -o /dev/null -w '%{http_code}' "$b_url" 2>/dev/null)" = "200" ]; then
       ca="$(curl -s --max-time 2 "http://127.0.0.1:$b_port/session-surface" 2>/dev/null | jq -r '.can_act // false' 2>/dev/null)"
       [ "$ca" = "true" ] && saw_canact=1
@@ -631,7 +637,7 @@ run_part_b() {
       fi
       # Grace fallback: can_act + seated PC but STILL no narration after ~2.5min → proceed anyway
       # (the persona will report the empty opening scene — a real finding, e.g. #357).
-      if [ "$saw_canact" = "1" ] && [ "$saw_pc" = "1" ] && [ "$i" -ge 50 ]; then
+      if [ "$saw_canact" = "1" ] && [ "$saw_pc" = "1" ] && [ "$i" -ge "$grace_polls" ]; then
         ready=1; log "[B] proceeding without opening narration after $((i*3))s (chat empty — persona will judge it; possible #357)."; break
       fi
     fi

--- a/qa/ui_playtest_app.sh
+++ b/qa/ui_playtest_app.sh
@@ -619,6 +619,10 @@ run_part_b() {
   # the narration instead of grace-proceeding into an empty scene (3s per poll).
   local ready_polls="${WOS_APP_PLAYER_READY_POLLS:-120}"
   local grace_polls="${WOS_APP_NARRATION_GRACE_POLLS:-50}"
+  # An Opus cold-open finishes its narration ~300s (vs Sonnet ~280s at the wire); the Sonnet-tuned
+  # 50-poll (~150s) grace would grace-proceed into an empty scene. Default an Opus DM to a longer
+  # wait so the persona sees the real opening (env still overrides either tier).
+  case "$DM_MODEL" in *opus*) ready_polls="${WOS_APP_PLAYER_READY_POLLS:-200}"; grace_polls="${WOS_APP_NARRATION_GRACE_POLLS:-130}" ;; esac
   for i in $(seq 1 "$ready_polls"); do   # up to ~ready_polls*3s for the full cold-open
     if [ "$(curl -s -o /dev/null -w '%{http_code}' "$b_url" 2>/dev/null)" = "200" ]; then
       ca="$(curl -s --max-time 2 "http://127.0.0.1:$b_port/session-surface" 2>/dev/null | jq -r '.can_act // false' 2>/dev/null)"

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -44,12 +44,19 @@ PORT_EXPLICIT=0
 if declare -F clawdnd_choose_port >/dev/null 2>&1; then
   PORT="$(clawdnd_choose_port "$PORT" "$PORT_EXPLICIT")" || exit 1
 fi
-BUDGET="${CLAWDND_PLAY_BUDGET:-1.50}"                   # per DM turn
-SESSION_BUDGET="${CLAWDND_PLAY_SESSION_BUDGET:-15.00}"  # aggregate ceiling for the whole session
-MAX_TURNS="${CLAWDND_PLAY_MAX_TURNS:-40}"              # hard turn cap (worst case = MAX_TURNS×BUDGET)
-# The DM model is an env var (default sonnet) so Opus-vs-sonnet structural-adherence testing
-# is a one-flag flip — mirrors qa/run_duo.sh (decision-dm-driver.md §3).
+# The DM model is an env var (default opus, owner 2026-06-06) — one-flag flip; mirrors qa/run_duo.sh.
 CLAWDND_DM_MODEL="$(worldos_env DM_MODEL opus)"
+# Budgets scale to the DM model: an Opus turn — especially the max-effort cold-open world-build —
+# costs ~5x a Sonnet turn, so the Sonnet-tuned $1.50/$15 caps trip error_max_budget_usd on the Opus
+# cold-open and the backend never seats a PC. These are CAPS, not spends — routine beats spend far
+# less than the cap; the session ceiling bounds any runaway turn.
+case "$CLAWDND_DM_MODEL" in
+  *opus*) _PT_DEF=12.00; _SESS_DEF=30.00 ;;
+  *)      _PT_DEF=1.50;  _SESS_DEF=15.00 ;;
+esac
+BUDGET="${CLAWDND_PLAY_BUDGET:-$_PT_DEF}"                    # per DM turn (model-aware default)
+SESSION_BUDGET="${CLAWDND_PLAY_SESSION_BUDGET:-$_SESS_DEF}"  # aggregate session ceiling (model-aware)
+MAX_TURNS="${CLAWDND_PLAY_MAX_TURNS:-40}"              # hard turn cap (worst case = MAX_TURNS×BUDGET)
 DM_TURNS=0
 
 # --- Lean-per-beat context (PERF, default OFF → byte-identical to today). --------------

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -109,8 +109,16 @@ fi
 # companion-alive + relay machinery. The human is the player (acts via the dashboard,
 # NOT a claude -p agent); the companions are the claude -p peers.
 # ===========================================================================
-BUDGET="${CLAWDND_PLAY_BUDGET:-1.50}"                   # per agent turn (DM or companion)
-SESSION_BUDGET="${CLAWDND_PLAY_SESSION_BUDGET:-15.00}"  # aggregate ceiling for the whole session
+# Budgets scale to the DM model (resolved above): an Opus turn — especially the max-effort cold-open
+# world-build — costs ~5x a Sonnet turn, so the Sonnet-tuned $1.50/$15 caps trip error_max_budget_usd
+# on the Opus cold-open → the backend never seats a PC. CAPS, not spends — routine beats (and the
+# Sonnet companion facade) spend far less than the cap; the session ceiling bounds any runaway turn.
+case "$CLAWDND_DM_MODEL" in
+  *opus*) _PT_DEF=12.00; _SESS_DEF=30.00 ;;
+  *)      _PT_DEF=1.50;  _SESS_DEF=15.00 ;;
+esac
+BUDGET="${CLAWDND_PLAY_BUDGET:-$_PT_DEF}"                    # per agent turn (DM or companion; model-aware)
+SESSION_BUDGET="${CLAWDND_PLAY_SESSION_BUDGET:-$_SESS_DEF}"  # aggregate session ceiling (model-aware)
 MAX_TURNS="${CLAWDND_PLAY_MAX_TURNS:-40}"               # hard cap on agent turns (DM + companions)
 if declare -F clawdnd_choose_port >/dev/null 2>&1; then
   PORT="$(clawdnd_choose_port "$PORT" "$PORT_EXPLICIT")" || exit 1

--- a/servers/engine/tests/test_dm_budget_scaling.py
+++ b/servers/engine/tests/test_dm_budget_scaling.py
@@ -60,6 +60,16 @@ class DmBudgetScalingTests(unittest.TestCase):
         export = window.find("export CLAWDND_PLAY_BUDGET")
         self.assertTrue(0 <= branch < export, "the opus branch must set the cap before it is exported")
 
+    def test_run_duo_floors_opus_per_turn_budget(self):
+        """run_duo must floor a low per-turn budget for an Opus DM so the cold-open survives.
+
+        The sweep passes \\$2.00 and fast_probe \\$0.80 to run_duo; the Opus cold-open costs ~\\$2.4,
+        so without a floor the duo cold-open trips error_max_budget_usd just like the .app backend did.
+        """
+        src = self._read("qa/run_duo.sh")
+        self.assertIn("*opus*)", src, "run_duo must branch the per-turn budget on an opus model")
+        self.assertRegex(src, r"BUDGET=4\.00", "run_duo must floor the Opus per-turn budget >= the cold-open cost")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/servers/engine/tests/test_dm_budget_scaling.py
+++ b/servers/engine/tests/test_dm_budget_scaling.py
@@ -1,0 +1,65 @@
+"""Guard: the per-DM-turn budget default scales to the DM model.
+
+#682 flipped the default DM model to Opus. The Opus max-effort cold-open world-build costs ~5x a
+Sonnet turn, so the old Sonnet-tuned $1.50 per-turn cap tripped `error_max_budget_usd` on the very
+first (cold-open) turn and the faithful backend never seated a player character (observed on the VM
+2026-06-06: failure_bucket=no_actor, spend $0). Both the production play scripts AND the .app QA
+harness must therefore scale the per-turn cap to the model. These are CAPS, not spends — routine
+beats spend far less; the session ceiling bounds any runaway turn.
+"""
+import re
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class DmBudgetScalingTests(unittest.TestCase):
+    def _read(self, rel):
+        return (ROOT / rel).read_text(encoding="utf-8")
+
+    def test_production_play_scripts_scale_budget_to_model(self):
+        for rel in ("scripts/play.sh", "scripts/play_party.sh"):
+            src = self._read(rel)
+            self.assertIn("*opus*)", src, f"{rel} must branch the budget default on an opus model")
+            # an Opus per-turn default well above the Sonnet $1.50 cap (covers the cold-open)
+            self.assertRegex(
+                src, r"_PT_DEF=1[0-9]\.00",
+                f"{rel} must set an Opus per-turn default >= $10",
+            )
+            self.assertIn(
+                "CLAWDND_PLAY_BUDGET:-$_PT_DEF", src,
+                f"{rel} must consume the model-aware per-turn default",
+            )
+            self.assertIn(
+                "CLAWDND_PLAY_SESSION_BUDGET:-$_SESS_DEF", src,
+                f"{rel} must consume the model-aware session default",
+            )
+
+    def test_app_harness_scales_per_turn_budget_to_model(self):
+        src = self._read("qa/ui_playtest_app.sh")
+        self.assertIn(
+            'case "$DM_MODEL" in *opus*)', src,
+            "ui_playtest_app.sh (claude lane) must scale the per-turn DM budget to the model",
+        )
+        self.assertRegex(
+            src, r"CLAWDND_PLAY_BUDGET:=1[0-9]\.00",
+            "ui_playtest_app.sh must set an Opus per-turn cap >= $10",
+        )
+
+    def test_no_unconditional_sonnet_cap_in_claude_lane(self):
+        """The claude backend lane must not pin the per-turn cap to $1.50 unconditionally."""
+        src = self._read("qa/ui_playtest_app.sh")
+        # locate the claude lane block and assert the model-aware branch precedes the export
+        claude_idx = src.find("    claude)")
+        self.assertGreater(claude_idx, -1, "claude backend lane not found")
+        # within ~600 chars of the claude lane, the opus branch must appear before the export
+        window = src[claude_idx:claude_idx + 700]
+        self.assertIn("*opus*)", window, "claude lane must contain the model-aware budget branch")
+        branch = window.find("*opus*)")
+        export = window.find("export CLAWDND_PLAY_BUDGET")
+        self.assertTrue(0 <= branch < export, "the opus branch must set the cap before it is exported")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/servers/engine/tests/test_opus_coldopen_tuning.py
+++ b/servers/engine/tests/test_opus_coldopen_tuning.py
@@ -1,0 +1,49 @@
+"""Guard: the Opus DM cold-open is tuned to finish in time WITH narration.
+
+#682 made Opus the default DM. The Opus ``--effort max`` cold-open world-build is generation-bound and
+overruns the cold-open timeout (measured on the VM 2026-06-06: ``max`` never finishes <400s, the turn is
+killed before it writes narration, the backend grace-proceeds into an empty scene; ``--effort high``
+finishes ~300s WITH a full BG-caliber opening — "the lamps of Sorcerous Sundries burn low and blue…").
+
+So the cold-open effort + deadline + the QA narration-wait are MODEL-AWARE: Opus gets high / 500s /
+a longer narration grace; Sonnet is unchanged (max / 400s / the historic grace).
+"""
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+class OpusColdOpenTuningTests(unittest.TestCase):
+    def _read(self, rel):
+        return (ROOT / rel).read_text(encoding="utf-8")
+
+    def test_coldopen_effort_is_high_for_opus(self):
+        src = self._read("qa/lib_beat_driver.sh")
+        self.assertRegex(src, r"_co_default=max", "non-opus cold-open effort stays max")
+        self.assertRegex(src, r"\*opus\*\)\s*_co_default=high", "Opus cold-open effort must default to high")
+        self.assertIn(
+            'worldos_env DM_EFFORT_COLDOPEN "$_co_default"', src,
+            "the cold-open effort must consume the model-aware default",
+        )
+
+    def test_coldopen_timeout_has_opus_margin(self):
+        src = self._read("qa/lib_beat_driver.sh")
+        self.assertRegex(src, r"_co_timeout=400", "non-opus cold-open timeout stays 400s")
+        self.assertRegex(src, r"\*opus\*\)\s*_co_timeout=5\d\d", "Opus cold-open timeout must have margin (>=500s)")
+        self.assertIn(
+            'worldos_env COLDOPEN_TIMEOUT "$_co_timeout"', src,
+            "the cold-open timeout must consume the model-aware default",
+        )
+
+    def test_harness_narration_wait_longer_for_opus(self):
+        src = self._read("qa/ui_playtest_app.sh")
+        self.assertIn("WOS_APP_NARRATION_GRACE_POLLS", src, "narration grace must be env-configurable")
+        self.assertRegex(
+            src, r"\*opus\*\).*WOS_APP_NARRATION_GRACE_POLLS:-1\d\d",
+            "Opus narration grace must default longer (>=100 polls, i.e. >300s)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#682 flipped the default DM model to **Opus** but the surrounding tuning was Sonnet-shaped, so the Opus default was **broken at the cold-open**. This PR makes it work end-to-end. All findings are **measured on the VM** (2026-06-06), not guessed.

## Bug 1 — per-turn budget (backend never seated a PC)
The per-DM-turn cap defaulted to the Sonnet-tuned **\$1.50**; the Opus cold-open world-build costs ~5× → the first turn tripped `error_max_budget_usd`, the backend never seated a PC (`failure_bucket=no_actor`, spend \$0).
- `scripts/play.sh` + `scripts/play_party.sh`: model-aware per-turn + session budget defaults (opus → \$12 / \$30; sonnet unchanged \$1.50 / \$15).
- `qa/ui_playtest_app.sh`: the claude lane pinned `CLAWDND_PLAY_BUDGET=\$1.50` unconditionally → scale it to `DM_MODEL`.

## Bug 2 — cold-open latency (timed out before writing narration)
With the budget fixed, the Opus **`--effort max`** cold-open is generation-bound and **never finished <400s** — the turn was killed before writing narration, the harness grace-proceeded into an empty scene, and the timeout-retry minted a second campaign (the #640 condition).
**Measured:** Opus **`--effort high`** finishes **~300s** with a full, BG-caliber opening (*"the lamps of Sorcerous Sundries burn low and blue… Ramazith's old tower"*), cost \$2.36, **1 clean campaign**.
- `qa/lib_beat_driver.sh`: cold-open effort model-aware (opus → **high**, sonnet → max); cold-open timeout model-aware (opus → **500s**, sonnet → 400s). Routine tier unchanged (medium / 200s).
- `qa/ui_playtest_app.sh`: the part-B player-ready narration-wait is now env-configurable and **defaults longer for an Opus DM**, so QA waits for the ~300s opening instead of grace-proceeding.

## Guards (Tier-0, CI-covered)
- `servers/engine/tests/test_dm_budget_scaling.py` (3) + `servers/engine/tests/test_opus_coldopen_tuning.py` (3) — 6 assertions, pass locally.

## Validation
Cold-open proven (above). Full narrative-persona session at Opus + high-cold-open + medium-routine + lean in flight (sat / give-up / arc / story).