### PR TITLE
fix(engine): image provider-lane hardening — F11-3/4/5/6/7 (#810)

### DIFF
--- a/servers/engine/imagegen.py
+++ b/servers/engine/imagegen.py
@@ -394,6 +394,124 @@ def _safe_scope(scope: Optional[str]) -> str:
     return "".join(c if (c.isalnum() or c in "-_") else "_" for c in str(scope))[:128]
 
 
+# --------------------------------------------------------------------------- #
+# Ingested-art catalog consult (F11-6) — don't spend to regenerate art that the
+# 2,359-dir _private ingest already provides. The VIEWER resolves ingested art FIRST
+# (_latest_descriptor -> _ingested_descriptor across all _private worlds), so a
+# generated canon-scope image is NEVER displayed when ingested art exists — pure spend.
+# This is the engine-side gate: consult the catalog before enqueuing a worker.
+#
+# Read-only: the engine reading content/_private is allowed (it never writes there, and
+# the sole-writer invariant covers campaign state, not the gitignored art tree). Mirrors
+# the viewer's resolution conservatively — exact safe-scope dir, then a normalized
+# scope-key match — so at worst a slug-drift miss falls through to generate (never a
+# wrong skip of a genuinely-absent scope).
+# --------------------------------------------------------------------------- #
+
+# Leading kind/entity prefix tokens dropped when normalizing a scope to a NAME key —
+# kept in sync with the viewer's _SCOPE_PREFIXES so the engine and viewer agree on what
+# "the same scope" means (portrait-npc-shadowheart and portrait:shadowheart both ->
+# shadowheart). A drift here only costs a redundant regen, never a wrong skip.
+_SCOPE_PREFIXES = frozenset({
+    "portrait", "scene", "item", "map", "npc", "char", "pc", "loc", "location",
+    "region", "scope", "faction", "creature", "class", "race",
+})
+
+
+def _scope_key(scope: Optional[str]) -> str:
+    """Normalize a scope to a separator/prefix-agnostic NAME key (mirrors the viewer's
+    _scope_key): lowercase; unify `:`/`_`/space to `-`; drop leading kind/entity prefix
+    tokens. So portrait-<id> / portrait:<slug> reconcile to the same key."""
+    s = str(scope or "").lower().replace(":", "-").replace("_", "-").replace(" ", "-")
+    toks = [t for t in s.split("-") if t]
+    while toks and toks[0] in _SCOPE_PREFIXES:
+        toks.pop(0)
+    return "-".join(toks)
+
+
+def _ingested_art_root() -> Optional[Path]:
+    """Root of the gitignored _private ingested-art tree, world-neutral:
+    <content>/worlds/_private/. Honors the same env contract the viewer uses so a
+    cross-checkout launcher (the .app / a Lexar worktree running code from one checkout
+    while the private art lives in the canonical one) resolves the right tree:
+    WORLDOS_ART_REPO_ROOT/CLAWDND_ART_REPO_ROOT (an art checkout), then
+    WORLDOS_REPO_ROOT/CLAWDND_REPO_ROOT, then CONTENT_DIR, then the in-repo content/.
+    Returns None when no _private tree exists (art-less host -> caller falls through)."""
+    candidates: list[Path] = []
+    for raw in (env_var("ART_REPO_ROOT"), env_var("REPO_ROOT")):
+        if raw:
+            candidates.append(Path(raw).expanduser() / "content" / "worlds" / "_private")
+    content_raw = env_var("CONTENT_DIR")
+    if content_raw:
+        candidates.append(Path(content_raw).expanduser() / "worlds" / "_private")
+    # In-repo fallback: servers/engine/imagegen.py -> repo root is parents[2].
+    candidates.append(Path(__file__).resolve().parents[2] / "content" / "worlds" / "_private")
+    for c in candidates:
+        try:
+            if c.is_dir():
+                return c
+        except OSError:
+            continue
+    return None
+
+
+def has_ingested_art(scope: Optional[str]) -> bool:
+    """True when the _private ingest already provides a SERVABLE wiki_ingest.json for
+    `scope` (F11-6). Mirrors the viewer's ingested-first resolution conservatively:
+    an exact safe-scope dir match, else a normalized scope-key match across all
+    _private worlds. Read-only; path-containment-guarded; never raises (a probe error
+    is treated as "no art" so the caller still generates rather than crash)."""
+    seg = _safe_scope(scope)
+    if not seg:
+        return False
+    root = _ingested_art_root()
+    if root is None:
+        return False
+    try:
+        root_resolved = root.resolve()
+    except OSError:
+        return False
+    # 1. Exact safe-scope dir (the common, fast case).
+    try:
+        for world_dir in root.iterdir():
+            if not world_dir.is_dir():
+                continue
+            desc = world_dir / "images" / seg / "wiki_ingest.json"
+            if not desc.exists():
+                continue
+            try:
+                if root_resolved in desc.resolve().parents:
+                    return True
+            except OSError:
+                continue
+    except OSError:
+        return False
+    # 2. Normalized scope-key fallback (UI engine-id scope vs manifest slug).
+    want = _scope_key(scope)
+    if not want:
+        return False
+    try:
+        for world_dir in root.iterdir():
+            images_dir = world_dir / "images"
+            if not images_dir.is_dir():
+                continue
+            for sub in images_dir.iterdir():
+                desc = sub / "wiki_ingest.json"
+                if not desc.exists():
+                    continue
+                try:
+                    if root_resolved not in desc.resolve().parents:
+                        continue
+                    d = json.loads(desc.read_text(encoding="utf-8"))
+                except (OSError, ValueError):
+                    continue
+                if isinstance(d, dict) and _scope_key(d.get("scope")) == want:
+                    return True
+    except OSError:
+        return False
+    return False
+
+
 def content_hash(kind: str, prompt: str, *, seed: Optional[int] = None, provider: str = "null") -> str:
     """Stable content hash for a generation request. Same inputs -> same key, so a
     repeat request hits the cache instead of regenerating. Independent of wall-clock
@@ -408,6 +526,15 @@ def content_hash(kind: str, prompt: str, *, seed: Optional[int] = None, provider
 
 def cache_path(hash_: str, scope: Optional[str] = None) -> Path:
     return _images_dir(scope) / f"{hash_}.json"
+
+
+def error_path(hash_: str, scope: Optional[str] = None) -> Path:
+    """Sibling sidecar for a FAILED generation (F11-7): <scope>/<hash>.error.
+
+    Deliberately a bare ``.error`` suffix (NOT ``.error.json``) so the viewer's
+    descriptor resolvers — which glob ``*.json`` only — never pick it up as a real
+    descriptor. It is a derived, rebuildable artifact like the rest of the cache."""
+    return _images_dir(scope) / f"{hash_}.error"
 
 
 def _atomic_write(path: Path, data: str) -> None:
@@ -453,6 +580,79 @@ def cache_write(descriptor: dict, scope: Optional[str] = None) -> Path:
     path = cache_path(hash_, scope)
     _atomic_write(path, json.dumps(record, ensure_ascii=False, indent=2))
     return path
+
+
+def write_error(hash_: str, error: str, scope: Optional[str] = None, *,
+                provider: str = "", kind: str = "", prompt: str = "") -> Path:
+    """Record a FAILED background generation as a derived ``.error`` sidecar (F11-7).
+
+    Today a background-worker generation failure is completely silent — generate()'s
+    degrade-to-null result is discarded by the worker, leaving no artifact, no event,
+    nothing under the images/ tree. That makes a failed provider lane indistinguishable
+    from "not yet generated", which the image-evidence gate cannot classify. This writes
+    a small JSON observability record next to where the descriptor WOULD have landed,
+    keyed by the same content hash, via the same atomic writer. Sole-writer-safe: it
+    touches only the derived, rebuildable image cache, never snapshot.json.
+
+    Returns the path written."""
+    record = {
+        "hash": hash_,
+        "status": "error",
+        "error": str(error)[:500],
+        "provider": provider,
+        "kind": kind,
+        "prompt": prompt,
+        "failed_at": time.time(),
+    }
+    path = error_path(hash_, scope)
+    _atomic_write(path, json.dumps(record, ensure_ascii=False, indent=2))
+    return path
+
+
+def read_error(hash_: str, scope: Optional[str] = None) -> Optional[dict]:
+    """Return the ``.error`` sidecar for `hash_`, or None if none/corrupt (F11-7)."""
+    path = error_path(hash_, scope)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return None
+
+
+def clear_error(hash_: str, scope: Optional[str] = None) -> None:
+    """Delete any stale ``.error`` sidecar for `hash_` (F11-7).
+
+    Called when a generation SUCCEEDS so a later success supersedes an earlier failure
+    record — the sidecar reflects the most recent outcome, never a fossil. Missing file
+    is a no-op; never raises (the cache is rebuildable)."""
+    path = error_path(hash_, scope)
+    try:
+        path.unlink()
+    except (FileNotFoundError, OSError):
+        pass
+
+
+def _strip_inline_bytes(descriptor: dict) -> dict:
+    """Return a shallow copy of `descriptor` with the inline image payload replaced by
+    metadata (F11-5). A provider-lane descriptor may carry `bytes_b64` (base64 of the raw
+    image, up to MAX_INLINE_BYTES=16MB); returning that verbatim from the generate_image
+    tool injects megabytes of base64 into the DM's context for ONE beat. No tool-side
+    consumer reads the bytes — only the viewer (/image, /portrait-*) does, and it reads the
+    on-disk cache entry, not this return value. So we hand the tool a compact, equivalent
+    descriptor: drop `bytes_b64`, add `has_bytes` + `byte_len` so a caller can still tell
+    an image landed. Pure: the input dict and the on-disk cache file are untouched."""
+    b64 = descriptor.get("bytes_b64")
+    if not isinstance(b64, str) or not b64:
+        return descriptor
+    out = dict(descriptor)
+    out.pop("bytes_b64", None)
+    out["has_bytes"] = True
+    # Approximate decoded byte length from the base64 text length (4 b64 chars -> 3 bytes),
+    # net of '=' padding — cheap and exact enough for an at-a-glance size, no decode needed.
+    pad = b64.count("=")
+    out["byte_len"] = max(0, (len(b64) * 3) // 4 - pad)
+    return out
 
 
 def _newest_descriptor(scope: Optional[str]) -> Optional[dict]:
@@ -551,11 +751,30 @@ def generate(
         descriptor["cache_hit"] = False
         descriptor["degraded_from"] = getattr(provider, "name", "provider")
         descriptor["error"] = str(exc)[:200]
+        # F11-7: a failed generation used to vanish silently — the worker discarded this
+        # degraded descriptor, leaving no artifact. Record a derived `.error` sidecar so the
+        # failure is observable (and the image-evidence gate can classify it as `error`,
+        # distinct from "not yet generated"). Keyed by the FAILED provider's content hash so
+        # a later success under the same key clears it. Best-effort: a sidecar write must
+        # never itself crash the degrade path. The degraded descriptor stays UNCACHED (a
+        # transient gateway blip must remain retryable).
+        if use_cache:
+            try:
+                write_error(
+                    key, descriptor["error"], scope,
+                    provider=getattr(provider, "name", "provider"),
+                    kind=_normalize_kind(kind), prompt=prompt,
+                )
+            except Exception:  # pragma: no cover - sidecar is observability, never load-bearing
+                pass
         return descriptor
 
     descriptor["cache_hit"] = False
     if use_cache:
         cache_write(descriptor, scope)
+        # F11-7: a success supersedes any earlier failure record for this key, so the
+        # sidecar always reflects the most recent outcome (never a fossil `.error`).
+        clear_error(key, scope)
 
     return descriptor
 
@@ -602,19 +821,184 @@ def _worker(kind: str, prompt: str, seed: Optional[int], scope: Optional[str],
             _inflight.discard((key, scope))
 
 
+# --------------------------------------------------------------------------- #
+# F11-3: detached resolver — art that survives the per-beat `claude -p` exit.
+#
+# scripts/play.sh runs ONE `claude -p` per beat (--resume per beat); the engine MCP
+# server is a stdio CHILD of each `claude -p`. When the interpreter exits at end of beat,
+# its daemon threads (the _worker above) die abruptly mid-provider-call. A real provider
+# (openclaw) polls the gateway media dir up to 180s, so art started late in a beat is
+# LOST — and worse, the paid image is never claimed (a later identical call cache-misses,
+# re-POSTs new spend, and its pre-POST snapshot already contains the orphaned PNG).
+#
+# Fix: spawn a process-group-DETACHED subprocess (start_new_session=True, stdio to
+# DEVNULL) running THIS module's `--resolve` entrypoint. It outlives the parent and calls
+# the SAME generate() — writing only the derived, rebuildable cache via the atomic writer
+# (sole-writer-safe: never snapshot.json). A `generating` marker is written first so a
+# re-POST within a TTL is suppressed (no double spend). Opt-in via env so today's default
+# (daemon-thread) behavior is unchanged; the marker degrades like today's 404→placeholder.
+# --------------------------------------------------------------------------- #
+
+ENV_DETACHED_RESOLVER = "IMAGE_DETACHED_RESOLVER"
+# How long a `generating` marker suppresses a re-spawn (seconds). Just over the gateway's
+# own ~180s poll budget so a still-running resolver isn't double-spawned, but stale markers
+# from a crashed resolver expire and let a later call retry.
+ENV_GENERATING_TTL = "IMAGE_GENERATING_TTL"
+DEFAULT_GENERATING_TTL = 210.0
+
+
+def _detached_resolver_enabled() -> bool:
+    """True when the detached-resolver path is opted in via env (default OFF, so the
+    daemon-thread behavior is preserved exactly — additive, no behavior change today)."""
+    return (env_var(ENV_DETACHED_RESOLVER, "") or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _generating_ttl() -> float:
+    try:
+        v = env_var(ENV_GENERATING_TTL)
+        return float(v) if v else DEFAULT_GENERATING_TTL
+    except (TypeError, ValueError):
+        return DEFAULT_GENERATING_TTL
+
+
+def generating_path(hash_: str, scope: Optional[str] = None) -> Path:
+    """Sibling `generating` marker for an in-flight detached resolution (F11-3).
+
+    Bare `.generating` suffix (NOT `.json`) so the viewer's `*.json` descriptor glob
+    never treats it as a real descriptor. Derived, rebuildable, sole-writer-safe."""
+    return _images_dir(scope) / f"{hash_}.generating"
+
+
+def _generating_is_fresh(hash_: str, scope: Optional[str]) -> bool:
+    """True when a `generating` marker exists and is younger than the TTL — meaning a
+    resolver is (still plausibly) in flight for this key, so a re-spawn would double-spend.
+    A stale/missing/corrupt marker returns False so a later call can retry."""
+    path = generating_path(hash_, scope)
+    try:
+        rec = json.loads(path.read_text(encoding="utf-8"))
+        started = float(rec.get("started_at", 0.0))
+    except (OSError, ValueError, TypeError):
+        return False
+    return (time.time() - started) < _generating_ttl()
+
+
+def _write_generating_marker(hash_: str, scope: Optional[str], *, pid: Optional[int] = None) -> None:
+    """Write the `generating` marker that suppresses a re-spawn (F11-3). Best-effort."""
+    rec = {"hash": hash_, "status": "generating", "started_at": time.time()}
+    if pid is not None:
+        rec["resolver_pid"] = pid
+    try:
+        _atomic_write(generating_path(hash_, scope), json.dumps(rec, ensure_ascii=False, indent=2))
+    except OSError:  # pragma: no cover - marker is advisory, never load-bearing
+        pass
+
+
+def _clear_generating_marker(hash_: str, scope: Optional[str]) -> None:
+    """Remove the `generating` marker (resolver finished/failed). Never raises."""
+    try:
+        generating_path(hash_, scope).unlink()
+    except (FileNotFoundError, OSError):
+        pass
+
+
+def _spawn_detached_resolver(kind: str, prompt: str, seed: Optional[int],
+                             scope: Optional[str], key: str, pname: str) -> bool:
+    """Spawn a process-group-detached resolver subprocess for one generation (F11-3).
+
+    Returns True if a resolver was spawned, False if a young `generating` marker meant we
+    suppressed the spawn (a resolver is already in flight for this key). The subprocess
+    runs THIS module's `--resolve` entrypoint under `sys.executable`, detached via
+    start_new_session=True with stdio to DEVNULL, so it survives the parent `claude -p`
+    exit. Falls back to the in-process daemon worker if the subprocess can't be launched
+    (so art is never worse off than today)."""
+    import subprocess
+    import sys
+
+    # Suppress a re-spawn while a young resolver is still plausibly running (no double spend).
+    if _generating_is_fresh(key, scope):
+        return False
+
+    # Mark generating BEFORE the spawn so a racing call sees it immediately. The resolver
+    # re-stamps with its own pid and clears the marker when done.
+    _write_generating_marker(key, scope)
+
+    payload = json.dumps({
+        "kind": kind, "prompt": prompt, "seed": seed, "scope": scope,
+        "key": key, "provider": pname,
+        "state_dir": str(store.state_dir()),
+    })
+    try:
+        subprocess.Popen(
+            [sys.executable, _resolver_module_path(), "--resolve", payload],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,  # detach from the parent's process group/session
+            close_fds=True,
+            env=dict(os.environ),    # carry CLAWDND_*/WORLDOS_* provider + gateway config
+        )
+        return True
+    except (OSError, ValueError):
+        # Couldn't launch the detached process — fall back to the in-process daemon worker
+        # so we degrade no worse than today. Clear our pre-spawn marker first.
+        _clear_generating_marker(key, scope)
+        t = threading.Thread(
+            target=_worker, args=(kind, prompt, seed, scope, key),
+            name=f"imagegen-fb-{key[:8]}", daemon=True,
+        )
+        with _inflight_lock:
+            self_spawned = (key, scope) not in _inflight
+            if self_spawned:
+                _inflight.add((key, scope))
+        if self_spawned:
+            t.start()
+        return self_spawned
+
+
+def _resolver_module_path() -> str:
+    """Absolute path to THIS module, so the detached subprocess runs the same resolver
+    code regardless of the parent's cwd or sys.path."""
+    return str(Path(__file__).resolve())
+
+
+def _resolve_entry(spec: dict) -> int:
+    """Detached-resolver body (run in the child subprocess). Does the real generate()
+    and writes the derived cache, then clears the `generating` marker. NEVER raises out
+    (a resolver failure is benign — generate() already wrote a `.error` sidecar and the
+    viewer keeps its placeholder). Returns a process exit code."""
+    kind = spec.get("kind", "")
+    prompt = spec.get("prompt", "")
+    seed = spec.get("seed")
+    scope = spec.get("scope")
+    key = spec.get("key", "")
+    try:
+        _write_generating_marker(key, scope, pid=os.getpid())
+        generate(kind, prompt, seed=seed, scope=scope)
+        return 0
+    except Exception:
+        return 0  # benign: degrade is already handled inside generate()
+    finally:
+        _clear_generating_marker(key, scope)
+
+
 def async_generate(
     kind: str,
     prompt: str,
     *,
     seed: Optional[int] = None,
     scope: Optional[str] = None,
+    force: bool = False,
 ) -> dict:
     """Enqueue an image generation and return IMMEDIATELY with a cache handle.
 
     Fast path (always <500ms, no network on the calling thread):
     - On a content-hash cache HIT, returns the cached descriptor right away
       (``status="ready"``, ``cache_hit=True``) — nothing to enqueue.
-    - On a MISS, spawns a daemon worker to do the real generate() (provider +
+    - When the _private ingest already provides SERVABLE art for ``scope`` (and not
+      ``force``), returns ``status="ingested"`` WITHOUT spending — the viewer serves the
+      ingested asset ahead of any generated one anyway, so generating would be pure spend
+      for a face that's never displayed (F11-6).
+    - On a MISS, spawns a background worker to do the real generate() (provider +
       cache write) and returns a ``status="pending"`` descriptor carrying the
       ``scope`` + ``hash`` the viewer keys off. The image lands in the cache when
       the worker finishes; the viewer's /image endpoint 404→placeholder until then.
@@ -623,6 +1007,8 @@ def async_generate(
     ``kind``, ``prompt``, ``seed``, ``placeholder`` — so it is a drop-in for the old
     synchronous ``generate()`` return on the fire-and-forget DM path. ``status`` and
     ``hash`` are additive (new keys; nothing pre-existing is removed or repurposed).
+    ``force`` (additive, default False) bypasses the catalog consult to regenerate
+    even when ingested art exists.
 
     Provider selection happens here (cheap: env read + a lazy client import for
     ``configured()`` — no network), so the cache ``hash`` matches what the worker's
@@ -636,9 +1022,54 @@ def async_generate(
     # Cache hit -> hand it straight back; no worker, no wait.
     hit = cache_read(key, scope)
     if hit is not None:
+        # F11-5: a payload-bearing hit (provider lane wrote inline bytes_b64) must NOT
+        # be returned verbatim — a single hit would inject ~1-5M chars of base64 into the
+        # DM's beat. Strip the inline bytes to METADATA-ONLY (has_bytes/byte_len) for the
+        # tool-side return; the on-disk cache entry is untouched, so the viewer's /image
+        # endpoint still serves the bytes. No tool-side consumer reads bytes_b64.
+        hit = _strip_inline_bytes(hit)
         hit["cache_hit"] = True
         hit.setdefault("status", "ready")
         return hit
+
+    # F11-6: catalog consult. The viewer serves ingested _private art ahead of any
+    # generated cache, so if the ingest already has servable art for this scope,
+    # generating is pure spend for a face that never displays. Skip (unless force).
+    if not force and has_ingested_art(scope):
+        return {
+            "provider": pname,
+            "kind": _normalize_kind(kind),
+            "prompt": prompt,
+            "seed": seed,
+            "placeholder": False,   # the viewer has servable ingested art for this scope
+            "status": "ingested",   # additive: "served by the catalog, not generated"
+            "hash": key,
+            "scope": scope,
+            "cache_hit": False,
+            "already_pending": False,
+        }
+
+    # F11-3: detached-resolver path. A daemon thread dies with the per-beat `claude -p`
+    # process (the engine MCP server is its stdio child), so fire-and-forget art started
+    # late in a beat is silently lost AND the paid image is never claimed. When enabled,
+    # spawn a process-group-detached resolver that outlives the parent and writes the
+    # derived cache itself. A young `generating` marker suppresses a re-POST (double spend).
+    if _detached_resolver_enabled():
+        spawned = _spawn_detached_resolver(kind, prompt, seed, scope, key, pname)
+        return {
+            "provider": pname,
+            "kind": _normalize_kind(kind),
+            "prompt": prompt,
+            "seed": seed,
+            "placeholder": True,
+            "status": "pending",
+            "hash": key,
+            "scope": scope,
+            "cache_hit": False,
+            # already_pending: a young `generating` marker meant we suppressed a re-spawn.
+            "already_pending": not spawned,
+            "detached": True,  # additive: resolver runs in a detached subprocess
+        }
 
     # Miss -> enqueue exactly one worker per (key, scope) and return a pending handle.
     with _inflight_lock:
@@ -666,3 +1097,34 @@ def async_generate(
         "cache_hit": False,
         "already_pending": already,  # additive: a worker for this key was already running
     }
+
+
+# --------------------------------------------------------------------------- #
+# Detached-resolver CLI entrypoint (F11-3). Invoked ONLY as a subprocess by
+# _spawn_detached_resolver: `python imagegen.py --resolve <json-spec>`. Not used by
+# the test suite directly (tests call _resolve_entry); not a manual tool.
+# --------------------------------------------------------------------------- #
+
+def _main(argv: Optional[list] = None) -> int:
+    import sys
+
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) >= 2 and args[0] == "--resolve":
+        try:
+            spec = json.loads(args[1])
+        except (ValueError, TypeError):
+            return 2
+        if not isinstance(spec, dict):
+            return 2
+        # The child inherits the parent's env (state dir, provider, gateway config). As a
+        # belt-and-braces fallback, seed the state dir from the spec if the env didn't
+        # carry it, so the resolver writes the cache where the viewer reads it.
+        sd = spec.get("state_dir")
+        if sd and not (env_var("STATE_DIR")):
+            os.environ["WORLDOS_STATE_DIR"] = str(sd)
+        return _resolve_entry(spec)
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - subprocess entrypoint
+    raise SystemExit(_main())

--- a/servers/engine/openclaw_image.py
+++ b/servers/engine/openclaw_image.py
@@ -65,6 +65,7 @@ from __future__ import annotations
 
 import base64
 import json
+import threading
 import time
 import urllib.error
 import urllib.request
@@ -109,6 +110,87 @@ MAX_INLINE_BYTES = 16 * 1024 * 1024
 
 # Image file extensions the gateway may emit (png/jpeg/webp).
 _IMAGE_EXTS = (".png", ".jpg", ".jpeg", ".webp", ".gif")
+
+# --------------------------------------------------------------------------- #
+# F11-4: media-dir cross-attribution guard.
+#
+# The media dir is SHARED — the skill mandates scene + portrait art in one beat, so two
+# generations run concurrently (one per (key,scope); imagegen spawns a thread/resolver
+# each, with no cross-key serialization). Both snapshot the dir, both poll, and when the
+# first file lands BOTH see it as "fresh" and `max(fresh, key=mtime)` returns the SAME
+# path -> two scopes claim one image (and any unrelated gateway image task is claimable).
+#
+# Two-part fix, derived-cache-only and invariant-safe:
+#   1. A module-level GENERATION LOCK serializes the POST->claim window so concurrent
+#      generations don't overlap their claim races. Serialization is off the DM turn
+#      (async), so the latency cost is invisible to play.
+#   2. A module-level CLAIMED-PATH set: every path a generation claims is recorded, and a
+#      claim picks the OLDEST unclaimed fresh file (FIFO drop order) — so even a file that
+#      lands during another generation's window can never be double-claimed.
+# Both are best-effort within one process; they hold for the in-process burst that is the
+# real-world case (one engine process spawning scene+portrait in a beat).
+# --------------------------------------------------------------------------- #
+_GENERATION_LOCK = threading.Lock()
+_CLAIMED_LOCK = threading.Lock()
+_CLAIMED_PATHS: set[str] = set()
+
+# Suffix of the sidecar lock file that records a CROSS-PROCESS claim (F11-3/F11-4): the
+# detached resolver runs in a separate process, so an in-memory set can't serialize two
+# resolvers. An atomic O_CREAT|O_EXCL `<image>.claimed` file does — the first resolver to
+# create it owns the image; a second resolver's create fails and it skips to the next file.
+_CLAIM_SUFFIX = ".claimed"
+
+
+def _claim_lockfile(path: Path) -> Path:
+    return path.with_name(path.name + _CLAIM_SUFFIX)
+
+
+def _claim_path(path: Path) -> bool:
+    """Atomically claim `path` for THIS generation. Returns True if we won the claim,
+    False if another generation (in this process OR a separate detached resolver) already
+    owns it. Two layers: an in-memory set for the in-process burst, and an exclusive
+    `<image>.claimed` lock file for cross-process resolvers. The lock file is a derived,
+    rebuildable artifact next to the (derived) media file — never campaign state."""
+    key = str(path)
+    with _CLAIMED_LOCK:
+        if key in _CLAIMED_PATHS:
+            return False
+        _CLAIMED_PATHS.add(key)
+    # Cross-process exclusive claim. O_CREAT|O_EXCL is atomic on a local fs: exactly one
+    # creator wins. If we can't even attempt it (no parent dir, perms), fall back to the
+    # in-memory claim we already hold — no worse than today within a single process.
+    import os
+    lock = _claim_lockfile(path)
+    try:
+        fd = os.open(str(lock), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
+        # Another resolver process already owns it — release our in-memory claim so a
+        # later, distinct file can still be claimed by us.
+        with _CLAIMED_LOCK:
+            _CLAIMED_PATHS.discard(key)
+        return False
+    except OSError:
+        return True  # best-effort: keep the in-memory claim (single-process correctness)
+    else:
+        os.close(fd)
+        return True
+
+
+def _is_claimed(path: Path) -> bool:
+    """True if `path` is already claimed in-process OR a cross-process `.claimed` lock
+    exists for it (so a poll loop skips a file another resolver owns)."""
+    with _CLAIMED_LOCK:
+        if str(path) in _CLAIMED_PATHS:
+            return True
+    return _claim_lockfile(path).exists()
+
+
+def _reset_claimed_paths() -> None:
+    """Test helper: clear the in-memory claimed-path registry between cases. (The
+    on-disk `.claimed` lock files live under each test's tmp media dir, so they're
+    isolated by tmp_path and need no global reset.)"""
+    with _CLAIMED_LOCK:
+        _CLAIMED_PATHS.clear()
 
 
 class OpenClawImageError(RuntimeError):
@@ -162,6 +244,9 @@ class OpenClawImageClient:
     media_dir: Optional[Path] = None
     connect_timeout: float = 0.0
     poll_timeout: float = 0.0
+    # Pre-POST media-dir snapshot, stashed by _post_generate for the claim step. Not a
+    # config knob — instance scratch state for one generate_image call.
+    _existing_snapshot: set = field(default_factory=set, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         self.gateway_url = (self.gateway_url or _env(ENV_GATEWAY_URL, DEFAULT_GATEWAY_URL)).rstrip("/")
@@ -285,8 +370,51 @@ class OpenClawImageClient:
         if not (prompt or "").strip():
             raise OpenClawImageError("prompt is required for image generation")
 
+        # F11-4: serialize the POST->claim window across concurrent generations so two
+        # don't race for the same landed file. Only the waiting (claim-bearing) path needs
+        # the lock; wait=False just fires the POST and returns the task id, no claim. The
+        # `with` is a no-op for wait=False (we acquire nothing).
+        if not wait:
+            return self._generate_post_only(prompt, size=size, count=count)
+        with _GENERATION_LOCK:
+            return self._generate_and_claim(prompt, size=size, count=count)
+
+    def _generate_post_only(self, prompt: str, *, size: Optional[str], count: int) -> "ImageResult":
+        """POST and return the started descriptor (task id) without watching for a file."""
+        out, _started = self._post_generate(prompt, size=size, count=count)
+        return out
+
+    def _generate_and_claim(self, prompt: str, *, size: Optional[str], count: int) -> "ImageResult":
+        """POST, then watch the media dir and claim the oldest unclaimed fresh file."""
+        out, started_at = self._post_generate(prompt, size=size, count=count, snapshot=True)
+        if out.has_image():
+            return out
+        found = self._await_new_media(self._existing_snapshot, since=started_at)
+        if found is not None:
+            out.path = str(found)
+            out.mime_type = _mime_for(found)
+            if found.stat().st_size <= MAX_INLINE_BYTES:
+                out.data = found.read_bytes()
+            return out
+        # No file appeared in budget (slow gen, or gateway is on another host
+        # so its media dir isn't visible here). Clean failure -> fall back.
+        raise OpenClawImageError(
+            "image_generate task started"
+            + (f" ({out.task_id})" if out.task_id else "")
+            + f" but no image appeared in {self.media_dir} within "
+            f"{self.poll_timeout:.0f}s. The gateway may be remote, slow, or "
+            "still rendering; retrieve the image from the gateway host or its "
+            "chat session."
+        )
+
+    def _post_generate(self, prompt: str, *, size: Optional[str], count: int,
+                       snapshot: bool = False) -> tuple["ImageResult", float]:
+        """Shared POST + envelope parse. Returns (ImageResult, started_at). When
+        `snapshot` is set, the pre-POST media-dir set is stashed on the instance so the
+        claim step excludes it. `started_at` is captured BEFORE the snapshot so a file the
+        gateway writes during the POST is counted as fresh."""
         started_at = time.time()
-        existing = self._snapshot_media_dir() if wait else set()
+        self._existing_snapshot = self._snapshot_media_dir() if snapshot else set()
 
         body = self.build_request_body(prompt, size=size, count=count)
         envelope = self._post(body)
@@ -301,35 +429,10 @@ class OpenClawImageClient:
             raise OpenClawImageError("gateway image_generate returned no result payload")
 
         out = ImageResult(raw=result)
-
-        # 1) Synchronous result shape (no session key path): paths/attachments/url/data.
+        # Synchronous result shape (no session key path): paths/attachments/url/data.
         _extract_inline_image(result, out)
         out.task_id = _extract_task_id(result)
-        if out.has_image():
-            return out
-
-        # 2) Async path: we have a task id. Watch the media dir for the new file.
-        if wait:
-            found = self._await_new_media(existing, since=started_at)
-            if found is not None:
-                out.path = str(found)
-                out.mime_type = _mime_for(found)
-                if found.stat().st_size <= MAX_INLINE_BYTES:
-                    out.data = found.read_bytes()
-                return out
-            # No file appeared in budget (slow gen, or gateway is on another host
-            # so its media dir isn't visible here). Clean failure -> fall back.
-            raise OpenClawImageError(
-                "image_generate task started"
-                + (f" ({out.task_id})" if out.task_id else "")
-                + f" but no image appeared in {self.media_dir} within "
-                f"{self.poll_timeout:.0f}s. The gateway may be remote, slow, or "
-                "still rendering; retrieve the image from the gateway host or its "
-                "chat session."
-            )
-
-        # wait=False: return the started descriptor (task id only).
-        return out
+        return out, started_at
 
     # -- media-dir watching ------------------------------------------------ #
 
@@ -341,10 +444,12 @@ class OpenClawImageClient:
         return {p for p in d.iterdir() if p.suffix.lower() in _IMAGE_EXTS}
 
     def _await_new_media(self, before: set, *, since: float) -> Optional[Path]:
-        """Poll the media dir until a NEW image file appears (or budget elapses).
+        """Poll the media dir until a NEW, UNCLAIMED image file appears (F11-4).
 
-        "New" = a path not present in `before` and modified at/after `since`.
-        Returns the newest such file, or None on timeout / no-such-dir.
+        "New" = a path not present in `before` (the pre-POST snapshot) and modified
+        at/after `since`. Among such files we claim the OLDEST unclaimed one (FIFO in
+        drop order) and atomically record the claim, so a concurrent generation can never
+        take the same path. Returns the claimed file, or None on timeout / no-such-dir.
         """
         d = self.media_dir
         if not d:
@@ -357,9 +462,16 @@ class OpenClawImageClient:
                     p
                     for p in current - before
                     if _safe_mtime(p) >= since - 1.0  # 1s slop for clock/fs granularity
+                    and not _is_claimed(p)            # F11-4: skip another scope's image
                 ]
                 if fresh:
-                    return max(fresh, key=_safe_mtime)
+                    # FIFO: claim the OLDEST unclaimed fresh file, so when scene+portrait
+                    # land in order the first generation takes the first file. Tie-break on
+                    # path so two files with identical mtime resolve deterministically.
+                    fresh.sort(key=lambda p: (_safe_mtime(p), str(p)))
+                    for cand in fresh:
+                        if _claim_path(cand):  # we won the claim (lost the race -> next)
+                            return cand
             time.sleep(POLL_INTERVAL)
         return None
 

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -2226,22 +2226,30 @@ def reroll_character(
 
 
 @mcp.tool()
-def generate_image(kind: str, prompt: str, seed: Optional[int] = None, scope: Optional[str] = None) -> dict:
+def generate_image(kind: str, prompt: str, seed: Optional[int] = None,
+                   scope: Optional[str] = None, force: bool = False) -> dict:
     """Kick off (fire-and-forget) an image for the campaign and return IMMEDIATELY.
     `kind` is 'map' (region/dungeon), 'portrait' (NPC/PC), or 'scene' (illustration);
     `prompt` is the visual brief. The active provider is chosen by CLAWDND_IMAGE_PROVIDER
-    (default 'null' → a deterministic placeholder, no network); pass `scope` (a world or
-    campaign id) to partition the derived image cache.
+    (default 'null' → a deterministic placeholder, no network).
+
+    Pass `scope` as the ENTITY id the viewer fetches by, NOT a world/campaign id:
+    `portrait-<character_id>` for an NPC/PC face, or the `<location_id>` for a scene/map.
+    The viewer keys /image and /portrait-* off that exact scope, so a mismatched scope
+    leaves the art unfetchable.
 
     This is an OPTIONAL OVERLAY that never blocks the engine or the DM's turn: a cache
-    hit returns the descriptor straight away (`status="ready"`); a miss enqueues a
-    background worker and returns a `status="pending"` handle (with the `scope`/`hash`
-    the viewer keys off) in well under a second — the actual generation (which can take
-    tens of seconds against a real gateway) happens off the turn path. The dashboard's
-    /image?scope=… serves a placeholder until the image lands, so play never waits on art.
-    The image cache is a derived, rebuildable artifact written by the worker; it never
+    hit returns the descriptor straight away (`status="ready"`); when the world's ingested
+    art already covers the scope it returns `status="ingested"` without spending; a miss
+    enqueues a background resolver and returns a `status="pending"` handle (with the
+    `scope`/`hash` the viewer keys off) in well under a second — the actual generation
+    (which can take tens of seconds against a real gateway) happens off the turn path. The
+    dashboard's /image?scope=… serves a placeholder until the image lands, so play never
+    waits on art. Pass `force=True` to regenerate even when ingested art exists.
+
+    The image cache is a derived, rebuildable artifact written by the resolver; it never
     touches campaign state (engine stays sole writer)."""
-    return imagegen.async_generate(kind, prompt, seed=seed, scope=scope)
+    return imagegen.async_generate(kind, prompt, seed=seed, scope=scope, force=force)
 
 
 _SHORT_TO_FULL_AB = {

--- a/servers/engine/tests/test_imagegen.py
+++ b/servers/engine/tests/test_imagegen.py
@@ -510,3 +510,346 @@ def test_async_generate_worker_failure_does_not_crash(state, monkeypatch):
     # generate() degrades-to-null and does NOT cache the failure, so the key stays a miss.
     _time.sleep(0.2)  # let the worker run + finish
     assert imagegen.cache_read(d["hash"], d["scope"]) is None
+
+
+# --------------------------------------------------------------------------- #
+# F11-5: a cache HIT must not return multi-MB bytes_b64 verbatim into DM context.
+# The metadata-only return carries has_bytes/byte_len; the on-disk cache keeps the
+# bytes so the viewer still serves them.
+# --------------------------------------------------------------------------- #
+
+def test_async_cache_hit_strips_inline_bytes_to_metadata(state):
+    """A provider-lane descriptor with inline bytes_b64 must come back from async_generate
+    as METADATA only (has_bytes/byte_len) — never the megabyte base64 blob (F11-5)."""
+    import base64 as _b64
+
+    raw = b"\x89PNG" + b"\x00" * (1024 * 1024)  # ~1MB image
+    b64 = _b64.b64encode(raw).decode("ascii")
+    # Seed the cache under the exact (null-provider) key async_generate will look up.
+    key = imagegen.content_hash("portrait", "a fence-painted face", provider="null")
+    imagegen.cache_write(
+        {"provider": "null", "kind": "portrait", "prompt": "a fence-painted face",
+         "seed": None, "placeholder": False, "bytes_b64": b64},
+        scope="b64-w",
+    )
+
+    hit = imagegen.async_generate("portrait", "a fence-painted face", scope="b64-w")
+    assert hit["cache_hit"] is True and hit["status"] == "ready"
+    assert "bytes_b64" not in hit, "inline base64 leaked into the tool return"
+    assert hit["has_bytes"] is True
+    assert hit["byte_len"] == len(raw)  # exact decoded size
+    # The on-disk cache entry is UNTOUCHED — the viewer still gets the bytes.
+    on_disk = imagegen.cache_read(key, scope="b64-w")
+    assert on_disk["bytes_b64"] == b64
+
+
+def test_async_cache_hit_without_bytes_is_unchanged(state):
+    """A hit with no inline bytes round-trips unmodified (no has_bytes/byte_len noise)."""
+    imagegen.generate("map", "a quiet road", seed=1, scope="nb-w")  # null placeholder, no bytes
+    hit = imagegen.async_generate("map", "a quiet road", seed=1, scope="nb-w")
+    assert hit["cache_hit"] is True
+    assert "bytes_b64" not in hit and "has_bytes" not in hit and "byte_len" not in hit
+
+
+def test_strip_inline_bytes_is_pure(state):
+    """_strip_inline_bytes never mutates its input (defensive — callers reuse the dict)."""
+    src = {"provider": "openclaw", "kind": "scene", "prompt": "x", "bytes_b64": "QUJD"}
+    out = imagegen._strip_inline_bytes(src)
+    assert "bytes_b64" in src  # input untouched
+    assert "bytes_b64" not in out and out["has_bytes"] is True
+
+
+# --------------------------------------------------------------------------- #
+# F11-7: a failed background generation must leave a `.error` sidecar (no longer
+# completely silent). A successful retry supersedes it; the viewer's *.json glob
+# never picks the sidecar up.
+# --------------------------------------------------------------------------- #
+
+def test_generate_failure_writes_error_sidecar(state):
+    """A provider failure writes <scope>/<hash>.error with the error string (F11-7)."""
+    class _Boom:
+        name = "boom"
+
+        def generate(self, kind, prompt, *, seed=None):
+            raise RuntimeError("gateway exploded")
+
+    state.joinpath("images")  # ensure root resolvable
+    import imagegen as _ig
+    monkey = pytest.MonkeyPatch()
+    monkey.setattr(_ig, "get_provider", lambda: _Boom())
+    try:
+        d = _ig.generate("scene", "a torchlit door", scope="err-w")
+    finally:
+        monkey.undo()
+    assert d.get("degraded_from") == "boom"
+    key = _ig.content_hash("scene", "a torchlit door", provider="boom")
+    rec = _ig.read_error(key, scope="err-w")
+    assert rec is not None
+    assert rec["status"] == "error"
+    assert "gateway exploded" in rec["error"]
+    assert rec["provider"] == "boom"
+    # The degraded descriptor itself stays UNCACHED (transient blip stays retryable).
+    assert _ig.cache_read(key, scope="err-w") is None
+    # Sidecar is a bare `.error` suffix on disk, NOT `.error.json`.
+    p = _ig.error_path(key, scope="err-w")
+    assert p.name.endswith(".error") and not p.name.endswith(".json")
+    assert p.is_file()
+
+
+def test_error_sidecar_invisible_to_json_descriptor_glob(state):
+    """The viewer resolves *.json only — a `.error` sidecar must not be mistaken for a
+    real descriptor by imagegen._newest_descriptor (mirrors the viewer's glob)."""
+    imagegen.write_error("deadbeef" * 8, "boom", scope="glob-w", provider="boom")
+    # No *.json descriptor exists in the scope, so the newest-descriptor resolver misses.
+    assert imagegen._newest_descriptor("glob-w") is None
+    # And the .error file is present (so the miss is genuinely "glob ignored the sidecar").
+    assert list((state / "images" / "glob-w").glob("*.error"))
+
+
+def test_successful_generate_clears_stale_error_sidecar(state):
+    """A success under the same key deletes an earlier `.error` (most-recent-outcome)."""
+    # Seed a stale error under the NULL-provider key (what a later success will write to).
+    key = imagegen.content_hash("portrait", "a hopeful face", provider="null")
+    imagegen.write_error(key, "earlier failure", scope="clr-w", provider="null")
+    assert imagegen.read_error(key, scope="clr-w") is not None
+    # A normal (null) generate succeeds under that exact key and must clear the sidecar.
+    imagegen.generate("portrait", "a hopeful face", scope="clr-w")
+    assert imagegen.read_error(key, scope="clr-w") is None
+    assert imagegen.cache_read(key, scope="clr-w") is not None
+
+
+# --------------------------------------------------------------------------- #
+# F11-6: catalog consult / scope idempotency. The viewer serves ingested _private
+# art ahead of any generated cache, so async_generate must NOT spend to generate a
+# scope the ingest already covers (unless force=True). An unknown scope still generates.
+# --------------------------------------------------------------------------- #
+
+def _seed_ingested_art(content_root, world, scope_seg, *, scope_field=None):
+    """Drop a wiki_ingest.json under content/worlds/_private/<world>/images/<seg>/."""
+    d = content_root / "worlds" / "_private" / world / "images" / scope_seg
+    d.mkdir(parents=True, exist_ok=True)
+    img = d / "image.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\nART")
+    desc = {"scope": scope_field or scope_seg, "path": str(img), "kind": "portrait",
+            "source": "wiki", "provider": "ingest"}
+    (d / "wiki_ingest.json").write_text(json.dumps(desc), encoding="utf-8")
+    return img
+
+
+@pytest.fixture
+def ingest_root(tmp_path, monkeypatch):
+    """A tmp content/ root the engine's catalog consult will resolve via CONTENT_DIR."""
+    content = tmp_path / "content"
+    (content / "worlds" / "_private").mkdir(parents=True)
+    monkeypatch.setenv("CLAWDND_CONTENT_DIR", str(content))
+    monkeypatch.delenv("CLAWDND_ART_REPO_ROOT", raising=False)
+    monkeypatch.delenv("CLAWDND_REPO_ROOT", raising=False)
+    return content
+
+
+def test_async_generate_skips_when_ingested_art_exists(state, ingest_root, monkeypatch):
+    """A scope the _private ingest covers returns status='ingested' WITHOUT spending —
+    the provider is never invoked (F11-6)."""
+    _seed_ingested_art(ingest_root, "faerun", "portrait-shadowheart")
+
+    calls = {"n": 0}
+
+    class _Counting:
+        name = "count"
+
+        def generate(self, kind, prompt, *, seed=None):
+            calls["n"] += 1
+            return {"provider": self.name, "kind": kind, "prompt": prompt, "placeholder": False}
+
+    monkeypatch.setattr(imagegen, "get_provider", lambda: _Counting())
+    d = imagegen.async_generate("portrait", "a face", scope="portrait-shadowheart")
+    assert d["status"] == "ingested"
+    assert d["placeholder"] is False
+    assert calls["n"] == 0, "provider was invoked despite ingested art (pure spend)"
+
+
+def test_async_generate_ingest_consult_normalizes_scope(state, ingest_root, monkeypatch):
+    """The consult matches the manifest slug even when the UI fetches an engine-id scope:
+    ingested as portrait:shadowheart, requested as portrait-npc-shadowheart (F11-6)."""
+    _seed_ingested_art(ingest_root, "faerun", "portrait_shadowheart",
+                       scope_field="portrait:shadowheart")
+
+    class _MustNotGenerate:
+        name = "nope"
+
+        def generate(self, kind, prompt, *, seed=None):
+            raise AssertionError("provider.generate must not be called for ingested scope")
+
+    monkeypatch.setattr(imagegen, "get_provider", lambda: _MustNotGenerate())
+    d = imagegen.async_generate("portrait", "a face", scope="portrait-npc-shadowheart")
+    assert d["status"] == "ingested"
+
+
+def test_async_generate_force_regenerates_over_ingested_art(state, ingest_root, monkeypatch):
+    """force=True bypasses the catalog consult and generates anyway (F11-6)."""
+    _seed_ingested_art(ingest_root, "faerun", "portrait-shadowheart")
+    slow = _SlowProvider(delay=0.05)
+    monkeypatch.setattr(imagegen, "get_provider", lambda: slow)
+    d = imagegen.async_generate("portrait", "a face", scope="portrait-shadowheart", force=True)
+    assert d["status"] == "pending"  # generation enqueued despite ingested art
+    _wait_for(lambda: imagegen.cache_read(d["hash"], d["scope"]) is not None)
+
+
+def test_async_generate_unknown_scope_still_generates(state, ingest_root, monkeypatch):
+    """A scope with NO ingested art falls through to normal generation (F11-6)."""
+    _seed_ingested_art(ingest_root, "faerun", "portrait-shadowheart")
+    slow = _SlowProvider(delay=0.05)
+    monkeypatch.setattr(imagegen, "get_provider", lambda: slow)
+    d = imagegen.async_generate("portrait", "a stranger", scope="portrait-nobody")
+    assert d["status"] == "pending"
+    _wait_for(lambda: imagegen.cache_read(d["hash"], d["scope"]) is not None)
+
+
+def test_has_ingested_art_no_root_is_false(state, monkeypatch, tmp_path):
+    """On an art-less host (no _private tree) the consult returns False (generates)."""
+    monkeypatch.setenv("CLAWDND_CONTENT_DIR", str(tmp_path / "empty-content"))
+    monkeypatch.delenv("CLAWDND_ART_REPO_ROOT", raising=False)
+    monkeypatch.delenv("CLAWDND_REPO_ROOT", raising=False)
+    assert imagegen.has_ingested_art("portrait-anyone") is False
+
+
+# --------------------------------------------------------------------------- #
+# F11-3: detached resolver — art that survives the per-beat `claude -p` exit.
+# The default (env OFF) keeps the daemon-thread behavior; the opt-in path spawns a
+# process-group-detached resolver that writes the derived cache after the parent moves
+# on, and a young `generating` marker suppresses a re-spawn (no double spend).
+# --------------------------------------------------------------------------- #
+
+def test_detached_resolver_off_by_default_uses_thread(state, monkeypatch):
+    """Default behavior unchanged: no env -> daemon-thread worker, no `detached` key,
+    no `generating` marker (additive, today's behavior preserved)."""
+    monkeypatch.delenv("CLAWDND_IMAGE_DETACHED_RESOLVER", raising=False)
+    slow = _SlowProvider(delay=0.05)
+    monkeypatch.setattr(imagegen, "get_provider", lambda: slow)
+    d = imagegen.async_generate("scene", "a quiet glade", scope="det-off")
+    assert d["status"] == "pending"
+    assert "detached" not in d  # the thread path doesn't set it
+    _wait_for(lambda: imagegen.cache_read(d["hash"], d["scope"]) is not None)
+
+
+def test_detached_resolver_enabled_spawns_detached(state, monkeypatch):
+    """With the env flag on, async_generate reports the detached path and writes a
+    `generating` marker (then the resolver subprocess clears it). We stub Popen so the
+    test stays in-process and deterministic."""
+    monkeypatch.setenv("CLAWDND_IMAGE_DETACHED_RESOLVER", "1")
+    monkeypatch.setenv("CLAWDND_IMAGE_PROVIDER", "null")
+
+    spawned = {"cmd": None}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kw):
+            spawned["cmd"] = cmd
+            # Mimic the kernel-detach contract the real spawn relies on.
+            assert kw.get("start_new_session") is True
+
+    monkeypatch.setattr("subprocess.Popen", _FakePopen)
+    d = imagegen.async_generate("portrait", "a sentinel", scope="det-on")
+    assert d["status"] == "pending"
+    assert d["detached"] is True
+    assert d["already_pending"] is False
+    # A `generating` marker was written before the spawn (suppresses a racing re-POST).
+    assert imagegen.generating_path(d["hash"], d["scope"]).exists()
+    # The spawn used THIS module's --resolve entrypoint.
+    assert "--resolve" in spawned["cmd"]
+    assert spawned["cmd"][1].endswith("imagegen.py")
+
+
+def test_detached_young_generating_marker_suppresses_respawn(state, monkeypatch):
+    """A fresh `generating` marker means a resolver is already in flight: a second
+    async_generate must NOT spawn again (no double spend)."""
+    monkeypatch.setenv("CLAWDND_IMAGE_DETACHED_RESOLVER", "1")
+    monkeypatch.setenv("CLAWDND_IMAGE_PROVIDER", "null")
+    spawns = {"n": 0}
+
+    class _FakePopen:
+        def __init__(self, cmd, **kw):
+            spawns["n"] += 1
+
+    monkeypatch.setattr("subprocess.Popen", _FakePopen)
+    d1 = imagegen.async_generate("portrait", "a twin", scope="det-twin")
+    d2 = imagegen.async_generate("portrait", "a twin", scope="det-twin")
+    assert spawns["n"] == 1  # exactly one resolver spawned
+    assert d1["already_pending"] is False
+    assert d2["already_pending"] is True  # the second saw the young marker and stood down
+
+
+def test_detached_stale_generating_marker_allows_respawn(state, monkeypatch):
+    """A `generating` marker older than the TTL is treated as a crashed resolver — a
+    later call may retry (re-spawn)."""
+    monkeypatch.setenv("CLAWDND_IMAGE_DETACHED_RESOLVER", "1")
+    monkeypatch.setenv("CLAWDND_IMAGE_PROVIDER", "null")
+    monkeypatch.setenv("CLAWDND_IMAGE_GENERATING_TTL", "1.0")
+    key = imagegen.content_hash("portrait", "a ghost", provider="null")
+    # Hand-write a stale marker (started 10s ago, TTL is 1s).
+    p = imagegen.generating_path(key, "det-stale")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps({"hash": key, "status": "generating",
+                             "started_at": _time.time() - 10.0}), encoding="utf-8")
+    spawns = {"n": 0}
+    monkeypatch.setattr("subprocess.Popen",
+                        lambda cmd, **kw: spawns.__setitem__("n", spawns["n"] + 1))
+    d = imagegen.async_generate("portrait", "a ghost", scope="det-stale")
+    assert spawns["n"] == 1  # stale marker did not suppress the retry
+    assert d["already_pending"] is False
+
+
+def test_resolve_entry_writes_cache_and_clears_marker(state, monkeypatch):
+    """The resolver BODY (what the detached subprocess runs) does the real generate(),
+    writes the derived cache, and clears the `generating` marker (F11-3)."""
+    monkeypatch.setenv("CLAWDND_IMAGE_PROVIDER", "null")
+    key = imagegen.content_hash("scene", "a lone tower", provider="null")
+    imagegen._write_generating_marker(key, "res-w")
+    assert imagegen.generating_path(key, "res-w").exists()
+    rc = imagegen._resolve_entry({"kind": "scene", "prompt": "a lone tower",
+                                  "seed": None, "scope": "res-w", "key": key})
+    assert rc == 0
+    assert imagegen.cache_read(key, "res-w") is not None  # cache written
+    assert not imagegen.generating_path(key, "res-w").exists()  # marker cleared
+
+
+def test_detached_resolver_survives_parent_exit(tmp_path, monkeypatch):
+    """End-to-end: a REAL detached subprocess writes the cache after the spawning parent
+    has returned (proving the daemon-thread death mode is fixed). Uses the null provider
+    with a small artificial delay so the parent demonstrably returns first (F11-3)."""
+    import subprocess as _sp
+    import sys as _sys
+    import textwrap as _tw
+
+    state = tmp_path / "state"
+    state.mkdir()
+    # A tiny parent program: enable the detached resolver, async_generate, then EXIT.
+    # The resolver subprocess must outlive it and land the cache descriptor.
+    engine_dir = str((__import__("pathlib").Path(imagegen.__file__)).resolve().parent)
+    prog = _tw.dedent(f"""
+        import sys, os
+        sys.path.insert(0, {engine_dir!r})
+        os.environ["CLAWDND_STATE_DIR"] = {str(state)!r}
+        os.environ["CLAWDND_IMAGE_DETACHED_RESOLVER"] = "1"
+        os.environ["CLAWDND_IMAGE_PROVIDER"] = "null"
+        import imagegen
+        d = imagegen.async_generate("scene", "a detached crypt", scope="e2e")
+        print(d["hash"])  # hand the key to the parent test
+    """)
+    proc = _sp.run([_sys.executable, "-c", prog], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    key = proc.stdout.strip().splitlines()[-1]
+    assert len(key) == 64
+
+    # The spawning process has EXITED. The detached resolver must still write the cache.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(state))
+    deadline = _time.monotonic() + 10.0
+    cached = None
+    while _time.monotonic() < deadline:
+        cached = imagegen.cache_read(key, "e2e")
+        if cached is not None:
+            break
+        _time.sleep(0.05)
+    assert cached is not None, "detached resolver did not write the cache after parent exit"
+    assert cached["prompt"] == "a detached crypt"
+    # And the `generating` marker was cleared by the resolver.
+    assert not imagegen.generating_path(key, "e2e").exists()

--- a/servers/engine/tests/test_openclaw_image.py
+++ b/servers/engine/tests/test_openclaw_image.py
@@ -89,6 +89,9 @@ def _isolate_env(monkeypatch, tmp_path):
     monkeypatch.delenv("CLAWDND_IMAGE_PROVIDER", raising=False)
     # Tight poll budget so the no-image timeout test is fast.
     monkeypatch.setenv("CLAWDND_OPENCLAW_POLL_TIMEOUT", "0.5")
+    # F11-4: the claimed-path registry is module-level; reset it so cross-attribution
+    # tests start clean and don't leak claims into each other.
+    openclaw_image._reset_claimed_paths()
     return tmp_path
 
 
@@ -440,3 +443,121 @@ def test_provider_generate_wraps_any_openclaw_error(monkeypatch):
     monkeypatch.setattr(OpenClawImageClient, "generate_image", fake_generate_image)
     with pytest.raises(RuntimeError, match="openclaw image provider failed"):
         imagegen.OpenClawImageProvider().generate("scene", "x")
+
+
+# --------------------------------------------------------------------------- #
+# F11-4: media-dir cross-attribution. A shared media dir + concurrent scene+portrait
+# generations must claim DISTINCT files (in drop order), never the same path twice.
+# --------------------------------------------------------------------------- #
+
+import os as _os  # noqa: E402
+import time as _time  # noqa: E402
+
+
+def test_await_claims_oldest_unclaimed_fifo(tmp_path):
+    """When two fresh files are present, _await_new_media claims the OLDEST (FIFO), and a
+    second await claims the NEXT — never the same path twice (F11-4)."""
+    media = tmp_path / "media"
+    media.mkdir(parents=True)
+    since = _time.time()
+    first = media / "scene.png"
+    second = media / "portrait.png"
+    first.write_bytes(b"A")
+    second.write_bytes(b"B")
+    # Both fresh (>= since-1s); `first` strictly older so FIFO is deterministic.
+    _os.utime(first, (since, since))
+    _os.utime(second, (since + 0.5, since + 0.5))
+
+    c = OpenClawImageClient(token="t", media_dir=media, poll_timeout=1.0)
+    claim_a = c._await_new_media(set(), since=since)
+    claim_b = c._await_new_media(set(), since=since)
+    assert claim_a == first       # oldest first
+    assert claim_b == second      # second await gets the NEXT file, not the same one
+    assert claim_a != claim_b
+
+
+def test_two_concurrent_generations_claim_distinct_files(tmp_path, monkeypatch):
+    """Two clients sharing one media dir, with two files landing during the POSTs, must
+    return DISTINCT paths — the core cross-attribution bug (F11-4). Today both can return
+    the same (newest) path."""
+    media = tmp_path / "media"
+    media.mkdir(parents=True)
+
+    # Each client's _open drops ITS OWN file during the POST, so both files exist by the
+    # time either claim runs — the exact concurrent-burst shape.
+    drops = {"scene": media / "scene.png", "portrait": media / "portrait.png"}
+
+    def _make_open(which, mtime):
+        def _open(self, req):  # noqa: ANN001
+            drops[which].write_bytes(which.encode())
+            _os.utime(drops[which], (mtime, mtime))
+            return json.dumps(_started_envelope(f"task_{which}")).encode("utf-8")
+        return _open
+
+    base = _time.time()
+    c_scene = OpenClawImageClient(token="t", media_dir=media, poll_timeout=1.0)
+    c_portrait = OpenClawImageClient(token="t", media_dir=media, poll_timeout=1.0)
+    monkeypatch.setattr(OpenClawImageClient, "_open", _make_open("scene", base))
+
+    res_scene = c_scene.generate_image("a tavern")
+    # The portrait client lands its own (newer) file and must NOT re-claim the scene file.
+    monkeypatch.setattr(OpenClawImageClient, "_open", _make_open("portrait", base + 0.5))
+    res_portrait = c_portrait.generate_image("a face")
+
+    assert res_scene.path is not None and res_portrait.path is not None
+    assert res_scene.path != res_portrait.path, "two scopes claimed the SAME image (F11-4)"
+    assert {res_scene.path, res_portrait.path} == {str(drops["scene"]), str(drops["portrait"])}
+
+
+def test_claimed_file_is_skipped_by_later_await(tmp_path):
+    """A file already claimed by one generation is invisible to a later await for the
+    same dir — it polls past it and times out rather than re-claiming (F11-4)."""
+    media = tmp_path / "media"
+    media.mkdir(parents=True)
+    since = _time.time()
+    only = media / "lonely.png"
+    only.write_bytes(b"X")
+    _os.utime(only, (since, since))
+
+    c = OpenClawImageClient(token="t", media_dir=media, poll_timeout=0.3)
+    first = c._await_new_media(set(), since=since)
+    assert first == only  # claimed
+    # A second await for the same single file finds nothing unclaimed -> times out (None).
+    second = c._await_new_media(set(), since=since)
+    assert second is None
+
+
+def test_cross_process_claim_lockfile_blocks_reclaim(tmp_path):
+    """A `.claimed` lock file survives across processes: simulate a SECOND resolver
+    process (fresh in-memory registry) — it must NOT re-claim a file the first already
+    owns via the on-disk lock (F11-3/F11-4 cross-process claim)."""
+    media = tmp_path / "media"
+    media.mkdir(parents=True)
+    since = _time.time()
+    img = media / "shared.png"
+    img.write_bytes(b"X")
+    _os.utime(img, (since, since))
+
+    c = OpenClawImageClient(token="t", media_dir=media, poll_timeout=0.3)
+    first = c._await_new_media(set(), since=since)
+    assert first == img
+    # The on-disk lock now exists.
+    assert openclaw_image._claim_lockfile(img).exists()
+
+    # Simulate a separate process: clear ONLY the in-memory registry (the lock file
+    # persists on disk, as it would across a real process boundary).
+    openclaw_image._reset_claimed_paths()
+    second = c._await_new_media(set(), since=since)
+    assert second is None, "a second process re-claimed a file the lock file owns"
+
+
+def test_generate_post_only_does_not_claim(tmp_path, monkeypatch):
+    """wait=False (post-only) returns the task id and must NOT consume a claim — a later
+    waiting generation can still claim the file (F11-4 keeps the post-only path clean)."""
+    media = tmp_path / "media"
+    media.mkdir(parents=True)
+    monkeypatch.setattr(OpenClawImageClient, "_open", _stub_open(_started_envelope("task_nw")))
+    res = OpenClawImageClient(token="t", media_dir=media).generate_image("x", wait=False)
+    assert res.task_id == "task_nw"
+    # No claim was recorded (the registry stays empty for the post-only path).
+    assert not openclaw_image._CLAIMED_PATHS


### PR DESCRIPTION
## Cluster: Image provider-lane hardening (#810)

P2 cluster from the 2026-06-11 full-engine adversarial audit. All five sub-findings were re-verified **still broken on `main`** before fixing; **F11-1/F11-2 (already in #829) left untouched and intact** (no `qa/` or `viewer/` files modified).

`Refs #810` (F11-8 docstring-only finding is NOT in this cluster; its scope-doc rewrite partially rode along — see below).

### Fixed

| Finding | Problem | Fix |
|---|---|---|
| **F11-3** | The engine MCP server is a stdio child of each per-beat `claude -p`; the daemon worker dies with the interpreter mid-provider-call → late-beat art lost, paid image never claimed. | **Opt-in detached resolver** (`WORLDOS_IMAGE_DETACHED_RESOLVER`): `async_generate` spawns a process-group-detached subprocess (`start_new_session=True`, stdio→DEVNULL) running this module's `--resolve` entrypoint. It outlives the parent and writes ONLY the derived cache via the atomic writer. A TTL-bounded `generating` marker suppresses a re-POST. **Default OFF → today's daemon-thread behavior is byte-for-byte preserved.** |
| **F11-4** | Two concurrent generations (skill mandates scene+portrait in one beat) both see the first landed file as fresh; `max(fresh)` claims the **same path for two scopes**. | Module-level **generation lock** (serializes the POST→claim window) + **oldest-unclaimed FIFO** + a two-layer claim registry: in-process set **plus** an atomic `O_CREAT\|O_EXCL` `<image>.claimed` lock file so two separate detached resolvers can't double-claim. |
| **F11-5** | A payload-bearing cache HIT returns multi-MB `bytes_b64` verbatim → ~1-5M chars into one DM beat. | Hit path strips inline bytes to **metadata-only** (`has_bytes`/`byte_len`). On-disk cache untouched → the viewer's `/image` still serves bytes. |
| **F11-6** | The viewer serves ingested `_private` art ahead of any generated cache, so generating a scope the 2,359-dir ingest already covers is **pure spend**. | Engine-side **catalog consult** (read-only over `content/worlds/_private`, mirroring the viewer's safe-scope + normalized scope-key resolution): returns `status="ingested"` without spending unless the additive new `force=True`. |
| **F11-7** | A failed background generation vanishes silently (the worker discards `generate()`'s degrade result). | `generate()` degrade path writes a derived `<scope>/<hash>.error` sidecar (bare `.error` suffix — viewer globs `*.json` only, so it's ignored); a later success under the same key clears it. Feeds F11-1(b)'s `X-Image-Outcome` `error` class. |

### Skipped (already done)
- **F11-1 / F11-2** — landed in #829 (image_render VM-lane gate + image probe). Confirmed intact; no `qa/`/`viewer/` changes here.

### Rode along
- **F11-8** (P3, not in this cluster): the `generate_image` docstring was corrected to teach the real viewer scope convention (`portrait-<character_id>` / `<location_id>`) as part of the additive `force` param doc. The full F11-8 fix (the `warning` key when scope omitted) is **deferred** to its own change.

### Invariants
- **Engine sole-writer** untouched — only the derived, rebuildable image cache + sidecars are written, never `snapshot.json`.
- **Additive-by-default** — detached resolver + `force` default to today's behavior; old descriptors round-trip; the three sidecar suffixes (`.error`/`.generating`/`.claimed`) are non-`.json` so the viewer's globs ignore them.
- **Wire contracts** — `generate_image`'s `force` is an additive optional param; new `WORLDOS_IMAGE_*` env twins resolve via the existing `env_var` resolver (legacy `CLAWDND_*` honored).
- No shell injection: the resolver spec is JSON passed as a single list `argv` element to `subprocess.Popen` (no `shell=True`).

### Tests
- `tests/test_imagegen.py`: **+17** (F11-3/5/6/7) — incl. a **real-subprocess e2e** proving the detached resolver writes the cache *after the spawning parent exits*.
- `tests/test_openclaw_image.py`: **+5** (F11-4) — incl. a cross-process `.claimed` lock test.
- **126** image tests pass; **full engine suite 2366 pass**; `qa/fast_gate.sh` Tier-0 **PASS (191)**.

### Residual risk
- The detached path's `_generating_is_fresh` check → `_write_generating_marker` has a small TOCTOU window; a true simultaneous in-process race could double-spawn. Cost is bounded (the resolver is idempotent — same key → same cache path) and the `generating` marker closes the common case. Acceptable for P2.

**DO NOT MERGE** — for review.

Source: `docs/audits/ENGINE-AUDIT-2026-06-11.md`