### PR TITLE
fix(viewer): wire Rest & Prepare relay + browsable level-up subclasses (#610 #617 #607)

### DIFF
--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -1204,7 +1204,7 @@ function ScreenRouter({ screen, state, setState, onNavigate, campMode, setCampMo
     case "roster":    return <ScreenRoster state={state} setState={setState} onNavigate={onNavigate} preferredProvider={preferredProvider} />;
     case "table":     return <ScreenTable state={state} setState={setState} onNavigate={onNavigate} liveSession={liveSession} />;
     case "combat":    return <ScreenCombat state={state} setState={setState} onNavigate={onNavigate} />;
-    case "character": return <ScreenCharacter state={state} setState={setState} onNavigate={onNavigate} />;
+    case "character": return <ScreenCharacter state={state} setState={setState} onNavigate={onNavigate} liveSession={liveSession} />;
     case "create":    return <ScreenCreate state={state} setState={setState} onNavigate={onNavigate} preferredProvider={preferredProvider} />;
     case "forge":     return <ScreenForge state={state} setState={setState} onNavigate={onNavigate} />;
     case "relations": return <ScreenRelations state={state} setState={setState} onNavigate={onNavigate} />;

--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -16,7 +16,7 @@ function characterPortraitScope(p) {
   return (p && p.id) ? "portrait-" + p.id : "";
 }
 
-function ScreenCharacter({ onNavigate, state, setState }) {
+function ScreenCharacter({ onNavigate, state, setState, liveSession }) {
   const surfaceQuery = window.combatSurfaceFromCampaign
     ? window.combatSurfaceFromCampaign(
         (Array.isArray(state?.campaigns) ? state.campaigns : []).find((c) => c.id === state?.activeCampaign) ||
@@ -34,6 +34,16 @@ function ScreenCharacter({ onNavigate, state, setState }) {
   const [restOpen, setRestOpen] = React.useState(false);
   const [levelUpOpen, setLevelUpOpen] = React.useState(false);
   const toast = window.useToast ? window.useToast() : (() => {});
+
+  // #610/#617 — the Rest & Prepare relay. The Make-camp / Seal-the-choices CTAs write THROUGH THE
+  // ENGINE (sole writer) via /move, exactly as camp-sidebar.jsx and the level-up picker do — the
+  // viewer never mutates HP / slots / prepared spells itself. They are live + functional when a
+  // session is attached (`can_act`) AND the DM isn't mid-turn (#402), honestly disabled + explained
+  // otherwise. `dmBusy` rides the app-level liveSession hook, mirroring ScreenMap → CampSidebar.
+  const canAct = Boolean(surface?.can_act);
+  const dmPending = liveSession?.pending || null;
+  const dmBusy = Boolean(dmPending && !dmPending.stuck);
+  const campaignId = surface?.campaign_id || state?.activeCampaign || "";
 
   const loadSurface = React.useCallback(async (isCancelled = () => false) => {
     try {
@@ -303,7 +313,19 @@ function ScreenCharacter({ onNavigate, state, setState }) {
         </div>
       </div>
 
-      {restOpen && <RestPrepareModal hero={hero} party={party} onClose={() => setRestOpen(false)} toast={toast} setState={setState} />}
+      {restOpen && (
+        <RestPrepareModal
+          hero={hero}
+          party={party}
+          campaignId={campaignId}
+          canAct={canAct}
+          dmBusy={dmBusy}
+          onClose={() => setRestOpen(false)}
+          onDone={() => { setRestOpen(false); loadSurface(); }}
+          toast={toast}
+          setState={setState}
+        />
+      )}
       {levelUpOpen && (
         <LevelUpModal
           hero={hero}
@@ -424,9 +446,23 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
     }
   };
 
-  // Confirm is blocked ONLY while submitting or when a subclass is required but unnamed — it is
-  // never permanently disabled (that is the RestPrepareModal display-only stub; the picker writes).
-  const confirmDisabled = submitting || (subclassDue && !subclassName.trim());
+  // #607: is there an XP-legal level to advance into? The planner only lists LEGAL options (it
+  // pushes no-XP paths to blocked_options), so an EMPTY options list when the modal was opened on a
+  // pending subclass means "no XP earned yet for the next level" — the affordance is open to NAME
+  // the missed subclass, but a level-up confirm would be illegal. The free-standing subclass naming
+  // still rides the next earned level-up; until then, block + explain.
+  const noLegalLevel = !loading && !error && options.length === 0;
+  const subclassNeedsName = subclassDue && !subclassName.trim();
+  // Confirm is blocked while submitting, when a subclass is required but unnamed, or when there is
+  // no XP-legal level to advance into — never PERMANENTLY (that is the old display-only stub). The
+  // reason is surfaced as a hover tooltip so the disabled state is never a mystery (the optimizer
+  // persona's complaint: a dead "Confirm advancement" with no explanation of WHY).
+  const confirmBlockReason = noLegalLevel
+    ? "No XP earned yet — there's no level to advance into. Earn more XP first."
+    : subclassNeedsName
+      ? "Name (or pick) your " + subclassGroupLabel + " to confirm — the DM finalizes it"
+      : "";
+  const confirmDisabled = submitting || !!confirmBlockReason;
 
   return (
     <div style={{
@@ -509,8 +545,12 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
                         data-worldos-testid="levelup-subclass-options">
                         {subclassOptions.map((opt) => {
                           const selected = subclassName.trim().toLowerCase() === (opt.name || "").toLowerCase();
+                          // #607: each option lists the level-3 features it grants so the picker is a
+                          // real BROWSABLE comparison ("what each tradition gives me"), not a name list.
+                          const optFeatures = Array.isArray(opt.features) ? opt.features : [];
                           return (
                             <button key={opt.name} type="button"
+                              aria-pressed={selected}
                               onClick={() => setSubclassName(opt.name)}
                               data-worldos-testid={"levelup-subclass-option-" + (opt.name || "").toLowerCase().replace(/[^a-z0-9]+/g, "-")}
                               style={{
@@ -522,6 +562,17 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
                               }}>
                               <div style={{ fontFamily: "var(--f-display)", fontSize: 13 }}>{opt.name}</div>
                               {opt.desc && <div className="body-sm" style={{ opacity: 0.85, marginTop: 2 }}>{opt.desc}</div>}
+                              {optFeatures.length > 0 && (
+                                <ul style={{ margin: "6px 0 0", paddingLeft: 16 }}
+                                  data-worldos-testid={"levelup-subclass-features-" + (opt.name || "").toLowerCase().replace(/[^a-z0-9]+/g, "-")}>
+                                  {optFeatures.map((f, i) => (
+                                    <li key={i} className="body-sm" style={{ opacity: 0.9, marginTop: 1 }}>
+                                      <strong>{(f && f.name) || String(f)}</strong>
+                                      {f && f.desc ? <span style={{ opacity: 0.8 }}> — {f.desc}</span> : null}
+                                    </li>
+                                  ))}
+                                </ul>
+                              )}
                             </button>
                           );
                         })}
@@ -560,10 +611,19 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
               <div style={{ display: "flex", gap: 10, marginTop: 24, justifyContent: "flex-end" }}>
                 <BrassButton tone="ghost" onClick={onClose} testId="modal-close" ariaLabel="Close level up modal">Not yet</BrassButton>
                 <BrassButton onClick={confirm} disabled={confirmDisabled} testId="levelup-confirm"
-                  ariaLabel="Confirm level up and relay to the Dungeon Master">
+                  ariaLabel="Confirm level up and relay to the Dungeon Master"
+                  title={confirmBlockReason || "Relays the advancement to the DM via /move — the engine resolves the level-up"}>
                   {submitting ? "Relaying…" : "Confirm advancement"}
                 </BrassButton>
               </div>
+              {/* #607: when Confirm is disabled, say WHY inline (a hover tooltip alone is invisible
+                  to touch + screen-reader users) — never a silently dead button. */}
+              {confirmBlockReason && (
+                <div className="hand muted" style={{ fontSize: 11, marginTop: 8, textAlign: "right" }}
+                  data-worldos-testid="levelup-confirm-reason">
+                  {confirmBlockReason}.
+                </div>
+              )}
             </>
           )}
         </Panel>
@@ -572,10 +632,15 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
   );
 }
 
-function RestPrepareModal({ hero, party, onClose, toast, setState }) {
+function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, onDone, toast, setState }) {
   const [step, setStep] = React.useState("rest");
   const [restType, setRestType] = React.useState("long");
   const [prepared, setPrepared] = React.useState({});
+  const [submitting, setSubmitting] = React.useState(false);
+  // #robustness: synchronous in-flight lock (mirrors LevelUpModal / screen-table.jsx). The
+  // `submitting` STATE only updates on re-render, so a rapid double-click would otherwise relay
+  // TWO rest/prepare intents. The ref blocks the second call within the same tick.
+  const submittingRef = React.useRef(false);
   // Watch order is drawn from the LIVE party (first names), never the hardcoded demo trio.
   const watchOrder = (Array.isArray(party) ? party : []).map((p) => (p.name || "").split(" ")[0]).filter(Boolean);
 
@@ -602,28 +667,71 @@ function RestPrepareModal({ hero, party, onClose, toast, setState }) {
     }
   };
 
-  // Display-only: this modal has no write route to the engine. The toasts below are
-  // neutral previews — nothing here mutates HP, spell slots, or prepared spells.
+  // #610/#617 — relay a composed `do` move-intent to the DM (sole writer) and let the engine
+  // resolve it through long_rest/short_rest + prepare_spells (refreshing HP + spell slots,
+  // advancing the clock, recording prepared spells). The viewer NEVER writes snapshot — this is
+  // the same write path camp-sidebar.jsx and LevelUpModal use. Synchronously locked + busy-gated.
+  const relayMove = async (text, onSuccess, eyebrow, title) => {
+    if (submittingRef.current) return;
+    if (dmBusy) {
+      toast({ kind: "danger", eyebrow: "Camp", title: "The Dungeon Master is still narrating", body: "Resolve the current beat first — then make camp and rest." });
+      return;
+    }
+    if (!canAct) {
+      toast({ kind: "danger", eyebrow: "Camp", title: "The chronicle is read-only", body: "Start a session to make camp, rest, and prepare spells." });
+      return;
+    }
+    submittingRef.current = true;
+    setSubmitting(true);
+    try {
+      const response = await fetch("/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "do", text, campaign: campaignId }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload.ok === false) throw new Error(payload.reason || "move " + response.status);
+      toast({ kind: "rest", eyebrow, title, body: "Move relayed to the DM — the engine resolves it, refreshes the party, and advances the clock." });
+      if (onSuccess) onSuccess();
+    } catch (e) {
+      toast({ kind: "danger", eyebrow, title: title + " not sent", body: (e && e.message) || "The viewer could not reach /move." });
+      submittingRef.current = false;
+      setSubmitting(false);
+    }
+  };
+
+  // Make camp: relay the chosen rest, then advance to the spell-preparation step.
   const completeRest = () => {
-    toast({
-      kind: "rest",
-      eyebrow: (restType === "long" ? "Long rest" : "Short rest") + " (preview)",
-      title: "Rest preview",
-      body: "Display-only — rest is not saved to the engine.",
-    });
-    setStep("prep");
+    const watch = watchOrder.length > 0 ? ` ${watchOrder.join(", then ")} keep watch.` : "";
+    const text = restType === "long"
+      ? `${hero.name} and the party make camp and take a long rest — restore HP, recover all spell slots, and refresh abilities, then advance the clock to morning.${watch}`
+      : `${hero.name} and the party take a short rest — spend Hit Dice to recover HP and refresh short-rest abilities.${watch}`;
+    relayMove(text, () => { submittingRef.current = false; setSubmitting(false); setStep("prep"); },
+      restType === "long" ? "Long rest" : "Short rest", "Rest");
   };
 
   const completePrep = () => {
-    const count = Object.values(prepared).reduce((s, l) => s + l.length, 0);
-    toast({
-      kind: "item",
-      eyebrow: "Spellbook (preview)",
-      title: count + " spell" + (count !== 1 ? "s" : "") + " selected",
-      body: "Display-only — spell preparation is not saved to the engine.",
-    });
-    onClose();
+    // Compose the prepared list (level-tagged) into the intent so the engine records exactly
+    // which spells are prepared for the day; empty = "leave my preparation unchanged".
+    const named = Object.keys(prepared)
+      .sort((a, b) => Number(a) - Number(b))
+      .flatMap((lv) => (prepared[lv] || []).map((n) => n))
+      .filter(Boolean);
+    const text = named.length > 0
+      ? `${hero.name} prepares today's spells: ${named.join(", ")}.`
+      : `${hero.name} keeps their currently prepared spells.`;
+    relayMove(text, () => { if (onDone) onDone(); else onClose(); },
+      "Spellbook", "Preparation");
   };
+
+  // Why the CTAs are disabled, surfaced as a hover tooltip (and the inline note below) so a dead
+  // button is never a mystery — mirrors camp-sidebar.jsx and the level-up picker.
+  const blockReason = !canAct
+    ? "The chronicle is read-only — start a session to make camp and rest"
+    : dmBusy
+      ? "The Dungeon Master is still narrating — resolve the current beat first"
+      : "";
+  const ctaDisabled = submitting || !!blockReason;
 
   return (
     <div style={{
@@ -685,10 +793,17 @@ function RestPrepareModal({ hero, party, onClose, toast, setState }) {
 
               <div style={{ display: "flex", gap: 10, marginTop: 24, justifyContent: "flex-end" }}>
                 <BrassButton tone="ghost" onClick={onClose} testId="modal-close" ariaLabel="Close rest and prepare modal">Not yet</BrassButton>
-                <BrassButton onClick={completeRest} disabled title="Display-only — rest is not saved to the engine">
-                  Make camp <span style={{ fontSize: 9, opacity: 0.7 }}>(preview)</span>
+                <BrassButton onClick={completeRest} disabled={ctaDisabled} testId="rest-make-camp"
+                  ariaLabel="Make camp and relay the rest to the Dungeon Master"
+                  title={blockReason || "Relays the rest to the DM via /move — the engine refreshes HP + spell slots and advances the clock"}>
+                  {submitting ? "Relaying…" : "Make camp"}
                 </BrassButton>
               </div>
+              {blockReason && (
+                <div className="hand muted" style={{ fontSize: 11, marginTop: 8, textAlign: "right" }}>
+                  {blockReason}.
+                </div>
+              )}
             </>
           ) : (
             <>
@@ -759,8 +874,10 @@ function RestPrepareModal({ hero, party, onClose, toast, setState }) {
                 </span>
                 <div style={{ display: "flex", gap: 10 }}>
                   <BrassButton tone="ghost" onClick={onClose} testId="modal-close" ariaLabel="Close rest and prepare modal">Close book</BrassButton>
-                  <BrassButton onClick={completePrep} disabled title="Display-only — spell preparation is not saved to the engine">
-                    Seal the choices <span style={{ fontSize: 9, opacity: 0.7 }}>(preview)</span>
+                  <BrassButton onClick={completePrep} disabled={ctaDisabled} testId="rest-prepare-spells"
+                    ariaLabel="Seal today's prepared spells and relay to the Dungeon Master"
+                    title={blockReason || "Relays your prepared spells to the DM via /move — the engine records the day's preparation"}>
+                    {submitting ? "Relaying…" : "Seal the choices"}
                   </BrassButton>
                 </div>
               </div>

--- a/viewer/tests/test_rest_camp_levelup_wiring.py
+++ b/viewer/tests/test_rest_camp_levelup_wiring.py
@@ -1,0 +1,434 @@
+"""Behavior tests for the #610/#617 Rest-&-Prepare relay + the #607 level-up subclass browse.
+
+From the RRI-5e98e6f optimizer sweep — two MAJOR viewer-side wiring gaps where the ENGINE already
+works but the viewer did not use it:
+
+  (1) Rest & Prepare (RestPrepareModal, screen-character.jsx): the "Make camp" + "Seal the choices"
+      CTAs were `disabled` display-only stubs ("…not saved to the engine"), so spell re-preparation
+      and slot recovery were non-functional. The engine's long_rest / short_rest / prepare_spells
+      already work; the fix relays a composed `do` move-intent to /move (the SAME write path
+      camp-sidebar.jsx + LevelUpModal use — the viewer stays a read-only move-sink). The CTA is
+      ENABLED + functional when a session is attached (can_act) AND the DM isn't mid-turn (dmBusy),
+      and honestly DISABLED + explained otherwise.
+
+  (2) Level-up dialog (LevelUpModal): the subclass picker must BROWSE all engine-exposed options
+      (each with its level-3 feature breakdown — a real comparison), not just one; and the disabled
+      "Confirm advancement" must say WHY (a subclass needs naming, or no XP is earned yet) instead of
+      being a silently-dead button.
+
+These exercise the REAL components by transpiling the actual `screen-character.jsx` with the SAME
+bundled Babel-standalone the browser uses and rendering the modal under a createElement-capturing
+React stub (state persists, effects RUN so the /build-options fetch lands, setState re-renders) with
+a scripted fetch — so the test tracks the shipped JSX, not a reimplementation (mirrors
+test_cold_open_progress.py + test_recovery_timing.py). A test can: render with props, drain the async
+fetch, find a node by testid, INVOKE its onClick, re-render, and read the resulting /move POST.
+"""
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+_OPENWORLDS = Path(__file__).resolve().parents[1] / "openworlds"
+_SCREEN_CHARACTER = _OPENWORLDS / "screen-character.jsx"
+_BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+
+_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+// ---- a real-enough React: hook cells + effects persist; setState re-renders; effects RUN -------
+// (ported from test_recovery_timing.py's stub, plus a createElement that builds a walkable tree so
+// we can find a node by testid and invoke its onClick — the tree-walk from test_cold_open_progress.py.)
+function makeReact() {
+  const stateCells = [], refCells = [], cbCells = [], effects = [];
+  let sIdx = 0, rIdx = 0, cIdx = 0, eIdx = 0;
+  let renderFn = null, result = null;
+  const pendingEffects = [];
+  let flushing = false;
+
+  function useState(init) {
+    const i = sIdx++;
+    if (stateCells[i] === undefined) stateCells[i] = { v: typeof init === 'function' ? init() : init };
+    const cell = stateCells[i];
+    const set = (next) => { cell.v = (typeof next === 'function') ? next(cell.v) : next; render(); flushEffects(); };
+    return [cell.v, set];
+  }
+  function useRef(init) { const i = rIdx++; if (refCells[i] === undefined) refCells[i] = { current: init }; return refCells[i]; }
+  function depsEqual(a, b) { if (!a || !b || a.length !== b.length) return false; for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false; return true; }
+  function useCallback(fn, deps) { const i = cIdx++; const prev = cbCells[i]; if (prev === undefined || !depsEqual(prev.deps, deps)) { cbCells[i] = { fn, deps }; return fn; } return prev.fn; }
+  function useEffect(fn, deps) {
+    const i = eIdx++;
+    const prev = effects[i];
+    const changed = !prev || !depsEqual(prev.deps, deps);
+    if (changed) {
+      pendingEffects.push(() => { if (prev && typeof prev.cleanup === 'function') prev.cleanup(); const cleanup = fn(); effects[i] = { deps, cleanup: typeof cleanup === 'function' ? cleanup : null }; });
+      if (!prev) effects[i] = { deps, cleanup: null }; else effects[i].deps = deps;
+    }
+  }
+  function createElement(type, props) {
+    const children = Array.prototype.slice.call(arguments, 2);
+    return { type, props: props || {}, children };
+  }
+  function render() { sIdx = 0; rIdx = 0; cIdx = 0; eIdx = 0; result = renderFn(); }
+  function flushEffects() { if (flushing) return; flushing = true; try { while (pendingEffects.length) pendingEffects.shift()(); } finally { flushing = false; } }
+  const React = { useState, useRef, useCallback, useEffect, createElement, Fragment: 'F' };
+  function mount(fn) { renderFn = fn; render(); flushEffects(); }
+  function commit() { flushEffects(); }
+  function api() { return result; }
+  return { React, mount, commit, api };
+}
+
+// ---- a SCRIPTED fetch capturing POST bodies; /build-options returns the scripted planner --------
+let PLANNER = null;            // the /build-options planner payload (set per test)
+const posts = [];              // every /move POST {url, body}
+function fetchStub(url, opts) {
+  const u = String(url).split('?')[0];
+  if (u === '/build-options') {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(PLANNER || { ok: false, errors: ['no planner'] }) });
+  }
+  if (u === '/move') {
+    let body = {}; try { body = JSON.parse((opts && opts.body) || '{}'); } catch (_e) {}
+    posts.push({ url: u, body });
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+  }
+  return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+}
+
+const reactHost = makeReact();
+
+// Chrome components the modal renders (Panel, BrassButton, …) live on window in the browser; stub
+// each as a createElement passthrough so the node carries its testid/title/onClick/disabled props
+// (BrassButton must render to a real <button>-like node we can find + click).
+function passthrough(name) { return function (props) { const p = props || {}; const kids = (p.children !== undefined) ? [].concat(p.children) : []; return reactHost.React.createElement(name, p, ...kids); }; }
+
+const sandbox = {
+  React: reactHost.React,
+  ReactDOM: { createRoot: () => ({ render() {} }) },
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible', getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
+  setTimeout: (fn) => { return 0; }, clearTimeout: () => {}, setInterval: () => 0, clearInterval: () => {},
+  fetch: fetchStub,
+  // the modals attach a keydown Escape handler via window.addEventListener in a useEffect.
+  addEventListener() {}, removeEventListener() {},
+  encodeURIComponent, URLSearchParams, Promise, JSON, Set, Array, Object, String, Boolean, Number, Math,
+  console,
+};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+
+function load(p) {
+  let src = fs.readFileSync(p, 'utf8');
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+// Provide the chrome/toast stubs as globals BEFORE the screen module loads (Babel emits bare refs).
+for (const name of ['Panel','BrassButton','Divider','SectionTitle','Pill','Placeholder','Img','Glyph','CornerOrnament']) {
+  sandbox[name] = passthrough(name);
+}
+const toastCalls = [];
+sandbox.useToast = () => (t) => { toastCalls.push(t); };
+sandbox.slug = (n) => (n || '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+sandbox.combatSurfaceFromCampaign = () => '';
+
+load(%(screen_character)s);
+
+// ---- tree helpers ----------------------------------------------------------------------------
+function findByTestId(node, id, hits) {
+  hits = hits || [];
+  if (node == null || typeof node !== 'object') return hits;
+  if (Array.isArray(node)) { for (const c of node) findByTestId(c, id, hits); return hits; }
+  const props = node.props || {};
+  if (props['data-worldos-testid'] === id || props.testId === id) hits.push(node);
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) findByTestId(c, id, hits);
+  return hits;
+}
+function collectText(node, out) {
+  out = out || [];
+  if (node == null || node === false) return out;
+  if (typeof node === 'string' || typeof node === 'number') { out.push(String(node)); return out; }
+  if (Array.isArray(node)) { for (const c of node) collectText(c, out); return out; }
+  const props = node.props || {};
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) collectText(c, out);
+  return out;
+}
+function firstProps(node, id) { const hits = findByTestId(node, id); return hits.length ? (hits[0].props || {}) : null; }
+
+async function settle() { await new Promise((r) => setImmediate(r)); await new Promise((r) => setImmediate(r)); reactHost.commit(); }
+
+const h = {
+  mountRest: (props) => { reactHost.mount(() => sandbox.window.RestPrepareModal(props)); },
+  mountLevelUp: (props) => { reactHost.mount(() => sandbox.window.LevelUpModal(props)); },
+  setPlanner: (p) => { PLANNER = p; },
+  tree: () => reactHost.api(),
+  settle,
+  // find a node by testid and read a prop (disabled/title/etc.)
+  props: (id) => firstProps(reactHost.api(), id),
+  // INVOKE the onClick of the node with this testid, then re-render + drain async.
+  click: async (id) => { const hits = findByTestId(reactHost.api(), id); if (!hits.length) throw new Error('no node ' + id); const oc = (hits[0].props || {}).onClick; if (typeof oc !== 'function') throw new Error('no onClick on ' + id); oc(); await settle(); },
+  text: () => collectText(reactHost.api()).join(' ␟ '),
+  posts: () => posts,
+  toasts: () => toastCalls,
+  exists: (id) => findByTestId(reactHost.api(), id).length,
+};
+
+const script = %(script)s;
+eval('(async () => { ' + script + ' })()')
+  .then((result) => { process.stdout.write(JSON.stringify(result)); })
+  .catch((e) => { console.error(e && e.stack || e); process.exit(1); });
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + render the JSX")
+class _Harness(unittest.TestCase):
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_SCREEN_CHARACTER, _BABEL):
+            assert p.exists(), f"missing {p}"
+
+    def _run(self, script: str):
+        program = _HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "screen_character": json.dumps(str(_SCREEN_CHARACTER)),
+            "script": json.dumps(script),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program, text=True, capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+
+# A minimal hero + a few props the modals need.
+_HERO = (
+    "{ id: 'char_1', name: 'Dal Lightspark', class: 'wizard', level: 5, "
+    "xp: 6500, xpMax: 14000, spells: [], spellSlots: {} }"
+)
+
+
+class RestPrepareWiringTests(_Harness):
+    """#610/#617 — the Make-camp / Seal-the-choices CTAs relay a real `do` /move (not a dead stub)."""
+
+    def _mount(self, can_act="true", dm_busy="false"):
+        return (
+            "h.mountRest({ hero: " + _HERO + ", party: [{ id:'char_1', name:'Dal Lightspark' }],"
+            " campaignId: 'camp1', canAct: " + can_act + ", dmBusy: " + dm_busy + ","
+            " onClose: function(){}, onDone: function(){}, toast: h.toasts ? (function(t){}) : (function(){}),"
+            " setState: function(){} });"
+        )
+
+    def test_make_camp_is_enabled_and_dispatches_a_do_move_when_party_can_rest(self):
+        out = self._run(
+            self._mount("true", "false") +
+            "var before = h.props('rest-make-camp');"
+            "await h.click('rest-make-camp');"
+            "var posts = h.posts();"
+            "return ({ disabled_before: !!before.disabled, has_test_id: !!before,"
+            "  posts: posts.length, post: posts[0] || null });"
+        )
+        self.assertFalse(out["disabled_before"], "Make camp must be ENABLED when the party can rest (can_act, not dmBusy)")
+        self.assertEqual(out["posts"], 1, "clicking Make camp must POST exactly one /move (the camp relay)")
+        self.assertEqual(out["post"]["url"], "/move")
+        self.assertEqual(out["post"]["body"]["kind"], "do", "the camp relay is a structured `do` move-intent")
+        self.assertEqual(out["post"]["body"]["campaign"], "camp1")
+        # the composed intent names a long rest (restoring slots) — the engine resolves it.
+        self.assertIn("long rest", out["post"]["body"]["text"].lower())
+        self.assertIn("spell slot", out["post"]["body"]["text"].lower())
+
+    def test_make_camp_disabled_with_reason_when_read_only(self):
+        out = self._run(
+            self._mount("false", "false") +
+            "var p = h.props('rest-make-camp');"
+            "var hasReason = (h.text().indexOf('read-only') !== -1);"
+            "return ({ disabled: !!p.disabled, title: p.title || '', reason_shown: hasReason });"
+        )
+        self.assertTrue(out["disabled"], "Make camp must be disabled when the chronicle is read-only")
+        self.assertIn("read-only", out["title"].lower(), "the disabled button must explain WHY via title")
+        self.assertTrue(out["reason_shown"], "the read-only reason must also be shown inline (not only as a hover title)")
+
+    def test_make_camp_disabled_with_reason_when_dm_is_narrating(self):
+        out = self._run(
+            self._mount("true", "true") +
+            "var p = h.props('rest-make-camp');"
+            "return ({ disabled: !!p.disabled, title: p.title || '' });"
+        )
+        self.assertTrue(out["disabled"], "Make camp must be disabled while the DM is mid-turn")
+        self.assertIn("narrating", out["title"].lower(), "the dm-busy disabled reason must be in the tooltip")
+
+    def test_read_only_modal_carries_camp_reason_and_posts_nothing(self):
+        # Defense-in-depth: the read-only modal renders the inline reason AND never posts a /move
+        # (the engine is sole writer; a read-only chronicle must not relay). The button being
+        # disabled blocks the click; this pins that opening the modal alone writes nothing.
+        out = self._run(
+            self._mount("false", "false") +
+            "return ({ posts_at_mount: h.posts().length, has_reason: (h.text().indexOf('read-only') !== -1) });"
+        )
+        self.assertEqual(out["posts_at_mount"], 0, "no /move should be posted just by opening the modal")
+        self.assertTrue(out["has_reason"], "the read-only modal must show the inline why (a fix-introduced affordance)")
+
+    def test_prepare_spells_button_is_wired_after_resting(self):
+        # After a successful Make-camp relay the modal advances to the prep step; the Seal CTA there
+        # must also relay a real /move (prepare_spells), not be a dead stub.
+        out = self._run(
+            self._mount("true", "false") +
+            "await h.click('rest-make-camp');"          # relays the rest, advances to 'prep'
+            "var sealExists = h.exists('rest-prepare-spells');"
+            "var sealProps = h.props('rest-prepare-spells');"
+            "await h.click('rest-prepare-spells');"      # relays the preparation
+            "var posts = h.posts();"
+            "return ({ seal_exists: sealExists, seal_disabled: !!(sealProps && sealProps.disabled),"
+            "  total_posts: posts.length, last: posts[posts.length - 1] || null });"
+        )
+        self.assertTrue(out["seal_exists"], "after resting, the prep step's Seal CTA must render")
+        self.assertFalse(out["seal_disabled"], "the Seal CTA must be enabled (live session, not busy)")
+        self.assertEqual(out["total_posts"], 2, "Make-camp + Seal must each relay one /move")
+        self.assertEqual(out["last"]["body"]["kind"], "do")
+        self.assertIn("prepare", out["last"]["body"]["text"].lower())
+
+    def test_no_display_only_stub_copy_remains(self):
+        # The old "not saved to the engine" display-only language must be GONE from the modal.
+        out = self._run(
+            self._mount("true", "false") +
+            "return ({ text: h.text() });"
+        )
+        self.assertNotIn("not saved to the engine", out["text"])
+        self.assertNotIn("(preview)", out["text"], "the Make-camp CTA is real now, not a (preview) stub")
+
+
+# A planner with the wizard subclass block carrying MULTIPLE options + per-option features, so the
+# 'browse all subclasses' assertion is meaningful regardless of the (single-entry) SRD data file.
+_PLANNER_WITH_SUBCLASSES = json.dumps({
+    "ok": True,
+    "planner": {
+        "options": [{
+            "class_name": "wizard",
+            "from": {"level": 2}, "to": {"level": 3, "class_level": 3},
+            "hp_gain": 6,
+            "features_gained": [{"name": "Arcane Tradition Subclass"}],
+            "choices": {"asi_required": False, "feat_allowed": False, "multiclass_allowed": True},
+            "subclass": {
+                "required": True,
+                "group_label": "Arcane Tradition",
+                "current": None,
+                "options": [
+                    {"name": "Evoker", "desc": "Sculpt spells.",
+                     "features": [{"name": "Evocation Savant", "desc": "Free evocation spells."},
+                                  {"name": "Sculpt Spells", "desc": "Carve safe pockets."}]},
+                    {"name": "Abjurer", "desc": "Ward against harm.",
+                     "features": [{"name": "Arcane Ward", "desc": "A shield of force."}]},
+                    {"name": "Diviner", "desc": "Glimpse the future.",
+                     "features": [{"name": "Portent", "desc": "Replace a roll."}]},
+                ],
+            },
+        }],
+    },
+})
+
+
+class LevelUpSubclassBrowseTests(_Harness):
+    """#607 — the level-up dialog browses ALL engine-exposed subclasses (with feature previews), and
+    the disabled Confirm says WHY."""
+
+    def _mount(self, hero=_HERO, planner=_PLANNER_WITH_SUBCLASSES):
+        return (
+            "h.setPlanner(" + planner + ");"
+            "h.mountLevelUp({ hero: " + hero + ", campaignId: 'camp1',"
+            " onClose: function(){}, onDone: function(){}, toast: function(){} });"
+            "await h.settle();"
+        )
+
+    def test_all_subclass_options_are_listed_not_just_the_first(self):
+        out = self._run(
+            self._mount() +
+            "return ({"
+            "  evoker: h.exists('levelup-subclass-option-evoker'),"
+            "  abjurer: h.exists('levelup-subclass-option-abjurer'),"
+            "  diviner: h.exists('levelup-subclass-option-diviner'),"
+            "  text: h.text() });"
+        )
+        self.assertGreaterEqual(out["evoker"], 1, "Evoker option must render")
+        self.assertGreaterEqual(out["abjurer"], 1, "Abjurer option must render — not just the first subclass")
+        self.assertGreaterEqual(out["diviner"], 1, "Diviner option must render — the dialog browses ALL options")
+        # the names are visible for a browsable comparison
+        for name in ("Evoker", "Abjurer", "Diviner"):
+            self.assertIn(name, out["text"])
+
+    def test_each_option_shows_its_feature_breakdown_for_comparison(self):
+        out = self._run(
+            self._mount() +
+            "return ({"
+            "  evoker_features: h.exists('levelup-subclass-features-evoker'),"
+            "  abjurer_features: h.exists('levelup-subclass-features-abjurer'),"
+            "  text: h.text() });"
+        )
+        self.assertGreaterEqual(out["evoker_features"], 1, "Evoker's feature list makes it a real comparison")
+        self.assertGreaterEqual(out["abjurer_features"], 1, "Abjurer's feature list renders too")
+        # the actual feature NAMES are present (so a player can compare what each grants)
+        self.assertIn("Sculpt Spells", out["text"])
+        self.assertIn("Arcane Ward", out["text"])
+        self.assertIn("Portent", out["text"])
+
+    def test_selecting_an_option_fills_the_named_subclass(self):
+        out = self._run(
+            self._mount() +
+            "var before = h.props('levelup-confirm');"
+            "await h.click('levelup-subclass-option-abjurer');"
+            "var after = h.props('levelup-confirm');"
+            "return ({ disabled_before: !!before.disabled, disabled_after: !!after.disabled });"
+        )
+        self.assertTrue(out["disabled_before"], "Confirm is disabled until a due subclass is named")
+        self.assertFalse(out["disabled_after"], "picking a subclass option must enable Confirm")
+
+    def test_disabled_confirm_explains_unnamed_subclass(self):
+        out = self._run(
+            self._mount() +
+            "var p = h.props('levelup-confirm');"
+            "var reasonShown = h.exists('levelup-confirm-reason');"
+            "return ({ disabled: !!p.disabled, title: p.title || '', reason_shown: reasonShown, text: h.text() });"
+        )
+        self.assertTrue(out["disabled"], "with a subclass due + unnamed, Confirm is disabled")
+        self.assertIn("Arcane Tradition", out["title"], "the tooltip must name what's required (the subclass group)")
+        self.assertGreaterEqual(out["reason_shown"], 1, "the why must also be shown inline (touch/screen-reader)")
+
+
+# A planner with NO legal level option (no XP earned) but a pending subclass on the hero — opening
+# the dialog to name the missed subclass. Confirm must block with a 'no XP' tooltip.
+_PLANNER_NO_XP = json.dumps({"ok": True, "planner": {"options": []}})
+_HERO_PENDING_NO_XP = (
+    "{ id: 'char_1', name: 'Dal Lightspark', class: 'wizard', level: 5, "
+    "xp: 100, xpMax: 14000, pendingSubclass: true, spells: [], spellSlots: {} }"
+)
+
+
+class LevelUpNoXpTooltipTests(_Harness):
+    """#607 — when the dialog is open on a pending subclass but no XP is earned for a new level, the
+    disabled Confirm explains 'no XP earned' rather than being a silently-dead button."""
+
+    def test_no_xp_confirm_is_disabled_with_an_explanatory_tooltip(self):
+        out = self._run(
+            "h.setPlanner(" + _PLANNER_NO_XP + ");"
+            "h.mountLevelUp({ hero: " + _HERO_PENDING_NO_XP + ", campaignId: 'camp1',"
+            " onClose: function(){}, onDone: function(){}, toast: function(){} });"
+            "await h.settle();"
+            "var p = h.props('levelup-confirm');"
+            "var reasonShown = h.exists('levelup-confirm-reason');"
+            "return ({ disabled: !!p.disabled, title: (p.title || '').toLowerCase(),"
+            "  reason_shown: reasonShown, text: h.text().toLowerCase() });"
+        )
+        self.assertTrue(out["disabled"], "with no XP-legal level, Confirm must be disabled")
+        self.assertIn("xp", out["title"], "the tooltip must explain it's blocked on XP (no level to advance into)")
+        self.assertGreaterEqual(out["reason_shown"], 1, "the no-XP reason must be shown inline too")
+        self.assertIn("no xp", out["text"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Two MAJOR viewer-side UI-wiring bugs the optimizer persona filed in the **RRI-5e98e6f** 5-persona sweep (2026-06-14). In both, the **engine already works** (the 31-PR fix-phase landed `long_rest` / `short_rest` / `prepare_spells` and PR #742 wired `preview_level_up` subclass blocks) — the viewer just did not display/use it. This is viewer wiring + rendering only; the engine is untouched.

### (1) Rest & Prepare is now functional — #610 / #617
`RestPrepareModal` (screen-character.jsx) had its **"Make camp"** and **"Seal the choices"** CTAs hard-`disabled` as display-only stubs (`"…not saved to the engine"`), so **spell re-preparation + slot recovery were dead**. They now relay a composed `do` move-intent to `/move` — the **same read-only move-sink path** `camp-sidebar.jsx` and `LevelUpModal` already use (the engine is the sole writer; the viewer never mutates snapshot). The engine resolves it through `long_rest`/`short_rest` + `prepare_spells` (refresh HP + slots, advance the clock, record prepared spells).

- Enabled + functional when a session is attached (`can_act`) **and** the DM isn't mid-turn (`dmBusy`, #402); honestly **disabled + explained** (hover `title` **and** an inline note) otherwise.
- Synchronous double-submit ref-lock (mirrors `LevelUpModal` / screen-table.jsx).
- Threads `liveSession` into `ScreenCharacter` (additive prop) for the `dmBusy` gate, mirroring `ScreenMap → CampSidebar`.

### (2) Level-up dialog browses ALL subclasses + says why Confirm is disabled — #607
- The subclass picker now lists **every** engine-exposed option (`option.subclass.options`), each with its **level-3 feature breakdown** — a real browsable comparison ("what each tradition grants"), not just the first / a name-only line.
- The disabled **"Confirm advancement"** now explains **WHY** (hover tooltip + inline note): a subclass needs naming, or **no XP is earned yet** (the planner lists no legal level to advance into) — never a silently-dead button.

## Invariants held
Viewer stays **read-only + move-sink** (renders via React text nodes / `createElement`; no `dangerouslySetInnerHTML`; client `sanitizeNarration` preserved). **Additive** — no existing screen/test broken. **Wire contracts frozen** (`/move kind:"do"`, `/build-options`, `/character-surface`). **No engine change** — round-trip safe.

## Tests
New `viewer/tests/test_rest_camp_levelup_wiring.py` — the JSX behaviour harness (transpiles the real `screen-character.jsx` through the vendored babel under a node vm, renders the real `RestPrepareModal` / `LevelUpModal`, drives the scripted `/build-options` + `/move` fetch, finds nodes by testid, invokes `onClick`, re-renders). **11 new tests** (8 verified RED against pre-fix screen-character.jsx).

- `RestPrepareWiringTests` (6): Make-camp enabled + POSTs one `do` /move (long-rest intent naming slot recovery); disabled + reason when read-only / dm-busy; opening writes nothing; the prep step's Seal CTA relays too; no display-only "(preview)" / "not saved" copy remains.
- `LevelUpSubclassBrowseTests` (4): all subclass options + their feature breakdowns render; selecting one enables Confirm; the unnamed-subclass disable carries the inline+tooltip why.
- `LevelUpNoXpTooltipTests` (1): no-XP Confirm is disabled with an explanatory "no XP earned" tooltip + inline note.

**Gates:** full viewer suite **516 passed / 1 skipped**; `bash qa/fast_gate.sh` Tier-0 **PASS** (195 deterministic engine tests, engine untouched).

These are gate-movers from the RRI-5e98e6f optimizer sweep. **Do not merge** (milestone v1.0.4 staging).