### PR TITLE
fix(#928): reconcile the say arg shape so companion/party runs don't trip no_rejected_tool_calls

### DIFF
--- a/servers/engine/player_server.py
+++ b/servers/engine/player_server.py
@@ -305,28 +305,57 @@ def validate_attack(pc: Character, target: str, weapon: str) -> tuple[bool, str]
 
 
 # --- the player's ENTIRE tool surface --------------------------------------------
-@mcp.tool()
-def say(line: str) -> dict:
-    """Speak your character's OWN words (dialogue). Just your line — quotes are fine."""
-    return _record("say", line)
+def _text_arg(canonical: str, *aliases: str) -> str:
+    """Coalesce the canonical free-text arg with the intuitive aliases an LLM reaches for —
+    the SAME additive discipline the engine uses across server.py (``travel_to`` accepts
+    ``destination``/``to``; ``spawn_monster`` accepts ``monster``/``creature``; etc.).
+
+    #928: a companion peer-agent's ``say`` call arrived as ``{message: ...}`` (not the
+    canonical ``line``), so FastMCP's ``sayArguments`` model raised ``Field required
+    [type=missing]`` BEFORE the function body ran — a hard schema rejection that trips the
+    FATAL ``no_rejected_tool_calls`` behavioral gate and REDs the whole party run before a
+    companion thaw can even be measured. The fix is purely additive: accept the canonical
+    name OR the common aliases (``message`` / ``text``), coalescing to the first non-blank.
+    The emitted MOVE record is byte-identical (it always carried ``text``), so the relay
+    (``[\\(.kind)] \\(.text)``) and every existing consumer are unchanged. ``canonical``
+    wins if more than one is supplied."""
+    for v in (canonical, *aliases):
+        if (v or "").strip():
+            return v
+    return canonical
 
 
 @mcp.tool()
-def do(action: str) -> dict:
+def say(line: str = "", message: str = "", text: str = "") -> dict:
+    """Speak your character's OWN words (dialogue). Just your line — quotes are fine.
+
+    Pass your words via ``line`` (canonical) or the aliases ``message`` / ``text`` —
+    ``line`` wins if more than one is given (so a companion agent that reaches for the
+    intuitive ``message``/``text`` is never schema-refused, #928)."""
+    return _record("say", _text_arg(line, message, text))
+
+
+@mcp.tool()
+def do(action: str = "", message: str = "", text: str = "") -> dict:
     """Declare a physical action your character ATTEMPTS — intent only. The DM and the
-    dice decide if it works; do NOT describe the world or assert the result."""
-    return _record("do", action)
+    dice decide if it works; do NOT describe the world or assert the result.
+
+    Pass the action via ``action`` (canonical) or the aliases ``message`` / ``text``."""
+    return _record("do", _text_arg(action, message, text))
 
 
 @mcp.tool()
-def clarify(question: str) -> dict:
+def clarify(question: str = "", message: str = "", text: str = "") -> dict:
     """Ask the DM a CLARIFYING QUESTION before you commit to an action — exactly like asking a
     real Dungeon Master at the table ("Is the guard armed? How far is the door? Do I recognize
     this sigil? What do I actually know about this person?"). This is NOT an action and does NOT
     advance the scene or spend your turn: the DM answers what your character could plausibly
     perceive or know, then you still get to act. Reach for it when the scene is ambiguous and the
     answer would change your choice — better a quick question than a blind guess. Bounded: up to
-    3 questions before you must act (so it can't become an endless back-and-forth)."""
+    3 questions before you must act (so it can't become an endless back-and-forth).
+
+    Pass the question via ``question`` (canonical) or the aliases ``message`` / ``text``."""
+    question = _text_arg(question, message, text)
     if not question.strip():
         return {"ok": False, "error": "ask a real question"}
     if _consecutive_clarifies() >= _CLARIFY_PER_TURN:

--- a/servers/engine/tests/test_player_facade_actor.py
+++ b/servers/engine/tests/test_player_facade_actor.py
@@ -319,3 +319,90 @@ def test_pure_facade_read_does_not_flip_the_live_campaign(live, monkeypatch):
     assert before == after  # no updated_at bumped -> the live pointer can't have flipped
     # and the freshest campaign is unchanged (the read didn't make camp-actor "win" by writing)
     assert max(after, key=lambda k: after[k] or 0) == max(before, key=lambda k: before[k] or 0)
+
+
+# --- #928: a companion's wrong-but-intuitive `say` arg shape must NOT be schema-refused ---
+# A companion peer-agent called say({"message": ...}) instead of the canonical {"line": ...}.
+# FastMCP's auto-generated `sayArguments` model rejected it with
+#   `1 validation error for sayArguments / line / Field required [type=missing]`
+# BEFORE the function body ran — a hard schema rejection that trips the FATAL
+# `no_rejected_tool_calls` behavioral gate and REDs the whole party run. The fix is additive:
+# say/do/clarify accept the canonical name OR the aliases message/text, coalescing to the
+# first non-blank, so an agent reaching for the natural field name is never refused. These
+# tests exercise the REAL rejection surface — the MCP tool manager (which builds + validates
+# the pydantic args model), not a direct Python kwargs call — so they would RED pre-fix.
+def _call_tool(name: str, args: dict):
+    """Invoke a registered MCP tool through the tool manager (the path the peer-agent uses),
+    so we validate against the AUTO-GENERATED pydantic args model — the exact layer that
+    raised the #928 `Field required` rejection. Returns the tool's result dict."""
+    import asyncio
+
+    return asyncio.run(ps.mcp._tool_manager.call_tool(name, args))
+
+
+def _result_dict(res):
+    """The tool manager returns a (content, structured) shape across mcp versions; pull the
+    structured ``{"ok": ..., "move": {...}}`` dict the facade actually returns."""
+    if isinstance(res, tuple):
+        for part in res:
+            if isinstance(part, dict):
+                return part.get("result", part)
+        return res[-1]
+    return res
+
+
+def test_companion_say_with_message_alias_is_not_rejected(live, monkeypatch):
+    # THE #928 REPRO: the companion peer-agent's `say` arrived as {"message": ...}. Pre-fix
+    # this raised `1 validation error for sayArguments / line / Field required` through the
+    # tool manager and tripped the FATAL no_rejected_tool_calls gate. Post-fix it succeeds and
+    # records the dialogue verbatim — the move record is byte-identical (kind="say", text=...).
+    monkeypatch.setenv("CLAWDND_ACTOR_ID", "char-ally")
+    monkeypatch.setenv("CLAWDND_ACTOR_ROLE", "companion")
+    res = _result_dict(_call_tool("say", {"message": "Seraphine steadies her mace."}))
+    assert res["ok"] is True
+    row = live.rows()[-1]
+    assert row["kind"] == "say"
+    assert row["text"] == "Seraphine steadies her mace."
+    assert row["role"] == "companion" and row["actor_id"] == "char-ally"
+
+
+def test_say_text_alias_also_accepted(live, monkeypatch):
+    # The other intuitive alias an LLM reaches for: say({"text": ...}).
+    monkeypatch.setenv("CLAWDND_ACTOR_ID", "char-ally")
+    res = _result_dict(_call_tool("say", {"text": "'On your left.'"}))
+    assert res["ok"] is True
+    assert live.rows()[-1]["text"] == "'On your left.'"
+
+
+def test_do_and_clarify_message_alias_not_rejected(live, monkeypatch):
+    # The same additive tolerance covers the other free-text declares (do/clarify) — the
+    # identical schema-rejection class. A wrong-shaped `do`/`clarify` must not RED a run either.
+    monkeypatch.setenv("CLAWDND_ACTOR_ID", "char-ally")
+    do_res = _result_dict(_call_tool("do", {"message": "I move to flank the ogre."}))
+    assert do_res["ok"] is True
+    assert live.rows()[-1]["text"] == "I move to flank the ogre."
+    clr_res = _result_dict(_call_tool("clarify", {"message": "Is the guard armed?"}))
+    assert clr_res["ok"] is True
+    assert live.rows()[-1]["kind"] == "clarify"
+    assert live.rows()[-1]["text"] == "Is the guard armed?"
+
+
+def test_canonical_line_still_works_and_wins_over_alias(live, monkeypatch):
+    # INVARIANT: the canonical `line` is unchanged for the solo/.app + existing duo path, and
+    # if both are somehow supplied, `line` wins (deterministic precedence, like server.py's
+    # alias coalescing). The solo viewer /move sink is a SEPARATE path and unaffected by this.
+    monkeypatch.setenv("CLAWDND_ACTOR_ID", "char-ally")
+    assert ps.say("'Canonical.'")["ok"] is True       # direct positional, today's call
+    assert live.rows()[-1]["text"] == "'Canonical.'"
+    res = _result_dict(_call_tool("say", {"line": "'wins'", "message": "'loses'"}))
+    assert res["ok"] is True
+    assert live.rows()[-1]["text"] == "'wins'"         # canonical takes precedence
+
+
+def test_empty_say_call_records_blank_line_not_a_crash(live, monkeypatch):
+    # All three blank (or omitted) -> coalesces to the canonical "" and records a blank say,
+    # same as a positional empty string would. No KeyError / no schema rejection.
+    monkeypatch.setenv("CLAWDND_ACTOR_ID", "char-ally")
+    res = _result_dict(_call_tool("say", {}))
+    assert res["ok"] is True
+    assert live.rows()[-1]["text"] == ""


### PR DESCRIPTION
## Problem (#928, item 2)

In a party run (`qa/run_party.sh`) and the part-B built-`.app` capture (`qa/ui_playtest_app.sh` → `scripts/play_party.sh`), a companion peer-agent's `say` tool call was REJECTED:

```
Error executing tool say: 1 validation error for sayArguments
line
  Field required [type=missing, input_value={'message': 'Seraphine ...'}, input_type=dict]
```

The companion agent called `say` with `{message: ...}`, but FastMCP's auto-generated `sayArguments` model requires `line`. The validation fails BEFORE the function body runs — a hard schema rejection that trips the **FATAL `no_rejected_tool_calls`** behavioral gate (`qa/assert_behavioral.py` A8). The party-runner backend then errors out ~50s after an otherwise-successful cold-open, so the palette persona never gets to play → the full-`.app` arc capture can't complete and companion-approval can't be measured.

## Root cause

The player-facade free-text tools `say(line)` / `do(action)` / `clarify(question)` (`servers/engine/player_server.py`) were the **one corner of the tool surface without a tolerant keyword alias**. Every comparable tool in `server.py` already coalesces intuitive arg-name aliases to the canonical name *specifically so an LLM reaching for a natural field name is never schema-refused*:

- `travel_to` → `destination` / `to` / `location_id`
- `spawn_monster` → `monster` / `creature`
- `attack` → `character_id` / `npc_id` / `id`
- …and ~15 more

The companion prompt already says `say("…")` (positional) — the LLM *chooses* `message`/`text` regardless. Patching the prompt is brittle (the model will keep reaching for the natural name); the structural fix is to make the tool tolerant, matching the whole codebase's "never false-RED on an intuitive-but-wrong field name" discipline.

## Fix (additive)

`say` / `do` / `clarify` now accept the canonical name **OR** the aliases `message` / `text`, coalescing to the first non-blank via a shared `_text_arg` helper (mirrors the `record_decision` decision→summary alias pattern and the server.py alias coalescing). The canonical name wins if more than one is supplied.

## Invariants preserved

- **engine = sole writer** — pure facade arg-shape change, no engine write semantics touched.
- **additive only** — no breaking rename; canonical `line`/`action`/`question` unchanged; default duo/solo behavior byte-identical.
- **wire contract unchanged** — the emitted MOVE record always carried `text`, so the party relay (`map("[\(.kind)] \(.text)")`) and every existing consumer are unaffected.
- **solo/.app path unaffected** — the viewer `/move` say sink is a SEPARATE path (`viewer/server.py` `sanitize_move`, writing `{kind:"say", text:...}`), not the MCP tool; it never imports `player_server.say`.
- **gate NOT weakened** — the bad shape now SUCCEEDS at the tool layer rather than being hidden from `no_rejected_tool_calls`.

## Tests (TDD: RED → GREEN)

Added tests in `servers/engine/tests/test_player_facade_actor.py` that drive the **real rejection surface** — the MCP tool manager (`ps.mcp._tool_manager.call_tool`), which builds + validates the auto-generated pydantic args model, not a direct Python kwargs call:

- `test_companion_say_with_message_alias_is_not_rejected` — the exact #928 repro (`{message: ...}`). **RED pre-fix** with the literal `Field required for sayArguments / line` error; GREEN after.
- `test_say_text_alias_also_accepted`
- `test_do_and_clarify_message_alias_not_rejected`
- `test_canonical_line_still_works_and_wins_over_alias` (precedence + solo-path invariant note)
- `test_empty_say_call_records_blank_line_not_a_crash`

## Verification

- `bash qa/fast_gate.sh` → PASS (221 deterministic engine tests)
- `servers/engine` full suite → **2784 passed**
- `qa/test_assert_behavioral.py` → **27 passed** (the `no_rejected_tool_calls` gate logic itself is intact — not weakened)
- RED confirmed: reverting just the `say` signature reproduces the exact #928 `sayArguments / line / Field required` rejection.

Refs #928.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Player action commands (`say`, `do`, `clarify`) now accept alternative parameter names alongside canonical arguments, preventing validation failures and improving integration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->