### PR TITLE
feat(engine): per-tool-call timing sidecar (Wave-1 1A)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -12,9 +12,14 @@ in later epics; this server already owns dice, characters, and persistence.
 from __future__ import annotations
 
 import difflib
+import fcntl
+import functools
+import json
+import os
 import random
 import re
 import sys
+import time
 from typing import Optional
 
 from mcp.server.fastmcp import FastMCP
@@ -110,6 +115,119 @@ from store import load_slot as _load_slot_store
 from store import save_slot as _save_slot_store
 
 mcp = FastMCP("worldos-engine")
+
+
+# ---------------------------------------------------------------------------
+# Per-tool-call timing instrumentation (Wave-1 1A) — pure observability.
+#
+# Default-OFF: the writer is a NO-OP unless WORLDOS_TOOLTIMING_PATH is set, so
+# production pays nothing. When set, every MCP tool call appends ONE JSONL line
+# to that path recording its wall time. This is an EXTERNAL sidecar — it does
+# NOT touch campaign state (no save_campaign / campaign_lock) and never changes
+# a tool's return value, side effects, or JSON schema.
+#
+# Schema neutrality is load-bearing: the wrapper uses functools.wraps(fn) so
+# inspect.signature() and FastMCP's schema generation see the ORIGINAL function
+# (__name__/__doc__/__wrapped__/__annotations__ are preserved). The emitted
+# list_tools() wire shape must stay byte-identical to the un-wrapped baseline.
+#
+# Sidecar line schema (THE CONTRACT — a sibling tool reads this; do not drift):
+#   {"ts": <float unix epoch s>, "tool": "<name>", "wall_ms": <float>,
+#    "ok": <bool>, "campaign_id": <str or null>}
+# ---------------------------------------------------------------------------
+
+
+def _timing_campaign_id(args: tuple, kwargs: dict):
+    """Best-effort, cheap, never-raising extraction of a campaign_id for the
+    sidecar: a ``campaign_id`` kwarg wins, else the first positional arg if it
+    is a str, else None. (Most state-mutating engine tools take campaign_id as
+    their first parameter.)"""
+    try:
+        cid = kwargs.get("campaign_id")
+        if isinstance(cid, str):
+            return cid
+        if args and isinstance(args[0], str):
+            return args[0]
+    except Exception:
+        pass
+    return None
+
+
+def _record_tool_timing(tool_name: str, wall_ms: float, ok: bool, campaign_id, ts: float) -> None:
+    """Append one timing line to WORLDOS_TOOLTIMING_PATH. NO-OP when the env var
+    is unset/empty (this is what keeps production impact zero). Best-effort: the
+    entire writer is guarded so a sidecar-write failure can NEVER propagate into
+    the tool call or change its result. flock-append mirrors player_server.py so
+    concurrent engine writers can't interleave a half-written JSONL line."""
+    path = os.environ.get("WORLDOS_TOOLTIMING_PATH")
+    if not path:
+        return
+    try:
+        line = json.dumps(
+            {
+                "ts": ts,
+                "tool": tool_name,
+                "wall_ms": wall_ms,
+                "ok": ok,
+                "campaign_id": campaign_id if isinstance(campaign_id, str) else None,
+            },
+            separators=(",", ":"),
+        )
+        with open(path, "a", encoding="utf-8") as f:
+            try:
+                fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            except OSError:
+                pass
+            f.write(line + "\n")
+            f.flush()
+            try:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+    except Exception:
+        # Observability must never break a tool call. Swallow everything.
+        pass
+
+
+_orig_tool = mcp.tool
+
+
+def _timed_tool(*dargs, **dkwargs):
+    """Drop-in replacement for ``mcp.tool`` that times every subsequently-
+    registered tool. Returns a decorator which wraps the target fn (preserving
+    its identity via functools.wraps so the emitted schema is byte-identical),
+    then registers the wrapped fn through the ORIGINAL ``mcp.tool`` decorator."""
+
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapped(*args, **kwargs):
+            ts = time.time()
+            start = time.perf_counter()
+            ok = True
+            try:
+                return fn(*args, **kwargs)
+            except BaseException:
+                ok = False
+                raise
+            finally:
+                wall_ms = (time.perf_counter() - start) * 1000.0
+                _record_tool_timing(
+                    getattr(fn, "__name__", "<unknown>"),
+                    wall_ms,
+                    ok,
+                    _timing_campaign_id(args, kwargs),
+                    ts,
+                )
+
+        return _orig_tool(*dargs, **dkwargs)(wrapped)
+
+    return decorator
+
+
+# Reassign the instance attribute so every later ``@mcp.tool()`` is wrapped.
+# FastMCP.tool is a plain method (not a slot/property), so an instance-level
+# attribute cleanly shadows it for all subsequent registrations.
+mcp.tool = _timed_tool
 
 
 def _parse_ability(value: str) -> Ability:

--- a/servers/engine/tests/test_tool_timing.py
+++ b/servers/engine/tests/test_tool_timing.py
@@ -1,0 +1,123 @@
+"""Per-tool-call timing sidecar (Wave-1 1A) — observability contract tests.
+
+The engine wraps every ``@mcp.tool()`` with a timing shim that, ONLY when
+``WORLDOS_TOOLTIMING_PATH`` is set, appends one JSONL line per tool call to that
+path. This file pins the three load-bearing guarantees:
+
+  1. env SET   -> a matching JSONL line per call, all five keys, correct types,
+                  and the ``tool`` name == the tool actually called.
+  2. env UNSET -> NO file written and NO error (the production NO-OP path).
+  3. a tool that RAISES still emits a timing line with ``ok: false`` (the
+     ``finally:`` records failures too).
+
+A sibling tool reads this sidecar, so the schema is a contract:
+  {"ts": float, "tool": str, "wall_ms": float, "ok": bool,
+   "campaign_id": str|None}
+"""
+
+import json
+
+import pytest
+
+import server
+
+
+@pytest.fixture(autouse=True)
+def isolated_state(tmp_path, monkeypatch):
+    # Each test gets its own campaign-state dir so real tools persist cleanly.
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path / "state"))
+    yield
+
+
+def _read_lines(path):
+    text = path.read_text(encoding="utf-8")
+    return [json.loads(ln) for ln in text.splitlines() if ln.strip()]
+
+
+EXPECTED_KEYS = {"ts", "tool", "wall_ms", "ok", "campaign_id"}
+
+
+def _assert_well_formed(rec):
+    assert set(rec.keys()) == EXPECTED_KEYS, rec
+    assert isinstance(rec["ts"], float)
+    assert isinstance(rec["tool"], str) and rec["tool"]
+    assert isinstance(rec["wall_ms"], float)
+    assert rec["wall_ms"] >= 0.0
+    assert isinstance(rec["ok"], bool)
+    assert rec["campaign_id"] is None or isinstance(rec["campaign_id"], str)
+
+
+def test_sidecar_records_each_tool_call(tmp_path, monkeypatch):
+    sidecar = tmp_path / "tooltiming.jsonl"
+    monkeypatch.setenv("WORLDOS_TOOLTIMING_PATH", str(sidecar))
+
+    # Call a few REAL tools: a world-seed mutation then a read tool.
+    res = server.start_world("baldurs-gate")
+    cid = res["campaign_id"]
+    server.look_around(cid)
+    server.list_worlds()
+
+    assert sidecar.exists(), "sidecar file was not written while env var was set"
+    recs = _read_lines(sidecar)
+    assert len(recs) == 3, f"expected one line per tool call, got {len(recs)}: {recs}"
+
+    for rec in recs:
+        _assert_well_formed(rec)
+
+    by_tool = [r["tool"] for r in recs]
+    assert by_tool == ["start_world", "look_around", "list_worlds"], by_tool
+
+    # campaign_id best-effort: look_around's first positional arg is the campaign id.
+    look = next(r for r in recs if r["tool"] == "look_around")
+    assert look["campaign_id"] == cid
+    assert look["ok"] is True
+
+    start = next(r for r in recs if r["tool"] == "start_world")
+    assert start["ok"] is True
+    # start_world's first positional arg is a world_id (a str), so the best-effort
+    # campaign_id grab returns that world_id verbatim — the contract is "first
+    # positional str", not "a validated campaign id".
+    assert start["campaign_id"] == "baldurs-gate"
+
+    # list_worlds takes no args -> campaign_id is null.
+    lw = next(r for r in recs if r["tool"] == "list_worlds")
+    assert lw["campaign_id"] is None
+    assert lw["ok"] is True
+
+
+def test_no_sidecar_when_env_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("WORLDOS_TOOLTIMING_PATH", raising=False)
+    would_be = tmp_path / "should_not_exist.jsonl"
+
+    # Calling a tool must neither write a file nor raise.
+    res = server.start_world("baldurs-gate")
+    server.look_around(res["campaign_id"])
+
+    assert not would_be.exists()
+    # No file should appear anywhere in tmp from the timing writer.
+    assert not list(tmp_path.glob("*.jsonl"))
+
+
+def test_empty_env_is_noop(tmp_path, monkeypatch):
+    # An empty (falsy) path must behave like unset — no write, no error.
+    monkeypatch.setenv("WORLDOS_TOOLTIMING_PATH", "")
+    server.start_world("baldurs-gate")
+    assert not list(tmp_path.glob("*.jsonl"))
+
+
+def test_failing_tool_still_records_ok_false(tmp_path, monkeypatch):
+    sidecar = tmp_path / "tooltiming.jsonl"
+    monkeypatch.setenv("WORLDOS_TOOLTIMING_PATH", str(sidecar))
+
+    # look_around on a non-existent campaign raises (via _require) — the timing
+    # line must still be emitted from the finally: block with ok=false.
+    with pytest.raises(Exception):
+        server.look_around("camp_does_not_exist")
+
+    recs = _read_lines(sidecar)
+    assert len(recs) == 1, recs
+    rec = recs[0]
+    _assert_well_formed(rec)
+    assert rec["tool"] == "look_around"
+    assert rec["ok"] is False
+    assert rec["campaign_id"] == "camp_does_not_exist"


### PR DESCRIPTION
## Wave-1 1A — per-tool-call timing instrumentation

Pure observability, **additive, default-OFF in production**. Wraps every `@mcp.tool()` registration once (right after `mcp = FastMCP(...)`) so each tool call records its wall time to a JSONL sidecar **only when `WORLDOS_TOOLTIMING_PATH` is set** — production pays nothing.

### Why
We have per-*beat* generation timing (`duration_api_ms` → `latency_rollup`) but **no per-tool-call timing** — so "did this combat turn cost 3 min in the tool or in generation?" is unanswerable. This is the missing sub-beat granularity (the latency-forensics skill's authoritative tool-vs-generation split).

### What
- A timing decorator that delegates to the original `mcp.tool` via `functools.wraps(fn)` → **the emitted JSON schema is byte-identical** (verified: list_tools = 120,284 B before and after).
- Best-effort flock-append writer; the entire writer is `try/except` so a sidecar failure can never reach the tool call. Writes to an **external** sidecar — never through `save_campaign`/`campaign_lock` (engine sole-writer invariant intact).
- Timing recorded in a `finally:` (failures timed too, `ok:false`).

### Sidecar contract (consumed by the Wave-1 1B rollup)
`{"ts": <float unix epoch s>, "tool": "<name>", "wall_ms": <float>, "ok": <bool>, "campaign_id": <str|null>}`

### Tests
- New `tests/test_tool_timing.py` (4): env-set records correct lines; env-unset/empty writes nothing & never raises; a raising tool still emits `ok:false`.
- `qa/fast_gate.sh` tier-0 **222 passed**. Sanity slices exercising many real tool calls through the wrapper: 92 passed.
- Note: `test_list_tools_json_under_budget` is RED on **both** baseline and this branch at the identical 120,284 B — pre-existing SYN-02 (284 B over budget), **not** introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic per-tool execution timing observability that records wall-time and success/failure status when enabled via configuration.

* **Tests**
  * Added new automated tests validating JSONL timing output, including behavior when the feature is disabled and ensuring failures are still recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->