### PR TITLE
fix(viewer): inventory inspector prefers persisted item stats over by-name catalog re-resolve (#756 / F09-7)

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -946,11 +946,13 @@ function StatLine({ k, v }) {
 }
 
 // A short stat line for an equipped item's tooltip / slot caption from the read-model's
-// REAL catalog stats — "1d8 slashing" for a weapon, "AC 18" for armor — or "" when the
-// item is a catalog-miss (then we show just its name; never a fabricated stat).
+// REAL stats — "1d8 slashing" for a weapon, "AC 14 + DEX (max +2)" for armor, a shield's
+// bonus "+2" — or "" when neither the item's persisted stats nor the catalog have one (then
+// we show just its name; never a fabricated stat). acDisplay carries the F09-6 dex rule.
 function equippedStat(it) {
   if (!it) return "";
   if (it.damage) return [it.damage, it.damageType].filter(Boolean).join(" ");
+  if (it.acDisplay) return it.acDisplay;
   if (typeof it.ac === "number") return `AC ${it.ac}`;
   return "";
 }

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -553,7 +553,14 @@ function itemStatRows(item) {
     const v = item.versatile ? `${dmg} (${item.versatile} two-handed)` : dmg;
     rows.push({ k: "Damage", v });
   }
-  if (typeof item.ac === "number") rows.push({ k: "Armor Class", v: String(item.ac) });
+  // F09-6 armor dex rule: the server composes acDisplay from REAL fields — medium reads
+  // "AC 14 + DEX (max +2)", a shield reads its bonus "+2" (not the misleading flat "AC 2").
+  // Fall back to the bare AC only for an older surface that predates acDisplay.
+  if (item.acDisplay) {
+    rows.push({ k: item.armorCategory === "shield" ? "Shield" : "Armor", v: item.acDisplay });
+  } else if (typeof item.ac === "number") {
+    rows.push({ k: "Armor Class", v: String(item.ac) });
+  }
   if (item.attunement) rows.push({ k: "Attunement", v: "Required" });
   return rows;
 }
@@ -713,12 +720,14 @@ function ItemDetail({ item, hero, toast, canAct, postInvMove, examineSignal }) {
         </>
       )}
 
-      {/* Stat block — Weight/Value always (catalog-backfilled), plus the REAL combat stats the
-          read-model now surfaces from the SRD item catalog: damage dice + type for weapons (with
-          the Versatile two-handed die folded in, #756), base AC for armor/shields. A field absent
-          from the catalog record is simply not rendered — never a fabricated number (e.g. a
-          free-text "Longsword +1" the catalog can't resolve shows weight/value only). Built from
-          the pure itemStatRows() so the harness drives the exact shipped rows. */}
+      {/* Stat block — Weight/Value always, plus the REAL combat stats the read-model surfaces:
+          damage dice + type for weapons (Versatile two-handed die folded in, #756), and the
+          F09-6 armor line for armor/shields (medium "AC 14 + DEX (max +2)", a shield's bonus
+          "+2"). The stats come from the item's OWN persisted fields first (F09-7 / #756),
+          falling back to the SRD catalog only for a datum it lacks — so a renamed/enchanted
+          "Longsword +1" the catalog can't resolve still shows its real numbers, while an item
+          with no stat renders no row (never a fabricated number). Built from the pure
+          itemStatRows() so the harness drives the exact shipped rows. */}
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginTop: 14 }}>
         {statRows.map((r) => <StatLine key={r.k} k={r.k} v={r.v} />)}
       </div>

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3547,12 +3547,14 @@ _ABILITY_KEYS = ("strength", "dexterity", "constitution", "intelligence", "wisdo
 def _equipped_items(ch: dict) -> list[dict]:
     """Projected list of a character's EQUIPPED gear for the heroes-screen paper-doll +
     the inventory equip slots. Each entry carries name/slot/glyph plus the item's REAL SRD
-    combat stats (kind / damage / damageType / ac / rarity / attunement) when the catalog
-    resolves the name — so the doll's slot tooltip can read "Main Hand · 1d8 slashing"
-    honestly, and stays just the name when the catalog has no record. The engine carries no
-    canonical slot on the Item model, so `slot` is whatever the snapshot recorded (else "Worn");
-    the screen's name->slot inference places it in the doll cell (forward-compatible if the
-    engine ever emits a real slot id)."""
+    combat stats (kind / damage / damageType / ac / rarity / attunement, plus the F09-6 armor
+    dex-rule fields) — PREFERRING the item's own persisted F09-7 stats and falling back to the
+    by-name catalog only for a field it lacks (so the doll's slot tooltip reads "Main Hand ·
+    1d8 slashing" honestly even for a renamed/enchanted blade the catalog can't resolve, and
+    stays just the name when neither source has a stat). The engine carries no canonical slot
+    on the Item model, so `slot` is whatever the snapshot recorded (else "Worn"); the screen's
+    name->slot inference places it in the doll cell (forward-compatible if the engine ever
+    emits a real slot id)."""
     out: list[dict] = []
     for it in (ch.get("inventory") or []):
         if not isinstance(it, dict) or not bool(it.get("equipped")):
@@ -3561,17 +3563,20 @@ def _equipped_items(ch: dict) -> list[dict]:
         if not name:
             continue
         meta = _catalog_meta(name)
-        damage = _text(meta.get("damage")) if meta else ""
-        ac_raw = meta.get("ac") if meta else None
+        stats = _item_stat_block(it, meta)
         out.append({
             "slot": _text(it.get("slot"), "Worn"),
             "name": name,
             "glyph": name.lower(),
-            "kind": _text(meta.get("kind")) if meta else "",
-            "damage": damage,
-            "damageType": _text(meta.get("damage_type")) if (meta and damage) else "",
-            "ac": int(ac_raw) if isinstance(ac_raw, (int, float)) else None,
-            "rarity": (_text(it.get("rarity")) or (_text(meta.get("rarity")) if meta else "")) or "",
+            "kind": stats["kind"],
+            "damage": stats["damage"],
+            "damageType": stats["damageType"],
+            "ac": stats["ac"],
+            "armorCategory": stats["armorCategory"],
+            "acDexMod": stats["acDexMod"],
+            "acDexCap": stats["acDexCap"],
+            "acDisplay": stats["acDisplay"],
+            "rarity": stats["rarity"],
             "attunement": bool(it.get("requires_attunement") or (meta.get("requires_attunement") if meta else False)),
         })
     return out
@@ -4201,6 +4206,92 @@ def _catalog_stat_block(name: str) -> dict:
     }
 
 
+def _armor_ac_display(ac: "int | None", armor_category: str, ac_dex_mod: str, ac_dex_cap: "int | None") -> str:
+    """Compose the F09-6 armor-class line for the item inspector from REAL fields only.
+
+    A SHIELD grants a +N BONUS to AC (not a flat AC), so it reads "+2" — never the bare "AC 2"
+    that misreads as a flat armor class. BODY armor reads its base AC plus exactly the DEX rule
+    its category allows: medium caps the modifier ("AC 14 + DEX (max +2)"), light adds it in
+    full ("AC 11 + DEX"), heavy adds none ("AC 18"). Returns "" when there is no AC datum at
+    all, so the screen renders no AC row (HONEST — never a fabricated number)."""
+    if ac is None:
+        return ""
+    if (armor_category or "").lower() == "shield":
+        return f"+{ac}"
+    mod = (ac_dex_mod or "").lower()
+    if mod == "capped" and ac_dex_cap is not None:
+        return f"AC {ac} + DEX (max +{ac_dex_cap})"
+    if mod == "full":
+        return f"AC {ac} + DEX"
+    return f"AC {ac}"
+
+
+def _item_stat_block(item: dict, meta: dict) -> dict:
+    """Resolve an item's mechanical stat block for the read-model, PREFERRING the item's own
+    persisted F09-7 fields (kind / rarity / cost_gp / damage / damage_type / ac /
+    armor_category / ac_dex_mod / ac_dex_cap / properties — stamped onto the Item at grant time
+    by add_item/buy_item) and falling back to the by-name SRD catalog record (``meta``) ONLY for
+    a field the item itself lacks.
+
+    This is the #756 / F09-7 fix: an item's stats now live on the Item, so a renamed/enchanted
+    item the catalog can't resolve ("Longsword +1", "Healing Potion") still renders its REAL
+    numbers — while a pre-F09-7 snapshot (no stat fields at all) still backfills from the catalog
+    exactly as before. HONEST: a datum neither persisted nor catalog-resolvable stays "" / None,
+    never fabricated.
+
+    Returns camelCase keys for the screen contract (``damage_type`` -> ``damageType``;
+    ``cost_gp`` -> the numeric ``costGp`` the caller renders as a gp "value" string), the raw
+    armor dex-rule fields (``armorCategory`` / ``acDexMod`` / ``acDexCap``), and a composed
+    ``acDisplay`` honouring the F09-6 rule."""
+    meta = meta if isinstance(meta, dict) else {}
+
+    def pick_str(field: str, meta_key: "str | None" = None) -> str:
+        v = _text(item.get(field))
+        return v if v else _text(meta.get(meta_key or field))
+
+    def pick_num(field: str, meta_key: "str | None" = None):
+        v = _num(item.get(field))
+        return v if v is not None else _num(meta.get(meta_key or field))
+
+    damage = pick_str("damage")
+    ac_num = pick_num("ac")
+    ac = int(ac_num) if ac_num is not None else None
+    armor_category = pick_str("armor_category")
+    ac_dex_mod = pick_str("ac_dex_mod")
+    cap_num = pick_num("ac_dex_cap")
+    ac_dex_cap = int(cap_num) if cap_num is not None else None
+    # The item persists `cost_gp`; the catalog record carries the same datum under `cost`. A
+    # legacy free-text grant may instead carry a bare `cost`, so honour that last.
+    cost = pick_num("cost_gp", "cost")
+    if cost is None:
+        cost = _num(item.get("cost"))
+
+    # Property chips: prefer the item's own persisted SRD tags (stealth-disadvantage, str-13,
+    # attune:…); fall back to the catalog's only when the item carries none. Same formatter.
+    raw_props = item.get("properties")
+    if not (isinstance(raw_props, list) and raw_props):
+        raw_props = meta.get("properties")
+    prop_chips = _catalog_property_chips({"properties": raw_props or []})
+
+    return {
+        "kind": pick_str("kind"),
+        "rarity": pick_str("rarity"),
+        # Damage type is only meaningful alongside a dice expression (mirrors today's contract).
+        "damage": damage,
+        "damageType": pick_str("damage_type") if damage else "",
+        # #756 Versatile two-handed die — not a persisted Item field today, so it resolves from
+        # the catalog (persisted-first via pick_str keeps it forward-compatible). Damage-gated.
+        "versatile": pick_str("versatile") if damage else "",
+        "ac": ac,
+        "armorCategory": armor_category,
+        "acDexMod": ac_dex_mod,
+        "acDexCap": ac_dex_cap,
+        "acDisplay": _armor_ac_display(ac, armor_category, ac_dex_mod, ac_dex_cap),
+        "costGp": cost,
+        "propertyChips": prop_chips,
+    }
+
+
 def _inventory_items(cid: str, ch: dict) -> list[dict]:
     inventory = ch.get("inventory")
     out: list[dict] = []
@@ -4213,63 +4304,55 @@ def _inventory_items(cid: str, ch: dict) -> list[dict]:
         if not name:
             continue
         qty = _num(item.get("quantity"))
-        weight = _num(item.get("weight"))
-        cost = _num(item.get("cost"))
-        rarity = _text(item.get("rarity"))
-        # Resolve the SRD catalog record ONCE. It is the source of the item's stat block
-        # (damage dice / damage type / base AC / weapon properties / attunement clause) and
-        # also backfills weight/value/rarity the granted item omits. The engine stays the
-        # source of truth — a granted item's own value always wins; the catalog only fills
-        # gaps and supplies combat stats the Item model has no field for. A name the catalog
-        # can't resolve (e.g. "Longsword +1", "Healing Potion") yields {} -> the stat fields
-        # stay empty exactly as today (HONEST: never fabricate a number the engine lacks).
+        # Resolve the SRD catalog record ONCE — used both as the FALLBACK source for any stat
+        # the item itself doesn't persist and to backfill weight the granted item omits. The
+        # item's OWN persisted stats win (F09-7 / #756): a name the catalog can't resolve
+        # ("Longsword +1", "Healing Potion") still renders its persisted numbers, and a
+        # pre-F09-7 snapshot (no stat fields) still backfills from the catalog exactly as today.
+        # HONEST: a datum neither persisted nor resolvable stays empty — never fabricated.
         meta = _catalog_meta(name)
-        if meta:
-            if weight is None or weight <= 0:
-                weight = _num(meta.get("weight"))
-            if cost is None or cost <= 0:
-                cost = _num(meta.get("cost"))
-            if not rarity:
-                rarity = _text(meta.get("rarity"))
-        # Damage / AC: real catalog stats. Damage type is only meaningful with a dice expr.
-        damage = _text(meta.get("damage")) if meta else ""
-        damage_type = _text(meta.get("damage_type")) if (meta and damage) else ""
-        # #756: a Versatile weapon's two-handed damage die (e.g. "1d8") — only meaningful
-        # alongside the one-handed `damage`; absent for non-versatile gear.
-        versatile = _text(meta.get("versatile")) if (meta and damage) else ""
-        ac_raw = meta.get("ac") if meta else None
-        ac = int(ac_raw) if isinstance(ac_raw, (int, float)) else None
-        # Catalog `kind` ("weapon"/"armor"/"wondrous"/"potion"/"ring"/…) is the SRD's own
-        # classification; carry it through as the item's category alongside the coarse `type`
-        # the grid filters on (so the detail can read "Martial Weapon" / "Wondrous Item").
-        kind = _text(meta.get("kind")) if meta else ""
-        attunement = bool(item.get("requires_attunement") or (meta.get("requires_attunement") if meta else False))
-        # Property chips: the granted item's recorded "attuned" state first, then the catalog's
-        # real per-item properties (weapon simple/improvised, attunement clause). De-duped, no fab.
+        stats = _item_stat_block(item, meta)
+        # Weight prefers the item's recorded value (model default 0.0 -> backfill from catalog).
+        weight = _num(item.get("weight"))
+        if (weight is None or weight <= 0) and meta:
+            weight = _num(meta.get("weight"))
+        cost = stats["costGp"]
+        # Property chips: the granted item's recorded "attuned" state first, then its own
+        # (or the catalog's) per-item property tags. De-duped, never fabricated.
         properties = ["Attuned"] if item.get("attuned") else []
-        for chip in (_catalog_property_chips(meta) if meta else []):
+        for chip in stats["propertyChips"]:
             if chip not in properties:
                 properties.append(chip)
+        attunement = bool(item.get("requires_attunement") or (meta.get("requires_attunement") if meta else False))
         out.append({
             "id": f"{cid}:{idx}:{name}",
             "owner": cid,
             "name": name,
             "qty": int(qty) if qty is not None else 1,
             "type": _infer_item_type(name, item),
-            "kind": kind,
+            # Catalog `kind` ("weapon"/"armor"/"wondrous"/"potion"/…) is the SRD's own
+            # classification; carried alongside the coarse `type` the grid filters on (so the
+            # detail can read "Martial Weapon" / "Wondrous Item").
+            "kind": stats["kind"],
             "glyph": _text(item.get("glyph"), name.lower()),
             "equipped": bool(item.get("equipped")),
             "weight": f"{weight:g} lb" if weight is not None and weight > 0 else "—",
             "value": f"{cost:g} gp" if cost is not None and cost > 0 else "—",
-            "rarity": rarity or "common",
+            "rarity": stats["rarity"] or "common",
             "desc": _text(item.get("description"), "No description recorded."),
-            # Combat stat block (empty string / None when the catalog has no such datum —
+            # Combat stat block (empty string / None when neither persisted nor resolvable —
             # the screen hides each row that is blank). damage e.g. "1d8", damageType "slashing",
-            # ac e.g. 18 (base AC for armor / shields). versatile e.g. "1d8" (two-handed die, #756).
-            "damage": damage,
-            "damageType": damage_type,
-            "versatile": versatile,
-            "ac": ac,
+            # versatile e.g. "1d8" (two-handed die, #756), ac e.g. 18 (base AC for armor / +N for
+            # a shield). armorCategory / acDexCap drive the F09-6 dex-rule line (acDisplay:
+            # "AC 14 + DEX (max +2)" / a shield's "+2").
+            "damage": stats["damage"],
+            "damageType": stats["damageType"],
+            "versatile": stats["versatile"],
+            "ac": stats["ac"],
+            "armorCategory": stats["armorCategory"],
+            "acDexMod": stats["acDexMod"],
+            "acDexCap": stats["acDexCap"],
+            "acDisplay": stats["acDisplay"],
             "attunement": attunement,
             "attuned": bool(item.get("attuned")),
             "properties": properties,

--- a/viewer/tests/test_item_inspector.py
+++ b/viewer/tests/test_item_inspector.py
@@ -122,6 +122,28 @@ class ItemInspectorBehaviourTests(unittest.TestCase):
         )
         self.assertNotIn("Armor Class", {r["k"] for r in rows})
 
+    def test_acdisplay_dex_rule_row_for_medium_armor(self):
+        # F09-6: when the read-model supplies the composed acDisplay, the armor row reads the
+        # full dex rule under an "Armor" label (not the redundant "Armor Class AC 14…").
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Breastplate', type: 'armor', ac: 14, "
+            "  armorCategory: 'medium', acDisplay: 'AC 14 + DEX (max +2)' });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Armor"), "AC 14 + DEX (max +2)")
+        self.assertNotIn("Armor Class", kv)  # the acDisplay branch supersedes the bare row
+
+    def test_acdisplay_shield_shows_bonus_not_flat_ac(self):
+        # F09-6: a shield grants a +N bonus, so the row reads "+2" under a "Shield" label —
+        # never the misleading flat "AC 2".
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Shield', type: 'armor', ac: 2, "
+            "  armorCategory: 'shield', acDisplay: '+2' });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Shield"), "+2")
+        self.assertNotIn("Armor Class", kv)
+
     # --- symptom 2: a VERSATILE weapon shows its 1d8 two-handed damage --------
     def test_versatile_weapon_shows_two_handed_die(self):
         """A Versatile weapon must read its one-handed damage AND its two-handed die — the

--- a/viewer/tests/test_readmodel_surfaces.py
+++ b/viewer/tests/test_readmodel_surfaces.py
@@ -534,6 +534,110 @@ class ReadModelSurfaceTests(unittest.TestCase):
         self.assertTrue(cloak["attunement"])
         self.assertIn("Attuned", cloak["properties"])
 
+    def test_inventory_surface_prefers_persisted_stats_when_catalog_cannot_resolve(self):
+        # #756 / F09-7 root-cause fix: a renamed/enchanted item the SRD catalog can NOT resolve
+        # by name still renders its REAL stats — because the engine now persists them on the
+        # Item at grant time (add_item/buy_item). The viewer prefers those persisted fields over
+        # the (failing) by-name catalog re-resolve. The by-name path used to drop these entirely.
+        self.assertEqual(server._catalog_meta("Moonsteel Saber +1"), {})  # the catalog truly misses
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["characters"]["cassian"]["inventory"].append({
+            "name": "Moonsteel Saber +1", "quantity": 1, "equipped": False,
+            "kind": "weapon", "rarity": "very rare", "cost_gp": 750,
+            "damage": "1d6", "damage_type": "slashing", "properties": ["finesse"],
+        })
+        self._write("camp_persist", snap)
+        _status, surface = self._get_json("/inventory-surface?campaign=camp_persist")
+        cassian = {m["id"]: m for m in surface["party"]}["cassian"]
+        blade = {i["name"]: i for i in cassian["items"]}["Moonsteel Saber +1"]
+        self.assertEqual(blade["damage"], "1d6")
+        self.assertEqual(blade["damageType"], "slashing")
+        self.assertEqual(blade["kind"], "weapon")
+        self.assertEqual(blade["rarity"], "very rare")
+        self.assertEqual(blade["value"], "750 gp")          # cost_gp -> the "value" gp string
+        self.assertIn("finesse", blade["properties"])       # persisted SRD tag surfaces as a chip
+
+    def test_inventory_surface_persisted_stats_win_over_resolvable_catalog(self):
+        # Preference is PERSISTED-FIRST, not catalog-first: a "Dwarven Plate" the catalog DOES
+        # resolve (base AC 18) but whose snapshot persists a different AC (20) renders the
+        # persisted 20 — the engine, not the read-time catalog, is the source of truth (F09-7).
+        self.assertEqual(server._catalog_meta("Dwarven Plate").get("ac"), 18)  # catalog says 18
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["characters"]["cassian"]["inventory"].append({
+            "name": "Dwarven Plate", "quantity": 1, "kind": "armor", "ac": 20,
+            "armor_category": "heavy", "ac_dex_mod": "none",
+        })
+        self._write("camp_persistwin", snap)
+        _status, surface = self._get_json("/inventory-surface?campaign=camp_persistwin")
+        cassian = {m["id"]: m for m in surface["party"]}["cassian"]
+        plate = {i["name"]: i for i in cassian["items"]}["Dwarven Plate"]
+        self.assertEqual(plate["ac"], 20)
+        self.assertEqual(plate["acDisplay"], "AC 20")
+
+    def test_inventory_surface_armor_dex_rule_display(self):
+        # F09-6 armor dex rule, surfaced from PERSISTED fields (names the catalog can't resolve).
+        # Medium armor caps the DEX bonus -> "AC 14 + DEX (max +2)"; a shield grants a BONUS, so
+        # it reads "+2" (NOT the misleading flat "AC 2"); heavy armor adds no DEX -> flat "AC 20";
+        # light armor adds the full DEX -> "AC 11 + DEX".
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["characters"]["cassian"]["inventory"].extend([
+            {"name": "Bronze Breastplate", "quantity": 1, "kind": "armor", "ac": 14,
+             "armor_category": "medium", "ac_dex_mod": "capped", "ac_dex_cap": 2},
+            {"name": "Battered Shield", "quantity": 1, "kind": "armor", "ac": 2,
+             "armor_category": "shield", "ac_dex_mod": "none"},
+            {"name": "Ironwall Plate", "quantity": 1, "kind": "armor", "ac": 20,
+             "armor_category": "heavy", "ac_dex_mod": "none"},
+            {"name": "Quilted Jerkin", "quantity": 1, "kind": "armor", "ac": 11,
+             "armor_category": "light", "ac_dex_mod": "full"},
+        ])
+        self._write("camp_armor", snap)
+        _status, surface = self._get_json("/inventory-surface?campaign=camp_armor")
+        cassian = {m["id"]: m for m in surface["party"]}["cassian"]
+        items = {i["name"]: i for i in cassian["items"]}
+        bp = items["Bronze Breastplate"]
+        self.assertEqual(bp["acDisplay"], "AC 14 + DEX (max +2)")
+        self.assertEqual(bp["armorCategory"], "medium")
+        self.assertEqual(bp["acDexCap"], 2)
+        self.assertEqual(items["Battered Shield"]["acDisplay"], "+2")
+        self.assertEqual(items["Battered Shield"]["armorCategory"], "shield")
+        self.assertEqual(items["Ironwall Plate"]["acDisplay"], "AC 20")
+        self.assertEqual(items["Quilted Jerkin"]["acDisplay"], "AC 11 + DEX")
+
+    def test_inventory_surface_armor_dex_rule_falls_back_to_catalog(self):
+        # Pre-F09-7 snapshot: a free-text armor with NO persisted stat fields still renders the
+        # F09-6 dex rule via the by-name catalog re-resolve — so old saves don't regress. The
+        # real catalog "Breastplate" is medium/cap-2; the real "Shield" is a +2 bonus.
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["characters"]["cassian"]["inventory"].extend([
+            {"name": "Breastplate", "quantity": 1},
+            {"name": "Shield", "quantity": 1},
+        ])
+        self._write("camp_armorfb", snap)
+        _status, surface = self._get_json("/inventory-surface?campaign=camp_armorfb")
+        cassian = {m["id"]: m for m in surface["party"]}["cassian"]
+        items = {i["name"]: i for i in cassian["items"]}
+        self.assertEqual(items["Breastplate"]["acDisplay"], "AC 14 + DEX (max +2)")
+        self.assertEqual(items["Shield"]["acDisplay"], "+2")
+
+    def test_equipped_items_prefer_persisted_stats_and_dex_rule(self):
+        # The heroes-screen paper-doll projection (_equipped_items) gets the same persisted-first
+        # treatment: an EQUIPPED renamed blade the catalog can't resolve still carries its damage,
+        # and an equipped shield carries the "+2" dex-rule display (not "AC 2").
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["characters"]["cassian"]["inventory"].extend([
+            {"name": "Moonsteel Saber +1", "quantity": 1, "equipped": True,
+             "kind": "weapon", "damage": "1d6", "damage_type": "slashing"},
+            {"name": "Battered Shield", "quantity": 1, "equipped": True, "kind": "armor",
+             "ac": 2, "armor_category": "shield", "ac_dex_mod": "none"},
+        ])
+        self._write("camp_equip", snap)
+        _status, surface = self._get_json("/inventory-surface?campaign=camp_equip")
+        cassian = {m["id"]: m for m in surface["party"]}["cassian"]
+        equipped = {e["name"]: e for e in cassian["equipped"]}
+        self.assertEqual(equipped["Moonsteel Saber +1"]["damage"], "1d6")
+        self.assertEqual(equipped["Moonsteel Saber +1"]["damageType"], "slashing")
+        self.assertEqual(equipped["Battered Shield"]["acDisplay"], "+2")
+
     # ── relations ───────────────────────────────────────────────────────────────
 
     def test_relations_surface_projects_factions_npcs_and_arcs(self):


### PR DESCRIPTION
## Why

The #756 inventory inspector recovered each item's stat block by **re-resolving the SRD catalog by name at read time** (`_inventory_items` / `_equipped_items` in `viewer/server.py`). Two problems:

1. It **fails for renamed/enchanted items** the catalog can't resolve — e.g. `"Longsword +1"`, `"Healing Potion"` → blank stat rows.
2. It **ignored the per-item stats the engine now persists** at grant time (F09-7, #862): `kind / rarity / cost_gp / damage / damage_type / ac / armor_category / ac_dex_mod / ac_dex_cap / properties` are stamped onto the `Item` by `add_item` / `buy_item` from the SRD catalog — but the viewer never read them.

## What

- **Persisted-first resolution.** New shared `_item_stat_block(item, meta)` prefers the item's own persisted F09-7 fields and falls back to the by-name `_catalog_meta` re-resolve **only per-field** — so renamed/enchanted items render their real numbers, and **pre-F09-7 snapshots still backfill from the catalog** exactly as before. Used by both `_inventory_items` and `_equipped_items` (DRY).
- **camelCase contract mapping.** `damage_type` → `damageType`; `cost_gp` → the `"value"` gp string (the old code read a nonexistent `cost` key, so persisted prices never showed).
- **F09-6 armor dex rule** surfaced in the item detail via new `_armor_ac_display(...)`:
  - medium → `"AC 14 + DEX (max +2)"`
  - shield → its **bonus** `"+2"` (not the misleading flat `"AC 2"`)
  - light → `"AC 11 + DEX"`, heavy → flat `"AC 18"`
- **Screen:** `screen-inventory.jsx` (~L557) renders `acDisplay`; `screen-character.jsx`'s `equippedStat` (paper-doll tooltip) gets the same shield fix.
- **HONEST contract preserved:** a datum neither persisted nor catalog-resolvable stays `""` / `None` — never fabricated.

## Tests

`viewer/tests/test_readmodel_surfaces.py` (+5):
- persisted stats render when the catalog **misses** (`"Moonsteel Saber +1"`);
- persisted **wins over** a resolvable catalog record (Dwarven Plate: persisted AC 20 beats catalog 18);
- shield / medium / heavy / light **dex-rule display** strings;
- **catalog fallback** for a pre-F09-7 free-text armor (old saves don't regress);
- **equipped-item** persisted stats + shield dex rule.

Full local viewer suite: **510 passed, 1 skipped** (`uv run … pytest viewer/tests -p no:xdist`).

## Invariants
Additive, viewer-only (read-model projection + one JSX render line). No engine/state writes; the engine stays the sole writer and source of truth (persisted item stats win over the read-time catalog). Refs #756, F09-7 (#862), F09-6.