### PR TITLE
qa(vm): drop --axe from the VM ui_audit lane (Mac-pathed detection; honest-gate)

### DIFF
--- a/qa/vm/sweep_v2.sh
+++ b/qa/vm/sweep_v2.sh
@@ -141,7 +141,12 @@ sleep 6
 # WORLDOS_STATE_DIR on the audit call too: ui_audit_health.sh's --ui-gate seed step needs the
 # SAME state dir the audit viewer serves, so an empty auditstate gets one resumable campaign
 # (play_reachable can never pass against an empty launcher).
-WORLDOS_STATE_DIR=/root/worldos-qa/auditstate timeout 600 bash qa/ui_audit_health.sh --port $aport --quick --axe --ui-gate > "$RES/ui_audit.log" 2>&1
+# NO --axe on the VM lane (deliberate): the axe driver detection is Mac-pathed (mac_arm-*
+# chromedriver dirs + /Applications Chrome) and would HARD-FAIL here by the honest-gate
+# calibration — historically it silently WARN-skipped, so axe NEVER actually ran on the VM
+# and rc1's "FAIL(axe)" was a misattribution. axe coverage rides the Mac lane until Linux
+# driver support lands (tracked); the VM ui_audit verdict = the structural + ui-gate checks.
+WORLDOS_STATE_DIR=/root/worldos-qa/auditstate timeout 600 bash qa/ui_audit_health.sh --port $aport --quick --ui-gate > "$RES/ui_audit.log" 2>&1
 note "ui_audit rc=$?"; [ -f "$RES/av.pid" ] && kill "$(cat "$RES/av.pid")" 2>/dev/null
 
 # 4) RRI


### PR DESCRIPTION
Follow-up to #762's calibration: with --axe now a hard fail when the driver can't run, the Linux VM lane (Mac-pathed detection: mac_arm-* dirs, /Applications Chrome) would fail every sweep on an unrunnable check. Drop --axe on the VM (it never actually ran there — the silent skip was rc1's 'FAIL(axe)' misattribution); the VM verdict = structural + seeded ui-gate checks; axe rides the Mac lane until Linux driver support lands. Static lane 13/13, bash -n clean.