### PR TITLE
viewer(#972 defense-in-depth): strip OOC authoring-preamble leaks in sanitizeNarration

### DIFF
--- a/viewer/openworlds/screen-table.jsx
+++ b/viewer/openworlds/screen-table.jsx
@@ -13,6 +13,9 @@
 // #347 extends it with a SENTENCE-level pass that strips story-craft scaffolding (dice
 // tallies, plot-structure jargon, "beat complete" stage-directions) embedded mid-line —
 // see the `_isScaffoldingSentence` block below for the HIGH-CONFIDENCE-only patterns.
+// The #972-companion arm (`_AUTHORING_PREAMBLE`) extends that sentence-level pass to the
+// first-person OOC authoring-preamble family ("Now let me seat <X> as the player character",
+// "Continuity check — let me correct that") — the viewer backstop for the source fix in PR #972.
 const DM_ENGINE_TOOLS = [
   "remember", "recall", "recall_decisions", "log_event", "add_quest",
   "update_decision", "record_decision", "add_consequence", "check_consequences",
@@ -169,16 +172,56 @@ const _BEAT_TRANSITION = new RegExp(
     "\\bon to the next " + _STRUCT + "\\b" +
   ")", "i",
 );
-// True when a WHOLE sentence is plot-craft jargon or a stage-direction (drop the sentence).
-// The tally is handled separately (in-place excision), so it's NOT a whole-sentence-drop trigger.
+// (5) #972-companion / DEFENSE-IN-DEPTH: the first-person OOC AUTHORING-PREAMBLE family — the DM
+// agent "thinking out loud" as an author/operator ("Now let me seat <X> as the player character",
+// "Continuity check — let me correct that", "Let me set the order of it", "Here's how round one
+// actually went:", "let me set their advancement through the engine"). A 2026-06-17 craft audit
+// found these shipping to players verbatim. The PRIMARY fix landed at the SOURCE in PR #972 (the
+// DM SKILL.md FICTION-ONLY rule + the deterministic `narration_no_ooc_leak` gate in
+// qa/assert_behavioral.py). This viewer arm is the backstop for anything that still reaches the
+// chronicle (old transcripts, edge cases) — so the player never sees the seam.
+//
+// These patterns MIRROR qa/assert_behavioral.py::_NARRATION_LEAK byte-for-byte (the 5 authoring-
+// preamble arms; that file's 6th arm — `inciting incident` — is already covered above by
+// `_CRAFT_JARGON`, so it is not duplicated here). The two layers MUST stay consistent: keep this
+// in sync with `_NARRATION_LEAK` when either changes. As with the rest of this file, the arms are
+// HIGH-CONFIDENCE OOC-ONLY phrasings that never occur in in-character D&D fiction or dialogue, so a
+// clean beat is never stripped (the viewer DELETES the matched sentence, so it must be at least as
+// tight as the count-only gate). The gate's machine-checked FP-hardening is carried over verbatim:
+//   • `through the engine` is verb/noun-anchored to the game-ENGINE sense — a literal-machinery
+//     "Steam screamed through the engine block" (Gond/artificer/Steel-Watch fiction) MUST survive;
+//   • the seat arm is full-word "as the player character" only — a bare in-world "PC" initialism /
+//     "the player of the lute" MUST survive (the dropped `as the pc` collision);
+//   • the round-replay arm is anchored on "here's how round <n> … went" — a bare "round one went"
+//     in fiction MUST survive.
+const _AUTHORING_PREAMBLE = new RegExp(
+  "(?:" +
+    // "seat <X> as the player character" — full words only (never the bare "PC" initialism)
+    "\\bas the player character\\b|" +
+    // "<set their> advancement through the engine" — the game-ENGINE sense, not literal machinery
+    "\\b(?:advancement|leveling|progression|run it|route it|resolve it|process it" +
+      "|the (?:move|action|roll|turn)) through the engine\\b|" +
+    // first-person authoring self-correction
+    "\\bcontinuity check\\b|" +
+    // OOC combat-replay framing (round-anchored; a bare "round one went" is left alone)
+    "\\bhere'?s how round \\w+ (?:actually )?went\\b|" +
+    // OOC initiative / turn-ordering preamble
+    "\\blet me set the order of it\\b" +
+  ")", "i",
+);
+// True when a WHOLE sentence is plot-craft jargon, a stage-direction, or an OOC authoring preamble
+// (drop the sentence). The tally is handled separately (in-place excision), so it's NOT a
+// whole-sentence-drop trigger.
 function _isScaffoldingSentence(sentence) {
   const s = (sentence || "").trim();
   if (!s) return false;
-  return _CRAFT_JARGON.test(s) || _STAGE_DIRECTION.test(s) || _BEAT_TRANSITION.test(s);
+  return _CRAFT_JARGON.test(s) || _STAGE_DIRECTION.test(s) || _BEAT_TRANSITION.test(s)
+    || _AUTHORING_PREAMBLE.test(s);
 }
 function _hasScaffolding(text) {
   return _TALLY_TEST.test(text) || _CRAFT_JARGON.test(text)
-    || _STAGE_DIRECTION.test(text) || _BEAT_TRANSITION.test(text);
+    || _STAGE_DIRECTION.test(text) || _BEAT_TRANSITION.test(text)
+    || _AUTHORING_PREAMBLE.test(text);
 }
 // Clean scaffolding from one line, preserving the real prose. Two grains:
 //   1. excise dice/check TALLY phrases in place (keeps the rest of their sentence);

--- a/viewer/tests/test_sanitize_narration.py
+++ b/viewer/tests/test_sanitize_narration.py
@@ -254,6 +254,66 @@ class SanitizeNarrationTests(unittest.TestCase):
         self.assertEqual(out["mixed"], "The guard leans closer.\nThe rooftop hand tightens on the dart.")
         self.assertEqual(out["near_miss"], cases["near_miss"])
 
+    # DEFENSE-IN-DEPTH viewer arm for the 2026-06-17 craft audit (source fix: PR #972 — the DM
+    # SKILL.md FICTION-ONLY rule + the deterministic `narration_no_ooc_leak` gate in
+    # qa/assert_behavioral.py::_NARRATION_LEAK). The audit found the first-person OOC AUTHORING-
+    # PREAMBLE family shipping to players verbatim. These are the exact 5 leak lines; the viewer
+    # must strip them even from an old transcript the source fix never touched.
+    def test_strips_ooc_authoring_preamble_leaks(self):
+        cases = {
+            "seat_as_pc": "Now let me seat Rolan as the player character.",
+            "continuity_check": "Continuity check — let me correct that.",
+            "set_order": "Let me set the order of it.",
+            "round_replay": "Here's how round one actually went:",
+            "advancement_through_engine": "Now let me set their advancement through the engine.",
+        }
+        out = self._sanitize_many(cases)
+        for key in cases:
+            with self.subTest(case=key):
+                self.assertEqual(out[key], "")
+
+    def test_authoring_preamble_stripped_inline_and_in_multiline_beat(self):
+        # The audit also saw these land as a trailing CLAUSE inside a real line and as their own
+        # line inside an otherwise-real beat. The real prose around them must survive (sentence-
+        # surgical strip), mirroring the #347 scaffolding behavior.
+        cases = {
+            "trailing_clause": (
+                "Rolan squares his shoulders beneath the portcullis. "
+                "Now let me seat Rolan as the player character."
+            ),
+            "multiline_beat": (
+                "The lantern gutters as Rolan steps into the ring of torchlight.\n"
+                "Now let me set their advancement through the engine.\n"
+                "He draws his blade, eyes fixed on the cultist."
+            ),
+        }
+        out = self._sanitize_many(cases)
+        self.assertEqual(out["trailing_clause"], "Rolan squares his shoulders beneath the portcullis.")
+        self.assertNotIn("as the player character", out["multiline_beat"].lower())
+        self.assertNotIn("through the engine", out["multiline_beat"].lower())
+        self.assertIn("The lantern gutters", out["multiline_beat"])
+        self.assertIn("He draws his blade", out["multiline_beat"])
+
+    def test_authoring_preamble_guard_preserves_legitimate_fiction(self):
+        # The false-positive guard, mirroring _NARRATION_LEAK's FP-hardening notes: a literal-
+        # machinery "through the engine" (the bare form that wrongly matched Gond/artificer/Steel-
+        # Watch fiction — now verb/noun-anchored), an in-world "PC" / "the player" that is NOT
+        # "the player character" (the full-word hardening), and ordinary "let me …" dialogue must
+        # all pass through verbatim. Story quality is the north star — never strip real fiction.
+        legit = {
+            "engine_block": "Steam screamed through the engine block, and the boiler shrieked.",
+            "engine_housing": "The acolyte guided the brass rod through the engine housing.",
+            "introduce_dialogue": '"Let me introduce you to the captain," she said.',
+            "set_table_dialogue": '"Let me set the table," the innkeeper said with a tired smile.',
+            "player_of_lute": "She nodded as the player of the lute began a slow, sad air.",
+            "round_went": "Round one went badly for the goblins; two fled into the dark.",
+            "order_of_battle": "Let me see the order of battle before we ride, the captain muttered.",
+        }
+        out = self._sanitize_many(legit)
+        for key, original in legit.items():
+            with self.subTest(case=key):
+                self.assertEqual(out[key], original)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What

Defense-in-depth **viewer arm** for the 2026-06-17 craft audit's OOC **authoring-preamble** leak. Adds a high-confidence, OOC-only whole-sentence-drop (`_AUTHORING_PREAMBLE`) to `sanitizeNarration` in `viewer/openworlds/screen-table.jsx`, so the first-person DM "thinking out loud" lines the audit found shipping to players verbatim are stripped before the chronicle renders them:

- "Now let me seat \<X\> as the player character"
- "Continuity check — … let me correct that"
- "Let me set the order of it"
- "Here's how round one actually went:"
- "let me set their advancement through the engine"

## Why this, given #972 already shipped

The **primary** fix landed in **#972**: the DM `SKILL.md` FICTION-ONLY rule + the deterministic `narration_no_ooc_leak` gate in `qa/assert_behavioral.py::_NARRATION_LEAK` — that stops the leak **at the source** (the DM prompt). This PR is the **viewer backstop** for anything that still reaches the viewer (old transcripts, edge cases): the engine stays the sole writer; this is a read/projection filter only.

## How

- New `_AUTHORING_PREAMBLE` regex wired into the existing `_isScaffoldingSentence` (whole-sentence drop) + `_hasScaffolding` (fast path) — the same #347/#752 sentence-level machinery that already strips dice tallies / plot-craft jargon / stage-directions. Fully **additive**: no existing arm changed or weakened.
- Patterns **mirror `_NARRATION_LEAK` byte-for-byte** (the 5 authoring-preamble arms; the 6th — `inciting incident` — is already covered by the file's `_CRAFT_JARGON`, so it's not duplicated). A comment cross-references the gate and asks future edits to keep the two layers in sync.
- The viewer **deletes** the matched sentence (vs. the gate, which only counts), so it must be **at least as tight** as the gate. The gate's machine-checked FP-hardening is carried over verbatim:
  - `through the engine` is verb/noun-anchored to the game-ENGINE sense → literal machinery ("Steam screamed through the engine block") survives;
  - the seat arm is full-word `as the player character` only → a bare in-world "PC" / "the player of the lute" survives;
  - the round-replay arm is `here's how round <n> … went`-anchored → a bare "round one went" survives.

## Tests

3 new cases in `viewer/tests/test_sanitize_narration.py` (which transpile + run the **real shipped `.jsx`** via the bundled Babel):
- all 5 verbatim leaks → stripped to `""`;
- inline trailing-clause + multiline-beat → surgical strip (real prose survives);
- legit-fiction / dialogue FP guards → pass through verbatim.

**13/13** sanitize tests pass. Full `viewer/tests/` suite: **749 passed, 6 skipped**, 1 pre-existing env failure unrelated to this change (`test_portrait_gen` subprocess: `ModuleNotFoundError: No module named 'pydantic'`).

Lane: macOS/OpenWorlds (viewer). No engine/content changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed narration sanitization to remove out-of-character authoring preambles that were leaking into visible narrative text. Enhanced detection with additional sentence-level filtering rules.

* **Tests**
  * Added comprehensive test coverage verifying that authoring preambles are stripped correctly, including inline and multiline cases, while preserving legitimate narrative content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->