### PR TITLE
fix(app): resolve PATH from static tool dirs, never a login shell (#892 follow-up)

### DIFF
--- a/macos/WorldOSApp/Sources/WorldOSApp/App/WorldOSApp.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/App/WorldOSApp.swift
@@ -12,9 +12,9 @@ struct WorldOSApp: App {
         // #892: launched from Finder/Dock/`open -n`, the app inherits the bare LaunchServices
         // PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) and cannot find the provider CLIs
         // (claude/codex/openclaw) or the engine's uv/node — every Shell.which guard returns nil,
-        // so no provider can start and the launch wedges (`no_launcher`). Resolve the login-shell
-        // PATH once here, before any provider detection / Shell.which runs.
-        EnvironmentBootstrap.ensureLoginPATH()
+        // so no provider can start and the launch wedges (`no_launcher`). Prepend the standard
+        // tool dirs once here (no login shell → no profile side effects), before any detection.
+        EnvironmentBootstrap.ensureToolPath()
     }
 
     var body: some Scene {

--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/EnvironmentBootstrap.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/EnvironmentBootstrap.swift
@@ -1,46 +1,40 @@
 import Foundation
 
-/// Resolves the user's login-shell PATH at startup and injects it into this process's
-/// environment, so child processes — the provider CLIs (`claude`/`codex`/`openclaw`), the
-/// engine's `uv`/`node`/`python3`, and the `Shell.which()` availability guards — can find
-/// tools installed outside the bare LaunchServices PATH.
+/// Augments this process's PATH at startup with the standard macOS tool directories, so child
+/// processes — the provider CLIs (`claude`/`codex`/`openclaw`), the engine's `uv`/`node`/`python3`,
+/// and the `Shell.which()` availability guards — can be found.
 ///
-/// WHY (#892): when the `.app` is launched from Finder/Dock or `open -n`, it inherits the bare
-/// LaunchServices PATH (`/usr/bin:/bin:/usr/sbin:/sbin`) — `launchctl getenv PATH` is unset and
-/// nothing here re-resolved it. Every provider CLI lives OUTSIDE that PATH (`claude` in
-/// `~/.local/bin`; `codex`/`openclaw`/`uv`/`node` in `/opt/homebrew/bin`), so `Shell.which()`
-/// returns nil → each provider's guard throws "<CLI> is missing" → no session ever mints → the
-/// native launch wedges (the part-A gate reports `no_launcher`, and a real user can't start a
-/// game). The Codex/OpenClaw lanes partly dodged this only because they exec via `/bin/zsh -lc`
-/// (a login shell self-heals the child's PATH) — but their `Shell.which` guards run against the
-/// bare PATH and fail first. Resolving the login PATH once at startup fixes every lane uniformly.
-/// This is the canonical macOS GUI-app PATH fix.
+/// WHY (#892): launched from Finder/Dock or `open -n`, the app inherits the bare LaunchServices
+/// PATH (`/usr/bin:/bin:/usr/sbin:/sbin`; `launchctl getenv PATH` is unset). Every provider CLI
+/// lives outside it (`claude` in `~/.local/bin`; `codex`/`openclaw`/`uv`/`node` in
+/// `/opt/homebrew/bin`), so `Shell.which()` returns nil → each provider guard throws "<CLI> is
+/// missing" → no session mints → the launch wedges (`no_launcher`), and a real user can't start a
+/// game.
+///
+/// We deliberately do NOT resolve PATH by running a login shell (`zsh -lc`). A login shell sources
+/// the user's profile (`~/.zshenv`/`~/.zprofile`/`~/.zlogin`), which can have arbitrary side
+/// effects — keychain access, auto-starting other tools, touching removable volumes — so *merely
+/// launching the app* would fire all of them (observed: a keychain/codesign prompt and a removable
+/// -disk access request just from app startup). Instead we prepend a STATIC allowlist of well-known
+/// tool directories that exist. It is deterministic, runs **zero user code**, and spawns no
+/// subprocess.
 enum EnvironmentBootstrap {
-    /// Capture the login-shell PATH and merge it into this process's PATH via `setenv`, so that
-    /// `ProcessInfo.processInfo.environment["PATH"]` (and thus every child + every `Shell.which`)
-    /// carries it. Idempotent — merging an already-merged PATH yields the same set, so a second
-    /// call is a no-op. MUST run before any provider detection / `Shell.which`.
-    static func ensureLoginPATH(
-        runLoginShell: (String) -> String? = EnvironmentBootstrap.defaultRunLoginShell
-    ) {
+    /// Prepend the standard tool dirs (that exist) to this process's PATH via `setenv`, so every
+    /// child + every `Shell.which` sees them. Idempotent. MUST run before any provider detection.
+    static func ensureToolPath() {
         let current = ProcessInfo.processInfo.environment["PATH"] ?? ""
-        let login = runLoginShell(resolvedShellPath())
-        let merged = augmentedPATH(currentPATH: current, loginPATH: login)
+        let merged = augmentedPATH(currentPATH: current, extraDirs: standardToolDirs())
         if merged != current && !merged.isEmpty {
             setenv("PATH", merged, 1)
         }
     }
 
-    /// Pure + testable: merge the login-shell PATH with the current PATH — login dirs first (so
-    /// the user's tools win), the existing PATH appended, de-duped in order. Returns `currentPATH`
-    /// unchanged when the login shell yields nothing usable (fail-safe: never make PATH worse).
-    static func augmentedPATH(currentPATH: String, loginPATH: String?) -> String {
-        guard let loginRaw = loginPATH?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !loginRaw.isEmpty else {
-            return currentPATH
-        }
-        let ordered = loginRaw.split(separator: ":").map(String.init)
-            + currentPATH.split(separator: ":").map(String.init)
+    /// Pure + testable: prepend `extraDirs` to `currentPATH`, deduped in order (extras first so the
+    /// user's installed tools win — e.g. a Homebrew `python3` over the system copy, matching the
+    /// PATH a login shell would have produced). Returns `currentPATH` unchanged when there is
+    /// nothing new to add.
+    static func augmentedPATH(currentPATH: String, extraDirs: [String]) -> String {
+        let ordered = extraDirs + currentPATH.split(separator: ":").map(String.init)
         var seen = Set<String>()
         var merged: [String] = []
         for dir in ordered where !dir.isEmpty && seen.insert(dir).inserted {
@@ -49,51 +43,19 @@ enum EnvironmentBootstrap {
         return merged.joined(separator: ":")
     }
 
-    /// Prefer the user's `$SHELL` (covers bash users whose PATH lives in `.bash_profile`); fall
-    /// back to `/bin/zsh`, the macOS default and what the provider adapters already assume.
-    private static func resolvedShellPath() -> String {
-        if let shell = ProcessInfo.processInfo.environment["SHELL"],
-           shell.hasPrefix("/"),
-           FileManager.default.isExecutableFile(atPath: shell) {
-            return shell
-        }
-        return "/bin/zsh"
-    }
-
-    /// Run `<shell> -lc 'printf %s "$PATH"'` (login, non-interactive — matches the provider
-    /// adapters; sources the profile without the interactive-shell hang risk) and return its
-    /// stdout. A 5s watchdog guarantees a misconfigured profile can never hang app launch.
-    private static func defaultRunLoginShell(_ shellPath: String) -> String? {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: shellPath)
-        process.arguments = ["-lc", "printf %s \"$PATH\""]
-        let out = Pipe()
-        process.standardOutput = out
-        process.standardError = Pipe()
-        do {
-            try process.run()
-        } catch {
-            return nil
-        }
-        // Drain stdout CONCURRENTLY with the process, then wait — never read after waiting.
-        // readDataToEndOfFile blocks until the child closes stdout (at exit) while continuously
-        // emptying the pipe, so a chatty login profile that prints >64KB of banner/MOTD to stdout
-        // can't fill the OS pipe buffer and deadlock the wait (which would silently fall back to
-        // the bare PATH and re-introduce the very wedge this fixes). The captured bytes are read
-        // back only after the semaphore barrier, which publishes the background writes here.
-        let reader = out.fileHandleForReading
-        let captured = NSMutableData()
-        let done = DispatchSemaphore(value: 0)
-        DispatchQueue.global().async {
-            captured.append(reader.readDataToEndOfFile())
-            process.waitUntilExit()
-            done.signal()
-        }
-        if done.wait(timeout: .now() + .seconds(5)) == .timedOut {
-            process.terminate()
-            return nil
-        }
-        guard process.terminationStatus == 0 else { return nil }
-        return String(data: captured as Data, encoding: .utf8)
+    /// The well-known macOS dev-tool install locations, filtered to those that actually exist on
+    /// this machine. Covers the overwhelming majority of setups: `claude`/`uv` via the standard
+    /// installer (`~/.local/bin`) and `codex`/`openclaw`/`uv`/`node`/`gh`/`python3` via Homebrew
+    /// (Apple-Silicon `/opt/homebrew`, Intel `/usr/local`). Computing this runs no user code.
+    private static func standardToolDirs() -> [String] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let fileManager = FileManager.default
+        return [
+            "\(home)/.local/bin",
+            "/opt/homebrew/bin",
+            "/opt/homebrew/sbin",
+            "/usr/local/bin",
+            "/usr/local/sbin",
+        ].filter { fileManager.fileExists(atPath: $0) }
     }
 }

--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/ProviderAdapters.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/ProviderAdapters.swift
@@ -174,8 +174,11 @@ struct CodexProvider: ProviderAdapter {
         let command = configuredCommand.isEmpty ? defaultCodexCommand : configuredCommand
         return ProviderLaunchRequest(
             name: "Codex game",
+            // #892: `-f -c` skips ALL rc files (incl. ~/.zshenv) — a login/rc shell would source the
+            // user's profile and fire its side effects (keychain/Eva/removable-disk prompts). The CLIs
+            // are on PATH via the startup tool-dir prepend (EnvironmentBootstrap), inherited here.
             executable: "/bin/zsh",
-            arguments: ["-lc", command],
+            arguments: ["-f", "-c", command],
             environment: providerEnvironment(
                 kind: kind,
                 world: world,
@@ -259,8 +262,11 @@ struct OpenClawProvider: ProviderAdapter {
         }
         return ProviderLaunchRequest(
             name: "OpenClaw game",
+            // #892: `-f -c` skips ALL rc files (incl. ~/.zshenv) so app/game start never sources the
+            // user's profile (keychain/Eva/removable-disk side effects). CLIs are on PATH via the
+            // startup tool-dir prepend (EnvironmentBootstrap), inherited here.
             executable: "/bin/zsh",
-            arguments: ["-lc", command],
+            arguments: ["-f", "-c", command],
             environment: providerEnvironment(
                 kind: kind,
                 world: world,
@@ -356,8 +362,9 @@ struct ScriptedProvider: ProviderAdapter {
         }
         return ProviderLaunchRequest(
             name: "Scripted smoke game",
+            // #892: `-f -c` skips ALL rc files so launching never sources the user's profile.
             executable: "/bin/zsh",
-            arguments: ["-lc", "scripts/play_scripted_dm.sh"],
+            arguments: ["-f", "-c", "scripts/play_scripted_dm.sh"],
             environment: providerEnvironment(
                 kind: kind,
                 world: world,


### PR DESCRIPTION
## The problem (regression from #914)

#914 fixed #892 by resolving PATH at app startup via a **login shell** (`zsh -lc`). That sources the user's shell profile (`~/.zshenv`/`~/.zprofile`/`~/.zlogin`) — and **merely launching the app** ran all of it. On the owner's machine that fired:
- a **keychain / codesign password prompt** (the profile auto-touches OpenClaw/Eva, which reaches its Mac Keychain OAuth vault) — brushing the **never-touch-Eva** invariant,
- a **removable-disk (LEXAR) access request** (the profile references `/Volumes/LEXAR`),

all as pure collateral. The app only ever needed PATH — not the profile.

## Fix

- **`EnvironmentBootstrap`**: resolve PATH from a **static allowlist of standard tool dirs that exist** (`~/.local/bin`, `/opt/homebrew/{bin,sbin}`, `/usr/local/{bin,sbin}`). Deterministic, **runs zero user code, spawns no subprocess**. Verified it finds `claude`/`codex`/`openclaw`/`uv`/`node`. (This also removes the >64KB stdout pipe-deadlock that the #914 review flagged — there's no subprocess at all now.)
- **`ProviderAdapters`**: the codex/openclaw/scripted lanes launched via `/bin/zsh -lc` — the **same latent profile-sourcing** whenever a user starts one of those games (and `-c` alone still sources `~/.zshenv`). Switch to **`-f -c`** (skip ALL rc files); the CLIs are on PATH via the startup prepend, inherited by the child (verified: `zsh -f -c` passes the parent PATH through verbatim).

The claude provider (the default / autostart lane) already used `/usr/bin/env bash` (no profile) — unchanged, and it's what the #914 GREEN gate exercised.

## Verification

- Static dirs resolve all 5 CLIs from a simulated bare GUI PATH — zero subprocess, zero profile.
- `zsh -f -c` inherits the parent PATH verbatim (profile not sourced).
- `swift build` clean; grep confirms no `-lc`/login-shell remains in the launch path; `EnvironmentBootstrap` spawns no `Process`.
- The #892 mint logic is unchanged — only the PATH *source* swaps from "login-shell output" to "known dirs", which removed the side effects.

Note: a full `.app` relaunch (mint `can_act:true`) is intentionally not re-run here to avoid surprising the owner with another launch while they're mid-investigation; the mint path is unchanged from the #914 GREEN run and the tool-resolution is independently verified above. Happy to re-run the native gate to confirm end-to-end on request.