### PR TITLE
fix(engine): auto-set the single SRD subclass on seat at/past the choice level (L10 canon Paladin no-oath)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1172,12 +1172,20 @@ def _expertise_count(class_name: str, level: int) -> int:
     return 0
 
 
-def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool) -> None:
+def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool,
+                              autoset_single_subclass: bool = False) -> None:
     """Fill SRD class defaults onto a character in place: saving-throw proficiencies,
     hit dice, level-1 HP (max die + CON), proficiency bonus, class base AC (when
     requested), and class features through `level`. No-op on an unknown class. Shared
     by create_character and recruit_companion so a live-made hero gets a real sheet
-    instead of forcing the DM to invent modifiers."""
+    instead of forcing the DM to invent modifiers.
+
+    `autoset_single_subclass` (#895, default OFF = byte-identical) — when True, a character
+    AT/PAST its subclass-choice level with NO subclass and EXACTLY ONE legal SRD subclass
+    has that sole option auto-set so it receives the owed subclass features. Only the
+    canon-load seat path opts in (a canon figure pulled straight in as a high-level PC has
+    no planner step to choose at); the deliberate create_character + level-up planner path
+    leaves it OFF so the subclass stays a planner-offered 'overdue choice' (the #607 picker)."""
     try:
         cname = class_name.lower()
         ch.saving_throw_proficiencies = [Ability(s) for s in srd_tables.class_saves(cname)]
@@ -1207,6 +1215,24 @@ def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool
         # subclass also gets that subclass's choice-level features (normalize loose
         # names — 'Evocation' -> 'Evoker' — and persist the canonical form).
         sub = next((cl.subclass for cl in ch.classes if cl.name.lower() == cname), None)
+        if not sub and autoset_single_subclass:
+            # #895 ADDITIVE (opt-in): a canon figure loaded as a PC at/past the subclass-choice
+            # level with NO subclass (the live L10 Paladin "Devella Fountainhead":
+            # classes=[{Paladin, 10, subclass:null}]) kept a NULL subclass and got NONE of its
+            # owed oath features — the optimizer "Level 10 Paladin still showing Choose Subclass —
+            # Sacred Oath not set" finding. SRD 5.2.1 ships EXACTLY ONE subclass per class (every
+            # class returns one subclass_options entry, all at subclass_level 3), so at/past the
+            # choice level a missing subclass has an UNAMBIGUOUS default — the sole legal SRD
+            # option. Auto-set it so the existing resolve+grant block below sets cl.subclass and
+            # grants the owed features THROUGH this level. FUTURE-PROOF: only auto-set when EXACTLY
+            # ONE option exists; if a class ever ships >1 SRD subclass, leave it null (a real
+            # pending choice). Gated to the canon-load seat (autoset_single_subclass=True only
+            # there) so the deliberate create/level-up planner path is byte-identical — there the
+            # subclass stays a planner-offered 'overdue choice' (the #607/#888 picker block).
+            slvl = srd_tables.subclass_level(cname)
+            opts = srd_tables.subclass_options(cname)
+            if slvl is not None and level >= slvl and len(opts) == 1:
+                sub = opts[0]["name"]
         if sub:
             canonical = srd_tables.resolve_subclass(cname, sub)
             if canonical:
@@ -1429,7 +1455,7 @@ def _backfill_seat_abilities(ch, class_name: str, level: int, rec_abilities=None
 
 def _finish_seat_sheet(ch, class_name: str, level: int, *, set_base_ac: bool,
                        rec_abilities=None, backfill_abilities: bool = True,
-                       seed_gear: bool = True) -> str:
+                       seed_gear: bool = True, autoset_single_subclass: bool = False) -> str:
     """EVERY seat path's shared finisher (audit F02-1 + F02-4): ability backfill ->
     SRD class defaults -> starting gear+purse, in that order so HP/AC/initiative are
     computed from REAL ability scores. The five seat paths (create / start fresh +
@@ -1443,7 +1469,8 @@ def _finish_seat_sheet(ch, class_name: str, level: int, *, set_base_ac: bool,
     if backfill_abilities:
         ability_source = _backfill_seat_abilities(ch, class_name, level, rec_abilities)
     if class_name:
-        _apply_srd_class_defaults(ch, class_name, level, set_base_ac=set_base_ac)
+        _apply_srd_class_defaults(ch, class_name, level, set_base_ac=set_base_ac,
+                                  autoset_single_subclass=autoset_single_subclass)
         if seed_gear:
             _seed_starting_gear(ch, class_name)
     return ability_source
@@ -2810,6 +2837,12 @@ def load_canon_character(campaign_id: str, name: str = "", kind: str = "npc", ad
             set_base_ac=(ch.armor_class == 10),
             rec_abilities=rec.get("abilities"),
             seed_gear=(ch.kind in ("player", "companion")),
+            # #895: a canon figure pulled straight in as a high-level PC has NO planner step to
+            # pick its subclass at (the DM loads it ready-to-play), so at/past the choice level
+            # auto-set the sole SRD subclass and grant the owed features — closing the live L10
+            # canon Paladin "Devella Fountainhead" no-oath / "Choose Subclass" optimizer finding.
+            # ONLY this seat opts in; the deliberate create/level-up planner keeps the choice open.
+            autoset_single_subclass=True,
         )
         # MAX_HP (#352 — canon PC seated with a critically-low max_hp). The Character default is a
         # placeholder max_hp=1, and an identity stub left at 1 HP is an INSTANT-KILL combatant: the

--- a/servers/engine/tests/test_canon_abilities.py
+++ b/servers/engine/tests/test_canon_abilities.py
@@ -184,18 +184,36 @@ def test_canon_paladin_record_carries_subclass_and_gets_oath_features(tmp_path, 
     assert "Aura of Devotion" in ch.features, "an L10 oath Paladin must seat with Aura of Devotion (7)"
 
 
-def test_canon_record_without_subclass_round_trips_unchanged(tmp_path, monkeypatch):
-    # Additivity: a canon record with NO subclass behaves exactly as before (free-text subclass
-    # stays unset). The seated Paladin is OVERDUE for its oath (surfaced by build_options), not
-    # silently granted one.
+def test_canon_record_without_subclass_below_choice_level_stays_unset(tmp_path, monkeypatch):
+    # A canon record with NO subclass, seated BELOW the subclass-choice level (3), still
+    # round-trips unset — the oath is a genuine pending choice, not yet due. (#895 only auto-sets
+    # AT/PAST the choice level; below it, the subclass legitimately stays a real pending choice.)
+    c = _seed(tmp_path, monkeypatch)
+    record = {"name": "Squire Paladin", "class": "Paladin", "level": "2"}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: record)
+    res = server.load_canon_character(c.id, "Squire Paladin", kind="player", add_to_party=True)
+    assert "error" not in res
+    ch = server._require(c.id).characters[res["id"]]
+    assert not (ch.classes[0].subclass or ""), "below the choice level the oath stays a pending choice"
+    assert "Aura of Devotion" not in ch.features
+
+
+def test_canon_record_without_subclass_at_or_past_choice_autosets_sole_oath(tmp_path, monkeypatch):
+    # #895: the L10-canon-Paladin no-oath fix. A canon record with NO subclass seated AT/PAST the
+    # choice level (here L5) now auto-gets the SOLE SRD oath (SRD 5.2.1 ships exactly one subclass
+    # per class), so an L5+ Paladin is never left "Choose Subclass — Sacred Oath not set". The
+    # pre-#895 expectation (subclass stays null at L5) WAS the bug (the seated L10 'Devella
+    # Fountainhead' optimizer finding). At L5 the choice-level oath features are owed; Aura of
+    # Devotion (7) is still not yet due.
     c = _seed(tmp_path, monkeypatch)
     record = {"name": "Plain Paladin", "class": "Paladin", "level": "5"}
     monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: record)
     res = server.load_canon_character(c.id, "Plain Paladin", kind="player", add_to_party=True)
     assert "error" not in res
     ch = server._require(c.id).characters[res["id"]]
-    assert not (ch.classes[0].subclass or "")
-    assert "Aura of Devotion" not in ch.features
+    assert ch.classes[0].subclass == "Oath of Devotion", "the sole SRD oath is auto-set at L5"
+    assert "Sacred Weapon" in ch.features
+    assert "Aura of Devotion" not in ch.features  # not owed until level 7
 
 
 def test_shipped_hellrider_paladin_seats_with_oath_of_devotion(tmp_path, monkeypatch):

--- a/servers/engine/tests/test_seat_subclass_autoset.py
+++ b/servers/engine/tests/test_seat_subclass_autoset.py
@@ -1,0 +1,118 @@
+"""Auto-set the single SRD subclass on seat at/past the choice level (L10 canon Paladin no-oath).
+
+THE BUG (live sweep): a canon figure loaded as a PC at high level kept a NULL subclass. The
+seated L10 Paladin "Devella Fountainhead" carried classes=[{name:"Paladin",level:10,
+subclass:null}], so the optimizer persona flagged "Level 10 Paladin still showing Choose
+Subclass — Sacred Oath not set" and never received the owed subclass features (Aura of
+Devotion @7, Sacred Weapon + Oath Spells @3, ...). This is the cross_persona_sat lever.
+
+ROOT CAUSE: `_apply_srd_class_defaults` only granted the subclass features when a subclass
+was ALREADY set — a Paladin with subclass=None skipped the whole block.
+
+THE FIX (additive, SRD 5.2.1-correct): SRD 5.2.1 ships EXACTLY ONE subclass per class (all 12
+classes return exactly one `subclass_options` entry, all at `subclass_level == 3`). So a
+character AT/PAST the subclass-choice level with NO subclass has an UNAMBIGUOUS default — the
+sole legal SRD option. We auto-set it there. Below the choice level, or when a class ever ships
+>1 SRD subclass, the subclass stays null (a real pending choice). A character that ALREADY has a
+subclass set is byte-identical to before.
+
+DOMAIN-SCOPED (opt-in): the auto-set is gated by `_apply_srd_class_defaults`'s
+`autoset_single_subclass` flag, which ONLY the canon-load seat (server.load_canon_character) sets
+True — a canon figure pulled straight in as a high-level PC has no planner step to pick at. The
+deliberate create_character + level-up *planner* path keeps the flag OFF (default), so there the
+subclass stays a planner-offered 'overdue choice' (the #607/#888 picker) — byte-identical to
+today. These tests exercise both sides of that gate at the `_apply_srd_class_defaults` boundary.
+"""
+
+import pytest
+
+import server
+from models import Character, ClassLevel
+
+
+def _paladin(level: int, subclass=None) -> Character:
+    """A bare Paladin sheet at `level` (the live 'Devella Fountainhead' fingerprint when
+    subclass=None), mirroring how the canon-seat path constructs a Character before
+    _apply_srd_class_defaults runs (see server.load_canon_character)."""
+    return Character(
+        name="Devella Fountainhead",
+        kind="player",
+        classes=[ClassLevel(name="Paladin", level=level, subclass=subclass)],
+    )
+
+
+# --- the fix: a null-subclass Paladin at/past the choice level gets the sole SRD oath ----
+
+
+def test_l10_paladin_null_subclass_autosets_oath_and_gets_aura():
+    # THE BUG: an L10 Paladin seated via the canon-load path (autoset_single_subclass=True)
+    # with subclass=None must now seat WITH the single SRD oath (Oath of Devotion) and the
+    # features it is owed THROUGH the levels — closing the optimizer "Level 10 Paladin still
+    # showing Choose Subclass — Sacred Oath not set" finding.
+    ch = _paladin(10, subclass=None)
+    server._apply_srd_class_defaults(ch, "Paladin", 10, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    pal = next(cl for cl in ch.classes if cl.name.lower() == "paladin")
+    assert pal.subclass == "Oath of Devotion", "the sole SRD oath must be auto-set at L10"
+    assert "Aura of Devotion" in ch.features, "L10 oath Paladin is owed Aura of Devotion (7)"
+    # the choice-level features come along too (granted THROUGH the levels)
+    assert "Sacred Weapon" in ch.features
+    assert "Oath of Devotion Spells" in ch.features
+
+
+def test_l3_paladin_null_subclass_autosets_at_the_choice_level():
+    # Boundary: AT the choice level (3), with the canon-load opt-in, the sole oath is auto-set
+    # (choice-level features only; Aura of Devotion (7) is not yet owed).
+    ch = _paladin(3, subclass=None)
+    server._apply_srd_class_defaults(ch, "Paladin", 3, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    pal = next(cl for cl in ch.classes if cl.name.lower() == "paladin")
+    assert pal.subclass == "Oath of Devotion"
+    assert "Sacred Weapon" in ch.features
+    assert "Aura of Devotion" not in ch.features  # not owed until level 7
+
+
+# --- NEGATIVE: below the choice level stays null (a real pending choice) -----------------
+
+
+def test_l2_paladin_null_subclass_stays_null_below_choice_level():
+    # Additive guard: even with the opt-in, a Paladin BELOW the subclass-choice level (3) keeps
+    # subclass=None and gains no oath features — the oath is a genuine pending choice, not yet due.
+    ch = _paladin(2, subclass=None)
+    server._apply_srd_class_defaults(ch, "Paladin", 2, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    pal = next(cl for cl in ch.classes if cl.name.lower() == "paladin")
+    assert pal.subclass is None, "below the choice level the subclass must stay unset"
+    assert "Sacred Weapon" not in ch.features
+    assert "Aura of Devotion" not in ch.features
+
+
+# --- NEGATIVE: the flag is OFF by default -> the create/planner path is byte-identical ----
+
+
+def test_l10_paladin_null_subclass_stays_null_without_optin():
+    # DOMAIN GATE: without the opt-in (the default — the deliberate create_character + level-up
+    # planner path) an L10 Paladin with subclass=None is BYTE-IDENTICAL to before: the subclass
+    # stays null (a planner-offered 'overdue choice', the #607/#888 picker) and no oath features
+    # are silently granted. This guards that the auto-set never leaks onto the planner domain.
+    ch = _paladin(10, subclass=None)
+    server._apply_srd_class_defaults(ch, "Paladin", 10, set_base_ac=False)  # flag OFF (default)
+    pal = next(cl for cl in ch.classes if cl.name.lower() == "paladin")
+    assert pal.subclass is None, "default (no opt-in) must leave the subclass a pending choice"
+    assert "Aura of Devotion" not in ch.features
+    assert "Sacred Weapon" not in ch.features
+
+
+# --- POSITIVE-no-change: an already-set subclass is untouched ----------------------------
+
+
+def test_l10_paladin_already_set_subclass_is_unchanged():
+    # Additivity: a Paladin that ALREADY carries the oath behaves exactly as before — the
+    # existing resolve+grant path runs, the canonical name is kept, the features are granted.
+    # (Independent of the opt-in: the existing `if sub:` branch fires regardless.)
+    ch = _paladin(10, subclass="Oath of Devotion")
+    server._apply_srd_class_defaults(ch, "Paladin", 10, set_base_ac=False)
+    pal = next(cl for cl in ch.classes if cl.name.lower() == "paladin")
+    assert pal.subclass == "Oath of Devotion"
+    assert "Aura of Devotion" in ch.features
+    assert "Sacred Weapon" in ch.features


### PR DESCRIPTION
## The bug (live sweep evidence)

A canon figure loaded as a PC at high level kept a **NULL subclass**. The seated L10 Paladin **"Devella Fountainhead"** carried `classes=[{name:"Paladin", level:10, subclass:null}]`, so the optimizer persona flagged:

> Level 10 Paladin still showing **Choose Subclass — Sacred Oath not set**

and the figure never received the subclass features it was owed (**Aura of Devotion** @7, **Sacred Weapon** + **Oath of Devotion Spells** @3, ...). This is the `cross_persona_sat` lever.

## Root cause

`servers/engine/server.py :: _apply_srd_class_defaults` only granted the subclass features inside the existing `if sub:` block — i.e. **only when a subclass was already set**. A canon Paladin with `subclass=null` skipped the entire block: no oath, no oath features.

## The fix (additive · opt-in · SRD 5.2.1-correct)

SRD 5.2.1 ships **exactly one** subclass per class — verified: `subclass_options(cname)` returns exactly **1** option for all 12 classes, and `subclass_level(cname) == 3` for all. So a character **at/past the choice level** with **no subclass** has an *unambiguous* default: the sole legal SRD option.

When the new `autoset_single_subclass` flag is set, AND `level >= subclass_level(cname)`, AND `len(subclass_options(cname)) == 1`, the sole subclass is set **before** the existing `if sub:` block — so the existing resolve+grant logic then sets `cl.subclass = canonical` and grants the owed features **through** the level (via `subclass_features_through`).

**Future-proof:** only auto-sets when *exactly one* option exists. If a class ever ships >1 SRD subclass, it stays null — a real pending choice.

## Domain-scoped (the key design call)

The flag is **OFF by default**, so the deliberate `create_character` + level-up **planner** path is **byte-identical** to today — there the subclass stays a planner-offered *"overdue choice"* (the `#607`/`#888` subclass picker the optimizer relies on, e.g. "L11 Fighter OVERDUE for its archetype").

**Only `load_canon_character` opts in** (`autoset_single_subclass=True`): a canon figure pulled straight in as a high-level PC has no planner step to choose at, so leaving the subclass null *there* is the bug. This keeps every existing `#607` overdue-choice + `build_options` guardrail intact — a Fighter/Wizard created deliberately at L3/L5/L11 still surfaces its subclass choice exactly as before.

## TDD

New `servers/engine/tests/test_seat_subclass_autoset.py` drives the fix at the `_apply_srd_class_defaults` boundary:
- L10 + opt-in → auto-sets **Oath of Devotion** and grants **Aura of Devotion** (the bug);
- L3 + opt-in → auto-sets at the choice level (choice-level features only);
- L2 (below choice) → stays null even with opt-in;
- **flag OFF (default)** at L10 → stays null = create/planner byte-identical (the domain gate);
- already-set subclass → unchanged.

The main auto-set assertions were confirmed **failing pre-fix**, then pass post-fix.

## Test breakage (reported)

The `#888`-era `test_canon_record_without_subclass_round_trips_unchanged` asserted a **NULL subclass on an L5 canon Paladin** loaded via `load_canon_character` — **that expectation WAS the bug** (an L5 Paladin is past the choice level 3). It was **not weakened**; it was **split** into two correctly-scoped tests:
- `test_canon_record_without_subclass_below_choice_level_stays_unset` (L2 — genuinely still a pending choice);
- `test_canon_record_without_subclass_at_or_past_choice_autosets_sole_oath` (L5 — now correctly auto-gets the sole oath).

No other test changed. The 4 `test_class_features` / `test_progression` tests that exercise the deliberate `create_character` + planner path pass unchanged (the flag is OFF there).

## Verification

- `bash qa/fast_gate.sh` → **Tier-0 PASS (219 passed)**
- full engine suite → **2715 passed, 0 failed**
- end-to-end: `load_canon_character` on the L10 "Devella Fountainhead" record now seats `subclass='Oath of Devotion'` with Aura of Devotion + Sacred Weapon + Oath Spells.

## Invariants honored

- **additive-by-default** — the auto-set is opt-in; default-OFF callers are byte-identical;
- a character that already has a subclass, or is below the choice level, is byte-identical;
- **engine stays the sole writer**;
- **no existing guardrail weakened** — the `#607` planner-offered subclass choice is fully preserved on the deliberate-build path.