### PR TITLE
fix(wrappers): v1.0.4 beat-reliability set — deadlines, timeout shim, cold-open guards, party heartbeat + soft-tick (audit F12-1/3/4/5/8)

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -474,21 +474,27 @@ clawdnd_dm_effort_arg() {
 # for the SAME reason the effort tier splits them (clawdnd_dm_effort_arg, keyed off `first`):
 #   • the COLD OPEN (first != 0) is the one-time, --effort max, full world-build — generate the
 #     world, scene, PC, opening NPCs + portraits. That MAX-EFFORT cold open routinely runs ~280–400s;
-#     the routine 200s deadline KILLS it mid-build (the masked "cold-open reproducibly broken" mode),
+#     the routine deadline KILLS it mid-build (the masked "cold-open reproducibly broken" mode),
 #     so the cold open gets a generous deadline: WORLDOS_COLDOPEN_TIMEOUT (default 400s).
 #   • CONTINUING / routine beats (first = 0) are --effort medium and resolve one move against
-#     established canon — fast — so they keep the existing per-beat deadline CLAWDND_BEAT_TIMEOUT
-#     (default 200s), unchanged. (Routine behavior is byte-identical to today.)
+#     established canon — faster — so they get the per-beat deadline CLAWDND_BEAT_TIMEOUT
+#     (default 360s — see the F12-1 note below).
 # Keyed off the SAME `first` signal as the effort + lean levers, so cold-open=full+max+400s and the
-# long tail=lean+medium+200s stay in lock-step. Applies ONLY to the DM turn (player/companion turns
+# long tail=lean+medium+360s stay in lock-step. Applies ONLY to the DM turn (player/companion turns
 # are never wrapped in a per-beat timeout at all).
 #
 # Both knobs resolve through the same WORLDOS_/CLAWDND_ fallback as everything else (worldos_env):
 #   WORLDOS_COLDOPEN_TIMEOUT (default 400) — the cold open's deadline, in seconds.
-#   CLAWDND_BEAT_TIMEOUT     (default 200) — every continuing beat's deadline (today's knob, kept).
+#   CLAWDND_BEAT_TIMEOUT     (default 360) — every continuing beat's deadline (today's knob, kept).
 # Note: CLAWDND_BEAT_TIMEOUT keeps its CLAWDND_ name (it predates the WorldOS rename and is the
 # documented routine knob); only the NEW cold-open knob takes the WORLDOS_ name. worldos_env still
 # honors a WORLDOS_BEAT_TIMEOUT override of the routine tier for forward-compat.
+#
+# F12-1 (audit 2026-06-11): the routine default was a flat 200s, which killed ~18% of HEALTHY
+# routine beats (measured on 206 run_duo beats, same opus/medium defaults: p50=152 p90=224
+# p95=264 max=360 — run_duo has no timeout, so its >200s completions are the honest
+# counterfactual for what the product lanes were killing). 360s covers the measured max; an
+# explicit CLAWDND_BEAT_TIMEOUT/WORLDOS_BEAT_TIMEOUT override still wins unchanged.
 #
 # Unlike the effort/lean helpers (which populate an array spliced into argv), this just ECHOES the
 # resolved seconds — the caller uses it as the scalar `timeout <secs>` argument. $1 = first?(1/0)
@@ -501,8 +507,67 @@ clawdnd_dm_timeout() {
     case "${CLAWDND_DM_MODEL:-}" in *opus*) _co_timeout=500 ;; esac
     worldos_env COLDOPEN_TIMEOUT "$_co_timeout"
   else
-    worldos_env BEAT_TIMEOUT 200
+    worldos_env BEAT_TIMEOUT 360
   fi
+}
+
+# RETRY DEADLINE (F12-1's second half): both dm_turn paths captured `beat_timeout` ONCE and the
+# ONE retry re-invoked with the SAME deadline verbatim — so a healthy-but-long beat that tripped
+# the routine deadline was killed AGAIN at the same mark (two kills, zero narration). Attempt 2
+# ESCALATES to the model-aware COLD-OPEN tier (clawdnd_dm_timeout 1 — opus 500 / default 400,
+# env-overridable via WORLDOS_COLDOPEN_TIMEOUT like everything else), and never DE-escalates: if
+# the caller's attempt-1 deadline was already larger (an explicit CLAWDND_BEAT_TIMEOUT override,
+# or a cold-open retry whose tier == the escalation tier), the larger value is kept. A
+# non-numeric base (an env typo) is treated as 0 → the escalation tier (3.2-clean: no arrays,
+# pure case/test). ECHOES the resolved seconds. $1 = attempt 1's deadline in seconds.
+clawdnd_dm_retry_timeout() {
+  local base="${1:-0}" esc
+  case "$base" in ''|*[!0-9]*) base=0 ;; esac
+  esc="$(clawdnd_dm_timeout 1)"
+  if [ "$base" -gt "$esc" ]; then
+    printf '%s' "$base"
+  else
+    printf '%s' "$esc"
+  fi
+}
+
+# BOUNDED-COMMAND SHIM (F12-8): `timeout(1)` is a GNU coreutils binary that does NOT exist on
+# stock macOS (/usr/bin/timeout is absent on Darwin; only Homebrew coreutils provides one) — so
+# every `timeout <secs> claude …` beat on a non-coreutils Mac died rc=127 ("command not found")
+# in under a second, the retry died the same way, and the empty narration was masked. This shim
+# is the ONE bounded-invocation front door for the harnesses: it uses timeout(1) when present
+# (cheapest — no extra interpreter per beat), else falls back to a python3 subprocess that
+# preserves the exact rc semantics callers branch on:
+#   rc=124 — the deadline killed the command (timeout(1)'s contract; the retry triggers on it),
+#   rc=127 / rc=126 — command not found / not executable,
+#   any other rc — the child's own exit code, passed through verbatim.
+# stdout/stderr/stdin of the child pass through untouched (python3 -c keeps stdin free — the
+# callers redirect stdout per-attempt). Fallback kill is SIGKILL (subprocess.run's TimeoutExpired
+# path) vs timeout(1)'s SIGTERM — acceptable here: the wrapped beat is by definition wedged, and
+# every caller treats 124 as "dead, retry". Bash 3.2-clean: no arrays, "$@" pass-through only.
+# $1 = seconds, $2.. = the command. NOTE: callers should prefer this over bare `timeout` for any
+# new bounded call (F12-9/11/12 land on this same shim).
+worldos_timeout() {
+  local _secs="$1"; shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$_secs" "$@"
+    return $?
+  fi
+  python3 -c '
+import subprocess, sys
+secs = float(sys.argv[1])
+cmd = sys.argv[2:]
+try:
+    sys.exit(subprocess.run(cmd, timeout=secs).returncode)
+except subprocess.TimeoutExpired:
+    sys.exit(124)
+except FileNotFoundError:
+    sys.exit(127)
+except PermissionError:
+    sys.exit(126)
+except KeyboardInterrupt:
+    sys.exit(130)
+' "$_secs" "$@"
 }
 
 # RE-MINT SESSION ON RETRY (the ONE shared implementation of "never reuse a CONSUMED session id").
@@ -620,6 +685,38 @@ combat = s.get("combat") or {}
 combat_active = 1 if isinstance(combat, dict) and combat.get("active") else 0
 print("\t".join([str(day), tod, str(visited), str(npcs_met), str(cur),
                  str(cur_visited), str(combat_active)]))
+PY
+}
+
+# SEATING GUARD (F12-3): is a PLAYER PC seated in this campaign's party? The cold open's seating
+# is DM-STOCHASTIC (a forensic .app run built the world but ended its cold-open turn WITHOUT ever
+# calling create_character(kind="player") — party=[] and an unplayable "no_actor" surface), so
+# BOTH product opener paths guard it: check, ONE reseat retry, then a LOUD abort. Factored here —
+# the audit's recurring fix shape is "extract the shared helper, stop patching one path"
+# (play_party.sh carried this guard locally; play.sh had nothing). Matches the viewer's
+# _action_actor contract exactly: seated == a party member whose character record is
+# kind="player". SNAPSHOT-READ-ONLY (never writes; engine stays the sole writer). A missing
+# snapshot or a blank campaign id (the dead-cold-open mode: CAMPAIGN_ID="") is NOT seated.
+# $1 = STATE_DIR  $2 = campaign_id ; returns 0 = seated, 1 = not seated.
+clawdnd_pc_seated() {
+  local state_dir="$1" campaign_id="${2:-}"
+  [ -n "${campaign_id//[[:space:]]/}" ] || return 1
+  local snap="$state_dir/campaigns/$campaign_id/snapshot.json"
+  [ -f "$snap" ] || return 1   # no snapshot at all -> definitely not seated
+  python3 - "$snap" <<'PY'
+import json, sys
+try:
+    snap = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(1)
+chars = snap.get("characters") if isinstance(snap.get("characters"), dict) else {}
+party = snap.get("party") if isinstance(snap.get("party"), list) else []
+# Match the viewer's _action_actor: a party member whose record is kind="player".
+seated = any(
+    isinstance(chars.get(cid), dict) and chars.get(cid, {}).get("kind") == "player"
+    for cid in party if isinstance(cid, str)
+)
+sys.exit(0 if seated else 1)
 PY
 }
 

--- a/scripts/launch_common.sh
+++ b/scripts/launch_common.sh
@@ -37,6 +37,20 @@ clawdnd_missing_commands() {
   fi
 }
 
+# F12-8 (#787): `timeout(1)` is a GNU coreutils binary ABSENT on stock macOS — and the DM beat
+# wrappers used to invoke it bare, so on a non-coreutils Mac every beat died rc=127 in <1s,
+# silently. The play lanes now bound every DM call through worldos_timeout (qa/lib_beat_driver.sh),
+# which falls back to a python3 subprocess with the same rc=124 deadline semantics — so the binary
+# is no longer a HARD requirement and this check WARNS instead of failing the launch closed (a
+# fail would refuse a host the shim fully serves). The native tool is still preferred (no extra
+# interpreter per beat), hence the brew hint. Always returns 0.
+clawdnd_warn_if_no_timeout() {
+  command -v timeout >/dev/null 2>&1 && return 0
+  echo "[worldos] note: GNU timeout(1) not found — DM beat deadlines will use the built-in python3 fallback." >&2
+  echo "[worldos]       For the native tool: brew install coreutils" >&2
+  return 0
+}
+
 clawdnd_port_available() {
   local port="$1"
   case "$port" in

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -32,6 +32,12 @@ fi
 if declare -F clawdnd_missing_commands >/dev/null 2>&1; then
   clawdnd_missing_commands python3 claude uv jq curl || exit 127
 fi
+# F12-8 (#787): timeout(1) is a coreutils binary stock macOS lacks. The DM beats are bounded via
+# the worldos_timeout shim (python3 fallback), so absence is non-fatal — but warn with the brew
+# hint so the native tool gets installed.
+if declare -F clawdnd_warn_if_no_timeout >/dev/null 2>&1; then
+  clawdnd_warn_if_no_timeout
+fi
 # Shared beat-driver helpers: the C soft clock-tick backstop + the A beat-aware runbooks —
 # the SAME implementation the QA duo loop sources, so the human-paced and QA loops can't drift.
 # shellcheck source=../qa/lib_beat_driver.sh
@@ -78,10 +84,13 @@ CLAWDND_LEAN_BEATS="${CLAWDND_LEAN_BEATS:-1}"
 # the session. The deadline is TIERED off the cold-open `first` signal (clawdnd_dm_timeout in
 # qa/lib_beat_driver.sh, the sibling of the effort tier): the cold open's --effort max world-build
 # runs ~280–400s so it gets WORLDOS_COLDOPEN_TIMEOUT (default 400s); continuing/routine beats keep
-# CLAWDND_BEAT_TIMEOUT (default 200s, unchanged). Both knobs are read inside dm_turn via the helper;
-# this line documents the routine default. Applies in BOTH lean/legacy modes (it only wraps the
-# existing claude -p call) and ONLY to the DM turn.
-CLAWDND_BEAT_TIMEOUT="${CLAWDND_BEAT_TIMEOUT:-200}"
+# CLAWDND_BEAT_TIMEOUT (default 360s — F12-1: the old flat 200s killed ~18% of HEALTHY routine
+# beats, measured routine max=360s). The ONE retry ESCALATES its deadline to the cold-open tier
+# via clawdnd_dm_retry_timeout (attempt 2 never reuses attempt 1's deadline verbatim). Both knobs
+# are read inside dm_turn via the helper; this line documents (and seeds) the routine default.
+# Applies in BOTH lean/legacy modes (it only wraps the existing claude -p call) and ONLY to the
+# DM turn.
+CLAWDND_BEAT_TIMEOUT="${CLAWDND_BEAT_TIMEOUT:-360}"
 # Recent player-facing narration tail the lean re-ground asks scene_context for (generous by
 # default so continuity survives the lean boundary — named NPCs, prior choices, the scene).
 CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
@@ -243,8 +252,9 @@ fi
 # caller's #357 fallback recovers any prose the DM streamed live. The deadline is TIERED off the
 # SAME `first` cold-open signal as the effort tier (clawdnd_dm_timeout, qa/lib_beat_driver.sh): the
 # cold open (first=1) is the --effort max world-build that runs ~280–400s, so it gets a generous
-# WORLDOS_COLDOPEN_TIMEOUT (default 400s) instead of the 200s that was KILLING it; continuing beats
-# keep CLAWDND_BEAT_TIMEOUT (default 200s). Echoes the DM's final text.
+# WORLDOS_COLDOPEN_TIMEOUT (default 400s) instead of the routine deadline that was KILLING it;
+# continuing beats keep CLAWDND_BEAT_TIMEOUT (default 360s — F12-1). The ONE retry escalates its
+# deadline via clawdnd_dm_retry_timeout. Echoes the DM's final text.
 dm_turn() {
   local first="$1" msg="$2" campaign_id="${3:-}" out resume=() extra=() rc beat_timeout
   # #623: prepend the live-progress rule (the ONE shared CLAWDND_LIVE_PROGRESS_RULE in
@@ -274,11 +284,14 @@ dm_turn() {
   clawdnd_dm_effort_arg "$first"
   # TIMEOUT TIER (shared helper, qa/lib_beat_driver.sh): the cold open's max-effort world-build runs
   # ~280–400s, so it gets WORLDOS_COLDOPEN_TIMEOUT (default 400s); continuing beats keep
-  # CLAWDND_BEAT_TIMEOUT (default 200s). Keyed off the SAME `first` signal as the effort tier above.
+  # CLAWDND_BEAT_TIMEOUT (default 360s). Keyed off the SAME `first` signal as the effort tier above.
   beat_timeout="$(clawdnd_dm_timeout "$first")"
   out="$DM_LOG.$(date +%s%N).jsonl"
+  # F12-8: worldos_timeout (qa/lib_beat_driver.sh) — timeout(1) when present, else a python3
+  # fallback with the same rc=124 semantics. A bare `timeout` died rc=127 on stock (non-coreutils)
+  # Macs, killing every beat in <1s with the failure masked.
   _dm_invoke() {
-    timeout "$beat_timeout" \
+    worldos_timeout "$beat_timeout" \
       claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
         --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
         --output-format stream-json --verbose > "$out" 2>> "$DM_LOG.err"
@@ -293,7 +306,11 @@ dm_turn() {
     # in use." → 0-byte → empty narration. A lean beat re-mints via clawdnd_dm_lean_args; the
     # cold-open / legacy --resume path re-mints via clawdnd_dm_remint_session_on_retry. (The
     # re-ground directive $extra is unchanged — we only refresh the session id.)
-    echo "[play] DM turn rc=$rc (timeout=${beat_timeout}s) — retrying once with a fresh session" >&2
+    # F12-1: the retry must NOT reuse attempt 1's deadline verbatim — a healthy-but-long beat that
+    # tripped the routine deadline would just be killed again at the same mark. Escalate attempt 2
+    # to the model-aware cold-open tier (never de-escalating below attempt 1's).
+    beat_timeout="$(clawdnd_dm_retry_timeout "$beat_timeout")"
+    echo "[play] DM turn rc=$rc — retrying once with a fresh session (deadline escalated to ${beat_timeout}s)" >&2
     clawdnd_dm_lean_args "$first" "$campaign_id" "$CLAWDND_LEAN_TAIL"
     if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
       resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
@@ -413,6 +430,13 @@ fi
 # #357: same empty-reply fallback as the beat loop — recover the engine's logged opening
 # narration if the DM's first turn ended on a tool call rather than prose.
 clawdnd_resolve_dm_reply "$DMSG" "$STATE_DIR"; DMSG="$CLAWDND_DM_REPLY"
+# F12-3 (#777): a cold open that produced NO opening (both attempts dead — the 401-class double
+# failure proven 2026-06-02) must ABORT NON-ZERO here, BEFORE the move loop. Recording the blank
+# unconditionally left an unflagged EMPTY chat row and an indefinitely-"running" session in which
+# every beat resumed a nonexistent DM session and masked — under a live viewer serving the empty
+# state. A non-zero exit surfaces through the native bridge instead. (play_party.sh has carried
+# this same abort since its ensemble landed; this is the play.sh port.)
+[ -z "$DMSG" ] && { echo "[play] DM produced no opening — aborting (see $COMBINED)" >&2; exit 1; }
 
 # Resolve the campaign id the DM just minted, BEFORE writing the opening to the chronicle —
 # record_dm_reply (#720) needs it to log the opening narration to the engine session log so the
@@ -441,6 +465,42 @@ if [ "$CLAWDND_LEAN_BEATS" = "1" ]; then
   else
     echo "[play] lean-beats ON but campaign id not found under $STATE_DIR/campaigns — beats use the normal resume path" >&2
   fi
+fi
+
+# --- F12-3 (#777): the cold open MUST leave a PLAYABLE session ----------------------------------
+# (a) NO CAMPAIGN: a cold open that minted no campaign at all is unplayable — the heartbeat, lean
+# re-ground, and record_dm_reply all no-op on an empty id, and every beat would fail and mask.
+# Abort loudly instead of reporting "running" forever.
+if [ -z "$CAMPAIGN_ID" ]; then
+  echo "[play] COLD OPEN MINTED NO CAMPAIGN under $STATE_DIR/campaigns — aborting rather than leave a 'running' unplayable session (see $COMBINED)." >&2
+  exit 1
+fi
+# (b) SEATING GUARD: the DM creates/selects the PC live in the cold-open turn, which is
+# DM-STOCHASTIC — a forensic .app run built the world but ended the turn with party=[] (the
+# viewer's "no_actor" unplayable surface). Guard it the same way the DM turn itself is guarded
+# (the pattern play_party.sh proved; the check is the SHARED clawdnd_pc_seated in
+# qa/lib_beat_driver.sh — snapshot-read-only, the viewer's _action_actor contract): one reseat
+# retry on a FRESH session id (the consumed cold-open --session-id would collide), then a loud
+# non-zero abort. Covers BOTH opener paths — the authored-hero and DM-invents openers converge
+# here (the hero path pre-seeds the PC, so it normally passes on the first check).
+if ! clawdnd_pc_seated "$STATE_DIR" "$CAMPAIGN_ID"; then
+  echo "[play] cold open seated NO player PC (party has no kind=\"player\" member) — retrying the cold open ONCE on a fresh session…" >&2
+  DSID="$(uuidgen 2>/dev/null || python3 -c 'import uuid;print(uuid.uuid4())')"
+  RESEAT_DMSG="$(dm_turn 1 "Your previous cold-open turn for campaign $CAMPAIGN_ID did NOT seat the player's character — the party still has no kind=\"player\" member, so the game is UNPLAYABLE. Fix this NOW, before anything else.
+
+- use campaign_id=$CAMPAIGN_ID for EVERY engine call. DO NOT call start_world — it would mint a NEW campaign id and ORPHAN this save.
+- SEAT THE PLAYER CHARACTER by SELECTING a real canon NPC — NEVER invent a custom character: list_canon_characters(playable_only=true), pick a fitting MID-TIER canon figure with an ingested portrait + real backstory, then load_canon_character(that name, kind=\"player\", add_to_party=true). The party MUST contain the player's kind=\"player\" PC when this turn ends.
+- This is a SOLO session: seat ONLY the player — do NOT recruit companions.
+- Then CLOSE the turn by writing the opening SCENE as 2nd-person player-facing prose addressed to \"you\" (where the player IS, what they see/hear/smell, who is present + a real quoted line), ending on a clear open moment + choice. NEVER end on a tool call or a 3rd-person setup brief." "$CAMPAIGN_ID")"
+  clawdnd_resolve_dm_reply "$RESEAT_DMSG" "$STATE_DIR"; RESEAT_DMSG="$CLAWDND_DM_REPLY"
+  DM_TURNS=$((DM_TURNS + 1))   # the reseat turn counts toward the cap (parity with play_party)
+  # #720: the reseat turn re-writes the opening scene — route it through record_dm_reply too.
+  if [ -n "$RESEAT_DMSG" ]; then DMSG="$RESEAT_DMSG"; record_dm_reply "$CAMPAIGN_ID" "$DMSG" reseat; echo "[play] reseat turn opened: ${DMSG:0:120}…"; fi
+  if ! clawdnd_pc_seated "$STATE_DIR" "$CAMPAIGN_ID"; then
+    echo "[play] COLD-OPEN SEATED NO PC: after a retry the party still has no kind=\"player\" member — aborting rather than hand the player a no_actor session (see $COMBINED)." >&2
+    exit 1
+  fi
+  echo "[play] reseat OK — a player PC is now seated in the party."
 fi
 
 # Stop the (otherwise human-paced, unbounded) loop once the session hits its cost or turn

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -62,6 +62,12 @@ fi
 if declare -F clawdnd_missing_commands >/dev/null 2>&1; then
   clawdnd_missing_commands python3 claude uv jq curl || exit 127
 fi
+# F12-8 (#787): timeout(1) is a coreutils binary stock macOS lacks. The DM beats are bounded via
+# the worldos_timeout shim (python3 fallback), so absence is non-fatal — but warn with the brew
+# hint so the native tool gets installed.
+if declare -F clawdnd_warn_if_no_timeout >/dev/null 2>&1; then
+  clawdnd_warn_if_no_timeout
+fi
 WORLD="${1:-baldurs-gate}"
 RUN="${2:-play-$(date +%Y%m%d-%H%M%S)}"
 PORT="${3:-${CLAWDND_PLAY_PORT:-8765}}"
@@ -315,7 +321,7 @@ turn() {
     # TIMEOUT TIER (shared helper, qa/lib_beat_driver.sh) — SAME implementation scripts/play.sh's
     # dm_turn uses: the cold open's --effort max world-build runs ~280–400s, so it gets
     # WORLDOS_COLDOPEN_TIMEOUT (default 400s); continuing beats get CLAWDND_BEAT_TIMEOUT (default
-    # 200s). Keyed off the SAME `first` signal as the effort tier above. This wraps the DM turn in
+    # 360s). Keyed off the SAME `first` signal as the effort tier above. This wraps the DM turn in
     # `timeout` (parity with play.sh dm_turn — play_party is the native app's entry point and
     # previously had NO per-beat deadline, so a wedged DM turn could hang the session indefinitely;
     # the one-retry below recovers a transient timeout). DM turn ONLY — the companion facade never
@@ -325,8 +331,11 @@ turn() {
     # DM turn with ONE retry (parity with scripts/play.sh dm_turn — play_party is the native app's
     # entry point and previously had NO DM retry, so a transient cold-open failure was permanent).
     local rc
+    # F12-8: worldos_timeout (qa/lib_beat_driver.sh) — timeout(1) when present, else a python3
+    # fallback with the same rc=124 semantics. A bare `timeout` died rc=127 on stock
+    # (non-coreutils) Macs, killing every beat in <1s with the failure masked.
     _dm_invoke() {
-      timeout "$beat_timeout" \
+      worldos_timeout "$beat_timeout" \
         claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
           --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
           --output-format stream-json --verbose > "$out" 2>> "$DM_LOG.err"
@@ -337,7 +346,10 @@ turn() {
       # consumed --session-id ("Session ID … is already in use."). Lean re-mints itself; the
       # cold-open / --resume path re-mints via the shared helper. ($extra is unchanged.)
       clawdnd_report_attempt_failure "$out" "$rc"
-      echo "[play-party] DM turn rc=$rc (timeout=${beat_timeout}s) — retrying once with a fresh session" >&2
+      # F12-1: the retry must NOT reuse attempt 1's deadline verbatim — escalate attempt 2 to the
+      # model-aware cold-open tier (never de-escalating below attempt 1's), same as play.sh.
+      beat_timeout="$(clawdnd_dm_retry_timeout "$beat_timeout")"
+      echo "[play-party] DM turn rc=$rc — retrying once with a fresh session (deadline escalated to ${beat_timeout}s)" >&2
       clawdnd_dm_lean_args "$first" "${CAMPAIGN_ID:-}" "$CLAWDND_LEAN_TAIL"
       if [ "${#CLAWDND_DM_LEAN_SESSION[@]}" -gt 0 ]; then
         resume=("${CLAWDND_DM_LEAN_SESSION[@]}")
@@ -457,6 +469,14 @@ echo "  Save dir: $STATE_DIR"
 # (the DM must NOT recruit its own — it re-grounds via get_state and finds the party), and
 # (2) the human's moves AND each companion's moves will arrive as tagged declarations.
 COMP_NAME_LIST="$(printf '%s' "$SEED_JSON" | jq -r '[.companions[].name] | join(", ")')"
+# F12-4 (#790, completes #623): the model-INDEPENDENT wrapper heartbeat — the party lane never
+# emitted it (the helper's own doc says it was factored "so every harness shares it"; only play.sh
+# called it). The campaign id is PRE-SEEDED in this lane, so even the cold open can heartbeat —
+# /events gets a row within ~1s and the viewer flips its opening spinner instead of staying blank
+# for the ~280-500s world-build. Post-#763 this is also what flips the viewer's progress state at
+# heartbeat INGEST. Same shared helper play.sh calls (its exact wrapper lines are what app.jsx
+# filters and the #763 fallback recognizes — never a local text bank). first=1 → opening teaser.
+clawdnd_emit_progress_heartbeat "$CAMPAIGN_ID" 1 0
 DMSG="$(turn dm "$DSID" 1 "You are the Dungeon Master for a ClawDnD adventure played by ONE human plus an AI PARTY. Activate and follow your \`dungeon-master\` skill — run its \"Generating a world live\" mode and hold its craft bar (mechanics sourced from the engine, NPCs speak, the world pushes back, scenes played not logged).
 
 Begin a session in a living world for a single human player (who acts through the dashboard) traveling with a party of companions who ALREADY EXIST in the world:
@@ -490,28 +510,11 @@ echo "[play-party] DM opened: ${DMSG:0:120}…"
 # code break. Guard it the same way the DM TURN itself is guarded (one retry, then fail loud):
 # read the snapshot for a seated player actor; if none, retry the cold open ONCE on a FRESH
 # session with a hard seat-only directive; if STILL none, abort with a clear, non-silent error
-# rather than hand the player a no_actor session. Mirrors viewer/server.py `_action_actor`:
-# a seated PC = a party member whose character record is kind="player".
-pc_seated() {  # 0 = a player PC is seated in the party; 1 = none
-  local snap="$CAMP_DIR/snapshot.json"
-  [ -f "$snap" ] || return 1   # no snapshot at all -> definitely not seated
-  python3 - "$snap" <<'PY'
-import json, sys
-try:
-    snap = json.load(open(sys.argv[1]))
-except Exception:
-    sys.exit(1)
-chars = snap.get("characters") if isinstance(snap.get("characters"), dict) else {}
-party = snap.get("party") if isinstance(snap.get("party"), list) else []
-# Match the viewer's _action_actor: a party member whose record is kind="player".
-seated = any(
-    isinstance(chars.get(cid), dict) and chars.get(cid, {}).get("kind") == "player"
-    for cid in party if isinstance(cid, str)
-)
-sys.exit(0 if seated else 1)
-PY
-}
-if ! pc_seated; then
+# rather than hand the player a no_actor session. The check itself is the SHARED
+# clawdnd_pc_seated (qa/lib_beat_driver.sh — F12-3 factored this lane's local copy into the lib
+# so play.sh runs the IDENTICAL guard): snapshot-read-only, mirrors viewer/server.py
+# `_action_actor` — a seated PC = a party member whose character record is kind="player".
+if ! clawdnd_pc_seated "$STATE_DIR" "$CAMPAIGN_ID"; then
   echo "[play-party] cold open seated NO player PC (party has no kind=\"player\" member) — retrying the cold open ONCE on a fresh session…" >&2
   # Fresh session id so the retry's first=1 --session-id can't collide with the consumed $DSID.
   DSID="$(uuidgen 2>/dev/null || python3 -c 'import uuid;print(uuid.uuid4())')"
@@ -524,7 +527,7 @@ if ! pc_seated; then
   AGENT_TURNS=$((AGENT_TURNS + 1))
   # #720: the reseat turn re-writes the opening scene — route it through record_dm_reply too.
   if [ -n "$RESEAT_DMSG" ]; then DMSG="$RESEAT_DMSG"; record_dm_reply "$CAMPAIGN_ID" "$DMSG" reseat; echo "[play-party] reseat turn opened: ${DMSG:0:120}…"; fi
-  if ! pc_seated; then
+  if ! clawdnd_pc_seated "$STATE_DIR" "$CAMPAIGN_ID"; then
     echo "[play-party] COLD-OPEN SEATED NO PC: after a retry the party still has no kind=\"player\" member — aborting rather than hand the player a no_actor session (see $COMBINED)." >&2
     exit 1
   fi
@@ -616,6 +619,17 @@ while true; do
     BEAT_NO=$((BEAT_NO + 1))
     RUNBOOK="$(clawdnd_runbook_for_beat "$BEAT_NO" 8 "$PREV_LOC" "$STATE_DIR")"
     echo "[play-party] beat $BEAT_NO runbook: ${RUNBOOK%% (*}…"
+    # F12-5 (#791): read the clock BEFORE the beat so the soft clock-tick backstop below can tell
+    # whether the DM advanced it this beat (mirrors play.sh's pre-beat PROG_PRE capture).
+    PROG_PRE="$(clawdnd_read_progress "$STATE_DIR")"
+    PREV_DAY="$(printf '%s' "$PROG_PRE" | cut -f1)"; PREV_DAY="${PREV_DAY:-1}"
+    PREV_TOD="$(printf '%s' "$PROG_PRE" | cut -f2)"; PREV_TOD="${PREV_TOD:-morning}"
+    # F12-4 (#790): wrapper heartbeat NOW — after the human's move is read and BEFORE the
+    # companion turns, so the player isn't staring at a dead spinner through companion latency +
+    # the DM's long think (each companion is its own claude -p ahead of the DM turn). Same shared
+    # helper play.sh calls; best-effort + non-fatal; engine stays the sole writer (it routes
+    # through log_engine_narration). 0-based index so the teaser rotation matches play.sh's.
+    clawdnd_emit_progress_heartbeat "$CAMPAIGN_ID" 0 "$((BEAT_NO - 1))"
 
     # Each living companion reacts to the LAST DM narration + (implicitly) the unfolding
     # beat, taking its own move via its facade. Relay ONLY structured moves to the DM.
@@ -651,6 +665,13 @@ Then PLAY the next beat as a full lived scene — NOT a fragment: any NPC (or co
     clawdnd_resolve_dm_reply "$DMSG" "$STATE_DIR"; DMSG="$CLAWDND_DM_REPLY"
     # #720: route the per-beat DM reply through record_dm_reply (engine_logged stamp on success).
     record_dm_reply "$CAMPAIGN_ID" "$DMSG" beat; AGENT_TURNS=$((AGENT_TURNS + 1))
+    # F12-5 (#791) — C soft clock-tick backstop (the SAME shared helper play.sh:504 + both duo
+    # loops call; play_party was the ONLY beat loop without it, so party sessions could freeze at
+    # day-1 morning forever): advance ONE phase via the engine ONLY if the DM left the clock
+    # frozen this beat. The helper defers to a DM-advanced clock, skips during combat (combat
+    # time is rounds, not phases), never fails the loop, and the engine stays the sole writer
+    # (advance_time).
+    clawdnd_soft_tick "$ROOT" "$STATE_DIR" "$PREV_DAY" "$PREV_TOD"
     # Remember this beat's location so the next beat's runbook can detect a stuck party (travel cue).
     PREV_LOC="$(printf '%s' "$(clawdnd_read_progress "$STATE_DIR")" | cut -f5)"
   else

--- a/servers/engine/tests/test_adversarial_release.py
+++ b/servers/engine/tests/test_adversarial_release.py
@@ -191,9 +191,13 @@ def test_coldopen_play_party_guards_player_pc_seating():
     # (1) the prompt mandates seating the PC (kind="player", add_to_party) up front.
     assert 'create_character with kind=\\"player\\" and add_to_party=true' in text
     # (2) a snapshot-backed guard exists and matches the viewer's _action_actor notion of a
-    #     seated PC (a party member whose record is kind="player").
-    assert "pc_seated()" in text
-    assert 'get("kind") == "player"' in text
+    #     seated PC (a party member whose record is kind="player"). F12-3 (#777) factored the
+    #     guard into the SHARED lib (clawdnd_pc_seated) so play.sh runs the identical check —
+    #     the _action_actor-matching python now lives there, called from this lane.
+    assert "clawdnd_pc_seated" in text
+    lib = (_ROOT / "qa" / "lib_beat_driver.sh").read_text(encoding="utf-8")
+    assert "clawdnd_pc_seated()" in lib
+    assert 'get("kind") == "player"' in lib
     # (3) the guard retries the cold open ONCE, then aborts loudly on a still-unseated party.
     assert "retrying the cold open ONCE" in text
     assert "COLD-OPEN SEATED NO PC" in text and "exit 1" in text

--- a/servers/engine/tests/test_wrapper_reliability.py
+++ b/servers/engine/tests/test_wrapper_reliability.py
@@ -1,0 +1,352 @@
+"""v1.0.4 wrapper-reliability set (audit F12-1, F12-3, F12-4, F12-5, F12-8 — issues #777 #787 #790 #791).
+
+The beat-reliability cluster from docs/audits/ENGINE-AUDIT-2026-06-11.md unit 12:
+
+* F12-1 (#753-adjacent): the flat 200s routine-beat deadline killed ~18% of HEALTHY beats
+  (measured routine p90=224s, max=360s), and the ONE retry re-used the SAME deadline verbatim.
+  Fix: routine default 200 -> 360 in ``clawdnd_dm_timeout`` + a ``clawdnd_dm_retry_timeout``
+  escalation (attempt 2 gets the model-aware cold-open tier, never less than attempt 1's).
+* F12-8 (#787): ``timeout(1)`` is a coreutils binary ABSENT on stock macOS — every beat died
+  rc=127 in <1s, masked. Fix: the ``worldos_timeout`` shim (timeout(1) when present, else a
+  python3 subprocess fallback preserving rc=124 deadline semantics) + a non-fatal preflight
+  warning with the brew hint.
+* F12-3 (#777): play.sh's cold open recorded an EMPTY opening unconditionally and entered the
+  move loop anyway (the indefinitely-"running" dead session, 401-class proven 2026-06-02).
+  Fix: the empty-DMSG abort + the ``clawdnd_pc_seated`` seating guard (factored to the lib,
+  REUSED by play_party.sh) with one reseat retry then a loud abort.
+* F12-4 (#790): play_party.sh never emitted the model-independent progress heartbeat #623
+  factored into the lib for it (post-#763 the viewer flips progress at heartbeat INGEST).
+* F12-5 (#791): play_party.sh was the ONLY beat loop without the soft clock-tick backstop.
+
+Pattern follows test_dm_session_remint.py: gateway-free, no live claude/network, the REAL bash
+helpers exercised under /bin/bash (macOS system bash 3.2 — also guards 3.2-cleanliness), plus
+static anti-drift asserts on the wrapper call sites. Discovered + run via servers/engine pytest.
+"""
+
+import json
+import os
+import re
+import stat
+import subprocess
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+LIB = ROOT / "qa" / "lib_beat_driver.sh"
+COMMON = ROOT / "scripts" / "launch_common.sh"
+
+
+def _bash(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["/bin/bash", "-c", script], capture_output=True, text=True, cwd=str(ROOT)
+    )
+
+
+def _src(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+# A lib preamble that neutralizes ambient WORLDOS_/CLAWDND_ knobs so defaults are what we test.
+_CLEAN = (
+    'set -u\n'
+    'unset WORLDOS_BEAT_TIMEOUT CLAWDND_BEAT_TIMEOUT WORLDOS_COLDOPEN_TIMEOUT '
+    'CLAWDND_COLDOPEN_TIMEOUT CLAWDND_DM_MODEL WORLDOS_DM_MODEL 2>/dev/null || true\n'
+    f'. "{LIB}"\n'
+)
+
+
+# ============================== F12-8: the worldos_timeout shim ==============================
+
+def test_worldos_timeout_is_transparent_for_a_fast_command():
+    """rc + stdout of the wrapped command pass through untouched (no deadline hit)."""
+    r = _bash(_CLEAN + 'worldos_timeout 5 /bin/sh -c "echo HELLO; exit 7"; echo "rc=$?"')
+    assert r.returncode == 0, r.stderr
+    assert "HELLO" in r.stdout, (r.stdout, r.stderr)
+    assert "rc=7" in r.stdout, "the child's exit code must pass through verbatim"
+
+
+def test_worldos_timeout_kills_at_the_deadline_with_rc_124():
+    """A wedged command is killed at the deadline and the caller sees timeout(1)'s rc=124."""
+    t0 = time.monotonic()
+    r = _bash(_CLEAN + 'worldos_timeout 1 sleep 30; echo "rc=$?"')
+    wall = time.monotonic() - t0
+    assert r.returncode == 0, r.stderr
+    assert "rc=124" in r.stdout, (r.stdout, r.stderr)
+    assert wall < 15, f"the deadline must actually kill the child (took {wall:.1f}s)"
+
+
+def test_worldos_timeout_works_without_a_timeout_binary(tmp_path):
+    """The F12-8 victim host: NO timeout(1) anywhere on PATH. The shim must still enforce the
+    deadline (rc=124) and stay rc-transparent via the python3 subprocess fallback."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    # a minimal PATH: python3 (for the fallback) + sleep (the test child). No timeout.
+    py = subprocess.run(["/bin/bash", "-lc", "command -v python3"], capture_output=True, text=True).stdout.strip()
+    assert py, "test needs a resolvable python3"
+    os.symlink(py, bindir / "python3")
+    os.symlink("/bin/sleep", bindir / "sleep")
+    script = (
+        _CLEAN
+        + f'PATH="{bindir}"\n'
+        + 'command -v timeout >/dev/null 2>&1 && { echo TIMEOUT_STILL_ON_PATH; exit 1; }\n'
+        + 'worldos_timeout 1 sleep 30; echo "to-rc=$?"\n'
+        + 'worldos_timeout 5 /bin/sh -c "exit 7"; echo "pass-rc=$?"\n'
+        + 'worldos_timeout 5 /nonexistent-cmd-f128; echo "nf-rc=$?"\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, (r.stdout, r.stderr)
+    assert "TIMEOUT_STILL_ON_PATH" not in r.stdout
+    assert "to-rc=124" in r.stdout, ("fallback must preserve rc=124 deadline semantics", r.stdout, r.stderr)
+    assert "pass-rc=7" in r.stdout, ("fallback must pass the child's rc through", r.stdout, r.stderr)
+    assert "nf-rc=127" in r.stdout, ("fallback must preserve rc=127 command-not-found semantics", r.stdout, r.stderr)
+
+
+def test_worldos_timeout_prefers_the_native_binary_when_present(tmp_path):
+    """When timeout(1) IS on PATH the shim must use it (no python interpreter per beat)."""
+    stubdir = tmp_path / "stub"
+    stubdir.mkdir()
+    stub = stubdir / "timeout"
+    stub.write_text('#!/bin/sh\necho NATIVE-TIMEOUT-USED\nshift\nexec "$@"\n')
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+    r = _bash(_CLEAN + f'PATH="{stubdir}:$PATH"\nworldos_timeout 5 /bin/echo hi; echo "rc=$?"')
+    assert r.returncode == 0, r.stderr
+    assert "NATIVE-TIMEOUT-USED" in r.stdout, (r.stdout, r.stderr)
+    assert "hi" in r.stdout and "rc=0" in r.stdout
+
+
+def test_play_lanes_invoke_the_dm_through_the_shim():
+    """Static anti-drift: both product lanes wrap the DM `claude -p` in worldos_timeout — a bare
+    `timeout "$beat_timeout"` (the rc=127 dependency) must NOT remain in either."""
+    for name in ("scripts/play.sh", "scripts/play_party.sh"):
+        src = _src(name)
+        assert 'worldos_timeout "$beat_timeout"' in src, f"{name} must use the worldos_timeout shim"
+        # a BARE invocation = `timeout` as a standalone command word (helpers like worldos_timeout
+        # and clawdnd_dm_retry_timeout end in the same token, hence the word-boundary lookbehind).
+        assert not re.search(r'(?<![\w_])timeout "\$beat_timeout"', src), (
+            f"{name} still invokes the bare coreutils `timeout` (rc=127 on stock macOS)"
+        )
+
+
+def test_preflight_warns_about_missing_timeout_with_a_brew_hint():
+    """launch_common.sh preflight names the coreutils dep (non-fatal: the shim covers absence,
+    so this WARNS with the brew hint instead of failing a launch the shim can serve)."""
+    common = _src("scripts/launch_common.sh")
+    assert "clawdnd_warn_if_no_timeout" in common, "preflight must check for timeout(1)"
+    assert "brew install coreutils" in common, "the warning must carry the brew hint"
+    # both play lanes run the check at startup
+    for name in ("scripts/play.sh", "scripts/play_party.sh"):
+        assert "clawdnd_warn_if_no_timeout" in _src(name), f"{name} must run the timeout preflight"
+    # behavioral: with timeout absent the check WARNS (brew hint on stderr) and returns 0.
+    r = _bash(
+        f'set -u; . "{COMMON}"\n'
+        'PATH="/nonexistent-only"\n'
+        'clawdnd_warn_if_no_timeout; echo "rc=$?"\n'
+    )
+    assert r.returncode == 0, r.stderr
+    assert "rc=0" in r.stdout, "the preflight warning must never fail the launch"
+    assert "brew install coreutils" in r.stderr, (r.stdout, r.stderr)
+
+
+# ====================== F12-1: routine deadline + retry-deadline recompute ======================
+
+def test_routine_beat_timeout_default_is_360():
+    """Measured routine p90=224s / max=360s — the flat 200s default killed ~18% of healthy beats."""
+    r = _bash(_CLEAN + 'echo "bt=$(clawdnd_dm_timeout 0)"')
+    assert r.returncode == 0, r.stderr
+    assert "bt=360" in r.stdout, (r.stdout, r.stderr)
+
+
+def test_routine_beat_timeout_env_override_still_wins():
+    """CLAWDND_BEAT_TIMEOUT keeps its name + precedence (frozen wire contract); WORLDOS_ twin wins."""
+    r = _bash(
+        _CLEAN
+        + 'CLAWDND_BEAT_TIMEOUT=222; echo "c=$(clawdnd_dm_timeout 0)"\n'
+        + 'WORLDOS_BEAT_TIMEOUT=233; echo "w=$(clawdnd_dm_timeout 0)"\n'
+    )
+    assert r.returncode == 0, r.stderr
+    assert "c=222" in r.stdout, r.stdout
+    assert "w=233" in r.stdout, r.stdout
+
+
+def test_retry_timeout_escalates_to_the_coldopen_tier():
+    """Attempt 2 must NOT reuse attempt 1's deadline: it escalates to the model-aware cold-open
+    tier (opus 500 / default 400) and never DE-escalates below attempt 1's deadline."""
+    r = _bash(
+        _CLEAN
+        + 'CLAWDND_DM_MODEL=opus\n'
+        + 'echo "opus360=$(clawdnd_dm_retry_timeout 360)"\n'
+        + 'echo "opus600=$(clawdnd_dm_retry_timeout 600)"\n'
+        + 'CLAWDND_DM_MODEL=sonnet\n'
+        + 'echo "sonnet360=$(clawdnd_dm_retry_timeout 360)"\n'
+    )
+    assert r.returncode == 0, r.stderr
+    assert "opus360=500" in r.stdout, ("a routine retry escalates to the opus cold-open tier", r.stdout)
+    assert "opus600=600" in r.stdout, ("never de-escalate below attempt 1's deadline", r.stdout)
+    assert "sonnet360=400" in r.stdout, ("non-opus escalates to the 400s cold-open tier", r.stdout)
+
+
+def test_retry_timeout_tolerates_a_garbage_base():
+    """3.2-clean robustness: a non-numeric base (an env typo) still yields the escalation tier."""
+    r = _bash(_CLEAN + 'CLAWDND_DM_MODEL=opus; echo "g=$(clawdnd_dm_retry_timeout banana)"')
+    assert r.returncode == 0, r.stderr
+    assert "g=500" in r.stdout, r.stdout
+
+
+def test_play_lanes_recompute_the_retry_deadline():
+    """Static anti-drift: both dm_turn paths captured beat_timeout ONCE and reused it verbatim on
+    the retry (the F12-1 reuse bug) — they must now recompute via clawdnd_dm_retry_timeout."""
+    for name in ("scripts/play.sh", "scripts/play_party.sh"):
+        src = _src(name)
+        assert 'beat_timeout="$(clawdnd_dm_retry_timeout "$beat_timeout")"' in src, (
+            f"{name} retry must recompute its deadline (attempt 2 escalates, never reuses verbatim)"
+        )
+
+
+def test_play_sh_documented_routine_default_matches_the_lib():
+    """play.sh's CLAWDND_BEAT_TIMEOUT line both documents AND seeds the routine default — it must
+    agree with the lib's 360 (a 200 left here would silently pin the old kill deadline)."""
+    play = _src("scripts/play.sh")
+    assert 'CLAWDND_BEAT_TIMEOUT="${CLAWDND_BEAT_TIMEOUT:-360}"' in play, (
+        "play.sh must seed/document the raised 360s routine default"
+    )
+    assert ':-200}' not in play, "the stale 200s default must not survive anywhere in play.sh"
+
+
+# ================= F12-3: cold-open failure abort + the shared seating guard =================
+
+def _seed_snapshot(state_dir: Path, camp: str, characters: dict, party: list):
+    d = state_dir / "campaigns" / camp
+    d.mkdir(parents=True)
+    (d / "snapshot.json").write_text(json.dumps({"characters": characters, "party": party}))
+
+
+def test_pc_seated_helper_matches_the_viewer_contract(tmp_path):
+    """clawdnd_pc_seated == viewer _action_actor: seated means a party member whose character
+    record is kind=player. Snapshot-read-only; missing/blank inputs -> not seated (rc=1)."""
+    sd = tmp_path / "state"
+    _seed_snapshot(sd, "c-seated", {"pc1": {"kind": "player"}, "n1": {"kind": "npc"}}, ["pc1"])
+    _seed_snapshot(sd, "c-npc-only", {"n1": {"kind": "npc"}, "co1": {"kind": "companion"}}, ["co1"])
+    _seed_snapshot(sd, "c-pc-not-in-party", {"pc1": {"kind": "player"}}, [])
+    script = (
+        f'set -u; . "{LIB}"\n'
+        f'clawdnd_pc_seated "{sd}" c-seated; echo "seated=$?"\n'
+        f'clawdnd_pc_seated "{sd}" c-npc-only; echo "npc=$?"\n'
+        f'clawdnd_pc_seated "{sd}" c-pc-not-in-party; echo "unparty=$?"\n'
+        f'clawdnd_pc_seated "{sd}" c-missing; echo "missing=$?"\n'
+        f'clawdnd_pc_seated "{sd}" ""; echo "blank=$?"\n'
+    )
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    assert "seated=0" in r.stdout, (r.stdout, r.stderr)
+    assert "npc=1" in r.stdout, "a party of companions/NPCs only is NOT seated"
+    assert "unparty=1" in r.stdout, "a player character outside the party is NOT seated"
+    assert "missing=1" in r.stdout, "no snapshot -> not seated"
+    assert "blank=1" in r.stdout, "a blank campaign id -> not seated (the dead-cold-open mode)"
+
+
+def test_play_sh_cold_open_aborts_on_an_empty_opening():
+    """The F12-3 masking half: a blank cold-open DMSG must abort non-zero BEFORE the move loop
+    (today it recorded an unflagged empty row and entered the loop = a running unplayable session)."""
+    play = _src("scripts/play.sh")
+    assert "DM produced no opening" in play, "play.sh must carry the empty-opening abort"
+    abort_at = play.index("DM produced no opening")
+    loop_at = play.index("while true; do")
+    assert abort_at < loop_at, "the abort must fire BEFORE the move loop is entered"
+    # the abort exits non-zero (surfaces via the native bridge instead of masking)
+    abort_line = next(ln for ln in play.splitlines() if "DM produced no opening" in ln)
+    assert "exit 1" in abort_line, abort_line
+
+
+def test_play_sh_runs_the_seating_guard_with_one_reseat_then_loud_abort():
+    """play.sh must guard seating like play_party: clawdnd_pc_seated, ONE reseat retry on a fresh
+    session, then a LOUD non-zero abort on the second miss — in both opener paths (the hero and
+    DM-invents openers converge before the guard, so one guard covers both)."""
+    play = _src("scripts/play.sh")
+    assert play.count("clawdnd_pc_seated") >= 2, "guard must re-check after the reseat retry"
+    assert "COLD-OPEN SEATED NO PC" in play, "the second miss must abort loudly"
+    guard_at = play.index("clawdnd_pc_seated")
+    loop_at = play.index("while true; do")
+    assert guard_at < loop_at, "the seating guard must run BEFORE the move loop"
+    # the reseat retry runs on a FRESH session id (a consumed cold-open --session-id collides)
+    reseat_at = play.index("clawdnd_pc_seated")
+    tail = play[reseat_at:loop_at]
+    assert "DSID=" in tail, "the reseat retry must mint a fresh session id"
+
+
+def test_play_party_reuses_the_lib_seating_guard():
+    """F12-3 unify: play_party.sh's local pc_seated() is replaced by the SHARED lib helper —
+    one implementation, zero drift (the audit's fix shape: extract the helper, stop patching one path)."""
+    party = _src("scripts/play_party.sh")
+    assert "clawdnd_pc_seated" in party, "play_party.sh must call the shared seating guard"
+    assert "pc_seated()" not in party, "the local pc_seated() must be deleted (lib is the one impl)"
+    assert party.count('clawdnd_pc_seated "$STATE_DIR" "$CAMPAIGN_ID"') >= 2, (
+        "both the initial check and the post-reseat re-check must use the shared helper"
+    )
+
+
+def test_pc_seated_lives_in_the_lib():
+    lib = _src("qa/lib_beat_driver.sh")
+    assert "clawdnd_pc_seated()" in lib, "the seating guard must be factored into the shared lib"
+
+
+# ============== F12-4: play_party wrapper heartbeat (the lane #623 never reached) ==============
+
+def test_play_party_emits_the_wrapper_heartbeat_on_the_cold_open():
+    """The campaign id is pre-seeded in the party lane, so even the cold open can heartbeat —
+    the call must precede the cold-open DM turn."""
+    party = _src("scripts/play_party.sh")
+    assert "clawdnd_emit_progress_heartbeat" in party, "play_party.sh must emit the wrapper heartbeat"
+    hb_at = party.index('clawdnd_emit_progress_heartbeat "$CAMPAIGN_ID" 1 0')
+    coldopen_at = party.index('DMSG="$(turn dm "$DSID" 1')
+    assert hb_at < coldopen_at, "the cold-open heartbeat must precede the cold-open DM turn"
+
+
+def test_play_party_emits_the_wrapper_heartbeat_before_companion_moves():
+    """Per-beat: the heartbeat lands after the human move is read and BEFORE companion_moves, so
+    the player isn't staring at a dead spinner through companion latency."""
+    party = _src("scripts/play_party.sh")
+    beat_hb_at = party.index('clawdnd_emit_progress_heartbeat "$CAMPAIGN_ID" 0')
+    human_move_at = party.index('chatlog player "$PMSG"')
+    companions_at = party.index('COMP_BLOCK="$(companion_moves')
+    assert human_move_at < beat_hb_at < companions_at, (
+        "the per-beat heartbeat must land after the human move is read and BEFORE companion_moves"
+    )
+
+
+def test_play_party_heartbeat_uses_the_shared_helper_not_a_local_bank():
+    """#763 decontamination: the heartbeat MUST be the shared lib helper (its exact wrapper lines
+    are what app.jsx filters and the #763 fallback recognizes) — never a local text bank."""
+    party = _src("scripts/play_party.sh")
+    assert "CLAWDND_OPENING_PROGRESS_TEXT=" not in party, "no local heartbeat bank (lib owns the text)"
+    assert "CLAWDND_MOVE_PROGRESS_TEXTS=" not in party, "no local heartbeat bank (lib owns the text)"
+
+
+# ===================== F12-5: play_party soft clock-tick backstop =====================
+
+def test_play_party_soft_ticks_after_each_recorded_beat():
+    """Mirror of play.sh:475-478/504: capture PREV_DAY/PREV_TOD pre-beat, clawdnd_soft_tick after
+    record_dm_reply — play_party was the ONLY beat loop without the backstop (frozen day-1 morning)."""
+    party = _src("scripts/play_party.sh")
+    assert 'clawdnd_soft_tick "$ROOT" "$STATE_DIR" "$PREV_DAY" "$PREV_TOD"' in party, (
+        "play_party.sh must run the soft clock-tick backstop"
+    )
+    prev_at = party.index('PREV_DAY=')
+    dm_beat_at = party.index('DMSG="$(turn dm "$DSID" 0 "[ARC CUE')
+    record_at = party.index('record_dm_reply "$CAMPAIGN_ID" "$DMSG" beat')
+    tick_at = party.index('clawdnd_soft_tick')
+    assert prev_at < dm_beat_at, "PREV_DAY/PREV_TOD must be captured BEFORE the DM beat"
+    assert record_at < tick_at, "the tick runs AFTER record_dm_reply (defer to the DM's own clock)"
+    assert 'PREV_TOD=' in party
+
+
+# =============================== syntax: every touched script ===============================
+
+def test_touched_scripts_are_bash_n_clean():
+    for rel in (
+        "scripts/play.sh",
+        "scripts/play_party.sh",
+        "scripts/launch_common.sh",
+        "qa/lib_beat_driver.sh",
+    ):
+        r = subprocess.run(["/bin/bash", "-n", str(ROOT / rel)], capture_output=True, text=True)
+        assert r.returncode == 0, (rel, r.stderr)


### PR DESCRIPTION
Fixes the five-finding wrapper-reliability cluster from the 2026-06-11 engine audit (`docs/audits/ENGINE-AUDIT-2026-06-11.md`, unit 12 — skeptic-verified at a245a2c, re-validated against current main c1061e7). One branch because they share `qa/lib_beat_driver.sh` + both play lanes.

Closes #777 (F12-3) · Closes #787 (F12-8) · Closes #790 (F12-4) · Closes #791 (F12-5) · enriches #753 (F12-1 wrapper half — no dedicated issue).

## Root causes

- **F12-1** — `clawdnd_dm_timeout` returned a flat 200s for routine beats while measured healthy routine beats run p90=224s / max=360s (206-beat run_duo counterfactual, same opus/medium defaults) → ~18% of healthy beats were killed; and both `dm_turn` paths captured `beat_timeout` once and re-invoked the retry with the SAME deadline verbatim → the long beat was killed twice.
- **F12-8** — `timeout(1)` is a coreutils binary absent on stock Darwin; `play.sh`/`play_party.sh` invoked it bare → on a non-coreutils Mac every beat died rc=127 in <1s, masked. Preflight (`clawdnd_missing_commands`) never checked it.
- **F12-3** — `play.sh` recorded the cold-open DMSG UNCONDITIONALLY and entered the move loop: a double-failed cold open (401-class, proven 2026-06-02) left an unflagged EMPTY chat row + `CAMPAIGN_ID=""` + every beat resuming a nonexistent session — an indefinitely-"running" unplayable session under a live viewer. `play_party.sh` already carried both guards; play.sh had neither.
- **F12-4** — `clawdnd_emit_progress_heartbeat` (factored in #623 "so every harness shares it") had zero `play_party.sh` callers; post-#763 the viewer flips progress at heartbeat INGEST, so the party lane never flipped.
- **F12-5** — `play_party.sh` was the ONLY beat loop without `clawdnd_soft_tick` (no `PREV_DAY`/`PREV_TOD` capture) → party sessions could freeze at day-1 morning indefinitely.

## Fix

- `qa/lib_beat_driver.sh`: routine default 200→360 (env overrides win unchanged); NEW `clawdnd_dm_retry_timeout` (attempt 2 escalates to the model-aware cold-open tier — opus 500 / default 400 — never de-escalates below attempt 1); NEW `worldos_timeout` shim (timeout(1) when present, else python3 subprocess preserving rc=124/127/126; stdin/stdout pass-through); NEW `clawdnd_pc_seated` (snapshot-read-only, viewer `_action_actor` contract).
- `scripts/launch_common.sh`: `clawdnd_warn_if_no_timeout` — WARNS with the `brew install coreutils` hint (non-fatal by design: the shim fully serves a timeout-less host, so failing closed would be a regression; flagged as a deliberate deviation from the "hard preflight" reading of the spec).
- `scripts/play.sh`: empty-opening abort (non-zero, BEFORE the move loop), no-campaign abort, seating guard with ONE reseat retry (fresh session id, canon-pickup directive) then loud abort; shim swap; retry-deadline recompute; `CLAWDND_BEAT_TIMEOUT` seed line 200→360.
- `scripts/play_party.sh`: local `pc_seated()` deleted in favor of the shared lib helper (unify, not duplicate); cold-open heartbeat (pre-seeded campaign id) + per-beat heartbeat after the human move BEFORE `companion_moves` (same shared helper play.sh calls — no local text bank, #763 contamination-safe); `PREV_DAY`/`PREV_TOD` capture + `clawdnd_soft_tick` after `record_dm_reply`; shim swap; retry-deadline recompute.

## Tests (red-first)

`servers/engine/tests/test_wrapper_reliability.py` — 22 new tests, watched fail before the fix (19 red / 3 pre-existing-pass), in the `test_dm_session_remint.py` pytest-over-/bin/bash pattern:
- `worldos_timeout`: rc/stdout pass-through, rc=124 at the deadline, PATH-stripped no-binary fallback (124/7/127), native-binary preference, both-lane call-site swap, preflight brew hint (static + behavioral).
- F12-1: default=360, env precedence, retry escalation (opus 360→500, 600→600 no de-escalation, sonnet 360→400), garbage-base tolerance, both-lane recompute asserts, play.sh seed-line assert.
- F12-3: `clawdnd_pc_seated` behavioral matrix (seated / npc-only / pc-not-in-party / no-snapshot / blank-id), play.sh abort-before-loop + reseat-then-loud-abort statics, play_party lib-reuse statics.
- F12-4/5: static anti-drift call-site + ORDERING asserts (cold-open heartbeat before the cold-open turn; per-beat heartbeat between the human move and `companion_moves`; soft-tick after `record_dm_reply` with pre-beat capture).
- `bash -n` on all four touched scripts.

`test_adversarial_release.py::test_coldopen_play_party_guards_player_pc_seating` updated to track the factored helper (assert intent unchanged — the `_action_actor`-matching python now lives in the lib).

## Verification

- Full engine suite: **1805 passed** (single-process, `-p no:xdist`).
- `qa/fast_gate.sh`: **PASS** (188 deterministic tier tests).
- `/bin/bash -n` clean on `scripts/play.sh`, `scripts/play_party.sh`, `scripts/launch_common.sh`, `qa/lib_beat_driver.sh`; new bash is 3.2-clean (no new arrays, no globstar, heredocs never inside `$()`).
- Invariants: engine stays sole writer (guards snapshot-read-only; heartbeat/tick via `log_engine_narration`/`advance_time`); wire contracts frozen (CLAWDND_* names kept, no new env names); additive (explicit env overrides keep today's behavior).

## Notes / residual

- `qa/ui_playtest.sh` (+`run_duo.sh`, codex wrapper, companion turns) still use bare/no `timeout` — deliberately out of scope here; F12-9/F12-11/F12-12 land on this same `worldos_timeout` shim.
- The retry log line changed shape (`timeout=Ns` → `deadline escalated to Ns`); repo grep found no consumer of the old wording.

🤖 Generated with Claude Code