### PR TITLE
fix(viewer): demote party-less orphan campaigns in auto-follow (hero-bind party-wipe)

### DIFF
--- a/viewer/server.py
+++ b/viewer/server.py
@@ -532,25 +532,45 @@ def _campaign_recency(snap_path: Path) -> float:
     return best
 
 
+def _campaign_has_player(snap: dict) -> bool:
+    """True when the snapshot has a seated PLAYER character — the signal that a campaign is a real,
+    playable run rather than a half-minted orphan (start_world ran but load_canon_character never
+    seated a PC). RRI 2026-06-09: a timed-out cold-open RETRY re-ran start_world and minted a
+    SECOND, party-less campaign; this lets the auto-follow pick demote that empty orphan below the
+    seated run so the viewer never projects a 'wiped' party while a real run exists."""
+    chars = snap.get("characters")
+    if not isinstance(chars, dict):
+        return False
+    return any(isinstance(c, dict) and c.get("kind") == "player" for c in chars.values())
+
+
 def _pick_campaign(arg: str | None) -> str | None:
     """Resolve which campaign to project. An explicit arg wins; otherwise pick the
     most-recently-ACTIVE campaign by recency (#38) so launching the viewer follows
     whatever run is live without a relaunch. Snapshots that fail to parse are
-    skipped so a half-written/corrupt one can't win the race and blank the view."""
+    skipped so a half-written/corrupt one can't win the race and blank the view.
+    A campaign with a SEATED PLAYER is preferred over a party-less orphan (a cold-open
+    retry's second mint, or a fresh start_world before the PC seats); recency only
+    tie-breaks AMONG real runs, so a just-orphaned empty sibling can never win the
+    auto-follow and blank the table while a seated run is live (the hero-bind party-wipe)."""
     if arg:
         return arg
     cdir = _campaigns_dir()
     if not cdir.is_dir():
         return None
-    snaps: list[tuple[str, float]] = []
+    snaps: list[tuple[str, bool, float]] = []
     for p in cdir.glob("*/snapshot.json"):
         try:
-            if not json.loads(p.read_text(encoding="utf-8")):
+            snap = json.loads(p.read_text(encoding="utf-8"))
+            if not snap:
                 continue  # empty/`{}` snapshot — nothing to show; don't let it win
         except (json.JSONDecodeError, OSError):
             continue
-        snaps.append((p.parent.name, _campaign_recency(p)))
-    return max(snaps, key=lambda x: x[1])[0] if snaps else None
+        snaps.append((p.parent.name, _campaign_has_player(snap), _campaign_recency(p)))
+    # Prefer a seated run (has_player True > False), then recency. A party-less orphan only wins
+    # when EVERY candidate is party-less (a brand-new game between start_world and the PC seat),
+    # so a legitimate fresh game is at most briefly demoted, never stranded.
+    return max(snaps, key=lambda x: (x[1], x[2]))[0] if snaps else None
 
 
 def _campaign_dir(campaign_id: str) -> Path:

--- a/viewer/tests/test_live_view_recovery.py
+++ b/viewer/tests/test_live_view_recovery.py
@@ -367,5 +367,34 @@ class LiveViewRecoveryTests(unittest.TestCase):
         self.assertIn("read-only", str(body.get("reason", "")))
 
 
+    # -- the cold-open-retry party-less orphan must not win auto-follow (hero-bind party-wipe) --
+    # RRI 2026-06-09: a timed-out cold-open retry re-ran start_world and minted a SECOND, party-less
+    # campaign (NPCs only, no seated PC) NEWER than the real run. The recency-only `_pick_campaign`
+    # followed the empty orphan, so the table projected a "wiped" empty party while the seated run
+    # sat right there in the same store. The pick must DEMOTE a party-less orphan below any seated
+    # run; recency only tie-breaks AMONG real runs.
+    def test_empty_party_orphan_loses_to_seated_run_despite_newer_recency(self):
+        self._enable_move_sink()
+        # The real run: a seated PLAYER, but OLDER (the timed-out attempt's beats froze).
+        self._write("seated_run", _snap("Rolan's Tale"), age_seconds=240)
+        # The orphan: NEWER, but party-less (start_world minted it; load_canon_character never ran).
+        self._write("empty_orphan",
+                    {"title": "Orphan", "party": [],
+                     "characters": {"npc1": {"id": "npc1", "name": "Aldra", "kind": "npc"}}},
+                    age_seconds=0)
+        self.assertEqual(server._pick_campaign(None), "seated_run",
+                         "a party-less orphan must not win auto-follow over a seated run")
+
+    def test_all_party_less_falls_back_to_recency(self):
+        """When NO campaign has a seated PC yet (a brand-new game between start_world and the seat),
+        the pick falls back to recency — the demotion only matters when a SEATED run exists to
+        prefer, so a legitimate fresh game is at most briefly demoted, never stranded."""
+        self._enable_move_sink()
+        self._write("fresh_a", {"title": "A", "party": [], "characters": {}}, age_seconds=10)
+        self._write("fresh_b", {"title": "B", "party": [], "characters": {}}, age_seconds=0)
+        self.assertEqual(server._pick_campaign(None), "fresh_b",
+                         "with no seated run, recency still decides among the party-less")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Why
RRI 2026-06-09 — persona **vm2-opuslean-narr2** filed two critical bugs ("Bind the hero silently wipes the party"; sat=2, gave up). Root cause (adversarially verified): a timed-out cold-open **retry re-ran `start_world` and minted a SECOND, party-less campaign** (NPCs only, no seated PC) that was *newer* than the real run. `_pick_campaign` picks `max(recency)` over all campaigns, so the empty orphan won the auto-follow and the table projected a **"wiped" empty party** while the seated run sat in the same store.

## Fix
`_pick_campaign` now prefers a campaign with a **seated player** (new `_campaign_has_player`) over a party-less one; recency only tie-breaks **among real runs**. So a just-orphaned empty sibling can never win the view while a seated run is live. A brand-new game (`party:[]` for the seconds between `start_world` and the PC seat) is at most briefly demoted, never stranded.

- **Pure read-model** — never writes; engine stays sole writer, viewer stays read-only.
- The `#38` auto-follow and `#640` heal recovery tests are unchanged (they seat a player → `has_player` true → identical recency behavior).

## Tests (`viewer/tests/test_live_view_recovery.py`)
- `test_empty_party_orphan_loses_to_seated_run_despite_newer_recency` — RED→GREEN (reproduces the exact on-disk situation: seated run older, empty orphan newer).
- `test_all_party_less_falls_back_to_recency` — guards the legitimate fresh-game window.
- **Full viewer suite: 442 passed, 1 skipped** (no regression).

Part of the Phase-2 reliability sweep (the sat/critical/give-up gates). The cold-open retry that *creates* the orphan (engine-side double-mint) + the spinner affordance + the wall-of-text header-monotonicity guard land as follow-up PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced campaign auto-selection to prioritize campaigns containing active player characters over those without.
  * Refined campaign selection tie-breaking to use snapshot and session recency when player status is equal across campaigns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->