### PR TITLE
fix(viewer): budget-aware stuck-backstop — stop false-firing 'stuck' on healthy slow turns (refs #745, follow-up to #746)

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -238,12 +238,23 @@ const PENDING_BACKSTOP_MS = 12 * 60 * 1000;       // …with the original hard b
 // CLEARS pending to null (a plain re-enabled bar, NO "Try again", the partial narration stranded). That is
 // the ~12–15-min lockout the newbie gave up on. This ceiling bounds TOTAL stall from submit regardless of
 // how many partials trickle in (progress does not reset it), and resolves to the SAME recoverable `stuck`
-// state (the bar re-opens as "Try again"). It is generous enough to clear a worst-case HEALTHY beat (which
-// RESOLVES on /chat → clearPending cancels every timer long before this fires), so it never false-positives
-// on a slow-but-alive turn; it only ever fires on a genuine freeze. Strictly between the position windows
-// and the 12-min null-backstop, so the ordering is: position recovery (resettable) < stuck-backstop (hard,
-// recoverable) < null-backstop (hard, last-resort clear).
-const PENDING_STUCK_BACKSTOP_MS = 5 * 60 * 1000;  // #745: hard stuck ceiling from submit (progress does NOT reset it).
+// state (the bar re-opens as "Try again"). It must be generous enough to clear a worst-case HEALTHY beat
+// (which RESOLVES on /chat → clearPending cancels every timer long before this fires), so it never
+// false-positives on a slow-but-alive turn; it only ever fires on a genuine freeze. Strictly between the
+// position windows and the 12-min null-backstop, so the ordering is: position recovery (resettable) <
+// stuck-backstop (hard, recoverable) < null-backstop (hard, last-resort clear).
+// #746: the ceiling is BUDGET-AWARE by turn position, because the original flat 5-min value sat BELOW the
+// system's own healthy turn budgets and false-fired `stuck` on healthy slow turns: the cold open measures
+// ~300s with a 400–500s deadline (qa/lib_beat_driver.sh clawdnd_dm_timeout — 500s for Opus), and a healthy
+// CONTINUING beat can legitimately run ~400s (scripts/play.sh CLAWDND_BEAT_TIMEOUT=200s + ONE retry). When
+// the flat ceiling fired mid-flight on a working turn, pendingActive flipped false (the action bar
+// re-opened, screen-table.jsx), the "DM seems stuck" toast fired, and retryStuck re-POSTed the move — so
+// the SAME intent resolved TWICE once the in-flight beat landed. The fix: firstBeat (the cold open) ⇒
+// 9 min (≥ the 500s cold-open budget); later beats ⇒ 7 min (≥ the ~400s timeout+retry budget). Both stay
+// strictly under the 12-min null-backstop, preserving the #745 ordering above — a genuine
+// trickle-then-freeze still surfaces the recoverable `stuck` affordance well before the silent null clear.
+const PENDING_STUCK_BACKSTOP_MS = 7 * 60 * 1000;        // #745/#746: later-beat hard stuck ceiling from submit (progress does NOT reset it).
+const PENDING_STUCK_BACKSTOP_FIRST_MS = 9 * 60 * 1000;  // #746: first-beat (cold-open) hard stuck ceiling — clears the 400–500s cold-open budget.
 // #648: a JUST-armed narrating turn is protected from a SPURIOUS same-tick clear (the immediate
 // post-armPending surface poll, a /chat cursor-reset re-reading the prior resolved turn's line as a
 // fresh resolution, or a transient campaignId flip tripping the per-run reset) for this long — so the
@@ -258,6 +269,12 @@ const PENDING_ARM_GRACE_MS = 10 * 1000;
 // the hook's internal beat counter. firstBeat ⇒ the longer cold-open window; else the snappy one.
 function recoveryWindowMs(firstBeat) {
   return firstBeat ? PENDING_RECOVERY_FIRST_MS : PENDING_RECOVERY_MS;
+}
+// #746: the hard stuck-backstop ceiling by turn position, mirroring recoveryWindowMs — the single
+// source of truth armPending arms. Pure + exported (window.stuckBackstopMs below) so the
+// budget-aware ceiling contract is unit-testable without reaching into the hook's internals.
+function stuckBackstopMs(firstBeat) {
+  return firstBeat ? PENDING_STUCK_BACKSTOP_FIRST_MS : PENDING_STUCK_BACKSTOP_MS;
 }
 
 // #402: BOUND the live tail. `chatBeats` (every streamed/turn-end DM narration + dialogue beat) and
@@ -456,9 +473,13 @@ function useLiveSession(state) {
     // null-backstop (which strands the partial narration behind a plain re-enabled bar). It is generous
     // enough that a healthy turn always RESOLVES (clearPending → clearTimers) first, so it never trips a
     // slow-but-alive beat. Fires only when nothing has resolved by its deadline.
+    // #746: the ceiling is budget-aware by turn position (stuckBackstopMs): the cold open gets 9 min
+    // (its healthy budget is 400–500s), later beats 7 min (a healthy timeout+retry beat runs ~400s) —
+    // a flat 5 min sat INSIDE those budgets and false-fired on healthy slow turns (bar re-opened +
+    // "DM seems stuck" toast + retryStuck double-resolution while the beat was still in flight).
     stuckBackstopTimer.current = window.setTimeout(() => {
       setPendingState((p) => (p ? { ...p, stuck: true } : p));
-    }, PENDING_STUCK_BACKSTOP_MS);
+    }, stuckBackstopMs(firstBeat));
     backstopTimer.current = window.setTimeout(() => setPendingState(null), PENDING_BACKSTOP_MS);
   }, [clearTimers, setPendingState]);
 
@@ -727,12 +748,14 @@ window.useLiveSession = useLiveSession;
 // #348: expose the recovery-timing contract for tests (and devtools introspection). Purely
 // additive — nothing in the running app reads these off window; the hook uses the locals above.
 window.recoveryWindowMs = recoveryWindowMs;
+window.stuckBackstopMs = stuckBackstopMs;  // #746: the budget-aware hard-ceiling selector (pure)
 window.__PENDING_TIMING__ = {
   recoveryMs: PENDING_RECOVERY_MS,
   recoveryFirstMs: PENDING_RECOVERY_FIRST_MS,
   backstopMs: PENDING_BACKSTOP_MS,
   armGraceMs: PENDING_ARM_GRACE_MS,            // #648: the just-armed-turn protection window
-  stuckBackstopMs: PENDING_STUCK_BACKSTOP_MS,  // #745: hard stuck ceiling from submit (progress does NOT reset it)
+  stuckBackstopMs: PENDING_STUCK_BACKSTOP_MS,  // #745/#746: later-beat hard stuck ceiling from submit (progress does NOT reset it)
+  stuckBackstopFirstMs: PENDING_STUCK_BACKSTOP_FIRST_MS,  // #746: first-beat (cold-open) hard stuck ceiling
 };
 // #402: expose the live-tail bound for tests/devtools introspection (purely additive — the hook
 // closes over the consts directly; nothing in the running app reads these off window).

--- a/viewer/tests/test_recovery_timing.py
+++ b/viewer/tests/test_recovery_timing.py
@@ -13,15 +13,26 @@ legit multi-minute Act-opening → false 'stuck', narration lost at a cliffhange
   • LATER beats (the ~35–60s norm): the snappy PENDING_RECOVERY_MS (~90s).
   • The 12-min hard backstop is unchanged.
 
+#745 added a HARD stuck ceiling from submit (progress does NOT reset it) so a
+mid-stream trickle-then-freeze still recovers to the `stuck` 'Try again' affordance.
+#746 made that ceiling BUDGET-AWARE by turn position: the original flat 5-min value
+sat BELOW the system's own healthy turn budgets (cold open ~300s measured with a
+400–500s deadline; a continuing beat can run ~400s via play.sh's 200s timeout + ONE
+retry), so it false-fired `stuck` on healthy slow turns — re-opening the action bar,
+toasting "DM seems stuck", and letting a retry re-POST resolve the same intent TWICE.
+
 These tests exercise the REAL code by transpiling the actual `.jsx` with the SAME
 bundled Babel-standalone the browser uses and running it under Node with a
 deterministic React + fake-timer stub, so the test tracks the shipped behavior
 rather than a reimplementation (mirrors test_sanitize_narration.py). They cover:
 
-  • the timing CONTRACT (`recoveryWindowMs` for both branches + the constants);
+  • the timing CONTRACT (`recoveryWindowMs` + `stuckBackstopMs` for both branches
+    + the constants and their strict ordering);
   • the hook's observable FIRST-beat behavior (no false stuck at 91s; recovers
     after the long window; the 12-min backstop still force-clears) — the #348 fix;
-  • the LATER-beat branch (snappy 90s) — preserved for a genuine mid-session stall;
+  • the LATER-beat branch — the harness's /chat poll is LIVE, so a test can resolve
+    a turn (flipping firstBeat) and exercise the later-beat ceiling for real;
+  • the #745 mid-stream-stall ceiling + the #746 budget-aware false-fire fix;
   • the #344 contract (`armPending`/`clearPending` shape the retry path relies on).
 """
 
@@ -38,14 +49,18 @@ _SCREEN_TABLE = _OPENWORLDS / "screen-table.jsx"
 _BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
 
 
-# A self-contained Node harness: a minimal-but-real React stub (storing state, refs,
-# callbacks per render so setState re-renders the hook) plus a controllable clock + timer
-# queue. It transpiles screen-table.jsx (defines sanitizeNarration onto window, used by
-# app.jsx) then app.jsx with the bundled Babel, mounts useLiveSession over a live campaign,
-# and exposes a tiny scripting surface (`h`) so each test can arm/clear pending, advance the
-# fake clock, and read pending state — plus the pure `recoveryWindowMs` + constants.
+# A self-contained Node harness: a real-enough React stub (state/refs/callbacks/effects persist
+# across renders; useEffect bodies RUN, so the /chat + /events polls are live) plus a controllable
+# clock + one-shot timer queue AND a scripted fetch (a per-URL queue of JSON responses) with a
+# manual interval pump. The live /chat poll matters here (#746): resolving a turn — a {"role":"dm"}
+# line landing on /chat — is the ONLY thing that flips the hook's firstBeat off, and the later-beat
+# stuck-backstop branch can't be exercised without it. It transpiles screen-table.jsx (defines
+# sanitizeNarration onto window, used by app.jsx) then app.jsx with the bundled Babel, mounts
+# useLiveSession over a live campaign, and exposes a tiny scripting surface (`h`) so each test can
+# arm/clear pending, stream progress, RESOLVE turns, advance the fake clock, and read pending state
+# — plus the pure `recoveryWindowMs`/`stuckBackstopMs` + constants.
 #
-# `script` is a JS expression evaluated with `h`/`win` in scope; its value → JSON on stdout.
+# `script` is an async JS body evaluated with `h`/`win` in scope; its `return` value → JSON on stdout.
 _HARNESS = r"""
 const fs = require('fs');
 const vm = require('vm');
@@ -78,33 +93,103 @@ function advance(ms) {
   NOW = target;
 }
 
-// ---- a minimal real React: hook cells persist across re-renders ------------
+// ---- a real-enough React (ported from test_live_narration_stream.py) -------
+// Hook cells + effects persist across renders; useEffect bodies actually RUN so the /chat poll is
+// live and a test can RESOLVE a turn — flipping firstBeat — before arming the next one (#746 needs
+// the later-beat branch of the hook, which an effect-less stub cannot reach). KEY contract
+// (mirrors React's actual model): rendering and EFFECT-FLUSHING are decoupled — a setState only
+// recomputes the render output; effects run in a separate re-entrancy-guarded committed pass, so a
+// setState fired from inside an effect schedules (not recursively runs) the next flush.
 function makeReact() {
-  const cells = [];
-  let idx = 0;
+  const stateCells = [];
+  const refCells = [];
+  const cbCells = [];          // memoized { fn, deps } per useCallback slot
+  const effects = [];          // { deps, cleanup } per useEffect slot, in mount order
+  let sIdx = 0, rIdx = 0, cIdx = 0, eIdx = 0;
   let renderFn = null;
   let result = null;
+  const pendingEffects = [];   // effect bodies queued this render, drained by flushEffects()
+  let flushing = false;        // re-entrancy guard: a setState during a flush re-renders only
+
   function useState(init) {
-    const i = idx++;
-    if (cells[i] === undefined) cells[i] = { v: typeof init === 'function' ? init() : init };
-    const cell = cells[i];
-    const set = (next) => { cell.v = (typeof next === 'function') ? next(cell.v) : next; rerender(); };
+    const i = sIdx++;
+    if (stateCells[i] === undefined) stateCells[i] = { v: typeof init === 'function' ? init() : init };
+    const cell = stateCells[i];
+    const set = (next) => { cell.v = (typeof next === 'function') ? next(cell.v) : next; render(); };
     return [cell.v, set];
   }
   function useRef(init) {
-    const i = idx++;
-    if (cells[i] === undefined) cells[i] = { current: init };
-    return cells[i];
+    const i = rIdx++;
+    if (refCells[i] === undefined) refCells[i] = { current: init };
+    return refCells[i];
   }
-  // The /chat poll + clearTimers effects are NOT exercised here (we drive arm/clear + the
-  // clock directly), so useEffect/useCallback can be lightweight: callbacks pass through,
-  // effects are skipped (their cleanup-only/interval bodies aren't under test).
-  function useCallback(fn) { return fn; }
-  function useEffect() {}
-  function rerender() { idx = 0; result = renderFn(); }
+  function depsEqual(a, b) {
+    if (!a || !b || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+    return true;
+  }
+  // useCallback MUST memoize by deps (same identity when deps are unchanged) — a naive passthrough
+  // returns a fresh fn every render → every effect whose deps include a callback re-queues every
+  // render → an effect's setState re-renders → infinite loop at mount.
+  function useCallback(fn, deps) {
+    const i = cIdx++;
+    const prev = cbCells[i];
+    if (prev === undefined || !depsEqual(prev.deps, deps)) {
+      cbCells[i] = { fn, deps };
+      return fn;
+    }
+    return prev.fn;
+  }
+  function useEffect(fn, deps) {
+    const i = eIdx++;
+    const prev = effects[i];
+    const changed = !prev || !depsEqual(prev.deps, deps);
+    if (changed) {
+      pendingEffects.push(() => {
+        if (prev && typeof prev.cleanup === 'function') prev.cleanup();
+        const cleanup = fn();
+        effects[i] = { deps, cleanup: typeof cleanup === 'function' ? cleanup : null };
+      });
+      if (!prev) effects[i] = { deps, cleanup: null };  // seed so the slot exists
+      else effects[i].deps = deps;
+    }
+  }
+  function render() {
+    sIdx = 0; rIdx = 0; cIdx = 0; eIdx = 0;
+    result = renderFn();
+  }
+  function flushEffects() {
+    if (flushing) return;
+    flushing = true;
+    try { while (pendingEffects.length) pendingEffects.shift()(); }
+    finally { flushing = false; }
+  }
   const React = { useState, useRef, useCallback, useEffect, createElement: () => null, Fragment: 'F' };
-  function mount(fn) { renderFn = fn; rerender(); }
-  return { React, mount };
+  function mount(fn) { renderFn = fn; render(); flushEffects(); }
+  function commit() { flushEffects(); }
+  function api() { return result; }
+  return { React, mount, commit, api };
+}
+
+// ---- a SCRIPTED fetch + manual interval pump (ported from test_live_narration_stream.py) ----
+const responses = { '/events': [], '/chat': [] };
+function enqueue(path, payload) { responses[path].push(payload); }
+function pathOf(url) { return String(url).split('?')[0]; }
+function fetchStub(url) {
+  const p = pathOf(url);
+  const q = responses[p];
+  const payload = (q && q.length) ? q.shift() : {};   // empty when nothing scripted
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(payload) });
+}
+const intervals = [];
+function setIntervalStub(fn) { intervals.push(fn); return intervals.length; }
+function clearIntervalStub() {}
+// Fire every registered poll once AND await the async chain each returns (the polls do
+// `await fetch().json()` then setState), so a test reads fully-settled state afterward.
+async function tickAll() {
+  const ps = intervals.slice().map((fn) => { try { return fn(); } catch (_e) { return undefined; } });
+  await Promise.all(ps.map((p) => Promise.resolve(p)));
+  await new Promise((r) => setImmediate(r));
 }
 
 const reactHost = makeReact();
@@ -115,12 +200,15 @@ const sandbox = {
   ReactDOM: { createRoot: () => ({ render() {} }) },
   // getElementById returns truthy so screen-table.jsx's ensureDmNarrateStyle() IIFE early-returns
   // (it injects a <style> on first load; irrelevant to timing and needs no real DOM here).
-  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible', getElementById: () => ({}) },
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible', getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
   setTimeout: setTimeoutStub,
   clearTimeout: clearTimeoutStub,
-  setInterval: () => 0,
-  clearInterval: () => {},
-  fetch: () => Promise.resolve({ ok: false, json: () => Promise.resolve({}) }),
+  setInterval: setIntervalStub,
+  clearInterval: clearIntervalStub,
+  fetch: fetchStub,
+  // The JSX poll code runs INSIDE this vm context, so the web/JS globals it uses must be present
+  // here (a vm context does NOT inherit the host's globals).
+  URLSearchParams, Promise, JSON, Set, Array, Object, String, Boolean, Number,
   console,
 };
 sandbox.window = sandbox;
@@ -148,26 +236,40 @@ if (typeof useLiveSession !== 'function') throw new Error('useLiveSession not ex
 
 // Mount the hook over a LIVE campaign so its body runs (campaignId must be truthy).
 const state = { activeCampaign: 'camp1', campaigns: [{ id: 'camp1', campaign_id: 'camp1' }] };
-let api = null;
-reactHost.mount(() => { api = useLiveSession(state); return null; });
+reactHost.mount(() => useLiveSession(state));
 
 const win = sandbox.window;
+let chatNext = 0;
 const h = {
   now: () => NOW,
   advance,
-  pending: () => api.pending,
-  arm: (text) => api.armPending(text || 'do something'),
-  clear: () => api.clearPending(),
+  pending: () => reactHost.api().pending,
+  arm: (text) => reactHost.api().armPending(text || 'do something'),
+  clear: () => reactHost.api().clearPending(),
   // #745: drive the live-progress signal exactly as the /events poll does (a streamed paragraph
   // landed for the in-flight turn), so the mid-stream stall ceiling is exercised against the real code.
-  note: () => api.notePendingProgress(),
+  note: () => reactHost.api().notePendingProgress(),
+  // #746: RESOLVE the in-flight turn exactly as a real one resolves — a {"role":"dm"} line lands on
+  // /chat (the polled turn-END signal). That is the ONLY writer of resolvedTurnsRef, so the NEXT
+  // armPending is a LATER beat (firstBeat=false) — the branch the budget-aware ceiling keys on.
+  // NOTE: clearPending runs inside this (the #648 arm-grace applies — resolve > armGraceMs after arm).
+  resolveTurn: async (text) => {
+    chatNext += 1;
+    enqueue('/chat', { items: [{ role: 'dm', text: text || 'The beat resolves.' }], next: chatNext });
+    await tickAll();
+    reactHost.commit();
+  },
   recoveryWindowMs: (firstBeat) => win.recoveryWindowMs(firstBeat),
+  stuckBackstopMs: (firstBeat) => win.stuckBackstopMs(firstBeat),
   constants: () => win.__PENDING_TIMING__,
 };
 
+// The script body may await (resolveTurn drains the async pollers); run it inside an async arrow —
+// its `return` is the resolved value (mirrors test_live_narration_stream.py).
 const script = %(script)s;
-const result = (function () { return eval(script); })();
-process.stdout.write(JSON.stringify(result));
+eval('(async () => { ' + script + ' })()')
+  .then((result) => { process.stdout.write(JSON.stringify(result)); })
+  .catch((e) => { console.error(e && e.stack || e); process.exit(1); });
 """
 
 
@@ -206,7 +308,7 @@ class RecoveryTimingTests(_BabelHarness):
 
     # --- the timing CONTRACT: constants exported, correctly ordered -----------
     def test_constants_exported_and_ordered(self):
-        c = self._run("h.constants()")
+        c = self._run("return h.constants();")
         self.assertIn("recoveryMs", c)
         self.assertIn("recoveryFirstMs", c)
         self.assertIn("backstopMs", c)
@@ -221,16 +323,12 @@ class RecoveryTimingTests(_BabelHarness):
 
     # --- the pure selector: both branches (this is exactly what armPending calls) ---
     def test_recovery_window_selector_both_branches(self):
-        out = self._run("({ first: h.recoveryWindowMs(true), later: h.recoveryWindowMs(false) })")
+        out = self._run("return ({ first: h.recoveryWindowMs(true), later: h.recoveryWindowMs(false) });")
         self.assertEqual(out["first"], 4 * 60 * 1000)
         self.assertEqual(out["later"], 180 * 1000)  # #399: was 90s
 
     # --- #399 CORE: the FIRST-beat window covers a 120s turn without going stuck --------------
     # The first beat already gets the generous 4-min window, so a 120s turn is comfortably inside it.
-    # (The LATER-beat 180s window can't be exercised in THIS harness — flipping firstBeat=false needs
-    # a real DM beat to arrive via the /chat poll, which is stubbed here; that path is covered in
-    # test_live_narration_stream.py::test_resolved_beat_makes_next_turn_a_later_beat. Here we lock
-    # that NEITHER window trips at 120s, the worst-case content-rich turn the playtester gave up on.)
     def test_no_false_stuck_at_120s(self):
         out = self._run(
             "h.arm('open the scene');"
@@ -238,7 +336,7 @@ class RecoveryTimingTests(_BabelHarness):
             # window (and the new 180s later window) must NOT be.
             "h.advance(120 * 1000);"
             "var p1 = h.pending();"
-            "({ stuck_at_120s: !!(p1 && p1.stuck), active_at_120s: !!(p1 && !p1.stuck) })"
+            "return ({ stuck_at_120s: !!(p1 && p1.stuck), active_at_120s: !!(p1 && !p1.stuck) });"
         )
         self.assertFalse(out["stuck_at_120s"], "a 120s turn must not be falsely declared stuck (#399)")
         self.assertTrue(out["active_at_120s"], "a 120s turn should still be narrating (pending, not stuck)")
@@ -250,7 +348,7 @@ class RecoveryTimingTests(_BabelHarness):
             # 91s in — the OLD fixed window would already be 'stuck'. The first beat must NOT be.
             "h.advance(91 * 1000);"
             "var p1 = h.pending();"
-            "({ stuck_at_91s: !!(p1 && p1.stuck), firstBeat: !!(p1 && p1.firstBeat), active: !!(p1 && !p1.stuck) })"
+            "return ({ stuck_at_91s: !!(p1 && p1.stuck), firstBeat: !!(p1 && p1.firstBeat), active: !!(p1 && !p1.stuck) });"
         )
         self.assertFalse(out["stuck_at_91s"], "first beat falsely went stuck at 91s (the #348 bug)")
         self.assertTrue(out["active"], "first beat should still be narrating (pending, not stuck) at 91s")
@@ -265,7 +363,7 @@ class RecoveryTimingTests(_BabelHarness):
             # cross the 4-min first-beat deadline (total ~251s)
             "h.advance(160 * 1000);"
             "var late = h.pending();"
-            "({ early_stuck: !!(early && early.stuck), late_stuck: !!(late && late.stuck) })"
+            "return ({ early_stuck: !!(early && early.stuck), late_stuck: !!(late && late.stuck) });"
         )
         self.assertFalse(out["early_stuck"])
         self.assertTrue(out["late_stuck"], "a genuinely-stalled opening must STILL recover after its long window")
@@ -276,7 +374,7 @@ class RecoveryTimingTests(_BabelHarness):
             "h.arm('open the scene');"
             # Past the 12-min backstop — pending should be force-cleared to null.
             "h.advance((12 * 60 + 5) * 1000);"
-            "({ pending_is_null: h.pending() === null })"
+            "return ({ pending_is_null: h.pending() === null });"
         )
         self.assertTrue(out["pending_is_null"], "the 12-min backstop must still force-clear a wedged turn")
 
@@ -294,7 +392,7 @@ class RecoveryTimingTests(_BabelHarness):
             # this is what lets the #344 'Try again' re-arm cleanly via a fresh armPending.
             "h.advance((13 * 60) * 1000);"
             "var afterAdvance = h.pending();"
-            "({ armed_present: !!armed, cleared_null: cleared === null, no_resurrect: afterAdvance === null })"
+            "return ({ armed_present: !!armed, cleared_null: cleared === null, no_resurrect: afterAdvance === null });"
         )
         self.assertTrue(out["armed_present"])
         self.assertTrue(out["cleared_null"])
@@ -318,7 +416,7 @@ class RecoveryTimingTests(_BabelHarness):
             "var narrating = !!(p && !p.stuck);"
             "h.advance(h.constants().armGraceMs + 1000);"    # the real DM beat lands well past the grace
             "h.clear();"                                     # genuine resolution → clears
-            "({ armed: armed, survives: survived, narrating: narrating, resolves_later: h.pending() === null })"
+            "return ({ armed: armed, survives: survived, narrating: narrating, resolves_later: h.pending() === null });"
         )
         self.assertTrue(out["armed"], "armPending should arm a narrating turn")
         self.assertTrue(out["survives"], "#648: a same-tick clear must NOT wipe the just-armed spinner")
@@ -328,46 +426,125 @@ class RecoveryTimingTests(_BabelHarness):
 
 @unittest.skipIf(shutil.which("node") is None, "node is required to transpile + run the JSX hook")
 class MidStreamStallTests(_BabelHarness):
-    """#745 — the newbie mid-stream-stall give-up (the lone v1.0.4-rc2 RRI holdout @c92a393).
+    """#745 mid-stream-stall ceiling + #746 budget-aware false-fire fix.
 
-    A DM beat that STREAMS partial prose via /events and then FREEZES mid-generation must STILL recover
-    to the recoverable `stuck` 'Try again' affordance within a BOUNDED time — independent of how many
-    partial paragraphs landed. Before #745, `notePendingProgress` re-armed the FULL position window
-    (180s/240s) AND cleared `stuck` on every streamed paragraph, so a multi-paragraph trickle that then
-    froze kept pushing the deadline forward; recovery was deferred to the silent 12-min null-backstop
-    (clears pending to null → a plain re-enabled bar, no 'Try again', the partial narration stranded) —
-    the ~12–15-min lockout the newbie gave up on.
+    #745 (the newbie mid-stream-stall give-up, the lone v1.0.4-rc2 RRI holdout @c92a393): a DM beat
+    that STREAMS partial prose via /events and then FREEZES mid-generation must STILL recover to the
+    recoverable `stuck` 'Try again' affordance within a BOUNDED time — independent of how many partial
+    paragraphs landed. The fix is a HARD stuck-backstop armed once in armPending that progress does
+    NOT reset; a trickle can no longer defer recovery to the silent 12-min null-backstop.
 
-    The fix is a HARD stuck-backstop armed once in armPending that progress does NOT reset
-    (PENDING_STUCK_BACKSTOP_MS, ~5 min from submit). A trickle can no longer defer recovery past it, and
-    it resolves to the SAME recoverable `stuck` state (NOT a null clear). It is deliberately generous so
-    a long-but-HEALTHY streaming turn (which RESOLVES on /chat → clearPending cancels every timer) never
-    trips it — preserving the #348/#399/#623 live-progress behavior. These tests drive the REAL hook
-    (armPending + notePendingProgress + a fake clock) so they track the shipped behavior.
+    #746: the #745 ceiling was a FLAT 5 min — BELOW the system's own healthy turn budgets. The cold
+    open measures ~300s with a 400–500s deadline (qa/lib_beat_driver.sh clawdnd_dm_timeout; 500s for
+    Opus), and a healthy CONTINUING beat can run ~400s (scripts/play.sh CLAWDND_BEAT_TIMEOUT=200s +
+    ONE retry). So the ceiling false-fired `stuck` on healthy slow turns: the action bar re-opened
+    mid-flight, the 'DM seems stuck' toast fired, and retryStuck re-POSTed the move — the SAME intent
+    resolving TWICE once the in-flight beat landed. The fix makes the ceiling budget-aware by turn
+    position (`stuckBackstopMs`, mirroring `recoveryWindowMs`): firstBeat ⇒ 9 min (≥ the 500s
+    cold-open budget); later beats ⇒ 7 min (≥ the ~400s timeout+retry budget). Both stay strictly
+    under the 12-min null-backstop, so the #745 ordering (resettable position window < hard stuck
+    ceiling < null clear) — and its trickle-then-freeze protection — is retained.
+
+    These tests drive the REAL hook (armPending + notePendingProgress + the live /chat resolution
+    path + a fake clock) so they track the shipped behavior.
     """
 
-    def test_stuck_backstop_constant_exported_and_strictly_ordered(self):
-        c = self._run("h.constants()")
+    def test_stuck_backstop_constants_exported_and_strictly_ordered(self):
+        c = self._run("return h.constants();")
         self.assertIn("stuckBackstopMs", c)
-        # The hard stuck ceiling sits STRICTLY between the (resettable) position windows and the 12-min
-        # null-backstop: position recovery < stuck-backstop < null-backstop. So a frozen turn always
-        # surfaces the recoverable `stuck` affordance BEFORE the last-resort null clear.
+        self.assertIn("stuckBackstopFirstMs", c)  # #746: the first-beat (cold-open) ceiling
+        # The hard stuck ceilings sit STRICTLY between their (resettable) position windows and the
+        # 12-min null-backstop: position recovery < stuck-backstop < null-backstop, per branch. So a
+        # frozen turn always surfaces the recoverable `stuck` affordance BEFORE the last-resort null
+        # clear, and a healthy in-budget turn resolves before either.
         self.assertLess(c["recoveryMs"], c["stuckBackstopMs"])
-        self.assertLess(c["recoveryFirstMs"], c["stuckBackstopMs"])
-        self.assertLess(c["stuckBackstopMs"], c["backstopMs"])
-        self.assertEqual(c["stuckBackstopMs"], 5 * 60 * 1000)
+        self.assertLess(c["recoveryFirstMs"], c["stuckBackstopFirstMs"])
+        self.assertLess(c["stuckBackstopMs"], c["stuckBackstopFirstMs"])
+        self.assertLess(c["stuckBackstopFirstMs"], c["backstopMs"])
+        # #746 budget-awareness: each ceiling clears its branch's HEALTHY budget with margin —
+        # cold open: 400–500s deadline (500s Opus, qa/lib_beat_driver.sh) ⇒ first ceiling ≥ 500s;
+        # later beats: 200s timeout + ONE retry ≈ 400s (scripts/play.sh) ⇒ later ceiling ≥ 400s.
+        self.assertGreaterEqual(c["stuckBackstopFirstMs"], 500 * 1000,
+                                "#746: the first-beat ceiling must clear the 500s cold-open budget")
+        self.assertGreaterEqual(c["stuckBackstopMs"], 400 * 1000,
+                                "#746: the later-beat ceiling must clear the ~400s timeout+retry budget")
+        # Concretely: later = 7 min, first = 9 min.
+        self.assertEqual(c["stuckBackstopMs"], 7 * 60 * 1000)
+        self.assertEqual(c["stuckBackstopFirstMs"], 9 * 60 * 1000)
+
+    # --- #746: the pure ceiling selector, both branches (exactly what armPending arms) --------
+    def test_stuck_backstop_selector_both_branches(self):
+        out = self._run("return ({ first: h.stuckBackstopMs(true), later: h.stuckBackstopMs(false) });")
+        self.assertEqual(out["first"], 9 * 60 * 1000)
+        self.assertEqual(out["later"], 7 * 60 * 1000)
+
+    # --- #746 CORE (THE MISSING BAND): a healthy first beat resolving at ~350–450s ------------
+    def test_healthy_first_beat_in_the_cold_open_budget_band_never_shows_stuck(self):
+        """The false-fire band the flat 5-min ceiling created: the cold open measures ~300s healthy
+        with a 400–500s deadline, so a first beat that streams progress and resolves at ~430s is
+        HEALTHY — yet the old ceiling flagged it `stuck` at 300s mid-flight (action bar re-opened,
+        'DM seems stuck' toast, retryStuck double-resolution). Sample `stuck` right after each clock
+        step BEFORE the next paragraph's progress note — a streamed paragraph CLEARS stuck, so
+        sampling after note() would mask the mid-window false fire."""
+        out = self._run(
+            "h.arm('open the scene');"
+            "var sawStuck = false; var stuckAtS = [];"
+            # a paragraph streams every 30s through 420s — a healthy cold open inside its budget.
+            "for (var i = 0; i < 14; i++) { h.advance(30 * 1000);"
+            "  var p = h.pending(); if (p && p.stuck) { sawStuck = true; stuckAtS.push((i + 1) * 30); }"
+            "  h.note(); }"
+            # …and RESOLVES on /chat at ~430s, squarely inside the measured 400–500s cold-open band.
+            "h.advance(10 * 1000);"
+            "var q = h.pending(); if (q && q.stuck) sawStuck = true;"
+            "await h.resolveTurn('The gates of Embergloom swing open.');"
+            "return ({ saw_stuck: sawStuck, stuck_at_s: stuckAtS, resolved_null: h.pending() === null });"
+        )
+        self.assertFalse(out["saw_stuck"],
+                         f"#746: a HEALTHY first beat resolving at ~430s must NEVER show stuck "
+                         f"(false-fired at {out['stuck_at_s']}s — the stuck toast + bar re-open + "
+                         f"retryStuck double-resolution on a working turn)")
+        self.assertTrue(out["resolved_null"], "the healthy turn resolves normally on /chat")
+
+    # --- #746 CORE: a healthy LATER beat resolving at ~380s (timeout + one retry) -------------
+    def test_healthy_later_beat_resolving_within_the_retry_budget_never_shows_stuck(self):
+        """play.sh gives a continuing beat 200s + ONE retry, so a healthy later beat can resolve at
+        ~380s. The old flat 5-min ceiling fired at 300s — mid-retry — on a turn the system itself
+        still considered in-budget. Resolving turn 1 first (a real /chat dm line) flips firstBeat
+        off, so this exercises the LATER-beat ceiling branch of the real hook."""
+        out = self._run(
+            # Turn 1 resolves → the next armPending is a LATER beat (firstBeat=false).
+            "await h.resolveTurn('You arrive at the tavern.');"
+            "h.arm('strike the bandit');"
+            "var armed = h.pending();"
+            "var sawStuck = false;"
+            # the first attempt times out at ~200s and the retry streams; prose lands every 30s.
+            # Sample stuck right after each step BEFORE the note (a note clears stuck).
+            "for (var i = 0; i < 12; i++) { h.advance(30 * 1000);"
+            "  var p = h.pending(); if (p && p.stuck) sawStuck = true;"
+            "  h.note(); }"
+            "h.advance(20 * 1000);"   # ~380s from submit — the retry lands
+            "var q = h.pending(); if (q && q.stuck) sawStuck = true;"
+            "await h.resolveTurn('The bandit crumples.');"
+            "return ({ later_beat: !!(armed && !armed.firstBeat), saw_stuck: sawStuck,"
+            "          resolved_null: h.pending() === null });"
+        )
+        self.assertTrue(out["later_beat"],
+                        "precondition: after a resolved turn the next arm must be a LATER beat (firstBeat=false)")
+        self.assertFalse(out["saw_stuck"],
+                         "#746: a healthy later beat resolving at ~380s (200s timeout + one retry) "
+                         "must NEVER show stuck mid-flight")
+        self.assertTrue(out["resolved_null"], "the healthy retry-path turn resolves normally on /chat")
 
     def test_multi_partial_trickle_then_freeze_recovers_to_stuck_not_null(self):
-        """The literal newbie scenario: SEVERAL paragraphs stream ('You give the sergeant your own
-        name… The charcoal touches the paper… That's the arithmetic o—') then it freezes mid-word. Each
-        partial used to reset the full window AND clear `stuck`, deferring recovery to the 12-min
-        null-backstop. Now the hard stuck-backstop (progress does NOT reset it) surfaces the recoverable
-        `stuck` 'Try again' affordance — bounded, and as `stuck` (pending non-null), not a silent clear."""
+        """The literal #745 newbie scenario, RETAINED under #746: SEVERAL paragraphs stream ('You give
+        the sergeant your own name… The charcoal touches the paper… That's the arithmetic o—') then it
+        freezes mid-word. Each partial used to reset the full window AND clear `stuck`, deferring
+        recovery to the 12-min null-backstop. Recovery must surface the recoverable `stuck` 'Try
+        again' affordance — bounded (≤ the first-beat hard ceiling), and as `stuck` (pending
+        non-null), not a silent clear."""
         out = self._run(
             "h.arm('give my own name');"
-            # eight partials, 30s apart (a plausibly-alive trickle) → 240s of streaming. Under the OLD code
-            # `stuck` never fired during this (every partial reset the full window AND cleared stuck), and
-            # recovery waited for the 12-min null-backstop. Capture that the trickle stays alive…
+            # eight partials, 30s apart (a plausibly-alive trickle) → 240s of streaming.
             "for (var i = 0; i < 8; i++) { h.advance(30 * 1000); h.note(); }"
             "var duringTrickle = h.pending();"
             # …then the final paragraph FREEZES. Walk forward; capture when `stuck` first fires and the
@@ -376,9 +553,9 @@ class MidStreamStallTests(_BabelHarness):
             "while (t < 11 * 60 * 1000) { h.advance(5 * 1000); t += 5 * 1000;"
             "  var q = h.pending(); if (q === null) { nulledFirst = (stuckAt === null); break; }"
             "  if (q && q.stuck) { stuckAt = t; break; } }"
-            "({ alive_during_trickle: !!(duringTrickle && !duringTrickle.stuck && duringTrickle.streaming),"
+            "return ({ alive_during_trickle: !!(duringTrickle && !duringTrickle.stuck && duringTrickle.streaming),"
             "   stuck_fired: stuckAt !== null, stuck_at_ms_from_submit: stuckAt,"
-            "   nulled_before_stuck: nulledFirst, still_pending_at_stuck: !!(h.pending()) })"
+            "   nulled_before_stuck: nulledFirst, still_pending_at_stuck: !!(h.pending()) });"
         )
         self.assertTrue(out["alive_during_trickle"],
                         "a flowing trickle stays narrating (not stuck) — the live-progress feel is preserved")
@@ -386,32 +563,37 @@ class MidStreamStallTests(_BabelHarness):
                         "#745: a trickle-then-freeze MUST recover to `stuck`, not vanish via the 12-min null-backstop")
         self.assertFalse(out["nulled_before_stuck"],
                          "recovery must surface the RECOVERABLE `stuck` affordance, not a silent null clear")
-        # The give-up was a ~12–15-min lockout. The hard ceiling bounds total stall from submit well under
-        # that — it fires by PENDING_STUCK_BACKSTOP_MS regardless of how many partials trickled in.
+        # The give-up was a ~12–15-min lockout. Recovery stays bounded well under that: the (resettable)
+        # position window re-armed at the LAST partial fires first, and the budget-aware hard ceiling
+        # (#746: 9 min for the first beat) caps it regardless of how many partials trickled in.
         self.assertIsNotNone(out["stuck_at_ms_from_submit"])
-        self.assertLessEqual(out["stuck_at_ms_from_submit"], 5 * 60 * 1000 + 5 * 1000,
-                             "the hard stuck-backstop must fire by ~5 min from submit, not the 12-min null-backstop")
+        self.assertLessEqual(out["stuck_at_ms_from_submit"], 9 * 60 * 1000 + 5 * 1000,
+                             "a trickle-then-freeze must go stuck by the (first-beat) hard ceiling, "
+                             "not the 12-min null-backstop")
         self.assertTrue(out["still_pending_at_stuck"],
                         "recovery surfaces the `stuck` 'Try again' affordance (pending stays non-null)")
 
     def test_stuck_backstop_is_not_reset_by_progress(self):
-        """The crux: streamed progress re-arms the per-progress recovery timer but must NOT push the hard
-        stuck-backstop forward. So even a long, frequent trickle is bounded by the submit-anchored ceiling."""
+        """The #745 crux, RETAINED at the #746 ceiling: streamed progress re-arms the per-progress
+        recovery timer but must NOT push the hard stuck-backstop forward. A trickle that streams right
+        up near the (now 9-min first-beat) ceiling and then freezes goes stuck AT the submit-anchored
+        ceiling — progress cannot defer it."""
         out = self._run(
             "h.arm('do');"
-            # frequent partials right up to just before the 5-min ceiling — each resets the position timer
-            # (proving the turn looks 'alive' to the per-progress path) but must NOT move the hard ceiling.
-            "for (var i = 0; i < 9; i++) { h.advance(30 * 1000); h.note(); }"   # 270s of streaming
-            "var at270 = h.pending();"
-            # cross the 5-min submit ceiling with NO further progress → the hard backstop fires `stuck`.
-            "h.advance(35 * 1000);"   # 305s from submit, past the 300s ceiling
-            "var at305 = h.pending();"
-            "({ alive_at_270s: !!(at270 && !at270.stuck), stuck_at_305s: !!(at305 && at305.stuck) })"
+            # frequent partials up to 510s — inside the 540s first-beat ceiling; each resets the
+            # position timer (the turn looks 'alive' to the per-progress path) but must NOT move the
+            # hard ceiling.
+            "for (var i = 0; i < 17; i++) { h.advance(30 * 1000); h.note(); }"   # 510s of streaming
+            "var at510 = h.pending();"
+            # cross the 9-min submit ceiling with NO further progress → the hard backstop fires `stuck`.
+            "h.advance(35 * 1000);"   # 545s from submit, past the 540s ceiling
+            "var at545 = h.pending();"
+            "return ({ alive_at_510s: !!(at510 && !at510.stuck), stuck_at_545s: !!(at545 && at545.stuck) });"
         )
-        self.assertTrue(out["alive_at_270s"],
+        self.assertTrue(out["alive_at_510s"],
                         "frequent progress keeps the turn narrating up to the ceiling (per-progress timer reset)")
-        self.assertTrue(out["stuck_at_305s"],
-                        "#745: the hard stuck-backstop is anchored to submit — progress must NOT defer it")
+        self.assertTrue(out["stuck_at_545s"],
+                        "#745/#746: the hard stuck-backstop is anchored to submit — progress must NOT defer it")
 
     def test_healthy_streaming_turn_that_resolves_never_trips_the_stuck_backstop(self):
         """A long-but-HEALTHY streaming turn RESOLVES on /chat (clearPending) before the hard ceiling, which
@@ -419,17 +601,17 @@ class MidStreamStallTests(_BabelHarness):
         #348/#399/#623 live-progress contract is preserved)."""
         out = self._run(
             "h.arm('open the scene');"
-            # 4 minutes of healthy streaming (well past the 240s first-beat window, UNDER the 5-min ceiling),
+            # 4 minutes of healthy streaming (past the 240s first-beat window, under the ceiling),
             # then the turn resolves on /chat (clearPending) — exactly what a real completed beat does.
             "for (var i = 0; i < 8; i++) { h.advance(30 * 1000); h.note(); }"   # 240s
             "h.advance(h.constants().armGraceMs + 1000);"
             "h.clear();"                                   # the turn RESOLVED on /chat
             "var resolved = h.pending();"
-            # advance far past the 5-min stuck-backstop AND the 12-min null-backstop — a resolved turn must
+            # advance far past the stuck-backstop AND the 12-min null-backstop — a resolved turn must
             # not resurrect any stuck/pending state (the timers were cancelled by clearPending).
             "h.advance(13 * 60 * 1000);"
             "var afterAll = h.pending();"
-            "({ resolved_null: resolved === null, no_resurrect: afterAll === null })"
+            "return ({ resolved_null: resolved === null, no_resurrect: afterAll === null });"
         )
         self.assertTrue(out["resolved_null"], "a resolved healthy turn clears pending")
         self.assertTrue(out["no_resurrect"],
@@ -438,14 +620,15 @@ class MidStreamStallTests(_BabelHarness):
     def test_pre_stream_slow_open_still_uses_the_full_window(self):
         """A slow cold-open that streams NOTHING yet keeps the generous first-beat window — the #348/#399
         false-stuck guard. The stuck-backstop is a HARD additional ceiling, not a replacement: it does not
-        clip the legit pre-stream think (which is well under 5 min) to anything shorter."""
+        clip the legit pre-stream think to anything shorter, and a genuinely-SILENT beat is still flagged
+        by the adaptive recovery window (180s/240s) — the ceiling's job is only the mid-stream stall."""
         out = self._run(
             "h.arm('open the scene');"
-            # 120s with NO streamed paragraph — neither the 240s first-beat window nor the 5-min ceiling
+            # 120s with NO streamed paragraph — neither the 240s first-beat window nor the ceiling
             # has elapsed, so the turn is still narrating (no false stuck).
             "h.advance(120 * 1000);"
             "var p = h.pending();"
-            "({ stuck_at_120s_no_stream: !!(p && p.stuck), narrating: !!(p && !p.stuck) })"
+            "return ({ stuck_at_120s_no_stream: !!(p && p.stuck), narrating: !!(p && !p.stuck) });"
         )
         self.assertFalse(out["stuck_at_120s_no_stream"],
                          "the pre-stream slow open must keep the full window — no false stuck at 120s")
@@ -473,8 +656,8 @@ class PlayGateLockoutTests(_BabelHarness):
 
     def _gate(self, surface_status: str, app_status_js: str, pending_stuck: str):
         return self._run(
-            f"win.computePlayGate({{ surfaceStatus: {json.dumps(surface_status)},"
-            f" appStatus: {app_status_js}, pendingStuck: {pending_stuck} }})"
+            f"return (win.computePlayGate({{ surfaceStatus: {json.dumps(surface_status)},"
+            f" appStatus: {app_status_js}, pendingStuck: {pending_stuck} }}));"
         )
 
     # B) the raw dev string never reaches the player ---------------------------
@@ -538,7 +721,7 @@ class ColdOpenAwaitingTests(_BabelHarness):
         base = dict(surfaceStatus="ready", live=True, isLiveView=False, pendingActive=False,
                     pendingStuck=False, visibleLogLength=0, partyEmpty=True)
         base.update(over)
-        return self._run("win.computeColdOpenAwaiting(%s)" % json.dumps(base))
+        return self._run("return (win.computeColdOpenAwaiting(%s));" % json.dumps(base))
 
     def test_fires_at_the_real_coldopen_frame(self):
         # The exact bug frame: live=true, is_live_view=false (a desync the heal hasn't caught), the
@@ -578,7 +761,7 @@ class SurfaceFreshnessTests(_BabelHarness):
     time (day/HP/location reverting while the live chronicle held). Everything else applies."""
 
     def _apply(self, prev, nxt):
-        return self._run("win.shouldApplySurface(%s, %s)" % (json.dumps(prev), json.dumps(nxt)))
+        return self._run("return (win.shouldApplySurface(%s, %s));" % (json.dumps(prev), json.dumps(nxt)))
 
     def test_strictly_older_same_campaign_is_rejected(self):
         self.assertFalse(self._apply({"campaign_id": "c", "updated_at": 200},


### PR DESCRIPTION
## P0 — the #746 stuck-backstop false-fires on healthy slow turns

Refs #745 (the mid-stream-stall lockout); follow-up to the merged #746 (which shipped the ceiling this PR retunes). Audit-verified root cause — sanity-rechecked against the cited lines before editing:

- `viewer/openworlds/app.jsx`: `PENDING_STUCK_BACKSTOP_MS = 5 * 60 * 1000` (flat 300s), armed once at submit in `armPending`, NOT `firstBeat`-aware; progress does not reset it (by design, #745).
- But the system's own **healthy** budgets exceed 300s:
  - cold open: ~300s measured with a **400–500s** deadline (`qa/lib_beat_driver.sh` `clawdnd_dm_timeout` — 500s for Opus; verified at lines ~441–447);
  - continuing beat: `scripts/play.sh` `CLAWDND_BEAT_TIMEOUT=200s` + ONE retry ⇒ a healthy beat can run **~400s**.
- When the ceiling fires falsely mid-flight: `pendingActive` flips false → the action bar re-opens (`screen-table.jsx` ~614), the "DM seems stuck" toast fires (~796–798), and `retryStuck` re-POSTs the move (~875+) → the **same intent resolves twice** once the in-flight beat lands.

## Fix (audit option (a), minimal)

Budget-aware ceiling by turn position via a pure `stuckBackstopMs(firstBeat)` selector (mirrors `recoveryWindowMs`, exported for tests):

| branch | ceiling | clears budget |
|---|---|---|
| first beat (cold open) | `PENDING_STUCK_BACKSTOP_FIRST_MS = 9 min` (540s) | ≥ 500s Opus cold-open deadline |
| later beats | `PENDING_STUCK_BACKSTOP_MS = 7 min` (420s) | ≥ ~400s timeout + one-retry |

Ordering invariant preserved per branch: position recovery (180s/240s, resettable) < stuck ceiling (420s/540s, hard, recoverable) < 12-min null-backstop. `firstBeat` detection unchanged (`resolvedTurnsRef.current === 0`, the #406 semantics).

**Option (b) (arm the ceiling only on the first streamed paragraph) deliberately NOT implemented:** with the ceiling submit-anchored (required to keep it under the null-backstop) and strictly above the recovery windows, arming at submit vs. at first paragraph is observationally identical — a never-streaming turn is flagged `stuck` by the adaptive recovery window (180s/240s) long before the ceiling, and a streaming turn arms it anyway. (b) would add arm-state in the progress path for zero behavioral delta, so it fails the "only if it stays small" bar on the value side.

## Tests (red-first; `viewer/tests/test_recovery_timing.py`)

Harness upgrade: the recovery-timing harness now runs **real effects + a scripted `/chat` poll** (ported from `test_live_narration_stream.py`, keeping the deterministic fake-timer queue). Resolving a turn via a real `/chat` dm line is the only writer of `resolvedTurnsRef`, so tests can now exercise the **later-beat** branch of the real hook — previously unreachable (the old harness's documented limitation).

Proven RED on main @ f24a102 (5 failed, 30 passed), then GREEN after the fix:

1. **The missing band** — `test_healthy_first_beat_in_the_cold_open_budget_band_never_shows_stuck`: healthy first beat streams every 30s, resolves ~430s. RED on main: false-fired at exactly **300s** (assertion message captured `[300]s`).
2. **Later beat** — `test_healthy_later_beat_resolving_within_the_retry_budget_never_shows_stuck`: turn 1 resolved via the live /chat path (`firstBeat=false` precondition asserted), turn 2 streams + resolves ~380s. RED on main.
3. **#745 protection retained** — `test_multi_partial_trickle_then_freeze_recovers_to_stuck_not_null` (recovers to recoverable `stuck`, never the silent null clear, bounded ≤ the first-beat ceiling) and `test_stuck_backstop_is_not_reset_by_progress` rewritten at the new 9-min value (trickle to 510s, freeze, stuck at 545s — progress cannot defer the submit-anchored ceiling).
4. **Contract** — `test_stuck_backstop_constants_exported_and_strictly_ordered` (per-branch ordering + explicit ≥500s / ≥400s budget floors) and `test_stuck_backstop_selector_both_branches`.

## Verification (honest)

- `python3 -m pytest viewer/tests/test_recovery_timing.py -q -p no:xdist` → **35 passed** (was 5 failed / 30 passed pre-fix — red-first proven).
- Full viewer suite `python3 -m pytest viewer/tests -q -p no:xdist` → **486 passed, 6 skipped, 48 subtests passed**.
- `bash qa/fast_gate.sh` → **PASS** (188 passed, deterministic engine tier).
- Not verified live: an end-to-end slow-beat run in the app (the 5–9-minute timer band isn't practical to observe in a quick manual session); the Node harness drives the real transpiled hook code as the proxy.

## Invariants

- Viewer-only; engine untouched (sole-writer unaffected). No wire-contract changes. `__PENDING_TIMING__` change is additive (new `stuckBackstopFirstMs` key; existing keys keep meaning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined stuck recovery timeout behavior to adapt dynamically based on turn position, providing more intelligent recovery windows for the live session indicator.

* **Tests**
  * Updated recovery timing test coverage to validate the new adaptive timeout behavior across different turn states and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->