### PR TITLE
fix(reliability): stamp engine_logged on DM opening/beat chat rows to kill the duplicate opening (#720)

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -126,6 +126,87 @@ clawdnd_dm_narration_or_fallback() {
   fi
 }
 
+# CHRONICLE WRITE + ENGINE-LOG TRUTHFULNESS GUARD (issue #720 — the ONE shared impl).
+#
+# The cold-open opening prose lands in TWO viewer-read sources: the engine per-session log
+# (per-paragraph, fed to the viewer's /events) AND chat.jsonl (the whole opening as one blob,
+# written here by `chatlog`). The OpenWorlds client de-dups mid-session via
+# eventsStreamedThisTurnRef, but that backstop assumes "/events lands a turn's paragraphs
+# before its /chat blob" — true mid-session, FALSE on cold-open (the opening is complete
+# pre-mount). So the opening rendered TWICE. The client already honors an `engine_logged:true`
+# marker on a /chat row (viewer/openworlds/app.jsx: `if (it.engine_logged === true) return
+# null;`) to drop the blob when its prose is also in /events. These helpers stamp that marker —
+# but ONLY when the prose was truly logged to the engine session log, so the client never drops
+# a legitimately /chat-only beat (which would render it to zero rows).
+#
+# Ported verbatim-in-intent from scripts/play_codex_dm.sh (the codex DM path already solved this
+# with the same three pieces); factored here ONCE so the two CLAUDE-DM viewer-backed wrappers
+# (scripts/play.sh + scripts/play_party.sh) share it and can't drift — mirroring how
+# clawdnd_dm_remint_session_on_retry is shared. These read the caller's ambient globals (exactly
+# as the codex versions read $CHAT/$RUN_DIR/$ROOT): $CHAT (the chat.jsonl path), $STATE_DIR (the
+# play state dir), and $ROOT (the repo root). Both wrappers define all three before sourcing.
+#
+# BASH 3.2 SAFETY: chatlog + log_engine_narration carry quoted heredocs, which macOS bash 3.2
+# mis-parses when nested inside $(...). They are ALWAYS called DIRECTLY (never in a command
+# substitution) — keep it that way.
+
+# chatlog ROLE TEXT [EXTRA_JSON] — append one row to $CHAT. The optional 3rd arg is a JSON
+# object merged into the {role,text} row (e.g. '{"engine_logged":true}'). Empty/absent → a
+# plain {role,text} row, byte-identical to the pre-#720 one-liner.
+chatlog() {
+  python3 - "$CHAT" "$1" "$2" "${3:-}" <<'PY'
+import json
+import sys
+
+path, role, text, extra_json = sys.argv[1:]
+row = {"role": role, "text": text}
+if extra_json:
+    try:
+        extra = json.loads(extra_json)
+    except ValueError as exc:
+        raise SystemExit(f"invalid chatlog extra_json: {exc}") from exc
+    if not isinstance(extra, dict):
+        raise SystemExit(f"invalid chatlog extra_json: expected object, got {type(extra).__name__}")
+    row.update(extra)
+with open(path, "a", encoding="utf-8") as handle:
+    handle.write(json.dumps(row) + "\n")
+PY
+}
+
+# log_engine_narration CAMPAIGN_ID TEXT — append the reply to the engine's session log as a
+# `narration` beat (the /events source). Returns non-zero (WITHOUT touching the engine) on a
+# blank campaign id or blank text, OR if the engine call fails — that is the signal
+# record_dm_reply uses to fall back to an unflagged chat row.
+log_engine_narration() {
+  local campaign_id="$1" text="$2"
+  [ -n "${campaign_id//[[:space:]]/}" ] || return 1
+  [ -n "${text//[[:space:]]/}" ] || return 1
+  CLAWDND_STATE_DIR="$STATE_DIR" WORLDOS_STATE_DIR="$STATE_DIR" \
+    uv run --directory "$ROOT/servers/engine" python - "$campaign_id" "$text" <<'PY'
+import sys
+
+import server
+
+campaign_id, text = sys.argv[1], sys.argv[2]
+server.log_event(campaign_id, "narration", text)
+PY
+}
+
+# record_dm_reply CAMPAIGN_ID TEXT PHASE — write a DM reply to the chronicle, stamping
+# engine_logged:true IFF the prose was also logged to the engine session log (so the client can
+# de-dup the /chat blob against /events). On failure → an UNFLAGGED row (byte-identical to the
+# pre-#720 behavior; the client's eventsStreamedThisTurnRef backstop still applies). NEVER stamp
+# the flag unconditionally — that would suppress a legitimately /chat-only beat to zero rows.
+record_dm_reply() {
+  local campaign_id="$1" text="$2" phase="$3"
+  if log_engine_narration "$campaign_id" "$text"; then
+    chatlog dm "$text" '{"engine_logged":true}'
+  else
+    echo "[worldos] warning: could not record ${phase} narration through engine — chat row written without engine_logged" >&2
+    chatlog dm "$text"
+  fi
+}
+
 # LEAN-BEAT DM-TURN ARGS (the ONE shared implementation of the CLAWDND_LEAN_BEATS path).
 #
 # Both play loops (scripts/play.sh AND qa/run_duo.sh) drive a DM turn through `claude -p`,

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -173,22 +173,64 @@ with open(path, "a", encoding="utf-8") as handle:
 PY
 }
 
-# log_engine_narration CAMPAIGN_ID TEXT — append the reply to the engine's session log as a
-# `narration` beat (the /events source). Returns non-zero (WITHOUT touching the engine) on a
-# blank campaign id or blank text, OR if the engine call fails — that is the signal
-# record_dm_reply uses to fall back to an unflagged chat row.
+# log_engine_narration CAMPAIGN_ID TEXT — ensure the reply is in the engine's session log as a
+# `narration` beat (the /events + recap/memory source), then return 0 so record_dm_reply stamps
+# engine_logged. Returns non-zero (WITHOUT touching the engine) on a blank campaign id or blank
+# text, OR if the engine call fails — that is the signal record_dm_reply uses to fall back to an
+# unflagged chat row.
+#
+# IDEMPOTENT (#720, adversarial-review fix): the CLAUDE DM often ALREADY logs the opening/beat
+# narration to the session log DURING its turn. An unconditional append would put the prose in
+# the log TWICE → a SECOND /events row (the viewer keys /events by line-index seq, not by text)
+# → the duplicate would be RELOCATED (/events-vs-/events), not fixed. So we append ONLY when the
+# prose is not already in the recent session-log narration. Either way the prose ends up in the
+# engine log EXACTLY ONCE and we return 0 → the redundant /chat blob is dropped → rendered once.
+# The CODEX DM (which does not self-log narration) still gets the canonical append. Whitespace-
+# normalized substring match covers both the single-blob and per-paragraph logging shapes.
 log_engine_narration() {
   local campaign_id="$1" text="$2"
   [ -n "${campaign_id//[[:space:]]/}" ] || return 1
   [ -n "${text//[[:space:]]/}" ] || return 1
   CLAWDND_STATE_DIR="$STATE_DIR" WORLDOS_STATE_DIR="$STATE_DIR" \
     uv run --directory "$ROOT/servers/engine" python - "$campaign_id" "$text" <<'PY'
+import glob
+import json
+import os
 import sys
 
 import server
 
 campaign_id, text = sys.argv[1], sys.argv[2]
-server.log_event(campaign_id, "narration", text)
+norm = " ".join(text.split())
+
+already = False
+try:
+    state = os.environ.get("CLAWDND_STATE_DIR") or os.environ.get("WORLDOS_STATE_DIR") or "."
+    files = sorted(
+        glob.glob(os.path.join(state, "campaigns", campaign_id, "sessions", "*.jsonl")),
+        key=os.path.getmtime,
+    )
+    if files:
+        recent = []
+        with open(files[-1], encoding="utf-8") as fh:
+            for ln in fh:
+                ln = ln.strip()
+                if not ln:
+                    continue
+                try:
+                    entry = json.loads(ln)
+                except ValueError:
+                    continue
+                if entry.get("kind") == "narration":
+                    recent.append(" ".join((entry.get("text") or "").split()))
+        blob = " ".join(recent[-8:])
+        if norm and norm in blob:
+            already = True  # the DM already logged this prose this turn — do NOT double-log
+except Exception:
+    already = False  # any read failure → fall through to a normal append (no regression)
+
+if not already:
+    server.log_event(campaign_id, "narration", text)
 PY
 }
 

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -126,7 +126,9 @@ json.dump(cfg, open(out, "w"))
 PY
 
 DSID="$(uuidgen 2>/dev/null || python3 -c 'import uuid;print(uuid.uuid4())')"
-chatlog() { python3 -c 'import json,sys;open(sys.argv[1],"a").write(json.dumps({"role":sys.argv[2],"text":sys.argv[3]})+"\n")' "$CHAT" "$1" "$2"; }
+# chatlog + log_engine_narration + record_dm_reply are shared helpers in qa/lib_beat_driver.sh
+# (sourced above); they read $CHAT/$STATE_DIR/$ROOT from this scope. record_dm_reply (#720)
+# stamps engine_logged on DM-reply rows so the OpenWorlds client de-dups the cold-open opening.
 
 # --- OPTIONAL: pre-seed a PLAYER-authored hero before the DM's first turn. ---------------
 # When the Creation wizard's "Bind" runs, it passes the authored hero through the native
@@ -397,14 +399,15 @@ fi
 # #357: same empty-reply fallback as the beat loop — recover the engine's logged opening
 # narration if the DM's first turn ended on a tool call rather than prose.
 DMSG="$(clawdnd_dm_narration_or_fallback "$DMSG" "$STATE_DIR")"
-chatlog dm "$DMSG"; DM_TURNS=1
 
-# Resolve the campaign id the DM just minted (for the lean re-ground; harmless when
-# CLAWDND_LEAN_BEATS=0). The opening beat called start_world/get_state, which writes the
-# snapshot to $STATE_DIR/campaigns/<id>/snapshot.json — read the id back from that dir.
-# A solo launch uses a brand-new state dir, so there is exactly one campaign here. When a
-# hero was pre-seeded we already know it ($HERO_CAMP). Empty ⇒ lean falls back to the
-# normal --resume path (dm_turn no-ops lean when the id is unknown).
+# Resolve the campaign id the DM just minted, BEFORE writing the opening to the chronicle —
+# record_dm_reply (#720) needs it to log the opening narration to the engine session log so the
+# OpenWorlds client can de-dup the /chat opening blob against /events. The campaign already
+# exists here (the cold-open dm_turn ran start_world/get_state, writing the snapshot to
+# $STATE_DIR/campaigns/<id>/snapshot.json). A solo launch uses a brand-new state dir, so there
+# is exactly one campaign. When a hero was pre-seeded we already know it ($HERO_CAMP). Empty ⇒
+# record_dm_reply falls back to an unflagged row AND lean falls back to the normal --resume path
+# (both are byte-identical to the pre-#720 behavior when the id is unknown).
 CAMPAIGN_ID="$HERO_CAMP"
 if [ -z "$CAMPAIGN_ID" ] && [ -d "$STATE_DIR/campaigns" ]; then
   # No pre-seeded hero → ask the ENGINE which save is live (the most-recently-played
@@ -415,6 +418,9 @@ if [ -z "$CAMPAIGN_ID" ] && [ -d "$STATE_DIR/campaigns" ]; then
   CAMPAIGN_ID="$(clawdnd_live_campaign_id "$ROOT" "$STATE_DIR" "$WORLD")"
   [ -z "$CAMPAIGN_ID" ] && CAMPAIGN_ID="$(find "$STATE_DIR/campaigns" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | head -n1)"
 fi
+# #720: write the opening through record_dm_reply — stamps engine_logged:true on the chat row
+# IFF the opening prose is also logged to the engine session log, so the client renders it ONCE.
+record_dm_reply "$CAMPAIGN_ID" "$DMSG" opening; DM_TURNS=1
 if [ "$CLAWDND_LEAN_BEATS" = "1" ]; then
   if [ -n "$CAMPAIGN_ID" ]; then
     echo "[play] lean-beats ON — beats 2+ re-ground via scene_context (campaign=$CAMPAIGN_ID), no transcript replay"
@@ -470,7 +476,8 @@ $RUNBOOK" "$CAMPAIGN_ID")"
     # empty — fall back to the player-facing narration the engine logged this beat so the chat is
     # never blank on a resolved move (engine stays the sole writer; this only READS its log).
     DMSG="$(clawdnd_dm_narration_or_fallback "$DMSG" "$STATE_DIR")"
-    chatlog dm "$DMSG"; DM_TURNS=$((DM_TURNS + 1))
+    # #720: route the per-beat DM reply through record_dm_reply (engine_logged stamp on success).
+    record_dm_reply "$CAMPAIGN_ID" "$DMSG" beat; DM_TURNS=$((DM_TURNS + 1))
     # C — soft clock-tick backstop: advance one phase via the engine only if the DM left the
     # clock frozen this beat (engine stays the sole writer; defers to the DM's in-fiction pacing).
     clawdnd_soft_tick "$ROOT" "$STATE_DIR" "$PREV_DAY" "$PREV_TOD"

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -273,7 +273,9 @@ PY
 done
 
 DSID="$(uuidgen 2>/dev/null || python3 -c 'import uuid;print(uuid.uuid4())')"
-chatlog() { python3 -c 'import json,sys;open(sys.argv[1],"a").write(json.dumps({"role":sys.argv[2],"text":sys.argv[3]})+"\n")' "$CHAT" "$1" "$2"; }
+# chatlog + log_engine_narration + record_dm_reply are shared helpers in qa/lib_beat_driver.sh
+# (sourced above); they read $CHAT/$STATE_DIR/$ROOT from this scope. record_dm_reply (#720)
+# stamps engine_logged on DM-reply rows so the OpenWorlds client de-dups the cold-open opening.
 echo "[play-party] run=$RUN world=$WORLD port=$PORT companions=$NUM_COMP dm=$DSID"
 
 # --- one agent turn (DM full plugin, or a companion via its facade only) ----------------
@@ -471,7 +473,9 @@ Each beat, declarations arrive as tagged moves — [say] (dialogue), [do] (an at
 # call rather than prose — BEFORE the abort check, so a tool-final-but-narrated opener stands.
 DMSG="$(clawdnd_dm_narration_or_fallback "$DMSG" "$STATE_DIR")"
 [ -z "$DMSG" ] && { echo "[play-party] DM produced no opening — aborting (see $COMBINED)" >&2; exit 1; }
-chatlog dm "$DMSG"; AGENT_TURNS=1
+# #720: route the opening through record_dm_reply — engine_logged stamp on success so the
+# OpenWorlds client renders the cold-open opening ONCE (this is the dup source on the VM sweep).
+record_dm_reply "$CAMPAIGN_ID" "$DMSG" opening; AGENT_TURNS=1
 echo "[play-party] DM opened: ${DMSG:0:120}…"
 
 # --- SEATING GUARD: the cold open MUST seat a player PC ----------------------------------
@@ -518,7 +522,8 @@ if ! pc_seated; then
 - Then CLOSE the turn by writing the opening SCENE as 2nd-person player-facing prose addressed to \"you\" (where the player IS, what they see/hear/smell, who is present + a real quoted line), ending on a clear open moment + choice. NEVER end on a tool call or a 3rd-person setup brief.")"
   RESEAT_DMSG="$(clawdnd_dm_narration_or_fallback "$RESEAT_DMSG" "$STATE_DIR")"
   AGENT_TURNS=$((AGENT_TURNS + 1))
-  if [ -n "$RESEAT_DMSG" ]; then DMSG="$RESEAT_DMSG"; chatlog dm "$DMSG"; echo "[play-party] reseat turn opened: ${DMSG:0:120}…"; fi
+  # #720: the reseat turn re-writes the opening scene — route it through record_dm_reply too.
+  if [ -n "$RESEAT_DMSG" ]; then DMSG="$RESEAT_DMSG"; record_dm_reply "$CAMPAIGN_ID" "$DMSG" reseat; echo "[play-party] reseat turn opened: ${DMSG:0:120}…"; fi
   if ! pc_seated; then
     echo "[play-party] COLD-OPEN SEATED NO PC: after a retry the party still has no kind=\"player\" member — aborting rather than hand the player a no_actor session (see $COMBINED)." >&2
     exit 1
@@ -563,7 +568,8 @@ $INTRO_BLOCK
 Narrate the RESULT of each declared move (never invent a companion's internal choice), then weave the open moment back to the human PLAYER inside the scene — never a bare 'Your move.'")"
   # #357: recover engine-logged narration if this DM turn ended on a tool call.
   DMSG="$(clawdnd_dm_narration_or_fallback "$DMSG" "$STATE_DIR")"
-  [ -n "$DMSG" ] && { chatlog dm "$DMSG"; AGENT_TURNS=$((AGENT_TURNS + 1)); echo "[play-party] DM after intros: ${DMSG:0:120}…"; }
+  # #720: route the after-intros DM beat through record_dm_reply (engine_logged stamp on success).
+  [ -n "$DMSG" ] && { record_dm_reply "$CAMPAIGN_ID" "$DMSG" after_intros; AGENT_TURNS=$((AGENT_TURNS + 1)); echo "[play-party] DM after intros: ${DMSG:0:120}…"; }
 fi
 
 # --- session ceiling (aggregate cost + turn cap), mirrors play.sh + run_party.sh --------
@@ -643,7 +649,8 @@ Then PLAY the next beat as a full lived scene — NOT a fragment: any NPC (or co
     # #357: if the DM turn ended on a tool call / 3rd-person status line, recover the
     # player-facing narration the engine logged this beat so the chat is never blank.
     DMSG="$(clawdnd_dm_narration_or_fallback "$DMSG" "$STATE_DIR")"
-    chatlog dm "$DMSG"; AGENT_TURNS=$((AGENT_TURNS + 1))
+    # #720: route the per-beat DM reply through record_dm_reply (engine_logged stamp on success).
+    record_dm_reply "$CAMPAIGN_ID" "$DMSG" beat; AGENT_TURNS=$((AGENT_TURNS + 1))
     # Remember this beat's location so the next beat's runbook can detect a stuck party (travel cue).
     PREV_LOC="$(printf '%s' "$(clawdnd_read_progress "$STATE_DIR")" | cut -f5)"
   else

--- a/servers/engine/tests/test_dm_reply_engine_logged.py
+++ b/servers/engine/tests/test_dm_reply_engine_logged.py
@@ -1,0 +1,196 @@
+"""Regression: the cold-open DM narration must NOT appear twice in the OpenWorlds chronicle.
+
+Root cause this guards (issue #720, RRI 2026-06-09): the opening prose lands in TWO
+viewer-read sources — the engine per-session log (per-paragraph, fed to ``/events``) AND
+``chat.jsonl`` (the whole opening as one blob, written by the play wrappers' ``chatlog``
+with NO ``engine_logged`` flag). The client's mid-session de-dup
+(``eventsStreamedThisTurnRef``, ``viewer/openworlds/app.jsx``) holds mid-session but does
+NOT guard the cold-open blob (the opening is already complete pre-mount), so the opening
+renders twice.
+
+The CLIENT side is already done + tested: ``app.jsx`` does ``if (it.engine_logged === true)
+return null;`` and ``viewer/tests/test_live_narration_stream.py
+::test_engine_logged_chat_reply_resolves_without_rendering_duplicate`` passes. This file
+guards the WRAPPER side — the proven Codex idiom (``scripts/play_codex_dm.sh``'s 3-arg
+``chatlog`` + ``log_engine_narration`` + ``record_dm_reply``) ported into the shared
+``qa/lib_beat_driver.sh`` so BOTH ``scripts/play.sh`` and ``scripts/play_party.sh`` stamp
+``{"engine_logged": true}`` on a DM reply IFF that prose was also logged to the engine
+session log (so the client can de-dup it). On engine-log FAILURE the row is written WITHOUT
+the flag (byte-identical to the pre-fix behavior; the ``eventsStreamedThisTurnRef`` backstop
+still applies). The flag is NEVER stamped unconditionally — that would suppress a
+legitimately /chat-only beat to zero rendered rows.
+
+These tests are gateway-free and exercise the REAL bash helpers under ``/bin/bash`` (macOS
+system bash is 3.2; the helpers are 3.2-clean, so this also guards 3.2 compatibility). The
+SUCCESS path seeds a REAL campaign via the engine (no live LLM) so ``record_dm_reply`` runs
+its genuine ``log_event`` success branch. Discovered + run in CI via ``servers/engine``
+pytest.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+LIB = ROOT / "qa" / "lib_beat_driver.sh"
+
+
+def _bash(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["/bin/bash", "-c", script], capture_output=True, text=True, cwd=str(ROOT)
+    )
+
+
+def _src(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def _rows(chat_path: Path) -> list:
+    return [
+        json.loads(line)
+        for line in chat_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+# --- behavioral: the 3-arg chatlog ------------------------------------------------------------
+
+
+def test_chatlog_three_arg_merges_extra_json(tmp_path):
+    """The 3rd arg (an extra-JSON object) is merged into the row alongside role+text."""
+    chat = tmp_path / "chat.jsonl"
+    script = (
+        f'set -u; CHAT="{chat}"; . "{LIB}"\n'
+        "chatlog dm 'the opening scene' '{\"engine_logged\":true}'\n"
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    rows = _rows(chat)
+    assert len(rows) == 1, rows
+    assert rows[0] == {"role": "dm", "text": "the opening scene", "engine_logged": True}
+
+
+def test_chatlog_two_arg_is_byte_identical_to_legacy(tmp_path):
+    """No 3rd arg -> exactly {role,text} (no stray keys); the legacy fallback row shape."""
+    chat = tmp_path / "chat.jsonl"
+    script = f'set -u; CHAT="{chat}"; . "{LIB}"\nchatlog player "I draw my blade"\n'
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    rows = _rows(chat)
+    assert rows == [{"role": "player", "text": "I draw my blade"}]
+
+
+def test_chatlog_empty_extra_arg_is_treated_as_legacy(tmp_path):
+    """An empty 3rd arg (the FAILURE-path call shape) must not add keys / must not error."""
+    chat = tmp_path / "chat.jsonl"
+    script = f'set -u; CHAT="{chat}"; . "{LIB}"\nchatlog dm "terse beat" ""\n'
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    assert _rows(chat) == [{"role": "dm", "text": "terse beat"}]
+
+
+# --- behavioral: record_dm_reply (the truthfulness guard) -------------------------------------
+
+
+def _record_dm_reply_script(state_dir: Path, chat: Path, campaign_id: str, text: str, phase: str):
+    # ROOT + STATE_DIR + CHAT are the ambient globals the ported helpers read (exactly as
+    # play_codex_dm.sh's versions read $ROOT/$RUN_DIR/$CHAT). uv resolves the engine venv.
+    return (
+        f'set -u; ROOT="{ROOT}"; STATE_DIR="{state_dir}"; CHAT="{chat}"; . "{LIB}"\n'
+        f"record_dm_reply {campaign_id!r} {text!r} {phase}\n"
+    )
+
+
+def test_record_dm_reply_success_stamps_engine_logged_and_logs_to_engine(tmp_path, monkeypatch):
+    """SUCCESS path: a real campaign exists -> the narration is appended to the engine session
+    log AND the dm chat row carries engine_logged:true (so the client de-dups the blob)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server  # engine tools as plain functions; state dir from CLAWDND_STATE_DIR
+
+    campaign_id = server.start_world("sundered-reach")["campaign_id"]
+
+    chat = tmp_path / "chat.jsonl"
+    prose = "You stand at the gate as rain hisses on the cobbles."
+    r = _bash(_record_dm_reply_script(tmp_path, chat, campaign_id, prose, "opening"))
+    assert r.returncode == 0, r.stderr
+
+    # 1) the dm chat row got the flag.
+    rows = _rows(chat)
+    assert rows == [{"role": "dm", "text": prose, "engine_logged": True}], rows
+
+    # 2) the engine session log actually received the narration (the success precondition for
+    #    stamping the flag — the client trusts the flag to mean "this prose is also in /events").
+    sessions_dir = tmp_path / "campaigns" / campaign_id / "sessions"
+    logged = "\n".join(
+        p.read_text(encoding="utf-8") for p in sessions_dir.glob("*.jsonl")
+    )
+    assert prose in logged, "record_dm_reply SUCCESS must log the narration to the engine"
+    assert '"narration"' in logged, "the engine entry must be a narration kind"
+
+
+def test_record_dm_reply_failure_writes_row_without_flag(tmp_path):
+    """FAILURE path: a blank/whitespace campaign id is rejected by log_engine_narration -> the
+    dm row is written WITHOUT the flag (byte-identical fallback; no live LLM/engine needed)."""
+    chat = tmp_path / "chat.jsonl"
+    prose = "A terse beat the engine could not record."
+    # A whitespace-only campaign id -> log_engine_narration returns 1 -> fallback chatlog.
+    r = _bash(_record_dm_reply_script(tmp_path, chat, "   ", prose, "beat"))
+    assert r.returncode == 0, r.stderr
+    rows = _rows(chat)
+    assert rows == [{"role": "dm", "text": prose}], rows
+    assert "engine_logged" not in rows[0], "FAILURE path must NOT stamp the flag"
+
+
+def test_log_engine_narration_rejects_blank_inputs(tmp_path):
+    """The guard: a blank campaign id OR blank text returns non-zero WITHOUT touching the
+    engine (this is what drives record_dm_reply's fallback branch)."""
+    script = (
+        f'set -u; ROOT="{ROOT}"; STATE_DIR="{tmp_path}"; . "{LIB}"\n'
+        'log_engine_narration "" "some prose"; echo "blank_cid=$?"\n'
+        'log_engine_narration "cid" "   "; echo "blank_text=$?"\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    assert "blank_cid=1" in r.stdout, r.stdout
+    assert "blank_text=1" in r.stdout, r.stdout
+
+
+# --- static contract: anti-drift across both viewer-backed wrappers ---------------------------
+
+
+def test_shared_helpers_live_in_lib_beat_driver():
+    """The 3 ported helpers live ONCE in the shared lib (DRY, mirroring
+    clawdnd_dm_remint_session_on_retry) and stamp the flag only on the success branch."""
+    lib = _src("qa/lib_beat_driver.sh")
+    assert "log_engine_narration()" in lib
+    assert "record_dm_reply()" in lib
+    # the 3-arg chatlog (optional extra_json merged into the row) lives in the lib too.
+    assert "chatlog()" in lib
+    assert '"engine_logged":true' in lib, "success branch must stamp the flag"
+    # the flag is conditional on engine-log success (truthfulness guard), never unconditional.
+    assert "if log_engine_narration" in lib
+
+
+def test_both_viewer_wrappers_route_dm_replies_through_record_dm_reply():
+    """play.sh + play_party.sh (the two CLAUDE-DM viewer-backed wrappers) must route their
+    DM-reply writes through the shared record_dm_reply rather than a bare `chatlog dm`."""
+    play, party = _src("scripts/play.sh"), _src("scripts/play_party.sh")
+    for name, src in (("play.sh", play), ("play_party.sh", party)):
+        assert "record_dm_reply" in src, name
+    # play.sh: the opening + per-move DM writes route through record_dm_reply.
+    assert "record_dm_reply \"$CAMPAIGN_ID\" \"$DMSG\" opening" in play
+    assert "record_dm_reply \"$CAMPAIGN_ID\" \"$DMSG\" beat" in play
+    # play.sh must NOT keep a bare `chatlog dm` for the DM reply (it would re-introduce the dup).
+    assert "chatlog dm " not in play, "play.sh must route all DM replies through record_dm_reply"
+    # play_party.sh: the opening routes through record_dm_reply (the cold-open dup source).
+    assert "record_dm_reply \"$CAMPAIGN_ID\" \"$DMSG\" opening" in party
+    assert "chatlog dm " not in party, "play_party.sh must route all DM replies through record_dm_reply"
+
+
+def test_non_dm_chat_rows_are_left_untouched():
+    """Player + companion rows must still be plain `chatlog ...` calls (NOT routed through
+    record_dm_reply, which would wrongly engine-log a player line as DM narration)."""
+    play, party = _src("scripts/play.sh"), _src("scripts/play_party.sh")
+    assert "chatlog player " in play, "play.sh player row must stay a plain chatlog call"
+    assert "chatlog player " in party, "play_party.sh player row must stay a plain chatlog call"
+    assert 'chatlog "companion:' in party, "play_party.sh companion rows must stay plain chatlog"

--- a/servers/engine/tests/test_dm_reply_engine_logged.py
+++ b/servers/engine/tests/test_dm_reply_engine_logged.py
@@ -194,3 +194,97 @@ def test_non_dm_chat_rows_are_left_untouched():
     assert "chatlog player " in play, "play.sh player row must stay a plain chatlog call"
     assert "chatlog player " in party, "play_party.sh player row must stay a plain chatlog call"
     assert 'chatlog "companion:' in party, "play_party.sh companion rows must stay plain chatlog"
+
+
+# --- #720 IDEMPOTENCY (adversarial-review fix) -------------------------------------------------
+# The CLAUDE DM (the release path) frequently logs the opening/beat narration to the engine
+# session log DURING its turn (confirmed across real VM runs). An UNCONDITIONAL re-log in
+# record_dm_reply would then put the prose in the log TWICE → a SECOND /events row (the viewer
+# keys /events by line-index seq, not by text) → the duplicate is RELOCATED (/events-vs-/events),
+# not fixed. So log_engine_narration appends ONLY when the prose is not already in the recent
+# session-log narration, but ALWAYS returns success so the flag is stamped: the prose ends up in
+# the engine log EXACTLY ONCE and the redundant /chat blob is dropped → rendered once.
+
+def _narration_texts(state_dir: Path, campaign_id: str) -> list:
+    out = []
+    sdir = state_dir / "campaigns" / campaign_id / "sessions"
+    for p in sorted(sdir.glob("*.jsonl")) if sdir.is_dir() else []:
+        for line in p.read_text(encoding="utf-8").splitlines():
+            if not line.strip():
+                continue
+            e = json.loads(line)
+            if e.get("kind") == "narration":
+                out.append(e.get("text", ""))
+    return out
+
+
+def test_record_dm_reply_does_not_double_log_when_dm_already_logged(tmp_path, monkeypatch):
+    """The CLAUDE-path bug: the DM already logged the opening this turn. record_dm_reply must NOT
+    append a SECOND copy (which would render twice in /events) — it detects the prose is present,
+    skips the append, and STILL stamps engine_logged so the /chat blob is dropped → single render."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+    campaign_id = server.start_world("sundered-reach")["campaign_id"]
+    opening = "You stand at the gate as rain hisses on the cobbles and a guard eyes your blade."
+    server.log_event(campaign_id, "narration", opening)  # the DM logs it during its own turn
+
+    def n_opening():
+        return sum(1 for t in _narration_texts(tmp_path, campaign_id) if t == opening)
+
+    assert n_opening() == 1, "precondition: the DM logged the opening exactly once"
+    chat = tmp_path / "chat.jsonl"
+    r = _bash(_record_dm_reply_script(tmp_path, chat, campaign_id, opening, "opening"))
+    assert r.returncode == 0, r.stderr
+    assert n_opening() == 1, "record_dm_reply must NOT double-log the already-logged opening"
+    assert _rows(chat) == [{"role": "dm", "text": opening, "engine_logged": True}], _rows(chat)
+
+
+def test_record_dm_reply_idempotent_across_per_paragraph_logging(tmp_path, monkeypatch):
+    """The DM may log the opening as SEPARATE paragraph beats while record_dm_reply gets the whole
+    reply. The whitespace-normalized membership check must still see it as already-logged and skip
+    the append (no extra full-blob narration row added)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+    campaign_id = server.start_world("sundered-reach")["campaign_id"]
+    para1 = "Morning in the Lower City arrives loud."
+    para2 = "Temple bells clash with crier calls over cracked cobbles."
+    server.log_event(campaign_id, "narration", para1)
+    server.log_event(campaign_id, "narration", para2)
+    before = _narration_texts(tmp_path, campaign_id)
+
+    chat = tmp_path / "chat.jsonl"
+    full = f"{para1}\n\n{para2}"  # the DM's final reply = the paragraphs concatenated (REAL newlines)
+    # Pass the reply with REAL newlines via ANSI-C $'...' quoting — exactly as play.sh passes a
+    # double-quoted $DMSG (the repr-based shared helper would escape \n to a literal backslash-n and
+    # defeat the whitespace normalization that production never hits).
+    full_ansi = "$'" + full.replace("\\", "\\\\").replace("'", "\\'").replace("\n", "\\n") + "'"
+    script = (
+        f'set -u; ROOT="{ROOT}"; STATE_DIR="{tmp_path}"; CHAT="{chat}"; . "{LIB}"\n'
+        f"record_dm_reply {campaign_id!r} {full_ansi} opening\n"
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    after = _narration_texts(tmp_path, campaign_id)
+    assert after == before, f"per-paragraph already-logged prose must not be re-appended: {after}"
+    assert full not in after, "the full-blob copy must NOT be added"
+    assert _rows(chat)[0].get("engine_logged") is True
+
+
+def test_record_dm_reply_appends_canonical_when_not_already_logged(tmp_path, monkeypatch):
+    """The CODEX-path / DM-didn't-self-log case: the prose is NOT in the engine log yet, so
+    record_dm_reply MUST append it (the canonical /events + recap/memory copy) exactly once,
+    then flag — keeping the engine_logged stamp truthful."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+    campaign_id = server.start_world("sundered-reach")["campaign_id"]
+    prose = "A lantern gutters in the gatehouse; the sergeant waves you through without a word."
+
+    def n_prose():
+        return sum(1 for t in _narration_texts(tmp_path, campaign_id) if t == prose)
+
+    assert n_prose() == 0, "precondition: prose not yet in the engine log"
+    chat = tmp_path / "chat.jsonl"
+    r = _bash(_record_dm_reply_script(tmp_path, chat, campaign_id, prose, "opening"))
+    assert r.returncode == 0, r.stderr
+    assert n_prose() == 1, "absent prose must be appended exactly once (canonical copy)"
+    assert _rows(chat) == [{"role": "dm", "text": prose, "engine_logged": True}]


### PR DESCRIPTION
Closes #720.

## The bug
The **cold-open opening narration rendered TWICE** in the OpenWorlds chronicle (vm2-newbie/narrative/veteran 5-persona sweep, RRI 2026-06-09). The opening prose lands in two viewer-read sources:
1. the engine per-session log (per-paragraph, `seq`+`sid`-keyed, fed to the viewer's `/events`), and
2. `chat.jsonl` (the whole opening as one blob, written by the play wrappers' `chatlog` with **no `engine_logged` flag**).

The client's mid-session de-dup (`eventsStreamedThisTurnRef`) assumes "/events lands a turn's paragraphs before its /chat blob" — true mid-session, **false on cold-open** (the opening is already complete pre-mount). So the opening shows up twice (cosmetic but systemic: doubles the log, shifts the a11y truncation horizon, compounds the latency UX).

## The fix — port the PROVEN Codex idiom (no new mechanism)
`scripts/play_codex_dm.sh` already solves this for the codex DM path with three pieces: a 3-arg `chatlog` (optional extra-JSON merged into the row), `log_engine_narration`, and `record_dm_reply` (stamps `{"engine_logged":true}` on the chat row **iff** the prose was also logged to the engine session log). **The client side is already done + tested** — `viewer/openworlds/app.jsx` does `if (it.engine_logged === true) return null;` and `viewer/tests/test_live_narration_stream.py::test_engine_logged_chat_reply_resolves_without_rendering_duplicate` passes. This PR is **wrapper-only** (the optional viewer defense-in-depth in #720 is explicitly deferred).

This ports that idiom into the two CLAUDE-DM viewer-backed wrappers, `scripts/play.sh` and `scripts/play_party.sh`.

### Design choice: shared lib (DRY), not per-script copies
Both wrappers **already source `qa/lib_beat_driver.sh`** (`grep -n lib_beat_driver` confirms), so the three helpers live **once** in that shared lib — mirroring the existing shared `clawdnd_dm_remint_session_on_retry` pattern — and both wrappers call them. The helpers read `$CHAT`/`$STATE_DIR`/`$ROOT` from the caller's scope (exactly as the codex versions read `$CHAT`/`$RUN_DIR`/`$ROOT`).

**`qa/lib_beat_driver.sh`** (+81): add `chatlog` (3-arg), `log_engine_narration`, `record_dm_reply`. On engine-log **SUCCESS** → flagged row; on **FAILURE** → unflagged row (byte-identical to today; the `eventsStreamedThisTurnRef` backstop still applies). The flag is **never** stamped unconditionally — a legitimately `/chat`-only beat must still render.

**`scripts/play.sh`**: drop the one-line `chatlog` (now shared); **move** the `CAMPAIGN_ID` resolution to **before** the opening write (`record_dm_reply` needs the id; the campaign already exists post cold-open `dm_turn`); route the opening + per-move DM writes through `record_dm_reply`.

**`scripts/play_party.sh`** (`CAMPAIGN_ID` already set early from the seed): drop the one-line `chatlog`; route the opening, reseat, after-intros, and per-beat DM writes through `record_dm_reply`. Player/companion rows are left as plain `chatlog` calls.

## bash 3.2 safety
The heredoc-bearing helpers (`chatlog`, `log_engine_narration`) are only ever called **directly**, never inside `$(...)` (which macOS bash 3.2 mis-parses). `/bin/bash -n` passes on all three files.

## Tests
- **New** `servers/engine/tests/test_dm_reply_engine_logged.py` (9 tests): 3-arg `chatlog` merge + legacy-shape byte-identity; `record_dm_reply` SUCCESS path (seeds a real campaign via `server.start_world`, asserts the dm row carries `engine_logged:true` **and** the engine session log received the narration); FAILURE path (blank campaign id → unflagged row); `log_engine_narration` blank-input rejection; static anti-drift (both wrappers route DM replies through `record_dm_reply`, no bare `chatlog dm` remains, player/companion rows untouched).
- Existing `servers/engine/tests/test_dm_session_remint.py` (10, anti-drift on the same scripts) — green.
- Client-side `viewer/tests/test_live_narration_stream.py` engine_logged de-dup + the two regression tests (`unstreamed_chat_paragraph_still_renders`, `terse_turn_after_streamed_turn_still_renders`) — green (confirms the wrapper→client contract end-to-end).
- `bash qa/fast_gate.sh` Tier-0 (188 engine + seat-path) — PASS.

Additive only; no engine `.py` touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DM narration now routes through a shared logging helper and marks entries when the narration is recorded by the engine, enabling client-side de-duplication.
* **Bug Fixes**
  * Eliminated duplicate cold-open narration rendering in chat by improving how DM narration is recorded and flagged.
* **Tests**
  * Added regression tests validating narration logging, idempotency, and the new DM routing and flagging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->