### PR TITLE
fix(qa): emit the immediate progress heartbeat on the ui_playtest move lane (match production) — dogfood fidelity

### DIFF
--- a/qa/test_ui_playtest_heartbeat.sh
+++ b/qa/test_ui_playtest_heartbeat.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# BEHAVIORAL TEST (no model call): proves qa/ui_playtest.sh now emits the immediate,
+# model-INDEPENDENT progress heartbeat on BOTH its DM lanes — the cold-open turn and the
+# per-move resolver loop — exactly like the production solo path (scripts/play.sh:440 / :620).
+#
+# THE GAP IT GUARDS (dogfood FIDELITY): the production solo loop calls
+# clawdnd_emit_progress_heartbeat BEFORE the long DM `claude -p` think, so a wrapper-authored
+# `narration` row lands in the engine /events within ~1s and the OpenWorlds viewer flips its
+# spinner to "the scene is arriving above" (viewer/openworlds/app.jsx isWrapperProgressLine →
+# notePendingProgress). The QA dogfood lane (ui_playtest.sh) had a CUSTOM inline dm_turn +
+# resolver loop that NEVER emitted the heartbeat, so a dogfood's chronicle stayed BLANK for the
+# whole ~82s beat — making the GUI playtest OVERSTATE perceived latency vs production. This is a
+# QA-HARNESS-ONLY, zero-quality-cost fidelity fix (additive; the engine stays the sole writer —
+# the heartbeat routes through log_engine_narration).
+#
+# We assert two layers, mirroring qa/test_run_duo_dm_timeout.sh's structure:
+#   STRUCTURAL — ui_playtest.sh statically wires clawdnd_emit_progress_heartbeat into BOTH the
+#     cold-open lane and the resolver loop, derives a LIVE campaign id (never a blank id, which
+#     would no-op the helper), and emits the heartbeat BEFORE the dm_turn call in each lane.
+#   BEHAVIORAL — sourcing the REAL qa/lib_beat_driver.sh with log_engine_narration stubbed, the
+#     heartbeat with a real campaign id writes a wrapper-progress row (a /events narration row)
+#     for the live campaign BEFORE the model turn; a blank id no-ops (best-effort, never fails a
+#     beat). The continuing-beat text ROTATES (the live-campaign row is non-empty + wrapper-shaped).
+#
+# Sources the REAL qa/lib_beat_driver.sh. Self-contained under mktemp; macOS + ubuntu CI safe.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/qa/lib_beat_driver.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+STATE_DIR="$TMP/state"; mkdir -p "$STATE_DIR/campaigns"
+
+fail=0
+chk() { if eval "$2"; then echo "PASS: $1"; else echo "FAIL: $1"; fail=1; fi; }
+
+UIPT="$ROOT/qa/ui_playtest.sh"
+
+# ── STRUCTURAL: ui_playtest.sh wires the heartbeat + the live-progress rule on its DM lanes ───
+# PRIMARY: the resolver loop emits the model-INDEPENDENT heartbeat per move (the production-parity
+# win). The cold-open lane mints its campaign INSIDE the turn (start_world), so — exactly like
+# scripts/play.sh's DEFAULT (no pre-seeded hero) cold open — there is no pre-turn campaign id to
+# target; its coverage is the MODEL-COOPERATIVE live-progress rule (asserted just below), which the
+# shared dm_turn now prepends to BOTH lanes. So the heartbeat is wired (≥1) AND the dm_turn carries
+# the live-progress rule, matching production parity on both halves.
+chk "ui_playtest wires clawdnd_emit_progress_heartbeat (per-move resolver lane)" \
+  'grep -q "clawdnd_emit_progress_heartbeat" "$UIPT"'
+# MODEL-COOPERATIVE half: dm_turn prepends the shared live-progress rule to the DM prompt (covers
+# BOTH the cold-open and resolver turns), parity with scripts/play.sh:288.
+chk "dm_turn prepends the shared CLAWDND_LIVE_PROGRESS_RULE (covers cold-open + resolver)" \
+  'grep -q "CLAWDND_LIVE_PROGRESS_RULE" "$UIPT"'
+# The resolver loop must derive a LIVE campaign id (clawdnd_live_campaign_id is the engine-
+# authoritative selector play.sh uses) — a blank id no-ops the helper, so the derivation is the crux.
+chk "ui_playtest derives the live campaign id (clawdnd_live_campaign_id)" \
+  'grep -q "clawdnd_live_campaign_id" "$UIPT"'
+# The resolver loop emits the heartbeat AFTER echoing the player's move (chatlog player) and
+# BEFORE resolving via dm_turn — so /events has a row before the long model think.
+chk "resolver emits heartbeat between 'chatlog player' and the dm_turn resolve" \
+  'awk "/chatlog player/{p=1} p&&/clawdnd_emit_progress_heartbeat/{h=1} p&&/DMSG=.*dm_turn 0/{print (h?\"OK\":\"NO\"); exit}" "$UIPT" | grep -q OK'
+
+# SECONDARY (alwaysLoad parity): the QA lane's generated dm.mcp.json pins the engine tools
+# (un-defer), env-gated default-on like scripts/play.sh + qa/run_duo.sh, so the DM does not burn a
+# ToolSearch round-trip re-discovering engine tools every move (production has it default-on).
+chk "ui_playtest's dm.mcp.json gen pins the engine tools (alwaysLoad parity, env-gated)" \
+  'grep -q "alwaysLoad" "$UIPT" && grep -q "CLAWDND_ENGINE_ALWAYSLOAD" "$UIPT"'
+
+# ── BEHAVIORAL: with log_engine_narration STUBBED, the heartbeat lands a wrapper row pre-turn ──
+# log_engine_narration in the real lib shells into `uv run servers/engine` (no engine in CI), so
+# stub it to capture (campaign_id, text) — the SAME seam clawdnd_emit_progress_heartbeat routes
+# through. This proves the helper writes a row for a real id and no-ops a blank id.
+EVENTS="$TMP/events.ndjson"; : > "$EVENTS"
+log_engine_narration() {
+  local campaign_id="$1" text="$2"
+  [ -n "${campaign_id//[[:space:]]/}" ] || return 1
+  [ -n "${text//[[:space:]]/}" ] || return 1
+  printf '%s\t%s\n' "$campaign_id" "$text" >> "$EVENTS"
+  return 0
+}
+
+CID="camp-live-0001"
+
+# Cold open (first=1) → the opening teaser row for the live campaign.
+clawdnd_emit_progress_heartbeat "$CID" 1 0
+chk "cold-open heartbeat wrote one /events row for the live campaign" \
+  '[ "$(grep -c "^$CID	" "$EVENTS")" -eq 1 ]'
+chk "cold-open row carries the opening progress teaser" \
+  'grep -q "^$CID	$CLAWDND_OPENING_PROGRESS_TEXT$" "$EVENTS"'
+
+# Continuing beat (first=0, idx=0) → a rotating MOVE teaser row, emitted BEFORE the model turn.
+clawdnd_emit_progress_heartbeat "$CID" 0 0
+chk "continuing-beat heartbeat wrote a SECOND row for the live campaign" \
+  '[ "$(grep -c "^$CID	" "$EVENTS")" -eq 2 ]'
+co_text="${CLAWDND_MOVE_PROGRESS_TEXTS[0]}"
+chk "continuing row carries a rotating MOVE progress teaser (idx 0)" \
+  'grep -q "^$CID	$co_text$" "$EVENTS"'
+# Every emitted row is a recognized wrapper-progress line (so app.jsx flips the spinner + returns
+# null; engine memory consumers exact-match filter it) — i.e. zero quality cost, perceived only.
+chk "every emitted heartbeat row is a wrapper-progress line" \
+  'python3 -c "import sys; sys.path.insert(0,\"$ROOT/servers/engine\"); import wrapper_progress as w; rows=[l.split(chr(9),1)[1].rstrip(chr(10)) for l in open(\"$EVENTS\")]; sys.exit(0 if rows and all(w.is_wrapper_progress_line(t) for t in rows) else 1)"'
+
+# A BLANK campaign id no-ops (best-effort — a heartbeat failure must never fail a beat) — no new row.
+before="$(wc -l < "$EVENTS" | tr -d ' ')"
+clawdnd_emit_progress_heartbeat "" 0 1
+after="$(wc -l < "$EVENTS" | tr -d ' ')"
+chk "blank campaign id no-ops the heartbeat (no /events row written)" '[ "$before" = "$after" ]'
+chk "heartbeat with a blank id still returns 0 (never fails a beat)" \
+  'clawdnd_emit_progress_heartbeat "" 0 1; [ $? -eq 0 ]'
+
+[ "$fail" = 0 ] && echo "ALL ASSERTIONS PASSED" || echo "SOME ASSERTIONS FAILED"
+exit "$fail"

--- a/qa/ui_playtest.sh
+++ b/qa/ui_playtest.sh
@@ -75,7 +75,7 @@ URL="http://127.0.0.1:$PORT/openworlds/"
 # (Identical to run_duo.sh — guards the version-skew that RED-caps a run if the DM
 #  engine runs older models.py than the snapshot writer.)
 python3 - "$ROOT/qa/qa.mcp.example.json" "$STATE_DIR" "$DM_CFG" "$ROOT" <<'PY'
-import json, sys
+import json, os, sys
 cfg_path, state, out, root = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
 cfg = json.load(open(cfg_path))
 for name, srv in cfg.get("mcpServers", {}).items():
@@ -89,6 +89,14 @@ for name, srv in cfg.get("mcpServers", {}).items():
         args[i + 1] = f"{root}/servers/{pkg}"
     if name == "clawdnd-engine":
         srv.setdefault("env", {})["CLAWDND_STATE_DIR"] = state
+        # Dogfood FIDELITY (parity with scripts/play.sh:142 + qa/run_duo.sh): PIN the engine tools
+        # (un-defer) so the DM stops burning a ~9s ToolSearch round-trip re-discovering the engine MCP
+        # tools EVERY move — production has alwaysLoad default-on, so without this the dogfood overstates
+        # per-move latency vs the real player surface. Set CLAWDND_ENGINE_ALWAYSLOAD=0 for the deferred
+        # baseline (the latency A/B arm). This generation block is LOCAL to this QA runner (it re-roots
+        # qa/qa.mcp.example.json into the run's own $DM_CFG) — NOT shared with the production play.sh gen.
+        if os.environ.get("CLAWDND_ENGINE_ALWAYSLOAD", "1") == "1":
+            srv["alwaysLoad"] = True
 json.dump(cfg, open(out, "w"))
 PY
 
@@ -157,6 +165,14 @@ dm_turn() {
   # SYN-01: pre-beat log-tail mark (once per beat — this driver is single-attempt) so the
   # caller's resolve can tell a GENUINE #357 recovery from RECYCLED pre-beat prose.
   clawdnd_dm_prebeat_mark "$STATE_DIR"
+  # #623 dogfood FIDELITY: prepend the live-progress rule (the ONE shared CLAWDND_LIVE_PROGRESS_RULE
+  # in qa/lib_beat_driver.sh — parity with scripts/play.sh:288 + scripts/play_party.sh + the codex DM)
+  # so the DM logs an EARLY /events narration beat. Its ABSENCE here mirrored the SOLO-path #623 bug:
+  # the dogfood DM emitted nothing to /events until the full ~82s beat completed, so the viewer stayed
+  # blank and the playtest OVERSTATED perceived latency vs production. This is the MODEL-COOPERATIVE
+  # half; the caller ALSO emits the model-INDEPENDENT heartbeat (clawdnd_emit_progress_heartbeat) per
+  # move before the resolve, exactly like scripts/play.sh:620. Additive — engine stays the sole writer.
+  msg="$CLAWDND_LIVE_PROGRESS_RULE"$'\n\n'"$msg"
   [ "$first" = "0" ] && resume=(--resume "$DSID") || resume=(--session-id "$DSID")
   beat_timeout="$(clawdnd_dm_timeout "$first")"
   out="$RUNDIR/dm/turn.$(date +%s%N).jsonl"
@@ -203,6 +219,9 @@ fi
 # until the harness kills it (player done / beats hit / budget out).
 (
   MCURSOR="$(wc -l < "$MOVES" 2>/dev/null | tr -d ' ')"; MCURSOR="${MCURSOR:-0}"
+  # #623 dogfood FIDELITY: a 0-based continuing-beat index so the per-move heartbeat ROTATES its
+  # teaser (clawdnd_emit_progress_heartbeat, below) exactly as scripts/play.sh:620 rotates off DM_TURNS.
+  DMLOOP_BEAT=0
   while true; do
     total="$(wc -l < "$MOVES" 2>/dev/null | tr -d ' ')"; total="${total:-0}"
     if [ "$total" -gt "$MCURSOR" ]; then
@@ -210,6 +229,21 @@ fi
       PMSG="$(printf '%s' "$new" | jq -rs 'map("[\(.kind)] \(.text // .name // "")") | join("  ")' 2>/dev/null)"
       [ -z "$PMSG" ] && continue
       chatlog player "$PMSG"
+      # #623 dogfood FIDELITY: emit the IMMEDIATE, model-INDEPENDENT progress heartbeat NOW — right
+      # after the player's move is echoed and BEFORE the long DM think — so /events has a wrapper
+      # `narration` row within ~1s and the OpenWorlds viewer flips its spinner to "the scene is
+      # arriving above" (app.jsx isWrapperProgressLine → notePendingProgress), exactly as production
+      # (scripts/play.sh:620). Without this the dogfood's chronicle stayed BLANK until the final
+      # persist (~+82s), making the GUI playtest OVERSTATE perceived latency vs the real player surface.
+      # This lane has no CAMPAIGN_ID var, so derive the LIVE id the way play.sh does (the engine-
+      # authoritative most-recently-played save; #640 — never a blind first-dir pick when the engine
+      # can answer), falling back to the first subdir only if the engine can't. A blank id no-ops the
+      # helper (best-effort; never fails a beat) — so the derivation is the crux. Engine stays the SOLE
+      # writer (the heartbeat routes through log_engine_narration). first=0 + DMLOOP_BEAT → rotates.
+      HB_CID="$(clawdnd_live_campaign_id "$ROOT" "$STATE_DIR" "$WORLD")"
+      [ -z "$HB_CID" ] && HB_CID="$(find "$STATE_DIR/campaigns" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; 2>/dev/null | head -n1)"
+      clawdnd_emit_progress_heartbeat "$HB_CID" 0 "$DMLOOP_BEAT"
+      DMLOOP_BEAT=$((DMLOOP_BEAT + 1))
       DMSG="$(dm_turn 0 "The player does:
 
 $PMSG


### PR DESCRIPTION
## Problem — dogfood FIDELITY gap (perceived latency, zero quality cost)

Latency-forensics (proven with timestamps) found that the GUI dogfood lane measures the player surface **less faithfully** than production:

- **Production solo path** (`scripts/play.sh`) emits an immediate, model-INDEPENDENT progress beat via `clawdnd_emit_progress_heartbeat` *before* the long DM `claude -p` think — so a wrapper `narration` row lands in `/events` within ~1s and the OpenWorlds viewer flips its spinner to "the scene is arriving above" (`viewer/openworlds/app.jsx` `isWrapperProgressLine` → `notePendingProgress`). It also prepends `CLAWDND_LIVE_PROGRESS_RULE` so the model logs an early in-voice beat too.
- **QA dogfood lane** (`qa/ui_playtest.sh`) has a CUSTOM inline `dm_turn` + a background DM-resolver loop that **never** called `clawdnd_emit_progress_heartbeat` and **never** prepended `CLAWDND_LIVE_PROGRESS_RULE`. So a dogfood's chronicle stayed **BLANK** until the final persist (~+82s), making the GUI playtest **OVERSTATE** perceived latency vs the real player surface (a newbie dogfood filed it MAJOR: "30+s blank, feels frozen").

The intrinsic ~100s generation is **NOT** the target — only this perceived-latency, zero-quality-cost harness gap.

## Fix (QA-harness only, additive)

**PRIMARY** — in the resolver loop, right after the player's move is echoed (`chatlog player`) and **before** the `dm_turn` resolve:
- Derive the **LIVE** campaign id the way `play.sh` does — `clawdnd_live_campaign_id` (engine-authoritative most-recently-played save; #640 — never a blind first-dir pick when the engine can answer), falling back to the first campaign subdir only if the engine can't.
- Call `clawdnd_emit_progress_heartbeat "$HB_CID" 0 "$DMLOOP_BEAT"` with a 0-based, **rotating** continuing-beat index (mirrors `scripts/play.sh:620`). A blank id no-ops the helper (best-effort; never fails a beat) — so the id derivation is the crux.
- Prepend the shared `CLAWDND_LIVE_PROGRESS_RULE` inside `dm_turn` (model-cooperative half, parity with `scripts/play.sh:288`). This covers **both** the cold-open and resolver turns. The cold-open lane mints its campaign **inside** the turn (`start_world`), so — exactly like `play.sh`'s DEFAULT cold open (no pre-seeded hero) — it has no pre-turn id to target and the live-progress rule is its coverage.

**SECONDARY** — the QA lane's generated `dm.mcp.json` now pins the engine tools (`"alwaysLoad": true`, env-gated default-on via `CLAWDND_ENGINE_ALWAYSLOAD`, parity with `scripts/play.sh` + `qa/run_duo.sh`) so the DM stops burning a ~9s `ToolSearch` round-trip re-discovering engine tools every move. This generation block is **LOCAL** to the runner (it re-roots `qa/qa.mcp.example.json` into the run's own `$DM_CFG`) — **not** shared with production `play.sh`'s gen — so it is safe to touch. Set `CLAWDND_ENGINE_ALWAYSLOAD=0` for the deferred baseline (the latency A/B arm).

## Invariants

- QA-harness-only change: `qa/ui_playtest.sh` + its `dm.mcp.json` generation.
- The engine, production `play.sh`/`play_party.sh`, the viewer, and every wire contract are **untouched**.
- The heartbeat routes through the engine's `log_engine_narration` — **engine stays the sole writer**.
- Additive.
- `--effort` is out of scope (owner's quality lever) and untouched.

## TDD

`qa/test_ui_playtest_heartbeat.sh` (RED→GREEN) asserts:
- **Structural** — the resolver wires the heartbeat between `chatlog player` and the `dm_turn` resolve, with a derived live id; `dm_turn` carries the live-progress rule; the `alwaysLoad` parity (env-gated).
- **Behavioral** (with `log_engine_narration` stubbed — no engine needed in CI) — the heartbeat writes a wrapper-progress `/events` row for the live campaign **before** the model turn, the continuing-beat text rotates, every emitted row is a recognized wrapper-progress line (so `app.jsx` flips the spinner + returns null; engine memory consumers exact-match filter it), and a **blank id no-ops** (best-effort, returns 0).

```
RED  (pre-edit): 3 structural assertions FAIL, behavioral PASS
GREEN (post-edit): ALL ASSERTIONS PASSED
```

`bash qa/fast_gate.sh` → **221 passed** (deterministic engine + seat-path + rest/travel/combat tier intact).