### PR TITLE
test(engine+viewer): guard build_options subclass picker carries named higher-level archetype features (#607)

### DIFF
--- a/servers/engine/tests/test_class_features.py
+++ b/servers/engine/tests/test_class_features.py
@@ -156,6 +156,39 @@ def test_build_options_subclass_options_carry_full_feature_detail(cid):
     assert all(f.get("desc") and f.get("level") for f in feats), feats
 
 
+def test_build_options_subclass_options_carry_named_higher_level_features(cid):
+    # #607 regression guard (the precise gap): the sibling test above only checks
+    # len(features) >= 2 — a count the TERSE list (the lone choice-level pair) already
+    # satisfies — so it never proves the HIGHER-level archetype features reach the
+    # build_options picker. The viewer subclass picker reads build_options (GET
+    # /build-options); the optimizer asked to COMPARE archetypes by their full feature
+    # set, so build_options must carry the SAME higher-level Champion features the
+    # preview_level_up path does (Additional Fighting Style L7, Superior Critical L15,
+    # Survivor L18), each WITH rules text + an int level. Fails fast if the call site ever
+    # drops full_features=True back to the terse two-feature list.
+    fid = server.create_character(
+        cid, "Sera", kind="player", class_name="Fighter", level=2,
+        abilities={"strength": 16, "constitution": 14}, apply_srd_defaults=True,
+    )["id"]
+    planner = server.build_options(cid, fid)
+    fopt = next(o for o in planner["options"] if o["class_name"] == "fighter")
+    sub = fopt.get("subclass")
+    assert sub and sub["required"] is True
+    champion = next(o for o in sub["options"] if o["name"] == "Champion")
+    feat_names = {f["name"] for f in champion["features"]}
+    # the choice-level pair is always present…
+    assert {"Improved Critical", "Remarkable Athlete"} <= feat_names, feat_names
+    # …AND the higher-level archetype features the terse list omits (the real gap).
+    assert {"Additional Fighting Style", "Superior Critical", "Survivor"} <= feat_names, feat_names
+    # Each carries SRD rules text AND an int level (terse features are level=None, so this
+    # also red-flags a revert to the terse list even if the count check above passed).
+    by_name = {f["name"]: f for f in champion["features"]}
+    for fname in ("Improved Critical", "Superior Critical", "Survivor"):
+        feat = by_name[fname]
+        assert feat.get("desc"), f"{fname} must carry SRD rules text"
+        assert isinstance(feat.get("level"), int), f"{fname} must carry an int level, got {feat.get('level')!r}"
+
+
 # ── #624 backfill (rc2 audit): a MISSED subclass choice is offered at the NEXT
 # level-up — an L5 wizard with no Arcane Tradition (the pendingSubclass case) must
 # still get the options block, not the free-text fallback. ──────────────────────

--- a/viewer/tests/test_build_options_bridge.py
+++ b/viewer/tests/test_build_options_bridge.py
@@ -82,6 +82,34 @@ class BuildOptionsBridgeTests(unittest.TestCase):
         self.assertTrue(all(o.get("desc") for o in sub["options"]))
         self.assertTrue(all(o.get("features") for o in sub["options"]))
 
+    def test_build_options_surfaces_higher_level_subclass_features(self):
+        # #607 regression guard at the BRIDGE seam: the rich subclass features the engine
+        # planner carries (full_features=True) must survive build_options_response
+        # serialization to the viewer picker — not just the level-3 pair. A Fighter L2->L3
+        # Champion must arrive with its higher-level archetype features (Superior Critical
+        # L15, Survivor L18), each with rules text. Fails if the bridge strips feature
+        # detail OR the engine call site reverts to the terse two-feature list.
+        engine = server._engine_server()
+        campaign_id = engine.create_campaign("Higher")["id"]
+        character_id = engine.create_character(
+            campaign_id, "Sera", kind="player", class_name="Fighter", level=2,
+            apply_srd_defaults=True,
+            abilities={"strength": 16, "constitution": 14, "dexterity": 12},
+        )["id"]
+        response = server.build_options_response(campaign_id, character_id)
+        self.assertTrue(response["ok"])
+        fighter = next(o for o in response["planner"]["options"] if o["class_name"] == "fighter")
+        sub = fighter.get("subclass")
+        self.assertIsNotNone(sub, "fighter at L2->L3 must carry a subclass-choice block")
+        champion = next(o for o in sub["options"] if o["name"] == "Champion")
+        feat_names = {f["name"] for f in champion["features"]}
+        self.assertLessEqual(
+            {"Additional Fighting Style", "Superior Critical", "Survivor"},
+            feat_names,
+            f"higher-level archetype features must survive the bridge, got {sorted(feat_names)}",
+        )
+        self.assertTrue(all(f.get("desc") for f in champion["features"]))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What & why

The viewer level-up subclass picker (`viewer/openworlds/screen-character.jsx`) reads `build_options` via `GET /build-options`. The reported concern: that path served the *terse* 2-feature subclass list because `build_options` called `_subclass_block_for(...)` without `full_features=True`.

**Validation first (per clawdnd-dev discipline): the production fix already shipped.** Git history shows PR #878 (commit `4b6dcd4`) — the same PR that added the rich picker — *also* changed the `build_options` call site to pass `full_features=True` in its own diff. On current `main`, **both** call sites already pass it:
- `preview_level_up` → `servers/engine/server.py:6225`
- `build_options` → `servers/engine/server.py:6354`

Empirically confirmed: `build_options` for a Fighter L2→L3 returns the full Champion set (Improved Critical L3, Remarkable Athlete L3, Additional Fighting Style L7, Heroic Warrior L10, Superior Critical L15, Survivor L18), each with rules text + int level.

## The genuine gap this PR closes

The only `build_options` guard (`test_build_options_subclass_options_carry_full_feature_detail`) asserts just `len(features) >= 2` — a count the terse choice-level pair nearly satisfies — so it never pinned that the **named** higher-level features reach the picker with rules text. That named assertion existed only on the `preview_level_up` path (`test_preview_subclass_options_carry_higher_level_features`).

Two regression guards added on the `build_options` path:
- **engine** (`test_class_features.py`): `test_build_options_subclass_options_carry_named_higher_level_features` — asserts the Champion block from `build_options` carries `{Additional Fighting Style, Superior Critical, Survivor}`, each with SRD rules text + an int level (terse features are `level=None`).
- **viewer bridge** (`test_build_options_bridge.py`): `test_build_options_surfaces_higher_level_subclass_features` — asserts those features survive `build_options_response` serialization to the picker.

## Red→green proof

Surgically reverted `full_features=True` at the `build_options` call site only (left `preview_level_up` intact): both new guards failed with only `{Improved Critical, Remarkable Athlete}`. Restored → both pass.

## Nothing else relies on the terse list from build_options

The two remaining terse `subclass_options(...)` callers (`server.py:1306` single-option auto-set at canon-load; `srd_tables.py:310` alias resolution) are name-only paths, not the picker display path — correctly left terse.

## Tests
- Full engine suite (single-process): **2745 passed** in 48.6s
- `viewer/tests/test_levelup_picker.py` + `test_build_options_bridge.py`: **9 passed**
- `scripts/license_check.py`: passed

Tests-only, additive — no production change.