### PR TITLE
fix(viewer): C-create-char Beta-gap — #721 + #607

### DIFF
--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -352,7 +352,13 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
   const [loading, setLoading] = React.useState(true);
   const [chosenClass, setChosenClass] = React.useState((hero.class || "").toLowerCase());
   const [subclassName, setSubclassName] = React.useState("");
-  const [asiNote, setAsiNote] = React.useState("");
+  // #607: the ASI/feat choice is STRUCTURED now (not a free-text note). `asiBumps` maps an ability
+  // abbrev (str/dex/…) to its chosen increment; the engine's contract is +2 to one ability OR +1 to
+  // two (each capped at 20 — server.py `_validated_asi_choice`). `takingFeat` flips to the feat path
+  // (mutually exclusive: the engine rejects both). `featName` carries the chosen feat's name.
+  const [asiBumps, setAsiBumps] = React.useState({});
+  const [takingFeat, setTakingFeat] = React.useState(false);
+  const [featName, setFeatName] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
   // #robustness: synchronous in-flight lock (mirrors screen-table.jsx). The `submitting` STATE
   // only updates on re-render, so a rapid double-click would otherwise relay TWO level-up intents
@@ -415,6 +421,41 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
   const featAllowed = !!(option && option.choices && option.choices.feat_allowed);
   const toLevel = (option && option.to && option.to.level) || (Number(hero.level) + 1);
 
+  // #607: the structured ability-score stepper. ABILITIES is the canonical 6 in 5e order; each abbrev
+  // maps to the engine's full ability name (the level_up `asi` contract keys on full names). The
+  // current score is read from the engine read-model (hero.stats.<abbrev>) so the 20-cap is honest.
+  const ABILITIES = ["str", "dex", "con", "int", "wis", "cha"];
+  const ASI_FULL = {
+    str: "strength", dex: "dexterity", con: "constitution",
+    int: "intelligence", wis: "wisdom", cha: "charisma",
+  };
+  const heroStats = (hero && hero.stats) || {};
+  const asiTotal = ABILITIES.reduce((n, ab) => n + (Number(asiBumps[ab]) || 0), 0);
+  const asiAtCap = (ab) => (Number(heroStats[ab]) || 0) + (Number(asiBumps[ab]) || 0) >= 20;
+  // A +1 is legal while: fewer than 2 points spent total; this ability isn't already at +2 (so a
+  // single ability can take at most +2); no THIRD ability would be touched; and the post-bump score
+  // stays ≤ 20 (the engine cap). Mirrors `_validated_asi_choice` so the viewer never composes an
+  // intent the engine would reject.
+  const canBumpAsi = (ab) => {
+    if (asiTotal >= 2) return false;
+    if ((Number(asiBumps[ab]) || 0) >= 2) return false;
+    const distinct = ABILITIES.filter((a) => (Number(asiBumps[a]) || 0) > 0);
+    if (distinct.length >= 2 && !(Number(asiBumps[ab]) || 0)) return false;
+    return !asiAtCap(ab);
+  };
+  const bumpAsi = (ab, delta) => setAsiBumps((prev) => {
+    const cur = Number(prev[ab]) || 0;
+    const nextVal = Math.max(0, cur + delta);
+    const next = Object.assign({}, prev);
+    if (nextVal <= 0) delete next[ab]; else next[ab] = nextVal;
+    return next;
+  });
+  // The structured choice is complete when: in feat mode, a feat is named; otherwise the full +2 ASI
+  // is allocated. Drives both the disabled-Confirm reason and the composed move text.
+  const featChosen = takingFeat && !!featName.trim();
+  const asiComplete = asiTotal === 2;
+  const asiChoiceReady = takingFeat ? featChosen : asiComplete;
+
   const confirm = async () => {
     if (submittingRef.current) return;
     submittingRef.current = true;
@@ -423,8 +464,16 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
     const parts = ["I advance " + (hero.name || "my character") + " to level " + toLevel + " as a " + cls];
     if (subclassDue && subclassName.trim()) parts.push("choosing the " + subclassName.trim() + " subclass");
     if (asiRequired) {
-      parts.push("and for my ability score improvement" + (featAllowed ? " (or feat)" : "") + ": " +
-                 (asiNote.trim() || "ask me which to take"));
+      // #607: compose the STRUCTURED choice into an unambiguous intent the DM relays to level_up.
+      // Feat path and ASI path are mutually exclusive (the engine rejects both).
+      if (takingFeat && featName.trim()) {
+        parts.push("and instead of an ability score improvement, I take the " + featName.trim() + " feat");
+      } else {
+        const picks = ABILITIES
+          .filter((ab) => (Number(asiBumps[ab]) || 0) > 0)
+          .map((ab) => "+" + asiBumps[ab] + " " + ab.toUpperCase());
+        parts.push("and for my ability score improvement: " + (picks.join(" and ") || "ask me which to take"));
+      }
     }
     const text = parts.join(", ") + ".";
     try {
@@ -460,15 +509,24 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
   // still rides the next earned level-up; until then, block + explain.
   const noLegalLevel = !loading && !error && options.length === 0;
   const subclassNeedsName = subclassDue && !subclassName.trim();
-  // Confirm is blocked while submitting, when a subclass is required but unnamed, or when there is
-  // no XP-legal level to advance into — never PERMANENTLY (that is the old display-only stub). The
-  // reason is surfaced as a hover tooltip so the disabled state is never a mystery (the optimizer
-  // persona's complaint: a dead "Confirm advancement" with no explanation of WHY).
+  // #607: at an ASI level the structured choice must be COMPLETE before confirming — either a full
+  // +2 ability allocation or a named feat. An incomplete choice blocks Confirm with a reason (never a
+  // silently-dead button) so the viewer never composes a half-formed intent the engine would reject.
+  const asiNeedsChoice = asiRequired && !asiChoiceReady;
+  // Confirm is blocked while submitting, when a subclass is required but unnamed, when an ASI/feat
+  // choice is incomplete, or when there is no XP-legal level to advance into — never PERMANENTLY
+  // (that is the old display-only stub). The reason is surfaced as a hover tooltip + inline text so
+  // the disabled state is never a mystery (the optimizer persona's complaint: a dead "Confirm
+  // advancement" with no explanation of WHY).
   const confirmBlockReason = noLegalLevel
     ? "No XP earned yet — there's no level to advance into. Earn more XP first."
     : subclassNeedsName
       ? "Name (or pick) your " + subclassGroupLabel + " to confirm — the DM finalizes it"
-      : "";
+      : asiNeedsChoice
+        ? (takingFeat
+            ? "Name the feat you're taking to confirm"
+            : "Allocate your ability score improvement (+2 to one, or +1 to two) to confirm")
+        : "";
   const confirmDisabled = submitting || !!confirmBlockReason;
 
   return (
@@ -602,16 +660,108 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
               )}
 
               {asiRequired && (
-                <div style={{ marginTop: 16 }}>
+                <div style={{ marginTop: 16 }} data-worldos-testid="levelup-asi-section">
                   <SectionTitle>Ability Score Improvement{featAllowed ? " or feat" : ""}</SectionTitle>
-                  <input type="text" value={asiNote} onChange={(e) => setAsiNote(e.target.value)}
-                    placeholder={featAllowed ? "e.g. +2 STR — or a feat like Great Weapon Master" : "e.g. +2 STR, or +1 STR / +1 CON"}
-                    data-worldos-testid="levelup-asi-input"
-                    style={{
-                      width: "100%", padding: "8px 10px", boxSizing: "border-box",
-                      boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.4)",
-                      background: "rgba(255,250,235,0.5)", fontFamily: "var(--f-body)", fontSize: 14,
-                    }} />
+                  {/* #607: a structured choice, not a free-text note. When the campaign allows feats,
+                      a toggle swaps between the ASI stepper and a named-feat input (mutually exclusive —
+                      the engine rejects taking both). */}
+                  {featAllowed && (
+                    <div style={{ display: "flex", gap: 8, marginBottom: 12 }} role="tablist" aria-label="Improvement type">
+                      <button type="button" onClick={() => setTakingFeat(false)}
+                        aria-pressed={!takingFeat}
+                        data-worldos-testid="levelup-asi-toggle"
+                        style={{
+                          padding: "6px 12px", cursor: "pointer",
+                          background: !takingFeat ? "linear-gradient(180deg, var(--b-200), var(--b-400))" : "transparent",
+                          boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.35)",
+                          color: !takingFeat ? "var(--w-300)" : "var(--ink-800)",
+                          fontFamily: "var(--f-display)", fontSize: 12,
+                        }}>
+                        Raise abilities
+                      </button>
+                      <button type="button" onClick={() => setTakingFeat(true)}
+                        aria-pressed={takingFeat}
+                        data-worldos-testid="levelup-feat-toggle"
+                        style={{
+                          padding: "6px 12px", cursor: "pointer",
+                          background: takingFeat ? "linear-gradient(180deg, var(--b-200), var(--b-400))" : "transparent",
+                          boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.35)",
+                          color: takingFeat ? "var(--w-300)" : "var(--ink-800)",
+                          fontFamily: "var(--f-display)", fontSize: 12,
+                        }}>
+                        Take a feat instead
+                      </button>
+                    </div>
+                  )}
+
+                  {takingFeat ? (
+                    <div data-worldos-testid="levelup-feat-pane">
+                      <p className="body-sm muted" style={{ marginTop: 0 }}>
+                        Name the feat your character takes — the DM finalizes it against the world's options.
+                      </p>
+                      <input type="text" value={featName} onChange={(e) => setFeatName(e.target.value)}
+                        placeholder="e.g. Great Weapon Master"
+                        data-worldos-testid="levelup-feat-input"
+                        style={{
+                          width: "100%", padding: "8px 10px", boxSizing: "border-box",
+                          boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.4)",
+                          background: "rgba(255,250,235,0.5)", fontFamily: "var(--f-body)", fontSize: 14,
+                        }} />
+                    </div>
+                  ) : (
+                    <div data-worldos-testid="levelup-asi-stepper">
+                      <p className="body-sm muted" style={{ marginTop: 0 }}>
+                        Spend +2: either +2 into one ability, or +1 into two. Scores cap at 20.
+                      </p>
+                      <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 8 }}>
+                        {ABILITIES.map((ab) => {
+                          const bump = Number(asiBumps[ab]) || 0;
+                          const base = Number(heroStats[ab]) || 0;
+                          const shown = base + bump;
+                          return (
+                            <div key={ab} style={{
+                              display: "flex", alignItems: "center", justifyContent: "space-between", gap: 6,
+                              padding: "6px 8px",
+                              boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.3)",
+                              background: bump > 0 ? "rgba(176,141,87,0.14)" : "transparent",
+                            }}>
+                              <div>
+                                <div className="eyebrow" style={{ fontSize: 10 }}>{ab.toUpperCase()}</div>
+                                <div style={{ fontFamily: "var(--f-display)", fontSize: 15, color: "var(--ink-900)" }}>
+                                  {shown}{bump > 0 ? <span style={{ color: "var(--emerald)", fontSize: 11 }}> (+{bump})</span> : null}
+                                </div>
+                              </div>
+                              <div style={{ display: "flex", gap: 4 }}>
+                                <button type="button" onClick={() => bumpAsi(ab, -1)} disabled={bump <= 0}
+                                  aria-label={"Lower " + ASI_FULL[ab] + " improvement"}
+                                  data-worldos-testid={"levelup-asi-dec-" + ab}
+                                  style={{
+                                    width: 24, height: 24, cursor: bump <= 0 ? "default" : "pointer",
+                                    opacity: bump <= 0 ? 0.4 : 1,
+                                    boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.4)",
+                                    background: "transparent", fontFamily: "var(--f-display)",
+                                  }}>−</button>
+                                <button type="button" onClick={() => bumpAsi(ab, 1)} disabled={!canBumpAsi(ab)}
+                                  aria-label={"Raise " + ASI_FULL[ab] + " improvement"}
+                                  data-worldos-testid={"levelup-asi-inc-" + ab}
+                                  title={asiAtCap(ab) ? "Already at the 20 cap" : (asiTotal >= 2 ? "Both points are already spent" : "")}
+                                  style={{
+                                    width: 24, height: 24, cursor: !canBumpAsi(ab) ? "default" : "pointer",
+                                    opacity: !canBumpAsi(ab) ? 0.4 : 1,
+                                    boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.4)",
+                                    background: "transparent", fontFamily: "var(--f-display)",
+                                  }}>+</button>
+                              </div>
+                            </div>
+                          );
+                        })}
+                      </div>
+                      <div className="hand muted" style={{ fontSize: 11, marginTop: 8 }}
+                        data-worldos-testid="levelup-asi-remaining">
+                        {2 - asiTotal > 0 ? (2 - asiTotal) + " point" + (2 - asiTotal === 1 ? "" : "s") + " left to spend" : "All set — +2 allocated"}
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
 

--- a/viewer/openworlds/screen-create.jsx
+++ b/viewer/openworlds/screen-create.jsx
@@ -248,8 +248,19 @@ function ScreenCreate({ onNavigate, state, setState, preferredProvider = "" }) {
   // no supervisor to summon — fall back to the read-only table so the surface stays reachable.
   const bindHero = async () => {
     if (summoning) return;
+    // #721: outside the native app (a plain browser preview) there is no supervisor to summon. The
+    // old behavior silently called onNavigate("table") — a PHANTOM SUCCESS: the player pressed
+    // "Bind the hero", the wizard vanished onto a read-only table, and no game was ever minted, yet
+    // nothing said so. SURFACE the failure instead (inline error + danger toast) so the player knows
+    // the bind needs the WorldOS app — never a silent no-op. (No bridge => no /move, no state write.)
     if (!window.OpenWorldsNative?.hasBridge?.()) {
-      onNavigate("table");
+      const message = "Hero binding needs the WorldOS app — open the native app to bind a hero.";
+      setSummonError(message);
+      toast({
+        kind: "danger",
+        title: "Could not bind the hero",
+        body: message,
+      });
       return;
     }
     const spec = {
@@ -328,7 +339,7 @@ function ScreenCreate({ onNavigate, state, setState, preferredProvider = "" }) {
         <Divider />
         <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
           {steps.map((s, i) => (
-            <button key={s.id} onClick={() => setStep(i)} style={{
+            <button key={s.id} onClick={() => setStep(i)} data-worldos-testid={"create-step-" + s.id} style={{
               display: "grid", gridTemplateColumns: "28px 1fr auto", gap: 8, alignItems: "center",
               padding: "10px 12px",
               textAlign: "left",
@@ -382,7 +393,7 @@ function ScreenCreate({ onNavigate, state, setState, preferredProvider = "" }) {
           {step < steps.length - 1 ? (
             <BrassButton onClick={next}>Continue →</BrassButton>
           ) : (
-            <BrassButton tone="crimson" onClick={bindHero} disabled={summoning}>
+            <BrassButton tone="crimson" onClick={bindHero} disabled={summoning} testId="bind-hero">
               {summoning ? "Binding the hero…" : "Bind the hero"}
             </BrassButton>
           )}

--- a/viewer/tests/test_create_bind_bridge.py
+++ b/viewer/tests/test_create_bind_bridge.py
@@ -1,0 +1,229 @@
+"""#721 — 'Bind the hero' must SURFACE the missing-native-bridge failure, not phantom-succeed.
+
+`screen-create.jsx`'s `bindHero` mints a real provider session through the native supervisor
+(`window.OpenWorldsNative`). Outside the native app (a plain browser preview) there is no bridge.
+The old behavior silently called `onNavigate("table")` — a PHANTOM SUCCESS: the player pressed
+"Bind the hero", the wizard vanished onto a read-only table, and nothing told them the bind never
+actually happened (no game was minted).
+
+This guard mounts the REAL ScreenCreate through the babel-vm harness (the established pattern from
+test_rest_camp_levelup_wiring.py), drives the wizard to its final Bind step, and clicks
+'Bind the hero' with `window.OpenWorldsNative` undefined. It asserts:
+
+  * the failure is SURFACED — an inline summonError is rendered, AND a danger toast fires;
+  * the bind does NOT phantom-succeed — onNavigate("table") is NOT called.
+
+Read-only / additive: this is a presentation-only reliability fix — no engine state is written
+(there is no bridge, so no /move, no startProviderSession). The viewer stays a move-sink.
+"""
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+_OPENWORLDS = Path(__file__).resolve().parents[1] / "openworlds"
+_SCREEN_CREATE = _OPENWORLDS / "screen-create.jsx"
+_BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+
+# A minimal-but-real React (hook cells + effects + a walkable createElement tree), a passthrough for
+# every chrome component screen-create renders, and a tree-walk to find a node by testid + invoke its
+# onClick — the exact harness shape proven in test_rest_camp_levelup_wiring.py.
+_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+function makeReact() {
+  const stateCells = [], refCells = [], cbCells = [], memoCells = [], effects = [];
+  let sIdx = 0, rIdx = 0, cIdx = 0, mIdx = 0, eIdx = 0;
+  let renderFn = null, result = null;
+  const pendingEffects = [];
+  let flushing = false;
+
+  function useState(init) {
+    const i = sIdx++;
+    if (stateCells[i] === undefined) stateCells[i] = { v: typeof init === 'function' ? init() : init };
+    const cell = stateCells[i];
+    const set = (next) => { cell.v = (typeof next === 'function') ? next(cell.v) : next; render(); flushEffects(); };
+    return [cell.v, set];
+  }
+  function useRef(init) { const i = rIdx++; if (refCells[i] === undefined) refCells[i] = { current: init }; return refCells[i]; }
+  function depsEqual(a, b) { if (!a || !b || a.length !== b.length) return false; for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false; return true; }
+  function useCallback(fn, deps) { const i = cIdx++; const prev = cbCells[i]; if (prev === undefined || !depsEqual(prev.deps, deps)) { cbCells[i] = { fn, deps }; return fn; } return prev.fn; }
+  function useMemo(fn, deps) { const i = mIdx++; const prev = memoCells[i]; if (prev === undefined || !depsEqual(prev.deps, deps)) { const v = fn(); memoCells[i] = { v, deps }; return v; } return prev.v; }
+  function useEffect(fn, deps) {
+    const i = eIdx++;
+    const prev = effects[i];
+    const changed = !prev || !depsEqual(prev.deps, deps);
+    if (changed) {
+      pendingEffects.push(() => { if (prev && typeof prev.cleanup === 'function') prev.cleanup(); const cleanup = fn(); effects[i] = { deps, cleanup: typeof cleanup === 'function' ? cleanup : null }; });
+      if (!prev) effects[i] = { deps, cleanup: null }; else effects[i].deps = deps;
+    }
+  }
+  function createElement(type, props) {
+    const children = Array.prototype.slice.call(arguments, 2);
+    return { type, props: props || {}, children };
+  }
+  function render() { sIdx = 0; rIdx = 0; cIdx = 0; mIdx = 0; eIdx = 0; result = renderFn(); }
+  function flushEffects() { if (flushing) return; flushing = true; try { while (pendingEffects.length) pendingEffects.shift()(); } finally { flushing = false; } }
+  const React = { useState, useRef, useCallback, useMemo, useEffect, createElement, Fragment: 'F' };
+  function mount(fn) { renderFn = fn; render(); flushEffects(); }
+  function commit() { flushEffects(); }
+  function api() { return result; }
+  return { React, mount, commit, api };
+}
+
+const reactHost = makeReact();
+
+function passthrough(name) { return function (props) { const p = props || {}; const kids = (p.children !== undefined) ? [].concat(p.children) : []; return reactHost.React.createElement(name, p, ...kids); }; }
+
+const navCalls = [];
+const toastCalls = [];
+
+const sandbox = {
+  React: reactHost.React,
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible', getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
+  setTimeout: (fn) => 0, clearTimeout: () => {}, setInterval: () => 0, clearInterval: () => {},
+  fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+  addEventListener() {}, removeEventListener() {},
+  encodeURIComponent, URLSearchParams, Promise, JSON, Set, Array, Object, String, Boolean, Number, Math, Date,
+  console,
+  location: { replace() {} },
+};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+
+function load(p) {
+  let src = fs.readFileSync(p, 'utf8');
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+for (const name of ['Panel','BrassButton','Divider','SectionTitle','Pill','Placeholder','Img','Glyph','CornerOrnament']) {
+  sandbox[name] = passthrough(name);
+}
+sandbox.useToast = () => (t) => { toastCalls.push(t); };
+sandbox.inkInput = {};
+// OpenWorldsBuilding stub (begin/clear are called around the mint). NO OpenWorldsNative on window —
+// that is exactly the no-bridge condition under test.
+sandbox.OpenWorldsBuilding = { begin() {}, clear() {} };
+
+load(%(screen_create)s);
+
+function findByTestId(node, id, hits) {
+  hits = hits || [];
+  if (node == null || typeof node !== 'object') return hits;
+  if (Array.isArray(node)) { for (const c of node) findByTestId(c, id, hits); return hits; }
+  const props = node.props || {};
+  if (props['data-worldos-testid'] === id || props.testId === id) hits.push(node);
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) findByTestId(c, id, hits);
+  return hits;
+}
+function collectText(node, out) {
+  out = out || [];
+  if (node == null || node === false) return out;
+  if (typeof node === 'string' || typeof node === 'number') { out.push(String(node)); return out; }
+  if (Array.isArray(node)) { for (const c of node) collectText(c, out); return out; }
+  const props = node.props || {};
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) collectText(c, out);
+  return out;
+}
+function firstProps(node, id) { const hits = findByTestId(node, id); return hits.length ? (hits[0].props || {}) : null; }
+
+async function settle() { await new Promise((r) => setImmediate(r)); await new Promise((r) => setImmediate(r)); reactHost.commit(); }
+
+const h = {
+  mountCreate: (props) => { reactHost.mount(() => sandbox.window.ScreenCreate(props)); },
+  tree: () => reactHost.api(),
+  settle,
+  props: (id) => firstProps(reactHost.api(), id),
+  click: async (id) => { const hits = findByTestId(reactHost.api(), id); if (!hits.length) throw new Error('no node ' + id); const oc = (hits[0].props || {}).onClick; if (typeof oc !== 'function') throw new Error('no onClick on ' + id); oc(); await settle(); },
+  text: () => collectText(reactHost.api()).join(' ' + String.fromCharCode(31) + ' '),
+  navCalls: () => navCalls,
+  toasts: () => toastCalls,
+  exists: (id) => findByTestId(reactHost.api(), id).length,
+};
+sandbox.__navCalls = navCalls;
+
+const script = %(script)s;
+eval('(async () => { ' + script + ' })()')
+  .then((result) => { process.stdout.write(JSON.stringify(result)); })
+  .catch((e) => { console.error(e && e.stack || e); process.exit(1); });
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + render the JSX")
+class _Harness(unittest.TestCase):
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_SCREEN_CREATE, _BABEL):
+            assert p.exists(), f"missing {p}"
+
+    def _run(self, script: str):
+        program = _HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "screen_create": json.dumps(str(_SCREEN_CREATE)),
+            "script": json.dumps(script),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program, text=True, capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+
+# Mount ScreenCreate, drive to the final Bind step (the left-rail 'Bind' step button jumps there),
+# and click 'Bind the hero'. onNavigate records its calls so a phantom-success is observable.
+_MOUNT = (
+    "var nav = h.navCalls();"
+    "h.mountCreate({ onNavigate: function(dest){ nav.push(dest); }, state: {}, setState: function(){} });"
+    "await h.settle();"
+    "await h.click('create-step-review');"        # jump to the last (review/Bind) step
+)
+
+
+class BindHeroNoBridgeTests(_Harness):
+    """#721 — without the native bridge, Bind surfaces the failure (error + toast) and does NOT
+    silently navigate to the read-only table (phantom success)."""
+
+    def test_bind_without_bridge_surfaces_error_and_does_not_phantom_navigate(self):
+        out = self._run(
+            _MOUNT +
+            "await h.click('bind-hero');"
+            "var nav = h.navCalls();"
+            "return ({ nav: nav, toasts: h.toasts(), text: h.text() });"
+        )
+        # PHANTOM SUCCESS guard: the bind must NOT navigate to the read-only table.
+        self.assertNotIn("table", out["nav"],
+                         "without the native bridge, Bind must NOT silently navigate to the read-only table")
+        # The failure is SURFACED inline (summonError) — the player learns the bind didn't happen.
+        joined = out["text"].lower()
+        self.assertTrue(
+            ("native" in joined) or ("worldos app" in joined) or ("app to bind" in joined),
+            "the no-bridge failure must be surfaced inline (an error mentioning the native app)",
+        )
+        # AND a danger toast fires (the established failure-surface pattern in bindHero's catch).
+        danger = [t for t in out["toasts"] if (t or {}).get("kind") == "danger"]
+        self.assertTrue(danger, "a danger toast must fire so the no-bridge failure is not silent")
+
+    def test_bind_button_has_a_stable_test_id(self):
+        # The Bind CTA must be findable (a stable testId) so its behavior is guardable — this is the
+        # affordance the player presses; an un-testid'd button can silently regress.
+        out = self._run(
+            _MOUNT +
+            "return ({ bind: h.exists('bind-hero') });"
+        )
+        self.assertGreaterEqual(out["bind"], 1, "the 'Bind the hero' button must carry a stable testId")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_levelup_asi_feat_picker.py
+++ b/viewer/tests/test_levelup_asi_feat_picker.py
@@ -1,0 +1,364 @@
+"""#607 — the level-up flow's ASI / feat choice is a STRUCTURED picker, not a free-text note.
+
+The old LevelUpModal surfaced the ability-score-improvement choice (5e levels 4/8/12/16/19) as a
+single free-text box (`asiNote`): the player typed "+2 STR" into prose and hoped the DM parsed it.
+That is the free-text trap this issue closes — replace it with:
+
+  * an ability-score STEPPER (one +/- control per ability) that enforces the engine's ASI contract
+    (`level_up(asi=...)` → `_validated_asi_choice`: +2 to one ability OR +1 to two, each capped at
+    20 — server.py); the composed `/move` intent encodes the exact picks the engine resolves;
+  * a FEAT picker at ASI levels when the campaign allows feats (`option.choices.feat_allowed`): a
+    toggle to "take a feat instead" + a named feat input, mutually exclusive with the ASI (the engine
+    rejects both: "choose either asi or feat, not both").
+
+The viewer stays a read-only move-sink: it composes a `do` move-intent text and POSTs it to /move;
+the ENGINE (sole writer) applies the ASI/feat via its level_up tool. This exercises the SHIPPED
+screen-character.jsx through the bundled-Babel + createElement-capturing harness (same as
+test_rest_camp_levelup_wiring.py) so the test tracks the real JSX, not a reimplementation.
+"""
+
+import json
+import shutil
+import subprocess
+import unittest
+from pathlib import Path
+
+
+_OPENWORLDS = Path(__file__).resolve().parents[1] / "openworlds"
+_SCREEN_CHARACTER = _OPENWORLDS / "screen-character.jsx"
+_BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+
+_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+function makeReact() {
+  const stateCells = [], refCells = [], cbCells = [], memoCells = [], effects = [];
+  let sIdx = 0, rIdx = 0, cIdx = 0, mIdx = 0, eIdx = 0;
+  let renderFn = null, result = null;
+  const pendingEffects = [];
+  let flushing = false;
+
+  function useState(init) {
+    const i = sIdx++;
+    if (stateCells[i] === undefined) stateCells[i] = { v: typeof init === 'function' ? init() : init };
+    const cell = stateCells[i];
+    const set = (next) => { cell.v = (typeof next === 'function') ? next(cell.v) : next; render(); flushEffects(); };
+    return [cell.v, set];
+  }
+  function useRef(init) { const i = rIdx++; if (refCells[i] === undefined) refCells[i] = { current: init }; return refCells[i]; }
+  function depsEqual(a, b) { if (!a || !b || a.length !== b.length) return false; for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false; return true; }
+  function useCallback(fn, deps) { const i = cIdx++; const prev = cbCells[i]; if (prev === undefined || !depsEqual(prev.deps, deps)) { cbCells[i] = { fn, deps }; return fn; } return prev.fn; }
+  function useMemo(fn, deps) { const i = mIdx++; const prev = memoCells[i]; if (prev === undefined || !depsEqual(prev.deps, deps)) { const v = fn(); memoCells[i] = { v, deps }; return v; } return prev.v; }
+  function useEffect(fn, deps) {
+    const i = eIdx++;
+    const prev = effects[i];
+    const changed = !prev || !depsEqual(prev.deps, deps);
+    if (changed) {
+      pendingEffects.push(() => { if (prev && typeof prev.cleanup === 'function') prev.cleanup(); const cleanup = fn(); effects[i] = { deps, cleanup: typeof cleanup === 'function' ? cleanup : null }; });
+      if (!prev) effects[i] = { deps, cleanup: null }; else effects[i].deps = deps;
+    }
+  }
+  function createElement(type, props) {
+    const children = Array.prototype.slice.call(arguments, 2);
+    return { type, props: props || {}, children };
+  }
+  function render() { sIdx = 0; rIdx = 0; cIdx = 0; mIdx = 0; eIdx = 0; result = renderFn(); }
+  function flushEffects() { if (flushing) return; flushing = true; try { while (pendingEffects.length) pendingEffects.shift()(); } finally { flushing = false; } }
+  const React = { useState, useRef, useCallback, useMemo, useEffect, createElement, Fragment: 'F' };
+  function mount(fn) { renderFn = fn; render(); flushEffects(); }
+  function commit() { flushEffects(); }
+  function api() { return result; }
+  return { React, mount, commit, api };
+}
+
+let PLANNER = null;
+const posts = [];
+function fetchStub(url, opts) {
+  const u = String(url).split('?')[0];
+  if (u === '/build-options') {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(PLANNER || { ok: false, errors: ['no planner'] }) });
+  }
+  if (u === '/move') {
+    let body = {}; try { body = JSON.parse((opts && opts.body) || '{}'); } catch (_e) {}
+    posts.push({ url: u, body });
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: true }) });
+  }
+  return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+}
+
+const reactHost = makeReact();
+function passthrough(name) { return function (props) { const p = props || {}; const kids = (p.children !== undefined) ? [].concat(p.children) : []; return reactHost.React.createElement(name, p, ...kids); }; }
+
+const sandbox = {
+  React: reactHost.React,
+  ReactDOM: { createRoot: () => ({ render() {} }) },
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible', getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
+  setTimeout: (fn) => 0, clearTimeout: () => {}, setInterval: () => 0, clearInterval: () => {},
+  fetch: fetchStub,
+  addEventListener() {}, removeEventListener() {},
+  encodeURIComponent, URLSearchParams, Promise, JSON, Set, Array, Object, String, Boolean, Number, Math,
+  console,
+};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+
+function load(p) {
+  let src = fs.readFileSync(p, 'utf8');
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+for (const name of ['Panel','BrassButton','Divider','SectionTitle','Pill','Placeholder','Img','Glyph','CornerOrnament']) {
+  sandbox[name] = passthrough(name);
+}
+sandbox.useToast = () => (t) => {};
+sandbox.slug = (n) => (n || '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
+sandbox.combatSurfaceFromCampaign = () => '';
+
+load(%(screen_character)s);
+
+function findByTestId(node, id, hits) {
+  hits = hits || [];
+  if (node == null || typeof node !== 'object') return hits;
+  if (Array.isArray(node)) { for (const c of node) findByTestId(c, id, hits); return hits; }
+  const props = node.props || {};
+  if (props['data-worldos-testid'] === id || props.testId === id) hits.push(node);
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) findByTestId(c, id, hits);
+  return hits;
+}
+function collectText(node, out) {
+  out = out || [];
+  if (node == null || node === false) return out;
+  if (typeof node === 'string' || typeof node === 'number') { out.push(String(node)); return out; }
+  if (Array.isArray(node)) { for (const c of node) collectText(c, out); return out; }
+  const props = node.props || {};
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) collectText(c, out);
+  return out;
+}
+function firstProps(node, id) { const hits = findByTestId(node, id); return hits.length ? (hits[0].props || {}) : null; }
+
+async function settle() { await new Promise((r) => setImmediate(r)); await new Promise((r) => setImmediate(r)); reactHost.commit(); }
+
+const h = {
+  mountLevelUp: (props) => { reactHost.mount(() => sandbox.window.LevelUpModal(props)); },
+  setPlanner: (p) => { PLANNER = p; },
+  tree: () => reactHost.api(),
+  settle,
+  props: (id) => firstProps(reactHost.api(), id),
+  click: async (id) => { const hits = findByTestId(reactHost.api(), id); if (!hits.length) throw new Error('no node ' + id); const oc = (hits[0].props || {}).onClick; if (typeof oc !== 'function') throw new Error('no onClick on ' + id); oc(); await settle(); },
+  // set the value of an input-like node by invoking its onChange with a synthetic event.
+  change: async (id, value) => { const hits = findByTestId(reactHost.api(), id); if (!hits.length) throw new Error('no node ' + id); const oc = (hits[0].props || {}).onChange; if (typeof oc !== 'function') throw new Error('no onChange on ' + id); oc({ target: { value: value } }); await settle(); },
+  text: () => collectText(reactHost.api()).join(' ' + String.fromCharCode(31) + ' '),
+  posts: () => posts,
+  exists: (id) => findByTestId(reactHost.api(), id).length,
+};
+
+const script = %(script)s;
+eval('(async () => { ' + script + ' })()')
+  .then((result) => { process.stdout.write(JSON.stringify(result)); })
+  .catch((e) => { console.error(e && e.stack || e); process.exit(1); });
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + render the JSX")
+class _Harness(unittest.TestCase):
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_SCREEN_CHARACTER, _BABEL):
+            assert p.exists(), f"missing {p}"
+
+    def _run(self, script: str):
+        program = _HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "screen_character": json.dumps(str(_SCREEN_CHARACTER)),
+            "script": json.dumps(script),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program, text=True, capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+
+# An L3 fighter at its level-4 ASI (the SRD's first ASI level). The planner option flags the ASI
+# choice as required and feats as allowed (a campaign that turned feats on).
+_HERO_L3_FIGHTER = (
+    "{ id: 'char_1', name: 'Karlach', class: 'fighter', level: 3, "
+    "xp: 2700, xpMax: 6500, stats: { str: 15, dex: 13, con: 14, int: 8, wis: 10, cha: 12 }, "
+    "spells: [], spellSlots: {} }"
+)
+
+_PLANNER_ASI_AND_FEAT = json.dumps({
+    "ok": True,
+    "planner": {
+        "options": [{
+            "class_name": "fighter",
+            "from": {"level": 3}, "to": {"level": 4, "class_level": 4},
+            "hp_gain": 7,
+            "features_gained": [{"name": "Ability Score Improvement"}],
+            "choices": {"asi_required": True, "feat_allowed": True, "multiclass_allowed": True},
+        }],
+    },
+})
+
+# Same level but a campaign with feats OFF — the feat toggle must not appear; only the ASI stepper.
+_PLANNER_ASI_ONLY = json.dumps({
+    "ok": True,
+    "planner": {
+        "options": [{
+            "class_name": "fighter",
+            "from": {"level": 3}, "to": {"level": 4, "class_level": 4},
+            "hp_gain": 7,
+            "features_gained": [{"name": "Ability Score Improvement"}],
+            "choices": {"asi_required": True, "feat_allowed": False, "multiclass_allowed": True},
+        }],
+    },
+})
+
+
+class LevelUpAsiStepperTests(_Harness):
+    """#607 — the ASI choice is a structured ability-score stepper enforcing the engine's
+    +2-to-one / +1-to-two contract, and the composed /move encodes the exact picks."""
+
+    def _mount(self, hero=_HERO_L3_FIGHTER, planner=_PLANNER_ASI_AND_FEAT):
+        return (
+            "h.setPlanner(" + planner + ");"
+            "h.mountLevelUp({ hero: " + hero + ", campaignId: 'camp1',"
+            " onClose: function(){}, onDone: function(){}, toast: function(){} });"
+            "await h.settle();"
+        )
+
+    def test_no_free_text_asi_note_remains(self):
+        """The old free-text asiNote box is GONE — the choice is structured now, not prose."""
+        out = self._run(self._mount() + "return ({ legacy_input: h.exists('levelup-asi-input') });")
+        self.assertEqual(out["legacy_input"], 0,
+                         "the free-text levelup-asi-input must be replaced by a structured picker")
+
+    def test_a_stepper_exists_for_every_ability(self):
+        out = self._run(
+            self._mount() +
+            "return ({"
+            "  str: h.exists('levelup-asi-inc-str'), dex: h.exists('levelup-asi-inc-dex'),"
+            "  con: h.exists('levelup-asi-inc-con'), int: h.exists('levelup-asi-inc-int'),"
+            "  wis: h.exists('levelup-asi-inc-wis'), cha: h.exists('levelup-asi-inc-cha'),"
+            "  dec: h.exists('levelup-asi-dec-str'), text: h.text() });"
+        )
+        for ab in ("str", "dex", "con", "int", "wis", "cha"):
+            self.assertGreaterEqual(out[ab], 1, f"the {ab.upper()} +1 control must render")
+        self.assertGreaterEqual(out["dec"], 1, "a -1 control must render for an allocated ability")
+
+    def test_confirm_blocked_until_two_points_allocated(self):
+        out = self._run(
+            self._mount() +
+            "var before = h.props('levelup-confirm');"
+            "await h.click('levelup-asi-inc-str');"          # +1 STR (1 of 2)
+            "var mid = h.props('levelup-confirm');"
+            "await h.click('levelup-asi-inc-dex');"          # +1 DEX (2 of 2)
+            "var after = h.props('levelup-confirm');"
+            "return ({ disabled_before: !!before.disabled, disabled_mid: !!mid.disabled,"
+            "  disabled_after: !!after.disabled, title_before: before.title || '' });"
+        )
+        self.assertTrue(out["disabled_before"], "Confirm is blocked before any ASI points are allocated")
+        self.assertTrue(out["disabled_mid"], "Confirm stays blocked with only 1 of 2 points allocated")
+        self.assertFalse(out["disabled_after"], "allocating the full +2 (here +1/+1) enables Confirm")
+
+    def test_two_into_one_ability_is_allowed_and_caps_at_two(self):
+        out = self._run(
+            self._mount() +
+            "await h.click('levelup-asi-inc-str');"          # +1 STR
+            "await h.click('levelup-asi-inc-str');"          # +2 STR (full)
+            "var afterTwo = h.props('levelup-confirm');"
+            "var incThree = h.exists('levelup-asi-inc-str');" # a 3rd +1 control must be gone/blocked
+            "await h.click('levelup-confirm');"
+            "return ({ disabled_after_two: !!afterTwo.disabled, post: (h.posts()[0] || null) });"
+        )
+        self.assertFalse(out["disabled_after_two"], "+2 into a single ability is a legal full allocation")
+        self.assertIsNotNone(out["post"], "confirming a full +2 STR must relay a /move")
+        text = out["post"]["body"]["text"].lower()
+        self.assertEqual(out["post"]["body"]["kind"], "do")
+        self.assertIn("+2 str", text, "the composed intent must encode the structured +2 STR pick")
+
+    def test_split_asi_encodes_both_picks_in_the_move(self):
+        out = self._run(
+            self._mount() +
+            "await h.click('levelup-asi-inc-str');"
+            "await h.click('levelup-asi-inc-con');"
+            "await h.click('levelup-confirm');"
+            "return ({ post: (h.posts()[0] || null) });"
+        )
+        self.assertIsNotNone(out["post"])
+        text = out["post"]["body"]["text"].lower()
+        self.assertIn("+1 str", text)
+        self.assertIn("+1 con", text)
+
+    def test_a_score_cannot_be_raised_above_twenty(self):
+        """The engine caps an ASI at 20; the stepper must not let a 20-score ability take more."""
+        hero20 = _HERO_L3_FIGHTER.replace("str: 15", "str: 20")
+        out = self._run(
+            self._mount(hero=hero20) +
+            "var p = h.props('levelup-asi-inc-str');"
+            "return ({ disabled: !!(p && p.disabled), exists: h.exists('levelup-asi-inc-str') });"
+        )
+        # The +1 STR control is present but disabled (the ability is already at the 20 cap).
+        self.assertTrue(out["disabled"], "raising a 20-score ability must be blocked (the engine caps at 20)")
+
+
+class LevelUpFeatPickerTests(_Harness):
+    """#607 — at an ASI level where the campaign allows feats, a 'take a feat instead' toggle +
+    named feat input appears (mutually exclusive with the ASI), and the /move encodes the feat."""
+
+    def _mount(self, planner=_PLANNER_ASI_AND_FEAT):
+        return (
+            "h.setPlanner(" + planner + ");"
+            "h.mountLevelUp({ hero: " + _HERO_L3_FIGHTER + ", campaignId: 'camp1',"
+            " onClose: function(){}, onDone: function(){}, toast: function(){} });"
+            "await h.settle();"
+        )
+
+    def test_feat_toggle_present_only_when_feats_allowed(self):
+        with_feats = self._run(self._mount() + "return ({ toggle: h.exists('levelup-feat-toggle') });")
+        self.assertGreaterEqual(with_feats["toggle"], 1, "the feat toggle must render when feat_allowed")
+        without = self._run(self._mount(_PLANNER_ASI_ONLY) + "return ({ toggle: h.exists('levelup-feat-toggle') });")
+        self.assertEqual(without["toggle"], 0, "no feat toggle when the campaign disables feats")
+
+    def test_taking_a_feat_swaps_in_a_named_input_and_disables_the_stepper(self):
+        out = self._run(
+            self._mount() +
+            "await h.click('levelup-feat-toggle');"
+            "return ({ feat_input: h.exists('levelup-feat-input'),"
+            "  stepper: h.exists('levelup-asi-inc-str') });"
+        )
+        self.assertGreaterEqual(out["feat_input"], 1, "choosing a feat must reveal a named feat input")
+        self.assertEqual(out["stepper"], 0, "the ASI stepper is hidden in feat mode (mutually exclusive)")
+
+    def test_feat_mode_requires_a_name_then_encodes_it_in_the_move(self):
+        out = self._run(
+            self._mount() +
+            "await h.click('levelup-feat-toggle');"
+            "var blocked = h.props('levelup-confirm');"
+            "await h.change('levelup-feat-input', 'Great Weapon Master');"
+            "var ready = h.props('levelup-confirm');"
+            "await h.click('levelup-confirm');"
+            "return ({ blocked: !!blocked.disabled, ready: !!ready.disabled, post: (h.posts()[0] || null) });"
+        )
+        self.assertTrue(out["blocked"], "feat mode with no feat named must block Confirm")
+        self.assertFalse(out["ready"], "naming the feat enables Confirm")
+        self.assertIsNotNone(out["post"])
+        text = out["post"]["body"]["text"].lower()
+        self.assertIn("great weapon master", text, "the composed intent must name the chosen feat")
+        self.assertIn("feat", text, "the intent must signal a feat choice (not an ASI)")
+        # mutually exclusive: an ASI was never allocated, so the intent must NOT also claim an ASI bump.
+        self.assertNotIn("+1 str", text)
+        self.assertNotIn("+2 str", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two isolated single-file v1.0.4 Player-Ready-Beta gap fixes (owner C — create/character islands). Both are **presentation-only**: the viewer stays a read-only move-sink; the engine remains the sole writer. Additive — no wire-contract changes, old snapshots round-trip.

### #721 — `screen-create.jsx`: 'Bind the hero' no longer phantom-succeeds without the native bridge
Closes #721.

`bindHero` mints a real provider session through `window.OpenWorldsNative`. Outside the native app (a plain browser preview) there is no bridge, and the old code silently called `onNavigate("table")` — a **phantom success**: the wizard vanished onto a read-only table, *no game was ever minted*, and nothing told the player.

Fix: on the bridge-undefined branch, set `summonError` (rendered inline) **and** fire a `danger` toast — "Hero binding needs the WorldOS app — open the native app to bind a hero." No bridge ⇒ no `/move`, no state write. Added stable testIds (`bind-hero`, `create-step-<id>`) so the affordance is guardable.

### #607 — `screen-character.jsx`: structured ASI / feat picker at level-up
Closes #607.

The level-up modal surfaced the ability-score-improvement choice (5e levels 4/8/12/16/19) as a single free-text box (`asiNote`) — the player typed "+2 STR" into prose and hoped the DM parsed it. Replaced with a **structured picker**:

- an **ability-score stepper** (one ±1 control per ability) enforcing the engine's `level_up` contract — +2 to one ability **or** +1 to two, each capped at 20 (mirrors `servers/engine/server.py` `_validated_asi_choice`), so the viewer never composes an intent the engine would reject;
- a **feat picker** ("take a feat instead" + named feat input) at ASI levels where the campaign allows feats (`option.choices.feat_allowed`), **mutually exclusive** with the ASI (the engine rejects both);
- `Confirm` is honestly **blocked + explained** (inline + tooltip) until the choice is complete — never a silently-dead button.

The composed `do` `/move` intent encodes the exact structured picks the DM relays to `preview_level_up`/`level_up`. Reads the canonical engine planner `option.choices` — no forked predicates.

## Invariants honored
- **Read-only on engine state** — no state writes/mutations; both surfaces only compose presentation + a `/move` move-intent (engine = sole writer).
- **Additive** — new local UI state defaults to today's behavior; no read-model field added; old snapshots round-trip.
- **Canonical predicates reused** — `option.choices.{asi_required,feat_allowed}` and the existing `/move` `kind:"do"` move-sink pattern (same as the subclass picker + camp sidebar).
- **No wire contract broken.**

## Tests (TDD — RED first, then GREEN)
- `viewer/tests/test_create_bind_bridge.py` (#721): mounts the real `ScreenCreate` via the babel-vm jsdom harness, drives to the Bind step, clicks Bind with `window.OpenWorldsNative` undefined, asserts the inline error + danger toast fire and `onNavigate("table")` is **not** called.
- `viewer/tests/test_levelup_asi_feat_picker.py` (#607): mounts the real `LevelUpModal`; asserts the legacy free-text box is gone, the stepper enforces +2/+1+1/20-cap, the feat toggle appears only when feats are allowed and swaps in a named input, and the `/move` text encodes the structured ASI/feat picks.

Verification:
- Full viewer suite: **668 passed, 1 skipped** (`python -m pytest viewer/tests -q -p no:xdist`).
- `bash qa/fast_gate.sh`: **PASS** (221 deterministic engine tests).