### PR TITLE
fix(qa): surface auto-concentration save in the distill (recovers mis-scored combat-sprints)

### DIFF
--- a/qa/distill.py
+++ b/qa/distill.py
@@ -53,6 +53,35 @@ def _audit_fields(res) -> list[str]:
             f"    `↳ maneuver-damage: {md.get('maneuver', '?')} {md.get('die', '?')}="
             f"{md.get('rolled', '?')} applied={md.get('applied', md.get('applies_to', '?'))}`"
         )
+    # #792 auto-concentration: attack/apply_damage auto-roll the CON save when a
+    # concentrating creature takes damage. The result sits AFTER target_state in the JSON,
+    # so the 240-char preview truncates it and the Angry-DM lens mis-reads a tool-sourced
+    # save as a hallucinated "10 vs 10" prose number. Surface it so the lens can audit it.
+    cs = data.get("concentration_save")
+    if isinstance(cs, dict):
+        verdict = "MAINTAINED" if cs.get("maintained") else "BROKEN"
+        spell = cs.get("spell")
+        out.append(
+            f"    `↳ concentration-save: {cs.get('target', cs.get('character_id', '?'))} "
+            f"{str(cs.get('ability', 'con')).upper()} {cs.get('roll', '?')} "
+            f"(nat {cs.get('natural', '?')}) vs DC {cs.get('dc', '?')} → {verdict}"
+            + (f" ({spell})" if spell else "")
+            + "`"
+        )
+    # #792/F3-6: when concentration breaks, the held victims (Hold Person/Monster) are freed.
+    freed = data.get("freed_targets")
+    if isinstance(freed, list) and freed:
+        out.append(
+            f"    `↳ freed-on-concentration-end: "
+            f"{', '.join(str(f) for f in freed if f)}`"
+        )
+    # #792: a deferred on-hit advantage rider (e.g. Guiding Bolt) consumed by the next attack.
+    adv = data.get("advantage_consumed")
+    if adv:
+        src = adv if isinstance(adv, str) else (
+            adv.get("source") if isinstance(adv, dict) else None
+        )
+        out.append(f"    `↳ advantage-consumed{f': {src}' if src else ''}`")
     return out
 
 

--- a/qa/test_distill.py
+++ b/qa/test_distill.py
@@ -54,6 +54,35 @@ def test_audit_fields_surfaces_maneuver_damage():
     assert "maneuver-damage: Trip Attack 1d8=6 applied=True" in lines[0]
 
 
+def test_audit_fields_surfaces_concentration_save():
+    # The #792 auto-concentration roll sits after target_state in the result JSON, so the
+    # 240-char preview truncates it and the Angry-DM lens mis-scores a tool-sourced save as a
+    # hallucinated "10 vs 10" prose number. Surfacing it closes the highest-risk false defect.
+    res = json.dumps(
+        {"ok": True, "concentration_save": {
+            "target": "Maren", "rolled": True, "ability": "con",
+            "dc": 10, "roll": 13, "natural": 11, "maintained": True, "spell": "Hold Person"}}
+    )
+    lines = distill._audit_fields(res)
+    assert len(lines) == 1
+    assert "concentration-save: Maren CON 13 (nat 11) vs DC 10 → MAINTAINED (Hold Person)" in lines[0]
+    # A broken save renders BROKEN.
+    broken = json.dumps({"concentration_save": {
+        "target": "Maren", "ability": "con", "dc": 14, "roll": 8, "maintained": False}})
+    assert "→ BROKEN" in distill._audit_fields(broken)[0]
+
+
+def test_audit_fields_surfaces_freed_targets_and_advantage_consumed():
+    # Held victims released when concentration breaks (#792/F3-6), and a consumed on-hit
+    # advantage rider (Guiding Bolt) — both engine-auto-fired, both truncated by the preview.
+    freed = distill._audit_fields(json.dumps({"freed_targets": ["goblin-1", "goblin-2"]}))
+    assert len(freed) == 1 and "freed-on-concentration-end: goblin-1, goblin-2" in freed[0]
+    adv = distill._audit_fields(json.dumps({"advantage_consumed": "Guiding Bolt"}))
+    assert len(adv) == 1 and "advantage-consumed: Guiding Bolt" in adv[0]
+    # Empty/absent → no-op.
+    assert distill._audit_fields(json.dumps({"freed_targets": [], "advantage_consumed": None})) == []
+
+
 def test_audit_fields_is_safe_on_non_json_non_dict_and_irrelevant():
     assert distill._audit_fields("not json at all") == []
     assert distill._audit_fields(json.dumps([1, 2, 3])) == []


### PR DESCRIPTION
Evidence-mined mech-climb keystone. The Angry-DM lens mis-scored #792's auto-concentration save as a hallucination because qa/distill.py truncated the result block (240-char preview, concentration_save sits after target_state). Surface concentration_save + freed_targets + advantage_consumed past the truncation (mirrors the #209/#213 audit lines). QA-harness only. Should lift the mech median from 3.8 toward ~4.0+ on re-score of the existing transcripts (no combat re-run).