### PR TITLE
fix(engine): wire quest-evolution seam + fire scheduled consequences + throttle manual events (F05-1, F14-4, SYN-04)

### DIFF
--- a/content/worlds/baldurs-gate/world.json
+++ b/content/worlds/baldurs-gate/world.json
@@ -89,7 +89,8 @@
   "events": [
     {
       "id": "event-raphael-bargain",
-      "trigger": "manual",
+      "trigger": "day_reached",
+      "trigger_threshold": 4,
       "anchor_npc_id": "npc-raphael",
       "prompt": "A door you did not open is suddenly ajar, and the room beyond it is warmer than the Gate's winter has any right to be. Raphael is already seated, one boot crossed over a knee, a decanter of something that smells of cinnamon and cinders breathing on the table between you. 'I do hope you'll forgive the intrusion,' the cambion says, and means it, and smiles. 'But you have a problem, and I — improbably, I admit — happen to be the solution. There is coin here. Real coin, the kind that makes a hard month soft. All I ask in return is a small kindness, owed and unspecified, to be named at my leisure. No menace, friend. Only an arrangement between reasonable people. The wine is excellent, and the offer will not embarrass you. Shall we?'",
       "options": [
@@ -118,7 +119,8 @@
     },
     {
       "id": "event-fist-checkpoint",
-      "trigger": "manual",
+      "trigger": "day_reached",
+      "trigger_threshold": 2,
       "anchor_npc_id": "npc-wyll",
       "prompt": "The checkpoint on the bridge wasn't here yesterday — a few sawhorses, a brazier, and four Flaming Fist in mismatched armour who look like they've slept in it. The sergeant working the line is young and grey-faced with exhaustion, and the wagon he's stopped is packed with shivering Lower City families fleeing a tenement fire. 'Toll's gone up,' he says, not meeting their eyes, and the number he names is robbery dressed as policy — coin these people plainly do not have. One of his own troopers has gone very still, watching him; this isn't sanctioned, and everyone on the bridge knows it. The sergeant's gaze flicks to you, the obvious outsider with the look of someone who carries weight. 'You vouching for this lot? Or paying their way? Either works. I just need the line moving and my palm warm before the captain rides through.'",
       "options": [
@@ -159,7 +161,8 @@
     },
     {
       "id": "event-guild-offer",
-      "trigger": "manual",
+      "trigger": "day_reached",
+      "trigger_threshold": 5,
       "anchor_npc_id": "npc-astarion",
       "prompt": "You don't find the Guild; the Guild finds you, the way it finds everyone eventually. A woman with a fixer's easy smile slides onto the bench across from you in the Elfsong's quietest corner — too well-dressed for the dockside, too plainly armed for the Upper City — and sets a sealed packet on the wood between you without a word of greeting. 'Nine-Fingers sends her regards,' she says, 'and a small kindness, freely given, to a newcomer who keeps interesting company.' Inside: enough coin to matter, and a name and an address. 'There's a man at that address who's been talking to the Fist about people he shouldn't. We don't want him hurt — gods, no, the Guild doesn't do murders, that's the Bhaalists. We just want his ledgers gone before he hands them over. Quiet work. Profitable. And the Guild remembers a favour the way a creditor remembers a debt — fondly, and forever. First one's on the house. Interested?'",
       "options": [
@@ -200,7 +203,8 @@
     },
     {
       "id": "event-refugee-crisis",
-      "trigger": "manual",
+      "trigger": "day_reached",
+      "trigger_threshold": 3,
       "anchor_npc_id": "npc-jaheira",
       "prompt": "It starts as shouting and ends, the way these things do, with you in the middle of it. A knot of tiefling refugees — gaunt, road-worn, a clutch of children among them — has been stopped at the edge of Rivington by a patriar's hired men and a clerk waving a writ: the empty lot where the refugees have been sheltering through the winter has been 'lawfully claimed,' and they're to be cleared out tonight, into the cold, writ or no writ. The refugees' spokeswoman, a horned woman with a healer's worn hands and a voice gone hoarse from pleading, turns to you because you're the only one watching who doesn't look bought. 'They'll die out there — the little ones first. We're not asking for charity. We're asking for one night, and someone who'll stand in the doorway long enough for the cold to break.' The hired men are already loosening their cudgels. The clerk looks like he'd take a bribe or a threat with equal relief, just to be elsewhere.",
       "options": [
@@ -245,7 +249,8 @@
     },
     {
       "id": "event-patriar-bargain",
-      "trigger": "manual",
+      "trigger": "day_reached",
+      "trigger_threshold": 6,
       "anchor_npc_id": "npc-the-emperor",
       "prompt": "The invitation came on cream-coloured paper and the wine, when you arrive, is older than your grandparents. The patriar receiving you behind the Basilisk Gate is all warmth and worry — a soft, ringed man whose family name opens doors and whose hands, he wants you to understand, are entirely clean. 'A delicate matter,' he says, 'and you come recommended as discreet.' A rival house has a document; the document concerns a debt his family owes to the Black Network — the Zhentarim — a debt he'd rather the Council never see as the dukedom vote approaches. He wants the document, and he wants the rival to understand it was taken, and he is prepared to be 'lavishly grateful.' 'You'd be doing the Gate a service, truly — that family are vipers, and I am, whatever my creditors, a patriot.' Behind the worry, his eyes are flat and measuring. This is not a man asking for help. This is a man buying a tool, and pricing you.",
       "options": [

--- a/content/worlds/tidal-commonwealth/world.json
+++ b/content/worlds/tidal-commonwealth/world.json
@@ -149,7 +149,8 @@
   "events": [
     {
       "id": "event-league-cache",
-      "trigger": "manual",
+      "trigger": "day_reached",
+      "trigger_threshold": 2,
       "anchor_npc_id": "npc-captain-drev",
       "prompt": "The salvage rig COLD LAMP was supposed to run a routine outer-shallows survey. It came back three days late, two crew short, and with its cargo hold locked from the inside. Captain Drev Ossian intercepts you at the Ironhull docks before the League inspectors arrive: the crew found something at the rim that isn't in any of the Basin charts, something the League factors will auction to the highest bidder the moment they see it — and two cities are already watching the dock. 'I need it in different hands before the inspectors open that hold,' he says. He does not specify what different hands means, or what COLD LAMP found.",
       "options": [
@@ -191,7 +192,8 @@
     },
     {
       "id": "event-warden-summons",
-      "trigger": "manual",
+      "trigger": "day_reached",
+      "trigger_threshold": 4,
       "anchor_npc_id": "npc-warden-estris",
       "prompt": "A letter arrives sealed with the Compact Council's administrative mark — not the official seal, which would require a formal summons and a logged record, but the Secretary-Warden's private mark, which means whoever sent it did not want a record of the sending. The note inside is three sentences: the date, a location in Ironhull Station's lower records room, and the words 'I am aware that the Compact has no authority to ask you to attend. I am asking anyway. —E.V.' The location is accessible at the time given, the Compact's official business is scheduled elsewhere, and whatever the Secretary-Warden wants, she has been careful to make it deniable.",
       "options": [

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -405,6 +405,13 @@ class Event(_StrictModel):
     options: list["ParleyOption"] = Field(default_factory=list)  # the tagged choices; freeform is ALWAYS also allowed (#141)
     anchor_npc_id: str = ""  # optional canon-NPC binding (the owner's priority — bind to a roster NPC)
     resolved: bool = False  # idempotency: a fired Event never re-presents or re-applies
+    # SYN-04 (F07-3): the in-world day this Event was FIRST surfaced to the DM via the
+    # every-beat scene_context bundle. ADDITIVE — None == never presented (old snapshots
+    # round-trip). Once stamped, scene_context returns the event as a COMPACT STUB instead
+    # of re-sending its full ~1KB prose every beat (the standalone present_events tool is
+    # unaffected and still returns the full payload). Stamped under campaign_lock (engine =
+    # sole writer), mirroring check_companion_arc's arc-progress write on the same path.
+    first_presented_day: Optional[int] = None
 
 
 class CompanionDossier(_StrictModel):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -8281,14 +8281,28 @@ def _maybe_schedule_quest_evolution(c: Campaign, q: Quest) -> Optional[Consequen
 
 
 @mcp.tool()
-def complete_quest(campaign_id: str, quest_id: str, status: str = "completed") -> dict:
+def complete_quest(
+    campaign_id: str,
+    quest_id: str,
+    status: str = "completed",
+    evolves_to: str = "",
+    callback_in_days: int = 0,
+) -> dict:
     """Resolve a quest. status: completed | failed | active.
 
-    Rule-of-three evolution (Quest & Arc engine, Layer 1): if the quest resolves
-    (status -> completed) and carries an ``evolves_to`` follow-on, the engine
-    schedules a Consequence so the thread echoes later (surfaced via
-    check_consequences). Additive + idempotent: empty ``evolves_to`` == today's
-    behavior; re-resolving never double-schedules."""
+    Rule-of-three evolution (Quest & Arc engine, Layer 1): close a won thread with an
+    ECHO so a session becomes a saga. Pass ``evolves_to`` (a follow-on hook/quest id or
+    a free seed tag the DM weaves on callback) and optionally ``callback_in_days`` (the
+    in-world days before it returns; 0 = due immediately) — when the quest resolves
+    (status -> completed) the engine schedules a Consequence that surfaces later via
+    ``check_consequences`` / ``scene_context``. The grateful family becomes a feud, the
+    spared villain returns. You may instead pre-set ``evolves_to`` on the quest (content/
+    questgen) and call this without the kwarg — a field already on the quest is honored.
+
+    Additive + idempotent: omit ``evolves_to`` (and leave the field empty) == today's
+    behavior, byte-for-byte; passing an empty ``evolves_to`` never clobbers a field the
+    quest already carries; re-resolving never double-schedules (the ``evolves_from:<id>``
+    note guards it)."""
     if status not in ("completed", "failed", "active"):
         raise ValueError("status must be completed | failed | active")
     with campaign_lock(campaign_id):
@@ -8297,6 +8311,14 @@ def complete_quest(campaign_id: str, quest_id: str, status: str = "completed") -
         if q is None:
             raise ValueError(f"no quest {quest_id!r}")
         q.status = status  # type: ignore[assignment]
+        # F05-1: make the skill-documented evolution seam reachable. Set the rule-of-three
+        # fields from the kwargs ONLY when explicitly provided, so an empty kwarg never
+        # clobbers a field content/questgen already authored on the quest. Assigned under
+        # the lock BEFORE _maybe_schedule_quest_evolution reads them (engine = sole writer).
+        if evolves_to.strip():
+            q.evolves_to = evolves_to.strip()
+        if callback_in_days:
+            q.callback_in_days = max(0, int(callback_in_days))
         evolution = _maybe_schedule_quest_evolution(c, q)
         # A completed quest is an unambiguous "real win" — auto-award milestone XP in
         # xp-mode (deterministic, no LLM judgment) so progression isn't a manual chore the
@@ -9572,6 +9594,99 @@ def _scene_recent_narration(c: Campaign, limit: int) -> list[dict]:
     ]
 
 
+def _scene_fire_due_consequences(campaign_id: str) -> list[dict]:
+    """F14-4: fire (and surface) the authored Consequences that have come due as of the
+    current day, ON the every-beat scene_context path. Source: ENGINE-AUDIT-2026-06-11
+    (F14-4) — add_consequence was write-only; nothing on the beat loop called
+    ``consequences.due()``, so scheduled world-beats structurally never fired. This is the
+    READ the WRITE was missing.
+
+    Acquires the campaign_lock, fires the due consequences (``consequences.due`` marks each
+    fired so it never re-tells on a later beat — idempotent — and SKIPS worldsim thread
+    beats, which belong to ``world_tick``), then saves ONLY when something fired (no
+    churn on the common no-op beat). Mirrors check_consequences' return shape so the DM
+    sees the same fields it would from the standalone tool."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        fired = consequences_mod.due(c)
+        if fired:  # save only on an actual state change (avoid an updated_at bump per beat)
+            save_campaign(c)
+        return [
+            {"id": x.id, "text": x.text, "note": x.note, "trigger_day": x.trigger_day}
+            for x in fired
+        ]
+
+
+# SYN-04: how many full manual-prose events scene_context surfaces per beat (the read
+# valve). The audit measured 5 full BG event prompts (~6.5KB ≈ 1.6K tok) riding EVERY
+# beat; surfacing at most one keeps the bundle lean while the rest rotate / wait.
+_SCENE_EVENTS_FULL_PER_BEAT = 1
+# A presented-event stub's prompt head length (enough to recognise the thread, not the
+# full ~1KB prose).
+_EVENT_STUB_HEAD_CHARS = 60
+
+
+def _event_full_projection(ev: Event) -> dict:
+    """The FULL event projection (same shape present_events surfaces)."""
+    return {
+        "id": ev.id,
+        "prompt": ev.prompt,
+        "trigger": ev.trigger,
+        "anchor_npc_id": ev.anchor_npc_id,
+        "options": [
+            {"label": opt.label, "tag": opt.tag, "skill": opt.skill, "dc": opt.dc}
+            for opt in ev.options
+        ],
+    }
+
+
+def _event_stub_projection(ev: Event) -> dict:
+    """A COMPACT stub for an already-presented event — enough to keep the thread in the
+    DM's view (recognise it, re-offer its options) WITHOUT re-sending the full prose every
+    beat. Source: SYN-04 leg (c)."""
+    head = (ev.prompt or "")[:_EVENT_STUB_HEAD_CHARS]
+    return {
+        "id": ev.id,
+        "prompt_head": head,
+        "option_labels": [opt.label for opt in ev.options],
+        "note": "already presented — resolve_event by id when the player picks",
+    }
+
+
+def _scene_events_throttled(campaign_id: str) -> dict:
+    """SYN-04: the scene_context EVENTS block — surfaces at most ``_SCENE_EVENTS_FULL_PER_BEAT``
+    NOT-YET-PRESENTED event(s) in full, stamps each ``first_presented_day`` under the
+    campaign_lock (engine = sole writer), renders already-presented live events as compact
+    STUBS, and reports the remaining unpresented count as ``manual_queued`` (they rotate in
+    on later beats). Source: ENGINE-AUDIT-2026-06-11 (SYN-04 / F05-3 + F07-3).
+
+    The standalone ``present_events`` tool is UNCHANGED (full payload, read-only) — only this
+    every-beat bundle throttles. Queued / stubbed events stay resolvable: ``resolve_event``
+    looks them up by id directly from ``c.events``."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        live = events_mod.present(c)  # unresolved + trigger holds, id-ordered
+        fresh = [ev for ev in live if ev.first_presented_day is None]
+        already = [ev for ev in live if ev.first_presented_day is not None]
+
+        surfaced = fresh[:_SCENE_EVENTS_FULL_PER_BEAT]
+        queued = fresh[_SCENE_EVENTS_FULL_PER_BEAT:]
+
+        stamped = False
+        for ev in surfaced:
+            ev.first_presented_day = c.day  # stamp: presented this beat
+            stamped = True
+        if stamped:  # save only when we actually stamped (no per-beat churn otherwise)
+            save_campaign(c)
+
+        return {
+            "events": [_event_full_projection(ev) for ev in surfaced],
+            "presented": [_event_stub_projection(ev) for ev in already],
+            "manual_queued": len(queued),
+            "free_form": True,  # #141: the player may ALWAYS act outside the menu
+        }
+
+
 @mcp.tool()
 def scene_context(
     campaign_id: str,
@@ -9598,8 +9713,18 @@ def scene_context(
                         ``flags``. Always present; empty collections == today.
       - ``director``  — get_campaign_director(campaign_id): the top structural
                         debts the campaign OWES right now (advisory, read-only).
-      - ``events``    — present_events(campaign_id): stumble-into decisionals whose
-                        contract-safe trigger has fired this beat (READ-ONLY).
+      - ``events``    — the THROTTLED stumble-into decisionals (SYN-04): at most ONE
+                        not-yet-presented Event surfaces in FULL per beat (``events``);
+                        the engine stamps its ``first_presented_day`` so a later beat
+                        renders it as a compact STUB (``presented``) instead of re-sending
+                        its full ~1KB prose every turn; the rest queue as ``manual_queued``
+                        (a count, rotating in over later beats). Resolve any of them by id
+                        via ``resolve_event``. The standalone ``present_events`` tool still
+                        returns the FULL, read-only payload when you want every option.
+      - ``consequences_due`` — the authored Consequences that come DUE this beat, FIRED
+                        (and surfaced) here so the deferred world actually moves (F14-4).
+                        Always present; ``[]`` when nothing is due. Idempotent: each fires
+                        exactly once (worldsim thread-beats are left for ``world_tick``).
       - ``companion_arcs`` — check_companion_arc(campaign_id): bonds that just
                         turned / a ``betrayal_warning`` to foreshadow. (This is the
                         one sub-call that persists arc progress — same effect as
@@ -9622,13 +9747,18 @@ def scene_context(
                         active quests, combat status, pacing_mode, seed_params.
                         LAST because it carries the volatile values (clock, HP).
 
-    Read-mostly: it runs the SAME code paths as the individual tools (so behavior
-    and side effects are identical — including check_companion_arc's arc-progress
-    save), just bundled. ``durable`` + ``recent_narration`` are pure READS/derivations
-    over committed state — scene_context NEVER writes campaign state itself. Use this
-    every beat in place of the separate get_state / get_campaign_director /
-    present_events / check_companion_arc calls. For a returning NPC you still want
-    recall_npc(npc_id) / get_scene on arrival — those stay their own calls.
+    Read-MOSTLY: ``durable`` / ``recent_narration`` / ``recall`` / ``state`` are pure
+    reads/derivations. Three sub-paths persist engine-mutated progress under the
+    campaign_lock — the same shape check_companion_arc has always had on this bundle:
+    ``companion_arcs`` saves arc progress, ``events`` stamps each surfaced Event's
+    ``first_presented_day`` (so it stops re-riding every beat, SYN-04), and
+    ``consequences_due`` marks fired the consequences it surfaces (so the deferred world
+    actually moves AND never re-fires, F14-4). Each save is guarded — it happens only when
+    that sub-path actually changed state, so a beat with nothing to fire/stamp writes only
+    what check_companion_arc already wrote. Use this every beat in place of the separate
+    get_state / get_campaign_director / present_events / check_companion_arc /
+    check_consequences calls. For a returning NPC you still want recall_npc(npc_id) /
+    get_scene on arrival — those stay their own calls.
     """
     # Each delegate takes (and fully releases) the per-campaign flock before the
     # next runs — sequential, never nested — so this is deadlock-free even though
@@ -9641,7 +9771,14 @@ def scene_context(
     out: dict = {
         "durable": _scene_durable_threads(_require(campaign_id)),
         "director": get_campaign_director(campaign_id),
-        "events": present_events(campaign_id),
+        # SYN-04: the THROTTLED events view (<=1 full event/beat + first_presented_day
+        # stamping + stubs + manual_queued) instead of present_events' full every-beat
+        # dump. The standalone present_events tool is unchanged.
+        "events": _scene_events_throttled(campaign_id),
+        # F14-4: fire (and surface) the authored consequences that come due this beat —
+        # the every-beat READ that add_consequence's WRITE was missing. Always present
+        # (empty list when nothing is due) so the DM can rely on the key.
+        "consequences_due": _scene_fire_due_consequences(campaign_id),
         "companion_arcs": check_companion_arc(campaign_id),
     }
     if recent_narration and recent_narration > 0:

--- a/servers/engine/tests/test_beat_roundtrip.py
+++ b/servers/engine/tests/test_beat_roundtrip.py
@@ -33,14 +33,21 @@ def test_scene_context_bundles_the_beat_reads(cid):
     present_events + check_companion_arc + get_state, and each delegated section
     equals the individual tool's output (the additions never regress the bundle)."""
     sc = server.scene_context(cid)
-    assert set(sc) == {"durable", "director", "events", "companion_arcs", "state"}
+    # consequences_due (F14-4) is always present; events is the throttled view (SYN-04).
+    assert set(sc) == {
+        "durable", "director", "events", "companion_arcs", "consequences_due", "state"
+    }
     # Each DELEGATED section is byte-equal to calling the tool directly (state can
     # carry no time-varying fields here, so a direct compare is safe).
     assert sc["state"] == server.get_state(cid)
     assert sc["director"] == server.get_campaign_director(cid)
-    assert sc["events"] == server.present_events(cid)
     # companion_arc is idempotent across beats, so a second call matches too.
     assert sc["companion_arcs"] == server.check_companion_arc(cid)
+    # The throttled events view (SYN-04): empty fixture -> no events surfaced/stubbed.
+    assert sc["events"] == {
+        "events": [], "presented": [], "manual_queued": 0, "free_form": True
+    }
+    assert sc["consequences_due"] == []  # nothing scheduled in the fixture
 
 
 def test_scene_context_is_durable_first_then_volatile_state(cid):
@@ -275,6 +282,63 @@ def test_scene_context_does_not_deadlock(cid):
     it did, this call would hang. Reaching the assert proves it returns."""
     sc = server.scene_context(cid, recall_query="taproom")
     assert sc["state"]["id"] == cid
+
+
+# ── F14-4: scene_context fires due consequences each beat ────────────────────
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F14-4). add_consequence was
+# write-only — nothing on the every-beat path called consequences.due(), so 18
+# writes fired 0 times. scene_context now fires (and surfaces) them under lock.
+
+
+def test_scene_context_fires_due_consequences(cid):
+    """A consequence scheduled for today surfaces in scene_context['consequences_due']
+    AND is marked fired (engine rolls, the DM is told). Source: F14-4."""
+    server.add_consequence(cid, 0, "The siege engines arrive at the gate.")
+    sc = server.scene_context(cid)
+    assert "consequences_due" in sc
+    texts = [d["text"] for d in sc["consequences_due"]]
+    assert "The siege engines arrive at the gate." in texts
+    # marked fired in persisted state (idempotent — won't re-fire next beat)
+    c = store.load_campaign(cid)
+    assert all(con.fired for con in c.consequences)
+
+
+def test_scene_context_consequences_fire_once_then_stop(cid):
+    """Idempotent: a consequence fires on the beat it comes due and NOT on later beats
+    (the DM isn't re-told the same world-beat every turn). Source: F14-4."""
+    server.add_consequence(cid, 0, "A spared villain returns.")
+    first = server.scene_context(cid)
+    assert any(d["text"] == "A spared villain returns." for d in first["consequences_due"])
+    second = server.scene_context(cid)
+    assert second["consequences_due"] == []  # already fired -> empty, not re-told
+
+
+def test_scene_context_consequences_due_empty_when_none_due(cid):
+    """A not-yet-due consequence does NOT fire and the key is present-but-empty (so the
+    DM can rely on it). Source: F14-4."""
+    server.add_consequence(cid, 5, "Reinforcements arrive next week.")
+    sc = server.scene_context(cid)
+    assert sc["consequences_due"] == []
+    c = store.load_campaign(cid)
+    assert not any(con.fired for con in c.consequences)  # untouched
+
+
+def test_scene_context_does_not_fire_worldsim_thread_beats(cid):
+    """Consequences carrying a thread_id belong to worldsim (world_tick), NOT the
+    authored-consequence lane — scene_context must not consume them. Source: F14-4
+    (mirrors consequences.due's thread_id skip)."""
+    with store.campaign_lock(cid):
+        c = store.load_campaign(cid)
+        from models import Consequence
+        c.consequences.append(
+            Consequence(trigger_day=c.day, text="A background thread ticks.",
+                        thread_id="thread-x")
+        )
+        store.save_campaign(c)
+    sc = server.scene_context(cid)
+    assert sc["consequences_due"] == []  # worldsim beat left for world_tick
+    c = store.load_campaign(cid)
+    assert not c.consequences[0].fired  # not consumed
 
 
 # ── persist_beat: the end-of-beat write cluster in one call ──────────────────

--- a/servers/engine/tests/test_content.py
+++ b/servers/engine/tests/test_content.py
@@ -22,6 +22,33 @@ SYNTH = {
 }
 
 
+# ── SYN-04 content lint: no world over-uses the always-on 'manual' event trigger ──
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (SYN-04 / F05-3). A 'manual' trigger
+# is ALWAYS available until resolved; a world authored with many manual events rides
+# their full prose into every beat's bundle (~6.5KB at BG's 5 events). Authored events
+# should carry real triggers (day_reached / reputation_at / flag_set); at most one
+# manual per world is allowed (a deliberate cold-open drop). This lint red-guards the
+# regression at the content seam.
+
+
+def test_shipped_worlds_do_not_overuse_manual_event_trigger():
+    for w in content.list_worlds():
+        data = content.load_world_data(w["id"])
+        events = data.get("events") or []
+        if isinstance(events, dict):
+            events = list(events.values())
+        manual = [
+            e for e in events
+            if isinstance(e, dict) and (e.get("trigger") or "manual") == "manual"
+        ]
+        assert len(manual) <= 1, (
+            f"world {w['id']!r} has {len(manual)} 'manual' events "
+            f"({[e.get('id') for e in manual]}); authored events should use real "
+            f"triggers (day_reached/reputation_at/flag_set) so they don't ride every "
+            f"beat's bundle as full prose (SYN-04). At most 1 manual per world."
+        )
+
+
 def test_seed_campaign_synthetic():
     c = content.seed_campaign(SYNTH)
     assert isinstance(c, Campaign)

--- a/servers/engine/tests/test_dashboard.py
+++ b/servers/engine/tests/test_dashboard.py
@@ -122,6 +122,59 @@ def test_re_resolving_quest_does_not_double_schedule(cid):
     assert len(evo) == 1 and evo[0].id == first_conseq_id  # still exactly one
 
 
+# ── F05-1: the evolution tool seam (complete_quest sets evolves_to directly) ──
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F05-1). Before this fix the ONLY
+# way to set evolves_to/callback_in_days was direct model mutation (see _set_evolution
+# above) — the skill-documented call complete_quest(..., evolves_to=, callback_in_days=)
+# TypeError'd, so the saga mechanism was dead in 100% of real campaigns.
+
+
+def test_complete_quest_evolves_to_kwarg_schedules_evolution(cid):
+    """The skill-documented call shape works: passing evolves_to + callback_in_days
+    on complete_quest sets the fields AND schedules the rule-of-three follow-on in ONE
+    call (no separate update). Source: F05-1."""
+    qid = server.add_quest(cid, "Recover the Sunblade")["id"]
+    before = store.load_campaign(cid)
+    start_day = before.day
+    assert before.consequences == []
+
+    out = server.complete_quest(
+        cid, qid, "completed",
+        evolves_to="hook_shadow_returns", callback_in_days=3,
+    )
+    assert out["status"] == "completed"
+    assert out["evolution_scheduled"]["evolves_to"] == "hook_shadow_returns"
+    assert out["evolution_scheduled"]["trigger_day"] == start_day + 3
+
+    c = store.load_campaign(cid)
+    q = c.quests[qid]
+    # the fields are persisted on the quest (the seam that was unreachable)
+    assert q.evolves_to == "hook_shadow_returns" and q.callback_in_days == 3
+    evo = [con for con in c.consequences if con.note == f"evolves_from:{qid}"]
+    assert len(evo) == 1 and evo[0].trigger_day == start_day + 3
+    assert "hook_shadow_returns" in evo[0].text and "Recover the Sunblade" in evo[0].text
+
+
+def test_complete_quest_without_evolves_to_kwarg_is_unchanged(cid):
+    """ADDITIVE: omitting evolves_to is byte-identical to today — no fields set, nothing
+    scheduled. Source: F05-1 (defaults preserve today's behavior)."""
+    qid = server.add_quest(cid, "Plain Errand")["id"]
+    out = server.complete_quest(cid, qid, "completed")
+    assert "evolution_scheduled" not in out
+    c = store.load_campaign(cid)
+    assert c.quests[qid].evolves_to == "" and c.consequences == []
+
+
+def test_complete_quest_evolves_to_kwarg_does_not_clobber_preset_field(cid):
+    """If the quest ALREADY carries an evolves_to (content/questgen authored it) and the
+    DM calls complete_quest WITHOUT the kwarg, the preset field is preserved and still
+    schedules. The kwarg only sets when explicitly provided. Source: F05-1."""
+    qid = server.add_quest(cid, "Ancient Pact")["id"]
+    _set_evolution(cid, qid, evolves_to="seed_preauthored", callback_in_days=1)
+    out = server.complete_quest(cid, qid, "completed")  # no kwarg
+    assert out["evolution_scheduled"]["evolves_to"] == "seed_preauthored"
+
+
 def test_dashboard_rollup_resolves_links(cid):
     server.create_character(cid, "Hero", kind="player", max_hp=10)
     server.add_quest(cid, "Find the drain", giver_id="brakka", location_id="loc-sump")

--- a/servers/engine/tests/test_event_parley_layer3.py
+++ b/servers/engine/tests/test_event_parley_layer3.py
@@ -98,6 +98,22 @@ def test_event_models_default_shapes():
     ev = Event(prompt="p")
     assert ev.trigger == "manual" and ev.resolved is False and ev.options == []
     assert ev.id.startswith("event_")
+    # SYN-04 (F07-3): first_presented_day defaults to None (never presented yet) — additive.
+    assert ev.first_presented_day is None
+
+
+def test_event_first_presented_day_additive_round_trip():
+    """SYN-04: an old Event snapshot without first_presented_day loads with None and
+    round-trips. Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (SYN-04 / F07-3)."""
+    ev = _event(eid="event_fp")
+    data = ev.model_dump(mode="json")
+    old = {k: v for k, v in data.items() if k != "first_presented_day"}
+    assert "first_presented_day" not in old
+    reloaded = Event.model_validate(old)
+    assert reloaded.first_presented_day is None
+    # a stamped value round-trips too
+    ev.first_presented_day = 7
+    assert Event.model_validate(ev.model_dump(mode="json")).first_presented_day == 7
 
 
 def test_event_round_trips_with_full_outcome():
@@ -680,12 +696,17 @@ def _seed_bg(ending: str = "") -> Campaign:
 
 def test_bg_raphael_event_seeds_and_surfaces():
     """The authored Raphael bribe Event loads from the base world and surfaces via present
-    (manual trigger), bound to the canon anchor NPC, with the bribe option carrying the
-    took_bribe decision_flag + the negative Flaming-Fist ripple + the rule-of-three echo."""
+    once its day_reached trigger arms (SYN-04: not at minute one), bound to the canon
+    anchor NPC, with the bribe option carrying the took_bribe decision_flag + the negative
+    Flaming-Fist ripple + the rule-of-three echo."""
     c = _seed_bg()
     assert RAPHAEL_EVENT in c.events, "the authored Raphael Event must seed from world.json"
     ev = c.events[RAPHAEL_EVENT]
     assert ev.prompt.strip(), "the Event must carry a prompt the DM voices"
+    # SYN-04: a day_reached trigger so the devil's bargain doesn't open the campaign cold.
+    assert ev.trigger == "day_reached" and ev.trigger_threshold >= 1
+    assert not any(e.id == RAPHAEL_EVENT for e in events_mod.present(c)), \
+        "must NOT surface on day 1 (the trigger hasn't armed) — SYN-04 fix"
     # bound to a canon roster NPC (the owner's anchoring priority) — Raphael is in the roster
     assert ev.anchor_npc_id == "npc-raphael"
     assert c.characters.get("npc-raphael") is not None, "anchor NPC must exist in the roster"
@@ -697,7 +718,8 @@ def test_bg_raphael_event_seeds_and_surfaces():
     assert bribe.outcome.schedule_in_days > 0 and bribe.outcome.schedule_text.strip()  # L1 echo
     # a refuse path exists (a choice the player can decline cleanly)
     assert events_mod.find_option(ev, "Refuse him") is not None
-    # surfaces NOW (manual trigger, unresolved)
+    # surfaces once the in-world day reaches the trigger (still unresolved)
+    c.day = ev.trigger_threshold
     assert any(e.id == RAPHAEL_EVENT for e in events_mod.present(c))
 
 
@@ -789,20 +811,28 @@ BG_FILL_EVENTS = {
 
 def test_bg_fill_events_seed_and_surface():
     """All four authored fill Events load from the base world, bind to a canon roster anchor NPC,
-    surface via present (manual trigger), and each offers a clean decline/walk-away path."""
+    surface via present once their day_reached trigger arms (SYN-04: staggered, not all at
+    minute one), and each offers a clean decline/walk-away path."""
     c = _seed_bg()
+    # SYN-04: none ride beat 1 — they carry real (day_reached) triggers, not 'manual'.
+    day1_ids = {e.id for e in events_mod.present(c)}
+    for eid in BG_FILL_EVENTS:
+        assert eid not in day1_ids, f"{eid} must NOT surface on day 1 (SYN-04 fix)"
+    # advance the clock past the latest trigger so all four are now available.
+    c.day = max(c.events[eid].trigger_threshold for eid in BG_FILL_EVENTS)
     present_ids = {e.id for e in events_mod.present(c)}
     for eid, (fac_id, _flag) in BG_FILL_EVENTS.items():
         assert eid in c.events, f"the authored fill Event {eid!r} must seed from world.json"
         ev = c.events[eid]
         assert ev.prompt.strip(), f"{eid} must carry a prompt the DM voices"
+        assert ev.trigger == "day_reached", f"{eid} must use a real trigger, not manual (SYN-04)"
         # bound to a canon roster NPC (the owner's anchoring priority)
         assert ev.anchor_npc_id and c.characters.get(ev.anchor_npc_id) is not None, (
             f"{eid} must anchor to a real roster NPC"
         )
         # at least 2 options, and at least one carries the entangling decision_flag the content names
         assert len(ev.options) >= 2
-        assert ev.id in present_ids, f"{eid} (manual trigger, unresolved) must surface via present"
+        assert ev.id in present_ids, f"{eid} (day_reached trigger, unresolved) must surface via present"
         # the touched faction is a real seeded faction (so the rep ripple lands, not degrades)
         assert fac_id in c.factions
 
@@ -912,3 +942,105 @@ def test_bg_fill_astarion_seam_end_to_end():
     # and the advisory telegraph fires so the DM can foreshadow the fracture
     warn = companion_arc._betrayal_warning(astarion, c)
     assert warn is not None and warn["decision_flag_active"] is True
+
+
+# =========================================================================
+# SYN-04 — scene_context throttles manual events to <=1 + stamps
+# first_presented_day so an event presents ONCE then stops re-riding every beat.
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (SYN-04 / F05-3 + F07-3).
+# present_events (standalone) stays the FULL, read-only payload; the throttle +
+# write live in scene_context's events block.
+# =========================================================================
+
+
+def test_present_events_standalone_unchanged_and_full(l3_campaign):
+    """The standalone present_events tool keeps the FULL payload AND stays read-only
+    (the audit's invariant: only scene_context's events block throttles/stamps).
+    Source: SYN-04 leg (b)/(c)."""
+    cid, _pc, _comp = l3_campaign
+    for i in range(3):
+        _inject_event(cid, _event(eid=f"event_full_{i}", trigger="manual",
+                                   prompt=f"Manual event {i} with full prose here."))
+    before = store.load_campaign(cid).model_dump(mode="json")
+    out = server.present_events(cid)
+    after = store.load_campaign(cid).model_dump(mode="json")
+    # all 3 surface, with prompt prose, and NOTHING was written (still read-only)
+    assert len(out["events"]) == 3
+    assert all(e["prompt"] for e in out["events"])
+    assert before == after
+
+
+def test_scene_context_throttles_to_one_manual_event_with_queue(l3_campaign):
+    """scene_context surfaces at most ONE manual event in full + reports the rest as a
+    manual_queued count (the audit's ~6.5KB-every-beat fix). Source: SYN-04 leg (b)."""
+    cid, _pc, _comp = l3_campaign
+    for i in range(3):
+        _inject_event(cid, _event(eid=f"event_q_{i}", trigger="manual",
+                                   prompt=f"Manual decisional {i}."))
+    ev_block = server.scene_context(cid)["events"]
+    # exactly one full event surfaced, the other two are queued (not full prose)
+    assert len(ev_block["events"]) == 1
+    assert ev_block["manual_queued"] == 2
+    assert ev_block["events"][0]["prompt"]  # the surfaced one carries full prose
+
+
+def test_scene_context_stamps_first_presented_day_and_stub_on_repeat(l3_campaign):
+    """An event presented via scene_context is stamped first_presented_day; a LATER
+    scene_context returns it as a compact stub (not full prose), so it stops re-riding
+    every beat at ~1.6K tok. Source: SYN-04 leg (c)."""
+    cid, _pc, _comp = l3_campaign
+    _inject_event(cid, _event(eid="event_once", trigger="manual",
+                              prompt="A long stumble-into prompt that costs tokens every beat."))
+    c = store.load_campaign(cid)
+    day = c.day
+
+    first = server.scene_context(cid)["events"]
+    assert len(first["events"]) == 1
+    # stamped under lock (engine = sole writer; scene_context now writes here)
+    assert store.load_campaign(cid).events["event_once"].first_presented_day == day
+
+    # next beat: already presented -> compact stub, NOT the full prompt prose again
+    second = server.scene_context(cid)["events"]
+    assert second["events"] == []  # not re-surfaced as a fresh full event
+    stubs = second.get("presented", [])
+    assert any(s["id"] == "event_once" for s in stubs)
+    stub = next(s for s in stubs if s["id"] == "event_once")
+    assert "prompt" not in stub or len(stub.get("prompt", "")) < 80  # head only, not full prose
+
+
+def test_scene_context_queued_manual_event_stays_resolvable(l3_campaign):
+    """A manual event throttled OUT of the surfaced slot is still resolvable by id
+    (resolve_event looks it up directly in c.events). Source: SYN-04 leg (b)."""
+    cid, _pc, _comp = l3_campaign
+    _inject_event(cid, _event(eid="event_aaa", trigger="manual", prompt="First."))
+    _inject_event(cid, _event(eid="event_zzz", trigger="manual", options=[
+        ParleyOption(label="Help", outcome=Outcome(faction_id="fac-fist", reputation_delta=5)),
+    ], prompt="Second."))
+    block = server.scene_context(cid)["events"]
+    surfaced_ids = [e["id"] for e in block["events"]]
+    assert "event_aaa" in surfaced_ids and block["manual_queued"] == 1
+    # the QUEUED event (event_zzz) is still resolvable by id
+    res = server.resolve_event(cid, "event_zzz", "Help")
+    assert res["resolved"] is True
+    assert store.load_campaign(cid).factions["fac-fist"].reputation == 5
+
+
+def test_scene_context_triggered_event_surfaces_full_once(l3_campaign):
+    """A non-manual (flag_set) event surfaces FULL exactly once the trigger arms, then
+    becomes a stub. Source: SYN-04 (the content leg moves events off 'manual')."""
+    cid, _pc, _comp = l3_campaign
+    _inject_event(cid, _event(eid="event_flag", trigger="flag_set",
+                              trigger_value="armed", prompt="The flag-gated moment."))
+    # not armed: not surfaced
+    assert server.scene_context(cid)["events"]["events"] == []
+    # arm it
+    with store.campaign_lock(cid):
+        c = store.load_campaign(cid)
+        c.flags["armed"] = True
+        store.save_campaign(c)
+    first = server.scene_context(cid)["events"]
+    assert [e["id"] for e in first["events"]] == ["event_flag"]
+    # next beat: stub, not full again
+    second = server.scene_context(cid)["events"]
+    assert second["events"] == []
+    assert any(s["id"] == "event_flag" for s in second.get("presented", []))

--- a/servers/engine/tests/test_second_seed.py
+++ b/servers/engine/tests/test_second_seed.py
@@ -91,11 +91,16 @@ def test_seed_world_zero_skip_diagnostics():
 
 
 def test_event_surfaces_via_present_events():
-    """The authored manual-trigger event must surface via events_mod.present."""
+    """The authored event surfaces via events_mod.present once its day_reached trigger
+    arms (SYN-04: authored events carry real triggers now, not 'manual')."""
     world = _load_world()
     c, _ = _seed_world(world)
     assert EVENT_ID in c.events, f"event {EVENT_ID!r} not seeded"
     ev = c.events[EVENT_ID]
+    # SYN-04: a real trigger, so it does not ride beat 1; advance the clock to arm it.
+    assert ev.trigger == "day_reached"
+    assert EVENT_ID not in [e.id for e in events_mod.present(c)]  # not on day 1
+    c.day = ev.trigger_threshold
     present_ids = [e.id for e in events_mod.present(c)]
     assert EVENT_ID in present_ids, (
         f"{EVENT_ID!r} not in present_events; present={present_ids}"

--- a/skills/dungeon-master/reference/living-arcs.md
+++ b/skills/dungeon-master/reference/living-arcs.md
@@ -22,8 +22,9 @@ complete_quest(campaign_id, quest_id, evolves_to="<a follow-on hook or a free se
 ```
 
 The engine schedules the follow-on as a consequence — due `callback_in_days` later (or immediately, if
-0) — and surfaces it back to you through `check_consequences` when its day comes. You weave the return;
-the engine just makes sure it *comes back*. The grateful family you saved becomes a feud over the reward.
+0) — and surfaces it back to you when its day comes: it fires automatically into `scene_context`'s
+`consequences_due` (the beat re-ground you read every turn), and `check_consequences` shows it too. You
+weave the return; the engine just makes sure it *comes back*. The grateful family you saved becomes a feud over the reward.
 The smuggler you let walk owes you, and one day comes to collect — or to be collected. The cult you broke
 left one survivor who remembers your face. Reach for the *consequence* of the resolution, not a sequel
 hook bolted on: what did winning *cost*, who did it *make*, what did it leave *unfinished*. (If you forget,


### PR DESCRIPTION
## Story-gate wave: three "written-but-never-read" defects in the quest/event/consequence region

Source: `docs/audits/ENGINE-AUDIT-2026-06-11.md`. These three share `events.py` / the server quest region, so they're owned coherently. The win: the engine TRACKS evolution / consequences / events that no consumer read — this wires each WRITE to a READ the DM actually sees every beat, and stops the event prose from contaminating that surface.

### F05-1 (#824) — rule-of-three quest evolution was unreachable
**Root cause:** `complete_quest(campaign_id, quest_id, status)` only; `SKILL.md:96` + `reference/living-arcs.md:21` document `complete_quest(..., evolves_to=…, callback_in_days=N)` which `TypeError`'d. The `Quest.evolves_to` / `callback_in_days` fields and the `_maybe_schedule_quest_evolution` helper were correct — no tool set the fields. The saga mechanism was dead in 100% of campaigns; the Director nagged an impossible action.
**Fix:** add optional `evolves_to` / `callback_in_days` params; set them under the existing `campaign_lock` BEFORE the evolution helper runs. ADDITIVE — omitting them is byte-identical to today; an empty kwarg never clobbers a field content/questgen pre-authored.

### F14-4 (#793) — scheduled consequences structurally never fired
**Root cause:** `add_consequence` was write-only; `consequences.due()` had call sites only in `check_consequences` (zero adoption) + `downtime` — nothing on the beat loop fired them (18 writes / 0 fires). `scene_context`'s durable block omitted pending consequences entirely.
**Fix:** `scene_context` (the every-beat re-ground the DM reads) now fires + surfaces due consequences as a new additive `consequences_due` key, under `campaign_lock`, saving only when something fired. Idempotent (each fires once; worldsim thread-beats are left for `world_tick`). This also closes the F05-1 loop end-to-end: a resolved quest's scheduled evolution now actually reaches the DM.

### SYN-04 (#785) — all authored events were `manual` → rode every beat as full prose
**Root cause:** `events.py:49-50` `trigger_holds("manual")` is unconditionally True; `present()` was uncapped; `scene_context` embedded the full projection every beat. BG 5/5 + tidal 2/2 events were `manual` — **6,569 B (~1.6K tok) every beat from beat 1**, 78% of the base bundle, incl. Raphael's bargain at minute one (contradicting `living-arcs.md:41-43`).
**Fix (three legs):**
- **(a) content** — BG/tidal events moved off `manual` to staggered `day_reached` triggers (BG days 2-6, tidal 2/4); a content lint asserts ≤1 manual event per shipped world.
- **(b) read valve** — `scene_context`'s events block surfaces ≤1 not-yet-presented event in full + a `manual_queued` count (rotates over beats). Standalone `present_events` keeps the full, read-only payload.
- **(c) memory** — additive `Event.first_presented_day` (None default, round-trips); stamped under lock when surfaced; already-presented live events return a compact stub. `scene_context`'s "NEVER writes" docstring updated.

**Measured:** BG day-1 events block **6,569 B → 70 B**; day-6 rotation ~1.3–1.8 KB (one full event + stubs, vs the old all-full-every-beat).

## Invariants
- **Engine = sole writer** — every new write is under `campaign_lock` + `save_campaign`, guarded to save only on an actual state change (no per-beat `updated_at` churn beyond what `check_companion_arc` already does).
- **Additive-by-default** — new model field + new tool params default to today's behavior; old snapshots round-trip (explicit tests).
- **Engine rolls, the DM is told** — fired consequences + surfaced events appear in the bundle, never silently mutated.
- **Frozen wire/model ids untouched.**

## Tests
- New: `test_dashboard.py` (F05-1 tool seam + no-clobber + additive), `test_beat_roundtrip.py` (F14-4 fire-once / not-due / thread-beat-skip), `test_event_parley_layer3.py` (SYN-04 throttle / stamp / stub / queued-still-resolvable / first_presented_day round-trip), `test_content.py` (manual-event lint).
- Amended 3 enshrining tests for the new triggers/keys (the old tests asserted events surfaced at day 1 as `manual`).
- **Full engine suite: 2096 passed.** `qa/fast_gate.sh` Tier-0: **PASS**.

Source: docs/audits/ENGINE-AUDIT-2026-06-11.md

Closes #824
Closes #793
Closes #785