### PR TITLE
feat(engine): acts-engine — runtime act cursor + act-transition cues + advance tools (Phase B 1-3)

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1685,6 +1685,27 @@ class PreludeBeat(_StrictModel):
     ref_id: str = ""      # the bound noun: companion id for 'meeting', grievance/hook id for 'inciting_incident'
 
 
+class NarrativeArc(_StrictModel):
+    """The engine-owned 3-act cursor — a single integer act plus the act-local bookkeeping
+    the 3-act-shape cues / felt-shape scorer read. ENGINE = SOLE WRITER: mutated only by the
+    engine under campaign_lock (persist_beat bumps ``beats_in_act``; advance_act / mark_reversal
+    / mark_climax stamp the rest).
+
+    ADDITIVE: every field is defaulted so this is a valid ``default_factory`` and an old
+    snapshot lacking the ``narrative_arc`` key deserializes to this all-defaulted instance —
+    EMPTY == today (act 1, day 1, no beats, nothing landed) — and round-trips byte-identically
+    under ``_StrictModel`` (extra=forbid). Mirrors the additive idiom of campaign_backlog /
+    scene_debts (present-by-default, empty == today's behavior)."""
+
+    act: int = 1                       # 1/2/3 — the contiguous act the engine ADVANCED into
+    day_act_entered: int = 1           # Campaign.day when the current act began
+    beats_in_act: int = 0              # act-local persist_beat tally (engine bumps each beat)
+    midpoint_reversal_landed: bool = False  # engine sets True when the Act-2 reversal is recorded
+    climax_landed: bool = False        # engine sets True when the Act-3 climax is recorded
+    reversal_day: int = 0              # Campaign.day the reversal landed (0 = not yet) — for day-banding
+    climax_day: int = 0                # Campaign.day the climax landed (0 = not yet)
+
+
 class Campaign(_StrictModel):
     id: str = Field(default_factory=lambda: _new_id("camp"))
     title: str
@@ -1764,6 +1785,13 @@ class Campaign(_StrictModel):
     # companion_quest_arcs; seeded from a world/ending `events` block (content.py). Engine
     # sole-writer (resolve_event under campaign_lock + save_campaign).
     events: dict[str, "Event"] = Field(default_factory=dict)
+    # The engine-owned 3-act cursor (setup -> midpoint reversal -> climax). The 3-act-shape
+    # obligation cues + felt-shape scorer read it; the engine is the SOLE WRITER (persist_beat
+    # ticks beats_in_act, advance_act / mark_reversal / mark_climax stamp the cursor, all under
+    # campaign_lock). Present-by-default with EVERY field defaulted, exactly like campaign_backlog/
+    # faction_arcs/events: EMPTY == today's behavior byte-for-byte, and an old snapshot lacking
+    # the key round-trips to this all-defaulted NarrativeArc (act=1).
+    narrative_arc: NarrativeArc = Field(default_factory=NarrativeArc)
 
     characters: dict[str, Character] = Field(default_factory=dict)  # id -> Character (PCs, companion, NPCs)
     # Intel-tier bestiary codex (#263): creature_slug -> the HIGHEST intel tier the party has

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -202,6 +202,12 @@ def _combatant_ref(ch: Character) -> dict:
 # the model field stays a bare str so OLD logs with legacy kinds still round-trip (additive).
 _LOG_EVENT_KINDS = frozenset({"narration", "dialogue", "roll", "system", "combat"})
 
+# The 3-act-shape act_one_stalled cue thresholds (read in _compute_beat_obligations). Grounded
+# in storycraft.md:38/40 — the scope must WIDEN, never stall in setup; 8 act-local beats ≈ a
+# third of a ~24-beat session. Tunable from a duo A/B without touching the cue logic.
+_ACT1_STALL_DAYS = 4
+_ACT1_STALL_BEATS = 8
+
 
 def _validate_log_kind(kind: str) -> str:
     """Normalize + validate a DM-supplied beat kind against the whitelist (F07-6). Returns
@@ -11424,6 +11430,94 @@ def _compute_beat_obligations(c: Campaign) -> list[dict]:
             "detail": detail,
         })
 
+    # 7. ACT-TRANSITION cues — fold the 3-act-shape mandate (setup -> midpoint reversal ->
+    #    climax) into the every-beat digest by reading the engine-owned NarrativeArc cursor
+    #    (act / day_act_entered / beats_in_act / landed flags). At most ONE fires per beat (the
+    #    cursor is a single integer act, so A/B/C are mutually exclusive). Every field read is a
+    #    defensive getattr, so an arc-less / older / partial NarrativeArc DEGRADES a cue to
+    #    silent rather than raising. ADDITIVE: a fresh/old/default arc sits at act=1,
+    #    day_in_act=0, beats_in_act=0 → Cue C's predicate is False and Cues A/B require act 2/3,
+    #    so ALL three are absent and this block adds NOTHING (byte-identical empty digest).
+    arc = getattr(c, "narrative_arc", None)
+    act = getattr(arc, "act", 1) if arc is not None else None
+    if act in (1, 2, 3):
+        beats_in_act = getattr(arc, "beats_in_act", 0) or 0
+        # ENGINE-ENGAGEMENT GATE (the additive contract): the day-band only counts once the
+        # engine has actually DRIVEN the arc — it bumps beats_in_act every persist_beat and
+        # stamps day_act_entered (a real day) only via advance_act. A pristine/aged-but-never-
+        # advanced Act-1 arc (the default day_act_entered=1 on a campaign whose day clock moved
+        # on its own) is NOT a stalled act — it is "empty == today". So measure elapsed days
+        # only when the arc is engaged (beats bumped, or the engine advanced past Act 1); an
+        # un-engaged arc reads day_in_act=0, exactly as the additive proof requires. This keeps
+        # test_healthy_campaign_yields_no_obligations (day-5 default arc, beats=0) empty.
+        engaged = beats_in_act > 0 or (act is not None and act > 1)
+        if engaged:
+            day_in_act = day - (getattr(arc, "day_act_entered", day) or day)
+        else:
+            day_in_act = 0
+
+        # CUE A — act_midpoint_owed (Act 2: the MIDPOINT REVERSAL is still owed).
+        if (
+            act == 2
+            and not getattr(arc, "midpoint_reversal_landed", False)
+            and (day_in_act >= 2 or beats_in_act >= 4)
+        ):
+            obligations.append({
+                "kind": "act_midpoint_owed",
+                "act": 2,
+                "beats_in_act": beats_in_act,
+                "day_in_act": day_in_act,
+                "severity": "med",
+                "detail": (
+                    "The story is in its rising middle but the MIDPOINT REVERSAL is still owed — "
+                    "the turn the player must absorb (the ally is the informant, the rescue is a "
+                    "trap, the prize is already gone) and a price that lands on them PERSONALLY. "
+                    "Land it now, then record_decision(...) the choice it forces (and call "
+                    "mark_reversal) so the reversal is gauged, not just narrated. A clean "
+                    "escalation with the hero untouched caps the story score at 'very good'."
+                ),
+            })
+
+        # CUE B — act_climax_owed (Act 3: the CLIMAX is still owed). HIGH severity — the climax
+        #    is the load-bearing payoff (the lone other `high` is companion_betrayal deep-red).
+        elif (
+            act == 3
+            and not getattr(arc, "climax_landed", False)
+            and (day_in_act >= 2 or beats_in_act >= 4)
+        ):
+            obligations.append({
+                "kind": "act_climax_owed",
+                "act": 3,
+                "beats_in_act": beats_in_act,
+                "day_in_act": day_in_act,
+                "severity": "high",
+                "detail": (
+                    "This is the final act and the CLIMAX is still owed — converge the threads "
+                    "into a decisive, co-authored confrontation that PAYS OFF what Act 1 set up "
+                    "and what the midpoint cost. Hand the player the discovery and let THEM react "
+                    "(interruptible exchange, never a villain monologue). Resolve the spine quest "
+                    "(complete_quest) and call mark_climax; signal every live named thread in the "
+                    "denouement and open no new sub-plots now."
+                ),
+            })
+
+        # CUE C — act_one_stalled (stuck in Act 1 too long — the beat-cap / slow-burn artifact).
+        elif act == 1 and (day_in_act >= _ACT1_STALL_DAYS or beats_in_act >= _ACT1_STALL_BEATS):
+            obligations.append({
+                "kind": "act_one_stalled",
+                "act": 1,
+                "beats_in_act": beats_in_act,
+                "day_in_act": day_in_act,
+                "severity": "med",
+                "detail": (
+                    f"The setup has run long ({beats_in_act} beats / {day_in_act} days in Act 1) "
+                    "— the inciting hook should have pulled the party into rising action by now. "
+                    "Escalate: turn the local trouble toward the larger thread, raise the stakes a "
+                    "notch, and push past the threshold (advance_act(to_act=2)). A session that "
+                    "lingers in setup reads as a tour, not an adventure."
+                ),
+            })
+
     return obligations
 
 
@@ -12074,6 +12168,12 @@ def persist_beat(
                 # tagged causes, under the SAME lock+save (engine = sole writer). Empty/None
                 # tags == [] (no move), so an untagged decision leg is byte-identical to today.
                 approval_results = _apply_approval_tags(c, decision_approval_tags)
+            # ACT-CURSOR tick (engine = sole writer): one act-local beat per persist_beat that
+            # carries a write, in this same critical section. Drives the 3-act-shape cues
+            # (act_midpoint_owed / act_climax_owed / act_one_stalled) and the felt-shape scorer.
+            # Defensive: a partial/older snapshot lacking the arc is left untouched (additive).
+            if getattr(c, "narrative_arc", None) is not None:
+                c.narrative_arc.beats_in_act += 1
             save_campaign(c)  # ONE atomic write for all of the above
 
     # advance_time as its own locked call (sequential, not nested → no deadlock).
@@ -12115,6 +12215,72 @@ def persist_beat(
         except Exception:
             pass
     return out
+
+
+@mcp.tool()
+def advance_act(campaign_id: str, to_act: int, note: str = "") -> dict:
+    """Advance the engine-owned 3-act cursor when the FICTION crosses an act threshold — the
+    DM-driven boundary verb the act-shape cues lean on (act_one_stalled cues the 1→2 push,
+    act_climax_owed the converge). Sets the act, stamps day_act_entered = the current in-world
+    day, and resets the act-local beat tally. CONTIGUOUS ONLY: the cursor advances by exactly +1
+    (1→2→3); a non-contiguous jump (e.g. 1→3) or a rewind is REJECTED (the cursor never skips an
+    act or runs backward). Engine = sole writer (campaign_lock + save_campaign)."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        arc = c.narrative_arc
+        target = int(to_act)
+        # Only the immediate next act (monotonic +1, capped at 3) is legal. Reject a skip/rewind
+        # with a ValueError naming the legal next act — like persist_beat's degrade-to-advisory,
+        # this surfaces a clear correction rather than silently corrupting the cursor.
+        if target < 1 or target > 3:
+            raise ValueError(f"to_act must be 1, 2, or 3 (got {to_act!r})")
+        legal_next = arc.act + 1
+        if target != legal_next:
+            raise ValueError(
+                f"non-contiguous act advance: cursor is at act {arc.act}; the only legal next act "
+                f"is {legal_next} (acts advance by +1, no skips or rewinds)"
+            )
+        arc.act = target
+        arc.day_act_entered = c.day
+        arc.beats_in_act = 0
+        save_campaign(c)
+        return {"act": arc.act, "day_act_entered": arc.day_act_entered}
+
+
+@mcp.tool()
+def mark_reversal(campaign_id: str) -> dict:
+    """Record that the Act-2 MIDPOINT REVERSAL actually LANDED — the turn the player absorbed.
+    Sets midpoint_reversal_landed=True and stamps reversal_day = the current in-world day. This
+    clears the act_midpoint_owed cue and feeds the felt-shape scorer's day-banding from an
+    engine-stamped day. IDEMPOTENT: a re-call is a no-op that returns the original landed day.
+    Engine = sole writer (campaign_lock + save_campaign)."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        arc = c.narrative_arc
+        if arc.midpoint_reversal_landed:
+            return {"midpoint_reversal_landed": True, "reversal_day": arc.reversal_day}
+        arc.midpoint_reversal_landed = True
+        arc.reversal_day = c.day
+        save_campaign(c)
+        return {"midpoint_reversal_landed": True, "reversal_day": arc.reversal_day}
+
+
+@mcp.tool()
+def mark_climax(campaign_id: str) -> dict:
+    """Record that the Act-3 CLIMAX actually LANDED — the load-bearing payoff. Sets
+    climax_landed=True and stamps climax_day = the current in-world day. This clears the
+    act_climax_owed cue and feeds the felt-shape scorer's day-banding from an engine-stamped day.
+    IDEMPOTENT: a re-call is a no-op that returns the original landed day. Engine = sole writer
+    (campaign_lock + save_campaign)."""
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        arc = c.narrative_arc
+        if arc.climax_landed:
+            return {"climax_landed": True, "climax_day": arc.climax_day}
+        arc.climax_landed = True
+        arc.climax_day = c.day
+        save_campaign(c)
+        return {"climax_landed": True, "climax_day": arc.climax_day}
 
 
 if __name__ == "__main__":

--- a/servers/engine/tests/test_beat_obligations.py
+++ b/servers/engine/tests/test_beat_obligations.py
@@ -24,6 +24,7 @@ from models import (
     CompanionArc,
     CompanionDossier,
     Consequence,
+    NarrativeArc,
     Quest,
 )
 
@@ -479,3 +480,121 @@ def test_scene_context_durable_surfaces_approaching_betrayal(cid):
     sc = server.scene_context(cid)
     assert "obligations" in sc["durable"]
     assert "companion_betrayal_approaching" in _kinds(sc["durable"]["obligations"])
+
+
+# --- act-transition cues (the engine-owned 3-act cursor) --------------------
+#
+# Three mutually-exclusive cues read the NarrativeArc cursor (act / day_act_entered /
+# beats_in_act / landed flags). At most ONE fires per beat (the cursor is a single integer
+# act). An arc-less / default campaign (act=1, day_in_act=0, beats_in_act=0) adds NONE of
+# them — the additive/empty contract (byte-identical empty digest).
+
+
+_ACT_KINDS = {"act_midpoint_owed", "act_climax_owed", "act_one_stalled"}
+
+
+def test_act_midpoint_owed_fires_in_act2_when_reversal_unlanded():
+    """Act 2, reversal not landed, far enough in (day_in_act>=2) -> the midpoint reversal is
+    owed (severity med)."""
+    c = Campaign(title="Arc")
+    c.narrative_arc = NarrativeArc(act=2, day_act_entered=1)
+    c.day = 4  # day_in_act == 3 (>= 2)
+    obligations = server._compute_beat_obligations(c)
+    kinds = _kinds(obligations)
+    assert "act_midpoint_owed" in kinds
+    owed = next(o for o in obligations if o["kind"] == "act_midpoint_owed")
+    assert owed["act"] == 2
+    assert owed["severity"] == "med"
+    assert "REVERSAL" in owed["detail"] or "reversal" in owed["detail"].lower()
+    # mutually exclusive: no other act cue
+    assert kinds & _ACT_KINDS == {"act_midpoint_owed"}
+
+
+def test_act_midpoint_owed_fires_on_beats_threshold():
+    """beats_in_act>=4 trips it even on the day it was entered (day_in_act==0)."""
+    c = Campaign(title="Arc")
+    c.narrative_arc = NarrativeArc(act=2, day_act_entered=1, beats_in_act=4)
+    c.day = 1  # day_in_act == 0, but beats_in_act >= 4
+    assert "act_midpoint_owed" in _kinds(server._compute_beat_obligations(c))
+
+
+def test_act_midpoint_owed_absent_once_reversal_landed():
+    """Once the engine stamps midpoint_reversal_landed, the cue clears."""
+    c = Campaign(title="Arc")
+    c.narrative_arc = NarrativeArc(act=2, day_act_entered=1, midpoint_reversal_landed=True)
+    c.day = 6
+    assert "act_midpoint_owed" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_act_midpoint_owed_silent_early_in_act2():
+    """Just entered Act 2 (day_in_act<2, beats_in_act<4) -> not yet owed."""
+    c = Campaign(title="Arc")
+    c.narrative_arc = NarrativeArc(act=2, day_act_entered=3, beats_in_act=1)
+    c.day = 3  # day_in_act == 0
+    assert "act_midpoint_owed" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_act_climax_owed_fires_in_act3_high_severity():
+    """Act 3, climax unlanded, day_in_act>=2 -> the climax is owed (severity HIGH)."""
+    c = Campaign(title="Arc")
+    c.narrative_arc = NarrativeArc(act=3, day_act_entered=1)
+    c.day = 3  # day_in_act == 2 (>= 2)
+    obligations = server._compute_beat_obligations(c)
+    kinds = _kinds(obligations)
+    assert "act_climax_owed" in kinds
+    owed = next(o for o in obligations if o["kind"] == "act_climax_owed")
+    assert owed["act"] == 3
+    assert owed["severity"] == "high"
+    assert "CLIMAX" in owed["detail"] or "climax" in owed["detail"].lower()
+    assert kinds & _ACT_KINDS == {"act_climax_owed"}
+
+
+def test_act_climax_owed_absent_once_climax_landed():
+    c = Campaign(title="Arc")
+    c.narrative_arc = NarrativeArc(act=3, day_act_entered=1, climax_landed=True)
+    c.day = 8
+    assert "act_climax_owed" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_act_one_stalled_fires_when_setup_runs_long_by_days():
+    """An ENGINE-DRIVEN Act 1 (beats bumped) that has run long on the day-clock
+    (day_in_act>=4, below the beats threshold) -> the setup has run long (severity med).
+    beats_in_act>0 means the engine engaged the arc, so the day-band counts."""
+    c = Campaign(title="Arc")
+    c.narrative_arc = NarrativeArc(act=1, day_act_entered=1, beats_in_act=3)
+    c.day = 5  # day_in_act == 4 (>= _ACT1_STALL_DAYS), beats 3 (< _ACT1_STALL_BEATS)
+    obligations = server._compute_beat_obligations(c)
+    kinds = _kinds(obligations)
+    assert "act_one_stalled" in kinds
+    stalled = next(o for o in obligations if o["kind"] == "act_one_stalled")
+    assert stalled["act"] == 1
+    assert stalled["severity"] == "med"
+    assert "advance_act" in stalled["detail"] or "Act 1" in stalled["detail"]
+    assert kinds & _ACT_KINDS == {"act_one_stalled"}
+
+
+def test_act_one_stalled_fires_on_beats_threshold():
+    """beats_in_act>=8 trips it even early in the day-clock."""
+    c = Campaign(title="Arc")
+    c.narrative_arc = NarrativeArc(act=1, day_act_entered=1, beats_in_act=8)
+    c.day = 1  # day_in_act == 0, but beats_in_act >= _ACT1_STALL_BEATS
+    assert "act_one_stalled" in _kinds(server._compute_beat_obligations(c))
+
+
+def test_act_one_not_stalled_when_setup_is_fresh():
+    """A fresh Act 1 (day_in_act<4, beats_in_act<8) does NOT nag."""
+    c = Campaign(title="Arc")
+    c.narrative_arc = NarrativeArc(act=1, day_act_entered=1, beats_in_act=3)
+    c.day = 3  # day_in_act == 2
+    assert "act_one_stalled" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_arcless_default_campaign_yields_no_act_cues():
+    """The ADDITIVE/EMPTY contract: a default-arc campaign (act=1, day_in_act=0,
+    beats_in_act=0) trips NONE of the three act cues -> byte-identical empty digest."""
+    c = Campaign(title="Arc")  # default narrative_arc
+    c.day = 1
+    obligations = server._compute_beat_obligations(c)
+    assert _kinds(obligations) & _ACT_KINDS == set()
+    # A healthy, companion-less, default-arc beat is still fully empty.
+    assert obligations == []

--- a/servers/engine/tests/test_narrative_arc.py
+++ b/servers/engine/tests/test_narrative_arc.py
@@ -1,0 +1,185 @@
+"""The engine-owned 3-act cursor (NarrativeArc) — model + the engine write points.
+
+WorldOS folds the 3-act-shape mandate (setup -> midpoint reversal -> climax) into a
+single integer cursor the ENGINE owns and advances under campaign_lock. This is the
+canonical contract `Campaign.narrative_arc: NarrativeArc` with field `.act`.
+
+ADDITIVE: an old snapshot lacking the key deserializes to the all-defaulted arc
+(act=1, day_act_entered=1, beats_in_act=0, nothing landed) — empty == today, and it
+round-trips byte-identically under `_StrictModel` (extra=forbid). The engine is the
+SOLE WRITER: persist_beat bumps the act-local beat tally, and advance_act /
+mark_reversal / mark_climax stamp the cursor — each under campaign_lock + save_campaign.
+
+Mirrors test_campaign_backlog.py (the additive-model idiom) and the locked-tool tests.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+import server
+import store
+from models import Campaign, NarrativeArc
+
+
+def _camp(day: int = 1) -> Campaign:
+    return Campaign(title="T", day=day)
+
+
+# --- INCREMENT 1: the model is additive (an empty arc == today's behavior) --------------------
+
+
+def test_default_narrative_arc_is_present_and_all_defaulted():
+    # Present-by-default (not Optional), every field defaulted, so the cursor is a valid
+    # default_factory and EMPTY == today: act 1, day 1, no beats, nothing landed.
+    c = _camp()
+    assert isinstance(c.narrative_arc, NarrativeArc)
+    arc = c.narrative_arc
+    assert arc.act == 1
+    assert arc.day_act_entered == 1
+    assert arc.beats_in_act == 0
+    assert arc.midpoint_reversal_landed is False
+    assert arc.climax_landed is False
+    assert arc.reversal_day == 0
+    assert arc.climax_day == 0
+
+
+def test_old_snapshot_without_narrative_arc_roundtrips_unchanged():
+    # The additive contract: an OLD snapshot dict lacking the key deserializes to the
+    # all-defaulted arc (act=1), and the full dump -> validate -> dump is byte-identical.
+    old = {"title": "Old Hold", "day": 7, "time_of_day": "evening"}
+    c = Campaign.model_validate(old)
+    assert c.narrative_arc.act == 1
+    assert c.narrative_arc.day_act_entered == 1
+    assert c.narrative_arc.beats_in_act == 0
+
+    dumped = c.model_dump(mode="json")
+    assert dumped["narrative_arc"] == {
+        "act": 1,
+        "day_act_entered": 1,
+        "beats_in_act": 0,
+        "midpoint_reversal_landed": False,
+        "climax_landed": False,
+        "reversal_day": 0,
+        "climax_day": 0,
+    }
+    again = Campaign.model_validate(dumped)
+    assert again.model_dump(mode="json") == dumped
+
+
+def test_narrative_arc_rejects_typoed_field():
+    # _StrictModel (extra=forbid) still rejects a typo'd field on the new model.
+    with pytest.raises(ValidationError):
+        NarrativeArc(actt=2)
+
+
+# --- INCREMENT 3: the engine writes (persist_beat tick + the three boundary tools) ------------
+
+
+@pytest.fixture
+def cid(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    c = _camp()
+    store.save_campaign(c)
+    return c.id
+
+
+def test_persist_beat_increments_beats_in_act(cid):
+    # Every persist_beat that carries a write ticks the act-local beat tally by one.
+    before = store.load_campaign(cid).narrative_arc.beats_in_act
+    server.persist_beat(campaign_id=cid, events=[{"kind": "narration", "text": "A beat lands."}])
+    after = store.load_campaign(cid).narrative_arc.beats_in_act
+    assert after == before + 1
+    server.persist_beat(campaign_id=cid, events=[{"kind": "narration", "text": "Another beat."}])
+    assert store.load_campaign(cid).narrative_arc.beats_in_act == before + 2
+
+
+def test_advance_act_sets_act_and_resets_beats(cid):
+    # Bump some beats first so we can prove the reset.
+    server.persist_beat(campaign_id=cid, events=[{"kind": "narration", "text": "x"}])
+    c = store.load_campaign(cid)
+    c.day = 5
+    store.save_campaign(c)
+    out = server.advance_act(cid, 2)
+    arc = store.load_campaign(cid).narrative_arc
+    assert arc.act == 2
+    assert arc.day_act_entered == 5
+    assert arc.beats_in_act == 0
+    assert out["act"] == 2
+    assert out["day_act_entered"] == 5
+
+
+def test_advance_act_rejects_non_contiguous_jump(cid):
+    # Only +1 is legal (1 -> 2 -> 3); a 1 -> 3 jump is rejected, naming the legal next act.
+    with pytest.raises(ValueError):
+        server.advance_act(cid, 3)
+    # The cursor is unchanged after the rejected jump.
+    assert store.load_campaign(cid).narrative_arc.act == 1
+
+
+def test_advance_act_full_chain(cid):
+    server.advance_act(cid, 2)
+    assert store.load_campaign(cid).narrative_arc.act == 2
+    server.advance_act(cid, 3)
+    assert store.load_campaign(cid).narrative_arc.act == 3
+    # No act past 3.
+    with pytest.raises(ValueError):
+        server.advance_act(cid, 4)
+
+
+def test_mark_reversal_stamps_landed_and_day_idempotently(cid):
+    c = store.load_campaign(cid)
+    c.day = 9
+    store.save_campaign(c)
+    server.mark_reversal(cid)
+    arc = store.load_campaign(cid).narrative_arc
+    assert arc.midpoint_reversal_landed is True
+    assert arc.reversal_day == 9
+    # Idempotent: a re-call on a later day keeps the ORIGINAL landed day.
+    c = store.load_campaign(cid)
+    c.day = 12
+    store.save_campaign(c)
+    server.mark_reversal(cid)
+    arc = store.load_campaign(cid).narrative_arc
+    assert arc.midpoint_reversal_landed is True
+    assert arc.reversal_day == 9
+
+
+def test_mark_climax_stamps_landed_and_day_idempotently(cid):
+    c = store.load_campaign(cid)
+    c.day = 14
+    store.save_campaign(c)
+    server.mark_climax(cid)
+    arc = store.load_campaign(cid).narrative_arc
+    assert arc.climax_landed is True
+    assert arc.climax_day == 14
+    c = store.load_campaign(cid)
+    c.day = 20
+    store.save_campaign(c)
+    server.mark_climax(cid)
+    arc = store.load_campaign(cid).narrative_arc
+    assert arc.climax_landed is True
+    assert arc.climax_day == 14
+
+
+# --- INCREMENT 3 end-to-end: the cues now fire on real runs -------------------
+
+
+def test_act_midpoint_owed_fires_end_to_end_via_persist_beat(cid):
+    """With the engine writing the cursor, the Act-2 midpoint cue rides the EVERY-BEAT
+    persist_beat return on a real run (advance to act 2, day moves, beats accumulate)."""
+    server.advance_act(cid, 2)
+    c = store.load_campaign(cid)
+    c.day = 4  # day_in_act >= 2 since day_act_entered was stamped at day 1
+    store.save_campaign(c)
+    out = server.persist_beat(
+        cid, events=[{"kind": "narration", "text": "The middle of the story turns."}]
+    )
+    kinds = {o["kind"] for o in out.get("obligations", [])}
+    assert "act_midpoint_owed" in kinds
+    # Once the reversal is recorded, the cue clears on the next beat.
+    server.mark_reversal(cid)
+    out2 = server.persist_beat(
+        cid, events=[{"kind": "narration", "text": "The party reels from the turn."}]
+    )
+    kinds2 = {o["kind"] for o in out2.get("obligations", [])}
+    assert "act_midpoint_owed" not in kinds2


### PR DESCRIPTION
The audit's deepest finding: the 3-act structure had **zero engine state**. Increments 1–3 of the acts-engine give acts real teeth (additive, engine-sole-writer):

1. **Model** — `NarrativeArc` on `Campaign.narrative_arc` (all fields defaulted → old snapshots round-trip, empty==today).
2. **Cues** — three mutually-exclusive every-beat obligations: `act_midpoint_owed` (the reversal is owed), `act_climax_owed` (high), `act_one_stalled` (the beat-cap artifact). An engine-engagement gate keeps a default arc byte-identical to today.
3. **Writes** — `persist_beat` bumps `beats_in_act`; `advance_act` (contiguous-only), `mark_reversal`, `mark_climax` (idempotent).

+tests; 185 + fast_gate 222 green; the additive guardrail holds. Next: the felt-shape scorer (4–5) reads `narrative_arc.act` + day-bands the reversal/climax so structural_completeness can tell a real 3-act shape from a flat tour.