### PR TITLE
fix(engine): multi-target Bane no longer crashes mid-cast; SRD full-word save abilities resolve

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -6904,7 +6904,13 @@ def cast_spell(
         # combat.apply_damage pipeline as everything else (resistances, temp HP, downing, the
         # concentration-check DC). One lock, one write. Surfaced as a per-target result table.
         aoe_result = None
-        if aoe_targets:
+        # A curated buff/debuff (Bless / Bane / Shield of Faith / Shield) is resolved by its
+        # numeric rider — already applied to every beneficiary above and surfaced via
+        # `effect_riders` below — NOT by engine area damage. Bane in particular carries a stray
+        # srd524 `damage_roll` (and a full-word save ability) that would otherwise be rolled here
+        # as bogus area damage; so a rider spell skips the save-for-damage path entirely. (The
+        # multi-target rider work that began encouraging the target_ids path surfaced this.)
+        if aoe_targets and not rider_fields:
             spec = _aoe_damage_spec(
                 curated, srd,
                 slot_used if isinstance(slot_used, int) else spell_level,
@@ -6925,7 +6931,11 @@ def cast_spell(
                     "targets": [{"character_id": t.id, "name": t.name} for t in aoe_targets],
                 }
             else:
-                save_ab = Ability(spec["save_ability"])
+                # _parse_ability accepts BOTH the 3-letter enum code and the FULL WORD — every
+                # srd524 record spells `saving_throw_ability` as the full word ('constitution',
+                # 'dexterity', …), so all ~68 SRD-only save-for-damage spells (Cone of Cold,
+                # Cloudkill, Chain Lightning, …) used to crash here on Ability('constitution').
+                save_ab = _parse_ability(spec["save_ability"])
                 dmg = dice_mod.roll(spec["damage"])  # ONE roll shared across the whole area
                 rows: list[dict] = []
                 for t in aoe_targets:

--- a/servers/engine/tests/test_effect_riders.py
+++ b/servers/engine/tests/test_effect_riders.py
@@ -328,3 +328,57 @@ def test_shield_of_faith_via_target_ids_buffs_each_ally(tmp_path, monkeypatch):
     for who in (a, b):
         effs = [e for e in server.get_character(cid, who)["active_effects"] if e["name"] == "Shield of Faith"]
         assert effs and effs[0]["ac_bonus"] == 2 and effs[0]["linked_to_concentration"] is True
+
+
+# --- Bane via target_ids: a DEBUFF must apply its rider, NOT deal damage, and not crash ---
+
+def test_bane_via_target_ids_applies_rider_to_each_foe_and_deals_no_damage(tmp_path, monkeypatch):
+    # Bane is an SRD-only DEBUFF: its tracked effect is the -1d4 save/attack rider, NOT damage.
+    # But its srd524 record carries a stray damage_roll='1d4' AND a full-word
+    # saving_throw_ability='charisma'. A target_ids cast used to enter the AoE save-for-damage
+    # path and hard-crash on Ability('charisma') (the enum code is 'cha') — AFTER the slot was
+    # already spent. Bane must instead apply its -1d4 save rider to EACH foe and deal NO damage.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("BaneAoE")["id"]
+    caster = server.create_character(cid, "Hex", kind="player", max_hp=10)["id"]
+    server.update_character(cid, caster, patch={
+        "spell_slots": {"1": {"maximum": 2, "used": 0}}})
+    a = server.create_character(cid, "ThugA", kind="monster", max_hp=20)["id"]
+    b = server.create_character(cid, "ThugB", kind="monster", max_hp=20)["id"]
+    r = server.cast_spell(cid, caster, "Bane", target_ids=[a, b])  # must NOT raise
+    for foe in (a, b):
+        sheet = server.get_character(cid, foe)
+        assert sheet["current_hp"] == 20, f"{foe} wrongly took Bane 'damage'"
+        effs = [e for e in sheet["active_effects"] if e["name"] == "Bane"]
+        assert effs, f"{foe} got no Bane rider"
+        assert effs[0]["save_bonus_dice"] == "-1d4"
+        assert effs[0]["linked_to_concentration"] is True
+    # the engine rolled NO area damage for a pure debuff
+    assert "aoe" not in r or r["aoe"].get("shared_damage") is None
+    # ...and the -1d4 actually bites on a foe's save (engine-rolled, like the single-target case)
+    _rig(monkeypatch, d20_natural=10, d4=3)
+    out = server.saving_throw(cid, a, "wis", dc=10)
+    assert out["roll"] == 7 and out["success"] is False
+    assert out["bonus_dice"][0]["source"] == "Bane" and out["bonus_dice"][0]["rolled"] == -3
+
+
+def test_srd_only_area_damage_spell_with_full_word_save_ability_resolves(tmp_path, monkeypatch):
+    # The crash class Bane surfaced is general: ALL ~68 SRD-only save-for-damage spells spell
+    # their save ability as the FULL WORD ('constitution', 'dexterity', …), but the AoE resolver
+    # fed it straight to Ability(...) (which only knows the 3-letter codes). A real SRD-only area
+    # damage spell (Cone of Cold: 8d8 cold, CON save) cast via target_ids must resolve the engine
+    # save-for-half table — not crash AFTER the slot spend.
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("ConeAoE")["id"]
+    caster = server.create_character(cid, "Evoker", kind="player", max_hp=20)["id"]
+    server.update_character(cid, caster, patch={
+        "spell_slots": {"5": {"maximum": 1, "used": 0}}})
+    a = server.create_character(cid, "FoeA", kind="monster", max_hp=100)["id"]
+    b = server.create_character(cid, "FoeB", kind="monster", max_hp=100)["id"]
+    r = server.cast_spell(cid, caster, "Cone of Cold", target_ids=[a, b])  # must NOT raise
+    aoe = r["aoe"]
+    assert aoe["save_ability"] == "con"  # the full word 'constitution' resolved to the enum code
+    assert aoe["shared_damage"]["type"] == "cold"
+    assert len(aoe["targets"]) == 2
+    for foe in (a, b):  # each foe took the engine-resolved damage (full on fail / half on save)
+        assert server.get_character(cid, foe)["current_hp"] < 100


### PR DESCRIPTION
## The bug

`cast_spell(campaign_id, caster, "Bane", target_ids=[a, b])` **hard-crashed mid-cast** with
`ValueError: 'charisma' is not a valid Ability` at `server.py` (the AoE save-for-damage
resolver) — **after the spell slot was already spent**, leaving the campaign in a half-cast
state. Single-target Bane (`target_id=...`) was fine; only the multi-target path crashed.

Found by an adversarial review (2026-06-17). Pre-existing, but surfaced by the multi-target
rider work (#973) which began encouraging the `target_ids` path for Bless/Bane.

## Root cause — two orthogonal defects

**1. Bane is a debuff, not a damage spell.** Bane's tracked effect is the `-1d4` save/attack
rider. But its `srd524` record carries a **stray `damage_roll='1d4'`** (with empty
`damage_types`), so a `target_ids` cast wrongly entered the AoE *save-for-damage* path and
tried to roll area damage for a pure debuff.

**2. SRD save abilities are full words.** The AoE resolver fed the save ability straight to
`Ability(spec["save_ability"])`, but the `Ability` enum only knows the 3-letter codes
(`cha`, `con`, …) while **every** `srd524` record spells `saving_throw_ability` as the full
word (`charisma`, `constitution`, …). This is **not Bane-specific**: all ~68 SRD-only
save-for-damage spells (Cone of Cold, Cloudkill, Chain Lightning, Blight, …) crash the same
way on a multi-target cast.

## The fix (minimal, additive)

1. A curated buff/debuff (Bless / Bane / Shield of Faith / Shield — `combat.spell_effect_riders`)
   **skips the save-for-damage path entirely**. Its rider is already applied to every
   beneficiary and surfaced via `effect_riders`; the engine rolls **no** damage. → Bane via
   `target_ids` applies its `-1d4` save rider to each foe and deals no damage.
2. Reuse the existing `_parse_ability` helper (already accepts both the 3-letter code and the
   full word) at the AoE resolver instead of raw `Ability(...)`. → All SRD-only area
   save-for-damage spells resolve their full-word save ability instead of crashing.

Single-target casts and code-only/curated damage spells are byte-unchanged. The only behavior
change: the 4 rider spells cast via `target_ids` no longer emit an `aoe` result key (they
were never area-damage spells) — no test or caller depended on that.

## Tests (`servers/engine/tests/test_effect_riders.py`)

- `test_bane_via_target_ids_applies_rider_to_each_foe_and_deals_no_damage` — no crash; each
  foe gets the `-1d4` `save_bonus_dice` rider; each foe takes **no** damage; the `-1d4` bites
  on a foe's save. (RED before: `ValueError: 'charisma' …`)
- `test_srd_only_area_damage_spell_with_full_word_save_ability_resolves` — Cone of Cold (8d8
  cold, CON save) via `target_ids` resolves the save-for-half table; `save_ability == "con"`.
  (RED before: `ValueError: 'constitution' …`)

## Verification (local, single-process — CI is degraded repo-wide on an unrelated QA-taxonomy lane)

- `uv run --directory servers/engine python -m pytest -q -p no:xdist` → **2892 passed**
- `python3 scripts/license_check.py` → passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed spell resolution logic to correctly handle rider-based spells (Bane, Bless, Shield of Faith, Shield), preventing erroneous AoE damage application.
* Fixed spell casting compatibility with SRD records using full-word ability names in saving throw definitions, eliminating crashes during area damage spell resolution.

## Tests
* Added test coverage for rider spell behavior with multi-target casting.
* Added test coverage for area damage spells with alternative saving throw ability formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->