### PR TITLE
fix(viewer): roster shows only playable+alive heroes, with level/class + a beginner entry — dogfood

### DIFF
--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -118,6 +118,29 @@ _SELF_DEAD_CUE = re.compile(
     r"|\b(?:died|perished)\b"         # intransitive: "who died on the beach"
     r"|\b(?:killed|slain|murdered)\s+by\b",  # passive victim: "killed by a githyanki patrol"
 )
+
+# A SELF-death declared NOT in the opener but LATER in the bio (#912 UI complement / dogfood MAJOR).
+# Alexander Rainforest opens as a living citizen — "When the party reach him in Act Three, Rainforest
+# is already dead." lands in the THIRD sentence, so the opener-only scan (above) missed it and the
+# picker offered a corpse as a playable hero. This second cue scans the WHOLE backstory, but is far
+# NARROWER than `_SELF_DEAD_CUE` because a whole-bio scan is far more exposed to false positives (a
+# bio that merely mentions a third party's death — "appears … if Alfira is dead", "if he is dead").
+# Guards that make it safe to run over the whole bio:
+#   • subject-anchored: a capitalized Name token or a subject pronoun (he/she/they/it) must sit
+#     within ~6 words BEFORE the cue (so the death attaches to the SUBJECT, not a clause object);
+#   • the cue is a STATE/RESULT phrase that a conditional third party never carries: "already/now
+#     dead", "found dead/slain", "lies dead" — NOT a bare "is dead" (which "if Alfira is dead" has);
+#   • a `(?<!if )` lookbehind drops the conditional "if X is dead/found dead" third-party form.
+# This catches the genuinely-dead (Rainforest, Peartree, Prinski) with zero corpus false positives.
+_BODY_DEAD_CUE = re.compile(
+    r"(?<!if )"
+    r"(?:\b[A-Z][a-z'’-]+\b|\bhe\b|\bshe\b|\bthey\b|\bit\b)"
+    r"(?:\s+[a-z'’(),-]+){0,6}\s+"
+    r"(?:(?:is|was|are|were)\s+(?:already|now)\s+dead"
+    r"|(?:is|was)\s+found\s+(?:dead|slain)"
+    r"|lies\s+dead)\b",
+    re.IGNORECASE,
+)
 # Leading wiki magic-word directives (e.g. __notoc__, __NOTOC__) to strip off an opener.
 _WIKI_DIRECTIVE_PREFIX = re.compile(r"^(?:__[a-z]+__\s*)+", re.IGNORECASE)
 # F10-7: the SAME wiki magic words anywhere in a string (not just the opener), with any
@@ -165,8 +188,15 @@ def is_dead_record(rec: dict) -> bool:
     for field in ("status", "fate", "life_status"):
         if ending_role_from_status(str(rec.get(field, "") or "")) == "died":
             return True
-    opener = _death_opener(rec.get("backstory", ""))
-    return bool(opener) and bool(_SELF_DEAD_CUE.search(opener))
+    backstory = rec.get("backstory", "")
+    opener = _death_opener(backstory)
+    if opener and _SELF_DEAD_CUE.search(opener):
+        return True
+    # A self-death declared LATER in the bio (the dogfood MAJOR: the picker offered "Alexander
+    # Rainforest", a corpse whose death lands in the third sentence). Scanned with the much
+    # narrower, subject-anchored `_BODY_DEAD_CUE` so a third party's death never false-positives.
+    body = strip_wiki_directives(" ".join(str(backstory or "").split()))
+    return bool(body) and bool(_BODY_DEAD_CUE.search(body))
 
 
 def list_canon_characters(
@@ -351,6 +381,14 @@ def _backstory_snippet(text: str, limit: int = 220) -> str:
     return (cut or s[:limit]) + "…"
 
 
+# The curated beginner subset (`recommended_only`): playable + alive figures that are legible AND
+# characterful in a level-based picker — a real class, a mid-tier level (not the level-1 long tail
+# nor the level-12 capstones), and a backstory. Bounded so a newcomer sees a handful, not a wall.
+_RECOMMENDED_MIN_LEVEL = 3
+_RECOMMENDED_MAX_LEVEL = 10
+_RECOMMENDED_CAP = 18
+
+
 def roster_surface(
     world_id: str,
     *,
@@ -359,6 +397,8 @@ def roster_surface(
     level: str = "",
     playable_only: bool = True,
     alive_only: "bool | None" = None,
+    require_stats: bool = False,
+    recommended_only: bool = False,
     limit: int = 120,
 ) -> dict:
     """Read-only roster projection for the canon-NPC PICKER (the "reverse character creator").
@@ -381,6 +421,18 @@ def roster_surface(
     Dead figures don't contribute facet chips either (the filter runs before the tallies). Any
     of race / char_class / level narrows the result (case-insensitive exact match on the record's
     field; an empty filter is ignored). De-duplicated by name (a figure on two wikis collapses).
+
+    `require_stats` (default False — the default call is byte-identical to before) drops records
+    that carry NEITHER a class NOR a level: a level-based picker that lists "Amanita Szarr — Vampire
+    or Vampire Spawn" (no class, no level) is confusing. A record with EITHER stat still rides along
+    (most canon townsfolk have a level but no class — they should stay pickable), only the
+    doubly-blank are dropped. The facets are tallied BEFORE this filter so the chips are unchanged.
+
+    `recommended_only` (default False) returns a small CURATED beginner subset instead of the full
+    roster, so a newcomer is not dropped into ~2,000 alphabetical names: playable + alive figures
+    that carry a class AND a mid-tier level (3–10) AND a backstory — legible, characterful picks —
+    capped to a handful. The response carries `recommended: True` and the full list stays reachable
+    via a normal (recommended_only=False) call. `race`/`class`/`level` filters still apply on top.
 
     Also returns `facets` — the distinct race / class / level values present in the playable
     roster (BEFORE the race/class/level filters narrow it, frequency-ordered so the densest chips
@@ -449,6 +501,24 @@ def roster_surface(
             if levell and rlevel.lower() != levell:
                 continue
 
+            # Legibility filter: in a level-based picker, a record with NEITHER a class NOR a level
+            # is just a name (e.g. "Amanita Szarr — Vampire or Vampire Spawn"). Drop the doubly-blank
+            # when asked; a record with EITHER stat survives. (Runs AFTER the facet tallies above.)
+            if require_stats and not rclass and not rlevel:
+                continue
+
+            # Beginner subset: a class + a mid-tier numeric level + a backstory — legible AND
+            # characterful. Skips the level-1 long tail, the capstones, and the bare names.
+            if recommended_only:
+                if not rclass or not str(rec.get("backstory", "") or "").strip():
+                    continue
+                try:
+                    lvn = int(rlevel)
+                except (TypeError, ValueError):
+                    continue
+                if not (_RECOMMENDED_MIN_LEVEL <= lvn <= _RECOMMENDED_MAX_LEVEL):
+                    continue
+
             slug = p.stem  # the file slug IS the portrait/id key (portrait-<slug> resolves)
             out.append({
                 "id": slug,
@@ -467,9 +537,12 @@ def roster_surface(
     # `total` is the FULL matched count; the returned list is capped to `limit` so the picker
     # grid stays renderable (the unfiltered playable roster is ~2,000 — far too many cards/images
     # to paint at once). The UI shows "showing N of total" and narrows via the facet chips. A
-    # `limit <= 0` means "no cap" (the test/headless path that wants the whole slice).
+    # `limit <= 0` means "no cap" (the test/headless path that wants the whole slice). The
+    # recommended subset is intentionally a handful, so it ignores `limit` and caps to its own size.
     total = len(out)
-    if limit and limit > 0:
+    if recommended_only:
+        out = out[:_RECOMMENDED_CAP]
+    elif limit and limit > 0:
         out = out[:limit]
 
     def _by_count(store: dict) -> list[str]:
@@ -486,7 +559,7 @@ def roster_surface(
                 return (1, dc[0].lower())
         return [v[0] for v in sorted(store.values(), key=_key)]
 
-    return {
+    resp = {
         "world_id": world_id,
         "total": total,            # full matched count (before the render cap)
         "returned": len(out),      # how many cards this payload actually carries
@@ -498,6 +571,12 @@ def roster_surface(
             "levels": _sorted_levels(facet_levels),
         },
     }
+    if recommended_only:
+        # Beginner-surface marker the picker reads to show its "Recommended for beginners" framing
+        # and a "see the full roster" affordance. Only set when asked, so the default payload shape
+        # (and the existing tests asserting it) are unchanged.
+        resp["recommended"] = True
+    return resp
 
 
 # The free-prose fields a canon record exposes to the DM / portrait prompt. F10-7 scrubs

--- a/servers/engine/tests/test_playable_alive.py
+++ b/servers/engine/tests/test_playable_alive.py
@@ -26,6 +26,12 @@ import server
 WORLD = "baldurs-gate"
 DAL = "Dal Lightspark"          # canon-DEAD: "a dead gold dwarven Harper whose corpse is in …"
 LIVING_PC = "Aubree"            # living half-elf ranger of the Flaming Fist, has an ingested portrait
+# canon-DEAD where the death is declared NOT in the opener but later in the bio (dogfood MAJOR):
+# Alexander Rainforest's opener reads as a living citizen — "… Rainforest is already dead." lands
+# in the THIRD sentence, so the opener-only scan missed it and the picker offered a corpse as a PC.
+RAINFOREST = "Alexander Rainforest"  # "… When the party reach him in Act Three, Rainforest is already dead."
+PEARTREE = "Franc Peartree"          # "… Peartree (if encountered) is already dead."
+PRINSKI = "Waldemar Prinski"         # "… he is found dead in the Iron Throne soon after."
 
 
 def _seed(tmp_path, monkeypatch):
@@ -75,6 +81,39 @@ def test_is_dead_record_does_not_false_positive_on_a_living_figure():
         assert content.is_dead_record(rec) is False, rec["name"]
 
 
+def test_is_dead_record_flags_a_self_death_declared_later_in_the_bio():
+    # Dogfood MAJOR: a corpse whose death is declared NOT in the opener but mid-bio. The opener
+    # ("Alexander Rainforest was a citizen of Baldur's Gate.") reads as a living NPC, so the
+    # opener-only scan let the picker offer him as a playable hero. The body cue must catch the
+    # later self-declaration ("… Rainforest is already dead.").
+    for nm in (RAINFOREST, PEARTREE, PRINSKI):
+        rec = content.load_canon_character(WORLD, nm)
+        assert rec is not None, nm
+        assert content.is_dead_record(rec) is True, nm
+
+
+def test_body_dead_cue_does_not_false_positive_on_a_third_party_death():
+    # FALSE-POSITIVE GUARD for the widened (whole-bio) scan: a LIVING figure whose bio mentions
+    # SOMEONE ELSE's death — "appears … if Alfira is dead", "if he is dead" (a different NPC),
+    # "declaration that Aylin was dead" — must NOT be flagged. The cue is subject-anchored and
+    # ignores the conditional "if X is dead" third-party form.
+    # NB: the third-party death cue lands in a LATER sentence (the opener is a clean living
+    # intro), mirroring the real corpus — so this exercises the widened whole-bio scan, not the
+    # separate opener cue. A conditional "if X is dead" must never flag the SUBJECT.
+    living = [
+        {"name": "Chell-like", "class": "Bard", "level": "3",
+         "backstory": "Chell is a tiefling bard of the Lower City. She appears as a replacement character for Alfira during the camp celebration if Alfira is dead."},
+        {"name": "Kavil-like", "class": "Fighter", "level": "4",
+         "backstory": "Kavil is a stout dwarf of the Flaming Fist. He appears as a replacement for Bex during the camp celebration if he is dead."},
+        {"name": "Olys-like", "class": "Ranger", "level": "5",
+         "backstory": "Olys is an Asmodeus tiefling ranger and Harper. If one of the original Harper allies is dead, he can take their place during the assault."},
+        {"name": "Isobel-like", "class": "Cleric", "level": "6",
+         "backstory": "Isobel is a cleric of Selune who lives at Last Light Inn. She saw a change in her father, and with his declaration that Aylin was dead, she could see no recourse but to run."},
+    ]
+    for rec in living:
+        assert content.is_dead_record(rec) is False, rec["name"]
+
+
 def test_living_canon_pc_is_not_flagged_dead():
     aubree = content.load_canon_character(WORLD, LIVING_PC)
     assert aubree is not None
@@ -105,6 +144,73 @@ def test_roster_surface_excludes_the_dead_from_cards_and_facets():
     assert LIVING_PC in names
     # the dead-only id slug must not be present either
     assert "dal-lightspark" not in {c["id"] for c in surf["characters"]}
+
+
+def test_roster_surface_excludes_a_mid_bio_dead_figure():
+    # The UI complement to #912: the picker must never OFFER what the seat REFUSES. A corpse
+    # whose death is declared mid-bio (Alexander Rainforest) must be absent from every card.
+    surf = content.roster_surface(WORLD, playable_only=True, limit=0)
+    names = {c["name"] for c in surf["characters"]}
+    for nm in (RAINFOREST, PEARTREE, PRINSKI):
+        assert nm not in names, nm
+    assert "alexander-rainforest" not in {c["id"] for c in surf["characters"]}
+
+
+# --- require_stats: drop entries illegible in a level-based picker ----------
+
+def test_roster_surface_require_stats_drops_records_lacking_both_class_and_level():
+    # "Amanita Szarr — Vampire or Vampire Spawn" has neither class nor level — confusing in a
+    # level-based picker. require_stats=True drops records missing BOTH (a townsperson with a
+    # level but no class, or a class but no level, still rides along — only the doubly-blank go).
+    full = content.roster_surface(WORLD, playable_only=True, limit=0)
+    stats = content.roster_surface(WORLD, playable_only=True, require_stats=True, limit=0)
+    full_names = {c["name"] for c in full["characters"]}
+    stats_names = {c["name"] for c in stats["characters"]}
+    assert "Amanita Szarr" in full_names, "default surface keeps the classless/levelless figure"
+    assert "Amanita Szarr" not in stats_names, "require_stats drops the doubly-blank figure"
+    # Every surviving card has at least ONE of class / level so it is legible in the picker.
+    for c in stats["characters"]:
+        assert (c.get("class") or "").strip() or (c.get("level") or "").strip(), c["name"]
+    # require_stats is additive-narrowing: a strict subset, and it never re-admits the dead.
+    assert stats_names <= full_names
+    assert RAINFOREST not in stats_names
+
+
+def test_roster_surface_require_stats_defaults_off_so_default_surface_is_unchanged():
+    # The default (require_stats unset) call is byte-identical to before — no silent narrowing.
+    a = content.roster_surface(WORLD, playable_only=True, limit=0)
+    b = content.roster_surface(WORLD, playable_only=True, require_stats=False, limit=0)
+    assert a == b
+
+
+# --- recommended_only: a curated beginner subset ----------------------------
+
+def test_roster_surface_recommended_only_is_a_small_curated_legible_subset():
+    # BEGINNER ENTRY: a newcomer should not be dropped into ~2,000 alphabetical names. The
+    # recommended subset leads with playable+alive mid-tier figures that carry BOTH a class AND
+    # a level AND a backstory — legible, characterful picks — and is small.
+    rec = content.roster_surface(WORLD, playable_only=True, recommended_only=True)
+    cards = rec["characters"]
+    assert cards, "the recommended subset should not be empty for the shipped roster"
+    assert rec["recommended"] is True
+    assert len(cards) <= 24, "the beginner subset stays small (not the whole roster)"
+    full = content.roster_surface(WORLD, playable_only=True, limit=0)
+    assert rec["total"] < full["total"], "recommended is a strict narrowing of the full roster"
+    rec_names = {c["name"] for c in cards}
+    for c in cards:
+        assert (c.get("class") or "").strip(), c["name"]
+        assert (c.get("level") or "").strip(), c["name"]
+        assert (c.get("backstory") or "").strip(), c["name"]
+    # never the dead, never a malformed figure
+    assert RAINFOREST not in rec_names and DAL not in rec_names
+    assert "Amanita Szarr" not in rec_names
+
+
+def test_roster_surface_recommended_only_defaults_off():
+    a = content.roster_surface(WORLD, playable_only=True, limit=0)
+    b = content.roster_surface(WORLD, playable_only=True, recommended_only=False, limit=0)
+    assert a == b
+    assert a.get("recommended") in (None, False)
 
 
 # --- the hard seat gate ------------------------------------------------------

--- a/viewer/openworlds/screen-roster.jsx
+++ b/viewer/openworlds/screen-roster.jsx
@@ -154,12 +154,23 @@ function ScreenRoster({ onNavigate, state, setState, preferredProvider = "" }) {
   const [race, setRace] = React.useState("");
   const [klass, setKlass] = React.useState("");
   const [level, setLevel] = React.useState("");
+  // BEGINNER ENTRY: the picker OPENS on a small curated "recommended for beginners" set rather than
+  // dropping a newcomer into ~2,000 alphabetical names. Applying any filter, or clicking "Browse the
+  // full roster", flips to the full playable+alive roster (illegible no-class/no-level records still
+  // dropped via ?require_stats). The full list is always one click away — the curation is a default,
+  // never a wall.
+  const [browseAll, setBrowseAll] = React.useState(false);
   const [surface, setSurface] = React.useState(null);  // null until first fetch
   const [error, setError] = React.useState("");
   const [loading, setLoading] = React.useState(true);
   const [summoningName, setSummoningName] = React.useState("");
   const [bindNote, setBindNote] = React.useState("");
   const toast = window.useToast ? window.useToast() : (() => {});
+
+  const anyFilter = Boolean(race || klass || level);
+  // The recommended surface is the default ONLY while unfiltered and the player hasn't asked to see
+  // everything — a filter is an explicit "search the whole roster" intent.
+  const recommended = !browseAll && !anyFilter;
 
   // Facets come from the FIRST (unfiltered) load so the chips offer every option regardless of
   // the current narrowing; held separately so a narrowing fetch (which returns facets for the
@@ -177,6 +188,13 @@ function ScreenRoster({ onNavigate, state, setState, preferredProvider = "" }) {
       if (race) params.set("race", race);
       if (klass) params.set("class", klass);
       if (level) params.set("level", level);
+      if (recommended) {
+        // The curated beginner subset (each card has a class + a mid-tier level + a backstory).
+        params.set("recommended", "1");
+      } else {
+        // The full roster, minus the illegible no-class/no-level records (#dogfood).
+        params.set("require_stats", "1");
+      }
       const qs = params.toString();
       const response = await fetch("/roster-surface" + (qs ? "?" + qs : ""), { cache: "no-store" });
       if (!response.ok) throw new Error(`roster surface ${response.status}`);
@@ -200,7 +218,7 @@ function ScreenRoster({ onNavigate, state, setState, preferredProvider = "" }) {
     } finally {
       if (!isCancelled()) setLoading(false);
     }
-  }, [rosterCampaignId, activeCampaign.source, activeCampaign.runId, race, klass, level]);
+  }, [rosterCampaignId, activeCampaign.source, activeCampaign.runId, race, klass, level, recommended]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -265,7 +283,8 @@ function ScreenRoster({ onNavigate, state, setState, preferredProvider = "" }) {
   const total = typeof surface?.total === "number" ? surface.total : characters.length;
   const shown = typeof surface?.returned === "number" ? surface.returned : characters.length;
   const capped = total > shown;  // more heroes match than the grid is painting — narrow to see them
-  const anyFilter = Boolean(race || klass || level);
+  // The payload itself reports whether it's the curated subset (the engine sets recommended:true).
+  const isRecommended = Boolean(surface?.recommended);
 
   return (
     <div className="screen" style={{ height: "100%", display: "flex", flexDirection: "column", gap: 10, padding: 14 }}>
@@ -277,8 +296,9 @@ function ScreenRoster({ onNavigate, state, setState, preferredProvider = "" }) {
             <div className="eyebrow" style={{ color: "var(--crimson)" }}>Choose your hero</div>
             <h1 className="h1" style={{ fontSize: 26, marginTop: 2 }}>Take up a life already lived</h1>
             <p className="hand" style={{ fontSize: 14, color: "var(--ink-700)", margin: "6px 0 0", maxWidth: 620 }}>
-              Filter the chronicle's living roster and step into a real figure of the Sword Coast —
-              their face, their past, their place in the world. You will play <em>as</em> them.
+              {isRecommended
+                ? <>New to the Sword Coast? Start with a handful of <em>recommended</em> heroes — each a real figure with a class, a level, and a story. Filter or browse the full roster whenever you like; you will play <em>as</em> them.</>
+                : <>Filter the chronicle's living roster and step into a real figure of the Sword Coast — their face, their past, their place in the world. You will play <em>as</em> them.</>}
             </p>
           </div>
           <BrassButton tone="ghost" size="sm" onClick={() => onNavigate("launcher")}>Back to Chronicles</BrassButton>
@@ -290,14 +310,27 @@ function ScreenRoster({ onNavigate, state, setState, preferredProvider = "" }) {
         <FilterRow title="Class" options={facets.classes} value={klass} onChange={setKlass} />
         <FilterRow title="Level" options={facets.levels} value={level} onChange={setLevel} />
 
-        <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 4 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 12, marginTop: 4, flexWrap: "wrap" }}>
           <div className="body-sm muted">
             {loading
               ? "Reading the roster…"
-              : capped
-                ? `Showing ${shown} of ${total} heroes — narrow by race, class, or level to see the rest`
-                : `${total} ${total === 1 ? "hero" : "heroes"} available${anyFilter ? " · filtered" : ""}`}
+              : isRecommended
+                ? `${shown} ${shown === 1 ? "hero" : "heroes"} recommended for newcomers — or browse the full roster`
+                : capped
+                  ? `Showing ${shown} of ${total} heroes — narrow by race, class, or level to see the rest`
+                  : `${total} ${total === 1 ? "hero" : "heroes"} available${anyFilter ? " · filtered" : ""}`}
           </div>
+          {/* Beginner ⇄ full-roster toggle. A filter implies "search everything", so it lives
+              alongside Clear filters; with no filter it flips the curated default on and off. */}
+          {!anyFilter && (
+            <button
+              type="button"
+              onClick={() => setBrowseAll((x) => !x)}
+              style={{ background: "transparent", border: 0, color: "var(--crimson)", cursor: "pointer", fontFamily: "var(--f-display)", fontSize: 11, letterSpacing: "0.14em", textTransform: "uppercase" }}
+            >
+              {isRecommended ? "Browse the full roster" : "Show recommended"}
+            </button>
+          )}
           {anyFilter && (
             <button
               type="button"

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -913,16 +913,22 @@ def build_roster_response(
     level: str = "",
     limit: int = 120,
     world_id: Optional[str] = "",
+    require_stats: bool = False,
+    recommended_only: bool = False,
 ) -> dict:
     """GET /roster-surface read model — the canon-NPC PICKER ("reverse character creator").
 
     Bridges to the engine-owned canon-roster projection (``content.roster_surface``): the
-    PLAYABLE roster (origins/legends EXCLUDED via the record ``playable`` flag), filtered by
-    race / class / level, each row carrying {id, name, race, class, level, role, backstory
-    snippet, portrait_scope}. Also returns the distinct race/class/level ``facets`` so the picker
-    can offer filter chips. The world is resolved from the campaign's snapshot (or the shipped
-    default for a brand-new game). READ-ONLY — exposes no write/seat path; the bind happens via
-    the native startProviderSession bridge / load_canon_character, never here. Mirrors
+    PLAYABLE+ALIVE roster (origins/legends EXCLUDED via the record ``playable`` flag, canon-DEAD
+    figures excluded via ``is_dead_record`` — the picker must never OFFER a hero the seat path
+    REFUSES, #912), filtered by race / class / level, each row carrying {id, name, race, class,
+    level, role, backstory snippet, portrait_scope}. Also returns the distinct race/class/level
+    ``facets`` so the picker can offer filter chips. ``require_stats`` drops records that carry
+    neither a class nor a level (illegible in a level-based picker); ``recommended_only`` returns a
+    small curated beginner subset (and marks the payload ``recommended:true``). Both default off, so
+    the unparametrized call is unchanged. The world is resolved from the campaign's snapshot (or the
+    shipped default for a brand-new game). READ-ONLY — exposes no write/seat path; the bind happens
+    via the native startProviderSession bridge / load_canon_character, never here. Mirrors
     build_bestiary_response: a graceful empty payload when the engine can't be imported."""
     engine = _load_engine_server()
     if world_id is None:
@@ -948,6 +954,8 @@ def build_roster_response(
             char_class=char_class,
             level=level,
             playable_only=True,
+            require_stats=require_stats,
+            recommended_only=recommended_only,
             limit=limit,
         )
     except Exception as exc:
@@ -7784,6 +7792,12 @@ class _Handler(BaseHTTPRequestHandler):
             race = (qs.get("race") or [""])[0]
             char_class = (qs.get("class") or qs.get("char_class") or [""])[0]
             level = (qs.get("level") or [""])[0]
+            # ?require_stats drops records with neither a class nor a level (illegible in a
+            # level-based picker, e.g. "Amanita Szarr — Vampire or Vampire Spawn"); ?recommended
+            # returns the small curated beginner subset. Both default OFF — the bare call is
+            # byte-identical to before. (Same truthy convention as ?once / ?reference above.)
+            require_stats = (qs.get("require_stats") or ["0"])[0].strip().lower() in ("1", "true", "yes", "on")
+            recommended_only = (qs.get("recommended") or ["0"])[0].strip().lower() in ("1", "true", "yes", "on")
             # Cap the returned cards so the picker grid stays renderable (the unfiltered playable
             # roster is ~2,000). ?limit tunes it; bounded to [1, 500] (a bad value -> the default).
             try:
@@ -7799,9 +7813,15 @@ class _Handler(BaseHTTPRequestHandler):
                     if isinstance(raw_world_id, str) and raw_world_id.strip()
                     else None
                 )
-                self._json(build_roster_response(cid, race, char_class, level, limit, world_id=world_id))
+                self._json(build_roster_response(
+                    cid, race, char_class, level, limit, world_id=world_id,
+                    require_stats=require_stats, recommended_only=recommended_only,
+                ))
                 return
-            self._json(build_roster_response(cid, race, char_class, level, limit))
+            self._json(build_roster_response(
+                cid, race, char_class, level, limit,
+                require_stats=require_stats, recommended_only=recommended_only,
+            ))
         elif route in ("/monitor", "/monitor.html"):
             # The MULTI-CAMPAIGN monitor: one live page showing EVERY campaign across the play
             # store + all parallel QA runs (watch the stress tests + any live game in one place).

--- a/viewer/tests/test_roster_surface.py
+++ b/viewer/tests/test_roster_surface.py
@@ -242,6 +242,54 @@ class RosterSurfaceTests(unittest.TestCase):
         if "2" in levels and "10" in levels:
             self.assertLess(levels.index("2"), levels.index("10"))
 
+    # ── dogfood MAJOR: the picker must never OFFER a dead / malformed figure ──────
+
+    def test_a_mid_bio_dead_figure_is_never_offered(self):
+        # Alexander Rainforest is canon-DEAD (his bio: "… Rainforest is already dead.") but the
+        # death is declared mid-bio, so the opener-only scan once let the picker list him as a
+        # playable hero with a live "Play as" button. He must now be absent from every page.
+        status, surface = self._get_json("/roster-surface?limit=500")
+        self.assertEqual(status, 200)
+        names = {c.get("name") for c in surface.get("characters", [])}
+        ids = {c.get("id") for c in surface.get("characters", [])}
+        self.assertNotIn("Alexander Rainforest", names, "a canon-dead figure must never be offered")
+        self.assertNotIn("alexander-rainforest", ids)
+
+    def test_require_stats_drops_records_lacking_level_and_class(self):
+        # "Amanita Szarr — Vampire or Vampire Spawn" has neither class nor level (illegible in a
+        # level-based picker). ?require_stats=1 drops records missing BOTH; survivors carry at
+        # least one of class / level. The default surface still lists her (no silent narrowing).
+        _, default = self._get_json("/roster-surface?limit=500")
+        default_names = {c.get("name") for c in default.get("characters", [])}
+        self.assertIn("Amanita Szarr", default_names)
+        _, strict = self._get_json("/roster-surface?require_stats=1&limit=500")
+        self.assertEqual(strict.get("world_id"), "baldurs-gate")
+        for c in strict.get("characters", []):
+            self.assertTrue(
+                (c.get("class") or "").strip() or (c.get("level") or "").strip(),
+                f"{c.get('name')} is illegible (no class and no level)",
+            )
+        self.assertNotIn("Amanita Szarr", {c.get("name") for c in strict.get("characters", [])})
+
+    def test_recommended_surface_is_a_small_legible_beginner_set(self):
+        # BEGINNER ENTRY: ?recommended=1 returns a small curated set of playable+alive figures
+        # that each carry a class AND a level AND a backstory — not the ~2,000-name firehose.
+        status, surface = self._get_json("/roster-surface?recommended=1")
+        self.assertEqual(status, 200)
+        self.assertTrue(surface.get("recommended"))
+        cards = surface.get("characters", [])
+        self.assertTrue(cards, "the recommended set should not be empty for the shipped roster")
+        self.assertLessEqual(len(cards), 24)
+        for c in cards:
+            self.assertTrue((c.get("class") or "").strip(), c.get("name"))
+            self.assertTrue((c.get("level") or "").strip(), c.get("name"))
+        names = {c.get("name") for c in cards}
+        self.assertNotIn("Alexander Rainforest", names)  # never the dead
+        self.assertNotIn("Amanita Szarr", names)         # never the malformed
+        # and the full roster is still reachable (recommended is a strict narrowing).
+        _, full = self._get_json("/roster-surface?limit=500")
+        self.assertLess(surface.get("total", 0), full.get("total", 0))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The dogfood (MAJOR)

A no-prior-knowledge dogfooder filed MAJOR against the **"Choose Your Hero"** roster:

1. It listed **canon-DEAD figures as selectable heroes** with a live "Play as" button and no warning — e.g. *Alexander Rainforest*, flagged dead in his own bio. This contradicts **#912** (the engine seat already REFUSES dead + banned-BG3-origin PCs via `load_canon_character`). **The UI must never OFFER what the engine REFUSES.**
2. 1,992 heroes, alphabetical, no beginner curation — overwhelming.
3. Some heroes show **no level/class** (e.g. *"Amanita Szarr — Vampire or Vampire Spawn"*) — confusing in a level-based picker.

## Root cause

The picker already routes through `content.roster_surface(playable_only=True)` → `alive_only`, which calls `is_dead_record`. But `is_dead_record` scanned only the backstory **opener** for a self-death declaration. Rainforest *opens* as a living citizen and his death (*"… When the party reach him in Act Three, Rainforest is already dead."*) lands in the **third sentence**, so the opener-only scan missed it and the corpse leaked into the roster. Two other corpses (*Franc Peartree*, *Waldemar Prinski*) had the same shape.

## The fix (additive, reuses the EXISTING canonical predicates — no divergent fork)

1. **`is_dead_record`** gains a second, much **narrower subject-anchored** cue (`_BODY_DEAD_CUE`) that scans the **whole bio** for an unambiguous self-death (`<subject> … is already/now dead`, `found dead/slain`, `lies dead`). Guarded against the third-party false positives a whole-bio scan invites (*"appears … if Alfira is dead"*, *"if he is dead"*) via subject-anchoring, a state/result phrase (never a bare "is dead"), and a `(?<!if )` lookbehind. Because this is the **canonical predicate**, the single change fixes **both** the roster **and** the seat path — the UI complement to #912. Catches the 3 genuinely-dead figures with **zero corpus false positives**.

2. **`roster_surface`** gains:
   - `require_stats` — drop records lacking **both** class and level (illegible in a level-based picker, e.g. *Amanita Szarr*); a record with **either** stat survives, so the classless-but-leveled townsfolk stay pickable.
   - `recommended_only` — a small **curated beginner subset**: playable+alive figures with a class + a mid-tier level (3–10) + a backstory, capped to a handful, payload flagged `recommended:true`.
   - **Both default OFF**, so the unparametrized projection is byte-identical to before.

3. **Viewer stays READ-ONLY.** `build_roster_response` + `/roster-surface` forward the two flags via `?require_stats` / `?recommended` (no writes, no wire-contract change; engine stays sole writer). `screen-roster.jsx` **opens on the recommended subset** for newcomers, with a one-click **"Browse the full roster"** toggle (full view applies `require_stats` to hide no-stat records). The full list stays reachable.

## Net effect on the shipped baldurs-gate roster

- Playable+alive roster: 1992 → **1989** (the 3 mid-bio corpses now excluded; Dal already was).
- `?require_stats`: drops **109** no-class/no-level records.
- `?recommended`: **18** curated cards (from a 522-strong mid-tier pool), each with class + level + backstory.

## Tests (TDD: RED → GREEN)

- `servers/engine/tests/test_playable_alive.py` — `is_dead_record` flags the mid-bio deaths (Rainforest/Peartree/Prinski), does **not** false-positive on third-party deaths, and `roster_surface` excludes the dead, drops doubly-blank records under `require_stats`, and returns a small legible `recommended` subset (defaults proven off).
- `viewer/tests/test_roster_surface.py` — the same contract over HTTP against the shipped roster: a mid-bio dead figure is never offered, `?require_stats` drops the no-stat records, `?recommended` returns a small legible beginner set with the full roster still reachable.

## Verification

- `bash qa/fast_gate.sh` — **PASS** (221 deterministic engine + seat-path tests).
- Full engine suite: **2769 passed**.
- Full viewer suite: **657 passed, 1 skipped** (the 1 skip is the gitignored ingested-portrait test).
- `screen-roster.jsx` transforms cleanly under the vendored Babel.

## Invariants honored

Viewer READ-ONLY on engine state (presentation + a read filter, no writes/mutation) · reuses the existing canonical predicates (no divergent fork) · additive · no wire-contract change · engine stays sole writer.