### PR TITLE
fix(viewer): #826 nav-away mid-narration resilience + #825 full chronicle narration

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -446,6 +446,26 @@ function useLiveSession(state) {
     setPendingState(null);
   }, [clearTimers, setPendingState]);
 
+  // #826: authoritatively ROLL BACK the optimistic in-flight arm when the /move POST itself is
+  // REJECTED by the server (the move never started, so there is no DM turn to wait for). postMove now
+  // arms the narrating gate the INSTANT the player commits — BEFORE the network round-trip — so the
+  // one-move-at-a-time gate SURVIVES a navigation during the in-flight window (the App-level pending
+  // state outlives ScreenTable's unmount, where a re-mounted submittingRef would otherwise re-open
+  // the bar and let a second move double-fire the lane = the #826 state corruption). When that POST
+  // comes back an ERROR, the gate must clear NOW — but a plain clearPending would be SWALLOWED by the
+  // #648 arm-grace (it deliberately ignores a spurious clear inside the first PENDING_ARM_GRACE_MS).
+  // This is NOT spurious: it is the server's authoritative rejection, so it bypasses the grace. It is
+  // surgical — it only clears the move WE optimistically armed (text match against the still-pending,
+  // not-yet-streaming turn) so it can never clobber a newer live turn (e.g. a fast retry).
+  const abandonPending = React.useCallback((text) => {
+    const p = pendingRef.current;
+    if (!p || p.streaming) return;                          // a streaming turn is real — never abandon it
+    const want = String(text == null ? "" : text);
+    if (want && String(p.text == null ? "" : p.text) !== want) return;  // not the move we armed — no-op
+    clearTimers();
+    setPendingState(null);
+  }, [clearTimers, setPendingState]);
+
   // #342 + #348: arm the narrating indicator + a recovery timeout. If a DM beat doesn't arrive within
   // the recovery window the turn is flagged `stuck` (the bar re-enables with a "try again" hint)
   // instead of staying frozen until the 12-minute backstop. A real beat (below) clears it outright.
@@ -757,7 +777,7 @@ function useLiveSession(state) {
   // (consistent with armPending/clearPending; the /events poll calls the same ref). Purely additive —
   // existing consumers destructure named fields, so nothing breaks; it also makes the mid-stream stall
   // ceiling unit-testable without reaching into the hook's internals.
-  return { chatBeats, log, pending, armPending, clearPending, recordPlayerEcho, notePendingProgress };
+  return { chatBeats, log, pending, armPending, clearPending, abandonPending, recordPlayerEcho, notePendingProgress };
 }
 window.useLiveSession = useLiveSession;
 // #348: expose the recovery-timing contract for tests (and devtools introspection). Purely

--- a/viewer/openworlds/chrome.jsx
+++ b/viewer/openworlds/chrome.jsx
@@ -269,10 +269,48 @@ function PortraitSilhouette() {
   );
 }
 
+// #826: how many times Img RETRIES a scope whose /image 404s, and the backoff between tries. The
+// scene image is fire-and-forget (#399): the engine returns a "pending" descriptor immediately and a
+// daemon worker writes the real art OFF the turn path, so /image legitimately 404s for a window after
+// a new scope appears. The OLD Img latched `failed` on the first onError and only ever cleared it on
+// a SCOPE CHANGE — so a same-scope image that became servable LATER stayed frozen on the placeholder
+// forever (a dead handle). That froze the scene art when a player navigated away mid-narration and
+// back (the surface re-projects the same scope, but the latched component never re-attempts). These
+// retries let the component recover when the pending art lands, while a bounded budget + backoff
+// keeps a genuinely-missing image from hammering the endpoint.
+const _IMG_MAX_RETRIES = 8;
+const _IMG_RETRY_MS = 4000;
+
 function Img({ scope, label, w, h, framed, style, className, fit = "cover" }) {
+  // `attempt` doubles as the cache-buster + the retry counter; `failed` is the per-attempt error
+  // latch (placeholder while we wait), NOT a permanent freeze.
+  const [attempt, setAttempt] = React.useState(0);
   const [failed, setFailed] = React.useState(false);
-  React.useEffect(() => { setFailed(false); }, [scope]);
+  const retryRef = React.useRef(null);
+  const clearRetry = () => {
+    if (retryRef.current != null) { window.clearTimeout(retryRef.current); retryRef.current = null; }
+  };
+  // A new scope is a fresh subject — reset the retry budget + error latch and cancel any pending retry.
+  React.useEffect(() => {
+    setFailed(false);
+    setAttempt(0);
+    return clearRetry;
+  }, [scope]);
   const isPortrait = /(^|[-:/])(portrait|pc|npc|char)/i.test(scope || "");
+  const onError = () => {
+    // #826: do NOT permanently latch. Show the placeholder for THIS attempt, then — if we still have
+    // retry budget for this scope (the #399 pending-art window) — schedule another try so a scope
+    // whose image becomes servable later RECOVERS instead of freezing on a dead handle. Past the
+    // budget we stop (a genuinely-missing image), still on the graceful placeholder.
+    setFailed(true);
+    if (attempt >= _IMG_MAX_RETRIES) return;
+    clearRetry();
+    retryRef.current = window.setTimeout(() => {
+      retryRef.current = null;
+      setFailed(false);          // clear the per-attempt latch …
+      setAttempt((a) => a + 1);  // … and re-mount the <img> (cache-busted) to re-probe /image.
+    }, _IMG_RETRY_MS);
+  };
   if (!scope || failed) {
     return (
       <Placeholder label={isPortrait ? "" : label} w={w} h={h} framed={framed} style={style} className={className}>
@@ -280,12 +318,18 @@ function Img({ scope, label, w, h, framed, style, className, fit = "cover" }) {
       </Placeholder>
     );
   }
+  // The cache-buster (`v=attempt`) forces the browser to actually re-request the scope on a retry
+  // rather than re-serve the cached 404; attempt 0 keeps the original URL shape (no change for the
+  // happy path / existing tests that assert the `/image?scope=` prefix).
+  const src = attempt > 0
+    ? `/image?scope=${encodeURIComponent(scope)}&v=${attempt}`
+    : `/image?scope=${encodeURIComponent(scope)}`;
   return (
     <img
-      src={`/image?scope=${encodeURIComponent(scope)}`}
+      src={src}
       alt={label || ""}
       loading="lazy"
-      onError={() => setFailed(true)}
+      onError={onError}
       className={`ow-img ${framed ? "framed" : ""} ${className || ""}`}
       style={{ width: w, height: h, objectFit: fit, display: "block", ...(style || {}) }}
     />

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -769,6 +769,10 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
   // LOCKOUT P0 play gate); a turn the recovery timeout flagged `stuck` is NO LONGER pending — the bar
   // re-opens (and `stuckRetryUnblocked` lets the retry probe the server even through an app-status latch).
   const armPending = session.armPending;
+  // #826: the authoritative rollback for an OPTIMISTIC arm — postMove arms the narrating gate the
+  // instant the player commits (before the /move round-trip) so the one-move gate survives a nav
+  // during the in-flight window; abandonPending rolls it back if the POST is rejected.
+  const abandonPending = session.abandonPending;
   const recordPlayerEcho = session.recordPlayerEcho;
   // #385: the COLD-OPEN (first beat) gets action-bar copy that reads as "the DM is taking its turn"
   // (alive) rather than the generic "Narrating…" — so the locked bar matches the obviously-alive
@@ -837,6 +841,19 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
     // #344: capture the (already-neutralized) move + label + actionId so a later "Try again"
     // recovery can re-POST this exact turn if the DM stalls on it.
     lastMoveRef.current = { move: cleanMove, label: text, actionId };
+    // #826: arm the narrating gate OPTIMISTICALLY — the INSTANT the player commits, BEFORE the /move
+    // round-trip resolves. The arm + the echo live in the app-level useLiveSession hook, so they
+    // SURVIVE this screen unmounting: if the player navigates away (Table→Map) DURING the in-flight
+    // POST and back, the App still holds `pending` (the one-move gate) and the chronicle echo. The old
+    // order armed only AFTER the await, leaving a window where a nav-away/nav-back remounted ScreenTable
+    // with a fresh submittingRef=false AND pending=null — the bar re-opened and a SECOND move could
+    // double-fire the one-move-at-a-time lane (the #826 state corruption). recordPlayerEcho is #399-
+    // idempotent, so re-POST/retry paths don't duplicate the echo.
+    recordPlayerEcho(hero.name, text, cleanMove);
+    armPending(text);
+    // #402: a new turn was just submitted — force the chronicle back to the bottom on the next content
+    // change even if the player had scrolled up, so they always see their move land + the DM reply begin.
+    snapNextRef.current = true;
     try {
       const response = await fetch(writeLane.endpoint || "/move", {
         method: "POST",
@@ -847,14 +864,14 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
       if (!response.ok || payload.ok === false) {
         throw new Error(payload.reason || `move ${response.status}`);
       }
-      recordPlayerEcho(hero.name, text, cleanMove);
-      armPending(text);
-      // #402: a new turn was just submitted — force the chronicle back to the bottom on the next
-      // content change even if the player had scrolled up, so they always see their move land and
-      // the DM's reply begin. The auto-follow effect honors this one-shot, then re-arms stickiness.
-      snapNextRef.current = true;
       loadSurface();
     } catch (error) {
+      // #826: the POST was REJECTED — the move never started, so authoritatively roll back the
+      // optimistic arm (abandonPending bypasses the #648 arm-grace; it's surgical — clears ONLY the
+      // move we just armed, never a newer live turn). Then surface the honest failure toast. Falls back
+      // to clearPending on an older bundle that predates abandonPending.
+      if (typeof abandonPending === "function") abandonPending(text);
+      else if (typeof session.clearPending === "function") session.clearPending();
       toast({ kind: "danger", title: "Move not sent", body: error?.message || `The viewer could not reach ${writeLane.endpoint || "/move"}.` });
     } finally {
       submittingRef.current = false;

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1650,6 +1650,24 @@ def _session_action_context(snapshot: dict, location: dict, summary: str, quests
     }
 
 
+# #825: a generous DoS-only ceiling for a single chronicle history row's text. Set FAR above any real
+# multi-paragraph DM beat (a long Act-opening beat is a few KB), so it can never cut a genuine turn;
+# it exists only to bound a pathological row. _bounded_chronicle_text cuts on a WORD boundary when it
+# trips, so even that case is never sliced mid-word (the #825 complaint).
+_CHRONICLE_ROW_TEXT_MAX = 64 * 1024
+
+
+def _bounded_chronicle_text(text: str) -> str:
+    """Return the FULL beat text (the #825 fix — no fixed mid-word ceiling), trimming only a
+    pathological row past _CHRONICLE_ROW_TEXT_MAX and, even then, on the last whitespace boundary so
+    the cut never lands inside a word."""
+    if len(text) <= _CHRONICLE_ROW_TEXT_MAX:
+        return text
+    head = text[:_CHRONICLE_ROW_TEXT_MAX]
+    cut = head.rfind(" ")
+    return (head[:cut] if cut > 0 else head).rstrip()
+
+
 def _session_recent_events(raw_events: list[dict] | None) -> list[dict]:
     out: list[dict] = []
     for row in raw_events or []:
@@ -1660,7 +1678,17 @@ def _session_recent_events(raw_events: list[dict] | None) -> list[dict]:
         text = _text(row.get("text") or row.get("detail") or row.get("summary"))
         if not text:
             continue
-        item = {"kind": kind, "text": text[:1000]}
+        # #825: the chronicle's leading history band must carry the FULL DM beat. The old fixed
+        # `text[:1000]` ceiling cut a long narration MID-WORD with no ellipsis/expand — three
+        # personas (rc2 adversarial+narrative, rc1 veteran) reported the remainder unreadable. The
+        # chronicle render region is already a scrollable role="log" (screen-table.jsx), and the #752
+        # a11y bound is the ROW cap (CHRONICLE_RENDER_CAP / MAX_LIVE_BEATS) — NOT a per-row char cut —
+        # so removing this ceiling does not reintroduce the #752 a11y-tree flood. We keep only a
+        # generous DoS guard at _CHRONICLE_ROW_TEXT_MAX, set far above any real multi-paragraph beat
+        # so it can never slice a genuine DM turn (and we cut on a WORD boundary if it ever trips, so
+        # even a pathological row is never cut mid-word). Engine stays sole writer — this is the
+        # read-only viewer bridge projecting state the engine already wrote.
+        item = {"kind": kind, "text": _bounded_chronicle_text(text)}
         if label:
             item["label"] = label[:120]
         # Carry the stable session-log line index (`seq`) through to the surface when present, so the

--- a/viewer/tests/test_nav_chronicle_resilience.py
+++ b/viewer/tests/test_nav_chronicle_resilience.py
@@ -1,0 +1,395 @@
+"""Behavior tests for the two v1.0.4 viewer orphans #826 + #825 (engine-audit Section-4 coverage gaps).
+
+These exercise the REAL shipped code (no reimplementation) — the chronicle bridge projection
+(viewer/server.py), the scene-image component (viewer/openworlds/chrome.jsx), and the app-level
+in-flight turn state (viewer/openworlds/app.jsx `useLiveSession`) — mirroring the sibling
+JS-behavior harnesses (test_recovery_timing.py, test_chronicle_hygiene.py).
+
+#826 — Navigating away mid-narration corrupts session state + permanently freezes the scene image
+   (rc2 adversarial; engine-audit Section-4 orphan #5). A user-initiated nav DURING an in-flight
+   beat (distinct from the #745/#648 STALLED-beat trigger) must not (a) drop the one-move gate (so a
+   nav-away/nav-back can't double-submit into the one-move-at-a-time lane — state corruption), nor
+   (b) latch a DEAD scene-image handle that stays frozen after the #399 fire-and-forget image
+   finally becomes servable. Two legs:
+     • the optimistic in-flight gate: `useLiveSession` must arm the pending turn the instant the
+       player commits (BEFORE the network round-trip resolves) so the gate SURVIVES a remount; and a
+       genuine POST rejection must be able to cleanly ABANDON that optimistic arm (the new
+       `abandonPending`) WITHOUT being swallowed by the #648 arm-grace.
+     • the scene-image handle: `Img` (chrome.jsx) must NOT permanently latch `failed` — a #399
+       pending scene that 404s then becomes servable must be recoverable, not frozen forever.
+
+#825 — Chronicle truncates DM narration mid-word at a fixed ceiling (3 personas, rc1+rc2;
+   engine-audit Section-4 orphan #1). The chronicle's leading history band (`_session_recent_events`
+   in viewer/server.py) hard-cut every row to `text[:1000]`, slicing a long DM beat mid-word with no
+   ellipsis / no expand — the remainder unreadable. The full narration must round-trip into the
+   chronicle (the render region is already a scrollable `role="log"`, and the #752 a11y bound is the
+   ROW cap CHRONICLE_RENDER_CAP/MAX_LIVE_BEATS — NOT a per-row char ceiling), so removing the
+   per-row char cut does not reintroduce the #752 a11y flood.
+
+Skipped where Node is not on PATH (the JS-behavior legs only).
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+OPENWORLDS = HERE.parent / "openworlds"
+VIEWER_ROOT = HERE.parent
+APP_JSX = OPENWORLDS / "app.jsx"
+SCREEN_TABLE = OPENWORLDS / "screen-table.jsx"
+CHROME = OPENWORLDS / "chrome.jsx"
+BABEL = OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+
+def _node() -> str:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node not on PATH; skipping JS-behavior test")
+    return node
+
+
+# ===========================================================================================
+# #825 — the chronicle bridge must NOT cut a long DM beat mid-word at a fixed char ceiling.
+# ===========================================================================================
+@pytest.fixture(scope="module")
+def viewer_server():
+    sys.path.insert(0, str(VIEWER_ROOT))
+    import server  # noqa: WPS433  (viewer/server.py)
+
+    return server
+
+
+def _long_dm_beat(n_chars: int = 4000) -> str:
+    # A realistic multi-paragraph DM narration well past the old 1000-char ceiling. We deterministically
+    # place an unbroken 80-char run straddling index 1000 so a fixed [:1000] slice would visibly cut
+    # mid-word — the exact #825 complaint. Then pad with prose to n_chars.
+    body = (
+        "The torchlight gutters as you descend the winding stair into the undercroft, "
+        "each step slick with centuries of damp. "
+    )
+    head = "A" * 970          # exactly 970 chars, no spaces
+    midword = "x" * 80        # straddles index 1000 (970..1050), no spaces
+    text = head + midword + " " + (body * 60)
+    text = text[:n_chars]
+    assert text[999] != " " and text[1000] != " ", "fixture must straddle a word at the old ceiling"
+    return text
+
+
+def test_825_chronicle_history_band_does_not_truncate_long_narration_midword(viewer_server):
+    long_text = _long_dm_beat(4000)
+    rows = viewer_server._session_recent_events(
+        [{"kind": "narration", "text": long_text, "seq": 0, "sid": "s1"}]
+    )
+    assert len(rows) == 1
+    got = rows[0]["text"]
+    # The FULL beat must survive — no fixed-ceiling mid-word cut.
+    assert got == long_text, (
+        f"chronicle history band truncated DM narration: kept {len(got)} of {len(long_text)} chars"
+    )
+
+
+def test_825_short_narration_is_unchanged(viewer_server):
+    text = "A short, clean beat the DM narrated."
+    rows = viewer_server._session_recent_events([{"kind": "narration", "text": text}])
+    assert rows and rows[0]["text"] == text
+
+
+def test_825_no_fixed_1000_char_ceiling_on_narration_rows(viewer_server):
+    # Pin the regression directly: a beat that is exactly 1500 chars must come back at 1500, not 1000.
+    text = "x" * 1500
+    rows = viewer_server._session_recent_events([{"kind": "narration", "text": text}])
+    assert rows and len(rows[0]["text"]) == 1500, "a fixed 1000-char ceiling is back"
+
+
+# ===========================================================================================
+# #826 (image leg) — `Img` must not permanently latch a DEAD handle on a recoverable error.
+# ===========================================================================================
+def _img_recovers_after_error() -> dict:
+    """Mount the REAL `Img` (chrome.jsx) with a stateful React stub + a controllable clock, fire
+    onError (a #399 pending scene 404), then advance the retry timer (the pending art has landed and
+    the same scope is now servable) and report whether the component RECOVERED to an <img> or stayed
+    frozen on the Placeholder (the #826 dead handle). Also reports the retry URL is cache-busted so a
+    cached 404 is actually re-requested."""
+    program = (
+        "const fs = require('fs'); const vm = require('vm');\n"
+        + "const Babel = require(%s);\n" % json.dumps(str(BABEL))
+        + "const src = fs.readFileSync(%s, 'utf8');\n" % json.dumps(str(CHROME))
+        + r"""
+// A controllable clock so the timer-driven retry (the #826 fix mirrors the browser: a pending image
+// lands after a delay and the component re-probes) is deterministic.
+let NOW = 1000;
+const timers = [];
+let nextId = 1;
+function setTimeoutStub(fn, ms) { const id = nextId++; timers.push({ id, at: NOW + (ms || 0), fn, cleared: false }); return id; }
+function clearTimeoutStub(id) { const t = timers.find((t) => t.id === id); if (t) t.cleared = true; }
+function advance(ms) {
+  const target = NOW + ms;
+  while (true) {
+    const due = timers.filter((t) => !t.cleared && t.at <= target).sort((a, b) => a.at - b.at)[0];
+    if (!due) break; NOW = due.at; due.cleared = true; due.fn();
+  }
+  NOW = target;
+}
+// A minimal stateful React: useState cells persist across renders; useEffect bodies RUN and their
+// deps are honored (so an effect only re-runs when its deps change — exactly the browser's model).
+function makeReact() {
+  let stateCells = [], effectCells = [], sIdx = 0, eIdx = 0, renderFn = null, result = null;
+  const pendingEffects = [];
+  function useState(init) {
+    const i = sIdx++;
+    if (stateCells[i] === undefined) stateCells[i] = { v: (typeof init === 'function' ? init() : init) };
+    const cell = stateCells[i];
+    const set = (n) => { cell.v = (typeof n === 'function' ? n(cell.v) : n); render(); };
+    return [cell.v, set];
+  }
+  function useEffect(fn, deps) {
+    const i = eIdx++;
+    const prev = effectCells[i];
+    const changed = !prev || !deps || deps.some((d, k) => d !== prev.deps[k]);
+    if (changed) { if (prev && typeof prev.cleanup === 'function') { try { prev.cleanup(); } catch (e) {} }
+      effectCells[i] = { deps }; pendingEffects.push({ i, fn }); }
+  }
+  function useCallback(fn) { return fn; }
+  function useRef(init) { const i = 'r' + (sIdx++); if (stateCells[i] === undefined) stateCells[i] = { current: init }; return stateCells[i]; }
+  function createElement(type, props, ...children) {
+    return { type: (typeof type === 'function' ? (type.name || 'C') : type), fn: (typeof type === 'function' ? type : null),
+             props: props || {}, children: children.flat(Infinity).filter((c) => c != null) }; }
+  function flush() { while (pendingEffects.length) { const { i, fn } = pendingEffects.shift(); const cl = fn(); if (effectCells[i]) effectCells[i].cleanup = (typeof cl === 'function') ? cl : undefined; } }
+  function render() { sIdx = 0; eIdx = 0; result = renderFn(); flush(); return result; }
+  function mount(fn) { renderFn = fn; return render(); }
+  return { React: { useState, useEffect, useCallback, useRef, createElement, Fragment: 'F' }, render, mount, get result() { return result; } };
+}
+const host = makeReact();
+const sb = { React: host.React, console, setTimeout: setTimeoutStub, clearTimeout: clearTimeoutStub };
+sb.window = sb;
+vm.createContext(sb);
+const code = Babel.transform(src, { presets: ['react'], filename: 'chrome.jsx' }).code;
+vm.runInContext(code, sb);
+const Img = sb.window.Img;
+if (typeof Img !== 'function') throw new Error('Img not exported on window');
+
+// Walk the createElement tree to find the first <img> (and its props) if present.
+function findImg(node) {
+  if (!node || typeof node !== 'object') return null;
+  if (node.type === 'img') return node;
+  for (const c of (node.children || [])) { const r = findImg(c); if (r) return r; }
+  return null;
+}
+const scope = 'scene:undercroft';
+host.mount(() => Img({ scope, label: 'scene', h: 260 }));
+const firstImg = findImg(host.result);
+const hadImgInitially = !!firstImg;
+// Simulate the /image 404 (a #399 fire-and-forget scene that is not yet servable).
+if (firstImg && firstImg.props.onError) firstImg.props.onError();
+const afterErrorImg = findImg(host.result);
+const frozenAfterError = !afterErrorImg;   // dropped to Placeholder
+// The async worker finishes — the SAME scope is now servable. Advancing the retry clock must let the
+// component RECOVER (re-mount the <img>) rather than stay frozen on a dead handle.
+advance(5000);
+const recoveredImg = findImg(host.result);
+const recovered = !!recoveredImg;
+const retryUrlCacheBusted = !!(recoveredImg && /[?&]v=\d+/.test(String(recoveredImg.props.src || "")));
+process.stdout.write(JSON.stringify({ hadImgInitially, frozenAfterError, recovered, retryUrlCacheBusted }));
+"""
+    )
+    proc = subprocess.run(
+        [_node(), "--input-type=commonjs"], input=program, text=True, capture_output=True
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"node failed: {proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+def test_826_scene_image_does_not_latch_dead_handle_after_recoverable_error():
+    out = _img_recovers_after_error()
+    assert out["hadImgInitially"], "Img should render an <img> for a real scope"
+    assert out["frozenAfterError"], "an onError should fall back to the Placeholder (expected)"
+    # The #826 fix: once the same-scope image becomes servable, the component must be able to recover
+    # — NOT stay permanently frozen on a dead handle.
+    assert out["recovered"], "scene image stayed FROZEN on a dead handle after a recoverable error (#826)"
+    assert out["retryUrlCacheBusted"], "the retry must cache-bust the URL so a cached 404 is re-requested"
+
+
+# ===========================================================================================
+# #826 (state leg) — the in-flight turn gate must be armed OPTIMISTICALLY (survives nav) and a
+# genuine POST rejection must cleanly ABANDON it (bypassing the #648 arm-grace).
+# ===========================================================================================
+_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+let NOW = 1000000;
+const timers = [];
+let nextId = 1;
+function setTimeoutStub(fn, ms) { const id = nextId++; timers.push({ id, at: NOW + (ms || 0), fn, cleared: false }); return id; }
+function clearTimeoutStub(id) { const t = timers.find((t) => t.id === id); if (t) t.cleared = true; }
+function setIntervalStub() { return nextId++; }
+function clearIntervalStub() {}
+function advance(ms) {
+  const target = NOW + ms;
+  while (true) {
+    const due = timers.filter((t) => !t.cleared && t.at <= target).sort((a, b) => a.at - b.at)[0];
+    if (!due) break;
+    NOW = due.at; due.cleared = true; due.fn();
+  }
+  NOW = target;
+}
+
+function makeReact() {
+  const stateCells = []; const refCells = []; const cbCells = []; const effects = [];
+  let sIdx = 0, rIdx = 0, cIdx = 0, eIdx = 0;
+  let renderFn = null; let result = null;
+  const pendingEffects = []; let flushing = false;
+  function useState(init) {
+    const i = sIdx++;
+    if (stateCells[i] === undefined) stateCells[i] = { v: typeof init === 'function' ? init() : init };
+    const cell = stateCells[i];
+    const set = (next) => { cell.v = (typeof next === 'function') ? next(cell.v) : next; render(); };
+    return [cell.v, set];
+  }
+  function useRef(init) { const i = rIdx++; if (refCells[i] === undefined) refCells[i] = { current: init }; return refCells[i]; }
+  function useCallback(fn, deps) {
+    const i = cIdx++; const prev = cbCells[i];
+    if (!prev || !deps || deps.some((d, k) => d !== prev.deps[k])) cbCells[i] = { fn, deps };
+    return cbCells[i].fn;
+  }
+  function useEffect(fn, deps) {
+    const i = eIdx++; const prev = effects[i];
+    const changed = !prev || !deps || deps.some((d, k) => d !== prev.deps[k]);
+    if (changed) { effects[i] = { deps, cleanup: prev && prev.cleanup }; pendingEffects.push({ i, fn }); }
+  }
+  function flushEffects() {
+    if (flushing) return; flushing = true;
+    while (pendingEffects.length) {
+      const { i, fn } = pendingEffects.shift();
+      if (effects[i] && typeof effects[i].cleanup === 'function') { try { effects[i].cleanup(); } catch (e) {} }
+      const cl = fn(); if (effects[i]) effects[i].cleanup = (typeof cl === 'function') ? cl : undefined;
+    }
+    flushing = false;
+  }
+  function render() { sIdx = 0; rIdx = 0; cIdx = 0; eIdx = 0; result = renderFn(); if (!flushing) flushEffects(); return result; }
+  function mount(fn) { renderFn = fn; render(); }
+  function commit() { render(); }
+  function api() { return result; }
+  return { React: { useState, useRef, useCallback, useEffect, createElement: (t, p, ...c) => ({ t, p, c }), Fragment: 'F' }, mount, commit, api };
+}
+
+const reactHost = makeReact();
+const sandbox = {
+  React: reactHost.React,
+  ReactDOM: { createRoot: () => ({ render() {} }) },
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible', getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
+  setTimeout: setTimeoutStub, clearTimeout: clearTimeoutStub, setInterval: setIntervalStub, clearInterval: clearIntervalStub,
+  fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [], next: 0 }) }),
+  URLSearchParams, Promise, JSON, Set, Array, Object, String, Boolean, Number, console,
+};
+sandbox.window = sandbox; sandbox.window.window = sandbox;
+sandbox.Date = { now: () => NOW };
+vm.createContext(sandbox);
+
+function load(p, stripBootstrap) {
+  let src = fs.readFileSync(p, 'utf8');
+  if (stripBootstrap) { const i = src.indexOf('ReactDOM.createRoot'); if (i !== -1) src = src.slice(0, i); }
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+load(%(screen_table)s);
+load(%(app)s, true);
+
+const useLiveSession = sandbox.window.useLiveSession;
+if (typeof useLiveSession !== 'function') throw new Error('useLiveSession not exported');
+const state = { activeCampaign: 'camp1', campaigns: [{ id: 'camp1', campaign_id: 'camp1' }] };
+reactHost.mount(() => useLiveSession(state));
+const win = sandbox.window;
+const h = {
+  now: () => NOW,
+  advance,
+  pending: () => reactHost.api().pending,
+  arm: (text) => reactHost.api().armPending(text || 'do something'),
+  clear: () => reactHost.api().clearPending(),
+  abandon: (text) => (typeof reactHost.api().abandonPending === 'function'
+      ? reactHost.api().abandonPending(text)
+      : (() => { throw new Error('abandonPending not exported'); })()),
+  hasAbandon: () => typeof reactHost.api().abandonPending === 'function',
+};
+const script = %(script)s;
+(async () => {
+  const out = await script(h, win);
+  process.stdout.write(JSON.stringify(out));
+})().catch((e) => { process.stderr.write(String(e && e.stack || e)); process.exit(1); });
+"""
+
+
+def _run_hook(script_js: str) -> dict:
+    program = _HARNESS % {
+        "babel": json.dumps(str(BABEL)),
+        "screen_table": json.dumps(str(SCREEN_TABLE)),
+        "app": json.dumps(str(APP_JSX)),
+        # `script_js` is a raw JS arrow-function body — injected verbatim (NOT JSON-quoted), exactly
+        # like test_recovery_timing.py's `%(script)s`. The harness assigns `const script = <it>;`.
+        "script": script_js,
+    }
+    proc = subprocess.run(
+        [_node(), "--input-type=commonjs"], input=program, text=True, capture_output=True, timeout=60
+    )
+    if proc.returncode != 0:
+        raise AssertionError(f"node failed: {proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+def test_826_in_flight_gate_survives_immediately_after_arm():
+    # The optimistic arm: the instant the player commits (armPending called BEFORE the network
+    # resolves), the one-move gate is live — so a nav-away/nav-back that remounts ScreenTable (its
+    # local submittingRef resets) still sees `pending` truthy and blocks a second submit. We assert
+    # the gate is up RIGHT after arm (t=0), with no advance — the in-flight window.
+    out = _run_hook(
+        "async (h) => { h.arm('I open the door'); "
+        "return { pendingRightAfterArm: !!h.pending(), text: h.pending() && h.pending().text }; }"
+    )
+    assert out["pendingRightAfterArm"], "the gate must be armed in the in-flight window (before the POST resolves)"
+    assert out["text"] == "I open the door"
+
+
+def test_826_abandon_pending_clears_optimistic_arm_within_grace():
+    # A genuine POST rejection must be able to ROLL BACK the optimistic arm immediately — even inside
+    # the #648 arm-grace (which deliberately ignores a SPURIOUS clearPending). abandonPending is the
+    # authoritative rollback (the move was rejected by the server), so it must clear NOW, not wait for
+    # the recovery window. Distinct from clearPending, which #648 grace correctly swallows here.
+    # advance(500) stays well inside the 10s arm-grace; clear() is the spurious clear #648 ignores;
+    # abandon() is the authoritative rollback that must clear NOW.
+    out = _run_hook(
+        "async (h) => { "
+        "h.arm('rejected move'); "
+        "const armed = !!h.pending(); "
+        "h.advance(500); "
+        "h.clear(); const stillThereAfterClear = !!h.pending(); "
+        "h.abandon('rejected move'); const goneAfterAbandon = !h.pending(); "
+        "return { hasAbandon: h.hasAbandon(), armed, stillThereAfterClear, goneAfterAbandon }; }"
+    )
+    assert out["hasAbandon"], "useLiveSession must export abandonPending (the optimistic-arm rollback)"
+    assert out["armed"], "armPending must arm a turn"
+    assert out["stillThereAfterClear"], "#648 arm-grace must still ignore a spurious clearPending"
+    assert out["goneAfterAbandon"], "abandonPending must authoritatively roll back the optimistic arm"
+
+
+def test_826_abandon_only_rolls_back_the_matching_in_flight_move():
+    # abandonPending must NOT wipe a DIFFERENT in-flight turn — if (somehow) a newer turn is pending,
+    # abandoning the OLD move's text is a no-op (it can't clobber the live turn). Keeps the rollback
+    # surgical: only the move WE optimistically armed and the server rejected gets cleared.
+    # advance(15000) clears the grace so a real clear WOULD work; the mismatched abandon text is a no-op.
+    out = _run_hook(
+        "async (h) => { "
+        "h.arm('newer live move'); "
+        "h.advance(15000); "
+        "h.abandon('an old, different move'); "
+        "return { stillPending: !!h.pending(), text: h.pending() && h.pending().text }; }"
+    )
+    assert out["stillPending"], "abandoning a non-matching move must not clear the live turn"
+    assert out["text"] == "newer live move"


### PR DESCRIPTION
Fixes the two **v1.0.4 viewer orphans** flagged by the engine-audit Section-4 coverage check (rc1+rc2 persona complaints with no prior issue). Both are viewer-scope only — the engine stays sole writer (`viewer/server.py` is the read-only bridge projecting state the engine already wrote; no campaign-state writes, no wire-contract changes).

Source: `docs/audits/ENGINE-AUDIT-2026-06-11.md` (Section-4 orphans #1 + #5). Refs #826, #825.

---

## #826 — Navigating away mid-narration corrupts session state + freezes the scene image (rc2 adversarial)

A user-initiated nav **during an in-flight beat** — distinct from the #745/#648 *stalled-beat* trigger. Two independent legs:

**1. State corruption (double-fire).** `postMove` armed the one-move gate only **after** the `/move` POST resolved. If the player navigated away (Table→Map) during the in-flight POST and back, ScreenTable remounted with a fresh `submittingRef=false` **and** `pending=null` → the action bar re-opened → a second move could **double-fire the one-move-at-a-time lane**.
  - Fix: arm the gate **optimistically before the await**. The arm + echo live in the app-level `useLiveSession` hook, so they **survive ScreenTable unmounting**. On a POST rejection, roll back via a new, surgical `abandonPending(text)` that **bypasses the #648 arm-grace** (an authoritative server rejection is not a spurious clear) and only clears the move we armed — never a newer live turn.
  - Preserves the **#745/#746 recovery contract** and the **#399/#406 first-beat window** (`armPending`/`notePendingProgress` untouched).

**2. Scene-image freeze (dead handle).** `chrome.jsx` `Img` latched `failed` on the first `onError` and only ever cleared it on a **scope change** — so a #399 fire-and-forget scene that 404s while its art is still being generated stayed **frozen on the placeholder forever**, even once the same-scope image became servable.
  - Fix: bounded, backed-off, cache-busted retries so the component **recovers when the pending art lands** (and stops after the budget for a genuinely-missing image). No dead latch.

## #825 — Chronicle truncates DM narration mid-word at a fixed ceiling (3 personas: rc2 adversarial+narrative, rc1 veteran)

The chronicle's leading history band (`_session_recent_events`) hard-cut every row to `text[:1000]`, slicing a long DM beat **mid-word** with no ellipsis/expand — the remainder unreadable.
  - Fix: render the **full beat** (`_bounded_chronicle_text`). The render region is already a scrollable `role="log"`, and the **#752 a11y bound is the ROW cap** (`CHRONICLE_RENDER_CAP` / `MAX_LIVE_BEATS`), **not** a per-row char ceiling — so removing the cut does not reintroduce the #752 a11y-tree flood. Only a generous DoS guard remains (64 KB, far above any real beat), and even it cuts on a word boundary.
  - The combat battle-log's separate `text[:1000]` (terse round summaries, not DM prose) is intentionally **out of scope**.

---

## Tests (TDD via the JSX behaviour harness — `test_recovery_timing.py` pattern)

New `viewer/tests/test_nav_chronicle_resilience.py` (7 tests, all green):
- **#826 state:** optimistic-arm-survives-the-in-flight-window + authoritative `abandonPending` rollback (bypasses the #648 grace) + abandon-is-surgical (won't clobber a newer live turn).
- **#826 image:** the real `Img` recovers (re-mounts a cache-busted `<img>`) after a recoverable `onError`, instead of freezing on a dead handle.
- **#825 chronicle:** a long DM beat round-trips in full through `_session_recent_events` — no mid-word truncation; the exact 1000-char regression is pinned.

**Verification:**
- New file: `7 passed`.
- Full viewer suite: `505 passed, 1 skipped`.
- `qa/fast_gate.sh` Tier-0: `195 passed` ✅.

**Invariants held:** engine sole-writer untouched; additive-by-default (`abandonPending` is a new exported callback; old `clearPending` fallback kept for older bundles; `Img` URL keeps the `/image?scope=` shape on the happy path); wire contracts frozen.

Final GUI confirmation comes from the re-measure sweep — this PR is the sound fix + the deterministic JSX-harness proof. **Do not merge** pending that sweep.