### PR TITLE
fix(engine): enforce alive + BG3-origin-ban on the PC seat (load_canon_character kind=player) — #305

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -2809,6 +2809,23 @@ def load_canon_character(campaign_id: str, name: str = "", kind: str = "npc", ad
                 "dead_in_canon": True,
                 "name": canonical,
             }
+        # HARD GATE (#305 sibling): a BANNED BG3-ORIGIN hero (Astarion/Gale/Karlach/Lae'zel/
+        # Shadowheart/Wyll/Halsin — each ships `playable: false`) may be a temporary COMPANION or
+        # lore NPC, but must NEVER be seated as the PLAYER CHARACTER. `is_playable(rec)` is the ONE
+        # canonical origin-ban predicate (the same one list_canon_characters(playable_only=True) and
+        # start_character's `pickup:` refusal already use) — the picker FILTERED them out, but this
+        # SEAT didn't re-check, so a DM/seed that NAMED an origin as the player seated them anyway.
+        # Mirrors the dead gate above: kind=="player" only (companion/npc still allowed through
+        # below); returns the standard {"error", "origin_banned"} dict so play.sh falls back.
+        if kind == "player" and not content_mod.is_playable(rec):
+            return {
+                "error": (f"{canonical} is a banned Baldur's Gate 3 origin hero — they can only "
+                          f"join as a temporary companion, never the player character. Pick a "
+                          f"living minor figure (list_canon_characters(playable_only=True) lists "
+                          f"the playable, non-origin figures)."),
+                "origin_banned": True,
+                "name": canonical,
+            }
         dup = next((ch for ch in c.characters.values()
                     if ch.name.strip().lower() == canonical.strip().lower()), None)
         if dup is not None:

--- a/servers/engine/tests/test_origin_ban_pc_seat.py
+++ b/servers/engine/tests/test_origin_ban_pc_seat.py
@@ -1,0 +1,109 @@
+"""A banned BG3-ORIGIN hero must never be seated as the PLAYER (#305 sibling gate).
+
+The owner banned the seven core Baldur's Gate 3 origin heroes — Astarion, Gale, Karlach,
+Lae'zel, Shadowheart, Wyll (and Halsin) — as PLAYABLE PCs: they may ONLY appear as temporary
+COMPANIONS / lore NPCs, never as the hero the player embodies. Each ships marked
+`"playable": false`, and `content.is_playable(rec)` is the ONE canonical origin-ban predicate
+the playable surfaces already honour:
+  * `content.list_canon_characters(playable_only=True)` drops them from the picker;
+  * `server.start_character(origin="pickup:<name>")` refuses them with a "legend of this era"
+    error (server.py ~1830, `not is_playable(rec)`).
+
+But `server.load_canon_character(name, kind="player", …)` SEATED whatever name was passed
+WITHOUT re-checking `is_playable` — so a DM/seed that NAMED an origin as the player seated
+them anyway (the filter existed, the seat didn't enforce). These guard the additive engine
+gate that mirrors the existing #305 DEAD gate:
+  * `kind="player"` of a banned origin (playable:false) is REJECTED with a clear error;
+  * `kind="companion"` / `kind="npc"` of that SAME origin still SUCCEEDS (origins are allowed
+    as temporary companions / lore NPCs — only the PC seat is guarded);
+  * a LIVING, NON-origin (playable) canon figure as the player is UNCHANGED (happy path).
+"""
+
+import content
+import server
+
+WORLD = "baldurs-gate"
+ORIGIN = "Astarion"          # banned BG3 origin hero (playable:false), alive in canon
+# Gale is ALSO a banned origin (playable:false, alive) but is NOT pre-seeded into the world,
+# so the companion/npc load runs the FRESH-seat path (not the `already_present` short-circuit
+# that a pre-seeded NPC like Astarion would hit) — the clean assertion for "still a companion".
+ORIGIN_UNSEEDED = "Gale"
+LIVING_PC = "Aubree"         # living half-elf ranger, playable minor figure (the happy path)
+
+
+def _seed(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    c = content.seed_world(content.load_world_data(WORLD))
+    server.save_campaign(c)
+    return c
+
+
+# --- the canon corpus actually marks the origins playable:false (and alive) -------
+
+def test_astarion_is_a_banned_living_origin_in_canon():
+    # Belt-and-suspenders: the gate must trip on the ORIGIN-BAN flag, not on death — Astarion
+    # is alive, so the existing #305 dead-gate would NOT catch him. The new gate must.
+    rec = content.load_canon_character(WORLD, ORIGIN)
+    assert rec is not None, "Astarion must resolve from the canon roster"
+    assert content.is_playable(rec) is False, "a banned origin ships playable:false"
+    assert content.is_dead_record(rec) is False, "Astarion is alive — not caught by the dead gate"
+
+
+# --- the hard seat gate: banned origin rejected as the PC --------------------------
+
+def test_seat_guard_rejects_a_banned_origin_player(tmp_path, monkeypatch):
+    c = _seed(tmp_path, monkeypatch)
+    res = server.load_canon_character(c.id, ORIGIN, kind="player", add_to_party=True)
+    assert res.get("error"), "seating a banned origin as the PC must return an error"
+    assert res.get("origin_banned") is True
+    assert "companion" in res["error"].lower(), "the error must point at companion-only use"
+    # and nothing got seated as the player
+    chars = server._require(c.id).characters.values()
+    assert not any(ch.kind == "player" for ch in chars)
+
+
+def test_banned_origin_still_loadable_as_a_companion(tmp_path, monkeypatch):
+    # The ban is targeted at the PC ONLY — an origin CAN be a temporary companion. Gale is an
+    # un-seeded banned origin, so this runs the FRESH companion seat (not `already_present`).
+    c = _seed(tmp_path, monkeypatch)
+    res = server.load_canon_character(c.id, ORIGIN_UNSEEDED, kind="companion", add_to_party=True)
+    assert "error" not in res, "a banned origin must still load as a companion"
+    assert res["kind"] == "companion"
+
+
+def test_banned_origin_still_loadable_as_a_lore_npc(tmp_path, monkeypatch):
+    # …and as a lore NPC (Bestiary Persons tab). Only kind="player" is guarded.
+    c = _seed(tmp_path, monkeypatch)
+    res = server.load_canon_character(c.id, ORIGIN_UNSEEDED, kind="npc")
+    assert "error" not in res, "a banned origin must still load as a lore NPC"
+    assert res["kind"] == "npc"
+
+
+def test_living_non_origin_canon_pc_is_seatable(tmp_path, monkeypatch):
+    # HAPPY PATH UNCHANGED: a living, playable (non-origin) canon figure seats as the PC.
+    c = _seed(tmp_path, monkeypatch)
+    res = server.load_canon_character(c.id, LIVING_PC, kind="player", add_to_party=True)
+    assert "error" not in res, res
+    ch = server._require(c.id).characters[res["id"]]
+    assert ch.kind == "player" and ch.id in server._require(c.id).party
+
+
+def test_synthetic_banned_origin_blocked_playable_record_allowed(tmp_path, monkeypatch):
+    # Belt-and-suspenders with a SYNTHETIC pair (robust to canon-corpus edits): a playable:false
+    # record is gated as the PC, an otherwise-identical playable record is not. Patch the content
+    # loader the tool calls (same technique as test_canon_abilities / test_playable_alive).
+    c = _seed(tmp_path, monkeypatch)
+    banned = {"name": "Origin Hero", "class": "Fighter", "level": "3", "playable": False,
+              "backstory": "Origin Hero is a living legend of the Sword Coast, a top hero."}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: dict(banned))
+    res = server.load_canon_character(c.id, "Origin Hero", kind="player", add_to_party=True)
+    assert res.get("origin_banned") is True and res.get("error")
+    # …but the SAME banned record IS allowed as a companion.
+    res_comp = server.load_canon_character(c.id, "Origin Hero", kind="companion")
+    assert "error" not in res_comp and res_comp["kind"] == "companion"
+
+    playable = {"name": "Minor Figure", "class": "Fighter", "level": "3", "playable": True,
+                "backstory": "Minor Figure is a living guard who patrols the Lower City."}
+    monkeypatch.setattr(server.content_mod, "load_canon_character", lambda world_id, name: dict(playable))
+    res2 = server.load_canon_character(c.id, "Minor Figure", kind="player", add_to_party=True)
+    assert "error" not in res2 and not res2.get("origin_banned")


### PR DESCRIPTION
## The bug (owner, 2026-06-15)

QA runs (and players) could get seated as a PC a character who should NOT be playable:

- a canon-**DEAD** figure (Dal Lightspark is canonically dead — #305; "a corpse must never be picked up as the PC"), and
- a **banned BG3-origin hero** (Astarion, Gale, Karlach, Lae'zel, Shadowheart, Wyll, Halsin — banned as PCs; they may ONLY appear as temporary **companions/NPCs**).

Owner: *"I banned all the core original Baldur's Gate 3 characters... the system doesn't always respect that,"* and *"there's a dead character that was chosen for the QA runs."*

## Root cause — the filter exists but the seat didn't enforce

`list_canon_characters(playable_only=True)` correctly drops dead figures (`alive_only` / `is_dead_record`) **and** the BG3 origins (each ships `playable: false`). `start_character`'s `pickup:` path re-checks **both** (`not is_playable(rec)` → "legend of this era"; `is_dead_record(rec)` → dead-in-canon).

But `load_canon_character(name, kind="player", …)` **seated whatever name was passed**. The `#305` **dead** gate was already present on this seat — but the **origin-ban** sibling was **missing**: `is_playable(rec)` was never re-checked on the player seat. So a DM/seed that *named* a banned origin as the player seated them anyway. The rule was surfaced (in prompts) but not enforced in the engine.

The seven origins are all `playable: false` **and alive** in canon, so the existing dead gate does **not** catch them — confirming the origin-ban gate is genuinely missing.

## The fix (additive, engine = sole writer, enforce-don't-advise)

One new guard in `load_canon_character`, inserted right after the existing `#305` dead gate and mirroring it exactly:

```python
if kind == "player" and not content_mod.is_playable(rec):
    return {"error": "<name> is a banned Baldur's Gate 3 origin hero — companion only, never the PC…",
            "origin_banned": True, "name": canonical}
```

- Reuses the **ONE** canonical origin-ban predicate `content.is_playable(rec)` — the same one `list_canon_characters(playable_only=True)` and `start_character`'s `pickup:` refusal use. **No second list.**
- `kind="player"` only. `kind="companion"` and `kind="npc"` **still allow** these figures (a banned origin can be a temporary companion; an NPC can be anyone).
- A **living, non-origin** canon figure as the player is **byte-identical** (today's happy path).
- Returns the standard `{"error", "origin_banned"}` dict so `play.sh` falls back to a living, playable pick (same shape contract as the dead gate's `dead_in_canon`).

## Invariants

Additive (the living-non-origin player seat + all companion/npc seats are byte-identical — only a new early-return guard is inserted); engine sole writer; old snapshots round-trip (seat-time gate, no persisted-state change); reuses existing alive + origin-ban predicates (no forked second list); no guardrail test weakened.

## Tests — TDD, failing first

New `servers/engine/tests/test_origin_ban_pc_seat.py` (mirrors `test_playable_alive.py` / `test_canon_abilities.py` fixtures):

| test | role |
|------|------|
| `test_astarion_is_a_banned_living_origin_in_canon` | corpus fact: origins are `playable:false` **and alive** (the dead gate wouldn't catch them) |
| `test_seat_guard_rejects_a_banned_origin_player` | **RAISE** — Astarion as `kind="player"` errors (`origin_banned`), nothing seated as player |
| `test_synthetic_banned_origin_blocked_playable_record_allowed` | **RAISE** — synthetic `playable:false` blocked as PC, allowed as companion; `playable:true` allowed as PC |
| `test_banned_origin_still_loadable_as_a_companion` | allow — Gale as `kind="companion"` succeeds |
| `test_banned_origin_still_loadable_as_a_lore_npc` | allow — Gale as `kind="npc"` succeeds |
| `test_living_non_origin_canon_pc_is_seatable` | happy path unchanged — living minor figure seats as PC |

The two **RAISE** tests FAIL pre-fix (Astarion / synthetic origin got seated as the PC) and pass after. The four allow/happy-path/fact tests pass both before and after, isolating the missing gate to the `kind="player"` path.

## Verification

- Focused: `tests/test_origin_ban_pc_seat.py` → **6 passed**.
- Related guardrails (`test_playable_alive`, `test_seat_paths`, `test_canon_abilities`, `test_content`, `test_seat_census`, `test_seat_subclass_autoset`, `test_canon_maxhp`, `test_companion`) → **168 passed**.
- `bash qa/fast_gate.sh` → **221 passed**, FAST-GATE T0 PASS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Baldur's Gate 3 origin heroes can no longer be seated as the player character. These characters remain available as companions and NPCs. Users will receive guidance to select a living non-origin figure instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->