### PR TITLE
fix(world): gate wander tables to region/biome + surface soft-tick world content (F04-1, F04-2)

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -867,10 +867,35 @@ sys.exit(0 if seated else 1)
 PY
 }
 
+# The state-dir-scoped CARRY-FORWARD file (F04-2). The soft-tick advances the world
+# clock between beats and the engine's advance_time DISCLOSES the world beats / backlog
+# developments / effect expiries it processed — but the harness historically printed only
+# day/time_of_day and DISCARDED that living-world content to stderr, so a thread beat that
+# fired "while the party slept" was lost before the DM ever saw it (invariant-4 breach, on
+# the CALLER side — the engine already returns it). We persist those lines HERE, then the
+# NEXT beat's runbook prepends them as a "While time passed:" block so the DM weaves them in.
+# One file per run state-dir; read-and-cleared each beat (see clawdnd_take_carryforward).
+clawdnd_carryforward_path() {
+  printf '%s/.worldos_softtick_carry.txt' "$1"
+}
+
+# Read-and-CLEAR the carry-forward block for this state dir (F04-2). Echoes the stored
+# "While time passed:" block (possibly multi-line) and removes the file so each surfaced
+# beat is woven EXACTLY once — never re-fed on a later beat. Empty (and a clean no-op) when
+# nothing was carried. $1 = STATE_DIR.
+clawdnd_take_carryforward() {
+  local f; f="$(clawdnd_carryforward_path "$1")"
+  [ -f "$f" ] || return 0
+  cat "$f" 2>/dev/null
+  rm -f "$f" 2>/dev/null
+}
+
 # The C backstop. After a DM beat, compare the live clock to the clock BEFORE the beat; if the
 # DM did NOT advance it this beat, advance ONE phase through the engine (advance_time(phases=1))
 # so the day cannot freeze at morning. Engine stays the sole writer. No-op (and silent) until a
-# snapshot exists. Echoes a short "[tick] …" status to stderr for the run log.
+# snapshot exists. Echoes a short "[tick] …" status to stderr for the run log. F04-2: also
+# persists the engine's returned world beats / developments / effect-expiries to the carry-
+# forward file so the NEXT beat's runbook surfaces them to the DM (they were being discarded).
 # $1 = ROOT (repo root)  $2 = STATE_DIR  $3 = prev_day  $4 = prev_tod
 clawdnd_soft_tick() {
   local root="$1" state_dir="$2" prev_day="$3" prev_tod="$4"
@@ -899,14 +924,45 @@ clawdnd_soft_tick() {
   # blanket-suppress, so a real engine failure is visible. On a contended host `uv` can return a
   # transient cache error; that's non-fatal here (the NEXT beat re-reads the clock and re-ticks),
   # so we never let the tick's exit status fail the loop (the function always returns 0).
-  local camp out; camp="$(basename "$(dirname "$snap")")"
-  out="$(WORLDOS_STATE_DIR="$state_dir" CLAWDND_STATE_DIR="$state_dir" uv run --directory "$root/servers/engine" python - "$camp" 2>&1 <<'PY'
+  local camp out carry; camp="$(basename "$(dirname "$snap")")"
+  carry="$(clawdnd_carryforward_path "$state_dir")"
+  out="$(WORLDOS_STATE_DIR="$state_dir" CLAWDND_STATE_DIR="$state_dir" uv run --directory "$root/servers/engine" python - "$camp" "$carry" 2>&1 <<'PY'
 import sys
 import server
 camp = sys.argv[1]
+carry_path = sys.argv[2] if len(sys.argv) > 2 else ""
 try:
     r = server.advance_time(camp, phases=1, note="harness soft clock-tick backstop")
     print(f"[tick] clock frozen this beat -> engine advanced to day {r.get('day')} {r.get('time_of_day')}")
+    # F04-2: the engine DISCLOSES the living-world content it processed this tick. Persist it
+    # so the NEXT runbook surfaces it to the DM instead of dropping it to the run log.
+    # Only the genuinely-narratable channels (world beats fired, backlog developments,
+    # effect expiries). Empty channels add NOTHING (no carry file, no token cost on a quiet
+    # tick). Best-effort: a write failure never fails the loop (the tick already advanced).
+    def _lines(v):
+        return [str(x).strip() for x in (v or []) if str(x).strip()]
+    beats = _lines(r.get("world_beats"))
+    devs = _lines(r.get("world_developments"))
+    exps = _lines(r.get("expired_effects"))
+    if (beats or devs or exps) and carry_path:
+        chunks = []
+        for line in beats:
+            chunks.append(f"- {line}")
+        for line in devs:
+            chunks.append(f"- {line}")
+        if exps:
+            chunks.append("- effects that ran out overnight: " + ", ".join(exps))
+        block = ("While time passed (the world moved between beats — weave these into THIS "
+                 "scene; do not silently drop them):\n" + "\n".join(chunks))
+        try:
+            # APPEND so a second frozen tick before the next beat does not clobber the first
+            # tick content; the next beat reads-and-clears the whole accumulation.
+            with open(carry_path, "a", encoding="utf-8") as fh:
+                if fh.tell() > 0:
+                    fh.write("\n")
+                fh.write(block + "\n")
+        except OSError as e:
+            print(f"[tick] (carry-forward write skipped: {e})")
 except Exception as e:
     print(f"[tick] soft-tick FAILED ({e})")
 PY
@@ -926,8 +982,29 @@ PY
 #   4. stuck (no move in N beats) -> "travel/peopling" — move the party OR bring a new named NPC.
 #   5. otherwise                  -> "rising-action" — escalate; keep friction that sticks.
 # Echoes the runbook text (a short paragraph). Never empty.
+# F04-2: BEFORE the runbook body, this prepends the soft-tick CARRY-FORWARD block (the
+# living-world content the engine processed while the clock advanced last beat) so the DM
+# is TOLD what moved between beats instead of it being discarded. The carry is read-and-
+# cleared, so it surfaces exactly once. A quiet tick carries nothing -> byte-identical to
+# the old single-paragraph runbook.
 # $1 = beat (1-based)  $2 = total beats  $3 = prev_location_id (loc at beat start)  $4 = STATE_DIR
 clawdnd_runbook_for_beat() {
+  local state_dir="$4" carry body
+  carry="$(clawdnd_take_carryforward "$state_dir")"
+  body="$(_clawdnd_runbook_body "$@")"
+  if [ -n "$carry" ]; then
+    # The world-moved block leads (it's the freshest fact the DM must honor), then the
+    # moment-specific runbook. Two newlines so the DM reads them as distinct directives.
+    printf '%s\n\n%s' "$carry" "$body"
+  else
+    printf '%s' "$body"
+  fi
+}
+
+# The runbook BODY — the moment-specific story directive (the original selector). Kept as an
+# inner helper so clawdnd_runbook_for_beat can prepend the F04-2 carry-forward block in ONE
+# place that BOTH opener paths (play.sh / play_party.sh) already route through.
+_clawdnd_runbook_body() {
   local beat="$1" beats="$2" prev_loc="$3" state_dir="$4"
   local prog day tod visited npcs_met cur_loc cur_visited
   prog="$(clawdnd_read_progress "$state_dir")"

--- a/qa/tests/_seed_softtick_fixture.py
+++ b/qa/tests/_seed_softtick_fixture.py
@@ -1,0 +1,50 @@
+"""F04-2 fixture: seed a campaign with a thread-beat due TODAY so the harness soft-tick's
+advance_time(phases=1) fires it into `world_beats` — the content the leak used to discard.
+
+Run with WORLDOS_STATE_DIR/CLAWDND_STATE_DIR pointed at a temp state dir (the shell proof
+does this). Prints ONLY the campaign id on success so the caller can capture it.
+"""
+import os
+import sys
+
+# Make the engine package importable however we're invoked (the shell proof runs us with
+# `uv run --directory servers/engine python <abs-path>`, which puts THIS file's dir on the
+# path, not the engine dir). WORLDOS_ENGINE_DIR is set by the proof; fall back to the repo layout.
+_engine = os.environ.get("WORLDOS_ENGINE_DIR") or os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "servers", "engine",
+)
+if _engine not in sys.path:
+    sys.path.insert(0, _engine)
+
+import server  # noqa: E402
+import store  # noqa: E402
+from models import Consequence  # noqa: E402
+
+
+def main() -> int:
+    cid = server.create_campaign("F04-2 soft-tick carry-forward proof")["id"]
+    # Seat a player PC so the snapshot looks like a real run (clawdnd_snapshot_path finds it).
+    server.create_character(cid, "Renn", kind="player")
+
+    c = store.load_campaign(cid)
+    # A standing thread-beat DUE today: worldsim.tick fires it on the next clock advance and
+    # re-arms it forward (so it can't double-fire). The text is what must reach the DM.
+    c.consequences.append(
+        Consequence(
+            trigger_day=c.day,  # due now -> fires on the soft-tick's advance_time
+            text="FIXTURE-BEAT: the marketplace fixers move on the docks while the party sleeps",
+            note="F04-2 fixture thread-beat",
+            thread_id="thread-fixture-f042",
+        )
+    )
+    # Put the clock at evening so advance_time(phases=1) rolls a real phase (steps > 0 -> tick).
+    c.time_of_day = "evening"
+    store.save_campaign(c)
+
+    print(cid)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/tests/test_softtick_carryforward.sh
+++ b/qa/tests/test_softtick_carryforward.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# F04-2 PROOF — the harness soft-tick must SURFACE the living-world content the engine
+# processes between beats (world beats / backlog developments / effect expiries) into the
+# NEXT beat's runbook, instead of discarding it to the run log.
+#
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F04-2, issue #823).
+#
+# Deterministic, $0, no LLM. Drives the REAL engine (advance_time) + the REAL shell helpers
+# (clawdnd_soft_tick / clawdnd_runbook_for_beat / clawdnd_take_carryforward). Asserts:
+#   1. a due thread-beat fired by the soft-tick lands in the carry-forward file as a
+#      "While time passed:" block (BEFORE: discarded);
+#   2. the next beat's runbook PREPENDS that block (the DM is told);
+#   3. the carry is read-and-CLEARED (surfaced exactly once — the following runbook is clean);
+#   4. a QUIET tick (nothing fired) writes NO carry file (no token cost on a still world).
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT/qa/lib_beat_driver.sh"
+
+FAILS=0
+note() { printf '  %s\n' "$*"; }
+fail() { printf '  ✗ %s\n' "$*"; FAILS=$((FAILS + 1)); }
+pass() { printf '  ✓ %s\n' "$*"; }
+
+STATE_DIR="$(mktemp -d "${TMPDIR:-/tmp}/wos_f04_2_XXXXXX")"
+trap 'rm -rf "$STATE_DIR"' EXIT
+
+# --- Seed a campaign with a thread-beat due TODAY (fires on the next clock advance) ----------
+CID="$(WORLDOS_STATE_DIR="$STATE_DIR" CLAWDND_STATE_DIR="$STATE_DIR" \
+  uv run --directory "$ROOT/servers/engine" python "$ROOT/qa/tests/_seed_softtick_fixture.py" 2>&1)"
+if [ -z "$CID" ] || printf '%s' "$CID" | grep -qi "error\|traceback"; then
+  fail "fixture seed failed: $CID"
+  echo "── F04-2 PROOF: FAIL ($FAILS) ──"; exit 1
+fi
+note "seeded campaign $CID (state=$STATE_DIR)"
+
+SNAP="$(clawdnd_snapshot_path "$STATE_DIR")"
+[ -n "$SNAP" ] && pass "snapshot present for the harness" || fail "no snapshot found"
+
+CARRY="$(clawdnd_carryforward_path "$STATE_DIR")"
+[ -f "$CARRY" ] && fail "carry file exists BEFORE any tick (should be absent)" || pass "no carry file pre-tick"
+
+# --- (1) Run the soft-tick. The clock is FROZEN (prev == cur), so it advances one phase, fires
+#         the due thread-beat, and must persist it to the carry file. ---------------------------
+PROG="$(clawdnd_read_progress "$STATE_DIR")"
+PREV_DAY="$(printf '%s' "$PROG" | cut -f1)"
+PREV_TOD="$(printf '%s' "$PROG" | cut -f2)"
+clawdnd_soft_tick "$ROOT" "$STATE_DIR" "$PREV_DAY" "$PREV_TOD" 2>/dev/null
+
+if [ -f "$CARRY" ]; then
+  pass "soft-tick WROTE the carry-forward file"
+  if grep -q "While time passed" "$CARRY"; then
+    pass "carry file carries the 'While time passed' block"
+  else
+    fail "carry file missing the 'While time passed' header: $(cat "$CARRY")"
+  fi
+  if grep -qi "marketplace fixers\|the world moved\|FIXTURE-BEAT" "$CARRY"; then
+    pass "carry file carries the fired thread-beat text"
+  else
+    fail "carry file missing the fired beat text. Contents:"; sed 's/^/      /' "$CARRY"
+  fi
+else
+  fail "soft-tick did NOT write a carry file (the F04-2 leak)"
+fi
+
+# --- (2) The next beat's runbook must PREPEND the carry block (the DM is told). --------------
+RB="$(clawdnd_runbook_for_beat 3 8 "loc-nowhere" "$STATE_DIR")"
+if printf '%s' "$RB" | grep -q "While time passed"; then
+  pass "next runbook surfaces the carry block to the DM"
+else
+  fail "next runbook did NOT surface the carry block"
+fi
+if printf '%s' "$RB" | grep -q "RUNBOOK —"; then
+  pass "runbook still carries its moment-specific body (carry is ADDITIVE)"
+else
+  fail "runbook body was clobbered by the carry prepend"
+fi
+
+# --- (3) Read-and-CLEAR: the carry surfaces exactly once. ------------------------------------
+[ -f "$CARRY" ] && fail "carry file NOT cleared after the runbook read it" || pass "carry file cleared (surfaced once)"
+RB2="$(clawdnd_runbook_for_beat 4 8 "loc-nowhere" "$STATE_DIR")"
+if printf '%s' "$RB2" | grep -q "While time passed"; then
+  fail "the SECOND runbook re-fed the already-surfaced carry block"
+else
+  pass "the second runbook is clean (no stale re-feed)"
+fi
+if printf '%s' "$RB2" | grep -q "RUNBOOK —"; then
+  pass "the second runbook still has its body"
+else
+  fail "the second runbook is empty"
+fi
+
+# --- (4) A QUIET tick (clock already moved by a 'DM' beat) writes NO carry. ------------------
+# Bump the clock so the soft-tick sees prev != cur and no-ops (no advance, nothing fired).
+QPROG="$(clawdnd_read_progress "$STATE_DIR")"
+QDAY="$(printf '%s' "$QPROG" | cut -f1)"; QTOD="$(printf '%s' "$QPROG" | cut -f2)"
+clawdnd_soft_tick "$ROOT" "$STATE_DIR" "$((QDAY - 1))" "yesteryear" 2>/dev/null  # prev != cur -> no-op
+[ -f "$CARRY" ] && fail "a no-op soft-tick wrote a carry file (should be silent)" || pass "no-op tick wrote no carry (no token cost on a still world)"
+
+echo "── F04-2 PROOF: $([ "$FAILS" -eq 0 ] && echo PASS || echo "FAIL ($FAILS)") ──"
+[ "$FAILS" -eq 0 ]

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -1611,6 +1611,13 @@ def seed_world(world: dict, start_at: str = "", ending: str = "") -> Campaign:
             description=reg.get("description", ""),
             connections=reg.get("connections", []),
             notes=" ".join(reg.get("tags", [])),
+            # F04-1: stamp `region` on authored regions (was '' — they omitted the kwarg,
+            # so the wander resolver fell through to the wilderness BASE_RATE). Mirror the
+            # ingested-area path (content.py uses area["region"]); an authored region IS its
+            # own parent zone, so its name is the natural region label. A world MAY override
+            # by declaring an explicit `region` on the source record. Additive: old snapshots
+            # already carry the (defaulted-'') field, so they round-trip unchanged.
+            region=str(reg.get("region", reg.get("name", ""))),
             hex=reg.get("hex"),
             # The world's authored regions are KNOWN day-1 — they are the shipped nav
             # graph the player can already see in the atlas (issue #261). A world MAY

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1075,6 +1075,10 @@ def travel_to(campaign_id: str, destination_id: str = "", advance_time: bool = F
                     dest_loc.region if dest_loc is not None else "",
                     difficulty="medium",
                     location_id=destination_id,
+                    # F04-1: resolve danger off the destination's region + name + tags so
+                    # a city street doesn't roll a wilderness ambush (the bare region of a
+                    # Baldur's Gate area matches no keyword); the payload region stays bare.
+                    match_region=_composite_region_match(dest_loc),
                 )
                 if staged:
                     result["wandering_encounter"] = staged
@@ -2278,6 +2282,23 @@ def _spawn_creature_chars(c: Campaign, canonical: str, count: int, location_id) 
     return spawned
 
 
+def _composite_region_match(loc) -> str:
+    """The MATCH string the wander resolver should see for a location (F04-1).
+
+    A location's danger signal lives across THREE fields: `region` (the parent zone,
+    often a bare name like "Baldur's Gate" that matches no keyword), `name` (e.g.
+    "The Lower City"), and `notes` (where ingest joins the area's tags — "market city
+    hub"). The bare `region` alone is what the resolver historically saw, so every
+    Baldur's Gate scene fell through to the wilderness BASE_RATE. Joining all three
+    lets the substring matcher catch the real keyword ("city"/"market"/"sewer"). The
+    payload's WIRE `region` value stays `loc.region` (the seams pass this only to the
+    resolver, never as the displayed region) so the contract's semantics don't shift."""
+    if loc is None:
+        return ""
+    parts = [loc.region or "", loc.name or "", loc.notes or ""]
+    return " ".join(p for p in parts if p).strip()
+
+
 def _stage_wandering_encounter(
     c: Campaign,
     region: str,
@@ -2287,6 +2308,7 @@ def _stage_wandering_encounter(
     location_id=None,
     force: bool = False,
     rng: random.Random | None = None,
+    match_region: str | None = None,
 ) -> Optional[dict]:
     """Roll + (on a hit) STAGE a Kingmaker-style wandering encounter (mutates; caller
     holds the lock + saves). Composes the pure `wander` module with the existing spawn
@@ -2316,17 +2338,28 @@ def _stage_wandering_encounter(
 
     Returns None when nothing was staged (flag off, roll missed) so the seam simply
     omits the key. A combat pick that can't spawn / can't size degrades to a boon
-    inside `pick_typed_encounter`, so a hit always yields SOME staged encounter."""
+    inside `pick_typed_encounter`, so a hit always yields SOME staged encounter.
+
+    F04-1: `match_region` (when given) is the composite "<region> <name> <notes>" the
+    seam built so the resolver can read the location's danger keyword from its NAME +
+    tags, not just the bare parent zone (a Baldur's Gate area's region="Baldur's Gate"
+    matches no keyword). The chance/pool/type are picked off `match_region`; the
+    returned payload's `region` key stays the DISPLAY `region` so the wire value's
+    semantics are unchanged. `match_region=None` (the default) reproduces today's
+    behavior exactly (resolve off `region`)."""
     if not force and not c.house_rules.wandering_encounters:
         return None
     region = region or ""
-    if not force and not wander.roll_encounter(region, modifiers, rng=rng):
+    # The resolver reads the COMPOSITE (region + name + notes) when the seam supplied
+    # one; the displayed `region` stays bare. Default None -> resolve off `region`.
+    resolve_region = match_region if match_region is not None else region
+    if not force and not wander.roll_encounter(resolve_region, modifiers, rng=rng):
         return None
     levels = _party_levels(c)
     r = rng or random.Random()
     picked = wander.pick_typed_encounter(
         levels,
-        region,
+        resolve_region,
         rng=r,
         target_difficulty=difficulty,
         house_difficulty=c.house_rules.difficulty,
@@ -6580,6 +6613,9 @@ def long_rest(campaign_id: str, character_id: str, watch: str = "") -> dict:
                 difficulty="medium",
                 modifiers=modifiers,
                 location_id=c.current_location_id,
+                # F04-1: resolve the camp-watch danger off the camp location's region +
+                # name + tags (a city camp is a guarded inn, not a wilderness bivouac).
+                match_region=_composite_region_match(cur_loc),
             )
             if staged:
                 out["wandering_encounter"] = staged
@@ -9000,11 +9036,19 @@ def roll_wandering_encounter(campaign_id: str, region: str = "", difficulty: str
         if c.combat.active:
             raise ValueError("combat already active — resolve it (end_combat) before staging another encounter")
         region_in = region.strip()
+        # F04-1: when `region` is defaulted to the current location, resolve danger off
+        # that location's COMPOSITE (region + name + tags) so a city scene reads civilized.
+        # An EXPLICIT `region` arg matches off itself (no location context to enrich) — the
+        # caller chose that string deliberately.
         if not region_in:
             cur_loc = c.locations.get(c.current_location_id) if c.current_location_id else None
             region_in = cur_loc.region if cur_loc is not None else ""
+            match_region = _composite_region_match(cur_loc)
+        else:
+            match_region = region_in
         staged = _stage_wandering_encounter(
-            c, region_in, difficulty=difficulty, location_id=c.current_location_id, force=True
+            c, region_in, difficulty=difficulty, location_id=c.current_location_id,
+            force=True, match_region=match_region,
         )
         if staged is None:
             return {"staged": False, "region": region_in, "difficulty": difficulty}

--- a/servers/engine/tests/test_wander.py
+++ b/servers/engine/tests/test_wander.py
@@ -194,6 +194,62 @@ def test_compound_region_danger_adjective_wins(region, expected_tier, expected_r
 
 
 # =========================================================================
+# F04-1: URBAN keywords + composite match string (city scenes must read civilized,
+#        not roll wilderness ambushes). The matcher only ever sees a region string;
+#        the engine seams pass a COMPOSITE "<region> <name> <notes>" so a Baldur's
+#        Gate area (region="Baldur's Gate", tags="market city hub") resolves to the
+#        civilized tier instead of the BASE_RATE wilderness default.
+# =========================================================================
+
+
+def test_city_keyword_is_civilized_low_rate():
+    # the bare "city" keyword (already present) — a city scene is patrolled, low risk
+    assert wander.encounter_chance("city") == wander.REGION_RATES["city"]
+    assert wander.encounter_chance("city") <= 0.12
+
+
+def test_bg_composite_match_string_resolves_civilized():
+    # all 14 BG areas ship region="Baldur's Gate" (no keyword) + city/market/etc tags
+    # joined into notes; the COMPOSITE the seam builds catches "city" -> civilized 0.08,
+    # NOT the BASE_RATE 0.30 wilderness default that the bare region string yields.
+    bare = wander.encounter_chance("Baldur's Gate")
+    composite = wander.encounter_chance("Baldur's Gate The Lower City market city hub")
+    assert bare == wander.BASE_RATE  # the bug: the bare region matches nothing
+    assert composite <= 0.12  # the fix: the composite reads civilized
+    assert composite == wander.REGION_RATES["city"]
+    # and the creature pool for that composite is civilized, not wilderness
+    assert wander._region_tier("Baldur's Gate The Lower City market city hub") == "civilized"
+
+
+@pytest.mark.parametrize(
+    "keyword",
+    ["market", "tavern", "harbor", "dock", "port", "slum", "warren", "quarter", "temple", "palace"],
+)
+def test_new_urban_keywords_are_civilized(keyword):
+    """The urban keywords F04-1 adds must land in the civilized band (low rate, civilized
+    creature pool) so a market/tavern/harbor/temple scene doesn't roll a wilderness ambush."""
+    assert keyword in wander.REGION_RATES, f"{keyword!r} missing from REGION_RATES"
+    assert wander.REGION_RATES[keyword] <= 0.12, f"{keyword!r} not in the civilized rate band"
+    assert wander._region_tier(f"the {keyword} district") == "civilized"
+
+
+def test_sewer_and_undercity_are_non_civilized():
+    """`sewer`/`undercity` are urban-UNDERGROUND — dungeon-flavored, NOT civilized — and
+    must match BEFORE the `city` substring (note "undercity" CONTAINS "city")."""
+    for region in ("the undercity sewers crime dungeon", "a flooded sewer tunnel"):
+        tier = wander._region_tier(region)
+        assert tier != "civilized", f"{region!r} resolved civilized; expected non-civilized ({tier})"
+        # the chance must NOT be the tame civilized 0.08 — these are dangerous places
+        assert wander.encounter_chance(region) > wander.REGION_RATES["city"]
+
+
+def test_undercity_substring_does_not_leak_to_city():
+    # "The Undercity" (an authored BG region whose name contains "city") must NOT read as
+    # a tame civilized city — the undercity/sewer keyword wins the ordering tie.
+    assert wander._region_tier("The Undercity") != "civilized"
+
+
+# =========================================================================
 # INTEGRATION: engine seams stage real monster Characters + the payload
 # =========================================================================
 

--- a/servers/engine/tests/test_wander_region_match.py
+++ b/servers/engine/tests/test_wander_region_match.py
@@ -1,0 +1,181 @@
+"""F04-1: region danger/creature tables must MATCH shipped content.
+
+Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F04-1, issue #822).
+
+The bug: every Baldur's Gate area/region ships region="Baldur's Gate" (or '' for the
+authored regions), which matches NO wander keyword, so the resolver falls back to the
+BASE_RATE (0.30) wilderness model — a city street rolls a 30% chance of a *wolf/ogre*
+ambush. The signal that says "this is a city" lives in the location's NAME + tags
+(joined into `notes`), surfaces the matcher never saw.
+
+The fix: (1) the three staging seams build a COMPOSITE match string
+"<region> <name> <notes>" and pass it to the resolver (the wire `region` value stays
+loc.region); (2) wander.py gains urban keywords (market/tavern/harbor/.../quarter)
+in the civilized band + sewer/undercity in the non-civilized band; (3) content.py
+seeds the authored regions' `region` field (was '').
+"""
+
+import random
+
+import pytest
+
+import content
+import server
+import store
+import wander
+
+
+# --- (1) CONTENT: the authored BG regions now seed a non-empty `region` -------------
+
+
+def test_authored_regions_seed_region_field():
+    """content.seed_world must stamp `region` on authored regions (was '' — the F04-1
+    seed-side half). Old snapshots round-trip (the field already existed); this only
+    changes what a FRESH seed writes."""
+    w = content.load_world_data("baldurs-gate")
+    c = content.seed_world(w)
+    # the authored Lower City hub now carries a region (its own name) — not ''
+    lower = c.locations.get("loc-lower-city")
+    assert lower is not None
+    assert lower.region, "authored region seeded with empty region (F04-1 seed half not applied)"
+
+
+# --- (2) RESOLVER coverage over the real shipped BG world ----------------------------
+
+
+def _bg_campaign():
+    w = content.load_world_data("baldurs-gate")
+    return content.seed_world(w)
+
+
+def _composite(loc) -> str:
+    """The match string the engine seams build (mirrors server-side _stage seam)."""
+    return f"{loc.region} {loc.name} {loc.notes}".strip()
+
+
+def test_bg_locations_resolve_non_base_rate_keyword():
+    """Spec: ≥90% of BG locations must resolve a non-BASE_RATE keyword via the composite
+    (today: 0% — every one falls to BASE_RATE)."""
+    c = _bg_campaign()
+    locs = list(c.locations.values())
+    assert len(locs) >= 20, f"expected the full BG graph, got {len(locs)} locations"
+    resolved = 0
+    for loc in locs:
+        comp = _composite(loc)
+        if wander._match_keyword(comp, wander.REGION_RATES) is not None:
+            resolved += 1
+    frac = resolved / len(locs)
+    assert frac >= 0.90, f"only {resolved}/{len(locs)} ({frac:.0%}) BG locations resolve a keyword"
+
+
+def test_bg_city_scenes_read_civilized_via_composite():
+    """A BG *city* location (tagged 'city') must resolve to the civilized tier + low rate
+    through the composite — NOT the wilderness BASE_RATE."""
+    c = _bg_campaign()
+    city_locs = [
+        loc for loc in c.locations.values()
+        if "city" in (loc.notes or "").lower() and "sewer" not in (loc.notes or "").lower()
+        and "dungeon" not in (loc.notes or "").lower() and "ruins" not in (loc.notes or "").lower()
+    ]
+    assert city_locs, "no plain-city BG locations found — content drifted"
+    for loc in city_locs:
+        comp = _composite(loc)
+        chance = wander.encounter_chance(comp)
+        assert chance <= 0.12, f"{loc.name!r} composite {comp!r} chance {chance} > 0.12 (wilderness leak)"
+        assert wander._region_tier(comp) == "civilized", f"{loc.name!r} not civilized via composite"
+
+
+def test_bg_undercity_sewers_read_non_civilized_via_composite():
+    """The Undercity / sewers areas (urban-underground) must read NON-civilized via the
+    composite even though their names/tags also contain 'city'."""
+    c = _bg_campaign()
+    underground = [
+        loc for loc in c.locations.values()
+        if "sewer" in (loc.notes or "").lower() or "undercity" in (loc.name or "").lower().replace(" ", "")
+        or "undercity" in f"{loc.region}{loc.name}".lower().replace(" ", "")
+    ]
+    assert underground, "no undercity/sewer BG locations found — content drifted"
+    for loc in underground:
+        comp = _composite(loc)
+        assert wander._region_tier(comp) != "civilized", (
+            f"{loc.name!r} composite {comp!r} read civilized; expected non-civilized"
+        )
+
+
+# --- (3) SEAM: the staged payload keeps the DISPLAY region, matches off the composite -
+
+
+@pytest.fixture
+def city_camp(tmp_path, monkeypatch):
+    """A campaign whose current location is a CITY scene: region='Baldur's Gate',
+    notes carry the 'city' tag (mirroring a real ingested BG area)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("City Test")["id"]
+    start = server.add_location(cid, "The Lower City", region="Baldur's Gate")["id"]
+    dest = server.add_location(
+        cid, "Bloomridge Market", connections=[start], region="Baldur's Gate"
+    )["id"]
+    pc = server.create_character(cid, "Renn", kind="player")["id"]
+    server.update_character(cid, pc, {"classes": [{"name": "fighter", "level": 3}]})
+    # the 'city' signal lives in NOTES (tags joined into notes by the ingest path);
+    # add_location has no notes kwarg, so set it directly (mirrors content.py:1665).
+    c = store.load_campaign(cid)
+    c.locations[start].notes = "market city hub"
+    c.locations[dest].notes = "market city hub"
+    store.save_campaign(c)
+    return cid, start, dest
+
+
+def test_city_travel_leg_does_not_stage_wilderness_pool(city_camp, monkeypatch):
+    """A forced city travel-leg combat must draw from the CIVILIZED pool, never the
+    wilderness pool — the F04-1 core fix (no wolves in the Lower City)."""
+    monkeypatch.setattr(wander, "roll_encounter", lambda *a, **k: True)
+    monkeypatch.setattr(wander, "_weighted_choice", lambda *a, **k: "combat")
+    wilderness = set(wander.REGION_CREATURES["wilderness"]) - set(wander.REGION_CREATURES["civilized"])
+    civilized = set(wander.REGION_CREATURES["civilized"])
+    cid, _start, dest = city_camp
+    drawn = set()
+    for _ in range(20):
+        out = server.travel_to(cid, dest, advance_time=True)
+        we = out.get("wandering_encounter")
+        if we and we.get("type") == "combat":
+            for foe in we["foes"]:
+                drawn.add(foe["name"])
+        # reset position for the next leg
+        c = store.load_campaign(cid)
+        c.current_location_id = _start_of(c, dest)
+        # despawn staged monsters so the next leg starts clean
+        for mid in [i for i, ch in c.characters.items() if ch.kind == "monster"]:
+            del c.characters[mid]
+        store.save_campaign(c)
+    assert drawn, "no combat staged across 20 forced legs"
+    assert drawn.issubset(civilized), f"city leg drew wilderness creatures: {drawn - civilized}"
+    assert not (drawn & wilderness), f"city leg drew wilderness-only creatures: {drawn & wilderness}"
+
+
+def test_city_seam_payload_keeps_display_region(city_camp, monkeypatch):
+    """The staged payload's `region` key must stay the DISPLAY value (loc.region =
+    'Baldur's Gate'), NOT the composite match string (don't change the wire semantics)."""
+    monkeypatch.setattr(wander, "roll_encounter", lambda *a, **k: True)
+    monkeypatch.setattr(wander, "_weighted_choice", lambda *a, **k: "boon")
+    cid, _start, dest = city_camp
+    out = server.travel_to(cid, dest, advance_time=True)
+    we = out["wandering_encounter"]
+    assert we["region"] == "Baldur's Gate", f"payload region leaked the composite: {we['region']!r}"
+
+
+def test_city_roll_wandering_encounter_keeps_display_region(city_camp, monkeypatch):
+    """The explicit roll_wandering_encounter tool: civilized pool + display region."""
+    monkeypatch.setattr(wander, "_weighted_choice", lambda *a, **k: "boon")
+    cid, _start, _dest = city_camp
+    out = server.roll_wandering_encounter(cid)
+    assert out["staged"] is True
+    assert out["region"] == "Baldur's Gate", f"explicit-roll region is {out['region']!r}"
+
+
+def _start_of(c, dest):
+    """The non-dest location id (the start) — helper for the multi-leg reset."""
+    for lid in c.locations:
+        if lid != dest:
+            return lid
+    return c.current_location_id

--- a/servers/engine/wander.py
+++ b/servers/engine/wander.py
@@ -51,9 +51,32 @@ REGION_RATES: dict[str, float] = {
     "dread": 0.55,
     "deathly": 0.55,
     "underdark": 0.55,
-    # tame / civilized — patrolled, low risk
+    # urban UNDERGROUND (F04-1) — sewers / the Undercity. These are city-adjacent but
+    # genuinely dangerous, NOT tame, so they sit in the danger band. They MUST precede
+    # "city" below: "undercity" contains the substring "city", so without this ordering
+    # an authored "The Undercity" region would mis-resolve to the tame civilized tier.
+    "undercity": 0.45,
+    "sewer": 0.42,
+    # tame / civilized — patrolled, low risk. URBAN keywords (F04-1) join the original
+    # town/city set so a market/tavern/harbor/temple/quarter scene reads as a city
+    # street, not a wilderness trail: a Baldur's Gate area ships region="Baldur's Gate"
+    # with these tags joined into its notes, and the staging seam matches off the
+    # composite "<region> <name> <notes>".
     "town": 0.08,
     "city": 0.08,
+    "market": 0.08,
+    "tavern": 0.07,
+    "harbor": 0.10,
+    "harbour": 0.10,
+    "dock": 0.10,
+    "port": 0.10,
+    "wharf": 0.10,
+    "slum": 0.12,
+    "warren": 0.12,
+    "quarter": 0.08,
+    "district": 0.08,
+    "temple": 0.10,
+    "palace": 0.08,
     "village": 0.10,
     "keep": 0.10,
     "road": 0.15,
@@ -92,7 +115,19 @@ _REGION_TIER: dict[str, str] = {
     "shadow": "undead", "blight": "undead", "dread": "undead",
     "deathly": "undead", "dungeon": "undead",
     "underdark": "underdark",
+    # urban UNDERGROUND (F04-1) — sewers / the Undercity read as the urban-underground
+    # "underdark" creature tier (kobolds/giant spiders/ghouls/ogres — vermin & lurkers),
+    # NOT civilized. MUST precede "city" (the substring hazard — "undercity" ⊃ "city").
+    "undercity": "underdark", "sewer": "underdark",
+    # tame / civilized — patrolled streets. The urban keywords (F04-1) draw from the
+    # civilized pool (Bandit/Guard/Scout/Tough/Cultist/Bandit Captain) — a city threat
+    # is a cutpurse or a patrol, never a wolf pack.
     "town": "civilized", "city": "civilized", "village": "civilized",
+    "market": "civilized", "tavern": "civilized", "harbor": "civilized",
+    "harbour": "civilized", "dock": "civilized", "port": "civilized",
+    "wharf": "civilized", "slum": "civilized", "warren": "civilized",
+    "quarter": "civilized", "district": "civilized", "temple": "civilized",
+    "palace": "civilized",
     "keep": "civilized", "road": "civilized", "safe": "civilized",
     "haven": "civilized", "sanctuary": "civilized",
     "marsh": "swamp", "swamp": "swamp", "bog": "swamp", "river": "swamp",


### PR DESCRIPTION
Closes #822 (F04-1), Closes #823 (F04-2). Source: `docs/audits/ENGINE-AUDIT-2026-06-11.md`.

This is the story-gate wave shape twice over: state the engine TRACKS but no consumer reads correctly. F04-1 = a danger model that matches *no* shipped content; F04-2 = living-world content the engine discloses but the caller discards.

## F04-1 — region danger/creature tables never matched any shipped content (#822)

**Root cause.** The wander resolver (`wander.encounter_chance` / `_region_pool` / `pick_typed_encounter`) only ever saw a location's bare `region` string. Every Baldur's Gate area ships `region="Baldur's Gate"`; the 13 authored regions were seeded with `region=''` (content.py omitted the kwarg). Neither matches any keyword, so a city scene fell through to `BASE_RATE` (0.30) + the **wilderness** creature pool — wolves/ogres/giant-spiders ambushing the party inside the Lower City at ~4x the intended civilized frequency (0.30 vs 0.08). The "this is a city" signal lives in the location **name** + **tags** (joined into `notes`, e.g. `"market city hub"`) — surfaces the matcher never saw.

**Fix (additive, surgical).**
1. The three staging seams (`travel_to`, `long_rest` camp-watch, `roll_wandering_encounter`) build a **composite** match string `"<region> <name> <notes>"` and pass it to the resolver via a new optional `match_region` param on `_stage_wandering_encounter`. The payload's wire `region` key stays `loc.region` — display semantics unchanged. `match_region=None` reproduces today's behavior exactly.
2. `wander.py` gains urban keywords: `market/tavern/harbor/dock/port/wharf/slum/warren/quarter/district/temple/palace` in the civilized band, and `sewer/undercity` in the danger band **before** `city` (substring hazard: "undercity" ⊃ "city"). Pure module; signatures unchanged.
3. `content.py` stamps `region` on authored regions (was `''`), mirroring the ingested-area path.

**Result (census over the real shipped BG world):** 27/27 locations now resolve a non-`BASE_RATE` keyword — city districts → civilized 0.08; undercity/sewers/temple-of-bhaal/foundry-ruins/underdark/avernus → dungeon/undead 0.45–0.50; Sword Coast → coast. The Undercity (whose *name* contains "city") correctly reads non-civilized.

## F04-2 — production soft-tick silently discarded world content (#823)

**Root cause.** `clawdnd_soft_tick` (the every-idle-beat backstop in `play.sh` / `play_party.sh` / `run_duo*`) calls `advance_time(phases=1)` and printed **only** `day`/`time_of_day`, discarding the `world_beats` / `world_developments` / `expired_effects` the engine discloses in its return. A thread beat that fired "while the party slept" was lost to the run log before the DM ever saw it. Per the audit this is an **invariant-4 breach on the CALLER** — the engine's `advance_time` already returns everything (verified: server.py:8542-8550).

**Fix (zero engine change).** `clawdnd_soft_tick` persists those lines to a state-dir-scoped carry-forward file as a "While time passed:" block; `clawdnd_runbook_for_beat` (the ONE shared helper every opener + duo path routes through) read-and-clears it and **prepends** it to the next beat's runbook — so the DM is told, exactly once. A quiet tick writes nothing (no token cost on a still world). Fixed in the shared helper so both opener paths *and* the duo QA runners get it.

## Tests
- **engine:** `tests/test_wander.py` (+15 urban-keyword/composite/ordering/substring cases), `tests/test_wander_region_match.py` (**new** — authored-region seed, ≥90% BG coverage, city→civilized via composite, undercity/sewers→non-civilized, city travel-leg never stages a wilderness creature, payload keeps display region). **55 pass.**
- **harness:** `qa/tests/test_softtick_carryforward.sh` (**new** — real engine + real helpers: fired beat lands in the carry file, next runbook surfaces it, read-and-cleared exactly once, no-op tick stays silent). **11 assertions pass.**
- Full engine suite **2103 passed**; `qa/fast_gate.sh` Tier-0 **188 passed**.

## Invariants
- Engine stays sole writer (F04-2 is caller-side carry-file I/O only; no engine state change). `match_region` is additive with a default that reproduces today's behavior. Old snapshots round-trip (`Location.region` field pre-existed, defaulted `''`; the seed change only affects fresh seeds; the seam composite reads name+notes regardless, so even old saves benefit). Token-mass: the carry block is emitted only when the engine actually fired content, and the wander composite costs nothing at the surface (it never enters scene_context).

DO NOT MERGE — awaiting review.