### PR TITLE
fix(viewer): Market inspector renders F09-6 armor dex rule (acDisplay), consistent with Stash (#756 / F09-6 / F09-7 / #874)

### DIFF
--- a/viewer/openworlds/screen-merchant.jsx
+++ b/viewer/openworlds/screen-merchant.jsx
@@ -24,6 +24,14 @@ function enrichWare(item, catalog) {
   // The ware's OWN explicit fields win; the catalog only fills gaps + supplies the combat
   // stats the hardcoded stock never carried.
   if (typeof merged.ac !== "number" && typeof rec.ac === "number") merged.ac = rec.ac;
+  // F09-6 / #874: carry the catalog's composed armor dex-rule line so the Market inspector
+  // reads "AC 14 + DEX (max +2)" for medium armor and a shield's "+2" bonus (not the
+  // misleading flat "AC 14"/"AC 2"), consistently with the Stash inspector — itemStatRows()
+  // prefers acDisplay over the bare AC. The hardcoded stock never carries these, so fill them.
+  if (!merged.acDisplay && rec.acDisplay) merged.acDisplay = rec.acDisplay;
+  if (!merged.armorCategory && rec.armorCategory) merged.armorCategory = rec.armorCategory;
+  if (!merged.acDexMod && rec.acDexMod) merged.acDexMod = rec.acDexMod;
+  if (typeof merged.acDexCap !== "number" && typeof rec.acDexCap === "number") merged.acDexCap = rec.acDexCap;
   if (!merged.damage && rec.damage) { merged.damage = rec.damage; merged.damageType = rec.damageType; }
   if (!merged.versatile && rec.versatile) merged.versatile = rec.versatile;
   if (!merged.weight || merged.weight === "—") { if (rec.weight && rec.weight !== "—") merged.weight = rec.weight; }

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -4181,7 +4181,12 @@ def _catalog_stat_block(name: str) -> dict:
     no AC value' + 'Quarterstaff Examine is missing Versatile / 1d8 two-handed' findings).
 
     Returns ``{"resolved": False}`` for a name the catalog cannot resolve (free-text /
-    homebrew gear) so the caller shows weight/price only — never a fabricated number."""
+    homebrew gear) so the caller shows weight/price only — never a fabricated number.
+
+    F09-6 / #874: surfaces the SAME composed armor dex-rule (``armorCategory`` /
+    ``acDexMod`` / ``acDexCap`` + a ``acDisplay`` line via ``_armor_ac_display``) the Stash
+    inspector carries, so the Market reads "AC 14 + DEX (max +2)" for medium armor and a
+    shield's bonus "+2" — not the misleading flat "AC 14"/"AC 2"."""
     meta = _catalog_meta(name)
     if not meta:
         return {"resolved": False}
@@ -4189,6 +4194,11 @@ def _catalog_stat_block(name: str) -> dict:
     weight = _num(meta.get("weight"))
     cost = _num(meta.get("cost"))
     ac_raw = meta.get("ac")
+    ac = int(ac_raw) if isinstance(ac_raw, (int, float)) else None
+    armor_category = _text(meta.get("armor_category"))
+    ac_dex_mod = _text(meta.get("ac_dex_mod"))
+    cap_raw = meta.get("ac_dex_cap")
+    ac_dex_cap = int(cap_raw) if isinstance(cap_raw, (int, float)) else None
     return {
         "resolved": True,
         "name": _text(meta.get("name"), name),
@@ -4199,7 +4209,11 @@ def _catalog_stat_block(name: str) -> dict:
         "damage": damage,
         "damageType": _text(meta.get("damage_type")) if damage else "",
         "versatile": _text(meta.get("versatile")) if damage else "",
-        "ac": int(ac_raw) if isinstance(ac_raw, (int, float)) else None,
+        "ac": ac,
+        "armorCategory": armor_category,
+        "acDexMod": ac_dex_mod,
+        "acDexCap": ac_dex_cap,
+        "acDisplay": _armor_ac_display(ac, armor_category, ac_dex_mod, ac_dex_cap),
         "attunement": bool(meta.get("requires_attunement")),
         "properties": _catalog_property_chips(meta),
         "description": _text(meta.get("description")),

--- a/viewer/tests/test_item_inspector.py
+++ b/viewer/tests/test_item_inspector.py
@@ -229,6 +229,37 @@ class ItemInspectorBehaviourTests(unittest.TestCase):
         )
         self.assertEqual(out2["price"], 3)
 
+    # --- F09-6 / #874: the Market path renders the same honest armor dex rule -----
+    # The FULL Market render: enrichWare() must carry the catalog's composed acDisplay +
+    # armorCategory onto the ware, so window.itemStatRows() (the SAME helper the Stash uses)
+    # reads "AC 14 + DEX (max +2)" for medium armor and a shield's bonus "+2" — never the
+    # misleading flat "AC 14"/"AC 2" the bare ac would render.
+    def test_market_breastplate_renders_acdisplay_dex_rule(self):
+        rows = self._run(
+            "var ware = win.enrichWare("
+            "  { name: 'Breastplate', type: 'armor', weight: '20 lb', price: 400 },"
+            "  { 'Breastplate': { resolved: true, ac: 14, kind: 'armor',"
+            "      armorCategory: 'medium', acDexMod: 'capped', acDexCap: 2,"
+            "      acDisplay: 'AC 14 + DEX (max +2)', properties: [] } });"
+            "return win.itemStatRows(ware);"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Armor"), "AC 14 + DEX (max +2)")
+        self.assertNotIn("Armor Class", kv)  # the acDisplay branch supersedes the bare AC
+
+    def test_market_shield_renders_bonus_not_flat_ac(self):
+        rows = self._run(
+            "var ware = win.enrichWare("
+            "  { name: 'Shield', type: 'armor', weight: '6 lb', price: 10 },"
+            "  { 'Shield': { resolved: true, ac: 2, kind: 'armor',"
+            "      armorCategory: 'shield', acDexMod: 'none', acDexCap: null,"
+            "      acDisplay: '+2', properties: [] } });"
+            "return win.itemStatRows(ware);"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Shield"), "+2")
+        self.assertNotIn("Armor Class", kv)
+
 
 # ── served-source guards: the wiring the pure-helper harness can't observe ─────
 
@@ -308,6 +339,21 @@ class ItemInspectorWiringTests(unittest.TestCase):
         self.assertEqual(items["Longsword"]["damage"], "1d8")
         self.assertTrue(items["Plate"]["resolved"])
         self.assertEqual(items["Plate"]["ac"], 18)
+
+    # F09-6 / #874: the catalog endpoint (the Market's source of truth) composes the SAME
+    # honest armor dex-rule the Stash inspector carries — medium armor reads its DEX cap and
+    # a shield reads its bonus, so the Market never re-exhibits the flat "AC 14"/"AC 2" bug.
+    def test_item_catalog_endpoint_composes_armor_acdisplay(self):
+        status, _ctype, body = self._get("/item-catalog?name=Breastplate&name=Shield")
+        items = json.loads(body)["items"]
+        bp = items["Breastplate"]
+        self.assertTrue(bp["resolved"])
+        self.assertEqual(bp["armorCategory"], "medium")
+        self.assertEqual(bp["acDisplay"], "AC 14 + DEX (max +2)")
+        sh = items["Shield"]
+        self.assertTrue(sh["resolved"])
+        self.assertEqual(sh["armorCategory"], "shield")
+        self.assertEqual(sh["acDisplay"], "+2")  # a +N bonus, never the flat "AC 2"
 
     # Examine opens a PANEL (dialog), not a toast
     def test_examine_opens_a_panel_not_a_toast(self):


### PR DESCRIPTION
## What

The viewer's **STASH** inventory inspector renders the F09-6 armor dex rule honestly (PR #874): a medium Breastplate reads **"AC 14 + DEX (max +2)"**, a Shield reads its bonus **"+2"** (not the misleading flat "AC 2"). That path uses `_item_stat_block(item, meta)` → `_armor_ac_display(...)` in `viewer/server.py`.

The **MARKET** inspector, however, uses a *separate* function `_catalog_stat_block(name)` (added by PR #872 for the `/item-catalog` endpoint), which still returned a bare `"ac": int(...)` with no `armorCategory` / `acDexMod` / `acDexCap` / `acDisplay`. So a Breastplate or Shield viewed in the Market still read the flat **"AC 14"** / **"AC 2"** — diverging from the Stash and re-exhibiting the exact F09-6 shield "+2 not AC 2" bug.

This PR closes that gap so the two inspectors agree.

## Changes (additive)

- **`viewer/server.py` — `_catalog_stat_block`**: now also surfaces `armorCategory` / `acDexMod` / `acDexCap` (already carried by the catalog `meta` via `itemcatalog.resolve()`) and a composed `acDisplay`, **reusing `_armor_ac_display(...)`** rather than re-implementing. Same HONEST contract — no fabricated numbers; the `ac` value is unchanged.
- **`viewer/openworlds/screen-merchant.jsx` — `enrichWare`**: folds the catalog's `acDisplay` / `armorCategory` / `acDexMod` / `acDexCap` onto the merged ware (ware's own explicit fields still win). The detail pane already renders via the shared `window.itemStatRows(...)`, which prefers `item.acDisplay` with a "Shield"/"Armor" label and falls back to a bare "Armor Class" row — so the Market now reads exactly like the Stash.
- **`viewer/tests/test_item_inspector.py`**: +3 tests.
  - JS-harness (drives the real shipped `enrichWare` → `itemStatRows`): Market Breastplate → `Armor: AC 14 + DEX (max +2)`; Market Shield → `Shield: +2` (never the flat "AC 2"). Verified red→green: both FAIL against the unedited `enrichWare`.
  - Served endpoint: `/item-catalog?name=Breastplate&name=Shield` returns `acDisplay` "AC 14 + DEX (max +2)" and "+2".

## Verification

- `viewer/tests/test_item_inspector.py` — 21 passed (17 prior + 3 new + batch).
- `viewer/tests/test_readmodel_surfaces.py` — 35 passed, 4 subtests (no regression on the Stash path).
- `scripts/license_check.py` — passed.
- New tests confirmed meaningful: both Market harness tests fail against `origin/main`'s `enrichWare` and pass with the fix.

Refs #756, F09-6, F09-7, PR #874.