### PR TITLE
fix(engine): character-progression integrity cluster — ASI/feat debt, CON-HP retro, recompute-refill, resource drift, seat census (Refs #794)

### DIFF
--- a/data/srd/class_features.json
+++ b/data/srd/class_features.json
@@ -279,8 +279,8 @@
     "16": [{"name": "Ability Score Improvement", "desc": "Increase one ability score by 2 or two by 1 (max 20), or take a feat."}],
     "17": [{"name": "Sneak Attack (9d6)", "desc": "Your Sneak Attack damage increases; subclass feature gained.", "sneak_attack_dice": "9d6"}],
     "18": [{"name": "Elusive", "desc": "No attack roll has advantage against you while you aren't incapacitated."}],
-    "19": [{"name": "Ability Score Improvement", "desc": "Increase one ability score by 2 or two by 1 (max 20), or take a feat."}],
-    "20": [{"name": "Stroke of Luck", "desc": "Turn a missed attack into a hit or a failed check into a 20 once per short or long rest.", "sneak_attack_dice": "10d6"}]
+    "19": [{"name": "Ability Score Improvement", "desc": "Increase one ability score by 2 or two by 1 (max 20), or take a feat."}, {"name": "Sneak Attack (10d6)", "desc": "Your Sneak Attack damage increases to 10d6.", "sneak_attack_dice": "10d6"}],
+    "20": [{"name": "Stroke of Luck", "desc": "Turn a missed attack into a hit or a failed check into a 20 once per short or long rest."}]
   },
   "sorcerer": {
     "1": [

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -715,6 +715,17 @@ class Character(_StrictModel):
     # progression
     xp: int = 0
     features: list[str] = Field(default_factory=list)  # class/subclass features gained
+    # Feats taken at ASI levels (Great Weapon Master, Sentinel, …). The engine doesn't yet
+    # model every feat's mechanics, but a chosen feat is now RECORDED on a structured ledger
+    # the DM/viewer surface (the feat path used to be 100% inert — buried only in `notes`).
+    # ADDITIVE: [] == today's behavior; old snapshots round-trip (audit F02-3).
+    feats: list[str] = Field(default_factory=list)
+    # OUTSTANDING build choices owed to the character but not yet settled — e.g. an ASI/feat
+    # that was DUE at a level-up but neither was supplied ("ASI/feat due: Fighter level 4"),
+    # or an Expertise/Fighting-Style pick. Recorded so a skipped choice is recoverable instead
+    # of silently lost; settled by update_character / a later level_up. ADDITIVE: [] == today's
+    # behavior; old snapshots round-trip (audit F02-3 / F02-15).
+    pending_choices: list[str] = Field(default_factory=list)
     extra_attacks: int = 0  # extra attacks per Attack action (Extra Attack feature)
     sneak_attack_dice: str = ""  # e.g. "3d6" (rogue Sneak Attack), "" if none
     # A defensive REACTION that adds this many points to AC against ONE melee attack that

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1197,6 +1197,20 @@ def _class_level_hp(class_name: str, level: int, con_mod: int) -> "int | None":
     return max(1, die + con_mod + (lvl - 1) * per_level_after_first)
 
 
+def _expertise_count(class_name: str, level: int) -> int:
+    """How many skills carry EXPERTISE (double proficiency) for a single-class character of
+    `class_name` at `level`, per SRD 5.2. Rogue: 2 at L1, 4 at L6. Bard: 2 at L2, 4 at L9.
+    Every other class: 0. Pure — drives the F02-15 default-fill so an engine-built rogue's
+    expertise math is correct out of the box (a real build choice the DM can refine later)."""
+    cname = (class_name or "").lower()
+    lvl = max(1, int(level)) if str(level).lstrip("-").isdigit() else 1
+    if cname == "rogue":
+        return 4 if lvl >= 6 else 2
+    if cname == "bard":
+        return 4 if lvl >= 9 else (2 if lvl >= 2 else 0)
+    return 0
+
+
 def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool) -> None:
     """Fill SRD class defaults onto a character in place: saving-throw proficiencies,
     hit dice, level-1 HP (max die + CON), proficiency bonus, class base AC (when
@@ -1264,6 +1278,18 @@ def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool
                 explicit = [s for s in pool if s != "any" and s in SKILL_ABILITIES]
                 pool = explicit + [s for s in SKILL_ABILITIES if s not in explicit]
             ch.skill_proficiencies = pool[: int(sk.get("count", 0))]
+        # F02-15: a class that grants EXPERTISE (rogue L1/L6, bard L2/L9) had NO engine grant
+        # path — every engine-built rogue's expertise-skill math was short by PB (skill_bonus pays
+        # 2xPB only from skill_expertise, which only update_character's `expertise` alias ever
+        # wrote). Default-fill the expertise picks from the character's OWN proficiencies (so they
+        # always map to a real skill), mirroring the skill default-fill above. Only fills an
+        # otherwise-empty list, so a hand-authored / DM-chosen expertise set is respected. The
+        # actual chosen skills are a build choice the DM/optimizer can later refine via
+        # update_character — this just makes the rogue mechanically correct out of the box.
+        if not ch.skill_expertise:
+            exp_n = _expertise_count(cname, level)
+            if exp_n > 0:
+                ch.skill_expertise = list(ch.skill_proficiencies[:exp_n])
         _recompute_spellcasting(ch)
         _seed_starting_spells(ch, cname, level)
         _recompute_class_resources(ch)
@@ -1271,7 +1297,7 @@ def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool
         pass  # unknown class -> keep the explicit values
 
 
-def _recompute_level_scaled_stats(ch, patch: dict) -> None:
+def _recompute_level_scaled_stats(ch, patch: dict, prior_hit_dice_remaining: "int | None" = None) -> None:
     """OVERWRITE the purely level-derived stats — proficiency bonus, hit dice, max HP, and
     extra attacks — to match ``ch.classes`` after a class/level change, so a DOWN-level retier
     (a canon L12 Fighter patched to L3) does NOT keep the higher tier's inflated math.
@@ -1293,7 +1319,15 @@ def _recompute_level_scaled_stats(ch, patch: dict) -> None:
         if single_class and "hit_dice" not in keys:
             ch.hit_dice = f"{total}d{srd_tables.hit_die(cname)}"
             if "hit_dice_remaining" not in keys:
-                ch.hit_dice_remaining = min(ch.hit_dice_remaining, total)
+                # F02-5: cap the SPENT pool against the new total — never REFILL it. The caller
+                # passes the pre-recompute remaining because _apply_srd_class_defaults ran first
+                # and unconditionally reset hit_dice_remaining to `level` (which would refund every
+                # spent die on a stat/level patch). Fall back to the current value when no prior
+                # was supplied (the level_up path keeps its own +1 accounting).
+                spent_basis = (prior_hit_dice_remaining
+                               if prior_hit_dice_remaining is not None
+                               else ch.hit_dice_remaining)
+                ch.hit_dice_remaining = max(0, min(spent_basis, total))
         if single_class and "max_hp" not in keys:
             recomputed = _class_level_hp(cname, total, ch.ability_modifier(Ability.CON))
             if recomputed:
@@ -1781,6 +1815,19 @@ def start_character(
                 "available_count": count,
                 "note": "list_canon_characters(playable_only=True, q=…) to search pickups.",
             }
+        # HARD GATE (F02-8, mirrors load_canon_character's #305 player gate): a canon-DEAD figure
+        # may be a lore NPC but must NEVER be seated as the PLAYER — the prestige-CRPG framing
+        # breaks if the PC's canon-truth is "dead and rotting". pickup only checked is_playable
+        # (a flag that defaults True), never is_dead_record — so a playable-but-dead record slipped
+        # through. Return the same {"error", "dead_in_canon"} shape so play.sh falls back to a living pick.
+        if content_mod.is_dead_record(rec):
+            return {
+                "error": (f"{rec.get('name', who)} is dead in canon and cannot be the player "
+                          f"character — pick a living figure (list_canon_characters("
+                          f"playable_only=True) lists only living, playable figures)."),
+                "dead_in_canon": True,
+                "name": rec.get("name", who),
+            }
         resolved = f"pickup:{rec.get('name', who)}"
         pickup_canon_name = str(rec.get("name", who) or who)  # match the roster by canon identity
         build["name"] = name or rec.get("name", who)
@@ -1848,6 +1895,17 @@ def start_character(
                     ch, cn, lvl, set_base_ac=(int(build["armor_class"]) == 10),
                     rec_abilities=(rec or {}).get("abilities"),
                     backfill_abilities=not build["abilities"])
+            # F02-8: promoting a roster STUB to the PLAYER must clear any stale death state — a
+            # bare identity stub (max_hp=1) can be flagged dead/stable after one combat hit, and
+            # seating a dead PC deadlocks the facade (the PC can't act, can't long_rest). Mirrors
+            # recruit_companion's clear. Guarded on living HP so this never resurrects a 0-HP record.
+            if ch.current_hp > 0 and (ch.dead or ch.stable or ch.death_saves.successes
+                                      or ch.death_saves.failures):
+                ch.dead = False
+                ch.stable = False
+                ch.death_saves = DeathSaves()
+                ch.conditions = [cond for cond in ch.conditions if cond != Condition.UNCONSCIOUS]
+            ch.met = True  # an active player is, by convention, met
             if ch.id not in c.party:
                 c.party.append(ch.id)
             save_campaign(c)
@@ -2055,10 +2113,12 @@ def reroll_character(
          record is KEPT in `characters` (a memorial — the fallen hero the world remembers).
       4. Add the new PC to the party as the sole `kind=="player"`.
 
-    Gear and gold are LOST with the body by default — a new character earns their own kit
-    (use `add_item`/`adjust_currency` if the fiction lets the party loot the corpse). HOW
-    the new hero arrives in the world is the DM's narration, not this tool's job. On a
-    party WIPE, call this once per fallen member (there is no separate batch tool).
+    The DEAD PC's gear and gold are LOST with the body — they stay on the corpse, never
+    transferred to the new hero (use `add_item`/`adjust_currency` if the fiction lets the party
+    loot it). The new character is seated with their OWN class-appropriate starting kit (a modest
+    purse + the armor/weapon that justify their AC), at the party's current location. HOW the new
+    hero arrives in the world is the DM's narration, not this tool's job. On a party WIPE, call
+    this once per fallen member (there is no separate batch tool).
 
     Returns ``{new_pc: {id, name, kind, level, in_party}, memorial: {id, name, now_kind}}``.
     """
@@ -2096,11 +2156,23 @@ def reroll_character(
             else [],
             abilities=scores,
             initiative_bonus=scores.modifier(Ability.DEX),
+            # F02-12: seat the new hero IN THE SCENE — at the party's current location, not a
+            # null location_id that only the next travel would fix (a just-rerolled PC was shown
+            # a scene behind the party). met=True for consistency (a player is implicitly met —
+            # create_character sets it; the model comment documents the convention).
+            location_id=c.current_location_id,
+            met=True,
         )
         if skills:  # explicit skill choices win over the class default-fill
             new.skill_proficiencies = [s.lower() for s in skills if s.lower() in SKILL_ABILITIES]
         if class_name:
-            _apply_srd_class_defaults(new, class_name, lvl, set_base_ac=True)
+            # F02-12: route through the shared seat finisher so the new hero's AC is BACKED by a
+            # real kit (the old path set an armored class_base_ac over an empty inventory — AC 16
+            # with no armor). The "gear lost with the body" rule applies to the DEAD PC's loot;
+            # the new character still earns their own starting kit (the docstring says so), so AC
+            # and inventory AGREE. backfill only when no explicit abilities were passed.
+            _finish_seat_sheet(new, class_name, lvl, set_base_ac=True,
+                               backfill_abilities=not abilities, seed_gear=True)
 
         # KEYSTONE — demote the corpse off kind=="player" so the facade stops resolving it,
         # and remove it from the party. Keep the record in `characters` as a memorial (it
@@ -2981,9 +3053,16 @@ def update_character(campaign_id: str, character_id: str = "", patch: dict = Non
         old_sig = [(cl.name.lower(), cl.level, (cl.subclass or "")) for cl in ch.classes]
         new_sig = [(cl.name.lower(), cl.level, (cl.subclass or "")) for cl in new_ch.classes]
         if old_sig != new_sig and new_ch.classes:
+            # F02-5: a class/level retier must re-derive the POOL SIZE (hit_dice string scales
+            # to the new level) but must NOT silently refill a previously-SPENT pool. Capture the
+            # pre-recompute remaining BEFORE _apply_srd_class_defaults unconditionally resets it
+            # to `level`, so _recompute_level_scaled_stats can cap against the spent count (a DM
+            # who patched a brand-new full-pool record still gets `min(spent, total)` == today).
+            prior_hit_dice_remaining = new_ch.hit_dice_remaining
             _apply_srd_class_defaults(new_ch, new_ch.classes[0].name,
                                       new_ch.total_level, set_base_ac=False)
-            _recompute_level_scaled_stats(new_ch, patch or {})
+            _recompute_level_scaled_stats(new_ch, patch or {},
+                                          prior_hit_dice_remaining=prior_hit_dice_remaining)
         # #733: keep initiative_bonus == DEX modifier when a patch changes the DEX score.
         # Every engine write derives initiative_bonus from the DEX modifier (create_character,
         # level_up's ASI path, the canon-load derivation), but update_character — the path a DM
@@ -2996,6 +3075,20 @@ def update_character(campaign_id: str, character_id: str = "", patch: dict = Non
         dex_changed = ch.ability_modifier(Ability.DEX) != new_ch.ability_modifier(Ability.DEX)
         if dex_changed and "initiative_bonus" not in (patch or {}):
             new_ch.initiative_bonus = new_ch.ability_modifier(Ability.DEX)
+        # F02-6: a CON change retro-adjusts max HP by the CON-modifier DELTA across every level
+        # the character has (raising CON grants +1 HP per level; a corrective drop removes them,
+        # floored at 1). Delta-based — it respects a DM-authored HP base and a multiclass sheet
+        # rather than re-deriving from scratch. Skipped when the SAME patch set max_hp explicitly
+        # (a DM-chosen HP wins) or already recomputed the class math above (a class-sig retier
+        # re-derives max_hp from the new total_level, which already reflects the new CON).
+        con_changed = ch.ability_modifier(Ability.CON) != new_ch.ability_modifier(Ability.CON)
+        class_sig_changed = old_sig != new_sig and new_ch.classes
+        if (con_changed and "max_hp" not in (patch or {}) and not class_sig_changed
+                and new_ch.total_level > 0):
+            con_delta = new_ch.ability_modifier(Ability.CON) - ch.ability_modifier(Ability.CON)
+            hp_delta = con_delta * new_ch.total_level
+            new_ch.max_hp = max(1, new_ch.max_hp + hp_delta)
+            new_ch.current_hp = max(1, min(new_ch.current_hp, new_ch.max_hp))
         c.characters[character_id] = new_ch
         save_campaign(c)
         return c.characters[character_id].model_dump(mode="json")
@@ -5280,12 +5373,13 @@ def level_up(
             raise ValueError(f"{class_name} level {new_class_level} does not grant an ASI or feat choice")
 
         die = srd_tables.hit_die(cname)
-        con = ch.ability_modifier(Ability.CON)
-        if hp_method == "roll":
-            base = hp_roll if hp_roll is not None else dice_mod.roll(f"1d{die}", seed=seed).total
-        else:
-            base = srd_tables.average_hp(die)
-        gain = max(1, base + con)
+
+        # F02-6: apply a CON-raising ASI BEFORE sizing this level's HP so the new level
+        # uses the POST-ASI CON (the SRD intent — a +CON at this level adds HP at this
+        # level too), and so we can retro-adjust the prior levels by the CON-mod delta.
+        # `con_before` is captured here; `applied`/abilities mutate just below.
+        con_before = ch.ability_modifier(Ability.CON)
+        prior_total_level = ch.total_level  # levels the character ALREADY had before this one
 
         # Normalize a chosen subclass to its canonical SRD name when the table knows
         # it ('Evocation' -> 'Evoker'); an unknown/world-canon name passes through
@@ -5306,14 +5400,8 @@ def level_up(
         else:
             ch.classes.append(ClassLevel(name=class_name.capitalize(), level=1, subclass=subclass))
 
-        ch.max_hp += gain
-        ch.current_hp += gain
-        ch.hit_dice_remaining += 1
-        # keep the hit_dice string in sync (single-class; was left stale after level_up)
-        if len({cl.name.lower() for cl in ch.classes}) == 1:
-            ch.hit_dice = f"{sum(cl.level for cl in ch.classes)}d{die}"
-
         applied = None
+        pending_choice_recorded = False
         if is_asi_level:
             if pending_asi:
                 for ability, inc in pending_asi.items():
@@ -5321,7 +5409,39 @@ def level_up(
                 applied = {"asi": pending_asi}
             elif feat:
                 applied = {"feat": feat}
+                # F02-3: record the chosen feat on a STRUCTURED ledger the DM/viewer can read,
+                # not just buried in free-text notes (the feat path was 100% inert). The note
+                # line stays for back-compat; `feats` is the surface the engine/viewer key off.
+                if feat not in ch.feats:
+                    ch.feats.append(feat)
                 ch.notes = (ch.notes + f" | feat: {feat}").strip(" |")
+            else:
+                # F02-3: an ASI/feat was DUE this level but NEITHER was supplied. Previously
+                # this choice was silently dropped and no surface ever offered it again. RECORD
+                # the debt on the pending-choice ledger so the DM (or update_character) can
+                # settle it later. Additive: a level-up that DOES take the choice records nothing.
+                label = f"ASI/feat due: {class_name.capitalize()} level {new_class_level}"
+                if label not in ch.pending_choices:
+                    ch.pending_choices.append(label)
+                pending_choice_recorded = True
+
+        # F02-6: now that any CON-raising ASI has landed, size THIS level's HP with the
+        # POST-ASI CON, and retro-adjust the HP already banked at the prior levels by the
+        # CON-modifier delta (raising CON grants +1 HP per level you already have; lowering it
+        # via a corrective drop removes them, floored so HP never goes < 1).
+        con_after = ch.ability_modifier(Ability.CON)
+        if hp_method == "roll":
+            base = hp_roll if hp_roll is not None else dice_mod.roll(f"1d{die}", seed=seed).total
+        else:
+            base = srd_tables.average_hp(die)
+        gain = max(1, base + con_after)
+        con_retro = (con_after - con_before) * prior_total_level
+        ch.max_hp = max(1, ch.max_hp + gain + con_retro)
+        ch.current_hp = max(1, ch.current_hp + gain + con_retro)
+        ch.hit_dice_remaining += 1
+        # keep the hit_dice string in sync (single-class; was left stale after level_up)
+        if len({cl.name.lower() for cl in ch.classes}) == 1:
+            ch.hit_dice = f"{sum(cl.level for cl in ch.classes)}d{die}"
 
         ch.proficiency_bonus = srd_tables.proficiency_bonus(ch.total_level)
         ch.initiative_bonus = ch.ability_modifier(Ability.DEX)
@@ -5353,12 +5473,29 @@ def level_up(
             if f.get("sneak_attack_dice"):
                 ch.sneak_attack_dice = f["sneak_attack_dice"]
 
+        # F02-14: in XP leveling mode, WARN (never block — the engine stays the sole writer and
+        # the DM may have a reason) when the character isn't yet XP-entitled to the level they
+        # just took. Milestone campaigns level by story beat, so the check is xp-mode-only.
+        # `prior_total_level` is the level BEFORE this up; entitlement is by current xp.
+        xp_warning = None
+        if c.leveling_mode == "xp":
+            entitled = srd_tables.level_for_xp(ch.xp)
+            new_total = ch.total_level
+            if new_total > entitled:
+                xp_warning = (
+                    f"{ch.name} leveled to {new_total} but has only enough XP for level "
+                    f"{entitled} ({ch.xp} XP). Award XP first (award_xp/award_party_xp) or set "
+                    f"house_rules / leveling_mode='milestone' if leveling by story beat."
+                )
+
         c.characters[character_id] = Character.model_validate(ch.model_dump(mode="json"))
         save_campaign(c)
         sheet = c.characters[character_id].model_dump(mode="json")
         sheet["_hp_gained"] = gain
         sheet["_asi_applied"] = applied
         sheet["_features_gained"] = gained
+        sheet["_pending_choice_recorded"] = pending_choice_recorded
+        sheet["_xp_warning"] = xp_warning
         return sheet
 
 
@@ -5451,12 +5588,11 @@ def preview_level_up(
             errors.append(f"does not meet the multiclass prerequisite for {class_name}")
 
     die = srd_tables.hit_die(cname)
-    con = preview.ability_modifier(Ability.CON)
-    if hp_method == "roll":
-        base = hp_roll if hp_roll is not None else dice_mod.roll(f"1d{die}", seed=seed).total
-    else:
-        base = srd_tables.average_hp(die)
-    gain = max(1, base + con)
+    # F02-6 (preview/actual parity): mirror level_up — apply a CON-raising ASI BEFORE sizing
+    # this level's HP, and retro-adjust the prior levels by the CON-mod delta, so the previewed
+    # hp_gain/max_hp match what level_up will actually write.
+    con_before = preview.ability_modifier(Ability.CON)
+    prior_total_level = preview.total_level
 
     if existing:
         existing.level += 1
@@ -5466,12 +5602,6 @@ def preview_level_up(
     else:
         preview.classes.append(ClassLevel(name=class_name.capitalize(), level=1, subclass=subclass))
         new_class_level = 1
-
-    preview.max_hp += gain
-    preview.current_hp += gain
-    preview.hit_dice_remaining += 1
-    if len({cl.name.lower() for cl in preview.classes}) == 1:
-        preview.hit_dice = f"{sum(cl.level for cl in preview.classes)}d{die}"
 
     if srd_tables.is_asi_level(cname, new_class_level):
         choice_requirements.append(
@@ -5495,6 +5625,19 @@ def preview_level_up(
                 applied = {"feat": feat}
     elif asi or feat:
         errors.append(f"{class_name} level {new_class_level} does not grant an ASI or feat choice")
+
+    con_after = preview.ability_modifier(Ability.CON)
+    if hp_method == "roll":
+        base = hp_roll if hp_roll is not None else dice_mod.roll(f"1d{die}", seed=seed).total
+    else:
+        base = srd_tables.average_hp(die)
+    gain = max(1, base + con_after)
+    con_retro = (con_after - con_before) * prior_total_level
+    preview.max_hp = max(1, preview.max_hp + gain + con_retro)
+    preview.current_hp = max(1, preview.current_hp + gain + con_retro)
+    preview.hit_dice_remaining += 1
+    if len({cl.name.lower() for cl in preview.classes}) == 1:
+        preview.hit_dice = f"{sum(cl.level for cl in preview.classes)}d{die}"
 
     preview.proficiency_bonus = srd_tables.proficiency_bonus(preview.total_level)
     preview.initiative_bonus = preview.ability_modifier(Ability.DEX)

--- a/servers/engine/srd_tables.py
+++ b/servers/engine/srd_tables.py
@@ -318,6 +318,24 @@ def _rage_uses(level: int) -> int:
     return n
 
 
+def _second_wind_uses(level: int) -> int:
+    # SRD 5.2 Fighter: Second Wind has 2 uses at L1, 3 at L4, 4 at L10.
+    if level >= 10:
+        return 4
+    if level >= 4:
+        return 3
+    return 2 if level >= 1 else 0
+
+
+def _wild_shape_uses(level: int) -> int:
+    # SRD 5.2 Druid: 2 uses at L2, 3 at L6, 4 at L17 — kept (does NOT drop) at L20.
+    if level >= 17:
+        return 4
+    if level >= 6:
+        return 3
+    return 2 if level >= 2 else 0
+
+
 def _channel_divinity_cleric(level: int) -> int:
     # Cleric: 2 uses at L2, 3 at L6, 4 at L18 (SRD 5.2).
     if level < 2:
@@ -364,13 +382,16 @@ _CLASS_RESOURCES: dict[str, dict] = {
         "sorcery_points": ("Sorcery Points", "long", lambda lvl, cha: lvl if lvl >= 2 else 0),
     },
     "fighter": {
-        # Second Wind from L1; Action Surge from L2 (2 uses at L17). Short-rest.
-        "second_wind": ("Second Wind", "short", lambda lvl, cha: 1),
+        # Second Wind from L1; SRD 5.2 scales the pool 2/3/4 at L1/L4/L10 (the old flat
+        # "1" undercounted every Fighter — audit F02-11). Action Surge from L2 (2 at L17).
+        "second_wind": ("Second Wind", "short", lambda lvl, cha: _second_wind_uses(lvl)),
         "action_surge": ("Action Surge", "short", lambda lvl, cha: (2 if lvl >= 17 else 1) if lvl >= 2 else 0),
     },
     "druid": {
-        # Wild Shape: 2 uses from L2 (Archdruid grants unlimited at L20 -> not pooled).
-        "wild_shape": ("Wild Shape", "short", lambda lvl, cha: 0 if lvl >= 20 else (2 if lvl >= 2 else 0)),
+        # Wild Shape (SRD 5.2): 2 uses at L2, 3 at L6, 4 at L17 — and the pool PERSISTS at
+        # L20 (the 2014 "Archdruid unlimited -> not pooled" zero was mixed-edition drift
+        # against the engine's 2024 feature tables; under 5.2 the pool stays at 4 — F02-11).
+        "wild_shape": ("Wild Shape", "short", lambda lvl, cha: _wild_shape_uses(lvl)),
     },
 }
 

--- a/servers/engine/tests/test_class_resources.py
+++ b/servers/engine/tests/test_class_resources.py
@@ -44,7 +44,10 @@ def test_resource_formulas_across_classes():
     }
     assert srd_tables.class_resources_through("bard", 5, cha_mod=3)["bardic_inspiration"]["recharge"] == "short"
     f = srd_tables.class_resources_through("fighter", 2)
-    assert f["second_wind"]["max"] == 1 and f["second_wind"]["recharge"] == "short"
+    # SRD 5.2 Second Wind scales 2/3/4 at L1/L4/L10 (was a flat "1" — audit F02-11).
+    assert f["second_wind"]["max"] == 2 and f["second_wind"]["recharge"] == "short"
+    assert srd_tables.class_resources_through("fighter", 4)["second_wind"]["max"] == 3
+    assert srd_tables.class_resources_through("fighter", 10)["second_wind"]["max"] == 4
     assert f["action_surge"]["max"] == 1
     assert "ki" not in srd_tables.class_resources_through("monk", 1)  # no Ki before L2
     assert srd_tables.class_resources_through("wizard", 5) == {}  # no pools

--- a/servers/engine/tests/test_progression_integrity.py
+++ b/servers/engine/tests/test_progression_integrity.py
@@ -1,0 +1,319 @@
+"""P2 cluster — Character progression integrity (issue #794).
+
+Covers the still-broken progression-integrity sub-findings from the WorldOS
+adversarial engine audit (docs/audits/ENGINE-AUDIT-2026-06-11.md, unit 02):
+
+  * F02-3  missed ASI silently dropped; feat 100% inert -> record the debt on a
+           `pending_choices` ledger and SURFACE a chosen feat's effect for the DM.
+  * F02-5  class-sig recompute REFILLS spent hit dice on a stat/level patch.
+  * F02-6  CON rises never retro-adjust max HP (level-up + update_character).
+  * F02-8  pickup seats a canon-DEAD record / promote keeps the death state.
+  * F02-10 recruit keeps a stub HP at level>1 (instant-kill combatant).
+  * F02-11 resource-table drift: Second Wind / Wild Shape counts, sneak 10d6@19.
+  * F02-12 reroll PC: location None + AC over an empty inventory.
+  * F02-14 no XP-entitlement advisory when leveling_mode == "xp".
+  * F02-15 Expertise inert at grant (rides F02-3's ledger; default-fill interim).
+
+Every fix is ADDITIVE: old snapshots round-trip, new fields default to today's
+behavior. The cross-path seat census (F02-18) lives in test_seat_census.py.
+"""
+
+import pytest
+
+import server
+import srd_tables
+import store
+from models import Character, Ability
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("CLAWDND_ACTOR_ID", raising=False)
+    monkeypatch.delenv("CLAWDND_ACTOR_ROLE", raising=False)
+    yield
+
+
+def _snapshot(cid):
+    return store.load_campaign(cid)
+
+
+# --------------------------------------------------------------------------- #
+# F02-11 — SRD-table drift (pure srd_tables, no campaign)                      #
+# --------------------------------------------------------------------------- #
+def test_second_wind_uses_scale_2_3_4_by_srd_5_2():
+    # SRD 5.2: Second Wind has 2 uses at L1, 3 at L4, 4 at L10.
+    def sw(level):
+        return srd_tables.class_resources_through("fighter", level).get("second_wind", {}).get("max")
+    assert sw(1) == 2
+    assert sw(3) == 2
+    assert sw(4) == 3
+    assert sw(9) == 3
+    assert sw(10) == 4
+    assert sw(20) == 4
+
+
+def test_wild_shape_uses_scale_2_3_4_and_persist_at_20():
+    # SRD 5.2: Wild Shape 2 @ L2, 3 @ L6, 4 @ L17 — and the pool PERSISTS at L20
+    # (the 2014 "Archdruid unlimited -> not pooled" zero was mixed-edition drift).
+    def ws(level):
+        return srd_tables.class_resources_through("druid", level).get("wild_shape", {}).get("max")
+    assert ws(1) is None  # no feature yet
+    assert ws(2) == 2
+    assert ws(5) == 2
+    assert ws(6) == 3
+    assert ws(16) == 3
+    assert ws(17) == 4
+    assert ws(20) == 4  # must NOT drop to 0/None at 20
+
+
+def test_rogue_sneak_attack_is_10d6_at_level_19():
+    # SRD 5.2: Sneak Attack reaches 10d6 at L19 (every odd level), NOT L20.
+    def sneak(level):
+        dice = ""
+        for f in srd_tables.features_through("rogue", level):
+            if f.get("sneak_attack_dice"):
+                dice = f["sneak_attack_dice"]
+        return dice
+    assert sneak(17) == "9d6"
+    assert sneak(19) == "10d6"
+    assert sneak(20) == "10d6"
+
+
+def test_engine_built_l19_rogue_has_10d6_sneak_attack():
+    cid = server.create_campaign("rogue19")["id"]
+    rid = server.create_character(cid, "Astar", kind="player", class_name="Rogue",
+                                  level=19, apply_srd_defaults=True,
+                                  abilities={"dexterity": 18})["id"]
+    assert server.get_character(cid, rid)["sneak_attack_dice"] == "10d6"
+
+
+# --------------------------------------------------------------------------- #
+# F02-5 — class-sig recompute must NOT refill spent hit dice                   #
+# --------------------------------------------------------------------------- #
+def test_class_sig_patch_preserves_spent_hit_dice():
+    cid = server.create_campaign("hd")["id"]
+    fid = server.create_character(cid, "Gale", kind="player", class_name="Wizard",
+                                  apply_srd_defaults=True, abilities={"constitution": 12})["id"]
+    server.update_character(cid, fid, {"hit_dice_remaining": 0})  # spend all hit dice
+    out = server.update_character(cid, fid, {"classes": [{"name": "Wizard", "level": 3}]})
+    # Down/up-level retier recomputes the *pool size* (the hit_dice string scales to 3d6)
+    # but a previously-SPENT pool must NOT silently refill — they stay spent (0).
+    assert out["hit_dice"] == "3d6"
+    assert out["hit_dice_remaining"] == 0
+
+
+def test_class_sig_patch_caps_hit_dice_on_down_level():
+    cid = server.create_campaign("hd2")["id"]
+    fid = server.create_character(cid, "Karc", kind="player", class_name="Fighter",
+                                  level=12, apply_srd_defaults=True,
+                                  abilities={"constitution": 14})["id"]
+    # all 12 hit dice available, then patch DOWN to L3 -> the pool can't exceed 3.
+    out = server.update_character(cid, fid, {"classes": [{"name": "Fighter", "level": 3}]})
+    assert out["hit_dice"] == "3d10"
+    assert out["hit_dice_remaining"] == 3
+
+
+# --------------------------------------------------------------------------- #
+# F02-6 — CON rises retro-adjust max HP                                        #
+# --------------------------------------------------------------------------- #
+def test_con_asi_retro_adjusts_max_hp_on_level_up():
+    cid = server.create_campaign("conhp")["id"]
+    fid = server.create_character(cid, "Bru", kind="player", class_name="Fighter",
+                                  apply_srd_defaults=True, abilities={"constitution": 14})["id"]
+    server.level_up(cid, fid, "Fighter")  # L2  -> 12 + 8
+    server.level_up(cid, fid, "Fighter")  # L3  -> 28
+    before = server.get_character(cid, fid)["max_hp"]  # 28
+    out = server.level_up(cid, fid, "Fighter", asi={"constitution": 2})  # L4, CON 14->16
+    # The L4 gain itself uses the POST-ASI CON (+3): average 6 + 3 = 9.
+    # PLUS the CON modifier rose by +1 -> +1 HP retro on the 3 prior levels = +3.
+    assert out["abilities"]["constitution"] == 16
+    assert out["max_hp"] == before + 9 + 3  # = 40
+
+
+def test_preview_and_actual_agree_on_con_asi_hp():
+    # preview_level_up's hp_gain/max_hp must MATCH what level_up actually writes for a CON ASI
+    # (preview applies the ASI before sizing HP, same as the real path) — no preview/actual drift.
+    cid = server.create_campaign("parity")["id"]
+    fid = server.create_character(cid, "Twin", kind="player", class_name="Fighter",
+                                  apply_srd_defaults=True, abilities={"constitution": 14})["id"]
+    server.level_up(cid, fid, "Fighter")
+    server.level_up(cid, fid, "Fighter")
+    before_hp = server.get_character(cid, fid)["max_hp"]
+    prev = server.preview_level_up(cid, fid, "Fighter", asi={"constitution": 2})
+    act = server.level_up(cid, fid, "Fighter", asi={"constitution": 2})
+    # the per-level gain reported by preview matches the actual gain (post-ASI CON in both)
+    assert prev["hp_gain"] == act["_hp_gained"]
+    assert prev["to"]["total_level"] == sum(cl["level"] for cl in act["classes"])
+    # and the actual end-state HP folds in the per-level gain PLUS the CON-mod retro
+    # (this fighter's CON 14->16 over 3 prior levels = +3 retro on top of the gain)
+    assert act["max_hp"] == before_hp + act["_hp_gained"] + 3
+
+
+def test_con_patch_retro_adjusts_max_hp():
+    cid = server.create_campaign("conpatch")["id"]
+    fid = server.create_character(cid, "Dorn", kind="player", class_name="Fighter",
+                                  level=5, apply_srd_defaults=True,
+                                  abilities={"constitution": 14})["id"]
+    before = server.get_character(cid, fid)["max_hp"]
+    out = server.update_character(cid, fid, {"abilities": {"constitution": 16}})  # +1 mod
+    assert out["max_hp"] == before + 5  # +1 per level over 5 levels
+
+
+def test_con_drop_patch_lowers_max_hp_but_floors_at_one():
+    cid = server.create_campaign("condrop")["id"]
+    fid = server.create_character(cid, "Frail", kind="player", class_name="Wizard",
+                                  level=3, apply_srd_defaults=True,
+                                  abilities={"constitution": 14})["id"]
+    before = server.get_character(cid, fid)["max_hp"]
+    out = server.update_character(cid, fid, {"abilities": {"constitution": 12}})  # -1 mod
+    assert out["max_hp"] == before - 3
+
+
+def test_explicit_max_hp_in_same_patch_wins_over_con_retro():
+    cid = server.create_campaign("conexplicit")["id"]
+    fid = server.create_character(cid, "Authored", kind="player", class_name="Fighter",
+                                  level=5, apply_srd_defaults=True,
+                                  abilities={"constitution": 14})["id"]
+    out = server.update_character(cid, fid, {"abilities": {"constitution": 16}, "max_hp": 99})
+    assert out["max_hp"] == 99  # DM-authored HP wins; no retro on top
+
+
+# --------------------------------------------------------------------------- #
+# F02-3 / F02-15 — pending-choice ledger + feat surfacing                      #
+# --------------------------------------------------------------------------- #
+def test_skipped_asi_records_pending_choice_debt():
+    cid = server.create_campaign("debt")["id"]
+    fid = server.create_character(cid, "Aria", kind="player", class_name="Fighter",
+                                  apply_srd_defaults=True,
+                                  abilities={"strength": 16, "constitution": 12})["id"]
+    server.level_up(cid, fid, "Fighter")  # L2
+    server.level_up(cid, fid, "Fighter")  # L3
+    out = server.level_up(cid, fid, "Fighter")  # L4 ASI level, NEITHER asi nor feat chosen
+    # The due-but-skipped choice is now RECORDED (was silently dropped, unrecoverable).
+    assert any("Fighter" in p and "4" in p for p in out["pending_choices"])
+    assert out["_pending_choice_recorded"] is True
+    # round-trips on the persisted record
+    assert _snapshot(cid).characters[fid].pending_choices == out["pending_choices"]
+
+
+def test_taking_asi_does_not_record_debt():
+    cid = server.create_campaign("nodebt")["id"]
+    fid = server.create_character(cid, "Nim", kind="player", class_name="Fighter",
+                                  apply_srd_defaults=True,
+                                  abilities={"strength": 16, "constitution": 12})["id"]
+    server.level_up(cid, fid, "Fighter")
+    server.level_up(cid, fid, "Fighter")
+    out = server.level_up(cid, fid, "Fighter", asi={"strength": 2})  # L4 ASI taken
+    assert out["pending_choices"] == []
+
+
+def test_feat_choice_is_surfaced_for_the_dm():
+    cid = server.create_campaign("feat")["id"]
+    fid = server.create_character(cid, "Tav", kind="player", class_name="Fighter",
+                                  apply_srd_defaults=True,
+                                  abilities={"strength": 16, "constitution": 12})["id"]
+    server.level_up(cid, fid, "Fighter")
+    server.level_up(cid, fid, "Fighter")
+    out = server.level_up(cid, fid, "Fighter", feat="Great Weapon Master")  # L4 feat
+    assert out["_asi_applied"] == {"feat": "Great Weapon Master"}
+    # the feat lands on a structured ledger the DM/viewer can read (not just buried in notes)
+    assert "Great Weapon Master" in out["feats"]
+    assert "Great Weapon Master" in _snapshot(cid).characters[fid].feats
+    # no missed-ASI debt is recorded when a feat WAS taken
+    assert out["pending_choices"] == []
+
+
+def test_engine_built_rogue_gets_expertise_default_fill():
+    # F02-15: a rogue gains Expertise at L1; before, no engine grant path wrote
+    # skill_expertise, so every engine-built rogue's expertise math was short by PB.
+    cid = server.create_campaign("rogue")["id"]
+    rid = server.create_character(cid, "Sly", kind="player", class_name="Rogue",
+                                  apply_srd_defaults=True, abilities={"dexterity": 16})["id"]
+    sheet = server.get_character(cid, rid)
+    # two skills carry expertise (the SRD rogue's L1 Expertise grant), drawn from the
+    # character's own proficiencies.
+    assert len(sheet["skill_expertise"]) == 2
+    for sk in sheet["skill_expertise"]:
+        assert sk in sheet["skill_proficiencies"]
+
+
+# --------------------------------------------------------------------------- #
+# F02-14 — XP-entitlement advisory in xp mode                                 #
+# --------------------------------------------------------------------------- #
+def test_level_up_warns_when_xp_below_entitlement_in_xp_mode():
+    cid = server.create_campaign("xpguard")["id"]
+    fid = server.create_character(cid, "Greedy", kind="player", class_name="Fighter",
+                                  apply_srd_defaults=True)["id"]
+    # leveling_mode defaults to "xp"; the PC has 0 XP -> not entitled to L2.
+    out = server.level_up(cid, fid, "Fighter")
+    assert out["_xp_warning"]  # advisory present, non-empty
+    assert out["max_hp"] > 0  # but the level-up STILL happened (warn-don't-block)
+
+
+def test_level_up_no_xp_warning_when_entitled():
+    cid = server.create_campaign("xpok")["id"]
+    fid = server.create_character(cid, "Earner", kind="player", class_name="Fighter",
+                                  apply_srd_defaults=True)["id"]
+    server.award_xp(cid, fid, 500)  # past the L2 threshold (300)
+    out = server.level_up(cid, fid, "Fighter")
+    assert out.get("_xp_warning") in (None, "")
+
+
+def test_level_up_no_xp_warning_in_milestone_mode():
+    cid = server.create_campaign("milestone")["id"]
+    fid = server.create_character(cid, "Story", kind="player", class_name="Fighter",
+                                  apply_srd_defaults=True)["id"]
+    # leveling_mode lives on the Campaign (a milestone game levels by story beat).
+    camp = store.load_campaign(cid)
+    camp.leveling_mode = "milestone"
+    store.save_campaign(camp)
+    out = server.level_up(cid, fid, "Fighter")  # 0 XP but milestone mode
+    assert out.get("_xp_warning") in (None, "")
+
+
+# --------------------------------------------------------------------------- #
+# F02-12 — reroll seats a complete PC                                         #
+# --------------------------------------------------------------------------- #
+def _kill(cid, char_id):
+    server.apply_damage(cid, char_id, 9999)
+    assert store.load_campaign(cid).characters[char_id].dead is True
+
+
+def test_reroll_pc_seated_at_party_location_and_met():
+    cid = server.create_campaign("reroll")["id"]
+    # establish a current location for the campaign
+    c = store.load_campaign(cid)
+    from models import Location
+    loc = Location(name="The Crossroads")
+    c.locations[loc.id] = loc
+    c.current_location_id = loc.id
+    store.save_campaign(c)
+    pc = server.create_character(cid, "Aldric", kind="player", class_name="fighter",
+                                 level=3, apply_srd_defaults=True,
+                                 abilities={"strength": 16, "constitution": 14})["id"]
+    _kill(cid, pc)
+    out = server.reroll_character(cid, pc, "Mara", class_name="rogue", level=3,
+                                  abilities={"dexterity": 16, "constitution": 12})
+    new_id = out["new_pc"]["id"]
+    new = _snapshot(cid).characters[new_id]
+    assert new.location_id == loc.id  # seated where the party currently is (not None)
+    assert new.met is True  # a player is implicitly met (consistency with create_character)
+
+
+def test_reroll_pc_ac_consistent_with_inventory():
+    cid = server.create_campaign("rerollac")["id"]
+    pc = server.create_character(cid, "Aldric", kind="player", class_name="fighter",
+                                 level=3, apply_srd_defaults=True,
+                                 abilities={"strength": 16, "constitution": 14})["id"]
+    _kill(cid, pc)
+    out = server.reroll_character(cid, pc, "Mara", class_name="fighter", level=3,
+                                  abilities={"strength": 16, "constitution": 14})
+    new = _snapshot(cid).characters[out["new_pc"]["id"]]
+    # the AC the new hero shows must be JUSTIFIED by gear on the sheet — an armored AC
+    # over an empty pack was the F02-12 defect. Either the kit is seeded to back the AC,
+    # or the AC is the unarmored value; never an unbacked armored AC.
+    has_armor = any("armor" in (it.name or "").lower() or "mail" in (it.name or "").lower()
+                    for it in new.inventory)
+    if new.armor_class > 12:
+        assert has_armor, "armored AC must be backed by an armor item on the sheet"

--- a/servers/engine/tests/test_reroll.py
+++ b/servers/engine/tests/test_reroll.py
@@ -122,9 +122,12 @@ def test_reroll_does_not_transfer_gear_or_gold():
 
     c = store.load_campaign(cid)
     new = c.characters[out["new_pc"]["id"]]
-    # Gear/gold are LOST with the body by default — the new character earns their own kit.
-    assert new.inventory == []
-    assert new.currency.gp == 0
+    # The DEAD PC's gear/gold is LOST with the body — never TRANSFERRED to the new hero.
+    # (F02-12: the new character is seated with their OWN class-appropriate starting kit so
+    # their AC is backed by armor on the sheet, but NONE of the corpse's distinctive loot.)
+    assert not any(i.name == "Flametongue Greatsword" for i in new.inventory)
+    assert not any(i.name == "Healing Potion" for i in new.inventory)
+    assert new.currency.gp != 250  # not the corpse's purse
     # The corpse keeps what it died with (the fiction hook for a lootable body).
     corpse = c.characters[pc]
     assert any(i.name == "Flametongue Greatsword" for i in corpse.inventory)

--- a/servers/engine/tests/test_seat_census.py
+++ b/servers/engine/tests/test_seat_census.py
@@ -1,0 +1,170 @@
+"""F02-8 + F02-18 — cross-path SEAT CENSUS net.
+
+Five of unit-02's findings are literally "one seat path missed a fix another got"
+(F02-1/4/8/9/10/12). This is the highest-leverage prevention: assert the SAME
+invariants across EVERY seat path (create / start fresh / pickup-fresh /
+pickup-promote / recruit / reroll / load_canon), so a future single-path patch
+that forgets a sibling path trips here.
+
+The invariant bundle (audit F02-18, a)-(l), as it applies to the still-relevant
+paths after the F02-1/2/4 fixes landed in #833):
+  (a) a seated PC/companion with a known class at level L has hit_dice == "Ld<die>";
+  (b) max_hp is at least the SRD class+level floor (no stub HP at level>1);
+  (c) an armored AC (>12) is backed by an armor item on the sheet (or is the
+      class unarmored default);
+  (g) carve-out for reroll's "gear lost with the body": the new hero is seated with
+      a kit that JUSTIFIES its AC (we seed gear), so the same (c) check holds;
+  (h) a freshly seated, living PC/companion is NOT dead/stable (no death state);
+  (i) a canon-DEAD record is never seatable as the PLAYER on ANY pickup path.
+"""
+
+import re
+
+import pytest
+
+import content as content_mod
+import server
+import store
+from models import Ability
+
+
+WORLD = "baldurs-gate"
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("CLAWDND_ACTOR_ID", raising=False)
+    monkeypatch.delenv("CLAWDND_ACTOR_ROLE", raising=False)
+    yield
+
+
+def _seeded_world_campaign():
+    c = content_mod.seed_world(content_mod.load_world_data(WORLD))
+    server.save_campaign(c)
+    return c.id
+
+
+# --------------------------------------------------------------------------- #
+# Shared seat-invariant assertions                                            #
+# --------------------------------------------------------------------------- #
+def _assert_seat_invariants(ch, *, expect_alive=True):
+    """The cross-path bundle, applied to one seated record."""
+    if not ch.classes:
+        return  # class-less nobody — nothing to derive
+    import srd_tables
+    cname = ch.classes[0].name.lower()
+    try:
+        die = srd_tables.hit_die(cname)
+    except ValueError:
+        return  # unknown/homebrew class
+    level = ch.total_level
+    single = len({cl.name.lower() for cl in ch.classes}) == 1
+    if single:
+        # (a) hit dice string scaled to level
+        assert ch.hit_dice == f"{level}d{die}", (
+            f"{ch.name}: hit_dice {ch.hit_dice!r} != {level}d{die}")
+        # (b) no stub HP at level>1
+        floor = server._class_level_hp(cname, level, ch.ability_modifier(Ability.CON))
+        assert ch.max_hp >= floor, (
+            f"{ch.name}: max_hp {ch.max_hp} below class floor {floor} at L{level}")
+    # (c) armored AC is backed by armor on the sheet
+    if ch.armor_class > 12:
+        has_armor = any(
+            re.search(r"armor|mail|plate|leather|shield", (it.name or "").lower())
+            for it in ch.inventory
+        )
+        assert has_armor, (
+            f"{ch.name}: AC {ch.armor_class} (>12) with no armor item on the sheet")
+    # (h) a living seat carries no death state
+    if expect_alive:
+        assert not ch.dead and not ch.stable, f"{ch.name}: seated with a death flag set"
+        assert ch.death_saves.successes == 0 and ch.death_saves.failures == 0
+
+
+# --------------------------------------------------------------------------- #
+# (a)/(b)/(c)/(h) hold on EVERY living seat path                               #
+# --------------------------------------------------------------------------- #
+def test_create_character_seat_invariants():
+    cid = server.create_campaign("c")["id"]
+    fid = server.create_character(cid, "Borg", kind="player", class_name="Fighter",
+                                  level=5, apply_srd_defaults=True,
+                                  abilities={"constitution": 14})["id"]
+    _assert_seat_invariants(store.load_campaign(cid).characters[fid])
+
+
+def test_start_character_fresh_seat_invariants():
+    cid = server.create_campaign("s")["id"]
+    out = server.start_character(cid, origin="veteran_l5", name="Vex", class_name="Fighter",
+                                 abilities={"constitution": 14})
+    _assert_seat_invariants(store.load_campaign(cid).characters[out["id"]])
+
+
+def test_recruit_companion_seat_invariants_at_level_5():
+    cid = server.create_campaign("r")["id"]
+    npc = server.create_character(cid, "Helm", kind="npc")["id"]
+    out = server.recruit_companion(cid, npc, class_name="Fighter", level=5,
+                                   abilities={"constitution": 14})
+    _assert_seat_invariants(store.load_campaign(cid).characters[out["id"]])
+
+
+def test_reroll_seat_invariants():
+    cid = server.create_campaign("rr")["id"]
+    pc = server.create_character(cid, "Dead", kind="player", class_name="Fighter",
+                                 level=4, apply_srd_defaults=True,
+                                 abilities={"constitution": 14})["id"]
+    server.apply_damage(cid, pc, 9999)
+    out = server.reroll_character(cid, pc, "New", class_name="Fighter", level=4,
+                                  abilities={"constitution": 14})
+    _assert_seat_invariants(store.load_campaign(cid).characters[out["new_pc"]["id"]])
+
+
+# --------------------------------------------------------------------------- #
+# (h) promote-via-pickup must clear a stale death state                       #
+# --------------------------------------------------------------------------- #
+def test_pickup_promote_clears_death_state_on_a_dead_roster_record(monkeypatch):
+    cid = _seeded_world_campaign()
+    c = store.load_campaign(cid)
+    # Inject a PLAYABLE, ALIVE-in-canon roster NPC that is currently marked dead at the
+    # seat (e.g. a stub that died in combat as a bare identity). pickup:promote it.
+    from models import Character, DeathSaves
+    npc = Character(id="npc-thatcher", name="Thatcher", kind="npc", classes=[])
+    npc.dead = True
+    npc.stable = True
+    npc.death_saves = DeathSaves(failures=3)
+    c.characters[npc.id] = npc
+    store.save_campaign(c)
+
+    rec = {"name": "Thatcher", "class": "Fighter", "level": 5, "playable": True,
+           "abilities": {"strength": 16, "constitution": 14}}
+    monkeypatch.setattr(content_mod, "load_canon_character", lambda w, n: rec)
+    monkeypatch.setattr(content_mod, "is_playable", lambda r: True)
+    monkeypatch.setattr(content_mod, "is_dead_record", lambda r: False)
+
+    out = server.start_character(cid, origin="pickup:Thatcher")
+    assert out.get("promoted_existing") is True
+    seated = store.load_campaign(cid).characters[out["id"]]
+    assert seated.kind == "player"
+    assert seated.current_hp > 0
+    assert not seated.dead and not seated.stable
+    assert seated.death_saves.failures == 0
+    _assert_seat_invariants(seated)
+
+
+# --------------------------------------------------------------------------- #
+# (i) a canon-DEAD record is never seatable as the PLAYER via pickup          #
+# --------------------------------------------------------------------------- #
+def test_pickup_rejects_a_canon_dead_record_as_the_player(monkeypatch):
+    cid = _seeded_world_campaign()
+    rec = {"name": "Ghoulen", "class": "Wizard", "level": 5, "playable": True,
+           "backstory": "Ghoulen is a dead necromancer whose corpse lies in the crypt."}
+    monkeypatch.setattr(content_mod, "load_canon_character", lambda w, n: rec)
+    monkeypatch.setattr(content_mod, "is_playable", lambda r: True)
+    monkeypatch.setattr(content_mod, "is_dead_record", lambda r: True)
+
+    out = server.start_character(cid, origin="pickup:Ghoulen")
+    assert "error" in out
+    assert out.get("dead_in_canon") is True
+    # nothing was seated
+    assert all(ch.name != "Ghoulen" or ch.kind != "player"
+               for ch in store.load_campaign(cid).characters.values())


### PR DESCRIPTION
## P2 cluster #794 — Character progression integrity

Fixes the still-broken progression-integrity sub-findings from the WorldOS adversarial engine audit. **F02-1/2/4 were already absorbed by #833** — confirmed on main and skipped (not re-fixed/reverted). Every change is **additive**: old snapshots round-trip, new model fields default to today's behavior, `_StrictModel extra=forbid` preserved, the engine stays the sole writer.

Source of truth: `docs/audits/ENGINE-AUDIT-2026-06-11.md` (unit 02, Part C) + issue #794.

### Fixed

| ID | What was broken | Fix |
|----|-----------------|-----|
| **F02-3** | A due ASI/feat was silently dropped when neither was supplied (no surface ever offered it again); the feat path was 100% inert (`notes += " | feat: X"`). | Record the debt on a new `pending_choices: list[str]` ledger; a chosen feat lands on a new `feats: list[str]` ledger the DM/viewer key off. Both settleable via `update_character`, exposed in `get_character`. |
| **F02-5** | A class/level retier patch REFILLED a previously-spent hit-dice pool (`_apply_srd_class_defaults` reset `hit_dice_remaining=level`, then `min(level, total)` kept the refill). | `update_character` captures the pre-recompute remaining and `_recompute_level_scaled_stats` caps the SPENT basis against the new total — never refills. |
| **F02-6** | CON rises never retro-adjusted max HP; level-gain used pre-ASI CON. | `level_up` applies a CON ASI before sizing the new level's HP (post-ASI CON) and adds +1/level retro for prior levels; `update_character` delta-adjusts max_hp on a CON patch (explicit max_hp / class-sig retier win). `preview_level_up` mirrors the order → no preview/actual drift. |
| **F02-8** | `pickup:` seated a canon-DEAD record as the PLAYER; promote kept stale death state. | Hard-gate `is_dead_record` out of the player seat (mirrors the #305 `load_canon` gate); clear dead/stable/death_saves on promote (mirrors `recruit_companion`). |
| **F02-10** | Recruit kept stub HP at level>1. | Covered by #833's `_finish_seat_sheet`; the seat census pins the HP floor across paths. |
| **F02-11** | SRD-table drift: Second Wind flat `1`, Wild Shape `2` (and `0` at L20), rogue Sneak Attack 10d6 keyed at L20. | Second Wind 2/3/4 @ L1/4/10; Wild Shape 2/3/4 @ L2/6/17 (persists at L20); Sneak Attack 10d6 @ **L19** (data fix). |
| **F02-12** | Reroll PC: `location_id=None` until next travel; armored AC over an empty inventory. | Seat at `c.current_location_id`, `met=True`, route through the seat finisher so AC is backed by a real starting kit. The dead PC's distinctive loot still stays on the corpse. |
| **F02-14** | No XP-entitlement guard in `xp` leveling mode. | `level_up` WARNS (never blocks) when the PC isn't XP-entitled to the level; milestone campaigns unaffected. |
| **F02-15** | Expertise inert at grant — no engine write path to `skill_expertise`. | Classes that grant Expertise (rogue L1/L6, bard L2/L9) default-fill `skill_expertise` from their own proficiencies; a DM can refine the picks. |
| **F02-18** | No cross-path seat-census test net. | New `tests/test_seat_census.py` asserts the invariant bundle (hit-dice scaling, no stub HP, armored-AC-backed-by-armor, no death state) across create / start / recruit / reroll / pickup-promote, plus the dead-canon pickup gate. |

### Deferred (Refs #794, not Closes)

- **F02-7** — multiclass deletes Pact Magic + pact `used` reset. The corrected fix-spec needs a distinct `pact_slots` representation **plus** dropping both `len==1` gates (`_recompute_spellcasting` **and** `rests.py` short-rest recovery) so a merged pool isn't refilled wrong. That's a separate seam (M effort) and is left for a follow-up to avoid a half-wired Pact change.

### Verification

- `tests/test_progression_integrity.py` + `tests/test_seat_census.py` — **26 new tests** (TDD: red → minimal additive fix → green).
- Full engine suite: **2228 passed** (`uv run --directory servers/engine python -m pytest -q -p no:xdist`).
- `bash qa/fast_gate.sh` — **Tier-0 PASS** (188 deterministic).
- Two existing tests updated to the SRD-correct / new-design expectation: `test_class_resources` (Second Wind 2/3/4) and `test_reroll` (corpse loot not *transferred*, new hero gets a fresh kit).

Additive/round-trip confirmed: old snapshots with no `feats`/`pending_choices` keys deserialize unchanged; a typo still trips `extra=forbid`.

**Do not merge** — review per the P2 wave process.