### PR TITLE
fix(engine): apply Bless/Bane riders to every multi-target beneficiary, not just one

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -6768,6 +6768,9 @@ def cast_spell(
         # sweep paths when concentration ends). None for every other spell == byte-identical.
         rider_fields = combat.spell_effect_riders(canonical)
         rider_child_target = None
+        rider_aoe_targets: list = []   # non-caster beneficiaries from a target_ids (AoE) rider cast
+        caster_in_aoe = False          # the caster is itself in target_ids (a self+ally Bless)
+        caster_gets_rider = False
         if duration is not None:
             if not concentrates and target_id and target_id != character_id:
                 tgt = c.characters.get(target_id)
@@ -6775,6 +6778,24 @@ def cast_spell(
                     effect_holder = tgt
             if rider_fields and concentrates and target_id and target_id != character_id:
                 rider_child_target = c.characters.get(target_id)
+            # MULTI-TARGET (AoE) riders (#bless-aoe): a concentration rider spell (Bless/Bane) cast
+            # on an explicit target_ids list writes a linked child to EVERY non-caster beneficiary,
+            # and lets the caster-twin carry the rider ONLY when the caster is itself in the list.
+            # Without this a target_ids cast left rider_child_target=None, so the rider landed on the
+            # caster-twin (below) and the named allies got no engine d4 — the gs-ember-deep
+            # Bless-on-[ally, self] bug, where the PC ally was blessed in fiction but not in engine.
+            if rider_fields and concentrates and aoe_targets:
+                for _t in aoe_targets:
+                    if _t.id == character_id:
+                        caster_in_aoe = True
+                    elif _t.id != getattr(rider_child_target, "id", None) \
+                            and all(_t.id != x.id for x in rider_aoe_targets):
+                        rider_aoe_targets.append(_t)
+            # the caster-twin carries the rider on a self-cast (no separate/AoE target) OR when the
+            # caster is an explicit beneficiary in target_ids — never when it blesses only others.
+            caster_gets_rider = bool(rider_fields) and (
+                caster_in_aoe or (rider_child_target is None and not aoe_targets)
+            )
             # ON-HIT RIDER DEFER (#186). An ATTACK-ROLL spell whose timed effect lands on a
             # SEPARATE target is a 5e on-hit rider (Guiding Bolt: "on a hit, the next attack
             # against it has Advantage"). The cast and the spell attack are two calls, so the
@@ -6827,11 +6848,12 @@ def cast_spell(
                     eff.expires_day, eff.expires_phase_index = _effect_clock_deadline(
                         c, duration["hours"], duration["days"]
                     )
-                # SYN-06: when THIS effect is the beneficiary record (self-cast / Shield /
-                # a non-concentration targeted buff), copy the curated rider numbers onto
-                # it. With a separate child target the caster-side twin stays a pure
-                # concentration tracker (blessing an ally must not also bless the caster).
-                if rider_fields and rider_child_target is None:
+                # SYN-06: when THIS effect is a beneficiary record (self-cast / Shield / a
+                # non-concentration targeted buff, OR the caster is itself in a target_ids list),
+                # copy the curated rider numbers onto it. With separate child targets the caster-side
+                # twin stays a pure concentration tracker (blessing only allies must not bless the
+                # caster). caster_gets_rider encodes exactly that (see #bless-aoe above).
+                if caster_gets_rider:
                     eff.ac_bonus = int(rider_fields.get("ac_bonus", 0))
                     eff.attack_bonus_dice = rider_fields.get("attack_bonus_dice", "")
                     eff.save_bonus_dice = rider_fields.get("save_bonus_dice", "")
@@ -6844,7 +6866,8 @@ def cast_spell(
                 # clock as the twin, carries the mechanical rider, flagged so BOTH sweep
                 # paths (next_turn's inverse sweep + drop_concentration) release it the
                 # moment the caster's concentration ends. Refresh-not-stack, like the twin.
-                if rider_child_target is not None:
+                for _rt in (([rider_child_target] if rider_child_target is not None else [])
+                            + rider_aoe_targets):
                     child = ActiveEffect(
                         name=canonical,
                         source_id=character_id,
@@ -6859,10 +6882,8 @@ def cast_spell(
                         attack_bonus_dice=rider_fields.get("attack_bonus_dice", ""),
                         save_bonus_dice=rider_fields.get("save_bonus_dice", ""),
                     )
-                    rider_child_target.active_effects = [
-                        e for e in rider_child_target.active_effects if e.name != canonical
-                    ]
-                    rider_child_target.active_effects.append(child)
+                    _rt.active_effects = [e for e in _rt.active_effects if e.name != canonical]
+                    _rt.active_effects.append(child)
         mod = _casting_mod(ch)
         prof = ch.proficiency_bonus
         c.characters[character_id] = Character.model_validate(ch.model_dump(mode="json"))
@@ -6870,10 +6891,10 @@ def cast_spell(
             c.characters[effect_holder.id] = Character.model_validate(
                 effect_holder.model_dump(mode="json")
             )
-        if rider_child_target is not None and rider_child_target is not effect_holder:
-            c.characters[rider_child_target.id] = Character.model_validate(
-                rider_child_target.model_dump(mode="json")
-            )
+        for _rt in (([rider_child_target] if rider_child_target is not None else [])
+                    + rider_aoe_targets):
+            if _rt is not effect_holder and _rt.id != character_id:
+                c.characters[_rt.id] = Character.model_validate(_rt.model_dump(mode="json"))
         # AoE / MULTI-TARGET RESOLUTION (F03-4). Targets were validated up front (before the
         # slot spend). Now the area save-for-damage spell is resolved by the ENGINE: ONE shared
         # damage roll for the whole area, then a per-target saving throw vs the caster's DC,
@@ -7025,11 +7046,17 @@ def cast_spell(
             # SYN-06 (#780): tell the DM the buff has ENGINE-APPLIED teeth — which numbers,
             # on whom — so it isn't narrated as flavor and then double-applied by hand.
             if rider_fields:
+                _rider_holders = [t.id for t in rider_aoe_targets]
+                if rider_child_target is not None:
+                    _rider_holders.insert(0, rider_child_target.id)
+                if caster_gets_rider:
+                    _rider_holders.append(effect_holder.id)
                 result["effect_riders"] = {
                     "holder_id": (
                         rider_child_target.id if rider_child_target is not None
-                        else effect_holder.id
+                        else (rider_aoe_targets[0].id if rider_aoe_targets else effect_holder.id)
                     ),
+                    "holder_ids": _rider_holders or [effect_holder.id],
                     **rider_fields,
                     "note": (
                         "Engine-applied: ac_bonus is folded into the holder's effective AC; "

--- a/servers/engine/tests/test_effect_riders.py
+++ b/servers/engine/tests/test_effect_riders.py
@@ -197,6 +197,26 @@ def test_drop_concentration_frees_linked_children(tmp_path, monkeypatch):
     assert server.get_character(cid, ally)["active_effects"] == []
 
 
+def test_drop_concentration_frees_all_aoe_linked_children(tmp_path, monkeypatch):
+    # Multi-target Bless via target_ids: dropping concentration must release the linked child on
+    # EVERY blessed ally, not just one — the sweep is keyed on the caster's concentration, so all
+    # children fall together.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("DropConcAoE")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    a = server.create_character(cid, "AllyA", kind="player", max_hp=30)["id"]
+    b = server.create_character(cid, "AllyB", kind="player", max_hp=30)["id"]
+    server.cast_spell(cid, cleric, "Bless", target_ids=[a, b])
+    assert server.get_character(cid, a)["active_effects"] and server.get_character(cid, b)["active_effects"]
+    out = server.drop_concentration(cid, cleric)
+    assert out["ended"] is True
+    freed = {(f["character_id"], f["name"]) for f in out["freed_targets"]}
+    assert (a, "Bless") in freed and (b, "Bless") in freed
+    assert server.get_character(cid, a)["active_effects"] == []
+    assert server.get_character(cid, b)["active_effects"] == []
+
+
 def test_failed_concentration_save_frees_linked_children_immediately(tmp_path, monkeypatch):
     # F3-6: a failed concentration save now releases the blessed ally's linked child in the
     # SAME call (surfaced in freed_targets), not deferred to the next next_turn sweep. The
@@ -230,3 +250,81 @@ def test_cast_result_advertises_engine_applied_riders(tmp_path, monkeypatch):
     assert riders["holder_id"] == ally
     assert riders["attack_bonus_dice"] == "1d4"
     assert riders["save_bonus_dice"] == "1d4"
+
+
+# --- Bless / Bane via target_ids (multi-target / AoE) — the rider must reach EVERY beneficiary ---
+
+def test_bless_via_target_ids_blesses_each_ally_not_the_caster(tmp_path, monkeypatch):
+    # Bless cast on an explicit target_ids list (the multi-target path) must give the +1d4 rider to
+    # EVERY named ally — not just one, and NOT the caster (who blessed others). The bug: the rider
+    # logic only handled the singular target_id, so a target_ids cast landed the rider on the
+    # caster-twin and left the named allies with nothing.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("BlessAoE")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    a = server.create_character(cid, "AllyA", kind="player", max_hp=30)["id"]
+    b = server.create_character(cid, "AllyB", kind="player", max_hp=30)["id"]
+    server.cast_spell(cid, cleric, "Bless", target_ids=[a, b])
+    for ally_id in (a, b):
+        effs = [e for e in server.get_character(cid, ally_id)["active_effects"] if e["name"] == "Bless"]
+        assert effs, f"{ally_id} got no Bless rider"
+        assert effs[0]["attack_bonus_dice"] == "1d4"
+        assert effs[0]["save_bonus_dice"] == "1d4"
+        assert effs[0]["linked_to_concentration"] is True
+    # the caster holds the concentration twin but carries NO rider numbers (it blessed others, not itself)
+    caster_bless = [e for e in server.get_character(cid, cleric)["active_effects"] if e["name"] == "Bless"]
+    assert caster_bless, "caster should still hold the concentration twin"
+    assert all(e["attack_bonus_dice"] == "" and e["save_bonus_dice"] == "" for e in caster_bless), \
+        "caster wrongly received the Bless rider when it blessed only others"
+    # and the engine actually rolls the d4 on each ally's attack (not just one of them)
+    _rig(monkeypatch, d20_natural=10, d4=3)
+    foe = server.create_character(cid, "Thug", kind="monster", max_hp=30, armor_class=12)["id"]
+    r = server.attack(cid, attacker_id=a, target_id=foe, attack_bonus=0, damage_dice="1d6")
+    assert r["attack_roll"]["total"] == 13 and r["hit"] is True
+    assert r["attack_roll"]["bonus_dice"][0]["source"] == "Bless"
+
+
+def test_bless_via_target_ids_including_caster_blesses_both(tmp_path, monkeypatch):
+    # The exact gs-ember-deep cast: Bless target_ids=[ally, caster]. BOTH must carry the rider — the
+    # ally via a concentration-linked child, the caster via its own twin (it IS a beneficiary here).
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("BlessSelfAlly")["id"]
+    cleric = server.create_character(cid, "Toll", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    ally = server.create_character(cid, "Kield", kind="player", max_hp=30)["id"]
+    server.cast_spell(cid, cleric, "Bless", target_ids=[ally, cleric])
+    for who in (ally, cleric):
+        effs = [e for e in server.get_character(cid, who)["active_effects"] if e["name"] == "Bless"]
+        assert effs and effs[0]["attack_bonus_dice"] == "1d4", f"{who} missing Bless rider"
+    ally_bless = [e for e in server.get_character(cid, ally)["active_effects"] if e["name"] == "Bless"][0]
+    assert ally_bless["linked_to_concentration"] is True  # the ally holds the linked child
+
+
+def test_cast_result_advertises_all_rider_holders_for_multi_target(tmp_path, monkeypatch):
+    # The cast result surfaces EVERY rider holder so the DM (and the GUI) can see who got blessed.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("AdvertAoE")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    a = server.create_character(cid, "AllyA", kind="player", max_hp=30)["id"]
+    b = server.create_character(cid, "AllyB", kind="player", max_hp=30)["id"]
+    r = server.cast_spell(cid, cleric, "Bless", target_ids=[a, b])
+    riders = r["effect_riders"]
+    assert set(riders["holder_ids"]) == {a, b}
+    assert riders["attack_bonus_dice"] == "1d4"
+
+
+def test_shield_of_faith_via_target_ids_buffs_each_ally(tmp_path, monkeypatch):
+    # The multi-target rider path is rider-AGNOSTIC (not Bless-specific): Shield of Faith
+    # (ac_bonus, concentration) cast on a target_ids list gives EACH ally the +2 AC linked child.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("SoFAoE")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    a = server.create_character(cid, "AllyA", kind="player", max_hp=30, armor_class=14)["id"]
+    b = server.create_character(cid, "AllyB", kind="player", max_hp=30, armor_class=12)["id"]
+    server.cast_spell(cid, cleric, "Shield of Faith", target_ids=[a, b])
+    for who in (a, b):
+        effs = [e for e in server.get_character(cid, who)["active_effects"] if e["name"] == "Shield of Faith"]
+        assert effs and effs[0]["ac_bonus"] == 2 and effs[0]["linked_to_concentration"] is True


### PR DESCRIPTION
**SRD-fidelity bug found by the 2026-06-17 craft audit.** In gs-ember-deep, Brother Toll cast `Bless` via `target_ids=[PC, self]` but the PC got **no engine +1d4** (blessed in fiction, not in engine). Root cause: cast_spell's rider logic only handled the singular `target_id`; an AoE/multi-target cast left `rider_child_target=None`, so the rider landed on the caster-twin and every named ally got nothing.

**Fix** (additive, in cast_spell): derive `rider_aoe_targets` + `caster_in_aoe`, and `caster_gets_rider` = self-cast OR caster-is-an-explicit-beneficiary. The caster-twin carries the rider only when it should; the linked concentration-child creation + persistence now loop over **every** beneficiary. Result surfaces `holder_ids`. Rider-agnostic (Shield of Faith via target_ids works too).

Reproduced (3 RED tests) → fixed → **16 effect_riders + 196 concentration/aoe/combat tests + fast_gate GREEN**. **Adversarially reviewed → SHIP** (7 invariants confirmed via reproductions: caster-inclusion, no double-application, multi-holder concentration release, refresh-not-stack, persistence, object identity; no spurious AoE damage on a buff).

**Out of scope (pre-existing, flagged):** Bane via target_ids hard-crashes in the *separate* AoE save-for-damage path (server.py:6928, 'charisma' vs 'cha' enum) — tracked as a follow-up; this PR covers Bless + Shield of Faith.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved incorrect application of concentration-linked spell effects (Bless, Shield of Faith) in multi-target scenarios.
  * Improved handling of caster participation when included in multi-target spell targets.
  * Spell responses now accurately report all affected targets for concentration-linked effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->