### PR TITLE
feat(engine): inter-companion approval — stance + secondary delta (Phase C chain B, 1-2/3)

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -445,6 +445,23 @@ class Event(_StrictModel):
     first_presented_day: Optional[int] = None
 
 
+class CompanionStance(_StrictModel):
+    """How a companion stands toward OTHER companions — turns a roster into an ENSEMBLE
+    (E2 inter-companion approval). Keys are OTHER companion IDS (content-owned, never
+    engine-coded). The ally/rival lists drive a SECONDARY, smaller approval delta when a
+    decision sides with/against a NAMED companion: hurting an ally hurts me, siding against
+    a rival pleases me (the inverse-of-an-ally signal).
+
+    ADDITIVE: attached to a CompanionDossier via `stance` (default None), so a stance-less
+    dossier behaves exactly as today (empty == today) and every existing snapshot round-trips
+    byte-for-byte under extra='forbid'."""
+
+    # Companions this one DEFENDS — hurting them hurts me (secondary -delta), helping them helps me.
+    allies: list[str] = Field(default_factory=list)
+    # Companions this one RESENTS — siding against them pleases me (secondary +delta), helping them stings.
+    rivals: list[str] = Field(default_factory=list)
+
+
 class CompanionDossier(_StrictModel):
     """A companion's structured identity — the OPERATIONAL state the engine's living-world
     systems act on (camp scheduling, banter selection, approval causes, companion quest
@@ -481,6 +498,12 @@ class CompanionDossier(_StrictModel):
     # Standing ties to other figures: id-or-name -> a short relationship tag ("old ally",
     # "estranged sister"). Keys live in CONTENT (the seed files), never engine code.
     relationships: dict[str, str] = Field(default_factory=dict)
+    # How this companion stands toward OTHER companions (E2 ENSEMBLE). allies/rivals are lists
+    # of OTHER companion ids that drive a SECONDARY ±_APPROVAL_SECONDARY_DELTA when a decision
+    # sides with/against a named companion (hurt my ally -> I sour; side against my rival -> I
+    # warm). ADDITIVE default None: a stance-less dossier behaves exactly as today (no secondary
+    # moves), so every existing snapshot round-trips unchanged. Keys live in CONTENT, never code.
+    stance: Optional[CompanionStance] = None
     # Per-cause approval INTENSITY (E4 weighted delta). Keys are the SAME lowercase_snake
     # cause-keys in approval_likes/approval_dislikes; the value is a POSITIVE magnitude (the
     # LIST the key sits on decides sign) used as the base approval swing for that cause. An
@@ -1274,6 +1297,12 @@ class Decision(_StrictModel):
     # gauge move happened once, at record time, on the DM-supplied tags). The KEY vocabulary
     # lives in CONTENT (the companion dossiers), never in engine code.
     approval_tags: list[str] = Field(default_factory=list)
+    # The companion this decision SIDES WITH / AGAINST (E2 ENSEMBLE) — an explicit companion id
+    # the DM names so the inter-companion SECONDARY approval delta can ripple onto that
+    # companion's allies/rivals. Stored for RECALL. ADDITIVE default "": an old snapshot with no
+    # `targets_companion` round-trips unchanged, and omitting it leaves the gauge move
+    # byte-identical to today (no secondary pass).
+    targets_companion: str = ""
 
 
 CampBeatKind = Literal["solo", "pair_banter", "arc", "decision_callback"]

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -10515,6 +10515,14 @@ def advance_faction_arc(
 # an explicit per-tag delta (then the explicit value — sign and magnitude — is authoritative).
 _APPROVAL_DEFAULT_DELTA = 10
 
+# Inter-companion SECONDARY swing (E2 ENSEMBLE) — HALF the primary ±10, because "how you treat
+# ANOTHER companion" is a softer signal than how you treat THIS one. When a decision moves a
+# named target companion's gauge, every OTHER party companion whose stance lists the target as
+# an ally/rival feels a smaller ripple: hurt my ally -> -5, side against my rival -> +5 (and the
+# inverses when the decision HELPED the target). The engine owns the magnitude; CONTENT owns the
+# relationship keys (the dossier's stance lists). Empty stance == today (no secondary move).
+_APPROVAL_SECONDARY_DELTA = 5
+
 # Cross-beat anti-grind decay (E4) keyed on approval_cause_counts — the n-th REALIZED fire of a
 # cause on a companion scales the weighted/default base by this factor (the last entry repeats
 # for n >= 3). Deterministic (no RNG/clock): grinding "mercy" yields 10,5,3,0 instead of 40.
@@ -10577,7 +10585,14 @@ def _normalize_approval_tags(approval_tags) -> list[tuple[str, Optional[int]]]:
     return out
 
 
-def _apply_approval_tags(c: "Campaign", approval_tags, *, decision_id: str = "") -> list[dict]:
+def _apply_approval_tags(
+    c: "Campaign",
+    approval_tags,
+    *,
+    targets_companion: str = "",
+    actor_ids=None,
+    decision_id: str = "",
+) -> list[dict]:
     """Move every PARTY companion's approval gauge by the decision's tagged causes (the BG
     "soul"): each tag matching a companion's ``dossier.approval_likes`` applies +10 (or the
     tag's explicit/weighted delta), each matching ``approval_dislikes`` applies -10; the
@@ -10594,6 +10609,24 @@ def _apply_approval_tags(c: "Campaign", approval_tags, *, decision_id: str = "")
     event back to the driving Decision; it defaults to "" so a caller that omits it is
     byte-identical to today on the GAUGE move (the ledger append is purely additive state).
 
+    The mover composes three layers in a FIXED order so the secondary pass can read the
+    primary realized deltas:
+      LAYER 1 (PRIMARY) — the weighted/decayed like/dislike pass above, building a
+        ``primary_by_id`` map of each moved companion's REALIZED signed delta this call.
+      LAYER 2 (RESOLVE TARGET) — pick the companion this decision sided with/against from
+        ``targets_companion`` (the explicit id the DM named).
+      LAYER 3 (SECONDARY / E2 ENSEMBLE) — for each OTHER party companion whose dossier.stance
+        lists the target as ally/rival, apply a smaller ``±_APPROVAL_SECONDARY_DELTA`` keyed
+        on whether the target's primary delta this call was negative (hurt) or positive
+        (helped): {ally,hurt}->-5, {ally,help}->+5, {rival,hurt}->+5, {rival,help}->-5. Each
+        secondary move is clamped once and logged as its own ApprovalEvent (note carries the
+        cause). The secondary NEVER fires on the target itself, on a no-stance companion, or
+        when the target is not a MOVED party companion this call (degrade to no-op — never
+        guess from fiction).
+
+    ``targets_companion``/``actor_ids`` default to ""/None so a caller that omits them is
+    BYTE-IDENTICAL to today (LAYER 3 is a no-op: no target -> no secondary pass).
+
     Scope is ``c.party`` companions WITH a dossier — non-companions, dossier-less companions,
     and companions not in the party are skipped. Empty/None ``approval_tags`` -> [] (no move),
     so the caller's return shape stays byte-identical to today."""
@@ -10601,6 +10634,9 @@ def _apply_approval_tags(c: "Campaign", approval_tags, *, decision_id: str = "")
     if not pairs:
         return []
     results: list[dict] = []
+    # E2: the REALIZED signed primary delta per moved companion this call — LAYER 3 reads it to
+    # decide whether the targeted companion was hurt (<0) or helped (>0).
+    primary_by_id: dict[str, int] = {}
     for cid in getattr(c, "party", []) or []:
         ch = c.characters.get(cid)
         if ch is None or getattr(ch, "kind", None) != "companion":
@@ -10668,6 +10704,71 @@ def _apply_approval_tags(c: "Campaign", approval_tags, *, decision_id: str = "")
             "delta": new - old,
             "matched_keys": matched,
         })
+        # E2 LAYER 3 input: the REALIZED signed delta for the secondary pass to read.
+        primary_by_id[ch.id] = new - old
+
+    # ----- LAYER 2: resolve the TARGETED companion (E2 ENSEMBLE) -----
+    # The 'target' is the companion this decision sided WITH / AGAINST (an explicit id the DM
+    # named via targets_companion). Default "" => no target => the secondary pass below is a
+    # no-op, so a caller that omits targets_companion is byte-identical to today. actor_ids is
+    # accepted for signature-compat / future fallback but the cleanest contract-safe signal is
+    # the explicit target id (never guess the target from who-acted).
+    target_id = (targets_companion or "").strip()
+
+    # ----- LAYER 3: SECONDARY inter-companion pass (E2 ENSEMBLE) -----
+    # Runs ONLY when a target is named AND that target is a party companion that ACTUALLY MOVED
+    # this call (target_id in primary_by_id) with a NON-ZERO realized delta — otherwise there is
+    # no "hurt vs helped" signal to ripple, so skip (degrade to no-op; never guess from fiction).
+    if target_id and target_id in primary_by_id:
+        target_delta = primary_by_id[target_id]
+        if target_delta != 0:
+            helped = target_delta > 0
+            for cid in getattr(c, "party", []) or []:
+                if cid == target_id:
+                    continue  # the secondary NEVER fires on the target itself
+                comp = c.characters.get(cid)
+                if comp is None or getattr(comp, "kind", None) != "companion":
+                    continue
+                dossier = getattr(comp, "companion_dossier", None)
+                stance = getattr(dossier, "stance", None) if dossier is not None else None
+                if stance is None:
+                    continue  # a stance-less companion has no inter-companion signal
+                allies = getattr(stance, "allies", []) or []
+                rivals = getattr(stance, "rivals", []) or []
+                if target_id in allies:
+                    # Hurt my ally -> I sour (-5); help my ally -> I warm (+5).
+                    sec = _APPROVAL_SECONDARY_DELTA if helped else -_APPROVAL_SECONDARY_DELTA
+                    secondary_cause = f"ally_of:{target_id}"
+                elif target_id in rivals:
+                    # Side against my rival -> I warm (+5); help my rival -> I sour (-5).
+                    sec = -_APPROVAL_SECONDARY_DELTA if helped else _APPROVAL_SECONDARY_DELTA
+                    secondary_cause = f"rival_of:{target_id}"
+                else:
+                    continue  # this companion holds no stance toward the target
+                old2 = comp.attitude_value
+                new2 = _clamp_attitude(old2 + sec)  # one clamp per secondary move
+                comp.attitude_value = new2
+                # E5 LEDGER: log the secondary too, so the ledger explains WHY a gauge moved on
+                # a companion the decision never directly tagged. cause is the stance-derived
+                # marker ('sided_against_ally' / 'sided_against_rival' valence is in the note).
+                comp.approval_log.append(ApprovalEvent(
+                    day=getattr(c, "day", 1),
+                    cause=secondary_cause,
+                    delta=new2 - old2,
+                    new_value=new2,
+                    decision_id=decision_id,
+                    note=secondary_cause,
+                ))
+                comp.approval_log = comp.approval_log[-40:]
+                results.append({
+                    "id": comp.id,
+                    "name": comp.name,
+                    "old_value": old2,
+                    "new_value": new2,
+                    "delta": new2 - old2,
+                    "secondary_cause": secondary_cause,
+                })
+
     return results
 
 
@@ -10683,6 +10784,7 @@ def record_decision(
     decision: str = "",
     *,
     approval_tags: Optional[list] = None,
+    targets_companion: str = "",
 ) -> dict:
     """Record a party decision so the DM and companions can call back to it later
     ('last time we trusted Grett...'). Capture the choice after a deliberation:
@@ -10696,7 +10798,14 @@ def record_decision(
     dossier lists a matching `approval_likes` (+10 default) / `approval_dislikes` (-10), the
     ENGINE moves `attitude_value` (clamped to ±100) and reports it under `approval_results`.
     This is how a player's choices turn a companion's arc (the BG "soul") — the DM TAGS the
-    cause, the engine OWNS the number. Omit it (the default) for a choice no companion weighs."""
+    cause, the engine OWNS the number. Omit it (the default) for a choice no companion weighs.
+
+    `targets_companion` (optional) names the companion this decision SIDED WITH / AGAINST
+    (E2 ENSEMBLE). When the named companion's gauge MOVES this call, every OTHER party
+    companion whose dossier.stance lists the target as an ally/rival feels a smaller secondary
+    ripple (hurt my ally -> -5; side against my rival -> +5; the inverses when the target was
+    helped). Omit it (the default) for a choice that doesn't turn on one companion — the
+    gauge move is then byte-identical to today (no secondary pass)."""
     summary = summary if summary else decision  # `decision` is an accepted alias for `summary`
     if not summary:
         raise ValueError("record_decision needs a summary (pass `summary` or its alias `decision`)")
@@ -10712,6 +10821,8 @@ def record_decision(
             # store the DM-supplied causes for RECALL (normalized keys); the gauge move below
             # is applied ONCE here, never re-derived on load.
             approval_tags=[k for k, _ in _normalize_approval_tags(approval_tags)],
+            # the companion this choice sided with/against (E2), stored for recall.
+            targets_companion=(targets_companion or "").strip(),
         )
         c.decisions.append(d)
         flag = sets_flag.strip()
@@ -10719,8 +10830,14 @@ def record_decision(
             c.flags[flag] = True  # content-defined; arms a matching agenda's decision_flag
         # GAUGE-NOT-FICTION: move every party companion's approval by the tagged causes, under
         # the SAME lock+save as the decision row (engine = sole writer). Empty/None tags == [].
-        # decision_id links each ledger event back to this Decision (E5 recall).
-        approval_results = _apply_approval_tags(c, approval_tags, decision_id=d.id)
+        # decision_id links each ledger event back to this Decision (E5 recall). targets_companion
+        # (default "") drives the E2 secondary inter-companion ripple — omitted == today.
+        approval_results = _apply_approval_tags(
+            c, approval_tags,
+            targets_companion=d.targets_companion,
+            actor_ids=d.actor_ids,
+            decision_id=d.id,
+        )
         save_campaign(c)
         out = {"id": d.id, "summary": d.summary, "chosen": d.chosen, "day": d.day}
         if flag:

--- a/servers/engine/tests/test_companion_dossier.py
+++ b/servers/engine/tests/test_companion_dossier.py
@@ -303,3 +303,68 @@ def test_recruit_synthesized_dossier_is_terse(tmp_path, monkeypatch):
     assert all(len(p) <= 200 for p in d["camp_prompts"])  # each clause truncated
     # the dossier does NOT duplicate the long backstory wholesale
     assert long_clause not in d["camp_prompts"]
+
+
+# --- INC-B1: CompanionStance (E2 inter-companion stance), additive ----------
+
+def test_dossier_stance_defaults_none():
+    """A dossier carries no stance by default — empty == today (no inter-companion signal)."""
+    assert CompanionDossier().stance is None
+
+
+def test_companion_stance_empty_lists_default():
+    from models import CompanionStance
+    s = CompanionStance()
+    assert s.allies == [] and s.rivals == []
+
+
+def test_companion_stance_round_trips_a_payload():
+    from models import CompanionStance
+    s = CompanionStance(allies=["comp-a", "comp-b"], rivals=["comp-c"])
+    reloaded = CompanionStance.model_validate(s.model_dump(mode="json"))
+    assert reloaded.allies == ["comp-a", "comp-b"]
+    assert reloaded.rivals == ["comp-c"]
+
+
+def test_dossier_with_stance_round_trips():
+    payload = {
+        "approval_likes": ["mercy"],
+        "stance": {"allies": ["comp-ally"], "rivals": ["comp-rival"]},
+    }
+    d = CompanionDossier.model_validate(payload)
+    assert d.stance is not None
+    assert d.stance.allies == ["comp-ally"] and d.stance.rivals == ["comp-rival"]
+    # full json round-trip is stable
+    reloaded = CompanionDossier.model_validate(d.model_dump(mode="json"))
+    assert reloaded.stance.allies == ["comp-ally"]
+
+
+def test_old_dossier_snapshot_without_stance_loads_none():
+    """A pre-stance dossier snapshot deserializes with stance=None (additive default)."""
+    d = CompanionDossier(approval_likes=["duty"])
+    raw = d.model_dump(mode="json")
+    old = {k: v for k, v in raw.items() if k != "stance"}
+    assert "stance" not in old
+    reloaded = CompanionDossier.model_validate(old)
+    assert reloaded.stance is None
+
+
+def test_old_campaign_snapshot_without_stance_loads():
+    """A whole Campaign snapshot whose dossiers predate `stance` deserializes unchanged."""
+    c = Campaign(title="Pre-stance")
+    ch = Character(name="Ally", kind="companion",
+                   companion_dossier=CompanionDossier(approval_likes=["mercy"]))
+    c.characters[ch.id] = ch
+    c.party.append(ch.id)
+    raw = c.model_dump(mode="json")
+    for cd in raw["characters"].values():
+        if cd.get("companion_dossier") is not None:
+            cd["companion_dossier"].pop("stance", None)
+    reloaded = Campaign.model_validate(raw)
+    assert reloaded.characters[ch.id].companion_dossier.stance is None
+
+
+def test_companion_stance_rejects_unknown_field():
+    from models import CompanionStance
+    with pytest.raises(ValidationError):
+        CompanionStance(enemies=["oops"])  # type: ignore[call-arg]

--- a/servers/engine/tests/test_decision_approval.py
+++ b/servers/engine/tests/test_decision_approval.py
@@ -88,6 +88,23 @@ def test_old_campaign_snapshot_with_tagless_decisions_loads():
     assert reloaded.decisions[0].approval_tags == []
 
 
+# --- INC-B1: Decision.targets_companion (E2 ENSEMBLE), additive --------------
+
+def test_decision_targets_companion_defaults_empty():
+    assert Decision(summary="sided with the rogue").targets_companion == ""
+
+
+def test_old_decision_snapshot_without_targets_companion_round_trips():
+    """A stored Decision predating targets_companion loads unchanged (additive default)."""
+    d = Decision(summary="defended the cleric", chosen="yes")
+    raw = d.model_dump(mode="json")
+    old = {k: v for k, v in raw.items() if k != "targets_companion"}
+    assert "targets_companion" not in old
+    reloaded = Decision.model_validate(old)
+    assert reloaded.targets_companion == ""
+    assert reloaded.summary == "defended the cleric"
+
+
 # --- record_decision: the core mechanic -------------------------------------
 
 def test_like_applies_plus_ten(tmp_path, monkeypatch):


### PR DESCRIPTION
Companions become an ensemble — a companion reacts to how you treat **another**.

- **B1** `CompanionStance` (allies/rivals) on the dossier + `Decision.targets_companion` (additive).
- **B2** a secondary approval delta: a decision targeting a companion moves that companion's allies down / rivals up (after the weighted primary pass, clamped, ledger-logged). Byte-identical when `targets_companion` is omitted.

183 + fast_gate 222 green. (B3, the mutual-rival friction cue, is a small follow-up — a rate limit cut the build agent off before it.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Companions can now have defined ally and rival relationships that factor into approval calculations.
  * Party decisions can now explicitly target a specific companion, triggering secondary approval adjustments to their allies and rivals.

* **Tests**
  * Added comprehensive test coverage for companion relationship handling and decision targeting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->