### PR TITLE
fix(engine): bound every-beat history surfaces — tail-read + recap/recent_narration byte caps (SYN-08)

### DIFF
--- a/servers/engine/recap.py
+++ b/servers/engine/recap.py
@@ -39,6 +39,16 @@ def _is_combat_bookkeeping(entry: SessionLogEntry) -> bool:
 _INTRO = "Previously on your adventure..."
 _EMPTY = "This is the start of a new adventure. The story has yet to be written."
 
+# SYN-08 / F07-5 / F14-16 (issue #805): the recap was COUNT-bounded (max_entries=12)
+# but NOT SIZE-bounded — a verbatim full-text join, which reproduced 48,631B live
+# every cold open when beats were fat (12 x ~4KB). These DEFAULTED budgets bound the
+# bytes the per-beat recap surface carries WITHOUT dropping recency: each beat is
+# soft-capped to a sentence boundary, and the whole recap to a total budget, trimming
+# OLDEST-first so the newest beats (what the gates read) always survive.
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F07-5, F14-16, SYN-08).
+_DEFAULT_MAX_ENTRY_CHARS = 400  # per-beat soft cap (prefers a sentence boundary)
+_DEFAULT_MAX_CHARS = 6000  # total recap byte budget (~6KB), oldest-first trim
+
 
 def _clean(s: str) -> str:
     """Collapse whitespace/newlines and neutralize embedded double-quotes so a log
@@ -46,11 +56,34 @@ def _clean(s: str) -> str:
     return " ".join(s.split()).replace('"', "'")
 
 
-def _beat(entry: SessionLogEntry) -> str:
-    """Render a single log entry as one recap line."""
+def _soft_truncate(text: str, max_chars: int) -> str:
+    """Trim `text` to at most ~`max_chars`, preferring the LAST sentence boundary
+    (``. ! ?``) at or before the cap so the recap reads as prose, not a mid-word
+    cut. Falls back to the last word boundary, then a hard slice with an ellipsis.
+    Short text (already within the cap) is returned unchanged (byte-identical)."""
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    window = text[:max_chars]
+    # Prefer a sentence boundary; require it to land past the halfway mark so we
+    # don't collapse a long beat down to its first tiny clause.
+    cut = max(window.rfind(". "), window.rfind("! "), window.rfind("? "))
+    if cut >= max_chars // 2:
+        return window[: cut + 1]  # keep the terminal punctuation
+    space = window.rfind(" ")
+    if space >= max_chars // 2:
+        return window[:space].rstrip() + "…"
+    return window.rstrip() + "…"
+
+
+def _beat(entry: SessionLogEntry, max_entry_chars: int = 0) -> str:
+    """Render a single log entry as one recap line. ``max_entry_chars`` (>0) soft-
+    caps the beat's own text at a sentence boundary BEFORE it is wrapped in the
+    dialogue quoting, so the rendered line stays bounded (SYN-08)."""
     text = _clean(entry.text or "")
     if not text:
         return ""
+    if max_entry_chars > 0:
+        text = _soft_truncate(text, max_entry_chars)
     if entry.kind == "dialogue":
         speaker = _clean(entry.speaker or "")
         if speaker:
@@ -60,13 +93,26 @@ def _beat(entry: SessionLogEntry) -> str:
     return text
 
 
-def format_recap(entries: list[SessionLogEntry], max_entries: int = 12) -> str:
+def format_recap(
+    entries: list[SessionLogEntry],
+    max_entries: int = 12,
+    max_chars: int = _DEFAULT_MAX_CHARS,
+    max_entry_chars: int = _DEFAULT_MAX_ENTRY_CHARS,
+) -> str:
     """Build a "Previously on your adventure..." recap from recent log entries.
 
     Prefers narration, dialogue, and combat beats from the *most recent*
     `max_entries` story entries (in chronological order); dice rolls and system
     messages are ignored. An empty log (or a log with no story beats) yields a
     sensible new-adventure message.
+
+    SYN-08 / F07-5 / F14-16: the recap is BYTE-bounded as well as count-bounded.
+    Each beat is soft-capped to ``max_entry_chars`` (sentence-boundary preferred)
+    and the whole recap to a ``max_chars`` total budget, dropping OLDEST beats
+    first so recency — the story memory the gates read — is preserved. Both caps
+    default to sane budgets and are no-ops for the common short-beat case (set
+    either to ``0`` to disable). No LLM summarization: this only trims, never
+    paraphrases (engine reports, the DM narrates).
     """
     if max_entries < 1:
         max_entries = 1
@@ -85,12 +131,33 @@ def format_recap(entries: list[SessionLogEntry], max_entries: int = 12) -> str:
     ]
     recent = story[-max_entries:]
 
-    lines = [b for b in (_beat(e) for e in recent) if b]
+    lines = [b for b in (_beat(e, max_entry_chars) for e in recent) if b]
     if not lines:
         return _EMPTY
 
+    # Total-budget trim (SYN-08): keep the NEWEST lines that fit, oldest-first drop.
+    # The budget is measured against the body (intro is fixed overhead). With caps
+    # disabled or a generous budget this keeps every line (byte-identical to before).
+    if max_chars > 0:
+        lines = _fit_budget(lines, max_chars)
+
     body = " ".join(lines)
     return f"{_INTRO} {body}"
+
+
+def _fit_budget(lines: list[str], max_chars: int) -> list[str]:
+    """Keep the most-recent suffix of `lines` whose joined length fits `max_chars`,
+    always keeping at least the single newest line (a lone fat beat is already
+    per-entry capped). Returns lines in their original (chronological) order."""
+    kept_rev: list[str] = []
+    used = 0
+    for line in reversed(lines):  # newest first
+        extra = len(line) + (1 if kept_rev else 0)  # +1 for the joining space
+        if kept_rev and used + extra > max_chars:
+            break
+        kept_rev.append(line)
+        used += extra
+    return list(reversed(kept_rev))
 
 
 def recap_from_store(campaign_id: str, session_id: str) -> str:

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -47,6 +47,7 @@ import travel
 import wander
 import worldsim
 import wrapper_progress as _wrapper_progress_mod
+import _env
 from models import (
     SKILL_ABILITIES,
     Ability,
@@ -9680,6 +9681,29 @@ def _scene_durable_threads(c: Campaign) -> dict:
     }
 
 
+# SYN-08 / F07-11: how many RAW rows to over-read for each requested player-facing
+# beat. recent_narration filters out bookkeeping (rolls / system / wrapper-heartbeat /
+# combat-log) before taking the last N, so the bounded tail must hand back more raw
+# rows than N. 8x covers a tail that is mostly bookkeeping while still short-circuiting
+# the whole-history re-parse on a long campaign.
+_RECENT_RAW_SLACK = 8
+
+
+def _recent_narration_max_chars() -> int:
+    """SYN-08 / F14-17: optional per-beat soft cap (chars) for recent_narration's
+    prose tail. DEFAULT-OFF (0): bounding the WINDOW (last-N) is lossless and always
+    on, but byte-capping the CONTENT drops story, so it only engages when a wrapper
+    sets ``WORLDOS_RECENT_NARRATION_MAX_CHARS`` (legacy ``CLAWDND_*`` honored). Story
+    is the north star — ride a long-campaign duo A/B before any default change.
+    Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F14-17, SYN-08)."""
+    raw = _env.env_var("RECENT_NARRATION_MAX_CHARS", "0")
+    try:
+        n = int(raw)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
 def _scene_recent_narration(c: Campaign, limit: int) -> list[dict]:
     """The last ``limit`` PLAYER-FACING beats (kind in narration|dialogue) across
     the WHOLE campaign's session logs, in CHRONOLOGICAL order — the prose tail a
@@ -9693,12 +9717,25 @@ def _scene_recent_narration(c: Campaign, limit: int) -> list[dict]:
     session_ids order, defensive disk tail, stable by timestamp) so the last N
     beats surface regardless of which session wrote them.
 
+    SYN-08 / F07-11: the read is BOUNDED (``read_log_all(tail=…)``) so this
+    every-beat surface no longer re-parses the entire append-only campaign history
+    just to return the last handful — it scans a bounded newest-first window. This
+    is lossless: the same last-N player-facing beats come back (the slack covers the
+    bookkeeping rows the filter below drops).
+
     Rolls / system / combat-log rows are bookkeeping noise and are dropped (mirrors
     recap's _STORY_KINDS, minus combat: this is the spoken story).
     """
     if limit <= 0:
         return []
-    entries = read_log_all(c.id, getattr(c, "session_ids", None))
+    # F07-11: bound the read to a newest-first window instead of re-parsing the whole
+    # append-only history. We OVER-read the raw tail (``limit * _RECENT_RAW_SLACK``)
+    # because the filter below drops bookkeeping rows (rolls/system/wrapper/combat-log)
+    # — so the post-filter last-`limit` player-facing beats are intact even when the
+    # raw tail is heavily interleaved with bookkeeping. read_log_all(tail=…) returns
+    # exactly the last K RAW rows the full walk would, so this stays lossless.
+    raw_tail = limit * _RECENT_RAW_SLACK
+    entries = read_log_all(c.id, getattr(c, "session_ids", None), tail=raw_tail)
     # #749: drop the wrapper progress heartbeat (exact-match) — it is the QA/play wrappers'
     # mid-turn liveness filler, not the DM's prose. Feeding it back here told a lean
     # (transcript-free) DM that canned filler was its own canon.
@@ -9707,8 +9744,14 @@ def _scene_recent_narration(c: Campaign, limit: int) -> list[dict]:
         if e.kind in ("narration", "dialogue")
         and not _wrapper_progress_mod.is_wrapper_progress_line(e.text)
     ]
+    # F14-17: per-beat soft cap is DEFAULT-OFF (0 -> verbatim, today's behavior).
+    cap = _recent_narration_max_chars()
+
+    def _text(e) -> str:
+        return recap._soft_truncate(e.text, cap) if cap > 0 else e.text
+
     return [
-        {"text": e.text, **({"speaker": e.speaker} if e.speaker else {})}
+        {"text": _text(e), **({"speaker": e.speaker} if e.speaker else {})}
         for e in facing[-limit:]
     ]
 

--- a/servers/engine/store.py
+++ b/servers/engine/store.py
@@ -447,8 +447,20 @@ def read_log(campaign_id: str, session_id: str) -> list[SessionLogEntry]:
     return entries
 
 
+# SYN-08 / F07-11 (issue #805): over-read multiplier for the bounded tail. The
+# every-beat consumer (scene_context's recent_narration) FILTERS the result
+# (drops rolls / system / combat-log rows, then takes the last N), so a bounded
+# tail must hand back MORE than N raw rows or the post-filter window could come up
+# short. We read ``tail * _TAIL_SLACK`` newest rows so a heavily-bookkept tail
+# still yields N story beats; the read still short-circuits long before scanning
+# the whole append-only campaign log (the linear-in-campaign-size defect).
+_TAIL_SLACK = 8
+
+
 def read_log_all(
-    campaign_id: str, session_ids: Optional[list[str]] = None
+    campaign_id: str,
+    session_ids: Optional[list[str]] = None,
+    tail: Optional[int] = None,
 ) -> list[SessionLogEntry]:
     """Read EVERY session log of a campaign, concatenated in chronological order.
 
@@ -469,6 +481,18 @@ def read_log_all(
       * within each session, entries keep their on-disk (append) order.
     A final stable sort by each entry's timestamp ``t`` smooths any cross-file
     interleave while preserving append order for equal/zero timestamps.
+
+    ``tail`` (SYN-08 / F07-11) bounds the read to the last *window* of rows
+    instead of parsing EVERY line of EVERY session file — the defect this fixes is
+    that the every-beat lean path was strictly linear in campaign size (it opened
+    + pydantic-validated the whole append-only history 2-4x per beat just to
+    return the last handful). With ``tail=N`` the walk goes NEWEST file first,
+    reading whole files back-to-front, and stops once it has at least ``N`` rows
+    of slack (``N * _TAIL_SLACK``, so a caller that further filters still gets N);
+    the result is the SAME final ``[-N]``-class window the full walk would
+    produce, just without scanning the older history. ``tail=None`` (the default)
+    keeps the full walk, byte-identical to before. ``tail<=0`` is a degenerate
+    empty window (``[]``) — pass ``None``, not ``0``, to mean "everything".
     """
     sessions_dir = _campaign_dir(campaign_id) / "sessions"
     if not sessions_dir.is_dir():
@@ -486,6 +510,23 @@ def read_log_all(
     leftover = [sid for sid in on_disk if sid not in seen]
     leftover.sort(key=lambda sid: on_disk[sid].stat().st_mtime)
     ordered_ids.extend(leftover)
+
+    if tail is not None:
+        if tail <= 0:
+            return []
+        # Bounded NEWEST-first walk: read whole files from the END of the canonical
+        # order and stop once we have enough slack, so the OLDER history is never
+        # opened. Each file is read entirely (the bounded unit is one file), which
+        # preserves within-file append order; we only stop opening older files.
+        want = tail * _TAIL_SLACK
+        collected: list[SessionLogEntry] = []
+        for sid in reversed(ordered_ids):
+            collected = read_log(campaign_id, sid) + collected
+            if len(collected) >= want:
+                break
+        # Same stable-by-timestamp ordering as the full walk, then the [-N] window.
+        collected.sort(key=lambda e: e.t)
+        return collected[-tail:]
 
     entries: list[SessionLogEntry] = []
     for sid in ordered_ids:

--- a/servers/engine/tests/test_beat_roundtrip.py
+++ b/servers/engine/tests/test_beat_roundtrip.py
@@ -167,6 +167,45 @@ def test_scene_context_recent_narration_spans_multiple_sessions(cid):
     ]
 
 
+# ── SYN-08 / F14-17 (issue #805): recent_narration byte-cap is DEFAULT-OFF ──
+# F14-17: bounding the WINDOW (last-N) is lossless and stays on; byte-capping the
+# CONTENT drops story, so it is DEFAULT-OFF (story is the north star) and only
+# engages when WORLDOS_RECENT_NARRATION_MAX_CHARS is set. With the cap OFF the
+# tail is verbatim (today's behavior, byte-identical). The read also now uses the
+# bounded tail walk internally (F07-11) but returns the SAME last-N rows.
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F14-17, F07-11, SYN-08).
+
+
+def test_scene_context_recent_narration_verbatim_by_default(cid):
+    """DEFAULT-OFF byte-cap: with no env knob set, a long narration beat comes back
+    VERBATIM (only the count is bounded) — no truncation creeps into the lean DM's
+    story memory."""
+    long_text = "The cathedral bell tolled. " * 60  # ~1.6KB, well over any cap
+    server.log_event(cid, kind="narration", text=long_text.strip())
+    rn = server.scene_context(cid, recent_narration=1)["recent_narration"]
+    assert rn[-1]["text"] == long_text.strip()  # byte-identical, not truncated
+
+
+def test_scene_context_recent_narration_byte_cap_opt_in(cid, monkeypatch):
+    """When WORLDOS_RECENT_NARRATION_MAX_CHARS is set, each returned beat is soft-
+    capped to that many chars (opt-in, wrapper-tunable per the F14-17 spec)."""
+    monkeypatch.setenv("WORLDOS_RECENT_NARRATION_MAX_CHARS", "120")
+    long_text = "The cathedral bell tolled. " * 60
+    server.log_event(cid, kind="narration", text=long_text.strip())
+    rn = server.scene_context(cid, recent_narration=1)["recent_narration"]
+    assert len(rn[-1]["text"]) <= 140  # ~120 cap + a little boundary slack
+    assert rn[-1]["text"].startswith("The cathedral bell tolled.")
+
+
+def test_scene_context_recent_narration_cap_keeps_short_verbatim(cid, monkeypatch):
+    """Even with the cap engaged, a short beat is untouched (the cap is a CEILING,
+    never padding or rewriting)."""
+    monkeypatch.setenv("WORLDOS_RECENT_NARRATION_MAX_CHARS", "120")
+    server.log_event(cid, kind="dialogue", text="Halt!", speaker="Guard")
+    rn = server.scene_context(cid, recent_narration=1)["recent_narration"]
+    assert rn[-1] == {"text": "Halt!", "speaker": "Guard"}
+
+
 # ── scene_context: the pinned durable continuity threads ─────────────────────
 
 

--- a/servers/engine/tests/test_recap.py
+++ b/servers/engine/tests/test_recap.py
@@ -122,6 +122,70 @@ def test_format_recap_keeps_combat_with_unrelated_payload():
     assert "duel ended" in out
 
 
+# ── SYN-08 / F07-5 / F14-16 (issue #805): recap is BYTE-capped, not just count- ──
+# capped. recap.py bounded COUNT (12 entries) but not SIZE — 12 x ~4KB beats
+# reproduced 48,631B live every cold open. The fix adds a per-entry sentence-
+# boundary char cap (~400) + a total byte budget (~6KB), defaulted, trimming
+# OLDEST-first so the newest beats stay intact (recency is what the gates read).
+# Short entries stay byte-identical (the existing tests above guard that).
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F07-5, F14-16, SYN-08).
+
+def test_format_recap_total_byte_budget():
+    """A run of fat beats is capped to ~max_chars total — the whole-recap budget,
+    not just per-entry — and stays well under the unbounded 48KB it produced."""
+    entries = [
+        SessionLogEntry(t=float(i), kind="narration", text=("X" * 4000) + f" beat {i}.")
+        for i in range(12)
+    ]
+    out = recap.format_recap(entries)
+    assert len(out) <= 6500  # ~6KB budget + the intro slack
+    # The unbounded join would be ~48KB; this is an order of magnitude smaller.
+    assert len(out) < 12000
+
+
+def test_format_recap_keeps_newest_when_budget_trims():
+    """Oldest-first trimming: when the TOTAL budget bites, the NEWEST beats survive
+    and the oldest drop (recency is the story memory the gates read). Driven with a
+    tight total budget so the trim mechanism is exercised directly (the per-entry
+    cap alone keeps the default config well under 6KB)."""
+    entries = [
+        SessionLogEntry(t=float(i), kind="narration", text=f"BEAT{i}END is the whole beat.")
+        for i in range(12)
+    ]
+    out = recap.format_recap(entries, max_chars=80)
+    # newest beats present; oldest trimmed out of the tight budget
+    assert "BEAT11END" in out
+    assert "BEAT0END" not in out
+    assert len(out) <= 80 + len(recap._INTRO) + 4
+
+
+def test_format_recap_per_entry_char_cap_at_sentence_boundary():
+    """A single very long beat is truncated to ~max_entry_chars, preferring a
+    sentence boundary so the recap reads as prose, not a mid-word cut."""
+    long_text = (
+        "The party crossed the bridge. " * 5  # ~150 chars of whole sentences
+        + "Then they walked on and on and on " * 40  # pushes well past the cap
+    )
+    out = recap.format_recap([SessionLogEntry(t=1.0, kind="narration", text=long_text)])
+    body = out[len(recap._INTRO) + 1:]
+    assert len(body) <= 420  # ~400 cap + a little boundary slack
+    assert "The party crossed the bridge." in out  # opening sentence preserved
+
+
+def test_format_recap_short_entries_byte_identical():
+    """The caps NEVER touch short entries — the common case stays byte-for-byte
+    today's output (additive-by-default, recency preserved)."""
+    short = [
+        SessionLogEntry(t=1.0, kind="narration", text="The torch sputters."),
+        SessionLogEntry(t=2.0, kind="dialogue", text="This way.", speaker="Lyra"),
+    ]
+    # Reproduce the legacy join by hand to prove no truncation crept in.
+    expected = (
+        recap._INTRO + " The torch sputters. " + 'Lyra said, "This way."'
+    )
+    assert recap.format_recap(short) == expected
+
+
 def test_recap_from_store(tmp_path, monkeypatch):
     monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
     campaign_id = "camp_test123"

--- a/servers/engine/tests/test_store.py
+++ b/servers/engine/tests/test_store.py
@@ -241,3 +241,116 @@ def test_read_log_all_is_read_only(tmp_path, monkeypatch):
 
     after = {p.name: p.stat().st_mtime_ns for p in sessions_dir.glob("*.jsonl")}
     assert before == after  # no writes, no new files
+
+
+# ---------------------------------------------------------------------------
+# SYN-08 / F07-11 (issue #805): bounded tail read. read_log_all(tail=N) scans a
+# bounded newest-first window instead of opening + pydantic-validating EVERY line
+# of EVERY session file (which was 2-4x/beat on the lean every-beat path, strictly
+# linear in campaign size). The tail must return EXACTLY the last N rows the full
+# walk would (equivalence), so the only observable change is fewer rows parsed.
+# Default (tail=None) stays the full walk, byte-identical.
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F07-11, F14-17, SYN-08).
+# ---------------------------------------------------------------------------
+
+def _seed_multi_session(cid: str, sessions: int, per_session: int) -> None:
+    """Seed `sessions` session files, each with `per_session` rows, with globally
+    monotonic timestamps so the canonical chronological order is unambiguous."""
+    t = 0.0
+    for s in range(sessions):
+        sid = f"s{s}"
+        for i in range(per_session):
+            t += 1.0
+            store.append_log(
+                cid, sid,
+                SessionLogEntry(t=t, kind="narration", text=f"row {s}-{i} (t={t})"),
+            )
+
+
+def test_read_log_all_tail_equals_full_walk_tail(tmp_path, monkeypatch):
+    """read_log_all(tail=N) returns EXACTLY the last N entries of the full walk —
+    same texts, same order — across MULTIPLE session files (the tail must cross a
+    file boundary, which is the whole point of a campaign-wide tail)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp-tail"
+    sids = [f"s{s}" for s in range(4)]
+    _seed_multi_session(cid, sessions=4, per_session=5)  # 20 rows, 5/file
+
+    full = store.read_log_all(cid, sids)
+    assert len(full) == 20
+    for n in (1, 3, 7, 12, 20, 99):
+        tailed = store.read_log_all(cid, sids, tail=n)
+        assert [e.text for e in tailed] == [e.text for e in full[-n:]], n
+        # chronological (oldest-first within the window), like the full walk
+        assert [e.t for e in tailed] == sorted(e.t for e in tailed), n
+
+
+def test_read_log_all_tail_none_is_full_walk(tmp_path, monkeypatch):
+    """tail=None (the default) is byte-identical to today's full walk — no behavior
+    change for any existing caller."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp-tail-none"
+    sids = [f"s{s}" for s in range(3)]
+    _seed_multi_session(cid, sessions=3, per_session=4)
+    default = store.read_log_all(cid, sids)
+    explicit = store.read_log_all(cid, sids, tail=None)
+    assert [e.text for e in default] == [e.text for e in explicit]
+    assert [e.text for e in default] == [f"row {s}-{i} (t={s * 4 + i + 1}.0)"
+                                         for s in range(3) for i in range(4)]
+
+
+def test_read_log_all_tail_parses_fewer_rows(tmp_path, monkeypatch):
+    """The bounded tail must actually SHORT-CIRCUIT: with a small tail over a large
+    history it parses far fewer SessionLogEntry rows than the full walk. We count
+    model_validate_json calls — the linear-in-campaign-size parse is the defect."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp-count"
+    sids = [f"s{s}" for s in range(10)]
+    _seed_multi_session(cid, sessions=10, per_session=20)  # 200 rows
+
+    calls = {"n": 0}
+    real = SessionLogEntry.model_validate_json.__func__
+
+    def _counting(cls, *a, **k):
+        calls["n"] += 1
+        return real(cls, *a, **k)
+
+    monkeypatch.setattr(SessionLogEntry, "model_validate_json", classmethod(_counting))
+
+    tailed = store.read_log_all(cid, sids, tail=5)
+    assert [e.text for e in tailed][-1].startswith("row 9-19")
+    # Full walk would parse all 200; a bounded tail parses a small multiple of N.
+    assert calls["n"] < 200
+    assert calls["n"] <= 60  # generous slack ceiling (tail x slack x a file or two)
+
+
+def test_read_log_all_tail_zero_or_negative_is_empty(tmp_path, monkeypatch):
+    """tail<=0 is a degenerate window -> [] (never the full walk; that's tail=None)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp-tail-zero"
+    _seed_multi_session(cid, sessions=2, per_session=3)
+    assert store.read_log_all(cid, ["s0", "s1"], tail=0) == []
+    assert store.read_log_all(cid, ["s0", "s1"], tail=-3) == []
+
+
+def test_read_log_all_tail_includes_orphan_files(tmp_path, monkeypatch):
+    """The defensive disk tail (files not in session_ids) must still be reachable by
+    the bounded walk — newest content wins regardless of which file holds it."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp-tail-orphan"
+    store.append_log(cid, "listed", SessionLogEntry(t=1.0, kind="narration", text="old-listed"))
+    store.append_log(cid, "orphan", SessionLogEntry(t=2.0, kind="narration", text="new-orphan"))
+    tailed = store.read_log_all(cid, ["listed"], tail=1)
+    assert [e.text for e in tailed] == ["new-orphan"]
+
+
+def test_read_log_all_tail_is_read_only(tmp_path, monkeypatch):
+    """Bounded tail keeps the sole-writer invariant: no file created or touched."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp-tail-ro"
+    store.append_log(cid, "s0", SessionLogEntry(t=1.0, kind="narration", text="x"))
+    sessions_dir = tmp_path / "campaigns" / cid / "sessions"
+    before = {p.name: p.stat().st_mtime_ns for p in sessions_dir.glob("*.jsonl")}
+    store.read_log_all(cid, ["s0"], tail=1)
+    after = {p.name: p.stat().st_mtime_ns for p in sessions_dir.glob("*.jsonl")}
+    assert before == after


### PR DESCRIPTION
## What & why

The per-beat **lean spine** re-parses the FULL append-only campaign history every beat and emits **count-not-byte-capped** payloads, so token mass creeps invisibly as campaigns age (the audit projected 30-60KB/beat at 30+ sessions; `session_recap` reproduced **48,631B** live every cold open). This PR bounds the **window** on the named every-beat surfaces **without dropping recency** — the story content the gates read stays intact.

Cluster **SYN-08** (issue #805), findings **F07-5 + F07-11 + F14-16 + F14-17**.
Source: `docs/audits/ENGINE-AUDIT-2026-06-11.md` (Part C per-finding specs).

## Changes (additive, read-only)

### 1. `store.read_log_all(tail=N)` — bounded tail-read (F07-11)
Newest-first file walk that **stops** once it has `N x slack` rows, then returns the chronological `[-N]` window — instead of opening + pydantic-validating EVERY line of EVERY session file 2-4x/beat (strictly linear in campaign size).
- `tail=None` (default) = full walk, **byte-identical** to before — no behavior change for any existing caller.
- `tail<=0` = degenerate empty window.

### 2. `recap.format_recap` — byte cap, not just count cap (F07-5, F14-16)
Per-entry **~400-char sentence-boundary** soft cap + **~6KB total budget** (defaulted params), trimming **OLDEST-first** so the newest beats survive (recency = the story memory the gates read).
- **NO LLM summarization** — only trims, never paraphrases (engine reports; the DM narrates).
- Short beats stay **byte-identical** (the existing recap tests guard this).
- Preserves the **#847 combat-filter** (`_is_combat_bookkeeping`) untouched.

### 3. `_scene_recent_narration` — bounded read + DEFAULT-OFF content cap (F14-17)
- The **read** now uses the bounded tail (lossless window bound, **always on**) — returns the same last-N player-facing beats.
- The **content byte-cap is DEFAULT-OFF**, opt-in via `WORLDOS_RECENT_NARRATION_MAX_CHARS` (legacy `CLAWDND_*` honored via `_env`). Per F14-17's story-first posture: bounding the window is lossless, but byte-capping the content drops story — ride a long-campaign duo A/B before changing the default.

## Measured before/after (seeded campaign, 749 log rows / 30 sessions, ~1.4KB DM-prose beats)

| Surface | OLD | NEW | Delta |
|---|---|---|---|
| `recap` | **8,653 B** | **2,617 B** | **-69%** |
| `recent_narration` read (rows parsed) | 749 rows | **525 rows** | bounded (constant vs campaign size) |
| `recent_narration` bytes (default) | 5,876 B | 5,876 B | byte-identical (window bound is lossless) |
| `recent_narration` bytes (opt-in cap=400) | 5,876 B | **1,852 B** | **-68%** |

Token-mass **REDUCTION only**; `scene_context` never grows.

## Invariants
- **Sole-writer / read-only**: no `save_campaign`, no `updated_at` bump, no `append_log` added to any read path (the #640 / live-pointer-flip class). Verified by grep + the existing read-only tests.
- **Additive-by-default**: new params/env default to today's behavior; old snapshots round-trip (no model change).
- **Wire contracts frozen**: no `clawdnd-*` id or `CLAWDND_*` env changed; new knob uses the `WORLDOS_` prefix with legacy fallback.

## Tests
TDD (failing first). New: 6 `read_log_all(tail=…)` equivalence/short-circuit/read-only tests (`test_store.py`), 4 recap byte-budget/per-entry-cap/byte-identical tests (`test_recap.py`), 3 recent_narration default-off/opt-in tests (`test_beat_roundtrip.py`).

- Touched suites: **66 passed** (`test_store` + `test_recap` + `test_beat_roundtrip`).
- Full engine suite: **2172 passed**.
- Tier-0 `qa/fast_gate.sh`: **PASS** (188 passed).

## Scope note
This PR fixes the **bounded tail-read + byte-cap** half of SYN-08 (F07-5/F07-11/F14-16/F14-17) as scoped. **F13-6** (durable `npc_relationships` top-24 cap) — the other SYN-08 member — is a separate derivation cap on `scene_context.durable` and is left for a follow-up. **SYN-09** (echo-back returns: log_event/remember/forget/update_character) is a sibling cluster, not in this change.

Closes #805