### PR TITLE
fix(viewer): active hero is the authoritative kind=player actor, not party[0]

### DIFF
--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -579,6 +579,31 @@ function buildChronicleLog(recentEvents, chatBeats, log) {
 // Exposed for tests/devtools introspection (additive — the component calls the local fn directly).
 if (typeof window !== "undefined") window.buildChronicleLog = buildChronicleLog;
 
+// GROUP C / #seat-order — resolve WHICH party member is the player's hero (the one whose sheet the
+// header + active-hero chip show) from the SERVER'S AUTHORITATIVE actor, never from party ORDER. The
+// owner saw a banned/stale companion (an "ACTIVE ASTARION / Lvl 1 Adventurer") shown as the hero
+// because the seed read `party[0]?.id`: whoever the engine happened to list first (a stale companion)
+// became the displayed hero, with the no-class "Adventurer" fallback. The engine already publishes the
+// real active actor at `surface.actor` ({id,name,kind}, itself already preferring kind=player — see
+// viewer/server.py _action_actor), and each party card carries its `kind`. So resolve in priority:
+//   1. surface.actor.id            — the engine's authoritative active actor (the truth)
+//   2. the first kind="player" PC  — the real player-controlled hero, regardless of list order
+//   3. party[0].id                 — last-resort fallback (preserves today's behavior when neither
+//                                    an actor nor a kind=player card is present, e.g. a demo surface)
+// PURE + read-only: it only READS the surface the engine already published; it never writes engine
+// state and never breaks the wire contract. Returns the chosen id (a string, possibly "").
+function resolveActiveHeroId(surface, party) {
+  const roster = Array.isArray(party) ? party : [];
+  const actorId = surface && surface.actor && surface.actor.id;
+  if (typeof actorId === "string" && actorId && roster.some((p) => p && p.id === actorId)) {
+    return actorId;
+  }
+  const pc = roster.find((p) => p && p.kind === "player");
+  if (pc && pc.id) return pc.id;
+  return (roster[0] && roster[0].id) || "";
+}
+if (typeof window !== "undefined") window.resolveActiveHeroId = resolveActiveHeroId;
+
 // LOCKOUT P0 — the detach-locks-the-action-bar play gate, as ONE pure function so the exact
 // boolean logic is unit-testable (mirrors app.jsx's `recoveryWindowMs`). Inputs are the surface +
 // app-status facts the component already has; outputs are every derived play-gate flag + the single
@@ -737,7 +762,10 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
   const calendar = surface?.calendar?.available ? surface.calendar : null;
   const calendarMoon = Array.isArray(calendar?.moons) ? calendar.moons[0] : null;
   const calendarDetail = calendar ? [calendar.season, calendarMoon ? `${calendarMoon.name}: ${calendarMoon.phase}` : ""].filter(Boolean).join(" · ") : "";
-  const [activeHero, setActiveHero] = React.useState(() => party[0]?.id || "");
+  // #seat-order: seed the active hero from the ENGINE'S authoritative actor (surface.actor), then the
+  // first kind="player" PC, and only THEN party[0] — so the displayed/active hero is always the real
+  // PC, never a stale companion the engine happened to order first (see resolveActiveHeroId).
+  const [activeHero, setActiveHero] = React.useState(() => resolveActiveHeroId(surface, party));
   const hero = party.find((p) => p.id === activeHero) || party[0] || { id: "", name: "Hero", short: "Hero", level: 1, class: "Adventurer", hp: 1, hpMax: 1 };
   const visibleQuests = quests.filter((q) => !q.status || q.status === "active" || q.status === "open");
   const canAct = Boolean(surface?.can_act);

--- a/viewer/tests/test_active_hero_order.py
+++ b/viewer/tests/test_active_hero_order.py
@@ -1,0 +1,139 @@
+"""GROUP C / #seat-order — the active hero is the engine's AUTHORITATIVE kind=player actor, not party[0].
+
+The owner, playing the real shipped macOS .app, saw a banned/stale companion shown as the hero —
+the "ACTIVE ASTARION / Lvl 1 Adventurer" display bug. ROOT CAUSE (verified, NOT a #912 seat
+bypass): the OpenWorlds table screen picked the active hero by PARTY ORDER, not by the engine's
+authoritative active actor. `viewer/openworlds/screen-table.jsx` seeded
+`activeHero = party[0]?.id`, so whoever the engine happened to list FIRST (a stale companion like
+Astarion) became the displayed hero — and the header's hero lookup fell to the no-class
+`{class:"Adventurer", level:1}` placeholder.
+
+THE FIX (additive, viewer read-only): `resolveActiveHeroId(surface, party)` resolves the hero from
+the engine's authoritative actor FIRST — `surface.actor.id` (the engine's active actor, itself
+already a kind=player PC; see viewer/server.py `_action_actor`), then the first party card with
+`kind === "player"`, and ONLY THEN `party[0]` as a last resort. So the displayed/active hero is
+always the real player-controlled PC, never a stale companion ordered first.
+
+These tests exercise the REAL shipped browser function (no reimplementation): mirroring the sibling
+JS-behavior tests (test_chronicle_hygiene.py) we brace-match `resolveActiveHeroId` out of the actual
+`screen-table.jsx` and eval it under Node, so the test tracks shipped behavior. Skipped if Node is
+not on PATH.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+OPENWORLDS = HERE.parent / "openworlds"
+SCREEN_TABLE = OPENWORLDS / "screen-table.jsx"
+
+
+def _node() -> str:
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("node not on PATH; skipping JS-behavior test")
+    return node
+
+
+def _extract_fn(src: str, name: str) -> str:
+    """Brace-match a top-level `function name(...) { ... }` out of the source (mirror of the
+    sibling test_chronicle_hygiene._extract_fn)."""
+    marker = f"function {name}("
+    start = src.index(marker)
+    depth = 0
+    for i in range(start, len(src)):
+        c = src[i]
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return src[start : i + 1]
+    raise AssertionError(f"could not brace-match {name}()")
+
+
+def _resolve(surface, party) -> str:
+    src = SCREEN_TABLE.read_text(encoding="utf-8")
+    fn = _extract_fn(src, "resolveActiveHeroId")
+    snippet = (
+        fn
+        + "\nconst __surface = "
+        + json.dumps(surface)
+        + ";\nconst __party = "
+        + json.dumps(party)
+        + ";\nprocess.stdout.write(String(resolveActiveHeroId(__surface, __party)));\n"
+    )
+    proc = subprocess.run([_node(), "-e", snippet], capture_output=True, text=True, timeout=30)
+    if proc.returncode != 0:
+        raise AssertionError(f"node failed: {proc.stderr}")
+    return proc.stdout
+
+
+# A realistic stale-order party: the COMPANION is listed first (party[0]) and the real PC is later —
+# the exact shape that surfaced "ACTIVE ASTARION" as the hero under the old party[0] seed.
+_ASTARION = {"id": "astarion-1", "name": "Astarion", "kind": "companion", "class": "Rogue", "level": 3}
+_PC = {"id": "pc-tav", "name": "Tav", "kind": "player", "class": "Wizard", "level": 1}
+
+
+def test_companion_first_is_not_shown_as_the_hero_when_actor_is_the_pc():
+    # The core regression: surface.actor is the authoritative kind=player PC and party[0] is a
+    # companion. The displayed active hero MUST be the PC, never party[0]. (Old code returned
+    # party[0].id = "astarion-1" — the "ACTIVE ASTARION" bug.)
+    surface = {"actor": {"id": "pc-tav", "name": "Tav", "kind": "player"}}
+    party = [_ASTARION, _PC]
+    assert _resolve(surface, party) == "pc-tav"
+
+
+def test_actor_wins_over_party_order_even_when_pc_is_last():
+    # The authoritative actor is honoured regardless of where the PC sits in the roster.
+    surface = {"actor": {"id": "pc-tav", "name": "Tav", "kind": "player"}}
+    party = [_ASTARION, {"id": "shadowheart-1", "name": "Shadowheart", "kind": "companion"}, _PC]
+    assert _resolve(surface, party) == "pc-tav"
+
+
+def test_falls_back_to_kind_player_when_no_actor():
+    # No surface.actor (e.g. a surface that predates the field) → still pick the kind=player PC,
+    # not the companion at party[0].
+    surface = {}
+    party = [_ASTARION, _PC]
+    assert _resolve(surface, party) == "pc-tav"
+
+
+def test_falls_back_to_kind_player_when_actor_not_in_roster():
+    # surface.actor names an id that is NOT a current party card (stale/cross-campaign) → ignore it
+    # and pick the kind=player PC, never the companion party[0].
+    surface = {"actor": {"id": "ghost-actor", "kind": "player"}}
+    party = [_ASTARION, _PC]
+    assert _resolve(surface, party) == "pc-tav"
+
+
+def test_last_resort_is_party0_when_no_actor_and_no_player_card():
+    # Neither an authoritative actor nor a kind=player card (e.g. a demo/companion-only surface) →
+    # preserve today's behavior: fall back to party[0].id. (Invariant: keep the existing fallback.)
+    surface = {}
+    party = [{"id": "c1", "name": "Comp One", "kind": "companion"},
+             {"id": "c2", "name": "Comp Two", "kind": "companion"}]
+    assert _resolve(surface, party) == "c1"
+
+
+def test_empty_party_yields_empty_string():
+    # No roster at all → empty id (the component's own hero-lookup then uses its placeholder). The
+    # resolver must not throw on an empty/absent party.
+    assert _resolve({}, []) == ""
+    assert _resolve({"actor": {"id": "x", "kind": "player"}}, []) == ""
+
+
+def test_actor_preferred_even_when_a_different_player_card_exists():
+    # If the engine names a SPECIFIC active actor, honour that exact id even if another kind=player
+    # card is also present (multi-PC roster) — the engine's actor is the truth, not "first player".
+    surface = {"actor": {"id": "pc-two", "kind": "player"}}
+    party = [
+        {"id": "pc-one", "name": "Aldric", "kind": "player"},
+        {"id": "pc-two", "name": "Bryn", "kind": "player"},
+    ]
+    assert _resolve(surface, party) == "pc-two"


### PR DESCRIPTION
## GROUP C — ACTIVE-HERO ORDERING (the "ACTIVE ASTARION / Lvl 1 Adventurer" display bug)

The owner, playing the **real shipped macOS `.app`** (not the QA harness — that masked it), saw a **banned/stale companion shown as the hero**: "ACTIVE ASTARION / Lvl 1 Adventurer".

### Root cause (verified — NOT a #912 seat bypass)
The frontend picked the active hero by **party ORDER**, not by the engine's authoritative active actor. `viewer/openworlds/screen-table.jsx` seeded:

```js
const [activeHero, setActiveHero] = React.useState(() => party[0]?.id || "");
const hero = party.find((p) => p.id === activeHero) || party[0] || { ...class:"Adventurer"... };
```

So whoever the engine happened to list **first** (a stale companion like Astarion) became the displayed hero, and the header's hero lookup fell to the no-class `{class:"Adventurer", level:1}` placeholder.

### Fix (additive, viewer read-only)
New pure helper `resolveActiveHeroId(surface, party)` resolves the active hero from the **server's authoritative actor first**, in priority:

1. `surface.actor.id` — the engine's authoritative active actor (itself already a kind=player PC; see `viewer/server.py` `_action_actor`), validated to be a current party card
2. the first party card with `kind === "player"` — the real player-controlled PC, regardless of list order
3. `party[0].id` — last-resort fallback (preserves today's behavior; e.g. a demo/companion-only surface)

The `activeHero` seed now calls `resolveActiveHeroId(surface, party)`. The existing `hero` lookup fallback chain (`party.find(...) || party[0] || {Adventurer placeholder}`) is **preserved** as the final resort.

### Invariants held
- **Viewer read-only** — presentation only; reads `surface.actor` + `party[].kind` the engine already publishes; no engine write.
- **Additive** — one new pure function + a 1-line seed change; no guard weakened.
- **No wire-contract break** — reuses existing fields (`surface.actor`, `party[].kind`).

### TDD (babel-vm / Node harness, mirrors `test_chronicle_hygiene.py`)
`viewer/tests/test_active_hero_order.py` brace-matches the **real shipped** `resolveActiveHeroId` out of `screen-table.jsx` and evals it under Node — so it tracks shipped behavior, not a reimplementation.

- **RED** against the old `party[0]` seed (returns the companion `astarion-1`).
- **GREEN** after the fix (returns the PC `pc-tav`).
- Core assertion: when `surface.actor` is a kind=player PC and `party[0]` is a companion, the displayed active hero is the **PC**, never `party[0]`.

### Verification
- `qa/fast_gate.sh` → **PASS** (221 passed; seat-path/engine intact).
- Viewer suite → **708 passed, 6 skipped**, 7 new passed. (1 failure: `test_portrait_gen::...test_null_default_returns_placeholder_no_network` — pre-existing `ModuleNotFoundError: No module named 'pydantic'` env issue, fails identically on the pristine base; unrelated to this change.)
- `swift build --package-path macos/WorldOSApp` → **Build complete** (the `.app` serves the viewer over HTTP from `/openworlds/`, so the JSX fix is observable in the real `.app` without recompiling Swift).