### PR TITLE
fix(economy): fuzzy resolve crash, qty pricing, priceless!=free, equip TELL (audit F09-1/2/3/5-stage-1)

### DIFF
--- a/servers/engine/inventory.py
+++ b/servers/engine/inventory.py
@@ -53,6 +53,33 @@ def gain(ch: Character, gp_amount: float) -> Currency:
     return ch.currency
 
 
+def gp_to_cp(gp_amount: float) -> int:
+    """Exact copper value of a (2-decimal) gp amount — the public face of the
+    Decimal conversion so tool-level totals (unit price x quantity, F09-2) stay
+    copper-exact instead of accumulating float drift."""
+    return _gp_to_cp(gp_amount)
+
+
+def pay_cp(ch: Character, amount_cp: int) -> Currency:
+    """Spend an exact copper amount (making change). Raises on negative or
+    insufficient funds. Copper-exact sibling of pay() for unit x quantity totals."""
+    if amount_cp < 0:
+        raise ValueError("cannot pay a negative amount")
+    have = total_copper(ch.currency)
+    if have < amount_cp:
+        raise ValueError("insufficient funds")
+    ch.currency = _from_copper(have - amount_cp)
+    return ch.currency
+
+
+def gain_cp(ch: Character, amount_cp: int) -> Currency:
+    """Gain an exact copper amount. Copper-exact sibling of gain()."""
+    if amount_cp < 0:
+        raise ValueError("cannot gain a negative amount")
+    ch.currency = _from_copper(total_copper(ch.currency) + amount_cp)
+    return ch.currency
+
+
 def adjust_currency(ch: Character, cp=0, sp=0, ep=0, gp=0, pp=0) -> Currency:
     """Add/subtract specific coin denominations (no auto change-making). Raises if
     any denomination would go negative."""

--- a/servers/engine/itemcatalog.py
+++ b/servers/engine/itemcatalog.py
@@ -108,6 +108,16 @@ def _num(value, default: float = 0.0) -> float:
         return default
 
 
+def _cost(value) -> Optional[float]:
+    """Tri-state listed price (F09-3): a positive price parses like _num; anything
+    else — missing, null, '', unparseable, or 0/'0.00' (how the SRD dump marks
+    every magic item) — is None, meaning "no listed price". Priceless is NOT free:
+    buy_item demands an explicit cost_gp when this is None instead of silently
+    charging 0 gp for a Bag of Holding."""
+    n = _num(value, default=0.0)
+    return n if n > 0 else None
+
+
 def _int(value, default: int = 0) -> int:
     """Integer fields (AC). Like _num but coerces to int and tolerates strings/floats/
     None — a non-numeric value (e.g. a homebrew pack with ac_base:'plate') degrades to
@@ -158,7 +168,7 @@ def _flatten(model: str, fields: dict) -> dict:
             "rarity": "",
             "requires_attunement": False,
             "weight": _num(fields.get("weight")),
-            "cost": _num(fields.get("cost")),
+            "cost": _cost(fields.get("cost")),
             "description": fields.get("desc", "") or "",
             "properties": [
                 p for p, on in (("simple", fields.get("is_simple")),
@@ -181,7 +191,7 @@ def _flatten(model: str, fields: dict) -> dict:
             "rarity": "",
             "requires_attunement": False,
             "weight": _num(fields.get("weight")),
-            "cost": _num(fields.get("cost")),
+            "cost": _cost(fields.get("cost")),
             "description": fields.get("desc", "") or "",
             "properties": props,
             "ac": _int(fields.get("ac_base")),
@@ -195,7 +205,7 @@ def _flatten(model: str, fields: dict) -> dict:
         "rarity": (fields.get("rarity") or "").strip(),
         "requires_attunement": bool(fields.get("requires_attunement")),
         "weight": _num(fields.get("weight")),
-        "cost": _num(fields.get("cost")),
+        "cost": _cost(fields.get("cost")),
         "description": fields.get("desc", "") or "",
         "properties": [],
     }
@@ -262,7 +272,9 @@ def resolve(name: str) -> Optional[dict]:
         return rec
     matches = find(name, limit=2)
     if len(matches) == 1:
-        return idx.get(matches[0].lower())
+        # find() returns the flattened records themselves (F09-1: this used to
+        # call .lower() on the dict and crash every unique-substring match).
+        return matches[0]
     return None
 
 

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -5816,14 +5816,65 @@ def _apply_item_catalog(
     )
 
 
+def _equip_mechanics(ch: Character, item_name: str, equipped: bool) -> Optional[dict]:
+    """F09-5 stage 1 — TELL, don't enforce: report the mechanical consequences of
+    an equip/unequip so the DM can apply them through the existing writer paths.
+    The engine deliberately does NOT auto-write armor_class here: AC effects (e.g.
+    Mage Armor) flow through update_character today, and a silent equip-side write
+    would fight that path (stage 2 / #806 owns the AC-ownership design). Returns
+    None for items with no catalog mechanics (free-text gear) so the response stays
+    exactly the pre-existing payload."""
+    rec = itemcatalog.resolve(item_name)
+    if rec is None:
+        return None
+    current_ac, _ = _effective_armor_class(ch)
+    if rec.get("kind") == "armor" and rec.get("ac"):
+        cat_ac = int(rec["ac"])
+        if "shield" in rec["name"].lower():
+            # The SRD flattens a shield's ac_base as 2 — it is a +2 bonus on top
+            # of the wearer's AC, not a base AC of 2.
+            suggested = current_ac + cat_ac if equipped else current_ac - cat_ac
+            basis = f"shield {'+' if equipped else '-'}{cat_ac}"
+        elif equipped:
+            suggested = cat_ac
+            basis = f"base AC {cat_ac}; apply the armor's DEX-mod rule on top"
+        else:
+            suggested = 10 + ch.ability_modifier(Ability.DEX)
+            basis = "unarmored baseline 10 + DEX"
+        return {
+            "applied": False,
+            "current_ac": current_ac,
+            "suggested_ac": suggested,
+            "ac_delta": suggested - current_ac,
+            "note": (
+                f"AC does not change on its own ({basis}): call "
+                f"update_character(armor_class={suggested}) to apply it"
+            ),
+        }
+    if rec.get("damage"):
+        return {
+            "applied": False,
+            "damage": rec["damage"],
+            "damage_type": rec.get("damage_type", ""),
+            "note": (
+                "weapon stats are not auto-applied: pass damage_dice="
+                f"{rec['damage']!r} (plus ability/magic bonuses) and the matching "
+                "attack_bonus to attack()"
+            ),
+        }
+    return None
+
+
 @mcp.tool()
 def lookup_item(name: str) -> dict:
     """Look up a single SRD item by name (case-insensitive) in the bundled
     ~960-item catalog (magic items, weapons, armor, gear, potions, etc.). Returns
     the flattened record — {name, kind, rarity, requires_attunement, weight, cost,
     description, properties} plus damage/damage_type for weapons and ac for armor —
-    or {"error", "suggestions"} on a miss. Use this (then add_item with
-    item_name=...) to grant a REAL item instead of free-texting it."""
+    or {"error", "suggestions"} on a miss. `cost` is the listed price in gp, or
+    null when the SRD lists no price (every magic item) — null means the DM sets
+    the price, NOT that it is free. Use this (then add_item with item_name=...)
+    to grant a REAL item instead of free-texting it."""
     rec = itemcatalog.resolve(name)
     if rec is None:
         return {"error": f"no item named {name!r} in the SRD catalog",
@@ -5880,13 +5931,22 @@ def remove_item(campaign_id: str, character_id: str, name: str, quantity: int = 
 
 @mcp.tool()
 def equip_item(campaign_id: str, character_id: str, name: str, equipped: bool = True) -> dict:
-    """Equip an item (or unequip with equipped=False)."""
+    """Equip an item (or unequip with equipped=False). Equipping is ADVISORY for
+    mechanics: for catalog-recognized armor/shields/weapons the response carries a
+    `mechanics` block ({suggested_ac, ac_delta, note} or {damage, damage_type,
+    note}) — the engine does NOT change armor_class or attacks on its own, so
+    apply the AC via update_character(armor_class=...) and pass weapon stats to
+    attack()."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _char(c, character_id)
         it = inventory.set_equipped(ch, name, equipped)
         save_campaign(c)
-        return it.model_dump()
+        out = it.model_dump()
+        mech = _equip_mechanics(ch, it.name, equipped)
+        if mech is not None:
+            out["mechanics"] = mech
+        return out
 
 
 @mcp.tool()
@@ -5918,42 +5978,72 @@ def buy_item(
     campaign_id: str, character_id: str, name: str = "", cost_gp: float = -1.0, quantity: int = 1,
     weight: float = 0.0, requires_attunement: Optional[bool] = None, description: str = "", item_name: str = "",
 ) -> dict:
-    """Buy an item: pay cost_gp (making change from the purse) and add it to inventory.
-    Raises if the character can't afford it.
+    """Buy an item: pay cost_gp PER UNIT x quantity (making change from the purse)
+    and add it to inventory. Raises if the character can't afford the total.
 
     Pass `item_name` to buy a REAL SRD item by name: name, weight, attunement, a
     rich description, AND the catalog price are filled from the bundled catalog
     (leave `cost_gp` unset to charge the SRD price, or pass `cost_gp` to override —
-    e.g. a haggled or marked-up price). Omit `item_name` for the original free-text
-    path (then `name` and `cost_gp` are required)."""
+    e.g. a haggled or marked-up price). Items with NO listed SRD price (every magic
+    item) require an explicit cost_gp — the DM sets the price (cost_gp=0 only for a
+    deliberate free grant; or just use add_item). Omit `item_name` for the original
+    free-text path (then `name` and `cost_gp` are required).
+
+    Returns the updated purse + inventory plus {unit_cost_gp, total_cost_gp}."""
     name, weight, requires_attunement, description, rec = _apply_item_catalog(
         item_name, name, weight, requires_attunement, description
     )
     if cost_gp < 0:  # sentinel: caller didn't state a price
-        cost_gp = rec.get("cost", 0.0) if rec else -1.0
-        if cost_gp < 0:
+        catalog_cost = rec.get("cost") if rec else None
+        if catalog_cost is None:
+            if rec is not None:  # resolved, but the SRD lists no price (F09-3: priceless != free)
+                raise ValueError(
+                    f"{rec['name']!r} has no listed price in the SRD catalog — pass an "
+                    "explicit cost_gp (the DM sets the price; cost_gp=0 only if deliberately free)"
+                )
             raise ValueError("buy_item needs cost_gp (or an item_name that resolves in the catalog)")
+        cost_gp = catalog_cost
     if not name:
         raise ValueError("buy_item needs a name (or an item_name that resolves in the catalog)")
+    if quantity <= 0:
+        raise ValueError("quantity must be positive")
+    total_cp = inventory.gp_to_cp(cost_gp) * int(quantity)  # F09-2: unit x qty, copper-exact
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _char(c, character_id)
-        inventory.pay(ch, cost_gp)
+        inventory.pay_cp(ch, total_cp)
         inventory.add_item(ch, name, quantity, weight, requires_attunement, description)
         save_campaign(c)
-        return {"currency": ch.currency.model_dump(), "inventory": [i.model_dump() for i in ch.inventory]}
+        return {
+            "currency": ch.currency.model_dump(),
+            "inventory": [i.model_dump() for i in ch.inventory],
+            "unit_cost_gp": float(cost_gp),
+            "total_cost_gp": total_cp / 100,
+        }
 
 
 @mcp.tool()
 def sell_item(campaign_id: str, character_id: str, name: str, price_gp: float, quantity: int = 1) -> dict:
-    """Sell an item: remove it and add price_gp to the purse."""
+    """Sell an item: remove `quantity` of it and add price_gp PER UNIT x quantity
+    to the purse. Returns the updated purse + inventory plus {unit_price_gp,
+    total_price_gp}."""
+    if quantity <= 0:
+        raise ValueError("quantity must be positive")
+    if price_gp < 0:
+        raise ValueError("cannot gain a negative amount")
+    total_cp = inventory.gp_to_cp(price_gp) * int(quantity)  # F09-2 mirror: unit x qty
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _char(c, character_id)
         inventory.remove_item(ch, name, quantity)
-        inventory.gain(ch, price_gp)
+        inventory.gain_cp(ch, total_cp)
         save_campaign(c)
-        return {"currency": ch.currency.model_dump(), "inventory": [i.model_dump() for i in ch.inventory]}
+        return {
+            "currency": ch.currency.model_dump(),
+            "inventory": [i.model_dump() for i in ch.inventory],
+            "unit_price_gp": float(price_gp),
+            "total_price_gp": total_cp / 100,
+        }
 
 
 @mcp.tool()

--- a/servers/engine/tests/test_itemcatalog.py
+++ b/servers/engine/tests/test_itemcatalog.py
@@ -71,7 +71,11 @@ def test_flattened_record_shape():
         assert key in rec, key
     assert isinstance(rec["properties"], list)
     assert isinstance(rec["requires_attunement"], bool)
-    assert isinstance(rec["weight"], float) and isinstance(rec["cost"], float)
+    assert isinstance(rec["weight"], float)
+    # cost is TRI-STATE (F09-3): None = no listed price (every magic item);
+    # a priced item carries a float.
+    assert rec["cost"] is None
+    assert isinstance(itemcatalog.resolve("Longsword")["cost"], float)
 
 
 def test_find_potion_returns_matches():
@@ -96,8 +100,22 @@ def test_resolve_unknown_returns_none_and_suggests():
 
 
 def test_resolve_loose_substring_when_unambiguous():
-    # surrounding whitespace + a unique substring still resolves
-    assert itemcatalog.resolve("  bag of holding  ")["name"] == "Bag of Holding"
+    # F09-1: a TRUE substring (not collapsing to the exact index key) + surrounding
+    # whitespace resolves via the fuzzy branch — this used to raise AttributeError
+    # ('dict' object has no attribute 'lower') on every unique-substring match.
+    assert itemcatalog.resolve("  bag of hold  ")["name"] == "Bag of Holding"
+
+
+def test_resolve_unique_substring_returns_the_record():
+    # F09-1: the fuzzy branch returns the full catalog record, same shape as exact.
+    rec = itemcatalog.resolve("bag of hold")
+    assert rec is not None and rec["name"] == "Bag of Holding"
+    assert rec["kind"] == "wondrous"
+
+
+def test_resolve_ambiguous_substring_returns_none():
+    # 2+ matches stay ambiguous -> None (the caller offers find()/suggest()).
+    assert itemcatalog.resolve("potion of") is None
 
 
 def test_pack_precedence_srd_wins_and_pack_adds(tmp_path, monkeypatch):
@@ -289,3 +307,175 @@ def test_buy_item_freetext_path_unchanged(cid):
     out = server.buy_item(cid, "grett", "Torch", cost_gp=1)
     assert out["currency"]["gp"] == 19
     assert _item(out["inventory"], "Torch")["name"] == "Torch"
+
+
+def _cp_total(cur: dict) -> int:
+    return cur["cp"] + cur["sp"] * 10 + cur["ep"] * 50 + cur["gp"] * 100 + cur["pp"] * 1000
+
+
+# --- F09-1: fuzzy resolve through the tool path (the live-repro surface) -----
+
+
+def test_lookup_item_tool_fuzzy_substring_resolves():
+    # F09-1 live repro: the fuzzy lookup used to surface as a raw MCP tool error.
+    rec = server.lookup_item("bag of hold")
+    assert rec["name"] == "Bag of Holding" and "error" not in rec
+
+
+# --- F09-3: priceless != free --------------------------------------------------
+
+
+def test_unpriced_magic_item_cost_is_none():
+    # The SRD dump stores 0 / "0.00" for every magic item — that means "no listed
+    # price", not "free". Flatten emits None; a real price survives exactly.
+    assert itemcatalog.resolve("Bag of Holding")["cost"] is None
+    assert itemcatalog.resolve("Candle")["cost"] == 0.01  # sub-gp price preserved
+
+
+def test_no_catalog_item_flattens_to_zero_cost():
+    # Census guard (F09-3): nothing in the index is "free by accident" — every
+    # record either carries a positive price or None. The SRD split is exactly
+    # 760 unpriced (757 magic items + 3 unpriced mundane index entries) / 200 priced.
+    records = list(itemcatalog._index().values())
+    zero_or_negative = [r["name"] for r in records if r["cost"] is not None and r["cost"] <= 0]
+    assert zero_or_negative == []
+    assert sum(1 for r in records if r["cost"] is None) == 760
+
+
+def test_lookup_item_reports_unpriced_cost_as_null():
+    # lookup_item/find_items show cost: null honestly (LLM-read payload).
+    assert server.lookup_item("Bag of Holding")["cost"] is None
+    out = server.find_items("Bag of Holding", limit=1)
+    assert out["items"][0]["cost"] is None
+
+
+def test_buy_unpriced_item_requires_explicit_cost(cid):
+    server.adjust_currency(cid, "grett", gp=50)
+    before = server.get_character(cid, "grett")
+    with pytest.raises(ValueError, match="cost_gp"):
+        server.buy_item(cid, "grett", item_name="Bag of Holding")
+    # the error names the gap (the item with no listed price)
+    with pytest.raises(ValueError, match="no listed price"):
+        server.buy_item(cid, "grett", item_name="Bag of Holding")
+    # nothing persisted: purse unchanged, bag NOT granted
+    after = server.get_character(cid, "grett")
+    assert _cp_total(after["currency"]) == _cp_total(before["currency"])
+    assert all(i["name"] != "Bag of Holding" for i in after["inventory"])
+
+
+def test_buy_unpriced_item_with_explicit_cost_works(cid):
+    server.adjust_currency(cid, "grett", gp=500)
+    out = server.buy_item(cid, "grett", item_name="Bag of Holding", cost_gp=400)
+    assert out["currency"]["gp"] == 100
+    assert _item(out["inventory"], "Bag of Holding")
+
+
+def test_buy_item_explicit_zero_cost_is_a_deliberate_free_grant(cid):
+    # cost_gp=0 stays expressible as the DM's explicit choice (a gift/reward).
+    before = server.get_character(cid, "grett")
+    out = server.buy_item(cid, "grett", item_name="Bag of Holding", cost_gp=0)
+    assert _cp_total(out["currency"]) == _cp_total(before["currency"])
+    assert _item(out["inventory"], "Bag of Holding")
+
+
+# --- F09-2: unit price x quantity ---------------------------------------------
+
+
+def test_buy_item_charges_unit_price_times_quantity(cid):
+    server.adjust_currency(cid, "grett", gp=100)
+    out = server.buy_item(cid, "grett", item_name="Potion of Healing", quantity=2)
+    assert out["currency"]["gp"] == 0  # 100 - 50 x 2
+    assert out["unit_cost_gp"] == 50.0
+    assert out["total_cost_gp"] == 100.0
+    assert _item(out["inventory"], "Potion of Healing")["quantity"] == 2
+
+
+def test_buy_item_insufficient_for_total_raises_and_persists_nothing(cid):
+    server.adjust_currency(cid, "grett", gp=100)  # enough for 1 unit, not 5
+    before = server.get_character(cid, "grett")
+    with pytest.raises(ValueError, match="insufficient funds"):
+        server.buy_item(cid, "grett", item_name="Potion of Healing", quantity=5)
+    after = server.get_character(cid, "grett")
+    assert _cp_total(after["currency"]) == _cp_total(before["currency"])
+    assert after["inventory"] == before["inventory"]
+
+
+def test_buy_item_sub_cp_exact_for_fractional_prices(cid):
+    server.adjust_currency(cid, "grett", gp=1)
+    before = server.get_character(cid, "grett")
+    out = server.buy_item(cid, "grett", item_name="Candle", quantity=7)  # 0.01 gp each
+    assert _cp_total(before["currency"]) - _cp_total(out["currency"]) == 7  # exactly 7 cp
+    assert out["unit_cost_gp"] == 0.01
+    assert out["total_cost_gp"] == 0.07
+    assert _item(out["inventory"], "Candle")["quantity"] == 7
+
+
+def test_buy_item_rejects_non_positive_quantity(cid):
+    server.adjust_currency(cid, "grett", gp=10)
+    before = server.get_character(cid, "grett")
+    with pytest.raises(ValueError, match="quantity"):
+        server.buy_item(cid, "grett", "Torch", cost_gp=1, quantity=0)
+    after = server.get_character(cid, "grett")
+    assert _cp_total(after["currency"]) == _cp_total(before["currency"])
+
+
+def test_sell_item_credits_unit_price_times_quantity(cid):
+    server.add_item(cid, "grett", name="Pelt", quantity=3)
+    before = server.get_character(cid, "grett")
+    out = server.sell_item(cid, "grett", "Pelt", price_gp=0.5, quantity=3)
+    assert _cp_total(out["currency"]) - _cp_total(before["currency"]) == 150  # 0.5 gp x 3
+    assert out["unit_price_gp"] == 0.5
+    assert out["total_price_gp"] == 1.5
+    assert all(i["name"] != "Pelt" for i in out["inventory"])
+
+
+# --- F09-5 stage 1: equip TELLs the mechanical consequences --------------------
+
+
+def test_equip_catalog_armor_tells_suggested_ac(cid):
+    server.add_item(cid, "grett", item_name="Plate Armor")
+    out = server.equip_item(cid, "grett", "Plate Armor")
+    assert out["equipped"] is True
+    mech = out["mechanics"]
+    assert mech["applied"] is False  # stage 1 is TELL-only
+    assert mech["suggested_ac"] == 18
+    assert mech["ac_delta"] == 18 - mech["current_ac"]
+    assert "update_character(armor_class=18)" in mech["note"]
+    # the engine did NOT silently change AC (stage 2 / #806 owns enforcement)
+    assert server.get_character(cid, "grett")["armor_class"] == mech["current_ac"]
+
+
+def test_equip_shield_tells_plus_two_delta(cid):
+    server.add_item(cid, "grett", item_name="Shield")
+    out = server.equip_item(cid, "grett", "Shield")
+    mech = out["mechanics"]
+    assert mech["ac_delta"] == 2  # a shield is +2 ON TOP of current AC, not "AC 2"
+    assert mech["suggested_ac"] == mech["current_ac"] + 2
+    unequip = server.equip_item(cid, "grett", "Shield", equipped=False)
+    assert unequip["mechanics"]["ac_delta"] == -2
+
+
+def test_unequip_body_armor_suggests_unarmored_baseline(cid):
+    server.add_item(cid, "grett", item_name="Plate Armor")
+    server.equip_item(cid, "grett", "Plate Armor")
+    out = server.equip_item(cid, "grett", "Plate Armor", equipped=False)
+    sheet = server.get_character(cid, "grett")
+    dex_mod = (sheet["abilities"]["dexterity"] - 10) // 2
+    assert out["mechanics"]["suggested_ac"] == 10 + dex_mod
+
+
+def test_equip_catalog_weapon_tells_attack_implications(cid):
+    server.add_item(cid, "grett", item_name="Longsword")
+    out = server.equip_item(cid, "grett", "Longsword")
+    mech = out["mechanics"]
+    assert mech["applied"] is False
+    assert mech["damage"] == "1d8" and mech["damage_type"] == "slashing"
+    assert "attack" in mech["note"]
+
+
+def test_equip_freetext_item_payload_unchanged(cid):
+    # additive regression: non-catalog items return exactly today's payload.
+    server.add_item(cid, "grett", name="lucky pebble")
+    out = server.equip_item(cid, "grett", "lucky pebble")
+    assert out["equipped"] is True
+    assert "mechanics" not in out


### PR DESCRIPTION
Implements the audited, skeptic-verified economy fix set from `docs/audits/ENGINE-AUDIT-2026-06-11.md` (unit 09).

Closes #781 · Closes #789 · Closes #798 · Refs #806 (stage 1 only)

## Root causes → fixes

### F09-1 (#781) — `itemcatalog.resolve()` AttributeError on every unique-substring match
- **Root cause:** `resolve()`'s fuzzy branch did `idx.get(matches[0].lower())`, but `find()` returns `list[dict]` — every unique-substring match (`"bag of hold"`) crashed as a raw MCP tool error. The branch never worked; the existing test's input collapsed to the exact index key.
- **Fix:** return `matches[0]` (the record — same live lru-cached dict as the exact path, identical exposure). 0 / 2+ matches still return `None`.

### F09-2 (#789) — `buy_item` charged unit price ONCE regardless of quantity; `sell_item` mirrored
- **Root cause:** `inventory.pay(ch, cost_gp)` once, then `add_item(..., quantity)` — 5 potions @ 50 gp cost 50 gp. Sell gained the unit price once for a whole stack.
- **Fix:** total = unit × qty, **copper-exact** via new `inventory.gp_to_cp` + `pay_cp`/`gain_cp` (`pay`/`gain` untouched — #808/F09-11 owns their denomination rework). Additive response fields `{unit_cost_gp, total_cost_gp}` / `{unit_price_gp, total_price_gp}`. Failure ordering preserved: no save until end, an insufficient-funds raise persists nothing.

### F09-3 (#798) — 760/960 catalog items (every magic item) purchasable for 0 gp
- **Root cause:** the SRD dump encodes "no listed price" as `0` / `"0.00"` (757 MagicItem + 3 Item records — exactly the audit's 760-falsy census); `_num()` flattened that to `0.0` and `buy_item`'s `rec.get("cost", 0.0)` sentinel paid it. A Bag of Holding was free.
- **Fix:** flatten emits tri-state `cost: None` for non-positive/missing prices (`_cost()`; catalog dict is module-local, never persisted — no `_StrictModel` exposure). `buy_item` on an unpriced item raises an actionable `ValueError` naming the item and `cost_gp` ("no listed price … the DM sets the price"). Explicit `cost_gp=0` stays expressible as a deliberate free grant. `lookup_item`/`find_items` report `cost: null` honestly (LLM-read payload, not a frozen viewer/move wire contract).
- **Data note (validated against current main):** the issue text said `cost: null/""`; the fixture actually stores `0`/`"0.00"`. The fix maps any non-positive listed cost to `None` — this reproduces the verified 760/200 split exactly and is the only reading that actually closes the live free-buy repro.

### F09-5 stage 1 (#806) — `equip_item` 100% cosmetic → TELL the DM the mechanical consequences
- **Fix (v1 advisory ONLY):** equip/unequip of catalog-recognized gear adds an additive `mechanics` block:
  - armor/shields: `{applied: false, current_ac (via the effective-AC path `_effective_armor_class`), suggested_ac, ac_delta, note: "call update_character(armor_class=N) to apply"}`. A shield is reported as **+2 on top of current AC**, not "AC 2"; unequip mirrors (body armor suggests the 10+DEX unarmored baseline).
  - weapons: `{applied: false, damage, damage_type, note: pass attack_bonus/damage_dice to attack()}`.
- The engine still does **not** auto-write `armor_class` — stage 2 (auto-apply, slot rules, the two-writer AC-ownership decision vs Mage-Armor-style `update_character` flows) deliberately stays open in #806. Free-text items return exactly the prior payload (additive regression-tested).

## Invariants
- Engine sole-writer: all mutations under `campaign_lock`, save-at-end-only; no new persisted model fields (old snapshots round-trip untouched).
- Additive wire: only new response keys on LLM-read tool returns; free-text paths byte-identical.
- TELL pattern: mechanical effects surfaced in the tool return the DM reads (F09-5 v1), enforcement staged.

## Tests
- `servers/engine/tests/test_itemcatalog.py`: 46 tests (was 27; +19 new) — fuzzy/ambiguous resolve incl. the live tool-path repro; tri-state cost + census guard (0 zero-cost records, exactly 760 unpriced); unpriced-buy raises naming `cost_gp` + persists nothing; explicit-cost and explicit-zero grants; qty×unit pricing, insufficient-at-total persists nothing, sub-cp exactness (Candle 0.01 × 7 = exactly 7 cp), response fields; sell mirror; equip TELL matrix (plate, shield ±2, unequip baseline, weapon, free-text unchanged, AC not auto-applied). Two existing tests updated per spec (the dead-substring lookalike, the record-shape cost assert).
- Full engine suite: **1824 passed** (single-process). `qa/fast_gate.sh` Tier-0: **PASS**.
- Live re-run of all four audit repros: fuzzy resolve OK, qty-5 buy raises insufficient-funds, BoH free-buy now raises naming the gap, plate equip TELLs `suggested_ac=18 / ac_delta` vs effective AC.

DO NOT MERGE without review — audited fix set, v1.0.5 milestone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Equipment now displays suggested mechanics when equipped: armor class for armor/shields and damage parameters for weapons.
  * Improved item purchasing and selling with better handling of unpriced catalog items.

* **Bug Fixes**
  * Fixed catalog item substring matching that was causing incorrect resolution.

* **Tests**
  * Expanded test coverage for item pricing, transaction mechanics, and equipment suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->