### PR TITLE
fix(engine): reconcile Barbarian rage-uses to the single SRD-5.2 source (audit F02-11, #794)

### DIFF
--- a/data/srd/class_features.json
+++ b/data/srd/class_features.json
@@ -1,7 +1,7 @@
 {
   "barbarian": {
     "1": [
-      {"name": "Rage", "desc": "Bonus action; advantage on Str checks/saves, bonus melee damage, resist bludgeoning/piercing/slashing. Lasts 1 min.", "rage_damage": 2, "rage_uses": 2},
+      {"name": "Rage", "desc": "Bonus action; advantage on Str checks/saves, bonus melee damage, resist bludgeoning/piercing/slashing. Lasts 1 min."},
       {"name": "Unarmored Defense", "desc": "While not wearing armor, AC equals 10 + Dex mod + Con mod. Can use a shield."},
       {"name": "Weapon Mastery", "desc": "Use the mastery property of two weapons you have proficiency with; can change choices on a long rest."}
     ],
@@ -27,12 +27,12 @@
     "12": [{"name": "Ability Score Improvement", "desc": "Increase one ability score by 2 or two by 1 (max 20), or take a feat."}],
     "13": [{"name": "Improved Brutal Strike", "desc": "Brutal Strike gains additional effect options and stronger benefits."}],
     "14": [{"name": "Subclass Feature", "desc": "Gain a feature granted by your Primal Path subclass."}],
-    "15": [{"name": "Persistent Rage", "desc": "Your rage is so fierce it ends early only if you choose to end it or fall unconscious.", "rage_uses": 5}],
+    "15": [{"name": "Persistent Rage", "desc": "Your rage is so fierce it ends early only if you choose to end it or fall unconscious."}],
     "16": [{"name": "Ability Score Improvement", "desc": "Increase one ability score by 2 or two by 1 (max 20), or take a feat."}],
-    "17": [{"name": "Improved Brutal Strike", "desc": "Brutal Strike can apply two effects and deals an extra 2d10 damage.", "rage_uses": 6}],
+    "17": [{"name": "Improved Brutal Strike", "desc": "Brutal Strike can apply two effects and deals an extra 2d10 damage."}],
     "18": [{"name": "Indomitable Might", "desc": "If a Strength check total is less than your Strength score, you can use your Strength score instead."}],
     "19": [{"name": "Ability Score Improvement", "desc": "Increase one ability score by 2 or two by 1 (max 20), or take a feat."}],
-    "20": [{"name": "Primal Champion", "desc": "Your Strength and Constitution scores increase by 4, to a maximum of 25.", "rage_damage": 4, "rage_uses": 6}]
+    "20": [{"name": "Primal Champion", "desc": "Your Strength and Constitution scores increase by 4, to a maximum of 25."}]
   },
   "bard": {
     "1": [

--- a/servers/engine/tests/test_progression_integrity.py
+++ b/servers/engine/tests/test_progression_integrity.py
@@ -88,6 +88,59 @@ def test_engine_built_l19_rogue_has_10d6_sneak_attack():
     assert server.get_character(cid, rid)["sneak_attack_dice"] == "10d6"
 
 
+def test_rogue_sneak_attack_full_curve_spot_checks():
+    # SRD 5.2 Sneak Attack = ceil(level / 2) d6 — spot the endpoints the audit named.
+    def sneak(level):
+        dice = ""
+        for f in srd_tables.features_through("rogue", level):
+            if f.get("sneak_attack_dice"):
+                dice = f["sneak_attack_dice"]
+        return dice
+    assert sneak(1) == "1d6"
+    assert sneak(19) == "10d6"
+    assert sneak(20) == "10d6"
+
+
+def test_rage_uses_table_has_single_srd_correct_source():
+    """F02-11 (rage half): the Barbarian rage-uses curve must come from ONE
+    SRD-5.2-correct source. The live engine table is srd_tables._RAGE_USES
+    (5 uses at L12 — SRD 5.2). The class_features.json `rage_uses`/`rage_damage`
+    hints were DEAD (no code reads them — server.py only reads extra_attacks /
+    sneak_attack_dice) AND contradicted that table (they asserted 5 uses arrives
+    at L15, not L12). A contradicting dead source is a maintenance trap, so the
+    reconciliation removes those hints, leaving _RAGE_USES the sole authority.
+
+    This test locks BOTH halves: (a) the engine curve is the SRD 5.2 table, and
+    (b) class_features.json carries no rage_uses/rage_damage hint that could
+    silently drift back out of sync with it.
+    """
+    # (a) the live engine rage-uses curve == SRD 5.2 (2/3/4/5/6 @ 1/3/6/12/17).
+    def rage(level):
+        return srd_tables.class_resources_through("barbarian", level)["rage"]["max"]
+    assert rage(1) == 2
+    assert rage(3) == 3
+    assert rage(6) == 4
+    assert rage(11) == 4
+    assert rage(12) == 5   # SRD 5.2: the 5th use arrives at L12 (NOT L15)
+    assert rage(16) == 5
+    assert rage(17) == 6
+    assert rage(20) == 6
+
+    # (b) no contradicting dead hint survives in the class-features table — the
+    # rage curve has exactly one source of truth.
+    barb = srd_tables._load("class_features").get("barbarian", {})
+    offenders = [
+        (lv, f.get("name"))
+        for lv, feats in barb.items()
+        for f in feats
+        if "rage_uses" in f or "rage_damage" in f
+    ]
+    assert offenders == [], (
+        "class_features.json still carries dead rage_uses/rage_damage hints that "
+        f"no code reads and that contradict srd_tables._RAGE_USES: {offenders}"
+    )
+
+
 # --------------------------------------------------------------------------- #
 # F02-5 — class-sig recompute must NOT refill spent hit dice                   #
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What

Closes the **remaining live half** of audit **F02-11** (SRD resource-table drift, cluster #794). Three of the four F02-11 sub-defects named in `docs/audits/ENGINE-AUDIT-2026-06-11.md` Part C were already fixed and tested by **#856 / #885** and are verified intact here:

- **Sneak Attack** — `10d6` at **L19** (not L20), `ceil(level/2)d6` curve.
- **Second Wind** — `2/3/4` at L1/L4/L10 (the #885 scaling, *not* the legacy flat `1`).
- **Wild Shape** — `2/3/4` at L2/L6/L17 and **persists at 4 at L20**.

The one part #856 left untouched was the **Barbarian rage hints** in `data/srd/class_features.json`.

## Why

Those `rage_uses` / `rage_damage` hints were **DEAD** — `server.py`'s feature-apply loops read only `extra_attacks` and `sneak_attack_dice`; nothing consumes `rage_uses` / `rage_damage` (grep-verified). The live rage curve is `srd_tables._RAGE_USES` (`{1:2, 3:3, 6:4, 12:5, 17:6}`), which matches **SRD 5.2** (the 5th use arrives at **L12**).

The dead JSON hints **contradicted** that table — they asserted 5 uses at **L15** (`Persistent Rage`) and pinned `rage_damage` at levels the engine never reads. A dead-and-contradicting source is a maintenance trap (a future "wire the hints" change would silently ship the wrong curve), so the reconciliation **removes the hints**, leaving `_RAGE_USES` the sole SRD-correct authority. Feature names + rules text (which *are* surfaced on the sheet) are untouched.

### Wild Shape L20 nuance (audit flagged — DO NOT "fix")
The 2014 *"Archdruid unlimited → not pooled"* zero was already corrected to **4** by #856 (under SRD 5.2 the pool persists at 4). Confirmed here it stays **4** and was **not** regressed.

## Invariants

Additive-by-default: no code path reads the removed keys, so behavior is unchanged and old snapshots round-trip. Engine stays the sole writer; no wire contracts touched; no guardrail test weakened. Every value verified against SRD 5.2 before applying.

## Tests (`servers/engine/tests/test_progression_integrity.py`)

- `test_rage_uses_table_has_single_srd_correct_source` — locks the SRD 5.2 rage curve (5@12, **not** 5@15) **and** asserts `class_features.json` carries no contradicting dead `rage_uses` / `rage_damage` hint. **RED before this change** (4 offenders: Rage@1, Persistent Rage@15, Improved Brutal Strike@17, Primal Champion@20).
- `test_rogue_sneak_attack_full_curve_spot_checks` — spot-checks `L1=1d6`, `L19=10d6`, `L20=10d6`.

## Verification

- Focused: `tests/test_progression_integrity.py` → **22 passed**.
- Full engine suite → **2721 passed**, 0 failed.
- `qa/fast_gate.sh` → **PASS** (219 deterministic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated Barbarian class feature data structure to remove redundant numeric fields.

* **Tests**
  * Expanded progression integrity test coverage to validate Rogue and Barbarian feature scaling against authoritative game rules data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->