### PR TITLE
fix: strip removable-volume env-var leak (.app + QA harness) — LEXAR popup + viewer-not-ready P0

### DIFF
--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/AppProcessService.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/AppProcessService.swift
@@ -312,7 +312,13 @@ final class AppProcessService: ObservableObject {
         stream: LogStream,
         providerMetadata: ProviderLaunchMetadata? = nil
     ) throws -> ManagedProcess {
-        var mergedEnvironment = ProcessInfo.processInfo.environment
+        // Drop foreign env vars that point at a removable volume (e.g. GBRAIN_SKILLS_DIR=/Volumes/…
+        // inherited from a shell launch's ~/.zshenv) BEFORE merging the caller's overlay. A child
+        // reading one enumerates the volume → a modal removable-volume TCC prompt that can't be
+        // answered headlessly: it blocks every shell-launched GUI run and stalls viewer startup.
+        // The caller's `environment` (the app's own WORLDOS_* roots, which may intentionally be on
+        // /Volumes for a removable-volume worktree) is applied AFTER, so it survives.
+        var mergedEnvironment = EnvironmentBootstrap.withoutRemovableVolumeLeaks(ProcessInfo.processInfo.environment)
         environment.forEach { key, value in mergedEnvironment[key] = value }
 
         let process = Process()

--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/EnvironmentBootstrap.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/EnvironmentBootstrap.swift
@@ -43,6 +43,30 @@ enum EnvironmentBootstrap {
         return merged.joined(separator: ":")
     }
 
+    /// Strip inherited env vars whose VALUE points at a removable volume (`/Volumes/...`) before
+    /// they reach a child process. A child handed such a var enumerates the volume to read it,
+    /// which fires a modal "WorldOS would like to access files on a removable volume" TCC prompt.
+    ///
+    /// WHY (the P0 this fixes): the launching shell's `~/.zshenv` can export a foreign tool's path
+    /// onto a removable disk — observed: `GBRAIN_SKILLS_DIR=/Volumes/LEXAR/repos/eva-brain/skills`.
+    /// `.zshenv` is sourced by EVERY zsh, so any shell-launched app (`open -n` from a build/QA
+    /// script) inherits it; we then merge the full inherited environment into every viewer/provider
+    /// we spawn (`AppProcessService.launchManagedProcess`), and the provider's skills loader reads
+    /// `GBRAIN_SKILLS_DIR` → enumerates `/Volumes/LEXAR` → the prompt. It can't be answered
+    /// headlessly, so it blocks unattended/CI builds and every shell-launched GUI run, and the
+    /// modal stalls viewer startup ("viewer did not become ready"). The app needs NONE of these
+    /// foreign vars.
+    ///
+    /// The app's OWN repo/art roots — which may legitimately live on a removable-volume worktree —
+    /// are re-applied by the caller's explicit `environment` overlay (merged AFTER this filter), so
+    /// an intentional `/Volumes` WorldOS root still survives. We match `hasPrefix("/Volumes/")` on
+    /// the VALUE: this targets bare single-path vars (the real-world offender) and never touches
+    /// PATH or any `:`-separated list (those don't START with `/Volumes/`), so tool discovery is
+    /// unaffected. Pure + deterministic.
+    static func withoutRemovableVolumeLeaks(_ environment: [String: String]) -> [String: String] {
+        environment.filter { _, value in !value.hasPrefix("/Volumes/") }
+    }
+
     /// The well-known macOS dev-tool install locations, filtered to those that actually exist on
     /// this machine. Covers the overwhelming majority of setups: `claude`/`uv` via the standard
     /// installer (`~/.local/bin`) and `codex`/`openclaw`/`uv`/`node`/`gh`/`python3` via Homebrew

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -30,7 +30,11 @@
 # worktree) are preserved. Shell mirror of the native app's
 # EnvironmentBootstrap.withoutRemovableVolumeLeaks filter.
 for _wos_rmvol_k in $(env | awk -F= '$2 ~ /^\/Volumes\// {print $1}'); do
-  case "$_wos_rmvol_k" in WORLDOS_*|CLAWDND_*) continue ;; esac
+  # Skip our own roots, and any non-identifier token: a value with an embedded newline can make
+  # awk emit a bogus "key", and `unset` on a non-identifier errors — which would abort a future
+  # sourcer that runs `set -e`. (Today's sourcers use `set -uo pipefail` only, so this is belt-and-
+  # suspenders to keep the shared lib safe regardless of the caller's shell options.)
+  case "$_wos_rmvol_k" in WORLDOS_*|CLAWDND_*|""|[0-9]*|*[!A-Za-z0-9_]*) continue ;; esac
   unset "$_wos_rmvol_k"
 done
 unset _wos_rmvol_k

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -20,6 +20,21 @@
 # Sourced by BOTH loops so the two harnesses can't drift. Pure bash + a tiny `uv run` python
 # shim into servers/engine (the engine's venv has the deps; bare python3 does not).
 
+# --- Removable-volume env hygiene (the LEXAR-popup P0) -----------------------------
+# Strip inherited env vars whose value points at a removable volume (/Volumes/...) — e.g.
+# GBRAIN_SKILLS_DIR=/Volumes/LEXAR/... exported unconditionally by a user's ~/.zshenv. The DM is
+# a `claude -p` child of this shell; claude's skills loader reads such a var and enumerates the
+# volume → a modal "WorldOS would like to access files on a removable volume" TCC prompt that
+# can't be answered headlessly and silently stalls/blocks the QA + dogfood run. The harness needs
+# none of them; our OWN roots (WORLDOS_*/CLAWDND_*, which may intentionally live on a /Volumes
+# worktree) are preserved. Shell mirror of the native app's
+# EnvironmentBootstrap.withoutRemovableVolumeLeaks filter.
+for _wos_rmvol_k in $(env | awk -F= '$2 ~ /^\/Volumes\// {print $1}'); do
+  case "$_wos_rmvol_k" in WORLDOS_*|CLAWDND_*) continue ;; esac
+  unset "$_wos_rmvol_k"
+done
+unset _wos_rmvol_k
+
 # --- WorldOS rename env-compat (issue #295, W0-E) ---------------------------------
 # Resolve an env var by suffix, preferring WORLDOS_<suffix> and falling back to the
 # legacy CLAWDND_<suffix> (one-time stderr deprecation warning), else a default.


### PR DESCRIPTION
## P0 — the LEXAR removable-volume popup that breaks live GUI runs + autonomy

A user's `~/.zshenv` exports `GBRAIN_SKILLS_DIR=/Volumes/LEXAR/repos/eva-brain/skills` (a foreign tool's path on a **removable volume**). `.zshenv` is sourced by **every** zsh, so any **shell-launched** WorldOS — the `.app` via `open -n` from a build/QA script, OR the shell QA loops — inherits it. Children that read it (the viewer; `claude`'s skills loader) **enumerate the removable volume** → a modal *"WorldOS would like to access files on a removable volume"* TCC prompt. It can't be answered headlessly: it blocked every shell-launched GUI run + the autonomy/QA path, and the modal **stalled viewer startup** → the GUI showed *"Viewer did not become ready at …/openworlds/: Could not connect to the server."*

(Not hit by a Finder/Dock double-click — `launchctl` env has no `GBRAIN_SKILLS_DIR`. It's specifically the shell-launch / autonomy path.)

## Fix (two layers, one root cause)
1. **App** (`AppProcessService.launchManagedProcess`): `EnvironmentBootstrap.withoutRemovableVolumeLeaks()` drops inherited env vars whose value `hasPrefix("/Volumes/")` **before** merging the caller's overlay — so the viewer + every provider spawn clean. The app's OWN repo/art roots (which may legitimately be on a `/Volumes` worktree) are re-applied by the explicit `environment` overlay merged **after** the filter, so they survive. PATH / `:`-lists untouched (they don't START with `/Volumes/`).
2. **QA harness** (`qa/lib_beat_driver.sh`, sourced by play.sh/play_party.sh/run_duo.sh/run_party.sh): the same strip on source, preserving `WORLDOS_*`/`CLAWDND_*`.

## Verified
- Fix-built `.app` launched **with `GBRAIN_SKILLS_DIR` set** → its viewer env `GBRAIN=0` (clean), viewer binds + serves `/state` 200 + `/openworlds/` 200, **no popup**. (Pre-fix: viewer `GBRAIN=1`, popup, viewer-not-ready.)
- Shell guard: `GBRAIN_SKILLS_DIR` stripped, `WORLDOS_REPO_ROOT=/Volumes/...` **preserved**, PATH intact, shellcheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted macOS permission prompts when launching background subprocesses by filtering out environment entries that reference removable volumes before they’re forwarded. This helps prevent unnecessary TCC dialogs and makes process startup feel more reliable.
* **Chores / QA**
  * Updated the QA harness environment handling to avoid inheriting removable-volume-related variables, improving consistency during automated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->