### PR TITLE
feat(viewer): Rest & Prepare spell-selection commit (optimizer: choose prepared spells)

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -339,10 +339,11 @@ function ScreenCharacter({ onNavigate, state, setState, liveSession }) {
   );
 }
 
-// #397 — the build-choice PICKER. Unlike RestPrepareModal (display-only), this writes for real:
-// it reads the engine-owned legal level-up preview from /build-options (HP/features/slots — never
-// faked), and on confirm relays a `do` move-intent to the DM, who resolves it through the engine
-// level_up tool (sole writer) exactly as camp-sidebar.jsx relays "make camp". The subclass is NOT
+// #397 — the build-choice PICKER. Like RestPrepareModal's prepare step (which relays prepare_spells
+// the same way), this writes for real: it reads the engine-owned legal level-up preview from
+// /build-options (HP/features/slots — never faked), and on confirm relays a `do` move-intent to the
+// DM, who resolves it through the engine level_up tool (sole writer) exactly as camp-sidebar.jsx
+// relays "make camp" and RestPrepareModal relays the rest + prepare. The subclass is NOT
 // a hardcoded dropdown — the engine does not enumerate world-canon subclasses (class_data has no
 // subclass list); the player NAMES it and the DM, which knows the world's options, finalizes it.
 function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
@@ -700,8 +701,25 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hero.id]);
 
+  // The prepared CAP (engine-mirrored read-model: prepared-caster-level + casting-ability mod;
+  // half for a Paladin/Ranger). A prepared caster may have only `cap` LEVELED spells prepared at
+  // once — the optimizer's MAJOR "only 3 of 7 prepared" with no visible budget. null/absent for a
+  // known-caster (Bard/Sorcerer/Warlock) or non-caster -> no cap is enforced or shown.
+  const cap = (typeof hero.preparedCap === "number" && hero.preparedCap > 0) ? hero.preparedCap : null;
+  // CANTRIPS (spell level 0) are ALWAYS-known and never count against the prepared cap — only
+  // leveled spells (level >= 1) consume the budget. Count the currently-selected leveled spells.
+  const leveledSelected = Object.keys(prepared)
+    .filter((lv) => Number(lv) > 0)
+    .reduce((sum, lv) => sum + ((prepared[lv] || []).length), 0);
+  const atCap = cap !== null && leveledSelected >= cap;
+
   const toggleSpell = (lv, name) => {
     const cur = prepared[lv] || [];
+    const selecting = !cur.includes(name);
+    // Block SELECTING a new LEVELED spell once the cap is full (deselecting is always allowed; a
+    // cantrip at level 0 is never blocked). The engine remains the sole writer — this is a UI
+    // guard so the relayed preparation can never exceed the caster's legal prepared count.
+    if (selecting && Number(lv) > 0 && atCap) return;
     if (cur.includes(name)) {
       setPrepared({ ...prepared, [lv]: cur.filter((n) => n !== name) });
     } else {
@@ -904,6 +922,26 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
                 {hero.name} reads by the dying fire. Choose what will be at hand when the day breaks — the whole class spell list is yours to browse. Unchosen spells remain bound to the page.
               </p>
 
+              {/* The prepared CAP budget: "N / cap selected" of LEVELED spells (cantrips excluded).
+                  The optimizer's MAJOR was "3 of 7 prepared" with no visible budget — this shows
+                  exactly how many leveled spells fit. Shown only when the read-model gives a cap
+                  (a prepared caster); a known-caster/non-caster sees no counter (never a fake cap). */}
+              {cap !== null && prepPool.length > 0 && (
+                <div data-worldos-testid="prep-cap-counter" aria-live="polite" style={{
+                  marginTop: 14, padding: "8px 12px",
+                  display: "flex", justifyContent: "space-between", alignItems: "baseline",
+                  background: atCap ? "rgba(122,40,32,0.10)" : "rgba(176,141,87,0.08)",
+                  boxShadow: atCap ? "inset 0 0 0 1px var(--crimson)" : "inset 0 0 0 1px rgba(140,100,60,0.3)",
+                }}>
+                  <span className="eyebrow" style={{ fontSize: 10, color: atCap ? "var(--crimson)" : "var(--ink-700)" }}>
+                    Leveled spells prepared
+                  </span>
+                  <span style={{ fontFamily: "var(--f-display)", fontSize: 16, color: atCap ? "var(--crimson)" : "var(--emerald)" }}>
+                    {`${leveledSelected} / ${cap} selected`}
+                  </span>
+                </div>
+              )}
+
               {/* #754 — pick from the FULL browsable class list (hero.preparableSpells), grouped
                   by spell level and capped to the caster's highest slot level by the engine. The
                   optimizer could never SELECT a new spell before; now the entire preparable pool
@@ -925,11 +963,17 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
                     <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
                       {group.list.map((sp) => {
                         const isPrepared = cur.includes(sp.name);
+                        // A LEVELED (level >= 1) spell that ISN'T already selected is disabled once
+                        // the cap is full — you can't prepare more than the budget. Cantrips
+                        // (group.level 0) and already-selected spells (to deselect) stay clickable.
+                        const capBlocked = !isPrepared && group.level > 0 && atCap;
                         return (
                           <button
                             key={sp.name}
                             data-worldos-testid={`prep-spell-${slug(sp.name)}`}
                             aria-pressed={isPrepared ? "true" : "false"}
+                            disabled={capBlocked}
+                            title={capBlocked ? `Prepared cap reached (${cap}) — unprepare a spell to make room` : undefined}
                             onClick={() => toggleSpell(group.level, sp.name)}
                             style={{
                               display: "grid", gridTemplateColumns: "40px 1fr auto", gap: 10, alignItems: "center",
@@ -941,7 +985,8 @@ function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, on
                               boxShadow: isPrepared
                                 ? "inset 0 0 0 1px var(--b-500), inset 0 0 0 3px var(--p-100), inset 0 0 0 4px var(--b-400), 0 0 14px -4px var(--gold-glow)"
                                 : "inset 0 0 0 1px rgba(140,100,60,0.25)",
-                              cursor: "pointer",
+                              cursor: capBlocked ? "not-allowed" : "pointer",
+                              opacity: capBlocked ? 0.45 : 1,
                               transition: "all 140ms",
                             }}
                           >

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3860,6 +3860,11 @@ def _character_sheet(cid: str, ch: dict) -> dict:
         # currently prepared. A prepared caster (Paladin/Cleric/Druid/Wizard) plans FROM this;
         # empty for a non-caster. Derived from the engine's own srd524 class↔spell map.
         "preparableSpells": _preparable_spells_view(ch),
+        # How many LEVELED spells this prepared caster may have prepared at once (5e cap:
+        # prepared-caster-level + casting-ability mod; half for a Paladin/Ranger). Drives the
+        # Rest & Prepare "N / cap selected" counter + the over-prepare block so the viewer can
+        # enforce the cap without engine math. None for a known-caster / non-caster (no cap UI).
+        "preparedCap": _prepared_spell_cap(ch),
         # Character-level casting summary (Spell Save DC + Spell Attack Bonus) for the top
         # of the Spells tab. None for a non-caster (Fighter/Rogue) — the screen omits it
         # rather than show a fake DC. Derived from the PC's casting ability + proficiency.
@@ -4031,6 +4036,16 @@ _CASTING_ABILITY = {
     "ranger": "wisdom", "sorcerer": "charisma", "warlock": "charisma", "wizard": "intelligence",
 }
 
+# Which classes PREPARE spells each day (vs the known-casters Bard/Sorcerer/Warlock that learn a
+# fixed list and never re-prepare). Mirrors the engine's prepared-caster set — the only classes a
+# Rest & Prepare CAP applies to. Value = the SRD caster-progression tier ("full" or "half") that
+# drives how many prepared-caster levels count toward the cap (a half-caster contributes only half
+# its level, rounded down per the SRD 2024 preparation rule the task specifies).
+_PREPARED_CASTER_TIER = {
+    "cleric": "full", "druid": "full", "wizard": "full",
+    "paladin": "half", "ranger": "half",
+}
+
 
 def _casting_ability(ch: dict) -> str | None:
     """The full ability key (e.g. "intelligence") the character casts with, from their
@@ -4090,6 +4105,51 @@ def _character_spellcasting(ch: dict) -> dict | None:
         "spellSaveDc": _spell_save_dc(ch),
         "spellAttackBonus": _spell_attack_bonus(ch),
     }
+
+
+def _prepared_spell_cap(ch: dict) -> int | None:
+    """How many LEVELED spells a PREPARED caster may have prepared at once (5e prepared-caster
+    rule), so the Rest & Prepare UI can enforce "N / cap selected" and block over-preparation.
+
+    Per SRD: a prepared caster prepares (prepared-caster-level + casting-ability modifier) spells,
+    minimum 1. A FULL prepared caster (Cleric/Druid/Wizard) counts its whole class level; a
+    HALF-caster (Paladin/Ranger) counts floor(class_level / 2) — the formula the task specifies
+    for a L10 Paladin (floor(10/2) = 5, + CHA mod). Multiclass prepared casters sum each prepared
+    class's level contribution, then add the single casting-ability modifier (the engine's
+    _casting_ability picks the first caster class). Cantrips are ALWAYS-known and never counted
+    against this cap — the caller excludes level-0 spells.
+
+    Returns None for a non-preparing caster — the known-casters Bard/Sorcerer/Warlock (no daily
+    preparation) and every non-caster (Fighter/Rogue/NPC). The UI then shows no cap and never
+    fabricates one. Reads only engine-set classes/abilities (read-only; no new engine math)."""
+    classes = ch.get("classes") if isinstance(ch.get("classes"), list) else []
+    if not classes:
+        # Fall back to the single `class`/`klass` + top-level `level` for a thin sheet.
+        cname = _text(ch.get("class") or ch.get("klass")).lower()
+        tier = _PREPARED_CASTER_TIER.get(cname)
+        if tier is None:
+            return None
+        lvl = _num(ch.get("level"))
+        lvl = int(lvl) if lvl is not None else 1
+        classes = [{"name": cname, "level": lvl}]
+    prepared_levels = 0
+    has_prepared_class = False
+    for cl in classes:
+        if not isinstance(cl, dict):
+            continue
+        tier = _PREPARED_CASTER_TIER.get(_text(cl.get("name") or cl.get("class_name")).lower())
+        if tier is None:
+            continue
+        has_prepared_class = True
+        lvl = _num(cl.get("level"))
+        lvl = int(lvl) if lvl is not None else 1
+        prepared_levels += lvl if tier == "full" else (lvl // 2)
+    if not has_prepared_class:
+        return None
+    ability = _casting_ability(ch)
+    abilities = ch.get("abilities") if isinstance(ch.get("abilities"), dict) else {}
+    mod = _ability_mod(abilities.get(ability)) if ability else 0
+    return max(1, prepared_levels + mod)
 
 
 def _highest_slot_level_from_sheet(ch: dict) -> int:

--- a/viewer/tests/test_charsheet_depth.py
+++ b/viewer/tests/test_charsheet_depth.py
@@ -126,6 +126,41 @@ class CharsheetDepthTests(unittest.TestCase):
         self.assertEqual(cast["spellSaveDc"], 15)
         self.assertEqual(cast["spellAttackBonus"], 7)
 
+    # ── prepared-spell CAP (Rest & Prepare budget) ──────────────────────────────
+
+    def test_prepared_cap_full_caster_is_level_plus_ability_mod(self):
+        """A FULL prepared caster (Wizard L3, INT 16 -> +3) prepares level + mod = 3 + 3 = 6."""
+        self.assertEqual(server._prepared_spell_cap(_SNAPSHOT["characters"]["elara"]), 6)
+
+    def test_prepared_cap_half_caster_paladin_is_floor_half_level_plus_mod(self):
+        """A HALF-caster Paladin (L10, CHA 16 -> +3) prepares floor(10/2) + 3 = 8 — the formula the
+        Rest & Prepare task specifies for the L10 Paladin in the complaint."""
+        paladin = {
+            "id": "wyll", "name": "Wyll",
+            "classes": [{"name": "Paladin", "level": 10, "subclass": "Oath of Vengeance"}],
+            "abilities": {"strength": 16, "dexterity": 10, "constitution": 14,
+                          "intelligence": 10, "wisdom": 11, "charisma": 16},
+            "proficiency_bonus": 4,
+        }
+        self.assertEqual(server._prepared_spell_cap(paladin), 8)
+
+    def test_prepared_cap_never_below_one(self):
+        """The cap floors at 1 even when level + a NEGATIVE ability mod would compute lower (a L1
+        half-caster Ranger with WIS 8 -> floor(1/2)=0 + (-1) = -1, clamped to 1)."""
+        ranger = {
+            "id": "r", "name": "Ranger",
+            "classes": [{"name": "Ranger", "level": 1}],
+            "abilities": {"wisdom": 8, "strength": 14, "dexterity": 16,
+                          "constitution": 12, "intelligence": 10, "charisma": 10},
+        }
+        self.assertEqual(server._prepared_spell_cap(ranger), 1)
+
+    def test_prepared_cap_none_for_known_caster_and_non_caster(self):
+        """A KNOWN-caster (Bard — never re-prepares) and a non-caster (Fighter) have NO cap, so the
+        Rest & Prepare UI shows no budget (never a fabricated one)."""
+        self.assertIsNone(server._prepared_spell_cap(_SNAPSHOT["characters"]["lyric"]))   # Bard
+        self.assertIsNone(server._prepared_spell_cap(_SNAPSHOT["characters"]["thornwick"]))  # Fighter
+
     # ── end-to-end via the real /character-surface route ────────────────────────
 
     def setUp(self):
@@ -216,6 +251,16 @@ class CharsheetDepthTests(unittest.TestCase):
         # Key present for a stable shape, value None -> the Spells tab header omits itself.
         self.assertIn("spellcasting", thornwick)
         self.assertIsNone(thornwick["spellcasting"])
+
+    def test_surface_exposes_prepared_cap_for_prepared_caster(self):
+        # The Rest & Prepare "N / cap selected" budget: the read-model emits preparedCap so the
+        # spell-selection UI can enforce the cap. Wizard L3 INT+3 -> 6; a Fighter has no cap (None).
+        self._write("camp_depth", _SNAPSHOT)
+        _status, surface = self._get_json("/character-surface?campaign=camp_depth")
+        party = self._party(surface)
+        self.assertEqual(party["elara"]["preparedCap"], 6)
+        self.assertIn("preparedCap", party["thornwick"])
+        self.assertIsNone(party["thornwick"]["preparedCap"])
 
     def test_surface_surfaces_engine_class_features(self):
         """Bug 2: the engine's `features` NAMES reach the surface (as classFeatures) so the

--- a/viewer/tests/test_spellbook_preparable.py
+++ b/viewer/tests/test_spellbook_preparable.py
@@ -221,6 +221,30 @@ _FIGHTER = (
     "xp: 6500, xpMax: 14000, spells: [], spellSlots: [], preparableSpells: [] }"
 )
 
+# A L10 Paladin with a prepared CAP of 5 (floor(10/2) + a +0 CHA mod, the read-model's
+# _prepared_spell_cap) and TWO cantrips in the browsable pool. Cantrips are always-known and must
+# NOT count against the cap. Currently prepares 2 leveled spells (Bless + Cure Wounds) -> 3 leveled
+# slots of the cap remain free. Used by the CAP-enforcement tests.
+_PALADIN_CAP = (
+    "{ id: 'wyll', name: 'Wyll', class: 'paladin', level: 10, preparedCap: 5, "
+    "xp: 64000, xpMax: 85000, "
+    "spells: [{ level: 'Prepared', list: ["
+    "  { name: 'Bless', glyph: 'spell', levelLabel: 'Level 1' },"
+    "  { name: 'Cure Wounds', glyph: 'spell', levelLabel: 'Level 1' } ] }], "
+    "spellSlots: [{ level: 1, max: 4, used: 0 }, { level: 2, max: 3, used: 0 }, { level: 3, max: 2, used: 0 }], "
+    "preparableSpells: ["
+    "  { name: 'Light', level: 0, levelLabel: 'Cantrip', glyph: 'spell' },"
+    "  { name: 'Sacred Flame', level: 0, levelLabel: 'Cantrip', glyph: 'spell' },"
+    "  { name: 'Bless', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Cure Wounds', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Divine Smite', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Command', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Shield of Faith', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
+    "  { name: 'Aid', level: 2, levelLabel: 'Level 2', glyph: 'spell' },"
+    "  { name: 'Lesser Restoration', level: 2, levelLabel: 'Level 2', glyph: 'spell' },"
+    "  { name: 'Daylight', level: 3, levelLabel: 'Level 3', glyph: 'spell' } ] }"
+)
+
 # The browsable preparable pool (the full Paladin L1-3 list), shared by the browser tests.
 _POOL = (
     "[ { name: 'Bless', level: 1, levelLabel: 'Level 1', glyph: 'spell' },"
@@ -286,6 +310,74 @@ class RestPrepareBrowsablePoolTests(_Harness):
         text = moves[-1]["body"]["text"].lower()
         self.assertIn("bless", text)
         self.assertIn("cure wounds", text)
+
+
+class RestPrepareCapTests(_Harness):
+    """The prepared CAP: a prepared caster prepares only (cap) LEVELED spells. The UI must show
+    "N / cap selected" and block selecting a NEW leveled spell past the cap (cantrips excluded)."""
+
+    def _mount(self):
+        return (
+            "h.mountRest({ hero: " + _PALADIN_CAP + ", party: [{ id:'wyll', name:'Wyll' }],"
+            " campaignId: 'camp1', canAct: true, dmBusy: false,"
+            " onClose: function(){}, onDone: function(){}, toast: function(){}, setState: function(){} });"
+        )
+
+    def test_prep_step_shows_selected_over_cap_counter(self):
+        # The prep step renders an "N / cap selected" counter seeded from the current 2 prepared
+        # leveled spells against the cap of 5 — the optimizer's "3 of 7 prepared" with no visible
+        # budget. (testid prep-cap-counter; text contains "2 / 5".)
+        out = self._run(
+            self._mount() +
+            "await h.click('rest-make-camp');"
+            "return ({ has_counter: h.exists('prep-cap-counter'),"
+            "  counter: (h.props('prep-cap-counter') ? null : null), text: h.text() });"
+        )
+        self.assertGreaterEqual(out["has_counter"], 1,
+                                "the prep step must show an 'N / cap selected' counter against the prepared cap")
+        self.assertIn("2 / 5", out["text"],
+                      "the counter is seeded from the current prepared count (2) and the cap (5)")
+
+    def test_selecting_past_the_cap_is_blocked(self):
+        # Start at 2 prepared (Bless, Cure Wounds). Select 3 MORE leveled spells -> 5 (== cap).
+        # The remaining unselected leveled spells must then be DISABLED (can't exceed the cap).
+        out = self._run(
+            self._mount() +
+            "await h.click('rest-make-camp');"
+            "await h.click('prep-spell-divine-smite');"     # 3
+            "await h.click('prep-spell-command');"          # 4
+            "await h.click('prep-spell-aid');"              # 5 == cap
+            "var smite = h.props('prep-spell-divine-smite');"
+            "var daylight = h.props('prep-spell-daylight');"
+            "return ({ counter: h.text(),"
+            "  daylight_disabled: !!(daylight && daylight.disabled),"
+            "  selected_still_enabled: !!(smite && smite.disabled === false || (smite && !smite.disabled)) });"
+        )
+        self.assertIn("5 / 5", out["counter"], "selecting up to the cap reads 5 / 5")
+        self.assertTrue(out["daylight_disabled"],
+                        "an unselected leveled spell must be DISABLED once the cap is reached")
+        self.assertTrue(out["selected_still_enabled"],
+                        "an already-selected spell must stay clickable so the player can deselect it")
+
+    def test_cantrips_are_excluded_from_the_cap(self):
+        # Fill the leveled cap to 5, then a CANTRIP must remain selectable (cantrips are always-known
+        # and never counted against the prepared cap) — and selecting it must NOT change the counter.
+        out = self._run(
+            self._mount() +
+            "await h.click('rest-make-camp');"
+            "await h.click('prep-spell-divine-smite');"     # 3
+            "await h.click('prep-spell-command');"          # 4
+            "await h.click('prep-spell-aid');"              # 5 == cap
+            "var light_before = h.props('prep-spell-light');"
+            "await h.click('prep-spell-light');"            # a CANTRIP — must be allowed at cap
+            "return ({ cantrip_disabled: !!(light_before && light_before.disabled),"
+            "  counter_after_cantrip: h.text() });"
+        )
+        self.assertFalse(out["cantrip_disabled"],
+                         "a cantrip must stay selectable even when the leveled cap is full (cantrips are excluded)")
+        # The counter still reads 5 / 5 — the cantrip did not consume a leveled prepared slot.
+        self.assertIn("5 / 5", out["counter_after_cantrip"],
+                      "selecting a cantrip must not advance the leveled prepared-cap counter")
 
 
 class SpellbookAvailableSectionTests(_Harness):


### PR DESCRIPTION
## What & why

The optimizer sweep (3582dc2) filed 2 MAJORs against a L10 Paladin's Rest & Prepare: "only 3 of 7 spells prepared" and "no spell preparation UI — cannot choose which spells to prepare."

Since then, #754 (browsable full class list) + #873 (wire the relay) already made the `RestPrepareModal` prep step **select + commit for real**: it browses `hero.preparableSpells` grouped by level, pre-seeds the currently-prepared set, lets the player toggle spells, and "Seal the choices" relays a `do` move-intent naming `prepare_spells` through `/move` — the engine resolves it (sole writer); the viewer posts an intent only (read-only invariant), the **same relay the #397 build-choice picker uses**.

What was still missing — and what this PR adds — is the **prepared CAP**: the optimizer's "3 of 7" had **no visible budget and no enforcement**. A prepared caster may only have a bounded number of *leveled* spells prepared.

## The fix (additive, viewer-only, no wire/schema break)

- **Read-model** (`viewer/server.py`): derive + surface `hero.preparedCap`. Per SRD, a prepared caster prepares `(prepared-caster-level + casting-ability mod)` **leveled** spells (min 1); a **half-caster** Paladin/Ranger counts `floor(level/2)` (the formula the task specifies for the L10 Paladin). `None` for a known-caster (Bard/Sorcerer/Warlock — never re-prepares) or a non-caster — no fabricated cap. Engine-mirrored caster-type (full/half); reads only engine-set classes/abilities.
- **`RestPrepareModal`** (`screen-character.jsx`): show **"N / cap selected"** of leveled spells; **block selecting a new leveled spell once the cap is full** (deselect always allowed; an over-prepared stale set is shown honestly in red); and **exclude cantrips** (always-known, never counted against the cap). The existing rest flow, Escape-dismiss, pre-seed, and the `prepare_spells` relay are untouched.

## Invariants

- Viewer stays **read-only** on state — it posts a `do` intent; it never mutates prepared spells. Engine remains the sole writer (`prepare_spells`).
- Purely **additive**: a new `preparedCap` read-model field + UI guard. No endpoint, schema, or wire change. No guardrail test weakened.

## Tests (TDD — confirmed RED pre-fix, GREEN after)

Node viewer harness, mirroring `test_spellbook_preparable.py` / `test_charsheet_depth.py`:

- `RestPrepareCapTests` (renders the real modal): the counter renders "N / cap selected"; selecting past the cap is blocked (an unselected leveled spell is `disabled` at cap, a selected one stays clickable to deselect); cantrips are excluded from the cap.
- `CharsheetDepthTests`: `_prepared_spell_cap` = `level + mod` (full), `floor(level/2) + mod` (half Paladin), floors at 1, `None` for known-caster/non-caster; and the `/character-surface` route exposes `preparedCap`.

## Verification

- `bash qa/fast_gate.sh` -> PASS (221 engine tests).
- Full viewer suite: **572 tests**; the only failures are 3 **pre-existing, environment-only** `test_full_jsonschema_when_available` errors (in `test_build_loop.py` / `test_render_backdrop.py` / `test_render_tilemap.py` — files this PR does not touch) that skip-error because `jsonschema` isn't installed locally. The 16 prepared-spell + charsheet-depth tests (incl. the 7 new) all pass.