### PR TITLE
fix(engine): seed companion arc+dossier on all 3 creation paths; enrich companion_advise (F06-1, F06-3)

### DIFF
--- a/servers/engine/companion.py
+++ b/servers/engine/companion.py
@@ -227,7 +227,13 @@ def suggest_action(
     }
 
 
-def deliberate(companion: Character, situation: str = "", callbacks: Optional[list] = None) -> dict:
+def deliberate(
+    companion: Character,
+    situation: str = "",
+    callbacks: Optional[list] = None,
+    standing: Optional[dict] = None,
+    dossier: Optional[object] = None,
+) -> dict:
     """Build a persona-agnostic advice frame for a NON-combat beat — what the
     companion should weigh in on, NOT the words (the persona/agent authors the
     actual line). This is the storytelling counterpart to suggest_action: it makes
@@ -236,9 +242,21 @@ def deliberate(companion: Character, situation: str = "", callbacks: Optional[li
 
     `situation` is the DM's free-text description of the moment; `callbacks` are
     relevant past-memory hits (from the ledger's recall) to ground the opinion.
-    Returns ``{companion, voice_id, personality, callbacks, prompt}`` — the prompt
-    is an instruction the DM (or a Tier-2 forked agent) voices in the companion's
-    own voice."""
+
+    `standing` (F06-3, optional) is the engine-computed approval reading — e.g.
+    ``{"band": "warm", "attitude_value": 45}`` — derived by the caller from the
+    companion's gauge so the DM voices a companion who already HAS a leaning, not a
+    blank neutral. `dossier` (optional) is the companion's ``CompanionDossier`` whose
+    approval_likes/dislikes are surfaced in the return for the DM's human judgment of
+    whether THIS moment wins or loses the companion's regard (the engine reads the
+    gauge; the DM judges the cause — the F6-2 division of labor).
+
+    Returns ``{companion, voice_id, personality, callbacks, prompt}`` plus —
+    only when the optional data is passed — ``standing`` / ``approval_likes`` /
+    ``approval_dislikes``. The prompt is an instruction the DM (or a Tier-2 forked
+    agent) voices in the companion's own voice. ADDITIVE: with no standing/dossier
+    passed the return is byte-identical to the original five-key frame, so the pure
+    module stays pure and every existing caller is unaffected."""
     cbs = [c.get("text", "") if isinstance(c, dict) else str(c) for c in (callbacks or [])]
     cbs = [t for t in cbs if t]
     prompt = (
@@ -248,15 +266,37 @@ def deliberate(companion: Character, situation: str = "", callbacks: Optional[li
     )
     if companion.personality:
         prompt += f" Stay true to who you are: {companion.personality}"
+    # F06-3: fold the engine-computed standing into the voicing instruction so the line
+    # carries the companion's current leaning toward the party (a warm ally and a souring
+    # one react DIFFERENTLY to the same moment) — the band is a read of the gauge only.
+    band = standing.get("band") if isinstance(standing, dict) else None
+    if band:
+        prompt += (
+            f" Your current standing with the party is {band} — let that color how warmly "
+            f"or coolly you speak."
+        )
     if cbs:
         prompt += " Ground it in what you remember: " + " | ".join(cbs)
-    return {
+    out = {
         "companion": companion.name,
         "voice_id": companion.voice_id,
         "personality": companion.personality,
         "callbacks": cbs,
         "prompt": prompt,
     }
+    # ADDITIVE: only attach the enrichment keys when the data was actually passed, so a
+    # caller that supplies nothing gets today's exact five-key frame (the pure-module
+    # guarantee). approval causes go in the RETURN for the DM to judge — never auto-applied.
+    if isinstance(standing, dict) and standing:
+        out["standing"] = standing
+    if dossier is not None:
+        likes = list(getattr(dossier, "approval_likes", []) or [])
+        dislikes = list(getattr(dossier, "approval_dislikes", []) or [])
+        if likes:
+            out["approval_likes"] = likes
+        if dislikes:
+            out["approval_dislikes"] = dislikes
+    return out
 
 
 @runtime_checkable

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1451,6 +1451,55 @@ def _seat_flat10_warnings(ch, class_label: str, where: str) -> list[str]:
     return [warn]
 
 
+def _seed_companion_operational_state(ch) -> None:
+    """Seed a companion's ARC and DOSSIER if absent — the shared finisher every
+    companion-creation path runs so the relationship system (camp_scene /
+    check_companion_arc / agendas) has state to track (F06-1).
+
+    Two of the three creation paths used to SKIP this (create_character — the dominant
+    path at 111 calls — seeded neither; load_canon_character seeded the dossier but never
+    an arc), so 20/20 live snapshot companions had arc=None/dossier=None and the whole arc
+    machine was structurally inert. recruit_companion already did this inline; this is the
+    extracted shared helper (the same logic, byte-for-byte) called by all three.
+
+    Both writes are None-GUARDED, so an ending-seeded / canon / roster arc or dossier is
+    NEVER overwritten — the DM can still author a richer one via set_companion_arc /
+    update_character. Caller holds campaign_lock; this mutates the passed Character in
+    place and does not save. NOT called for players/npcs/monsters — companion-only on every
+    path."""
+    # A companion needs an ARC for the relationship system (camp_scene / check_companion_arc)
+    # to have anything to track — QA found a freshly-recruited canon companion with arc=null,
+    # so camp + the gates were inert. If none was seeded (i.e. not an ending-tied
+    # companion_seed), give a light DEFAULT: one loyalty gate at a moderate approval, so the
+    # bond can deepen at camp. Guarded on None, so an ending-seeded arc is never overwritten;
+    # the DM can set_companion_arc to author a richer, character-specific arc.
+    if ch.arc is None:
+        ch.arc = CompanionArc.model_validate({"arc_gates": [
+            {"kind": "loyalty", "threshold": 25,
+             "note": f"a deepening trust with {ch.name}, earned fighting beside them"}]})
+    # A companion also needs a DOSSIER for the living-world systems (camp scheduling,
+    # banter selection, approval causes) to have operational state to act on (#68). If
+    # none was seeded (i.e. not an ending/roster/canon dossier), synthesize a MINIMAL
+    # one from what the record ALREADY carries — the personality/backstory hint and the
+    # memory facts become terse camp prompts, so a freshly-recruited companion isn't a
+    # blank slate at camp. Guarded on None so a seeded dossier is NEVER overwritten; the
+    # DM can flesh it out via update_character. We don't invent wants/values/approval
+    # causes the record doesn't imply — the DM authors those as the bond develops.
+    if ch.companion_dossier is None:
+        # backstory/personality are the recruit/canon sources; biography is the
+        # create_character authoring field — fall through them so every path has a hint.
+        seed_hint = (ch.backstory or ch.personality or ch.biography or "").strip()
+        camp_prompts: list[str] = []
+        if seed_hint:
+            # one short clause, not the whole biography — keep the dossier operational
+            clause = seed_hint.replace("\n", " ").split(". ")[0].strip()
+            if clause:
+                camp_prompts.append(clause[:200])
+        # the NPC's seeded hook / remembered facts make good, character-specific camp talk
+        camp_prompts.extend(m.strip() for m in ch.memory if m.strip())
+        ch.companion_dossier = CompanionDossier(camp_prompts=camp_prompts[:4])
+
+
 @mcp.tool()
 def create_character(
     campaign_id: str,
@@ -1543,6 +1592,12 @@ def create_character(
         # location_id wins; otherwise default to the party's current location.
         if kind in ("npc", "monster"):
             ch.location_id = location_id or c.current_location_id
+        # F06-1: a companion made on THIS path (the dominant one, 111 calls) used to get
+        # NO arc and NO dossier, so camp/gates/agendas were inert (20/20 live snapshots).
+        # Route it through the shared seeding helper — companion-only, None-guarded so an
+        # explicitly-passed arc/dossier is never clobbered.
+        if kind == "companion":
+            _seed_companion_operational_state(ch)
         c.characters[ch.id] = ch
         # INVARIANT: a kind="player" character is always in the party (it's the protagonist),
         # even if add_to_party=False was passed; a companion joins only when add_to_party.
@@ -1907,35 +1962,14 @@ def recruit_companion(
             ch.stable = False
             ch.death_saves = DeathSaves()
             ch.conditions = [cond for cond in ch.conditions if cond != Condition.UNCONSCIOUS]
-        # A companion needs an ARC for the relationship system (camp_scene / check_companion_arc)
-        # to have anything to track — QA found a freshly-recruited canon companion with arc=null,
-        # so camp + the gates were inert. If none was seeded (i.e. not an ending-tied
-        # companion_seed), give a light DEFAULT: one loyalty gate at a moderate approval, so the
-        # bond can deepen at camp. Guarded on None, so an ending-seeded arc is never overwritten;
-        # the DM can set_companion_arc to author a richer, character-specific arc.
-        if ch.arc is None:
-            ch.arc = CompanionArc.model_validate({"arc_gates": [
-                {"kind": "loyalty", "threshold": 25,
-                 "note": f"a deepening trust with {ch.name}, earned fighting beside them"}]})
-        # A companion also needs a DOSSIER for the living-world systems (camp scheduling,
-        # banter selection, approval causes) to have operational state to act on (#68). If
-        # none was seeded (i.e. not an ending/roster/canon dossier), synthesize a MINIMAL
-        # one from what the record ALREADY carries — the personality/backstory hint and the
-        # memory facts become terse camp prompts, so a freshly-recruited companion isn't a
-        # blank slate at camp. Guarded on None so a seeded dossier is NEVER overwritten; the
-        # DM can flesh it out via update_character. We don't invent wants/values/approval
-        # causes the record doesn't imply — the DM authors those as the bond develops.
-        if ch.companion_dossier is None:
-            seed_hint = (ch.backstory or ch.personality or "").strip()
-            camp_prompts: list[str] = []
-            if seed_hint:
-                # one short clause, not the whole biography — keep the dossier operational
-                clause = seed_hint.replace("\n", " ").split(". ")[0].strip()
-                if clause:
-                    camp_prompts.append(clause[:200])
-            # the NPC's seeded hook / remembered facts make good, character-specific camp talk
-            camp_prompts.extend(m.strip() for m in ch.memory if m.strip())
-            ch.companion_dossier = CompanionDossier(camp_prompts=camp_prompts[:4])
+        # A companion needs an ARC + DOSSIER for the relationship system (camp_scene /
+        # check_companion_arc / banter / approval causes) to have state to track — QA found a
+        # freshly-recruited canon companion with arc=null, so camp + the gates were inert.
+        # The shared seeding helper (F06-1) gives a None-guarded default arc (a loyalty gate so
+        # the bond can deepen) + a minimal dossier synthesized from what the record already
+        # carries (backstory/personality/memory -> terse camp prompts). Guarded on None so an
+        # ending-seeded arc/dossier is NEVER overwritten; the DM authors richer ones later.
+        _seed_companion_operational_state(ch)
         ch.met = True  # joining the party means the party has met them
         if ch.id not in c.party:
             c.party.append(ch.id)
@@ -2714,6 +2748,12 @@ def load_canon_character(campaign_id: str, name: str = "", kind: str = "npc", ad
             ch.met = True  # brought into the party => met
             if ch.id not in c.party:
                 c.party.append(ch.id)
+        # F06-1: this path seeded the DOSSIER (above) but never an ARC, so a canon-loaded
+        # companion had arc=null and camp/gates were inert. Run the shared seeding helper
+        # (companion-only, None-guarded) so it adds the default arc — and only synthesizes a
+        # dossier if the canon record didn't already carry one (_coerce_dossier left it None).
+        if ch.kind == "companion":
+            _seed_companion_operational_state(ch)
         c.characters[ch.id] = ch
         save_campaign(c)
         # ADDITIVE WARNING (non-fatal): a PLAYER or a SPELLCASTER that still ended at the flat-10
@@ -7355,6 +7395,23 @@ def companion_suggest_action(campaign_id: str, companion_id: str) -> dict:
     return companion.suggest_action(_char(c, companion_id), c.combat, c.characters)
 
 
+def _attitude_band(attitude_value: int) -> str:
+    """Map the numeric approval gauge (-100..+100, 0 = neutral) to a single band label
+    from the canonical attitude vocabulary (npc.ATTITUDE_TRACK), so companion_advise can
+    tell the DM the companion's CURRENT leaning. A pure read of the gauge only — the same
+    five bands a social_check moves a companion through, just keyed off the number instead
+    of the free-text track. Cutoffs are deterministic and centered on 0 (neutral)."""
+    if attitude_value <= -50:
+        return "hostile"
+    if attitude_value <= -15:
+        return "wary"
+    if attitude_value < 25:
+        return "indifferent"
+    if attitude_value < 60:
+        return "friendly"
+    return "helpful"
+
+
 @mcp.tool()
 def companion_advise(campaign_id: str, companion_id: str, situation: str = "") -> dict:
     """Get the companion's in-character take on the CURRENT (non-combat) moment so
@@ -7362,11 +7419,29 @@ def companion_advise(campaign_id: str, companion_id: str, situation: str = "") -
     a short `situation` (the choice/discovery/lull at hand); it pulls relevant
     memory callbacks via recall and returns the companion's voice_id + personality
     + callbacks + a prompt to voice from. Speak the companion's line in its voice,
-    then let the player respond / deliberate with it. Read-only."""
+    then let the player respond / deliberate with it. Read-only.
+
+    Also folds in the companion's STANDING (the approval band derived from its gauge),
+    its dossier's `approval_likes`/`approval_dislikes` (so the DM can judge whether THIS
+    moment wins or loses the companion's regard), and an `arc` summary (gates + how far
+    the next locked gate is) — so the voiced line already carries the relationship,
+    instead of a blank-neutral opinion. The engine reads the gauge; the DM judges the
+    cause (it never auto-moves approval here). Best-effort: a companion with no dossier/
+    arc still returns the base frame (F06-3)."""
     c = _require(campaign_id)
     comp = _char(c, companion_id)
     callbacks = ledger_mod.recall(campaign_id, situation, limit=3) if situation.strip() else []
-    return companion.deliberate(comp, situation, callbacks=callbacks)
+    # F06-3: the standing band is a pure read of the engine-mutated approval gauge.
+    standing = {"band": _attitude_band(comp.attitude_value),
+                "attitude_value": comp.attitude_value}
+    out = companion.deliberate(
+        comp, situation, callbacks=callbacks,
+        standing=standing,
+        dossier=getattr(comp, "companion_dossier", None),
+    )
+    # Arc/gate-distance summary (same read _camp_arc_summary gives camp); None when no arc.
+    out["arc"] = _camp_arc_summary(comp)
+    return out
 
 
 def _camp_arc_summary(comp) -> Optional[dict]:

--- a/servers/engine/tests/test_companion_arc.py
+++ b/servers/engine/tests/test_companion_arc.py
@@ -509,6 +509,10 @@ def test_personal_quest_gate_stage_unlock_reports_actual_arc_status(camp):
 
 def test_set_companion_arc_rejects_missing_personal_quest_link_without_mutation(camp):
     cid, comp = camp
+    # F06-1: a companion now carries a seeded DEFAULT arc at creation; the no-mutation
+    # guarantee is that a REJECTED set_companion_arc leaves that arc UNCHANGED (the bad
+    # personal_quest gate is never applied), not that arc is None.
+    before = store.load_campaign(cid).characters[comp].arc.model_dump(mode="json")
 
     with pytest.raises(ValueError, match="no companion quest arc"):
         server.set_companion_arc(cid, comp, {
@@ -519,11 +523,14 @@ def test_set_companion_arc_rejects_missing_personal_quest_link_without_mutation(
             }],
         })
 
-    assert store.load_campaign(cid).characters[comp].arc is None
+    after = store.load_campaign(cid).characters[comp].arc.model_dump(mode="json")
+    assert after == before  # the seeded default arc is intact; the bad arc was not applied
+    assert not any(g["kind"] == "personal_quest" for g in after["arc_gates"])
 
 
 def test_set_companion_arc_rejects_stage_without_quest_arc(camp):
     cid, comp = camp
+    before = store.load_campaign(cid).characters[comp].arc.model_dump(mode="json")
 
     with pytest.raises(ValueError, match="stage_id requires quest_arc_id"):
         server.set_companion_arc(cid, comp, {
@@ -534,7 +541,9 @@ def test_set_companion_arc_rejects_stage_without_quest_arc(camp):
             }],
         })
 
-    assert store.load_campaign(cid).characters[comp].arc is None
+    after = store.load_campaign(cid).characters[comp].arc.model_dump(mode="json")
+    assert after == before  # the seeded default arc is intact; the bad arc was not applied
+    assert not any(g["kind"] == "personal_quest" for g in after["arc_gates"])
 
 
 def test_set_companion_quest_arc_rejects_replacing_referenced_stage(camp):

--- a/servers/engine/tests/test_companion_seed_advise.py
+++ b/servers/engine/tests/test_companion_seed_advise.py
@@ -1,0 +1,228 @@
+"""F06-1 + F06-3 — companion operational-state seeding parity + advise enrichment.
+
+Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F6-1, F6-3).
+
+F06-1: TWO of the THREE companion-creation paths seed NO arc and NO dossier, so the
+arc machine (camp_scene / check_companion_arc / agendas) is structurally inert on the
+DOMINANT path (`create_character`, 111 calls vs 38 recruit) — 20/20 live snapshot
+companions had arc=None/dossier=None. The fix routes ALL THREE paths through the shared
+`_seed_companion_operational_state` helper that recruit_companion already implemented
+inline, None-guarded so an ending-seeded arc/dossier is never overwritten, additive so
+old snapshots (arc=None) still load.
+
+F06-3: `companion_advise` (the ONLY companion surface in live use, 54 calls) ignores the
+dossier, the approval gauge, and the arc. The fix folds those into its return at near-zero
+cost: a stance hint derived from the engine-computed attitude band (reads only the gauge),
+the dossier's approval causes for human judgment, and an arc/gate-distance summary — so
+100% of existing advise beats get richer. The `deliberate` module stays PURE: with no
+dossier/standing passed it is byte-identical to today (the additive guarantee).
+"""
+
+import pytest
+
+import companion as companion_mod
+import server
+from models import Campaign, Character, CompanionArc, CompanionDossier
+
+
+# ============================================================================
+# F06-1 — seeding parity across all three companion-creation paths
+# ============================================================================
+
+
+def test_create_character_companion_seeds_arc_and_dossier(tmp_path, monkeypatch):
+    """The DOMINANT path: a companion made via create_character must get a default arc
+    AND a (possibly empty-but-present) dossier, so camp/gates/agendas have state to track.
+    Before the fix this companion had arc=None / dossier=None (20/20 live snapshots)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Seed")["id"]
+    res = server.create_character(cid, "Lyra", kind="companion", class_name="Ranger")
+    ch = server.get_character(cid, res["id"])
+    assert ch["arc"] is not None, "create_character companion must seed an arc (was None)"
+    assert ch["companion_dossier"] is not None, "create_character companion must seed a dossier"
+    # the default arc carries a loyalty gate so the bond can deepen at camp
+    assert any(g["kind"] == "loyalty" for g in ch["arc"]["arc_gates"])
+
+
+def test_create_character_player_and_npc_unchanged(tmp_path, monkeypatch):
+    """ONLY companions are seeded — a player / npc / monster is byte-identical to today
+    (no arc/dossier), so the change is scoped and additive."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Seed")["id"]
+    pc = server.get_character(cid, server.create_character(cid, "Hero", kind="player")["id"])
+    npc = server.get_character(cid, server.create_character(cid, "Bartender", kind="npc")["id"])
+    mon = server.get_character(cid, server.create_character(cid, "Goblin", kind="monster")["id"])
+    assert pc["arc"] is None and pc["companion_dossier"] is None
+    assert npc["arc"] is None and npc["companion_dossier"] is None
+    assert mon["arc"] is None and mon["companion_dossier"] is None
+
+
+def test_create_character_companion_synthesizes_dossier_from_prose(tmp_path, monkeypatch):
+    """A companion created with personality prose gets that folded into a terse camp prompt —
+    the same synthesis recruit_companion does, so the dossier isn't a blank slate."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Seed")["id"]
+    res = server.create_character(
+        cid, "Sable", kind="companion",
+        biography="A defrocked cleric haunted by a vow she broke. Speaks in clipped warnings.",
+    )
+    d = server.get_character(cid, res["id"])["companion_dossier"]
+    assert d is not None
+    # biography prose becomes a terse camp prompt (the create_character authoring source)
+    assert any("defrocked cleric" in p for p in d["camp_prompts"])
+
+
+def test_load_canon_character_seeds_arc(tmp_path, monkeypatch):
+    """load_canon_character already seeds the DOSSIER but never an ARC — after the fix a
+    canon-loaded companion carries both, so camp/gates work on the canon path too."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    bg = server.start_world("baldurs-gate", ending="netherbrain-destroyed-heroes-live")["campaign_id"]
+    res = server.load_canon_character(bg, "Gale", kind="companion", add_to_party=True)
+    ch = server.get_character(bg, res["id"])
+    assert ch["arc"] is not None, "canon-loaded companion must seed an arc"
+    assert ch["companion_dossier"] is not None
+
+
+def test_load_canon_character_npc_not_seeded(tmp_path, monkeypatch):
+    """A canon figure pulled as an NPC (not a companion) gets NO arc — seeding is
+    companion-only on every path."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    bg = server.start_world("baldurs-gate")["campaign_id"]
+    res = server.load_canon_character(bg, "Gale", kind="npc")
+    ch = server.get_character(bg, res["id"])
+    assert ch["arc"] is None
+
+
+def test_seeding_never_overwrites_an_ending_seeded_arc(tmp_path, monkeypatch):
+    """The None-guard discipline: an ending-seeded companion keeps its AUTHORED arc when
+    recruited — the helper never clobbers a richer, character-specific arc."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    bg = server.start_world("baldurs-gate", ending="illithid-ascension")["campaign_id"]
+    before = server.get_character(bg, "npc-the-emperor")
+    before_arc = before.get("arc")
+    server.recruit_companion(bg, "npc-the-emperor", class_name="Wizard", abilities={"intelligence": 18})
+    after = server.get_character(bg, "npc-the-emperor")
+    # the seeded dossier survives (existing contract), and IF an arc was authored it is untouched
+    assert "dominion" in after["companion_dossier"]["values"]
+    if before_arc is not None:
+        assert after["arc"] == before_arc
+
+
+def test_recruit_still_seeds_arc_and_dossier(tmp_path, monkeypatch):
+    """The path that ALREADY worked must keep working after the extract-shared-helper refactor."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Seed")["id"]
+    npc = server.create_character(cid, "Bram", kind="npc")["id"]
+    server.update_character(cid, npc, {
+        "backstory": "A grizzled sellsword. Quiet about his past.",
+        "memory": ["owes a debt to the Harpers"],
+    })
+    out = server.recruit_companion(cid, npc, class_name="Fighter")
+    assert out["arc_seeded"] is True and out["dossier_seeded"] is True
+    ch = server.get_character(cid, npc)
+    assert ch["arc"] is not None
+    assert "A grizzled sellsword" in ch["companion_dossier"]["camp_prompts"]
+    assert "owes a debt to the Harpers" in ch["companion_dossier"]["camp_prompts"]
+
+
+def test_old_snapshot_with_arcless_companion_round_trips():
+    """ADDITIVE round-trip: an old snapshot whose companion predates seeding (arc=None,
+    companion_dossier=None) must still deserialize unchanged — the helper runs at CREATE
+    time, never breaking a load of pre-fix state."""
+    ch = Character(name="Old", kind="companion", attitude_value=10)
+    data = ch.model_dump(mode="json")
+    assert data["arc"] is None and data["companion_dossier"] is None
+    again = Character.model_validate(data)
+    assert again.arc is None and again.companion_dossier is None
+
+
+# ============================================================================
+# F06-3 — companion_advise reads dossier / approval-gauge / arc
+# ============================================================================
+
+
+def test_deliberate_with_no_dossier_or_standing_is_byte_identical():
+    """The PURE-MODULE additive guarantee: deliberate() called without the new dossier/
+    standing args returns EXACTLY today's keys — no new keys leak when no enrichment data
+    is passed."""
+    comp = Character(name="Vesper", kind="companion", voice_id="companion-default",
+                     personality="a warm field medic who argues for mercy")
+    frame = companion_mod.deliberate(comp, situation="a cornered goblin begs", callbacks=[])
+    assert set(frame) == {"companion", "voice_id", "personality", "callbacks", "prompt"}
+
+
+def test_deliberate_folds_standing_and_dossier_when_passed():
+    """deliberate() given a standing band + dossier approval causes surfaces them in the
+    return for human judgment — the engine reads the gauge, the DM judges the cause."""
+    comp = Character(name="Astra", kind="companion", voice_id="companion-default",
+                     personality="a sharp-tongued sorceress")
+    dossier = CompanionDossier(approval_likes=["bold defiance of tyrants"],
+                               approval_dislikes=["needless cruelty"])
+    frame = companion_mod.deliberate(
+        comp, situation="the duke offers a bribe",
+        standing={"band": "warm", "attitude_value": 45},
+        dossier=dossier,
+    )
+    assert frame["standing"]["band"] == "warm"
+    assert frame["standing"]["attitude_value"] == 45
+    assert "bold defiance of tyrants" in frame["approval_likes"]
+    assert "needless cruelty" in frame["approval_dislikes"]
+    # the stance is reflected into the prompt so the DM voices a companion who already has a leaning
+    assert "warm" in frame["prompt"]
+
+
+def test_companion_advise_surfaces_band_and_approval_causes(tmp_path, monkeypatch):
+    """The live surface (companion_advise) now reads the seeded dossier + the approval gauge
+    + the arc and folds them into its return — every existing advise beat gets richer at
+    near-zero token cost."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Advise")["id"]
+    res = server.create_character(cid, "Mira", kind="companion", class_name="Cleric")
+    comp_id = res["id"]
+    # author the dossier's approval causes + nudge the gauge into a clear band
+    server.update_character(cid, comp_id, {
+        "attitude_value": 55,
+        "companion_dossier": {"approval_likes": ["protecting the weak"],
+                              "approval_dislikes": ["betraying a trust"]},
+    })
+    out = server.companion_advise(cid, comp_id, situation="a beggar asks for coin")
+    assert out["standing"]["attitude_value"] == 55
+    assert out["standing"]["band"]  # a non-empty band label derived from the gauge
+    assert "protecting the weak" in out["approval_likes"]
+    assert "betraying a trust" in out["approval_dislikes"]
+    # the seeded default arc is summarized (gate + how far the next locked gate is)
+    assert out["arc"] is not None
+    assert "gates" in out["arc"]
+
+
+def test_companion_advise_without_dossier_or_arc_degrades_cleanly(tmp_path, monkeypatch):
+    """A companion with no dossier and no arc (e.g. an old snapshot loaded pre-backfill, or
+    an NPC mid-promotion) advises WITHOUT the optional keys rather than erroring — the
+    enrichment is best-effort and the base frame always returns."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Advise")["id"]
+    # build a bare companion record directly (no seeding) to mimic a pre-fix snapshot
+    c = server.load_campaign(cid)
+    bare = Character(name="Husk", kind="companion", voice_id="companion-default")
+    c.characters[bare.id] = bare
+    c.party.append(bare.id)
+    server.save_campaign(c)
+    out = server.companion_advise(cid, bare.id, situation="a quiet road")
+    assert out["voice_id"] and "prompt" in out  # base frame still returns
+    assert out["standing"]["attitude_value"] == 0  # gauge always readable
+    assert out["arc"] is None  # no arc -> summary is None, not an error
+
+
+def test_companion_advise_standing_band_tracks_the_gauge(tmp_path, monkeypatch):
+    """The band is a deterministic read of attitude_value only (the gauge) — a hostile and a
+    devoted companion get DIFFERENT band labels from the SAME tool, so the DM voices the
+    right leaning."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Advise")["id"]
+    cold = server.create_character(cid, "Frost", kind="companion")["id"]
+    warm = server.create_character(cid, "Ember", kind="companion")["id"]
+    server.update_character(cid, cold, {"attitude_value": -70})
+    server.update_character(cid, warm, {"attitude_value": 80})
+    cold_band = server.companion_advise(cid, cold, situation="x")["standing"]["band"]
+    warm_band = server.companion_advise(cid, warm, situation="x")["standing"]["band"]
+    assert cold_band != warm_band

--- a/servers/engine/tests/test_qa_fixes.py
+++ b/servers/engine/tests/test_qa_fixes.py
@@ -637,7 +637,10 @@ def test_camp_scene_gathers_each_companion_with_standing_and_arc(tmp_path, monke
     assert jbeat["attitude_value"] == 25
     assert jbeat["arc"]["next_gate"] == {"kind": "loyalty", "threshold": 40, "points_away": 15}
     mbeat = next(b for b in out["beats"] if b["companion"] == "Minsc")
-    assert mbeat["arc"] is None                                   # no arc -> no summary, no crash
+    # F06-1: a companion made via create_character now carries the SEEDED DEFAULT arc (a
+    # loyalty gate at threshold 25), so the camp beat surfaces that default summary — camp is
+    # no longer inert for a companion the DM never hand-authored an arc for.
+    assert mbeat["arc"]["next_gate"] == {"kind": "loyalty", "threshold": 25, "points_away": 25}
 
 
 def test_long_rest_hints_camp_only_when_companions_present(tmp_path, monkeypatch):


### PR DESCRIPTION
Closes #769 · Closes #770
Source: `docs/audits/ENGINE-AUDIT-2026-06-11.md` (F6-1, F6-3)

This is a story-gate fix: the engine TRACKS companion relationship state (arc, dossier, approval gauge) that the dominant creation path never seeds and the only live companion surface never reads. We wire the WRITE to the READ the DM actually sees.

## Root cause

**F06-1 (#769) — 2 of 3 companion-creation paths seed no arc/dossier.**
`recruit_companion` seeded both arc + dossier inline; **`create_character` — the dominant path (111 calls vs 38 recruit) — seeded NEITHER**; `load_canon_character` seeded the dossier but never an arc. Result: **20/20 live snapshot companions had `arc=None`/`companion_dossier=None`**, so the entire relationship machine (`camp_scene` / `check_companion_arc` / agendas / banter) was structurally inert on the path players actually use. `start_adventure`'s own docstring prescribes the unseeded `create_character` path.

**F06-3 (#770) — `companion_advise` ignores dossier, gauge, and arc.**
`companion_advise` is the ONLY companion surface in live use (54 calls). It read only name/voice_id/personality + recall callbacks — voicing a blank-neutral opinion regardless of how the relationship actually stood.

## Fix

**F06-1 (extract-shared-helper).** The arc+dossier seeding `recruit_companion` did inline is extracted into `_seed_companion_operational_state(ch)` and called by ALL THREE creation paths, companion-only. Both writes stay **None-guarded** — an ending-seeded / canon / roster arc or dossier is never overwritten. The dossier synthesis now also falls through `biography` (the `create_character` authoring field) so that path's prose seeds a terse camp prompt. **Additive**: the helper runs at CREATE time only, so an old snapshot with `arc=None`/`companion_dossier=None` still deserializes unchanged.

**F06-3.** `companion_advise` computes a STANDING band — a pure read of the `attitude_value` gauge via the new `_attitude_band` (keyed to `npc.ATTITUDE_TRACK`) — and passes it plus the dossier into `deliberate()`. `deliberate()` gains optional `standing`/`dossier` args; **with neither passed its return is byte-identical to today's 5-key frame** (the pure module stays pure). When passed, it folds the band into the voicing prompt and surfaces `approval_likes`/`approval_dislikes` in the RETURN for the DM to judge whether THIS moment wins/loses regard (engine reads the gauge; the DM judges the cause — the F6-2 division of labor, **never auto-moving approval**). `companion_advise` also attaches the arc/gate-distance summary (the same `_camp_arc_summary` read camp uses). Best-effort: a companion with no dossier/arc still returns the base frame.

## Files changed
- `servers/engine/server.py` — new `_seed_companion_operational_state` helper (extracted from recruit); called from `create_character`, `recruit_companion`, `load_canon_character`; new `_attitude_band`; enriched `companion_advise`.
- `servers/engine/companion.py` — `deliberate()` gains optional additive `standing`/`dossier` args.
- `servers/engine/tests/test_companion_seed_advise.py` — new, 13 tests.
- `servers/engine/tests/test_companion_arc.py` (×2) + `test_qa_fixes.py` (×1) — behavior-coupled assertions updated for the now-seeded default arc.

## Tests
New file (13): seeding parity across all 3 paths; player/npc/monster untouched; ending-seeded arc never overwritten; biography-prose synthesis; old arcless snapshot round-trips; `deliberate` byte-identical with no enrichment; folds standing+dossier when passed; `companion_advise` surfaces band/approval-causes/arc; degrades cleanly with no dossier/arc; band tracks the gauge (hostile != devoted).

Updated 3 tests: a REJECTED `set_companion_arc` now leaves the SEEDED default arc intact (was `arc is None`); camp surfaces the seeded default arc summary.

## Verification
- Full engine suite: **2095 passed** (single-process, `-p no:xdist`).
- Tier-0 `bash qa/fast_gate.sh`: **PASS** (188 deterministic).
- Manual smoke: old-snapshot round-trip `arc=None` unchanged; live `companion_advise` returns `standing`/`approval_likes`/`approval_dislikes`/`arc` with the band folded into the prompt.

## Invariants
Engine sole-writer under `campaign_lock`; additive round-trip (new params/fields default to today's behavior, old snapshots load); engine rolls / DM is told (standing surfaced, approval causes returned for human judgment, never auto-applied); wire contracts frozen (no `clawdnd-*`/`CLAWDND_*` changes).

DO NOT MERGE pending review.