### PR TITLE
fix(codex-lane): version-skew fixes (unbound var + removed codex-cli flags)

### DIFF
--- a/scripts/play_codex_actor.sh
+++ b/scripts/play_codex_actor.sh
@@ -214,8 +214,6 @@ export CLAWDND_ACTOR_ID="${CLAWDND_ACTOR_ID:-}"
 export CLAWDND_ACTOR_ROLE="${CLAWDND_ACTOR_ROLE:-player}"
 
 codex exec \
-  --ignore-user-config \
-  --ignore-rules \
   --sandbox read-only \
   --json \
   ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} \

--- a/scripts/play_codex_dm.sh
+++ b/scripts/play_codex_dm.sh
@@ -436,8 +436,6 @@ codex_dm_turn() {
   : > "$LAST_MESSAGE"
   local status=0
   codex exec \
-    --ignore-user-config \
-    --ignore-rules \
     --sandbox read-only \
     --json \
     ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} \

--- a/scripts/play_codex_dm.sh
+++ b/scripts/play_codex_dm.sh
@@ -497,6 +497,7 @@ choose_move_progress_text() {
   local count="${#MOVE_PROGRESS_TEXTS[@]}"
   printf '%s\n' "${MOVE_PROGRESS_TEXTS[$((idx % count))]}"
 }
+CLAWDND_PLAY_COMPANIONS="${CLAWDND_PLAY_COMPANIONS:-}"   # default empty — the codex/solo lane (ui_playtest_app) doesn't set it; set -u would otherwise abort
 if [ -n "${CLAWDND_PLAY_COMPANIONS//[[:space:]]/}" ]; then
   COMPANION_TOOL_RULE="Companion rule: only add companions named by CLAWDND_PLAY_COMPANIONS (${CLAWDND_PLAY_COMPANIONS}). Do not add any other companion to the party."
 else


### PR DESCRIPTION
While smoking a GPT-DM baseline (codex lane), the de-risk found 3 issues; fixed the 2 code bugs:
1. \`play_codex_dm.sh:500\` — \`\${CLAWDND_PLAY_COMPANIONS//…}\` on an **unset** var tripped \`set -u\` (the codex/solo lane doesn't set it) → backend exited before the first DM turn. Defaulted to empty.
2. \`play_codex_dm.sh\` + \`play_codex_actor.sh\` — \`codex exec\` used \`--ignore-user-config\` / \`--ignore-rules\`, **removed in codex-cli 0.120.0** → usage printed, opening turn failed. Dropped them (the \`-c mcp_servers\` overrides still wire clawdnd-engine/rules; the host has no \`~/.codex/config.toml\`).

**3rd issue (NOT a code bug, environment):** codex authenticates **directly to OpenAI** (\`401 wss://api.openai.com\`, "Not logged in"); our GPT tokens are **OpenClaw-gateway-only**. So the codex lane is auth-blocked on this host — a GPT DM should run via the **gateway** (\`openclaw agent\`, like the working scorer), which needs a configured \`clawdnd-qa-dm\` agent (SKILL as instructions + engine MCP) to avoid the per-message SKILL E2BIG. Separate work.