### PR TITLE
content: two new golden spines (competing multi-companion agendas + gothic horror)

### DIFF
--- a/content/campaigns/hollow-mile/adventure.json
+++ b/content/campaigns/hollow-mile/adventure.json
@@ -1,0 +1,866 @@
+{
+  "id": "hollow-mile",
+  "title": "The Physician of Hollow Mile",
+  "ruleset": "SRD 5.2",
+  "level_range": [
+    3,
+    7
+  ],
+  "session_length_minutes": 240,
+  "premise": "Hollow Mile is a fen-locked hamlet of forty souls strung along a single sunken road, and for three winters it has been dying of a wasting plague the locals call the Grey Quiet: a sickness that does not kill so much as STILL — the afflicted go cold and slow and finally lie down in the reed-beds and do not get up, and on the third night after they lie down, they rise, grey and patient and wrong, and walk back toward the houses they loved. Between the hamlet and that horror stands one woman: Doctor Eline Mourn, a plague-doctor in a long oiled coat and a beaked leather mask, who came here three winters ago and has held the Grey Quiet at bay with a tincture of her own devising — the Stillwater Draught — that buys the dying a few more lucid weeks. The village worships her. What no one in Hollow Mile knows, and what Eline has buried with a physician's iron discipline, is that the Grey Quiet is HERS: it is the failed first version of the very cure she now doses them with, a draught she invented years ago in another town to save a single dying child — her ward, a girl named Wren — that instead unmade the girl into the first of the grey-walkers, and seeped from that one body into the water table and the fen and finally here, where Eline followed it to atone. She is not the plague's villain by malice. She is its MOTHER, dosing a wound she opened, certain that if she can only refine the draught one more time she can close it — and beneath the bog, in a drowned chapel-crypt, the Stillwater Spring still runs with the original cursed reagent, and the grey-walking remains of Wren still wait at its heart, the proof and the source and the thing Eline cannot bring herself to burn.",
+  "hook": "A reed-cutter's boy named Tomas Vane has gone cold. The Grey Quiet has him — he is slowing, going grey at the lips, and his mother Halda has spent the family's last coin and her last hope flagging down the only outsiders to take the sunken road into Hollow Mile in a season: the party. She does not want a cure she cannot buy; she wants someone with a strong arm and no village fear to walk her dying boy to Doctor Mourn's surgery at the end of the Mile before the cold takes him, and to stand watch on the third night if the worst comes — because the last family that lost someone to the Grey Quiet woke on the third night to find their dead at the door, grey and smiling, and the village will not speak of what they had to do. Bring the boy to the physician. Stand the third-night watch. And try not to ask why a hamlet of forty souls needs a plague-doctor who never takes off her mask.",
+  "themes": [
+    "the healer who is the disease — atonement that perpetuates the wound",
+    "a cure that became a curse, dosed daily to hide its source",
+    "the body saved at the cost of the soul — what 'saving' someone is worth",
+    "gothic dread: the dead who walk home, the bog that remembers, the mask that never comes off",
+    "mercy as a clinical decision — ending suffering vs. burning the sick to be safe"
+  ],
+  "voices": {
+    "narrator-dm": "The Dungeon Master's narration voice. Used for boxed read-aloud text and scene description.",
+    "companion-default": "Doctor Eline Mourn, the party's companion — a masked plague-doctor holding the Grey Quiet at bay in Hollow Mile, and the secret mother of the plague itself.",
+    "npc-elder": "Old Sexton Brell, the hamlet's grave-keeper and unofficial elder, and the drowned, grey-walking remains of the child Wren when she finally speaks.",
+    "npc-rogue": "Corliss Vane, a reed-smuggler turned grave-robber who has been quietly selling the bog's 'grey water' upriver — the antagonist who would seize the Spring for profit.",
+    "npc-male-1": "Tomas Vane, the dying reed-cutter's boy, and assorted frightened, grey-touched villagers of the Mile.",
+    "npc-female-1": "Halda Vane, the boy's mother and the quest-giver, and Sister Ovick, the bog-chapel's last lay-keeper."
+  },
+  "antagonist": {
+    "id": "antagonist",
+    "name": "Corliss Vane",
+    "title": "The Reed-Factor of Hollow Mile",
+    "voice_id": "npc-rogue",
+    "hidden": true,
+    "goal": "To seize the Stillwater Spring — the source of the cursed reagent under the bog — and sell its grey water as a miracle upriver, where rich men dying of ordinary things will pay a fortune for a draught that 'stills' their pain and, three nights later, makes more grey-walkers for him to harvest. Corliss does not believe in the curse as a curse; he believes in it as a RESERVE he has been quietly tapping for two winters, skimming bog-water past Sister Ovick's wards and Eline's vigilance and shipping it to a buyer he will not name. He poses as a put-upon local factor — kin to the dying Vanes, a man who 'just moves reeds' — while in truth he is the reason the Grey Quiet has begun to spread BEYOND Hollow Mile: he has been carrying it out by the bottle. His endgame is to get the party (or Eline) to break the chapel's last wards and open the Spring for him, then take it whole.",
+    "scheme_by_act": [
+      "ACT 1: As the party brings the dying boy down the Mile and stands the third-night watch, Corliss plays the helpful kinsman — lending a cart, pointing the way to Doctor Mourn, warning them off the bog 'for their own good.' In truth he is watching to see whether these outsiders can do what he cannot: get past Eline's secrecy and Ovick's wards to the Spring. He plants the first lie (that the physician's draught is what spreads the sickness) to turn the party against Eline early.",
+      "ACT 2: With the party drawn into the mystery and Eline's secret cracking open, Corliss makes his move on the bog. He has been grave-robbing the grey-walkers for the reagent in their veins and ships it upriver; the party's descent toward the drowned chapel-crypt threatens his supply. He sabotages the wards, frames Eline (or the party) for a fresh outbreak, and races them toward the Stillwater Spring — because whoever reaches the cursed reagent first controls it. The midpoint reversal: the 'cure' the party may have been fighting to protect is the plague, and the man who warned them off the bog is the one harvesting it.",
+      "ACT 3: At the Stillwater Spring in the drowned crypt, Corliss means to seize the reagent whole — and the only thing standing between him and an endless supply of grey-walkers to sell is the party, Eline, and the grey-walking child Wren at the Spring's heart. He will bargain, threaten, and finally fight to keep the Spring flowing; destroying the Spring (burning the cursed reagent at its source) is the cure for the whole fen, but it kills Wren — and forces Eline's choice. Corliss's victory is the Spring left running and sold; the party's is the Spring unmade, whatever it costs."
+    ],
+    "reveal": "Corliss is introduced in Act 1 as the dying family's helpful, harried kinsman — the one outsider-friendly local who lends a cart and 'just wants the sickness gone like everyone else.' Clues accumulate: bottles of bog-water that shouldn't exist; reed-barges that ride low and leave at odd hours; grey-walkers found grave-robbed of the very fluid that animates them; a warning to stay off the bog that sounds less like care and more like a man guarding a claim. The reveal that the 'helpful factor' is the one SPREADING the Grey Quiet for profit — and means to seize the Spring — lands across Act 2 and at the crypt; he is the human predator feeding on a tragedy Eline made and is trying to end.",
+    "stat_block": "Corliss fights at the Act 3 climax at the Spring, and prefers an ambush to a stand-up fight. Use the bundled Bandit Captain stat block (AC 15, HP 65, CR 2) reflavored as a fen-hardened reed-smuggler — twin gutting-knives, a thrown net, and a grey-water flask he'll smash to raise a fresh walker as cover. He surrounds himself with hired bog-runners (Thugs/Toughs) and, if the wards are down, the grey-walkers themselves (Zombies) drawn to the Spring. He is a CR 2-ish profiteer who controls a horror he doesn't fear; run him as a cornered animal protecting a claim, not a mastermind.",
+    "max_hp": 65,
+    "armor_class": 15,
+    "hit_dice": "10d8+20",
+    "proficiency_bonus": 3,
+    "abilities": {
+      "strength": 15,
+      "dexterity": 16,
+      "constitution": 14,
+      "intelligence": 12,
+      "wisdom": 11,
+      "charisma": 15
+    },
+    "damage_resistances": [],
+    "damage_immunities": [],
+    "condition_immunities": []
+  },
+  "companions": [
+    {
+      "id": "companion-eline",
+      "name": "Doctor Eline Mourn",
+      "voice_id": "companion-default",
+      "race": "Human",
+      "background": "Sage",
+      "classes": [
+        {
+          "name": "Cleric",
+          "level": 3,
+          "subclass": "Life Domain"
+        }
+      ],
+      "abilities": {
+        "strength": 10,
+        "dexterity": 12,
+        "constitution": 13,
+        "intelligence": 16,
+        "wisdom": 15,
+        "charisma": 11
+      },
+      "proficiency_bonus": 2,
+      "armor_class": 14,
+      "max_hp": 24,
+      "hit_dice": "3d8",
+      "hit_dice_remaining": 3,
+      "skill_proficiencies": [
+        "Medicine",
+        "Arcana",
+        "Insight",
+        "Investigation"
+      ],
+      "saving_throw_proficiencies": [
+        "wis",
+        "cha"
+      ],
+      "spells_known": [],
+      "spells_prepared": [
+        "Cure Wounds",
+        "Lesser Restoration",
+        "Spare the Dying",
+        "Bless",
+        "Detect Poison and Disease",
+        "Prayer of Healing"
+      ],
+      "spell_slots": {
+        "1": {
+          "maximum": 4,
+          "used": 0
+        },
+        "2": {
+          "maximum": 2,
+          "used": 0
+        }
+      },
+      "personality": "A spare, exact woman of perhaps forty whose face no one in Hollow Mile has ever seen — she wears the long oiled coat and the beaked leather plague-mask of her trade indoors and out, and removes it only to eat, alone, with her back to the door. She speaks in the clean, unhurried cadence of someone who has delivered too much bad news to flinch from it, and she is, by every visible measure, the best thing that ever happened to the Mile: she sits with the dying, eases the cold, and has held the Grey Quiet to a slow burn for three winters with a tincture of her own making. She believes in the body the way a faithless person believes in arithmetic — that flesh is a problem with a solution, that suffering is data, that there is no soul-sized wound she cannot, given time and a clean enough table, close. What she carries under the mask is not a face but a fact: the Grey Quiet is HERS, the failed first draught she brewed years ago to save one dying child — her ward, Wren — that unmade the girl instead, and she has spent every winter since dosing a poison she invented, certain that one more refinement will make it a cure at last. She is gentle with the suffering and merciless with sentiment; she will end a hopeless case cleanly rather than let it linger, and she has no patience for anyone who would let a person rot to keep a principle. She joined the party as the only hands in the hamlet who don't already worship or fear her — and because some buried part of her hopes they will be the ones who finally make her do the thing she cannot: go down to the Spring and burn it, Wren and all.",
+      "notes": "Healer, lore-anchor, and the campaign's MORAL CORE — the secret author of the plague, holding it at bay out of an atonement that quietly perpetuates it. In combat she is the party's medic and a Life-Domain anvil: Cure Wounds, Lesser Restoration to lift the grey-chill, Spare the Dying on a downed ally, Bless to steady the third-night watch; as the party levels treat her as leveling with them (Cleric matching party level — Channel Divinity: Preserve Life by Act 2, Spirit Guardians and a Mass Cure Wounds register by Act 3). Out of combat she is the inside view of the Grey Quiet — she knows the draught, the grey-walkers' patterns, the chapel wards, and the truth of the Spring, but she is RISKY to lean on, because every step toward the source is a step toward the thing she has hidden: that the cure is the curse and the curse has a name, Wren. This is the FORK (see arc + agenda). Honored — trusted with the truth, helped toward ending the suffering rather than hiding it — Eline confesses, leads the party to the Spring, and helps them unmake it even though it kills the child she's been keeping. Curdled — if the party treats the grey-walkers as monsters to be torched wholesale, lets the sick burn to be safe, or (the seal of it) SEIZES the cursed reagent for use or profit instead of destroying it and saving the ward — Eline does NOT snap in a rage. She decides, with clinical cold, that the party is now the disease: a thing spreading her wound for gain, to be excised. Her turn fires when the reagent is taken (prize_seized), and she stands against the party as a physician removing a contaminant — the most chilling thing she could become. The DM should give Eline her own voiced line each scene (a clinician's register: terse, kind, exact) and reach her combat choices through companion_suggest_action.",
+      "companion_dossier": {
+        "wound": "Years ago she invented a draught to save one dying child — her ward, Wren — and it unmade the girl into the first grey-walker and seeped into the water to make a plague; she has dosed the wound she opened ever since, certain one more refinement will close it, and cannot bring herself to burn the child still waiting at the Spring.",
+        "wants": [
+          "refine the Stillwater Draught into a true cure that closes the Grey Quiet for good",
+          "spare the people of Hollow Mile the suffering she set loose, one cold case at a time",
+          "be forgiven the thing she will not name — or made, finally, to end it"
+        ],
+        "fears": [
+          "that the only cure for the fen is burning the Spring and Wren with it — the one mercy she cannot perform herself",
+          "that her atonement is just a slower way of keeping the wound open",
+          "that someone will take the cursed reagent and spread her single failure across the whole river"
+        ],
+        "values": [
+          "saving the savable",
+          "the body over the soul"
+        ],
+        "approval_likes": [
+          "ending suffering quickly",
+          "trusting evidence over superstition",
+          "treat_the_grey_walkers_as_patients",
+          "ease_a_hopeless_case_cleanly",
+          "destroy_the_cursed_reagent",
+          "tell_a_hard_truth_plainly"
+        ],
+        "approval_dislikes": [
+          "letting someone suffer for a principle",
+          "burning the sick to be safe",
+          "torch_the_grey_walkers_wholesale",
+          "seize_the_reagent_for_use",
+          "sell_the_grey_water",
+          "sentiment_over_the_scalpel"
+        ],
+        "banter_tags": [
+          "clinical_grief_for_wren",
+          "physician_pragmatism",
+          "contempt_for_village_superstition",
+          "the_mask_and_what_it_hides"
+        ],
+        "camp_prompts": [
+          "Eline cleans her instruments by the fire long after they are clean, and finally asks the party, mask still on, whether they think a person can be SAVED and damned by the same hand — and which half they'd choose to be remembered for.",
+          "She describes the Grey Quiet's progression with terrible, gentle precision — the cold, the slowing, the third-night rising — and then stops, because she has just described it the way a mother describes a child's first steps, and she does not finish the sentence.",
+          "Pressed about the mask, she says only that a physician who shows the dying her face makes it about herself; then, quieter, that there is a face she could not stand to wear in front of certain people, and that one of them is waiting somewhere very cold and very patient."
+        ],
+        "relationships": {
+          "Wren": "the dead ward — the child her first cure unmade; the grey-walker at the Spring's heart",
+          "Sister Ovick": "wary ally — the chapel-keeper who suspects what Eline is and warded the Spring against her",
+          "Corliss Vane": "unknown predator — the factor skimming the Spring she is trying to seal"
+        }
+      },
+      "arc": {
+        "arc_gates": [
+          {
+            "id": "eline-gate-loyalty",
+            "kind": "loyalty",
+            "threshold": 20,
+            "note": "Eline lets the mask slip — not literally, but the discipline. After the party stands the third-night watch with her and does not flinch, she admits the draught is hers, that it only buys time, and that she does not believe the Grey Quiet is a natural sickness. The first crack: she trusts the party with the fact that she is hiding something larger, and that she is tired of hiding it alone."
+          },
+          {
+            "id": "eline-gate-quest",
+            "kind": "personal_quest",
+            "threshold": 40,
+            "quest_arc_id": "cqarc-eline-stillwater",
+            "stage_id": "cqstage-eline-confession",
+            "note": "Eline's own quest opens — the cure that became a curse. She confesses the whole of it: Wren, the first draught, the Spring beneath the bog where the original cursed reagent still runs and the grey-walking child still waits. She asks the party's help to reach the Stillwater Spring and do what she has never been able to do — unmake it at the source — knowing it means destroying the last of Wren. LINKED via quest_arc_id to the companion-quest-arc 'cqarc-eline-stillwater' (stage 'cqstage-eline-confession'); the personal_quest is the cure-that-became-a-curse made a first-class arc."
+          },
+          {
+            "id": "eline-gate-betrayal",
+            "kind": "betrayal",
+            "threshold": 15,
+            "note": "THE FORK. If the party has treated the grey-walkers as vermin to be torched, let the sick burn to be safe over Eline's objection, sided with Corliss's profit, or moved to SEIZE the cursed reagent rather than destroy it, Eline's clinical certainty curdles toward a verdict: that the party is a vector, not an ally — a thing spreading her wound. This gate is reachable only when approval has curdled; honored, it stays locked forever. It is not rage; it is a diagnosis."
+          }
+        ],
+        "agenda": {
+          "trigger": "prize_seized",
+          "value": null,
+          "note": "Eline's verdict lands. When the cursed reagent is SEIZED — taken from the Spring for use, study, or sale instead of destroyed — the engine flag 'prize_seized' is set and Eline's agenda fires DETERMINISTICALLY (the prize_seized trigger reads only campaign.flags['prize_seized']; it does NOT roll). She does not snap; she DECIDES. With the same unhurried calm she uses on the dying, she concludes that the party has become the disease — carriers who will spread her single failure across the whole river — and that a good physician excises a contaminant before it spreads. She turns against the party clinically, coldly, as a real attack: she will try to destroy the seized reagent and the hands that hold it, grieving and certain, telling them she is sorry, that this is the kindest cut, that she should never have let them near the Spring. NOTE on decision_flag: 'let_the_ward_burn' is the CONTENT-defined decision flag the DM sets (record_decision/set_flag) when the party CHOOSES to burn the Spring and end Wren — i.e. they paid the cost rather than took the prize. The engine reads decision_flag ONLY for attitude_below agendas (to escalate the snap roll), so it does NOT gate this prize_seized fire; it is carried here to record the campaign's central choice for recall and to mark the path that AVOIDS the turn (let the ward burn = unmake, don't seize = no prize_seized = no turn). To fire Eline's turn, set 'prize_seized' when the party takes the reagent; to keep her, let the ward burn and never set 'prize_seized'.",
+          "decision_flag": "let_the_ward_burn"
+        }
+      }
+    }
+  ],
+  "npcs": [
+    {
+      "id": "halda-vane",
+      "name": "Halda Vane",
+      "voice_id": "npc-female-1",
+      "personality": "A broad, weather-cracked reed-cutter's wife in her forties, hands scarred from forty years of cutting fen-reed, eyes hollowed by three winters of watching the Grey Quiet take her neighbors and now her boy. She is not a frightened woman by nature — she has buried a husband and held a hamlet's grief — but the Grey Quiet has worn her down to a single raw want: to get her son Tomas to Doctor Mourn before the cold takes him, and to not be alone on the third night if the worst comes. She flags the party down on the sunken road with the flat, practical desperation of someone who has stopped expecting miracles and will settle for strong arms and an outsider's nerve.",
+      "attitude": "exhausted, practical, desperate",
+      "role": "primary quest-giver",
+      "wants": "To get her dying boy Tomas safely to Doctor Mourn's surgery at the end of the Mile, and to have someone unafraid stand the third-night watch with her if he goes cold — because the last family that lost someone woke to find their dead at the door.",
+      "knows": [
+        "Tomas has the Grey Quiet — cold, grey at the lips, slowing — and only Doctor Mourn's Stillwater Draught buys the afflicted any lucid time at all.",
+        "The third night after someone 'lies down' is when they rise, grey and patient, and walk home; the village deals with it in ways no one will speak of.",
+        "Her kinsman Corliss Vane lent a cart and 'knows the road,' but warns everyone off the bog — and she's noticed his barges ride low and leave at odd hours.",
+        "Doctor Mourn never removes her mask, sits with the dying when no one else will, and is the only reason anyone in Hollow Mile is still alive."
+      ],
+      "secret": "Halda half-suspects that her husband, who 'lay down' two winters ago and whom she swears she put in the ground herself, is one of the grey-walkers that come to the edge of the reeds at night — and she has left bread out for him every third night since, unable to decide if it is mercy or madness. She'll confess this only to a party that has earned her trust, and it makes the horror's human cost unbearable.",
+      "stat_block": "Noncombatant. If endangered, treat as Commoner; she will not fight but will put herself between a grey-walker and her son without hesitation."
+    },
+    {
+      "id": "corliss-vane",
+      "name": "Corliss Vane",
+      "voice_id": "npc-rogue",
+      "personality": "A lean, affable reed-factor in his thirties with a fen-runner's easy smile and a barge-pole's reach, kin (distantly) to the dying Vanes and seemingly the most helpful man in Hollow Mile: he lends carts, knows the safe paths, and 'just wants the sickness gone like everyone else.' Under the helpfulness is a poacher's patience and a profiteer's cold arithmetic. He discovered two winters ago that the bog's grey water — the fluid in the grey-walkers' veins, the runoff of the Spring — fetches a fortune upriver as a 'stilling draught' among the dying rich, and he has been quietly grave-robbing the walkers and skimming the bog ever since, shipping it past Sister Ovick's wards and Doctor Mourn's vigilance. He is the reason the Grey Quiet has begun to spread BEYOND Hollow Mile, and he means to own the Spring outright. Charming, useful, and utterly without horror at what he traffics in.",
+      "attitude": "helpful and folksy (publicly); coldly possessive (once unmasked)",
+      "role": "hidden antagonist — see top-level 'antagonist' for stats and scheme",
+      "wants": "To seize the Stillwater Spring and its cursed reagent whole, and sell its grey water upriver forever — using the party (or Eline) to break the chapel's last wards and open the source he can't reach himself.",
+      "knows": [
+        "Everything about the grey water as a COMMODITY: how to harvest it from the walkers, how to ship it past the wards, who buys it upriver, and what it does (and that he does not care).",
+        "That Doctor Mourn is hiding something about the plague's origin — he doesn't know it's hers, but he knows her secrecy is a lever he can pull to turn the party against her.",
+        "Where the drowned chapel and the Stillwater Spring lie, and that Sister Ovick's wards and Eline's vigilance are the only things between him and an endless supply.",
+        "That the third-night rising follows a pattern he can predict and exploit — he plants a 'fresh outbreak' to frame Eline or the party when it suits him."
+      ],
+      "secret": "He is the spreader, not just a skimmer — three towns upriver have begun to report a grey wasting, and it is his barges that carried it there in stoppered bottles. If the party learns this before the crypt, his whole folksy cover collapses; he'll kill to keep it, or flee to the Spring to seize it before they can.",
+      "stat_block": "See top-level 'antagonist'. Bandit Captain (AC 15, HP 65, CR 2) reflavored as a fen-smuggler — twin gutting-knives, a thrown net, a grey-water flask he smashes to raise a walker as cover. Surrounds himself with hired bog-runners (Thugs/Toughs) and, with the wards down, the grey-walkers (Zombies). Fights cornered, prefers ambush, will bargain before blades.",
+      "max_hp": 65,
+      "armor_class": 15,
+      "hit_dice": "10d8+20",
+      "proficiency_bonus": 3,
+      "abilities": {
+        "strength": 15,
+        "dexterity": 16,
+        "constitution": 14,
+        "intelligence": 12,
+        "wisdom": 11,
+        "charisma": 15
+      }
+    },
+    {
+      "id": "sexton-brell",
+      "name": "Old Sexton Brell",
+      "voice_id": "npc-elder",
+      "personality": "Hollow Mile's grave-keeper and nearest thing to an elder: a stooped, mud-stained old man who has dug every grave in the hamlet for fifty years and, these last three winters, dug most of them twice. He is dry, fatalistic, and unexpectedly kind — the only villager who speaks plainly about the third-night rising, because someone has to, and he is too old to be afraid of much. He keeps the burial-ledger, knows who 'lay down' and when, and has noticed (though he can't prove it) that some of his graves have been opened from outside, the bodies robbed of nothing a thief would want. He is the party's lore-anchor for the Grey Quiet's pattern and the human memory of the hamlet's slow dying.",
+      "attitude": "dry, fatalistic, plain-spoken, willing",
+      "role": "ally / lore-giver / village memory",
+      "wants": "To see the Grey Quiet ended before he has to bury the last soul in the Mile, and to be able to keep his dead in the ground where he put them.",
+      "knows": [
+        "The exact pattern of the Grey Quiet: the cold, the slowing, the lying-down, the third-night rising, and that Doctor Mourn's draught only slows it, never stops it.",
+        "That his graves have been opened from OUTSIDE and the bodies tampered with — robbed of something only he would notice was missing (the grey fluid) — and that the reed-barges leave low and at odd hours.",
+        "The location of the old bog-chapel and the drowned crypt beneath it, abandoned a generation ago when the fen swallowed it, and that Sister Ovick still keeps its wards.",
+        "That Doctor Mourn came to the Mile three winters ago, the same winter the Grey Quiet started, and that he has never decided whether that is a blessing or the worst thing he knows."
+      ],
+      "secret": "Brell has known, in his bones, since the first winter, that Doctor Mourn arrived WITH the sickness, not against it — but she has done nothing but ease his neighbors' deaths since, and he has chosen, deliberately, not to look too hard at the timing, because a hamlet that loses its physician on a suspicion loses everything. Sharing that choice — and the grave evidence — is his trust-gift to the party.",
+      "stat_block": "Noncombatant by age, but not helpless — if cornered among the graves he swings a sexton's spade as a Commoner (or a Guard, AC 16, HP 11, if he must defend Ovick). He'd rather hand the party a lantern and a name than fight.",
+      "max_hp": 11,
+      "armor_class": 12,
+      "hit_dice": "2d8+2",
+      "proficiency_bonus": 2,
+      "abilities": {
+        "strength": 11,
+        "dexterity": 10,
+        "constitution": 12,
+        "intelligence": 11,
+        "wisdom": 14,
+        "charisma": 10
+      }
+    },
+    {
+      "id": "sister-ovick",
+      "name": "Sister Ovick",
+      "voice_id": "npc-female-1",
+      "personality": "The last lay-keeper of the drowned bog-chapel — a gaunt, soft-spoken woman in her fifties who tends a faith the hamlet has all but abandoned and keeps, almost alone, the wards that hold the Stillwater Spring sealed beneath the crypt. She is no warrior-priest; her power is patience, salt, candlewax, and a refusal to leave. She suspects more than anyone what lies at the Spring — she has heard the grey-walking child speak from beyond the wards — and she has warded the crypt as much against Doctor Mourn (whose grief she fears will open it) as against Corliss (whose greed she knows will). She is the moral counterweight: where Eline would refine the wound and Corliss would sell it, Ovick has spent her life simply HOLDING THE LINE so it spreads no further, and she is very tired.",
+      "attitude": "quiet, watchful, weary, principled",
+      "role": "ally / ward-keeper / moral counterweight",
+      "wants": "To keep the Stillwater Spring sealed so the Grey Quiet spreads no further — and, if it must be opened, to see it UNMADE rather than harvested, even at the cost of the child still bound there.",
+      "knows": [
+        "The wards on the drowned crypt: how they hold, how they're failing, and that someone (Corliss) has been damaging them from outside to skim the Spring.",
+        "The truth of the Spring — that the original cursed reagent runs there and that the first grey-walker, a child, is bound at its heart — and that this is the SOURCE, not a symptom.",
+        "That Doctor Mourn's draught is made from a refined, weakened form of the same cursed water, and that the physician's grief is the second-greatest danger to the wards after Corliss's greed.",
+        "How the Spring can be UNMADE — consecrated fire and the breaking of the binding at its heart — and that doing so will end the child Wren along with the curse."
+      ],
+      "secret": "Ovick once, in the first winter, let Doctor Mourn into the crypt to 'see the source,' believing the physician might cure it — and Eline knelt at the Spring and could not do what had to be done, and Ovick has kept her out ever since, blaming herself for nearly losing the line to a mother's love. That guilt is why she warded so hard. Sharing it tells the party exactly what Eline's fork is.",
+      "stat_block": "Noncombatant by oath, but defends the wards as a Priest (AC 13, HP 27, CR 2) — Bless, Cure Wounds, Sanctuary, and a consecrating flame she can call once at the Spring; she protects the crypt and the party, never strikes to kill the living.",
+      "max_hp": 27,
+      "armor_class": 13,
+      "hit_dice": "5d8+5",
+      "proficiency_bonus": 2,
+      "abilities": {
+        "strength": 9,
+        "dexterity": 10,
+        "constitution": 12,
+        "intelligence": 13,
+        "wisdom": 16,
+        "charisma": 13
+      }
+    },
+    {
+      "id": "tomas-vane",
+      "name": "Tomas Vane",
+      "voice_id": "npc-male-1",
+      "personality": "Halda's son, a reed-cutter's boy of perhaps fourteen, going grey at the lips and cold in the hands with the early Grey Quiet — lucid still, frightened, trying hard to be brave for his mother. He drifts between sharp clarity and the slow, dreamy stillness the sickness brings, and in his clear moments he is funny and kind and unbearably alive; in the still ones he talks about the reeds 'singing' and a cold light under the bog that wants him to lie down. He is the campaign's human stake made flesh: not a quest-object but a boy the party can save, lose, or be forced to watch through the third-night watch.",
+      "attitude": "frightened, lucid, fading",
+      "role": "the human stake / the ticking case (Act 1, recurring)",
+      "wants": "To not lie down. To get warm. To not frighten his mother. To beat the thing that took his neighbors.",
+      "knows": [
+        "How the Grey Quiet FEELS from inside — the cold, the slowing, the 'song' under the bog, the pull to lie down in the reeds — intelligence the party gets nowhere else.",
+        "That Doctor Mourn's draught helps, but that he can feel it stop working a little more each dose.",
+        "That he has seen the grey-walkers up close at the reed-line at night and that one of them 'looks at the chapel like it wants to go home.'",
+        "Small, true things about the hamlet a frightened boy notices: whose barge leaves at night, where the safe path is, which graves the dogs won't go near."
+      ],
+      "secret": "Tomas, in his stillest moments, has begun to HEAR the grey-walking child Wren at the Spring — a girl's voice asking, over and over, whether the cold doctor is going to come and make it stop or come and make it worse. He doesn't understand it, but a party that listens to him gently learns the Spring is awake and waiting, and that it remembers Eline.",
+      "stat_block": "Noncombatant (Commoner, but frail — treat as 1 HP of plot-health on the third-night clock). If the Grey Quiet claims him and he is not saved, he 'lies down' and rises on the third night as a Zombie reflavored grey — a horror the party may have to face as someone they knew.",
+      "max_hp": 4,
+      "armor_class": 10,
+      "hit_dice": "1d8",
+      "proficiency_bonus": 2,
+      "abilities": {
+        "strength": 9,
+        "dexterity": 11,
+        "constitution": 8,
+        "intelligence": 12,
+        "wisdom": 11,
+        "charisma": 13
+      }
+    }
+  ],
+  "locations": [
+    {
+      "id": "loc-mile-end",
+      "name": "Mile-End & Doctor Mourn's Surgery",
+      "description": "The party's hub: the lower end of Hollow Mile's single sunken road, where the reed-cutters' cottages crowd against the fen and, at the very end, past the chapel-path, stands Doctor Mourn's surgery — a tall, lamplit cottage of scrubbed tables, hanging herbs, and stoppered tinctures, the cleanest room in a hamlet of mud. This is the safe base: the party returns between acts to rest, dose the dying, share findings with Sexton Brell and (warily) Sister Ovick, and sit with Eline by the surgery fire. It is also where the third-night watch is stood, where the Grey Quiet's slow arithmetic is felt, and where the village's gratitude to its masked physician sits in plain sight against the dread the party slowly learns to feel.",
+      "connections": [
+        "loc-reedfen-graves",
+        "loc-drowned-chapel"
+      ],
+      "notes": "HOME-BASE HUB. Halda Vane (quest-giver) and the dying Tomas, Sexton Brell (lore/village memory), and Doctor Mourn's surgery anchor it; Eline, the companion, is the party's inside view of the Grey Quiet. The party rests, levels, doses, and stands the third-night watch here. Eline's loyalty gate (20) can open here after the watch. Connections fan out to the two field-sites; the drowned chapel (Act 2/3) is reached down the chapel-path through the reedfen."
+    },
+    {
+      "id": "loc-reedfen-graves",
+      "name": "The Reedfen & the Sexton's Graves (Act 1 / Act 2)",
+      "description": "The drowned country around Hollow Mile: black-water channels through head-high reed that 'sing' in the wind, plank-paths that sink underfoot, and on the only dry rise, the hamlet's crowded graveyard, where Sexton Brell has dug every plot twice. Will-o'-wisp lights drift over the deep water; at night the grey-walkers come slow and patient to the reed-line, looking toward the chapel like homesick things. By day the party reads the graves Brell says were opened from outside, follows the low-riding barge-tracks, and learns the Grey Quiet's pattern; by night they stand the third-night watch and meet the walking dead as people they may have known.",
+      "connections": [
+        "loc-mile-end",
+        "loc-drowned-chapel"
+      ],
+      "notes": "ACT 1 SITE + Act 2 approach (levels 3-5). Three beats: EXPLORATION (read the tampered graves and the burial-ledger, follow the barge-tracks, find a stoppered grey-water bottle that shouldn't exist; bog hazards — sinking plank-paths, will-o'-wisp lure, cold water); SOCIAL (Brell's plain testimony on the third-night pattern and the opened graves; Halda's bread-for-the-dead confession; Corliss playing the helpful kinsman while warning the party off the bog); COMBAT (the third-night watch — grey-walkers (Zombies) come to the reed-line; the moral knife is that one may be someone the party knew, and Eline treats them as patients, not monsters). See scenes scene-a1-*."
+    },
+    {
+      "id": "loc-drowned-chapel",
+      "name": "The Drowned Bog-Chapel & Crypt (Act 2)",
+      "description": "Down the chapel-path where the fen has swallowed the old shrine to the waist, the Drowned Bog-Chapel leans half-submerged in black water, its bell-tower a roost for fen-birds, its nave flooded to the altar-rail. Sister Ovick keeps a candle burning on the one dry step and the wards salted on the crypt-stair that descends, below the waterline, toward the Stillwater Spring. Here the party crosses from mystery into horror: the truth of the Grey Quiet's source, the failing wards Corliss has been damaging, the grave-robbed reagent, and the first cold breath of the drowned crypt where a child's voice waits in the dark.",
+      "connections": [
+        "loc-mile-end",
+        "loc-reedfen-graves",
+        "loc-stillwater-spring"
+      ],
+      "notes": "ACT 2 SITE (levels 4-6). Three beats: EXPLORATION (the flooded nave and the warded crypt-stair — sabotaged wards, grave-robbed reagent, the chapel's records of the first winter; water/dark hazards, a salt-line puzzle); SOCIAL (Sister Ovick, the ward-keeper who knows the Spring is the SOURCE and that Eline once knelt there and could not act — the midpoint reversal that the cure is the curse; Eline's personal-quest gate (40) and her confession land here, LINKING the cure-that-became-a-curse arc); COMBAT (Corliss's bog-runners and the grey-walkers drawn by the failing wards; the fork pressure-tests as Corliss makes his pitch to seize the Spring). The crypt-stair descends to the Stillwater Spring (Act 3 venue), revealed here. Eline's betrayal agenda may be armed here if approval has curdled."
+    },
+    {
+      "id": "loc-stillwater-spring",
+      "name": "The Stillwater Spring, Beneath the Crypt (Act 3)",
+      "description": "At the bottom of the drowned crypt-stair, below the waterline and the failing wards, a low vaulted chamber holds the Stillwater Spring — a still, grey, faintly luminous pool that does not ripple, where the original cursed reagent wells up from the deep fen and has run, slow and patient, for years. The cold here is the cold of the Grey Quiet itself; the walls are scratched with a child's tally-marks; and at the pool's heart, neither living nor properly dead, the grey-walking remains of the ward Wren sit waiting in the water, the first of the walkers and the binding that keeps the Spring awake. This is where the cure must be unmade at its source — and where Eline must finally do, or fail to do, the one thing three winters of atonement have been avoiding.",
+      "connections": [
+        "loc-drowned-chapel"
+      ],
+      "notes": "ACT 3 SITE (levels 6-7). Three beats: EXPLORATION (descend the warded crypt-stair to the Spring; the binding at its heart, the consecrating-fire method Ovick knows, the cold/horror hazards; the PRIZE — the cursed reagent — is here, seizable); SOCIAL (the confrontation: Wren speaks; Eline's fork resolves — confess-and-unmake (loyalty) or, if the party SEIZES the reagent over destroying it, her prize_seized agenda fires; Corliss arrives to seize the Spring whole and bargains/threatens); COMBAT (the climax: Corliss [Bandit Captain] + bog-runners [Thugs] + grey-walkers [Zombies]; the true win is UNMAKING the Spring — burning the cursed reagent at its source — not a body count, but it costs Wren; if the reagent is seized instead, Eline turns). Reachable only after Act 2 reveals the crypt-stair and the Spring."
+    }
+  ],
+  "arcs": [
+    {
+      "id": "arc-1-third-night",
+      "title": "Act 1 — The Third-Night Watch",
+      "level_range": [
+        3,
+        4
+      ],
+      "beats": [
+        {
+          "id": "a1-hook",
+          "title": "Hook — The Boy Going Grey",
+          "location_id": "loc-mile-end",
+          "summary": "On the sunken road into Hollow Mile, the reed-cutter's wife Halda Vane flags the party down over her dying son Tomas — grey at the lips, going cold with the Grey Quiet — and begs them to walk him to Doctor Mourn's surgery and stand the third-night watch if it comes to that. The party meets the masked physician Eline Mourn (their companion), the helpful kinsman Corliss, and the dread the hamlet won't name."
+        },
+        {
+          "id": "a1-challenge",
+          "title": "Challenge — Reading the Fen",
+          "location_id": "loc-reedfen-graves",
+          "summary": "While Tomas is dosed, the party works the reedfen: Sexton Brell's tampered graves and burial-ledger, the low-riding barge-tracks, a stoppered grey-water bottle that shouldn't exist, and the Grey Quiet's third-night pattern. Corliss plays helpful while warning them off the bog; Eline lets the first crack show — the draught is hers and it only buys time."
+        },
+        {
+          "id": "a1-climax",
+          "title": "Climax — What Comes Back",
+          "location_id": "loc-reedfen-graves",
+          "summary": "The third night falls and the grey-walkers come slow to the reed-line — and one of them may be someone the party has met. Eline treats them as patients, not monsters, and how the party answers (ease them, study them, or torch them wholesale) is the act's moral knife. The party holds the watch, learns the walkers turn toward the chapel like homesick things, and earns the first thread to the source."
+        }
+      ]
+    },
+    {
+      "id": "arc-2-drowned-chapel",
+      "title": "Act 2 — The Drowned Chapel",
+      "level_range": [
+        4,
+        6
+      ],
+      "beats": [
+        {
+          "id": "a2-hook",
+          "title": "Hook — The Cure Is the Curse",
+          "location_id": "loc-mile-end",
+          "summary": "Back at the surgery, the party puts the bog-bottle, the tampered graves, and the walkers-turning-home together — and Eline, or Sister Ovick, names the unbearable shape of it: the Grey Quiet is not a natural sickness, and the draught holding it at bay is a weakened form of the very thing that causes it. The trail leads down the chapel-path to the drowned crypt and the source beneath it."
+        },
+        {
+          "id": "a2-challenge",
+          "title": "Challenge — The Ward-Keeper's Line",
+          "location_id": "loc-drowned-chapel",
+          "summary": "At the half-submerged bog-chapel, Sister Ovick keeps the failing wards on the crypt-stair — wards Corliss has been sabotaging to skim the Spring. The MIDPOINT REVERSAL lands: the source is the Stillwater Spring below, the first grey-walker is a child, and Doctor Mourn once knelt there and could not act. Eline confesses (her personal-quest gate, LINKED to the cure-that-became-a-curse arc); the fork tightens as Corliss makes his pitch."
+        },
+        {
+          "id": "a2-climax",
+          "title": "Climax — The Wards Break",
+          "location_id": "loc-drowned-chapel",
+          "summary": "Corliss's hand is forced: his bog-runners and the grey-walkers drawn by the failing wards converge on the crypt as he moves to open the way to the Spring. The party holds the line with Ovick, secures the consecrating-fire method, and learns the cost ahead — to unmake the Spring is to end the child Wren. The crypt-stair to the Stillwater Spring opens; Eline's betrayal agenda arms if approval has curdled."
+        }
+      ]
+    },
+    {
+      "id": "arc-3-stillwater",
+      "title": "Act 3 — The Stillwater Spring",
+      "level_range": [
+        6,
+        7
+      ],
+      "beats": [
+        {
+          "id": "a3-hook",
+          "title": "Hook — Down to the Source",
+          "location_id": "loc-mile-end",
+          "summary": "The party prepares for the descent: Ovick's consecrating fire, the truth of the binding, and the weight of what's coming — for the only cure for the whole fen is to burn the cursed reagent at its source, and that ends Wren. Eline reaches her crisis. With Corliss racing to seize the Spring first, the party goes down the warded crypt-stair before mercy and greed both run out of time."
+        },
+        {
+          "id": "a3-challenge",
+          "title": "Challenge — The Cold Pool",
+          "location_id": "loc-stillwater-spring",
+          "summary": "Below the waterline, the Stillwater Spring waits — still, grey, luminous, the child Wren bound at its heart, the cursed reagent welling cold from the deep. The party must reach the binding, ready the consecrating fire, and choose: unmake the Spring (the cure, at Wren's cost) or SEIZE the reagent (for use, study, or Corliss's coin). Wren speaks; Eline's fork resolves on what the party does at the pool."
+        },
+        {
+          "id": "a3-climax",
+          "title": "Climax — The Unmaking",
+          "location_id": "loc-stillwater-spring",
+          "summary": "Corliss arrives to seize the Spring whole, his runners and the raised grey-walkers at his back, and the party must break his hold on the source. The true victory is UNMAKING the Spring — consecrating fire to the cursed reagent, the binding broken, Wren released — which cures the fen but ends the child and forces Eline's choice. If instead the party seizes the reagent, 'prize_seized' fires and Doctor Mourn turns, clinical and cold, to excise the contaminant the party has become."
+        }
+      ]
+    }
+  ],
+  "scenes": [
+    {
+      "id": "scene-a1-hook",
+      "name": "The Boy Going Grey",
+      "type": "social",
+      "location_id": "loc-mile-end",
+      "read_aloud": "The sunken road into Hollow Mile runs below the level of the fen, a green tunnel of head-high reed that whispers on both sides though there is no wind. Where the road meets the first cottages, a broad woman with reed-scarred hands steps into your path and does not move, because in her arms is a boy of perhaps fourteen, grey at the lips and shivering with a cold that has nothing to do with the season. 'You're outsiders,' she says, flat, like it's the only good news she's had in a month. 'You don't have the fear yet.' She shifts the boy's weight; he stirs, mumbles something about the reeds singing, goes still again. 'His name's Tomas. Mine's Halda. He's got the Grey Quiet, and the only thing that slows it is the doctor at the end of the Mile.' Her jaw works. 'Walk him down for me. And if the cold takes him before we get there — stand the third night with me. The last family that lost someone didn't. They woke up to find their dead at the door.' Down the Mile, at the very end past a sunken chapel-path, a tall lamplit cottage burns its lights against the dusk, and a figure in a long oiled coat and a beaked leather mask watches from the door.",
+      "dm_notes": "Establish the hub, the human stake, and the gothic dread — and plant the companion in plain sight. Halda Vane (npc-female-1) is the quest-giver: practical, worn past fear, asking not for a cure she can't buy but for strong arms and an outsider's nerve. Tomas (npc-male-1) is the ticking case — lucid but fading, and his 'the reeds are singing / a cold light wants me to lie down' is the first real eeriness. Play the dread quiet and physical: the windless whispering reed, the cold that isn't weather, the village's refusal to name the third-night rising. THE COMPANION: Doctor Eline Mourn (companion-default) is the masked physician at the Mile's end — she takes the boy with clean, exact hands, doses him with the Stillwater Draught, and is by every visible measure the hamlet's salvation. She NEVER removes the mask. She speaks like a clinician (terse, kind, no sentiment) and recruits to the party as the only hands here that don't already worship or fear her — frame it as her asking the capable outsiders to help her hold the line, not the party hiring her. Do NOT tip that the plague is hers; that reveal is Act 2's payoff. THE ANTAGONIST hides here too: Corliss Vane (npc-rogue) appears as the helpful kinsman — lends a cart, knows the road, and warns the party 'stay off the bog, for your own good' (the first note that sounds more like a man guarding a claim than care). Sexton Brell (npc-elder, dry/fatalistic) can be met here or at the graves and gives the first plain word about the third-night rising. The hook is moral, not monetary — a dying boy, a frightened hamlet, a watch to stand — plus Eline's quiet, magnetic strangeness.",
+      "checks": [
+        {
+          "skill": "Medicine",
+          "dc": 13,
+          "success": "You read Tomas the way the masked doctor does — and what you find is wrong in a way no plague should be. This isn't infection; it's something closer to a slow freezing of the will, the body going quiet by degrees, and faint in his cold blood is a grey shimmer you've never seen in any sickness. Doctor Mourn watches you find it, and through the beak of the mask, very quietly, says: 'You see it too. Good. Then you won't waste my time pretending it's a fever.' (Flags that the Grey Quiet is unnatural, and earns Eline's first flicker of regard — trusting_evidence_over_superstition.)",
+          "failure": "It's a wasting sickness, cold and grey and bad — beyond your skill to name. The doctor takes the boy without comment and doses him; you've helped carry him, and that's enough for now. The strangeness of the thing waits for a closer look."
+        },
+        {
+          "skill": "Insight",
+          "dc": 13,
+          "success": "Two reads under the surface. Halda is telling the plain truth and is far past hoping for a cure — she wants a WATCH stood, which means she expects the boy to die and rise. And the masked doctor, for all her clean calm, carries something heavier than a hard case: when Halda says 'the Grey Quiet,' the beaked mask turns away a fraction, the way a person turns from a thing they can't look at straight. (Flags Eline's hidden weight and the realness of the third-night dread.)",
+          "failure": "A frightened mother, a dying boy, a strange doctor in a stranger hamlet — grim, but it reads as exactly the grim job it appears to be. The doctor's calm is just a professional's calm; the unease keeps for later."
+        }
+      ],
+      "encounter": null,
+      "transitions": "When the party takes Halda's case — walking Tomas to the surgery and agreeing to the watch — they're drawn into the hamlet's slow dying. Working the fen and the graves while Tomas is dosed moves to scene-a1-fen at loc-reedfen-graves; the third-night watch is scene-a1-watch."
+    },
+    {
+      "id": "scene-a1-fen",
+      "name": "Reading the Fen",
+      "type": "exploration",
+      "location_id": "loc-reedfen-graves",
+      "read_aloud": "While the boy sleeps under the doctor's draught, you walk the drowned country around Hollow Mile, and it does not want you. Plank-paths sink underfoot into black water; the reed sings without wind; pale lights drift over the deep channels, beautiful and patient, exactly far enough off the path to drown you. On the one dry rise stands the graveyard, and old Sexton Brell leans on his spade among plots he says he's dug twice, and points with a mud-black finger at three graves whose earth has been opened — not by any animal, and not from the inside. In the reeds by the water you find a barge-pole's scrape in the mud and, half-sunk where it was dropped, a small stoppered bottle of still grey water that catches the light wrong, the way the boy's blood did.",
+      "dm_notes": "ACT 1 EXPLORATION and the start of the mystery's spine. Threads: (1) The TAMPERED GRAVES — Brell (npc-elder) shows three graves opened from OUTSIDE, the bodies robbed of nothing a normal thief would want (Investigation: the corpses were drained of the grey fluid; someone is harvesting the dead). (2) The BARGE-TRACKS — low-riding barge scrapes and night-departures lead toward the deep fen and, eventually, the chapel (Survival/Investigation to follow; they tie to Corliss). (3) The GREY-WATER BOTTLE — a stoppered sample that 'catches the light wrong' (Arcana/Medicine: it's the same grey shimmer as Tomas's blood, refined; the first hard clue that the sickness is being BOTTLED). (4) The third-night PATTERN — Brell lays it out plainly: cold, slowing, lying-down, third-night rising, and that the walkers drift toward the old chapel 'like they want to go home.' SOCIAL: Halda may confess she leaves bread out for her dead husband on the third night (the human cost); Corliss (npc-rogue) turns up 'to help,' lends a hand, and warns the party off the deep bog with a smile that doesn't reach his eyes. COMPANION: Eline (companion-default) reads the grey-water bottle with a stillness that should worry a sharp party (Insight) — she recognizes it, and covers; this is where her loyalty gate (20) can begin to open if the party has been decent and unsuperstitious. Hazards: sinking plank-paths (DC 12 Dexterity/Acrobatics), will-o'-wisp lure off the path (DC 13 Wisdom save to resist the pretty lights; treat as terrain/atmosphere, not a fight unless the party blunders deep), cold water (exhaustion risk on a long soak).",
+      "checks": [
+        {
+          "skill": "Investigation",
+          "dc": 14,
+          "success": "You work the three opened graves and the burial-ledger together and the picture is grave-robbery of the strangest kind: the bodies weren't taken or robbed of valuables — they were DRAINED, each one tapped for the grey fluid in its veins, the same grey that shimmers in the bottle and in Tomas's blood. Cross-referenced against the barge-tracks, someone is harvesting the dead of Hollow Mile and carrying the take out by water at night. (You're holding proof the Grey Quiet is being collected and shipped — by a hand that knows exactly what it's worth.)",
+          "failure": "The graves were opened from outside and the bodies disturbed, but the busy, sunken earth and Brell's old ledger won't give you the why at a glance. You DO confirm the openings are recent and deliberate, and the barge-tracks are real — enough to know someone is working the graves and the water, even if the purpose waits for the chapel."
+        },
+        {
+          "skill": "Arcana",
+          "dc": 13,
+          "success": "The stoppered grey water is no natural thing. It carries a faint, cold necromantic resonance — death held at a stillpoint, neither rot nor rest — the same signature as the chill in Tomas's blood, but concentrated and refined, as if someone distilled the sickness down to its essence and bottled it. This is not a symptom of the Grey Quiet; it is the Grey Quiet, purified — and purifying it took skill and intent. (The first hard proof the plague is MADE, not caught.)",
+          "failure": "The water is cold past reason and 'wrong' to the touch, and your senses recoil from it, but you can't pin the resonance precisely — only that it's the same wrongness as the boy's blood, and that water doesn't sit that still on its own. Eline, if asked, will name it 'the Quiet, concentrated,' and say no more."
+        },
+        {
+          "skill": "Insight",
+          "dc": 14,
+          "success": "Watching Eline handle the grey-water bottle, you catch what her mask is built to hide: she didn't discover it, she RECOGNIZED it — her gloved hands went still the way Halda's did over her dying son, and for half a breath the clinician's calm was grief wearing a coat. She covers smoothly, but you know now that the doctor holding the Grey Quiet at bay knows this poison far better than three winters of treating it could teach her. (Plants the truth of Eline's secret without spending the reveal; played gently, it deepens her loyalty gate rather than spooking her.)",
+          "failure": "Eline studies the bottle with a physician's detachment and hands it back with a clinical word about 'the concentrated agent.' Whatever she feels stays behind the beak of the mask; you learn the substance is dangerous, not that the doctor is bound to it."
+        }
+      ],
+      "encounter": null,
+      "transitions": "The grave-evidence and the barge-tracks point two ways: out to the deep fen and the chapel-path (Act 2), and forward to the third night, when the dead the party has been reading about come back. When dusk of the third night falls, move to scene-a1-watch. (A party that pushes straight for the chapel can be slowed by the bog and the failing light; the watch comes first.)"
+    },
+    {
+      "id": "scene-a1-watch",
+      "name": "What Comes Back",
+      "type": "combat",
+      "location_id": "loc-reedfen-graves",
+      "read_aloud": "The third night comes the way Brell said it would: still, and cold, and wrong. You stand the watch at the reed-line with Halda's lantern between you, and somewhere past midnight the singing of the reeds changes pitch, and they come — slow, patient figures wading up out of the black water, grey-skinned and unhurried, water streaming off them, their faces calm as sleepers. They do not lunge. They WALK, steady and homeward, toward the lamplit Mile and the chapel beyond it, as if they are only late getting home. The lantern catches the nearest one's face, and Halda makes a sound you will not forget — because you have seen this man before, in a portrait over her hearth, two winters in the ground. Beside you, Doctor Mourn does not draw a weapon. She lifts her bag. 'They are not attacking,' she says, very evenly. 'They are PATIENTS. Try to remember that, whatever happens next.'",
+      "dm_notes": "First COMBAT and the campaign's tonal thesis: the grey-walkers (Zombies, reflavored grey and homeward) are the WALKING DEAD AS VICTIMS, not gleeful monsters — they shamble toward the Mile and the chapel 'to go home,' and one of them is Halda's dead husband (a gut-punch the party must navigate). The fight: 2-3 grey-walkers (Zombie, AC 8, HP 22, CR 1/4) wading up at the reed-line; they are slow, relentless, and dangerous in numbers but not malicious — they grapple and drag toward the water more than they savage. THE MORAL KNIFE: Eline (companion-default) will NOT torch them; she treats them as patients, tries to ease/restrain rather than destroy, and how the party answers is a major approval beat — easing/containing them and respecting Halda's dead (ease_a_hopeless_case_cleanly / treat_the_grey_walkers_as_patients) wins Eline hard; torching them wholesale over her objection (torch_the_grey_walkers_wholesale / burning the sick to be safe) is the first push toward her betrayal gate (15). The walkers' turning-toward-the-chapel is the key CLUE the party carries forward (they're drawn to the Spring). If Tomas died and rose, this is where the party may face HIM — reserve that for a party that failed his case, and play it for everything. HAZARD: the deep water at the reed-line (a walker that grapples a PC drags toward drowning — DC 13 Strength to break free); the will-o'-wisps may gather. Eline's loyalty gate (20) opens here for a party that stands the watch and honors the dead. Do NOT make this a slasher beat; make it a grief beat with stakes.",
+      "checks": [
+        {
+          "skill": "Religion",
+          "dc": 13,
+          "success": "You understand what you're seeing — not undead raised to kill, but souls STILLED, held at a deathless stillpoint and called homeward by something that has them on a tether. Naming a rite of rest over Halda's husband (or any walker) lets you lay it down GENTLY — eased back into true death rather than hacked apart — and the others slow, as if the gesture matters to them. (Eline's approval surges; the surest way to hold the watch without butchery, and a clue that the walkers answer to a source, not a hunger.)",
+          "failure": "The walkers are beyond a prayer's easy reach tonight; you can still put them down, but the hard way, and Halda has to watch her husband fall a second time. The rite waits until you understand the source better (the chapel, the Spring) — for now, hold the line however you can."
+        },
+        {
+          "skill": "Insight",
+          "dc": 12,
+          "success": "You watch where they GO. Not at you — past you, every grey face turned the same way, wading toward the sunken chapel-path at the Mile's end 'like they want to go home.' Whatever is pulling them is down that path and under the water, and it is pulling hard enough to walk the dead through a hamlet full of the living without a glance. (The thread to the drowned chapel and the source — Act 2's direction, earned in the worst possible moment.)",
+          "failure": "In the dark and the grief and the cold water it's all you can do to hold the line; the walkers' purpose is lost in the chaos. You survive the watch and keep the Mile, but the WHERE of what's pulling them waits for daylight and Brell's plain word about the chapel."
+        }
+      ],
+      "encounter": {
+        "monsters": [
+          {
+            "name": "Zombie",
+            "count": 3,
+            "reflavor": "Grey-walkers — the Grey Quiet's dead, wading up grey and homeward, water streaming off them. NOT malicious: they walk toward the Mile and the chapel 'to go home,' grapple and drag toward the water more than they savage. One is Halda's dead husband (play the grief). Use bundled Zombie (CR 1/4). At least one can be laid to rest gently (Religion) rather than destroyed."
+          }
+        ],
+        "tactics": "The grey-walkers wade up slow and relentless at the reed-line, ignoring the party where they can to push HOMEWARD toward the chapel-path; they grapple and drag toward the deep water rather than maul, making drowning the real threat. They are turned/eased by a rite of rest (Religion) and put down hard by force; Eline tries to contain and ease, never torch, and pleads for the same. The deep water behind the line is a drowning hazard (a grappled PC dragged in makes DC 13 Strength saves). Keep the body count optional and the grief central — a watch that ends with the dead laid gently to rest is the BETTER outcome and the one Eline's approval rewards.",
+        "scaling": "Party of 1-2 or all-squishy: 2 grey-walkers (Zombies). Party of 3-4: 3 Zombies. Party of 4+ or running hot: 4-5 Zombies, or 3 + a stronger 'first-risen' walker (Ogre Zombie or a Ghoul for a faster, hungrier horror). If Tomas died and rose, add him as a single grey-walker the party must face as someone they tried to save — worth more than any XP line.",
+        "xp": 300,
+        "xp_note": "3x Zombie (50 each = 150), budgeted up to ~300 with the third-night stakes and the grief of Halda's husband. Award FULL value whether the walkers are destroyed, eased to rest (Religion), or contained — laying them down gently is overcoming the encounter, not avoiding it, and a story bonus for honoring Halda's dead."
+      },
+      "transitions": "With the watch held and the dead — eased or felled — laid down, the party has the thread that matters: the grey-walkers turn toward the chapel-path, drawn by something under the water. They return to loc-mile-end (level 4-ish) to regroup; Act 2's hook (the cure-is-the-curse reveal with Eline and Ovick, and the descent to the drowned chapel) opens. Eline's loyalty gate (20) likely stands open after a watch well kept."
+    },
+    {
+      "id": "scene-a2-hook",
+      "name": "The Cure Is the Curse",
+      "type": "social",
+      "location_id": "loc-mile-end",
+      "read_aloud": "Back in the clean lamplight of the surgery you lay it all on the scrubbed table: the stoppered grey water, the rubbing of a tampered grave, Brell's ledger of the lying-down and the rising, and the one fact none of you can put down — that the dead don't claw, they WALK, homeward, toward the drowned chapel at the end of the Mile. Doctor Mourn stands very still over the evidence, the lamp throwing the beak of her mask long across the wall. For a long moment she says nothing. Then she takes the stoppered bottle, holds it to the light, and you watch a woman decide whether to lie. 'The Stillwater Draught I give your boy,' she says at last, and her clinician's calm has a hairline crack in it, 'is a weakened form of exactly this. The thing in this bottle is not what causes the Grey Quiet.' She sets it down with great care. 'It is the Grey Quiet. Refined. And I have been dosing this hamlet with a gentler cup of the same cold water for three winters, because it was the only thing I had that slowed it.' She looks at you through the mask. 'You wanted to know what I'm hiding. There. Now ask me the next question, and I will tell you whether I can bear to answer it.'",
+      "dm_notes": "ACT 2 HOOK and the MIDPOINT REVERSAL stated plainly: the cure is the curse — the draught holding the Grey Quiet at bay is a weakened form of the very thing that causes it. This is the campaign's spine turning over, and it should land as horror, not gotcha. Eline (companion-default) cracks the first layer of her secret here: the draught is hers and it's the same cold water, refined. She does NOT yet name Wren or the Spring unless the party reaches her personal-quest gate (40) — keep the full confession (Wren, the first cure, the Spring beneath the chapel) for the chapel/crypt where it has a stage to live in (it's LINKED to the cqarc-eline-stillwater quest-arc, stage cqstage-eline-confession). Sister Ovick (npc-female-1) can be introduced here or at the chapel as the ward-keeper who knows the SOURCE — she's the one who can name the Stillwater Spring beneath the drowned crypt and that the first walker is a child. Corliss (npc-rogue) works the other side: he plants the LIE that the doctor's draught is what spreads the sickness (a half-truth that turns the party against Eline if they're inclined to superstition) — watch for a party that buys it and treats Eline as the villain, which is a fast push toward her betrayal gate (15). THE FORK FRAMING: this is where the party's posture toward Eline sets — do they treat her as a monster who made a plague, or a physician trying to end the thing she set loose? Trusting_evidence_over_superstition and giving her the chance to atone (rather than torching her) is the loyalty path. Cassian-equivalent here is Ovick: the moral counterweight who has spent her life HOLDING THE LINE. Name the DROWNED CHAPEL and the crypt-stair as the next destination. NOTE: if the party never opened Eline's loyalty gate, run this as a colder, warier scene — she reveals less, and a freed grave-prisoner or Ovick supplies the same reveal; don't hard-gate the descent on Eline's trust.",
+      "checks": [
+        {
+          "skill": "Insight",
+          "dc": 13,
+          "success": "You meet Eline's confession without recoiling, and you see the whole shape of her in it: not a poisoner gloating, but a woman who has been holding a wound shut with her bare hands for three winters and is exhausted past the mask. Naming it gently — 'you didn't catch this; you MADE it, and you've been trying to unmake it ever since' — reaches her completely. She doesn't deny it. She tells you there is more, and worse, and that she will show you if you'll come down to the chapel. (Opens her toward the personal-quest gate; the surest way to keep the fork on the loyalty side instead of treating her as the villain Corliss wants her to be.)",
+          "failure": "You catch that Eline is telling a partial truth and bracing for a verdict — but pressing for the rest, or recoiling from her, makes her shut the mask and go clinical and cold again. She'll still guide you toward the chapel, but the full confession, and the warmth of her trust, waits until you've shown her you won't burn her for what she's about to admit."
+        },
+        {
+          "skill": "Investigation",
+          "dc": 13,
+          "success": "Working Eline's draught against the bottled grey water, you confirm the chemistry of the horror: same agent, same cold resonance, hers merely diluted and buffered — and the dilution is FAILING, a little more each batch, which is why the draught buys less time every dose. Whatever the source is, it's growing stronger, and the trail of refinement and the barge-tracks both run to the same place: the drowned chapel and whatever the wards there are holding under the water. (Confirms the cure-is-the-curse and points hard at the crypt.)",
+          "failure": "The two samples are plainly kin and plainly dangerous, but the exact chemistry stays past your reach in a surgery this small. You know the draught is a weaker cousin of the bottled curse and that both lead toward the chapel — enough to go down, even without the full picture."
+        }
+      ],
+      "encounter": null,
+      "transitions": "Armed with the cure-is-the-curse and the chapel as the source, the party takes the chapel-path down through the reedfen to the drowned bog-chapel — move to scene-a2-chapel at loc-drowned-chapel. (A party that bought Corliss's lie and turned on Eline still ends up at the chapel — Ovick and the wards force the truth into the open below.)"
+    },
+    {
+      "id": "scene-a2-chapel",
+      "name": "The Ward-Keeper's Line",
+      "type": "exploration",
+      "location_id": "loc-drowned-chapel",
+      "read_aloud": "The chapel-path ends where the fen has eaten a shrine to the waist. The Drowned Bog-Chapel leans in the black water, its nave flooded to the altar-rail, its bell-tower a roost for pale birds that do not sing. On the one dry step a single candle burns, and behind it stands a gaunt woman in a lay-keeper's grey, a line of salt across the crypt-stair at her back and a look on her face like she has been waiting three winters for you and dreading it the whole time. 'You brought the doctor,' Sister Ovick says, and it is not quite an accusation. Below her, the crypt-stair descends into water and dark, and from somewhere far down it, faint and patient and unmistakably a child's, a voice is singing the same tune the reeds sing. The salt-line at the stair-head is broken in two places, scuffed away from the OUTSIDE, and recently. 'Someone's been breaking my wards,' Ovick says softly. 'Skimming what's below to sell. And the more he breaks them, the louder she sings, and the more of them lie down and walk.' She looks at Eline, and her voice goes very gentle and very hard at once. 'You know what's down there, doctor. You've known the whole time. Are you finally going to help me end it — or just kneel by it and weep again?'",
+      "dm_notes": "ACT 2 EXPLORATION + the SOCIAL heart that delivers the full reversal and Eline's confession. Sister Ovick (npc-female-1) is the ward-keeper and moral counterweight: she has held the Stillwater Spring sealed for years and knows it is the SOURCE — the original cursed reagent, and the first grey-walker, a CHILD, bound at its heart. She names that Eline once knelt at the Spring and could not act, which is why Ovick warded so hard (against the doctor's grief as much as the smuggler's greed). Threads: (1) The SABOTAGED WARDS — the salt-lines are broken from outside, recently (Investigation/Perception: Corliss has been breaking them to skim the Spring; the more broken, the more walkers rise). (2) The CHAPEL RECORDS — the first winter's entries place Doctor Mourn's arrival with the sickness, not against it (the timing Brell wouldn't look at). (3) The CRYPT-STAIR — descends below the waterline toward the Spring; warded, cold, and a child's voice singing up it (the binding is awake and aware). (4) ELINE'S CONFESSION + PERSONAL-QUEST GATE: if the party has earned it (approval/loyalty), Eline tells the WHOLE of it here — Wren, the ward she tried to save; the first draught that unmade the girl into the first walker; the Spring where the cursed reagent still runs and Wren still waits; and that she has never been able to do the one thing that would end it: burn the Spring, Wren and all. THIS IS HER personal_quest GATE (threshold 40), LINKED via quest_arc_id 'cqarc-eline-stillwater' (stage 'cqstage-eline-confession') — she asks the party's help to reach the Spring and unmake it. (5) THE FORK: Corliss's pressure peaks — he wants the wards down and the Spring open to seize; a party that sides with his profit, or that treats Wren/the walkers as monsters to be torched, or that eyes the cursed reagent as a PRIZE to take, pushes toward the betrayal gate (15) and ARMS the prize_seized agenda. COMPANION: give Eline the confession as her arc's emotional center; if her loyalty gate isn't open, Ovick carries the reveal and Eline confirms it coldly. Hazards: flooded nave (difficult terrain/swim), the broken wards (a Religion/Arcana check to re-salt and slow the rising), the cold of the crypt-stair.",
+      "checks": [
+        {
+          "skill": "Insight",
+          "dc": 14,
+          "success": "You read Eline at the threshold of her confession and meet it true — naming, gently, that the child's voice singing up the stair is someone she KNOWS, someone she's been keeping down there in the cold rather than ending. It breaks the last of the mask. She tells you all of it: Wren, the ward she brewed the first draught to save; how it unmade the girl into the first of the walkers and seeped into the water to make the Quiet; the Stillwater Spring below where the cursed reagent still runs and Wren still waits; and that the only cure is to burn the Spring, Wren and all, and that she has never once been able to do it. She asks your help to go down and do what she cannot. (Opens her personal-quest gate (40), LINKED to cqarc-eline-stillwater / cqstage-eline-confession — the cure-that-became-a-curse made her quest; the single best insurance against the fork.)",
+          "failure": "Eline goes white behind the mask and gives you the bones of it — that the source is below, that she is bound to it, that it cannot simply be cured — but the rest, and Wren's name, stay locked behind a grief she can't open under Ovick's eyes. Sister Ovick supplies the shape of the truth regardless: a child at the Spring's heart, a cure that has to be UNMADE not refined. You'll go down knowing what waits, if not the whole of what it costs the doctor."
+        },
+        {
+          "skill": "Investigation",
+          "dc": 13,
+          "success": "You work the broken salt-lines and the chapel records together and the smuggler's hand is plain: the wards were scuffed from the OUTSIDE, recently and repeatedly, by someone tapping the Spring below and shipping the take by barge — and the first-winter records put Doctor Mourn's arrival the same season the Quiet began. The sabotage is fresh enough that whoever's doing it means to open the way to the Spring soon, with you here or not. (Ties Corliss to the broken wards and the harvest; sets the race to the Spring.)",
+          "failure": "The wards are broken and the records are damp and half-ruined; you can tell someone's been at the stair from outside and that the chapel is older than the hamlet's memory, but the smuggler's full pattern and the timing of Eline's arrival stay murky until Ovick or Eline spells it out. You know the way down is being forced — not yet by whom."
+        },
+        {
+          "skill": "Religion",
+          "dc": 13,
+          "success": "Working with Sister Ovick, you read the wards for what they are — a binding of REST laid over a thing that refuses to rest, salt and candle and patience holding a stillpoint shut — and you can help her re-lay the broken lines, slowing the rising and buying the hamlet time. More, you learn the METHOD of unmaking: consecrated fire to the cursed reagent at its source, and the breaking of the binding at the Spring's heart — which is to say, the ending of whatever the binding holds. (Secures the Act 3 win-method and earns Ovick as a firm ally; names, without flinching, that unmaking the Spring ends the child bound there.)",
+          "failure": "The wards are beyond your hand to mend tonight, and Ovick re-lays what she can alone; you grasp that the source must be UNMADE rather than cured, but the exact rite — consecrating fire, the breaking of the binding — waits on Ovick's instruction at the Spring itself. You go down knowing the goal, not yet the method."
+        }
+      ],
+      "encounter": null,
+      "transitions": "With the reversal landed (the cure is the curse, the source is the Spring, the first walker is a child), Eline's confession told or Ovick's truth in hand, and the unmaking-method learned, the party faces the forced descent. As Corliss's hand closes on the wards, move to scene-a2-break — the fight to hold the crypt and open the stair on the party's terms, not the smuggler's."
+    },
+    {
+      "id": "scene-a2-break",
+      "name": "The Wards Break",
+      "type": "combat",
+      "location_id": "loc-drowned-chapel",
+      "read_aloud": "It happens fast, the way the bog does things. A barge-pole splashes in the dark of the flooded nave; a stoppered bottle arcs out of the reeds and shatters on the broken salt-line, and the grey water in it hisses where it lands. Sister Ovick cries out and throws salt, but the last of the ward gutters — and down the crypt-stair the child's singing swells, glad and terrible, and answered. Out of the black water of the nave the grey-walkers rise, drawn up the chapel-path to the source that calls them; and along the gallery, where the helpful kinsman Corliss Vane stands with a gutting-knife in each hand and bog-runners at his back, the folksy smile is finally, entirely gone. 'Nothing personal, doctor,' Corliss says, almost kindly, over the singing. 'But that Spring's been feeding three towns and a buyer who pays in gold, and I'm not about to let a hamlet of corpses and a weepy physician seal it up now. Hold them off my wards, lads. Once it's open, it's mine.'",
+      "dm_notes": "ACT 2 CLIMAX — the second COMBAT, Corliss's hand forced into the open, and the race for the Spring. Corliss (npc-rogue, see top-level 'antagonist') drops the helpful-kinsman mask here: he's the smuggler skimming the Spring, and he means to break the last wards and seize the source. He does NOT necessarily fight to the death here — he wants the wards DOWN and the way OPEN, and may break off toward the Spring (Act 3) once the salt-line is gone, leaving the party and Ovick to the rising walkers (he survives to the climax unless the party is exceptional; capturing him here yields the buyer and the full smuggling picture). The fight is twofold: (1) Corliss's BOG-RUNNERS (Thug/Tough, AC 12, HP 32) trying to break/keep-broken the wards, and (2) the GREY-WALKERS (Zombies) rising from the nave, drawn up toward the singing — a chaos of the hostile-living and the pitiable-dead at once. THE OBJECTIVE is to HOLD/RE-LAY the wards (a Religion/Arcana skill-objective with Ovick) and decide the way down is opened on the PARTY's terms, not Corliss's. THE FORK pressure-tests: Corliss may pitch the party directly ('there's coin in that water; the doctor wants to BURN a fortune') — taking his deal, eyeing the reagent as profit, or torching the rising walkers wholesale over Eline's plea pushes hard toward her betrayal gate (15) and arms the prize_seized agenda. COMPANION: Eline fights to PROTECT the walkers from being slaughtered even as they menace the party (treat_the_grey_walkers_as_patients) and to keep the reagent from Corliss's hands — a wrenching split; honor it and her loyalty deepens toward the climax. Ovick (Priest) fights only to defend the wards and the party, calling Sanctuary and Bless, never to kill. HAZARDS: the flooded nave (difficult terrain/swim, drowning if grappled under), the broken salt-line (a re-lay objective under fire), the cold. STAKES: lose, and the wards break uncontrolled and the Spring opens to Corliss; win, and the party descends to the Spring ready, with Corliss beaten back or captured.",
+      "checks": [
+        {
+          "skill": "Religion",
+          "dc": 14,
+          "success": "Working beside Ovick under fire, you re-lay the broken salt-lines and steady the binding — not sealing the Spring (that's the climax) but holding the rising walkers at the threshold and denying Corliss the uncontrolled break he wants. The way down opens on YOUR terms: warded, deliberate, with the singing held to a murmur. (Wins the objective; the party descends ready instead of overrun, and Ovick's consecrating fire is secured for the Spring.)",
+          "failure": "The wards won't hold under Corliss's sabotage and the walkers' pull; the salt-line breaks wide and the singing swells. You can still take the stair, but you go down with the Spring fully awake and the walkers loose behind you — a harder descent, and Corliss already racing ahead into the dark."
+        },
+        {
+          "skill": "Intimidation",
+          "dc": 14,
+          "success": "You break the bog-runners' nerve — hired muscle has no stomach for a chapel full of singing dead — and one or more throw down and flee or talk, naming Corliss's buyer upriver and the three towns already going grey from his bottles. A cornered runner (or Corliss, if trapped) confirms the endgame: he means to take the Spring whole and sell it forever. (Damning, and the lever to expose Corliss as the SPREADER, not just a skimmer.)",
+          "failure": "The runners hold, paid too well and too afraid of Corliss to break, and he covers his own break toward the Spring behind them. You win the nave the hard way and piece his plan together from Ovick and the bottles — and he's already on the stair ahead of you."
+        }
+      ],
+      "encounter": {
+        "monsters": [
+          {
+            "name": "Thug",
+            "count": 3,
+            "reflavor": "Corliss's hired bog-runners — fen-smugglers paid to break the wards and guard the harvest, surrender-prone once the singing dead start rising around them. Resolves to bundled 'Tough' (CR 1/2). Scale to 2 for a light party, 4 for a strong one."
+          },
+          {
+            "name": "Zombie",
+            "count": 3,
+            "reflavor": "Grey-walkers rising from the flooded nave, drawn UP toward the singing Spring — pitiable, relentless, a hazard to both sides. Use bundled Zombie (CR 1/4); Eline pleads to ease, not slaughter, them. They menace the living indiscriminately but turn always toward the source."
+          }
+        ],
+        "boss": {
+          "name": "Corliss Vane",
+          "npc_id": "antagonist",
+          "stats": "Bandit Captain (AC 15, HP 65, CR 2) — twin gutting-knives, a thrown net, a grey-water flask to raise a walker as cover. Scale down to a Spy (AC 12, HP 27) for a light table.",
+          "note": "Forces the wards open here and may BREAK OFF toward the Spring once the salt-line is gone rather than fight to the death — he must survive to the Act 3 climax unless the party is exceptional. Makes his profit-pitch to the party (arming the fork). Capturing him yields the buyer, the three poisoned towns, and the full plan."
+        },
+        "tactics": "Corliss opens by shattering a grey-water bottle on the wards to force the break, then plays keep-away — keeping bog-runners and rising walkers between himself and the party while he works the salt-line, and breaking toward the crypt-stair once it's open. The runners cluster on the wards and the gallery; they break under Intimidation or once the walkers rise thick around them. The grey-walkers are a two-sided hazard (they menace everyone, drift toward the Spring) and Eline fights to spare them. Ovick holds the wards (Sanctuary/Bless), never striking to kill. The flooded nave is difficult terrain and a drowning risk; the re-lay-the-wards objective (Religion) runs alongside the fight. Keep the dual objective live — HOLD the wards / deny Corliss the uncontrolled open — so the fight is about the source, not just the bodies. If the fork has curdled, Corliss's pitch lands and the party may turn toward the reagent-as-prize; note it for the agenda.",
+        "scaling": "Party of 1-2 or all-squishy: Corliss as Spy + 1 Thug + 2 Zombies. Party of 3-4: Corliss (Bandit Captain) + 2-3 Thugs + 3 Zombies. Party of 4+ or running hot: Corliss + 3 Thugs + 4 Zombies + a stronger first-risen walker (Ogre Zombie/Ghoul). Corliss breaks off toward the Spring rather than dying here regardless of party size.",
+        "xp": 1200,
+        "xp_note": "Corliss (Bandit Captain, 450, or Spy 200 on a light table) + 3x Thug/Tough (100) + 3x Zombie (50) ~= 900-1500; budget ~1200 toward the act. Award FULL value for holding the wards, beating back or capturing Corliss, and easing rather than slaughtering the walkers, however it's done — denying Corliss the Spring is the win, not the kill count."
+      },
+      "transitions": "With the wards held or broken, Corliss beaten back or fled toward the Spring, and the crypt-stair open, the party regroups (level 5-6) and prepares the descent — move to scene-a3-hook at loc-mile-end, then down the stair to the Stillwater Spring (loc-stillwater-spring). If the fork has curdled — Corliss's deal taken, the walkers torched, the reagent eyed as profit — Eline's prize_seized agenda is armed for what the party does at the pool. If honored, she goes down with the party to do, at last, the thing she could never do alone."
+    },
+    {
+      "id": "scene-a3-hook",
+      "name": "Down to the Source",
+      "type": "social",
+      "location_id": "loc-mile-end",
+      "read_aloud": "There is little night left and less to say. Sister Ovick lays out what the unmaking needs — consecrated fire, carried down to the Spring; the binding at its heart broken; and the cold courage to do both while a child's voice begs you not to. She presses a brand of chapel-flame and a vial of holy water into your hands, and will not meet Eline's eyes. By the surgery fire, Doctor Mourn cleans instruments that are already clean, and finally sets them down. 'I have gone down those stairs a hundred times in three winters,' she says, very quietly, the mask off at last and turned away so you cannot see her face, only the lamplight on a tear she does not bother to hide. 'And a hundred times I have knelt by that cold water and told Wren I would find another way. There is no other way. There was never another way.' She turns the mask over in her hands. 'When we are down there, and she asks me to save her again — and she will — I do not know if I can do what has to be done. So I am asking you.' She looks at you, bare-faced and unbearable. 'If I cannot burn it, you must. Whatever I say. Promise me you will not let me keep her cold to spare myself.'",
+      "dm_notes": "ACT 3 HOOK — the turn from investigation to the unmaking, and Eline's crisis. The stakes are named and total: the ONLY cure for the whole fen is to burn the cursed reagent at the Stillwater Spring's source, and that ends the grey-walking child Wren. Sister Ovick (npc-female-1) supplies the method and the tools (consecrating fire, holy water) and the firm, grieving clarity that it MUST be done. ELINE REACHES HER CRISIS: this is the fork's last fork before the pool. If honored (approval high, personal-quest gate 40 open), she takes the mask off — a huge intimacy beat — and BEGS the party to do what she cannot if her nerve fails: burn the Spring even if she pleads otherwise, because she knows Wren will ask to be saved again and she does not trust herself. If curdled (or the party bought Corliss's profit-pitch, torched the walkers, or is eyeing the reagent as a prize), play her grief as armored and watchful instead, and let the descent feel like a thing she's bracing to STOP if the party goes wrong at the pool. Let the party PREPARE: Ovick's fire and holy water, last rest and doses, Brell's blunt blessing, a Potion of Healing or two from the surgery. NOTE: the descent and the choice are unavoidable — Corliss is already below or racing there, so the party goes down whatever their posture. Make this scene about RESOLVE and the unbearable cost: a cure that is also a small, particular murder, and a companion asking the party to be her courage or her conscience.",
+      "checks": [
+        {
+          "skill": "Insight",
+          "dc": 14,
+          "success": "You read Eline at the edge of the thing she's avoided for three winters and meet it whole — not promising her it won't hurt, but promising her she won't have to carry it alone, and that you'll be her hands if her hands fail. It settles something in her that three winters of penance never could: she commits to going down and seeing it through, and even if Wren's voice unmakes her at the pool, she trusts the party to finish it. (Locks the loyalty path; the single best insurance against the prize_seized fork at the Spring — a party Eline trusts to do the hard mercy is a party she will not turn on.)",
+          "failure": "You miss the depth of what she's asking, or answer it with a plan instead of a presence, and Eline puts the mask back on and goes clinical and grim. She'll go down — she has to — but whether she helps you burn the Spring or throws herself between you and Wren at the last stays open, and dangerous, into the climax."
+        },
+        {
+          "skill": "Religion",
+          "dc": 13,
+          "success": "Taking Ovick's instruction to heart, you understand the unmaking as a RITE, not just arson: consecrated fire to the cursed water, holy water to the binding, and a true rest spoken over the child at its heart so that what you do is a release and not a destruction. Done right, Wren is freed, not merely burned — a mercy inside the horror. (Earns the cleanest possible Act 3 resolution and a real comfort to offer Eline: that ending it ends Wren's cold patience too, the way a cure should.)",
+          "failure": "You grasp the mechanics — fire, holy water, the breaking of the binding — but not the grace-note that would make it a release rather than a ruin. You can still unmake the Spring; it will simply be a harder, colder thing to do and to carry, and Ovick's voice will have to carry the rite alone at the pool."
+        }
+      ],
+      "encounter": null,
+      "transitions": "When the party is ready — fire in hand, the cost understood, Eline's crisis met or left open — they take the warded crypt-stair down below the waterline to the Stillwater Spring. Move to scene-a3-spring at loc-stillwater-spring."
+    },
+    {
+      "id": "scene-a3-spring",
+      "name": "The Unmaking",
+      "type": "combat",
+      "location_id": "loc-stillwater-spring",
+      "read_aloud": "The crypt-stair ends below the waterline in a low vaulted chamber where the cold is the cold of the Grey Quiet itself, and at its heart lies the Stillwater Spring — a flat grey pool, faintly luminous, that does not ripple though water drips into it from a hundred cracks. The walls are scratched with a child's careful tally-marks, three winters of them. And in the center of the still water, neither living nor dead, a small grey figure sits with her knees drawn up, singing the tune the reeds sing, and when your light falls on her she lifts her face and it is a child's face, patient and cold and glad to see you. 'You came,' Wren says, in a voice like water under ice. Her grey eyes find Eline, behind you, frozen on the last step. 'You came BACK. I knew you would. You're going to make it stop now, aren't you?' She smiles. 'You're going to save me again.' Behind you on the stair, a gutting-knife scrapes stone, and Corliss Vane's voice comes down out of the dark, delighted: 'There it is. There's the fortune. Take the water, friends — all of it — and we'll all walk out of here rich. Or burn a king's ransom for a dead girl's sake. Your choice. Mine's made.'",
+      "dm_notes": "THE CLIMAX — the final COMBAT, the unmaking, and the fork's resolution. THREE forces meet at the Spring: (1) WREN (npc-elder voice when she truly speaks — a child's cadence over something older), the grey-walking ward at the binding's heart, who asks Eline to 'save her again' — the most devastating pressure in the campaign; (2) CORLISS (npc-rogue / top-level antagonist), arrived to SEIZE the Spring and its reagent whole, pitching the party to take the water for profit; (3) ELINE (companion-default) at her absolute crisis. THE CENTRAL CHOICE, and the fork: the party can UNMAKE THE SPRING — consecrating fire to the cursed reagent, holy water and a rite of rest to break the binding and RELEASE Wren — which CURES THE WHOLE FEN (every grey-walker laid to rest, the Grey Quiet ended at its source, the draught no longer needed) at the cost of the child; OR the party can SEIZE THE REAGENT (take the grey water for use, study, or Corliss's coin) instead of destroying it. THE AGENDA — if the party SEIZES the reagent (sets the campaign flag 'prize_seized'), Eline's agenda FIRES: she does NOT rage — she DECIDES, with clinical cold, that the party has become the disease, carriers who will spread her single failure across the river, and that a physician excises a contaminant. She turns against the party as a real attack — grieving, certain, telling them she's sorry, that this is the kindest cut, trying to destroy the seized reagent and the hands that hold it. Arm this by setting 'prize_seized' (the engine trigger) when the party takes the water, and the content-flag 'let_the_ward_burn' should be set TRUE only if the party CHOSE to end Wren / burn the Spring (i.e. paid the cost) — the agenda's decision_flag reads it as the ESCAPE valve: a party that seized the prize and did NOT let the ward burn is exactly who Eline turns on. If the party UNMAKES the Spring (the intended victory), Eline — if honored — either does it herself (her arc's catharsis: the cure she could finally perform) or lets the party be her hands while she holds Wren and says goodbye; her agenda never fires. CORLISS fights to keep the Spring flowing: Bandit Captain (AC 15, HP 65, CR 2) + bog-runners (Thug/Tough) + grey-walkers (Zombies) raised from the pool; he flees a lost Spring rather than die for it (a Corliss loose with a few bottles is a fine dangling thread). RUN A SOFT CLOCK: each round the party delays the unmaking, the Spring's pull strengthens and more walkers rise up the stair behind them — race to burn the source, not just to kill Corliss. WIN CONDITION: unmaking the Spring (curing the fen) is the victory, whether or not Corliss is slain; the real boss is the SOURCE and the choice, not Corliss's HP. Give Eline and Wren the climactic exchange; let the party's choice at the pool be the campaign's last and heaviest word.",
+      "checks": [
+        {
+          "skill": "Religion",
+          "dc": 15,
+          "success": "You carry Ovick's rite to its end at the pool — consecrating fire to the cursed water, holy water to the binding, and a true rest spoken over Wren so the unmaking is a RELEASE and not a butchery. The grey light gutters; the Spring's pull collapses; up and down the fen, every grey-walker lies gently down at last; and Wren, freed, looks at Eline with a child's whole face for one clean moment before she goes. (THE VICTORY: the Grey Quiet ended at its source, the fen cured, Wren released rather than merely destroyed — the cleanest unmaking, and the catharsis of Eline's whole arc.)",
+          "failure": "The rite resists you under the singing and the cold and Corliss's blades; you can still set the consecrating fire to the reagent and break the Spring by force, but it's a harder, colder ending — Wren burned rather than gently released, the cure bought without the grace-note. Lean on Ovick's voice (if she's with you) or simply finish it; the fen is cured either way, but the manner of it is a thing the party and Eline will carry."
+        },
+        {
+          "skill": "Persuasion",
+          "dc": 15,
+          "success": "You reach Eline at the unbearable moment — when Wren asks to be saved again and the doctor's nerve fails — and give her the words she gave you: that the kindest thing she can do for the child she loves is to let her rest, that keeping Wren cold to spare herself was never mercy, that this is the cure she came three winters to perform. It steadies her. She kneels, takes Wren's grey hand, and either sets the fire herself or holds the child while you do — the release she could never reach alone. (Resolves her loyalty arc at its peak; turns the unmaking from a thing done TO her grief into a thing done THROUGH it.)",
+          "failure": "Eline cannot be talked across the last step in time — she's frozen, or pleading with Wren, or between you and the pool — and the unmaking has to happen around her grief rather than through it. If she's honored she won't stop you, only weep; if her fork has curdled and the party reaches for the reagent instead, this is where her agenda takes her, and the next thing she says is a verdict, not a plea."
+        },
+        {
+          "skill": "Intimidation",
+          "dc": 14,
+          "success": "You break Corliss off the Spring — calling across the chamber that there's no fortune in a pool you're about to burn, that his runners are dying for a dead girl's bathwater, that the buyer upriver will never see another bottle. His muscle wavers; one by one they back off the pool, and Corliss, seeing the Spring lost, snatches what bottles he can and bolts up the stair rather than die for it. (Clears the way to unmake the Spring; a fled Corliss with a few bottles is a deliberate dangling thread for a darker sequel.)",
+          "failure": "Corliss and his runners hold the pool, too greedy or too far in to break, and you'll have to win the Spring the hard way — by force, while the walkers rise and the clock runs. The unmaking happens under blades, not after them."
+        }
+      ],
+      "encounter": {
+        "monsters": [
+          {
+            "name": "Thug",
+            "count": 3,
+            "reflavor": "Corliss's bog-runners holding the pool so the harvest can be taken — the most turnable foes here (Intimidation peels them off once they grasp there's no fortune in burnt water). Resolves to bundled 'Tough' (CR 1/2)."
+          },
+          {
+            "name": "Zombie",
+            "count": 4,
+            "reflavor": "Grey-walkers rising up the crypt-stair, drawn to the awakened Spring — a soft clock made flesh (more each round the unmaking is delayed). Pitiable; all of them lie down for good the instant the Spring is unmade. Use bundled Zombie (CR 1/4)."
+          }
+        ],
+        "boss": {
+          "name": "Corliss Vane",
+          "npc_id": "antagonist",
+          "stats": "Bandit Captain (AC 15, HP 65, CR 2) — twin gutting-knives, thrown net, a grey-water flask to raise a walker as cover. Spy (AC 12, HP 27) for a light table.",
+          "note": "Here to seize the Spring whole and sell it forever; pitches the party to take the reagent for profit (arming the prize_seized fork). Fights to keep the Spring flowing but FLEES a lost Spring rather than die for it — a Corliss loose with a few bottles is a fine dangling thread. The real boss is the SOURCE and the choice, not his HP; unmaking the Spring is the win even if he escapes."
+        },
+        "support_boss": {
+          "name": "Doctor Eline Mourn (only if her agenda fires)",
+          "npc_id": "companion-eline",
+          "stats": "Cleric (Life Domain), leveled with the party (~lvl 6-7): Spirit Guardians, Hold Person, Inflict Wounds, Cure Wounds turned to harm, Channel Divinity. A controller-medic, not a brawler.",
+          "note": "ONLY if the party SEIZES the reagent (prize_seized fires and the ward was NOT let burn). She does not rage — she turns CLINICAL and cold, a physician excising a contaminant, trying to destroy the seized reagent and the hands holding it, grieving and certain ('this is the kindest cut'). If honored, she is NOT an enemy — she is the one who helps unmake the Spring. Run her turn as heartbreak, never villainy."
+        },
+        "tactics": "Wren's plea and Corliss's pitch both land BEFORE initiative — give the fork its full weight at the pool. If it comes to blades, Corliss plays keep-away (runners and raised walkers between himself and the party, grey-water flasks for fresh cover), breaking for the stair if the Spring is clearly lost. The grey-walkers are a RISING CLOCK — more each round the unmaking is delayed, drawn up from the fen — so the party races to set the consecrating fire, not to clear the room. The bog-runners break under Intimidation once they see the Spring burning. If the party UNMAKES the Spring, every walker in the chamber and the fen lies down the instant the binding breaks — the fight ends with the cure, not the kill. If the party SEIZES the reagent instead, set 'prize_seized' and run Eline's agenda turn (clinical, grieving) — the climax becomes the party vs. the doctor they failed, the worst victory in the campaign. Keep the SOURCE the boss: burning the Spring is the win.",
+        "scaling": "Party of 1-2 or all-squishy: Corliss as Spy + 1 Thug + 2 Zombies, clock ~6 rounds. Party of 3-4: Corliss (Bandit Captain) + 2-3 Thugs + 3-4 Zombies, clock ~5 rounds. Party of 4+ or running hot: Corliss + 3 Thugs + 4-5 Zombies + a first-risen horror (Ogre Zombie/Ghoul), clock ~4 rounds. If Eline's agenda fires, she replaces a chunk of the encounter's threat as the climactic adversary — scale Corliss DOWN accordingly so the party isn't crushed; her turn is the story, not a second boss-stack.",
+        "xp": 2400,
+        "xp_note": "Corliss (Bandit Captain, 450, or Spy 200 light) + 3x Thug/Tough (100) + 4x Zombie (50) ~= 950-1550; budget ~2400 for the climax with the unmaking-stakes. Award the FULL value for UNMAKING THE SPRING — curing the fen and releasing Wren — even if Corliss flees rather than falls; ending the Grey Quiet at its source, not slaying the smuggler, is the victory. If Eline's agenda fires and the party survives her, award the climax value but mark the ending as the campaign's hardest."
+      },
+      "transitions": "When the Spring is unmade — the consecrating fire set, the binding broken, Wren released, the walkers laid to rest and the fen cured — or, in the dark ending, when the reagent is seized and Eline's verdict is survived, the party climbs the crypt-stair out of the cold. Return to loc-mile-end for the conclusion. (If Corliss fled with bottles, the dangling thread climbs out with you.)"
+    }
+  ],
+  "rewards": {
+    "xp": 4000,
+    "xp_breakdown": {
+      "act1-third-night-watch": 300,
+      "act2-drowned-chapel-break": 1200,
+      "act3-stillwater-spring": 2400,
+      "social-exploration-bonuses": 1100,
+      "note": "~4000-5000 XP across three acts plus social/exploration story bonuses, tuned for a party starting around level 3 and finishing near level 7. Many DMs will prefer MILESTONE leveling: level 4 after the third-night watch (Act 1), level 5-6 across the drowned chapel (Act 2), level 7 before or during the Stillwater Spring climax (Act 3). Award full encounter XP for merciful and investigative resolutions — easing the grey-walkers to rest, re-laying the wards, and unmaking the Spring count fully as overcoming each act; a watch that ends with the dead laid down gently is a BETTER win, not a lesser one."
+    },
+    "currency": {
+      "gp": 200,
+      "note": "Hollow Mile is poor; the early reward is moral, not monetary. Halda has almost nothing but gratitude and a warm hearth. The coin that exists is grim: Corliss's grey-water cache and his upriver buyer's down-payment (~120 gp in smuggler's silver, recoverable in Act 2/3) and a small purse Sister Ovick's order presses on the party after the unmaking (~80 gp). Taking Corliss's grey-water money to SELL is a fork-flagged choice (sell_the_grey_water), not a clean reward."
+    },
+    "loot": [
+      {
+        "item": "Potion of Healing",
+        "rarity": "common",
+        "count": "2-4 across the campaign",
+        "note": "From Doctor Mourn's surgery and Sister Ovick's chapel stores before the descent. 2d4+2 HP each."
+      },
+      {
+        "item": "Consecrating Brand & Vial of Holy Water (Ovick's)",
+        "value": "the campaign's true key",
+        "note": "The chapel-flame brand and holy water Sister Ovick presses on the party to UNMAKE the Stillwater Spring — consecrated fire to the cursed reagent, holy water to break the binding. Not a saleable item; the Act 3 win-tool and the means to release Wren rather than merely destroy her."
+      },
+      {
+        "item": "Wren's tally-stone",
+        "value": "0 gp (story item)",
+        "note": "A small water-smoothed stone the grey-walking child kept her three winters of tally-marks beside, recoverable when the Spring is unmade. A keepsake of the ward released — and, for Eline, the proof that the cure she came to perform was finally, mercifully done. If the party seized the reagent instead, this stone is the thing they DIDN'T save."
+      },
+      {
+        "item": "The Stillwater Draught (Eline's recipe)",
+        "rarity": "uncommon (story)",
+        "note": "Doctor Mourn's diluted tincture — slows the Grey Quiet's progression for a few weeks per dose, useless once the Spring is unmade and the Quiet ended. A story-reward that loses its purpose with the cure; a party that hoards it is keeping a cousin of the curse alive."
+      },
+      {
+        "item": "Corliss's grey-water cache & buyer's ledger",
+        "value": "evidence / fork-flagged coin",
+        "note": "The smuggler's stoppered bottles of cursed reagent and the ledger naming his upriver buyer and the three poisoned towns. Evidence that exposes Corliss as the SPREADER (and a thread to a darker sequel) — and a temptation: selling it (sell_the_grey_water) or keeping it for use (seize_the_reagent_for_use) is exactly the choice that fires Eline's agenda."
+      }
+    ],
+    "story_rewards": [
+      "If the Stillwater Spring was UNMADE, the Grey Quiet ends at its source: every grey-walker in the fen lies down for good, the lying-down stops, and Hollow Mile — what's left of it — can bury its dead once and keep them buried. The draught is no longer needed; the third-night watch is never stood again.",
+      "If Wren was RELEASED rather than merely burned (the Religion-rite path), Eline is given the one thing three winters of penance never could: the cure she came to perform, done as a mercy. She takes off the mask for good, and may stay on as a healer-companion who finally believes a body and a soul can be saved by the same hand — or take up Sister Ovick's leashless, line-holding work in the fen.",
+      "If Eline was honored to the loyalty path and helped unmake the Spring, she walks out of Hollow Mile free of the wound she's carried — grieving, but whole, a physician who finally chose the hard mercy over the long hiding. If her prize_seized agenda fired instead, the party carries the campaign's hardest ending: a healer they failed into a verdict, who turned on them clinically and cold because they took the curse for a prize, and the knowledge that they made the cure cost more than the collar — that they became the disease she diagnosed.",
+      "If Corliss was exposed and beaten but FLED with bottles, the Grey Quiet is finished in Hollow Mile but loose upriver in a smuggler's hold — a deliberate dangling thread for a future return, and a darker mirror: a man who saw a tragedy and priced it.",
+      "Unmaking the Spring rather than harvesting it means the Grey Quiet ends as a horror but the QUESTION it asked — what it means to SAVE someone, whether a body kept cold is a person spared or a person held, and whether a kindness that perpetuates a wound is a kindness at all — lingers over Hollow Mile's slow recovery. Sister Ovick's patient, line-holding mercy inherits the fen."
+    ]
+  },
+  "conclusion": "Dawn over Hollow Mile, and for the first time in three winters the reeds are only reeds — no singing, no wind that isn't there, no grey shapes wading homeward at the water's edge. The Stillwater Spring is a scorched hollow under the drowned chapel; the grey-walkers lie where they lay down, dead the ordinary way at last, and Sexton Brell can finally dig a grave and trust it to stay closed. Halda Vane keeps her boy Tomas, warm and grey no longer, or buries him for good — and either way stops leaving bread out on the third night. How the hamlet remembers it is up to the party: as the winter strangers came down the sunken road and unmade the cold thing under the bog, or as the winter they learned that the kindest hands in Hollow Mile had made the wound they were healing, and chose, at the last, whether the cure was worth the child at the bottom of the Spring. The Grey Quiet is ended. Doctor Eline Mourn's mask hangs by the surgery door, or it does not, depending on what the party let her become — a healer who saved a soul by losing it, or a physician who decided, with terrible calm, that the people who came to help her were the contamination after all. Either way the fen is quiet now, the true quiet, the kind the dead are owed. (Hook for a future return: a smuggler loose upriver with bottles of cold grey water, three towns already going still, and a buyer who pays in gold for a kindness that ends three nights later at the door.)",
+  "dm_quickref": {
+    "definition_of_done_mapping": {
+      "exploration": "scene-a1-fen (read the reedfen — tampered graves, barge-tracks, the grey-water bottle, the third-night pattern; bog hazards), scene-a2-chapel (the drowned chapel and warded crypt-stair — sabotaged wards, chapel records, the cure-is-the-curse reversal, the descent revealed), and scene-a3-spring's approach (descend the warded crypt-stair to the Stillwater Spring, ready the consecrating fire, find the binding and the prize).",
+      "social": "scene-a1-hook (Halda + the dying boy + the masked physician companion), scene-a1-fen (Brell's plain testimony, Halda's bread-for-the-dead, Corliss the helpful kinsman), scene-a2-hook (Eline cracks the secret: the cure is the curse), scene-a2-chapel (Sister Ovick + Eline's full confession and her LINKED personal-quest gate — Wren, the first cure, the Spring), scene-a3-hook (the unmaking named, Eline's crisis and her plea), and the climax's reach-Eline Persuasion (DC 15) + turn-the-runners Intimidation.",
+      "combat_act1": "scene-a1-watch — 3x Zombie (grey-walkers, eased or felled), a grief beat with stakes, not a slasher.",
+      "combat_act2": "scene-a2-break — Corliss (Bandit Captain/Spy) + 3x Thug (Tough, bog-runners) + 3x Zombie (rising walkers), with a hold/re-lay-the-wards objective and the fork's pressure.",
+      "combat_act3": "scene-a3-spring — Corliss (Bandit Captain) + 3x Thug (Tough) + 4x Zombie, with the RISING-WALKER clock, the UNMAKE-vs-SEIZE choice, and Eline's prize_seized turn if the reagent is taken."
+    },
+    "bundled_assets_used": {
+      "monsters_act1": [
+        "Zombie (x3, scene-a1-watch grey-walkers — one is Halda's dead husband; eased to rest or felled)"
+      ],
+      "monsters_act2": [
+        "Bandit Captain OR Spy (Corliss, the smuggler — drops his cover, forces the wards)",
+        "Thug -> Tough (x3, scene-a2-break bog-runners)",
+        "Zombie (x3, grey-walkers rising from the flooded nave)",
+        "Ogre Zombie / Ghoul (optional first-risen horror for a strong party)"
+      ],
+      "monsters_act3": [
+        "Bandit Captain (Corliss, seizing the Spring — flees a lost Spring rather than dies)",
+        "Thug -> Tough (x3, bog-runners holding the pool)",
+        "Zombie (x4, the rising-walker clock — all lie down when the Spring is unmade)",
+        "Cleric/Life Domain (Doctor Eline Mourn — ONLY if her prize_seized agenda fires; the heartbreak turn, not a stacked boss)"
+      ],
+      "monsters_optional": [
+        "Commoner (Halda, Tomas, freed villagers — noncombatants)",
+        "Priest (Sister Ovick — defends the wards/party, never kills)",
+        "Guard (Sexton Brell, if cornered among the graves)"
+      ],
+      "spells_in_play": [
+        "Eline (Cleric/Life Domain): Cure Wounds, Lesser Restoration (lift the grey-chill), Spare the Dying, Bless, Detect Poison and Disease, Prayer of Healing; by Act 3, Spirit Guardians, Mass Cure Wounds — turned to harm ONLY if her agenda fires",
+        "Sister Ovick (Priest): Bless, Cure Wounds, Sanctuary, a consecrating flame at the Spring — protective only",
+        "party casters across the fen, the drowned chapel, and the crypt"
+      ],
+      "conditions_in_play": [
+        "Grappled/Restrained (grey-walkers dragging toward the deep water — a drowning hazard, Acts 1-3)",
+        "Frightened (the third-night watch, the singing crypt, the cold of the Spring)",
+        "Prone / difficult terrain (sinking plank-paths, the flooded nave, the cold pool)",
+        "Charmed / Held (Eline's Hold Person / Wren's pull, Act 3 — 'the cold that wants you to lie down')",
+        "Exhaustion (cold-water soaks and long bog-crossings)"
+      ]
+    },
+    "the_source_is_the_boss_note": "The real antagonist of the climax is the STILLWATER SPRING and the CHOICE at it — unmake the cursed reagent at its source (cure the fen, release Wren) or seize it (for use, study, or Corliss's coin). Corliss (Bandit Captain) is the human predator who'd sell the horror, but he prefers to bargain and flees a lost Spring rather than die for it — a Corliss loose upriver with bottles is a fine dangling thread. The campaign's WIN is UNMAKING the Spring: burning the cursed reagent so every grey-walker lies down and the Grey Quiet ends at its source. The LOSS/DARK state is the reagent SEIZED — the curse kept alive as a prize, which fires the companion's clinical turn. Do NOT make this a fight to a smuggler's death; make it a choice about what saving someone is worth.",
+    "the_companion_fork_note": "Doctor Eline Mourn is the campaign's deliberate FORK and its moral core — the secret MOTHER of the plague, atoning by dosing the wound she opened. Her arc has THREE gates: loyalty (20, she admits the draught is hers after the watch), personal_quest (40, LINKED via quest_arc_id to the companion-quest-arc 'cqarc-eline-stillwater' stage 'cqstage-eline-confession' — she confesses Wren, the first cure, and the Spring, and asks the party's help to unmake it), and a BETRAYAL gate (15, reachable only when approval curdles). Her CompanionAgenda uses the PRIZE_SEIZED trigger (NOT attitude_below): when the party SEIZES the cursed reagent (sets the engine flag 'prize_seized') instead of destroying it, her agenda fires DETERMINISTICALLY and she turns CLINICALLY — a physician excising a contaminant, not a betrayer in a rage. ENGINE-ACCURATE: the prize_seized trigger reads ONLY campaign.flags['prize_seized'] (companion_arc._agenda_triggered) — it does not roll and does not read the decision_flag. The decision_flag 'let_the_ward_burn' is therefore carried for CONTENT/recall, not engine gating (the engine reads decision_flag only for attitude_below agendas, to escalate the snap roll): set it TRUE via record_decision/set_flag when the party CHOOSES to burn the Spring and end Wren (the path that AVOIDS the turn), so the chronicle records the choice. To FIRE Eline's turn, set the engine flag 'prize_seized' when the party takes the reagent at scene-a3-spring; to KEEP her, have them let the ward burn (unmake the Spring) and never seize the prize. Honored, she helps unmake the Spring and walks out free; grasping, she diagnoses the party as the disease.",
+    "linked_personal_quest_note": "Eline's personal_quest gate (eline-gate-quest, threshold 40) is LINKED to a first-class companion-quest-arc via quest_arc_id='cqarc-eline-stillwater' and stage_id='cqstage-eline-confession' (authored in the top-level 'companion_quest_arcs' block). The arc 'The Cure That Became a Curse' tracks Eline's journey from confession (the gate's stage) through reaching the Spring to the unmaking. NOTE on loading: seed_campaign() folds the 'companions' (with their arc + dossier), 'npcs', 'locations', and 'scenes', but does NOT itself seed a campaign-level 'companion_quest_arcs' block (only world/ending seeds do, via content._seed_companion_quest_arcs). So at runtime the linked arc must be registered with set_companion_quest_arc (or seeded from the world/ending) for the gate's link to resolve live; until then the gate latches a one-shot link_error (F06-11) and stays locked but recoverable — the personal_quest still plays from the gate's 'note'. See schema_notes.",
+    "pacing": "Designed as a ~3-4 session gothic-horror arc (one act per ~80-min session, or a long single sitting). Act 1 ~ levels 3-4 (hook + reedfen + third-night watch). Act 2 ~ levels 4-6 (drowned chapel + the cure-is-the-curse reversal + Eline's confession + the wards break). Act 3 ~ levels 6-7 (the descent + the Stillwater Spring climax + the unmaking choice). Use the per-scene scaling notes to tune each fight to party size, and prefer milestone leveling (4 / 5-6 / 7) for clean act breaks. A tonal DEPARTURE from the engine's heroic/intrigue defaults: run it slow, cold, and grieving — dread over spectacle, mercy over monster-mash.",
+    "originality_note": "This campaign is original gothic-horror prose written for WorldOS on SRD 5.2 primitives, released as fan content under the same terms as the bundled world seeds (SRD 5.2 / CC-BY-4.0 rules). It uses only SRD 5.2 mechanics and bundled creature stat blocks (Zombie, Thug/Tough, Bandit Captain, Spy, Priest, Commoner, Guard, optional Ogre Zombie/Ghoul). No published or copyrighted adventure text is reproduced; Hollow Mile, the Grey Quiet, the Stillwater Draught and Spring, Doctor Eline Mourn, the ward Wren, the smuggler Corliss Vane, the Vane family, Sexton Brell, and Sister Ovick are original creations. NONE of the seven BG3 origin companions (Astarion, Gale, Karlach, Lae'zel, Shadowheart, Wyll, Halsin) appear as PC or companion; the companion Doctor Eline Mourn is wholly original and non-origin."
+  },
+  "companion_quest_arcs": [
+    {
+      "id": "cqarc-eline-stillwater",
+      "companion_id": "companion-eline",
+      "title": "The Cure That Became a Curse",
+      "status": "locked",
+      "note": "Doctor Eline Mourn's personal quest — the cure she invented years ago to save her ward Wren, which unmade the girl into the first grey-walker and became the Grey Quiet. Unlocked by her personal_quest arc-gate (eline-gate-quest, threshold 40) via quest_arc_id link. Tracks her path from confession, to reaching the Stillwater Spring, to the unmaking she could never perform alone — and whose failure-state (the reagent seized rather than destroyed) fires her prize_seized agenda.",
+      "stages": [
+        {
+          "id": "cqstage-eline-confession",
+          "title": "The Mask Comes Off",
+          "status": "locked",
+          "unlock_gate_id": "eline-gate-quest",
+          "location_id": "loc-drowned-chapel",
+          "note": "Eline confesses the whole of it at the drowned chapel: Wren, the first draught, the Stillwater Spring beneath the crypt where the cursed reagent still runs and the grey-walking child still waits. She asks the party's help to do what three winters of atonement never could — go down and unmake it at the source. This is the stage the personal_quest gate makes available."
+        },
+        {
+          "id": "cqstage-eline-descent",
+          "title": "Down to the Spring",
+          "status": "locked",
+          "location_id": "loc-stillwater-spring",
+          "note": "The party and Eline descend the warded crypt-stair to the Stillwater Spring, consecrating fire in hand, to reach the binding at its heart — past Corliss's grasp and the rising walkers. The point of no return before the choice."
+        },
+        {
+          "id": "cqstage-eline-unmaking",
+          "title": "The Hard Mercy",
+          "status": "locked",
+          "location_id": "loc-stillwater-spring",
+          "note": "Resolution: unmake the Spring (consecrating fire to the reagent, the binding broken, Wren released) — curing the fen at the cost of the child and giving Eline the cure she came to perform — OR fail her, by seizing the reagent as a prize, which fires her prize_seized agenda and turns the quest's healer against the party. The arc resolves on what the party does at the pool."
+        }
+      ]
+    }
+  ]
+}

--- a/content/campaigns/hollow-mile/adventure.md
+++ b/content/campaigns/hollow-mile/adventure.md
@@ -1,0 +1,263 @@
+# The Physician of Hollow Mile
+
+*A WorldOS gothic-horror campaign — SRD 5.2, levels 3 → 7, ~3–4 sessions.*
+*A deliberate tonal departure from the engine's heroic/intrigue defaults: run it slow, cold, and grieving — dread over spectacle, mercy over monster-mash.*
+*Original fan-content prose on SRD primitives. Released under the same terms as the bundled world seeds (SRD 5.2 / CC-BY-4.0 rules). NOT official, never sold.*
+
+---
+
+## The Pitch
+
+**Hollow Mile** is a fen-locked hamlet of forty souls strung along one sunken road, and for three
+winters it has been dying of a wasting plague the locals call the **Grey Quiet** — a sickness that does
+not kill so much as *still*. The afflicted go cold and slow and finally lie down in the reed-beds and do
+not get up. And on the **third night** after they lie down, they *rise*, grey and patient and wrong, and
+walk back toward the houses they loved.
+
+Between the hamlet and that horror stands one woman: **Doctor Eline Mourn**, a plague-doctor in a long
+oiled coat and a beaked leather mask, who came three winters ago and has held the Grey Quiet to a slow
+burn with a tincture of her own devising — the **Stillwater Draught**. The village worships her. What no
+one knows is that the Grey Quiet is *hers*: the failed first version of the very cure she now doses them
+with, a draught she invented years ago to save one dying child — her ward, **Wren** — that unmade the
+girl into the first grey-walker instead, and seeped from that one body into the water and the fen. She is
+not the plague's villain by malice. She is its **mother**, dosing a wound she opened, certain that one
+more refinement will close it. And beneath the bog, in a drowned chapel-crypt, the **Stillwater Spring**
+still runs with the original cursed reagent — and the grey-walking remains of Wren still wait at its
+heart, the proof and the source and the thing Eline cannot bring herself to burn.
+
+## The Hidden Antagonist
+
+**Corliss Vane, "the Reed-Factor of Hollow Mile."** Not a robed cultist — an affable fen-smuggler with a
+barge-pole's reach and a poacher's patience, kin to the dying Vanes and seemingly the most *helpful* man
+in the Mile. Two winters ago he discovered the bog's grey water fetches a fortune upriver as a "stilling
+draught" among the dying rich, and he has been quietly grave-robbing the walkers and skimming the Spring
+ever since — shipping the curse out by the bottle, the reason the Grey Quiet has begun to spread *beyond*
+Hollow Mile. He means to seize the Spring **whole** and sell it forever, and he'll use the party (or
+Eline) to break the chapel's last wards and open the source he can't reach himself.
+
+- **Public face:** the put-upon kinsman who "just moves reeds," lends a cart, knows the safe paths — and
+  warns everyone off the bog *"for your own good"* (the first note that sounds less like care than a man
+  guarding a claim).
+- **The reveal** lands across Act 2: the helpful factor is the one *spreading* the Grey Quiet for profit,
+  the grave-robbed reagent and the low-riding night barges are his, and three towns upriver are already
+  going grey from his bottles.
+- **Stats (Acts 2–3):** reflavored **Bandit Captain** (AC 15, HP 65, CR 2) — twin gutting-knives, a
+  thrown net, a grey-water flask he smashes to raise a walker as cover. A cornered profiteer protecting a
+  claim, who *bargains before blades* and **flees a lost Spring rather than die for it.**
+
+## The Companion — and the Fork
+
+**Doctor Eline Mourn** (Cleric/Life Domain 3, `companion-default`) — the masked plague-doctor holding
+the Grey Quiet at bay, and the **secret mother of the plague itself**. She believes in the body the way a
+faithless person believes in arithmetic: that flesh is a problem with a solution, that suffering is data,
+that there is no soul-sized wound she cannot, given time and a clean enough table, close. She is gentle
+with the suffering and merciless with sentiment — she will end a hopeless case cleanly rather than let it
+linger. She joined the party as the only hands in the hamlet that don't already worship or fear her, and
+because some buried part of her hopes they will make her finally do the thing she cannot: go down to the
+Spring and burn it, Wren and all.
+
+She is the campaign's moral core **and a real fork** — but note the fork is *cold*, not hot:
+
+| Path | What it takes | What she becomes |
+|------|---------------|------------------|
+| **Loyalty** (gates 20 → 40) | Trust her with the truth; treat the grey-walkers as patients; ease hopeless cases cleanly; help her **unmake** the Spring rather than hide it | She confesses, leads the party to the Spring, and performs — at last — the hard mercy she came three winters to do. She walks out free, grieving but whole. |
+| **Betrayal** (gate 15 + agenda) | Torch the walkers wholesale; let the sick burn to be safe; side with Corliss's profit; and — the seal of it — **seize the cursed reagent** instead of destroying it | She does **not** snap. She *decides*, clinically, that the party has become the disease — carriers who will spread her failure across the river — and turns to **excise the contaminant**, grieving and certain. |
+
+Her `CompanionArc` has **three gates** — `loyalty` @20, a **quest-LINKED** `personal_quest` @40 (linked
+via `quest_arc_id` → `cqarc-eline-stillwater`, the cure-that-became-a-curse arc), and a `betrayal` @15 —
+and a `CompanionAgenda` on the **`prize_seized`** trigger (not `attitude_below`). When the party *seizes*
+the reagent (the engine flag `prize_seized` is set), her turn fires **deterministically** and she comes
+for the party as a physician removing a contaminant. Honored, she's the hands that finally close the
+wound; grasping, she's the clinical verdict the party earns.
+
+> **Engine note.** The `prize_seized` trigger fires on `campaign.flags['prize_seized']` alone — the
+> agenda's `decision_flag` (`let_the_ward_burn`) is *not* read by this trigger (the engine reads
+> `decision_flag` only for `attitude_below` agendas). It's carried to record the campaign's central choice
+> and to mark the path that *avoids* the turn: **let the ward burn = unmake the Spring = don't seize =
+> she never turns.**
+
+## Structure — Hub & Three Spokes
+
+The party returns to **Mile-End & Doctor Mourn's Surgery** between acts to rest, level, dose the dying,
+and stand the third-night watch — and slowly learn that the kindest hands in Hollow Mile made the wound
+they're healing. One site per act radiates from the hub down the chapel-path into the bog.
+
+| Act | Levels | Site | The Beat |
+|----|--------|------|----------|
+| **1 — The Third-Night Watch** | 3–4 | **The Reedfen & the Sexton's Graves** | Walk the dying boy to the surgery; read the fen — tampered graves, night-barge tracks, a grey-water bottle that shouldn't exist; then stand the **third-night watch** as the grey-walkers wade up homeward, and one of them is someone you've met. Eline treats them as *patients*, not monsters. |
+| **2 — The Drowned Chapel** | 4–6 | **The half-submerged bog-chapel & warded crypt** | Descend the chapel-path to Sister Ovick's failing wards. The **midpoint reversal**: the cure is the curse, the source is the Spring below, the first walker is a *child* — and Eline **confesses** (her quest-linked personal-quest gate). Corliss's hand is forced and the wards break. |
+| **3 — The Stillwater Spring** | 6–7 | **The drowned crypt's cold pool** | Down to the source, consecrating fire in hand. Wren asks Eline to "save her again." **Unmake the Spring** (cure the fen, release the child) or **seize the reagent** (and fire Eline's clinical turn) — with Corliss racing to take the Spring whole. |
+
+Each act exercises **exploration + social + combat**. Merciful and investigative resolutions earn full XP
+— easing the walkers to rest, re-laying the wards, or **unmaking the Spring** counts fully as overcoming
+each act.
+
+## Monsters per Act (all bundled SRD stat blocks, CR-tuned)
+
+- **Act 1 (lv 3–4):** grey-walkers = **Zombie** ×3 (CR 1/4), reflavored grey and homeward; one is Halda's
+  dead husband. A *grief* beat, not a slasher.
+- **Act 2 (lv 4–6):** **Corliss = Bandit Captain** (CR 2) *or* **Spy** for a light table + **Tough** ×3
+  (bog-runners) + **Zombie** ×3 (rising walkers). Optional **Ogre Zombie / Ghoul** first-risen horror.
+- **Act 3 (lv 6–7):** **Corliss = Bandit Captain** (CR 2) + **Tough** ×3 + **Zombie** ×4 (a *rising-walker
+  clock*), with the **unmake-vs-seize** choice and — only if her agenda fires — **Doctor Eline Mourn**
+  (Cleric/Life Domain, leveled with the party) as the heartbreak adversary.
+
+Every name resolves through `spawn_monster` / the bundled bestiary. Per-scene scaling notes tune each
+fight to party size.
+
+## The Real Boss — the Source, Not the Smuggler's HP
+
+Corliss is the human predator who'd *sell* the horror, but **the real antagonist of the climax is the
+Stillwater Spring and the choice at it.** Corliss prefers to bargain and flees a lost Spring rather than
+die for it — a Corliss loose upriver with a few bottles is a fine dangling thread. The **win** is
+**unmaking the Spring**: consecrating fire to the cursed reagent so every grey-walker lies down for good
+and the Grey Quiet ends at its source. The **dark state** is the reagent **seized** — the curse kept
+alive as a prize, which fires Eline's clinical turn and makes the party the disease she diagnosed. Don't
+make this a fight to a smuggler's death; make it a choice about **what saving someone is worth**.
+
+## How It Ends
+
+Dawn over Hollow Mile, and for the first time in three winters the reeds are *only reeds* — no singing,
+no grey shapes wading homeward. The Spring is a scorched hollow under the drowned chapel; the walkers lie
+where they lay down, dead the ordinary way at last, and **Sexton Brell** can finally dig a grave and
+trust it to stay closed. The party decides how the hamlet remembers it — as the winter strangers came
+down the sunken road and unmade the cold thing under the bog, or as the winter they learned the kindest
+hands in the Mile had *made* the wound they were healing, and chose, at the last, whether the cure was
+worth the child at the bottom of the Spring. *The Grey Quiet is ended. Doctor Eline Mourn's mask hangs by
+the surgery door — or it does not, depending on what the party let her become.*
+
+---
+
+## Sample Scene Prose
+
+> *(These expand the read-aloud + dm_notes in `adventure.json` into the playable, slow-and-cold prose the
+> DM voices at the table. Boxed text is for the players; the rest is staging.)*
+
+### Act 1 · The Boy Going Grey — *the hook, on the sunken road*
+
+> The sunken road into Hollow Mile runs below the level of the fen, a green tunnel of head-high reed that
+> whispers on both sides though there is no wind. Where the road meets the first cottages, a broad woman
+> with reed-scarred hands steps into your path and does not move, because in her arms is a boy of perhaps
+> fourteen, grey at the lips and shivering with a cold that has nothing to do with the season.
+>
+> *"You're outsiders,"* she says, flat, like it's the only good news she's had in a month. *"You don't
+> have the fear yet."*
+
+**Lean on the dread, and keep it physical** — the windless whispering reed, the cold that isn't weather,
+the village's refusal to *name* the third-night rising. Halda (`npc-female-1`) doesn't want a cure she
+can't buy; she wants strong arms to walk her boy down, and someone unafraid to **stand the third night**
+if the worst comes. At the Mile's end, the masked physician watches from her door:
+
+> The figure in the beaked mask takes Tomas from his mother's arms with hands that are clean and exact
+> and do not shake. *"Grey Quiet,"* she says — a statement, not a question. *"Third stage, maybe fourth.
+> I can slow it."* The mask turns to you. *"I can always slow it. I have never once stopped it. If you've
+> come to help, understand that first, so you don't hope at me. Hope is the one thing I can't dose."*
+
+**Eline never removes the mask.** A sharp **Medicine (DC 13)** reveals the Grey Quiet is *unnatural* — a
+freezing of the will, a grey shimmer in the blood no sickness should have — and earns her first flicker
+of regard (`trusting_evidence_over_superstition`).
+
+### Act 1 · What Comes Back — *the third-night watch*
+
+> Past midnight the singing of the reeds changes pitch, and they come — slow, patient figures wading up
+> out of the black water, grey-skinned and unhurried, water streaming off them, their faces calm as
+> sleepers. They do not lunge. They *walk*, steady and homeward, toward the lamplit Mile and the chapel
+> beyond it, as if they are only late getting home.
+
+The lantern catches the nearest one's face, and **Halda makes a sound you will not forget** — because it
+is the man in the portrait over her hearth, two winters in the ground. **The grey-walkers (Zombie ×3) are
+victims, not monsters**: they shamble *home*, grappling and dragging toward the water more than savaging.
+This is **Eline's moral knife** — she lifts her bag, not a blade:
+
+> *"They are not attacking,"* Doctor Mourn says, very evenly, stepping between you and the nearest grey
+> face. *"They are PATIENTS. A body can be saved and still be lost, and that is what you are looking at.
+> Ease them. Lay them down. But do not — "* her voice does not rise, which is worse — *"do not burn them
+> to feel safe. I will remember if you do."*
+
+Easing them to rest (**Religion DC 13**) and honoring Halda's dead wins Eline hard and opens her
+**loyalty gate (20)**; torching them wholesale over her plea is the first push toward her **betrayal gate
+(15)**. The walkers all turn the same way — toward the chapel — *the* clue the party carries into Act 2.
+
+### Act 2 · The Ward-Keeper's Line — *the reversal, and the confession*
+
+> On the one dry step of the drowned chapel a single candle burns, and behind it stands a gaunt woman in
+> a lay-keeper's grey, a line of salt across the crypt-stair at her back. From somewhere far down it,
+> faint and patient and unmistakably a child's, a voice is singing the same tune the reeds sing.
+
+**Sister Ovick** (`npc-female-1`) is the moral counterweight — the woman who has spent her life simply
+**holding the line** so the curse spreads no further, where Eline would refine the wound and Corliss
+would sell it. She names the unbearable shape of it: the source is the Spring below, and the first walker
+is a *child*. And she turns to the doctor:
+
+> *"You know what's down there, doctor. You've known the whole time."* Ovick's voice goes very gentle and
+> very hard at once. *"Are you finally going to help me end it — or just kneel by it and weep again?"*
+
+If the party has earned it (**Insight DC 14**), this is where **Eline confesses the whole of it** — Wren,
+the first draught, the Spring, the cure she has never been able to perform — her **quest-linked
+personal-quest gate (40)**:
+
+> *"Her name was Wren,"* Eline says, and the clinician's voice finally cracks clean through. *"She was
+> nine, and she was dying, and I made something to save her. It did not save her. It made... this. All of
+> this. Every grey face in that water is a copy of the first mistake I ever refused to bury."* She looks
+> at you through the mask. *"I cannot burn her. Three winters, and I cannot. So I am asking you to come
+> down there with me — and if I kneel by that cold water and lose my nerve again, you finish it. Whatever
+> I say."*
+
+### Act 3 · The Unmaking — *the cold pool, the choice*
+
+> In the center of the still grey water, neither living nor dead, a small grey figure sits with her knees
+> drawn up, singing the tune the reeds sing, and when your light falls on her she lifts a child's face,
+> patient and cold and glad to see you. *"You came,"* Wren says, in a voice like water under ice. Her grey
+> eyes find Eline, frozen on the last step. *"You came BACK. You're going to save me again, aren't you?"*
+
+This is the campaign's last and heaviest word. **Unmake the Spring** — consecrating fire to the reagent,
+holy water and a rite of rest to break the binding and *release* Wren (**Religion DC 15**) — and the Grey
+Quiet ends at its source, every walker in the fen laid down, at the cost of the child. Or **seize the
+reagent** — and `prize_seized` fires, and Doctor Mourn turns:
+
+> *"I'm sorry,"* Eline says, and she means it, and that is the worst part. She does not raise her voice.
+> She sets down her bag and takes up the consecrating brand instead, and her eyes are wet and perfectly
+> certain. *"You were going to carry it out of here. Sell it, or study it, or just keep it, and it would
+> spread, the way it always spreads. I made one mistake. I will not let you make it a thousand. Hold
+> still. This is the kindest cut I have left."*
+
+If the party reaches her in time (**Persuasion DC 15**) and gives her back her own words, she kneels,
+takes Wren's grey hand, and performs — through her grief, not around it — the cure she came three winters
+to do:
+
+> *"You can't save me again,"* Eline tells the child, very softly, the mask off at last. *"I can only let
+> you rest. I should have let you rest a long time ago. I'm here. Close your eyes."* And she sets the fire
+> to the cold water, and for one clean moment Wren's face is only a child's face, before she goes.
+
+---
+
+## Running Notes
+
+- **Tone first.** This is a tonal *departure* — gothic horror, not heroic adventure or city intrigue. Run
+  it slow and cold: the windless singing reed, the cold that isn't weather, the dead who walk *home*. Dread
+  over spectacle; mercy over monster-mash. The scariest thing in the campaign is a kind woman in a mask.
+- **The grey-walkers are victims, never enemies.** Easing and laying them to rest is the campaign's heart
+  and Eline's chief approval surface; a "combat" that ends with the dead laid down gently is a *better*
+  win, not a softer one. One of them is Halda's husband — play the grief.
+- **Leveling:** milestone recommended — level 4 after the third-night watch, 5–6 across the drowned chapel,
+  7 before/during the Stillwater Spring. (~4,000–5,000 XP total if you prefer encounter XP.)
+- **The fork is cold, not hot.** Eline does *not* rage. When her `prize_seized` agenda fires she turns
+  *clinically* — a physician excising a contaminant, grieving and certain. Run it as heartbreak, never
+  villainy. The single best insurance against the turn is a party she trusts to do the hard mercy.
+- **Set the flags honestly.** Set the engine flag `prize_seized` when the party *takes* the cursed reagent
+  at `scene-a3-spring` — that, alone, fires Eline's turn. Set the content flag `let_the_ward_burn` via
+  `record_decision`/`set_flag` when they *choose* to burn the Spring and end Wren (the path that avoids the
+  turn), so the chronicle records the choice. The engine does **not** read `decision_flag` for a
+  `prize_seized` agenda — it's there to record the choice and mark the safe path, not to gate the fire.
+- **The linked personal-quest.** Eline's `personal_quest` gate (`eline-gate-quest`, @40) is **linked** via
+  `quest_arc_id` → `cqarc-eline-stillwater` / `stage_id` → `cqstage-eline-confession` (authored in the
+  top-level `companion_quest_arcs` block). `seed_campaign()` folds the companion (with arc + dossier), the
+  NPCs, locations and scenes, but does **not** itself seed a campaign-level `companion_quest_arcs` block —
+  so at runtime register the arc with `set_companion_quest_arc` (or seed it from the world/ending) for the
+  link to resolve live. Until then the gate latches a one-shot `link_error` (F06-11) and stays
+  *locked-but-recoverable*; the personal-quest still plays from the gate's `note`. See `schema_notes`.
+- **Validation:** `validate_adventure()` returns `[]`; `seed_campaign()` loads cleanly with Doctor Eline
+  Mourn in the party (Cleric/Life Domain 3), the full dossier, a 3-gate arc (`loyalty` 20, a quest-linked
+  `personal_quest` 40, a `betrayal` 15), and a `CompanionAgenda` on the `prize_seized` trigger
+  (`decision_flag: let_the_ward_burn`). The companion and antagonist are original, non-origin characters;
+  none of the seven banned BG3 origins appears as PC or companion.

--- a/content/campaigns/three-knives/adventure.json
+++ b/content/campaigns/three-knives/adventure.json
@@ -1,0 +1,1135 @@
+{
+  "id": "three-knives",
+  "title": "Three Knives at the Ledger-Gate",
+  "ruleset": "SRD 5.2",
+  "level_range": [
+    3,
+    7
+  ],
+  "session_length_minutes": 240,
+  "world_id": "baldurs-gate",
+  "era": "1492 DR, the winter after the Absolute fell",
+  "premise": "Risen-Gate is a contested border town on the Risen Road, the last walled crossing before the Lower City of Baldur's Gate, and the war left it with no king. Three powers now hold it by the throat at once: a remnant of the Flaming Fist who still keep the law by the letter, the smugglers' Vine who keep the desperate fed by breaking that law, and the almshouse of the Pale Sister who keeps the dying alive and asks no questions of either. They have shared the gate-tolls in an uneasy three-way truce for a year — and now a road-reaver warlord called Maddox Crale, who calls himself the Tollwright, has set a noose around the town and means to own the gate and everyone who passes through it. The militia is broken, the truce is fraying, and the only people who can hold Risen-Gate are three who hate each other's methods: Sergeant Vael of the Fist, who will not bend the law to save a life; Korrin the Fence of the Vine, who will break any law to save one; and Sister Anwen of the almshouse, who will spend mercy on friend and enemy alike. They will each follow the party — and each of them is watching how the party answers the judgment-calls a siege forces, because every choice that satisfies one of the three curdles another. Maddox is the blade at the gate. The three knives are the ones at the party's back, and which of them turns depends entirely on which value the party betrays.",
+  "hook": "The truce keeper is dead. Old Reeve Hessom, who held Risen-Gate's three powers in balance for a year, was found at dawn with his throat open and the toll-strongbox emptied — and within the hour the Fist had arrested a starving Vine runner caught with three of the missing coins, the almshouse had taken in a man beaten half to death by that same Fist patrol, and the Tollwright's outriders had burned the eastern grain-barns in the night. Each of the three powers blames the others; each is one wrong move from open knives in the street; and a road-reaver army is two days out. The party arrives at the gate as outsiders with no debt to any faction, which is exactly why the dying reeve's clerk — a frightened girl named Pip who saw who really opened the strongbox — runs to them and no one else. She will only say it once, and quietly: it wasn't the runner, it wasn't the Fist, it wasn't the Vine. The reeve was killed to break the truce on purpose, two days before the Tollwright arrives — and whoever did it wanted Risen-Gate at its own throat when the army came. Find out who, before the town tears itself apart and hands Maddox the gate without a fight.",
+  "themes": [
+    "three good people whose definitions of 'good' cannot all be satisfied at once",
+    "law, survival, and mercy as competing — not complementary — virtues",
+    "a single choice that wins one ally by betraying another",
+    "the siege as a forge: every judgment-call has a human cost and a watching companion",
+    "the enemy at the gate is less dangerous than the knives at your back"
+  ],
+  "voices": {
+    "narrator-dm": "The Dungeon Master's narration voice. Used for boxed read-aloud text and scene description.",
+    "companion-default": "Sergeant Maelin Vael, the law-first companion — a by-the-book Flaming Fist sergeant holding Risen-Gate's order together with her bare hands.",
+    "npc-elder": "Sister Anwen of the Pale Sister's almshouse, the mercy-first companion, and old Reeve Hessom in his dying breath.",
+    "npc-rogue": "Korrin Vane, 'the Fence,' the survival-first companion — a Vine smuggler who keeps the desperate fed by breaking the law that keeps them in line.",
+    "npc-male-1": "Maddox Crale, the Tollwright — the road-reaver warlord besieging the gate — and assorted reavers, Fist troopers, and Vine runners.",
+    "npc-female-1": "Pip, the reeve's terrified clerk and the campaign's first witness, and Brannick, the doomed Vine runner the Fist arrests."
+  },
+  "antagonist": {
+    "id": "antagonist",
+    "name": "Maddox Crale, the Tollwright",
+    "title": "Reaver-Lord of the Risen Road",
+    "voice_id": "npc-male-1",
+    "hidden": false,
+    "goal": "To take Risen-Gate whole and undamaged and own the only walled crossing on the Risen Road — turning the toll-gate into his private tollwright's bench, where every wagon, refugee, and grain-cart between the city and the north pays him to live. Maddox does not want to storm the walls and burn what he means to keep; he wants the town to break ITSELF. A garrison at its own throat is a gate that opens from within. So before his army arrives he murders the one man holding the three-way truce together, seeds each faction's worst suspicion of the others, and lets law, survival, and mercy do his siege-work for him — arriving on the second day to accept the surrender of a town too busy knifing itself to fight him. He believes a wall is only as strong as the agreement behind it, and he has spent his whole reaver's career learning that the agreement is always the weak point.",
+    "scheme_by_act": [
+      "ACT 1: Maddox's work is already done before the party arrives — his planted killer murdered Reeve Hessom, emptied the toll-strongbox to frame the Vine, and slipped three marked coins onto a starving runner so the Fist would arrest him within the hour. The party investigates the murder through a town tearing along its three seams, and discovers the truth Pip the clerk saw: the reeve was killed to BREAK THE TRUCE on a timer, two days before the army comes. To learn anything, the party must work with all three factions at once — and recruit the three who lead them: Vael, Korrin, and Anwen. The first thread: someone wants this town at its own throat.",
+      "ACT 2: With the truce already cracking, Maddox tightens the screw from outside — outriders burn the grain, poison a well, and drag prisoners to the reaver-camp to be ransomed back at a price that empties the almshouse and the Vine's coffers both. The town's three powers are forced into impossible joint decisions under his pressure: who eats when the grain burns, who hangs for the reeve, who is left outside the wall when the gates close. Every one of these is a judgment-call that satisfies one companion's value and betrays another's — and the party, not the dead reeve, is now the balance-point. The midpoint: the party learns Maddox's planted agent is still INSIDE the walls, and that the truce can still be saved or shattered for good depending on which value the party has been spending.",
+      "ACT 3: Maddox arrives at the gate and offers terms — open the gate, name him Tollwright, and the town lives; resist, and he takes it over their corpses. But his real weapon is the fracture he's spent two days widening: at the climax, whichever companion the party has betrayed most across the siege reaches their breaking point, and Maddox (or his inside agent) has an offer waiting precisely for that wound. The party must hold the gate, expose and put down the inside agent, and break Maddox's host — but they must do it with three knives at their back, two of which stand with them and one of which, the one they failed, may turn. The win is holding Risen-Gate AND holding the three together; the loss is a gate that opens from within because the party spent one virtue too cheaply."
+    ],
+    "reveal": "Maddox is no hidden villain — every faction names him as the army on the road from the first scene. The REVEAL is not who he is but what his weapon actually is: not the host outside but the fracture inside, and the slow, dawning understanding that the murdered reeve, the framed runner, the burned grain, and every cruel either-or the siege forces are all ONE plan to make Risen-Gate destroy itself before he arrives. The second reveal is the inside agent — Maddox left one of his own people in the town a year ago, bonded into one of the three factions, and that agent is the hand that killed the reeve and keeps the wounds open. The hardest reveal lands last and is about the PARTY: that the companion who turns at the climax does so not because Maddox is persuasive but because the party, choosing among three good people under pressure, genuinely betrayed one of them — and the engine, not the DM, makes that betrayal real.",
+    "stat_block": "Maddox fights in the Act 3 climax at the gate, and unlike a schemer he WILL trade blades — he is a road-reaver who came up by the sword and respects only a wall that fights back. Use the bundled Knight stat block (AC 18, HP 52, CR 3) scaled up for a level 6-7 party (or a Veteran/Gladiator at a harder table; a Bandit Captain + Knight for a two-body boss), reflavored as a scarred toll-warlord with a reaver's banner. He commands from horseback at the gate, surrounded by his host (Bandits/Thugs/Scouts + a Berserker or two), and his real threat is the inside agent and the turned companion, not his own HP. He offers terms before blades and will withdraw a broken host to bleed the town another season rather than die on a held wall — a Tollwright who rides off to set a new toll elsewhere is a fine dangling thread.",
+    "max_hp": 52,
+    "armor_class": 18,
+    "hit_dice": "8d8+16",
+    "proficiency_bonus": 2,
+    "abilities": {
+      "strength": 16,
+      "dexterity": 11,
+      "constitution": 14,
+      "intelligence": 11,
+      "wisdom": 11,
+      "charisma": 15
+    },
+    "damage_resistances": [],
+    "damage_immunities": [],
+    "condition_immunities": []
+  },
+  "companions": [
+    {
+      "id": "companion-vael",
+      "name": "Sergeant Maelin Vael",
+      "voice_id": "companion-default",
+      "race": "Human",
+      "background": "Soldier",
+      "classes": [
+        {
+          "name": "Fighter",
+          "level": 3
+        }
+      ],
+      "abilities": {
+        "strength": 16,
+        "dexterity": 12,
+        "constitution": 15,
+        "intelligence": 11,
+        "wisdom": 13,
+        "charisma": 10
+      },
+      "proficiency_bonus": 2,
+      "armor_class": 18,
+      "max_hp": 28,
+      "hit_dice": "3d10",
+      "hit_dice_remaining": 3,
+      "skill_proficiencies": [
+        "Athletics",
+        "Intimidation",
+        "Perception",
+        "Investigation"
+      ],
+      "saving_throw_proficiencies": [
+        "str",
+        "con"
+      ],
+      "spells_known": [],
+      "spells_prepared": [],
+      "spell_slots": {},
+      "personality": "The last sergeant of the Flaming Fist garrison left holding Risen-Gate, and she holds it by the law or not at all. Vael came up in a company that fell apart around her during the Absolute war — officers who took bribes, troopers who looted the dead, a captain who hanged the wrong man because it was easier than finding the right one — and she decided, in the wreckage, that the only thing standing between a town and the mob is the LAW applied the same to everyone, no exceptions, no mercy bought and no rule bent. She is not cruel and she is not a zealot for cruelty; she is a zealot for PROCESS, certain that the moment you hang a man without trial because you're sure, or let a thief walk because he's hungry, you have become the thing the law exists to stop. She keeps her word like a debt of honor and despises a summary execution above all things — not because she's soft, but because a killing without due process is exactly the lawlessness she's bleeding to hold back. She'll follow the party because someone with no faction's debt is the only honest broker left in Risen-Gate, and because she needs the reeve's murder solved by EVIDENCE before the town hangs the wrong man and proves her worst fear true. Blunt, disciplined, allergic to expedience, and quietly terrified that holding the line will cost her every person she's trying to protect.",
+      "notes": "LAW-FIRST companion. Front-line anvil (sword-and-board Fighter: Second Wind, Action Surge by Act 2, a third tier by Act 3) and the party's INVESTIGATION/INTIMIDATION social muscle — she wants the murderer found by evidence and tried, not lynched. Her approval vocabulary is DELIBERATELY ORTHOGONAL to Korrin's and Anwen's: she rewards keeping_your_word and due_process and is wounded by summary_execution and bending the law for a sympathetic case — which means the SAME choice that wins Korrin (springing a desperate thief, cutting a deal that skirts the law) LOSES Vael, and the same choice that wins Anwen (sparing an enemy without trial) can read to Vael as exactly the lawlessness she's holding back. She is the moral pole of ORDER. THE FORK: honored, Vael becomes the party's incorruptible captain at the gate, the one who keeps the defense from becoming a massacre. Curdled — if the party breaks its word to her, executes a prisoner out of hand, or lets the law be spent like coin — her betrayal agenda fires on the decision_flag 'broke_your_oath': she does not join Maddox for gold, she WITHDRAWS the Fist from a defense she no longer believes is lawful, or stands aside / turns at the climax, certain the party has become the lawlessness she swore to stop. Reach her combat choices through companion_suggest_action; give her a voiced line each scene. Level her as a Fighter matching the party.",
+      "companion_dossier": {
+        "wound": "She watched her own company rot from the inside during the war — bribed officers, looted dead, a man hanged without trial because certainty was cheaper than evidence — and decided the law applied without exception is the only wall between a town and the mob, so she cannot bend it even once without feeling the whole wall give.",
+        "wants": [
+          "solve the reeve's murder by EVIDENCE and try the killer, not lynch a convenient suspect",
+          "hold Risen-Gate by the law so it's still worth holding when the siege ends",
+          "be a soldier of a law she doesn't have to be ashamed of, for once"
+        ],
+        "fears": [
+          "that holding the line by the book will get the very people she's protecting killed",
+          "becoming the kind of officer she watched destroy her old company — certain, expedient, lawless",
+          "that the law is already too broken to be worth the blood she's spending on it"
+        ],
+        "values": [
+          "due process over a convenient certainty",
+          "a word kept is a debt paid",
+          "the law applied the same to the powerful and the starving alike",
+          "order that protects, not order that punishes"
+        ],
+        "approval_likes": [
+          "keeping_your_word",
+          "due_process",
+          "try_the_accused",
+          "hold_the_law_under_pressure",
+          "refuse_a_bribe",
+          "evidence_over_certainty",
+          "protect_a_prisoner",
+          "treat_powerful_and_poor_alike"
+        ],
+        "approval_dislikes": [
+          "summary_execution",
+          "break_your_word",
+          "spring_the_framed_runner",
+          "bend_the_law_to_save_a_life",
+          "sparing_an_enemy",
+          "cut_a_lawless_deal",
+          "lynch_a_suspect",
+          "take_a_bribe"
+        ],
+        "banter_tags": [
+          "old_fist_company_that_rotted",
+          "law_as_the_only_wall",
+          "contempt_for_expedience",
+          "soldier_discipline"
+        ],
+        "camp_prompts": [
+          "Vael cleans her blade by the fire and asks the party, flatly, whether they think a law you bend for a good reason is still a law the next morning — or just a favor you'll have to do again for someone worse.",
+          "She names the man her old captain hanged without trial — wrong man, she's sure of it now — and admits she joined this fight so she'd never have to watch that happen again, then asks if the party means to make her watch it anyway.",
+          "After a hard day she says the part that frightens her isn't Maddox. It's how EASY it would be to do the lawless thing once, to save someone, and how she can already feel the party tempting her to it — and how much she wants to let them."
+        ]
+      },
+      "arc": {
+        "arc_gates": [
+          {
+            "id": "vael-gate-trust",
+            "kind": "loyalty",
+            "threshold": 25,
+            "note": "Vael decides the party is the honest broker Risen-Gate has lacked since the reeve died — she shows them the Fist's real evidence on the murder (the marked coins don't match the strongbox's tally; the framed runner couldn't have done it) and chooses to solve this by law WITH the party instead of around them. The first time she trusts an outsider with the truth."
+          },
+          {
+            "id": "vael-gate-quest",
+            "kind": "personal_quest",
+            "threshold": 50,
+            "note": "Vael's own quest opens — to find and TRY the reeve's true killer rather than let the town hang Brannick the runner, clearing the framed man and proving the murder was a deliberate strike at the truce. She asks the party's help to do it by the book under siege conditions, knowing every faction would rather she pick a convenient suspect and be done."
+          },
+          {
+            "id": "vael-gate-betrayal",
+            "kind": "betrayal",
+            "threshold": 20,
+            "note": "THE FORK FOR VAEL. If the party has broken its word to her, executed a prisoner out of hand, lynched a suspect, or spent the law like coin to please the Vine or the almshouse, her faith breaks. She does not turn for gold — she WITHDRAWS the Fist from a defense she's decided is no longer lawful, or at the climax stands aside / turns her troopers against a party that has become the very lawlessness she swore to hold back. Reachable only when approval has curdled and 'broke_your_oath' is set; honored, this gate stays locked forever."
+          },
+          {
+            "id": "vael-gate-loyalty",
+            "kind": "loyalty",
+            "threshold": 75,
+            "note": "Vael breaks the law's back the RIGHT way — once, knowingly, for the party — and survives it whole. At the gate she stands as the incorruptible captain of the defense, tries the true killer in front of the whole town instead of lynching him, and proves the law can hold a wall without becoming the mob. The soldier of an honest order she was afraid she'd never get to be."
+          }
+        ],
+        "agenda": {
+          "trigger": "attitude_below",
+          "value": 20,
+          "note": "Vael's faith in the party as honest brokers collapses. Pushed past her breaking point — her word broken, a prisoner executed without trial, the law spent like coin to buy the Vine or the almshouse's favor — she does the grim thing she fears most: she decides the party has become the lawlessness she's bleeding to stop, and withdraws the Fist from the defense (or turns her troopers) at the climax, certain that holding a gate for people who've abandoned the law is just helping the wrong mob win. The turn fires as a real event, ideally at the gate when the party is most exposed: she tells them she swore an oath to the law, not to them, and they made her choose.",
+          "decision_flag": "broke_your_oath"
+        }
+      }
+    },
+    {
+      "id": "companion-korrin",
+      "name": "Korrin Vane",
+      "voice_id": "npc-rogue",
+      "race": "Half-Elf",
+      "background": "Criminal",
+      "classes": [
+        {
+          "name": "Rogue",
+          "level": 3
+        }
+      ],
+      "abilities": {
+        "strength": 10,
+        "dexterity": 16,
+        "constitution": 13,
+        "intelligence": 13,
+        "wisdom": 12,
+        "charisma": 14
+      },
+      "proficiency_bonus": 2,
+      "armor_class": 15,
+      "max_hp": 21,
+      "hit_dice": "3d8",
+      "hit_dice_remaining": 3,
+      "skill_proficiencies": [
+        "Stealth",
+        "Deception",
+        "Sleight_of_Hand",
+        "Persuasion"
+      ],
+      "saving_throw_proficiencies": [
+        "dex",
+        "int"
+      ],
+      "spells_known": [],
+      "spells_prepared": [],
+      "spell_slots": {},
+      "personality": "Korrin 'the Fence' Vane runs the Vine — the smugglers' web that has kept Risen-Gate's poor alive through a year of war by moving grain past the Fist's tolls, springing debtors before the law could break them, and feeding the people the toll-takers and almshouses between them couldn't reach. Korrin learned the lesson young and hard: that the LAW is a luxury of people who've already eaten, that rigid rules applied to the desperate don't keep order, they keep the poor poor and dead, and that the only mercy worth a damn is the one that gets there before the funeral. Where Vael sees the wall between the town and the mob, Korrin sees the toll that starves the mob into existence. Korrin is a charmer and a cynic with a genuinely soft center under the patter — sparing a cornered thief, cutting a deal that lets a desperate person walk, bending or breaking a law that's about to get someone killed, these are not crimes to Korrin, they're the whole job. What Korrin can't abide is rigid law for its own sake — the rule that hangs the runner for three coins while the powerful skim the tolls, the process that takes two days a starving family doesn't have. Korrin follows the party because the reeve's murder is about to get a Vine runner hanged for a crime the Vine didn't commit, and because someone with no faction's collar is the only one who might cut the right deal instead of enforcing the wrong rule.",
+      "notes": "SURVIVAL-FIRST companion. Skirmisher/face (Rogue: Sneak Attack, Cunning Action, Expertise; Uncanny Dodge by Act 2, more Sneak dice by Act 3) and the party's DECEPTION/STEALTH/PERSUASION lever for the deals, springs, and back-channels the siege needs. Korrin's approval vocabulary is DELIBERATELY ORTHOGONAL to Vael's: Korrin rewards cutting_a_deal and sparing_a_desperate_thief and is wounded by rigid_law_that_gets_people_killed — which means the SAME by-the-book choice that wins Vael (try the accused, hold the law, refuse to spring the runner) LOSES Korrin, and the deal that delights Korrin is exactly the lawlessness that wounds Vael. Korrin sits ACROSS from Vael on the law/survival axis and at an ANGLE to Anwen (they agree on saving the desperate, but Korrin will cut a hard deal Anwen finds cruel, and Anwen will spare an enemy Korrin finds suicidal). The moral pole of SURVIVAL. THE FORK: honored, Korrin opens the Vine's whole web for the defense — smuggled grain, secret ways through the wall, a runner network worth an army. Curdled — if the party enforces a rigid law that gets Korrin's people killed, turns in a desperate thief, or lets a starving runner hang to keep the Fist happy — the betrayal agenda fires on 'turned_in_the_thief': Korrin doesn't join Maddox, Korrin takes the Vine and GOES, pulling the smuggled grain and the secret ways out from under a town that proved the law mattered more than its people — or worse, cuts a separate deal with the Tollwright to get the desperate out while the party holds an emptier wall. Reach combat choices via companion_suggest_action; voiced line each scene; level as a Rogue matching the party.",
+      "companion_dossier": {
+        "wound": "Korrin watched the law work exactly as written once — a starving cousin hanged for stealing bread while the toll-takers who skimmed the granary walked free — and learned that rigid rules applied to the desperate don't keep the peace, they keep the poor dying on schedule, so now the only mercy Korrin trusts is the one that breaks the rule in time.",
+        "wants": [
+          "keep the Vine's people — the desperate, the runners, the debtors — alive THROUGH the siege, by whatever deal it takes",
+          "see the framed runner Brannick walk free instead of hanging for the powerful's crime",
+          "prove that bending the law to save a life is the realest kind of order there is"
+        ],
+        "fears": [
+          "that the law will do what it always does — hang the poor on time, on the books, and call it justice",
+          "that being the one who cuts the hard deals has hollowed out the soft center Korrin still protects",
+          "that the party will choose the rule over the people and Korrin will have followed the wrong knife"
+        ],
+        "values": [
+          "the life in front of you over the rule in the book",
+          "a deal that saves someone over a process that's too slow to",
+          "mercy that gets there before the funeral",
+          "no one is worth less than the toll they couldn't pay"
+        ],
+        "approval_likes": [
+          "cutting_a_deal",
+          "sparing_a_desperate_thief",
+          "spring_the_framed_runner",
+          "bend_the_law_to_save_a_life",
+          "feed_the_desperate_first",
+          "spend_lives_to_save_lives",
+          "back_the_poor_over_the_powerful",
+          "find_the_third_option"
+        ],
+        "approval_dislikes": [
+          "rigid_law_that_gets_people_killed",
+          "turn_in_the_thief",
+          "let_the_runner_hang",
+          "hold_the_law_under_pressure",
+          "enforce_the_toll_on_the_starving",
+          "refuse_to_deal",
+          "side_with_the_powerful_on_principle",
+          "summary_execution"
+        ],
+        "banter_tags": [
+          "the_cousin_the_law_hanged",
+          "law_as_a_luxury_of_the_fed",
+          "the_vine_keeps_people_alive",
+          "charm_over_a_soft_center"
+        ],
+        "camp_prompts": [
+          "Korrin shuffles a deck of marked toll-chits by the fire and asks the party, lightly, whether they think there's a difference between a law and a leash — and whether Vael's noticed she can't tell them apart.",
+          "Korrin names the cousin the law hanged for a loaf of bread, all the proper paperwork in order, and asks the party — not lightly now — what good a wall is if it's built to keep the hungry on the wrong side of it.",
+          "After a hard day Korrin admits the deals have a cost: that cutting the hard one too many times leaves you good at it, and that the soft center the patter protects is getting harder to find, and asks if the party's noticed Korrin getting colder."
+        ]
+      },
+      "arc": {
+        "arc_gates": [
+          {
+            "id": "korrin-gate-trust",
+            "kind": "loyalty",
+            "threshold": 25,
+            "note": "Korrin decides the party might actually find the third option instead of enforcing the easy rule — and opens the first Vine secret: that Brannick the framed runner was set up, that the marked coins were planted, and that the Vine has a way through the wall the Fist doesn't know about. The first time Korrin trusts an outsider with a runner's life."
+          },
+          {
+            "id": "korrin-gate-quest",
+            "kind": "personal_quest",
+            "threshold": 50,
+            "note": "Korrin's own quest opens — to get Brannick and the most vulnerable of the Vine's people out of the gallows' and the siege's reach before the law or the reaver-camp claims them, using the smuggled ways Korrin has been holding in reserve. Korrin asks the party's help to spring a man the Fist has charged, knowing it puts them crosswise to Vael."
+          },
+          {
+            "id": "korrin-gate-betrayal",
+            "kind": "betrayal",
+            "threshold": 20,
+            "note": "THE FORK FOR KORRIN. If the party has enforced a rigid law that got Vine people killed, turned in a desperate thief, or let the framed runner hang to keep the Fist's favor, Korrin's last faith in the party breaks. Korrin doesn't ride to Maddox for coin — Korrin pulls the Vine OUT, taking the smuggled grain, the runner-network, and the secret ways with them, leaving a town that chose the rule over its people to hold an emptier wall; or cuts a separate evacuation deal with the Tollwright. Reachable only when approval has curdled and 'turned_in_the_thief' is set; honored, this gate stays locked forever."
+          },
+          {
+            "id": "korrin-gate-loyalty",
+            "kind": "loyalty",
+            "threshold": 75,
+            "note": "Korrin throws the whole Vine behind the defense — smuggled grain to feed the walls, the secret ways to flank the reaver-camp, the runner-network turned into the town's eyes and hands. Korrin proves that the web built to break the law can save the town the law alone couldn't, and finds, holding the line beside Vael of all people, that the soft center survived after all."
+          }
+        ],
+        "agenda": {
+          "trigger": "attitude_below",
+          "value": 20,
+          "note": "Korrin's faith that the party will choose people over rules collapses. Pushed past the breaking point — a rigid law enforced that got Vine people killed, a desperate thief turned in, the framed runner left to hang for the Fist's approval — Korrin does the survivor's math: a town that spends its poor to keep its rules is a town worth leaving. Korrin pulls the Vine and the smuggled grain and the secret ways out at the worst moment (or cuts a private deal with the Tollwright to evacuate the desperate while the party holds a hollow wall), and tells the party they should have saved the people in front of them instead of the principle behind them.",
+          "decision_flag": "turned_in_the_thief"
+        }
+      }
+    },
+    {
+      "id": "companion-anwen",
+      "name": "Sister Anwen",
+      "voice_id": "npc-elder",
+      "race": "Human",
+      "background": "Acolyte",
+      "classes": [
+        {
+          "name": "Cleric",
+          "level": 3
+        }
+      ],
+      "abilities": {
+        "strength": 11,
+        "dexterity": 12,
+        "constitution": 14,
+        "intelligence": 12,
+        "wisdom": 16,
+        "charisma": 13
+      },
+      "proficiency_bonus": 2,
+      "armor_class": 16,
+      "max_hp": 24,
+      "hit_dice": "3d8",
+      "hit_dice_remaining": 3,
+      "skill_proficiencies": [
+        "Medicine",
+        "Insight",
+        "Persuasion",
+        "Religion"
+      ],
+      "saving_throw_proficiencies": [
+        "wis",
+        "cha"
+      ],
+      "spells_known": [],
+      "spells_prepared": [
+        "Cure Wounds",
+        "Bless",
+        "Healing Word",
+        "Sanctuary",
+        "Spiritual Weapon",
+        "Lesser Restoration"
+      ],
+      "spell_slots": {
+        "1": {
+          "maximum": 4,
+          "used": 0
+        },
+        "2": {
+          "maximum": 2,
+          "used": 0
+        }
+      },
+      "personality": "Sister Anwen keeps the Pale Sister's almshouse just inside Risen-Gate's wall, and she has spent the war years learning the one lesson the Fist and the Vine both refuse: that the wounded man in front of you has no faction. She tends Fist troopers and Vine runners and reaver prisoners on the same cots with the same hands, asks no one's allegiance before she stops their bleeding, and has buried enough people killed by certainty — the law's and the lawless's both — to believe that the only thing worth defending is the person, not the cause. Anwen is not naive; she is the most clear-eyed person in the town about what cruelty costs, precisely because she's the one who sews it up afterward. She will spare an enemy who's down, tend a man both other factions want dead, and refuse, absolutely, to let the defense of the town become a slaughter of the people outside it — because the moment you decide some lives are collateral, you've already lost the thing the wall was supposed to protect. What wounds her is collateral cruelty: the prisoner killed to send a message, the well poisoned to starve the camp that holds women and children, the wounded left outside the gate to die so the town inside can feel safe. She follows the party because the siege is about to demand exactly those cruelties and someone has to be the voice that says the cost is too high — and because the reeve, before he died, was the one man who'd let her tend both sides without calling it treason.",
+      "notes": "MERCY-FIRST companion. Healer/support and the party's MEDICINE/INSIGHT/PERSUASION conscience (Cleric: Cure Wounds, Healing Word, Bless, Spiritual Weapon, Sanctuary; Channel Divinity and 2nd-tier slots by Act 2; 3rd-tier by Act 3 — keeps the anvil standing). Anwen's approval vocabulary is DELIBERATELY ORTHOGONAL: she rewards sparing_an_enemy and tending_the_wounded and is wounded by collateral_cruelty — which means a choice that satisfies Vael (execute the lawful sentence, hold the gate shut against the desperate-but-dangerous crowd outside) or Korrin (a hard deal that spends some lives to save more, a poisoned well that breaks the camp) can read to Anwen as the collateral cruelty she cannot abide. She agrees with Korrin on saving the desperate but splits on METHOD (she won't spend lives to save lives); she agrees with Vael on order but splits on MERCY (she'll spare the enemy the law would hang). The moral pole of MERCY. THE FORK: honored, Anwen's almshouse becomes the heart that keeps the defense human — healing the walls, turning prisoners into witnesses, brokering the surrender of reavers who'd rather not die. Curdled — if the party orders a massacre, kills prisoners to send a message, leaves the wounded outside to die, or poisons the well — the betrayal agenda fires on 'ordered_the_massacre': Anwen doesn't take up arms against the party, she WITHDRAWS her mercy and her sanctuary, throws open the almshouse to the enemy wounded the party left to die, declares the town's defense a thing she will not bless, and at the climax stands between the party and the people they mean to slaughter — a pacifist's betrayal that costs the party their healer and their conscience at once. Reach combat choices via companion_suggest_action; voiced line each scene; level as a Cleric matching the party.",
+      "companion_dossier": {
+        "wound": "She has buried too many people killed by other people's certainty — the law's righteous executions and the lawless's necessary sacrifices both — and learned in the burying that the moment you decide some lives are collateral, you've already lost the thing you were defending, so she will not let one more person become acceptable losses, not for law, not for survival, not for the town.",
+        "wants": [
+          "keep the defense of Risen-Gate from becoming a slaughter of the desperate outside its wall",
+          "tend every wounded soul — Fist, Vine, or reaver — as a person with no faction",
+          "prove that a town can be saved without spending the people it decides don't count"
+        ],
+        "fears": [
+          "that the siege will make collateral cruelty feel necessary and everyone will agree to it but her",
+          "that she's the only one left who counts the cost, and that her count doesn't matter",
+          "that mercy is a luxury the wall can't afford, and that she'll be proven a fool for spending it"
+        ],
+        "values": [
+          "the wounded man in front of you has no faction",
+          "no life is acceptable collateral",
+          "mercy spent on an enemy is still mercy, and still worth it",
+          "a town saved by cruelty has already lost what the wall was for"
+        ],
+        "approval_likes": [
+          "sparing_an_enemy",
+          "tending_the_wounded",
+          "shelter_the_desperate_at_the_gate",
+          "take_a_prisoner_alive",
+          "refuse_collateral_cruelty",
+          "broker_a_surrender",
+          "heal_friend_and_foe_alike",
+          "find_the_third_option"
+        ],
+        "approval_dislikes": [
+          "collateral_cruelty",
+          "order_the_massacre",
+          "kill_a_prisoner_to_send_a_message",
+          "leave_the_wounded_outside_to_die",
+          "poison_the_well",
+          "spend_lives_to_save_lives",
+          "execute_the_surrendered",
+          "summary_execution"
+        ],
+        "banter_tags": [
+          "the_wounded_have_no_faction",
+          "buried_by_others_certainty",
+          "mercy_is_not_a_luxury",
+          "clear_eyed_about_cruelty"
+        ],
+        "camp_prompts": [
+          "Anwen rolls bandages by the fire and asks the party, quietly, whether they've noticed that Vael and Korrin agree on exactly one thing — that there's a line of people who can be allowed to die for the cause — and that they only disagree on where to draw it.",
+          "She names a reaver boy she tended last winter who'd have died if she'd asked his allegiance first, and asks the party whether the wall they're about to defend is worth more than the boy on the wrong side of it.",
+          "After a hard day Anwen admits the thing she's most afraid of isn't the army. It's the moment the siege makes a cruelty feel reasonable to her too — and she asks the party to tell her, when it comes, if she's stopped counting the cost."
+        ]
+      },
+      "arc": {
+        "arc_gates": [
+          {
+            "id": "anwen-gate-trust",
+            "kind": "loyalty",
+            "threshold": 25,
+            "note": "Anwen decides the party can be trusted to count the cost with her — she lets them into the almshouse to see who she's really keeping alive (a reaver prisoner the Fist wants hanged, a Vine runner the law wants charged, both on the same cots) and tells them the one thing she knows that the factions don't: who among the wounded saw the reeve die. The first time she trusts an outsider with a life both sides want ended."
+          },
+          {
+            "id": "anwen-gate-quest",
+            "kind": "personal_quest",
+            "threshold": 50,
+            "note": "Anwen's own quest opens — to get the desperate non-combatants (and the wounded the factions want dead) safely through the siege without any of them becoming the acceptable losses the defense keeps demanding, and to broker the surrender of reavers who'd rather not die for the Tollwright. She asks the party's help to defend the town WITHOUT a massacre, knowing both Vael and Korrin have already drawn their lines."
+          },
+          {
+            "id": "anwen-gate-betrayal",
+            "kind": "betrayal",
+            "threshold": 20,
+            "note": "THE FORK FOR ANWEN. If the party has ordered a massacre, killed prisoners to send a message, left the wounded outside the gate to die, or poisoned the reaver-camp's well, Anwen's faith that the defense can stay human breaks. She does not raise a blade — she WITHDRAWS her mercy and sanctuary, opens the almshouse to the enemy wounded the party abandoned, declares the town's defense a thing she cannot bless, and at the climax stands between the party and the people they mean to slaughter. Reachable only when approval has curdled and 'ordered_the_massacre' is set; honored, this gate stays locked forever."
+          },
+          {
+            "id": "anwen-gate-loyalty",
+            "kind": "loyalty",
+            "threshold": 75,
+            "note": "Anwen makes the almshouse the heart of a defense that stays human — healing the walls, turning prisoners into witnesses against the inside agent, brokering the surrender of reavers who lay down arms rather than die for a toll. She proves that the town can be held without spending the people it decided didn't count, and stands at the gate as the conscience that kept the victory from costing the thing it was won to protect."
+          }
+        ],
+        "agenda": {
+          "trigger": "attitude_below",
+          "value": 20,
+          "note": "Anwen's faith that the defense can stay human collapses. Pushed past the breaking point — a massacre ordered, prisoners killed to send a message, the wounded left outside to die, the well poisoned — she does the one thing a healer can: she stops healing the party's war. She withdraws her mercy and her sanctuary, opens the almshouse to the enemy wounded the party abandoned, declares the town's defense a cruelty she will not bless, and at the climax stands unarmed between the party and the people they mean to slaughter, telling them she swore to count every cost and they made the cost too high.",
+          "decision_flag": "ordered_the_massacre"
+        }
+      }
+    }
+  ],
+  "npcs": [
+    {
+      "id": "pip",
+      "name": "Pip",
+      "voice_id": "npc-female-1",
+      "personality": "The dead reeve's clerk: a sharp, half-starved girl of perhaps sixteen who kept Reeve Hessom's toll-ledgers and slept in the gatehouse loft, which is why she was the one awake when the strongbox was opened and the reeve's throat was cut. She is terrified — she saw enough to know the killer wasn't who the Fist arrested, and not enough to be safe from whoever it really was — and she runs to the party precisely because they owe no faction and so can't be the one who silences her. Quick, frightened, fiercely loyal to the old reeve who fed her, and the first thread of the whole mystery.",
+      "attitude": "terrified, watchful, testing",
+      "role": "primary quest-giver / first witness",
+      "wants": "To stay alive, to see the reeve's real killer found, and to make someone with a sword understand that the murder was meant to break the truce on a timer — two days before the army comes.",
+      "knows": [
+        "She saw the strongbox opened from the inside — the killer had a key or knew where the reeve hid his, which the arrested Vine runner Brannick never could have.",
+        "The three marked coins found on Brannick don't match the strongbox's tally — they were planted; the rest of the toll-money went somewhere else.",
+        "The killer moved like someone who belonged in the gatehouse — not a stranger over the wall. Someone the reeve trusted enough to turn his back on.",
+        "The reeve, dying, said one word she didn't understand: 'Tollwright.' She didn't know then that it was a name."
+      ],
+      "secret": "Pip pocketed the reeve's real key-ring when she fled — the one that opens the strongbox and the gatehouse postern — and lives in terror that the killer knows she has it. It's the physical clue that the murder was an inside job; she'll surrender it only to a party that earns her trust, and it's the human stake (a hunted child holding the one piece of proof) that makes the conspiracy real.",
+      "stat_block": "Noncombatant. If endangered, treat as Commoner; she will hide, run, or trade her one secret for protection before she'll fight."
+    },
+    {
+      "id": "maddox",
+      "name": "Maddox Crale, the Tollwright",
+      "voice_id": "npc-male-1",
+      "personality": "The road-reaver warlord on the Risen Road: a broad, scarred man of fifty with a toll-collector's ledger chained at his belt and a reaver's banner over his host, who calls himself the Tollwright because he means to make the only walled crossing for forty miles into his private toll-bench. Maddox is not a berserker; he is a patient, almost genial siege-craftsman who learned over a long career that walls are strong and the agreements behind them are not, and that the cheapest way to take a town is to make it break itself. He murdered the reeve, framed the Vine, and seeded the factions' worst suspicions of each other not out of cruelty but out of economy — a garrison at its own throat surrenders a gate undamaged. He offers terms before blades, respects a wall that fights back, and will ride off to set a toll elsewhere rather than die on a held wall. The genial menace of a man who has done this to a dozen towns and expects this one to fall the same easy way.",
+      "attitude": "genial, patient, then implacable",
+      "role": "antagonist — see top-level 'antagonist' for stats and scheme",
+      "wants": "To take Risen-Gate whole and own its toll-gate — by making the town surrender itself, ideally without spending a reaver; and to use the fracture he planted (the murdered truce, the inside agent, whichever companion the party betrays) as his real siege-engine.",
+      "knows": [
+        "Everything about the plan: he ordered the reeve killed, the Vine framed, the suspicions seeded — and he left an inside agent in Risen-Gate a year ago, bonded into one of the three factions.",
+        "Exactly which pressures will crack the truce: who eats when the grain burns, who hangs for the reeve, who's left outside when the gates shut — every judgment-call the siege forces.",
+        "That a town divided three ways will hand him the gate, and that the surest lever is whichever of the three leaders the party has wounded most — he has an offer ready for that wound.",
+        "The reaver-host's true strength and weakness: it's a mercenary band that will break and ride off if the wall holds and the toll looks too expensive — he can't afford a real siege, only a cheap surrender."
+      ],
+      "secret": "His host is weaker than it looks — a reaver band that came for an easy toll, not a battle; if the town holds together and the wall fights back, the cost outruns the prize and Maddox rides off. His whole strategy depends on the town breaking first, which means the PARTY holding the three companions together is the thing that actually defeats him — the fracture is the weapon, and the party's choices are what arm or disarm it.",
+      "stat_block": "See top-level 'antagonist'. Knight (AC 18, HP 52, CR 3) scaled up for a level 6-7 party (Veteran/Gladiator, or Bandit Captain + Knight for a two-body boss at a strong table), reflavored as a scarred toll-warlord on horseback at the gate. He fights in the Act 3 climax, surrounded by his host (Bandits/Thugs/Scouts + a Berserker), offers terms before blades, and withdraws a broken host rather than die on a held wall.",
+      "max_hp": 52,
+      "armor_class": 18,
+      "hit_dice": "8d8+16",
+      "proficiency_bonus": 2,
+      "abilities": {
+        "strength": 16,
+        "dexterity": 11,
+        "constitution": 14,
+        "intelligence": 11,
+        "wisdom": 11,
+        "charisma": 15
+      }
+    },
+    {
+      "id": "brannick",
+      "name": "Brannick",
+      "voice_id": "npc-female-1",
+      "personality": "The Vine runner the Fist arrested for the reeve's murder: a gaunt, frightened young man caught with three of the missing toll-coins he swears he found in the gutter, now chained in the gatehouse cell awaiting a hanging the whole town wants over with. Brannick is no killer — he's a starving runner who moved grain for Korrin's Vine and happened to be the convenient body when the frame needed one. He is the living fulcrum of the campaign's central tension: Vael wants him TRIED (and is increasingly sure he's innocent), Korrin wants him SPRUNG (a man hanging for the powerful's crime), Anwen wants him SPARED (a life the siege would spend). Terrified, protesting, and the human face of every judgment-call the party makes.",
+      "attitude": "terrified, pleading, innocent",
+      "role": "the framed prisoner / the fulcrum of the central choice (Act 1-2)",
+      "wants": "To not hang for a murder he didn't commit, to get back to the Vine and the sister he runs grain for, and to make someone believe he found those coins instead of stealing them off a dead man.",
+      "knows": [
+        "Where he really found the three marked coins — dropped on the postern path, the way a planter would scatter a frame, not the way a thief would hide a haul.",
+        "That a hooded figure he took for a Fist trooper passed him on the postern path that night, going FROM the gatehouse — the inside agent, though Brannick doesn't know it.",
+        "The Vine's small secrets (a way through the wall, who runs which grain) that make him valuable to spring and dangerous to hang.",
+        "That he is going to die for nothing unless someone with no stake in the factions chooses to look."
+      ],
+      "secret": "Brannick recognized the hooded figure's gait and ring — he knows, without knowing he knows, who the inside agent is, because he's seen them in one of the three factions' colors. Drawing it out of him (Persuasion/Insight, and keeping him alive long enough) is a key to the Act 2 midpoint reveal — which is exactly why springing OR trying OR sparing him all matter, and why letting him hang buries the clue with him.",
+      "stat_block": "Noncombatant while chained (Commoner). If freed he'll run, not fight; his value is the clue he carries and the choice he forces, not his sword-arm."
+    },
+    {
+      "id": "reeve-hessom",
+      "name": "Reeve Hessom",
+      "voice_id": "npc-elder",
+      "personality": "The murdered truce-keeper, seen only in the opening and in flashback/testimony: an old, tired, scrupulously fair toll-reeve who held Risen-Gate's three powers in a year-long balance by being the one man all three trusted to be honest. Hessom believed the town survived only because law, survival, and mercy each got a third of the say and none got all of it — a living argument for the very balance the party must now keep. His murder is the inciting wound; his memory is the campaign's lost center, the thing the three companions are each, in their own incompatible way, trying to honor.",
+      "attitude": "dead (the inciting victim); fair and weary in testimony",
+      "role": "the murdered truce-keeper / the lost center (Act 1)",
+      "wants": "(In memory and final words) To have the truce survive him — to have the three powers hold together against the road instead of turning on each other, which is exactly what his killer engineered.",
+      "knows": [
+        "(Via his ledger, his hidden notes, and Pip's testimony) That he feared the truce was being undermined from inside — he'd noticed toll-money going missing in small amounts for months before the night it all vanished.",
+        "That he kept a private record of which faction each suspicious shortfall traced to — and that the pattern pointed not at any of the three powers but at a single hand moving among all of them.",
+        "That he said 'Tollwright' as he died — he'd learned the name of the army on the road, and learned it too late.",
+        "(His example) That the only thing that ever held Risen-Gate was no single virtue getting the whole say."
+      ],
+      "secret": "Hessom had begun to suspect the inside agent before he died, and hid his evidence (a coded ledger-page) where only someone who understood all three factions could find it — which means recovering it rewards a party that has engaged ALL THREE companions, not just one. His death proves he was right and too slow; his hidden page is the thread to the inside agent.",
+      "stat_block": "Deceased. Appears only as a body, a voice in his dying line, and as testimony/documents. Noncombatant."
+    },
+    {
+      "id": "corporal-dass",
+      "name": "Corporal Dass",
+      "voice_id": "npc-male-1",
+      "personality": "Vael's second in the broken Fist garrison: a hard, frightened veteran who wants the reeve's murder closed FAST — hang the runner, calm the town, hold the wall — and chafes against Vael's insistence on evidence and trial while an army marches. Dass is not corrupt, he's scared and tired, the everyman who thinks expedience is mercy when the clock's running. He's the soft seam in the Fist: pushed, he'll argue for the lynching that would shatter the truce and damn Vael's faith; turned, he becomes the trooper who helps the party try the real killer in the open. The voice of 'just hang him and be done' that the party (and Vael) must answer.",
+      "attitude": "tense, expedient, turnable",
+      "role": "Fist insider / pressure toward the easy injustice (Act 1-2)",
+      "wants": "To close the murder, quiet the town, and hold the gate alive — and to not have to think too hard about whether the runner's actually guilty.",
+      "knows": [
+        "The Fist's evidence on the murder (the marked coins, the cell, the timeline) — and, if pressed honestly, that the timeline doesn't fit the runner.",
+        "That half the garrison wants Brannick hanged tonight and that Vael is the only thing stopping it — a lynching that would break the truce exactly as the killer intends.",
+        "The gatehouse layout, the watch rotation, and who had access to the reeve's key the night he died (a short, damning list).",
+        "That a hooded figure in Fist colors was seen on the postern path — which he's been afraid to report because it points inside his own company."
+      ],
+      "secret": "Dass himself was briefly bribed months ago — a small thing, a toll waved through — by a smiling face he now realizes might have been the inside agent, and his fear of being exposed as the rot makes him push hardest for the quick hanging that would bury the question. A party that offers him a way to come clean rather than just leverage turns him into a witness instead of an obstacle.",
+      "stat_block": "If forced to fight, a Guard or Veteran (AC 16, HP 58, CR 3); but he is a turnable insider, not a combatant — he'd far rather argue for the lynching than draw on the party."
+    },
+    {
+      "id": "mother-sefin",
+      "name": "Mother Sefin",
+      "voice_id": "npc-elder",
+      "personality": "The eldest of the Vine and Korrin's old mentor — a wry, weather-beaten woman who ran grain past tolls before Korrin was born and remembers when Risen-Gate's law hanged her own people for feeding theirs. She's the Vine's institutional memory and its conscience-of-survival: the one who taught Korrin that the law is a luxury of the fed, and the one now quietly worried that Korrin has gotten too good at the hard deals. She's an ally and a lore-anchor — she knows the Vine's secret ways, the history of the three-way truce, and why the powerful have always skimmed the tolls the runners hang for. A wary friend to a party that proves it won't spend the poor.",
+      "attitude": "wary, dry-humored, loyal to her own",
+      "role": "ally / Vine lore-anchor / Korrin's mirror",
+      "wants": "To keep the Vine's people alive through the siege, to see Korrin stay the person under the patter, and to make the party understand that the wall starves the people it's supposed to protect.",
+      "knows": [
+        "The Vine's secret ways through and under Risen-Gate's wall — the smuggled routes that are worth an army in a siege.",
+        "The real history of the toll: that the powerful have skimmed it for generations while the runners hanged, which is why the Vine exists at all.",
+        "That the reeve was the rare honest toll-man and that his murder smells like an inside job to anyone who's watched the gate for thirty years.",
+        "Where the Vine has stockpiled grain the burned barns didn't reach — the supply that can feed the walls if the party keeps Korrin on side."
+      ],
+      "secret": "Sefin has long suspected there's a planted Tollwright agent in the town — she's seen a face move too easily between all three factions over the past year — but with no proof and no faction willing to hear the Vine accuse anyone, she's kept it to herself. She'll share the suspicion (and a description) with a party that has earned the Vine's trust, seeding the inside-agent reveal.",
+      "stat_block": "Noncombatant by age, but no fool — if the Vine's quarter is attacked she defends her people as a Spy (AC 12, HP 27, CR 1), fighting dirty and from cover; she'd rather smuggle the vulnerable out than stand and trade blows."
+    }
+  ],
+  "locations": [
+    {
+      "id": "loc-gatehouse",
+      "name": "The Risen-Gate Gatehouse & Toll-Yard (Hub)",
+      "description": "The party's hub: the great twin-towered gatehouse of Risen-Gate, where the Risen Road passes through the wall and every wagon, refugee, and grain-cart pays its toll — now a tense, ungoverned heart with the reeve dead, his strongbox empty, and his blood not yet scrubbed from the toll-bench. The toll-yard inside the gate is where the three powers meet and glare: a Fist watch-post on one side, the Vine's runners loitering in the shadow of the wall on the other, the Pale Sister's almshouse just within bowshot of the gate. Refugees from the burned barns crowd the yard; everyone has a side; the truce that held this all together died with the reeve. This is the safe base the party returns to between acts — to rest, resupply, share findings with Pip and the three companions, and feel the town tighten one notch closer to its own throat each day the army draws nearer.",
+      "connections": [
+        "loc-fist-post",
+        "loc-vine-quarter",
+        "loc-almshouse",
+        "loc-reaver-camp"
+      ],
+      "notes": "HOME-BASE HUB. Pip (quest-giver/first witness), Brannick (the chained fulcrum in the gatehouse cell), and the three companions (Vael at the Fist post, Korrin among the Vine, Anwen at the almshouse) all orbit here. The party rests, levels, and gathers clues here; the three-way tension is reinforced every act by the crowding refugees and the army's approach. The hub fans out to the three faction sites (Act 1-2) and the reaver-camp/gate (Act 3). CRITICAL STAGING: this is where the three competing-agenda companions are recruited (Act 1) and where the judgment-calls that move their gauges in opposite directions are presented (every act)."
+    },
+    {
+      "id": "loc-fist-post",
+      "name": "The Flaming Fist Watch-Post (Act 1 — Law)",
+      "description": "The remnant garrison's strong-point against the inner wall: a cramped barracks-and-cell of stacked arms, a duty-roster nailed to the door, and the gatehouse holding-cell where Brannick the framed runner waits to hang. Sergeant Vael runs it on discipline and too little sleep, Corporal Dass argues for the quick hanging, and half the garrison would lynch the runner tonight if Vael let them. This is where the LAW makes its claim on the murder — by evidence and trial if Vael has her way, by the noose if she doesn't — and where the party recruits the law-first knife.",
+      "connections": [
+        "loc-gatehouse"
+      ],
+      "notes": "ACT 1 SITE — the LAW pole (levels 3-4). Recruit Sergeant Vael here. Beats: SOCIAL (Vael wants the murder solved by evidence; Dass wants Brannick hanged tonight — the party's first orthogonal judgment-call: back due process [+Vael, -Korrin] or push for a fast resolution); EXPLORATION (the Fist's evidence — the marked coins that don't match the tally, the watch-rotation, the postern path; clues the murder was an inside job); the first taste of the central tension — that trying Brannick by the book pleases Vael and infuriates Korrin, and that the lynching half the garrison wants would shatter the truce on the killer's schedule. See scenes scene-a1-*."
+    },
+    {
+      "id": "loc-vine-quarter",
+      "name": "The Vine's Quarter (Act 1 — Survival)",
+      "description": "A warren of lean-tos and cellar-ways in the lee of the wall where the Vine keeps the desperate fed: smuggled grain in false-bottomed carts, runners coming and going through gaps the Fist doesn't know about, Mother Sefin holding court over a soup-pot that feeds the people the tolls and the almshouse between them can't reach. With the barns burned and a runner in the Fist's cell, the quarter is frightened and furious — the law is about to hang one of its own for the powerful's crime. This is where SURVIVAL makes its claim — that the rules are killing the poor on schedule — and where the party recruits the survival-first knife.",
+      "connections": [
+        "loc-gatehouse"
+      ],
+      "notes": "ACT 1 SITE — the SURVIVAL pole (levels 3-4). Recruit Korrin the Fence here. Beats: SOCIAL (Korrin wants Brannick SPRUNG — a man hanging for a crime the Vine didn't commit — and the Vine's grain and secret ways are the price of Korrin's loyalty; the orthogonal judgment-call sharpens: spring the runner [+Korrin, -Vael] or insist on the lawful trial [+Vael, -Korrin]); EXPLORATION (the Vine's secret ways through the wall, the stockpiled grain that can feed a siege, Mother Sefin's lore on the toll and her suspicion of an inside agent); the deepening tension — that the same mercy Korrin calls survival, Vael calls lawlessness. See scenes scene-a1-*."
+    },
+    {
+      "id": "loc-almshouse",
+      "name": "The Pale Sister's Almshouse (Act 1 — Mercy)",
+      "description": "A low, lime-washed hall of cots just inside the wall where Sister Anwen tends the wounded of every side — a Fist trooper and a Vine runner and a captured reaver boy on the same row of beds, all bleeding the same red. Refugees from the burned barns crowd the doorway; the man the Fist beat half to death lies in the corner; and Anwen moves among them all asking no one's allegiance. This is where MERCY makes its claim — that the wounded have no faction and no life is acceptable collateral — and where the party recruits the mercy-first knife, and first feels how her conscience cuts across both the law's and the survival's.",
+      "connections": [
+        "loc-gatehouse"
+      ],
+      "notes": "ACT 1 SITE — the MERCY pole (levels 3-4). Recruit Sister Anwen here. Beats: SOCIAL (Anwen tends all three factions' wounded and the captured reaver the Fist wants hanged; the orthogonal judgment-call completes the triangle — sparing the reaver prisoner [+Anwen] reads as lawlessness to Vael and naivety to Korrin, who'd trade the prisoner for leverage); EXPLORATION (a wounded witness who saw the reeve die, the reaver boy's intel on Maddox's host, Anwen's clear-eyed read of who really benefits from the truce breaking). Establishes that Anwen agrees with Korrin on saving the desperate but splits on method, and with Vael on order but splits on mercy. See scenes scene-a1-*."
+    },
+    {
+      "id": "loc-reaver-camp",
+      "name": "The Tollwright's Camp & the Held Gate (Act 2-3 — the Siege)",
+      "description": "Out beyond the wall on the Risen Road, the reaver-host's camp blooms like a wound: cookfires and ransom-pens and Maddox Crale's banner over a command-tent, with outriders ranging in to burn the grain, poison the wells, and drag prisoners back to be ransomed at a price that bleeds the town white. In Act 2 the party raids and reconnoiters here under the siege's pressure; in Act 3 Maddox brings the host to the gate itself and offers his terms, and the held gatehouse becomes the climactic battlefield where the town's three knives stand together or one turns. This is where the ENEMY makes his claim — and where the fracture he planted inside the wall finally pays out.",
+      "connections": [
+        "loc-gatehouse"
+      ],
+      "notes": "ACT 2-3 SITE (levels 4-7). Act 2 EXPLORATION/COMBAT: raid the reaver-camp to free ransomed prisoners, recover burned-grain intel, and discover Maddox's inside agent and the joint-decision pressures (who eats, who hangs, who's left outside) — every one a judgment-call that satisfies one companion and betrays another. The MIDPOINT REVERSAL lands here: the inside agent is still within the walls, and the truce can be saved or shattered for good. Act 3 SOCIAL/COMBAT: Maddox brings the host to the held gate, offers terms, and the climax turns on whether the three companions stand together — with whichever one the party betrayed most reaching their breaking point and, on their decision_flag, turning. The win is holding the gate AND the three. See scenes scene-a2-* and scene-a3-*."
+    }
+  ],
+  "arcs": [
+    {
+      "id": "arc-1-three-knives",
+      "title": "Act 1 — Three Knives, One Gate",
+      "level_range": [
+        3,
+        4
+      ],
+      "beats": [
+        {
+          "id": "a1-hook",
+          "title": "Hook — The Truce-Keeper's Throat",
+          "location_id": "loc-gatehouse",
+          "summary": "The reeve is dead, the strongbox empty, a starving runner arrested, the barns burning — and the three powers of Risen-Gate are one wrong move from open knives with a reaver army two days out. Pip the clerk, who saw the killer wasn't who the Fist arrested, runs to the only outsiders in town: the reeve was murdered to break the truce on a timer, two days before Maddox arrives. Find out who, before the town tears itself apart."
+        },
+        {
+          "id": "a1-recruit",
+          "title": "Challenge — Three Who Cannot Agree",
+          "location_id": "loc-gatehouse",
+          "summary": "To investigate the murder the party must work with all three factions — and recruit their three leaders, whose values cannot all be satisfied at once: Vael of the Fist (try the runner by law), Korrin of the Vine (spring the runner who's framed), and Anwen of the almshouse (spare the prisoner the law would hang). The first judgment-calls land: every choice that wins one of the three costs another. The party becomes the truce's new balance-point."
+        },
+        {
+          "id": "a1-climax",
+          "title": "Climax — The Runner's Rope",
+          "location_id": "loc-fist-post",
+          "summary": "The town's fury (and Maddox's design) come to a head over Brannick: half the Fist wants him lynched tonight, the Vine wants him sprung, the almshouse wants him spared. How the party handles the framed runner is the act's defining orthogonal choice — and the first to move all three gauges in different directions. The murder's first proof (it was an inside job, on a timer) is carried back to the hub as the truce holds or cracks by a thread."
+        }
+      ]
+    },
+    {
+      "id": "arc-2-the-siege-tightens",
+      "title": "Act 2 — The Siege Tightens",
+      "level_range": [
+        4,
+        6
+      ],
+      "beats": [
+        {
+          "id": "a2-hook",
+          "title": "Hook — The Screw Turns From Outside",
+          "location_id": "loc-gatehouse",
+          "summary": "Maddox's outriders burn the grain, poison a well, and drag prisoners to the reaver-camp to be ransomed at a price that bleeds the town. The three powers are forced into impossible joint decisions under the pressure — who eats, who hangs, who's left outside the wall — and the party, not the dead reeve, is now the balance-point. Every joint decision is a judgment-call that pleases one companion and wounds another."
+        },
+        {
+          "id": "a2-challenge",
+          "title": "Challenge — The Camp and the Agent",
+          "location_id": "loc-reaver-camp",
+          "summary": "The party raids the reaver-camp — freeing ransomed prisoners, recovering Maddox's plans, and turning a reaver or two — while the siege's joint-decisions keep splitting the three companions. The recovered intel and Brannick's half-known clue converge on the midpoint reversal: Maddox's planted agent is still INSIDE the walls, the hand that killed the reeve, and the truce can still be saved or shattered for good depending on which value the party has been spending."
+        },
+        {
+          "id": "a2-climax",
+          "title": "Climax — Which Virtue You Spent",
+          "location_id": "loc-reaver-camp",
+          "summary": "The midpoint cost lands: cornering the inside agent forces a final-stretch judgment-call that pleases one companion and betrays another (try the agent / cut a deal with them / spare them), and by act's end the party can see plainly which of the three they've wounded most. Whichever gauge has curdled below its breaking point is now armed — Vael's 'broke_your_oath,' Korrin's 'turned_in_the_thief,' or Anwen's 'ordered_the_massacre' — for the climax to turn."
+        }
+      ]
+    },
+    {
+      "id": "arc-3-the-held-gate",
+      "title": "Act 3 — The Held Gate",
+      "level_range": [
+        6,
+        7
+      ],
+      "beats": [
+        {
+          "id": "a3-hook",
+          "title": "Hook — The Tollwright at the Wall",
+          "location_id": "loc-gatehouse",
+          "summary": "Maddox brings the host to the gate and offers terms: open it, name him Tollwright, and the town lives. The party must rally the three factions to hold — but the fracture Maddox spent two days widening is at its worst, and whichever companion the party betrayed most across the siege reaches their breaking point, with the Tollwright's offer waiting precisely for that wound. The party prepares to hold a gate with three knives at their back, one of which may turn."
+        },
+        {
+          "id": "a3-challenge",
+          "title": "Challenge — Unmasking the Hand Within",
+          "location_id": "loc-reaver-camp",
+          "summary": "Before the assault, the party must expose and put down Maddox's inside agent — the hand that killed the reeve and kept the wounds open — and clear Brannick by trying the real killer in the open (or watch the truce shatter for good). Doing it WITH the three companions, or with one already turning, sets the shape of the final stand. The agent's exposure is the last lever that can pull the wounded companion back from the brink — or confirm the break."
+        },
+        {
+          "id": "a3-climax",
+          "title": "Climax — Three Knives at the Gate",
+          "location_id": "loc-reaver-camp",
+          "summary": "Maddox assaults the held gate. The climax turns on the three: two stand with the party and one — the value the party spent too cheaply — may turn on their decision_flag, withdrawing the Fist (Vael), pulling the Vine and the grain (Korrin), or throwing open the almshouse to the abandoned wounded (Anwen). The win is holding Risen-Gate AND holding the three together; breaking Maddox's host (which only ever came for a cheap toll) by keeping the town whole is the true victory, not a body count."
+        }
+      ]
+    }
+  ],
+  "scenes": [
+    {
+      "id": "scene-a1-hook",
+      "name": "The Truce-Keeper's Throat",
+      "type": "social",
+      "location_id": "loc-gatehouse",
+      "read_aloud": "Risen-Gate is a town holding its breath the wrong way — too tight, about to break. The reeve's blood is still a dark smear on the toll-bench under the gatehouse arch; the strongbox beside it hangs open and empty; and across the crowded toll-yard, three knots of armed and frightened people stare each other down: red-cloaked Fist troopers with a runner in chains, Vine folk muttering in the wall's shadow, and the almshouse doorway where a beaten man is carried in. Smoke from the burned eastern barns hazes the morning sun. And out of the press, a half-starved girl with ink-stained fingers catches your sleeve and pulls you into the lee of the gate-tower, her eyes everywhere at once. 'You don't owe any of them,' she breathes. 'That's why it has to be you.' She swallows. 'They arrested Brannick for killing the reeve. It wasn't him. I was awake. The strongbox opened from the INSIDE — and the reeve, before he... he said one word. Tollwright. Two days. The army's two days out, and someone killed the one man holding this town together two days before it gets here. On PURPOSE.' Her grip tightens. 'Find out who. Please. Before they all start killing each other and hand the gate over without a fight.'",
+      "dm_notes": "Establish the hub, the three-way fracture, and the central engine of the campaign: a murder engineered to break a three-way truce on a timer. Pip (npc-female-1) is the quest-giver/first witness — terrified, sharp, running to the party precisely because they owe no faction. Plant the THREE POLES visibly in the toll-yard: the Fist (law) with the chained runner, the Vine (survival) in the wall's shadow, the almshouse (mercy) taking in the beaten man — the party will recruit a leader from each, and those leaders' values CANNOT all be satisfied at once. Plant the antagonist by name through Pip's dying-word clue ('Tollwright') and the smoke of the burned barns — Maddox is not hidden, the mystery is WHO inside the walls is his hand and which value the party will spend. Do NOT resolve the murder here; the inside-job clue (strongbox opened from inside, marked coins don't fit) is the thread. CRITICAL FRAMING for the whole campaign: make the party feel, from this first scene, that there is no choice that pleases everyone — backing the Fist's arrest pleases law and wounds survival; freeing the runner pleases survival and wounds law; sheltering everyone pleases mercy and reads as weakness to both. The three companions are recruited next (scene-a1-recruit); seed their presence here (a hard-eyed sergeant by the cell, a charming half-elf among the Vine, a calm healer in the almshouse doorway). The hook is moral and civic, not monetary — Risen-Gate has almost no coin to offer, only its survival.",
+      "checks": [
+        {
+          "skill": "Insight",
+          "dc": 13,
+          "success": "You read the yard under the fear: the three factions aren't just grieving, they're being PLAYED — each one's worst suspicion of the others has been freshly fed, and the timing (a murder exactly two days before an army) is far too neat to be a robbery gone wrong. Pip is telling the truth and is more afraid of being silenced than of the reavers. Someone wanted this town at its own throat. (Flags the conspiracy and the inside-job nature of the murder.)",
+          "failure": "You take it as it looks: a robbery-murder, a caught thief, three frightened factions, an army coming. The pieces are there but you don't yet see the hand arranging them — the unease keeps for later, once you've met the three who lead the factions."
+        },
+        {
+          "skill": "Persuasion",
+          "dc": 12,
+          "success": "Your steadiness reaches Pip. She tells you the rest: the three marked coins on Brannick don't match the strongbox's tally — they were PLANTED — and the killer moved like someone the reeve trusted enough to turn his back on. She also admits, barely, that she pocketed the reeve's real key-ring when she fled and is terrified the killer knows she has it. (The human stake — a hunted child holding the one proof it was an inside job.)",
+          "failure": "Pip holds the worst back, too frightened to trust strangers fully — she gives you Brannick's name, the 'Tollwright' word, and that it wasn't the runner, enough to start. The planted coins and the key-ring she's hiding wait until you've earned more trust."
+        }
+      ],
+      "encounter": null,
+      "transitions": "Taking Pip's case, the party must work all three factions to investigate — move to scene-a1-recruit, where they meet and recruit Vael (loc-fist-post), Korrin (loc-vine-quarter), and Anwen (loc-almshouse), and feel the first orthogonal judgment-calls."
+    },
+    {
+      "id": "scene-a1-recruit",
+      "name": "Three Who Cannot Agree",
+      "type": "social",
+      "location_id": "loc-gatehouse",
+      "read_aloud": "To learn who killed the reeve, you have to walk into all three armed camps that hate each other — and each one wants something different from you before it will talk. At the Fist post, Sergeant Vael looks up from a duty-roster with the flat, tired eyes of someone holding a wall with her bare hands: 'You've no faction's coin in you. Good. Then help me do this RIGHT — by the evidence, by a trial — before my own troopers hang that runner tonight and prove this town's not worth saving.' In the Vine's quarter, a half-elf with a card-sharp's smile and a soft, furious center leans off a grain-cart: 'Vael wants to TRY him. Try him. There's an army coming and she wants to hold a hearing. That runner's going to hang for a crime the powerful committed, same as always — unless someone with no stake cuts him loose. You in?' And in the almshouse doorway, a calm woman with a healer's steady hands and a graveyard's worth of clear sight says, simply: 'They both want to USE him — try him, spring him, it's the same coin. I want him to LIVE. Him, and the reaver boy the Fist wants hanged, and the man they beat this morning. Nobody in this town is acceptable losses. Not yet. Will you help me keep it that way?'",
+      "dm_notes": "THE STRUCTURAL HEART of Act 1: recruit all three competing-agenda companions and establish their ORTHOGONAL approval vocabularies in one scene, so the player feels from the start that the gauges move in OPPOSITE directions on a single choice. VAEL (companion-default, law-first) wants Brannick TRIED — rewards due_process/keeping_your_word, wounded by summary_execution/bending the law. KORRIN (npc-rogue, survival-first) wants Brannick SPRUNG — rewards cutting_a_deal/sparing_a_desperate_thief, wounded by rigid_law_that_gets_people_killed/turning in the thief. ANWEN (npc-elder, mercy-first) wants Brannick (and the reaver prisoner) SPARED and ALIVE — rewards sparing_an_enemy/tending_the_wounded, wounded by collateral_cruelty. Recruit each via their own pole (the Fist post / the Vine quarter / the almshouse — the three Act-1 sites). KEY TEACHING BEAT: surface explicitly that you cannot satisfy all three on Brannick — backing the trial pleases Vael and stings Korrin; springing him pleases Korrin and stings Vael; insisting he simply be kept alive pleases Anwen but reads as weakness/lawlessness to the other two. Let the party make a provisional lean here and TAG it with the right approval cause-keys (record_decision / the approval system) so a player sees Vael's bar rise as Korrin's falls. This is the campaign's promise: a single tagged decision moves three gauges, and not in the same direction. Do NOT force a final answer on Brannick yet — that's the act's climax (scene-a1-climax). Use this scene to RECRUIT (all three join), to establish the triangle, and to let the party start spending — and feeling the cost of — their first virtue. Note the partial alignments: Korrin and Anwen both want to save the desperate (but split on method — Korrin will cut a hard deal Anwen finds cruel); Vael and Anwen both want order (but split on mercy — Vael will hang the guilty Anwen would spare).",
+      "checks": [
+        {
+          "skill": "Insight",
+          "dc": 13,
+          "success": "Talking to all three, you see the geometry of it clearly: these are three GOOD people whose definitions of good can't all be true at once. Vael's law would hang a man Korrin's mercy would free, and Anwen would spare the very enemy the law means to make an example of. There is no neutral ground — only which virtue you choose to spend. Naming this honestly to each of them earns a flicker of respect (and primes their trust gates): you, at least, see the trap they're in. (Best primer for keeping all three on side.)",
+          "failure": "You catch that the three don't get along but read it as ordinary faction rivalry, not a true collision of values — so you don't yet see that pleasing one will cost you another. You can still recruit all three, but the first time you make a real call on Brannick, the whiplash will surprise you."
+        },
+        {
+          "skill": "Persuasion",
+          "dc": 13,
+          "success": "You convince all three that an outsider with no faction's debt is exactly the honest broker Risen-Gate has lacked since the reeve died — and all three agree to follow you, each trusting you to honor THEIR value when the choices come. You leave with three companions, three secret advantages (the Fist's evidence, the Vine's secret ways, the almshouse's wounded witnesses), and three watching consciences. (Recruits the full trio; opens the investigation on all three threads.)",
+          "failure": "You win one or two of them readily but the third holds back, wary — recruit the holdout by proving your good faith on the next judgment-call rather than by argument. (The DM may let the party recruit all three across the act rather than all at once; the trio assembled by the climax is the goal.)"
+        }
+      ],
+      "encounter": null,
+      "transitions": "With the three knives recruited (and the triangle felt), the murder investigation and the fight over Brannick's fate come to a head — move to scene-a1-climax at loc-fist-post. The Fist's evidence, the Vine's secret ways, and the almshouse's witnesses all point at an inside job; the party's first defining orthogonal choice is how to handle the framed runner."
+    },
+    {
+      "id": "scene-a1-climax",
+      "name": "The Runner's Rope",
+      "type": "combat",
+      "location_id": "loc-fist-post",
+      "read_aloud": "It comes to a head at dusk in the toll-yard, around the gatehouse cell where Brannick sits chained and grey-faced. Half the Fist garrison has gathered with a rope and the certainty of frightened men — Corporal Dass at their head, arguing that a hanging tonight will quiet the town before the army comes. The Vine has gathered too, knives loose, ready to spring their runner or die trying. And in the almshouse doorway Sister Anwen stands with her arms folded, refusing to let it become a slaughter either way. Sergeant Vael plants herself between the rope and the cell, sword still sheathed, jaw set: 'No one hangs without a trial. Not while I hold this post.' Korrin slides up at your shoulder, all easy menace: 'Or we cut him loose right now and let the law catch up later — your call, friend.' The whole yard turns to look at YOU — the one with no faction's collar. Whatever you do next, two of these three are going to remember it.",
+      "dm_notes": "ACT 1 CLIMAX — the first defining orthogonal choice, dramatized as a powder-keg, and the act's combat IF it ignites. THE CHOICE on Brannick is the campaign's first three-way fork, and it MUST move the gauges in different directions — tag it with the right cause-keys: (a) BACK VAEL — insist on a lawful trial, hold the line against the lynching (+Vael: due_process/keeping_your_word/hold_the_law_under_pressure; -Korrin: rigid_law/process_over_a_dying_person, though Korrin grudgingly tolerates a trial over a hanging); (b) BACK KORRIN — spring Brannick from the cell (+Korrin: spring_the_framed_runner/cutting_a_deal/bend_the_law_to_save_a_life; -Vael: spring_a_thief_uncharged/break_the_law); (c) BACK DASS/THE LYNCHING — let or help the garrison hang him fast (-Vael HARD: summary_execution/lynch_a_suspect AND sets risk toward 'broke_your_oath'; -Korrin HARD: let_the_runner_hang/turned_in_the_thief — this is the worst option for the truce and the killer's preferred outcome; -Anwen: summary_execution/collateral_cruelty); (d) ANWEN'S THIRD WAY — get Brannick OUT of the rope's and the law's reach alive into the almshouse's sanctuary while the party investigates (+Anwen: sparing_an_enemy/shelter_the_desperate; partial +both others if framed as 'keep him alive to find the truth'). COMBAT may ignite: if the party (or events) tip toward the lynching or a Vine jailbreak-by-force, the yard erupts — Fist troopers (Guard/Thug) vs Vine runners (Bandit/Scout), with the party choosing a side or trying to stop both. Use this as the act's combat. The companions' reactions are the POINT: stage Vael, Korrin, and Anwen each visibly responding to the party's choice — bars moving in opposite directions on screen. Whatever happens, the murder's first proof (inside job, planted coins, the 'Tollwright' word) is secured and carried to the hub. If the party hangs Brannick, they bury his clue with him (a real cost — he knew the agent's gait); if they keep him alive (trial or sanctuary), his clue survives to Act 2. Set decision_flags HONESTLY: 'broke_your_oath' if the party betrays a promise to Vael or backs the lynching after siding with the law; 'turned_in_the_thief' if they let Brannick hang or hand him over; 'ordered_the_massacre' is not yet in play (saved for the siege's crueler choices). DO NOT fire any agenda this early — these flags ARM later turns; the gauges should only be nudged here.",
+      "checks": [
+        {
+          "skill": "Persuasion",
+          "dc": 14,
+          "success": "You take the yard's temperature and turn it — talking Dass's troopers down from the rope while promising the Vine their runner won't hang for nothing, buying the time to find the real killer. The lynching dissolves; the truce holds by a thread; and you've shown all three companions you can hold the center under pressure. (Best outcome for keeping the trio together: nobody dies, the clue survives in Brannick, and every gauge holds or rises.)",
+          "failure": "Your words aren't enough — the yard tips toward violence, and you'll have to choose a side with steel or watch the truce shatter into open fighting (roll initiative; see encounter). Whatever you choose, two of the three companions will remember which way you drew your blade."
+        },
+        {
+          "skill": "Intimidation",
+          "dc": 14,
+          "success": "You break the moment by force of will — facing down whichever mob is closest to the killing, Fist or Vine, until they back off the brink. It holds the peace, but it costs you: the side you cowed remembers being cowed, and the companion who led them marks how you used fear instead of fairness. (Holds the truce but spends a little trust; tag the cost to whichever pole you leaned on.)",
+          "failure": "The threat lands wrong and someone's nerve snaps — initiative; the yard goes to knives, and the party is in the middle of a riot that is exactly what the killer wanted."
+        }
+      ],
+      "encounter": {
+        "monsters": [
+          {
+            "name": "Guard",
+            "count": 3,
+            "reflavor": "Flaming Fist troopers in the lynch-mob — frightened, not evil; resolves to bundled 'Guard' (CR 1/8) or 'Thug' (Tough, CR 1/2) for a stronger fight. They break if Vael or the party stands them down, or once one of their own falls. Only fight if the yard ignites toward the lynching."
+          },
+          {
+            "name": "Scout",
+            "count": 3,
+            "reflavor": "Vine runners ready to spring Brannick by force — knife-fighters defending their own; resolves to bundled 'Scout' (CR 1/2) or 'Bandit' (CR 1/8). They fight only if a jailbreak-by-force is chosen or the yard erupts; Korrin can call them off."
+          }
+        ],
+        "tactics": "This combat is OPTIONAL — it ignites only if the party tips toward the lynching or a force-jailbreak, or fails to defuse the yard. If it happens, it's a RIOT, not a clean fight: Fist troopers vs Vine runners with the party caught in the middle, choosing whom to protect (each choice a gauge-mover). The companions act on their values — Vael interposes against the lynchers, Korrin moves to free Brannick, Anwen shields the wounded and the unarmed. The IDEAL resolution is stopping the violence entirely (Persuasion/Intimidation); award full XP for defusing the riot without a death. Keep it survivable for a level 3-4 party.",
+        "scaling": "Party of 1-2 or all-squishy: 2 Guards + 2 Scouts. Party of 3-4: 3 Guards + 3 Scouts. Party of 4+ or running hot: add a Veteran (a hard-line Fist officer) or a Thug to the side the party opposes. Defusing the riot (no combat) is always the best outcome and earns full value.",
+        "xp": 400,
+        "xp_note": "3x Guard (25) + 3x Scout (100) ~= 375; budget ~400 with the story-stakes of the riot. Award FULL value for DEFUSING the riot without bloodshed (the best outcome) exactly as for winning the fight — stopping the killing is the win, since a riot is what the killer wanted."
+      },
+      "transitions": "However Brannick's rope resolves, the party carries the murder's first proof (inside job, planted coins, the 'Tollwright' word) back to loc-gatehouse — and the first scored read of which virtue they've spent. They are now level 4-ish; Act 2's siege pressure (scene-a2-hook) opens. If Brannick lives, his clue survives; if he hanged, it's buried with him and 'turned_in_the_thief' may be set."
+    },
+    {
+      "id": "scene-a2-hook",
+      "name": "The Screw Turns From Outside",
+      "type": "social",
+      "location_id": "loc-gatehouse",
+      "read_aloud": "Maddox doesn't wait for you to solve his murder. In the night his outriders fire the last grain-stores and foul the north well, and at dawn his ransom-riders drag a dozen townsfolk — Fist, Vine, and almshouse-folk alike — out to the reaver-camp to be bought back at a price that would empty every coffer in Risen-Gate. By the time you reach the toll-yard the three factions are screaming at each other across the reeve's old bench: the Fist wants the remaining grain locked under guard and rationed by law; the Vine wants it OPENED to the starving now, rules be damned; and Sister Anwen stands between them with a list of the ransomed and the wounded, asking who, exactly, the town has decided it can afford to lose. Vael's hand is white on her sword-hilt. Korrin's smile is gone. And all three of them turn, again, to you — because the reeve who used to make these calls is a stain on the bench, and you're the one holding his balance now.",
+      "dm_notes": "ACT 2 HOOK and the engine's loudest move: the siege FORCES joint decisions that cannot satisfy all three companions, and the party — not the dead reeve — is now the balance-point. Maddox (npc-male-1, named but still off-screen) tightens from outside: burned grain, poisoned well, ransomed prisoners. The judgment-calls of Act 2 are RATION/RANSOM/RESCUE dilemmas, each orthogonal: (1) THE GRAIN — lock and ration it by law (+Vael: due_process/hold_the_law_under_pressure; -Korrin: rigid_law/enforce_the_toll_on_the_starving) vs open it to the desperate now (+Korrin: feed_the_desperate_first/bend_the_law_to_save_a_life; -Vael: bend_the_law/break_the_rule under siege); (2) THE RANSOM — pay it (drains the town but saves the prisoners; +Anwen if it saves lives), refuse it (hold the coin for defense; -Anwen: spend_lives_to_save_lives if prisoners are abandoned), or RAID the camp to free them (the Act 2 combat); (3) THE POISONED WELL / RETALIATION — a chance arises to poison the reaver-camp's OWN well in return (+Korrin/Vael as ruthless pragmatism, -Anwen HARD: poison_the_well/collateral_cruelty, arms 'ordered_the_massacre'). Stage each so the party SEES the gauges split. This is where the orthogonality does its real damage: a single ration-or-open call moves Vael and Korrin in opposite directions, and the retaliation calls put Anwen against both. Brother/Mother Sefin (Vine) and Corporal Dass (Fist) voice the factions' pressures. Seed the MIDPOINT here: the recovered intel and Brannick's clue (if he lives) start to converge on an INSIDE AGENT — someone moving between all three factions, the reeve's killer, still in the walls. Reveal it fully at scene-a2-challenge/climax. The companions' arc gates (trust 25, personal-quest 50) should be opening across Act 2 for the companions the party has honored; the betrayal gates (20) loom for any the party has wounded.",
+      "checks": [
+        {
+          "skill": "Insight",
+          "dc": 14,
+          "success": "Reading the three factions' panic, you see the trap Maddox built: every joint decision the siege forces is rigged so that helping one faction wounds another — the grain, the ransom, the wells, all of it. The reeve held this together by giving no virtue the whole say; you realize the ONLY way through is to keep doing the same impossible balancing he did, and that Maddox is counting on you to fail at it. (Names the campaign's core strategy: hold all three, or the gate falls from within.)",
+          "failure": "You see three factions in crisis and a hard set of calls to make, but not yet that the calls are RIGGED to divide them — so you make them as best you can, and only later feel how each one cost you a companion you didn't mean to wound."
+        },
+        {
+          "skill": "Investigation",
+          "dc": 13,
+          "success": "Cross-referencing the reeve's recovered ledger with the night's sabotage, you find the pattern he died noticing: the grain that burned, the well that fouled, the prisoners taken — all of it required INSIDE knowledge of the town's stores and watch-rotations. Someone within the walls is feeding Maddox, and has been for a year. The hunt for the inside agent begins. (Threads the midpoint reveal.)",
+          "failure": "The sabotage looks like ordinary reaver cruelty from outside — you don't yet see the inside hand guiding it. Mother Sefin's suspicion or Brannick's clue, drawn out later, will point you at the agent within."
+        }
+      ],
+      "encounter": null,
+      "transitions": "To break the ransom and chase the inside agent, the party strikes at the reaver-camp — move to scene-a2-challenge at loc-reaver-camp. The grain/ransom/retaliation calls made here are tagged to the three gauges and carried forward; honored companions open their trust/quest gates, wounded ones edge toward their breaking points."
+    },
+    {
+      "id": "scene-a2-challenge",
+      "name": "The Camp and the Agent",
+      "type": "exploration",
+      "location_id": "loc-reaver-camp",
+      "read_aloud": "Out past the wall, under a moonless sky, the Tollwright's camp sprawls along the Risen Road: cookfires and picket-lines, ransom-pens where Risen-Gate's taken folk huddle behind hurdles, and at the center a command-tent under a banner stitched with a toll-keeper's scales and a reaver's red hand. You came to free the prisoners and steal the enemy's plans — and as you move through the camp's edges, a reaver sentry you've cornered tells you something that turns the night cold: 'You think the Tollwright's clever? He's got a hand INSIDE your gate. Has done a year. Killed your reeve himself, that one — walks your streets in your own colors.' Behind you, your three companions go very still. Whatever you've made them feel about each other these past two days, every one of them is now wondering the same thing: which of the three factions is the killer wearing?",
+      "dm_notes": "ACT 2 CHALLENGE — the raid (EXPLORATION/COMBAT-adjacent) and the MIDPOINT REVERSAL. The party raids the reaver-camp: free the ransomed prisoners (a rescue and an approval surface — Anwen's value), steal Maddox's plans (the strength/weakness of his host: a mercenary band that will break if the wall holds and the toll looks too costly), and turn a reaver or two (Anwen's broker_a_surrender, or Korrin's cutting_a_deal). THE BIG REVEAL lands here: Maddox planted an INSIDE AGENT a year ago, bonded into one of the three factions — the hand that killed the reeve and keeps the wounds open. This is the midpoint reversal: the enemy isn't only outside, it's been at the party's back the whole time, and the truce can still be saved or shattered for good. Crucially, the reveal RAISES THE STAKES on the companion fork: now every faction suspects the others of harboring the killer, and the party's accumulated choices (which virtue they've spent) determine whether the three trust the party enough to hunt the agent TOGETHER or splinter into mutual accusation. Drawing out WHO the agent is should reward a party that engaged all three companions: the reeve's hidden coded page (recoverable only by someone who understands all three factions), Brannick's half-known clue (the agent's gait/ring, if he's alive), and Mother Sefin's year-long suspicion together name the agent — DM's choice of which faction the agent wears (a hard-liner in the Fist, a turncoat in the Vine, or a false penitent in the almshouse), staged to cut against whichever companion the party has leaned on least (so the reveal complicates rather than confirms). The siege's joint-decisions keep splitting the gauges throughout the raid (who to free first, whether to burn the camp's stores — collateral_cruelty risk for Anwen). Combat with reaver pickets may interrupt; let the reveal and the rescue breathe.",
+      "checks": [
+        {
+          "skill": "Stealth",
+          "dc": 14,
+          "success": "You move through the camp's pickets like smoke — reaching the ransom-pens to free the prisoners and the command-tent to lift Maddox's plans without raising the host. You learn the Tollwright's secret: his band came for a cheap toll, not a battle, and will break and ride off if the wall holds and the cost runs high. Holding the town TOGETHER is how you beat him. (The strategic key to Act 3, taken clean.)",
+          "failure": "A picket spots you and the camp stirs — you can still free the prisoners and grab the plans, but you'll fight your way out (reaver Bandits/Thugs/Scouts; see scaling) and Maddox now knows you raided him. The intel is the same; the exit is bloodier."
+        },
+        {
+          "skill": "Persuasion",
+          "dc": 14,
+          "success": "You turn a reaver — a tired sellsword who'd rather not die for a toll — and they confirm the inside agent in full: planted a year ago, bonded into one of your three factions, the hand that opened the strongbox and cut the reeve's throat. Combined with the reeve's hidden page or Brannick's clue, you can now name WHICH faction the killer wears. (Secures the inside-agent reveal and the lever to expose them in Act 3.)",
+          "failure": "The reaver won't talk, or talks too vaguely — you have the SHAPE of the inside agent (a year planted, the reeve's killer, in one of your factions) but not the name, until you work the reeve's hidden page, Brannick, or Mother Sefin's suspicion back at the hub. The hunt narrows but isn't done."
+        },
+        {
+          "skill": "Insight",
+          "dc": 13,
+          "success": "Watching your three companions absorb the news that the killer wears one of their colors, you read exactly where the trust stands: the ones you've honored look to YOU to find the truth; the one you've wounded looks at the other two with new suspicion. You see, plainly, which gauge has curdled and which agenda is arming — and you have one act left to pull them back or lose them. (A clear read of the fork's state going into Act 3.)",
+          "failure": "The companions take the reveal hard and you can't quite read who's closest to breaking — the fork's state stays murky until it resolves at the gate, and you may be surprised by which knife turns."
+        }
+      ],
+      "encounter": {
+        "monsters": [
+          {
+            "name": "Bandit",
+            "count": 4,
+            "reflavor": "Reaver pickets and ransom-guards — sellswords who came for a cheap toll; resolves to bundled 'Bandit' (CR 1/8) or 'Thug' (Tough, CR 1/2) for a harder camp. They break and surrender readily once the fight turns (Anwen's broker_a_surrender / Korrin's deal both work on them)."
+          },
+          {
+            "name": "Scout",
+            "count": 2,
+            "reflavor": "Maddox's outriders — the ones who burned the grain and fouled the well; resolves to bundled 'Scout' (CR 1/2). Hit-and-fade skirmishers guarding the camp's edges and the command-tent."
+          },
+          {
+            "name": "Berserker",
+            "count": 1,
+            "reflavor": "A reaver enforcer in the camp — used for a stronger party or to guard the ransom-pens; resolves to bundled 'Berserker' (CR 2). Drop for a light table."
+          }
+        ],
+        "tactics": "The raid rewards stealth (Stealth to avoid the fight, or to free prisoners before the alarm) but combat may ignite at the pickets or the pens. Reavers are sellswords, not fanatics — they surrender or flee once the fight turns or their pay looks unlikely (a major approval beat: Anwen wants them taken alive, Korrin wants them turned, Vael wants them tried). The ransomed prisoners are noncombatants to be freed and shielded. If the party chooses to BURN the camp's stores or POISON its well in retaliation, that's a collateral_cruelty beat that wounds Anwen hard and may arm 'ordered_the_massacre.' Keep the inside-agent reveal central — the fight is the cover for the intel, not the point.",
+        "scaling": "Party of 1-2 or all-squishy: 2 Bandits + 1 Scout, no Berserker. Party of 3-4: 4 Bandits + 2 Scouts + 1 Berserker. Party of 4+ or running hot: 5 Bandits + 2 Scouts + 2 Berserkers (or a Veteran reaver-captain). Stealth/Persuasion can skip or shrink the fight entirely; reward freeing the prisoners and lifting the plans however it's done.",
+        "xp": 900,
+        "xp_note": "4x Bandit (25) + 2x Scout (100) + Berserker (450) ~= 750-1000; budget ~900 toward the act. Award FULL value for freeing the ransomed prisoners and recovering Maddox's plans whether by stealth, parley, or blade — the rescue and the intel are the win, and turning/sparing reavers counts fully."
+      },
+      "transitions": "With the prisoners freed, Maddox's plans in hand, and the inside agent revealed (or nearly named), the party returns to close on the agent — move to scene-a2-climax at loc-reaver-camp/the gatehouse approach. The act's final judgment-call (how to handle the cornered agent) sets the gauges' final state going into the held gate."
+    },
+    {
+      "id": "scene-a2-climax",
+      "name": "Which Virtue You Spent",
+      "type": "combat",
+      "location_id": "loc-reaver-camp",
+      "read_aloud": "You corner the inside agent on the dark road back to the gate — Maddox's hand within the walls, the one who killed the reeve and kept all three factions bleeding at each other for two days. They don't run. They turn, calm, wearing the colors of one of your own factions, and they make the offer Maddox sent them to make: 'You've already done half my master's work, you know. You've spent these three like coin — I've watched you do it. So spend one more. Hand me to the faction that wants me hanged and call it justice. Cut me loose for what I know and call it a deal. Or kill me quiet and call it mercy on a town that can't afford a trial.' They smile, because they know the trap. 'Whatever you choose, one of your three is going to watch you do it. And the Tollwright will be at your gate by dawn.'",
+      "dm_notes": "ACT 2 CLIMAX — the second combat AND the final, sharpest orthogonal choice of the siege, which sets each gauge's state going into Act 3. The cornered INSIDE AGENT (the reeve's killer, wearing one faction's colors — DM's choice per scene-a2-challenge) forces a three-way judgment-call that is the mirror of Brannick's in Act 1, now with the stakes maxed: (a) TRY THE AGENT publicly by law (+Vael HARD: due_process/try_the_accused/evidence_over_certainty — this is Vael's whole quest; -Korrin if it's slow/rigid under siege; partial +Anwen if it spares a life); (b) CUT A DEAL — spare the agent for what they know, or turn them (+Korrin: cutting_a_deal/find_the_third_option; -Vael HARD: cut_a_lawless_deal/let_the_powerful_skip_the_rule — letting the reeve's MURDERER walk for information is the deepest cut to Vael, can set 'broke_your_oath'; partial +Anwen for sparing); (c) EXECUTE the agent on the road, quiet and certain (-Vael HARD: summary_execution — the thing she fears most, sets 'broke_your_oath'; -Anwen HARD: kill_a_prisoner/collateral_cruelty/execute_the_surrendered, sets 'ordered_the_massacre'; +Korrin only if framed as protecting the desperate, but Korrin dislikes summary_execution too); (d) HAND THE AGENT to a faction that wants them dead (similar to c, can set 'turned_in_the_thief' if done cynically). The POINT: by the end of this scene the party can SEE which of the three they've wounded most across the whole siege, and the matching decision_flag ('broke_your_oath' / 'turned_in_the_thief' / 'ordered_the_massacre') is set, ARMING that companion's attitude_below(20) agenda for the climax. COMBAT: the agent doesn't fight alone if the party moves on them — Maddox sent a covering squad (reaver Scouts/Bandits + the agent themselves, statted as a Spy or Assassin per party level). The agent is a Spy (AC 12, HP 27, CR 1) for a light table or an Assassin (AC 15, HP 78, CR 8) for a level 5-6 party — a mid-boss. THEY MAY ESCAPE to Maddox's side for the Act 3 finale if the party doesn't put them down cleanly (a fine setup — the agent at the gate in Act 3). CRITICAL: stage the companions watching. Whichever gauge is lowest after this scene is the knife that may turn at the gate. Do NOT fire the agenda yet — that's the climax; this scene sets the flag and the gauge. If the party has honored all three (no gauge below 20), no agenda arms and all three stand at the gate — the hardest, best outcome.",
+      "checks": [
+        {
+          "skill": "Investigation",
+          "dc": 15,
+          "success": "Before you decide the agent's fate, you wring the truth from them and the reeve's recovered page: the full plan (murder the truce, frame the Vine, let the town break itself), Maddox's timing, and the proof that clears Brannick for good. You can now expose the whole scheme in the open at the gate — the single best lever for pulling a wavering companion back AND for turning the town's fury outward at Maddox instead of inward at each other. (Secures the Act 3 exposure.)",
+          "failure": "The agent gives up fragments but keeps the worst back, or dies/flees before you can wring it out — you go into Act 3 knowing there WAS a plan but not able to prove it cleanly, leaning harder on the companions' testimony and the gate-stand to break Maddox."
+        },
+        {
+          "skill": "Insight",
+          "dc": 14,
+          "success": "You read the agent's offer for the trap it is — Maddox wants you to spend a third virtue here, to wound a third companion on the eve of the gate. Seeing it, you can choose the option that holds your three TOGETHER (try the agent with the others' consent, or expose them publicly) instead of the one that breaks a fourth thing. (The clearest path to keeping all three knives at your back for the climax.)",
+          "failure": "The offer rattles you and you can't quite see the manipulation under it — you make the call on the agent's fate half-blind to which companion it costs, and may arm a betrayal you didn't intend."
+        }
+      ],
+      "encounter": {
+        "monsters": [
+          {
+            "name": "Spy",
+            "count": 1,
+            "reflavor": "The INSIDE AGENT — Maddox's hand in the walls, the reeve's killer, wearing one faction's colors. Spy (AC 12, HP 27, CR 1) for a light table; upgrade to Assassin (AC 15, HP 78, CR 8) as a mid-boss for a level 5-6 party. May surrender (to be tried), flee to Maddox's side for Act 3, or die — per the party's choice."
+          },
+          {
+            "name": "Scout",
+            "count": 3,
+            "reflavor": "Maddox's covering squad sent to extract the agent — reaver outriders; resolves to bundled 'Scout' (CR 1/2). They cover the agent's escape if the fight turns; scale to 2 for a light party, 4 for a strong one."
+          }
+        ],
+        "boss": {
+          "name": "The Inside Agent",
+          "npc_id": "",
+          "stats": "Spy (AC 12, HP 27, CR 1) for a light table; Assassin (AC 15, HP 78, CR 8) as a mid-boss for a level 5-6 party. Wears one of the three factions' colors (DM's choice).",
+          "note": "The reeve's killer and Maddox's hand within. The act's final judgment-call is what to DO with them (try / deal / execute / hand over) — the choice that sets each companion's final gauge and arms a betrayal. They may surrender, flee to the gate for Act 3, or die. Wringing the full plan from them (Investigation) secures the Act 3 exposure."
+        },
+        "tactics": "If the party moves to seize or kill the agent, the covering Scouts engage to cover the agent's escape — the agent fights cunning and from cover (Spy/Assassin), aiming to flee to Maddox if losing. But the SCENE's real weight is the CHOICE, not the fight: the agent OFFERS the three-way trap (try/deal/execute/hand-over) before blades, and how the party answers sets the gauges and the decision_flag. Stage all three companions present and reacting. If the party tries the agent or exposes them, that's a clean win that holds the trio; if they execute or deal cynically, a gauge curdles and an agenda arms. Keep the agent escapable so they can reappear at the gate.",
+        "scaling": "Party of 1-2 or all-squishy: agent as Spy + 1 Scout. Party of 3-4: agent as Spy (or Assassin) + 3 Scouts. Party of 4+ or running hot: agent as Assassin + 4 Scouts + a Berserker. The choice matters more than the fight at every size; keep the agent able to flee to Act 3.",
+        "xp": 1500,
+        "xp_note": "Agent as Assassin (3900 at CR 8 — a deliberate spike for the inside-agent mid-boss; soften to Spy 200 for a light table) + 3x Scout (100); budget ~1500 toward the act (or ~500 if the agent is run as a Spy / talked down). Award FULL value for trying, turning, capturing, or putting down the agent and for wringing out the plan, however it's done."
+      },
+      "transitions": "With the inside agent handled (tried, dealt with, executed, or fled to Maddox), the party returns to loc-gatehouse to brace for the assault — move to scene-a3-hook. The gauges' final state is now set: whichever companion the party wounded most is armed to turn at the gate; honored companions stand ready to fight. The Tollwright will be at the wall by dawn."
+    },
+    {
+      "id": "scene-a3-hook",
+      "name": "The Tollwright at the Wall",
+      "type": "social",
+      "location_id": "loc-gatehouse",
+      "read_aloud": "Dawn comes the color of old iron, and so does Maddox Crale. The reaver-host stands in ranks on the Risen Road, banners dripping, and the Tollwright himself rides to within a stone's throw of the gate — a broad, scarred man with a toll-ledger chained at his belt and a smile like a closing account. 'Risen-Gate!' he calls, genial as a creditor. 'I've no quarrel with your walls. Open the gate, name me Tollwright, pay your toll like sensible folk — and you all live to grumble about it. Or hold out, and I'll take it over your corpses and charge your widows double.' He lets it land. 'You've spent two days at each other's throats. I know — I arranged it. So I'll make it easy: send me the one who's ready to be done with the rest, and the gate opens itself.' Behind you in the toll-yard, your three companions stand at the wall — Vael with her troopers, Korrin with the Vine, Anwen with the wounded — and one of them, the one you spent too cheap, will not quite meet your eyes.",
+      "dm_notes": "ACT 3 HOOK — the antagonist arrives, names his weapon out loud (the fracture he planted), and the companion fork reaches its crisis. Maddox (npc-male-1) offers terms and openly invites the betrayal: 'send me the one who's ready to be done with the rest.' This is RESOLVE and STAKES: the party must rally the three factions to HOLD the gate, but the fracture is at its worst, and whichever companion the party betrayed most (the lowest gauge, the set decision_flag) is at their breaking point with Maddox's offer aimed precisely at their wound. Stage the wounded companion's distance visibly ('will not quite meet your eyes'). This is the fork's LAST chance to pull them back: exposing the inside agent and clearing Brannick in the open (scene-a3-challenge) is the lever that can do it — proving the murder was Maddox's doing turns the town's fury outward and can reach a wavering companion. If the party honored all three (no gauge below 20), all three stand firm and the offer falls flat — the hardest, best position. Let the party PREPARE: rally the factions (each companion brings their faction's strength to the wall ONLY if their gauge holds — Vael's troopers, Korrin's grain and secret ways, Anwen's healing and brokered reaver-surrenders), recover last supplies, choose where the inside agent (if fled) will strike. Then they brace for the assault. The three companions' arc gates (loyalty 75) can lock here for the honored; the betrayal gates (20) loom for the wounded. NOTE: even a party that wounded one companion can still WIN the gate with the other two — the campaign does not require a perfect run, but the cost of the turned knife is real.",
+      "checks": [
+        {
+          "skill": "Persuasion",
+          "dc": 14,
+          "success": "You rally the wall — and, more importantly, you reach the companion you wounded. Naming honestly what you spent and why, and showing them the plan to expose Maddox's hand in the open, you give the wavering one a reason to stand that's better than the Tollwright's offer. The three factions take their places at the gate; if a gauge was low, this is the best chance to keep that knife from turning. (Rallies the defense and may pull a wavering companion back from the brink.)",
+          "failure": "You can rally the wall but not fully close the wound — the factions take their places, but the companion you spent too cheap stays distant, and whether they turn at the climax now rests on the exposure of the inside agent and the events at the gate, not your words here."
+        },
+        {
+          "skill": "Insight",
+          "dc": 14,
+          "success": "You read your three companions cold and know exactly where each stands: which two are solid, which one Maddox's offer has its hooks in, and what — the agent's exposure, a kept word, a spared life — might still reach them. You go into the assault knowing the shape of the knife at your back and how to keep it sheathed. (Clarifies the fork's state and the lever to pull before the climax.)",
+          "failure": "You can't quite tell which way the wounded companion will break — you go into the held gate uncertain whether the third knife stands with you or turns, and may learn the answer the hard way."
+        }
+      ],
+      "encounter": null,
+      "transitions": "Before the assault, the party moves to expose Maddox's inside agent and clear Brannick in the open — move to scene-a3-challenge. Whether they hold all three or one wavers, the held gate is where it all resolves."
+    },
+    {
+      "id": "scene-a3-challenge",
+      "name": "Unmasking the Hand Within",
+      "type": "exploration",
+      "location_id": "loc-reaver-camp",
+      "read_aloud": "With Maddox's host drawn up and the gate barred, you have one chance before the assault to do the thing that can save the town from itself: prove, in front of all three factions at once, that the reeve was murdered by the Tollwright's planted hand — not by the Vine, not by the Fist, not by any of them. You gather them in the torchlit toll-yard — Vael and her troopers, Korrin and the Vine, Anwen and the wounded, the freed prisoners, Pip with the reeve's key-ring, Brannick (if he lives) ready to name the gait he saw on the postern path. The evidence is on the bench: the reeve's coded page, the planted coins, the inside agent's confession or colors. The whole town leans in. If you can make them SEE it — that their two days of knives were Maddox's doing, not each other's — the fracture closes and the gate holds. If you can't, the wound the Tollwright opened stays open, and one of your three will walk through it.",
+      "dm_notes": "ACT 3 CHALLENGE — the EXPLORATION/SOCIAL set-up for the climax: expose Maddox's inside agent and clear Brannick in the OPEN, before all three factions, turning the town's fury outward at the Tollwright instead of inward at each other. This is the campaign's thesis-beat: the murder was engineered to break the truce, and PROVING it is what re-fuses the three. Threads: (1) TABLE THE EVIDENCE — the reeve's coded page (recoverable by a party that engaged all three factions), the planted coins, Pip's key-ring, Brannick's eyewitness gait-clue (if he lives — a real cost if he hanged in Act 1), the inside agent's confession/colors (if captured) — assembled into an undeniable public case (Investigation/Persuasion before the assembled factions); (2) CLEAR BRANNICK — trying the real killer in the open clears the framed runner and proves Vael's whole quest right (a huge loyalty beat for Vael; if Brannick hanged, this is a grief-beat instead — the clue died with him); (3) THE LAST LEVER ON THE FORK — a successful, public exposure is the single best chance to pull a WAVERING companion back: it shows the wounded one that the real enemy was always Maddox, that their two days of pain were manufactured, and gives them a reason to stand. Stage the wounded companion deciding in real time. If the exposure LANDS and the wounded gauge isn't too far gone, the agenda may be defused (the companion stands at the gate after all); if it FAILS or the gauge is too low, the agenda is confirmed and that knife turns at the climax. The inside agent, if they fled in Act 2, may try to SABOTAGE the exposure here (a chase/skill-challenge to stop them disrupting the assembly). The honored companions each contribute (Vael lends the law's weight to the trial, Korrin the Vine's testimony, Anwen the wounded witnesses) — IF their gauge holds. This scene is the hinge between the set-up and the final stand.",
+      "checks": [
+        {
+          "skill": "Persuasion",
+          "dc": 16,
+          "success": "You lay the whole plot bare before the assembled town — the murdered truce, the framed runner, the planted hand, the two days of manufactured knives — and you make them SEE it. The fury that was turning inward turns outward at the gate, at Maddox, where it belongs. Brannick is cleared; the inside agent is named; and the companion you wounded, watching the truth land, finds a reason to stand with you after all that's stronger than the Tollwright's offer. (The best outcome: the fracture closes, the fork is defused, all three knives face the enemy.)",
+          "failure": "The case doesn't quite land — Maddox's seeds of doubt are deep, or the evidence is thin (a clue died with Brannick, or the agent fled before confessing) — and the town stays half-convinced its enemy is across the yard, not across the wall. The wounded companion's wound stays open into the climax, and whether they turn now rests on the gate itself."
+        },
+        {
+          "skill": "Investigation",
+          "dc": 15,
+          "success": "You assemble the evidence into a chain no one can break: the reeve's coded page decoded, the coins traced to the agent's hand, the timeline that exonerates Brannick and damns the planted killer. Laid out cold, it's undeniable — the factions cannot pretend the murder was each other's doing. (Makes the public exposure land; the surest way to re-fuse the three and defuse the fork.)",
+          "failure": "Gaps remain — a missing page, a dead witness, a fled agent — and Ferreth's... Maddox's people cry frame-up; the case persuades some and not others. Lean on the companions' testimony (Persuasion) and the gate-stand to finish what the evidence couldn't."
+        }
+      ],
+      "encounter": null,
+      "transitions": "However the exposure lands, Maddox's host advances and the assault begins — move to scene-a3-climax at the held gate. If the exposure succeeded and the wounded gauge recovered, all three stand; if it failed or the gauge is too low, the betrayal agenda is confirmed and that knife turns at the gate."
+    },
+    {
+      "id": "scene-a3-climax",
+      "name": "Three Knives at the Gate",
+      "type": "combat",
+      "location_id": "loc-reaver-camp",
+      "read_aloud": "The horns sound and the Tollwright's host comes on — ladders against the wall, riders at the barred gate, the red hand and the toll-scales surging up the Risen Road. You take your place on the gatehouse, and so do your three: Vael with her troopers, Korrin with the Vine and the smuggled grain, Anwen with the wounded and the brokered prisoners — three knives at your back, drawn at last not against each other but against the wall-breakers. And then, in the thick of it, the one you spent too cheaply turns to look at you — and whether their blade comes up beside yours or against it depends entirely on which value you betrayed across these two long days. Maddox Crale rides into the gate's shadow, genial to the last. 'Last toll, friends,' he calls over the din. 'Open the gate — or let me show you what a town at its own throat is worth.'",
+      "dm_notes": "THE CLIMAX — the final combat at the held gate, where the THREE-COMPANION FORK pays out and the campaign resolves. THE CORE MECHANIC: whichever companion the party betrayed most across the siege (the lowest gauge, the SET decision_flag) reaches their breaking point and their attitude_below(20) agenda FIRES — but each turns DIFFERENTLY, per their value and decision_flag: (a) VAEL ('broke_your_oath') — does not join Maddox for gold; she WITHDRAWS the Fist from a defense she's decided is no longer lawful (her troopers stand down or leave the wall), or turns to stop the party if they've become the lawlessness she swore against — 'I swore an oath to the law, not to you, and you made me choose.' (b) KORRIN ('turned_in_the_thief') — pulls the Vine and the smuggled grain and the secret ways OUT at the worst moment, or cuts a private deal with Maddox to evacuate the desperate while the party holds a hollow wall — 'You should have saved the people in front of you instead of the principle behind them.' (c) ANWEN ('ordered_the_massacre') — withdraws her mercy and sanctuary, opens the almshouse to the enemy wounded the party abandoned, and stands unarmed between the party and the people they mean to slaughter — 'I swore to count every cost, and you made the cost too high.' IMPORTANT: only the MOST-betrayed companion (lowest gauge below 20 with its flag set) turns; the OTHER TWO stand with the party. If NO gauge is below 20 (the party honored all three — the hardest, best run), ALL THREE stand and Maddox's whole strategy collapses, because the fracture was his only real weapon. THE FIGHT: Maddox = Knight (AC 18, HP 52, CR 3) scaled up (Veteran/Gladiator, or Bandit Captain + Knight for a strong table) on horseback at the gate, with his host (Bandits/Thugs/Scouts + Berserker[s]) and the inside agent (if they fled/survived, as Spy/Assassin). TWO WIN CONDITIONS, and the second is the real one: (1) break/drive off Maddox's host, and (2) HOLD THE GATE WHOLE — keep the town from opening from within, which means keeping at least two of the three companions (and their factions' strength) at the wall. Run a soft CLOCK: each round the town's unity frays (a turned companion, a faltering faction), the gate edges toward being opened from inside; the party must shore up the wall AND the alliance. Maddox is a sellsword-lord, not a fanatic: if the wall HOLDS and his host's losses mount, he breaks off and rides away to set a toll elsewhere (a fine dangling thread — a Tollwright loose on the roads), because his band only ever came for a cheap toll. THE REAL BOSS is the FRACTURE, not Maddox's HP: a party that kept the three together wins even if Maddox escapes, because a whole town is a gate that doesn't open from within. COMPANION CULMINATIONS (loyalty path): an honored Vael tries the inside agent in the open instead of lynching him and keeps the defense lawful; an honored Korrin's Vine flanks the reaver-camp through the secret ways and feeds the wall; an honored Anwen brokers reaver-surrenders and keeps the victory from becoming a massacre. Give each their climactic beat. If a companion turned, the other two get a line acknowledging the cost. The win is holding Risen-Gate AND holding the three — or as many as the party didn't spend.",
+      "checks": [
+        {
+          "skill": "Persuasion",
+          "dc": 17,
+          "success": "At the height of the assault you turn Maddox's own weapon against him — calling out, so the whole wall hears, that the Tollwright's only real army was the lie that set the town against itself, and that the lie is DEAD now, exposed, and the gate is one town again. The wavering hold; the reavers, who came for a cheap toll and not a real fight, see a wall that won't break and a unity that won't crack. (Re-fuses any last fracture and breaks the host's nerve — the cleanest win, holding the three AND the gate.)",
+          "failure": "Maddox laughs it off — 'pretty words don't lower a drawbridge' — and the assault grinds on; win the gate the other way: hold the wall by force, keep the factions at their posts, and break the host's will by making the toll cost more than it's worth."
+        },
+        {
+          "skill": "Intimidation",
+          "dc": 15,
+          "success": "You break the reaver-host's nerve from the wall — showing the sellswords that this gate fights back, that the easy toll they were promised is a slaughter now, that Maddox lied to them about a town ready to fall. Reavers at the edges break and ride off; the host's momentum cracks. (A win-condition: make the toll too expensive and the mercenary band routs, even if Maddox himself escapes.)",
+          "failure": "The reavers hold under Maddox's eye, and you'll have to hold the wall the hard way — by the blade and by keeping your three companions at their posts — until the host breaks or the gate does."
+        },
+        {
+          "skill": "Athletics",
+          "dc": 15,
+          "success": "You hold the breach — bracing the gate, throwing back the ladder-parties, standing in the gap where the wall is thinnest — and buy the town the minutes it needs for the factions to rally and the host to break. (The martial win-condition: physically hold the gate WHOLE so it can't be opened from within or broken from without.)",
+          "failure": "The breach is hard-pressed and you give ground — the gate strains toward opening; lean on your companions' factions (an honored Vael's troopers, Korrin's flank, Anwen's rallied wounded) and the other win-conditions to hold what you can."
+        }
+      ],
+      "encounter": {
+        "monsters": [
+          {
+            "name": "Bandit",
+            "count": 4,
+            "reflavor": "Reaver assault-troops at the wall and gate — sellswords who came for a cheap toll; resolves to bundled 'Bandit' (CR 1/8) or 'Thug' (Tough, CR 1/2) for a harder fight. The most breakable enemies — they rout if the wall holds and the toll looks too costly (Intimidation / a held breach)."
+          },
+          {
+            "name": "Scout",
+            "count": 2,
+            "reflavor": "Maddox's outriders harrying the wall and the postern — hit-and-fade skirmishers; resolves to bundled 'Scout' (CR 1/2). Used to threaten a flank or the gate from inside if a companion turned and opened a way."
+          },
+          {
+            "name": "Berserker",
+            "count": 2,
+            "reflavor": "Reaver shock-troops leading the ladder-assault; resolves to bundled 'Berserker' (CR 2). The host's muscle; drop to 1 for a light party, hold 2-3 for a strong one."
+          }
+        ],
+        "boss": {
+          "name": "Maddox Crale, the Tollwright",
+          "npc_id": "antagonist",
+          "stats": "Knight (AC 18, HP 52, CR 3) scaled up for a level 6-7 party; Veteran (CR 3) or Gladiator (CR 5) at a harder table, or Bandit Captain + Knight for a two-body boss. On horseback at the gate, surrounded by his host.",
+          "note": "The reaver-lord. He offers terms before blades and fights from the gate's shadow; if the wall HOLDS and his host's losses mount, he breaks off and rides away to set a toll elsewhere rather than die (a fine dangling thread). Breaking his HOST's nerve and holding the gate whole is the win, not his corpse."
+        },
+        "support_boss": {
+          "name": "The Inside Agent",
+          "npc_id": "",
+          "stats": "Spy (AC 12, HP 27, CR 1) or Assassin (AC 15, HP 78, CR 8) per Act 2 — present only if they fled/survived scene-a2-climax.",
+          "note": "If the agent escaped Act 2, they're at the gate — trying to open it from within, or fighting at Maddox's side. Exposing them in scene-a3-challenge weakens them here; an unexposed agent may nearly open the gate (the soft clock's worst outcome). A turned companion may aid them — the fracture made flesh."
+        },
+        "tactics": "Maddox offers terms first; the fork resolves as the assault begins. If a companion turned (lowest gauge below 20, flag set), run their turn HERE per their decision_flag — Vael withdraws the Fist, Korrin pulls the Vine and grain, Anwen withdraws sanctuary and stands between the party and a slaughter — a real engine event, heartbreaking, not cartoonish. The OTHER TWO companions fight at full value (an honored companion's faction-strength is decisive: Vael's troopers hold the wall, Korrin's Vine flanks the camp through the secret ways, Anwen's healing and brokered surrenders keep the breach human). The reavers are sellswords who ROUT if the toll looks too costly (Intimidation / a held breach / a broken Maddox). The THREE WIN-CONDITIONS — re-fuse the town (Persuasion), break the host's nerve (Intimidation), or hold the gate whole by force (Athletics/combat) — let social, martial, and skill-focused parties each win. The real boss is the FRACTURE: holding the gate WHOLE (not opening from within) and keeping at least two knives at your back is the victory even if Maddox rides off. Run the soft unity-clock: a turned companion or a faltering faction edges the gate toward opening; shore up wall AND alliance.",
+        "scaling": "Party of 1-2 or all-squishy: Maddox (Knight) + 2 Bandits + 1 Berserker; unity-clock ~6 rounds. Party of 3-4: Maddox (Knight/Veteran) + 4 Bandits + 2 Scouts + 2 Berserkers + the agent (if survived); unity-clock ~5 rounds. Party of 4+ or running hot: Maddox (Gladiator, or Bandit Captain + Knight) + 5 Bandits + 2 Scouts + 3 Berserkers + the agent (Assassin); unity-clock ~4 rounds. Always keep ALL win-conditions live and the fork central — the finale is about holding the three and the gate, not the body count.",
+        "xp": 4500,
+        "xp_note": "Maddox (Knight 700, or Gladiator 1800) + agent (Assassin 3900 or Spy 200, if present) + 4x Bandit (25) + 2x Scout (100) + 2x Berserker (450) ~= 2800-7700; budget ~4500 for the climax. Award FULL value for HOLDING THE GATE WHOLE and keeping the town together — driving off Maddox's host and keeping the three (or the two you didn't spend) at the wall — even if Maddox himself escapes. Holding Risen-Gate as one town, not slaying a sellsword-lord, is the victory."
+      },
+      "transitions": "When the gate holds whole, the host breaks and Maddox is beaten or ridden off, and the inside agent is put down or taken — Risen-Gate stands as one town, and the truce the reeve died for outlives him. Return to loc-gatehouse for the conclusion. If a companion turned, the party holds the gate a knife short, and carries that cost into the dawn."
+    }
+  ],
+  "rewards": {
+    "xp": 8000,
+    "xp_breakdown": {
+      "act1-the-runners-rope": 400,
+      "act2-camp-and-agent": 2400,
+      "act3-held-gate": 4500,
+      "social-exploration-bonuses": 700,
+      "note": "~8000 XP across three acts plus social/exploration story bonuses, tuned for a party starting around level 3 and finishing near level 7 (Baldur's Gate's mature post-Absolute tier). Many DMs will prefer MILESTONE leveling: level 4 after the Runner's Rope (Act 1), level 5-6 across the reaver-camp and the inside-agent (Act 2), level 7 before or during the held gate (Act 3). Award full encounter XP for diplomatic and stealth resolutions — defusing the riot, turning reavers, re-fusing the town, or holding the gate by parley counts fully as overcoming the finale. NOTE: the campaign's hardest 'win' is holding all THREE companions together — a feat of balance, not of XP — and the loss state is a gate opened from within because the party spent one virtue too cheaply."
+    },
+    "currency": {
+      "gp": 300,
+      "note": "Risen-Gate is a poor border town bled by siege; the early reward is civic, not monetary. The real coin comes from the reaver-camp's loot (the ransom-chest the Tollwright meant to fill, ~150 gp recovered in Act 2) and a grateful (and surviving) town settling ~150 gp and the freedom of the road on the party after the gate holds (Act 3). The factions have little to give but their gratitude, their grain, and their secret ways."
+    },
+    "loot": [
+      {
+        "item": "Potion of Healing",
+        "rarity": "common",
+        "count": "2-4 across the campaign",
+        "note": "From the almshouse's stores (Anwen, if honored) and the reaver-camp's supplies. 2d4+2 HP each."
+      },
+      {
+        "item": "The Reeve's Coded Ledger-Page",
+        "value": "the campaign's true prize",
+        "note": "Reeve Hessom's hidden record naming the inside agent's pattern across all three factions — the evidence that exposes Maddox's plot in the open at the gate and re-fuses the town. Recoverable by a party that engaged ALL THREE companions (it takes all three factions' knowledge to read). A story-reward and the Act 3 exposure-lever, not a saleable item."
+      },
+      {
+        "item": "The Vine's Map of the Secret Ways",
+        "value": "0 gp (story item)",
+        "note": "Korrin's (and Mother Sefin's) map of the smuggled routes through and under Risen-Gate's wall — worth an army in a siege: a flank on the reaver-camp, a way to feed the walls, an escape for the vulnerable. A keepsake of Korrin's loyalty (granted on the loyalty path); pulled away if Korrin turns."
+      },
+      {
+        "item": "The Pale Sister's Writ of Sanctuary",
+        "rarity": "uncommon (story/social)",
+        "note": "Anwen's almshouse writ, recognized by all three factions and even by honorable reavers — lets the bearer claim sanctuary for the wounded and broker a surrender. A social key (granted on Anwen's loyalty path); withdrawn if she turns."
+      },
+      {
+        "item": "Vael's Sealed Writ of the Law",
+        "value": "evidence / authority",
+        "note": "Sergeant Vael's Fist commission and the reeve's seal of office, which let the bearer convene a lawful trial recognized by the town — the instrument that clears Brannick and tries the real killer in the open. Granted on Vael's loyalty path; the law's weight withdrawn if she turns."
+      },
+      {
+        "item": "The Tollwright's Ledger",
+        "value": "evidence / leverage",
+        "note": "Maddox Crale's own toll-ledger, recovered if he's beaten or driven off — proof of the dozen towns he's broken this same way, and a warning of where he'll set his next toll. Evidence, a future hook, and a grim trophy of the road."
+      }
+    ],
+    "story_rewards": [
+      "If all THREE companions were held together (no gauge spent below its breaking point), the party achieves the campaign's hardest victory: a town that held as ONE against the wall-breaker, three incompatible virtues balanced rather than spent — and Vael, Korrin, and Anwen, who could not agree on anything, agree at last that the party was the honest broker Risen-Gate needed. The truce the reeve died for outlives him, held by hands that learned to keep three knives sheathed at once.",
+      "If Vael was honored to the loyalty gate, she tries the inside agent in the open instead of lynching him, proves the law can hold a wall without becoming the mob, and stays on as the incorruptible captain of a Risen-Gate worth holding. If she was curdled and withdrew the Fist, the party held the gate without the law's weight — and carries the knowledge that they spent her oath like coin and she let them.",
+      "If Korrin was honored to the loyalty gate, the Vine's grain feeds the walls and its secret ways flank the reaver-camp, and Korrin finds the soft center survived after all, standing the line beside Vael of all people. If Korrin was curdled and pulled the Vine, the party held a hollower wall — and learned that a town which spends its poor to keep its rules is a town its people will leave.",
+      "If Anwen was honored to the loyalty gate, the almshouse keeps the victory human — brokered reaver-surrenders, prisoners turned to witnesses, a gate held without a massacre — and Anwen proves the town could be saved without spending the people it decided didn't count. If she was curdled and withdrew her mercy, the party won a crueler victory, with their healer and their conscience standing between them and the slaughter they'd ordered.",
+      "If Maddox was driven off rather than slain, the Tollwright is loose on the Risen Road with his ledger and his method intact — a sellsword-lord who'll set a new toll and break a new truce elsewhere, a deliberate dangling thread and a darker mirror: the fracture was always the weapon, and somewhere ahead is another town with three good people who can't all be right at once.",
+      "Holding the GATE WHOLE rather than merely killing the man means the question the siege asked — whether law, survival, and mercy can ever all be satisfied at once, and what a town becomes when it has to choose among them under the knife — lingers over Risen-Gate's rebuilding. The reeve's balance, kept or broken, is the campaign's true measure, not the body count at the wall."
+    ]
+  },
+  "conclusion": "Dawn finds Risen-Gate still standing — or standing wounded, depending on what the party spent to hold it. The reaver-host is gone from the Risen Road, broken on a wall that fought back or bought off by a toll the town refused to pay with its own people; Maddox Crale is dead in the gate's shadow or riding north with his ledger to find an easier truce to break. The strongbox is refilled, the reeve is buried with his murderer named beside the open grave, and Brannick the runner walks free with the truth on the record. How the town remembers it is up to the party: as the day three knives that could never agree stood together at the gate and held it as one — or as the day the party learned, the hard way, that you cannot spend law to buy survival, or survival to buy mercy, without one of the three turning in your hand. Either way the truce the old reeve died for has outlived him, fragile and real, held now by a town that knows exactly how easily it breaks. Vael keeps the law; Korrin keeps the people fed; Anwen keeps them alive; and the gate, this winter, opens only to those who pay an honest toll — and to no Tollwright at all. (Hook for a future return: a sellsword-lord loose on the roads with a proven method, a hard-won truce that has to prove it can hold without the party there to balance it, and three companions who will remember which virtue they were, the night the choices came.)",
+  "dm_quickref": {
+    "definition_of_done_mapping": {
+      "exploration": "scene-a1-recruit (work all three faction sites to recruit the trio and gather the murder evidence), scene-a2-challenge (raid the reaver-camp, free prisoners, lift Maddox's plans, surface the inside agent), and scene-a3-challenge (assemble and table the public exposure that re-fuses the town).",
+      "social": "scene-a1-hook (Pip + the engineered murder), scene-a1-recruit (recruit the three competing-agenda companions and establish their ORTHOGONAL vocabularies), scene-a1-climax (the Runner's Rope — the first three-way orthogonal choice), scene-a2-hook (the siege's joint-decisions split the gauges), scene-a2-climax (the inside agent's three-way trap sets the final gauges + decision_flags), scene-a3-hook (Maddox's offer + the fork's crisis), scene-a3-challenge (the public exposure as the last lever on the fork), and the climax's re-fuse-the-town Persuasion (DC 17).",
+      "combat_act1": "scene-a1-climax — OPTIONAL riot: 3x Guard (Fist) + 3x Scout (Vine), best resolved by defusing it (no deaths).",
+      "combat_act2": "scene-a2-challenge (reaver-camp: Bandits + Scouts + Berserker, with a free-the-prisoners objective) and scene-a2-climax (the inside agent as Spy/Assassin mid-boss + Scouts, with the three-way choice that arms a betrayal).",
+      "combat_act3": "scene-a3-climax — Maddox (Knight/Veteran/Gladiator) + the inside agent (Spy/Assassin, if survived) + Bandits/Scouts/Berserkers, with the UNITY-CLOCK objective, the THREE-COMPANION FORK paying out, and three win-conditions (re-fuse the town / break the host / hold the gate whole)."
+    },
+    "bundled_assets_used": {
+      "monsters_act1": [
+        "Guard (x3, scene-a1-climax Fist lynch-mob — or Thug/Tough for a harder fight)",
+        "Scout (x3, scene-a1-climax Vine runners — or Bandit)"
+      ],
+      "monsters_act2": [
+        "Bandit -> Thug/Tough (x4, scene-a2-challenge reaver pickets/ransom-guards)",
+        "Scout (x2-3, Maddox's outriders)",
+        "Berserker (x1, reaver enforcer — scale to party)",
+        "Spy OR Assassin (the inside agent, scene-a2-climax mid-boss — scale to party)"
+      ],
+      "monsters_act3": [
+        "Knight (Maddox, the Tollwright — final boss; Veteran/Gladiator or Bandit Captain + Knight for a strong table)",
+        "Spy OR Assassin (the inside agent, if survived Act 2)",
+        "Bandit -> Thug/Tough (x4, reaver assault-troops)",
+        "Scout (x2, outriders/flankers)",
+        "Berserker (x2, reaver shock-troops)"
+      ],
+      "monsters_optional": [
+        "Commoner (Pip, Brannick, Reeve Hessom, freed prisoners, refugees — noncombatants)",
+        "Veteran (Corporal Dass if forced to fight; a hard-line Fist officer)",
+        "Spy (Mother Sefin if the Vine quarter is attacked — defends, prefers to smuggle the vulnerable out)"
+      ],
+      "spells_in_play": [
+        "Sister Anwen (companion Cleric): Cure Wounds, Healing Word, Bless, Sanctuary, Spiritual Weapon, Lesser Restoration — keeps the anvil standing and the defense human",
+        "Sergeant Vael (companion Fighter): Second Wind, Action Surge (Act 2), martial maneuvers (Act 3) — the wall's anvil",
+        "Korrin (companion Rogue): Sneak Attack, Cunning Action, Uncanny Dodge (Act 2) — the skirmisher/face for the deals and the secret ways",
+        "party casters across the toll-yard, the reaver-camp, and the held gate"
+      ],
+      "conditions_in_play": [
+        "Prone / difficult terrain (the crowded toll-yard riot, the reaver-camp's picket-lines, the breach at the held gate)",
+        "Frightened (the siege pressure; reavers routing under Intimidation)",
+        "Grappled/Restrained (the ransom-pens and the wall-breach scrums)",
+        "Charmed/Surrendered (turned reavers, brokered surrenders — Anwen's and Korrin's social levers)"
+      ]
+    },
+    "the_three_knives_note": "The real engine of this campaign is THREE COMPANIONS WITH ORTHOGONAL APPROVAL VOCABULARIES, so a single tagged decision moves their gauges in OPPOSITE directions. VAEL is law-first (likes keeping_your_word/due_process, dislikes summary_execution); KORRIN is survival-first (likes cutting_a_deal/sparing_a_desperate_thief, dislikes rigid_law_that_gets_people_killed); ANWEN is mercy-first (likes sparing_an_enemy/tending_the_wounded, dislikes collateral_cruelty). On the central choices — Brannick's rope (Act 1), the grain/ransom/retaliation calls (Act 2), the inside agent's fate (Act 2) — pleasing one curdles another: a lawful trial pleases Vael and stings Korrin; springing the runner pleases Korrin and stings Vael; sparing an enemy pleases Anwen and reads as lawlessness to Vael and naivety to Korrin. TAG every central choice with the right cause-keys via record_decision/the approval system so the player SEES the gauges split. The campaign's hardest victory is holding all THREE — a feat of balance the dead reeve managed and Maddox is betting the party can't.",
+    "the_companion_fork_note": "Each of the three companions carries a 4-gate arc (trust 25, personal_quest 50, BETRAYAL 20, loyalty 75) and an attitude_below(20) CompanionAgenda with a DISTINCT decision_flag: Vael's 'broke_your_oath' (broken word / summary execution / law spent like coin), Korrin's 'turned_in_the_thief' (rigid law that got people killed / the runner left to hang / a desperate thief turned in), Anwen's 'ordered_the_massacre' (a massacre ordered / prisoners killed / wounded abandoned / the well poisoned). At the climax, ONLY the most-betrayed companion (lowest gauge below 20 with its flag set) turns, and each turns DIFFERENTLY per their value — Vael withdraws the Fist, Korrin pulls the Vine and grain, Anwen withdraws her sanctuary and stands between the party and a slaughter. The other two stand with the party. Honored, all three stay and Maddox's whole strategy (the fracture) collapses — the best, hardest run. Set the flags HONESTLY via record_decision/set_flag at the central choices (scene-a1-climax, scene-a2-hook, scene-a2-climax): 'broke_your_oath' when the party breaks faith with the law, 'turned_in_the_thief' when they spend the desperate to keep a rule, 'ordered_the_massacre' when they choose collateral cruelty. Those flags ARM the turns; the engine rolls them, the content names the cause.",
+    "pacing": "Designed as a ~4-session arc (one act per ~80-min session, or a long single sitting). Act 1 ~ levels 3-4 (the murder, recruiting the three knives, the Runner's Rope). Act 2 ~ levels 4-6 (the siege's joint-decisions, the reaver-camp raid, the inside agent, the gauges' final state). Act 3 ~ levels 6-7 (the Tollwright's terms, the public exposure, the held gate where the fork pays out). Use the per-scene scaling notes to tune each fight to party size, and prefer milestone leveling (4 / 5-6 / 7) for clean act breaks. The campaign's distinctive pressure is the THREE-WAY orthogonal choice — surface the gauges splitting on every central decision so the player feels the cost of each spent virtue.",
+    "originality_note": "This campaign is original prose written for WorldOS, set in the bundled 'baldurs-gate' world seed (post-BG3, 1492 DR) and released as FAN CONTENT under the same terms as content/worlds/baldurs-gate/world.json (Wizards Fan Content Policy + Larian for BG3 elements; SRD 5.2 / CC-BY-4.0 rules). It uses only SRD 5.2 mechanics and the bundled creature stat blocks (Guard, Scout, Bandit, Thug/Tough, Berserker, Spy, Assassin, Knight, Veteran, Gladiator, Bandit Captain, Commoner). No published or copyrighted adventure text is reproduced. Risen-Gate, the Risen Road, the three-way truce, Reeve Hessom, the Tollwright Maddox Crale and his inside agent, Sergeant Maelin Vael, Korrin 'the Fence' Vane, Sister Anwen, Pip, Brannick, Corporal Dass, and Mother Sefin are ALL ORIGINAL creations — and crucially, the three companions are NON-ORIGIN, ORIGINAL characters, never the seven banned BG3 origin heroes. They are staged against canon BG geography and factions (the Lower City, the Flaming Fist, a smugglers' web in the Vine, a Pale Sister's almshouse, the patriars' tolls) in our own words. The campaign's signature is its THREE COMPETING-AGENDA companions whose orthogonal approval vocabularies turn one choice into three opposite consequences."
+  }
+}

--- a/content/campaigns/three-knives/adventure.md
+++ b/content/campaigns/three-knives/adventure.md
@@ -1,0 +1,266 @@
+# Three Knives at the Ledger-Gate
+
+*A WorldOS Baldur's Gate campaign — SRD 5.2, levels 3 → 7, ~4 sessions.*
+*Set in the bundled `baldurs-gate` world seed (post-BG3, 1492 DR — the winter after the Absolute fell).*
+*Original fan-content prose on SRD primitives. Released under the same terms as the baldurs-gate world seed (Wizards Fan Content Policy + Larian for BG3 elements; SRD 5.2 / CC-BY-4.0 rules). NOT official, never sold.*
+
+---
+
+## The Pitch
+
+**Risen-Gate** is a contested border town on the Risen Road — the last walled crossing before the
+Lower City of Baldur's Gate — and the war left it with no one to rule it. Three powers hold it by the
+throat at once: a remnant of the **Flaming Fist** who keep the law by the letter, the smugglers' **Vine**
+who keep the desperate fed by breaking that law, and the **Pale Sister's almshouse** who keep the dying
+alive and ask no questions of either. They've shared the gate-tolls in an uneasy three-way truce for a
+year. Now a road-reaver warlord, **Maddox Crale, the Tollwright**, has set a noose around the town and
+means to own the gate and everyone who passes through it.
+
+The genius of his siege is that he doesn't intend to break the wall — he intends to make the town break
+*itself*. Before his army arrives he murders the one man holding the truce together, frames the Vine,
+seeds each faction's worst suspicion of the others, and lets **law, survival, and mercy** do his
+siege-work for him. A garrison at its own throat is a gate that opens from within.
+
+The party arrives as outsiders who owe no faction — which is exactly why the dead reeve's terrified clerk
+runs to *them*. And to hold Risen-Gate, the party will have to lead three people who hate each other's
+methods, and answer the judgment-calls a siege forces, knowing that **every choice that satisfies one of
+the three curdles another.**
+
+## The Antagonist
+
+**Maddox Crale, "the Tollwright."** Not a hidden villain — every faction names him as the army on the
+road from the first scene. He's a patient, almost genial siege-craftsman who learned over a long career
+that *walls are strong and the agreements behind them are not.* He murdered the reeve, framed the runner,
+and planted an **inside agent** a year ago, bonded into one of the three factions. His real weapon is the
+**fracture** he widens day by day, and his masterstroke at the climax is an offer aimed precisely at
+whichever companion the party has wounded most.
+
+- **The reveal** is not *who* he is but *what his weapon is*: the slow understanding that the murdered
+  reeve, the framed runner, the burned grain, and every cruel either-or the siege forces are **one plan**
+  to make the town destroy itself before he arrives.
+- **The inside agent** — his hand within the walls, the reeve's killer — is the second reveal (Act 2
+  midpoint), staged in the colors of whichever faction the party has leaned on *least*.
+- **The hardest reveal is about the party:** the companion who turns at the climax does so because the
+  party genuinely *betrayed* one of three good people under pressure — and the engine, not the DM, makes
+  that betrayal real.
+- **Stats (Act 3):** **Knight** (AC 18, HP 52, CR 3) scaled up (Veteran/Gladiator, or Bandit Captain +
+  Knight) — a sellsword-lord who *trades blades* but whose host only ever came for a cheap toll. If the
+  wall holds and the cost runs high, he rides off to set a toll elsewhere — a fine dangling thread.
+
+## The Companions — Three Knives, Orthogonal Vocabularies
+
+The spine of this campaign is **three competing-agenda companions whose approval vocabularies are
+deliberately orthogonal**, so a single tagged decision moves their gauges in *opposite* directions. All
+three are **original, non-origin characters** — never the seven BG3 origin heroes.
+
+| Companion | Pole | Likes (sample) | Dislikes (sample) | Agenda flag |
+|-----------|------|----------------|-------------------|-------------|
+| **Sgt. Maelin Vael** (Fighter, `companion-default`) | **LAW** | `keeping_your_word`, `due_process`, `hold_the_law_under_pressure` | `summary_execution`, `spring_the_framed_runner`, `sparing_an_enemy` | `broke_your_oath` |
+| **Korrin "the Fence" Vane** (Rogue, `npc-rogue`) | **SURVIVAL** | `cutting_a_deal`, `sparing_a_desperate_thief`, `spring_the_framed_runner`, `bend_the_law_to_save_a_life` | `rigid_law_that_gets_people_killed`, `turn_in_the_thief`, `hold_the_law_under_pressure` | `turned_in_the_thief` |
+| **Sister Anwen** (Cleric, `npc-elder`) | **MERCY** | `sparing_an_enemy`, `tending_the_wounded`, `broker_a_surrender` | `collateral_cruelty`, `order_the_massacre`, `spend_lives_to_save_lives` | `ordered_the_massacre` |
+
+**The orthogonality is a literal engine fact, not just a narrative one** — the same cause-key is a *like*
+for one and a *dislike* for another, so one tag splits two gauges:
+
+- `spring_the_framed_runner` / `bend_the_law_to_save_a_life` → **+Korrin, −Vael** (survival vs law)
+- `hold_the_law_under_pressure` → **+Vael, −Korrin** (law vs survival, the other direction)
+- `sparing_an_enemy` → **+Anwen, −Vael** (mercy vs law)
+- `spend_lives_to_save_lives` → **+Korrin, −Anwen** (the *method* split — survival vs mercy)
+- `summary_execution` → **all three dislike it** (the one shared red line)
+
+Note the *partial* alignments that make the triangle live: Korrin and Anwen both want to save the
+desperate but split on **method** (Korrin will cut a hard deal Anwen finds cruel); Vael and Anwen both
+want order but split on **mercy** (Vael will hang the guilty Anwen would spare).
+
+### The Fork — three knives, one turns
+
+Each companion carries a 4-gate arc — **loyalty (25) → personal_quest (50) → loyalty (75)**, plus a
+**betrayal (20)** gate reachable *only when approval curdles* — and an `attitude_below 20`
+`CompanionAgenda` armed by a **distinct** `decision_flag`. At the climax, **only the most-betrayed
+companion turns**, and each turns *differently*, in character:
+
+| Companion | Flag | The turn |
+|-----------|------|----------|
+| **Vael** | `broke_your_oath` | Not for gold — she **withdraws the Fist** from a defense she's decided is no longer lawful, or turns to stop a party that became the lawlessness she swore against. *"I swore an oath to the law, not to you."* |
+| **Korrin** | `turned_in_the_thief` | **Pulls the Vine, the grain, and the secret ways** out at the worst moment — or cuts a private evacuation deal with Maddox. *"You should have saved the people in front of you."* |
+| **Anwen** | `ordered_the_massacre` | **Withdraws her mercy and sanctuary**, opens the almshouse to the wounded the party abandoned, and stands *unarmed* between the party and a slaughter. *"You made the cost too high."* |
+
+The **other two stand with the party.** And if the party honored all three — no gauge below 20 — **all
+three stand**, and Maddox's whole strategy collapses, because the fracture was his only real weapon. That
+perfect run is the campaign's hardest victory: a feat of balance, not of XP.
+
+## Structure — Hub & Spokes
+
+The party returns to **the Risen-Gate Gatehouse & Toll-Yard** between acts to rest, level, and feel the
+town tighten one notch closer to its own throat. The three faction sites radiate from the hub in Act 1;
+the reaver-camp/held-gate is the Act 2–3 spoke.
+
+| Act | Levels | Sites | The Beat |
+|----|--------|-------|----------|
+| **1 — Three Knives, One Gate** | 3–4 | **Fist Post / Vine Quarter / Almshouse** | The reeve is murdered to break the truce on a timer. Recruit the three competing-agenda companions, one per pole. The **Runner's Rope**: how the party handles the framed runner Brannick is the first three-way orthogonal choice — and the first to move all three gauges in different directions. |
+| **2 — The Siege Tightens** | 4–6 | **The Tollwright's Camp** | Maddox burns the grain, fouls the wells, ransoms prisoners — forcing impossible joint decisions (who eats, who hangs, who's left outside). Raid the camp; uncover the **inside agent** (midpoint reversal). Cornering the agent forces the sharpest choice of the siege and **sets each gauge's final state + decision_flag.** |
+| **3 — The Held Gate** | 6–7 | **The Held Gatehouse** | Maddox brings the host and offers terms aimed at the party's worst-spent virtue. **Expose the inside agent** in the open (the last lever to pull a wavering knife back), then **hold the gate** — where the fork pays out: two stand, one may turn. |
+
+Each act exercises **exploration + social + combat.** Diplomatic, stealth, and political resolutions earn
+full XP — defusing the riot, turning reavers, re-fusing the town, or holding the gate by parley counts as
+overcoming the finale.
+
+## Monsters per Act (all bundled SRD stat blocks, CR-tuned)
+
+- **Act 1 (lv 3–4):** *Optional* riot — **Guard** ×3 (Fist) + **Scout** ×3 (Vine). Best resolved by
+  *defusing* it (no deaths). Veteran/Thug for a harder table.
+- **Act 2 (lv 4–6):** reaver-camp — **Bandit** ×4 + **Scout** ×2 + **Berserker** ×1; the **inside agent**
+  as **Spy** (light) or **Assassin** (CR 8 mid-boss) + **Scout** ×3.
+- **Act 3 (lv 6–7):** **Maddox = Knight** (CR 3, scale to Veteran/Gladiator or Bandit Captain + Knight) +
+  the **agent** (Spy/Assassin, if survived) + **Bandit** ×4 + **Scout** ×2 + **Berserker** ×2, against a
+  **unity-clock**.
+
+Every name resolves through `spawn_monster` / the bundled bestiary. Per-scene scaling notes tune each
+fight to party size.
+
+## The Real Boss — the Fracture, Not Maddox's HP
+
+Maddox is the human enemy the party fights, but **the real antagonist is the fracture** — the three-way
+collision of law, survival, and mercy that he engineered and the party either holds together or spends
+apart. His host is a sellsword band that came for a *cheap toll*; if the wall holds and the cost runs
+high, it routs and Maddox rides off to set a toll elsewhere. The **win** is **holding the gate whole** —
+keeping the town from opening from within — which means keeping at least two of the three knives at the
+wall. The **loss** state is a gate opened from within because the party spent one virtue too cheaply.
+Three win-conditions keep the finale open to any party: **re-fuse the town** (Persuasion), **break the
+host's nerve** (Intimidation), or **hold the gate by force** (Athletics/combat).
+
+## How It Ends
+
+Dawn finds Risen-Gate still standing — or standing *wounded*, depending on what the party spent to hold
+it. The reaver-host is gone; Maddox is dead in the gate's shadow or riding north with his ledger. The
+strongbox is refilled, the reeve buried with his murderer named beside the open grave, and Brannick walks
+free. How the town remembers it is up to the party: as the day three knives that could never agree stood
+together at the gate and held it as one — or as the day the party learned, the hard way, that *you cannot
+spend law to buy survival, or survival to buy mercy, without one of the three turning in your hand.*
+Either way the truce the old reeve died for has outlived him, fragile and real — *Vael keeps the law,
+Korrin keeps the people fed, Anwen keeps them alive,* and the gate opens only to those who pay an honest
+toll, and to no Tollwright at all.
+
+---
+
+## Sample Scene Prose
+
+> *(These expand the read-aloud + dm_notes in `adventure.json` into the playable, BG-register prose the
+> DM voices at the table. Boxed text is for the players; the rest is staging.)*
+
+### Act 1 · Three Who Cannot Agree — *recruiting the trio, at the toll-yard*
+
+> To learn who killed the reeve, you have to walk into all three armed camps that hate each other — and
+> each one wants something different from you before it will talk.
+
+This is the **structural heart** of Act 1. Recruit all three, and *establish their orthogonal
+vocabularies in one scene* so the player feels the gauges move in opposite directions on a single choice.
+
+> At the Fist post, **Sergeant Vael** looks up from a duty-roster with the flat, tired eyes of someone
+> holding a wall with her bare hands. *"You've no faction's coin in you. Good. Then help me do this RIGHT
+> — by the evidence, by a trial — before my own troopers hang that runner tonight and prove this town's
+> not worth saving."*
+>
+> In the Vine's quarter, **Korrin** leans off a grain-cart, all card-sharp's smile and furious soft
+> center. *"Vael wants to TRY him. There's an army coming and she wants to hold a hearing. That runner's
+> going to hang for a crime the powerful committed, same as always — unless someone with no stake cuts
+> him loose. You in?"*
+>
+> And in the almshouse doorway, **Sister Anwen** says it simplest. *"They both want to USE him. I want him
+> to LIVE. Him, and the reaver boy the Fist wants hanged, and the man they beat this morning. Nobody in
+> this town is acceptable losses. Not yet. Will you help me keep it that way?"*
+
+**Teach the trap explicitly:** you cannot satisfy all three on Brannick. Backing the trial pleases Vael
+and stings Korrin; springing him pleases Korrin and stings Vael; insisting he simply be kept alive
+pleases Anwen and reads as weakness to both. Tag a provisional lean with the right cause-keys and let the
+player *see* Vael's bar rise as Korrin's falls.
+
+### Act 1 · The Runner's Rope — *the first three-way fork*
+
+> Half the Fist garrison has gathered with a rope and the certainty of frightened men. The Vine has
+> gathered too, knives loose. And in the almshouse doorway Sister Anwen refuses to let it become a
+> slaughter either way. Sergeant Vael plants herself between the rope and the cell, sword sheathed: *"No
+> one hangs without a trial. Not while I hold this post."* Korrin slides up at your shoulder, all easy
+> menace: *"Or we cut him loose right now and let the law catch up later — your call, friend."*
+
+The whole yard turns to **you** — the one with no faction's collar. **Tag the choice** so it splits:
+
+- **Back Vael** (lawful trial): `due_process`, `hold_the_law_under_pressure` (+Vael, −Korrin)
+- **Back Korrin** (spring him): `spring_the_framed_runner`, `bend_the_law_to_save_a_life` (+Korrin, −Vael)
+- **Back the lynching** (worst — the killer's preferred outcome): `summary_execution`, `lynch_a_suspect`
+  (−Vael HARD, arms `broke_your_oath`; −Korrin HARD `let_the_runner_hang`; −Anwen)
+- **Anwen's third way** (keep him alive in sanctuary to find the truth): `sparing_an_enemy`,
+  `shelter_the_desperate_at_the_gate` (+Anwen; partial +both if framed as "keep him alive for the truth")
+
+If the party **hangs Brannick, they bury his clue with him** (he knew the agent's gait) — a real cost.
+The riot is *optional* combat; **defusing it earns full XP**, because a riot is exactly what the killer
+wanted.
+
+### Act 2 · Which Virtue You Spent — *the inside agent's trap*
+
+> They turn, calm, wearing the colors of one of your own factions, and make the offer Maddox sent them to
+> make. *"You've already done half my master's work — you've spent these three like coin, I've watched
+> you. So spend one more. Hand me to the faction that wants me hanged and call it justice. Cut me loose
+> for what I know and call it a deal. Or kill me quiet and call it mercy on a town that can't afford a
+> trial."* They smile, because they know the trap. *"Whatever you choose, one of your three is going to
+> watch you do it."*
+
+This is the **mirror of the Runner's Rope, stakes maxed** — and it **sets each gauge's final state +
+decision_flag** going into the climax:
+
+- **Try the agent** publicly (Vael's whole quest): `due_process`, `try_the_accused` (+Vael HARD)
+- **Cut a deal / spare for intel:** `cutting_a_deal` (+Korrin; −Vael HARD `cut_a_lawless_deal`, can set
+  `broke_your_oath` — letting the reeve's *murderer* walk is the deepest cut to Vael)
+- **Execute on the road:** `summary_execution` (−all three; −Anwen HARD `kill_a_prisoner` /
+  `execute_the_surrendered`, sets `ordered_the_massacre`; sets `broke_your_oath`)
+- **Hand to a faction that wants them dead:** can set `turned_in_the_thief` if done cynically
+
+By scene's end the party can *see* which knife they've wounded most. **Don't fire the agenda yet** — this
+scene *arms* it; the climax fires it.
+
+### Act 3 · Three Knives at the Gate — *the fork pays out*
+
+> The horns sound and the Tollwright's host comes on. You take your place on the gatehouse, and so do your
+> three — three knives at your back, drawn at last not against each other but against the wall-breakers.
+> And then the one you spent too cheaply turns to look at you, and whether their blade comes up beside
+> yours or against it depends entirely on which value you betrayed across these two long days.
+
+Run the **fork** per the lowest gauge + set flag. If **Vael** broke (`broke_your_oath`):
+
+> Vael lowers her blade and steps back from the wall, her troopers wavering behind her. *"I swore an oath
+> to the law, not to you. And you made me choose."* The Fist withdraws from a gate she's decided is no
+> longer worth holding lawfully.
+
+If the party honored all three, give them the perfect-run payoff — Maddox's weapon turned to nothing:
+
+> Three people who could not agree on anything stand shoulder to shoulder at the gate. The Tollwright's
+> genial smile finally falters: the town he came to find at its own throat is one town, and a sellsword
+> band that came for a cheap toll has no stomach for a wall that won't break.
+
+The **DC 17 Persuasion** doesn't kill Maddox — it turns his own weapon against him, calling out so the
+whole wall hears that the lie that divided them is *dead*, and the gate is one town again.
+
+---
+
+## Running Notes
+
+- **Leveling:** milestone recommended — level 4 after the Runner's Rope (Act 1), 5–6 across the
+  reaver-camp and inside-agent (Act 2), 7 before/during the held gate (Act 3). (~8,000 XP total if you
+  prefer encounter XP.)
+- **Surface the gauges splitting.** The campaign's distinctive pressure is the *three-way orthogonal
+  choice* — on every central decision (Brannick's rope, the grain/ransom/retaliation calls, the agent's
+  fate), tag the right cause-keys and let the player *watch* one bar rise as another falls. That visible
+  split is the whole promise.
+- **Only the most-betrayed companion turns.** The other two stand. If no gauge is below 20, *all three*
+  stand and Maddox's strategy collapses — the hardest, best run. The campaign does not require a perfect
+  run; the cost of a turned knife is real but survivable.
+- **Set the fork flags honestly.** Call `record_decision` / `set_flag` with `broke_your_oath` when the
+  party breaks faith with the law, `turned_in_the_thief` when they spend the desperate to keep a rule, and
+  `ordered_the_massacre` when they choose collateral cruelty (scene-a1-climax, scene-a2-hook,
+  scene-a2-climax). Those flags *arm* the agendas — the engine rolls the turn, the content names the cause.
+- **The real boss is the fracture, not Maddox.** Holding the gate whole and keeping two-of-three knives at
+  your back is the win even if Maddox rides off. A Tollwright loose on the roads is a fine dangling thread.
+- **Validation:** `generate_campaign`-shaped (named antagonist, hook/challenge/climax beats, hub + sites
+  per act, **three full companion dossiers + 4-gate arcs each incl. a `betrayal` gate + a distinct-flag
+  `CompanionAgenda`**). `validate_adventure()` returns `[]`; `seed_campaign()` loads cleanly with all
+  three companions — Vael, Korrin, and Anwen — in the party.


### PR DESCRIPTION
Scale the proven golden-spine pattern to new shapes, each exercising a gate kind the original two spines didn't use.

**three-knives** — a 3-companion party with **orthogonal** approval vocabularies, so one `record_decision` moves the gauges in opposite directions (`hold_the_law_under_pressure`: +Vael/−Korrin; `sparing_an_enemy`: +Anwen/−Vael), with `summary_execution` a shared red line. Each has a distinct `attitude_below` agenda → the climax turns whichever companion you betrayed most. 9 scenes.

**hollow-mile** — gothic horror; Dr. Eline Mourn exercises the **quest-linked** personal_quest gate + a **prize_seized** (non-attitude) agenda — a clinical-cold turn. 8 scenes, a `companion_quest_arcs` block.

Both: `validate_adventure` **CLEAN**, `seed_campaign` seats every companion with full vocab + agenda, snake_case keys, zero banned-origin refs. Orthogonal-gauge math verified as a real engine fact (not just narrated).

The **romance** spine (ashfall-reach, exercising the romance gate) follows — its author hit a transient socket error and is re-running.