### PR TITLE
qa: real known-RED corpus fixture for narration_no_ooc_leak (replaces #977 TODO)

### DIFF
--- a/qa/gate_corpus/builder.py
+++ b/qa/gate_corpus/builder.py
@@ -44,6 +44,7 @@ REAL_RED_PROVENANCE = {
     "dice_used": "openworlds-c2-234542 (roll=attack=save=social=skill_check=0)",
     "player_in_party": "ow-duoF-112226, ow-rv1-134258, ow-swA-123842 (party=1 players=0)",
     "dm_voices_characters": "ow-rv1-134258 (0/9 DM turns with quoted dialogue, companion present)",
+    "narration_no_ooc_leak": "2026-06-17 craft audit (#972): 5+ first-person OOC authoring preambles in a 4.6-prose run, un-gated, inflated the LLM story score to 4.8",
 }
 
 
@@ -133,6 +134,36 @@ def case_dm_produced_output():
     # also necessarily trips dice_used + player_in_party; the corpus asserts the EXPECTED check
     # APPEARS among the fails, which is the faithful semantic for a dead run.)
     return [], {"party": [], "characters": {}}, None, None
+
+
+def case_narration_no_ooc_leak():
+    # chk 1b: player-facing DM prose leaks OUT-OF-CHARACTER craft-scaffolding. FATAL when
+    # n_leak >= 3 AND dm_text >= MIN_BEATS(6) — a pervasively-broken player surface. Models the
+    # 2026-06-17 craft audit (#972): first-person authoring preambles in a 4.6-prose run, entirely
+    # un-gated, inflated the LLM story score to 4.8. A clean `roll` keeps dice_used passing; NO
+    # companion so dm_voices_characters stays inert; the baseline state (day=2, 2 visited, xp>0)
+    # keeps the world/xp floors passing at session_beats==dm_text; no chat/moves -> the facade lane
+    # is inert; 6 (< STRUCTURAL_MIN_BEATS=10) beats + no companion -> structural_completeness inert.
+    # 6 DM text beats (== MIN_BEATS), 4 of them leaking the exact OOC patterns _NARRATION_LEAK_RE
+    # bans, so narration_no_ooc_leak is the SOLE fatal fail.
+    texts = [
+        # leak: "as the player character"
+        "Now let me seat Dal Lightspark as the player character and open on the tavern.",
+        # clean in-fiction prose (scores 0 leaks)
+        "Rain hammers the shutters of the Elfsong Tavern as you shoulder inside, the common room "
+        "thick with pipe-smoke and low talk.",
+        # leak: "continuity check"
+        "Continuity check — let me correct that: the barkeep already named the missing caravan a moment ago.",
+        # clean in-fiction prose (quoted dialogue; no companion present, so dm_voices stays inert)
+        "The barkeep leans close, her voice dropping. \"You're asking after the caravan? Bad "
+        "business, that — three nights gone now.\"",
+        # leak: "inciting incident"
+        "This is the inciting incident of the arc, so I'll raise the stakes before the scene turns.",
+        # leak: "here's how round <n> actually went"
+        "Here's how round one actually went: the cutpurse moved first and the lantern guttered out.",
+    ]
+    events = _roll() + [_assistant_text(t) for t in texts]
+    return events, _clean_player_state(), None, None
 
 
 def case_both_sides_acted():
@@ -349,6 +380,7 @@ def case_xp_awarded_on_progression():
 _CASES_SPEC: list[tuple] = [
     ("dm_produced_output", case_dm_produced_output, "dm_produced_output",
      "a truly dead/blank run necessarily also trips dice_used + player_in_party"),
+    ("narration_no_ooc_leak", case_narration_no_ooc_leak, "narration_no_ooc_leak"),
     ("both_sides_acted", case_both_sides_acted, "both_sides_acted"),
     ("player_turns_structured", case_player_turns_structured, "player_turns_structured"),
     ("dm_voices_characters", case_dm_voices_characters, "dm_voices_characters"),

--- a/qa/gate_corpus/cases/narration_no_ooc_leak/run.jsonl
+++ b/qa/gate_corpus/cases/narration_no_ooc_leak/run.jsonl
@@ -1,0 +1,8 @@
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "t_roll", "name": "mcp__engine__roll", "input": {"sides": 20}}]}}
+{"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": "t_roll", "content": [{"type": "text", "text": "{\"total\": 14}"}], "is_error": false}]}}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "Now let me seat Dal Lightspark as the player character and open on the tavern."}]}}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "Rain hammers the shutters of the Elfsong Tavern as you shoulder inside, the common room thick with pipe-smoke and low talk."}]}}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "Continuity check \u2014 let me correct that: the barkeep already named the missing caravan a moment ago."}]}}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "The barkeep leans close, her voice dropping. \"You're asking after the caravan? Bad business, that \u2014 three nights gone now.\""}]}}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "This is the inciting incident of the arc, so I'll raise the stakes before the scene turns."}]}}
+{"type": "assistant", "message": {"content": [{"type": "text", "text": "Here's how round one actually went: the cutpurse moved first and the lantern guttered out."}]}}

--- a/qa/gate_corpus/cases/narration_no_ooc_leak/state.json
+++ b/qa/gate_corpus/cases/narration_no_ooc_leak/state.json
@@ -1,0 +1,27 @@
+{
+  "party": [
+    "pc1"
+  ],
+  "leveling_mode": "xp",
+  "day": 2,
+  "time_of_day": "evening",
+  "current_location_id": "loc_camp",
+  "characters": {
+    "pc1": {
+      "name": "Dal",
+      "kind": "player",
+      "xp": 300,
+      "location_id": "loc_camp"
+    }
+  },
+  "locations": {
+    "loc_start": {
+      "name": "Tavern",
+      "visited": true
+    },
+    "loc_camp": {
+      "name": "Camp",
+      "visited": true
+    }
+  }
+}

--- a/qa/gate_corpus/manifest.json
+++ b/qa/gate_corpus/manifest.json
@@ -13,6 +13,15 @@
       "multi_fatal_reason": "a truly dead/blank run necessarily also trips dice_used + player_in_party"
     },
     {
+      "case_dir": "narration_no_ooc_leak",
+      "expected_red_check": "narration_no_ooc_leak",
+      "artifacts": [
+        "run.jsonl",
+        "state.json"
+      ],
+      "real_red_provenance": "2026-06-17 craft audit (#972): 5+ first-person OOC authoring preambles in a 4.6-prose run, un-gated, inflated the LLM story score to 4.8"
+    },
+    {
       "case_dir": "both_sides_acted",
       "expected_red_check": "both_sides_acted",
       "artifacts": [
@@ -178,12 +187,6 @@
         "state.json"
       ],
       "real_red_provenance": ""
-    },
-    {
-      "case_dir": "TODO__narration_no_ooc_leak",
-      "expected_red_check": "narration_no_ooc_leak",
-      "todo": true,
-      "reason": "no faithful minimal fixture constructed yet (auto-flagged by builder)"
     }
   ]
 }


### PR DESCRIPTION
## Follow-up to #977
#977 closed the gate-corpus coverage gap for `narration_no_ooc_leak` with a **TODO placeholder** (the canonical builder auto-flag). That satisfied the coverage audit but left the anti-goalpost corpus *not actually exercising* the check's RED path — so a future edit that weakened `_NARRATION_LEAK_RE` or the `n_leak>=3 / dm_text>=MIN_BEATS` fatal threshold would slip past the corpus (only `test_assert_behavioral.py` would catch it).

This replaces the TODO with a **faithful minimal known-RED fixture**, modeled on the real 2026-06-17 craft audit (#972).

## The fixture (`qa/gate_corpus/cases/narration_no_ooc_leak/`)
6 DM text beats (`== MIN_BEATS`), **4 leaking** the exact OOC patterns the gate bans, 2 clean in-fiction beats:
- `as the player character` · `continuity check` · `inciting incident` · `here's how round one actually went`

**Isolation** (so the per-case corpus test's `failed == {expected}` holds): a clean `roll` keeps `dice_used` green; no companion keeps `dm_voices_characters` inert; baseline state (day=2, 2 visited, xp>0) passes the world/xp floors; no chat/moves keeps the facade lane inert; 6 (<10) beats + no companion keeps `structural_completeness` inert.

## Verification
Gate run directly on the fixture:
```
RED: 1 behavioral assertion(s) FAILED.
  [FAIL] narration_no_ooc_leak — 4 player-facing beat(s) leaked OOC craft-scaffolding/bookkeeping/system-vocab — e.g. 'Now let me seat Dal Lightspark as the player character...' [pervasive => RED]
```
Exactly one FATAL, fully isolated.

```
$ uv run --directory servers/engine python -m pytest \
    ../../qa/test_behavioral_gate_corpus.py ../../qa/test_root_cause_analyzer.py -q -p no:xdist
39 passed   # was 38 passed + 1 skipped (the TODO is now a real, exercised case)
```

Builder regeneration is deterministic — **zero churn** to the other 18 fixtures (diff is the new case dir + the manifest TODO→real-case swap + the generator). `assert_behavioral.py` untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for narration validation scenarios to improve quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->