### PR TITLE
fix(engine): warn on positive attitude_below thresholds at the model layer

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -10,6 +10,7 @@ serves the player, the companion, and all NPCs.
 from __future__ import annotations
 
 import time
+import warnings
 from enum import Enum
 from typing import Any, Literal, Optional
 from uuid import uuid4
@@ -284,6 +285,27 @@ class CompanionAgenda(_StrictModel):
         # IMMEDIATELY (M2). Fail loud at author time instead of silently arming.
         if self.trigger in ("attitude_below", "day_reached") and self.value is None:
             raise ValueError(f"agenda trigger {self.trigger!r} requires an explicit `value`")
+        # A second footgun on the SAME field: a POSITIVE `attitude_below` value. The agenda
+        # fires while `attitude_value < value`, and a freshly-recruited companion seeds at the
+        # neutral default `attitude_value=0` — so a positive breaking point means the bond is
+        # ALREADY past it at recruit and the engine rolls a betrayal from beat 1 with NO player
+        # wrongdoing (the #996 inversion: +20 thresholds armed a betrayal in ~93% of fresh
+        # parties within 5 beats). A betrayal breaking point must be NEGATIVE — the bond has to
+        # actually sour first (real spines use -20/-30). This is the UNCONDITIONAL net beneath
+        # generator.validate_adventure's author-time check: that content-lint is opt-in (it is
+        # NOT run on the seed_campaign path, the snapshot-load path, or the ending-overlay
+        # companion_seeds construction), whereas this validator runs on EVERY construction.
+        # WARN, never raise: a model validator also runs on snapshot LOAD, and the
+        # additive/round-trip invariant forbids failing to load an already-persisted snapshot
+        # (a positive value was always a latent bug, but it must not turn a saved game un-loadable).
+        if self.trigger == "attitude_below" and self.value is not None and self.value > 0:
+            warnings.warn(
+                f"CompanionAgenda attitude_below value={self.value} is POSITIVE: a companion at "
+                f"the neutral seed default (attitude_value=0) is already past this breaking point "
+                f"and will roll a betrayal from recruit with no player wrongdoing. A betrayal "
+                f"threshold must be negative (real spines use -20/-30 — the bond must sour first).",
+                stacklevel=2,
+            )
         return self
 
 

--- a/servers/engine/tests/test_beat_obligations.py
+++ b/servers/engine/tests/test_beat_obligations.py
@@ -362,7 +362,7 @@ def test_scene_context_durable_omits_obligations_on_healthy_fixture(cid):
 # gap that left "betrayals never engage" even though the engine machinery (issue #142) works.
 
 
-def _betrayer(attitude, threshold=18, fired=False, decision_flag="") -> Character:
+def _betrayer(attitude, threshold=-20, fired=False, decision_flag="") -> Character:
     """A companion carrying an attitude_below betrayal agenda (Sergeant Ondine Marsh's shape)."""
     return Character(
         name="Sergeant Ondine Marsh",
@@ -378,15 +378,15 @@ def _betrayer(attitude, threshold=18, fired=False, decision_flag="") -> Characte
 
 def test_betrayal_approaching_fires_when_bond_curdles_past_breaking_point():
     """A live attitude_below agenda + a bond soured into the warning band (regard -30,
-    threshold 18) -> the DM is cued to foreshadow the fracture this beat."""
-    comp = _betrayer(attitude=-30, threshold=18)
+    threshold -20) -> the DM is cued to foreshadow the fracture this beat."""
+    comp = _betrayer(attitude=-30, threshold=-20)
     c = _campaign_with(comp, day=4)
     appr = [o for o in server._compute_beat_obligations(c)
             if o["kind"] == "companion_betrayal_approaching"]
     assert appr, "a curdled betrayal agenda must surface a cue"
     o = appr[0]
     assert o["name"] == "Sergeant Ondine Marsh"
-    assert o["attitude_value"] == -30 and o["threshold"] == 18
+    assert o["attitude_value"] == -30 and o["threshold"] == -20
     assert o["deep_red"] is False  # -30 has not yet passed the deep-red marker (-40)
     assert "REAL attack" in o["detail"]
 
@@ -400,6 +400,10 @@ def test_betrayal_approaching_silent_above_the_breaking_point():
     assert "companion_betrayal_approaching" not in _kinds(server._compute_beat_obligations(c))
 
 
+# The warm (positive) threshold is the DELIBERATE point of this one test — the model validator
+# rightly warns that a positive threshold is an authoring footgun, but here we exercise the
+# engine's defensive robustness (telegraph even a warm-threshold agenda once live), so suppress it.
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_betrayal_approaching_fires_for_a_warm_threshold_agenda_once_live():
     """Regression for the silent-snap window: a content agenda with a warm (positive) threshold
     that is LIVE (regard below it) NOW telegraphs instead of firing from nowhere — the anchor fix."""
@@ -411,7 +415,7 @@ def test_betrayal_approaching_fires_for_a_warm_threshold_agenda_once_live():
 def test_betrayal_approaching_silent_for_warm_companion():
     """The gs-ledger-betray case: even a 'cruel' player ran a liberatory arc, regard rose to
     50 -> the agenda never went live and the cue does NOT false-fire."""
-    comp = _betrayer(attitude=50, threshold=18)
+    comp = _betrayer(attitude=50, threshold=-20)
     c = _campaign_with(comp, day=6)
     assert "companion_betrayal_approaching" not in _kinds(server._compute_beat_obligations(c))
 
@@ -425,7 +429,7 @@ def test_betrayal_approaching_silent_without_agenda():
 
 def test_betrayal_approaching_silent_when_agenda_already_fired():
     """A FIRED agenda is the event itself, not a warning -> never re-cued as approaching."""
-    comp = _betrayer(attitude=-50, threshold=18, fired=True)
+    comp = _betrayer(attitude=-50, threshold=-20, fired=True)
     c = _campaign_with(comp, day=4)
     assert "companion_betrayal_approaching" not in _kinds(server._compute_beat_obligations(c))
 
@@ -433,7 +437,7 @@ def test_betrayal_approaching_silent_when_agenda_already_fired():
 def test_betrayal_approaching_marks_deep_red_and_decision_flag():
     """Deep red (regard past -40) + a recorded decision_flag spike both surface — severity
     rises to high and the cue tells the DM to foreshadow harder."""
-    comp = _betrayer(attitude=-45, threshold=18, decision_flag="took_ferreths_coin")
+    comp = _betrayer(attitude=-45, threshold=-20, decision_flag="took_ferreths_coin")
     c = _campaign_with(comp, day=6)
     c.flags["took_ferreths_coin"] = True
     appr = [o for o in server._compute_beat_obligations(c)
@@ -448,13 +452,13 @@ def test_betrayal_approaching_marks_deep_red_and_decision_flag():
 
 def _make_betrayer_run(cid: str) -> None:
     """Mutate the live campaign: a party companion whose attitude_below agenda has curdled
-    past its breaking point into the warning band (regard -30, threshold 18)."""
+    past its breaking point into the warning band (regard -30, threshold -20)."""
     c = store.load_campaign(cid)
     comp = Character(
         name="Sergeant Ondine Marsh",
         kind="companion",
         attitude_value=-30,
-        arc=CompanionArc(agenda=CompanionAgenda(trigger="attitude_below", value=18)),
+        arc=CompanionArc(agenda=CompanionAgenda(trigger="attitude_below", value=-20)),
     )
     c.characters[comp.id] = comp
     c.party.append(comp.id)

--- a/servers/engine/tests/test_companion_arc.py
+++ b/servers/engine/tests/test_companion_arc.py
@@ -15,6 +15,7 @@ Issue #142 — attitude_below is now a RISING PROBABILITY ROLL:
 """
 
 import random
+import warnings
 
 import pytest
 
@@ -304,7 +305,7 @@ def test_agenda_fire_is_idempotent():
 
 def test_gate_and_agenda_evaluate_together():
     gate = ArcGate(kind="betrayal", threshold=10, note="cracks show")
-    agenda = CompanionAgenda(trigger="attitude_below", value=5)
+    agenda = CompanionAgenda(trigger="attitude_below", value=-5)  # negative breaking point
     ch = _companion(attitude=15, gates=[gate], agenda=agenda)
     c = _campaign_with(ch)
 
@@ -313,7 +314,7 @@ def test_gate_and_agenda_evaluate_together():
     res = companion_arc.evaluate(ch, c, rng=rng)
     assert len(res["newly_unlocked"]) == 1 and res["agenda_fired"] is False
 
-    # approval collapses deep below 5: agenda eventually fires, gate stays unlocked
+    # approval collapses deep below -5: agenda eventually fires, gate stays unlocked
     ch.attitude_value = -90  # near the floor → near-cap P so it fires in few beats
     fired = False
     for _ in range(200):
@@ -425,6 +426,26 @@ def test_threshold_agenda_requires_explicit_value():
     comp = _companion(agenda=CompanionAgenda(trigger="day_reached", value=5))
     assert companion_arc._agenda_triggered(comp, _campaign_with(comp, day=1)) is False
     assert companion_arc._agenda_triggered(comp, _campaign_with(comp, day=5)) is True
+
+
+def test_attitude_below_positive_value_warns():
+    # #996 footgun on the SAME validator: a POSITIVE attitude_below value arms the betrayal
+    # from recruit — a fresh companion seeds at attitude_value=0, already < a positive
+    # threshold, so the engine rolls a turn from beat 1 with NO player wrongdoing (simulated:
+    # +20 -> ~93% of fresh parties betrayed within 5 beats; the negated -20 -> 0%). The model
+    # validator WARNS rather than raises: it runs on snapshot LOAD too, and the round-trip
+    # invariant forbids failing to load an already-saved game. generator.validate_adventure is
+    # the LOUD author-time gate; this is the unconditional net at every construction.
+    with pytest.warns(UserWarning, match="POSITIVE"):
+        CompanionAgenda(trigger="attitude_below", value=20)
+
+    # The correct negative convention, the value==0 boundary (a fresh av=0 is NOT below it),
+    # and a positive day_reached value (a different trigger) must NOT warn.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning in this block becomes a test failure
+        CompanionAgenda(trigger="attitude_below", value=-20)
+        CompanionAgenda(trigger="attitude_below", value=0)
+        CompanionAgenda(trigger="day_reached", value=20)
 
 
 # --- companion quest arcs (#70) ---------------------------------------------


### PR DESCRIPTION
## TL;DR

The reported #996 betrayal footgun (three-knives companions turning from beat 1 with zero
player wrongdoing) **was already fixed before this PR**. This PR adds the **one remaining
defense-in-depth layer** — a model-validator warning — and proves the current state is sound
with a simulation.

## What I found (validate-before-fixing)

The task described the **pre-#999 (#996) state**. On current `main` the content already reads
`"value": -20` for all three companions. Two fixes already landed:

1. **#999** (`4107994`) — removed the inverted positive-threshold betrayal *gates*, negated the
   `attitude_below` agenda values `+20 → -20`, and anchored the telegraph to each agenda's own
   threshold (closing the #983 silent window).
2. **`generator._validate_companions`** — already a committed author-time content lint that flags
   both a positive-threshold betrayal gate **and** a positive `attitude_below` agenda value.

## Simulation evidence (real engine, not a re-impl)

2000 fresh three-knives campaigns × 5 beats, well-treated party (attitude at the seed default,
no decision flags), via `content.seed_campaign` + `companion_arc.evaluate`:

| Content | Early betrayal within 5 beats |
|---|---|
| **REAL `-20` (current `main`, post-#999)** | **0.0%** |
| Mutated `+20` copy (the #996 state) | **93.3%** — reproduces the reported number exactly |

The mutated-copy run confirms the harness faithfully reproduces the reported methodology; the
real-content run confirms the fix holds end-to-end. (Sim was a throwaway; not committed.)

## What this PR actually changes

The only layer left uncovered: **`CompanionAgenda._require_threshold`** — the validator that runs
**unconditionally on every construction**: `seed_campaign`, **snapshot load**, and the
ending-overlay `companion_seeds` path (content.py:1252). `validate_adventure` is an *opt-in* lint
that none of those paths invoke, so the model validator is the only universal net.

- **models.py** — warn (mirroring `validate_adventure`'s message) when an `attitude_below` agenda
  has `value > 0`. **Warn, never raise:** the validator also runs on snapshot load, and the
  additive/round-trip invariant forbids making an already-saved game un-loadable. (The author-time
  hard error already lives in `validate_adventure`.)
- **tests** — `+1` `test_attitude_below_positive_value_warns` (positive warns; `-20`, `0`, and a
  positive `day_reached` do not). Re-anchored stale `+18`/`+5` betrayer fixtures to the correct
  negative convention (behavior-preserving — each attitude stays on the same side of `-20`); the
  one test that *deliberately* exercises a warm/positive threshold (the silent-window regression)
  is marked `filterwarnings(ignore::UserWarning)`.

Three-knives content is **not** touched — #999's `-20` is correct and the sim confirms it. Deeper
per-companion thresholds (e.g. `-25`/`-30` à la ashfall-reach) would be narrative-feel tuning, not
a correctness fix; left to the owner.

## Tests

`uv run --directory servers/engine python -m pytest tests/ -q -p no:xdist` → **2988 passed, 1 failed**.

The single failure — `test_tool_schema_budget` (`list_tools` JSON 120284 B > 120000 B) — **pre-exists
on `main`** (introduced by #1004's Phase C tool surface) and is **unrelated**: the byte count is
**identical with this PR's diff stashed**, so this change adds nothing to the schema. Flagged
separately for the Phase C lane.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation warning when companion agenda configurations incorrectly use positive values for attitude-based triggers, helping users identify and correct configuration issues.

* **Tests**
  * Updated test scenarios to verify warning behavior for companion agenda validation.
  * Added new test to confirm proper warning generation for misconfigured agenda triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->