### PR TITLE
qa: sync gate guards (root-cause taxonomy + corpus manifest) with structural_completeness + narration_no_ooc_leak

### DIFF
--- a/qa/BEHAVIORAL_GATE_TAXONOMY.json
+++ b/qa/BEHAVIORAL_GATE_TAXONOMY.json
@@ -172,9 +172,9 @@
     },
     "structural_completeness": {
       "category": "ENGINE_INVARIANT",
-      "likely_code_locations": ["servers/engine/companion.py", "servers/engine/server.py", "servers/engine/questgen.py"],
+      "likely_code_locations": ["servers/engine/server.py", "servers/engine/models.py", "servers/engine/companion.py"],
       "retest": "bash qa/run_duo.sh duo-retest",
-      "hint": "A >=10-beat session with a companion never engaged a core relationship/quest system: either no companion's attitude_value moved off 0 AND no camp/long_rest happened, or an active quest was left open across a >=2-location arc with no quest-resolution call. Either the DM never invoked the relationship/quest tools (record_decision approval_tags / adjust_attitude / camp_scene / complete_quest evolves_to — DM adherence) or those engine writes never landed (engine). Check the approval/attitude write in companion.py, the record_decision/camp_scene/complete_quest handlers in server.py, and the quest-resolution/evolution path in questgen.py. FATAL (skipped in the combat-sprint lane); validate at >=24 beats so an authored campaign quest has room to resolve."
+      "hint": "A >=10-beat session with a companion never engaged a core relationship/quest system: either no companion's attitude_value moved off 0 AND no camp/long_rest happened, or an active quest was left open across a >=2-location arc with no quest-resolution call. Either the DM never invoked the relationship/quest tools (record_decision / adjust_attitude / camp_scene / complete_quest evolves_to — DM adherence) or those engine writes never landed (engine). All those tool handlers + the attitude_value/quest-status writes live in server.py (adjust_attitude, record_decision, camp_scene, complete_quest, and the rule-of-three evolution _maybe_schedule_quest_evolution / evolves_to); the field definitions are in models.py; companion.py only surfaces approval CAUSES (approval_tags) for the DM to apply — it never writes state itself. The gate trips at >=10 beats (STRUCTURAL_MIN_BEATS); when validating authored campaigns run >=24 beats so the main quest has room to resolve, else the unresolved-arc sub-check false-REDs. FATAL; skipped in the combat-sprint lane."
     },
     "world_peopled": {
       "category": "DM_ADHERENCE",

--- a/qa/BEHAVIORAL_GATE_TAXONOMY.json
+++ b/qa/BEHAVIORAL_GATE_TAXONOMY.json
@@ -32,6 +32,12 @@
       "retest": "bash qa/run_duo.sh duo-retest",
       "hint": "Zero quoted dialogue across the whole run with a companion present — a log, not a scene. The DM narrated only atmosphere. Strengthen the DM prompt's dialogue mandate; it is FATAL only when a companion is in the party."
     },
+    "narration_no_ooc_leak": {
+      "category": "DM_ADHERENCE",
+      "likely_code_locations": ["skills/dungeon-master/SKILL.md", "qa/play_dm_duo.txt", "qa/assert_behavioral.py"],
+      "retest": "bash qa/run_duo.sh duo-retest",
+      "hint": "Player-facing DM prose leaked OUT-OF-CHARACTER craft-scaffolding / first-person authoring preambles / raw system vocab (e.g. 'Now let me seat <X> as the player character', 'Continuity check — let me correct that') — a felt-quality defect the LLM story scorer blends away. Fix at the source: the DM's FICTION-ONLY voice mandate in skills/dungeon-master/SKILL.md (and the duo DM prompt qa/play_dm_duo.txt). Proportionate severity: 0 leaks pass, 1-2 incidental leaks WARN, >=3 in a substantial run (dm_text>=MIN_BEATS) is a pervasively-broken player surface => RED. If a clean in-fiction beat is mis-flagged, tighten the _NARRATION_LEAK_RE patterns in qa/assert_behavioral.py."
+    },
     "dm_beat_honesty": {
       "category": "HARNESS_WIRING",
       "likely_code_locations": ["qa/lib_beat_driver.sh", "qa/run_duo.sh", "qa/dm_narration_fallback.py"],
@@ -163,6 +169,12 @@
       "likely_code_locations": ["servers/engine/travel.py", "servers/engine/server.py", "servers/engine/models.py"],
       "retest": "bash qa/run_duo.sh duo-retest",
       "hint": "The party visited <2 locations after a substantial session — it never left the opening scene. Either the DM never called travel_to/add_location(make_current=True) (DM adherence) or the location.visited flag never set (engine). Check travel.py's visited-marking write."
+    },
+    "structural_completeness": {
+      "category": "ENGINE_INVARIANT",
+      "likely_code_locations": ["servers/engine/companion.py", "servers/engine/server.py", "servers/engine/questgen.py"],
+      "retest": "bash qa/run_duo.sh duo-retest",
+      "hint": "A >=10-beat session with a companion never engaged a core relationship/quest system: either no companion's attitude_value moved off 0 AND no camp/long_rest happened, or an active quest was left open across a >=2-location arc with no quest-resolution call. Either the DM never invoked the relationship/quest tools (record_decision approval_tags / adjust_attitude / camp_scene / complete_quest evolves_to — DM adherence) or those engine writes never landed (engine). Check the approval/attitude write in companion.py, the record_decision/camp_scene/complete_quest handlers in server.py, and the quest-resolution/evolution path in questgen.py. FATAL (skipped in the combat-sprint lane); validate at >=24 beats so an authored campaign quest has room to resolve."
     },
     "world_peopled": {
       "category": "DM_ADHERENCE",

--- a/qa/gate_corpus/manifest.json
+++ b/qa/gate_corpus/manifest.json
@@ -178,6 +178,12 @@
         "state.json"
       ],
       "real_red_provenance": ""
+    },
+    {
+      "case_dir": "TODO__narration_no_ooc_leak",
+      "expected_red_check": "narration_no_ooc_leak",
+      "todo": true,
+      "reason": "no faithful minimal fixture constructed yet (auto-flagged by builder)"
     }
   ]
 }


### PR DESCRIPTION
## Problem
Two QA **guard** tests were RED on `main` (the `CI` / `qa-release-gate-tests` job has been failing on `main` for several commits). Both stem from one root cause: the gate checks `structural_completeness` and `narration_no_ooc_leak` were added to `qa/assert_behavioral.py` without updating the guard metadata that's supposed to track the gate.

1. `test_root_cause_analyzer.py::test_taxonomy_matches_real_gate_check_names` — the root-cause taxonomy (`qa/BEHAVIORAL_GATE_TAXONOMY.json`) was missing both checks.
2. `test_behavioral_gate_corpus.py::test_manifest_covers_every_fatal_check` — the gate-corpus manifest had no fixture **and** no TODO entry for `narration_no_ooc_leak` (a FATAL check: `chk(... fatal=_leak_red)`). `structural_completeness` already had a fixture, so only the taxonomy was missing it.

Both were **pre-existing on `main`** and independent of each other; the corpus failure does not read the taxonomy at all.

## Fix (guard metadata only — `assert_behavioral.py` untouched)

**Taxonomy** (`qa/BEHAVIORAL_GATE_TAXONOMY.json`) — added both entries:

| check | category | rationale |
|---|---|---|
| `structural_completeness` | `ENGINE_INVARIANT` | FATAL duo-lane check that a ≥10-beat companion session engaged a core relationship/quest system. Reads engine-written state — structurally parallel to `party_traveled` / `world_advanced_time`. Locations → `companion.py` / `server.py` / `questgen.py`. |
| `narration_no_ooc_leak` | `DM_ADHERENCE` | Player-facing OOC craft-scaffolding leak gate (0 pass / 1-2 WARN / ≥3 RED). About the DM's narrated prose; remediation → FICTION-ONLY mandate in `skills/dungeon-master/SKILL.md` + duo DM prompt; `_NARRATION_LEAK_RE` as the false-positive tuning point. |

**Corpus manifest** (`qa/gate_corpus/manifest.json`) — ran the canonical sync `python qa/gate_corpus/builder.py`, which deterministically regenerated all 18 fixtures (byte-identical, zero churn) and auto-added a `TODO__narration_no_ooc_leak` entry (a faithful minimal OOC-leak fixture is deferred work, flagged with a reason).

## Test
```
$ uv run --directory servers/engine python -m pytest \
    ../../qa/test_behavioral_gate_corpus.py ../../qa/test_root_cause_analyzer.py -q -p no:xdist
38 passed, 1 skipped
```

No behavior change to any gate; only the analyzer's RED→actionable-location mapping and the corpus coverage audit gain the two checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new automated QA checks to enforce narrative consistency (preventing out-of-character information leakage) and structural completeness.
  * Introduced a new regression-corpus case for the narrative consistency check, currently marked as pending until the minimal required fixture content is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->