### PR TITLE
fix(engine): Spellcasting correctness P2 cluster — AoE path, all concentration-end releases, learn/prepare canonicalization, prepared discipline, innate casting (#797)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -6435,9 +6435,33 @@ def cast_spell(
                         f"advance with next_turn so the order stays in sync."
                     )
                 cast_consumes_reaction = True
-        known = set(ch.spells_known) | set(ch.spells_prepared)
-        if known and canonical not in known:
-            raise ValueError(f"{ch.name} doesn't know or have {canonical!r} prepared")
+        # KNOWN / PREPARED GATE (F03-7 + F03-8). Compare CASE-INSENSITIVELY (F03-7): the
+        # cast-side `canonical` is the proper-cased SRD name, but legacy snapshots may carry
+        # raw-cased strings (learn_spells/prepare_spells now canonicalize on write, but old
+        # campaigns round-trip), so casefold both sides — a lowercase-stored "magic missile"
+        # still matches the canonical "Magic Missile".
+        known_cf = {s.strip().lower() for s in ch.spells_known}
+        prepared_cf = {s.strip().lower() for s in ch.spells_prepared}
+        cf = canonical.strip().lower()
+        if spell_level == 0:
+            # Cantrips are never "prepared" in 5e — a known cantrip is always castable. Gate
+            # only against the union (lenient when both lists are empty, today's behavior).
+            if (known_cf or prepared_cf) and cf not in (known_cf | prepared_cf):
+                raise ValueError(f"{ch.name} doesn't know {canonical!r}")
+        elif prepared_cf:
+            # F03-8: a prepared caster (non-empty prepared list) casts a LEVELED spell only if
+            # it is PREPARED — knowing it is not enough. This gives preparation real mechanical
+            # weight (Rolan's snapshot: known(7) ⊋ prepared(4) was a no-op union before).
+            if cf not in prepared_cf:
+                raise ValueError(
+                    f"{ch.name} knows {canonical!r} but hasn't prepared it — "
+                    f"prepare_spells it first, or cast a prepared spell"
+                )
+        elif known_cf:
+            # Legacy / known-caster path: no prepared list (sorcerer, or an old snapshot that
+            # only set spells_known) keeps the lenient known-only gate — byte-identical behavior.
+            if cf not in known_cf:
+                raise ValueError(f"{ch.name} doesn't know or have {canonical!r} prepared")
         slot_used = None
         # A ritual cast consumes NO slot (#813) — the +10 minutes is the cost; the
         # spell resolves at its base level (a ritual can't be upcast).
@@ -7577,24 +7601,78 @@ def set_class_resource(
         }
 
 
+def _canonicalize_spell_list(spells_list: list, existing: list, mode: str) -> list:
+    """Validate + canonicalize a learn/prepare spell list (F03-7). Each entry must be a
+    known SRD spell (any casing); unknown entries raise listing ALL of them, so the cast
+    gate compares the proper-cased name against proper-cased stored names. `mode='replace'`
+    (default) substitutes the list; `mode='add'` appends the new spells to `existing`
+    (de-duped, canonical-cased, order-preserving). Raises ValueError on an unknown name or
+    an unrecognized mode — rejection BEFORE any state change, like every engine write."""
+    if mode not in ("replace", "add"):
+        raise ValueError(f"mode must be 'replace' or 'add', got {mode!r}")
+    canonical: list[str] = []
+    unknown: list[str] = []
+    for raw in spells_list:
+        name = spells.canonical_name(str(raw))
+        if name is None:
+            unknown.append(str(raw))
+        else:
+            canonical.append(name)
+    if unknown:
+        raise ValueError(
+            "unknown spell(s) (not in the SRD): "
+            + ", ".join(repr(u) for u in unknown)
+            + " — check spelling; only SRD spells can be learned/prepared"
+        )
+    if mode == "add":
+        result = list(existing)
+        have = {s.strip().lower() for s in existing}
+        for name in canonical:
+            if name.strip().lower() not in have:
+                result.append(name)
+                have.add(name.strip().lower())
+        return result
+    # replace: de-dupe the incoming list (keep first-seen canonical casing/order)
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for name in canonical:
+        if name.strip().lower() not in seen:
+            deduped.append(name)
+            seen.add(name.strip().lower())
+    return deduped
+
+
 @mcp.tool()
-def learn_spells(campaign_id: str, character_id: str, spells_list: list) -> dict:
-    """Set a character's known spells (replaces the list)."""
+def learn_spells(campaign_id: str, character_id: str, spells_list: list,
+                 mode: str = "replace") -> dict:
+    """Set a character's KNOWN spells. Each name is VALIDATED + CANONICALIZED (F03-7): an
+    unknown spell (typo, non-SRD) is rejected listing the offenders, and any casing you pass
+    ("fire bolt") is stored proper-cased ("Fire Bolt") so the case-sensitive cast gate accepts
+    a later cast. `mode='replace'` (default) substitutes the whole list; `mode='add'` appends
+    the new spells to the existing known list (de-duped) — so you can teach one spell without
+    re-listing the whole spellbook. Rejection happens BEFORE any change (nothing is stored on
+    an unknown name)."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _char(c, character_id)
-        ch.spells_known = list(spells_list)
+        ch.spells_known = _canonicalize_spell_list(spells_list, ch.spells_known, mode)
         save_campaign(c)
         return {"spells_known": ch.spells_known}
 
 
 @mcp.tool()
-def prepare_spells(campaign_id: str, character_id: str, spells_list: list) -> dict:
-    """Set a character's prepared spells (replaces the list)."""
+def prepare_spells(campaign_id: str, character_id: str, spells_list: list,
+                   mode: str = "replace") -> dict:
+    """Set a character's PREPARED spells. Each name is VALIDATED + CANONICALIZED (F03-7) like
+    learn_spells. With a non-empty prepared list, cast_spell now enforces preparation for
+    LEVELED spells (F03-8): a prepared caster (cleric/wizard/druid) casts only what it has
+    prepared, while cantrips stay always-castable once known. `mode='replace'` (default)
+    substitutes the list (your daily preparation); `mode='add'` appends. An unknown spell is
+    rejected before any change."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _char(c, character_id)
-        ch.spells_prepared = list(spells_list)
+        ch.spells_prepared = _canonicalize_spell_list(spells_list, ch.spells_prepared, mode)
         save_campaign(c)
         return {"spells_prepared": ch.spells_prepared}
 

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -3166,8 +3166,12 @@ def add_condition(
         if added:
             ch.conditions.append(cond)
         if cond in combat.INCAPACITATING:
+            was_conc = ch.concentration
             ch.concentration = None  # SRD: incapacitation breaks concentration
             combat.expire_concentration_effects(ch)  # ...and its engine-tracked effect
+            # F3-6: incapacitation ends the spell — free its held victims NOW (Hold Person
+            # paralysis, an allied Bless child), not a round later at next_turn's sweep.
+            _release_held_targets(c, character_id, was_conc or "")
         # Save-ends linkage (#209): record a TARGET-side ActiveEffect carrying the recurring
         # end-of-turn save + the condition it imposed, so next_turn self-enforces the escape.
         # The marker is NOT a concentration twin (concentration=False) — the caster's twin
@@ -4948,6 +4952,9 @@ def attack(
             warn = combat.melee_range_warning(c.combat.zones, attacker, target, az, tz)
             if warn:
                 result["range_warning"] = warn
+        # F3-6: capture the target's concentration BEFORE damage may down it (combat.apply_damage*
+        # clears it but is Character-pure and can't free the victim) — see the release after.
+        was_conc_target = target.concentration
         if hit:
             # A pending DAMAGE-maneuver bonus (#213) folds the already-rolled superiority die
             # into THIS strike as one extra typed component. The die is NOT re-rolled and NOT
@@ -5031,6 +5038,13 @@ def attack(
                     "applied": man_bonus.amount > 0,
                 }
             result["target_state"] = outcome
+            # F3-6: if this strike downed/killed a concentrating caster, free its held targets
+            # NOW (Hold Person paralysis, an allied Bless child) — the combat layer cleared the
+            # caster's concentration but can't see the campaign-wide victims.
+            if was_conc_target and target.concentration is None:
+                freed = _release_held_targets(c, target_id, was_conc_target)
+                if freed:
+                    result["freed_targets"] = freed
             kx = _award_kill_xp(c, target)
             if kx:
                 result["kill_xp"] = kx
@@ -5256,14 +5270,26 @@ def apply_damage(
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         target = _char(c, target_id)
+        was_conc = target.concentration  # F3-6: capture before damage may down the caster
         out = combat.apply_damage(target, amount, crit=crit, half=half, damage_type=damage_type)
         # F01-9: the engine auto-rolls the concentration save the instant damage lands
         # (combat.py returned the DC; it stays dice-free). Surfaced under
         # ``concentration_save`` so the DM narrates the break/hold without having to call
         # concentration_save by hand. None == target wasn't concentrating (unchanged path).
+        # This MAY break concentration (clears target.concentration on a failed save) — the
+        # F3-6 block below then frees any victims that spell was holding.
         conc = _auto_concentration_save(target, out.get("concentration_dc"))
         if conc is not None:
             out["concentration_save"] = conc
+        # F3-6: if this damage ended the caster's concentration — by downing/killing it
+        # (combat.apply_damage cleared it, but is Character-pure and can't see the victims) OR
+        # by the auto-rolled save above failing — free its held targets NOW. Inert when the
+        # target wasn't concentrating or is still concentrating.
+        freed = _release_held_targets(c, target_id, was_conc or "") if (
+            was_conc and target.concentration is None
+        ) else []
+        if freed:
+            out["freed_targets"] = freed
         kx = _award_kill_xp(c, target)
         if kx:
             out["kill_xp"] = kx
@@ -5331,6 +5357,40 @@ def set_temp_hp(campaign_id: str, target_id: str = "", amount: int = 0,
         return {"temp_hp": ch.temp_hp, "hp": f"{ch.current_hp}/{ch.max_hp}"}
 
 
+def _release_held_targets(c, caster_id: str, spell_name: str) -> list[dict]:
+    """Free every TARGET still locked by the just-ended concentration `spell_name` of
+    caster `caster_id` (F3-6): a repeat-save marker (Hold Person -> paralyzed) OR a
+    concentration-linked numeric-rider child (Bless on an ally, SYN-06/#780) is the
+    victim's twin of the caster's concentration — with the concentration gone the spell
+    is over, so drop the effect and lift the condition it imposed. This is the SAME
+    inverse-link reconciliation next_turn performs (server.py ~4017), run NOW at the
+    concentration-end site instead of a round later — so the four non-drop end paths
+    (failed concentration_save, caster incapacitation, caster 0 HP/death, a recast that
+    displaces the prior concentration) release the victim immediately, exactly like
+    drop_concentration already does. Returns the freed-target list (possibly empty).
+
+    A no-op when `spell_name` is falsy (the caster wasn't concentrating on anything) —
+    so every caller can pass the captured prior concentration unconditionally."""
+    freed: list[dict] = []
+    if not spell_name:
+        return freed
+    for holder in list(c.characters.values()):
+        for eff in list(holder.active_effects):
+            # A repeat-save marker (Hold Person) OR a concentration-linked numeric-rider
+            # child (Bless on an ally): both are target-side twins of THIS caster's
+            # concentration and end with it. A non-concentration save-ends source (a
+            # monster's innate hold) carries no source_id link, so it's never swept here.
+            if eff.repeat_save is None and not eff.linked_to_concentration:
+                continue
+            if eff.source_id != caster_id:
+                continue
+            if eff.name != spell_name:
+                continue
+            combat.end_repeat_save_effect(holder, eff)
+            freed.append({"character_id": holder.id, "name": eff.name})
+    return freed
+
+
 @mcp.tool()
 def concentration_save(campaign_id: str, character_id: str, dc: int) -> dict:
     """Roll a concentration saving throw (CON save) at the given DC (usually
@@ -5345,10 +5405,15 @@ def concentration_save(campaign_id: str, character_id: str, dc: int) -> dict:
         total = r.total + rider_bonus
         maintained = total >= dc
         expired: list[str] = []
+        freed: list[dict] = []
         if not maintained:
+            was = ch.concentration
             ch.concentration = None
             # The engine-tracked concentration effect ends with the concentration.
             expired = combat.expire_concentration_effects(ch)
+            # F3-6: a broken concentration ends the spell — so free its held victims NOW
+            # (Hold Person paralysis, an allied Bless child), not a round later at next_turn.
+            freed = _release_held_targets(c, character_id, was or "")
         save_campaign(c)
         out = {
             "roll": total,
@@ -5357,6 +5422,7 @@ def concentration_save(campaign_id: str, character_id: str, dc: int) -> dict:
             "maintained": maintained,
             "concentration": ch.concentration,
             "expired_effects": expired,
+            "freed_targets": freed,
         }
         if rider_rolls:
             out["bonus_dice"] = rider_rolls
@@ -5384,27 +5450,11 @@ def drop_concentration(campaign_id: str, character_id: str, reason: str = "") ->
         ch.concentration = None
         # The caster's own engine-tracked concentration effect(s) end with the concentration.
         expired = combat.expire_concentration_effects(ch)
-        # TARGET-side twin: a repeat-save marker (Hold Person -> paralyzed) is the victim's
-        # twin of THIS caster's concentration. With the concentration gone the spell is over,
-        # so free every holder whose marker is sourced to this caster + this spell — drop the
-        # effect and lift the condition it imposed. Mirrors next_turn's inverse-link sweep
-        # (server.py ~2999) so a voluntarily-dropped hold releases its victim immediately,
+        # TARGET-side twin: free every holder still locked by this caster's just-dropped
+        # concentration (Hold Person victim, an allied Bless child). Mirrors next_turn's
+        # inverse-link sweep so a voluntarily-dropped hold releases its victim immediately,
         # not a round later. We can only reconcile the spell we just dropped (`was`).
-        freed: list[dict] = []
-        if was:
-            for holder in list(c.characters.values()):
-                for eff in list(holder.active_effects):
-                    # A repeat-save marker (Hold Person) OR a concentration-linked numeric-
-                    # rider child (Bless on an ally — SYN-06/#780): both are target-side
-                    # twins of THIS caster's concentration and end with it.
-                    if eff.repeat_save is None and not eff.linked_to_concentration:
-                        continue
-                    if eff.source_id != character_id:
-                        continue
-                    if eff.name != was:
-                        continue
-                    combat.end_repeat_save_effect(holder, eff)
-                    freed.append({"character_id": holder.id, "name": eff.name})
+        freed = _release_held_targets(c, character_id, was or "")
         save_campaign(c)
         return {
             "ended": was is not None,
@@ -6406,7 +6456,13 @@ def cast_spell(
             # two stay one source of truth. Drop ALL prior concentration effects (covers
             # both replacing a different spell and recasting the same one — the fresh
             # effect registered below is authoritative). Do it BEFORE setting the field.
+            displaced_conc = ch.concentration
             combat.expire_concentration_effects(ch)
+            # F3-6: a recast that DISPLACES a different prior concentration ends that spell —
+            # free its held victims NOW (e.g. the cleric drops Hold Person to cast Bless), not
+            # a round later. Skip when recasting the SAME spell (the fresh marker rewrites it).
+            if displaced_conc and displaced_conc != canonical:
+                _release_held_targets(c, character_id, displaced_conc)
             ch.concentration = canonical  # replaces (breaks) any prior concentration
         # Register an engine-tracked timed effect so the spell auto-expires (instead of
         # relying on the DM to remember it). Concentration spells hold the effect on the

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -5391,6 +5391,39 @@ def _release_held_targets(c, caster_id: str, spell_name: str) -> list[dict]:
     return freed
 
 
+def _aoe_damage_spec(curated, srd, slot_level: int, caster_level: int, casting_mod: int):
+    """The damage expression + save ability + on-save rule + damage type for an AoE/multi-target
+    SAVE spell (F03-4), from whichever data source carries it, or None when the spell isn't a
+    resolvable save-for-damage area spell. Returns ``{damage, save_ability, on_save, damage_type}``
+    (save_ability/damage_type as short strings). Curated spells use resolve_effect (so upcast is
+    applied); an srd524-only spell uses its base damage_roll (upcast is prose-only there — kept
+    consistent with cast_spell's documented degrade contract: the BASE dice are rolled, the DM
+    upcasts by hand if the prose says so)."""
+    if curated is not None:
+        eff = spells.resolve_effect(curated, slot_level, caster_level, casting_mod)
+        if eff.get("kind") != "save" or not eff.get("damage"):
+            return None
+        return {
+            "damage": eff["damage"],
+            "save_ability": (eff.get("save_ability") or "dex"),
+            "on_save": (eff.get("on_save") or "half"),
+            "damage_type": (eff.get("damage_type") or ""),
+        }
+    if srd is not None:
+        save_ab = (srd.get("saving_throw_ability") or "").strip().lower()
+        dmg = srd.get("damage_roll") or ""
+        if not save_ab or not dmg:
+            return None  # not a save-for-damage area spell (e.g. Hold Person: save, no damage)
+        types = srd.get("damage_types") or []
+        return {
+            "damage": dmg,
+            "save_ability": save_ab,
+            "on_save": "half",  # SRD area save-for-half is the overwhelming default
+            "damage_type": (types[0] if types else ""),
+        }
+    return None
+
+
 @mcp.tool()
 def concentration_save(campaign_id: str, character_id: str, dc: int) -> dict:
     """Roll a concentration saving throw (CON save) at the given DC (usually
@@ -6327,6 +6360,8 @@ def cast_spell(
     npc_id: str = "",
     id: str = "",
     as_ritual: bool = False,
+    innate: bool = False,
+    target_ids: Optional[list] = None,
 ) -> dict:
     """Cast a spell — works for ANY of the ~339 SRD spells. Consumes a spell slot
     (cantrips use none); upcasts when slot_level exceeds the spell's level; sets
@@ -6396,6 +6431,27 @@ def cast_spell(
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _char(c, character_id)
+        # AoE / MULTI-TARGET VALIDATION (F03-4): validate-BEFORE-spend. Resolve EVERY id in
+        # `target_ids` up front; if ANY is unknown, reject the WHOLE cast cleanly here — BEFORE
+        # the slot spend / concentration set (the engine's rejection-before-state-change
+        # discipline). A non-empty list means "the engine resolves the area's per-target damage
+        # saves itself" (one shared damage roll, full/half per save). Empty/None = today's
+        # single-target behavior, byte-identical. Order-preserving + de-duped.
+        aoe_targets: list = []
+        if target_ids:
+            seen_ids: set[str] = set()
+            for tid in target_ids:
+                tid = str(tid)
+                if tid in seen_ids:
+                    continue
+                tgt = c.characters.get(tid)
+                if tgt is None:
+                    raise ValueError(
+                        f"unknown target id {tid!r} in target_ids — the whole AoE cast is "
+                        f"rejected (no slot spent). Check the id and re-cast."
+                    )
+                seen_ids.add(tid)
+                aoe_targets.append(tgt)
         # SRD: an incapacitated creature can't take an action — and a spell's casting time is
         # (almost always) an action/bonus/reaction, so refuse the cast outright rather than
         # spend the caster's slot / set concentration. Mirrors the attack() guard. (extends #42)
@@ -6463,14 +6519,35 @@ def cast_spell(
             if cf not in known_cf:
                 raise ValueError(f"{ch.name} doesn't know or have {canonical!r} prepared")
         slot_used = None
+        # INNATE CASTING (F03-11): a monster/NPC casts a leveled spell from an innate/at-will
+        # trait (a Mage Hand Press archmage, a drow's Darkness) — there is no Vancian slot to
+        # spend. `innate=True` skips the slot CHECK and SPEND but keeps every other cast
+        # semantic (concentration, duration, the on-hit/save-ends rider, the DC), so an enemy
+        # Hold Person routes through cast_spell and composes with F03-6's release. No-slot
+        # state integrity: slot_used is reported as "innate" (not a level). Still honors the
+        # downcast guard so you can't claim a sub-level cast.
+        if spell_level > 0 and not as_ritual and innate:
+            lvl = spell_level if slot_level is None else slot_level
+            if lvl < spell_level:
+                raise ValueError(f"cannot cast a level-{spell_level} spell with a level-{lvl} slot")
+            slot_used = "innate"
         # A ritual cast consumes NO slot (#813) — the +10 minutes is the cost; the
         # spell resolves at its base level (a ritual can't be upcast).
-        if spell_level > 0 and not as_ritual:
+        elif spell_level > 0 and not as_ritual:
             lvl = spell_level if slot_level is None else slot_level
             if lvl < spell_level:
                 raise ValueError(f"cannot cast a level-{spell_level} spell with a level-{lvl} slot")
             slot = ch.spell_slots.get(lvl)
             if slot is None or slot.used >= slot.maximum:
+                # Enrich the affordance for a monster/NPC caster (F03-11): no spawn path seeds
+                # spell_slots, so a stat-block caster has none — point at innate=True rather than
+                # leaving a dead end. PCs keep the plain slot-exhausted message.
+                if ch.kind in ("monster", "npc"):
+                    raise ValueError(
+                        f"{ch.name} has no level-{lvl} spell slot — a monster/NPC stat block "
+                        f"carries no Vancian slots. For an innate/at-will trait cast, pass "
+                        f"innate=True (no slot spent); otherwise seed spell_slots first."
+                    )
                 raise ValueError(f"no level-{lvl} spell slot available")
             slot.used += 1
             slot_used = lvl
@@ -6608,6 +6685,87 @@ def cast_spell(
             c.characters[rider_child_target.id] = Character.model_validate(
                 rider_child_target.model_dump(mode="json")
             )
+        # AoE / MULTI-TARGET RESOLUTION (F03-4). Targets were validated up front (before the
+        # slot spend). Now the area save-for-damage spell is resolved by the ENGINE: ONE shared
+        # damage roll for the whole area, then a per-target saving throw vs the caster's DC,
+        # applying full damage on a fail and half on a success (5e area-save default). Existing
+        # save discipline applies per target via combat.save_modifiers (a paralyzed target
+        # auto-fails its DEX save; restrained → disadvantage), and damage runs through the same
+        # combat.apply_damage pipeline as everything else (resistances, temp HP, downing, the
+        # concentration-check DC). One lock, one write. Surfaced as a per-target result table.
+        aoe_result = None
+        if aoe_targets:
+            spec = _aoe_damage_spec(
+                curated, srd,
+                slot_used if isinstance(slot_used, int) else spell_level,
+                ch.total_level, mod,
+            )
+            save_dc = 8 + prof + mod
+            if spec is None:
+                # A non-damage area spell (or an un-resolvable record): we still validated the
+                # ids and report them, but the DM resolves the effect (no engine damage to roll).
+                aoe_result = {
+                    "shared_damage": None,
+                    "save_dc": save_dc,
+                    "note": (
+                        "No engine-resolvable area damage for this spell — the targets are "
+                        "validated; resolve the effect per target by hand (saving_throw + "
+                        "apply_damage / add_condition)."
+                    ),
+                    "targets": [{"character_id": t.id, "name": t.name} for t in aoe_targets],
+                }
+            else:
+                save_ab = Ability(spec["save_ability"])
+                dmg = dice_mod.roll(spec["damage"])  # ONE roll shared across the whole area
+                rows: list[dict] = []
+                for t in aoe_targets:
+                    auto_fail, disadvantage = combat.save_modifiers(t, save_ab)
+                    sr = dice_mod.roll(
+                        f"1d20+{t.saving_throw_bonus(save_ab)}", disadvantage=disadvantage
+                    )
+                    saved = (not auto_fail) and sr.total >= save_dc
+                    half = saved and spec["on_save"] == "half"
+                    # A successful save vs an on_save != "half" spell (rare for pure damage)
+                    # negates entirely; resolve that as zero applied.
+                    if saved and spec["on_save"] != "half":
+                        outcome = {**combat.status(t), "damage_to_hp": 0, "absorbed": 0,
+                                   "concentration_dc": None}
+                    else:
+                        was_tc = t.concentration  # F03-6: free this target's held victims if downed
+                        outcome = combat.apply_damage(
+                            t, dmg.total, half=half, damage_type=spec["damage_type"]
+                        )
+                        if was_tc and t.concentration is None:
+                            _release_held_targets(c, t.id, was_tc)
+                    c.characters[t.id] = Character.model_validate(t.model_dump(mode="json"))
+                    kx = _award_kill_xp(c, t)
+                    row = {
+                        "character_id": t.id,
+                        "name": t.name,
+                        "save_roll": sr.total,
+                        "natural": sr.natural,
+                        "saved": saved,
+                        "damage_taken": outcome.get("damage_to_hp", 0),
+                        "current_hp": outcome.get("current_hp"),
+                        "halved": half,
+                    }
+                    if auto_fail:
+                        row["auto_fail"] = True
+                    if disadvantage:
+                        row["disadvantage"] = True
+                    if outcome.get("concentration_dc"):
+                        row["concentration_dc"] = outcome["concentration_dc"]
+                    if kx:
+                        row["kill_xp"] = kx
+                    rows.append(row)
+                aoe_result = {
+                    "shared_damage": {"total": dmg.total, "expr": spec["damage"],
+                                      "type": spec["damage_type"], "detail": dmg.detail},
+                    "save_ability": save_ab.value,
+                    "save_dc": save_dc,
+                    "on_save": spec["on_save"],
+                    "targets": rows,
+                }
         # An off-turn / reaction cast spends the caster's reaction (the combatant record
         # is separate from the character, so the re-validation above didn't touch it).
         if cast_consumes_reaction and caster_cb is not None:
@@ -6629,6 +6787,20 @@ def cast_spell(
                 str(lv): s.maximum - s.used for lv, s in updated.spell_slots.items()
             },
         }
+        # AoE / multi-target table (F03-4): the engine-resolved per-target save+damage outcomes
+        # (one shared damage roll, full/half per save). Present only when target_ids was passed.
+        if aoe_result is not None:
+            result["aoe"] = aoe_result
+        # AREA SHAPE (F03-4): surface the spell's geometry (Cone/Sphere/Line + size) from the
+        # srd524 record so the DM can describe the area and pick who's caught — 52 spells carry
+        # it and it was previously never told. Additive; absent when the record has no shape.
+        shape_rec = srd or {}
+        if shape_rec.get("shape_type"):
+            shape = {"type": shape_rec.get("shape_type")}
+            if shape_rec.get("shape_size"):
+                shape["size"] = shape_rec.get("shape_size")
+                shape["unit"] = shape_rec.get("shape_size_unit") or "feet"
+            result["shape"] = shape
         # Ritual surfacing (#813): a ritual cast is told to the DM explicitly (no slot
         # was spent); a NORMAL cast of a ritual-tagged spell advertises the slot-free
         # option so the DM learns it exists. Both fields are additive.

--- a/servers/engine/spells.py
+++ b/servers/engine/spells.py
@@ -52,6 +52,21 @@ def srd_spell(name: str):
     return _srd524().get(name.strip().lower())
 
 
+def canonical_name(name: str) -> Optional[str]:
+    """The canonical-cased SRD spell name for `name` (case-insensitive), or None if
+    `name` is not any of the ~339 SRD spells. Prefers the hand-authored curated record's
+    casing, falling back to the srd524 dump — both store the proper name, the lookup tables
+    casefold on read. Used by learn_spells/prepare_spells to canonicalize+validate on WRITE
+    (F03-7), so the case-sensitive cast gate compares like against like."""
+    if not name or not name.strip():
+        return None
+    key = name.strip().lower()
+    rec = _all().get(key) or _srd524().get(key)
+    if rec is None:
+        return None
+    return rec.get("name") or name.strip()
+
+
 def _parse_dice(expr: str) -> tuple[int, int]:
     """Parse the dice part of 'NdM(+K)' -> (N, M), ignoring any flat modifier."""
     body = expr.lower().split("+")[0].split("-")[0]

--- a/servers/engine/tests/test_effect_durations.py
+++ b/servers/engine/tests/test_effect_durations.py
@@ -620,25 +620,24 @@ def test_paralyzed_does_not_autofail_the_wis_repeat_save(monkeypatch):
 
 def test_caster_losing_concentration_frees_the_paralyzed_target(monkeypatch):
     """INVERSE direction (#209): if the CASTER's concentration ends (here: incapacitated),
-    Hold Person is over — so next_turn frees the target (drops the marker + the paralyzed
-    condition) instead of leaving it locked indefinitely. One source of truth, both ways."""
+    Hold Person is over — the target is freed. F3-6 moved that release to the concentration-end
+    SITE (the add_condition call), so the foe is freed IMMEDIATELY, not a round later — and the
+    next_turn inverse-link sweep is then a clean no-op backstop (nothing left to reconcile)."""
     cid = server.create_campaign("S")["id"]
     caster = _hold_caster(cid)
     foe = _humanoid(cid, wis=8)
     _lock_foe_with_hold_person(cid, caster, foe, monkeypatch)
     assert "paralyzed" in server.get_character(cid, foe)["conditions"]
-    # Break the caster's concentration directly (stun it) — its twin effect drops immediately,
-    # but the TARGET's marker + paralyzed persist until the reconciliation pass in next_turn.
+    # Break the caster's concentration directly (stun it). F3-6: the target's marker + paralyzed
+    # are now freed in this SAME call, not deferred to next_turn.
     server.add_condition(cid, caster, "stunned")
     assert server.get_character(cid, caster)["concentration"] is None  # concentration broke
-    assert "paralyzed" in server.get_character(cid, foe)["conditions"]  # not yet reconciled
-    # A FAILED foe save would normally KEEP the lock — but the caster no longer concentrates,
-    # so the reconciliation frees the foe regardless of the (irrelevant) save roll.
+    assert _effects(cid, foe) == []  # freed NOW (was: locked until next_turn)
+    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]
+    # The next_turn sweep is now a no-op backstop for this foe — nothing left to expire.
     monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(1))
     v = server.next_turn(cid)
-    assert {"character_id": foe, "name": "Hold Person"} in v["expired_effects"]
-    assert _effects(cid, foe) == []
-    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]  # freed via the link
+    assert {"character_id": foe, "name": "Hold Person"} not in v["expired_effects"]
 
 
 def test_non_concentration_save_ends_source_is_not_concentration_swept(monkeypatch):
@@ -1120,3 +1119,111 @@ def test_plain_buff_clock_expiry_regression_conditions_untouched():
     assert _effects(cid, cleric) == []
     assert server.get_character(cid, cleric)["concentration"] is None
     assert "poisoned" in server.get_character(cid, cleric)["conditions"]
+
+
+# --- F3-6: ALL concentration-end paths release the held victim IMMEDIATELY -----
+# drop_concentration already frees (test_drop_concentration_clears_field_and_linked_effect
+# + #830); these cover the OTHER four end paths that previously only cleared the caster side
+# and left the victim locked until the next next_turn sweep.
+def _ic_hold_pair(cid, monkeypatch):
+    """Set up an in-combat Hold Person lock and return (caster, foe). Leaves the foe paralyzed
+    with a self-enforcing marker linked to the caster's concentration."""
+    caster = _hold_caster(cid)
+    foe = _humanoid(cid, wis=8)
+    _lock_foe_with_hold_person(cid, caster, foe, monkeypatch)
+    assert "paralyzed" in server.get_character(cid, foe)["conditions"]
+    return caster, foe
+
+
+def test_failed_concentration_save_frees_held_victim_immediately(monkeypatch):
+    """F3-6: a FAILED concentration_save ends the spell — its paralyzed victim is freed in the
+    SAME call (surfaced in freed_targets), not a round later at next_turn."""
+    cid = server.create_campaign("S")["id"]
+    caster, foe = _ic_hold_pair(cid, monkeypatch)
+    out = server.concentration_save(cid, caster, 999)  # forced fail
+    assert out["maintained"] is False
+    assert {"character_id": foe, "name": "Hold Person"} in out["freed_targets"]
+    assert _effects(cid, foe) == []
+    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]
+    assert server.get_character(cid, caster)["concentration"] is None
+
+
+def test_caster_incapacitation_frees_held_victim_immediately(monkeypatch):
+    """F3-6: incapacitating the caster (stunned) breaks concentration — the Hold Person victim
+    is freed in the SAME add_condition call, not a round later."""
+    cid = server.create_campaign("S")["id"]
+    caster, foe = _ic_hold_pair(cid, monkeypatch)
+    server.add_condition(cid, caster, "stunned")  # incapacitating -> breaks concentration
+    assert server.get_character(cid, caster)["concentration"] is None
+    assert _effects(cid, foe) == []  # freed NOW (was: still locked until next_turn)
+    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]
+
+
+def test_recast_displacing_concentration_frees_prior_victim_immediately(monkeypatch):
+    """F3-6: casting a NEW concentration spell that displaces a prior Hold Person frees that
+    hold's victim in the SAME cast_spell call (one source of truth)."""
+    cid = server.create_campaign("S")["id"]
+    caster, foe = _ic_hold_pair(cid, monkeypatch)
+    # Give the caster a second concentration spell to displace Hold Person with.
+    server.learn_spells(cid, caster, ["Hold Person", "Shield of Faith"])
+    server.prepare_spells(cid, caster, ["Hold Person", "Shield of Faith"])
+    # The caster (back on its own turn) recasts a different concentration spell, displacing
+    # Hold Person — its held victim must be freed in the SAME cast call.
+    _advance_to(cid, caster)
+    server.cast_spell(cid, caster, "Shield of Faith")  # different concentration spell
+    assert server.get_character(cid, caster)["concentration"] == "Shield of Faith"
+    assert _effects(cid, foe) == []  # the displaced hold's victim is freed immediately
+    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]
+
+
+def test_caster_downed_via_apply_damage_frees_held_victim_immediately(monkeypatch):
+    """F3-6: dropping the caster to 0 HP via apply_damage ends concentration AND frees the
+    Hold Person victim in the SAME call (the combat layer is Character-pure, so the server
+    tool does the campaign-wide release)."""
+    cid = server.create_campaign("S")["id"]
+    caster, foe = _ic_hold_pair(cid, monkeypatch)
+    hp = server.get_character(cid, caster)["max_hp"]
+    out = server.apply_damage(cid, caster, hp + 50)  # massive -> down/dead, concentration ends
+    assert server.get_character(cid, caster)["concentration"] is None
+    assert {"character_id": foe, "name": "Hold Person"} in out["freed_targets"]
+    assert _effects(cid, foe) == []
+    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]
+
+
+def test_caster_downed_via_attack_frees_held_victim_immediately(monkeypatch):
+    """F3-6: a melee strike that downs the concentrating caster frees the Hold Person victim
+    in the SAME attack() call (the OTHER server-side damage path the spec calls out)."""
+    cid = server.create_campaign("S")["id"]
+    caster = _hold_caster(cid)
+    foe = _humanoid(cid, wis=8)
+    bruiser = server.create_character(cid, "Bruiser", kind="monster", max_hp=40,
+                                      abilities={"strength": 18})["id"]
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(10))
+    server.start_combat(cid, [caster, foe, bruiser])
+    _advance_to(cid, caster)
+    out = server.cast_spell(cid, caster, "Hold Person", target_id=foe)
+    server.add_condition(cid, foe, "paralyzed", **{
+        k: out["condition_rider"][k]
+        for k in ("repeat_save_ability", "repeat_save_dc", "source_id", "spell_name")
+    })
+    assert "paralyzed" in server.get_character(cid, foe)["conditions"]
+    # Drop the caster to 1 HP so any landed hit downs it; advance to the bruiser's turn.
+    server.set_hp(cid, caster, 1)
+    _advance_to(cid, bruiser)
+    # Force a nat-20 (guaranteed crit hit) so the strike lands and downs the 1-HP caster.
+    monkeypatch.setattr(server.dice_mod, "roll", _d20_roll(20))
+    res = server.attack(cid, bruiser, caster, damage_dice="2d6")
+    assert res["hit"] is True
+    assert server.get_character(cid, caster)["concentration"] is None
+    assert {"character_id": foe, "name": "Hold Person"} in res["freed_targets"]
+    assert "paralyzed" not in server.get_character(cid, foe)["conditions"]
+
+
+def test_concentration_save_release_inert_when_no_held_victim(monkeypatch):
+    """ADDITIVE: a failed concentration_save with no held victim surfaces an empty
+    freed_targets — byte-compatible with the prior return plus the new (empty) key."""
+    cid = server.create_campaign("S")["id"]
+    c = _cleric(cid)
+    server.cast_spell(cid, c, "Bless")  # self-buff, no held target
+    out = server.concentration_save(cid, c, 999)
+    assert out["maintained"] is False and out["freed_targets"] == []

--- a/servers/engine/tests/test_effect_riders.py
+++ b/servers/engine/tests/test_effect_riders.py
@@ -197,9 +197,10 @@ def test_drop_concentration_frees_linked_children(tmp_path, monkeypatch):
     assert server.get_character(cid, ally)["active_effects"] == []
 
 
-def test_next_turn_sweep_frees_linked_children(tmp_path, monkeypatch):
-    # The inverse-link sweep: caster's concentration broke some other way (a failed
-    # concentration save) -> the next next_turn releases the blessed ally's child.
+def test_failed_concentration_save_frees_linked_children_immediately(tmp_path, monkeypatch):
+    # F3-6: a failed concentration save now releases the blessed ally's linked child in the
+    # SAME call (surfaced in freed_targets), not deferred to the next next_turn sweep. The
+    # sweep remains a clean no-op backstop afterward.
     monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
     cid = server.create_campaign("SweepConc")["id"]
     caster = server.create_character(cid, "Priest", kind="monster", max_hp=20)["id"]
@@ -211,9 +212,11 @@ def test_next_turn_sweep_frees_linked_children(tmp_path, monkeypatch):
     # break the caster's concentration the non-voluntary way (impossible DC)
     cs = server.concentration_save(cid, caster, dc=100)
     assert cs["maintained"] is False
+    assert {"character_id": ally, "name": "Bless"} in cs["freed_targets"]
+    assert server.get_character(cid, ally)["active_effects"] == []  # freed immediately
+    # The next_turn sweep is a no-op backstop now (nothing left to reconcile).
     nt = server.next_turn(cid)
-    assert {"character_id": ally, "name": "Bless"} in nt["expired_effects"]
-    assert server.get_character(cid, ally)["active_effects"] == []
+    assert {"character_id": ally, "name": "Bless"} not in nt["expired_effects"]
 
 
 def test_cast_result_advertises_engine_applied_riders(tmp_path, monkeypatch):

--- a/servers/engine/tests/test_spellcasting.py
+++ b/servers/engine/tests/test_spellcasting.py
@@ -223,6 +223,9 @@ def _wizard_at(cid, level, name="Gale"):
     w = server.create_character(cid, name, kind="player", class_name="Wizard", level=level,
                                 apply_srd_defaults=True, abilities={"intelligence": 16})["id"]
     server.learn_spells(cid, w, ["Acid Splash", "Eldritch Blast", "Fireball"])
+    # Prepare Fireball too (F03-8: a non-empty prepared list now gates leveled casts; the
+    # seeded loadout doesn't include Fireball, so add it for the scaling tests that cast it).
+    server.prepare_spells(cid, w, ["Fireball"], mode="add")
     return w
 
 
@@ -320,3 +323,107 @@ def test_non_ritual_normal_casts_unchanged_no_ritual_fields():
     w = _ritual_wizard(cid)
     out = server.cast_spell(cid, w, "Magic Missile")
     assert "ritual_cast" not in out and "ritual_available" not in out
+
+
+# --- F03-7: learn/prepare canonicalize + validate; case-insensitive cast gate ----
+def _blank_wizard(cid, **abil):
+    """A wizard with NO seeded loadout (apply_srd_defaults False) so the spellbook is exactly
+    what the test learns — isolates the gate from the starter-loadout union."""
+    ab = {"intelligence": 16, "constitution": 12}
+    ab.update(abil)
+    w = server.create_character(cid, "Gale", kind="player", class_name="Wizard",
+                                apply_srd_defaults=True, abilities=ab)["id"]
+    server.learn_spells(cid, w, [])      # clear seeded known
+    server.prepare_spells(cid, w, [])    # clear seeded prepared
+    return w
+
+
+def test_learn_lowercase_then_cast_canonical_passes():
+    """F03-7 (THE BUG): learn_spells stored raw strings, so a lowercase learn made the
+    canonical-cased cast gate reject every cast. Now names are canonicalized on write."""
+    cid = server.create_campaign("S")["id"]
+    w = _blank_wizard(cid)
+    server.learn_spells(cid, w, ["magic missile"])  # lowercase
+    sheet = server.get_character(cid, w)
+    assert sheet["spells_known"] == ["Magic Missile"]  # stored proper-cased
+    server.cast_spell(cid, w, "Magic Missile")  # previously raised "doesn't know" — now OK
+
+
+def test_learn_unknown_spell_rejected_at_learn_time_listing_offenders():
+    """F03-7: an unknown/typo spell is rejected when LEARNED (not silently stored to fail at
+    cast), and the error names every offender so the DM can fix the input."""
+    cid = server.create_campaign("S")["id"]
+    w = _blank_wizard(cid)
+    with pytest.raises(ValueError, match="Definitely Not A Spell"):
+        server.learn_spells(cid, w, ["Magic Missile", "Definitely Not A Spell"])
+    # Nothing was stored (rejection before any state change).
+    assert server.get_character(cid, w)["spells_known"] == []
+
+
+def test_learn_mode_add_appends_without_relisting():
+    """F03-7: mode='add' appends new spells to the known list (de-duped) — teach one without
+    re-listing the whole spellbook. Default mode stays 'replace'."""
+    cid = server.create_campaign("S")["id"]
+    w = _blank_wizard(cid)
+    server.learn_spells(cid, w, ["Magic Missile"])
+    out = server.learn_spells(cid, w, ["fire bolt", "Magic Missile"], mode="add")  # dup ignored
+    assert out["spells_known"] == ["Magic Missile", "Fire Bolt"]
+
+
+def test_prepare_unknown_spell_rejected():
+    """F03-7: prepare_spells validates+canonicalizes identically."""
+    cid = server.create_campaign("S")["id"]
+    w = _blank_wizard(cid)
+    with pytest.raises(ValueError, match="unknown spell"):
+        server.prepare_spells(cid, w, ["Not Real"])
+
+
+def test_legacy_lowercase_snapshot_still_casts():
+    """F03-7 round-trip: an OLD snapshot whose spells_known carries raw-cased strings (written
+    before canonicalization) must still cast — the gate compares case-insensitively on read."""
+    cid = server.create_campaign("S")["id"]
+    w = _blank_wizard(cid)
+    # Simulate a legacy snapshot via the raw model patch (bypasses learn_spells canonicalization).
+    server.update_character(cid, w, patch={"spells_known": ["magic missile"],
+                                           "spells_prepared": ["magic missile"]})
+    server.cast_spell(cid, w, "Magic Missile")  # casefolded compare accepts the legacy casing
+
+
+# --- F03-8: prepared discipline — a non-empty prepared list gates leveled casts --
+def test_unprepared_leveled_cast_rejected_when_prepared_nonempty():
+    """F03-8 (THE NO-OP): with a non-empty prepared list, a leveled spell that is KNOWN but
+    NOT PREPARED is now rejected — preparation has mechanical weight (was a union no-op)."""
+    cid = server.create_campaign("S")["id"]
+    w = _blank_wizard(cid)
+    server.learn_spells(cid, w, ["Magic Missile", "Shield"])
+    server.prepare_spells(cid, w, ["Shield"])  # Magic Missile known but NOT prepared
+    with pytest.raises(ValueError, match="hasn't prepared"):
+        server.cast_spell(cid, w, "Magic Missile")
+    server.cast_spell(cid, w, "Shield")  # prepared -> allowed
+
+
+def test_empty_prepared_keeps_lenient_known_gate():
+    """F03-8 legacy guard: an EMPTY prepared list keeps the lenient known-only gate (today's
+    behavior) — a known-spell cast still works without preparing it (sorcerer / old snapshot)."""
+    cid = server.create_campaign("S")["id"]
+    w = _blank_wizard(cid)
+    server.learn_spells(cid, w, ["Magic Missile"])  # known, prepared stays empty
+    server.cast_spell(cid, w, "Magic Missile")  # lenient: empty prepared -> known gate only
+
+
+def test_cantrip_castable_when_known_even_if_not_prepared():
+    """F03-8: cantrips are never 'prepared' in 5e — a known cantrip is castable even with a
+    non-empty (leveled) prepared list that doesn't list it."""
+    cid = server.create_campaign("S")["id"]
+    w = _blank_wizard(cid)
+    server.learn_spells(cid, w, ["Fire Bolt", "Magic Missile"])
+    server.prepare_spells(cid, w, ["Magic Missile"])  # leveled prep; cantrip not listed
+    server.cast_spell(cid, w, "Fire Bolt")  # cantrip -> allowed via known, not prepared
+
+
+def test_both_lists_empty_stays_fully_lenient():
+    """F03-8 / F03-7 additive: with BOTH lists empty the gate is skipped entirely (today's
+    behavior for a monster/NPC or an un-loadout-ed caster) — no rejection."""
+    cid = server.create_campaign("S")["id"]
+    w = _blank_wizard(cid)
+    server.cast_spell(cid, w, "Magic Missile")  # no known/prepared -> lenient pass

--- a/servers/engine/tests/test_spellcasting.py
+++ b/servers/engine/tests/test_spellcasting.py
@@ -427,3 +427,197 @@ def test_both_lists_empty_stays_fully_lenient():
     cid = server.create_campaign("S")["id"]
     w = _blank_wizard(cid)
     server.cast_spell(cid, w, "Magic Missile")  # no known/prepared -> lenient pass
+
+
+# --- F03-11: innate casting — monsters/NPCs route a leveled spell through cast_spell ---
+def test_monster_leveled_cast_without_slot_is_rejected_with_innate_hint():
+    """F03-11 (THE GAP): no spawn path seeds spell_slots, so a monster casting a leveled spell
+    fails for lack of a slot — but the error now POINTS at innate=True instead of dead-ending."""
+    cid = server.create_campaign("S")["id"]
+    foe = server.create_character(cid, "Drow Mage", kind="monster", max_hp=40,
+                                  abilities={"charisma": 16})["id"]
+    with pytest.raises(ValueError, match="innate=True"):
+        server.cast_spell(cid, foe, "Hold Person")  # no slots seeded
+
+
+def test_innate_leveled_cast_skips_slot_and_sets_concentration():
+    """F03-11: innate=True casts a leveled spell with NO slot spent (slot_used='innate') while
+    keeping concentration/duration — an enemy caster's spell state is now engine-tracked."""
+    cid = server.create_campaign("S")["id"]
+    foe = server.create_character(cid, "Drow Mage", kind="monster", max_hp=40,
+                                  abilities={"charisma": 16})["id"]
+    out = server.cast_spell(cid, foe, "Hold Person", innate=True)
+    assert out["slot_used"] == "innate"
+    assert out["concentration"] == "Hold Person"
+    assert server.get_character(cid, foe)["concentration"] == "Hold Person"
+
+
+def test_innate_monster_hold_person_concentration_and_release_compose_with_f0306():
+    """F03-11 + F03-6: a spawned monster casts Hold Person innate=True on a PC, the PC is
+    paralyzed with a self-enforcing marker linked to the MONSTER's concentration — and
+    breaking the monster's concentration (drop_concentration) frees the PC immediately."""
+    cid = server.create_campaign("S")["id"]
+    monster = server.create_character(cid, "Drow Mage", kind="monster", max_hp=40,
+                                      abilities={"charisma": 16})["id"]
+    pc = server.create_character(cid, "Hero", kind="player", max_hp=30,
+                                 abilities={"wisdom": 8})["id"]
+    out = server.cast_spell(cid, monster, "Hold Person", target_id=pc, innate=True)
+    assert out["slot_used"] == "innate"
+    rider = out["condition_rider"]  # the save-ends rider is still surfaced
+    server.add_condition(cid, pc, "paralyzed", **{
+        k: rider[k] for k in ("repeat_save_ability", "repeat_save_dc", "source_id", "spell_name")
+    })
+    assert "paralyzed" in server.get_character(cid, pc)["conditions"]
+    # Breaking the monster's concentration frees the PC (composes with F03-6's release).
+    freed = server.drop_concentration(cid, monster)
+    assert {"character_id": pc, "name": "Hold Person"} in freed["freed_targets"]
+    assert "paralyzed" not in server.get_character(cid, pc)["conditions"]
+
+
+def test_innate_downcast_still_rejected():
+    """F03-11: innate skips the SLOT check but still honors the downcast guard — you can't
+    claim a level-2 spell cast at level 1."""
+    cid = server.create_campaign("S")["id"]
+    foe = server.create_character(cid, "Drow Mage", kind="monster", max_hp=40,
+                                  abilities={"charisma": 16})["id"]
+    with pytest.raises(ValueError, match="level-1 slot"):
+        server.cast_spell(cid, foe, "Hold Person", slot_level=1, innate=True)
+
+
+def test_innate_false_default_is_byte_identical_for_pc():
+    """ADDITIVE: innate defaults False — a PC's normal slot-spending cast is unchanged."""
+    cid = server.create_campaign("S")["id"]
+    w = server.create_character(cid, "Gale", kind="player", class_name="Wizard",
+                                apply_srd_defaults=True, abilities={"intelligence": 16})["id"]
+    out = server.cast_spell(cid, w, "Magic Missile")  # default innate=False -> spends a slot
+    assert out["slot_used"] == 1
+    assert out["slots_remaining"]["1"] == 1  # a slot was consumed
+
+
+def test_innate_cantrip_unaffected_no_slot_either_way():
+    """F03-11 regression: a cantrip needs no slot regardless of innate — the flag is inert for
+    a level-0 spell (a monster could already cast cantrips; this stays true)."""
+    cid = server.create_campaign("S")["id"]
+    foe = server.create_character(cid, "Drow Mage", kind="monster", max_hp=40,
+                                  abilities={"charisma": 16})["id"]
+    out = server.cast_spell(cid, foe, "Fire Bolt", innate=True)
+    assert out["slot_used"] is None  # cantrip path untouched by innate
+
+
+# --- F03-4: AoE / multi-target cast path (validate-before-spend) ------------------
+from dice import DiceRoll  # noqa: E402
+
+
+def _fixed_roll(d20_natural: int, dmg_total: int):
+    """A dice stub: every 1d20 save rolls the given natural (+ the expression's flat mod);
+    every other expression (the shared AoE damage) returns dmg_total. Deterministic per-target
+    save outcomes + a single known damage figure."""
+    def _roll(expression, advantage=False, disadvantage=False, seed=None):
+        if expression.startswith("1d20"):
+            mod = 0
+            if "+" in expression:
+                mod = int(expression.split("+", 1)[1])
+            return DiceRoll(expression=expression, total=d20_natural + mod, rolls=[d20_natural],
+                            modifier=mod, detail="", is_d20=True, natural=d20_natural,
+                            crit=(d20_natural == 20), fumble=(d20_natural == 1))
+        return DiceRoll(expression=expression, total=dmg_total, rolls=[dmg_total], detail="")
+    return _roll
+
+
+def _aoe_wizard(cid, level=3):
+    w = server.create_character(cid, "Gale", kind="player", class_name="Wizard", level=level,
+                                apply_srd_defaults=True, abilities={"intelligence": 16})["id"]
+    server.learn_spells(cid, w, ["Burning Hands"])
+    server.prepare_spells(cid, w, ["Burning Hands"], mode="add")
+    return w
+
+
+def test_aoe_burning_hands_one_shared_roll_per_target_halving(monkeypatch):
+    """F03-4: Burning Hands at three targets — ONE shared damage roll, a per-target DEX save,
+    full damage on a fail and half on a save. Slot spent once."""
+    cid = server.create_campaign("S")["id"]
+    w = _aoe_wizard(cid)
+    # Three monsters: one with low DEX (fails) and one with high DEX (we'll force the roll to
+    # decide outcome) — outcome is driven by the forced d20 natural below.
+    a = server.create_character(cid, "Orc A", kind="monster", max_hp=30, abilities={"dexterity": 10})["id"]
+    b = server.create_character(cid, "Orc B", kind="monster", max_hp=30, abilities={"dexterity": 10})["id"]
+    c2 = server.create_character(cid, "Orc C", kind="monster", max_hp=30, abilities={"dexterity": 10})["id"]
+    # Force a low save (nat 2 -> total 2, under any DC) so all three FAIL -> full damage.
+    monkeypatch.setattr(server.dice_mod, "roll", _fixed_roll(2, 12))
+    out = server.cast_spell(cid, w, "Burning Hands", target_ids=[a, b, c2])
+    assert out["slot_used"] == 1  # one slot, even for three targets
+    aoe = out["aoe"]
+    assert aoe["shared_damage"]["total"] == 12  # ONE roll shared across the area
+    assert aoe["save_ability"] == "dex" and aoe["save_dc"] == out["spell_save_dc"]
+    assert len(aoe["targets"]) == 3
+    for row in aoe["targets"]:
+        assert row["saved"] is False and row["damage_taken"] == 12 and row["halved"] is False
+    # Every target actually lost 12 HP through the shared apply_damage pipeline.
+    for tid in (a, b, c2):
+        assert server.get_character(cid, tid)["current_hp"] == 18
+
+
+def test_aoe_successful_save_halves(monkeypatch):
+    """F03-4: a target who SAVES takes half the shared damage (5e area save-for-half)."""
+    cid = server.create_campaign("S")["id"]
+    w = _aoe_wizard(cid)
+    tgt = server.create_character(cid, "Nimble", kind="monster", max_hp=30,
+                                  abilities={"dexterity": 20})["id"]
+    monkeypatch.setattr(server.dice_mod, "roll", _fixed_roll(20, 12))  # nat 20 -> save succeeds
+    out = server.cast_spell(cid, w, "Burning Hands", target_ids=[tgt])
+    row = out["aoe"]["targets"][0]
+    assert row["saved"] is True and row["halved"] is True and row["damage_taken"] == 6  # 12 // 2
+    assert server.get_character(cid, tgt)["current_hp"] == 24
+
+
+def test_aoe_paralyzed_target_auto_fails_dex_save(monkeypatch):
+    """F03-4: a paralyzed target AUTO-FAILS its DEX save (combat.save_modifiers) — full damage
+    even though the forced roll would otherwise succeed."""
+    cid = server.create_campaign("S")["id"]
+    w = _aoe_wizard(cid)
+    tgt = server.create_character(cid, "Held", kind="monster", max_hp=30,
+                                  abilities={"dexterity": 20})["id"]
+    server.add_condition(cid, tgt, "paralyzed")
+    monkeypatch.setattr(server.dice_mod, "roll", _fixed_roll(20, 12))  # nat 20 would save...
+    out = server.cast_spell(cid, w, "Burning Hands", target_ids=[tgt])
+    row = out["aoe"]["targets"][0]
+    assert row["saved"] is False and row.get("auto_fail") is True  # ...but paralysis auto-fails DEX
+    assert row["damage_taken"] == 12
+    assert server.get_character(cid, tgt)["current_hp"] == 18
+
+
+def test_aoe_unknown_id_rejected_before_slot_spend(monkeypatch):
+    """F03-4 (THE INVARIANT): an unknown id ANYWHERE in target_ids rejects the WHOLE cast
+    BEFORE the slot is spent — rejection-before-state-change. The slot is untouched."""
+    cid = server.create_campaign("S")["id"]
+    w = _aoe_wizard(cid)
+    real = server.create_character(cid, "Real", kind="monster", max_hp=30)["id"]
+    before = server.get_character(cid, w)["spell_slots"]["1"]["used"]
+    with pytest.raises(ValueError, match="unknown target id"):
+        server.cast_spell(cid, w, "Burning Hands", target_ids=[real, "ghost_id"])
+    after = server.get_character(cid, w)["spell_slots"]["1"]["used"]
+    assert after == before  # slot UNSPENT — clean rejection
+    assert server.get_character(cid, w)["concentration"] is None
+    assert server.get_character(cid, real)["current_hp"] == 30  # no damage applied
+
+
+def test_aoe_upcast_scales_shared_damage(monkeypatch):
+    """F03-4: an upcast AoE rolls the upcast-scaled dice once. Burning Hands at slot 2 is 4d6
+    (3d6 + 1d6 upcast) — the shared roll uses that expr."""
+    cid = server.create_campaign("S")["id"]
+    w = _aoe_wizard(cid, level=3)  # has a 2nd-level slot
+    tgt = server.create_character(cid, "Orc", kind="monster", max_hp=40, abilities={"dexterity": 10})["id"]
+    monkeypatch.setattr(server.dice_mod, "roll", _fixed_roll(2, 14))
+    out = server.cast_spell(cid, w, "Burning Hands", slot_level=2, target_ids=[tgt])
+    assert out["slot_used"] == 2
+    assert out["aoe"]["shared_damage"]["expr"] == "4d6"  # 3d6 base + 1d6 upcast, rolled once
+    assert out["shape"]["type"] == "cone" and out["shape"]["size"] == 15  # F03-4 shape surfacing
+
+
+def test_single_target_cast_unchanged_no_aoe_key():
+    """ADDITIVE: a normal single-target / no-target cast carries NO `aoe` key — byte-identical
+    for every existing caller (empty/omitted target_ids = today's behavior)."""
+    cid = server.create_campaign("S")["id"]
+    w = _aoe_wizard(cid)
+    out = server.cast_spell(cid, w, "Burning Hands")  # no target_ids
+    assert "aoe" not in out


### PR DESCRIPTION
## Summary

Implements the **P2 cluster "Spellcasting correctness"** (#797) — the spellcasting gaps beyond the P1 fix-waves. All five sub-findings were re-verified as **still broken on current main** before implementation (the P1 waves did not absorb any of these), then fixed additively with TDD.

**Source:** `docs/audits/ENGINE-AUDIT-2026-06-11.md` (Part C, unit 03)

### Findings fixed (all 5)

**F03-6 — every concentration-end path now releases the held victim immediately.**
`drop_concentration` already freed held victims (#830 + SYN-06); the *other four* end paths only cleared the caster side and left the victim locked until the next `next_turn` sweep. Extracted `_release_held_targets(c, caster_id, spell_name)` (the same inverse-link reconciliation `next_turn` runs) and wired it into all four:
- failed `concentration_save`
- caster incapacitation (`add_condition` INCAPACITATING)
- a recast that **displaces** a different prior concentration (`cast_spell`)
- caster dropped to 0 HP / killed — hooked at **both** server-side damage paths (`apply_damage` tool **and** `attack()`'s auto-apply), since `combat.apply_damage` is Character-pure and can't see the campaign-wide victim (per the spec's correction).

`drop_concentration` refactored to use the shared helper (no behavior change). The `next_turn` sweep stays as a backstop. Two pre-existing tests that asserted the *deferred* (next_turn) release were updated to assert the new *immediate* release + a clean no-op backstop.

**F03-7 — learn/prepare canonicalize + validate; the cast gate is case-insensitive.**
`learn_spells`/`prepare_spells` stored raw strings, so a lowercase learn made the canonical-cased cast gate reject every cast. Now both VALIDATE + CANONICALIZE each name (new `spells.canonical_name()`): unknown spells are rejected listing the offenders (before any state change), and any casing is stored proper-cased. The cast gate compares case-insensitively so legacy raw-cased snapshots still cast. Additive `mode="add"|"replace"` (default `replace`).

**F03-8 — prepared-caster discipline now has mechanical weight.**
The gate unioned known ∪ prepared, so preparation was a no-op. Now with a **non-empty** prepared list a **leveled** cast must be PREPARED (knowing isn't enough). Legacy-safe: cantrips stay always-castable once known; an **empty** prepared list keeps the lenient known-only union (sorcerer / old snapshot); both-empty stays fully lenient.

**F03-4 — AoE/multi-target cast path with validate-before-spend.**
`cast_spell` gains additive `target_ids: list[str] = []`. Targets are validated **up front** — any unknown id rejects the WHOLE cast **before** the slot spend (rejection-before-state-change). For a save-for-damage area spell the engine then resolves it: **ONE shared damage roll**, a per-target save vs the caster's DC via `combat.save_modifiers` (paralyzed auto-fails DEX; restrained → disadvantage), full damage on a fail / half on a save, all through `combat.apply_damage`. One lock, one write; per-target result table surfaced as `result["aoe"]`. The area **shape** (Cone/Sphere/Line + size, from the 52 srd524 records that carry it) is surfaced as `result["shape"]`. Empty/omitted `target_ids` = today's single-target behavior, byte-identical.

**F03-11 — monster/NPC innate casting routes through `cast_spell`.**
Additive `innate: bool = False`. A monster/NPC innate/at-will leveled cast (no Vancian slot) skips the slot check/spend (`slot_used="innate"`) while keeping concentration/duration/rider/DC — so an enemy Hold Person routes through `cast_spell` and **composes with F03-6's release** (breaking the monster's concentration frees the PC). The downcast guard still applies; the no-slot error for a monster/NPC caster now points at `innate=True` instead of dead-ending.

### Skipped (already done) / deferred
- None skipped — all five sub-findings were still broken on main.
- No deferrals. This addresses the whole cluster → `Closes #797`.

## Invariants
- **Additive-by-default**: every new field/param defaults to today's behavior; old snapshots round-trip (legacy-casing regression test included). Byte-identical single-target / no-target casts (`aoe`/`shape` keys absent).
- **Engine sole-writer, one write**: AoE applies all per-target damage + the single persist inside one `campaign_lock`.
- **Engine rolls, the DM is told**: AoE surfaces the full per-target table + shared roll + shape; releases surface `freed_targets`.
- **SRD 5.2**: area save-for-half default; cantrips aren't prepared; incapacitation/0-HP break concentration; paralysis auto-fails DEX saves.

## Tests
TDD (red → minimal additive fix → green) per sub-finding. New: 6 F03-6, 11 F03-7/F03-8, 6 F03-11, 6 F03-4. Updated 2 superseded next_turn-deferral tests to the new immediate-release behavior.

- **Engine suite: 2229 passed** (`uv run --directory servers/engine python -m pytest -q -p no:xdist`)
- **Viewer suite: 493 passed, 6 skipped** (dedicated `.venv-viewer`, single-process)
- **Tier-0 fast gate: PASS** (`bash qa/fast_gate.sh` — 188 deterministic engine/seat-path/rest/travel/combat)

Do not merge — adversarial review pending.