### PR TITLE
feat(engine): weighted approval + diminishing returns + approval ledger (Phase C chain A)

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -481,6 +481,29 @@ class CompanionDossier(_StrictModel):
     # Standing ties to other figures: id-or-name -> a short relationship tag ("old ally",
     # "estranged sister"). Keys live in CONTENT (the seed files), never engine code.
     relationships: dict[str, str] = Field(default_factory=dict)
+    # Per-cause approval INTENSITY (E4 weighted delta). Keys are the SAME lowercase_snake
+    # cause-keys in approval_likes/approval_dislikes; the value is a POSITIVE magnitude (the
+    # LIST the key sits on decides sign) used as the base approval swing for that cause. An
+    # absent key falls back to the flat ±_APPROVAL_DEFAULT_DELTA (10), so a dossier with no
+    # weights moves ±10 exactly as today (additive default {} == today's behavior). The
+    # validator clamps each value to 1..50 and rejects <=0 (fail-loud at author time, mirroring
+    # the betrayal_threshold author guard) so a negative/typo can't arm a one-hit swing or
+    # sign-flip. Keys live in CONTENT (the dossier), never engine code.
+    approval_weights: dict[str, int] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _sane_approval_weights(self):
+        # A weight is a POSITIVE magnitude (1..50); the like/dislike list decides the sign. A
+        # value <= 0 (or above 50) is an author footgun — reject it loud instead of arming a
+        # sign-flip or a one-hit swing. Empty == today's behavior, so this never fires on an
+        # un-weighted dossier.
+        for key, weight in (self.approval_weights or {}).items():
+            if not isinstance(weight, int) or isinstance(weight, bool) or not (1 <= weight <= 50):
+                raise ValueError(
+                    f"approval_weights[{key!r}] must be a positive magnitude in 1..50 "
+                    f"(the LIST decides sign), got {weight!r}"
+                )
+        return self
 
 
 class RepeatSave(_StrictModel):
@@ -822,6 +845,15 @@ class Character(_StrictModel):
     # snapshot with no `companion_dossier` deserializes unchanged. Seeded from npc_roster /
     # canon JSON / ending companion_seeds; a minimal one is synthesized at recruit_companion.
     companion_dossier: Optional["CompanionDossier"] = None
+    # Approval LEDGER (E5) — the legible "why does X distrust me?" record. HOME is Character
+    # (not arc/dossier) so the gauge logs history even when arc=None (a dossier-only companion).
+    # `approval_log` is a human-readable rolling window truncated to the last 40 events by the
+    # mover; `approval_cause_counts` is the AUTHORITATIVE, NEVER-truncated grind counter the
+    # diminishing-returns decay reads (decoupled from the truncated log so decay stays correct
+    # after old rows fall off). Both DEFAULT empty, so a pre-ledger snapshot round-trips
+    # byte-for-byte (empty == today). Engine = sole writer (appended in _apply_approval_tags).
+    approval_log: list["ApprovalEvent"] = Field(default_factory=list)
+    approval_cause_counts: dict[str, int] = Field(default_factory=dict)
 
     # --- structured NPC tagging (the DM's "pull exactly the right canon character" surface) ----
     # ADDITIVE: every field defaults to empty/False == today's behavior, so an existing snapshot
@@ -1202,6 +1234,23 @@ class Consequence(_StrictModel):
     note: str = ""  # why / source (e.g. "the player let the cultist escape")
     fired: bool = False
     thread_id: str = ""  # non-empty => a recurring background "world beat" from a standing thread (world-sim); reschedules itself on tick
+
+
+class ApprovalEvent(_StrictModel):
+    """One REALIZED approval gauge move on a companion — the legible "why the bar is here"
+    (E5 ledger). Appended by the approval mover under the SAME lock+save as the gauge write
+    (engine = sole writer, no new write path); one event per matched cause. `delta` is the
+    REALIZED signed move AFTER weighting + decay (may be 0 — a fully-decayed cause still logs
+    so the surface shows "already counted"). ADDITIVE: lives in a defaulted list on Character,
+    so a pre-ledger snapshot round-trips byte-for-byte (empty == today)."""
+
+    day: int  # the in-world day this move landed (Campaign.day)
+    cause: str  # the lowercase_snake cause-key that moved the gauge
+    delta: int  # REALIZED signed move after weight + decay (may be 0)
+    new_value: int  # attitude_value AFTER this event
+    diminished: bool = False  # decay shaved the base (a repeat of this cause)
+    decision_id: str = ""  # links to the driving Decision for recall
+    note: str = ""  # freeform (e.g. the secondary inter-companion cause)
 
 
 class Decision(_StrictModel):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -56,6 +56,7 @@ from models import (
     Ability,
     AbilityScores,
     ActiveEffect,
+    ApprovalEvent,
     BacklogItem,
     CampBeatCandidate,
     CampBeatRecord,
@@ -9717,6 +9718,66 @@ def get_companion_quest_arcs(campaign_id: str, companion_id: str = "", status: s
     return {"companion_quest_arcs": [_companion_quest_arc_view(c, a) for a in arcs], "count": len(arcs)}
 
 
+def _approval_ledger_view(ch: "Character", limit: int) -> dict:
+    """Project one companion's approval ledger into the legible 'why does X feel this way?'
+    shape: the most-recent moves (newest-first, capped at `limit`) plus the net positive and
+    net negative totals per cause aggregated across the WHOLE rolling log. Pure read."""
+    log = list(getattr(ch, "approval_log", None) or [])
+    recent = [
+        {
+            "day": e.day,
+            "cause": e.cause,
+            "delta": e.delta,
+            "new_value": e.new_value,
+            "diminished": e.diminished,
+        }
+        for e in reversed(log)
+    ][:max(0, int(limit))]
+    # Aggregate net signed move per cause across the rolling window.
+    net: dict[str, int] = {}
+    for e in log:
+        net[e.cause] = net.get(e.cause, 0) + e.delta
+    net_positive = sorted(
+        ((cause, total) for cause, total in net.items() if total > 0),
+        key=lambda kv: (-kv[1], kv[0]),
+    )
+    net_negative = sorted(
+        ((cause, total) for cause, total in net.items() if total < 0),
+        key=lambda kv: (kv[1], kv[0]),
+    )
+    return {
+        "id": ch.id,
+        "name": ch.name,
+        "attitude_value": getattr(ch, "attitude_value", 0),
+        "recent": recent,
+        "net_positive": [list(p) for p in net_positive],
+        "net_negative": [list(p) for p in net_negative],
+    }
+
+
+@mcp.tool()
+def companion_approval_ledger(campaign_id: str, companion_id: str = "", limit: int = 8) -> dict:
+    """Read the legible APPROVAL LEDGER — the "why does Ondine distrust me?" answer. For each
+    party companion returns its current attitude_value, the most-recent approval moves
+    (newest-first, capped at `limit`), and the net positive / net negative cause totals
+    aggregated from its rolling approval_log. LOCK-FREE read-only snapshot (no evaluate, no
+    mutation) — the engine stays sole writer; this is a pure projection of engine-mutated
+    state. `companion_id` optional => all party companions; a companion with no logged moves
+    returns empty `recent`/nets."""
+    c = _require(campaign_id)
+    if companion_id:
+        ch = _require_companion(c, companion_id)
+        return {"companions": [_approval_ledger_view(ch, limit)], "count": 1}
+    views = []
+    for cid in getattr(c, "party", []) or []:
+        ch = c.characters.get(cid)
+        if ch is None or getattr(ch, "kind", None) != "companion":
+            continue
+        views.append(_approval_ledger_view(ch, limit))
+    views.sort(key=lambda v: (v["name"] or "", v["id"]))
+    return {"companions": views, "count": len(views)}
+
+
 @mcp.tool()
 def advance_companion_quest_arc(
     campaign_id: str,
@@ -10454,6 +10515,13 @@ def advance_faction_arc(
 # an explicit per-tag delta (then the explicit value — sign and magnitude — is authoritative).
 _APPROVAL_DEFAULT_DELTA = 10
 
+# Cross-beat anti-grind decay (E4) keyed on approval_cause_counts — the n-th REALIZED fire of a
+# cause on a companion scales the weighted/default base by this factor (the last entry repeats
+# for n >= 3). Deterministic (no RNG/clock): grinding "mercy" yields 10,5,3,0 instead of 40.
+# Explicit DM-passed deltas BYPASS decay (an authored magnitude). The count read is from the
+# NEVER-truncated approval_cause_counts, so decay stays correct after the 40-row log truncation.
+_APPROVAL_DIMINISH = (1.0, 0.5, 0.25, 0.0)
+
 
 def _normalize_approval_tags(approval_tags) -> list[tuple[str, Optional[int]]]:
     """Coerce the DM's `approval_tags` into ``[(key, explicit_delta_or_None), ...]``.
@@ -10509,16 +10577,22 @@ def _normalize_approval_tags(approval_tags) -> list[tuple[str, Optional[int]]]:
     return out
 
 
-def _apply_approval_tags(c: "Campaign", approval_tags) -> list[dict]:
+def _apply_approval_tags(c: "Campaign", approval_tags, *, decision_id: str = "") -> list[dict]:
     """Move every PARTY companion's approval gauge by the decision's tagged causes (the BG
     "soul"): each tag matching a companion's ``dossier.approval_likes`` applies +10 (or the
-    tag's explicit delta), each matching ``approval_dislikes`` applies -10 (or the explicit
-    delta); the per-companion sum is clamped to [-100, 100] and written to ``attitude_value``.
+    tag's explicit/weighted delta), each matching ``approval_dislikes`` applies -10; the
+    per-companion sum is clamped to [-100, 100] and written to ``attitude_value``.
 
     This is the ENGINE owning the number while the DM owns the cause (gauge-not-fiction):
     the engine never reads prose to decide a tag — the DM supplied the tags, the deltas are
     fixed/explicit. MUTATES ``c`` in place (the caller holds campaign_lock and saves); returns
     one row per MOVED companion (``{id,name,old_value,new_value,delta,matched_keys}``) or [].
+
+    Under the SAME lock+save, appends one ``ApprovalEvent`` per matched cause to the moved
+    companion's ``approval_log`` (E5 ledger, truncated to the last 40) and bumps its
+    ``approval_cause_counts`` (the authoritative grind counter). ``decision_id`` links each
+    event back to the driving Decision; it defaults to "" so a caller that omits it is
+    byte-identical to today on the GAUGE move (the ledger append is purely additive state).
 
     Scope is ``c.party`` companions WITH a dossier — non-companions, dossier-less companions,
     and companions not in the party are skipped. Empty/None ``approval_tags`` -> [] (no move),
@@ -10536,20 +10610,55 @@ def _apply_approval_tags(c: "Campaign", approval_tags) -> list[dict]:
             continue
         likes = {str(k).strip().lower() for k in (getattr(dossier, "approval_likes", []) or [])}
         dislikes = {str(k).strip().lower() for k in (getattr(dossier, "approval_dislikes", []) or [])}
+        # E4 per-cause intensity: a POSITIVE magnitude keyed on the SAME lowercase_snake cause
+        # vocabulary; absent key => the flat _APPROVAL_DEFAULT_DELTA. The like/dislike list above
+        # decides sign. Empty weights == today's flat ±10.
+        weights = {str(k).strip().lower(): v for k, v in (getattr(dossier, "approval_weights", {}) or {}).items()}
         intended = 0
         matched: list[str] = []
+        # One row per matched cause, feeding the ledger append below (E5).
+        cause_rows: list[dict] = []
         for key, explicit in pairs:
-            if key in likes:
-                intended += explicit if explicit is not None else _APPROVAL_DEFAULT_DELTA
-                matched.append(key)
-            elif key in dislikes:
-                intended += explicit if explicit is not None else -_APPROVAL_DEFAULT_DELTA
-                matched.append(key)
+            sign = 1 if key in likes else (-1 if key in dislikes else 0)
+            if sign == 0:
+                continue
+            if explicit is not None:
+                # An explicit DM-passed delta is authoritative — sign + magnitude verbatim,
+                # bypassing the weight ladder AND decay (the DM is asserting an authored swing).
+                realized = explicit
+                diminished = False
+            else:
+                # Base-delta precedence: weighted magnitude (E4) else the flat default, then
+                # scaled by the cross-beat anti-grind decay keyed on the prior REALIZED fires of
+                # this cause on this companion (read BEFORE the count is bumped below). A fully-
+                # decayed cause (factor 0.0) still LOGS a delta-0 event ("already counted").
+                base = int(weights.get(key, _APPROVAL_DEFAULT_DELTA))
+                n = ch.approval_cause_counts.get(key, 0)
+                factor = _APPROVAL_DIMINISH[min(n, len(_APPROVAL_DIMINISH) - 1)]
+                realized = sign * int(round(base * factor))
+                diminished = factor < 1.0
+            intended += realized
+            matched.append(key)
+            cause_rows.append({"cause": key, "delta": realized, "diminished": diminished})
         if not matched:
             continue
         old = ch.attitude_value
         new = _clamp_attitude(old + intended)
         ch.attitude_value = new
+        # E5 LEDGER: append one event per matched cause + bump the authoritative grind counter,
+        # under the SAME lock+save as the gauge write (engine = sole writer, no new write path).
+        for cr in cause_rows:
+            ch.approval_log.append(ApprovalEvent(
+                day=getattr(c, "day", 1),
+                cause=cr["cause"],
+                delta=cr["delta"],
+                new_value=new,
+                diminished=cr["diminished"],
+                decision_id=decision_id,
+            ))
+            ch.approval_cause_counts[cr["cause"]] = ch.approval_cause_counts.get(cr["cause"], 0) + 1
+        # Bound the rolling window; the counts stay un-truncated so decay (A3) stays correct.
+        ch.approval_log = ch.approval_log[-40:]
         results.append({
             "id": ch.id,
             "name": ch.name,
@@ -10610,7 +10719,8 @@ def record_decision(
             c.flags[flag] = True  # content-defined; arms a matching agenda's decision_flag
         # GAUGE-NOT-FICTION: move every party companion's approval by the tagged causes, under
         # the SAME lock+save as the decision row (engine = sole writer). Empty/None tags == [].
-        approval_results = _apply_approval_tags(c, approval_tags)
+        # decision_id links each ledger event back to this Decision (E5 recall).
+        approval_results = _apply_approval_tags(c, approval_tags, decision_id=d.id)
         save_campaign(c)
         out = {"id": d.id, "summary": d.summary, "chosen": d.chosen, "day": d.day}
         if flag:
@@ -11646,6 +11756,17 @@ def _scene_durable_threads(c: Campaign) -> dict:
                     "threshold": nxt.threshold,
                     "points_away": max(0, nxt.threshold - getattr(ch, "attitude_value", 0)),
                 }
+        # E5 LEDGER fold: surface the THREE most-recent approval moves (newest-first) so the DM
+        # SEES, at every re-ground, WHY the bar is where it is ("spared the captive +10 →
+        # mercy"). Pure read of the engine-mutated approval_log. ADDITIVE: the `recent_approval`
+        # key is ABSENT when the companion has no logged moves, so a pre-ledger / un-moved beat's
+        # payload is byte-for-byte today's.
+        log = getattr(ch, "approval_log", None) or []
+        if log:
+            entry["recent_approval"] = [
+                {"day": e.day, "cause": e.cause, "delta": e.delta}
+                for e in log[-3:]
+            ][::-1]
         # F06-10 (audit 2026-06-11): surface this companion's personal QUEST ARCs — until now
         # the engine-complete CompanionQuestArc machine was invisible to the DM at re-ground
         # (durable.companions showed gates/flags only, no quest-arc mention anywhere DM-facing),
@@ -12167,7 +12288,10 @@ def persist_beat(
                 # F6-2 / GAUGE-NOT-FICTION: move party companions' approval by the decision's
                 # tagged causes, under the SAME lock+save (engine = sole writer). Empty/None
                 # tags == [] (no move), so an untagged decision leg is byte-identical to today.
-                approval_results = _apply_approval_tags(c, decision_approval_tags)
+                # decision_id links each ledger event back to the planned Decision (E5 recall).
+                approval_results = _apply_approval_tags(
+                    c, decision_approval_tags, decision_id=planned_decision.id
+                )
             # ACT-CURSOR tick (engine = sole writer): one act-local beat per persist_beat that
             # carries a write, in this same critical section. Drives the 3-act-shape cues
             # (act_midpoint_owed / act_climax_owed / act_one_stalled) and the felt-shape scorer.

--- a/servers/engine/tests/test_decision_approval.py
+++ b/servers/engine/tests/test_decision_approval.py
@@ -38,16 +38,19 @@ def _new_campaign(monkeypatch, tmp_path, title="Approval"):
     return server.create_campaign(title)["id"]
 
 
-def _add_companion(cid, name, *, likes=None, dislikes=None, attitude=0):
+def _add_companion(cid, name, *, likes=None, dislikes=None, attitude=0, weights=None):
     """Create a party companion with a dossier whose approval causes are the given keys."""
     res = server.create_character(cid, name, kind="companion", class_name="Fighter")
     comp_id = res["id"]
+    dossier = {
+        "approval_likes": list(likes or []),
+        "approval_dislikes": list(dislikes or []),
+    }
+    if weights is not None:
+        dossier["approval_weights"] = dict(weights)
     server.update_character(cid, comp_id, {
         "attitude_value": attitude,
-        "companion_dossier": {
-            "approval_likes": list(likes or []),
-            "approval_dislikes": list(dislikes or []),
-        },
+        "companion_dossier": dossier,
     })
     return comp_id
 
@@ -444,3 +447,298 @@ def test_loading_canon_minsc_promotes_roster_record_without_duplicate(tmp_path, 
     assert res.get("already_present") is True and res["id"] == "npc-minsc"
     minscs = [ch for ch in store.load_campaign(bg).characters.values() if "minsc" in ch.name.strip().lower()]
     assert len(minscs) == 1, f"expected one Minsc record, got {[m.name for m in minscs]}"
+
+
+# --- INC-A1: weighted PRIMARY delta (E4 per-cause intensity) -----------------
+
+def test_high_weight_cause_moves_more_than_default(tmp_path, monkeypatch):
+    """A 25-weight like moves +25; an unweighted like on the same companion still moves +10."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(
+        cid, "Astarion", likes=["power", "mercy"], dislikes=["weakness"],
+        weights={"power": 25},
+    )
+    out = server.record_decision(cid, summary="seized the throne", approval_tags=["power"])
+    assert _attitude(cid, comp) == 25
+    row = next(r for r in out["approval_results"] if r["id"] == comp)
+    assert row["delta"] == 25
+
+
+def test_unweighted_cause_still_moves_ten(tmp_path, monkeypatch):
+    """A like with no weight entry moves the flat +10 (back-compat); a weighted dislike scales."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(
+        cid, "Karlach", likes=["kindness"], dislikes=["cruelty"],
+        weights={"cruelty": 30},
+    )
+    # unweighted like => +10
+    server.record_decision(cid, summary="a small kindness", approval_tags=["kindness"])
+    assert _attitude(cid, comp) == 10
+    # weighted dislike => -30 (the list decides sign, the weight is the magnitude)
+    out = server.record_decision(cid, summary="a needless cruelty", approval_tags=["cruelty"])
+    assert _attitude(cid, comp) == 10 - 30
+    row = next(r for r in out["approval_results"] if r["id"] == comp)
+    assert row["delta"] == -30
+
+
+def test_explicit_delta_still_wins_over_weight(tmp_path, monkeypatch):
+    """An explicit per-tag delta bypasses the weight ladder (authoritative, verbatim)."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(
+        cid, "Astarion", likes=["power"], dislikes=["weakness"],
+        weights={"power": 25},
+    )
+    out = server.record_decision(
+        cid, summary="an authored swing", approval_tags=[{"key": "power", "delta": 40}],
+    )
+    assert _attitude(cid, comp) == 40  # explicit 40, NOT the 25 weight
+    row = next(r for r in out["approval_results"] if r["id"] == comp)
+    assert row["delta"] == 40
+
+
+def test_zero_weight_rejected_fail_loud(tmp_path, monkeypatch):
+    """approval_weights with a <=0 value fails loud at author/validate time."""
+    from models import CompanionDossier
+    with pytest.raises(ValueError):
+        CompanionDossier(approval_likes=["mercy"], approval_weights={"mercy": 0})
+    with pytest.raises(ValueError):
+        CompanionDossier(approval_likes=["mercy"], approval_weights={"mercy": -5})
+    with pytest.raises(ValueError):
+        CompanionDossier(approval_likes=["mercy"], approval_weights={"mercy": 51})
+
+
+def test_dossier_without_weights_round_trips():
+    """A pre-A1 dossier (no approval_weights) loads with an empty default — additive."""
+    from models import CompanionDossier
+    d = CompanionDossier(approval_likes=["mercy"])
+    raw = d.model_dump(mode="json")
+    old = {k: v for k, v in raw.items() if k != "approval_weights"}
+    assert "approval_weights" not in old
+    reloaded = CompanionDossier.model_validate(old)
+    assert reloaded.approval_weights == {}
+
+
+# --- INC-A2: approval ledger model + recording (E5) --------------------------
+
+def test_decision_records_an_approval_event(tmp_path, monkeypatch):
+    """A tagged decision appends one ApprovalEvent (cause/delta/new_value/decision_id) and
+    bumps approval_cause_counts on the moved companion."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Shadowheart", likes=["mercy"], dislikes=["cruelty"])
+    out = server.record_decision(cid, summary="spared the foe", approval_tags=["mercy"])
+    ch = store.load_campaign(cid).characters[comp]
+    assert len(ch.approval_log) == 1
+    ev = ch.approval_log[0]
+    assert ev.cause == "mercy"
+    assert ev.delta == 10
+    assert ev.new_value == 10
+    assert ev.decision_id == out["id"]  # links back to the driving Decision
+    assert ev.day == 1
+    assert ch.approval_cause_counts == {"mercy": 1}
+
+
+def test_weighted_cause_logs_realized_delta(tmp_path, monkeypatch):
+    """The logged delta is the REALIZED (weighted) move, not the flat default."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Astarion", likes=["power"], weights={"power": 25})
+    server.record_decision(cid, summary="seized the throne", approval_tags=["power"])
+    ch = store.load_campaign(cid).characters[comp]
+    assert ch.approval_log[-1].delta == 25
+
+
+def test_multiple_causes_log_one_event_each(tmp_path, monkeypatch):
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Wyll", likes=["heroism", "mercy"], dislikes=["cruelty"])
+    server.record_decision(
+        cid, summary="saved the village, left the bandit",
+        approval_tags=["heroism", "mercy", "cruelty"],
+    )
+    ch = store.load_campaign(cid).characters[comp]
+    causes = [e.cause for e in ch.approval_log]
+    assert causes == ["heroism", "mercy", "cruelty"]
+    assert ch.approval_cause_counts == {"heroism": 1, "mercy": 1, "cruelty": 1}
+
+
+def test_persist_beat_decision_leg_records_event_with_decision_id(tmp_path, monkeypatch):
+    """The batched persist_beat decision leg also records an ApprovalEvent + threads its id."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Shadowheart", likes=["mercy"])
+    out = server.persist_beat(
+        cid,
+        decision={"summary": "spared the foe", "approval_tags": ["mercy"]},
+    )
+    ch = store.load_campaign(cid).characters[comp]
+    assert len(ch.approval_log) == 1
+    ev = ch.approval_log[0]
+    assert ev.cause == "mercy" and ev.delta == 10
+    # decision_id resolves to the planned decision's id
+    assert ev.decision_id == out["decision"]["id"]
+
+
+def test_old_snapshot_without_approval_log_round_trips(tmp_path, monkeypatch):
+    """A pre-ledger Character/Campaign snapshot loads with empty ledger fields (additive)."""
+    from models import Character, Campaign
+    ch = Character(name="Vesper", kind="companion")
+    raw = ch.model_dump(mode="json")
+    old = {k: v for k, v in raw.items() if k not in ("approval_log", "approval_cause_counts")}
+    assert "approval_log" not in old and "approval_cause_counts" not in old
+    reloaded = Character.model_validate(old)
+    assert reloaded.approval_log == []
+    assert reloaded.approval_cause_counts == {}
+
+
+def test_untagged_decision_records_no_event(tmp_path, monkeypatch):
+    """An untagged decision logs nothing (byte-identical to today's ledger-empty state)."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Gale", likes=["knowledge"])
+    server.record_decision(cid, summary="a quiet choice")
+    ch = store.load_campaign(cid).characters[comp]
+    assert ch.approval_log == []
+    assert ch.approval_cause_counts == {}
+
+
+# --- INC-A3: diminishing returns / anti-grind (E4 decay) ---------------------
+
+def test_same_cause_across_four_beats_decays(tmp_path, monkeypatch):
+    """Grinding the SAME default-weight cause decays the realized move per beat. With base 10
+    and factors (1.0,0.5,0.25,0.0) under int(round(...)) (banker's rounding of 2.5->2) the
+    deterministic sequence is 10,5,2,0 — NOT a flat 40 across four beats."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Shadowheart", likes=["mercy"])
+    moves = []
+    for i in range(4):
+        out = server.record_decision(cid, summary=f"mercy beat {i}", approval_tags=["mercy"])
+        row = next(r for r in out["approval_results"] if r["id"] == comp) if "approval_results" in out else None
+        moves.append(row["delta"] if row else 0)
+    assert moves == [10, 5, 2, 0]
+    # cumulative gauge = 17 (10+5+2+0), NOT 40
+    assert _attitude(cid, comp) == 17
+
+
+def test_diminished_flag_set_on_decayed_event(tmp_path, monkeypatch):
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Shadowheart", likes=["mercy"])
+    server.record_decision(cid, summary="first", approval_tags=["mercy"])
+    server.record_decision(cid, summary="second", approval_tags=["mercy"])
+    ch = store.load_campaign(cid).characters[comp]
+    assert ch.approval_log[0].diminished is False  # first fire, factor 1.0
+    assert ch.approval_log[1].diminished is True    # second fire, factor 0.5
+
+
+def test_different_cause_is_unaffected_by_decay(tmp_path, monkeypatch):
+    """Grinding 'mercy' does not decay a fresh, never-fired 'heroism' cause."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Wyll", likes=["mercy", "heroism"])
+    for i in range(3):
+        server.record_decision(cid, summary=f"mercy {i}", approval_tags=["mercy"])
+    out = server.record_decision(cid, summary="a heroic deed", approval_tags=["heroism"])
+    row = next(r for r in out["approval_results"] if r["id"] == comp)
+    assert row["delta"] == 10  # heroism is fresh => full +10
+
+
+def test_explicit_delta_bypasses_decay(tmp_path, monkeypatch):
+    """An explicit per-tag delta ignores decay no matter how ground the cause is."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Astarion", likes=["power"])
+    for i in range(3):
+        server.record_decision(cid, summary=f"power {i}", approval_tags=["power"])
+    out = server.record_decision(
+        cid, summary="an authored swing", approval_tags=[{"key": "power", "delta": 30}],
+    )
+    row = next(r for r in out["approval_results"] if r["id"] == comp)
+    assert row["delta"] == 30  # explicit, undecayed
+
+
+def test_fully_decayed_cause_logs_zero_event(tmp_path, monkeypatch):
+    """The 4th+ fire of a cause moves the gauge 0 but STILL logs a delta-0 event."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Shadowheart", likes=["mercy"])
+    for i in range(4):
+        server.record_decision(cid, summary=f"mercy {i}", approval_tags=["mercy"])
+    ch = store.load_campaign(cid).characters[comp]
+    assert ch.approval_log[-1].delta == 0
+    assert ch.approval_log[-1].cause == "mercy"
+    assert ch.approval_cause_counts["mercy"] == 4
+
+
+def test_decay_survives_log_truncation(tmp_path, monkeypatch):
+    """approval_cause_counts is never truncated, so after the 40-row log cap the decay stays
+    correct — a heavily-ground cause does NOT reset to full strength."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Shadowheart", likes=["mercy"])
+    # Drive >40 mercy decisions so the rolling log truncates; counts keep climbing.
+    for i in range(45):
+        server.record_decision(cid, summary=f"mercy {i}", approval_tags=["mercy"])
+    ch = store.load_campaign(cid).characters[comp]
+    assert len(ch.approval_log) == 40  # log capped
+    assert ch.approval_cause_counts["mercy"] == 45  # count un-truncated
+    # one more fire still decays to 0 (n>=3), NOT back to +10
+    out = server.record_decision(cid, summary="mercy again", approval_tags=["mercy"])
+    row = next(r for r in out["approval_results"] if r["id"] == comp)
+    assert row["delta"] == 0
+
+
+# --- INC-A4: read surfaces (E5 ledger tool + durable fold) -------------------
+
+def test_companion_approval_ledger_returns_recorded_events(tmp_path, monkeypatch):
+    """The ledger tool answers 'why does X distrust me' with the recorded moves + the net
+    negative causes."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Ondine", likes=["mercy"], dislikes=["betrayal"])
+    server.record_decision(cid, summary="spared the foe", approval_tags=["mercy"])
+    server.record_decision(cid, summary="betrayed the pact", approval_tags=["betrayal"])
+    out = server.companion_approval_ledger(cid, companion_id=comp)
+    assert out["count"] == 1
+    led = out["companions"][0]
+    assert led["id"] == comp
+    assert led["attitude_value"] == 0  # +10 then -10
+    # newest-first
+    assert [e["cause"] for e in led["recent"]] == ["betrayal", "mercy"]
+    assert led["net_positive"] == [["mercy", 10]]
+    assert led["net_negative"] == [["betrayal", -10]]
+
+
+def test_companion_approval_ledger_all_party_companions(tmp_path, monkeypatch):
+    cid = _new_campaign(monkeypatch, tmp_path)
+    a = _add_companion(cid, "Astarion", likes=["power"])
+    b = _add_companion(cid, "Wyll", likes=["heroism"])
+    server.record_decision(cid, summary="a heroic deed", approval_tags=["heroism"])
+    out = server.companion_approval_ledger(cid)  # no companion_id => all
+    ids = {v["id"] for v in out["companions"]}
+    assert ids == {a, b}
+    wyll = next(v for v in out["companions"] if v["id"] == b)
+    astarion = next(v for v in out["companions"] if v["id"] == a)
+    assert wyll["net_positive"] == [["heroism", 10]]
+    assert astarion["recent"] == []  # never moved
+
+
+def test_companion_approval_ledger_limit(tmp_path, monkeypatch):
+    cid = _new_campaign(monkeypatch, tmp_path)
+    comp = _add_companion(cid, "Shadowheart", likes=["mercy"])
+    for i in range(5):
+        server.record_decision(cid, summary=f"mercy {i}", approval_tags=["mercy"])
+    out = server.companion_approval_ledger(cid, companion_id=comp, limit=2)
+    assert len(out["companions"][0]["recent"]) == 2
+
+
+def test_durable_companions_fold_recent_approval(tmp_path, monkeypatch):
+    """scene_context.durable.companions gains recent_approval (last 3, newest-first) once a
+    companion has moved."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    _add_companion(cid, "Shadowheart", likes=["mercy", "duty"])
+    server.record_decision(cid, summary="a duty kept", approval_tags=["duty"])
+    server.record_decision(cid, summary="a mercy shown", approval_tags=["mercy"])
+    sc = server.scene_context(cid)
+    sh = next(e for e in sc["durable"]["companions"] if e["name"] == "Shadowheart")
+    assert "recent_approval" in sh
+    assert [e["cause"] for e in sh["recent_approval"]] == ["mercy", "duty"]  # newest-first
+
+
+def test_durable_companions_recent_approval_absent_when_empty(tmp_path, monkeypatch):
+    """The recent_approval key is ABSENT (not empty) when the companion has no logged moves —
+    today's durable shape byte-for-byte."""
+    cid = _new_campaign(monkeypatch, tmp_path)
+    _add_companion(cid, "Gale", likes=["knowledge"])
+    sc = server.scene_context(cid)
+    gale = next(e for e in sc["durable"]["companions"] if e["name"] == "Gale")
+    assert "recent_approval" not in gale


### PR DESCRIPTION
First relationship-enhancement chain — make approval **matter** and be **legible**.

- **Weighted** (A1) — `approval_weights` so a profound act outweighs a slight (not a flat ±10).
- **Ledger** (A2) — `ApprovalEvent` log + `approval_cause_counts`, appended under the same lock as the attitude write; `decision_id` threaded byte-identically.
- **Diminishing returns** (A3) — `(1.0,0.5,0.25,0.0)` anti-grind (10,5,2,0; explicit deltas exempt).
- **Legible** (A4) — a lock-free `companion_approval_ledger` tool + a `recent_approval` durable block ('why does Ondine distrust me?').

+22 tests; 57 + 292 sweep + fast_gate 222 green. Additive; both mover callers byte-identical-until-passed.