### PR TITLE
fix(engine): World-clock & rest seams P2 cluster (#799) — one-rest/day guard, temp-HP & degraded-concentration on long rest, downtime(0) no-op, add_location/long_rest sibling seams, level-banded wander picker

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -678,6 +678,13 @@ class Character(_StrictModel):
     conditions: list[Condition] = Field(default_factory=list)
     exhaustion: int = 0  # 0-6
     concentration: Optional[str] = None  # spell currently concentrated on
+    # The campaign `day` on which this character LAST finished a long rest (the morning
+    # the rest landed). The long_rest seam stamps it after rolling the clock and refuses a
+    # second long rest the same calendar day (SRD: at most one long rest per 24h) — closing
+    # the "rest 6x at dawn to instantly clear exhaustion 6->0 for free" exploit (audit F04-3).
+    # Default -1 == "never rested" == today's behavior; old snapshots round-trip and a fresh
+    # day-1 character can rest immediately. Per-character so a party still converges on one dawn.
+    last_long_rest_day: int = -1
     # Engine-tracked timed spell effects (Bless 10 rounds, Hex 1 hour, Mage Armor 8h)
     # that auto-expire via next_turn / clock-advance tools instead of relying on the DM
     # to remember. Empty == today's behavior. See ActiveEffect; set by cast_spell.

--- a/servers/engine/rests.py
+++ b/servers/engine/rests.py
@@ -88,6 +88,11 @@ def long_rest(ch: Character) -> dict:
     total_hd = ch.total_level
     recovered = max(1, total_hd // 2)
     ch.hit_dice_remaining = min(total_hd, ch.hit_dice_remaining + recovered)
+    # SRD 5.2: temporary hit points last "until depleted or you finish a long rest" —
+    # clear them so a stale temp-HP buffer doesn't survive the night (F04-4). Reported
+    # via the `temp_hp_cleared` key so the DM can narrate the ward fading.
+    temp_hp_cleared = ch.temp_hp
+    ch.temp_hp = 0
     ch.current_hp = ch.max_hp
     ch.exhaustion = max(0, ch.exhaustion - 1)
     for slot in ch.spell_slots.values():
@@ -105,4 +110,5 @@ def long_rest(ch: Character) -> dict:
         "exhaustion": ch.exhaustion,
         "spell_slots_restored": True,
         "resources_restored": resources_restored,
+        "temp_hp_cleared": temp_hp_cleared,
     }

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -988,6 +988,9 @@ def add_location(
         # — current_location stuck at the previous place while the prose described the new one).
         world_beats: list[str] = []
         world_developments: list[str] = []
+        strategic_events: list = []
+        expired_effects: list[dict] = []
+        wandering_encounter: Optional[dict] = None
         arrived = False
         party_relocated: list[str] = []
         if make_current and c.current_location_id != loc.id:
@@ -1003,10 +1006,34 @@ def add_location(
             # make_current targets the place the party is already standing in (no travel = no time
             # passes). Gating on `arrived` stops a self-target add_location from burning a phase.
             if advance_time and arrived:
+                before_day = c.day
                 travel.advance_clock(c, 1)
                 world_beats = [b.text for b in worldsim.tick(c, max_beats=1)]
                 # The proactive backlog rides the same arrival time-passage (idempotent by day).
                 world_developments = [_backlog_line(d) for d in worldsim.tick_backlog(c, max_events=1)]
+                # F04-6: this advance path previously stopped here, omitting the sibling
+                # side-effects that travel_to's advance runs — the strategic clock, the timed-
+                # effect expiry sweep, and the destination wander roll. So a fight staged
+                # immediately on a live-gen arrival used STALE buffs (Bless/Mage Armor past their
+                # deadline) and never sprang a wandering encounter. Mirror travel_to here.
+                strategic_events = worldsim.tick_strategic(c) if c.day > before_day else []
+                # A phase elapsed (a journey to the new scene): expire timed spell effects whose
+                # duration ran out (minute/round-scale die on any phase advance).
+                expired_effects = _expire_clock_effects_all(c)
+                # Kingmaker-style WANDERING ENCOUNTER on arrival, mirroring travel_to: roll for
+                # the new location's region (composite match per F04-1) and stage a TYPED
+                # encounter on a hit. Skipped if a fight is already live (combat never auto-
+                # starts). The `arrived` gate already keeps a self-target call a clock no-op.
+                if not c.combat.active:
+                    staged = _stage_wandering_encounter(
+                        c,
+                        loc.region,
+                        difficulty="medium",
+                        location_id=loc.id,
+                        match_region=_composite_region_match(loc),
+                    )
+                    if staged:
+                        wandering_encounter = staged
         # Orphan guard: a non-current location with no edges can never be reached.
         if loc.id != c.current_location_id and not loc.connections:
             warnings.append(
@@ -1014,7 +1041,7 @@ def add_location(
                 f"again with connections=[an existing location id] to wire it into the map"
             )
         save_campaign(c)
-    return {
+    result = {
         "id": loc.id,
         "name": loc.name,
         "connections": loc.connections,
@@ -1029,6 +1056,15 @@ def add_location(
         "location_count": len(c.locations),
         "warnings": warnings,
     }
+    # F04-6: additive keys surfaced ONLY when the advance path actually ran (mirrors
+    # travel_to's conditional keys), so the non-advancing / update paths stay byte-identical.
+    if strategic_events:
+        result["strategic_events"] = strategic_events
+    if expired_effects:
+        result["expired_effects"] = expired_effects
+    if wandering_encounter is not None:
+        result["wandering_encounter"] = wandering_encounter
+    return result
 
 
 @mcp.tool()
@@ -7537,6 +7573,23 @@ def long_rest(campaign_id: str, character_id: str, watch: str = "") -> dict:
         if c.combat.active:
             raise ValueError("cannot rest during active combat — call end_combat first")
         ch = _char(c, character_id)
+        # ONE-LONG-REST-PER-DAY GUARD (SRD 5.2: at most one long rest per 24h). A long
+        # rest landing on a morning costs zero clock time (steps == 0), so without this a
+        # party could re-rest 6x at dawn and clear exhaustion 6->0 for free. Refuse a second
+        # long rest the same calendar day the character last finished one — checked at ENTRY,
+        # BEFORE rests.long_rest mutates, so a blocked call changes NO state (F04-3). The stamp
+        # (set after the clock advance below) records the day the rest landed; this compares it
+        # to today's `day`. Per-character so a party still converges on a single dawn: each
+        # member gets their one rest, and only a REPEAT by the same member that day is blocked.
+        if ch.last_long_rest_day == c.day:
+            return {
+                "ok": False,
+                "error": (f"{ch.name} has already taken a long rest today (day {c.day}); a "
+                          f"character can benefit from only one long rest per day. Advance the "
+                          f"clock (travel / advance_time / downtime) before resting again."),
+                "day": c.day,
+                "time_of_day": c.time_of_day,
+            }
         out = rests.long_rest(ch)
         c.characters[character_id] = Character.model_validate(ch.model_dump(mode="json"))
         # A long rest is an overnight (~8h) and ends the next morning: advance the
@@ -7559,10 +7612,35 @@ def long_rest(campaign_id: str, character_id: str, watch: str = "") -> dict:
         day, tod = travel.advance_clock(c, steps)
         out["day"] = day
         out["time_of_day"] = tod
+        # F04-3: stamp the day this rest LANDED on (the morning it ended) so a second long
+        # rest the same calendar day is refused by the entry guard above. Mutate the
+        # re-validated copy that is persisted (not the pre-validation `ch`).
+        c.characters[character_id].last_long_rest_day = c.day
         # An overnight (~8h) ends timed spell effects: minute/round-scale, hour/day-scale
         # past their deadline, AND every hour-scale buff (Mage Armor/Aid/Longstrider) via
         # long_rest=True — even when resting in the morning is a clock no-op (steps == 0).
-        out["expired_effects"] = _expire_clock_effects_all(c, long_rest=True)
+        expired = _expire_clock_effects_all(c, long_rest=True)
+        # F04-4: a long rest ends concentration. The clock sweep above already drops a
+        # TWINNED concentration effect (via _commit_expiry), but a DEGRADED-path concentration
+        # (a duration-less concentration spell sets ch.concentration without an effect twin —
+        # server.py cast_spell) survives the sweep. Clear it on the RESTER (others' buffs are
+        # the clock sweep's job) and surface the released effect names so the DM narrates it.
+        rester = c.characters[character_id]
+        if rester.concentration is not None:
+            for name in combat.expire_concentration_effects(rester):
+                expired.append({"character_id": rester.id, "name": name})
+            rester.concentration = None
+        out["expired_effects"] = expired
+        # F04-7: a long rest rolls the day over but every OTHER day-moving seam (travel_to,
+        # advance_time, downtime) also ticks the world. Without this the overnight's standing
+        # threads / proactive backlog / strategic clock land LATE (at the next tick-bearing
+        # seam, mid-next-leg) instead of "the world moved while you slept". Gate on the same
+        # once-per-overnight `steps > 0` so a per-member party rolls ONCE; idempotent by
+        # elapsed days so a second member's morning rest is a no-op (no double-advance).
+        if steps > 0:
+            out["world_beats"] = [b.text for b in worldsim.tick(c, max_beats=2)]
+            out["world_developments"] = [_backlog_line(d) for d in worldsim.tick_backlog(c, max_events=2)]
+            out["strategic_events"] = worldsim.tick_strategic(c)
         # CAMP-WATCH AMBUSH — gated on `steps > 0` so it rolls ONCE per overnight (the
         # member whose rest actually rolls the clock to morning), NOT once per party
         # member resting the same night. Region = the camp's current location; a careful/
@@ -9629,16 +9707,38 @@ def downtime(campaign_id: str, days: int, note: str = "") -> dict:
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         elapsed = max(0, int(days))
+        # F04-5: a zero/negative downtime is a no-op, NOT a clock rewind. The unconditional
+        # `c.time_of_day = "morning"` reset below would turn "day 3 night" into "day 3 morning"
+        # (time runs BACKWARD) for downtime(0) or any negative span — the only non-monotonic
+        # clock path in the engine. worldsim.tick also fires+re-arms a due thread regardless of
+        # elapsed, so a 0-day downtime could consume a standing beat. Return early WITHOUT
+        # touching the clock or running any tick/expiry sweep; point the DM at advance_time for
+        # within-day passage. (advance_time itself floors at 0 steps and is a true no-op.)
+        if elapsed <= 0:
+            return {
+                "day": c.day,
+                "days_elapsed": 0,
+                "note": note,
+                "no_op": True,
+                "message": ("downtime needs at least 1 day; the clock was not changed. To move "
+                            "time within the current day, use advance_time (phases / to)."),
+                "due_consequences": [],
+                "world_beats": [],
+                "world_developments": [],
+                "strategic_events": [],
+                "expired_effects": [],
+            }
         c.day += elapsed
         c.time_of_day = "morning"
         due = consequences_mod.due(c)
         beats = worldsim.tick(c, max_beats=2)  # a long span → a couple of threads stirred
         dev = worldsim.tick_backlog(c, max_events=2)  # ...and the backlog advances over the span
-        strategic = worldsim.tick_strategic(c) if elapsed > 0 else []
+        strategic = worldsim.tick_strategic(c)
         # The clock jumped forward days — expire timed effects like every sibling time-seam
         # (advance_time/travel_to/long_rest/short_rest). A multi-day downtime clears hour/day-scale
         # buffs (Mage Armor) and any sub-hour leftover; this was the only seam that omitted it.
-        expired = _expire_clock_effects_all(c) if elapsed > 0 else []
+        # (elapsed is guaranteed > 0 here — the zero/negative case returned early above.)
+        expired = _expire_clock_effects_all(c)
         save_campaign(c)
         return {
             "day": c.day,

--- a/servers/engine/tests/test_qa_fixes.py
+++ b/servers/engine/tests/test_qa_fixes.py
@@ -654,6 +654,9 @@ def test_long_rest_hints_camp_only_when_companions_present(tmp_path, monkeypatch
     pc = server.create_character(cid, "Lone", kind="player")["id"]
     assert "camp_hint" not in server.long_rest(cid, pc)           # solo -> no camp nudge
     server.create_character(cid, "Karlach", kind="companion")
+    # advance to the NEXT day before resting again — the one-long-rest-per-day guard (F04-3)
+    # refuses a repeat rest the same calendar day, so move the clock first (the realistic flow).
+    server.advance_time(cid, to="morning")  # roll to the next dawn
     assert "camp_hint" in server.long_rest(cid, pc)              # a companion in the party -> nudge
 
 

--- a/servers/engine/tests/test_world_clock_rest_seams.py
+++ b/servers/engine/tests/test_world_clock_rest_seams.py
@@ -1,0 +1,353 @@
+"""World-clock & rest-seam correctness — P2 cluster (issue #799).
+
+Covers the seam-level defects from the 2026-06-11 full-engine audit (unit 04):
+
+  * F04-3  one-long-rest-per-day guard (no repeatable free instant restore)
+  * F04-4  long rest clears temp HP + ends degraded-path (twin-less) concentration
+  * F04-5  downtime(0)/negative is a no-op, not a clock rewind
+  * F04-6  add_location(make_current, advance_time) runs travel_to's sibling seams
+           (strategic tick + effect expiry + a destination wander roll)
+  * F04-7  long_rest ticks the world (beats / backlog / strategic) once per overnight
+  * F04-8  the wandering-combat picker is level-banded before the seeded draw
+
+Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (Part C, unit 04).
+"""
+
+import random
+
+import pytest
+
+import encounter
+import server
+import wander
+from models import ActiveEffect, Character, Consequence
+
+
+def _pc(cid, name="Hero", **kw):
+    return server.create_character(cid, name, kind="player", class_name="Fighter",
+                                   apply_srd_defaults=True, **kw)["id"]
+
+
+# =========================================================================
+# F04-3 — one long rest per 24h (calendar day) guard
+# =========================================================================
+def test_f04_3_second_long_rest_same_day_is_refused(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Guard")["id"]
+    c = server._require(cid)
+    c.day, c.time_of_day = 3, "evening"
+    server.save_campaign(c)
+    pc = _pc(cid, "Karlach")
+    first = server.long_rest(cid, pc)
+    assert first.get("ok", True) is not False  # the first rest succeeds
+    assert (first["day"], first["time_of_day"]) == (4, "morning")
+    # a SECOND long rest the same calendar day (day 4 morning) is refused, no state change
+    before = server.get_character(cid, pc)
+    second = server.long_rest(cid, pc)
+    assert second["ok"] is False
+    assert "already taken a long rest" in second["error"]
+    assert (second["day"], second["time_of_day"]) == (4, "morning")
+    assert server.get_character(cid, pc) == before  # byte-identical sheet — nothing mutated
+
+
+def test_f04_3_blocked_rest_does_not_clear_exhaustion(tmp_path, monkeypatch):
+    # The exploit: at morning a rest costs 0 clock time, so 6 rests would clear exhaustion
+    # 6->0 instantly. The guard stops the chain after the first.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Exhaust")["id"]
+    pc = _pc(cid, "Worn")
+    ch = server._require(cid)
+    ch.characters[pc].exhaustion = 6
+    server.save_campaign(ch)
+    server.long_rest(cid, pc)  # day-1 morning rest: exhaustion 6 -> 5 (one rest = one level)
+    assert server.get_character(cid, pc)["exhaustion"] == 5
+    for _ in range(5):  # five more same-day attempts all blocked
+        out = server.long_rest(cid, pc)
+        assert out["ok"] is False
+    assert server.get_character(cid, pc)["exhaustion"] == 5  # still 5 — not driven to 0
+
+
+def test_f04_3_next_day_rest_is_allowed(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("NextDay")["id"]
+    c = server._require(cid)
+    c.day, c.time_of_day = 1, "evening"
+    server.save_campaign(c)
+    pc = _pc(cid, "Shadowheart")
+    server.long_rest(cid, pc)                       # finishes day 2 morning
+    server.advance_time(cid, to="morning")          # roll to day 3 morning
+    out = server.long_rest(cid, pc)                 # a genuinely new day -> allowed
+    assert out.get("ok", True) is not False
+    assert out["day"] == 3 and out["time_of_day"] == "morning"
+
+
+def test_f04_3_party_still_converges_on_one_morning(tmp_path, monkeypatch):
+    # Per-character stamps must NOT break the documented convergence: each member rests once
+    # the same overnight and they all land on a single dawn (the guard only blocks a REPEAT
+    # by the same member, never a different member resting that night).
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Converge")["id"]
+    c = server._require(cid)
+    c.day, c.time_of_day = 5, "night"
+    server.save_campaign(c)
+    a = _pc(cid, "Lae'zel")
+    b = _pc(cid, "Gale")
+    d = _pc(cid, "Wyll")
+    outs = [server.long_rest(cid, x) for x in (a, b, d)]
+    assert all(o.get("ok", True) is not False for o in outs)         # all three rested
+    assert all((o["day"], o["time_of_day"]) == (6, "morning") for o in outs)  # one dawn
+    assert server._require(cid).day == 6
+
+
+# =========================================================================
+# F04-4 — long rest clears temp HP and ends degraded-path concentration
+# =========================================================================
+def test_f04_4_long_rest_clears_temp_hp(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("TempHP")["id"]
+    pc = _pc(cid, "Warded")
+    c = server._require(cid)
+    c.characters[pc].temp_hp = 8
+    c.day, c.time_of_day = 1, "evening"  # ensure the rest actually rolls over
+    server.save_campaign(c)
+    out = server.long_rest(cid, pc)
+    assert out["temp_hp_cleared"] == 8
+    assert server.get_character(cid, pc)["temp_hp"] == 0
+
+
+def test_f04_4_long_rest_ends_degraded_path_concentration(tmp_path, monkeypatch):
+    # The GENUINE degraded path (the F04-4 defect): a duration-less concentration spell sets
+    # ch.concentration WITHOUT registering an effect twin. No clock sweep ever clears a twin-less
+    # concentration (only _commit_expiry of an effect does, and there is none) — so before this
+    # fix it survived the night. Rest at MORNING (steps == 0) so the clock sweep can't even run a
+    # phase advance — isolating the new rest-seam clear as the only thing that ends it.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Conc")["id"]
+    pc = _pc(cid, "Focused")
+    c = server._require(cid)
+    ch = c.characters[pc]
+    ch.concentration = "Bless"           # set, but NO active_effects twin (degraded path)
+    assert ch.active_effects == []
+    c.day, c.time_of_day = 2, "morning"  # already morning -> the clock sweep won't expire anything
+    server.save_campaign(c)
+    out = server.long_rest(cid, pc)
+    assert out.get("ok", True) is not False
+    assert server.get_character(cid, pc)["concentration"] is None  # the rest seam cleared it
+
+
+def test_f04_4_long_rest_ends_twinned_concentration_and_names_it(tmp_path, monkeypatch):
+    # The twinned path is already handled by the clock sweep, but the rest seam must surface the
+    # released effect name in expired_effects regardless of which path cleared it.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Conc2")["id"]
+    pc = _pc(cid, "Bound")
+    c = server._require(cid)
+    ch = c.characters[pc]
+    ch.concentration = "Hold Person"
+    ch.active_effects = [ActiveEffect(name="Hold Person", scale="minutes", concentration=True,
+                                      rounds_remaining=10)]
+    c.day, c.time_of_day = 2, "evening"
+    server.save_campaign(c)
+    out = server.long_rest(cid, pc)
+    assert server.get_character(cid, pc)["concentration"] is None
+    names = {e["name"] for e in out["expired_effects"]}
+    assert "Hold Person" in names
+
+
+def test_f04_4_rests_helper_clears_temp_hp_unit():
+    ch = Character(name="T", max_hp=20, current_hp=20, temp_hp=5,
+                   classes=[{"name": "Fighter", "level": 4}])
+    out = __import__("rests").long_rest(ch)
+    assert ch.temp_hp == 0 and out["temp_hp_cleared"] == 5
+
+
+# =========================================================================
+# F04-5 — downtime(0)/negative is a no-op, not a clock rewind
+# =========================================================================
+def test_f04_5_downtime_zero_does_not_rewind_clock(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("DT0")["id"]
+    c = server._require(cid)
+    c.day, c.time_of_day = 3, "night"  # the bug: this would become day-3 MORNING (backward)
+    server.save_campaign(c)
+    out = server.downtime(cid, 0)
+    assert out.get("no_op") is True and out["days_elapsed"] == 0
+    persisted = server._require(cid)
+    assert (persisted.day, persisted.time_of_day) == (3, "night")  # clock untouched
+
+
+def test_f04_5_downtime_negative_does_not_rewind_clock(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("DTneg")["id"]
+    c = server._require(cid)
+    c.day, c.time_of_day = 4, "evening"
+    server.save_campaign(c)
+    out = server.downtime(cid, -3)
+    assert out["days_elapsed"] == 0
+    assert (server._require(cid).day, server._require(cid).time_of_day) == (4, "evening")
+
+
+def test_f04_5_downtime_zero_does_not_fire_a_due_thread(tmp_path, monkeypatch):
+    # worldsim.tick fires a thread-beat whenever trigger_day <= day regardless of elapsed, so a
+    # 0-day downtime must NOT consume (and re-arm) a standing thread beat.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("DTthread")["id"]
+    c = server._require(cid)
+    c.day = 5
+    c.consequences.append(Consequence(text="the bell tolls", trigger_day=5,
+                                       thread_id="thread-1"))
+    server.save_campaign(c)
+    out = server.downtime(cid, 0)
+    assert out["world_beats"] == [] and out["due_consequences"] == []
+    # the thread stays armed at day 5 (NOT re-armed forward, i.e. not consumed)
+    assert server._require(cid).consequences[0].trigger_day == 5
+
+
+def test_f04_5_downtime_positive_still_advances(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("DT2")["id"]
+    c = server._require(cid)
+    c.day, c.time_of_day = 2, "evening"
+    server.save_campaign(c)
+    out = server.downtime(cid, 2)
+    assert out["days_elapsed"] == 2
+    assert (server._require(cid).day, server._require(cid).time_of_day) == (4, "morning")
+
+
+# =========================================================================
+# F04-6 — add_location advance path mirrors travel_to's sibling seams
+# =========================================================================
+def test_f04_6_add_location_advance_expires_stale_effects(tmp_path, monkeypatch):
+    # A minutes-scale effect on the party member should die when add_location advances the
+    # clock (previously it survived because the seam skipped the expiry sweep).
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("AL")["id"]
+    pc = _pc(cid, "Caster")
+    server.add_location(cid, "Start", make_current=True)
+    c = server._require(cid)
+    c.characters[pc].active_effects = [
+        ActiveEffect(name="Bless", scale="minutes", rounds_remaining=1)]
+    server.save_campaign(c)
+    out = server.add_location(cid, "Siltwharf Steps", make_current=True, advance_time=True)
+    assert out["arrived"] is True
+    names = {e["name"] for e in out.get("expired_effects", [])}
+    assert "Bless" in names
+    assert server.get_character(cid, pc)["active_effects"] == []
+
+
+def test_f04_6_add_location_no_advance_is_byte_identical(tmp_path, monkeypatch):
+    # The non-advancing path must NOT grow the new sibling keys (additive-only on advance).
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("AL2")["id"]
+    server.add_location(cid, "Hub", make_current=True)
+    out = server.add_location(cid, "Side Room", make_current=True, advance_time=False,
+                              connections=[])
+    for k in ("strategic_events", "expired_effects", "wandering_encounter"):
+        assert k not in out  # no advance ran -> no sibling keys
+
+
+def test_f04_6_add_location_advance_can_stage_wander(tmp_path, monkeypatch):
+    # With a forced encounter roll, the advance path stages a destination wandering encounter
+    # (mirroring travel_to) — previously this seam never rolled one.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    monkeypatch.setattr(wander, "roll_encounter", lambda *a, **k: True)
+    cid = server.create_campaign("ALwander")["id"]
+    _pc(cid, "Scout", abilities={"constitution": 14})
+    server.add_location(cid, "Camp", make_current=True)
+    out = server.add_location(cid, "Deep Forest", make_current=True, advance_time=True,
+                              region="forest")
+    assert "wandering_encounter" in out
+    assert out["wandering_encounter"].get("type")  # a typed payload was produced
+
+
+# =========================================================================
+# F04-7 — long_rest ticks the world once per overnight
+# =========================================================================
+def test_f04_7_long_rest_ticks_the_world(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Tick")["id"]
+    c = server._require(cid)
+    c.day, c.time_of_day = 4, "evening"
+    # a standing thread beat due today/tomorrow should FIRE when the overnight rolls the day
+    # over (previously long_rest ticked nothing, so the beat landed late at the next seam)
+    c.consequences.append(Consequence(text="the cult's ritual stirs", trigger_day=5,
+                                       thread_id="thread-7"))
+    server.save_campaign(c)
+    pc = _pc(cid, "Sleeper")
+    out = server.long_rest(cid, pc)
+    # the rest now exposes the world-tick keys (they were absent on the broken seam)
+    assert "world_beats" in out and "world_developments" in out and "strategic_events" in out
+    assert "the cult's ritual stirs" in out["world_beats"]  # the dawn beat fired during the rest
+    # ...and the thread re-armed forward (the timer rolled), proving the tick really ran
+    assert server._require(cid).consequences[0].trigger_day > 5
+
+
+def test_f04_7_morning_rest_does_not_tick(tmp_path, monkeypatch):
+    # A second member's already-morning rest (steps == 0) must NOT re-tick the world.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Tick2")["id"]
+    c = server._require(cid)
+    c.day, c.time_of_day = 1, "morning"
+    server.save_campaign(c)
+    pc = _pc(cid, "Dawn")
+    out = server.long_rest(cid, pc)  # already morning -> clock no-op -> no world tick keys
+    assert "world_beats" not in out
+
+
+# =========================================================================
+# F04-8 — wandering-combat picker is level-banded
+# =========================================================================
+def test_f04_8_low_party_never_staged_a_party_wiping_solo():
+    # An L1 party in an undead region must never be ambushed by a >= 2-bands-over solo
+    # (the CR-5 Wraith was staged as a deadly solo against [1, 1]).
+    party = [1, 1]
+    order = {d: i for i, d in enumerate(("trivial",) + encounter.DIFFICULTIES)}
+    want = order["medium"]
+    for seed in range(200):
+        spec = wander.pick_encounter(party, "the Haunted Barrow",
+                                     rng=random.Random(seed))[0]
+        band = order[encounter.encounter_difficulty(party, [spec["xp_each"]] * spec["count"])]
+        solo = order[encounter.encounter_difficulty(party, [spec["xp_each"]])]
+        assert solo < want + 2          # never a >=2-band-over solo
+        assert band <= want + 1         # the staged group stays near the target band
+
+
+def test_f04_8_high_party_never_staged_an_all_trivial_swarm():
+    # An L15 party in a low-CR region must never field a 12-count trivial swarm.
+    party = [15, 15, 15, 15]
+    order = {d: i for i, d in enumerate(("trivial",) + encounter.DIFFICULTIES)}
+    staged_trivial_full = 0
+    for seed in range(200):
+        spec = wander.pick_encounter(party, "city", rng=random.Random(seed))[0]
+        band = encounter.encounter_difficulty(party, [spec["xp_each"]] * spec["count"])
+        if band == "trivial" and spec["count"] == 12:
+            staged_trivial_full += 1
+    assert staged_trivial_full == 0
+
+
+def test_f04_8_band_filter_never_empties_a_nonempty_pool():
+    # Even a wildly mismatched pool/party must yield a (nearest-band) foe, never [].
+    for party in ([1], [1, 1], [20, 20, 20, 20]):
+        for region in ("forest", "swamp", "the Haunted Barrow", "city"):
+            specs = wander.pick_encounter(party, region, rng=random.Random(3))
+            assert specs and specs[0]["xp_each"] > 0
+
+
+def test_f04_8_pick_still_deterministic_under_seed():
+    a = wander.pick_encounter([5, 5, 5], "swamp", rng=random.Random(99))
+    b = wander.pick_encounter([5, 5, 5], "swamp", rng=random.Random(99))
+    assert a == b
+
+
+def test_f04_8_band_pool_pure_helper_drops_overmatch():
+    # Direct unit check of the filter: a chunky solo (>= 2 bands over) is dropped for a low
+    # party but a budget-appropriate creature survives.
+    party = [1, 1]
+    pool = wander._resolved_pool("the Haunted Barrow")
+    assert pool  # the region resolves creatures
+    filtered = wander._level_band_pool(pool, party, "medium")
+    order = {d: i for i, d in enumerate(("trivial",) + encounter.DIFFICULTIES)}
+    want = order["medium"]
+    for _canon, _name, xp in filtered:
+        solo = order[encounter.encounter_difficulty(party, [xp])]
+        assert solo < want + 2

--- a/servers/engine/wander.py
+++ b/servers/engine/wander.py
@@ -294,6 +294,59 @@ def _count_for_budget(party_levels: list[int], unit_xp: int, target_difficulty: 
     return best_count
 
 
+_BAND_ORDER = {d: i for i, d in enumerate(("trivial",) + encounter.DIFFICULTIES)}
+
+
+def _level_band_pool(
+    pool: list[tuple[str, str, int]],
+    party_levels: list[int],
+    target_difficulty: str,
+) -> list[tuple[str, str, int]]:
+    """Pre-filter a resolved creature pool to those that can stage a `target_difficulty`-ish
+    fight for `party_levels`, BEFORE the seeded kind draw (F04-8). The raw pool is a single
+    flavor band (ascending CR), so a uniform draw can stage a CR-5 Wraith against an L1 party
+    (deadly as a SOLO) or twelve trivial Bandits against an L15 party — both violate the
+    module's own "sized to the party's XP budget" contract.
+
+    Drops a candidate when, for this party, it is EITHER:
+      * too strong — its band as a SINGLE unit is >= 2 bands over the target (a chunky solo a
+        party of this level shouldn't be ambushed by); OR
+      * too weak — even 12 of it (the sizing cap) can't reach the target band.
+
+    Returns the survivors preserving order. When the filter empties (no candidate lands near
+    the target — e.g. a flavor pool entirely out of the party's league), returns the
+    NEAREST-band candidates instead of [] so a non-empty pool always yields a foe (the caller
+    treats [] only as "no resolvable creature"). Pure; party_levels is assumed non-empty."""
+    want = _BAND_ORDER.get(target_difficulty, _BAND_ORDER["medium"])
+    survivors: list[tuple[str, str, int]] = []
+    # (candidate, distance-from-target of its best achievable single-unit-or-capped band)
+    scored: list[tuple[tuple[str, str, int], int]] = []
+    for cand in pool:
+        unit_xp = cand[2]
+        solo_band = _BAND_ORDER.get(
+            encounter.encounter_difficulty(party_levels, [unit_xp]), 0)
+        max_band = _BAND_ORDER.get(
+            encounter.encounter_difficulty(party_levels, [unit_xp] * 12), 0)
+        # The band window this candidate can actually hit: from its solo band up to its
+        # capped (x12) band. Distance to target = how far that window is from `want`.
+        if max_band < want:
+            dist = want - max_band          # too weak even at the cap
+        elif solo_band > want:
+            dist = solo_band - want         # too strong even as a single unit
+        else:
+            dist = 0                        # the window straddles the target
+        scored.append((cand, dist))
+        too_strong = solo_band >= want + 2
+        too_weak = max_band < want
+        if not too_strong and not too_weak:
+            survivors.append(cand)
+    if survivors:
+        return survivors
+    # Nearest-band fallback: keep only the candidate(s) closest to the target band.
+    best = min(d for _c, d in scored)
+    return [c for c, d in scored if d == best]
+
+
 def pick_encounter(
     party_levels: list[int],
     region: str = "",
@@ -324,6 +377,10 @@ def pick_encounter(
     pool = _resolved_pool(region)
     if not pool:
         return []
+    # F04-8: level-band the pool BEFORE the seeded draw so a uniform pick can't stage a
+    # party-wiping solo (CR-5 Wraith vs an L1 party) or a trivial all-12 swarm (Bandits vs
+    # L15s). Falls back to nearest-band so a non-empty pool always yields a foe.
+    pool = _level_band_pool(pool, list(party_levels), target_difficulty)
     r = rng or random.Random()
     canonical, _pool_name, unit_xp = r.choice(pool)
     count = _count_for_budget(list(party_levels), unit_xp, target_difficulty)


### PR DESCRIPTION
## P2 cluster: World-clock & rest seams (closes #799)

Six seam-level defects from the 2026-06-11 full-engine adversarial audit (unit 04, Part C). All sub-findings F04-3 … F04-8 implemented. **Additive / round-trip safe**; engine stays sole writer; SRD 5.2 correct.

Source: `docs/audits/ENGINE-AUDIT-2026-06-11.md` (unit 04, Part C per-finding specs).

### Fixed

**F04-3 — no one-long-rest-per-24h guard.** Additive `Character.last_long_rest_day` (default `-1` = never rested = today's behavior; old snapshots round-trip). The `long_rest` seam refuses a second rest the same calendar day at **entry** (no state change), and stamps the landed day **after** the clock advance. Closes the "rest 6× at dawn to clear exhaustion 6→0 for free" exploit. Per-character, so a party still converges on one morning.

**F04-4 — long rest neither clears temp HP nor ends degraded-path concentration.** `rests.long_rest` zeroes `temp_hp` (SRD 5.2: temp HP lasts until depleted or a long rest) and reports `temp_hp_cleared`. The server seam ends the **rester's** twin-less (degraded-path) concentration — the case the clock sweep cannot reach — and names the released effects. (The twinned path was already handled by the long-rest clock sweep; verified.)

**F04-5 — `downtime(0)`/negative REWINDS the clock.** Now returns early with the current clock + a pointer to `advance_time`, skipping the unconditional `time_of_day = "morning"` reset (which ran time **backward**: day-3 night → day-3 morning) and all three ticks. Per the corrected fix-spec, `worldsim.tick` fires a due thread regardless of `elapsed`, so the early return also prevents a 0-day downtime from consuming/re-arming a standing beat.

**F04-6 — `add_location(make_current, advance_time)` advanced the clock without sibling side-effects.** The advance path now mirrors `travel_to`: `tick_strategic` + the timed-effect expiry sweep + a destination wander roll (composite-region match per F04-1, gated `not c.combat.active`). New payload keys are surfaced **only on the advance path** (`strategic_events`/`expired_effects`/`wandering_encounter`); the non-advance / update paths stay byte-identical.

**F04-7 — `long_rest` rolled the day over but never ticked the world.** Inside the existing once-per-overnight `steps > 0` gate it now runs `worldsim.tick` / `tick_backlog` / `tick_strategic`, so the overnight's standing threads / proactive backlog / strategic clock land "while you slept" instead of late at the next seam. Idempotent by elapsed day (a second member's morning rest is a no-op).

**F04-8 — wandering-combat picker is level-blind.** `wander.pick_encounter` pre-filters the region pool by unit XP vs party budget **before** the seeded draw: drops a ≥2-bands-over solo (no more CR-5 Wraith vs an L1 party) and a creature that can't reach the target band even at the ×12 cap (no more 12 trivial Bandits vs L15s); a nearest-band fallback keeps a non-empty pool from emptying. Pure module; return shape unchanged.

### Skipped — already done (confirmed intact, not in this cluster)

- **F04-1 / F04-2** are P1 (not this cluster). F04-1's `_composite_region_match` resolver is present and reused by the F04-6 wander roll; `test_wander_region_match.py` green.

### Deferred

- None. All six cluster sub-findings (F04-3 … F04-8) are addressed → **Closes #799**.

### Tests

- New `servers/engine/tests/test_world_clock_rest_seams.py` — **22 tests**, red-first verified (stashed the source fixes and confirmed the bug-catching tests fail against unfixed `main`, including the genuine twin-less degraded-concentration path).
- Updated `test_qa_fixes.py::test_long_rest_hints_camp_only_when_companions_present` to advance the clock between the two rests (the one-rest/day guard makes a same-day repeat a no-op) — intent preserved.
- **Full engine suite: 2367 passed** (`uv run --directory servers/engine python -m pytest -q -p no:xdist`).
- **Tier-0 `qa/fast_gate.sh`: PASS.**
- Round-trip invariant verified: an old snapshot without `last_long_rest_day`/`temp_hp` deserializes with the safe defaults and rests freely.

### Invariants

Additive-by-default (new model field defaults to today's behavior; new payload keys conditional); engine = sole writer (all mutations under `campaign_lock` + `save_campaign`); wire contracts frozen (no id/env changes); `wander` stays a pure module. No shell changes (no bash 3.2 surface touched). NOTE: #850 just touched this region — diff kept minimal and the camp-watch block left untouched.

**Do not merge** — for review.