### PR TITLE
fix(qa): render expired-effect NAME in soft-tick carry-forward, not raw dict repr (F04-2 follow-up)

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -1020,7 +1020,22 @@ try:
     # effect expiries). Empty channels add NOTHING (no carry file, no token cost on a quiet
     # tick). Best-effort: a write failure never fails the loop (the tick already advanced).
     def _lines(v):
-        return [str(x).strip() for x in (v or []) if str(x).strip()]
+        # Channels differ in item shape: world_beats / world_developments are plain
+        # strings, but expired_effects is list[{character_id, name}] (see
+        # _expire_clock_effects_all in servers/engine/server.py). Render the human-
+        # readable name for a dict item (falling back to str(x) only if it has no usable
+        # "name"), and pass strings through unchanged — so the expiry line reads
+        # "Bless, Mage Armor", NOT the raw "{'character_id': 'pc-1', 'name': 'Bless'}"
+        # dict repr the player would otherwise see (F04-2 follow-up).
+        out = []
+        for x in (v or []):
+            if isinstance(x, dict):
+                s = str(x.get("name") or "").strip() or str(x).strip()
+            else:
+                s = str(x).strip()
+            if s:
+                out.append(s)
+        return out
     beats = _lines(r.get("world_beats"))
     devs = _lines(r.get("world_developments"))
     exps = _lines(r.get("expired_effects"))

--- a/qa/tests/_seed_softtick_fixture.py
+++ b/qa/tests/_seed_softtick_fixture.py
@@ -1,5 +1,9 @@
-"""F04-2 fixture: seed a campaign with a thread-beat due TODAY so the harness soft-tick's
-advance_time(phases=1) fires it into `world_beats` — the content the leak used to discard.
+"""F04-2 fixture: seed a campaign with (a) a thread-beat due TODAY so the harness soft-tick's
+advance_time(phases=1) fires it into `world_beats`, AND (b) a minute-scale clock effect that
+EXPIRES on that same phase advance so it lands in `expired_effects` — the two living-world
+channels the leak used to discard. The expiry channel is list[{character_id, name}] (NOT plain
+strings like the others), which is why its carry line must render the effect NAME, not the raw
+dict repr (F04-2 follow-up).
 
 Run with WORLDOS_STATE_DIR/CLAWDND_STATE_DIR pointed at a temp state dir (the shell proof
 does this). Prints ONLY the campaign id on success so the caller can capture it.
@@ -19,7 +23,7 @@ if _engine not in sys.path:
 
 import server  # noqa: E402
 import store  # noqa: E402
-from models import Consequence  # noqa: E402
+from models import ActiveEffect, Consequence  # noqa: E402
 
 
 def main() -> int:
@@ -38,6 +42,15 @@ def main() -> int:
             thread_id="thread-fixture-f042",
         )
     )
+    # A minute-scale clock effect that EXPIRES on the soft-tick's phase advance: out of combat,
+    # ANY time-of-day phase advance expires a round/minute-scale effect
+    # (combat.expire_clock_effects), so advance_time(phases=1) reports it in `expired_effects`.
+    # That channel is list[{character_id, name}] (dicts, unlike the string-valued world_beats /
+    # world_developments), so the carry line must surface the effect NAME ("Bless"), never the
+    # raw "{'character_id': ..., 'name': 'Bless'}" dict repr (the F04-2-follow-up bug).
+    pc = next(iter(c.characters.values()))
+    pc.active_effects.append(ActiveEffect(name="Bless", scale="minutes", rounds_remaining=10))
+
     # Put the clock at evening so advance_time(phases=1) rolls a real phase (steps > 0 -> tick).
     c.time_of_day = "evening"
     store.save_campaign(c)

--- a/qa/tests/test_softtick_carryforward.sh
+++ b/qa/tests/test_softtick_carryforward.sh
@@ -58,6 +58,20 @@ if [ -f "$CARRY" ]; then
   else
     fail "carry file missing the fired beat text. Contents:"; sed 's/^/      /' "$CARRY"
   fi
+  # --- EXPIRY CHANNEL (the dict-repr leak). The expired clock effect (Bless) must surface as
+  #     its clean NAME on the "effects that ran out" line, NEVER as the raw {character_id, name}
+  #     dict repr. The engine returns expired_effects as list[{character_id, name}]; before the
+  #     fix str(x) rendered the whole dict, leaking "character_id" + braces to the player. -----
+  if grep -q "effects that ran out overnight: .*Bless" "$CARRY"; then
+    pass "carry file carries the expired effect's clean NAME (Bless)"
+  else
+    fail "carry file missing the clean expired-effect name. Contents:"; sed 's/^/      /' "$CARRY"
+  fi
+  if grep -q "character_id" "$CARRY"; then
+    fail "carry file leaked the raw dict repr (found 'character_id'). Contents:"; sed 's/^/      /' "$CARRY"
+  else
+    pass "carry file does NOT leak the raw dict repr (no 'character_id')"
+  fi
 else
   fail "soft-tick did NOT write a carry file (the F04-2 leak)"
 fi


### PR DESCRIPTION
## Problem

The F04-2 soft-tick carry-forward (PR #850, `qa/lib_beat_driver.sh` → `clawdnd_soft_tick`'s embedded Python heredoc) surfaces the engine's `expired_effects` to the DM. But `server.advance_time()` returns `expired_effects` as `list[dict]` — each item is `{"character_id": ..., "name": ...}` (`_expire_clock_effects_all`, `servers/engine/server.py:6124`). The shared `_lines` helper did `str(x)` on every item, so the expiry line leaked the raw dict repr to the DM:

```
- effects that ran out overnight: {'character_id': 'pc-1', 'name': 'Bless'}, {'character_id': 'pc-2', 'name': 'Mage Armor'}
```

`world_beats` / `world_developments` are already clean strings, so ONLY the expiry channel was affected.

## Fix

Make `_lines` dict-aware: for a dict item render `x["name"]` (fall back to `str(x)` if there's no usable name); pass strings through unchanged. The expiry line now reads:

```
- effects that ran out overnight: Bless, Mage Armor
```

Byte-identical behavior for the string-valued channels (only dict items get the new path).

## Test coverage

The existing fixture (`qa/tests/_seed_softtick_fixture.py`) only seeded a thread-beat, so the **expiry channel was untested**. This PR:

- Seeds a minute-scale `ActiveEffect` ("Bless") on the PC that expires on the soft-tick's `advance_time(phases=1)` phase advance → lands in `expired_effects`.
- Adds two assertions to `qa/tests/test_softtick_carryforward.sh`: the carry block contains the clean name **Bless**, and does **NOT** contain the substring `character_id`.

### Red→green proof
- With the fix: F04-2 PROOF **PASS** (13/13).
- Reverting only the `_lines` fix: the `character_id` assertion **FAILS**, showing the exact leak `- effects that ran out overnight: {'character_id': 'char_...', 'name': 'Bless'}`.

## Invariants
- QA-harness-only change; no engine code touched (engine stays the sole writer). Additive — old snapshots and the string channels are unaffected. Local single-process deterministic `$0`/no-LLM proof.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed soft-clock carry-forward processing to display expired effects with human-readable names instead of raw internal data structures.

* **Tests**
  * Updated test fixtures to include clock effects that expire during time advancement and strengthened assertions to verify clean effect names are displayed and internal data is not exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->