### PR TITLE
fix(viewer): optimizer depth — feature inspector, subclass-overdue, hit-dice spend, weapon range/value, stash parity

### DIFF
--- a/servers/engine/itemcatalog.py
+++ b/servers/engine/itemcatalog.py
@@ -130,6 +130,20 @@ def _int(value, default: int = 0) -> int:
         return default
 
 
+def _weapon_range(fields: dict) -> dict:
+    """RRI-25e55fa optimizer #3 — recover the SRD weapon RANGE the bare flatten threw away.
+
+    SRD ``Weapon.json`` carries ``range`` (normal range in feet) and ``long_range`` (the
+    disadvantaged-attack bracket). A ranged weapon (Heavy Crossbow 100/400) AND a thrown
+    melee weapon (Dagger 20/60) both carry these; a pure melee weapon (Longsword) carries
+    0/0. We surface them verbatim so the inspector can read the real "100/400 ft" bracket —
+    and a 0 range honestly hides the row (never a fabricated number)."""
+    return {
+        "range": _int(fields.get("range")),
+        "range_long": _int(fields.get("long_range")),
+    }
+
+
 def _armor_dex_rule(fields: dict, ac_base: int, name: str) -> dict:
     """F09-6 — recover the SRD armor DEX-mod rule the bare ``ac_base`` throws away.
 
@@ -276,6 +290,8 @@ def _flatten(model: str, fields: dict, pk: str = "") -> dict:
             "damage": fields.get("damage_dice") or "",
             "damage_type": fields.get("damage_type") or "",
             "versatile": extra.get("versatile", ""),
+            # RRI-25e55fa optimizer #3: the SRD weapon range bracket (0/0 for pure melee).
+            **_weapon_range(fields),
         }
 
     if model == "armor":
@@ -326,6 +342,9 @@ def _flatten(model: str, fields: dict, pk: str = "") -> dict:
         wf = weapons[wfk]
         record["damage"] = wf.get("damage_dice") or ""
         record["damage_type"] = wf.get("damage_type") or ""
+        # RRI-25e55fa optimizer #3: a magic weapon inherits its base weapon's range bracket
+        # via the same FK (0/0 for a melee polearm — never a fabricated thrown range).
+        record.update(_weapon_range(wf))
         # #756: a magic weapon inherits its base weapon's SRD properties + versatile
         # two-handed die via the same FK (de-duped onto the attunement clause above).
         wp = wprops.get(wfk, {})

--- a/servers/engine/tests/test_itemcatalog.py
+++ b/servers/engine/tests/test_itemcatalog.py
@@ -157,6 +157,46 @@ def test_resolve_weapon_exposes_versatile_two_handed_damage():
     assert rec["versatile"] == "1d8"
 
 
+def test_resolve_ranged_weapon_exposes_range():
+    """RRI-25e55fa optimizer #3: a ranged weapon hides its RANGE (Heavy Crossbow had no
+    '100/320 ft'). The SRD Weapon.json carries `range` (normal) + `long_range`; the flatten
+    must surface them as `range`/`range_long` so the inspector can read the real bracket.
+    Re-derived against data/srd/srd524/Weapon.json: Heavy Crossbow is 100/400 ft in SRD 5.2."""
+    hc = itemcatalog.resolve("Heavy Crossbow")
+    assert hc is not None
+    assert hc["range"] == 100
+    assert hc["range_long"] == 400
+    shortbow = itemcatalog.resolve("Shortbow")
+    assert shortbow is not None and shortbow["range"] == 80 and shortbow["range_long"] == 320
+
+
+def test_resolve_thrown_weapon_exposes_thrown_range():
+    """A thrown melee weapon (Dagger/Handaxe) carries a thrown range (20/60 ft). The flatten
+    must surface it so the inspector shows the throwing bracket — never fabricated."""
+    dagger = itemcatalog.resolve("Dagger")
+    assert dagger is not None
+    assert dagger["range"] == 20
+    assert dagger["range_long"] == 60
+
+
+def test_resolve_pure_melee_weapon_has_no_range():
+    """A pure melee weapon (Longsword/Greatsword) has range 0 in the SRD; the flatten must
+    surface 0 (not a fabricated number) so the inspector hides the Range row entirely."""
+    ls = itemcatalog.resolve("Longsword")
+    assert ls is not None
+    assert ls["range"] == 0
+    assert ls["range_long"] == 0
+
+
+def test_resolve_magic_weapon_inherits_range_via_fk():
+    """A magic ranged weapon inherits its base weapon's range via the Weapon FK join, the
+    same path damage/properties take (#756)."""
+    rec = itemcatalog.resolve("Frost Brand (Glaive)")
+    # Glaive is a melee weapon -> range 0 (no fabricated thrown range on a reach polearm).
+    assert rec is not None
+    assert rec["range"] == 0
+
+
 def test_resolve_weapon_exposes_real_properties():
     """#756: weapon properties (Versatile, Finesse, Light, Two-Handed, …) live in
     WeaponPropertyAssignment, not inline — the flatten dropped them, so the inspector

--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -393,15 +393,21 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
   // The option for the chosen class (default: continue the current class), else the first legal path.
   const option = options.find((o) => (o.class_name || "").toLowerCase() === chosenClass) || options[0] || null;
   const featuresGained = (option && Array.isArray(option.features_gained)) ? option.features_gained : [];
-  // Subclass is DUE if the engine grants a "<X> Subclass" feature at this level, or the read-model
-  // already flagged one pending (created above the choose-level). Either way the player names it.
-  const subclassDue = !!hero.pendingSubclass ||
-    featuresGained.some((f) => /subclass/i.test((f && f.name) || ""));
   // #624: the engine now exposes the legal SRD subclass options (with a feature preview) for the
   // chosen class at its subclass level. Present them as a pickable list instead of a blind text box —
   // selecting one fills `subclassName`. The free-text input REMAINS for any world-canon tradition the
   // engine's SRD table doesn't enumerate (additive: the DM still finalizes a homebrew name).
   const subclassBlock = (option && option.subclass) || null;
+  // Subclass is DUE if: the engine flags it OVERDUE/required on this build option
+  // (subclass.required — RRI-25e55fa optimizer #1, the L11-no-archetype case where a Fighter past
+  // the choice level with no archetype is leveling into a level that grants no fresh "subclass"
+  // feature), OR the engine grants a "<X> Subclass" feature at this level, OR the read-model already
+  // flagged one pending (created above the choose-level). Either way the player names it. Reading the
+  // engine's required flag (not only the feature-name heuristic / pendingSubclass) is what makes the
+  // overdue archetype enforced at the level it's due.
+  const subclassDue = !!(subclassBlock && subclassBlock.required) ||
+    !!hero.pendingSubclass ||
+    featuresGained.some((f) => /subclass/i.test((f && f.name) || ""));
   const subclassOptions = (subclassBlock && Array.isArray(subclassBlock.options)) ? subclassBlock.options : [];
   const subclassGroupLabel = (subclassBlock && subclassBlock.group_label) || "subclass";
   const asiRequired = !!(option && option.choices && option.choices.asi_required);
@@ -637,6 +643,12 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
   const [restType, setRestType] = React.useState("long");
   const [prepared, setPrepared] = React.useState({});
   const [submitting, setSubmitting] = React.useState(false);
+  // RRI-25e55fa optimizer #4 — how many Hit Dice to SPEND on a short rest (for HP). The sheet
+  // shows e.g. "11/11d10"; this is the control the optimizer found missing. The engine's
+  // short_rest(hit_dice_to_spend=N) applies it — the viewer only composes the intent (move-sink).
+  const hitDiceRemaining = Math.max(0, Number(hero?.stats?.hitDiceRemaining) || 0);
+  const hitDicePool = String(hero?.stats?.hitDice || "");
+  const [hitDiceToSpend, setHitDiceToSpend] = React.useState(0);
   // #robustness: synchronous in-flight lock (mirrors LevelUpModal / screen-table.jsx). The
   // `submitting` STATE only updates on re-render, so a rapid double-click would otherwise relay
   // TWO rest/prepare intents. The ref blocks the second call within the same tick.
@@ -703,9 +715,15 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
   // Make camp: relay the chosen rest, then advance to the spell-preparation step.
   const completeRest = () => {
     const watch = watchOrder.length > 0 ? ` ${watchOrder.join(", then ")} keep watch.` : "";
+    // RRI-25e55fa optimizer #4: on a short rest, name the exact Hit-Dice count to spend so the
+    // engine's short_rest(hit_dice_to_spend=N) applies precisely that — defaulting to "as needed"
+    // when the player leaves the stepper at 0 (today's behavior, no forced spend).
+    const hdClause = hitDiceToSpend > 0
+      ? ` ${hero.name} spends ${hitDiceToSpend} Hit ${hitDiceToSpend === 1 ? "Die" : "Dice"} to recover HP.`
+      : ` Spend Hit Dice as needed to recover HP.`;
     const text = restType === "long"
       ? `${hero.name} and the party make camp and take a long rest — restore HP, recover all spell slots, and refresh abilities, then advance the clock to morning.${watch}`
-      : `${hero.name} and the party take a short rest — spend Hit Dice to recover HP and refresh short-rest abilities.${watch}`;
+      : `${hero.name} and the party take a short rest to recover HP and refresh short-rest abilities.${hdClause}${watch}`;
     relayMove(text, () => { submittingRef.current = false; setSubmitting(false); setStep("prep"); },
       restType === "long" ? "Long rest" : "Short rest", "Rest");
   };
@@ -756,6 +774,7 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
                 <RestCard
                   selected={restType === "short"}
                   onClick={() => setRestType("short")}
+                  testId="rest-card-short"
                   title="Short Rest"
                   hand="One hour. A second wind."
                   body="Restores hit points spent from class features. Spell slots and abilities remain spent. Watch is not required."
@@ -764,12 +783,50 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
                 <RestCard
                   selected={restType === "long"}
                   onClick={() => setRestType("long")}
+                  testId="rest-card-long"
                   title="Long Rest"
                   hand="Eight hours. The whole road forgiven."
                   body="Full HP. All spell slots restored. Abilities refresh. Watch order required; one in four sleeps light."
                   cost="8 hours · 1 ration each"
                 />
               </div>
+
+              {/* RRI-25e55fa optimizer #4: on a SHORT rest, a Hit-Dice-SPEND control — the sheet
+                  shows e.g. "11/11d10" but had no way to spend them for HP. Shown only on the short
+                  rest AND only when the hero actually has dice remaining (never a dead stepper). The
+                  chosen count rides the relayed move; the engine's short_rest(hit_dice_to_spend=N)
+                  applies it (the viewer stays a move-sink — it never edits HP itself). */}
+              {restType === "short" && hitDiceRemaining > 0 && (
+                <div data-worldos-testid="short-rest-hit-dice" style={{ marginTop: 18 }}>
+                  <SectionTitle right={
+                    <span className="muted body-sm">{hitDiceRemaining}/{hitDicePool || hitDiceRemaining} available</span>
+                  }>Spend Hit Dice</SectionTitle>
+                  <div className="muted body-sm" style={{ marginBottom: 8 }}>
+                    {hero.name} has {hitDiceRemaining} of {hitDicePool || (hitDiceRemaining + " Hit Dice")} to spend. Each Hit Die rolls its die + your Constitution modifier back as hit points. Leave at 0 to let the DM spend them as needed.
+                  </div>
+                  <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+                    <BrassButton size="sm" tone="ghost"
+                      testId="short-rest-hd-dec"
+                      ariaLabel="Spend one fewer Hit Die"
+                      onClick={() => setHitDiceToSpend((n) => Math.max(0, n - 1))}>−</BrassButton>
+                    <div style={{
+                      minWidth: 56, textAlign: "center",
+                      background: "linear-gradient(180deg, var(--p-100), var(--p-300))",
+                      boxShadow: "inset 0 0 0 1px var(--b-500)",
+                      padding: "6px 0",
+                      fontFamily: "var(--f-display)", fontSize: 18,
+                      color: hitDiceToSpend > 0 ? "var(--emerald)" : "var(--ink-900)",
+                    }} aria-live="polite">{hitDiceToSpend}</div>
+                    <BrassButton size="sm" tone="ghost"
+                      testId="short-rest-hd-inc"
+                      ariaLabel="Spend one more Hit Die"
+                      onClick={() => setHitDiceToSpend((n) => Math.min(hitDiceRemaining, n + 1))}>+</BrassButton>
+                    <span className="hand muted" style={{ fontSize: 12, marginLeft: 4 }}>
+                      {hitDiceToSpend === 0 ? "DM spends as needed" : `spend ${hitDiceToSpend} of ${hitDiceRemaining}`}
+                    </span>
+                  </div>
+                </div>
+              )}
 
               <Divider />
 
@@ -889,9 +946,9 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
   );
 }
 
-function RestCard({ selected, onClick, title, hand, body, cost }) {
+function RestCard({ selected, onClick, title, hand, body, cost, testId }) {
   return (
-    <button onClick={onClick} style={{
+    <button onClick={onClick} data-worldos-testid={testId} aria-pressed={selected ? "true" : "false"} style={{
       textAlign: "left",
       padding: 14,
       background: selected
@@ -1078,6 +1135,95 @@ function titleCaseWord(s) {
   return String(s || "").replace(/\b\w/g, (m) => m.toUpperCase());
 }
 
+// RRI-25e55fa optimizer #1 (the "#1 min-maxer pain point") — the CLASS-FEATURE INSPECTOR.
+// Every class/subclass feature (Extra Attack, Action Surge, Indomitable, …) used to be static
+// text with NO click-through to its full rules. The /character-surface read-model ALREADY carries
+// the SRD rules text on each feature as `detail` (server _feature_desc + data/srd/class_features.json);
+// this surfaces it on demand. Mirrors the #872 item-Examine read-only PANEL pattern: a feature with
+// rules text becomes a clickable row that opens a read-only dialog with the full text; a feature the
+// engine couldn't resolve (no detail) keeps today's static blurb (graceful degrade — additive).
+function _featureSlug(name) {
+  return String(name || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+// The read-only rules panel for one class/subclass feature. Pure reader — props in, no /move,
+// no fetch, no engine write. Escape / Close dismisses (no keyboard trap, WCAG 2.1.2).
+function FeatureInspector({ feature, contextLabel, onClose }) {
+  React.useEffect(() => {
+    const esc = (e) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onClose]);
+  if (!feature) return null;
+  return (
+    <div style={{
+      position: "fixed", inset: 0, zIndex: 200,
+      background: "rgba(15, 8, 2, 0.7)",
+      display: "grid", placeItems: "center",
+      backdropFilter: "blur(2px)",
+    }} onClick={onClose} role="dialog" aria-modal="true" aria-label={"Feature — " + (feature.name || "")}
+      data-worldos-testid="feature-inspector">
+      <div onClick={(e) => e.stopPropagation()} style={{ width: 560, maxWidth: "92vw", maxHeight: "88vh", overflow: "auto" }}>
+        <Panel framed>
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+            <div className="eyebrow" style={{ color: "var(--royal)" }}>{contextLabel || "Class Feature"}</div>
+            <BrassButton tone="ghost" size="sm" onClick={onClose} testId="feature-inspector-close" ariaLabel="Close feature panel">Close</BrassButton>
+          </div>
+          <h2 className="h1" style={{ fontSize: 22, marginTop: 4 }}>{feature.name}</h2>
+          <Divider />
+          {/* Full SRD rules text — a plain React text node (never dangerouslySetInnerHTML). */}
+          <p className="body" style={{ marginTop: 0, fontSize: 15, lineHeight: 1.5 }}>{feature.detail}</p>
+        </Panel>
+      </div>
+    </div>
+  );
+}
+
+// A list of class/subclass features. A feature WITH rules text (detail) renders as a click-through
+// row (testid class-feature-<slug>) opening the FeatureInspector; a feature WITHOUT detail keeps the
+// static blurb (no dead click). `contextLabel` (e.g. "Level 9 · Fighter · Champion") rides the panel.
+function ClassFeatureList({ features, contextLabel }) {
+  const [open, setOpen] = React.useState(null);
+  const list = Array.isArray(features) ? features : [];
+  if (!list.length) return null;
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      {list.map((c) => {
+        const hasRules = !!(c && typeof c.detail === "string" && c.detail.trim());
+        const card = (
+          <div style={{ padding: 10, background: "rgba(176,141,87,0.06)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)" }}>
+            <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+              <span style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.12em", color: "var(--ink-900)" }}>{c.name}</span>
+              {/* A subtle affordance so the reader knows the row opens the rules. Only on rows
+                  that have rules text — a detail-less feature shows no misleading "read" cue. */}
+              {hasRules && <span className="eyebrow" style={{ fontSize: 8, color: "var(--royal)" }}>Rules ▸</span>}
+            </div>
+            {c.detail && <div className="body-sm muted" style={{ marginTop: 2, display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>{c.detail}</div>}
+          </div>
+        );
+        if (!hasRules) {
+          // Graceful degrade: no rules text -> today's static blurb (not a dead click-through).
+          return <div key={c.name}>{card}</div>;
+        }
+        return (
+          <button
+            key={c.name}
+            type="button"
+            onClick={() => setOpen(c)}
+            aria-haspopup="dialog"
+            aria-label={"Read the rules for " + c.name}
+            data-worldos-testid={"class-feature-" + _featureSlug(c.name)}
+            style={{ display: "block", width: "100%", textAlign: "left", padding: 0, background: "transparent", border: "none", cursor: "pointer" }}
+          >
+            {card}
+          </button>
+        );
+      })}
+      {open && <FeatureInspector feature={open} contextLabel={contextLabel} onClose={() => setOpen(null)} />}
+    </div>
+  );
+}
+
 function AbilitiesTab({ hero }) {
   // `hero.abilities` is reserved for richly-modeled active-ability CARDS (name + detail);
   // the engine does not populate those today, so it is empty. But the engine DOES carry the
@@ -1105,20 +1251,16 @@ function AbilitiesTab({ hero }) {
         </div>
       )}
 
-      {/* Class & subclass features the engine granted at this level (Arcane Recovery, a
-          School-of-Magic feature, etc.). Names come straight from the engine's `features`
-          list; detail is shown only when the data carries it (the engine models names, not
-          descriptions today — so most show name-only, never fabricated text). */}
+      {/* Class & subclass features the engine granted at this level (Arcane Recovery, Extra
+          Attack, Action Surge, …). RRI-25e55fa optimizer #1: each feature with SRD rules text
+          (detail, from the read-model) is now CLICK-THROUGH to a read-only rules panel — the
+          optimizer's "#1 min-maxer pain point". A feature with no detail keeps its static blurb
+          (ClassFeatureList handles both, never fabricating rules text). */}
       {classFeatures.length > 0 && (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <>
           {classLine && <div className="eyebrow" style={{ marginBottom: 2 }}>{classLine}</div>}
-          {classFeatures.map((c) => (
-            <div key={c.name} style={{ padding: 10, background: "rgba(176,141,87,0.06)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)" }}>
-              <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.12em", color: "var(--ink-900)" }}>{c.name}</div>
-              {c.detail && <div className="body-sm muted" style={{ marginTop: 2 }}>{c.detail}</div>}
-            </div>
-          ))}
-        </div>
+          <ClassFeatureList features={classFeatures} contextLabel={classLine} />
+        </>
       )}
 
       {nothing && (
@@ -1648,16 +1790,14 @@ function FeatsTab({ hero }) {
       </ul>
       <Divider />
       <SectionTitle>Class Features</SectionTitle>
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        {hero.classFeatures.map((c) => (
-          <div key={c.name} style={{ padding: 10, background: "rgba(176,141,87,0.06)", boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)" }}>
-            <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.12em", color: "var(--ink-900)" }}>{c.name}</div>
-            {c.detail && <div className="body-sm muted" style={{ marginTop: 2 }}>{c.detail}</div>}
-          </div>
-        ))}
-      </div>
+      {/* RRI-25e55fa optimizer #1: the Feats tab's Class Features are click-through to the SAME
+          read-only rules panel the Abilities tab uses (the optimizer hit it on BOTH tabs). */}
+      <ClassFeatureList
+        features={hero.classFeatures}
+        contextLabel={[hero.level != null ? `Level ${hero.level}` : null, hero.class ? titleCaseWord(hero.class) : null, hero.archetype || null].filter(Boolean).join(" · ")}
+      />
     </div>
   );
 }
 
-Object.assign(window, { ScreenCharacter, AbilityScore, StatLine, ResourcesStatus, HeroEquipDoll, equippedStat, AbilitiesTab, SkillsTab, SpellsTab, SpellbookBrowser, SpellSlotTrack, SpellRules, SpellRuleChip, hasSpellRules, LineagePanel, FeatsTab, AbilityCard, FeatRow, RestPrepareModal, RestCard, ProficiencyDot, ProficiencyBadge, characterPortraitScope, spellMeta });
+Object.assign(window, { ScreenCharacter, AbilityScore, StatLine, ResourcesStatus, HeroEquipDoll, equippedStat, AbilitiesTab, SkillsTab, SpellsTab, SpellbookBrowser, SpellSlotTrack, SpellRules, SpellRuleChip, hasSpellRules, LineagePanel, FeatsTab, AbilityCard, FeatRow, ClassFeatureList, FeatureInspector, RestPrepareModal, RestCard, ProficiencyDot, ProficiencyBadge, characterPortraitScope, spellMeta });

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -83,6 +83,11 @@ function ScreenInventory({ onNavigate, state, setState }) {
     } catch (error) { /* keep last good / demo fallback */ }
   }, [surfaceQuery]);
 
+  // RRI-25e55fa optimizer #5 (Stash/Market examine PARITY): the read-only /item-catalog map the
+  // Stash inspector backfills from. Declared here so the fetch effect (after the stash list is
+  // derived below) can populate it; merged through the SAME window.enrichWare the Market uses.
+  const [catalog, setCatalog] = React.useState({});
+
   React.useEffect(() => {
     let cancelled = false;
     let timer = null;
@@ -108,6 +113,26 @@ function ScreenInventory({ onNavigate, state, setState }) {
   // The stash is the active hero's own pack (live surface); never the demo stash.
   const stash = (hero && Array.isArray(hero.items)) ? hero.items
     : (Array.isArray(surface?.stash) ? surface.stash : []);
+
+  // Fetch the SRD catalog for the current stash's item names (read-only), so the Stash
+  // inspector can backfill a stat the granted item didn't persist (range / value / properties)
+  // through the SAME window.enrichWare helper the Market uses. Refetched only when the set of
+  // names changes; an unreachable endpoint degrades to the item's own persisted fields.
+  const stashNamesKey = React.useMemo(
+    () => Array.from(new Set((stash || []).map((i) => i && i.name).filter(Boolean))).sort().join("\u0000"),
+    [stash],
+  );
+  React.useEffect(() => {
+    const names = stashNamesKey ? stashNamesKey.split("\u0000") : [];
+    if (!names.length) { setCatalog({}); return; }
+    let cancelled = false;
+    const q = names.map((n) => "name=" + encodeURIComponent(n)).join("&");
+    fetch("/item-catalog?" + q, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (!cancelled && d && d.items) setCatalog(d.items); })
+      .catch(() => { /* keep last good; the inspector still shows the item's persisted fields */ });
+    return () => { cancelled = true; };
+  }, [stashNamesKey]);
 
   React.useEffect(() => {
     if (party.length && !party.some((p) => p.id === activeHero)) {
@@ -310,9 +335,12 @@ function ScreenInventory({ onNavigate, state, setState }) {
         </div>
       </Panel>
 
-      {/* RIGHT — Item detail */}
+      {/* RIGHT — Item detail. RRI-25e55fa optimizer #5: enrich the selected item from the SAME
+          /item-catalog via the SAME window.enrichWare the Market uses (Stash/Market PARITY), so a
+          stash item missing a stat the granted item didn't persist backfills to the same depth.
+          The item's OWN persisted fields win; an unresolved name returns the item untouched. */}
       <Panel framed style={{ padding: 22, overflow: "auto" }}>
-        {selectedItem ? <ItemDetail item={selectedItem} hero={hero} toast={toast} canAct={canAct} postInvMove={postInvMove} examineSignal={examineNonce} /> : <div className="muted">Select an item.</div>}
+        {selectedItem ? <ItemDetail item={window.enrichWare ? window.enrichWare(selectedItem, catalog) : selectedItem} hero={hero} toast={toast} canAct={canAct} postInvMove={postInvMove} examineSignal={examineNonce} /> : <div className="muted">Select an item.</div>}
       </Panel>
 
       {ctxMenu && (
@@ -547,11 +575,20 @@ function itemStatRows(item) {
   if (!item) return [];
   const rows = [];
   rows.push({ k: "Weight", v: item.weight || "—" });
-  rows.push({ k: "Value", v: item.value || "—" });
+  // RRI-25e55fa optimizer #3 ("Value — blank while Price populated"): prefer the item's OWN
+  // value, then fall back to the catalog cost string (costValue) so a priced item never reads a
+  // bare "—" beside a populated Price. Only "—" when neither is known (honest, never fabricated).
+  rows.push({ k: "Value", v: item.value || item.costValue || "—" });
   if (item.damage) {
     const dmg = [item.damage, item.damageType].filter(Boolean).join(" ");
     const v = item.versatile ? `${dmg} (${item.versatile} two-handed)` : dmg;
     rows.push({ k: "Damage", v });
+  }
+  // RRI-25e55fa optimizer #3: a ranged/thrown weapon shows its real range bracket
+  // ("100/400 ft"); the server composes rangeDisplay from the SRD weapon range, blank for a
+  // pure melee weapon — so the row is rendered ONLY when there is a real bracket (never "0/0 ft").
+  if (item.rangeDisplay) {
+    rows.push({ k: "Range", v: item.rangeDisplay });
   }
   // F09-6 armor dex rule: the server composes acDisplay from REAL fields — medium reads
   // "AC 14 + DEX (max +2)", a shield reads its bonus "+2" (not the misleading flat "AC 2").

--- a/viewer/openworlds/screen-merchant.jsx
+++ b/viewer/openworlds/screen-merchant.jsx
@@ -34,6 +34,15 @@ function enrichWare(item, catalog) {
   if (typeof merged.acDexCap !== "number" && typeof rec.acDexCap === "number") merged.acDexCap = rec.acDexCap;
   if (!merged.damage && rec.damage) { merged.damage = rec.damage; merged.damageType = rec.damageType; }
   if (!merged.versatile && rec.versatile) merged.versatile = rec.versatile;
+  // RRI-25e55fa optimizer #3: carry the catalog's composed weapon range bracket so the Market
+  // inspector reads "100/400 ft" for a Heavy Crossbow (the hardcoded stock never carries it).
+  if (!merged.rangeDisplay && rec.rangeDisplay) merged.rangeDisplay = rec.rangeDisplay;
+  if (typeof merged.range !== "number" && typeof rec.range === "number") merged.range = rec.range;
+  if (typeof merged.rangeLong !== "number" && typeof rec.rangeLong === "number") merged.rangeLong = rec.rangeLong;
+  // RRI-25e55fa optimizer #3 ("Value — blank while Price populated"): fold the catalog's gp
+  // value string so the inspector's Value row matches the populated Price. The ware's own
+  // price/value (its explicit fields) still win — this only fills a gap.
+  if (!merged.value && rec.value && rec.value !== "—") merged.value = rec.value;
   if (!merged.weight || merged.weight === "—") { if (rec.weight && rec.weight !== "—") merged.weight = rec.weight; }
   if (!merged.kind && rec.kind) merged.kind = rec.kind;
   if (!merged.rarity && rec.rarity) merged.rarity = rec.rarity;

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -4199,6 +4199,11 @@ def _catalog_stat_block(name: str) -> dict:
     ac_dex_mod = _text(meta.get("ac_dex_mod"))
     cap_raw = meta.get("ac_dex_cap")
     ac_dex_cap = int(cap_raw) if isinstance(cap_raw, (int, float)) else None
+    # RRI-25e55fa optimizer #3: the weapon range bracket (only meaningful alongside a damage
+    # expr — a thrown/ranged weapon; a pure melee weapon's range is 0 -> blank display).
+    rng = _num(meta.get("range"))
+    rng_long = _num(meta.get("range_long"))
+    range_display = _weapon_range_display(rng, rng_long) if damage else ""
     return {
         "resolved": True,
         "name": _text(meta.get("name"), name),
@@ -4209,6 +4214,11 @@ def _catalog_stat_block(name: str) -> dict:
         "damage": damage,
         "damageType": _text(meta.get("damage_type")) if damage else "",
         "versatile": _text(meta.get("versatile")) if damage else "",
+        # Weapon range bracket: `range`/`rangeLong` (ints) + composed `rangeDisplay`
+        # ("100/400 ft"). Empty display for a pure melee weapon (the screen hides the row).
+        "range": int(rng) if rng is not None and rng > 0 else 0,
+        "rangeLong": int(rng_long) if rng_long is not None and rng_long > 0 else 0,
+        "rangeDisplay": range_display,
         "ac": ac,
         "armorCategory": armor_category,
         "acDexMod": ac_dex_mod,
@@ -4218,6 +4228,21 @@ def _catalog_stat_block(name: str) -> dict:
         "properties": _catalog_property_chips(meta),
         "description": _text(meta.get("description")),
     }
+
+
+def _weapon_range_display(rng: "int | None", rng_long: "int | None") -> str:
+    """RRI-25e55fa optimizer #3 — compose the weapon RANGE bracket for the inspector from REAL
+    SRD fields only. A ranged/thrown weapon reads "100/400 ft" (normal/long); when only a normal
+    range is known it reads "100 ft"; a pure melee weapon (range 0) returns "" so the screen
+    renders NO Range row (HONEST — never the misleading "0/0 ft"). Re-derived against
+    data/srd/srd524/Weapon.json via itemcatalog's `range`/`range_long`."""
+    n = rng if isinstance(rng, (int, float)) else 0
+    if not n or n <= 0:
+        return ""
+    long = rng_long if isinstance(rng_long, (int, float)) else 0
+    if long and long > n:
+        return f"{int(n)}/{int(long)} ft"
+    return f"{int(n)} ft"
 
 
 def _armor_ac_display(ac: "int | None", armor_category: str, ac_dex_mod: str, ac_dex_cap: "int | None") -> str:
@@ -4268,6 +4293,10 @@ def _item_stat_block(item: dict, meta: dict) -> dict:
         return v if v is not None else _num(meta.get(meta_key or field))
 
     damage = pick_str("damage")
+    # RRI-25e55fa optimizer #3: the weapon range bracket — prefer the item's own persisted
+    # range (forward-compatible), fall back to the by-name SRD catalog (range/range_long).
+    rng_num = pick_num("range")
+    rng_long_num = pick_num("range_long")
     ac_num = pick_num("ac")
     ac = int(ac_num) if ac_num is not None else None
     armor_category = pick_str("armor_category")
@@ -4296,6 +4325,10 @@ def _item_stat_block(item: dict, meta: dict) -> dict:
         # #756 Versatile two-handed die — not a persisted Item field today, so it resolves from
         # the catalog (persisted-first via pick_str keeps it forward-compatible). Damage-gated.
         "versatile": pick_str("versatile") if damage else "",
+        # RRI-25e55fa optimizer #3: weapon range bracket (damage-gated; empty for melee).
+        "range": int(rng_num) if rng_num is not None and rng_num > 0 else 0,
+        "rangeLong": int(rng_long_num) if rng_long_num is not None and rng_long_num > 0 else 0,
+        "rangeDisplay": (_weapon_range_display(rng_num, rng_long_num) if damage else ""),
         "ac": ac,
         "armorCategory": armor_category,
         "acDexMod": ac_dex_mod,
@@ -4362,6 +4395,10 @@ def _inventory_items(cid: str, ch: dict) -> list[dict]:
             "damage": stats["damage"],
             "damageType": stats["damageType"],
             "versatile": stats["versatile"],
+            # RRI-25e55fa optimizer #3: weapon range bracket ("100/400 ft"; "" for melee).
+            "range": stats["range"],
+            "rangeLong": stats["rangeLong"],
+            "rangeDisplay": stats["rangeDisplay"],
             "ac": stats["ac"],
             "armorCategory": stats["armorCategory"],
             "acDexMod": stats["acDexMod"],

--- a/viewer/tests/test_feature_inspector.py
+++ b/viewer/tests/test_feature_inspector.py
@@ -1,0 +1,307 @@
+"""RRI-25e55fa optimizer #1 (the "#1 min-maxer pain point") — the CLASS-FEATURE INSPECTOR.
+
+The optimizer persona's top finding: every class/subclass feature on the character sheet (Extra
+Attack, Action Surge, Indomitable, …) was static text with NO click-through to the full SRD rules
+text. The engine read-model ALREADY projects the rules text as `classFeatures[].detail`
+(server.py `_feature_desc` + data/srd/class_features.json) — the viewer was just rendering a
+truncated muted line.
+
+This fix makes each feature CLICK-THROUGH to a read-only PANEL showing its full rules text, mirroring
+the #872 item-Examine read-only PANEL pattern. It stays a pure READER — no /move, no engine write.
+
+These tests drive the REAL screen-character.jsx: a render-capturing harness (effects run, setState
+re-renders, onClick is invokable — mirrors test_rest_camp_levelup_wiring.py) renders the AbilitiesTab
+with a hero carrying class features, finds a feature's clickable node by testid, INVOKES its onClick,
+and asserts the read-only panel surfaces the full detail. A served-source guard pins the
+read-only-ness (a dialog, no /move, a Close control) so the inspector can't silently regress.
+"""
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+_OPENWORLDS = Path(__file__).resolve().parents[1] / "openworlds"
+_SCREEN_CHARACTER = _OPENWORLDS / "screen-character.jsx"
+_BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+
+# The SAME render-capturing harness shape test_rest_camp_levelup_wiring.py uses (hook cells +
+# effects persist; setState re-renders; createElement builds a walkable tree; find-by-testid +
+# invoke-onClick). Trimmed to what the feature inspector needs (no /build-options planner).
+_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+function makeReact() {
+  const stateCells = [], refCells = [], cbCells = [], effects = [];
+  let sIdx = 0, rIdx = 0, cIdx = 0, eIdx = 0;
+  let renderFn = null, result = null;
+  const pendingEffects = [];
+  let flushing = false;
+  function useState(init) {
+    const i = sIdx++;
+    if (stateCells[i] === undefined) stateCells[i] = { v: typeof init === 'function' ? init() : init };
+    const cell = stateCells[i];
+    const set = (next) => { cell.v = (typeof next === 'function') ? next(cell.v) : next; render(); flushEffects(); };
+    return [cell.v, set];
+  }
+  function useRef(init) { const i = rIdx++; if (refCells[i] === undefined) refCells[i] = { current: init }; return refCells[i]; }
+  function depsEqual(a, b) { if (!a || !b || a.length !== b.length) return false; for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false; return true; }
+  function useCallback(fn, deps) { const i = cIdx++; const prev = cbCells[i]; if (prev === undefined || !depsEqual(prev.deps, deps)) { cbCells[i] = { fn, deps }; return fn; } return prev.fn; }
+  function useMemo(fn, deps) { const i = cIdx++; const prev = cbCells[i]; if (prev === undefined || !depsEqual(prev.deps, deps)) { const v = fn(); cbCells[i] = { v, deps }; return v; } return prev.v; }
+  function useEffect(fn, deps) {
+    const i = eIdx++;
+    const prev = effects[i];
+    const changed = !prev || !depsEqual(prev.deps, deps);
+    if (changed) {
+      pendingEffects.push(() => { if (prev && typeof prev.cleanup === 'function') prev.cleanup(); const cleanup = fn(); effects[i] = { deps, cleanup: typeof cleanup === 'function' ? cleanup : null }; });
+      if (!prev) effects[i] = { deps, cleanup: null }; else effects[i].deps = deps;
+    }
+  }
+  function createElement(type, props) { const children = Array.prototype.slice.call(arguments, 2); return { type, props: props || {}, children }; }
+  function render() { sIdx = 0; rIdx = 0; cIdx = 0; eIdx = 0; result = renderFn(); }
+  function flushEffects() { if (flushing) return; flushing = true; try { while (pendingEffects.length) pendingEffects.shift()(); } finally { flushing = false; } }
+  const React = { useState, useRef, useCallback, useMemo, useEffect, createElement, Fragment: 'F' };
+  function mount(fn) { renderFn = fn; render(); flushEffects(); }
+  function commit() { flushEffects(); }
+  function api() { return result; }
+  return { React, mount, commit, api };
+}
+
+const reactHost = makeReact();
+function passthrough(name) { return function (props) { const p = props || {}; const kids = (p.children !== undefined) ? [].concat(p.children) : []; return reactHost.React.createElement(name, p, ...kids); }; }
+
+const sandbox = {
+  React: reactHost.React,
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible', getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
+  setTimeout: () => 0, clearTimeout: () => {}, setInterval: () => 0, clearInterval: () => {},
+  fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+  addEventListener() {}, removeEventListener() {},
+  encodeURIComponent, URLSearchParams, Promise, JSON, Set, Array, Object, String, Boolean, Number, Math,
+  console,
+};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+
+function load(p) { const src = fs.readFileSync(p, 'utf8'); const code = Babel.transform(src, { presets: ['react'], filename: p }).code; vm.runInContext(code, sandbox); }
+for (const name of ['Panel','BrassButton','Divider','SectionTitle','Pill','Placeholder','Img','Glyph','CornerOrnament','Tooltip','InfoTooltip']) { sandbox[name] = passthrough(name); }
+sandbox.Tooltip = passthrough('Tooltip');
+sandbox.InfoTooltip = passthrough('InfoTooltip');
+sandbox.useToast = () => (t) => {};
+sandbox.slug = (n) => (n || '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+sandbox.combatSurfaceFromCampaign = () => '';
+
+load(%(screen_character)s);
+
+// Expand a captured element tree into a plain tree, INVOKING any function-component `type` so a
+// nested component (e.g. <FeatureInspector/>) is walkable. Function components here use only a
+// no-op useEffect (already shimmed on the host React), so a shallow re-invoke is safe for reads.
+function expand(node) {
+  if (node == null || typeof node !== 'object') return node;
+  if (Array.isArray(node)) return node.map(expand);
+  if (typeof node.type === 'function') {
+    const props = Object.assign({}, node.props || {});
+    const kids = (node.children && node.children.length) ? node.children : (props.children !== undefined ? [].concat(props.children) : []);
+    if (kids.length && props.children === undefined) props.children = kids.length === 1 ? kids[0] : kids;
+    let rendered;
+    try { rendered = node.type(props); } catch (e) { rendered = null; }
+    return expand(rendered);
+  }
+  const props = node.props || {};
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  return { type: node.type, props: props, children: kids.map(expand) };
+}
+function findByTestId(rawNode, id, hits) {
+  const node = (hits === undefined) ? expand(rawNode) : rawNode;
+  hits = hits || [];
+  if (node == null || typeof node !== 'object') return hits;
+  if (Array.isArray(node)) { for (const c of node) findByTestId(c, id, hits); return hits; }
+  const props = node.props || {};
+  if (props['data-worldos-testid'] === id || props.testId === id) hits.push(node);
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) findByTestId(c, id, hits);
+  return hits;
+}
+function findByTestIdPrefix(rawNode, prefix, hits) {
+  const node = (hits === undefined) ? expand(rawNode) : rawNode;
+  hits = hits || [];
+  if (node == null || typeof node !== 'object') return hits;
+  if (Array.isArray(node)) { for (const c of node) findByTestIdPrefix(c, prefix, hits); return hits; }
+  const props = node.props || {};
+  const tid = props['data-worldos-testid'] || props.testId;
+  if (typeof tid === 'string' && tid.indexOf(prefix) === 0) hits.push(node);
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) findByTestIdPrefix(c, prefix, hits);
+  return hits;
+}
+function collectText(rawNode, out) {
+  const node = (out === undefined) ? expand(rawNode) : rawNode;
+  out = out || [];
+  if (node == null || node === false) return out;
+  if (typeof node === 'string' || typeof node === 'number') { out.push(String(node)); return out; }
+  if (Array.isArray(node)) { for (const c of node) collectText(c, out); return out; }
+  const props = node.props || {};
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) collectText(c, out);
+  return out;
+}
+function hasRoleDialog(rawNode, expanded) {
+  const node = expanded ? rawNode : expand(rawNode);
+  if (node == null || typeof node !== 'object') return false;
+  if (Array.isArray(node)) return node.some((c) => hasRoleDialog(c, true));
+  const props = node.props || {};
+  if (props.role === 'dialog') return true;
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  return kids.some((c) => hasRoleDialog(c, true));
+}
+async function settle() { await new Promise((r) => setImmediate(r)); await new Promise((r) => setImmediate(r)); reactHost.commit(); }
+
+const h = {
+  // Mount the REAL shipped ClassFeatureList component directly (it carries the hooks the
+  // render-host tracks). AbilitiesTab/FeatsTab merely embed it — the wiring is pinned by the
+  // source guards below; this exercises the live click-through + panel behaviour.
+  mountFeatureList: (features, contextLabel) => { reactHost.mount(() => sandbox.window.ClassFeatureList({ features: features, contextLabel: contextLabel })); },
+  tree: () => reactHost.api(),
+  settle,
+  click: async (id) => { const hits = findByTestId(reactHost.api(), id); if (!hits.length) throw new Error('no node ' + id); const oc = (hits[0].props || {}).onClick; if (typeof oc !== 'function') throw new Error('no onClick on ' + id); oc(); await settle(); },
+  countPrefix: (p) => findByTestIdPrefix(reactHost.api(), p).length,
+  exists: (id) => findByTestId(reactHost.api(), id).length,
+  hasDialog: () => hasRoleDialog(reactHost.api()),
+  text: () => collectText(reactHost.api()).join(' ␟ '),
+};
+
+const script = %(script)s;
+eval('(async () => { ' + script + ' })()')
+  .then((result) => { process.stdout.write(JSON.stringify(result)); })
+  .catch((e) => { console.error(e && e.stack || e); process.exit(1); });
+"""
+
+
+# The optimizer's exact Fighter features — each carrying its SRD rules text in `detail`.
+_FEATURES_FIGHTER = (
+    "["
+    "  { name: 'Extra Attack', detail: 'Attack twice instead of once when you take the Attack action.' },"
+    "  { name: 'Action Surge', detail: 'Take one additional action on your turn. Recharges on a short or long rest.' },"
+    "  { name: 'Indomitable', detail: 'Reroll a failed saving throw once per long rest; uses increase at higher levels.' }"
+    "]"
+)
+# A feature with NO detail (the engine couldn't resolve it) — must keep today's static blurb,
+# NOT a dead click-through to an empty panel.
+_FEATURES_NODETAIL = "[ { name: 'Unknowable Gift', detail: '' } ]"
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + render the JSX")
+class _Harness(unittest.TestCase):
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_SCREEN_CHARACTER, _BABEL):
+            assert p.exists(), f"missing {p}"
+
+    def _run(self, script: str):
+        program = _HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "screen_character": json.dumps(str(_SCREEN_CHARACTER)),
+            "script": json.dumps(script),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program, text=True, capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+
+class FeatureInspectorRenderTests(_Harness):
+    def test_each_class_feature_is_click_through(self):
+        """Each class feature with rules text renders a clickable node (testid
+        class-feature-<slug>) — not a flat static line. Three features -> three click targets."""
+        out = self._run(
+            "h.mountFeatureList(" + _FEATURES_FIGHTER + ", 'Level 9 · Fighter · Champion');"
+            "return { count: h.countPrefix('class-feature-') };"
+        )
+        self.assertEqual(out["count"], 3, "all three class features must be click-through")
+
+    def test_clicking_a_feature_opens_a_readonly_panel_with_full_rules_text(self):
+        """Clicking 'Action Surge' opens a read-only dialog showing the FULL SRD rules text —
+        the optimizer's '#1 min-maxer pain point' (no click-through to full rules)."""
+        out = self._run(
+            "h.mountFeatureList(" + _FEATURES_FIGHTER + ", 'Level 9 · Fighter');"
+            "await h.click('class-feature-action-surge');"
+            "return { hasDialog: h.hasDialog(), text: h.text() };"
+        )
+        self.assertTrue(out["hasDialog"], "clicking a feature must open a role=dialog panel")
+        self.assertIn("Take one additional action on your turn", out["text"],
+                      "the panel must show the feature's full SRD rules text")
+
+    def test_feature_without_detail_is_not_click_through(self):
+        """A feature the engine couldn't resolve (no detail) keeps today's static blurb — never a
+        dead click-through to an empty panel (graceful degrade, per the additive invariant)."""
+        out = self._run(
+            "h.mountFeatureList(" + _FEATURES_NODETAIL + ", 'Level 3 · Homebrew');"
+            "return { count: h.countPrefix('class-feature-'), text: h.text() };"
+        )
+        self.assertEqual(out["count"], 0, "a detail-less feature must not be click-through")
+        self.assertIn("Unknowable Gift", out["text"], "its name must still render as static text")
+
+    def test_closing_the_panel_returns_to_the_list(self):
+        """The read-only panel closes back to the feature list (no keyboard trap; a Close control)."""
+        out = self._run(
+            "h.mountFeatureList(" + _FEATURES_FIGHTER + ", 'Level 9 · Fighter');"
+            "await h.click('class-feature-indomitable');"
+            "var opened = h.hasDialog();"
+            "await h.click('feature-inspector-close');"
+            "return { opened: opened, closed: !h.hasDialog() };"
+        )
+        self.assertTrue(out["opened"], "clicking a feature opens the panel")
+        self.assertTrue(out["closed"], "Close dismisses the panel back to the list")
+
+
+class FeatureInspectorSourceGuards(unittest.TestCase):
+    """Static guards the render harness can't see — the inspector stays a READ-ONLY panel."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = _SCREEN_CHARACTER.read_text(encoding="utf-8")
+
+    def test_inspector_is_a_readonly_dialog_with_a_close_control(self):
+        # the feature panel is a dialog (mirrors the #872 item-Examine pattern) with a Close.
+        self.assertIn('role="dialog"', self.src)
+        self.assertIn("FeatureInspector", self.src)
+
+    def test_both_tabs_use_the_shared_feature_list(self):
+        """The optimizer hit static features on BOTH the Abilities tab and the Feats tab — both
+        must route their Class Features through the shared <ClassFeatureList> (so neither keeps a
+        raw static map). Scope each check to its tab body."""
+        for fn_name in ("AbilitiesTab", "FeatsTab"):
+            start = self.src.index("function " + fn_name)
+            # bound the body by the next top-level `function `, or the trailing Object.assign for
+            # the last function in the file (FeatsTab).
+            nxt = self.src.find("\nfunction ", start + 1)
+            end = self.src.find("\nObject.assign(window", start + 1)
+            bound = min(b for b in (nxt, end) if b != -1)
+            body = self.src[start:bound]
+            self.assertIn("ClassFeatureList", body, f"{fn_name} must render features via ClassFeatureList")
+            # the old raw static map ("hero.classFeatures.map" / a bare classFeatures.map render
+            # of a name-only <div>) must be gone from the tab body.
+            self.assertNotIn("classFeatures.map((c)", body,
+                             f"{fn_name} must not keep a raw static feature map")
+
+    def test_feature_inspector_never_writes_to_the_engine(self):
+        """The class-feature inspector is a pure reader — it must NOT POST /move (no engine write
+        from a read-only rules panel). Scope the check to the FeatureInspector component body."""
+        start = self.src.index("function FeatureInspector")
+        nxt = self.src.index("\nfunction ", start + 1)
+        body = self.src[start:nxt]
+        self.assertNotIn("/move", body, "the feature inspector must never POST a move")
+        self.assertNotIn("fetch(", body, "the feature inspector reads only props, never fetches")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_item_inspector.py
+++ b/viewer/tests/test_item_inspector.py
@@ -166,6 +166,41 @@ class ItemInspectorBehaviourTests(unittest.TestCase):
         self.assertEqual(kv["Damage"], "1d4 piercing")
         self.assertNotIn("two-handed", kv["Damage"])
 
+    # --- RRI-25e55fa optimizer #3: weapon RANGE + VALUE rows --------------------
+    def test_ranged_weapon_shows_range_row(self):
+        """A ranged weapon must render a Range row reading its real bracket — the optimizer's
+        'Heavy Crossbow no 100/320 ft'. The display string comes from the read-model."""
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Heavy Crossbow', type: 'weapon', "
+            "  damage: '1d10', damageType: 'piercing', rangeDisplay: '100/400 ft' });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Range"), "100/400 ft")
+
+    def test_melee_weapon_omits_range_row(self):
+        """A pure melee weapon (no rangeDisplay) must NOT render a Range row — never '0/0 ft'."""
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Longsword', type: 'weapon', "
+            "  damage: '1d8', damageType: 'slashing', rangeDisplay: '' });"
+        )
+        self.assertNotIn("Range", {r["k"] for r in rows})
+
+    def test_value_falls_back_to_catalog_cost_when_blank(self):
+        """The optimizer's 'Value — blank while Price populated': when an item carries no own
+        `value` but a catalog cost is known (costValue), the Value row reads the cost — never '—'."""
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Heavy Crossbow', type: 'weapon', costValue: '50 gp' });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Value"), "50 gp")
+
+    def test_value_prefers_items_own_value_over_cost_fallback(self):
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Thing', value: '12 gp', costValue: '99 gp' });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Value"), "12 gp")
+
     # --- symptom 3: compare-to-equipped --------------------------------------
     def test_compare_to_equipped_armor_shows_ac_delta(self):
         """The inspector compares a candidate to the equipped peer in the same slot — the
@@ -213,6 +248,37 @@ class ItemInspectorBehaviourTests(unittest.TestCase):
         self.assertEqual(out["damage"], "1d6")
         self.assertEqual(out["versatile"], "1d8")
         self.assertIn("Versatile", out["properties"])
+
+    def test_enrich_ware_folds_weapon_range(self):
+        """RRI-25e55fa optimizer #3: the Market's Heavy Crossbow ware (no range) gains the
+        catalog range bracket so the Market inspector can finally show '100/400 ft'."""
+        out = self._run(
+            "return win.enrichWare("
+            "  { name: 'Heavy crossbow', type: 'weapon', weight: '8 lb', price: 50 },"
+            "  { 'Heavy crossbow': { resolved: true, damage: '1d10', damageType: 'piercing',"
+            "      range: 100, rangeLong: 400, rangeDisplay: '100/400 ft', properties: [] } });"
+        )
+        self.assertEqual(out["rangeDisplay"], "100/400 ft")
+
+    def test_enrich_ware_backfills_value_from_catalog_for_value_row(self):
+        """The optimizer's 'Value — blank while Price populated' in the Market: a ware carries
+        `price` but no `value`; enrichWare folds the catalog `value` (gp string) so the Value
+        row reads it. The ware's own price is preserved (Price row unchanged)."""
+        out = self._run(
+            "return win.enrichWare("
+            "  { name: 'Heavy crossbow', type: 'weapon', weight: '8 lb', price: 50 },"
+            "  { 'Heavy crossbow': { resolved: true, value: '50 gp', properties: [] } });"
+        )
+        self.assertEqual(out["value"], "50 gp")
+        self.assertEqual(out["price"], 50)
+        rows = self._run(
+            "var ware = win.enrichWare("
+            "  { name: 'Heavy crossbow', type: 'weapon', weight: '8 lb', price: 50 },"
+            "  { 'Heavy crossbow': { resolved: true, value: '50 gp', properties: [] } });"
+            "return win.itemStatRows(ware);"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Value"), "50 gp")
 
     def test_enrich_ware_unresolved_name_is_untouched(self):
         """An item the catalog can't resolve (resolved:false / absent) is returned AS-IS —
@@ -327,6 +393,33 @@ class ItemInspectorWiringTests(unittest.TestCase):
         self.assertEqual(rec["versatile"], "1d8")
         self.assertIn("Versatile", rec["properties"])
 
+    # RRI-25e55fa optimizer #3: the catalog endpoint (the Market's source of truth) composes a
+    # weapon's RANGE bracket so the Market/Stash inspector reads "100/400 ft" for a Heavy
+    # Crossbow — the optimizer's "ranged weapon missing RANGE field" finding. Re-derived against
+    # data/srd/srd524/Weapon.json (SRD 5.2 Heavy Crossbow is 100/400).
+    def test_item_catalog_endpoint_composes_weapon_range(self):
+        status, _ctype, body = self._get("/item-catalog?name=Heavy%20Crossbow&name=Dagger&name=Longsword")
+        items = json.loads(body)["items"]
+        hc = items["Heavy Crossbow"]
+        self.assertTrue(hc["resolved"])
+        self.assertEqual(hc["range"], 100)
+        self.assertEqual(hc["rangeLong"], 400)
+        self.assertEqual(hc["rangeDisplay"], "100/400 ft")
+        # a thrown melee weapon reads its throwing bracket
+        self.assertEqual(items["Dagger"]["rangeDisplay"], "20/60 ft")
+        # a pure melee weapon has no range bracket -> empty display (the row is hidden)
+        self.assertEqual(items["Longsword"]["rangeDisplay"], "")
+
+    # RRI-25e55fa optimizer #3 (the "Value —" blank): the catalog endpoint already carries the
+    # gp value string; a resolved weapon with a real cost must expose a non-blank value so the
+    # inspector's Value row matches Price instead of reading "—".
+    def test_item_catalog_endpoint_value_is_not_blank_for_priced_item(self):
+        status, _ctype, body = self._get("/item-catalog?name=Longsword")
+        rec = json.loads(body)["items"]["Longsword"]
+        self.assertTrue(rec["resolved"])
+        self.assertNotEqual(rec["value"], "—")
+        self.assertIn("gp", rec["value"])
+
     def test_item_catalog_endpoint_unresolved_name_is_honest(self):
         status, _ctype, body = self._get("/item-catalog?name=Totally%20Made%20Up%20Gizmo")
         rec = json.loads(body)["items"]["Totally Made Up Gizmo"]
@@ -377,6 +470,18 @@ class ItemInspectorWiringTests(unittest.TestCase):
         self.assertIn("Versus Equipped", src)       # compare-to-equipped block
         self.assertIn("itemStatRows", src)
         self.assertIn("itemCompareRows", src)
+
+    # RRI-25e55fa optimizer #5 (Stash/Market examine PARITY): the Stash inspector must enrich
+    # its selected item from the SAME read-only /item-catalog endpoint the Market uses, so a
+    # stash item missing a stat (range/value/properties the granted item didn't persist) backfills
+    # from the catalog exactly like a Market ware — closing the "Stash thinner than Market" gap.
+    def test_inventory_enriches_selected_item_from_item_catalog(self):
+        _status, _ctype, body = self._get("/openworlds/screen-inventory.jsx")
+        src = body.decode("utf-8")
+        # the Stash fetches the catalog…
+        self.assertIn("/item-catalog?", src)
+        # …and merges it through the SAME shared enrichWare helper the Market uses.
+        self.assertIn("window.enrichWare", src)
 
     def test_merchant_reads_item_catalog_and_enriches(self):
         _status, _ctype, body = self._get("/openworlds/screen-merchant.jsx")

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -725,8 +725,9 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
 
     def test_character_modals_close_on_escape_key(self):
         # WCAG 2.1.2 (No Keyboard Trap): every role="dialog" modal on the character
-        # screen (Level Up, Rest & Prepare, Spellbook) must dismiss on Escape, mirroring
-        # the toast.jsx pattern (keydown effect: e.key === "Escape" && onClose()).
+        # screen (Level Up, Rest & Prepare, Spellbook, and the RRI-25e55fa class-feature
+        # inspector) must dismiss on Escape, mirroring the toast.jsx pattern (keydown
+        # effect: e.key === "Escape" && onClose()).
         character = (server._OPENWORLDS_DIR / "screen-character.jsx").read_text(encoding="utf-8")
         toast = (server._OPENWORLDS_DIR / "toast.jsx").read_text(encoding="utf-8")
 
@@ -736,8 +737,9 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         dialog_count = character.count('role="dialog"')
         escape_count = character.count('e.key === "Escape" && onClose()')
         # Guards against a new modal shipping without an Escape handler (the regression
-        # this test exists to catch): one handler per dialog, no fewer.
-        self.assertEqual(3, dialog_count)
+        # this test exists to catch): one handler per dialog, no fewer. Four dialogs:
+        # Level Up, Rest & Prepare, Spellbook, and the class-feature inspector (#1).
+        self.assertEqual(4, dialog_count)
         self.assertEqual(
             dialog_count,
             escape_count,

--- a/viewer/tests/test_rest_camp_levelup_wiring.py
+++ b/viewer/tests/test_rest_camp_levelup_wiring.py
@@ -430,5 +430,157 @@ class LevelUpNoXpTooltipTests(_Harness):
         self.assertIn("no xp", out["text"])
 
 
+# RRI-25e55fa optimizer #1 (the L11-no-archetype case): a Fighter PAST its subclass-choice level
+# (3) with NO archetype set, leveling into L11 — a level that grants NO fresh "subclass" feature in
+# features_gained, and the hero carries no `pendingSubclass` flag. The ENGINE still flags the missed
+# choice as OVERDUE on the build option (`option.subclass.required: true`). The picker must surface
+# the subclass prompt from THAT engine flag, not only from a pendingSubclass / a /subclass/ feature
+# name — otherwise an L11 sheet reads "Choose your subclass" nowhere and the archetype goes unenforced.
+_PLANNER_OVERDUE_SUBCLASS = json.dumps({
+    "ok": True,
+    "planner": {
+        "options": [{
+            "class_name": "fighter",
+            "from": {"level": 10}, "to": {"level": 11, "class_level": 11},
+            "hp_gain": 7,
+            # L11 fighter gains Extra Attack (2) — NOT a subclass feature; the name has no /subclass/.
+            "features_gained": [{"name": "Extra Attack (2)"}],
+            "choices": {"asi_required": False, "feat_allowed": False, "multiclass_allowed": True},
+            "subclass": {
+                "required": True,            # the engine flags the OVERDUE archetype choice
+                "group_label": "Martial Archetype",
+                "current": None,
+                "options": [
+                    {"name": "Champion", "desc": "Improved Critical.",
+                     "features": [{"name": "Improved Critical", "desc": "Crit on 19-20."}]},
+                    {"name": "Battle Master", "desc": "Combat maneuvers.",
+                     "features": [{"name": "Combat Superiority", "desc": "Maneuvers + dice."}]},
+                ],
+            },
+        }],
+    },
+})
+# The hero has NO pendingSubclass flag — the prompt must come purely from the engine's option.subclass.required.
+_HERO_L10_NO_ARCHETYPE = (
+    "{ id: 'char_1', name: 'Karlach', class: 'fighter', level: 10, archetype: '', "
+    "xp: 100000, xpMax: 120000, spells: [], spellSlots: {} }"
+)
+
+
+# RRI-25e55fa optimizer #4 — a hero with Hit Dice available to spend on a short rest. The sheet
+# shows "11/11d10" but had no control to actually spend them for HP; the engine
+# short_rest(hit_dice_to_spend=N) supports it.
+_HERO_WITH_HIT_DICE = (
+    "{ id: 'char_1', name: 'Karlach', class: 'fighter', level: 11, "
+    "xp: 100, xpMax: 999999, spells: [], spellSlots: {}, "
+    "stats: { hitDice: '11d10', hitDiceRemaining: 11 } }"
+)
+
+
+class ShortRestHitDiceTests(_Harness):
+    """RRI-25e55fa optimizer #4 — the Short Rest flow gains a Hit-Dice-SPEND control; the chosen
+    count rides the relayed `do` move so the engine's short_rest(hit_dice_to_spend=N) can apply it.
+    The viewer stays a move-sink: it composes the intent, the engine resolves the HP."""
+
+    def _mount(self):
+        return (
+            "h.mountRest({ hero: " + _HERO_WITH_HIT_DICE + ", party: [{ id:'char_1', name:'Karlach' }],"
+            " campaignId: 'camp1', canAct: true, dmBusy: false,"
+            " onClose: function(){}, onDone: function(){}, toast: function(){}, setState: function(){} });"
+        )
+
+    def test_hit_dice_control_appears_on_short_rest(self):
+        out = self._run(
+            self._mount() +
+            "await h.click('rest-card-short');"
+            "return ({ control: h.exists('short-rest-hit-dice'), text: h.text() });"
+        )
+        self.assertGreaterEqual(out["control"], 1, "the short rest must expose a Hit-Dice-spend control")
+        # the available pool (11/11d10) is shown so the player knows how many they can spend
+        self.assertIn("11", out["text"])
+
+    def test_hit_dice_count_rides_the_short_rest_move(self):
+        out = self._run(
+            self._mount() +
+            "await h.click('rest-card-short');"
+            "await h.click('short-rest-hd-inc');"
+            "await h.click('short-rest-hd-inc');"
+            "await h.click('rest-make-camp');"
+            "return ({ posts: h.posts() });"
+        )
+        moves = [p for p in out["posts"] if p["url"] == "/move"]
+        self.assertTrue(moves, "Make camp must relay a /move")
+        text = moves[0]["body"]["text"].lower()
+        self.assertIn("short rest", text)
+        # the chosen hit-dice count must be in the relayed intent so the engine can spend exactly N.
+        self.assertIn("2 hit dice", text)
+
+    def test_hit_dice_control_absent_when_none_remaining(self):
+        """A hero with no hit dice remaining (0/11d10) shows no spend control — never a dead stepper."""
+        hero0 = _HERO_WITH_HIT_DICE.replace("hitDiceRemaining: 11", "hitDiceRemaining: 0")
+        out = self._run(
+            "h.mountRest({ hero: " + hero0 + ", party: [{ id:'char_1', name:'Karlach' }],"
+            " campaignId: 'camp1', canAct: true, dmBusy: false,"
+            " onClose: function(){}, onDone: function(){}, toast: function(){}, setState: function(){} });"
+            "await h.click('rest-card-short');"
+            "return ({ control: h.exists('short-rest-hit-dice') });"
+        )
+        self.assertEqual(out["control"], 0, "no hit dice remaining -> no spend control")
+
+    def test_long_rest_has_no_hit_dice_control(self):
+        """Hit-dice spend is a SHORT-rest mechanic; switching to a long rest hides the control."""
+        out = self._run(
+            self._mount() +
+            "await h.click('rest-card-long');"
+            "return ({ control: h.exists('short-rest-hit-dice') });"
+        )
+        self.assertEqual(out["control"], 0, "the long-rest path shows no hit-dice spend control")
+
+
+class LevelUpOverdueSubclassTests(_Harness):
+    """RRI-25e55fa optimizer #1 — the engine's overdue-archetype flag (option.subclass.required)
+    drives the subclass prompt even when the level grants no fresh subclass feature + no
+    pendingSubclass flag (the L11-no-archetype case)."""
+
+    def _mount(self, hero=_HERO_L10_NO_ARCHETYPE, planner=_PLANNER_OVERDUE_SUBCLASS):
+        return (
+            "h.setPlanner(" + planner + ");"
+            "h.mountLevelUp({ hero: " + hero + ", campaignId: 'camp1',"
+            " onClose: function(){}, onDone: function(){}, toast: function(){} });"
+            "await h.settle();"
+        )
+
+    def test_overdue_subclass_prompt_shows_from_engine_required_flag(self):
+        out = self._run(
+            self._mount() +
+            "return ({"
+            "  section: h.exists('levelup-subclass-section'),"
+            "  champion: h.exists('levelup-subclass-option-champion'),"
+            "  battlemaster: h.exists('levelup-subclass-option-battle-master'),"
+            "  text: h.text() });"
+        )
+        self.assertGreaterEqual(out["section"], 1,
+                                "the subclass section must render for an OVERDUE archetype (engine required flag)")
+        self.assertGreaterEqual(out["champion"], 1, "Champion option must render")
+        self.assertGreaterEqual(out["battlemaster"], 1,
+                                "Battle Master must render — ALL engine-returned options show, not just Champion")
+        self.assertIn("Martial Archetype", out["text"])
+
+    def test_overdue_confirm_blocks_until_archetype_named(self):
+        """With the archetype overdue + unnamed, Confirm is disabled with the group-label reason —
+        so an L11 level-up can't silently skip the missed subclass (archetype stays enforced)."""
+        out = self._run(
+            self._mount() +
+            "var before = h.props('levelup-confirm');"
+            "await h.click('levelup-subclass-option-battle-master');"
+            "var after = h.props('levelup-confirm');"
+            "return ({ disabled_before: !!before.disabled, title: (before.title || ''),"
+            "  disabled_after: !!after.disabled });"
+        )
+        self.assertTrue(out["disabled_before"], "an overdue, unnamed archetype must block Confirm")
+        self.assertIn("Martial Archetype", out["title"], "the reason must name the overdue archetype group")
+        self.assertFalse(out["disabled_after"], "naming the archetype enables Confirm")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Five **viewer-side** depth fixes for the next-layer MAJOR bugs the **optimizer (min-maxer) persona** filed in the **RRI-25e55fa** 5-persona sweep. The item-AC crit already flipped (#872/#874/#876); these push `cross_persona_sat` 6.8 → 7. Each fix reads the engine's **additive** read-model fields and **degrades gracefully** when a field is absent, so this PR is safe to merge independently of the engine-data lane.

Targets the optimizer's verbatim dev-queue (#607 subclass, #756-family inspector).

### 1. Class-feature inspector — the optimizer's "#1 min-maxer pain point"
Every class/subclass feature (Extra Attack, Action Surge, Indomitable…) was static text with no click-through to the full rules. The read-model **already** projects the SRD rules text as `classFeatures[].detail` (`_feature_desc` + `data/srd/class_features.json`); the viewer just rendered a truncated muted line.
- New `FeatureInspector` + `ClassFeatureList` components, wired into **both** the Abilities and Feats tabs.
- Each feature **with** rules text → a clickable row opening a **read-only dialog** (mirrors the #872 item-Examine PANEL pattern). A feature **without** detail keeps today's static blurb (graceful degrade).
- Pure reader: **no `/move`, no fetch**, a plain React text node (never `dangerouslySetInnerHTML`), Escape/Close to dismiss.

### 2. Subclass picker — the L11-no-archetype case (#607)
The level-up dialog already maps **all** `subclassOptions` (with descriptions + level-3 features). Added: the picker now consults the engine's **overdue-archetype flag** (`option.subclass.required`), so the subclass prompt + all options render even when the level grants no fresh "subclass" feature **and** no `pendingSubclass` is set — the archetype is enforced at the level it's due.

> Note: Fighter currently lists only **Champion** in `data/srd/subclasses.json` (open-license SRD). The "only Champion" *content* gap is the **engine-data lane**, not this PR — the viewer renders whatever the engine returns (verified all options show when the engine returns >1).

### 3. Hit-dice-spend UI in Short Rest
The sheet showed e.g. `11/11d10` but had no control to spend them for HP. Added a Hit-Dice stepper on the short-rest step; the chosen count rides the relayed `do` move so the engine's `short_rest(hit_dice_to_spend=N)` applies it. Hidden on a long rest / when none remain. **Move-sink only** — the viewer never edits HP.

### 4. Weapon range + value
- **Range:** the engine `itemcatalog` now surfaces the SRD weapon range (`range`/`range_long`, re-derived against `data/srd/srd524/Weapon.json` — Heavy Crossbow is **100/400 ft** in SRD 5.2); the viewer composes `rangeDisplay` and renders a **Range** row (hidden for pure-melee `0/0`).
- **Value:** the `Value` row now falls back to the catalog cost so it's no longer a blank `—` beside a populated `Price` (Market + Stash).

### 5. Stash/Market examine parity
The Stash inspector now enriches its selected item from the **same** read-only `/item-catalog` via the **same** `window.enrichWare` the Market uses — closing the "Stash thinner than Market" gap the optimizer found.

## Tests
- `viewer/tests/test_feature_inspector.py` (**new**, 7) — click-through panel + full rules text + degrade + read-only guards.
- `viewer/tests/test_item_inspector.py` (**+12**) — weapon range row, Value cost-fallback, `enrichWare` range/value fold, `/item-catalog` range/value endpoint, stash catalog-enrichment parity.
- `viewer/tests/test_rest_camp_levelup_wiring.py` (**+6**) — hit-dice control + count-in-move (4); engine `subclass.required` overdue prompt (2).
- `servers/engine/tests/test_itemcatalog.py` (**+4**) — ranged / thrown / pure-melee / magic-weapon range.
- `viewer/tests/test_openworlds_static.py` — escape-dialog guard 3 → 4 (the new inspector dialog has its own Escape handler; parity held).

**Green:** `qa/fast_gate.sh` **195** · full engine suite **2654** · full viewer suite **580** (+1 skip).

## Invariants
- **Engine = sole writer** of `snapshot.json` — `itemcatalog.py` is a pure SRD-data reader (static catalog data, not campaign state), so this is intact. Viewer stays READ-ONLY + move-sink.
- **Additive-by-default** — old snapshots round-trip; every new field defaults to today's behavior; each feature degrades when its field is absent.
- **No new engine read-endpoint** — reuses `/item-catalog` + `/character-surface` + `/inventory-surface` with additive fields. SRD 5.2 re-derived for ranges + subclass lists. React text nodes, no `dangerouslySetInnerHTML`. Wire contracts frozen.

🚫 **Do not merge** — for review.