### PR TITLE
feat(viewer+engine): browsable full class spell list for prepared casters (#754)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -2552,7 +2552,38 @@ def get_character(campaign_id: str, character_id: str = "", target_id: str = "",
     sheet = ch.model_dump(mode="json")
     sheet["class_resources_view"] = _class_resources_view(ch)
     sheet["combat_numbers"] = _combat_numbers(ch)
+    sheet["preparable_spells"] = _preparable_spells(ch)
     return sheet
+
+
+def _highest_slot_level(ch: Character) -> int:
+    """The highest spell-slot level the character actually has a slot for (0 == no leveled
+    slots). Caps the browsable preparable pool so a half-caster (a L10 Paladin -> L3 slots)
+    sees only spells it can slot. Reads engine-owned spell_slots; pure."""
+    return max((int(lvl) for lvl, s in ch.spell_slots.items() if s.maximum > 0), default=0)
+
+
+def _preparable_spells(ch: Character) -> list[dict]:
+    """The full SRD class spell list a PREPARED caster can browse to choose what to prepare
+    (#754) — each ``{name, level}``, capped to the caster's highest available slot level. The
+    persona complaint: a Paladin's Spellbook showed only the FEW currently-prepared spells, not
+    the dozens-strong list to plan FROM. Derived from the engine's own srd524 class↔spell map
+    (spells.class_spell_list) so it is SRD-correct + additive — a non-caster (no caster class /
+    no slots) returns [] and nothing else on the sheet changes.
+
+    Half-casters (Paladin/Ranger) and full prepared casters (Cleric/Druid/Wizard) all benefit;
+    a class the SRD map doesn't know yields []. The pool merges every caster class the character
+    has (multiclass), de-duped by name, sorted by (level, name)."""
+    max_lvl = _highest_slot_level(ch)
+    if max_lvl <= 0:
+        return []
+    merged: dict[str, dict] = {}
+    for cl in ch.classes:
+        if not srd_tables.casting_ability(cl.name):
+            continue  # only real caster classes contribute a preparable pool
+        for entry in spells.class_spell_list(cl.name, max_level=max_lvl):
+            merged.setdefault(entry["name"].lower(), entry)
+    return sorted(merged.values(), key=lambda s: (s["level"], s["name"]))
 
 
 @mcp.tool()

--- a/servers/engine/spells.py
+++ b/servers/engine/spells.py
@@ -87,6 +87,59 @@ def all_spell_names() -> list[str]:
     return sorted(names.values())
 
 
+# --- class spell LISTS (the preparable pool) — #754 ---------------------------
+#
+# The srd524 dump stamps each spell with a `classes` list of "srd-2024_<class>" slugs
+# (e.g. Bless -> ['srd-2024_cleric', 'srd-2024_paladin']). That is the SRD's own
+# class↔spell mapping — the set of spells a member of <class> can choose to PREPARE
+# (the browsable pool a prepared caster plans from), distinct from the spells the
+# character has currently prepared/known. We re-derive the list straight off that
+# field so the engine stays the single source of truth (no hand-maintained list to
+# drift from the SRD). Pure + cached; additive — a class the dump doesn't know returns [].
+_CLASS_SLUG_PREFIX = "srd-2024_"
+
+
+@functools.lru_cache(maxsize=None)
+def _class_spell_index() -> dict[str, list[dict]]:
+    """Map each SRD class (lowercase short name: 'paladin', 'wizard', …) to the list of
+    that class's spell records (srd524 fields), sorted by (level, name). Built once from
+    the `classes` slugs the srd524 dump stamps on every spell. Pure — no campaign state."""
+    index: dict[str, list[dict]] = {}
+    for rec in _srd524().values():
+        for slug in rec.get("classes") or []:
+            s = str(slug)
+            if not s.startswith(_CLASS_SLUG_PREFIX):
+                continue
+            cls = s[len(_CLASS_SLUG_PREFIX):].strip().lower()
+            if cls:
+                index.setdefault(cls, []).append(rec)
+    for cls, rows in index.items():
+        rows.sort(key=lambda r: (int(r.get("level") or 0), str(r.get("name") or "")))
+    return index
+
+
+def class_spell_list(class_name: str, max_level: Optional[int] = None) -> list[dict]:
+    """The full SRD spell list a `class_name` member can PREPARE — the browsable preparable
+    pool (#754), NOT what a given character has prepared. Each entry is ``{name, level}``
+    (canonical-cased name + integer spell level), sorted by (level, name). Re-derived from
+    the srd524 `classes` field, so it's SRD-correct and never hand-maintained.
+
+    `max_level` (when given) caps the list to spells of that spell level or lower — pass a
+    caster's highest available SLOT level so the pool only shows spells they can actually
+    slot (a L10 Paladin -> levels 1–3). `max_level=0` keeps only cantrips; None (default) =
+    the whole class list. Unknown class -> [] (additive: a non-caster shows nothing)."""
+    rows = _class_spell_index().get(str(class_name).strip().lower(), [])
+    out: list[dict] = []
+    for rec in rows:
+        lvl = int(rec.get("level") or 0)
+        if max_level is not None and lvl > int(max_level):
+            continue
+        name = rec.get("name")
+        if name:
+            out.append({"name": str(name), "level": lvl})
+    return out
+
+
 def _parse_dice(expr: str) -> tuple[int, int]:
     """Parse the dice part of 'NdM(+K)' -> (N, M), ignoring any flat modifier."""
     body = expr.lower().split("+")[0].split("-")[0]

--- a/servers/engine/tests/test_spellcasting.py
+++ b/servers/engine/tests/test_spellcasting.py
@@ -110,6 +110,68 @@ def test_unknown_spell_raises():
         server.cast_spell(cid, w, "Wish")  # not bundled
 
 
+# --- #754: the browsable preparable pool (the full class spell list) ----------
+def test_class_spell_list_paladin_full_pool():
+    # A prepared caster must be able to BROWSE the full class spell list, not just what's
+    # currently prepared. The Paladin SRD list is half-caster (spell levels 1–5) — derived
+    # straight from the srd524 `classes` field, so it is SRD-correct, not hand-maintained.
+    pool = spells.class_spell_list("paladin")
+    names = {s["name"] for s in pool}
+    assert "Bless" in names and "Cure Wounds" in names and "Divine Smite" in names
+    assert len(pool) >= 30, "the full Paladin list is dozens of spells, not just the prepared few"
+    levels = {s["level"] for s in pool}
+    assert max(levels) == 5 and 0 not in levels, "Paladin: spell levels 1–5 (half-caster, no cantrips)"
+    # sorted (level, name) and each entry carries an integer level
+    assert pool == sorted(pool, key=lambda s: (s["level"], s["name"]))
+
+
+def test_class_spell_list_capped_by_max_level():
+    # A L10 Paladin has slots up to level 3 — the browsable pool should cap there so it only
+    # shows spells they can actually slot, while still being the WHOLE list at those levels.
+    capped = spells.class_spell_list("paladin", max_level=3)
+    assert capped, "a capped pool is non-empty"
+    assert max(s["level"] for s in capped) == 3
+    full = spells.class_spell_list("paladin")
+    assert len(capped) < len(full), "capping to L3 drops the L4–L5 Paladin spells"
+    # the cap keeps the FULL set at each allowed level (not just the prepared ones)
+    l1_capped = {s["name"] for s in capped if s["level"] == 1}
+    l1_full = {s["name"] for s in full if s["level"] == 1}
+    assert l1_capped == l1_full
+
+
+def test_class_spell_list_unknown_class_is_empty():
+    assert spells.class_spell_list("fighter") == []
+    assert spells.class_spell_list("") == []
+
+
+def test_get_character_surfaces_preparable_pool_for_prepared_caster():
+    # The character read-endpoint returns the full class spell list (the preparable pool for
+    # class+highest-slot-level) ALONGSIDE the prepared set, so the viewer Spellbook can show
+    # BOTH. Additive: prepared/known are unchanged.
+    cid = server.create_campaign("S")["id"]
+    p = server.create_character(cid, "Wyll", kind="player", class_name="Paladin",
+                                level=10, apply_srd_defaults=True)["id"]
+    sheet = server.get_character(cid, p)
+    pool = sheet["preparable_spells"]
+    names = {s["name"] for s in pool}
+    # the full browsable pool is far larger than the few prepared, and is capped to the
+    # caster's highest slot level (a L10 Paladin -> levels 1–3).
+    assert len(pool) > len(sheet["spells_prepared"])
+    assert "Divine Smite" in names and "Bless" in names
+    assert max(s["level"] for s in pool) == 3
+    # prepared/known are untouched (additive)
+    assert sheet["spells_prepared"] == ["Bless", "Cure Wounds", "Shield of Faith"]
+
+
+def test_get_character_non_caster_has_empty_preparable_pool():
+    # A Fighter (no caster class) gets an empty preparable pool — never a fabricated list.
+    cid = server.create_campaign("S")["id"]
+    f = server.create_character(cid, "Brawn", kind="player", class_name="Fighter",
+                                apply_srd_defaults=True)["id"]
+    sheet = server.get_character(cid, f)
+    assert sheet["preparable_spells"] == []
+
+
 # --- hardening regressions (from adversarial review) ---
 def test_half_on_save_damage():  # C1
     cid = server.create_campaign("S")["id"]

--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -655,6 +655,8 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
   const submittingRef = React.useRef(false);
   // Watch order is drawn from the LIVE party (first names), never the hardcoded demo trio.
   const watchOrder = (Array.isArray(party) ? party : []).map((p) => (p.name || "").split(" ")[0]).filter(Boolean);
+  // name→slug for stable testids (mirror HeroEquipDoll); window.slug is the shared chrome helper.
+  const slug = window.slug || ((n) => (n || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, ""));
 
   // a11y (WCAG 2.1.2 — no keyboard trap): Escape dismisses the dialog, mirroring toast.jsx.
   React.useEffect(() => {
@@ -663,18 +665,46 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
     return () => window.removeEventListener("keydown", esc);
   }, [onClose]);
 
-  const availableSpells = hero.spells || [];
-  // Data-driven from the live hero. The /character-surface read-model does not project
-  // spell-slot counts (it carries spell names only), so this stays empty rather than
-  // inventing the old 4/3/1 — every slot row is gated on max > 0, so empty = no fabricated pips.
-  const slots = (hero.spellSlots && typeof hero.spellSlots === "object") ? hero.spellSlots : {};
+  // #754 — the BROWSABLE preparable pool: the full class spell list this caster can choose
+  // to prepare FROM (the read-model's hero.preparableSpells), grouped by spell level. This is
+  // the optimizer's MAJOR complaint — the prep step used to iterate only hero.spells (the few
+  // currently prepared/known), so a Paladin could never SELECT a new spell to prepare. We group
+  // the full pool by level so the player picks from everything they can slot.
+  const prepPool = (() => {
+    const byLevel = {};
+    for (const sp of (Array.isArray(hero.preparableSpells) ? hero.preparableSpells : [])) {
+      const lv = Number(sp.level) || 0;
+      (byLevel[lv] = byLevel[lv] || []).push(sp);
+    }
+    return Object.keys(byLevel)
+      .map((k) => Number(k))
+      .sort((a, b) => a - b)
+      .map((lv) => ({ level: lv, list: byLevel[lv] }));
+  })();
+
+  // Pre-seed the picker with the caster's CURRENTLY prepared spells (from hero.spells'
+  // "Prepared" group) so opening the modal shows their real preparation, and "Seal" edits it.
+  React.useEffect(() => {
+    const seed = {};
+    for (const grp of (Array.isArray(hero.spells) ? hero.spells : [])) {
+      if (String(grp.level).toLowerCase() !== "prepared") continue;
+      for (const sp of (grp.list || [])) {
+        // place each prepared spell into its level bucket using the pool's known level
+        const inPool = (Array.isArray(hero.preparableSpells) ? hero.preparableSpells : [])
+          .find((p) => p.name === sp.name);
+        const lv = inPool ? (Number(inPool.level) || 0) : 0;
+        (seed[lv] = seed[lv] || []).push(sp.name);
+      }
+    }
+    if (Object.keys(seed).length) setPrepared(seed);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hero.id]);
 
   const toggleSpell = (lv, name) => {
     const cur = prepared[lv] || [];
-    const max = slots[lv] || 0;
     if (cur.includes(name)) {
       setPrepared({ ...prepared, [lv]: cur.filter((n) => n !== name) });
-    } else if (cur.length < max) {
+    } else {
       setPrepared({ ...prepared, [lv]: [...cur, name] });
     }
   };
@@ -735,8 +765,10 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
       .sort((a, b) => Number(a) - Number(b))
       .flatMap((lv) => (prepared[lv] || []).map((n) => n))
       .filter(Boolean);
+    // Name prepare_spells + "replace" explicitly so the DM resolves it with one engine call: the
+    // chosen set IS the day's complete preparation (the engine = sole writer of spells_prepared).
     const text = named.length > 0
-      ? `${hero.name} prepares today's spells: ${named.join(", ")}.`
+      ? `${hero.name} prepares today's spells — set their prepared spells (prepare_spells, replace) to exactly: ${named.join(", ")}.`
       : `${hero.name} keeps their currently prepared spells.`;
     relayMove(text, () => { if (onDone) onDone(); else onClose(); },
       "Spellbook", "Preparation");
@@ -869,29 +901,36 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
               <Divider />
 
               <p className="body" style={{ marginTop: 0 }}>
-                {hero.name} reads by the dying fire. Choose what will be at hand when the day breaks. Unchosen spells remain bound to the page.
+                {hero.name} reads by the dying fire. Choose what will be at hand when the day breaks — the whole class spell list is yours to browse. Unchosen spells remain bound to the page.
               </p>
 
-              {availableSpells.map((group) => {
+              {/* #754 — pick from the FULL browsable class list (hero.preparableSpells), grouped
+                  by spell level and capped to the caster's highest slot level by the engine. The
+                  optimizer could never SELECT a new spell before; now the entire preparable pool
+                  is here. The chosen set rides the relayed move; the engine's prepare_spells records
+                  it (the viewer stays a move-sink). Empty pool -> an honest invitation, not a stub. */}
+              {prepPool.length === 0 ? (
+                <div data-worldos-testid="prep-empty-pool" className="muted body-sm" style={{ marginTop: 16 }}>
+                  This hero has no preparable spells (no spell slots, or not a prepared caster).
+                </div>
+              ) : prepPool.map((group) => {
                 const cur = prepared[group.level] || [];
-                const max = slots[group.level] || 0;
-                if (max === 0) return null;
                 return (
-                  <div key={group.level} style={{ marginTop: 18 }}>
+                  <div key={group.level} style={{ marginTop: 18 }} data-worldos-testid={`prep-level-${group.level}`}>
                     <SectionTitle right={
-                      <span className="muted body-sm">{cur.length} / {max} prepared</span>
+                      <span className="muted body-sm">{cur.length} prepared · {group.list.length} available</span>
                     }>
-                      Level {group.level}
+                      {group.level === 0 ? "Cantrips" : `Level ${group.level}`}
                     </SectionTitle>
                     <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
                       {group.list.map((sp) => {
                         const isPrepared = cur.includes(sp.name);
-                        const canPrep = cur.length < max;
                         return (
                           <button
                             key={sp.name}
+                            data-worldos-testid={`prep-spell-${slug(sp.name)}`}
+                            aria-pressed={isPrepared ? "true" : "false"}
                             onClick={() => toggleSpell(group.level, sp.name)}
-                            disabled={!isPrepared && !canPrep}
                             style={{
                               display: "grid", gridTemplateColumns: "40px 1fr auto", gap: 10, alignItems: "center",
                               padding: 10,
@@ -902,8 +941,7 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
                               boxShadow: isPrepared
                                 ? "inset 0 0 0 1px var(--b-500), inset 0 0 0 3px var(--p-100), inset 0 0 0 4px var(--b-400), 0 0 14px -4px var(--gold-glow)"
                                 : "inset 0 0 0 1px rgba(140,100,60,0.25)",
-                              cursor: (!isPrepared && !canPrep) ? "not-allowed" : "pointer",
-                              opacity: (!isPrepared && !canPrep) ? 0.5 : 1,
+                              cursor: "pointer",
                               transition: "all 140ms",
                             }}
                           >
@@ -1602,9 +1640,13 @@ function SpellsTab({ hero }) {
   // the snapshot stores no spell blocks to fabricate from.
   const groups = (Array.isArray(hero.spells) ? hero.spells : []).filter((g) => g && Array.isArray(g.list) && g.list.length);
   const slots = Array.isArray(hero.spellSlots) ? hero.spellSlots : [];
-  const isCaster = slots.length > 0 || groups.length > 0;
+  // #754 — the browsable preparable pool (the full class spell list this caster can prepare FROM),
+  // distinct from the few they have prepared/known. Surfaces in the Spellbook so a prepared caster
+  // (Paladin/Cleric/…) can browse the WHOLE list, not just their current preparation.
+  const preparable = (Array.isArray(hero.preparableSpells) ? hero.preparableSpells : []);
+  const isCaster = slots.length > 0 || groups.length > 0 || preparable.length > 0;
   // #268: every caster gets a working "Browse spellbook" path — a read-only inspector over
-  // the hero's known + prepared spells (the surface's hero.spells groups). The empty state
+  // the hero's prepared/known spells AND the full preparable class list (#754). The empty state
   // INVITES the browse instead of dead-ending; preparation stays in the Rest & Prepare modal.
   const [browsing, setBrowsing] = React.useState(false);
   const spellCount = groups.reduce((n, g) => n + g.list.length, 0);
@@ -1701,17 +1743,39 @@ function SpellsTab({ hero }) {
         </div>
       )}
 
-      {browsing && <SpellbookBrowser hero={hero} groups={groups} onClose={() => setBrowsing(false)} />}
+      {browsing && <SpellbookBrowser hero={hero} groups={groups} preparable={preparable} onClose={() => setBrowsing(false)} />}
     </div>
   );
 }
 
-function SpellbookBrowser({ hero, groups, onClose }) {
-  // Read-only spellbook inspector (#268). Surfaces the hero's known + prepared spells from
-  // the /character-surface read-model — no preparation here (the Rest & Prepare modal owns
-  // that write-flow). When the engine carries no spell NAMES, we say so honestly rather than
-  // fabricate an SRD list, and point the player at Rest & Prepare.
+function SpellbookBrowser({ hero, groups, preparable, onClose }) {
+  // Read-only spellbook inspector (#268 + #754). Surfaces TWO things from the
+  // /character-surface read-model: (1) the hero's currently PREPARED/KNOWN spells, and
+  // (2) the FULL browsable class spell list they can prepare FROM (hero.preparableSpells) —
+  // the optimizer's MAJOR complaint that a Paladin could only see the few prepared, never the
+  // whole list. Preparation still happens in Rest & Prepare (this stays read-only); here the
+  // player BROWSES + plans. When the engine carries no spell data we say so honestly.
   const list = (Array.isArray(groups) ? groups : []).filter((g) => g && Array.isArray(g.list) && g.list.length);
+  const pool = (Array.isArray(preparable) ? preparable : []);
+  // name→slug for stable testids (mirror HeroEquipDoll); window.slug is the shared chrome helper.
+  const slug = window.slug || ((n) => (n || "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, ""));
+  // Names the hero already has prepared — so the browsable list can MARK prepared vs available.
+  const preparedNames = new Set();
+  for (const g of list) {
+    if (String(g.level).toLowerCase() === "prepared") {
+      for (const sp of (g.list || [])) preparedNames.add(sp.name);
+    }
+  }
+  // Group the full preparable pool by spell level for a scannable browse.
+  const poolByLevel = (() => {
+    const byLevel = {};
+    for (const sp of pool) {
+      const lv = Number(sp.level) || 0;
+      (byLevel[lv] = byLevel[lv] || []).push(sp);
+    }
+    return Object.keys(byLevel).map((k) => Number(k)).sort((a, b) => a - b)
+      .map((lv) => ({ level: lv, list: byLevel[lv] }));
+  })();
   // a11y (WCAG 2.1.2 — no keyboard trap): Escape dismisses the dialog, mirroring toast.jsx.
   React.useEffect(() => {
     const esc = (e) => e.key === "Escape" && onClose();
@@ -1736,7 +1800,7 @@ function SpellbookBrowser({ hero, groups, onClose }) {
 
           {list.length ? (
             list.map((group) => (
-              <div key={group.level} style={{ marginTop: 16 }}>
+              <div key={group.level} style={{ marginTop: 16 }} data-worldos-testid={`spellbook-group-${slug(String(group.level))}`}>
                 <SectionTitle right={<span className="muted body-sm">{group.list.length}</span>}>
                   {spellGroupLabel(group.level)}
                 </SectionTitle>
@@ -1769,6 +1833,54 @@ function SpellbookBrowser({ hero, groups, onClose }) {
               No spells are inscribed in this hero's book yet. Open <em>Rest &amp; Prepare</em>
               {" "}to bind spells to the day.
             </p>
+          )}
+
+          {/* #754 — the FULL browsable class spell list (what this caster CAN prepare). Clearly
+              separated from "prepared/known" above, and each entry is tagged Prepared vs Available
+              so a prepared caster (Paladin/Cleric/…) can plan from the whole list, not just the few. */}
+          {poolByLevel.length > 0 && (
+            <div data-worldos-testid="spellbook-available">
+              <Divider />
+              <SectionTitle right={<span className="muted body-sm">{pool.length}</span>}>
+                Available to Prepare
+              </SectionTitle>
+              <p className="hand muted" style={{ fontSize: 12, marginTop: -2, marginBottom: 8 }}>
+                The full {hero.class ? titleCaseWord(hero.class) + " " : ""}spell list you can choose from at <em>Rest &amp; Prepare</em>.
+              </p>
+              {poolByLevel.map((group) => (
+                <div key={group.level} style={{ marginTop: 12 }} data-worldos-testid={`spellbook-available-level-${group.level}`}>
+                  <SectionTitle right={<span className="muted body-sm">{group.list.length}</span>}>
+                    {group.level === 0 ? "Cantrips" : `Level ${group.level}`}
+                  </SectionTitle>
+                  <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
+                    {group.list.map((sp) => {
+                      const isPrepared = preparedNames.has(sp.name);
+                      return (
+                        <div key={sp.name} data-worldos-testid={`spellbook-available-spell-${slug(sp.name)}`} style={{
+                          padding: 9,
+                          background: isPrepared ? "linear-gradient(180deg, var(--p-100), var(--p-200))" : "rgba(176,141,87,0.05)",
+                          boxShadow: isPrepared
+                            ? "inset 0 0 0 1px var(--b-500), inset 0 0 0 3px var(--p-100), inset 0 0 0 4px var(--b-400)"
+                            : "inset 0 0 0 1px rgba(140,100,60,0.2)",
+                        }}>
+                          <div style={{ display: "flex", gap: 8, alignItems: "center", justifyContent: "space-between", minWidth: 0 }}>
+                            <div style={{ minWidth: 0 }}>
+                              <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.05em", color: "var(--ink-900)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                                {sp.name}
+                              </div>
+                              <div className="hand muted" style={{ fontSize: 11 }}>{spellMeta(sp)}</div>
+                            </div>
+                            <span className="eyebrow" style={{ fontSize: 8, color: isPrepared ? "var(--emerald)" : "var(--ink-500)", whiteSpace: "nowrap" }}>
+                              {isPrepared ? "Prepared" : "Available"}
+                            </span>
+                          </div>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </div>
           )}
 
           <Divider />

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3855,6 +3855,11 @@ def _character_sheet(cid: str, ch: dict) -> dict:
         "stats": stats,
         "skills": skills,
         "spells": spells,
+        # #754 — the BROWSABLE preparable pool: the FULL SRD class spell list this caster can
+        # choose to prepare (capped to their highest slot level), distinct from the few they've
+        # currently prepared. A prepared caster (Paladin/Cleric/Druid/Wizard) plans FROM this;
+        # empty for a non-caster. Derived from the engine's own srd524 class↔spell map.
+        "preparableSpells": _preparable_spells_view(ch),
         # Character-level casting summary (Spell Save DC + Spell Attack Bonus) for the top
         # of the Spells tab. None for a non-caster (Fighter/Rogue) — the screen omits it
         # rather than show a fake DC. Derived from the PC's casting ability + proficiency.
@@ -4080,6 +4085,74 @@ def _character_spellcasting(ch: dict) -> dict | None:
         "spellSaveDc": _spell_save_dc(ch),
         "spellAttackBonus": _spell_attack_bonus(ch),
     }
+
+
+def _highest_slot_level_from_sheet(ch: dict) -> int:
+    """The highest spell-slot level the character has a slot for, read straight off the
+    snapshot's ``spell_slots`` ({level: {maximum, used}}). 0 == no leveled slots. Mirrors
+    engine server._highest_slot_level so the viewer caps the preparable pool the SAME way."""
+    slots = ch.get("spell_slots")
+    if not isinstance(slots, dict):
+        return 0
+    best = 0
+    for lvl, pool in slots.items():
+        if not isinstance(pool, dict):
+            continue
+        mx = _num(pool.get("maximum"))
+        if mx is not None and int(mx) > 0:
+            try:
+                best = max(best, int(lvl))
+            except (TypeError, ValueError):
+                continue
+    return best
+
+
+def _preparable_spells_view(ch: dict) -> list[dict]:
+    """The full SRD class spell list a PREPARED caster can BROWSE to choose what to prepare
+    (#754) — each ``{name, level, levelLabel, school, ...}`` enriched spell card, capped to the
+    caster's highest available slot level. Mirrors engine server._preparable_spells: derived
+    from the engine's own srd524 class↔spell map (spells.class_spell_list) so the pool is
+    SRD-correct, NOT a viewer-fabricated list. The viewer stays a pure reader — it surfaces the
+    same data the engine's get_character endpoint computes (additive, default empty).
+
+    Returns [] for a non-caster (no caster class / no slots), or when the engine spells module
+    can't be imported (the viewer degrades to today's behavior — no fabricated pool)."""
+    max_lvl = _highest_slot_level_from_sheet(ch)
+    if max_lvl <= 0:
+        return []
+    # Reuse the same lazily-imported engine `spells` module the spell cards already use.
+    global _SPELLS_MOD, _SPELLS_TRIED
+    if _SPELLS_MOD is None and not _SPELLS_TRIED:
+        _SPELLS_TRIED = True
+        _SPELLS_MOD = _engine_module("spells")
+    mod = _SPELLS_MOD
+    if mod is None or not hasattr(mod, "class_spell_list"):
+        return []
+    save_dc = _spell_save_dc(ch)
+    classes = ch.get("classes") if isinstance(ch.get("classes"), list) else []
+    merged: dict[str, dict] = {}
+    for cl in classes:
+        if not isinstance(cl, dict):
+            continue
+        cname = _text(cl.get("name") or cl.get("class_name"))
+        # Only real caster classes contribute a preparable pool (mirror _casting_ability).
+        if not cname or cname.lower() not in _CASTING_ABILITY:
+            continue
+        try:
+            entries = mod.class_spell_list(cname, max_level=max_lvl) or []
+        except Exception:
+            entries = []
+        for entry in entries:
+            name = _text(entry.get("name"))
+            if not name or name.lower() in merged:
+                continue
+            lvl = entry.get("level")
+            lvl = int(lvl) if isinstance(lvl, (int, float)) else 0
+            # Enrich each pool spell with its full SRD rules card (level/school/range/save/…)
+            # so the Spellbook can show the same rich detail as a prepared spell.
+            card = _spell_card(name, "available", save_dc)
+            merged[name.lower()] = card
+    return sorted(merged.values(), key=lambda s: (int(s.get("level") or 0), _text(s.get("name"))))
 
 
 def _spell_card(name: str, time_label: str, save_dc: int | None) -> dict:

--- a/viewer/tests/test_readmodel_surfaces.py
+++ b/viewer/tests/test_readmodel_surfaces.py
@@ -435,6 +435,47 @@ class ReadModelSurfaceTests(unittest.TestCase):
         self.assertIsNone(fbolt["saveDc"])
         self.assert_no_private_keys(surface)
 
+    def test_character_surface_surfaces_browsable_preparable_pool_for_a_prepared_caster(self):
+        # #754 (optimizer): the Spellbook must let a prepared caster BROWSE the full class spell
+        # list (what they can prepare FROM), not just the few currently prepared. The surface
+        # projects `preparableSpells` — the whole Paladin list, capped to the caster's highest
+        # slot level (L10 Paladin -> L1–3), enriched with the same SRD rules cards.
+        snap = copy.deepcopy(_SNAPSHOT)
+        snap["party"].append("wyll")
+        snap["characters"]["wyll"] = {
+            "id": "wyll", "name": "Wyll", "kind": "player", "race": "Human",
+            "classes": [{"name": "Paladin", "level": 10}],
+            "abilities": {"charisma": 18, "strength": 16, "constitution": 14},
+            "proficiency_bonus": 4, "armor_class": 18, "max_hp": 84, "current_hp": 84,
+            "spells_known": ["Bless", "Cure Wounds", "Shield of Faith"],
+            "spells_prepared": ["Bless", "Cure Wounds", "Shield of Faith"],
+            "spell_slots": {"1": {"maximum": 4, "used": 0}, "2": {"maximum": 3, "used": 0},
+                            "3": {"maximum": 2, "used": 0}},
+        }
+        self._write("camp_paladin", snap)
+        _status, surface = self._get_json("/character-surface?campaign=camp_paladin")
+        wyll = {c["id"]: c for c in surface["party"]}["wyll"]
+        pool = wyll["preparableSpells"]
+        names = {sp["name"] for sp in pool}
+        # the browsable pool is far larger than the 3 prepared, and includes Paladin spells the
+        # character has NOT prepared (the whole point — a planning surface).
+        self.assertGreater(len(pool), len(wyll["spells"][0]["list"]))
+        self.assertIn("Divine Smite", names)   # a Paladin spell not in the prepared 3
+        self.assertIn("Bless", names)
+        # capped to the highest slot level (L3) — no L4/L5 spells the L10 Paladin can't slot
+        self.assertEqual(max(sp["level"] for sp in pool), 3)
+        # each pool entry is enriched with its SRD rules card (level + school, not just a name)
+        smite = next(sp for sp in pool if sp["name"] == "Divine Smite")
+        self.assertIn("levelLabel", smite)
+        self.assert_no_private_keys(surface)
+
+    def test_character_surface_preparable_pool_empty_for_non_caster(self):
+        # A Fighter (Cassian) has no caster class -> no preparable pool is fabricated.
+        self._write("camp_marches", _SNAPSHOT)
+        _status, surface = self._get_json("/character-surface?campaign=camp_marches")
+        hero = {c["id"]: c for c in surface["party"]}["cassian"]
+        self.assertEqual(hero["preparableSpells"], [])
+
     def test_character_surface_omits_spell_dc_for_non_caster_but_keeps_rules(self):
         # HONEST data: Cassian is a Fighter (no SRD caster class), so no spell save DC is
         # fabricated — but the spell's own rules text (school/range/duration) still resolves,

--- a/viewer/tests/test_spellbook_preparable.py
+++ b/viewer/tests/test_spellbook_preparable.py
@@ -1,0 +1,335 @@
+"""Behavior tests for #754 — the browsable preparable spell pool in the OpenWorlds character screen.
+
+From a real optimizer-persona complaint in the 2026-06-15 confirm sweep: a prepared caster
+(Paladin) could NOT plan because the Spellbook + Rest & Prepare only showed the FEW currently
+prepared/known spells — never the full class spell list to prepare FROM.
+
+Two surfaces are fixed in screen-character.jsx, both fed by the read-model's additive
+``hero.preparableSpells`` (the engine's srd524-derived class spell list):
+
+  (1) RestPrepareModal prep step: iterates the FULL preparable pool (grouped by level), so the
+      caster can SELECT a spell they have NOT prepared. The chosen set rides the relayed `do`
+      /move which names prepare_spells (the viewer stays a move-sink; the engine prepares).
+
+  (2) SpellbookBrowser: renders an "Available to Prepare" section listing the whole class list,
+      each tagged Prepared vs Available — alongside the existing prepared/known groups.
+
+These exercise the REAL components by transpiling the shipped screen-character.jsx with the SAME
+bundled Babel-standalone the browser uses, rendering under a createElement-capturing React stub
+(state persists, effects run, setState re-renders), with a scripted fetch — so the test tracks the
+shipped JSX, not a reimplementation (mirrors test_rest_camp_levelup_wiring.py).
+"""
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+_OPENWORLDS = Path(__file__).resolve().parents[1] / "openworlds"
+_SCREEN_CHARACTER = _OPENWORLDS / "screen-character.jsx"
+_BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+
+_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+function makeReact() {
+  const stateCells = [], refCells = [], cbCells = [], effects = [];
+  let sIdx = 0, rIdx = 0, cIdx = 0, eIdx = 0;
+  let renderFn = null, result = null;
+  const pendingEffects = [];
+  let flushing = false;
+  function useState(init) {
+    const i = sIdx++;
+    if (stateCells[i] === undefined) stateCells[i] = { v: typeof init === 'function' ? init() : init };
+    const cell = stateCells[i];
+    const set = (next) => { cell.v = (typeof next === 'function') ? next(cell.v) : next; render(); flushEffects(); };
+    return [cell.v, set];
+  }
+  function useRef(init) { const i = rIdx++; if (refCells[i] === undefined) refCells[i] = { current: init }; return refCells[i]; }
+  function depsEqual(a, b) { if (!a || !b || a.length !== b.length) return false; for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false; return true; }
+  function useCallback(fn, deps) { const i = cIdx++; const prev = cbCells[i]; if (prev === undefined || !depsEqual(prev.deps, deps)) { cbCells[i] = { fn, deps }; return fn; } return prev.fn; }
+  function useMemo(fn, deps) { const i = cIdx++; const prev = cbCells[i]; if (prev === undefined || !depsEqual(prev.deps, deps)) { const v = fn(); cbCells[i] = { v, deps }; return v; } return prev.v; }
+  function useEffect(fn, deps) {
+    const i = eIdx++;
+    const prev = effects[i];
+    const changed = !prev || !depsEqual(prev.deps, deps);
+    if (changed) {
+      pendingEffects.push(() => { if (prev && typeof prev.cleanup === 'function') prev.cleanup(); const cleanup = fn(); effects[i] = { deps, cleanup: typeof cleanup === 'function' ? cleanup : null }; });
+      if (!prev) effects[i] = { deps, cleanup: null }; else effects[i].deps = deps;
+    }
+  }
+  function createElement(type, props) {
+    const children = Array.prototype.slice.call(arguments, 2);
+    return { type, props: props || {}, children };
+  }
+  function render() { sIdx = 0; rIdx = 0; cIdx = 0; eIdx = 0; result = renderFn(); }
+  function flushEffects() { if (flushing) return; flushing = true; try { while (pendingEffects.length) pendingEffects.shift()(); } finally { flushing = false; } }
+  const React = { useState, useRef, useCallback, useMemo, useEffect, createElement, Fragment: 'F' };
+  function mount(fn) { renderFn = fn; render(); flushEffects(); }
+  function commit() { flushEffects(); }
+  function api() { return result; }
+  return { React, mount, commit, api };
+}
+
+const posts = [];
+function fetchStub(url, opts) {
+  const u = String(url).split('?')[0];
+  if (u === '/move') {
+    let body = {}; try { body = JSON.parse((opts && opts.body) || '{}'); } catch (_e) {}
+    posts.push({ url: u, body });
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+  }
+  return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+}
+
+const reactHost = makeReact();
+function passthrough(name) { return function (props) { const p = props || {}; const kids = (p.children !== undefined) ? [].concat(p.children) : []; return reactHost.React.createElement(name, p, ...kids); }; }
+
+const sandbox = {
+  React: reactHost.React,
+  ReactDOM: { createRoot: () => ({ render() {} }) },
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible', getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
+  setTimeout: (fn) => { return 0; }, clearTimeout: () => {}, setInterval: () => 0, clearInterval: () => {},
+  fetch: fetchStub,
+  addEventListener() {}, removeEventListener() {},
+  encodeURIComponent, URLSearchParams, Promise, JSON, Set, Array, Object, String, Boolean, Number, Math,
+  console,
+};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+
+function load(p) {
+  let src = fs.readFileSync(p, 'utf8');
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+for (const name of ['Panel','BrassButton','Divider','SectionTitle','Pill','Placeholder','Img','Glyph','CornerOrnament']) {
+  sandbox[name] = passthrough(name);
+}
+const toastCalls = [];
+sandbox.useToast = () => (t) => { toastCalls.push(t); };
+sandbox.slug = (n) => (n || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+sandbox.combatSurfaceFromCampaign = () => '';
+
+load(%(screen_character)s);
+
+function findByTestId(node, id, hits) {
+  hits = hits || [];
+  if (node == null || typeof node !== 'object') return hits;
+  if (Array.isArray(node)) { for (const c of node) findByTestId(c, id, hits); return hits; }
+  const props = node.props || {};
+  if (props['data-worldos-testid'] === id || props.testId === id) hits.push(node);
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) findByTestId(c, id, hits);
+  return hits;
+}
+function findByPrefix(node, prefix, hits) {
+  hits = hits || [];
+  if (node == null || typeof node !== 'object') return hits;
+  if (Array.isArray(node)) { for (const c of node) findByPrefix(c, prefix, hits); return hits; }
+  const props = node.props || {};
+  const tid = props['data-worldos-testid'];
+  if (typeof tid === 'string' && tid.indexOf(prefix) === 0) hits.push(tid);
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) findByPrefix(c, prefix, hits);
+  return hits;
+}
+function collectText(node, out) {
+  out = out || [];
+  if (node == null || node === false) return out;
+  if (typeof node === 'string' || typeof node === 'number') { out.push(String(node)); return out; }
+  if (Array.isArray(node)) { for (const c of node) collectText(c, out); return out; }
+  const props = node.props || {};
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) collectText(c, out);
+  return out;
+}
+function firstProps(node, id) { const hits = findByTestId(node, id); return hits.length ? (hits[0].props || {}) : null; }
+async function settle() { await new Promise((r) => setImmediate(r)); await new Promise((r) => setImmediate(r)); reactHost.commit(); }
+
+const h = {
+  mountRest: (props) => { reactHost.mount(() => sandbox.window.RestPrepareModal(props)); },
+  mountBrowser: (props) => { reactHost.mount(() => sandbox.window.SpellbookBrowser(props)); },
+  mountSpellsTab: (props) => { reactHost.mount(() => sandbox.window.SpellsTab(props)); },
+  tree: () => reactHost.api(),
+  settle,
+  props: (id) => firstProps(reactHost.api(), id),
+  click: async (id) => { const hits = findByTestId(reactHost.api(), id); if (!hits.length) throw new Error('no node ' + id); const oc = (hits[0].props || {}).onClick; if (typeof oc !== 'function') throw new Error('no onClick on ' + id); oc(); await settle(); },
+  text: () => collectText(reactHost.api()).join(' ␟ '),
+  posts: () => posts,
+  exists: (id) => findByTestId(reactHost.api(), id).length,
+  byPrefix: (p) => findByPrefix(reactHost.api(), p),
+};
+
+const script = %(script)s;
+eval('(async () => { ' + script + ' })()')
+  .then((result) => { process.stdout.write(JSON.stringify(result)); })
+  .catch((e) => { console.error(e && e.stack || e); process.exit(1); });
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + render the JSX")
+class _Harness(unittest.TestCase):
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_SCREEN_CHARACTER, _BABEL):
+            assert p.exists(), f"missing {p}"
+
+    def _run(self, script: str):
+        program = _HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "screen_character": json.dumps(str(_SCREEN_CHARACTER)),
+            "script": json.dumps(script),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program, text=True, capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+
+# A L10 Paladin: prepares 3 spells, but the browsable preparable pool is the full L1–3 list.
+_PALADIN = (
+    "{ id: 'wyll', name: 'Wyll', class: 'paladin', level: 10, "
+    "xp: 64000, xpMax: 85000, "
+    "spells: [{ level: 'Prepared', list: ["
+    "  { name: 'Bless', glyph: 'spell', levelLabel: 'Level 1' },"
+    "  { name: 'Cure Wounds', glyph: 'spell', levelLabel: 'Level 1' } ] }], "
+    "spellSlots: [{ level: 1, max: 4, used: 0 }, { level: 2, max: 3, used: 0 }, { level: 3, max: 2, used: 0 }], "
+    "preparableSpells: ["
+    "  { name: 'Bless', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Cure Wounds', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Divine Smite', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Command', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Aid', level: 2, levelLabel: 'Level 2', glyph: 'spell' },"
+    "  { name: 'Lesser Restoration', level: 2, levelLabel: 'Level 2', glyph: 'spell' },"
+    "  { name: 'Daylight', level: 3, levelLabel: 'Level 3', glyph: 'spell' } ] }"
+)
+
+# A non-caster Fighter: no preparableSpells, no caster surfaces.
+_FIGHTER = (
+    "{ id: 'lae', name: 'Laezel', class: 'fighter', level: 5, "
+    "xp: 6500, xpMax: 14000, spells: [], spellSlots: [], preparableSpells: [] }"
+)
+
+# The browsable preparable pool (the full Paladin L1-3 list), shared by the browser tests.
+_POOL = (
+    "[ { name: 'Bless', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Cure Wounds', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Divine Smite', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Command', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Aid', level: 2, levelLabel: 'Level 2', glyph: 'spell' },"
+    "  { name: 'Lesser Restoration', level: 2, levelLabel: 'Level 2', glyph: 'spell' },"
+    "  { name: 'Daylight', level: 3, levelLabel: 'Level 3', glyph: 'spell' } ]"
+)
+
+
+class RestPrepareBrowsablePoolTests(_Harness):
+    def _mount(self):
+        return (
+            "h.mountRest({ hero: " + _PALADIN + ", party: [{ id:'wyll', name:'Wyll' }],"
+            " campaignId: 'camp1', canAct: true, dmBusy: false,"
+            " onClose: function(){}, onDone: function(){}, toast: function(){}, setState: function(){} });"
+        )
+
+    def test_prep_step_lists_the_full_preparable_pool_not_just_prepared(self):
+        out = self._run(
+            self._mount() +
+            "await h.click('rest-make-camp');"          # advance to the prep step
+            "var ids = h.byPrefix('prep-spell-');"
+            "return ({ spell_ids: ids, has_smite: h.exists('prep-spell-divine-smite'),"
+            "  level3: h.exists('prep-level-3'), text: h.text() });"
+        )
+        # the FULL class list is browsable (7 pool spells across L1-3), not just the 2 prepared.
+        self.assertGreaterEqual(len(out["spell_ids"]), 7,
+                                "the prep step must list the whole preparable pool, not just prepared spells")
+        self.assertGreaterEqual(out["has_smite"], 1,
+                                "Divine Smite (NOT currently prepared) must be selectable — the optimizer's blocker")
+        self.assertGreaterEqual(out["level3"], 1, "L3 spells are browsable (a L10 Paladin can slot them)")
+
+    def test_selecting_a_new_spell_rides_the_prepare_move(self):
+        out = self._run(
+            self._mount() +
+            "await h.click('rest-make-camp');"
+            "await h.click('prep-spell-divine-smite');"   # select a NEW spell to prepare
+            "await h.click('rest-prepare-spells');"        # seal -> relay prepare_spells
+            "return ({ posts: h.posts() });"
+        )
+        moves = [p for p in out["posts"] if p["url"] == "/move"]
+        # Make-camp + Seal each relay one /move.
+        self.assertEqual(len(moves), 2)
+        prep = moves[-1]["body"]
+        self.assertEqual(prep["kind"], "do", "the prepare relay is a structured `do` move-intent (move-sink)")
+        text = prep["text"].lower()
+        self.assertIn("prepare_spells", text, "the intent must name the engine's prepare_spells tool")
+        self.assertIn("divine smite", text, "the newly-selected spell must ride the relayed preparation")
+
+    def test_currently_prepared_spells_are_preselected(self):
+        # Opening the prep step pre-seeds the picker with the caster's CURRENT preparation, so
+        # "Seal" without changes keeps Bless + Cure Wounds (it edits, never silently wipes).
+        out = self._run(
+            self._mount() +
+            "await h.click('rest-make-camp');"
+            "await h.click('rest-prepare-spells');"        # seal WITHOUT changing anything
+            "return ({ posts: h.posts() });"
+        )
+        moves = [p for p in out["posts"] if p["url"] == "/move"]
+        text = moves[-1]["body"]["text"].lower()
+        self.assertIn("bless", text)
+        self.assertIn("cure wounds", text)
+
+
+class SpellbookAvailableSectionTests(_Harness):
+    def _mount(self, hero=_PALADIN):
+        return (
+            "h.mountBrowser({ hero: " + hero + ","
+            " groups: [{ level: 'Prepared', list: ["
+            "  { name: 'Bless', glyph: 'spell' }, { name: 'Cure Wounds', glyph: 'spell' } ] }],"
+            " preparable: " + _POOL + ","
+            " onClose: function(){} });"
+        )
+
+    def test_spellbook_shows_available_to_prepare_section_with_full_list(self):
+        out = self._run(
+            self._mount() +
+            "return ({ section: h.exists('spellbook-available'),"
+            "  smite: h.exists('spellbook-available-spell-divine-smite'),"
+            "  l3: h.exists('spellbook-available-level-3'),"
+            "  ids: h.byPrefix('spellbook-available-spell-'), text: h.text() });"
+        )
+        self.assertGreaterEqual(out["section"], 1, "the Spellbook must show an 'Available to Prepare' section")
+        self.assertGreaterEqual(out["smite"], 1,
+                                "Divine Smite (browsable, not prepared) must appear in the available list")
+        self.assertGreaterEqual(len(out["ids"]), 7, "the WHOLE class list shows, not just the prepared few")
+        self.assertIn("Available to Prepare", out["text"])
+
+    def test_available_list_marks_prepared_vs_available(self):
+        out = self._run(
+            self._mount() +
+            "return ({ text: h.text() });"
+        )
+        # Bless is prepared -> tagged Prepared; Divine Smite is not -> tagged Available.
+        self.assertIn("Prepared", out["text"])
+        self.assertIn("Available", out["text"])
+
+
+class NonCasterTests(_Harness):
+    def test_non_caster_spellbook_has_no_available_section(self):
+        out = self._run(
+            "h.mountBrowser({ hero: " + _FIGHTER + ", groups: [], preparable: [], onClose: function(){} });"
+            "return ({ section: h.exists('spellbook-available') });"
+        )
+        self.assertEqual(out["section"], 0, "a non-caster shows no preparable pool (never fabricated)")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Persona complaint (2026-06-15 confirm sweep, optimizer — MAJOR)

A Paladin / prepared caster genuinely **could not plan**:
1. **"Spellbook shows ONLY prepared spells — full Paladin spell list not browsable"** (#754). A prepared caster should be able to BROWSE the full class spell list (the spells available to prepare), not just the currently-prepared few.
2. **"Rest & Prepare has NO interactive spell-selection step — can't choose prepared spells."** The engine `prepare_spells` tool existed but no viewer step let the caster choose which spells to prepare from a browsable pool.

## Fix

**Engine** (`servers/engine/spells.py`, `servers/engine/server.py`) — additive, derived-only, round-trips; engine stays sole writer:
- `spells.class_spell_list(class_name, max_level=None)` re-derives a class's full SRD spell list straight from the **srd524 `classes` field** (`srd-2024_<class>` slugs), sorted by `(level, name)`, optionally capped to a slot level. SRD-correct: Paladin L1 == the 13 srd524 paladin L1 spells; half-casters (Paladin/Ranger) carry no cantrips.
- `get_character` returns a new **`preparable_spells`** field — the full preparable pool for the caster's class(es), **capped to the highest available slot level** (a L10 Paladin → 30 spells across L1–3), multiclass-merged. `[]` for a non-caster. **Never persisted** (purely derived).

**Viewer** (`viewer/server.py`, `viewer/openworlds/screen-character.jsx`) — read-only move-sink, no new write path:
- `/character-surface` party shape carries `hero.preparableSpells` (enriched spell cards), mirroring the engine derivation via the lazily-imported engine `spells` module.
- **SpellbookBrowser** now shows an **"Available to Prepare"** section: the WHOLE class list, each entry tagged **Prepared** vs **Available**, alongside the existing prepared/known groups.
- **RestPrepareModal** prep step iterates the FULL preparable pool (grouped by level) so the caster can SELECT a spell they have NOT prepared; the chosen set rides the existing `do` `/move` which now explicitly names **`prepare_spells` (replace)** — the engine prepares (viewer stays a move-sink, exactly the #610/#617/#873 relay pattern). Currently-prepared spells are pre-seeded so "Seal" edits, never silently wipes.

## Invariants honored
- **Engine = sole writer**: `preparable_spells` is a *read-only derived* field on `get_character`; never written to the snapshot (verified: not persisted, round-trips stable). The viewer relays a `do` move — it never writes campaign state.
- **Additive-by-default**: new field defaults to `[]` for non-casters / old snapshots; nothing else on the sheet changes.
- **SRD 5.2 correctness**: derived against `data/srd/srd524/Spell.json` (the class↔spell map), so the list is never hand-maintained and can't drift.
- **Wire contracts frozen**: no new `/move` kind, no env/id changes; reuses the existing `do` relay.

## Tests
- `servers/engine/tests/test_spellcasting.py` **(+5)**: `class_spell_list` full pool / max-level cap / unknown-class-empty; `get_character` `preparable_spells` for a L10 Paladin + empty for a Fighter.
- `viewer/tests/test_readmodel_surfaces.py` **(+2)**: `/character-surface` surfaces the browsable pool for a prepared caster (enriched, capped to L3) + empty for a non-caster.
- `viewer/tests/test_spellbook_preparable.py` **(new, +8)**: JSX-harness over the shipped `screen-character.jsx` — prep step lists the full pool / selects a non-prepared spell / relays `prepare_spells` / pre-selects current preparation; SpellbookBrowser shows the Available-to-Prepare section + Prepared-vs-Available marking; non-caster guard.
- **Tier-0 `qa/fast_gate.sh`: PASS** (215 deterministic engine tests). Combined engine+viewer regression: 307 passed.

DO NOT MERGE — for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prepared casters now see the full class spell pool when preparing spells, organized by spell level
  * Added "Available to Prepare" section in spellbook showing prepared versus available spells
  * Spell preparation UI seeds selections with currently prepared spells

<!-- end of auto-generated comment: release notes by coderabbit.ai -->