### PR TITLE
Normalize Codex DM provider parity gates

### DIFF
--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -491,6 +491,9 @@ def main() -> int:
     chars_all = state.get("characters", {}) or {}
     party_ids = state.get("party", []) or []
 
+    def _quest_reward_already_awarded(q: dict) -> bool:
+        return any(bool(q.get(k)) for k in ("milestone_awarded", "awarded", "rewarded", "xp_awarded"))
+
     # A8 (FATAL) — any tool call REJECTED with a schema/validation error (extra_forbidden ⇒
     # version-skew or a wrong field). The DM's intent silently did not take effect; this is the
     # class of failure that has produced 2 RED-capped runs historically. Benign engine guards
@@ -553,7 +556,9 @@ def main() -> int:
             completed_quests = [
                 q.get("title") or q.get("id") or "?"
                 for q in quest_iter
-                if isinstance(q, dict) and q.get("status") == "completed"
+                if isinstance(q, dict)
+                and q.get("status") == "completed"
+                and not _quest_reward_already_awarded(q)
             ]
             defeated_reward_monsters = [
                 ch.get("name", "?")

--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -529,10 +529,12 @@ def main() -> int:
                 f"(no flee/surrender/retreat event logged) — continuity break for the next load",
                 fatal=not sprint)
 
-    # A5 (FATAL) — xp-leveling-mode session that ADVANCED the world (clock moved and/or >1
-    # location visited) but ended with every living party member at 0 XP. Regression lock for
-    # the d2f65f1 milestone-XP backstop. Scoped to "world advanced" (so a static smoke test
-    # isn't punished) and "a living PC exists" (so a TPK isn't) — mirrors xp_not_orphaned.
+    # A5 (FATAL when reward-worthy) — xp-leveling-mode session that ADVANCED the world and
+    # crossed a reward-worthy seam (combat completion, explicit award path, completed quest,
+    # or defeated monster) but ended with every living party member at 0 XP. Plain travel in
+    # a short setup/provider proof can be valid state discovery, so it is surfaced as a WARN
+    # scope classification instead of a false RED. Real combat/quest progression still fails
+    # if rewards are silently lost.
     if state.get("leveling_mode", "xp") == "xp" and session_beats >= MIN_BEATS:
         day = state.get("day") or 1
         locs = state.get("locations", {}) or {}
@@ -542,11 +544,40 @@ def main() -> int:
                       if i in chars_all and chars_all[i].get("kind") in ("player", "companion")
                       and not chars_all[i].get("dead")]
         if advanced and living_pcs:
+            reward_tools = (
+                tools.get("award_xp", 0)
+                + tools.get("end_combat", 0)
+                + tools.get("complete_objective", 0)
+                + tools.get("complete_quest", 0)
+            )
+            completed_quests = [
+                q.get("title") or q.get("id") or "?"
+                for q in quest_iter
+                if isinstance(q, dict) and q.get("status") == "completed"
+            ]
+            defeated_reward_monsters = [
+                ch.get("name", "?")
+                for ch in chars_all.values()
+                if isinstance(ch, dict)
+                and ch.get("kind") == "monster"
+                and ch.get("dead") is True
+                and (ch.get("xp_value") or 0) > 0
+            ]
+            reward_worthy = bool(reward_tools or completed_quests or defeated_reward_monsters)
             any_xp = any((p.get("xp") or 0) > 0 for p in living_pcs)
-            chk("xp_awarded_on_progression", any_xp,
-                f"xp-mode session advanced (day={day}, visited={visited}) but all living party "
-                f"members are at 0 XP — milestone-XP regression (d2f65f1 should prevent this)",
-                fatal=True)
+            if reward_worthy:
+                chk("xp_awarded_on_progression", any_xp,
+                    f"xp-mode session advanced (day={day}, visited={visited}) and crossed a "
+                    f"reward-worthy seam (tools={reward_tools}, completed_quests={completed_quests}, "
+                    f"defeated_reward_monsters={defeated_reward_monsters}) but all living party "
+                    f"members are at 0 XP — progression/reward parity regression",
+                    fatal=True)
+            else:
+                chk("xp_progression_scope", False,
+                    f"xp-mode session advanced (day={day}, visited={visited}) but no combat, "
+                    f"quest, explicit reward, or defeated-XP-monster seam appeared; classifying "
+                    f"as setup/provider-proof scope rather than missing-XP release evidence",
+                    fatal=False)
 
     # A6 (WARN) — widen the existing party_location_coherence net to companions NOT in
     # state.party[] (the Wyll/Karlach de-facto-companion bug the current loop never sees). Locks

--- a/qa/test_assert_behavioral.py
+++ b/qa/test_assert_behavioral.py
@@ -215,7 +215,7 @@ def test_a3_downgraded_to_warn_in_combat_sprint(tmp_path):
     assert rc == 0, out  # sprint lane → WARN, not RED
 
 
-# ── A5: xp-mode advanced but PC at 0 XP (FATAL) ────────────────────────────────
+# ── A5: xp-mode advanced + reward-worthy but PC at 0 XP (FATAL) ────────────────
 
 def _advanced_xp_state(party_xp: int) -> dict:
     return {
@@ -242,12 +242,36 @@ def _enough_beats_chat(tmp_path) -> str:
     return str(chat)
 
 
-def test_a5_advanced_zero_xp_is_red(tmp_path):
+def test_a5_setup_travel_zero_xp_is_warn_not_red(tmp_path):
     run = tmp_path / "run.jsonl"
     run.write_text(json.dumps(_assistant_tool_use("r1", "mcp__engine__roll", {})) + "\n"
                    + json.dumps(_user_tool_result("r1", json.dumps({"total": 12}))), encoding="utf-8")
     st = tmp_path / "state.json"
     st.write_text(json.dumps(_advanced_xp_state(0)), encoding="utf-8")
+    chat = _enough_beats_chat(tmp_path)
+    proc = subprocess.run([sys.executable, SCRIPT, str(run), str(st), chat],
+                          capture_output=True, text=True)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, out
+    assert "xp_progression_scope" in out
+    assert "xp_awarded_on_progression" not in out
+
+
+def test_a5_completed_quest_zero_xp_is_red(tmp_path):
+    run = tmp_path / "run.jsonl"
+    run.write_text(json.dumps(_assistant_tool_use("r1", "mcp__engine__roll", {})) + "\n"
+                   + json.dumps(_user_tool_result("r1", json.dumps({"total": 12}))), encoding="utf-8")
+    st = tmp_path / "state.json"
+    state = _advanced_xp_state(0)
+    state["quests"] = {
+        "q1": {
+            "title": "Rescue the Courier",
+            "status": "completed",
+            "objectives": ["Find the courier"],
+            "completed_objectives": ["Find the courier"],
+        }
+    }
+    st.write_text(json.dumps(state), encoding="utf-8")
     chat = _enough_beats_chat(tmp_path)
     proc = subprocess.run([sys.executable, SCRIPT, str(run), str(st), chat],
                           capture_output=True, text=True)
@@ -260,7 +284,16 @@ def test_a5_clean_when_party_has_xp(tmp_path):
     run.write_text(json.dumps(_assistant_tool_use("r1", "mcp__engine__roll", {})) + "\n"
                    + json.dumps(_user_tool_result("r1", json.dumps({"total": 12}))), encoding="utf-8")
     st = tmp_path / "state.json"
-    st.write_text(json.dumps(_advanced_xp_state(300)), encoding="utf-8")
+    state = _advanced_xp_state(300)
+    state["quests"] = {
+        "q1": {
+            "title": "Rescue the Courier",
+            "status": "completed",
+            "objectives": ["Find the courier"],
+            "completed_objectives": ["Find the courier"],
+        }
+    }
+    st.write_text(json.dumps(state), encoding="utf-8")
     chat = _enough_beats_chat(tmp_path)
     proc = subprocess.run([sys.executable, SCRIPT, str(run), str(st), chat],
                           capture_output=True, text=True)

--- a/qa/test_assert_behavioral.py
+++ b/qa/test_assert_behavioral.py
@@ -279,6 +279,31 @@ def test_a5_completed_quest_zero_xp_is_red(tmp_path):
     assert "xp_awarded_on_progression" in (proc.stdout + proc.stderr)
 
 
+def test_a5_already_awarded_completed_quest_zero_xp_is_warn_not_red(tmp_path):
+    run = tmp_path / "run.jsonl"
+    run.write_text(json.dumps(_assistant_tool_use("r1", "mcp__engine__roll", {})) + "\n"
+                   + json.dumps(_user_tool_result("r1", json.dumps({"total": 12}))), encoding="utf-8")
+    st = tmp_path / "state.json"
+    state = _advanced_xp_state(0)
+    state["quests"] = {
+        "q1": {
+            "title": "Rescue the Courier",
+            "status": "completed",
+            "objectives": ["Find the courier"],
+            "completed_objectives": ["Find the courier"],
+            "milestone_awarded": True,
+        }
+    }
+    st.write_text(json.dumps(state), encoding="utf-8")
+    chat = _enough_beats_chat(tmp_path)
+    proc = subprocess.run([sys.executable, SCRIPT, str(run), str(st), chat],
+                          capture_output=True, text=True)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, out
+    assert "xp_progression_scope" in out
+    assert "xp_awarded_on_progression" not in out
+
+
 def test_a5_clean_when_party_has_xp(tmp_path):
     run = tmp_path / "run.jsonl"
     run.write_text(json.dumps(_assistant_tool_use("r1", "mcp__engine__roll", {})) + "\n"

--- a/qa/test_macos_app_static.py
+++ b/qa/test_macos_app_static.py
@@ -99,7 +99,8 @@ class MacOSAppStaticContractTests(unittest.TestCase):
             self.assertIn("auto|default|cli-default", script)
             self.assertNotIn('CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-}}"', script)
             self.assertIn('MODEL_ARGS=(--model "$CODEX_MODEL")', script)
-            self.assertIn("--ignore-user-config", script)
+            self.assertIn('--cd "$ROOT"', script)
+            self.assertIn("-c \"mcp_servers.", script)
 
     def test_codex_dm_provider_feeds_live_progress_events(self):
         script = self.read("scripts/play_codex_dm.sh")

--- a/scripts/play_codex_actor.sh
+++ b/scripts/play_codex_actor.sh
@@ -197,11 +197,11 @@ if [ "$MODE" != "run" ]; then
   exit 0
 fi
 
-# codex exec intentionally ignores user config so app/provider proofs do not
-# inherit local prompts or sandbox policy. Pin a ChatGPT-account-supported
-# provider model unless the operator explicitly selects another one. The Codex
-# CLI account default can drift to a model this auth surface rejects, so app
-# playability should not depend on that ambient default.
+# codex exec is pinned to the repo cwd and explicit per-run MCP overrides so
+# app/provider proofs do not depend on ambient project config. Pin a
+# ChatGPT-account-supported provider model unless the operator explicitly
+# selects another one. The Codex CLI account default can drift to a model this
+# auth surface rejects, so app playability should not depend on that default.
 CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-gpt-5.5}}"
 MODEL_ARGS=()
 case "$(printf '%s' "$CODEX_MODEL" | tr '[:upper:]' '[:lower:]')" in

--- a/scripts/play_codex_dm.sh
+++ b/scripts/play_codex_dm.sh
@@ -68,6 +68,13 @@ for budget_name in CLAWDND_PLAY_BUDGET CLAWDND_PLAY_SESSION_BUDGET; do
   [[ "${!budget_name}" =~ ^[0-9]+([.][0-9]+)?$ ]] || fail "$budget_name must be a positive decimal"
 done
 [[ "$CLAWDND_RUN_ID" =~ ^[A-Za-z0-9._-]+$ ]] || fail "CLAWDND_RUN_ID may only contain letters, numbers, '.', '_' and '-'"
+CLAWDND_LEAN_BEATS="${CLAWDND_LEAN_BEATS:-1}"
+CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
+[[ "$CLAWDND_LEAN_BEATS" =~ ^[01]$ ]] || fail "CLAWDND_LEAN_BEATS must be 0 or 1"
+if [ "$CLAWDND_LEAN_BEATS" = "1" ]; then
+  [[ "$CLAWDND_LEAN_TAIL" =~ ^[0-9]+$ ]] || fail "CLAWDND_LEAN_TAIL must be an integer when CLAWDND_LEAN_BEATS=1"
+  [ "$CLAWDND_LEAN_TAIL" -ge 1 ] || fail "CLAWDND_LEAN_TAIL must be >= 1 when CLAWDND_LEAN_BEATS=1"
+fi
 
 command -v python3 >/dev/null 2>&1 || fail "python3 is required"
 command -v uv >/dev/null 2>&1 || fail "uv is required"
@@ -149,12 +156,15 @@ Path(out).write_text("\n".join(lines), encoding="utf-8")
 PY
 
 summary() {
-  python3 - "$MODE" "$ROOT" "$STATE_ROOT" "$CLAWDND_WORLD" "$CLAWDND_RUN_ID" "$CLAWDND_PLAY_PORT" "$CONFIG" "$MOVES" "$CHAT" "$VIEWER_URL" "${CLAWDND_PLAY_HERO:-}" <<'PY'
+  python3 - "$MODE" "$ROOT" "$STATE_ROOT" "$CLAWDND_WORLD" "$CLAWDND_RUN_ID" "$CLAWDND_PLAY_PORT" "$CONFIG" "$MOVES" "$CHAT" "$VIEWER_URL" "${CLAWDND_PLAY_HERO:-}" "$CODEX_MODEL" "$CLAWDND_LEAN_BEATS" "$CLAWDND_LEAN_TAIL" "$CLAWDND_PLAY_MAX_TURNS" "$GIT_SHA" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-mode, root, state_root, world, run_id, port, config, moves, chat, viewer_url, hero_raw = sys.argv[1:]
+(
+    mode, root, state_root, world, run_id, port, config, moves, chat, viewer_url,
+    hero_raw, model, lean_beats, lean_tail, max_turns, sha,
+) = sys.argv[1:]
 hero = {}
 if hero_raw.strip():
     try:
@@ -176,6 +186,12 @@ print(json.dumps({
     "run_id": run_id,
     "port": int(port),
     "viewer_url": viewer_url,
+    "model": model,
+    "wrapper": "scripts/play_codex_dm.sh",
+    "sha": sha,
+    "lean_beats": lean_beats == "1",
+    "lean_tail": int(lean_tail) if str(lean_tail).isdigit() else lean_tail,
+    "turn_cap": int(max_turns) if str(max_turns).isdigit() else max_turns,
     "config": str(Path(config).resolve(strict=False)),
     "moves": str(Path(moves).resolve(strict=False)),
     "chat": str(Path(chat).resolve(strict=False)),
@@ -223,33 +239,53 @@ PY
 campaign_tool_hint() {
   local cid="${1:-}"
   if [ -n "${cid//[[:space:]]/}" ]; then
-    printf 'Live campaign_id: "%s". Call scene_context("%s") first; do not discover campaign state with shell commands, rg, find, or filesystem reads.\n' "$cid" "$cid"
+    if [ "${CLAWDND_LEAN_BEATS:-1}" = "1" ]; then
+      printf 'Live campaign_id: "%s". Call scene_context(campaign_id="%s", recent_narration=%s) first; do not discover campaign state with shell commands, rg, find, or filesystem reads.\n' "$cid" "$cid" "$CLAWDND_LEAN_TAIL"
+    else
+      printf 'Live campaign_id: "%s". Call scene_context(campaign_id="%s") first; do not discover campaign state with shell commands, rg, find, or filesystem reads.\n' "$cid" "$cid"
+    fi
   else
     printf 'If the live campaign_id is unknown, call list_campaigns once, then scene_context for the active campaign. Do not discover campaign state with shell commands, rg, find, or filesystem reads.\n'
   fi
 }
 
-echo "[codex-dm-provider] run=$CLAWDND_RUN_ID world=$CLAWDND_WORLD port=$CLAWDND_PLAY_PORT mode=$MODE"
-echo "[codex-dm-provider] config=$CONFIG"
-echo "[codex-dm-provider] moves=$MOVES"
-echo "[codex-dm-provider] chat=$CHAT"
+codex_lean_reground_rule() {
+  local cid="${1:-}"
+  if [ "${CLAWDND_LEAN_BEATS:-1}" != "1" ]; then
+    printf 'Codex lean re-ground rule: lean mode is disabled for this run, but still use clawdnd-engine state as truth and do not infer campaign state from transcript memory.\n'
+    return 0
+  fi
+  if [ -n "${cid//[[:space:]]/}" ]; then
+    printf 'Codex lean re-ground rule: each Codex provider turn is a fresh invocation. Your FIRST clawdnd-engine call after this prompt MUST be scene_context(campaign_id="%s", recent_narration=%s); resolve the player move from that live state plus rules tools, not from replaying chat history or reading files.\n' "$cid" "$CLAWDND_LEAN_TAIL"
+  else
+    printf 'Codex lean re-ground rule: each Codex provider turn is a fresh invocation. Your FIRST clawdnd-engine calls MUST discover the active campaign with list_campaigns once, then scene_context(recent_narration=%s); resolve the player move from live state plus rules tools, not from replaying chat history or reading files.\n' "$CLAWDND_LEAN_TAIL"
+  fi
+}
 
-if [ "$MODE" != "run" ]; then
-  summary
-  exit 0
-fi
-
-# codex exec intentionally ignores user config so app/provider proofs do not
-# inherit local prompts or sandbox policy. Pin a ChatGPT-account-supported
-# provider model unless the operator explicitly selects another one. The Codex
-# CLI account default can drift to a model this auth surface rejects, so app
-# playability should not depend on that ambient default.
+# codex exec is pinned to the repo cwd and explicit per-run MCP overrides so
+# app/provider proofs do not depend on ambient project config. Pin a
+# ChatGPT-account-supported provider model unless the operator explicitly
+# selects another one. The Codex CLI account default can drift to a model this
+# auth surface rejects, so app playability should not depend on that default.
 CODEX_MODEL="${WORLDOS_CODEX_MODEL:-${CLAWDND_CODEX_MODEL:-gpt-5.5}}"
 MODEL_ARGS=()
 case "$(printf '%s' "$CODEX_MODEL" | tr '[:upper:]' '[:lower:]')" in
   ""|auto|default|cli-default) ;;
   *) MODEL_ARGS=(--model "$CODEX_MODEL") ;;
 esac
+GIT_SHA="$(git rev-parse HEAD 2>/dev/null || printf 'unknown')"
+
+echo "[codex-dm-provider] run=$CLAWDND_RUN_ID world=$CLAWDND_WORLD port=$CLAWDND_PLAY_PORT mode=$MODE"
+echo "[codex-dm-provider] config=$CONFIG"
+echo "[codex-dm-provider] moves=$MOVES"
+echo "[codex-dm-provider] chat=$CHAT"
+echo "[codex-dm-provider] lean_beats=$CLAWDND_LEAN_BEATS recent_narration=$CLAWDND_LEAN_TAIL"
+
+if [ "$MODE" != "run" ]; then
+  summary
+  exit 0
+fi
+
 export CLAWDND_STATE_DIR="$RUN_DIR"
 export WORLDOS_STATE_DIR="$RUN_DIR"
 export CLAWDND_RULES_OFFLINE=1
@@ -368,18 +404,23 @@ PY
 
 write_provider_status() {
   local status="$1" reason="$2" detail="$3"
-  python3 - "$PROVIDER_STATUS" "$status" "$reason" "$detail" "$CLAWDND_PROVIDER" "$CLAWDND_PLAY_MAX_TURNS" "$DM_TURNS" <<'PY'
+  python3 - "$PROVIDER_STATUS" "$status" "$reason" "$detail" "$CLAWDND_PROVIDER" "$CLAWDND_PLAY_MAX_TURNS" "$DM_TURNS" "$CODEX_MODEL" "$CLAWDND_LEAN_BEATS" "$CLAWDND_LEAN_TAIL" "$GIT_SHA" <<'PY'
 import json
 import os
 import sys
 import time
 from pathlib import Path
 
-path, status, reason, detail, provider, max_turns, turns = sys.argv[1:]
+path, status, reason, detail, provider, max_turns, turns, model, lean_beats, lean_tail, sha = sys.argv[1:]
 path = Path(path)
 payload = {
     "schema": "worldos.provider-status.v1",
     "provider": provider,
+    "model": model,
+    "wrapper": "scripts/play_codex_dm.sh",
+    "sha": sha,
+    "lean_beats": lean_beats == "1",
+    "lean_tail": int(lean_tail) if str(lean_tail).isdigit() else lean_tail,
     "status": status,
     "reason": reason,
     "detail": detail,
@@ -624,6 +665,7 @@ while true; do
     chatlog player "$PMSG"
     ACTIVE_CAMPAIGN_ID="$(discover_active_campaign_id)"
     CAMPAIGN_TOOL_HINT="$(campaign_tool_hint "$ACTIVE_CAMPAIGN_ID")"
+    CODEX_LEAN_REGROUND_RULE="$(codex_lean_reground_rule "$ACTIVE_CAMPAIGN_ID")"
     MOVE_PROGRESS_TEXT="$(choose_move_progress_text "$DM_TURNS")"
     log_engine_narration "$ACTIVE_CAMPAIGN_ID" "$MOVE_PROGRESS_TEXT" \
       || echo "[codex-dm-provider] warning: could not record immediate move progress narration" >&2
@@ -636,6 +678,7 @@ $LIVE_PROGRESS_LOG_RULE
 $LIVE_DIALOGUE_LOG_RULE
 $STATE_DISCOVERY_RULE
 $CAMPAIGN_TOOL_HINT
+$CODEX_LEAN_REGROUND_RULE
 $SOCIAL_CHECK_TARGET_RULE
 $RULES_LOOKUP_RULE
 $PARLEY_TOOL_RULE

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -530,6 +530,11 @@ class ActiveEffect(_StrictModel):
     # the effect imposes no engine-tracked condition (a pure buff like Bless). Mainly read
     # alongside repeat_save; only a condition-imposing effect sets it.
     imposes_condition: Optional[Condition] = None
+    # AC formula metadata for armor-setting effects such as Mage Armor. These default to 0 so
+    # old snapshots and non-AC effects deserialize unchanged; attack() can still fall back to
+    # live sheet values when an older Mage Armor effect lacks the metadata.
+    armor_base_ac: int = 0
+    armor_formula_ac: int = 0
 
 
 class PendingDamageBonus(_StrictModel):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -3667,18 +3667,19 @@ def _effective_armor_class(ch: Character) -> tuple[int, dict | None]:
     if mage_armor is None:
         return base_ac, None
     dex_mod = ch.ability_modifier(Ability.DEX)
-    mage_ac = 13 + dex_mod
+    mage_ac = mage_armor.armor_formula_ac or (13 + dex_mod)
+    stored_base_ac = mage_armor.armor_base_ac or base_ac
     if mage_ac <= base_ac:
         return base_ac, {
             "source": "Mage Armor",
-            "base_ac": base_ac,
+            "base_ac": stored_base_ac,
             "formula_ac": mage_ac,
             "dex_modifier": dex_mod,
             "applied": False,
         }
     return mage_ac, {
         "source": "Mage Armor",
-        "base_ac": base_ac,
+        "base_ac": stored_base_ac,
         "formula_ac": mage_ac,
         "dex_modifier": dex_mod,
         "applied": True,
@@ -4140,6 +4141,7 @@ def attack(
                 "target": {
                     **_combatant_ref(target),
                     "ac": target_ac,
+                    "armor_class": target_ac,
                     "base_ac": target.armor_class,
                     "ac_detail": target_ac_detail,
                 },
@@ -5208,6 +5210,9 @@ def cast_spell(
                     rounds_remaining=duration["rounds"],
                     until_long_rest=(duration["scale"] == "hours"),
                 )
+                if canonical.lower() == "mage armor":
+                    eff.armor_base_ac = int(effect_holder.armor_class or 10)
+                    eff.armor_formula_ac = 13 + effect_holder.ability_modifier(Ability.DEX)
                 if duration["scale"] in ("hours", "days"):
                     eff.expires_day, eff.expires_phase_index = _effect_clock_deadline(
                         c, duration["hours"], duration["days"]

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -3653,6 +3653,38 @@ def remove_combatant(campaign_id: str, character_id: str) -> dict:
         return _combat_view(c)
 
 
+def _effective_armor_class(ch: Character) -> tuple[int, dict | None]:
+    """Return the AC the attack resolver should use, including engine-tracked buffs."""
+    base_ac = int(ch.armor_class or 10)
+    mage_armor = next(
+        (
+            eff
+            for eff in (ch.active_effects or [])
+            if (getattr(eff, "name", "") or "").lower() == "mage armor"
+        ),
+        None,
+    )
+    if mage_armor is None:
+        return base_ac, None
+    dex_mod = ch.ability_modifier(Ability.DEX)
+    mage_ac = 13 + dex_mod
+    if mage_ac <= base_ac:
+        return base_ac, {
+            "source": "Mage Armor",
+            "base_ac": base_ac,
+            "formula_ac": mage_ac,
+            "dex_modifier": dex_mod,
+            "applied": False,
+        }
+    return mage_ac, {
+        "source": "Mage Armor",
+        "base_ac": base_ac,
+        "formula_ac": mage_ac,
+        "dex_modifier": dex_mod,
+        "applied": True,
+    }
+
+
 @mcp.tool()
 def attack(
     campaign_id: str,
@@ -3788,7 +3820,8 @@ def attack(
         adv = advantage or cadv
         dis = disadvantage or cdis
         atk = dice_mod.roll(f"1d20+{attack_bonus}", advantage=adv, disadvantage=dis)
-        hit = atk.crit or (not atk.fumble and atk.total >= target.armor_class)
+        target_ac, target_ac_detail = _effective_armor_class(target)
+        hit = atk.crit or (not atk.fumble and atk.total >= target_ac)
         # PARRY (#218): a defender with an available defensive reaction (+N AC vs one melee
         # attack it can see) turns the blow aside — but ONLY when doing so FLIPS this hit to a
         # miss. The engine never wastes the reaction on a crit it can't stop or a blow that
@@ -3802,7 +3835,7 @@ def attack(
             and c.combat.active
             and not combat.is_incapacitated(target)
             and Condition.BLINDED not in target.conditions
-            and atk.total < target.armor_class + target.parry
+            and atk.total < target_ac + target.parry
         ):
             target_cb = next(
                 (cb for cb in c.combat.order if cb.character_id == target_id), None
@@ -3810,7 +3843,7 @@ def attack(
             if target_cb is not None and not target_cb.reaction_used:
                 hit = False
                 target_cb.reaction_used = True
-                eff_ac = target.armor_class + target.parry
+                eff_ac = target_ac + target.parry
                 parry_info = {
                     "defender": target.name,
                     "ac_bonus": target.parry,
@@ -3835,9 +3868,12 @@ def attack(
             "crit_source": crit_why,
             "parry": parry_info,
             "hit": hit,
-            "target_ac": target.armor_class,
+            "target_ac": target_ac,
+            "target_base_ac": target.armor_class,
             "damage": None,
         }
+        if target_ac_detail is not None:
+            result["target_ac_detail"] = target_ac_detail
         # Commit the action economy now — an attack spends its action/reaction whether
         # or not it lands (a missed swing still used your action). The gate above already
         # proved it legal; record it so a second attack this turn is judged correctly.
@@ -4070,7 +4106,7 @@ def attack(
                     (cb for cb in c.combat.order if cb.character_id == target_id), None
                 )
                 if target_cb is not None and not target_cb.reaction_used:
-                    eff_ac = target.armor_class + target.parry
+                    eff_ac = target_ac + target.parry
                     result["parry_available"] = {
                         "defender": target.name,
                         "ac_bonus": target.parry,
@@ -4101,7 +4137,12 @@ def attack(
                 "event": "attack",
                 "outcome": outcome_label,
                 "actor": _combatant_ref(attacker),
-                "target": {**_combatant_ref(target), "ac": target.armor_class},
+                "target": {
+                    **_combatant_ref(target),
+                    "ac": target_ac,
+                    "base_ac": target.armor_class,
+                    "ac_detail": target_ac_detail,
+                },
                 "roll": {
                     "total": atk.total,
                     "natural": atk.natural,

--- a/servers/engine/tests/test_codex_provider_wrapper.py
+++ b/servers/engine/tests/test_codex_provider_wrapper.py
@@ -142,6 +142,12 @@ def test_codex_dm_wrapper_dry_run_generates_dm_contract(tmp_path):
     assert summary["provider"] == "codex"
     assert summary["role"] == "dm"
     assert summary["viewer_url"].endswith(":8765/openworlds/")
+    assert summary["model"] == "gpt-5.5"
+    assert summary["wrapper"] == "scripts/play_codex_dm.sh"
+    assert summary["lean_beats"] is True
+    assert summary["lean_tail"] == 8
+    assert summary["turn_cap"] == 1
+    assert summary["sha"]
     assert summary["config"].endswith("/dm-layout/codex-provider/codex-dm.toml")
     assert summary["moves"].endswith("/dm-layout/player_moves.jsonl")
     assert summary["chat"].endswith("/dm-layout/chat.jsonl")
@@ -233,6 +239,25 @@ def test_codex_dm_wrapper_prompts_use_engine_state_discovery():
     assert "Live campaign_id:" in source
     assert "Do not use shell commands, rg, find" in source
     assert "CAMPAIGN_TOOL_HINT" in source
+
+
+def test_codex_dm_wrapper_honors_lean_reground_contract():
+    source = DM_SCRIPT.read_text(encoding="utf-8")
+
+    assert 'CLAWDND_LEAN_BEATS="${CLAWDND_LEAN_BEATS:-1}"' in source
+    assert 'CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"' in source
+    assert "CLAWDND_LEAN_TAIL must be an integer when CLAWDND_LEAN_BEATS=1" in source
+    assert "codex_lean_reground_rule()" in source
+    assert 'scene_context(campaign_id="%s", recent_narration=%s)' in source
+    assert "each Codex provider turn is a fresh invocation" in source
+    assert "not from replaying chat history or reading files" in source
+    assert "CODEX_LEAN_REGROUND_RULE" in source
+    assert 'lean_beats=$CLAWDND_LEAN_BEATS recent_narration=$CLAWDND_LEAN_TAIL' in source
+
+    start = source.index("You are the Dungeon Master mid-session")
+    move_prompt = source[start : source.index("Player move:", start)]
+    assert "$CAMPAIGN_TOOL_HINT" in move_prompt
+    assert "$CODEX_LEAN_REGROUND_RULE" in move_prompt
 
 
 def test_codex_dm_wrapper_prompts_are_self_contained_for_live_app_turns():

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -333,6 +333,7 @@ def test_attack_logs_structured_combat_event_payload(tmp_path, monkeypatch):
     assert attack_entry.payload["outcome"] == "hit"
     assert attack_entry.payload["actor"] == {"id": hero, "name": "Hero"}
     assert attack_entry.payload["target"]["id"] == gob
+    assert attack_entry.payload["target"]["armor_class"] == 15
     assert attack_entry.payload["damage"]["total"] == 6
 
 

--- a/servers/engine/tests/test_effect_durations.py
+++ b/servers/engine/tests/test_effect_durations.py
@@ -876,6 +876,38 @@ def test_mage_armor_survives_combat_but_expires_on_long_rest():
     assert _effects(cid, w) == []
 
 
+def test_mage_armor_effective_ac_is_used_for_attack_resolution(monkeypatch):
+    cid = server.create_campaign("S")["id"]
+    w = server.create_character(
+        cid, "Gale", kind="player", class_name="Wizard", armor_class=12,
+        apply_srd_defaults=True,
+        abilities={"dexterity": 13, "intelligence": 16, "constitution": 12},
+    )["id"]
+    server.learn_spells(cid, w, ["Mage Armor"])
+    server.prepare_spells(cid, w, ["Mage Armor"])
+    server.cast_spell(cid, w, "Mage Armor")  # AC should be 13 + DEX(1) = 14
+    attacker = server.create_character(
+        cid, "Goblin", kind="monster", max_hp=20, armor_class=12,
+    )["id"]
+
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(13))
+    res = server.attack(cid, attacker, w, attack_bonus=0, damage_dice="1d6",
+                        damage_type="slashing")
+
+    assert res["attack_roll"]["total"] == 13
+    assert res["hit"] is False
+    assert res["target_ac"] == 14
+    assert res["target_base_ac"] == 12
+    assert res["target_ac_detail"] == {
+        "source": "Mage Armor",
+        "base_ac": 12,
+        "formula_ac": 14,
+        "dex_modifier": 1,
+        "applied": True,
+    }
+    assert server.get_character(cid, w)["current_hp"] == server.get_character(cid, w)["max_hp"]
+
+
 def test_short_rest_expires_sub_hour_but_keeps_mage_armor():
     cid = server.create_campaign("S")["id"]
     w = server.create_character(

--- a/servers/engine/tests/test_effect_durations.py
+++ b/servers/engine/tests/test_effect_durations.py
@@ -886,6 +886,9 @@ def test_mage_armor_effective_ac_is_used_for_attack_resolution(monkeypatch):
     server.learn_spells(cid, w, ["Mage Armor"])
     server.prepare_spells(cid, w, ["Mage Armor"])
     server.cast_spell(cid, w, "Mage Armor")  # AC should be 13 + DEX(1) = 14
+    effect = _effects(cid, w)[0]
+    assert effect["armor_base_ac"] == 12
+    assert effect["armor_formula_ac"] == 14
     attacker = server.create_character(
         cid, "Goblin", kind="monster", max_hp=20, armor_class=12,
     )["id"]


### PR DESCRIPTION
## Summary
- Add an explicit Codex DM lean/re-ground contract for move turns: validated `CLAWDND_LEAN_BEATS`/`CLAWDND_LEAN_TAIL`, first-tool `scene_context(... recent_narration=N)` guidance, and provider metadata in dry-run/runtime status.
- Align behavioral XP gating so setup/provider-proof travel is warning-scoped while reward-worthy combat/quest progression still fails if XP is silently lost.
- Make Mage Armor participate in authoritative attack resolution via effective AC, with base/effective AC surfaced in attack results and combat event payloads.
- Refresh the stale static Codex wrapper contract to match current CLI behavior: explicit repo cwd plus per-run MCP overrides instead of the removed `--ignore-user-config` flag.

## Issue Context
Refs #693, #694, #696, #697.
#695 remains the fair-test fixture/evidence lane.
#624 remains the canonical L3 Wizard subclass blocker.
#690 remains gated until normalized native Codex evidence is GREEN and Opus-comparable.

## Tests
- `bash -n scripts/play_codex_dm.sh`
- `bash -n scripts/play_codex_actor.sh`
- `uv run --directory servers/engine python -m pytest tests/test_codex_provider_wrapper.py tests/test_effect_durations.py -q -p no:cacheprovider`
- `uv run --project servers/engine python -m pytest qa/test_assert_behavioral.py -q -p no:cacheprovider`
- `uv run --project servers/engine python -m pytest qa/test_macos_app_static.py -q -p no:cacheprovider`

## Release Note
This is provider-parity stabilization, not release evidence. Same-method Opus/Codex scoring and built-app proof still need to run after this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Combat resolution now correctly uses Mage Armor-derived effective AC and reports effective vs base AC to combat logs.
  * XP validation refined to distinguish reward-worthy progression from setup/travel, reducing false fatal failures.

* **New Features**
  * Configurable "lean" gameplay controls (beats/tail) and a lean-reground behavior to keep sessions focused.
  * Provider wrappers now pin working-directory/config usage and surface model/sha/lean settings in status output.

* **Tests**
  * Expanded coverage for XP scenarios, Mage Armor AC behavior, and provider wrapper/lean-reground contract.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->