### PR TITLE
fix(qa): story_readout outcome line no longer renders narration as a boolean value

### DIFF
--- a/qa/story_readout.py
+++ b/qa/story_readout.py
@@ -257,9 +257,24 @@ def _tool_summary(name: str, inp) -> str:
     return " ".join(bits[:4])
 
 
+# Keys whose engine value is strictly boolean. On a beat with several tool results joined into
+# one blob, the permissive value capture can grab adjacent narration/lore prose as a "value"; a
+# boolean key whose captured value isn't true/false is such a mis-capture — drop it so the outcome
+# line never renders garble like `success="The Book of Grace …`.
+_BOOL_OUT_KEYS = {"success", "failed", "crit", "hit", "defeated", "dead"}
+
+
 def _outcome(txt: str) -> str:
     m = _OUT_KEYS.findall(txt or "")
-    return " ".join(f"{k}={v.strip()[:18]}" for k, v in m[:7])
+    bits = []
+    for k, v in m[:12]:
+        v = v.strip().strip('"').strip()
+        if k in _BOOL_OUT_KEYS and v.lower() not in ("true", "false"):
+            continue  # narration captured as a boolean value — skip the garble
+        if not v:
+            continue
+        bits.append(f"{k}={v[:18]}")
+    return " ".join(bits[:7])
 
 
 # Tool calls whose INPUT can carry a companion approval move via `approval_tags`. In real play

--- a/qa/test_story_readout_outcome.py
+++ b/qa/test_story_readout_outcome.py
@@ -1,0 +1,47 @@
+"""Self-test for story_readout._outcome()'s garble guard.
+
+Found on the gs-ledger-deep authored-spine run (BG golden spine, story-craft 4.8): on a beat with
+several tool results joined into one blob, the permissive `_OUT_KEYS` value capture grabbed adjacent
+narration/lore prose as a boolean "value", rendering an outcome line like
+
+    → dc=14 success="The Book of Grace dc=13 success="Two finds. First dc=13 success="You read Tobias Q
+
+A boolean engine key (success/failed/crit/hit/defeated/dead) whose captured value isn't true/false is
+such a mis-capture — _outcome now drops it, so the readout (a shipped artifact) never renders garble.
+The COVERAGE stamp is computed elsewhere (analyze) and is unaffected.
+
+Stdlib + pytest only; self-contained. Run single-process:
+    uv run --directory servers/engine python -m pytest qa/test_story_readout_outcome.py -p no:xdist
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import story_readout as sr  # noqa: E402
+
+
+def test_narration_captured_as_success_value_is_dropped():
+    # The real-world garble shape: a `"success"` key whose value is narration prose, not a boolean.
+    garble = '"dc": 14, "success": "The Book of Grace is open, success= laid bare on the lectern'
+    out = sr._outcome(garble)
+    assert "Book of Grace" not in out, out
+    assert "success=The" not in out and 'success="' not in out, out
+    # the legitimate numeric key still renders
+    assert "dc=14" in out, out
+
+
+def test_real_boolean_outcomes_survive():
+    clean = '"roll": 8, "dc": 13, "success": false'
+    out = sr._outcome(clean)
+    assert "roll=8" in out and "dc=13" in out and "success=false" in out, out
+
+
+def test_true_survives_and_quotes_are_stripped():
+    # attitude is a free-text key; its surrounding quotes should be stripped, not rendered.
+    txt = '"success": true, "attitude": "anxious"'
+    out = sr._outcome(txt)
+    assert "success=true" in out, out
+    assert "attitude=anxious" in out and 'attitude="' not in out, out


### PR DESCRIPTION
Found while rendering the gs-ledger-deep golden-spine transcript (BG spine, story-craft 4.8) into a readable story for review.

**Bug:** on a beat with several tool results joined into one blob, `_OUT_KEYS`' permissive value capture grabbed adjacent narration/lore prose as a "value", so the `→ outcome` summary line rendered garble like:

    → dc=14 success="The Book of Grace dc=13 success="Two finds. First dc=13 success="You read Tobias Q

**Fix:** `_outcome()` now drops a boolean engine key (success/failed/crit/hit/defeated/dead) whose captured value isn't `true`/`false` (that's a mis-capture), strips stray quotes, and skips empties. The `COVERAGE` stamp is computed in `analyze()` and is unaffected. Cosmetic-only on the readout artifact; no engine/game change.

Adds `qa/test_story_readout_outcome.py` (3 cases). 34 story_readout/coverage tests pass single-process. Verified on the real gs-ledger-deep transcript: garble gone, coverage stamp byte-identical (`recruit ✓ camp ✓ approval-moved ✓ combat ✓ quest-resolved ✓ evolved ✓`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved outcome parsing robustness by distinguishing boolean outcome fields and validating they contain proper true/false values. Prevents narration text from being incorrectly rendered as boolean outcomes.

* **Tests**
  * Added test coverage validating outcome parsing behavior, including cases with mixed field types and quote stripping for free-text fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->