### PR TITLE
fix: scale remaining Opus budget caps (combat-sprint + ui_playtest + run_party)

### DIFF
--- a/qa/run_combat_sprint.sh
+++ b/qa/run_combat_sprint.sh
@@ -17,6 +17,10 @@ cd "$ROOT" || exit 1
 
 RUN="${1:-cs-$(date +%H%M%S)}"
 CLAWDND_DM_MODEL="$(worldos_env DM_MODEL opus)"
+# Combat runs the whole multi-round fight on ONE budget (pre-seeded, no cold-open). An Opus combat
+# costs ~5x a Sonnet one, so the Sonnet-tuned $1.50 cap cut it off mid-fight (observed 2026-06-06:
+# error_max_budget_usd at num_turns=26 / mid-Round 2 -> low coverage, mech 3.1). Scale to the model.
+case "$CLAWDND_DM_MODEL" in *opus*) CS_BUDGET="${CLAWDND_PLAY_BUDGET:-5.00}" ;; *) CS_BUDGET="${CLAWDND_PLAY_BUDGET:-1.50}" ;; esac
 T="$ROOT/qa/transcripts"
 STATE_DIR="$ROOT/qa/state/$RUN"
 mkdir -p "$T" "$STATE_DIR"
@@ -74,7 +78,7 @@ claude -p "$PROMPT" \
   --mcp-config "$DM_CFG" --strict-mcp-config \
   --model "$CLAWDND_DM_MODEL" \
   --permission-mode bypassPermissions \
-  --max-budget-usd 1.50 \
+  --max-budget-usd "$CS_BUDGET" \
   --output-format stream-json --verbose \
   > "$T/$RUN.jsonl" 2>"$T/$RUN.err"
 echo "[cs] play exit=$? ($(wc -l < "$T/$RUN.jsonl") events)"

--- a/qa/run_party.sh
+++ b/qa/run_party.sh
@@ -57,6 +57,9 @@ MAX_TURNS="${CLAWDND_PARTY_MAX_TURNS:-60}"               # hard agent-turn cap (
 # adherence lever (decision §3); the actor model drives the player/companion facade agents.
 CLAWDND_DM_MODEL="$(worldos_env DM_MODEL opus)"
 CLAWDND_ACTOR_MODEL="$(worldos_env ACTOR_MODEL sonnet)"
+# Opus needs more than the Sonnet-tuned $0.80 per-call cap (the DM cold-open alone is ~$2.4); floor it
+# for an Opus DM so the cold-open lands. CAP, not spend; the Sonnet companion facade spends far less.
+case "$CLAWDND_DM_MODEL" in *opus*) if awk "BEGIN{exit !($BUDGET < 4.0)}"; then BUDGET=4.00; fi ;; esac
 T="qa/transcripts"; STATE_DIR="$ROOT/qa/state/$RUN"
 mkdir -p "$T" "$STATE_DIR"; rm -rf "$STATE_DIR/campaigns" 2>/dev/null
 

--- a/qa/ui_playtest.sh
+++ b/qa/ui_playtest.sh
@@ -36,7 +36,10 @@ PW_DIR="$ROOT/qa/playwright"
 PW_CHANNEL="$(worldos_env UIPT_CHANNEL "")"   # "" = bundled chromium; "chrome" = system Chrome
 DM_MODEL="$(worldos_env DM_MODEL opus)"
 PLAYER_MODEL="$(worldos_env UIPT_PLAYER_MODEL sonnet)"
-DM_BUDGET="$(worldos_env UIPT_DM_BUDGET 1.50)"        # per DM turn
+# Per-DM-turn budget scales to the model: the Opus cold-open world-build needs ~$12; the Sonnet-tuned
+# $1.50 cap trips error_max_budget_usd on the Opus cold-open (the PC never seats). Sonnet unchanged.
+case "$DM_MODEL" in *opus*) _uipt_dm_def=12.00 ;; *) _uipt_dm_def=1.50 ;; esac
+DM_BUDGET="$(worldos_env UIPT_DM_BUDGET "$_uipt_dm_def")"        # per DM turn (model-aware)
 PERSONA_FILE="$ROOT/qa/play_player_browser_${PERSONA}.txt"
 
 [ -f "$PERSONA_FILE" ] || { echo "[uipt] no persona brief at $PERSONA_FILE" >&2; exit 2; }

--- a/servers/engine/tests/test_dm_budget_scaling.py
+++ b/servers/engine/tests/test_dm_budget_scaling.py
@@ -79,6 +79,15 @@ class DmBudgetScalingTests(unittest.TestCase):
         self.assertRegex(src, r"CS_BUDGET=\"\$\{CLAWDND_PLAY_BUDGET:-5\.00\}\"", "Opus combat budget must be >= $5")
         self.assertIn('--max-budget-usd "$CS_BUDGET"', src, "must consume the model-aware combat budget")
 
+    def test_auxiliary_harnesses_scale_budget_to_model(self):
+        """ui_playtest.sh (per-DM-turn) + run_party.sh (per-call) must scale their Opus budgets too."""
+        uipt = self._read("qa/ui_playtest.sh")
+        self.assertIn("*opus*)", uipt, "ui_playtest must branch the DM budget on an opus model")
+        self.assertRegex(uipt, r"_uipt_dm_def=12\.00", "ui_playtest Opus per-DM-turn default must be >= $12")
+        party = self._read("qa/run_party.sh")
+        self.assertIn("*opus*)", party, "run_party must branch/floor the per-call budget on an opus model")
+        self.assertRegex(party, r"BUDGET=4\.00", "run_party must floor the Opus per-call budget")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/servers/engine/tests/test_dm_budget_scaling.py
+++ b/servers/engine/tests/test_dm_budget_scaling.py
@@ -70,6 +70,15 @@ class DmBudgetScalingTests(unittest.TestCase):
         self.assertIn("*opus*)", src, "run_duo must branch the per-turn budget on an opus model")
         self.assertRegex(src, r"BUDGET=4\.00", "run_duo must floor the Opus per-turn budget >= the cold-open cost")
 
+    def test_combat_sprint_scales_budget_to_model(self):
+        """run_combat_sprint runs the whole multi-round fight on ONE budget (no cold-open); the Opus
+        combat needs >$1.50 (observed: error_max_budget_usd mid-Round 2 cut coverage and the mech score).
+        """
+        src = self._read("qa/run_combat_sprint.sh")
+        self.assertIn("*opus*)", src, "run_combat_sprint must branch the combat budget on an opus model")
+        self.assertRegex(src, r"CS_BUDGET=\"\$\{CLAWDND_PLAY_BUDGET:-5\.00\}\"", "Opus combat budget must be >= $5")
+        self.assertIn('--max-budget-usd "$CS_BUDGET"', src, "must consume the model-aware combat budget")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A staged single-test de-risk (your suggestion — test the most-affected gate before a full sweep) ran the Opus combat-sprint and found the **5th instance** of #682's Opus-budget pattern: `run_combat_sprint.sh` capped the DM at the Sonnet-tuned **\$1.50**, so the Opus combat tripped `error_max_budget_usd` at num_turns=26 / **mid-Round 2** (cost \$1.54) — cutting combat coverage short and producing an artifact mech read of 3.1 (the 5e mechanics that *did* run were behavioral-GREEN).

A follow-up budget audit found two more Opus-facing harnesses still Sonnet-tuned. All fixed model-aware (caps, not spends):
- `qa/run_combat_sprint.sh`: per-fight budget \$1.50 → \$5 for opus.
- `qa/ui_playtest.sh`: per-DM-turn \$1.50 → \$12 for opus.
- `qa/run_party.sh`: per-call \$0.80 → \$4 floor for opus.
- `servers/engine/tests/test_dm_budget_scaling.py`: guards for all three (6 assertions total).

Sweep-path harnesses (ui_playtest_app + run_duo) were already fixed in #684. dryrun_*.sh / score.sh / play_human.sh are pinned Sonnet (correct). This closes the Opus-budget-cap class so no future Opus run is wasted by a mid-run cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new tests to validate budget scaling behavior in QA harnesses across different model configurations.

* **Chores**
  * Updated QA test scripts to dynamically allocate resources based on the selected model, with higher budgets for premium model variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->