### PR TITLE
fix(engine): recompute initiative_bonus when a patch changes DEX (#733)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -2582,6 +2582,18 @@ def update_character(campaign_id: str, character_id: str = "", patch: dict = Non
             _apply_srd_class_defaults(new_ch, new_ch.classes[0].name,
                                       new_ch.total_level, set_base_ac=False)
             _recompute_level_scaled_stats(new_ch, patch or {})
+        # #733: keep initiative_bonus == DEX modifier when a patch changes the DEX score.
+        # Every engine write derives initiative_bonus from the DEX modifier (create_character,
+        # level_up's ASI path, the canon-load derivation), but update_character — the path a DM
+        # uses to correct/raise a stat directly — only recomputed the level-scaled class math, so
+        # a DEX edit left initiative_bonus FROZEN (optimizer RRI: "+1 shown vs +2 expected" — the
+        # combat roll 1d20+initiative_bonus and the heroes-screen `initiative` both read the stale
+        # value). Recompute from the new modifier when DEX moved, UNLESS the same patch set
+        # initiative_bonus EXPLICITLY (a DM Alert-feat/house-rule override wins). Purely additive:
+        # a non-DEX patch leaves the field exactly as before.
+        dex_changed = ch.ability_modifier(Ability.DEX) != new_ch.ability_modifier(Ability.DEX)
+        if dex_changed and "initiative_bonus" not in (patch or {}):
+            new_ch.initiative_bonus = new_ch.ability_modifier(Ability.DEX)
         c.characters[character_id] = new_ch
         save_campaign(c)
         return c.characters[character_id].model_dump(mode="json")

--- a/servers/engine/tests/test_engine.py
+++ b/servers/engine/tests/test_engine.py
@@ -176,3 +176,103 @@ def test_pacing_mode_default_set_and_invalid():
 
     with pytest.raises(Exception):
         server.set_pacing(cid, "leisurely")  # not a valid mode
+
+
+def test_initiative_bonus_equals_dex_modifier_on_create():
+    # #733: a freshly created character's initiative_bonus must equal its DEX modifier.
+    # DEX 14 -> +2 (the optimizer report: "+1 shown vs +2 expected").
+    import server
+
+    cid = server.create_campaign("Init Create")["id"]
+    pid = server.create_character(
+        cid, "Tav", kind="player", class_name="Rogue", level=1,
+        apply_srd_defaults=True, abilities={"dexterity": 14},
+    )["id"]
+    sheet = server.get_character(cid, pid)
+    assert sheet["abilities"]["dexterity"] == 14
+    assert sheet["initiative_bonus"] == 2  # == DEX modifier
+
+
+def test_initiative_bonus_recomputes_after_dex_patch():
+    # #733 root cause: update_character changed the DEX score but left initiative_bonus
+    # STALE (it only recomputed level-scaled stats on a class/level change). A DM stat
+    # correction / ASI-by-patch therefore left initiative wrong (e.g. +2 frozen while the
+    # DEX modifier became +4 or +1) — the exact "+1 shown vs +2 expected" divergence.
+    import server
+
+    cid = server.create_campaign("Init Patch")["id"]
+    pid = server.create_character(
+        cid, "Tav", kind="player", class_name="Rogue", level=1,
+        apply_srd_defaults=True, abilities={"dexterity": 14},
+    )["id"]
+    assert server.get_character(cid, pid)["initiative_bonus"] == 2  # baseline DEX 14 -> +2
+
+    # DEX up: 14 -> 18 (+4). initiative_bonus must track the new modifier.
+    server.update_character(cid, pid, patch={"abilities": {"dexterity": 18}})
+    sheet = server.get_character(cid, pid)
+    assert sheet["abilities"]["dexterity"] == 18
+    assert sheet["initiative_bonus"] == 4  # was stale +2 before the fix
+
+    # DEX down: 18 -> 12 (+1). A down-change must also be honored (not floored at the old value).
+    server.update_character(cid, pid, patch={"abilities": {"dexterity": 12}})
+    sheet = server.get_character(cid, pid)
+    assert sheet["abilities"]["dexterity"] == 12
+    assert sheet["initiative_bonus"] == 1
+
+    # round-trips through the snapshot the viewer reads
+    assert store.load_campaign(cid).characters[pid].initiative_bonus == 1
+
+
+def test_initiative_bonus_untouched_by_non_dex_patch():
+    # The recompute is scoped to DEX-affecting patches: a non-DEX edit (HP, or even a
+    # different ability) must NOT disturb a DM-set initiative_bonus.
+    import server
+
+    cid = server.create_campaign("Init NonDex")["id"]
+    pid = server.create_character(
+        cid, "Tav", kind="player", class_name="Fighter", level=1,
+        apply_srd_defaults=True, abilities={"dexterity": 14},
+    )["id"]
+    # DM hand-sets a higher initiative (e.g. an Alert-feat house rule): +7.
+    server.update_character(cid, pid, patch={"initiative_bonus": 7})
+    assert server.get_character(cid, pid)["initiative_bonus"] == 7
+
+    # A non-DEX patch must leave that explicit value alone.
+    server.update_character(cid, pid, patch={"current_hp": 5})
+    assert server.get_character(cid, pid)["initiative_bonus"] == 7
+
+    # An explicit initiative_bonus in the SAME patch wins even alongside a DEX change.
+    server.update_character(cid, pid, patch={"abilities": {"dexterity": 18}, "initiative_bonus": 9})
+    sheet = server.get_character(cid, pid)
+    assert sheet["abilities"]["dexterity"] == 18
+    assert sheet["initiative_bonus"] == 9  # DM override wins over the DEX-derived +4
+
+
+def test_start_combat_rolls_with_fresh_initiative_after_dex_patch(monkeypatch):
+    # End-to-end: after a DEX patch the COMBAT roll (1d20 + initiative_bonus) must use the
+    # fresh modifier, not the stale one. Pin the d20 to a known natural so the modifier is
+    # the only variable.
+    import server
+    import dice as dice_mod
+
+    def _fixed(expression, advantage=False, disadvantage=False, seed=None):
+        from dice import DiceRoll
+        bonus = 0
+        if "+" in expression:
+            bonus = int(expression.split("+", 1)[1])
+        return DiceRoll(expression=expression, total=10 + bonus, rolls=[10],
+                        modifier=bonus, is_d20=True, natural=10)
+
+    cid = server.create_campaign("Init Combat")["id"]
+    pid = server.create_character(
+        cid, "Tav", kind="player", class_name="Rogue", level=1,
+        apply_srd_defaults=True, abilities={"dexterity": 14},
+    )["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", abilities={"dexterity": 8})["id"]
+
+    server.update_character(cid, pid, patch={"abilities": {"dexterity": 18}})  # +2 -> +4
+
+    monkeypatch.setattr(server.dice_mod, "roll", _fixed)
+    view = server.start_combat(cid, [pid, gob])
+    tav_init = next(o["initiative"] for o in view["order"] if o["character_id"] == pid)
+    assert tav_init == 14  # natural 10 + fresh DEX modifier +4 (would be 12 with the stale +2)


### PR DESCRIPTION
## Issue
Fixes #733 — initiative roll modifier did not match the character's DEX modifier (**+1 shown vs +2 expected**, optimizer persona, v1.0.4-rc1 RRI `fa97b34`).

## Root cause (reproduced against the actual code)
`create_character` correctly sets `initiative_bonus = scores.modifier(Ability.DEX)` (server.py:1341), and `level_up`'s ASI path recomputes it (server.py:4783). **`update_character` did not.** When a patch changed the DEX *score* (a DM stat correction, an ASI-by-patch, a canon-adjust), the engine only recomputed the level-scaled *class* math on a class/level-signature change — `initiative_bonus` was left **frozen at its pre-edit value**.

Reproduced directly:
```
CREATE  DEX 14 -> initiative_bonus = 2   (correct: DEX mod +2)
PATCH   DEX 14 -> 18 -> initiative_bonus = 2  (STALE; should be +4)
PATCH   DEX 18 -> 12 -> initiative_bonus = 2  (STALE; should be +1)
```
Both display surfaces read the stale field — the heroes-screen `initiative` (`viewer/server.py` `_character_sheet`: `initiative = int(init_bonus)`) and the combat roll `1d20+initiative_bonus` (server.py:2976) — producing the "+1 vs +2" divergence.

## Fix (additive)
In `update_character`, after validation: if the patch moved the DEX *modifier* and the same patch did **not** set `initiative_bonus` explicitly, recompute `initiative_bonus = new_ch.ability_modifier(Ability.DEX)`. An explicit `initiative_bonus` in the patch (a DM Alert-feat / house-rule override) still wins. A non-DEX patch leaves the field exactly as before; old snapshots round-trip unchanged.

## Tests (servers/engine/tests/test_engine.py)
- `test_initiative_bonus_equals_dex_modifier_on_create`
- `test_initiative_bonus_recomputes_after_dex_patch` (DEX up **and** down)
- `test_initiative_bonus_untouched_by_non_dex_patch` (explicit override preserved across a non-DEX patch and in the same patch)
- `test_start_combat_rolls_with_fresh_initiative_after_dex_patch` (end-to-end: combat roll uses the fresh modifier)

Watched the two core tests FAIL before the fix (`assert 12 == 14`, stale `initiative_bonus == 2`), pass after.

## Verification
- `pytest tests/test_engine.py tests/test_combat.py tests/test_class_resources.py tests/test_progression.py tests/test_canon_abilities.py` — **205 passed**.
- `bash qa/fast_gate.sh` — **PASS** (188 engine + seat-path).

## Invariants
Engine remains sole writer; additive-by-default (`_StrictModel extra="forbid"` untouched, no new fields, defaults to today's behavior on non-DEX patches); no wire-contract change.