### PR TITLE
feat(planning): multi-level level-up roadmap (path-to-20 view)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -6401,6 +6401,59 @@ def build_options(campaign_id: str, character_id: str) -> dict:
 
 
 @mcp.tool()
+def level_roadmap(campaign_id: str, character_id: str, through_level: int = 20) -> dict:
+    """A READ-ONLY projection of what a character GAINS at each level from its current
+    level + 1 through ``through_level`` (≤20) — the "see your path to 20" planning view
+    (the build-optimizer persona's last gap: "no upcoming-features view / nothing to
+    theorycraft against"; build_options only shows the SINGLE next level).
+
+    Projects the PC's PRIMARY class (the one with the most levels — the engine cannot know
+    a player's FUTURE multiclass picks) forward along the real SRD tables: class features
+    gained (srd_tables.features_at), subclass features newly owed if a subclass is chosen
+    (subclass_features_through delta), whether the level grants an ASI/feat
+    (is_asi_level), the proficiency bonus (proficiency_bonus of the TOTAL level), notable
+    class-resource changes (class_resources_through delta), and — for casters — a
+    spell-slot change note. Returns ``{character_id, character_name, primary_class,
+    subclass, from:{total_level, class_level}, through_level, multiclass, roadmap:[…]}``.
+
+    Pure projection — NEVER writes campaign state, NEVER fabricates (an entry exists only
+    when an SRD table carries it). GUARDED: an empty ``roadmap`` when the PC is already at
+    ``through_level``, has no class (a stat-block NPC/monster), or the primary class is
+    unknown to the tables. Mirrors the read-only feats()/feature_catalog pattern."""
+    c = _require(campaign_id)
+    ch = _char(c, character_id)
+    base = {
+        "character_id": ch.id,
+        "character_name": ch.name,
+        "through_level": min(20, int(through_level)),
+    }
+    # Guard: a stat-block entity with no class track (monster/NPC) has nothing to project.
+    if not ch.classes:
+        return {**base, "primary_class": None, "subclass": None, "multiclass": False,
+                "from": {"total_level": ch.total_level, "class_level": 0}, "roadmap": []}
+    # The continuation track is the PRIMARY class — most levels, ties broken by sheet order
+    # (the player keeps leveling their main class; we don't invent a future multiclass dip).
+    primary = max(ch.classes, key=lambda cl: cl.level)
+    cha_mod = ch.ability_modifier(Ability.CHA)
+    roadmap = srd_tables.level_roadmap(
+        primary.name,
+        primary.level,
+        subclass=primary.subclass,
+        current_total_level=ch.total_level,
+        through_level=int(through_level),
+        cha_mod=cha_mod,
+    )
+    return {
+        **base,
+        "primary_class": primary.name.lower(),
+        "subclass": primary.subclass,
+        "multiclass": len(ch.classes) > 1,
+        "from": {"total_level": ch.total_level, "class_level": primary.level},
+        "roadmap": roadmap,
+    }
+
+
+@mcp.tool()
 def spell_save_dc(campaign_id: str, character_id: str) -> dict:
     """Return a caster's spell save DC (8 + proficiency + casting modifier) and
     spell attack bonus (proficiency + casting modifier)."""

--- a/servers/engine/srd_tables.py
+++ b/servers/engine/srd_tables.py
@@ -563,3 +563,150 @@ def class_resources_through(class_name: str, level: int, cha_mod: int = 0) -> di
             recharge = "short"
         out[res_id] = {"max": mx, "recharge": recharge}
     return out
+
+
+# ── Level-up roadmap — read-only multi-level projection (#882 build-optimizer) ───
+#
+# The LevelUpModal/build_options surface shows only the SINGLE next level. The
+# build-optimizer persona's last planning gap was "no upcoming-features view /
+# nothing to theorycraft against". `level_roadmap` is a PURE projection of the SRD
+# progression tables (features_through / subclass_features_through / is_asi_level /
+# proficiency_bonus / class_resources_through) from CURRENT class level + 1 through
+# `through_level`. It NEVER writes campaign state and NEVER fabricates: every entry
+# comes straight from a curated SRD table; a class/subclass the tables don't know
+# simply contributes nothing at that level.
+#
+# Honest scope: the projection continues a SINGLE class track (the one passed in —
+# the tool feeds the PC's PRIMARY class), because the engine cannot know a player's
+# FUTURE multiclass choices. The class-level the projection advances is `class_name`'s
+# own level, so a Fighter 5 (total 5) sees its Fighter-6/7/… features; the prof bonus
+# tracks TOTAL character level so a multiclassed PC's prof column stays correct.
+
+
+def _resources_changed_note(class_name: str, from_level: int, to_level: int, cha_mod: int) -> str:
+    """A terse human note for the class-resource pools whose MAX changes when this class
+    goes from `from_level` to `to_level` (e.g. 'Rage 3→4'). Empty when nothing changes —
+    so the roadmap row simply omits the note. Pure: derived from class_resources_through."""
+    before = class_resources_through(class_name, from_level, cha_mod)
+    after = class_resources_through(class_name, to_level, cha_mod)
+    parts: list[str] = []
+    for rid in sorted(set(before) | set(after)):
+        old = before.get(rid, {}).get("max", 0)
+        new = after.get(rid, {}).get("max", 0)
+        if old != new:
+            label = rid.replace("_", " ").title()
+            parts.append(f"{label} {old}→{new}" if old else f"{label} {new}")
+    return ", ".join(parts)
+
+
+def level_roadmap(
+    class_name: str,
+    current_class_level: int,
+    subclass: str | None = None,
+    current_total_level: int | None = None,
+    through_level: int = 20,
+    cha_mod: int = 0,
+) -> list[dict]:
+    """Project a SINGLE class's per-level progression from ``current_class_level + 1``
+    through ``through_level`` (capped at 20), as a list of
+    ``{level, class_level, features:[{name, desc?}], is_asi_or_feat, prof_bonus,
+    resources_note?, spell_slots_note?, subclass_features:[…]}``.
+
+    ``level`` is the projected TOTAL character level (so the prof column matches a
+    multiclassed PC); ``class_level`` is this class's own level at that step. Each
+    upcoming level lists the class features GAINED at that class level
+    (``features_at``), the subclass features newly owed (``subclass_features_through``
+    delta), whether it's an ASI/feat level (``is_asi_level``), the proficiency bonus
+    (``proficiency_bonus`` of the total level), a class-resource change note
+    (``class_resources_through`` delta), and — for casters — a spell-slot change note.
+
+    GUARDED + HONEST: returns ``[]`` if the class is unknown, the PC is already at
+    ``through_level`` (nothing upcoming), or ``through_level <= current``. Never writes,
+    never fabricates — a level whose tables carry nothing yields an empty ``features``
+    list but still reports the prof bonus / ASI flag (those ARE known from the tables)."""
+    cls = class_name.lower()
+    try:
+        class_data(cls)
+    except ValueError:
+        return []
+    cap = min(20, int(through_level))
+    cur_class = max(0, int(current_class_level))
+    # The projection advances this class's own level; the TOTAL level rises in lockstep
+    # with each class level gained (other classes are held fixed — we don't invent
+    # future multiclass picks). Offset = total - this-class-level at the start.
+    total_now = int(current_total_level) if current_total_level is not None else cur_class
+    offset = total_now - cur_class
+    roadmap: list[dict] = []
+    for clvl in range(cur_class + 1, cap + 1):
+        total_level = clvl + offset
+        if total_level > 20:
+            break
+        features = [
+            {"name": f["name"], **({"desc": f["desc"]} if f.get("desc") else {})}
+            for f in features_at(cls, clvl)
+        ]
+        # Subclass features NEWLY owed at this class level (the through-delta), so a
+        # roadmap row shows the archetype feature that lands here — not the whole list.
+        prev_sub = {
+            str(f.get("name", "")).lower()
+            for f in subclass_features_through(cls, subclass, clvl - 1)
+        }
+        sub_features = [
+            {"name": f["name"], **({"desc": f["desc"]} if f.get("desc") else {})}
+            for f in subclass_features_through(cls, subclass, clvl)
+            if str(f.get("name", "")).lower() not in prev_sub
+        ]
+        entry: dict = {
+            "level": total_level,
+            "class_level": clvl,
+            "class_name": cls,
+            "features": features,
+            "is_asi_or_feat": is_asi_level(cls, clvl),
+            "prof_bonus": proficiency_bonus(total_level),
+        }
+        if sub_features:
+            entry["subclass_features"] = sub_features
+        note = _resources_changed_note(cls, clvl - 1, clvl, cha_mod)
+        if note:
+            entry["resources_note"] = note
+        slot_note = _slot_change_note(cls, clvl - 1, clvl, offset)
+        if slot_note:
+            entry["spell_slots_note"] = slot_note
+        roadmap.append(entry)
+    return roadmap
+
+
+def _slot_change_note(class_name: str, from_clvl: int, to_clvl: int, offset: int) -> str:
+    """A terse spell-slot change note for a single caster class going from `from_clvl`
+    to `to_clvl` (e.g. '+1 L3 slot' / 'L1×2→×3'). Empty for non-casters or no change.
+    Cheap projection: full/half/third casters read the multiclass slot table at the
+    projected total level; a Warlock reads its pact-slot table by warlock level. Pure."""
+    cls = class_name.lower()
+    try:
+        ct = caster_type(cls)
+    except ValueError:
+        return ""
+    if ct == "pact":
+        before = warlock_pact_slots(from_clvl) or {}
+        after = warlock_pact_slots(to_clvl) or {}
+        b_n, b_l = before.get("slots", 0), before.get("level", 0)
+        a_n, a_l = after.get("slots", 0), after.get("level", 0)
+        if (b_n, b_l) == (a_n, a_l):
+            return ""
+        if b_l != a_l and a_l:
+            return f"Pact slots now L{a_l}×{a_n}"
+        return f"Pact slots ×{b_n}→×{a_n}"
+    if ct not in ("full", "half", "third"):
+        return ""
+    before = multiclass_slots([(cls, from_clvl)]) if from_clvl >= 1 else {}
+    after = multiclass_slots([(cls, to_clvl)])
+    parts: list[str] = []
+    for lvl in sorted(set(before) | set(after)):
+        old = before.get(lvl, 0)
+        new = after.get(lvl, 0)
+        if old != new:
+            if old == 0:
+                parts.append(f"new L{lvl} slots (×{new})")
+            else:
+                parts.append(f"L{lvl} ×{old}→×{new}")
+    return ", ".join(parts)

--- a/servers/engine/tests/test_level_roadmap.py
+++ b/servers/engine/tests/test_level_roadmap.py
@@ -1,0 +1,189 @@
+"""Engine tests for the read-only multi-level LEVEL-UP ROADMAP (#882 build-optimizer).
+
+`server.level_roadmap` is a PURE projection of the SRD progression tables from the PC's
+current level + 1 through `through_level`. These assert it returns the right upcoming
+levels (with the Fighter ASI levels flagged + features present), is byte-for-byte
+non-mutating, and is GUARDED — a PC at the cap and a non-class entity both return [].
+"""
+
+import pytest
+
+import server
+import srd_tables
+import store
+
+
+@pytest.fixture(autouse=True)
+def isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    yield
+
+
+def _campaign_snapshot(campaign_id: str) -> dict:
+    return store.load_campaign(campaign_id).model_dump(mode="json")
+
+
+# --- pure helper (srd_tables.level_roadmap) ---------------------------------------
+
+
+def test_pure_helper_projects_fighter_5_through_8_with_asi_flags():
+    roadmap = srd_tables.level_roadmap("fighter", 5, through_level=8)
+    levels = [row["level"] for row in roadmap]
+    assert levels == [6, 7, 8]  # current 5 -> next is 6, capped at 8
+    by_level = {row["level"]: row for row in roadmap}
+    # Fighter bonus-ASI levels: 6 and 8 are ASI/feat; 7 is not (SRD).
+    assert by_level[6]["is_asi_or_feat"] is True
+    assert by_level[8]["is_asi_or_feat"] is True
+    assert by_level[7]["is_asi_or_feat"] is False
+    # Proficiency bonus tracks total level (still +3 at 6-8).
+    assert all(row["prof_bonus"] == 3 for row in roadmap)
+    # Every row carries its own class level and the projected class name.
+    assert by_level[6]["class_level"] == 6
+    assert by_level[6]["class_name"] == "fighter"
+
+
+def test_pure_helper_features_match_srd_features_at():
+    # Each row's features come STRAIGHT from features_at — never fabricated.
+    roadmap = srd_tables.level_roadmap("wizard", 4, through_level=6)
+    for row in roadmap:
+        expected = {f["name"] for f in srd_tables.features_at("wizard", row["class_level"])}
+        assert {f["name"] for f in row["features"]} == expected
+
+
+def test_pure_helper_caster_spell_slot_note_present():
+    # A wizard leveling 4 -> 5 opens L3 slots; the projection surfaces that note.
+    roadmap = srd_tables.level_roadmap("wizard", 4, through_level=5)
+    row = roadmap[0]
+    assert row["level"] == 5
+    assert "spell_slots_note" in row and "L3" in row["spell_slots_note"]
+
+
+def test_pure_helper_unknown_class_returns_empty():
+    assert srd_tables.level_roadmap("definitely-not-a-class", 3) == []
+
+
+def test_pure_helper_at_cap_returns_empty():
+    assert srd_tables.level_roadmap("fighter", 20, through_level=20) == []
+    assert srd_tables.level_roadmap("fighter", 5, through_level=5) == []
+
+
+def test_pure_helper_subclass_features_only_when_chosen():
+    # Without a subclass, no subclass_features key appears on any row.
+    plain = srd_tables.level_roadmap("cleric", 2, through_level=8)
+    assert all("subclass_features" not in row for row in plain)
+    # With a chosen subclass, the archetype features land on their SRD levels.
+    chosen = srd_tables.level_roadmap("cleric", 2, subclass="Life Domain", through_level=8)
+    assert any("subclass_features" in row for row in chosen)
+
+
+# --- @mcp.tool() wrapper (server.level_roadmap) -----------------------------------
+
+
+def test_level_roadmap_fighter_5_flags_asi_levels_and_lists_features_without_mutating():
+    cid = server.create_campaign("Roadmap fighter")["id"]
+    fid = server.create_character(
+        cid,
+        "Ren",
+        kind="player",
+        class_name="Fighter",
+        level=5,
+        apply_srd_defaults=True,
+        abilities={"strength": 16, "dexterity": 14, "constitution": 12},
+    )["id"]
+    before = _campaign_snapshot(cid)
+
+    out = server.level_roadmap(cid, fid, through_level=20)
+
+    assert out["character_id"] == fid
+    assert out["primary_class"] == "fighter"
+    assert out["multiclass"] is False
+    assert out["from"] == {"total_level": 5, "class_level": 5}
+    roadmap = out["roadmap"]
+    # Projects 6..20 (15 upcoming levels).
+    assert [row["level"] for row in roadmap] == list(range(6, 21))
+    by_level = {row["level"]: row for row in roadmap}
+    # Fighter ASI/feat levels include 6, 8, 12, 14, 16, 19 (the bonus martial ASIs).
+    for asi_lvl in (6, 8, 12, 14, 16, 19):
+        assert by_level[asi_lvl]["is_asi_or_feat"] is True, asi_lvl
+    # And a non-ASI level is NOT flagged.
+    assert by_level[7]["is_asi_or_feat"] is False
+    # Proficiency bonus rises with total level: +3 at 6-8, +4 at 9-12, … +6 at 17-20.
+    assert by_level[8]["prof_bonus"] == 3
+    assert by_level[9]["prof_bonus"] == 4
+    assert by_level[17]["prof_bonus"] == 6
+    # A real class feature is projected (Extra Attack (2) lands at Fighter 11 in SRD).
+    assert any(
+        f["name"]
+        for row in roadmap
+        for f in row["features"]
+    )
+    # Read-only: the campaign snapshot is byte-identical.
+    assert _campaign_snapshot(cid) == before
+
+
+def test_level_roadmap_at_max_level_returns_empty_guarded():
+    cid = server.create_campaign("Roadmap maxed")["id"]
+    fid = server.create_character(
+        cid,
+        "Capstone",
+        kind="player",
+        class_name="Fighter",
+        level=20,
+        apply_srd_defaults=True,
+        abilities={"strength": 18, "constitution": 14},
+    )["id"]
+    before = _campaign_snapshot(cid)
+
+    out = server.level_roadmap(cid, fid, through_level=20)
+
+    assert out["roadmap"] == []
+    assert out["from"]["total_level"] == 20
+    assert _campaign_snapshot(cid) == before
+
+
+def test_level_roadmap_respects_through_level_window():
+    cid = server.create_campaign("Roadmap window")["id"]
+    fid = server.create_character(
+        cid, "Ren", kind="player", class_name="Fighter", level=5, apply_srd_defaults=True,
+    )["id"]
+
+    out = server.level_roadmap(cid, fid, through_level=8)
+
+    assert [row["level"] for row in out["roadmap"]] == [6, 7, 8]
+
+
+def test_level_roadmap_multiclass_projects_primary_and_flags_multiclass():
+    cid = server.create_campaign("Roadmap multiclass")["id"]
+    server.set_house_rules(cid, {"multiclass_allowed": True})
+    # Build a Fighter 4 then level it once into Wizard so the PC is Fighter 4 / Wizard 1.
+    fid = server.create_character(
+        cid,
+        "Eldritch Knight Wannabe",
+        kind="player",
+        class_name="Fighter",
+        level=4,
+        apply_srd_defaults=True,
+        abilities={"strength": 14, "intelligence": 16, "constitution": 12},
+    )["id"]
+    server.level_up(cid, fid, "Wizard")
+    before = _campaign_snapshot(cid)
+
+    out = server.level_roadmap(cid, fid, through_level=20)
+
+    assert out["multiclass"] is True
+    # The primary (most-levels) class is Fighter (4 vs Wizard 1) — projected from clvl 5.
+    assert out["primary_class"] == "fighter"
+    assert out["from"]["class_level"] == 4
+    assert out["roadmap"][0]["class_level"] == 5
+    # Total level continues from 5 (Fighter 4 + Wizard 1).
+    assert out["roadmap"][0]["level"] == 6
+    assert _campaign_snapshot(cid) == before
+
+
+def test_level_roadmap_non_class_entity_returns_empty_guarded():
+    cid = server.create_campaign("Roadmap monster")["id"]
+    # A stat-block NPC created without a class track has no progression to project.
+    nid = server.create_character(cid, "Goblin", kind="npc")["id"]
+    out = server.level_roadmap(cid, nid, through_level=20)
+    assert out["primary_class"] is None
+    assert out["roadmap"] == []

--- a/viewer/openworlds/screen-character.jsx
+++ b/viewer/openworlds/screen-character.jsx
@@ -364,6 +364,12 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
   // loaded the first time the feat pane opens (`takingFeat`), then filtered client-side by `featSearch`.
   const [feats, setFeats] = React.useState(null);   // null = not yet loaded; [] = loaded/empty
   const [featSearch, setFeatSearch] = React.useState("");
+  // #882 roadmap: the "see your path to 20" planning view. Lazily fetched (GET /level-roadmap) the
+  // first time the player expands it, so the common confirm-the-next-level flow pays no extra fetch.
+  // This is a READ-ONLY projection of the SRD tables — it relays NOTHING (not an action, a plan).
+  const [roadmapOpen, setRoadmapOpen] = React.useState(false);
+  const [roadmap, setRoadmap] = React.useState(null);   // null = not yet loaded; [] = loaded/empty
+  const [roadmapError, setRoadmapError] = React.useState("");
   const [submitting, setSubmitting] = React.useState(false);
   // #robustness: synchronous in-flight lock (mirrors screen-table.jsx). The `submitting` STATE
   // only updates on re-render, so a rapid double-click would otherwise relay TWO level-up intents
@@ -412,6 +418,32 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
     })();
     return () => { cancelled = true; };
   }, [takingFeat, feats]);
+
+  // #882 roadmap: load the multi-level projection the first time the player expands the "path to 20"
+  // panel (so the common flow pays no fetch). Read-only GET /level-roadmap — a pure projection of the
+  // SRD tables, relays nothing. On any failure we leave `roadmap` as [] (the panel shows a quiet note).
+  React.useEffect(() => {
+    if (!roadmapOpen || roadmap !== null) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const url = "/level-roadmap?campaign=" + encodeURIComponent(campaignId || "") +
+                    "&character=" + encodeURIComponent(hero.id || "") + "&through=20";
+        const response = await fetch(url, { cache: "no-store" });
+        const payload = await response.json();
+        if (cancelled) return;
+        if (payload && payload.ok && payload.roadmap && Array.isArray(payload.roadmap.roadmap)) {
+          setRoadmap(payload.roadmap.roadmap);
+        } else {
+          setRoadmap([]);
+          setRoadmapError((payload && Array.isArray(payload.errors) && payload.errors[0]) || "");
+        }
+      } catch (e) {
+        if (!cancelled) { setRoadmap([]); setRoadmapError("Could not reach the roadmap planner."); }
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [roadmapOpen, roadmap, campaignId, hero.id]);
 
   // a11y (WCAG 2.1.2 — no keyboard trap): Escape dismisses the dialog, mirroring toast.jsx.
   React.useEffect(() => {
@@ -840,6 +872,100 @@ function LevelUpModal({ hero, campaignId, onClose, onDone, toast }) {
                         data-worldos-testid="levelup-asi-remaining">
                         {2 - asiTotal > 0 ? (2 - asiTotal) + " point" + (2 - asiTotal === 1 ? "" : "s") + " left to spend" : "All set — +2 allocated"}
                       </div>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* #882 roadmap: "See your path to 20" — a READ-ONLY projection of the upcoming levels
+                  (features, ASI/feat markers, prof bonus, slot/resource notes) so a build-optimizing
+                  player can theorycraft beyond the single next level. It relays NOTHING — purely a
+                  planning view. Lazily fetched on expand; renders nothing when the roadmap is empty
+                  (already at 20 / a non-class entity) beyond a quiet note. */}
+              {Number(hero.level) < 20 && (
+                <div style={{ marginTop: 20, paddingTop: 16, borderTop: "1px solid rgba(140,100,60,0.25)" }}
+                  data-worldos-testid="levelup-roadmap-section">
+                  <button type="button" onClick={() => setRoadmapOpen((v) => !v)}
+                    aria-expanded={roadmapOpen}
+                    data-worldos-testid="levelup-roadmap-toggle"
+                    style={{
+                      display: "flex", alignItems: "center", gap: 8, width: "100%",
+                      padding: "8px 12px", cursor: "pointer", textAlign: "left",
+                      boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.35)",
+                      background: roadmapOpen ? "rgba(176,141,87,0.12)" : "transparent",
+                      color: "var(--ink-800)", fontFamily: "var(--f-display)", fontSize: 13,
+                    }}>
+                    <span style={{ transform: roadmapOpen ? "rotate(90deg)" : "none", transition: "transform 0.15s" }}>▸</span>
+                    See your path to 20
+                  </button>
+                  {roadmapOpen && (
+                    <div data-worldos-testid="levelup-roadmap-pane" style={{ marginTop: 10 }}>
+                      {roadmap === null ? (
+                        <p className="body-sm muted" style={{ margin: 0 }}>Charting your path…</p>
+                      ) : roadmap.length === 0 ? (
+                        <p className="body-sm muted" style={{ margin: 0 }}
+                          data-worldos-testid="levelup-roadmap-empty">
+                          {roadmapError || "No further progression to project from here."}
+                        </p>
+                      ) : (
+                        <div style={{ display: "flex", flexDirection: "column", gap: 8, maxHeight: 300, overflowY: "auto" }}
+                          data-worldos-testid="levelup-roadmap-list">
+                          {roadmap.map((row) => {
+                            const feats = Array.isArray(row.features) ? row.features : [];
+                            const subFeats = Array.isArray(row.subclass_features) ? row.subclass_features : [];
+                            return (
+                              <div key={row.level}
+                                data-worldos-testid={"levelup-roadmap-level-" + row.level}
+                                style={{
+                                  padding: "8px 12px",
+                                  boxShadow: "inset 0 0 0 1px rgba(140,100,60,0.3)",
+                                  background: "rgba(255,250,235,0.4)",
+                                }}>
+                                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "baseline", gap: 8 }}>
+                                  <span style={{ fontFamily: "var(--f-display)", fontSize: 13, color: "var(--ink-900)" }}>
+                                    Level {row.level}
+                                  </span>
+                                  <span className="body-sm" style={{ opacity: 0.8, whiteSpace: "nowrap" }}>
+                                    Prof +{row.prof_bonus}
+                                    {row.is_asi_or_feat ? (
+                                      <span style={{ color: "var(--emerald)", marginLeft: 6 }}
+                                        data-worldos-testid={"levelup-roadmap-asi-" + row.level}>• ASI / feat</span>
+                                    ) : null}
+                                  </span>
+                                </div>
+                                {feats.length > 0 && (
+                                  <ul style={{ margin: "6px 0 0", paddingLeft: 18 }}>
+                                    {feats.map((f) => (
+                                      <li key={f.name} className="body-sm" style={{ opacity: 0.9 }}>
+                                        <span style={{ fontFamily: "var(--f-body)", color: "var(--ink-800)" }}>{f.name}</span>
+                                      </li>
+                                    ))}
+                                  </ul>
+                                )}
+                                {subFeats.length > 0 && (
+                                  <ul style={{ margin: "4px 0 0", paddingLeft: 18 }}>
+                                    {subFeats.map((f) => (
+                                      <li key={f.name} className="body-sm" style={{ opacity: 0.85, fontStyle: "italic" }}>
+                                        {f.name}
+                                      </li>
+                                    ))}
+                                  </ul>
+                                )}
+                                {(row.resources_note || row.spell_slots_note) && (
+                                  <div className="body-sm muted" style={{ marginTop: 4 }}>
+                                    {[row.spell_slots_note, row.resources_note].filter(Boolean).join(" · ")}
+                                  </div>
+                                )}
+                                {feats.length === 0 && subFeats.length === 0 && !row.resources_note && !row.spell_slots_note && (
+                                  <div className="body-sm muted" style={{ marginTop: 4, opacity: 0.7 }}>
+                                    No new features — ability/proficiency growth only.
+                                  </div>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -838,6 +838,83 @@ def build_options_response(campaign_id: Optional[str], character_id: Optional[st
     }
 
 
+def level_roadmap_response(
+    campaign_id: Optional[str], character_id: Optional[str], through_level: int = 20
+) -> dict:
+    """GET /level-roadmap read model — the "see your path to 20" planning view.
+
+    Mirrors build_options_response: validates the campaign path + character id, then calls
+    the engine-owned read-only level_roadmap projection (current level + 1 through
+    ``through_level``). It NEVER writes a snapshot and exposes no level_up relay — it is a
+    planning view, not an action. A non-class entity (stat-block NPC/monster) or a PC
+    already at ``through_level`` comes back with an empty ``roadmap`` (the UI renders
+    nothing), which is correct, not an error.
+    """
+    safe_campaign = _safe_campaign_id(campaign_id)
+    if not safe_campaign:
+        return _progression_error("invalid_campaign", "missing or unsafe campaign id")
+
+    safe_character = _clean_character_id(character_id)
+    if not safe_character:
+        return _progression_error(
+            "invalid_character",
+            "missing or unsafe character id",
+            campaign_id=safe_campaign,
+        )
+
+    snapshot = _read_snapshot(safe_campaign)
+    if not snapshot:
+        return _progression_error(
+            "state_unavailable",
+            "campaign snapshot is unavailable",
+            campaign_id=safe_campaign,
+            character_id=safe_character,
+        )
+    chars = snapshot.get("characters")
+    if not isinstance(chars, dict) or safe_character not in chars:
+        return _progression_error(
+            "invalid_character",
+            "character is not present in this campaign snapshot",
+            campaign_id=safe_campaign,
+            character_id=safe_character,
+        )
+
+    try:
+        through = int(through_level)
+    except (TypeError, ValueError):
+        through = 20
+    through = max(1, min(20, through))
+
+    engine = _load_engine_server()
+    if engine is None or not hasattr(engine, "level_roadmap"):
+        detail = _ENGINE_IMPORT_ERROR or "engine level_roadmap is unavailable"
+        return _progression_error(
+            "engine_unavailable",
+            f"engine level roadmap unavailable: {detail}",
+            campaign_id=safe_campaign,
+            character_id=safe_character,
+        )
+
+    try:
+        roadmap = engine.level_roadmap(safe_campaign, safe_character, through)
+    except Exception as exc:
+        return _progression_error(
+            "engine_error",
+            str(exc),
+            campaign_id=safe_campaign,
+            character_id=safe_character,
+        )
+    return {
+        "ok": True,
+        "code": "ok",
+        "campaign_id": safe_campaign,
+        "character_id": safe_character,
+        "source": "engine.level_roadmap",
+        "roadmap": roadmap,
+        "errors": [],
+    }
+
+
 def build_bestiary_response(query: str = "", limit: int = 20, campaign_id: str = "", reference: bool = False) -> dict:
     """GET /bestiary-surface read model.
 
@@ -8133,6 +8210,20 @@ class _Handler(BaseHTTPRequestHandler):
             cid = (qs.get("campaign") or [""])[0] or self._view_campaign(qs)
             character_id = (qs.get("character") or [""])[0]
             self._json(build_options_response(cid, character_id))
+        elif route == "/level-roadmap":
+            # Read-only multi-level progression roadmap ("see your path to 20"). Same
+            # campaign/character scoping as /build-options, then engine.level_roadmap — a
+            # pure projection of the SRD tables from current level + 1 through ?through
+            # (default/cap 20). It exposes NO level_up relay; it's a planning view only.
+            qs = parse_qs(parsed.query)
+            cid = (qs.get("campaign") or [""])[0] or self._view_campaign(qs)
+            character_id = (qs.get("character") or [""])[0]
+            raw_through = (qs.get("through") or ["20"])[0]
+            try:
+                through = int(raw_through)
+            except (TypeError, ValueError):
+                through = 20
+            self._json(level_roadmap_response(cid, character_id, through))
         elif route == "/item-catalog":
             # #756 read-only SRD item stat-block lookup by name. Lets the Market inspector
             # enrich a client-side ware (which carries only name/weight/price) with its real

--- a/viewer/tests/test_level_roadmap_bridge.py
+++ b/viewer/tests/test_level_roadmap_bridge.py
@@ -1,0 +1,120 @@
+"""Viewer-bridge tests for the read-only level-up ROADMAP surface (#882).
+
+`server.level_roadmap_response` validates the campaign/character scope, then calls the
+engine-owned read-only `level_roadmap` projection and packages it for the /character
+"see your path to 20" panel. These mirror test_build_options_bridge.py: assert the
+projection survives the bridge unmutated, the campaign snapshot is never written, and the
+guards (unsafe campaign, missing character, PC at the cap) behave honestly.
+"""
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(server)
+
+
+class LevelRoadmapBridgeTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("CLAWDND_STATE_DIR")
+        os.environ["CLAWDND_STATE_DIR"] = str(self._tmp)
+
+    def tearDown(self):
+        if self._old_state is None:
+            os.environ.pop("CLAWDND_STATE_DIR", None)
+        else:
+            os.environ["CLAWDND_STATE_DIR"] = self._old_state
+
+    def _snapshot_path(self, campaign_id: str) -> Path:
+        return self._tmp / "campaigns" / campaign_id / "snapshot.json"
+
+    def test_level_roadmap_response_projects_upcoming_levels_without_mutating_snapshot(self):
+        engine = server._engine_server()
+        campaign_id = engine.create_campaign("Roadmap")["id"]
+        character_id = engine.create_character(
+            campaign_id,
+            "Ren",
+            kind="player",
+            class_name="Fighter",
+            level=5,
+            apply_srd_defaults=True,
+            abilities={"strength": 16, "dexterity": 14, "constitution": 12},
+        )["id"]
+        before = json.loads(self._snapshot_path(campaign_id).read_text(encoding="utf-8"))
+
+        response = server.level_roadmap_response(campaign_id, character_id, 20)
+        after = json.loads(self._snapshot_path(campaign_id).read_text(encoding="utf-8"))
+
+        self.assertTrue(response["ok"])
+        self.assertEqual(response["source"], "engine.level_roadmap")
+        self.assertEqual(response["campaign_id"], campaign_id)
+        roadmap = response["roadmap"]
+        self.assertEqual(roadmap["primary_class"], "fighter")
+        self.assertEqual(roadmap["from"], {"total_level": 5, "class_level": 5})
+        rows = roadmap["roadmap"]
+        # Projects 6..20.
+        self.assertEqual([r["level"] for r in rows], list(range(6, 21)))
+        by_level = {r["level"]: r for r in rows}
+        # Fighter ASI/feat levels survive the bridge flagged.
+        for asi_lvl in (6, 8, 12, 14, 16, 19):
+            self.assertTrue(by_level[asi_lvl]["is_asi_or_feat"], asi_lvl)
+        self.assertFalse(by_level[7]["is_asi_or_feat"])
+        # Proficiency bonus rises across the bridge.
+        self.assertEqual(by_level[9]["prof_bonus"], 4)
+        # The snapshot is byte-identical — read-only.
+        self.assertEqual(after, before)
+
+    def test_level_roadmap_response_window_caps_at_through_level(self):
+        engine = server._engine_server()
+        campaign_id = engine.create_campaign("Window")["id"]
+        character_id = engine.create_character(
+            campaign_id, "Ren", kind="player", class_name="Fighter", level=5,
+            apply_srd_defaults=True,
+        )["id"]
+
+        response = server.level_roadmap_response(campaign_id, character_id, 8)
+
+        self.assertTrue(response["ok"])
+        self.assertEqual([r["level"] for r in response["roadmap"]["roadmap"]], [6, 7, 8])
+
+    def test_level_roadmap_response_empty_at_cap_is_not_an_error(self):
+        engine = server._engine_server()
+        campaign_id = engine.create_campaign("Capped")["id"]
+        character_id = engine.create_character(
+            campaign_id, "Capstone", kind="player", class_name="Fighter", level=20,
+            apply_srd_defaults=True, abilities={"strength": 18, "constitution": 14},
+        )["id"]
+
+        response = server.level_roadmap_response(campaign_id, character_id, 20)
+
+        self.assertTrue(response["ok"])
+        self.assertEqual(response["roadmap"]["roadmap"], [])
+
+    def test_level_roadmap_response_rejects_unsafe_campaign_id(self):
+        response = server.level_roadmap_response("../secret", "pc", 20)
+
+        self.assertFalse(response["ok"])
+        self.assertEqual(response["code"], "invalid_campaign")
+        self.assertIn("campaign", response["errors"][0])
+
+    def test_level_roadmap_response_rejects_missing_character(self):
+        engine = server._engine_server()
+        campaign_id = engine.create_campaign("NoChar")["id"]
+
+        response = server.level_roadmap_response(campaign_id, "does-not-exist", 20)
+
+        self.assertFalse(response["ok"])
+        self.assertEqual(response["code"], "invalid_character")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes the build-optimizer's last planning gap. A read-only 'See your path to 20' panel projects the PC's class progression (features/ASI/prof/slots per level) from the engine's SRD tables — engine stays sole writer, relays no move. New level_roadmap() tool + /level-roadmap route + LevelUpModal panel. Tests: engine 11 + viewer 5 + full viewer suite 752 + fast_gate 222.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "See your path to 20" planning view in the level-up modal. Players can preview upcoming levels showing proficiency bonus progression, ability score improvements/feat opportunities, new class features, and spell slot changes—without affecting current character state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->