### PR TITLE
Normalize Codex provider origin fixtures

### DIFF
--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -274,6 +274,11 @@ Fair-test shape:
 
 - DM provider: `CODEX_HOME=~/.codex-worldos-qa WORLDOS_CODEX_MODEL=gpt-5.5` or `gpt-5.4`
   through `scripts/play_codex_dm.sh`, which wires engine/rules/voice MCP per `codex exec -c`.
+- Fixture: use an explicit origin template, not a loose canon-name pickup, when comparing providers.
+  The Codex provider accepts `CLAWDND_PLAY_HERO='{"origin":"template:rolan-evoker"}'`
+  or `CLAWDND_PLAY_CANON_HERO=template:rolan-evoker`, seating `Rolan - Tiefling Evoker`
+  through the engine's `start_character(origin="template:rolan-evoker")` path so subclass,
+  level, ability scores, and spell list are preserved in evidence.
 - Player: Sonnet via the constrained `clawdnd-player` facade, using a combat-seeking persona
   when the question is mechanical viability.
 - Scoring: Sonnet `qa/score.sh` on Tolkien story and Angry-DM 5e fidelity, plus

--- a/scripts/play_codex_dm.sh
+++ b/scripts/play_codex_dm.sh
@@ -34,6 +34,7 @@ Required environment:
 Optional:
   CLAWDND_PLAY_COMPANIONS
   CLAWDND_PLAY_HERO
+  CLAWDND_PLAY_CANON_HERO (canon name, or origin spec such as template:rolan-evoker)
   WORLDOS_CODEX_MODEL (default: gpt-5.5; set to auto/default/cli-default to let Codex CLI choose)
   CLAWDND_CODEX_MODEL (legacy fallback)
   CLAWDND_STATE_ROOT
@@ -156,14 +157,14 @@ Path(out).write_text("\n".join(lines), encoding="utf-8")
 PY
 
 summary() {
-  python3 - "$MODE" "$ROOT" "$STATE_ROOT" "$CLAWDND_WORLD" "$CLAWDND_RUN_ID" "$CLAWDND_PLAY_PORT" "$CONFIG" "$MOVES" "$CHAT" "$VIEWER_URL" "${CLAWDND_PLAY_HERO:-}" "$CODEX_MODEL" "$CLAWDND_LEAN_BEATS" "$CLAWDND_LEAN_TAIL" "$CLAWDND_PLAY_MAX_TURNS" "$GIT_SHA" <<'PY'
+  python3 - "$MODE" "$ROOT" "$STATE_ROOT" "$CLAWDND_WORLD" "$CLAWDND_RUN_ID" "$CLAWDND_PLAY_PORT" "$CONFIG" "$MOVES" "$CHAT" "$VIEWER_URL" "${CLAWDND_PLAY_HERO:-}" "${CLAWDND_PLAY_CANON_HERO:-}" "$CODEX_MODEL" "$CLAWDND_LEAN_BEATS" "$CLAWDND_LEAN_TAIL" "$CLAWDND_PLAY_MAX_TURNS" "$GIT_SHA" <<'PY'
 import json
 import sys
 from pathlib import Path
 
 (
     mode, root, state_root, world, run_id, port, config, moves, chat, viewer_url,
-    hero_raw, model, lean_beats, lean_tail, max_turns, sha,
+    hero_raw, fallback_hero, model, lean_beats, lean_tail, max_turns, sha,
 ) = sys.argv[1:]
 hero = {}
 if hero_raw.strip():
@@ -175,6 +176,12 @@ if hero_raw.strip():
             hero = {"raw": hero_raw}
     except json.JSONDecodeError:
         hero = {"raw": hero_raw}
+elif fallback_hero.strip():
+    fallback = fallback_hero.strip()
+    if fallback.startswith(("template:", "pickup:")) or fallback in {"nobody_l1", "veteran_l5"}:
+        hero = {"origin": fallback}
+    else:
+        hero = {"canon": True, "name": fallback}
 print(json.dumps({
     "ok": True,
     "mode": mode,
@@ -296,6 +303,9 @@ HERO_PC_ID=""
 HERO_PC_NAME=""
 HERO_PC_RACE=""
 HERO_PC_CLASS=""
+HERO_PC_SUBCLASS=""
+HERO_PC_LEVEL=""
+HERO_PC_SPELLS=""
 HERO_SEED_JSON="$(CLAWDND_STATE_DIR="$RUN_DIR" WORLDOS_STATE_DIR="$RUN_DIR" uv run --directory "$ROOT/servers/engine" python - "$CLAWDND_WORLD" "${CLAWDND_PLAY_HERO:-}" "${CLAWDND_PLAY_CANON_HERO:-Alfira}" <<'PY'
 import json
 import sys
@@ -305,6 +315,8 @@ import server
 world, spec_raw, fallback_name = sys.argv[1], sys.argv[2], sys.argv[3]
 explicit = False
 canon_name = ""
+origin_spec = ""
+name_override = ""
 if spec_raw.strip():
     explicit = True
     try:
@@ -315,61 +327,106 @@ if spec_raw.strip():
     if not isinstance(spec, dict):
         sys.stderr.write("native hero spec must be a JSON object\n")
         sys.exit(1)
-    if not spec.get("canon"):
-        sys.stderr.write("Codex DM provider currently supports native roster canon hero specs only\n")
-        sys.exit(1)
-    canon_name = str(spec.get("name") or "").strip()
-    if not canon_name:
-        sys.stderr.write("native roster canon hero spec is missing name\n")
+    origin_raw = str(spec.get("origin") or spec.get("template") or "").strip()
+    if origin_raw:
+        if spec.get("template") and ":" not in origin_raw:
+            origin_raw = f"template:{origin_raw}"
+        origin_spec = origin_raw
+        name_override = str(spec.get("name") or "").strip()
+    elif spec.get("canon"):
+        canon_name = str(spec.get("name") or "").strip()
+        if not canon_name:
+            sys.stderr.write("native roster canon hero spec is missing name\n")
+            sys.exit(1)
+    else:
+        sys.stderr.write("Codex DM provider hero spec must include canon=true or origin/template\n")
         sys.exit(1)
 else:
-    canon_name = fallback_name.strip() or "Alfira"
+    fallback = fallback_name.strip() or "Alfira"
+    if fallback.startswith(("template:", "pickup:")) or fallback in {"nobody_l1", "veteran_l5"}:
+        origin_spec = fallback
+    else:
+        canon_name = fallback
 
 started = server.start_world(world)
 camp = started.get("campaign_id") if isinstance(started, dict) else ""
 if not camp:
     sys.stderr.write("start_world did not return a campaign_id\n")
     sys.exit(1)
-server.start_session(camp, title=f"Codex DM: {canon_name}")
-
-names = [canon_name]
-if not explicit:
-    try:
-        roster = server.list_canon_characters(camp, playable_only=True).get("available") or []
-    except Exception:
-        roster = []
-    for row in roster:
-        if not isinstance(row, dict):
-            continue
-        name = str(row.get("name") or "").strip()
-        if name and name not in names:
-            names.append(name)
+title_name = origin_spec or canon_name
+server.start_session(camp, title=f"Codex DM: {title_name}")
 
 rec = {}
+seed_source = "canon"
 errors = []
-for name in names:
+if origin_spec:
+    seed_source = "origin"
     try:
-        candidate = server.load_canon_character(camp, name, kind="player", add_to_party=True)
+        candidate = server.start_character(camp, origin=origin_spec, name=name_override)
     except Exception as exc:
-        errors.append(f"{name}: {exc}")
-        continue
+        sys.stderr.write(f"origin pickup failed for {origin_spec!r}: {exc}\n")
+        sys.exit(1)
     if isinstance(candidate, dict) and not candidate.get("error") and candidate.get("id"):
         rec = candidate
-        canon_name = name
-        break
-    errors.append(f"{name}: {(candidate or {}).get('error') if isinstance(candidate, dict) else candidate}")
+    else:
+        sys.stderr.write(f"origin pickup failed for {origin_spec!r}: {candidate}\n")
+        sys.exit(1)
+else:
+    names = [canon_name]
+    if not explicit:
+        try:
+            roster = server.list_canon_characters(camp, playable_only=True).get("available") or []
+        except Exception:
+            roster = []
+        for row in roster:
+            if not isinstance(row, dict):
+                continue
+            name = str(row.get("name") or "").strip()
+            if name and name not in names:
+                names.append(name)
 
-if not isinstance(rec, dict) or rec.get("error"):
-    sys.stderr.write("canon pickup failed: " + "; ".join(errors[:5]) + "\n")
-    sys.exit(1)
+    for name in names:
+        try:
+            candidate = server.load_canon_character(camp, name, kind="player", add_to_party=True)
+        except Exception as exc:
+            errors.append(f"{name}: {exc}")
+            continue
+        if isinstance(candidate, dict) and not candidate.get("error") and candidate.get("id"):
+            rec = candidate
+            canon_name = name
+            break
+        errors.append(f"{name}: {(candidate or {}).get('error') if isinstance(candidate, dict) else candidate}")
+
+    if not isinstance(rec, dict) or rec.get("error"):
+        sys.stderr.write("canon pickup failed: " + "; ".join(errors[:5]) + "\n")
+        sys.exit(1)
+
+pc_id = str(rec.get("id") or "")
+pc_full = {}
+if pc_id:
+    try:
+        state = server.get_state(camp)
+        pc_full = ((state.get("campaign") or {}).get("characters") or {}).get(pc_id) or {}
+    except Exception:
+        pc_full = {}
+classes = pc_full.get("classes") if isinstance(pc_full, dict) else []
+head_class = classes[0] if isinstance(classes, list) and classes and isinstance(classes[0], dict) else {}
+spells = []
+if isinstance(pc_full, dict):
+    spells = [str(s) for s in (pc_full.get("spells_known") or pc_full.get("spells_prepared") or []) if str(s).strip()]
 
 print(json.dumps({
     "campaign_id": camp,
+    "seed_source": seed_source,
+    "origin": origin_spec,
     "pc": {
-        "id": rec.get("id") or "",
-        "name": rec.get("name") or canon_name,
-        "race": str(rec.get("race") or ""),
-        "class": str(rec.get("class") or ""),
+        "id": pc_id,
+        "name": rec.get("name") or pc_full.get("name") or canon_name or name_override,
+        "race": str(rec.get("race") or pc_full.get("race") or ""),
+        "class": str(rec.get("class") or head_class.get("name") or ""),
+        "level": rec.get("level") or head_class.get("level") or "",
+        "subclass": head_class.get("subclass") or "",
+        "spells": spells,
     },
 }))
 PY
@@ -379,8 +436,11 @@ HERO_PC_ID="$(printf '%s' "$HERO_SEED_JSON" | jq -r '.pc.id // ""')"
 HERO_PC_NAME="$(printf '%s' "$HERO_SEED_JSON" | jq -r '.pc.name // ""')"
 HERO_PC_RACE="$(printf '%s' "$HERO_SEED_JSON" | jq -r '.pc.race // ""')"
 HERO_PC_CLASS="$(printf '%s' "$HERO_SEED_JSON" | jq -r '.pc.class // ""')"
+HERO_PC_LEVEL="$(printf '%s' "$HERO_SEED_JSON" | jq -r '.pc.level // ""')"
+HERO_PC_SUBCLASS="$(printf '%s' "$HERO_SEED_JSON" | jq -r '.pc.subclass // ""')"
+HERO_PC_SPELLS="$(printf '%s' "$HERO_SEED_JSON" | jq -r '(.pc.spells // []) | join(", ")')"
 [ -n "$HERO_CAMP" ] || fail "solo player pre-seed returned no campaign"
-echo "[codex-dm-provider] seeded solo player: $HERO_PC_NAME ($HERO_PC_RACE $HERO_PC_CLASS) in campaign $HERO_CAMP"
+echo "[codex-dm-provider] seeded solo player: $HERO_PC_NAME ($HERO_PC_RACE level $HERO_PC_LEVEL $HERO_PC_CLASS ${HERO_PC_SUBCLASS:+/$HERO_PC_SUBCLASS}) in campaign $HERO_CAMP"
 
 chatlog() {
   python3 - "$CHAT" "$1" "$2" "${3:-}" <<'PY'
@@ -404,21 +464,34 @@ PY
 
 write_provider_status() {
   local status="$1" reason="$2" detail="$3"
-  python3 - "$PROVIDER_STATUS" "$status" "$reason" "$detail" "$CLAWDND_PROVIDER" "$CLAWDND_PLAY_MAX_TURNS" "$DM_TURNS" "$CODEX_MODEL" "$CLAWDND_LEAN_BEATS" "$CLAWDND_LEAN_TAIL" "$GIT_SHA" <<'PY'
+  python3 - "$PROVIDER_STATUS" "$status" "$reason" "$detail" "$CLAWDND_PROVIDER" "$CLAWDND_PLAY_MAX_TURNS" "$DM_TURNS" "$CODEX_MODEL" "$CLAWDND_LEAN_BEATS" "$CLAWDND_LEAN_TAIL" "$GIT_SHA" "${HERO_SEED_JSON:-}" <<'PY'
 import json
 import os
 import sys
 import time
 from pathlib import Path
 
-path, status, reason, detail, provider, max_turns, turns, model, lean_beats, lean_tail, sha = sys.argv[1:]
+path, status, reason, detail, provider, max_turns, turns, model, lean_beats, lean_tail, sha, seed_json = sys.argv[1:]
 path = Path(path)
+fixture = {}
+if seed_json.strip():
+    try:
+        seed = json.loads(seed_json)
+    except json.JSONDecodeError:
+        seed = {}
+    if isinstance(seed, dict):
+        fixture = {
+            "seed_source": seed.get("seed_source"),
+            "origin": seed.get("origin"),
+            "pc": seed.get("pc") if isinstance(seed.get("pc"), dict) else {},
+        }
 payload = {
     "schema": "worldos.provider-status.v1",
     "provider": provider,
     "model": model,
     "wrapper": "scripts/play_codex_dm.sh",
     "sha": sha,
+    "fixture": fixture,
     "lean_beats": lean_beats == "1",
     "lean_tail": int(lean_tail) if str(lean_tail).isdigit() else lean_tail,
     "status": status,
@@ -597,13 +670,14 @@ $REWARD_MUTATION_RULE
 $OPENING_PERSIST_BEAT_RULE
 $COMPANION_TOOL_RULE
 
-Native-selected canon hero already seated:
+Native-selected hero already seated:
 - campaign_id: "$HERO_CAMP"
-- player: "$HERO_PC_NAME" ($HERO_PC_RACE $HERO_PC_CLASS), id "$HERO_PC_ID"
+- player: "$HERO_PC_NAME" ($HERO_PC_RACE level $HERO_PC_LEVEL $HERO_PC_CLASS${HERO_PC_SUBCLASS:+ / $HERO_PC_SUBCLASS}), id "$HERO_PC_ID"
+${HERO_PC_SPELLS:+- known/prepared spells from engine sheet: $HERO_PC_SPELLS}
 
 Start from that already-seated player:
 - call get_state("$HERO_CAMP") FIRST to read the campaign;
-- do NOT call start_world, start_session, or load_canon_character for the player;
+- do NOT call start_world, start_session, start_character, or load_canon_character for the player;
 - open a 2nd-person, player-facing scene centered on "$HERO_PC_NAME" with real sensory details, at least one quoted NPC line, and a clear open moment.
 
 Your final reply must be non-empty opening narration for the player, not a setup note and not a tool-only ending.

--- a/servers/engine/tests/test_codex_provider_wrapper.py
+++ b/servers/engine/tests/test_codex_provider_wrapper.py
@@ -178,13 +178,40 @@ def test_codex_dm_wrapper_dry_run_surfaces_native_selected_hero(tmp_path):
     assert summary["hero"] == {"canon": True, "name": "Abby"}
 
 
+def test_codex_dm_wrapper_dry_run_surfaces_origin_template_hero(tmp_path):
+    hero = json.dumps({"origin": "template:rolan-evoker"})
+    result = _run_dm(["--dry-run"], _env(tmp_path, CLAWDND_PLAY_HERO=hero))
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    summary = json.loads(result.stdout[result.stdout.index("{") :])
+    assert summary["hero"] == {"origin": "template:rolan-evoker"}
+
+
+def test_codex_dm_wrapper_dry_run_surfaces_fallback_origin_template_hero(tmp_path):
+    result = _run_dm(
+        ["--dry-run"],
+        _env(tmp_path, CLAWDND_PLAY_CANON_HERO="template:rolan-evoker"),
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    summary = json.loads(result.stdout[result.stdout.index("{") :])
+    assert summary["hero"] == {"origin": "template:rolan-evoker"}
+
+
 def test_codex_dm_wrapper_honors_native_selected_hero():
     source = DM_SCRIPT.read_text(encoding="utf-8")
 
     assert "CLAWDND_PLAY_HERO" in source
     assert "CLAWDND_PLAY_CANON_HERO" in source
+    assert "origin_spec" in source
+    assert 'server.start_character(camp, origin=origin_spec, name=name_override)' in source
     assert 'server.load_canon_character(camp, name, kind="player", add_to_party=True)' in source
-    assert "Native-selected canon hero already seated" in source
+    assert "Native-selected hero already seated" in source
+    assert "HERO_PC_SUBCLASS" in source
+    assert "HERO_PC_SPELLS" in source
+    assert '"fixture": fixture' in source
+    assert "known/prepared spells from engine sheet" in source
+    assert "do NOT call start_world, start_session, start_character, or load_canon_character" in source
     assert "seeded solo player" in source
 
 


### PR DESCRIPTION
## Summary
- let the Codex DM provider seat explicit origin fixtures such as `template:rolan-evoker`
- surface requested fallback fixture metadata in dry-run summaries and resolved fixture metadata in provider status
- document the fair-test fixture requirement so Codex/Opus comparisons do not accidentally compare loose canon pickup against a subclassed spellcaster fixture

## Why
The native Codex fair-test lane needs to compare the same seeded player fixture used for Opus-style evidence. Passing plain `Rolan` through the older Codex wrapper could resolve through the canon pickup path and lose fixture detail such as subclass/spells, keeping the score comparison apples-to-oranges. This PR makes `template:rolan-evoker` a first-class Codex provider seed.

## Validation
- `bash -n scripts/play_codex_dm.sh`
- `git diff --check`
- `uv run --directory servers/engine python -m pytest tests/test_codex_provider_wrapper.py -q -p no:cacheprovider` -> 27 passed
- `uv run --directory servers/engine python -m pytest tests/test_content.py::test_start_character_rolan_evoker_template_yields_spells -q -p no:cacheprovider` -> 1 passed
- Direct dry-run with `CLAWDND_PLAY_CANON_HERO=template:rolan-evoker` reported `hero.origin=template:rolan-evoker`

## Follow-up
After this lands, rerun the native Codex fair-test with `--hero template:rolan-evoker` before spending more time on #690 gateway/plugin work.

Refs #693
Refs #695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a "canon hero" via environment variable configuration.
  * Extended status reporting to include hero fixture information (level, subclass, spells).

* **Documentation**
  * Updated fixture guidance for GPT provider comparison testing with explicit template specifications.

* **Tests**
  * Added contract tests validating hero origin template selection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->