### PR TITLE
fix(qa): bi-name scorer-model override env in score.sh — green qa-release-gate

### DIFF
--- a/qa/score.sh
+++ b/qa/score.sh
@@ -15,20 +15,23 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # --- (a) Scorer-model pinning (DETERMINISM GUARD; additive — unset env == today) --------
 # The scorer model is PINNED at a single canonical model (sonnet — the documented gate
-# baseline; never flip it casually). Setting CLAWDND_SCORER_MODEL swaps the scorer, which
+# baseline; never flip it casually). Setting WORLDOS_SCORER_MODEL swaps the scorer, which
 # silently skews every score on the gate. So an override is only honored with an EXPLICIT
-# opt-in (CLAWDND_ALLOW_SCORER_OVERRIDE=1) for a deliberate scorer-calibration probe /
+# opt-in (WORLDOS_ALLOW_SCORER_OVERRIDE=1) for a deliberate scorer-calibration probe /
 # re-baseline (e.g. "does a stronger scorer read Opus craft higher than sonnet does?") —
-# see docs/MODEL-TIERING. CLAWDND_SCORER_MODEL set WITHOUT the opt-in is an ERROR, so a
-# stray env var can't quietly move the baseline.
+# see docs/MODEL-TIERING. WORLDOS_SCORER_MODEL set WITHOUT the opt-in is an ERROR, so a
+# stray env var can't quietly move the baseline. The legacy CLAWDND_* names are still read
+# as a fallback (the clawdnd->worldos rename bi-names direct readers) so old call sites work.
 CANONICAL_SCORER_MODEL="sonnet"
-if [ -n "${CLAWDND_SCORER_MODEL:-}" ] && [ "${CLAWDND_ALLOW_SCORER_OVERRIDE:-}" != "1" ]; then
-  echo "[score] REFUSING scorer-model override: CLAWDND_SCORER_MODEL='${CLAWDND_SCORER_MODEL}' is set but CLAWDND_ALLOW_SCORER_OVERRIDE=1 is NOT." >&2
+SCORER_MODEL_OVERRIDE="${WORLDOS_SCORER_MODEL:-${CLAWDND_SCORER_MODEL:-}}"
+ALLOW_SCORER_OVERRIDE="${WORLDOS_ALLOW_SCORER_OVERRIDE:-${CLAWDND_ALLOW_SCORER_OVERRIDE:-}}"
+if [ -n "$SCORER_MODEL_OVERRIDE" ] && [ "$ALLOW_SCORER_OVERRIDE" != "1" ]; then
+  echo "[score] REFUSING scorer-model override: WORLDOS_SCORER_MODEL='${SCORER_MODEL_OVERRIDE}' is set but WORLDOS_ALLOW_SCORER_OVERRIDE=1 is NOT." >&2
   echo "[score]   The scorer is pinned to '${CANONICAL_SCORER_MODEL}' (the gate baseline); a silent model swap skews every score." >&2
-  echo "[score]   To deliberately re-baseline with a different scorer, also export CLAWDND_ALLOW_SCORER_OVERRIDE=1." >&2
+  echo "[score]   To deliberately re-baseline with a different scorer, also export WORLDOS_ALLOW_SCORER_OVERRIDE=1." >&2
   exit 3
 fi
-SCORER_MODEL="${CLAWDND_SCORER_MODEL:-$CANONICAL_SCORER_MODEL}"
+SCORER_MODEL="${SCORER_MODEL_OVERRIDE:-$CANONICAL_SCORER_MODEL}"
 
 # --- (b) prompt_construction_hash: rubric+schema+template fingerprint (NOT the transcript)
 # Computed by the shared helper so score.sh and the test agree by construction. Used to

--- a/qa/score_openclaw.sh
+++ b/qa/score_openclaw.sh
@@ -29,9 +29,10 @@ BUDGET="${6:-1.50}"
 # Default agent = `main` (the canonical gateway agent; the old `clawdnd-qa` default isn't configured on
 # every host). By DEFAULT pass NO --model override (use the agent's native model, e.g. main=gpt-5.5) —
 # many gateway agents REJECT a foreign model override ("Model override … is not allowed for agent").
-# Only pass one when CLAWDND_SCORER_MODEL is explicitly set AND allowed for the agent.
-AGENT="${CLAWDND_SCORER_AGENT:-main}"
-MODEL="${CLAWDND_SCORER_MODEL:-}"
+# Only pass one when WORLDOS_SCORER_MODEL is explicitly set AND allowed for the agent
+# (the legacy CLAWDND_* names are still read as a fallback — the rename bi-names readers).
+AGENT="${WORLDOS_SCORER_AGENT:-${CLAWDND_SCORER_AGENT:-main}}"
+MODEL="${WORLDOS_SCORER_MODEL:-${CLAWDND_SCORER_MODEL:-}}"
 MODEL_ARGS=(); [ -n "$MODEL" ] && MODEL_ARGS=(--model "$MODEL")
 # A fresh session id per scoring run so a scorer turn never pollutes the agent's main session.
 SESSION_ID="${CLAWDND_SCORER_SESSION:-qa-score-$(basename "${OUT%.json}")}"


### PR DESCRIPTION
## Why
`qa-release-gate-tests` is currently **RED on main** (independent of any feature PR). The clawdnd→worldos rename (#984–#987) updated `qa/test_score_determinism.py` to expect the new `WORLDOS_*` env names in `score.sh`'s scorer-override guard message, but `score.sh` still read/echoed the old `CLAWDND_SCORER_MODEL` / `CLAWDND_ALLOW_SCORER_OVERRIDE` names. So `test_scorer_override_without_optin_errors` failed its `assert "worldos_scorer_model" in combined` (`1 failed, 328 passed`).

## Fix
Read `WORLDOS_SCORER_MODEL` / `WORLDOS_ALLOW_SCORER_OVERRIDE` first, falling back to the legacy `CLAWDND_*` names — the same `${WORLDOS_X:-${CLAWDND_X:-…}}` bi-naming the rename already uses for readers (`dry_run_gate_fix.sh`, the `worldos_env` helper) — and name the `WORLDOS_*` vars in the two guard messages.

**Backward-compatible:** a call site still setting `CLAWDND_*` keeps working, so `test_scorer_override_with_optin_proceeds` and the default-unset path are unchanged.

Also bi-named the same scorer-model/agent reads in `qa/score_openclaw.sh` (the only other scorer wrapper still reading `CLAWDND_*` directly; `score_codex.sh` and `lib_beat_driver.sh` were already bi-named).

## Verification
Full qa-release-gate pytest set green locally: **329 passed, 3 skipped, 2 subtests**. `bash -n` clean on both scripts; `license_check` passes. No engine code touched.

Follow-up to the rename PRs (#984–#987); unblocks the qa gate on main and on every open PR.