### PR TITLE
feat(viewer): render NPC speaker portraits inline in the chronicle (#943)

### DIFF
--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -1671,14 +1671,27 @@ function LogEntry({ entry }) {
     const text = sanitizeNarration(entry.text);
     if (!text) return null;
     const speaker = cleanRowLabel(entry.who || entry.label);
+    // #943: render the speaker's PORTRAIT inline to the left of the dialogue, so the chronicle (the
+    // primary story view) shows WHO is speaking — same felt as the combat-backdrop fix (#937). The
+    // shared <Img> resolves `portrait-<name>` for canon NPCs/companions and degrades a missing scope
+    // (generic NPCs) to the app's neutral silhouette — the same degraded state used in party/camp/
+    // dialogue. A row WITHOUT a speaker stays byte-identical to before (no portrait, no layout change).
+    if (speaker) {
+      return (
+        <div style={{ margin: "10px 0", display: "flex", gap: 8, alignItems: "flex-start" }}>
+          <Img scope={"portrait-" + speaker} label={speaker} w={34} h={42} framed />
+          <div>
+            <span style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--royal)" }}>
+              {speaker}
+            </span>
+            <span className="body" style={{ marginLeft: 8, fontStyle: "italic" }}>{text}</span>
+          </div>
+        </div>
+      );
+    }
     return (
       <div style={{ margin: "10px 0" }}>
-        {speaker ? (
-          <span style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--royal)" }}>
-            {speaker}
-          </span>
-        ) : null}
-        <span className="body" style={{ marginLeft: speaker ? 8 : 0, fontStyle: "italic" }}>{text}</span>
+        <span className="body" style={{ marginLeft: 0, fontStyle: "italic" }}>{text}</span>
       </div>
     );
   }
@@ -1718,13 +1731,20 @@ function LogEntry({ entry }) {
         <div className="body" style={{ margin: "10px 0", color: "var(--ink-800)" }}>{entry.text}</div>
       );
     }
+    // #943: a NON-self actor is a named NPC — render their portrait inline to the left of the
+    // "Name — action" line (same <Img> + canon-resolves/generic-silhouette behavior as the dialogue
+    // branch). The self path (handled above) and the no-actorLabel path stay byte-identical — the
+    // player already knows they are the actor.
     return (
-      <div style={{ margin: "10px 0" }}>
-        <span style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--ink-900)" }}>
-          {actorLabel}
-        </span>
-        <span className="hand" style={{ marginLeft: 8, color: "var(--ink-700)" }}>—</span>
-        <span className="body" style={{ marginLeft: 8, color: "var(--ink-800)" }}>{entry.text}</span>
+      <div style={{ margin: "10px 0", display: "flex", gap: 8, alignItems: "flex-start" }}>
+        <Img scope={"portrait-" + actorLabel} label={actorLabel} w={34} h={42} framed />
+        <div>
+          <span style={{ fontFamily: "var(--f-display)", fontSize: 12, letterSpacing: "0.18em", textTransform: "uppercase", color: "var(--ink-900)" }}>
+            {actorLabel}
+          </span>
+          <span className="hand" style={{ marginLeft: 8, color: "var(--ink-700)" }}>—</span>
+          <span className="body" style={{ marginLeft: 8, color: "var(--ink-800)" }}>{entry.text}</span>
+        </div>
       </div>
     );
   }

--- a/viewer/tests/test_chronicle_hygiene.py
+++ b/viewer/tests/test_chronicle_hygiene.py
@@ -143,7 +143,14 @@ def _render_log_entries(entries: list[dict]) -> list[str]:
         + " props: props||{}, children: children.flat(Infinity).filter(c=>c!=null) }; }\n"
         + "const React = { useState:()=>[null,()=>{}], useRef:()=>({}), useCallback:f=>f, useEffect:()=>{},"
         + " createElement:h, Fragment:'F' };\n"
-        + "const sb = { React }; sb.window = sb; vm.createContext(sb); vm.runInContext(code, sb);\n"
+        # #943: in the browser, screen-table.jsx and chrome.jsx are sibling <script type='text/babel'>
+        # tags that share one global scope, so screen-table can reference chrome's <Img> (the speaker
+        # portrait now rendered inline on dialogue/named-action rows) as a global. This harness transpiles
+        # ONLY screen-table.jsx in isolation, so we stub the cross-file <Img> on the shared sandbox global
+        # exactly as chrome.jsx publishes it (`Object.assign(window, { Img })`). The stub returns no text,
+        # so every visible-text assertion below is unchanged — this only resolves the bare cross-file ref.
+        + "const Img = (props) => h('Img', props);\n"
+        + "const sb = { React, Img }; sb.window = sb; vm.createContext(sb); vm.runInContext(code, sb);\n"
         + "const LogEntry = sb.window.LogEntry;\n"
         + "if (typeof LogEntry !== 'function') throw new Error('LogEntry not exported on window');\n"
         + "function textOf(n){ if(n==null) return ''; if(typeof n==='string'||typeof n==='number') return String(n);"


### PR DESCRIPTION
## The gap (verified)

The chronicle / session-log is the **primary story view**, but `LogEntry`
(`viewer/openworlds/screen-table.jsx`) rendered the speaker/actor *name* in
**text only** — no face — in two branches:

- the **DIALOGUE** branch (engine `dialogue` recentEvents rows), and
- the **named-ACTION** branch (the non-self `actorLabel` path — an NPC the
  engine names).

Seeing **who** speaks is high-felt — the same gap the combat-backdrop fix
(#937) closed for combat scenes.

## The change (additive, viewer read-only)

Render the speaker's **portrait inline to the left** of the name + text block
(a compact flex row, `gap: 8`, `alignItems: flex-start`), reusing the **proven
shared `<Img>`** the party panel already uses (`scope` / `label` / `w` / `h` /
`framed`) — no new image component:

```jsx
<Img scope={"portrait-" + speaker} label={speaker} w={34} h={42} framed />
```

- **DIALOGUE branch** — when `speaker` is truthy, render the portrait slot;
  when empty/falsey the row renders **byte-identical to today** (no portrait,
  no layout change).
- **named-ACTION branch** — when `actorLabel` is truthy (non-self NPC), render
  the portrait slot. The **self path** (`isSelf` → "You") and the
  **no-actorLabel path** stay byte-identical — the player already knows they
  are the actor.
- The `narration` / `roll` / `dialog` / fallback branches are **untouched** —
  narration rows have no speaker and get **no** portrait.

## Canon resolves / generic silhouette (no server change)

`scope="portrait-<name>"` is servable for canon NPCs/companions — empirically
`portrait-Astarion` / `portrait-Shadowheart` / `portrait-Wyll` / `portrait-Rolan`
/ `portrait-Florrick` all resolve (the server's `_safe_scope` handles casing +
spaces). A **generic** NPC (Sergeant Crale, A Guard) 404s, and the shared
`<Img>` degrades a portrait-scope miss to the app's neutral
`PortraitSilhouette` — the **same degraded state** used everywhere else
(party / camp / dialogue). Canon faces resolve; generics get a neutral
silhouette. **No server / surface change.**

## Harness-limitation note

This is a **JSX-render-only** change. The Python viewer harness structurally
**cannot revert-check a render** (accepted limitation; precedent:
condition-chips in #937) — it asserts the **visible text** of a `LogEntry`,
not its layout. The chronicle-hygiene test transpiles `screen-table.jsx` in
**isolation**, so the cross-file `<Img>` — published by `chrome.jsx` onto the
shared `window` global in the browser (`Object.assign(window, { Img })`) — was
undefined in the sandbox. The test sandbox now stubs `Img` exactly as
`chrome.jsx` publishes it; the stub yields **no text**, so every visible-text
assertion is unchanged. Please **manually review** the render slot.

## Verification

- Viewer suite green single-process: `uv run --directory servers/engine python
  -m pytest ../../viewer/tests/ -q -p no:xdist` → **732 passed, 1 skipped, 65
  subtests passed**.
- `screen-table.jsx` parses cleanly under the **in-page Babel `react` preset**
  (the same transform the browser uses) — no syntax error.

Do **not** merge — for review.