### PR TITLE
fix(qa+combat): surface monster Multiattack budget + ceiling rejection in distilled transcript (F01-1 / csmed-4)

### DIFF
--- a/qa/distill.py
+++ b/qa/distill.py
@@ -24,13 +24,58 @@ def _short(v, n=220) -> str:
     return s if len(s) <= n else s[: n - 1] + "…"
 
 
+def _multiattack_rejection_line(text: str) -> str | None:
+    """Render a one-line audit note when ``text`` is the engine's attack-budget rejection
+    (the per-action ceiling that enforces a monster's stat-block Multiattack or a PC's
+    Extra-Attack/Action-Surge limit). Matches the exact engine phrasings from
+    combat.check_action_attack so ordinary error prose never trips it. Returns None when the
+    text is not such a rejection."""
+    import re as _re
+
+    m = _re.search(
+        r"(this creature's Multiattack grants \d+ attack\(s\) per turn[^\"']*)",
+        text,
+        _re.IGNORECASE,
+    )
+    if m is None:
+        m = _re.search(
+            r"((?:no attacks left this turn|already attacked this turn)[^\"']*)",
+            text,
+            _re.IGNORECASE,
+        )
+    if m is None:
+        return None
+    reason = " ".join(m.group(1).split()).rstrip(".")
+    return f"    `↳ attack-rejected: {reason}`"
+
+
 def _audit_fields(res) -> list[str]:
     """Surface engine-auto-fired mechanics that the 240-char tool_result preview truncates,
     so the scorer can AUDIT them tool-sourced rather than only in DM prose (a recurring
     Angry-DM finding). Currently: next_turn's ``repeat_saves`` (Hold Person/Monster
-    end-of-turn escape saves, #209) and attack/use_resource ``maneuver_damage`` (the Battle
-    Master superiority die, #213). Best-effort: a non-JSON or shape-mismatched result yields
-    nothing (the normal truncated `← …` preview line still stands)."""
+    end-of-turn escape saves, #209), attack/use_resource ``maneuver_damage`` (the Battle
+    Master superiority die, #213), and attack()'s Multiattack/Extra-Attack BUDGET — both the
+    ``attacks_made/allowed_this_turn`` ceiling on a swing AND the engine's REJECTION of an
+    over-budget attack (F01-1 / csmed-4: the Ghoul's two-Bite Multiattack ceiling IS enforced
+    in the engine, but the 585-char attack result truncates at 240 so the scorer never sees
+    the budget — it then reads a DM that 'conjured a Multiattack that doesn't exist'). The
+    rejection arrives as either a plain exception string or an ``{"error": …}`` envelope.
+    Best-effort: a non-JSON, non-dict, irrelevant result yields nothing (the normal truncated
+    `← …` preview line still stands)."""
+    # A plain-string is_error tool_result (the MCP layer renders the exception text directly,
+    # not JSON) — surface a Multiattack/attack-budget REJECTION before the JSON parse, since a
+    # bare string would otherwise json.loads-fail straight to []. Only fires on the engine's
+    # exact ceiling phrasing so ordinary error prose stays untouched.
+    if isinstance(res, str):
+        try:
+            json.loads(res)  # is it actually JSON? if so, fall through to the dict path
+            is_plain = False
+        except (json.JSONDecodeError, ValueError):
+            is_plain = True
+        if is_plain:
+            line = _multiattack_rejection_line(res)
+            return [line] if line else []
+
     try:
         data = json.loads(res) if isinstance(res, str) else res
     except (json.JSONDecodeError, TypeError, ValueError):
@@ -38,6 +83,29 @@ def _audit_fields(res) -> list[str]:
     if not isinstance(data, dict):
         return []
     out: list[str] = []
+    # A JSON-enveloped error ({"error": "…cannot attack: …Multiattack grants N…"}).
+    err = data.get("error") or data.get("detail")
+    if isinstance(err, str):
+        line = _multiattack_rejection_line(err)
+        if line:
+            out.append(line)
+    # A resolved attack swing: surface the per-turn attack BUDGET when it is > 1 (a real
+    # Multiattack or Extra-Attack ceiling). Single-attack swings (allowed == 1, the 95% case)
+    # surface nothing — no noise, mirroring repeat_saves/maneuver_damage firing only when
+    # there is a mechanic to audit. This is the tool-sourced proof the engine constrained the
+    # monster to its stat-block Multiattack (csmed-4): "Ghoul 1/2 attacks this turn".
+    allowed = data.get("attacks_allowed_this_turn")
+    made = data.get("attacks_made_this_turn")
+    if isinstance(allowed, int) and allowed > 1 and isinstance(made, int):
+        # The engine surfaces ``multiattack_grants`` (the stat-block Multiattack count) only
+        # when the budget IS a monster Multiattack; its absence means the budget came from
+        # Extra Attack / Action Surge (a PC). Label accordingly — never guess "Multiattack"
+        # for a PC's Extra Attack.
+        kind = "Multiattack" if isinstance(data.get("multiattack_grants"), int) else "Extra Attack"
+        actor = data.get("attacker", "the attacker")  # always present on an attack() return
+        out.append(
+            f"    `↳ attack-budget: {actor} {made}/{allowed} attacks this turn ({kind})`"
+        )
     for rs in data.get("repeat_saves", []) or []:
         if not isinstance(rs, dict):
             continue

--- a/qa/test_distill.py
+++ b/qa/test_distill.py
@@ -94,6 +94,89 @@ def test_audit_fields_surfaces_freed_targets_and_advantage_consumed():
     assert len(adv) == 1 and "advantage-consumed: Guiding Bolt" in adv[0]
     # Empty/absent → no-op.
     assert distill._audit_fields(json.dumps({"freed_targets": [], "advantage_consumed": None})) == []
+def test_audit_fields_surfaces_multiattack_budget():
+    # An attack() return for a Multiattack monster (the Ghoul: 2 Bites) carries
+    # attacks_made_this_turn / attacks_allowed_this_turn — but the 240-char preview
+    # truncates them (the attack result is ~585 chars), so the scorer cannot SEE the
+    # engine constrain the monster to its Multiattack budget. csmed-4 ("the Ghoul
+    # conjured a two-Claw Multiattack that doesn't exist") is this blindness: the
+    # ceiling IS enforced, but its tool-sourcing never reaches the distilled transcript.
+    res = json.dumps(
+        {
+            "attacker": "Ghoul",
+            "target": "Hero",
+            "attack_roll": {"total": 21, "natural": 17, "detail": "1d20[17] +4 = 21"},
+            "hit": True,
+            "attacks_made_this_turn": 1,
+            "attacks_allowed_this_turn": 2,
+            "multiattack_grants": 2,  # engine-surfaced: the budget IS a stat-block Multiattack
+        }
+    )
+    lines = distill._audit_fields(res)
+    assert len(lines) == 1
+    assert "attack-budget: Ghoul 1/2 attacks this turn (Multiattack)" in lines[0]
+
+
+def test_audit_fields_labels_pc_extra_attack_budget_not_multiattack():
+    # A PC's multi-strike turn comes from Extra Attack / Action Surge, NOT Multiattack —
+    # the engine omits multiattack_grants, so distill must label it "(Extra Attack)" and
+    # never miscredit a PC with a monster Multiattack.
+    res = json.dumps(
+        {
+            "attacker": "Fighter",
+            "target": "Orc",
+            "hit": True,
+            "attacks_made_this_turn": 1,
+            "attacks_allowed_this_turn": 2,
+        }
+    )
+    lines = distill._audit_fields(res)
+    assert len(lines) == 1
+    assert "attack-budget: Fighter 1/2 attacks this turn (Extra Attack)" in lines[0]
+
+
+def test_audit_fields_suppresses_single_attack_budget():
+    # A plain single-attack swing (PC with no Extra Attack: allowed=1) must NOT surface a
+    # budget line — no noise for the 95% of attacks that are one strike (additive discipline,
+    # mirrors maneuver_damage/repeat_saves only firing when there is something to audit).
+    res = json.dumps(
+        {
+            "attacker": "Hero",
+            "target": "Goblin",
+            "hit": True,
+            "attacks_made_this_turn": 1,
+            "attacks_allowed_this_turn": 1,
+        }
+    )
+    assert distill._audit_fields(res) == []
+
+
+def test_audit_fields_surfaces_rejected_multiattack_overflow_plain_string():
+    # The REJECTED 3rd attack (a ValueError) reaches the transcript as a PLAIN-STRING
+    # is_error tool_result (the MCP layer renders the exception text, not JSON). distill
+    # must surface it so the scorer sees the engine REFUSE the phantom attack — the exact
+    # csmed-4 evidence ("a Multiattack that doesn't exist" was the DM narrating past a
+    # ceiling the engine had already enforced).
+    res = (
+        "Ghoul cannot attack: this creature's Multiattack grants 2 attack(s) "
+        "per turn; 2 already made this turn."
+    )
+    lines = distill._audit_fields(res)
+    assert len(lines) == 1
+    assert "attack-rejected: this creature's Multiattack grants 2 attack(s) per turn" in lines[0]
+
+
+def test_audit_fields_surfaces_rejected_multiattack_overflow_json_error():
+    # Same rejection when the MCP layer wraps it as {"error": "..."} JSON.
+    res = json.dumps(
+        {
+            "error": "Ghoul cannot attack: this creature's Multiattack grants 2 attack(s) "
+            "per turn; 2 already made this turn."
+        }
+    )
+    lines = distill._audit_fields(res)
+    assert len(lines) == 1
+    assert "attack-rejected: this creature's Multiattack grants 2 attack(s) per turn" in lines[0]
 
 
 def test_audit_fields_is_safe_on_non_json_non_dict_and_irrelevant():

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4791,6 +4791,14 @@ def attack(
                     c.combat.surge_actions,
                     ma,
                 )
+                # When the budget comes from a stat-block Multiattack (ma>0), surface the
+                # grant explicitly so the distilled transcript reads the ceiling tool-sourced
+                # (F01-1 / csmed-4: a monster narrated "a Multiattack that doesn't exist" was
+                # the DM running past a ceiling the engine HAD enforced — invisible because the
+                # attack result truncates in qa/distill.py). Absent for PCs (ma=0), so Extra
+                # Attack / Action Surge budgets stay labelled as themselves; purely additive.
+                if ma > 0:
+                    result["multiattack_grants"] = ma
         # Zone-aware range (S2.7): a MELEE attack needs attacker & target in the same
         # or an adjacent zone; ranged reaches any zone. Advisory only — surface a
         # warning, never hard-block. Inert when no zones are declared. Position lives

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -1372,6 +1372,75 @@ def test_monster_combat_no_multiattack_key_for_single_attack_monster(tmp_path, m
     assert "multiattack" not in w, "no-Multiattack monster must not gain a composition key"
 
 
+# --- F01-1 / csmed-4 end-to-end: the Ghoul's enforced Multiattack budget must reach the
+#     DISTILLED transcript (the surface the Angry-DM lens reads) ----------------------------
+
+
+def test_ghoul_multiattack_budget_and_rejection_survive_distill(tmp_path, monkeypatch):
+    """csmed-4: "the Ghoul conjured a two-Claw Multiattack that doesn't exist." The engine
+    DOES enforce the Ghoul's two-Bite ceiling (a 3rd attack raises), but the 585-char attack
+    result truncates at 240 in qa/distill.py — so the scorer never SEES the tool-sourced
+    budget and reads the DM as improvising attacks. This wires the REAL engine results through
+    distill._audit_fields and asserts the budget on each legal swing AND the ceiling rejection
+    on the over-budget swing both surface as auditable, tool-sourced lines."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import json as _json
+    import sys as _sys
+    from pathlib import Path as _Path
+
+    _sys.path.insert(0, str(_Path(__file__).resolve().parents[3] / "qa"))
+    import distill  # noqa: E402
+
+    import server
+
+    cid = server.create_campaign("Ghoul csmed-4")["id"]
+    pc = server.create_character(cid, "Hero", kind="player", max_hp=60)["id"]
+    gid = server.spawn_monster(cid, "Ghoul")["spawned"][0]["id"]
+    server.start_combat(cid, [pc, gid])
+    if server.get_state(cid)["current_turn"] == pc:
+        server.use_action(cid, pc, "skip")
+        server.next_turn(cid)
+    assert server.get_state(cid)["current_turn"] == gid
+
+    # Two legal Bites — each return must surface "Ghoul 1/2" then "Ghoul 2/2".
+    r1 = server.attack(cid, gid, pc, attack_bonus=4, damage_dice="1d6")
+    r2 = server.attack(cid, gid, pc, attack_bonus=4, damage_dice="1d6")
+    assert r1["attacks_allowed_this_turn"] == 2
+    # The engine surfaces the stat-block Multiattack grant explicitly (tool-sourced label).
+    assert r1["multiattack_grants"] == 2
+    assert r2["multiattack_grants"] == 2
+    lines1 = distill._audit_fields(_json.dumps(r1, default=str))
+    lines2 = distill._audit_fields(_json.dumps(r2, default=str))
+    assert any("attack-budget: Ghoul 1/2 attacks this turn (Multiattack)" in ln for ln in lines1)
+    assert any("attack-budget: Ghoul 2/2 attacks this turn (Multiattack)" in ln for ln in lines2)
+
+    # The over-budget 3rd attack raises — and its message, surfaced as a plain-string
+    # is_error tool_result, distills to an attack-rejected audit line.
+    with pytest.raises(ValueError, match="Multiattack grants 2 attack") as ei:
+        server.attack(cid, gid, pc, attack_bonus=4, damage_dice="1d6")
+    rej = distill._audit_fields(str(ei.value))
+    assert len(rej) == 1
+    assert "attack-rejected: this creature's Multiattack grants 2 attack(s) per turn" in rej[0]
+
+
+def test_pc_attack_omits_multiattack_grants(tmp_path, monkeypatch):
+    """Additive-default invariant: a PC swing (no stat-block Multiattack) must NOT carry the
+    new ``multiattack_grants`` key — the field is monster-only, so PC attack results stay
+    byte-identical to before (distill then labels any PC multi-strike as Extra Attack)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("PC no multiattack_grants")["id"]
+    pc = server.create_character(cid, "Hero", kind="player", max_hp=40)["id"]
+    gob = server.spawn_monster(cid, "Goblin")["spawned"][0]["id"]
+    server.start_combat(cid, [pc, gob])
+    if server.get_state(cid)["current_turn"] == gob:
+        server.next_turn(cid)
+    assert server.get_state(cid)["current_turn"] == pc
+    r = server.attack(cid, pc, gob, attack_bonus=4, damage_dice="1d8")
+    assert "multiattack_grants" not in r
+
+
 # --- #210 end-to-end through attack() ---
 
 


### PR DESCRIPTION
## What the Angry-DM lens deducted on

**csmed-4 (high):** *"the Ghoul conjured a two-Claw Multiattack that doesn't exist in its stat block."*

The lens double-weights `tool_fidelity` / `rules_as_written` / `mechanical_completeness`, and a CRITICAL defect is **a narrated number with no traceable tool call**. csmed-4 read as exactly that.

## Why the engine was already right — but scored wrong

The **F01-1 multiattack overcount** (parser + per-action ceiling) is already closed on `main` by **#832**:

- `_parse_multiattack_count` reduces a Multiattack desc to its **counting clause** — drops `replace`/`instead of` sentences, keeps the FIRST `", or it/the-X makes"` alternative (and crucially does **not** split bare `" or "` inside a counting clause: "two Javelin or Morningstar attacks").
- The **Ghoul** re-derives to **2 Bites** against `data/srd/srd524/CreatureAction.json` (`"The ghoul makes two Bite attacks."`) — count=2, composition=`[Bite, Bite]`; the single-action Claw is NOT in the sequence.
- `attack()` → `combat.check_action_attack` **raises** on the over-budget swing (`Multiattack grants 2 attack(s) per turn`).
- A full **344/330-block sweep** confirms **zero residual overcounts**; the existing `test_multiattack_parser.py` (13 corrected creatures + dragons/Marilith/Bugbear/Assassin controls + Werewolf 3rd-attack-rejected integration) is green.

So the ceiling is enforced and **non-bypassable** on the action-attack path. The defect was **visibility, not enforcement.**

The Angry-DM lens reads **`qa/distill.py`** output, which truncates every `tool_result` to **240 chars**. The `attack()` return is **~585 chars**, so `attacks_made_this_turn` / `attacks_allowed_this_turn` — and the rejection reason on the 3rd swing — **never reach the distilled transcript.** The scorer then reads a DM narrating attacks past a ceiling it cannot see → a CRITICAL "untraceable number."

This is the binding invariant *"surface the mechanic in the tool return so the distilled transcript shows it tool-sourced."* `_audit_fields` already does this for `repeat_saves` (#209) and `maneuver_damage` (#213); this extends it to the **attack budget**.

## The fix (additive, engine-as-told, SRD-correct)

- **`servers/engine/server.py` — `attack()`**: when the budget is a stat-block Multiattack (`ma > 0`), surface `result["multiattack_grants"] = ma`. **Absent for PCs** (`ma = 0`) → Extra Attack / Action Surge results stay byte-identical. Transient tool-return field only; never persisted → no snapshot round-trip impact (`_StrictModel extra=forbid` untouched).
- **`qa/distill.py` — `_audit_fields()`**: emit `↳ attack-budget: <actor> M/N attacks this turn (Multiattack|Extra Attack)` when `allowed > 1` (single-attack swings stay **silent** — no noise for the 95% case), and `↳ attack-rejected: ...Multiattack grants N attack(s)...` when a ceiling `ValueError` reaches the transcript (handles a **plain exception string** OR an `{"error": ...}` envelope). The `(Multiattack)` label is authoritative — only when `multiattack_grants` is present; a PC's Extra Attack is never miscredited.

### Distilled output, after

```
  - `→ attack({"attacker_id": "ghoul"})`
    `← {"attacker": "Ghoul", ... "attacks_made_this_turn": 1, "attacks_allowed_this_turn": 2 ...}`
    `↳ attack-budget: Ghoul 1/2 attacks this turn (Multiattack)`
  - `→ attack({"attacker_id": "ghoul"})`
    `← Ghoul cannot attack: this creature's Multiattack grants 2 attack(s) per turn; 2 already made this turn.`
    `↳ attack-rejected: this creature's Multiattack grants 2 attack(s) per turn; 2 already made this turn`
```

The lens now reads the ceiling **tool-sourced** and can refute "a Multiattack that doesn't exist" directly.

## SRD basis

SRD 5.2 (2024) Ghoul, `data/srd/srd524`: **Multiattack = "The ghoul makes two Bite attacks."** Bite and Claw are separate actions; the Claw is single-action with the paralysis rider. Re-derived against the raw data, not invented.

## Tests

- `qa/test_distill.py` **+5**: `test_audit_fields_surfaces_multiattack_budget`, `test_audit_fields_labels_pc_extra_attack_budget_not_multiattack`, `test_audit_fields_suppresses_single_attack_budget`, `test_audit_fields_surfaces_rejected_multiattack_overflow_plain_string`, `test_audit_fields_surfaces_rejected_multiattack_overflow_json_error`.
- `servers/engine/tests/test_combat.py` **+2** (end-to-end through the real engine): `test_ghoul_multiattack_budget_and_rejection_survive_distill` (Ghoul 1/2 → 2/2 budget surfaces; 3rd-attack rejection distills), `test_pc_attack_omits_multiattack_grants` (additive-default guard).
- **Red-first verified** (budget + rejection tests failed before the fix).
- Engine suite **2683 passed**; `bash qa/fast_gate.sh` **PASS** (Tier-0, 197 passed).

**Invariants:** additive-by-default (new transient result field, PC path byte-identical); engine = sole writer (no new write path); SRD-correct (re-derived against `data/srd/srd524`); wire contract additive only.

Source: mech-climb evidence agent (combat-sprint scorecards), csmed-4 high; audit `docs/audits/ENGINE-AUDIT-2026-06-11.md` F1-1.

**DO NOT MERGE** pending review.