### PR TITLE
qa(phase-1): first XCTest coverage for the macOS app + CI swift test step

### DIFF
--- a/.github/workflows/macos-swift.yml
+++ b/.github/workflows/macos-swift.yml
@@ -39,3 +39,10 @@ jobs:
 
       - name: Build native app
         run: swift build --package-path macos/WorldOSApp
+
+      - name: Run native app unit tests (XCTest)
+        # Phase-1 (DETERMINISTIC-1): first real test coverage for the macOS app — hermetic unit
+        # tests for EnvironmentBootstrap (login-PATH + /Volumes leak-strip, the recent P0s) and
+        # PortFinder. macos-latest ships full Xcode, so XCTest is available here (it is NOT on a
+        # CommandLineTools-only host, which is why this could only be verified in CI).
+        run: swift test --package-path macos/WorldOSApp

--- a/macos/WorldOSApp/Package.swift
+++ b/macos/WorldOSApp/Package.swift
@@ -11,6 +11,13 @@ let package = Package(
         .executable(name: "WorldOSApp", targets: ["WorldOSApp"])
     ],
     targets: [
-        .executableTarget(name: "WorldOSApp")
+        .executableTarget(name: "WorldOSApp"),
+        // Additive: unit tests for the pure helpers (PATH augmentation / removable-volume env
+        // filtering / port availability) via `@testable import WorldOSApp`. The app target is
+        // otherwise unchanged; removing this target restores today's behavior exactly.
+        .testTarget(
+            name: "WorldOSAppTests",
+            dependencies: ["WorldOSApp"]
+        )
     ]
 )

--- a/macos/WorldOSApp/Tests/WorldOSAppTests/EnvironmentBootstrapTests.swift
+++ b/macos/WorldOSApp/Tests/WorldOSAppTests/EnvironmentBootstrapTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+
+@testable import WorldOSApp
+
+/// Unit tests for the two pure, P0-causing helpers in `EnvironmentBootstrap`:
+///   - `augmentedPATH(currentPATH:extraDirs:)`  (login-PATH resolution, #892)
+///   - `withoutRemovableVolumeLeaks(_:)`         (strip `/Volumes/*` env leaks)
+///
+/// These are deliberately hermetic: they exercise ONLY the pure string/dict logic and never
+/// touch the filesystem, the network, env mutation (`setenv`), or a real app launch.
+final class EnvironmentBootstrapTests: XCTestCase {
+
+    // MARK: - augmentedPATH
+
+    /// Extras are prepended ahead of the existing PATH so a user-installed tool wins over the
+    /// system copy (the whole point of #892: a Homebrew `python3` must shadow `/usr/bin/python3`).
+    func testAugmentedPATHPrependsExtrasAheadOfExisting() {
+        let result = EnvironmentBootstrap.augmentedPATH(
+            currentPATH: "/usr/bin:/bin",
+            extraDirs: ["/opt/homebrew/bin", "/Users/me/.local/bin"]
+        )
+        XCTAssertEqual(result, "/opt/homebrew/bin:/Users/me/.local/bin:/usr/bin:/bin")
+    }
+
+    /// The bare LaunchServices PATH (#892 reproduction): Finder/`open -n` hands the app
+    /// `/usr/bin:/bin:/usr/sbin:/sbin` with none of the tool dirs. After augmentation the tool
+    /// dirs must be present AND ordered first.
+    func testAugmentedPATHFixesBareLaunchServicesPATH() {
+        let bare = "/usr/bin:/bin:/usr/sbin:/sbin"
+        let result = EnvironmentBootstrap.augmentedPATH(
+            currentPATH: bare,
+            extraDirs: ["/Users/me/.local/bin", "/opt/homebrew/bin"]
+        )
+        let entries = result.split(separator: ":").map(String.init)
+        XCTAssertEqual(entries.first, "/Users/me/.local/bin")
+        XCTAssertTrue(entries.contains("/opt/homebrew/bin"))
+        // Original entries are preserved (nothing dropped).
+        for original in bare.split(separator: ":").map(String.init) {
+            XCTAssertTrue(entries.contains(original), "dropped existing PATH entry \(original)")
+        }
+    }
+
+    /// De-dup is order-preserving: a dir already on PATH must not appear twice, and an extra that
+    /// duplicates an existing entry keeps only its (earlier) prepended position.
+    func testAugmentedPATHDeduplicatesPreservingOrder() {
+        let result = EnvironmentBootstrap.augmentedPATH(
+            currentPATH: "/opt/homebrew/bin:/usr/bin:/bin",
+            extraDirs: ["/opt/homebrew/bin", "/usr/local/bin"]
+        )
+        XCTAssertEqual(result, "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
+        // No entry appears more than once.
+        let entries = result.split(separator: ":").map(String.init)
+        XCTAssertEqual(entries.count, Set(entries).count)
+    }
+
+    /// Empty extras → identity (additive-by-default: empty == today's behavior).
+    func testAugmentedPATHEmptyExtrasReturnsCurrentUnchanged() {
+        let current = "/usr/bin:/bin"
+        XCTAssertEqual(
+            EnvironmentBootstrap.augmentedPATH(currentPATH: current, extraDirs: []),
+            current
+        )
+    }
+
+    /// Empty current PATH with extras → just the extras, no leading/trailing/empty separators.
+    func testAugmentedPATHEmptyCurrentYieldsExtrasOnly() {
+        let result = EnvironmentBootstrap.augmentedPATH(
+            currentPATH: "",
+            extraDirs: ["/opt/homebrew/bin", "/usr/local/bin"]
+        )
+        XCTAssertEqual(result, "/opt/homebrew/bin:/usr/local/bin")
+        XCTAssertFalse(result.hasPrefix(":"))
+        XCTAssertFalse(result.hasSuffix(":"))
+    }
+
+    /// Empty path components (e.g. a stray `::` or leading/trailing colon in the inherited PATH)
+    /// are dropped, never re-emitted as empty entries.
+    func testAugmentedPATHDropsEmptyComponents() {
+        let result = EnvironmentBootstrap.augmentedPATH(
+            currentPATH: "/usr/bin::/bin:",
+            extraDirs: []
+        )
+        XCTAssertEqual(result, "/usr/bin:/bin")
+    }
+
+    // MARK: - withoutRemovableVolumeLeaks
+
+    /// The exact real-world P0 offender: `GBRAIN_SKILLS_DIR=/Volumes/LEXAR/...` exported by a
+    /// launching shell's `~/.zshenv` must be stripped, or a spawned provider enumerates the
+    /// removable volume and fires the un-answerable TCC modal that wedges CI/QA launches.
+    func testRemovableVolumeLeakStripsGBrainSkillsDir() {
+        let env = [
+            "GBRAIN_SKILLS_DIR": "/Volumes/LEXAR/repos/eva-brain/skills",
+            "HOME": "/Users/me",
+        ]
+        let cleaned = EnvironmentBootstrap.withoutRemovableVolumeLeaks(env)
+        XCTAssertNil(cleaned["GBRAIN_SKILLS_DIR"], "removable-volume env var was not stripped")
+        XCTAssertEqual(cleaned["HOME"], "/Users/me", "non-/Volumes var must survive")
+    }
+
+    /// Only the VALUE prefix matters. Anything whose value starts with `/Volumes/` is dropped,
+    /// regardless of the variable name.
+    func testRemovableVolumeLeakStripsAnyVarPointingAtVolumes() {
+        let env = [
+            "SOME_TOOL_HOME": "/Volumes/USB/tool",
+            "ANOTHER": "/Volumes/External/data/cache",
+            "SAFE": "/Users/me/data",
+        ]
+        let cleaned = EnvironmentBootstrap.withoutRemovableVolumeLeaks(env)
+        XCTAssertNil(cleaned["SOME_TOOL_HOME"])
+        XCTAssertNil(cleaned["ANOTHER"])
+        XCTAssertEqual(cleaned["SAFE"], "/Users/me/data")
+    }
+
+    /// PATH and other `:`-separated lists do NOT start with `/Volumes/`, so tool discovery is
+    /// never collateral damage — even if some entry mid-list lives on a volume.
+    func testRemovableVolumeLeakDoesNotTouchPATHList() {
+        let path = "/opt/homebrew/bin:/Volumes/LEXAR/bin:/usr/bin"
+        let env = ["PATH": path, "LDFLAGS": "-L/Volumes/LEXAR/lib"]
+        let cleaned = EnvironmentBootstrap.withoutRemovableVolumeLeaks(env)
+        XCTAssertEqual(cleaned["PATH"], path, "PATH must be left intact")
+        // A flag value that merely CONTAINS /Volumes but does not START with it is preserved.
+        XCTAssertEqual(cleaned["LDFLAGS"], "-L/Volumes/LEXAR/lib")
+    }
+
+    /// Empty environment → empty result (additive-by-default identity).
+    func testRemovableVolumeLeakEmptyEnvironmentIsIdentity() {
+        XCTAssertTrue(EnvironmentBootstrap.withoutRemovableVolumeLeaks([:]).isEmpty)
+    }
+
+    /// An env with no `/Volumes/` values round-trips unchanged.
+    func testRemovableVolumeLeakLeavesCleanEnvironmentUnchanged() {
+        let env = ["HOME": "/Users/me", "LANG": "en_US.UTF-8", "PWD": "/Users/me/project"]
+        XCTAssertEqual(EnvironmentBootstrap.withoutRemovableVolumeLeaks(env), env)
+    }
+
+    /// A WorldOS root that legitimately lives under `/Volumes/...` IS stripped by this filter —
+    /// which is intentional: the caller re-applies its own repo/art roots via an explicit
+    /// `environment` overlay merged AFTER this filter, so this function alone must drop it.
+    func testRemovableVolumeLeakStripsEvenWorldOSOwnRoot() {
+        let env = ["WORLDOS_REPO": "/Volumes/LEXAR/ClawDnD"]
+        XCTAssertTrue(
+            EnvironmentBootstrap.withoutRemovableVolumeLeaks(env).isEmpty,
+            "filter alone must drop /Volumes values; caller re-applies intentional roots after"
+        )
+    }
+}

--- a/macos/WorldOSApp/Tests/WorldOSAppTests/PortFinderTests.swift
+++ b/macos/WorldOSApp/Tests/WorldOSAppTests/PortFinderTests.swift
@@ -1,0 +1,139 @@
+import Darwin
+import Foundation
+import XCTest
+
+@testable import WorldOSApp
+
+/// Unit tests for `PortFinder` availability + selection logic.
+///
+/// Hermetic: the only sockets bound are loopback (`127.0.0.1`) listeners this test opens and
+/// closes itself, within the test process. No outbound network, no app launch.
+final class PortFinderTests: XCTestCase {
+
+    // MARK: - isAvailable: range guards
+
+    func testIsAvailableRejectsPortZero() {
+        XCTAssertFalse(PortFinder.isAvailable(0))
+    }
+
+    func testIsAvailableRejectsNegativePort() {
+        XCTAssertFalse(PortFinder.isAvailable(-1))
+    }
+
+    func testIsAvailableRejectsAbove65535() {
+        XCTAssertFalse(PortFinder.isAvailable(65536))
+        XCTAssertFalse(PortFinder.isAvailable(99999))
+    }
+
+    // MARK: - isAvailable: real binding
+
+    /// A port that nobody is listening on should report available. We pick a free port by binding
+    /// then releasing, then assert `isAvailable` agrees once it's released.
+    func testIsAvailableReportsTrueForAFreePort() {
+        guard let free = bindEphemeralThenRelease() else {
+            XCTFail("could not determine a free loopback port")
+            return
+        }
+        XCTAssertTrue(PortFinder.isAvailable(free), "a released port should be reported available")
+    }
+
+    /// An OCCUPIED port must report unavailable. We hold a live loopback listener on a concrete
+    /// port for the duration of the assertion, then release it.
+    func testIsAvailableReportsFalseForAnOccupiedPort() {
+        guard let (fd, port) = openLoopbackListener() else {
+            XCTFail("could not open a loopback listener to occupy a port")
+            return
+        }
+        defer { close(fd) }
+        XCTAssertFalse(
+            PortFinder.isAvailable(port),
+            "a port held by a live bound listener must be reported unavailable"
+        )
+    }
+
+    // MARK: - firstFreePort
+
+    /// When the preferred port is free, it is returned as-is.
+    func testFirstFreePortReturnsPreferredWhenFree() {
+        guard let free = bindEphemeralThenRelease() else {
+            XCTFail("could not determine a free loopback port")
+            return
+        }
+        XCTAssertEqual(PortFinder.firstFreePort(startingAt: free), free)
+    }
+
+    /// When the preferred port is occupied, the finder must NOT return it; it must hand back a
+    /// different, actually-available port (from the nearby window or the 8765-8805 fallback band).
+    func testFirstFreePortSkipsOccupiedPreferred() {
+        guard let (fd, port) = openLoopbackListener() else {
+            XCTFail("could not open a loopback listener to occupy a port")
+            return
+        }
+        defer { close(fd) }
+        let chosen = PortFinder.firstFreePort(startingAt: port)
+        XCTAssertNotNil(chosen)
+        if let chosen {
+            XCTAssertNotEqual(chosen, port, "must not return the occupied preferred port")
+            XCTAssertTrue(PortFinder.isAvailable(chosen), "returned port must actually be free")
+            XCTAssertTrue((1...65535).contains(chosen), "returned port must be in valid range")
+        }
+    }
+
+    /// A nonsensical preferred port is clamped into the valid range and still yields a usable port.
+    func testFirstFreePortClampsOutOfRangePreferred() {
+        let chosen = PortFinder.firstFreePort(startingAt: 0)
+        XCTAssertNotNil(chosen, "should still find a free port even from a clamped start")
+        if let chosen {
+            XCTAssertTrue((1...65535).contains(chosen))
+            XCTAssertTrue(PortFinder.isAvailable(chosen))
+        }
+    }
+
+    // MARK: - Test helpers (loopback only, fully cleaned up)
+
+    /// Open a real `bind()`+`listen()` loopback listener on an OS-chosen ephemeral port. Returns
+    /// the live fd (caller must close) and the concrete port number it landed on, so the test can
+    /// assert against a port that is genuinely occupied for the lifetime of the fd.
+    private func openLoopbackListener() -> (fd: Int32, port: Int)? {
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        guard fd >= 0 else { return nil }
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = 0  // ask the kernel for an ephemeral port
+        addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+
+        let bindResult = withUnsafePointer(to: &addr) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard bindResult == 0, listen(fd, 1) == 0 else {
+            close(fd)
+            return nil
+        }
+
+        var bound = sockaddr_in()
+        var len = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let nameResult = withUnsafeMutablePointer(to: &bound) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                getsockname(fd, $0, &len)
+            }
+        }
+        guard nameResult == 0 else {
+            close(fd)
+            return nil
+        }
+        let port = Int(UInt16(bigEndian: bound.sin_port))
+        return (fd, port)
+    }
+
+    /// Bind an ephemeral loopback port, learn its number, then release it — yielding a port that
+    /// was free a moment ago (best-effort "free port" probe for the available-path tests).
+    private func bindEphemeralThenRelease() -> Int? {
+        guard let (fd, port) = openLoopbackListener() else { return nil }
+        close(fd)
+        return port
+    }
+}

--- a/macos/WorldOSApp/Tests/WorldOSAppTests/PortFinderTests.swift
+++ b/macos/WorldOSApp/Tests/WorldOSAppTests/PortFinderTests.swift
@@ -44,7 +44,7 @@ final class PortFinderTests: XCTestCase {
             XCTFail("could not open a loopback listener to occupy a port")
             return
         }
-        defer { close(fd) }
+        defer { Darwin.close(fd) }
         XCTAssertFalse(
             PortFinder.isAvailable(port),
             "a port held by a live bound listener must be reported unavailable"
@@ -69,7 +69,7 @@ final class PortFinderTests: XCTestCase {
             XCTFail("could not open a loopback listener to occupy a port")
             return
         }
-        defer { close(fd) }
+        defer { Darwin.close(fd) }
         let chosen = PortFinder.firstFreePort(startingAt: port)
         XCTAssertNotNil(chosen)
         if let chosen {
@@ -95,22 +95,22 @@ final class PortFinderTests: XCTestCase {
     /// the live fd (caller must close) and the concrete port number it landed on, so the test can
     /// assert against a port that is genuinely occupied for the lifetime of the fd.
     private func openLoopbackListener() -> (fd: Int32, port: Int)? {
-        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        let fd = Darwin.socket(AF_INET, SOCK_STREAM, 0)
         guard fd >= 0 else { return nil }
 
         var addr = sockaddr_in()
         addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
         addr.sin_family = sa_family_t(AF_INET)
         addr.sin_port = 0  // ask the kernel for an ephemeral port
-        addr.sin_addr = in_addr(s_addr: inet_addr("127.0.0.1"))
+        addr.sin_addr = in_addr(s_addr: Darwin.inet_addr("127.0.0.1"))
 
         let bindResult = withUnsafePointer(to: &addr) {
             $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
             }
         }
-        guard bindResult == 0, listen(fd, 1) == 0 else {
-            close(fd)
+        guard bindResult == 0, Darwin.listen(fd, 1) == 0 else {
+            Darwin.close(fd)
             return nil
         }
 
@@ -118,11 +118,11 @@ final class PortFinderTests: XCTestCase {
         var len = socklen_t(MemoryLayout<sockaddr_in>.size)
         let nameResult = withUnsafeMutablePointer(to: &bound) {
             $0.withMemoryRebound(to: sockaddr.self, capacity: 1) {
-                getsockname(fd, $0, &len)
+                Darwin.getsockname(fd, $0, &len)
             }
         }
         guard nameResult == 0 else {
-            close(fd)
+            Darwin.close(fd)
             return nil
         }
         let port = Int(UInt16(bigEndian: bound.sin_port))
@@ -133,7 +133,7 @@ final class PortFinderTests: XCTestCase {
     /// was free a moment ago (best-effort "free port" probe for the available-path tests).
     private func bindEphemeralThenRelease() -> Int? {
         guard let (fd, port) = openLoopbackListener() else { return nil }
-        close(fd)
+        Darwin.close(fd)
         return port
     }
 }


### PR DESCRIPTION
## Phase 1 — macOS app test coverage (audit gap DETERMINISTIC-1)

The `WorldOSApp` Swift target had **zero tests in CI** — `macos-swift.yml` only ran `swift build`,
leaving environment bootstrap / port-finding (the surface behind the recent `/Volumes` leak + PATH
P0s) unguarded. This adds the first hermetic XCTest target and runs it in CI.

- `Package.swift`: additive `.testTarget(WorldOSAppTests)` via `@testable import` of the app module.
- Tests cover the **pure functions** behind recent P0s: `EnvironmentBootstrap.augmentedPATH()`
  (login-PATH resolution, #892/#914) and `withoutRemovableVolumeLeaks()` (strips `/Volumes/*` env
  vars like `GBRAIN_SKILLS_DIR`, #946), plus `PortFinder` availability. No network, no real launch.
- `macos-swift.yml`: adds a `swift test` step after the build.

> ⚠️ **CI-verified only.** The dev host is CommandLineTools-only (no XCTest module), so `swift test`
> and the `@testable import` of the `@main` executable target can only be exercised on the
> `macos-latest` runner. The macOS Swift job on this PR is the verification — if the `@testable`
> import needs a small library-target split, I'll adjust on this branch before merge.

Split from the Phase-1 foundation PR (#949) so the unverifiable-locally Swift lane doesn't gate the
verified Python/QA work.