### PR TITLE
fix(engine,qa): bound canon-roster surfaces + latency ledger + real persist_beat atomicity guard (SYN-03, F13-4, F14-3)

### DIFF
--- a/qa/latency_rollup.py
+++ b/qa/latency_rollup.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Derive the F13-4 latency ledger (s_per_beat / coldopen_s / turns_per_beat) for a duo
+run from the per-beat ``*.dm.<ns>.jsonl`` transcripts the runners ALREADY write.
+
+WHY THIS EXISTS
+---------------
+#753 asks for a per-beat latency BUDGET, but ``qa/scores_db.py`` had no latency columns to
+judge a run against (audit F13-4) — and the ``worldos-latency-forensics`` skill already
+MANDATES recording ``s/beat``, ``cold-open-s``, ``turns/beat`` on every run. This module is
+the missing derivation: it reads the SDK-authoritative ``duration_api_ms`` (the model
+thinking + emitting — "the real cost", per the skill's MEASURE-FIRST method) and ``num_turns``
+out of each beat's final ``result`` event and rolls them up into the three columns, so the
+runners can stamp them with no new instrumentation.
+
+THE METHOD (matches worldos-latency-forensics)
+----------------------------------------------
+* GENERATION time per beat = the final ``result`` event's ``duration_api_ms`` (NOT
+  ``duration_ms``, which folds in tool/orchestration time — the skill is explicit that
+  ``duration_api_ms`` is authoritative and engine tool-exec is ~1–4% of a beat).
+* The COLD OPEN is the FIRST beat of a run (the one-time, max-effort world-build). Its cost
+  is reported SEPARATELY as ``coldopen_s`` and EXCLUDED from the routine ``s_per_beat`` mean —
+  mixing it in poisons the routine-beat budget (a cold open is 2–4× a routine beat).
+* ``s_per_beat`` / ``turns_per_beat`` are the MEAN over the CONTINUING (routine) beats.
+* FAILED beats (``is_error`` / non-null ``api_error_status`` — e.g. a 401) are NOT real beats
+  and are dropped from every statistic (they would otherwise deflate the means).
+
+A beat's transcript is the run's ``<run>.dm.<nanos>.jsonl`` file; the cold open is the
+EARLIEST by the nanosecond timestamp in the filename (the runners write one file per beat in
+beat order). The final ``result`` event is the authoritative one (a stream-json transcript
+emits exactly one terminal ``result``); we take the LAST ``result`` line defensively.
+
+USAGE
+-----
+    # As a CLI — point it at a run's transcript dir + run id; prints the rollup JSON:
+    python3 qa/latency_rollup.py --dir "$T" --run "$RUN"
+    python3 qa/latency_rollup.py path/to/run.dm.123.jsonl path/to/run.dm.456.jsonl
+
+    # From Python:
+    from latency_rollup import rollup_run
+    r = rollup_run(transcript_dir, run_id)   # -> {"s_per_beat", "coldopen_s",
+                                             #     "turns_per_beat", "beats", ...}
+    add_run(..., **{k: r[k] for k in ("s_per_beat", "coldopen_s", "turns_per_beat")})
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+# A beat transcript is "<run>.dm.<nanoseconds>.jsonl"; capture the nanos for beat ordering.
+_DM_RE = re.compile(r"\.dm\.(\d+)\.jsonl$")
+
+
+def _final_result(path: str | Path) -> Optional[dict]:
+    """Return the LAST ``type=="result"`` event in a stream-json transcript, or None.
+
+    Streams are large; scan line-by-line and keep the last result (the terminal one).
+    Tolerant of partial/garbage lines (a crashed beat may leave a half-written file)."""
+    last: Optional[dict] = None
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line or '"type":"result"' not in line and '"type": "result"' not in line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict) and obj.get("type") == "result":
+                    last = obj
+    except OSError:
+        return None
+    return last
+
+
+def _is_failed(res: dict) -> bool:
+    """A beat is FAILED (drop it) if the SDK flags an error result — e.g. a 401 whose
+    ``result`` text is the API error string, not a reply (SYN-01 / F13-5 class)."""
+    return bool(res.get("is_error")) or res.get("api_error_status") not in (None, "")
+
+
+def _api_seconds(res: dict) -> Optional[float]:
+    """GENERATION seconds for a beat from ``duration_api_ms``. Clamp negatives to 0 (the
+    VM parallel-segment artifact the audit flags); None when the field is absent."""
+    ms = res.get("duration_api_ms")
+    if not isinstance(ms, (int, float)):
+        return None
+    return max(0.0, float(ms) / 1000.0)
+
+
+def beat_files(transcript_dir: str | Path, run_id: str) -> list[str]:
+    """The run's per-beat DM transcripts, ordered cold-open-FIRST (ascending nanos)."""
+    pat = os.path.join(str(transcript_dir), f"{run_id}.dm.*.jsonl")
+    files = [p for p in glob.glob(pat) if _DM_RE.search(p)]
+    files.sort(key=lambda p: int(_DM_RE.search(p).group(1)))  # type: ignore[union-attr]
+    return files
+
+
+def rollup_files(files: list[str]) -> dict[str, Any]:
+    """Roll a beat-ordered list of DM transcript paths up into the latency ledger.
+
+    Returns ``{s_per_beat, coldopen_s, turns_per_beat, beats, cold_open_turns,
+    failed_beats}``. The latency columns are None when there is no data to derive them
+    from (no successful beats / no continuing beat), so an empty run records NULL rather
+    than a misleading 0."""
+    api_s: list[float] = []          # successful-beat generation seconds, in beat order
+    turns: list[float] = []          # successful-beat num_turns, in beat order
+    failed = 0
+    for path in files:
+        res = _final_result(path)
+        if res is None:
+            continue
+        if _is_failed(res):
+            failed += 1
+            continue
+        secs = _api_seconds(res)
+        n = res.get("num_turns")
+        if secs is None:
+            continue
+        api_s.append(secs)
+        turns.append(float(n) if isinstance(n, (int, float)) else 0.0)
+
+    out: dict[str, Any] = {
+        "s_per_beat": None,
+        "coldopen_s": None,
+        "turns_per_beat": None,
+        "beats": len(api_s),          # successful beats counted
+        "cold_open_turns": None,
+        "failed_beats": failed,
+    }
+    if not api_s:
+        return out
+
+    # Beat 0 is the cold open; beats 1..N are the continuing (routine) beats.
+    out["coldopen_s"] = round(api_s[0], 1)
+    out["cold_open_turns"] = turns[0]
+    routine_s = api_s[1:]
+    routine_t = turns[1:]
+    if routine_s:
+        out["s_per_beat"] = round(sum(routine_s) / len(routine_s), 1)
+        out["turns_per_beat"] = round(sum(routine_t) / len(routine_t), 1)
+    return out
+
+
+def rollup_run(transcript_dir: str | Path, run_id: str) -> dict[str, Any]:
+    """Convenience: discover a run's beat transcripts under ``transcript_dir`` and roll up."""
+    return rollup_files(beat_files(transcript_dir, run_id))
+
+
+def _main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Derive the F13-4 latency ledger from DM beat transcripts.")
+    ap.add_argument("--dir", help="transcript directory ($T) — used with --run")
+    ap.add_argument("--run", help="run id ($RUN) — used with --dir")
+    ap.add_argument("--out", help="write the rollup JSON here (also printed to stdout)")
+    ap.add_argument("files", nargs="*", help="explicit beat transcript paths (overrides --dir/--run)")
+    args = ap.parse_args(argv)
+
+    if args.files:
+        files = sorted(args.files, key=lambda p: int(m.group(1)) if (m := _DM_RE.search(p)) else 0)
+        result = rollup_files(files)
+    elif args.dir and args.run:
+        result = rollup_run(args.dir, args.run)
+    else:
+        ap.error("pass either explicit transcript files, or --dir and --run")
+        return 2
+
+    blob = json.dumps(result, indent=2)
+    if args.out:
+        Path(args.out).write_text(blob + "\n", encoding="utf-8")
+    print(blob)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -394,5 +394,15 @@ if [ "${GATE:-0}" != "0" ]; then
   clawdnd_cap_score_red "$T/$RUN.score.json" "$GATE_REASON" story
   clawdnd_cap_score_red "$T/$RUN.angrydm.json" "$GATE_REASON"
 fi
-echo "[duo] done. story-craft=$(jq -r '.overall//"?"' "$T/$RUN.tolkien.json" 2>/dev/null) mechanical=$(jq -r '.overall//"?"' "$T/$RUN.score.json" 2>/dev/null) angry-dm=$(jq -r '.overall//"?"' "$T/$RUN.angrydm.json" 2>/dev/null) behavioral=$([ "$GATE" = 0 ] && echo GREEN || echo RED)"
+# F13-4 (#753): derive the latency ledger (s_per_beat / coldopen_s / turns_per_beat) from the
+# per-beat $RUN.dm.<ns>.jsonl transcripts this run already wrote — the missing #753 budget ledger.
+# Non-fatal: a derivation hiccup must never fail an otherwise-good run. The JSON is the handoff
+# for scores_db.add_run(**{s_per_beat,coldopen_s,turns_per_beat}); the figures also print here.
+LATENCY_JSON="$T/$RUN.latency.json"
+if python3 qa/latency_rollup.py --dir "$T" --run "$RUN" --out "$LATENCY_JSON" >/dev/null 2>&1; then
+  LAT_SUMMARY="$(jq -r '"s/beat="+(.s_per_beat|tostring)+" cold-open="+(.coldopen_s|tostring)+"s turns/beat="+(.turns_per_beat|tostring)' "$LATENCY_JSON" 2>/dev/null)"
+else
+  LAT_SUMMARY="latency=unavailable"
+fi
+echo "[duo] done. story-craft=$(jq -r '.overall//"?"' "$T/$RUN.tolkien.json" 2>/dev/null) mechanical=$(jq -r '.overall//"?"' "$T/$RUN.score.json" 2>/dev/null) angry-dm=$(jq -r '.overall//"?"' "$T/$RUN.angrydm.json" 2>/dev/null) behavioral=$([ "$GATE" = 0 ] && echo GREEN || echo RED) ${LAT_SUMMARY:-}"
 exit $GATE

--- a/qa/scores_db.py
+++ b/qa/scores_db.py
@@ -104,6 +104,13 @@ COLUMNS: tuple[str, ...] = (
     "rri",                # Release-Readiness Index (0-10), NULL if not an RRI sweep
     "critical_bugs",      # count of critical bugs, NULL if not measured
     "image_render_rate",  # 0.0-1.0 image render success rate, NULL if not measured
+    # --- latency ledger (F13-4 / #753): the per-beat GENERATION cost the #753 budget is
+    # judged against. Derived from each beat's `duration_api_ms` (the worldos-latency-
+    # forensics method) by qa/latency_rollup.py. NULL on rows recorded before latency
+    # stamping (pre-F13-4 runs read back NULL — additive, migration-free). ---
+    "s_per_beat",         # mean GENERATION seconds per CONTINUING (routine) beat (cold open excluded)
+    "coldopen_s",         # cold-open (first/world-build beat) GENERATION seconds
+    "turns_per_beat",     # mean claude -p `num_turns` per CONTINUING beat (ToolSearch / round-trip proxy)
     "pass",               # 1 (pass) / 0 (fail) / NULL (no pass/fail verdict)
     "source_path",        # where the evidence lives (file/dir, LEXAR or repo-relative)
     "notes",              # free-text context: what was under test, caveats, confidence flags
@@ -113,6 +120,8 @@ COLUMNS: tuple[str, ...] = (
 _REAL_COLS = {
     "story_overall", "mech_overall", "angrydm_overall", "cross_persona_sat",
     "rri", "image_render_rate",
+    # F13-4 latency ledger (all wall-clock seconds / turn counts → REAL)
+    "s_per_beat", "coldopen_s", "turns_per_beat",
 }
 _INT_COLS = {"critical_bugs", "pass"}
 
@@ -278,6 +287,9 @@ _MD_COLS = [
     ("rri", "RRI"),
     ("critical_bugs", "Crit"),
     ("image_render_rate", "Img%"),
+    ("s_per_beat", "s/beat"),
+    ("coldopen_s", "cold-open s"),
+    ("turns_per_beat", "turns/beat"),
     ("pass", "Pass"),
     ("source_path", "Source"),
     ("notes", "Notes"),

--- a/qa/test_latency_rollup.py
+++ b/qa/test_latency_rollup.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tests for qa/latency_rollup.py — the F13-4 latency-ledger derivation.
+
+Pure-stdlib; builds synthetic stream-json DM beat transcripts so the rollup is verified
+against KNOWN inputs (independent of the gitignored qa/transcripts/* fixtures). Run with:
+    uv run --directory servers/engine python -m pytest qa/test_latency_rollup.py -q -p no:xdist
+or:
+    python3 -m pytest qa/test_latency_rollup.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+QA_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(QA_DIR))
+
+import latency_rollup  # noqa: E402
+
+
+def _write_beat(d: Path, run: str, nanos: int, *, api_ms, num_turns=1,
+                is_error=False, api_error_status=None, with_field=True):
+    """Write a minimal stream-json transcript whose terminal result event carries the
+    given duration_api_ms / num_turns (the only fields the rollup reads)."""
+    res = {"type": "result", "subtype": "success", "is_error": is_error,
+           "api_error_status": api_error_status, "duration_ms": (api_ms or 0) + 3000,
+           "num_turns": num_turns, "result": "prose"}
+    if with_field and api_ms is not None:
+        res["duration_api_ms"] = api_ms
+    path = d / f"{run}.dm.{nanos}.jsonl"
+    lines = [
+        json.dumps({"type": "system", "subtype": "init"}),
+        json.dumps({"type": "assistant", "message": {"content": "…"}}),
+        json.dumps(res),
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_cold_open_separated_from_routine_mean(tmp_path):
+    run = "duo-r"
+    # beat 0 (cold open): 240s / 18 turns. beats 1-3 (routine): 100/80/120s, 4/3/5 turns.
+    _write_beat(tmp_path, run, 1000, api_ms=240000, num_turns=18)
+    _write_beat(tmp_path, run, 2000, api_ms=100000, num_turns=4)
+    _write_beat(tmp_path, run, 3000, api_ms=80000, num_turns=3)
+    _write_beat(tmp_path, run, 4000, api_ms=120000, num_turns=5)
+    r = latency_rollup.rollup_run(tmp_path, run)
+    assert r["coldopen_s"] == 240.0           # the first beat, reported separately
+    assert r["s_per_beat"] == 100.0           # mean(100,80,120) — cold open EXCLUDED
+    assert r["turns_per_beat"] == 4.0         # mean(4,3,5)
+    assert r["beats"] == 4 and r["failed_beats"] == 0
+
+
+def test_beats_ordered_by_filename_nanos_not_glob_order(tmp_path):
+    # The cold open is the EARLIEST nanosecond timestamp even if written/globbed out of order.
+    run = "duo-o"
+    _write_beat(tmp_path, run, 5000, api_ms=90000, num_turns=4)    # routine, later
+    _write_beat(tmp_path, run, 1000, api_ms=300000, num_turns=20)  # COLD OPEN, earliest
+    _write_beat(tmp_path, run, 3000, api_ms=110000, num_turns=6)   # routine, middle
+    r = latency_rollup.rollup_run(tmp_path, run)
+    assert r["coldopen_s"] == 300.0                 # nanos=1000 beat, not the first globbed
+    assert r["s_per_beat"] == 100.0                 # mean(90,110)
+
+
+def test_failed_beats_are_excluded(tmp_path):
+    # A 401-class failed beat (is_error / api_error_status) is dropped from every statistic.
+    run = "duo-f"
+    _write_beat(tmp_path, run, 1000, api_ms=200000, num_turns=10)               # cold open
+    _write_beat(tmp_path, run, 2000, api_ms=100000, num_turns=4)                # routine OK
+    _write_beat(tmp_path, run, 3000, api_ms=1164, num_turns=1, is_error=True)   # 401, drop
+    _write_beat(tmp_path, run, 4000, api_ms=0, num_turns=1, api_error_status="401")  # drop
+    _write_beat(tmp_path, run, 5000, api_ms=120000, num_turns=6)               # routine OK
+    r = latency_rollup.rollup_run(tmp_path, run)
+    assert r["failed_beats"] == 2
+    assert r["beats"] == 3                          # cold open + 2 good routine beats
+    assert r["s_per_beat"] == 110.0                 # mean(100,120) — the failed beats gone
+
+
+def test_single_cold_open_only_yields_null_routine(tmp_path):
+    # A run with ONLY a cold open (no continuing beat) records coldopen_s but NULL routine
+    # stats — never a misleading 0.
+    run = "duo-1"
+    _write_beat(tmp_path, run, 1000, api_ms=180000, num_turns=12)
+    r = latency_rollup.rollup_run(tmp_path, run)
+    assert r["coldopen_s"] == 180.0
+    assert r["s_per_beat"] is None and r["turns_per_beat"] is None
+    assert r["beats"] == 1
+
+
+def test_empty_run_is_all_null(tmp_path):
+    r = latency_rollup.rollup_run(tmp_path, "no-such-run")
+    assert r["coldopen_s"] is None and r["s_per_beat"] is None
+    assert r["turns_per_beat"] is None and r["beats"] == 0
+
+
+def test_missing_duration_api_ms_beat_is_skipped(tmp_path):
+    # A beat whose result lacks duration_api_ms can't be costed — skip it (don't crash).
+    run = "duo-m"
+    _write_beat(tmp_path, run, 1000, api_ms=200000, num_turns=10)        # cold open
+    _write_beat(tmp_path, run, 2000, api_ms=None, with_field=False, num_turns=4)  # no api_ms
+    _write_beat(tmp_path, run, 3000, api_ms=100000, num_turns=5)         # routine
+    r = latency_rollup.rollup_run(tmp_path, run)
+    assert r["beats"] == 2                           # the no-api_ms beat dropped
+    assert r["s_per_beat"] == 100.0
+
+
+def test_negative_api_ms_clamped_to_zero(tmp_path):
+    # VM parallel-segment artifact: a negative/oversized api split clamps at 0 (audit caveat).
+    run = "duo-n"
+    _write_beat(tmp_path, run, 1000, api_ms=200000, num_turns=10)
+    _write_beat(tmp_path, run, 2000, api_ms=-5000, num_turns=3)
+    r = latency_rollup.rollup_run(tmp_path, run)
+    assert r["s_per_beat"] == 0.0                    # clamped, not negative
+
+
+def test_cli_writes_out_json(tmp_path, capsys):
+    run = "duo-cli"
+    _write_beat(tmp_path, run, 1000, api_ms=240000, num_turns=18)
+    _write_beat(tmp_path, run, 2000, api_ms=100000, num_turns=4)
+    out = tmp_path / "lat.json"
+    rc = latency_rollup._main(["--dir", str(tmp_path), "--run", run, "--out", str(out)])
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["coldopen_s"] == 240.0 and data["s_per_beat"] == 100.0

--- a/qa/test_scores_db.py
+++ b/qa/test_scores_db.py
@@ -84,6 +84,48 @@ def test_pass_bool_coerced_to_int(tmp_path):
     assert scores_db.fetch_rows(db)[0]["pass"] == 1
 
 
+# --- F13-4: the latency ledger columns (s_per_beat / coldopen_s / turns_per_beat) ---
+
+def test_latency_columns_are_registered_and_real(tmp_path):
+    # The three F13-4 columns exist, are REAL-typed, and round-trip a write.
+    for col in ("s_per_beat", "coldopen_s", "turns_per_beat"):
+        assert col in scores_db.COLUMNS, f"{col} missing from COLUMNS"
+        assert scores_db._coltype(col) == "REAL"
+    db = tmp_path / "t.db"
+    scores_db.add_run(
+        "duo-lat", db_path=db, surface="engine-duo",
+        s_per_beat=80.5, coldopen_s=174.0, turns_per_beat=4.3,
+    )
+    row = scores_db.fetch_rows(db)[0]
+    assert row["s_per_beat"] == 80.5
+    assert row["coldopen_s"] == 174.0
+    assert row["turns_per_beat"] == 4.3
+
+
+def test_latency_columns_read_null_on_pre_f134_rows(tmp_path):
+    # ADDITIVITY: a row recorded WITHOUT the latency fields (a pre-F13-4 run) reads back
+    # NULL for all three — the new columns never break an old write.
+    db = tmp_path / "t.db"
+    scores_db.add_run("duo-old", db_path=db, surface="engine-duo", story_overall=4.1)
+    row = scores_db.fetch_rows(db)[0]
+    assert row["s_per_beat"] is None
+    assert row["coldopen_s"] is None
+    assert row["turns_per_beat"] is None
+
+
+def test_latency_columns_alter_into_an_old_db(tmp_path):
+    # A db created before F13-4 (no latency columns) gets them ALTER-added on connect.
+    db = tmp_path / "old.db"
+    conn = sqlite3.connect(db)
+    conn.execute('CREATE TABLE runs ("run_id" TEXT PRIMARY KEY, "surface" TEXT, "story_overall" REAL)')
+    conn.commit()
+    conn.close()
+    conn = scores_db.connect(db)
+    cols = {r["name"] for r in conn.execute("PRAGMA table_info(runs)")}
+    conn.close()
+    assert {"s_per_beat", "coldopen_s", "turns_per_beat"} <= cols
+
+
 def test_render_markdown_contains_header_and_rows(tmp_path):
     db = tmp_path / "t.db"
     md = tmp_path / "led.md"

--- a/qa/vm/sweep_v2.sh
+++ b/qa/vm/sweep_v2.sh
@@ -188,6 +188,9 @@ fi
 note "3-lens duo..."
 timeout 3600 bash qa/run_duo.sh vm2-duo baldurs-gate veteran 8 5.00 > "$RES/duo.log" 2>&1
 for f in tolkien angrydm; do s="qa/transcripts/vm2-duo.$f.json"; [ -f "$s" ] && cp "$s" "$RES/duo-$f.json" && note "  $f overall=$(python3 -c "import json;print(json.load(open('$s')).get('overall'))" 2>/dev/null)"; done
+# F13-4 (#753): carry the duo's derived latency ledger into the sweep results so scores_db
+# can stamp s_per_beat/coldopen_s/turns_per_beat (the #753 budget ledger). run_duo wrote it.
+LAT="qa/transcripts/vm2-duo.latency.json"; [ -f "$LAT" ] && cp "$LAT" "$RES/duo-latency.json" && note "  latency $(python3 -c "import json;d=json.load(open('$LAT'));print('s/beat=%s cold-open=%ss turns/beat=%s'%(d.get('s_per_beat'),d.get('coldopen_s'),d.get('turns_per_beat')))" 2>/dev/null)"
 DCOMB="qa/transcripts/vm2-duo.combined.jsonl"; DSTATE="qa/transcripts/vm2-duo.state.json"
 [ -f "$DCOMB" ] && { python3 qa/assert_behavioral.py "$DCOMB" "$DSTATE" > "$RES/behavioral.log" 2>&1; echo "rc=$?" >> "$RES/behavioral.log"; note "behavioral rc=$(tail -1 "$RES/behavioral.log")"; }
 aport=8861; lsof -ti:$aport 2>/dev/null | xargs kill -9 2>/dev/null

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -8,6 +8,7 @@ hook becomes the opening quest. The DM skill then reads the scenes and runs play
 
 from __future__ import annotations
 
+import difflib
 import json
 import random
 import re
@@ -153,7 +154,10 @@ def is_dead_record(rec: dict) -> bool:
 
 
 def list_canon_characters(
-    world_id: str, playable_only: bool = False, alive_only: "bool | None" = None
+    world_id: str,
+    playable_only: bool = False,
+    alive_only: "bool | None" = None,
+    name_contains: str = "",
 ) -> list[dict]:
     """The ingested canon characters available for a world — {name, race, class,
     playable, role} each — from content/worlds/<id>/characters/*.json. De-duplicated by
@@ -164,9 +168,15 @@ def list_canon_characters(
     picked up as the PC — #305). It defaults to follow `playable_only`: the player-facing
     "who can I play?" surface (`playable_only=True`) is alive-only, while a raw inventory
     (`playable_only=False`) lists the dead too unless the caller asks otherwise. Pass it
-    explicitly to override."""
+    explicitly to override.
+
+    `name_contains` (SYN-03) is a case-insensitive substring filter on the display name —
+    `""` (the default) filters nothing, so the unfiltered call is byte-identical to before.
+    It is the engine-side query that lets the `list_canon_characters` tool bound the
+    180KB+ flagship roster (2,076 records) instead of dumping it whole."""
     if alive_only is None:
         alive_only = playable_only
+    needle = name_contains.strip().lower()
     out: list[dict] = []
     seen: set[str] = set()
     for cdir in _characters_dirs(world_id):
@@ -179,6 +189,8 @@ def list_canon_characters(
                 continue
             nm = (rec.get("name") or p.stem).strip()
             if nm.lower() in seen:
+                continue
+            if needle and needle not in nm.lower():
                 continue
             playable = is_playable(rec)
             if playable_only and not playable:
@@ -194,6 +206,37 @@ def list_canon_characters(
                 "role": rec.get("role", ""),
             })
     return out
+
+
+def suggest_canon_names(
+    world_id: str, query: str, limit: int = 5, playable_only: bool = False
+) -> "tuple[list[str], int]":
+    """Resolve-then-suggest helper for a canon-character MISS (SYN-03): return
+    ``(did_you_mean, available_count)`` — up to `limit` candidate NAMES for `query`
+    plus the total roster size — NEVER the whole roster.
+
+    Mirrors ``itemcatalog.suggest``: case-insensitive substring matches first
+    (ranked shortest-name-first so a tight hit like "Minsc" beats "Minsc and Boo"),
+    then a ``difflib.get_close_matches`` fuzzy fallback over the full name list for a
+    typo'd query. `playable_only` scopes the suggestions to pickup-eligible figures
+    (the `start_character` pickup miss); `False` (default) suggests across the whole
+    cast (the `load_canon_character` npc/companion miss). Names only — the lightweight
+    payload for an error dict, so a 2,076-record world's miss stays a sub-2KB reply."""
+    roster = list_canon_characters(world_id, playable_only=playable_only)
+    names = [r["name"] for r in roster]
+    total = len(names)
+    q = (query or "").strip().lower()
+    if not q:
+        return ([], total)
+    subs = sorted(
+        (n for n in names if q in n.lower()),
+        key=lambda n: (len(n), n.lower()),
+    )[:limit]
+    if subs:
+        return (subs, total)
+    # No substring hit — a typo or a wrong name. difflib over the full name list.
+    fuzzy = difflib.get_close_matches(query, names, n=limit, cutoff=0.6)
+    return (fuzzy, total)
 
 
 def find_canon_characters(

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1736,9 +1736,27 @@ def start_character(
         c0 = _require(campaign_id)
         rec = content_mod.load_canon_character(c0.world_id, who) if c0.world_id else None
         if rec is None:
-            avail = [x["name"] for x in (content_mod.list_canon_characters(c0.world_id, playable_only=True) if c0.world_id else [])]
-            return {"error": f"no canon character {who!r} for world {c0.world_id!r}", "playable": avail}
+            # SYN-03: resolve-then-suggest scoped to PICKUP-ELIGIBLE figures — never dump
+            # the whole playable roster as the error payload. Keep the `error` key.
+            did_you_mean, count = (
+                content_mod.suggest_canon_names(c0.world_id, who, playable_only=True)
+                if c0.world_id else ([], 0)
+            )
+            return {
+                "error": f"no canon character {who!r} for world {c0.world_id!r}",
+                "playable": True,
+                "did_you_mean": did_you_mean,
+                "available_count": count,
+                "note": "list_canon_characters(playable_only=True, q=…) to search pickups.",
+            }
         if not content_mod.is_playable(rec):
+            # A real figure, just not a pickup. Suggest a FEW pickup-eligible alternatives
+            # near the requested name (or the roster head when there's nothing close) —
+            # not the whole playable list.
+            did_you_mean, count = (
+                content_mod.suggest_canon_names(c0.world_id, who, playable_only=True)
+                if c0.world_id else ([], 0)
+            )
             return {
                 "error": (
                     f"{rec.get('name', who)!r} is a legend of this era — they appear as an "
@@ -1746,7 +1764,9 @@ def start_character(
                     f"load_canon_character to encounter them in the world."
                 ),
                 "playable": False,
-                "playable_options": [x["name"] for x in (content_mod.list_canon_characters(c0.world_id, playable_only=True) if c0.world_id else [])],
+                "did_you_mean": did_you_mean,
+                "available_count": count,
+                "note": "list_canon_characters(playable_only=True, q=…) to search pickups.",
             }
         resolved = f"pickup:{rec.get('name', who)}"
         pickup_canon_name = str(rec.get("name", who) or who)  # match the roster by canon identity
@@ -2540,20 +2560,52 @@ def get_character(campaign_id: str, character_id: str = "", target_id: str = "",
 
 
 @mcp.tool()
-def list_canon_characters(campaign_id: str, playable_only: bool = False) -> dict:
-    """Who's available to pull into THIS world from the ingested canon roster (the
-    post-BG3 cast — Shadowheart, Astarion, Gale, …). Returns {name, race, class,
-    playable, role} each. Use load_canon_character to bring one in as an NPC/companion.
+def list_canon_characters(
+    campaign_id: str, playable_only: bool = False, q: str = "", limit: int = 100
+) -> dict:
+    """Who's available to pull into THIS world from the ingested canon roster. Use
+    load_canon_character to bring one in as an NPC/companion.
 
-    The top heroes of the era (the BG3 origin companions) are `playable: false` — they
-    remain legends/quest-givers/encounterable NPCs but are NOT a hero the player embodies.
-    Pass `playable_only=True` for just the minor figures a player may pick up as their PC
-    via start_character(origin="pickup:<name>")."""
+    The flagship world ships a LARGE roster (the post-BG3 wiki-first ingest is ~2,000
+    canon records), so this surface is BOUNDED: filter with `q` and page with `limit`
+    instead of dumping the whole cast (~180KB) every call. For a STRUCTURED pull
+    ("the merchant in this region", "a Harper", "an antagonist") reach for `find_npcs`
+    (tags / faction / role / location) — it is the precise picker.
+
+      * `q`      — case-insensitive substring of the display name (e.g. "shadow",
+                   "minsc"). Empty (default) lists the roster head.
+      * `limit`  — max rows returned (default 100, capped at 200). When more match than
+                   fit, `truncated` is True and `note` points at `find_npcs`/`q`.
+
+    Returns ``{world_id, total, returned, available:[{name, race, class, playable,
+    role}], truncated, note?}`` — `total` is the full match count, `available` the
+    bounded page. The top heroes of the era (the BG3 origin companions) are
+    `playable: false` — legends/quest-givers/encounterable NPCs, not a hero the player
+    embodies; pass `playable_only=True` for just the minor figures a player may pick up
+    as their PC via start_character(origin="pickup:<name>")."""
     c = _require(campaign_id)
-    return {
+    if not c.world_id:
+        return {"world_id": "", "total": 0, "returned": 0, "available": [], "truncated": False}
+    n = max(1, min(int(limit), 200))
+    matches = content_mod.list_canon_characters(
+        c.world_id, playable_only=playable_only, name_contains=q
+    )
+    total = len(matches)
+    page = matches[:n]
+    out = {
         "world_id": c.world_id,
-        "available": content_mod.list_canon_characters(c.world_id, playable_only=playable_only) if c.world_id else [],
+        "total": total,
+        "returned": len(page),
+        "available": page,
+        "truncated": total > len(page),
     }
+    if out["truncated"]:
+        out["note"] = (
+            f"{total} canon characters match; showing {len(page)}. Narrow with q=… "
+            f"(name substring) or use find_npcs(tag/faction_id/arc_role/canon_location_id) "
+            f"for a structured pull."
+        )
+    return out
 
 
 @mcp.tool()
@@ -2625,8 +2677,19 @@ def load_canon_character(campaign_id: str, name: str = "", kind: str = "npc", ad
         c = _require(campaign_id)
         rec = content_mod.load_canon_character(c.world_id, name) if c.world_id else None
         if rec is None:
-            avail = [x["name"] for x in (content_mod.list_canon_characters(c.world_id) if c.world_id else [])]
-            return {"error": f"no canon character {name!r} for world {c.world_id!r}", "available": avail}
+            # SYN-03: resolve-then-suggest — NEVER dump the whole roster (180KB on the
+            # flagship world). load_canon_character already does exact + unique-substring
+            # resolution, so a miss here is a typo or a wrong name: offer up-to-5
+            # did_you_mean names + the roster size, keep the `error` key (play.sh reads it).
+            did_you_mean, count = (
+                content_mod.suggest_canon_names(c.world_id, name) if c.world_id else ([], 0)
+            )
+            return {
+                "error": f"no canon character {name!r} for world {c.world_id!r}",
+                "did_you_mean": did_you_mean,
+                "available_count": count,
+                "note": "list_canon_characters(q=…) to search the roster.",
+            }
         canonical = rec.get("name", name)
         # HARD GATE (#305): a canon-DEAD figure (a corpse like Dal Lightspark, whose lineage
         # opens "a dead gold dwarven Harper whose corpse is in the Shadow-Cursed Lands") may

--- a/servers/engine/tests/test_beat_roundtrip.py
+++ b/servers/engine/tests/test_beat_roundtrip.py
@@ -456,12 +456,20 @@ def test_persist_beat_does_not_advance_clock_during_combat(cid):
 
 
 def _session_log_lines(cid: str) -> list:
-    """Every session-log entry across the campaign (to assert atomic non-application)."""
+    """Every session-log entry across the campaign, read DISK-FIRST (atomicity guard).
+
+    Uses ``store.read_log_all`` (which walks every ``sessions/*.jsonl`` on disk, INCLUDING
+    files not yet registered in the persisted ``session_ids``), NOT a ``read_log`` over
+    ``session_ids`` only. That distinction is load-bearing for the F14-3 atomicity guard
+    below: a NON-atomic persist_beat appends an event to disk and THEN raises (before
+    ``save_campaign``), leaving the orphan file on disk but NOT in the persisted
+    ``session_ids``. A ``session_ids``-only reader would miss that orphan and report a
+    FALSE GREEN (the prior version of this helper did exactly that — the cellar-rats
+    fixture opens no session, so the leaked beat's session id was never persisted and the
+    test passed even against the buggy apply-before-validate code). read_log_all's
+    defensive disk tail witnesses the leaked row, so the guard can actually fail red."""
     c = store.load_campaign(cid)
-    entries = []
-    for sid in c.session_ids:
-        entries.extend(store.read_log(cid, sid))
-    return entries
+    return list(store.read_log_all(cid, getattr(c, "session_ids", None)))
 
 
 def test_persist_beat_chosen_null_does_not_crash(cid):
@@ -501,18 +509,40 @@ def test_persist_beat_bad_memory_id_is_actionable_not_bare_keyerror(cid):
 
 
 def test_persist_beat_events_not_applied_when_later_section_fails(cid):
-    # ATOMICITY (events-only window, F14-3): a good event + a bad memory item must
-    # leave ZERO new session-log rows — validation precedes the first append_log.
-    char = _a_char(cid)
-    before = len(_session_log_lines(cid))
+    """ATOMICITY guard for the F14-3 events-only window — a REAL red→green test.
+
+    A persist_beat with a GOOD events section but a section that FAILS validation AFTER it
+    (a bad memories id) must leave ZERO new session-log rows: the whole batch is validated
+    BEFORE the first ``append_log``, so the events leg is never half-applied (a crash
+    mid-batch otherwise leaves an orphan chronicle row that a retry then duplicates).
+
+    This drives the atomicity path the prior version did NOT:
+      * a session is OPENED FIRST (start_session), so a leaked event lands in a session that
+        IS on disk AND registered — the orphan is observable to any reader, not hidden by an
+        unpersisted session_ids list (the false-green the old fixture created);
+      * the count is taken via read_log_all (disk tail), which sees a leaked row even if the
+        save that would register its session never happens.
+
+    Proof it would FAIL a non-atomic implementation: the OLD persist_beat appended the event
+    to the session jsonl IMMEDIATELY (events → _log_session_entry → append_log), THEN
+    validated memories — so against that code this asserts the leaked "ORPHAN …" row, the
+    count goes up by one, and the test goes RED. Verified by hand-reproducing the
+    apply-before-validate interleave (event written to disk, then the bad id raises): the
+    disk tail shows before→before+1 while a session_ids-only read shows before→before. Only
+    the validate-then-apply HEAD code keeps the count flat. """
+    server.start_session(cid)  # open a session so a leaked event row is on the persisted path
+    orphan = "ORPHAN row that must NEVER persist when a later section fails."
+    before = _session_log_lines(cid)
+    n_before = len(before)
     with pytest.raises(Exception):
         server.persist_beat(
             cid,
-            events=[{"kind": "narration", "text": "This line must NOT persist."}],
+            events=[{"kind": "narration", "text": orphan}],
             memories=[{"character_id": "no-such-id", "fact": "x"}],
         )
-    after = len(_session_log_lines(cid))
-    assert after == before  # the events leg was NOT applied
+    after = _session_log_lines(cid)
+    assert len(after) == n_before  # the events leg was NOT applied (no orphan row)
+    assert all(orphan not in (e.text or "") for e in after)  # specifically, the orphan text never landed
 
 
 def test_persist_beat_event_text_alias_honored(cid):

--- a/servers/engine/tests/test_content.py
+++ b/servers/engine/tests/test_content.py
@@ -563,19 +563,46 @@ def test_start_world_echoes_chosen_ending(tmp_path, monkeypatch):
 def test_list_canon_characters_playable_filter(tmp_path, monkeypatch):
     monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
     cid = server.start_world("baldurs-gate")["campaign_id"]
-    allc = server.list_canon_characters(cid)["available"]
-    names = {x["name"] for x in allc}
-    # every record now reports a playable flag; the seven origin heroes are NOT playable
-    assert {"Astarion", "Gale", "Karlach", "Lae'zel", "Shadowheart", "Wyll", "Halsin"} <= names
-    by_name = {x["name"]: x for x in allc}
-    assert by_name["Astarion"]["playable"] is False and by_name["Astarion"]["role"] == "hero"
-    assert by_name["Minsc"]["playable"] is True
+    # SYN-03: the surface is BOUNDED — the unfiltered call no longer dumps all ~2,076
+    # records; it returns a `limit`-capped page with a `{total, returned, truncated}`
+    # envelope. Query the heroes by name (`q`) instead of scanning the whole roster.
+    full = server.list_canon_characters(cid)
+    assert full["total"] > full["returned"] and full["truncated"] is True
+    assert full["returned"] == len(full["available"]) == 100  # default page
+    assert "note" in full and "find_npcs" in full["note"]
+    for hero in ("Astarion", "Gale", "Karlach", "Lae'zel", "Shadowheart", "Wyll", "Halsin"):
+        hit = server.list_canon_characters(cid, q=hero)["available"]
+        by_name = {x["name"]: x for x in hit}
+        assert hero in by_name, f"{hero} should be findable via q="
+    assert server.list_canon_characters(cid, q="Astarion")["available"][0]["playable"] is False
+    minsc = {x["name"]: x for x in server.list_canon_characters(cid, q="Minsc")["available"]}
+    assert minsc["Minsc"]["playable"] is True
     # the playable-only filter keeps just the minor figures a player can pick up;
     # the original four plus the three new caster-party additions (Rolan, Lia, Isobel)
-    play = {x["name"] for x in server.list_canon_characters(cid, playable_only=True)["available"]}
-    assert {"Jaheira", "Minsc", "Withers", "Jergal"} <= play  # original minor figures present
-    assert {"Rolan", "Lia", "Isobel"} <= play              # new caster-party figures present
-    assert "Astarion" not in play and "Gale" not in play
+    for figure in ("Jaheira", "Minsc", "Withers", "Jergal", "Rolan", "Lia", "Isobel"):
+        play = {x["name"] for x in server.list_canon_characters(cid, playable_only=True, q=figure)["available"]}
+        assert figure in play
+    # a hero is never in the PLAYABLE slice even when queried by name
+    assert "Astarion" not in {
+        x["name"] for x in server.list_canon_characters(cid, playable_only=True, q="Astarion")["available"]
+    }
+
+
+def test_list_canon_characters_envelope_and_query(tmp_path, monkeypatch):
+    # SYN-03: the bounded envelope on the flagship roster — {total, returned, truncated},
+    # a working `q` substring filter, and a `limit` that pages without losing the total.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.start_world("baldurs-gate")["campaign_id"]
+    capped = server.list_canon_characters(cid, limit=10)
+    assert capped["returned"] == len(capped["available"]) == 10
+    assert capped["total"] > 10 and capped["truncated"] is True
+    # q narrows the TOTAL, not just the page
+    sh = server.list_canon_characters(cid, q="shadow")
+    assert sh["total"] >= 1 and all("shadow" in r["name"].lower() for r in sh["available"])
+    assert sh["total"] < capped["total"]  # a substring search is a strict subset
+    # limit is hard-capped at 200 even if a caller asks for more
+    big = server.list_canon_characters(cid, limit=99999)
+    assert big["returned"] <= 200
 
 
 def test_roster_surface_excludes_origins_and_filters():
@@ -671,7 +698,10 @@ def test_start_character_pickup_rejects_hero_accepts_minor(tmp_path, monkeypatch
     ph = server.start_character(cid, origin="pickup:Astarion")
     assert "error" in ph and ph["playable"] is False
     assert "legend" in ph["error"].lower() and "npc" in ph["error"].lower()
-    assert "Minsc" in ph["playable_options"]  # points the player at who they CAN pick up
+    # SYN-03: suggests a FEW pickup-eligible names (did_you_mean), never the whole list
+    assert isinstance(ph["did_you_mean"], list) and len(ph["did_you_mean"]) <= 5
+    assert ph["available_count"] > 5  # the roster is large; we did NOT dump it
+    assert "playable_options" not in ph  # the old full-list key is gone
     # the heroes remain encounterable as NPCs — load_canon_character(kind="npc") is
     # unrestricted (they're already seeded into the world roster by start_world)
     assert server.load_canon_character(cid, "Astarion", kind="npc").get("id") == "npc-astarion"
@@ -1671,16 +1701,16 @@ def test_new_origins_appear_in_list_origin_templates():
 
 
 def test_new_characters_appear_in_list_canon_characters(tmp_path, monkeypatch):
-    """Rolan, Lia, and Isobel are discoverable as playable canon characters."""
+    """Rolan, Lia, and Isobel are discoverable as playable canon characters.
+    (SYN-03: the roster is now bounded, so look them up by `q` rather than scanning
+    the capped head of the ~2,000-record list.)"""
     monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
     cid = server.start_world("baldurs-gate")["campaign_id"]
-    chars = server.list_canon_characters(cid)["available"]
-    names = {c["name"] for c in chars}
-    for expected in ("Rolan", "Lia", "Isobel"):
-        assert expected in names, f"{expected} missing from list_canon_characters"
-    by_name = {c["name"]: c for c in chars}
-    # These are minor figures (playable: true, role: "")
     for who in ("Rolan", "Lia", "Isobel"):
+        chars = server.list_canon_characters(cid, q=who)["available"]
+        by_name = {c["name"]: c for c in chars}
+        assert who in by_name, f"{who} missing from list_canon_characters(q={who!r})"
+        # These are minor figures (playable: true, role: "")
         assert by_name[who]["playable"] is True, f"{who} must be playable"
         assert by_name[who].get("role", "") == "", f"{who} role must be empty"
 
@@ -1886,3 +1916,111 @@ def test_seed_world_propagates_rumoured_and_never_overrides_with_discovered_defa
 
     both = c.locations["loc-both"]
     assert both.rumoured is True and both.discovered is True  # explicit author values both honored
+
+
+# ── SYN-03: canon-roster surfaces are BOUNDED + misses resolve-then-suggest ──
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (SYN-03 / F10-3 + F13-2 + F13-3 + F14-1).
+# A 2,076-record flagship roster was returned WHOLE (180KB) by list_canon_characters and
+# DUMPED AS THE ERROR PAYLOAD (28KB) on a load_canon_character miss. These tests pin the
+# additive limit/name_contains filter + the resolve-then-suggest miss path against a
+# synthetic large roster, so the contract is verified independent of the shipped BG data.
+
+
+def _synth_roster_world(root, world_id="synthville", n=300):
+    """Write `n` canon-character JSON records into a tmp content dir and return its id.
+    Records are Hero 0..n with a couple of known names ('Minsc and Boo', 'Shadowmaiden')
+    so the resolve-then-suggest paths have something deterministic to match."""
+    cdir = root / "worlds" / world_id / "characters"
+    cdir.mkdir(parents=True, exist_ok=True)
+    for i in range(n):
+        rec = {"name": f"Hero {i:03d}", "race": "Human", "class": "Fighter",
+               "playable": (i % 2 == 0)}
+        (cdir / f"hero-{i:03d}.json").write_text(json.dumps(rec), encoding="utf-8")
+    # two named anchors for substring / fuzzy resolution
+    (cdir / "minsc-and-boo.json").write_text(
+        json.dumps({"name": "Minsc and Boo", "race": "Human", "class": "Ranger", "playable": True}),
+        encoding="utf-8")
+    (cdir / "shadowmaiden.json").write_text(
+        json.dumps({"name": "Shadowmaiden", "race": "Elf", "class": "Cleric", "playable": True}),
+        encoding="utf-8")
+    return world_id
+
+
+def test_list_canon_characters_name_contains_is_additive(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_CONTENT_DIR", str(tmp_path / "content"))
+    wid = _synth_roster_world(tmp_path / "content")
+    # default (no filter) is byte-identical to before: the full 302-record list
+    full = content.list_canon_characters(wid)
+    assert len(full) == 302
+    # name_contains is a case-insensitive substring filter
+    minsc = content.list_canon_characters(wid, name_contains="minsc")
+    assert [r["name"] for r in minsc] == ["Minsc and Boo"]
+    heroes = content.list_canon_characters(wid, name_contains="Hero 01")
+    assert len(heroes) == 10 and all("Hero 01" in r["name"] for r in heroes)
+
+
+def test_suggest_canon_names_substring_then_fuzzy(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_CONTENT_DIR", str(tmp_path / "content"))
+    wid = _synth_roster_world(tmp_path / "content")
+    # a "Minsc" query is a SUBSTRING of "Minsc and Boo" — resolves by substring, ≤5, total reported
+    sugg, total = content.suggest_canon_names(wid, "Minsc")
+    assert sugg == ["Minsc and Boo"] and total == 302
+    # a typo'd query with no substring hit falls back to difflib fuzzy
+    fuzzy, _ = content.suggest_canon_names(wid, "Shadowmaidn")
+    assert "Shadowmaiden" in fuzzy and len(fuzzy) <= 5
+    # playable_only scopes BOTH the suggestions and the count. Hero 001 is non-playable
+    # (odd index), so a playable-only "Hero 001" query never surfaces it.
+    play, ptotal = content.suggest_canon_names(wid, "Hero 001", playable_only=True)
+    assert "Hero 001" not in play and ptotal < total  # the playable subset is smaller
+    # an even-indexed hero IS playable and resolves under playable_only
+    play2, _ = content.suggest_canon_names(wid, "Hero 002", playable_only=True)
+    assert "Hero 002" in play2
+
+
+def _campaign_on_synth_world(tmp_path, monkeypatch):
+    """A live campaign whose `world_id` points at the synthetic 300-record roster — built
+    without a full world.json (the canon tools only read the world's characters dir).
+
+    The campaign is created against the REAL bundled content (cellar-rats adventure), then
+    CONTENT_DIR is redirected to the synthetic roster so the canon-character reads resolve
+    there. Ordering matters: redirecting first would hide the cellar-rats adventure data."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path / "state"))
+    cid = server.start_adventure("cellar-rats")["campaign_id"]
+    monkeypatch.setenv("WORLDOS_CONTENT_DIR", str(tmp_path / "content"))
+    wid = _synth_roster_world(tmp_path / "content")
+    with server.campaign_lock(cid):
+        c = server._require(cid)
+        c.world_id = wid
+        server.save_campaign(c)
+    return cid
+
+
+def test_canon_miss_payload_is_small_and_suggestive(tmp_path, monkeypatch):
+    # The flagship-class regression: a miss must NOT serialize the whole roster.
+    cid = _campaign_on_synth_world(tmp_path, monkeypatch)
+    miss = server.load_canon_character(cid, "Nonexistent Person")
+    assert "error" in miss  # play.sh reads this key — preserved
+    assert "available" not in miss  # the old full-roster dump key is GONE
+    assert isinstance(miss["did_you_mean"], list) and len(miss["did_you_mean"]) <= 5
+    assert miss["available_count"] == 302  # tells the DM the roster size without listing it
+    blob = json.dumps(miss)
+    assert len(blob) < 2048, f"miss payload should be <2KB, got {len(blob)}B"
+
+
+def test_canon_miss_resolves_substring_class_before_suggesting(tmp_path, monkeypatch):
+    # "Minsc" should RESOLVE (load_canon_character's unique-substring step), not miss.
+    cid = _campaign_on_synth_world(tmp_path, monkeypatch)
+    hit = server.load_canon_character(cid, "Minsc")
+    assert hit.get("name") == "Minsc and Boo" and "error" not in hit
+
+
+def test_start_character_pickup_miss_suggests_not_dumps(tmp_path, monkeypatch):
+    # SYN-03: the start_character pickup miss must suggest, never dump the playable roster.
+    cid = _campaign_on_synth_world(tmp_path, monkeypatch)
+    miss = server.start_character(cid, origin="pickup:Shadowmaidn")  # typo
+    assert "error" in miss and miss["playable"] is True
+    assert "did_you_mean" in miss and len(miss["did_you_mean"]) <= 5
+    assert "Shadowmaiden" in miss["did_you_mean"]  # fuzzy-resolved
+    assert "playable" in miss and isinstance(miss["available_count"], int)
+    assert miss["available_count"] > 5  # large roster, NOT dumped
+    assert len(json.dumps(miss)) < 2048

--- a/servers/engine/tests/test_spatial_xp.py
+++ b/servers/engine/tests/test_spatial_xp.py
@@ -69,8 +69,11 @@ def test_end_combat_auto_awards_xp_in_xp_mode(cid):
 def test_load_canon_character_pulls_real_identity(cid):
     # the BG canon roster is ingested (content/worlds/baldurs-gate/characters/*.json, S2.5)
     c = store.load_campaign(cid); c.world_id = "baldurs-gate"; store.save_campaign(c)
-    names = {a["name"] for a in server.list_canon_characters(cid)["available"]}
-    assert {"Shadowheart", "Astarion"} <= names
+    # SYN-03: the roster surface is bounded — query by name rather than scanning the
+    # capped head of the ~2,000-record list.
+    for who in ("Shadowheart", "Astarion"):
+        names = {a["name"] for a in server.list_canon_characters(cid, q=who)["available"]}
+        assert who in names
     res = server.load_canon_character(cid, "Shadowheart", kind="companion", add_to_party=True)
     assert "error" not in res, res
     sheet = server.get_character(cid, res["id"])


### PR DESCRIPTION
Three coherent measurement + roster + test-quality fixes from the 2026-06-11 engine audit. All additive, frozen-wire-safe, sole-writer-preserving. **Do not merge** — for review.

**Source:** `docs/audits/ENGINE-AUDIT-2026-06-11.md`
Closes #783 · Refs #753, #316, #847

---

## (1) SYN-03 — canon-roster surfaces were unbounded (`#783`, F10-3+F13-2+F13-3+F14-1)

On the flagship world (2,076 canon records since the wiki-first ingest):
- `list_canon_characters` returned **all records verbatim** (~180KB / ~45K tokens; 8 of 249 calling transcripts hit hard MCP-cap errors).
- a `load_canon_character` **miss dumped the whole roster** as the 28KB error payload — the harness offloaded it to a tool-results file and the DM burned ~5–9 Read/grep round-trips paging it back inside the cold-open give-up band.

**Fix (additive, read-only, the `error` key preserved):**
- `list_canon_characters` gains `q` (name substring) + `limit` (default 100, cap 200) and a `{world_id, total, returned, available, truncated, note?}` envelope. `find_npcs`' `limit:int=50` and `roster_surface`'s `{total,returned}` are the in-file precedents. Small worlds (`<=limit`) are **byte-identical**; only the large flagship roster is now paged (where the full dump was already an error).
- **resolve-then-suggest on every miss** (`load_canon_character` + `start_character` pickup-miss + not-playable case): `did_you_mean` (substring → `difflib.get_close_matches`, ≤5) + `available_count`, **never** the full list. New `content.suggest_canon_names(...)` mirrors `itemcatalog.suggest`; `content.list_canon_characters` gains an additive `name_contains` filter (default `""` → unchanged).
- Consumers (`scripts/play_codex_dm.sh`, `qa/ui_playtest_app.sh`) read `available` for PC selection and still get 100 playable candidates — robust to the bound.

Verified against the real BG roster: `suggest_canon_names("Shadowhart")` (typo) → `Shadowheart` in <2KB.

Cross-link: **#316 is the viewer half** (Roster screen pool count) — viewer untouched here.

## (2) F13-4 — no latency ledger for the `#753` budget (enriches `#753`)

`qa/scores_db.py` had no latency columns, so the `#753` per-beat budget had nothing to be judged against — and the `worldos-latency-forensics` skill already **mandates** recording `s/beat`, `cold-open-s`, `turns/beat` on every run.

**Fix (additive, migration-free):**
- `scores_db.py`: `+s_per_beat` / `+coldopen_s` / `+turns_per_beat` (REAL). `_ensure_schema` ALTER-adds them; **pre-F13-4 rows read back NULL**.
- new **`qa/latency_rollup.py`** derives them from each beat's existing `duration_api_ms` (the skill's authoritative GENERATION metric) + `num_turns`: cold open = first beat (reported separately, **excluded** from the routine mean); failed/401 beats dropped; negative VM splits clamped at 0.
- wired `qa/run_duo.sh` (emits `$RUN.latency.json` + prints `s/beat=…`) and `qa/vm/sweep_v2.sh` (copies `duo-latency.json`) — where the `.dm.<ns>.jsonl` data already exists. Validated against a real run: cold-open 257.5s, s/beat 138.4, turns/beat 5.7.

## (3) TEST-QUALITY — false-green atomicity test (hardens the just-merged F14-3 `#847`)

`test_persist_beat_events_not_applied_when_later_section_fails` **passed on buggy main AND post-fix**: the `cellar-rats` fixture opens no session, so a leaked event row's session id was never persisted and the `session_ids`-only helper never witnessed it.

**Rewrite into a real red→green guard:** open a session first (the orphan lands on the persisted path) and count via `read_log_all` (disk tail). `_session_log_lines` now reads disk-first so it can't blind future atomicity tests.

**Proven** by hand-reproducing the apply-before-validate interleave:
| | raised | count flat | no orphan | test |
|---|---|---|---|---|
| buggy (apply→validate) | ✓ | ✗ (before→before+1) | ✗ | **RED** |
| HEAD (validate→apply) | ✓ | ✓ | ✓ | **GREEN** |

---

## Tests
- engine suite: **2,165 passed** (`uv run --directory servers/engine python -m pytest -q -p no:xdist`)
- scores_db + latency: **46 passed** (`test_scores_db.py`, `test_scores_db_comparability.py`, `test_latency_rollup.py`)
- Tier-0 fast gate: **PASS** (188 deterministic)
- New tests: SYN-03 (`test_list_canon_characters_envelope_and_query`, `test_suggest_canon_names_substring_then_fuzzy`, `test_canon_miss_payload_is_small_and_suggestive`, `test_canon_miss_resolves_substring_class_before_suggesting`, `test_start_character_pickup_miss_suggests_not_dumps`, `test_list_canon_characters_name_contains_is_additive`); F13-4 (`test_latency_columns_*` ×3, `test_*` ×8 in `test_latency_rollup.py`); test-quality rewrite.
- Updated for the bounded contract (in-scope, same finding's surface): `test_list_canon_characters_playable_filter`, `test_new_characters_appear_in_list_canon_characters`, `test_start_character_pickup_rejects_hero_accepts_minor`, `test_load_canon_character_pulls_real_identity`.

## Invariants
Engine sole-writer untouched; reads stay reads (no `save_campaign`/`updated_at` bump). Additive: `_StrictModel` round-trip safe, new params default to today's behavior, scores_db columns ALTER-add. Token-mass **reduced** (roster + roster-as-error). Frozen wire (`error`/`available` keys preserved). `qa/scores.db` deliberately not committed (schema migration is idempotent on next real use).