### PR TITLE
qa(phase-2): detect_regression — machine-readable "better or worse than baseline?" for the implementing agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,8 @@ jobs:
             ../../qa/test_claude_auth_isolation.py \
             ../../qa/test_snapshot_world_state.py \
             ../../qa/test_score_determinism.py \
-            ../../qa/test_lens_variance.py
+            ../../qa/test_lens_variance.py \
+            ../../qa/test_detect_regression.py
 
   server-contracts:
     # Phase-1 (DETERMINISTIC-2): deterministic cross-service MCP contract tests

--- a/qa/detect_regression.py
+++ b/qa/detect_regression.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Is this candidate run BETTER or WORSE than the comparable baseline? — the QA harness's
+machine-readable regression signal for the implementing agent.
+
+The agent asks one question after a scored run: *did I regress quality vs the last known-good build,
+or is this within scorer noise?* This tool answers it WITHOUT the agent spelunking the ledger by hand:
+
+  1. Build the candidate's comparability key (surface, dm_model, methodology, lens_config_version).
+  2. Find the single canonical GREEN baseline for THAT EXACT key (``scores_db.get_canonical_baseline``).
+     The key includes ``lens_config_version`` so the comparison is ruler-fenced — a candidate scored
+     under a different lens ruler has NO comparable baseline (we refuse rather than emit a false
+     REGRESSED; cross-ruler deltas are not apples-to-apples, per qa/REGRESSION-FORENSICS.md).
+  3. Per lens (story/mech/angry), classify ``candidate - baseline`` against the published per-lens
+     NOISE FLOOR (qa/lens_noise_floor.py): beyond +floor = IMPROVED, beyond -floor = REGRESSED, else
+     WITHIN_NOISE. A behavioral GREEN→RED flip is a regression regardless of lens deltas.
+
+Verdict (overall): REGRESSED if any lens regressed OR behavioral flipped GREEN→RED; else IMPROVED if any
+lens improved and none regressed; else WITHIN_NOISE; NO_BASELINE / NO_DATA when there is nothing to compare.
+
+Usage:
+    python qa/detect_regression.py --candidate <run_id> [--db qa/scores.db] [--json]
+    python qa/detect_regression.py --candidate-json '<json>'|@file.json [--db ...] [--json]
+
+Exit codes (so CI / the agent can gate): 0 = IMPROVED/WITHIN_NOISE, 2 = REGRESSED, 3 = NO_BASELINE/NO_DATA.
+This is a pure reader — it never writes state, scores a transcript, or runs a game.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+_QA_DIR = Path(__file__).resolve().parent
+if str(_QA_DIR) not in sys.path:
+    sys.path.insert(0, str(_QA_DIR))
+
+import scores_db  # noqa: E402
+from lens_noise_floor import LENS_COLUMNS, NOISE_FLOOR, classify_delta, delta_floor  # noqa: E402
+
+# Verdict -> process exit code. NO_BASELINE/NO_DATA are advisory (no signal), distinct from a regression.
+_EXIT = {"IMPROVED": 0, "WITHIN_NOISE": 0, "REGRESSED": 2, "NO_BASELINE": 3, "NO_DATA": 3}
+
+
+def _key_of(candidate: dict) -> dict:
+    """The comparability key (surface, dm_model, methodology, lens_config_version) from a candidate."""
+    return {c: candidate.get(c) for c in scores_db._BASELINE_KEY}
+
+
+def detect_regression(candidate: dict, db_path: Path | str = scores_db.DB_PATH) -> dict:
+    """Compare ``candidate`` (a run dict: comparability key + lens overalls + behavioral) against the
+    canonical GREEN baseline for its key. Returns a machine-readable verdict dict."""
+    key = _key_of(candidate)
+    baseline = scores_db.get_canonical_baseline(db_path=db_path, **key)
+
+    result: dict = {
+        "candidate_run": candidate.get("run_id"),
+        "baseline_run": baseline.get("run_id") if baseline else None,
+        "comparability_key": key,
+        "per_lens": [],
+        "behavioral": {
+            "candidate": candidate.get("behavioral"),
+            "baseline": baseline.get("behavioral") if baseline else None,
+            "regressed": False,
+        },
+    }
+
+    if baseline is None:
+        result["verdict"] = "NO_BASELINE"
+        result["message"] = (
+            "No canonical GREEN baseline for this comparability key "
+            f"({key}). Set one with: scores_db.set_canonical_baseline(<run_id>) "
+            "after a trusted GREEN run, then re-run. Cross-ruler comparison is intentionally refused."
+        )
+        return result
+
+    # Per-lens deltas vs the noise floor.
+    classes: list[str] = []
+    for col in LENS_COLUMNS:
+        cand_v = candidate.get(col)
+        base_v = baseline.get(col)
+        if cand_v is None or base_v is None:
+            result["per_lens"].append(
+                {"lens": col, "label": NOISE_FLOOR[col]["label"], "candidate": cand_v,
+                 "baseline": base_v, "delta": None, "floor": delta_floor(col), "classification": "NO_DATA"}
+            )
+            continue
+        delta = round(float(cand_v) - float(base_v), 4)
+        cls = classify_delta(col, delta)
+        classes.append(cls)
+        result["per_lens"].append(
+            {"lens": col, "label": NOISE_FLOOR[col]["label"], "candidate": cand_v, "baseline": base_v,
+             "delta": delta, "floor": delta_floor(col), "classification": cls}
+        )
+
+    # A behavioral GREEN -> RED flip is a regression regardless of lens deltas (the deterministic gate
+    # caps quality anyway; surface it explicitly so the agent sees the real cause).
+    behavioral_regressed = (
+        str(candidate.get("behavioral") or "").upper() == "RED"
+        and str(baseline.get("behavioral") or "").upper() == "GREEN"
+    )
+    result["behavioral"]["regressed"] = behavioral_regressed
+
+    if behavioral_regressed or "REGRESSED" in classes:
+        verdict = "REGRESSED"
+    elif "IMPROVED" in classes:
+        verdict = "IMPROVED"
+    elif classes:
+        verdict = "WITHIN_NOISE"
+    else:
+        verdict = "NO_DATA"
+    result["verdict"] = verdict
+    result["message"] = _summary(result)
+    return result
+
+
+def _summary(result: dict) -> str:
+    lines = [f"{result['verdict']}: candidate {result.get('candidate_run')} vs baseline {result['baseline_run']}"]
+    for p in result["per_lens"]:
+        if p["delta"] is None:
+            lines.append(f"  {p['label']:24s} no-data (cand={p['candidate']} base={p['baseline']})")
+        else:
+            sign = "+" if p["delta"] >= 0 else ""
+            lines.append(
+                f"  {p['label']:24s} {p['baseline']} -> {p['candidate']} "
+                f"({sign}{p['delta']}, floor ±{p['floor']}) {p['classification']}"
+            )
+    if result["behavioral"]["regressed"]:
+        lines.append("  behavioral: GREEN -> RED  (regression)")
+    return "\n".join(lines)
+
+
+def _load_candidate(args) -> dict:
+    if args.candidate_json:
+        raw = args.candidate_json
+        if raw.startswith("@"):
+            raw = Path(raw[1:]).read_text()
+        return json.loads(raw)
+    # --candidate <run_id>: look the row up in the ledger.
+    rows = {r["run_id"]: r for r in scores_db.fetch_rows(db_path=args.db)}
+    row = rows.get(args.candidate)
+    if row is None:
+        raise SystemExit(f"detect_regression: no run '{args.candidate}' in {args.db}")
+    return row
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    src = p.add_mutually_exclusive_group(required=True)
+    src.add_argument("--candidate", help="run_id of the candidate run (looked up in --db)")
+    src.add_argument("--candidate-json", help="candidate run as JSON, or @path to a JSON file")
+    p.add_argument("--db", default=str(scores_db.DB_PATH), help="path to scores.db")
+    p.add_argument("--json", action="store_true", help="emit the machine-readable verdict as JSON")
+    args = p.parse_args(argv)
+
+    candidate = _load_candidate(args)
+    result = detect_regression(candidate, db_path=args.db)
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        print(result.get("message", result["verdict"]))
+    return _EXIT.get(result["verdict"], 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/lens_noise_floor.py
+++ b/qa/lens_noise_floor.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Canonical per-lens SCORING NOISE FLOOR — the single source of truth.
+
+The three LLM lenses (story-craft/Tolkien, mechanical, angry-dm/5e-fidelity) are stochastic: two
+behaviorally-GREEN runs that share a comparability key still differ run-to-run. ``qa/test_lens_variance.py``
+measured that spread on the committed corpus; this module is where the resulting floor lives so EVERY
+consumer reads the same numbers:
+
+  - ``qa/test_lens_variance.py``  — asserts the live corpus spread stays under this floor.
+  - ``qa/detect_regression.py``   — a candidate-vs-baseline lens delta within the floor is **noise, not a
+                                    regression** (single-duo for velocity, median-of-N for gating).
+  - ``qa/SCORING.md`` § "Variance & noise floor" — the human-readable mirror; keep it in sync with this.
+
+`max_range` (max within-cluster max-min) is the right threshold for a TWO-run DELTA: a candidate run that
+differs from the baseline by no more than the range floor is indistinguishable from scorer noise.
+`max_stdev` (population stdev) is the right threshold for the SPREAD of an N-run cluster.
+
+If a future re-score blows past these, raise the floor HERE (one edit) and update SCORING.md — the
+self-consistency test in test_lens_variance.py guards the structure.
+"""
+
+from __future__ import annotations
+
+# lens db-column -> (max population stdev across a comparable GREEN cluster, max range of that cluster).
+# Mirrors qa/SCORING.md § "Variance & noise floor" (measured: story 0.15/0.30, mech 0.25/0.50,
+# angry 0.35/0.70; documented floor rounds up for headroom on a thin corpus).
+NOISE_FLOOR: dict[str, dict] = {
+    "story_overall": {"max_stdev": 0.20, "max_range": 0.40, "label": "story-craft (Tolkien)"},
+    "mech_overall": {"max_stdev": 0.30, "max_range": 0.60, "label": "mechanical"},
+    "angrydm_overall": {"max_stdev": 0.40, "max_range": 0.80, "label": "angry-dm (5e fidelity)"},
+}
+
+# The three lens columns, in canonical display order.
+LENS_COLUMNS: tuple[str, ...] = tuple(NOISE_FLOOR.keys())
+
+
+def delta_floor(lens_col: str) -> float:
+    """The noise band (max_range) for a candidate-vs-baseline delta on ``lens_col``."""
+    return float(NOISE_FLOOR[lens_col]["max_range"])
+
+
+def classify_delta(lens_col: str, delta: float) -> str:
+    """Classify a candidate-minus-baseline ``delta`` against the lens noise floor.
+
+    Returns "IMPROVED" (delta beyond +floor), "REGRESSED" (beyond -floor), or "WITHIN_NOISE".
+    """
+    floor = delta_floor(lens_col)
+    if delta > floor:
+        return "IMPROVED"
+    if delta < -floor:
+        return "REGRESSED"
+    return "WITHIN_NOISE"

--- a/qa/test_detect_regression.py
+++ b/qa/test_detect_regression.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Tests for qa/detect_regression.py — the candidate-vs-canonical-baseline regression signal.
+
+Run (single-process):
+    uv run --directory servers/engine python -m pytest qa/test_detect_regression.py -q -p no:xdist
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+QA_DIR = Path(__file__).resolve().parent
+if str(QA_DIR) not in sys.path:
+    sys.path.insert(0, str(QA_DIR))
+
+import detect_regression as dr  # noqa: E402
+import scores_db  # noqa: E402
+
+# A comparability key (surface, dm_model, methodology, lens_config_version) all four runs share.
+KEY = dict(
+    surface="engine-duo",
+    dm_model="opus",
+    methodology="duo-8beat",
+    lens_config_version="lc_testfloor1",
+)
+
+
+def _seed_baseline(db, **overrides):
+    """Add a behaviorally-GREEN baseline run and mark it canonical. Returns its run_id."""
+    fields = dict(story_overall=4.0, mech_overall=3.6, angrydm_overall=3.4, behavioral="GREEN", **{"pass": 1})
+    fields.update(overrides)
+    scores_db.add_run("baseline-1", db_path=db, **KEY, **fields)
+    scores_db.set_canonical_baseline("baseline-1", db_path=db)
+    return "baseline-1"
+
+
+def test_no_baseline_when_none_set(tmp_path):
+    db = tmp_path / "s.db"
+    scores_db.add_run("cand", db_path=db, **KEY, story_overall=4.0, behavioral="GREEN")
+    out = dr.detect_regression({"run_id": "cand", **KEY, "story_overall": 4.0, "behavioral": "GREEN"}, db_path=db)
+    assert out["verdict"] == "NO_BASELINE"
+    assert out["baseline_run"] is None
+
+
+def test_improved_beyond_floor(tmp_path):
+    db = tmp_path / "s.db"
+    _seed_baseline(db)  # story 4.0
+    cand = {"run_id": "c", **KEY, "story_overall": 4.6, "mech_overall": 3.6, "angrydm_overall": 3.4, "behavioral": "GREEN"}
+    out = dr.detect_regression(cand, db_path=db)
+    assert out["verdict"] == "IMPROVED"
+    story = next(p for p in out["per_lens"] if p["lens"] == "story_overall")
+    assert story["classification"] == "IMPROVED"
+    assert story["delta"] == pytest.approx(0.6)
+
+
+def test_regressed_beyond_floor(tmp_path):
+    db = tmp_path / "s.db"
+    _seed_baseline(db)  # story 4.0
+    cand = {"run_id": "c", **KEY, "story_overall": 3.4, "mech_overall": 3.6, "angrydm_overall": 3.4, "behavioral": "GREEN"}
+    out = dr.detect_regression(cand, db_path=db)
+    assert out["verdict"] == "REGRESSED"
+    story = next(p for p in out["per_lens"] if p["lens"] == "story_overall")
+    assert story["classification"] == "REGRESSED"
+
+
+def test_within_noise_is_not_a_regression(tmp_path):
+    db = tmp_path / "s.db"
+    _seed_baseline(db)  # story 4.0 mech 3.6 angry 3.4
+    # All deltas inside the per-lens range floors (story 0.40 / mech 0.60 / angry 0.80).
+    cand = {"run_id": "c", **KEY, "story_overall": 4.2, "mech_overall": 3.5, "angrydm_overall": 3.7, "behavioral": "GREEN"}
+    out = dr.detect_regression(cand, db_path=db)
+    assert out["verdict"] == "WITHIN_NOISE"
+    assert all(p["classification"] == "WITHIN_NOISE" for p in out["per_lens"] if p["delta"] is not None)
+
+
+def test_behavioral_red_is_regression_even_if_lenses_within_noise(tmp_path):
+    db = tmp_path / "s.db"
+    _seed_baseline(db)
+    cand = {"run_id": "c", **KEY, "story_overall": 4.1, "mech_overall": 3.6, "angrydm_overall": 3.4, "behavioral": "RED"}
+    out = dr.detect_regression(cand, db_path=db)
+    assert out["verdict"] == "REGRESSED"
+    assert out["behavioral"]["regressed"] is True
+
+
+def test_ruler_fencing_different_lens_config_is_not_comparable(tmp_path):
+    db = tmp_path / "s.db"
+    _seed_baseline(db)  # lens_config_version lc_testfloor1
+    # Candidate scored under a DIFFERENT lens ruler -> the canonical baseline does NOT apply.
+    cand = dict(KEY)
+    cand["lens_config_version"] = "lc_OTHER"
+    cand.update({"run_id": "c", "story_overall": 3.0, "behavioral": "GREEN"})
+    out = dr.detect_regression(cand, db_path=db)
+    assert out["verdict"] == "NO_BASELINE"  # cross-ruler comparison is refused, not a false REGRESSED
+
+
+def test_missing_lens_is_no_data_not_false_regression(tmp_path):
+    db = tmp_path / "s.db"
+    _seed_baseline(db)
+    # Candidate only scored story; mech/angry absent -> NO_DATA for those, verdict from story alone.
+    cand = {"run_id": "c", **KEY, "story_overall": 4.1, "behavioral": "GREEN"}
+    out = dr.detect_regression(cand, db_path=db)
+    assert out["verdict"] == "WITHIN_NOISE"
+    mech = next(p for p in out["per_lens"] if p["lens"] == "mech_overall")
+    assert mech["classification"] == "NO_DATA"
+
+
+def test_cli_candidate_by_run_id_json_and_exit_codes(tmp_path, capsys):
+    db = tmp_path / "s.db"
+    _seed_baseline(db)
+    scores_db.add_run("cand-regressed", db_path=db, **KEY, story_overall=3.3, mech_overall=3.6, angrydm_overall=3.4, behavioral="GREEN")
+    rc = dr.main(["--candidate", "cand-regressed", "--db", str(db), "--json"])
+    captured = capsys.readouterr().out
+    payload = json.loads(captured)
+    assert payload["verdict"] == "REGRESSED"
+    assert payload["candidate_run"] == "cand-regressed"
+    assert payload["baseline_run"] == "baseline-1"
+    assert rc == 2  # REGRESSED -> exit 2 (so CI / the agent can gate on it)
+
+
+def test_cli_no_baseline_exit_3(tmp_path, capsys):
+    db = tmp_path / "s.db"
+    scores_db.add_run("lonely", db_path=db, **KEY, story_overall=4.0, behavioral="GREEN")
+    rc = dr.main(["--candidate", "lonely", "--db", str(db), "--json"])
+    assert rc == 3  # NO_BASELINE -> advisory exit 3 (distinct from regression)

--- a/qa/test_lens_variance.py
+++ b/qa/test_lens_variance.py
@@ -47,26 +47,13 @@ sys.path.insert(0, str(QA_DIR))
 
 import scores_db  # noqa: E402  (canonical ledger reader; reuse, do not duplicate)
 
-# ---------------------------------------------------------------------------------------
-# DOCUMENTED NOISE FLOOR (must mirror qa/SCORING.md § "Variance & noise floor").
-#
-# These are the MAXIMUM within-cluster spread we tolerate for re-scores of the same
-# comparable run. They were DERIVED empirically from the comparable GREEN clusters in the
-# committed qa/scores.db (2026-06-16 snapshot, 75 rows): the observed max within-cluster
-# population stdev was story 0.15 / mech 0.25 / angry-dm 0.35 (ranges 0.30 / 0.50 / 0.70).
-# We round UP to a defensible bound (a little headroom for the next re-score) and record
-# it as the contract. Angry-DM is the noisiest lens (adversarial, exhaustive 5e checklist),
-# which is exactly why release gating leans on median-of-N hardest there.
-#
-# Each entry: lens-column -> (max_stdev, max_range). If a future re-score blows past these,
-# this test goes RED and forces a conscious re-derivation of the floor (and the doc).
-# ---------------------------------------------------------------------------------------
-NOISE_FLOOR = {
-    "story_overall": {"max_stdev": 0.20, "max_range": 0.40, "label": "story-craft (Tolkien)"},
-    "mech_overall": {"max_stdev": 0.30, "max_range": 0.60, "label": "mechanical"},
-    "angrydm_overall": {"max_stdev": 0.40, "max_range": 0.80, "label": "angry-dm (5e fidelity)"},
-}
-LENS_COLUMNS = tuple(NOISE_FLOOR.keys())
+# DOCUMENTED NOISE FLOOR — now the single source of truth in qa/lens_noise_floor.py (shared with
+# qa/detect_regression.py and mirrored in qa/SCORING.md § "Variance & noise floor"). It was DERIVED
+# empirically from the comparable GREEN clusters in the committed qa/scores.db (2026-06-16 snapshot):
+# observed max within-cluster population stdev story 0.15 / mech 0.25 / angry-dm 0.35 (ranges
+# 0.30 / 0.50 / 0.70), rounded UP for headroom. If a future re-score blows past these, this test goes
+# RED — raise the floor in qa/lens_noise_floor.py (one edit) and update SCORING.md.
+from lens_noise_floor import LENS_COLUMNS, NOISE_FLOOR  # noqa: E402
 
 # Per-lens scorecard filename suffix -> ledger lens column (for qa/transcripts/*.json).
 CARD_SUFFIX_TO_LENS = {


### PR DESCRIPTION
## Phase 2 (reframed) — the flagship agent-facing signal

Per the owner's clarification, Phase 2 is **tools the main implementing agent invokes** to get the data
it needs and catch regressions earlier — **not** a separate auto-looping/auto-merging daemon. This is
the flagship: after any scored run the agent asks *"did I regress vs the last known-good build, or is
this within scorer noise?"* and gets a machine-readable answer without hand-reading the ledger.

### `qa/detect_regression.py`
- Given a candidate run (`--candidate <run_id>` from `scores.db`, or `--candidate-json`), finds the
  single **canonical GREEN baseline** for its exact comparability key — `surface / dm_model /
  methodology / lens_config_version` (built on Phase-1's `is_canonical_baseline` column).
- Per lens, classifies `candidate − baseline` against the published noise floor →
  **IMPROVED / REGRESSED / WITHIN_NOISE**; `NO_BASELINE` / `NO_DATA` when there's nothing comparable.
- **Ruler-fenced**: a candidate scored under a different `lens_config_version` has no comparable
  baseline (→ `NO_BASELINE`, never a false `REGRESSED`) — per `qa/REGRESSION-FORENSICS.md`.
- A behavioral **GREEN→RED** flip is a regression regardless of lens deltas.
- Pure reader (no state writes). `--json` for the agent; exit `0`/`2`/`3` so CI or the agent can gate.

### Single source of truth for the noise floor
- `qa/lens_noise_floor.py` (new) holds the per-lens floor (story 0.40 / mech 0.60 / angry 0.80 range),
  shared by `detect_regression` + `test_lens_variance` + `SCORING.md`. `test_lens_variance.py` now
  imports it instead of duplicating the constant.

### Verification (local single-process)
`test_detect_regression.py` **9 passed** (verdicts, ruler-fencing, behavioral-RED, missing-lens, CLI
exit codes); `test_lens_variance.py` **6 passed / 1 skip** after the import refactor. Added to the CI
`qa-release-gate-tests` job. The `scores.db` lazy-migration (PR #949's `connect()` adds the 2 columns
on read) is intentionally **excluded** — a data artifact, settled separately.

How the agent uses it: run the gate → `detect_regression.py --json` → if `REGRESSED`, follow up with the
next Phase-2 tools (`root_cause_analyzer`, `evidence_audit`) — all on demand, nothing auto-acts.