### PR TITLE
fix(combat): Multiattack counting-clause parser + monster save proficiencies / CR-derived PB at spawn (audit F01-1, F01-2)

### DIFF
--- a/servers/engine/bestiary.py
+++ b/servers/engine/bestiary.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import functools
 import json
+import math
 import re
+from fractions import Fraction
 from pathlib import Path
 from typing import Optional
 
@@ -202,7 +204,9 @@ def _authored_entries() -> tuple[dict[str, dict], tuple[str, ...]]:
                 "abilities": _authored_abilities(row.get("abilities")),
                 "challenge_rating": _norm_cr(row.get("challenge_rating", row.get("cr", "0"))),
                 "experience_points": int(row.get("experience_points", row.get("xp", 0)) or 0),
-                "proficiency_bonus": int(row.get("proficiency_bonus", 2) or 2),
+                # 0 == "not specified" so the stat-block flattening can fall back to
+                # the CR-derived PB (F01-2); an authored explicit value still wins.
+                "proficiency_bonus": int(row.get("proficiency_bonus") or 0),
                 "initiative_bonus": int(row.get("initiative_bonus", 0) or 0),
                 "damage_resistances": _as_list(row.get("damage_resistances")),
                 "damage_immunities": _as_list(row.get("damage_immunities")),
@@ -239,6 +243,22 @@ def _norm_cr(cr) -> str:
     if val in fractions:
         return fractions[val]
     return str(int(val))
+
+
+def _pb_from_cr(cr: str) -> int:
+    """Standard 5e proficiency bonus for a challenge rating: PB = 2 + (⌈CR⌉−1)//4
+    (CR 0–4 → +2, 5–8 → +3, 9–12 → +4, 13–16 → +5, 17–20 → +6, 21–24 → +7,
+    25–28 → +8, 29–30 → +9). The srd524 Creature dump carries
+    ``proficiency_bonus: null`` for EVERY creature, so the old flat-2 fallback
+    flattened all 344 stat blocks to PB 2 — wrong saves, skill checks, and grapple
+    DCs for every high-CR monster (audit F01-2, #773). Accepts the engine's
+    canonical CR strings ('0', '1/8', '1/4', '1/2', '1'..'30'); unparseable input
+    keeps the conservative 2. Pure."""
+    try:
+        val = float(Fraction(str(cr).strip()))
+    except (ValueError, ZeroDivisionError):
+        return 2
+    return 2 + (max(math.ceil(val), 1) - 1) // 4
 
 
 def _as_list(value) -> list[str]:
@@ -335,7 +355,8 @@ def _stat_block_from_authored(entry: dict, fallback_name: str) -> dict:
         "abilities": dict(f.get("abilities") or {}),
         "cr": cr,
         "xp": xp,
-        "proficiency_bonus": int(f.get("proficiency_bonus") or 2),
+        # srd524 stores proficiency_bonus as null universally — derive from CR (F01-2).
+        "proficiency_bonus": int(f.get("proficiency_bonus") or _pb_from_cr(cr)),
         "initiative_bonus": int(f.get("initiative_bonus") or 0),
         "damage_resistances": _as_list(f.get("damage_resistances")),
         "damage_immunities": _as_list(f.get("damage_immunities")),
@@ -389,7 +410,8 @@ def stat_block(name: str) -> Optional[dict]:
         "abilities": abilities,
         "cr": cr,
         "xp": xp,
-        "proficiency_bonus": int(f.get("proficiency_bonus") or 2),
+        # srd524 stores proficiency_bonus as null universally — derive from CR (F01-2).
+        "proficiency_bonus": int(f.get("proficiency_bonus") or _pb_from_cr(cr)),
         "initiative_bonus": int(f.get("initiative_bonus") or 0),
         "damage_resistances": _as_list(f.get("damage_resistances")),
         "damage_immunities": _as_list(f.get("damage_immunities")),

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -625,6 +625,12 @@ class Character(_StrictModel):
     skill_proficiencies: list[str] = Field(default_factory=list)
     skill_expertise: list[str] = Field(default_factory=list)
     saving_throw_proficiencies: list[Ability] = Field(default_factory=list)
+    # Printed-total escape hatch for monster saves whose source data doesn't decompose
+    # as ability mod + CR-derived proficiency bonus (4/344 srd524 quirks, e.g. the
+    # Octopus's CON 30). Keys are Ability values ('dex'); consulted FIRST by
+    # saving_throw_bonus. Set at spawn time by _monster_character_from_statblock.
+    # Empty == today's behavior; old snapshots round-trip (audit F01-2, #773).
+    save_bonus_overrides: dict[str, int] = Field(default_factory=dict)
 
     # vitals
     armor_class: int = 10
@@ -804,6 +810,11 @@ class Character(_StrictModel):
         return bonus
 
     def saving_throw_bonus(self, ability: Ability) -> int:
+        # Printed-total override first (monster spawns whose stat-block save totals
+        # don't decompose as mod + PB — see save_bonus_overrides; F01-2, #773).
+        override = self.save_bonus_overrides.get(ability.value)
+        if override is not None:
+            return override
         bonus = self.ability_modifier(ability)
         if ability in self.saving_throw_proficiencies:
             bonus += self.proficiency_bonus

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1940,6 +1940,57 @@ def _bump_intel(c: Campaign, slug: str, tier: int) -> None:
     c.bestiary_intel[slug] = max(c.bestiary_intel.get(slug, 0), int(tier))
 
 
+def _monster_character_from_statblock(sb: dict, label: str, *, location_id=None) -> Character:
+    """Build a combat-ready monster Character from a bestiary stat block — the SINGLE
+    construction path shared by spawn_monster and _spawn_creature_chars (F01-2, #773;
+    the two hand-rolled ctors had drifted: the wandering path silently lost Parry —
+    F01-11). Transfers abilities, AC/HP/hit dice, the CR-derived proficiency bonus,
+    initiative, R/I/V + condition immunities, Parry, actions-on-notes, XP value, and
+    the creature slug — plus the creature's PRINTED save proficiencies:
+      - ``saving_throw_proficiencies``: a flag per save the stat block lists (with the
+        CR-derived PB, mod + PB reproduces the printed total for 128/132 creatures);
+      - ``save_bonus_overrides``: the printed total for the residual srd524 data
+        quirks, so ``saving_throw_bonus`` == the printed stat block for ALL creatures.
+    Pure construction: the caller registers the Character on the campaign and saves
+    (sole-writer), anchoring at ``location_id`` (wandering) or leaving it None."""
+    scores = AbilityScores(**{_SHORT_TO_FULL_AB[k]: v for k, v in sb["abilities"].items()})
+    actions_note = " | ".join(f"{a['name']}: {a['desc']}" for a in sb["actions"][:10])
+    summary = f"CR {sb['cr']}, {sb['xp']} XP. {sb['size']} {sb['type']}. Actions: {actions_note}"
+    pb = int(sb["proficiency_bonus"])
+    save_profs: list[Ability] = []
+    overrides: dict[str, int] = {}
+    for short, printed in (sb.get("saves") or {}).items():
+        try:
+            ab = Ability(short)
+        except ValueError:
+            continue  # defensive: unknown ability key in authored data
+        save_profs.append(ab)
+        if scores.modifier(ab) + pb != int(printed):
+            overrides[ab.value] = int(printed)
+    return Character(
+        name=label,
+        kind="monster",
+        abilities=scores,
+        max_hp=sb["hp"],
+        current_hp=sb["hp"],
+        armor_class=sb["ac"],
+        hit_dice=sb["hit_dice"],
+        proficiency_bonus=pb,
+        saving_throw_proficiencies=save_profs,
+        save_bonus_overrides=overrides,
+        initiative_bonus=sb["initiative_bonus"] or scores.modifier(Ability.DEX),
+        damage_resistances=sb["damage_resistances"],
+        damage_immunities=sb["damage_immunities"],
+        damage_vulnerabilities=sb["damage_vulnerabilities"],
+        condition_immunities=sb["condition_immunities"],
+        parry=bestiary.parry_bonus(sb),
+        notes=summary,
+        xp_value=sb["xp"],
+        location_id=location_id,
+        creature_slug=bestiary.creature_slug(sb["name"]),
+    )
+
+
 @mcp.tool()
 def spawn_monster(campaign_id: str, name: str = "", count: int = 1,
                   monster: str = "", monster_name: str = "", creature: str = "") -> dict:
@@ -1970,9 +2021,6 @@ def spawn_monster(campaign_id: str, name: str = "", count: int = 1,
             sugg = [s for s in ("Bandit", "Guard", "Cultist", "Tough", "Scout") if bestiary.resolve(s)]
         return {"error": f"no creature named {name!r} in the bestiary", "suggestions": sugg}
     n = max(1, min(int(count), 20))
-    scores = AbilityScores(**{_SHORT_TO_FULL_AB[k]: v for k, v in sb["abilities"].items()})
-    actions_note = " | ".join(f"{a['name']}: {a['desc']}" for a in sb["actions"][:10])
-    summary = f"CR {sb['cr']}, {sb['xp']} XP. {sb['size']} {sb['type']}. Actions: {actions_note}"
     slug = bestiary.creature_slug(sb["name"])  # stable intel/art join key for this TYPE
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
@@ -2012,25 +2060,7 @@ def spawn_monster(campaign_id: str, name: str = "", count: int = 1,
                 ch.name = label
                 spawned.append({"id": ch.id, "name": ch.name, "reused": True})
                 continue
-            ch = Character(
-                name=label,
-                kind="monster",
-                abilities=scores,
-                max_hp=sb["hp"],
-                current_hp=sb["hp"],
-                armor_class=sb["ac"],
-                hit_dice=sb["hit_dice"],
-                proficiency_bonus=sb["proficiency_bonus"],
-                initiative_bonus=sb["initiative_bonus"] or scores.modifier(Ability.DEX),
-                damage_resistances=sb["damage_resistances"],
-                damage_immunities=sb["damage_immunities"],
-                damage_vulnerabilities=sb["damage_vulnerabilities"],
-                condition_immunities=sb["condition_immunities"],
-                parry=bestiary.parry_bonus(sb),
-                notes=summary,
-                xp_value=sb["xp"],
-                creature_slug=slug,
-            )
+            ch = _monster_character_from_statblock(sb, label)
             c.characters[ch.id] = ch
             spawned.append({"id": ch.id, "name": ch.name})
         # Tier 1 — sighted: spawning puts the creature on the table; the party has laid
@@ -2069,42 +2099,21 @@ def list_bestiary(query: str = "", limit: int = 20, player_safe: bool = True) ->
 
 def _spawn_creature_chars(c: Campaign, canonical: str, count: int, location_id) -> list[dict]:
     """Add `count` combat-ready monster Characters for a canonical bestiary name to the
-    campaign (mutates; caller holds the lock + saves). Mirrors `spawn_monster`'s
-    construction EXACTLY — same stat-block flattening, abilities, AC/HP, resistances,
-    actions-on-notes, and `xp_value` — but anchors each spawn at `location_id` (the
-    scene the wandering encounter erupts in) so the local cast shows it, and returns
-    nothing on an unresolvable name (defensive; the picker only hands us resolvable
-    names). Returns `[{"id","name"}]` for the spawned foes."""
+    campaign (mutates; caller holds the lock + saves). Constructs through the SAME
+    `_monster_character_from_statblock` factory as `spawn_monster` (F01-2; the old
+    hand-rolled copy had drifted and silently lost Parry — F01-11) — but anchors each
+    spawn at `location_id` (the scene the wandering encounter erupts in) so the local
+    cast shows it, and returns nothing on an unresolvable name (defensive; the picker
+    only hands us resolvable names). Returns `[{"id","name"}]` for the spawned foes."""
     sb = bestiary.stat_block(canonical)
     if sb is None:
         return []
     n = max(1, min(int(count), 20))
-    scores = AbilityScores(**{_SHORT_TO_FULL_AB[k]: v for k, v in sb["abilities"].items()})
-    actions_note = " | ".join(f"{a['name']}: {a['desc']}" for a in sb["actions"][:10])
-    summary = f"CR {sb['cr']}, {sb['xp']} XP. {sb['size']} {sb['type']}. Actions: {actions_note}"
     slug = bestiary.creature_slug(sb["name"])  # stable intel/art join key for this TYPE
     spawned: list[dict] = []
     for i in range(n):
         label = f"{sb['name']} {i + 1}" if n > 1 else sb["name"]
-        ch = Character(
-            name=label,
-            kind="monster",
-            abilities=scores,
-            max_hp=sb["hp"],
-            current_hp=sb["hp"],
-            armor_class=sb["ac"],
-            hit_dice=sb["hit_dice"],
-            proficiency_bonus=sb["proficiency_bonus"],
-            initiative_bonus=sb["initiative_bonus"] or scores.modifier(Ability.DEX),
-            damage_resistances=sb["damage_resistances"],
-            damage_immunities=sb["damage_immunities"],
-            damage_vulnerabilities=sb["damage_vulnerabilities"],
-            condition_immunities=sb["condition_immunities"],
-            notes=summary,
-            xp_value=sb["xp"],
-            location_id=location_id,
-            creature_slug=slug,
-        )
+        ch = _monster_character_from_statblock(sb, label, location_id=location_id)
         c.characters[ch.id] = ch
         spawned.append({"id": ch.id, "name": ch.name})
     # Tier 1 — sighted: a wandering encounter erupting into the scene = the party sees it.
@@ -2797,6 +2806,33 @@ def set_hp(
         return out
 
 
+def _multiattack_counting_clause(desc: str) -> str:
+    """Reduce a Multiattack desc to its COUNTING clause before parsing (#771, F01-1).
+
+    Two SRD wording families inflated the naive number-sum for 13/344 creatures
+    (~+50% DPR, ENFORCED by attack()'s ceiling and INSTRUCTED via "Run N attack
+    call(s)"):
+      - substitution riders: "It can replace one attack with a Bite attack." (+1)
+      - alternatives: "..., or it makes two Hurl Flame attacks." (both branches summed)
+    1) sentence-split and drop any sentence containing 'replace' / 'instead of';
+    2) split on the alternative-CLAUSE pattern ',? or (it|the X) makes' and keep the
+       FIRST alternative — NOT bare ' or ', which also appears INSIDE counting
+       clauses ("two Javelin or Morningstar attacks" — Bugbear Stalker; "using
+       Shortsword or Light Crossbow in any combination" — Assassin) and must
+       survive untouched.
+    Falls back to the raw desc when filtering leaves nothing (defensive). Pure."""
+    import re as _re
+    sentences = _re.split(r"(?<=[.!?])\s+", desc)
+    kept = [
+        s for s in sentences
+        if not _re.search(r"\breplace\b|\binstead of\b", s, _re.IGNORECASE)
+    ]
+    clause = _re.split(
+        r",?\s+or\s+(?:it|the\s+\w+)\s+makes\b", " ".join(kept), flags=_re.IGNORECASE
+    )[0]
+    return clause if clause.strip() else desc
+
+
 def _parse_multiattack_count(desc: str) -> int:
     """Return the total number of attack rolls a monster makes when it uses Multiattack.
 
@@ -2804,11 +2840,14 @@ def _parse_multiattack_count(desc: str) -> int:
     - "makes two X attacks"              → 2
     - "makes one X attack and one Y attack" → 1+1 = 2
     - "makes one Ram attack, one Bite attack, and one Claw attack" → 3
-    Counts every (number + 'attack/attacks') clause, summing them.
+    Counts every (number + 'attack/attacks') clause, summing them — AFTER reducing
+    the desc to its counting clause (replace/instead-of riders and ', or it makes'
+    alternatives dropped; see _multiattack_counting_clause, #771).
     Falls back to the first number word in the desc when no clause matches,
     and ultimately defaults to 1 (conservative).
     """
     import re as _re
+    desc = _multiattack_counting_clause(desc)
     _WORD_TO_NUM = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6}
     # Split on 'and' and ',' to get individual attack clauses
     parts = _re.split(r"\band\b|\,", desc, flags=_re.IGNORECASE)
@@ -2840,8 +2879,11 @@ def _parse_multiattack_composition(desc: str) -> list[str]:
     returns [] when no '<count> <Name> attack(s)' clause parses (the caller then
     degrades to the count-only surfacing — never aborts). Title-cases each name so it
     matches the stat-block action names (which the resolver looks up case-sensitively
-    only for display)."""
+    only for display). Shares _parse_multiattack_count's counting-clause pre-filter
+    (#771) so the sequence never spans a ', or it makes' alternative (Medusa surfaced
+    a fully-resolving wrong 6-attack sequence) or a 'replace one attack' rider."""
     import re as _re
+    desc = _multiattack_counting_clause(desc)
     _WORD_TO_NUM = {"one": 1, "two": 2, "three": 3, "four": 4, "five": 5, "six": 6}
     names: list[str] = []
     # <count> <name words> attack(s) — name is 1-3 words, stops at 'attack(s)'.

--- a/servers/engine/tests/test_monster_saves_pb.py
+++ b/servers/engine/tests/test_monster_saves_pb.py
@@ -1,0 +1,197 @@
+"""F01-2 (#773): spawned monsters must carry their printed save proficiencies, and
+monster proficiency bonus must be CR-derived — not the flat 2 the srd524 dump's
+universal `proficiency_bonus: null` collapsed every creature to.
+
+Two stacked defects on main:
+  1. Neither spawn constructor set `saving_throw_proficiencies` — 132/344 creatures
+     with printed proficient saves lost them on spawn (Hold Monster vs a dragon used
+     the bare ability mod: marquee save-or-suck trivialized).
+  2. ALL 344 stat blocks surfaced `proficiency_bonus == 2` regardless of CR — monster
+     skill checks and `combat.grapple_save_dc` (8 + STR mod + prof) wrong at high CR.
+
+Fix shape (per the audit's corrected spec): derive PB from CR at the bestiary layer
+(PB = 2 + (ceil(CR)-1)//4), set the save flags via the shared
+`_monster_character_from_statblock` factory used by BOTH spawn paths, and carry a
+printed-total `save_bonus_overrides` for the residual data quirks — so
+`saving_throw_bonus` equals the printed stat block for ALL creatures.
+Old snapshots round-trip untouched (the fix applies at spawn time).
+"""
+
+import pytest
+
+
+# Standard 5e CR -> proficiency bonus table boundaries.
+CR_PB_CASES = [
+    ("0", 2), ("1/8", 2), ("1/4", 2), ("1/2", 2), ("1", 2), ("4", 2),
+    ("5", 3), ("8", 3), ("9", 4), ("12", 4), ("13", 5), ("16", 5),
+    ("17", 6), ("20", 6), ("21", 7), ("24", 7), ("25", 8), ("28", 8),
+    ("29", 9), ("30", 9),
+]
+
+
+@pytest.mark.parametrize("cr,pb", CR_PB_CASES)
+def test_pb_from_cr_table(cr, pb):
+    """PB = 2 + (ceil(CR)-1)//4 over the full standard table, fractions included."""
+    import bestiary
+
+    assert bestiary._pb_from_cr(cr) == pb
+
+
+def test_pb_from_cr_garbage_defaults_to_2():
+    import bestiary
+
+    assert bestiary._pb_from_cr("") == 2
+    assert bestiary._pb_from_cr("unknown") == 2
+
+
+def test_stat_block_pb_is_cr_derived():
+    """The flattened stat block carries the CR-derived PB (raw field is null in srd524)."""
+    import bestiary
+
+    assert bestiary.stat_block("Adult Gold Dragon")["proficiency_bonus"] == 6  # CR 17
+    assert bestiary.stat_block("Aboleth")["proficiency_bonus"] == 4  # CR 10
+    assert bestiary.stat_block("Goblin Warrior")["proficiency_bonus"] == 2  # CR 1/4
+
+
+def test_spawned_dragon_keeps_printed_saves(tmp_path, monkeypatch):
+    """Red-first marquee case: a spawned Adult Gold Dragon (CR 17) must make a DEX
+    save at the PRINTED +8 (mod +2 + PB 6) — on main it rolled at the bare +2."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+    from models import Ability
+
+    cid = server.create_campaign("Dragon Saves F01-2")["id"]
+    did = server.spawn_monster(cid, "Adult Gold Dragon")["spawned"][0]["id"]
+    # Read the PERSISTED model back (snapshot round-trip included for free).
+    ch = server._require(cid).characters[did]
+    assert ch.proficiency_bonus == 6
+    assert ch.saving_throw_bonus(Ability.DEX) == 8, "printed DEX save is +8"
+    assert ch.saving_throw_bonus(Ability.WIS) == 8, "printed WIS save is +8"
+    # Non-proficient saves stay at the bare ability modifier.
+    assert Ability.CON not in ch.saving_throw_proficiencies
+    assert ch.saving_throw_bonus(Ability.CON) == ch.ability_modifier(Ability.CON)
+
+
+def test_full_sweep_saving_throw_bonus_matches_printed():
+    """Every bestiary creature with printed proficient saves spawns with
+    saving_throw_bonus == the printed total — all of them, no exceptions
+    (the residual data quirks ride save_bonus_overrides)."""
+    import bestiary
+    import server
+    from models import Ability
+
+    checked = 0
+    seen: set[str] = set()
+    for key in bestiary._index().keys():
+        sb = bestiary.stat_block(key)
+        if sb is None or sb["name"] in seen:
+            continue
+        seen.add(sb["name"])
+        saves = sb.get("saves") or {}
+        if not saves:
+            continue
+        ch = server._monster_character_from_statblock(sb, sb["name"])
+        for short, printed in saves.items():
+            got = ch.saving_throw_bonus(Ability(short))
+            assert got == printed, (
+                f"{sb['name']} {short.upper()} save: spawned {got} != printed {printed}"
+            )
+        checked += 1
+    # Tracks the committed srd524 dataset (audit F01-2 measured exactly 132).
+    assert checked == 132, f"expected 132 creatures with printed saves; swept {checked}"
+
+
+def test_residual_data_quirk_rides_override():
+    """A creature whose printed total doesn't decompose as mod + CR-derived PB gets a
+    printed-total override (audit found 4 such srd524 quirks; Octopus is one)."""
+    import bestiary
+    import server
+    from models import Ability
+
+    sb = bestiary.stat_block("Octopus")
+    assert sb["saves"], "Octopus carries printed saves in srd524"
+    ch = server._monster_character_from_statblock(sb, "Octopus")
+    assert ch.save_bonus_overrides, "the quirk must be carried as an override"
+    for short, printed in sb["saves"].items():
+        assert ch.saving_throw_bonus(Ability(short)) == printed
+
+
+def test_no_saves_creature_has_no_flags_or_overrides():
+    """A creature with no printed save proficiencies spawns clean (no flags, no overrides)."""
+    import bestiary
+    import server
+
+    sb = bestiary.stat_block("Wolf")
+    assert not sb["saves"]
+    ch = server._monster_character_from_statblock(sb, "Wolf")
+    assert ch.saving_throw_proficiencies == []
+    assert ch.save_bonus_overrides == {}
+
+
+def test_grapple_dc_uses_cr_derived_pb():
+    """combat.grapple_save_dc (8 + STR mod + prof) heals with the CR-derived PB —
+    on main every high-CR grappler imposed a DC computed with PB=2."""
+    import bestiary
+    import combat
+    import server
+    from models import Ability
+
+    sb = bestiary.stat_block("Adult Gold Dragon")
+    ch = server._monster_character_from_statblock(sb, "Adult Gold Dragon")
+    assert combat.grapple_save_dc(ch) == 8 + ch.ability_modifier(Ability.STR) + 6
+
+
+def test_monster_skill_bonus_uses_cr_derived_pb():
+    """Character.skill_bonus reads the same proficiency_bonus — a spawned high-CR
+    monster's proficient-skill math is CR-correct (companion defect in F01-2)."""
+    import bestiary
+    import server
+
+    sb = bestiary.stat_block("Adult Gold Dragon")
+    ch = server._monster_character_from_statblock(sb, "Adult Gold Dragon")
+    ch.skill_proficiencies = ["insight"]
+    from models import Ability
+
+    assert ch.skill_bonus("insight") == ch.ability_modifier(Ability.WIS) + 6
+
+
+def test_wander_spawn_parity_with_spawn_monster(tmp_path, monkeypatch):
+    """Both spawn paths construct through the SAME factory: the wandering-encounter
+    path must carry the identical PB / save flags / overrides / Parry as spawn_monster
+    (the hand-rolled wander ctor had drifted — it silently lost Parry, audit F01-11)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Wander Parity F01-2")["id"]
+    sid = server.spawn_monster(cid, "Bandit Captain")["spawned"][0]["id"]
+    with server.campaign_lock(cid):
+        c = server._require(cid)
+        wid = server._spawn_creature_chars(c, "Bandit Captain", 1, None)[0]["id"]
+        server.save_campaign(c)
+    chars = server._require(cid).characters  # the persisted models
+    spawn_ch, wander_ch = chars[sid], chars[wid]
+    assert wander_ch.parry == spawn_ch.parry == 2, "Bandit Captain's Parry is +2 on BOTH paths"
+    assert wander_ch.proficiency_bonus == spawn_ch.proficiency_bonus
+    assert wander_ch.saving_throw_proficiencies == spawn_ch.saving_throw_proficiencies != []
+    assert wander_ch.save_bonus_overrides == spawn_ch.save_bonus_overrides
+
+
+def test_old_snapshot_round_trips_without_new_field():
+    """Additive-by-default: a pre-fix snapshot (no save_bonus_overrides key, PB=2,
+    no save flags) deserializes unchanged — the fix applies at spawn time only."""
+    from models import Character
+
+    legacy = {
+        "name": "Old Ogre",
+        "kind": "monster",
+        "max_hp": 59,
+        "current_hp": 59,
+        "proficiency_bonus": 2,
+    }
+    ch = Character.model_validate(legacy)
+    assert ch.save_bonus_overrides == {}
+    assert ch.saving_throw_proficiencies == []
+    assert ch.proficiency_bonus == 2  # legacy stored value respected, no migration
+    # And the new field survives a JSON round-trip.
+    again = Character.model_validate(ch.model_dump(mode="json"))
+    assert again.save_bonus_overrides == {}

--- a/servers/engine/tests/test_multiattack_parser.py
+++ b/servers/engine/tests/test_multiattack_parser.py
@@ -1,0 +1,165 @@
+"""F01-1 (#771): the Multiattack parser must not overcount 'replace one attack'
+riders or ', or it makes' alternatives.
+
+The naive parser split the desc on `and`/`,` and summed every numbered
+"attack(s)" clause, so 13/344 bestiary creatures were granted phantom extra
+attacks (~+50% DPR) — and the bad count was ENFORCED (attack()'s per-action
+ceiling) and INSTRUCTED ("Run N attack call(s)"), not merely displayed.
+
+Two SRD wording families were misread:
+  - substitution riders: "It can replace one attack with a Bite attack." (+1)
+  - alternatives: "..., or it makes two Hurl Flame attacks." (both branches summed)
+
+The fix pre-filters the desc to its COUNTING clause (drop replace/instead-of
+sentences; keep the FIRST ", or it/the-X makes" alternative) — and must NOT
+split on bare " or ", which appears INSIDE counting clauses ("two Javelin or
+Morningstar attacks" — Bugbear Stalker).
+"""
+
+import pytest
+
+# The 13 overcounted creatures from the audit's full-344 sweep (skeptic-verified),
+# with their RAW-correct Multiattack counts. Pulled from the LIVE bestiary so the
+# test guards the real data path end-to-end.
+OVERCOUNTED = [
+    ("Absolute Soul Seer", 2),  # main parsed 4: both alternatives summed
+    ("Barbed Devil", 2),        # main parsed 4: both alternatives summed
+    ("Clay Golem", 2),          # main parsed 5: "or three Slam if Hasten" summed
+    ("Medusa", 3),              # main parsed 6: both alternatives summed
+    ("Cloud Giant", 2),         # main parsed 3: "replace one attack" rider +1
+    ("Horned Devil", 3),        # main parsed 4: "replace one attack" rider +1
+    ("Infernal Inquisitor", 3), # main parsed 4: "replace one attack" rider +1
+    ("Wight", 2),               # main parsed 3: "replace one attack" rider +1
+    ("Werebear", 2),            # main parsed 3: "replace one attack with a Bite" +1
+    ("Wereboar", 2),
+    ("Wererat", 2),
+    ("Weretiger", 2),
+    ("Werewolf", 2),
+]
+
+# Creatures whose standard wordings must parse EXACTLY as before (the corrected
+# pre-filter changed only the 13 above in the full-344 sweep). Includes the two
+# bare-" or "-inside-a-counting-clause traps and the accidentally-correct dragons.
+UNCHANGED_CONTROLS = [
+    ("Adult Gold Dragon", 3),  # "It can replace one attack…" sentence has no comma — was already 3
+    ("Marilith", 6),           # "makes six Pact Blade attacks and uses Constrict"
+    ("Bugbear Stalker", 2),    # "two Javelin or Morningstar attacks" — bare ' or ' INSIDE the clause
+    ("Assassin", 3),           # "using Shortsword or Light Crossbow in any combination"
+    ("Aboleth", 2),            # "two Tentacle attacks and uses either…"
+    ("Bandit Captain", 2),     # "two attacks, using Scimitar and Pistol in any combination"
+]
+
+
+def _live_desc(name: str) -> str:
+    import bestiary
+
+    sb = bestiary.stat_block(name)
+    assert sb is not None, f"{name} missing from the bestiary"
+    ma = next((a for a in sb.get("actions", []) if a["name"].lower() == "multiattack"), None)
+    assert ma is not None, f"{name} has no Multiattack action"
+    return ma["desc"]
+
+
+@pytest.mark.parametrize("name,expected", OVERCOUNTED)
+def test_overcounted_creatures_corrected(name, expected):
+    """Each of the 13 overcounted creatures parses to its RAW-correct count (#771)."""
+    import server
+
+    assert server._parse_multiattack_count(_live_desc(name)) == expected
+
+
+@pytest.mark.parametrize("name,expected", UNCHANGED_CONTROLS)
+def test_standard_wordings_unchanged(name, expected):
+    """Standard wordings (incl. bare-' or ' inside counting clauses) stay byte-identical."""
+    import server
+
+    assert server._parse_multiattack_count(_live_desc(name)) == expected
+
+
+@pytest.mark.parametrize(
+    "desc,expected",
+    [
+        # rider sentence dropped (substitution, not a third attack)
+        (
+            "The werewolf makes two attacks, using Scratch or Longbow in any combination. "
+            "It can replace one attack with a Bite attack.",
+            2,
+        ),
+        # ", or it makes" alternative — first branch only
+        (
+            "The devil makes one Claws attack and one Tail attack, "
+            "or it makes two Hurl Flame attacks.",
+            2,
+        ),
+        ("The golem makes two Slam attacks, or it makes three Slam attacks if it used Hasten this turn.", 2),
+        (
+            "The medusa makes two Claw attacks and one Snake Hair attack, "
+            "or it makes three Poison Ray attacks.",
+            3,
+        ),
+        # bare " or " inside a counting clause must NOT be split
+        ("The bugbear makes two Javelin or Morningstar attacks.", 2),
+        # "instead of" rider variant
+        ("The creature makes two Slam attacks. It can use Stomp instead of one Slam attack.", 2),
+        # plain wordings (regression guard for the pre-filter)
+        ("The captain makes two attacks, using Scimitar and Pistol in any combination.", 2),
+        ("makes one Ram attack, one Bite attack, and one Claw attack", 3),
+    ],
+)
+def test_counting_clause_wordings(desc, expected):
+    """Pure-string parser table over the rider/alternative/trap wordings (F01-1)."""
+    import server
+
+    assert server._parse_multiattack_count(desc) == expected
+
+
+def test_medusa_composition_first_alternative_only():
+    """The composition must come from the FIRST alternative — not a merged 6-attack
+    sequence spanning both branches (the fully-resolving wrong instruction the audit
+    flagged: Medusa surfaced a coherent-looking 6-attack sequence; real allowance 3)."""
+    import server
+
+    desc = (
+        "The medusa makes two Claw attacks and one Snake Hair attack, "
+        "or it makes three Poison Ray attacks."
+    )
+    assert server._parse_multiattack_composition(desc) == ["Claw", "Claw", "Snake Hair"]
+
+
+def test_replace_rider_excluded_from_composition():
+    """A 'replace one attack' rider must not inject a phantom attack name."""
+    import server
+
+    desc = (
+        "The wight makes two attacks, using Necrotic Sword or Necrotic Bow in any "
+        "combination. It can replace one attack with a use of Life Drain."
+    )
+    # "two attacks" has no attack NAME between the count and 'attacks' — composition
+    # degrades to [] (count-only surfacing), and crucially contains no Life Drain entry.
+    assert server._parse_multiattack_composition(desc) == []
+
+
+def test_werewolf_third_attack_rejected(tmp_path, monkeypatch):
+    """Integration (F01-1): the Werewolf's Multiattack is TWO attacks — the engine
+    must reject the third attack in one action. On main the parser counted 3 and
+    attack() permitted AND instructed all three (live probe: attacks [1,2,3] resolved)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Werewolf F01-1")["id"]
+    pc = server.create_character(cid, "Hero", kind="player", max_hp=60)["id"]
+    wid = server.spawn_monster(cid, "Werewolf")["spawned"][0]["id"]
+    server.start_combat(cid, [pc, wid])
+    # Initiative order is random; if the PC won, pass its turn to reach the werewolf.
+    if server.get_state(cid)["current_turn"] == pc:
+        server.use_action(cid, pc, "skip")
+        server.next_turn(cid)
+    assert server.get_state(cid)["current_turn"] == wid
+
+    a1 = server.attack(cid, wid, pc, attack_bonus=4, damage_dice="1d8")
+    assert a1["attacks_allowed_this_turn"] == 2, (
+        f"Werewolf Multiattack allowance must be 2; got {a1['attacks_allowed_this_turn']}"
+    )
+    server.attack(cid, wid, pc, attack_bonus=4, damage_dice="1d8")
+    with pytest.raises(ValueError, match="Multiattack grants 2 attack"):
+        server.attack(cid, wid, pc, attack_bonus=4, damage_dice="1d8")


### PR DESCRIPTION
Closes #771
Closes #773
Refs #792 — F01-11 (wandering spawns lose Parry) is structurally fixed by the shared spawn factory; the rest of that cluster is untouched.

## Root cause

**F01-1 (#771).** `_parse_multiattack_count` split the Multiattack desc on `and`/`,` and summed every numbered "attack(s)" clause, so it could not distinguish additive clauses from:
- substitution riders — "It can replace one attack with a Bite attack." (+1 phantom attack), and
- alternatives — "…, or it makes two Hurl Flame attacks." (both branches summed).

13/344 creatures were granted extra attacks (~+50% DPR: Medusa 6-not-3, Clay Golem 5-not-2, all five were-creatures 3-not-2, …) — and the bad count was **enforced** (attack()'s per-action ceiling) and **instructed** ("Run N attack call(s)"; Medusa's composition fully resolved into a coherent-looking wrong 6-attack sequence). `_parse_multiattack_composition` shared the blindness.

**F01-2 (#773).** Two stacked defects: (1) neither spawn constructor set `saving_throw_proficiencies` — 132/344 creatures lost their printed proficient saves on spawn (Hold Monster vs a dragon rolled at the bare ability mod); (2) the srd524 dump carries `proficiency_bonus: null` for every creature, so the `or 2` fallback flattened ALL 344 stat blocks to PB 2 — monster skill checks and `combat.grapple_save_dc` (8 + STR mod + prof) wrong for every high-CR monster. The audit's original flags-only spec was skeptic-REFUTED (with PB 2, flags ship new wrong numbers); this implements the corrected spec.

## Fix

- `server._multiattack_counting_clause` (new, pure): sentence-split, drop replace/instead-of sentences, keep the FIRST `,? or (it|the X) makes` alternative — **not** bare `" or "`, which appears inside counting clauses ("two Javelin or Morningstar attacks" — Bugbear Stalker). Wired into both `_parse_multiattack_count` and `_parse_multiattack_composition`. Sweep-verified vs main over all 344 stat blocks: exactly the 13 cited creatures change, everything else byte-identical (dragons/Marilith/Bugbear Stalker/Assassin untouched).
- `bestiary._pb_from_cr` (new, pure): standard table PB = 2 + (⌈CR⌉−1)//4; used as the stat-block fallback when the raw field is null (SRD + authored paths).
- `server._monster_character_from_statblock` (new): the SINGLE monster construction path, now used by BOTH `spawn_monster` and `_spawn_creature_chars` (the hand-rolled wander copy had drifted and silently lost Parry — F01-11). Sets `saving_throw_proficiencies` from the stat block's printed saves; where the printed total ≠ mod + CR-derived PB (4 srd524 data quirks, e.g. Octopus), carries the printed total in the new additive `Character.save_bonus_overrides` (consulted first by `saving_throw_bonus`).
- Grapple DCs / monster skill checks heal via the same `proficiency_bonus` — no combat.py change needed.

**Invariants:** engine stays sole writer (factory is pure construction; callers register + save under the lock). Additive-by-default: `save_bonus_overrides` defaults `{}`; old snapshots round-trip unchanged — already-spawned monsters keep their stored PB 2 / no flags (fix applies at spawn time, no migration). Wire contracts: only additive keys in tool returns. No shell touched.

## Tests (TDD — red on main, green here; 1865 engine tests pass, fast-gate T0 PASS)

`tests/test_multiattack_parser.py` (30):
- table-driven over the 13 overcounted creatures from LIVE bestiary data → RAW-correct counts
- 6 unchanged controls (Adult Gold Dragon, Marilith, Bugbear Stalker, Assassin, Aboleth, Bandit Captain)
- 8 pure-string rider/alternative/trap wordings; Medusa composition = first alternative only; replace-rider excluded from composition
- integration: Werewolf's 3rd attack in one action REJECTED (main permitted attacks [1,2,3])

`tests/test_monster_saves_pb.py` (30):
- `_pb_from_cr` full-table parametrize (20 boundary cases) + garbage default
- red-first marquee: spawned Adult Gold Dragon DEX save == printed +8 (was +2), PB == 6
- full-sweep: `saving_throw_bonus` == printed total for ALL 132 creatures with printed saves; no-saves creature spawns clean; Octopus quirk rides the override
- grapple DC + skill bonus use the CR-derived PB
- wander/spawn_monster factory parity incl. Parry (+2 on both paths)
- old-snapshot round-trip without the new field

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Monsters now calculate proficiency bonuses based on CR level for accurate combat mechanics
  - Monster saving throws correctly preserve printed stat block values
  - Fixed Multiattack parsing to eliminate overcounted attacks on certain creatures

* **Tests**
  - Added comprehensive test coverage for proficiency bonus derivation and attack sequence parsing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->