### PR TITLE
fix(viewer): unify Market+Stash currency on one shared purse helper (RRI-5e98e6f)

### DIFF
--- a/viewer/openworlds/chrome.jsx
+++ b/viewer/openworlds/chrome.jsx
@@ -35,6 +35,45 @@ window.itemArtScope = function itemArtScope(itemOrName) {
   return aliased ? "item-" + aliased : "";
 };
 
+// ── Shared currency layer (RRI-5e98e6f optimizer finding: "Stash 35 GP, Market 232 GP") ──
+// The coin purse is engine-owned (server `_currency_for` → {cp,sp,ep,gp,pp} ints) and rides on
+// EACH party member of BOTH the /character-surface and /inventory-surface read models
+// (`party[i].currency`). The Market used to read a non-existent top-level `surface.currency` and
+// fell through to a hardcoded demo purse ({gp:232}), while the Stash showed the live per-hero
+// purse (e.g. 35gp) — the 35-vs-232 contradiction. Both screens now derive their displayed coins
+// from these ONE shared helpers so the same character renders the same purse + total everywhere.
+// Read-only: these only project engine-owned numbers; they never write campaign state.
+const _COIN_KEYS = ["pp", "gp", "sp", "ep", "cp"];
+
+// Coerce any currency-ish object to the canonical {pp,gp,sp,ep,cp} int shape (mirrors the engine
+// `_currency_for`). Tolerates undefined/null/garbage by zeroing — never throws, never invents.
+window.normalizeCurrency = function normalizeCurrency(cur) {
+  const src = (cur && typeof cur === "object") ? cur : {};
+  const out = {};
+  for (const k of _COIN_KEYS) {
+    const n = Number(src[k]);
+    out[k] = Number.isFinite(n) ? Math.trunc(n) : 0;
+  }
+  return out;
+};
+
+// The ONE 5e gp-equivalent conversion (1pp=10gp, 1ep=0.5gp, 1sp=0.1gp, 1cp=0.01gp). Using this
+// single converter on both screens is what keeps a "total" from diverging between them.
+window.currencyTotalGp = function currencyTotalGp(cur) {
+  const c = window.normalizeCurrency(cur);
+  return c.pp * 10 + c.gp + c.ep * 0.5 + c.sp * 0.1 + c.cp * 0.01;
+};
+
+// Select the SAME source-of-truth hero's purse both screens render: the active hero by id, else
+// the first party member. Both surfaces are projected from the same snapshot in the same `party`
+// order, so an absent/blank active id (the Market has no hero switcher) lands on party[0] — which
+// is exactly the Stash's default active hero. Always returns the normalized coin shape.
+window.partyPurse = function partyPurse(party, activeId) {
+  const list = Array.isArray(party) ? party : [];
+  const hero = list.find((p) => p && p.id === activeId) || list[0] || null;
+  return window.normalizeCurrency(hero && hero.currency);
+};
+
 const NAV_GROUPS = [
   {
     id: "g_table", label: "Table", glyph: "dice",

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -98,6 +98,13 @@ function ScreenInventory({ onNavigate, state, setState }) {
   }, [loadSurface]);
 
   const hero = party.find((p) => p.id === activeHero) || party[0] || null;
+  // RRI-5e98e6f: derive the displayed coin purse from the ONE shared selector + normalizer the
+  // Market also uses, so the same character's coins read identically on both screens (no
+  // 35-vs-232 divergence). partyPurse resolves the active hero (else party[0]) and zeroes/ints it.
+  const purse = window.partyPurse
+    ? window.partyPurse(party, hero?.id || activeHero)
+    : { pp: 0, gp: Number(hero?.currency?.gp) || 0, sp: 0, ep: 0, cp: 0 };
+  const purseTotalGp = window.currencyTotalGp ? window.currencyTotalGp(purse) : purse.gp;
   // The stash is the active hero's own pack (live surface); never the demo stash.
   const stash = (hero && Array.isArray(hero.items)) ? hero.items
     : (Array.isArray(surface?.stash) ? surface.stash : []);
@@ -181,16 +188,26 @@ function ScreenInventory({ onNavigate, state, setState }) {
         {/* I-09: PP/GP/SP are the everyday 5e coinage — always shown. Electrum (EP) and Copper
             (CP) are minted only rarely; the surface emits them as 0 by default, so an empty
             EP/CP slot is dead chrome. Render those two only when the hero actually holds them
-            (data-driven, hide-when-absent) — never fabricate a metal the engine isn't tracking. */}
+            (data-driven, hide-when-absent) — never fabricate a metal the engine isn't tracking.
+            RRI-5e98e6f: the displayed purse comes from window.partyPurse(party, activeHero) — the
+            ONE shared selector the Market also uses — so the Stash and the Market never disagree
+            on the same character's coins (the 35-vs-232 contradiction). */}
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 6, marginTop: 6 }}>
-          <CoinSlot tone="#e5e4e2" label="PP" val={String(hero.currency?.pp ?? 0)} />
-          <CoinSlot tone="#d4b97a" label="GP" val={String(hero.currency?.gp ?? 0)} />
-          <CoinSlot tone="#c0c0c0" label="SP" val={String(hero.currency?.sp ?? 0)} />
+          <CoinSlot tone="#e5e4e2" label="PP" val={String(purse.pp)} />
+          <CoinSlot tone="#d4b97a" label="GP" val={String(purse.gp)} />
+          <CoinSlot tone="#c0c0c0" label="SP" val={String(purse.sp)} />
         </div>
-        {((hero.currency?.ep ?? 0) > 0 || (hero.currency?.cp ?? 0) > 0) && (
+        {(purse.ep > 0 || purse.cp > 0) && (
           <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginTop: 6 }}>
-            {(hero.currency?.ep ?? 0) > 0 && <CoinSlot tone="#b08860" label="EP" val={String(hero.currency.ep)} />}
-            {(hero.currency?.cp ?? 0) > 0 && <CoinSlot tone="#8a6a45" label="CP" val={String(hero.currency.cp)} />}
+            {purse.ep > 0 && <CoinSlot tone="#b08860" label="EP" val={String(purse.ep)} />}
+            {purse.cp > 0 && <CoinSlot tone="#8a6a45" label="CP" val={String(purse.cp)} />}
+          </div>
+        )}
+        {/* Unified gp-equivalent total (the one shared converter the Market uses) — only when
+            there is mixed coin to roll up; a plain-gold purse reads its total off the GP slot. */}
+        {(purse.pp > 0 || purse.ep > 0 || purse.sp > 0 || purse.cp > 0) && (
+          <div className="hand muted" style={{ fontSize: 12, marginTop: 6, textAlign: "right" }}>
+            ≈ {Number.isInteger(purseTotalGp) ? purseTotalGp : purseTotalGp.toFixed(2)} gp total
           </div>
         )}
       </Panel>
@@ -568,6 +585,42 @@ function itemCompareRows(item, equipped) {
   return { peer: peer.name, rows };
 }
 
+/* RRI-5e98e6f (optimizer minor): itemize a PACK/KIT's contents when the engine already carries
+   them in the item's description. The engine grants e.g. an "Explorer's Pack" whose description is
+   a manifest ("Bedroll, rations, rope, torches, and the like."). This is a READ-ONLY reformatting
+   of the engine-provided desc into a bulleted contents list — it parses ONLY the desc string the
+   surface already returns and never fabricates an item the engine isn't tracking. Returns [] for a
+   non-pack item or a description that isn't a contents manifest, so the list is shown only when
+   there is real content to itemize. */
+function packContents(item) {
+  if (!item) return [];
+  const name = String(item.name || "").toLowerCase();
+  if (!/\b(pack|kit|pouch|set|tools?|supplies)\b/.test(name)) return [];
+  let desc = String(item.desc || "").trim();
+  if (!desc) return [];
+  // Drop a trailing catch-all clause ("…, and the like.", "…, etc.") — it is flavor, not an item.
+  desc = desc.replace(/[.;]\s*$/, "").replace(/\s*,?\s*(and\s+)?(the like|so on|etc\.?|more)\s*$/i, "");
+  // Split on commas and a trailing "and"/"&" conjunction; trim, drop empties + a leading article.
+  const parts = desc
+    .split(/\s*,\s*|\s+and\s+|\s*&\s*/i)
+    .map((s) => s.trim().replace(/^(a|an|the)\s+/i, ""))
+    .filter(Boolean);
+  // Only itemize when the desc actually reads like a list (≥2 entries) — a one-line prose
+  // description is left to the paragraph above, untouched.
+  if (parts.length < 2) return [];
+  // De-dupe case-insensitively, cap to a sane number, and Title-case the first letter for display.
+  const seen = new Set();
+  const out = [];
+  for (const p of parts) {
+    const key = p.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(p.charAt(0).toUpperCase() + p.slice(1));
+    if (out.length >= 12) break;
+  }
+  return out;
+}
+
 function ItemDetail({ item, hero, toast, canAct, postInvMove, examineSignal }) {
   // #756: Examine opens a real read-only PANEL (the full description + every resolved
   // stat), not a fleeting toast — the optimizer's "Examine fires a toast ONLY". Local
@@ -579,6 +632,8 @@ function ItemDetail({ item, hero, toast, canAct, postInvMove, examineSignal }) {
   React.useEffect(() => { if (examineSignal) setExamineOpen(true); }, [examineSignal]);
   const statRows = itemStatRows(item);
   const compare = itemCompareRows(item, hero && hero.equipped);
+  // RRI-5e98e6f: a pack/kit's contents, itemized from the engine desc (read-only).
+  const contents = packContents(item);
 
   if (examineOpen) {
     return (
@@ -642,6 +697,21 @@ function ItemDetail({ item, hero, toast, canAct, postInvMove, examineSignal }) {
       <p className="body dropcap" style={{ marginTop: 0, fontSize: 15 }}>
         {item.desc}
       </p>
+
+      {/* RRI-5e98e6f: itemize a pack/kit's contents (e.g. Explorer's Pack) when the engine
+          description carries them — a read-only reformatting of the desc the surface already
+          returns. Hidden for non-packs / prose descriptions (packContents returns []). */}
+      {contents.length > 0 && (
+        <>
+          <Divider />
+          <div className="eyebrow">Contents</div>
+          <ul style={{ margin: "6px 0 0", paddingLeft: 18, color: "var(--ink-700)" }}>
+            {contents.map((c) => (
+              <li key={c} className="body-sm" style={{ marginBottom: 2 }}>{c}</li>
+            ))}
+          </ul>
+        </>
+      )}
 
       {/* Stat block — Weight/Value always (catalog-backfilled), plus the REAL combat stats the
           read-model now surfaces from the SRD item catalog: damage dice + type for weapons (with
@@ -752,4 +822,4 @@ function itemCategory(item) {
 
 function toRoman(n) { return ["", "I", "II", "III", "IV", "V"][n] || n; }
 
-Object.assign(window, { ScreenInventory, CoinSlot, ItemSlot, ItemDetail, EQUIP_SLOTS, PaperDoll, EquipSlotCell, inferEquipSlotId, assignEquipSlots, ITEM_TYPES, ITEM_KINDS, itemCategory, toRoman, slug, itemScope, itemStatRows, itemCompareRows });
+Object.assign(window, { ScreenInventory, CoinSlot, ItemSlot, ItemDetail, packContents, EQUIP_SLOTS, PaperDoll, EquipSlotCell, inferEquipSlotId, assignEquipSlots, ITEM_TYPES, ITEM_KINDS, itemCategory, toRoman, slug, itemScope, itemStatRows, itemCompareRows });

--- a/viewer/openworlds/screen-merchant.jsx
+++ b/viewer/openworlds/screen-merchant.jsx
@@ -94,13 +94,21 @@ function ScreenMerchant({ onNavigate, state, setState }) {
   const canAct = Boolean(surface?.can_act);
   const campaignId = surface?.campaign_id || "";
   const surfaceLoading = surfaceStatus === "loading";
-  // MK-13: the purse shown + spent-against is the LIVE currency when the surface carries it
-  // (engine = sole writer; matches the Stash). Falls back to the local demo purse only in
-  // read-only preview (no live session) — where the local-spend simulation still applies.
-  const liveCur = surface?.currency;
-  const coins = liveCur
-    ? { gp: Number(liveCur.gp) || 0, sp: Number(liveCur.sp) || 0, cp: Number(liveCur.cp) || 0, pp: Number(liveCur.pp) || 0, ep: Number(liveCur.ep) || 0 }
+  // MK-13 (RRI-5e98e6f optimizer "Stash 35 GP, Market 232 GP"): the purse shown + spent-against
+  // is the LIVE currency when a session is attached (engine = sole writer; matches the Stash). The
+  // coin purse rides PER party member of /character-surface (`party[i].currency`, the SAME engine
+  // field the inventory shows) — NOT a top-level `surface.currency`, which never existed, so the
+  // Market silently fell through to the hardcoded demo {gp:232} while the Stash showed live coin.
+  // The Market has no hero switcher, so window.partyPurse lands on party[0] — exactly the Stash's
+  // default active hero — via the ONE shared currency helper. Falls back to the local demo purse
+  // only in read-only preview (no live party) where the local-spend simulation still applies.
+  const liveParty = Array.isArray(surface?.party) ? surface.party : [];
+  const coins = liveParty.length
+    ? window.partyPurse(liveParty, "")
     : localCoins;
+  // The unified gp-equivalent total — the same converter the Stash uses, so a "total" never
+  // diverges between the two screens.
+  const purseTotalGp = window.currencyTotalGp(coins);
   const toast = window.useToast ? window.useToast() : (() => {});
 
   // Sell-tab inventory. The Market is a display-only prototype and has NO live shop/stash
@@ -422,11 +430,26 @@ function ScreenMerchant({ onNavigate, state, setState }) {
       {/* RIGHT — Cart + balance */}
       <Panel framed style={{ padding: 22, display: "flex", flexDirection: "column", minHeight: 0 }}>
         <SectionTitle>Your Purse</SectionTitle>
+        {/* RRI-5e98e6f: render the SAME coin breakdown as the Stash (PP/GP/SP always; EP/CP only
+            when held) from the same shared purse, so the two screens never disagree on the coins. */}
         <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 6 }}>
+          <CoinSlot tone="#e5e4e2" label="PP" val={coins.pp} />
           <CoinSlot tone="#d4b97a" label="GP" val={coins.gp} />
           <CoinSlot tone="#c0c0c0" label="SP" val={coins.sp} />
-          <CoinSlot tone="#b08860" label="CP" val={coins.cp} />
         </div>
+        {(coins.ep > 0 || coins.cp > 0) && (
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6, marginTop: 6 }}>
+            {coins.ep > 0 && <CoinSlot tone="#b08860" label="EP" val={coins.ep} />}
+            {coins.cp > 0 && <CoinSlot tone="#8a6a45" label="CP" val={coins.cp} />}
+          </div>
+        )}
+        {/* Unified gp-equivalent total (the one shared converter) — only meaningful when there is
+            mixed coin to roll up; a plain-gold purse already reads its total off the GP slot. */}
+        {(coins.pp > 0 || coins.ep > 0 || coins.sp > 0 || coins.cp > 0) && (
+          <div className="hand muted" style={{ fontSize: 12, marginTop: 6, textAlign: "right" }}>
+            ≈ {Number.isInteger(purseTotalGp) ? purseTotalGp : purseTotalGp.toFixed(2)} gp total
+          </div>
+        )}
 
         <Divider />
 
@@ -509,7 +532,13 @@ function ScreenMerchant({ onNavigate, state, setState }) {
               }).catch((e) => toast({ kind: "danger", title: "Move not sent", body: e?.message || "viewer unreachable" }))
                 .finally(() => { submittingRef.current = false; });
             } else {
-              setLocalCoins((prev) => ({ ...prev, gp: prev.gp + balanceDelta }));
+              // Read-only preview: the local-spend simulation only applies when the displayed
+              // purse IS the local demo purse (no live party). When a live party purse is shown
+              // (read-only view of a live session, can_act=false), do NOT fake a coin change —
+              // the engine is the sole writer; just clear the counter (honest no-write).
+              if (!liveParty.length) {
+                setLocalCoins((prev) => ({ ...prev, gp: prev.gp + balanceDelta }));
+              }
               setCart([]);
               submittingRef.current = false;
             }

--- a/viewer/tests/test_currency_consistency.py
+++ b/viewer/tests/test_currency_consistency.py
@@ -1,0 +1,315 @@
+"""Behavior tests for the shared currency-display helpers (RRI-5e98e6f optimizer finding:
+"Stash shows 35 GP, Market shows 232 GP (same character)").
+
+ROOT CAUSE the optimizer caught: the Market (screen-merchant.jsx) read `surface.currency`
+off `/character-surface`, but that endpoint returns NO top-level `currency` — the live coin
+purse lives PER party member (`surface.party[i].currency`, the same engine field
+`_currency_for(ch)` the inventory's `/inventory-surface` carries). So `surface.currency` was
+always `undefined` and the Market fell through to a HARDCODED demo purse (`{ gp: 232 }`),
+while the Stash (screen-inventory.jsx) showed the live per-hero purse (e.g. 35 GP) — the
+exact 35-vs-232 contradiction.
+
+The fix is a SINGLE shared currency layer in chrome.jsx (loaded before every screen):
+
+  • window.normalizeCurrency(cur)  — coerce ANY currency object to {pp,gp,sp,ep,cp} ints
+    (mirrors the engine `_currency_for`), so both screens speak one shape.
+  • window.currencyTotalGp(cur)    — the ONE gp-equivalent conversion (5e: 1pp=10gp,
+    1ep=0.5gp, 1sp=0.1gp, 1cp=0.01gp) so a "total" never diverges between screens.
+  • window.partyPurse(party, activeId) — select the SAME hero's purse both screens render:
+    the active hero by id, else the first party member. Both surfaces are projected from the
+    same snapshot in the same `party` order, so this picks ONE source-of-truth character.
+
+Both screens now derive their displayed coins from `window.partyPurse(...)` of the same
+live `party`, so the Market and the Stash render the IDENTICAL purse for the same character
+(no hardcoded-232 fallback when a live session is attached). The viewer stays read-only.
+
+These tests transpile the REAL chrome.jsx with the SAME bundled Babel the browser uses and
+exercise the pure helpers under Node (mirrors the pure-selector tests in
+test_recovery_timing.py — computeColdOpenAwaiting / shouldApplySurface), so they track the
+shipped helper, not a reimplementation.
+"""
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+_OPENWORLDS = Path(__file__).resolve().parents[1] / "openworlds"
+_CHROME = _OPENWORLDS / "chrome.jsx"
+_INVENTORY = _OPENWORLDS / "screen-inventory.jsx"
+_BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+
+# chrome.jsx defines its helpers + JSX components as plain functions and ends with an
+# Object.assign(window, {...}) export — NO ReactDOM bootstrap. Its module-scope JSX is only
+# INSIDE function bodies (transpiled to React.createElement calls that run on invocation), so a
+# trivial React stub is enough to load it; we only call the pure currency helpers here.
+_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+const sandbox = {
+  React: { createElement: () => null, Fragment: 'F' },
+  document: { addEventListener() {}, removeEventListener() {}, getElementById: () => ({}),
+              head: { appendChild() {} }, createElement: () => ({}) },
+  JSON, Object, Array, String, Boolean, Number, Math, console,
+};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+
+function load(p) {
+  const src = fs.readFileSync(p, 'utf8');
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+load(%(chrome)s);
+
+const win = sandbox.window;
+const script = %(script)s;
+const result = (function () { %(body)s })();
+process.stdout.write(JSON.stringify(result));
+""".replace("%(body)s", "return eval(script);")
+
+
+class _CurrencyHarness(unittest.TestCase):
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_CHROME, _BABEL):
+            cls.assertTrue(p.exists(), f"missing {p}")
+
+    def _run(self, script: str):
+        program = _HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "chrome": json.dumps(str(_CHROME)),
+            "script": json.dumps(script),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program,
+            text=True,
+            capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + run chrome.jsx")
+class CurrencyHelperContractTests(_CurrencyHarness):
+    """The shared helpers exist with the contract both screens rely on."""
+
+    def test_helpers_are_exported_on_window(self):
+        out = self._run(
+            "({ norm: typeof win.normalizeCurrency, total: typeof win.currencyTotalGp,"
+            "   purse: typeof win.partyPurse })"
+        )
+        self.assertEqual(out["norm"], "function", "normalizeCurrency must be a shared window helper")
+        self.assertEqual(out["total"], "function", "currencyTotalGp must be a shared window helper")
+        self.assertEqual(out["purse"], "function", "partyPurse must be a shared window helper")
+
+    def test_normalize_coerces_to_int_coin_fields(self):
+        out = self._run("win.normalizeCurrency({ gp: '35', sp: 4, junk: 99 })")
+        # mirrors the engine _currency_for shape: all five coins as ints, no stray fields.
+        self.assertEqual(set(out.keys()), {"pp", "gp", "sp", "ep", "cp"})
+        self.assertEqual(out["gp"], 35)
+        self.assertEqual(out["sp"], 4)
+        self.assertEqual(out["pp"], 0)
+
+    def test_normalize_tolerates_missing_or_garbage_input(self):
+        for js in ("win.normalizeCurrency(undefined)", "win.normalizeCurrency(null)",
+                   "win.normalizeCurrency('nope')"):
+            out = self._run(js)
+            self.assertEqual(out, {"pp": 0, "gp": 0, "sp": 0, "ep": 0, "cp": 0})
+
+    def test_total_gp_uses_the_canonical_5e_conversion(self):
+        # 2pp=20gp + 35gp + 1ep=0.5gp + 4sp=0.4gp + 50cp=0.5gp => 56.4 gp-equivalent.
+        out = self._run("win.currencyTotalGp({ pp: 2, gp: 35, ep: 1, sp: 4, cp: 50 })")
+        self.assertAlmostEqual(out, 56.4, places=2)
+
+    def test_total_gp_of_plain_gold_is_that_gold(self):
+        self.assertEqual(self._run("win.currencyTotalGp({ gp: 35 })"), 35)
+        self.assertEqual(self._run("win.currencyTotalGp({ gp: 232 })"), 232)
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + run chrome.jsx")
+class PartyPurseSelectionTests(_CurrencyHarness):
+    """partyPurse picks ONE source-of-truth hero — the SAME selection both screens make."""
+
+    _PARTY = (
+        "[{ id: 'h1', currency: { gp: 35, sp: 4 } },"
+        " { id: 'h2', currency: { gp: 999 } }]"
+    )
+
+    def test_active_hero_purse_is_selected(self):
+        out = self._run(f"win.partyPurse({self._PARTY}, 'h1')")
+        self.assertEqual(out["gp"], 35)
+        self.assertEqual(out["sp"], 4)
+
+    def test_falls_back_to_first_member_when_active_absent(self):
+        # Both screens default to party[0] when no active id matches — the Market has no hero
+        # switcher, so it always lands on party[0], which is the Stash's default active hero.
+        out = self._run(f"win.partyPurse({self._PARTY}, 'nobody')")
+        self.assertEqual(out["gp"], 35, "absent active id -> first party member (party[0])")
+        out2 = self._run(f"win.partyPurse({self._PARTY}, '')")
+        self.assertEqual(out2["gp"], 35)
+
+    def test_empty_party_yields_zeroed_purse(self):
+        out = self._run("win.partyPurse([], 'h1')")
+        self.assertEqual(out, {"pp": 0, "gp": 0, "sp": 0, "ep": 0, "cp": 0})
+
+    def test_result_is_normalized_coin_shape(self):
+        out = self._run(f"win.partyPurse({self._PARTY}, 'h1')")
+        self.assertEqual(set(out.keys()), {"pp", "gp", "sp", "ep", "cp"})
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + run chrome.jsx")
+class MarketStashParityTests(_CurrencyHarness):
+    """THE optimizer finding: for one live party state, the Market and the Stash must derive
+    the IDENTICAL purse + total from the SAME shared helper — no 35-vs-232 divergence."""
+
+    # A single live party (the shape BOTH /character-surface and /inventory-surface carry under
+    # `party[i].currency`, projected from the same snapshot in the same order). Hero one holds 35gp.
+    _LIVE_PARTY = (
+        "[{ id: 'astarion', currency: { gp: 35, sp: 12, cp: 7 } },"
+        " { id: 'shadowheart', currency: { gp: 80 } }]"
+    )
+
+    def test_market_and_stash_render_the_same_purse_and_total(self):
+        out = self._run(
+            # STASH path (screen-inventory): active hero of the live party, via the shared helper.
+            f"var party = {self._LIVE_PARTY};"
+            "var stashPurse = win.partyPurse(party, 'astarion');"
+            "var stashTotal = win.currencyTotalGp(stashPurse);"
+            # MARKET path (screen-merchant): no hero switcher, so it lands on the same party[0]
+            # via the SAME shared helper — NOT a hardcoded 232 demo purse.
+            "var marketPurse = win.partyPurse(party, '');"
+            "var marketTotal = win.currencyTotalGp(marketPurse);"
+            "({ stashPurse: stashPurse, marketPurse: marketPurse,"
+            "   stashTotal: stashTotal, marketTotal: marketTotal,"
+            "   stashGp: stashPurse.gp, marketGp: marketPurse.gp })"
+        )
+        # The 35-vs-232 contradiction is gone: identical purse object, identical gp, identical total.
+        self.assertEqual(out["stashPurse"], out["marketPurse"],
+                         "Market and Stash must read the SAME purse for the same character")
+        self.assertEqual(out["stashGp"], out["marketGp"],
+                         "the displayed GP must match across screens (no hardcoded 232)")
+        self.assertEqual(out["stashGp"], 35, "both screens show the live 35 GP, not the demo 232")
+        self.assertAlmostEqual(out["stashTotal"], out["marketTotal"], places=6,
+                               msg="the gp-equivalent total must be computed by the one shared converter")
+
+    def test_market_does_not_invent_232_from_a_live_party(self):
+        # Whatever party[0] holds, the shared selection never yields the legacy demo 232.
+        out = self._run(
+            f"win.currencyTotalGp(win.partyPurse({self._LIVE_PARTY}, ''))"
+        )
+        self.assertNotEqual(out, 232)
+        # 35 + 12sp(1.2) + 7cp(0.07) = 36.27
+        self.assertAlmostEqual(out, 36.27, places=2)
+
+
+# screen-inventory.jsx defines its components + the pure `packContents` helper as plain
+# functions and ends with an Object.assign(window, {...}) export — NO ReactDOM bootstrap, and its
+# module-scope JSX is only inside function bodies. A trivial React stub loads it; we call only the
+# pure packContents helper. (window.Tooltip etc. are referenced inside render bodies, never at load.)
+_INV_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+const sandbox = {
+  React: { createElement: () => null, Fragment: 'F' },
+  document: { addEventListener() {}, removeEventListener() {}, getElementById: () => ({}),
+              head: { appendChild() {} }, createElement: () => ({}) },
+  JSON, Object, Array, String, Boolean, Number, Math, RegExp, Set, console,
+};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+
+function load(p) {
+  const src = fs.readFileSync(p, 'utf8');
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+load(%(inventory)s);
+
+const win = sandbox.window;
+const script = %(script)s;
+const result = (function () { return eval(script); })();
+process.stdout.write(JSON.stringify(result));
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + run screen-inventory.jsx")
+class PackContentsTests(unittest.TestCase):
+    """RRI-5e98e6f minor: itemize a pack/kit's contents from the engine-provided description —
+    read-only reformatting, never fabrication (returns [] for non-packs / prose / a thin list)."""
+
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_INVENTORY, _BABEL):
+            cls.assertTrue(p.exists(), f"missing {p}")
+
+    def _run(self, script: str):
+        program = _INV_HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "inventory": json.dumps(str(_INVENTORY)),
+            "script": json.dumps(script),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program, text=True, capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+    def test_explorers_pack_is_itemized_from_its_engine_description(self):
+        # The exact engine grant (servers/engine/server.py): an "Explorer's Pack" whose description
+        # is the manifest "Bedroll, rations, rope, torches, and the like."
+        out = self._run(
+            "win.packContents({ name: \"Explorer's Pack\","
+            " desc: 'Bedroll, rations, rope, torches, and the like.' })"
+        )
+        # The real contents are listed; the "…and the like" catch-all is dropped (not an item).
+        self.assertEqual(out, ["Bedroll", "Rations", "Rope", "Torches"])
+        self.assertNotIn("The like", out)
+
+    def test_non_pack_item_is_not_itemized(self):
+        # A weapon's prose description must NOT be shredded into a fake contents list.
+        out = self._run(
+            "win.packContents({ name: 'Longsword',"
+            " desc: 'A versatile blade, balanced and keen.' })"
+        )
+        self.assertEqual(out, [], "a non-pack item must not be itemized")
+
+    def test_pack_with_prose_description_is_not_itemized(self):
+        # A pack whose desc is a single prose sentence (no list) is left to the paragraph.
+        out = self._run(
+            "win.packContents({ name: 'Burglar\\'s Pack', desc: 'A discreet bag of tricks.' })"
+        )
+        self.assertEqual(out, [], "a one-line prose description is not a contents manifest")
+
+    def test_empty_or_missing_desc_yields_empty(self):
+        for js in ("win.packContents({ name: \"Explorer's Pack\" })",
+                   "win.packContents({ name: \"Explorer's Pack\", desc: '' })",
+                   "win.packContents(null)"):
+            self.assertEqual(self._run(js), [])
+
+    def test_dungeoneers_pack_dedupes_and_titlecases(self):
+        out = self._run(
+            "win.packContents({ name: \"Dungeoneer's Pack\","
+            " desc: 'a crowbar, a hammer, pitons, torches, torches, rations and a waterskin' })"
+        )
+        # de-duped (one "Torches"), title-cased, leading article stripped.
+        self.assertEqual(out, ["Crowbar", "Hammer", "Pitons", "Torches", "Rations", "Waterskin"])
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/viewer/tests/test_item_icons.py
+++ b/viewer/tests/test_item_icons.py
@@ -238,10 +238,15 @@ class InventoryPolishPassTests(unittest.TestCase):
         self.assertIn("setSortKey(", src)
 
     def test_electrum_and_copper_hidden_when_zero(self):
-        """I-09: EP/CP coin slots render only when the hero actually holds them."""
+        """I-09: EP/CP coin slots render only when the hero actually holds them.
+        RRI-5e98e6f: the purse now flows through the shared window.partyPurse normalizer, so the
+        hide-when-zero guard reads off the normalized `purse` (purse.ep/purse.cp), not the raw
+        hero.currency — same behavior, one shared source-of-truth with the Market."""
         src = self._src()
-        self.assertIn("(hero.currency?.ep ?? 0) > 0", src)
-        self.assertIn("(hero.currency?.cp ?? 0) > 0", src)
+        self.assertIn("purse.ep > 0", src)
+        self.assertIn("purse.cp > 0", src)
+        # …and the purse is derived from the SHARED selector both screens use (no per-screen drift).
+        self.assertIn("window.partyPurse", src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

The **RRI-5e98e6f optimizer sweep** filed: *"Stash shows 35 GP, Market shows 232 GP (same character)."*

**Root cause (viewer-side rendering/wiring gap):** the Market (`screen-merchant.jsx`) read a *top-level* `surface.currency` off `/character-surface` — but that endpoint emits the coin purse **per party member** (`party[i].currency`, the same engine `_currency_for` field the Stash's `/inventory-surface` carries). There is **no** top-level `currency`, so `surface.currency` was always `undefined` and the Market silently fell through to a **hardcoded demo purse** (`{ gp: 232 }`), while the Stash showed the live per-hero purse (e.g. 35 GP). That is the exact 35-vs-232 contradiction.

The engine already had the data (the currency emit landed in the prior 31-PR fix phase — see `test_charsheet_depth.py::test_surface_exposes_currency_for_market_purse`); the viewer just didn't consume it correctly.

## The fix — one shared currency layer

Added to `chrome.jsx` (loaded before every screen), consumed by **both** screens so the same character renders the same purse:

- `window.normalizeCurrency(cur)` → canonical `{pp,gp,sp,ep,cp}` ints (mirrors the engine `_currency_for`; tolerates `undefined`/`null`/garbage by zeroing).
- `window.currencyTotalGp(cur)` → the **one** 5e gp-equivalent conversion (1pp=10gp, 1ep=0.5, 1sp=0.1, 1cp=0.01), so a "total" can't diverge between screens.
- `window.partyPurse(party, id)` → selects the **same** source-of-truth hero (active by id, else `party[0]`). The Market has no hero switcher, so it lands on `party[0]` — exactly the Stash's default active hero.

The Market now derives coins from `window.partyPurse(surface.party, "")` when a live party is attached, and only uses the local demo purse in read-only preview (no live party). The preview local-spend sim is gated so it never fakes a coin change over a live purse. Both screens render the same PP/GP/SP (EP/CP when held) breakdown plus a unified gp-equivalent total.

**Optimizer minor:** itemize a pack/kit's contents (e.g. Explorer's Pack) in `ItemDetail` via `packContents()` — a read-only reformatting of the engine's own item `description` (`"Bedroll, rations, rope, torches, and the like."` → bulleted Contents). Returns `[]` for non-packs / prose; never fabricates an item the engine isn't tracking.

## Invariants honored
- **Viewer read-only / move-sink** — engine remains sole writer; no campaign state written.
- **Render via React text nodes** (auto-escaped); no `dangerouslySetInnerHTML`.
- **Additive** — no engine change; the `/character-surface` + `/inventory-surface` read payloads are **unchanged** (this PR only consumes the existing per-member `currency`).

## Tests (JSX behaviour harness — real `.jsx` through the vendored babel under node vm)
- **NEW** `viewer/tests/test_currency_consistency.py` (16 tests): the shared helpers' contract; `partyPurse` selection (active hero / `party[0]` fallback / empty party); **Market + Stash render the IDENTICAL purse + total** for one party state (no 232); `packContents` itemization (Explorer's/Dungeoneer's Pack, non-pack rejected, prose rejected, dedupe+title-case).
- `viewer/tests/test_item_icons.py`: updated the EP/CP hide-when-zero pin to the new shared-purse form (`purse.ep`/`purse.cp` + `window.partyPurse`).

**Full viewer suite: 521 passed, 1 skipped.** `qa/fast_gate.sh`: **PASS** (195 engine; engine untouched).

_from the RRI-5e98e6f optimizer sweep_

> [!NOTE]
> Gate-mover for v1.0.4. **Do not merge** — for review.