### PR TITLE
qa(phase-1): autonomous-QA foundation — regression base, scoring determinism, test infra, cadence, velocity

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,23 @@
+# Coverage configuration for WorldOS / ClawDnD (QA Lab Phase-1, additive).
+#
+# Report-only: this file controls what coverage.py measures and which paths it
+# omits. It deliberately does NOT set fail_under -- coverage stays advisory so
+# CI cannot flake on a threshold. The ci-integrator wires the actual
+# `--cov=. --cov-report=term-missing` report flags onto the pytest steps.
+[run]
+branch = True
+omit =
+    */tests/*
+    */__pycache__/*
+    */.venv/*
+    */.venv-viewer/*
+
+[report]
+omit =
+    */tests/*
+    */__pycache__/*
+    */.venv/*
+    */.venv-viewer/*
+exclude_lines =
+    pragma: no cover
+    if __name__ == .__main__.:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,17 +12,23 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Engine tests
-        run: uv run --directory servers/engine --group dev pytest -q
+        # Phase-1 (DETERMINISTIC-3): coverage is report-only (no --cov-fail-under yet) so it
+        # surfaces untested paths without flaking CI. pytest-cov is in the dev group.
+        run: uv run --directory servers/engine --group dev pytest -q --cov=. --cov-report=term-missing
       - name: Rules tests
         env:
           CLAWDND_RULES_OFFLINE: "1"
-        run: uv run --directory servers/rules --group dev pytest -q
+        run: uv run --directory servers/rules --group dev pytest -q --cov=. --cov-report=term-missing
       - name: Voice tests (torch-free; null backend + static metadata)
-        run: uv run --directory servers/voice --group dev pytest -q
+        run: uv run --directory servers/voice --group dev pytest -q --cov=. --cov-report=term-missing
       - name: Single-flight launch-guard test (scripts/launch_common.sh lock)
         # Pure bash + POSIX mkdir/kill -0/rm — no uv/claude/viewer. Proves a second concurrent
         # play_party.sh cold-open is cleanly rejected and the lock self-heals (release / dead holder).
         run: bash qa/test_play_party_single_flight.sh
+      - name: Velocity-gates test (fast_gate green-cache + release_gate RAM preflight; pure bash)
+        # Phase-1 (VELOCITY-1/4): proves the opt-in fast_gate cache short-circuits a same-SHA
+        # rerun and the release_gate RAM preflight refuses a sweep under a forced-low-RAM stub.
+        run: bash qa/test_velocity_gates.sh
 
   viewer-tests:
     # The viewer is where most recent regressions landed, but its suite was not in
@@ -82,7 +88,28 @@ jobs:
             ../../qa/test_scores_db.py \
             ../../qa/test_release_gate_static.py \
             ../../qa/test_ui_playtest_score_image_outcomes.py \
-            ../../qa/test_claude_auth_isolation.py
+            ../../qa/test_claude_auth_isolation.py \
+            ../../qa/test_snapshot_world_state.py \
+            ../../qa/test_score_determinism.py \
+            ../../qa/test_lens_variance.py
+
+  server-contracts:
+    # Phase-1 (DETERMINISTIC-2): deterministic cross-service MCP contract tests
+    # (engine<->rules<->voice; null/torch-free voice backend, offline rules). The rules
+    # boundary runs through the rules venv (rapidfuzz), so sync BOTH servers before running.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+      - name: Sync rules venv (rapidfuzz/httpx for the offline rules worker)
+        env:
+          CLAWDND_RULES_OFFLINE: "1"
+        run: uv sync --directory servers/rules
+      - name: Cross-service MCP contract tests
+        env:
+          CLAWDND_RULES_OFFLINE: "1"
+        run: uv run --directory servers/engine --group dev python -m pytest -q -p no:xdist ../../servers/integration_tests
 
   license-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-quality-loop.yml
+++ b/.github/workflows/nightly-quality-loop.yml
@@ -1,0 +1,136 @@
+name: Nightly Quality Loop
+
+# The STANDING fitness cadence the harness lacked: qa/loop.sh (the recursive-improvement
+# loop gate) is never scheduled today, so a post-release regression in story-craft /
+# mechanical quality has nothing watching for it. This workflow runs the loop on a nightly
+# cron (plus on-demand) against the north-star thresholds (CLAWDND_STORY_MIN / CLAWDND_MECH_MIN).
+#
+# The duo path (qa/run_duo.sh) cold-opens a real `claude -p` DM+player, so it needs a live
+# model key. That key is provided as the repository secret ANTHROPIC_API_KEY:
+#   * secret PRESENT  -> run the live loop (K small) and post the scorecard.
+#   * secret ABSENT   -> SKIP the live loop and run a deterministic dry-run / self-check
+#                        instead, so this workflow is always present and green-able even
+#                        before the secret is added.
+#
+# Soft-fail by design: this cadence ALERTS, it never blocks merges. continue-on-error keeps
+# the job from going red on a below-bar loop result; the runlog + scorecard are uploaded as
+# an artifact for triage. The uv / checkout setup mirrors .github/workflows/ci.yml.
+
+on:
+  schedule:
+    # 09:17 UTC nightly (~02:17 America/Los_Angeles) — off the top of the hour to avoid
+    # the GitHub-cron thundering herd. cron is UTC-only on GitHub Actions.
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: "Number of duo runs (K) for the loop (small by default)."
+        required: false
+        default: "2"
+      beats:
+        description: "Beats per duo run."
+        required: false
+        default: "8"
+      budget:
+        description: "Per-call budget (USD) passed to qa/run_duo.sh."
+        required: false
+        default: "1.20"
+
+# Don't pile up nightly runs on top of each other; cancel an in-flight nightly when a newer
+# trigger lands. Manual dispatches still queue behind the cron group cleanly.
+concurrency:
+  group: nightly-quality-loop
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  quality-loop:
+    runs-on: ubuntu-latest
+    # Soft-fail: a below-bar loop (loop.sh exit 1) ALERTS via the uploaded scorecard but does
+    # NOT fail the job or block other merges. The deterministic self-check step below is the
+    # only hard gate, so a structurally broken harness is still caught.
+    continue-on-error: true
+    env:
+      # North-star thresholds the loop gates against (defaults mirror qa/loop.sh).
+      CLAWDND_STORY_MIN: "4.3"
+      CLAWDND_MECH_MIN: "4.5"
+      # K small (2 duos) for a nightly cadence; overridable on manual dispatch.
+      LOOP_RUNS: ${{ github.event.inputs.runs || '2' }}
+      LOOP_BEATS: ${{ github.event.inputs.beats || '8' }}
+      LOOP_BUDGET: ${{ github.event.inputs.budget || '1.20' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Detect live model key
+        id: keycheck
+        # The duo path needs a live model key. Gate the live loop on the repository secret
+        # ANTHROPIC_API_KEY; if it's absent we fall back to the deterministic self-check so the
+        # workflow is always present and green-able even before the secret is added.
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Nightly Quality Loop::ANTHROPIC_API_KEY present — running the live loop (K=${LOOP_RUNS})."
+          else
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Nightly Quality Loop::ANTHROPIC_API_KEY absent — skipping live loop, running deterministic self-check only."
+          fi
+
+      - name: Deterministic dry-run / self-check (no model key needed)
+        # ALWAYS runs. This is the hard gate of the workflow: it proves the loop harness is
+        # structurally intact (loop.sh parses, the per-run worker + thresholds resolve) without
+        # touching a model, the gateway, Eva, or any global mcp config. Gateway-free / null-backend.
+        run: |
+          set -euo pipefail
+          echo "[selfcheck] bash -n on the loop gate + its per-run worker"
+          bash -n qa/loop.sh
+          bash -n qa/run_duo.sh
+          echo "[selfcheck] loop gate + worker are present and executable"
+          test -x qa/loop.sh
+          test -x qa/run_duo.sh
+          echo "[selfcheck] north-star thresholds resolve: story>=${CLAWDND_STORY_MIN} mech>=${CLAWDND_MECH_MIN}"
+          # jq is the loop's scorecard tool; ubuntu-latest ships it, but assert it explicitly so a
+          # runner-image change can't silently neuter the loop's scoring.
+          command -v jq >/dev/null || { echo "::error title=Nightly Quality Loop::jq missing on runner"; exit 1; }
+          echo "[selfcheck] OK"
+
+      - name: Run the loop (live) — K small against the north-star bar
+        if: steps.keycheck.outputs.has_key == 'true'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        # The loop wraps K duo runs (each isolated, dual-lens scored + behavioral gate) and exits
+        # 1 if any run is below the bar. We DON'T let that fail the step (`|| true`) because this
+        # cadence is an alert, not a merge gate — the scorecard artifact carries the verdict.
+        run: |
+          set -uo pipefail
+          mkdir -p qa/transcripts
+          echo "[nightly] qa/loop.sh ${LOOP_RUNS} (beats=${LOOP_BEATS} budget=${LOOP_BUDGET})"
+          qa/loop.sh "${LOOP_RUNS}" baldurs-gate qa/play_player_duo.txt "${LOOP_BEATS}" "${LOOP_BUDGET}" \
+            2>&1 | tee qa/transcripts/nightly-loop.runlog || true
+          # Surface a below-bar result as a workflow annotation (soft alert, non-blocking).
+          if grep -qE '\[BELOW\]' qa/transcripts/nightly-loop.runlog 2>/dev/null; then
+            echo "::warning title=Nightly Quality Loop::One or more duo runs are BELOW the north-star bar — see the uploaded scorecard."
+          fi
+
+      - name: Upload loop runlog + scorecard
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-quality-loop-${{ github.run_id }}
+          # The loop writes per-run *.runlog / *.tolkien.json / *.score.json / *.gate.txt into
+          # qa/transcripts/. Upload whatever exists (the self-check-only path leaves just the
+          # runlog from this step, if any) — if-no-files-found: ignore keeps the no-key path green.
+          path: |
+            qa/transcripts/nightly-loop.runlog
+            qa/transcripts/loop-*.runlog
+            qa/transcripts/loop-*.tolkien.json
+            qa/transcripts/loop-*.score.json
+            qa/transcripts/loop-*.gate.txt
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -88,4 +88,11 @@ venv/
 
 # fast-gate rotation counter (Tier 1)
 /qa/.fast_gate_iter
+# fast-gate OPT-IN green-cache (CLAWDND_FASTGATE_CACHE=1) — cached GREEN verdicts keyed on
+# (git HEAD + persona + gate args). Pure inner-loop convenience; regenerable; never committed.
+/qa/.cache/
+# pytest-cov data files (coverage is report-only in CI; the .coverage db is never committed)
+.coverage
+.coverage.*
+servers/*/.coverage
 .qa-archive/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,66 @@
+# WorldOS / ClawDnD — minimal, OPT-IN pre-commit config (inner-loop friction-cutter).
+#
+# This is intentionally TINY and ADDITIVE: it does NOT run the test suite on every commit
+# (the 16GB host OOMs on parallel test workers — full/heavy runs always go to GitHub CI). It
+# runs only the two cheap, deterministic things worth catching BEFORE a commit lands:
+#
+#   1. license_check — the same fast committed-content gate CI runs (FORBIDDEN private-content
+#      prefixes + required licensing/attribution files). Catching a forbidden-path commit here
+#      saves a CI round-trip and a force-push to scrub history.
+#   2. pytest-focus-hint — a NON-blocking HINT that prints the focused, single-process pytest
+#      command for the engine tests touched by your staged change. It never runs pytest itself
+#      (so it can never OOM the host); it just hands you the exact command to run by hand.
+#
+# Enable locally (never required, never wired into CI):
+#   pip install pre-commit && pre-commit install
+# Run on demand without installing the git hook:
+#   pre-commit run --all-files
+#
+# The heavy verification path is unchanged: focused `uv run --directory servers/engine python -m
+# pytest -p no:xdist <file>` for the inner loop, and GitHub CI for the full suite.
+minimum_pre_commit_version: "2.20.0"
+default_install_hook_types: [pre-commit]
+
+repos:
+  - repo: local
+    hooks:
+      # 1. Fast committed-content / license gate (mirrors CI: `python3 scripts/license_check.py`).
+      - id: license-check
+        name: license_check (forbidden private content + required attribution)
+        entry: python3 scripts/license_check.py
+        language: system
+        pass_filenames: false
+        always_run: true
+
+      # 2. Focused changed-files pytest HINT — prints (does NOT run) the single-process pytest
+      #    command for the engine test files matching your staged change. Never blocks a commit
+      #    (verbose=true, always exits 0). Single-process by design (-p no:xdist); never xdist.
+      - id: pytest-focus-hint
+        name: pytest focus hint (changed engine tests — single-process; manual run)
+        # Literal block scalar so the embedded bash (with its case-colons) parses cleanly.
+        entry: |
+          bash -c '
+          changed=$(git diff --cached --name-only --diff-filter=ACM | grep -E "^servers/engine/.*[.]py$" || true)
+          [ -z "$changed" ] && exit 0
+          tests=""
+          for f in $changed; do
+            rel=${f#servers/engine/}
+            if [ "${rel#tests/}" != "$rel" ]; then
+              tests="$tests $rel"
+            else
+              base=$(basename "$rel" .py)
+              [ -f "servers/engine/tests/test_${base}.py" ] && tests="$tests tests/test_${base}.py"
+            fi
+          done
+          tests=$(printf "%s" "$tests" | tr " " "\n" | sort -u | tr "\n" " ")
+          if [ -n "$(printf "%s" "$tests" | tr -d " ")" ]; then
+            echo "  hint: focused single-process run for your staged engine change:"
+            echo "    uv run --directory servers/engine python -m pytest -q -p no:xdist $tests"
+          else
+            echo "  hint: staged engine code has no obviously-matching test file — consider adding one."
+          fi
+          exit 0'
+        language: system
+        pass_filenames: false
+        verbose: true
+        always_run: true

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -63,3 +63,49 @@ Default DM/player model = `sonnet` (`CLAWDND_DM_MODEL` / `CLAWDND_ACTOR_MODEL` e
 `[duo] done. story-craft=X mechanical=Y angry-dm=Z behavioral=GREEN|RED`
 - **RED** ⇒ X/Y/Z are RED-capped; read `$RUN.gate.txt` for the failed checks.
 - **GREEN** ⇒ real scores; compare against the North-Star targets and append via `qa/scores_db.py` `add_run(...)` (→ `scores_ledger.md`; `SCORECARD.md` is legacy).
+
+## 6. Variance & noise floor
+The three LLM lenses are **stochastic graders**: re-scoring the *same comparable run* yields
+a slightly different `overall` each time. You cannot read a score without knowing this
+jitter — a single 4.2 and a single 4.4 may be the same run scored twice. This section
+records the measured per-lens noise and the rule for when a single run is trustworthy.
+
+**How it's measured.** A "comparable cluster" = ≥2 **GREEN** runs that share the same
+`build_sha` + `surface` + `methodology` + `scorer_model` (+ ruler, when stamped). The
+spread (population stdev / range) of `overall` *within* a cluster is the scoring noise,
+because everything else is held fixed. We read this from the on-disk ledger
+(`qa/scores.db`: `story_overall` / `mech_overall` / `angrydm_overall`) and from any
+committed per-lens scorecards in `qa/transcripts/` (`*.tolkien.json` / `*.score.json` /
+`*.angrydm.json`). RED-capped scores are excluded (they're rubric-capped, not real).
+
+**Measured per-lens noise floor** (max within-cluster spread, GREEN, comparable; from the
+committed `qa/scores.db`, 2026-06-16 snapshot, 75 rows):
+
+| Lens | Measured max stdev | Measured max range | Documented floor (stdev / range) |
+|---|---|---|---|
+| **Story-craft** (Tolkien) | 0.15 | 0.30 | **0.20 / 0.40** |
+| **Mechanical** | 0.25 | 0.50 | **0.30 / 0.60** |
+| **Angry-DM** (5e fidelity) | 0.35 | 0.70 | **0.40 / 0.80** |
+
+The **documented floor** rounds the measured spread UP for a little headroom and is the
+contract enforced by `qa/test_lens_variance.py` (the test goes RED if a future re-score
+blows past it, forcing a conscious re-derivation of *both* this table and the test
+constant — they must stay mirrored). **Angry-DM is the noisiest lens** (adversarial,
+exhaustive 5e checklist), so it leans on median-of-N hardest. As the corpus grows, re-run
+the test's `__main__` diagnostic (`python3 qa/test_lens_variance.py`) and tighten the floor
+toward the new measured max.
+
+**The rule — single-duo for velocity, median-of-N for gating:**
+- **Velocity / inner loop:** a **single duo** is fine. Treat any score as `X ± floor`; a
+  delta smaller than the lens floor (e.g. story moved 4.2 → 4.3, < 0.40 range) is **noise,
+  not signal** — don't chase it.
+- **Release / auto-merge gating:** use the **median of N ≥ 3** comparable re-scores. The
+  median of 3 collapses worst-case single-run jitter to well inside the noise band (a
+  single run can sit a full half-floor from truth; the median of a straddling triple does
+  not), so a North-Star call (story ≥ 4.3, mech ≥ 4.5) is made against the median, not a
+  lucky/unlucky single draw. When a release decision hinges on a margin **smaller than the
+  lens floor**, N=3 is the minimum; widen to N=5 for the angry-dm lens specifically.
+- A score reported without N is implicitly N=1 — acceptable for velocity, **never** for a
+  gate. `qa/test_lens_variance.py` is the deterministic, CI-safe guard that keeps this
+  floor honest (it reads only on-disk artifacts; live re-derivation is an explicit,
+  opt-in, non-CI step gated behind `CLAWDND_LIVE_SCORER=1`).

--- a/qa/_score_prompt_hash.py
+++ b/qa/_score_prompt_hash.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Tiny, dependency-free helper that computes the scorer's `prompt_construction_hash`.
+
+WHY THIS EXISTS
+---------------
+`qa/score.sh` assembles a scoring prompt from (a) a lens rubric file, (b) an output
+schema file, and (c) a FIXED template scaffold (section headers + the JSON-only
+instruction). Over time the rubric or the scaffold can drift — and because the
+scorecard number depends on the prompt the LLM saw, a silent rubric/template change
+can move scores without anyone noticing. To make that drift *detectable*, we stamp a
+stable fingerprint into every score JSON artifact: the SHA-256 of
+
+    rubric-file-contents  +  schema-file-contents  +  the static template scaffold
+
+and DELIBERATELY NOT the transcript or the engine state (those vary per run, so the
+fingerprint stays constant across runs of the same lens — only rubric/template/schema
+edits move it). Identical rubric+template ⇒ identical hash; edit the rubric content ⇒
+the hash changes. That is exactly the property the determinism test asserts.
+
+This is the SINGLE source of truth for the scaffold + the hash recipe so that
+`score.sh` (which calls this module via `python`) and the test agree by construction —
+neither re-implements the string.
+
+ADDITIVE / SAFE: this module only reads files and prints a hex digest; it never writes
+state, never touches the engine, the gateway, Eva, or any global config.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import sys
+
+# The FIXED prompt scaffold that score.sh wraps around the rubric/schema/transcript/state.
+# This MUST stay byte-identical to the template string in qa/score.sh (the printf format,
+# with the runtime-substituted segments — rubric/schema/transcript/state — represented by
+# the {rubric}/{schema}/{transcript}/{state} placeholders). The hash covers the rubric +
+# schema CONTENTS and this scaffold, but NOT the transcript/state values, so it is stable
+# across runs and only moves when the rubric, schema, or this scaffold change.
+PROMPT_TEMPLATE_SCAFFOLD = (
+    "{rubric}\n\n"
+    "# ===== OUTPUT FORMAT =====\n"
+    "Respond with ONLY a single JSON object conforming to this schema — "
+    "no prose, no markdown, no code fences:\n"
+    "{schema}\n\n"
+    "# ===== DISTILLED TRANSCRIPT =====\n"
+    "{transcript}\n\n"
+    "# ===== FINAL ENGINE STATE (ground truth) =====\n"
+    "{state}\n"
+)
+
+
+def prompt_construction_hash(rubric_text: str, schema_text: str, scaffold: str = PROMPT_TEMPLATE_SCAFFOLD) -> str:
+    """Return the SHA-256 hex digest of (rubric contents + schema contents + scaffold).
+
+    The transcript and engine state are intentionally excluded — see the module docstring.
+    Inputs are joined with explicit NUL separators so that no concatenation collision is
+    possible (e.g. moving a trailing char between the rubric and the schema can never
+    yield the same digest).
+    """
+    h = hashlib.sha256()
+    for part in (rubric_text, schema_text, scaffold):
+        h.update(part.encode("utf-8"))
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+def hash_from_files(rubric_path: str, schema_path: str, scaffold: str = PROMPT_TEMPLATE_SCAFFOLD) -> str:
+    """Read the rubric + schema files (utf-8) and return the prompt_construction_hash."""
+    with open(rubric_path, encoding="utf-8") as fh:
+        rubric_text = fh.read()
+    with open(schema_path, encoding="utf-8") as fh:
+        schema_text = fh.read()
+    return prompt_construction_hash(rubric_text, schema_text, scaffold)
+
+
+def main(argv: list[str]) -> int:
+    """CLI: `_score_prompt_hash.py <rubric.md> <schema.json>` → prints the hex digest.
+
+    Used by score.sh via `python …` so the shell never re-implements the recipe.
+    """
+    if len(argv) != 3:
+        sys.stderr.write("usage: _score_prompt_hash.py <rubric.md> <schema.json>\n")
+        return 2
+    sys.stdout.write(hash_from_files(argv[1], argv[2]))
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/qa/fast_gate.sh
+++ b/qa/fast_gate.sh
@@ -19,22 +19,82 @@ set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 2
 LOG="${TMPDIR:-/tmp}/wos_fastgate_t0.log"
 
-echo "── FAST-GATE Tier 0 — deterministic engine + seat-path + rest/travel + combat ($0) ──"
-# Per the QA cost/signal map, these gate signals are FREE + INSTANT (no LLM, no cold-open world build):
-#   - test_canon_abilities  : SEAT-PATH skill correctness (the optimizer skill-case crit) + ability derivation (G2 data)
-#   - test_character_skill_normalization : the model-boundary skill-name normalizer (G2)
-#   - test_rests            : rest-that-restores HP/slots + advances the clock (G1 rest limb)
-#   - test_travel           : travel-that-moves location + clock (G1 travel limb)
-#   - test_combat           : combat resolved THROUGH the engine — start_combat/attack/rounds (G1 combat limb)
-TESTS="tests/test_canon_abilities.py tests/test_character_skill_normalization.py tests/test_rests.py tests/test_travel.py tests/test_combat.py"
+# ── OPT-IN green-cache (CLAWDND_FASTGATE_CACHE=1; default OFF == today's behavior) ──────────────
+# Re-running the gate on an UNCHANGED tree is pure waste: the deterministic tier is a pure function
+# of the working tree. When the cache is enabled we key a GREEN verdict on (git HEAD + persona +
+# gate args) and short-circuit an identical re-run to the cached verdict instead of re-running the
+# inner gate. This is an INNER-LOOP convenience only — strictly additive (off by default), never
+# wired into CI, and a RED result is NEVER cached (so a failure is always reproducible).
+#   CLAWDND_FASTGATE_CACHE=1        — turn the cache ON (default empty/0 = off = run every time).
+#   CLAWDND_FASTGATE_CACHE_DIR=...  — override the cache root (default qa/.cache/fastgate; gitignored).
+#   CLAWDND_FASTGATE_PERSONA=...    — persona discriminator folded into the key (default "default").
+#   CLAWDND_FASTGATE_INNER_CMD=...  — test seam: run this instead of the real pytest tier (mockable).
+_fastgate_cache_enabled() { [ "${CLAWDND_FASTGATE_CACHE:-0}" = "1" ]; }
 
-if uv run --directory servers/engine python -m pytest -q -p no:xdist $TESTS >"$LOG" 2>&1; then
-  echo "  ✓ deterministic engine tier: $(grep -oE '[0-9]+ passed' "$LOG" | tail -1)"
-else
+_fastgate_cache_key() {
+  # Key the cached verdict on the exact tree + persona + invocation. HEAD is the cheap proxy for the
+  # tree; a dirty tree still re-uses the key, so the cache is for clean SHA-pinned re-runs (the
+  # documented use). The persona + gate-args make the key persona/arg specific.
+  local head persona args
+  head="$(git rev-parse HEAD 2>/dev/null || echo nohead)"
+  persona="${CLAWDND_FASTGATE_PERSONA:-default}"
+  args="${FASTGATE_ARGS:-$*}"
+  printf '%s' "$head|$persona|$args" \
+    | { command -v shasum >/dev/null 2>&1 && shasum -a 256 || md5; } \
+    | awk '{print $1}'
+}
+
+# Inner deterministic tier — the real work. Returns the inner gate exit code. The test seam lets a
+# bash test substitute a mock that does not need uv/pytest (and counts its own invocations).
+_fastgate_run_inner() {
+  if [ -n "${CLAWDND_FASTGATE_INNER_CMD:-}" ]; then
+    "$CLAWDND_FASTGATE_INNER_CMD"
+    return $?
+  fi
+  echo "── FAST-GATE Tier 0 — deterministic engine + seat-path + rest/travel + combat ($0) ──"
+  # Per the QA cost/signal map, these gate signals are FREE + INSTANT (no LLM, no cold-open world build):
+  #   - test_canon_abilities  : SEAT-PATH skill correctness (the optimizer skill-case crit) + ability derivation (G2 data)
+  #   - test_character_skill_normalization : the model-boundary skill-name normalizer (G2)
+  #   - test_rests            : rest-that-restores HP/slots + advances the clock (G1 rest limb)
+  #   - test_travel           : travel-that-moves location + clock (G1 travel limb)
+  #   - test_combat           : combat resolved THROUGH the engine — start_combat/attack/rounds (G1 combat limb)
+  local TESTS="tests/test_canon_abilities.py tests/test_character_skill_normalization.py tests/test_rests.py tests/test_travel.py tests/test_combat.py"
+  if uv run --directory servers/engine python -m pytest -q -p no:xdist $TESTS >"$LOG" 2>&1; then
+    echo "  ✓ deterministic engine tier: $(grep -oE '[0-9]+ passed' "$LOG" | tail -1)"
+    return 0
+  fi
   echo "❌ FAST-GATE T0: ITERATE — deterministic engine tier failed (G1 combat/rest/travel · G2 seat-path):"
   grep -E "FAILED|Error|assert|[0-9]+ failed" "$LOG" | head -15
   echo "   full log: $LOG"
-  exit 1
+  return 1
+}
+
+CACHE_FILE=""
+if _fastgate_cache_enabled; then
+  CACHE_DIR="${CLAWDND_FASTGATE_CACHE_DIR:-$ROOT/qa/.cache/fastgate}"
+  CACHE_FILE="$CACHE_DIR/$(_fastgate_cache_key "$@").pass"
+  if [ -f "$CACHE_FILE" ]; then
+    echo "── FAST-GATE cache HIT (CLAWDND_FASTGATE_CACHE=1) — short-circuiting to the cached GREEN verdict ──"
+    echo "  key persona=${CLAWDND_FASTGATE_PERSONA:-default} sha=$(git rev-parse --short HEAD 2>/dev/null || echo nohead)"
+    echo "  cached: $(cat "$CACHE_FILE" 2>/dev/null)"
+    echo "  (inner gate NOT re-run; delete $CACHE_FILE or unset CLAWDND_FASTGATE_CACHE to force.)"
+    exit 0
+  fi
+fi
+
+if _fastgate_run_inner "$@"; then
+  if [ -n "$CACHE_FILE" ]; then
+    mkdir -p "$(dirname "$CACHE_FILE")"
+    printf 'PASS %s sha=%s persona=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      "$(git rev-parse --short HEAD 2>/dev/null || echo nohead)" \
+      "${CLAWDND_FASTGATE_PERSONA:-default}" > "$CACHE_FILE"
+    echo "  (cached GREEN verdict at $CACHE_FILE — re-run short-circuits while the tree is unchanged.)"
+  fi
+else
+  rc=$?
+  # NEVER cache a RED result: leave the file absent so the failure stays reproducible on re-run.
+  [ -n "$CACHE_FILE" ] && rm -f "$CACHE_FILE" 2>/dev/null || true
+  exit "$rc"
 fi
 
 echo "✅ FAST-GATE T0 PASS — core engine loops + seat path intact (\$0, deterministic)."

--- a/qa/release_gate.sh
+++ b/qa/release_gate.sh
@@ -47,6 +47,63 @@ fail()  { echo "❌ GATE-ABORT: $*" >&2; exit 1; }
 ok()    { echo "✓ $*"; }
 warn()  { echo "⚠ $*" >&2; }
 
+# ── RAM-aware preflight ─────────────────────────────────────────────────────────
+# Codifies the single most expensive bottleneck this project has hit: the 16GB Mac OOMs
+# mid-sweep (PROVEN — cratered to ~147M free, later personas never minted a backend, and the run
+# shipped a junk PARTIAL RRI). A 5-persona heavy claude -p sweep needs real headroom; launching
+# one on a memory-starved host fabricates/dies. Before committing to the sweep we measure
+# available RAM and, if it is below a safe floor, REFUSE (strict) or WARN (default), pointing at
+# the two safe lanes (GitHub CI / the support VM). Additive + default-soft: today's behavior is a
+# warning only — set CLAWDND_RAM_PREFLIGHT_STRICT=1 to make it a hard abort.
+#   CLAWDND_RAM_PREFLIGHT_FLOOR_MB   — safe floor (default 4096 MB; a 5-persona sweep wants headroom).
+#   CLAWDND_RAM_PREFLIGHT_STRICT=1   — turn the WARN into a hard GATE-ABORT.
+#   CLAWDND_RAM_PREFLIGHT_AVAIL_MB   — test seam: force the "available MB" reading (skip vm_stat).
+ram_available_mb() {
+  # Test override first so a low-RAM refusal can be exercised without starving the host.
+  if [ -n "${CLAWDND_RAM_PREFLIGHT_AVAIL_MB:-}" ]; then
+    printf '%s' "${CLAWDND_RAM_PREFLIGHT_AVAIL_MB}"
+    return 0
+  fi
+  # macOS: free + inactive + speculative pages are reclaimable-for-launch memory. Use the page size
+  # vm_stat itself reports; the BWK awk on macOS has no gawk match()-capture, so parse line by line.
+  if command -v vm_stat >/dev/null 2>&1; then
+    local ps; ps="$(sysctl -n hw.pagesize 2>/dev/null || echo 16384)"
+    vm_stat 2>/dev/null | awk -v ps="$ps" '
+      /Pages free/        {gsub(/\./,"",$3); free=$3}
+      /Pages inactive/    {gsub(/\./,"",$3); inact=$3}
+      /Pages speculative/ {gsub(/\./,"",$3); spec=$3}
+      END { if (ps=="") ps=16384; printf "%d", (free+inact+spec)*ps/1048576 }'
+    return 0
+  fi
+  # Linux fallback (support VM): MemAvailable in /proc/meminfo (kB).
+  if [ -r /proc/meminfo ]; then
+    awk '/^MemAvailable:/ {printf "%d", $2/1024}' /proc/meminfo
+    return 0
+  fi
+  printf ''   # unknown — caller treats empty as "unverified"
+}
+ram_preflight() {
+  local floor avail strict
+  floor="${CLAWDND_RAM_PREFLIGHT_FLOOR_MB:-4096}"
+  strict="${CLAWDND_RAM_PREFLIGHT_STRICT:-0}"
+  avail="$(ram_available_mb)"
+  if [ -z "$avail" ]; then
+    warn "could not read available RAM (no vm_stat / /proc/meminfo) — sweep headroom UNVERIFIED"
+    return 0
+  fi
+  if [ "$avail" -lt "$floor" ]; then
+    local msg="available RAM ${avail}MB is BELOW the safe floor ${floor}MB for a 5-persona sweep — \
+the host will likely OOM mid-sweep and ship a junk PARTIAL RRI. Run the heavy sweep on GitHub CI \
+or the support VM (root@support, ~/worldos-qa) instead, or free RAM first."
+    if [ "$strict" = "1" ]; then
+      fail "RAM preflight (strict): $msg"
+    fi
+    warn "RAM preflight: $msg (warning-only; set CLAWDND_RAM_PREFLIGHT_STRICT=1 to make this a hard refusal)"
+  else
+    ok "RAM headroom OK (available ${avail}MB ≥ floor ${floor}MB)"
+  fi
+}
+
 port_pids() { lsof -nP -iTCP:"$1" -sTCP:LISTEN -t 2>/dev/null || true; }
 pid_cwd() { lsof -a -p "$1" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1; }
 pid_cmd() { ps -p "$1" -o command= 2>/dev/null || true; }
@@ -87,6 +144,9 @@ free_port_range() {
 # (Every one of these maps to a real failure that cost real time this project.)
 preflight() {
   echo "── PREFLIGHT (integrity) ─────────────────────────────────────────"
+
+  # 0. RAM HEADROOM — refuse/warn before a 5-persona sweep can OOM the host (the proven bottleneck).
+  ram_preflight
 
   # 1. CANONICAL repo, not the deprecated LEXAR copy or a random worktree.
   case "$ROOT" in

--- a/qa/score.sh
+++ b/qa/score.sh
@@ -11,16 +11,61 @@
 set -uo pipefail
 
 MD="$1"; STATE="$2"; RUBRIC="$3"; SCHEMA="$4"; OUT="$5"; BUDGET="${6:-1.50}"
-# The scorer model is held CONSTANT at sonnet by default (the gate baseline; never flip it casually).
-# Overridable via CLAWDND_SCORER_MODEL ONLY for a deliberate scorer-calibration probe / re-baseline
-# (e.g. "does a stronger scorer read Opus craft higher than sonnet does?") — see docs/MODEL-TIERING.
-SCORER_MODEL="${CLAWDND_SCORER_MODEL:-sonnet}"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- (a) Scorer-model pinning (DETERMINISM GUARD; additive — unset env == today) --------
+# The scorer model is PINNED at a single canonical model (sonnet — the documented gate
+# baseline; never flip it casually). Setting CLAWDND_SCORER_MODEL swaps the scorer, which
+# silently skews every score on the gate. So an override is only honored with an EXPLICIT
+# opt-in (CLAWDND_ALLOW_SCORER_OVERRIDE=1) for a deliberate scorer-calibration probe /
+# re-baseline (e.g. "does a stronger scorer read Opus craft higher than sonnet does?") —
+# see docs/MODEL-TIERING. CLAWDND_SCORER_MODEL set WITHOUT the opt-in is an ERROR, so a
+# stray env var can't quietly move the baseline.
+CANONICAL_SCORER_MODEL="sonnet"
+if [ -n "${CLAWDND_SCORER_MODEL:-}" ] && [ "${CLAWDND_ALLOW_SCORER_OVERRIDE:-}" != "1" ]; then
+  echo "[score] REFUSING scorer-model override: CLAWDND_SCORER_MODEL='${CLAWDND_SCORER_MODEL}' is set but CLAWDND_ALLOW_SCORER_OVERRIDE=1 is NOT." >&2
+  echo "[score]   The scorer is pinned to '${CANONICAL_SCORER_MODEL}' (the gate baseline); a silent model swap skews every score." >&2
+  echo "[score]   To deliberately re-baseline with a different scorer, also export CLAWDND_ALLOW_SCORER_OVERRIDE=1." >&2
+  exit 3
+fi
+SCORER_MODEL="${CLAWDND_SCORER_MODEL:-$CANONICAL_SCORER_MODEL}"
+
+# --- (b) prompt_construction_hash: rubric+schema+template fingerprint (NOT the transcript)
+# Computed by the shared helper so score.sh and the test agree by construction. Used to
+# detect rubric/prompt-template drift across versions. Additive: it's stamped into the OUT
+# JSON after the scorecard is produced; the scorecard content is otherwise unchanged.
+PROMPT_HASH="$(python3 "$HERE/_score_prompt_hash.py" "$RUBRIC" "$SCHEMA")" || {
+  echo "[score] failed to compute prompt_construction_hash from $RUBRIC + $SCHEMA" >&2
+  exit 4
+}
 
 INPUT="$(printf '%s\n\n# ===== OUTPUT FORMAT =====\nRespond with ONLY a single JSON object conforming to this schema — no prose, no markdown, no code fences:\n%s\n\n# ===== DISTILLED TRANSCRIPT =====\n%s\n\n# ===== FINAL ENGINE STATE (ground truth) =====\n%s\n' \
   "$(cat "$RUBRIC")" "$(cat "$SCHEMA")" "$(cat "$MD")" "$(cat "$STATE")")"
 
 ERR="${OUT%.json}.err"
 RAW="${OUT%.json}.raw.json"   # raw claude --output-format json envelope (kept for the guard)
+
+# stamp_prompt_hash <json-file>: merge the prompt_construction_hash into a score JSON in place.
+stamp_prompt_hash() {
+  local f="$1" tmp
+  tmp="$(mktemp "${f}.XXXXXX")"
+  if jq --arg h "$PROMPT_HASH" '. + {prompt_construction_hash: $h}' "$f" > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$f"
+  else
+    rm -f "$tmp"
+  fi
+}
+
+# --- test-only dry-run hook (additive; unset == today) ---------------------------------
+# CLAWDND_SCORE_GUARD_ONLY=1 runs all guards + emits the hashed artifact, then exits 0
+# BEFORE the live `claude -p` loop. This keeps the determinism test gateway-free / offline
+# (it never touches Eva, the gateway, or any LLM). In normal use this is unset and the
+# script behaves exactly as before.
+if [ "${CLAWDND_SCORE_GUARD_ONLY:-}" = "1" ]; then
+  printf '{}\n' > "$OUT"
+  stamp_prompt_hash "$OUT"
+  exit 0
+fi
 
 attempt=0
 while [ "$attempt" -lt 3 ]; do
@@ -46,6 +91,7 @@ while [ "$attempt" -lt 3 ]; do
 
   # A valid scorecard parses as JSON AND carries a .scores object.
   if jq -e '.scores' "$OUT" >/dev/null 2>&1; then
+    stamp_prompt_hash "$OUT"   # (b) record rubric/prompt-template fingerprint for drift detection
     rm -f "$RAW"
     exit 0
   fi

--- a/qa/scores_db.py
+++ b/qa/scores_db.py
@@ -86,6 +86,8 @@ COLUMNS: tuple[str, ...] = (
     "actor_model",        # model driving the AI player/persona (often == dm_model)
     "scorer_model",       # model that produced the lens scores (claude / gpt-5.4 / derived)
     "methodology",        # free text, e.g. "3-lens duo 8-beat", "5-persona part-B", "handoff smoke"
+    "persona",            # persona file/name the run used (e.g. qa/play_player_duo.txt). NULL =
+                          # unstamped (additive; old rows / non-persona runs read back NULL).
     # --- comparability provenance (the missing stamps that broke cross-time comparison) ---
     "scoring_config_version",  # content hash of the FULL scoring RULER (rubrics+schemas+gates incl.
                                # RRI); see qa/scoring_config_version.py. Fences the RRI trend.
@@ -114,6 +116,11 @@ COLUMNS: tuple[str, ...] = (
     "pass",               # 1 (pass) / 0 (fail) / NULL (no pass/fail verdict)
     "source_path",        # where the evidence lives (file/dir, LEXAR or repo-relative)
     "notes",              # free-text context: what was under test, caveats, confidence flags
+    # --- canonical GREEN baseline marker (P1) ---
+    "is_canonical_baseline",  # 1 = this run is THE canonical GREEN baseline for its comparability
+                              # key (surface + dm_model + methodology + lens_config_version); 0/NULL
+                              # otherwise. At most ONE per key (set_canonical_baseline clears prior).
+                              # add_run defaults this to 0 — today's behavior is "not canonical".
 )
 
 # Numeric columns get REAL; pass is an INTEGER bool; the rest TEXT.
@@ -123,7 +130,7 @@ _REAL_COLS = {
     # F13-4 latency ledger (all wall-clock seconds / turn counts → REAL)
     "s_per_beat", "coldopen_s", "turns_per_beat",
 }
-_INT_COLS = {"critical_bugs", "pass"}
+_INT_COLS = {"critical_bugs", "pass", "is_canonical_baseline"}
 
 
 def _coltype(col: str) -> str:
@@ -189,6 +196,13 @@ def add_run(
     if fields.get("ts") is None:
         fields["ts"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
+    # Canonical-baseline marker defaults to 0 for NEW rows (today's behavior: "not canonical").
+    # The single-baseline-per-key invariant is enforced via set_canonical_baseline(), so stamping
+    # a 1 here is allowed (e.g. a backfill) but does NOT auto-clear siblings — use the helper for
+    # that. persona has no special default: omitting it simply leaves the column NULL (additive).
+    if fields.get("is_canonical_baseline") is None:
+        fields["is_canonical_baseline"] = 0
+
     # Auto-stamp the scoring RULERS unless the caller pinned them, so no scored run is ever recorded
     # without the ruler that produced it (the comparability fix). When BACKFILLING an old re-scored
     # transcript, pass scoring_config_version/rubric_label explicitly to record the ruler used THEN —
@@ -221,9 +235,11 @@ def add_run(
     if ppj is not None and not isinstance(ppj, str):
         fields["per_persona_json"] = json.dumps(ppj, ensure_ascii=False, sort_keys=True)
 
-    # Coerce bool pass -> int.
+    # Coerce bool pass / is_canonical_baseline -> int.
     if isinstance(fields.get("pass"), bool):
         fields["pass"] = int(fields["pass"])
+    if isinstance(fields.get("is_canonical_baseline"), bool):
+        fields["is_canonical_baseline"] = int(fields["is_canonical_baseline"])
 
     cols = ["run_id"] + [c for c in COLUMNS if c in fields]
     vals = [run_id] + [fields[c] for c in COLUMNS if c in fields]
@@ -249,6 +265,83 @@ def fetch_rows(db_path: Path | str = DB_PATH) -> list[dict]:
             "SELECT * FROM runs ORDER BY ts DESC, build_date DESC, run_id DESC"
         ).fetchall()
         return [dict(r) for r in rows]
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Canonical GREEN baseline (P1): mark / query the ONE reference run per comparability key
+# ---------------------------------------------------------------------------
+# The comparability key is (surface, dm_model, methodology, lens_config_version) — the same axes
+# that fence a quality trend. At most ONE run per key may be the canonical baseline; setting a new
+# one clears the prior (a re-baseline, not a duplicate). This is read-only over fiction and purely
+# additive: a db with zero canonical rows behaves exactly as today.
+_BASELINE_KEY: tuple[str, ...] = ("surface", "dm_model", "methodology", "lens_config_version")
+
+
+def set_canonical_baseline(run_id: str, *, db_path: Path | str = DB_PATH) -> None:
+    """Mark ``run_id`` as THE canonical GREEN baseline for its comparability key.
+
+    Reads the row's (surface, dm_model, methodology, lens_config_version), clears
+    ``is_canonical_baseline`` on every OTHER row sharing that exact key (so the invariant
+    "at most one canonical per key" holds), then sets it to 1 on ``run_id``. Raises if
+    ``run_id`` does not exist. Idempotent: re-marking the same run is a no-op.
+    """
+    own = isinstance(db_path, (str, os.PathLike))
+    conn = connect(db_path) if own else db_path  # type: ignore[arg-type]
+    try:
+        row = conn.execute(
+            "SELECT " + ", ".join(f'"{c}"' for c in _BASELINE_KEY) + " FROM runs WHERE run_id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None:
+            raise ValueError(f"run_id {run_id!r} not found; cannot set canonical baseline")
+        key_vals = [row[c] for c in _BASELINE_KEY]
+        # Build a NULL-safe equality predicate (IS handles NULL == NULL, which `=` does not).
+        where = " AND ".join(f'"{c}" IS ?' for c in _BASELINE_KEY)
+        # Clear the prior canonical baseline(s) sharing this exact key, except this run.
+        conn.execute(
+            f'UPDATE runs SET "is_canonical_baseline" = 0 '
+            f'WHERE {where} AND run_id != ? AND "is_canonical_baseline" = 1',
+            (*key_vals, run_id),
+        )
+        conn.execute(
+            'UPDATE runs SET "is_canonical_baseline" = 1 WHERE run_id = ?', (run_id,)
+        )
+        conn.commit()
+    finally:
+        if own:
+            conn.close()
+
+
+def get_canonical_baseline(
+    *,
+    surface: Optional[str] = None,
+    dm_model: Optional[str] = None,
+    methodology: Optional[str] = None,
+    lens_config_version: Optional[str] = None,
+    db_path: Path | str = DB_PATH,
+) -> Optional[dict]:
+    """Return the single canonical-baseline row for a comparability key, or ``None``.
+
+    The key is (surface, dm_model, methodology, lens_config_version); each is matched NULL-safely
+    (``IS``) so a key component left None matches rows whose column is NULL. Returns the row dict
+    with ``is_canonical_baseline == 1``, or ``None`` if no canonical baseline is set for that key.
+    """
+    key = {
+        "surface": surface,
+        "dm_model": dm_model,
+        "methodology": methodology,
+        "lens_config_version": lens_config_version,
+    }
+    where = " AND ".join(f'"{c}" IS ?' for c in _BASELINE_KEY)
+    conn = connect(db_path)
+    try:
+        row = conn.execute(
+            f'SELECT * FROM runs WHERE {where} AND "is_canonical_baseline" = 1 LIMIT 1',
+            tuple(key[c] for c in _BASELINE_KEY),
+        ).fetchone()
+        return dict(row) if row is not None else None
     finally:
         conn.close()
 

--- a/qa/snapshot_world_state.py
+++ b/qa/snapshot_world_state.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Read-only golden-state extractor for campaign snapshots (WorldOS QA Lab Phase-1).
+
+Loads a campaign ``snapshot.json`` and produces:
+
+  1. A CANONICAL, deterministically-ordered JSON projection of ONLY the
+     engine-mutated, regression-relevant world state — flags, faction
+     reputation/standing/rank/joined, NPC attitude_value + met, quest
+     status/objectives, quest_outcomes, day/time_of_day, last_combat_resolution,
+     party/companion roster, and world_state (tenor + facts).
+  2. A stable sha256 "golden hash" of that projection.
+
+This is a REGRESSION DETECTOR. It exists so two engine builds (or a before/after
+of a change) can be compared on the state that GATES play — the values gates and
+triggers read (invariant #3: gates read engine-mutated flags/reputation/
+attitude_value/day/standing, NEVER fiction) — without the comparison being
+swamped by prose, narration, timestamps, or RNG-seed noise that legitimately
+differs run-to-run.
+
+EXCLUDED on purpose (fiction / prose / noise — not regression-relevant):
+  * narrative prose: summary, lore, scenes, personality, backstory, appearance,
+    mannerisms, notes, memory, descriptions, recent_narration, read_aloud, …
+  * volatile noise: created_at / updated_at timestamps, engine_sha, any RNG seed,
+    active_session_id / session_ids ordering, and any UNKNOWN top-level key
+    (a future fiction/telemetry field can't perturb the hash by accident).
+
+Design notes (load-bearing invariants):
+  * READ-ONLY. This module imports NOTHING from the engine writer path and never
+    writes state. It only reads the snapshot file handed to it. The engine
+    remains the sole writer of state (invariant #1).
+  * ADDITIVE. It reads the engine's REAL field names but is defensive: a missing
+    field projects to its today's-behavior default, so an OLD snapshot lacking a
+    newer key round-trips to the same projection an empty-default would (invariant
+    #2). It tolerates either a Campaign-shaped dict or a small partial fixture.
+  * Importing the engine's pydantic models from qa/ is awkward (it would pull the
+    whole server) and unnecessary — we read the JSON directly but use the engine's
+    field names (per spec). The projection is the contract, not the model.
+
+CLI:
+  python qa/snapshot_world_state.py <snapshot.json>              # print projection JSON
+  python qa/snapshot_world_state.py <snapshot.json> --hash-only  # print the sha256 golden hash
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def load_snapshot(path: str | Path) -> dict:
+    """Read a snapshot.json off disk into a plain dict (READ-ONLY).
+
+    Raises FileNotFoundError if absent and ValueError if it isn't valid JSON / not
+    a JSON object. No engine import, no disk write — the only I/O is this read.
+    """
+    p = Path(path)
+    raw = p.read_text(encoding="utf-8")  # FileNotFoundError propagates as-is
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{p}: not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{p}: snapshot root must be a JSON object, got {type(data).__name__}")
+    return data
+
+
+def _canonicalize(obj: Any) -> Any:
+    """Recursively reorder every dict by key so the projection is order-independent.
+
+    Lists keep their order (a list's order can itself be regression-relevant — e.g.
+    objectives, party); the PROJECTION layer decides which lists to sort for
+    canonicality. dict ordering, by contrast, is never semantically meaningful in a
+    snapshot, so we always sort dict keys here. Scalars pass through unchanged.
+    """
+    if isinstance(obj, dict):
+        return {k: _canonicalize(obj[k]) for k in sorted(obj.keys())}
+    if isinstance(obj, list):
+        return [_canonicalize(x) for x in obj]
+    return obj
+
+
+def _sorted_str_keys(d: Any) -> dict:
+    """A dict with keys sorted (stringified) — for projecting id->value maps stably.
+    A non-dict (a malformed/absent value) projects to an empty dict (additive default).
+    """
+    if not isinstance(d, dict):
+        return {}
+    return {str(k): d[k] for k in sorted(d.keys(), key=str)}
+
+
+# ── projection ───────────────────────────────────────────────────────────────
+
+
+def _project_character(cid: str, ch: Any) -> dict:
+    """Regression-relevant slice of one Character.
+
+    Keeps ONLY engine-mutated, gate-readable values: the relationship gauge
+    (attitude_value), the met latch, vitals/progression that drive mechanical
+    outcomes (current_hp/max_hp/xp/dead/level via classes), conditions/exhaustion.
+    Drops ALL prose (name kept as a stable label only — it's an identity anchor, not
+    fiction the DM narrates; if a regression renames a char that IS worth catching).
+    """
+    if not isinstance(ch, dict):
+        return {}
+    return {
+        "id": ch.get("id", cid),
+        "name": ch.get("name", ""),
+        "kind": ch.get("kind", "player"),
+        # relationship gauge a companion-flip / attitude gate reads (invariant #3)
+        "attitude_value": ch.get("attitude_value", 0),
+        "met": bool(ch.get("met", False)),
+        # mechanical vitals/progression that change play outcomes
+        "current_hp": ch.get("current_hp"),
+        "max_hp": ch.get("max_hp"),
+        "temp_hp": ch.get("temp_hp", 0),
+        "xp": ch.get("xp", 0),
+        "exhaustion": ch.get("exhaustion", 0),
+        "dead": bool(ch.get("dead", False)),
+        "stable": bool(ch.get("stable", False)),
+        # conditions list is gate-relevant; sort for canonicality (order is noise here)
+        "conditions": sorted(str(c) for c in (ch.get("conditions") or [])),
+        # class levels (id+level) — a level-up regression is worth catching; prose excluded
+        "classes": [
+            {"name": (cl.get("name") if isinstance(cl, dict) else None),
+             "level": (cl.get("level") if isinstance(cl, dict) else None)}
+            for cl in (ch.get("classes") or [])
+        ],
+    }
+
+
+def _project_quest(qid: str, q: Any) -> dict:
+    """Regression-relevant slice of one Quest: stage/outcome state, never prose."""
+    if not isinstance(q, dict):
+        return {}
+    return {
+        "id": q.get("id", qid),
+        "title": q.get("title", ""),
+        "status": q.get("status", "active"),
+        "objectives": list(q.get("objectives") or []),
+        "completed_objectives": sorted(str(o) for o in (q.get("completed_objectives") or [])),
+        "milestone_awarded": bool(q.get("milestone_awarded", False)),
+    }
+
+
+def _project_faction(fid: str, f: Any) -> dict:
+    """Regression-relevant slice of one Faction: the gauges gates read, never prose."""
+    if not isinstance(f, dict):
+        return {}
+    return {
+        "id": f.get("id", fid),
+        "name": f.get("name", ""),
+        "reputation": f.get("reputation", 0),
+        "standing": f.get("standing", 0),
+        "rank": f.get("rank", 0),
+        "joined": bool(f.get("joined", False)),
+        "questline_arc_id": f.get("questline_arc_id", ""),
+    }
+
+
+def _project_world_state(ws: Any) -> dict | None:
+    """The authoritative structured world-state (tenor + facts) — the canon a gate/
+    trigger reads. None == today's behavior (no ending overlay). Facts dict is
+    key-sorted for canonicality."""
+    if not isinstance(ws, dict):
+        return None
+    return {
+        "world_tenor": ws.get("world_tenor", "hopeful"),
+        "facts": _sorted_str_keys(ws.get("facts")),
+    }
+
+
+def project_snapshot(snapshot: dict) -> dict:
+    """Project a campaign snapshot dict to its canonical, regression-relevant state.
+
+    The returned dict is the CONTRACT this extractor stabilizes: deterministically
+    ordered (dict keys sorted), fiction-excluded, and built from defaults so an old
+    snapshot projects identically to what its empty-default would. Engine field
+    names are used throughout (per spec) without importing the engine model.
+    """
+    if not isinstance(snapshot, dict):
+        raise TypeError(f"snapshot must be a dict, got {type(snapshot).__name__}")
+
+    chars = snapshot.get("characters") or {}
+    quests = snapshot.get("quests") or {}
+    factions = snapshot.get("factions") or {}
+
+    projection: dict[str, Any] = {
+        # campaign-clock (engine-mutated; drives day_reached triggers)
+        "day": snapshot.get("day", 1),
+        "time_of_day": snapshot.get("time_of_day", "morning"),
+        # the boolean world-flags gates/triggers read (invariant #3)
+        "flags": _sorted_str_keys(snapshot.get("flags")),
+        # replayability outcomes + the disengagement disposition the combat gate reads
+        "quest_outcomes": _sorted_str_keys(snapshot.get("quest_outcomes")),
+        "last_combat_resolution": snapshot.get("last_combat_resolution", ""),
+        # party/companion roster (order is meaningful — marching order / turn seating)
+        "party": list(snapshot.get("party") or []),
+        # the authoritative structured world-state (tenor + facts)
+        "world_state": _project_world_state(snapshot.get("world_state")),
+        # bestiary intel tier per creature type (monotonic engine gauge)
+        "bestiary_intel": _sorted_str_keys(snapshot.get("bestiary_intel")),
+        # progression / pacing dials the engine mutates
+        "leveling_mode": snapshot.get("leveling_mode", "xp"),
+        "pacing_mode": snapshot.get("pacing_mode", "adventure"),
+        # id->state maps, each key-sorted then per-entry projected (fiction-excluded)
+        "characters": {
+            cid: _project_character(cid, chars[cid])
+            for cid in sorted(chars.keys(), key=str)
+        } if isinstance(chars, dict) else {},
+        "quests": {
+            qid: _project_quest(qid, quests[qid])
+            for qid in sorted(quests.keys(), key=str)
+        } if isinstance(quests, dict) else {},
+        "factions": {
+            fid: _project_faction(fid, factions[fid])
+            for fid in sorted(factions.keys(), key=str)
+        } if isinstance(factions, dict) else {},
+    }
+
+    # Final canonical pass: sort every dict key recursively so the projection is
+    # byte-stable regardless of insertion order anywhere in the source snapshot.
+    return _canonicalize(projection)
+
+
+def golden_hash(snapshot: dict) -> str:
+    """Stable sha256 hexdigest of a snapshot's canonical regression projection.
+
+    Deterministic: ``json.dumps(..., sort_keys=True, separators=(",", ":"))`` over
+    the already-canonical projection removes whitespace + ordering variance, so the
+    same world-state always yields the same 64-char digest and a changed
+    regression value always yields a different one.
+    """
+    projection = project_snapshot(snapshot)
+    blob = json.dumps(projection, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(blob.encode("utf-8")).hexdigest()
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read-only golden-state extractor for a WorldOS campaign snapshot.json",
+    )
+    parser.add_argument("snapshot", help="path to a campaign snapshot.json")
+    parser.add_argument(
+        "--hash-only",
+        action="store_true",
+        help="print only the sha256 golden hash (default: print the canonical projection JSON)",
+    )
+    args = parser.parse_args(argv)
+
+    snapshot = load_snapshot(args.snapshot)
+    if args.hash_only:
+        print(golden_hash(snapshot))
+    else:
+        print(json.dumps(project_snapshot(snapshot), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/test_lens_variance.py
+++ b/qa/test_lens_variance.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Quantify SCORING NOISE so we know when a single duo run is trustworthy vs. when a
+median-of-N is required to gate a release / auto-merge.
+
+The three LLM lenses (story-craft / mechanical / angry-dm; see ``qa/SCORING.md``) are
+stochastic graders: re-scoring *the same comparable run* yields a slightly different
+``overall`` each time. This module measures that per-lens jitter from EXISTING on-disk
+score artifacts and asserts it stays under a documented NOISE FLOOR. The constants here
+and the "Variance & noise floor" section of ``qa/SCORING.md`` are the same numbers — if
+one drifts, this test makes the other one fail.
+
+Two on-disk sources are read (whichever exist):
+  1. ``qa/scores.db`` — the canonical SQLite ledger (``qa/scores_db.py``). Each ``runs``
+     row carries the three per-lens overalls (``story_overall`` / ``mech_overall`` /
+     ``angrydm_overall``). Rows that share a comparability key AND are behaviorally GREEN
+     form a "comparable cluster"; the spread *within* a cluster is the scoring noise.
+  2. ``qa/transcripts/*.{tolkien,score,angrydm}.json`` — committed per-lens scorecards, if
+     any. Each carries a single ``overall`` (see ``score_schema*.json``). Comparable cards
+     (same stem prefix, same lens) form a cluster the same way.
+
+LIVE-LLM scoring is NOT available in CI (gateway-free / null-backend; never touches Eva or
+the global mcp config), so every test here reads ONLY on-disk artifacts and is fully
+deterministic. A test that *would* need a live scorer is marked ``skipif`` and never runs
+in CI. If too few on-disk artifacts exist to compute a spread, the test SKIPS (it never
+fails for lack of data — an empty ledger is today's behavior).
+
+Pure stdlib (sqlite3 + json + statistics) + pytest. Imports neither the engine nor the
+viewer. Additive: a brand-new file; touches no existing test. Run:
+    uv run --directory servers/engine python -m pytest qa/test_lens_variance.py -q -p no:xdist
+or simply:
+    python3 -m pytest qa/test_lens_variance.py -q
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import pytest
+
+QA_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(QA_DIR))
+
+import scores_db  # noqa: E402  (canonical ledger reader; reuse, do not duplicate)
+
+# ---------------------------------------------------------------------------------------
+# DOCUMENTED NOISE FLOOR (must mirror qa/SCORING.md § "Variance & noise floor").
+#
+# These are the MAXIMUM within-cluster spread we tolerate for re-scores of the same
+# comparable run. They were DERIVED empirically from the comparable GREEN clusters in the
+# committed qa/scores.db (2026-06-16 snapshot, 75 rows): the observed max within-cluster
+# population stdev was story 0.15 / mech 0.25 / angry-dm 0.35 (ranges 0.30 / 0.50 / 0.70).
+# We round UP to a defensible bound (a little headroom for the next re-score) and record
+# it as the contract. Angry-DM is the noisiest lens (adversarial, exhaustive 5e checklist),
+# which is exactly why release gating leans on median-of-N hardest there.
+#
+# Each entry: lens-column -> (max_stdev, max_range). If a future re-score blows past these,
+# this test goes RED and forces a conscious re-derivation of the floor (and the doc).
+# ---------------------------------------------------------------------------------------
+NOISE_FLOOR = {
+    "story_overall": {"max_stdev": 0.20, "max_range": 0.40, "label": "story-craft (Tolkien)"},
+    "mech_overall": {"max_stdev": 0.30, "max_range": 0.60, "label": "mechanical"},
+    "angrydm_overall": {"max_stdev": 0.40, "max_range": 0.80, "label": "angry-dm (5e fidelity)"},
+}
+LENS_COLUMNS = tuple(NOISE_FLOOR.keys())
+
+# Per-lens scorecard filename suffix -> ledger lens column (for qa/transcripts/*.json).
+CARD_SUFFIX_TO_LENS = {
+    ".tolkien.json": "story_overall",
+    ".score.json": "mech_overall",
+    ".angrydm.json": "angrydm_overall",
+    ".angry_dm.json": "angrydm_overall",
+}
+
+# A cluster needs at least this many comparable scores before its spread is meaningful.
+_MIN_CLUSTER = 2
+# We need at least this many comparable clusters (across all lenses) before we ASSERT a
+# floor; otherwise the on-disk corpus is too thin and we SKIP rather than fail.
+_MIN_CLUSTERS_TO_ASSERT = 1
+
+
+def _green(behavioral) -> bool:
+    """A score is only a real number on a GREEN run; RED runs are rubric-capped to <=2.5
+    (see SCORING.md § RED-cap) and must NOT be mixed into a noise measurement."""
+    return (behavioral or "").strip().upper().startswith("GREEN")
+
+
+def _comparability_key(row: dict) -> tuple:
+    """Two scores are comparable only if produced by the same harness against the same
+    build with the same scorer under the same ruler. Fencing on these fields is what makes
+    the *remaining* spread attributable to scorer stochasticity rather than to a different
+    build / surface / methodology / scorer / rubric. ``lens_config_version`` /
+    ``scoring_config_version`` are folded in when present so a rubric recalibration never
+    silently lands in the same cluster as the old ruler."""
+    return (
+        row.get("build_sha"),
+        row.get("surface"),
+        row.get("methodology"),
+        row.get("scorer_model"),
+        row.get("lens_config_version"),
+        row.get("scoring_config_version"),
+    )
+
+
+def _clusters_from_ledger(rows: list[dict], lens: str) -> dict[tuple, list[float]]:
+    """Group GREEN, non-null per-lens overalls by comparability key."""
+    groups: dict[tuple, list[float]] = defaultdict(list)
+    for r in rows:
+        val = r.get(lens)
+        if val is None:
+            continue
+        if not _green(r.get("behavioral")):
+            continue
+        try:
+            groups[_comparability_key(r)].append(float(val))
+        except (TypeError, ValueError):
+            continue
+    return groups
+
+
+def _clusters_from_transcripts(transcripts_dir: Path) -> dict[str, dict[str, list[float]]]:
+    """Read committed per-lens scorecards in qa/transcripts/. Returns
+    {lens_column: {cluster_key: [overall, ...]}}. A "cluster" is the run-stem prefix that
+    precedes the lens suffix (e.g. ``runA.tolkien.json`` and ``runA.r2.tolkien.json`` only
+    cluster if their pre-suffix stems match exactly). Missing dir / no files -> empty."""
+    out: dict[str, dict[str, list[float]]] = {lens: defaultdict(list) for lens in LENS_COLUMNS}
+    if not transcripts_dir.is_dir():
+        return out
+    for path in sorted(transcripts_dir.rglob("*.json")):
+        name = path.name
+        lens = next((CARD_SUFFIX_TO_LENS[s] for s in CARD_SUFFIX_TO_LENS if name.endswith(s)), None)
+        if lens is None:
+            continue
+        suffix = next(s for s in CARD_SUFFIX_TO_LENS if name.endswith(s))
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        overall = data.get("overall")
+        if overall is None:
+            continue
+        try:
+            overall = float(overall)
+        except (TypeError, ValueError):
+            continue
+        # Cluster key = parent dir + stem with the lens suffix stripped + any "re-score"
+        # marker collapsed: we treat the leading token before the first '.' as the run id.
+        stem = name[: -len(suffix)]
+        run_id = stem.split(".", 1)[0]
+        cluster_key = f"{path.parent}::{run_id}"
+        out[lens][cluster_key].append(overall)
+    return out
+
+
+def _spreads_for_lens(lens: str) -> list[tuple[str, list[float], float, float]]:
+    """Return [(source_tag, values, pstdev, range)] for every comparable cluster (>=2
+    scores) of ``lens`` found on disk, across BOTH the ledger and committed transcripts."""
+    spreads: list[tuple[str, list[float], float, float]] = []
+
+    # 1. Ledger clusters.
+    if scores_db.DB_PATH.exists():
+        rows = scores_db.fetch_rows(scores_db.DB_PATH)
+        for key, vals in _clusters_from_ledger(rows, lens).items():
+            if len(vals) >= _MIN_CLUSTER:
+                spreads.append((f"ledger:{key}", vals, statistics.pstdev(vals), max(vals) - min(vals)))
+
+    # 2. Committed per-lens scorecards (qa/transcripts/).
+    tcards = _clusters_from_transcripts(QA_DIR / "transcripts")[lens]
+    for key, vals in tcards.items():
+        if len(vals) >= _MIN_CLUSTER:
+            spreads.append((f"transcript:{key}", vals, statistics.pstdev(vals), max(vals) - min(vals)))
+
+    return spreads
+
+
+def _total_clusters_on_disk() -> int:
+    return sum(len(_spreads_for_lens(lens)) for lens in LENS_COLUMNS)
+
+
+# =======================================================================================
+# Tests
+# =======================================================================================
+
+
+def test_noise_floor_constants_are_self_consistent():
+    """Cheap structural guard (always runs, needs no data): the documented floor covers all
+    three lenses with positive, finite bounds and a range >= stdev. This is the contract
+    the rest of the suite asserts against and that qa/SCORING.md must mirror."""
+    assert set(NOISE_FLOOR) == set(LENS_COLUMNS)
+    for lens, floor in NOISE_FLOOR.items():
+        assert floor["max_stdev"] > 0, lens
+        assert floor["max_range"] > 0, lens
+        # A range across >=2 samples is always >= the population stdev, so the range bound
+        # must not be tighter than the stdev bound or it could never be the binding one.
+        assert floor["max_range"] >= floor["max_stdev"], lens
+        assert floor["label"]
+
+
+@pytest.mark.parametrize("lens", LENS_COLUMNS)
+def test_per_lens_noise_within_documented_floor(lens):
+    """For each lens, every comparable on-disk cluster's spread must stay under the
+    documented noise floor. If NO comparable cluster exists for this lens yet, SKIP — a thin
+    corpus is today's behavior and must never fail CI (additive-by-default)."""
+    spreads = _spreads_for_lens(lens)
+    if not spreads:
+        pytest.skip(
+            f"no comparable on-disk clusters (>={_MIN_CLUSTER} GREEN re-scores) for "
+            f"{NOISE_FLOOR[lens]['label']} yet; cannot measure spread"
+        )
+    floor = NOISE_FLOOR[lens]
+    worst_stdev = max(s[2] for s in spreads)
+    worst_range = max(s[3] for s in spreads)
+    # Report the actual measured numbers in the failure message so a breach forces a
+    # conscious re-derivation of the floor (and the SCORING.md doc), not a silent bump.
+    detail = "; ".join(f"{tag} vals={vals} stdev={sd:.3f} range={rg:.2f}" for tag, vals, sd, rg in spreads)
+    assert worst_stdev <= floor["max_stdev"], (
+        f"{floor['label']}: measured within-cluster stdev {worst_stdev:.3f} exceeds documented "
+        f"noise floor {floor['max_stdev']} — re-derive the floor + update qa/SCORING.md. [{detail}]"
+    )
+    assert worst_range <= floor["max_range"], (
+        f"{floor['label']}: measured within-cluster range {worst_range:.2f} exceeds documented "
+        f"noise floor {floor['max_range']} — re-derive the floor + update qa/SCORING.md. [{detail}]"
+    )
+
+
+def test_at_least_one_comparable_cluster_exists_or_skip():
+    """Sanity: confirm SOME comparable cluster exists on disk so the floor is actually
+    being exercised. If the corpus is too thin, SKIP (don't fail) — this records that the
+    measurement is currently data-starved rather than passing vacuously."""
+    n = _total_clusters_on_disk()
+    if n < _MIN_CLUSTERS_TO_ASSERT:
+        pytest.skip(
+            "on-disk score corpus too thin to measure scoring noise "
+            f"({n} comparable clusters; need >= {_MIN_CLUSTERS_TO_ASSERT}). "
+            "Re-run once more GREEN re-scores are committed to qa/scores.db or qa/transcripts/."
+        )
+    assert n >= _MIN_CLUSTERS_TO_ASSERT
+
+
+def test_median_of_n_shrinks_jitter_below_single_run():
+    """The whole point of the noise floor: a SINGLE duo can sit a full noise-floor away from
+    truth, but the MEDIAN of N re-scores collapses that jitter. This is a deterministic
+    property test (no data needed) demonstrating WHY release/auto-merge gating uses
+    median-of-N while velocity work tolerates a single duo. For a worst-case symmetric
+    spread at the angry-dm floor, the median of 3 lands strictly inside the single-run
+    band — the documented rule's justification, in code."""
+    floor = NOISE_FLOOR["angrydm_overall"]["max_range"]
+    truth = 4.0
+    # Worst-case single run: as far from truth as the floor allows.
+    single_run_error = floor / 2.0
+    # Three re-scores straddling truth (low / on / high): median is the middle one.
+    samples = sorted([truth - single_run_error, truth, truth + single_run_error])
+    median = samples[1]
+    median_error = abs(median - truth)
+    assert median_error < single_run_error, (
+        "median-of-3 must beat a worst-case single run; this is the basis for the "
+        "single-duo-for-velocity / median-of-N-for-release rule in qa/SCORING.md"
+    )
+    assert median_error == 0.0  # symmetric straddle -> exact in this idealized model
+
+
+# ---------------------------------------------------------------------------------------
+# Live-scorer path: only meaningful with a real LLM scorer, which CI never has. This stays
+# skipped in CI (gateway-free / null-backend invariant) and is here purely to document that
+# the empirical re-derivation of the floor is an explicit, opt-in, NON-CI step.
+# ---------------------------------------------------------------------------------------
+_RUN_LIVE = os.environ.get("CLAWDND_LIVE_SCORER") == "1"
+
+
+@pytest.mark.skipif(
+    not _RUN_LIVE,
+    reason="needs a LIVE LLM scorer (score.sh / score_openclaw.sh) — not available in CI "
+    "(QA is gateway-free / null-backend). Set CLAWDND_LIVE_SCORER=1 to re-derive the floor.",
+)
+def test_live_rescore_floor_rederivation_placeholder():  # pragma: no cover - never runs in CI
+    raise AssertionError(
+        "Live re-derivation must be driven by qa/score.sh against committed transcripts, "
+        "writing fresh .tolkien/.score/.angrydm cards into qa/transcripts/ before re-running "
+        "the deterministic spread assertion above. This placeholder intentionally fails if "
+        "ever forced on without that harness."
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    for _lens in LENS_COLUMNS:
+        _s = _spreads_for_lens(_lens)
+        print(f"{_lens}: clusters={len(_s)}")
+        for tag, vals, sd, rg in _s:
+            print(f"   {tag}: n={len(vals)} stdev={sd:.3f} range={rg:.2f} vals={vals}")

--- a/qa/test_score_determinism.py
+++ b/qa/test_score_determinism.py
@@ -1,0 +1,203 @@
+"""Determinism + drift-detection guards for qa/score.sh (no live LLM).
+
+Covers the two ADDITIVE hardening features layered onto score.sh:
+
+  (a) Scorer-model pinning. score.sh pins a single canonical scorer model unless
+      CLAWDND_SCORER_MODEL is set. Setting CLAWDND_SCORER_MODEL WITHOUT the explicit
+      opt-in CLAWDND_ALLOW_SCORER_OVERRIDE=1 must ERROR (non-zero + a clear message) so
+      a stray env var can't silently swap the scorer and skew the gate baseline. With the
+      override flag, the script must proceed PAST the guard.
+
+  (b) prompt_construction_hash. score.sh stamps the sha256 of (rubric contents + schema
+      contents + the fixed prompt-template scaffold), NOT the transcript, into the score
+      JSON so rubric/template drift is detectable across versions. The hash is produced by
+      qa/_score_prompt_hash.py, which both score.sh and this test call.
+
+The shell-behavior tests use CLAWDND_SCORE_GUARD_ONLY=1 — an additive, test-only dry-run
+hook that makes score.sh run all guards + emit the hashed artifact, then exit 0 BEFORE the
+`claude -p` loop. So nothing here ever touches a live LLM, the gateway, Eva, or global mcp
+config. The guard-failure path doesn't even reach that hook (it errors first), so the
+not-logged-in / no-claude environment is irrelevant to it.
+
+Default behavior is unchanged: with both env vars unset, score.sh proceeds past the guard
+exactly as today (the additive-by-default invariant).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCORE_SH = ROOT / "qa" / "score.sh"
+HASH_PY = ROOT / "qa" / "_score_prompt_hash.py"
+
+
+# --- load the helper module directly (it lives in qa/, not on sys.path) ---------------
+def _load_hash_module():
+    spec = importlib.util.spec_from_file_location("_score_prompt_hash", HASH_PY)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+HASH = _load_hash_module()
+
+
+# --- fixtures the script needs (all dummy; the LLM never runs) -------------------------
+def _make_inputs(tmp_path: Path, rubric_text: str = "RUBRIC v1\nbody\n") -> dict:
+    rubric = tmp_path / "rubric.md"
+    schema = tmp_path / "schema.json"
+    md = tmp_path / "run.md"
+    state = tmp_path / "run.state.json"
+    out = tmp_path / "run.score.json"
+    rubric.write_text(rubric_text, encoding="utf-8")
+    schema.write_text('{"type":"object"}\n', encoding="utf-8")
+    md.write_text("# transcript\nDM: hello\n", encoding="utf-8")
+    state.write_text('{"day": 1}\n', encoding="utf-8")
+    return {
+        "rubric": rubric,
+        "schema": schema,
+        "md": md,
+        "state": state,
+        "out": out,
+    }
+
+
+def _run_score(inputs: dict, env_overrides: dict, guard_only: bool = True) -> subprocess.CompletedProcess:
+    """Invoke score.sh with a minimal env. PATH keeps bash + python + jq reachable."""
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": os.environ.get("HOME", "/tmp"),
+    }
+    if guard_only:
+        env["CLAWDND_SCORE_GUARD_ONLY"] = "1"
+    env.update(env_overrides)
+    return subprocess.run(
+        [
+            "bash",
+            str(SCORE_SH),
+            str(inputs["md"]),
+            str(inputs["state"]),
+            str(inputs["rubric"]),
+            str(inputs["schema"]),
+            str(inputs["out"]),
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+# ====================================================================================
+# (a) Scorer-model pinning guard
+# ====================================================================================
+def test_scorer_override_without_optin_errors(tmp_path):
+    """CLAWDND_SCORER_MODEL set, no opt-in flag → non-zero exit + a clear guard message."""
+    inputs = _make_inputs(tmp_path)
+    proc = _run_score(inputs, {"CLAWDND_SCORER_MODEL": "opus"})
+    assert proc.returncode != 0, (
+        "score.sh must REFUSE a CLAWDND_SCORER_MODEL override without the opt-in flag; "
+        f"got rc={proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+    )
+    combined = (proc.stdout + proc.stderr).lower()
+    # The message must name the override env + the opt-in flag so the operator knows the fix.
+    assert "clawdnd_scorer_model" in combined
+    assert "clawdnd_allow_scorer_override" in combined
+    # The guard must fire BEFORE producing an artifact (no score JSON written).
+    assert not inputs["out"].exists(), "guard-failed run must not write a score artifact"
+
+
+def test_scorer_override_with_optin_proceeds(tmp_path):
+    """CLAWDND_SCORER_MODEL + CLAWDND_ALLOW_SCORER_OVERRIDE=1 → proceeds past the guard."""
+    inputs = _make_inputs(tmp_path)
+    proc = _run_score(
+        inputs,
+        {"CLAWDND_SCORER_MODEL": "opus", "CLAWDND_ALLOW_SCORER_OVERRIDE": "1"},
+    )
+    assert proc.returncode == 0, (
+        "with the opt-in flag, score.sh must proceed past the guard (guard-only dry run "
+        f"exits 0); got rc={proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+    )
+    # Proceeding past the guard means the hashed artifact got stamped.
+    assert inputs["out"].exists(), "proceeding past the guard must reach the artifact-stamp step"
+    payload = json.loads(inputs["out"].read_text(encoding="utf-8"))
+    assert "prompt_construction_hash" in payload
+
+
+def test_default_unset_proceeds_past_guard(tmp_path):
+    """Additive-by-default: with NO scorer env vars set, score.sh proceeds (today's behavior)."""
+    inputs = _make_inputs(tmp_path)
+    proc = _run_score(inputs, {})
+    assert proc.returncode == 0, (
+        "default (no env) must proceed past the guard exactly as today; "
+        f"got rc={proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+    )
+    assert inputs["out"].exists()
+
+
+# ====================================================================================
+# (b) prompt_construction_hash: stable for identical rubric+template; moves on rubric edit
+# ====================================================================================
+def test_hash_stable_for_identical_rubric_and_template():
+    """Same rubric + same schema + same scaffold ⇒ identical hash (deterministic)."""
+    a = HASH.prompt_construction_hash("RUBRIC", "SCHEMA")
+    b = HASH.prompt_construction_hash("RUBRIC", "SCHEMA")
+    assert a == b
+    # sha256 hex digest shape.
+    assert len(a) == 64 and all(c in "0123456789abcdef" for c in a)
+
+
+def test_hash_changes_when_rubric_content_changes():
+    """Editing the rubric content must move the hash (drift is detectable)."""
+    base = HASH.prompt_construction_hash("RUBRIC v1", "SCHEMA")
+    edited = HASH.prompt_construction_hash("RUBRIC v2 — added a dimension", "SCHEMA")
+    assert base != edited
+
+
+def test_hash_excludes_transcript_and_state():
+    """The hash must NOT depend on the transcript or engine state — only rubric/schema/scaffold.
+
+    We prove this end-to-end: two guard-only runs with identical rubric+schema but DIFFERENT
+    transcript/state must stamp the SAME prompt_construction_hash.
+    """
+    inputs_a = _make_inputs(Path(_tmpdir()))
+    inputs_b = _make_inputs(Path(_tmpdir()))
+    # Give B a wildly different transcript + state; keep rubric/schema content identical.
+    inputs_b["md"].write_text("# totally different transcript\n" * 50, encoding="utf-8")
+    inputs_b["state"].write_text('{"day": 999, "flags": {"x": true}}\n', encoding="utf-8")
+
+    proc_a = _run_score(inputs_a, {})
+    proc_b = _run_score(inputs_b, {})
+    assert proc_a.returncode == 0 and proc_b.returncode == 0, (
+        f"a.stderr={proc_a.stderr}\nb.stderr={proc_b.stderr}"
+    )
+    ha = json.loads(inputs_a["out"].read_text(encoding="utf-8"))["prompt_construction_hash"]
+    hb = json.loads(inputs_b["out"].read_text(encoding="utf-8"))["prompt_construction_hash"]
+    assert ha == hb, "prompt_construction_hash must be invariant to transcript/state content"
+
+
+def test_shell_hash_matches_python_helper():
+    """The hash stamped by score.sh (via the helper CLI) equals the helper's Python result."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        inputs = _make_inputs(Path(d), rubric_text="RUBRIC for parity\n")
+        proc = _run_score(inputs, {})
+        assert proc.returncode == 0, proc.stderr
+        stamped = json.loads(inputs["out"].read_text(encoding="utf-8"))["prompt_construction_hash"]
+        expected = HASH.hash_from_files(str(inputs["rubric"]), str(inputs["schema"]))
+        assert stamped == expected
+
+
+# --- helper: a throwaway tmp dir without the pytest fixture (for the two-run hash test) -
+def _tmpdir() -> str:
+    import tempfile
+
+    return tempfile.mkdtemp(prefix="worldos-score-det-")

--- a/qa/test_scores_db.py
+++ b/qa/test_scores_db.py
@@ -155,6 +155,146 @@ def test_schema_migration_adds_missing_column(tmp_path):
     assert "story_overall" in cols and "notes" in cols and "rri" in cols
 
 
+# --- P1: persona + is_canonical_baseline (additive comparability columns) ---
+
+def test_persona_and_canonical_columns_are_registered(tmp_path):
+    # Both new columns exist in COLUMNS; persona is TEXT, is_canonical_baseline is INTEGER.
+    assert "persona" in scores_db.COLUMNS, "persona missing from COLUMNS"
+    assert "is_canonical_baseline" in scores_db.COLUMNS, "is_canonical_baseline missing from COLUMNS"
+    assert scores_db._coltype("persona") == "TEXT"
+    assert scores_db._coltype("is_canonical_baseline") == "INTEGER"
+
+
+def test_persona_roundtrips_and_canonical_defaults_zero(tmp_path):
+    # add_run accepts persona; is_canonical_baseline defaults to 0 (NOT canonical) when omitted.
+    db = tmp_path / "t.db"
+    scores_db.add_run(
+        "duo-p", db_path=db, surface="engine-duo", persona="qa/play_player_duo.txt",
+        story_overall=4.2,
+    )
+    row = scores_db.fetch_rows(db)[0]
+    assert row["persona"] == "qa/play_player_duo.txt"
+    assert row["is_canonical_baseline"] == 0  # default — today's behavior is "not canonical"
+
+
+def test_persona_defaults_none_when_omitted(tmp_path):
+    # A row recorded without a persona reads back NULL (additive, old-snapshot behavior).
+    db = tmp_path / "t.db"
+    scores_db.add_run("duo-np", db_path=db, surface="engine-duo", story_overall=4.0)
+    row = scores_db.fetch_rows(db)[0]
+    assert row["persona"] is None
+
+
+def test_new_columns_read_default_on_pre_p1_rows(tmp_path):
+    # ADDITIVITY: a row written to a db created BEFORE these columns existed reads back
+    # the defaults (persona NULL, is_canonical_baseline 0) once the column is ALTER-added.
+    db = tmp_path / "old.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        'CREATE TABLE runs ("run_id" TEXT PRIMARY KEY, "surface" TEXT, "story_overall" REAL)'
+    )
+    conn.execute('INSERT INTO runs ("run_id", "surface", "story_overall") VALUES (?,?,?)',
+                 ("legacy", "engine-duo", 4.5))
+    conn.commit()
+    conn.close()
+    rows = scores_db.fetch_rows(db)  # connect() ALTERs in the new columns
+    legacy = {r["run_id"]: r for r in rows}["legacy"]
+    assert legacy["persona"] is None
+    # ALTER TABLE ADD COLUMN gives existing rows NULL (not 0) — the read path / add_run is what
+    # supplies the 0 default for NEW rows; old rows are simply "unstamped" (NULL), which is fine.
+    assert legacy["is_canonical_baseline"] is None
+
+
+def test_new_columns_alter_into_an_old_db(tmp_path):
+    # A db created before P1 (no persona/is_canonical_baseline) gets them ALTER-added on connect.
+    db = tmp_path / "old.db"
+    conn = sqlite3.connect(db)
+    conn.execute('CREATE TABLE runs ("run_id" TEXT PRIMARY KEY, "surface" TEXT)')
+    conn.commit()
+    conn.close()
+    conn = scores_db.connect(db)
+    cols = {r["name"] for r in conn.execute("PRAGMA table_info(runs)")}
+    conn.close()
+    assert {"persona", "is_canonical_baseline"} <= cols
+
+
+def test_migration_is_idempotent(tmp_path):
+    # Connecting twice (re-running the ADD COLUMN migration) does not error or duplicate columns.
+    db = tmp_path / "t.db"
+    scores_db.connect(db).close()
+    scores_db.connect(db).close()  # second connect must be a no-op migration
+    conn = scores_db.connect(db)
+    cols = [r["name"] for r in conn.execute("PRAGMA table_info(runs)")]
+    conn.close()
+    # no duplicate columns, and both new ones present exactly once
+    assert cols.count("persona") == 1
+    assert cols.count("is_canonical_baseline") == 1
+
+
+def test_set_and_get_canonical_baseline_roundtrip(tmp_path):
+    db = tmp_path / "t.db"
+    key = dict(surface="engine-duo", dm_model="sonnet",
+               methodology="3-lens duo 8-beat", lens_config_version="lc_aaaaaaaaaaaa")
+    scores_db.add_run("duo-base", db_path=db, story_overall=4.3, **key)
+    # before marking, there is no canonical baseline for this key
+    assert scores_db.get_canonical_baseline(db_path=db, **key) is None
+    scores_db.set_canonical_baseline("duo-base", db_path=db)
+    got = scores_db.get_canonical_baseline(db_path=db, **key)
+    assert got is not None
+    assert got["run_id"] == "duo-base"
+    assert got["is_canonical_baseline"] == 1
+
+
+def test_single_canonical_per_comparability_key_enforced(tmp_path):
+    # Setting a new canonical baseline for the SAME comparability key clears the prior one.
+    db = tmp_path / "t.db"
+    key = dict(surface="engine-duo", dm_model="opus",
+               methodology="3-lens duo 8-beat", lens_config_version="lc_bbbbbbbbbbbb")
+    scores_db.add_run("base-1", db_path=db, story_overall=4.1, **key)
+    scores_db.add_run("base-2", db_path=db, story_overall=4.4, **key)
+    scores_db.set_canonical_baseline("base-1", db_path=db)
+    scores_db.set_canonical_baseline("base-2", db_path=db)  # supersedes base-1
+
+    by_id = {r["run_id"]: r for r in scores_db.fetch_rows(db)}
+    assert by_id["base-1"]["is_canonical_baseline"] == 0  # cleared
+    assert by_id["base-2"]["is_canonical_baseline"] == 1
+    got = scores_db.get_canonical_baseline(db_path=db, **key)
+    assert got["run_id"] == "base-2"
+
+
+def test_canonical_baselines_isolated_across_keys(tmp_path):
+    # Two DIFFERENT comparability keys may EACH have their own canonical baseline simultaneously.
+    db = tmp_path / "t.db"
+    key_a = dict(surface="engine-duo", dm_model="sonnet",
+                 methodology="duo", lens_config_version="lc_111111111111")
+    key_b = dict(surface="GUI-built-app", dm_model="opus",
+                 methodology="5-persona", lens_config_version="lc_222222222222")
+    scores_db.add_run("a", db_path=db, **key_a)
+    scores_db.add_run("b", db_path=db, **key_b)
+    scores_db.set_canonical_baseline("a", db_path=db)
+    scores_db.set_canonical_baseline("b", db_path=db)  # must NOT clear "a" (different key)
+
+    by_id = {r["run_id"]: r for r in scores_db.fetch_rows(db)}
+    assert by_id["a"]["is_canonical_baseline"] == 1
+    assert by_id["b"]["is_canonical_baseline"] == 1
+    assert scores_db.get_canonical_baseline(db_path=db, **key_a)["run_id"] == "a"
+    assert scores_db.get_canonical_baseline(db_path=db, **key_b)["run_id"] == "b"
+
+
+def test_set_canonical_baseline_unknown_run_raises(tmp_path):
+    db = tmp_path / "t.db"
+    scores_db.connect(db).close()
+    with pytest.raises(ValueError):
+        scores_db.set_canonical_baseline("nope-not-here", db_path=db)
+
+
+def test_add_run_accepts_is_canonical_baseline_directly(tmp_path):
+    # add_run can stamp is_canonical_baseline=1 at insert time (e.g. a backfill of a known baseline).
+    db = tmp_path / "t.db"
+    scores_db.add_run("direct", db_path=db, surface="engine-duo", is_canonical_baseline=1)
+    assert scores_db.fetch_rows(db)[0]["is_canonical_baseline"] == 1
+
+
 # --- the forensic seed itself (proves the reconstruction is reproducible) ---
 
 def test_seed_is_reproducible_and_classified(tmp_path):

--- a/qa/test_snapshot_world_state.py
+++ b/qa/test_snapshot_world_state.py
@@ -1,0 +1,251 @@
+"""Tests for qa/snapshot_world_state.py — the read-only golden-state extractor.
+
+These lock the THREE regression-detection contracts the extractor exists to
+provide:
+
+  (i)  DETERMINISM — the same snapshot hashes identically across two calls (the
+       projection is canonically ordered, so a re-run never spuriously diffs).
+  (ii) CANONICAL + FICTION-EXCLUDED — reordering a snapshot's dict keys, or
+       adding a fiction/narration/prose field (or noise like timestamps / RNG
+       seed), does NOT change the hash. Only engine-mutated, regression-relevant
+       state is projected.
+  (iii) SENSITIVE — flipping an engine-mutated regression value (a flag, a
+       faction reputation, a quest stage/status, an NPC attitude, the day) DOES
+       change the hash, so a real regression is caught.
+
+The extractor is READ-ONLY: it never imports the engine writer path and never
+touches disk except to read the snapshot file it is handed.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Import the module-under-test by file path. It lives beside this test in qa/;
+# we don't rely on qa/ being on sys.path (the engine's pytest pythonpath is the
+# engine dir), so load it explicitly.
+_QA_DIR = Path(__file__).resolve().parent
+_MOD_PATH = _QA_DIR / "snapshot_world_state.py"
+_spec = importlib.util.spec_from_file_location("snapshot_world_state", _MOD_PATH)
+assert _spec and _spec.loader
+snapshot_world_state = importlib.util.module_from_spec(_spec)
+sys.modules["snapshot_world_state"] = snapshot_world_state
+_spec.loader.exec_module(snapshot_world_state)
+
+project_snapshot = snapshot_world_state.project_snapshot
+golden_hash = snapshot_world_state.golden_hash
+load_snapshot = snapshot_world_state.load_snapshot
+
+
+def _fixture_snapshot() -> dict:
+    """A minimal but representative campaign snapshot dict.
+
+    Uses the engine's real Campaign field names so the extractor's projection is
+    exercised against the actual schema. Carries each regression-relevant family
+    (flags / faction reputation+standing / quest status+stage / NPC
+    attitude_value / day+time_of_day / quest_outcomes / party roster / world_state
+    facts) PLUS plenty of fiction/prose/timestamp/RNG noise that MUST be excluded.
+    """
+    return {
+        "id": "camp_fixture",
+        "title": "The Embergloom Pact",
+        "summary": "Long prose summary the DM narrates — pure fiction, must be excluded.",
+        "ruleset": "SRD 5.2",
+        # --- noise that MUST NOT affect the golden hash ---
+        "created_at": 1700000000.0,
+        "updated_at": 1700009999.5,
+        "engine_sha": "abc1234",
+        # --- engine-mutated, regression-relevant state ---
+        "day": 7,
+        "time_of_day": "evening",
+        "flags": {"prize_seized": True, "gate_open": False},
+        "quest_outcomes": {"main_arc": "tyranny_ending"},
+        "last_combat_resolution": "fled",
+        "party": ["char_pc", "char_companion"],
+        "world_state": {
+            "world_tenor": "grim",
+            "facts": {"netherbrain": "claimed", "the_emperor": "slain"},
+        },
+        "characters": {
+            "char_pc": {
+                "id": "char_pc",
+                "name": "Rolan",
+                "kind": "player",
+                "current_hp": 18,
+                "max_hp": 24,
+                "xp": 900,
+                "attitude": "guarded",
+                "attitude_value": 0,
+                "personality": "Prose about Rolan the wizard — fiction, excluded.",
+                "backstory": "A long backstory the DM voices — fiction, excluded.",
+            },
+            "char_npc": {
+                "id": "char_npc",
+                "name": "Shadowheart",
+                "kind": "npc",
+                "attitude": "warming",
+                "attitude_value": 35,
+                "met": True,
+                "memory": ["She remembers the night raid — fiction, excluded."],
+                "notes": "DM notes prose — excluded.",
+            },
+        },
+        "quests": {
+            "q_main": {
+                "id": "q_main",
+                "title": "Break the Pact",
+                "description": "Long quest prose — fiction, excluded.",
+                "status": "active",
+                "objectives": ["find the relic", "confront the warlock"],
+                "completed_objectives": ["find the relic"],
+            }
+        },
+        "factions": {
+            "fac_harpers": {
+                "id": "fac_harpers",
+                "name": "The Harpers",
+                "description": "Faction lore prose — fiction, excluded.",
+                "reputation": 25,
+                "standing": 10,
+                "rank": 2,
+                "joined": True,
+            }
+        },
+        # A fiction-heavy block that must be wholly excluded from the projection.
+        "lore": ["Page one of world-bible prose.", "Page two of world-bible prose."],
+        "scenes": [{"read_aloud": "Boxed text the DM reads aloud.", "dm_notes": "secret"}],
+        "session_ids": ["sess_a", "sess_b"],
+        "active_session_id": "sess_b",
+    }
+
+
+def test_determinism_same_snapshot_hashes_identically(tmp_path):
+    snap = _fixture_snapshot()
+    p = tmp_path / "snapshot.json"
+    p.write_text(json.dumps(snap), encoding="utf-8")
+
+    h1 = golden_hash(load_snapshot(p))
+    h2 = golden_hash(load_snapshot(p))
+    assert h1 == h2
+    assert isinstance(h1, str) and len(h1) == 64  # sha256 hexdigest
+
+
+def test_reordering_keys_does_not_change_hash():
+    snap = _fixture_snapshot()
+    # Build a deeply key-reordered copy: reverse the insertion order of every dict.
+    def reorder(obj):
+        if isinstance(obj, dict):
+            return {k: reorder(obj[k]) for k in reversed(list(obj.keys()))}
+        if isinstance(obj, list):
+            return [reorder(x) for x in obj]
+        return obj
+
+    reordered = reorder(snap)
+    assert list(reordered.keys()) != list(snap.keys())  # genuinely reordered
+    assert golden_hash(reordered) == golden_hash(snap)
+
+
+def test_adding_fiction_field_does_not_change_hash():
+    snap = _fixture_snapshot()
+    base = golden_hash(snap)
+
+    noisy = copy.deepcopy(snap)
+    # Add / mutate ONLY fiction / prose / narration / timestamp / RNG noise.
+    noisy["summary"] = "A completely different summary — still fiction."
+    noisy["lore"].append("A brand-new lore page.")
+    noisy["scenes"].append({"read_aloud": "New boxed text."})
+    noisy["updated_at"] = 9999999999.0
+    noisy["created_at"] = 1.0
+    noisy["engine_sha"] = "deadbeef"
+    noisy["rng_seed"] = 424242  # unknown noise key
+    noisy["recent_narration"] = "The torch gutters as you descend the stair."
+    noisy["characters"]["char_pc"]["personality"] = "rewritten personality prose"
+    noisy["characters"]["char_pc"]["backstory"] = "rewritten backstory prose"
+    noisy["characters"]["char_npc"]["memory"].append("a new remembered fiction beat")
+    noisy["quests"]["q_main"]["description"] = "rewritten quest prose"
+    noisy["factions"]["fac_harpers"]["description"] = "rewritten faction prose"
+
+    assert golden_hash(noisy) == base
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda s: s["flags"].update({"prize_seized": False}), id="flag_flip"),
+        pytest.param(lambda s: s["factions"]["fac_harpers"].update({"reputation": -50}), id="reputation"),
+        pytest.param(lambda s: s["factions"]["fac_harpers"].update({"standing": 99}), id="standing"),
+        pytest.param(lambda s: s["quests"]["q_main"].update({"status": "completed"}), id="quest_status"),
+        pytest.param(
+            lambda s: s["quests"]["q_main"]["completed_objectives"].append("confront the warlock"),
+            id="quest_stage",
+        ),
+        pytest.param(lambda s: s["characters"]["char_npc"].update({"attitude_value": -40}), id="attitude_value"),
+        pytest.param(lambda s: s.update({"day": 99}), id="day"),
+        pytest.param(lambda s: s.update({"time_of_day": "midnight"}), id="time_of_day"),
+        pytest.param(lambda s: s["quest_outcomes"].update({"main_arc": "hope_ending"}), id="quest_outcome"),
+        pytest.param(
+            lambda s: s["world_state"]["facts"].update({"the_emperor": "allied"}),
+            id="world_state_fact",
+        ),
+        pytest.param(lambda s: s["party"].append("char_new"), id="party_roster"),
+        pytest.param(lambda s: s.update({"last_combat_resolution": "captured"}), id="combat_resolution"),
+    ],
+)
+def test_changing_regression_value_changes_hash(mutate):
+    snap = _fixture_snapshot()
+    base = golden_hash(snap)
+    mutated = copy.deepcopy(snap)
+    mutate(mutated)
+    assert mutated != snap  # the mutation actually changed the dict
+    assert golden_hash(mutated) != base
+
+
+def test_projection_excludes_fiction_keys():
+    """The projection json must not carry any prose/narration field verbatim."""
+    snap = _fixture_snapshot()
+    proj = project_snapshot(snap)
+    blob = json.dumps(proj)
+    for forbidden in (
+        "world-bible prose",
+        "Boxed text",
+        "backstory the DM voices",
+        "Prose about Rolan",
+        "Long quest prose",
+        "Faction lore prose",
+        "night raid",
+    ):
+        assert forbidden not in blob, f"fiction leaked into projection: {forbidden!r}"
+
+
+def test_cli_hash_only(tmp_path):
+    """The CLI prints a bare 64-char sha256 with --hash-only, and JSON otherwise."""
+    import subprocess
+
+    snap = _fixture_snapshot()
+    p = tmp_path / "snapshot.json"
+    p.write_text(json.dumps(snap), encoding="utf-8")
+
+    out_hash = subprocess.run(
+        [sys.executable, str(_MOD_PATH), str(p), "--hash-only"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    assert len(out_hash) == 64
+    assert out_hash == golden_hash(snap)
+
+    out_json = subprocess.run(
+        [sys.executable, str(_MOD_PATH), str(p)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    # The non-hash output is the canonical projection JSON.
+    parsed = json.loads(out_json)
+    assert parsed == project_snapshot(snap)

--- a/qa/test_velocity_gates.sh
+++ b/qa/test_velocity_gates.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# VELOCITY-GATES TEST (no model call, $0, deterministic) — proves the two inner-loop
+# friction-cutters are ADDITIVE and OFF by default:
+#
+#   (A) qa/fast_gate.sh OPT-IN green-cache (CLAWDND_FASTGATE_CACHE=1):
+#       - default OFF  => the inner gate runs EVERY time (today's behavior, untouched).
+#       - cache ON     => a 1st run executes the inner gate + records a green verdict keyed on
+#                         (git HEAD + persona + gate args); a 2nd run on the SAME key short-circuits
+#                         to the cached verdict WITHOUT re-running the inner gate.
+#       - a RED inner result is NEVER cached (you must be able to re-run and see it fail).
+#
+#   (B) qa/release_gate.sh RAM-aware PREFLIGHT:
+#       - under a forced-LOW-RAM stub the preflight WARNS by default (warning-only — today's
+#         sweep still proceeds) and REFUSES (non-zero, "GATE-ABORT") under
+#         CLAWDND_RAM_PREFLIGHT_STRICT=1, pointing at GitHub CI / the support VM.
+#       - under a forced-HIGH-RAM stub the preflight is silent-OK even in strict mode.
+#
+# We drive both scripts WITHOUT touching Eva / the gateway / any model: the inner fast-gate run is
+# mocked via CLAWDND_FASTGATE_INNER_CMD, and available RAM is forced via CLAWDND_RAM_PREFLIGHT_AVAIL_MB.
+# We invoke release_gate's preflight in --preflight-only mode so no sweep ever launches.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+fail=0
+chk() { if eval "$2"; then echo "PASS: $1"; else echo "FAIL: $1"; fail=1; fi; }
+
+# ──────────────────────────────────────────────────────────────────────────────
+# (A) fast_gate.sh green-cache
+# ──────────────────────────────────────────────────────────────────────────────
+# Mock inner gate: increments a counter file each time it runs, and obeys an exit code we control.
+# This lets us assert the inner gate was (not) invoked on the 2nd run.
+COUNTER="$TMP/inner_runs"; : > "$COUNTER"
+CACHE_HOME="$TMP/cache"            # redirect the cache root away from the repo
+
+mk_inner() {  # $1 = exit code the mock inner gate should return
+  local rc="$1"
+  cat > "$TMP/inner.sh" <<STUB
+#!/usr/bin/env bash
+printf 'x' >> "$COUNTER"
+echo "  ✓ deterministic engine tier: 42 passed (MOCK)"
+exit $rc
+STUB
+  chmod +x "$TMP/inner.sh"
+}
+runs() { cat "$COUNTER" 2>/dev/null; }   # emits the accumulated 'x' marks (one per inner-gate run)
+
+run_fastgate() {  # runs fast_gate.sh with the mocked inner + redirected cache home
+  CLAWDND_FASTGATE_CACHE=1 \
+  CLAWDND_FASTGATE_INNER_CMD="$TMP/inner.sh" \
+  CLAWDND_FASTGATE_CACHE_DIR="$CACHE_HOME" \
+  CLAWDND_FASTGATE_PERSONA="velocity-test" \
+    bash "$ROOT/qa/fast_gate.sh" >"$TMP/fg.out" 2>&1
+}
+
+# A0: default OFF — inner gate runs every time, no cache dir created.
+: > "$COUNTER"; mk_inner 0
+CLAWDND_FASTGATE_INNER_CMD="$TMP/inner.sh" CLAWDND_FASTGATE_CACHE_DIR="$TMP/cache_off" \
+  bash "$ROOT/qa/fast_gate.sh" >/dev/null 2>&1
+CLAWDND_FASTGATE_INNER_CMD="$TMP/inner.sh" CLAWDND_FASTGATE_CACHE_DIR="$TMP/cache_off" \
+  bash "$ROOT/qa/fast_gate.sh" >/dev/null 2>&1
+chk "cache OFF by default: inner gate runs BOTH times (today's behavior)" '[ "$(runs)" = "xx" ]'
+chk "cache OFF by default: no cache dir is created"                       '[ ! -d "$TMP/cache_off" ]'
+
+# A1: cache ON, GREEN — 1st run executes the inner gate.
+: > "$COUNTER"; mk_inner 0
+run_fastgate; rc1=$?
+chk "cache ON, 1st run: inner gate executed once"  '[ "$(runs)" = "x" ]'
+chk "cache ON, 1st run: PASS exit 0"               '[ "$rc1" = "0" ]'
+
+# A2: cache ON, GREEN — 2nd run on the SAME key short-circuits, inner gate NOT re-run.
+run_fastgate; rc2=$?
+chk "cache ON, 2nd run: inner gate NOT re-run (still one execution)" '[ "$(runs)" = "x" ]'
+chk "cache ON, 2nd run: still PASS exit 0"                          '[ "$rc2" = "0" ]'
+chk "cache ON, 2nd run: announces a cache HIT"                      'grep -qi "cache" "$TMP/fg.out" && grep -qi "hit\|cached" "$TMP/fg.out"'
+
+# A3: a RED inner result is NEVER cached — re-runs keep executing the inner gate.
+: > "$COUNTER"; CACHE_HOME="$TMP/cache_red"; mk_inner 1
+run_fastgate; rcr1=$?
+run_fastgate; rcr2=$?
+chk "cache ON, RED is not cached: inner gate runs BOTH times" '[ "$(runs)" = "xx" ]'
+chk "cache ON, RED 1st run: non-zero exit"                    '[ "$rcr1" != "0" ]'
+chk "cache ON, RED 2nd run: still non-zero exit"              '[ "$rcr2" != "0" ]'
+
+# ──────────────────────────────────────────────────────────────────────────────
+# (B) release_gate.sh RAM-aware preflight
+# ──────────────────────────────────────────────────────────────────────────────
+# We run release_gate in --preflight-only mode so the heavy sweep never launches, and force the
+# "available RAM" reading via CLAWDND_RAM_PREFLIGHT_AVAIL_MB. We don't care whether the OTHER
+# integrity checks (art / port / sha) pass — we only assert the RAM-preflight branch behaves.
+run_preflight() {  # $1 = forced avail MB ; $2..= extra env assignments (e.g. STRICT=1)
+  local avail="$1"; shift
+  env "$@" CLAWDND_RAM_PREFLIGHT_AVAIL_MB="$avail" \
+    bash "$ROOT/qa/release_gate.sh" --preflight-only >"$TMP/rg.out" 2>&1
+}
+
+# B0: LOW RAM, default (non-strict) — WARNS but does NOT abort on the RAM check.
+run_preflight 800 >/dev/null 2>&1 || true   # may still fail on art/port; that's fine
+chk "low-RAM non-strict: emits a RAM warning"                'grep -qi "RAM\|memory" "$TMP/rg.out" && grep -qi "low\|below\|pressure\|warn" "$TMP/rg.out"'
+chk "low-RAM non-strict: points at CI / support VM"          'grep -qi "CI\|support VM\|support-vm\|GitHub" "$TMP/rg.out"'
+chk "low-RAM non-strict: did NOT abort on the RAM check"     '! grep -qi "GATE-ABORT.*RAM\|GATE-ABORT.*memory" "$TMP/rg.out"'
+
+# B1: LOW RAM, STRICT — REFUSES with a non-zero exit and a clear RAM abort message.
+run_preflight 800 CLAWDND_RAM_PREFLIGHT_STRICT=1; rc_strict=$?
+chk "low-RAM strict: refuses (non-zero exit)"                '[ "$rc_strict" != "0" ]'
+chk "low-RAM strict: aborts ON the RAM check specifically"   'grep -qi "GATE-ABORT" "$TMP/rg.out" && grep -qi "RAM\|memory" "$TMP/rg.out"'
+
+# B2: HIGH RAM, STRICT — the RAM gate is silent-OK (no RAM warning, no RAM abort).
+run_preflight 64000 CLAWDND_RAM_PREFLIGHT_STRICT=1 >/dev/null 2>&1 || true  # may fail later on art/port
+chk "high-RAM strict: no RAM abort"   '! grep -qi "GATE-ABORT.*RAM\|GATE-ABORT.*memory" "$TMP/rg.out"'
+chk "high-RAM strict: no low-RAM warning" '! ( grep -qi "RAM\|memory" "$TMP/rg.out" && grep -qi "below\|low\b" "$TMP/rg.out" )'
+
+echo ""
+[ "$fail" = 0 ] && echo "ALL ASSERTIONS PASSED" || echo "SOME ASSERTIONS FAILED"
+exit "$fail"

--- a/servers/engine/pyproject.toml
+++ b/servers/engine/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=8"]
+dev = ["pytest>=8", "pytest-cov>=6.0", "pytest-timeout>=2.3"]
 
 [tool.uv]
 package = false
@@ -17,3 +17,4 @@ package = false
 [tool.pytest.ini_options]
 pythonpath = ["."]
 testpaths = ["tests"]
+addopts = "--tb=short"

--- a/servers/engine/tests/conftest.py
+++ b/servers/engine/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest configuration for the engine test suite.
+
+Additive test-hygiene infra (WorldOS QA Lab Phase-1). Registers the custom
+markers used to opt slow / occasionally-flaky tests out of the default fast
+lane. Empty == today's behavior: nothing is marked yet, so collection and
+execution are unchanged. This file only *declares* the markers so that
+`-W error::pytest.PytestUnknownMarkWarning` (or `--strict-markers`) stays
+green once tests start using them.
+"""
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    )
+    config.addinivalue_line(
+        "markers",
+        "flaky: marks tests as occasionally flaky (may be retried or quarantined)",
+    )

--- a/servers/engine/uv.lock
+++ b/servers/engine/uv.lock
@@ -90,6 +90,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -99,7 +101,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8" }]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
+]
 
 [[package]]
 name = "click"
@@ -120,6 +126,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/d7/477ad149490e6cb849f28abea1dabb9c823cea72e7500c81b4240ce619c0/coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f", size = 219848, upload-time = "2026-05-26T20:38:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/91/82/a5eb47257c50601bb7b9a9d2857c67b7a3a85ad74180eb2c98bb1fbe0ce5/coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4", size = 220354, upload-time = "2026-05-26T20:38:40.232Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8b/78419b5391a5cb706b6544390507e469d83ffc9a8248b02c4011aceb9365/coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1", size = 250771, upload-time = "2026-05-26T20:38:41.782Z" },
+    { url = "https://files.pythonhosted.org/packages/77/63/e77aaacd491182210d639636b7a8bba23ffffa9b82aa3762da9431855fa9/coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f", size = 252683, upload-time = "2026-05-26T20:38:43.305Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/a022e3cfbec2ac241640003cb3a817e161d9c7f5aa9b49173756cdc03204/coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129", size = 254791, upload-time = "2026-05-26T20:38:45.361Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d6/967e408aca4c1ceb88cb0cc677169110ae7f5995fb5eaf5fb1f5a1bb8f5d/coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860", size = 256748, upload-time = "2026-05-26T20:38:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/be/869188f7fe28638078ec479331ace6dc5f7b40b7153eb616f47ab79404d8/coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c", size = 250907, upload-time = "2026-05-26T20:38:48.493Z" },
+    { url = "https://files.pythonhosted.org/packages/07/aa/adb7d3b4278d690e68703abcd76ab1b948242e3668d921711551b78f9ddb/coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7", size = 252483, upload-time = "2026-05-26T20:38:50.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/61/331c74103c62dcb0c4b9b3a0de9a61aca016208b0a90f109592a9f9ecc28/coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec", size = 250545, upload-time = "2026-05-26T20:38:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b6/c5dae3c104d89be04828f61810e6b3473825482e4c288cc4ed04553e08ae/coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef", size = 254310, upload-time = "2026-05-26T20:38:53.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a1/2b9d5863e3b83c01ad8199e3c597802fbb3a9dc90b058885804c20296d31/coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df", size = 250266, upload-time = "2026-05-26T20:38:55.414Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/0e511fbdb269359be26fe678a1c3fa1f2aa2a01573cc3f54268c8d6d4797/coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9", size = 251174, upload-time = "2026-05-26T20:38:57.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/10/e55307b622b3dd9671cb321824502dc10f93e72f2802b9946159a8edadeb/coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548", size = 222354, upload-time = "2026-05-26T20:38:58.727Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/107421693cfb71e4f1ca5bf70443f64d4161878068d07a3e51c7ad21d17b/coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e", size = 223290, upload-time = "2026-05-26T20:39:00.413Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/1d/3e3644585eb29e9dafefb19555078529a4d7cce12bd21929664eea989277/coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3", size = 221953, upload-time = "2026-05-26T20:39:02.159Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -436,6 +486,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -554,6 +630,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/servers/integration_tests/__init__.py
+++ b/servers/integration_tests/__init__.py
@@ -1,0 +1,7 @@
+"""WorldOS QA Lab Phase-1 — cross-service contract tests.
+
+Deterministic, gateway-free proof of the engine / rules / voice MCP boundaries.
+No live LLM, null TTS backend, offline rules (no network). See
+``test_server_contracts.py`` for the suite and ``conftest.py`` for the import /
+subprocess fixtures.
+"""

--- a/servers/integration_tests/conftest.py
+++ b/servers/integration_tests/conftest.py
@@ -1,0 +1,222 @@
+"""Fixtures for the cross-service contract suite.
+
+Two import strategies, picked per server by what the *engine* venv can load
+in-process (the suite runs under the engine venv, per the sprint spec):
+
+  * **voice** — imported IN-PROCESS. The voice server's only hard dep is ``mcp``,
+    which the engine venv has, so we import its ``server`` module directly and
+    force the NULL TTS backend (no PyTorch / Kokoro / audio). Lightest +
+    deterministic.
+
+  * **rules** — driven through ONE long-lived SUBPROCESS. The rules server imports
+    ``rapidfuzz`` at module top level and that wheel is NOT installed in the
+    engine venv, so an in-process import is not feasible here. Instead a single
+    worker process is launched in the *rules* venv (which has rapidfuzz),
+    imports the rules ``server`` once, and answers JSON line-protocol requests
+    over stdin/stdout. One process for the whole session keeps it fast
+    (~0.3s cold, then near-instant) and single-process from the host's view —
+    no xdist, no per-test spawn. ``CLAWDND_RULES_OFFLINE=1`` is set in its env
+    exactly as the rules suite does, so it never touches the network.
+
+The engine is the SOLE WRITER of state and the player facade is READ-ONLY; this
+suite only *reads* across the MCP boundaries (lookups + speak), so it is
+gateway-free and never mutates game state, Eva, or any global config.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Repo / server layout (absolute paths — cwd is not assumed).
+# ---------------------------------------------------------------------------
+SERVERS_DIR = Path(__file__).resolve().parent.parent          # .../servers
+REPO_ROOT = SERVERS_DIR.parent                                # repo root
+ENGINE_DIR = SERVERS_DIR / "engine"
+RULES_DIR = SERVERS_DIR / "rules"
+VOICE_DIR = SERVERS_DIR / "voice"
+
+RULES_VENV_PY = RULES_DIR / ".venv" / "bin" / "python"
+
+
+# ---------------------------------------------------------------------------
+# voice — in-process import under the engine venv, NULL backend forced.
+# ---------------------------------------------------------------------------
+@pytest.fixture(scope="session")
+def voice_server(monkeypatch_session):
+    """The voice MCP ``server`` module, imported in-process with the silent
+    NULL TTS backend so no audio / PyTorch is ever touched (CI-safe)."""
+    # Force the null backend before the module (and any lazy backend build) runs.
+    monkeypatch_session.setenv("WORLDOS_TTS_BACKEND", "null")
+    monkeypatch_session.setenv("CLAWDND_TTS_BACKEND", "null")
+    # The voice package uses `pythonpath = ["."]`; mirror that so `import server`,
+    # `import registry`, `from _env import ...`, `from interface import ...`
+    # resolve to the voice package, not the engine one.
+    if str(VOICE_DIR) not in sys.path:
+        sys.path.insert(0, str(VOICE_DIR))
+    import importlib
+
+    # Import (or re-import) cleanly so the forced env var is in effect.
+    for name in ("server", "registry", "interface", "stt", "_env"):
+        sys.modules.pop(name, None)
+    mod = importlib.import_module("server")
+    # Sanity: we really are on the null backend, not Kokoro.
+    assert mod._backend_name() == "null"
+    return mod
+
+
+@pytest.fixture(scope="session")
+def monkeypatch_session():
+    """A session-scoped monkeypatch (the built-in one is function-scoped)."""
+    mp = pytest.MonkeyPatch()
+    yield mp
+    mp.undo()
+
+
+# ---------------------------------------------------------------------------
+# rules — one long-lived subprocess worker in the rules venv (offline).
+# ---------------------------------------------------------------------------
+# Worker program: import the rules `server` once, then loop reading one JSON
+# request per line {"fn": "<name>", "args": [...]} and emit one JSON reply per
+# line {"ok": true, "result": ...} / {"ok": false, "error": "..."}. stdout is
+# kept clean (JSON only); the _env deprecation banner goes to stderr. The rules
+# dir is passed via argv[1] (NOT str.format) so the program needs no brace
+# escaping and stays readable.
+_RULES_WORKER = r"""
+import json, sys
+sys.path.insert(0, sys.argv[1])
+import server as s
+
+# Whitelisted read-only entrypoints exposed across the boundary.
+_FNS = {
+    "find_condition": s.find_condition,
+    "find_spell": s.find_spell,
+    "find_monster": s.find_monster,
+    "find_rule": s.find_rule,
+    "find_item": s.find_item,
+    "find_feat": s.find_feat,
+    "find_class": s.find_class,
+    "find_background": s.find_background,
+    "find_species": s.find_species,
+    "search": s.search,
+    "lookup_spell": s.lookup_spell,
+    "lookup_monster": s.lookup_monster,
+    "lookup_condition": s.lookup_condition,
+    "sizes": lambda: {
+        "conditions": len(s._CONDITIONS), "spells": len(s._SPELLS),
+        "monsters": len(s._MONSTERS), "rules": len(s._RULES),
+    },
+}
+
+sys.stdout.write("READY\n")
+sys.stdout.flush()
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        req = json.loads(line)
+        if req.get("fn") == "__quit__":
+            break
+        fn = _FNS[req["fn"]]
+        result = fn(*req.get("args", []), **req.get("kwargs", {}))
+        sys.stdout.write(json.dumps({"ok": True, "result": result}) + "\n")
+    except Exception as exc:  # report, don't die — keeps the worker alive
+        sys.stdout.write(json.dumps({"ok": False, "error": f"{type(exc).__name__}: {exc}"}) + "\n")
+    sys.stdout.flush()
+"""
+
+
+class RulesClient:
+    """Thin JSON-line client over the long-lived rules worker subprocess."""
+
+    def __init__(self, proc: subprocess.Popen):
+        self._proc = proc
+
+    def call(self, fn: str, *args, **kwargs):
+        req = json.dumps({"fn": fn, "args": list(args), "kwargs": kwargs})
+        assert self._proc.stdin is not None and self._proc.stdout is not None
+        self._proc.stdin.write(req + "\n")
+        self._proc.stdin.flush()
+        line = self._proc.stdout.readline()
+        if not line:
+            raise RuntimeError("rules worker closed unexpectedly")
+        reply = json.loads(line)
+        if not reply.get("ok"):
+            raise RuntimeError(f"rules worker error: {reply.get('error')}")
+        return reply["result"]
+
+    # Convenience wrappers mirroring the rules server's public API.
+    def find_spell(self, name):
+        return self.call("find_spell", name)
+
+    def find_monster(self, name):
+        return self.call("find_monster", name)
+
+    def find_condition(self, name):
+        return self.call("find_condition", name)
+
+    def find_rule(self, name):
+        return self.call("find_rule", name)
+
+    def find_item(self, name):
+        return self.call("find_item", name)
+
+    def search(self, query, category=None):
+        return self.call("search", query, **({"category": category} if category else {}))
+
+    def lookup_spell(self, name):
+        return self.call("lookup_spell", name)
+
+    def sizes(self):
+        return self.call("sizes")
+
+
+@pytest.fixture(scope="session")
+def rules_client():
+    """A session-scoped, single subprocess client for the rules server.
+
+    Launched in the rules venv (has rapidfuzz) with the network disabled. One
+    process serves the whole module — no parallel workers, no per-test spawn.
+    """
+    if not RULES_VENV_PY.exists():
+        pytest.skip(f"rules venv python not found at {RULES_VENV_PY}")
+    env = dict(os.environ)
+    env["CLAWDND_RULES_OFFLINE"] = "1"   # offline, exactly as the rules suite sets it
+    env["WORLDOS_RULES_OFFLINE"] = "1"   # canonical name too (no deprecation noise)
+    env["PYTHONUNBUFFERED"] = "1"
+    proc = subprocess.Popen(
+        [str(RULES_VENV_PY), "-c", _RULES_WORKER, str(RULES_DIR)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,  # swallow the _env deprecation banner
+        text=True,
+        cwd=str(RULES_DIR),
+        env=env,
+    )
+    # Wait for the worker's READY handshake (bounded so a broken import fails fast).
+    try:
+        assert proc.stdout is not None
+        ready = proc.stdout.readline().strip()
+        if ready != "READY":
+            proc.kill()
+            raise RuntimeError(f"rules worker failed to start (got {ready!r})")
+    except Exception:
+        proc.kill()
+        raise
+    client = RulesClient(proc)
+    yield client
+    # Teardown: ask it to quit, then ensure it's gone.
+    try:
+        if proc.stdin is not None and proc.poll() is None:
+            proc.stdin.write(json.dumps({"fn": "__quit__"}) + "\n")
+            proc.stdin.flush()
+        proc.wait(timeout=5)
+    except Exception:
+        proc.kill()

--- a/servers/integration_tests/test_server_contracts.py
+++ b/servers/integration_tests/test_server_contracts.py
@@ -1,0 +1,232 @@
+"""Cross-service contract tests for the WorldOS MCP boundaries.
+
+Deterministic and gateway-free: no live LLM, NULL TTS backend, OFFLINE rules
+(no network). These prove the SHAPES the DM / orchestrator relies on when it
+calls across the engine / rules / voice services — so a schema drift on any one
+boundary fails here instead of silently corrupting a live game.
+
+Run (single-process, under the engine venv)::
+
+    uv run --directory servers/engine python -m pytest servers/integration_tests -q -p no:xdist
+
+The rules calls go through ONE long-lived subprocess worker in the rules venv
+(see conftest); voice is imported in-process on the NULL backend.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Expected reply schemas (the contract the DM depends on).
+_SPELL_KEYS = {"name", "level", "school", "_source"}
+_MONSTER_KEYS = {"name", "ac", "hp", "abilities", "_source"}
+_CONDITION_KEYS = {"name", "_source"}
+_SPEAK_KEYS = {"ok", "voice_id", "backend", "backend_voice", "audio_path", "played", "detail"}
+_TRANSCRIBE_KEYS = {"text", "backend"}
+
+
+# ===========================================================================
+# (a) engine -> rules: exact-match lookups + schema on the bundled SRD.
+# ===========================================================================
+class TestRulesExactMatchAndSchema:
+    def test_rules_worker_offline_dataset_loaded(self, rules_client):
+        # Proves the worker booted in the rules venv with the full bundled SRD
+        # merged in (not just the starter slice) and the network disabled.
+        sizes = rules_client.sizes()
+        assert sizes["spells"] > 100
+        assert sizes["monsters"] > 100
+        assert sizes["conditions"] >= 14
+
+    def test_spell_exact_match_fireball(self, rules_client):
+        r = rules_client.find_spell("Fireball")
+        assert r is not None
+        assert r["name"] == "Fireball"
+        assert r["level"] == 3
+        assert r["school"] == "Evocation"
+        assert r["_source"] == "srd-bundled"  # came from bundled data, NOT the API
+
+    def test_spell_exact_match_schema(self, rules_client):
+        r = rules_client.find_spell("Fire Bolt")
+        assert r is not None
+        # Contract: every spell carries at least these keys.
+        assert _SPELL_KEYS <= set(r.keys())
+        assert r["level"] == 0
+        assert r["school"] == "Evocation"
+
+    def test_monster_exact_match_goblin(self, rules_client):
+        r = rules_client.find_monster("goblin")
+        assert r is not None
+        assert r["name"] == "Goblin"
+        assert r["ac"] == 15 and r["hp"] == 7
+        assert r["abilities"]["dex"] == 14
+        assert r["_source"] == "srd-bundled"
+
+    def test_monster_exact_match_schema(self, rules_client):
+        r = rules_client.find_monster("Tarrasque")
+        assert r is not None
+        assert _MONSTER_KEYS <= set(r.keys())
+        assert r["cr"] == "30"
+        assert r["abilities"]["str"] == 30
+        assert r["actions"]  # actions joined from the fixture children
+
+    def test_condition_exact_match_prone(self, rules_client):
+        r = rules_client.find_condition("prone")
+        assert r is not None
+        assert r["name"] == "Prone"
+        assert _CONDITION_KEYS <= set(r.keys())
+        assert r["_source"] == "srd-bundled"
+
+    def test_rule_lookup_advantage(self, rules_client):
+        r = rules_client.find_rule("advantage")
+        assert r is not None
+        assert "Advantage" in r["name"]
+        assert r["_source"] == "srd-bundled"
+
+    def test_item_lookup_schema(self, rules_client):
+        longsword = rules_client.find_item("Longsword")
+        assert longsword is not None and longsword["damage"] == "1d8"
+        bag = rules_client.find_item("Bag of Holding")
+        assert bag is not None and bag["rarity"] == "uncommon"
+
+    def test_lookup_spell_tool_wrap_found(self, rules_client):
+        # The MCP tool wraps results as {"found": True/False, ...} — the shape
+        # the orchestrator branches on.
+        wrapped = rules_client.lookup_spell("Fireball")
+        assert wrapped["found"] is True
+        assert wrapped["name"] == "Fireball"
+
+    def test_lookup_spell_tool_wrap_miss(self, rules_client):
+        wrapped = rules_client.lookup_spell("definitely-not-a-spell-zzz")
+        assert wrapped["found"] is False
+        assert wrapped["query"] == "definitely-not-a-spell-zzz"
+        assert "name" not in wrapped  # miss carries only found + query
+
+    def test_unknown_returns_none_offline(self, rules_client):
+        # Genuinely absent + offline -> None (no silent API fallthrough).
+        assert rules_client.find_spell("not-a-spell-zzz") is None
+        assert rules_client.find_monster("definitely-not-a-real-monster-xyz") is None
+
+
+# ===========================================================================
+# (b) rules fuzzy recovery: typo'd / mangled queries recover the right entry.
+# ===========================================================================
+class TestRulesFuzzyRecovery:
+    def test_condition_typo_recovers(self, rules_client):
+        r = rules_client.find_condition("prnoe")  # transposed
+        assert r is not None and r["name"] == "Prone"
+
+    def test_spell_spacing_recovers(self, rules_client):
+        r = rules_client.find_spell("magicmissile")  # missing space
+        assert r is not None and r["name"] == "Magic Missile"
+
+    def test_spell_truncation_recovers_fullset(self, rules_client):
+        # A full-set entry (not in the starter slice) recovered from a typo.
+        r = rules_client.find_spell("firebal")
+        assert r is not None and r["name"] == "Fireball"
+
+    def test_fuzzy_recovers_exact_level_and_school(self, rules_client):
+        # Fuzzy match still returns the canonical record, not a near-miss.
+        r = rules_client.find_spell("firebal")
+        assert r["level"] == 3 and r["school"] == "Evocation"
+
+    def test_search_substring_across_layers(self, rules_client):
+        names = {h["name"] for h in rules_client.search("fire")}
+        assert "Fire Bolt" in names      # starter slice
+        assert "Fireball" in names       # full set
+
+    def test_search_category_filter(self, rules_client):
+        hits = rules_client.search("go", category="monster")
+        assert any(h["name"] == "Goblin" for h in hits)
+        assert all(h["category"] == "monster" for h in hits)
+
+
+# ===========================================================================
+# (c) engine -> voice: speak() on the NULL backend returns the schema and
+#     degrades gracefully when the backend is unavailable (never raises).
+# ===========================================================================
+class TestVoiceContract:
+    def test_speak_null_backend_schema(self, voice_server):
+        out = voice_server.speak("Hello, adventurer.", voice_id="narrator-dm", play=False)
+        assert set(out.keys()) == _SPEAK_KEYS
+        assert out["ok"] is True
+        assert out["backend"] == "null"
+        assert out["voice_id"] == "narrator-dm"
+        assert out["audio_path"] is None
+        assert out["played"] is False
+
+    def test_speak_resolves_logical_voice_id(self, voice_server):
+        # The logical voice_id is echoed back unchanged; the backend voice is
+        # resolved separately (registry), so character data never depends on the
+        # active backend.
+        out = voice_server.speak("A line.", voice_id="companion-default", play=False)
+        assert out["voice_id"] == "companion-default"
+        assert isinstance(out["backend_voice"], str)
+
+    def test_speak_default_voice_id(self, voice_server):
+        out = voice_server.speak("Narration.", play=False)
+        assert out["voice_id"] == "narrator-dm"  # documented default
+        assert out["ok"] is True
+
+    def test_list_voices_null_backend(self, voice_server):
+        voices = voice_server.list_voices()
+        assert isinstance(voices, list) and voices
+        assert all("id" in v and "name" in v for v in voices)
+
+    def test_transcribe_null_backend_schema(self, voice_server):
+        out = voice_server.transcribe("/nonexistent/audio.wav")
+        assert set(out.keys()) == _TRANSCRIBE_KEYS
+        assert isinstance(out["text"], str)
+        assert out["backend"]  # a backend name is always reported
+
+    def test_speak_degrades_when_backend_raises(self, voice_server, monkeypatch):
+        # A TTS backend that blows up (missing deps / model-load / playback) must
+        # DEGRADE to the silent null backend and STILL return cleanly — never
+        # raise out of speak() and break the story loop (#55). Voice is an
+        # adapter: the engine rolls, the DM is told; a dead speaker is text-only.
+        class Boom:
+            name = "kokoro"
+
+            def speak(self, *a, **k):
+                raise ImportError("kokoro/torch unavailable")
+
+        monkeypatch.setenv("CLAWDND_TTS_BACKEND", "kokoro")
+        monkeypatch.setenv("WORLDOS_TTS_BACKEND", "kokoro")
+        monkeypatch.setitem(voice_server._backends, "kokoro", Boom())
+        out = voice_server.speak("The dragon roars.", voice_id="narrator-dm", play=False)
+        assert out["ok"] is True            # never raised
+        assert out["backend"] == "null"     # fell back to silent
+        assert out["audio_path"] is None
+        assert "fail" in out["detail"].lower()
+        assert set(out.keys()) == _SPEAK_KEYS  # same schema as the happy path
+
+    def test_speak_never_raises_on_unknown_voice_id(self, voice_server):
+        # An unknown logical voice_id still resolves (registry falls back) and
+        # returns the contract schema rather than raising.
+        out = voice_server.speak("Mystery speaker.", voice_id="totally-unknown-xyz", play=False)
+        assert out["ok"] is True
+        assert set(out.keys()) == _SPEAK_KEYS
+        assert out["voice_id"] == "totally-unknown-xyz"
+
+
+# ===========================================================================
+# Cross-boundary integration: a single fictional beat touches both services
+# the same way the DM would — rules lookup feeds the voiced narration. Proves
+# the two boundaries compose without sharing state (gateway-free, no mutation).
+# ===========================================================================
+class TestCrossBoundaryComposition:
+    def test_rules_lookup_then_voiced_narration(self, rules_client, voice_server):
+        spell = rules_client.find_spell("Fireball")
+        assert spell["name"] == "Fireball" and spell["level"] == 3
+        line = f"The mage hurls a level-{spell['level']} {spell['name']}!"
+        out = voice_server.speak(line, voice_id="narrator-dm", play=False)
+        assert out["ok"] is True and out["backend"] == "null"
+        assert set(out.keys()) == _SPEAK_KEYS
+
+    def test_boundaries_are_independent(self, rules_client, voice_server):
+        # Reading rules does not change anything the voice boundary returns, and
+        # vice versa — neither service is the state writer (engine is).
+        before = voice_server.speak("Before.", play=False)
+        rules_client.find_monster("goblin")
+        after = voice_server.speak("After.", play=False)
+        assert before["backend"] == after["backend"] == "null"
+        assert before["voice_id"] == after["voice_id"]

--- a/servers/rules/pyproject.toml
+++ b/servers/rules/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=8"]
+dev = ["pytest>=8", "pytest-cov>=6.0", "pytest-timeout>=2.3"]
 
 [tool.uv]
 package = false
@@ -18,3 +18,4 @@ package = false
 [tool.pytest.ini_options]
 pythonpath = ["."]
 testpaths = ["tests"]
+addopts = "--tb=short"

--- a/servers/rules/tests/conftest.py
+++ b/servers/rules/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest configuration for the rules test suite.
+
+Additive test-hygiene infra (WorldOS QA Lab Phase-1). Registers the custom
+markers used to opt slow / occasionally-flaky tests out of the default fast
+lane. Empty == today's behavior: nothing is marked yet, so collection and
+execution are unchanged. This file only *declares* the markers so that
+`-W error::pytest.PytestUnknownMarkWarning` (or `--strict-markers`) stays
+green once tests start using them.
+"""
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    )
+    config.addinivalue_line(
+        "markers",
+        "flaky: marks tests as occasionally flaky (may be retried or quarantined)",
+    )

--- a/servers/rules/uv.lock
+++ b/servers/rules/uv.lock
@@ -91,6 +91,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -101,7 +103,11 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8" }]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
+]
 
 [[package]]
 name = "click"
@@ -122,6 +128,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/d7/477ad149490e6cb849f28abea1dabb9c823cea72e7500c81b4240ce619c0/coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f", size = 219848, upload-time = "2026-05-26T20:38:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/91/82/a5eb47257c50601bb7b9a9d2857c67b7a3a85ad74180eb2c98bb1fbe0ce5/coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4", size = 220354, upload-time = "2026-05-26T20:38:40.232Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8b/78419b5391a5cb706b6544390507e469d83ffc9a8248b02c4011aceb9365/coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1", size = 250771, upload-time = "2026-05-26T20:38:41.782Z" },
+    { url = "https://files.pythonhosted.org/packages/77/63/e77aaacd491182210d639636b7a8bba23ffffa9b82aa3762da9431855fa9/coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f", size = 252683, upload-time = "2026-05-26T20:38:43.305Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/a022e3cfbec2ac241640003cb3a817e161d9c7f5aa9b49173756cdc03204/coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129", size = 254791, upload-time = "2026-05-26T20:38:45.361Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d6/967e408aca4c1ceb88cb0cc677169110ae7f5995fb5eaf5fb1f5a1bb8f5d/coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860", size = 256748, upload-time = "2026-05-26T20:38:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/be/869188f7fe28638078ec479331ace6dc5f7b40b7153eb616f47ab79404d8/coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c", size = 250907, upload-time = "2026-05-26T20:38:48.493Z" },
+    { url = "https://files.pythonhosted.org/packages/07/aa/adb7d3b4278d690e68703abcd76ab1b948242e3668d921711551b78f9ddb/coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7", size = 252483, upload-time = "2026-05-26T20:38:50.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/61/331c74103c62dcb0c4b9b3a0de9a61aca016208b0a90f109592a9f9ecc28/coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec", size = 250545, upload-time = "2026-05-26T20:38:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b6/c5dae3c104d89be04828f61810e6b3473825482e4c288cc4ed04553e08ae/coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef", size = 254310, upload-time = "2026-05-26T20:38:53.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a1/2b9d5863e3b83c01ad8199e3c597802fbb3a9dc90b058885804c20296d31/coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df", size = 250266, upload-time = "2026-05-26T20:38:55.414Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/0e511fbdb269359be26fe678a1c3fa1f2aa2a01573cc3f54268c8d6d4797/coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9", size = 251174, upload-time = "2026-05-26T20:38:57.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/10/e55307b622b3dd9671cb321824502dc10f93e72f2802b9946159a8edadeb/coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548", size = 222354, upload-time = "2026-05-26T20:38:58.727Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/107421693cfb71e4f1ca5bf70443f64d4161878068d07a3e51c7ad21d17b/coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e", size = 223290, upload-time = "2026-05-26T20:39:00.413Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/1d/3e3644585eb29e9dafefb19555078529a4d7cce12bd21929664eea989277/coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3", size = 221953, upload-time = "2026-05-26T20:39:02.159Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -438,6 +488,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -591,6 +667,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/servers/voice/pyproject.toml
+++ b/servers/voice/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["pytest>=8"]
+dev = ["pytest>=8", "pytest-cov>=6.0", "pytest-timeout>=2.3"]
 kokoro = ["kokoro>=0.9.4", "soundfile>=0.13.1"]
 
 [tool.uv]
@@ -17,3 +17,4 @@ package = false
 [tool.pytest.ini_options]
 pythonpath = ["."]
 testpaths = ["tests"]
+addopts = "--tb=short"

--- a/servers/voice/tests/conftest.py
+++ b/servers/voice/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest configuration for the voice test suite.
+
+Additive test-hygiene infra (WorldOS QA Lab Phase-1). Registers the custom
+markers used to opt slow / occasionally-flaky tests out of the default fast
+lane. Empty == today's behavior: nothing is marked yet, so collection and
+execution are unchanged. This file only *declares* the markers so that
+`-W error::pytest.PytestUnknownMarkWarning` (or `--strict-markers`) stays
+green once tests start using them.
+"""
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    )
+    config.addinivalue_line(
+        "markers",
+        "flaky: marks tests as occasionally flaky (may be retried or quarantined)",
+    )

--- a/servers/voice/uv.lock
+++ b/servers/voice/uv.lock
@@ -191,6 +191,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-timeout" },
 ]
 kokoro = [
     { name = "kokoro" },
@@ -201,7 +203,11 @@ kokoro = [
 requires-dist = [{ name = "mcp", specifier = ">=1.2.0" }]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8" }]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
+]
 kokoro = [
     { name = "kokoro", specifier = ">=0.9.4" },
     { name = "soundfile", specifier = ">=0.13.1" },
@@ -244,6 +250,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ca/65/efd0fe8a936fc8ca2978cb7b82581fb20d901c6039e746a808f746b7647b/confection-1.3.3.tar.gz", hash = "sha256:f0f6810d567ff73993fe74d218ca5e1ffb6a44fb03f391257fc5d033546cbfaa", size = 54895, upload-time = "2026-03-24T18:45:24.331Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/e4/d66708bdf0d92fb4d49b22cdff4b10cec38aca5dcd7e81d909bb55c65cd7/confection-1.3.3-py3-none-any.whl", hash = "sha256:b9fef9ee84b237ef4611ec3eb5797b70e13063e6310ad9f15536373f5e313c82", size = 35902, upload-time = "2026-03-24T18:45:22.664Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/d7/477ad149490e6cb849f28abea1dabb9c823cea72e7500c81b4240ce619c0/coverage-7.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:478b5bcd63c2e1357c5c7e16c070690df7b07f676b1c114d7b93e533c664309f", size = 219848, upload-time = "2026-05-26T20:38:38.715Z" },
+    { url = "https://files.pythonhosted.org/packages/91/82/a5eb47257c50601bb7b9a9d2857c67b7a3a85ad74180eb2c98bb1fbe0ce5/coverage-7.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a24a81f9715ee42ef59a316cc11611c98fe23920f7c81861315c9f3ff4a230f4", size = 220354, upload-time = "2026-05-26T20:38:40.232Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8b/78419b5391a5cb706b6544390507e469d83ffc9a8248b02c4011aceb9365/coverage-7.14.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:196a13319ad88d6d8ef5ab489ec4f44ddde2143c0c7d5b27786f6c3ffd56a7e1", size = 250771, upload-time = "2026-05-26T20:38:41.782Z" },
+    { url = "https://files.pythonhosted.org/packages/77/63/e77aaacd491182210d639636b7a8bba23ffffa9b82aa3762da9431855fa9/coverage-7.14.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3d452fd08b5c72c5167c93e6867b5c08500bd40f2a21e1e854a500550b6cc36f", size = 252683, upload-time = "2026-05-26T20:38:43.305Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/a022e3cfbec2ac241640003cb3a817e161d9c7f5aa9b49173756cdc03204/coverage-7.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23bf7fa51ac02e07fc7c96849b82946da47ae862dc8f86d183b2a4864fc38129", size = 254791, upload-time = "2026-05-26T20:38:45.361Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d6/967e408aca4c1ceb88cb0cc677169110ae7f5995fb5eaf5fb1f5a1bb8f5d/coverage-7.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bcaa50684dcaadfa599ac48f81103c756d791cfd85c97203d2217c593d48b860", size = 256748, upload-time = "2026-05-26T20:38:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/be/869188f7fe28638078ec479331ace6dc5f7b40b7153eb616f47ab79404d8/coverage-7.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4ea1c034f95c9b056e856b794630b17f9fa3d57e4800ff1e503d3be0f9c9078c", size = 250907, upload-time = "2026-05-26T20:38:48.493Z" },
+    { url = "https://files.pythonhosted.org/packages/07/aa/adb7d3b4278d690e68703abcd76ab1b948242e3668d921711551b78f9ddb/coverage-7.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c7e057326434e441306226fbeb5d1aaf14a2637efe97ba668306635835f32ad7", size = 252483, upload-time = "2026-05-26T20:38:50.074Z" },
+    { url = "https://files.pythonhosted.org/packages/43/61/331c74103c62dcb0c4b9b3a0de9a61aca016208b0a90f109592a9f9ecc28/coverage-7.14.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:59baf88468dbc8d63b1887afd92bda52e40bb1561696e5819670601403810cec", size = 250545, upload-time = "2026-05-26T20:38:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b6/c5dae3c104d89be04828f61810e6b3473825482e4c288cc4ed04553e08ae/coverage-7.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:d34d75f892b3ab73ba11cab5442cce7b3e168fd64162b16f0e1e0d09c508edef", size = 254310, upload-time = "2026-05-26T20:38:53.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a1/2b9d5863e3b83c01ad8199e3c597802fbb3a9dc90b058885804c20296d31/coverage-7.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3a56abc20a472baf0304c455721bc601477440d28ecfde8a03dde79ede07e0df", size = 250266, upload-time = "2026-05-26T20:38:55.414Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/0e511fbdb269359be26fe678a1c3fa1f2aa2a01573cc3f54268c8d6d4797/coverage-7.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6a3cb83d1552c0cd1b4906655b6a33fd4a8473229633a901c6b73bf86914dee9", size = 251174, upload-time = "2026-05-26T20:38:57.141Z" },
+    { url = "https://files.pythonhosted.org/packages/85/10/e55307b622b3dd9671cb321824502dc10f93e72f2802b9946159a8edadeb/coverage-7.14.1-cp311-cp311-win32.whl", hash = "sha256:10274a1fbeb8ec5d72966e17bb198a3104257aca4ac09d98667c5f8aca8c8548", size = 222354, upload-time = "2026-05-26T20:38:58.727Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/107421693cfb71e4f1ca5bf70443f64d4161878068d07a3e51c7ad21d17b/coverage-7.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:87ebdf787d4888e3f3f2d523eadc6e18c6d18c6d0eb173801a189641627fb37e", size = 223290, upload-time = "2026-05-26T20:39:00.413Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/1d/3e3644585eb29e9dafefb19555078529a4d7cce12bd21929664eea989277/coverage-7.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:dd34767fa19848d35659ffc0a75314f58c7af3f1cd87ec521e8292a1238398a3", size = 221953, upload-time = "2026-05-26T20:39:02.159Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -1219,6 +1269,32 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1746,6 +1822,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
     { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
     { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/viewer/tests/conftest.py
+++ b/viewer/tests/conftest.py
@@ -1,0 +1,20 @@
+"""Shared pytest configuration for the viewer test suite.
+
+Additive test-hygiene infra (WorldOS QA Lab Phase-1). Registers the custom
+markers used to opt slow / occasionally-flaky tests out of the default fast
+lane. Empty == today's behavior: nothing is marked yet, so collection and
+execution are unchanged. This file only *declares* the markers so that
+`-W error::pytest.PytestUnknownMarkWarning` (or `--strict-markers`) stays
+green once tests start using them.
+"""
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers",
+        "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    )
+    config.addinivalue_line(
+        "markers",
+        "flaky: marks tests as occasionally flaky (may be retried or quarantined)",
+    )


### PR DESCRIPTION
## Phase 1 of the QA Lab Autonomous-QA Upgrade Program

Follows a 55-agent adversarial audit of the QA harness (43 verified gaps) and the owner-approved
plan. **Everything here is additive** — empty/unset == today's behavior, old data round-trips,
each piece is independently removable. No load-bearing invariant touched (engine remains sole
state writer; gates read engine-mutated values, never fiction; QA stays gateway-free/null-backend).

### What lands (audit gap IDs)
- **Regression base** — `qa/scores_db.py` gains `persona` + `is_canonical_baseline` columns
  (idempotent `ALTER` migration; `set/get_canonical_baseline`; one canonical baseline per
  surface/model/methodology/lens key). Unblocks the Phase-2 machine-readable regression detector.
  `qa/snapshot_world_state.py` is a read-only golden-state hash over **engine-mutated fields only**
  (fiction/prose/timestamps excluded). [REGRESSION-2/4]
- **Scoring determinism** — `qa/score.sh` pins the scorer model (errors on `CLAWDND_SCORER_MODEL`
  without `CLAWDND_ALLOW_SCORER_OVERRIDE=1`) and stamps a `prompt_construction_hash` so rubric/prompt
  drift is detectable across versions (`qa/_score_prompt_hash.py`). `qa/test_lens_variance.py` +
  `qa/SCORING.md` publish the measured per-lens noise floor (single-duo for velocity, median-of-N for
  release/auto-merge gating). [SCORE-DETERMINISM-1, PROMPT-VERSION-DRIFT-4, VARIANCE-SINGLE-DUO-3]
- **Testing ability** — conftest `slow`/`flaky` markers (engine/rules/voice/viewer); `pytest-cov` +
  `pytest-timeout` in dev groups; `.coveragerc`; CI coverage is **report-only** (no `--cov-fail-under`
  yet, so it surfaces untested paths without flaking CI). New `servers/integration_tests/` deterministic
  cross-service MCP contract suite (engine↔rules↔voice, null/offline backends) + a CI `server-contracts`
  job. [DETERMINISTIC-2/3/4]
- **Cadence** — `.github/workflows/nightly-quality-loop.yml` runs `qa/loop.sh` on a schedule (the
  "recursive-improvement loop" was never scheduled). Live step is gated on an `ANTHROPIC_API_KEY`
  repo secret; without it the job runs a deterministic self-check so the workflow is always green-able.
  Soft-fail (alerts, does not block). [AUTONOMY-1, NO-SCHEDULED-LOOP-5]
- **Velocity** — `qa/fast_gate.sh` opt-in green-cache (`CLAWDND_FASTGATE_CACHE=1`); `qa/release_gate.sh`
  RAM-aware preflight (codifies the OOM bottleneck → points at CI/support-VM); `.pre-commit-config.yaml`.
  [VELOCITY-1/2/3/4]

### Verification (local single-process, worktree off `origin/main`)
scores_db **26**, snapshot **17**, score-determinism **7**, lens-variance skip, integration-contracts
**26**, velocity-gates bash **all pass**, conftest collection **2837 tests**, zero existing tests
weakened. Full suites gate on GitHub CI (this PR).

### Notes
- Built via an UltraCode workflow (9 parallel TDD builders + adversarial diff review); the orchestrator
  owned all git/PR. Data artifacts (`scores.db`/`scores_ledger.md`) are deliberately **not** in this diff
  — the schema migration applies lazily on connect in production.
- The macOS Swift XCTest target ships separately (CommandLineTools-only host has no XCTest → CI-verified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage reporting across all services with branch coverage enabled.
  * Added deterministic quality assurance tests for score stability and snapshot validation.
  * New cross-service integration tests validating rules and voice service contracts.

* **Chores**
  * Introduced nightly quality automation workflow with live and deterministic check modes.
  * Added resource preflight validation and caching optimizations for quality gates.
  * Configured pre-commit hooks for code quality enforcement.

* **Documentation**
  * Documented scoring variance measurement and noise floor thresholds for release decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->