### PR TITLE
fix(engine): Mithral/Elven Chain armor negate base stealth/STR pills in itemcatalog (#896)

### DIFF
--- a/servers/engine/itemcatalog.py
+++ b/servers/engine/itemcatalog.py
@@ -190,6 +190,38 @@ def _armor_dex_rule(fields: dict, ac_base: int, name: str) -> dict:
     return {"armor_category": "medium", "ac_dex_mod": "capped", "ac_dex_cap": cap}
 
 
+# Name prefixes for magic armors whose own 5e rules REMOVE the base armor's
+# Stealth/STR penalties but whose SRD desc carries no machine-detectable clause
+# saying so (unlike Mithral). Matched case-insensitively. Kept tiny + explicit:
+# "Elven Chain" covers "Elven Chain Mail" + "Elven Chain Shirt".
+_BASE_PENALTY_NEGATING_PREFIXES = ("elven chain",)
+
+
+def _armor_negates_base_restrictions(name: str, desc: str) -> bool:
+    """A few SRD magic armors explicitly REMOVE the base armor's Stealth
+    disadvantage + Strength requirement that the ``armor`` FK would otherwise
+    fold onto the record. Detect them so the FK fold below never stamps a false
+    penalty pill that contradicts the item's own rules text.
+
+    - **Mithral Armor (any base)** — the SRD desc states outright that if the
+      base "normally imposes Disadvantage on Dexterity (Stealth) checks or has a
+      Strength requirement, the mithral version ... doesn't." Detected from the
+      description (stable, machine-readable) so it covers every Mithral Armor
+      (Chain Mail)/(Plate)/(Splint)/... variant without a per-item list.
+    - **Elven Chain (Mail/Shirt)** — 5e elven chain has no Stealth disadvantage
+      and no STR requirement, but the SRD dump's desc carries no such clause, so
+      it is matched by name prefix.
+
+    Only governs the stealth/STR pills; AC + the DEX-mod rule still inherit via
+    the FK. Additive + narrow: any armor not in these two cases is unaffected.
+    """
+    d = (desc or "").lower()
+    if "mithral" in d and "doesn't" in d:
+        return True
+    low = (name or "").lower()
+    return any(low.startswith(p) for p in _BASE_PENALTY_NEGATING_PREFIXES)
+
+
 @functools.lru_cache(maxsize=None)
 def _weapon_armor_join() -> tuple[dict, dict]:
     """({weapon_pk: weapon_fields}, {armor_pk: armor_fields}) merged across all
@@ -392,11 +424,14 @@ def _flatten(model: str, fields: dict, pk: str = "") -> dict:
         # An Item/MagicItem armor inherits its base armor's SRD stealth-disadvantage
         # + STR-requirement via the same FK (mirrors the model=="armor" path above;
         # SRD Armor: e.g. Chain Mail grants_stealth_disadvantage=true str=13). De-duped
-        # onto any prior props, like the weapon-FK block just above.
-        if af.get("grants_stealth_disadvantage") and "stealth-disadvantage" not in record["properties"]:
-            record["properties"].append("stealth-disadvantage")
-        if af.get("strength_score_required") and f"str-{af['strength_score_required']}" not in record["properties"]:
-            record["properties"].append(f"str-{af['strength_score_required']}")
+        # onto any prior props, like the weapon-FK block just above. EXCEPTION: a few
+        # SRD magic armors (Mithral / Elven Chain) whose own rules text removes those
+        # base penalties — fold nothing for them so the inspector shows no false pill.
+        if not _armor_negates_base_restrictions(record["name"], record["description"]):
+            if af.get("grants_stealth_disadvantage") and "stealth-disadvantage" not in record["properties"]:
+                record["properties"].append("stealth-disadvantage")
+            if af.get("strength_score_required") and f"str-{af['strength_score_required']}" not in record["properties"]:
+                record["properties"].append(f"str-{af['strength_score_required']}")
     elif fields.get("armor_class"):
         # Homebrew/inline armor_class with no DEX-rule data: keep the bare AC. Without
         # ac_add_dexmod we can't infer the category — leave the rule keys absent so the

--- a/servers/engine/tests/test_armor_props_fold.py
+++ b/servers/engine/tests/test_armor_props_fold.py
@@ -46,3 +46,62 @@ def test_stealth_str_pills_are_not_duplicated():
     rec = itemcatalog.resolve("Chain Mail")
     assert rec["properties"].count("stealth-disadvantage") == 1
     assert rec["properties"].count("str-13") == 1
+
+
+# --- Negation: a few SRD magic armors REMOVE the base armor's stealth/STR -----
+# penalties their `armor` FK would otherwise fold in (Mithral / Elven Chain).
+# Suppressing these mirrors the item's own rules text — without it the inspector
+# rendered a false penalty pill (the gap #899's FK fold made newly visible).
+
+def _no_stealth_or_str(rec):
+    return not any(p == "stealth-disadvantage" or p.startswith("str-")
+                   for p in rec["properties"])
+
+
+def test_mithral_chain_mail_suppresses_base_stealth_and_str():
+    # SRD desc: "If the armor normally imposes Disadvantage on Dexterity
+    # (Stealth) checks or has a Strength requirement, the mithral version ...
+    # doesn't." Its `armor` FK is srd-2024_chain-mail (stealth + str-13), but
+    # the mithral version negates both.
+    rec = itemcatalog.resolve("Mithral Armor (Chain Mail)")
+    assert rec is not None
+    assert rec["kind"] == "armor"
+    assert rec["ac"]  # AC still inherited via the FK; only the penalties drop
+    assert _no_stealth_or_str(rec), rec["properties"]
+
+
+def test_mithral_plate_and_splint_suppress_base_stealth_and_str():
+    # Plate (str-15) and Splint (str-15) bases both impose stealth + STR; the
+    # mithral versions negate both via the same desc clause.
+    for name in ("Mithral Armor (Plate)", "Mithral Armor (Splint)",
+                 "Mithral Armor (Half Plate)", "Mithral Armor (Scale Mail)",
+                 "Mithral Armor (Ring Mail)"):
+        rec = itemcatalog.resolve(name)
+        assert rec is not None, name
+        assert _no_stealth_or_str(rec), (name, rec["properties"])
+
+
+def test_elven_chain_mail_suppresses_base_stealth_and_str():
+    # 5e Elven Chain has no Stealth disadvantage and no STR requirement, but the
+    # SRD dump carries no negation clause in its desc, so it is matched by name
+    # prefix. Its `armor` FK is srd-2024_chain-mail (stealth + str-13).
+    rec = itemcatalog.resolve("Elven Chain Mail")
+    assert rec is not None
+    assert rec["kind"] == "armor"
+    assert rec["ac"]  # +1 base armor AC still inherited
+    assert _no_stealth_or_str(rec), rec["properties"]
+
+
+def test_elven_chain_shirt_has_no_stealth_or_str_pill():
+    # Chain Shirt base carries no penalty, so this was already clean — guard it
+    # so the negation set never regresses it into carrying a pill.
+    rec = itemcatalog.resolve("Elven Chain Shirt")
+    assert rec is not None
+    assert _no_stealth_or_str(rec), rec["properties"]
+
+
+def test_negation_does_not_regress_plain_chain_mail():
+    # Non-negating heavy armor MUST keep its pills — the negation set is narrow.
+    rec = itemcatalog.resolve("Chain Mail")
+    assert "stealth-disadvantage" in rec["properties"]
+    assert "str-13" in rec["properties"]


### PR DESCRIPTION
## Problem

PR #899 taught the Item/MagicItem **armor-FK fold** in `itemcatalog._flatten` to inherit the base armor's `grants_stealth_disadvantage` + `strength_score_required` as `stealth-disadvantage` / `str-N` inspector pills. That's correct for Adamantine, +1/+2/+3, Demon/Dwarven armors — but **wrong** for two SRD magic items whose own rules text *negates* exactly those penalties:

- **Mithral Armor (any base)** — SRD desc: *"If the armor normally imposes Disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't."*
- **Elven Chain Mail / Shirt** — 5e elven chain has no Stealth disadvantage and no STR requirement.

Before this fix both resolved with `['stealth-disadvantage','str-13']`, contradicting the item's own description and rendering a **false penalty pill** in the viewer item inspector.

```
# before
Mithral Armor (Chain Mail)  -> ['stealth-disadvantage', 'str-13']   # WRONG
Mithral Armor (Plate)       -> ['stealth-disadvantage', 'str-15']   # WRONG
Mithral Armor (Splint)      -> ['stealth-disadvantage', 'str-15']   # WRONG
Elven Chain Mail            -> ['stealth-disadvantage', 'str-13']   # WRONG
# after
Mithral Armor (*)           -> []   (ac + category still inherited)
Elven Chain Mail / Shirt    -> []
Chain Mail / Plate / Splint -> pills KEPT (unchanged)
```

## Fix

A narrow `_armor_negates_base_restrictions(name, desc)` gate on the FK fold:

- **Mithral** is **description-driven** — desc contains `mithral` + `doesn't` (stable, machine-detectable text; covers all 9 Mithral variants with no per-item list).
- **Elven Chain** is **name-prefix-matched** (`"elven chain"`) — its SRD desc carries no negation clause, so prefix is the right signal.

Only the two penalty pills are suppressed; **AC + the DEX-mod rule still inherit via the FK**. Additive + narrow: any armor outside these two cases is untouched (plain Chain Mail / Plate / Splint / Half Plate keep their pills — regression-guarded).

This is a **pre-existing data-fidelity gap that #899 made newly visible — NOT a regression of #899.** Tracked on #896.

## Tests
- `tests/test_armor_props_fold.py` — **9/9** (6 new negation/guard tests; the 3 prior #899 negatives stay green)
- Full engine suite — **2749/2749** single-process
- `viewer/tests/test_item_inspector.py` — **43/43**
- `scripts/license_check.py` — green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed magic armors that negate base armor penalties (Mithral, Elven Chain) incorrectly applying stealth disadvantage and strength requirements.

* **Tests**
  * Added comprehensive test coverage for magic armor penalty negation across variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->