### PR TITLE
feat(viewer): beginner playstyle guidance on the recommended roster — dogfood onboarding

### DIFF
--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -389,6 +389,49 @@ _RECOMMENDED_MAX_LEVEL = 10
 _RECOMMENDED_CAP = 18
 
 
+# A pure class -> plain-language PLAYSTYLE hint, so a no-prior-knowledge player has a BASIS TO
+# CHOOSE on the roster: each card teaches itself ("what is it like to play this?") without
+# fabricating any lore — the hint is a generic property of the 5e class, not of the figure.
+# Keyed by the lower-cased class name (the record stores e.g. "Fighter"); absent -> no hint.
+_CLASS_PLAYSTYLE: dict[str, str] = {
+    "fighter": "Sturdy front-line — simple to play",
+    "barbarian": "Tough melee bruiser — easy, forgiving",
+    "paladin": "Armoured holy warrior — durable, simple",
+    "rogue": "Sneaky striker — light and nimble",
+    "ranger": "Bow or blade in the wilds — straightforward",
+    "cleric": "Heal and fight — flexible support",
+    "monk": "Fast unarmed fighter — mobile, tricky",
+    "bard": "Charming jack-of-all-trades — versatile",
+    "wizard": "Fragile, but versatile spells — for tinkerers",
+    "sorcerer": "Innate blaster — powerful but fragile",
+    "warlock": "Pact magic and blasts — bursty, fragile",
+    "druid": "Shapeshifter and nature magic — versatile",
+}
+
+# The EASY-STARTER subset of the recommended set: simple, forgiving classes at a low-ish level —
+# the obvious safe pick for a first session. Fragile casters are intentionally excluded.
+_EASY_STARTER_CLASSES = frozenset({"fighter", "barbarian", "cleric", "rogue", "paladin", "ranger"})
+_EASY_STARTER_MAX_LEVEL = 6
+
+
+def class_playstyle_hint(char_class: str) -> str:
+    """Pure, read-only lookup: a short plain-language PLAYSTYLE hint for a 5e class (or "" when the
+    class is blank/unknown — absent-safe, never a fabricated phrase). Lets a roster card teach a
+    newcomer how the figure PLAYS without inventing any lore. Case-insensitive on the class name."""
+    return _CLASS_PLAYSTYLE.get(str(char_class or "").strip().lower(), "")
+
+
+def _is_easy_starter(char_class: str, level: str) -> bool:
+    """Whether a recommended figure is an obvious safe FIRST pick: a simple, forgiving class at a
+    low-ish level. Pure + absent-safe (a blank/odd class or non-numeric level -> not flagged)."""
+    if str(char_class or "").strip().lower() not in _EASY_STARTER_CLASSES:
+        return False
+    try:
+        return int(str(level or "").strip()) <= _EASY_STARTER_MAX_LEVEL
+    except (TypeError, ValueError):
+        return False
+
+
 def roster_surface(
     world_id: str,
     *,
@@ -407,7 +450,14 @@ def roster_surface(
     canon NPC to play AS — they never invent one. This returns the richer per-record shape the
     picker card needs (the light `list_canon_characters` drops level/backstory/id):
 
-      {id, name, race, class, level, role, playable, backstory (short snippet), portrait_scope}
+      {id, name, race, class, level, role, playable, backstory (short snippet), portrait_scope,
+       playstyle, easy_starter}
+
+    `playstyle` is a pure class-derived plain-language hint (e.g. Fighter -> "Sturdy front-line —
+    simple to play"; "" when the class is blank/unknown) so a no-prior-knowledge player has a basis
+    to choose — each card teaches itself, no fabricated lore. `easy_starter` flags the obvious safe
+    FIRST pick (a simple class at a low-ish level); it is only set on the curated recommended
+    surface and defaults False elsewhere. Both are additive + absent-safe (old payloads round-trip).
 
     `id` is the file slug (content/worlds/<id>/characters/<slug>.json) — there is no `id` field on
     the records, and the slug is what `portrait-<slug>` resolves to (the ingested face). `level` is
@@ -532,6 +582,13 @@ def roster_surface(
                 # The /image scope the picker card renders. Ingested canon faces resolve by the
                 # name slug (the viewer's _scope_key folds portrait-<slug> -> <slug>).
                 "portrait_scope": "portrait-" + slug,
+                # #dogfood onboarding: a BASIS TO CHOOSE for a no-prior-knowledge player. The
+                # `playstyle` hint is a pure class->phrase derivation (each card teaches itself, no
+                # fabricated lore); it rides EVERY card and is "" when the class is blank/unknown.
+                # `easy_starter` flags the obvious safe first pick — only meaningful on the curated
+                # recommended surface, so it defaults False on the full roster (absent-safe).
+                "playstyle": class_playstyle_hint(rclass),
+                "easy_starter": bool(recommended_only) and _is_easy_starter(rclass, rlevel),
             })
 
     # `total` is the FULL matched count; the returned list is capped to `limit` so the picker

--- a/servers/engine/tests/test_content.py
+++ b/servers/engine/tests/test_content.py
@@ -707,6 +707,63 @@ def test_roster_surface_caps_the_unfiltered_roster():
     assert full["total"] == capped["total"]
 
 
+def test_class_playstyle_hint_is_a_pure_class_derived_phrase():
+    # The class->playstyle helper is a pure, read-only lookup: a plain-language teaser for the
+    # newcomer ("what is it like to play this class?"). Known simple classes get a hint; an
+    # unknown/blank class returns "" (absent-safe — the card just shows no hint).
+    assert content.class_playstyle_hint("Fighter")  # a real phrase, not empty
+    assert content.class_playstyle_hint("Wizard")
+    # case-insensitive on the class name
+    assert content.class_playstyle_hint("fighter") == content.class_playstyle_hint("Fighter")
+    # absent-safe: no class -> no hint (the card stays clean, never a fabricated phrase)
+    assert content.class_playstyle_hint("") == ""
+    assert content.class_playstyle_hint("Some Unknown Homebrew Class") == ""
+    # the hint is short, plain language (a single clause), never lore — bounded length
+    assert len(content.class_playstyle_hint("Fighter")) <= 60
+
+
+def test_roster_cards_carry_a_playstyle_hint_derived_from_class():
+    # ADDITIVE: every card that HAS a class exposes a plain-language `playstyle` hint derived from
+    # that class (option a — each card teaches itself). Cards without a class have it blank.
+    r = content.roster_surface("baldurs-gate", char_class="Wizard")
+    assert r["characters"]
+    for c in r["characters"]:
+        assert "playstyle" in c  # the field is always present (absent-safe shape)
+        assert c["playstyle"] == content.class_playstyle_hint(c.get("class", ""))
+    # a Wizard card carries the wizard hint specifically (not empty)
+    assert all(c["playstyle"] for c in r["characters"])
+
+
+def test_recommended_cards_flag_an_easy_starter_subset():
+    # BEGINNER ENTRY (option b): the recommended set marks a small EASY-STARTER subset — simple,
+    # forgiving classes at a low-ish level — with `easy_starter:true` so a first-timer has an
+    # obvious safe pick. The flag is additive and present (bool) on every recommended card.
+    rec = content.roster_surface("baldurs-gate", recommended_only=True)
+    cards = rec["characters"]
+    assert cards, "the recommended set should not be empty for the shipped roster"
+    for c in cards:
+        assert isinstance(c.get("easy_starter"), bool)  # always a bool, never missing
+        assert "playstyle" in c  # recommended cards also teach themselves
+    starters = [c for c in cards if c["easy_starter"]]
+    assert starters, "at least one easy-starter should be flagged for a newcomer"
+    # an easy-starter is a SIMPLE, forgiving class at a low-ish level (never a fragile caster)
+    simple = {"fighter", "barbarian", "cleric", "rogue", "paladin", "ranger"}
+    for c in starters:
+        assert (c.get("class") or "").strip().lower() in simple, c.get("name")
+        assert int(c.get("level") or "99") <= content._EASY_STARTER_MAX_LEVEL, c.get("name")
+    # the easy-starter subset is a STRICT subset (curation, not the whole recommended set)
+    assert len(starters) <= len(cards)
+
+
+def test_easy_starter_flag_absent_safe_off_recommended_path():
+    # The easy-starter flag only rides the recommended surface; the full-roster path is byte-stable
+    # except for the additive playstyle field — easy_starter defaults False there (absent-safe).
+    full = content.roster_surface("baldurs-gate", char_class="Wizard")
+    for c in full["characters"]:
+        # a fragile caster on the full surface is never auto-flagged an easy starter
+        assert c.get("easy_starter", False) is False
+
+
 def test_start_character_origins(tmp_path, monkeypatch):
     monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
     cid = server.start_world("baldurs-gate")["campaign_id"]

--- a/viewer/openworlds/screen-roster.jsx
+++ b/viewer/openworlds/screen-roster.jsx
@@ -107,6 +107,21 @@ function RosterCard({ npc, onPlay, busy }) {
             <span style={{ fontFamily: "var(--f-display)", fontSize: 14, color: "var(--ink-900)", marginLeft: 4 }}>{npc.level}</span>
           </div>
         ) : null}
+        {/* #dogfood onboarding (option b): the obvious safe FIRST pick. The engine flags a small
+            easy-starter subset of the recommended set (simple classes, low-ish level); the card
+            wears a "Great for your first session" ribbon so a newcomer has a clear safe choice. */}
+        {npc.easy_starter ? (
+          <div style={{
+            position: "absolute", top: 8, left: 8,
+            padding: "3px 9px",
+            background: "linear-gradient(180deg, var(--b-200), var(--b-400))",
+            boxShadow: "inset 0 0 0 1px var(--b-600), inset 0 1px 0 rgba(255,250,220,0.6)",
+          }}>
+            <span className="eyebrow" style={{ fontSize: 9, color: "var(--w-300)", letterSpacing: "0.08em" }}>
+              Great for your first session
+            </span>
+          </div>
+        ) : null}
       </div>
       <div style={{ padding: "12px 14px 14px", display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
         <div style={{ fontFamily: "var(--f-display)", fontSize: 17, letterSpacing: "0.04em", color: "var(--ink-900)", lineHeight: 1.15 }}>
@@ -115,6 +130,14 @@ function RosterCard({ npc, onPlay, busy }) {
         <div className="eyebrow" style={{ color: "var(--crimson)", marginTop: 3, fontSize: 10 }}>
           {ident || "of the Sword Coast"}
         </div>
+        {/* #dogfood onboarding (option a): a plain-language playstyle hint so a no-prior-knowledge
+            player has a BASIS TO CHOOSE — each card teaches itself how the figure PLAYS. Derived
+            engine-side from the class (pure class→phrase, no fabricated lore); absent-safe. */}
+        {npc.playstyle ? (
+          <div className="body-sm" style={{ color: "var(--ink-600)", marginTop: 4, fontSize: 11, fontStyle: "italic" }}>
+            {npc.playstyle}
+          </div>
+        ) : null}
         {npc.backstory ? (
           <p className="hand" style={{ fontSize: 13, color: "var(--ink-700)", margin: "8px 0 0", lineHeight: 1.4 }}>
             {npc.backstory}

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -1408,6 +1408,17 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertIn('params.set("run", activeCampaign.runId);', source)
         self.assertNotIn('params.set("campaign", campaignId);', source)
 
+    def test_roster_card_renders_beginner_playstyle_guidance(self):
+        # #dogfood onboarding: the roster card must give a newcomer a BASIS TO CHOOSE — a
+        # plain-language playstyle hint (option a) AND an "easy starter" tag (option b). Both are
+        # read straight off the additive roster-surface fields; the viewer fabricates no lore.
+        source = (Path(__file__).resolve().parents[1] / "openworlds" / "screen-roster.jsx").read_text(encoding="utf-8")
+        # the card renders the class-derived playstyle hint carried on the surface
+        self.assertIn("npc.playstyle", source)
+        # the easy-starter subset is surfaced with a beginner-friendly label
+        self.assertIn("npc.easy_starter", source)
+        self.assertIn("Great for your first session", source)
+
     def test_monitor_play_campaign_links_openworlds_not_legacy_dashboard(self):
         source = (Path(__file__).resolve().parents[1] / "monitor.html").read_text(encoding="utf-8")
 

--- a/viewer/tests/test_roster_surface.py
+++ b/viewer/tests/test_roster_surface.py
@@ -290,6 +290,65 @@ class RosterSurfaceTests(unittest.TestCase):
         _, full = self._get_json("/roster-surface?limit=500")
         self.assertLess(surface.get("total", 0), full.get("total", 0))
 
+    # ── BEGINNER GUIDANCE: a basis to choose (#dogfood onboarding) ────────────────
+
+    def test_every_recommended_card_exposes_a_plain_language_playstyle_hint(self):
+        # The newbie dogfood gap: ~18 recommended heroes with no hint about how each PLAYS. Every
+        # recommended card (each has a class by construction) must now carry a plain-language
+        # `playstyle` hint derived from its class — so each card teaches itself (option a).
+        status, surface = self._get_json("/roster-surface?recommended=1")
+        self.assertEqual(status, 200)
+        cards = surface.get("characters", [])
+        self.assertTrue(cards, "the recommended set should not be empty")
+        for c in cards:
+            hint = c.get("playstyle")
+            self.assertTrue(
+                isinstance(hint, str) and hint.strip(),
+                f"{c.get('name')} (a {c.get('class')}) exposes no playstyle hint",
+            )
+
+    def test_recommended_surface_flags_an_easy_starter_subset(self):
+        # Option b: an obvious safe pick. At least one recommended card is tagged
+        # `easy_starter:true` ("Great for your first session"), and the flag is a bool on every
+        # card (additive, absent-safe). Easy-starters are simple, forgiving classes.
+        status, surface = self._get_json("/roster-surface?recommended=1")
+        self.assertEqual(status, 200)
+        cards = surface.get("characters", [])
+        self.assertTrue(cards)
+        for c in cards:
+            self.assertIsInstance(c.get("easy_starter"), bool, c.get("name"))
+        starters = [c for c in cards if c.get("easy_starter")]
+        self.assertTrue(starters, "a first-timer needs at least one flagged safe pick")
+        simple = {"fighter", "barbarian", "cleric", "rogue", "paladin", "ranger"}
+        for c in starters:
+            self.assertIn((c.get("class") or "").strip().lower(), simple, c.get("name"))
+
+    def test_full_recommended_set_is_still_reachable_alongside_the_guidance(self):
+        # The guidance is a hint layered ON the curated set, never a further wall: the full
+        # recommended set still rides along (same count as without the new fields would imply),
+        # and the broad full roster is still one click away (a strict superset).
+        _, rec = self._get_json("/roster-surface?recommended=1")
+        rec_cards = rec.get("characters", [])
+        self.assertTrue(rec_cards)
+        # the easy-starter subset never shrinks the recommended set — non-starters remain present
+        non_starters = [c for c in rec_cards if not c.get("easy_starter")]
+        self.assertTrue(non_starters, "the full recommended set stays reachable, not just starters")
+        # the whole roster is still reachable (recommended is a strict narrowing of it)
+        _, full = self._get_json("/roster-surface?limit=500")
+        self.assertLess(rec.get("total", 0), full.get("total", 0))
+
+    def test_playstyle_hint_rides_the_full_roster_too(self):
+        # The hint is derived from class, so it isn't recommended-only: a full-roster card that has
+        # a class carries it too (each card teaches itself everywhere), and a no-class card is
+        # absent-safe (blank hint, never a fabricated phrase).
+        status, surface = self._get_json("/roster-surface?class=Wizard")
+        self.assertEqual(status, 200)
+        cards = surface.get("characters", [])
+        self.assertTrue(cards)
+        for c in cards:
+            self.assertIn("playstyle", c)  # field always present (round-trip-safe shape)
+            self.assertTrue(c["playstyle"].strip(), c.get("name"))  # a classed card has a hint
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The felt-friction (newbie dogfood, verbatim)

> "Roster is overwhelming for a newcomer — 18 'recommended' heroes, all named BG3 NPCs from different Acts and levels, with no hint about which is a good STARTING choice. A first-timer has no basis to choose."

The #919 beginner-curation already filters to ~18 recommended heroes, but a true first-timer still couldn't tell which is an *easy first hero*. This closes that last no-prior-knowledge gap by giving the player a **basis to choose** — polish, not a rebuild.

## What changed (additive, presentation-only)

Two new optional fields on the **existing** `roster-surface` projection (`content.roster_surface`), rendered on `screen-roster.jsx`'s `RosterCard`:

- **`playstyle`** — a pure, class-derived, plain-language hint on **every** card, so each card teaches itself how the figure *plays*:
  - Fighter → "Sturdy front-line — simple to play"
  - Wizard → "Fragile, but versatile spells — for tinkerers"
  - Cleric → "Heal and fight — flexible support" … (12 classes mapped)
  - Derived engine-side via `class_playstyle_hint()` — a pure read-only helper beside `roster_surface`. **No fabricated lore**: the hint is a generic property of the 5e *class*, not of the figure. `""` when the class is blank/unknown.
- **`easy_starter`** — a small **EASY-STARTER** subset of the recommended set (simple, forgiving classes — Fighter / Barbarian / Cleric / Rogue / Paladin / Ranger — at a low-ish level) gets a **"Great for your first session"** ribbon, so a first-timer has an obvious safe pick.

Both options (a) per-card playstyle hint **and** (b) easy-starter tag are implemented.

## Invariants honoured

- **Viewer read-only** — the screen only *reads* the new fields; no engine write was added.
- **Additive + absent-safe** — both fields default to `""` / `False`; old payloads round-trip; the wire contract is unchanged.
- **Reuses the existing roster-surface** — no fork; the hint is derived from the class already on each entry.
- **Full set stays reachable** — `easy_starter` flags a strict subset of the recommended set; the full recommended set and the whole ~2,000-name roster are still one click away.

## Tests (TDD: RED → GREEN)

- `servers/engine/tests/test_content.py` — pure `class_playstyle_hint` lookup (case-insensitive, absent-safe, bounded), per-card `playstyle`, the `easy_starter` subset (simple classes, low level), and absent-safe off the recommended path.
- `viewer/tests/test_roster_surface.py` — over HTTP: every recommended card exposes a plain-language playstyle hint, an easy-starter subset is flagged, the full recommended set + whole roster stay reachable, and the hint rides the full roster too.
- `viewer/tests/test_openworlds_static.py` — the card renders `npc.playstyle`, `npc.easy_starter`, and the "Great for your first session" label.

### Verification

- `bash qa/fast_gate.sh` → **PASS** (221 passed, deterministic engine tier intact).
- `viewer/tests/test_roster_surface.py` + `test_openworlds_static.py` → **86 passed, 1 skipped** (skip = gitignored portrait art).
- `servers/engine/tests/test_content.py` (full, via `uv`) → **90 passed**, zero regressions.