### PR TITLE
qa(rri): image_render Mac-handoff evidence path + wire support-preflight into the sweep + ui_audit calibration (#730)

### DIFF
--- a/qa/release_readiness.py
+++ b/qa/release_readiness.py
@@ -20,6 +20,16 @@ The two NEW signals the plan calls for — image-render-rate and palette-live �
 here (image rate from score.json/network.ndjson) and passed in (palette-live), so this stays
 a pure disk reader.
 
+image_render gate sources (signals.image_render_source):
+  - "vm-network"  : per-run network.ndjson /image rows exist -> the REAL rate is computed
+                    and is authoritative (recorded 404s can never be papered over).
+  - "mac-handoff" : no per-run /image denominator exists (the VM cannot serve gitignored
+                    _private art) AND a valid --handoff-json at the same --build-sha proved
+                    health.image_probe_ok:true + the private art root across every
+                    required handoff gate. This is a representative built-app image
+                    probe, NOT a render rate — weaker but real Mac evidence.
+  - "none"        : neither source -> the gate stays a HARD FAIL with an evidence gap.
+
 Usage:
   release_readiness.py --runs <run-dir>[,<run-dir>...] \
       [--story story.json] [--mech mech.json] \
@@ -318,6 +328,14 @@ def validate_handoff_json(handoff_json: str, expected_sha: str) -> tuple[dict, l
         "handoff_score": 0,
         "commit_sha": "",
         "gates": {},
+        # Image evidence is a SEPARATE, stricter signal than handoff validity: the
+        # handoff stays valid for native_gate even when its app-status snapshots never
+        # recorded health.image_probe_ok, but image_render may only ride the handoff
+        # when EVERY required gate proved the probe + the private art root. The probe
+        # is honest-but-weaker than a render rate: it proves the built app resolved a
+        # representative descriptor for the live scene's imageScope, not a percentage
+        # of all image requests.
+        "image_evidence": {"image_probe_ok": False, "art_root_present": False, "gates": {}},
     }
     if not handoff_json:
         return proof, []
@@ -352,6 +370,8 @@ def validate_handoff_json(handoff_json: str, expected_sha: str) -> tuple[dict, l
     by_name = {str(g.get("name") or ""): g for g in gates if isinstance(g, dict)}
     proof["gates"] = {}
     manifest_paths_seen: set[Path] = set()
+    gate_image_probe: dict[str, bool] = {}
+    gate_art_root: dict[str, bool] = {}
     for gate_name in REQUIRED_HANDOFF_GATES:
         gate = by_name.get(gate_name)
         if not gate:
@@ -414,6 +434,7 @@ def validate_handoff_json(handoff_json: str, expected_sha: str) -> tuple[dict, l
 
         handoff_gate = manifest.get("handoff_gate") if isinstance(manifest.get("handoff_gate"), dict) else {}
         art = manifest.get("art") if isinstance(manifest.get("art"), dict) else {}
+        gate_art_root[gate_name] = art.get("private_root_present") is True
         live = manifest.get("live") if isinstance(manifest.get("live"), dict) else {}
         evidence_files = manifest.get("evidence_files") if isinstance(manifest.get("evidence_files"), dict) else {}
         checks = {
@@ -448,6 +469,10 @@ def validate_handoff_json(handoff_json: str, expected_sha: str) -> tuple[dict, l
                     if app_status_error:
                         gaps.append(handoff_gap(str(evidence_file), f"app-status snapshot {app_status_error}"))
                         continue
+                    health = app_status.get("health") if isinstance(app_status.get("health"), dict) else {}
+                    gate_image_probe[gate_name] = (
+                        gate_image_probe.get(gate_name, True) and health.get("image_probe_ok") is True
+                    )
                     if app_status.get("schema") != "worldos.app-status.v1":
                         gaps.append(handoff_gap(str(evidence_file), "app-status schema is missing or wrong"))
                     if app_status.get("state_authority") != "engine":
@@ -457,6 +482,20 @@ def validate_handoff_json(handoff_json: str, expected_sha: str) -> tuple[dict, l
                     app_status_build = app_status.get("build") if isinstance(app_status.get("build"), dict) else {}
                     if expected_sha and not build_sha_matches(str(app_status_build.get("sha") or ""), expected_sha):
                         gaps.append(handoff_gap(str(evidence_file), f"app-status build.sha {app_status_build.get('sha') or 'missing'} does not match --build-sha {expected_sha}"))
+    proof["image_evidence"] = {
+        # True only when EVERY required gate parsed >=1 app-status snapshot and ALL of
+        # that gate's snapshots reported health.image_probe_ok:true. A gate with no
+        # parsed snapshots stays absent from gate_image_probe and fails the all().
+        "image_probe_ok": all(gate_image_probe.get(g) is True for g in REQUIRED_HANDOFF_GATES),
+        "art_root_present": all(gate_art_root.get(g) is True for g in REQUIRED_HANDOFF_GATES),
+        "gates": {
+            g: {
+                "image_probe_ok": gate_image_probe.get(g, False) is True,
+                "art_root_present": gate_art_root.get(g, False) is True,
+            }
+            for g in REQUIRED_HANDOFF_GATES
+        },
+    }
     proof["valid"] = not gaps
     return proof, gaps
 
@@ -617,6 +656,29 @@ def main() -> int:
     image_missing_personas = [str(p["persona"]) for p in persona_scores if p["image_total"] <= 0]
     image_evidence_complete = bool(persona_scores) and not image_missing_personas
     img_rate = (sum(p["image_ok"] for p in img_runs) / sum(p["image_total"] for p in img_runs)) if img_runs else 0.0
+    total_image_denominator = sum(p["image_total"] for p in img_runs)
+
+    # image_render source selection. The VM cannot serve gitignored _private art, so a
+    # split VM+Mac sweep structurally has NO per-run /image denominator; the Mac handoff
+    # is then the authoritative image evidence (built-app image_probe_ok + private art
+    # root across every required handoff gate, at the SAME --build-sha). Precedence is
+    # honest: any recorded VM image traffic computes the REAL rate (a handoff can never
+    # paper over recorded 404s), and when NEITHER source exists the gate stays a hard
+    # fail with an evidence gap — a VM-only sweep without a handoff still reports the gap.
+    handoff_image_evidence = handoff_proof.get("image_evidence") if isinstance(handoff_proof.get("image_evidence"), dict) else {}
+    handoff_image_ok = bool(
+        args.handoff_json
+        and args.build_sha
+        and handoff_proof.get("valid")
+        and handoff_image_evidence.get("image_probe_ok") is True
+        and handoff_image_evidence.get("art_root_present") is True
+    )
+    if total_image_denominator > 0:
+        image_render_source = "vm-network"
+    elif persona_scores and handoff_image_ok:
+        image_render_source = "mac-handoff"
+    else:
+        image_render_source = "none"
 
     story = read_json(Path(args.story)) if args.story else {}
     mech = read_json(Path(args.mech)) if args.mech else {}
@@ -736,11 +798,18 @@ def main() -> int:
         evidence_gaps.append({"gate": "ui_audit", "missing": "--ui-audit-log", "detail": "UI audit log path not supplied"})
     elif not Path(args.ui_audit_log).exists():
         evidence_gaps.append({"gate": "ui_audit", "missing": args.ui_audit_log, "detail": "UI audit log path missing"})
-    if image_missing_personas:
+    if image_missing_personas and image_render_source != "mac-handoff":
+        image_gap_detail = f"no /image requests recorded for: {', '.join(image_missing_personas)}"
+        if args.handoff_json and image_render_source == "none":
+            image_gap_detail += (
+                "; Mac handoff supplied but did not prove image evidence"
+                " (needs valid same-SHA handoff with health.image_probe_ok:true"
+                " + art root present across all required gates)"
+            )
         evidence_gaps.append({
             "gate": "image_render",
             "missing": "network.ndjson image denominator",
-            "detail": f"no /image requests recorded for: {', '.join(image_missing_personas)}",
+            "detail": image_gap_detail,
         })
     if not args.palette_live:
         evidence_gaps.append({"gate": "palette_live", "missing": "--palette-live", "detail": "palette-live result not supplied"})
@@ -753,6 +822,18 @@ def main() -> int:
     if split_vm_handoff_evidence:
         native_evidence_gap_gates.add("support_preflight")
     native_gate_detail = f"source={native_source or 'n/a'} {native_detail or 'part_a=' + (native or 'n/a')}".strip()
+    if image_render_source == "mac-handoff":
+        # The Mac handoff also rides the support-preflight contract on a split sweep:
+        # image_render must not pass off a handoff whose split rollup is unproven.
+        image_render_ok = not (evidence_gap_gates & ({"image_render"} | native_evidence_gap_gates))
+        image_render_detail = (
+            "source=mac-handoff; built-app image_probe_ok + private art root proven across "
+            f"{','.join(REQUIRED_HANDOFF_GATES)} at --build-sha {args.build_sha} "
+            "(representative built-app probe, NOT a VM render rate; vm denominator=0)"
+        )
+    else:
+        image_render_ok = image_evidence_complete and img_rate >= 0.95 and "image_render" not in evidence_gap_gates
+        image_render_detail = f"source={image_render_source}; rate={img_rate:.2%}; denominator={total_image_denominator}"
 
     # ---- the 11 gates (each contributes to RRI; all must hold for 10/10) ----
     gates = {
@@ -774,8 +855,7 @@ def main() -> int:
                                f"behavioral={args.behavioral or 'n/a'}"),
         "ui_audit":           (args.ui_audit == "PASS" and "ui_audit" not in evidence_gap_gates,
                                f"ui_audit={args.ui_audit or 'n/a'}"),
-        "image_render":       (image_evidence_complete and img_rate >= 0.95 and "image_render" not in evidence_gap_gates,
-                               f"rate={img_rate:.2%}; denominator={sum(p['image_total'] for p in img_runs)}"),
+        "image_render":       (image_render_ok, image_render_detail),
         "palette_live":       (args.palette_live == "true" and "palette_live" not in evidence_gap_gates,
                                f"palette_live={args.palette_live or 'n/a'}"),
     }
@@ -850,7 +930,8 @@ def main() -> int:
             "behavioral": args.behavioral,
             "ui_audit": args.ui_audit,
             "image_render_rate": round(img_rate, 4),
-            "image_request_denominator": sum(p["image_total"] for p in img_runs),
+            "image_render_source": image_render_source,
+            "image_request_denominator": total_image_denominator,
             "image_missing_personas": image_missing_personas,
             "palette_live": args.palette_live,
             "run_build_shas": build_shas,

--- a/qa/test_release_gate_static.py
+++ b/qa/test_release_gate_static.py
@@ -112,6 +112,50 @@ class ReleaseGateStaticContractTests(unittest.TestCase):
         self.assertIn('[ "$PART_A_RESULT" = "PASS" ] || EXIT_OK=0', source)
         self.assertIn('[ "$PART_B_RESULT" = "PASS" ] && [ "$PART_B_SCORE_PASS" = "true" ] || EXIT_OK=0', source)
 
+    def test_sweep_v2_runs_support_preflight_before_personas_and_rolls_it_up(self):
+        # #730: the VM sweep never produced the support-preflight artifact, so split
+        # VM+Mac rollups always carried the support_preflight evidence gap.
+        source = (ROOT / "qa" / "vm" / "sweep_v2.sh").read_text(encoding="utf-8")
+
+        self.assertIn("qa/support_vm_preflight.py", source)
+        self.assertIn('--expected-sha "$SHA"', source)
+        self.assertIn("--private-art-mode required", source)
+        self.assertIn("--no-fail", source)
+        self.assertIn('"$RES/support_preflight.json"', source)
+        self.assertIn('--support-preflight-json "$RES/support_preflight.json"', source)
+        # The preflight must run BEFORE the personas (canary included) so a blocked
+        # host is recorded before any model spend.
+        self.assertLess(source.index("qa/support_vm_preflight.py"), source.index("CANARY: newbie"))
+        # The rollup invocation carries the artifact.
+        self.assertLess(source.index("qa/release_readiness.py"), source.index('--support-preflight-json "$RES/support_preflight.json"'))
+        # ui_audit gets the auditstate dir so its --ui-gate seed step can act on it.
+        self.assertIn("WORLDOS_STATE_DIR=/root/worldos-qa/auditstate timeout 600 bash qa/ui_audit_health.sh", source)
+
+    def test_ui_audit_health_axe_missing_driver_is_hard_fail(self):
+        # rc1 was misattributed as FAIL(axe) when axe never ran: a missing
+        # browser-driver-manager silently WARN-skipped the sweep. When --axe is
+        # requested, a missing driver must FAIL loudly with the install command.
+        source = (ROOT / "qa" / "ui_audit_health.sh").read_text(encoding="utf-8")
+
+        self.assertIn('fail "--axe requested but npx is not on PATH', source)
+        self.assertIn('fail "--axe requested but browser-driver-manager', source)
+        self.assertIn("npx --yes browser-driver-manager install chrome=", source)
+        self.assertNotIn('warn "browser-driver-manager not installed', source)
+        self.assertNotIn('warn "npx not on PATH; skipping --axe"', source)
+
+    def test_ui_audit_health_seeds_resumable_campaign_for_play_reachable(self):
+        # The play_reachable ui-gate probe can never pass against an EMPTY auditstate
+        # (no Resume/Continue CTA exists without a resumable campaign) — seed one
+        # minimal campaign first, guarded so an already-seeded state is untouched.
+        source = (ROOT / "qa" / "ui_audit_health.sh").read_text(encoding="utf-8")
+
+        self.assertIn('AUDIT_STATE_DIR="${WORLDOS_STATE_DIR:-${CLAWDND_STATE_DIR:-}}"', source)
+        self.assertIn('campaigns/*/snapshot.json', source)
+        self.assertIn('server.start_world(', source)
+        self.assertIn("uv run --directory servers/engine python", source)
+        # Seeding must happen before the probe runs.
+        self.assertLess(source.index("AUDIT_STATE_DIR"), source.index("node qa/ui_gate_probe.js"))
+
     def test_solo_play_contract_does_not_silently_recruit_companion(self):
         play = (ROOT / "scripts" / "play.sh").read_text(encoding="utf-8")
         party = (ROOT / "scripts" / "play_party.sh").read_text(encoding="utf-8")

--- a/qa/test_release_readiness.py
+++ b/qa/test_release_readiness.py
@@ -219,7 +219,16 @@ class ReleaseReadinessContractTests(unittest.TestCase):
         palette.write_text(json.dumps({"can_act": True}), encoding="utf-8")
         return story, mech, behavioral, audit, palette
 
-    def write_persona_run(self, tmp: Path, persona: str, *, sha: str = "deadbee", include_part_a: bool = True) -> Path:
+    def write_persona_run(
+        self,
+        tmp: Path,
+        persona: str,
+        *,
+        sha: str = "deadbee",
+        include_part_a: bool = True,
+        include_image_traffic: bool = True,
+        image_status: int = 200,
+    ) -> Path:
         run = tmp / f"gate-{persona}"
         player = run / "player"
         player.mkdir(parents=True)
@@ -242,10 +251,15 @@ class ReleaseReadinessContractTests(unittest.TestCase):
         if include_part_a:
             payload["part_a"] = {"result": "PASS"}
         (run / "run.json").write_text(json.dumps(payload), encoding="utf-8")
-        (player / "network.ndjson").write_text(
-            json.dumps({"url": f"http://127.0.0.1/image?scope={persona}", "status": 200}),
-            encoding="utf-8",
-        )
+        if include_image_traffic:
+            (player / "network.ndjson").write_text(
+                json.dumps({"url": f"http://127.0.0.1/image?scope={persona}", "status": image_status}),
+                encoding="utf-8",
+            )
+        else:
+            # A VM sweep that never recorded /image traffic at all (the gitignored
+            # _private art case): network.ndjson exists but carries no image rows.
+            (player / "network.ndjson").write_text("", encoding="utf-8")
         return run
 
     def test_missing_expected_persona_score_marks_partial_and_fails_release(self):
@@ -501,6 +515,7 @@ class ReleaseReadinessContractTests(unittest.TestCase):
             self.assertTrue(payload["partial"])
             self.assertIn("image_render", payload["failed_gates"])
             self.assertEqual(payload["signals"]["image_request_denominator"], 0)
+            self.assertEqual(payload["signals"]["image_render_source"], "none")
             self.assertIn(
                 {"gate": "image_render", "missing": "network.ndjson image denominator", "detail": "no /image requests recorded for: newbie"},
                 payload["evidence_gaps"],
@@ -1251,6 +1266,177 @@ class ReleaseReadinessContractTests(unittest.TestCase):
             )
             self.assertEqual(payload["handoff_evidence"]["gates"]["built_app_codex_playtest"]["manifest_verdict"], "passed")
             self.assertIn("handoff_json=", payload["gate_detail"]["native_gate"])
+            self.assertEqual(payload["signals"]["image_render_source"], "vm-network")
+
+    def test_image_render_accepts_same_sha_mac_handoff_when_vm_has_no_denominator(self):
+        # The split VM+Mac lane: the VM cannot serve gitignored _private art, so its
+        # network.ndjson never records /image traffic. A valid same-SHA Mac handoff whose
+        # app-status snapshots prove health.image_probe_ok (and whose manifests prove the
+        # private art root) is accepted as the image_render gate source.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(tmp, persona, include_part_a=False, include_image_traffic=False)
+                for persona in personas
+            ]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            handoff = self.write_handoff_bundle(
+                tmp,
+                app_status_overrides={"health": {"image_probe_ok": True}},
+            )
+            support_preflight = self.write_support_preflight(tmp)
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--handoff-json",
+                str(handoff),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(payload["release_ready"])
+            self.assertNotIn("image_render", payload["failed_gates"])
+            self.assertEqual(payload["signals"]["image_render_source"], "mac-handoff")
+            self.assertEqual(payload["signals"]["image_request_denominator"], 0)
+            # Honest record: the per-persona VM gap is still visible in signals even
+            # though the Mac handoff carries the gate.
+            self.assertEqual(sorted(payload["signals"]["image_missing_personas"]), sorted(personas))
+            self.assertTrue(payload["handoff_evidence"]["image_evidence"]["image_probe_ok"])
+            self.assertTrue(payload["handoff_evidence"]["image_evidence"]["art_root_present"])
+            self.assertNotIn("image_render", {gap["gate"] for gap in payload["evidence_gaps"]})
+            self.assertIn("mac-handoff", payload["gate_detail"]["image_render"])
+
+    def test_image_render_handoff_without_image_probe_keeps_evidence_gap(self):
+        # A handoff that is valid for native_gate but whose app-status snapshots never
+        # proved health.image_probe_ok must NOT carry the image_render gate.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(tmp, persona, include_part_a=False, include_image_traffic=False)
+                for persona in personas
+            ]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            handoff = self.write_handoff_bundle(tmp)  # no health.image_probe_ok in app-status
+            support_preflight = self.write_support_preflight(tmp)
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--handoff-json",
+                str(handoff),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertIn("image_render", payload["failed_gates"])
+            self.assertEqual(payload["signals"]["image_render_source"], "none")
+            self.assertFalse(payload["handoff_evidence"]["image_evidence"]["image_probe_ok"])
+            self.assertIn("image_render", {gap["gate"] for gap in payload["evidence_gaps"]})
+            # native_gate is still allowed to ride the handoff — only image_render
+            # demanded the extra image evidence.
+            self.assertEqual(payload["signals"]["native_gate"], "PASS")
+
+    def test_vm_image_denominators_take_precedence_over_mac_handoff(self):
+        # When the VM DID record /image traffic, the real rate is the gate source —
+        # a same-SHA Mac handoff with image evidence cannot paper over recorded 404s.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(tmp, persona, include_part_a=False, image_status=404)
+                for persona in personas
+            ]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            handoff = self.write_handoff_bundle(
+                tmp,
+                app_status_overrides={"health": {"image_probe_ok": True}},
+            )
+            support_preflight = self.write_support_preflight(tmp)
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--handoff-json",
+                str(handoff),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertIn("image_render", payload["failed_gates"])
+            self.assertEqual(payload["signals"]["image_render_source"], "vm-network")
+            self.assertEqual(payload["signals"]["image_request_denominator"], 5)
+            self.assertEqual(payload["signals"]["image_render_rate"], 0.0)
 
     def test_split_vm_persona_evidence_requires_support_preflight(self):
         with tempfile.TemporaryDirectory() as td:

--- a/qa/ui_audit_health.sh
+++ b/qa/ui_audit_health.sh
@@ -255,16 +255,23 @@ fi
 # 12. Optional: axe-core a11y sweep. Off by default (needs browser-driver-manager
 # + a matching ChromeDriver). Loop-5 baseline (2026-05-29) recorded 11 violations
 # across 8 screens — 10 scrollable-region-focusable + 1 label. Filed as #291 + #292.
+#
+# HONEST-GATE calibration: when --axe is REQUESTED, a missing npx / driver is a HARD
+# FAIL, not a warn-skip. rc1's "FAIL(axe)" was misattributed — axe never actually ran
+# because browser-driver-manager was missing and the sweep silently skipped it. A
+# requested check that cannot run must fail loudly with the install command; the
+# path WITHOUT --axe is unchanged (still fully opt-in).
 if [ "$AXE" -eq 1 ]; then
   if ! command -v npx >/dev/null 2>&1; then
-    warn "npx not on PATH; skipping --axe"
+    fail "--axe requested but npx is not on PATH — axe did NOT run. Install Node, then: npx --yes browser-driver-manager install chrome=<major-version>"
   else
     CHROME_VER=$(/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --version 2>/dev/null | awk '{print $3}' | awk -F. '{print $1}')
     DRIVER_DIR=$(ls -d "$HOME/.browser-driver-manager/chromedriver/mac_arm-${CHROME_VER}"* 2>/dev/null | head -1)
     CHROME_TEST_DIR=$(ls -d "$HOME/.browser-driver-manager/chrome/mac_arm-${CHROME_VER}"* 2>/dev/null | head -1)
-    if [ -z "$DRIVER_DIR" ] || [ -z "$CHROME_TEST_DIR" ]; then
-      warn "browser-driver-manager not installed for Chrome ${CHROME_VER}; install with:"
-      warn "  npx --yes browser-driver-manager install chrome=${CHROME_VER}"
+    if [ -z "$CHROME_VER" ]; then
+      fail "--axe requested but Chrome's major version could not be detected (is Google Chrome installed at /Applications?) — axe did NOT run. Install Chrome, then: npx --yes browser-driver-manager install chrome=<major-version>"
+    elif [ -z "$DRIVER_DIR" ] || [ -z "$CHROME_TEST_DIR" ]; then
+      fail "--axe requested but browser-driver-manager is not installed for Chrome ${CHROME_VER} — axe did NOT run. Install with: npx --yes browser-driver-manager install chrome=${CHROME_VER}"
     else
       CHROMEDRIVER="$DRIVER_DIR/chromedriver-mac-arm64/chromedriver"
       CHROME_TEST="$CHROME_TEST_DIR/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
@@ -311,6 +318,39 @@ if [ "$UI_GATE" -eq 1 ]; then
   elif [ ! -f qa/ui_gate_probe.js ]; then
     warn "qa/ui_gate_probe.js missing; --ui-gate skipped"
   else
+    # 13-pre. play_reachable seed — the launcher's Resume/Continue CTA only renders when
+    # a RESUMABLE campaign exists in the viewer's CURRENT state dir (canResume comes from
+    # root_is_current in viewer/server.py), so the probe can NEVER pass against an empty
+    # auditstate. Seed exactly one minimal resumable campaign (server.start_world — the
+    # smallest robust path; campaigns.json re-reads on snapshot mtime change so no viewer
+    # restart is needed). Guarded: an already-seeded state dir is never touched, and a
+    # failed/unavailable seed only WARNs — the probe then fails honestly on its own.
+    AUDIT_STATE_DIR="${WORLDOS_STATE_DIR:-${CLAWDND_STATE_DIR:-}}"
+    if [ -n "$AUDIT_STATE_DIR" ]; then
+      if ls "$AUDIT_STATE_DIR"/campaigns/*/snapshot.json >/dev/null 2>&1; then
+        pass "ui-gate seed: state dir already has >=1 campaign ($AUDIT_STATE_DIR)"
+      elif ! command -v uv >/dev/null 2>&1; then
+        warn "ui-gate seed: uv not on PATH — cannot seed empty state dir $AUDIT_STATE_DIR; play_reachable will fail honestly"
+      else
+        SEED_LOG=/tmp/ow-ui-gate-seed.log
+        if WORLDOS_STATE_DIR="$AUDIT_STATE_DIR" CLAWDND_STATE_DIR="$AUDIT_STATE_DIR" \
+           uv run --directory servers/engine python - >"$SEED_LOG" 2>&1 <<'PY'
+import server
+result = server.start_world("baldurs-gate")
+cid = result.get("campaign_id") if isinstance(result, dict) else None
+if not cid and isinstance(result, dict):
+    cid = result.get("id") or (result.get("campaign") or {}).get("id")
+print("seeded campaign:", cid or result)
+PY
+        then
+          pass "ui-gate seed: minimal resumable campaign seeded into $AUDIT_STATE_DIR"
+        else
+          warn "ui-gate seed: server.start_world failed (see $SEED_LOG) — play_reachable will fail honestly against the empty state"
+        fi
+      fi
+    else
+      warn "ui-gate seed: WORLDOS_STATE_DIR/CLAWDND_STATE_DIR not set — cannot verify/seed the viewer's state dir; play_reachable needs a resumable campaign"
+    fi
     # Per-screen placeholder ceilings (Loop-9 baseline + 2 slack) — kept inline
     # in the python report block below (macOS ships bash 3.2 which has no
     # associative arrays; rather than gate the script on bash 4, we let python

--- a/qa/vm/sweep_v2.sh
+++ b/qa/vm/sweep_v2.sh
@@ -51,6 +51,35 @@ for p in $(seq 8810 8830) 8884 8885; do lsof -ti:$p 2>/dev/null | xargs kill -9 
 sleep 4
 note "start build=$SHA (parallel mode, lean ON — production-matching, fast Opus beats)"
 
+# 0.5) SUPPORT-VM PREFLIGHT (#730) — run BEFORE any persona spend so a blocked host is
+# recorded up front, and so the split VM+Mac RRI rollup can prove same-SHA heavy-lane
+# readiness (release_readiness.py requires --support-preflight-json whenever VM persona
+# evidence relies on --handoff-json for the Mac native proof). The CLI writes
+# support_vm_preflight.json into --artifact-dir; we copy it to the stable rollup path.
+# --no-fail: a blocked preflight is RECORDED, not fatal — the sweep continues and the
+# rollup surfaces the gap honestly (verdict/ready_for_rri carry the blockers).
+# On this VM the private art IS rsynced into the repo at content/worlds/_private,
+# so --private-art-mode required with --art-root at the repo root is correct.
+note "support-VM preflight (artifact-first; failure tolerated + surfaced in the rollup)..."
+rm -f "$RES/support_preflight.json" 2>/dev/null
+mkdir -p "$RES/preflight"
+timeout 300 python3 qa/support_vm_preflight.py \
+  --repo "$PWD" \
+  --expected-sha "$SHA" \
+  --artifact-dir "$RES/preflight" \
+  --artifact-return-target "$RES" \
+  --art-root "$PWD" \
+  --private-art-mode required \
+  --no-fail \
+  > "$RES/preflight.log" 2>&1
+note "preflight rc=$? (rc is informational under --no-fail; see preflight.log)"
+if [ -f "$RES/preflight/support_vm_preflight.json" ]; then
+  cp "$RES/preflight/support_vm_preflight.json" "$RES/support_preflight.json"
+  note "preflight artifact -> $RES/support_preflight.json (ready_for_rri=$(python3 -c "import json;print(json.load(open('$RES/support_preflight.json')).get('ready_for_rri'))" 2>/dev/null))"
+else
+  note "preflight did NOT write support_vm_preflight.json — continuing; the RRI rollup will surface the support_preflight evidence gap honestly"
+fi
+
 run_persona(){  # $1=persona $2=port  -> writes results/score-$1.json
   local persona="$1" port="$2"
   # #735: wipe THIS persona's reused play-state stores (the solo run + the Part-B `-b` store)
@@ -109,7 +138,10 @@ DCOMB="qa/transcripts/vm2-duo.combined.jsonl"; DSTATE="qa/transcripts/vm2-duo.st
 aport=8861; lsof -ti:$aport 2>/dev/null | xargs kill -9 2>/dev/null
 ( WORLDOS_STATE_DIR=/root/worldos-qa/auditstate python3 viewer/server.py '' $aport >/dev/null 2>&1 & echo $! >"$RES/av.pid" )
 sleep 6
-timeout 600 bash qa/ui_audit_health.sh --port $aport --quick --axe --ui-gate > "$RES/ui_audit.log" 2>&1
+# WORLDOS_STATE_DIR on the audit call too: ui_audit_health.sh's --ui-gate seed step needs the
+# SAME state dir the audit viewer serves, so an empty auditstate gets one resumable campaign
+# (play_reachable can never pass against an empty launcher).
+WORLDOS_STATE_DIR=/root/worldos-qa/auditstate timeout 600 bash qa/ui_audit_health.sh --port $aport --quick --axe --ui-gate > "$RES/ui_audit.log" 2>&1
 note "ui_audit rc=$?"; [ -f "$RES/av.pid" ] && kill "$(cat "$RES/av.pid")" 2>/dev/null
 
 # 4) RRI
@@ -121,6 +153,7 @@ python3 qa/release_readiness.py \
   --behavioral $behav --behavioral-path "$RES/duo.log" \
   --ui-audit $audit --ui-audit-log "$RES/ui_audit.log" \
   --palette-live true --palette-source "$RES/ui_audit.log" \
+  --support-preflight-json "$RES/support_preflight.json" \
   --build-sha "$SHA" \
   --out "$RES/RRI.json" --scorecard-row > "$RES/rri.txt" 2>&1
 note "=== RRI ==="; cat "$RES/rri.txt" | tee -a "$LOG"


### PR DESCRIPTION
Pre-rc3 QA-harness batch: three audit-verified measurement gaps that made RRI 10/10 structurally unreachable or miscalibrated. All changes are additive with honest-gate semantics — no gate can pass without real evidence, and every degraded path reports its gap instead of silently passing.

## 1. `image_render` gets a Mac-evidence path (was release-blocking by construction)

`qa/release_readiness.py`'s `image_render` gate read ONLY per-run VM artifacts (`network.ndjson` image rates), but the VM cannot serve gitignored `_private` art — so the split VM+Mac lane could never reach 10/10. The "Mac handoff is authoritative for images" policy existed only in prose.

The gate now selects its source honestly, recorded as `signals.image_render_source`:

| source | when | gate semantics |
|---|---|---|
| `vm-network` | ANY per-run `/image` denominator > 0 | the REAL rate is computed and authoritative — a handoff can never paper over recorded 404s (precedence test included) |
| `mac-handoff` | no VM denominator AND a valid `--handoff-json` at the same `--build-sha` whose app-status snapshots prove `health.image_probe_ok:true` and whose manifests prove `art.private_root_present:true` across ALL of `web_scripted_smoke` / `built_app_scripted_smoke` / `built_app_codex_playtest` | gate passes; detail string states explicitly this is a **representative built-app probe, NOT a render rate** |
| `none` | neither | hard fail with the evidence gap, exactly as before — a VM-only sweep without a handoff still reports the gap |

**What the handoff actually proves about images (honest framing):** `image_probe_ok` (viewer/server.py `_app_status_image_probe`) proves the built app resolved a real art descriptor for the live scene's `imageScope` — i.e. the art pipeline serves a representative image on the Mac. It is weaker than a per-request render rate; the gate detail and the module docstring say so explicitly.

Handoff image evidence is a SEPARATE, stricter signal than handoff validity: `native_gate` may still ride a probe-less handoff (unchanged), but `image_render` may not. In `mac-handoff` mode the gate also rides the split-lane `native_gate`/`support_preflight` evidence contracts, so it cannot pass off a handoff whose split rollup is unproven.

## 2. support-preflight wired into the VM sweep (#730)

`qa/vm/sweep_v2.sh` never produced the support-preflight artifact, so split VM+Mac rollups permanently carried the `support_preflight` evidence gap. Now, BEFORE any persona spend (canary included):

- runs `python3 qa/support_vm_preflight.py --repo "$PWD" --expected-sha "$SHA" --artifact-dir "$RES/preflight" --art-root "$PWD" --private-art-mode required --no-fail` (the CLI has `--artifact-dir`, not `--out`; on the VM the private art IS present in-repo, so `required` is correct)
- copies the artifact to the stable rollup path `$RES/support_preflight.json`
- appends `--support-preflight-json "$RES/support_preflight.json"` to the `release_readiness.py` rollup call

Failure is tolerated gracefully (`--no-fail` + artifact-presence check + note lines): a blocked or crashed preflight is recorded and the sweep continues; the rollup surfaces the gap honestly. bash-3.2-clean (no arrays/associative arrays added).

## 3. `ui_audit_health.sh` calibration

- **(a) axe hard-fail:** `--axe` with a missing `npx`, undetectable Chrome, or missing browser-driver-manager is now a HARD FAIL that prints the exact install command (`npx --yes browser-driver-manager install chrome=<ver>`) — rc1's "FAIL(axe)" was misattributed because axe never actually ran and the script silently warn-skipped. The path without `--axe` is unchanged.
- **(b) play_reachable seed:** the launcher Resume/Continue CTA only renders when a resumable campaign exists in the viewer's CURRENT state dir (`canResume` ⇐ `root_is_current`), so the probe could NEVER pass against the empty auditstate. `--ui-gate` now seeds ONE minimal resumable campaign via `server.start_world("baldurs-gate")` (`uv run --directory servers/engine`) into `WORLDOS_STATE_DIR`/`CLAWDND_STATE_DIR` when the state dir has no campaign. Guarded: an already-seeded state is never touched; a missing env var or failed seed only WARNs and the probe fails honestly. `sweep_v2.sh` now passes `WORLDOS_STATE_DIR=/root/worldos-qa/auditstate` to the audit call so the seed targets the same dir the audit viewer serves.

**Empirical verification of the seed path** (not just static): `start_world` into a temp state dir mints `campaigns/<cid>/snapshot.json`; a live viewer booted on that dir reports the campaign with `canResume:true` via `/openworlds/campaigns.json`, including when seeded AFTER viewer boot (the catalog cache re-keys on snapshot mtime).

## Tests (red-first)

New in `qa/test_release_readiness.py` (all 4 failed before the implementation, KeyError/assert; pass after):
- `test_image_render_accepts_same_sha_mac_handoff_when_vm_has_no_denominator` — release_ready, `source=mac-handoff`, per-persona VM gap still visible in signals
- `test_image_render_handoff_without_image_probe_keeps_evidence_gap` — probe-less handoff: `native_gate` PASS but `image_render` FAILS with the gap
- `test_vm_image_denominators_take_precedence_over_mac_handoff` — recorded 404s compute rate 0.0 and fail despite a probe-proving handoff
- `+ image_render_source` assertions on the existing no-denominator and split-VM tests

New in `qa/test_release_gate_static.py` (all 3 failed red first):
- `test_sweep_v2_runs_support_preflight_before_personas_and_rolls_it_up`
- `test_ui_audit_health_axe_missing_driver_is_hard_fail`
- `test_ui_audit_health_seeds_resumable_campaign_for_play_reachable`

## Verification

- `uv run --directory servers/engine python -m pytest ../../qa/test_release_readiness.py ../../qa/test_release_gate_static.py -q -p no:xdist` → **46 passed** (33 + 13)
- full qa-release-gate CI lane locally (incl. `test_release_readiness_scope`, `test_scores_db*`) → 41 passed
- `bash -n qa/ui_audit_health.sh qa/vm/sweep_v2.sh` → clean
- `bash qa/fast_gate.sh` → PASS (188 engine tests)

## Constraints honored

Additive only. Untouched: `viewer/`, `servers/engine/{recap,ledger,server}.py`, `qa/lib_beat_driver.sh`, `qa/dm_narration_fallback.py`, scores_db/scoring_config.

## Known operational consequence (intentional)

The VM sweep invokes `--axe`; on a host without browser-driver-manager the ui_audit gate will now FAIL loudly with the install command instead of silently "passing" without axe. That is the calibration working as designed — install the driver on the VM (or drop `--axe` there deliberately) before the next sweep.

Refs #730. DO NOT MERGE before adversarial review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added contract tests for release gate validation workflows, including support preflight execution and UI audit health checks
  * Extended test harness for multi-environment image rendering scenarios across VM and Mac platforms

* **Chores**
  * Strengthened error detection by making missing QA tool prerequisites hard-fail rather than skip
  * Enhanced release readiness validation with improved image rendering source selection
  * Implemented campaign state pre-seeding to improve UI audit probe reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->