### PR TITLE
feat(engine+viewer): canon figures get + display a class-appropriate Fighting Style (sweep: veteran/optimizer)

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -770,6 +770,15 @@ class Character(_StrictModel):
     # of silently lost; settled by update_character / a later level_up. ADDITIVE: [] == today's
     # behavior; old snapshots round-trip (audit F02-3 / F02-15).
     pending_choices: list[str] = Field(default_factory=list)
+    # The chosen Fighting Style of a martial that gets one (Fighter at L1, Paladin/Ranger at L2
+    # per SRD 5.2) — its NAME ("Defense", "Archery", "Great Weapon Fighting", …). The Fighting
+    # Style used to render as a blank RULES STUB on a canon-loaded martial PC (the 3582dc2 sweep
+    # veteran/optimizer "Fighting Style not selected/displayed" finding); recording the NAME here
+    # lets the viewer show a named style. SET only on the canon-load seat (the autoset_single_subclass
+    # opt-in — a canon figure has no planner step to pick at); the create/level-up planner leaves it
+    # "" so the player chooses. ADDITIVE: "" == today's behavior; old snapshots round-trip byte-
+    # identical, non-martial classes are untouched, and the viewer ignores an absent key.
+    fighting_style: str = ""
     extra_attacks: int = 0  # extra attacks per Attack action (Extra Attack feature)
     sneak_attack_dice: str = ""  # e.g. "3d6" (rogue Sneak Attack), "" if none
     # A defensive REACTION that adds this many points to AC against ONE melee attack that

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1196,6 +1196,27 @@ def _expertise_count(class_name: str, level: int) -> int:
     return 0
 
 
+# Class -> the class-appropriate SRD 5.2 Fighting Style to DEFAULT a canon-loaded martial to when
+# the class grants Fighting Style by the character's level but the field is empty. Defense (+1 AC
+# while wearing armor) is the safe, universally-useful pick for the armored martials; Archery (+2
+# ranged attack) fits the Ranger's bow-first kit. All three are valid SRD 5.2 styles. The grant
+# LEVELS are not hard-coded here — they come from the SRD feature table (Fighter L1, Paladin/Ranger
+# L2; see _grants_fighting_style), so this map only encodes WHICH style, never WHEN.
+_DEFAULT_FIGHTING_STYLE = {"fighter": "Defense", "paladin": "Defense", "ranger": "Archery"}
+
+
+def _grants_fighting_style(class_name: str, level: int) -> bool:
+    """True iff `class_name` is granted a Fighting Style by SRD 5.2 at/through `level` (Fighter L1,
+    Paladin/Ranger L2). Derived from the SRD feature table — features_through carries a "Fighting
+    Style" entry at exactly the grant level — so the WHEN stays single-sourced in the data, not a
+    duplicated literal. A class that never gets one (Wizard) returns False at any level."""
+    try:
+        return any((f.get("name") or "").strip().lower() == "fighting style"
+                   for f in srd_tables.features_through(class_name, level))
+    except (ValueError, AttributeError, TypeError):
+        return False
+
+
 def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool,
                               autoset_single_subclass: bool = False) -> None:
     """Fill SRD class defaults onto a character in place: saving-throw proficiencies,
@@ -1222,6 +1243,22 @@ def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool
             ch.max_hp = _class_level_hp(cname, level, con) or ch.max_hp
             ch.current_hp = ch.max_hp
         ch.proficiency_bonus = srd_tables.proficiency_bonus(level)
+        # FIGHTING STYLE (canon-load default, opt-in — mirrors the #895 oath auto-set). A canon
+        # figure loaded straight in as a high-level martial PC (an L10 Paladin, an L11 Champion
+        # Fighter) showed "Fighting Style" as a blank RULES STUB — no style chosen or displayed
+        # (3582dc2 sweep, veteran/optimizer, MAJOR). Unlike a player-built char (whose planner
+        # surfaces the choice), the canon-load seat has NO planner step, so at/past the SRD grant
+        # level we DEFAULT to a class-appropriate style. Gated to the canon-load opt-in
+        # (autoset_single_subclass=True ONLY there), only fills an EMPTY field, and only when the
+        # class actually grants Fighting Style by this level (Fighter L1, Paladin/Ranger L2 — read
+        # from the SRD feature table via _grants_fighting_style). The create/level-up planner path
+        # (flag OFF), a class with no Fighting Style (Wizard), a level below the grant, and a sheet
+        # that already named a style all stay byte-identical to today.
+        if (autoset_single_subclass and not ch.fighting_style
+                and _grants_fighting_style(cname, level)):
+            default_style = _DEFAULT_FIGHTING_STYLE.get(cname)
+            if default_style:
+                ch.fighting_style = default_style
         if set_base_ac:
             # Unarmored Defense is ABILITY-derived, not a flat table value: a Barbarian is
             # 10 + DEX + CON and a Monk is 10 + DEX + WIS when wearing no armor (the abilities are
@@ -1234,6 +1271,18 @@ def _apply_srd_class_defaults(ch, class_name: str, level: int, set_base_ac: bool
                 ch.armor_class = 10 + dex + ch.abilities.modifier(Ability.WIS)
             else:
                 ch.armor_class = srd_tables.class_base_ac(cname)
+                # FIGHTING STYLE — Defense (+1 AC while wearing armor). FEASIBILITY-GATED and applied
+                # at this SINGLE clean insertion point: AC is set ONCE here from the worn-armor class
+                # base (16 for Fighter/Paladin/Cleric, 14 for Ranger — all reflect worn armor, > 10);
+                # equip_item is ADVISORY and never mutates armor_class; and a RE-SEAT passes
+                # set_base_ac=False (the canon-load path computes set_base_ac=(armor_class==10), so a
+                # second seat on an already-armored sheet skips this whole block) — so the +1 is
+                # applied exactly once and provably never double-counts. Gated on the Defense style
+                # (Archery is a ranged-attack bonus, not AC) and on a worn-armor base (> 10, so an
+                # unexpected unarmored base never silently gains AC). Only the canon-load opt-in ever
+                # sets ch.fighting_style above, so the create/level-up path never reaches this +1.
+                if ch.fighting_style == "Defense" and ch.armor_class > 10:
+                    ch.armor_class += 1
         through = list(srd_tables.features_through(cname, level))
         # #624: a character created directly at/above its subclass-choice level WITH a
         # subclass also gets that subclass's choice-level features (normalize loose

--- a/servers/engine/tests/test_fighting_style.py
+++ b/servers/engine/tests/test_fighting_style.py
@@ -1,0 +1,197 @@
+"""Canon-load default + display of a class-appropriate Fighting Style (sweep: veteran/optimizer).
+
+THE COMPLAINT (3582dc2 sweep, veteran + optimizer, MAJOR): a canon figure loaded as a PC
+(an L10 Paladin / an L11 Champion Fighter) showed "Fighting Style" only as a blank RULES
+STUB — no specific style chosen or displayed ("Fighting Style chosen at L2 is not displayed";
+"Fighting Style not selected/displayed — two slots unresolved"). SRD 5.2: a Fighter gets a
+Fighting Style at L1, a Paladin and a Ranger at L2.
+
+THE FIX (additive, mirrors the oath fix #895): an ADDITIVE `fighting_style: str = ""` on the
+Character, default-set ONLY on the canon-load seat (the `autoset_single_subclass` opt-in flag,
+the same gate #895 threads) to a CLASS-APPROPRIATE SRD style when the class grants Fighting
+Style by the character's level AND the field is empty: Paladin->"Defense", Fighter->"Defense",
+Ranger->"Archery". A class with NO Fighting Style (Wizard), a canon-load BELOW the grant level
+(Paladin L1), and the create/level-up planner path (flag OFF) all stay "" — byte-identical, so
+old snapshots round-trip and the player-built planner still surfaces the choice.
+
+AC EFFECT (feasibility-gated): the Defense style grants +1 AC while wearing armor. AC is set
+ONCE at the seat (inside `_apply_srd_class_defaults`'s `set_base_ac` block, from the class base
+AC that already reflects worn armor for the martials); equip_item is ADVISORY and never touches
+armor_class; a re-seat passes set_base_ac=False (AC != 10) so the whole block is skipped. That
+makes the `set_base_ac` block a CLEAN single insertion point — applied once, provably no
+double-count. These tests assert the +1 lands once and survives a re-seat.
+
+DOMAIN-SCOPED (opt-in): the default + AC effect are gated by the `autoset_single_subclass` flag,
+which ONLY the canon-load seat (server.load_canon_character) sets True. The create_character +
+level-up planner path keeps the flag OFF (default) -> byte-identical to today.
+"""
+
+import server
+from models import Character, ClassLevel
+
+
+def _sheet(class_name: str, level: int) -> Character:
+    """A bare class sheet at `level`, mirroring how the canon-seat path constructs a Character
+    before _apply_srd_class_defaults runs (see server.load_canon_character)."""
+    return Character(
+        name=f"Canon {class_name}",
+        kind="player",
+        classes=[ClassLevel(name=class_name, level=level, subclass=None)],
+    )
+
+
+# --- the fix: canon-load opt-in sets a class-appropriate Fighting Style by grant level ----
+
+
+def test_canon_paladin_l10_gets_defense_fighting_style():
+    # THE BUG: an L10 Paladin seated via the canon-load path (autoset_single_subclass=True) must
+    # now carry a NAMED Fighting Style ("Defense"), not a blank stub. Paladin grants it at L2.
+    ch = _sheet("Paladin", 10)
+    server._apply_srd_class_defaults(ch, "Paladin", 10, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    assert ch.fighting_style == "Defense", "an L10 canon Paladin is owed a class-appropriate style"
+
+
+def test_canon_fighter_l1_gets_defense_fighting_style():
+    # Fighter grants Fighting Style at L1 (SRD 5.2), so even a fresh L1 canon Fighter is owed one.
+    ch = _sheet("Fighter", 1)
+    server._apply_srd_class_defaults(ch, "Fighter", 1, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    assert ch.fighting_style == "Defense"
+
+
+def test_canon_fighter_l11_champion_gets_defense_fighting_style():
+    # The veteran's second exemplar: an L11 Champion Fighter. Still the L1 Fighting Style slot.
+    ch = _sheet("Fighter", 11)
+    server._apply_srd_class_defaults(ch, "Fighter", 11, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    assert ch.fighting_style == "Defense"
+
+
+def test_canon_ranger_l2_gets_archery_fighting_style():
+    # Ranger grants Fighting Style at L2 and the class-appropriate SRD default is Archery.
+    ch = _sheet("Ranger", 2)
+    server._apply_srd_class_defaults(ch, "Ranger", 2, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    assert ch.fighting_style == "Archery"
+
+
+# --- NEGATIVE: a class with NO Fighting Style stays "" -------------------------------------
+
+
+def test_canon_wizard_has_no_fighting_style():
+    # A Wizard never gains Fighting Style -> the field stays empty even on the canon-load seat.
+    ch = _sheet("Wizard", 10)
+    server._apply_srd_class_defaults(ch, "Wizard", 10, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    assert ch.fighting_style == ""
+
+
+# --- NEGATIVE: below the grant level stays "" (a real pending choice, not yet due) ---------
+
+
+def test_canon_paladin_l1_below_grant_level_stays_empty():
+    # A Paladin BELOW the L2 grant level keeps "" — the style is not yet owed.
+    ch = _sheet("Paladin", 1)
+    server._apply_srd_class_defaults(ch, "Paladin", 1, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    assert ch.fighting_style == ""
+
+
+def test_canon_ranger_l1_below_grant_level_stays_empty():
+    ch = _sheet("Ranger", 1)
+    server._apply_srd_class_defaults(ch, "Ranger", 1, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    assert ch.fighting_style == ""
+
+
+# --- NEGATIVE: the flag is OFF by default -> create/level-up planner path is byte-identical -
+
+
+def test_create_path_fighter_l1_stays_empty_without_optin():
+    # DOMAIN GATE: without the opt-in (the deliberate create_character + level-up planner path)
+    # even a Fighter at the grant level keeps fighting_style="" — the planner surfaces the choice
+    # for a player-built char. This guards that the auto-set never leaks onto the planner domain.
+    ch = _sheet("Fighter", 1)
+    server._apply_srd_class_defaults(ch, "Fighter", 1, set_base_ac=False)  # flag OFF (default)
+    assert ch.fighting_style == "", "default (no opt-in) must leave the style a planner choice"
+
+
+def test_create_path_paladin_l10_stays_empty_without_optin():
+    ch = _sheet("Paladin", 10)
+    server._apply_srd_class_defaults(ch, "Paladin", 10, set_base_ac=False)  # flag OFF (default)
+    assert ch.fighting_style == ""
+
+
+# --- POSITIVE-no-change: an already-chosen style is never clobbered ------------------------
+
+
+def test_existing_fighting_style_is_respected():
+    # Additivity: a sheet that ALREADY carries a chosen style (a hand-authored / DM-set canon
+    # record) keeps it — the default-fill only fills an EMPTY field.
+    ch = _sheet("Fighter", 6)
+    ch.fighting_style = "Great Weapon Fighting"
+    server._apply_srd_class_defaults(ch, "Fighter", 6, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    assert ch.fighting_style == "Great Weapon Fighting"
+
+
+# --- additive round-trip: an old snapshot with no field deserializes to "" -----------------
+
+
+def test_old_snapshot_without_field_round_trips_to_empty():
+    # ADDITIVE invariant: a snapshot predating the field has no `fighting_style` key; it must
+    # deserialize to "" (the default) and re-serialize without surprises.
+    legacy = {
+        "name": "Legacy Hero",
+        "classes": [{"name": "Fighter", "level": 5, "subclass": None}],
+    }
+    ch = Character.model_validate(legacy)
+    assert ch.fighting_style == ""
+
+
+# --- AC EFFECT (feasibility-gated): Defense grants +1 AC while wearing armor, no double-count -
+
+
+def test_canon_paladin_defense_grants_plus_one_ac_once():
+    # The Defense style grants +1 AC while wearing armor. A canon Paladin's base AC is 16 (Chain
+    # Mail / worn armor) -> with Defense the seat must land at 17. The +1 is applied at the single
+    # set_base_ac insertion point (after the base AC), gated on the Defense style.
+    ch = _sheet("Paladin", 10)
+    server._apply_srd_class_defaults(ch, "Paladin", 10, set_base_ac=True,
+                                     autoset_single_subclass=True)
+    assert ch.fighting_style == "Defense"
+    # Base Paladin AC is 16 (class_base_ac), +1 Defense = 17. (CON/DEX don't alter a worn-armor AC.)
+    assert ch.armor_class == 17, "Defense must add exactly +1 over the worn-armor base AC"
+
+
+def test_defense_ac_not_double_counted_on_reseat():
+    # NO DOUBLE-COUNT: a re-seat (the canon-load path passes set_base_ac=(armor_class==10), so a
+    # second seat on an already-armored sheet passes set_base_ac=False) must NOT add a second +1.
+    ch = _sheet("Paladin", 10)
+    server._apply_srd_class_defaults(ch, "Paladin", 10, set_base_ac=True,
+                                     autoset_single_subclass=True)
+    assert ch.armor_class == 17
+    # Re-seat with set_base_ac=False (AC is now 17, not 10) -> the whole AC block is skipped.
+    server._apply_srd_class_defaults(ch, "Paladin", 10, set_base_ac=False,
+                                     autoset_single_subclass=True)
+    assert ch.armor_class == 17, "a re-seat must not stack a second +1 (stays 17, not 18)"
+
+
+def test_create_path_no_ac_bonus_without_optin():
+    # The AC effect is gated to the canon-load opt-in: the create/level-up planner path (flag OFF)
+    # never gets the +1, so the base AC is byte-identical to today (16 for a Paladin).
+    ch = _sheet("Paladin", 10)
+    server._apply_srd_class_defaults(ch, "Paladin", 10, set_base_ac=True)  # flag OFF (default)
+    assert ch.fighting_style == ""
+    assert ch.armor_class == 16, "no opt-in -> no Defense +1; base worn-armor AC unchanged"
+
+
+def test_archery_ranger_no_ac_bonus():
+    # Archery is a ranged-attack bonus, NOT an AC bonus — a canon Ranger's AC must be the plain
+    # worn-armor base (14), proving the +1 is Defense-specific and never applied for Archery.
+    ch = _sheet("Ranger", 2)
+    server._apply_srd_class_defaults(ch, "Ranger", 2, set_base_ac=True,
+                                     autoset_single_subclass=True)
+    assert ch.fighting_style == "Archery"
+    assert ch.armor_class == 14, "Archery grants no AC; base worn-armor AC (14) unchanged"

--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -1893,10 +1893,45 @@ function SpellbookBrowser({ hero, groups, preparable, onClose }) {
   );
 }
 
+// Short SRD 5.2 effect blurbs for the Fighting Styles the engine defaults a canon martial to
+// (plus the other common SRD styles, so a hand-authored/DM-set style still reads with its effect).
+// The engine is the sole writer of hero.fightingStyle; this map is display-only flavor for the tab.
+const FIGHTING_STYLE_EFFECTS = {
+  "Defense": "+1 AC while you are wearing armor.",
+  "Archery": "+2 bonus to attack rolls you make with ranged weapons.",
+  "Dueling": "+2 damage when wielding a melee weapon in one hand and no other weapon.",
+  "Great Weapon Fighting": "Reroll 1s and 2s on a damage die of a two-handed melee weapon.",
+  "Two-Weapon Fighting": "Add your ability modifier to the damage of the off-hand attack.",
+  "Protection": "Use your reaction and shield to impose disadvantage on an attack against a nearby ally.",
+};
+
 function FeatsTab({ hero }) {
+  // The chosen Fighting Style of a canon martial (Fighter/Paladin/Ranger) — a NAMED style with its
+  // short SRD effect, so the slot is no longer the blank stub the sweep flagged. Omitted (honest
+  // empty-state) when the hero has none, matching the tab's other read-only sections.
+  const fightingStyle = String(hero.fightingStyle || "").trim();
   return (
     <div>
-      <SectionTitle ordinal="·">Weapon Proficiency</SectionTitle>
+      {fightingStyle && (
+        <>
+          <SectionTitle ordinal="·">Fighting Style</SectionTitle>
+          <div style={{
+            padding: 10,
+            marginBottom: 8,
+            background: "rgba(176,141,87,0.08)",
+            boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.25)",
+          }}>
+            <div style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.14em", textTransform: "uppercase", color: "var(--ink-900)" }}>
+              {fightingStyle}
+            </div>
+            {FIGHTING_STYLE_EFFECTS[fightingStyle] && (
+              <div className="body-sm muted" style={{ marginTop: 2 }}>{FIGHTING_STYLE_EFFECTS[fightingStyle]}</div>
+            )}
+          </div>
+          <Divider />
+        </>
+      )}
+      <SectionTitle ordinal={fightingStyle ? undefined : "·"}>Weapon Proficiency</SectionTitle>
       <ul className="body" style={{ paddingLeft: 18, margin: 0 }}>
         {hero.proficiencies.map((p) => (<li key={p}>{p}</li>))}
       </ul>

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3877,6 +3877,11 @@ def _character_sheet(cid: str, ch: dict) -> dict:
         "stable": bool(ch.get("stable")),
         "equipped": equipped,
         "feats": [{"name": f, "glyph": "feat", "detail": ""} for f in feat_names],
+        # The chosen Fighting Style NAME of a martial that gets one (engine sets ch.fighting_style
+        # on canon-loaded Fighters/Paladins/Rangers — #895-pattern). Surfaced so the FeatsTab can
+        # render a NAMED style instead of the blank rules stub (3582dc2 sweep veteran/optimizer).
+        # "" for a non-martial / unset sheet -> the tab omits the section honestly (read-only).
+        "fightingStyle": _text(ch.get("fighting_style")),
         "abilities": [],
         "proficiencies": features,
         "classFeatures": [{"name": f, "detail": _feature_desc(_class_feature_names, f)} for f in features],

--- a/viewer/tests/test_charsheet_depth.py
+++ b/viewer/tests/test_charsheet_depth.py
@@ -303,6 +303,23 @@ class CharsheetDepthTests(unittest.TestCase):
         self.assertFalse(self._party(surface2)["elara"]["pendingSubclass"])
         self.assertFalse(self._party(surface2)["thornwick"]["pendingSubclass"])
 
+    def test_surface_exposes_fighting_style_name(self):
+        """Fighting Style display (3582dc2 sweep, veteran/optimizer): the engine now records a
+        canon martial's chosen Fighting Style in `fighting_style`; the read-model must surface it
+        as `fightingStyle` so the FeatsTab can render a NAMED style instead of a blank stub."""
+        ch = copy.deepcopy(_SNAPSHOT["characters"]["thornwick"])  # L4 Fighter
+        ch["fighting_style"] = "Defense"
+        sheet = server._character_sheet("thornwick", ch)
+        self.assertEqual(sheet["fightingStyle"], "Defense")
+
+    def test_surface_fighting_style_empty_for_non_martial(self):
+        """A non-martial (Wizard) carries no Fighting Style -> the key is present (stable shape)
+        but empty, so the FeatsTab omits the section honestly rather than showing a blank style."""
+        ch = copy.deepcopy(_SNAPSHOT["characters"]["elara"])  # Wizard, no fighting_style field
+        sheet = server._character_sheet("elara", ch)
+        self.assertIn("fightingStyle", sheet)
+        self.assertEqual(sheet["fightingStyle"], "")
+
     def test_capitalized_skill_proficiencies_still_project(self):
         """QA 2026-06-03 (optimizer crit, sat=4): a canon-seated character can carry CAPITALIZED
         skill names on a stale snapshot (['Arcana','History',...]). The Skills tab must still mark


### PR DESCRIPTION
## The complaint (3582dc2 sweep, veteran + optimizer, MAJOR)

A canon figure loaded as a PC (an L10 Paladin / an L11 Champion Fighter) showed **"Fighting Style" only as a blank RULES STUB** — no specific style chosen or displayed ("Fighting Style chosen at L2 is not displayed"; "Fighting Style not selected/displayed — two slots unresolved"). SRD 5.2: a Fighter gets a Fighting Style at L1, a Paladin and a Ranger at L2.

## The fix (additive — mirrors the oath fix #895's pattern)

- **ENGINE** — an additive `fighting_style: str = ""` on `Character` (`servers/engine/models.py`). Default `""` → old snapshots round-trip **byte-identical**, non-martial classes unaffected, the viewer ignores an absent key.
- **CANON-LOAD DEFAULT (opt-in, ONLY `load_canon_character`)** — threaded through the **same `autoset_single_subclass` flag** #895 uses. When the class grants Fighting Style by the character's level (Fighter L1, Paladin/Ranger L2 — read from the SRD feature table via `_grants_fighting_style`, **not** a hard-coded literal) AND the field is empty, set a class-appropriate SRD default: **Paladin/Fighter → "Defense", Ranger → "Archery"** (valid SRD 5.2 styles; the safe, universally-useful picks). The create / level-up / non-canon-load paths stay `""` — the planner surfaces the choice for a player-built char; this is only the canon-load seat that has no planner step.
- **AC EFFECT — feasibility-gated → APPLIED.** Defense grants **+1 AC while wearing armor**. AC is set **once** at the seat (inside `_apply_srd_class_defaults`'s `set_base_ac` block, from the worn-armor class base — 16 for Fighter/Paladin, 14 for Ranger, all > 10); `equip_item` is **ADVISORY** and never mutates `armor_class`; and a **re-seat passes `set_base_ac=False`** (the canon-load path computes `set_base_ac=(armor_class==10)`, so a second seat on an already-armored sheet skips the whole block). That makes the `set_base_ac` block a **clean single insertion point — applied once, provably no double-count.** Gated on the Defense style + a worn-armor base (> 10). Archery is a ranged-attack bonus (no AC), and the create/level-up path never sets `fighting_style`, so it never reaches the +1.
- **READ-MODEL** — `viewer/server.py` `_character_sheet` exposes `fightingStyle` from `ch.fighting_style`.
- **VIEWER** — `viewer/openworlds/screen-character.jsx` `FeatsTab` renders the named style + its short SRD effect, so the stub becomes a named style. Omitted (honest empty-state) for a non-martial.

## Invariants

Additive: **single-class, create, level-up, non-canon-load, and non-martial classes are all byte-identical**. Engine is the sole writer; the viewer is read-only; no guardrail test was weakened.

## Tests (TDD — failing first, then green)

- `servers/engine/tests/test_fighting_style.py` (**15 cases**): canon-default per class/level (Paladin L10 / Fighter L1 / Fighter L11 Champion → Defense, Ranger L2 → Archery); Wizard stays `""`; below-grant (Paladin/Ranger L1) stays `""`; create-path stays `""` without the opt-in; an already-chosen style is respected; old-snapshot round-trips to `""`; **Defense +1 AC lands once (17) and is NOT double-counted on a re-seat**; Archery / non-opt-in get **no** AC bonus.
- `viewer/tests/test_charsheet_depth.py` (**+2 cases**): the read-model surfaces `fightingStyle` for a martial and `""` for a non-martial.

## Verification

| gate | result |
|---|---|
| `bash qa/fast_gate.sh` (AC / seat coverage) | **PASS** — 221 passed |
| full engine suite | **2744 passed** |
| full viewer suite | **623 passed, 1 skipped, 53 subtests passed** |
| `screen-character.jsx` babel transpile | OK |

`ac_effect = applied`.