### PR TITLE
fix(qa): scripted provider hermetic vs injected WORLDOS_STATE_DIR + busy port

### DIFF
--- a/scripts/play_scripted_dm.sh
+++ b/scripts/play_scripted_dm.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+# Shared launcher helpers (clawdnd_choose_port / clawdnd_port_available), sourced like play.sh
+# so the scripted provider can pick a free dashboard port instead of colliding on a busy 8765.
+COMMON="$ROOT/scripts/launch_common.sh"
+# shellcheck source=launch_common.sh
+[ -f "$COMMON" ] && . "$COMMON"
+
 if [ "${1:-}" = "--dry-run" ]; then
   printf 'scripted provider dry-run: requires no Claude, Codex, or OpenClaw\n'
   printf 'gate=%s world=%s run=%s port=%s\n' \
@@ -32,8 +38,24 @@ done
 
 WORLD="${CLAWDND_WORLD:-baldurs-gate}"
 RUN="${CLAWDND_RUN_ID:-scripted-smoke-$(date +%H%M%S)}"
-PORT="${CLAWDND_PLAY_PORT:-8765}"
 STATE_DIR="$ROOT/play-state/$RUN"
+# Pin BOTH state-dir env names to THIS run's hermetic play-state dir. The native .app's
+# startProviderSession injects WORLDOS_STATE_DIR (its launcher stateDir) into our environment
+# (#933); the engine resolves WORLDOS_STATE_DIR BEFORE CLAWDND_STATE_DIR, so without this the
+# cold-open bootstrap (which set only CLAWDND_STATE_DIR) leaks the campaign into the launcher's
+# dir while the viewer reads this one — a split write/read that yields an empty can_act:false
+# surface. Mirror play.sh:142 and export both up front so every child (bootstrap, viewer,
+# move-resolver) agrees on one dir regardless of inherited env.
+export WORLDOS_STATE_DIR="$STATE_DIR" CLAWDND_STATE_DIR="$STATE_DIR"
+# Choose a free dashboard port like play.sh: unless CLAWDND_PLAY_PORT is set explicitly, fall
+# back off a busy 8765 (the native launcher viewer) so the game viewer doesn't crash-loop on bind.
+PORT_REQUESTED="${CLAWDND_PLAY_PORT:-8765}"
+PORT_EXPLICIT=0; [ -n "${CLAWDND_PLAY_PORT:-}" ] && PORT_EXPLICIT=1
+if command -v clawdnd_choose_port >/dev/null 2>&1; then
+  PORT="$(clawdnd_choose_port "$PORT_REQUESTED" "$PORT_EXPLICIT")" || PORT="$PORT_REQUESTED"
+else
+  PORT="$PORT_REQUESTED"
+fi
 TRACE_DIR="$STATE_DIR/scripted-provider"
 MOVES="$STATE_DIR/player_moves.jsonl"
 CHAT="$STATE_DIR/chat.jsonl"


### PR DESCRIPTION
## Problem
The scripted part-A native gate (`qa/ui_playtest_app.sh`, the GUI-mechanical proxy) stopped minting a live session after #933. Root-caused via systematic debugging:

#933 made the native `.app` inject `WORLDOS_STATE_DIR` (its launcher stateDir) into the game subprocess (`AppProcessService.swift:222-223`). The **real** `play.sh` is hermetic against this (derives one per-run `STATE_DIR`, re-exports BOTH env names up front at `play.sh:132-142`, and `clawdnd_choose_port`s off a busy 8765) — so **the real claude game still mints correctly**. The **scripted** QA provider was not hermetic:

- its cold-open bootstrap set only `CLAWDND_STATE_DIR`; the engine resolves `WORLDOS_STATE_DIR` **first**, so the injected launcher dir won → the campaign was written **there** while the viewer (which re-pins both to `play-state/$RUN`) read an **empty** dir → `can_act:false`, no live surface;
- `PORT` defaulted to 8765 with no free-port fallback → collided with the launcher viewer → the game viewer crash-looped on bind.

## Fix (QA-harness only — no engine/wire/content change)
Mirror `play.sh`: source `launch_common.sh`, `export` both `WORLDOS_STATE_DIR` + `CLAWDND_STATE_DIR` to the per-run dir up front (so bootstrap, viewer, and move-resolver agree on one dir regardless of inherited env), and `clawdnd_choose_port` off a busy 8765 unless `CLAWDND_PLAY_PORT` is explicit.

## Verification
Reproduced the exact `.app` condition (busy 8765 + `WORLDOS_STATE_DIR` injected to a different dir):
- game snapshot lands in `play-state/<run>/campaigns/…` with **zero leak** into the injected dir;
- viewer binds **8766** (dodges the busy 8765);
- `/session-surface` → `can_act:true, is_live_view:true, actor Abby kind=player` (proper PC seated).

**Revert-check:** dropping the `export` restores the split write/read → empty `can_act:false` surface (causal).