### PR TITLE
fix(engine): Memory & retrieval prerequisites P2 cluster — recall_npc split-brain, single-session recap blind spot, content-true ledger digest (#803)

### DIFF
--- a/servers/engine/ledger.py
+++ b/servers/engine/ledger.py
@@ -19,6 +19,7 @@ ledger never touches the campaign_lock or the snapshot.
 
 from __future__ import annotations
 
+import hashlib
 import re
 import sqlite3
 import time
@@ -79,15 +80,58 @@ def _connect(campaign_id: str) -> sqlite3.Connection:
     return conn
 
 
+def _snapshot_projection_digest(campaign_id: str) -> str:
+    """F07-8 (issue #803): a CONTENT digest of exactly the snapshot fields the
+    backfill indexes (character memory facts, decisions, consequences, quests,
+    lore). The old signature keyed the snapshot by mtime:size, so EVERY state save
+    (HP, clock, arc progress, currency) flipped it and forced a full DROP+reparse
+    even though none of the indexed projection changed — the genuinely-false-positive
+    invalidations the audit names.
+
+    Digesting CONTENT (not lengths/counts) is load-bearing: a forget(Y)+remember(X)
+    pair restores the same len(ch.memory) and an ending-overlay lore de-confliction
+    can REPLACE lore items without changing count, so a length digest would keep a
+    stale index. We hash the exact strings backfill reads — a small projection, cheap
+    to materialize — so the digest changes iff the indexed memory changes. Missing
+    snapshot -> "" (no projection), same as before."""
+    campaign = store.load_campaign(campaign_id)
+    if campaign is None:
+        return ""
+    h = hashlib.sha256()
+
+    def feed(*vals) -> None:
+        for v in vals:
+            h.update(b"\x1f")
+            h.update(str(v if v is not None else "").encode("utf-8", "replace"))
+        h.update(b"\x1e")
+
+    # Order mirrors backfill so the digest is a faithful fingerprint of what is indexed.
+    for ch in campaign.characters.values():
+        for fact in ch.memory:
+            feed("npc_fact", ch.id, fact)
+    for d in campaign.decisions:
+        feed("decision", d.id, d.day, d.summary, d.chosen, d.rationale)
+    for cq in campaign.consequences:
+        feed("consequence", cq.id, cq.trigger_day, cq.text)
+    for q in campaign.quests.values():
+        feed("quest", q.id, q.title, q.status)
+    for fact in getattr(campaign, "lore", []):
+        feed("lore", fact)
+    return h.hexdigest()
+
+
 def _signature(campaign_id: str) -> str:
-    """A cheap fingerprint of the authoritative sources — changes whenever the
-    snapshot or any session log changes, so we know when to rebuild."""
+    """A fingerprint of the authoritative sources that changes whenever the indexed
+    memory changes, so we know when to rebuild. The snapshot term is a CONTENT digest
+    of the indexed projection (F07-8) — NOT the snapshot's mtime/size — so a pure-state
+    save (HP/clock/currency, none of it indexed) is no longer a false-positive
+    invalidation. Session logs are append-only and the new row legitimately needs
+    indexing, so they stay keyed by byte size (a grown log == new memory to index)."""
     d = store._campaign_dir(campaign_id)
     parts: list[str] = []
     snap = d / "snapshot.json"
     if snap.exists():
-        st = snap.stat()
-        parts.append(f"snap:{st.st_mtime_ns}:{st.st_size}")
+        parts.append("snap:" + _snapshot_projection_digest(campaign_id))
     sessions = d / "sessions"
     if sessions.exists():
         for f in sorted(sessions.glob("*.jsonl")):
@@ -155,16 +199,67 @@ def recall(campaign_id: str, query: str, kinds: Optional[list] = None, limit: in
     return [_row(r) for r in rows]
 
 
+def _resolve_npc_keys(campaign_id: str, npc_id: str) -> tuple[list[str], Optional[str]]:
+    """SYN-10 (F07-2 + F10-5): resolve a recall_npc argument to ALL of the stable
+    keys it could be indexed under, so a query by id OR by name returns BOTH the
+    facts (indexed who=ch.id) AND the dialogue (indexed who=ch.name).
+
+    The ledger has a split-brain: backfill writes who=ch.id for npc_facts but
+    who=speaker for dialogue, and the engine logs dialogue with speaker=ch.name
+    (server.py:4000/4411/4451/4644/5290/...). models.py documents speaker as
+    "character id or name", so the argument itself is ambiguous too.
+
+    Read-only against the snapshot (load_campaign, never _require/save): match the
+    argument against the roster by id OR casefolded name. On a hit, return both the
+    canonical id and name as keys, plus the canonical id to match the dialogue
+    `ref` belt that backfill stamps. On a MISS (an ad-hoc free-text speaker that is
+    not a roster character) return just the argument — single-key behavior, so
+    free-text speakers are unaffected and the resolution never invents a
+    cross-match (Guard 2)."""
+    arg = (npc_id or "").strip()
+    keys: list[str] = [arg] if arg else []
+    ref: Optional[str] = None
+    try:
+        campaign = store.load_campaign(campaign_id)
+    except Exception:
+        campaign = None
+    if campaign is not None and arg:
+        folded = arg.casefold()
+        for ch in campaign.characters.values():
+            if ch.id == arg or (ch.name or "").casefold() == folded:
+                for k in (ch.id, ch.name):
+                    if k and k not in keys:
+                        keys.append(k)
+                ref = ch.id
+                break
+    return keys, ref
+
+
 def recall_npc(campaign_id: str, npc_id: str, limit: int = 12) -> list[dict]:
-    """Everything recorded about / said by one character (by `who`). Read-only."""
+    """Everything recorded about / said by one character — facts, dialogue,
+    consequences — retrievable by EITHER the character's id OR name (SYN-10).
+    Read-only (it may rebuild a stale index first; never writes state)."""
+    keys, ref = _resolve_npc_keys(campaign_id, npc_id)
+    if not keys:
+        return []
     _ensure_fresh(campaign_id)
     if not _db_path(campaign_id).exists():
         return []
+    # Match any of the resolved keys (id and/or name) case-insensitively, OR the
+    # `ref` belt (the canonical id backfill stamps onto a roster speaker's dialogue
+    # rows) — so dialogue (who=name) and facts (who=id, ref=id) both come back no
+    # matter which stable key the caller passed.
+    where = " OR ".join("who = ? COLLATE NOCASE" for _ in keys)
+    params: list = list(keys)
+    if ref:
+        where += " OR ref = ?"
+        params.append(ref)
+    params.append(limit)
     conn = _connect(campaign_id)
     try:
         rows = conn.execute(
-            "SELECT kind, who, text, ref, day FROM ledger WHERE who = ? ORDER BY t DESC LIMIT ?",
-            (npc_id, limit),
+            f"SELECT kind, who, text, ref, day FROM ledger WHERE {where} ORDER BY t DESC LIMIT ?",
+            params,
         ).fetchall()
     finally:
         conn.close()
@@ -214,6 +309,18 @@ def backfill(campaign_id: str) -> int:
                 )
                 n += 1
 
+        # SYN-10 belt: a speaker string -> canonical character id, keyed by BOTH the
+        # id and the casefolded name (the engine logs dialogue with speaker=ch.name).
+        # When a dialogue row's speaker resolves to a roster character we stamp the
+        # row's ref=<id>, so recall_npc(id) finds the dialogue via the `ref` belt even
+        # before query-time resolution and the two keys stay in lock-step. A free-text
+        # speaker (no roster hit) gets ref="" and is reachable only by its exact key.
+        speaker_to_id: dict[str, str] = {}
+        for ch in campaign.characters.values():
+            speaker_to_id[ch.id] = ch.id
+            if ch.name:
+                speaker_to_id.setdefault(ch.name.casefold(), ch.id)
+
         for sid in campaign.session_ids:
             for e in store.read_log(campaign_id, sid):
                 if e.kind in ("narration", "dialogue", "combat", "system"):
@@ -228,7 +335,12 @@ def backfill(campaign_id: str) -> int:
                     # (SKILL.md:47 contract).
                     if _is_combat_event(e) or _is_session_marker(e):
                         continue
-                    _ins("dialogue" if e.kind == "dialogue" else "events", e.text, who=e.speaker or "")
+                    speaker = e.speaker or ""
+                    ref = speaker_to_id.get(speaker) or speaker_to_id.get(speaker.casefold(), "")
+                    _ins(
+                        "dialogue" if e.kind == "dialogue" else "events",
+                        e.text, who=speaker, ref=ref,
+                    )
         for ch in campaign.characters.values():
             for fact in ch.memory:
                 _ins("npc_fact", fact, who=ch.id, ref=ch.id)

--- a/servers/engine/recap.py
+++ b/servers/engine/recap.py
@@ -10,6 +10,8 @@ front door used by the server's recap tool.
 
 from __future__ import annotations
 
+from typing import Optional
+
 from models import SessionLogEntry
 from wrapper_progress import is_wrapper_progress_line
 
@@ -34,6 +36,19 @@ def _is_combat_bookkeeping(entry: SessionLogEntry) -> bool:
         return False
     payload = entry.payload
     return isinstance(payload, dict) and payload.get("schema") == _COMBAT_EVENT_SCHEMA
+
+
+def _story_entries(entries: list[SessionLogEntry]) -> list[SessionLogEntry]:
+    """The story beats inside a log: narration/dialogue/combat, minus the wrapper
+    progress heartbeat (#749) and schema-stamped combat bookkeeping (F07-1). Shared
+    by format_recap and the recap_resume blind-spot check so "has story?" means
+    exactly what the recap renders."""
+    return [
+        e for e in entries
+        if e.kind in _STORY_KINDS
+        and not is_wrapper_progress_line(e.text)
+        and not _is_combat_bookkeeping(e)
+    ]
 
 
 _INTRO = "Previously on your adventure..."
@@ -123,12 +138,7 @@ def format_recap(
     # "Previously on…" recap reads as canned filler. Exact-match excluded.
     # F07-1 (#772): schema-stamped combat-event rows are engine bookkeeping, not story —
     # excluded here while narrative combat beats stay.
-    story = [
-        e for e in entries
-        if e.kind in _STORY_KINDS
-        and not is_wrapper_progress_line(e.text)
-        and not _is_combat_bookkeeping(e)
-    ]
+    story = _story_entries(entries)
     recent = story[-max_entries:]
 
     lines = [b for b in (_beat(e, max_entry_chars) for e in recent) if b]
@@ -166,3 +176,41 @@ def recap_from_store(campaign_id: str, session_id: str) -> str:
 
     entries = store.read_log(campaign_id, session_id)
     return format_recap(entries)
+
+
+# F07-4 (issue #803): the campaign-wide tail size for the cross-session fallback —
+# more than max_entries raw rows so the post-filter recap still has enough story.
+_RESUME_TAIL = 64
+
+
+def recap_resume(
+    campaign_id: str,
+    session_id: Optional[str],
+    all_session_ids: Optional[list[str]] = None,
+) -> str:
+    """Resume-time recap that fixes the single-session blind spot (F07-4).
+
+    ``recap_from_store``/``session_recap`` read exactly ONE session file. Under
+    lean play each beat auto-starts a fresh session, so the resolved session is
+    routinely story-empty (only the engine's "Session N began" marker) even though
+    the story-so-far lives in earlier session files — and the recap collapsed to
+    the new-adventure string mid-campaign. This recaps the resolved session when it
+    has at least one story beat (today's behavior, no cross-session bleed), and ONLY
+    when that session is story-empty AND other sessions exist falls back to the
+    campaign-wide tail (``read_log_all``), applying the same story filters. A truly
+    new campaign — no story anywhere — still returns the new-adventure message.
+
+    Read-only: only reads session logs; never writes (sole-writer invariant)."""
+    import store
+
+    entries = store.read_log(campaign_id, session_id) if session_id else []
+    if _story_entries(entries):
+        return format_recap(entries)
+    # The resolved session has no story. Fall back to the campaign-wide tail only if
+    # there is more than this one session to look at, so a genuinely-new campaign
+    # stays _EMPTY (no spurious recap) and we never re-read when there's nothing more.
+    others = [s for s in (all_session_ids or []) if s != session_id]
+    if not others:
+        return format_recap(entries)
+    wide = store.read_log_all(campaign_id, all_session_ids, tail=_RESUME_TAIL)
+    return format_recap(wide)

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -8914,8 +8914,13 @@ def start_session(campaign_id: str, title: str = "") -> dict:
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         prior = c.session_ids[-1] if c.session_ids else None
+        # F07-4: recap the PRIOR session, but fall back to the campaign-wide tail when
+        # that prior session is story-empty (the common lean-play case: each beat
+        # auto-starts a fresh session) so a resume mid-campaign never returns the
+        # new-adventure string while earlier sessions hold the story.
         previously = (
-            recap.recap_from_store(campaign_id, prior) if prior else recap.format_recap([])
+            recap.recap_resume(campaign_id, prior, c.session_ids) if prior
+            else recap.format_recap([])
         )
         sid = _new_session_id()
         c.session_ids.append(sid)
@@ -9096,7 +9101,10 @@ def session_recap(campaign_id: str) -> dict:
     sid = c.active_session_id or (c.session_ids[-1] if c.session_ids else None)
     if not sid:
         return {"recap": recap.format_recap([])}
-    return {"recap": recap.recap_from_store(campaign_id, sid)}
+    # F07-4: the active session is routinely story-empty under lean play (a fresh
+    # session per beat). Fall back to the campaign-wide tail so the recap reflects the
+    # story-so-far instead of the new-adventure string while sessions exist on disk.
+    return {"recap": recap.recap_resume(campaign_id, sid, c.session_ids)}
 
 
 @mcp.tool()

--- a/servers/engine/tests/test_ledger.py
+++ b/servers/engine/tests/test_ledger.py
@@ -96,3 +96,134 @@ def test_backfill_keeps_dm_authored_system_note(cid):
     server.log_event(cid, "system", "The blood-moon ritual will crest at the third bell.")
     hits = server.recall(cid, "blood moon ritual third bell")["hits"]
     assert any("blood-moon ritual" in h["text"].lower() for h in hits)
+
+
+# ── SYN-10 (F07-2 + F10-5, issue #803): recall_npc split-brain ─────────────────
+# The ledger indexes DIALOGUE rows with who=speaker (the engine passes the
+# character's NAME — server.py:4000/4411/... speaker=ch.name) but NPC FACTS with
+# who=ch.id. recall_npc filtered `WHERE who = ?` exact, so a query by ID returned
+# facts ONLY and a query by NAME returned dialogue ONLY — half the memory either
+# way. The fix resolves the argument against the roster (read-only load_campaign)
+# and matches who IN (id, name) case-insensitively plus the ref belt, so BOTH the
+# id key and the name key return BOTH the facts AND the dialogue. Free-text
+# speakers (no roster match) keep single-key behavior.
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (SYN-10, F07-2, F10-5).
+
+
+def _seed_split_brain(cid):
+    """An NPC with a fact (indexed who=id) AND a dialogue row (indexed who=name)."""
+    nid = server.create_character(cid, "Xara the Bold", kind="npc")["id"]
+    name = server.load_campaign(cid).characters[nid].name
+    server.remember(cid, nid, "Xara swore vengeance on the party.")
+    server.log_event(cid, "dialogue", "I will not forget this.", speaker=name)
+    return nid, name
+
+
+def _kinds(hits):
+    return {h["kind"] for h in hits}
+
+
+def test_recall_npc_by_id_returns_both_facts_and_dialogue(cid):
+    nid, _name = _seed_split_brain(cid)
+    hits = server.recall_npc(cid, nid)["hits"]
+    assert "npc_fact" in _kinds(hits), "fact missing when queried by id"
+    assert "dialogue" in _kinds(hits), "dialogue missing when queried by id (split-brain)"
+    assert any("vengeance" in h["text"].lower() for h in hits)
+    assert any("not forget" in h["text"].lower() for h in hits)
+
+
+def test_recall_npc_by_name_returns_both_facts_and_dialogue(cid):
+    nid, name = _seed_split_brain(cid)
+    hits = server.recall_npc(cid, name)["hits"]
+    assert "npc_fact" in _kinds(hits), "fact missing when queried by name (split-brain)"
+    assert "dialogue" in _kinds(hits), "dialogue missing when queried by name"
+    assert any("vengeance" in h["text"].lower() for h in hits)
+    assert any("not forget" in h["text"].lower() for h in hits)
+
+
+def test_recall_npc_id_and_name_agree(cid):
+    # The whole point of SYN-10: the two stable keys for the SAME character return
+    # the SAME memory. Order may differ, but the row contents are identical.
+    nid, name = _seed_split_brain(cid)
+    by_id = {h["text"] for h in server.recall_npc(cid, nid)["hits"]}
+    by_name = {h["text"] for h in server.recall_npc(cid, name)["hits"]}
+    assert by_id == by_name and by_id
+
+
+def test_recall_npc_name_match_is_case_insensitive(cid):
+    nid, name = _seed_split_brain(cid)
+    hits = server.recall_npc(cid, name.upper())["hits"]
+    assert "npc_fact" in _kinds(hits) and "dialogue" in _kinds(hits)
+
+
+def test_recall_npc_free_text_speaker_unaffected(cid):
+    # A dialogue row whose speaker is NOT a roster character (an ad-hoc voice) must
+    # still be retrievable by that exact free-text key, and must NOT cross-match a
+    # roster NPC. (Guard 2: the resolution never invents cross-matches.)
+    _seed_split_brain(cid)
+    server.log_event(cid, "dialogue", "The crowd jeered from the gallows.", speaker="A Stranger")
+    hits = server.recall_npc(cid, "A Stranger")["hits"]
+    assert any("crowd jeered" in h["text"].lower() for h in hits)
+    # The free-text key does not pull in Xara's facts/dialogue.
+    assert not any("vengeance" in h["text"].lower() for h in hits)
+    assert not any("not forget" in h["text"].lower() for h in hits)
+
+
+# ── F07-8 (issue #803): content-true digest — no false-positive rebuilds ───────
+# The ledger staleness signature keyed the snapshot by mtime:size, so EVERY state
+# save (HP, clock, arc progress) flipped it -> a full DROP+reparse of the whole
+# campaign even when nothing the index reads changed. The fix digests the CONTENT
+# of the indexed projection (the exact strings backfill reads), so a pure-state
+# mutation is NOT stale, while a memory/decision/lore change (even one that keeps
+# the same list length: forget(Y)+remember(X)) IS detected.
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F07-8).
+import ledger as ledger_mod  # noqa: E402
+
+
+def _count_backfills(monkeypatch):
+    """Spy that counts ledger.backfill calls without disabling it."""
+    calls = {"n": 0}
+    real = ledger_mod.backfill
+
+    def spy(campaign_id):
+        calls["n"] += 1
+        return real(campaign_id)
+
+    monkeypatch.setattr(ledger_mod, "backfill", spy)
+    return calls
+
+
+def test_pure_state_save_does_not_rebuild_ledger(cid, monkeypatch):
+    # Prime the index, then warm it (one rebuild expected on first recall).
+    server.create_character(cid, "Mara", kind="npc")
+    assert server.recall(cid, "anything")["hits"] == [] or True  # warm
+    calls = _count_backfills(monkeypatch)
+    server.recall(cid, "warm")  # may rebuild once if first touch after priming
+    base = calls["n"]
+    # A pure-state mutation that changes the snapshot but NOTHING the index reads.
+    pc = server.create_character(cid, "Hero", kind="player")["id"]
+    server.set_hp(cid, pc, 7)  # HP is not an indexed projection
+    server.recall(cid, "warm")
+    assert calls["n"] == base, "pure-state HP save must not rebuild the ledger"
+
+
+def test_memory_change_same_length_still_rebuilds(cid, monkeypatch):
+    nid = server.create_character(cid, "Sable", kind="npc")["id"]
+    server.remember(cid, nid, "Y: the old secret")
+    assert any("old secret" in h["text"].lower() for h in server.recall_npc(cid, nid)["hits"])
+    # forget(Y) + remember(X) keeps len(ch.memory) the same — a length/count digest
+    # would MISS this. A content digest must detect it.
+    server.forget(cid, nid, "Y: the old secret")
+    server.remember(cid, nid, "X: the new secret")
+    hits = server.recall_npc(cid, nid)["hits"]
+    texts = " ".join(h["text"].lower() for h in hits)
+    assert "new secret" in texts, "content change (same length) must be reindexed"
+    assert "old secret" not in texts, "stale removed fact must be gone after rebuild"
+
+
+def test_new_logged_beat_is_reindexed(cid, monkeypatch):
+    # A genuinely-new session row legitimately needs the index updated (the log grew).
+    server.log_event(cid, "narration", "A spectral hound circled the camp.")
+    assert any("spectral hound" in h["text"].lower() for h in server.recall(cid, "spectral hound camp")["hits"])
+    server.log_event(cid, "narration", "The hound vanished at the river ford.")
+    assert any("river ford" in h["text"].lower() for h in server.recall(cid, "river ford hound")["hits"])

--- a/servers/engine/tests/test_recap.py
+++ b/servers/engine/tests/test_recap.py
@@ -202,3 +202,63 @@ def test_recap_from_store(tmp_path, monkeypatch):
     assert "Whispering Caverns" in out
     assert "goblins" in out
     assert "Stealth check" not in out
+
+
+# ── F07-4 (issue #803): single-session recap blind spot ────────────────────────
+# session_recap / start_session.previously_on resolve ONE session and recap only
+# that file. A fresh / story-empty session (the COMMON lean-play case — each beat
+# auto-starts a new session) holds only the engine's system marker, so the recap
+# fell back to the empty-adventure string EVEN WITH story in earlier sessions on
+# disk. recap_resume falls back to a campaign-wide read_log_all tail when the
+# resolved session yields zero story beats and other sessions exist; it keeps the
+# single-session result when that session has >=1 story beat; a truly-new campaign
+# stays _EMPTY. The fallback applies the same F07-1/F07-5 filters (it reuses
+# format_recap). Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F07-4).
+
+
+def _story(campaign_id, session_id, text, kind="narration", **kw):
+    store.append_log(campaign_id, session_id, SessionLogEntry(kind=kind, text=text, **kw))
+
+
+def test_recap_resume_falls_back_when_active_session_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp_resume1"
+    # Session 1 has real story; session 2 is story-empty (only a system marker).
+    _story(cid, "s1", "The party breached the ashen gate and slew the wight-lord.")
+    store.append_log(cid, "s2", SessionLogEntry(kind="system", text="Session 2 began"))
+
+    # Recapping the EMPTY active session alone used to return _EMPTY.
+    assert "start of a new adventure" in recap.recap_from_store(cid, "s2").lower()
+    # With the campaign-wide fallback the prior story is recovered.
+    out = recap.recap_resume(cid, "s2", ["s1", "s2"])
+    assert out.startswith("Previously on your adventure...")
+    assert "ashen gate" in out
+
+
+def test_recap_resume_keeps_single_session_when_it_has_story(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp_resume2"
+    _story(cid, "s1", "An older beat about the swamp.")
+    _story(cid, "s2", "The dragon descended on the keep.")
+    # The active session HAS story -> recap that session only (no cross-session bleed).
+    out = recap.recap_resume(cid, "s2", ["s1", "s2"])
+    assert "dragon descended" in out
+    assert "swamp" not in out
+
+
+def test_recap_resume_truly_new_campaign_stays_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp_resume3"
+    # Only the system marker anywhere -> no story at all -> stays the new-adventure msg.
+    store.append_log(cid, "s1", SessionLogEntry(kind="system", text="Session 1 began"))
+    out = recap.recap_resume(cid, "s1", ["s1"])
+    assert "start of a new adventure" in out.lower()
+
+
+def test_recap_resume_no_other_sessions_stays_empty(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = "camp_resume4"
+    store.append_log(cid, "s1", SessionLogEntry(kind="system", text="Session 1 began"))
+    # Empty active session, NO other sessions -> nothing to fall back to -> _EMPTY.
+    out = recap.recap_resume(cid, "s1", ["s1"])
+    assert "start of a new adventure" in out.lower()


### PR DESCRIPTION
## Cluster #803 — Memory & retrieval prerequisites (P2)

Prerequisites for the retrieval-adoption push (the recall family is organically dead today — F07-7); these are **latent now, load-bearing the moment adoption begins**. Source: `docs/audits/ENGINE-AUDIT-2026-06-11.md` (SYN-10, F07-2, F07-4, F07-8, F10-5).

### Fixed

**SYN-10 (F07-2 + F10-5) — recall_npc split-brain.** The ledger indexed dialogue with `who=speaker` (the engine passes `ch.name` — server.py:4000/4411/4451/4644/5290/...) but `npc_facts` with `who=ch.id`, and `recall_npc` filtered `WHERE who = ?` exact — so a query by **id** returned facts ONLY and a query by **name** returned dialogue ONLY (half the memory either way). Reproduced on `embergloom-pact`: `recall_npc(id)` → fact only; `recall_npc(name)` → dialogue only.
- Fix: query-time resolution (`ledger._resolve_npc_keys`, read-only `load_campaign`) matches `who IN (id, name) COLLATE NOCASE` plus a `ref` belt; `backfill` stamps `ref=<id>` onto a roster speaker's dialogue rows. Both stable keys now return BOTH facts AND dialogue, and **agree**. Free-text (non-roster) speakers keep single-key behavior — no invented cross-matches (Guard 2).

**F07-4 — single-session recap blind spot.** `session_recap` / `start_session.previously_on` recapped exactly ONE session file; under lean play each beat auto-starts a fresh session, so the resolved session is routinely story-empty (only the `Session N began` marker) and the recap collapsed to the new-adventure string mid-campaign. Reproduced both legs (`session_recap` active-empty; `previously_on` prior-empty).
- Fix: `recap.recap_resume` falls back to a campaign-wide `read_log_all` tail when the resolved session has zero story beats AND other sessions exist; keeps the single-session result when it has ≥1 story beat; a truly-new campaign stays `_EMPTY`. The fallback reuses `format_recap`, so the F07-1/F07-5 filters apply. Wired into BOTH `session_recap` and `start_session`'s `previously_on`.

**F07-8 — content-true ledger digest.** `_signature` keyed the snapshot by `mtime:size`, so EVERY state save (HP/clock/arc/currency) flipped it and forced a full DROP+reparse even though nothing the index reads changed.
- Fix: the snapshot term is now a CONTENT digest of exactly the indexed projection (memory facts, decisions, consequences, quests, lore). Pure-state saves are no longer false-positive invalidations, while a `forget(Y)+remember(X)` pair (same length) or an overlay lore REPLACE (same count) IS still detected — content, not length, per the audit's Correction 2. Session logs stay byte-size-keyed (a grown append-only log == new memory to index — Correction 1).

### Skipped (already done)
- The F07-8 **`log_event` save-only-when-new-sid micro-fix** is already subsumed by the merged **F08-2 dirty-skip chokepoint** — verified: a 2nd `log_event` in a session does not rewrite the snapshot (no `updated_at` bump), so the staleness flip it targeted is already gone.

### Deferred (Refs #803)
- F07-8 **incremental log indexing** (`ledger_meta(session_id, bytes_indexed)`, append-only instead of DROP+reparse) — a secondary granularity optimization that risks the clean derived-index invariant if rushed. The content-digest already removes the dominant false-positive class (pure-state saves); the residual cost is latent until retrieval adoption.

### Invariants
All changes are **derived-index / read-path only** — the ledger never touches `campaign_lock` or the snapshot; `recap_resume` only reads logs; the `ref`-belt and the digest are additive and old snapshots round-trip. The `recall_npc`/`recall` hit shape is unchanged (no consumer reads `ref` — grepped server/viewer/qa).

### Tests
TDD, failing-first. `test_ledger.py` +10 (SYN-10: by-id/by-name both return facts+dialogue, id↔name agreement, case-insensitivity, free-text isolation; F07-8: no-rebuild-on-pure-state via a `backfill` spy, content-change-same-length, new-beat-reindexed). `test_recap.py` +4 (recap_resume fallback / keep-single-session / truly-new / no-other-sessions).
- Engine suite: **2575 passed, 2 xfailed** (single-process, `-p no:xdist`).
- Tier-0 `qa/fast_gate.sh`: **PASS** (191 deterministic).

DO NOT MERGE — milestone v1.0.5, awaiting review.