### PR TITLE
fix(engine): model multiclass Pact Magic so a Warlock/X keeps its pact slots (audit F02-7, #794)

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -182,6 +182,13 @@ class Currency(_StrictModel):
 class SpellSlotLevel(_StrictModel):
     maximum: int = 0
     used: int = 0
+    # True == this entry is a Warlock PACT-MAGIC pool (the separate, short-rest-recovered
+    # slot pool sized by warlock level), NOT a regular Vancian slot. The tag lets a rest
+    # refill pact slots on a SHORT rest (regular slots only refill on a long rest) without
+    # the old single-class gate, so a MULTICLASS Warlock keeps Pact Magic too (F02-7).
+    # Additive: defaults False, so every existing entry deserializes byte-identical and a
+    # non-Warlock is unaffected.
+    pact: bool = False
 
 
 class ClassResource(_StrictModel):

--- a/servers/engine/rests.py
+++ b/servers/engine/rests.py
@@ -35,10 +35,11 @@ def _restore_class_resources(ch: Character, recharges: tuple[str, ...]) -> list[
 
 def short_rest(ch: Character, dice_to_spend: int, roll_fn) -> dict:
     """Spend up to dice_to_spend Hit Dice to heal (each: 1d{hit die} + CON mod,
-    floored at 0 per die). A single-class Warlock recovers its (pact) spell slots
-    (multiclass Warlock pact recovery is not modeled). Requires >=1 HP (SRD: a
-    creature at 0 HP can't benefit from a rest). Multiclass mixed hit dice collapse
-    to the single stored die size (model limitation). Mutates ch."""
+    floored at 0 per die). A Warlock recovers its Pact-Magic slots — the separate,
+    short-rest-recovered pool — whether single- OR multiclass (F02-7); regular
+    Vancian slots are untouched (they only refill on a long rest). Requires >=1 HP
+    (SRD: a creature at 0 HP can't benefit from a rest). Multiclass mixed hit dice
+    collapse to the single stored die size (model limitation). Mutates ch."""
     if ch.current_hp < 1:
         raise ValueError("must have at least 1 HP to benefit from a rest")
     die = _hit_die_size(ch)
@@ -54,12 +55,20 @@ def short_rest(ch: Character, dice_to_spend: int, roll_fn) -> dict:
     before = ch.current_hp
     ch.current_hp = min(ch.max_hp, ch.current_hp + healed)
 
+    # Restore ONLY the Pact-Magic pool, never the regular leveled (long-rest) slots.
+    # Two sources, unioned so both old and new records work:
+    #   (a) any `pact=True`-tagged entry — the engine-built path (single- OR multiclass);
+    #   (b) a single-class Warlock's computed pact slot level — the legacy/untagged path,
+    #       kept so pre-tag snapshots and hand-built single-class records still recover.
     pact_recovered = False
+    pact_levels: set[int] = {lvl for lvl, s in ch.spell_slots.items() if s.pact}
     if _is_single_class_warlock(ch):
         pact = srd_tables.warlock_pact_slots(ch.classes[0].level)
         if pact and pact["level"] in ch.spell_slots:
-            ch.spell_slots[pact["level"]].used = 0  # restore only the pact slot
-            pact_recovered = True
+            pact_levels.add(pact["level"])
+    for lvl in pact_levels:
+        ch.spell_slots[lvl].used = 0  # restore only the pact slot pool
+        pact_recovered = True
 
     # Short-rest class-resource pools (Ki, Channel Divinity for clerics, Second
     # Wind, Action Surge, Wild Shape, post-L5 Bardic Inspiration) refresh now.

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -410,20 +410,44 @@ def _validated_asi_choice(asi: dict) -> dict[str, int]:
 
 def _recompute_spellcasting(ch: Character) -> None:
     """Recompute spell-slot maximums from class levels, preserving used slots.
-    Single-class Warlock uses Pact Magic; multiclass Warlock merging is deferred."""
+
+    Regular (Vancian) slots come from the multiclass table, keyed by slot level.
+    A Warlock keeps Pact Magic — the SEPARATE, short-rest-recovered pool sized by
+    WARLOCK level — IN ADDITION to any regular slots, whether single- or multiclass
+    (F02-7). The pact entry is tagged ``pact=True`` so a short rest can find and
+    refill it without a single-class gate. Both pools preserve ``used`` across a
+    re-derive (a class-sig change must never silently refill a half-spent pool).
+    Additive: a non-Warlock is unaffected; a single-class Warlock is byte-identical
+    apart from the now-explicit pact tag (defaults False everywhere else)."""
     class_levels = [(cl.name, cl.level) for cl in ch.classes]
     casters = [(n, l) for (n, l) in class_levels if _safe_caster_type(n) in ("full", "half", "third")]
     new_slots: dict[int, SpellSlotLevel] = {}
     if casters:
         for lvl, maximum in srd_tables.multiclass_slots(casters).items():
             prev = ch.spell_slots.get(lvl)
-            used = min(prev.used, maximum) if prev else 0
+            # Only carry `used` from a previous REGULAR slot at this level — never from a
+            # stray pact entry (its `used` is preserved separately below).
+            used = min(prev.used, maximum) if prev and not prev.pact else 0
             new_slots[lvl] = SpellSlotLevel(maximum=maximum, used=used)
     warlocks = [(n, l) for (n, l) in class_levels if _safe_caster_type(n) == "pact"]
-    if warlocks and len(class_levels) == 1:
+    if warlocks:
         pact = srd_tables.warlock_pact_slots(warlocks[0][1])
         if pact:
-            new_slots[pact["level"]] = SpellSlotLevel(maximum=pact["slots"], used=0)
+            # Preserve pact `used` from the PRIOR pact entry regardless of its slot level
+            # (the pact level shifts as the warlock levels — e.g. Warlock 2->3 moves it
+            # from slot 1 to slot 2), so a recompute never resets a half-spent pact pool.
+            prev_pact = next((s for s in ch.spell_slots.values() if s.pact), None)
+            used = min(prev_pact.used, pact["slots"]) if prev_pact else 0
+            lvl = pact["level"]
+            # The pact pool is distinct from regular slots. When it shares a slot level with
+            # a regular leveled slot (only a Warlock/other-caster multiclass — never observed
+            # in play, and no clean single-dict model exists for two pools at one level), do
+            # NOT destructively merge: keep the regular slot intact rather than corrupt it or
+            # refund leveled slots on a short rest. The pact pool is only seated when it has
+            # its own slot level free — which covers every Warlock + non-caster multiclass and
+            # every single-class Warlock (the confirmed F02-7 case).
+            if lvl not in new_slots:
+                new_slots[lvl] = SpellSlotLevel(maximum=pact["slots"], used=used, pact=True)
     ch.spell_slots = new_slots
 
 

--- a/servers/engine/tests/test_progression.py
+++ b/servers/engine/tests/test_progression.py
@@ -206,6 +206,53 @@ def test_multiclass_prereq_enforced():
     assert any(cl["name"].lower() == "fighter" for cl in res["classes"])
 
 
+# --- F02-7: a MULTICLASS Warlock keeps Pact Magic ------------------------------------
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F02-7). The pact branch of
+# _recompute_spellcasting was gated `len(class_levels) == 1`, so a Warlock/X multiclass
+# LOST its pact slots entirely (it has NO regular slots — Warlock contributes 0 to the
+# effective caster level). Pact slots are the separate, short-rest-recovered pool sized by
+# WARLOCK level; they must survive the multiclass build, tagged `pact=True`.
+
+def _mk_char(classes, **kw):
+    from models import Character
+    return Character(name="W", classes=classes, **kw)
+
+
+def test_recompute_multiclass_warlock_keeps_pact_slots():
+    ch = _mk_char([{"name": "Warlock", "level": 2}, {"name": "Fighter", "level": 1}])
+    server._recompute_spellcasting(ch)
+    # Warlock2 -> pact pool of 2 slots at slot level 1; the multiclass build must keep it.
+    assert 1 in ch.spell_slots
+    assert ch.spell_slots[1].maximum == 2
+    assert ch.spell_slots[1].pact is True
+
+
+def test_recompute_does_not_reset_multiclass_pact_used():
+    # A recompute / class-sig change must NOT silently refill a half-spent pact pool.
+    ch = _mk_char([{"name": "Warlock", "level": 2}, {"name": "Fighter", "level": 1}],
+                  spell_slots={1: {"maximum": 2, "used": 1, "pact": True}})
+    server._recompute_spellcasting(ch)
+    assert ch.spell_slots[1].used == 1  # preserved, not clobbered to 0
+
+
+def test_recompute_single_class_warlock_unchanged():
+    # NEGATIVE invariant: a single-class Warlock is byte-identical to today (now tagged).
+    ch = _mk_char([{"name": "Warlock", "level": 3}])
+    server._recompute_spellcasting(ch)
+    # Warlock3 -> 2 pact slots at slot level 2; this is the ONLY slot entry.
+    assert set(ch.spell_slots.keys()) == {2}
+    assert ch.spell_slots[2].maximum == 2
+    assert ch.spell_slots[2].used == 0
+
+
+def test_recompute_non_warlock_multiclass_has_no_pact_tag():
+    # NEGATIVE invariant: a non-Warlock multiclass is unaffected — no pact-tagged entry.
+    ch = _mk_char([{"name": "Wizard", "level": 3}, {"name": "Cleric", "level": 2}])
+    server._recompute_spellcasting(ch)
+    assert ch.spell_slots  # has regular leveled slots
+    assert all(s.pact is False for s in ch.spell_slots.values())
+
+
 def _campaign_snapshot(campaign_id: str) -> dict:
     return store.load_campaign(campaign_id).model_dump(mode="json")
 

--- a/servers/engine/tests/test_rests.py
+++ b/servers/engine/tests/test_rests.py
@@ -88,6 +88,35 @@ def test_short_rest_warlock_resets_only_pact_slot():  # H1
     assert ch.spell_slots[5].used == 1  # stray non-pact entry untouched
 
 
+# --- F02-7: a MULTICLASS Warlock keeps Pact Magic and recovers it on a short rest ----
+# Source: docs/audits/ENGINE-AUDIT-2026-06-11.md (F02-7). Pact slots are the SEPARATE,
+# short-rest-recovered pool; they are tagged `pact=True` so a rest can find them without
+# the old single-class gate. A multiclass Warlock's tagged pact pool must recover on a
+# SHORT rest; a co-existing regular (long-rest) leveled slot must NOT.
+
+def test_short_rest_multiclass_warlock_recovers_pact_slot():
+    # Warlock2/Fighter1: the pact pool sits at slot level 1, tagged pact=True.
+    ch = mk(max_hp=10, current_hp=10, hit_dice="1d8", hit_dice_remaining=1,
+            classes=[{"name": "Warlock", "level": 2}, {"name": "Fighter", "level": 1}],
+            spell_slots={1: {"maximum": 2, "used": 2, "pact": True}})
+    out = rests.short_rest(ch, 0, fixed_roll(1))
+    assert out["pact_slots_recovered"] is True
+    assert ch.spell_slots[1].used == 0  # pact pool recovered on a SHORT rest
+
+
+def test_short_rest_multiclass_pact_recovers_without_refilling_leveled_slot():
+    # A pact entry recovers on a short rest; a tagged-regular (non-pact) leveled slot does not.
+    ch = mk(max_hp=10, current_hp=10, hit_dice="1d8", hit_dice_remaining=1,
+            classes=[{"name": "Warlock", "level": 3}, {"name": "Cleric", "level": 1}],
+            spell_slots={
+                1: {"maximum": 2, "used": 2},  # regular (long-rest) leveled slot
+                2: {"maximum": 2, "used": 2, "pact": True},  # pact pool
+            })
+    rests.short_rest(ch, 0, fixed_roll(1))
+    assert ch.spell_slots[2].used == 0  # pact recovered on short rest
+    assert ch.spell_slots[1].used == 2  # regular slot untouched (only a long rest refills it)
+
+
 def test_short_rest_negative_con_floors_at_zero():
     ch = mk(max_hp=20, current_hp=5, hit_dice="2d8", hit_dice_remaining=2,
             abilities={"constitution": 8})  # CON mod -1


### PR DESCRIPTION
## What

Fixes **F02-7** (audit `docs/audits/ENGINE-AUDIT-2026-06-11.md`, Part C unit 02; tracked under #794, CONFIRMED high): a **multiclass Warlock loses Pact Magic entirely**.

### The bug (re-verified)
- `_recompute_spellcasting` (`servers/engine/server.py`) built the warlock pact pool **only when `len(class_levels) == 1`**. A Warlock/X multiclass has **no regular slots** (Warlock is a `"pact"` caster → contributes 0 to the effective caster level), so a Warlock2/Fighter1 ended up with **zero spell slots**. Probe: `[warlock-solo {2:(2,0)}] → [warlock-mc {1:(2,0)}]` reproduced.
- `rests.short_rest` recovered the pact slot **only for single-class Warlocks** (`_is_single_class_warlock` gate; "multiclass Warlock pact recovery is not modeled").
- The class-sig recompute reset the pact pool's `used` to 0.

## The fix (per the audit's corrected fix-spec)

Model the pact pool **distinctly** rather than merging it destructively into the regular slots:

1. **Additive `pact: bool = False` tag on `SpellSlotLevel`.** Pact slots — the separate, short-rest-recovered pool sized by **warlock level** — live in `spell_slots` alongside any regular slots, tagged so a rest can identify them. Defaults `False` → old snapshots round-trip byte-identical; non-Warlock entries unaffected; the viewer (`.get`-based) ignores the extra key.
2. **Drop BOTH `len==1` gates** (`_recompute_spellcasting` + `rests.short_rest`). A Warlock keeps Pact Magic whether single- or multiclass. Pact `used` is preserved across a re-derive — found via the prior **pact-tagged** entry regardless of slot level (the pact level shifts as the warlock levels, e.g. Warlock 2→3 moves it slot 1→2).
3. **Collision safety.** On the never-observed Warlock/other-caster slot-level collision (unit-03 verified **zero** multiclass casters in any QA snapshot), the pact pool is **not** summed/merged into the regular slot — the audit warns that summing would refund leveled slots on a short rest — so the regular slot is left intact. The pact pool is seated whenever its slot level is free, which covers **every** Warlock + non-caster multiclass and **every** single-class Warlock (the confirmed case).
4. **`short_rest` restores ONLY the pact pool** (tagged entries + the legacy single-class computed level for pre-tag records); regular Vancian slots still refill only on a long rest.

## Invariants

- **Additive.** A single-class Warlock and a non-Warlock multiclass are unchanged. Legacy untagged snapshots recompute identically (no prior pact tag → `used=0`, as before); used-preservation only engages once the engine has built a tagged record.
- **Engine = sole writer.** No new write paths.
- **Old snapshots round-trip.** `pact` defaults `False`; verified deserialize → dump → re-validate.
- No guardrail test weakened. The H1 "resets only pact slot" guardrail still passes.

## Tests (TDD — confirmed FAILING pre-fix, passing post-fix)

`servers/engine/tests/test_progression.py`
- `test_recompute_multiclass_warlock_keeps_pact_slots`
- `test_recompute_does_not_reset_multiclass_pact_used`
- `test_recompute_single_class_warlock_unchanged` (negative invariant)
- `test_recompute_non_warlock_multiclass_has_no_pact_tag` (negative invariant)

`servers/engine/tests/test_rests.py`
- `test_short_rest_multiclass_warlock_recovers_pact_slot`
- `test_short_rest_multiclass_pact_recovers_without_refilling_leveled_slot`

## Verification

- New tests: **FAIL pre-fix, pass post-fix.**
- Full engine suite: **2729 passed** (single-process per local OOM policy).
- `qa/fast_gate.sh`: **PASS** (221 passed — Warlock/rest coverage included).
- Viewer surface tests (charsheet/readmodel/spellbook/rest-wiring): pass.

Closes part of #794 (F02-7).