### PR TITLE
chore(rename P8): fix stale clawdnd-play.command refs + dev.clawdnd TCC predicate

### DIFF
--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -253,7 +253,7 @@ the attribution:
 
 ```bash
 /usr/bin/log show --style compact --last 10m \
-  --predicate 'eventMessage CONTAINS[c] "dev.clawdnd" OR eventMessage CONTAINS[c] "kTCCServicePhotos" OR eventMessage CONTAINS[c] "kTCCServiceMediaLibrary"'
+  --predicate 'eventMessage CONTAINS[c] "dev.worldos" OR eventMessage CONTAINS[c] "kTCCServicePhotos" OR eventMessage CONTAINS[c] "kTCCServiceMediaLibrary"'
 ```
 
 If `AUTHREQ_ATTRIBUTION` shows `accessing=/usr/bin/find` or `accessing=codex`, classify it as harness

--- a/commands/play-dashboard.md
+++ b/commands/play-dashboard.md
@@ -8,9 +8,9 @@ Target world (optional id): $ARGUMENTS
 
 Tell the player how to launch it, then let them play in the browser:
 
-1. **Launch it** — the simplest path is to **double-click `clawdnd-play.command`** in the repo (a Desktop shortcut is installed by `scripts/install-desktop-shortcut.sh`). Or, from a terminal:
+1. **Launch it** — the simplest path is to **double-click `worldos-play.command`** in the repo (a Desktop shortcut is installed by `scripts/install-desktop-shortcut.sh`). Or, from a terminal:
    ```bash
-   ./clawdnd-play.command            # default world (baldurs-gate)
+   ./worldos-play.command            # default world (baldurs-gate)
    scripts/play.sh sundered-reach    # a specific world; see /world-list
    ```
    It opens `http://127.0.0.1:8765/dashboard`, flips the viewer into interactive (live) mode, and starts the DM, who opens the world live and hands the player a character + an open moment.
@@ -19,12 +19,12 @@ Tell the player how to launch it, then let them play in the browser:
 
 **Want AI companions in the party? (opt-in)** By default you play solo (just you + the DM). You can instead bring a party of **AI companions** who adventure alongside you — each is its OWN agent acting through the same constrained move palette you do (it can disagree, take the lead in its lane, even betray you), NOT the DM voicing it. The dashboard then shows you + your companions + the DM, beat by beat. Companions multiply the live AI cost (each is a separate `claude -p`), so they're **off unless you ask for them**:
 ```bash
-# Name companions with a 4th arg (or $CLAWDND_PLAY_COMPANIONS), COMMA-separated tokens
+# Name companions with a 4th arg (or $WORLDOS_PLAY_COMPANIONS), COMMA-separated tokens
 #   Name:class:persona_file[:spell1|spell2|…]   (the 4th field names a caster's spells)
 scripts/play_party.sh baldurs-gate '' 8765 \
   "Seraphine:cleric:qa/play_companion.txt:Cure Wounds|Guiding Bolt,Brogan:fighter:qa/play_companion.txt"
 # or via env (then double-click / run the .command as usual):
-CLAWDND_PLAY_COMPANIONS="Brogan:fighter:qa/play_companion.txt" ./clawdnd-play.command
+WORLDOS_PLAY_COMPANIONS="Brogan:fighter:qa/play_companion.txt" ./worldos-play.command
 ```
 `scripts/play_party.sh` (and the `.command`, which routes through it) is **identical to solo play when you give no companion spec** — so nothing changes for solo. With companions named, each is pre-seeded into the party with a real sheet, the DM creates *your* character live and opens the scene around the existing party, and every beat your move plus each living companion's moves are resolved together. The same budget / turn caps apply (companions count toward the session ceiling).
 

--- a/commands/world-play.md
+++ b/commands/world-play.md
@@ -4,7 +4,7 @@ argument-hint: "[world id] (e.g. sundered-reach) — optional; lists worlds if o
 ---
 The player wants to play in a living world (the generative / sandbox mode — the engine at its best).
 
-> Two ways to play this same living-world mode: **(a) here in Claude Code** — type your turns and the DM responds in chat (this command); **(b) in the dashboard** — play in the browser via the action palette while a live DM responds beside it (double-click `clawdnd-play.command`, or run `scripts/play.sh [world-id]`; see `/play-dashboard`). Same engine, same DM skill — pick the surface you prefer.
+> Two ways to play this same living-world mode: **(a) here in Claude Code** — type your turns and the DM responds in chat (this command); **(b) in the dashboard** — play in the browser via the action palette while a live DM responds beside it (double-click `worldos-play.command`, or run `scripts/play.sh [world-id]`; see `/play-dashboard`). Same engine, same DM skill — pick the surface you prefer.
 
 Target world (optional id): $ARGUMENTS
 


### PR DESCRIPTION
Final going-forward stragglers after the ClawDnD→WorldOS cutover: `commands/play-dashboard.md` + `commands/world-play.md` referenced the launcher by its old name (`clawdnd-play.command` → `worldos-play.command`; the script already exists as `worldos-play.command`), and `WorldOS-GUI-RUNBOOK.md`'s TCC log predicate checked the old bundle id (`dev.clawdnd` → `dev.worldos`, post-P5). Also flips a `CLAWDND_PLAY_COMPANIONS` example to `WORLDOS_*`. Preserves the documentary 'renamed from dev.clawdnd.app' comment.