### PR TITLE
feat(viewer): combat scene backdrop + condition chips on tokens (additive, read-only)

### DIFF
--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -99,6 +99,12 @@ function ScreenCombat({ onNavigate, state }) {
   const zones = Array.isArray(surface?.zones) ? surface.zones : [];
   const battleLog = Array.isArray(surface?.battleLog) ? surface.battleLog : [];
   const encounter = surface?.encounter || { active: false, name: "No active encounter" };
+  // FIX A (combat scene backdrop): the servable scene scope the server projects on
+  // the location block (`location:<id>`). Mirror the dialogue screen's sceneScope
+  // fallback so an older surface without imageScope still resolves via location.id;
+  // empty string -> CombatMap renders no backdrop (graceful, transparent).
+  const sceneScope = surface?.location?.imageScope ||
+    (surface?.location?.id ? `location:${surface.location.id}` : "");
   const commandCenter = surface?.commandCenter || {};
   const economy = surface?.actionEconomy || {};
   const canAct = Boolean(surface?.can_act);
@@ -212,7 +218,7 @@ function ScreenCombat({ onNavigate, state }) {
           </div>
 
           {encounter.active ? (
-            <CombatMap tokens={tokens} zones={zones} selected={selected?.id} onSelect={setSelectedToken} />
+            <CombatMap tokens={tokens} zones={zones} selected={selected?.id} onSelect={setSelectedToken} sceneScope={sceneScope} />
           ) : (
             <CombatEmptyState status={surfaceStatus} onNavigate={onNavigate} />
           )}
@@ -444,7 +450,7 @@ function CombatEmptyState({ status, onNavigate }) {
    A real measured-tile grid (range/LoS/flanking) is the evidence-gated #461 future: it requires
    the engine to gain authoritative coordinates (positionAuthority:"engine" + grid.mode==="grid").
    When that lands, a grid board plugs in here behind that flag; until then, zones are the truth. */
-function CombatMap({ tokens, zones, selected, onSelect }) {
+function CombatMap({ tokens, zones, selected, onSelect, sceneScope }) {
   const named = (zones || []).map((z) => (typeof z === "string" ? z : z && z.name)).filter(Boolean);
   const FIELD = "The Field";
   let zoneNames = named.slice();
@@ -467,9 +473,36 @@ function CombatMap({ tokens, zones, selected, onSelect }) {
       overflow: "hidden",
       display: "flex", gap: 10, padding: 12,
     }}>
+      {/* FIX A (combat scene backdrop): render the location/scene art as an
+          absolute-inset cover image BEHIND the zone bands (zIndex 0), mirroring the
+          dialogue screen's backdrop (screen-dialogue.jsx:177). The zone bands keep
+          their semi-transparent fills so the place reads through. <Img> degrades to a
+          silhouette/placeholder when the scope is empty/unservable, so an empty
+          sceneScope is a graceful no-op (the gradient base layer stays visible). */}
+      {sceneScope ? (
+        <Img
+          scope={sceneScope}
+          label="scene · battlefield"
+          w="100%"
+          h="100%"
+          fit="cover"
+          style={{ position: "absolute", inset: 0, zIndex: 0 }}
+        />
+      ) : null}
+      {/* Darkening scrim so token art / HP bars / zone labels keep contrast over a
+          bright backdrop (matches the dialogue vignette intent). Behind the bands. */}
+      {sceneScope ? (
+        <div style={{
+          position: "absolute", inset: 0, zIndex: 0,
+          background: "radial-gradient(ellipse at 50% 50%, rgba(20,10,4,0.35), rgba(20,10,4,0.72) 100%)",
+          pointerEvents: "none",
+        }} />
+      ) : null}
       {zoneNames.map((zn) => (
         <div key={zn} style={{
           flex: 1, minWidth: 0,
+          // FIX A: sit the zone bands above the absolute backdrop + scrim (zIndex 0).
+          position: "relative", zIndex: 1,
           display: "flex", flexDirection: "column",
           background: "rgba(30,18,10,0.30)",
           boxShadow: "inset 0 0 0 1px rgba(176,141,87,0.18)",
@@ -535,9 +568,39 @@ function hpBarFillInit(t, isFoe, ratio) {
 /* A single combatant token — now a FLOW element laid out inside its zone band (no absolute
    x/y on a fake grid). Visual language (circle, foe/ally tint, selection glow, honest HP bar,
    name) is preserved; only positioning changed from x/y-on-grid to zone-grouped flow. */
+/* FIX B (condition chips): a single compact status badge below a token, styled after
+   the existing CueChip (~line 397). Kept tiny so a row of 2-3 never overflows the
+   48px token column. Harmless slug-casing of the engine's condition string. */
+function ConditionChip({ condition }) {
+  const text = String(condition || "");
+  if (!text) return null;
+  return (
+    <span title={text} style={{
+      fontFamily: "var(--f-mono)",
+      fontSize: 7,
+      lineHeight: 1.2,
+      textTransform: "uppercase",
+      letterSpacing: "0.04em",
+      color: "var(--ink-700)",
+      padding: "1px 3px",
+      background: "rgba(176,141,87,0.16)",
+      boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.30)",
+      maxWidth: 44,
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      whiteSpace: "nowrap",
+    }}>{text}</span>
+  );
+}
+
 function CombatToken({ t, selected, onClick }) {
   const isFoe = t.team === "foe";
   const hpRatio = healthRatio(t);
+  // FIX B: render the first ~3 engine-supplied conditions as chips. No-op ([]/missing
+  // -> nothing renders) so a clean token is byte-for-byte unchanged. The engine is the
+  // sole writer; the viewer only reflects the conditions list already on the token.
+  const conditions = Array.isArray(t.conditions) ? t.conditions.filter(Boolean) : [];
+  const shownConditions = conditions.slice(0, 3);
   return (
     <button onClick={onClick} title={t.name} style={{
       position: "relative",
@@ -581,6 +644,17 @@ function CombatToken({ t, selected, onClick }) {
           background: hpBarFill(t, isFoe),
         }} />
       </div>
+      {/* FIX B: condition chips below the HP bar. No-op when there are none. */}
+      {shownConditions.length ? (
+        <div style={{
+          display: "flex", flexWrap: "wrap", gap: 2,
+          justifyContent: "center", maxWidth: 64,
+        }}>
+          {shownConditions.map((c, i) => (
+            <ConditionChip key={`${c}-${i}`} condition={c} />
+          ))}
+        </div>
+      ) : null}
       <div style={{
         fontFamily: "var(--f-display)", fontSize: 8, letterSpacing: "0.1em",
         textTransform: "uppercase", whiteSpace: "nowrap", maxWidth: 64,

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -2592,6 +2592,14 @@ def build_combat_surface(
     """Project a browser-safe OpenWorlds combat board from engine-owned state."""
     snapshot = snapshot if isinstance(snapshot, dict) else {}
     location = _session_location(snapshot)
+    # FIX A (combat scene backdrop): expose a servable scene image scope on the
+    # location block so the CombatMap can render the place art behind the zone bands.
+    # ADDITIVE — mirrors the proven session-surface (line ~2069) + catalog (~5597)
+    # `location:<id>` pattern the _safe_scope bridge resolves to ingested art.
+    # Degrades to "" when there is no current location, so the client renders no
+    # backdrop (transparent) rather than a broken scope. _session_location returns a
+    # fresh dict each call, so mutating it here cannot leak into the session surface.
+    location["imageScope"] = f"location:{location['id']}" if location["id"] else ""
     combat_view = build_combat_view(snapshot)
     action_model = build_action_model(snapshot, live=live, is_live_view=is_live_view)
     combat_active = bool(combat_view.get("active"))

--- a/viewer/tests/test_combat_backdrop_conditions.py
+++ b/viewer/tests/test_combat_backdrop_conditions.py
@@ -1,0 +1,157 @@
+"""Server-side contract tests backing two combat-screen felt-gap fixes.
+
+These assert the SURFACE FIELDS the viewer JSX renders (the JSX render itself is
+not unit-tested here):
+
+  FIX A — Combat scene backdrop: build_combat_surface must expose a servable
+    scene image scope on the location block, mirroring the proven session/catalog
+    pattern (`location:<id>` when a location exists, "" when it does not). This is
+    the data the CombatMap absolute-inset cover image binds to.
+
+  FIX B — Condition chips on tokens: each combat token must carry its `conditions`
+    list through to the surface (a no-op empty list when the combatant has none).
+    This is the data CombatToken renders as small badge chips.
+
+Both fixes are ADDITIVE. Each assertion below doubles as a revert-check: delete the
+viewer wiring and the matching assertion fails, so a future regression that drops
+the field is caught here rather than silently shipping a blank backdrop / bare token.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+def _surface_with_location() -> dict:
+    snapshot = {
+        "id": "camp_backdrop",
+        "title": "Ambush at the Gate",
+        "current_location_id": "gate",
+        "locations": {
+            "gate": {
+                "name": "Basilisk Gate",
+                "description": "A rain-slick gatehouse with overturned carts.",
+            },
+        },
+        "party": ["hero"],
+        "characters": {
+            "hero": {
+                "id": "hero",
+                "name": "Tav",
+                "kind": "player",
+                "current_hp": 18,
+                "max_hp": 24,
+                "armor_class": 17,
+                "conditions": ["blessed", "hasted"],
+            },
+            "gob": {
+                "id": "gob",
+                "name": "Goblin Sapper",
+                "kind": "monster",
+                "current_hp": 3,
+                "max_hp": 7,
+                "conditions": ["prone"],
+            },
+            "ogre": {
+                "id": "ogre",
+                "name": "Ogre Brute",
+                "kind": "monster",
+                "current_hp": 30,
+                "max_hp": 30,
+            },
+        },
+        "combat": {
+            "active": True,
+            "round": 2,
+            "turn_index": 0,
+            "order": [
+                {"character_id": "hero", "initiative": 18, "zone": "gate"},
+                {"character_id": "gob", "initiative": 9, "zone": "gate"},
+                {"character_id": "ogre", "initiative": 6, "zone": "gate"},
+            ],
+        },
+    }
+    return server.build_combat_surface(
+        snapshot,
+        campaign_id="camp_backdrop",
+        live=True,
+        is_live_view=True,
+    )
+
+
+class CombatBackdropScopeTests(unittest.TestCase):
+    """FIX A — the combat surface exposes a servable scene image scope."""
+
+    def test_location_block_carries_servable_image_scope(self):
+        surface = _surface_with_location()
+        # Mirrors the proven session-surface (server.py:2069) + catalog (server.py:5597)
+        # `location:<id>` pattern that the _safe_scope bridge resolves to ingested art.
+        self.assertEqual(surface["location"]["imageScope"], "location:gate")
+
+    def test_image_scope_matches_location_id(self):
+        surface = _surface_with_location()
+        loc = surface["location"]
+        # The scope must be derived from the SAME id the rest of the surface uses,
+        # so the backdrop and the encounter header agree on the place.
+        self.assertEqual(loc["imageScope"], f"location:{loc['id']}")
+
+    def test_image_scope_empty_string_when_no_location(self):
+        # No current_location_id / locations -> id is "" -> scope degrades to "".
+        # CombatMap then renders no backdrop (transparent) rather than a broken scope.
+        surface = server.build_combat_surface(
+            {"title": "Quiet Camp", "party": [], "characters": {}},
+            campaign_id="camp_void",
+            live=True,
+            is_live_view=True,
+        )
+        self.assertEqual(surface["location"]["imageScope"], "")
+
+    def test_image_scope_is_additive_existing_location_fields_preserved(self):
+        surface = _surface_with_location()
+        loc = surface["location"]
+        # Every pre-existing location field must survive byte-for-byte alongside the
+        # new imageScope key (wire-break guard for the additive invariant).
+        self.assertEqual(loc["id"], "gate")
+        self.assertEqual(loc["name"], "Basilisk Gate")
+        self.assertEqual(loc["region"], "Basilisk Gate")
+        self.assertEqual(
+            loc["description"], "A rain-slick gatehouse with overturned carts."
+        )
+
+
+class CombatTokenConditionsTests(unittest.TestCase):
+    """FIX B — combat tokens carry their conditions list through to the surface."""
+
+    def test_tokens_carry_conditions_list(self):
+        surface = _surface_with_location()
+        by_id = {t["id"]: t for t in surface["tokens"]}
+        # Ally conditions flow through verbatim (CombatToken renders these as chips).
+        self.assertEqual(by_id["hero"]["conditions"], ["blessed", "hasted"])
+        # Foe conditions also flow through (observable status, not hidden stats).
+        self.assertEqual(by_id["gob"]["conditions"], ["prone"])
+
+    def test_conditions_is_empty_list_no_op_when_absent(self):
+        surface = _surface_with_location()
+        by_id = {t["id"]: t for t in surface["tokens"]}
+        # A combatant with no conditions yields [] (never missing/None) so the JSX
+        # no-ops cleanly — the chip row renders nothing.
+        self.assertEqual(by_id["ogre"]["conditions"], [])
+
+    def test_conditions_is_always_a_list_of_strings(self):
+        surface = _surface_with_location()
+        for token in surface["tokens"]:
+            self.assertIsInstance(token["conditions"], list)
+            for cond in token["conditions"]:
+                self.assertIsInstance(cond, str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Two combat-screen felt-gaps — pure VIEWER changes, additive, TDD

Both gaps were **wiring** gaps: the data existed (or the proven pattern existed elsewhere) but the combat screen never used it. The Python engine stays the **sole writer** of state; the viewer only projects engine-owned data and posts move-intents. **No engine changes.**

---

### FIX A — Combat scene backdrop (GAP-IS-WIRING)

The `CombatMap` component (`viewer/openworlds/screen-combat.jsx`) rendered only a hardcoded gradient — it never showed the location/scene art, even though every other screen does.

**Server** (`viewer/server.py`, `build_combat_surface`): expose a servable scene image scope on the location block —
```python
location["imageScope"] = f"location:{location['id']}" if location["id"] else ""
```
This mirrors the proven session-surface (`server.py:2069`) and catalog (`server.py:5597`) `location:<id>` pattern that the viewer's `_safe_scope` bridge already resolves to ingested art. `_session_location` returns a **fresh dict** each call, so mutating it here cannot leak into the session surface — and every existing location field (`id`/`name`/`region`/`description`) is preserved.

**Client** (`CombatMap`): render the location art as an **absolute-inset cover `<Img>` behind the zone bands**, mirroring the dialogue screen's backdrop (`screen-dialogue.jsx:177`), plus a darkening scrim for token/HP/label contrast. Zone bands sit above it (`position:relative; zIndex:1`). The scope is derived with the same fallback the dialogue screen uses (`location.imageScope || location:<id>`), so an older surface still resolves. **When the scope is empty the backdrop is skipped entirely** — the existing gradient base layer stays, a graceful transparent no-op.

### FIX B — Condition chips on tokens (GAP-IS-WIRING)

The combat token object already carried `conditions` (a list of strings, built in `_combat_tokens`, `server.py:2204`) but `CombatToken` never rendered it.

`CombatToken` now renders the **first ~3 conditions as small badge chips below the HP bar**, styled after the existing `CueChip`. Compact (fontSize 7, capped width) so a row never overflows the 48px token column. **No-op when `conditions` is empty/absent** — a clean token is byte-for-byte unchanged.

---

### Invariants held (hard requirements)
- **Read-only:** no state writes — only new projected fields + new render.
- **Additive:** new fields only; every existing surface field/behavior preserved when the new data is absent.
- **No wire-break:** no existing surface field renamed, retyped, or reordered.

### Tests + revert-checks
`viewer/tests/test_combat_backdrop_conditions.py` asserts the **server-side contract** the JSX binds to (the in-browser JSX render is not unit-tested; the backing surface fields are). Each assertion doubles as a **revert-check** — delete the wiring and the matching test fails:

| Test | Revert-check it provides |
|---|---|
| `test_location_block_carries_servable_image_scope` | drop the server `imageScope` line → fails (KeyError) |
| `test_image_scope_matches_location_id` | scope must agree with the surface's location id |
| `test_image_scope_empty_string_when_no_location` | no location → `""` (client renders no backdrop, not a broken scope) |
| `test_image_scope_is_additive_existing_location_fields_preserved` | all pre-existing location fields survive alongside the new key |
| `test_tokens_carry_conditions_list` | ally + foe conditions flow through to the token |
| `test_conditions_is_empty_list_no_op_when_absent` | conditionless combatant yields `[]` (never None/missing) → JSX no-ops |
| `test_conditions_is_always_a_list_of_strings` | type guard for the chip render |

**Run:**
```
uv run --directory servers/engine python -m pytest ../../viewer/tests/test_combat_backdrop_conditions.py -q -p no:xdist
```

**Results:** new file 7 passed; existing `test_combat_surface.py` + `test_combat_event_cards.py` green (no regression); **full viewer suite: 731 passed, 1 skipped, 65 subtests passed**. Both JSX files validated against the same Babel `react` preset the browser uses.