### PR TITLE
fix(qa+viewer): make image_render passable on the VM lane + harden the image probe (audit F11-1, F11-2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
             ../../qa/test_release_readiness_scope.py \
             ../../qa/test_scores_db_comparability.py \
             ../../qa/test_scores_db.py \
-            ../../qa/test_release_gate_static.py
+            ../../qa/test_release_gate_static.py \
+            ../../qa/test_ui_playtest_score_image_outcomes.py
 
   license-check:
     runs-on: ubuntu-latest

--- a/qa/playwright/palette_server.js
+++ b/qa/playwright/palette_server.js
@@ -196,6 +196,12 @@ async function ensurePage() {
     const url = resp.url();
     const method = resp.request().method();
     const rec = { ts: nowIso(), url, status, method };
+    // Additive (audit F11-1b): the viewer's /image responses class their outcome via
+    // X-Image-Outcome (served|no-art|placeholder|error). Record it so scoring can
+    // exclude DESIGNED no-art/placeholder 404s from the render-rate denominator.
+    // Header absent (older viewer) => field absent => today's status-code behavior.
+    const imageOutcome = (resp.headers() || {})["x-image-outcome"];
+    if (imageOutcome) rec.image_outcome = imageOutcome;
     appendLine(NETWORK, rec);
     // The viewer 404s a missing /image?scope=... ON PURPOSE — it's graceful degradation
     // (the UI shows a silhouette/placeholder). On a fresh run with no cached art that fires

--- a/qa/release_readiness.py
+++ b/qa/release_readiness.py
@@ -21,14 +21,23 @@ here (image rate from score.json/network.ndjson) and passed in (palette-live), s
 a pure disk reader.
 
 image_render gate sources (signals.image_render_source):
-  - "vm-network"  : per-run network.ndjson /image rows exist -> the REAL rate is computed
-                    and is authoritative (recorded 404s can never be papered over).
-  - "mac-handoff" : no per-run /image denominator exists (the VM cannot serve gitignored
-                    _private art) AND a valid --handoff-json at the same --build-sha proved
+  - "vm-network"  : per-run network.ndjson /image rows with UNEXPECTED outcomes exist ->
+                    the REAL rate is computed and is authoritative (recorded unexpected
+                    404s can never be papered over). Rows classed as DESIGNED degradation
+                    by the viewer's X-Image-Outcome header (no-art/placeholder — the VM
+                    serves no _private art and runs a null provider, so its /image
+                    requests 404 by construction) are excluded from the denominator
+                    (audit F11-1b); rows without the field count exactly as before.
+  - "mac-handoff" : no per-run UNEXPECTED /image denominator exists AND a valid
+                    --handoff-json at the same --build-sha proved
                     health.image_probe_ok:true + the private art root across every
                     required handoff gate. This is a representative built-app image
                     probe, NOT a render rate — weaker but real Mac evidence.
   - "none"        : neither source -> the gate stays a HARD FAIL with an evidence gap.
+
+A score.json image_404s count with no success denominator is an EVIDENCE GAP, never a
+fabricated 0.0 rate (audit F11-1a) — KNOWN unexpected 404s (image_404s_unexpected > 0)
+hard-gap the gate; an unknown split gaps it only when no Mac handoff carries it.
 
 Usage:
   release_readiness.py --runs <run-dir>[,<run-dir>...] \
@@ -131,24 +140,66 @@ def read_ndjson(path: Path) -> list[dict]:
     return out
 
 
-def image_render_rate(run: Path, score: dict) -> tuple[float, int, int, str]:
-    """Fraction of image requests that returned bytes (not 404). Prefers network.ndjson
-    (200 vs 404 image responses); falls back to score.json's image_404s with an unknown
-    denominator (then rate is reported as 1.0 only if 0 404s, else conservative)."""
+# Designed-degradation classes of the additive X-Image-Outcome response header
+# (viewer/server.py _serve_image, audit F11-1b): `no-art` (no descriptor — the UI
+# shows its silhouette ON PURPOSE) and `placeholder` (a payload-less descriptor,
+# e.g. the null provider's placeholder). Network rows carrying these classes are
+# EXCLUDED from the render-rate denominator — they are not render failures.
+# Rows without the field (older captures) keep today's status-code behavior.
+DESIGNED_IMAGE_OUTCOMES = {"no-art", "no_art", "placeholder"}
+
+
+def _row_image_outcome(row: dict) -> str:
+    return str(row.get("image_outcome") or "").strip().lower()
+
+
+def image_render_rate(run: Path, score: dict) -> tuple[float, int, int, str, str]:
+    """Fraction of image requests that returned bytes (not 404), over UNEXPECTED
+    outcomes only. Returns (rate, ok, total, source, evidence_gap_detail).
+
+    Prefers network.ndjson rows (200 vs 404 image responses); rows whose additive
+    `image_outcome` field classes them as DESIGNED degradation (no-art/placeholder)
+    are excluded from the denominator — the VM has no _private art and a null image
+    provider, so every /image request 404s by construction and those 404s are NOT
+    render failures (audit F11-1). Rows without the field count exactly as before.
+
+    The score.json fallback carries a 404 COUNT with no success denominator. That can
+    never be converted into a rate: a 404-only count with an unknown denominator is an
+    EVIDENCE GAP (the 5th tuple element; total stays 0), never a fabricated 0.0 — the
+    fabricated denominator is what kept the image_render gate structurally un-passable
+    on the VM release lane and blocked the #762 mac-handoff source (audit F11-1a)."""
     network_paths = [run / "network.ndjson", run / "player" / "network.ndjson"]
     net_path = next((p for p in network_paths if p.exists()), network_paths[0])
     net = read_ndjson(net_path)
     img = [n for n in net if "/image" in str(n.get("url", ""))]
+    counted = [n for n in img if _row_image_outcome(n) not in DESIGNED_IMAGE_OUTCOMES]
+    if counted:
+        ok = sum(1 for n in counted if int(n.get("status", 0) or 0) and int(n.get("status")) < 400)
+        total = len(counted)
+        return (ok / total if total else 1.0), ok, total, str(net_path), ""
     if img:
-        ok = sum(1 for n in img if int(n.get("status", 0) or 0) and int(n.get("status")) < 400)
-        total = len(img)
-        return (ok / total if total else 1.0), ok, total, str(net_path)
+        # every recorded /image row was expectation-classed DESIGNED degradation —
+        # zero unexpected failures by direct row evidence, but also no denominator
+        # (total stays 0; the persona still needs mac-handoff coverage to pass).
+        return 1.0, 0, 0, str(net_path), ""
     # fallback: score.json carries image_404s but not the success count
     f404 = int(score.get("image_404s", 0) or 0)
     if f404 == 0:
-        return 1.0, 0, 0, str(run / "score.json")
-    # unknown denominator → report the 404 count, conservative rate
-    return 0.0, 0, f404, str(run / "score.json")
+        return 1.0, 0, 0, str(run / "score.json"), ""
+    # ui_playtest_score.py (header-aware capture) may have expectation-classed the
+    # 404s already: all-designed 404s are clean degradation (still no denominator);
+    # KNOWN unexpected 404s are a hard evidence gap that no handoff may paper over.
+    unexpected = score.get("image_404s_unexpected")
+    if isinstance(unexpected, int) and not isinstance(unexpected, bool):
+        if unexpected == 0:
+            return 1.0, 0, 0, str(run / "score.json"), ""
+        return 0.0, 0, 0, str(run / "score.json"), (
+            f"{unexpected} unexpected image 404s recorded but no denominator"
+        )
+    # unknown split (no header data) → evidence gap, never a fabricated denominator
+    return 0.0, 0, 0, str(run / "score.json"), (
+        f"{f404} image 404s recorded but no denominator"
+    )
 
 
 def split_csv(value: str) -> list[str]:
@@ -608,10 +659,13 @@ def main() -> int:
                 "part_b_failure_detail": part_b_obj.get("failure_detail") or "",
             })
             continue
-        rate, ok, total, image_source = image_render_rate(rd, sc)
+        rate, ok, total, image_source, image_gap = image_render_rate(rd, sc)
         persona = sc.get("persona") or expected_for_run or infer_persona(rd)
         if persona:
             completed_personas.append(str(persona))
+        unexpected_404s = sc.get("image_404s_unexpected")
+        if isinstance(unexpected_404s, bool) or not isinstance(unexpected_404s, int):
+            unexpected_404s = None
         persona_scores.append({
             "run": sc.get("run") or rd.name,
             "persona": persona,
@@ -624,6 +678,12 @@ def main() -> int:
             "image_ok": ok,
             "image_total": total,
             "image_source": image_source,
+            # Additive (audit F11-1a): a non-empty image_evidence_gap means this run
+            # recorded image 404s with NO success denominator — an evidence gap, never
+            # a fabricated rate. image_404s/unexpected are carried for honest detail.
+            "image_evidence_gap": image_gap,
+            "image_404s": int(sc.get("image_404s", 0) or 0),
+            "image_404s_unexpected": unexpected_404s,
             "run_build_sha": rj.get("build_sha") or "",
             "part_b_result": (rj.get("part_b") or {}).get("persona_loop") or "n/a",
             "part_b_score_pass": bool((rj.get("part_b") or {}).get("score_pass")),
@@ -658,13 +718,18 @@ def main() -> int:
     img_rate = (sum(p["image_ok"] for p in img_runs) / sum(p["image_total"] for p in img_runs)) if img_runs else 0.0
     total_image_denominator = sum(p["image_total"] for p in img_runs)
 
-    # image_render source selection. The VM cannot serve gitignored _private art, so a
-    # split VM+Mac sweep structurally has NO per-run /image denominator; the Mac handoff
-    # is then the authoritative image evidence (built-app image_probe_ok + private art
-    # root across every required handoff gate, at the SAME --build-sha). Precedence is
-    # honest: any recorded VM image traffic computes the REAL rate (a handoff can never
-    # paper over recorded 404s), and when NEITHER source exists the gate stays a hard
-    # fail with an evidence gap — a VM-only sweep without a handoff still reports the gap.
+    # image_render source selection. The VM cannot serve gitignored _private art and runs
+    # a null image provider, so every VM /image request 404s BY CONSTRUCTION — those are
+    # DESIGNED no-art outcomes, not render failures (audit F11-1: a real sweep always
+    # records /image 404s, so "the VM has no denominator" was empirically false; treating
+    # those 404s as a denominator kept this gate permanently un-passable). The denominator
+    # therefore counts only UNEXPECTED network rows (designed no-art/placeholder rows are
+    # excluded via X-Image-Outcome) and 404-only score.json counts are evidence gaps, never
+    # fabricated rates. The Mac handoff is then the authoritative image evidence (built-app
+    # image_probe_ok + private art root across every required handoff gate, at the SAME
+    # --build-sha). Precedence is honest: any UNEXPECTED recorded VM image traffic computes
+    # the REAL rate (a handoff can never paper over recorded unexpected 404s), and when
+    # NEITHER source exists the gate stays a hard fail with an evidence gap.
     handoff_image_evidence = handoff_proof.get("image_evidence") if isinstance(handoff_proof.get("image_evidence"), dict) else {}
     handoff_image_ok = bool(
         args.handoff_json
@@ -798,6 +863,33 @@ def main() -> int:
         evidence_gaps.append({"gate": "ui_audit", "missing": "--ui-audit-log", "detail": "UI audit log path not supplied"})
     elif not Path(args.ui_audit_log).exists():
         evidence_gaps.append({"gate": "ui_audit", "missing": args.ui_audit_log, "detail": "UI audit log path missing"})
+    # Personas whose image evidence is a 404 count with NO denominator (score.json
+    # fallback, audit F11-1a). KNOWN unexpected 404s are a hard gap no handoff may
+    # paper over; an unknown split (legacy capture) is a gap only when the Mac handoff
+    # does not carry the gate — on the VM lane those 404s are designed no-art outcomes.
+    image_gap_personas = [p for p in persona_scores if p.get("image_evidence_gap")]
+    blocking_image_gap_personas = [
+        p for p in image_gap_personas
+        if isinstance(p.get("image_404s_unexpected"), int) and p["image_404s_unexpected"] > 0
+    ]
+    nonblocking_image_gap_personas = [
+        p for p in image_gap_personas if p not in blocking_image_gap_personas
+    ]
+    if blocking_image_gap_personas:
+        evidence_gaps.append({
+            "gate": "image_render",
+            "missing": "image 404 denominator",
+            "detail": "unexpected image 404s recorded but no denominator: "
+            + ", ".join(f"{p['persona']} ({p['image_evidence_gap']})" for p in blocking_image_gap_personas),
+        })
+    if nonblocking_image_gap_personas and image_render_source != "mac-handoff":
+        evidence_gaps.append({
+            "gate": "image_render",
+            "missing": "image 404 denominator",
+            "detail": "image 404s recorded but no denominator (404-only score.json fallback; "
+            "designed no-art 404s are indistinguishable without X-Image-Outcome): "
+            + ", ".join(f"{p['persona']}={p['image_404s']}" for p in nonblocking_image_gap_personas),
+        })
     if image_missing_personas and image_render_source != "mac-handoff":
         image_gap_detail = f"no /image requests recorded for: {', '.join(image_missing_personas)}"
         if args.handoff_json and image_render_source == "none":
@@ -933,6 +1025,11 @@ def main() -> int:
             "image_render_source": image_render_source,
             "image_request_denominator": total_image_denominator,
             "image_missing_personas": image_missing_personas,
+            # Additive (audit F11-1a): personas whose runs recorded image 404s with no
+            # success denominator — honest record even when the Mac handoff carries the gate.
+            "image_404_personas_without_denominator": [
+                str(p["persona"]) for p in image_gap_personas
+            ],
             "palette_live": args.palette_live,
             "run_build_shas": build_shas,
         },

--- a/qa/test_release_readiness.py
+++ b/qa/test_release_readiness.py
@@ -228,30 +228,35 @@ class ReleaseReadinessContractTests(unittest.TestCase):
         include_part_a: bool = True,
         include_image_traffic: bool = True,
         image_status: int = 200,
+        network_rows: list[dict] | None = None,
+        extra_score_fields: dict | None = None,
     ) -> Path:
         run = tmp / f"gate-{persona}"
         player = run / "player"
         player.mkdir(parents=True)
-        (run / "score.json").write_text(
-            json.dumps(
-                {
-                    "run": f"gate-{persona}",
-                    "persona": persona,
-                    "completed_intro_flow": True,
-                    "persona_satisfaction": 9,
-                    "gave_up": False,
-                    "bug_reports_critical": 0,
-                    "console_errors": 0,
-                    "image_404s": 0,
-                }
-            ),
-            encoding="utf-8",
-        )
+        score = {
+            "run": f"gate-{persona}",
+            "persona": persona,
+            "completed_intro_flow": True,
+            "persona_satisfaction": 9,
+            "gave_up": False,
+            "bug_reports_critical": 0,
+            "console_errors": 0,
+            "image_404s": 0,
+        }
+        if extra_score_fields:
+            score.update(extra_score_fields)
+        (run / "score.json").write_text(json.dumps(score), encoding="utf-8")
         payload = {"build_sha": sha, "part_b": {"persona_loop": "PASS", "score_pass": True}}
         if include_part_a:
             payload["part_a"] = {"result": "PASS"}
         (run / "run.json").write_text(json.dumps(payload), encoding="utf-8")
-        if include_image_traffic:
+        if network_rows is not None:
+            (player / "network.ndjson").write_text(
+                "\n".join(json.dumps(row) for row in network_rows) + "\n",
+                encoding="utf-8",
+            )
+        elif include_image_traffic:
             (player / "network.ndjson").write_text(
                 json.dumps({"url": f"http://127.0.0.1/image?scope={persona}", "status": image_status}),
                 encoding="utf-8",
@@ -1437,6 +1442,313 @@ class ReleaseReadinessContractTests(unittest.TestCase):
             self.assertEqual(payload["signals"]["image_render_source"], "vm-network")
             self.assertEqual(payload["signals"]["image_request_denominator"], 5)
             self.assertEqual(payload["signals"]["image_render_rate"], 0.0)
+
+    def test_image_404s_without_denominator_is_an_evidence_gap_not_a_fabricated_rate(self):
+        # Audit F11-1a: score.json carries a 404 COUNT with no success count. The old
+        # fallback fabricated rate 0.0 with total=image_404s — a denominator that does
+        # not exist — which both hard-failed the gate AND (by total>0) selected the
+        # "vm-network" source, structurally blocking the mac-handoff source. A 404-only
+        # count with an unknown denominator must be an EVIDENCE GAP instead.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            run = self.write_persona_run(
+                tmp,
+                "newbie",
+                include_image_traffic=False,
+                extra_score_fields={"image_404s": 7},
+            )
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                str(run),
+                "--expected-personas",
+                "newbie",
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertIn("image_render", payload["failed_gates"])
+            # The fabricated denominator is gone: the 404 count contributes NOTHING.
+            self.assertEqual(payload["personas"][0]["image_total"], 0)
+            self.assertEqual(payload["signals"]["image_request_denominator"], 0)
+            self.assertEqual(payload["signals"]["image_render_source"], "none")
+            self.assertEqual(
+                payload["signals"]["image_404_personas_without_denominator"], ["newbie"]
+            )
+            gap_details = [
+                gap["detail"] for gap in payload["evidence_gaps"] if gap["gate"] == "image_render"
+            ]
+            self.assertTrue(
+                any("no denominator" in detail for detail in gap_details),
+                f"expected a no-denominator evidence gap, got: {gap_details}",
+            )
+
+    def test_designed_no_art_rows_are_excluded_from_image_denominator(self):
+        # Audit F11-1b: network rows expectation-classed as DESIGNED degradation by the
+        # viewer's X-Image-Outcome header (no-art / placeholder) are not render failures
+        # and must not poison the rate. Unclassified rows keep today's behavior.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            run = self.write_persona_run(
+                tmp,
+                "newbie",
+                network_rows=[
+                    {"url": "http://127.0.0.1/image?scope=a", "status": 404, "image_outcome": "no-art"},
+                    {"url": "http://127.0.0.1/image?scope=b", "status": 404, "image_outcome": "placeholder"},
+                    {"url": "http://127.0.0.1/image?scope=c", "status": 200},
+                    {"url": "http://127.0.0.1/image?scope=d", "status": 404},
+                ],
+            )
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                str(run),
+                "--expected-personas",
+                "newbie",
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 1)  # single persona: never release_ready
+            self.assertEqual(payload["signals"]["image_render_source"], "vm-network")
+            self.assertEqual(payload["signals"]["image_request_denominator"], 2)
+            self.assertEqual(payload["personas"][0]["image_ok"], 1)
+            self.assertEqual(payload["personas"][0]["image_total"], 2)
+            self.assertAlmostEqual(payload["signals"]["image_render_rate"], 0.5)
+
+    def test_image_render_mac_handoff_engages_when_vm_404s_are_all_designed(self):
+        # The F11-1 headline: the canonical 5-persona VM sweep ALWAYS records /image
+        # 404s (no _private art + null provider — they 404 by construction), so the
+        # mac-handoff source could never engage. When every recorded 404 is classed
+        # designed no-art, the VM contributes no denominator and a valid same-SHA Mac
+        # handoff with sound image evidence carries the gate.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(
+                    tmp,
+                    persona,
+                    include_part_a=False,
+                    network_rows=[
+                        {"url": f"http://127.0.0.1/image?scope=scene-{persona}", "status": 404, "image_outcome": "no-art"},
+                        {"url": f"http://127.0.0.1/image?scope=portrait-{persona}", "status": 404, "image_outcome": "no-art"},
+                    ],
+                    extra_score_fields={"image_404s": 2, "image_404s_designed": 2, "image_404s_unexpected": 0},
+                )
+                for persona in personas
+            ]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            handoff = self.write_handoff_bundle(
+                tmp,
+                app_status_overrides={"health": {"image_probe_ok": True}},
+            )
+            support_preflight = self.write_support_preflight(tmp)
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--handoff-json",
+                str(handoff),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(payload["release_ready"])
+            self.assertNotIn("image_render", payload["failed_gates"])
+            self.assertEqual(payload["signals"]["image_render_source"], "mac-handoff")
+            self.assertEqual(payload["signals"]["image_request_denominator"], 0)
+            self.assertNotIn("image_render", {gap["gate"] for gap in payload["evidence_gaps"]})
+
+    def test_legacy_404_only_scores_with_sound_handoff_pass_via_mac_handoff(self):
+        # Audit F11-1 red test (1): 5 personas whose score.json recorded image_404s>0
+        # with NO network rows and NO expectation classes (a legacy capture). On the VM
+        # lane those 404s are designed no-art outcomes; a valid same-SHA handoff with
+        # sound image evidence must carry the gate (today: hard FAIL 0.0/"vm-network").
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(
+                    tmp,
+                    persona,
+                    include_part_a=False,
+                    include_image_traffic=False,
+                    extra_score_fields={"image_404s": 5},
+                )
+                for persona in personas
+            ]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            handoff = self.write_handoff_bundle(
+                tmp,
+                app_status_overrides={"health": {"image_probe_ok": True}},
+            )
+            support_preflight = self.write_support_preflight(tmp)
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--handoff-json",
+                str(handoff),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(payload["release_ready"])
+            self.assertNotIn("image_render", payload["failed_gates"])
+            self.assertEqual(payload["signals"]["image_render_source"], "mac-handoff")
+            self.assertEqual(payload["signals"]["image_request_denominator"], 0)
+            # Honest record even when the handoff carries the gate.
+            self.assertEqual(
+                sorted(payload["signals"]["image_404_personas_without_denominator"]),
+                sorted(personas),
+            )
+
+    def test_known_unexpected_404s_without_denominator_block_even_with_handoff(self):
+        # When the capture DID classify the 404s and some were UNEXPECTED, that is real
+        # failure evidence — a Mac handoff must never paper over it (the #762 invariant,
+        # extended to the score.json fallback).
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(
+                    tmp,
+                    persona,
+                    include_part_a=False,
+                    include_image_traffic=False,
+                    extra_score_fields={"image_404s": 3, "image_404s_designed": 1, "image_404s_unexpected": 2},
+                )
+                for persona in personas
+            ]
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            handoff = self.write_handoff_bundle(
+                tmp,
+                app_status_overrides={"health": {"image_probe_ok": True}},
+            )
+            support_preflight = self.write_support_preflight(tmp)
+
+            rc, _text, payload = self.run_rri(
+                tmp,
+                "--runs",
+                ",".join(str(r) for r in runs),
+                "--expected-personas",
+                ",".join(personas),
+                "--story",
+                str(story),
+                "--mech",
+                str(mech),
+                "--behavioral",
+                "GREEN",
+                "--behavioral-path",
+                str(behavioral),
+                "--ui-audit",
+                "PASS",
+                "--ui-audit-log",
+                str(audit),
+                "--palette-live",
+                "true",
+                "--palette-source",
+                str(palette),
+                "--handoff-json",
+                str(handoff),
+                "--support-preflight-json",
+                str(support_preflight),
+                "--build-sha",
+                "deadbee",
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertIn("image_render", payload["failed_gates"])
+            gap_details = [
+                gap["detail"] for gap in payload["evidence_gaps"] if gap["gate"] == "image_render"
+            ]
+            self.assertTrue(
+                any("unexpected image 404s" in detail for detail in gap_details),
+                f"expected an unexpected-404 evidence gap, got: {gap_details}",
+            )
 
     def test_split_vm_persona_evidence_requires_support_preflight(self):
         with tempfile.TemporaryDirectory() as td:

--- a/qa/test_ui_playtest_score_image_outcomes.py
+++ b/qa/test_ui_playtest_score_image_outcomes.py
@@ -1,0 +1,96 @@
+"""ui_playtest_score.py expectation-classed image-404 split (audit F11-1b).
+
+The viewer's /image responses carry an additive X-Image-Outcome header which the
+capture harness records into network rows as `image_outcome`. The scorer must:
+  - keep `image_404s` as the raw total (wire-compatible with every old consumer);
+  - count `image_404s_designed` (no-art / placeholder = designed degradation);
+  - claim a KNOWN `image_404s_unexpected` only when EVERY 404 row carries a class
+    (a partial capture must not present unclassified 404s as proven-clean);
+  - emit `image_404s_unexpected: null` when the split is unknown (legacy captures).
+"""
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "qa" / "ui_playtest_score.py"
+
+
+class UiPlaytestScoreImageOutcomeTests(unittest.TestCase):
+    def score_run(self, network_rows: list[dict]) -> dict:
+        with tempfile.TemporaryDirectory() as td:
+            run = Path(td) / "run"
+            player = run / "player"
+            player.mkdir(parents=True)
+            (run / "meta.json").write_text(
+                json.dumps({"run": "run", "persona": "newbie", "world": "baldurs-gate"}),
+                encoding="utf-8",
+            )
+            (player / "network.ndjson").write_text(
+                "\n".join(json.dumps(row) for row in network_rows) + "\n",
+                encoding="utf-8",
+            )
+            proc = subprocess.run(
+                [sys.executable, str(SCRIPT), str(run)],
+                cwd=ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            return json.loads((run / "score.json").read_text(encoding="utf-8"))
+
+    def test_fully_classified_rows_split_designed_from_unexpected(self):
+        score = self.score_run(
+            [
+                {"url": "http://127.0.0.1/image?scope=a", "status": 404, "image_outcome": "no-art"},
+                {"url": "http://127.0.0.1/image?scope=b", "status": 404, "image_outcome": "placeholder"},
+                {"url": "http://127.0.0.1/image?scope=c", "status": 404, "image_outcome": "error"},
+            ]
+        )
+        self.assertEqual(score["image_404s"], 3)
+        self.assertEqual(score["image_404s_designed"], 2)
+        self.assertEqual(score["image_404s_unexpected"], 1)
+
+    def test_all_designed_rows_report_zero_unexpected(self):
+        score = self.score_run(
+            [
+                {"url": "http://127.0.0.1/image?scope=a", "status": 404, "image_outcome": "no-art"},
+                {"url": "http://127.0.0.1/image?scope=b", "status": 404, "image_outcome": "no-art"},
+            ]
+        )
+        self.assertEqual(score["image_404s"], 2)
+        self.assertEqual(score["image_404s_designed"], 2)
+        self.assertEqual(score["image_404s_unexpected"], 0)
+
+    def test_unclassified_rows_leave_unexpected_unknown(self):
+        # One 404 row lacks the outcome class (older viewer / mixed capture): the raw
+        # total stands, and the unexpected count must be null (unknown), NOT a guess.
+        score = self.score_run(
+            [
+                {"url": "http://127.0.0.1/image?scope=a", "status": 404, "image_outcome": "no-art"},
+                {"url": "http://127.0.0.1/image?scope=b", "status": 404},
+            ]
+        )
+        self.assertEqual(score["image_404s"], 2)
+        self.assertEqual(score["image_404s_designed"], 1)
+        self.assertIsNone(score["image_404s_unexpected"])
+
+    def test_non_image_failures_keep_existing_counters(self):
+        score = self.score_run(
+            [
+                {"url": "http://127.0.0.1/session-surface", "status": 500},
+                {"url": "http://127.0.0.1/image?scope=a", "status": 404, "image_outcome": "no-art"},
+            ]
+        )
+        self.assertEqual(score["image_404s"], 1)
+        self.assertEqual(score["network_failures"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qa/ui_playtest_score.py
+++ b/qa/ui_playtest_score.py
@@ -126,7 +126,26 @@ def main() -> int:
     def is_image_404(n: dict) -> bool:
         return n.get("status") == 404 and "/image?scope=" in (n.get("url") or "")
 
-    image_404s = sum(1 for n in network if is_image_404(n))
+    # Expectation-class the image 404s (audit F11-1b): the viewer's /image responses
+    # carry an additive X-Image-Outcome header (recorded into network rows as
+    # `image_outcome` by the capture harness). `no-art` / `placeholder` 404s are the
+    # DESIGNED degradation this file's own comment describes — only the rest are
+    # unexpected render failures. Rows without the field (older captures) stay
+    # unclassified: they count in image_404s exactly as before and the designed/
+    # unexpected split is simply not emitted as known-zero certainty.
+    DESIGNED_IMAGE_OUTCOMES = {"no-art", "no_art", "placeholder"}
+
+    def image_outcome(n: dict) -> str:
+        return str(n.get("image_outcome") or "").strip().lower()
+
+    image_404_rows = [n for n in network if is_image_404(n)]
+    image_404s = len(image_404_rows)
+    image_404s_designed = sum(1 for n in image_404_rows if image_outcome(n) in DESIGNED_IMAGE_OUTCOMES)
+    classified_404s = sum(1 for n in image_404_rows if image_outcome(n))
+    # Only claim a known unexpected count when EVERY 404 row carries an outcome class —
+    # a partial capture must not let release_readiness treat unclassified designed 404s
+    # as proven-clean (None = unknown, omitted from score.json).
+    image_404s_unexpected = (image_404s - image_404s_designed) if classified_404s == image_404s else None
     network_failures = sum(1 for n in network if not is_image_404(n))
 
     # --- completed intro flow? -----------------------------------------------
@@ -190,6 +209,11 @@ def main() -> int:
         "console_errors": console_errors,
         "network_failures": network_failures,
         "image_404s": image_404s,
+        # Additive expectation-classed split (audit F11-1b). image_404s stays the raw
+        # total for older consumers; designed = X-Image-Outcome no-art/placeholder;
+        # unexpected = the remainder, or null when any 404 row lacks the class.
+        "image_404s_designed": image_404s_designed,
+        "image_404s_unexpected": image_404s_unexpected,
         "bug_reports_total": len(bugs),
         "bug_reports_player": len(player_bugs),
         "bug_reports_auto": len(auto_bugs),

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -468,6 +468,58 @@ def _latest_descriptor(scope: Optional[str]) -> Optional[dict]:
     return _newest_json_descriptor(_images_dir(scope))
 
 
+def _image_serve_roots() -> list[Path]:
+    """Path-containment allowlist for a descriptor's `path` field (audit F11-2).
+
+    Factored out of `_serve_image` so the serve path and the app-status image probe
+    apply the SAME containment rule: the derived image cache, the OpenClaw gateway
+    media dir, and the gitignored _private ingested-art tree. The viewer is the
+    documented "pure reader": a descriptor's `path` must never let /image serve an
+    arbitrary file (e.g. /etc/passwd) even if tampered."""
+    _oh = os.environ.get("OPENCLAW_HOME")
+    return [
+        _state_dir() / "images",
+        Path(env_var_legacy("CLAWDND_OPENCLAW_MEDIA_DIR")
+             or ((Path(_oh) if _oh else Path.home() / ".openclaw") / "media" / "tool-image-generation")),
+        # W2b: ingested wiki art (gitignored _private; never committed).
+        _ingested_images_root(),
+    ]
+
+
+def _descriptor_servable(desc: Optional[dict]) -> bool:
+    """True iff `_serve_image` would answer this descriptor with a < 400 status (audit F11-2).
+
+    Mirrors the serve path exactly: a contained, readable, non-empty `path`; OR valid
+    base64 `bytes_b64`; OR a non-empty `url` (302 redirect). A descriptor that parses
+    but carries none of these — e.g. the null provider's payload-less placeholder —
+    is NOT servable, even though it exists on disk. This is the predicate the
+    app-status image probe must use: probe-true while /image 404s is the F11-2 hole.
+    (The engine-side portrait-gen snippet keeps its own inline copy of the payload
+    check — it runs in the engine subprocess and cannot import viewer helpers.)"""
+    if not isinstance(desc, dict):
+        return False
+    path = desc.get("path")
+    if isinstance(path, str) and path:
+        try:
+            rp = Path(path).resolve()
+            if (any(rp == r.resolve() or r.resolve() in rp.parents for r in _image_serve_roots())
+                    and rp.is_file() and rp.stat().st_size > 0):
+                return True
+        except OSError:
+            pass
+    b64 = desc.get("bytes_b64")
+    if isinstance(b64, str) and b64:
+        try:
+            if base64.b64decode(b64, validate=True):
+                return True
+        except (binascii.Error, ValueError):
+            pass
+    url = desc.get("url")
+    if isinstance(url, str) and url:
+        return True
+    return False
+
+
 def _portrait_by_name(scope: Optional[str], campaign_id: str) -> Optional[dict]:
     """Resolve a ``portrait-<engine-id>`` scope by the character's NAME when the id itself
     has no art. PCs are minted with opaque engine ids (``char_09bfb0ec913c``) while canon
@@ -5781,10 +5833,59 @@ def _move_run_id(dest: Path | None) -> str:
     return ""
 
 
-def _app_status_image_probe(surface: dict) -> bool:
+def _probe_image_scope(scope: str, campaign_id: str = "") -> str:
+    """Expectation-class one image scope exactly the way GET /image would resolve it
+    (audit F11-2): 'servable' (a descriptor exists AND /image would answer < 400),
+    'no-art' (no descriptor at all — designed silhouette degradation, NOT a failure),
+    'unservable' (a descriptor exists but /image would 404 it — e.g. the null
+    provider's payload-less placeholder; an unexpected outcome the probe must catch)."""
+    desc = _latest_descriptor(scope)
+    if desc is None:
+        desc = _portrait_by_name(scope, campaign_id)
+    if desc is None:
+        return "no-art"
+    return "servable" if _descriptor_servable(desc) else "unservable"
+
+
+def _app_status_image_probe(surface: dict) -> tuple[bool, dict]:
+    """Probe the live scene's image scope SET and return (ok, machine-readable detail).
+
+    Audit F11-2: the old probe was `bool(scope and _latest_descriptor(scope))` —
+    vacuously true on ANY parsed descriptor (including the cached null-provider
+    placeholder that `_serve_image` then 404s) and scene-scope-only (zero portrait
+    coverage). Now the probe:
+      - requires the SCENE descriptor to be genuinely SERVABLE (probe verdict ==
+        GET /image status < 400, via the shared `_descriptor_servable`), and
+      - covers `portrait-<id>` for every party member: a portrait with NO art stays
+        a designed silhouette miss (does not fail the probe), but a portrait whose
+        descriptor exists yet cannot be served is an unexpected failure.
+    The detail dict is emitted additively as app-status `health.image_probe` so the
+    Mac-handoff release evidence (qa/release_readiness.py) is expectation-classed,
+    not a vacuous bit."""
+    campaign_id = str(surface.get("campaign_id") or "")
     scene = surface.get("scene") if isinstance(surface.get("scene"), dict) else {}
-    scope = scene.get("imageScope") if isinstance(scene, dict) else ""
-    return bool(scope and _latest_descriptor(str(scope)))
+    scene_scope = str(scene.get("imageScope") or "") if isinstance(scene, dict) else ""
+    party = surface.get("party") if isinstance(surface.get("party"), list) else []
+    scopes: list[str] = []
+    if scene_scope:
+        scopes.append(scene_scope)
+    for card in party:
+        if isinstance(card, dict) and card.get("id"):
+            portrait_scope = f"portrait-{card['id']}"
+            if portrait_scope not in scopes:
+                scopes.append(portrait_scope)
+    outcomes = {s: _probe_image_scope(s, campaign_id) for s in scopes}
+    unservable = sorted(s for s, o in outcomes.items() if o == "unservable")
+    ok = bool(scene_scope) and outcomes.get(scene_scope) == "servable" and not unservable
+    detail = {
+        "ok": ok,
+        "scene_scope": scene_scope,
+        "probed": scopes,
+        "servable": sorted(s for s, o in outcomes.items() if o == "servable"),
+        "no_art": sorted(s for s, o in outcomes.items() if o == "no-art"),
+        "unservable": unservable,
+    }
+    return ok, detail
 
 
 def _browser_health_counts(console_log: str | None, network_log: str | None) -> tuple[int, int]:
@@ -5852,7 +5953,7 @@ def _app_status_readiness(*, live: dict | None, moves: Path | None, is_live_view
     )
     narration_present = chat_lines > 0 or recent_narration > 0
     art_present = art_root.is_dir()
-    image_probe_ok = _app_status_image_probe(surface)
+    image_probe_ok, image_probe_detail = _app_status_image_probe(surface)
     console_errors = max(0, int(console_errors or 0))
     network_failures = max(0, int(network_failures or 0))
 
@@ -5901,6 +6002,10 @@ def _app_status_readiness(*, live: dict | None, moves: Path | None, is_live_view
         "provider_ready": provider_ready,
         "provider_status": provider_status or {},
         "image_probe_ok": image_probe_ok,
+        # Additive machine-readable probe evidence (audit F11-2): which scopes were
+        # probed (scene + party portraits) and how each classed. Consumers that only
+        # read the boolean keep working; release evidence can read the classes.
+        "image_probe": image_probe_detail,
         "pending_player_turn": bool(pending_player_turn),
         "failure_bucket": failure_bucket,
         "failure_detail": failure_detail,
@@ -6350,6 +6455,8 @@ def main():
     )
     desc = imagegen.generate("portrait", prompt, seed=seed, scope=scope)
     # A real, servable portrait carries path/url/bytes_b64 and is NOT a placeholder/degraded.
+    # (Inline payload check mirroring the viewer's _descriptor_servable — this snippet runs
+    # inside the ENGINE subprocess and cannot import viewer helpers; keep the two in step.)
     servable = bool(desc.get("path") or desc.get("url") or desc.get("bytes_b64"))
     generated = servable and not desc.get("placeholder") and not desc.get("degraded_from")
     print(json.dumps({
@@ -6828,11 +6935,17 @@ class _Handler(BaseHTTPRequestHandler):
             # client disconnected — normal SSE teardown, not an error.
             return
 
-    def _send(self, code: int, body: bytes, ctype: str) -> None:
+    def _send(self, code: int, body: bytes, ctype: str,
+              extra_headers: Optional[dict] = None) -> None:
         self.send_response(code)
         self.send_header("Content-Type", ctype)
         self.send_header("Content-Length", str(len(body)))
         self.send_header("Cache-Control", "no-store")
+        # Additive: callers may attach extra response headers (e.g. /image's
+        # X-Image-Outcome classification, audit F11-1b). Default None = exactly
+        # today's behavior for every existing caller.
+        for key, value in (extra_headers or {}).items():
+            self.send_header(key, value)
         self.end_headers()
         self.wfile.write(body)
 
@@ -6854,7 +6967,16 @@ class _Handler(BaseHTTPRequestHandler):
         or a `url` (302 redirect). 404s cleanly when the scope/descriptor is absent or
         carries no servable image, so the dashboard keeps its placeholder. Content-Type
         comes from the descriptor's `mime_type` (default image/png). Pure reader — never
-        imports the engine, never writes."""
+        imports the engine, never writes.
+
+        Audit F11-1(b): every response carries an additive `X-Image-Outcome` header
+        classing the result — `served` (2xx/302), `no-art` (no descriptor at all: the
+        DESIGNED silhouette degradation), `placeholder` (a descriptor with nothing
+        servable, e.g. the null provider's placeholder: also designed degradation), or
+        `error` (a descriptor whose payload UNEXPECTEDLY failed to serve — uncontained/
+        unreadable path, invalid base64). Status codes and bodies are unchanged; QA
+        network captures use the header to compute render rates over unexpected
+        failures only, so designed no-art 404s stop poisoning the release gate."""
         desc = _latest_descriptor(scope)
         if not desc:
             # A PC pulled from canon is minted with an opaque engine id (portrait-char_…);
@@ -6865,36 +6987,31 @@ class _Handler(BaseHTTPRequestHandler):
             # silhouette placeholder. We deliberately do NOT substitute a class/race heraldic
             # crest — a coat of arms is not a person's face, and dressing a faceless PC in one
             # reads as a bug, not art. Canon NPCs resolve to real ingested portraits above.
-            self._send(404, b"no image", "text/plain")
+            self._send(404, b"no image", "text/plain", extra_headers={"X-Image-Outcome": "no-art"})
             return
         ctype = desc.get("mime_type")
         ctype = ctype if isinstance(ctype, str) and ctype.strip() else "image/png"
+        # Track whether a payload field was present but failed to serve — that is an
+        # UNEXPECTED outcome (`error`), distinct from a payload-less placeholder.
+        payload_failed = False
         # 1) a real file on disk — ONLY if it's contained under an expected image root
         # (the derived cache, the OpenClaw gateway media dir, or the gitignored _private
-        # ingested-art tree). The viewer is the documented "pure reader": a descriptor's
-        # `path` must never let /image serve an arbitrary file (e.g. /etc/passwd) even
-        # if tampered. W2b adds the _private ingested root so wiki_images.py output is
-        # served transparently alongside generated images.
+        # ingested-art tree — `_image_serve_roots`, shared with the app-status probe).
+        # The viewer is the documented "pure reader": a descriptor's `path` must never
+        # let /image serve an arbitrary file (e.g. /etc/passwd) even if tampered.
         path = desc.get("path")
         if isinstance(path, str) and path:
-            _oh = os.environ.get("OPENCLAW_HOME")
-            roots = [
-                _state_dir() / "images",
-                Path(env_var_legacy("CLAWDND_OPENCLAW_MEDIA_DIR")
-                     or ((Path(_oh) if _oh else Path.home() / ".openclaw") / "media" / "tool-image-generation")),
-                # W2b: ingested wiki art (gitignored _private; never committed).
-                _ingested_images_root(),
-            ]
             data = None
             try:
                 rp = Path(path).resolve()
-                if any(rp == r.resolve() or r.resolve() in rp.parents for r in roots):
+                if any(rp == r.resolve() or r.resolve() in rp.parents for r in _image_serve_roots()):
                     data = rp.read_bytes()
             except OSError:
                 data = None
             if data:
-                self._send(200, data, ctype)
+                self._send(200, data, ctype, extra_headers={"X-Image-Outcome": "served"})
                 return
+            payload_failed = True
         # 2) inline base64 bytes
         b64 = desc.get("bytes_b64")
         if isinstance(b64, str) and b64:
@@ -6903,8 +7020,9 @@ class _Handler(BaseHTTPRequestHandler):
             except (binascii.Error, ValueError):
                 data = None
             if data:
-                self._send(200, data, ctype)
+                self._send(200, data, ctype, extra_headers={"X-Image-Outcome": "served"})
                 return
+            payload_failed = True
         # 3) a remote URL — hand the browser a redirect (we don't proxy bytes)
         url = desc.get("url")
         if isinstance(url, str) and url:
@@ -6912,10 +7030,14 @@ class _Handler(BaseHTTPRequestHandler):
             self.send_header("Location", url)
             self.send_header("Cache-Control", "no-store")
             self.send_header("Content-Length", "0")
+            self.send_header("X-Image-Outcome", "served")
             self.end_headers()
             return
-        # descriptor exists but carries no servable image (e.g. null placeholder)
-        self._send(404, b"no image", "text/plain")
+        # descriptor exists but carries no servable image: a payload that FAILED is an
+        # unexpected `error`; a payload-less descriptor (e.g. null placeholder) is the
+        # designed `placeholder` degradation.
+        outcome = "error" if payload_failed else "placeholder"
+        self._send(404, b"no image", "text/plain", extra_headers={"X-Image-Outcome": outcome})
 
     def _serve_export(self, campaign_id: str) -> None:
         """GET /export?campaign=<id> — stream a campaign's snapshot.json as a download.

--- a/viewer/tests/test_image_probe.py
+++ b/viewer/tests/test_image_probe.py
@@ -1,0 +1,253 @@
+"""App-status image probe soundness + /image X-Image-Outcome classes (audit F11-1b/F11-2).
+
+F11-2: the old probe was ``bool(scope and _latest_descriptor(scope))`` — vacuously true on
+ANY parsed descriptor, including the cached null-provider placeholder that ``_serve_image``
+then 404s, and it covered the scene scope only (zero portrait coverage). These tests pin the
+hardened contract:
+
+  - a payload-less (null placeholder) SCENE descriptor must report ``image_probe_ok: false``;
+  - a party portrait whose descriptor exists but cannot be served fails the probe, while a
+    portrait with NO art at all stays a designed silhouette miss (does not fail it);
+  - matrix invariant: for every probed scope, probe class "servable" == (GET /image < 400);
+  - /image responses carry the additive ``X-Image-Outcome`` header
+    (served | no-art | placeholder | error) with status/body unchanged (F11-1b).
+
+Mirrors the test_openworlds_static.py harness: a real HTTP server over a temp state dir.
+"""
+
+import base64
+import http.client
+import importlib.util
+import json
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+class _QuietHandler(server._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:  # noqa: D401 - silence test HTTP logs
+        return
+
+
+SCENE_SCOPE = "location:loc-lower-city"
+PNG_BYTES = b"not-really-png-but-bytes-are-bytes"
+PNG_B64 = base64.b64encode(PNG_BYTES).decode("ascii")
+
+
+class ImageProbeTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._saved_env = {}
+        for var in (
+            "CLAWDND_STATE_DIR",
+            "WORLDOS_ART_REPO_ROOT",
+            "CLAWDND_ART_REPO_ROOT",
+            "WORLDOS_REPO_ROOT",
+            "CLAWDND_REPO_ROOT",
+            "WORLDOS_PLAYER_MOVES",
+            "CLAWDND_PLAYER_MOVES",
+            "WORLDOS_PROVIDER",
+            "CLAWDND_PROVIDER",
+        ):
+            self._saved_env[var] = os.environ.pop(var, None)
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        # Isolate from any real checkout's gitignored _private art (2k+ ingested dirs on
+        # dev boxes would make probe outcomes nondeterministic via the fuzzy slug match).
+        art_root = self._tmp / "art-root"
+        art_root.mkdir()
+        os.environ["WORLDOS_ART_REPO_ROOT"] = str(art_root)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        for var, value in self._saved_env.items():
+            if value is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = value
+
+    # ---- helpers -------------------------------------------------------------
+
+    def _get(self, path: str) -> tuple[int, http.client.HTTPMessage, bytes]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            response = conn.getresponse()
+            return response.status, response.headers, response.read()
+        finally:
+            conn.close()
+
+    def _write_campaign(self) -> None:
+        campaign_dir = self._tmp / "campaigns" / "camp_live"
+        campaign_dir.mkdir(parents=True)
+        (campaign_dir / "snapshot.json").write_text(
+            json.dumps(
+                {
+                    "id": "camp_live",
+                    "title": "Probe Save",
+                    "active_session_id": "session_live",
+                    "world_id": "baldurs-gate",
+                    "current_location_id": "loc-lower-city",
+                    "locations": {
+                        "loc-lower-city": {"id": "loc-lower-city", "name": "Lower City"},
+                    },
+                    "party": ["hero"],
+                    "characters": {
+                        "hero": {
+                            "id": "hero",
+                            "name": "Probe Hero",
+                            "kind": "player",
+                            "current_hp": 8,
+                            "max_hp": 8,
+                        },
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        _QuietHandler.campaign_id = "camp_live"
+
+    def _write_descriptor(self, scope: str, desc: dict) -> None:
+        cache_dir = self._tmp / "images" / server._safe_scope(scope)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        (cache_dir / "cache.json").write_text(json.dumps({"scope": scope, **desc}), encoding="utf-8")
+
+    def _app_status_health(self) -> dict:
+        status, _headers, body = self._get("/app-status?campaign=camp_live")
+        self.assertEqual(status, 200)
+        payload = json.loads(body.decode("utf-8"))
+        return payload["health"]
+
+    def _image_status_and_outcome(self, scope: str) -> tuple[int, str]:
+        status, headers, _body = self._get(f"/image?scope={scope}")
+        return status, headers.get("X-Image-Outcome", "")
+
+    def assert_probe_matches_serve(self, health: dict) -> None:
+        """Matrix invariant (F11-2): probe class 'servable' == GET /image status < 400."""
+        probe = health["image_probe"]
+        for scope in probe["probed"]:
+            status, _outcome = self._image_status_and_outcome(scope)
+            self.assertEqual(
+                scope in probe["servable"],
+                status < 400,
+                f"probe/serve disagree for {scope}: status={status} probe={probe}",
+            )
+
+    # ---- F11-2: probe soundness ----------------------------------------------
+
+    def test_null_placeholder_scene_descriptor_fails_probe(self):
+        # The F11-2 red test: a cached payload-less null-provider placeholder parses as a
+        # descriptor, so the old probe reported image_probe_ok:true while /image 404s the
+        # very same scope. The probe must require a SERVABLE outcome.
+        self._write_campaign()
+        self._write_descriptor(
+            SCENE_SCOPE, {"placeholder": True, "provider": "null", "status": "ready"}
+        )
+
+        health = self._app_status_health()
+
+        self.assertFalse(health["image_probe_ok"])
+        self.assertIn(SCENE_SCOPE, health["image_probe"]["unservable"])
+        status, outcome = self._image_status_and_outcome(SCENE_SCOPE)
+        self.assertEqual(status, 404)
+        self.assertEqual(outcome, "placeholder")
+        self.assert_probe_matches_serve(health)
+
+    def test_servable_scene_descriptor_passes_probe_and_no_art_portrait_does_not_fail_it(self):
+        self._write_campaign()
+        self._write_descriptor(SCENE_SCOPE, {"bytes_b64": PNG_B64, "mime_type": "image/png"})
+
+        health = self._app_status_health()
+
+        self.assertTrue(health["image_probe_ok"])
+        probe = health["image_probe"]
+        self.assertIn(SCENE_SCOPE, probe["servable"])
+        # Party coverage: the hero has NO art anywhere — a designed silhouette miss,
+        # recorded honestly but NOT a probe failure.
+        self.assertIn("portrait-hero", probe["probed"])
+        self.assertIn("portrait-hero", probe["no_art"])
+        self.assertEqual(probe["unservable"], [])
+        status, outcome = self._image_status_and_outcome(SCENE_SCOPE)
+        self.assertEqual(status, 200)
+        self.assertEqual(outcome, "served")
+        self.assert_probe_matches_serve(health)
+
+    def test_unservable_party_portrait_fails_probe_even_with_servable_scene(self):
+        # Portraits are the bulk of recorded /image 404s (rc1 bugs.ndjson) — a portrait
+        # descriptor that exists but cannot be served is an UNEXPECTED outcome.
+        self._write_campaign()
+        self._write_descriptor(SCENE_SCOPE, {"bytes_b64": PNG_B64, "mime_type": "image/png"})
+        self._write_descriptor(
+            "portrait-hero", {"placeholder": True, "provider": "null", "status": "ready"}
+        )
+
+        health = self._app_status_health()
+
+        self.assertFalse(health["image_probe_ok"])
+        self.assertIn("portrait-hero", health["image_probe"]["unservable"])
+        self.assert_probe_matches_serve(health)
+
+    def test_missing_scene_descriptor_keeps_probe_false(self):
+        # No descriptor at all for the scene: same verdict as before the fix (false) —
+        # the gate evidence cannot ride a scene that has no art.
+        self._write_campaign()
+
+        health = self._app_status_health()
+
+        self.assertFalse(health["image_probe_ok"])
+        self.assertIn(SCENE_SCOPE, health["image_probe"]["no_art"])
+        status, outcome = self._image_status_and_outcome(SCENE_SCOPE)
+        self.assertEqual(status, 404)
+        self.assertEqual(outcome, "no-art")
+        self.assert_probe_matches_serve(health)
+
+    # ---- F11-1b: X-Image-Outcome classes ---------------------------------------
+
+    def test_image_outcome_header_classes(self):
+        self._write_campaign()
+        # served (inline bytes)
+        self._write_descriptor("portrait-served", {"bytes_b64": PNG_B64, "mime_type": "image/png"})
+        # served (302 redirect to a remote url)
+        self._write_descriptor("portrait-remote", {"url": "https://example.invalid/face.png"})
+        # placeholder (descriptor with no payload at all — the null placeholder)
+        self._write_descriptor("portrait-null", {"placeholder": True, "provider": "null"})
+        # error (payload present but UNEXPECTEDLY unservable: path outside the containment roots)
+        outside = self._tmp / "outside-roots.png"
+        outside.write_bytes(PNG_BYTES)
+        self._write_descriptor("portrait-escape", {"path": str(outside)})
+
+        cases = {
+            "portrait-served": (200, "served"),
+            "portrait-remote": (302, "served"),
+            "portrait-null": (404, "placeholder"),
+            "portrait-escape": (404, "error"),
+            "portrait-not-a-scope": (404, "no-art"),
+        }
+        for scope, (want_status, want_outcome) in cases.items():
+            with self.subTest(scope=scope):
+                status, outcome = self._image_status_and_outcome(scope)
+                self.assertEqual(status, want_status)
+                self.assertEqual(outcome, want_outcome)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the audit's single P0 (F11-1, #776) together with its mandatory companion (F11-2, #784). Spec: `docs/audits/ENGINE-AUDIT-2026-06-11.md`, unit 11 (skeptic-verified).

Closes #776. Closes #784.

## Root cause

**F11-1 (P0) — image_render gate structurally un-passable on the VM release lane.**
- `qa/release_readiness.py` `image_render_rate`: with no network rows, the score.json fallback converted a 404-only count with **no success denominator** into a fabricated rate — `image_404s>0` → `(0.0, 0, f404)` — hard-failing the gate.
- Rollup precedence: that fabricated `image_total>0` fed `total_image_denominator>0` → source `"vm-network"`, which blocks the **landed #762 mac-handoff source** (only reachable at a literally-zero denominator). Zero is impossible on a real sweep: the VM has no gitignored `_private` art and a null image provider, so every `/image` request 404s **by construction** (rc1 empirics: all 5 personas `image_source=score.json`, denominator 75, rate 0.0).
- `qa/ui_playtest_score.py` counts every `/image?scope=` 404 with no expected/unexpected split, even though its own comment calls a missing /image "graceful degradation".

**F11-2 (P1, lands together) — `image_probe_ok` vacuously satisfiable.**
- `viewer/server.py` probe was `bool(scope and _latest_descriptor(scope))` — true for ANY parsed descriptor, including the cached null-provider placeholder that `_serve_image` then 404s (probe-true + serve-404 end to end), and scene-scope-only (zero portrait coverage). Post-#762 this bit is the load-bearing mac-handoff image evidence; the hole goes live the moment F11-1 is fixed.

## Fix (all additive; viewer stays a pure reader; wire contracts extended, never repurposed)

- **(a) Evidence gap, not fabricated rate** (`qa/release_readiness.py`): a 404 count with an unknown denominator returns `total=0` + a gap detail. KNOWN unexpected 404s (`image_404s_unexpected>0`) hard-gap the gate — a handoff can never paper over them; an unknown split (legacy captures) gaps it only when no Mac handoff carries the gate. New signal `image_404_personas_without_denominator` keeps the honest record even when the handoff carries it.
- **(b) `X-Image-Outcome` header** (`viewer/server.py _serve_image`): every /image response is classed `served|no-art|placeholder|error` (status/body unchanged). `qa/playwright/palette_server.js` records it into network rows; `image_render_rate` excludes designed `no-art`/`placeholder` rows from the denominator; `ui_playtest_score.py` emits the additive `image_404s_designed`/`image_404s_unexpected` split (unexpected stays `null` unless every 404 row is classed — a partial capture can't claim proven-clean). Header absent ⇒ exactly today's status-code behavior.
- **(c) Sound, expectation-classed probe** (`viewer/server.py`): `_descriptor_servable()` factored from the serve path (shared containment roots via `_image_serve_roots()`); probe verdict == (GET /image < 400). The probe now requires a SERVABLE scene descriptor and covers `portrait-<id>` for every party member — no-art portraits are designed misses, unservable descriptors fail. Additive `health.image_probe {ok, scene_scope, probed, servable, no_art, unservable}` upgrades the existing mac-handoff evidence (no third source added).

## Tests (red-first — all watched fail on the unfixed tree)

- `qa/test_release_readiness.py` (+5): no-denominator ⇒ evidence gap, never a fabricated rate/denominator; designed rows excluded from the denominator; **mac-handoff engages when VM rows are all designed no-art**; legacy 404-only scores + sound handoff ⇒ release-ready via mac-handoff; known unexpected 404s block even with a handoff. All 33 existing tests green unchanged (incl. `test_vm_image_denominators_take_precedence_over_mac_handoff` — real unexpected rows still win).
- `qa/test_ui_playtest_score_image_outcomes.py` (+4): split semantics + unknown-split honesty (added to the `qa-release-gate-tests` CI lane).
- `viewer/tests/test_image_probe.py` (+5): null-placeholder scene fails the probe (the F11-2 red test); probe==serve matrix invariant; portrait coverage; X-Image-Outcome classes incl. `error` on an uncontained path.

## Verification

- RED run (implementation stashed): 17 failures, including `image_probe_ok` True on a null placeholder.
- GREEN: full viewer suite **498 passed** (+1 skip), qa suites **124 + 101 passed**, exact `qa-release-gate-tests` CI-lane invocation passes locally.
- `bash qa/fast_gate.sh` Tier-0 **PASS** (188 deterministic engine tests). `node --check` clean. No engine surface touched; engine sole-writer untouched.

## Deviations from the spec (called out honestly)

- The inline servable predicate in `_PORTRAIT_GEN_SNIPPET` (engine-subprocess code string) cannot import viewer helpers — left inline with a keep-in-step comment instead of sharing `_descriptor_servable`.
- The optional `qa/image_probe.py` emitter was not added: the additive `health.image_probe` detail in app-status (which lands in handoff evidence snapshots) already provides the machine-readable artifact.
- Pre-existing (not this PR): 4 qa modules (`test_app_handoff_gate` etc.) only import with repo-root on sys.path — identical on main, not in any CI lane; all 124 pass when invoked from repo root.