### PR TITLE
fix(qa/app): gated isolated-config + env-token auth so the cold-open claude never hits the keychain/LEXAR (#892 follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
             ../../qa/test_scores_db_comparability.py \
             ../../qa/test_scores_db.py \
             ../../qa/test_release_gate_static.py \
-            ../../qa/test_ui_playtest_score_image_outcomes.py
+            ../../qa/test_ui_playtest_score_image_outcomes.py \
+            ../../qa/test_claude_auth_isolation.py
 
   license-check:
     runs-on: ubuntu-latest

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -1284,3 +1284,78 @@ PY
 )"
   [ -n "$out" ] && printf '%s' "$out"
 }
+
+# COLD-OPEN AUTH ISOLATION (#892 follow-up) — keep the GUI .app's cold-open `claude -p` (the DM)
+# off the macOS keychain and off any /Volumes (removable-disk) TCC prompt, so it runs headless
+# without popping a system dialog every build.
+#
+# ROOT CAUSE (already diagnosed — see #892): the .app-spawned `claude -p` (a) reads its OAuth
+# credential from the macOS KEYCHAIN, and because the .app is ad-hoc signed its cdhash changes on
+# EVERY build → the keychain item's ACL never includes the new cdhash → macOS re-prompts for
+# keychain access on every launch; and (b) touches stale `/Volumes/LEXAR/...` entries in the
+# user's ~/.claude.json `projects` map → a removable-disk TCC prompt. Both block headless
+# auto-testing.
+#
+# THE FIX (authoritative per Claude Code's `-p` auth model): run the cold-open claude with
+#   (1) a credential in the ENV — in `-p` mode CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY take
+#       precedence and the keychain is NEVER consulted; and
+#   (2) an ISOLATED CLAUDE_CONFIG_DIR — a scratch config holding exactly `{}` (NO projects map),
+#       so claude never reads the user's stale /Volumes project entries → no removable-disk prompt.
+#
+# GATED + ADDITIVE: this is a NO-OP unless a non-keychain credential is resolvable. With no env
+# token and no secret file, it changes NOTHING — the existing Terminal path (where the keychain
+# works fine interactively) is preserved byte-for-byte. Idempotent; ALWAYS returns 0 so it can
+# never break a caller (it is auth plumbing, never allowed to fail a launch).
+#
+# Credential resolution (priority order):
+#   (a) $CLAUDE_CODE_OAUTH_TOKEN or $ANTHROPIC_API_KEY already set+non-empty in the env → use as-is.
+#   (b) else a secret file at ${CLAWDND_CLAUDE_TOKEN_FILE:-$HOME/.worldos/claude-token} → read+trim;
+#       classify by prefix: 'sk-ant-' → ANTHROPIC_API_KEY, otherwise → CLAUDE_CODE_OAUTH_TOKEN.
+# Config dir: ${CLAWDND_CLAUDE_CONFIG_DIR:-${STATE_DIR:-$PWD}/.claude-cfg} (created; minimal `{}`
+# .claude.json written iff absent; exported as CLAUDE_CONFIG_DIR).
+# Reads ambient $STATE_DIR (the run's state dir, when the caller has set it) for the default
+# scratch config location. No args.
+clawdnd_isolate_claude_auth() {
+  local cred="" tok_file cfg_dir
+
+  # (a) env credential already present → respect it as-is (no reclassification, no file read).
+  if [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] || [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    cred="env"
+  else
+    # (b) fall back to the on-disk secret file (gated: only if it exists + has content).
+    tok_file="${CLAWDND_CLAUDE_TOKEN_FILE:-$HOME/.worldos/claude-token}"
+    if [ -f "$tok_file" ]; then
+      local raw
+      raw="$(cat "$tok_file" 2>/dev/null)"
+      # Trim surrounding whitespace/newlines (a `claude setup-token` dump often has a trailing \n).
+      raw="${raw#"${raw%%[![:space:]]*}"}"
+      raw="${raw%"${raw##*[![:space:]]}"}"
+      if [ -n "$raw" ]; then
+        case "$raw" in
+          sk-ant-*) export ANTHROPIC_API_KEY="$raw" ;;
+          *)        export CLAUDE_CODE_OAUTH_TOKEN="$raw" ;;
+        esac
+        cred="file"
+      fi
+    fi
+  fi
+
+  # NO credential resolved → true NO-OP. Do NOT set CLAUDE_CONFIG_DIR, do NOT export anything.
+  # This preserves today's working Terminal path (the keychain works fine interactively).
+  if [ -z "$cred" ]; then
+    echo "[auth] no env/file credential — using default (keychain) auth" >&2
+    return 0
+  fi
+
+  # A credential is in the env → also isolate the config dir so claude never reads the user's
+  # stale /Volumes project entries (no removable-disk TCC prompt). Idempotent: re-running just
+  # re-points at the same dir; the `{}` is only written when absent.
+  cfg_dir="${CLAWDND_CLAUDE_CONFIG_DIR:-${STATE_DIR:-$PWD}/.claude-cfg}"
+  mkdir -p "$cfg_dir" 2>/dev/null || true
+  if [ ! -f "$cfg_dir/.claude.json" ]; then
+    printf '%s\n' '{}' > "$cfg_dir/.claude.json" 2>/dev/null || true
+  fi
+  export CLAUDE_CONFIG_DIR="$cfg_dir"
+  echo "[auth] isolated CLAUDE_CONFIG_DIR + env credential (no keychain / no /Volumes)" >&2
+  return 0
+}

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -71,6 +71,11 @@ CLAWDND_LEAN_BEATS="${CLAWDND_LEAN_BEATS:-1}"
 CLAWDND_LEAN_TAIL="${CLAWDND_LEAN_TAIL:-8}"
 T="qa/transcripts"; STATE_DIR="$ROOT/qa/state/$RUN"
 mkdir -p "$T" "$STATE_DIR"; rm -rf "$STATE_DIR/campaigns" 2>/dev/null
+# #892 follow-up: keep the cold-open `claude -p` (the DM) off the macOS keychain + off any /Volumes
+# TCC prompt so the duo QA harness runs headless. GATED no-op without an env/file credential (so the
+# Terminal/keychain path is byte-unchanged). Called ONCE here, after STATE_DIR, before the first DM
+# `claude -p` below. Defined in qa/lib_beat_driver.sh (sourced above). Never fails the run.
+clawdnd_isolate_claude_auth
 
 # DM gets the engine (state dir patched in); the player gets an EMPTY strict config.
 DM_CFG="$STATE_DIR/dm.mcp.json"; PLAYER_CFG="$STATE_DIR/player.mcp.json"

--- a/qa/test_claude_auth_isolation.py
+++ b/qa/test_claude_auth_isolation.py
@@ -1,0 +1,200 @@
+"""Tests for clawdnd_isolate_claude_auth (qa/lib_beat_driver.sh) — the #892 follow-up that keeps
+the GUI .app's cold-open `claude -p` (the DM) off the macOS keychain + off any /Volumes TCC prompt.
+
+The helper is GATED + ADDITIVE:
+  (i)   an env credential preset (CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY) → isolate the config
+        dir (a scratch .claude.json holding `{}`, no "projects" map) and keep the token in the env.
+  (ii)  no env credential but a secret file → export the token from the file AND isolate the config.
+  (iii) neither → true NO-OP: CLAUDE_CONFIG_DIR is NOT set and no credential is exported (so the
+        Terminal/keychain path is byte-unchanged).
+
+Each case shells out to a bash subprocess that `source`s the lib, calls the helper, then prints the
+resulting env so the assertions read the REAL shell behavior (not a python re-impl). HOME is always
+redirected at a tmp dir and the default token-file path is forced under tmp, so the real
+~/.worldos/claude-token can NEVER be read.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+LIB = ROOT / "qa" / "lib_beat_driver.sh"
+
+# A bash harness: source the lib, run the helper, then emit the post-call env as KEY=VALUE lines the
+# test parses. We print exactly the three signals the assertions care about — set-but-empty is
+# distinguishable from unset because we always print the prefix.
+_HARNESS = r"""
+set -uo pipefail
+. "{lib}"
+clawdnd_isolate_claude_auth
+printf 'CLAUDE_CONFIG_DIR=%s\n' "${{CLAUDE_CONFIG_DIR:-}}"
+printf 'CLAUDE_CODE_OAUTH_TOKEN=%s\n' "${{CLAUDE_CODE_OAUTH_TOKEN:-}}"
+printf 'ANTHROPIC_API_KEY=%s\n' "${{ANTHROPIC_API_KEY:-}}"
+"""
+
+
+def _run(env_overrides: dict, home: Path) -> dict:
+    """Run the harness in a clean-ish env and return the parsed post-call env dict."""
+    env = {
+        # A minimal base env: PATH for bash + the binaries the helper might touch, HOME redirected.
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": str(home),
+    }
+    env.update(env_overrides)
+    proc = subprocess.run(
+        ["bash", "-c", _HARNESS.format(lib=str(LIB))],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"helper must always return 0; got {proc.returncode}\n{proc.stderr}"
+    out = {}
+    for line in proc.stdout.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            out[key] = value
+    return out
+
+
+def test_env_token_preset_isolates_config_and_survives(tmp_path):
+    """(i) CLAUDE_CODE_OAUTH_TOKEN preset in the env → CLAUDE_CONFIG_DIR is set to an isolated dir
+    whose .claude.json has NO "projects" key, and the token env survives unchanged."""
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = tmp_path / "scratch-cfg"
+    env = _run(
+        {
+            "CLAUDE_CODE_OAUTH_TOKEN": "fake-oauth-token-from-env",
+            "CLAWDND_CLAUDE_CONFIG_DIR": str(cfg),
+            # Force the file path under tmp so the real ~/.worldos can never be touched.
+            "CLAWDND_CLAUDE_TOKEN_FILE": str(tmp_path / "nonexistent-token"),
+        },
+        home,
+    )
+
+    # CLAUDE_CONFIG_DIR set to the isolated scratch dir.
+    assert env["CLAUDE_CONFIG_DIR"] == str(cfg)
+    cfg_json = cfg / ".claude.json"
+    assert cfg_json.exists(), "isolated config dir must hold a minimal .claude.json"
+    data = json.loads(cfg_json.read_text(encoding="utf-8"))
+    assert "projects" not in data, "isolated .claude.json must have NO projects map (no /Volumes)"
+    assert data == {}, "isolated .claude.json must be exactly {} (no oauth fields, no projects)"
+
+    # The preset token survives untouched (env precedence in -p mode → keychain never consulted).
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "fake-oauth-token-from-env"
+    # An sk-ant key wasn't supplied, so ANTHROPIC_API_KEY stays empty.
+    assert env["ANTHROPIC_API_KEY"] == ""
+
+
+def test_file_oauth_token_is_exported_and_config_isolated(tmp_path):
+    """(ii) No env credential, but a secret file (pointed at by CLAWDND_CLAUDE_TOKEN_FILE) holding a
+    fake oauth token → CLAUDE_CODE_OAUTH_TOKEN gets exported AND CLAUDE_CONFIG_DIR is isolated."""
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = tmp_path / "scratch-cfg"
+    token_file = tmp_path / "claude-token"
+    # A trailing newline (as `claude setup-token` dumps) must be trimmed by the helper.
+    token_file.write_text("fake-oauth-token-from-file\n", encoding="utf-8")
+
+    env = _run(
+        {
+            "CLAWDND_CLAUDE_TOKEN_FILE": str(token_file),
+            "CLAWDND_CLAUDE_CONFIG_DIR": str(cfg),
+        },
+        home,
+    )
+
+    # The file token was classified as an OAuth token (no sk-ant- prefix) and exported, trimmed.
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "fake-oauth-token-from-file"
+    assert env["ANTHROPIC_API_KEY"] == ""
+    # Config dir isolated, exactly {} (no projects map).
+    assert env["CLAUDE_CONFIG_DIR"] == str(cfg)
+    data = json.loads((cfg / ".claude.json").read_text(encoding="utf-8"))
+    assert data == {}
+    assert "projects" not in data
+
+
+def test_file_sk_ant_key_is_classified_as_anthropic_api_key(tmp_path):
+    """(ii, variant) A file credential starting with sk-ant- → exported as ANTHROPIC_API_KEY, not
+    CLAUDE_CODE_OAUTH_TOKEN (the prefix-classification branch)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = tmp_path / "scratch-cfg"
+    token_file = tmp_path / "claude-token"
+    token_file.write_text("sk-ant-fake-api-key\n", encoding="utf-8")
+
+    env = _run(
+        {
+            "CLAWDND_CLAUDE_TOKEN_FILE": str(token_file),
+            "CLAWDND_CLAUDE_CONFIG_DIR": str(cfg),
+        },
+        home,
+    )
+
+    assert env["ANTHROPIC_API_KEY"] == "sk-ant-fake-api-key"
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == ""
+    assert env["CLAUDE_CONFIG_DIR"] == str(cfg)
+
+
+def test_no_credential_is_a_true_noop(tmp_path):
+    """(iii) Neither an env credential nor a secret file → CLAUDE_CONFIG_DIR is NOT set (empty) and
+    no credential is exported. This preserves today's working Terminal/keychain path."""
+    home = tmp_path / "home"
+    home.mkdir()
+    # Point the token-file at a path that does not exist, under tmp — so the real ~/.worldos token
+    # (if the owner has one) can never leak into this test.
+    env = _run(
+        {
+            "CLAWDND_CLAUDE_TOKEN_FILE": str(tmp_path / "nonexistent-token"),
+            "CLAWDND_CLAUDE_CONFIG_DIR": str(tmp_path / "should-not-be-created"),
+        },
+        home,
+    )
+
+    assert env["CLAUDE_CONFIG_DIR"] == "", "no-credential path must NOT set CLAUDE_CONFIG_DIR"
+    assert env["CLAUDE_CODE_OAUTH_TOKEN"] == "", "no-credential path must export NO oauth token"
+    assert env["ANTHROPIC_API_KEY"] == "", "no-credential path must export NO api key"
+    # And the scratch config dir must not have been created (true no-op — no filesystem side effect).
+    assert not (tmp_path / "should-not-be-created").exists()
+
+
+def test_idempotent_when_called_twice(tmp_path):
+    """The helper must be safe to call more than once (re-pointing at the same dir, never erroring)."""
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = tmp_path / "scratch-cfg"
+    harness = (
+        'set -uo pipefail\n'
+        f'. "{LIB}"\n'
+        "clawdnd_isolate_claude_auth\n"
+        "clawdnd_isolate_claude_auth\n"
+        'printf \'CLAUDE_CONFIG_DIR=%s\\n\' "${CLAUDE_CONFIG_DIR:-}"\n'
+        'printf \'CLAUDE_CODE_OAUTH_TOKEN=%s\\n\' "${CLAUDE_CODE_OAUTH_TOKEN:-}"\n'
+    )
+    proc = subprocess.run(
+        ["bash", "-c", harness],
+        cwd=ROOT,
+        env={
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": str(home),
+            "CLAUDE_CODE_OAUTH_TOKEN": "fake-oauth-token-from-env",
+            "CLAWDND_CLAUDE_CONFIG_DIR": str(cfg),
+            "CLAWDND_CLAUDE_TOKEN_FILE": str(tmp_path / "nonexistent-token"),
+        },
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    out = dict(
+        line.partition("=")[::2] for line in proc.stdout.splitlines() if "=" in line
+    )
+    assert out["CLAUDE_CONFIG_DIR"] == str(cfg)
+    assert out["CLAUDE_CODE_OAUTH_TOKEN"] == "fake-oauth-token-from-env"
+    assert json.loads((cfg / ".claude.json").read_text(encoding="utf-8")) == {}

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -118,6 +118,12 @@ PROVIDER="$(worldos_env PROVIDER claude)"
 # so saves, the chat log, and the move sink stay together and out of the QA sandbox.
 STATE_DIR="$ROOT/play-state/$RUN"
 mkdir -p "$STATE_DIR"
+# #892 follow-up: keep the .app-spawned cold-open `claude -p` (the DM) off the macOS keychain +
+# off any /Volumes TCC prompt so it runs headless. GATED no-op without an env/file credential (so
+# the Terminal/keychain path is byte-unchanged); when a credential is resolvable it isolates the
+# config dir + puts the token in the env. Called ONCE here, after STATE_DIR, before the pre-seed +
+# DM cold-open below. Defined in qa/lib_beat_driver.sh (sourced above). Never fails a launch.
+clawdnd_isolate_claude_auth
 DM_CFG="$STATE_DIR/dm.mcp.json"
 MOVES="$STATE_DIR/player_moves.jsonl"; : > "$MOVES"
 CHAT="$STATE_DIR/chat.jsonl"; : > "$CHAT"

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -142,6 +142,12 @@ AGENT_TURNS=0
 # Product play state under play-state/ (git-ignored), same layout as play.sh.
 STATE_DIR="$ROOT/play-state/$RUN"
 mkdir -p "$STATE_DIR"
+# #892 follow-up: keep the .app-spawned cold-open `claude -p` (the DM) off the macOS keychain +
+# off any /Volumes TCC prompt so it runs headless. GATED no-op without an env/file credential.
+# Called ONCE here (the ENSEMBLE path; the solo path execs play.sh above, which calls it itself),
+# after STATE_DIR, before the companion pre-seed + DM cold-open below. Defined in
+# qa/lib_beat_driver.sh (sourced above). Never fails a launch.
+clawdnd_isolate_claude_auth
 DM_CFG="$STATE_DIR/dm.mcp.json"
 MOVES="$STATE_DIR/player_moves.jsonl"; : > "$MOVES"     # the HUMAN's moves (dashboard /move sink)
 CHAT="$STATE_DIR/chat.jsonl"; : > "$CHAT"


### PR DESCRIPTION
## Root cause (already diagnosed — #892)

The GUI `.app`-spawned cold-open `claude -p` (the DM) blocks headless auto-testing for two reasons:

1. **Keychain re-prompt every build.** In its default auth mode the cold-open `claude -p` reads its OAuth credential from the **macOS keychain**. The `.app` is ad-hoc signed, so its **cdhash changes on every build** → the keychain item's ACL never includes the new cdhash → macOS re-prompts for keychain access on every launch.
2. **Removable-disk (/Volumes) TCC prompt.** `claude` touches stale `/Volumes/LEXAR/...` entries in the user's `~/.claude.json` `projects` map → a removable-disk TCC prompt.

Both pop a blocking system dialog, so the cold-open can't run unattended.

## The fix (authoritative per Claude Code's `-p` auth model)

Run the cold-open `claude` with:

1. **A credential in the ENV** — in `-p` mode `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` take precedence and the **keychain is never consulted**.
2. **An isolated `CLAUDE_CONFIG_DIR`** — a scratch config holding exactly `{}` (no `projects` map) → `claude` never reads the user's stale `/Volumes` project entries → **no removable-disk prompt**.

New helper `clawdnd_isolate_claude_auth` in `qa/lib_beat_driver.sh` resolves a non-keychain credential in priority order — (a) `$CLAUDE_CODE_OAUTH_TOKEN`/`$ANTHROPIC_API_KEY` already in the env, else (b) a trimmed secret file at `${CLAWDND_CLAUDE_TOKEN_FILE:-$HOME/.worldos/claude-token}` (classified by prefix: `sk-ant-` → `ANTHROPIC_API_KEY`, else `CLAUDE_CODE_OAUTH_TOKEN`) — and, only when one is found, exports it + isolates `CLAUDE_CONFIG_DIR`.

Wired once into each cold-open entrypoint, after `STATE_DIR` is established and before the first `claude -p`:

- `scripts/play.sh` (the solo path; `play_party.sh`'s solo path `exec`s this)
- `scripts/play_party.sh` (the ensemble path)
- `qa/run_duo.sh`

## GATED — no-op without a credential

With **no** env token and **no** secret file the helper is a **true no-op**: it does **not** set `CLAUDE_CONFIG_DIR` and exports nothing, so the existing Terminal path (where the keychain works fine interactively) is preserved byte-for-byte. The helper is idempotent and always returns `0`, so it can never fail a launch. Additive only — no wire-contract changes, engine stays sole writer (this is QA/auth plumbing), viewer untouched.

## END-TO-END (no-popup) verification is PENDING

The no-popup behavior in the real `.app` requires a credential to exist. That is **owner action**, not done here:

```
claude setup-token   # then save the token to:
~/.worldos/claude-token
```

Once that file exists (or `CLAUDE_CODE_OAUTH_TOKEN`/`ANTHROPIC_API_KEY` is exported into the `.app`'s env), the cold-open isolates automatically. Until then every lane behaves exactly as today.

## Tests

`qa/test_claude_auth_isolation.py` (5 tests, single-process, `tmp_path`, never reads the real `~/.worldos`):

- **(i)** `CLAUDE_CODE_OAUTH_TOKEN` preset in env → `CLAUDE_CONFIG_DIR` set to an isolated dir whose `.claude.json` has **no** `projects` key (`== {}`), token env survives.
- **(ii)** no env credential but a temp secret file (via `CLAWDND_CLAUDE_TOKEN_FILE`) holding a fake oauth token → `CLAUDE_CODE_OAUTH_TOKEN` exported (trimmed) **and** `CLAUDE_CONFIG_DIR` isolated.
- **(ii-variant)** an `sk-ant-` file credential → classified as `ANTHROPIC_API_KEY`.
- **(iii)** neither → `CLAUDE_CONFIG_DIR` not set, nothing exported, scratch dir not created (true no-op).
- **(idempotency)** calling the helper twice is safe.

Run:
```
python3 -m pytest qa/test_claude_auth_isolation.py -q -p no:xdist
# 5 passed
```

`bash qa/fast_gate.sh` → 221 passed (engine baseline intact; this change touches no engine code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced startup process to avoid triggering unwanted macOS keychain and system access prompts during initialization.

* **Tests**
  * Added comprehensive QA test coverage for credential isolation and configuration management during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->