### PR TITLE
chore(rename P6-repo): in-repo ClawDnD-val checkout-path refs → WorldOS

### DIFF
--- a/.claude/skills/worldos-dev/SKILL.md
+++ b/.claude/skills/worldos-dev/SKILL.md
@@ -263,7 +263,7 @@ an unattended loop.
   inspect its worktree: if the staged diff is complete, commit it + CI-validate + open the PR
   yourself (recovered #305 → #329 this way; nothing lost). Don't re-do work a corpse already finished.
 - **NEVER `git checkout` / branch-op the SHARED canonical checkout while a parallel session holds a
-  branch.** `/Users/lume/ClawDnD-val` may be on another session's branch (e.g. loop-8). Branch-flips
+  branch.** `/Users/lume/WorldOS` may be on another session's branch (e.g. loop-8). Branch-flips
   there corrupt the sibling session. Do EVERY repo change via a **worktree agent off `origin/main`**
   (`git worktree add -b <branch> <path> origin/main`). If you must touch the shared checkout's main,
   do it as ONE atomic Bash (`git checkout main && test branch==main && add && commit && push`) — never

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@
 
 ## Codex Desktop Local-Resource Policy
 
-- Treat `/Users/lume/ClawDnD-val` as the canonical local Mac app/private-art checkout for WorldOS GUI and native-app testing.
+- Treat `/Users/lume/WorldOS` as the canonical local Mac app/private-art checkout for WorldOS GUI and native-app testing.
 - Use `/Volumes/LEXAR/Codex` for Codex artifacts, scratch files, screenshots, reports, and downloaded CI/VM artifacts.
 - Use same-disk local worktrees for GUI/native-app edits that must launch against private art. Lexar worktrees are fine for docs, backend-only, and non-GUI slices that do not launch the app against private art.
-- Before running install, build, or test commands, verify `pwd`. If a GUI/native app run is not in `/Users/lume/ClawDnD-val` or a same-disk worktree with `WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val`, explain why.
+- Before running install, build, or test commands, verify `pwd`. If a GUI/native app run is not in `/Users/lume/WorldOS` or a same-disk worktree with `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS`, explain why.
 - Prefer GitHub Actions or the 32GB support VM for heavyweight validation, full suites, matrix tests, long integration tests, and persona sweeps.
 - Run local tests only for fast feedback, local-only reproduction, validating unpushed edits, or Mac-only `.app` proof. Use the narrowest focused command first.
 - Do not launch multiple heavyweight local suites or persona sweeps in parallel on this Mac.

--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -8,7 +8,7 @@
 > `docs/AGENT_GRADE_APP_TESTABILITY.md` (app-status/evidence contract), `qa/GUI_WORKBOOK.md`
 > (historical punch-list), `qa/release_readiness.py` (the RRI scorer), `qa/SCORECARD.md` (the ledger).
 >
-> Takeover routing, 2026-06-01: `/Users/lume/ClawDnD-val` is the synced local app/private-art checkout
+> Takeover routing, 2026-06-01: `/Users/lume/WorldOS` is the synced local app/private-art checkout
 > and the default place to build/run/test the GUI and native app. The latest same-SHA app proof is
 > `da05101` from the 2026-06-07 current-main handoff rerun; later commits may sit above that proof
 > without becoming new product proof. Verify `origin/main` before acting, and rerun the handoff gate
@@ -24,12 +24,12 @@ the current commit. It catches stale tabs, dead launchers, missing private art, 
 failed `/move`, no narration, console/network errors, provider trace failures, and evidence gaps.
 
 ```bash
-cd /Users/lume/ClawDnD-val
+cd /Users/lume/WorldOS
 python3 qa/app_handoff_gate.py \
   --web-beats 5 \
   --built-beats 5 \
   --codex-moves 1 \
-  --art-root /Users/lume/ClawDnD-val \
+  --art-root /Users/lume/WorldOS \
   --scripted-budget 1.00 \
   --codex-budget 3.00 \
   --timeout 90 \
@@ -52,7 +52,7 @@ release-ready evidence by itself.
 
 | Port / route | Meaning | Guardrail |
 |---|---|---|
-| `8799 /openworlds/` | Canonical fast iteration surface from `/Users/lume/ClawDnD-val` | Use for LOOK, then rebuild/prove the app |
+| `8799 /openworlds/` | Canonical fast iteration surface from `/Users/lume/WorldOS` | Use for LOOK, then rebuild/prove the app |
 | `8899 /openworlds/` | Scripted/dev harness default | Valid only when same-port `/app-status` is live |
 | `8765` or dynamic app ports | Native app spawned viewer | Read `run.json` or `/app-status.viewer.port`; do not guess |
 | `8990-8999` | Browser persona harness range | Diagnostic browser evidence unless paired with app proof |
@@ -63,13 +63,13 @@ Release RRI's palette-live gate is stricter: it still requires at least six enab
 
 ## The two surfaces (never confuse them again)
 - **ITERATE — visible, playable, fast:** the OpenWorlds viewer served **from the local canonical repo**
-  `/Users/lume/ClawDnD-val` (which HAS the 2.9 GB `content/worlds/_private` art) as a LIVE PLAYABLE
+  `/Users/lume/WorldOS` (which HAS the 2.9 GB `content/worlds/_private` art) as a LIVE PLAYABLE
   session on **fixed port 8799**. This is where you fix one thing at a time and LOOK.
 - **GATE — truth:** the built `dist/WorldOS.app` via `qa/ui_playtest_app.sh` (part A native #356 +
   part B persona loop). Release is judged here. Same viewer code; adds the native shell.
 - **Why both:** identical viewer. 8799-from-local skips the build + guarantees art is present, so
   it's the honest fast loop. The `.app` is the shipped artifact. A non-local worktree may serve private art
-  only when `WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val` points at the local private-art checkout, but
+  only when `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS` points at the local private-art checkout, but
   use that as a fallback rather than the default because external-drive file prompts have broken local AI tests.
   The native app has a separate Private art repo path setting, and `script/build_and_run.sh` also writes
   the art root into `Info.plist` as `WorldOSArtRepoRoot` so LaunchServices env loss cannot hide missing art.
@@ -166,7 +166,7 @@ Release RRI's palette-live gate is stricter: it still requires at least six enab
 
 ## Stand up the iteration surface (8799, playable, from canonical)
 ```bash
-cd /Users/lume/ClawDnD-val
+cd /Users/lume/WorldOS
 # This is the intended local app checkout. Verify it is synced before testing:
 git rev-parse --short HEAD && git rev-parse --short origin/main
 pkill -f 'viewer/server.py'; pkill -f 'scripts/play.sh'; pkill -f 'play_party.sh'   # NOT node:18789 (Eva gateway)
@@ -205,7 +205,7 @@ streams mid-turn (`/events` count climbs during the turn) · a SOLO session has 
 1. Confirm the symptom on 8799 with ≥2 clean reads. If it doesn't reproduce, it's a stale/corrupt
    read — do NOT fix it (log to GUI_WORKBOOK "evaporated").
 2. Builder agent in a **same-disk local worktree off origin/main** when GUI/app tests need art:
-   `git -C /Users/lume/ClawDnD-val worktree add -B codex/<slug> /Users/lume/WorldOS-worktrees/wos-<slug> origin/main`
+   `git -C /Users/lume/WorldOS worktree add -B codex/<slug> /Users/lume/WorldOS-worktrees/wos-<slug> origin/main`
    Lexar worktrees remain fine for docs/backend/non-GUI slices that do not launch the viewer/app.
 3. PR → CI green (incl. `viewer-tests`) → admin-squash-merge → delete branch → prune worktree.
    **Builder PRs sometimes fail to push silently** (happened twice this session) — always
@@ -215,7 +215,7 @@ streams mid-turn (`/events` count climbs during the turn) · a SOLO session has 
 
 ## The gate sweep (Phase 3 — judged on the built .app)
 ```bash
-WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val \
+WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS \
 qa/release_gate.sh --personas newbie,veteran,adversarial,narrative,optimizer --budget 12 --port 8785
 ```
 RRI 10/10 = all 11 gates hold on ONE build across the canonical five personas
@@ -264,7 +264,7 @@ release-blocking product bug.
 Non-disruptive Mac smoke during takeover:
 ```bash
 WORLDOS_NO_STOP_EXISTING=1 \
-WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val \
+WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS \
 WORLDOS_PREFER_LAUNCH_ROOTS=1 \
 script/build_and_run.sh --verify
 ```
@@ -349,7 +349,7 @@ reverts the goal to "fix" and outranks new work.
 - Engine (`servers/engine`) = SOLE writer of campaign state. Don't touch wire contracts
   (`clawdnd-*`/`CLAWDND_*` MCP ids, `dev.worldos.app`); you MAY read `WORLDOS_ART_REPO_ROOT`.
 - `_private/` (the 2.9 GB art) is **never committed**. Building/serving from the local checkout is how the
-  art is present; worktrees can read it via `WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val` when needed.
+  art is present; worktrees can read it via `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS` when needed.
 - 16 GB Mac: tests on **GitHub CI / 32GB support VM** for heavyweight sweeps, never heavy local suites. Parallel read-only agents are
   fine; do not launch multiple heavyweight persona sweeps locally.
 - **Verify, don't trust:** ≥2 clean reads for any claim; the RRI scorer reads disk, not the live

--- a/WorldOS-OPERATING-GOAL.md
+++ b/WorldOS-OPERATING-GOAL.md
@@ -18,7 +18,7 @@
                    re-measure could move several gates at once. RELEASE MODEL = RRI-FIRST: v1.0.x tags =
                    semver feature-labels; RRI 10/10 = release-authority; tag-after-proof ("Player-Ready
                    Beta" = first RRI 10/10; "1.0 GA" = +notarized +feature-parity). Milestone v1.0.4 (#27).
-     CANONICAL:    /Users/lume/ClawDnD-val is now the synced local app/private-art checkout and
+     CANONICAL:    /Users/lume/WorldOS is now the synced local app/private-art checkout and
                    the default place to build/run/test the Mac app. Keep GUI/runtime tests on this
                    local disk so macOS does not prompt on Lexar-hosted assets.
      WORKTREES:    For tracked edits, prefer same-disk local worktrees when GUI/app tests need assets.
@@ -252,7 +252,7 @@ verifier; can revert the goal to "fix" anytime.
   NEXT build is the evidence. Close issues only on next-build non-reproduction. **Honest scores only.**
 - Engine (`servers/engine`) = **SOLE writer** of campaign state. Don't touch wire contracts
   (`clawdnd-*` / `CLAWDND_*` / `dev.worldos.app`). Build/run/test the Mac app from
-  `/Users/lume/ClawDnD-val` so private art stays on the local disk and macOS does not prompt on Lexar
+  `/Users/lume/WorldOS` so private art stays on the local disk and macOS does not prompt on Lexar
   files. Use **same-disk local worktrees** for GUI-affecting tracked edits, Lexar for evidence/snapshots,
   and the 32GB support VM / GitHub CI for heavy tests. `_private/` never committed.
 
@@ -272,9 +272,9 @@ verifier; can revert the goal to "fix" anytime.
   added the hybrid 100/100 app handoff gate. PR #505 then hardened the RRI bridge so Mac handoff
   evidence can be supplied with `--handoff-json` while support-VM persona artifacts supply the heavy
   sweep. PR #506 then synced these docs to the `fd9dba5` proof without changing product code. PR #508 added the
-  support-VM preflight artifact gate. The local app/private-art checkout `/Users/lume/ClawDnD-val` was
+  support-VM preflight artifact gate. The local app/private-art checkout `/Users/lume/WorldOS` was
   later verified against current `origin/main` at `da05101`, and the Mac app handoff was rerun on that
-  exact SHA from a clean same-disk worktree with `WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val`.
+  exact SHA from a clean same-disk worktree with `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS`.
 - The stale local pre-sync artifacts were preserved before the fast-forward at
   `/Volumes/LEXAR/Codex/worldos-local-checkout-snapshot-20260531T223923` and in `stash@{0}`
   (`pre-sync local takeover docs 2026-05-31`). Treat those as evidence, not current release truth.
@@ -352,7 +352,7 @@ verifier; can revert the goal to "fix" anytime.
   campaign, provider, private-art presence, move sink, actor, enabled actions, readiness, and failure buckets
   without mutating state; the scripted provider can prove wiring behind a dev/test gate; and stable a11y/DOM
   hooks make the UI more driveable. A current-session `:8899` probe briefly showed `080497e`, scripted
-  provider, private art root at `/Users/lume/ClawDnD-val`, `can_act:true`, five enabled actions,
+  provider, private art root at `/Users/lume/WorldOS`, `can_act:true`, five enabled actions,
   `ready_for_smoke:true`, and no reported console/network failures; a later read found the port already
   down. Browser-based checks should use the live port discovered from `run.json` or `/app-status`, and if
   a browser session cannot reach local URLs, fall back to `/app-status`, `/session-surface`, app screenshots,

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -9,7 +9,7 @@
 > `WorldOS-OPERATING-GOAL.md` first, then `WorldOS-GUI-RUNBOOK.md`, `qa/QA_TOOLS.md`, and
 > `qa/SCORECARD.md`. The work queue later in this file is historical unless it agrees with those
 > sources.
-> **Local/VM routing, 2026-06-01:** `/Users/lume/ClawDnD-val` is the synced local app/private-art
+> **Local/VM routing, 2026-06-01:** `/Users/lume/WorldOS` is the synced local app/private-art
 > checkout and should be used for GUI/native-app testing. Use `/Volumes/LEXAR/Codex` for evidence,
 > snapshots, and logs; do not make Lexar the default GUI runtime tree because external-drive
 > permissions can break local AI/browser tests. Heavy backend/persona sweeps belong on GitHub CI or
@@ -260,8 +260,8 @@ fresh scored evidence explicitly changes that decision.
 Preflight, from the Mac where Codex CLI is logged in:
 
 ```bash
-cd /Users/lume/ClawDnD-val
-scripts/codex_qa_home.sh ~/.codex-worldos-qa /Users/lume/ClawDnD-val
+cd /Users/lume/WorldOS
+scripts/codex_qa_home.sh ~/.codex-worldos-qa /Users/lume/WorldOS
 CODEX_HOME=~/.codex-worldos-qa codex login status
 CODEX_HOME=~/.codex-worldos-qa codex --version
 ```

--- a/macos/WorldOSApp/Sources/WorldOSApp/Services/RepositoryLocator.swift
+++ b/macos/WorldOSApp/Sources/WorldOSApp/Services/RepositoryLocator.swift
@@ -83,7 +83,7 @@ enum RepositoryLocator {
             environment["CLAWDND_ART_REPO_ROOT"],
             Bundle.main.object(forInfoDictionaryKey: "WorldOSArtRepoRoot") as? String,
             defaultRepoPath(),
-            home.appendingPathComponent("ClawDnD-val").path,
+            home.appendingPathComponent("WorldOS").path,
             home.appendingPathComponent("repos/WorldOS").path,
         ]
         for raw in candidates {

--- a/qa/GUI_WORKBOOK.md
+++ b/qa/GUI_WORKBOOK.md
@@ -6,7 +6,7 @@
 > current release state. "Verified" means observed on the live playable surface or read from canonical
 > source at the time recorded, not a proxy guess.
 >
-> Current routing: iteration surface `http://127.0.0.1:8799/openworlds/` from `/Users/lume/ClawDnD-val`;
+> Current routing: iteration surface `http://127.0.0.1:8799/openworlds/` from `/Users/lume/WorldOS`;
 > gate surface built `dist/WorldOS.app`; fast handoff command `qa/app_handoff_gate.py`; release verdict
 > `qa/release_readiness.py`.
 
@@ -28,7 +28,7 @@ persona evidence. Issue #466 must either produce that clean RRI or fail with act
 - ✅ `launch.json` repointed off the deprecated LEXAR copy → canonical/8799/`/openworlds/`/live state.
 - ✅ 8799 playable from canonical: `can_act:true`, PC Rolan + Minsc, images + map render.
 - ✅ Lexar worktree `.app` smoke can launch without killing the canonical app and still read canonical
-  private art via `WORLDOS_ART_REPO_ROOT=/Users/lume/ClawDnD-val`.
+  private art via `WORLDOS_ART_REPO_ROOT=/Users/lume/WorldOS`.
 
 ## REAL bugs (verified; the actual punch-list)
 
@@ -38,7 +38,7 @@ persona evidence. Issue #466 must either produce that clean RRI or fail with act
 | G4 | Chronicle renders as ONE block despite well-formed prose | `LogEntry` rendered `{text}` with default `white-space`, collapsing `\n\n` paragraph breaks | Keep sanitization, render narration with `whiteSpace: "pre-line"` | Merged in #465; needs built-app live look + full gate | Static proof: `viewer/tests/test_openworlds_static.py::test_openworlds_table_chronicle_preserves_paragraph_breaks` |
 | G6 | Companion (Minsc/Alfira, kind='companion') silently in solo party at cold-open, no narrated meeting | solo play.sh could prompt the DM into seating/recruiting a companion at cold-open | Solo prompt now says the player begins alone; `play_party.sh` with empty companion spec execs solo `play.sh` unchanged | Merged in #465; needs live gate proof | Static proof: `qa/test_release_gate_static.py::test_solo_play_contract_does_not_silently_recruit_companion` |
 | G5 | "No streaming visible" — VERIFY (may be infra: owner watched a stale/wrong surface) | /events+useLiveSession+log_event exist; DM emits paragraph-rich prose; PR #394 merged streaming-lite for #393 | Confirm mid-turn log_event on live 8799; fix only if current built-app play still batches blank waits | #394 merged; #393 remains open until built-app Part A+B proves no latency give-ups | DM prose well-formed; streaming path exists; proof still owed on built app |
-| G7 | Worktree/.app builds 404 images (no _private) | `_ingested_images_root()` (server.py:203) hardcoded to server.py's repo → worktree has no _private | Split code repo from art repo: viewer honors `WORLDOS_ART_REPO_ROOT`; native app has a Private art repo path and launch-root override for gate builds | Merged in #465; needs #466 full gate proof | 2026-05-31 smoke: worktree `dist/WorldOS.app` pid 69755 launched without killing canonical app; spawned worktree `viewer/server.py` on 8765; `/image?scope=location:loc-lower-city` returned `200 904100`; Info.plist root=`/Volumes/LEXAR/repos/worldos-takeover-stabilization`, art=`/Users/lume/ClawDnD-val` |
+| G7 | Worktree/.app builds 404 images (no _private) | `_ingested_images_root()` (server.py:203) hardcoded to server.py's repo → worktree has no _private | Split code repo from art repo: viewer honors `WORLDOS_ART_REPO_ROOT`; native app has a Private art repo path and launch-root override for gate builds | Merged in #465; needs #466 full gate proof | 2026-05-31 smoke: worktree `dist/WorldOS.app` pid 69755 launched without killing canonical app; spawned worktree `viewer/server.py` on 8765; `/image?scope=location:loc-lower-city` returned `200 904100`; Info.plist root=`/Volumes/LEXAR/repos/worldos-takeover-stabilization`, art=`/Users/lume/WorldOS` |
 
 ## EVAPORATED on clean re-verification (were CORRUPTED READS — do NOT chase)
 - **G1 "palette all-disabled / PC kind=pc / no active character"** — FALSE. Live PC Rolan is `kind='player'`; palette enabled. (A corrupted snapshot read invented `kind='pc'`/`npc-alfira`. Builder A killed — pushed no PR.)

--- a/qa/QA_TOOLS.md
+++ b/qa/QA_TOOLS.md
@@ -5,7 +5,7 @@ This is the command map for agents. It does not replace the release truth in
 
 Default local paths:
 
-- App/private-art checkout: `/Users/lume/ClawDnD-val`.
+- App/private-art checkout: `/Users/lume/WorldOS`.
 - Evidence root: `/Volumes/LEXAR/Codex`.
 - Heavy persona/backend sweeps: GitHub CI or the owner-provided support VM after explicit preflight.
 
@@ -23,12 +23,12 @@ Default local paths:
 Copy-paste fast handoff command:
 
 ```bash
-cd /Users/lume/ClawDnD-val
+cd /Users/lume/WorldOS
 python3 qa/app_handoff_gate.py \
   --web-beats 5 \
   --built-beats 5 \
   --codex-moves 1 \
-  --art-root /Users/lume/ClawDnD-val \
+  --art-root /Users/lume/WorldOS \
   --scripted-budget 1.00 \
   --codex-budget 3.00 \
   --timeout 90 \

--- a/qa/app_handoff_gate.py
+++ b/qa/app_handoff_gate.py
@@ -31,7 +31,7 @@ from qa.app_failure_buckets import APP_FAILURE_BUCKETS  # noqa: E402
 
 
 DEFAULT_OUTPUT_ROOT = Path("/Volumes/LEXAR/Codex/worldos-agent-grade-app-testability")
-DEFAULT_ART_ROOT = Path("/Users/lume/ClawDnD-val")
+DEFAULT_ART_ROOT = Path("/Users/lume/WorldOS")
 
 
 def utc_stamp() -> str:

--- a/qa/fast_probe.sh
+++ b/qa/fast_probe.sh
@@ -26,7 +26,7 @@ fi
 # Reuse a shared install via symlink so Tier-1 runs from any worktree without a per-checkout npm install.
 PW="$ROOT/qa/playwright/node_modules"
 if [ ! -d "$PW" ]; then
-  for cand in "${WORLDOS_PLAYWRIGHT_DIR:-}" /root/worldos-qa/WorldOS/qa/playwright/node_modules "$HOME/ClawDnD-val/qa/playwright/node_modules"; do
+  for cand in "${WORLDOS_PLAYWRIGHT_DIR:-}" /root/worldos-qa/WorldOS/qa/playwright/node_modules "$HOME/WorldOS/qa/playwright/node_modules"; do
     [ -n "$cand" ] && [ -d "$cand" ] && { ln -s "$cand" "$PW" 2>/dev/null && echo "  (linked Playwright palette from $cand)"; break; }
   done
   [ -d "$PW" ] || echo "  ⚠ Playwright palette not found — persona half will skip. Install once: (cd qa/playwright && npm install && npx playwright install chromium)"

--- a/qa/gate_corpus/builder.py
+++ b/qa/gate_corpus/builder.py
@@ -35,7 +35,7 @@ _MANIFEST = _HERE / "manifest.json"
 _GATE = _HERE.parent / "assert_behavioral.py"
 
 # Real recorded REDs whose failure MODE each synthetic fixture is modeled on. Sourced from
-# /Users/lume/ClawDnD-val/qa/transcripts/*.gate.txt at corpus-build time. A blank value means
+# /Users/lume/WorldOS/qa/transcripts/*.gate.txt at corpus-build time. A blank value means
 # the check has no recorded real RED and the fixture is purely synthetic (still faithful to the
 # gate's documented trip condition).
 REAL_RED_PROVENANCE = {

--- a/qa/release_gate.sh
+++ b/qa/release_gate.sh
@@ -150,7 +150,7 @@ preflight() {
 
   # 1. CANONICAL repo, not the deprecated LEXAR copy or a random worktree.
   case "$ROOT" in
-    */ClawDnD-val) ok "repo root looks canonical: $ROOT";;
+    */ClawDnD-val|*/WorldOS) ok "repo root looks canonical: $ROOT";;
     *) warn "repo root is $ROOT — confirm this is the canonical checkout (NOT /Volumes/LEXAR deprecated copy)";;
   esac
 

--- a/qa/test_support_vm_preflight.py
+++ b/qa/test_support_vm_preflight.py
@@ -259,7 +259,7 @@ class SupportVMPreflightTests(unittest.TestCase):
                 "OPENAI_API_KEY": "sk-proj-supersecret123456",
                 "ANTHROPIC_API_KEY": "anthropic-supersecret",
                 "CODEX_TOKEN": "codex-token-secret",
-                "WORLDOS_ART_REPO_ROOT": "/Users/lume/ClawDnD-val",
+                "WORLDOS_ART_REPO_ROOT": "/Users/lume/WorldOS",
                 "UNRELATED_SECRET": "not-inspected",
             }
         )
@@ -268,7 +268,7 @@ class SupportVMPreflightTests(unittest.TestCase):
         self.assertNotIn("anthropic-supersecret", blob)
         self.assertNotIn("codex-token-secret", blob)
         self.assertNotIn("not-inspected", blob)
-        self.assertEqual(snapshot["WORLDOS_ART_REPO_ROOT"]["value"], "/Users/lume/ClawDnD-val")
+        self.assertEqual(snapshot["WORLDOS_ART_REPO_ROOT"]["value"], "/Users/lume/WorldOS")
 
     def test_teardown_commands_are_record_only(self):
         with tempfile.TemporaryDirectory() as td:

--- a/qa/ui_playtest_app.sh
+++ b/qa/ui_playtest_app.sh
@@ -1153,7 +1153,7 @@ repo_viewer_ports() {
     # Match EITHER an absolute argv path under repo root (the LAUNCHER, whose CWD is the .app's
     # temp dir, not the repo) OR CWD == repo root (the MINTED provider viewer, launched by
     # play*.sh with a RELATIVE `viewer/server.py`). Either way it is THIS checkout's viewer; this
-    # excludes other checkouts (e.g. /Users/lume/ClawDnD-val) and unrelated services.
+    # excludes other checkouts (e.g. /Users/lume/WorldOS) and unrelated services.
     if printf '%s' "$cmd" | grep -qF "$rootp/viewer/server.py" \
        || printf '%s' "$cmd" | grep -qF "$root/viewer/server.py" \
        || [ "$cwd" = "$rootp" ] || [ "$cwd" = "$root" ]; then


### PR DESCRIPTION
Companion to the local filesystem rename `/Users/lume/ClawDnD-val` → `/Users/lume/WorldOS`. Updates every committed checkout-path reference; `release_gate.sh` canonical-root check made **bi-name** (`*/ClawDnD-val|*/WorldOS)`) so it passes before and after the rename; `RepositoryLocator` home candidate → `WorldOS`; `DEFAULT_ART_ROOT` → `/Users/lume/WorldOS` (already env-bi-named + .exists()-guarded). Gates: vm-preflight 33, swift build complete, bash -n + py_compile clean.