### PR TITLE
fix(engine+viewer): Paladin oath features through the levels + Stash Examine depth (#888)

### DIFF
--- a/content/worlds/baldurs-gate/characters/hellrider-paladin.json
+++ b/content/worlds/baldurs-gate/characters/hellrider-paladin.json
@@ -2,6 +2,7 @@
   "name": "Hellrider Paladin",
   "race": "Tiefling",
   "class": "Paladin",
+  "subclass": "Oath of Devotion",
   "level": "10",
   "alignment": "",
   "appearance": "",

--- a/servers/engine/inventory.py
+++ b/servers/engine/inventory.py
@@ -22,7 +22,8 @@ _COINS_PER_POUND = 50  # SRD variant: 50 coins weigh 1 lb
 # the audit's watch-item is that _split_one MUST carry these or a split stack loses them.
 _STAT_FIELDS = (
     "kind", "rarity", "cost_gp", "damage", "damage_type",
-    "ac", "armor_category", "ac_dex_mod", "ac_dex_cap", "properties",
+    "ac", "armor_category", "ac_dex_mod", "ac_dex_cap",
+    "weapon_category", "mastery", "properties",
 )
 
 

--- a/servers/engine/itemcatalog.py
+++ b/servers/engine/itemcatalog.py
@@ -144,6 +144,18 @@ def _weapon_range(fields: dict) -> dict:
     }
 
 
+def _weapon_category(fields: dict) -> str:
+    """#888 — the SRD 5.2 weapon CATEGORY ("Simple" / "Martial") from the Weapon record's
+    ``is_simple`` flag. The veteran/optimizer Examine wants the proficiency tier ("is this a
+    Martial weapon I'm proficient with?"). The SRD encodes it ONLY as ``is_simple`` (True =>
+    Simple, False => Martial); there is no separate category string. Returns "" when the field
+    is absent (a non-Weapon record), so the inspector row is hidden — never fabricated."""
+    flag = fields.get("is_simple")
+    if flag is None:
+        return ""
+    return "Simple" if flag else "Martial"
+
+
 def _armor_dex_rule(fields: dict, ac_base: int, name: str) -> dict:
     """F09-6 — recover the SRD armor DEX-mod rule the bare ``ac_base`` throws away.
 
@@ -203,8 +215,8 @@ def _weapon_armor_join() -> tuple[dict, dict]:
 
 @functools.lru_cache(maxsize=None)
 def _weapon_property_join() -> dict[str, dict]:
-    """{weapon_pk: {"properties": [name, …], "versatile": "1d8"}} from the SRD
-    ``WeaponProperty.json`` + ``WeaponPropertyAssignment.json`` tables (#756).
+    """{weapon_pk: {"properties": [name, …], "versatile": "1d8", "mastery": "Topple"}}
+    from the SRD ``WeaponProperty.json`` + ``WeaponPropertyAssignment.json`` tables (#756).
 
     A weapon's classic properties (Versatile, Finesse, Light, Thrown, Two-Handed,
     Heavy, Reach, Ammunition, Loading, Reach) and — for a Versatile weapon — its
@@ -213,11 +225,13 @@ def _weapon_property_join() -> dict[str, dict]:
     property" and no 1d8 two-handed damage (the RRI-5e98e6f optimizer findings). We
     recover them read-only here.
 
-    The 2024 weapon-MASTERY properties (Topple/Nick/Sap/Graze/Slow/Vex/Cleave…,
-    ``type == "Mastery"``) are an advanced combat-option layer, not item descriptors a
-    buyer evaluates, so they are deliberately excluded from the chip list — only the
-    base properties (``type`` null) are surfaced. ``versatile`` carries the assignment
-    ``detail`` (the two-handed die, e.g. "1d8"); absent → "". Keyed by pk (the FK)."""
+    The 2024 weapon-MASTERY property (Topple/Nick/Sap/Graze/Slow/Vex/Cleave/Push,
+    ``type == "Mastery"``) is an advanced combat-option layer, kept OUT of the base
+    ``properties`` chip list (a buyer evaluating descriptors) but surfaced SEPARATELY
+    as ``mastery`` (#888 — the veteran/optimizer "Examine is missing the Weapon Mastery
+    property"): a weapon has exactly one in SRD 5.2, so it's a single string ("" when
+    none). ``versatile`` carries the assignment ``detail`` (the two-handed die, e.g.
+    "1d8"); absent → "". Keyed by pk (the FK)."""
     # property_pk -> {name, type}
     prop_meta: dict[str, dict] = {}
     for d in _dirs():
@@ -242,12 +256,18 @@ def _weapon_property_join() -> dict[str, dict]:
             meta = prop_meta.get(ppk)
             if not meta or not meta["name"]:
                 continue
-            slot = out.setdefault(wpk, {"properties": [], "versatile": ""})
+            slot = out.setdefault(wpk, {"properties": [], "versatile": "", "mastery": ""})
             seen_for = seen.setdefault(wpk, set())
             name = meta["name"]
             # Versatile: keep its two-handed die (the assignment `detail`).
             if name.lower() == "versatile" and not slot["versatile"]:
                 slot["versatile"] = str(f.get("detail") or "")
+            # The Mastery property is surfaced separately (not a descriptor chip). SRD 5.2
+            # gives a weapon exactly one; keep the first seen.
+            if meta["type"] == "Mastery":
+                if not slot["mastery"]:
+                    slot["mastery"] = name
+                continue
             # Base (non-Mastery) properties become item-descriptor chips; Mastery
             # options are excluded. De-dupe per weapon, preserve first-seen order.
             if meta["type"] is None and name not in seen_for:
@@ -290,6 +310,11 @@ def _flatten(model: str, fields: dict, pk: str = "") -> dict:
             "damage": fields.get("damage_dice") or "",
             "damage_type": fields.get("damage_type") or "",
             "versatile": extra.get("versatile", ""),
+            # #888 (veteran/optimizer Examine depth): the weapon CATEGORY (Simple/Martial,
+            # from the SRD `is_simple` flag) + the 2024 Weapon MASTERY property (Topple/Vex/…)
+            # so the Stash/Market inspector reads "Martial Weapon · Mastery: Sap" — additive.
+            "weapon_category": _weapon_category(fields),
+            "mastery": extra.get("mastery", ""),
             # RRI-25e55fa optimizer #3: the SRD weapon range bracket (0/0 for pure melee).
             **_weapon_range(fields),
         }
@@ -345,6 +370,8 @@ def _flatten(model: str, fields: dict, pk: str = "") -> dict:
         # RRI-25e55fa optimizer #3: a magic weapon inherits its base weapon's range bracket
         # via the same FK (0/0 for a melee polearm — never a fabricated thrown range).
         record.update(_weapon_range(wf))
+        # #888: a magic weapon inherits its base weapon's CATEGORY + MASTERY via the same FK.
+        record["weapon_category"] = _weapon_category(wf)
         # #756: a magic weapon inherits its base weapon's SRD properties + versatile
         # two-handed die via the same FK (de-duped onto the attunement clause above).
         wp = wprops.get(wfk, {})
@@ -353,6 +380,8 @@ def _flatten(model: str, fields: dict, pk: str = "") -> dict:
                 record["properties"].append(chip)
         if wp.get("versatile"):
             record["versatile"] = wp["versatile"]
+        if wp.get("mastery"):
+            record["mastery"] = wp["mastery"]
     afk = fields.get("armor")
     if afk and afk in armors:
         af = armors[afk]

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -166,6 +166,8 @@ class Item(_StrictModel):
     armor_category: str = ""           # light / medium / heavy / shield ("" = n/a)
     ac_dex_mod: str = ""               # full / capped / none ("" = n/a)
     ac_dex_cap: Optional[int] = None   # +N DEX cap for medium armor, else None
+    weapon_category: str = ""          # #888: Simple / Martial weapon-proficiency tier ("" = n/a)
+    mastery: str = ""                  # #888: 2024 Weapon Mastery property (Topple/Vex/Sap/...; "" = none)
     properties: list[str] = Field(default_factory=list)  # SRD tags (stealth-disadvantage, str-13, attune:...)
 
 

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -5886,7 +5886,12 @@ def level_up(
         # finally picks Oath of Devotion at level-up gets Sacred Weapon + Oath Spells AND Aura of
         # Devotion — not just the level-3 pair. _features_gained de-dupes against ch.features below.
         slvl = srd_tables.subclass_level(cname)
-        if subclass_newly_set and slvl is not None and new_class_level > slvl:
+        # Grant EVERY oath/archetype feature owed THROUGH the current level whenever the character
+        # HAS a subclass and is past its choice level — NOT only when it was just set. subclass_at()
+        # returns only the choice-level pair, so a NORMAL-progression Paladin leveling to L7 would
+        # otherwise never gain Aura of Devotion (it's computed by subclass_features_through). The
+        # grant loop below de-dupes by feature name, so re-running it each level-up is idempotent.
+        if cur_subclass and (cur_subclass or "").strip() and slvl is not None and new_class_level > slvl:
             gained = gained + srd_tables.subclass_features_through(cname, cur_subclass, new_class_level)
         for f in gained:
             if f["name"] not in ch.features:

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1215,7 +1215,11 @@ def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool
                         cl.subclass = canonical
                 slvl = srd_tables.subclass_level(cname)
                 if slvl is not None and level >= slvl:
-                    through += srd_tables.subclass_features_at(cname, canonical, slvl)
+                    # #888: grant EVERY subclass feature owed THROUGH this level, not just
+                    # the choice-level pair — a Paladin seated at L10 with Oath of Devotion
+                    # gets Sacred Weapon + Oath Spells (3) AND Aura of Devotion (7), closing
+                    # the optimizer/veteran "L10 Paladin missing 7 levels of subclass features".
+                    through += srd_tables.subclass_features_through(cname, canonical, level)
         for f in through:
             if f["name"] not in ch.features:
                 ch.features.append(f["name"])
@@ -2694,7 +2698,14 @@ def load_canon_character(campaign_id: str, name: str = "", kind: str = "npc", ad
                 lvl = max(1, int(rec.get("level") or 1))
             except (TypeError, ValueError):
                 lvl = 1
-            classes = [ClassLevel(name=str(rec["class"]), level=lvl)]
+            # #888 ADDITIVE: a canon record MAY carry a `subclass` (e.g. a L10 Paladin's
+            # "Oath of Devotion") so the seated figure gets its archetype features THROUGH the
+            # levels (_finish_seat_sheet -> _apply_srd_class_defaults -> subclass_features_through),
+            # instead of standing at L10 with NO Sacred Oath at all. Loosely named values
+            # ('Devotion') are normalized to the canonical SRD name downstream; an absent/unknown
+            # subclass stays free-text and round-trips exactly as before.
+            sub = str(rec.get("subclass") or "").strip()
+            classes = [ClassLevel(name=str(rec["class"]), level=lvl, subclass=sub or None)]
         ch = Character(
             name=canonical,
             # A canon figure can be pulled in as the PROTAGONIST (the player), not just an
@@ -5870,9 +5881,13 @@ def level_up(
         # #624 backfill: a subclass chosen LATE (the missed-choice case — set for
         # the first time at a level PAST the choice level) still grants its
         # choice-level features at the level-up that sets it, not nothing.
+        # #888: grant EVERY oath/archetype feature owed THROUGH the current level (choice-level
+        # pair PLUS each higher feature whose SRD level <= new_class_level), so an L10 Paladin who
+        # finally picks Oath of Devotion at level-up gets Sacred Weapon + Oath Spells AND Aura of
+        # Devotion — not just the level-3 pair. _features_gained de-dupes against ch.features below.
         slvl = srd_tables.subclass_level(cname)
         if subclass_newly_set and slvl is not None and new_class_level > slvl:
-            gained = gained + srd_tables.subclass_features_at(cname, cur_subclass, slvl)
+            gained = gained + srd_tables.subclass_features_through(cname, cur_subclass, new_class_level)
         for f in gained:
             if f["name"] not in ch.features:
                 ch.features.append(f["name"])
@@ -7225,6 +7240,10 @@ def _catalog_item_stats(rec: dict | None) -> dict | None:
         "armor_category": rec.get("armor_category", "") or "",
         "ac_dex_mod": rec.get("ac_dex_mod", "") or "",
         "ac_dex_cap": rec.get("ac_dex_cap"),
+        # #888: persist the weapon CATEGORY (Simple/Martial) + MASTERY property so a renamed/
+        # enchanted weapon the catalog can't resolve by name still carries them on the Item.
+        "weapon_category": rec.get("weapon_category", "") or "",
+        "mastery": rec.get("mastery", "") or "",
         "properties": list(rec.get("properties") or []),  # COPY — never alias the cache list
     }
 

--- a/servers/engine/srd_tables.py
+++ b/servers/engine/srd_tables.py
@@ -183,6 +183,16 @@ _SUBCLASS_FEATURE_LEVELS: dict[tuple[str, str], int] = {
     ("champion", "heroic warrior"): 10,
     ("champion", "superior critical"): 15,
     ("champion", "survivor"): 18,
+    # Paladin — Oath of Devotion (SRD 5.2 / 2024 PHB). The Sacred Oath grants its higher
+    # features at the Paladin subclass-feature levels (7 / 15 / 20 — exactly the
+    # "Subclass Feature" placeholders in class_features.json). Pinning these lets a Paladin
+    # seated/leveled AT or PAST those levels actually receive the oath features it is owed
+    # (the optimizer/veteran "L10 Paladin missing 7 levels of subclass features" finding).
+    # Sacred Weapon + Oath of Devotion Spells are the choice-level (3) features, derived
+    # automatically from subclasses.json — not pinned here.
+    ("oath-of-devotion", "aura of devotion"): 7,
+    ("oath-of-devotion", "smite of protection"): 15,
+    ("oath-of-devotion", "holy nimbus"): 20,
 }
 
 
@@ -301,6 +311,53 @@ def subclass_features_at(class_name: str, subclass: str | None, class_level: int
         if opt["name"] == canonical:
             return [dict(f) for f in opt.get("features", [])]
     return []
+
+
+def subclass_features_through(class_name: str, subclass: str | None, class_level: int) -> list[dict]:
+    """EVERY subclass feature a character is OWED by ``class_level`` — the choice-level
+    features (gained at the subclass-choice level) PLUS each higher archetype feature whose
+    canonical SRD level (from ``_SUBCLASS_FEATURE_LEVELS``) is ``<= class_level``.
+
+    This is the "features populate THROUGH the levels" path (the optimizer/veteran
+    "L10 Paladin has NO Sacred Oath subclass — missing 7 levels of subclass features"
+    finding): a Paladin SEATED at L10 with Oath of Devotion, or one that CHOOSES the oath
+    late at L10, gets Sacred Weapon + Oath of Devotion Spells (choice level 3) AND Aura of
+    Devotion (level 7) — not just the level-3 pair.
+
+    HONEST + additive: a feature with NO verifiable level (``_SUBCLASS_FEATURE_LEVELS`` has
+    no pin and it is not a choice-level feature) is NEVER auto-granted here — we don't
+    fabricate a level to decide it was earned. Empty for no subclass, an unknown subclass,
+    or a level below the subclass-choice level (today's behavior). The list is de-duped by
+    name (choice-level entries win) and ordered by level then name."""
+    canonical = resolve_subclass(class_name, subclass)
+    if not canonical:
+        return []
+    slvl = subclass_level(class_name)
+    if slvl is None or class_level < slvl:
+        return []
+    choice_names = {
+        str(f.get("name", "")).lower()
+        for f in subclass_features_at(class_name, canonical, slvl)
+    }
+    out: list[dict] = []
+    seen: set[str] = set()
+    # Choice-level features first (always owed once past the choice level).
+    for f in subclass_features_at(class_name, canonical, slvl):
+        key = str(f.get("name", "")).lower()
+        if key and key not in seen:
+            seen.add(key)
+            out.append({**dict(f), "level": slvl})
+    # Higher archetype features whose pinned SRD level is at/below this class level.
+    for f in subclass_full_features(class_name, canonical, slvl):
+        key = str(f.get("name", "")).lower()
+        if not key or key in seen or key in choice_names:
+            continue
+        lvl = f.get("level")
+        if isinstance(lvl, int) and slvl < lvl <= class_level:
+            seen.add(key)
+            out.append(dict(f))
+    out.sort(key=lambda f: (f.get("level") or 0, f.get("name", "")))
+    return out
 
 
 def caster_type(name: str) -> str:

--- a/servers/engine/tests/test_canon_abilities.py
+++ b/servers/engine/tests/test_canon_abilities.py
@@ -162,3 +162,49 @@ def test_classless_noncaster_npc_does_not_warn(tmp_path, monkeypatch):
     assert "error" not in res
     assert res["ability_source"] == "placeholder"
     assert res["warnings"] == []
+
+
+# ── #888: a canon record may carry a `subclass`; the seated figure gets it ──────
+
+
+def test_canon_paladin_record_carries_subclass_and_gets_oath_features(tmp_path, monkeypatch):
+    # ADDITIVE canon `subclass` field: a L10 Paladin canon record naming "Oath of Devotion"
+    # seats WITH that oath and its features THROUGH the levels (Sacred Weapon + Oath Spells at
+    # 3, Aura of Devotion at 7) — never an L10 Paladin with NO Sacred Oath. Inject a record via
+    # the content loader so the test owns the data (not coupled to a specific shipped roster name).
+    c = _seed(tmp_path, monkeypatch)
+    record = {"name": "Oathsworn Knight", "class": "Paladin", "subclass": "Oath of Devotion", "level": "10"}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: record)
+    res = server.load_canon_character(c.id, "Oathsworn Knight", kind="player", add_to_party=True)
+    assert "error" not in res
+    ch = server._require(c.id).characters[res["id"]]
+    assert ch.classes[0].subclass == "Oath of Devotion"
+    assert "Sacred Weapon" in ch.features
+    assert "Oath of Devotion Spells" in ch.features
+    assert "Aura of Devotion" in ch.features, "an L10 oath Paladin must seat with Aura of Devotion (7)"
+
+
+def test_canon_record_without_subclass_round_trips_unchanged(tmp_path, monkeypatch):
+    # Additivity: a canon record with NO subclass behaves exactly as before (free-text subclass
+    # stays unset). The seated Paladin is OVERDUE for its oath (surfaced by build_options), not
+    # silently granted one.
+    c = _seed(tmp_path, monkeypatch)
+    record = {"name": "Plain Paladin", "class": "Paladin", "level": "5"}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: record)
+    res = server.load_canon_character(c.id, "Plain Paladin", kind="player", add_to_party=True)
+    assert "error" not in res
+    ch = server._require(c.id).characters[res["id"]]
+    assert not (ch.classes[0].subclass or "")
+    assert "Aura of Devotion" not in ch.features
+
+
+def test_shipped_hellrider_paladin_seats_with_oath_of_devotion(tmp_path, monkeypatch):
+    # End-to-end against the SHIPPED content file (content/worlds/baldurs-gate/characters/
+    # hellrider-paladin.json) — seeded with the oath so a player who seats the canon L10
+    # Hellrider Paladin gets a real Sacred Oath, not a blank one. Guards the content edit.
+    c = _seed(tmp_path, monkeypatch)
+    res = server.load_canon_character(c.id, "Hellrider Paladin", kind="npc")
+    assert "error" not in res, res
+    ch = server._require(c.id).characters[res["id"]]
+    assert ch.classes[0].subclass == "Oath of Devotion"
+    assert "Aura of Devotion" in ch.features

--- a/servers/engine/tests/test_class_features.py
+++ b/servers/engine/tests/test_class_features.py
@@ -362,6 +362,25 @@ def test_create_paladin_at_l10_with_oath_populates_higher_features(cid):
     assert "Holy Nimbus" not in sheet["features"]
 
 
+def test_level_up_existing_oath_paladin_gains_higher_oath_feature(cid):
+    # The verifier-found gap: NORMAL-progression oath features were never granted. A Paladin who
+    # ALREADY has Oath of Devotion at L6 (no Aura yet — Aura lands at 7) must GAIN Aura of Devotion
+    # when leveling 6 -> 7. subclass_features_at(7) returns only the choice-level pair, so the grant
+    # must come from the through-features path, which used to be gated to a NEWLY-set subclass.
+    pid = server.create_character(
+        cid, "Wyll", kind="player", class_name="Paladin", level=6, subclass="Oath of Devotion",
+        abilities={"strength": 16, "charisma": 16, "constitution": 14}, apply_srd_defaults=True,
+    )["id"]
+    before = server.get_character(cid, pid)
+    assert "Aura of Devotion" not in before["features"], "Aura is a level-7 feature; not owed at L6"
+    server.level_up(cid, pid, "Paladin")  # 6 -> 7
+    after = server.get_character(cid, pid)
+    assert after["classes"][0]["level"] == 7
+    assert "Aura of Devotion" in after["features"], "leveling an existing-oath Paladin to 7 must grant Aura of Devotion"
+    # No early fabrication of the 15/20 features.
+    assert "Smite of Protection" not in after["features"]
+
+
 def test_create_paladin_loose_oath_name_normalizes_and_populates(cid):
     # The DM/record may name the oath loosely ("Devotion") — it normalizes to the canonical
     # SRD name and still grants the through-features.

--- a/servers/engine/tests/test_class_features.py
+++ b/servers/engine/tests/test_class_features.py
@@ -307,3 +307,115 @@ def test_preview_subclass_block_is_additive_no_mutation(cid):
     out = server.preview_level_up(cid, wid, "Wizard")  # L1 -> L2, below the choice level
     assert out.get("subclass_choice") is None  # not due yet
     assert server.get_character(cid, wid) == before  # preview never mutates
+
+
+# ── #888 / optimizer+veteran: subclass features populate THROUGH the levels ──────
+# "Level 10 Paladin has NO Sacred Oath subclass — missing 7 levels of subclass
+# features." SRD 5.2 ships exactly ONE shippable Paladin oath (Oath of Devotion),
+# whose higher features land at 7 (Aura of Devotion) / 15 (Smite of Protection) /
+# 20 (Holy Nimbus) — exactly the "Subclass Feature" placeholders. The fix: a
+# Paladin seated/leveled AT or PAST those levels with the oath actually RECEIVES
+# the oath features it is owed, not just the level-3 pair.
+
+
+def test_subclass_features_through_paladin_oath_of_devotion():
+    # The pure table: through L10 an Oath of Devotion Paladin is owed Sacred Weapon +
+    # Oath of Devotion Spells (choice level 3) AND Aura of Devotion (7) — but NOT yet
+    # Smite of Protection (15) or Holy Nimbus (20).
+    through10 = {f["name"]: f.get("level")
+                 for f in srd_tables.subclass_features_through("paladin", "Oath of Devotion", 10)}
+    assert "Sacred Weapon" in through10 and through10["Sacred Weapon"] == 3
+    assert "Oath of Devotion Spells" in through10
+    assert through10.get("Aura of Devotion") == 7, "an L10 oath Paladin is owed Aura of Devotion (7)"
+    assert "Smite of Protection" not in through10  # a level-15 feature isn't owed at 10
+    assert "Holy Nimbus" not in through10           # a level-20 feature isn't owed at 10
+    # …and at L20 it has the FULL oath progression (no fabricated levels).
+    through20 = {f["name"]: f.get("level")
+                 for f in srd_tables.subclass_features_through("paladin", "Devotion", 20)}
+    assert through20.get("Aura of Devotion") == 7
+    assert through20.get("Smite of Protection") == 15
+    assert through20.get("Holy Nimbus") == 20
+
+
+def test_subclass_features_through_below_choice_level_is_empty():
+    # Below the subclass-choice level nothing is owed (additive — today's behavior).
+    assert srd_tables.subclass_features_through("paladin", "Oath of Devotion", 2) == []
+    # an unknown subclass is honest-empty too (never a fabrication)
+    assert srd_tables.subclass_features_through("paladin", "not-an-oath", 10) == []
+
+
+def test_create_paladin_at_l10_with_oath_populates_higher_features(cid):
+    # A Paladin CREATED directly at L10 with Oath of Devotion (the seed path,
+    # _apply_srd_class_defaults) gets the choice-level features AND Aura of Devotion (7) —
+    # the optimizer's "missing 7 levels of subclass features" is closed.
+    pid = server.create_character(
+        cid, "Zevlor", kind="player", class_name="Paladin", level=10, subclass="Oath of Devotion",
+        abilities={"strength": 16, "charisma": 16, "constitution": 14}, apply_srd_defaults=True,
+    )["id"]
+    sheet = server.get_character(cid, pid)
+    assert sheet["classes"][0]["subclass"] == "Oath of Devotion"
+    assert "Sacred Weapon" in sheet["features"]
+    assert "Oath of Devotion Spells" in sheet["features"]
+    assert "Aura of Devotion" in sheet["features"], "an L10 oath Paladin must have Aura of Devotion (7)"
+    # a level-15/20 oath feature is NOT granted early (no fabrication)
+    assert "Smite of Protection" not in sheet["features"]
+    assert "Holy Nimbus" not in sheet["features"]
+
+
+def test_create_paladin_loose_oath_name_normalizes_and_populates(cid):
+    # The DM/record may name the oath loosely ("Devotion") — it normalizes to the canonical
+    # SRD name and still grants the through-features.
+    pid = server.create_character(
+        cid, "Karlach", kind="player", class_name="Paladin", level=10, subclass="Devotion",
+        abilities={"charisma": 16, "constitution": 14}, apply_srd_defaults=True,
+    )["id"]
+    sheet = server.get_character(cid, pid)
+    assert sheet["classes"][0]["subclass"] == "Oath of Devotion"
+    assert "Aura of Devotion" in sheet["features"]
+
+
+def test_level_up_late_oath_choice_populates_through_features(cid):
+    # The "OR" branch the task names: an L10 Paladin with NO oath (overdue) who finally
+    # CHOOSES Oath of Devotion at level-up gets the oath features THROUGH the levels —
+    # Sacred Weapon + Oath Spells AND the already-earned Aura of Devotion (7), not just
+    # the level-3 pair.
+    pid = server.create_character(
+        cid, "Wyll", kind="player", class_name="Paladin", level=10,
+        abilities={"charisma": 16, "constitution": 14}, apply_srd_defaults=True,
+    )["id"]
+    assert "Aura of Devotion" not in server.get_character(cid, pid)["features"]
+    out = server.level_up(cid, pid, "Paladin", subclass="Oath of Devotion")  # -> level 11
+    gained = {f["name"] for f in out["_features_gained"]}
+    assert {"Sacred Weapon", "Oath of Devotion Spells", "Aura of Devotion"} <= gained
+    sheet = server.get_character(cid, pid)
+    assert {"Sacred Weapon", "Oath of Devotion Spells", "Aura of Devotion"} <= set(sheet["features"])
+
+
+def test_update_character_setting_oath_late_populates_through_features(cid):
+    # Setting the oath via update_character on an L10 Paladin (the sheet edit path) re-derives
+    # the class defaults and grants the owed oath features through the levels.
+    pid = server.create_character(
+        cid, "Minsc", kind="player", class_name="Paladin", level=10,
+        abilities={"charisma": 16, "constitution": 14}, apply_srd_defaults=True,
+    )["id"]
+    server.update_character(cid, pid, patch={"subclass": "Oath of Devotion"})
+    sheet = server.get_character(cid, pid)
+    assert sheet["classes"][0]["subclass"] == "Oath of Devotion"
+    assert "Aura of Devotion" in sheet["features"]
+
+
+def test_champion_through_features_unchanged_additive(cid):
+    # Additivity guard: a Fighter created at L10 with Champion now also receives its owed
+    # higher features (Additional Fighting Style 7, Heroic Warrior 10) — the same
+    # through-the-levels grant, proving the change generalizes and isn't Paladin-special.
+    fid = server.create_character(
+        cid, "Lae'zel", kind="player", class_name="Fighter", level=10, subclass="Champion",
+        abilities={"strength": 16, "constitution": 14}, apply_srd_defaults=True,
+    )["id"]
+    sheet = server.get_character(cid, fid)
+    assert "Improved Critical" in sheet["features"]
+    assert "Additional Fighting Style" in sheet["features"]
+    assert "Heroic Warrior" in sheet["features"]
+    # Superior Critical (15) / Survivor (18) are NOT owed at 10 (no fabrication)
+    assert "Superior Critical" not in sheet["features"]
+    assert "Survivor" not in sheet["features"]

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -584,6 +584,23 @@ function itemStatRows(item) {
     const v = item.versatile ? `${dmg} (${item.versatile} two-handed)` : dmg;
     rows.push({ k: "Damage", v });
   }
+  // #888 (veteran/optimizer Examine depth): the SHEET-CORRECT to-hit for THIS weapon in the
+  // owner's pack — the server composes attackBonus as prof + the governing ability mod (Stash
+  // only; the Market has no owner). Rendered only when present (a non-weapon yields null/none).
+  if (typeof item.attackBonus === "number") {
+    rows.push({ k: "Attack", v: (item.attackBonus >= 0 ? "+" : "") + item.attackBonus });
+  }
+  // #888: the weapon CATEGORY (Simple/Martial proficiency tier) so the player can answer "is this
+  // a Martial weapon I'm proficient with?". Server-resolved from the SRD is_simple flag; blank
+  // for non-weapons / unresolved (row hidden — never fabricated).
+  if (item.weaponCategory) {
+    rows.push({ k: "Category", v: item.weaponCategory + " Weapon" });
+  }
+  // #888: the 2024 Weapon MASTERY property (Topple/Vex/Sap/…) — the advanced combat option the
+  // veteran reads on a weapon. Server-resolved from the SRD Mastery assignment; blank when none.
+  if (item.mastery) {
+    rows.push({ k: "Mastery", v: item.mastery });
+  }
   // RRI-25e55fa optimizer #3: a ranged/thrown weapon shows its real range bracket
   // ("100/400 ft"); the server composes rangeDisplay from the SRD weapon range, blank for a
   // pure melee weapon — so the row is rendered ONLY when there is a real bracket (never "0/0 ft").

--- a/viewer/openworlds/screen-merchant.jsx
+++ b/viewer/openworlds/screen-merchant.jsx
@@ -34,6 +34,11 @@ function enrichWare(item, catalog) {
   if (typeof merged.acDexCap !== "number" && typeof rec.acDexCap === "number") merged.acDexCap = rec.acDexCap;
   if (!merged.damage && rec.damage) { merged.damage = rec.damage; merged.damageType = rec.damageType; }
   if (!merged.versatile && rec.versatile) merged.versatile = rec.versatile;
+  // #888: carry the catalog's weapon CATEGORY (Simple/Martial) + 2024 MASTERY property so the
+  // Market inspector reads "Martial Weapon · Mastery: Sap" — Stash/Market parity. The hardcoded
+  // stock never carries these, so fill them (the ware's own value, if any, still wins).
+  if (!merged.weaponCategory && rec.weaponCategory) merged.weaponCategory = rec.weaponCategory;
+  if (!merged.mastery && rec.mastery) merged.mastery = rec.mastery;
   // RRI-25e55fa optimizer #3: carry the catalog's composed weapon range bracket so the Market
   // inspector reads "100/400 ft" for a Heavy Crossbow (the hardcoded stock never carries it).
   if (!merged.rangeDisplay && rec.rangeDisplay) merged.rangeDisplay = rec.rangeDisplay;

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -4224,6 +4224,11 @@ def _catalog_stat_block(name: str) -> dict:
         "acDexMod": ac_dex_mod,
         "acDexCap": ac_dex_cap,
         "acDisplay": _armor_ac_display(ac, armor_category, ac_dex_mod, ac_dex_cap),
+        # #888: the weapon CATEGORY (Simple/Martial) + 2024 MASTERY property (damage-gated:
+        # only meaningful on a weapon) so the Market inspector reads "Martial Weapon · Mastery:
+        # Sap". Empty for non-weapons / unresolved — the screen hides the row (never fabricated).
+        "weaponCategory": _text(meta.get("weapon_category")) if damage else "",
+        "mastery": _text(meta.get("mastery")) if damage else "",
         "attunement": bool(meta.get("requires_attunement")),
         "properties": _catalog_property_chips(meta),
         "description": _text(meta.get("description")),
@@ -4263,6 +4268,49 @@ def _armor_ac_display(ac: "int | None", armor_category: str, ac_dex_mod: str, ac
     if mod == "full":
         return f"AC {ac} + DEX"
     return f"AC {ac}"
+
+
+def _weapon_attack_bonus(ch: dict, item: dict, meta: dict) -> "int | None":
+    """#888 — the SHEET-CORRECT to-hit for a weapon in this owner's pack: proficiency bonus +
+    the governing ability modifier, exactly mirroring the engine's ``_combat_numbers`` rule
+    (server.py) so the Stash Examine reads the SAME number the DM attacks with — never an
+    invented one. The governing ability:
+
+      * FINESSE weapon  -> max(STR, DEX)   (5e finesse: the better of the two)
+      * RANGED weapon   -> DEX             (Ammunition, or a ranged-only weapon with a range
+                                            bracket and NO Thrown property, e.g. a Blowgun)
+      * otherwise melee -> STR             (incl. a Thrown melee weapon like a Javelin)
+
+    Honest + additive: returns None for a NON-weapon (no damage) so the screen hides the row,
+    and matches ``_combat_numbers`` by ALWAYS adding the proficiency bonus (the surfaced "sheet"
+    number the engine itself shows — it does not down-rate for a non-proficient weapon). The
+    +N magic bonus a named weapon ("Longsword +1") implies is NOT folded in (the catalog can't
+    parse it), keeping the number conservative rather than fabricated."""
+    # Only weapons have a to-hit.
+    if not _text(item.get("damage")) and not (meta and _text(meta.get("damage"))):
+        return None
+    abilities = ch.get("abilities") if isinstance(ch.get("abilities"), dict) else {}
+    str_mod = _ability_mod(abilities.get("strength"))
+    dex_mod = _ability_mod(abilities.get("dexterity"))
+    prof = _num(ch.get("proficiency_bonus"))
+    prof = int(prof) if prof is not None else 2
+    # The weapon's SRD properties (persisted on the Item first, else the by-name catalog).
+    raw_props = item.get("properties")
+    if not (isinstance(raw_props, list) and raw_props):
+        raw_props = (meta or {}).get("properties") or []
+    props = {str(p).strip().lower() for p in raw_props}
+    rng = _num(item.get("range"))
+    if rng is None:
+        rng = _num((meta or {}).get("range"))
+    is_finesse = "finesse" in props
+    is_ranged = ("ammunition" in props) or (rng is not None and rng > 0 and "thrown" not in props)
+    if is_finesse:
+        ability_mod = max(str_mod, dex_mod)
+    elif is_ranged:
+        ability_mod = dex_mod
+    else:
+        ability_mod = str_mod
+    return prof + ability_mod
 
 
 def _item_stat_block(item: dict, meta: dict) -> dict:
@@ -4334,6 +4382,11 @@ def _item_stat_block(item: dict, meta: dict) -> dict:
         "acDexMod": ac_dex_mod,
         "acDexCap": ac_dex_cap,
         "acDisplay": _armor_ac_display(ac, armor_category, ac_dex_mod, ac_dex_cap),
+        # #888: weapon CATEGORY (Simple/Martial) + 2024 MASTERY property — persisted-first
+        # (F09-7 Item fields) then by-name catalog fallback, damage-gated. The Stash Examine
+        # depth the veteran/optimizer asked for ("category + Weapon Mastery property").
+        "weaponCategory": pick_str("weapon_category") if damage else "",
+        "mastery": pick_str("mastery") if damage else "",
         "costGp": cost,
         "propertyChips": prop_chips,
     }
@@ -4359,6 +4412,10 @@ def _inventory_items(cid: str, ch: dict) -> list[dict]:
         # HONEST: a datum neither persisted nor resolvable stays empty — never fabricated.
         meta = _catalog_meta(name)
         stats = _item_stat_block(item, meta)
+        # #888: the SHEET-CORRECT to-hit for this weapon in THIS owner's pack (prof + governing
+        # ability mod) — Stash-only (the Market has no owner), the depth the veteran/optimizer
+        # asked for. None for a non-weapon so the row is hidden.
+        attack_bonus = _weapon_attack_bonus(ch, item, meta)
         # Weight prefers the item's recorded value (model default 0.0 -> backfill from catalog).
         weight = _num(item.get("weight"))
         if (weight is None or weight <= 0) and meta:
@@ -4404,6 +4461,12 @@ def _inventory_items(cid: str, ch: dict) -> list[dict]:
             "acDexMod": stats["acDexMod"],
             "acDexCap": stats["acDexCap"],
             "acDisplay": stats["acDisplay"],
+            # #888: weapon CATEGORY (Simple/Martial), 2024 MASTERY property, and the owner's
+            # sheet-correct ATTACK BONUS (to-hit) — the Stash Examine depth the veteran/optimizer
+            # asked for. Empty/None for non-weapons so the screen hides each row (never fabricated).
+            "weaponCategory": stats["weaponCategory"],
+            "mastery": stats["mastery"],
+            "attackBonus": attack_bonus,
             "attunement": attunement,
             "attuned": bool(item.get("attuned")),
             "properties": properties,

--- a/viewer/tests/test_item_inspector.py
+++ b/viewer/tests/test_item_inspector.py
@@ -166,6 +166,59 @@ class ItemInspectorBehaviourTests(unittest.TestCase):
         self.assertEqual(kv["Damage"], "1d4 piercing")
         self.assertNotIn("two-handed", kv["Damage"])
 
+    # --- #888: Stash Examine DEPTH — attack bonus, weapon category, Weapon Mastery ----
+    def test_weapon_inspector_shows_attack_bonus_category_and_mastery(self):
+        """The veteran/optimizer "Stash Examine is SHALLOW — no attack bonus, weapon category,
+        or Mastery property" finding: a weapon inspector must render the sheet-correct to-hit,
+        the Simple/Martial category, and the 2024 Weapon Mastery property."""
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Longsword', type: 'weapon', damage: '1d8', "
+            "  damageType: 'slashing', attackBonus: 6, weaponCategory: 'Martial', mastery: 'Sap' });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Attack"), "+6", "the to-hit must read as a signed bonus")
+        self.assertEqual(kv.get("Category"), "Martial Weapon")
+        self.assertEqual(kv.get("Mastery"), "Sap")
+
+    def test_negative_attack_bonus_renders_with_sign(self):
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Club', type: 'weapon', damage: '1d4', attackBonus: -1 });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Attack"), "-1")
+
+    def test_zero_attack_bonus_still_renders(self):
+        # +0 is a real, meaningful to-hit — it must show (typeof-number gate, not truthiness).
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Sling', type: 'weapon', damage: '1d4', attackBonus: 0 });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Attack"), "+0")
+
+    def test_nonweapon_omits_attack_category_mastery_rows(self):
+        # An item with no weapon stats must NOT fabricate an Attack/Category/Mastery row.
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Healing Potion', type: 'potion', weight: '0.5 lb' });"
+        )
+        keys = {r["k"] for r in rows}
+        self.assertNotIn("Attack", keys)
+        self.assertNotIn("Category", keys)
+        self.assertNotIn("Mastery", keys)
+
+    def test_enrich_ware_folds_category_and_mastery_for_market_parity(self):
+        """Stash/Market parity: the Market ware gains the catalog's weapon category + mastery so
+        the Market inspector reads them too (it carries no owner, so no attack bonus)."""
+        rows = self._run(
+            "var ware = win.enrichWare("
+            "  { name: 'Greataxe', type: 'weapon', weight: '7 lb', price: 30 },"
+            "  { 'Greataxe': { resolved: true, damage: '1d12', damageType: 'slashing',"
+            "      weaponCategory: 'Martial', mastery: 'Cleave', properties: [] } });"
+            "return win.itemStatRows(ware);"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Category"), "Martial Weapon")
+        self.assertEqual(kv.get("Mastery"), "Cleave")
+
     # --- RRI-25e55fa optimizer #3: weapon RANGE + VALUE rows --------------------
     def test_ranged_weapon_shows_range_row(self):
         """A ranged weapon must render a Range row reading its real bracket — the optimizer's
@@ -433,6 +486,24 @@ class ItemInspectorWiringTests(unittest.TestCase):
         self.assertTrue(items["Plate"]["resolved"])
         self.assertEqual(items["Plate"]["ac"], 18)
 
+    # #888: the catalog endpoint (the Market's source of truth) exposes the weapon CATEGORY
+    # (Simple/Martial) + the 2024 Weapon MASTERY property so the Market/Stash inspector can read
+    # them — the veteran/optimizer "Examine missing category + Mastery" finding.
+    def test_item_catalog_endpoint_exposes_weapon_category_and_mastery(self):
+        status, _ctype, body = self._get("/item-catalog?name=Longsword&name=Dagger&name=Studded%20Leather")
+        items = json.loads(body)["items"]
+        ls = items["Longsword"]
+        self.assertTrue(ls["resolved"])
+        self.assertEqual(ls["weaponCategory"], "Martial")
+        self.assertEqual(ls["mastery"], "Sap")   # SRD 5.2 Longsword Mastery is Sap
+        dg = items["Dagger"]
+        self.assertEqual(dg["weaponCategory"], "Simple")
+        self.assertEqual(dg["mastery"], "Nick")
+        # armor carries NO weapon category/mastery (honest empties — the row is hidden)
+        sl = items["Studded Leather"]
+        self.assertEqual(sl["weaponCategory"], "")
+        self.assertEqual(sl["mastery"], "")
+
     # F09-6 / #874: the catalog endpoint (the Market's source of truth) composes the SAME
     # honest armor dex-rule the Stash inspector carries — medium armor reads its DEX cap and
     # a shield reads its bonus, so the Market never re-exhibits the flat "AC 14"/"AC 2" bug.
@@ -490,6 +561,68 @@ class ItemInspectorWiringTests(unittest.TestCase):
         self.assertIn("enrichWare", src)            # …and merges it into the detail pane
         self.assertIn("window.itemStatRows", src)   # rendering the real stat rows (AC/damage)
         self.assertIn("Versus ", src)               # compare block in the Market inspector
+
+
+class StashAttackBonusReadModelTests(unittest.TestCase):
+    """#888: the Stash read-model computes the SHEET-CORRECT to-hit + carries weapon category /
+    mastery for an owner's weapon — exercised directly against the viewer read-model helpers
+    (no HTTP), so the wiring the JSX harness can't see (the owner-aware attack bonus) is proven."""
+
+    # A STR 18 (+4) / DEX 14 (+2), proficiency +3 fighter-ish owner.
+    OWNER = {
+        "abilities": {"strength": 18, "dexterity": 14, "constitution": 14,
+                      "intelligence": 10, "wisdom": 10, "charisma": 10},
+        "proficiency_bonus": 3,
+    }
+
+    def test_str_melee_weapon_attack_bonus(self):
+        # A Longsword (no Finesse, melee) uses STR: +3 prof + 4 STR = +7.
+        item = {"name": "Longsword", "damage": "1d8", "properties": []}
+        meta = server._catalog_meta("Longsword")
+        self.assertEqual(server._weapon_attack_bonus(self.OWNER, item, meta), 7)
+
+    def test_finesse_weapon_uses_better_ability(self):
+        # A Rapier (Finesse) uses max(STR 4, DEX 2) = 4: +3 + 4 = +7 here.
+        item = {"name": "Rapier", "damage": "1d8", "properties": ["Finesse"]}
+        meta = server._catalog_meta("Rapier")
+        self.assertEqual(server._weapon_attack_bonus(self.OWNER, item, meta), 7)
+        # …and a DEX-heavy owner's finesse weapon uses DEX.
+        dexy = {"abilities": {"strength": 8, "dexterity": 18}, "proficiency_bonus": 3}
+        self.assertEqual(server._weapon_attack_bonus(dexy, item, meta), 3 + 4)
+
+    def test_ranged_weapon_uses_dex(self):
+        # A Heavy Crossbow (Ammunition, ranged) uses DEX: +3 + 2 = +5.
+        item = {"name": "Heavy Crossbow", "damage": "1d10", "properties": ["Ammunition"]}
+        meta = server._catalog_meta("Heavy Crossbow")
+        self.assertEqual(server._weapon_attack_bonus(self.OWNER, item, meta), 5)
+
+    def test_thrown_melee_weapon_uses_str(self):
+        # A Javelin (Thrown, not Finesse, not Ammunition) is a STR melee weapon: +3 + 4 = +7.
+        item = {"name": "Javelin", "damage": "1d6", "properties": ["Thrown"]}
+        meta = server._catalog_meta("Javelin")
+        self.assertEqual(server._weapon_attack_bonus(self.OWNER, item, meta), 7)
+
+    def test_non_weapon_has_no_attack_bonus(self):
+        item = {"name": "Healing Potion", "damage": ""}
+        self.assertIsNone(server._weapon_attack_bonus(self.OWNER, item, server._catalog_meta("Healing Potion")))
+
+    def test_inventory_items_carry_attack_bonus_category_mastery(self):
+        # The full read-model projection: an owner holding a Longsword surfaces its to-hit, the
+        # Martial category, and the Sap mastery — the end-to-end Stash Examine depth.
+        ch = {**self.OWNER, "inventory": [{"name": "Longsword"}]}
+        items = server._inventory_items("c1", ch)
+        self.assertEqual(len(items), 1)
+        it = items[0]
+        self.assertEqual(it["attackBonus"], 7)
+        self.assertEqual(it["weaponCategory"], "Martial")
+        self.assertEqual(it["mastery"], "Sap")
+
+    def test_inventory_nonweapon_item_has_null_attack_bonus(self):
+        ch = {**self.OWNER, "inventory": [{"name": "Studded Leather"}]}
+        it = server._inventory_items("c1", ch)[0]
+        self.assertIsNone(it["attackBonus"])
+        self.assertEqual(it["weaponCategory"], "")
+        self.assertEqual(it["mastery"], "")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Persona complaints fixed (2026-06-15 5-persona confirm sweep — optimizer + veteran)

### (1) "Level 10 Paladin has NO Sacred Oath subclass — missing 7 levels of subclass features"
**Investigation:** the seeded canon Paladin (`content/worlds/baldurs-gate/characters/hellrider-paladin.json`, a L10 `Paladin`) carried **no** oath, and even when an oath was *chosen*, only the **level-3** features were granted — the higher already-earned features (Aura of Devotion at 7, etc.) never populated. SRD 5.2 ships exactly **one** shippable Paladin oath, **Oath of Devotion** (others are licensed PHB), whose features land at **3 / 7 / 15 / 20** — exactly the `"Subclass Feature"` placeholders in `class_features.json`. Re-derived against `data/srd/srd524` + the 2024 PHB.

**Fix (additive):**
- `srd_tables.py`: pin the Oath of Devotion feature levels (`aura-of-devotion`→7, `smite-of-protection`→15, `holy-nimbus`→20) and add **`subclass_features_through(class, subclass, level)`** — every archetype feature owed by a class level (choice-level pair PLUS each higher feature whose **verified** SRD level ≤ the level). HONEST: a feature with no verifiable level is never auto-granted.
- `_apply_srd_class_defaults` (seed/from-scratch + `update_character` retier) and the `level_up` late-choice backfill now grant features **through** the level — a Paladin **seated** at L10 with the oath, or one that **chooses** it late, receives Aura of Devotion (7), not just the L3 pair.
- `load_canon_character` reads an **additive canon `subclass`** field; the shipped Hellrider Paladin is seeded with `"Oath of Devotion"` so seating it gives a **real** Sacred Oath. A record **without** a subclass round-trips unchanged — the overdue prompt still fires via `build_options`/`preview_level_up` (the task's "OR" branch; this closes its "once chosen, features populate through the levels" half).

### (2) "Item inspector (Stash/Examine) is SHALLOW — no attack bonus, weapon category, or Mastery property"
#872 enriched the **Market**; the **Stash Examine** was still thin.

**Fix (additive):**
- `itemcatalog.py`: additively expose **`weapon_category`** (Simple/Martial, from the SRD `is_simple` flag) + the **2024 Weapon Mastery** property (Topple/Vex/Sap/…, surfaced separately from the descriptor chips). Re-derived from `data/srd/srd524/Weapon.json` + `WeaponProperty*`.
- `Item` model + `add_item`/`buy_item` persist `weapon_category` + `mastery` (round-trip safe).
- viewer read-model: the **Stash** now carries the **sheet-correct attack bonus** (prof + governing ability mod, mirroring engine `_combat_numbers`: finesse→max(STR,DEX), ranged→DEX, else STR), the **category**, and the **mastery**; the **Market** gains category + mastery for parity (no owner → no attack bonus). `screen-inventory.jsx` renders **Attack / Category / Mastery** rows; `enrichWare` folds category+mastery.

## Invariants honored
Additive-by-default (empty == today; old snapshots round-trip; `_StrictModel extra=forbid` intact). Engine = sole writer; viewer read-only (React text nodes). SRD 5.2 re-derived against `data/srd`. Wire contracts frozen. The catalog read-endpoint (`/item-catalog`) gained additive fields defaulting to today.

## Tests
- Engine: **2703 passed** (`-p no:xdist`). New in `test_class_features.py` (subclass_features_through, seeded L10 oath Paladin, loose-name normalize, late level-up choice, update_character set, Champion through-features additivity) + `test_canon_abilities.py` (canon `subclass` field, no-subclass round-trip, shipped Hellrider Paladin seats with the oath).
- Viewer: **593 passed, 1 skipped, 53 subtests** (`viewer/tests/`). New in `test_item_inspector.py` — JSX-harness rows (Attack/Category/Mastery, signed/zero/negative bonus, non-weapon omission, Market parity) + read-model unit tests (`_weapon_attack_bonus` STR/finesse/ranged/thrown, `_inventory_items` wiring) + `/item-catalog` endpoint category+mastery guard.
- `qa/fast_gate.sh` **T0 PASS** (218). `scripts/license_check.py` passed.

DO NOT MERGE — review per the dev loop.