### PR TITLE
fix(audit): author_companion_gauges sign guard + agenda merge (2 HIGH)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -9608,6 +9608,15 @@ def author_companion_gauges(
     companion_id = companion_id or companion or character_id
     if not companion_id:
         raise ValueError("author_companion_gauges needs a companion id (`companion_id` or an alias)")
+    # A betrayal agenda fires when attitude_value falls BELOW its threshold, so the threshold must be
+    # NEGATIVE — a brand-new companion sits at 0, and a non-negative threshold would put them already
+    # below it and roll a betrayal every beat from the moment they join (the engine's snap curve).
+    if betrayal_threshold is not None and betrayal_threshold >= 0:
+        raise ValueError(
+            f"betrayal_threshold must be NEGATIVE — the attitude_value the bond must fall BELOW to "
+            f"break (e.g. -30). {betrayal_threshold} would arm an agenda that betrays a neutral "
+            f"companion immediately. Omit it for a companion who can deepen but never turn."
+        )
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _require_companion(c, companion_id)
@@ -9624,15 +9633,26 @@ def author_companion_gauges(
         # the arc's existing gates are preserved.
         agenda_armed = False
         if betrayal_threshold is not None:
+            existing = ch.arc.agenda if ch.arc is not None else None
+            # Don't silently clobber a content-authored agenda of a DIFFERENT shape (e.g. a
+            # prize_seized / day_reached turn) — that's the author's design; redirect to set_companion_arc.
+            if existing is not None and existing.trigger != "attitude_below":
+                raise ValueError(
+                    f"{ch.name} already has a {existing.trigger!r} agenda authored in content; "
+                    f"author_companion_gauges won't overwrite it. Use set_companion_arc to change it."
+                )
             if ch.arc is None:
                 ch.arc = CompanionArc.model_validate({"arc_gates": [
                     {"kind": "loyalty", "threshold": 25,
                      "note": f"a deepening trust with {ch.name}, earned fighting beside them"}]})
-            ch.arc.agenda = CompanionAgenda.model_validate({
-                "trigger": "attitude_below",
-                "value": int(betrayal_threshold),
-                "decision_flag": (betrayal_decision_flag or "").strip(),
-            })
+            # MERGE onto an existing attitude_below agenda so a re-author that only re-tunes the
+            # threshold PRESERVES its decision_flag + note; re-arming resets the fired latch.
+            base = existing.model_dump() if existing is not None else {}
+            base.update({"trigger": "attitude_below", "value": int(betrayal_threshold), "fired": False})
+            flag = (betrayal_decision_flag or "").strip()
+            if flag:
+                base["decision_flag"] = flag
+            ch.arc.agenda = CompanionAgenda.model_validate(base)
             agenda_armed = True
         save_campaign(c)
         return {

--- a/servers/engine/tests/test_author_companion_gauges.py
+++ b/servers/engine/tests/test_author_companion_gauges.py
@@ -75,6 +75,37 @@ def test_author_is_additive_preserves_camp_prompts(tmp_path, monkeypatch):
     assert d.approval_dislikes == []          # not passed -> unchanged (empty)
 
 
+def test_betrayal_threshold_must_be_negative(tmp_path, monkeypatch):
+    """A non-negative betrayal_threshold would arm an agenda that betrays a neutral (attitude 0)
+    companion immediately — reject it at the seam."""
+    import pytest
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    bg = server.start_world("baldurs-gate")["campaign_id"]
+    comp_id = _vocabless_companion(bg)
+    for bad in (0, 20, 100):
+        with pytest.raises(ValueError, match="NEGATIVE"):
+            server.author_companion_gauges(bg, companion_id=comp_id, approval_likes=["mercy"],
+                                           betrayal_threshold=bad)
+    # the dossier was still written for the first (pre-agenda) call? no — the raise is BEFORE the
+    # lock, so nothing was written; a clean negative threshold works:
+    res = server.author_companion_gauges(bg, companion_id=comp_id, approval_likes=["mercy"],
+                                         betrayal_threshold=-25)
+    assert res["betrayal_agenda_armed"] is True
+
+
+def test_reauthor_preserves_agenda_decision_flag(tmp_path, monkeypatch):
+    """Re-arming to re-tune the threshold preserves the existing agenda's decision_flag (additive)."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    bg = server.start_world("baldurs-gate")["campaign_id"]
+    comp_id = _vocabless_companion(bg)
+    server.author_companion_gauges(bg, companion_id=comp_id, approval_likes=["mercy"],
+                                   betrayal_threshold=-30, betrayal_decision_flag="took_the_coin")
+    # re-author with a new threshold but NO flag — the flag must survive
+    server.author_companion_gauges(bg, companion_id=comp_id, betrayal_threshold=-20)
+    ag = store.load_campaign(bg).characters[comp_id].arc.agenda
+    assert ag.value == -20 and ag.decision_flag == "took_the_coin"
+
+
 def test_author_without_threshold_leaves_agenda_unarmed(tmp_path, monkeypatch):
     """Omitting betrayal_threshold deepens-but-never-turns: no agenda is armed (the default seeded
     loyalty arc stays agenda-less)."""


### PR DESCRIPTION
Two HIGH findings from the deep acts/arcs red-team audit, both in #995's tool:

1. **Sign guard** — `betrayal_threshold` accepted a *positive* value → armed an `attitude_below` agenda that betrays a **neutral** companion immediately (a companion at 0 is already below a positive threshold). Now rejects non-negative thresholds.
2. **Agenda merge** — re-arming full-replaced the agenda, dropping a content-authored `decision_flag`/`note`; now merges onto an existing `attitude_below` agenda and refuses to clobber a different-trigger one.

+2 tests; 37 + fast_gate T0 green. First slice of the audit-fix program.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced companion betrayal mechanics validation to require negative thresholds, preventing unintended betrayal triggering.
  * Improved preservation of existing companion behavior definitions to prevent accidental overwrites during reconfiguration.
  * Added automatic initialization of companion loyalty arcs when needed.

* **Tests**
  * Added validation tests for betrayal threshold enforcement and companion behavior preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->