### PR TITLE
fix(engine): recasting a concentration spell on a new target frees the old target's orphaned child

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -6748,10 +6748,16 @@ def cast_spell(
             # effect registered below is authoritative). Do it BEFORE setting the field.
             displaced_conc = ch.concentration
             combat.expire_concentration_effects(ch)
-            # F3-6: a recast that DISPLACES a different prior concentration ends that spell —
-            # free its held victims NOW (e.g. the cleric drops Hold Person to cast Bless), not
-            # a round later. Skip when recasting the SAME spell (the fresh marker rewrites it).
-            if displaced_conc and displaced_conc != canonical:
+            # F3-6: displacing a prior concentration ends that spell — free its held victims NOW
+            # (e.g. the cleric drops Hold Person to cast Bless), not a round later. This fires
+            # even when RECASTING THE SAME spell, because the new cast targets a possibly-DIFFERENT
+            # set: a prior target that drops out of the new set (Bless on [a] then [b]) must be
+            # released here, or it keeps an orphaned linked child of a Bless it's no longer part
+            # of. The fresh children are re-registered below, so a same-target refresh frees-then-
+            # re-adds (idempotent); only targets dropped from the new set stay freed. The release
+            # never touches the caster's own twin — that is concentration-flagged (already expired
+            # just above), not a linked_to_concentration child.
+            if displaced_conc:
                 _release_held_targets(c, character_id, displaced_conc)
             ch.concentration = canonical  # replaces (breaks) any prior concentration
         # Register an engine-tracked timed effect so the spell auto-expires (instead of

--- a/servers/engine/tests/test_effect_riders.py
+++ b/servers/engine/tests/test_effect_riders.py
@@ -382,3 +382,34 @@ def test_srd_only_area_damage_spell_with_full_word_save_ability_resolves(tmp_pat
     assert len(aoe["targets"]) == 2
     for foe in (a, b):  # each foe took the engine-resolved damage (full on fail / half on save)
         assert server.get_character(cid, foe)["current_hp"] < 100
+
+
+# --- recasting a concentration spell on a NEW target frees the OLD target's orphaned child ---
+
+def test_recast_concentration_rider_on_new_target_frees_old_targets_child(tmp_path, monkeypatch):
+    # A caster concentrates on ONE Bless at a time, so casting Bless again ENDS the prior Bless.
+    # The first target's linked child must be released — not left orphaned. The bug: the
+    # concentration-displacement release fired only when the spell NAME changed, so a same-spell
+    # recast onto a DIFFERENT target left the old ally still carrying the +1d4 rider of a Bless
+    # it is no longer part of (it would keep rolling the engine d4 forever).
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("BlessRecast")["id"]
+    cleric = server.create_character(cid, "Pious", kind="player", class_name="Cleric",
+                                     level=1, apply_srd_defaults=True)["id"]
+    a = server.create_character(cid, "AllyA", kind="player", max_hp=30)["id"]
+    b = server.create_character(cid, "AllyB", kind="player", max_hp=30)["id"]
+    server.cast_spell(cid, cleric, "Bless", target_ids=[a])
+    assert [e for e in server.get_character(cid, a)["active_effects"] if e["name"] == "Bless"], \
+        "A should hold the first Bless"
+    # recast Bless on a DIFFERENT target — the caster can only concentrate on one Bless
+    server.cast_spell(cid, cleric, "Bless", target_ids=[b])
+    # B now holds the rider...
+    b_bless = [e for e in server.get_character(cid, b)["active_effects"] if e["name"] == "Bless"]
+    assert b_bless and b_bless[0]["save_bonus_dice"] == "1d4"
+    # ...and A's stale child is GONE — A is no longer part of the active Bless
+    a_bless = [e for e in server.get_character(cid, a)["active_effects"] if e["name"] == "Bless"]
+    assert a_bless == [], "A still carries a stale Bless rider after the recast moved to B"
+    # and the engine no longer rolls the +1d4 on A's save (A isn't blessed anymore)
+    _rig(monkeypatch, d20_natural=10, d4=3)
+    out = server.saving_throw(cid, a, "wis", dc=12)
+    assert "bonus_dice" not in out, "A's save still got an orphaned Bless d4"


### PR DESCRIPTION
## The bug

A caster concentrates on **one** spell at a time, so casting Bless (or any concentration rider
spell) again **ends** the prior instance. But the concentration-displacement release in
`cast_spell` only fired when the spell **name** changed (`displaced_conc != canonical`), so a
**same-spell recast onto a different target set** left the dropped target carrying an orphaned
linked child:

```
cast Bless target_ids=[a]   -> A holds the +1d4 child
cast Bless target_ids=[b]   -> B holds the child, but A KEEPS its stale child
```

A then kept rolling the engine `+1d4` on its saves/attacks **forever**, for a Bless it is no
longer part of. Pre-existing; found by the 2026-06-17 adversarial review alongside the Bane AoE
crash fixed in #978.

> Note: the same review's "AoE concentration auto-fail frees all children" item was **confirmed
> correct** (already covered by `_release_held_targets` + existing tests) — not a bug, not touched
> here.

## Root cause

`_release_held_targets` correctly sweeps every `linked_to_concentration` child of a caster's
ended concentration — but it was gated behind `displaced_conc != canonical`. The author assumed
the refresh-not-stack logic covered a same-spell recast, but that only rewrites the **new** target
set; a target that **drops out** of the new set is never revisited.

## The fix (one line + comment)

Release prior held targets whenever concentration is displaced, **including a same-spell recast**.
The fresh children are re-registered just below, so:
- a same-**target** refresh frees-then-re-adds (idempotent — verified by the existing refresh tests);
- only targets **dropped** from the new set stay freed.

The release never touches the caster's own twin: that effect is `concentration`-flagged (already
expired one line above by `expire_concentration_effects`), not a `linked_to_concentration` child,
so it is outside `_release_held_targets`'s match.

## Test (`servers/engine/tests/test_effect_riders.py`)

`test_recast_concentration_rider_on_new_target_frees_old_targets_child` — cast Bless on `[a]`,
recast on `[b]`: B holds the rider; **A's child is gone**; A's save no longer gets the orphaned
`+1d4`. (RED before: A retained `attack_bonus_dice: '1d4'`.)

## Verification (local, single-process — CI is degraded repo-wide on an unrelated QA-taxonomy lane)

- `uv run --directory servers/engine python -m pytest -q -p no:xdist` -> **2893 passed**
- `python3 scripts/license_check.py` -> passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concentration spell recasting issue where effects from previous targets were not properly removed when the spell was recast on different targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->