### PR TITLE
test(engine): lock F02-6 additive invariant — non-CON ASI/patch leaves max HP unchanged (#794)

### DIFF
--- a/servers/engine/tests/test_progression_integrity.py
+++ b/servers/engine/tests/test_progression_integrity.py
@@ -179,6 +179,35 @@ def test_explicit_max_hp_in_same_patch_wins_over_con_retro():
     assert out["max_hp"] == 99  # DM-authored HP wins; no retro on top
 
 
+def test_non_con_asi_on_level_up_adds_only_the_normal_gain():
+    # Guardrail for the additive-by-default invariant: a NON-CON ASI (STR) leaves the CON
+    # modifier untouched, so the retro term is exactly 0 — the new level adds only its normal
+    # gain (avg + CON mod), never a spurious retro adjustment. A CON ASI moving HP must NOT
+    # mean every ASI moves HP.
+    cid = server.create_campaign("strasi")["id"]
+    fid = server.create_character(cid, "Sword", kind="player", class_name="Fighter",
+                                  apply_srd_defaults=True, abilities={"constitution": 14})["id"]
+    server.level_up(cid, fid, "Fighter")  # L2
+    server.level_up(cid, fid, "Fighter")  # L3
+    before = server.get_character(cid, fid)["max_hp"]
+    out = server.level_up(cid, fid, "Fighter", asi={"strength": 2})  # L4, CON unchanged
+    # Fighter d10 + CON 14 (+2): the L4 gain is avg 6 + 2 = 8, with NO retro term.
+    assert out["abilities"]["constitution"] == 14  # CON untouched
+    assert out["max_hp"] == before + 8
+
+
+def test_non_con_patch_leaves_max_hp_unchanged():
+    # A patch that changes a non-CON ability (STR) must not perturb max HP at all — the CON-retro
+    # branch is gated on a CON-modifier delta, so a STR edit is a pure no-op for HP.
+    cid = server.create_campaign("strpatch")["id"]
+    fid = server.create_character(cid, "Lift", kind="player", class_name="Fighter",
+                                  level=5, apply_srd_defaults=True,
+                                  abilities={"strength": 14, "constitution": 14})["id"]
+    before = server.get_character(cid, fid)["max_hp"]
+    out = server.update_character(cid, fid, {"abilities": {"strength": 16}})
+    assert out["max_hp"] == before  # non-CON ability change leaves HP exactly as it was
+
+
 # --------------------------------------------------------------------------- #
 # F02-3 / F02-15 — pending-choice ledger + feat surfacing                      #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Adds two regression-lock guardrail tests for **F02-6** (#794) — the CON-HP retro-adjustment — covering the one TDD scenario the audit named but that had no dedicated HP assertion: **"a non-CON ASI leaves HP unchanged."**

## Background

The F02-6 fix itself (CON-raising ASI never retro-adjusted max HP; level-gain used pre-ASI CON) **already landed in #856** via a delta-based retro adjustment:

```
max_hp += (con_mod_after - con_mod_before) * prior_total_level
```

applied consistently across `level_up` (server.py:5860-5923), `level_up_preview` (6077-6123), and `update_character` (3055-3068). The existing `test_progression_integrity.py` cluster covers the positive cases (CON-ASI on level-up, CON-patch up/down, preview/actual parity, explicit-max_hp-wins).

The audit's TDD strategy (`docs/audits/ENGINE-AUDIT-2026-06-11.md` Part C, F02-6) explicitly listed **"a non-CON ASI leaves HP unchanged"** as a required case. The existing STR-ASI test (`test_taking_asi_does_not_record_debt`) only asserted the pending-choice ledger, not the HP arithmetic — so the additive-by-default invariant on the non-CON path was unprotected.

## Change (additive, tests only)

- `test_non_con_asi_on_level_up_adds_only_the_normal_gain` — a STR ASI at L4 adds only the normal level gain (avg 6 + CON 2 = 8); the retro term is exactly 0 because CON is untouched.
- `test_non_con_patch_leaves_max_hp_unchanged` — a STR patch via `update_character` is a pure HP no-op (the retro branch is gated on a CON-modifier delta).

No production code is touched.

## Verification

- `uv run --directory servers/engine python -m pytest tests/test_progression_integrity.py -q -p no:xdist` → **22 passed** (20 existing + 2 new).
- `bash qa/fast_gate.sh` → **PASS (219 passed)**.
- **Mutation-verified non-vacuous:** forcing the retro term to fire on any ability patch (`con_delta = 1`) makes `test_non_con_patch_leaves_max_hp_unchanged` fail `49 != 44`; reverting restores green.

## Invariants

Additive-by-default (old snapshots round-trip; no production code changed), engine stays sole-writer, no wire-contract change, no guardrail weakened or deleted.