### PR TITLE
fix(qa): guarantee a per-beat progress signal so a slow DM beat is never perceived as dropped/hung (closes #623)

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -249,6 +249,75 @@ record_dm_reply() {
   fi
 }
 
+# LIVE-PROGRESS + WRAPPER HEARTBEAT (#623 — the ONE shared implementation of the perceived-latency fix).
+#
+# The bug #623 ("beat silently DROPPED / HUNG >10min, no recovery") was a PERCEIVED-latency defect, not
+# real DM unreliability: forensics on the filing run showed all beats ran cleanly at ttft 2-5s / 85-157s
+# wall with ZERO timeouts/retries/empty-fallbacks. The defect is that /events stayed BLANK for the whole
+# beat → the OpenWorlds viewer's notePendingProgress streaming-flip never fired → the player stared at a
+# static "weaving the next beat" spinner and called a healthy 157s beat a "drop"/"hang". Two layers close
+# the gap (BOTH perceived-latency — neither touches wall-clock; the bounded timeout+retry+#357 fallback
+# are unchanged):
+#
+#   1. WRAPPER HEARTBEAT (model-INDEPENDENT, the guarantee): clawdnd_emit_progress_heartbeat writes a
+#      short wrapper-authored `narration` row to the engine session log via log_engine_narration BEFORE
+#      the DM `claude -p` even starts. That row lands in /events within ~1s, so the viewer flips its
+#      spinner to "the scene is arriving above" no matter how long the model thinks — and crucially, even
+#      when the model SKIPS the cooperative early log_event (Eva measured exactly that: a run with the rule
+#      present but streaming refs = 0). This is the same proven pattern the Codex DM wrapper already uses
+#      (scripts/play_codex_dm.sh: OPENING_PROGRESS_TEXT / MOVE_PROGRESS_TEXTS), factored here so every
+#      harness shares it. The player is NEVER staring at nothing.
+#
+#   2. CLAWDND_LIVE_PROGRESS_RULE (model-COOPERATIVE, the richer signal): prepended to the DM beat prompt
+#      so the model ALSO logs an early in-voice progress beat. Was already in scripts/play_party.sh +
+#      scripts/play_codex_dm.sh but MISSING from scripts/play.sh (the SOLO path that filed #623) — that
+#      absence is the bug. Factored here verbatim so the three harnesses can never drift again.
+#
+# The heartbeat is best-effort: a blank campaign id or an engine error no-ops (return 0) — it is a
+# perceived-latency nicety, never allowed to fail a beat. The engine stays the SOLE WRITER (this only
+# routes through log_engine_narration, which appends a narration event exactly as the DM's own would).
+CLAWDND_LIVE_PROGRESS_RULE="Live progress rule: after you know the live campaign and scene, call log_event(kind=\"narration\", text=\"...\") ONCE with a short, non-duplicate, player-facing progress beat BEFORE any longer resolution work. This is how /events shows visible story progress while your turn is still running. The progress beat MUST be 2nd-person prose addressed to \"you\" (a vivid one-line teaser of where the player stands or what they sense) — it is rendered STRAIGHT into the player's Chronicle. NEVER log a 3rd-person scene summary, a \"Cold open —\"/\"Scene:\"/\"Setup:\" header, a \"Choice: X or Y\" branch list, bracketed stage directions, or any director/planning note: that scaffolding is your private scratchpad and shatters immersion if it reaches the player. Keep the final reply as the full 2nd-person scene; do not copy this progress beat verbatim, because the wrapper records the final reply through the engine after the turn."
+
+# The wrapper-authored heartbeat texts. SHORT 2nd-person teasers (they render straight into the player's
+# Chronicle). The cold open (first=1) gets the opening teaser; continuing beats (first=0) ROTATE by index
+# so a multi-beat session never repeats the same line. Mirrors play_codex_dm.sh's two text banks.
+CLAWDND_OPENING_PROGRESS_TEXT="The first scene gathers around you; voices, risks, and choices come into focus."
+CLAWDND_MOVE_PROGRESS_TEXTS=(
+  "Your choice takes hold; nearby voices, risks, and consequences begin to answer."
+  "The world turns with your action; the scene shifts toward its answer."
+  "Your move lands; attention gathers around what changes next."
+  "Momentum carries through the scene; consequences are beginning to surface."
+)
+
+# clawdnd_progress_beat_text FIRST BEAT_INDEX — echo the heartbeat teaser for this beat. $1=first?(1/0)
+# (the same cold-open signal as the effort/timeout tiers); $2=a 0-based beat index used to ROTATE the
+# continuing-beat bank. Cold open → the opening teaser; continuing beat → MOVE_PROGRESS_TEXTS[idx % N].
+clawdnd_progress_beat_text() {
+  local first="$1" idx="${2:-0}"
+  if [ "$first" != "0" ]; then
+    printf '%s' "$CLAWDND_OPENING_PROGRESS_TEXT"
+    return 0
+  fi
+  [[ "$idx" =~ ^[0-9]+$ ]] || idx=0
+  local count="${#CLAWDND_MOVE_PROGRESS_TEXTS[@]}"
+  printf '%s' "${CLAWDND_MOVE_PROGRESS_TEXTS[$((idx % count))]}"
+}
+
+# clawdnd_emit_progress_heartbeat CAMPAIGN_ID FIRST BEAT_INDEX — write the wrapper-authored progress beat
+# to the engine session log (via log_engine_narration) so /events has a row to render BEFORE the model's
+# long think. Best-effort + idempotent: a blank campaign id no-ops; log_engine_narration's substring guard
+# (it already de-dups against the recent narration tail) means a heartbeat the DM happens to echo isn't
+# double-logged. ALWAYS returns 0 — a heartbeat failure must never fail a beat. Reads ambient $STATE_DIR /
+# $ROOT exactly as log_engine_narration / record_dm_reply do. $1=campaign_id $2=first?(1/0) $3=beat index.
+clawdnd_emit_progress_heartbeat() {
+  local campaign_id="$1" first="${2:-0}" idx="${3:-0}" text
+  [ -n "${campaign_id//[[:space:]]/}" ] || return 0
+  text="$(clawdnd_progress_beat_text "$first" "$idx")"
+  log_engine_narration "$campaign_id" "$text" \
+    || printf '%s\n' "[worldos] note: could not record progress heartbeat (non-fatal)" >&2
+  return 0
+}
+
 # LEAN-BEAT DM-TURN ARGS (the ONE shared implementation of the CLAWDND_LEAN_BEATS path).
 #
 # Both play loops (scripts/play.sh AND qa/run_duo.sh) drive a DM turn through `claude -p`,

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -247,6 +247,13 @@ fi
 # keep CLAWDND_BEAT_TIMEOUT (default 200s). Echoes the DM's final text.
 dm_turn() {
   local first="$1" msg="$2" campaign_id="${3:-}" out resume=() extra=() rc beat_timeout
+  # #623: prepend the live-progress rule (the ONE shared CLAWDND_LIVE_PROGRESS_RULE in
+  # qa/lib_beat_driver.sh — parity with scripts/play_party.sh + scripts/play_codex_dm.sh) so the DM
+  # logs an EARLY /events narration beat. Its ABSENCE in this SOLO path was the #623 bug: the DM
+  # emitted nothing to /events until the full 85-157s beat completed, so the viewer showed blank and
+  # the persona perceived a 'dropped'/'hung' beat. This is the MODEL-COOPERATIVE half; the harness
+  # also emits a model-INDEPENDENT heartbeat (clawdnd_emit_progress_heartbeat) before each beat below.
+  msg="$CLAWDND_LIVE_PROGRESS_RULE"$'\n\n'"$msg"
   # The lean-beat path (fresh session + re-ground directive) is the ONE shared implementation
   # in qa/lib_beat_driver.sh — qa/run_duo.sh drives the SAME helper, so the two harnesses can't
   # drift. It populates CLAWDND_DM_LEAN_{SESSION,EXTRA} when this is a continuing beat AND
@@ -369,6 +376,13 @@ echo "  Save dir: $STATE_DIR"
 # above), so the DM must NOT start_world and must NOT create a character — it re-grounds via
 # get_state and opens a scene around the EXISTING authored PC.
 if [ -n "$HERO_CAMP" ]; then
+  # #623 (model-INDEPENDENT heartbeat): the authored-hero campaign ALREADY EXISTS ($HERO_CAMP, pre-
+  # seeded above), so write a wrapper-authored opening progress beat to its engine log BEFORE the long
+  # cold-open turn — /events renders it within ~1s and the viewer's opening spinner flips to "the scene
+  # is arriving above" instead of staying blank for the ~280-500s world-build. (The DEFAULT cold open
+  # below mints its campaign INSIDE the turn, so it has no pre-turn campaign to target — it relies on
+  # the #718 cold-open spinner + the live-progress rule the DM turn carries.) first=1 → opening teaser.
+  clawdnd_emit_progress_heartbeat "$HERO_CAMP" 1 0
   DMSG="$(dm_turn 1 "You are the Dungeon Master for a solo ClawDnD adventure. Activate and follow your \`dungeon-master\` skill — run its \"Generating a world live\" mode and hold its craft bar (mechanics sourced from the engine, NPCs speak, the world pushes back, scenes played not logged).
 
 Begin a SOLO session in a living world for a single human player who will act through the dashboard. The player AUTHORED their own character in the Creation wizard, so the world AND the player's character ALREADY EXIST — they were pre-seeded for you:
@@ -465,6 +479,13 @@ while true; do
     BEAT_NO=$((DM_TURNS + 1))
     RUNBOOK="$(clawdnd_runbook_for_beat "$BEAT_NO" "$MAX_TURNS" "$PREV_LOC" "$STATE_DIR")"
     echo "[play] beat $BEAT_NO runbook: ${RUNBOOK%% (*}…"
+    # #623 (model-INDEPENDENT heartbeat): write a wrapper-authored progress beat to the engine NOW,
+    # before the DM's long think, so /events has a row to render within ~1s and the viewer flips its
+    # spinner to "the scene is arriving above" — the player is never left staring at a blank chronicle
+    # for the full 85-157s beat (the perceived 'drop'/'hang' #623 filed). Best-effort + non-fatal; the
+    # engine stays the sole writer (it routes through log_engine_narration). DM_TURNS = the 0-based beat
+    # index → the heartbeat text rotates so a long session never repeats the same teaser.
+    clawdnd_emit_progress_heartbeat "$CAMPAIGN_ID" 0 "$DM_TURNS"
     DMSG="$(dm_turn 0 "The player does:
 
 $PMSG

--- a/servers/engine/tests/test_dm_session_remint.py
+++ b/servers/engine/tests/test_dm_session_remint.py
@@ -246,3 +246,119 @@ def test_play_sh_wires_the_coldopen_resume_helper():
     play = _src("scripts/play.sh")
     assert "clawdnd_coldopen_retry_msg()" in lib, "the resume-directive helper must exist in the lib"
     assert 'msg="$(clawdnd_coldopen_retry_msg "$first"' in play, "play.sh retry must reassign msg via the helper"
+
+
+# --- #623: the SOLO play.sh path needs the SAME live-progress signal the party/codex paths have --
+# The sweep_v8 run that filed #623 used the SOLO scripts/play.sh path. Forensics (Eva, on the run's
+# own dm.*.jsonl): all four beats ran cleanly at ttft 2-5s and 85-157s wall — NO real drop/hang. The
+# defect is PERCEIVED latency: play.sh had NEITHER the live-progress rule NOR the wrapper-authored
+# heartbeat the party (#623) + codex paths already carry, so /events stayed blank for the whole beat
+# (the viewer's notePendingProgress streaming-flip never fired) → the player stared at a static
+# spinner and called it a dropped/hung beat. The fix is two-layer, both PERCEIVED-latency, neither
+# touching wall-clock: a model-INDEPENDENT wrapper heartbeat (a guaranteed early /events row) + the
+# model-cooperative live-progress rule. The existing bounded timeout+retry+#357 fallback is unchanged.
+
+
+def test_live_progress_rule_is_shared_in_the_lib():
+    """Anti-drift: factor the live-progress rule into the ONE shared lib so the harnesses can't drift.
+    The string must be defined in lib_beat_driver.sh and carry its load-bearing intent."""
+    lib = _src("qa/lib_beat_driver.sh")
+    assert "CLAWDND_LIVE_PROGRESS_RULE=" in lib, "the live-progress rule must live in the shared lib"
+    assert "Live progress rule" in lib and "log_event" in lib and "narration" in lib
+
+
+def test_play_sh_applies_the_live_progress_rule_to_the_beat_turn():
+    """#623: scripts/play.sh (the SOLO claude DM path that filed #623) must apply the live-progress
+    rule to its per-beat DM turn — parity with play_party.sh + play_codex_dm.sh. Its ABSENCE is the
+    bug: the solo DM emitted nothing to /events until the full 85-157s beat completed."""
+    play = _src("scripts/play.sh")
+    assert "CLAWDND_LIVE_PROGRESS_RULE" in play, "play.sh must reference the shared live-progress rule"
+    assert "$CLAWDND_LIVE_PROGRESS_RULE" in play, "the rule must be spliced into the DM beat prompt"
+
+
+def test_progress_heartbeat_helpers_exist_in_the_lib():
+    """The model-INDEPENDENT heartbeat: a wrapper-authored progress beat the harness logs to /events
+    itself, BEFORE the model runs — so the viewer flips off the generic spinner within ~1s no matter
+    how long the model thinks (or whether it skips the cooperative early log_event). Mirrors the codex
+    DM wrapper's proven OPENING_PROGRESS_TEXT / MOVE_PROGRESS_TEXTS pattern, factored to the shared lib."""
+    lib = _src("qa/lib_beat_driver.sh")
+    assert "clawdnd_progress_beat_text()" in lib, "the heartbeat-text chooser must exist in the lib"
+    assert "clawdnd_emit_progress_heartbeat()" in lib, "the heartbeat emitter must exist in the lib"
+    # the emitter routes through the shared engine-log helper (engine stays the sole writer).
+    assert "log_engine_narration" in lib
+
+
+def test_progress_beat_text_is_second_person_and_rotates():
+    """The heartbeat text must be a SHORT 2nd-person player-facing teaser (it renders straight into
+    the Chronicle), and continuing beats must ROTATE so a multi-beat session doesn't repeat one line.
+    The cold open (first=1) gets its own opening teaser; continuing beats (first=0) cycle by index."""
+    script = (
+        f'set -u; . "{LIB}"\n'
+        'echo "open:$(clawdnd_progress_beat_text 1 0)"\n'
+        'echo "b0:$(clawdnd_progress_beat_text 0 0)"\n'
+        'echo "b1:$(clawdnd_progress_beat_text 0 1)"\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    lines = {ln.split(":", 1)[0]: ln.split(":", 1)[1] for ln in r.stdout.splitlines() if ":" in ln}
+    # every teaser is non-empty 2nd-person prose addressed to "you"
+    for key in ("open", "b0", "b1"):
+        assert lines.get(key, "").strip(), f"{key} progress teaser must be non-empty"
+        assert "you" in lines[key].lower(), f"{key} teaser must be 2nd-person (address 'you')"
+    # continuing beats rotate (index 0 != index 1) so a long session never repeats the same line
+    assert lines["b0"] != lines["b1"], "continuing-beat teasers must rotate by index"
+
+
+def test_emit_progress_heartbeat_logs_a_narration_event(tmp_path, monkeypatch):
+    """End-to-end: the emitter must write a real `narration` row to the engine session log for the
+    given campaign — the row the viewer's /events poll reads to flip the spinner to 'streaming'. Mints
+    a real campaign via the engine, then drives the bash helper against the SAME state dir; a blank
+    campaign id must no-op (no crash, no row) since the heartbeat is best-effort, never fatal."""
+    import json as _json
+    import sys as _sys
+
+    state = tmp_path / "state"
+    state.mkdir()
+    # Mint a real campaign + a session through the engine (the heartbeat needs a real campaign to log
+    # into; an empty dir makes log_event raise — which the helper swallows, but then there's no row).
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(state))
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(state))
+    _sys.path.insert(0, str(ROOT / "servers" / "engine"))
+    import server  # the engine module (servers/engine on sys.path)
+
+    camp = server.create_campaign("Heartbeat")["id"]
+    server.start_session(camp)
+
+    script = (
+        f'set -u; . "{LIB}"\n'
+        f'export ROOT="{ROOT}"; export STATE_DIR="{state}"\n'
+        f'export CLAWDND_STATE_DIR="{state}"; export WORLDOS_STATE_DIR="{state}"\n'
+        # blank campaign id must no-op (the heartbeat is best-effort, never fatal)
+        'clawdnd_emit_progress_heartbeat "" 1 0; echo "blank-rc=$?"\n'
+        # a real campaign id must log a narration progress beat
+        f'clawdnd_emit_progress_heartbeat "{camp}" 0 0; echo "real-rc=$?"\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    assert "blank-rc=0" in r.stdout, ("blank id must no-op cleanly", r.stdout, r.stderr)
+    assert "real-rc=0" in r.stdout, ("a real heartbeat must return 0", r.stdout, r.stderr)
+    # the engine must have appended at least one narration row for the campaign
+    sess_dir = state / "campaigns" / camp / "sessions"
+    rows = []
+    for f in sess_dir.glob("*.jsonl"):
+        for ln in f.read_text().splitlines():
+            ln = ln.strip()
+            if ln:
+                rows.append(_json.loads(ln))
+    narr = [x for x in rows if x.get("kind") == "narration" and (x.get("text") or "").strip()]
+    assert narr, ("the heartbeat must log a player-facing narration row to the engine", r.stdout, r.stderr)
+    assert "you" in narr[-1]["text"].lower(), "the logged heartbeat must be 2nd-person prose"
+
+
+def test_play_sh_emits_the_heartbeat_before_each_dm_turn():
+    """Anti-drift: play.sh must call the heartbeat emitter on BOTH its openers and the per-beat turn,
+    so a guaranteed /events row precedes the model's long think on every beat type."""
+    play = _src("scripts/play.sh")
+    assert play.count("clawdnd_emit_progress_heartbeat") >= 2, (
+        "play.sh must emit the heartbeat on the cold-open AND per-beat paths"
+    )


### PR DESCRIPTION
## Issue
Closes #623 — "[reliability] DM beats silently drop / hang >10min with no recovery — sabotages story personas (crit)".

## Root cause (validate-before-fixing)
Per the issue's own forensics comment (Eva, measured on the filing sweep_v8 run's `dm.*.jsonl`): **the "silent drop" + "10-min hang" are NOT real DM unreliability.** All four beats ran cleanly at ttft 2–5s / 85–157s wall with **zero** timeouts, retries, empty-fallbacks, or provider_errors. The defect is **perceived latency**: `/events` stayed BLANK for the whole beat → the OpenWorlds viewer's `notePendingProgress` streaming-flip never fired → the player stared at a static "weaving the next beat" spinner and called a healthy 157s beat a "drop" (beat 1) and the cumulative wait a "hang".

I reproduced the gap against the actual code, not the bug report: the live-progress signal exists in **`scripts/play_party.sh`** (#623) and **`scripts/play_codex_dm.sh`**, but was **MISSING from `scripts/play.sh`** — the SOLO path the sweep_v8 narrative/newbie run used. So the solo DM emitted nothing player-facing to `/events` until the full beat completed. (`servers/engine/tests/test_dm_session_remint.py::test_play_party_dm_has_live_progress_rule` already guarded the party path; there was no equivalent for `play.sh`.)

## Fix — two layers, both perceived-latency (no wall-clock change)
Per `worldos-latency-forensics`, speed levers are REFUTED — beats are generation-bound. This fix is purely PERCEIVED-latency + recovery. The existing bounded timeout (`clawdnd_dm_timeout`, 200s/400–500s) + one-retry + the #357 empty-narration fallback are **unchanged**; the gap was that the player got **no signal during the bounded wait**, so the existing recovery felt bypassed.

1. **Wrapper heartbeat (model-INDEPENDENT — the guarantee).** New `clawdnd_emit_progress_heartbeat` writes a short wrapper-authored 2nd-person `narration` row to the engine session log via the shared `log_engine_narration` **before** the DM `claude -p` starts. It lands in `/events` within ~1s, so the viewer flips its spinner to "the scene is arriving above" no matter how long the model thinks — and crucially **even when the model SKIPS the cooperative early `log_event`** (Eva measured exactly that: rule present, streaming refs = 0). Same proven pattern the Codex DM wrapper uses (`OPENING_PROGRESS_TEXT` / `MOVE_PROGRESS_TEXTS`), factored into the shared lib. `play.sh` emits it on the per-beat loop and the authored-hero cold open. Best-effort + non-fatal (blank id / engine error → `return 0`); engine stays the sole writer.

2. **`CLAWDND_LIVE_PROGRESS_RULE` (model-COOPERATIVE — the richer signal).** Factored verbatim into the shared `qa/lib_beat_driver.sh` (anti-drift) and applied to `play.sh`'s DM beat prompt — parity with the party + codex paths. Its absence in the solo path was the bug.

## Files changed
- `qa/lib_beat_driver.sh` — `CLAWDND_LIVE_PROGRESS_RULE` (shared), `clawdnd_progress_beat_text`, `clawdnd_emit_progress_heartbeat` (+69 lines).
- `scripts/play.sh` — apply the live-progress rule in `dm_turn`; emit the heartbeat before each per-beat turn and the authored-hero cold open (+21 lines).
- `servers/engine/tests/test_dm_session_remint.py` — 6 new TDD tests (+116 lines).

## Tests (TDD — watched them fail first)
- `test_live_progress_rule_is_shared_in_the_lib`
- `test_play_sh_applies_the_live_progress_rule_to_the_beat_turn`
- `test_progress_heartbeat_helpers_exist_in_the_lib`
- `test_progress_beat_text_is_second_person_and_rotates`
- `test_emit_progress_heartbeat_logs_a_narration_event` (real engine campaign + bash helper under `/bin/bash`)
- `test_play_sh_emits_the_heartbeat_before_each_dm_turn`

`test_dm_session_remint.py`: **21 passed**. Harness-adjacent engine tests (codex wrapper, narration fallback, engine_logged, budget scaling, lean discipline/contamination, opus coldopen, adversarial release, house bio): **111 passed**. qa static gates: **24 passed**. Verified under system bash 3.2.57 directly.

## fast_gate
`bash qa/fast_gate.sh` → **PASS** (188 passed, deterministic engine tier).

## Additive / invariants
Purely additive (+206 / -0). Engine stays the sole writer (heartbeat routes through `log_engine_narration`, which `log_event`-appends a narration exactly as the DM's own would; its substring guard de-dups). No wire-contract changes. Bash 3.2-clean (the only bashism, `[[ =~ ]]`, is byte-identical to the codex path's proven usage).

## What remains for the GUI sweep
This fix makes the progress signal **model-independent**, so it should hold on the built app too — but the `dist/WorldOS.app` render is the gate surface. Remaining verification: confirm on the BUILT `.app` that the `/events` heartbeat row visibly flips the spinner within ~1s of a move (the headless-proxy path that filed #623 could not replicate streaming).