### PR TITLE
feat(qa,engine): overnight refinements — run-retry robustness, approval stamp, camp cue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         # Phase-2 (AUTONOMY-6): proves the agent's pre-PR fix self-check computes the median + GREEN/
         # below-bar verdict + exit codes correctly, with the live runner stubbed (no model key).
         run: bash qa/test_dry_run_gate_fix.sh
+      - name: run_duo retry robustness test (transient-vs-real failure classification; pure bash)
+        # Proves turn_retry now retries a TRANSIENT 500/overload/429/timeout cluster up to 4x with
+        # backoff (the gs-ember-18b overnight-run killer) but FAILS FAST on a 401/403 auth error,
+        # with the claude turn fully stubbed (no model key).
+        run: bash qa/test_run_duo_retry_robustness.sh
 
   viewer-tests:
     # The viewer is where most recent regressions landed, but its suite was not in
@@ -103,7 +108,9 @@ jobs:
             ../../qa/test_behavioral_gate_corpus.py \
             ../../qa/test_deterministic_rri_gate.py \
             ../../qa/test_orchestrate_split_rri.py \
-            ../../qa/test_visual_regression_check.py
+            ../../qa/test_visual_regression_check.py \
+            ../../qa/test_structural_coverage.py \
+            ../../qa/test_story_readout_approval.py
 
   server-contracts:
     # Phase-1 (DETERMINISTIC-2): deterministic cross-service MCP contract tests

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -418,6 +418,10 @@ clawdnd_dm_result_is_error() {
 clawdnd_dm_final_text() {
   local out="$1" state_dir="$2" rc="${3:-0}"
   printf '%s\n' "$out" > "$state_dir/.dm_last_result" 2>/dev/null || true
+  # Persist the attempt's exit code too (the turn helpers run inside $(...) subshells, so the
+  # caller's transient-vs-real retry classifier can't see a local rc) — paired with .dm_last_result
+  # so clawdnd_dm_failure_is_transient gets the SAME (out, rc) this attempt produced.
+  printf '%s\n' "$rc" > "$state_dir/.dm_last_rc" 2>/dev/null || true
   if clawdnd_dm_result_is_error "$out"; then
     clawdnd_report_attempt_failure "$out" "$rc"
     return 0
@@ -865,6 +869,66 @@ clawdnd_report_attempt_failure() {
     401|403) echo "[dm-attempt] -> HTTP $status is an AUTH failure and is NOT retryable: check 'claude' login / ANTHROPIC_API_KEY (apiKeySource was likely \"none\"). The retry will also fail until auth is restored." >&2 ;;
   esac
   return 0
+}
+
+# TRANSIENT-vs-REAL FAILURE CLASSIFICATION (the overnight-run killer fix). A long playtest
+# (gs-ember-18b) died at beat 4 when a DM turn hit a SERVER-SIDE HTTP 500 AND the single retry
+# also 500'd — one transient cluster aborted a 2-3h run. turn_retry retried only ONCE on empty
+# output and could not tell a SERVER blip (worth several backed-off retries) from a DETERMINISTIC
+# failure (an auth 401/403, a bad request — retrying is pointless and just burns time + budget).
+# This shared classifier is the front door both harnesses' retry loops consult.
+#
+# clawdnd_dm_failure_is_transient OUT RC — is THIS failed DM attempt a TRANSIENT/server-side blip
+# that a backed-off retry could recover from? Reads the SAME per-attempt stream-json ($out) +
+# exit code the report/extract helpers use; never touches engine state.
+#   return 0 (TRANSIENT — retry): rc=124 timeout; HTTP 408/409/425/429/500/502/503/504/520-529;
+#            or error text naming overload / rate-limit / internal-server / unavailable / gateway /
+#            connection-reset / timeout. These are server-side or load-shed and clear on retry.
+#   return 1 (REAL / fail-fast):  HTTP 400/401/403/404/422 (auth/permission/bad-request — the
+#            #357 + clawdnd_report_attempt_failure re-auth path owns 401/403); error text naming
+#            authenticate / permission / invalid-request / budget; OR no recognizable transient
+#            signal at all (a deterministic bad turn — do NOT retry 4× and mask it).
+# Auth ALWAYS wins over a co-occurring 5xx token (a 401 body must never be read as transient).
+clawdnd_dm_failure_is_transient() {
+  local out="$1" rc="${2:-0}" status body
+  # An rc=124 timeout writes no result event — it is a server/network slowness signal: TRANSIENT.
+  [ "$rc" = "124" ] && return 0
+  status="$(grep -oE '"(api_error_status|status)":[[:space:]]*[0-9]{3}' "$out" 2>/dev/null | grep -oE '[0-9]{3}' | head -n1)"
+  # FAIL-FAST classes first — a deterministic status is NEVER overridden by a transient text token.
+  case "$status" in
+    400|401|403|404|405|422) return 1 ;;
+  esac
+  case "$status" in
+    408|409|425|429|500|502|503|504|520|521|522|523|524|525|526|527|529) return 0 ;;
+  esac
+  # No decisive status — fall back to the error text. Auth/permission/bad-request markers are REAL
+  # and checked FIRST so an "authentication_error" body can never be mistaken for transient.
+  body="$(jq -rs 'map(select(.type=="result"))[-1].result // ""' "$out" 2>/dev/null)"
+  [ -n "$body" ] || body="$(grep -oE '"result":[[:space:]]*"[^"]*"' "$out" 2>/dev/null | head -n1)"
+  printf '%s' "$body" | grep -qiE 'authenticat|unauthor|permission|forbidden|invalid[_ ]?(request|api[_ ]?key)|x-api-key|credit balance|budget|max.budget' && return 1
+  printf '%s' "$body" | grep -qiE 'overloaded|rate[_ ]?limit|too many requests|internal server|service unavailable|bad gateway|gateway time|server error|temporarily|connection (reset|error|refused)|econnreset|etimedout|timed? ?out|503|529|500 ' && return 0
+  # Nothing recognizably transient -> treat as REAL (fail fast; do not mask a deterministic failure).
+  return 1
+}
+
+# clawdnd_dm_retry_backoff ATTEMPT — sleep before retry #ATTEMPT (1-indexed: the wait BEFORE the
+# 2nd, 3rd, 4th try) on a TRANSIENT failure, giving a server-side 500/overload cluster time to
+# clear instead of hammering it. Schedule: 3s, 8s, 20s (capped). Bounded + finite by design — the
+# caller also caps the attempt count, so a transient cluster can never loop forever. Override the
+# whole sleep via CLAWDND_RETRY_SLEEP_CMD (a test seam — a bash test substitutes a no-op that just
+# records the requested seconds, so the suite doesn't actually wait ~30s).
+clawdnd_dm_retry_backoff() {
+  local attempt="${1:-1}" secs
+  case "$attempt" in
+    1) secs=3 ;;
+    2) secs=8 ;;
+    *) secs=20 ;;
+  esac
+  if [ -n "${CLAWDND_RETRY_SLEEP_CMD:-}" ]; then
+    "$CLAWDND_RETRY_SLEEP_CMD" "$secs"
+  else
+    sleep "$secs"
+  fi
 }
 
 # COLD-OPEN RETRY: RESUME the minted campaign instead of re-seeding (#719). The DEFAULT cold-open

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -209,17 +209,49 @@ turn() {
   fi
 }
 
-# A turn, with ONE retry on empty output (a transient CLI/auth/rate blip shouldn't
-# silently truncate a run). Echoes the reply text (possibly empty after the retry).
+# A turn, with TRANSIENT-AWARE retry on empty output. A blip shouldn't silently truncate a run —
+# but the RIGHT number of retries depends on WHY the turn came back empty:
+#   • TRANSIENT (server-side HTTP 500/502/503/529, an "overloaded"/429 rate-limit, an rc=124
+#     timeout, an empty-result blip) — retry up to CLAWDND_DM_MAX_ATTEMPTS (default 4) total, with
+#     a short 3s/8s/20s backoff between, so a 500 CLUSTER no longer aborts a 2-3h overnight run
+#     (the gs-ember-18b beat-4 death: a 500 + a single retry that also 500'd killed the whole run).
+#   • REAL / fail-fast (a 401/403 auth error, a deterministic bad turn) — do NOT hammer it 4×: take
+#     the ONE historical retry (which also re-mints a cold-open session id — see below) and stop.
+#     An auth failure stays loudly NON-retryable via clawdnd_report_attempt_failure's re-auth hint.
+# The classifier reads the SAME (out, rc) the just-finished attempt persisted to
+# $STATE_DIR/.dm_last_result + .dm_last_rc (the turn helpers run in $(...) subshells, so a local rc
+# can't escape — the files are the subshell-safe channel). Bounded by the attempt cap → never loops
+# forever. Echoes the reply text (possibly empty after the last attempt).
 turn_retry() {
-  local r
-  # SYN-01: pre-beat log-tail mark — ONCE per beat, BEFORE attempt 1 (the retry must not
+  local r last_out last_rc transient attempt max
+  max="${CLAWDND_DM_MAX_ATTEMPTS:-4}"
+  # SYN-01: pre-beat log-tail mark — ONCE per beat, BEFORE attempt 1 (the retries must not
   # re-mark: attempt 1's logged prose still counts as this beat's), so the resolve path can
   # tell a GENUINE #357 recovery from RECYCLED pre-beat prose. File-based (subshell-safe).
   clawdnd_dm_prebeat_mark "$STATE_DIR"
   r="$(turn "$@")"
-  if [ -z "$r" ]; then
-    echo "[duo] empty turn ($1) — retrying once…" >&2
+  attempt=1
+  while [ -z "$r" ] && [ "$attempt" -lt "$max" ]; do
+    # Classify WHY attempt #$attempt came back empty, from what it just persisted.
+    last_out="$(cat "$STATE_DIR/.dm_last_result" 2>/dev/null | tail -n1)"
+    last_rc="$(cat "$STATE_DIR/.dm_last_rc" 2>/dev/null | tail -n1)"; last_rc="${last_rc:-0}"
+    transient=0
+    clawdnd_dm_failure_is_transient "$last_out" "$last_rc" && transient=1
+    # FAIL-FAST: a REAL failure (auth/deterministic) gets exactly the ONE historical retry, never 4×.
+    # We allow that single retry (attempt==1) because it ALSO re-mints a cold-open session id that an
+    # auth-failed-but-registered attempt 1 would otherwise collide on; past that, stop and don't mask
+    # a deterministic failure as flakiness. (clawdnd_report_attempt_failure already surfaced the
+    # 401/403 re-auth hint when the attempt ran.)
+    if [ "$transient" != "1" ] && [ "$attempt" -ge 2 ]; then
+      echo "[duo] empty turn ($1) — failure looks REAL (not transient); not retrying further." >&2
+      break
+    fi
+    if [ "$transient" = "1" ]; then
+      echo "[duo] empty turn ($1) — TRANSIENT failure (rc=$last_rc); retry $((attempt + 1))/$max after backoff…" >&2
+      clawdnd_dm_retry_backoff "$attempt"
+    else
+      echo "[duo] empty turn ($1) — retrying once…" >&2
+    fi
     # A cold-open ($3=1) retry must NOT reuse $2's already-registered --session-id (a failed but
     # registered attempt → "Session ID … is already in use." → empty output again). F12-11: re-mint
     # via the SHARED clawdnd_dm_remint_session_on_retry (qa/lib_beat_driver.sh) — the SAME re-mint
@@ -228,8 +260,8 @@ turn_retry() {
     # mode is `--session-id $2`, so it populates CLAWDND_DM_RETRY_SESSION with a FRESH `--session-id
     # <uuid>` we hand back to turn as the new sid. Continuing beats ($3=0) use --resume (safe to
     # repeat) — the helper leaves the array empty and we retry verbatim; lean continuing beats already
-    # mint their own fresh id inside turn(). The empty-output trigger above is preserved (it now ALSO
-    # fires on a timeout, which clawdnd_dm_final_text turns into an empty reply).
+    # mint their own fresh id inside turn(). The empty-output trigger also fires on a timeout, which
+    # clawdnd_dm_final_text turns into an empty reply.
     if [ "${3:-}" = "1" ]; then
       clawdnd_dm_remint_session_on_retry --session-id "$2"
       local _fresh="$2"
@@ -238,7 +270,8 @@ turn_retry() {
     else
       r="$(turn "$@")"
     fi
-  fi
+    attempt=$((attempt + 1))
+  done
   printf '%s' "$r"
 }
 

--- a/qa/story_readout.py
+++ b/qa/story_readout.py
@@ -262,11 +262,33 @@ def _outcome(txt: str) -> str:
     return " ".join(f"{k}={v.strip()[:18]}" for k, v in m[:7])
 
 
+# Tool calls whose INPUT can carry a companion approval move via `approval_tags`. In real play
+# the DM most often moves regard by persisting the beat's DECISION (persist_beat / record_decision
+# carrying approval_tags) — the engine returns `approval_results` and stamps attitude_value — NOT
+# by a bare adjust_attitude. coverage_from_tool_counts only counts adjust_attitude /
+# check_companion_arc / advance_companion_quest_arc, so the stamp read `approval ·` while the
+# engine state showed attitude moved. These names let analyze() detect the persist_beat path too.
+_APPROVAL_TAG_TOOLS = {"persist_beat", "record_decision"}
+# A tool_RESULT that proves the engine MOVED regard: it returned approval_results, or an attitude/
+# approval delta field. Field-shaped (a JSON key), never a bare prose mention of "approval".
+_APPROVAL_RESULT = re.compile(
+    r'"(approval_results|attitude_results)"\s*:\s*[\[{]'           # the engine's approval payload
+    r'|"(attitude|approval)(_value|_delta|_change)?"\s*:\s*-?\d'  # a numeric attitude/approval field
+    r'|"(attitude|approval)_delta"\s*:',
+    re.I,
+)
+
+
 def analyze(path: str):
     """Return (render_lines, coverage_dict)."""
     render, beat = [], 0
     calls: dict[str, int] = {}
     evolves, approval_deltas, betrayal_flag = [], 0, False
+    # Did approval MOVE via the persist_beat/record_decision path (approval_tags in an input, or
+    # an approval_results/attitude-delta in a result)? coverage_from_tool_counts can't see this —
+    # it only rolls up the adjust_attitude/check_companion_arc tool NAMES — so the stamp showed
+    # `approval ·` on a run where the engine state had attitude_value moved. Detect it here.
+    approval_signal = False
     locations, days = set(), set()
     for role, kind, name, payload, raw in _events(path):
         if kind == "text":
@@ -291,6 +313,15 @@ def analyze(path: str):
                     approval_deltas += int(payload.get("delta") or 0)
                 except Exception:
                     pass
+            # A persist_beat / record_decision carrying non-empty approval_tags MOVES regard via
+            # the decision path (the engine returns approval_results). This is the common real-play
+            # path the tool-NAME counts miss.
+            if name in _APPROVAL_TAG_TOOLS and isinstance(payload, dict):
+                tags = payload.get("approval_tags")
+                if isinstance(payload.get("decision"), dict):
+                    tags = tags or payload["decision"].get("approval_tags")
+                if tags not in (None, "", [], {}):
+                    approval_signal = True
             if name in STORY_TOOLS:
                 s = _tool_summary(name, payload)
                 render.append(f"    ⚙ {name}({s})")
@@ -303,11 +334,19 @@ def analyze(path: str):
                     or '"attitude_below"' in low
                     or re.search(r'"agenda[_a-z]*"\s*:\s*("?fir|true|\{)', low)):
                 betrayal_flag = True
+            # An engine RESULT proving regard moved (approval_results payload, or an attitude/
+            # approval delta) — the persist_beat decision path's return shape.
+            if _APPROVAL_RESULT.search(payload or ""):
+                approval_signal = True
             o = _outcome(payload)
             if o and any(s in o for s in ("roll=", "success=", "hit=", "damage=", "defeated=",
                                           "attitude=", "approval=", "evolves_to=")):
                 render.append(f"      → {o}")
     cov = coverage_from_tool_counts(calls)
+    # Fold the persist_beat/record_decision approval-move signal into the approval_moved bucket so
+    # the stamp reflects the SAME movement the engine state records. coverage_from_tool_counts is
+    # left intact (the #961 behavioral assertion reuses it for the camp/quest buckets only).
+    cov["approval_moved"] = bool(cov.get("approval_moved")) or approval_signal
     cov["beats"] = beat
     cov["quest_evolved"] = len(evolves)
     cov["approval_delta"] = approval_deltas

--- a/qa/test_run_duo_retry_robustness.sh
+++ b/qa/test_run_duo_retry_robustness.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# BEHAVIORAL TEST (no model call): proves qa/run_duo.sh's turn_retry now survives a TRANSIENT
+# server-side failure cluster instead of aborting the whole run on the first retry.
+#
+# The motivating incident (gs-ember-18b): a long overnight playtest died at beat 4 when a DM turn
+# hit HTTP 500 AND the single retry ALSO hit 500 — one transient cluster killed a 2-3h run. The fix:
+#   • clawdnd_dm_failure_is_transient (qa/lib_beat_driver.sh) classifies a failed attempt as
+#     TRANSIENT (5xx / overloaded / 429 / rc=124 timeout) vs REAL/fail-fast (401/403 auth, a
+#     deterministic bad turn);
+#   • turn_retry retries a TRANSIENT failure up to CLAWDND_DM_MAX_ATTEMPTS (default 4) with a
+#     short backoff, but a REAL failure gets only the ONE historical retry (never 4×), preserving
+#     the 401/403 re-auth fail-fast.
+#
+# It sources the REAL qa/lib_beat_driver.sh and reproduces run_duo.sh's DM branch + the NEW
+# turn_retry VERBATIM, with stub claude executables. Self-contained under mktemp; macOS + CI safe.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/qa/lib_beat_driver.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+STATE_DIR="$TMP/state"; mkdir -p "$STATE_DIR"
+T="$TMP"; RUN="r"; COMBINED="$TMP/combined.jsonl"; : > "$COMBINED"
+DM_CFG="$TMP/dm.json"; : > "$DM_CFG"
+CLAWDND_DM_MODEL="sonnet"; BUDGET="1.50"; CLAWDND_LEAN_TAIL=8
+# Test seam: a backoff that records the seconds it was asked to wait instead of actually sleeping.
+BACKOFF_LOG="$TMP/backoff.log"; : > "$BACKOFF_LOG"
+fake_sleep() { printf '%s\n' "$1" >> "$BACKOFF_LOG"; }
+export BACKOFF_LOG
+CLAWDND_RETRY_SLEEP_CMD="fake_sleep"
+# fake_sleep is a bash function — clawdnd_dm_retry_backoff calls it directly (NOT via timeout/PATH),
+# so a function is fine here.
+export -f fake_sleep 2>/dev/null || true
+
+fail=0
+chk() { if eval "$2"; then echo "PASS: $1"; else echo "FAIL: $1"; fail=1; fi; }
+
+# Stub-claude on PATH (worldos_timeout execs `claude` as an EXTERNAL command, which cannot see a
+# bash function). A COUNTER file lets one stub return 500 twice then succeed.
+BIN="$TMP/bin"; mkdir -p "$BIN"; PATH="$BIN:$PATH"
+CALLS="$TMP/calls"; echo 0 > "$CALLS"; export CALLS
+
+# ---- VERBATIM-in-intent: run_duo.sh turn() DM branch + the NEW turn_retry --------------------
+turn() {
+  local role="$1" sid="$2" first="$3" msg="$4" out resume=() extra=() rc=0 beat_timeout
+  [ "$first" = "0" ] && resume=(--resume "$sid") || resume=(--session-id "$sid")
+  clawdnd_dm_effort_arg "$first"
+  out="$T/$RUN.dm.$(date +%s%N).jsonl"
+  beat_timeout="$(clawdnd_dm_timeout "$first")"
+  worldos_timeout "$beat_timeout" \
+    claude -p "$msg" ${resume[@]+"${resume[@]}"} ${extra[@]+"${extra[@]}"} --plugin-dir "$ROOT" --mcp-config "$DM_CFG" --strict-mcp-config \
+      --model "$CLAWDND_DM_MODEL" ${CLAWDND_DM_EFFORT[@]+"${CLAWDND_DM_EFFORT[@]}"} --permission-mode bypassPermissions --max-budget-usd "$BUDGET" \
+      --output-format stream-json --verbose > "$out" 2>> "$T/$RUN.dm.err"
+  rc=$?
+  cat "$out" >> "$COMBINED"
+  if [ "$rc" -ne 0 ] && ! clawdnd_dm_result_is_error "$out"; then
+    clawdnd_report_attempt_failure "$out" "$rc"
+  fi
+  clawdnd_dm_final_text "$out" "$STATE_DIR" "$rc"
+}
+
+# turn_retry copied VERBATIM from qa/run_duo.sh (the function under test).
+turn_retry() {
+  local r last_out last_rc transient attempt max
+  max="${CLAWDND_DM_MAX_ATTEMPTS:-4}"
+  clawdnd_dm_prebeat_mark "$STATE_DIR"
+  r="$(turn "$@")"
+  attempt=1
+  while [ -z "$r" ] && [ "$attempt" -lt "$max" ]; do
+    last_out="$(cat "$STATE_DIR/.dm_last_result" 2>/dev/null | tail -n1)"
+    last_rc="$(cat "$STATE_DIR/.dm_last_rc" 2>/dev/null | tail -n1)"; last_rc="${last_rc:-0}"
+    transient=0
+    clawdnd_dm_failure_is_transient "$last_out" "$last_rc" && transient=1
+    if [ "$transient" != "1" ] && [ "$attempt" -ge 2 ]; then
+      echo "[duo] empty turn ($1) — failure looks REAL (not transient); not retrying further." >&2
+      break
+    fi
+    if [ "$transient" = "1" ]; then
+      echo "[duo] empty turn ($1) — TRANSIENT failure (rc=$last_rc); retry $((attempt + 1))/$max after backoff…" >&2
+      clawdnd_dm_retry_backoff "$attempt"
+    else
+      echo "[duo] empty turn ($1) — retrying once…" >&2
+    fi
+    if [ "${3:-}" = "1" ]; then
+      clawdnd_dm_remint_session_on_retry --session-id "$2"
+      local _fresh="$2"
+      [ "${#CLAWDND_DM_RETRY_SESSION[@]}" -ge 2 ] && _fresh="${CLAWDND_DM_RETRY_SESSION[1]}"
+      r="$(turn "$1" "$_fresh" "$3" "${@:4}")"
+    else
+      r="$(turn "$@")"
+    fi
+    attempt=$((attempt + 1))
+  done
+  printf '%s' "$r"
+}
+
+# ── Classifier unit checks (no turn loop) ──────────────────────────────────────────────────────
+mk_result() { printf '%s\n' "$1" > "$TMP/cls.jsonl"; printf '%s' "$TMP/cls.jsonl"; }
+F500="$(mk_result '{"type":"result","is_error":true,"api_error_status":500,"result":"API Error: 500 Internal server error"}')"
+chk "classify: HTTP 500 is TRANSIENT"        'clawdnd_dm_failure_is_transient "'"$F500"'" 0'
+F529="$(mk_result '{"type":"result","is_error":true,"api_error_status":529,"result":"Overloaded"}')"
+chk "classify: HTTP 529 overloaded is TRANSIENT" 'clawdnd_dm_failure_is_transient "'"$F529"'" 0'
+F429="$(mk_result '{"type":"result","is_error":true,"api_error_status":429,"result":"rate_limit_error"}')"
+chk "classify: HTTP 429 rate-limit is TRANSIENT" 'clawdnd_dm_failure_is_transient "'"$F429"'" 0'
+F401="$(mk_result '{"type":"result","is_error":true,"api_error_status":401,"result":"API Error: 401 authentication_error"}')"
+chk "classify: HTTP 401 auth is REAL (fail-fast)"  '! clawdnd_dm_failure_is_transient "'"$F401"'" 0'
+F403="$(mk_result '{"type":"result","is_error":true,"api_error_status":403,"result":"permission_error"}')"
+chk "classify: HTTP 403 is REAL (fail-fast)"       '! clawdnd_dm_failure_is_transient "'"$F403"'" 0'
+FOVR="$(mk_result '{"type":"result","is_error":true,"result":"Overloaded: the service is temporarily unavailable, please retry"}')"
+chk "classify: text-only 'overloaded' is TRANSIENT" 'clawdnd_dm_failure_is_transient "'"$FOVR"'" 0'
+chk "classify: rc=124 timeout is TRANSIENT"        'clawdnd_dm_failure_is_transient "/nonexistent" 124'
+FOK="$(mk_result '{"type":"result","is_error":false,"result":"a fine beat"}')"
+chk "classify: a clean result is NOT transient"    '! clawdnd_dm_failure_is_transient "'"$FOK"'" 0'
+
+# ── Backoff schedule ───────────────────────────────────────────────────────────────────────────
+: > "$BACKOFF_LOG"
+clawdnd_dm_retry_backoff 1; clawdnd_dm_retry_backoff 2; clawdnd_dm_retry_backoff 3
+chk "backoff schedule is 3s, 8s, 20s" '[ "$(tr "\n" " " < "$BACKOFF_LOG")" = "3 8 20 " ]'
+
+# ── (A) 500 twice then SUCCEED → the beat SUCCEEDS over 3 attempts (the gs-ember-18b fix) ──────
+cat > "$BIN/claude" <<STUB
+#!/usr/bin/env bash
+n=\$(cat "$CALLS"); n=\$((n + 1)); echo "\$n" > "$CALLS"
+if [ "\$n" -le 2 ]; then
+  printf '%s\n' '{"type":"result","is_error":true,"api_error_status":500,"result":"API Error: 500 Internal server error"}'
+  exit 0
+fi
+printf '%s\n' '{"type":"result","subtype":"success","is_error":false,"result":"The torchlight gutters as you step into the vault."}'
+exit 0
+STUB
+chmod +x "$BIN/claude"
+echo 0 > "$CALLS"; : > "$BACKOFF_LOG"
+reply="$(turn_retry dm "DSID" 0 'Resolve the move.' 2>"$TMP/errA")"
+chk "500x2-then-OK → beat SUCCEEDS (non-empty reply)" '[ -n "$reply" ]'
+chk "500x2-then-OK → reply is the 3rd attempt's prose" 'printf "%s" "$reply" | grep -q "torchlight gutters"'
+chk "500x2-then-OK → claude called exactly 3 times" '[ "$(cat "$CALLS")" = "3" ]'
+chk "500x2-then-OK → backed off twice (3s, 8s)" '[ "$(tr "\n" " " < "$BACKOFF_LOG")" = "3 8 " ]'
+
+# ── (B) all-500 cluster → 4 attempts total, then give up (does NOT loop forever) ──────────────
+cat > "$BIN/claude" <<STUB
+#!/usr/bin/env bash
+n=\$(cat "$CALLS"); n=\$((n + 1)); echo "\$n" > "$CALLS"
+printf '%s\n' '{"type":"result","is_error":true,"api_error_status":500,"result":"API Error: 500 Internal server error"}'
+exit 0
+STUB
+chmod +x "$BIN/claude"
+echo 0 > "$CALLS"; : > "$BACKOFF_LOG"
+replyB="$(turn_retry dm "DSID" 0 'Resolve.' 2>"$TMP/errB")"
+chk "all-500 → reply empty (failed beat, surfaced honestly)" '[ -z "$replyB" ]'
+chk "all-500 → exactly 4 attempts (the cap, not infinite)"   '[ "$(cat "$CALLS")" = "4" ]'
+
+# ── (C) 401 auth → FAIL-FAST: only the ONE historical retry (NOT 4×), re-auth hint preserved ──
+cat > "$BIN/claude" <<STUB
+#!/usr/bin/env bash
+n=\$(cat "$CALLS"); n=\$((n + 1)); echo "\$n" > "$CALLS"
+printf '%s\n' '{"type":"result","is_error":true,"api_error_status":401,"result":"API Error: 401 authentication_error"}'
+exit 0
+STUB
+chmod +x "$BIN/claude"
+echo 0 > "$CALLS"; : > "$BACKOFF_LOG"
+replyC="$(turn_retry dm "DSID" 0 'Resolve.' 2>"$TMP/errC")"
+chk "401 → reply empty (failed beat)"                  '[ -z "$replyC" ]'
+chk "401 → fail-fast: only 2 attempts (1 historical retry, NOT 4)" '[ "$(cat "$CALLS")" = "2" ]'
+chk "401 → NO backoff sleeps (auth is not transient)"  '[ ! -s "$BACKOFF_LOG" ]'
+chk "401 → re-auth hint preserved (NOT retryable)"     'grep -q "NOT retryable" "$TMP/errC"'
+
+# ── (D) 500 then 401 → switches to fail-fast once the failure stops being transient ───────────
+cat > "$BIN/claude" <<STUB
+#!/usr/bin/env bash
+n=\$(cat "$CALLS"); n=\$((n + 1)); echo "\$n" > "$CALLS"
+if [ "\$n" -eq 1 ]; then
+  printf '%s\n' '{"type":"result","is_error":true,"api_error_status":500,"result":"API Error: 500 Internal server error"}'
+else
+  printf '%s\n' '{"type":"result","is_error":true,"api_error_status":401,"result":"API Error: 401 authentication_error"}'
+fi
+exit 0
+STUB
+chmod +x "$BIN/claude"
+echo 0 > "$CALLS"; : > "$BACKOFF_LOG"
+replyD="$(turn_retry dm "DSID" 0 'Resolve.' 2>"$TMP/errD")"
+chk "500-then-401 → reply empty (failed beat)" '[ -z "$replyD" ]'
+# attempt1=500(transient,retry), attempt2=401(real). attempt2's empty is classified REAL and
+# attempt>=2 -> break. So 3 attempts max? No: attempt1 empty(transient)->retry=attempt2;
+# attempt2 empty, classified REAL, attempt(now 2)>=2 -> break. => 2 calls total.
+chk "500-then-401 → stops at 2 (transient retry, then REAL fail-fast)" '[ "$(cat "$CALLS")" = "2" ]'
+
+[ "$fail" = 0 ] && echo "ALL ASSERTIONS PASSED" || echo "SOME ASSERTIONS FAILED"
+exit "$fail"

--- a/qa/test_story_readout_approval.py
+++ b/qa/test_story_readout_approval.py
@@ -1,0 +1,154 @@
+"""Self-tests for story_readout.analyze()'s APPROVAL-MOVED stamp detection.
+
+The bug: the COVERAGE stamp marked `approval-moved` only from the adjust_attitude /
+check_companion_arc / advance_companion_quest_arc tool-NAME counts (via
+coverage_from_tool_counts). But in real play the DM most often moves a companion's regard by
+PERSISTING the beat's decision — persist_beat / record_decision carrying `approval_tags`, with the
+engine returning `approval_results` and stamping attitude_value. So the stamp read `approval ·`
+while the engine state showed attitude moved (attitude_value=10). analyze() now ALSO detects
+approval movement from (a) a persist_beat/record_decision INPUT with non-empty approval_tags, or
+(b) a tool_RESULT carrying approval_results / an attitude-or-approval delta — without touching
+coverage_from_tool_counts (the #961 behavioral assertion reuses that helper for camp/quest only).
+
+Stdlib + pytest only; self-contained. Run single-process:
+    uv run --directory servers/engine python -m pytest qa/test_story_readout_approval.py -p no:xdist
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import story_readout as sr  # noqa: E402
+
+
+# ── transcript builders (claude -p stream-json shape that story_readout._events parses) ──────────
+
+def _assistant_tool_use(name: str, inp: dict) -> str:
+    return json.dumps({
+        "type": "assistant",
+        "message": {"role": "assistant",
+                    "content": [{"type": "tool_use", "name": name, "input": inp}]},
+    })
+
+
+def _tool_result(text: str) -> str:
+    return json.dumps({
+        "type": "user",
+        "message": {"role": "user",
+                    "content": [{"type": "tool_result", "content": text}]},
+    })
+
+
+def _assistant_text(text: str) -> str:
+    return json.dumps({
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+    })
+
+
+def _write(tmp_path: Path, lines) -> str:
+    p = tmp_path / "dm.jsonl"
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return str(p)
+
+
+# ── the load-bearing case: persist_beat carrying approval_tags stamps approval ✓ ─────────────────
+
+def test_persist_beat_approval_tags_stamps_approval(tmp_path):
+    """A persist_beat carrying a decision with non-empty approval_tags (the engine returns
+    approval_results) — no adjust_attitude / check_companion_arc anywhere — must stamp approval ✓.
+    This is the exact real-play shape the old tool-name-count stamp missed (showed `approval ·`)."""
+    path = _write(tmp_path, [
+        _assistant_text("You meet Karlach at the forge; she sizes you up."),
+        _assistant_tool_use("persist_beat", {
+            "summary": "Player defended Karlach's honor",
+            "decision": {"choice": "stood up for her", "approval_tags": ["karlach_approves"]},
+        }),
+        _tool_result(json.dumps({"ok": True, "approval_results": [
+            {"companion": "Karlach", "attitude_value": 10, "delta": 10}]})),
+    ])
+    _render, cov = sr.analyze(path)
+    assert cov["approval_moved"] is True
+    line = sr.stamp(cov)
+    assert "approval-moved ✓" in line
+
+
+def test_record_decision_approval_tags_stamps_approval(tmp_path):
+    """record_decision carrying approval_tags at the INPUT top level (not nested) also fires."""
+    path = _write(tmp_path, [
+        _assistant_tool_use("record_decision", {
+            "choice": "spared the cultist", "approval_tags": ["shadowheart_disapproves"]}),
+    ])
+    _render, cov = sr.analyze(path)
+    assert cov["approval_moved"] is True
+    assert "approval-moved ✓" in sr.stamp(cov)
+
+
+def test_approval_results_in_tool_result_stamps_approval(tmp_path):
+    """Even if the input is opaque, an engine RESULT carrying approval_results proves the move."""
+    path = _write(tmp_path, [
+        _assistant_tool_use("persist_beat", {"summary": "a tense exchange"}),
+        _tool_result(json.dumps({"approval_results": [{"companion": "Lae'zel", "attitude_value": -5}]})),
+    ])
+    _render, cov = sr.analyze(path)
+    assert cov["approval_moved"] is True
+
+
+def test_attitude_delta_in_result_stamps_approval(tmp_path):
+    """A bare attitude_delta field in a result (the older shape) also counts."""
+    path = _write(tmp_path, [
+        _assistant_tool_use("adjust_attitude", {"target": "Gale", "delta": 5}),
+        _tool_result(json.dumps({"attitude_delta": 5, "attitude_value": 5})),
+    ])
+    _render, cov = sr.analyze(path)
+    assert cov["approval_moved"] is True
+
+
+# ── negative cases: no false positives ───────────────────────────────────────────────────────────
+
+def test_no_approval_signal_stamps_dot(tmp_path):
+    """A run with NO approval movement (empty approval_tags, no approval_results, no attitude tool)
+    keeps approval ·. The fix must not flip the stamp on unrelated persist_beat calls."""
+    path = _write(tmp_path, [
+        _assistant_text("The road stretches on under a grey sky."),
+        _assistant_tool_use("persist_beat", {"summary": "travel beat", "decision": {"choice": "kept walking"}}),
+        _tool_result(json.dumps({"ok": True, "day": 3})),
+    ])
+    _render, cov = sr.analyze(path)
+    assert cov["approval_moved"] is False
+    assert "approval-moved ·" in sr.stamp(cov)
+
+
+def test_empty_approval_tags_does_not_fire(tmp_path):
+    """An explicit empty approval_tags list is NOT a move."""
+    path = _write(tmp_path, [
+        _assistant_tool_use("persist_beat", {"decision": {"choice": "x", "approval_tags": []}}),
+        _tool_result(json.dumps({"ok": True})),
+    ])
+    _render, cov = sr.analyze(path)
+    assert cov["approval_moved"] is False
+
+
+def test_prose_mention_of_approval_does_not_fire(tmp_path):
+    """A result whose TEXT merely mentions 'approval' (no field) must NOT false-positive — the
+    detector is field-shaped (a JSON key), never a bare word."""
+    path = _write(tmp_path, [
+        _assistant_tool_use("persist_beat", {"summary": "a chat about approval ratings"}),
+        _tool_result("The crowd murmured their approval as the speech ended."),
+    ])
+    _render, cov = sr.analyze(path)
+    assert cov["approval_moved"] is False
+
+
+# ── the legacy path is preserved: adjust_attitude tool name still stamps ✓ ───────────────────────
+
+def test_adjust_attitude_tool_name_still_stamps(tmp_path):
+    """The pre-existing tool-NAME signal (adjust_attitude) must still fire — no regression."""
+    path = _write(tmp_path, [
+        _assistant_tool_use("adjust_attitude", {"target": "Astarion", "delta": 8}),
+    ])
+    _render, cov = sr.analyze(path)
+    assert cov["approval_moved"] is True

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -10972,6 +10972,46 @@ def _compute_beat_obligations(c: Campaign) -> list[dict]:
                 ),
             })
 
+    # 2b. camp_scene_skipped — the party RESTED today (a companion's last_long_rest_day == today)
+    #     but NO camp scene was recorded for them this day. A live run showed the DM call long_rest
+    #     (3x) yet SKIP camp_scene — companions recover HP/slots but never get their social beat, so
+    #     regard + arcs stay frozen despite the rest. This catches the "rested-but-no-camp" gap that
+    #     camp_overdue (which fires on a STALE rest) can't see: here the rest is FRESH but the camp
+    #     beat is missing. If a camp record DOES exist for a companion today, they are NOT flagged.
+    if party_companions:
+        # Companion ids that already got a camp beat recorded TODAY (defensive: tolerate a missing
+        # camp_beats / records / malformed record without raising).
+        camp_state = getattr(c, "camp_beats", None)
+        records = getattr(camp_state, "records", None) or [] if camp_state is not None else []
+        camped_today: set = set()
+        for rec in records:
+            rec_day = getattr(rec, "day", None)
+            if rec_day != day:
+                continue
+            for cid in getattr(rec, "companion_ids", None) or []:
+                camped_today.add(str(cid))
+        rested_no_camp = []
+        for comp in party_companions:
+            rest_day = getattr(comp, "last_long_rest_day", -1)
+            rest_day = rest_day if isinstance(rest_day, int) else -1
+            # Rested TODAY (the party made camp today) but this companion has no camp record today.
+            if rest_day == day and str(getattr(comp, "id", "")) not in camped_today:
+                rested_no_camp.append(comp)
+        if rested_no_camp:
+            names = [getattr(comp, "name", None) or "the companion" for comp in rested_no_camp]
+            who = names[0] if len(names) == 1 else ", ".join(names[:-1]) + f" and {names[-1]}"
+            obligations.append({
+                "kind": "camp_scene_skipped",
+                "severity": "med",
+                "character_ids": [getattr(comp, "id", None) for comp in rested_no_camp],
+                "names": names,
+                "detail": (
+                    f"The party rested but skipped camp — call camp_scene now to give {who} a real "
+                    f"beat (a worry, a memory, an arc moment) and move their regard. A long_rest that "
+                    f"refreshes HP/slots but lands no camp scene leaves the relationship system inert."
+                ),
+            })
+
     # 3. quest_resolvable / quest_stalled — active quests the engine can SEE are ripe or
     #    stuck. (Both read engine-mutated state, never Decision prose.)
     quests = getattr(c, "quests", None) or {}

--- a/servers/engine/tests/test_beat_obligations.py
+++ b/servers/engine/tests/test_beat_obligations.py
@@ -18,6 +18,7 @@ import store
 from models import (
     ArcGate,
     Campaign,
+    CampBeatRecord,
     Character,
     CompanionArc,
     CompanionDossier,
@@ -107,6 +108,77 @@ def test_camp_overdue_when_last_rest_is_three_days_old():
     comp = _companion(likes=["mercy"], attitude=10, last_long_rest_day=2)
     c = _campaign_with(comp, day=5)  # 5 - 2 == 3 days since rest
     assert "camp_overdue" in _kinds(server._compute_beat_obligations(c))
+
+
+# --- camp_scene_skipped: rested TODAY but no camp scene landed --------------
+
+
+def test_camp_scene_skipped_fires_when_party_rested_today_with_no_camp_record():
+    """The live-run bug: the DM long_rest'd (companion's last_long_rest_day == today) but never
+    called camp_scene — so there's NO CampBeatRecord for the companion today. The obligation fires,
+    names the companion, and cues camp_scene."""
+    comp = _companion(name="Karlach", attitude=10, last_long_rest_day=5)
+    c = _campaign_with(comp, day=5)  # rested TODAY (day 5), no camp record at all
+    obligations = server._compute_beat_obligations(c)
+    assert "camp_scene_skipped" in _kinds(obligations)
+    skipped = next(o for o in obligations if o["kind"] == "camp_scene_skipped")
+    assert skipped["names"] == ["Karlach"]
+    assert comp.id in skipped["character_ids"]
+    assert "camp_scene" in skipped["detail"]
+    # It is NOT also camp_overdue (the rest is FRESH today, not 3+ days stale).
+    assert "camp_overdue" not in _kinds(obligations)
+
+
+def test_camp_scene_skipped_does_not_fire_when_a_camp_record_exists_today():
+    """A camp record FOR THIS companion ON THIS DAY means camp happened — do not fire."""
+    comp = _companion(name="Karlach", attitude=10, last_long_rest_day=5)
+    c = _campaign_with(comp, day=5)
+    c.camp_beats.records.append(
+        CampBeatRecord(id="banter-1", day=5, companion_ids=[comp.id], kind="solo")
+    )
+    assert "camp_scene_skipped" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_camp_scene_skipped_does_not_fire_when_rest_was_a_prior_day():
+    """If the companion rested YESTERDAY (last_long_rest_day != today) the 'rested-today-but-no-
+    camp' gap doesn't apply — camp_overdue owns the stale-rest case, not this obligation."""
+    comp = _companion(name="Karlach", attitude=10, last_long_rest_day=4)
+    c = _campaign_with(comp, day=5)  # rested day 4, today is 5
+    assert "camp_scene_skipped" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_camp_scene_skipped_fires_only_for_the_companion_without_a_record_today():
+    """Two companions rested today; one got a camp beat, the other didn't — only the one WITHOUT a
+    record today is flagged."""
+    camped = _companion(name="Shadowheart", attitude=10, last_long_rest_day=5)
+    skipped_comp = _companion(name="Lae'zel", attitude=10, last_long_rest_day=5)
+    c = _campaign_with(camped, skipped_comp, day=5)
+    c.camp_beats.records.append(
+        CampBeatRecord(id="banter-1", day=5, companion_ids=[camped.id], kind="solo")
+    )
+    obligations = server._compute_beat_obligations(c)
+    assert "camp_scene_skipped" in _kinds(obligations)
+    skipped = next(o for o in obligations if o["kind"] == "camp_scene_skipped")
+    assert skipped["names"] == ["Lae'zel"]
+    assert camped.id not in skipped["character_ids"]
+    assert skipped_comp.id in skipped["character_ids"]
+
+
+def test_camp_scene_skipped_silent_for_companionless_party():
+    pc = Character(name="Hero", kind="player", last_long_rest_day=5)
+    c = _campaign_with(pc, day=5)
+    assert "camp_scene_skipped" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_camp_scene_skipped_record_from_a_prior_day_does_not_suppress():
+    """A camp record exists, but from a PRIOR day — today's rest still has no camp scene, so it
+    fires (the record must match TODAY's day to suppress)."""
+    comp = _companion(name="Karlach", attitude=10, last_long_rest_day=5)
+    c = _campaign_with(comp, day=5)
+    c.camp_beats.records.append(
+        CampBeatRecord(id="banter-old", day=2, companion_ids=[comp.id], kind="solo")
+    )
+    assert "camp_scene_skipped" in _kinds(server._compute_beat_obligations(c))
 
 
 def test_quest_stalled_surfaces():


### PR DESCRIPTION
Three additive refinements a live validation surfaced: (1) **run_duo retry robustness** — transient HTTP 500s now retry up to 4× with backoff (a 500 killed an overnight run at beat 4); real/auth failures still fail fast. (2) **readout approval stamp** counts the persist_beat approval_tags path so it agrees with the state-based scorecard. (3) **camp_scene_skipped** obligation fires when the DM long_rests but skips the camp conversation. Full suite 2868 + fast_gate 222 + 97 qa tests; CI-wired; no regressions.