### PR TITLE
fix(spells): cantrip tier scaling, ritual casting, OOC save-ends condition release (audit F03-2/F03-3/F03-5)

### DIFF
--- a/servers/engine/combat.py
+++ b/servers/engine/combat.py
@@ -550,10 +550,26 @@ def _commit_expiry(ch: Character, surviving: list[ActiveEffect], expired: list[A
     """Apply an expiry result: keep `surviving`, and if any `expired` effect was the
     concentration twin, clear `ch.concentration` too — when a concentration spell's
     DURATION runs out the spell is over, so the field and the effect stay one source of
-    truth (the inverse of expire_concentration_effects). Returns the expired names."""
+    truth (the inverse of expire_concentration_effects). An expired effect that IMPOSED
+    a condition (a save-ends marker — Hold Person's `paralyzed`) takes that condition
+    with it (F03-5/#819): the duration elapsed, so the victim is freed exactly as a
+    successful repeat save would have freed them. Without this, an out-of-combat phase
+    advance drops the marker but strands the condition FOREVER — every engine path that
+    could lift it (end_repeat_save_effect via next_turn's sweeps, drop_concentration's
+    freed loop) matches on the now-gone marker. This cannot misfire in combat:
+    tick_round_effects exempts repeat-save markers from the round tick, and only
+    add_condition sets `imposes_condition` (always alongside `repeat_save`).
+    Returns the expired names."""
     ch.active_effects = surviving
     if any(eff.concentration for eff in expired):
         ch.concentration = None
+    lifted = {eff.imposes_condition for eff in expired if eff.imposes_condition is not None}
+    if lifted:
+        # Defensive: a SURVIVING marker that still imposes the same condition keeps it
+        # (two save-ends sources on one victim — they normally share the same sweep).
+        lifted -= {e.imposes_condition for e in surviving if e.imposes_condition is not None}
+        if lifted:
+            ch.conditions = [cn for cn in ch.conditions if cn not in lifted]
     return [eff.name for eff in expired]
 
 

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -5249,11 +5249,18 @@ def cast_spell(
     spell: str = "",
     npc_id: str = "",
     id: str = "",
+    as_ritual: bool = False,
 ) -> dict:
     """Cast a spell — works for ANY of the ~339 SRD spells. Consumes a spell slot
     (cantrips use none); upcasts when slot_level exceeds the spell's level; sets
     concentration if the spell concentrates (breaking any prior). If spells_known/
     prepared are set, the spell must be among them (skipped leniently when empty).
+
+    RITUAL CASTING (#813): pass ``as_ritual=True`` for a ritual-tagged spell (Detect
+    Magic, Identify…) to cast it WITHOUT spending a slot — the ritual takes 10 extra
+    minutes instead, so it is refused during active combat. Concentration/duration
+    semantics are unchanged. A normal cast of a ritual spell surfaces
+    ``ritual_available: true`` so you know the slot-free option exists.
 
     For the hand-authored spells the engine fully resolves the effect (returns
     `automated:true` + `effect` with upcast/cantrip-scaled damage/heal). For every
@@ -5290,6 +5297,13 @@ def cast_spell(
     canonical = (curated or srd).get("name", spell_name)
     spell_level = int((curated.get("level", 0) if curated else srd.get("level", 0)) or 0)
     concentrates = bool(curated.get("concentration") if curated else srd.get("concentration"))
+    # Ritual tag (#813): the srd524 records carry `ritual`; curated records may too.
+    is_ritual = bool((curated or {}).get("ritual") or (srd or {}).get("ritual"))
+    if as_ritual and not is_ritual:
+        raise ValueError(
+            f"{canonical} is not a ritual spell — only a ritual-tagged spell can be "
+            f"cast with as_ritual=True. Cast it normally (spending a slot) instead."
+        )
     # The spell's timed duration (if any), normalized from whichever data source carries
     # it — both curated and srd524 records have a `duration` string (see spells.parse_duration).
     duration = spells.parse_duration(curated.get("duration") if curated else srd.get("duration"))
@@ -5311,6 +5325,15 @@ def cast_spell(
         if combat.is_incapacitated(ch):
             incap = ", ".join(cn.value for cn in ch.conditions if cn in combat.INCAPACITATING)
             raise ValueError(f"{ch.name} is incapacitated ({incap}) and cannot cast a spell")
+        # Ritual casting takes 10 extra MINUTES — combat runs in 6-second rounds, so a
+        # ritual can't be performed while combat is active (#813). Rejected BEFORE any
+        # state change (no slot, no concentration), like every other cast rejection.
+        if as_ritual and c.combat.active:
+            raise ValueError(
+                f"cannot cast {canonical} as a ritual during active combat — a ritual "
+                f"takes 10 extra minutes. Cast it normally (spending a slot) or wait "
+                f"until combat ends."
+            )
         # Turn ownership (mirrors attack()): while combat is active and the caster is in
         # the initiative order, an action-cast is legal only on the caster's own turn.
         # An off-turn cast (or an explicitly-declared reaction spell — Shield, Counterspell,
@@ -5339,7 +5362,9 @@ def cast_spell(
         if known and canonical not in known:
             raise ValueError(f"{ch.name} doesn't know or have {canonical!r} prepared")
         slot_used = None
-        if spell_level > 0:
+        # A ritual cast consumes NO slot (#813) — the +10 minutes is the cost; the
+        # spell resolves at its base level (a ritual can't be upcast).
+        if spell_level > 0 and not as_ritual:
             lvl = spell_level if slot_level is None else slot_level
             if lvl < spell_level:
                 raise ValueError(f"cannot cast a level-{spell_level} spell with a level-{lvl} slot")
@@ -5452,6 +5477,13 @@ def cast_spell(
                 str(lv): s.maximum - s.used for lv, s in updated.spell_slots.items()
             },
         }
+        # Ritual surfacing (#813): a ritual cast is told to the DM explicitly (no slot
+        # was spent); a NORMAL cast of a ritual-tagged spell advertises the slot-free
+        # option so the DM learns it exists. Both fields are additive.
+        if as_ritual:
+            result["ritual_cast"] = True
+        elif is_ritual:
+            result["ritual_available"] = True
         # Surface the engine-tracked timed effect (if any) so the DM knows it'll
         # auto-expire — and on whom it's tracked. An ON-HIT rider (#186) is NOT on the
         # target yet, so report it as a `pending_effect` keyed to its target: it lands
@@ -5487,7 +5519,18 @@ def cast_spell(
             result["school"] = srd.get("school")
             result["save_ability"] = srd.get("saving_throw_ability") or None
             result["attack_roll"] = bool(srd.get("attack_roll"))
-            result["base_damage"] = srd.get("damage_roll") or None
+            # Damage-cantrip tier scaling (F03-2 / #808): the srd record stores the
+            # LEVEL-1 dice, but the note below tells the DM to resolve with these
+            # values — so at caster levels 5/11/17 `base_damage` must carry the
+            # tier-scaled dice (an L11 Ray of Frost is 3d8, not 1d8). The original
+            # die is kept additively in `base_damage_level1`. Eldritch Blast (beam-
+            # scaled) and non-scaling cantrips fall back to the verbatim roll + prose.
+            base_damage = srd.get("damage_roll") or None
+            scaled = spells.scaled_cantrip_damage(srd, ch.total_level)
+            if scaled is not None:
+                result["base_damage_level1"] = base_damage
+                base_damage = scaled
+            result["base_damage"] = base_damage
             result["damage_types"] = srd.get("damage_types") or None
             result["upcast"] = srd.get("higher_level") or None
             result["casting_time"] = srd.get("casting_time")

--- a/servers/engine/spells.py
+++ b/servers/engine/spells.py
@@ -59,6 +59,44 @@ def _parse_dice(expr: str) -> tuple[int, int]:
     return int(n or 1), int(sides)
 
 
+_PLAIN_DICE_RE = re.compile(r"^\s*(\d+)d(\d+)\s*$", re.IGNORECASE)
+
+
+def cantrip_tier(caster_level: int) -> int:
+    """A damage cantrip's dice tier at this caster level: 1 base die, then 2/3/4
+    at levels 5/11/17 (the SRD's universal damage-cantrip progression)."""
+    lvl = int(caster_level or 1)
+    return 1 + (lvl >= 5) + (lvl >= 11) + (lvl >= 17)
+
+
+def scaled_cantrip_damage(record: dict, caster_level: int) -> Optional[str]:
+    """Tier-scaled ``NdM`` damage for a STANDARD srd damage cantrip at this caster
+    level, or None when tier scaling does not apply (F03-2 / #808). The srd dump
+    stores the LEVEL-1 dice in ``damage_roll``; for the standard "damage increases
+    ... at levels 5 (2dM), 11 (3dM), and 17 (4dM)" cantrips the structured value the
+    DM is told to roll must be the tier-scaled one. Returns None for:
+
+    * leveled spells (they upcast by slot, not caster level);
+    * Eldritch Blast — excluded BY NAME (audit-hardened): it scales in BEAMS, each
+      its own 1d10 attack roll, so a pooled "3d10" would misstate the mechanic;
+    * cantrips whose ``higher_level`` prose carries no damage increase (Guidance,
+      Resistance: the srd dump stores their 1d4 bonus die as a ``damage_roll``,
+      but they genuinely never scale — N×tier would be wrong the other way);
+    * any non-``NdM`` damage expression (defensive; all 14 are plain today).
+    """
+    if int(record.get("level") or 0) != 0:
+        return None
+    m = _PLAIN_DICE_RE.match(str(record.get("damage_roll") or ""))
+    if m is None:
+        return None
+    if str(record.get("name") or "").strip().lower() == "eldritch blast":
+        return None
+    if "damage increases" not in str(record.get("higher_level") or "").lower():
+        return None
+    n, sides = int(m.group(1)), int(m.group(2))
+    return f"{n * cantrip_tier(caster_level)}d{sides}"
+
+
 def _scale_per_dart(per: str, darts: int) -> str:
     """'1d4+1' x darts -> '{darts}d4+{darts}'."""
     count, sides = _parse_dice(per)

--- a/servers/engine/tests/test_effect_durations.py
+++ b/servers/engine/tests/test_effect_durations.py
@@ -1063,3 +1063,60 @@ def test_drop_concentration_is_a_noop_when_not_concentrating():
     assert out["was_concentrating_on"] is None
     assert out["concentration"] is None
     assert out["freed_targets"] == [] and out["expired_effects"] == []
+
+
+# --- F03-5 (#819): OOC expiry of a save-ends marker must free its condition ---------
+# Out of combat, any phase advance expires minute/round-scale effects — INCLUDING the
+# save-ends marker (Hold Person -> paralyzed). The expiry must lift the condition the
+# marker imposed, or the victim stays paralyzed FOREVER (every engine path that could
+# free them matches on the marker, which is now gone; remove_condition is the only out).
+
+def _ooc_hold(cid):
+    """Cast Hold Person OUT of combat and apply the self-enforcing paralyzed marker."""
+    caster = _hold_caster(cid)
+    foe = _humanoid(cid)
+    out = server.cast_spell(cid, caster, "Hold Person", target_id=foe)
+    server.add_condition(cid, foe, "paralyzed", **{
+        k: out["condition_rider"][k]
+        for k in ("repeat_save_ability", "repeat_save_dc", "source_id", "spell_name")
+    })
+    assert "paralyzed" in server.get_character(cid, foe)["conditions"]
+    return caster, foe
+
+
+def test_ooc_phase_advance_frees_hold_person_victim():
+    """THE BUG (F03-5): advance_time one phase out of combat expires the save-ends
+    marker — the paralyzed condition it imposed must lift WITH it (the minute elapsed;
+    the victim is freed), and the caster's concentration twin clears symmetrically."""
+    cid = server.create_campaign("S")["id"]
+    caster, foe = _ooc_hold(cid)
+    out = server.advance_time(cid, phases=1)
+    expired = {(e["character_id"], e["name"]) for e in out["expired_effects"]}
+    assert (foe, "Hold Person") in expired  # the marker expired (and is surfaced)
+    assert _effects(cid, foe) == []  # marker gone
+    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]  # freed
+    assert server.get_character(cid, caster)["concentration"] is None  # twin cleared
+
+
+def test_short_rest_frees_hold_person_victim():
+    """Same stranding through the short-rest sweep (~1 hour ends every sub-hour effect)."""
+    cid = server.create_campaign("S")["id"]
+    caster, foe = _ooc_hold(cid)
+    server.short_rest(cid, caster)
+    assert _effects(cid, foe) == []
+    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]
+    assert server.get_character(cid, caster)["concentration"] is None
+
+
+def test_plain_buff_clock_expiry_regression_conditions_untouched():
+    """Regression guard: a plain Bless expiry (no imposed condition) behaves exactly as
+    before — effect gone, concentration cleared, pre-existing conditions untouched."""
+    cid = server.create_campaign("S")["id"]
+    cleric = _cleric(cid)
+    server.cast_spell(cid, cleric, "Bless")
+    server.add_condition(cid, cleric, "poisoned")  # unrelated condition must survive
+    out = server.advance_time(cid, phases=1)
+    assert {(e["character_id"], e["name"]) for e in out["expired_effects"]} == {(cleric, "Bless")}
+    assert _effects(cid, cleric) == []
+    assert server.get_character(cid, cleric)["concentration"] is None
+    assert "poisoned" in server.get_character(cid, cleric)["conditions"]

--- a/servers/engine/tests/test_spellcasting.py
+++ b/servers/engine/tests/test_spellcasting.py
@@ -174,3 +174,149 @@ def test_caster_ships_with_a_castable_starter_loadout():
                                   apply_srd_defaults=True)["id"]
     fsheet = server.get_character(cid, ftr)
     assert not fsheet["spells_known"] and not fsheet["spells_prepared"]
+
+
+# --- F03-2 (#808): srd damage-cantrip tier scaling --------------------------------
+# The srd degrade path used to copy the LEVEL-1 damage_roll verbatim into
+# `base_damage` while the note tells the DM to "resolve with the values above" —
+# actively wrong at caster levels 5/11/17. The structured field must carry the
+# tier-scaled dice; the original die survives additively in `base_damage_level1`.
+
+# The 13 cited non-curated damage cantrips (the 14th, Fire Bolt, is curated and
+# already scaled via resolve_effect). Ten tier-scale per their own higher_level
+# prose; Eldritch Blast is beam-scaled (excluded BY NAME — pooled "3d10" would
+# misstate 3 separate 1d10 attack rolls); Guidance/Resistance carry a 1d4 in the
+# srd dump's damage_roll but genuinely never scale (empty higher_level).
+_SCALING_CANTRIPS = {
+    "Acid Splash": "d6",
+    "Chill Touch": "d10",
+    "Poison Spray": "d12",
+    "Produce Flame": "d8",
+    "Ray of Frost": "d8",
+    "Sacred Flame": "d8",
+    "Shocking Grasp": "d8",
+    "Sorcerous Burst": "d8",
+    "Starry Wisp": "d8",
+    "Vicious Mockery": "d6",
+}
+_NON_SCALING_CANTRIPS = ["Eldritch Blast", "Guidance", "Resistance"]
+
+
+@pytest.mark.parametrize("name,die", sorted(_SCALING_CANTRIPS.items()))
+@pytest.mark.parametrize("lvl,tier", [(1, 1), (4, 1), (5, 2), (10, 2), (11, 3), (16, 3), (17, 4), (20, 4)])
+def test_scaled_cantrip_damage_table(name, die, lvl, tier):
+    rec = spells.srd_spell(name)
+    assert spells.scaled_cantrip_damage(rec, lvl) == f"{tier}{die}"
+
+
+@pytest.mark.parametrize("name", _NON_SCALING_CANTRIPS)
+@pytest.mark.parametrize("lvl", [1, 5, 11, 17])
+def test_non_scaling_cantrips_return_none(name, lvl):
+    assert spells.scaled_cantrip_damage(spells.srd_spell(name), lvl) is None
+
+
+def test_leveled_spells_never_tier_scale():
+    assert spells.scaled_cantrip_damage(spells.srd_spell("Fireball"), 17) is None
+
+
+def _wizard_at(cid, level, name="Gale"):
+    w = server.create_character(cid, name, kind="player", class_name="Wizard", level=level,
+                                apply_srd_defaults=True, abilities={"intelligence": 16})["id"]
+    server.learn_spells(cid, w, ["Acid Splash", "Eldritch Blast", "Fireball"])
+    return w
+
+
+@pytest.mark.parametrize("lvl,expected", [(1, "1d6"), (5, "2d6"), (11, "3d6"), (17, "4d6")])
+def test_cast_srd_cantrip_reports_tier_scaled_base_damage(lvl, expected):
+    cid = server.create_campaign("S")["id"]
+    w = _wizard_at(cid, lvl, name=f"Gale{lvl}")
+    out = server.cast_spell(cid, w, "Acid Splash")
+    assert out["automated"] is False
+    assert out["base_damage"] == expected
+    assert out["base_damage_level1"] == "1d6"  # the original die is never lost
+
+
+def test_eldritch_blast_base_damage_stays_per_beam():
+    """Eldritch Blast scales in BEAMS (separate attack roll each) — a pooled '3d10'
+    would be wrong. The structured field stays the per-beam die; the prose explains."""
+    cid = server.create_campaign("S")["id"]
+    w = _wizard_at(cid, 11)
+    out = server.cast_spell(cid, w, "Eldritch Blast")
+    assert out["base_damage"] == "1d10"
+    assert "base_damage_level1" not in out
+    assert "beam" in (out["upcast"] or "").lower()
+
+
+def test_leveled_srd_spell_base_damage_untouched():
+    cid = server.create_campaign("S")["id"]
+    w = _wizard_at(cid, 11)
+    out = server.cast_spell(cid, w, "Fireball")
+    assert out["base_damage"] == "8d6"
+    assert "base_damage_level1" not in out
+
+
+# --- F03-3 (#813): ritual casting --------------------------------------------------
+# cast_spell(as_ritual=True) on a ritual-tagged spell consumes NO slot (the ritual
+# takes +10 minutes instead); concentration/duration semantics are unchanged.
+# as_ritual on a non-ritual spell raises; as_ritual during active combat raises;
+# a normal cast of a ritual spell surfaces `ritual_available: true`.
+
+def _ritual_wizard(cid):
+    w = server.create_character(cid, "Gale", kind="player", class_name="Wizard",
+                                apply_srd_defaults=True, abilities={"intelligence": 16})["id"]
+    server.learn_spells(cid, w, ["Detect Magic", "Magic Missile"])
+    return w
+
+
+def test_ritual_cast_spends_no_slot_and_keeps_concentration():
+    cid = server.create_campaign("S")["id"]
+    w = _ritual_wizard(cid)
+    before = server.get_character(cid, w)["spell_slots"]
+    out = server.cast_spell(cid, w, "Detect Magic", as_ritual=True)
+    assert out["slot_used"] is None
+    assert out["ritual_cast"] is True
+    assert out["concentration"] == "Detect Magic"  # concentration semantics unchanged
+    after = server.get_character(cid, w)["spell_slots"]
+    assert after == before  # not a single slot spent
+    # the engine-tracked timed effect still registers (10 minutes)
+    assert out["active_effect"]["name"] == "Detect Magic"
+
+
+def test_normal_cast_of_ritual_spell_spends_slot_and_flags_ritual_available():
+    cid = server.create_campaign("S")["id"]
+    w = _ritual_wizard(cid)
+    out = server.cast_spell(cid, w, "Detect Magic")
+    assert out["slot_used"] == 1  # today's behavior: the slot is spent
+    assert out["ritual_available"] is True  # ...but the DM learns the option exists
+    assert "ritual_cast" not in out
+
+
+def test_as_ritual_on_non_ritual_spell_rejected_before_any_spend():
+    cid = server.create_campaign("S")["id"]
+    w = _ritual_wizard(cid)
+    with pytest.raises(ValueError, match="not a ritual"):
+        server.cast_spell(cid, w, "Magic Missile", as_ritual=True)
+    sheet = server.get_character(cid, w)
+    assert sheet["spell_slots"]["1"]["used"] == 0  # rejected cleanly, nothing spent
+    assert sheet["concentration"] is None
+
+
+def test_as_ritual_refused_in_active_combat():
+    cid = server.create_campaign("S")["id"]
+    w = _ritual_wizard(cid)
+    foe = server.create_character(cid, "Grunt", kind="monster", max_hp=10)["id"]
+    server.start_combat(cid, [w, foe])
+    with pytest.raises(ValueError, match="combat"):
+        server.cast_spell(cid, w, "Detect Magic", as_ritual=True)
+    sheet = server.get_character(cid, w)
+    assert sheet["spell_slots"]["1"]["used"] == 0
+    assert sheet["concentration"] is None
+
+
+def test_non_ritual_normal_casts_unchanged_no_ritual_fields():
+    """Default-path regression: a plain cast of a non-ritual spell carries neither
+    ritual field (byte-identical for existing callers)."""
+    cid = server.create_campaign("S")["id"]
+    w = _ritual_wizard(cid)
+    out = server.cast_spell(cid, w, "Magic Missile")
+    assert "ritual_cast" not in out and "ritual_available" not in out


### PR DESCRIPTION
Implements three audited, skeptic-verified spell-engine fixes from `docs/audits/ENGINE-AUDIT-2026-06-11.md` (unit 03). Closes #808, closes #813, closes #819.

## F03-2 (#808) — 13/14 damage cantrips handed the DM unscaled level-1 dice at L5/11/17

**Root cause:** the srd degrade path copied `srd.damage_roll` verbatim into `base_damage` while the result note instructs the DM to "resolve with the values above" — actively wrong for any caster ≥ L5 (L11 Ray of Frost reported 1d8, real value 3d8). Only curated Fire Bolt scaled.

**Fix:** new pure helper `spells.scaled_cantrip_damage(record, caster_level)` (tier = 1 + (lvl≥5) + (lvl≥11) + (lvl≥17); `base_damage = f"{N*tier}d{M}"`), applied in cast_spell's srd path keyed on `ch.total_level`. The original die survives additively in `base_damage_level1`. **Eldritch Blast excluded by name** (audit-hardened: beam-scaled — a pooled "3d10" would misstate 3 separate 1d10 attack rolls; it falls back to the verbatim roll + prose). Leveled spells and the curated path untouched.

**One guarded nuance (documented deviation):** the audit census counted "14 cantrips with damage_roll, all plain NdM" — but two of them (Guidance, Resistance) carry their 1d4 *bonus die* in `damage_roll` and genuinely never scale (empty `higher_level`). Blanket N×tier would have made *their* structured field actively wrong in the opposite direction, so scaling additionally requires the record's own "damage increases" higher_level prose. The ten true scalers scale; EB/Guidance/Resistance fall back verbatim. All spec'd test cases pass unchanged.

## F03-3 (#813) — no ritual casting; Detect Magic (top QA utility cast) burned a L1 slot every time

**Root cause:** `srd.ritual` loaded but never read; the slot spend was unconditional (`if spell_level > 0:`); no ritual param existed.

**Fix (exactly the 5-point spec):** additive `as_ritual: bool = False` on cast_spell —
1. requires the spell's ritual tag (`as_ritual` on a non-ritual spell raises);
2. skips the slot spend; concentration/duration semantics unchanged (ritual resolves at base level — no upcast);
3. refused during active combat (ritual = +10 minutes; combat runs in 6s rounds) — both rejections fire **before any state change**, preserving the engine's reject-before-spend discipline;
4. a normal cast of a ritual spell surfaces `ritual_available: true`, a ritual cast surfaces `ritual_cast: true`;
5. default `False` = byte-identical for every existing caller (regression test asserts neither field appears on plain non-ritual casts).

## F03-5 (#819) — OOC expiry of a save-ends marker stranded its condition (Hold Person victim paralyzed FOREVER)

**Root cause (verified chain):** any phase advance routes all characters through `expire_clock_effects`, which drops the rounds-scale save-ends marker with no exemption; `_commit_expiry` cleared concentration only — never `imposes_condition`; once the marker is gone, every condition-lifting path (`end_repeat_save_effect` via next_turn's sweeps, drop_concentration's freed loop) has nothing to match. `remove_condition` was the only out. Short-rest path identical.

**Fix (spec'd, pure helper, no schema):** `_commit_expiry` now lifts `imposes_condition` alongside the expiring marker — the duration elapsed, the victim is freed exactly as a successful repeat save would have done; the caster's concentration twin expires in the same sweep, clearing symmetrically. Cannot misfire in combat: `tick_round_effects` exempts repeat-save markers from the round tick, and only `add_condition` sets `imposes_condition` (always alongside `repeat_save`). Includes a defensive surviving-marker guard (a still-live second marker imposing the same condition keeps it).

## Tests (all red-first; 103 new)

- **F03-2:** table-driven tier matrix across the 13 cited cantrips — 10 scalers × 8 caster levels (1/4/5/10/11/16/17/20) through `scaled_cantrip_damage`, plus EB/Guidance/Resistance → None × 4 tiers, plus integration through cast_spell: Acid Splash 1d6/2d6/3d6/4d6 at 1/5/11/17 with `base_damage_level1` kept; EB stays per-beam 1d10; Fireball (leveled) untouched.
- **F03-3:** ritual cast spends no slot + keeps concentration + registers the timed effect; normal cast spends the slot + flags `ritual_available`; as_ritual on non-ritual raises with nothing spent; as_ritual in active combat raises with nothing spent; plain-cast regression (no ritual fields).
- **F03-5:** OOC Hold Person + rider, `advance_time` one phase → marker expired & surfaced, paralyzed lifted, caster concentration None; same via `short_rest`; plain-Bless expiry regression (unrelated condition untouched).

## Verification

- `uv run --directory servers/engine python -m pytest tests -q -p no:xdist` → **1912 passed**
- `bash qa/fast_gate.sh` → **T0 PASS** (188 deterministic)
- Invariants: no model/schema changes (old snapshots round-trip untouched); engine sole-writer (all mutation under campaign_lock, persisted by the existing save paths); engine-rolls-DM-is-told (scaled dice + ritual fields surfaced in the tool return; expiry surfaced via existing `expired_effects`); wire contracts additive only (optional kwarg + optional result fields).

Findings: F03-2, F03-3, F03-5 — source `docs/audits/ENGINE-AUDIT-2026-06-11.md` + `/tmp/engine-audit/unit-03-verified.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed condition markers remaining stuck when their source effects expire; concentration now properly clears and conditions update accordingly.

* **New Features**
  * Ritual casting now available for ritual-eligible spells without consuming spell slots.
  * Cantrip damage automatically scales based on caster level tier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->