### PR TITLE
fix(engine): API ergonomics & error surfaces P2 cluster (#812)

### DIFF
--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -552,6 +552,24 @@ def main() -> int:
                 f"{len(benign)} engine guard rejection(s) (recoverable, DM expected to retry): "
                 f"{[n for n, _ in benign]}", fatal=False)
 
+    # F14-13 (#812): SOFT errors. A few tools return a DICT-shaped {"error": ...} with
+    # is_error=False (load_canon_character miss, start_character pickup miss, the bestiary
+    # miss, the dead-PC path) — invisible to the is_error-only A8 gate above. CONVENTION
+    # (documented here, the consumer the convention was blocked on): a tool that cannot do
+    # what was asked returns a top-level string ``error`` key; the gate COUNTS those soft
+    # errors so a masked-soft-failure run can't read as silently clean. REPORT-ONLY (WARN,
+    # never RED) — these are recoverable, the DM is told and re-asks; the gate/discount policy
+    # stays the maintainers' call (mirrors dm_beat_honesty). Additive: a clean run is at zero.
+    soft_errors = [
+        (n, r["error"]) for (n, inp, r, err, text) in evs
+        if not err and isinstance(r, dict) and isinstance(r.get("error"), str)
+    ]
+    if soft_errors:
+        chk("tool_soft_errors", False,
+            f"{len(soft_errors)} soft-error return(s) (dict {{'error':…}}, is_error=False — "
+            f"invisible to A8): {[n for n, _ in soft_errors]}; "
+            f"first: {soft_errors[0][1][:140]}. Reported only; recoverable.", fatal=False)
+
     # A3 (FATAL; WARN under CLAWDND_GATE_COMBAT_SPRINT) — end_combat called but a hostile is
     # still alive (kind=monster, current_hp>0, dead=false) with NO flee/surrender/retreat event
     # logged. The clearest pure-state defect: it corrupts the save for the next session load and

--- a/qa/test_assert_behavioral.py
+++ b/qa/test_assert_behavioral.py
@@ -147,6 +147,36 @@ def test_a8_benign_engine_guard_is_not_red_only_warn(tmp_path):
     assert "engine_guards_hit" in out  # surfaced as a WARN
 
 
+# ── F14-13 (#812): SOFT errors (dict {"error": ...}, is_error=False) are visible ──
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F14-13). Some tools return a
+# dict-shaped {"error": ...} with is_error=False — invisible to the is_error-only A8
+# gate. A report-only `tool_soft_errors` counter SURFACES them (WARN, never RED) so a
+# masked soft-failure run can't read as silently clean.
+
+def test_f14_13_soft_error_dict_is_counted_as_warn(tmp_path):
+    events = [
+        _assistant_tool_use("s1", "mcp__engine__load_canon_character", {"who": "nobody"}),
+        _user_tool_result("s1", json.dumps(
+            {"error": "no canon character 'nobody' for world 'baldurs-gate'",
+             "did_you_mean": ["Minsc"]})),  # is_error=False (soft error)
+    ]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out  # report-only: never flips the gate RED
+    assert "tool_soft_errors" in out  # the soft error is now VISIBLE to the gate
+
+
+def test_f14_13_clean_run_reports_zero_soft_errors_silently(tmp_path):
+    # A run with NO soft errors must not WARN (the counter is at zero → PASS, no noise).
+    events = [
+        _assistant_tool_use("ok1", "mcp__engine__look_around", {}),
+        _user_tool_result("ok1", json.dumps({"location": {"id": "a", "name": "Hall"}})),
+    ]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    # the counter line is PASS (no soft errors), not a WARN
+    assert "[WARN] tool_soft_errors" not in out
+
+
 # ── A3: end_combat with a living, un-fled hostile (FATAL) ──────────────────────
 
 def test_a3_end_combat_with_living_hostile_is_red(tmp_path):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -48,6 +48,7 @@ import wander
 import worldsim
 import wrapper_progress as _wrapper_progress_mod
 import _env
+from pydantic import ValidationError
 from models import (
     SKILL_ABILITIES,
     Ability,
@@ -3036,6 +3037,24 @@ def load_canon_character(campaign_id: str, name: str = "", kind: str = "npc", ad
         }
 
 
+def _readable_validation_error(exc, *, where: str) -> str:
+    """A bounded, DM-readable one-liner from a pydantic ValidationError (F14-11 / #812).
+
+    The raw `str(ValidationError)` is a multi-KB wall ending in an ``errors.pydantic.dev``
+    URL — a DM who reads that gives up on the tool and freehands. We surface only the first
+    few field errors as ``field: message`` pairs, ≤~400 chars, no URL. ADDITIVE: callers
+    still get a ``ValueError`` so the strict typo-forbid guard (a bad patch still RAISES)
+    is preserved — only the wording shrinks."""
+    parts: list[str] = []
+    for err in exc.errors()[:3]:
+        loc = ".".join(str(p) for p in err.get("loc", ())) or "(root)"
+        parts.append(f"{loc}: {err.get('msg', 'invalid')}")
+    n = len(exc.errors())
+    more = f" (+{n - 3} more)" if n > 3 else ""
+    body = "; ".join(parts) + more
+    return f"{where}: {body[:400]}"
+
+
 @mcp.tool()
 def update_character(campaign_id: str, character_id: str = "", patch: dict = None,
                      target_id: str = "", id: str = "") -> dict:
@@ -3106,7 +3125,22 @@ def update_character(campaign_id: str, character_id: str = "", patch: dict = Non
             data["skill_proficiencies"] = flat_skills
         if flat_expertise is not None:
             data["skill_expertise"] = flat_expertise
-        new_ch = Character.model_validate(data)
+        # F14-11 (#812): `in_party` is a COMPUTED read field (ch.id in c.party), NOT a Character
+        # field — a DM who patched it tripped extra="forbid" with a raw multi-KB pydantic wall.
+        # Pop it BEFORE model_validate and translate to a c.party mutation that mirrors
+        # recruit_companion / dismiss (the sole-writer membership edit). Truthy -> join; falsey ->
+        # leave. Omitted -> membership untouched (byte-identical to today). The mutation is applied
+        # AFTER the validated sheet is stored below, so a rejected patch never strands membership.
+        in_party_intent = data.pop("in_party", None)
+        # F14-11: a genuine type/typo error inside the model is wrapped into ONE bounded, readable
+        # line (no errors.pydantic.dev wall) so the DM can fix it in the next call instead of
+        # freehanding. STILL raises a ValueError, so the strict typo-forbid guard stays load-bearing.
+        try:
+            new_ch = Character.model_validate(data)
+        except ValidationError as exc:
+            raise ValueError(
+                _readable_validation_error(exc, where="update_character patch is invalid")
+            ) from exc
         # Recompute derived class math when the class/level SIGNATURE changed — via EITHER the flat
         # aliases OR a direct `classes` patch. (RRI 2026-06-09: a canon L12 Fighter "Gravedigger
         # Karcen" was patched to L3 via the canonical {"classes":[{"name":"Fighter","level":3}]}
@@ -3158,8 +3192,22 @@ def update_character(campaign_id: str, character_id: str = "", patch: dict = Non
             new_ch.max_hp = max(1, new_ch.max_hp + hp_delta)
             new_ch.current_hp = max(1, min(new_ch.current_hp, new_ch.max_hp))
         c.characters[character_id] = new_ch
+        # F14-11 (#812): apply the translated party-membership intent AFTER the validated sheet is
+        # stored (a rejected patch never reaches here). Mirrors recruit_companion / dismiss: a
+        # truthy in_party joins, a falsey one leaves. Idempotent + order-preserving.
+        if in_party_intent is not None:
+            if in_party_intent:
+                if character_id not in c.party:
+                    c.party.append(character_id)
+            else:
+                c.party = [pid for pid in c.party if pid != character_id]
         save_campaign(c)
-        return c.characters[character_id].model_dump(mode="json")
+        out = c.characters[character_id].model_dump(mode="json")
+        # Surface the computed membership so a DM who set in_party sees it took (mirrors the
+        # `in_party` key recruit_companion / load_canon_character already return). Always present
+        # for a stable shape; additive (a field that was never on the model_dump).
+        out["in_party"] = character_id in c.party
+        return out
 
 
 @mcp.tool()
@@ -6391,6 +6439,31 @@ def _expire_clock_effects_all(c: Campaign, *, long_rest: bool = False) -> list[d
     return report
 
 
+def _castable_affordance(ch) -> str:
+    """A terse "what this caster CAN cast right now" clause for a cast_spell refusal
+    (F14-7 / #812): the prepared spells (or the known list when there's no prepared
+    list) plus the available-vs-max slot table. A refusal that just says "doesn't know X"
+    wastes a DM beat (the DM freehands a hallucinated spell); naming the castable set lets
+    the very next call recover. Bounded (≤8 names) so the message stays scannable; pure —
+    reads the sheet, never mutates."""
+    spells_list = ch.spells_prepared or ch.spells_known
+    label = "prepared" if ch.spells_prepared else "known"
+    parts: list[str] = []
+    if spells_list:
+        shown = ", ".join(spells_list[:8])
+        more = "" if len(spells_list) <= 8 else f" (+{len(spells_list) - 8} more)"
+        parts.append(f"{label}: {shown}{more}")
+    # available/max per slot level, low→high; only levels the caster actually has
+    slots = [
+        f"L{lvl} {s.maximum - s.used}/{s.maximum}"
+        for lvl, s in sorted(ch.spell_slots.items())
+        if s.maximum > 0
+    ]
+    if slots:
+        parts.append("slots " + ", ".join(slots))
+    return ("; ".join(parts)) if parts else ""
+
+
 @mcp.tool()
 def cast_spell(
     campaign_id: str,
@@ -6449,7 +6522,12 @@ def cast_spell(
         curated = None
     srd = spells.srd_spell(spell_name)
     if curated is None and srd is None:
-        raise ValueError(f"unknown spell {spell_name!r}")
+        # F14-7 (#812): a bare "unknown spell 'X'" on a typo wastes a DM beat. Surface a
+        # did-you-mean of the nearest SRD spell name(s) so the next call recovers. ADDITIVE:
+        # the "unknown spell {name!r}" key/prefix is preserved (consumers match on it).
+        near = difflib.get_close_matches(spell_name, spells.all_spell_names(), n=3, cutoff=0.6)
+        hint = f" — did you mean {', '.join(repr(n) for n in near)}?" if near else ""
+        raise ValueError(f"unknown spell {spell_name!r}{hint}")
     canonical = (curated or srd).get("name", spell_name)
     spell_level = int((curated.get("level", 0) if curated else srd.get("level", 0)) or 0)
     concentrates = bool(curated.get("concentration") if curated else srd.get("concentration"))
@@ -6543,11 +6621,16 @@ def cast_spell(
         known_cf = {s.strip().lower() for s in ch.spells_known}
         prepared_cf = {s.strip().lower() for s in ch.spells_prepared}
         cf = canonical.strip().lower()
+        # F14-7 (#812): a known/prepared/cantrip refusal must NAME what the caster CAN cast so
+        # the DM's next call recovers instead of freehanding a hallucinated spell. The leading
+        # clause (the error KEY consumers match on) is unchanged; the affordance is appended.
         if spell_level == 0:
             # Cantrips are never "prepared" in 5e — a known cantrip is always castable. Gate
             # only against the union (lenient when both lists are empty, today's behavior).
             if (known_cf or prepared_cf) and cf not in (known_cf | prepared_cf):
-                raise ValueError(f"{ch.name} doesn't know {canonical!r}")
+                cantrips = [s for s in (ch.spells_known + ch.spells_prepared)]
+                known_str = ", ".join(dict.fromkeys(cantrips)) or "(none)"
+                raise ValueError(f"{ch.name} doesn't know {canonical!r} — knows: {known_str}")
         elif prepared_cf:
             # F03-8: a prepared caster (non-empty prepared list) casts a LEVELED spell only if
             # it is PREPARED — knowing it is not enough. This gives preparation real mechanical
@@ -6555,13 +6638,17 @@ def cast_spell(
             if cf not in prepared_cf:
                 raise ValueError(
                     f"{ch.name} knows {canonical!r} but hasn't prepared it — "
-                    f"prepare_spells it first, or cast a prepared spell"
+                    f"prepare_spells it first, or cast a prepared spell. "
+                    f"Castable now: {_castable_affordance(ch)}"
                 )
         elif known_cf:
             # Legacy / known-caster path: no prepared list (sorcerer, or an old snapshot that
             # only set spells_known) keeps the lenient known-only gate — byte-identical behavior.
             if cf not in known_cf:
-                raise ValueError(f"{ch.name} doesn't know or have {canonical!r} prepared")
+                raise ValueError(
+                    f"{ch.name} doesn't know or have {canonical!r} prepared. "
+                    f"Castable now: {_castable_affordance(ch)}"
+                )
         slot_used = None
         # INNATE CASTING (F03-11): a monster/NPC casts a leveled spell from an innate/at-will
         # trait (a Mage Hand Press archmage, a drow's Darkness) — there is no Vancian slot to
@@ -6592,7 +6679,17 @@ def cast_spell(
                         f"carries no Vancian slots. For an innate/at-will trait cast, pass "
                         f"innate=True (no slot spent); otherwise seed spell_slots first."
                     )
-                raise ValueError(f"no level-{lvl} spell slot available")
+                # F14-7 (#812): a PC out of this slot level must SEE the slot table (what they CAN
+                # still cast / upcast with) — a bare "no slot" sends the DM freehanding. The
+                # "no level-{lvl} spell slot available" key/prefix is preserved (additive tail).
+                slot_table = ", ".join(
+                    f"L{l} {s.maximum - s.used}/{s.maximum}"
+                    for l, s in sorted(ch.spell_slots.items()) if s.maximum > 0
+                ) or "(no slots remaining)"
+                raise ValueError(
+                    f"no level-{lvl} spell slot available — slots: {slot_table}. "
+                    f"Cast a cantrip, upcast into a higher slot, or rest."
+                )
             slot.used += 1
             slot_used = lvl
         if concentrates:

--- a/servers/engine/spells.py
+++ b/servers/engine/spells.py
@@ -67,6 +67,26 @@ def canonical_name(name: str) -> Optional[str]:
     return rec.get("name") or name.strip()
 
 
+@functools.lru_cache(maxsize=1)
+def all_spell_names() -> list[str]:
+    """Every castable spell's canonical-cased name (curated + the full srd524 dump),
+    de-duped, for did-you-mean fuzzy matching on an unknown-spell refusal (F14-7 / #812).
+
+    Prefers the curated record's casing where both sources carry a spell (curated is the
+    hand-authored, full-automation set). Pure + cached — same provenance as srd_spell /
+    canonical_name, so a suggestion always names a spell cast_spell can actually resolve."""
+    names: dict[str, str] = {}
+    for rec in _srd524().values():
+        n = rec.get("name")
+        if n:
+            names[n.lower()] = n
+    for rec in _all().values():  # curated casing wins
+        n = rec.get("name")
+        if n:
+            names[n.lower()] = n
+    return sorted(names.values())
+
+
 def _parse_dice(expr: str) -> tuple[int, int]:
     """Parse the dice part of 'NdM(+K)' -> (N, M), ignoring any flat modifier."""
     body = expr.lower().split("+")[0].split("-")[0]

--- a/servers/engine/store.py
+++ b/servers/engine/store.py
@@ -29,6 +29,19 @@ from models import Campaign, SessionLogEntry
 
 log = logging.getLogger(__name__)
 
+
+class SnapshotSchemaError(RuntimeError):
+    """A snapshot is incompatible with the running engine's schema even after the tolerant
+    top-level-key strip (F14-2 / #812) — typically a SUB-model skew (an old engine reading a
+    newer save whose nested model gained a field, or vice-versa).
+
+    Subclasses RuntimeError so every existing ``except RuntimeError`` consumer (load_campaign,
+    the enumerators, start_session's drift surfacing) keeps working unchanged. The message is
+    BOUNDED (≤500 chars) and ACTIONABLE — it names the skew direction, both engine SHAs, the
+    campaign id, the first few offending field locations, and concrete recovery moves — instead
+    of dumping the raw multi-KB pydantic wall (with its ``errors.pydantic.dev`` URL) that a DM
+    reads and gives up on. The full pydantic detail survives on ``__cause__`` for logs."""
+
 # Resolved-once cache for the engine's short git SHA. `None` = not yet resolved; a string
 # (possibly "") = resolved. We stamp this onto every saved snapshot so a campaign records the
 # engine version that last wrote it. Sentinel-based so a genuine "" (git unavailable) is cached
@@ -169,6 +182,42 @@ def last_dropped_keys(campaign_id: str) -> list[str]:
     return list(_LAST_DROPPED_KEYS.get(campaign_id, []))
 
 
+def _bounded_schema_error_message(exc: ValidationError, data: dict) -> str:
+    """Build the BOUNDED, ACTIONABLE SnapshotSchemaError message from a pydantic
+    ValidationError + the raw snapshot dict (F14-2 / #812).
+
+    Carries: the "incompatible with the current schema" phrase (the historical key consumers
+    and tests match on), the skew DIRECTION + both engine SHAs (snapshot-stamped vs running),
+    the first ≤3 offending field LOCATIONS (NOT the verbose per-error messages — those carry the
+    errors.pydantic.dev URL), and two concrete RECOVERY moves. The whole thing is clamped to
+    ≤500 chars; the full pydantic detail stays recoverable via the exception's ``__cause__``."""
+    snap_sha = str(data.get("engine_sha") or "") or "unknown"
+    run_sha = engine_sha() or "unknown"
+    # Skew direction: an UNKNOWN sub-model field means the snapshot was written by a NEWER engine
+    # (the field didn't exist when this engine's schema was authored); a MISSING-required error
+    # leans the other way. Default to "newer" (the dominant extra="forbid" case).
+    errs = exc.errors()
+    types = {e.get("type") for e in errs}
+    direction = (
+        "the snapshot is NEWER than this engine (it carries field(s) this engine doesn't know)"
+        if "extra_forbidden" in types
+        else "the snapshot may be OLDER than this engine (a required field is absent/changed)"
+    )
+    locs = []
+    for e in errs[:3]:
+        loc = ".".join(str(p) for p in e.get("loc", ())) or "(root)"
+        locs.append(loc)
+    loc_str = ", ".join(locs) or "(unknown)"
+    msg = (
+        f"snapshot is incompatible with the current schema after stripping unknown top-level "
+        f"keys — {direction}. snapshot engine_sha={snap_sha}, running engine_sha={run_sha}. "
+        f"First skew field(s): {loc_str}. "
+        f"Recover: run this engine sha (or migrate the save), or restore the pre-skew bytes from "
+        f"the {_PRE_TOLERANT_BACKUP} sidecar."
+    )
+    return msg[:500]
+
+
 def _validate_tolerant(raw: str) -> tuple[Campaign, list[str]]:
     """Side-effect-free tolerant parse: drop unknown top-level keys, validate, and report which
     keys were dropped (F08-3/F08-4 shared core).
@@ -176,8 +225,10 @@ def _validate_tolerant(raw: str) -> tuple[Campaign, list[str]]:
     PURE — no disk writes, no module-state mutation — so the enumerators (F08-4) can reuse it
     without turning a listing into a writer (the "pure reads don't write" invariant). Only the
     callable load path (:func:`_tolerant_load`) layers on the write-once backup + dropped-key
-    recording. Raises RuntimeError if the snapshot is incompatible even after stripping unknown
-    top-level keys (genuine corruption — not a schema-skew we can recover)."""
+    recording. Raises SnapshotSchemaError (a RuntimeError subclass) if the snapshot is
+    incompatible even after stripping unknown top-level keys — a SUB-model skew or genuine
+    corruption. The error is BOUNDED + ACTIONABLE (F14-2); the raw pydantic wall is NOT embedded
+    (it survives on the exception's ``__cause__`` for logs)."""
     import json
     data: dict = json.loads(raw)
     known = set(Campaign.model_fields)
@@ -187,10 +238,7 @@ def _validate_tolerant(raw: str) -> tuple[Campaign, list[str]]:
     try:
         return Campaign.model_validate(data), dropped
     except ValidationError as exc:
-        raise RuntimeError(
-            f"snapshot is incompatible with the current schema and cannot be loaded even "
-            f"after stripping unknown top-level keys.  Validation error: {exc}"
-        ) from exc
+        raise SnapshotSchemaError(_bounded_schema_error_message(exc, data)) from exc
 
 
 def _tolerant_load(campaign_id: str, raw: str) -> Campaign:
@@ -203,8 +251,15 @@ def _tolerant_load(campaign_id: str, raw: str) -> Campaign:
     schema."""
     try:
         c, dropped = _validate_tolerant(raw)
+    except SnapshotSchemaError as exc:
+        # F14-2 (#812): name the campaign id but keep the SnapshotSchemaError type AND the ≤500
+        # budget — prepend the id, then re-clamp so the whole surface stays bounded + actionable.
+        raise SnapshotSchemaError(
+            f"load_campaign({campaign_id!r}): {exc}"[:500]
+        ) from exc.__cause__
     except RuntimeError as exc:
-        # Preserve the historical load_campaign error wording (callers/tests match on it).
+        # Any non-schema RuntimeError (e.g. a malformed JSON path that surfaced as RuntimeError):
+        # preserve the historical load_campaign error wording (callers/tests match on it).
         raise RuntimeError(f"load_campaign({campaign_id!r}): {exc}") from exc
     _LAST_DROPPED_KEYS[campaign_id] = list(dropped)
     if dropped:

--- a/servers/engine/tests/test_qa_fixes.py
+++ b/servers/engine/tests/test_qa_fixes.py
@@ -168,6 +168,65 @@ def test_update_character_skills_alias_maps_to_proficiencies(tmp_path, monkeypat
         server.update_character(cid, pc, {"skilz": ["Stealth"]})
 
 
+# --- F14-11 (#812): update_character in_party translation + readable errors --------
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F14-11). `in_party` is a COMPUTED
+# read field (c.id in c.party), not a Character field — a DM patching it tripped
+# extra="forbid" with a raw multi-KB pydantic wall. Translate it to a c.party mutation
+# (mirror recruit/dismiss), and wrap a genuine validation error into ONE readable line.
+
+def _in_party(cid, needle):
+    return any(m.get("id") == needle or m.get("name") == needle
+               for m in server.get_state(cid)["party"])
+
+
+def test_update_character_in_party_true_adds_to_party(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.start_world("baldurs-gate")["campaign_id"]
+    npc = server.create_character(cid, "Tagalong", kind="companion", max_hp=10,
+                                  add_to_party=False)["id"]
+    assert not _in_party(cid, npc)
+    out = server.update_character(cid, npc, {"in_party": True})
+    assert out["in_party"] is True
+    # membership really mutated c.party (not just the returned dict)
+    assert _in_party(cid, npc)
+
+
+def test_update_character_in_party_false_removes_from_party(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.start_world("baldurs-gate")["campaign_id"]
+    comp = server.create_character(cid, "Ally", kind="companion", max_hp=10,
+                                   add_to_party=True)["id"]
+    assert _in_party(cid, comp)
+    out = server.update_character(cid, comp, {"in_party": False})
+    assert out["in_party"] is False
+    assert not _in_party(cid, comp)
+
+
+def test_update_character_in_party_composes_with_other_fields(tmp_path, monkeypatch):
+    """`in_party` is popped before model_validate, so it coexists with normal field edits."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.start_world("baldurs-gate")["campaign_id"]
+    npc = server.create_character(cid, "Joiner", kind="companion", max_hp=10,
+                                  add_to_party=False)["id"]
+    out = server.update_character(cid, npc, {"in_party": True, "armor_class": 15})
+    assert out["in_party"] is True and out["armor_class"] == 15
+
+
+def test_update_character_validation_error_is_readable_and_bounded(tmp_path, monkeypatch):
+    """A genuine type error returns ONE readable ValueError, not a multi-KB pydantic wall
+    with an errors.pydantic.dev URL. The error must still RAISE (typo-forbid stays red)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.start_world("baldurs-gate")["campaign_id"]
+    pc = server.create_character(cid, "Hero", kind="player", max_hp=10)["id"]
+    with pytest.raises(ValueError) as ei:
+        # current_hp expects an int; a dict is a clean type error inside the model
+        server.update_character(cid, pc, {"current_hp": {"bad": "shape"}})
+    msg = str(ei.value)
+    assert "errors.pydantic.dev" not in msg  # no URL wall
+    assert len(msg) <= 500  # bounded
+    assert "current_hp" in msg  # names the offending field
+
+
 def test_player_kind_always_in_party(tmp_path, monkeypatch):
     # QA ow-rv1: a canon PC loaded via load_canon_character(kind="player") got kind=player
     # but sat OUTSIDE c.party (add_to_party defaults False) → player_in_party gate RED with

--- a/servers/engine/tests/test_spellcasting.py
+++ b/servers/engine/tests/test_spellcasting.py
@@ -621,3 +621,87 @@ def test_single_target_cast_unchanged_no_aoe_key():
     w = _aoe_wizard(cid)
     out = server.cast_spell(cid, w, "Burning Hands")  # no target_ids
     assert "aoe" not in out
+
+
+# --- F14-7 (#812): cast_spell refusals name WHY + what the caster CAN cast -----------
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F14-7). A refusal that just says
+# "doesn't know X" or "no level-N slot" wastes a ~100s DM beat (the DM freehands =
+# hallucination). The refusal must name the cause AND list the castable affordance
+# (known/prepared spells, the slot table) so the next call recovers. ADDITIVE: the
+# ValueError TYPE and the leading clause are preserved (consumers still match on them).
+
+def _prepared_wizard(cid, level=3, name="Rolan"):
+    w = server.create_character(cid, name, kind="player", class_name="Wizard", level=level,
+                                apply_srd_defaults=True, abilities={"intelligence": 16})["id"]
+    # A prepared caster with a small, known set so the refusal has something to list.
+    server.learn_spells(cid, w, ["Magic Missile", "Shield", "Mage Armor"])
+    server.prepare_spells(cid, w, ["Magic Missile", "Shield"])
+    return w
+
+
+def test_unprepared_leveled_refusal_lists_prepared_spells():
+    """A prepared caster casting a known-but-unprepared spell sees WHAT IS prepared."""
+    cid = server.create_campaign("S")["id"]
+    w = _prepared_wizard(cid)
+    with pytest.raises(ValueError) as ei:
+        server.cast_spell(cid, w, "Mage Armor")  # known, not prepared
+    msg = str(ei.value)
+    assert "hasn't prepared" in msg  # cause preserved
+    assert "Magic Missile" in msg and "Shield" in msg  # the prepared affordance is named
+
+
+def test_unknown_to_known_caster_refusal_lists_known_spells():
+    """A known-caster (no prepared list) refusal names the known spells the caster CAN cast."""
+    cid = server.create_campaign("S")["id"]
+    w = server.create_character(cid, "Sorc", kind="player", class_name="Sorcerer", level=3,
+                                apply_srd_defaults=True, abilities={"charisma": 16})["id"]
+    server.learn_spells(cid, w, ["Magic Missile", "Burning Hands"])
+    # Clear the prepared list so the known-only gate (the F14-7 line 6564 path) applies — a
+    # sorcerer/legacy snapshot with spells_known but no prepared list.
+    server.update_character(cid, w, patch={"spells_prepared": []})
+    with pytest.raises(ValueError) as ei:
+        server.cast_spell(cid, w, "Fireball")  # not known
+    msg = str(ei.value)
+    assert "doesn't know or have" in msg  # cause/key preserved
+    assert "Magic Missile" in msg  # the known affordance is named
+
+
+def test_cantrip_refusal_lists_known_cantrips():
+    """A cantrip not in the known set names the cantrips the caster DOES know."""
+    cid = server.create_campaign("S")["id"]
+    w = server.create_character(cid, "Mage", kind="player", class_name="Wizard", level=1,
+                                apply_srd_defaults=True, abilities={"intelligence": 16})["id"]
+    server.learn_spells(cid, w, ["Fire Bolt", "Magic Missile"])
+    with pytest.raises(ValueError) as ei:
+        server.cast_spell(cid, w, "Ray of Frost")  # cantrip not known
+    msg = str(ei.value)
+    assert "doesn't know" in msg
+    assert "Fire Bolt" in msg  # the known affordance is named
+
+
+def test_slot_exhausted_refusal_shows_slot_table():
+    """A PC out of a given slot level sees the remaining slot table (what they CAN cast)."""
+    cid = server.create_campaign("S")["id"]
+    w = server.create_character(cid, "Gale", kind="player", class_name="Wizard", level=1,
+                                apply_srd_defaults=True, abilities={"intelligence": 16})["id"]
+    server.learn_spells(cid, w, ["Magic Missile"])
+    server.prepare_spells(cid, w, ["Magic Missile"])
+    server.cast_spell(cid, w, "Magic Missile")  # burns slot 1 of 2
+    server.cast_spell(cid, w, "Magic Missile")  # burns slot 2 of 2
+    with pytest.raises(ValueError) as ei:
+        server.cast_spell(cid, w, "Magic Missile")  # no level-1 slots left
+    msg = str(ei.value)
+    assert "no level-1 spell slot" in msg  # cause/key preserved
+    assert "slots" in msg.lower()  # the slot table is surfaced
+
+
+def test_unknown_spell_refusal_suggests_close_match():
+    """An unknown (misspelled) spell name surfaces a did-you-mean fuzzy suggestion."""
+    cid = server.create_campaign("S")["id"]
+    w = server.create_character(cid, "Gale", kind="player", class_name="Wizard", level=3,
+                                apply_srd_defaults=True, abilities={"intelligence": 16})["id"]
+    with pytest.raises(ValueError) as ei:
+        server.cast_spell(cid, w, "Magick Missle")  # typo for Magic Missile
+    msg = str(ei.value)
+    assert "unknown spell" in msg  # key preserved
+    assert "Magic Missile" in msg  # did-you-mean

--- a/servers/engine/tests/test_store.py
+++ b/servers/engine/tests/test_store.py
@@ -132,6 +132,63 @@ def test_load_genuinely_incompatible_raises(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# (d2) F14-2 (#812): a sub-model-skew snapshot (an unknown key INSIDE a nested
+#      Character) raises a BOUNDED, DM-readable SnapshotSchemaError — not the raw
+#      multi-KB pydantic wall with an errors.pydantic.dev URL. SnapshotSchemaError
+#      subclasses RuntimeError so existing `except RuntimeError` consumers are intact.
+# ---------------------------------------------------------------------------
+
+def _submodel_skew_snapshot() -> dict:
+    """A valid Campaign snapshot whose nested Character carries an unknown sub-model field
+    (the F14-2 skew class the top-level tolerant net does NOT absorb — sub-model strictness
+    is intentional)."""
+    from models import Character
+    snap = _minimal_snapshot()
+    ch = json.loads(Character(name="Skewed", kind="player").model_dump_json())
+    ch["a_field_a_newer_engine_added"] = 123  # sub-model extra -> extra="forbid" fails
+    snap["characters"] = {ch["id"]: ch}
+    return snap
+
+
+def test_submodel_skew_raises_snapshot_schema_error(tmp_path, monkeypatch):
+    snapshot = _submodel_skew_snapshot()
+    cid = _write_snapshot(tmp_path, monkeypatch, snapshot)
+    with pytest.raises(store.SnapshotSchemaError) as ei:
+        store.load_campaign(cid)
+    # SnapshotSchemaError IS a RuntimeError (existing consumers catch RuntimeError).
+    assert isinstance(ei.value, RuntimeError)
+
+
+def test_submodel_skew_error_is_bounded_and_actionable(tmp_path, monkeypatch):
+    snapshot = _submodel_skew_snapshot()
+    cid = _write_snapshot(tmp_path, monkeypatch, snapshot)
+    with pytest.raises(store.SnapshotSchemaError) as ei:
+        store.load_campaign(cid)
+    msg = str(ei.value)
+    assert len(msg) <= 500, f"error must be bounded; got {len(msg)} chars"
+    assert "errors.pydantic.dev" not in msg  # no URL wall
+    assert cid in msg  # campaign id named
+    # the offending sub-model field location is named (first error loc)
+    assert "a_field_a_newer_engine_added" in msg or "characters" in msg
+    # a recovery move is offered (actionable, not a dead end)
+    assert "snapshot.pre-tolerant.json" in msg or "engine" in msg.lower()
+
+
+def test_submodel_skew_error_names_both_shas_and_skew_direction(tmp_path, monkeypatch):
+    """The bounded error carries the snapshot's engine_sha + the running engine_sha and a
+    skew-direction word so the DM/operator can tell which side is newer."""
+    snapshot = _submodel_skew_snapshot()
+    snapshot["engine_sha"] = "abc1234"  # the snapshot was written by this engine sha
+    cid = _write_snapshot(tmp_path, monkeypatch, snapshot)
+    with pytest.raises(store.SnapshotSchemaError) as ei:
+        store.load_campaign(cid)
+    msg = str(ei.value)
+    assert "abc1234" in msg  # the snapshot's stamped sha
+    # a skew-direction hint (newer/older) is present
+    assert "newer" in msg.lower() or "older" in msg.lower()
+
+
+# ---------------------------------------------------------------------------
 # (e) observability version-stamp: save→load preserves schema_version +
 #     engine_sha, and an OLD snapshot lacking both fields still loads (defaults)
 # ---------------------------------------------------------------------------

--- a/servers/engine/tests/test_travel.py
+++ b/servers/engine/tests/test_travel.py
@@ -79,6 +79,69 @@ def test_travel_to_unknown_raises():
         travel.travel_to(c, "nope")
 
 
+# --- F14-5 (#812): route hints on an unreachable dest + did-you-mean on a typo ----
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F14-5). A rejection that only lists
+# the DIRECT exits sends the DM stepping blindly; the engine holds the full graph, so a
+# known-but-not-adjacent dest gets a BFS first-step hint. An UNKNOWN id gets a did-you-mean.
+
+def _chain_camp(current="a") -> Campaign:
+    """a<->b<->c<->e, plus a<->x (a separate branch). e is reachable from a only via b,c."""
+    return Campaign(
+        title="T",
+        current_location_id=current,
+        locations={
+            "a": Location(id="a", name="Hall", connections=["b", "x"]),
+            "b": Location(id="b", name="Cellar", connections=["a", "c"]),
+            "c": Location(id="c", name="Vault", connections=["b", "e"]),
+            "e": Location(id="e", name="Crypt", connections=["c"]),
+            "x": Location(id="x", name="Garden", connections=["a"]),
+            "z": Location(id="z", name="Sealed Room", connections=[]),  # unreachable island
+        },
+    )
+
+
+def test_unreachable_known_dest_gives_bfs_first_step():
+    """Traveling toward a known-but-not-adjacent dest names the FIRST step of the route."""
+    c = _chain_camp("a")
+    with pytest.raises(ValueError) as ei:
+        travel.travel_to(c, "e")  # known, reachable via b->c->e, not a direct exit
+    msg = str(ei.value)
+    assert "not connected" in msg  # cause/key preserved
+    assert "Cellar" in msg  # the BFS first step (b = Cellar) is named
+    assert "via" in msg.lower() or "route" in msg.lower()  # a route hint is given
+    assert c.current_location_id == "a"  # no mutation on a rejected travel
+
+
+def test_unreachable_disconnected_dest_says_no_route():
+    """A known dest with NO path from here says so (instead of a misleading exit list)."""
+    c = _chain_camp("a")
+    with pytest.raises(ValueError) as ei:
+        travel.travel_to(c, "z")  # known but on a disconnected island
+    msg = str(ei.value)
+    assert "not connected" in msg
+    assert "no known route" in msg.lower()
+
+
+def test_unknown_dest_id_suggests_close_match():
+    """A misspelled destination id surfaces a did-you-mean of the nearest known id/name."""
+    c = _chain_camp("a")
+    with pytest.raises(ValueError) as ei:
+        travel.travel_to(c, "celler")  # typo for "b" (Cellar) — fuzzy on name
+    msg = str(ei.value)
+    assert "unknown location" in msg  # key preserved
+    assert "Cellar" in msg or "'b'" in msg  # did-you-mean names the close match
+
+
+def test_unreachable_route_hint_does_not_mutate():
+    """The BFS hint path is a pure read — no visited flip, no location change, no clock tick."""
+    c = _chain_camp("a")
+    before = (c.current_location_id, c.locations["e"].visited, c.day, c.time_of_day)
+    with pytest.raises(ValueError):
+        travel.travel_to(c, "e", advance_time=True)
+    after = (c.current_location_id, c.locations["e"].visited, c.day, c.time_of_day)
+    assert before == after
+
+
 def test_travel_to_current_rejected():
     c = _camp("a")
     with pytest.raises(ValueError, match="already at"):

--- a/servers/engine/travel.py
+++ b/servers/engine/travel.py
@@ -18,11 +18,44 @@ at night.
 
 from __future__ import annotations
 
+import difflib
+from collections import deque
+
 from models import Campaign, Location
 
 # The in-world day, in order. Travel advances along this cycle; passing the end
 # rolls over into the next day.
 PHASES: tuple[str, ...] = ("morning", "afternoon", "evening", "night")
+
+
+def _bfs_first_step(campaign: Campaign, start_id: str, dest_id: str) -> Location | None:
+    """The FIRST hop a shortest path from `start_id` to `dest_id` takes, or None when no
+    path exists (F14-5 / #812). A pure breadth-first walk of the location graph the engine
+    already holds — so a rejection of a known-but-not-adjacent dest can name the next step
+    ("go via the Cellar") instead of leaving the DM to step blindly. Read-only: no mutation."""
+    if start_id == dest_id:
+        return None
+    # parent map: child_id -> the immediate-neighbour-of-start it was first reached through
+    first_hop: dict[str, str] = {}
+    seen: set[str] = {start_id}
+    q: deque[str] = deque()
+    start = campaign.locations.get(start_id)
+    for nxt in (start.connections if start is not None else []):
+        if nxt in campaign.locations and nxt not in seen:
+            seen.add(nxt)
+            first_hop[nxt] = nxt  # a direct neighbour's first hop is itself
+            q.append(nxt)
+    while q:
+        cur_id = q.popleft()
+        if cur_id == dest_id:
+            return campaign.locations.get(first_hop[cur_id])
+        cur = campaign.locations.get(cur_id)
+        for nxt in (cur.connections if cur is not None else []):
+            if nxt in campaign.locations and nxt not in seen:
+                seen.add(nxt)
+                first_hop[nxt] = first_hop[cur_id]  # inherit the originating first hop
+                q.append(nxt)
+    return None
 
 
 def reachable(campaign: Campaign) -> list[Location]:
@@ -85,7 +118,20 @@ def travel_to(campaign: Campaign, destination_id: str, advance_time: bool = Fals
     """
     dest = campaign.locations.get(destination_id)
     if dest is None:
-        raise ValueError(f"unknown location id {destination_id!r}")
+        # F14-5 (#812): a bare "unknown location id" on a typo sends the DM guessing. Surface a
+        # did-you-mean of the nearest known location id/name so the next call recovers. The
+        # "unknown location id {id!r}" key/prefix is preserved (additive tail).
+        corpus = {loc.id: loc.name for loc in campaign.locations.values()}
+        candidates = list(corpus) + [n for n in corpus.values() if n]
+        near = difflib.get_close_matches(destination_id, candidates, n=3, cutoff=0.5)
+        # map any matched display-name back to "id (name)" so the DM gets the id to pass
+        name_to_id = {n: i for i, n in corpus.items() if n}
+        shown = []
+        for m in near:
+            lid = m if m in corpus else name_to_id.get(m, m)
+            shown.append(f"{lid} ({corpus.get(lid, m)})")
+        hint = f" — did you mean {', '.join(dict.fromkeys(shown))}?" if shown else ""
+        raise ValueError(f"unknown location id {destination_id!r}{hint}")
 
     cur_id = campaign.current_location_id
     if cur_id is not None:
@@ -97,9 +143,19 @@ def travel_to(campaign: Campaign, destination_id: str, advance_time: bool = Fals
             exits = ", ".join(
                 f"{loc.id} ({loc.name})" for loc in reachable(campaign)
             ) or "(none)"
+            # F14-5 (#812): the engine holds the WHOLE graph — a known-but-not-adjacent dest
+            # gets a BFS first-step route hint ("travel via <id> (<name>)") instead of only the
+            # direct exits, so a multi-hop journey doesn't bounce 18% of the time. A genuinely
+            # disconnected dest says so plainly. Pure read; no mutation on a rejected travel.
+            step = _bfs_first_step(campaign, cur_id, destination_id)
+            if step is not None:
+                route = (f" To reach {dest.name!r} ({dest.id}), travel via "
+                         f"{step.id} ({step.name}).")
+            else:
+                route = f" There is no known route from here to {dest.name!r}."
             raise ValueError(
                 f"cannot travel to {destination_id!r}: not connected to the current "
-                f"location. Reachable from here: {exits}"
+                f"location. Reachable from here: {exits}.{route}"
             )
 
     first_visit = not dest.visited


### PR DESCRIPTION
## Cluster #812 — API ergonomics & error surfaces (P2)

Theme: a bad/Pythonic error or bloated return wastes a ~100s DM beat (the DM gives up on the tool and freehands = hallucination). Each change makes a cited refusal **actionable + bounded** while **preserving the error KEY/shape** consumers read (additive did-you-mean / hint tails, never a breaking change). All changes are small + localized — no broad refactor.

Source: `docs/audits/ENGINE-AUDIT-2026-06-11.md` (Part C per-finding deep sections).

### Fixed

**F14-7 — cast_spell refusals name WHY + what the caster CAN cast**
- known / prepared / cantrip refusals append the castable affordance (prepared or known spells + the available/max slot table) via a new `_castable_affordance` helper
- the PC slot-exhausted refusal surfaces the slot table; the `no level-N spell slot available` key is preserved
- the unknown-spell refusal adds a `difflib` did-you-mean (new `spells.all_spell_names()` corpus)

**F14-5 — travel_to BFS route hints + did-you-mean**
- a known-but-not-adjacent destination now gets a BFS first-step route hint (new pure `_bfs_first_step` over the connection graph the engine already holds), instead of only listing direct exits
- an unknown destination id gets a did-you-mean over location ids/names
- the `not connected` / `Reachable from here` phrasing is preserved; pure read (no mutation on a rejected travel)

**F14-11 — update_character `in_party` translation + readable validation errors**
- `in_party` (a *computed* read field, `ch.id in c.party`, not a Character field) is popped before `model_validate` and translated to a `c.party` join/leave (mirrors recruit / dismiss) instead of tripping `extra="forbid"` with a raw pydantic wall
- a genuine `ValidationError` is wrapped into one bounded readable line (no `errors.pydantic.dev` URL) via `_readable_validation_error` — still raises `ValueError`, so the strict typo-forbid guard stays load-bearing
- the return dict surfaces the computed `in_party` (additive)

**F14-2 — bounded SnapshotSchemaError**
- the tolerant-load final-except now raises `SnapshotSchemaError` (a **RuntimeError subclass**, so every `except RuntimeError` consumer is intact) with a ≤500-char actionable message: skew direction + both engine SHAs + campaign id + first 3 skew field locs + 2 recovery moves
- the raw pydantic wall is **not** embedded; it survives on `__cause__` for logs
- the historical `incompatible with the current schema` phrase is preserved (the genuinely-incompatible test still passes)
- per the spec correction, the tolerant net is **not** extended into sub-models (sub-model strictness is intentional; warn-and-drop would risk silent round-trip data loss)

**F14-13 — soft-error counter the gate can see**
- a report-only `tool_soft_errors` counter in `qa/assert_behavioral.py` surfaces dict-shaped `{"error": ...}` returns with `is_error=False` (invisible to the `is_error`-only A8 gate)
- WARN, never RED (these are recoverable; the DM is told and re-asks) — mirrors the existing `dm_beat_honesty` report-only pattern; the soft-error convention is documented at the code site (the consumer it was blocked on)

### Deferred (Refs #812)

- **F14-9** (cold-open session-open composite) — a new additive tool with a parity test; `depends_on F14-1` (not in this cluster). Larger than a localized error-surface change; deferred to keep the PR tight.
- **F14-10** (clawdnd-rules adoption) — the finding's own fix step 1 is "score one gate transcript's rulings vs SRD FIRST; if misses aren't real, demote the SKILL rule." A transcript-scoring / SKILL.md domain check, not a code error-surface edit.
- **F14-18** (voice/rules `alwaysLoad`) — per the spec must be "paid for by F14-6's trim" and is duo A/B-gated (latency-forensics discipline). F14-6 is not in this cluster; wiring alwaysLoad now would regress the 175KB token surface the audit is reducing.

### Invariants preserved
- Engine stays the sole writer; the travel route-hint and cast affordance paths are **pure reads** (no `updated_at` bump, no mutation on a rejected call).
- Additive-by-default: every error KEY/prefix consumers match on is preserved; old snapshots round-trip; new return fields are additive.
- `clawdnd-*` ids and `CLAWDND_*` env untouched.

### Tests
- new: +5 F14-7 (`test_spellcasting.py`), +4 F14-5 (`test_travel.py`), +6 F14-11 (`test_qa_fixes.py`), +3 F14-2 (`test_store.py`), +2 F14-13 (`test_assert_behavioral.py`)
- full engine suite: **2579 passed, 2 xfailed**
- qa suite: **236 passed**
- Tier-0 `qa/fast_gate.sh`: **PASS**

Do not merge — for review.