### PR TITLE
feat(planning): wire up the min-maxer planning layer (4 discoverability fixes)

### DIFF
--- a/servers/engine/featcatalog.py
+++ b/servers/engine/featcatalog.py
@@ -1,0 +1,141 @@
+"""Feat catalog: the SRD 5.2 feat list (name / full effect text / prerequisite).
+
+Pure module (no MCP, no campaign I/O). Mirrors ``feature_catalog`` and ``itemcatalog`` —
+it reads the vendored SRD 5.2.1 dump (``data/srd/srd524/Feat.json`` + ``FeatBenefit.json``,
+the Open5e srd-2024 fixtures, CC-BY-4.0) and exposes each feat's full effect text by name so
+the level-up planner can present a BROWSABLE list of real feats instead of a blind free-text box
+(the level-up planner's one real gap: 17 SRD feats exist but no enumeration tool surfaced them).
+
+This module surfaces the bundled data READ-ONLY — it never authors content, and a feat the dump
+doesn't carry simply isn't listed (the caller never fabricates one). Each ``Feat`` record is a
+Django fixture ``{model, pk, fields}`` whose ``fields`` carry ``name``, ``desc``, ``prerequisite``
+and ``type``; each ``FeatBenefit`` record links to its feat via ``parent`` (the feat's pk) and
+carries the specific benefit's ``name`` + ``desc`` — we fold those benefit lines into the feat's
+effect text so a planner sees what the feat actually DOES, not just the one-line intro.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+from pathlib import Path
+from typing import Optional
+
+_ROOT = Path(__file__).resolve().parents[2] / "data" / "srd"
+_PRIMARY = _ROOT / "srd524"  # canonical SRD 5.2
+
+
+def _dirs() -> list[Path]:
+    """Feat-data dirs in PRECEDENCE order: srd524 first (canonical), then any later pack under
+    data/srd/ that carries a Feat.json (first-wins, exactly like feature_catalog._dirs)."""
+    dirs = [_PRIMARY]
+    if _ROOT.is_dir():
+        for sub in sorted(_ROOT.iterdir()):
+            if sub.is_dir() and sub != _PRIMARY:
+                dirs.append(sub)
+    return [d for d in dirs if (d / "Feat.json").exists()]
+
+
+def _rows(path: Path) -> list[dict]:
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _benefits_by_parent(d: Path) -> dict[str, list[str]]:
+    """{feat_pk: [benefit_desc, …]} for the FeatBenefit rows in dir ``d``, in fixture order, so a
+    feat's effect text can append its specific benefits (the real rules, not just the intro line)."""
+    out: dict[str, list[str]] = {}
+    for r in _rows(d / "FeatBenefit.json"):
+        if not isinstance(r, dict):
+            continue
+        f = r.get("fields") or {}
+        parent = str(f.get("parent") or "").strip()
+        name = str(f.get("name") or "").strip()
+        desc = str(f.get("desc") or "").strip()
+        if not parent or not desc:
+            continue
+        line = f"{name}: {desc}" if name else desc
+        out.setdefault(parent, []).append(line)
+    return out
+
+
+@functools.lru_cache(maxsize=None)
+def _index() -> list[dict]:
+    """All SRD feats as ``{name, desc, prerequisite, type}`` in fixture order, deduped by name
+    (first-wins across dirs — srd524 canonical). ``desc`` is the feat's intro text plus each of its
+    FeatBenefit lines folded in, so the planner shows what the feat actually does. Built once."""
+    out: list[dict] = []
+    seen: set[str] = set()
+    for d in _dirs():
+        benefits = _benefits_by_parent(d)
+        for r in _rows(d / "Feat.json"):
+            if not isinstance(r, dict):
+                continue
+            f = r.get("fields") or {}
+            name = str(f.get("name") or "").strip()
+            if not name:
+                continue
+            key = name.lower()
+            if key in seen:
+                continue  # first-wins
+            seen.add(key)
+            intro = str(f.get("desc") or "").strip()
+            pk = str(r.get("pk") or "")
+            lines = benefits.get(pk, [])
+            # Compose the full effect text: the intro, then each named benefit on its own line.
+            parts = [p for p in ([intro] + lines) if p]
+            desc = "\n".join(parts)
+            out.append({
+                "name": name,
+                "desc": desc,
+                "prerequisite": str(f.get("prerequisite") or "").strip(),
+                "type": str(f.get("type") or "").strip(),
+            })
+    return out
+
+
+def count() -> int:
+    """Total distinct feats in the catalog."""
+    return len(_index())
+
+
+def all_feats() -> list[dict]:
+    """Every SRD feat, each a COPY of ``{name, desc, prerequisite, type}`` (so a caller can't
+    mutate the cache). The browsable feat list for the level-up planner."""
+    return [dict(r) for r in _index()]
+
+
+def find(query: str = "", limit: int = 0) -> list[dict]:
+    """Feats whose name OR prerequisite OR effect text matches ``query`` (case-insensitive
+    substring), in fixture order. Empty query returns all feats. ``limit`` (>0) caps the result.
+    Returns COPIES — never fabricates a feat the dump doesn't carry."""
+    q = (query or "").strip().lower()
+    rows = _index()
+    if q:
+        rows = [
+            r for r in rows
+            if q in r["name"].lower()
+            or q in r["prerequisite"].lower()
+            or q in r["desc"].lower()
+        ]
+    out = [dict(r) for r in rows]
+    if isinstance(limit, int) and limit > 0:
+        out = out[:limit]
+    return out
+
+
+def lookup(name: str) -> Optional[dict]:
+    """The full record for a feat by NAME (case-insensitive), or None on a miss — never a
+    fabricated entry. Returns a COPY ``{name, desc, prerequisite, type}``."""
+    if not name:
+        return None
+    key = name.strip().lower()
+    for r in _index():
+        if r["name"].lower() == key:
+            return dict(r)
+    return None

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -30,6 +30,7 @@ import dice as dice_mod
 import encounter
 import events as events_mod
 import faction_arc as faction_arc_mod
+import featcatalog
 import feature_catalog as feature_catalog_mod
 import generator
 import imagegen
@@ -7499,6 +7500,17 @@ def find_items(query: str, limit: int = 10) -> dict:
     first `limit` items. The DM's catalog browser for handing out loot."""
     matches = itemcatalog.find(query, max(1, min(int(limit), 50)))
     return {"query": query, "count": len(matches), "items": matches}
+
+
+@mcp.tool()
+def feats(query: str = "") -> dict:
+    """List the bundled SRD 5.2 feats, each {name, desc, prerequisite, type} — the browsable feat
+    catalog the level-up planner reads so a player picks a REAL feat (with its full effect text)
+    instead of a blind free-text box (the planner's one remaining gap). `query` (optional) filters
+    by name / prerequisite / effect text (case-insensitive substring); empty lists ALL feats.
+    Read-only; mirrors find_items / feature_catalog — it never authors content."""
+    matches = featcatalog.find(query)
+    return {"query": query, "count": len(matches), "feats": matches}
 
 
 @mcp.tool()

--- a/servers/engine/tests/test_featcatalog.py
+++ b/servers/engine/tests/test_featcatalog.py
@@ -1,0 +1,99 @@
+"""Feat catalog (pure module) + the read-only ``feats`` MCP tool.
+
+The level-up planner's one real gap: 17 SRD feats live in data/srd/srd524/Feat.json (+
+FeatBenefit.json) but no enumeration tool surfaced them, so the planner's feat choice was a
+BLIND free-text box. ``featcatalog`` exposes the bundled feat list read-only (mirrors
+``feature_catalog`` / ``itemcatalog``); the ``feats`` tool projects it for the viewer. Pure module —
+it never authors content; a feat the dump doesn't carry simply isn't listed.
+"""
+
+import sys
+from pathlib import Path
+
+# Ensure the ENGINE dir wins on sys.path before `import server`. A viewer test sharing the same
+# pytest process inserts viewer/ at sys.path[0] (viewer/server.py self-registers), which would
+# otherwise shadow `import server` with the VIEWER server (no `feats` tool). Engine-only runs are
+# unaffected; this just makes the combined collection deterministic.
+_ENGINE_DIR = str(Path(__file__).resolve().parents[1])
+if sys.path and sys.path[0] != _ENGINE_DIR:
+    sys.path.insert(0, _ENGINE_DIR)
+sys.modules.pop("server", None)  # drop any viewer-shadowed `server` so the engine one loads
+
+import featcatalog  # noqa: E402
+import server  # noqa: E402
+
+assert hasattr(server, "feats"), "expected the ENGINE server (with the feats tool), not the viewer server"
+
+
+# --- the pure module ------------------------------------------------------
+
+
+def test_catalog_loads_the_srd_feat_set():
+    # The bundled SRD 5.2 dump carries the 17 feats (Origin / General / Fighting Style / Epic Boon).
+    assert featcatalog.count() == 17
+
+
+def test_all_feats_carry_the_planner_fields():
+    feats = featcatalog.all_feats()
+    assert feats, "the catalog must list feats"
+    for f in feats:
+        assert f["name"], "every feat has a name"
+        # name / desc / prerequisite / type are the fields the planner reads
+        for field in ("name", "desc", "prerequisite", "type"):
+            assert field in f
+
+
+def test_alert_carries_its_full_effect_text_from_feat_benefits():
+    rec = featcatalog.lookup("Alert")
+    assert rec is not None
+    assert rec["name"] == "Alert"
+    # the FeatBenefit lines are folded into the effect text (not just the one-line intro)
+    assert "Initiative" in rec["desc"]
+    assert len(rec["desc"]) > 40
+
+
+def test_lookup_is_case_insensitive_and_misses_are_honest():
+    assert featcatalog.lookup("alert") is not None
+    assert featcatalog.lookup("ALERT") is not None
+    # a feat not in the SRD dump is an honest miss — never a fabricated entry
+    assert featcatalog.lookup("Totally Made Up Feat") is None
+
+
+def test_find_filters_by_name_prerequisite_and_desc():
+    # filter by prerequisite text (the Fighting Style feats share "Fighting Style Feature")
+    fs = featcatalog.find("fighting style")
+    assert fs, "a 'fighting style' query must match the fighting-style feats"
+    assert any(f["name"] == "Archery" for f in fs)
+    # empty query returns ALL feats
+    assert len(featcatalog.find("")) == 17
+    # limit caps the result
+    assert len(featcatalog.find("", limit=3)) == 3
+
+
+def test_records_are_copies_not_cache_aliases():
+    a = featcatalog.lookup("Alert")
+    a["desc"] = "MUTATED"
+    b = featcatalog.lookup("Alert")
+    assert b["desc"] != "MUTATED", "lookup must return a copy so a caller can't corrupt the cache"
+
+
+# --- the read-only `feats` MCP tool ---------------------------------------
+
+
+def test_feats_tool_lists_all_feats_with_effect_text():
+    out = server.feats()
+    assert out["count"] == 17
+    names = {f["name"] for f in out["feats"]}
+    assert {"Alert", "Magic Initiate", "Grappler"} <= names
+    alert = next(f for f in out["feats"] if f["name"] == "Alert")
+    assert alert["desc"], "each feat carries its effect text for the planner"
+    assert "prerequisite" in alert and "type" in alert
+
+
+def test_feats_tool_query_filters():
+    out = server.feats("grappler")
+    assert out["count"] >= 1
+    assert all("grappler" in (f["name"] + f["prerequisite"] + f["desc"]).lower() for f in out["feats"])
+    # the prerequisite rides through so the planner can show it
+    grappler = next(f for f in out["feats"] if f["name"] == "Grappler")
+    assert "13" in grappler["prerequisite"]

--- a/viewer/openworlds/camp-sidebar.jsx
+++ b/viewer/openworlds/camp-sidebar.jsx
@@ -53,7 +53,17 @@ function CampSidebar({ state, onExit, onBeginRest, onTalk, talkPartner, dmBusy }
   const [useRations, setUseRations] = React.useState(true);
   const [draggingHero, setDraggingHero] = React.useState(null);
   const [resting, setResting] = React.useState(false);
+  // After a camp long rest lands, surface a "Prepare spells" step for each prepared caster —
+  // routing the EXISTING RestPrepareModal (screen-character.jsx) at its `prep` step. `restedThisVisit`
+  // gates the affordance (the rest already happened); `prepHeroId` is the caster whose modal is open.
+  const [restedThisVisit, setRestedThisVisit] = React.useState(false);
+  const [prepHeroId, setPrepHeroId] = React.useState(null);
   const talkHero = talkPartner ? party.find((p) => p.id === talkPartner) : null;
+  // Prepared casters in camp = the party members the read-model gives a positive prepared-spell CAP
+  // (Cleric/Druid/Wizard/Paladin/Ranger). Known-casters (Bard/Sorcerer/Warlock) and non-casters have
+  // no cap, so they never get a (meaningless) "Prepare" affordance — the guard renders nothing.
+  const preparedCasters = party.filter((p) => typeof p.preparedCap === "number" && p.preparedCap > 0);
+  const prepHero = prepHeroId ? party.find((p) => p.id === prepHeroId) : null;
 
   // Engine-write gate. The camp sidebar is a READER of /character-surface; resting is an
   // engine action, so it only lands when a live session is attached (`can_act`). When the
@@ -135,6 +145,10 @@ function CampSidebar({ state, onExit, onBeginRest, onTalk, talkPartner, dmBusy }
         throw new Error(payload.reason || `move ${response.status}`);
       }
       toast({ kind: "rest", eyebrow: "Camp", title: "Resting", body: "Move relayed to the DM — the engine resolves the long rest, refreshes the party, and advances the clock to morning." });
+      // A long rest recovers all spell slots — now offer to (re)prepare spells for each prepared
+      // caster via the existing two-step modal's `prep` step, so the prominent camp rest matches the
+      // sheet's "Rest & Prepare" (CS-prep). Guarded below so it only shows when a prepared caster exists.
+      setRestedThisVisit(true);
     } catch (error) {
       toast({ kind: "danger", eyebrow: "Camp", title: "Rest not sent", body: error?.message || "The viewer could not reach /move." });
     } finally {
@@ -363,6 +377,7 @@ function CampSidebar({ state, onExit, onBeginRest, onTalk, talkPartner, dmBusy }
             disabled={!canAct || dmBusy || party.length === 0 || resting}
             onClick={beginRest}
             style={{ flex: 1 }}
+            data-worldos-testid="camp-begin-rest"
             title={
               !canAct
                 ? "The chronicle is read-only — start a session to rest"
@@ -386,6 +401,50 @@ function CampSidebar({ state, onExit, onBeginRest, onTalk, talkPartner, dmBusy }
           </div>
         ) : null}
       </div>
+
+      {/* CS-prep: after a camp long rest (which recovers all spell slots), surface a per-caster
+          "Prepare" affordance that opens the EXISTING RestPrepareModal at its `prep` step — closing
+          the gap where the prominent camp rest skipped the spell-prep step the sheet's "Rest &
+          Prepare" button offers. Guarded three ways: only after a rest landed THIS visit, only when a
+          prepared caster is in the party, and only when the modal component is actually loaded. */}
+      {restedThisVisit && preparedCasters.length > 0 && window.RestPrepareModal && (
+        <Panel framed style={{ padding: 12, flex: "0 0 auto" }} data-worldos-testid="camp-prepare-spells">
+          <SectionTitle>Prepare Spells</SectionTitle>
+          <div className="hand muted" style={{ fontSize: 11, margin: "2px 0 8px" }}>
+            The long rest refreshed everyone's slots. Set today's prepared spells:
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            {preparedCasters.map((p) => (
+              <BrassButton
+                key={p.id}
+                tone="ghost"
+                size="sm"
+                onClick={() => setPrepHeroId(p.id)}
+                title={`Open ${p.name}'s spell preparation`}
+                data-worldos-testid={`camp-prepare-${p.id}`}
+              >
+                Prepare {p.name.split(" ")[0]}'s spells
+              </BrassButton>
+            ))}
+          </div>
+        </Panel>
+      )}
+
+      {/* Route the EXISTING two-step modal at its `prep` step (no new prep UI). It relays the
+          prepare_spells intent through /move exactly as the sheet's flow does. */}
+      {prepHero && window.RestPrepareModal && (
+        <window.RestPrepareModal
+          hero={prepHero}
+          party={party}
+          campaignId={campaignId}
+          canAct={canAct}
+          dmBusy={dmBusy}
+          initialStep="prep"
+          onClose={() => setPrepHeroId(null)}
+          onDone={() => { setPrepHeroId(null); loadSurface(); }}
+          toast={toast}
+        />
+      )}
     </div>
   );
 }

--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -359,6 +359,11 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
   const [asiBumps, setAsiBumps] = React.useState({});
   const [takingFeat, setTakingFeat] = React.useState(false);
   const [featName, setFeatName] = React.useState("");
+  // #feat-browser: the browsable SRD feat list (from GET /feat-catalog), so the feat choice is a
+  // real picker showing each feat's effect text + prerequisite — not a blind free-text box. Lazily
+  // loaded the first time the feat pane opens (`takingFeat`), then filtered client-side by `featSearch`.
+  const [feats, setFeats] = React.useState(null);   // null = not yet loaded; [] = loaded/empty
+  const [featSearch, setFeatSearch] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
   // #robustness: synchronous in-flight lock (mirrors screen-table.jsx). The `submitting` STATE
   // only updates on re-render, so a rapid double-click would otherwise relay TWO level-up intents
@@ -388,6 +393,25 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
     })();
     return () => { cancelled = true; };
   }, [campaignId, hero.id]);
+
+  // #feat-browser: load the SRD feat catalog the first time the player opens the feat pane (so the
+  // common ASI path pays no fetch). Read-only GET /feat-catalog — the chosen feat name still rides
+  // the existing level_up relay. On any failure we leave `feats` as [] so the text input still works.
+  React.useEffect(() => {
+    if (!takingFeat || feats !== null) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const response = await fetch("/feat-catalog", { cache: "no-store" });
+        const payload = await response.json();
+        if (cancelled) return;
+        setFeats(Array.isArray(payload && payload.feats) ? payload.feats : []);
+      } catch (e) {
+        if (!cancelled) setFeats([]);  // honest empty -> the free-text input remains usable
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [takingFeat, feats]);
 
   // a11y (WCAG 2.1.2 — no keyboard trap): Escape dismisses the dialog, mirroring toast.jsx.
   React.useEffect(() => {
@@ -697,10 +721,66 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
                   {takingFeat ? (
                     <div data-worldos-testid="levelup-feat-pane">
                       <p className="body-sm muted" style={{ marginTop: 0 }}>
-                        Name the feat your character takes — the DM finalizes it against the world's options.
+                        Pick a feat below — each shows its effect and any prerequisite — or type a different one
+                        your world offers. The DM finalizes it.
                       </p>
+                      {/* #feat-browser: the browsable SRD feat list (GET /feat-catalog). Selecting a
+                          feat fills `featName` (which rides the existing level_up relay), mirroring the
+                          subclass-options picker above. The free-text input REMAINS below for any
+                          world-canon feat the SRD list doesn't enumerate (additive). */}
+                      {Array.isArray(feats) && feats.length > 0 && (
+                        <>
+                          <input type="text" value={featSearch} onChange={(e) => setFeatSearch(e.target.value)}
+                            placeholder="Filter feats…"
+                            data-worldos-testid="levelup-feat-search"
+                            style={{
+                              width: "100%", padding: "6px 10px", boxSizing: "border-box", marginBottom: 8,
+                              boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.4)",
+                              background: "rgba(255,250,235,0.5)", fontFamily: "var(--f-body)", fontSize: 13,
+                            }} />
+                          <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 10, maxHeight: 280, overflowY: "auto" }}
+                            data-worldos-testid="levelup-feat-options">
+                            {feats
+                              .filter((f) => {
+                                const q = featSearch.trim().toLowerCase();
+                                if (!q) return true;
+                                return ((f.name || "").toLowerCase().indexOf(q) !== -1)
+                                  || ((f.prerequisite || "").toLowerCase().indexOf(q) !== -1)
+                                  || ((f.desc || "").toLowerCase().indexOf(q) !== -1);
+                              })
+                              .map((f) => {
+                                const selected = featName.trim().toLowerCase() === (f.name || "").toLowerCase();
+                                return (
+                                  <button key={f.name} type="button"
+                                    aria-pressed={selected}
+                                    onClick={() => setFeatName(f.name)}
+                                    data-worldos-testid={"levelup-feat-option-" + (f.name || "").toLowerCase().replace(/[^a-z0-9]+/g, "-")}
+                                    style={{
+                                      textAlign: "left", padding: "8px 12px", cursor: "pointer",
+                                      background: selected ? "linear-gradient(180deg, var(--b-200), var(--b-400))" : "transparent",
+                                      boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.35)",
+                                      color: selected ? "var(--w-300)" : "var(--ink-800)",
+                                      fontFamily: "var(--f-body)", fontSize: 13,
+                                    }}>
+                                    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8 }}>
+                                      <span style={{ fontFamily: "var(--f-display)", fontSize: 13 }}>{f.name}</span>
+                                      {f.prerequisite ? (
+                                        <span className="body-sm" style={{ opacity: 0.8, whiteSpace: "nowrap" }}>
+                                          Prereq: {f.prerequisite}
+                                        </span>
+                                      ) : null}
+                                    </div>
+                                    {f.desc && (
+                                      <div className="body-sm" style={{ opacity: 0.85, marginTop: 3, whiteSpace: "pre-line" }}>{f.desc}</div>
+                                    )}
+                                  </button>
+                                );
+                              })}
+                          </div>
+                        </>
+                      )}
                       <input type="text" value={featName} onChange={(e) => setFeatName(e.target.value)}
-                        placeholder="e.g. Great Weapon Master"
+                        placeholder={Array.isArray(feats) && feats.length > 0 ? "…or type another feat your world offers" : "e.g. Great Weapon Master"}
                         data-worldos-testid="levelup-feat-input"
                         style={{
                           width: "100%", padding: "8px 10px", boxSizing: "border-box",
@@ -789,8 +869,11 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
   );
 }
 
-function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, onDone, toast, setState }) {
-  const [step, setStep] = React.useState("rest");
+function RestPrepareModal({ hero, party, campaignId, canAct, dmBusy, onClose, onDone, toast, setState, initialStep }) {
+  // initialStep lets a caller open this modal straight at the "prep" step (the camp long-rest
+  // affordance — the rest already happened, the player just wants to set their prepared spells).
+  // Defaults to "rest" so every existing caller (the sheet's "Rest & Prepare" button) is unchanged.
+  const [step, setStep] = React.useState(initialStep === "prep" ? "prep" : "rest");
   const [restType, setRestType] = React.useState("long");
   const [prepared, setPrepared] = React.useState({});
   const [submitting, setSubmitting] = React.useState(false);
@@ -1881,6 +1964,16 @@ function SpellsTab({ hero }) {
         </div>
       ) : null}
       <SpellSlotTrack slots={slots} />
+      {/* #half-caster: a muted line naming the next LOCKED slot level for a slower-than-full
+          caster (server.py _caster_tier_and_note), so an SRD-correct half-caster slot count
+          (e.g. an L10 Paladin topping out at 3rd-level slots) reads as intentional, not missing.
+          Guarded: renders NOTHING when the read-model has no note (full casters, top-slot
+          half-casters, non-casters). */}
+      {hero.spellcasting && hero.spellcasting.slotProgressionNote ? (
+        <div className="muted body-sm" style={{ marginTop: -10, marginBottom: 16 }}>
+          {hero.spellcasting.slotProgressionNote}
+        </div>
+      ) : null}
       {groups.length ? (
         groups.map((group) => (
           <div key={group.level} style={{ marginTop: 16 }}>

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1035,6 +1035,32 @@ def _merchant_ware(rec: dict) -> dict:
     }
 
 
+# Kind-grouping order for the default (no-query) merchant supply — the gear an adventurer actually
+# walks in to BUY, surfaced ahead of the priceless magic-item long tail. Lower rank = earlier.
+_MERCHANT_KIND_ORDER = {
+    "weapon": 0, "armor": 1, "shield": 1, "potion": 2,
+    "gear": 3, "adventuring gear": 3, "tool": 3, "ammunition": 3, "equipment": 3,
+}
+
+
+def _merchant_ware_sort_key(ware: dict) -> tuple:
+    """Sort key for the DEFAULT (no-query) merchant supply so the first wares are the PRICED,
+    mundane, actually-BUYABLE gear (weapons/armor/potions/adventuring gear) instead of the
+    alphabetical slice the raw catalog returns — which is dominated by PRICELESS magic items
+    (price None → "—", a disabled Take button), the "empty market" complaint.
+
+    Order: (1) priced-before-priceless, (2) kind-grouped (weapon→armor→potion→gear→…), (3) alpha.
+    Priceless items still SORT — they just land AFTER the priced gear, so the long tail stays
+    reachable by scrolling or by search (which bypasses this key). Keys off the PROJECTED ware's
+    own ``price`` (the value the screen displays + the Take button gates on), so the ordering and
+    the buyability the user sees always agree. Honest: fabricates nothing, drops nothing."""
+    price = ware.get("price")
+    priced = isinstance(price, int) and price > 0
+    kind = _text(ware.get("kind")).lower()
+    kind_rank = _MERCHANT_KIND_ORDER.get(kind, 9)
+    return (0 if priced else 1, kind_rank, _text(ware.get("name")).lower())
+
+
 def build_merchant_surface(
     campaign_id: str = "",
     query: str = "",
@@ -1105,10 +1131,25 @@ def build_merchant_surface(
     cat_mod = _engine_module("itemcatalog")
     if cat_mod is not None:
         try:
-            for rec in cat_mod.find(_text(query), limit=lim):
-                ware = _merchant_ware(rec)
-                if ware.get("name"):
-                    catalog.append(ware)
+            q = _text(query)
+            if q:
+                # A real search bypasses the priced-first reorder — the shopper asked for these
+                # exact items, so return the engine's name-match slice as-is (priceless magic
+                # items included, the whole point of searching for one).
+                for rec in cat_mod.find(q, limit=lim):
+                    ware = _merchant_ware(rec)
+                    if ware.get("name"):
+                        catalog.append(ware)
+            else:
+                # Default supply: project the FULL catalog (no slice yet), reorder priced-buyable
+                # gear ahead of the priceless long tail, THEN slice — otherwise the alphabetical
+                # first-`lim` would still be ~all magic items (the "empty market" complaint). We
+                # sort the PROJECTED wares so the ordering keys off the same `price` the screen
+                # shows (sub-1gp items that round to "—" land with the priceless tail, honestly).
+                wares = [w for r in cat_mod.find("", limit=cat_mod.count())
+                         if (w := _merchant_ware(r)).get("name")]
+                wares.sort(key=_merchant_ware_sort_key)
+                catalog = wares[:lim]
         except Exception:
             catalog = []  # the merchant roster still rides along; the screen shows wares only when present
     return {
@@ -4290,21 +4331,96 @@ def _spell_attack_bonus(ch: dict) -> int | None:
     return prof + _ability_mod(abilities.get(ability))
 
 
+_ORDINAL = {1: "1st", 2: "2nd", 3: "3rd", 4: "4th", 5: "5th",
+            6: "6th", 7: "7th", 8: "8th", 9: "9th"}
+
+
+def _caster_tier_and_note(ch: dict) -> tuple[str | None, str | None]:
+    """Classify the PC's spell-slot progression and, for a SLOWER-than-full caster, phrase the
+    next LOCKED slot level + the class level it unlocks at — context so a reader does NOT misread
+    an SRD-correct half-caster slot count as "missing slots" (the L10-Paladin false alarm).
+
+    Returns ``(casterTier, slotProgressionNote)`` where casterTier is the engine's own caster_type
+    of the PC's FIRST caster class ("full" / "half" / "third" / "pact"), and slotProgressionNote is
+    a short muted line like "Half-caster — 4th-level slots unlock at L13." or None when there is
+    nothing honest to say (full-casters, a half-caster already at its top slot, non-casters, or when
+    the engine srd_tables module can't be imported). The unlock LEVEL is DERIVED from the engine's
+    own SRD slot table (srd_tables.multiclass_slots), never a hardcoded fabrication — we scan the
+    PC's own class forward until its highest slot level rises, so the note tracks the real table.
+
+    Read-only: reads engine-bundled SRD tables and the snapshot's classes; writes nothing."""
+    srd = _engine_module("srd_tables")
+    if srd is None:
+        return (None, None)
+    classes = ch.get("classes") if isinstance(ch.get("classes"), list) else []
+    if not classes:
+        cname = _text(ch.get("class") or ch.get("klass"))
+        lvl = _num(ch.get("level"))
+        if cname:
+            classes = [{"name": cname, "level": int(lvl) if lvl is not None else 1}]
+    # First caster class (the ability/DC the rest of the summary keys off).
+    tier: str | None = None
+    cname = ""
+    clevel = 1
+    for cl in classes:
+        if not isinstance(cl, dict):
+            continue
+        nm = _text(cl.get("name") or cl.get("class_name"))
+        try:
+            ct = srd.caster_type(nm)
+        except Exception:
+            continue
+        if ct in ("full", "half", "third", "pact"):
+            tier = ct
+            cname = nm
+            lvl = _num(cl.get("level"))
+            clevel = int(lvl) if lvl is not None else 1
+            break
+    if tier is None:
+        return (None, None)
+    # Only slower-than-full single-class casters get a "next slot unlocks at LX" note — a full
+    # caster's slots already track level, and a multiclass blend has no single class column.
+    if tier not in ("half", "third") or len(classes) != 1:
+        return (tier, None)
+    try:
+        cur = srd.multiclass_slots([(cname, clevel)])
+        cur_hi = max(cur) if cur else 0
+        for nxt in range(clevel + 1, 21):
+            slots = srd.multiclass_slots([(cname, nxt)])
+            hi = max(slots) if slots else 0
+            if hi > cur_hi:
+                nxt_slot = _ORDINAL.get(cur_hi + 1, f"{cur_hi + 1}th")
+                label = "Half-caster" if tier == "half" else "Third-caster"
+                return (tier, f"{label} — {nxt_slot}-level slots unlock at L{nxt}.")
+    except Exception:
+        return (tier, None)
+    # Already at the class's top slot level — nothing further to unlock.
+    return (tier, None)
+
+
 def _character_spellcasting(ch: dict) -> dict | None:
     """Character-level spellcasting summary for the TOP of the Spells tab — the once-at-the-top
     Spell Save DC + Spell Attack Bonus a caster needs to plan (the way D&D Beyond shows them),
     derived from the PC's spellcasting ability + proficiency. Returns None for a non-caster
     (no SRD caster class) so the screen omits the block entirely — an honest Fighter shows
-    nothing, never a fabricated DC 0. Reuses the same #410 formula helpers (no new math)."""
+    nothing, never a fabricated DC 0. Reuses the same #410 formula helpers (no new math).
+
+    Also emits ``casterTier`` (full/half/third/pact) and, for a slower-than-full caster, a short
+    ``slotProgressionNote`` naming the next LOCKED slot level — context so a reader does not misread
+    an SRD-correct half-caster slot count as missing slots. Both are None/absent when there is
+    nothing honest to say (the guard lives in _caster_tier_and_note)."""
     ability = _casting_ability(ch)
     if ability is None:
         return None
+    tier, note = _caster_tier_and_note(ch)
     return {
         "ability": ability,
         # short SRD code (int/wis/cha) for a compact "INT" badge in the UI
         "abilityShort": ability[:3],
         "spellSaveDc": _spell_save_dc(ch),
         "spellAttackBonus": _spell_attack_bonus(ch),
+        "casterTier": tier,
+        "slotProgressionNote": note,
     }
 
 
@@ -4598,6 +4714,40 @@ def _catalog_stat_block(name: str) -> dict:
         "properties": _catalog_property_chips(meta),
         "description": _text(meta.get("description")),
     }
+
+
+def feat_catalog_response(query: str = "") -> dict:
+    """GET /feat-catalog read model — the browsable SRD feat list the level-up planner's feat pane
+    reads so a player picks a REAL feat (with its full effect text + prerequisite) instead of a
+    blind free-text box (the planner's one remaining gap). Mirrors the /item-catalog reader: it
+    bridges to the engine-owned PURE ``featcatalog`` module (the same data the engine ``feats`` tool
+    returns), filters by name/prerequisite/effect text when ``query`` is given, and projects each
+    feat into ``{name, desc, prerequisite, type}``. READ-ONLY: it never writes state and exposes no
+    mutate lane (the chosen feat name still rides the existing /move level_up relay). Returns an
+    empty ``feats`` list (with an ``error``) when the engine module can't be imported — never a
+    fabricated feat."""
+    cat = _engine_module("featcatalog")
+    if cat is None or not hasattr(cat, "find"):
+        detail = _ENGINE_IMPORT_ERROR or "engine feat catalog is unavailable"
+        return {"query": _text(query), "count": 0, "feats": [], "error": f"engine import failed: {detail}"}
+    try:
+        rows = cat.find(_text(query))
+    except Exception as exc:
+        return {"query": _text(query), "count": 0, "feats": [], "error": str(exc)}
+    feats: list[dict] = []
+    for r in rows:
+        if not isinstance(r, dict):
+            continue
+        name = _text(r.get("name"))
+        if not name:
+            continue
+        feats.append({
+            "name": name,
+            "desc": _text(r.get("desc")),
+            "prerequisite": _text(r.get("prerequisite")),
+            "type": _text(r.get("type")),
+        })
+    return {"query": _text(query), "count": len(feats), "feats": feats, "state_authority": "engine"}
 
 
 def _weapon_range_display(rng: "int | None", rng_long: "int | None") -> str:
@@ -8007,6 +8157,14 @@ class _Handler(BaseHTTPRequestHandler):
                     flat.append(key)
             flat = flat[:64]  # bound the batch so a query can't sweep the whole catalog
             self._json({"items": {n: _catalog_stat_block(n) for n in flat}})
+        elif route == "/feat-catalog":
+            # Read-only SRD feat list for the level-up planner's feat pane (mirrors /item-catalog).
+            # `?q=` filters by name / prerequisite / effect text; empty lists all 17 SRD feats. Pure
+            # reader: resolves against the bundled SRD feat catalog, mutates nothing, touches no
+            # campaign state. The CHOSEN feat name still rides the existing /move level_up relay.
+            qs = parse_qs(parsed.query)
+            query = (qs.get("q") or qs.get("query") or [""])[0]
+            self._json(feat_catalog_response(query))
         elif route == "/bestiary-surface":
             # Read-only player-safe bestiary/codex projection. No campaign or combat
             # mutation route is exposed here; the engine returns only public preview fields.

--- a/viewer/tests/test_charsheet_depth.py
+++ b/viewer/tests/test_charsheet_depth.py
@@ -126,6 +126,47 @@ class CharsheetDepthTests(unittest.TestCase):
         self.assertEqual(cast["spellSaveDc"], 15)
         self.assertEqual(cast["spellAttackBonus"], 7)
 
+    # ── caster-tier slot-progression context (the L10-Paladin "missing slots" false alarm) ──
+
+    def test_half_caster_paladin_emits_tier_and_unlock_note(self):
+        """A L10 Paladin (half-caster, SRD-correct 4/3/2 slots) surfaces casterTier=="half" and a
+        progression note naming the NEXT locked slot unlock — 4th-level slots at L13 — so a reader
+        does not misread the (correct) absence of a 4th slot as a missing slot."""
+        paladin = {
+            "id": "wyll", "name": "Wyll",
+            "classes": [{"name": "Paladin", "level": 10, "subclass": "Oath of Vengeance"}],
+            "abilities": {"strength": 16, "dexterity": 10, "constitution": 14,
+                          "intelligence": 10, "wisdom": 11, "charisma": 16},
+            "proficiency_bonus": 4,
+        }
+        cast = server._character_spellcasting(paladin)
+        self.assertIsNotNone(cast)
+        self.assertEqual(cast["casterTier"], "half")
+        self.assertIsNotNone(cast["slotProgressionNote"])
+        self.assertIn("13", cast["slotProgressionNote"])
+        self.assertIn("4th", cast["slotProgressionNote"])
+
+    def test_full_caster_has_tier_but_no_progression_note(self):
+        """A full caster (Wizard) is tagged casterTier=="full" but gets NO unlock note — its slots
+        already track level, so there is nothing to clarify (guarded: renders nothing)."""
+        cast = server._character_spellcasting(_SNAPSHOT["characters"]["elara"])
+        self.assertEqual(cast["casterTier"], "full")
+        self.assertIsNone(cast["slotProgressionNote"])
+
+    def test_max_level_half_caster_has_no_progression_note(self):
+        """A L17 Paladin already has 5th-level slots (the half-caster top) — there is nothing
+        further to unlock, so the note is None (no fabricated 'unlocks at L21')."""
+        paladin = {
+            "id": "wyll", "name": "Wyll",
+            "classes": [{"name": "Paladin", "level": 17}],
+            "abilities": {"charisma": 16, "strength": 16, "dexterity": 10,
+                          "constitution": 14, "intelligence": 10, "wisdom": 11},
+            "proficiency_bonus": 6,
+        }
+        cast = server._character_spellcasting(paladin)
+        self.assertEqual(cast["casterTier"], "half")
+        self.assertIsNone(cast["slotProgressionNote"])
+
     # ── prepared-spell CAP (Rest & Prepare budget) ──────────────────────────────
 
     def test_prepared_cap_full_caster_is_level_plus_ability_mod(self):

--- a/viewer/tests/test_feat_catalog.py
+++ b/viewer/tests/test_feat_catalog.py
@@ -1,0 +1,129 @@
+"""Route + projection tests for GET /feat-catalog — the browsable SRD feat list the level-up
+planner's feat pane reads (the planner's one real gap: 17 SRD feats existed but the feat choice
+was a BLIND free-text box). The viewer bridges to the engine-owned PURE ``featcatalog`` module
+(the same data the engine ``feats`` tool returns) and projects each feat into
+``{name, desc, prerequisite, type}``.
+
+INVARIANT: the surface is a pure READER. It exposes NO write/mutate lane — the chosen feat name
+still rides the existing /move level_up relay; the engine stays the sole writer. It never
+fabricates a feat (an engine-import failure returns an empty list with an ``error``).
+"""
+
+import http.client
+import importlib.util
+import json
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server_featcatalog", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+class _QuietHandler(server._Handler):
+    def log_message(self, *args, **kwargs):  # silence access logging in tests
+        pass
+
+
+@unittest.skipIf(
+    server._load_engine_server() is None,
+    f"engine unavailable in this interpreter: {server._ENGINE_IMPORT_ERROR}",
+)
+class FeatCatalogTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+        _QuietHandler.campaign_id = ""
+        _QuietHandler.transcript_path = ""
+        _QuietHandler.chat_path = ""
+        _QuietHandler.pinned = False
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _get_json(self, path: str) -> tuple[int, dict]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=15)
+        try:
+            conn.request("GET", path)
+            resp = conn.getresponse()
+            body = resp.read()
+            return resp.status, (json.loads(body.decode("utf-8")) if body else {})
+        finally:
+            conn.close()
+
+    # --- the projection helper -------------------------------------------------
+
+    def test_response_lists_all_srd_feats_with_planner_fields(self):
+        surface = server.feat_catalog_response("")
+        self.assertNotIn("error", surface)
+        self.assertEqual(surface["count"], 17)
+        feats = surface["feats"]
+        self.assertTrue(feats)
+        for f in feats:
+            for field in ("name", "desc", "prerequisite", "type"):
+                self.assertIn(field, f)
+        names = {f["name"] for f in feats}
+        self.assertIn("Alert", names)
+        self.assertIn("Grappler", names)
+
+    def test_response_query_filters(self):
+        surface = server.feat_catalog_response("grappler")
+        self.assertGreaterEqual(surface["count"], 1)
+        names = {f["name"] for f in surface["feats"]}
+        self.assertIn("Grappler", names)
+        grappler = next(f for f in surface["feats"] if f["name"] == "Grappler")
+        # the prerequisite rides through so the picker can show it
+        self.assertIn("13", grappler["prerequisite"])
+
+    # --- the HTTP route --------------------------------------------------------
+
+    def test_route_returns_the_feat_catalog(self):
+        status, surface = self._get_json("/feat-catalog")
+        self.assertEqual(status, 200)
+        self.assertEqual(surface["count"], 17)
+        names = {f["name"] for f in surface["feats"]}
+        self.assertIn("Magic Initiate", names)
+        # each feat carries its effect text (the planner shows it on each option)
+        alert = next(f for f in surface["feats"] if f["name"] == "Alert")
+        self.assertTrue(alert["desc"], "each feat must carry its effect text")
+
+    def test_route_query_param_filters_wares(self):
+        status, surface = self._get_json("/feat-catalog?q=fighting%20style")
+        self.assertEqual(status, 200)
+        self.assertGreaterEqual(surface["count"], 1)
+        names = {f["name"] for f in surface["feats"]}
+        self.assertIn("Archery", names)
+        self.assertTrue(
+            all("fighting style" in (f["name"] + f["prerequisite"] + f["desc"]).lower()
+                for f in surface["feats"]),
+            "the feat filter must narrow to matching feats",
+        )
+
+    def test_route_exposes_no_write_lane(self):
+        status, surface = self._get_json("/feat-catalog")
+        self.assertEqual(status, 200)
+        # the feat catalog is read only; it must not advertise a write lane.
+        self.assertNotIn("write_lane", surface)
+        self.assertEqual(surface.get("state_authority"), "engine")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_levelup_asi_feat_picker.py
+++ b/viewer/tests/test_levelup_asi_feat_picker.py
@@ -75,11 +75,15 @@ function makeReact() {
 }
 
 let PLANNER = null;
+let FEATS = null;   // the /feat-catalog payload (set per test that exercises the browsable feat picker)
 const posts = [];
 function fetchStub(url, opts) {
   const u = String(url).split('?')[0];
   if (u === '/build-options') {
     return Promise.resolve({ ok: true, json: () => Promise.resolve(PLANNER || { ok: false, errors: ['no planner'] }) });
+  }
+  if (u === '/feat-catalog') {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(FEATS || { feats: [] }) });
   }
   if (u === '/move') {
     let body = {}; try { body = JSON.parse((opts && opts.body) || '{}'); } catch (_e) {}
@@ -146,6 +150,7 @@ async function settle() { await new Promise((r) => setImmediate(r)); await new P
 const h = {
   mountLevelUp: (props) => { reactHost.mount(() => sandbox.window.LevelUpModal(props)); },
   setPlanner: (p) => { PLANNER = p; },
+  setFeats: (f) => { FEATS = f; },
   tree: () => reactHost.api(),
   settle,
   props: (id) => firstProps(reactHost.api(), id),
@@ -358,6 +363,69 @@ class LevelUpFeatPickerTests(_Harness):
         # mutually exclusive: an ASI was never allocated, so the intent must NOT also claim an ASI bump.
         self.assertNotIn("+1 str", text)
         self.assertNotIn("+2 str", text)
+
+
+# A small /feat-catalog payload the browsable picker loads when the feat pane opens (mirrors the
+# shape of GET /feat-catalog: {name, desc, prerequisite, type}).
+_FEAT_CATALOG = json.dumps({
+    "count": 2,
+    "feats": [
+        {"name": "Alert", "desc": "Initiative Proficiency: add your proficiency to initiative.",
+         "prerequisite": "", "type": "Origin"},
+        {"name": "Grappler", "desc": "You have advantage on attacks against grappled creatures.",
+         "prerequisite": "Level 4+, Strength or Dexterity 13+", "type": "General"},
+    ],
+})
+
+
+class LevelUpFeatBrowserTests(_Harness):
+    """#feat-browser — the feat pane is now a BROWSABLE picker (GET /feat-catalog) showing each
+    feat's effect + prerequisite; selecting one fills featName which rides the existing relay. The
+    free-text input REMAINS for world-canon feats the SRD list doesn't enumerate."""
+
+    def _mount(self):
+        return (
+            "h.setPlanner(" + _PLANNER_ASI_AND_FEAT + ");"
+            "h.setFeats(" + _FEAT_CATALOG + ");"
+            "h.mountLevelUp({ hero: " + _HERO_L3_FIGHTER + ", campaignId: 'camp1',"
+            " onClose: function(){}, onDone: function(){}, toast: function(){} });"
+            "await h.settle();"
+        )
+
+    def test_feat_options_render_after_opening_the_feat_pane(self):
+        out = self._run(
+            self._mount() +
+            "await h.click('levelup-feat-toggle');"   # opens the feat pane -> loads /feat-catalog
+            "return ({ options: h.exists('levelup-feat-options'),"
+            "  alert: h.exists('levelup-feat-option-alert'),"
+            "  grappler: h.exists('levelup-feat-option-grappler'),"
+            "  free_text: h.exists('levelup-feat-input'), text: h.text() });"
+        )
+        self.assertGreaterEqual(out["options"], 1, "the browsable feat list must render in the feat pane")
+        self.assertGreaterEqual(out["alert"], 1, "each SRD feat is a selectable option")
+        self.assertGreaterEqual(out["grappler"], 1)
+        self.assertGreaterEqual(out["free_text"], 1, "the free-text override input must remain (world-canon feats)")
+        # the option shows the feat's effect text + prerequisite (a real browse, not a name list)
+        self.assertIn("advantage on attacks against grappled", out["text"].lower())
+        self.assertIn("Strength or Dexterity 13+", out["text"])
+
+    def test_selecting_a_feat_option_fills_the_name_and_rides_the_move(self):
+        out = self._run(
+            self._mount() +
+            "await h.click('levelup-feat-toggle');"
+            "var before = h.props('levelup-confirm');"
+            "await h.click('levelup-feat-option-grappler');"   # selecting fills featName
+            "var after = h.props('levelup-confirm');"
+            "await h.click('levelup-confirm');"
+            "return ({ blocked_before: !!before.disabled, ready: !!after.disabled,"
+            "  post: (h.posts()[0] || null) });"
+        )
+        self.assertTrue(out["blocked_before"], "no feat chosen yet -> Confirm is blocked")
+        self.assertFalse(out["ready"], "selecting a feat option enables Confirm")
+        self.assertIsNotNone(out["post"])
+        text = out["post"]["body"]["text"].lower()
+        self.assertIn("grappler", text, "the chosen feat name must ride the existing level_up relay")
+        self.assertIn("feat", text)
 
 
 if __name__ == "__main__":

--- a/viewer/tests/test_merchant_surface.py
+++ b/viewer/tests/test_merchant_surface.py
@@ -138,6 +138,34 @@ class MerchantSurfaceTests(unittest.TestCase):
         ls_names = {w.get("name") for w in ls.get("catalog", [])}
         self.assertIn("Longsword", ls_names, "the SRD catalog must hold the canonical Longsword")
 
+    def test_default_supply_is_mostly_priced_buyable_gear(self):
+        # The "empty market" complaint: the raw alphabetical catalog slice is dominated by
+        # PRICELESS magic items (price None → disabled Take), so only a handful are buyable. The
+        # default (no-query) supply must lead with PRICED, mundane gear so the market reads stocked.
+        status, surface = self._get_json("/merchant-surface?limit=40")
+        self.assertEqual(status, 200)
+        catalog = surface.get("catalog", [])
+        self.assertTrue(catalog, "the default supply must carry wares")
+        priced = [w for w in catalog if isinstance(w.get("price"), int) and w["price"] > 0]
+        self.assertGreater(
+            len(priced), len(catalog) // 2,
+            f"the default merchant supply must be MOSTLY priced/buyable gear, "
+            f"got {len(priced)}/{len(catalog)} priced",
+        )
+
+    def test_default_supply_leads_with_priced_before_priceless(self):
+        # Sort contract: every priced ware sorts AHEAD of every priceless one in the default slice
+        # (priceless items still appear, just after the buyable gear — never dropped).
+        status, surface = self._get_json("/merchant-surface?limit=80")
+        self.assertEqual(status, 200)
+        flags = [bool(isinstance(w.get("price"), int) and w["price"] > 0)
+                 for w in surface.get("catalog", [])]
+        first_priceless = next((i for i, p in enumerate(flags) if not p), len(flags))
+        self.assertFalse(
+            any(flags[first_priceless:]),
+            "no priced ware may appear after the first priceless one in the default supply",
+        )
+
     def test_catalog_query_filters_wares(self):
         status, surface = self._get_json("/merchant-surface?q=longsword&limit=50")
         self.assertEqual(status, 200)

--- a/viewer/tests/test_rest_camp_levelup_wiring.py
+++ b/viewer/tests/test_rest_camp_levelup_wiring.py
@@ -33,6 +33,7 @@ from pathlib import Path
 
 _OPENWORLDS = Path(__file__).resolve().parents[1] / "openworlds"
 _SCREEN_CHARACTER = _OPENWORLDS / "screen-character.jsx"
+_CAMP_SIDEBAR = _OPENWORLDS / "camp-sidebar.jsx"
 _BABEL = _OPENWORLDS / "vendor" / "babel-standalone-7.29.0.min.js"
 
 
@@ -85,11 +86,15 @@ function makeReact() {
 
 // ---- a SCRIPTED fetch capturing POST bodies; /build-options returns the scripted planner --------
 let PLANNER = null;            // the /build-options planner payload (set per test)
+let SURFACE = null;            // the /character-surface read-model (set per camp-sidebar test)
 const posts = [];              // every /move POST {url, body}
 function fetchStub(url, opts) {
   const u = String(url).split('?')[0];
   if (u === '/build-options') {
     return Promise.resolve({ ok: true, json: () => Promise.resolve(PLANNER || { ok: false, errors: ['no planner'] }) });
+  }
+  if (u === '/character-surface') {
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(SURFACE || {}) });
   }
   if (u === '/move') {
     let body = {}; try { body = JSON.parse((opts && opts.body) || '{}'); } catch (_e) {}
@@ -135,6 +140,10 @@ sandbox.slug = (n) => (n || '').toLowerCase().replace(/[^a-z0-9]+/g, '-');
 sandbox.combatSurfaceFromCampaign = () => '';
 
 load(%(screen_character)s);
+// camp-sidebar.jsx defines CampSidebar (CS-prep: the camp long-rest → Prepare-spells affordance).
+// It's loaded AFTER screen-character.jsx (same order as index.html) so window.RestPrepareModal is
+// already defined when CampSidebar routes it. Loading it is additive — existing tests ignore it.
+load(%(camp_sidebar)s);
 
 // ---- tree helpers ----------------------------------------------------------------------------
 function findByTestId(node, id, hits) {
@@ -158,13 +167,28 @@ function collectText(node, out) {
   return out;
 }
 function firstProps(node, id) { const hits = findByTestId(node, id); return hits.length ? (hits[0].props || {}) : null; }
+// Find a rendered element whose `type` is a given component FUNCTION (this stub does not recurse
+// into function children, so to verify CampSidebar ROUTES RestPrepareModal we inspect the element
+// it emitted — its props carry the hero + initialStep the camp path wires through). Returns props.
+function findByType(node, fn, hits) {
+  hits = hits || [];
+  if (node == null || typeof node !== 'object') return hits;
+  if (Array.isArray(node)) { for (const c of node) findByType(c, fn, hits); return hits; }
+  if (node.type === fn) hits.push(node);
+  const props = node.props || {};
+  const kids = (node.children && node.children.length ? node.children : (props.children !== undefined ? [].concat(props.children) : []));
+  for (const c of kids) findByType(c, fn, hits);
+  return hits;
+}
 
 async function settle() { await new Promise((r) => setImmediate(r)); await new Promise((r) => setImmediate(r)); reactHost.commit(); }
 
 const h = {
   mountRest: (props) => { reactHost.mount(() => sandbox.window.RestPrepareModal(props)); },
   mountLevelUp: (props) => { reactHost.mount(() => sandbox.window.LevelUpModal(props)); },
+  mountCamp: (props) => { reactHost.mount(() => sandbox.window.CampSidebar(props)); },
   setPlanner: (p) => { PLANNER = p; },
+  setSurface: (s) => { SURFACE = s; },
   tree: () => reactHost.api(),
   settle,
   // find a node by testid and read a prop (disabled/title/etc.)
@@ -175,6 +199,8 @@ const h = {
   posts: () => posts,
   toasts: () => toastCalls,
   exists: (id) => findByTestId(reactHost.api(), id).length,
+  // props of the RestPrepareModal element CampSidebar routed (null if none rendered).
+  routedModal: () => { const hits = findByType(reactHost.api(), sandbox.window.RestPrepareModal); return hits.length ? (hits[0].props || {}) : null; },
 };
 
 const script = %(script)s;
@@ -190,13 +216,14 @@ class _Harness(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        for p in (_SCREEN_CHARACTER, _BABEL):
+        for p in (_SCREEN_CHARACTER, _CAMP_SIDEBAR, _BABEL):
             assert p.exists(), f"missing {p}"
 
     def _run(self, script: str):
         program = _HARNESS % {
             "babel": json.dumps(str(_BABEL)),
             "screen_character": json.dumps(str(_SCREEN_CHARACTER)),
+            "camp_sidebar": json.dumps(str(_CAMP_SIDEBAR)),
             "script": json.dumps(script),
         }
         proc = subprocess.run(
@@ -580,6 +607,82 @@ class LevelUpOverdueSubclassTests(_Harness):
         self.assertTrue(out["disabled_before"], "an overdue, unnamed archetype must block Confirm")
         self.assertIn("Martial Archetype", out["title"], "the reason must name the overdue archetype group")
         self.assertFalse(out["disabled_after"], "naming the archetype enables Confirm")
+
+
+class CampPrepareSpellsWiringTests(_Harness):
+    """CS-prep — the prominent camp long-rest (camp-sidebar.jsx beginRest) now surfaces a
+    Prepare-spells affordance that ROUTES THE EXISTING RestPrepareModal at its `prep` step for each
+    prepared caster, closing the gap where the camp rest skipped the spell-prep the sheet offers."""
+
+    # A live read-model surface with ONE prepared caster (preparedCap>0) + one non-preparing hero.
+    _SURFACE = json.dumps({
+        "can_act": True,
+        "campaign_id": "camp1",
+        "party": [
+            {"id": "wyll", "name": "Wyll Ravengard", "short": "Wyll",
+             "preparedCap": 8, "preparableSpells": [{"name": "Cure Wounds", "level": 1}]},
+            {"id": "karlach", "name": "Karlach Cliffgate", "short": "Karlach"},  # Barbarian — no cap
+        ],
+    })
+
+    def _mount(self, can_act="true", dm_busy="false"):
+        return (
+            "h.setSurface(" + self._SURFACE + ");"
+            "h.mountCamp({ state: { activeCampaign: 'camp1', campaigns: [{ id: 'camp1' }] },"
+            " onExit: function(){}, onBeginRest: function(){}, onTalk: function(){},"
+            " talkPartner: null, dmBusy: " + dm_busy + " });"
+            "await h.settle();"
+        )
+
+    def test_no_prepare_affordance_before_resting(self):
+        # The Prepare-spells panel only appears AFTER a camp rest lands — not on first open.
+        out = self._run(
+            self._mount() +
+            "return ({ panel: h.exists('camp-prepare-spells'),"
+            "  rest_btn: h.exists('camp-begin-rest') });"
+        )
+        self.assertEqual(out["rest_btn"], 1, "the camp Begin-Resting CTA must render")
+        self.assertEqual(out["panel"], 0, "no Prepare-spells affordance until a rest has been taken")
+
+    def test_prepare_affordance_appears_after_camp_rest_for_prepared_caster(self):
+        # After the camp long rest relays, a per-caster Prepare button appears for the prepared
+        # caster (Wyll) but NOT for the non-preparing hero (Karlach — no preparedCap).
+        out = self._run(
+            self._mount() +
+            "await h.click('camp-begin-rest');"   # relays the long rest -> restedThisVisit
+            "return ({ panel: h.exists('camp-prepare-spells'),"
+            "  wyll: h.exists('camp-prepare-wyll'), karlach: h.exists('camp-prepare-karlach'),"
+            "  rest_posts: h.posts().length, rest_post: h.posts()[0] || null });"
+        )
+        self.assertEqual(out["rest_posts"], 1, "the camp Begin-Resting must relay exactly one /move long rest")
+        self.assertEqual(out["rest_post"]["body"]["kind"], "do")
+        self.assertIn("long rest", out["rest_post"]["body"]["text"].lower())
+        self.assertGreaterEqual(out["panel"], 1, "after resting, the Prepare-spells affordance must render")
+        self.assertGreaterEqual(out["wyll"], 1, "a prepared caster (Wyll) gets a Prepare button")
+        self.assertEqual(out["karlach"], 0, "a non-preparing hero (Barbarian) gets NO Prepare button")
+
+    def test_prepare_button_routes_the_existing_modal_at_its_prep_step(self):
+        # Clicking the per-caster Prepare button ROUTES the EXISTING RestPrepareModal — opened
+        # straight at its `prep` step for THAT hero. We inspect the routed element's props (the camp
+        # path reuses the same component, not a new prep UI). The modal's own internal relay is
+        # covered by RestPrepareWiringTests.test_prepare_spells_button_is_wired_after_resting.
+        out = self._run(
+            self._mount() +
+            "var before = h.routedModal();"          # no modal before a Prepare click
+            "await h.click('camp-begin-rest');"      # rest relay
+            "await h.click('camp-prepare-wyll');"    # routes RestPrepareModal at prep step
+            "var m = h.routedModal();"
+            "return ({ before: before, routed: !!m,"
+            "  initial_step: m && m.initialStep, hero_id: m && m.hero && m.hero.id,"
+            "  campaign: m && m.campaignId, can_act: m && m.canAct });"
+        )
+        self.assertIsNone(out["before"], "no RestPrepareModal is routed before the Prepare button is clicked")
+        self.assertTrue(out["routed"], "clicking Prepare must route the EXISTING RestPrepareModal")
+        self.assertEqual(out["initial_step"], "prep",
+                         "the camp path must open the modal at its prep step (rest already happened)")
+        self.assertEqual(out["hero_id"], "wyll", "the routed modal targets the chosen prepared caster")
+        self.assertEqual(out["campaign"], "camp1", "the campaign id rides through to the modal's relay")
+        self.assertTrue(out["can_act"], "the live-session can_act flows through so the relay is enabled")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the build-optimizer persona's filed gaps from the rc3 honest baseline — all wire-up/projection issues, not missing features (engine + viewer were ~90% there):

1. **Half-caster slot trust** — spells tab now shows `casterTier` + a derived `slotProgressionNote` ("Half-caster — 4th-level slots unlock at L13", computed from the engine's own SRD table) under the slot track. Fixes the false-alarm "critical" (L10 Paladin 4/3/2 misread as missing slots). Guarded so non-applicable cases render nothing.
2. **Market priced-first** — `build_merchant_surface` sorts priced, buyable gear ahead of the priceless magic-item long tail (which stays reachable; search bypasses). Fixes the "empty market" (was alphabetical → ~all un-buyable).
3. **Camp spell-prep** — camp long-rest now surfaces a guarded "Prepare Spells" affordance per prepared caster, routing the existing `RestPrepareModal` at its prep step (players resting via Camp previously never saw prep).
4. **Feat browser** — new read-only engine `feats()` MCP tool (pure `featcatalog.py` over bundled SRD) + viewer `/feat-catalog` route + a browsable feat picker replacing the blind free-text box in `LevelUpModal`.

All additive + read-only (engine stays sole writer; no content authored). Tests: charsheet 23 / merchant 14 / rest-camp 20 / engine featcatalog 8 / viewer feat-catalog 5 / levelup picker 11; 271-test regression sweep green; fast_gate 222 + seat-path green.