### PR TITLE
test(viewer): lock in 2 more "act of <X>" survive-cases for the chronicle inter-beat strip

### DIFF
--- a/viewer/tests/test_chronicle_dedup_opening.py
+++ b/viewer/tests/test_chronicle_dedup_opening.py
@@ -187,6 +187,12 @@ def test_real_prose_mentioning_a_beat_or_transition_survives():
         "Start of the chapter that defined her, though she did not yet know it.",
         "Beginning the act of contrition, the old priest knelt in the ash.",
         "He took up his part of the story and carried it to the gate.",
+        # The "act of <X>" idiom (mercy/war/treason) is the worst over-strip risk, and the
+        # arm-1 "<end/start/beginning of the …>" form must spare it: the engine seam note ends
+        # on its own struct (beat|scene), but here the struct is "act"/"chapter" or sits
+        # mid-sentence with prose trailing, so the terminal-anchored arms leave it untouched.
+        "At the start of the act, the curtain rose on a darkened stage.",
+        "The beginning of the act of treason was a single forged letter.",
     ):
         out = _sanitize(prose)
         assert out.strip() == prose.strip(), f"real in-world prose was wrongly stripped: {prose!r} -> {out!r}"


### PR DESCRIPTION
## What

Adds two confirmed real-prose strings to the survive-case list in
`test_real_prose_mentioning_a_beat_or_transition_survives`
(`viewer/tests/test_chronicle_dedup_opening.py`):

- `At the start of the act, the curtain rose on a darkened stage.`
- `The beginning of the act of treason was a single forged letter.`

Both must pass through `sanitizeNarration` **unchanged**.

## Why

The `_BEAT_TRANSITION` regex added in #890 strips inter-beat transition meta-text
("End of beat.", "Beginning the next beat.") from the player-facing chronicle. Two of
its arms (`<end/close/beginning/start> of the <struct>` and `<begin/start> the <struct>`)
could over-strip legitimate fiction containing the `act of <X>` idiom
(act of mercy / war / treason / contrition) — the worst-offender class, since story
quality is the project's north star.

**The production fix is already shipped in #890 itself** (commit a422b57): the two arms
use `_STRUCT_FWD = "(?:beat|scene)"` (dropping `act`/`chapter`/`part`) and a terminal
`\s*[.!?]?\s*$` anchor. Verified under Node: all six confirmed false-positive sentences
survive the *current* regex, while the pre-fix form strips all six — and the engine seam
notes ("End of beat.", "Beginning the next beat.") still strip correctly.

The test file already covered 4 of the 6 confirmed strings (1 verbatim + 3 close
variants + a bonus "part of the story" case). This PR adds the remaining 2 so every
confirmed string is locked in as a regression guard. These have teeth: they fail against
the pre-fix regex, pass against the shipped one.

## Test

Test-only, additive (6 lines). No production change.

```
cd viewer && python3 -m pytest tests/test_chronicle_dedup_opening.py -q
# 13 passed
```