### PR TITLE
feat(engine+viewer): surface SRD weapon-mastery effects in the item inspector (optimizer: Sap unexplained)

### DIFF
--- a/servers/engine/itemcatalog.py
+++ b/servers/engine/itemcatalog.py
@@ -276,6 +276,52 @@ def _weapon_property_join() -> dict[str, dict]:
     return out
 
 
+# The canonical SRD 5.2 weapon-MASTERY effects, keyed by the mastery NAME the
+# WeaponProperty join resolves (#888). #888 surfaced the NAME ("Sap"); the 3582dc2
+# optimizer's MAJOR was that the Examine panel showed the name but NOT what it does
+# ("Weapon Mastery 'Sap' unexplained"). This is the authoritative effect text — one
+# canonical source so the engine is the sole writer and every surface (Stash/Market
+# inspector) reads the SAME wording. Verified against the SRD 5.2 weapon-mastery list.
+# A name absent from this map (a homebrew pack's novel mastery) resolves to "" so the
+# inspector hides the effect row rather than fabricating one.
+_MASTERY_EFFECTS = {
+    "Cleave": ("If you hit a creature with a melee attack roll using this weapon, you can make a "
+               "melee attack roll with the weapon against a second creature within 5 feet of the "
+               "first that is also within your reach. On a hit, the second creature takes the "
+               "weapon's damage, but don't add your ability modifier to that damage unless that "
+               "modifier is negative. You can make this extra attack only once per turn."),
+    "Graze": ("If your attack roll with this weapon misses a creature, you can deal damage "
+              "to that creature equal to the ability modifier you used to make the attack "
+              "roll. This damage is the same type dealt by the weapon, and it can be "
+              "increased only by increasing the ability modifier."),
+    "Nick": ("When you make the extra attack of the Light property, you can make it as part "
+             "of the Attack action instead of as a Bonus Action. You can make this extra "
+             "attack only once per turn."),
+    "Push": ("If you hit a creature with this weapon, you can push the creature up to 10 "
+             "feet straight away from yourself if it is Large or smaller."),
+    "Sap": ("If you hit a creature with this weapon, that creature has Disadvantage on its "
+            "next attack roll before the start of your next turn."),
+    "Slow": ("If you hit a creature with this weapon and deal damage to it, you can reduce "
+             "its Speed by 10 feet until the start of your next turn. If the creature is hit "
+             "more than once by weapons that have this property, the Speed reduction doesn't "
+             "exceed 10 feet."),
+    "Topple": ("If you hit a creature with this weapon, you can force the creature to make a "
+               "Constitution saving throw (DC 8 plus the ability modifier used to make the "
+               "attack roll and your Proficiency Bonus). On a failed save, the creature has "
+               "the Prone condition."),
+    "Vex": ("If you hit a creature with this weapon and deal damage to the creature, you have "
+            "Advantage on your next attack roll against that creature before the end of "
+            "your next turn."),
+}
+
+
+def _mastery_effect(name: str) -> str:
+    """The canonical SRD 5.2 effect text for a weapon-mastery NAME, or "" when the name is
+    empty or unknown (a homebrew mastery the map doesn't cover). The inspector reads this
+    verbatim so "Sap" no longer surfaces unexplained — never fabricated for a missing name."""
+    return _MASTERY_EFFECTS.get((name or "").strip(), "")
+
+
 def _flatten(model: str, fields: dict, pk: str = "") -> dict:
     """Flatten one source record (any of the 4 shapes) into the common catalog
     item dict. ``model`` is the fixture model tail ('magicitem'/'item'/'weapon'/
@@ -315,6 +361,10 @@ def _flatten(model: str, fields: dict, pk: str = "") -> dict:
             # so the Stash/Market inspector reads "Martial Weapon · Mastery: Sap" — additive.
             "weapon_category": _weapon_category(fields),
             "mastery": extra.get("mastery", ""),
+            # 3582dc2 optimizer (MAJOR "Weapon Mastery 'Sap' unexplained"): the canonical SRD
+            # 5.2 EFFECT text for that mastery NAME, so the inspector explains what it does.
+            # "" when the weapon has no mastery (or an unknown one) — the row is then hidden.
+            "mastery_effect": _mastery_effect(extra.get("mastery", "")),
             # RRI-25e55fa optimizer #3: the SRD weapon range bracket (0/0 for pure melee).
             **_weapon_range(fields),
         }
@@ -382,6 +432,9 @@ def _flatten(model: str, fields: dict, pk: str = "") -> dict:
             record["versatile"] = wp["versatile"]
         if wp.get("mastery"):
             record["mastery"] = wp["mastery"]
+            # 3582dc2 optimizer (MAJOR): a magic weapon inherits its base weapon's mastery
+            # EFFECT text via the same FK, so an enchanted Glaive explains Graze, not just names it.
+            record["mastery_effect"] = _mastery_effect(wp["mastery"])
     afk = fields.get("armor")
     if afk and afk in armors:
         af = armors[afk]

--- a/servers/engine/tests/test_itemcatalog.py
+++ b/servers/engine/tests/test_itemcatalog.py
@@ -239,6 +239,79 @@ def test_non_versatile_weapon_has_no_versatile_key_value():
     assert rec.get("versatile", "") == ""
 
 
+# --- weapon-mastery EFFECT text (the optimizer's "Weapon Mastery 'Sap' unexplained") ----
+def test_resolve_weapon_exposes_mastery_effect_alongside_name():
+    """The 3582dc2 optimizer MAJOR: the Examine panel shows a weapon's Mastery NAME ("Sap")
+    but NOT what it does. #888 surfaced `mastery`; this surfaces the canonical SRD 5.2 EFFECT
+    text as `mastery_effect` alongside it so a player reads what the property actually does.
+    A Longsword's Mastery is Sap (disadvantage on the target's next attack)."""
+    rec = itemcatalog.resolve("Longsword")
+    assert rec is not None
+    assert rec["mastery"] == "Sap"                       # the NAME (#888, unchanged)
+    effect = rec.get("mastery_effect", "")
+    assert effect, "a weapon with a Mastery must carry the SRD effect text"
+    assert "disadvantage" in effect.lower()
+    assert "next attack" in effect.lower()
+
+
+def test_mastery_effect_text_matches_srd_for_sap_topple_vex():
+    """Spot-check the canonical SRD 5.2 effect wording for three masteries the optimizer
+    named: Sap (disadvantage on next attack), Topple (Constitution save or knocked prone),
+    Vex (advantage on your next attack against that target)."""
+    sap = itemcatalog.resolve("Longsword")          # SRD: Sap
+    assert sap["mastery"] == "Sap"
+    assert "disadvantage" in sap["mastery_effect"].lower()
+    topple = itemcatalog.resolve("Battleaxe")       # SRD: Topple
+    assert topple["mastery"] == "Topple"
+    te = topple["mastery_effect"].lower()
+    assert "constitution" in te and "prone" in te
+    vex = itemcatalog.resolve("Rapier")             # SRD: Vex
+    assert vex["mastery"] == "Vex"
+    ve = vex["mastery_effect"].lower()
+    assert "advantage" in ve and "next attack" in ve
+
+
+def test_all_eight_srd_masteries_have_effect_text():
+    """Every one of the 8 SRD 5.2 weapon masteries (Cleave/Graze/Nick/Push/Sap/Slow/Topple/
+    Vex) must resolve to non-empty effect text — no mastery name surfaces unexplained."""
+    by_name = {
+        "Cleave": "Greataxe", "Graze": "Greatsword", "Nick": "Scimitar", "Push": "Warhammer",
+        "Sap": "Longsword", "Slow": "Club", "Topple": "Battleaxe", "Vex": "Rapier",
+    }
+    for mastery, weapon in by_name.items():
+        rec = itemcatalog.resolve(weapon)
+        assert rec is not None and rec["mastery"] == mastery, f"{weapon} should be {mastery}"
+        assert rec.get("mastery_effect"), f"{mastery} has no effect text"
+
+
+def test_non_mastery_weapon_has_empty_mastery_effect():
+    """A weapon the SRD gives no Mastery (a Net has no mastery) carries an empty mastery AND
+    an empty mastery_effect — never a fabricated effect for a missing name."""
+    rec = itemcatalog.resolve("Net")
+    assert rec is not None
+    assert rec.get("mastery", "") == ""
+    assert rec.get("mastery_effect", "") == ""
+
+
+def test_non_weapon_has_no_mastery_effect_byte_identical():
+    """ADDITIVE INVARIANT: a non-weapon (Plate Armor) gains no mastery_effect — its record is
+    untouched by this change (the key is absent, exactly as before)."""
+    rec = itemcatalog.resolve("Plate Armor")
+    assert rec is not None
+    assert "mastery" not in rec
+    assert "mastery_effect" not in rec
+
+
+def test_magic_weapon_inherits_mastery_effect_via_fk():
+    """A magic weapon inherits its base weapon's Mastery NAME and EFFECT via the same Weapon FK
+    join that carries damage/category (#888) — so an enchanted Glaive reads Graze's effect."""
+    rec = itemcatalog.resolve("Frost Brand (Glaive)")  # Glaive -> Graze
+    assert rec is not None
+    assert rec["mastery"] == "Graze"
+    assert rec.get("mastery_effect"), "a magic weapon must inherit the mastery effect text"
+    assert "miss" in rec["mastery_effect"].lower()
+
+
 def test_pack_precedence_srd_wins_and_pack_adds(tmp_path, monkeypatch):
     """A content pack never overrides an SRD item of the same name (srd524 is
     first-wins) but DOES contribute its own new items."""

--- a/viewer/openworlds/screen-inventory.jsx
+++ b/viewer/openworlds/screen-inventory.jsx
@@ -598,8 +598,13 @@ function itemStatRows(item) {
   }
   // #888: the 2024 Weapon MASTERY property (Topple/Vex/Sap/…) — the advanced combat option the
   // veteran reads on a weapon. Server-resolved from the SRD Mastery assignment; blank when none.
+  // 3582dc2 optimizer (MAJOR "Weapon Mastery 'Sap' unexplained"): fold the canonical SRD EFFECT
+  // text in beside the name so the row reads "Sap — <what it does>", not a bare unexplained name.
+  // masteryEffect is server-resolved from the engine's canonical map; fall back to name-only when
+  // an older surface didn't supply it (no regression on #888).
   if (item.mastery) {
-    rows.push({ k: "Mastery", v: item.mastery });
+    const me = item.masteryEffect;
+    rows.push({ k: "Mastery", v: me ? `${item.mastery} — ${me}` : item.mastery });
   }
   // RRI-25e55fa optimizer #3: a ranged/thrown weapon shows its real range bracket
   // ("100/400 ft"); the server composes rangeDisplay from the SRD weapon range, blank for a

--- a/viewer/openworlds/screen-merchant.jsx
+++ b/viewer/openworlds/screen-merchant.jsx
@@ -39,6 +39,9 @@ function enrichWare(item, catalog) {
   // stock never carries these, so fill them (the ware's own value, if any, still wins).
   if (!merged.weaponCategory && rec.weaponCategory) merged.weaponCategory = rec.weaponCategory;
   if (!merged.mastery && rec.mastery) merged.mastery = rec.mastery;
+  // 3582dc2 optimizer (MAJOR "Weapon Mastery 'Sap' unexplained"): carry the catalog's canonical
+  // SRD mastery EFFECT text so the Market inspector explains the property too (Stash/Market parity).
+  if (!merged.masteryEffect && rec.masteryEffect) merged.masteryEffect = rec.masteryEffect;
   // RRI-25e55fa optimizer #3: carry the catalog's composed weapon range bracket so the Market
   // inspector reads "100/400 ft" for a Heavy Crossbow (the hardcoded stock never carries it).
   if (!merged.rangeDisplay && rec.rangeDisplay) merged.rangeDisplay = rec.rangeDisplay;

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -4229,6 +4229,29 @@ def _catalog_meta(name: str) -> dict:
         return {}
 
 
+def _mastery_effect(name: str) -> str:
+    """The canonical SRD 5.2 weapon-mastery EFFECT text for a mastery NAME (3582dc2 optimizer
+    MAJOR: "Weapon Mastery 'Sap' unexplained"). The ENGINE is the sole author of the wording —
+    this delegates to itemcatalog's canonical map so the viewer never re-states the strings.
+    A persisted Item carries the mastery NAME (F09-7) but not the effect, so a renamed/enchanted
+    weapon still explains its mastery by deriving the text from that name. Empty string for an
+    empty/unknown mastery, so the inspector hides the row (never fabricated)."""
+    nm = (name or "").strip()
+    if not nm:
+        return ""
+    # Reuse the lazily-loaded engine module _catalog_meta primed; load it the same way.
+    global _ITEMCATALOG, _ITEMCATALOG_TRIED
+    if _ITEMCATALOG is None and not _ITEMCATALOG_TRIED:
+        _ITEMCATALOG_TRIED = True
+        _ITEMCATALOG = _engine_module("itemcatalog")
+    if _ITEMCATALOG is None:
+        return ""
+    try:
+        return _ITEMCATALOG._mastery_effect(nm) or ""
+    except Exception:
+        return ""
+
+
 # Weapon-property slugs the SRD catalog stamps on a Weapon record (`is_simple` ->
 # "simple", `is_improvised` -> "improvised") and the attunement clause it stamps on a
 # MagicItem ("attune:<detail>"). Rendered verbatim as pills; the leading "attune:" is
@@ -4307,6 +4330,9 @@ def _catalog_stat_block(name: str) -> dict:
         # Sap". Empty for non-weapons / unresolved — the screen hides the row (never fabricated).
         "weaponCategory": _text(meta.get("weapon_category")) if damage else "",
         "mastery": _text(meta.get("mastery")) if damage else "",
+        # 3582dc2 optimizer (MAJOR "Weapon Mastery 'Sap' unexplained"): the canonical SRD effect
+        # text the engine resolved alongside the name, so the Market inspector explains the property.
+        "masteryEffect": _text(meta.get("mastery_effect")) if damage else "",
         "attunement": bool(meta.get("requires_attunement")),
         "properties": _catalog_property_chips(meta),
         "description": _text(meta.get("description")),
@@ -4435,6 +4461,10 @@ def _item_stat_block(item: dict, meta: dict) -> dict:
     if cost is None:
         cost = _num(item.get("cost"))
 
+    # #888: the weapon MASTERY name (persisted-first, then by-name catalog) — gated on damage so
+    # only a weapon carries it. Captured once so the 3582dc2 effect text derives from the SAME name.
+    mastery = pick_str("mastery") if damage else ""
+
     # Property chips: prefer the item's own persisted SRD tags (stealth-disadvantage, str-13,
     # attune:…); fall back to the catalog's only when the item carries none. Same formatter.
     raw_props = item.get("properties")
@@ -4464,7 +4494,11 @@ def _item_stat_block(item: dict, meta: dict) -> dict:
         # (F09-7 Item fields) then by-name catalog fallback, damage-gated. The Stash Examine
         # depth the veteran/optimizer asked for ("category + Weapon Mastery property").
         "weaponCategory": pick_str("weapon_category") if damage else "",
-        "mastery": pick_str("mastery") if damage else "",
+        "mastery": mastery,
+        # 3582dc2 optimizer (MAJOR "Weapon Mastery 'Sap' unexplained"): the canonical SRD effect
+        # text. The Item persists only the mastery NAME (F09-7), so derive the effect from that
+        # name via the engine's canonical map — a renamed/enchanted weapon still explains its mastery.
+        "masteryEffect": _mastery_effect(mastery) if damage else "",
         "costGp": cost,
         "propertyChips": prop_chips,
     }
@@ -4544,6 +4578,9 @@ def _inventory_items(cid: str, ch: dict) -> list[dict]:
             # asked for. Empty/None for non-weapons so the screen hides each row (never fabricated).
             "weaponCategory": stats["weaponCategory"],
             "mastery": stats["mastery"],
+            # 3582dc2 optimizer (MAJOR): the canonical SRD effect text so the Stash Examine panel
+            # explains the mastery, not just names it. Empty for non-weapons (the row is hidden).
+            "masteryEffect": stats["masteryEffect"],
             "attackBonus": attack_bonus,
             "attunement": attunement,
             "attuned": bool(item.get("attuned")),

--- a/viewer/tests/test_item_inspector.py
+++ b/viewer/tests/test_item_inspector.py
@@ -180,6 +180,41 @@ class ItemInspectorBehaviourTests(unittest.TestCase):
         self.assertEqual(kv.get("Category"), "Martial Weapon")
         self.assertEqual(kv.get("Mastery"), "Sap")
 
+    # --- 3582dc2 optimizer (MAJOR): the Mastery EFFECT, not just the name -----------
+    def test_weapon_inspector_shows_mastery_effect_not_just_name(self):
+        """The 3582dc2 optimizer "Weapon Mastery 'Sap' unexplained": the inspector showed the
+        Mastery NAME but not WHAT IT DOES. The Mastery row must read name + effect so a player
+        understands the property (e.g. "Sap — ...Disadvantage on its next attack roll...")."""
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Longsword', type: 'weapon', damage: '1d8', "
+            "  damageType: 'slashing', mastery: 'Sap', "
+            "  masteryEffect: 'If you hit a creature with this weapon, that creature has "
+            "Disadvantage on its next attack roll before the start of your next turn.' });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertIn("Mastery", kv)
+        self.assertIn("Sap", kv["Mastery"])
+        self.assertIn("Disadvantage", kv["Mastery"],
+                      "the Mastery row must explain the effect, not just name it")
+
+    def test_mastery_without_effect_still_shows_name(self):
+        # A weapon whose effect text didn't resolve (older surface) must still show the NAME
+        # (no regression on #888) — the name-only row, never a blank.
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Longsword', type: 'weapon', damage: '1d8', "
+            "  mastery: 'Sap' });"
+        )
+        kv = {r["k"]: r["v"] for r in rows}
+        self.assertEqual(kv.get("Mastery"), "Sap")
+
+    def test_nonweapon_omits_mastery_effect_row(self):
+        # A non-weapon must NOT fabricate a Mastery row even if a masteryEffect leaks in.
+        rows = self._run(
+            "return win.itemStatRows({ name: 'Healing Potion', type: 'potion', "
+            "  masteryEffect: 'should not show' });"
+        )
+        self.assertNotIn("Mastery", {r["k"] for r in rows})
+
     def test_negative_attack_bonus_renders_with_sign(self):
         rows = self._run(
             "return win.itemStatRows({ name: 'Club', type: 'weapon', damage: '1d4', attackBonus: -1 });"
@@ -504,6 +539,20 @@ class ItemInspectorWiringTests(unittest.TestCase):
         self.assertEqual(sl["weaponCategory"], "")
         self.assertEqual(sl["mastery"], "")
 
+    # 3582dc2 optimizer (MAJOR "Weapon Mastery 'Sap' unexplained"): the catalog endpoint also
+    # exposes the mastery EFFECT text alongside the name so the Market/Stash inspector can explain
+    # what the property does — not just name it.
+    def test_item_catalog_endpoint_exposes_mastery_effect(self):
+        status, _ctype, body = self._get("/item-catalog?name=Longsword&name=Studded%20Leather")
+        items = json.loads(body)["items"]
+        ls = items["Longsword"]
+        self.assertEqual(ls["mastery"], "Sap")
+        self.assertIn("masteryEffect", ls)
+        self.assertIn("disadvantage", ls["masteryEffect"].lower())
+        self.assertIn("next attack", ls["masteryEffect"].lower())
+        # armor carries an empty mastery effect (honest empty — the row is hidden)
+        self.assertEqual(items["Studded Leather"]["masteryEffect"], "")
+
     # F09-6 / #874: the catalog endpoint (the Market's source of truth) composes the SAME
     # honest armor dex-rule the Stash inspector carries — medium armor reads its DEX cap and
     # a shield reads its bonus, so the Market never re-exhibits the flat "AC 14"/"AC 2" bug.
@@ -623,6 +672,17 @@ class StashAttackBonusReadModelTests(unittest.TestCase):
         self.assertIsNone(it["attackBonus"])
         self.assertEqual(it["weaponCategory"], "")
         self.assertEqual(it["mastery"], "")
+        # 3582dc2 optimizer: a non-weapon carries an empty mastery effect (row hidden).
+        self.assertEqual(it["masteryEffect"], "")
+
+    def test_inventory_weapon_carries_mastery_effect(self):
+        # 3582dc2 optimizer (MAJOR): the end-to-end Stash read-model surfaces the Sap mastery
+        # EFFECT text alongside the name, so the Examine panel explains what Sap does.
+        ch = {**self.OWNER, "inventory": [{"name": "Longsword"}]}
+        it = server._inventory_items("c1", ch)[0]
+        self.assertEqual(it["mastery"], "Sap")
+        self.assertIn("disadvantage", it["masteryEffect"].lower())
+        self.assertIn("next attack", it["masteryEffect"].lower())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The complaint (3582dc2 sweep · optimizer · MAJOR)

The Examine panel shows a weapon's Mastery **NAME** (e.g. "Sap") but **NOT what it does** — *"Weapon Mastery 'Sap' unexplained"*. #888 already surfaced the mastery NAME on the resolved weapon record; the gap was the **EFFECT** text.

## The fix (additive — factual SRD content + render)

### Engine (sole writer) — `servers/engine/itemcatalog.py`
- Add a canonical `_MASTERY_EFFECTS` map of the **8 SRD 5.2 weapon-mastery effects** (Cleave / Graze / Nick / Push / Sap / Slow / Topple / Vex), verbatim per the SRD 5.2 weapon-mastery list, plus a `_mastery_effect(name)` resolver.
- Surface `mastery_effect` on the resolved weapon record **alongside** the existing `mastery` name — in **both** the bare-`Weapon` flatten path and the magic-weapon FK path (so an enchanted Glaive inherits Graze's effect exactly like it inherits damage/category).

### Viewer (read-only) — `viewer/server.py`, `screen-inventory.jsx`, `screen-merchant.jsx`
- A `_mastery_effect` helper that **delegates to the engine's canonical map** — the engine stays the sole author of the wording; the viewer never restates the strings.
- Pass `masteryEffect` through all three read-model surfaces: the `/item-catalog` render record (Market source of truth), `_item_stat_block` (derives the effect from the persisted/resolved mastery NAME so a renamed/enchanted weapon still explains it), and the `_inventory_items` Stash projection.
- `screen-inventory.jsx`: the Mastery row reads **"Sap — <effect>"** when the effect is present, falling back to name-only otherwise (no #888 regression).
- `screen-merchant.jsx`: `enrichWare` carries `masteryEffect` for Stash/Market parity.

## Invariants (additive)
- A weapon with **no mastery** — and any **non-weapon** — is **byte-identical**: the `mastery_effect` key is absent, exactly as before.
- **Engine sole writer**; **viewer read-only**; no wire/schema break. The `Item` model is unchanged — the effect derives from the persisted mastery name.

## TDD
**Engine** (`tests/test_itemcatalog.py`, RED pre-fix):
- `test_resolve_weapon_exposes_mastery_effect_alongside_name`
- `test_mastery_effect_text_matches_srd_for_sap_topple_vex`
- `test_all_eight_srd_masteries_have_effect_text`
- `test_non_mastery_weapon_has_empty_mastery_effect`
- `test_non_weapon_has_no_mastery_effect_byte_identical`
- `test_magic_weapon_inherits_mastery_effect_via_fk`

**Viewer** (`tests/test_item_inspector.py`, RED pre-fix):
- `test_weapon_inspector_shows_mastery_effect_not_just_name`
- `test_mastery_without_effect_still_shows_name`
- `test_nonweapon_omits_mastery_effect_row`
- `test_item_catalog_endpoint_exposes_mastery_effect`
- `test_inventory_weapon_carries_mastery_effect`
- (plus a non-weapon negative-disclosure assertion in `test_inventory_nonweapon_item_has_null_attack_bonus`)

## Verification
- Engine: **2750 passed**
- Viewer: **628 passed, 1 skipped** (pre-existing), 53 subtests passed
- `bash qa/fast_gate.sh`: **PASS** (221 passed — deterministic engine + seat-path + rest/travel/combat)