### PR TITLE
fix(#756): item inspector shows AC / damage / Versatile two-handed / properties + Examine panel + compare-to-equipped

### DIFF
--- a/servers/engine/itemcatalog.py
+++ b/servers/engine/itemcatalog.py
@@ -187,15 +187,83 @@ def _weapon_armor_join() -> tuple[dict, dict]:
     return weapons, armors
 
 
-def _flatten(model: str, fields: dict) -> dict:
+@functools.lru_cache(maxsize=None)
+def _weapon_property_join() -> dict[str, dict]:
+    """{weapon_pk: {"properties": [name, …], "versatile": "1d8"}} from the SRD
+    ``WeaponProperty.json`` + ``WeaponPropertyAssignment.json`` tables (#756).
+
+    A weapon's classic properties (Versatile, Finesse, Light, Thrown, Two-Handed,
+    Heavy, Reach, Ammunition, Loading, Reach) and — for a Versatile weapon — its
+    two-handed damage die are stored ONLY in the assignment join, not inline on the
+    Weapon record. The flatten dropped them, so the inspector showed "no Versatile
+    property" and no 1d8 two-handed damage (the RRI-5e98e6f optimizer findings). We
+    recover them read-only here.
+
+    The 2024 weapon-MASTERY properties (Topple/Nick/Sap/Graze/Slow/Vex/Cleave…,
+    ``type == "Mastery"``) are an advanced combat-option layer, not item descriptors a
+    buyer evaluates, so they are deliberately excluded from the chip list — only the
+    base properties (``type`` null) are surfaced. ``versatile`` carries the assignment
+    ``detail`` (the two-handed die, e.g. "1d8"); absent → "". Keyed by pk (the FK)."""
+    # property_pk -> {name, type}
+    prop_meta: dict[str, dict] = {}
+    for d in _dirs():
+        for r in _rows(d / "WeaponProperty.json"):
+            if not isinstance(r, dict):
+                continue
+            pk = r.get("pk")
+            f = r.get("fields") or {}
+            if pk and pk not in prop_meta:
+                prop_meta[pk] = {"name": str(f.get("name") or ""), "type": f.get("type")}
+    out: dict[str, dict] = {}
+    seen: dict[str, set] = {}
+    for d in _dirs():
+        for r in _rows(d / "WeaponPropertyAssignment.json"):
+            if not isinstance(r, dict):
+                continue
+            f = r.get("fields") or {}
+            wpk = f.get("weapon")
+            ppk = f.get("property")
+            if not wpk or not ppk:
+                continue
+            meta = prop_meta.get(ppk)
+            if not meta or not meta["name"]:
+                continue
+            slot = out.setdefault(wpk, {"properties": [], "versatile": ""})
+            seen_for = seen.setdefault(wpk, set())
+            name = meta["name"]
+            # Versatile: keep its two-handed die (the assignment `detail`).
+            if name.lower() == "versatile" and not slot["versatile"]:
+                slot["versatile"] = str(f.get("detail") or "")
+            # Base (non-Mastery) properties become item-descriptor chips; Mastery
+            # options are excluded. De-dupe per weapon, preserve first-seen order.
+            if meta["type"] is None and name not in seen_for:
+                seen_for.add(name)
+                slot["properties"].append(name)
+    return out
+
+
+def _flatten(model: str, fields: dict, pk: str = "") -> dict:
     """Flatten one source record (any of the 4 shapes) into the common catalog
     item dict. ``model`` is the fixture model tail ('magicitem'/'item'/'weapon'/
-    'armor') used to pick the right shape."""
+    'armor') used to pick the right shape. ``pk`` is the source record's primary
+    key — used (#756) to look up a weapon's property assignments (Versatile/Finesse/
+    Two-Handed + the versatile two-handed die) by FK."""
     weapons, armors = _weapon_armor_join()
+    wprops = _weapon_property_join()
     name = fields.get("name", "")
 
     if model == "weapon":
         # Bare Weapon.json record: damage inline, no cost/desc/category.
+        props = [
+            p for p, on in (("simple", fields.get("is_simple")),
+                            ("improvised", fields.get("is_improvised"))) if on
+        ]
+        # #756: fold in the SRD weapon properties (Versatile/Finesse/…) + the
+        # versatile two-handed die from the assignment join, keyed by this pk.
+        extra = wprops.get(pk, {})
+        for chip in extra.get("properties", []):
+            if chip not in props:
+                props.append(chip)
         return {
             "name": name,
             "kind": "weapon",
@@ -204,12 +272,10 @@ def _flatten(model: str, fields: dict) -> dict:
             "weight": _num(fields.get("weight")),
             "cost": _cost(fields.get("cost")),
             "description": fields.get("desc", "") or "",
-            "properties": [
-                p for p, on in (("simple", fields.get("is_simple")),
-                                ("improvised", fields.get("is_improvised"))) if on
-            ],
+            "properties": props,
             "damage": fields.get("damage_dice") or "",
             "damage_type": fields.get("damage_type") or "",
+            "versatile": extra.get("versatile", ""),
         }
 
     if model == "armor":
@@ -260,6 +326,14 @@ def _flatten(model: str, fields: dict) -> dict:
         wf = weapons[wfk]
         record["damage"] = wf.get("damage_dice") or ""
         record["damage_type"] = wf.get("damage_type") or ""
+        # #756: a magic weapon inherits its base weapon's SRD properties + versatile
+        # two-handed die via the same FK (de-duped onto the attunement clause above).
+        wp = wprops.get(wfk, {})
+        for chip in wp.get("properties", []):
+            if chip not in record["properties"]:
+                record["properties"].append(chip)
+        if wp.get("versatile"):
+            record["versatile"] = wp["versatile"]
     afk = fields.get("armor")
     if afk and afk in armors:
         af = armors[afk]
@@ -296,24 +370,44 @@ def _index() -> dict[str, dict]:
                 key = name.lower()
                 if key not in out:  # FIRST-WINS — earlier dir/source takes precedence
                     try:  # one malformed record must never sink the whole catalog (H1)
-                        out[key] = _flatten(model, fields)
+                        out[key] = _flatten(model, fields, r.get("pk") or "")
                     except (TypeError, ValueError, AttributeError, KeyError):
                         continue
     return out
 
 
+# #756: the canonical-name suffixes a base item name is shortened FROM. Markets/
+# inventories carry the colloquial short form ("Studded Leather", "Leather", "Plate")
+# but the SRD catalog keys the full canonical name ("Studded Leather Armor"). A bare
+# substring of the short form is AMBIGUOUS (it also matches "Glamoured Studded
+# Leather", "Armor of Resistance (Studded Leather)", …) -> None -> no AC value, the
+# CRITICAL gate-flipper. Trying the base name + a canonical suffix gives an EXACT key
+# hit, which is precise and never ambiguous.
+_BASE_NAME_SUFFIXES = (" Armor", " Weapon")
+
+
 def resolve(name: str) -> Optional[dict]:
     """The catalog record for an item by (case-insensitive) name, or None.
 
-    Tries an exact normalized match first, then a single unambiguous substring
-    match (so 'bag of holding' and ' Longsword ' both resolve). Returns None when
-    absent or ambiguous — the caller should then offer ``find()`` suggestions."""
+    Tries an exact normalized match first, then a base-name + canonical-suffix exact
+    match (so 'Studded Leather' -> 'Studded Leather Armor'; #756), then a single
+    unambiguous substring match (so 'bag of holding' and ' Longsword ' both resolve).
+    Returns None when absent or ambiguous — the caller should then offer ``find()``
+    suggestions."""
     if not name:
         return None
     idx = _index()
-    rec = idx.get(name.strip().lower())
+    norm = name.strip().lower()
+    rec = idx.get(norm)
     if rec is not None:
         return rec
+    # #756: the colloquial short form + a canonical suffix is an EXACT (unambiguous)
+    # key — preferred over the fuzzy substring branch so "Studded Leather" resolves to
+    # "Studded Leather Armor" (carrying its real AC) instead of going ambiguous->None.
+    for suffix in _BASE_NAME_SUFFIXES:
+        rec = idx.get(norm + suffix.lower())
+        if rec is not None:
+            return rec
     matches = find(name, limit=2)
     if len(matches) == 1:
         # find() returns the flattened records themselves (F09-1: this used to

--- a/servers/engine/tests/test_itemcatalog.py
+++ b/servers/engine/tests/test_itemcatalog.py
@@ -118,6 +118,82 @@ def test_resolve_ambiguous_substring_returns_none():
     assert itemcatalog.resolve("potion of") is None
 
 
+# --- #756: base-name disambiguation + weapon property/versatile enrichment ---
+
+
+def test_resolve_base_armor_name_disambiguates_to_canonical_record():
+    """#756 (the CRITICAL gate-flipper from the RRI-5e98e6f optimizer sweep): the
+    market/inventory show 'Studded Leather' but the catalog keys it 'Studded Leather
+    Armor', and a bare-substring resolve is AMBIGUOUS (Armor of Resistance (Studded
+    Leather), Glamoured Studded Leather, …) -> None -> no AC value -> 'impossible to
+    evaluate the upgrade'. The base name + an armor/weapon suffix must resolve to the
+    canonical record so the inspector shows the real AC."""
+    rec = itemcatalog.resolve("Studded Leather")
+    assert rec is not None, "'Studded Leather' must resolve (it did not before #756)"
+    assert rec["name"] == "Studded Leather Armor"
+    assert rec["kind"] == "armor"
+    assert rec["ac"] == 12  # the real base AC the optimizer could not see
+    # the short forms a merchant/inventory actually carry all resolve
+    for short in ("studded leather", "Leather", "Plate", "Hide", "Splint"):
+        assert itemcatalog.resolve(short) is not None, short
+
+
+def test_base_name_disambiguation_does_not_override_an_exact_or_ambiguous_match():
+    # An exact key still wins (no regression): "Leather Armor" stays itself.
+    assert itemcatalog.resolve("Leather Armor")["name"] == "Leather Armor"
+    # A genuinely ambiguous prefix that is NOT a base+suffix name stays None.
+    assert itemcatalog.resolve("potion of") is None
+
+
+def test_resolve_weapon_exposes_versatile_two_handed_damage():
+    """#756: a Versatile weapon hides its two-handed die. The SRD stores it in
+    WeaponPropertyAssignment (versatile-wp detail '1d8' for the Quarterstaff); the
+    flattened record must surface it as `versatile` so the inspector can read
+    '1d6 (1d8 two-handed)' — the optimizer's 'Examine is missing the 1d8 two-handed
+    damage' finding."""
+    rec = itemcatalog.resolve("Quarterstaff")
+    assert rec is not None
+    assert rec["damage"] == "1d6"
+    assert rec["versatile"] == "1d8"
+
+
+def test_resolve_weapon_exposes_real_properties():
+    """#756: weapon properties (Versatile, Finesse, Light, Two-Handed, …) live in
+    WeaponPropertyAssignment, not inline — the flatten dropped them, so the inspector
+    had 'no Versatile property'. They must now appear on the record."""
+    qs = itemcatalog.resolve("Quarterstaff")
+    assert "Versatile" in qs["properties"]
+    # a finesse weapon carries Finesse; a longbow carries Two-Handed/Ammunition.
+    dagger = itemcatalog.resolve("Dagger")
+    assert dagger is not None and "Finesse" in dagger["properties"]
+    longbow = itemcatalog.resolve("Longbow")
+    assert longbow is not None and "Two-Handed" in longbow["properties"]
+
+
+def test_bare_weapon_flatten_merges_simple_flag_with_srd_properties():
+    # The pre-existing is_simple/is_improvised flags must not be dropped when the SRD
+    # WeaponProperty chips are merged in (additive, de-duped). The bare Weapon.json
+    # record carries is_simple; the FK join adds Versatile — both must survive on the
+    # SAME flattened record. (NB: the public catalog resolves "Quarterstaff" to the
+    # Item.json record, whose is_simple is null — so this asserts the weapon-shape
+    # flatten directly, the path a non-Item-shadowed simple weapon takes.)
+    rec = itemcatalog._flatten(
+        "weapon",
+        {"name": "Quarterstaff", "is_simple": True, "damage_dice": "1d6",
+         "damage_type": "bludgeoning"},
+        "srd-2024_quarterstaff",
+    )
+    assert "simple" in rec["properties"]
+    assert "Versatile" in rec["properties"]
+    assert rec["versatile"] == "1d8"
+
+
+def test_non_versatile_weapon_has_no_versatile_key_value():
+    # A weapon with no versatile assignment must not fabricate a two-handed die.
+    rec = itemcatalog.resolve("Dagger")
+    assert rec.get("versatile", "") == ""
+
+
 def test_pack_precedence_srd_wins_and_pack_adds(tmp_path, monkeypatch):
     """A content pack never overrides an SRD item of the same name (srd524 is
     first-wins) but DOES contribute its own new items."""

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -52,6 +52,9 @@ function ScreenInventory({ onNavigate, state, setState }) {
   const [activeHero, setActiveHero] = React.useState("");
   const [selectedItem, setSelectedItem] = React.useState(null);
   const [ctxMenu, setCtxMenu] = React.useState(null);
+  // #756: a monotonically-bumped nonce the right-click "Examine" raises so the detail
+  // pane opens its read-only Examine PANEL (not a toast). ItemDetail watches it.
+  const [examineNonce, setExamineNonce] = React.useState(0);
   const toast = window.useToast ? window.useToast() : (() => {});
 
   // Phase-4 wiring: when a live session is attached the surface reports can_act +
@@ -292,7 +295,7 @@ function ScreenInventory({ onNavigate, state, setState }) {
 
       {/* RIGHT — Item detail */}
       <Panel framed style={{ padding: 22, overflow: "auto" }}>
-        {selectedItem ? <ItemDetail item={selectedItem} hero={hero} toast={toast} canAct={canAct} postInvMove={postInvMove} /> : <div className="muted">Select an item.</div>}
+        {selectedItem ? <ItemDetail item={selectedItem} hero={hero} toast={toast} canAct={canAct} postInvMove={postInvMove} examineSignal={examineNonce} /> : <div className="muted">Select an item.</div>}
       </Panel>
 
       {ctxMenu && (
@@ -300,7 +303,7 @@ function ScreenInventory({ onNavigate, state, setState }) {
           x={ctxMenu.x} y={ctxMenu.y}
           onClose={() => setCtxMenu(null)}
           items={[
-            { label: "Examine", icon: "◈", hint: "E", onClick: () => toast({ kind: "item", title: ctxMenu.item.name, body: ctxMenu.item.desc }) },
+            { label: "Examine", icon: "◈", hint: "E", title: "Open the read-only Examine panel", onClick: () => { setSelectedItem(ctxMenu.item); setExamineNonce((n) => n + 1); } },
             canAct
               ? { label: "Equip", icon: "⚔", hint: "Q", title: "Relays to the DM via /move — the engine resolves it", onClick: () => postInvMove("do", { text: "I equip " + ctxMenu.item.name + "." }, { kind: "item", title: "Equipping " + ctxMenu.item.name, body: hero.name + " takes it up — relayed to the DM." }) }
               : { label: "Equip (preview)", icon: "⚔", hint: "Q", disabled: true, title: "Display-only — start a live session to act", onClick: () => toast({ kind: "item", title: "Equipped: " + ctxMenu.item.name, body: hero.name + " takes it up." }) },
@@ -517,7 +520,102 @@ function ItemSlot({ item, selected, onClick, onContextMenu, onContextKey }) {
   );
 }
 
-function ItemDetail({ item, hero, toast, canAct, postInvMove }) {
+// #756: pure stat-row builder for the item inspector — the SAME logic the harness
+// drives so "an armor inspector shows its AC" / "a versatile weapon shows 1d8 two-handed"
+// is proven against the real code, not a string grep. Each row is {k, v}; a field the
+// catalog didn't resolve is simply omitted (never a fabricated number). Damage folds the
+// Versatile two-handed die inline ("1d6 bludgeoning (1d8 two-handed)") — the optimizer's
+// "Examine is missing the Versatile property and the 1d8 two-handed damage" finding.
+function itemStatRows(item) {
+  if (!item) return [];
+  const rows = [];
+  rows.push({ k: "Weight", v: item.weight || "—" });
+  rows.push({ k: "Value", v: item.value || "—" });
+  if (item.damage) {
+    const dmg = [item.damage, item.damageType].filter(Boolean).join(" ");
+    const v = item.versatile ? `${dmg} (${item.versatile} two-handed)` : dmg;
+    rows.push({ k: "Damage", v });
+  }
+  if (typeof item.ac === "number") rows.push({ k: "Armor Class", v: String(item.ac) });
+  if (item.attunement) rows.push({ k: "Attunement", v: "Required" });
+  return rows;
+}
+
+// #756: compare a candidate item against what the hero currently has equipped in the
+// same conceptual slot, so the inspector can answer "is this an upgrade?" — the
+// optimizer's "no compare-on-hover anywhere in inventory or market". Returns null when
+// there is nothing comparable (no equipped peer, or neither carries a comparable stat).
+// Pure + display-only: reads hero.equipped (live read-model), writes nothing.
+function itemCompareRows(item, equipped) {
+  if (!item || !Array.isArray(equipped) || !equipped.length) return null;
+  // The peer is the equipped item inferred into the SAME doll slot as this candidate.
+  const slotOf = window.inferEquipSlotId ? window.inferEquipSlotId : () => "";
+  const mySlot = slotOf(item.name);
+  if (!mySlot) return null;
+  const peer = equipped.find((e) => e && e.name && slotOf(e.name) === mySlot && e.name !== item.name);
+  if (!peer) return null;
+  const rows = [];
+  // AC delta (armor): both numeric.
+  if (typeof item.ac === "number" && typeof peer.ac === "number") {
+    rows.push({ k: "Armor Class", mine: item.ac, theirs: peer.ac, delta: item.ac - peer.ac });
+  }
+  // Damage (weapons): compared as strings (dice exprs aren't linearly orderable), so just
+  // surface both sides — the player reads the upgrade. delta is null (no numeric ordering).
+  if (item.damage && peer.damage && item.damage !== peer.damage) {
+    rows.push({ k: "Damage", mine: item.damage, theirs: peer.damage, delta: null });
+  }
+  if (!rows.length) return null;
+  return { peer: peer.name, rows };
+}
+
+function ItemDetail({ item, hero, toast, canAct, postInvMove, examineSignal }) {
+  // #756: Examine opens a real read-only PANEL (the full description + every resolved
+  // stat), not a fleeting toast — the optimizer's "Examine fires a toast ONLY". Local
+  // display state; closing returns to the standard inspector. Reset when the item changes.
+  const [examineOpen, setExamineOpen] = React.useState(false);
+  React.useEffect(() => { setExamineOpen(false); }, [item && item.id]);
+  // The right-click "Examine" raises examineSignal (a nonce). Open the panel when it
+  // changes to a truthy value (the first bump after a fresh selection).
+  React.useEffect(() => { if (examineSignal) setExamineOpen(true); }, [examineSignal]);
+  const statRows = itemStatRows(item);
+  const compare = itemCompareRows(item, hero && hero.equipped);
+
+  if (examineOpen) {
+    return (
+      <div role="dialog" aria-label={"Examine " + (item.name || "item")}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+          <div className="eyebrow" style={{ color: "var(--royal)" }}>Examining</div>
+          <BrassButton tone="ghost" size="sm" onClick={() => setExamineOpen(false)} aria-label="Close examine panel">Close</BrassButton>
+        </div>
+        <div style={{ display: "flex", gap: 14, alignItems: "flex-start", marginTop: 6 }}>
+          <Img scope={itemScope(item)} label={item.name} w={88} h={88} framed />
+          <div style={{ minWidth: 0 }}>
+            <h2 className="h1" style={{ fontSize: 20, lineHeight: 1.1 }}>{item.name}</h2>
+            <div className="hand" style={{ fontSize: 13, color: "var(--ink-700)" }}>{itemCategory(item)}</div>
+          </div>
+        </div>
+        <Divider />
+        <p className="body" style={{ marginTop: 0, fontSize: 15 }}>{item.desc}</p>
+        {statRows.length > 0 && (
+          <>
+            <div className="eyebrow">Particulars</div>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginTop: 6 }}>
+              {statRows.map((r) => <StatLine key={r.k} k={r.k} v={r.v} />)}
+            </div>
+          </>
+        )}
+        {Array.isArray(item.properties) && item.properties.length > 0 && (
+          <>
+            <div className="eyebrow" style={{ marginTop: 12 }}>Properties</div>
+            <div className="tag-row" style={{ marginTop: 6, display: "flex", gap: 6, flexWrap: "wrap" }}>
+              {item.properties.map((p) => <Pill key={p}>{p}</Pill>)}
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div>
       <div style={{ display: "flex", gap: 14, alignItems: "flex-start" }}>
@@ -546,17 +644,39 @@ function ItemDetail({ item, hero, toast, canAct, postInvMove }) {
       </p>
 
       {/* Stat block — Weight/Value always (catalog-backfilled), plus the REAL combat stats the
-          read-model now surfaces from the SRD item catalog: damage dice + type for weapons, base
-          AC for armor/shields. A field absent from the catalog record is simply not rendered —
-          never a fabricated number (e.g. a free-text "Longsword +1" the catalog can't resolve
-          shows weight/value only, exactly today's behavior). */}
+          read-model now surfaces from the SRD item catalog: damage dice + type for weapons (with
+          the Versatile two-handed die folded in, #756), base AC for armor/shields. A field absent
+          from the catalog record is simply not rendered — never a fabricated number (e.g. a
+          free-text "Longsword +1" the catalog can't resolve shows weight/value only). Built from
+          the pure itemStatRows() so the harness drives the exact shipped rows. */}
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginTop: 14 }}>
-        <StatLine k="Weight" v={item.weight || "—"} />
-        <StatLine k="Value" v={item.value || "—"} />
-        {item.damage && <StatLine k="Damage" v={[item.damage, item.damageType].filter(Boolean).join(" ")} />}
-        {typeof item.ac === "number" && <StatLine k="Armor Class" v={`${item.ac}`} />}
-        {item.attunement && <StatLine k="Attunement" v="Required" />}
+        {statRows.map((r) => <StatLine key={r.k} k={r.k} v={r.v} />)}
       </div>
+
+      {/* #756: compare-to-equipped — "is this an upgrade?" The optimizer flagged the absence of any
+          compare affordance. Shown only when a comparable peer is equipped in the same slot. */}
+      {compare && (
+        <>
+          <Divider />
+          <div className="eyebrow">Versus Equipped</div>
+          <div className="muted body-sm" style={{ marginTop: 2 }}>Compared to {compare.peer}</div>
+          <div style={{ display: "grid", gap: 6, marginTop: 6 }}>
+            {compare.rows.map((r) => (
+              <div key={r.k} style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                <span className="muted body-sm">{r.k}</span>
+                <span style={{ fontFamily: "var(--f-mono)", fontSize: 12 }}>
+                  {String(r.mine)} <span className="muted">vs {String(r.theirs)}</span>
+                  {typeof r.delta === "number" && r.delta !== 0 && (
+                    <span style={{ marginLeft: 6, color: r.delta > 0 ? "var(--emerald)" : "var(--crimson)", fontFamily: "var(--f-display)" }}>
+                      {r.delta > 0 ? "+" + r.delta : String(r.delta)}
+                    </span>
+                  )}
+                </span>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
 
       {Array.isArray(item.properties) && item.properties.length > 0 && (
         <>
@@ -593,7 +713,7 @@ function ItemDetail({ item, hero, toast, canAct, postInvMove }) {
             Use (preview)
           </BrassButton>
         )}
-        <BrassButton tone="ghost" size="sm" onClick={() => toast && toast({ kind: "item", title: item.name, body: item.desc })}>Examine</BrassButton>
+        <BrassButton tone="ghost" size="sm" aria-haspopup="dialog" onClick={() => setExamineOpen(true)}>Examine</BrassButton>
         {canAct ? (
           <BrassButton tone="ghost" size="sm" title="Relays to the DM via /move — the engine resolves it" onClick={() => postInvMove("do", { text: "I drop the " + item.name + "." }, { kind: "danger", title: "Dropping " + item.name, body: "Relayed to the DM." })}>
             Drop
@@ -632,4 +752,4 @@ function itemCategory(item) {
 
 function toRoman(n) { return ["", "I", "II", "III", "IV", "V"][n] || n; }
 
-Object.assign(window, { ScreenInventory, CoinSlot, ItemSlot, ItemDetail, EQUIP_SLOTS, PaperDoll, EquipSlotCell, inferEquipSlotId, assignEquipSlots, ITEM_TYPES, ITEM_KINDS, itemCategory, toRoman, slug, itemScope });
+Object.assign(window, { ScreenInventory, CoinSlot, ItemSlot, ItemDetail, EQUIP_SLOTS, PaperDoll, EquipSlotCell, inferEquipSlotId, assignEquipSlots, ITEM_TYPES, ITEM_KINDS, itemCategory, toRoman, slug, itemScope, itemStatRows, itemCompareRows });

--- a/viewer/openworlds/screen-merchant.jsx
+++ b/viewer/openworlds/screen-merchant.jsx
@@ -10,6 +10,32 @@ function mItemScope(item) {
   return s ? "item-" + s : "";
 }
 
+// #756: merge a ware's hardcoded display fields with the read-only /item-catalog stat
+// block (AC / damage / versatile two-handed die / properties / weight / value) so the
+// Market inspector can show what an item IS — the optimizer's CRITICAL "Studded Leather
+// shows no AC value — impossible to evaluate the upgrade". `catalog` is the {name: rec}
+// map fetched from /item-catalog; an unresolved name (rec absent or resolved:false) leaves
+// the ware exactly as today (weight/price only — never a fabricated stat). Pure + additive.
+function enrichWare(item, catalog) {
+  if (!item) return item;
+  const rec = catalog && catalog[item.name];
+  if (!rec || rec.resolved === false) return item;
+  const merged = { ...item };
+  // The ware's OWN explicit fields win; the catalog only fills gaps + supplies the combat
+  // stats the hardcoded stock never carried.
+  if (typeof merged.ac !== "number" && typeof rec.ac === "number") merged.ac = rec.ac;
+  if (!merged.damage && rec.damage) { merged.damage = rec.damage; merged.damageType = rec.damageType; }
+  if (!merged.versatile && rec.versatile) merged.versatile = rec.versatile;
+  if (!merged.weight || merged.weight === "—") { if (rec.weight && rec.weight !== "—") merged.weight = rec.weight; }
+  if (!merged.kind && rec.kind) merged.kind = rec.kind;
+  if (!merged.rarity && rec.rarity) merged.rarity = rec.rarity;
+  if ((!Array.isArray(merged.properties) || !merged.properties.length) && Array.isArray(rec.properties) && rec.properties.length) {
+    merged.properties = rec.properties;
+  }
+  if (rec.attunement) merged.attunement = true;
+  return merged;
+}
+
 function ScreenMerchant({ onNavigate, state, setState }) {
   const [tab, setTab] = React.useState("buy");
   // MK-02/#548: the initial id MUST match a MERCHANTS entry and the first playable BG session
@@ -94,6 +120,43 @@ function ScreenMerchant({ onNavigate, state, setState }) {
   const presentTypes = Array.from(new Set((baseInv || []).map((i) => i.type).filter(Boolean)));
   const inv = typeFilter === "all" ? baseInv : baseInv.filter((i) => i.type === typeFilter);
 
+  // #756: enrich the wares with their real SRD stats from the read-only /item-catalog
+  // endpoint (AC / damage / Versatile two-handed / properties), so the Market inspector can
+  // show what an item IS and the player can evaluate an upgrade. Fetched once per merchant
+  // stock change; an unresolved name leaves the ware untouched (weight/price only).
+  const [catalog, setCatalog] = React.useState({});
+  React.useEffect(() => {
+    const names = Array.from(new Set((baseInv || []).map((i) => i && i.name).filter(Boolean)));
+    if (!names.length) { setCatalog({}); return; }
+    let cancelled = false;
+    const q = names.map((n) => "name=" + encodeURIComponent(n)).join("&");
+    fetch("/item-catalog?" + q, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (!cancelled && d && d.items) setCatalog(d.items); })
+      .catch(() => { /* keep last good; the ware still shows weight/price */ });
+    return () => { cancelled = true; };
+  }, [merchantId, tab]);
+
+  // #756: the party's equipped gear (live inventory surface) so the Market inspector can
+  // compare a ware to what the player already wears ("is this an upgrade?"). Read-only.
+  const [equipped, setEquipped] = React.useState([]);
+  React.useEffect(() => {
+    let cancelled = false;
+    fetch("/inventory-surface" + surfaceQuery, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (cancelled || !d || !Array.isArray(d.party)) return;
+        const all = [];
+        for (const m of d.party) for (const it of (m.equipped || [])) if (it && it.name) all.push(it);
+        setEquipped(all);
+      })
+      .catch(() => { /* no compare peers — the inspector just omits the Versus block */ });
+    return () => { cancelled = true; };
+  }, [surfaceQuery]);
+
+  const enrichedDetail = enrichWare(detailItem, catalog);
+  const detailCompare = window.itemCompareRows ? window.itemCompareRows(enrichedDetail, equipped) : null;
+
   return (
     <div className="screen" style={{ height: "100%", display: "flex", flexDirection: "column", gap: 8, padding: 14 }}>
       <div style={{ flex: 1, display: "grid", gridTemplateColumns: "260px 1fr 280px", gap: 14, minHeight: 0 }}>
@@ -162,27 +225,56 @@ function ScreenMerchant({ onNavigate, state, setState }) {
             ("Market items have no properties or compare pane"). Shows the last-hovered ware's
             facts; honest empty-state until a row is hovered. */}
         <SectionTitle>Item Detail</SectionTitle>
-        {detailItem ? (
+        {enrichedDetail ? (
           <div style={{ display: "flex", flexDirection: "column", gap: 6, marginBottom: 4 }}>
             <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
-              <Img scope={mItemScope(detailItem)} label={detailItem.glyph || detailItem.name} w={44} h={44} fit="contain" framed />
+              <Img scope={mItemScope(enrichedDetail)} label={enrichedDetail.glyph || enrichedDetail.name} w={44} h={44} fit="contain" framed />
               <div style={{ minWidth: 0 }}>
-                <div style={{ fontFamily: "var(--f-display)", fontSize: 14, color: detailItem.type === "rare" ? "var(--royal)" : "var(--ink-900)" }}>{detailItem.name}</div>
-                <Pill>{(window.ITEM_TYPES && window.ITEM_TYPES[detailItem.type]) || detailItem.type || "—"}</Pill>
+                <div style={{ fontFamily: "var(--f-display)", fontSize: 14, color: enrichedDetail.type === "rare" ? "var(--royal)" : "var(--ink-900)" }}>{enrichedDetail.name}</div>
+                <Pill>{(window.ITEM_TYPES && window.ITEM_TYPES[enrichedDetail.type]) || enrichedDetail.type || "—"}</Pill>
               </div>
             </div>
-            <div style={{ display: "flex", justifyContent: "space-between" }}>
-              <span className="muted body-sm">Weight</span>
-              <span style={{ fontFamily: "var(--f-mono)", fontSize: 12 }}>{detailItem.weight || "—"}</span>
-            </div>
+            {/* #756: the REAL stat block — AC for armor, damage (+ Versatile two-handed die) for
+                weapons — built from the same pure itemStatRows() the inventory inspector uses, so
+                the Market can finally answer "what is this?". A field the catalog can't resolve is
+                simply omitted; weight/price always show. */}
+            {(window.itemStatRows ? window.itemStatRows(enrichedDetail) : []).map((r) => (
+              <div key={r.k} style={{ display: "flex", justifyContent: "space-between" }}>
+                <span className="muted body-sm">{r.k}</span>
+                <span style={{ fontFamily: "var(--f-mono)", fontSize: 12 }}>{r.v}</span>
+              </div>
+            ))}
             <div style={{ display: "flex", justifyContent: "space-between" }}>
               <span className="muted body-sm">Price</span>
               <span style={{ fontFamily: "var(--f-mono)", fontSize: 12 }}>
-                {detailItem.price || (typeof detailItem.value === "string" && detailItem.value.match(/(\d+) gp/) ? parseInt(detailItem.value.match(/(\d+) gp/)[1]) : "—")}
+                {enrichedDetail.price || (typeof enrichedDetail.value === "string" && enrichedDetail.value.match(/(\d+) gp/) ? parseInt(enrichedDetail.value.match(/(\d+) gp/)[1]) : "—")}
                 <span className="muted" style={{ fontSize: 9, marginLeft: 2 }}>gp</span>
               </span>
             </div>
-            {detailItem.desc && <p className="body-sm" style={{ marginTop: 2, color: "var(--ink-700)" }}>{detailItem.desc}</p>}
+            {Array.isArray(enrichedDetail.properties) && enrichedDetail.properties.length > 0 && (
+              <div className="tag-row" style={{ display: "flex", gap: 4, flexWrap: "wrap", marginTop: 2 }}>
+                {enrichedDetail.properties.map((p) => <Pill key={p}>{p}</Pill>)}
+              </div>
+            )}
+            {detailCompare && (
+              <div style={{ marginTop: 4, paddingTop: 6, borderTop: "1px solid rgba(140,100,60,0.25)" }}>
+                <div className="eyebrow" style={{ fontSize: 9 }}>Versus {detailCompare.peer}</div>
+                {detailCompare.rows.map((r) => (
+                  <div key={r.k} style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline" }}>
+                    <span className="muted body-sm">{r.k}</span>
+                    <span style={{ fontFamily: "var(--f-mono)", fontSize: 12 }}>
+                      {String(r.mine)} <span className="muted">vs {String(r.theirs)}</span>
+                      {typeof r.delta === "number" && r.delta !== 0 && (
+                        <span style={{ marginLeft: 6, color: r.delta > 0 ? "var(--emerald)" : "var(--crimson)", fontFamily: "var(--f-display)" }}>
+                          {r.delta > 0 ? "+" + r.delta : String(r.delta)}
+                        </span>
+                      )}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+            {enrichedDetail.desc && <p className="body-sm" style={{ marginTop: 2, color: "var(--ink-700)" }}>{enrichedDetail.desc}</p>}
           </div>
         ) : (
           <div className="hand muted" style={{ fontSize: 12, marginBottom: 4 }}>Hover a ware to inspect its properties.</div>
@@ -495,4 +587,4 @@ const MERCHANTS = [
   },
 ];
 
-Object.assign(window, { ScreenMerchant, MERCHANTS, mItemScope });
+Object.assign(window, { ScreenMerchant, MERCHANTS, mItemScope, enrichWare });

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -4167,6 +4167,40 @@ def _catalog_property_chips(meta: dict) -> list[str]:
     return chips
 
 
+def _catalog_stat_block(name: str) -> dict:
+    """#756: the read-only SRD stat block for an item by NAME — the SAME combat fields
+    the inventory inspector carries (ac / damage / damageType / versatile / properties /
+    weight / value / rarity / kind / attunement), built straight from the catalog. Used
+    by the /item-catalog endpoint so the Market inspector can show a ware's AC / damage /
+    Versatile two-handed die / properties (the optimizer's CRITICAL 'Studded Leather shows
+    no AC value' + 'Quarterstaff Examine is missing Versatile / 1d8 two-handed' findings).
+
+    Returns ``{"resolved": False}`` for a name the catalog cannot resolve (free-text /
+    homebrew gear) so the caller shows weight/price only — never a fabricated number."""
+    meta = _catalog_meta(name)
+    if not meta:
+        return {"resolved": False}
+    damage = _text(meta.get("damage"))
+    weight = _num(meta.get("weight"))
+    cost = _num(meta.get("cost"))
+    ac_raw = meta.get("ac")
+    return {
+        "resolved": True,
+        "name": _text(meta.get("name"), name),
+        "kind": _text(meta.get("kind")),
+        "rarity": _text(meta.get("rarity")) or "common",
+        "weight": f"{weight:g} lb" if weight is not None and weight > 0 else "—",
+        "value": f"{cost:g} gp" if cost is not None and cost > 0 else "—",
+        "damage": damage,
+        "damageType": _text(meta.get("damage_type")) if damage else "",
+        "versatile": _text(meta.get("versatile")) if damage else "",
+        "ac": int(ac_raw) if isinstance(ac_raw, (int, float)) else None,
+        "attunement": bool(meta.get("requires_attunement")),
+        "properties": _catalog_property_chips(meta),
+        "description": _text(meta.get("description")),
+    }
+
+
 def _inventory_items(cid: str, ch: dict) -> list[dict]:
     inventory = ch.get("inventory")
     out: list[dict] = []
@@ -4200,6 +4234,9 @@ def _inventory_items(cid: str, ch: dict) -> list[dict]:
         # Damage / AC: real catalog stats. Damage type is only meaningful with a dice expr.
         damage = _text(meta.get("damage")) if meta else ""
         damage_type = _text(meta.get("damage_type")) if (meta and damage) else ""
+        # #756: a Versatile weapon's two-handed damage die (e.g. "1d8") — only meaningful
+        # alongside the one-handed `damage`; absent for non-versatile gear.
+        versatile = _text(meta.get("versatile")) if (meta and damage) else ""
         ac_raw = meta.get("ac") if meta else None
         ac = int(ac_raw) if isinstance(ac_raw, (int, float)) else None
         # Catalog `kind` ("weapon"/"armor"/"wondrous"/"potion"/"ring"/…) is the SRD's own
@@ -4228,9 +4265,10 @@ def _inventory_items(cid: str, ch: dict) -> list[dict]:
             "desc": _text(item.get("description"), "No description recorded."),
             # Combat stat block (empty string / None when the catalog has no such datum —
             # the screen hides each row that is blank). damage e.g. "1d8", damageType "slashing",
-            # ac e.g. 18 (base AC for armor / shields).
+            # ac e.g. 18 (base AC for armor / shields). versatile e.g. "1d8" (two-handed die, #756).
             "damage": damage,
             "damageType": damage_type,
+            "versatile": versatile,
             "ac": ac,
             "attunement": attunement,
             "attuned": bool(item.get("attuned")),
@@ -7317,6 +7355,30 @@ class _Handler(BaseHTTPRequestHandler):
             cid = (qs.get("campaign") or [""])[0] or self._view_campaign(qs)
             character_id = (qs.get("character") or [""])[0]
             self._json(build_options_response(cid, character_id))
+        elif route == "/item-catalog":
+            # #756 read-only SRD item stat-block lookup by name. Lets the Market inspector
+            # enrich a client-side ware (which carries only name/weight/price) with its real
+            # AC / damage / Versatile two-handed die / properties — the data the engine
+            # catalog already holds (PR #862) but the Market display never read. Pure reader:
+            # resolves names against the bundled SRD catalog; mutates nothing, touches no
+            # campaign state. An unresolvable name returns {"resolved": false} (the caller
+            # then shows weight/price only — never a fabricated stat).
+            qs = parse_qs(parsed.query)
+            # Accept repeated ?name=… params and/or a single newline-separated ?names=… so the
+            # Market can resolve a whole table in one round-trip.
+            raw_names = list(qs.get("name") or [])
+            for blob in (qs.get("names") or []):
+                raw_names.extend(blob.split("\n"))
+            # De-dupe (case-insensitive, order-preserving) and bound the batch.
+            seen_keys: set = set()
+            flat: list = []
+            for n in raw_names:
+                key = n.strip() if isinstance(n, str) else ""
+                if key and key.lower() not in seen_keys:
+                    seen_keys.add(key.lower())
+                    flat.append(key)
+            flat = flat[:64]  # bound the batch so a query can't sweep the whole catalog
+            self._json({"items": {n: _catalog_stat_block(n) for n in flat}})
         elif route == "/bestiary-surface":
             # Read-only player-safe bestiary/codex projection. No campaign or combat
             # mutation route is exposed here; the engine returns only public preview fields.

--- a/viewer/tests/test_item_inspector.py
+++ b/viewer/tests/test_item_inspector.py
@@ -1,0 +1,323 @@
+"""Behaviour tests for the #756 item-inspector fix (from the RRI-5e98e6f optimizer sweep).
+
+The optimizer filed #756 Critical with three concrete symptoms, all VIEWER-side render/
+wire gaps where the engine catalog already holds the data (PR #862):
+
+  1. Market -> Armor inspector: "Studded Leather shows no AC value — impossible to evaluate
+     the upgrade" (the CRITICAL gate-flipper).
+  2. Stash -> Quarterstaff "Examine" fires a toast ONLY; the inspector is missing the
+     Versatile property AND the 1d8 two-handed damage.
+  3. No compare-on-hover anywhere in inventory or market.
+
+These tests transpile the REAL screen-inventory.jsx + screen-merchant.jsx with the SAME
+bundled Babel-standalone the browser uses and run the pure inspector helpers under Node
+(mirrors test_recovery_timing.py). They drive the SHIPPED code — `itemStatRows`,
+`itemCompareRows`, `enrichWare` — so a passing test tracks real behaviour, not a string
+grep. A separate served-source guard asserts the wiring the harness can't see (Examine
+opens a PANEL/dialog instead of a toast; the Market reads /item-catalog; the read endpoint
+exists).
+"""
+
+import http.client
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_OPENWORLDS = Path(__file__).resolve().parents[1] / "openworlds"
+_INVENTORY = _OPENWORLDS / "screen-inventory.jsx"
+_MERCHANT = _OPENWORLDS / "screen-merchant.jsx"
+_BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+
+# A minimal Node harness: a stub React (createElement returns null — we only call the PURE
+# helpers, never render), a `window` sandbox, and the bundled Babel. It transpiles the real
+# screen JSX (whose module body just DEFINES functions + Object.assign(window, …)) then
+# evaluates a JS `script` with `win` (= window) in scope; the script's return → JSON stdout.
+_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+const React = {
+  useState: (i) => [typeof i === 'function' ? i() : i, () => {}],
+  useEffect: () => {},
+  useRef: (i) => ({ current: i }),
+  useCallback: (fn) => fn,
+  createElement: () => null,
+  Fragment: 'F',
+};
+const sandbox = {
+  React,
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible',
+              getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
+  fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+  setTimeout: () => 0, clearTimeout: () => {}, setInterval: () => 0, clearInterval: () => {},
+  encodeURIComponent, URLSearchParams, Promise, JSON, Set, Array, Object, String, Boolean, Number, Math,
+  console,
+};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+
+function load(p) {
+  const src = fs.readFileSync(p, 'utf8');
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+%(loads)s
+
+const win = sandbox.window;
+const script = %(script)s;
+eval('(() => { ' + script + ' })()');
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + run the JSX inspector helpers")
+class ItemInspectorBehaviourTests(unittest.TestCase):
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_INVENTORY, _MERCHANT, _BABEL):
+            assert p.exists(), f"missing {p}"
+
+    def _run(self, script: str, loads=(_INVENTORY, _MERCHANT)) -> dict:
+        loads_js = "\n".join(f"load({json.dumps(str(p))});" for p in loads)
+        program = _HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "loads": loads_js,
+            "script": json.dumps("var __r = (function(){ " + script + " })(); "
+                                 "process.stdout.write(JSON.stringify(__r));"),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program, text=True, capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+    # --- symptom 1 (CRITICAL): an ARMOR inspector shows its AC ----------------
+    def test_armor_inspector_shows_ac(self):
+        """An armor item with a resolved base AC must surface an "Armor Class" row — the
+        CRITICAL "Studded Leather shows no AC value" gate-flipper."""
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Studded Leather', type: 'armor', "
+            "  weight: '13 lb', value: '45 gp', ac: 12 });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertIn("Armor Class", kv, "the armor inspector must render an Armor Class row")
+        self.assertEqual(kv["Armor Class"], "12")
+
+    def test_armor_with_no_ac_omits_the_row_no_fabrication(self):
+        # A free-text item the catalog can't resolve (ac absent) must NOT fabricate an AC.
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Mystery Vest', type: 'armor', weight: '—', value: '—' });"
+        )
+        self.assertNotIn("Armor Class", {r["k"] for r in rows})
+
+    # --- symptom 2: a VERSATILE weapon shows its 1d8 two-handed damage --------
+    def test_versatile_weapon_shows_two_handed_die(self):
+        """A Versatile weapon must read its one-handed damage AND its two-handed die — the
+        optimizer's "Quarterstaff Examine is missing the 1d8 two-handed damage"."""
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Quarterstaff', type: 'weapon', "
+            "  damage: '1d6', damageType: 'bludgeoning', versatile: '1d8' });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertIn("Damage", kv)
+        self.assertIn("1d6", kv["Damage"])
+        self.assertIn("1d8 two-handed", kv["Damage"],
+                      "a Versatile weapon must show its 1d8 two-handed damage")
+
+    def test_non_versatile_weapon_shows_plain_damage(self):
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Dagger', type: 'weapon', damage: '1d4', damageType: 'piercing' });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv["Damage"], "1d4 piercing")
+        self.assertNotIn("two-handed", kv["Damage"])
+
+    # --- symptom 3: compare-to-equipped --------------------------------------
+    def test_compare_to_equipped_armor_shows_ac_delta(self):
+        """The inspector compares a candidate to the equipped peer in the same slot — the
+        optimizer's "no compare-on-hover anywhere". Studded Leather (AC 12) over Leather
+        Armor (AC 11) is a +1 upgrade."""
+        out = self._run(
+            "return win.itemCompareRows("
+            "  { name: 'Studded Leather Armor', ac: 12 },"
+            "  [{ name: 'Leather Armor', ac: 11 }]);"
+        )
+        self.assertIsNotNone(out, "a comparable equipped peer must yield a compare block")
+        self.assertEqual(out["peer"], "Leather Armor")
+        ac_row = next(r for r in out["rows"] if r["k"] == "Armor Class")
+        self.assertEqual(ac_row["mine"], 12)
+        self.assertEqual(ac_row["theirs"], 11)
+        self.assertEqual(ac_row["delta"], 1, "Studded Leather over Leather is a +1 AC upgrade")
+
+    def test_compare_returns_null_without_a_peer(self):
+        # Nothing equipped in the slot -> no compare block (not a fabricated 0-delta).
+        out = self._run(
+            "return win.itemCompareRows({ name: 'Studded Leather Armor', ac: 12 }, []);"
+        )
+        self.assertIsNone(out)
+
+    # --- the Market enrichment merge (symptom 1 in the Market) ----------------
+    def test_enrich_ware_fills_ac_from_catalog(self):
+        """The Market's hardcoded "Studded leather" ware (no AC) gains the catalog AC so the
+        Market inspector can finally show it — the literal CRITICAL Market finding."""
+        out = self._run(
+            "return win.enrichWare("
+            "  { name: 'Studded leather', type: 'armor', weight: '20 lb', price: 25 },"
+            "  { 'Studded leather': { resolved: true, ac: 12, kind: 'armor', properties: [] } });"
+        )
+        self.assertEqual(out["ac"], 12, "the Market ware must pick up its catalog AC")
+        # the ware's own price/weight are preserved (its explicit fields win)
+        self.assertEqual(out["price"], 25)
+
+    def test_enrich_ware_folds_versatile_and_properties(self):
+        out = self._run(
+            "return win.enrichWare("
+            "  { name: 'Quarterstaff', type: 'weapon', weight: '4 lb', price: 1 },"
+            "  { 'Quarterstaff': { resolved: true, damage: '1d6', damageType: 'bludgeoning',"
+            "      versatile: '1d8', properties: ['Versatile'] } });"
+        )
+        self.assertEqual(out["damage"], "1d6")
+        self.assertEqual(out["versatile"], "1d8")
+        self.assertIn("Versatile", out["properties"])
+
+    def test_enrich_ware_unresolved_name_is_untouched(self):
+        """An item the catalog can't resolve (resolved:false / absent) is returned AS-IS —
+        weight/price only, never a fabricated stat."""
+        out = self._run(
+            "return win.enrichWare("
+            "  { name: 'Crossbow bolts', type: 'weapon', weight: '3 lb', price: 6 },"
+            "  { 'Crossbow bolts': { resolved: false } });"
+        )
+        self.assertNotIn("ac", out)
+        self.assertEqual(out["price"], 6)
+        out2 = self._run(
+            "return win.enrichWare({ name: 'Whatsit', price: 3 }, {});"
+        )
+        self.assertEqual(out2["price"], 3)
+
+
+# ── served-source guards: the wiring the pure-helper harness can't observe ─────
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server_item_inspector", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+class _QuietHandler(server._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+
+class ItemInspectorWiringTests(unittest.TestCase):
+    """The render-wiring + the /item-catalog read endpoint, asserted against a live server."""
+
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _get(self, path: str):
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            response = conn.getresponse()
+            return response.status, response.headers.get("Content-Type", ""), response.read()
+        finally:
+            conn.close()
+
+    # the /item-catalog read endpoint exists + returns the real AC for the CRITICAL item
+    def test_item_catalog_endpoint_resolves_studded_leather_ac(self):
+        status, ctype, body = self._get("/item-catalog?name=Studded%20leather")
+        self.assertEqual(status, 200)
+        self.assertIn("application/json", ctype)
+        payload = json.loads(body)
+        rec = payload["items"]["Studded leather"]
+        self.assertTrue(rec["resolved"])
+        self.assertEqual(rec["ac"], 12, "the CRITICAL Studded Leather AC must come back from the endpoint")
+
+    def test_item_catalog_endpoint_exposes_versatile_die_and_properties(self):
+        status, _ctype, body = self._get("/item-catalog?name=Quarterstaff")
+        rec = json.loads(body)["items"]["Quarterstaff"]
+        self.assertEqual(rec["damage"], "1d6")
+        self.assertEqual(rec["versatile"], "1d8")
+        self.assertIn("Versatile", rec["properties"])
+
+    def test_item_catalog_endpoint_unresolved_name_is_honest(self):
+        status, _ctype, body = self._get("/item-catalog?name=Totally%20Made%20Up%20Gizmo")
+        rec = json.loads(body)["items"]["Totally Made Up Gizmo"]
+        self.assertFalse(rec["resolved"])
+
+    def test_item_catalog_endpoint_batches_multiple_names(self):
+        status, _ctype, body = self._get("/item-catalog?name=Longsword&name=Plate")
+        items = json.loads(body)["items"]
+        self.assertTrue(items["Longsword"]["resolved"])
+        self.assertEqual(items["Longsword"]["damage"], "1d8")
+        self.assertTrue(items["Plate"]["resolved"])
+        self.assertEqual(items["Plate"]["ac"], 18)
+
+    # Examine opens a PANEL (dialog), not a toast
+    def test_examine_opens_a_panel_not_a_toast(self):
+        _status, _ctype, body = self._get("/openworlds/screen-inventory.jsx")
+        src = body.decode("utf-8")
+        # the Examine action button opens the read-only panel state…
+        self.assertIn("setExamineOpen(true)", src)
+        self.assertIn('role="dialog"', src)
+        # …and the right-click "Examine" raises the panel nonce instead of toasting.
+        self.assertIn("setExamineNonce", src)
+        # the old toast-only Examine is gone (the right-click Examine no longer toasts desc).
+        self.assertNotIn(
+            'onClick: () => toast({ kind: "item", title: ctxMenu.item.name, body: ctxMenu.item.desc })',
+            src,
+        )
+
+    def test_inventory_renders_versatile_and_compare(self):
+        _status, _ctype, body = self._get("/openworlds/screen-inventory.jsx")
+        src = body.decode("utf-8")
+        self.assertIn("two-handed", src)            # versatile die folded into the damage row
+        self.assertIn("Versus Equipped", src)       # compare-to-equipped block
+        self.assertIn("itemStatRows", src)
+        self.assertIn("itemCompareRows", src)
+
+    def test_merchant_reads_item_catalog_and_enriches(self):
+        _status, _ctype, body = self._get("/openworlds/screen-merchant.jsx")
+        src = body.decode("utf-8")
+        self.assertIn("/item-catalog?", src)        # the Market fetches the catalog
+        self.assertIn("enrichWare", src)            # …and merges it into the detail pane
+        self.assertIn("window.itemStatRows", src)   # rendering the real stat rows (AC/damage)
+        self.assertIn("Versus ", src)               # compare block in the Market inspector
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the VIEWER half of #756 — the **CRITICAL gate-flipper** from the RRI-5e98e6f optimizer sweep (2026-06-14). The item inspector could not show what an item *is*; the engine catalog already held the data (PR #862), the viewer just never read/rendered it.

## Symptoms fixed (all filed by the optimizer)
1. **CRITICAL** — Market → Armor inspector: "Studded Leather shows no AC value — impossible to evaluate the upgrade."
2. Stash → Quarterstaff "Examine" fires a **toast only**; the inspector is missing the **Versatile** property and the **1d8 two-handed** damage.
3. No **compare-on-hover** anywhere in inventory or market.

## Root cause
- The colloquial name **"Studded Leather"** is keyed **"Studded Leather Armor"** in the SRD catalog, and a bare-substring resolve was *ambiguous* (also matches "Glamoured Studded Leather", "Armor of Resistance (Studded Leather)", …) → `None` → no AC.
- **Weapon properties + the Versatile two-handed die live in `WeaponPropertyAssignment` / `WeaponProperty`**, not inline on the Weapon record — the catalog flatten dropped them entirely.

## Changes

**Engine — additive to the SRD catalog flatten (NO persisted-schema change):**
- `itemcatalog._weapon_property_join()` folds the property tables into each weapon's `properties` (Versatile / Finesse / Two-Handed / Light / Thrown / Heavy / Reach / Ammunition …) + a new `versatile` field (the two-handed die, e.g. `"1d8"`). Mastery-tier properties are excluded (advanced combat-option layer, not item descriptors).
- `itemcatalog.resolve()` adds base-name + canonical-suffix disambiguation so `"Studded Leather"` → `"Studded Leather Armor"` (AC 12). Ambiguity semantics for non-base names (e.g. `"potion of"`) are unchanged.

**Viewer read-path (`server.py`) — additive to the read payload:**
- `_inventory_items` carries `versatile` through.
- New **read-only `/item-catalog?name=…` endpoint** + `_catalog_stat_block()` projection so the Market can enrich a hardcoded ware with its real AC / damage / versatile / properties. Pure reader — resolves names against the bundled SRD catalog, mutates nothing; an unresolvable name returns `{"resolved": false}` (never a fabricated stat).

**Viewer (jsx):**
- `screen-inventory`: `itemStatRows()` folds the Versatile two-handed die into the Damage row; **Examine** (button + right-click) opens a real read-only **panel** (`role="dialog"`), not a toast; `itemCompareRows()` adds a "Versus Equipped" AC/damage delta block.
- `screen-merchant`: fetches `/item-catalog` for the wares, `enrichWare()` merges the stats into the detail pane, and reuses the shared `itemStatRows()`/`itemCompareRows()` so the Market shows the same stat block + compare-to-equipped.

## Invariants honored
Viewer stays read-only + a move-sink (engine is sole writer); render via React text nodes (auto-escaped), no `dangerouslySetInnerHTML`; wire contracts frozen; the engine change is **additive to the read/flatten path only** (no persisted schema touched); unresolvable items show weight/price only — never a fabricated number.

## Tests
- `servers/engine/tests/test_itemcatalog.py` **+7**: base-name disambiguation, Versatile two-handed die, real weapon properties, simple/improvised merge, no-fabrication guards.
- `viewer/tests/test_item_inspector.py` **NEW — 16 cases**: a Babel-transpile behaviour harness drives the **real** `itemStatRows` / `itemCompareRows` / `enrichWare` (armor shows AC; versatile weapon shows `1d8 two-handed`; compare yields the `+1` AC delta; unresolved names untouched) + served-source/endpoint guards (Examine opens a dialog not a toast; `/item-catalog` returns the Studded Leather AC + Quarterstaff versatile die).

**Tier-0 `qa/fast_gate.sh`: PASS (195 passed).** Engine change is additive-only.

From the RRI-5e98e6f optimizer sweep. This single fix flips `zero_critical` for the optimizer. DO NOT MERGE (gate-mover for review).