### PR TITLE
fix(engine): seat-path integrity + _char resolve-then-suggest (audit F02-1, F02-2, F02-4, F14-8)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -11,6 +11,7 @@ in later epics; this server already owns dice, characters, and persistence.
 
 from __future__ import annotations
 
+import difflib
 import random
 import re
 import sys
@@ -120,11 +121,67 @@ def _require(campaign_id: str) -> Campaign:
     return c
 
 
+def _name_slug(s: str) -> str:
+    """Slugify a display name the way the DM does ('Maddala Deadeye' -> 'maddala-deadeye')."""
+    return re.sub(r"[^a-z0-9]+", "-", (s or "").strip().lower()).strip("-")
+
+
 def _char(c: Campaign, character_id: str) -> Character:
+    """Resolve a character id — tolerantly (audit F14-8). ~60 tools route every
+    character_id through this ONE site, so a bare dict-get-and-raise turned any id slip
+    ('maddala-deadeye' for char_2712a4348f3a "Maddala Deadeye") into a dead-end on all of
+    them: a wasted ~100s beat, or a silently-freehanded result. Resolution ladder,
+    deterministic and READ-ONLY:
+      1. exact dict-key hit (today's behavior — ids stay canonical, zero new cost);
+      2. unique case-insensitive match on id, display name, or slugified name;
+      3. unique substring match on name or id ('maddala' finds her too);
+      4. otherwise raise the SAME-SHAPED ValueError ("no character … in campaign"), now
+         carrying a did-you-mean of the <=5 nearest `id (name, kind)` via difflib.
+    On ANY ambiguity (two NPCs named "Guard") NEVER resolve — raise listing the
+    candidates; a mutating tool must never guess. A fuzzy hit is echoed on stderr (the
+    QA harness captures it) so silent resolution stays observable."""
     ch = c.characters.get(character_id)
-    if ch is None:
-        raise ValueError(f"no character {character_id!r} in campaign")
-    return ch
+    if ch is not None:
+        return ch
+    want = (character_id or "").strip()
+    wl = want.lower()
+    candidates: list[Character] = []
+    if wl:
+        slug = _name_slug(want)
+        exact = [x for x in c.characters.values()
+                 if x.id.lower() == wl or x.name.strip().lower() == wl
+                 or (slug and _name_slug(x.name) == slug)]
+        if len(exact) == 1:
+            print(f"[worldos:_char] resolved {character_id!r} -> {exact[0].id!r} "
+                  f"({exact[0].name})", file=sys.stderr)
+            return exact[0]
+        candidates = exact
+        if not exact:
+            sub = [x for x in c.characters.values()
+                   if wl in x.name.lower() or wl in x.id.lower()]
+            if len(sub) == 1:
+                print(f"[worldos:_char] resolved {character_id!r} -> {sub[0].id!r} "
+                      f"({sub[0].name})", file=sys.stderr)
+                return sub[0]
+            candidates = sub
+    if not candidates and wl:
+        # Nearest names/ids/slugs via difflib, mapped back to characters (dedup by id).
+        corpus: dict[str, Character] = {}
+        for x in c.characters.values():
+            for key in (x.id.lower(), x.name.strip().lower(), _name_slug(x.name)):
+                if key:
+                    corpus.setdefault(key, x)
+        seen: set[str] = set()
+        for m in difflib.get_close_matches(wl, list(corpus), n=10, cutoff=0.5):
+            x = corpus[m]
+            if x.id not in seen:
+                seen.add(x.id)
+                candidates.append(x)
+    msg = f"no character {character_id!r} in campaign"
+    hint = "; ".join(f"{x.id} ({x.name}, {x.kind})" for x in candidates[:5])
+    if hint:
+        msg += f". Did you mean: {hint}?"
+    raise ValueError(msg)
 
 
 _COMBAT_EVENT_SCHEMA = "clawdnd.combat_event.v1"
@@ -1280,8 +1337,9 @@ def _seed_starting_gear(ch, class_name: str) -> None:
 # leveled spells). Every name resolves in the srd524 casting DB so cast_spell works out of the
 # box. This exists because _recompute_spellcasting only sizes SLOTS — without seeding spells a
 # freshly-built caster has slots but NOTHING to cast (QA: a level-3 Wizard shipped with an empty
-# spellbook and never cast once). Half-casters (paladin/ranger) gain spells at L2, so they are
-# seeded only from level 2. Generic SRD spells — no proprietary list copied.
+# spellbook and never cast once). Half-casters (paladin/ranger) cast from LEVEL 1 under SRD 5.2
+# (the 2024 edition the engine's feature data follows — audit F02-2), so they seed from L1 like
+# everyone else. Generic SRD spells — no proprietary list copied.
 _STARTING_SPELLS: dict[str, dict[str, list[str]]] = {
     "wizard":   {"cantrips": ["Fire Bolt", "Mage Hand", "Light"],
                  "spells": ["Magic Missile", "Shield", "Mage Armor", "Detect Magic"]},
@@ -1307,19 +1365,90 @@ def _seed_starting_spells(ch, class_name: str, level: int) -> None:
     cast from turn one. Cantrips land in spells_known (always available); leveled spells land in
     BOTH spells_known and spells_prepared so casting works whether the class is a known- or a
     prepared-caster. Only fires when BOTH spell lists are empty (respects a template/canon record
-    that supplied its own spells) and only for the caster classes above. Half-casters wait for L2."""
+    that supplied its own spells) and only for the caster classes above. Half-casters seed from
+    L1 — SRD 5.2 paladins/rangers have Spellcasting at level 1 (the old `level < 2` gate was a
+    2014 assumption that, combined with the round-down caster level, made a L1 half-caster
+    unable to cast at all — audit F02-2)."""
     cname = (class_name or "").lower()
     loadout = _STARTING_SPELLS.get(cname)
     if not loadout:
         return
     if ch.spells_known or ch.spells_prepared:
         return  # respect spells a template / canon record already supplied
-    if cname in ("paladin", "ranger") and level < 2:
-        return  # half-casters have no spells (or slots) until level 2
     cantrips = list(loadout.get("cantrips", []))
     spells = list(loadout.get("spells", []))
     ch.spells_known = cantrips + spells
     ch.spells_prepared = list(spells)
+
+
+_ABILITY_FIELDS = ("strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma")
+
+
+def _backfill_seat_abilities(ch, class_name: str, level: int, rec_abilities=None) -> str:
+    """The ONE ability backfill every seat path shares (audit F02-1). Precedence,
+    deterministic and additive:
+      * a sheet that is already non-flat (hand-authored roster record, explicit caller
+        abilities applied upstream) is NEVER touched -> "explicit";
+      * an explicit record `abilities` block wins next -> "canon" (malformed degrades);
+      * else derive the class+level standard array (_derive_canon_abilities) -> "derived";
+      * a class-less / unknown-class sheet keeps the flat-10 default -> "placeholder".
+    initiative_bonus resets from the REAL DEX whenever abilities are (re)assigned, so
+    HP/AC/initiative downstream compute off real scores. Returns the ability_source."""
+    if any(getattr(ch.abilities, f) != 10 for f in _ABILITY_FIELDS):
+        return "explicit"  # a real sheet always wins over derivation
+    if isinstance(rec_abilities, dict) and rec_abilities:
+        try:
+            ch.abilities = AbilityScores(**rec_abilities)
+            ch.initiative_bonus = ch.abilities.modifier(Ability.DEX)
+            return "canon"
+        except (TypeError, ValueError):
+            pass  # malformed record block -> fall through to derivation/placeholder
+    derived = _derive_canon_abilities(class_name, level)
+    if derived is not None:
+        ch.abilities = derived
+        ch.initiative_bonus = ch.abilities.modifier(Ability.DEX)
+        return "derived"
+    return "placeholder"
+
+
+def _finish_seat_sheet(ch, class_name: str, level: int, *, set_base_ac: bool,
+                       rec_abilities=None, backfill_abilities: bool = True,
+                       seed_gear: bool = True) -> str:
+    """EVERY seat path's shared finisher (audit F02-1 + F02-4): ability backfill ->
+    SRD class defaults -> starting gear+purse, in that order so HP/AC/initiative are
+    computed from REAL ability scores. The five seat paths (create / start fresh +
+    promote / load_canon / recruit) each used to hand-roll a different subset of these
+    steps — pickup PCs seated flat-10, canon/recruit seats claimed an armor AC over an
+    empty pack — so the fix shape is one helper, not another one-path patch. Every step
+    self-guards (non-flat sheets, supplied kits/purses, non-stub HP, and unknown classes
+    are all left alone), making the whole call additive on an already-complete sheet.
+    Returns the ability_source ("explicit" | "canon" | "derived" | "placeholder")."""
+    ability_source = "explicit"
+    if backfill_abilities:
+        ability_source = _backfill_seat_abilities(ch, class_name, level, rec_abilities)
+    if class_name:
+        _apply_srd_class_defaults(ch, class_name, level, set_base_ac=set_base_ac)
+        if seed_gear:
+            _seed_starting_gear(ch, class_name)
+    return ability_source
+
+
+def _seat_flat10_warnings(ch, class_label: str, where: str) -> list[str]:
+    """The flat-10 PLACEHOLDER warning load_canon_character surfaces, shared with the
+    start_character seat paths (audit F02-1): a PLAYER (or any seated spellcaster) standing
+    at 10/10/10/10/10/10 acts at +0 on every check/save/DC — not a hard fail (a class-less
+    blank sheet is a documented origin), but QA and the DM must SEE it. Returned in the
+    tool result and echoed on stderr (the QA harness captures stderr)."""
+    is_flat = all(getattr(ch.abilities, f) == 10 for f in _ABILITY_FIELDS)
+    is_caster = bool(ch.spell_slots or ch.spells_known or ch.spells_prepared)
+    if not (is_flat and (ch.kind == "player" or is_caster)):
+        return []
+    who = "player" if ch.kind == "player" else "spellcaster"
+    warn = (f"{ch.name!r} ({class_label or 'class-less'}) seated as a {who} with a "
+            f"PLACEHOLDER 10/10/10/10/10/10 ability array — its checks, saves, and spell "
+            f"DCs are all +0. Pass `abilities` or flesh the sheet out via update_character.")
+    print(f"[worldos:{where}] WARNING: {warn}", file=sys.stderr)
+    return [warn]
 
 
 @mcp.tool()
@@ -1404,9 +1533,11 @@ def create_character(
         if skills:  # explicit skill choices win over the class default-fill
             ch.skill_proficiencies = [s.lower() for s in skills if s.lower() in SKILL_ABILITIES]
         if apply_srd_defaults and class_name:
-            _apply_srd_class_defaults(ch, class_name, level, set_base_ac=(armor_class == 10))
-            if kind in ("player", "companion"):
-                _seed_starting_gear(ch, class_name)  # gear + purse (was only seeded via start_character)
+            # create_character is the DM's direct authoring surface: an omitted `abilities`
+            # stays the explicit flat sheet (today's contract) — no derivation here.
+            _finish_seat_sheet(ch, class_name, level, set_base_ac=(armor_class == 10),
+                               backfill_abilities=False,
+                               seed_gear=(kind in ("player", "companion")))
         # Anchor NPCs/monsters to where they're introduced so "who's in the scene" is
         # the current location's cast — not the whole seeded world roster. Explicit
         # location_id wins; otherwise default to the party's current location.
@@ -1597,6 +1728,7 @@ def start_character(
         if existing is not None:
             ch = existing
             ch.kind = "player"  # type: ignore[assignment]
+            ability_source = "explicit"
             if build["abilities"]:
                 ch.abilities = scores
                 ch.initiative_bonus = scores.modifier(Ability.DEX)
@@ -1617,8 +1749,13 @@ def start_character(
             if build["skills"]:
                 ch.skill_proficiencies = [s.lower() for s in build["skills"] if s.lower() in SKILL_ABILITIES]
             if cn:
-                _apply_srd_class_defaults(ch, cn, lvl, set_base_ac=(int(build["armor_class"]) == 10))
-                _seed_starting_gear(ch, cn)  # AC/inventory consistency (no-op if gear already present)
+                # The shared finisher (F02-1/F02-4): backfill-when-flat (a hand-fleshed
+                # roster sheet wins; a flat-10 stub is repaired from the canon rec / the
+                # class array), SRD defaults, gear+purse — same ladder as every seat path.
+                ability_source = _finish_seat_sheet(
+                    ch, cn, lvl, set_base_ac=(int(build["armor_class"]) == 10),
+                    rec_abilities=(rec or {}).get("abilities"),
+                    backfill_abilities=not build["abilities"])
             if ch.id not in c.party:
                 c.party.append(ch.id)
             save_campaign(c)
@@ -1632,6 +1769,10 @@ def start_character(
                 "level": ch.total_level,
                 "in_party": ch.id in c.party,
                 "promoted_existing": True,  # reused the roster record (no duplicate minted)
+                # Which precedence seated the abilities (explicit/canon/derived/placeholder)
+                # + the same flat-10 warning load_canon surfaces — QA/DM must SEE a +0 PC.
+                "ability_source": ability_source,
+                "warnings": _seat_flat10_warnings(ch, cn, "start_character"),
                 "combat_numbers": _combat_numbers(ch),  # authoritative to-hit/damage — don't invent
             }
 
@@ -1658,11 +1799,17 @@ def start_character(
         if build["skills"]:  # explicit/template skill choices win over the class default-fill
             ch.skill_proficiencies = [s.lower() for s in build["skills"] if s.lower() in SKILL_ABILITIES]
         # Fill a real SRD sheet whenever a class is known (every origin but a class-less
-        # nobody_l1). set_base_ac only when AC is the unarmored default, mirroring
-        # create_character so an explicit/template AC is preserved.
+        # nobody_l1), via the shared finisher (F02-1/F02-4): when no explicit `abilities`
+        # were passed, the canon rec's block -> the class+level standard array backfills
+        # the flat-10 placeholder BEFORE HP/AC/initiative are computed (the pickup-origin
+        # PC used to seat all-10s). set_base_ac only when AC is the unarmored default,
+        # mirroring create_character so an explicit/template AC is preserved.
+        ability_source = "explicit" if build["abilities"] else "placeholder"
         if cn:
-            _apply_srd_class_defaults(ch, cn, lvl, set_base_ac=(int(build["armor_class"]) == 10))
-            _seed_starting_gear(ch, cn)  # AC/inventory consistency (no-op if gear already present)
+            ability_source = _finish_seat_sheet(
+                ch, cn, lvl, set_base_ac=(int(build["armor_class"]) == 10),
+                rec_abilities=(rec or {}).get("abilities"),
+                backfill_abilities=not build["abilities"])
         # Apply template-supplied spellbooks (additive: empty list == today's behavior).
         if build.get("spells_known"):
             ch.spells_known = list(build["spells_known"])
@@ -1681,6 +1828,10 @@ def start_character(
         "class": cn,
         "level": ch.total_level,
         "in_party": ch.id in c.party,
+        # Which precedence seated the abilities (explicit/canon/derived/placeholder) + the
+        # same flat-10 warning load_canon surfaces — QA/DM must SEE a +0 PC (F02-1).
+        "ability_source": ability_source,
+        "warnings": _seat_flat10_warnings(ch, cn, "start_character"),
         "combat_numbers": _combat_numbers(ch),  # authoritative to-hit/damage — don't invent
     }
 
@@ -1738,7 +1889,12 @@ def recruit_companion(
         if skills:  # explicit skill choices win over the class default-fill
             ch.skill_proficiencies = [s.lower() for s in skills if s.lower() in SKILL_ABILITIES]
         if apply_srd_defaults and class_name:
-            _apply_srd_class_defaults(ch, class_name, level, set_base_ac=(armor_class <= 0))
+            # The shared seat finisher (F02-1/F02-4): a flat-10 roster stub gains a class-
+            # appropriate array (explicit `abilities` / a hand-fleshed sheet always win),
+            # then SRD defaults, then the gear+purse kit the claimed AC implies — recruit
+            # used to apply the AC but never the armor (53 wild AC>=14-no-armor records).
+            _finish_seat_sheet(ch, class_name, level, set_base_ac=(armor_class <= 0),
+                               backfill_abilities=not abilities, seed_gear=True)
         # Recruiting fleshes out a real combat sheet — so a candidate who was flagged dead while
         # still a bare identity STUB (the load_canon_character stub spawns at max_hp=1, and one hit
         # in combat trips the SRD massive-damage instant-death rule) must NOT stay dead once they
@@ -2262,9 +2418,7 @@ def get_character(campaign_id: str, character_id: str = "", target_id: str = "",
     if not character_id:
         raise ValueError("get_character needs a character (pass `character_id` or an alias: `target_id`/`id`)")
     c = _require(campaign_id)
-    ch = c.characters.get(character_id)
-    if ch is None:
-        raise ValueError(f"no character {character_id!r} in campaign")
+    ch = _char(c, character_id)  # ONE resolve-then-suggest site (F14-8), not an inline copy
     sheet = ch.model_dump(mode="json")
     sheet["class_resources_view"] = _class_resources_view(ch)
     sheet["combat_numbers"] = _combat_numbers(ch)
@@ -2455,23 +2609,21 @@ def load_canon_character(campaign_id: str, name: str = "", kind: str = "npc", ad
         # explicit canon `abilities` block unchanged where one exists (forward-compatible — none in
         # the current corpus, but a hand-authored sheet must win). A class-less / unknown-class
         # record can't be sized, so it KEEPS the flat-10 default (today's behavior) and we warn.
-        ability_source = "placeholder"
-        canon_abilities = rec.get("abilities")
-        if isinstance(canon_abilities, dict) and canon_abilities:
-            try:
-                ch.abilities = AbilityScores(**canon_abilities)
-                ability_source = "canon"
-            except (TypeError, ValueError):
-                pass  # malformed canon abilities -> fall through to derivation/placeholder
-        if ability_source == "placeholder":
-            derived = _derive_canon_abilities(classes[0].name, classes[0].level) if classes else None
-            if derived is not None:
-                ch.abilities = derived
-                ch.initiative_bonus = ch.abilities.modifier(Ability.DEX)
-                ability_source = "derived"
-        if classes:
-            _apply_srd_class_defaults(ch, classes[0].name, classes[0].level,
-                                      set_base_ac=(ch.armor_class == 10))
+        # All of the above now runs through the shared seat finisher (F02-1/F02-4):
+        # canon `abilities` block -> derived class array -> placeholder, then the SRD
+        # defaults, then — for a PARTY seat (player/companion) — the starting gear+purse
+        # the claimed AC implies. load_canon used to apply the SRD AC but never the armor
+        # (Jun-9 Alfira: AC 14, inventory [], 0 gp — one of 53 wild AC>=14-no-armor
+        # records); a lore NPC pull stays gearless. The seeder self-guards, so a record
+        # that ships its own kit/purse is untouched.
+        ability_source = _finish_seat_sheet(
+            ch,
+            classes[0].name if classes else "",
+            classes[0].level if classes else 1,
+            set_base_ac=(ch.armor_class == 10),
+            rec_abilities=rec.get("abilities"),
+            seed_gear=(ch.kind in ("player", "companion")),
+        )
         # MAX_HP (#352 — canon PC seated with a critically-low max_hp). The Character default is a
         # placeholder max_hp=1, and an identity stub left at 1 HP is an INSTANT-KILL combatant: the
         # first hit trips combat's SRD massive-damage rule (damage >= max_hp at 0 HP) and flags it

--- a/servers/engine/srd_tables.py
+++ b/servers/engine/srd_tables.py
@@ -219,8 +219,15 @@ def standard_array() -> list[int]:
 
 
 def effective_caster_level(class_levels: list[tuple[str, int]]) -> int:
-    """Multiclass effective caster level: full=+level, half=+level//2,
-    third=+level//3 (per-class floor, summed). Pact/none contribute 0."""
+    """Effective caster level: full=+level, half=+ceil(level/2), third=+ceil(level/3)
+    (per-class, summed). Pact/none contribute 0.
+
+    SRD 5.2 (2024) rounds half- and third-casters UP — and with ceil the multiclass
+    slot table reproduces the PHB half-caster CLASS column exactly at every
+    single-class paladin/ranger level (L1->CL1->[2], L3->CL2->[3], L5->CL3->[4,2]),
+    so half-casters effectively get their own progression column. The old 2014
+    round-DOWN seated a L1 paladin/ranger with ZERO slots and under-slotted every
+    odd level (audit F02-2). Third-casters are unused today — future-proofing."""
     total = 0
     for name, level in class_levels:
         try:
@@ -230,9 +237,9 @@ def effective_caster_level(class_levels: list[tuple[str, int]]) -> int:
         if ct == "full":
             total += level
         elif ct == "half":
-            total += level // 2
+            total += (level + 1) // 2
         elif ct == "third":
-            total += level // 3
+            total += (level + 2) // 3
     return total
 
 

--- a/servers/engine/tests/test_char_resolver.py
+++ b/servers/engine/tests/test_char_resolver.py
@@ -1,0 +1,111 @@
+"""`_char` resolve-then-suggest (audit F14-8, issue #786).
+
+~60 id-taking tools route every character_id through `server._char`, which used to be a bare
+dict-get-and-raise: the observed gate-duo2 double failure passed 'maddala-deadeye' while the
+campaign held char_… "Maddala Deadeye", and the error named neither the valid ids nor the
+obvious match — a wasted ~100s beat per slip, or a silent freehand.
+
+The resolution ladder (deterministic, read-only):
+  1. exact dict-key hit (ids stay canonical);
+  2. unique case-insensitive match on id / display name / slugified name (spaces -> hyphens);
+  3. unique substring match on name or id;
+  4. otherwise the SAME-SHAPED ValueError ("no character …"), now with a did-you-mean of
+     the <=5 nearest `id (name, kind)` candidates.
+Ambiguity NEVER resolves (two NPCs named "Guard" -> raise listing both); a failed call
+mutates nothing.
+"""
+
+import pytest
+
+import server
+
+
+@pytest.fixture()
+def camp(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Resolver")["id"]
+    mid = server.create_character(cid, "Maddala Deadeye", kind="npc")["id"]
+    server.create_character(cid, "Rolan", kind="player")
+    return cid, mid
+
+
+def test_exact_id_still_wins(camp):
+    cid, mid = camp
+    c = server._require(cid)
+    assert server._char(c, mid).id == mid
+
+
+def test_slugified_name_resolves(camp):
+    # THE observed failure class: 'maddala-deadeye' for "Maddala Deadeye".
+    cid, mid = camp
+    c = server._require(cid)
+    assert server._char(c, "maddala-deadeye").id == mid
+
+
+def test_case_insensitive_name_resolves(camp):
+    cid, mid = camp
+    c = server._require(cid)
+    assert server._char(c, "maddala deadeye").id == mid
+    assert server._char(c, "MADDALA DEADEYE").id == mid
+
+
+def test_unique_substring_resolves(camp):
+    cid, mid = camp
+    c = server._require(cid)
+    assert server._char(c, "maddala").id == mid
+
+
+def test_typo_raises_with_did_you_mean(camp):
+    # 'madala' (missing d) matches nothing exactly — the error must keep its key shape
+    # ("no character … in campaign") AND carry the nearest `id (name, kind)` candidates.
+    cid, mid = camp
+    c = server._require(cid)
+    with pytest.raises(ValueError, match="no character") as ei:
+        server._char(c, "madala")
+    msg = str(ei.value)
+    assert mid in msg, f"did-you-mean must name the real id: {msg}"
+    assert "Maddala Deadeye" in msg
+    assert "Did you mean" in msg
+
+
+def test_ambiguous_name_never_resolves(camp):
+    cid, _mid = camp
+    g1 = server.create_character(cid, "Guard", kind="npc")["id"]
+    g2 = server.create_character(cid, "Guard", kind="npc")["id"]
+    c = server._require(cid)
+    with pytest.raises(ValueError, match="no character") as ei:
+        server._char(c, "guard")
+    msg = str(ei.value)
+    assert g1 in msg and g2 in msg, f"ambiguity must list BOTH candidates: {msg}"
+
+
+def test_no_match_keeps_plain_error_shape(camp):
+    cid, _mid = camp
+    c = server._require(cid)
+    with pytest.raises(ValueError, match="no character 'zzz-qqqqq' in campaign"):
+        server._char(c, "zzz-qqqqq")
+
+
+def test_tools_inherit_resolution_award_xp_slug(camp):
+    # The ~60-tool inheritance, on the tool that DID fail in gate-duo2: award_xp resolves
+    # the slug and lands the XP on the canonical record.
+    cid, mid = camp
+    before = server.get_character(cid, mid)["xp"]
+    out = server.award_xp(cid, "maddala-deadeye", 50, "resolver test")
+    assert "error" not in out
+    assert server.get_character(cid, mid)["xp"] >= before + 50
+
+
+def test_failed_resolution_mutates_nothing(camp):
+    # The no-mutation invariant on the failure path (award_xp narrated-not-executed class).
+    cid, mid = camp
+    before = server.get_character(cid, mid)["xp"]
+    with pytest.raises(ValueError, match="no character"):
+        server.award_xp(cid, "madala", 50, "must not land")
+    assert server.get_character(cid, mid)["xp"] == before
+
+
+def test_get_character_routes_through_resolver(camp):
+    # get_character had its own inline dict-get raise — same shape, now the same ONE site.
+    cid, mid = camp
+    assert server.get_character(cid, "maddala-deadeye")["id"] == mid

--- a/servers/engine/tests/test_progression.py
+++ b/servers/engine/tests/test_progression.py
@@ -40,13 +40,51 @@ def test_is_asi_level():
     [
         ([("Wizard", 5)], {1: 4, 2: 3, 3: 2}),
         ([("Cleric", 1), ("Wizard", 1)], {1: 3}),  # effective caster level 2
-        ([("Paladin", 1)], {}),  # half-caster level 1 -> CL 0
+        # Half-casters round UP (SRD 5.2 / audit F02-2) — the old 2014 round-DOWN gave a
+        # L1 paladin/ranger ZERO slots and under-slotted every odd level.
+        ([("Paladin", 1)], {1: 2}),  # CL 1 (was {} under round-down)
         ([("Paladin", 2)], {1: 2}),  # CL 1
-        ([("Paladin", 6), ("Sorcerer", 1)], {1: 4, 2: 3}),  # 3 + 1 = CL 4
+        ([("Paladin", 3)], {1: 3}),  # CL 2 (was {1: 2})
+        ([("Ranger", 5)], {1: 4, 2: 2}),  # CL 3 (was {1: 3})
+        ([("Paladin", 6), ("Sorcerer", 1)], {1: 4, 2: 3}),  # 3 + 1 = CL 4 (unchanged)
     ],
 )
 def test_multiclass_slots(class_levels, expected):
     assert srd_tables.multiclass_slots(class_levels) == expected
+
+
+@pytest.mark.parametrize(
+    "level,expected",
+    [
+        # With ceil rounding, the multiclass table reproduces the PHB half-caster
+        # progression column EXACTLY at every single-class paladin/ranger level.
+        (1, {1: 2}),
+        (2, {1: 2}),
+        (3, {1: 3}),
+        (5, {1: 4, 2: 2}),
+        (9, {1: 4, 2: 3, 3: 2}),
+        (13, {1: 4, 2: 3, 3: 3, 4: 1}),
+        (17, {1: 4, 2: 3, 3: 3, 4: 3, 5: 1}),
+        (19, {1: 4, 2: 3, 3: 3, 4: 3, 5: 2}),
+    ],
+)
+def test_half_caster_single_class_matches_phb_column(level, expected):
+    assert srd_tables.multiclass_slots([("Paladin", level)]) == expected
+    assert srd_tables.multiclass_slots([("Ranger", level)]) == expected
+
+
+def test_l1_half_caster_creation_gets_slots_and_spells():
+    # F02-2 compounding seed gate: a L1 paladin/ranger could not cast AT ALL — zero
+    # slots from the round-down table AND a `level < 2` gate in _seed_starting_spells.
+    cid = server.create_campaign("HalfCaster")["id"]
+    for cls, spell in (("paladin", "Cure Wounds"), ("ranger", "Hunter's Mark")):
+        out = server.create_character(cid, f"L1 {cls}", kind="player", class_name=cls,
+                                      level=1, apply_srd_defaults=True)
+        sheet = server.get_character(cid, out["id"])
+        assert sheet["spell_slots"], f"L1 {cls} must have spell slots"
+        assert sheet["spell_slots"]["1"]["maximum"] == 2, cls
+        assert sheet["spells_known"], f"L1 {cls} must seed a starting loadout"
+        assert spell in sheet["spells_prepared"], cls
 
 
 def test_warlock_pact():

--- a/servers/engine/tests/test_seat_paths.py
+++ b/servers/engine/tests/test_seat_paths.py
@@ -1,0 +1,277 @@
+"""Cross-path character-seat integrity (audit F02-1 + F02-4, issues #788 / #802).
+
+The five seat paths (create_character / start_character fresh+promote / load_canon_character /
+recruit_companion) had drifted into asymmetry: each hand-rolled a different subset of the
+finishing steps, so a pickup-origin PC seated at flat 10/10/10/10/10/10 (every check/save/DC
+at +0 — the May-31 Alfira) while canon-loaded players and recruited companions seated with an
+SRD armor AC over an EMPTY inventory and 0 gp (53 wild snapshot records).
+
+These tests guard the shared finisher (`server._finish_seat_sheet`) that every seat path now
+routes through:
+  * F02-1 — ability backfill: rec `abilities` block -> class+level derived array -> placeholder,
+    with initiative reset from the real DEX; explicit args always win; promote repairs a
+    flat-10 roster stub but never a hand-fleshed sheet; `ability_source` surfaces the winner.
+  * F02-4 — gear+purse seeding on load_canon (player/companion seats) and recruit_companion,
+    self-guarded so an authored kit/purse is untouched; lore NPC loads stay gearless.
+"""
+
+import pytest
+
+import content
+import server
+from models import Ability, Item
+
+WORLD = "baldurs-gate"
+ABK = ("strength", "dexterity", "constitution", "intelligence", "wisdom", "charisma")
+
+
+def _seed(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    c = content.seed_world(content.load_world_data(WORLD))
+    server.save_campaign(c)
+    return c
+
+
+def _vals(ch):
+    return {f: getattr(ch.abilities, f) for f in ABK}
+
+
+def _is_flat10(ch):
+    return all(v == 10 for v in _vals(ch).values())
+
+
+def _fake_canon(monkeypatch, rec):
+    """Route the content loader at a synthetic canon record (the test-canon pattern
+    test_canon_abilities.py established) so the FRESH-BUILD pickup path runs (the name
+    matches no seeded roster NPC, so no promote-in-place)."""
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: dict(rec))
+
+
+# --- F02-1: pickup / veteran / classed-nobody ability backfill ---------------------
+
+
+def test_pickup_origin_derives_abilities_not_flat10(tmp_path, monkeypatch):
+    # THE F02-1 defect: a pickup-origin PC seated all-10s (May-31 Alfira fingerprint).
+    c = _seed(tmp_path, monkeypatch)
+    _fake_canon(monkeypatch, {"name": "Vess Tallow", "class": "Ranger", "level": "5"})
+    res = server.start_character(c.id, origin="pickup:Vess Tallow")
+    assert "error" not in res
+    assert res["ability_source"] == "derived"
+    ch = server._require(c.id).characters[res["id"]]
+    assert not _is_flat10(ch), "pickup PC must NOT seat at the flat-10 placeholder"
+    # Ranger: DEX primary (15, +2 from the L4 ASI at level 5 -> 17); initiative from real DEX.
+    assert ch.abilities.dexterity == max(_vals(ch).values()) > 10
+    assert ch.initiative_bonus == ch.abilities.modifier(Ability.DEX) > 0
+    # HP computed off the REAL CON (the flat-10 probe seated a L5 ranger at 34).
+    assert ch.max_hp > 34
+    assert res["warnings"] == []  # a real sheet -> no placeholder warning
+
+
+def test_pickup_origin_honors_canon_abilities_block(tmp_path, monkeypatch):
+    c = _seed(tmp_path, monkeypatch)
+    explicit = {"strength": 8, "dexterity": 17, "constitution": 13,
+                "intelligence": 12, "wisdom": 14, "charisma": 11}
+    _fake_canon(monkeypatch, {"name": "Vess Tallow", "class": "Ranger", "level": "3",
+                              "abilities": dict(explicit)})
+    res = server.start_character(c.id, origin="pickup:Vess Tallow")
+    assert "error" not in res
+    assert res["ability_source"] == "canon"
+    ch = server._require(c.id).characters[res["id"]]
+    for f, v in explicit.items():
+        assert getattr(ch.abilities, f) == v, f
+    assert ch.initiative_bonus == ch.abilities.modifier(Ability.DEX) == 3
+
+
+def test_pickup_origin_explicit_abilities_arg_wins_over_rec(tmp_path, monkeypatch):
+    c = _seed(tmp_path, monkeypatch)
+    _fake_canon(monkeypatch, {"name": "Vess Tallow", "class": "Ranger", "level": "1",
+                              "abilities": {"dexterity": 17}})
+    mine = {"strength": 14, "dexterity": 12, "constitution": 15,
+            "intelligence": 10, "wisdom": 13, "charisma": 8}
+    res = server.start_character(c.id, origin="pickup:Vess Tallow", abilities=dict(mine))
+    assert "error" not in res
+    assert res["ability_source"] == "explicit"
+    ch = server._require(c.id).characters[res["id"]]
+    for f, v in mine.items():
+        assert getattr(ch.abilities, f) == v, f
+
+
+def test_pickup_promote_repairs_flat10_roster_stub(tmp_path, monkeypatch):
+    # B-MED-1 promote path: the roster stub is flat-10; pickup must repair it (F02-1's
+    # promote-when-flat), not keep the placeholder.
+    c = _seed(tmp_path, monkeypatch)
+    res = server.start_character(c.id, origin="pickup:Minsc")
+    assert "error" not in res and res.get("promoted_existing") is True
+    assert res["ability_source"] in ("canon", "derived")
+    ch = server._require(c.id).characters[res["id"]]
+    assert not _is_flat10(ch), "promoted roster stub must be repaired, not left flat-10"
+    assert ch.initiative_bonus == ch.abilities.modifier(Ability.DEX)
+    assert res["warnings"] == []
+
+
+def test_pickup_promote_keeps_hand_fleshed_roster_sheet(tmp_path, monkeypatch):
+    # A roster record someone already fleshed out (non-flat) must WIN over derivation.
+    c = _seed(tmp_path, monkeypatch)
+    hand = {"strength": 13, "dexterity": 9, "constitution": 16,
+            "intelligence": 11, "wisdom": 15, "charisma": 12}
+    server.create_character(c.id, "Vess Tallow", kind="npc", abilities=dict(hand))
+    _fake_canon(monkeypatch, {"name": "Vess Tallow", "class": "Ranger", "level": "2"})
+    res = server.start_character(c.id, origin="pickup:Vess Tallow")
+    assert "error" not in res and res.get("promoted_existing") is True
+    assert res["ability_source"] == "explicit"
+    ch = server._require(c.id).characters[res["id"]]
+    for f, v in hand.items():
+        assert getattr(ch.abilities, f) == v, f
+
+
+def test_veteran_l5_without_abilities_is_not_flat10(tmp_path, monkeypatch):
+    c = _seed(tmp_path, monkeypatch)
+    res = server.start_character(c.id, origin="veteran_l5", name="Vet", class_name="ranger")
+    assert "error" not in res
+    assert res["ability_source"] == "derived"
+    ch = server._require(c.id).characters[res["id"]]
+    assert not _is_flat10(ch)
+    assert ch.abilities.dexterity == 17  # ranger primary 15 + one ASI (L4)
+    assert ch.initiative_bonus == ch.abilities.modifier(Ability.DEX) == 3
+
+
+def test_classed_nobody_l1_without_abilities_is_not_flat10(tmp_path, monkeypatch):
+    c = _seed(tmp_path, monkeypatch)
+    res = server.start_character(c.id, origin="nobody_l1", name="Greenhorn", class_name="fighter")
+    assert "error" not in res
+    assert res["ability_source"] == "derived"
+    ch = server._require(c.id).characters[res["id"]]
+    assert ch.abilities.strength == 15  # fighter primary, no ASI at L1
+    assert not _is_flat10(ch)
+
+
+def test_classless_nobody_keeps_flat10_and_warns(tmp_path, monkeypatch):
+    # A class-less nobody is the documented blank sheet — flat-10 stays, but the SAME
+    # placeholder warning load_canon emits must surface so QA/the DM SEES the +0 PC.
+    c = _seed(tmp_path, monkeypatch)
+    res = server.start_character(c.id, origin="nobody_l1", name="Drifter")
+    assert "error" not in res
+    assert res["ability_source"] == "placeholder"
+    ch = server._require(c.id).characters[res["id"]]
+    assert _is_flat10(ch)  # unchanged contract for the class-less origin
+    assert res["warnings"], "a flat-10 player must surface a placeholder warning"
+    assert "PLACEHOLDER" in res["warnings"][0]
+
+
+# --- F02-4: gear + purse on the load_canon and recruit seat paths -------------------
+
+
+def test_load_canon_player_seat_seeds_gear_and_purse(tmp_path, monkeypatch):
+    # Jun-9 Alfira fingerprint: AC 14 / inventory [] / 0 gp via load_canon.
+    c = _seed(tmp_path, monkeypatch)
+    rec = {"name": "Sera Quickstep", "class": "Rogue", "level": "3"}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: dict(rec))
+    res = server.load_canon_character(c.id, "Sera Quickstep", kind="player", add_to_party=True)
+    assert "error" not in res
+    ch = server._require(c.id).characters[res["id"]]
+    names = [i.name for i in ch.inventory]
+    assert "Studded Leather" in names, f"AC-justifying armor missing: {names}"
+    assert any(i.name == "Studded Leather" and i.equipped for i in ch.inventory)
+    assert ch.currency.gp > 0, "seated player must not start broke (merchant pillar)"
+
+
+def test_load_canon_companion_seat_seeds_gear_and_purse(tmp_path, monkeypatch):
+    c = _seed(tmp_path, monkeypatch)
+    rec = {"name": "Brother Hale", "class": "Cleric", "level": "2"}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: dict(rec))
+    res = server.load_canon_character(c.id, "Brother Hale", kind="companion", add_to_party=True)
+    assert "error" not in res
+    ch = server._require(c.id).characters[res["id"]]
+    assert any(i.name == "Chain Mail" and i.equipped for i in ch.inventory)
+    assert ch.currency.gp > 0
+
+
+def test_load_canon_lore_npc_stays_gearless(tmp_path, monkeypatch):
+    # The seeding is a PARTY-seat affordance — a lore NPC pulled in for an encounter
+    # must not pocket a PC starting kit.
+    c = _seed(tmp_path, monkeypatch)
+    rec = {"name": "Quartermaster Lunt", "class": "Fighter", "level": "4"}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: dict(rec))
+    res = server.load_canon_character(c.id, "Quartermaster Lunt", kind="npc")
+    assert "error" not in res
+    ch = server._require(c.id).characters[res["id"]]
+    assert ch.inventory == []
+    assert ch.currency.gp == 0
+
+
+def test_recruit_companion_seeds_gear_and_purse(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Recruit gear")["id"]
+    npc = server.create_character(cid, "Bram", kind="npc")["id"]
+    server.recruit_companion(cid, npc, class_name="Fighter")
+    ch = server._require(cid).characters[npc]
+    assert any(i.name == "Chain Mail" and i.equipped for i in ch.inventory)
+    assert any(i.name == "Longsword" for i in ch.inventory)
+    assert ch.currency.gp > 0
+
+
+def test_recruit_companion_respects_authored_kit_and_purse(tmp_path, monkeypatch):
+    # The seeder self-guards: an authored inventory AND a non-zero purse win verbatim.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Recruit guard")["id"]
+    npc = server.create_character(cid, "Maeve", kind="npc")["id"]
+    c = server._require(cid)
+    c.characters[npc].inventory = [Item(name="Heirloom Blade", equipped=True)]
+    c.characters[npc].currency.gp = 3
+    server.save_campaign(c)
+    server.recruit_companion(cid, npc, class_name="Fighter")
+    ch = server._require(cid).characters[npc]
+    assert [i.name for i in ch.inventory] == ["Heirloom Blade"]
+    assert ch.currency.gp == 3
+
+
+def test_recruit_companion_backfills_flat10_stub_abilities(tmp_path, monkeypatch):
+    # Routing recruit through the SAME shared finisher means a bare roster stub gains a
+    # class-appropriate array (and HP computed off real CON), not a +0-everything sheet.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Recruit backfill")["id"]
+    npc = server.create_character(cid, "Bram", kind="npc")["id"]
+    server.recruit_companion(cid, npc, class_name="Fighter")
+    ch = server._require(cid).characters[npc]
+    assert not _is_flat10(ch)
+    assert ch.abilities.strength == 15
+    assert ch.initiative_bonus == ch.abilities.modifier(Ability.DEX)
+
+
+def test_recruit_companion_explicit_abilities_still_win(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Recruit explicit")["id"]
+    npc = server.create_character(cid, "Bram", kind="npc")["id"]
+    server.recruit_companion(cid, npc, class_name="Fighter",
+                             abilities={"strength": 18, "constitution": 14})
+    ch = server._require(cid).characters[npc]
+    assert ch.abilities.strength == 18 and ch.abilities.constitution == 14
+
+
+# --- the cross-path net: every classed party seat is armed, funded, and statted -----
+
+
+def test_all_party_seat_paths_yield_playable_funded_sheets(tmp_path, monkeypatch):
+    """Census-lite (the F02-18 spirit on the paths this fix-set touches): every classed
+    player/companion seat ends non-flat with a non-empty pack and a non-zero purse."""
+    c = _seed(tmp_path, monkeypatch)
+    cid = c.id
+    seated = []
+    seated.append(server.create_character(
+        cid, "Crea", kind="companion", class_name="rogue", apply_srd_defaults=True,
+        abilities={"dexterity": 16, "constitution": 12})["id"])
+    seated.append(server.start_character(cid, name="Star", class_name="fighter")["id"])
+    rec = {"name": "Canon Cleric", "class": "Cleric", "level": "2"}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: dict(rec))
+    seated.append(server.load_canon_character(cid, "Canon Cleric", kind="companion",
+                                              add_to_party=True)["id"])
+    npc = server.create_character(cid, "Rook", kind="npc")["id"]
+    server.recruit_companion(cid, npc, class_name="Ranger")
+    seated.append(npc)
+    live = server._require(cid)
+    for sid in seated:
+        ch = live.characters[sid]
+        assert not _is_flat10(ch), f"{ch.name} seated flat-10"
+        assert ch.inventory, f"{ch.name} seated with an empty pack"
+        assert ch.currency.gp > 0, f"{ch.name} seated broke"
+        assert ch.initiative_bonus == ch.abilities.modifier(Ability.DEX), ch.name


### PR DESCRIPTION
Closes #788, closes #796, closes #802, closes #786. Audit findings F02-1, F02-2, F02-4, F14-8 (docs/audits/ENGINE-AUDIT-2026-06-11.md; skeptic-verified unit-02/unit-14).

## Root causes
- **F02-1 (#788)** — the `pickup:` branch of `start_character` copied identity but never `rec["abilities"]` and never called `_derive_canon_abilities`; the fresh build then seated `AbilityScores(**{})` → flat 10/10/10/10/10/10 (+0 on every check/save/DC; the May-31 Alfira wild record). The promote branch only honored explicit `abilities`, so a flat roster stub was never repaired. Same gap for `veteran_l5` / classed `nobody_l1`.
- **F02-2 (#796)** — `_recompute_spellcasting` routes all casters through `multiclass_slots`, and `effective_caster_level` computed half-casters as `level // 2` (2014 round-down): a L1 paladin/ranger had ZERO slots; L3/L5 wrong under any edition. Compounded by a `level < 2` seed gate in `_seed_starting_spells`.
- **F02-4 (#802)** — `_seed_starting_gear` was called on only 2 of 5 seat paths; `load_canon_character` and `recruit_companion` applied the SRD class AC but never the armor that justifies it (53 wild player records with AC≥14 and no armor item; Jun-9 Alfira AC 14 / inventory [] / 0 gp).
- **F14-8 (#786)** — `_char` was a bare dict-get-and-raise; ~60 id-taking tools dead-ended on any id slip (`maddala-deadeye` for `char_…` "Maddala Deadeye" — the gate-duo2 double failure) with an error naming neither the valid ids nor the obvious match.

## Fix (the audit's fix shape: extract the shared helper, stop patching one path)
- New `_finish_seat_sheet` (ability backfill → `_apply_srd_class_defaults` → `_seed_starting_gear`, in that order so HP/AC/initiative compute off REAL scores; every step self-guards). **All seat call sites route through it**: `create_character` (behavior-preserving: its omitted-`abilities` contract keeps the explicit flat sheet), `start_character` fresh + promote, `load_canon_character` (gear only for player/companion seats — lore NPCs stay gearless), `recruit_companion`.
- New `_backfill_seat_abilities`: non-flat sheet wins ("explicit") → rec `abilities` block ("canon", malformed degrades) → class+level standard array ("derived") → flat-10 ("placeholder"); initiative resets from real DEX on every assignment. `start_character` now returns `ability_source` + the same flat-10 PLACEHOLDER warning `load_canon_character` surfaces (additive keys).
- `effective_caster_level`: half → `(level+1)//2`, third → `(level+2)//3` (SRD 5.2 round-up). With ceil the multiclass table reproduces the **PHB half-caster class column exactly at every single-class level** (L1→[2], L3→[3], L5→[4,2], L9→[4,3,2], L13→[4,3,3,1], L17→[4,3,3,3,1], L19→[4,3,3,3,2]) — half-casters get their own progression column. Seed gate dropped so the L1 loadout seeds. Slots re-derive only on mutation → old snapshots round-trip (no model changes anywhere in this PR).
- `_char` resolve-then-suggest, ONE site inherited by all ~60 tools: exact key → unique case-insensitive id/name/slugified-name → unique substring → raise the SAME-SHAPED `ValueError("no character … in campaign")` with a difflib top-5 did-you-mean of `id (name, kind)` (≤5 candidates, ~≤300B). Ambiguity (two NPCs named "Guard") NEVER resolves; resolution is read-only so failed calls mutate nothing; fuzzy hits echo on stderr for QA. `get_character`'s inline duplicate raise now routes through `_char`.

## Deliberate scope decisions
- `reroll_character` untouched — F02-12 owns its gear/AC story ("Leave reroll alone…" per the F02-4 spec).
- F14-20 rider (param-NAME aliases on 9 tools) dropped per the audit's own branch ("drop if F14-8's resolver lands first") — the only observed failure mode was wrong VALUE, which the resolver fixes for all nine at once since they route through `_char`.
- `resolved_from` echo is on stderr (QA captures it) instead of a new key in ~60 tool returns — keeps the wire contracts frozen; the issue offered both shapes ("decide in the PR; both invariant-safe").

## Tests (red-first)
- `tests/test_seat_paths.py` (15): pickup derive/canon-block/explicit-wins, promote-repairs-flat / keeps hand-fleshed, veteran+nobody derivation, class-less warning, load_canon gear (player/companion/lore-NPC), recruit gear + authored-kit guard + stub backfill + explicit-wins, cross-path census-lite.
- `tests/test_char_resolver.py` (10): exact id, slug, case-insensitive, substring, typo did-you-mean (id+name in message), ambiguity never resolves, plain error shape, award_xp slug inheritance, no-mutation-on-failure, get_character routing.
- `tests/test_progression.py`: multiclass rows updated to SRD 5.2 (Paladin-1 `{}`→`{1:2}`), PHB half-caster column parity at 8 levels × paladin+ranger, L1 creation has slots + seeded spells.

## Verification
- Full engine suite: **1842 passed** (`uv run --directory servers/engine python -m pytest tests -q -p no:xdist`).
- `qa/fast_gate.sh` Tier-0: **PASS** (188 deterministic).

DO NOT MERGE — awaiting review per the audit workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Character name resolution now supports fuzzy matching, case-insensitive search, and unique substring matching with "did you mean" suggestions for typos.

* **Bug Fixes**
  * Half-caster classes (Paladin, Ranger) now receive starting spells at level 1.
  * Improved ability score backfill consistency across all character creation paths.
  * Canon characters and companions now properly seed starting gear and gold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->