### PR TITLE
fix(engine): fold SRD armor stealth-disadvantage + STR-requirement into the item resolve path (inspector)

### DIFF
--- a/servers/engine/itemcatalog.py
+++ b/servers/engine/itemcatalog.py
@@ -389,6 +389,14 @@ def _flatten(model: str, fields: dict, pk: str = "") -> dict:
         record["ac"] = ac_base
         # F09-6: a magic armor inherits its base armor's DEX-mod rule via the FK join.
         record.update(_armor_dex_rule(af, ac_base, record["name"]))
+        # An Item/MagicItem armor inherits its base armor's SRD stealth-disadvantage
+        # + STR-requirement via the same FK (mirrors the model=="armor" path above;
+        # SRD Armor: e.g. Chain Mail grants_stealth_disadvantage=true str=13). De-duped
+        # onto any prior props, like the weapon-FK block just above.
+        if af.get("grants_stealth_disadvantage") and "stealth-disadvantage" not in record["properties"]:
+            record["properties"].append("stealth-disadvantage")
+        if af.get("strength_score_required") and f"str-{af['strength_score_required']}" not in record["properties"]:
+            record["properties"].append(f"str-{af['strength_score_required']}")
     elif fields.get("armor_class"):
         # Homebrew/inline armor_class with no DEX-rule data: keep the bare AC. Without
         # ac_add_dexmod we can't infer the category — leave the rule keys absent so the

--- a/servers/engine/tests/test_armor_props_fold.py
+++ b/servers/engine/tests/test_armor_props_fold.py
@@ -1,0 +1,48 @@
+"""Item armor-FK resolve path must fold the SRD armor's stealth/STR props.
+
+`itemcatalog.resolve("Chain Mail")` resolves via the Item.json record, whose
+`armor` FK joins to the bare Armor.json row. That FK block folded AC + the
+DEX-mod rule but DROPPED the armor's stealth-disadvantage + STR-requirement —
+so the viewer item inspector rendered Chain Mail with no STR-req/stealth pill.
+The `model == "armor"` path already builds those two props; this mirrors them
+onto the Item armor-FK path. Additive: an armor whose SRD source has
+stealth=false/str=null gains no pill.
+"""
+
+import itemcatalog
+
+
+def test_chain_mail_folds_stealth_disadvantage_and_str_req():
+    # SRD Armor.json: Chain Mail grants_stealth_disadvantage=true,
+    # strength_score_required=13 — both must surface as inspector pills.
+    rec = itemcatalog.resolve("Chain Mail")
+    assert rec is not None
+    assert rec["kind"] == "armor"
+    assert "stealth-disadvantage" in rec["properties"]
+    assert "str-13" in rec["properties"]
+
+
+def test_breastplate_has_no_stealth_or_str_pill():
+    # SRD: Breastplate is stealth=false / str=null — additive fix must NOT
+    # fabricate a pill for it.
+    rec = itemcatalog.resolve("Breastplate")
+    assert rec is not None
+    assert rec["kind"] == "armor"
+    assert not any(p == "stealth-disadvantage" or p.startswith("str-")
+                   for p in rec["properties"])
+
+
+def test_light_armor_has_no_stealth_or_str_pill():
+    # Light armor (Leather) is stealth=false / str=null — clean inspector.
+    rec = itemcatalog.resolve("Leather Armor")
+    assert rec is not None
+    assert rec["kind"] == "armor"
+    assert not any(p == "stealth-disadvantage" or p.startswith("str-")
+                   for p in rec["properties"])
+
+
+def test_stealth_str_pills_are_not_duplicated():
+    # De-dup guard: each pill appears at most once.
+    rec = itemcatalog.resolve("Chain Mail")
+    assert rec["properties"].count("stealth-disadvantage") == 1
+    assert rec["properties"].count("str-13") == 1


### PR DESCRIPTION
## What

`itemcatalog.resolve("Chain Mail")` returned `properties: []` — it **dropped** the SRD armor's stealth-disadvantage + STR-requirement. The viewer item inspector (`viewer/openworlds/screen-inventory.jsx` ~723/814) already renders `item.properties` as pills, so this was **engine-only**: once `resolve()` returns the props, they display.

## Root cause

`servers/engine/itemcatalog.py` — the Item/MagicItem armor-FK block folded **AC + the DEX rule** from the joined `Armor.json` row but **not** the armor's stealth/STR props. The `model == "armor"` path already builds them; the FK path didn't mirror them.

## Fix (additive)

Fold the **same two props** the `model=="armor"` path builds onto the Item armor-FK `record["properties"]`, de-duped (mirroring the weapon-FK block just above):

```python
if af.get("grants_stealth_disadvantage") and "stealth-disadvantage" not in record["properties"]:
    record["properties"].append("stealth-disadvantage")
if af.get("strength_score_required") and f"str-{af['strength_score_required']}" not in record["properties"]:
    record["properties"].append(f"str-{af['strength_score_required']}")
```

SRD source truth (`data/srd/srd524/Armor.json`): Chain Mail `grants_stealth_disadvantage=true` `strength_score_required=13`; Ring Mail/Scale Mail stealth=true str=null; Breastplate/Leather stealth=false str=null.

## Invariants

- **Additive**: an armor whose SRD source has stealth=false/str=null is unchanged → no pill added (Breastplate, Leather stay clean).
- **De-duped**: nothing doubles.
- **No wire/schema change.** No guardrail test weakened.

## TDD

New `servers/engine/tests/test_armor_props_fold.py`:
- `test_chain_mail_folds_stealth_disadvantage_and_str_req` — asserts both `stealth-disadvantage` + `str-13` pills (this **FAILED pre-fix**: `assert 'stealth-disadvantage' in []`).
- `test_breastplate_has_no_stealth_or_str_pill` — negative: Breastplate (stealth=false/str=null) gets no pill.
- `test_light_armor_has_no_stealth_or_str_pill` — negative: Leather Armor stays clean.
- `test_stealth_str_pills_are_not_duplicated` — de-dup guard.

## Verification

- `uv run --directory servers/engine python -m pytest tests/test_armor_props_fold.py -q -p no:xdist` → **4 passed**
- Full `tests/test_itemcatalog.py` → **76 passed** (72 existing + 4 new)
- `bash qa/fast_gate.sh` → **FAST-GATE T0 PASS** (219 passed)
- No existing test breakage. No existing test asserted Chain Mail had no props.