### PR TITLE
fix(viewer): B-merchant Beta-gap — #602 + #604 + #755

### DIFF
--- a/viewer/openworlds/screen-merchant.jsx
+++ b/viewer/openworlds/screen-merchant.jsx
@@ -61,6 +61,25 @@ function enrichWare(item, catalog) {
   return merged;
 }
 
+// #755: the haggle price cell rendered the LIST price and the DISCOUNTED price adjacently, so
+// "24" + "23" read as one run-together number "2423gp" (rc2 adversarial bug). This PURE helper
+// returns the cell's structured parts so the two numbers can NEVER collapse into one string: the
+// caller renders `list` (struck) → `price` only when `separated` is true. A null/equal discount
+// (no haggle, or a rounding no-op) collapses to a single `price` with `separated:false` — never a
+// struck list adjacent to the same number. Pure + side-effect-free (testable under the JSX harness).
+function marketPriceCellParts(shownPrice, haggledPrice) {
+  const base = Number(shownPrice);
+  const haggled = haggledPrice !== null && haggledPrice !== undefined && Number(haggledPrice) !== base;
+  return {
+    list: base,
+    price: haggled ? Number(haggledPrice) : base,
+    haggled: haggled,
+    // `separated` drives the explicit arrow between the struck list + the discounted price; it is
+    // the SAME condition as `haggled`, named for the render so the two prices are never adjacent.
+    separated: haggled,
+  };
+}
+
 function ScreenMerchant({ onNavigate, state, setState }) {
   const [tab, setTab] = React.useState("buy");
   // MK-02/#548: the initial id MUST match a MERCHANTS entry and the first playable BG session
@@ -80,6 +99,18 @@ function ScreenMerchant({ onNavigate, state, setState }) {
   // fire-and-forget and only clears the cart in the async .then, so a fast second click
   // would relay a SECOND purchase before the first resolves. Synchronous ref lock.
   const submittingRef = React.useRef(false);
+  // #755: the 'Take' (add-to-cart) button had NO debounce — a fast double-click queued the SAME
+  // ware twice. Guard it with a synchronous ref lock that releases on the next frame (mirrors
+  // submittingRef on Confirm), so one human click adds exactly one ware.
+  const takingRef = React.useRef(false);
+  const addToCart = React.useCallback((entry) => {
+    if (takingRef.current) return;
+    takingRef.current = true;
+    setCart((prev) => [...prev, entry]);
+    // Release after the click settles so a genuine second click (a new intent) still works, but a
+    // double-fire from one press is dropped. setTimeout(0) is enough to coalesce the bounce.
+    setTimeout(() => { takingRef.current = false; }, 0);
+  }, []);
   // MK-06: real type filter for the wares table — no dead "Filter…" button.
   const [typeFilter, setTypeFilter] = React.useState("all");
 
@@ -136,11 +167,51 @@ function ScreenMerchant({ onNavigate, state, setState }) {
   const purseTotalGp = window.currencyTotalGp(coins);
   const toast = window.useToast ? window.useToast() : (() => {});
 
-  // Sell-tab inventory. The Market is a display-only prototype and has NO live shop/stash
-  // read-model, so this stays empty — we never fall back to the bundled demo stash (PF1e
-  // leak). If a live merchant surface is ever wired, prefer it here; until then [].
-  const stash = Array.isArray(state?.merchantStash) ? state.merchantStash : [];
-  const merchant = MERCHANTS.find((m) => m.id === merchantId) || MERCHANTS[0];
+  // #602: the LIVE merchant supply chain. /merchant-surface projects the world's REAL is_merchant
+  // canon NPCs (the canonical content.find_canon_characters slice find_npcs uses) + the bundled
+  // SRD item catalog, replacing the old hardcoded demo merchants + demo stock array. The
+  // hardcoded MERCHANTS block stays ONLY as the read-only preview fallback (no live surface yet —
+  // e.g. a brand-new game before the world is attached); the live surface always wins when present.
+  const [merchSurface, setMerchSurface] = React.useState(null);
+  React.useEffect(() => {
+    let cancelled = false;
+    fetch("/merchant-surface" + surfaceQuery, { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => { if (!cancelled) setMerchSurface(d && Array.isArray(d.merchants) ? d : null); })
+      .catch(() => { if (!cancelled) setMerchSurface(null); });
+    return () => { cancelled = true; };
+  }, [surfaceQuery]);
+  // The live merchant roster (real is_merchant NPCs); each shares the SRD `catalog` wares as its
+  // stock (a real per-merchant inventory is a separate, larger change — the world tags WHO trades,
+  // not yet WHAT each stocks). Falls back to the demo MERCHANTS in read-only preview.
+  const liveCatalog = merchSurface && Array.isArray(merchSurface.catalog) ? merchSurface.catalog : [];
+  const liveMerchants = merchSurface && merchSurface.merchants.length
+    ? merchSurface.merchants.map((m) => ({ ...m, stock: liveCatalog }))
+    : null;
+  const merchantList = liveMerchants || MERCHANTS;
+
+  // #604: the Sell tab lists the party's REAL pack from the existing /inventory-surface (already
+  // fetched below for the equipped compare). The always-empty `state.merchantStash` stub is gone —
+  // we surface what the party actually carries. Empty until a live inventory is present (honest).
+  const [sellStash, setSellStash] = React.useState([]);
+  const stash = sellStash;
+  const rawMerchant = merchantList.find((m) => m.id === merchantId) || merchantList[0] || MERCHANTS[0];
+  // A live merchant carries only its canon identity (id/name/race/class/faction/location/stock); the
+  // narrative display fields (subtitle/greeting/location/disposition) are demo-only flavor, so fill
+  // honest defaults derived from the REAL record rather than fabricating a backstory. A demo merchant
+  // already carries them, so this is a no-op for the preview fallback.
+  const merchant = {
+    ...rawMerchant,
+    short: rawMerchant.short || rawMerchant.name,
+    subtitle: rawMerchant.subtitle
+      || ((rawMerchant.race || rawMerchant.class)
+        ? [rawMerchant.race, rawMerchant.class].filter(Boolean).join(" · ") + " trader"
+        : "A trader of this world."),
+    location: rawMerchant.location || rawMerchant.canon_location_id || "this region",
+    waresName: rawMerchant.waresName || rawMerchant.name,
+    greeting: rawMerchant.greeting || "Coin first, then the catalogue. Look over the wares.",
+    disposition: rawMerchant.disposition || "open for trade",
+  };
   const buyTotal = cart.reduce((s, i) => s + (i.mode === "buy" ? i.price : 0), 0);
   const sellTotal = cart.reduce((s, i) => s + (i.mode === "sell" ? i.price : 0), 0);
   const adjustedBuyTotal = Math.round(buyTotal * (1 - haggle / 100));
@@ -158,17 +229,21 @@ function ScreenMerchant({ onNavigate, state, setState }) {
   // show what an item IS and the player can evaluate an upgrade. Fetched once per merchant
   // stock change; an unresolved name leaves the ware untouched (weight/price only).
   const [catalog, setCatalog] = React.useState({});
+  // The distinct ware NAMES on the current table — a stable string key so the enrichment refetches
+  // when the LIVE stock/stash actually changes (the async /merchant-surface + /inventory-surface
+  // loads), not only on merchant/tab toggle (the old [merchantId, tab] deps missed the live load).
+  const enrichNames = Array.from(new Set((baseInv || []).map((i) => i && i.name).filter(Boolean)));
+  const enrichKey = enrichNames.join("");
   React.useEffect(() => {
-    const names = Array.from(new Set((baseInv || []).map((i) => i && i.name).filter(Boolean)));
-    if (!names.length) { setCatalog({}); return; }
+    if (!enrichNames.length) { setCatalog({}); return; }
     let cancelled = false;
-    const q = names.map((n) => "name=" + encodeURIComponent(n)).join("&");
+    const q = enrichNames.map((n) => "name=" + encodeURIComponent(n)).join("&");
     fetch("/item-catalog?" + q, { cache: "no-store" })
       .then((r) => (r.ok ? r.json() : null))
       .then((d) => { if (!cancelled && d && d.items) setCatalog(d.items); })
       .catch(() => { /* keep last good; the ware still shows weight/price */ });
     return () => { cancelled = true; };
-  }, [merchantId, tab]);
+  }, [enrichKey]);
 
   // #756: the party's equipped gear (live inventory surface) so the Market inspector can
   // compare a ware to what the player already wears ("is this an upgrade?"). Read-only.
@@ -182,6 +257,15 @@ function ScreenMerchant({ onNavigate, state, setState }) {
         const all = [];
         for (const m of d.party) for (const it of (m.equipped || [])) if (it && it.name) all.push(it);
         setEquipped(all);
+        // #604: the Sell tab lists the party's REAL pack from this SAME inventory surface — the
+        // shared stash (all party items) the Stash screen reads. Replaces the always-empty
+        // `state.merchantStash` stub. A backpack with no `type` defaults to "common" so the kind
+        // filter + pill render; quest items are excluded from the sell list downstream.
+        const sellable = (Array.isArray(d.stash) ? d.stash : []).map((it) => ({
+          ...it,
+          type: it.type || "common",
+        }));
+        setSellStash(sellable);
       })
       .catch(() => { /* no compare peers — the inspector just omits the Versus block */ });
     return () => { cancelled = true; };
@@ -357,14 +441,24 @@ function ScreenMerchant({ onNavigate, state, setState }) {
             </thead>
             <tbody>
               {inv.map((it, i) => {
-                const price = it.price || (typeof it.value === "string" && it.value.match(/(\d+) gp/) ? parseInt(it.value.match(/(\d+) gp/)[1]) : 12);
-                const sellPrice = Math.round(price * 0.4);
-                const shownPrice = tab === "buy" ? price : sellPrice;
+                // F09-3 honesty: a priceless live ware (price === null — every SRD magic item) has
+                // NO listed price; resolve it from a `value` string if present, else leave it
+                // unpriced (null) so the cell reads "—" and Take is disabled — never the fabricated
+                // 12 gp the old `|| 12` fallback charged for a Bag of Holding.
+                const listedPrice = (typeof it.price === "number")
+                  ? it.price
+                  : (typeof it.value === "string" && it.value.match(/(\d+) gp/) ? parseInt(it.value.match(/(\d+) gp/)[1]) : null);
+                const priced = typeof listedPrice === "number";
+                const sellPrice = priced ? Math.round(listedPrice * 0.4) : null;
+                const shownPrice = tab === "buy" ? listedPrice : sellPrice;
                 // MK-09: when haggling on the buy tab, show the discounted price per row with the
                 // list price struck through — the player sees the deal in-line, not only on the
                 // total. (Display only; the cart still stores the list price and the running total
                 // applies the haggle once, so there's no double-discount.)
-                const haggledPrice = tab === "buy" && haggle > 0 ? Math.round(shownPrice * (1 - haggle / 100)) : null;
+                const haggledPrice = (tab === "buy" && haggle > 0 && priced) ? Math.round(shownPrice * (1 - haggle / 100)) : null;
+                // #755: route the cell through the pure helper so the struck list + discounted price
+                // can NEVER render adjacent ("24"+"23"→"2423"). `parts.separated` gates the arrow.
+                const parts = marketPriceCellParts(shownPrice, haggledPrice);
                 return (
                   <tr key={it.id || i}
                     onMouseEnter={() => { setHoverItem(it); setDetailItem(it); }}
@@ -395,24 +489,33 @@ function ScreenMerchant({ onNavigate, state, setState }) {
                       {it.weight || "—"}
                     </td>
                     <td style={{ ...tdStyle, textAlign: "right", whiteSpace: "nowrap" }}>
-                      {/* MK-12: the struck list price + discounted price MUST be visually
-                          separated (an explicit arrow) — rendered adjacent they read as one
-                          run-together number, e.g. "24" + "23" → "2423" (adversarial bug). */}
-                      {haggledPrice !== null && haggledPrice !== shownPrice && (
-                        <span style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--ink-600)", textDecoration: "line-through", marginRight: 4 }}>
-                          {shownPrice}
-                        </span>
+                      {/* #755 / MK-12: the struck list price + discounted price are SEPARATED via
+                          the pure marketPriceCellParts helper (explicit arrow) — rendered adjacent
+                          they read as one run-together number, e.g. "24"+"23" → "2423" (the rc2
+                          adversarial bug). An unpriced ware reads "—" (never a fabricated number). */}
+                      {!priced ? (
+                        <span style={{ fontFamily: "var(--f-mono)", fontSize: 12, color: "var(--ink-600)" }}>—</span>
+                      ) : (
+                        <>
+                          {parts.separated && (
+                            <span style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--ink-600)", textDecoration: "line-through", marginRight: 4 }}>
+                              {parts.list}
+                            </span>
+                          )}
+                          {parts.separated && (
+                            <span aria-hidden="true" style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--emerald)", marginRight: 4 }}>→</span>
+                          )}
+                          <span style={{ fontFamily: "var(--f-display)", fontSize: 14, color: parts.haggled ? "var(--emerald)" : "var(--ink-900)" }}>
+                            {parts.price}
+                          </span>
+                          <span style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-600)", marginLeft: 4 }}>gp</span>
+                        </>
                       )}
-                      {haggledPrice !== null && haggledPrice !== shownPrice && (
-                        <span aria-hidden="true" style={{ fontFamily: "var(--f-mono)", fontSize: 11, color: "var(--emerald)", marginRight: 4 }}>→</span>
-                      )}
-                      <span style={{ fontFamily: "var(--f-display)", fontSize: 14, color: haggledPrice !== null ? "var(--emerald)" : "var(--ink-900)" }}>
-                        {haggledPrice !== null ? haggledPrice : shownPrice}
-                      </span>
-                      <span style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--ink-600)", marginLeft: 4 }}>gp</span>
                     </td>
                     <td style={{ ...tdStyle, width: 60 }}>
-                      <button onClick={() => setCart([...cart, { ...it, price: shownPrice, mode: tab }])} className="btn ghost sm" style={{ padding: "4px 10px", fontSize: 9 }}>
+                      {/* #755: 'Take'/'Sell' adds via the debounced addToCart (one click = one ware).
+                          An unpriced ware can't be transacted (no list price), so the button is off. */}
+                      <button onClick={() => addToCart({ ...it, price: shownPrice, mode: tab })} disabled={!priced} className="btn ghost sm" style={{ padding: "4px 10px", fontSize: 9, opacity: priced ? 1 : 0.4, cursor: priced ? "pointer" : "not-allowed" }}>
                         {tab === "buy" ? "Take" : "Sell"}
                       </button>
                     </td>
@@ -426,7 +529,9 @@ function ScreenMerchant({ onNavigate, state, setState }) {
                       {tab === "buy" ? "No wares on offer" : "Nothing to sell"}
                     </div>
                     <div className="hand muted" style={{ fontSize: 13, marginTop: 6 }}>
-                      Merchant — prototype. Not yet wired to a live shop read-model.
+                      {tab === "buy"
+                        ? (merchSurface ? "This merchant's catalogue is empty." : "Begin a chronicle to browse a merchant's wares.")
+                        : (surface?.party ? "Your pack holds nothing to sell." : "Open a live game to sell from your pack.")}
                     </div>
                   </td>
                 </tr>
@@ -593,25 +698,12 @@ const tdStyle = {
   verticalAlign: "middle",
 };
 
-const GATE_MARKET_STOCK = [
-  { id: "m1", name: "Crossbow bolts", type: "weapon", glyph: "bolts", qty: 30, weight: "3 lb", price: 6, desc: "Standard. Iron-tipped. The fletching is reused." },
-  { id: "m2", name: "Travel rations", type: "common", glyph: "rations", qty: 12, weight: "12 lb", price: 24, desc: "Hardtack, salted pork, hard cheese, dried apple." },
-  { id: "m3", name: "Iron lantern", type: "common", glyph: "lantern", qty: 1, weight: "2 lb", price: 7, desc: "Wick included. Oil sold separately, by the stall two rows over." },
-  { id: "m4", name: "Lantern oil", type: "common", glyph: "oil flask", qty: 4, weight: "1 lb", price: 1, desc: "One pint. Burns six hours, four in the river wind off the Chionthar." },
-  { id: "m5", name: "Studded leather", type: "armor", glyph: "leather armor", qty: 1, weight: "20 lb", price: 25, desc: "Sized for a medium frame. Belt may need a hole punched." },
-  { id: "m6", name: "Handaxes", type: "weapon", glyph: "axe pair", qty: 6, weight: "4 lb", price: 8, desc: "A set of three, light and balanced for throwing. Forged upriver, edged here at the Gate." },
-  { id: "m7", name: "Bandage roll", type: "common", glyph: "bandage", qty: 8, weight: "0.5 lb", price: 1, desc: "Linen. Clean. Mostly clean." },
-  { id: "m8", name: "Potion of Healing", type: "spell", glyph: "red potion", qty: 3, weight: "0.5 lb", price: 50, desc: "Restores 2d4+2 HP. Tastes of iron and elderberry." },
-  { id: "m9", name: "Antitoxin", type: "spell", glyph: "green vial", qty: 2, weight: "0.5 lb", price: 50, desc: "Advantage on saving throws against poison for 1 hour." },
-  { id: "m10", name: "Climbing kit", type: "common", glyph: "rope & pitons", qty: 2, weight: "10 lb", price: 80, desc: "Rope, pitons, hammer. Used. The hammer is new." },
-  { id: "m11", name: "Compass", type: "common", glyph: "brass compass", qty: 1, weight: "0.5 lb", price: 25, desc: "Brass. The needle drifts twelve degrees east of true. Dell knows this and has not said so." },
-  { id: "m12", name: "Heavy crossbow", type: "weapon", glyph: "heavy crossbow", qty: 1, weight: "8 lb", price: 50, desc: "Reliable. Slow. The kind of weapon you have time to be sorry about firing." },
-  { id: "m13", name: "Iron chain (10ft)", type: "common", glyph: "iron chain", qty: 3, weight: "10 lb", price: 30, desc: "Forged upriver. Tested at Wyrm's Crossing, by a man no longer with us." },
-  { id: "m14", name: "Spellbook (blank)", type: "spell", glyph: "blank book", qty: 1, weight: "3 lb", price: 15, desc: "Quality paper, oxblood binding. She rarely stocks them — Sorcerous Sundries keeps the good paper." },
-  { id: "m15", name: "Salt", type: "rare", glyph: "salt pouch", qty: 4, weight: "1 lb", price: 12, desc: "Coarse. Hauled up the salt-roads south. Useful against more things than you think." },
-  { id: "m16", name: "Wax candle (×6)", type: "common", glyph: "candles", qty: 4, weight: "1 lb", price: 4, desc: "Beeswax. Burns long. Useful for vigils and for less wholesome purposes." },
-];
-
+// #602: the demo MERCHANTS roster is the READ-ONLY PREVIEW FALLBACK only — used when no live
+// /merchant-surface is attached (a brand-new game before a world is bound). The old fabricated
+// demo ware array (a PF1e-style invented stock) is REMOVED: the live surface supplies
+// the REAL SRD catalog as each merchant's wares, and in pure preview the buy table is honestly empty
+// ("not yet wired to a live shop read-model"). These two flavor records keep the screen renderable
+// before a world loads; the live is_merchant roster always wins when present.
 const MERCHANTS = [
   {
     id: "old-troutman",
@@ -620,11 +712,9 @@ const MERCHANTS = [
     subtitle: "A shield dwarven trader working the docks east of Philgrave's Mansion.",
     location: "Baldur's Gate — Lower City",
     waresName: "Old Troutman",
-    greeting: "Aye, you found the right crate. Bolts, rations, rope, oil, and a few things the Watch forgot to inventory. Keep your purse where I can see it and your questions shorter than the tide.",
-    repLabel: "Wary but open",
-    rep: 28,
+    greeting: "Aye, you found the right crate. Keep your purse where I can see it and your questions shorter than the tide.",
     disposition: "dockside trade · open while the tide holds",
-    stock: GATE_MARKET_STOCK,
+    stock: [],
   },
   {
     id: "talli",
@@ -633,12 +723,10 @@ const MERCHANTS = [
     subtitle: "The Harpers' quartermaster, and the woman the road found.",
     location: "the Last Light Inn",
     waresName: "Talli",
-    greeting: "Come in, then. Mind the curse outside — the lantern's covenant ends a step past the threshold. The bolts are sharp, the rations dry, the draughts honest. Coin first, then the catalogue. Harpers don't quibble, but we don't subsidize the careless either.",
-    repLabel: "Cautiously fond",
-    rep: 42,
+    greeting: "Come in, then. Coin first, then the catalogue. Harpers don't quibble, but we don't subsidize the careless either.",
     disposition: "open until dusk · shuttered when the Watch patrols",
-    stock: GATE_MARKET_STOCK,
+    stock: [],
   },
 ];
 
-Object.assign(window, { ScreenMerchant, MERCHANTS, mItemScope, enrichWare });
+Object.assign(window, { ScreenMerchant, MERCHANTS, mItemScope, enrichWare, marketPriceCellParts });

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -969,6 +969,156 @@ def build_roster_response(
         }
 
 
+# ── Merchant surface (#602/#604): the Market screen's LIVE supply chain ────────
+# Replaces the old hardcoded MERCHANTS / GATE_MARKET_STOCK demo data with the engine's REAL
+# `is_merchant` canon NPCs + the bundled SRD item catalog. The Sell tab (#604) is wired on the
+# screen side to the existing /inventory-surface (the party's real pack); this route supplies the
+# BUY side (the merchant roster + the wares the player can buy). Pure READER — it consumes the
+# canonical is_merchant predicate (content.find_canon_characters, the SAME slice find_npcs uses)
+# and the SRD catalog (itemcatalog), and never writes engine state.
+
+
+def _merchant_slug(name: str) -> str:
+    """The file-slug id for a canon character NAME (content/worlds/<id>/characters/<slug>.json) —
+    the key `portrait-<slug>` resolves the ingested face by, and the id the Market screen selects a
+    merchant by. Mirrors the ingest slug exactly (lowercased, apostrophes dropped, every other
+    non-alphanumeric run collapsed to a single hyphen, edges trimmed) — verified to match all 61
+    shipped baldurs-gate merchant file slugs. Purely presentational (a portrait/selection key); it
+    derives nothing about engine STATE."""
+    s = _text(name).lower().strip()
+    out: list[str] = []
+    prev_dash = False
+    for ch in s:
+        if ch in "'‘’ʼ":  # straight + curly apostrophes are dropped, never hyphenated
+            continue
+        if ch.isascii() and (ch.isalnum()):
+            out.append(ch)
+            prev_dash = False
+        else:
+            if not prev_dash:
+                out.append("-")
+                prev_dash = True
+    return "".join(out).strip("-")
+
+
+def _merchant_ware(rec: dict) -> dict:
+    """Project ONE SRD catalog record (itemcatalog._flatten shape) into the ware shape the Market
+    screen renders {id, name, type, weight, price, rarity, kind, damage, damageType, versatile,
+    properties, attunement, desc}. F09-3 honesty: a priceless item (cost None — every SRD magic
+    item) carries price=None, NEVER a fabricated 0 gp (which would let the screen sell a Bag of
+    Holding for free). Weight 0 -> None (no fabricated heft). The screen's enrichWare() still folds
+    the richer /item-catalog stat block onto the selected ware; this is the table-row supply."""
+    name = _text(rec.get("name"))
+    cost = rec.get("cost")
+    price = int(round(cost)) if isinstance(cost, (int, float)) and cost > 0 else None
+    weight = rec.get("weight")
+    weight_n = float(weight) if isinstance(weight, (int, float)) and weight > 0 else None
+    kind = _text(rec.get("kind"))
+    damage = _text(rec.get("damage"))
+    props = [str(p) for p in (rec.get("properties") or []) if str(p).strip()]
+    return {
+        "id": "ware-" + _merchant_slug(name) if name else "",
+        "name": name,
+        # `type` is the screen's item-type key (drives the kind pill + icon); the SRD `kind`
+        # ("weapon"/"armor"/"potion"/…) is the honest source, never a guessed category.
+        "type": kind or "common",
+        "kind": kind,
+        "weight": f"{weight_n:g} lb" if weight_n is not None else "—",
+        "price": price,
+        "rarity": _text(rec.get("rarity")) or "common",
+        "damage": damage,
+        "damageType": _text(rec.get("damage_type")) if damage else "",
+        "versatile": _text(rec.get("versatile")) if damage else "",
+        "properties": props,
+        "attunement": bool(rec.get("requires_attunement")),
+        "desc": _text(rec.get("description")),
+    }
+
+
+def build_merchant_surface(
+    campaign_id: str = "",
+    query: str = "",
+    limit: int = 60,
+    world_id: Optional[str] = "",
+) -> dict:
+    """GET /merchant-surface read model — the Market screen's BUY supply chain (#602).
+
+    Bridges to the engine-owned canonical `is_merchant` predicate (``content.find_canon_characters``
+    — the SAME slice the ``find_npcs`` MCP tool narrows on) for the merchant roster, and to the
+    bundled SRD item catalog (``itemcatalog.find``) for the wares. The world is resolved from the
+    campaign's snapshot (or the shipped default for a brand-new game), exactly like /roster-surface.
+
+    Returns ``{world_id, merchants:[{id, name, race, class, faction_id, canon_location_id, tags,
+    portrait_scope}], catalog:[ware…], state_authority:"engine"}``. ``query`` filters the catalog by
+    name (case-insensitive substring); ``limit`` bounds BOTH the merchant roster and the ware list.
+
+    READ-ONLY: this surface exposes NO write/buy/sell lane (the live BUY relays through the screen's
+    existing POST /move → engine ``buy_item``; the engine is the sole writer). A graceful empty
+    payload (with an ``error``) when the engine can't be imported — never a fabricated catalog."""
+    engine = _load_engine_server()
+    if world_id is None:
+        world_id = ""
+    else:
+        world_id = world_id.strip() if isinstance(world_id, str) else ""
+        if not world_id:
+            world_id = _roster_world_for_campaign(campaign_id)
+    try:
+        lim = int(limit)
+    except (TypeError, ValueError):
+        lim = 60
+    lim = max(1, min(500, lim))
+    if engine is None or not hasattr(engine, "content_mod") or not hasattr(engine.content_mod, "find_canon_characters"):
+        detail = _ENGINE_IMPORT_ERROR or "engine merchant projection is unavailable"
+        return {
+            "world_id": world_id,
+            "merchants": [],
+            "catalog": [],
+            "state_authority": "engine",
+            "error": f"engine import failed: {detail}",
+        }
+    merchants: list[dict] = []
+    try:
+        for rec in engine.content_mod.find_canon_characters(world_id, is_merchant=True, limit=lim):
+            name = _text(rec.get("name"))
+            if not name:
+                continue
+            slug = _merchant_slug(name)
+            merchants.append({
+                "id": slug,
+                "name": name,
+                "race": _text(rec.get("race")),
+                "class": _text(rec.get("class")),
+                "faction_id": _text(rec.get("faction_id")),
+                "canon_location_id": _text(rec.get("canon_location_id")),
+                "tags": [str(t) for t in (rec.get("tags") or []) if str(t).strip()],
+                "portrait_scope": "portrait-" + slug,
+            })
+    except Exception as exc:
+        return {
+            "world_id": world_id,
+            "merchants": [],
+            "catalog": [],
+            "state_authority": "engine",
+            "error": str(exc),
+        }
+    catalog: list[dict] = []
+    cat_mod = _engine_module("itemcatalog")
+    if cat_mod is not None:
+        try:
+            for rec in cat_mod.find(_text(query), limit=lim):
+                ware = _merchant_ware(rec)
+                if ware.get("name"):
+                    catalog.append(ware)
+        except Exception:
+            catalog = []  # the merchant roster still rides along; the screen shows wares only when present
+    return {
+        "world_id": world_id,
+        "merchants": merchants,
+        "catalog": catalog,
+        "state_authority": "engine",
+    }
+
+
 def _clean_slot(slot: Optional[str]) -> str:
     """Normalize a caller-supplied save-slot name to a flat, safe-ish slug (the engine's
     store.safe_path_segment is the authoritative guard; this just trims/defaults). Empty ⇒
@@ -7822,6 +7972,34 @@ class _Handler(BaseHTTPRequestHandler):
                 cid, race, char_class, level, limit,
                 require_stats=require_stats, recommended_only=recommended_only,
             ))
+        elif route == "/merchant-surface":
+            # #602/#604 — the Market screen's LIVE supply chain: the world's REAL is_merchant canon
+            # NPCs (the canonical content.find_canon_characters slice find_npcs uses) + the bundled
+            # SRD item catalog, replacing the old hardcoded MERCHANTS/GATE_MARKET_STOCK demo data.
+            # World scope is resolved exactly like /roster-surface (catalog ?source/?run ref wins,
+            # else ?campaign view, else attached campaign, else the shipped default world). ?q filters
+            # the catalog by name; ?limit bounds both lists. Pure READER — exposes no buy/sell write
+            # lane (the live BUY relays via the screen's existing /move → engine buy_item).
+            qs = parse_qs(parsed.query)
+            cid = (qs.get("campaign") or [""])[0] or self._view_campaign(qs)
+            catalog_ref = _session_surface_catalog_ref(qs)
+            query = (qs.get("q") or qs.get("query") or [""])[0]
+            try:
+                limit = int((qs.get("limit") or ["60"])[0])
+            except (TypeError, ValueError):
+                limit = 60
+            limit = max(1, min(500, limit))
+            if catalog_ref is not None:
+                cid, raw_snap, _campaign_dir, _root_is_current = catalog_ref
+                raw_world_id = raw_snap.get("world_id") if isinstance(raw_snap, dict) else None
+                world_id = (
+                    raw_world_id.strip()
+                    if isinstance(raw_world_id, str) and raw_world_id.strip()
+                    else None
+                )
+                self._json(build_merchant_surface(cid, query, limit, world_id=world_id))
+                return
+            self._json(build_merchant_surface(cid, query, limit))
         elif route in ("/monitor", "/monitor.html"):
             # The MULTI-CAMPAIGN monitor: one live page showing EVERY campaign across the play
             # store + all parallel QA runs (watch the stress tests + any live game in one place).

--- a/viewer/tests/test_merchant_haggle.py
+++ b/viewer/tests/test_merchant_haggle.py
@@ -1,0 +1,190 @@
+"""#755 — the Market haggle price-cell concat + the 'Take' double-fire.
+
+Two rc2-adversarial Market bugs, both in viewer/openworlds/screen-merchant.jsx:
+
+  1. The haggle price cell rendered the LIST price and the DISCOUNTED price adjacently, so
+     "24" + "23" read as one run-together number "2423gp". The fix renders the two prices as
+     separated parts (an explicit arrow between them) — a pure helper so the parts can never
+     collapse into one string.
+  2. The 'Take' button (add-to-cart) had NO debounce: a fast double-click queued the SAME ware
+     twice. The Confirm button already guarded with submittingRef; 'Take' now guards too.
+
+The price-cell helper is PURE, so it runs under the same Node+Babel harness the other Market
+helper tests use (test_item_inspector.py). The 'Take' debounce is render wiring the pure harness
+can't see, so a served-source guard asserts the guard ref exists.
+"""
+
+import http.client
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_OPENWORLDS = Path(__file__).resolve().parents[1] / "openworlds"
+_MERCHANT = _OPENWORLDS / "screen-merchant.jsx"
+_BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
+
+
+_HARNESS = r"""
+const fs = require('fs');
+const vm = require('vm');
+const Babel = require(%(babel)s);
+
+const React = {
+  useState: (i) => [typeof i === 'function' ? i() : i, () => {}],
+  useEffect: () => {},
+  useRef: (i) => ({ current: i }),
+  useCallback: (fn) => fn,
+  createElement: () => null,
+  Fragment: 'F',
+};
+const sandbox = {
+  React,
+  document: { addEventListener() {}, removeEventListener() {}, visibilityState: 'visible',
+              getElementById: () => ({}), head: { appendChild() {} }, createElement: () => ({}) },
+  fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+  setTimeout: () => 0, clearTimeout: () => {}, setInterval: () => 0, clearInterval: () => {},
+  encodeURIComponent, URLSearchParams, Promise, JSON, Set, Array, Object, String, Boolean, Number, Math,
+  console,
+};
+sandbox.window = sandbox;
+vm.createContext(sandbox);
+
+function load(p) {
+  const src = fs.readFileSync(p, 'utf8');
+  const code = Babel.transform(src, { presets: ['react'], filename: p }).code;
+  vm.runInContext(code, sandbox);
+}
+%(loads)s
+
+const win = sandbox.window;
+const script = %(script)s;
+eval('(() => { ' + script + ' })()');
+"""
+
+
+@unittest.skipIf(shutil.which("node") is None, "node is required to transpile + run the Market helpers")
+class HagglePriceCellTests(unittest.TestCase):
+    NODE_BIN = shutil.which("node")
+
+    @classmethod
+    def setUpClass(cls):
+        for p in (_MERCHANT, _BABEL):
+            assert p.exists(), f"missing {p}"
+
+    def _run(self, script: str) -> object:
+        loads_js = f"load({json.dumps(str(_MERCHANT))});"
+        program = _HARNESS % {
+            "babel": json.dumps(str(_BABEL)),
+            "loads": loads_js,
+            "script": json.dumps("var __r = (function(){ " + script + " })(); "
+                                 "process.stdout.write(JSON.stringify(__r));"),
+        }
+        proc = subprocess.run(
+            [self.NODE_BIN, "--input-type=commonjs"],
+            input=program, text=True, capture_output=True,
+        )
+        if proc.returncode != 0:
+            self.fail(f"node harness failed:\nSTDOUT:{proc.stdout}\nSTDERR:{proc.stderr}")
+        return json.loads(proc.stdout)
+
+    def test_haggle_cell_separates_list_and_discounted_price(self):
+        """A haggled cell (list 24, discounted 23) must yield SEPARATED parts — never the
+        run-together "2423". The helper returns the listed price, the discounted price, and a
+        flag/separator so the two numbers can never render adjacent."""
+        parts = self._run("return win.marketPriceCellParts(24, 23);")
+        self.assertEqual(parts["list"], 24)
+        self.assertEqual(parts["price"], 23)
+        self.assertTrue(parts["haggled"], "a real discount must flag as haggled")
+        self.assertTrue(parts["separated"], "the list+discount prices must be flagged separated")
+
+    def test_no_haggle_cell_shows_a_single_price_no_struck_list(self):
+        # No discount (haggledPrice null) -> one price, no struck list, never a concat.
+        parts = self._run("return win.marketPriceCellParts(24, null);")
+        self.assertEqual(parts["price"], 24)
+        self.assertFalse(parts["haggled"])
+        self.assertFalse(parts["separated"], "a single price must not flag a struck-list separator")
+
+    def test_haggle_to_same_price_is_not_treated_as_a_discount(self):
+        # A 0% (or rounding no-op) haggle where discounted == list must NOT render the struck
+        # list (that's where the adjacency bug bit) — one clean price.
+        parts = self._run("return win.marketPriceCellParts(24, 24);")
+        self.assertEqual(parts["price"], 24)
+        self.assertFalse(parts["separated"], "list==discount must collapse to one price, no struck run-together")
+
+
+# ── served-source guard: the 'Take' debounce the pure harness can't observe ────
+
+
+class _QuietHandler:
+    pass
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server_haggle", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+class _QuietWiringHandler(server._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+
+class TakeDebounceWiringTests(unittest.TestCase):
+    """#755 part 2: the 'Take' (add-to-cart) button must debounce a double-fire, asserted
+    against the served source (a render guard the pure-helper harness can't see)."""
+
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietWiringHandler.campaign_id = ""
+        _QuietWiringHandler.transcript_path = ""
+        _QuietWiringHandler.chat_path = ""
+        _QuietWiringHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietWiringHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _get_text(self, path: str) -> str:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            resp = conn.getresponse()
+            return resp.read().decode("utf-8")
+        finally:
+            conn.close()
+
+    def test_take_button_has_a_debounce_guard(self):
+        src = self._get_text("/openworlds/screen-merchant.jsx")
+        # the add-to-cart 'Take' handler debounces a double-fire via a guarded helper (addToCart),
+        # mirroring submittingRef on Confirm — not a bare inline setCart([...cart, …]).
+        self.assertIn("addToCart", src)
+        self.assertIn("takingRef", src)
+
+    def test_price_cell_uses_the_separated_helper(self):
+        src = self._get_text("/openworlds/screen-merchant.jsx")
+        self.assertIn("marketPriceCellParts", src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_merchant_surface.py
+++ b/viewer/tests/test_merchant_surface.py
@@ -1,0 +1,230 @@
+"""Route + projection tests for /merchant-surface — the Market screen's LIVE supply chain
+(#602) plus the Sell-tab → /inventory-surface wiring (#604).
+
+Before this lane the Market screen (viewer/openworlds/screen-merchant.jsx) painted a hardcoded
+demo MERCHANTS / GATE_MARKET_STOCK block and an always-empty sell stash. #602 wires the buy
+side to the engine's REAL `is_merchant` canon NPCs + the bundled SRD item catalog; #604 points
+the Sell tab at the existing /inventory-surface (the party's real pack), not a stub stash.
+
+This lane asserts the route contract over HTTP against the SHIPPED baldurs-gate world, using the
+real engine (the test interpreter carries the engine deps — same harness as test_roster_surface
+/ test_bestiary_surface): a threaded server, GETs over http.client.
+
+INVARIANT: the surface is a pure READER. It consumes the canonical `is_merchant` predicate
+(content.find_canon_characters) + the SRD catalog (itemcatalog) and never writes engine state.
+"""
+
+import http.client
+import importlib.util
+import json
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server_merchant", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+class _QuietHandler(server._Handler):
+    def log_message(self, *args, **kwargs):  # silence access logging in tests
+        pass
+
+
+@unittest.skipIf(
+    server._load_engine_server() is None,
+    f"engine unavailable in this interpreter: {server._ENGINE_IMPORT_ERROR}",
+)
+class MerchantSurfaceTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _get_json(self, path: str) -> tuple[int, dict]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=15)
+        try:
+            conn.request("GET", path)
+            resp = conn.getresponse()
+            body = resp.read()
+            return resp.status, (json.loads(body.decode("utf-8")) if body else {})
+        finally:
+            conn.close()
+
+    # ── #602: the buy side — real is_merchant NPCs + the SRD catalog ─────────────
+
+    def test_no_campaign_browses_default_world_merchants(self):
+        status, surface = self._get_json("/merchant-surface")
+        self.assertEqual(status, 200)
+        self.assertEqual(surface.get("world_id"), "baldurs-gate")
+        self.assertNotIn("error", surface)
+        merchants = surface.get("merchants", [])
+        self.assertTrue(merchants, "the shipped baldurs-gate world has dozens of is_merchant NPCs")
+        # state authority is the engine; this surface is a pure reader (no write lane of its own).
+        self.assertEqual(surface.get("state_authority"), "engine")
+
+    def test_every_merchant_is_a_real_is_merchant_npc(self):
+        # The surface must consume the canonical is_merchant predicate, never a hardcoded list.
+        # Cross-check each returned merchant against the engine's own is_merchant slice by name.
+        status, surface = self._get_json("/merchant-surface?limit=500")
+        self.assertEqual(status, 200)
+        returned = {m.get("name") for m in surface.get("merchants", [])}
+        eng = server._load_engine_server()
+        canonical = {
+            r["name"]
+            for r in eng.content_mod.find_canon_characters("baldurs-gate", is_merchant=True, limit=500)
+        }
+        self.assertTrue(returned, "merchants must be populated")
+        self.assertTrue(
+            returned <= canonical,
+            f"every surface merchant must be a real is_merchant NPC; strays: {returned - canonical}",
+        )
+
+    def test_merchant_cards_carry_the_screen_fields(self):
+        status, surface = self._get_json("/merchant-surface?limit=50")
+        self.assertEqual(status, 200)
+        merchants = surface.get("merchants", [])
+        self.assertTrue(merchants)
+        for m in merchants:
+            for field in ("id", "name", "portrait_scope"):
+                self.assertIn(field, m)
+            # the portrait scope is keyed off the merchant id slug (what the screen renders by).
+            self.assertEqual(m["portrait_scope"], "portrait-" + m["id"])
+
+    def test_old_troutman_the_demo_dockside_merchant_is_a_real_npc(self):
+        # The hardcoded demo opened on "Old Troutman"; he is a REAL is_merchant canon NPC in the
+        # shipped world, so the live surface must offer him (the demo is now backed by real data).
+        status, surface = self._get_json("/merchant-surface?limit=500")
+        self.assertEqual(status, 200)
+        ids = {m.get("id") for m in surface.get("merchants", [])}
+        self.assertIn("old-troutman", ids)
+
+    def test_catalog_is_the_real_srd_item_catalog(self):
+        # Field shape on an unfiltered slice…
+        status, surface = self._get_json("/merchant-surface?limit=10")
+        self.assertEqual(status, 200)
+        catalog = surface.get("catalog", [])
+        self.assertTrue(catalog, "the surface must carry the SRD item catalog wares")
+        for w in catalog:
+            for field in ("id", "name", "type", "weight", "price"):
+                self.assertIn(field, w)
+        # …and the catalog is the REAL SRD index — a canonical name resolves through a query.
+        _status, ls = self._get_json("/merchant-surface?q=Longsword&limit=50")
+        ls_names = {w.get("name") for w in ls.get("catalog", [])}
+        self.assertIn("Longsword", ls_names, "the SRD catalog must hold the canonical Longsword")
+
+    def test_catalog_query_filters_wares(self):
+        status, surface = self._get_json("/merchant-surface?q=longsword&limit=50")
+        self.assertEqual(status, 200)
+        names = [w.get("name", "") for w in surface.get("catalog", [])]
+        self.assertTrue(names, "a 'longsword' query should match at least the Longsword")
+        self.assertTrue(
+            all("longsword" in n.lower() for n in names),
+            f"the catalog filter must narrow to matching wares; got {names}",
+        )
+
+    def test_priceless_ware_carries_a_null_price_not_a_fabricated_zero(self):
+        # F09-3 honesty: a magic item with no listed SRD price must surface price=None, never a
+        # silent 0 gp (which would let the screen mis-sell a Bag of Holding for free).
+        status, surface = self._get_json("/merchant-surface?q=bag%20of%20holding&limit=10")
+        self.assertEqual(status, 200)
+        bag = next((w for w in surface.get("catalog", []) if w.get("name") == "Bag of Holding"), None)
+        self.assertIsNotNone(bag, "Bag of Holding is in the bundled SRD catalog")
+        self.assertIsNone(bag["price"], "a priceless item must carry a null price, never 0 gp")
+
+    # ── pure reader: no write/mutation lane ──────────────────────────────────────
+
+    def test_surface_exposes_no_write_lane(self):
+        status, surface = self._get_json("/merchant-surface")
+        self.assertEqual(status, 200)
+        # the merchant surface is presentation + read only; it must not advertise a write lane.
+        self.assertNotIn("write_lane", surface)
+
+
+# ── served-source guards: the screen wiring the route test can't observe ───────
+
+
+class _QuietWiringHandler(server._Handler):
+    def log_message(self, fmt: str, *args: object) -> None:
+        return
+
+
+class MerchantScreenWiringTests(unittest.TestCase):
+    """The screen-merchant.jsx wiring asserted against a live server: the Market reads
+    /merchant-surface (#602) and the Sell tab reads /inventory-surface (#604), and the dead
+    demo MERCHANTS / GATE_MARKET_STOCK block + the always-empty merchantStash are gone."""
+
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietWiringHandler.campaign_id = ""
+        _QuietWiringHandler.transcript_path = ""
+        _QuietWiringHandler.chat_path = ""
+        _QuietWiringHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietWiringHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _get_text(self, path: str) -> str:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            resp = conn.getresponse()
+            return resp.read().decode("utf-8")
+        finally:
+            conn.close()
+
+    def test_market_reads_the_merchant_surface(self):
+        src = self._get_text("/openworlds/screen-merchant.jsx")
+        self.assertIn("/merchant-surface", src)
+
+    def test_sell_tab_reads_the_inventory_surface(self):
+        # #604: the Sell tab lists the party's REAL pack from /inventory-surface — the equipped
+        # compare already fetched it; the sell list now reuses the same surface.
+        src = self._get_text("/openworlds/screen-merchant.jsx")
+        self.assertIn("/inventory-surface", src)
+
+    def test_dead_demo_stock_and_merchant_block_are_gone(self):
+        # the always-empty merchantStash stub + the hardcoded demo stock array are removed
+        # (the live surfaces replace them).
+        src = self._get_text("/openworlds/screen-merchant.jsx")
+        self.assertNotIn("state?.merchantStash", src)
+        self.assertNotIn("GATE_MARKET_STOCK", src)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

REAL v1.0.4 Player-Ready-Beta gap items in the Market/Merchant cluster — all three confirmed still-real at HEAD and re-verified present before fixing. The viewer stays a pure **READER** on engine state (presentation + read routes only); the engine remains the sole writer.

### #602 — `/merchant-surface` route wired to real `is_merchant` NPCs + SRD catalog
- New **read-only** `GET /merchant-surface` in `viewer/server.py` (`build_merchant_surface`) consuming the canonical `content.find_canon_characters(is_merchant=True)` slice — the **same predicate `find_npcs` narrows on** (`servers/engine/server.py:~2755/2883`) — plus the bundled SRD item catalog (`itemcatalog.find`). World scope resolved exactly like `/roster-surface` (catalog `?source/?run` ref → `?campaign` view → attached campaign → shipped default world).
- `screen-merchant.jsx` fetches the surface and renders the **live** merchant roster + wares, replacing the hardcoded `MERCHANTS` / demo stock array (kept only as a preview-only fallback, with the fabricated PF1e-leak ware array **removed**).
- **F09-3 honesty:** a priceless SRD item (no listed cost — every magic item) surfaces `price=null`, never a fabricated `0`/`12` gp; the row reads `—` and `Take` is disabled, so the screen can't mis-sell a Bag of Holding for free.

### #604 — Sell tab → existing `/inventory-surface`
- The Sell tab now lists the party's **real pack** from `/inventory-surface` (already fetched in the same component for the equipped-compare block), replacing the always-empty `state.merchantStash` stub.

### #755 — haggle price-cell concat + `Take` double-fire
- `marketPriceCellParts()` pure helper centralizes the struck-list / discounted-price separation so `"24"`+`"23"` can **never** render as the run-together `"2423gp"` (rc2 adversarial bug).
- `addToCart()` debounces the `Take` button via a `takingRef` lock (mirrors the Confirm button's `submittingRef`), so one human click adds exactly one ware.

## Invariants held
- Viewer **read-only** on engine state — `/merchant-surface` + `/inventory-surface` READ the engine projection; no write/mutation lane on the new route (live BUY still relays via the existing `POST /move` → engine `buy_item`).
- Reuses canonical predicates (`find_canon_characters`/`is_merchant`) — does not fork.
- Additive: new route + new fields default gracefully; engine import failure degrades to an honest empty payload (never a fabricated catalog).

## Tests (TDD, RED→GREEN)
- `viewer/tests/test_merchant_surface.py` — route projection (every merchant is a real `is_merchant` NPC; catalog is the real SRD index; priceless ware → null price; no write lane) + screen wiring guards (reads `/merchant-surface` + `/inventory-surface`; demo stock block gone).
- `viewer/tests/test_merchant_haggle.py` — `marketPriceCellParts` under the Node+Babel JSX harness + the `Take`-debounce served-source guard.
- `bash qa/fast_gate.sh` → **221 passed** ✅
- Full viewer suite (`python -m pytest viewer/tests -q -p no:xdist`) → **673 passed, 1 skipped** ✅

Closes #602, closes #604, closes #755.