### PR TITLE
fix(combat): crit doubles the BM superiority die + atomic maneuver on attack (#213/A,B)

### DIFF
--- a/qa/distill.py
+++ b/qa/distill.py
@@ -49,9 +49,17 @@ def _audit_fields(res) -> list[str]:
         )
     md = data.get("maneuver_damage")
     if isinstance(md, dict):
+        # On a CRIT the superiority die doubles (SRD Critical Hits, #213/A): show that the
+        # doubling WAS applied (rolled is the doubled total) so the Angry-DM lens reads the
+        # crit-doubled die as tool-sourced, not a hallucinated number.
+        crit_tag = ""
+        if md.get("crit_doubled"):
+            crit_tag = (
+                f" CRIT×2 ({md.get('base_rolled', '?')}+{md.get('crit_extra', '?')})"
+            )
         out.append(
             f"    `↳ maneuver-damage: {md.get('maneuver', '?')} {md.get('die', '?')}="
-            f"{md.get('rolled', '?')} applied={md.get('applied', md.get('applies_to', '?'))}`"
+            f"{md.get('rolled', '?')}{crit_tag} applied={md.get('applied', md.get('applies_to', '?'))}`"
         )
     # #792 auto-concentration: attack/apply_damage auto-roll the CON save when a
     # concentrating creature takes damage. The result sits AFTER target_state in the JSON,

--- a/qa/test_distill.py
+++ b/qa/test_distill.py
@@ -54,6 +54,19 @@ def test_audit_fields_surfaces_maneuver_damage():
     assert "maneuver-damage: Trip Attack 1d8=6 applied=True" in lines[0]
 
 
+def test_audit_fields_surfaces_crit_doubled_maneuver_damage():
+    # On a crit the superiority die DOUBLES (#213/A) — the distill must show the doubling
+    # was applied (CRIT×2 + the base/extra split) so the Angry-DM lens reads it tool-sourced.
+    res = json.dumps(
+        {"ok": True, "maneuver_damage": {"maneuver": "Trip Attack", "die": "1d8",
+                                         "rolled": 12, "applied": True, "crit_doubled": True,
+                                         "base_rolled": 6, "crit_extra": 6}}
+    )
+    lines = distill._audit_fields(res)
+    assert len(lines) == 1
+    assert "maneuver-damage: Trip Attack 1d8=12 CRIT×2 (6+6) applied=True" in lines[0]
+
+
 def test_audit_fields_surfaces_concentration_save():
     # The #792 auto-concentration roll sits after target_state in the result JSON, so the
     # 240-char preview truncates it and the Angry-DM lens mis-scores a tool-sourced save as a

--- a/servers/engine/combat.py
+++ b/servers/engine/combat.py
@@ -92,6 +92,19 @@ def double_dice(expr: str) -> str:
     return _DICE.sub(lambda m: f"{(int(m.group(1) or 1)) * 2}d{m.group(2)}", expr)
 
 
+def crit_extra_dice(expr: str) -> str:
+    """The expression for the EXTRA dice a crit adds on top of an ALREADY-ROLLED value
+    (the Battle Master superiority-die case, #213/A). SRD Critical Hits: the maneuver's
+    superiority die is "other damage dice" and doubles on a crit — but the die was already
+    rolled once when the maneuver was declared, so a crit needs only ONE MORE copy of the
+    dice (flat modifiers never double). '1d8' -> '1d8'; '2d6' -> '2d6'; '1d8+3' -> '1d8';
+    a flat-only or empty expression has no dice to repeat -> '' (nothing to roll). Pure."""
+    dice_only = [
+        f"{int(c or 1)}d{s}" for c, s in _DICE.findall(expr or "")
+    ]
+    return "+".join(dice_only)
+
+
 def attack_modifiers(attacker: Character, target: Character, is_ranged: bool = False) -> tuple[bool, bool]:
     """(advantage, disadvantage) implied by the combatants' conditions AND any
     advantage-granting active_effect on the TARGET (Guiding Bolt's "next attack against it

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4574,6 +4574,9 @@ def attack(
     is_ranged: bool = False,
     is_reaction: bool = False,
     damage_rolls: list[dict] | None = None,
+    maneuver: str = "",
+    maneuver_resource: str = "superiority_dice",
+    maneuver_damage_type: str = "",
     character_id: str = "",
     npc_id: str = "",
     id: str = "",
@@ -4583,7 +4586,18 @@ def attack(
     natural 20 and auto-misses on a natural 1, doubles damage dice on a crit, and
     applies the damage. Condition-based advantage/disadvantage is detected (set
     is_ranged=True so a prone target gives disadvantage rather than advantage) and
-    combined with the explicit flags (they cancel if both apply)."""
+    combined with the explicit flags (they cancel if both apply).
+
+    Battle Master DAMAGE maneuvers (#213/B): pass ``maneuver`` (e.g. 'Trip Attack')
+    to declare a maneuver ATOMICALLY on this strike — the engine rolls + spends ONE
+    superiority die ONLY when the attack HITS (SRD: the die is spent "when you hit"),
+    folds it into the damage, and DOUBLES it on a crit (SRD Critical Hits: the
+    superiority die is "other damage dice"). A MISS spends nothing. ``maneuver_resource``
+    is the die pool to spend from (default 'superiority_dice'); ``maneuver_damage_type``
+    overrides the bonus's type (default: the weapon's). Empty ``maneuver`` == today's
+    behavior. (The older two-step path — use_resource(superiority_dice, maneuver=…) then
+    attack — still works and now also crit-doubles; declaring via attack() is preferred
+    because a miss no longer burns the die.)"""
     # Coalesce intuitive arg-name aliases to the canonical ids. The ATTACKER is the acting
     # character (alias `character_id`); the TARGET is the thing struck (aliases `npc_id`/`id`).
     # Canonical names win. (target_id ⇄ character_id is intentionally NOT done — `character_id`
@@ -4670,6 +4684,29 @@ def attack(
         man_bonus = attacker.pending_damage_bonus
         if man_bonus is not None:
             attacker.pending_damage_bonus = None
+        # ATOMIC maneuver (#213/B): a maneuver declared ON this attack rolls + spends its
+        # superiority die ONLY when the strike HITS (SRD: spent "when you hit"). Validate the
+        # pool NOW (before the roll) so a bad pool surfaces cleanly without burning state, but
+        # defer the spend/roll until after hit/crit is known. A refused maneuver does NOT void
+        # the attack — the strike still lands; only the bonus is dropped (with maneuver_error).
+        # Empty ``maneuver`` == today's behavior; the two paths are mutually exclusive (a
+        # declared-here maneuver wins over any pending bonus, which would be a double-declare).
+        man_decl = maneuver.strip()
+        man_decl_error = None
+        man_res = None
+        if man_decl:
+            man_res = attacker.class_resources.get(maneuver_resource)
+            if man_res is None:
+                man_decl_error = f"{attacker.name} has no {maneuver_resource!r} pool"
+            elif man_res.max - man_res.used < 1:
+                man_decl_error = f"no {maneuver_resource} left to spend on {man_decl}"
+            elif not man_res.size.strip():
+                man_decl_error = (
+                    f"{maneuver_resource!r} is a point pool (no die) — a damage maneuver "
+                    f"needs a die pool like Superiority Dice"
+                )
+            if man_decl_error is not None:
+                man_decl = ""  # refused: fall through as a plain attack, surface the error below
         cadv, cdis = combat.attack_modifiers(attacker, target, is_ranged=is_ranged)
         adv = advantage or cadv
         dis = disadvantage or cdis
@@ -4768,16 +4805,44 @@ def attack(
         # clears it but is Character-pure and can't free the victim) — see the release after.
         was_conc_target = target.concentration
         if hit:
-            # A pending DAMAGE-maneuver bonus (#213) folds the already-rolled superiority die
-            # into THIS strike as one extra typed component. The die is NOT re-rolled and NOT
-            # crit-doubled (5e: only weapon dice double; the maneuver die is added once),
-            # which is exactly what apply_damage_components does — it takes pre-rolled amounts.
-            # Defaults to the weapon's damage_type when the maneuver didn't specify one, so the
-            # bonus shares the strike's resistance treatment unless typed otherwise.
+            # ATOMIC maneuver (#213/B): the strike HIT, so NOW spend one superiority die and
+            # roll it (SRD: the die is spent "when you hit"). Synthesize the same
+            # PendingDamageBonus shape the two-step path produces so the fold/surface code
+            # below is shared. Validated above; man_res/maneuver_resource are live here.
+            if man_decl and man_res is not None:
+                man_res.used += 1
+                die_expr = f"1{man_res.size.strip()}"
+                man_roll = dice_mod.roll(die_expr)
+                man_bonus = PendingDamageBonus(
+                    amount=max(0, man_roll.total),
+                    source=man_decl,
+                    resource=maneuver_resource,
+                    expr=die_expr,
+                    detail=man_roll.detail,
+                    damage_type=maneuver_damage_type.strip(),
+                )
+            # CRIT doubles the superiority die (#213/A). SRD Critical Hits: the maneuver die is
+            # "other damage dice" and doubles on a crit. The die was already rolled once (at
+            # spend time, whichever path), so a crit rolls ONE MORE copy of the dice (flat mods
+            # never double) and adds it. man_extra_detail is surfaced so the DM sees the bump.
+            man_crit_doubled = False
+            man_extra = 0
+            man_extra_detail = ""
+            if man_bonus is not None and is_crit:
+                extra_expr = combat.crit_extra_dice(man_bonus.expr)
+                if extra_expr:
+                    man_extra_roll = dice_mod.roll(extra_expr)
+                    man_extra = max(0, man_extra_roll.total)
+                    man_extra_detail = man_extra_roll.detail
+                    man_crit_doubled = True
+            # The total maneuver damage folded into THIS strike: the spend-time die plus any
+            # crit-extra. None == no maneuver. Defaults to the weapon's damage_type so the
+            # bonus shares the strike's resistance treatment unless the maneuver typed it.
+            man_total = (man_bonus.amount + man_extra) if man_bonus is not None else 0
             man_part = None
-            if man_bonus is not None and man_bonus.amount > 0:
+            if man_bonus is not None and man_total > 0:
                 man_part = {
-                    "amount": man_bonus.amount,
+                    "amount": man_total,
                     "type": man_bonus.damage_type or damage_type,
                 }
             if damage_rolls or man_part is not None:
@@ -4806,13 +4871,16 @@ def attack(
                     )
                     parts_for_apply.append({"amount": ctotal, "type": ct})
                 if man_part is not None:
-                    # The maneuver die is a flat pre-rolled add (no expr to re-roll/double).
+                    # The maneuver die was pre-rolled (spend time) and, on a crit, doubled by
+                    # rolling one more die above — so it's a flat add here (the total, already
+                    # crit-aware). apply_damage_components takes pre-rolled amounts as-is.
                     comp_results.append({
                         "type": man_part["type"],
-                        "total": man_bonus.amount,
+                        "total": man_total,
                         "expr": man_bonus.expr,
                         "detail": man_bonus.detail,
                         "maneuver": man_bonus.source,
+                        "crit_doubled": man_crit_doubled,
                     })
                     parts_for_apply.append(man_part)
                 outcome = combat.apply_damage_components(
@@ -4841,14 +4909,22 @@ def attack(
                 result["damage"] = {"total": max(0, dmg.total), "type": damage_type, "expr": expr, "detail": dmg.detail}
             if man_bonus is not None:
                 # Surface the maneuver's contribution explicitly so the DM/log sees the die
-                # that landed (and that it WAS applied), distinct from the weapon dice.
-                result["maneuver_damage"] = {
+                # that landed (and that it WAS applied), distinct from the weapon dice. On a
+                # crit, ``rolled`` is the DOUBLED total (spend-time die + crit-extra) and
+                # crit_doubled flags it so the distilled transcript shows the doubling (#213/A).
+                md = {
                     "maneuver": man_bonus.source,
                     "die": man_bonus.expr,
-                    "rolled": man_bonus.amount,
+                    "rolled": man_total,
                     "detail": man_bonus.detail,
-                    "applied": man_bonus.amount > 0,
+                    "applied": man_total > 0,
+                    "crit_doubled": man_crit_doubled,
                 }
+                if man_crit_doubled:
+                    md["base_rolled"] = man_bonus.amount
+                    md["crit_extra"] = man_extra
+                    md["crit_extra_detail"] = man_extra_detail
+                result["maneuver_damage"] = md
             result["target_state"] = outcome
             # F3-6: if this strike downed/killed a concentrating caster, free its held targets
             # NOW (Hold Person paralysis, an allied Bless child) — the combat layer cleared the
@@ -4872,6 +4948,24 @@ def attack(
                 "applied": False,
                 "note": "attack missed — superiority die spent but no damage added",
             }
+        elif man_decl:
+            # ATOMIC maneuver (#213/B) on a MISS: NO die was spent (the spend happens only
+            # inside the hit branch). Surface that the maneuver was declared but cost nothing —
+            # the whole point of moving the spend onto the attack ("spent only when you hit").
+            result["maneuver_damage"] = {
+                "maneuver": man_decl,
+                "applied": False,
+                "spent": False,
+                "note": (
+                    "attack missed — maneuver declared but NO superiority die was spent "
+                    "(the die is spent only on a hit)"
+                ),
+            }
+        # If the declared maneuver was REFUSED (bad/point pool), surface why — the strike still
+        # resolved as a plain attack (no die spent, no bonus folded). Additive: only present on
+        # an invalid maneuver= declaration.
+        if man_decl_error is not None:
+            result["maneuver_error"] = man_decl_error
         # ON-HIT RIDER RESOLUTION (#186). An attack-roll spell (Guiding Bolt) recorded a
         # PENDING rider on the caster at cast_spell time instead of writing its timed effect
         # to the target. This attack resolves that spell attack when it's the caster striking

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -51,6 +51,24 @@ def test_double_dice(expr, expected):
     assert combat.double_dice(expr) == expected
 
 
+# --- crit-extra dice (the ADDITIONAL dice a crit adds to an already-rolled add, #213/A) ---
+@pytest.mark.parametrize(
+    "expr,expected",
+    [
+        ("1d8", "1d8"),       # superiority die: a crit rolls one more 1d8
+        ("2d6", "2d6"),       # a 2-die maneuver pool: a crit rolls 2 more d6
+        ("1d8+3", "1d8"),     # flat mods never double — only the dice repeat
+        ("1d10-1", "1d10"),
+        ("5", ""),            # no dice -> nothing to double on a crit
+        ("", ""),
+    ],
+)
+def test_crit_extra_dice(expr, expected):
+    """The expression for the EXTRA dice a crit adds on top of an already-rolled value:
+    only the dice repeat (flat modifiers never double), so 1d8 -> 1d8, 1d8+3 -> 1d8."""
+    assert combat.crit_extra_dice(expr) == expected
+
+
 # --- damage resolution order ---
 def test_temp_hp_absorbs_first():
     ch = mk(max_hp=20, current_hp=20, temp_hp=5)
@@ -2253,3 +2271,260 @@ def test_end_combat_resolution_records_disposition_for_living_hostiles(tmp_path,
     # start_combat clears the prior disposition so a later clean kill never inherits it
     server.start_combat(cid, [pid, mid])
     assert store.load_campaign(cid).last_combat_resolution == ""
+
+
+# =========================================================================
+# (A) CRIT doubles the Battle Master superiority die (#213/A).
+# SRD Critical Hits: the maneuver's superiority die is "other damage dice" and
+# MUST double on a crit. The legacy path pre-rolls the die at use_resource time;
+# on a crit the engine rolls the SAME die again and folds the extra in.
+# (B) ATOMIC maneuver on attack(): attack(maneuver=…) rolls+consumes the die only
+# on a HIT — a MISS spends nothing; a HIT folds it (doubling on a crit).
+# =========================================================================
+
+
+def _bm_roller(*, d20: int, crit: bool, fixed: dict[str, int]):
+    """A deterministic dice_mod.roll for Battle-Master tests that records every NON-d20
+    expression it rolled (so a test can assert the crit-extra superiority die was rolled).
+    d20 -> a hit/miss/crit-controlled d20 roll; any other expr -> fixed.get(stripped, 0)."""
+    from dice import DiceRoll
+
+    seen: list[str] = []
+
+    def _roll(expr, advantage=False, disadvantage=False, seed=None):
+        e = expr.replace(" ", "").lower()
+        if e.startswith("1d20"):
+            nat = 20 if crit else max(1, min(19, d20 - 5))
+            return DiceRoll(
+                expression=expr, total=d20, rolls=[nat], modifier=5,
+                detail=f"{expr}={d20}", is_d20=True, natural=nat, crit=crit,
+            )
+        seen.append(e)
+        total = fixed.get(e, 0)
+        return DiceRoll(expression=expr, total=total, rolls=[total], detail=f"{expr}[{total}]={total}")
+
+    return _roll, seen
+
+
+def _bm_fight(server, monkeypatch, tmp_path):
+    """A Hero(with a 1d8 superiority pool)-vs-Goblin fight with the Hero current."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("BM crit")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=20, armor_class=12)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=80, armor_class=10)["id"]
+    server.set_class_resource(cid, hero, "superiority_dice", max=6, recharge="short", size="d8")
+    server.start_combat(cid, [hero, gob])
+    if server.get_state(cid)["current_turn"] != hero:
+        server.next_turn(cid)
+    assert server.get_state(cid)["current_turn"] == hero
+    return cid, hero, gob
+
+
+# ---- (A) legacy use_resource path: crit doubles the pre-rolled superiority die ----
+def test_crit_doubles_legacy_maneuver_die(tmp_path, monkeypatch):
+    """RED for (A): on a CRIT, a Trip Attack's superiority die must DOUBLE. The die is
+    pre-rolled (1d8 -> 6) at use_resource; on a crit the engine rolls one more 1d8 (-> 6)
+    so the maneuver contributes 12 (6 + 6), not 6. Weapon 1d6+3 -> 7 doubles to 2d6+3 -> 8."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    # use_resource rolls 1d8 -> 6; the attack's crit-extra 1d8 -> 6 (same stub); weapon 2d6+3 -> 8.
+    roll, seen = _bm_roller(d20=30, crit=True, fixed={"1d8": 6, "2d6+3": 8})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    server.use_resource(cid, hero, "superiority_dice", maneuver="Trip Attack")
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+    assert res["crit"] is True and res["hit"] is True
+    # The crit-extra superiority die WAS rolled (a second 1d8 beyond the spend-time roll).
+    assert seen.count("1d8") == 2, f"crit must re-roll the superiority die; rolled exprs: {seen}"
+    md = res["maneuver_damage"]
+    assert md["rolled"] == 12, f"6 (spend) + 6 (crit-extra) = 12; got {md}"
+    assert md.get("crit_doubled") is True and md.get("base_rolled") == 6 and md.get("crit_extra") == 6
+    # weapon (8, crit-doubled) + maneuver (12) folded into ONE strike = 20.
+    assert res["damage"]["total"] == 20
+    assert server.get_character(cid, gob)["current_hp"] == 80 - 20
+
+
+def test_non_crit_legacy_maneuver_die_not_doubled(tmp_path, monkeypatch):
+    """A normal HIT (no crit) folds the pre-rolled die ONCE — the crit-extra path is inert
+    (regression guard so (A) only fires on a crit)."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    roll, seen = _bm_roller(d20=18, crit=False, fixed={"1d8": 6, "1d6+3": 7})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    server.use_resource(cid, hero, "superiority_dice", maneuver="Trip Attack")
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+    assert res["crit"] is False and res["hit"] is True
+    assert seen.count("1d8") == 1  # only the spend-time roll, no crit-extra
+    assert res["maneuver_damage"]["rolled"] == 6
+    assert res["maneuver_damage"].get("crit_doubled") in (False, None)
+    assert res["damage"]["total"] == 13  # weapon 7 + die 6
+
+
+# ---- (B) atomic attack(maneuver=…): roll+consume only on a hit ----
+def test_attack_maneuver_on_miss_consumes_no_die(tmp_path, monkeypatch):
+    """RED for (B): attack(maneuver='Trip Attack') on a MISS must spend NO superiority die
+    (the die is spent only 'when you hit'). The pool stays full and no damage lands."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    server.update_character(cid, gob, {"armor_class": 30})  # force a miss
+    roll, _ = _bm_roller(d20=6, crit=False, fixed={"1d8": 6, "1d6+3": 7})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    res = server.attack(cid, hero, gob, attack_bonus=0, damage_dice="1d6+3",
+                        damage_type="slashing", maneuver="Trip Attack")
+    assert res["hit"] is False
+    # NO die spent on a miss (the whole point of the atomic path).
+    assert server.get_character(cid, hero)["class_resources"]["superiority_dice"]["used"] == 0
+    assert server.get_character(cid, gob)["current_hp"] == 80
+    assert res.get("maneuver_damage", {}).get("applied") in (False, None)
+    assert server.get_character(cid, hero)["pending_damage_bonus"] is None
+
+
+def test_attack_maneuver_on_hit_consumes_one_and_folds_damage(tmp_path, monkeypatch):
+    """attack(maneuver='Trip Attack') on a HIT spends exactly ONE die and folds the rolled
+    superiority die into THIS strike's damage (weapon 7 + die 6 = 13)."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    roll, _ = _bm_roller(d20=18, crit=False, fixed={"1d8": 6, "1d6+3": 7})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3",
+                        damage_type="slashing", maneuver="Trip Attack")
+    assert res["hit"] is True and res["crit"] is False
+    assert server.get_character(cid, hero)["class_resources"]["superiority_dice"]["used"] == 1
+    assert res["maneuver_damage"]["maneuver"] == "Trip Attack"
+    assert res["maneuver_damage"]["rolled"] == 6 and res["maneuver_damage"]["applied"] is True
+    assert res["damage"]["total"] == 13
+    assert server.get_character(cid, gob)["current_hp"] == 80 - 13
+    # No lingering pending bonus (the atomic path consumes it in-line).
+    assert server.get_character(cid, hero)["pending_damage_bonus"] is None
+
+
+def test_attack_maneuver_on_crit_doubles_the_die(tmp_path, monkeypatch):
+    """attack(maneuver='Trip Attack') on a CRIT spends one die and DOUBLES it (6 + 6 = 12),
+    composing (A)+(B): the atomic path rolls the crit-extra superiority die too."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    roll, seen = _bm_roller(d20=30, crit=True, fixed={"1d8": 6, "2d6+3": 8})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3",
+                        damage_type="slashing", maneuver="Trip Attack")
+    assert res["crit"] is True and res["hit"] is True
+    assert server.get_character(cid, hero)["class_resources"]["superiority_dice"]["used"] == 1
+    assert seen.count("1d8") == 2  # spend roll + crit-extra
+    assert res["maneuver_damage"]["rolled"] == 12
+    assert res["maneuver_damage"].get("crit_doubled") is True
+    assert res["damage"]["total"] == 20  # weapon 8 (2d6+3) + maneuver 12
+
+
+def test_attack_maneuver_refused_on_point_pool_no_spend(tmp_path, monkeypatch):
+    """attack(maneuver=…) against a non-existent or point pool is refused cleanly with no
+    spend and no damage applied — the atomic path validates the pool like use_resource does."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    server.set_class_resource(cid, hero, "ki", max=5, recharge="short")  # point pool, no size
+    roll, _ = _bm_roller(d20=18, crit=False, fixed={"1d6+3": 7})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3",
+                        damage_type="slashing", maneuver="Trip Attack", maneuver_resource="ki")
+    # The strike still lands (a refused maneuver doesn't void the attack), but NO die spent
+    # and the refusal is surfaced.
+    assert res["hit"] is True
+    assert res["damage"]["total"] == 7  # weapon only, no maneuver folded
+    assert server.get_character(cid, hero)["class_resources"]["ki"]["used"] == 0
+    assert "maneuver_error" in res
+
+
+def test_attack_maneuver_additive_normal_attack_unchanged(tmp_path, monkeypatch):
+    """ADDITIVE: an attack with NO maneuver= is byte-identical to today (no die, no
+    maneuver_damage, no pool touched)."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    roll, _ = _bm_roller(d20=18, crit=False, fixed={"1d6+3": 7})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+    assert res["hit"] is True and res["damage"]["total"] == 7
+    assert "maneuver_damage" not in res
+    assert server.get_character(cid, hero)["class_resources"]["superiority_dice"]["used"] == 0
+
+
+def test_attack_maneuver_no_pool_refused_no_void(tmp_path, monkeypatch):
+    """attack(maneuver=…) when the attacker has NO such pool at all: refused cleanly (the
+    strike still lands, no spend) with maneuver_error surfaced — the atomic-path equivalent
+    of use_resource's 'no pool' signal."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    roll, _ = _bm_roller(d20=18, crit=False, fixed={"1d6+3": 7})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3",
+                        damage_type="slashing", maneuver="Trip Attack",
+                        maneuver_resource="energy_dice")  # no such pool
+    assert res["hit"] is True and res["damage"]["total"] == 7
+    assert "maneuver_error" in res and "energy_dice" in res["maneuver_error"]
+    assert "maneuver_damage" not in res
+
+
+def test_attack_maneuver_exhausted_pool_refused(tmp_path, monkeypatch):
+    """attack(maneuver=…) with the pool fully spent is refused (no negative spend), strike
+    still lands."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    server.update_character(cid, hero, {"class_resources": {"superiority_dice": {
+        "max": 6, "used": 6, "recharge": "short", "size": "d8"}}})
+    roll, _ = _bm_roller(d20=18, crit=False, fixed={"1d6+3": 7})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3",
+                        damage_type="slashing", maneuver="Trip Attack")
+    assert res["hit"] is True and res["damage"]["total"] == 7
+    assert "maneuver_error" in res
+    assert server.get_character(cid, hero)["class_resources"]["superiority_dice"]["used"] == 6
+
+
+def test_attack_maneuver_typed_damage_respects_resistance_on_crit(tmp_path, monkeypatch):
+    """An atomic maneuver with an explicit (resisted) damage type halves ONLY the maneuver
+    component, AND the crit-doubling is applied before resistance. weapon 1d6+3 -> 7 slashing
+    (full), maneuver fire die 6 doubled to 12, halved by resistance -> 6; HP -13."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    server.update_character(cid, gob, {"damage_resistances": ["fire"]})
+    roll, seen = _bm_roller(d20=30, crit=True, fixed={"1d8": 6, "2d6+3": 7})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3",
+                        damage_type="slashing", maneuver="Trip Attack", maneuver_damage_type="fire")
+    assert res["crit"] is True and res["hit"] is True
+    assert res["maneuver_damage"]["rolled"] == 12 and res["maneuver_damage"]["crit_doubled"] is True
+    # weapon 7 (slashing, full) + maneuver 12 fire -> halved to 6 = 13 to HP.
+    assert server.get_character(cid, gob)["current_hp"] == 80 - 13
+
+
+def test_attack_maneuver_atomic_takes_precedence_over_pending(tmp_path, monkeypatch):
+    """If a player BOTH pre-declares via use_resource AND passes maneuver= on the attack
+    (a double-declare), the atomic path wins deterministically — exactly one die's worth of
+    bonus is folded (not two), and no stale pending bonus lingers."""
+    import server
+    cid, hero, gob = _bm_fight(server, monkeypatch, tmp_path)
+    roll, _ = _bm_roller(d20=18, crit=False, fixed={"1d8": 6, "1d6+3": 7})
+    monkeypatch.setattr(server.dice_mod, "roll", roll)
+    server.use_resource(cid, hero, "superiority_dice", maneuver="Trip Attack")  # pending (1 die)
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3",
+                        damage_type="slashing", maneuver="Menacing Attack")  # atomic (1 die)
+    assert res["hit"] is True
+    # Exactly ONE die folded (the atomic one) — not both. weapon 7 + die 6 = 13.
+    assert res["damage"]["total"] == 13
+    assert res["maneuver_damage"]["maneuver"] == "Menacing Attack"
+    assert server.get_character(cid, hero)["pending_damage_bonus"] is None
+
+
+def test_attack_param_additive_old_snapshot_round_trips(tmp_path, monkeypatch):
+    """ADDITIVE invariant: the new attack() params add NO model field. A character snapshot
+    written without any maneuver state round-trips byte-identically (no pending_damage_bonus,
+    no new keys), and the attack signature defaults preserve today's behavior."""
+    import server
+    from models import Character
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("RT")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=20)["id"]
+    # The persisted snapshot (the strict model) carries no maneuver state by default.
+    stored = store.load_campaign(cid).characters[hero]
+    snap = stored.model_dump(mode="json")
+    again = Character.model_validate(snap).model_dump(mode="json")
+    assert again == snap  # byte-identical round-trip
+    assert again["pending_damage_bonus"] is None
+    assert again["pending_on_hit_riders"] == []


### PR DESCRIPTION
## What this fixes

The **combat-resolution trio** targeting the specific mechanical deductions the Angry-DM lens made across the combat-sprints (honest mech median 3.8; the gate needs ≥4.5). The lens double-weights tool_fidelity / rules_as_written / mechanical_completeness and hunts OMISSIONS (a due rule never invoked) hardest.

**Source: mech-climb evidence agent (combat-sprint scorecards).**

### (A) CRIT doubles the Battle Master superiority die — `#213/A` (HIGH, confirmed)
**Scorer reason (csmed-1):** *"the superiority die is 'other damage dice' and must also be doubled on a crit."*
**SRD rule (Critical Hits):** *"roll all of the attack's damage dice twice"* — the maneuver's superiority die is damage dice, so it doubles. Previously the maneuver die was a flat pre-rolled add that was never doubled on a crit (`server.py` old ~4808-4816 comment literally said *"not crit-doubled"*).
**Fix:** new pure helper `combat.crit_extra_dice(expr)` returns the dice-only portion (flat mods never double). The die was already rolled once at declare time, so on a crit the engine rolls **one more copy** of the dice and folds it in. Applies to **both** the legacy `use_resource(maneuver=…)` path and the new atomic path.

### (B) Atomic Battle Master maneuver on `attack()` — `#213/B` (HIGH frequency — docked 3 of 5 sprints)
**Problem:** `use_resource(superiority_dice, maneuver=…)` was called BEFORE the attack resolved, so declaring Trip/Menacing then MISSING still burned the die and the DM narrated the die "reattaching."
**SRD rule:** the superiority die is expended only *"when you hit a creature with a weapon attack."*
**Fix (engine-enforced, the robust path the scorers suggested):** additive `maneuver=`, `maneuver_resource=` (default `superiority_dice`), `maneuver_damage_type=` params on `attack()`. The die is rolled + consumed **atomically only on a HIT**, folds its damage, and doubles on a crit per (A). A **MISS spends nothing**. The old `use_resource` two-step path still works (additive). The maneuver outcome is surfaced in the attack return and the distill (`crit_doubled` → `CRIT×2 (base+extra)` line) so the lens reads it tool-sourced.

### (C) Guiding Bolt rider — `#194/#186` (MEDIUM-HIGH — VERIFIED, **SKIPPED, no fabricated fix**)
**Scorer reason (csmed-5):** *"cast_spell('Guiding Bolt') … neither follow-up shows advantage:true."*
**Verification:** the Guiding Bolt spell-attack's to-hit **IS a call to `attack()`** (cast_spell returns `spell_attack_bonus` and tells the DM to resolve via `attack(attack_bonus=spell_attack_bonus)`). That `attack()` call materializes the pending on-hit rider on a HIT with `grants_advantage=True`; the next attacker auto-gets advantage via `combat.attack_modifiers` and surfaces `advantage_consumed`. This is **already proven** by the existing full-cycle test `test_guiding_bolt_marker_auto_grants_advantage_to_next_attack_and_is_consumed` (test_effect_durations.py): cast → spell-attack hit → marker written → follow-up attacker `advantage:true` + `advantage_consumed:true`. The csmed-5 finding was a **play-time artifact** (the DM never actually called `attack()` for the bolt's to-hit), not an engine defect. The rider duration is 1 round and only ticks after materializing on hit, so it cannot expire prematurely. **No fix fabricated.**

## Invariants honored
- **Additive:** no new model field — the atomic path synthesizes a transient `PendingDamageBonus`; the new `attack()` params default to today's behavior. Old snapshots round-trip (test asserts byte-identical round-trip).
- **Engine rolls, DM is told:** the maneuver die + crit-extra are rolled in-engine and surfaced in the tool return + distill.
- **SRD 5.2 correct:** re-derived against Critical Hits + Battle Master maneuver rules.
- **Engine = sole writer:** the atomic spend mutates the live campaign object persisted by the existing `save_campaign(c)`.

## Tests
**`servers/engine/tests/test_combat.py`** (18 new):
- `test_crit_extra_dice` (6 parametrized cases) — the pure helper
- `test_crit_doubles_legacy_maneuver_die`, `test_non_crit_legacy_maneuver_die_not_doubled` — (A) legacy path
- `test_attack_maneuver_on_miss_consumes_no_die`, `test_attack_maneuver_on_hit_consumes_one_and_folds_damage`, `test_attack_maneuver_on_crit_doubles_the_die` — (B) atomic miss/hit/crit
- `test_attack_maneuver_refused_on_point_pool_no_spend`, `test_attack_maneuver_no_pool_refused_no_void`, `test_attack_maneuver_exhausted_pool_refused` — refusal without voiding the attack
- `test_attack_maneuver_typed_damage_respects_resistance_on_crit` — typed+resisted crit
- `test_attack_maneuver_atomic_takes_precedence_over_pending` — double-declare precedence
- `test_attack_maneuver_additive_normal_attack_unchanged`, `test_attack_param_additive_old_snapshot_round_trips` — additive + round-trip

**`qa/test_distill.py`** (1 new): `test_audit_fields_surfaces_crit_doubled_maneuver_damage`

## Test counts / gate
- New tests: **18** (test_combat.py) + **1** (test_distill.py) = 19; all green
- Full engine suite: **2690 passed** (single-process, `-p no:xdist`)
- `qa/test_distill.py`: 7 passed; `qa/test_assert_behavioral.py`: 30 passed
- **Tier-0 fast gate: PASS** (`bash qa/fast_gate.sh` — 213 deterministic engine tier)
- `scripts/license_check.py`: PASS

DO NOT MERGE — for review.