### PR TITLE
feat: VISION.md + worldos-decide (the 95%-confidence decision apparatus)

### DIFF
--- a/.claude/skills/worldos-decide/SKILL.md
+++ b/.claude/skills/worldos-decide/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: worldos-decide
+description: Use when facing a non-trivial WorldOS direction / architecture / prioritization decision you would otherwise escalate to the owner. Anchors the call to VISION.md + a scorecard, fires adversarial sub-agents, and gates on 95% confidence so you decide autonomously instead of asking. Invoke whenever you are about to write "should I do X or Y?" to the owner.
+---
+
+# WorldOS Decide — the 95%-confidence decision apparatus
+
+You are the creator/owner of WorldOS's *direction*. The owner has delegated decision-making and
+asked you to **stop bottlenecking on sign-off**: instead, reach **95% confidence** against the
+documented `VISION.md` and the invariants, then move. This skill is that apparatus — a repeatable
+"a version of you that takes the scorecard + the vision and asks 'am I 95% confident?'"
+
+## When to use
+
+- A direction / prioritization fork ("which lane next", "which option").
+- An architecture / shape decision on a load-bearing surface (tool API, schema, wire contract).
+- Any call where you'd otherwise ask the owner to choose.
+
+**Don't** use for: trivial mechanical edits, reversible flag-flips, or decisions the dogfood/data
+already settle. Just do those.
+
+## The protocol
+
+1. **Frame.** One line: the decision + the 2–3 *real* options + what's at stake + reversibility
+   (additive/easy-revert vs hard-to-undo).
+2. **Anchor.** Load `VISION.md` (repo root) — north star, pillars, invariants. Every option is
+   measured against it. (If the decision exposes a gap in the vision, that is an owner-escalation
+   signal — see step 5.)
+3. **Score — fire sub-agents** (Agent tool, or a Workflow for bigger calls). At minimum:
+   - **Scorer** — score the leading option against the SCORECARD below, *per criterion, with cited
+     evidence* (corpus, reach-for, run-the-system, dogfood). Returns per-criterion scores + an
+     overall confidence + the gaps.
+   - **Red-team skeptic** — the *strongest* case AGAINST the leading option; the failure modes; "what
+     would have to be true for this to be wrong?"; default-to-skeptical. Don't be diplomatic.
+   - Scale the panel to the stakes: 1 scorer + 1 skeptic for a medium call; for the biggest surfaces,
+     run the full `first-principles-architectural-decision` skill as the Score step (research → run →
+     reach-for → diagram → debate → decide).
+4. **Synthesize.** Combine the agents' outputs **plus your own research** into a CONFIDENCE (0–100%),
+   the GAPS to reach 95%, and a verdict. Don't take any agent's number at face value — they were told
+   to argue; extract the strongest version of each side and weigh it yourself.
+5. **Gate.**
+   - **≥95% AND every HARD GATE passes AND the red-team's strongest counter is rebutted → DECIDE and
+     proceed autonomously.** Record a one-paragraph decision note (what / why / reversibility) — a
+     decision doc under `docs/decisions/` for load-bearing calls, inline for smaller ones.
+   - **<95% → name the gap and close it** (more research, a probe, a dogfood, a tighter design) →
+     re-score. *Most gaps are evidence gaps, not owner-judgment gaps* — research, don't ask.
+   - **Escalate to the owner ONLY when** the call genuinely turns on owner-private context — product
+     taste, business priority, or a *change to the vision itself* — that no analysis resolves. Bring
+     the scorecard + your recommendation, not an open question.
+
+## The SCORECARD
+
+| Criterion | Question | Weight |
+|---|---|---|
+| **Vision alignment** | Advances ≥1 pillar (story / living world / correctness / alive-feel / accessible) without dulling another? Serves the north star? | high |
+| **Invariant safety** | Engine sole-writer, additive, gauge-not-fiction, viewer read-only, no wire-break, Eva-safe? | **HARD GATE** |
+| **Evidence** | Grounded in data (corpus / reach-for / run-the-system / dogfood) vs speculation? | high — thin evidence caps confidence |
+| **Efficacy / adoption** | Will it actually work *in the played session*? The reach-for trap: a correct tool the DM never calls, or a feature the player never feels, is a failure. | high |
+| **Reversibility** | Additive/default-empty/easy-revert? Or hard-to-undo (raises the bar; defer the irreversible sliver)? | medium |
+| **Scope-proportionality** | Effort proportional to felt value? The smallest change that moves the pillar? | medium |
+| **Adversarial robustness** | Survives the red-team's strongest counter? | high |
+
+## The 95% rule
+
+95% confidence = **vision-aligned + every HARD GATE passes + strong evidence + (reversible OR the
+irreversible part is deferred/justified) + the red-team's best shot is answered.**
+
+- If a **HARD GATE** (invariant) fails, you are NOT at 95% no matter how appealing the option —
+  redesign until it passes or drop it.
+- If the **evidence is thin**, you are NOT at 95% — research, don't guess. The methodology exists
+  because answers feel obvious in the moment and are wrong ~30% of the time.
+- If the change is **hard to reverse**, raise the bar: demand stronger evidence and defer the
+  irreversible part (e.g. a persistence schema) to its own decision.
+
+## Anti-patterns this guards against
+
+- **Sign-off theater** — asking the owner to choose when the evidence already decides. Run the gate;
+  if it clears 95%, just move.
+- **Confirmation-bias agents** — a single agent that "verifies" your hunch. Always pair a scorer with
+  a red-team skeptic.
+- **Speculative load-bearing code** — building the shape before the corpus/reach-for data is in.
+- **Score-gaming** — optimizing a rubric instead of the felt session (a HARD violation of the north
+  star).
+
+## Composes with
+
+- `first-principles-architectural-decision` — the heavyweight Score step for the biggest surfaces;
+  worldos-decide is the repeatable confidence-gate that wraps and invokes it.
+- `worldos-dev` (dev/QA loops) + the dogfood loop — the evidence source the Scorer cites.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,84 @@
+# WorldOS — Vision
+
+> The anchor every non-trivial decision is measured against. When you are about to ask the
+> owner "should I do X or Y?", run the `worldos-decide` skill against this document instead.
+
+## What it is
+
+WorldOS is a post-Baldur's-Gate-3 **living-world D&D 5e (SRD 5.2)** game: a deterministic Python
+engine that is the sole writer of world state, the **OpenWorlds** in-browser viewer, and a native
+macOS app. The player plays through **their own AI agent** — Claude Code, Codex, OpenClaw, Hermes,
+or the WorldOS app — which acts as the Dungeon Master against the engine. The engine guarantees the
+rules; the AI DM brings an **epic, Baldur's-Gate-caliber story** to life. The long arc: a
+universe-system that generates worlds you play with any agent.
+
+It is a real game **and** an experiment — in whether an autonomous agent can build, harden, and
+steer a game system to a shippable bar, making its own decisions against this documented vision.
+
+## North star
+
+**A no-prior-knowledge player launches the app, plays a complete 8-beat Baldur's-Gate-caliber arc,
+and never once feels "this is broken."** The felt player session is the product. RRI gates, test
+scores, and rubric numbers are *measurement*, never the target — no score-gaming.
+
+## The pillars (a good decision advances ≥1 without dulling another)
+
+1. **Story-craft first.** Epic, mature, BG-caliber storytelling; the DM's prose is the star; judge
+   it with a Tolkien lens. A correct-but-flat session is a failure.
+2. **A living, reactive world.** The world pushes back. Choices have *gauge-backed* consequences.
+   Companions have felt approval, telegraphed-then-fired betrayal, real agendas. NPCs speak; factions
+   move; the player's mark is left on the world.
+3. **Deterministic correctness.** SRD 5.2, faithfully. The engine rolls and resolves; the DM is
+   *told* the result and narrates it. No rules-cheating; fiction never overrides the dice.
+4. **It feels alive.** The screen always shows motion; the world responds promptly; no frozen,
+   ambiguous waits. Real art, not placeholders. The session has rhythm.
+5. **No-prior-knowledge accessible.** A first-timer is never lost, overwhelmed, or staring at jargon
+   or a dead control. Onboarding teaches itself.
+
+## Invariants (load-bearing — NEVER violate; an option that breaks one is wrong by definition)
+
+- **Engine = sole writer** of state (`snapshot.json` under `campaign_lock`, atomic replace).
+- **Additive-by-default** — empty == today; old snapshots round-trip; every new field defaults to
+  current behavior; each feature is independently removable.
+- **Gates/triggers read ONLY engine-mutated gauges** (flags, reputation, attitude, day, standing) —
+  **never fiction.** The DM judges the *cause*; the engine owns the *number*.
+- **Engine rolls; the DM is told.** Probability proposes, the DM disposes.
+- **Viewer is read-only** on state — it posts move-intents; it never mutates.
+- **Never break wire contracts** — additive, keyword-only, defaulted; never reorder/rename/retype an
+  existing param.
+- **QA is gateway-free and never touches Eva** (the owner's live agent) — no profile-sourcing, no
+  gateway reconfig, no Eva infra. One live Mac/GUI harness at a time. CI/full suites on GitHub.
+
+## The bar + release ladder
+
+- **Engine Excellent** *(met)* — behavioral GREEN; no engine defect in combat sprints; zero-critical
+  / arc-completes / no-give-ups; audit P0/P1 closed; a dogfood arc with no engine "broken" moment.
+- **Player-Ready Beta** — a real built `.app`; a no-prior-knowledge dogfood arc with no "broken"
+  moment; an honest, felt session.
+- **1.0 GA** — Beta + notarized signing + feature parity: companions felt, visual parity, story at
+  the bar.
+
+## How we build
+
+- **Dogfooding is the feedback spine.** Real play surfaces what matters; the dogfood log is the
+  prioritized backlog. Don't guess — play it. But *measure before you trust a complaint*: a felt
+  report can be a harness artifact or a mis-read (verify against the artifacts before fixing).
+- **Ultracode workflows for velocity** — fan-out builders (TDD → PR) → adversarial verifiers
+  (revert-check) → admin-merge → fast_gate.
+- **Adversarial verification before merge** — every merged PR is revert-checked (revert the fix → the
+  test goes RED for the documented reason; green-on-revert = reject).
+- **Research before load-bearing code** — a load-bearing surface (tool API / schema / wire) with 2+
+  real options gets a first-principles decision doc, not speculative code.
+- **Decisions are anchored here via `worldos-decide`** — score against this vision + the invariants,
+  fire adversarial sub-agents, reach 95% confidence, then move. Escalate to the owner *only* when the
+  call genuinely turns on their private context (product taste, business priority, a vision *change*)
+  that no analysis resolves — and then bring a recommendation, not an open question.
+
+## What we are NOT doing
+
+- Not optimizing a score for its own sake (no rubric-gaming).
+- Not generating portraits for the 2,000+ canon NPCs — they have wiki art. Image-gen is for **custom
+  characters + genuine gaps only**.
+- Not seating banned BG3 origin heroes (Astarion, Gale, Karlach, Lae'zel, Shadowheart, Wyll, Halsin)
+  or dead figures as PCs — they are companions/NPCs only.
+- Not shipping a correct-but-lifeless session and calling it done.


### PR DESCRIPTION
Builds the decision apparatus the owner asked for: stop bottlenecking on sign-off for direction/architecture calls — instead anchor every non-trivial decision to a documented vision + a scorecard, fire adversarial sub-agents, gate on 95% confidence, then move. Escalate to the owner ONLY when the call genuinely turns on owner-private taste/priority/vision-change.

- **VISION.md** (repo root) — the anchor: north star (a no-prior-knowledge player plays an 8-beat BG-caliber arc and never feels "broken"), the 5 pillars (story-craft / living world / correctness / alive-feel / accessible), the load-bearing invariants (engine sole-writer, additive, gauge-not-fiction, viewer read-only, no wire-break, Eva-safe), the release ladder, how-we-build, and the explicit NOT-doing list.
- **.claude/skills/worldos-decide** — the protocol: frame → anchor to VISION → fire a Scorer + a Red-team skeptic → synthesize → gate on 95% (invariant-safety is a HARD GATE). Composes with first-principles-architectural-decision for the biggest surfaces.

Docs + skill only; no production code. This is the experiment's substrate — an autonomous builder that makes its own calls against a written vision.