### PR TITLE
fix(viewer): route the live active-hero correction through the authoritative resolver (#932 completion)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ venv/
 
 # fast-gate rotation counter (Tier 1)
 /qa/.fast_gate_iter
+.qa-archive/

--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -904,9 +904,15 @@ function ScreenTable({ onNavigate, state, setState, liveSession }) {
     };
   }, [loadSurface]);
 
+  // #seat-order (live-update correction): if the active hero leaves the roster mid-session (companion
+  // churn or a campaign switch) re-seed through the SAME authoritative resolver the initial seed uses
+  // (resolveActiveHeroId — surface.actor → first kind="player" PC → party[0]), NOT party[0]. Re-seeding
+  // from party[0] here re-introduced the "ACTIVE ASTARION / Lvl 1 Adventurer" bug #932 fixed, on the
+  // live path: if a companion sorts to party[0] it would be picked as the displayed hero. `party` is a
+  // fresh reference on every applied surface poll, so the resolver always reads the current surface.actor.
   React.useEffect(() => {
     if (!party.some((p) => p.id === activeHero)) {
-      setActiveHero(party[0]?.id || "");
+      setActiveHero(resolveActiveHeroId(surface, party));
     }
   }, [party, activeHero]);
 

--- a/viewer/tests/test_active_hero_order.py
+++ b/viewer/tests/test_active_hero_order.py
@@ -137,3 +137,16 @@ def test_actor_preferred_even_when_a_different_player_card_exists():
         {"id": "pc-two", "name": "Bryn", "kind": "player"},
     ]
     assert _resolve(surface, party) == "pc-two"
+
+
+def test_live_correction_reseeds_to_pc_not_party0_companion_when_active_hero_leaves_roster():
+    # The LIVE-UPDATE correction path (screen-table.jsx effect ~907): the previously active hero
+    # ("pc-old") has left the roster mid-session (companion churn / campaign switch) and a COMPANION
+    # has sorted to party[0]. The effect re-seeds through this resolver — it MUST land on the engine's
+    # authoritative kind=player actor (the PC), NEVER party[0]. #932 fixed the initial seed but left
+    # this correction effect on the old party[0] path, which would re-pick the companion and resurrect
+    # the "ACTIVE ASTARION / Lvl 1 Adventurer" bug on the live path. (Under Node, the old line 909 —
+    # `party[0]?.id` — returned "astarion-1" for this exact shape; the resolver returns "pc-tav".)
+    surface = {"actor": {"id": "pc-tav", "name": "Tav", "kind": "player"}}
+    party = [_ASTARION, _PC]  # companion at party[0], the real PC later; "pc-old" is gone
+    assert _resolve(surface, party) == "pc-tav"


### PR DESCRIPTION
## Problem
#932 fixed the **initial** active-hero seed but left the **live-update correction** effect (`screen-table.jsx` ~907) re-seeding from `party[0]` when the active hero leaves the roster mid-session (companion churn / campaign switch). If a companion sorts to `party[0]` there, it resurrects the "ACTIVE ASTARION / Lvl 1 Adventurer" bug on the live path.

## Fix
Route the live correction through the same `resolveActiveHeroId` (surface.actor → first `kind=player` PC → `party[0]`) the initial seed uses. Strictly better than `party[0]`.

## Test
`test_live_correction_reseeds_to_pc_not_party0_companion_when_active_hero_leaves_roster` asserts the resolver lands on the `kind=player` actor (`pc-tav`), not the `party[0]` companion (`astarion-1`) — the contract the live effect now calls. 8/8 in the file pass.

Also: gitignore `.qa-archive/` (local archived QA state, never committed).