### PR TITLE
fix(engine): offer a missed subclass choice at the next level-up (#624 backfill)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4826,6 +4826,12 @@ def level_up(
         if subclass:
             subclass = srd_tables.resolve_subclass(cname, subclass) or subclass
 
+        # #624 backfill: is this level-up SETTING a subclass that was unset until
+        # now? (Captured before mutation — drives the missed-choice feature grant.)
+        subclass_newly_set = bool(
+            subclass and existing is not None and not (existing.subclass or "").strip()
+        )
+
         if existing:
             existing.level += 1
             if subclass:
@@ -4866,6 +4872,12 @@ def level_up(
             (cl.subclass for cl in ch.classes if cl.name.lower() == cname), None
         )
         gained = gained + srd_tables.subclass_features_at(cname, cur_subclass, new_class_level)
+        # #624 backfill: a subclass chosen LATE (the missed-choice case — set for
+        # the first time at a level PAST the choice level) still grants its
+        # choice-level features at the level-up that sets it, not nothing.
+        slvl = srd_tables.subclass_level(cname)
+        if subclass_newly_set and slvl is not None and new_class_level > slvl:
+            gained = gained + srd_tables.subclass_features_at(cname, cur_subclass, slvl)
         for f in gained:
             if f["name"] not in ch.features:
                 ch.features.append(f["name"])
@@ -5084,15 +5096,24 @@ def _subclass_block_for(cname: str, next_class_level: int, current_subclass: Opt
     """#624: the subclass-choice block a build option carries when leveling INTO a
     class's subclass-choice level without a subclass already set — the legal SRD
     options (each with a brief feature preview) so the surface renders a real list
-    instead of a free-text box. None when no choice is due at this level."""
+    instead of a free-text box. None when no choice is due at this level.
+
+    Backfill (rc2 audit): a character ALREADY PAST the choice level with the
+    subclass still unset (the pendingSubclass case — e.g. an L5 wizard with no
+    Arcane Tradition leveling to L6) is offered the missed choice at the next
+    level-up, matching common-practice 5e table rules. With a subclass already
+    set, nothing is offered past the choice level (unchanged)."""
     slvl = srd_tables.subclass_level(cname)
-    if slvl is None or next_class_level != slvl:
+    if slvl is None:
+        return None
+    unset = not bool((current_subclass or "").strip())
+    if next_class_level != slvl and not (unset and next_class_level > slvl):
         return None
     options = srd_tables.subclass_options(cname)
     if not options:
         return None
     return {
-        "required": not bool((current_subclass or "").strip()),
+        "required": unset,
         "group_label": srd_tables.subclass_group_label(cname),
         "current": current_subclass,
         "options": options,

--- a/servers/engine/tests/test_class_features.py
+++ b/servers/engine/tests/test_class_features.py
@@ -131,3 +131,54 @@ def test_build_options_exposes_subclass_choice_at_subclass_level(cid):
     names = {o["name"] for o in sub["options"]}
     assert "Evoker" in names
     assert all(o.get("desc") for o in sub["options"])
+
+
+# ── #624 backfill (rc2 audit): a MISSED subclass choice is offered at the NEXT
+# level-up — an L5 wizard with no Arcane Tradition (the pendingSubclass case) must
+# still get the options block, not the free-text fallback. ──────────────────────
+
+
+def test_build_options_backfills_missed_subclass_choice(cid):
+    # An L5 wizard with NO subclass set (already PAST the choice level) leveling to
+    # L6 must still get the subclass options block — a missed choice is offered at
+    # the next level-up (5e table-rules common practice).
+    wid = server.create_character(
+        cid, "Vex", kind="player", class_name="Wizard", level=5,
+        abilities={"intelligence": 16, "constitution": 14}, apply_srd_defaults=True,
+    )["id"]
+    planner = server.build_options(cid, wid)
+    wiz_opt = next(o for o in planner["options"] if o["class_name"] == "wizard")
+    sub = wiz_opt.get("subclass")
+    assert sub and sub["required"] is True
+    names = {o["name"] for o in sub["options"]}
+    assert "Evoker" in names
+    assert all(o.get("desc") for o in sub["options"])
+
+
+def test_build_options_no_subclass_block_past_level_when_already_chosen(cid):
+    # An L5 wizard who ALREADY has a tradition gets NO subclass block past the
+    # choice level — the choice is not re-offered (unchanged behavior).
+    wid = server.create_character(
+        cid, "Gale", kind="player", class_name="Wizard", level=5, subclass="Evoker",
+        abilities={"intelligence": 16, "constitution": 14}, apply_srd_defaults=True,
+    )["id"]
+    planner = server.build_options(cid, wid)
+    wiz_opt = next(o for o in planner["options"] if o["class_name"] == "wizard")
+    assert wiz_opt.get("subclass") is None
+
+
+def test_level_up_backfill_applies_choice_level_features(cid):
+    # Choosing the subclass on the backfill path (L5 wizard, no subclass, leveling
+    # to L6 with subclass named) still grants the CHOICE-LEVEL features — the
+    # missed L3 set (Evocation Savant + Sculpt Spells), not nothing.
+    wid = server.create_character(
+        cid, "Vex", kind="player", class_name="Wizard", level=5,
+        abilities={"intelligence": 16, "constitution": 14}, apply_srd_defaults=True,
+    )["id"]
+    out = server.level_up(cid, wid, "Wizard", subclass="Evocation")  # -> level 6
+    assert out["classes"][0]["subclass"] == "Evoker"  # normalized to canonical SRD name
+    gained = {f["name"] for f in out["_features_gained"]}
+    assert "Evocation Savant" in gained and "Sculpt Spells" in gained
+    sheet = server.get_character(cid, wid)
+    assert "Evocation Savant" in sheet["features"]
+    assert "Sculpt Spells" in sheet["features"]


### PR DESCRIPTION
Reopens the #624 acceptance; closes the backfill gap found by the rc2 audit.

## Root cause (audit-verified)
#624 was closed by #742, but the optimizer's ACTUAL path still got a free-text subclass box. The #742 subclass-options block (`_subclass_block_for` + the `build_options`/`preview_level_up` wiring in `servers/engine/server.py`) only fired when `next_class_level == slvl` exactly. A character ALREADY PAST the subclass-choice level with the subclass unset — the `pendingSubclass`/backfill case, e.g. an L5 wizard with no Arcane Tradition leveling to L6 — got NO options block, so `screen-character.jsx` fell back to free text. rc2 evidence: vm2-optimizer + vm2-veteran `bugs.ndjson`.

## Fix (additive, engine-only)
- **`_subclass_block_for`**: predicate extended to also fire when `next_class_level > slvl` AND the character's subclass for that class is unset — backfill semantics: a missed choice is offered at the next level-up, matching 5e table-rules common practice. When the subclass is already set, no block past the choice level (unchanged); the exact-level case is unchanged.
- **`level_up`**: a subclass set FOR THE FIRST TIME at a level past the choice level (`subclass_newly_set`, captured before mutation) now grants the choice-level features (e.g. Evocation Savant + Sculpt Spells), not nothing. The exact-level grant path is unchanged; the existing `f["name"] not in ch.features` dedupe keeps it idempotent.
- **Viewer: NO change needed** (verified). `screen-character.jsx:382-383` reads `option.subclass` from the planner and renders the pickable list whenever the block exists (free text remains only as the world-canon fallback), and `subclassDue` is already true on the backfill path via `hero.pendingSubclass` (viewer read-model). The #742 viewer contract tests (`viewer/tests/test_levelup_picker.py`) pass unchanged.

## Tests (TDD — red first, then green)
New in `servers/engine/tests/test_class_features.py`:
1. `test_build_options_backfills_missed_subclass_choice` — L5 wizard, subclass unset, build option to L6 carries the subclass block (required, Evoker present, descs present). **Failed on main.**
2. `test_build_options_no_subclass_block_past_level_when_already_chosen` — L5 wizard WITH subclass set: no block (guard; passes before + after).
3. Exact-level case L2→L3 still works — existing `test_build_options_exposes_subclass_choice_at_subclass_level` + `test_level_up_to_subclass_level_applies_subclass_features` pass unchanged.
4. `test_level_up_backfill_applies_choice_level_features` — backfill choice via `level_up(..., subclass="Evocation")` at L5→L6 applies the choice-level features + canonical-name normalization. **Failed on main.**

## Verification
- `tests/test_class_features.py`: 14 passed
- All engine tests touching level_up/build_options (`test_class_features` + `test_class_resources` + `test_effect_durations` + `test_progression` + `test_qa_fixes` + `test_spellcasting`): **221 passed**
- `viewer/tests/test_levelup_picker.py` + `viewer/tests/test_charsheet_depth.py`: 18 passed
- `bash qa/fast_gate.sh`: **PASS** (188 deterministic engine tests)

## Known follow-up (out of scope, per the audit's bundling check)
No FEAT/ASI choice-options block exists at ASI levels (4/8/12/16/19): `preview_level_up`/`build_options` expose only the `asi_or_feat` choice_requirement + `choices.asi_required`/`feat_allowed` booleans, and a feat is recorded as a free string in notes (`level_up`). There is no feat enumeration in `srd_tables`. Deliberately NOT built here — flagging as the known follow-up for the optimizer's build-choice surface.

Refs #624, #742.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Players can now select a subclass at later levels if missed at the standard choice level.
  
* **Bug Fixes**
  * Subclass features are now properly granted when subclass selection is deferred beyond the normal choice level.
  * Subclass options are correctly displayed in character advancement even after passing the standard choice level.

* **Tests**
  * Added coverage for deferred subclass selection and feature granting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->