### PR TITLE
fix(engine): dedup canon load against a fuller-display-name roster record (Wyll/Minsc)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -2827,8 +2827,21 @@ def load_canon_character(campaign_id: str, name: str = "", kind: str = "npc", ad
                 "origin_banned": True,
                 "name": canonical,
             }
+        # DEDUP (B-MED-1): match by exact canonical name across ALL kinds first (a player/monster
+        # already bearing this name still blocks a duplicate — today's behavior), THEN fall back
+        # to the roster matcher so a canon figure seeded under a FULLER display name is promoted
+        # in place instead of fresh-loaded as a duplicate: canon "Wyll" -> rostered "Wyll
+        # Ravengard" (npc-wyll), canon "Minsc" -> "Minsc and Boo" (npc-minsc).
+        # _find_existing_roster_match (the same matcher the start_character `pickup:` path trusts)
+        # only considers npc/companion roster records (never a player/monster) and keys on the
+        # resolved canonical name, so this is STRICTLY ADDITIVE — it can only ADD matches the
+        # exact-name check missed, never remove one. Empirically the only new matches across the
+        # baldurs-gate corpus (2076 canon files) are Wyll and Minsc, both correct same-figure
+        # dedups; the rostered record then flows through the documented load -> recruit_companion
+        # seating (and already carries its authored roster companion_dossier).
         dup = next((ch for ch in c.characters.values()
-                    if ch.name.strip().lower() == canonical.strip().lower()), None)
+                    if ch.name.strip().lower() == canonical.strip().lower()), None) \
+            or _find_existing_roster_match(c, canonical)
         if dup is not None:
             # Already present (commonly: the cold-open PRELUDE seeds the companion NPC, then the
             # DM tries to load them) — return a SUCCESS-shaped response, not a hard error, so the

--- a/servers/engine/tests/test_decision_approval.py
+++ b/servers/engine/tests/test_decision_approval.py
@@ -389,10 +389,10 @@ def test_shared_vocabulary_lets_one_tag_move_several_companions(tmp_path, monkey
     Gale, Wyll, AND Halsin in one record_decision — many arcs nudged by one tag. This is the
     cross-cutting authored vocabulary working on real canon content.
 
-    (Uses the three mercy-liking companions that take load_canon_character's FRESH-load path so
-    their authored dossier is applied; the rostered originals — Shadowheart/Astarion/Karlach —
-    are promoted in place WITHOUT the canon JSON dossier, an unrelated pre-existing canon/roster
-    merge gap flagged separately, not part of this feature.)"""
+    Gale/Halsin take load_canon_character's fresh-load path; Wyll is a rostered origin ("Wyll
+    Ravengard") promoted in place by the canon-load dedup. All three carry the canon `mercy`
+    like. Each is RECRUITED after load (the documented load -> recruit_companion seating that
+    brings a companion into the party); recruit is idempotent for the fresh-loaded two."""
     monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
     bg = server.start_world("baldurs-gate")["campaign_id"]
     ids = {}
@@ -401,6 +401,7 @@ def test_shared_vocabulary_lets_one_tag_move_several_companions(tmp_path, monkey
         ids[name] = res["id"]
         # confirm the authored dossier actually lists `mercy` as a like (content sanity)
         assert "mercy" in server.get_character(bg, res["id"])["companion_dossier"]["approval_likes"]
+        server.recruit_companion(bg, res["id"])  # seat them in the party (idempotent if already a companion)
     out = server.record_decision(bg, summary="spared the surrendering cultists",
                                  approval_tags=["mercy"])
     moved = {r["id"] for r in out["approval_results"]}
@@ -408,3 +409,38 @@ def test_shared_vocabulary_lets_one_tag_move_several_companions(tmp_path, monkey
     assert all(ids[n] in moved for n in ids), "a shared `mercy` tag should move every mercy-liking companion"
     for n in ids:
         assert server.get_character(bg, ids[n])["attitude_value"] == 10
+
+
+# --- canon-load dedup: a fuller-display-name roster record is promoted, not duplicated ---
+
+def test_loading_canon_wyll_promotes_roster_record_without_duplicate(tmp_path, monkeypatch):
+    """Wyll's roster display name is "Wyll Ravengard" but his canon name is "Wyll", so the
+    exact-name dedup MISSED the rostered record and load_canon_character fresh-loaded a SECOND
+    "Wyll" (a duplicate beside npc-wyll). Dedup must catch the fuller-display-name roster record
+    (via _find_existing_roster_match) and promote it in place: already_present, NO duplicate, and
+    after recruit a tagged moral choice moves him (his roster dossier already lists `mercy`)."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    bg = server.start_world("baldurs-gate")["campaign_id"]
+    res = server.load_canon_character(bg, "Wyll", kind="companion", add_to_party=True)
+    assert res.get("already_present") is True and res["id"] == "npc-wyll"
+    wylls = [ch for ch in store.load_campaign(bg).characters.values() if "wyll" in ch.name.strip().lower()]
+    assert len(wylls) == 1, f"expected one Wyll record, got {[w.name for w in wylls]}"
+    likes = server.get_character(bg, "npc-wyll")["companion_dossier"]["approval_likes"]
+    assert "mercy" in [k.lower() for k in likes]
+    server.recruit_companion(bg, "npc-wyll")
+    before = server.get_character(bg, "npc-wyll")["attitude_value"]
+    out = server.record_decision(bg, summary="spared the captive", approval_tags=["mercy"])
+    assert "npc-wyll" in {r["id"] for r in out["approval_results"]}
+    assert server.get_character(bg, "npc-wyll")["attitude_value"] > before
+
+
+def test_loading_canon_minsc_promotes_roster_record_without_duplicate(tmp_path, monkeypatch):
+    """Same fuller-display-name class as Wyll: canon "Minsc" vs rostered "Minsc and Boo"
+    (id npc-minsc). Dedup must promote the rostered record in place — already_present, no
+    second Minsc minted."""
+    monkeypatch.setenv("CLAWDND_STATE_DIR", str(tmp_path))
+    bg = server.start_world("baldurs-gate")["campaign_id"]
+    res = server.load_canon_character(bg, "Minsc", kind="companion", add_to_party=True)
+    assert res.get("already_present") is True and res["id"] == "npc-minsc"
+    minscs = [ch for ch in store.load_campaign(bg).characters.values() if "minsc" in ch.name.strip().lower()]
+    assert len(minscs) == 1, f"expected one Minsc record, got {[m.name for m in minscs]}"


### PR DESCRIPTION
## What
`load_canon_character` deduped against existing characters by **exact canonical name only**. A canon figure seeded into the world roster under a *fuller display name* therefore missed its own roster record and fresh-loaded a **second copy**:

- canon `Wyll` vs rostered `Wyll Ravengard` (`npc-wyll`)
- canon `Minsc` vs `Minsc and Boo` (`npc-minsc`)

Verified on current `main`: `load_canon_character("Wyll")` / `("Minsc")` each leave **two** records.

## Fix (strictly additive)
Keep the exact-name match across all kinds first (a player/monster of this name still blocks a duplicate — unchanged), then fall back to the existing `_find_existing_roster_match` helper — the same matcher the `start_character` `pickup:` path already trusts (exact name / `npc-<slug>` id / canonical name as a leading word of the display name). It only **adds** matches the exact check missed and never matches a player/monster, so it can't mis-promote a non-roster figure or remove a current match.

## Blast radius — measured, not assumed
Simulated the new matcher against **every** canon name in all 3 rostered worlds (**2076** canon files in baldurs-gate): exactly **two** new dedups, Wyll and Minsc, both correct same-figure promotions. The narrower alternative (rename the roster display name) was considered and rejected — it leaves Minsc broken and drops the "Ravengard" name. After the fix Wyll/Minsc behave identically to the other rostered origins (Astarion/Shadowheart/Karlach), flowing through the documented `load → recruit_companion` seating and their already-authored roster `companion_dossier`.

## Tests
- Wyll: load → `already_present(npc-wyll)`, exactly one Wyll record, dossier lists `mercy`, recruit, `record_decision` moves him.
- Minsc: load → `already_present(npc-minsc)`, exactly one Minsc record.
- `test_shared_vocabulary` updated to the `load → recruit` flow (Wyll now takes the `already_present` path; recruit is idempotent for fresh-loaded Gale/Halsin); stale "merge gap" note removed.

Full single-process engine suite: **2903 passed**. `license_check` passes.

## Context
Follow-up to the merged #940 (companion approval-on-decisions). The dossier-vocabulary half of the origin-cast wiring was already resolved on main (the roster entries now carry the correct lowercase_snake `companion_dossier`); this PR closes the remaining duplicate-record defect that the exact-name dedup left open.