### PR TITLE
Fix Codex fixture sheet metadata

### DIFF
--- a/scripts/play_codex_dm.sh
+++ b/scripts/play_codex_dm.sh
@@ -18,9 +18,10 @@ MODE="run"
 case "${1:-}" in
   --dry-run) MODE="dry-run"; shift ;;
   --smoke) MODE="smoke"; shift ;;
+  --seed-smoke) MODE="seed-smoke"; shift ;;
   -h|--help)
     cat <<'EOF'
-Usage: scripts/play_codex_dm.sh [--dry-run|--smoke]
+Usage: scripts/play_codex_dm.sh [--dry-run|--smoke|--seed-smoke]
 
 Required environment:
   CLAWDND_PROVIDER=codex
@@ -84,7 +85,7 @@ if [ "$MODE" = "run" ]; then
   command -v codex >/dev/null 2>&1 || fail "codex CLI is required for real provider runs"
 fi
 
-if [ "$MODE" = "smoke" ]; then
+if [ "$MODE" = "smoke" ] || [ "$MODE" = "seed-smoke" ]; then
   STATE_ROOT="${CLAWDND_STATE_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/clawdnd-codex-dm-smoke.XXXXXX")}"
 else
   STATE_ROOT="${CLAWDND_STATE_ROOT:-$ROOT/play-state}"
@@ -288,7 +289,7 @@ echo "[codex-dm-provider] moves=$MOVES"
 echo "[codex-dm-provider] chat=$CHAT"
 echo "[codex-dm-provider] lean_beats=$CLAWDND_LEAN_BEATS recent_narration=$CLAWDND_LEAN_TAIL"
 
-if [ "$MODE" != "run" ]; then
+if [ "$MODE" = "dry-run" ] || [ "$MODE" = "smoke" ]; then
   summary
   exit 0
 fi
@@ -405,15 +406,22 @@ pc_id = str(rec.get("id") or "")
 pc_full = {}
 if pc_id:
     try:
-        state = server.get_state(camp)
-        pc_full = ((state.get("campaign") or {}).get("characters") or {}).get(pc_id) or {}
+        pc_full = server.get_character(camp, pc_id)
     except Exception:
+        pc_full = {}
+    if not isinstance(pc_full, dict) or pc_full.get("error"):
         pc_full = {}
 classes = pc_full.get("classes") if isinstance(pc_full, dict) else []
 head_class = classes[0] if isinstance(classes, list) and classes and isinstance(classes[0], dict) else {}
 spells = []
 if isinstance(pc_full, dict):
-    spells = [str(s) for s in (pc_full.get("spells_known") or pc_full.get("spells_prepared") or []) if str(s).strip()]
+    seen = set()
+    for spell_list in (pc_full.get("spells_known") or [], pc_full.get("spells_prepared") or []):
+        for spell in spell_list:
+            name = str(spell).strip()
+            if name and name.lower() not in seen:
+                spells.append(name)
+                seen.add(name.lower())
 
 print(json.dumps({
     "campaign_id": camp,
@@ -441,6 +449,24 @@ HERO_PC_SUBCLASS="$(printf '%s' "$HERO_SEED_JSON" | jq -r '.pc.subclass // ""')"
 HERO_PC_SPELLS="$(printf '%s' "$HERO_SEED_JSON" | jq -r '(.pc.spells // []) | join(", ")')"
 [ -n "$HERO_CAMP" ] || fail "solo player pre-seed returned no campaign"
 echo "[codex-dm-provider] seeded solo player: $HERO_PC_NAME ($HERO_PC_RACE level $HERO_PC_LEVEL $HERO_PC_CLASS ${HERO_PC_SUBCLASS:+/$HERO_PC_SUBCLASS}) in campaign $HERO_CAMP"
+
+if [ "$MODE" = "seed-smoke" ]; then
+  python3 - "$HERO_SEED_JSON" "$GIT_SHA" <<'PY'
+import json
+import sys
+
+seed_json, sha = sys.argv[1], sys.argv[2]
+print(json.dumps({
+    "ok": True,
+    "mode": "seed-smoke",
+    "provider": "codex",
+    "role": "dm",
+    "sha": sha,
+    "seed": json.loads(seed_json),
+}, indent=2, sort_keys=True))
+PY
+  exit 0
+fi
 
 chatlog() {
   python3 - "$CHAT" "$1" "$2" "${3:-}" <<'PY'

--- a/servers/engine/tests/test_codex_provider_wrapper.py
+++ b/servers/engine/tests/test_codex_provider_wrapper.py
@@ -198,13 +198,37 @@ def test_codex_dm_wrapper_dry_run_surfaces_fallback_origin_template_hero(tmp_pat
     assert summary["hero"] == {"origin": "template:rolan-evoker"}
 
 
+def test_codex_dm_wrapper_seed_smoke_surfaces_origin_template_sheet(tmp_path):
+    result = _run_dm(
+        ["--seed-smoke"],
+        _env(tmp_path, CLAWDND_PLAY_CANON_HERO="template:rolan-evoker"),
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    summary = json.loads(result.stdout[result.stdout.index("{") :])
+    assert summary["ok"] is True
+    assert summary["mode"] == "seed-smoke"
+    seed = summary["seed"]
+    assert seed["seed_source"] == "origin"
+    assert seed["origin"] == "template:rolan-evoker"
+    pc = seed["pc"]
+    assert pc["class"] == "Wizard"
+    assert pc["level"] == 3
+    assert pc["subclass"] == "Evocation"
+    assert "Magic Missile" in pc["spells"]
+    assert "Mage Armor" in pc["spells"]
+
+
 def test_codex_dm_wrapper_honors_native_selected_hero():
     source = DM_SCRIPT.read_text(encoding="utf-8")
 
     assert "CLAWDND_PLAY_HERO" in source
     assert "CLAWDND_PLAY_CANON_HERO" in source
+    assert "--seed-smoke" in source
     assert "origin_spec" in source
     assert 'server.start_character(camp, origin=origin_spec, name=name_override)' in source
+    assert "server.get_character(camp, pc_id)" in source
     assert 'server.load_canon_character(camp, name, kind="player", add_to_party=True)' in source
     assert "Native-selected hero already seated" in source
     assert "HERO_PC_SUBCLASS" in source


### PR DESCRIPTION
## Summary
- switch Codex provider fixture metadata from `get_state()` summary reads to the full `get_character()` sheet
- add `scripts/play_codex_dm.sh --seed-smoke` so origin fixtures can be validated before starting a real Codex DM run
- cover `template:rolan-evoker` seed metadata in wrapper tests, including subclass and spell list

## Why
PR #699 correctly seated `template:rolan-evoker`, but the follow-up GPT-5.5 rerun exposed that provider status and the opening prompt still showed empty subclass/spells. The wrapper was reading `server.get_state()`, which is only a campaign summary and does not include character sheets. That made the attempted fair-test evidence contaminated before scoring.

Aborted contaminated run:
`/Volumes/LEXAR/Codex/worldos-codex-fair-test/codexfair-gpt55-origin-20260607T071151Z-b97e75f`

## Validation
- `bash -n scripts/play_codex_dm.sh`
- `git diff --check`
- direct `--seed-smoke` with `CLAWDND_PLAY_CANON_HERO=template:rolan-evoker` surfaced subclass `Evocation` and spells including `Magic Missile` and `Mage Armor`
- `uv run --directory servers/engine python -m pytest tests/test_codex_provider_wrapper.py -q -p no:cacheprovider` -> 28 passed
- `uv run --directory servers/engine python -m pytest tests/test_content.py::test_start_character_rolan_evoker_template_yields_spells -q -p no:cacheprovider` -> 1 passed

## Follow-up
After this lands, rerun the native Codex fair-test with `--hero template:rolan-evoker` and only score the clean rerun.

Refs #693
Refs #695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--seed-smoke` mode for streamlined seed generation, outputting structured JSON containing seed payload and deployment details
  * Improved character data initialization by enhancing the retrieval mechanism in solo-player pre-seed workflow
  * Enhanced spell collection system with automatic case-insensitive deduplication across known and prepared spell categories, reducing redundancy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->