### PR TITLE
fix(engine): finesse melee numbers + Sneak Attack surface + mechanical teeth for Bless/Bane/Shield of Faith/Shield (audit F01-4, F01-5, SYN-06)

### DIFF
--- a/servers/engine/combat.py
+++ b/servers/engine/combat.py
@@ -53,6 +53,27 @@ def spell_grants_advantage(spell_name: str) -> bool:
     return spell_name in _ADVANTAGE_GRANTING_SPELLS
 
 
+# Curated numeric-rider registry (audit SYN-06 / #780, merging F01-6 + F03-1): the spells
+# whose tracked ActiveEffect carries a MECHANICAL modifier the engine itself applies —
+# mirrors the _ADVANTAGE_GRANTING_SPELLS pattern above. Keyed by canonical spell name;
+# values are the ActiveEffect field overrides copied at cast time. A leading '-' on a dice
+# expression means the rolled amount is SUBTRACTED (Bane). SCOPE DISCIPLINE: exactly these
+# four spells (Bless +1d4 attack/save, Bane -1d4, Shield of Faith +2 AC, Shield +5 AC);
+# every other spell stays narrative exactly as before.
+_SPELL_EFFECT_RIDERS: dict[str, dict] = {
+    "Bless": {"attack_bonus_dice": "1d4", "save_bonus_dice": "1d4"},
+    "Bane": {"attack_bonus_dice": "-1d4", "save_bonus_dice": "-1d4"},
+    "Shield of Faith": {"ac_bonus": 2},
+    "Shield": {"ac_bonus": 5},
+}
+
+
+def spell_effect_riders(spell_name: str) -> dict | None:
+    """The curated mechanical rider fields for this spell's tracked effect (SYN-06), or
+    None for every un-curated spell (the overwhelmingly common case). Pure."""
+    return _SPELL_EFFECT_RIDERS.get(spell_name)
+
+
 def advantage_granting_effect(target: Character):
     """The first active_effect on ``target`` flagged as granting advantage to the next
     attack against it (Guiding Bolt's rider), or None. Pure — no mutation; attack() reads

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -535,6 +535,25 @@ class ActiveEffect(_StrictModel):
     # live sheet values when an older Mage Armor effect lacks the metadata.
     armor_base_ac: int = 0
     armor_formula_ac: int = 0
+    # GENERIC MECHANICAL RIDERS (audit SYN-06 / #780): before these fields, Bless / Bane /
+    # Shield of Faith / Shield were stored + duration-ticked and then IGNORED by every
+    # resolver — buffs were unrepresentable, not merely unautomated. Populated at cast_spell
+    # time from combat.spell_effect_riders (a curated registry mirroring
+    # _ADVANTAGE_GRANTING_SPELLS); consumed by _effective_armor_class (ac_bonus) and by
+    # attack / saving_throw / concentration_save / next_turn's repeat save (bonus dice —
+    # the ENGINE rolls them and surfaces the component). A leading '-' on a dice expression
+    # means the rolled amount is SUBTRACTED (Bane). All default to inert, so every existing
+    # effect and old snapshot deserializes unchanged.
+    ac_bonus: int = 0
+    attack_bonus_dice: str = ""  # e.g. "1d4" (Bless), "-1d4" (Bane); "" = none
+    save_bonus_dice: str = ""    # same convention, folded into saving throws
+    # A concentration CHILD effect: this effect lives on a TARGET of someone else's
+    # concentration spell (Bless on an ally) and must end the moment the caster
+    # (`source_id`) stops concentrating on the spell of this name. Swept by next_turn's
+    # inverse-link reconciliation and by drop_concentration — the same linkage repeat-save
+    # markers use, extended to numeric riders (the naive caster-side-only expiry provably
+    # never reached these). Defaults False: old snapshots and ordinary effects untouched.
+    linked_to_concentration: bool = False
 
 
 class PendingDamageBonus(_StrictModel):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -2232,12 +2232,16 @@ def _combat_numbers(ch: Character) -> dict:
     """The sheet-derived attack/save numbers the DM must pass to `attack` — surfaced so the
     DM reads AUTHORITATIVE values instead of inventing them (QA: a Rogue's to-hit was narrated
     as +7 by copying another combatant when the sheet gave +3). `attack` trusts the bonus you
-    hand it, so the correct number has to be visible at the point of attack. Melee uses STR,
-    ranged/finesse uses DEX; damage modifiers are the same ability mod."""
+    hand it, so the correct number has to be visible at the point of attack. Melee uses STR —
+    UNLESS the character carries a FINESSE weapon (audit F01-4 / #774): finesse uses
+    max(STR, DEX) on attack AND damage, so a rapier rogue's surfaced melee numbers are the
+    DEX ones, not a wrong STR line. Ranged uses DEX; damage modifiers are the same ability
+    mod. A rogue's Sneak Attack dice are surfaced too (audit F01-5 / #166) — the sheet tracks
+    them but the attack trigger never showed them, hiding ~half the class's damage."""
     prof = ch.proficiency_bonus
     str_mod = ch.ability_modifier(Ability.STR)
     dex_mod = ch.ability_modifier(Ability.DEX)
-    return {
+    nums = {
         "proficiency_bonus": prof,
         "ability_mods": {a.value: ch.ability_modifier(a) for a in Ability},
         "melee_attack_bonus": prof + str_mod,        # STR weapon
@@ -2247,6 +2251,40 @@ def _combat_numbers(ch: Character) -> dict:
         "note": "Pass these to attack(attack_bonus=…, damage_dice='NdM+<mod>'); the engine "
                 "trusts the number, so use the sheet's — never copy another combatant's.",
     }
+    # FINESSE (#774): if the character carries a finesse weapon (equipped first, else any
+    # carried), melee attack AND damage use max(STR, DEX) — 5e's finesse rule. Read-surface
+    # only: attack() keeps trusting the bonus the DM passes; non-finesse loadouts are
+    # byte-identical (no key, same numbers).
+    fin = next((it.name for it in ch.inventory
+                if it.equipped and srd_tables.is_finesse_weapon(it.name)), None)
+    if fin is None:
+        fin = next((it.name for it in ch.inventory
+                    if srd_tables.is_finesse_weapon(it.name)), None)
+    if fin is not None:
+        best = max(str_mod, dex_mod)
+        ability = "dex" if dex_mod > str_mod else "str"
+        nums["melee_attack_bonus"] = prof + best
+        nums["melee_damage_mod"] = best
+        nums["finesse"] = {
+            "weapon": fin,
+            "ability": ability,
+            "note": (f"{fin} is a finesse weapon — melee attack/damage use "
+                     f"max(STR, DEX) = {ability.upper()} here."),
+        }
+    # SNEAK ATTACK (F01-5, enriches #166): surface the sheet's dice + the 5e trigger at the
+    # point of attack, as a ready-to-pass damage_rolls component — the engine then rolls it
+    # (and crit-doubles it) through the existing multi-component path (#210). Absent for
+    # non-rogues (byte-identical).
+    if ch.sneak_attack_dice:
+        nums["sneak_attack"] = {
+            "dice": ch.sneak_attack_dice,
+            "note": (f"Sneak Attack, ONCE PER TURN: when the attack has advantage, OR an "
+                     f"ally is within 5 ft of the target and the attack lacks disadvantage, "
+                     f"add it to that attack's damage_rolls as a component "
+                     f"{{'dice': '{ch.sneak_attack_dice}', 'type': <weapon damage type>}} — "
+                     f"the engine rolls it and doubles it on a crit."),
+        }
+    return nums
 
 
 @mcp.tool()
@@ -3378,6 +3416,9 @@ def _turn_brief(ch: "Character", c: "Campaign") -> dict:
                 "ranged_damage_mod": nums["ranged_damage_mod"],
                 "extra_attacks": int(getattr(ch, "extra_attacks", 0)),
             }
+            for cue in ("finesse", "sneak_attack"):  # F01-4/F01-5: carry the cues per-turn
+                if cue in nums:
+                    brief["attack"][cue] = nums[cue]
             brief["note"] = "No bestiary data — use derived bonuses above; never invent."
     else:
         nums = _combat_numbers(ch)
@@ -3391,6 +3432,11 @@ def _turn_brief(ch: "Character", c: "Campaign") -> dict:
             "extra_attacks": extra,
             "attacks_per_action": attacks_per_action,
         }
+        # F01-4/F01-5 (#774/#166): the per-turn brief is the surface the DM actually reads
+        # each turn — carry the finesse and Sneak Attack cues here too, not just on the sheet.
+        for cue in ("finesse", "sneak_attack"):
+            if cue in nums:
+                brief["attack"][cue] = nums[cue]
         brief["note"] = (
             f"Declare use_action(kind='action') then make {attacks_per_action} attack call(s) "
             "using the sheet bonuses above — never invent or copy another combatant's."
@@ -3525,17 +3571,25 @@ def next_turn(campaign_id: str) -> dict:
                     f"1d20+{previous.saving_throw_bonus(rs.ability)}",
                     disadvantage=disadvantage,
                 )
-                success = (not auto_fail) and r.total >= rs.dc
+                # NUMERIC RIDERS (SYN-06 / #780): the end-of-turn repeat save is a saving
+                # throw — fold the holder's engine-tracked save bonus dice (Bless/Bane).
+                rs_rider_bonus, rs_rider_rolls = _roll_effect_bonus_dice(
+                    previous, "save_bonus_dice"
+                )
+                rs_total = r.total + rs_rider_bonus
+                success = (not auto_fail) and rs_total >= rs.dc
                 entry = {
                     "character_id": previous.id,
                     "name": eff.name,
                     "ability": rs.ability.value,
                     "dc": rs.dc,
-                    "roll": r.total,
+                    "roll": rs_total,
                     "natural": r.natural,
                     "success": success,
                     "ended": False,
                 }
+                if rs_rider_rolls:
+                    entry["bonus_dice"] = rs_rider_rolls
                 if auto_fail:
                     forcing = ", ".join(
                         cn.value for cn in previous.conditions if cn in combat.SAVE_AUTOFAIL
@@ -3614,12 +3668,17 @@ def next_turn(campaign_id: str) -> dict:
         # recast) — the spell is over, so the target must be freed here rather than staying
         # paralyzed indefinitely. Sweep every combatant's markers: when the source caster no
         # longer concentrates on that spell, drop the marker + clear the condition it imposed.
+        # SYN-06 (#780) extends the same sweep to concentration-linked NUMERIC-rider children
+        # (Bless on an ally lives target-side as a linked child) — before that, the naive
+        # caster-side expiry provably never reached them and the buff outlived the spell.
         for cb in order:
             holder = c.characters.get(cb.character_id)
             if holder is None:
                 continue
             for eff in list(holder.active_effects):
-                if eff.repeat_save is None or not eff.source_id:
+                if eff.repeat_save is None and not eff.linked_to_concentration:
+                    continue
+                if not eff.source_id:
                     continue
                 caster = c.characters.get(eff.source_id)
                 # Marker is orphaned when the caster is gone, or no longer concentrating on
@@ -3771,8 +3830,33 @@ def remove_combatant(campaign_id: str, character_id: str) -> dict:
         return _combat_view(c)
 
 
+def _roll_effect_bonus_dice(ch: Character, field: str) -> tuple[int, list[dict]]:
+    """Roll the numeric-rider bonus dice carried by ``ch``'s active effects (SYN-06 / #780:
+    Bless +1d4 / Bane -1d4) for the given field ('attack_bonus_dice' or 'save_bonus_dice').
+    THE ENGINE ROLLS — each component is rolled here and surfaced so the DM narrates the
+    d4 instead of being told a buff exists and then watching the engine ignore it. A
+    leading '-' subtracts the rolled amount (Bane). Returns (signed_total, components);
+    (0, []) for the overwhelmingly common no-rider case — byte-identical behavior."""
+    total = 0
+    rolls: list[dict] = []
+    for eff in ch.active_effects or []:
+        expr = (getattr(eff, field, "") or "").strip()
+        if not expr:
+            continue
+        sign = -1 if expr.startswith("-") else 1
+        r = dice_mod.roll(expr.lstrip("+-"))
+        signed = sign * r.total
+        total += signed
+        rolls.append({"source": eff.name, "dice": expr, "rolled": signed, "detail": r.detail})
+    return total, rolls
+
+
 def _effective_armor_class(ch: Character) -> tuple[int, dict | None]:
-    """Return the AC the attack resolver should use, including engine-tracked buffs."""
+    """Return the AC the attack resolver should use, including engine-tracked buffs:
+    Mage Armor's set-AC formula (the original special case) plus any additive ``ac_bonus``
+    riders (SYN-06 / #780 — Shield of Faith +2, Shield +5). Bonuses stack on top of
+    whichever base/formula AC wins, and each contribution is itemized in the detail dict
+    (``ac_bonuses``) so the DM sees WHY the AC moved."""
     base_ac = int(ch.armor_class or 10)
     mage_armor = next(
         (
@@ -3783,25 +3867,40 @@ def _effective_armor_class(ch: Character) -> tuple[int, dict | None]:
         None,
     )
     if mage_armor is None:
-        return base_ac, None
-    dex_mod = ch.ability_modifier(Ability.DEX)
-    mage_ac = mage_armor.armor_formula_ac or (13 + dex_mod)
-    stored_base_ac = mage_armor.armor_base_ac or base_ac
-    if mage_ac <= base_ac:
-        return base_ac, {
-            "source": "Mage Armor",
-            "base_ac": stored_base_ac,
-            "formula_ac": mage_ac,
-            "dex_modifier": dex_mod,
-            "applied": False,
-        }
-    return mage_ac, {
-        "source": "Mage Armor",
-        "base_ac": stored_base_ac,
-        "formula_ac": mage_ac,
-        "dex_modifier": dex_mod,
-        "applied": True,
-    }
+        ac, detail = base_ac, None
+    else:
+        dex_mod = ch.ability_modifier(Ability.DEX)
+        mage_ac = mage_armor.armor_formula_ac or (13 + dex_mod)
+        stored_base_ac = mage_armor.armor_base_ac or base_ac
+        if mage_ac <= base_ac:
+            ac, detail = base_ac, {
+                "source": "Mage Armor",
+                "base_ac": stored_base_ac,
+                "formula_ac": mage_ac,
+                "dex_modifier": dex_mod,
+                "applied": False,
+            }
+        else:
+            ac, detail = mage_ac, {
+                "source": "Mage Armor",
+                "base_ac": stored_base_ac,
+                "formula_ac": mage_ac,
+                "dex_modifier": dex_mod,
+                "applied": True,
+            }
+    # Additive AC riders (SYN-06): sum every active effect's ac_bonus (Shield of Faith +2,
+    # Shield +5) on top. No riders == today's return exactly (incl. detail None).
+    bonus_effects = [
+        eff for eff in (ch.active_effects or [])
+        if int(getattr(eff, "ac_bonus", 0) or 0) != 0
+    ]
+    if bonus_effects:
+        ac += sum(int(eff.ac_bonus) for eff in bonus_effects)
+        detail = dict(detail) if detail is not None else {}
+        detail["ac_bonuses"] = [
+            {"source": eff.name, "bonus": int(eff.ac_bonus)} for eff in bonus_effects
+        ]
+    return ac, detail
 
 
 @mcp.tool()
@@ -3939,8 +4038,14 @@ def attack(
         adv = advantage or cadv
         dis = disadvantage or cdis
         atk = dice_mod.roll(f"1d20+{attack_bonus}", advantage=adv, disadvantage=dis)
+        # NUMERIC RIDERS (SYN-06 / #780): fold the attacker's engine-tracked bonus dice
+        # (Bless +1d4 / Bane -1d4) into the attack total — the engine ROLLS the rider it
+        # advertises instead of tracking it as theater. Nat-20 auto-hit / nat-1 auto-miss
+        # still read the natural die; no riders == atk.total exactly as before.
+        rider_bonus, rider_rolls = _roll_effect_bonus_dice(attacker, "attack_bonus_dice")
+        atk_total = atk.total + rider_bonus
         target_ac, target_ac_detail = _effective_armor_class(target)
-        hit = atk.crit or (not atk.fumble and atk.total >= target_ac)
+        hit = atk.crit or (not atk.fumble and atk_total >= target_ac)
         # PARRY (#218): a defender with an available defensive reaction (+N AC vs one melee
         # attack it can see) turns the blow aside — but ONLY when doing so FLIPS this hit to a
         # miss. The engine never wastes the reaction on a crit it can't stop or a blow that
@@ -3954,7 +4059,7 @@ def attack(
             and c.combat.active
             and not combat.is_incapacitated(target)
             and Condition.BLINDED not in target.conditions
-            and atk.total < target_ac + target.parry
+            and atk_total < target_ac + target.parry
         ):
             target_cb = next(
                 (cb for cb in c.combat.order if cb.character_id == target_id), None
@@ -3969,7 +4074,7 @@ def attack(
                     "effective_ac": eff_ac,
                     "note": (
                         f"{target.name} spends its reaction to Parry — AC rises to {eff_ac}, "
-                        f"and the blow ({atk.total}) turns aside"
+                        f"and the blow ({atk_total}) turns aside"
                     ),
                 }
         # SRD: a melee hit against an unconscious/paralyzed creature auto-crits.
@@ -3980,7 +4085,7 @@ def attack(
         result = {
             "attacker": attacker.name,
             "target": target.name,
-            "attack_roll": {"total": atk.total, "natural": atk.natural, "detail": atk.detail},
+            "attack_roll": {"total": atk_total, "natural": atk.natural, "detail": atk.detail},
             "advantage": adv,
             "disadvantage": dis,
             "crit": is_crit,
@@ -3991,6 +4096,10 @@ def attack(
             "target_base_ac": target.armor_class,
             "damage": None,
         }
+        if rider_rolls:
+            # The engine-rolled rider components (SYN-06), itemized so the DM narrates
+            # "the blessing guides the blade (+3)" — and sees the buff actually counted.
+            result["attack_roll"]["bonus_dice"] = rider_rolls
         if target_ac_detail is not None:
             result["target_ac_detail"] = target_ac_detail
         # Commit the action economy now — an attack spends its action/reaction whether
@@ -4232,7 +4341,7 @@ def attack(
                         "effective_ac": eff_ac,
                         "note": (f"{target.name} has a Parry reaction (+{target.parry} AC vs one "
                                  f"melee hit) but it would not have stopped this blow (roll "
-                                 f"{atk.total} >= effective AC {eff_ac}). Reaction NOT spent — "
+                                 f"{atk_total} >= effective AC {eff_ac}). Reaction NOT spent — "
                                  "narrate the attempted-but-overwhelmed defense if you like."),
                     }
         outcome_label = "crit" if is_crit else ("hit" if hit else "miss")
@@ -4264,12 +4373,14 @@ def attack(
                     "ac_detail": target_ac_detail,
                 },
                 "roll": {
-                    "total": atk.total,
+                    "total": atk_total,
                     "natural": atk.natural,
                     "detail": atk.detail,
                     "attack_bonus": attack_bonus,
                     "advantage": adv,
                     "disadvantage": dis,
+                    # SYN-06: engine-rolled rider components (Bless/Bane), when any
+                    **({"bonus_dice": rider_rolls} if rider_rolls else {}),
                 },
                 "damage": result["damage"],
                 "target_state": result.get("target_state"),
@@ -4377,21 +4488,28 @@ def concentration_save(campaign_id: str, character_id: str, dc: int) -> dict:
         c = _require(campaign_id)
         ch = _char(c, character_id)
         r = dice_mod.roll(f"1d20+{ch.saving_throw_bonus(Ability.CON)}")
-        maintained = r.total >= dc
+        # NUMERIC RIDERS (SYN-06 / #780): a concentration save is a saving throw — fold
+        # the engine-tracked save bonus dice (Bless +1d4 / Bane -1d4) like saving_throw.
+        rider_bonus, rider_rolls = _roll_effect_bonus_dice(ch, "save_bonus_dice")
+        total = r.total + rider_bonus
+        maintained = total >= dc
         expired: list[str] = []
         if not maintained:
             ch.concentration = None
             # The engine-tracked concentration effect ends with the concentration.
             expired = combat.expire_concentration_effects(ch)
         save_campaign(c)
-        return {
-            "roll": r.total,
+        out = {
+            "roll": total,
             "natural": r.natural,
             "dc": dc,
             "maintained": maintained,
             "concentration": ch.concentration,
             "expired_effects": expired,
         }
+        if rider_rolls:
+            out["bonus_dice"] = rider_rolls
+        return out
 
 
 @mcp.tool()
@@ -4425,7 +4543,12 @@ def drop_concentration(campaign_id: str, character_id: str, reason: str = "") ->
         if was:
             for holder in list(c.characters.values()):
                 for eff in list(holder.active_effects):
-                    if eff.repeat_save is None or eff.source_id != character_id:
+                    # A repeat-save marker (Hold Person) OR a concentration-linked numeric-
+                    # rider child (Bless on an ally — SYN-06/#780): both are target-side
+                    # twins of THIS caster's concentration and end with it.
+                    if eff.repeat_save is None and not eff.linked_to_concentration:
+                        continue
+                    if eff.source_id != character_id:
                         continue
                     if eff.name != was:
                         continue
@@ -5362,11 +5485,21 @@ def cast_spell(
         # non-concentration buff with an explicit target holds it on that target.
         effect_holder = ch
         pending_rider = None  # set when the effect DEFERS to the spell-attack hit (#186)
+        # NUMERIC RIDERS (SYN-06 / #780): the curated <=4-spell registry (Bless, Bane,
+        # Shield of Faith, Shield) whose tracked effect carries a mechanical modifier the
+        # engine itself applies. A CONCENTRATION rider cast at a SEPARATE target ALSO
+        # writes a linked CHILD effect on that target (the caster-side twin stays the
+        # concentration tracker; the child carries the numbers and is released by the
+        # sweep paths when concentration ends). None for every other spell == byte-identical.
+        rider_fields = combat.spell_effect_riders(canonical)
+        rider_child_target = None
         if duration is not None:
             if not concentrates and target_id and target_id != character_id:
                 tgt = c.characters.get(target_id)
                 if tgt is not None:
                     effect_holder = tgt
+            if rider_fields and concentrates and target_id and target_id != character_id:
+                rider_child_target = c.characters.get(target_id)
             # ON-HIT RIDER DEFER (#186). An ATTACK-ROLL spell whose timed effect lands on a
             # SEPARATE target is a 5e on-hit rider (Guiding Bolt: "on a hit, the next attack
             # against it has Advantage"). The cast and the spell attack are two calls, so the
@@ -5419,17 +5552,52 @@ def cast_spell(
                     eff.expires_day, eff.expires_phase_index = _effect_clock_deadline(
                         c, duration["hours"], duration["days"]
                     )
+                # SYN-06: when THIS effect is the beneficiary record (self-cast / Shield /
+                # a non-concentration targeted buff), copy the curated rider numbers onto
+                # it. With a separate child target the caster-side twin stays a pure
+                # concentration tracker (blessing an ally must not also bless the caster).
+                if rider_fields and rider_child_target is None:
+                    eff.ac_bonus = int(rider_fields.get("ac_bonus", 0))
+                    eff.attack_bonus_dice = rider_fields.get("attack_bonus_dice", "")
+                    eff.save_bonus_dice = rider_fields.get("save_bonus_dice", "")
                 # Recasting the SAME spell on a holder refreshes (doesn't stack) it.
                 effect_holder.active_effects = [
                     e for e in effect_holder.active_effects if e.name != canonical
                 ]
                 effect_holder.active_effects.append(eff)
+                # SYN-06: the concentration-linked CHILD on the separate target — same
+                # clock as the twin, carries the mechanical rider, flagged so BOTH sweep
+                # paths (next_turn's inverse sweep + drop_concentration) release it the
+                # moment the caster's concentration ends. Refresh-not-stack, like the twin.
+                if rider_child_target is not None:
+                    child = ActiveEffect(
+                        name=canonical,
+                        source_id=character_id,
+                        concentration=False,
+                        scale=duration["scale"],
+                        rounds_remaining=duration["rounds"],
+                        until_long_rest=(duration["scale"] == "hours"),
+                        expires_day=eff.expires_day,
+                        expires_phase_index=eff.expires_phase_index,
+                        linked_to_concentration=True,
+                        ac_bonus=int(rider_fields.get("ac_bonus", 0)),
+                        attack_bonus_dice=rider_fields.get("attack_bonus_dice", ""),
+                        save_bonus_dice=rider_fields.get("save_bonus_dice", ""),
+                    )
+                    rider_child_target.active_effects = [
+                        e for e in rider_child_target.active_effects if e.name != canonical
+                    ]
+                    rider_child_target.active_effects.append(child)
         mod = _casting_mod(ch)
         prof = ch.proficiency_bonus
         c.characters[character_id] = Character.model_validate(ch.model_dump(mode="json"))
         if effect_holder is not ch:
             c.characters[effect_holder.id] = Character.model_validate(
                 effect_holder.model_dump(mode="json")
+            )
+        if rider_child_target is not None and rider_child_target is not effect_holder:
+            c.characters[rider_child_target.id] = Character.model_validate(
+                rider_child_target.model_dump(mode="json")
             )
         # An off-turn / reaction cast spends the caster's reaction (the combatant record
         # is separate from the character, so the re-validation above didn't touch it).
@@ -5477,6 +5645,22 @@ def cast_spell(
                 "rounds_remaining": duration["rounds"],
                 "concentration": concentrates,
             }
+            # SYN-06 (#780): tell the DM the buff has ENGINE-APPLIED teeth — which numbers,
+            # on whom — so it isn't narrated as flavor and then double-applied by hand.
+            if rider_fields:
+                result["effect_riders"] = {
+                    "holder_id": (
+                        rider_child_target.id if rider_child_target is not None
+                        else effect_holder.id
+                    ),
+                    **rider_fields,
+                    "note": (
+                        "Engine-applied: ac_bonus is folded into the holder's effective AC; "
+                        "attack/save bonus dice are rolled automatically on the holder's "
+                        "attack and saving throws and itemized in each roll's bonus_dice — "
+                        "do NOT add them again by hand."
+                    ),
+                }
         if curated is not None:
             result["automated"] = True
             result["effect"] = spells.resolve_effect(
@@ -5556,8 +5740,14 @@ def saving_throw(campaign_id: str, character_id: str, ability: str, dc: int) -> 
     ab = Ability(ability.lower())
     auto_fail, disadvantage = combat.save_modifiers(ch, ab)
     r = dice_mod.roll(f"1d20+{ch.saving_throw_bonus(ab)}", disadvantage=disadvantage)
-    out = {"ability": ab.value, "roll": r.total, "natural": r.natural, "dc": dc,
-           "success": (not auto_fail) and r.total >= dc}
+    # NUMERIC RIDERS (SYN-06 / #780): fold the engine-tracked save bonus dice (Bless +1d4 /
+    # Bane -1d4) into the total — the engine rolls the rider it advertises.
+    rider_bonus, rider_rolls = _roll_effect_bonus_dice(ch, "save_bonus_dice")
+    total = r.total + rider_bonus
+    out = {"ability": ab.value, "roll": total, "natural": r.natural, "dc": dc,
+           "success": (not auto_fail) and total >= dc}
+    if rider_rolls:
+        out["bonus_dice"] = rider_rolls
     if auto_fail:
         forcing = ", ".join(cn.value for cn in ch.conditions if cn in combat.SAVE_AUTOFAIL)
         out["reason"] = f"condition auto-fail: {ch.name} is {forcing} — STR/DEX saves automatically fail"

--- a/servers/engine/srd_tables.py
+++ b/servers/engine/srd_tables.py
@@ -52,6 +52,45 @@ def level_for_xp(xp: int) -> int:
     return lvl
 
 
+@functools.lru_cache(maxsize=None)
+def finesse_weapon_names() -> tuple[str, ...]:
+    """Lowercased display names of the SRD FINESSE weapons (audit F01-4 / #774), derived
+    from the raw srd524 dumps: WeaponPropertyAssignment.json maps the finesse property
+    slug (``srd-2024_finesse...`` — matched case-insensitively) to weapon slugs, and
+    Weapon.json maps those slugs to display names (slug-strip fallback when a name is
+    missing). Pure + cached; returns () when the data files are absent so the engine
+    never crashes on a trimmed data dir."""
+    base = _DIR / "srd524"
+    try:
+        assignments = json.loads((base / "WeaponPropertyAssignment.json").read_text(encoding="utf-8"))
+        weapons = json.loads((base / "Weapon.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return ()
+    slug_to_name = {
+        rec.get("pk", ""): str((rec.get("fields") or {}).get("name") or "")
+        for rec in weapons
+    }
+    names: list[str] = []
+    for rec in assignments:
+        f = rec.get("fields") or {}
+        if "finesse" not in str(f.get("property", "")).lower():
+            continue
+        slug = str(f.get("weapon", ""))
+        display = slug_to_name.get(slug) or slug.split("_", 1)[-1]
+        if display:
+            names.append(display.casefold())
+    return tuple(sorted(set(names)))
+
+
+def is_finesse_weapon(item_name: str) -> bool:
+    """Does this inventory item name a finesse weapon? Case-insensitive and
+    substring-tolerant so magic-item naming still matches ("Rapier +1", "Daggers")."""
+    n = (item_name or "").casefold()
+    if not n:
+        return False
+    return any(w in n for w in finesse_weapon_names())
+
+
 def class_data(name: str) -> dict:
     c = classes().get(name.lower())
     if c is None:

--- a/servers/engine/tests/test_effect_riders.py
+++ b/servers/engine/tests/test_effect_riders.py
@@ -1,0 +1,229 @@
+"""Engine-tracked buffs must have mechanical teeth (audit SYN-06 / #780, merges F01-6 + F03-1).
+
+Before this fix the engine advertised Bless / Bane / Shield of Faith / Shield in
+`active_effects`, ticked their durations — then authoritatively rolled WITHOUT them:
+ActiveEffect had no generic modifier fields at all (only the Mage Armor and
+Guiding-Bolt special cases). Worse, a concentration buff lived caster-side only, so
+Bless on an ally had no target-side record and could never expire with the caster's
+concentration (both sweep loops matched only repeat-save markers).
+
+The fix (per the audited spec):
+  * additive ActiveEffect fields ac_bonus / attack_bonus_dice / save_bonus_dice /
+    linked_to_concentration (defaults == today; old snapshots round-trip);
+  * a curated <=4-spell rider registry (Bless, Bane, Shield of Faith, Shield)
+    mirroring _ADVANTAGE_GRANTING_SPELLS;
+  * _effective_armor_class sums ac_bonus; attack / saving_throw / concentration_save /
+    the next_turn repeat save fold the bonus dice — the ENGINE rolls the d4 and
+    surfaces it in the roll detail;
+  * concentration children are released by BOTH sweep paths (next_turn's inverse
+    sweep and drop_concentration).
+"""
+
+import pytest
+
+from dice import DiceRoll
+from models import ActiveEffect, Character
+import combat
+import server
+
+
+def _rig(monkeypatch, d20_natural: int = 10, d4: int = 3):
+    """Deterministic dice: every 1d20 rolls `d20_natural` (no modifier), every
+    1d4 rolls `d4`; everything else delegates to the real roller."""
+    _orig = server.dice_mod.roll
+
+    def _rigged(expression, **kwargs):
+        if expression.startswith("1d20"):
+            return DiceRoll(expression=expression, total=d20_natural, rolls=[d20_natural],
+                            detail=f"{expression}[{d20_natural}] = {d20_natural}",
+                            is_d20=True, natural=d20_natural)
+        if expression.startswith("1d4"):
+            return DiceRoll(expression=expression, total=d4, rolls=[d4],
+                            detail=f"{expression}[{d4}] = {d4}")
+        return _orig(expression, **kwargs)
+
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged)
+
+
+# --- additive model fields: old snapshots round-trip --------------------------
+
+def test_active_effect_old_snapshot_round_trips():
+    eff = ActiveEffect.model_validate({"name": "Bless", "scale": "minutes",
+                                       "rounds_remaining": 10})
+    assert eff.ac_bonus == 0
+    assert eff.attack_bonus_dice == ""
+    assert eff.save_bonus_dice == ""
+    assert eff.linked_to_concentration is False
+    ch = Character.model_validate({
+        "name": "Old", "max_hp": 10, "current_hp": 10,
+        "active_effects": [{"name": "Mage Armor", "scale": "hours",
+                            "until_long_rest": True}],
+    })
+    assert ch.active_effects[0].ac_bonus == 0
+
+
+def test_rider_registry_curates_exactly_the_four_spells():
+    assert combat.spell_effect_riders("Bless") == {
+        "attack_bonus_dice": "1d4", "save_bonus_dice": "1d4"}
+    assert combat.spell_effect_riders("Bane") == {
+        "attack_bonus_dice": "-1d4", "save_bonus_dice": "-1d4"}
+    assert combat.spell_effect_riders("Shield of Faith") == {"ac_bonus": 2}
+    assert combat.spell_effect_riders("Shield") == {"ac_bonus": 5}
+    assert combat.spell_effect_riders("Fireball") is None
+
+
+# --- Shield of Faith: +2 AC via the effective-AC path -------------------------
+
+def test_shield_of_faith_raises_target_effective_ac(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("SoF")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    ally = server.create_character(cid, "Ward", kind="player", max_hp=30,
+                                   armor_class=14)["id"]
+    foe = server.create_character(cid, "Thug", kind="monster", max_hp=20)["id"]
+    server.cast_spell(cid, cleric, "Shield of Faith", target_id=ally)
+    # the ally carries a concentration-linked child effect with the +2
+    sheet = server.get_character(cid, ally)
+    effs = sheet["active_effects"]
+    assert len(effs) == 1 and effs[0]["name"] == "Shield of Faith"
+    assert effs[0]["ac_bonus"] == 2
+    assert effs[0]["linked_to_concentration"] is True
+    # ...and the attack resolver honors it: effective AC is base + 2
+    r = server.attack(cid, attacker_id=foe, target_id=ally,
+                      attack_bonus=0, damage_dice="1d4")
+    assert r["target_ac"] == 16
+    assert r["target_base_ac"] == 14
+    assert {"source": "Shield of Faith", "bonus": 2} in r["target_ac_detail"]["ac_bonuses"]
+
+
+def test_shield_reaction_self_buff_adds_5_ac(tmp_path, monkeypatch):
+    # Shield (1 round, self) — non-concentration, so the rider lands on the caster's
+    # own tracked effect and the effective-AC path sums it.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Shield")["id"]
+    wiz = server.create_character(cid, "Mim", kind="player", class_name="Wizard",
+                                  level=1, apply_srd_defaults=True, max_hp=20)["id"]
+    foe = server.create_character(cid, "Thug", kind="monster", max_hp=20)["id"]
+    base_ac = server.get_character(cid, wiz)["armor_class"]
+    server.cast_spell(cid, wiz, "Shield")
+    r = server.attack(cid, attacker_id=foe, target_id=wiz,
+                      attack_bonus=0, damage_dice="1d4")
+    assert r["target_ac"] == base_ac + 5
+    assert {"source": "Shield", "bonus": 5} in r["target_ac_detail"]["ac_bonuses"]
+
+
+# --- Bless / Bane: the engine rolls the d4 and surfaces it --------------------
+
+def test_blessed_attacker_gets_engine_rolled_d4(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("BlessAtk")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    ally = server.create_character(cid, "Sword", kind="player", max_hp=30)["id"]
+    foe = server.create_character(cid, "Thug", kind="monster", max_hp=30,
+                                  armor_class=12)["id"]
+    server.cast_spell(cid, cleric, "Bless", target_id=ally)
+    _rig(monkeypatch, d20_natural=10, d4=3)
+    r = server.attack(cid, attacker_id=ally, target_id=foe,
+                      attack_bonus=0, damage_dice="1d6")
+    # d20(10) + 0 + blessed d4(3) = 13 vs AC 12 -> the d4 turned a miss into a hit
+    assert r["attack_roll"]["total"] == 13
+    assert r["hit"] is True
+    bd = r["attack_roll"]["bonus_dice"]
+    assert bd == [{"source": "Bless", "dice": "1d4", "rolled": 3,
+                   "detail": "1d4[3] = 3"}]
+
+
+def test_blessed_save_includes_d4(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("BlessSave")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    ally = server.create_character(cid, "Sword", kind="player", max_hp=30)["id"]
+    server.cast_spell(cid, cleric, "Bless", target_id=ally)
+    _rig(monkeypatch, d20_natural=10, d4=3)
+    out = server.saving_throw(cid, ally, "wis", dc=12)
+    assert out["roll"] == 13
+    assert out["success"] is True
+    assert out["bonus_dice"][0]["source"] == "Bless"
+    assert out["bonus_dice"][0]["rolled"] == 3
+
+
+def test_baned_target_save_subtracts_d4(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Bane")["id"]
+    caster = server.create_character(cid, "Hex", kind="player", max_hp=10)["id"]
+    server.update_character(cid, caster, patch={
+        "spell_slots": {"1": {"maximum": 2, "used": 0}}})
+    foe = server.create_character(cid, "Thug", kind="monster", max_hp=20)["id"]
+    server.cast_spell(cid, caster, "Bane", target_id=foe)
+    _rig(monkeypatch, d20_natural=10, d4=3)
+    out = server.saving_throw(cid, foe, "wis", dc=10)
+    # d20(10) - bane d4(3) = 7 vs DC 10 -> the engine-applied penalty flipped it
+    assert out["roll"] == 7
+    assert out["success"] is False
+    assert out["bonus_dice"][0]["source"] == "Bane"
+    assert out["bonus_dice"][0]["rolled"] == -3
+
+
+def test_blessed_concentration_save_includes_d4(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("BlessConc")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    ally = server.create_character(cid, "Mage", kind="player", max_hp=20)["id"]
+    server.cast_spell(cid, cleric, "Bless", target_id=ally)
+    _rig(monkeypatch, d20_natural=10, d4=3)
+    out = server.concentration_save(cid, ally, dc=12)
+    assert out["roll"] == 13
+    assert out["maintained"] is True
+    assert out["bonus_dice"][0]["source"] == "Bless"
+
+
+# --- concentration break releases the linked children (BOTH paths) ------------
+
+def test_drop_concentration_frees_linked_children(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("DropConc")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    ally = server.create_character(cid, "Sword", kind="player", max_hp=30)["id"]
+    server.cast_spell(cid, cleric, "Bless", target_id=ally)
+    assert server.get_character(cid, ally)["active_effects"]  # child present
+    out = server.drop_concentration(cid, cleric)
+    assert out["ended"] is True
+    assert {"character_id": ally, "name": "Bless"} in out["freed_targets"]
+    assert server.get_character(cid, ally)["active_effects"] == []
+
+
+def test_next_turn_sweep_frees_linked_children(tmp_path, monkeypatch):
+    # The inverse-link sweep: caster's concentration broke some other way (a failed
+    # concentration save) -> the next next_turn releases the blessed ally's child.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("SweepConc")["id"]
+    caster = server.create_character(cid, "Priest", kind="monster", max_hp=20)["id"]
+    server.update_character(cid, caster, patch={
+        "spell_slots": {"1": {"maximum": 2, "used": 0}}})
+    ally = server.create_character(cid, "Brute", kind="monster", max_hp=20)["id"]
+    server.cast_spell(cid, caster, "Bless", target_id=ally)
+    server.start_combat(cid, [caster, ally])
+    # break the caster's concentration the non-voluntary way (impossible DC)
+    cs = server.concentration_save(cid, caster, dc=100)
+    assert cs["maintained"] is False
+    nt = server.next_turn(cid)
+    assert {"character_id": ally, "name": "Bless"} in nt["expired_effects"]
+    assert server.get_character(cid, ally)["active_effects"] == []
+
+
+def test_cast_result_advertises_engine_applied_riders(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Advert")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    ally = server.create_character(cid, "Sword", kind="player", max_hp=30)["id"]
+    r = server.cast_spell(cid, cleric, "Bless", target_id=ally)
+    riders = r["effect_riders"]
+    assert riders["holder_id"] == ally
+    assert riders["attack_bonus_dice"] == "1d4"
+    assert riders["save_bonus_dice"] == "1d4"

--- a/servers/engine/tests/test_finesse_sneak.py
+++ b/servers/engine/tests/test_finesse_sneak.py
@@ -1,0 +1,180 @@
+"""Finesse weapons + Sneak Attack at the combat-numbers surface (audit F01-4 / F01-5).
+
+F01-4 (#774): `_combat_numbers` hardcoded melee = prof + STR, so every DEX-martial
+(the engine's own default rogue, seeded with a finesse Shortsword) was handed wrong
+melee attack/damage numbers all campaign — under a "never invent" instruction that
+forbids the DM from correcting them. Finesse weapons must use max(STR, DEX) on
+attack AND damage.
+
+F01-5 (#166 cluster): `Character.sneak_attack_dice` was written by chargen/level-up
+and read by NOTHING in the combat path — ~half a rogue's damage invisible at the
+attack trigger. Surface it in `_combat_numbers` / `turn_brief` (the proven adherence
+channel) as a ready-to-pass `damage_rolls` component prompt.
+"""
+
+import pytest
+
+import server
+import srd_tables
+
+
+# --- the pure finesse lookup ------------------------------------------------
+
+def test_finesse_weapon_names_from_srd_data():
+    names = srd_tables.finesse_weapon_names()
+    # exactly the 6 srd524 WeaponPropertyAssignment finesse rows
+    assert set(names) == {"dagger", "dart", "rapier", "scimitar", "shortsword", "whip"}
+
+
+@pytest.mark.parametrize(
+    "item,expected",
+    [
+        ("Rapier", True),
+        ("rapier", True),
+        ("Rapier +1", True),        # substring-tolerant (magic-item naming)
+        ("Shortsword", True),
+        ("Daggers", True),          # plural still names the weapon
+        ("Greatsword", False),
+        ("Longsword", False),
+        ("Explorer's Pack", False),
+        ("", False),
+    ],
+)
+def test_is_finesse_weapon_matching(item, expected):
+    assert srd_tables.is_finesse_weapon(item) is expected
+
+
+# --- _combat_numbers: finesse uses max(STR, DEX) on attack AND damage --------
+
+def test_rogue_with_finesse_weapon_uses_dex_on_melee(tmp_path, monkeypatch):
+    # Red-first F01-4: DEX-16/STR-10 rogue (engine seeds an equipped Shortsword —
+    # finesse). Today melee_attack_bonus is prof + STR = +2; it must be prof + DEX = +5.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Finesse")["id"]
+    r = server.create_character(
+        cid, "Sly", kind="player", class_name="Rogue", level=3,
+        apply_srd_defaults=True,
+        abilities={"strength": 10, "dexterity": 16},
+    )
+    cn = server.get_character(cid, r["id"])["combat_numbers"]
+    prof = cn["proficiency_bonus"]
+    assert cn["melee_attack_bonus"] == prof + 3, cn
+    assert cn["melee_damage_mod"] == 3
+    # the surfaced cue names the weapon so the DM can narrate it
+    assert "Shortsword" in cn["finesse"]["weapon"]
+    assert cn["finesse"]["ability"] == "dex"
+
+
+def test_str_fighter_without_finesse_weapon_unchanged(tmp_path, monkeypatch):
+    # Greataxe barbarian: STR-only loadout — numbers byte-identical, no finesse key.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("NoFinesse")["id"]
+    r = server.create_character(
+        cid, "Krug", kind="player", class_name="Barbarian", level=1,
+        apply_srd_defaults=True,
+        abilities={"strength": 16, "dexterity": 14},
+    )
+    cn = server.get_character(cid, r["id"])["combat_numbers"]
+    assert cn["melee_attack_bonus"] == cn["proficiency_bonus"] + 3
+    assert cn["melee_damage_mod"] == 3
+    assert "finesse" not in cn
+
+
+def test_magic_finesse_weapon_name_still_matches(tmp_path, monkeypatch):
+    # "Rapier +1" must still register as finesse (substring-tolerant matching).
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Magic")["id"]
+    r = server.create_character(
+        cid, "Duelist", kind="player", class_name="Fighter", level=1,
+        apply_srd_defaults=True,
+        abilities={"strength": 10, "dexterity": 18},
+    )
+    server.update_character(cid, r["id"], patch={
+        "inventory": [{"name": "Rapier +1", "equipped": True}],
+    })
+    cn = server.get_character(cid, r["id"])["combat_numbers"]
+    assert cn["melee_attack_bonus"] == cn["proficiency_bonus"] + 4
+    assert cn["finesse"]["weapon"] == "Rapier +1"
+
+
+def test_carried_but_unequipped_finesse_weapon_still_counts(tmp_path, monkeypatch):
+    # Equipped-first, else any carried (the spec's fallback): a dagger in the pack
+    # still lets a DEX-martial fight with it.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Carried")["id"]
+    r = server.create_character(
+        cid, "Pock", kind="player", class_name="Fighter", level=1,
+        apply_srd_defaults=True,
+        abilities={"strength": 8, "dexterity": 16},
+    )
+    server.update_character(cid, r["id"], patch={
+        "inventory": [{"name": "Dagger", "equipped": False}],
+    })
+    cn = server.get_character(cid, r["id"])["combat_numbers"]
+    assert cn["melee_attack_bonus"] == cn["proficiency_bonus"] + 3
+    assert cn["finesse"]["weapon"] == "Dagger"
+
+
+def test_str_winner_with_finesse_weapon_keeps_str_numbers(tmp_path, monkeypatch):
+    # max(STR, DEX): a STR-16/DEX-10 fighter holding a dagger keeps the STR numbers
+    # (finesse is "may use DEX", never a penalty).
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("StrWins")["id"]
+    r = server.create_character(
+        cid, "Bron", kind="player", class_name="Fighter", level=1,
+        apply_srd_defaults=True,
+        abilities={"strength": 16, "dexterity": 10},
+    )
+    server.update_character(cid, r["id"], patch={
+        "inventory": [{"name": "Dagger", "equipped": True}],
+    })
+    cn = server.get_character(cid, r["id"])["combat_numbers"]
+    assert cn["melee_attack_bonus"] == cn["proficiency_bonus"] + 3
+    assert cn["melee_damage_mod"] == 3
+    assert cn["finesse"]["ability"] == "str"
+
+
+# --- sneak attack surfaced at the attack trigger ------------------------------
+
+def test_sneak_attack_surfaced_in_combat_numbers(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Sneak")["id"]
+    r = server.start_character(cid, name="Vex", origin="veteran_l5", class_name="Rogue",
+                               abilities={"dex": 16, "str": 10})
+    cn = server.get_character(cid, r["id"])["combat_numbers"]
+    sa = cn["sneak_attack"]
+    assert sa["dice"] == "3d6"  # level-5 rogue
+    # The note must teach the once-per-turn condition AND the damage_rolls shape so
+    # the engine rolls it (crit-doubling rides the existing multi-component path).
+    assert "once per turn" in sa["note"].lower()
+    assert "damage_rolls" in sa["note"]
+    assert "3d6" in sa["note"]
+
+
+def test_non_rogue_has_no_sneak_attack_key(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("NoSneak")["id"]
+    r = server.create_character(
+        cid, "Pious", kind="player", class_name="Cleric", level=3,
+        apply_srd_defaults=True,
+    )
+    cn = server.get_character(cid, r["id"])["combat_numbers"]
+    assert "sneak_attack" not in cn
+
+
+def test_turn_brief_carries_finesse_and_sneak(tmp_path, monkeypatch):
+    # The per-turn surface (the one the DM actually reads each turn, #166) must carry
+    # both cues, not just get_character.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Brief")["id"]
+    r = server.create_character(
+        cid, "Shade", kind="player", class_name="Rogue", level=5,
+        apply_srd_defaults=True,
+        abilities={"strength": 10, "dexterity": 16},
+    )
+    ch = server._require(cid).characters[r["id"]]
+    brief = server._turn_brief(ch, server._require(cid))
+    atk = brief["attack"]
+    assert atk["melee_attack_bonus"] == ch.proficiency_bonus + 3
+    assert atk["finesse"]["ability"] == "dex"
+    assert atk["sneak_attack"]["dice"] == ch.sneak_attack_dice


### PR DESCRIPTION
Audited, skeptic-verified fix set from `docs/audits/ENGINE-AUDIT-2026-06-11.md` (units 01+03). **Closes #774. Closes #780. Refs #166** (F01-5 enriches the combat-adherence cluster).

## Root causes

- **F01-4 (#774) — Finesse absent.** `_combat_numbers` hardcoded `melee_attack_bonus = prof + STR`; `Item` carries no weapon properties and the inventory was never inspected, so every DEX-martial (the engine's own seeded shortsword rogue) was handed wrong melee attack/damage numbers all campaign — under the "never invent — use the sheet's" instruction that forbids the DM from correcting. The finesse data sat unread in `data/srd/srd524/WeaponPropertyAssignment.json` (exactly 6 weapons).
- **F01-5 (refs #166) — Sneak Attack invisible at the attack trigger.** `Character.sneak_attack_dice` was written by chargen/level-up and read by NOTHING in the combat path (zero reads in `_combat_numbers`, `turn_brief`, `attack()`) — ~half a rogue's damage invisible, actively suppressed by the same "never invent" note.
- **SYN-06 (#780) — Engine-tracked buffs mechanically inert.** `ActiveEffect` had no generic modifier fields, so Bless/Bane/Shield of Faith/Shield were stored, advertised, duration-ticked — then the engine authoritatively rolled WITHOUT them. Concentration buffs lived caster-side only, and both sweep loops matched only repeat-save markers, so a Bless child could never expire with the caster's concentration.

## Fix (exactly per the verified specs)

- **Finesse (read-surface only):** cached `srd_tables.finesse_weapon_names()` / `is_finesse_weapon()` from the srd524 dumps (case-insensitive, substring-tolerant — "Rapier +1" matches). A carried finesse weapon (equipped-first, else any carried) flips surfaced melee attack AND damage to `max(STR, DEX)` with a `finesse` cue naming the weapon; carried per-turn by `turn_brief`. `attack()` keeps trusting the passed bonus — no resolver/model change.
- **Sneak Attack (v1 surface, the proven adherence channel):** `_combat_numbers` + `turn_brief` surface `sneak_attack {dice, note}`; the note teaches the 5e once-per-turn trigger and the exact `damage_rolls` component shape, so the engine rolls it and crit-doubles it free via the existing multi-component path (#210).
- **Buff riders (engine rolls, DM is told):** additive `ActiveEffect.ac_bonus` / `attack_bonus_dice` / `save_bonus_dice` / `linked_to_concentration` (defaults inert — old snapshots round-trip); curated ≤4-spell registry `combat.spell_effect_riders()` (Bless +1d4 atk/save, Bane −1d4, Shield of Faith +2 AC, Shield +5 AC) mirroring `_ADVANTAGE_GRANTING_SPELLS`; `_effective_armor_class` sums `ac_bonus` (itemized `ac_bonuses` detail); `attack` / `saving_throw` / `concentration_save` / `next_turn`'s repeat save fold the bonus dice — the engine rolls the d4 and itemizes it in `bonus_dice`. A concentration rider cast at a separate target writes a **linked child** effect carrying the numbers (the caster twin stays a pure concentration tracker — blessing an ally doesn't bless the caster), and BOTH sweep paths (`next_turn` inverse sweep + `drop_concentration`) release linked children the moment concentration ends. `cast_spell` returns `effect_riders` so the DM never double-applies by hand.

## Tests

- `tests/test_finesse_sneak.py` — 13 (incl. 9 param): SRD-derived name set; matching matrix; DEX-rogue melee = prof+DEX on attack AND damage; greataxe loadout byte-identical; "Rapier +1"; carried-unequipped fallback; STR-wins-max keeps STR; sneak dice + trigger note; non-rogue absent; turn_brief carries both cues.
- `tests/test_effect_riders.py` — 16 (incl. old-snapshot round-trip; registry curates exactly 4; SoF target AC == base+2 through `attack()`; Shield +5 self; engine-rolled blessed d4 flips a miss to a hit; blessed/baned saves and concentration save fold the d4 with itemized `bonus_dice`; concentration break frees children via BOTH paths; cast result advertises riders).
- Full engine suite: **1834 passed** (single-process). Tier-0 `qa/fast_gate.sh`: **PASS** (188 deterministic).

## Invariants

Engine sole-writer (all mutations under `campaign_lock`); additive-by-default (new model fields defaulted — old snapshots round-trip, regression-tested); engine rolls & the DM is told (rider dice rolled engine-side and itemized; sneak surfaced as a ready-to-pass component the engine rolls); wire contracts frozen (additive result keys only; combat-log `bonus_dice` only present when non-empty); no shell touched.

Scope discipline: exactly the 4 curated spells — no new effect plumbing beyond the cited registry; Shield auto-arbitration (F03-13) intentionally NOT included (separate finding, depends on this).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Spell effect modifiers (Bless, Bane, Shield of Faith, Shield) now apply their mechanical bonuses and penalties to attacks, saving throws, and AC.
* Finesse weapons now correctly use the higher of Strength or Dexterity for attack and damage rolls.
* Sneak attack dice are now surfaced in combat briefing details.
* Concentration-linked spell effects are now properly tracked and removed when concentration ends.

**Tests**
* Added comprehensive test coverage for spell effect modifiers and finesse weapon mechanics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->