### PR TITLE
fix(audit): Phase-A regressions (dedup, quest-link seed, coverage truth, validator, arc parity)

### DIFF
--- a/qa/story_readout.py
+++ b/qa/story_readout.py
@@ -74,6 +74,35 @@ def _act_of(name) -> int | None:
     return _ROMAN_ACT.get((m.group(2) or "").lower())
 
 
+# Short tool NAMES that, when carrying a fired/agenda signal in their RESULT, prove a betrayal
+# actually turned. The engine's only companion-arc evaluator is `check_companion_arc` (server.py)
+# — it returns the companion_arc.evaluate() shape: a `results` list whose entries carry
+# `agenda_fired: true` / a fired `agenda` dump / a `betrayal_warning`. The OLD code keyed betrayal
+# on `trigger_companion_agenda` / `companion_betrayal` / `resolve_companion_agenda` — tool names
+# that DO NOT EXIST in the engine — so a real betrayal could never stamp `betrayal ✓` and (worse)
+# the count for a non-existent tool was always 0, so the bucket was dead. We key on the real tool.
+_ARC_EVAL_TOOLS = ("check_companion_arc",)
+
+
+def _agenda_fired_in_state(state: dict) -> bool:
+    """GROUND-TRUTH betrayal signal from the snapshot: any companion whose sealed agenda has
+    actually FIRED (``character.arc.agenda.fired == True``). A fired agenda is the durable record
+    that the companion turned — companion_arc.evaluate() flips ``fired`` and the engine persists
+    it (the snapshot is the sole writer). Defensive: tolerates a missing/None arc or agenda, and a
+    list- OR dict-shaped ``characters`` collection. This is the snapshot analog of the transcript's
+    `check_companion_arc` ``agenda_fired`` result signal — either proves the betrayal landed."""
+    chars = (state or {}).get("characters", {}) or {}
+    char_list = list(chars.values()) if isinstance(chars, dict) else (chars if isinstance(chars, list) else [])
+    for c in char_list:
+        if not isinstance(c, dict):
+            continue
+        arc = c.get("arc")
+        agenda = arc.get("agenda") if isinstance(arc, dict) else None
+        if isinstance(agenda, dict) and bool(agenda.get("fired")):
+            return True
+    return False
+
+
 def structural_coverage_from_state(state: dict, tool_counts=None) -> dict:
     """A per-run STRUCTURAL-COVERAGE block derived from GROUND TRUTH (the final engine
     snapshot), not the player's actions — the owner's "full circle" (pairs with the #961
@@ -85,13 +114,15 @@ def structural_coverage_from_state(state: dict, tool_counts=None) -> dict:
         approval_moved (any companion ``attitude_value`` != 0), camped (any character with a
         ``last_long_rest_day`` >= 0), quest_resolved (any quest ``status`` == completed),
         quest_evolved (a completed quest carrying ``evolves_to`` OR a scheduled
-        ``consequences`` entry), traveled (>= 2 distinct ``visited`` locations), and
-        acts_reached (distinct "(Act N)" tags over the VISITED location NAMES, with a
-        visited-count/``day`` proxy when the world is untagged).
+        ``consequences`` entry), traveled (>= 2 distinct ``visited`` locations),
+        acts_reached (the highest CONTIGUOUS "(Act N)" tag visited from act 1 — coverage,
+        not max: visiting only the act-3 site reads 0, not 3 — with a visited-count proxy
+        when the world is untagged), and betrayal (a companion's sealed agenda actually
+        FIRED — ``character.arc.agenda.fired`` is True in the snapshot).
       * From ``tool_counts`` (optional — a {short_tool_name: count} mapping, reusing
-        ``coverage_from_tool_counts``): combat (a start_combat fired) and betrayal (a
-        companion betrayal/agenda tool engaged). When ``tool_counts`` is None those two
-        ride the snapshot only (combat ⇒ any kind=monster engaged; betrayal stays False).
+        ``coverage_from_tool_counts``): combat (a start_combat fired). When ``tool_counts``
+        is None, combat rides the snapshot only (any kind=monster engaged). betrayal is
+        snapshot-ground-truth and does not depend on ``tool_counts``.
 
     Additive + defensive: every field defaults to a safe falsy value, so a system-skipping
     run yields a LOW/false block and a complete run yields acts 3/3 + all ✓. Returns a dict
@@ -144,32 +175,44 @@ def structural_coverage_from_state(state: dict, tool_counts=None) -> dict:
     # >= ~6 visited locations OR a multi-day arc suggests the party pushed past Act 1, but
     # without authored tags we can only PROVE act 1 — so the proxy caps at 1 (honest: never
     # claim an act the world didn't tag). The proxy still distinguishes "moved at all".
+    #
+    # COVERAGE, not max-tag: an arc that visits ONLY the Act-3 site is not "in act 3/3" — the
+    # party skipped acts 1-2 (a fast-travel/QA shortcut, or a malformed run), so the structural
+    # claim "reached act 3" is a LIE. acts_reached is the highest CONTIGUOUS act actually
+    # visited from 1: act 1 if 1 is tagged, act 2 only if 1 AND 2 are, act 3 only if 1, 2 AND 3
+    # are. Visiting {3} reads 0 (act 1 itself never proven); {1,3} reads 1; {1,2,3} reads 3.
     tagged_acts = {a for l in visited_locs if (a := _act_of(l.get("name"))) is not None}
     if tagged_acts:
-        acts_reached = max(tagged_acts)
+        acts_reached = 0
+        for n in (1, 2, 3):
+            if n in tagged_acts:
+                acts_reached = n
+            else:
+                break  # a gap breaks the chain — never credit an act past the first missing one
     else:
         # Untagged world: we cannot prove Act 2/3 from names. acts_reached = 1 once any
         # location was visited (the run is at least in Act 1), else 0.
         acts_reached = 1 if distinct_visited >= 1 else 0
 
-    # combat / betrayal from the transcript tool counts (ground truth for "a system fired"),
-    # reusing the SAME bucket logic the readout stamp + the #961 gate share. When no tool
-    # counts are given, derive combat from the snapshot (a kind=monster was engaged) and leave
-    # betrayal False (it needs a transcript/result signal).
+    # combat from the transcript tool counts (ground truth for "a system fired"), reusing the
+    # SAME bucket logic the readout stamp + the #961 gate share. When no tool counts are given,
+    # derive combat from the snapshot (a kind=monster was engaged).
     combat = False
-    betrayal = False
     if tool_counts is not None:
         cov = coverage_from_tool_counts(tool_counts)
         combat = bool(cov.get("combat"))
-        # betrayal: an engaged companion-agenda / betrayal tool. coverage_from_tool_counts
-        # has no betrayal bucket, so read the raw counts for the known signals.
-        betrayal = bool(
-            int(tool_counts.get("trigger_companion_agenda", 0) or 0)
-            or int(tool_counts.get("companion_betrayal", 0) or 0)
-            or int(tool_counts.get("resolve_companion_agenda", 0) or 0)
-        )
     if not combat:
         combat = any(isinstance(c, dict) and c.get("kind") == "monster" for c in char_list)
+
+    # betrayal: a companion's sealed agenda ACTUALLY FIRED. The ground truth is the snapshot
+    # (`character.arc.agenda.fired == True`) — the durable record the engine writes when
+    # companion_arc.evaluate() flips the agenda. The OLD code keyed this on tool NAMES that don't
+    # exist in the engine (trigger_companion_agenda / companion_betrayal / resolve_companion_agenda),
+    # so a real betrayal stamped `betrayal ·` AND a system-skipping run could never disprove it —
+    # the bucket was dead. A bare `check_companion_arc` CALL is necessary-but-not-sufficient (the DM
+    # calls it every beat to evaluate; it usually returns nothing fired), so a call count alone must
+    # NOT stamp betrayal — only the fired agenda does. The snapshot is the sole, honest source.
+    betrayal = _agenda_fired_in_state(state)
 
     block = {
         "acts_reached": int(acts_reached),

--- a/qa/test_structural_coverage.py
+++ b/qa/test_structural_coverage.py
@@ -51,14 +51,18 @@ def _skipping_state() -> dict:
 def _complete_state() -> dict:
     """A COMPLETE run's final snapshot: companion recruited + approval moved + camped, a quest
     resolved AND carrying an `evolves_to`, three AUTHORED act-tagged visited locations, a monster
-    engaged (combat), a scheduled consequence."""
+    engaged (combat), a scheduled consequence, and a companion whose sealed betrayal agenda FIRED
+    (`arc.agenda.fired` True — the snapshot ground truth for `betrayal`)."""
     return {
         "day": 20,
         "party": ["pc1", "comp1"],
         "characters": {
             "pc1": {"name": "Dal", "kind": "player", "last_long_rest_day": 5},
             "comp1": {"name": "Karlach", "kind": "companion",
-                      "attitude_value": 40, "last_long_rest_day": 5},
+                      "attitude_value": 40, "last_long_rest_day": 5,
+                      "arc": {"arc_gates": [],
+                              "agenda": {"trigger": "attitude_below", "value": -20,
+                                         "fired": True, "note": "she turns"}}},
             "mon1": {"name": "Goblin Boss", "kind": "monster"},
         },
         "quests": {"q1": {"title": "The Embergloom Pact", "status": "completed",
@@ -94,7 +98,7 @@ def test_skipping_run_yields_low_block():
 
 def test_complete_run_yields_full_block():
     block = sr.structural_coverage_from_state(
-        _complete_state(), {"start_combat": 1, "trigger_companion_agenda": 1})
+        _complete_state(), {"start_combat": 1, "check_companion_arc": 1})
     assert block["acts_reached"] == 3
     assert block["recruited"] is True
     assert block["approval_moved"] is True
@@ -122,10 +126,74 @@ def test_acts_from_authored_tags_partial():
 
 
 def test_roman_numeral_act_tags():
+    """Roman-numeral act tags parse (Act I/II/III). Coverage rule still applies: the chain must
+    be contiguous from act 1, so BOTH the Act-I and Act-II sites must be visited to read 2."""
     state = _skipping_state()
-    state["locations"] = {"a": {"name": "Ruins (Act II)", "visited": True}}
+    state["locations"] = {"a": {"name": "Ruins (Act I)", "visited": True},
+                          "b": {"name": "Deeper Ruins (Act II)", "visited": True}}
     block = sr.structural_coverage_from_state(state)
     assert block["acts_reached"] == 2
+
+
+def test_visiting_only_act3_site_does_not_read_acts_3of3():
+    """REGRESSION (acts_reached false-pass): a run that visits ONLY the Act-3 site has SKIPPED
+    acts 1-2 — it is NOT "in act 3/3". acts_reached is the highest CONTIGUOUS act from 1, so a
+    sole Act-3 visit proves NO act (act 1 itself was never reached) → 0, summary 'acts 0/3'.
+    The OLD max-tag logic stamped 3/3, a lie that hides a malformed/shortcut arc."""
+    state = _skipping_state()
+    state["locations"] = {"c": {"name": "The Lower City (Act 3)", "visited": True}}
+    block = sr.structural_coverage_from_state(state)
+    assert block["acts_reached"] == 0, block["acts_reached"]
+    assert block["summary"].startswith("acts 0/3 ·")
+
+
+def test_acts_require_contiguous_coverage_not_max():
+    """acts_reached caps at the highest CONTIGUOUS act visited from 1. Visiting acts {1,3}
+    (the act-2 site skipped) credits only act 1 — the chain breaks at the missing act 2."""
+    state = _skipping_state()
+    state["locations"] = {
+        "a": {"name": "The Grove (Act 1)", "visited": True},
+        "c": {"name": "The Lower City (Act 3)", "visited": True},
+    }
+    block = sr.structural_coverage_from_state(state)
+    assert block["acts_reached"] == 1, block["acts_reached"]
+
+
+def test_betrayal_stamps_only_when_agenda_actually_fired():
+    """REGRESSION (betrayal coverage stamp lies): betrayal is keyed on the snapshot ground truth
+    `character.arc.agenda.fired`, NOT on non-existent tool names. A run whose companion's sealed
+    agenda FIRED stamps `betrayal ✓` even though the fake trigger_companion_agenda tool was never
+    called; a run where the agenda is armed-but-unfired stamps `betrayal ·`."""
+    # Armed but NOT fired → no betrayal, regardless of any check_companion_arc calls.
+    armed = _skipping_state()
+    armed["characters"]["comp1"]["arc"] = {
+        "arc_gates": [],
+        "agenda": {"trigger": "attitude_below", "value": -20, "fired": False},
+    }
+    block = sr.structural_coverage_from_state(armed, {"check_companion_arc": 12})
+    assert block["betrayal"] is False
+    assert "betrayal ·" in block["summary"]
+
+    # The agenda actually fired (the companion turned) → betrayal ✓, with NO fake tool present.
+    turned = _skipping_state()
+    turned["characters"]["comp1"]["arc"] = {
+        "arc_gates": [],
+        "agenda": {"trigger": "attitude_below", "value": -20, "fired": True},
+    }
+    block = sr.structural_coverage_from_state(turned, {"check_companion_arc": 3})
+    assert block["betrayal"] is True
+    assert "betrayal ✓" in block["summary"]
+
+
+def test_fake_betrayal_tool_names_no_longer_stamp_betrayal():
+    """The OLD code keyed betrayal on tool names that DO NOT EXIST in the engine
+    (trigger_companion_agenda / companion_betrayal / resolve_companion_agenda). Passing those
+    counts now proves nothing — without a fired agenda in the snapshot, betrayal stays False."""
+    block = sr.structural_coverage_from_state(
+        _skipping_state(),
+        {"trigger_companion_agenda": 9, "companion_betrayal": 9, "resolve_companion_agenda": 9},
+    )
+    assert block["betrayal"] is False
 
 
 def test_combat_from_snapshot_when_no_tool_counts():

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -857,6 +857,21 @@ def seed_campaign(adv: dict) -> Campaign:
         quest = Quest(title=adv.get("title", "Adventure"), description=adv["hook"])
         c.quests[quest.id] = quest
 
+    # F06-10/F06-11 (audit 2026-06-18): fold an OPTIONAL top-level `companion_quest_arcs` block
+    # so an AUTHORED campaign (not just a world/ending seed) can SHIP a first-class companion
+    # personal-quest arc. Without this, hollow-mile's Doctor Eline Mourn personal_quest gate
+    # links quest_arc_id 'cqarc-eline-stillwater' that nothing seeds — the link dangles forever
+    # (F06-11 latches a one-shot link_error and the gate stays locked-but-recoverable). Runs LAST
+    # in seed_campaign — AFTER the companions loop (so the arc's `companion_id` owner exists and
+    # is a companion) and AFTER quest seeding (so any `quest_ids` projection ref-checks). Reuses
+    # the same loader the world/overlay paths use: validates via CompanionQuestArc.model_validate,
+    # degrades-not-aborts a malformed/dangling entry, keys into c.companion_quest_arcs by id.
+    # Additive: an adventure with no `companion_quest_arcs` key seeds nothing (today's behavior;
+    # default {} round-trips).
+    _seed_companion_quest_arcs_block(
+        c, adv.get("companion_quest_arcs"), where="adventure companion_quest_arcs block"
+    )
+
     return c
 
 

--- a/servers/engine/generator.py
+++ b/servers/engine/generator.py
@@ -188,6 +188,122 @@ def validate_adventure(adv: dict) -> list[str]:
             if _is_nonempty_str(voice_id) and voice_id not in KNOWN_VOICE_IDS:
                 problems.append(f"antagonist has unknown voice_id {voice_id!r}")
 
+    # --- companions: arc gates / agendas / quest-arc links / approval keys ---
+    problems.extend(_validate_companions(adv))
+
+    return problems
+
+
+def _validate_companions(adv: dict) -> list[str]:
+    """Validate the companion-relationship structure of an adventure dict (arc gates,
+    sealed agendas, personal-quest links, and approval keys).
+
+    This is the author-time guard the audit found MISSING: ``validate_adventure`` had ZERO
+    companion-arc coverage, so a spine could ship with the inversion bugs the engine quietly
+    mis-fires on. The declarative shape mirrors the live models 1:1 (see ``models.ArcGate`` /
+    ``CompanionAgenda`` / ``CompanionQuestArc``, and the authored ``content/campaigns/*/
+    adventure.json``): ``adv['companions'][i].arc = {arc_gates: [...], agenda: {...}}`` with
+    a top-level ``adv['companion_quest_arcs']`` registry, and approval keys under
+    ``companion_dossier.approval_likes`` / ``approval_dislikes``.
+
+    Flags (each a ship-blocking authoring mistake the engine can't catch at play time):
+
+      * a ``personal_quest`` arc-gate whose ``quest_arc_id`` does NOT resolve to an authored
+        ``companion_quest_arc`` (a dangling link — the gate can never make a real arc available);
+      * a ``betrayal``-kind arc-gate with a POSITIVE ``threshold`` (the INVERSION bug — an
+        ArcGate unlocks when ``attitude_value >= threshold``, i.e. on HIGH approval, but a
+        betrayal must unlock on LOW/curdled approval, so a positive betrayal threshold means
+        the turn unlocks when the companion likes you most — backwards; should not ship);
+      * an ``attitude_below`` agenda with a POSITIVE ``value`` (the same inversion: the agenda
+        fires while ``attitude_value < value``, so a positive value arms the betrayal at HIGH
+        approval — a saboteur who turns the more you befriend them; real spines use NEGATIVE
+        values like -20/-30);
+      * a space-separated approval key in ``approval_likes`` / ``approval_dislikes`` (approval
+        keys are matched token-for-token against the ``approval_tags`` the engine records —
+        a key with whitespace can NEVER match, so the regard move it gates is silently dead).
+
+    Tolerant of everything optional: an adventure with no companions, a companion with no arc,
+    an arc with no gates/agenda, a companion with no dossier — all clean. Returns a list of
+    human-readable problem strings (empty == valid)."""
+    problems: list[str] = []
+
+    companions = adv.get("companions", [])
+    if companions in (None, []):
+        return problems
+    if not isinstance(companions, list):
+        problems.append(f"'companions' must be a list, got {type(companions).__name__}")
+        return problems
+
+    # The authored companion-quest-arc registry the personal_quest gates link into.
+    quest_arc_ids: set[str] = set()
+    cqa = adv.get("companion_quest_arcs", [])
+    if isinstance(cqa, list):
+        for arc in cqa:
+            if isinstance(arc, dict) and _is_nonempty_str(arc.get("id")):
+                quest_arc_ids.add(arc["id"])
+
+    for i, comp in enumerate(companions):
+        if not isinstance(comp, dict):
+            problems.append(f"companion[{i}] must be an object, got {type(comp).__name__}")
+            continue
+        label = comp.get("id") if _is_nonempty_str(comp.get("id")) else f"companion[{i}]"
+
+        arc = comp.get("arc")
+        if isinstance(arc, dict):
+            gates = arc.get("arc_gates", [])
+            if isinstance(gates, list):
+                for gate in gates:
+                    if not isinstance(gate, dict):
+                        continue
+                    kind = gate.get("kind")
+                    threshold = gate.get("threshold")
+                    # A betrayal gate must unlock on LOW (negative) approval — a positive
+                    # threshold inverts it (unlocks when liked most). Should not ship.
+                    if kind == "betrayal" and isinstance(threshold, (int, float)) \
+                            and not isinstance(threshold, bool) and threshold > 0:
+                        problems.append(
+                            f"companion {label!r} betrayal gate has a POSITIVE threshold "
+                            f"{threshold!r} (inverted — a betrayal must unlock on LOW/negative "
+                            f"approval, not high)"
+                        )
+                    # A personal_quest gate's quest_arc_id must resolve to an authored arc.
+                    if kind == "personal_quest":
+                        qid = gate.get("quest_arc_id")
+                        if _is_nonempty_str(qid) and qid not in quest_arc_ids:
+                            problems.append(
+                                f"companion {label!r} personal_quest gate links unknown "
+                                f"companion_quest_arc {qid!r}"
+                            )
+
+            agenda = arc.get("agenda")
+            if isinstance(agenda, dict):
+                # An attitude_below agenda fires while attitude_value < value, so its value is
+                # the breaking point — a POSITIVE value arms the betrayal at high approval
+                # (a saboteur who turns the MORE you befriend them). Real spines use -20/-30.
+                if agenda.get("trigger") == "attitude_below":
+                    val = agenda.get("value")
+                    if isinstance(val, (int, float)) and not isinstance(val, bool) and val > 0:
+                        problems.append(
+                            f"companion {label!r} attitude_below agenda has a POSITIVE value "
+                            f"{val!r} (inverted — it would arm the betrayal at HIGH approval; "
+                            f"the breaking point must be negative)"
+                        )
+
+        # Approval keys must be whitespace-free tokens (matched against engine approval_tags).
+        dossier = comp.get("companion_dossier")
+        if isinstance(dossier, dict):
+            for field in ("approval_likes", "approval_dislikes"):
+                keys = dossier.get(field, [])
+                if not isinstance(keys, list):
+                    continue
+                for key in keys:
+                    if isinstance(key, str) and any(ch.isspace() for ch in key):
+                        problems.append(
+                            f"companion {label!r} {field} key {key!r} contains whitespace "
+                            f"(approval keys must be whitespace-free tokens to match the "
+                            f"engine's approval_tags)"
+                        )
+
     return problems
 
 

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -564,6 +564,16 @@ def start_adventure(adventure_id: str) -> dict:
     the player + companion with create_character."""
     adv = content_mod.load_adventure_data(adventure_id)
     c = content_mod.seed_campaign(adv)
+    # content.seed_campaign does NOT run the companion operational-state finisher (that helper
+    # lives in server.py), so a dossier-authored adventure companion enters the party with
+    # arc=None — its gauge moves but no arc gate ever lingers, leaving the relationship system
+    # half-inert. Seed the missing arc/dossier here. Both writes inside the helper are
+    # None-GUARDED, so an authored arc/dossier (e.g. Vesper's, the spine companions') is NEVER
+    # overwritten — only a missing arc gets the light default.
+    for cid in getattr(c, "party", None) or []:
+        ch = c.characters.get(cid)
+        if ch is not None and getattr(ch, "kind", None) == "companion":
+            _seed_companion_operational_state(ch)
     save_campaign(c)
     loc = c.locations.get(c.current_location_id) if c.current_location_id else None
     return {
@@ -10446,20 +10456,50 @@ def _normalize_approval_tags(approval_tags) -> list[tuple[str, Optional[int]]]:
     +/-10 default) OR a list of ``{"key": str, "delta": int}`` dicts (an explicit per-tag
     swing). A bare string and a dict may be mixed. ``None`` / empty -> ``[]`` (the additive
     no-op). Keys are lowercased + stripped so they match the dossier's lowercase_snake
-    vocabulary regardless of the DM's casing; an empty/blank key is dropped."""
+    vocabulary regardless of the DM's casing; an empty/blank key is dropped.
+
+    A cause is COUNTED ONCE per decision: duplicate keys (``["mercy", "mercy"]`` — the same
+    moral cause named twice in one decision) are collapsed to a single (key, delta) pair so
+    the gauge moves +10 once, not +20 (the double-count regression). The FIRST occurrence's
+    explicit delta wins; a later bare-string repeat does not clobber an earlier explicit one.
+
+    A non-numeric explicit delta (``{"key": "mercy", "delta": "lots"}``) raises a CLEAR
+    ValueError naming the offending key — never a bare ``int()`` crash that aborts the whole
+    record_decision with an opaque message."""
     if not approval_tags:
         return []
+    # Dedup-preserving-order: collapse duplicate keys to ONE pair per distinct cause-key so a
+    # cause named twice in a single decision moves the gauge once. seen maps key -> index in out.
     out: list[tuple[str, Optional[int]]] = []
+    seen: dict[str, int] = {}
     for item in approval_tags:
         if isinstance(item, dict):
             key = str(item.get("key") or "").strip().lower()
             raw_delta = item.get("delta")
-            delta = None if raw_delta is None else int(raw_delta)
+            if raw_delta is None:
+                delta: Optional[int] = None
+            else:
+                try:
+                    delta = int(raw_delta)
+                except (TypeError, ValueError):
+                    raise ValueError(
+                        f"approval_tags delta for key {key or '(blank)'!r} must be an integer, "
+                        f"got {raw_delta!r}"
+                    )
         else:
             key = str(item or "").strip().lower()
             delta = None
-        if key:
-            out.append((key, delta))
+        if not key:
+            continue
+        if key in seen:
+            # Same cause already recorded this decision — keep the first pair, but let an
+            # explicit delta fill in for an earlier bare-string occurrence (None).
+            idx = seen[key]
+            if out[idx][1] is None and delta is not None:
+                out[idx] = (key, delta)
+            continue
+        seen[key] = len(out)
+        out.append((key, delta))
     return out
 
 
@@ -11128,7 +11168,11 @@ def _compute_beat_obligations(c: Campaign) -> list[dict]:
     for comp in party_companions:
         dossier = getattr(comp, "companion_dossier", None)
         likes = list(getattr(dossier, "approval_likes", []) or []) if dossier is not None else []
-        if likes:
+        dislikes = list(getattr(dossier, "approval_dislikes", []) or []) if dossier is not None else []
+        # GAUGEABLE if EITHER list is non-empty: the mover (_apply_approval_tags) matches a tag
+        # against likes OR dislikes, so a companion authored with only approval_dislikes can still
+        # be moved. Gating on likes alone falsely nags a dislikes-only companion as un-gauged forever.
+        if likes or dislikes:
             continue
         name = getattr(comp, "name", None) or "the companion"
         obligations.append({

--- a/servers/engine/tests/test_audit_regressions_approval.py
+++ b/servers/engine/tests/test_audit_regressions_approval.py
@@ -1,0 +1,250 @@
+"""Audit-regression guards (2026-06-18) for the companion-approval / obligation surface.
+
+Four CONFIRMED regressions, each fixed at its source in server.py:
+
+  1. DUPLICATE approval_tags DOUBLE-COUNT — ``approval_tags=["mercy", "mercy"]`` (the same
+     cause named twice in one decision) moved the gauge +20 instead of +10 because
+     _normalize_approval_tags emitted one (key, delta) per list item and _apply_approval_tags
+     accumulated. The fix collapses duplicate keys to ONE move per distinct cause per decision.
+
+  2. NON-NUMERIC explicit DELTA crash — ``{"key": "mercy", "delta": "lots"}`` raised a bare
+     ValueError out of ``int()`` and aborted the whole record_decision. The fix wraps the
+     coercion and raises a CLEAR, key-named ValueError instead.
+
+  3. DISLIKES-ONLY companion mis-cued — a companion authored with ONLY approval_dislikes is
+     fully gaugeable (the mover matches dislikes too), but companion_gauge_unauthored gated on
+     approval_LIKES only, so it nagged "un-gauged forever". The fix reads dislikes too.
+
+  4. ADVENTURE-COMPANION arc=None parity — content.seed_campaign does not run the companion
+     operational-state finisher, so a dossier-authored adventure companion (Vesper) entered the
+     party with arc=None. The fix runs _seed_companion_operational_state on each party companion
+     after seeding in start_adventure; the helper's None-guards preserve authored arcs.
+
+ADDITIVE: every fix is invariant-safe (engine stays sole writer; old snapshots round-trip;
+an authored arc/dossier is never overwritten). These tests are the RED→GREEN evidence.
+"""
+
+import pytest
+
+import content
+import server
+import store
+from models import Campaign, Character, CompanionArc, CompanionDossier
+
+
+# --- shared helpers (mirror test_decision_approval / test_beat_obligations) --
+
+
+def _new_campaign(monkeypatch, tmp_path, title="AuditRegression"):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    return server.create_campaign(title)["id"]
+
+
+def _add_companion(cid, name, *, likes=None, dislikes=None, attitude=0):
+    res = server.create_character(cid, name, kind="companion", class_name="Fighter")
+    comp_id = res["id"]
+    server.update_character(cid, comp_id, {
+        "attitude_value": attitude,
+        "companion_dossier": {
+            "approval_likes": list(likes or []),
+            "approval_dislikes": list(dislikes or []),
+        },
+    })
+    return comp_id
+
+
+def _attitude(cid, comp_id):
+    return server.get_character(cid, comp_id)["attitude_value"]
+
+
+def _kinds(obligations) -> set:
+    return {o["kind"] for o in obligations}
+
+
+# --- Fix 1: duplicate cause-key is counted ONCE per decision -----------------
+
+
+def test_duplicate_tag_moves_gauge_once_not_twice(tmp_path, monkeypatch):
+    """``["mercy", "mercy"]`` — the same cause named twice in one decision — moves +10, not +20."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Shadowheart", likes=["mercy"], dislikes=["cruelty"])
+    out = server.record_decision(cid, summary="spared the wounded foe", approval_tags=["mercy", "mercy"])
+    assert _attitude(cid, comp) == 10  # was 20 before the dedup fix
+    row = next(r for r in out["approval_results"] if r["id"] == comp)
+    assert row["delta"] == 10 and row["new_value"] == 10
+    # the matched cause is reported once, not twice
+    assert row["matched_keys"] == ["mercy"]
+
+
+def test_duplicate_tag_dedup_at_the_normalizer():
+    """Unit-level: the normalizer collapses duplicate keys to a single (key, delta) pair."""
+    pairs = server._normalize_approval_tags(["mercy", "mercy", "Mercy"])  # casing folds too
+    assert pairs == [("mercy", None)]
+
+
+def test_duplicate_dict_tag_keeps_first_explicit_delta():
+    """A cause named twice with an explicit delta on the first occurrence keeps that delta once."""
+    pairs = server._normalize_approval_tags([{"key": "power", "delta": 25}, {"key": "power", "delta": 99}])
+    assert pairs == [("power", 25)]
+
+
+def test_duplicate_explicit_delta_applies_once(tmp_path, monkeypatch):
+    """A doubled explicit-delta tag applies the delta ONCE (not twice)."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Astarion", likes=["power"])
+    out = server.record_decision(
+        cid, summary="seized the crown",
+        approval_tags=[{"key": "power", "delta": 25}, {"key": "power", "delta": 25}],
+    )
+    assert _attitude(cid, comp) == 25  # was 50 before the fix
+    row = next(r for r in out["approval_results"] if r["id"] == comp)
+    assert row["delta"] == 25
+
+
+def test_bare_string_repeat_fills_in_an_earlier_explicit_delta():
+    """First occurrence is a bare string (None delta); a later explicit dict for the same key
+    fills the delta in — still ONE pair (so a mixed restatement does not double-count)."""
+    pairs = server._normalize_approval_tags(["mercy", {"key": "mercy", "delta": 5}])
+    assert pairs == [("mercy", 5)]
+
+
+def test_distinct_keys_still_each_move(tmp_path, monkeypatch):
+    """Regression-guard for the fix: dedup is PER-KEY — two DISTINCT causes still both apply."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Wyll", likes=["heroism", "mercy"])
+    out = server.record_decision(cid, summary="brave + kind", approval_tags=["heroism", "mercy"])
+    assert _attitude(cid, comp) == 20  # +10 each, both distinct
+    row = next(r for r in out["approval_results"] if r["id"] == comp)
+    assert row["delta"] == 20
+    assert set(row["matched_keys"]) == {"heroism", "mercy"}
+
+
+# --- Fix 2: a non-numeric explicit delta is handled, not a bare int() crash --
+
+
+def test_non_numeric_delta_raises_clear_value_error():
+    """``{"key": "mercy", "delta": "lots"}`` raises a CLEAR ValueError naming the key — never an
+    opaque bare ``int('lots')`` crash that aborts the whole record_decision."""
+    with pytest.raises(ValueError) as ei:
+        server._normalize_approval_tags([{"key": "mercy", "delta": "lots"}])
+    msg = str(ei.value)
+    assert "mercy" in msg and "integer" in msg
+
+
+def test_non_numeric_delta_through_record_decision_raises_value_error(tmp_path, monkeypatch):
+    """End-to-end: the malformed delta surfaces as a ValueError (a clean tool error), not an
+    unhandled crash, and does NOT move the gauge."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Shadowheart", likes=["mercy"])
+    with pytest.raises(ValueError):
+        server.record_decision(
+            cid, summary="a garbled tag", approval_tags=[{"key": "mercy", "delta": "lots"}],
+        )
+    assert _attitude(cid, comp) == 0  # no partial move
+
+
+def test_numeric_string_delta_still_coerces():
+    """A numeric STRING delta (a common JSON-ish input) still coerces cleanly to int."""
+    pairs = server._normalize_approval_tags([{"key": "mercy", "delta": "15"}])
+    assert pairs == [("mercy", 15)]
+
+
+# --- Fix 3: a dislikes-ONLY companion is gaugeable, not nagged as un-gauged ---
+
+
+def _dislikes_only_companion(name="Astarion", dislikes=("naive_altruism",)) -> Character:
+    return Character(
+        name=name,
+        kind="companion",
+        attitude_value=0,
+        companion_dossier=CompanionDossier(approval_likes=[], approval_dislikes=list(dislikes)),
+    )
+
+
+def _campaign_with(*members: Character, day: int = 1) -> Campaign:
+    c = Campaign(title="Obligations")
+    for m in members:
+        c.characters[m.id] = m
+        c.party.append(m.id)
+    c.day = day
+    return c
+
+
+def test_dislikes_only_companion_does_not_trip_gauge_unauthored():
+    """A companion authored with ONLY approval_dislikes is gaugeable (the mover matches dislikes
+    too), so companion_gauge_unauthored must NOT fire — it was falsely nagging forever."""
+    comp = _dislikes_only_companion()
+    c = _campaign_with(comp, day=5)
+    assert "companion_gauge_unauthored" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_dislikes_only_companion_is_actually_moved_by_a_tag(tmp_path, monkeypatch):
+    """Proves the cue's premise: a dislikes-only companion really is moved by a matching tag,
+    so cueing it as 'un-gauged' would be wrong."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Astarion", dislikes=["naive_altruism"])
+    server.record_decision(cid, summary="a bleeding-heart gesture", approval_tags=["naive_altruism"])
+    assert _attitude(cid, comp) == -10
+
+
+def test_truly_vocabularyless_companion_still_trips_gauge_unauthored():
+    """Revert-guard: a companion with NEITHER likes nor dislikes still trips the cue (the real
+    un-gauged case the cue is meant to catch)."""
+    comp = Character(name="Recruit", kind="companion", companion_dossier=None)
+    c = _campaign_with(comp, day=5)
+    assert "companion_gauge_unauthored" in _kinds(server._compute_beat_obligations(c))
+
+
+# --- Fix 4: an adventure companion gets a default arc after start_adventure ---
+
+
+def test_adventure_companion_gets_default_arc(tmp_path, monkeypatch):
+    """Vesper (cellar-rats) is authored with a dossier but arc=None. After start_adventure the
+    operational-state finisher seeds a default loyalty arc so a gate can linger — the gauge moves
+    AND the arc machine has state to track."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.start_adventure("cellar-rats")["campaign_id"]
+    c = store.load_campaign(cid)
+    vesper = next(ch for ch in c.characters.values()
+                  if ch.kind == "companion" and ch.name == "Vesper")
+    assert vesper.arc is not None, "Vesper should get a default arc seeded at start_adventure"
+    assert vesper.arc.arc_gates, "the default arc carries at least one loyalty gate"
+    # the authored dossier is PRESERVED (the None-guards never overwrite authored state)
+    assert vesper.companion_dossier is not None
+    # and Vesper is a real party member
+    assert vesper.id in c.party
+
+
+def test_adventure_companion_default_arc_is_a_loyalty_gate(tmp_path, monkeypatch):
+    """The default arc is the light loyalty gate the shared finisher seeds (not an empty arc)."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.start_adventure("cellar-rats")["campaign_id"]
+    c = store.load_campaign(cid)
+    vesper = next(ch for ch in c.characters.values()
+                  if ch.kind == "companion" and ch.name == "Vesper")
+    kinds = {g.kind for g in vesper.arc.arc_gates}
+    assert "loyalty" in kinds
+
+
+@pytest.mark.parametrize("adventure_id,companion,authored_threshold", [
+    # the spine companions ship an AUTHORED arc — the None-guard must NOT overwrite it
+    ("embergloom-pact", "Brother Toll", None),
+    ("ashfall-reach", "Wren Calder", None),
+])
+def test_authored_spine_companion_arc_is_preserved(adventure_id, companion, authored_threshold,
+                                                   tmp_path, monkeypatch):
+    """A spine companion authored WITH an arc keeps that arc through start_adventure — the
+    None-guarded finisher only fills a MISSING arc, never clobbers an authored one."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    # capture the authored arc straight from the adventure module
+    adv = content.load_adventure_data(adventure_id)
+    authored = next(comp for comp in adv.get("companions", []) if comp.get("name") == companion)
+    authored_gate_count = len(authored.get("arc", {}).get("arc_gates", []) or [])
+    assert authored_gate_count > 0, "fixture sanity: this spine companion ships an authored arc"
+
+    cid = server.start_adventure(adventure_id)["campaign_id"]
+    c = store.load_campaign(cid)
+    ch = next(x for x in c.characters.values() if x.kind == "companion" and x.name == companion)
+    assert ch.arc is not None
+    # the authored gate count is intact — the finisher did not append/replace
+    assert len(ch.arc.arc_gates) == authored_gate_count

--- a/servers/engine/tests/test_beat_roundtrip.py
+++ b/servers/engine/tests/test_beat_roundtrip.py
@@ -338,14 +338,16 @@ def test_scene_context_durable_threads_present(cid):
         assert set(q) == {"id", "title", "status", "open_objectives"}
 
     # companions: standing bond shape (gauge + arc/betrayal flags), one row per companion.
-    # `quest_arcs` (F06-10) is ADDITIVE — present only when the companion owns a personal quest arc.
+    # Several keys are ADDITIVE — surfaced only when present: `quest_arcs` (F06-10, owns a personal
+    # quest arc); `approval_likes`/`approval_dislikes` (F6-2/#995, an authored vocabulary);
+    # `next_gate` (D2, the nearest un-unlocked gate's distance).
     comp_ids = {ch.id for ch in c.characters.values() if ch.kind == "companion"}
     assert {x["id"] for x in dur["companions"]} == comp_ids
     for x in dur["companions"]:
         assert {"id", "name", "attitude_value", "has_arc", "has_betrayal_agenda"} <= set(x)
         assert set(x) - {
             "id", "name", "attitude_value", "has_arc", "has_betrayal_agenda",
-        } <= {"quest_arcs"}
+        } <= {"quest_arcs", "approval_likes", "approval_dislikes", "next_gate"}
 
     # factions: both engine-mutated gauges surfaced.
     for f in dur["factions"]:

--- a/servers/engine/tests/test_generator.py
+++ b/servers/engine/tests/test_generator.py
@@ -67,3 +67,135 @@ def test_scaffold_filled_in_round_trips():
     )
     adv["scenes"].append({"id": "s1", "name": "Arrival", "type": "social", "location_id": "loc-gate"})
     assert generator.validate_adventure(adv) == []
+
+
+# --- companion-arc coverage (the previously-uncovered pass) -----------------------
+
+def _adv_with_companion(arc=None, dossier=None, quest_arcs=None):
+    """A minimal valid adventure carrying one companion (with an optional arc / dossier / a
+    top-level companion_quest_arcs registry) — the fixture each companion-pass test plants a
+    single bug into so the new check is exercised in isolation."""
+    adv = generator.scaffold_adventure("Companion Spine")
+    comp = {"id": "companion-vael", "name": "Vael", "voice_id": "companion-default"}
+    if arc is not None:
+        comp["arc"] = arc
+    if dossier is not None:
+        comp["companion_dossier"] = dossier
+    adv["companions"] = [comp]
+    if quest_arcs is not None:
+        adv["companion_quest_arcs"] = quest_arcs
+    return adv
+
+
+def test_real_authored_companion_spines_validate_clean():
+    """Every shipped companion-bearing spine must pass the new companion pass — the invariant
+    that the pass flags only the planted bugs below, never real content (the audit's whole point
+    is to add coverage WITHOUT breaking the authored campaigns)."""
+    for cid in ("hollow-mile", "embergloom-pact", "three-knives", "ashfall-reach",
+                "the-ledger-of-mercy"):
+        adv = content.load_adventure_data(cid)
+        comp_problems = [
+            p for p in generator.validate_adventure(adv)
+            if "companion" in p.lower() and ("gate" in p or "agenda" in p or "approval" in p)
+        ]
+        assert comp_problems == [], (cid, comp_problems)
+
+
+def test_positive_threshold_betrayal_gate_flagged():
+    """A 'betrayal'-kind arc-gate with a POSITIVE threshold is the inversion bug (a betrayal
+    that unlocks on HIGH approval) — it must be flagged so the spine can't ship undetected."""
+    adv = _adv_with_companion(arc={
+        "arc_gates": [{"id": "g1", "kind": "betrayal", "threshold": 15}],
+    })
+    problems = generator.validate_adventure(adv)
+    assert any("betrayal gate" in p and "POSITIVE" in p for p in problems), problems
+
+
+def test_negative_threshold_betrayal_gate_is_clean():
+    """A correctly-authored betrayal gate (NEGATIVE threshold — unlocks as approval curdles)
+    is clean."""
+    adv = _adv_with_companion(arc={
+        "arc_gates": [{"id": "g1", "kind": "betrayal", "threshold": -25}],
+    })
+    assert generator.validate_adventure(adv) == []
+
+
+def test_positive_attitude_below_agenda_value_flagged():
+    """An attitude_below agenda with a POSITIVE value arms the betrayal at HIGH approval — the
+    same inversion bug; flagged. (Real spines use -20/-30.)"""
+    adv = _adv_with_companion(arc={
+        "arc_gates": [],
+        "agenda": {"trigger": "attitude_below", "value": 20},
+    })
+    problems = generator.validate_adventure(adv)
+    assert any("attitude_below agenda" in p and "POSITIVE" in p for p in problems), problems
+
+
+def test_negative_attitude_below_agenda_value_is_clean():
+    adv = _adv_with_companion(arc={
+        "arc_gates": [],
+        "agenda": {"trigger": "attitude_below", "value": -20},
+    })
+    assert generator.validate_adventure(adv) == []
+
+
+def test_personal_quest_gate_dangling_quest_arc_id_flagged():
+    """A personal_quest gate whose quest_arc_id has no authored companion_quest_arc is a dangling
+    link — the gate can never make a real arc available — and must be flagged."""
+    adv = _adv_with_companion(
+        arc={"arc_gates": [{"id": "g1", "kind": "personal_quest", "threshold": 40,
+                            "quest_arc_id": "cqarc-does-not-exist"}]},
+        quest_arcs=[{"id": "cqarc-real", "companion_id": "companion-vael",
+                     "title": "Real Arc", "stages": []}],
+    )
+    problems = generator.validate_adventure(adv)
+    assert any("personal_quest gate links unknown" in p for p in problems), problems
+
+
+def test_personal_quest_gate_resolving_quest_arc_id_is_clean():
+    """When the quest_arc_id resolves to an authored companion_quest_arc, the link is clean."""
+    adv = _adv_with_companion(
+        arc={"arc_gates": [{"id": "g1", "kind": "personal_quest", "threshold": 40,
+                            "quest_arc_id": "cqarc-real"}]},
+        quest_arcs=[{"id": "cqarc-real", "companion_id": "companion-vael",
+                     "title": "Real Arc", "stages": []}],
+    )
+    assert generator.validate_adventure(adv) == []
+
+
+def test_space_separated_approval_key_flagged():
+    """An approval key with whitespace can never match the engine's token-shaped approval_tags,
+    so the regard move it gates is silently dead — flag it."""
+    adv = _adv_with_companion(dossier={
+        "approval_likes": ["tell_a_hard_truth", "trust the evidence"],  # second key has spaces
+        "approval_dislikes": ["sell_the_grey_water"],
+    })
+    problems = generator.validate_adventure(adv)
+    assert any("contains whitespace" in p and "trust the evidence" in p for p in problems), problems
+
+
+def test_clean_companion_with_arc_and_dossier_validates():
+    """A fully-correct companion (negative betrayal gate, resolving personal_quest link, negative
+    agenda value, whitespace-free approval keys) validates clean — no false positives."""
+    adv = _adv_with_companion(
+        arc={
+            "arc_gates": [
+                {"id": "g1", "kind": "loyalty", "threshold": 20},
+                {"id": "g2", "kind": "personal_quest", "threshold": 40,
+                 "quest_arc_id": "cqarc-vael"},
+                {"id": "g3", "kind": "betrayal", "threshold": -25},
+            ],
+            "agenda": {"trigger": "attitude_below", "value": -20,
+                       "decision_flag": "broke_your_oath"},
+        },
+        dossier={"approval_likes": ["keep_your_word"], "approval_dislikes": ["abandon_an_ally"]},
+        quest_arcs=[{"id": "cqarc-vael", "companion_id": "companion-vael",
+                     "title": "Vael's Oath", "stages": []}],
+    )
+    assert generator.validate_adventure(adv) == []
+
+
+def test_adventure_with_no_companions_is_clean():
+    """The companion pass is fully optional — an adventure with no companions key is untouched."""
+    adv = generator.scaffold_adventure("Solo")
+    assert generator.validate_adventure(adv) == []

--- a/servers/engine/tests/test_seed_campaign_companion_quest_arc.py
+++ b/servers/engine/tests/test_seed_campaign_companion_quest_arc.py
@@ -1,0 +1,79 @@
+"""Regression (audit 2026-06-18) — seed_campaign folds a top-level `companion_quest_arcs` block.
+
+THE BUG (HOLLOW-MILE QUEST-LINK DANGLES): `seed_campaign` folded locations / npcs / companions
+(+ their CompanionArc gates) / factions / hook, but had NO handling of a top-level
+`companion_quest_arcs` block. The authored hollow-mile campaign ships Doctor Eline Mourn with a
+`personal_quest` arc-gate that links `quest_arc_id='cqarc-eline-stillwater'` — but nothing seeded
+that arc, so the link dangled FOREVER at runtime (F06-11 latches a one-shot `link_error` and the
+gate stays locked-but-recoverable). The CompanionQuestArc content path existed only for
+world/ending seeds (`_seed_companion_quest_arcs`), never for an authored adventure module.
+
+THE FIX: `seed_campaign` now folds `adv['companion_quest_arcs']` via the same loader the
+world/overlay paths use (`_seed_companion_quest_arcs_block`) — AFTER the companions loop (so the
+arc's `companion_id` owner exists + is a companion) and AFTER quest seeding (so any `quest_ids`
+projection ref-checks). Additive + degrade-not-abort.
+
+These tests guard:
+  * seed_campaign('hollow-mile') seats the `cqarc-eline-stillwater` arc keyed by id, owned by the
+    real companion, validated through the model.
+  * the personal_quest gate's `quest_arc_id` RESOLVES to the seated arc (no dangle) — the engine's
+    own `_unlock_companion_quest_arc` returns an availability transition, not an `error`.
+  * the fold is additive: an adventure with no `companion_quest_arcs` key seeds nothing.
+
+Single-process only (the host OOMs on parallel pytest; never -n / xdist).
+"""
+
+import content as content_mod
+from companion_arc import _unlock_companion_quest_arc
+
+
+def test_seed_campaign_seats_companion_quest_arc_hollow_mile():
+    """The authored top-level `companion_quest_arcs` block is folded onto the Campaign, keyed by
+    id, owned by the roster companion, and round-tripped through CompanionQuestArc."""
+    adv = content_mod.load_adventure_data("hollow-mile")
+    c = content_mod.seed_campaign(adv)
+
+    arc = c.companion_quest_arcs.get("cqarc-eline-stillwater")
+    assert arc is not None, "seed_campaign must fold the top-level companion_quest_arcs block"
+    assert arc.companion_id == "companion-eline"
+    assert arc.title == "The Cure That Became a Curse"
+    # the owner exists in the roster and is a companion (the ref-check the loader enforces)
+    owner = c.characters.get(arc.companion_id)
+    assert owner is not None and owner.kind == "companion"
+    # the authored stage the personal_quest gate makes available survived the fold
+    assert any(s.id == "cqstage-eline-confession" for s in arc.stages)
+
+
+def test_seed_campaign_personal_quest_gate_link_resolves_no_dangle():
+    """Eline's personal_quest gate links quest_arc_id 'cqarc-eline-stillwater'. After the fold, the
+    engine's own resolution path resolves it to the seated arc/stage with NO link error — proving
+    the gate no longer dangles."""
+    adv = content_mod.load_adventure_data("hollow-mile")
+    c = content_mod.seed_campaign(adv)
+
+    comp = c.characters["companion-eline"]
+    assert comp.arc is not None
+    gate = next(g for g in comp.arc.arc_gates if g.kind == "personal_quest")
+    assert gate.quest_arc_id == "cqarc-eline-stillwater"
+
+    event = _unlock_companion_quest_arc(comp, c, gate)
+    assert event is not None
+    # the load-bearing assertion: the link resolves cleanly — no "no companion quest arc ..." dangle
+    assert "error" not in event, f"gate link still dangles: {event.get('error')!r}"
+    assert event["quest_arc_id"] == "cqarc-eline-stillwater"
+    assert event["stage_id"] == "cqstage-eline-confession"
+    # the gate surfaces the arc + its named stage as available (a real transition, not a no-op)
+    assert event.get("status") == "available"
+    assert event.get("stage_status") == "available"
+
+
+def test_seed_campaign_without_companion_quest_arcs_block_is_a_noop():
+    """The fold is additive: an adventure dict with no `companion_quest_arcs` key seeds nothing
+    (today's behavior for every campaign that doesn't author one)."""
+    adv = {
+        "title": "No-arc adventure",
+        "premise": "x",
+        "companions": [{"id": "comp-1", "name": "Aide"}],
+    }
+    c = content_mod.seed_campaign(adv)
+    assert c.companion_quest_arcs == {}


### PR DESCRIPTION
The remaining confirmed audit regressions (a 3-agent disjoint-file workflow + a pre-existing-test fix):

- **server.py** — dedup duplicate approval_tags (+10 not +20); non-numeric delta → clear ValueError not a crash; `companion_gauge_unauthored` reads dislikes too (dislikes-only companions are gaugeable); **arc parity** — `start_adventure` runs `_seed_companion_operational_state` so adventure companions (Vesper) get a default arc.
- **content.py** — `seed_campaign` folds `companion_quest_arcs` → hollow-mile's quest-link no longer dangles.
- **story_readout.py** — betrayal coverage stamp now reads the ground-truth `agenda.fired` (was keyed on phantom tool names); `acts_reached` capped at the highest *contiguous* act (no more act-skip false-pass).
- **generator.py** — `validate_adventure` gains a companions pass (flags dangling quest-links, positive-threshold betrayal gates, positive agenda values, space-keys) so future spines can't ship these undetected.
- Fixes a pre-existing red test (durable-row additive set missing #995's keys; not in fast_gate so it slipped).

+25 tests; 310 in-scope + fast_gate T0 222 green.