### PR TITLE
fix(engine): persistence-robustness cluster — pure reads stop flipping the live pointer (F08-2/3/4/5)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -95,7 +95,7 @@ _AB3_TO_FULL = {
 # Reverse: accept either the 3-letter code (the Ability enum value) or the full word
 # (how the SRD records spell saving_throw_ability, e.g. "wisdom") and resolve to an Ability.
 _FULL_TO_AB3 = {full: ab3 for ab3, full in _AB3_TO_FULL.items()}
-from store import append_log, campaign_lock, campaigns_for_world, read_log_all
+from store import append_log, campaign_lock, campaigns_for_world, last_dropped_keys, read_log_all
 from store import active_campaign_id as _active_campaign_id
 from store import list_campaigns as _list_campaigns
 from store import list_slots as _list_slots
@@ -591,7 +591,7 @@ def start_world(world_id: str, start_at: str = "", resume: str = "", ending: str
         prior = load_campaign(resume)
         if prior is not None and prior.world_id == world_id:
             ploc = prior.locations.get(prior.current_location_id) if prior.current_location_id else None
-            return {
+            resumed = {
                 "campaign_id": prior.id,
                 "world": prior.title,
                 "resumed": True,
@@ -606,6 +606,18 @@ def start_world(world_id: str, start_at: str = "", resume: str = "", ending: str
                 "regions": [{"id": l.id, "name": l.name} for l in prior.locations.values()],
                 "note": "Resumed an existing campaign. Call session_recap / get_state to re-ground, then start_session.",
             }
+            # F08-3: surface any tolerant-load schema drift on the resume path (see start_session).
+            drift = last_dropped_keys(prior.id)
+            if drift:
+                resumed["schema_drift"] = {
+                    "dropped_keys": drift,
+                    "note": (
+                        "This save was written by a different engine schema; the listed top-level "
+                        "field(s) were dropped on load. The original snapshot is preserved at "
+                        "snapshot.pre-tolerant.json."
+                    ),
+                }
+            return resumed
         # invalid/mismatched resume id -> fall through to a fresh start
 
     c = content_mod.seed_world(world, start_at=start_at, ending=ending)
@@ -7698,7 +7710,22 @@ def start_session(campaign_id: str, title: str = "") -> dict:
             ),
         )
         save_campaign(c)
-        return {"session_id": sid, "number": len(c.session_ids), "previously_on": previously}
+        out = {"session_id": sid, "number": len(c.session_ids), "previously_on": previously}
+        # F08-3: if this campaign's snapshot needed the TOLERANT load (unknown top-level keys from
+        # a newer/older schema were dropped), SURFACE the dropped key names on the resume path so
+        # schema-evolution data-loss is visible at the table — not just buried in a log line. The
+        # original bytes are recoverable from campaigns/<id>/snapshot.pre-tolerant.json.
+        drift = last_dropped_keys(campaign_id)
+        if drift:
+            out["schema_drift"] = {
+                "dropped_keys": drift,
+                "note": (
+                    "This save was written by a different engine schema; the listed top-level "
+                    "field(s) were dropped on load. The original snapshot is preserved at "
+                    "snapshot.pre-tolerant.json."
+                ),
+            }
+        return out
 
 
 @mcp.tool()

--- a/servers/engine/store.py
+++ b/servers/engine/store.py
@@ -116,7 +116,6 @@ def _atomic_write(path: Path, data: str) -> None:
 
 
 def save_campaign(campaign: Campaign) -> Path:
-    campaign.updated_at = time.time()
     # Version-stamp the snapshot: record the engine SHA that wrote it (cached, best-effort —
     # never aborts a save) and make sure schema_version is populated. schema_version's authority
     # is the manual constant on the Campaign model (default 1, bumped only on a breaking schema
@@ -125,8 +124,140 @@ def save_campaign(campaign: Campaign) -> Path:
     if not campaign.schema_version:
         campaign.schema_version = Campaign.model_fields["schema_version"].default
     path = _campaign_dir(campaign.id) / "snapshot.json"
+
+    # F08-2 dirty-skip chokepoint: a load -> (no mutation) -> save_campaign is a PURE READ and
+    # must not rewrite the snapshot or bump updated_at — otherwise it flips the #640
+    # "most-recently-updated == live" pointer (a cross-campaign check_*/world_tick/scene_context
+    # evaluation would silently steal the live pointer onto the inspected campaign). We detect a
+    # no-op by serializing with the CURRENT (pre-stamp) updated_at and byte-comparing to disk: if
+    # a tool mutated nothing, the candidate matches what we last wrote and we skip the write+stamp.
+    # A genuine mutation -> bytes differ -> we stamp updated_at and write as usual (so a real write
+    # is NEVER dropped). Note (F08-3 composition): after a TOLERANT load the in-memory dump differs
+    # from the on-disk bytes (dropped keys are gone), so the candidate != disk and we DO write —
+    # which is exactly why F08-3 stashes the original bytes independently BEFORE the drop.
+    candidate = campaign.model_dump_json(indent=2)
+    try:
+        if path.exists() and path.read_text(encoding="utf-8") == candidate:
+            return path  # byte-identical -> nothing changed -> no rewrite, no fresh stamp
+    except OSError:
+        # Unreadable on-disk snapshot: fall through to a normal write (never skip a real save).
+        pass
+
+    campaign.updated_at = time.time()
     _atomic_write(path, campaign.model_dump_json(indent=2))
     return path
+
+
+# F08-3: the most-recent set of unknown top-level keys the tolerant load dropped, per campaign id.
+# Observable so the resume path can SURFACE schema-evolution data-loss instead of it being log-only
+# (the audit's "make the drop observable" requirement). A clean strict load clears the entry.
+_LAST_DROPPED_KEYS: dict[str, list[str]] = {}
+
+# Sidecar name for the write-once pre-tolerant backup (F08-3). Lives beside snapshot.json; nothing
+# globs ``campaigns/<id>/*.json`` (list_slots globs slots/*.json; listings read snapshot.json by
+# name), so the sibling file is inert to the rest of the store.
+_PRE_TOLERANT_BACKUP = "snapshot.pre-tolerant.json"
+
+
+def last_dropped_keys(campaign_id: str) -> list[str]:
+    """The unknown top-level keys the LAST tolerant load of this campaign dropped (F08-3).
+
+    Empty when the most recent load was a clean strict parse (nothing dropped). The resume path
+    reads this to surface schema-evolution data-loss to the operator/DM rather than leaving it
+    log-only and invisible at the table — the original bytes remain recoverable from the
+    ``snapshot.pre-tolerant.json`` sidecar this load stashes."""
+    return list(_LAST_DROPPED_KEYS.get(campaign_id, []))
+
+
+def _validate_tolerant(raw: str) -> tuple[Campaign, list[str]]:
+    """Side-effect-free tolerant parse: drop unknown top-level keys, validate, and report which
+    keys were dropped (F08-3/F08-4 shared core).
+
+    PURE — no disk writes, no module-state mutation — so the enumerators (F08-4) can reuse it
+    without turning a listing into a writer (the "pure reads don't write" invariant). Only the
+    callable load path (:func:`_tolerant_load`) layers on the write-once backup + dropped-key
+    recording. Raises RuntimeError if the snapshot is incompatible even after stripping unknown
+    top-level keys (genuine corruption — not a schema-skew we can recover)."""
+    import json
+    data: dict = json.loads(raw)
+    known = set(Campaign.model_fields)
+    dropped = [k for k in list(data) if k not in known]
+    for k in dropped:
+        del data[k]
+    try:
+        return Campaign.model_validate(data), dropped
+    except ValidationError as exc:
+        raise RuntimeError(
+            f"snapshot is incompatible with the current schema and cannot be loaded even "
+            f"after stripping unknown top-level keys.  Validation error: {exc}"
+        ) from exc
+
+
+def _tolerant_load(campaign_id: str, raw: str) -> Campaign:
+    """Tolerant load for the CALLABLE path: parse + record dropped keys + stash the original bytes.
+
+    Wraps the pure :func:`_validate_tolerant` with the two F08-3 side effects (skipped by the
+    read-only enumerators): recording the dropped key names so the resume path can SURFACE the
+    loss, and stashing the ORIGINAL bytes write-once into ``snapshot.pre-tolerant.json`` so the
+    unknown data is recoverable even after the next save rewrites snapshot.json in the current
+    schema."""
+    try:
+        c, dropped = _validate_tolerant(raw)
+    except RuntimeError as exc:
+        # Preserve the historical load_campaign error wording (callers/tests match on it).
+        raise RuntimeError(f"load_campaign({campaign_id!r}): {exc}") from exc
+    _LAST_DROPPED_KEYS[campaign_id] = list(dropped)
+    if dropped:
+        log.warning(
+            "load_campaign(%s): dropping unrecognised top-level key(s) %s "
+            "— snapshot may be from a different schema version; the original bytes are "
+            "stashed in %s and the data in those fields is lost for this load.",
+            campaign_id,
+            dropped,
+            _PRE_TOLERANT_BACKUP,
+        )
+        # Stash the ORIGINAL bytes write-once BEFORE the drop takes effect on disk, so the unknown
+        # fields stay recoverable even after the next save rewrites snapshot.json in the current
+        # schema. Fixed filename (NOT timestamped) + skip-if-exists: the FIRST-skew bytes are the
+        # valuable ones, and a fresh-timestamp name would mint an unbounded backup per tolerant
+        # load. Best-effort: a backup-write failure must DEGRADE (log) — never abort the load (a
+        # read must not brick because a sibling write failed).
+        backup = _campaign_dir(campaign_id) / _PRE_TOLERANT_BACKUP
+        if not backup.exists():
+            try:
+                _atomic_write(backup, raw)
+            except OSError as exc:
+                log.warning(
+                    "load_campaign(%s): could not stash pre-tolerant backup %s: %s "
+                    "(continuing — the load is unaffected).",
+                    campaign_id, _PRE_TOLERANT_BACKUP, exc,
+                )
+    return c
+
+
+def _load_summary(snap: Path) -> Optional[Campaign]:
+    """Read-only tolerant parse of a snapshot file for the ENUMERATORS (F08-4).
+
+    The enumerators (list_campaigns / campaigns_for_world / active_campaign_id) must use the SAME
+    notion of "loadable" as load_campaign — otherwise a tolerant-loadable campaign is INVISIBLE to
+    listings and to the #640 live-pointer resolver (the resolver would silently pick the OTHER,
+    strict-only campaign). Strict parse first; tolerant retry only on strict failure. PURE: no
+    backup write, no module-state mutation (those side effects belong to the callable load path
+    only — a listing must never write). Genuinely-corrupt snapshots (RuntimeError) are skipped, so
+    real corruption can't crash or pollute a listing."""
+    try:
+        raw = snap.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    try:
+        return Campaign.model_validate_json(raw)
+    except ValidationError:
+        pass
+    try:
+        c, _ = _validate_tolerant(raw)
+        return c
+    except (RuntimeError, ValueError):
+        return None
 
 
 def load_campaign(campaign_id: str) -> Optional[Campaign]:
@@ -135,39 +266,18 @@ def load_campaign(campaign_id: str) -> Optional[Campaign]:
         return None
     raw = path.read_text(encoding="utf-8")
     try:
-        return Campaign.model_validate_json(raw)
+        c = Campaign.model_validate_json(raw)
+        _LAST_DROPPED_KEYS.pop(campaign_id, None)  # clean strict load: nothing dropped
+        return c
     except ValidationError:
         pass
 
-    # Tolerant fallback: drop any top-level keys the current schema doesn't know
-    # about (removed/renamed fields from an older or newer snapshot).  We only
-    # attempt this at the TOP level of Campaign — sub-model strictness is
-    # intentionally preserved.  Per-rename migrations (old-key → new-key) are
-    # added here per-release as needed; this generic net only handles field
-    # removal / unknown keys.
-    import json
-    data: dict = json.loads(raw)
-    known = set(Campaign.model_fields)
-    dropped = [k for k in list(data) if k not in known]
-    if dropped:
-        log.warning(
-            "load_campaign(%s): dropping unrecognised top-level key(s) %s "
-            "— snapshot may be from a different schema version; "
-            "data in those fields is lost for this load.",
-            campaign_id,
-            dropped,
-        )
-        for k in dropped:
-            del data[k]
-
-    try:
-        return Campaign.model_validate(data)
-    except ValidationError as exc:
-        raise RuntimeError(
-            f"load_campaign({campaign_id!r}): snapshot is incompatible with the "
-            f"current schema and cannot be loaded even after stripping unknown "
-            f"top-level keys.  Validation error: {exc}"
-        ) from exc
+    # Tolerant fallback: drop any top-level keys the current schema doesn't know about
+    # (removed/renamed fields from an older or newer snapshot).  We only attempt this at the TOP
+    # level of Campaign — sub-model strictness is intentionally preserved.  Per-rename migrations
+    # (old-key → new-key) are added in _tolerant_load per-release as needed; this generic net only
+    # handles field removal / unknown keys.
+    return _tolerant_load(campaign_id, raw)
 
 
 def _slots_dir(campaign_id: str) -> Path:
@@ -352,9 +462,8 @@ def list_campaigns() -> list[dict]:
         snap = d / "snapshot.json"
         if not snap.exists():
             continue
-        try:
-            c = Campaign.model_validate_json(snap.read_text(encoding="utf-8"))
-        except Exception:
+        c = _load_summary(snap)  # F08-4: tolerant-loadable campaigns stay visible to listings
+        if c is None:
             continue
         out.append({"id": c.id, "title": c.title, "updated_at": c.updated_at})
     return out
@@ -371,9 +480,8 @@ def campaigns_for_world(world_id: str) -> list[dict]:
         snap = d / "snapshot.json"
         if not snap.exists():
             continue
-        try:
-            c = Campaign.model_validate_json(snap.read_text(encoding="utf-8"))
-        except Exception:
+        c = _load_summary(snap)  # F08-4: same tolerant "loadable" definition as load_campaign
+        if c is None:
             continue
         if c.world_id == world_id:
             out.append({"id": c.id, "title": c.title, "day": c.day, "updated_at": c.updated_at})
@@ -413,9 +521,8 @@ def active_campaign_id(world_id: str = "") -> Optional[str]:
         snap = d / "snapshot.json"
         if not snap.exists():
             continue
-        try:
-            c = Campaign.model_validate_json(snap.read_text(encoding="utf-8"))
-        except Exception:
+        c = _load_summary(snap)  # F08-4: a tolerant-loadable campaign must not be skipped here —
+        if c is None:            # otherwise the #640 resolver silently picks the OTHER campaign
             continue
         if world_id and c.world_id != world_id:
             continue
@@ -431,8 +538,25 @@ def active_campaign_id(world_id: str = "") -> Optional[str]:
 def append_log(campaign_id: str, session_id: str, entry: SessionLogEntry) -> None:
     path = _campaign_dir(campaign_id) / "sessions" / f"{session_id}.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
+    # F08-5 newline-heal: if a prior append was torn (e.g. an OOM-kill mid-write left an
+    # unterminated final line with no trailing '\n'), a blind append would concatenate THIS entry
+    # onto that torn line — one physical line carrying both a broken JSON fragment and a good entry,
+    # so the poison grows and the good entry is unreadable too. Prefix a newline when the file's
+    # last byte isn't already one, fencing the torn fragment onto its own line (the reader then
+    # skips just that one line). Runs under the caller's campaign_lock, so no writer race. A fresh
+    # / empty file needs no prefix.
+    prefix = ""
+    try:
+        if path.exists() and path.stat().st_size > 0:
+            with open(path, "rb") as rf:
+                rf.seek(-1, os.SEEK_END)
+                if rf.read(1) != b"\n":
+                    prefix = "\n"
+    except OSError:
+        # Can't inspect the tail (race/permissions) — degrade to a plain append (today's behavior).
+        prefix = ""
     with open(path, "a", encoding="utf-8") as f:
-        f.write(entry.model_dump_json() + "\n")
+        f.write(prefix + entry.model_dump_json() + "\n")
 
 
 def read_log(campaign_id: str, session_id: str) -> list[SessionLogEntry]:
@@ -440,10 +564,26 @@ def read_log(campaign_id: str, session_id: str) -> list[SessionLogEntry]:
     if not path.exists():
         return []
     entries: list[SessionLogEntry] = []
+    bad = 0
     for line in path.read_text(encoding="utf-8").splitlines():
         line = line.strip()
-        if line:
+        if not line:
+            continue
+        # F08-5 reader tolerance: one TORN line (truncated mid-write by an OOM-kill, or a stray
+        # non-JSON line) must NOT brick the whole read. A single ValidationError used to raise out
+        # of read_log -> read_log_all -> recap_from_store -> start_session's recap, hand-repair the
+        # only fix. Skip the unparseable line and keep the rest; the recap/resume path stays alive.
+        # Acceptable loss: one bad entry, vs a bricked resume (the audit's explicit trade-off).
+        try:
             entries.append(SessionLogEntry.model_validate_json(line))
+        except ValidationError:
+            bad += 1
+    if bad:
+        log.warning(
+            "read_log(%s/%s): skipped %d unparseable session-log line(s) "
+            "(torn/truncated write) — continuing with the readable entries.",
+            campaign_id, session_id, bad,
+        )
     return entries
 
 

--- a/servers/engine/tests/test_store_persistence_robustness.py
+++ b/servers/engine/tests/test_store_persistence_robustness.py
@@ -1,0 +1,455 @@
+"""Tests for the F08 persistence-robustness cluster (audit ENGINE-AUDIT-2026-06-11).
+
+Covers four skeptic-verified defects in the single-writer persistence layer:
+
+* F08-2  save_campaign saves UNCONDITIONALLY on a pure read -> bumps updated_at ->
+         flips the #640 live-campaign pointer. A zero-mutation save must be a no-op
+         (no rewrite, no fresh stamp); a genuine mutation must STILL save.
+* F08-3  the tolerant load drops unknown top-level keys, then the next save destroys
+         them permanently. The tolerant path must first stash the original bytes in a
+         write-once ``snapshot.pre-tolerant.json`` and surface the dropped key names.
+* F08-4  the enumerators (list_campaigns / campaigns_for_world / active_campaign_id)
+         use the STRICT parse only, so a tolerant-loadable (unknown-key) campaign is
+         invisible to the #640 resolver and to listings. They must share the tolerant
+         loader.
+* F08-5  one torn session-log line poisons read_log / read_log_all until hand-repair.
+         The reader must skip-and-warn the torn line; append must newline-heal a file
+         whose last byte isn't a newline so the poison can't grow by concatenation.
+"""
+
+import json
+import logging
+
+import pytest
+
+import server
+import store
+from models import Campaign, SessionLogEntry
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _state(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+
+
+def _snapshot_path(tmp_path, cid: str):
+    return tmp_path / "campaigns" / cid / "snapshot.json"
+
+
+def _write_raw_snapshot(tmp_path, monkeypatch, data: dict) -> str:
+    _state(tmp_path, monkeypatch)
+    cid = data["id"]
+    snap_dir = tmp_path / "campaigns" / cid
+    snap_dir.mkdir(parents=True)
+    (snap_dir / "snapshot.json").write_text(json.dumps(data), encoding="utf-8")
+    return cid
+
+
+def _minimal_snapshot(extra: dict | None = None) -> dict:
+    c = Campaign(title="Test Campaign")
+    base = json.loads(c.model_dump_json())
+    if extra:
+        base.update(extra)
+    return base
+
+
+# ===========================================================================
+# F08-2 — pure read does NOT save / bump updated_at; a mutation DOES
+# ===========================================================================
+
+def test_pure_resave_does_not_rewrite_or_bump_updated_at(tmp_path, monkeypatch):
+    """A load -> (no mutation) -> save_campaign must be a no-op: the on-disk bytes
+    are byte-identical and updated_at is unchanged, so a pure read never flips the
+    #640 'most-recently-updated' live pointer."""
+    _state(tmp_path, monkeypatch)
+    c = Campaign(title="Pure-read campaign")
+    store.save_campaign(c)
+    path = _snapshot_path(tmp_path, c.id)
+
+    first_bytes = path.read_bytes()
+    first_mtime = path.stat().st_mtime_ns
+    first_updated = c.updated_at
+
+    # Re-load a fresh copy (as every tool does) and save it back WITHOUT mutating.
+    loaded = store.load_campaign(c.id)
+    assert loaded is not None
+    store.save_campaign(loaded)
+
+    assert path.read_bytes() == first_bytes, "pure re-save must not rewrite the snapshot"
+    assert path.stat().st_mtime_ns == first_mtime, "pure re-save must not touch the file"
+    assert loaded.updated_at == first_updated, "pure re-save must not bump updated_at"
+
+
+def test_mutating_resave_does_save_and_bumps_updated_at(tmp_path, monkeypatch):
+    """A genuine mutation must STILL save and bump updated_at — the dirty-skip guard
+    must not over-guard and drop a real write."""
+    _state(tmp_path, monkeypatch)
+    c = Campaign(title="Mutating campaign")
+    store.save_campaign(c)
+    path = _snapshot_path(tmp_path, c.id)
+    before_updated = c.updated_at
+
+    loaded = store.load_campaign(c.id)
+    assert loaded is not None
+    loaded.day = loaded.day + 1  # a real mutation
+    # Make sure wall-clock advances so updated_at strictly increases.
+    import time as _t
+    _t.sleep(0.01)
+    store.save_campaign(loaded)
+
+    on_disk = json.loads(path.read_text(encoding="utf-8"))
+    assert on_disk["day"] == c.day + 1, "a real mutation must be persisted to disk"
+    assert loaded.updated_at > before_updated, "a real mutation must bump updated_at"
+
+
+def test_pure_read_path_does_not_flip_live_pointer(tmp_path, monkeypatch):
+    """The #640 class: with two campaigns coexisting, a pure load+save of the OLDER
+    one must NOT make it the most-recently-updated (active) campaign."""
+    _state(tmp_path, monkeypatch)
+    import time as _t
+
+    a = Campaign(title="Camp A", world_id="w1")
+    store.save_campaign(a)
+    _t.sleep(0.01)
+    b = Campaign(title="Camp B", world_id="w1")
+    store.save_campaign(b)  # B is now the live (most-recently-updated) campaign
+
+    assert store.active_campaign_id("w1") == b.id
+
+    # A pure load+save of the OLDER campaign A must not steal the live pointer.
+    loaded_a = store.load_campaign(a.id)
+    assert loaded_a is not None
+    store.save_campaign(loaded_a)
+
+    assert store.active_campaign_id("w1") == b.id, (
+        "a zero-mutation save of camp A must not flip the live pointer to A"
+    )
+
+
+# ===========================================================================
+# F08-3 — tolerant load stashes original bytes write-once + surfaces dropped keys;
+#          the next save no longer destroys the unknown data irrecoverably
+# ===========================================================================
+
+def test_tolerant_load_writes_pre_tolerant_backup_once(tmp_path, monkeypatch):
+    """A tolerant load (unknown top-level key) must stash the ORIGINAL bytes in a
+    write-once ``snapshot.pre-tolerant.json`` so the dropped data is recoverable; a
+    second tolerant load must NOT create a second backup (first-skew bytes win)."""
+    _state(tmp_path, monkeypatch)
+    snapshot = _minimal_snapshot(extra={"future_field_from_newer_engine": {"x": 1}})
+    cid = _write_raw_snapshot(tmp_path, monkeypatch, snapshot)
+    original_bytes = _snapshot_path(tmp_path, cid).read_bytes()
+
+    backup = tmp_path / "campaigns" / cid / "snapshot.pre-tolerant.json"
+    assert not backup.exists()
+
+    result = store.load_campaign(cid)
+    assert result is not None
+    assert backup.exists(), "tolerant load must stash the original bytes"
+    assert backup.read_bytes() == original_bytes, "backup must be the verbatim pre-drop bytes"
+    backup_mtime = backup.stat().st_mtime_ns
+
+    # A second tolerant load must NOT clobber the first-skew backup (write-once).
+    store.load_campaign(cid)
+    assert backup.stat().st_mtime_ns == backup_mtime, "pre-tolerant backup is write-once"
+    # The valuable unknown key is still recoverable from the backup.
+    assert "future_field_from_newer_engine" in json.loads(backup.read_text(encoding="utf-8"))
+
+
+def test_tolerant_load_surfaces_dropped_keys(tmp_path, monkeypatch):
+    """The dropped key names must be observable (not log-only) so schema-evolution
+    data-loss is visible to the resume path."""
+    _state(tmp_path, monkeypatch)
+    snapshot = _minimal_snapshot(extra={"gone_key_a": 1, "gone_key_b": 2})
+    cid = _write_raw_snapshot(tmp_path, monkeypatch, snapshot)
+
+    store.load_campaign(cid)
+    dropped = store.last_dropped_keys(cid)
+    assert set(dropped) == {"gone_key_a", "gone_key_b"}
+
+
+def test_clean_load_records_no_dropped_keys_and_no_backup(tmp_path, monkeypatch):
+    """A normal (strict) load drops nothing: no pre-tolerant backup, empty dropped set."""
+    _state(tmp_path, monkeypatch)
+    c = Campaign(title="Clean")
+    store.save_campaign(c)
+    store.load_campaign(c.id)
+
+    assert store.last_dropped_keys(c.id) == []
+    assert not (tmp_path / "campaigns" / c.id / "snapshot.pre-tolerant.json").exists()
+
+
+def test_start_session_surfaces_schema_drift_on_resume(tmp_path, monkeypatch):
+    """The resume path (start_session) must SURFACE the dropped keys, not just log them —
+    so a campaign written by a different engine schema announces the data-loss at the table."""
+    _state(tmp_path, monkeypatch)
+    snapshot = _minimal_snapshot(extra={"newer_engine_field": {"x": 1}})
+    cid = _write_raw_snapshot(tmp_path, monkeypatch, snapshot)
+
+    out = server.start_session(cid)
+    assert "schema_drift" in out, "start_session must surface tolerant-load drift"
+    assert out["schema_drift"]["dropped_keys"] == ["newer_engine_field"]
+
+
+def test_start_session_no_drift_key_on_clean_campaign(tmp_path, monkeypatch):
+    """A clean (strict-loadable) campaign must NOT carry a schema_drift key (no false alarm)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Clean resume")["id"]
+    out = server.start_session(cid)
+    assert "schema_drift" not in out
+
+
+def test_backup_failure_does_not_abort_tolerant_load(tmp_path, monkeypatch, caplog):
+    """A backup-write failure must DEGRADE (log + still load), never abort the load."""
+    _state(tmp_path, monkeypatch)
+    snapshot = _minimal_snapshot(extra={"unknown_x": 1})
+    cid = _write_raw_snapshot(tmp_path, monkeypatch, snapshot)
+
+    import store as _store
+
+    def _boom(*a, **k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(_store, "_atomic_write", _boom)
+    with caplog.at_level(logging.WARNING, logger="store"):
+        result = _store.load_campaign(cid)
+    assert result is not None, "a backup failure must not brick the load"
+
+
+# ===========================================================================
+# F08-4 — enumerators see a tolerant-loadable (unknown-key) campaign
+# ===========================================================================
+
+def test_list_campaigns_includes_tolerant_loadable(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch)
+    snapshot = _minimal_snapshot(extra={"future_only_field": 1})
+    cid = _write_raw_snapshot(tmp_path, monkeypatch, snapshot)
+
+    ids = [row["id"] for row in store.list_campaigns()]
+    assert cid in ids, "list_campaigns must see a tolerant-loadable campaign"
+
+
+def test_campaigns_for_world_includes_tolerant_loadable(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch)
+    c = Campaign(title="World-scoped", world_id="w-tol")
+    snapshot = json.loads(c.model_dump_json())
+    snapshot["future_only_field"] = 1
+    cid = _write_raw_snapshot(tmp_path, monkeypatch, snapshot)
+
+    ids = [row["id"] for row in store.campaigns_for_world("w-tol")]
+    assert cid in ids, "campaigns_for_world must see a tolerant-loadable campaign"
+
+
+def test_active_campaign_id_resolves_tolerant_loadable(tmp_path, monkeypatch):
+    """The #640 resolver must not skip a tolerant-loadable campaign — otherwise the
+    live pointer silently resolves the WRONG (strict-only) campaign."""
+    _state(tmp_path, monkeypatch)
+    c = Campaign(title="Newest but tolerant", world_id="w-res")
+    snapshot = json.loads(c.model_dump_json())
+    snapshot["updated_at"] = 9_999_999_999.0  # clearly the most-recent
+    snapshot["future_only_field"] = 1
+    cid = _write_raw_snapshot(tmp_path, monkeypatch, snapshot)
+
+    assert store.active_campaign_id("w-res") == cid, (
+        "active_campaign_id must resolve the most-recent campaign even if it needs tolerant load"
+    )
+
+
+def test_enumerators_are_read_only_on_tolerant_loadable(tmp_path, monkeypatch):
+    """The enumerators must stay PURE reads: encountering a tolerant-loadable campaign must
+    NOT write the pre-tolerant backup or touch the snapshot (the 'pure reads don't write'
+    invariant — only the callable load path stashes the backup)."""
+    _state(tmp_path, monkeypatch)
+    c = Campaign(title="RO", world_id="w-ro")
+    snapshot = json.loads(c.model_dump_json())
+    snapshot["future_only_field"] = 1
+    cid = _write_raw_snapshot(tmp_path, monkeypatch, snapshot)
+    cdir = tmp_path / "campaigns" / cid
+    snap_mtime = (cdir / "snapshot.json").stat().st_mtime_ns
+
+    store.list_campaigns()
+    store.campaigns_for_world("w-ro")
+    store.active_campaign_id("w-ro")
+
+    assert not (cdir / "snapshot.pre-tolerant.json").exists(), "enumeration must not write a backup"
+    assert (cdir / "snapshot.json").stat().st_mtime_ns == snap_mtime, "enumeration must not touch the snapshot"
+
+
+def test_enumerators_skip_genuinely_corrupt(tmp_path, monkeypatch):
+    """A snapshot that is corrupt even after unknown-key stripping must still be
+    skipped (not crash the listing) — tolerance must not swallow real corruption."""
+    _state(tmp_path, monkeypatch)
+    good = Campaign(title="Good")
+    store.save_campaign(good)
+    bad_dir = tmp_path / "campaigns" / "camp-broken"
+    bad_dir.mkdir(parents=True)
+    # Missing required 'title' -> not loadable even tolerantly.
+    snap = _minimal_snapshot()
+    del snap["title"]
+    snap["id"] = "camp-broken"
+    (bad_dir / "snapshot.json").write_text(json.dumps(snap), encoding="utf-8")
+
+    ids = [row["id"] for row in store.list_campaigns()]
+    assert good.id in ids
+    assert "camp-broken" not in ids
+
+
+# ===========================================================================
+# F08-5 — torn session-log line is skipped (warn) instead of poisoning the read
+# ===========================================================================
+
+def test_read_log_skips_torn_final_line(tmp_path, monkeypatch, caplog):
+    _state(tmp_path, monkeypatch)
+    cid = "camp-torn"
+    store.append_log(cid, "s1", SessionLogEntry(t=1.0, kind="narration", text="good-1"))
+    store.append_log(cid, "s1", SessionLogEntry(t=2.0, kind="narration", text="good-2"))
+    # Simulate an OOM-killed half-write: append a truncated JSON line with no newline.
+    path = tmp_path / "campaigns" / cid / "sessions" / "s1.jsonl"
+    with open(path, "a", encoding="utf-8") as f:
+        f.write('{"t": 3.0, "kind": "narration", "text": "tor')  # torn, unterminated
+
+    with caplog.at_level(logging.WARNING, logger="store"):
+        entries = store.read_log(cid, "s1")
+    texts = [e.text for e in entries]
+    assert texts == ["good-1", "good-2"], "read_log must skip the torn line, not raise"
+
+
+def test_read_log_all_tolerates_torn_line(tmp_path, monkeypatch):
+    _state(tmp_path, monkeypatch)
+    cid = "camp-torn-all"
+    store.append_log(cid, "s1", SessionLogEntry(t=1.0, kind="narration", text="a"))
+    path = tmp_path / "campaigns" / cid / "sessions" / "s1.jsonl"
+    with open(path, "a", encoding="utf-8") as f:
+        f.write("{not even json")
+    # Must not raise.
+    texts = [e.text for e in store.read_log_all(cid, ["s1"])]
+    assert texts == ["a"]
+
+
+def test_append_heals_missing_trailing_newline(tmp_path, monkeypatch):
+    """If the last byte of an existing log isn't a newline (a torn write), the next
+    append must NOT concatenate onto it — it must newline-heal first so the poison
+    can't grow into a single line carrying both the torn entry and the good one."""
+    _state(tmp_path, monkeypatch)
+    cid = "camp-heal"
+    sessions = tmp_path / "campaigns" / cid / "sessions"
+    sessions.mkdir(parents=True)
+    path = sessions / "s1.jsonl"
+    # A torn line with NO trailing newline already on disk.
+    path.write_text('{"t": 1.0, "kind": "narration", "text": "tor', encoding="utf-8")
+
+    store.append_log(cid, "s1", SessionLogEntry(t=2.0, kind="narration", text="good"))
+
+    raw = path.read_text(encoding="utf-8")
+    lines = [ln for ln in raw.splitlines() if ln.strip()]
+    assert len(lines) == 2, f"append must newline-heal, not concatenate; got {raw!r}"
+    # The good entry must be parseable as its own line and recoverable.
+    texts = [e.text for e in store.read_log(cid, "s1")]
+    assert "good" in texts
+
+
+def test_append_to_clean_log_adds_no_extra_newline(tmp_path, monkeypatch):
+    """A normal append onto a well-terminated log must NOT inject a blank line (the
+    heal only fires when the last byte isn't already a newline)."""
+    _state(tmp_path, monkeypatch)
+    cid = "camp-clean-append"
+    store.append_log(cid, "s1", SessionLogEntry(t=1.0, kind="narration", text="a"))
+    store.append_log(cid, "s1", SessionLogEntry(t=2.0, kind="narration", text="b"))
+    path = tmp_path / "campaigns" / cid / "sessions" / "s1.jsonl"
+    raw = path.read_text(encoding="utf-8")
+    assert "\n\n" not in raw, f"no blank line on a clean append; got {raw!r}"
+    assert [e.text for e in store.read_log(cid, "s1")] == ["a", "b"]
+
+
+# ===========================================================================
+# F08-2 (tool level) — pure check_*/world_tick does NOT bump updated_at;
+#                       a mutating call DOES (the #640 live-pointer flip)
+# ===========================================================================
+
+@pytest.fixture
+def cid(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    return server.create_campaign("F08-2 World")["id"]
+
+
+def _updated_at(cid: str) -> float:
+    c = store.load_campaign(cid)
+    assert c is not None
+    return c.updated_at
+
+
+def test_check_consequences_pure_call_does_not_bump_updated_at(cid):
+    """check_consequences with nothing due is a PURE read — it must not bump updated_at
+    (which would flip the #640 live pointer onto this campaign)."""
+    before = _updated_at(cid)
+    res = server.check_consequences(cid)
+    assert res["due"] == []  # nothing scheduled -> zero mutation
+    assert _updated_at(cid) == before, "a no-op check_consequences must not bump updated_at"
+
+
+def test_check_consequences_mutating_call_does_bump_updated_at(cid):
+    """When a consequence actually fires (state mutates), the save must still land."""
+    out = server.add_consequence(cid, 2, "Reinforcements arrive.")
+    with store.campaign_lock(cid):
+        c = store.load_campaign(cid)
+        c.day = out["trigger_day"]
+        store.save_campaign(c)
+    import time as _t
+    before = _updated_at(cid)
+    _t.sleep(0.01)
+    res = server.check_consequences(cid)
+    assert len(res["due"]) == 1, "the consequence must fire (a real mutation)"
+    assert _updated_at(cid) > before, "a firing check_consequences must bump updated_at"
+
+
+def test_world_tick_repeat_same_day_does_not_bump_updated_at(cid):
+    """world_tick records its bookkeeping (``last_tick_day``) on the FIRST call of a day —
+    a genuine mutation that must save. A SECOND world_tick on the SAME day mutates nothing,
+    so it must be a true no-op (no rewrite, no updated_at bump, no live-pointer flip). This
+    is exactly why the F08-2 fix is a byte-compare chokepoint, not a blanket 'never save':
+    it distinguishes the real per-day mutation from the no-op repeat."""
+    server.world_tick(cid)  # first call: mutates last_tick_day -> saves (expected)
+    import time as _t
+    after_first = _updated_at(cid)
+    _t.sleep(0.01)
+    server.world_tick(cid)  # same day, nothing new due: a true no-op
+    assert _updated_at(cid) == after_first, "a same-day repeat world_tick must not bump updated_at"
+
+
+def test_check_companion_arc_pure_call_does_not_bump_updated_at(cid):
+    """check_companion_arc with no companions/arcs is a pure read — no updated_at bump."""
+    before = _updated_at(cid)
+    res = server.check_companion_arc(cid)
+    assert res["results"] == []
+    assert _updated_at(cid) == before, "a no-op check_companion_arc must not bump updated_at"
+
+
+def test_check_faction_arcs_pure_call_does_not_bump_updated_at(cid):
+    """check_faction_arcs with no arcs is a pure read — no updated_at bump."""
+    before = _updated_at(cid)
+    res = server.check_faction_arcs(cid)
+    assert res["results"] == []
+    assert _updated_at(cid) == before, "a no-op check_faction_arcs must not bump updated_at"
+
+
+def test_two_campaigns_pure_check_does_not_steal_live_pointer(tmp_path, monkeypatch):
+    """End-to-end #640 class: with two campaigns coexisting, calling a pure check_* on
+    the OLDER one must not make it the active (most-recently-updated) campaign."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import time as _t
+    a = server.create_campaign("Camp A")["id"]
+    _t.sleep(0.01)
+    b = server.create_campaign("Camp B")["id"]  # B is the live campaign
+    assert store.active_campaign_id() == b
+
+    # Pure inspections of the OLDER campaign (zero mutation -> must not save).
+    server.check_consequences(a)
+    server.check_companion_arc(a)
+    server.check_faction_arcs(a)
+
+    assert store.active_campaign_id() == b, (
+        "pure check_* on camp A must not flip the live pointer to A"
+    )


### PR DESCRIPTION
## What

Fixes the **P2 persistence-robustness cluster** (#804) from the WorldOS full-engine adversarial audit (2026-06-11). Four skeptic-verified defects in the single-writer persistence layer where a **pure read silently corrupted recency / dropped data / bricked resume**.

Source: `docs/audits/ENGINE-AUDIT-2026-06-11.md` (Part C, unit 08). Closes #804. Refs #640, #165, #741.

## Findings fixed

### F08-2 — pure reads flipped the #640 live-campaign pointer
`save_campaign` saved **unconditionally**. `check_consequences` / `check_companion_arc` / `check_faction_arcs` / `world_tick` — and `scene_context`, which delegates to `check_companion_arc` **every beat** — all `load → maybe-mutate → save`, so a call that mutated nothing still bumped `updated_at` and flipped the `active_campaign_id` resolver ("most-recently-updated == live") onto the *inspected* campaign. This is the silent Rolan↔Liara character-switch class.

**Fix (as filed):** a **dirty-skip chokepoint** in `save_campaign` — serialize with the *current* (pre-stamp) `updated_at`, byte-compare to the on-disk snapshot; byte-identical ⇒ return without writing or re-stamping. A genuine mutation differs ⇒ still stamps + writes (a real write is **never** dropped). Fixes all 92 call sites at the chokepoint for free. `world_tick` legitimately mutates `last_tick_day` on its first per-day call (so it saves once), then no-ops on a same-day repeat — exactly why the fix is a byte-compare, not a blanket "never save".

### F08-3 — tolerant load dropped unknown keys, next save destroyed them
The tolerant load drops unknown top-level keys then the next save rewrites current-schema-only, destroying them permanently. Now the original bytes are stashed **write-once** into `campaigns/<id>/snapshot.pre-tolerant.json` (fixed name + skip-if-exists — first-skew bytes are the valuable ones; `_atomic_write`; degrade-not-abort on backup failure), and the dropped key names are **surfaced** on the resume path (`start_session` / `start_world` resume return a `schema_drift` block) instead of being log-only.

### F08-4 — enumerators used the STRICT parse only
`list_campaigns` / `campaigns_for_world` / `active_campaign_id` used a bare strict parse, so a tolerant-loadable campaign was invisible to listings and to the #640 resolver (which then silently resolved the *other*, strict-only campaign). They now share the same tolerant loader (`_load_summary`: strict first, tolerant retry on failure) while staying **pure reads** — no backup write, no module-state mutation.

### F08-5 — one torn session-log line bricked recap/resume
A truncated final line (OOM-killed half-write) raised out of `read_log → read_log_all → recap_from_store → start_session`'s recap, hand-repair the only fix. `read_log` now **skips-and-warns** the unparseable line; `append_log` **newline-heals** when the file's last byte isn't a newline, so the poison can't grow by concatenating onto the torn fragment.

## Invariants upheld
- Engine stays **sole writer** (atomic temp + `os.replace`); pure reads do **not** save / bump `updated_at` (the whole point of this wave).
- **Additive-by-default:** old snapshots round-trip byte-identical through the chokepoint; `schema_drift` is an additive optional output field; the `pre-tolerant` sibling file is inert to every glob (`list_slots` globs `slots/*.json`; listings read `snapshot.json` by name). No schema or wire-contract change.
- This wave **reduces** per-beat write surface (no growth in `scene_context`).

## Tests
New `servers/engine/tests/test_store_persistence_robustness.py` (24, red→green):
- **F08-2:** pure `check_*` / same-day `world_tick` repeat does NOT change `updated_at` and does NOT flip the live pointer (two-campaign end-to-end); a firing `check_consequences` / first `world_tick` / any real mutation DOES still save + bump.
- **F08-3:** tolerant load writes the backup **once**, preserves the unknown key in the backup, surfaces dropped keys; `start_session` returns `schema_drift`; clean loads carry none.
- **F08-4:** enumerators see the tolerant campaign and the #640 resolver picks it; enumeration stays read-only; genuine corruption is still skipped.
- **F08-5:** torn lines are skipped not fatal in `read_log`/`read_log_all`; `append_log` newline-heals without injecting a blank line on a clean append.

## Verification
- New cluster file: **24 passed**.
- `test_store.py` + `test_slots.py` (existing persistence): **no regressions**.
- Full engine suite: **2183 passed**.
- `qa/fast_gate.sh` (Tier-0): **PASS** (188 deterministic).

DO NOT MERGE — awaiting review.