### PR TITLE
chore(rename P2): flip env-var writers to WORLDOS_*; bi-name direct readers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         run: uv run --directory servers/engine --group dev pytest -q --cov=. --cov-report=term-missing
       - name: Rules tests
         env:
-          CLAWDND_RULES_OFFLINE: "1"
+          WORLDOS_RULES_OFFLINE: "1"
         run: uv run --directory servers/rules --group dev pytest -q --cov=. --cov-report=term-missing
       - name: Voice tests (torch-free; null backend + static metadata)
         run: uv run --directory servers/voice --group dev pytest -q --cov=. --cov-report=term-missing
@@ -123,11 +123,11 @@ jobs:
         uses: astral-sh/setup-uv@v5
       - name: Sync rules venv (rapidfuzz/httpx for the offline rules worker)
         env:
-          CLAWDND_RULES_OFFLINE: "1"
+          WORLDOS_RULES_OFFLINE: "1"
         run: uv sync --directory servers/rules
       - name: Cross-service MCP contract tests
         env:
-          CLAWDND_RULES_OFFLINE: "1"
+          WORLDOS_RULES_OFFLINE: "1"
         run: uv run --directory servers/engine --group dev python -m pytest -q -p no:xdist ../../servers/integration_tests
 
   license-check:

--- a/.github/workflows/nightly-quality-loop.yml
+++ b/.github/workflows/nightly-quality-loop.yml
@@ -3,7 +3,7 @@ name: Nightly Quality Loop
 # The STANDING fitness cadence the harness lacked: qa/loop.sh (the recursive-improvement
 # loop gate) is never scheduled today, so a post-release regression in story-craft /
 # mechanical quality has nothing watching for it. This workflow runs the loop on a nightly
-# cron (plus on-demand) against the north-star thresholds (CLAWDND_STORY_MIN / CLAWDND_MECH_MIN).
+# cron (plus on-demand) against the north-star thresholds (WORLDOS_STORY_MIN / WORLDOS_MECH_MIN).
 #
 # The duo path (qa/run_duo.sh) cold-opens a real `claude -p` DM+player, so it needs a live
 # model key. That key is provided as the repository secret ANTHROPIC_API_KEY:
@@ -54,8 +54,8 @@ jobs:
     continue-on-error: true
     env:
       # North-star thresholds the loop gates against (defaults mirror qa/loop.sh).
-      CLAWDND_STORY_MIN: "4.3"
-      CLAWDND_MECH_MIN: "4.5"
+      WORLDOS_STORY_MIN: "4.3"
+      WORLDOS_MECH_MIN: "4.5"
       # K small (2 duos) for a nightly cadence; overridable on manual dispatch.
       LOOP_RUNS: ${{ github.event.inputs.runs || '2' }}
       LOOP_BEATS: ${{ github.event.inputs.beats || '8' }}
@@ -94,7 +94,7 @@ jobs:
           echo "[selfcheck] loop gate + worker are present and executable"
           test -x qa/loop.sh
           test -x qa/run_duo.sh
-          echo "[selfcheck] north-star thresholds resolve: story>=${CLAWDND_STORY_MIN} mech>=${CLAWDND_MECH_MIN}"
+          echo "[selfcheck] north-star thresholds resolve: story>=${WORLDOS_STORY_MIN} mech>=${WORLDOS_MECH_MIN}"
           # jq is the loop's scorecard tool; ubuntu-latest ships it, but assert it explicitly so a
           # runner-image change can't silently neuter the loop's scoring.
           command -v jq >/dev/null || { echo "::error title=Nightly Quality Loop::jq missing on runner"; exit 1; }

--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -52,7 +52,7 @@ jobs:
     # harness hiccup) from going red — the warning annotation + uploaded scorecards carry the signal.
     continue-on-error: true
     env:
-      # RELAXED PR thresholds (looser than the nightly north-star CLAWDND_STORY_MIN/MECH_MIN of
+      # RELAXED PR thresholds (looser than the nightly north-star WORLDOS_STORY_MIN/MECH_MIN of
       # 4.3/4.5) so a single PR duo isn't flagged over scorer noise. Below these -> soft warning.
       QG_STORY_MIN: "4.0"
       QG_MECH_MIN: "4.2"
@@ -101,7 +101,7 @@ jobs:
           tmp="$(mktemp -d)"
           printf '# transcript\n' > "$tmp/t.md"
           printf '{}\n'           > "$tmp/state.json"
-          CLAWDND_SCORE_GUARD_ONLY=1 bash qa/score.sh \
+          WORLDOS_SCORE_GUARD_ONLY=1 bash qa/score.sh \
             "$tmp/t.md" "$tmp/state.json" qa/rubric.md qa/score_schema.json "$tmp/out.json" 0.01
           test -s "$tmp/out.json"
           rm -rf "$tmp"

--- a/.mcp.json
+++ b/.mcp.json
@@ -16,7 +16,7 @@
       "command": "uv",
       "args": ["run", "--directory", "${CLAUDE_PLUGIN_ROOT}/servers/voice", "--group", "kokoro", "server.py"],
       "env": {
-        "CLAWDND_TTS_BACKEND": "kokoro"
+        "WORLDOS_TTS_BACKEND": "kokoro"
       }
     }
   }

--- a/commands/voice-toggle.md
+++ b/commands/voice-toggle.md
@@ -4,10 +4,10 @@ argument-hint: "[on|off] (optional; toggles if omitted)"
 ---
 The player wants to change voice output: $ARGUMENTS
 
-WorldOS's voice backend is chosen when the MCP servers launch (`CLAWDND_TTS_BACKEND` — `kokoro` for spoken audio, `null` for silent/text-only), so you can't relaunch it mid-session. Honor this as a **session preference**:
+WorldOS's voice backend is chosen when the MCP servers launch (`WORLDOS_TTS_BACKEND` — `kokoro` for spoken audio, `null` for silent/text-only), so you can't relaunch it mid-session. Honor this as a **session preference**:
 
 - **off / silent:** stop calling `clawdnd-voice` `speak`. Keep narrating and voicing characters in **text only**, still labeling each speaker so the player knows who's talking. Confirm voice is off.
-- **on / voiced:** resume calling `clawdnd-voice` `speak(text, voice_id)` for narration, NPCs, and the companion in their own voices. If the active backend is `null`, tell the player to set `CLAWDND_TTS_BACKEND=kokoro` and restart the session for actual audio.
+- **on / voiced:** resume calling `clawdnd-voice` `speak(text, voice_id)` for narration, NPCs, and the companion in their own voices. If the active backend is `null`, tell the player to set `WORLDOS_TTS_BACKEND=kokoro` and restart the session for actual audio.
 - **no argument:** flip the current preference.
 
 This is the reliable text fallback the experience promises — the game stays fully playable with voice off.

--- a/qa/dry_run_gate_fix.sh
+++ b/qa/dry_run_gate_fix.sh
@@ -33,8 +33,8 @@ cd "$ROOT" || exit 3
 RUNS=3
 GATE_KIND="combat-sprint"
 # Combat-sprint is mech-focused (Angry-DM 5e fidelity). Match loop.sh's published north-star bars.
-MECH_MIN="${CLAWDND_MECH_MIN:-4.5}"
-STORY_MIN="${CLAWDND_STORY_MIN:-4.3}"
+MECH_MIN="${WORLDOS_MECH_MIN:-${CLAWDND_MECH_MIN:-4.5}}"
+STORY_MIN="${WORLDOS_STORY_MIN:-${CLAWDND_STORY_MIN:-4.3}}"
 DO_REGRESS=0
 DB_PATH="qa/scores.db"        # default ONLY used when --regress is given; tests always pass a temp --db
 BASELINE_KEY=""               # comma k=v list folded into the candidate JSON for detect_regression

--- a/qa/loop.sh
+++ b/qa/loop.sh
@@ -11,14 +11,14 @@
 # behavioral gate, echoing `behavioral=GREEN|RED`); this wraps K of them and gates.
 #
 # Usage: qa/loop.sh [runs] [world] [persona] [beats] [budget-per-call]
-# Env:   CLAWDND_STORY_MIN (default 4.3)  CLAWDND_MECH_MIN (default 4.5)
+# Env:   WORLDOS_STORY_MIN (default 4.3)  WORLDOS_MECH_MIN (default 4.5)
 # Exit:  0 = all runs clear the bar; 1 = at least one below (RED); 2 = nothing ran.
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 2
 
 RUNS="${1:-2}"; WORLD="${2:-baldurs-gate}"; PERSONA="${3:-qa/play_player_duo.txt}"
 BEATS="${4:-8}"; BUDGET="${5:-1.20}"
-STORY_MIN="${CLAWDND_STORY_MIN:-4.3}"; MECH_MIN="${CLAWDND_MECH_MIN:-4.5}"
+STORY_MIN="${WORLDOS_STORY_MIN:-${WORLDOS_STORY_MIN:-4.3}}"; MECH_MIN="${WORLDOS_MECH_MIN:-${WORLDOS_MECH_MIN:-4.5}}"
 STAMP="$(date +%y%m%d-%H%M%S)"; T="qa/transcripts"
 mkdir -p "$T"
 

--- a/qa/qa.mcp.example.json
+++ b/qa/qa.mcp.example.json
@@ -23,7 +23,7 @@
         "server.py"
       ],
       "env": {
-        "CLAWDND_RULES_OFFLINE": "1"
+        "WORLDOS_RULES_OFFLINE": "1"
       }
     },
     "clawdnd-voice": {
@@ -36,7 +36,7 @@
         "server.py"
       ],
       "env": {
-        "CLAWDND_TTS_BACKEND": "null"
+        "WORLDOS_TTS_BACKEND": "null"
       }
     }
   }

--- a/qa/score.sh
+++ b/qa/score.sh
@@ -57,11 +57,11 @@ stamp_prompt_hash() {
 }
 
 # --- test-only dry-run hook (additive; unset == today) ---------------------------------
-# CLAWDND_SCORE_GUARD_ONLY=1 runs all guards + emits the hashed artifact, then exits 0
+# WORLDOS_SCORE_GUARD_ONLY=1 runs all guards + emits the hashed artifact, then exits 0
 # BEFORE the live `claude -p` loop. This keeps the determinism test gateway-free / offline
 # (it never touches Eva, the gateway, or any LLM). In normal use this is unset and the
 # script behaves exactly as before.
-if [ "${CLAWDND_SCORE_GUARD_ONLY:-}" = "1" ]; then
+if [ "${WORLDOS_SCORE_GUARD_ONLY:-${CLAWDND_SCORE_GUARD_ONLY:-}}" = "1" ]; then
   printf '{}\n' > "$OUT"
   stamp_prompt_hash "$OUT"
   exit 0

--- a/qa/test_score_determinism.py
+++ b/qa/test_score_determinism.py
@@ -13,7 +13,7 @@ Covers the two ADDITIVE hardening features layered onto score.sh:
       JSON so rubric/template drift is detectable across versions. The hash is produced by
       qa/_score_prompt_hash.py, which both score.sh and this test call.
 
-The shell-behavior tests use CLAWDND_SCORE_GUARD_ONLY=1 — an additive, test-only dry-run
+The shell-behavior tests use WORLDOS_SCORE_GUARD_ONLY=1 — an additive, test-only dry-run
 hook that makes score.sh run all guards + emit the hashed artifact, then exit 0 BEFORE the
 `claude -p` loop. So nothing here ever touches a live LLM, the gateway, Eva, or global mcp
 config. The guard-failure path doesn't even reach that hook (it errors first), so the
@@ -75,7 +75,7 @@ def _run_score(inputs: dict, env_overrides: dict, guard_only: bool = True) -> su
         "HOME": os.environ.get("HOME", "/tmp"),
     }
     if guard_only:
-        env["CLAWDND_SCORE_GUARD_ONLY"] = "1"
+        env["WORLDOS_SCORE_GUARD_ONLY"] = "1"
     env.update(env_overrides)
     return subprocess.run(
         [

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -201,10 +201,10 @@ cfg = {"mcpServers": {
         "env": {"WORLDOS_STATE_DIR": state_dir, "CLAWDND_STATE_DIR": state_dir}},
     "clawdnd-rules": {"type": "stdio", "command": "uv",
         "args": ["run", "--directory", f"{root}/servers/rules", "server.py"],
-        "env": {"CLAWDND_RULES_OFFLINE": "1"}},
+        "env": {"WORLDOS_RULES_OFFLINE": "1"}},
     "clawdnd-voice": {"type": "stdio", "command": "uv",
         "args": ["run", "--directory", f"{root}/servers/voice", "server.py"],
-        "env": {"CLAWDND_TTS_BACKEND": "null"}},
+        "env": {"WORLDOS_TTS_BACKEND": "null"}},
 }}
 json.dump(cfg, open(out, "w"))
 PY

--- a/scripts/play_codex_dm.sh
+++ b/scripts/play_codex_dm.sh
@@ -178,13 +178,13 @@ servers = [
         "clawdnd-rules",
         f"{root}/servers/rules",
         "server.py",
-        {"CLAWDND_RULES_OFFLINE": "1"},
+        {"WORLDOS_RULES_OFFLINE": "1"},
     ),
     (
         "clawdnd-voice",
         f"{root}/servers/voice",
         "server.py",
-        {"CLAWDND_TTS_BACKEND": "null"},
+        {"WORLDOS_TTS_BACKEND": "null"},
     ),
 ]
 lines = []
@@ -347,8 +347,8 @@ validate_codex_service_tier
 
 export CLAWDND_STATE_DIR="$RUN_DIR"
 export WORLDOS_STATE_DIR="$RUN_DIR"
-export CLAWDND_RULES_OFFLINE=1
-export CLAWDND_TTS_BACKEND=null
+export WORLDOS_RULES_OFFLINE=1
+export WORLDOS_TTS_BACKEND=null
 
 HERO_CAMP=""
 HERO_PC_ID=""
@@ -737,12 +737,12 @@ _codex_exec_once() {
     -c "mcp_servers.clawdnd-engine.default_tools_approval_mode=\"approve\"" \
     -c "mcp_servers.clawdnd-rules.command=\"uv\"" \
     -c "mcp_servers.clawdnd-rules.args=[\"run\",\"--directory\",\"$ROOT/servers/rules\",\"python\",\"server.py\"]" \
-    -c "mcp_servers.clawdnd-rules.env_vars=[\"CLAWDND_RULES_OFFLINE\"]" \
+    -c "mcp_servers.clawdnd-rules.env_vars=[\"WORLDOS_RULES_OFFLINE\"]" \
     -c "mcp_servers.clawdnd-rules.required=true" \
     -c "mcp_servers.clawdnd-rules.default_tools_approval_mode=\"approve\"" \
     -c "mcp_servers.clawdnd-voice.command=\"uv\"" \
     -c "mcp_servers.clawdnd-voice.args=[\"run\",\"--directory\",\"$ROOT/servers/voice\",\"python\",\"server.py\"]" \
-    -c "mcp_servers.clawdnd-voice.env_vars=[\"CLAWDND_TTS_BACKEND\"]" \
+    -c "mcp_servers.clawdnd-voice.env_vars=[\"WORLDOS_TTS_BACKEND\"]" \
     -c "mcp_servers.clawdnd-voice.required=true" \
     -c "mcp_servers.clawdnd-voice.default_tools_approval_mode=\"approve\"" \
     - < "$PROMPT_FILE" \

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -192,10 +192,10 @@ cfg = {"mcpServers": {
         "env": {"WORLDOS_STATE_DIR": state_dir, "CLAWDND_STATE_DIR": state_dir}},
     "clawdnd-rules": {"type": "stdio", "command": "uv",
         "args": ["run", "--directory", f"{root}/servers/rules", "server.py"],
-        "env": {"CLAWDND_RULES_OFFLINE": "1"}},
+        "env": {"WORLDOS_RULES_OFFLINE": "1"}},
     "clawdnd-voice": {"type": "stdio", "command": "uv",
         "args": ["run", "--directory", f"{root}/servers/voice", "server.py"],
-        "env": {"CLAWDND_TTS_BACKEND": "null"}},
+        "env": {"WORLDOS_TTS_BACKEND": "null"}},
 }}
 json.dump(cfg, open(out, "w"))
 PY

--- a/servers/integration_tests/conftest.py
+++ b/servers/integration_tests/conftest.py
@@ -15,7 +15,7 @@ in-process (the suite runs under the engine venv, per the sprint spec):
     imports the rules ``server`` once, and answers JSON line-protocol requests
     over stdin/stdout. One process for the whole session keeps it fast
     (~0.3s cold, then near-instant) and single-process from the host's view —
-    no xdist, no per-test spawn. ``CLAWDND_RULES_OFFLINE=1`` is set in its env
+    no xdist, no per-test spawn. ``WORLDOS_RULES_OFFLINE=1`` is set in its env
     exactly as the rules suite does, so it never touches the network.
 
 The engine is the SOLE WRITER of state and the player facade is READ-ONLY; this
@@ -54,7 +54,7 @@ def voice_server(monkeypatch_session):
     NULL TTS backend so no audio / PyTorch is ever touched (CI-safe)."""
     # Force the null backend before the module (and any lazy backend build) runs.
     monkeypatch_session.setenv("WORLDOS_TTS_BACKEND", "null")
-    monkeypatch_session.setenv("CLAWDND_TTS_BACKEND", "null")
+    monkeypatch_session.setenv("WORLDOS_TTS_BACKEND", "null")
     # The voice package uses `pythonpath = ["."]`; mirror that so `import server`,
     # `import registry`, `from _env import ...`, `from interface import ...`
     # resolve to the voice package, not the engine one.
@@ -188,7 +188,7 @@ def rules_client():
     if not RULES_VENV_PY.exists():
         pytest.skip(f"rules venv python not found at {RULES_VENV_PY}")
     env = dict(os.environ)
-    env["CLAWDND_RULES_OFFLINE"] = "1"   # offline, exactly as the rules suite sets it
+    env["WORLDOS_RULES_OFFLINE"] = "1"   # offline, exactly as the rules suite sets it
     env["WORLDOS_RULES_OFFLINE"] = "1"   # canonical name too (no deprecation noise)
     env["PYTHONUNBUFFERED"] = "1"
     proc = subprocess.Popen(

--- a/servers/integration_tests/test_server_contracts.py
+++ b/servers/integration_tests/test_server_contracts.py
@@ -189,7 +189,7 @@ class TestVoiceContract:
             def speak(self, *a, **k):
                 raise ImportError("kokoro/torch unavailable")
 
-        monkeypatch.setenv("CLAWDND_TTS_BACKEND", "kokoro")
+        monkeypatch.setenv("WORLDOS_TTS_BACKEND", "kokoro")
         monkeypatch.setenv("WORLDOS_TTS_BACKEND", "kokoro")
         monkeypatch.setitem(voice_server._backends, "kokoro", Boom())
         out = voice_server.speak("The dragon roars.", voice_id="narrator-dm", play=False)

--- a/servers/rules/server.py
+++ b/servers/rules/server.py
@@ -22,7 +22,7 @@ preserved under ``_starter`` so the curated engine fields are never lost. Every
 full-set entry also carries its untouched upstream record under ``_open5e``.
 
 The live dnd5eapi.co fallback still covers anything absent from both layers. Set
-CLAWDND_RULES_OFFLINE=1 to disable network lookups (used in CI).
+WORLDOS_RULES_OFFLINE=1 to disable network lookups (used in CI).
 """
 
 from __future__ import annotations

--- a/servers/rules/tests/test_rules.py
+++ b/servers/rules/tests/test_rules.py
@@ -6,7 +6,7 @@ import server
 @pytest.fixture(autouse=True)
 def offline(monkeypatch):
     # Never hit the network in tests; exercise only the bundled SRD data.
-    monkeypatch.setenv("CLAWDND_RULES_OFFLINE", "1")
+    monkeypatch.setenv("WORLDOS_RULES_OFFLINE", "1")
     yield
 
 

--- a/servers/voice/adapters/elevenlabs.py
+++ b/servers/voice/adapters/elevenlabs.py
@@ -1,7 +1,7 @@
 """ElevenLabs TTS backend (placeholder for Epic 10).
 
 The interface matches the Kokoro backend, so switching is a config change
-(CLAWDND_TTS_BACKEND=elevenlabs) once this is implemented. Until then it fails
+(WORLDOS_TTS_BACKEND=elevenlabs) once this is implemented. Until then it fails
 gracefully so selecting it never crashes the server.
 """
 
@@ -25,5 +25,5 @@ class ElevenLabsBackend:
             backend=self.name,
             backend_voice=backend_voice,
             text=text,
-            detail="ElevenLabs backend not yet implemented (use CLAWDND_TTS_BACKEND=kokoro)",
+            detail="ElevenLabs backend not yet implemented (use WORLDOS_TTS_BACKEND=kokoro)",
         )

--- a/servers/voice/server.py
+++ b/servers/voice/server.py
@@ -3,7 +3,7 @@
 A swappable voice layer with two directions:
 
   - text-to-speech: speak(text, voice_id) -> a backend selected by
-    CLAWDND_TTS_BACKEND synthesizes and plays audio. Each character/NPC carries
+    WORLDOS_TTS_BACKEND synthesizes and plays audio. Each character/NPC carries
     a logical voice_id; the registry resolves it to the active backend's real
     voice, so switching Kokoro -> ElevenLabs never touches character data.
   - speech-to-text: transcribe(audio_path) -> a backend selected by

--- a/servers/voice/tests/test_voice.py
+++ b/servers/voice/tests/test_voice.py
@@ -55,7 +55,7 @@ def test_issue55_tts_failure_falls_back_to_text_only(monkeypatch):
         def speak(self, *a, **k):
             raise ImportError("kokoro unavailable")
 
-    monkeypatch.setenv("CLAWDND_TTS_BACKEND", "kokoro")
+    monkeypatch.setenv("WORLDOS_TTS_BACKEND", "kokoro")
     monkeypatch.setitem(server._backends, "kokoro", Boom())
     out = server.speak("hello")
     assert out["backend"] == "null" and out["audio_path"] is None and out["ok"] is True

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -7256,7 +7256,7 @@ def _read_chat(since: int) -> tuple[list[dict], int]:
 # on. `uv run --directory servers/voice` gives us the right interpreter + deps +
 # import path (cwd-relative `import registry` / `from adapters... import` resolve
 # there, exactly as the voice server itself and playtest_voice.py do). The backend
-# is selected by CLAWDND_TTS_BACKEND, mirroring servers/voice/server.py._get_backend.
+# is selected by WORLDOS_TTS_BACKEND, mirroring servers/voice/server.py._get_backend.
 
 # Runs in the voice server's environment. Selects the backend the same way the voice
 # server does, speaks one line (play=True ⇒ afplay on macOS), and prints ONE compact


### PR DESCRIPTION
## Phase 2 of the ClawDnD→WorldOS cutover — env-var writers

The engine/rules/voice servers already READ env vars through the `WORLDOS_*`→`CLAWDND_*`
shim (`servers/*/_env.py`, validated by `test_env_compat.py`). This phase flips the
remaining **writers** to emit the canonical `WORLDOS_*`, and upgrades the few **direct**
shell readers to accept both.

### Non-breaking by construction
- **Shim-backed readers** (servers): flipping `.mcp.json` / CI / play-script env-blocks to `WORLDOS_*` is transparent (server reads `WORLDOS_` first, `CLAWDND_` fallback).
- **Direct shell readers made bi-name** (additive — legacy override still works):
  - `qa/loop.sh`, `qa/dry_run_gate_fix.sh`: `${WORLDOS_STORY_MIN:-${CLAWDND_STORY_MIN:-4.3}}` (+ MECH_MIN)
  - `qa/score.sh`: `${WORLDOS_SCORE_GUARD_ONLY:-${CLAWDND_SCORE_GUARD_ONLY:-}}`

### Writers flipped
`.mcp.json`, `qa/qa.mcp.example.json`, `.github/workflows/{ci,nightly-quality-loop,quality-gate}.yml`, `scripts/play.sh`/`play_party.sh`/`play_codex_dm.sh` env-blocks (+ codex `env_vars` pass-through, in lockstep), server test setters (rules/voice/integration), and doc/comment guidance.

### Preserved
- `servers/engine/tests/test_env_compat.py` — it asserts the `CLAWDND_` fallback warns-once and works.
- `clawdnd-rules` / `clawdnd-voice` MCP **server names** (Phase 4).
- The `CLAWDND_` fallbacks inside the new bi-name readers.

### Gates (offline, no LLM keys)
rules **16** · voice **17** · full engine suite **2893** · score-determinism **7** — all green. JSON/YAML valid; `bash -n` clean.