### PR TITLE
qa(macos-static): fix drifted campaignStore.reload contract string

### DIFF
--- a/qa/test_macos_app_static.py
+++ b/qa/test_macos_app_static.py
@@ -36,7 +36,7 @@ class MacOSAppStaticContractTests(unittest.TestCase):
         self.assertIn("StatusStrip(repoPath: activeRepoPath", root_view)
         self.assertIn("repoPath: activeRepoPathBinding", root_view)
         self.assertIn("artRepoPath: activeArtRepoPathBinding", root_view)
-        self.assertIn("campaignStore.reload(repoPath: activeRepoPath)", root_view)
+        self.assertIn("campaignStore.reload(repoPath: activeRepoPath, stateDir: stateDir)", root_view)
 
     def test_native_viewer_and_provider_forward_art_repo_env(self):
         app_process = self.read("macos/WorldOSApp/Sources/WorldOSApp/Services/AppProcessService.swift")


### PR DESCRIPTION
## What

`qa/test_macos_app_static.py::MacOSAppStaticContractTests::test_debug_control_center_honors_launch_root_overrides` was failing on `main`. It asserted that `RootView.swift` contains:

```
campaignStore.reload(repoPath: activeRepoPath)
```

…but the source was refactored to:

```swift
campaignStore.reload(repoPath: activeRepoPath, stateDir: stateDir)
```

This test is **not** currently invoked by CI (`.github/workflows/ci.yml` doesn't run `test_macos_app_static.py`), so the failure was latent.

## Diagnosis — behavior is intact (path a)

The debug Control Center launch-root-override behavior still exists, just under a different call shape. In `RootView.swift`:

- `activeRepoPath` still resolves to `launchRepoPathOverride ?? repoPath` (line 46–48), so the override is honored.
- `DebugControlCenterView` still reloads the campaign store via that override-aware path — `campaignStore.reload(repoPath: activeRepoPath, stateDir: stateDir)` (line 805, inside the struct's `refresh()`).

The expected string simply drifted when a `stateDir:` argument was added. Per the task's path (a), I updated the assertion to match the current wiring.

## Change

One line in `qa/test_macos_app_static.py`: expected string updated to `campaignStore.reload(repoPath: activeRepoPath, stateDir: stateDir)`. This **strengthens** the assertion (now also pins `stateDir`) — no other assertion in the file is weakened.

## Verification (local, single-process)

- `qa/test_macos_app_static.py` — **14 passed** (was 13 pass / 1 fail).
- Full `servers/engine/tests` — **2845 passed** (no engine surface touched; sanity check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test validation for macOS app to ensure proper handling of launch root overrides, confirming both repository path and state directory are correctly processed when reloading configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->