### PR TITLE
fix(reliability): cold-open retry resumes the minted campaign, not a second one (#719)

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -310,6 +310,39 @@ clawdnd_report_attempt_failure() {
   return 0
 }
 
+# COLD-OPEN RETRY: RESUME the minted campaign instead of re-seeding (#719). The DEFAULT cold-open
+# prompt (scripts/play.sh) says start_world + "if it returns existing_campaigns, start fresh", so a
+# timed-out attempt-1 that ALREADY minted+seeded a campaign gets a retry that mints a SECOND,
+# party-less campaign — the viewer auto-follows the empty orphan ⇒ party-wipe + frozen/input-locked
+# screen (the adversarially-verified engine root of two criticals, RRI 2026-06-09). This returns a
+# RESUME directive (get_state on the existing id, DO NOT start_world, seat a canon PC only if the
+# party is empty) when — and ONLY when — this is a DEFAULT cold-open RETRY (first=1, no authored
+# hero) AND attempt-1 left a live campaign. Otherwise it echoes the base message UNCHANGED:
+#   - first=0 (a continuing beat) — never a cold-open re-seed risk;
+#   - hero_camp set — the AUTHORED-hero opener already opens on the existing campaign;
+#   - live_cid empty — attempt-1 minted nothing, so the normal cold-open MUST run.
+# Byte-identical on every path except the one bug. Read-only; 3.2-safe (printf, no heredoc-in-$()).
+# $1=first  $2=hero_camp  $3=live_campaign_id  $4=world  $5=base_msg ; echoes the message to use.
+clawdnd_coldopen_retry_msg() {
+  local first="$1" hero_camp="$2" live_cid="$3" world="$4" base_msg="$5"
+  if [ "$first" != "1" ] || [ -n "$hero_camp" ] || [ -z "$live_cid" ]; then
+    printf '%s' "$base_msg"
+    return 0
+  fi
+  printf '%s' "You are the Dungeon Master for a solo ClawDnD adventure. Activate and follow your \`dungeon-master\` skill — run its \"Generating a world live\" mode and hold its craft bar (mechanics sourced from the engine, NPCs speak, the world pushes back, scenes played not logged).
+
+A previous cold-open attempt already minted THIS session's campaign, so the world ALREADY EXISTS — RESUME it, do NOT start over:
+- This session's campaign ALREADY EXISTS: use campaign_id=$live_cid for EVERY engine call. DO NOT call start_world(\"$world\") — it would mint a NEW campaign id and ORPHAN this save (the player's seated party would vanish).
+- call get_state(\"$live_cid\") FIRST to read the world bible (premise, era/chronology, tone, standing threads, seeded regions/factions/roster) AND the current party.
+- start_session only if get_state shows no active session.
+- If get_state shows the party is EMPTY (no PC seated yet), choose the player's hero by SELECTING a real canon NPC — NEVER invent a custom character: list_canon_characters(playable_only=true) (the 7 BG3 origin heroes are excluded), pick a fitting MID-TIER canon figure with an ingested portrait + real backstory, then load_canon_character(that name, kind=\"player\", add_to_party=true). If a PC is ALREADY in the party, KEEP them — do NOT reroll or replace.
+- This is a SOLO session: the player begins ALONE. Do NOT recruit a companion at cold-open and do NOT seat anyone but the player. A roster legend may APPEAR as a face in the world (voiced, with a real wound), but they are MET, not recruited.
+
+CRITICAL — your FINAL output THIS turn MUST BE the opening SCENE itself, written as 2nd-person player-facing prose (addressed to \"you\"): where the player IS, what they see/hear/smell, who is present and a real quoted line, ending on a clear open moment + choice. Re-ground via the tools FIRST, then CLOSE the turn by writing the scene. NEVER end this turn on a tool call, and NEVER let your reply be a 3rd-person setup brief or game-system notation.
+
+Their actions will arrive as tagged moves — [say] (their dialogue), [do] (an attempt), [check] (roll that skill), [cast]/[use]/[attack] (resolve via the engine) — one per turn from the dashboard."
+}
+
 # Read the run's progression facts from the snapshot in ONE python pass. Echoes a single
 # TAB-separated line:  day <TAB> time_of_day <TAB> visited_count <TAB> npcs_met <TAB>
 # current_location_id <TAB> current_location_visited(0/1) <TAB> combat_active(0/1)

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -292,6 +292,15 @@ dm_turn() {
       clawdnd_dm_remint_session_on_retry ${resume[@]+"${resume[@]}"}
       [ "${#CLAWDND_DM_RETRY_SESSION[@]}" -gt 0 ] && resume=("${CLAWDND_DM_RETRY_SESSION[@]}")
     fi
+    # #719: a DEFAULT cold-open (first=1) retry must RESUME attempt-1's minted campaign, not re-seed
+    # a SECOND party-less one (the cold-open prompt instructs start_world / "start fresh"). The helper
+    # returns $msg UNCHANGED for continuing beats, an authored hero, or a fresh first attempt with no
+    # live campaign — byte-identical except on the one bug. Read-only (asks the engine for the live
+    # save) and only on the slow retry path.
+    if [ "$first" = "1" ]; then
+      local _live_cid; _live_cid="$(clawdnd_live_campaign_id "$ROOT" "$STATE_DIR" "$WORLD")"
+      msg="$(clawdnd_coldopen_retry_msg "$first" "${HERO_CAMP:-}" "$_live_cid" "$WORLD" "$msg")"
+    fi
     out="$DM_LOG.$(date +%s%N).jsonl"
     _dm_invoke; rc=$?
     [ "$rc" -ne 0 ] && echo "[play] DM turn retry also rc=$rc — relying on engine-logged narration" >&2

--- a/servers/engine/tests/test_dm_session_remint.py
+++ b/servers/engine/tests/test_dm_session_remint.py
@@ -172,3 +172,77 @@ def test_play_party_drives_the_arc_runbook():
     # (2026-06-05 narrative crit: the DM rendered its scaffolding notes verbatim instead of a lived scene).
     assert "do NOT quote, echo, or render this line" in party.lower() or "Do NOT quote, echo, or render this line" in party
     assert "terse scaffolding" in party, "must forbid scaffolding-note output (prose-only rule)"
+
+
+# --- #719: the cold-open RETRY must RESUME the minted campaign, not re-seed a second one ------
+# Distinct from the session-id re-mint above (a 401 collision) AND from #640's play_party launch
+# reuse: here play.sh's DEFAULT cold-open prompt says start_world + "if existing_campaigns, start
+# fresh", so a timed-out attempt-1 (which already minted+seeded a campaign) gets a retry that mints
+# a SECOND, party-less campaign — the viewer auto-follows the empty orphan ⇒ party-wipe + input-lock.
+# The fix swaps the retry $msg to a resume directive (get_state, NO start_world) via a sourceable
+# helper, so it's deterministically testable with no LLM/engine/network.
+
+def test_coldopen_retry_resumes_existing_campaign_not_reseed():
+    """first=1 (cold-open) + no authored hero + attempt-1 ALREADY minted a campaign ⇒ the retry
+    message must RESUME that campaign (get_state + DO NOT start_world), NOT re-issue the fresh
+    cold-open start_world prompt (which would orphan the seated save)."""
+    script = (
+        f'set -u; . "{LIB}"\n'
+        'printf "%s" "$(clawdnd_coldopen_retry_msg 1 "" camp-EXISTING baldurs-gate '
+        '"FRESH_COLDOPEN_SENTINEL call start_world here")"\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    out = r.stdout
+    assert "camp-EXISTING" in out, out
+    assert "DO NOT call start_world" in out, out
+    assert "get_state" in out, out
+    assert "FRESH_COLDOPEN_SENTINEL" not in out, "the retry must NOT re-issue the fresh cold-open prompt"
+    # the default-opener semantics survive: a canon PC is seated ONLY if the party is empty (never invent).
+    assert "load_canon_character" in out, out
+    assert "NEVER invent" in out or "never invent" in out.lower(), out
+
+
+def test_coldopen_retry_unchanged_when_no_prior_campaign():
+    """first=1 but attempt-1 minted NOTHING (live id empty) ⇒ nothing to resume → run the normal
+    cold-open verbatim (byte-unchanged)."""
+    script = (
+        f'set -u; . "{LIB}"\n'
+        'printf "%s" "$(clawdnd_coldopen_retry_msg 1 "" "" baldurs-gate "BASEMSG_SENTINEL")"\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout == "BASEMSG_SENTINEL", r.stdout
+
+
+def test_coldopen_retry_unchanged_for_continuing_beat():
+    """first=0 (a continuing beat) ⇒ never a cold-open re-seed risk → base message unchanged even
+    if a campaign exists."""
+    script = (
+        f'set -u; . "{LIB}"\n'
+        'printf "%s" "$(clawdnd_coldopen_retry_msg 0 "" camp-EXISTING baldurs-gate "BASEMSG_SENTINEL")"\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout == "BASEMSG_SENTINEL", r.stdout
+
+
+def test_coldopen_retry_unchanged_for_authored_hero():
+    """An AUTHORED hero (HERO_CAMP set) already uses the clean existing-campaign opener — the helper
+    must not interfere (that branch owns its own resume directive)."""
+    script = (
+        f'set -u; . "{LIB}"\n'
+        'printf "%s" "$(clawdnd_coldopen_retry_msg 1 hero-camp-123 camp-EXISTING baldurs-gate "BASEMSG_SENTINEL")"\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    assert r.stdout == "BASEMSG_SENTINEL", r.stdout
+
+
+def test_play_sh_wires_the_coldopen_resume_helper():
+    """Anti-drift: the helper must exist in the shared lib AND play.sh's retry must reassign $msg
+    through it (so the cold-open retry resumes instead of re-seeding)."""
+    lib = _src("qa/lib_beat_driver.sh")
+    play = _src("scripts/play.sh")
+    assert "clawdnd_coldopen_retry_msg()" in lib, "the resume-directive helper must exist in the lib"
+    assert 'msg="$(clawdnd_coldopen_retry_msg "$first"' in play, "play.sh retry must reassign msg via the helper"


### PR DESCRIPTION
Closes #719.

## The bug (adversarially verified, RRI 2026-06-09)
The shared engine root of **two** RRI criticals — the hero-bind **party-wipe** and the **input-lock/no-spinner**. The DEFAULT cold-open prompt (`scripts/play.sh`) says `start_world("<world>")` + *"if it returns existing_campaigns, start fresh"*. When attempt-1 times out (`timeout(1)` rc=124, >400s) **after** already minting+seeding a campaign, play.sh's one-shot retry re-runs that identical prompt → the DM mints a **SECOND, party-less** campaign. The viewer auto-follows the newer empty orphan → "wiped" party + a frozen, input-locked screen.

PR #717 mitigated the **read-side** (viewer demotes party-less orphans) and #718 added the cold-open spinner — but the orphan was still **created** (a wasted cold-open + a data-loss footgun). This is the engine-side prevention.

## The fix (additive, invariant-safe — engine stays sole writer)
New shared helper **`clawdnd_coldopen_retry_msg`** (`qa/lib_beat_driver.sh`) returns a **RESUME directive** — `get_state(<id>)` first, **DO NOT** `start_world`, seat a canon PC only if the party is empty (never invent), then open the 2nd-person scene — when **and only when** this is a DEFAULT cold-open RETRY (`first=1`, no authored hero) **and** attempt-1 left a live campaign (`clawdnd_live_campaign_id`). Otherwise it echoes the base message **UNCHANGED**:
- `first=0` (continuing beat) — never a cold-open re-seed risk;
- `HERO_CAMP` set — the authored-hero opener already opens on the existing campaign;
- no live campaign — attempt-1 minted nothing, so the normal cold-open must run.

Wired into `dm_turn`'s retry in `play.sh`. **Byte-identical on every path except the one bug.** Read-only (asks the engine for the live save) and only on the slow retry path. **bash-3.2-clean** (`printf`, no heredoc-in-`$()` — the documented macOS-system-bash footgun).

The engine seam this relies on already exists + is tested: `start_world(resume=)` → `test_start_world_resume_continues_instead_of_orphaning` (`test_content.py`).

## Tests (deterministic, no LLM/network/engine)
5 new shell-helper tests in `test_dm_session_remint.py` (the pytest-via-`/bin/bash` pattern):
- resumes the existing campaign on the bug path (campaign_id + `DO NOT call start_world` + `get_state`, canon-PC-if-empty; NOT the fresh cold-open prompt);
- UNCHANGED for no-prior-campaign / continuing-beat / authored-hero;
- play.sh wiring anti-drift.

✅ 15/15 in-file · ✅ `fast_gate.sh` 188 engine + seat-path · ✅ `bash -n` clean on both scripts.

## Moves which RRI gates
`zero_critical` (the party-wipe + input-lock criticals at their root) → toward `no_give_up` + `cross_persona_sat` 4.4→7. Verify on the next VM part-B sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Campaign retries now properly resume existing campaigns instead of starting fresh, maintaining party and world state continuity during retry attempts.

* **Tests**
  * Added comprehensive test coverage for cold-open retry behavior, validating proper campaign resumption and state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->