### PR TITLE
fix(engine): companion location/XP sync — de-facto companions co-locate AND co-earn (#353)

### DIFF
--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -604,6 +604,44 @@ def main() -> int:
                 stray.append(f"{ch.get('name', cid)}@{loc}{tag}")
         chk("companion_location_synced", not stray,
             f"party/companion not at current_location_id={cur!r}: {stray}", fatal=False)
+        # #353 explicit travel-scoped alias of the same invariant: the relocate sweep
+        # (_move_party_to / travel_to) must leave EVERY de-facto companion at the party's
+        # current location once travel has occurred (day>1 OR ≥2 visited locations). Same
+        # `stray` set; named so the audit's "companion absent after travel_to" assertion has
+        # a first-class key (the duo smoke keeps asserting on companion_location_synced).
+        locs_a6 = state.get("locations", {}) or {}
+        traveled = (state.get("day") or 1) > 1 or sum(
+            1 for l in locs_a6.values() if isinstance(l, dict) and l.get("visited")) >= 2
+        if traveled:
+            chk("companion_location_synced_on_travel", not stray,
+                f"after travel, party/companion not at current_location_id={cur!r}: {stray}",
+                fatal=False)
+
+    # #353 (WARN) — companion XP-sync on award. The relocate sweep co-locates every
+    # kind='companion' (incl. de-facto companions not in c.party); the XP-award paths must
+    # keep that group in step. When a reward seam paid the PC up (the PC's XP > 0) but a
+    # LIVING co-located companion is still stuck at 0, the companion was excluded from the
+    # split — the asymmetry this fix closes. Scope-guarded so a companion that joined mid-run
+    # (still legitimately at 0) or a pre-reward setup beat never false-REDs:
+    #   • only fires in xp leveling mode, and
+    #   • only flags companions at the party's CURRENT location (co-located = should-have-earned).
+    if state.get("leveling_mode", "xp") == "xp":
+        cur_xp = state.get("current_location_id")
+        pc_xp_max = max(
+            (ch.get("xp") or 0)
+            for ch in chars_all.values()
+            if isinstance(ch, dict) and ch.get("kind") == "player"
+        ) if any(isinstance(ch, dict) and ch.get("kind") == "player" for ch in chars_all.values()) else 0
+        lagging = []
+        if pc_xp_max > 0 and cur_xp:
+            for ch in chars_all.values():
+                if not isinstance(ch, dict) or ch.get("kind") != "companion" or ch.get("dead"):
+                    continue
+                if ch.get("location_id") == cur_xp and (ch.get("xp") or 0) == 0:
+                    lagging.append(ch.get("name") or "?")
+        chk("companion_xp_synced_on_award", not lagging,
+            f"PC earned XP (max={pc_xp_max}) but co-located companion(s) still at 0 XP "
+            f"(excluded from the party split): {lagging}", fatal=False)
 
     # A7 (WARN) — a leveled caster/martial with a signature skill but a COMPLETELY EMPTY
     # skill_proficiencies list (the load_canon_character gap: it skips _apply_srd_class_defaults).

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -235,6 +235,45 @@ def _move_party_to(c: Campaign, location_id: str) -> list[str]:
     return moved
 
 
+def _party_xp_recipients(c: Campaign, include_companions: bool = True) -> list[str]:
+    """The ids that share a PARTY XP award — the LIVING travelling group, in a stable
+    order. Mirrors `_move_party_to`'s membership rule: the PC(s) plus every
+    kind='companion', whether or not the DM remembered to add them to `c.party`.
+
+    This is the XP twin of the relocate sweep (#353): a de-facto companion (kind=
+    'companion' but absent from c.party — e.g. loaded via
+    load_canon_character(add_to_party=False) and never recruited) walks WITH the party,
+    so it must also EARN with the party. Gating XP on `c.party` membership while the
+    relocate path gated on KIND left such a companion co-located in every scene yet
+    silently stuck at its starting XP (the audit's "award_party_xp does not increment
+    companion XP" symptom; the Wyll-froze-at-the-checkpoint family).
+
+    Order: c.party first (preserving the existing remainder-to-first-recipient payout so
+    the PC still takes any odd XP), then any de-facto companion not already in c.party.
+    Excludes the dead and, when `include_companions=False`, every companion. Standalone
+    NPCs / monsters never earn (they aren't part of the group)."""
+    party_set = set(c.party)
+    kinds = {"player", "companion"} if include_companions else {"player"}
+    recipients: list[str] = []
+    seen: set[str] = set()
+
+    def _eligible(cid: str) -> bool:
+        m = c.characters.get(cid)
+        return m is not None and m.kind in kinds and not m.dead
+
+    for cid in c.party:  # c.party order first — keeps the PC as the remainder taker
+        if cid not in seen and _eligible(cid):
+            recipients.append(cid)
+            seen.add(cid)
+    if include_companions:  # then de-facto companions the DM never added to c.party
+        for cid, member in c.characters.items():
+            if cid not in seen and cid not in party_set and member.kind == "companion" \
+                    and not member.dead:
+                recipients.append(cid)
+                seen.add(cid)
+    return recipients
+
+
 def _party_levels(c: Campaign) -> list[int]:
     """The total-level of every LIVING party member (PC + companion) — the input the
     encounter sizing (`encounter.py` / `wander.pick_encounter`) needs to budget a fight
@@ -4464,7 +4503,9 @@ def _award_kill_xp(c, monster) -> "dict | None":
         return None
     if getattr(monster, "kind", "") != "monster" or not monster.dead or monster.xp_value <= 0:
         return None
-    recipients = [c.characters[i] for i in c.party if i in c.characters and not c.characters[i].dead]
+    # The whole travelling group earns (PC + de-facto companions), #353 — mirrors the
+    # relocate sweep so a companion that co-locates also levels.
+    recipients = [c.characters[i] for i in _party_xp_recipients(c)]
     if not recipients:
         return None
     total = monster.xp_value
@@ -4489,8 +4530,8 @@ def _award_milestone_xp(c: Campaign, amount: int, reason: str) -> "dict | None":
     empty/dead party. Caller persists (sole-writer) and guards idempotency."""
     if c.leveling_mode != "xp" or amount <= 0:
         return None
-    recipients = [c.characters[i] for i in c.party
-                  if i in c.characters and not c.characters[i].dead]
+    # The whole travelling group earns (PC + de-facto companions), #353.
+    recipients = [c.characters[i] for i in _party_xp_recipients(c)]
     if not recipients:
         return None
     each, rem = divmod(amount, len(recipients))
@@ -4671,12 +4712,10 @@ def award_party_xp(
     by hand and calling award_xp repeatedly."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
-        kinds = {"player", "companion"} if include_companions else {"player"}
-        recipients = [
-            cid
-            for cid in c.party
-            if (m := c.characters.get(cid)) and m.kind in kinds and not m.dead
-        ]
+        # The travelling group earns together (#353): include de-facto companions —
+        # kind='companion' but not in c.party — the same set the relocate sweep co-locates,
+        # unless the caller opts out with include_companions=False.
+        recipients = _party_xp_recipients(c, include_companions=include_companions)
         if not recipients:
             raise ValueError("no eligible party members to award XP to")
         each, extra = divmod(max(0, amount), len(recipients))
@@ -6976,8 +7015,11 @@ def end_session(campaign_id: str, summary: str = "") -> dict:
         # party is at 0) fall back to the original modest milestone grant.
         award = None
         if c.leveling_mode == "xp":
-            living = [c.characters[i] for i in c.party
-                      if i in c.characters and not c.characters[i].dead]
+            # The travelling group (PC + de-facto companions) shares the parity top-up, #353 —
+            # a companion that fought all session but was never added to c.party closed at 0
+            # while the PC banked XP; the relocate sweep already walks it, so the reward
+            # backstop must too.
+            living = [c.characters[i] for i in _party_xp_recipients(c)]
             advanced = (c.day > 1 or c.time_of_day != "morning"
                         or sum(1 for loc in c.locations.values() if loc.visited) > 1)
             if living and advanced:

--- a/servers/engine/tests/test_companion_xp_sync.py
+++ b/servers/engine/tests/test_companion_xp_sync.py
@@ -1,0 +1,122 @@
+"""Companion XP-sync (#353): a de-facto companion earns party XP just as it travels.
+
+The travel/relocate path (`_move_party_to`) co-locates the travelling group by KIND —
+the PC(s) plus every kind='companion', whether or not the DM remembered to add them to
+`c.party` (the Wyll-froze-at-the-checkpoint bug, fixed in test_travel.py). The XP-award
+paths used to gate recipients on `c.party` MEMBERSHIP instead, so a de-facto companion
+(kind='companion', loaded via load_canon_character(add_to_party=False) or otherwise not
+in c.party) walked with the group but EARNED NOTHING — it read as co-located in the
+scene yet fell behind on progression (the audit's "award_party_xp does not increment
+companion XP" symptom).
+
+This locks the symmetry: the set that travels together earns party XP together. Covers
+all three award paths — award_party_xp (tool), _award_kill_xp, _award_milestone_xp.
+"""
+import pytest
+
+import server
+import store
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    yield
+
+
+def _pc_and_defacto_companion():
+    """A campaign (xp mode) with a PC in the party and a de-facto companion that is
+    kind='companion' but NOT in c.party (simulating load_canon_character(add_to_party=False)
+    / a never-recruited NPC-loaded companion). Returns (cid, pc, comp)."""
+    cid = server.create_campaign("Companion XP Sync")["id"]
+    assert server._require(cid).leveling_mode == "xp"
+    pc = server.create_character(cid, "Renn", kind="player", max_hp=20)["id"]
+    comp = server.create_character(cid, "Cinder", kind="companion", max_hp=16)["id"]
+    # Drop the companion from the party array while it stays kind='companion' — the
+    # de-facto-companion shape the relocate sweep already handles but the XP paths did not.
+    c = store.load_campaign(cid)
+    c.party = [p for p in c.party if p != comp]
+    store.save_campaign(c)
+    assert comp not in store.load_campaign(cid).party  # precondition
+    return cid, pc, comp
+
+
+# ─── award_party_xp (the tool the DM calls directly) ────────────────────────
+
+def test_award_party_xp_includes_defacto_companion():
+    cid, pc, comp = _pc_and_defacto_companion()
+    out = server.award_party_xp(cid, 200, reason="quest")
+    granted = {g["name"]: g["granted"] for g in out["grants"]}
+    # Both the PC and the de-facto companion share the award (100 each), not 200-to-the-PC.
+    assert granted == {"Renn": 100, "Cinder": 100}
+    assert out["split_between"] == 2
+    assert server.get_character(cid, comp)["xp"] == 100
+
+
+def test_award_party_xp_include_companions_false_still_excludes_companion():
+    """The opt-out still works: include_companions=False pays only the PC, even though the
+    companion is a de-facto party member."""
+    cid, pc, comp = _pc_and_defacto_companion()
+    out = server.award_party_xp(cid, 200, reason="solo glory", include_companions=False)
+    granted = {g["name"]: g["granted"] for g in out["grants"]}
+    assert granted == {"Renn": 200}
+    assert server.get_character(cid, comp)["xp"] == 0
+
+
+def test_award_party_xp_does_not_pay_standalone_npc():
+    """Broadening to de-facto companions must NOT drag a standalone kind='npc' into the split."""
+    cid, pc, comp = _pc_and_defacto_companion()
+    npc = server.create_character(cid, "Barkeep", kind="npc", add_to_party=False)["id"]
+    out = server.award_party_xp(cid, 200, reason="quest")
+    names = {g["name"] for g in out["grants"]}
+    assert "Barkeep" not in names
+    assert server.get_character(cid, npc)["xp"] == 0
+
+
+# ─── _award_kill_xp / end_combat backstop ───────────────────────────────────
+
+def test_kill_xp_includes_defacto_companion():
+    cid, pc, comp = _pc_and_defacto_companion()
+    res = server.spawn_monster(cid, "Goblin Warrior")
+    mob_id, mob_xp = res["spawned"][0]["id"], res["xp_each"]
+    assert mob_xp > 0
+    server.start_combat(cid, [pc, comp, mob_id])
+    server.set_hp(cid, mob_id, 0)  # killing blow → kill-time award fires
+    server.end_combat(cid, resolution="the goblin falls")
+    pc_xp = server.get_character(cid, pc)["xp"]
+    comp_xp = server.get_character(cid, comp)["xp"]
+    # The de-facto companion earned a share of the kill (not 0); PC + comp split the value.
+    assert comp_xp > 0
+    assert pc_xp + comp_xp == mob_xp
+
+
+# ─── session-close XP-parity backstop ───────────────────────────────────────
+
+def test_session_close_parity_tops_up_defacto_companion():
+    """The end-session reward backstop levels a 0-XP de-facto companion to the party's XP
+    parity (it fought all session but was never in c.party). Mirrors the in-party fixD case."""
+    cid, pc, comp = _pc_and_defacto_companion()
+    server.start_session(cid)
+    # The PC banked XP via the single-target tool; the de-facto companion is still at 0.
+    server.award_xp(cid, pc, 300, reason="solo award")
+    # Advance the world so the backstop's `advanced` gate is satisfied.
+    c = store.load_campaign(cid)
+    c.day = 2
+    store.save_campaign(c)
+    out = server.end_session(cid)
+    # The companion was raised to the PC's XP (parity), not left at 0.
+    assert server.get_character(cid, comp)["xp"] == 300
+    assert any(g["name"] == "Cinder" for g in out.get("grants", []))
+
+
+# ─── _award_milestone_xp (story/social/exploration top-up) ──────────────────
+
+def test_milestone_xp_includes_defacto_companion():
+    cid, pc, comp = _pc_and_defacto_companion()
+    c = store.load_campaign(cid)
+    res = server._award_milestone_xp(c, 100, reason="quest resolved")
+    store.save_campaign(c)
+    assert res is not None
+    names = {g["name"] for g in res["grants"]}
+    assert names == {"Renn", "Cinder"}
+    assert server.get_character(cid, comp)["xp"] == 50


### PR DESCRIPTION
## Issue
Closes #353. Audit symptom: after `travel_to` a recruited companion reads as absent/abandoned, and `award_party_xp` does not increment companion XP (only the player's).

## Validate-before-fixing
Reproduced against the actual engine FIRST:

- **Location-on-travel — ALREADY FIXED, does NOT reproduce.** `_move_party_to` (server.py) already co-locates the travelling group by KIND — the PC(s) plus every `kind='companion'`, whether or not it's in `c.party`. `test_travel.py::test_move_party_to_relocates_companion_not_in_party_array` already locks this, and the duo smoke's `companion_location_synced` passes for exactly this reason.
- **XP-on-award — the REAL remaining gap, reproduced.** The XP-award paths gated recipients on `c.party` **membership** (`for i in c.party`), while the relocate sweep gates on **kind**. So a *de-facto companion* (`kind='companion'` but not in `c.party` — e.g. `load_canon_character(add_to_party=False)`, or a never-recruited companion) walks with the party but earns nothing. Repro: `award_party_xp(cid, 200)` paid the PC 200 and the de-facto companion 0.

## Fix (additive; engine = sole writer)
Shared `_party_xp_recipients(c, include_companions=True)` helper mirrors `_move_party_to`'s membership rule — `c.party` order first (preserves the remainder-to-PC payout), then de-facto companions not already in `c.party`. Routed through:

- `award_party_xp` (honors `include_companions=False`)
- `_award_kill_xp` (kill-time + end_combat backstop)
- `_award_milestone_xp` (story/social/exploration top-up)
- the session-close XP-parity backstop (`end_session`)

Standalone NPCs/monsters still never earn. `include_companions=False` still excludes companions. Old snapshots round-trip (no schema change).

## Behavioral guards (qa/assert_behavioral.py)
- `companion_location_synced_on_travel` — travel-scoped alias of the existing `companion_location_synced` (fires once travel has occurred: day>1 or ≥2 visited).
- `companion_xp_synced_on_award` — flags a co-located **living** companion left at 0 XP after the PC earned (xp-mode, current-location-scoped to avoid false REDs on a just-joined companion).

## Tests
`servers/engine/tests/test_companion_xp_sync.py` (6, all written failing-first):
- `award_party_xp` / kill-xp / milestone / session-close-parity each include a de-facto companion
- `include_companions=False` still excludes the companion
- a standalone `kind='npc'` is never dragged into the split

## Verification
- New file: 6 passed
- Full engine suite: **1740 passed**
- `qa/test_assert_behavioral.py`: 21 passed
- `bash qa/fast_gate.sh`: **PASS** (188 engine + seat-path)

Confidence ~0.9. The location half was already correct; this closes the XP asymmetry and the matching transcript guards.