### PR TITLE
feat(qa): per-kind + per-tool timing rollup → scoring (Wave-1 1B)

### DIFF
--- a/qa/latency_rollup.py
+++ b/qa/latency_rollup.py
@@ -61,6 +61,27 @@ SIDECAR_COLUMNS = ("s_per_beat", "coldopen_s", "turns_per_beat")
 # A beat transcript is "<run>.dm.<nanoseconds>.jsonl"; capture the nanos for beat ordering.
 _DM_RE = re.compile(r"\.dm\.(\d+)\.jsonl$")
 
+# ---------------------------------------------------------------------------
+# Per-beat KIND attribution (Wave-1 1B). A beat's "kind" is read straight from the
+# tool_use names IN that beat's transcript — no sidecar needed. The earliest beat is the
+# COLD-OPEN (the one-time world-build); after that, a beat that fired a COMBAT tool is
+# `combat`, one that fired a CAMP/REST tool is `camp`, else `social`. Combat is checked
+# BEFORE camp so a beat that both fights and then rests reads as combat (the heavier kind).
+# Names match the engine's MCP tool names (server.py); transcripts carry them MCP-prefixed
+# (mcp__engine__attack) — we strip the prefix the same way story_readout does.
+_COMBAT_TOOLS = frozenset({
+    "start_combat", "attack", "make_attack", "cast_spell", "use_action", "use_resource",
+    "resolve_death_save", "death_save", "end_combat",
+})
+_CAMP_TOOLS = frozenset({"camp_scene", "long_rest", "record_camp_beat"})
+_BEAT_KINDS = ("cold-open", "combat", "camp", "social")
+
+
+def _short_tool(name: str) -> str:
+    """Bare engine tool name from a possibly MCP-prefixed tool_use name.
+    ``mcp__engine__attack`` -> ``attack`` (matches story_readout's ``.split("__")[-1]``)."""
+    return str(name or "").split("__")[-1]
+
 
 def _final_result(path: str | Path) -> Optional[dict]:
     """Return the LAST ``type=="result"`` event in a stream-json transcript, or None.
@@ -148,6 +169,55 @@ def _token_aggregates(rows: list[dict]) -> Optional[dict]:
         }
 
     return {"coldopen": block(rows[:1]), "routine": block(rows[1:])}
+def _wall_ms_from_result(res: dict) -> Optional[float]:
+    """Wall-clock ``duration_ms`` for a beat (generation + tool/orchestration time). None
+    when absent. Used only as the tool_exec_pct denominator (the WHOLE beat wall cost)."""
+    ms = res.get("duration_ms")
+    if not isinstance(ms, (int, float)):
+        return None
+    return max(0.0, float(ms))
+
+
+def _beat_tool_names(path: str | Path) -> set[str]:
+    """The set of (short) engine tool names used in one beat transcript.
+
+    Scans for ``tool_use`` events and collects their (de-prefixed) names. Tolerant of the
+    system/hook noise the harness prepends and of partial/garbage lines (a crashed beat may
+    leave a half-written file). Cheap, line-keyed pre-filter so we only json.loads lines that
+    could carry a tool_use."""
+    names: set[str] = set()
+    try:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                if '"tool_use"' not in line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                msg = obj.get("message") if isinstance(obj, dict) else None
+                content = msg.get("content") if isinstance(msg, dict) else None
+                if not isinstance(content, list):
+                    continue
+                for c in content:
+                    if isinstance(c, dict) and c.get("type") == "tool_use":
+                        names.add(_short_tool(c.get("name", "")))
+    except OSError:
+        return names
+    return names
+
+
+def _classify_kind(tool_names: set[str], *, is_cold_open: bool) -> str:
+    """Classify a beat from the tool names it fired. cold-open wins (it is positional, not
+    tool-derived); else combat > camp > social. Combat outranks camp so a beat that fights
+    then rests is attributed to the heavier kind."""
+    if is_cold_open:
+        return "cold-open"
+    if tool_names & _COMBAT_TOOLS:
+        return "combat"
+    if tool_names & _CAMP_TOOLS:
+        return "camp"
+    return "social"
 
 
 def beat_files(transcript_dir: str | Path, run_id: str) -> list[str]:
@@ -158,18 +228,120 @@ def beat_files(transcript_dir: str | Path, run_id: str) -> list[str]:
     return files
 
 
-def rollup_files(files: list[str]) -> dict[str, Any]:
+# ---------------------------------------------------------------------------
+# Tool-exec split (Wave-1 1B) — read the OPTIONAL 1A tool-timing sidecar.
+# ---------------------------------------------------------------------------
+# THE CONTRACT (produced by the engine, one JSON object per line):
+#   {"ts": <float unix epoch s>, "tool": "<name>", "wall_ms": <float>,
+#    "ok": <bool>, "campaign_id": <str|null>}
+# This is the AUTHORITATIVE per-tool wall-clock — the rollup's per-beat `duration_api_ms`
+# can't see in-tool time, so engine tool-exec cost only becomes visible via this sidecar.
+# Best-effort + tolerant: a missing/empty/garbled file yields no rows (the three derived
+# keys then degrade to None), and a row missing `wall_ms`/`tool` is skipped, never raised.
+
+
+def read_tool_timing(path: str | Path) -> list[dict[str, Any]]:
+    """Parse the 1A tool-timing JSONL sidecar into a list of ``{tool, wall_ms, ok, ...}`` rows.
+
+    Tolerant: a missing file -> ``[]``; blank lines and unparseable lines are skipped; a row
+    that is not an object, or lacks a string ``tool`` or a numeric ``wall_ms``, is skipped
+    (a partial/garbled sidecar degrades to fewer rows, never an exception)."""
+    rows: list[dict[str, Any]] = []
+    p = Path(path)
+    if not p.exists():
+        return rows
+    try:
+        with p.open("r", encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                tool = obj.get("tool")
+                wall = obj.get("wall_ms")
+                if not isinstance(tool, str) or not tool:
+                    continue
+                if not isinstance(wall, (int, float)):
+                    continue
+                rows.append(obj)
+    except OSError:
+        return rows
+    return rows
+
+
+def _tool_exec_split(rows: list[dict[str, Any]], total_wall_s: Optional[float],
+                     total_api_s: Optional[float]) -> dict[str, Any]:
+    """Compute ``mean_tool_call_ms`` / ``slowest_tool`` / ``tool_exec_pct`` from sidecar rows.
+
+    * ``mean_tool_call_ms``: mean of every row's ``wall_ms``.
+    * ``slowest_tool``: the tool with the largest TOTAL ``wall_ms`` summed across its calls
+      (the biggest cumulative cost, not a single slow outlier).
+    * ``tool_exec_pct``: total tool wall-seconds / the beat-time denominator. We prefer the
+      WHOLE-BEAT wall total (sum of each beat's ``duration_ms`` — generation + tool +
+      orchestration), since tool-exec is a fraction OF the whole beat; that is the honest
+      denominator. When no beat carried ``duration_ms`` we fall back to the total GENERATION
+      seconds (sum of ``duration_api_ms``) and the pct is then "tool wall vs generation",
+      which over-states slightly because generation excludes the tool/orchestration the tools
+      themselves consumed — flagged in the rollup via ``tool_exec_pct_basis``.
+
+    All three are None when there are no usable rows. tool_exec_pct is additionally None when
+    neither denominator is available/positive."""
+    out: dict[str, Any] = {
+        "mean_tool_call_ms": None,
+        "slowest_tool": None,
+        "tool_exec_pct": None,
+        "tool_exec_pct_basis": None,
+    }
+    if not rows:
+        return out
+
+    walls = [float(r["wall_ms"]) for r in rows]
+    out["mean_tool_call_ms"] = round(sum(walls) / len(walls), 1)
+
+    by_tool: dict[str, float] = {}
+    for r in rows:
+        by_tool[r["tool"]] = by_tool.get(r["tool"], 0.0) + float(r["wall_ms"])
+    # largest TOTAL wall_ms; ties broken by name for determinism.
+    out["slowest_tool"] = max(sorted(by_tool), key=lambda t: by_tool[t]) if by_tool else None
+
+    tool_s = sum(walls) / 1000.0
+    if total_wall_s is not None and total_wall_s > 0:
+        out["tool_exec_pct"] = round(tool_s / total_wall_s, 4)
+        out["tool_exec_pct_basis"] = "duration_ms"        # whole-beat wall (the honest denominator)
+    elif total_api_s is not None and total_api_s > 0:
+        out["tool_exec_pct"] = round(tool_s / total_api_s, 4)
+        out["tool_exec_pct_basis"] = "duration_api_ms"    # generation-only fallback (over-states)
+    return out
+
+
+def rollup_files(files: list[str], tooltiming: str | Path | None = None) -> dict[str, Any]:
     """Roll a beat-ordered list of DM transcript paths up into the latency ledger.
 
     Returns ``{s_per_beat, coldopen_s, turns_per_beat, beats, cold_open_turns,
-    failed_beats}``. The latency columns are None when there is no data to derive them
-    from (no successful beats / no continuing beat), so an empty run records NULL rather
-    than a misleading 0."""
+    failed_beats}`` plus the Wave-1 1B additions:
+      * per-kind GENERATION means derived from the transcripts alone (no sidecar):
+        ``combat_s_per_beat`` / ``social_s_per_beat`` / ``camp_s_per_beat`` — mean
+        ``duration_api_ms`` seconds over the SUCCESSFUL beats of that kind (the cold-open
+        beat is its OWN kind and excluded from all three; None when no beat of that kind).
+      * a tool-exec split from the OPTIONAL 1A ``tooltiming`` sidecar:
+        ``mean_tool_call_ms`` / ``slowest_tool`` / ``tool_exec_pct`` (+ ``tool_exec_pct_basis``).
+        DEGRADES GRACEFULLY — when ``tooltiming`` is None/missing/empty these are None and
+        the rest of the rollup is byte-for-byte unchanged.
+
+    The base latency columns are None when there is no data to derive them from (no successful
+    beats / no continuing beat), so an empty run records NULL rather than a misleading 0."""
     api_s: list[float] = []          # successful-beat generation seconds, in beat order
     turns: list[float] = []          # successful-beat num_turns, in beat order
     usage_rows: list[dict] = []      # successful-beat token usage + ttft, in beat order
+    wall_s: list[float] = []         # successful-beat WHOLE-BEAT wall seconds (duration_ms), beat order
+    kinds: list[str] = []            # successful-beat kind, in beat order (parallel to api_s)
     failed = 0
-    for path in files:
+    for i, path in enumerate(files):
         res = _final_result(path)
         if res is None:
             continue
@@ -183,6 +355,10 @@ def rollup_files(files: list[str]) -> dict[str, Any]:
         api_s.append(secs)
         turns.append(float(n) if isinstance(n, (int, float)) else 0.0)
         usage_rows.append(_usage(res))
+        w = _wall_ms_from_result(res)
+        wall_s.append(w / 1000.0 if w is not None else 0.0)
+        # Kind: the EARLIEST beat (i == 0 in the cold-open-first ordering) is the cold open.
+        kinds.append(_classify_kind(_beat_tool_names(path), is_cold_open=(i == 0)))
 
     out: dict[str, Any] = {
         "s_per_beat": None,
@@ -194,6 +370,15 @@ def rollup_files(files: list[str]) -> dict[str, Any]:
         # Additive (slab decision, Phase 3): per-beat token/cache ledger for the tiering A/B.
         # cold-open vs routine means of cache_creation / cache_read / input / output / ttft_ms.
         "tokens": _token_aggregates(usage_rows),
+        # Wave-1 1B per-kind generation means (None until proven by a beat of that kind).
+        "combat_s_per_beat": None,
+        "social_s_per_beat": None,
+        "camp_s_per_beat": None,
+        # Wave-1 1B tool-exec split (None unless a usable sidecar is supplied).
+        "mean_tool_call_ms": None,
+        "slowest_tool": None,
+        "tool_exec_pct": None,
+        "tool_exec_pct_basis": None,
     }
     if not api_s:
         return out
@@ -206,12 +391,33 @@ def rollup_files(files: list[str]) -> dict[str, Any]:
     if routine_s:
         out["s_per_beat"] = round(sum(routine_s) / len(routine_s), 1)
         out["turns_per_beat"] = round(sum(routine_t) / len(routine_t), 1)
+
+    # Per-kind generation means over the successful beats (cold-open kind excluded by
+    # construction — it is its own kind label, never combat/camp/social).
+    for kind, col in (("combat", "combat_s_per_beat"),
+                      ("social", "social_s_per_beat"),
+                      ("camp", "camp_s_per_beat")):
+        vals = [api_s[i] for i, k in enumerate(kinds) if k == kind]
+        if vals:
+            out[col] = round(sum(vals) / len(vals), 1)
+
+    # Tool-exec split from the optional 1A sidecar. The denominator prefers the whole-beat
+    # wall total (sum of duration_ms); falls back to total generation seconds when no beat
+    # carried duration_ms (basis stamped so the reader knows which was used).
+    if tooltiming is not None:
+        rows = read_tool_timing(tooltiming)
+        total_wall = sum(wall_s) if any(w > 0 for w in wall_s) else None
+        total_api = sum(api_s) if api_s else None
+        out.update(_tool_exec_split(rows, total_wall, total_api))
+
     return out
 
 
-def rollup_run(transcript_dir: str | Path, run_id: str) -> dict[str, Any]:
-    """Convenience: discover a run's beat transcripts under ``transcript_dir`` and roll up."""
-    return rollup_files(beat_files(transcript_dir, run_id))
+def rollup_run(transcript_dir: str | Path, run_id: str,
+               tooltiming: str | Path | None = None) -> dict[str, Any]:
+    """Convenience: discover a run's beat transcripts under ``transcript_dir`` and roll up.
+    Pass ``tooltiming`` to fold in the optional 1A tool-timing sidecar (see ``rollup_files``)."""
+    return rollup_files(beat_files(transcript_dir, run_id), tooltiming=tooltiming)
 
 
 def stamp_sidecars(rollup: dict[str, Any], run_dirs: Iterable[str | Path]) -> list[str]:
@@ -322,6 +528,9 @@ def _main(argv: Optional[list[str]] = None) -> int:
     ap = argparse.ArgumentParser(description="Derive the F13-4 latency ledger from DM beat transcripts.")
     ap.add_argument("--dir", help="transcript directory ($T) — used with --run")
     ap.add_argument("--run", help="run id ($RUN) — used with --dir")
+    ap.add_argument("--tooltiming", default=None, help="optional 1A tool-timing JSONL sidecar "
+                    "({ts,tool,wall_ms,ok,campaign_id} per line) — adds mean_tool_call_ms / "
+                    "slowest_tool / tool_exec_pct; absent/missing/empty degrades these to null")
     ap.add_argument("--out", help="write the rollup JSON here (also printed to stdout)")
     ap.add_argument("--stamp-into", default="", help="comma-separated PERSONA run dirs to stamp the "
                     "rollup into as <dir>/latency.json (the shape release_readiness.read_latency reads) "
@@ -342,9 +551,9 @@ def _main(argv: Optional[list[str]] = None) -> int:
 
     if args.files:
         files = sorted(args.files, key=lambda p: int(m.group(1)) if (m := _DM_RE.search(p)) else 0)
-        result = rollup_files(files)
+        result = rollup_files(files, tooltiming=args.tooltiming)
     elif args.dir and args.run:
-        result = rollup_run(args.dir, args.run)
+        result = rollup_run(args.dir, args.run, tooltiming=args.tooltiming)
     else:
         ap.error("pass either explicit transcript files, or --dir and --run")
         return 2

--- a/qa/scores_db.py
+++ b/qa/scores_db.py
@@ -113,6 +113,17 @@ COLUMNS: tuple[str, ...] = (
     "s_per_beat",         # mean GENERATION seconds per CONTINUING (routine) beat (cold open excluded)
     "coldopen_s",         # cold-open (first/world-build beat) GENERATION seconds
     "turns_per_beat",     # mean claude -p `num_turns` per CONTINUING beat (ToolSearch / round-trip proxy)
+    # --- Wave-1 1B: per-kind + per-tool timing attribution (qa/latency_rollup.py). Per-kind
+    # means split the routine s_per_beat by what the beat DID (a combat beat costs more than a
+    # social one); the tool-exec split (from the optional 1A {ts,tool,wall_ms,ok,campaign_id}
+    # sidecar) attributes how much of a beat is engine tool-exec vs model generation. All NULL
+    # on rows recorded before this stamping (additive, migration-free). ---
+    "combat_s_per_beat",  # mean GENERATION seconds over COMBAT beats (None when no combat beat)
+    "social_s_per_beat",  # mean GENERATION seconds over SOCIAL beats (None when no social beat)
+    "mean_tool_call_ms",  # mean per-tool-call wall_ms across the 1A sidecar (None w/o sidecar)
+    "slowest_tool",       # tool with the largest TOTAL summed wall_ms (None w/o sidecar)
+    "tool_exec_pct",      # sum(tool wall_s) / sum(beat duration_ms) — engine-exec fraction of a beat
+    "duration_wall_s",    # total WHOLE-BEAT wall seconds for the run (sum of duration_ms), if measured
     # --- structural coverage (the owner's "full circle"; pairs with the #961 structural_completeness
     # gate). Tracks whether a run actually EXERCISED whole systems (not just scored prose+dice): how
     # far the arc got + a one-line human roll-up. Derived from the engine snapshot + DM tool counts by
@@ -136,6 +147,9 @@ _REAL_COLS = {
     "rri", "image_render_rate",
     # F13-4 latency ledger (all wall-clock seconds / turn counts → REAL)
     "s_per_beat", "coldopen_s", "turns_per_beat",
+    # Wave-1 1B per-kind + per-tool timing (seconds / ms / ratio → REAL; slowest_tool is TEXT)
+    "combat_s_per_beat", "social_s_per_beat", "mean_tool_call_ms", "tool_exec_pct",
+    "duration_wall_s",
 }
 _INT_COLS = {"critical_bugs", "pass", "is_canonical_baseline", "acts_reached"}
 
@@ -390,6 +404,11 @@ _MD_COLS = [
     ("s_per_beat", "s/beat"),
     ("coldopen_s", "cold-open s"),
     ("turns_per_beat", "turns/beat"),
+    ("combat_s_per_beat", "combat s/beat"),
+    ("social_s_per_beat", "social s/beat"),
+    ("tool_exec_pct", "tool%"),
+    ("mean_tool_call_ms", "tool ms"),
+    ("slowest_tool", "slowest tool"),
     ("acts_reached", "Acts"),
     ("structural_coverage", "Structural coverage"),
     ("pass", "Pass"),
@@ -443,6 +462,8 @@ def render_markdown(db_path: Path | str = DB_PATH, md_path: Path | str = MD_PATH
         for key, _ in _MD_COLS:
             v = r.get(key)
             if key == "image_render_rate" and v is not None:
+                v = f"{float(v) * 100:.0f}%"
+            elif key == "tool_exec_pct" and v is not None:
                 v = f"{float(v) * 100:.0f}%"
             elif key == "pass" and v is not None:
                 v = "PASS" if int(v) else "FAIL"

--- a/qa/story_readout.py
+++ b/qa/story_readout.py
@@ -21,6 +21,15 @@ Input: a claude -p stream-json transcript (qa/transcripts/*.jsonl, *.dm.*.jsonl)
 """
 from __future__ import annotations
 import json, re, sys, glob, os
+from pathlib import Path
+
+# Reuse the latency rollup for the TIMING stamp — DON'T re-parse transcripts here. Defensive
+# import (story_readout is run as a script from varied cwds, like the tests do).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    import latency_rollup  # noqa: E402
+except Exception:  # pragma: no cover - latency_rollup is a sibling; absence only kills the stamp
+    latency_rollup = None  # type: ignore[assignment]
 
 # Tool calls that are STORY (kept in the render); everything else (Read, ToolSearch, speak,
 # scene_context, persist_beat logging, get_state, list_canon, ...) is harness noise, dropped.
@@ -641,6 +650,74 @@ def stamp(cov: dict) -> str:
     )
 
 
+# A beat transcript is "<run>.dm.<nanos>.jsonl"; split it into (transcript_dir, run_id) so the
+# latency rollup can discover the run's SIBLING beat files (a multi-beat run is many files).
+_DM_RUN_RE = re.compile(r"^(.*)\.dm\.\d+\.jsonl$")
+
+
+def _dir_and_run(path: str):
+    """Derive (transcript_dir, run_id) from a beat-transcript path, or (None, None) when the
+    path is not a "<run>.dm.<nanos>.jsonl" beat file (so the TIMING stamp is simply skipped)."""
+    d = os.path.dirname(path) or "."
+    m = _DM_RUN_RE.match(os.path.basename(path))
+    return (d, m.group(1)) if m else (None, None)
+
+
+def timing_stamp(transcript_dir, run_id, tooltiming=None) -> str:
+    """One-line ``TIMING | ...`` stamp, computed by REUSING qa/latency_rollup (no re-parsing).
+
+    Shape (clauses present only when there's data for them — degrade gracefully)::
+
+        TIMING | beat~86s gen~96s cold~240s | combat~140s social~70s camp~95s | tool=3% slowest=scene_context
+
+    * ``beat~`` = ``s_per_beat`` (routine-beat generation), ``cold~`` = ``coldopen_s``.
+    * the per-kind clause shows whichever of combat/social/camp the run actually had.
+    * the tool clause (``tool=…% slowest=…``) appears ONLY when a 1A ``tooltiming`` sidecar
+      was supplied AND parsed — otherwise it is omitted entirely (no sidecar → no claim).
+
+    Returns ``"TIMING | (no beat data)"`` when the rollup has no successful beats, and
+    ``"TIMING | (unavailable)"`` if the latency_rollup import failed."""
+    if latency_rollup is None:
+        return "TIMING | (unavailable)"
+    if not run_id:
+        return "TIMING | (no beat data)"
+    r = latency_rollup.rollup_run(transcript_dir, run_id, tooltiming=tooltiming)
+    if not r.get("beats"):
+        return "TIMING | (no beat data)"
+
+    def s(v):
+        return None if v is None else (f"{v:.0f}s" if float(v) >= 10 else f"{float(v):.1f}s")
+
+    head = []
+    if r.get("s_per_beat") is not None:
+        head.append(f"beat~{s(r['s_per_beat'])}")
+    if r.get("coldopen_s") is not None:
+        head.append(f"cold~{s(r['coldopen_s'])}")
+
+    kinds = []
+    for label, col in (("combat", "combat_s_per_beat"), ("social", "social_s_per_beat"),
+                       ("camp", "camp_s_per_beat")):
+        if r.get(col) is not None:
+            kinds.append(f"{label}~{s(r[col])}")
+
+    parts = ["TIMING"]
+    parts.append(" ".join(head) if head else "(cold-open only)")
+    if kinds:
+        parts.append(" ".join(kinds))
+    # Tool clause: only when the sidecar produced numbers (graceful degrade otherwise).
+    if r.get("tool_exec_pct") is not None or r.get("slowest_tool") is not None:
+        bits = []
+        if r.get("tool_exec_pct") is not None:
+            bits.append(f"tool={float(r['tool_exec_pct']) * 100:.0f}%")
+        if r.get("mean_tool_call_ms") is not None:
+            bits.append(f"call~{float(r['mean_tool_call_ms']):.0f}ms")
+        if r.get("slowest_tool"):
+            bits.append(f"slowest={r['slowest_tool']}")
+        if bits:
+            parts.append(" ".join(bits))
+    return " | ".join(parts)
+
+
 def main(argv):
     if not argv or argv[0] in ("-h", "--help"):
         print(__doc__)
@@ -650,6 +727,9 @@ def main(argv):
     out = None
     if "--out" in argv:
         out = argv[argv.index("--out") + 1]
+    tooltiming = None
+    if "--tooltiming" in argv:
+        tooltiming = argv[argv.index("--tooltiming") + 1]
     if os.path.isdir(path):
         cands = sorted(glob.glob(os.path.join(path, "**", "*.jsonl"), recursive=True),
                        key=lambda p: os.path.getsize(p), reverse=True)
@@ -660,14 +740,20 @@ def main(argv):
         path = cands[0]
     render, cov = analyze(path)
     line = stamp(cov)
+    # TIMING stamp — derive the run's transcript dir + id from the (possibly chosen) beat file
+    # so the rollup can see all of the run's sibling beats; reuse latency_rollup (no re-parse).
+    tdir, run_id = _dir_and_run(path)
+    tline = timing_stamp(tdir, run_id, tooltiming=tooltiming)
     if coverage_only:
         print(line)
+        print(tline)
         print(json.dumps({k: v for k, v in cov.items() if k != "calls"}))
         return 0
-    body = f"# Story readout — {os.path.basename(path)}\n\n{line}\n" + "\n".join(render) + f"\n\n{line}\n"
+    body = (f"# Story readout — {os.path.basename(path)}\n\n{line}\n{tline}\n"
+            + "\n".join(render) + f"\n\n{line}\n{tline}\n")
     if out:
         open(out, "w", encoding="utf-8").write(body)
-        print(f"wrote {out}\n{line}")
+        print(f"wrote {out}\n{line}\n{tline}")
     else:
         print(body)
     return 0

--- a/qa/test_latency_rollup.py
+++ b/qa/test_latency_rollup.py
@@ -277,3 +277,210 @@ def test_cli_compare_exit_codes(tmp_path):
     tiered_bad.write_text(json.dumps(_arm(236.0, 98.0, co_cc=150000.0, ro_cc=15000.0, ro_input=26000.0)))
     assert latency_rollup._main(["--compare", str(base), str(tiered_ok)]) == 0
     assert latency_rollup._main(["--compare", str(base), str(tiered_bad)]) == 1
+# ══════════════════════════════════════════════════════════════════════════════════════
+# Wave-1 1B: per-kind attribution (from transcripts) + tool-exec split (from the 1A sidecar)
+# ══════════════════════════════════════════════════════════════════════════════════════
+
+def _write_beat_with_tools(d: Path, run: str, nanos: int, *, api_ms, tools,
+                           num_turns=1, duration_ms=None):
+    """A beat transcript carrying ``tools`` (list of MCP-prefixed tool_use names) so the
+    per-kind classifier has something to read, plus a terminal result with duration_api_ms
+    (and optionally duration_ms for the tool_exec_pct denominator)."""
+    res = {"type": "result", "subtype": "success", "is_error": False,
+           "api_error_status": None, "num_turns": num_turns, "result": "prose"}
+    if api_ms is not None:
+        res["duration_api_ms"] = api_ms
+    if duration_ms is not None:
+        res["duration_ms"] = duration_ms
+    lines = [json.dumps({"type": "system", "subtype": "init"})]
+    for name in tools:
+        lines.append(json.dumps({
+            "type": "assistant",
+            "message": {"role": "assistant",
+                        "content": [{"type": "tool_use", "name": name, "input": {}}]},
+        }))
+    lines.append(json.dumps({"type": "assistant", "message": {"content": "…"}}))
+    lines.append(json.dumps(res))
+    path = d / f"{run}.dm.{nanos}.jsonl"
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_per_kind_combat_and_social_means(tmp_path):
+    # cold open (beat0), then a combat beat (140s) and a social beat (70s). The per-kind means
+    # are derived from the tool_use names alone — no sidecar.
+    run = "duo-kind"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=240000,
+                           tools=["mcp__engine__start_adventure"])           # cold open
+    _write_beat_with_tools(tmp_path, run, 2000, api_ms=140000,
+                           tools=["mcp__engine__start_combat", "mcp__engine__attack"])  # combat
+    _write_beat_with_tools(tmp_path, run, 3000, api_ms=70000,
+                           tools=["mcp__engine__social_check"])              # social (no combat/camp tool)
+    r = latency_rollup.rollup_run(tmp_path, run)
+    assert r["coldopen_s"] == 240.0
+    assert r["combat_s_per_beat"] == 140.0
+    assert r["social_s_per_beat"] == 70.0
+    assert r["camp_s_per_beat"] is None                # no camp beat
+
+
+def test_per_kind_camp_and_combat_precedence(tmp_path):
+    # camp means come from camp tools; a beat that BOTH fights and rests is attributed to combat
+    # (the heavier kind wins). Two combat beats average; the camp beat is its own mean.
+    run = "duo-camp"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=200000, tools=[])     # cold open (no tools)
+    _write_beat_with_tools(tmp_path, run, 2000, api_ms=100000,
+                           tools=["mcp__engine__attack"])                    # combat
+    _write_beat_with_tools(tmp_path, run, 3000, api_ms=120000,
+                           tools=["mcp__engine__cast_spell", "mcp__engine__long_rest"])  # combat (precedence)
+    _write_beat_with_tools(tmp_path, run, 4000, api_ms=90000,
+                           tools=["mcp__engine__camp_scene", "mcp__engine__record_camp_beat"])  # camp
+    r = latency_rollup.rollup_run(tmp_path, run)
+    assert r["combat_s_per_beat"] == 110.0             # mean(100, 120) — the long_rest beat is combat
+    assert r["camp_s_per_beat"] == 90.0
+    assert r["social_s_per_beat"] is None
+
+
+def test_per_kind_none_when_no_such_beat(tmp_path):
+    # A run with only cold-open + social beats has None for combat/camp (no fabricated 0).
+    run = "duo-soc"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=200000, tools=[])     # cold open
+    _write_beat_with_tools(tmp_path, run, 2000, api_ms=80000, tools=[])      # social (no tools)
+    r = latency_rollup.rollup_run(tmp_path, run)
+    assert r["social_s_per_beat"] == 80.0
+    assert r["combat_s_per_beat"] is None
+    assert r["camp_s_per_beat"] is None
+
+
+def test_per_kind_present_without_sidecar(tmp_path):
+    # Per-kind keys exist (None or value) even when NO --tooltiming is passed; the tool-exec
+    # split keys are None (graceful degrade).
+    run = "duo-nosc"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=200000, tools=[])
+    _write_beat_with_tools(tmp_path, run, 2000, api_ms=90000,
+                           tools=["mcp__engine__attack"])
+    r = latency_rollup.rollup_run(tmp_path, run)               # NO tooltiming
+    for k in ("combat_s_per_beat", "social_s_per_beat", "camp_s_per_beat",
+              "mean_tool_call_ms", "slowest_tool", "tool_exec_pct"):
+        assert k in r
+    assert r["combat_s_per_beat"] == 90.0
+    assert r["mean_tool_call_ms"] is None and r["slowest_tool"] is None
+    assert r["tool_exec_pct"] is None
+
+
+def _write_tooltiming(path: Path, rows) -> None:
+    """Write a 1A tool-timing JSONL sidecar (the contract:
+    {ts, tool, wall_ms, ok, campaign_id} per line)."""
+    with path.open("w", encoding="utf-8") as fh:
+        for r in rows:
+            if isinstance(r, str):
+                fh.write(r + "\n")                 # raw line (for the malformed-line test)
+            else:
+                fh.write(json.dumps(r) + "\n")
+
+
+def test_tooltiming_sidecar_slowest_and_mean(tmp_path):
+    # mean_tool_call_ms is the mean wall_ms; slowest_tool is the largest TOTAL summed wall_ms.
+    # scene_context: 200+220 = 420ms total; attack: 50ms; roll: 30ms → slowest = scene_context.
+    run = "duo-tt"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=200000, tools=[], duration_ms=205000)
+    _write_beat_with_tools(tmp_path, run, 2000, api_ms=100000,
+                           tools=["mcp__engine__attack"], duration_ms=103000)
+    sc = tmp_path / "tools.jsonl"
+    _write_tooltiming(sc, [
+        {"ts": 1.0, "tool": "scene_context", "wall_ms": 200.0, "ok": True, "campaign_id": "c1"},
+        {"ts": 2.0, "tool": "scene_context", "wall_ms": 220.0, "ok": True, "campaign_id": "c1"},
+        {"ts": 3.0, "tool": "attack", "wall_ms": 50.0, "ok": True, "campaign_id": "c1"},
+        {"ts": 4.0, "tool": "roll", "wall_ms": 30.0, "ok": True, "campaign_id": "c1"},
+    ])
+    r = latency_rollup.rollup_run(tmp_path, run, tooltiming=sc)
+    assert r["slowest_tool"] == "scene_context"
+    assert r["mean_tool_call_ms"] == 125.0           # mean(200,220,50,30)
+
+
+def test_tooltiming_exec_pct_uses_duration_ms_denominator(tmp_path):
+    # tool_exec_pct = sum(tool wall_s) / sum(beat duration_ms s). 500ms tools / 10s wall = 5%.
+    run = "duo-pct"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=200000, tools=[], duration_ms=4000)
+    _write_beat_with_tools(tmp_path, run, 2000, api_ms=100000, tools=[], duration_ms=6000)
+    sc = tmp_path / "tools.jsonl"
+    _write_tooltiming(sc, [
+        {"ts": 1.0, "tool": "a", "wall_ms": 300.0, "ok": True, "campaign_id": None},
+        {"ts": 2.0, "tool": "b", "wall_ms": 200.0, "ok": True, "campaign_id": None},
+    ])
+    r = latency_rollup.rollup_run(tmp_path, run, tooltiming=sc)
+    # 0.5s tools / 10.0s wall = 0.05; basis is the whole-beat wall (duration_ms).
+    assert r["tool_exec_pct"] == 0.05
+    assert r["tool_exec_pct_basis"] == "duration_ms"
+
+
+def test_tooltiming_exec_pct_falls_back_to_api_when_no_duration_ms(tmp_path):
+    # When NO beat carries duration_ms, the denominator falls back to total generation
+    # (duration_api_ms) and the basis is stamped so the reader knows it over-states.
+    run = "duo-fb"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=200000, tools=[])   # no duration_ms
+    _write_beat_with_tools(tmp_path, run, 2000, api_ms=300000, tools=[])   # no duration_ms
+    sc = tmp_path / "tools.jsonl"
+    _write_tooltiming(sc, [
+        {"ts": 1.0, "tool": "a", "wall_ms": 5000.0, "ok": True, "campaign_id": None},
+    ])
+    r = latency_rollup.rollup_run(tmp_path, run, tooltiming=sc)
+    # 5s tools / 500s generation = 0.01; basis stamped as the generation fallback.
+    assert r["tool_exec_pct"] == 0.01
+    assert r["tool_exec_pct_basis"] == "duration_api_ms"
+
+
+def test_tooltiming_absent_degrades_to_none(tmp_path):
+    # No --tooltiming at all → the three tool-exec keys are None, rest of rollup unchanged.
+    run = "duo-none"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=200000, tools=[])
+    _write_beat_with_tools(tmp_path, run, 2000, api_ms=90000, tools=[])
+    r = latency_rollup.rollup_run(tmp_path, run)
+    assert r["mean_tool_call_ms"] is None
+    assert r["slowest_tool"] is None
+    assert r["tool_exec_pct"] is None
+    assert r["s_per_beat"] == 90.0                   # base rollup intact
+
+
+def test_tooltiming_missing_file_degrades_gracefully(tmp_path):
+    # A --tooltiming PATH that does not exist → empty sidecar → None tool-exec keys (no crash).
+    run = "duo-miss"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=200000, tools=[])
+    _write_beat_with_tools(tmp_path, run, 2000, api_ms=90000, tools=[])
+    r = latency_rollup.rollup_run(tmp_path, run, tooltiming=tmp_path / "nope.jsonl")
+    assert r["mean_tool_call_ms"] is None and r["tool_exec_pct"] is None
+
+
+def test_tooltiming_empty_and_garbled_rows_skipped(tmp_path):
+    # Blank lines, malformed JSON, non-objects, and rows missing tool/wall_ms are skipped;
+    # only the valid row survives (tolerant, never raises).
+    run = "duo-garble"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=200000, tools=[], duration_ms=4000)
+    sc = tmp_path / "tools.jsonl"
+    _write_tooltiming(sc, [
+        "",                                                    # blank
+        "{not valid json",                                     # malformed
+        "[1,2,3]",                                             # not an object
+        {"ts": 1.0, "ok": True},                               # no tool / wall_ms
+        {"tool": "x"},                                         # no wall_ms
+        {"tool": "good", "wall_ms": 42.0, "ok": True, "campaign_id": None},  # the one valid row
+    ])
+    r = latency_rollup.rollup_run(tmp_path, run, tooltiming=sc)
+    assert r["mean_tool_call_ms"] == 42.0
+    assert r["slowest_tool"] == "good"
+
+
+def test_cli_tooltiming_flag(tmp_path):
+    # The CLI threads --tooltiming through to the rollup.
+    run = "duo-clitt"
+    _write_beat_with_tools(tmp_path, run, 1000, api_ms=200000, tools=[], duration_ms=4000)
+    sc = tmp_path / "tools.jsonl"
+    _write_tooltiming(sc, [
+        {"ts": 1.0, "tool": "scene_context", "wall_ms": 100.0, "ok": True, "campaign_id": None},
+    ])
+    out = tmp_path / "lat.json"
+    rc = latency_rollup._main(["--dir", str(tmp_path), "--run", run,
+                               "--tooltiming", str(sc), "--out", str(out)])
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["slowest_tool"] == "scene_context"
+    assert data["mean_tool_call_ms"] == 100.0

--- a/qa/test_scores_db.py
+++ b/qa/test_scores_db.py
@@ -607,3 +607,70 @@ def test_render_includes_structural_columns(tmp_path):
     assert "| Acts |" in md
     assert "Structural coverage" in md
     assert "acts 2/3 · recruit ✓ · camp ✓" in md
+
+
+# --- Wave-1 1B: per-kind + per-tool timing columns ---
+
+def test_timing_1b_columns_registered_with_right_types():
+    """The six 1B columns exist; five are REAL, slowest_tool is TEXT."""
+    for col in ("mean_tool_call_ms", "combat_s_per_beat", "social_s_per_beat",
+                "duration_wall_s", "tool_exec_pct"):
+        assert col in scores_db.COLUMNS, f"{col} missing from COLUMNS"
+        assert scores_db._coltype(col) == "REAL", f"{col} should be REAL"
+    assert "slowest_tool" in scores_db.COLUMNS
+    assert scores_db._coltype("slowest_tool") == "TEXT"
+
+
+def test_timing_1b_columns_roundtrip(tmp_path):
+    db = tmp_path / "t.db"
+    scores_db.add_run(
+        "duo-1b", db_path=db, surface="engine-duo",
+        mean_tool_call_ms=42.0, slowest_tool="scene_context",
+        combat_s_per_beat=140.0, social_s_per_beat=70.0,
+        duration_wall_s=620.0, tool_exec_pct=0.03,
+    )
+    row = scores_db.fetch_rows(db)[0]
+    assert row["mean_tool_call_ms"] == 42.0
+    assert row["slowest_tool"] == "scene_context"
+    assert row["combat_s_per_beat"] == 140.0
+    assert row["social_s_per_beat"] == 70.0
+    assert row["duration_wall_s"] == 620.0
+    assert row["tool_exec_pct"] == 0.03
+
+
+def test_timing_1b_columns_read_null_on_old_rows(tmp_path):
+    """ADDITIVITY: a row recorded without the 1B fields reads back NULL for all six."""
+    db = tmp_path / "t.db"
+    scores_db.add_run("duo-old", db_path=db, surface="engine-duo", story_overall=4.1)
+    row = scores_db.fetch_rows(db)[0]
+    for col in ("mean_tool_call_ms", "slowest_tool", "combat_s_per_beat",
+                "social_s_per_beat", "duration_wall_s", "tool_exec_pct"):
+        assert row[col] is None, f"{col} should read NULL on an old-style row"
+
+
+def test_timing_1b_columns_alter_into_an_old_db(tmp_path):
+    """A db created before 1B gets the six columns ALTER-added on connect (migration-free)."""
+    db = tmp_path / "old.db"
+    conn = sqlite3.connect(db)
+    conn.execute('CREATE TABLE runs ("run_id" TEXT PRIMARY KEY, "surface" TEXT, "s_per_beat" REAL)')
+    conn.commit()
+    conn.close()
+    conn = scores_db.connect(db)
+    cols = {r["name"] for r in conn.execute("PRAGMA table_info(runs)")}
+    conn.close()
+    assert {"mean_tool_call_ms", "slowest_tool", "combat_s_per_beat",
+            "social_s_per_beat", "duration_wall_s", "tool_exec_pct"} <= cols
+
+
+def test_render_includes_1b_timing_columns(tmp_path):
+    db = tmp_path / "t.db"
+    md_path = tmp_path / "ledger.md"
+    scores_db.add_run("sc3", db_path=db, surface="engine-duo",
+                      combat_s_per_beat=140.0, social_s_per_beat=70.0,
+                      tool_exec_pct=0.03, slowest_tool="scene_context")
+    md = scores_db.render_markdown(db, md_path)
+    assert "combat s/beat" in md
+    assert "social s/beat" in md
+    assert "slowest tool" in md
+    assert "scene_context" in md
+    assert "3%" in md                      # tool_exec_pct rendered as a percentage

--- a/qa/test_story_readout_timing.py
+++ b/qa/test_story_readout_timing.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Tests for story_readout's Wave-1 1B TIMING stamp (reuses qa/latency_rollup, no re-parse).
+
+The TIMING stamp sits next to the COVERAGE stamp and reports the per-beat / per-kind timing
+ledger derived from the run's *.dm.<nanos>.jsonl beat transcripts — plus an OPTIONAL tool-exec
+clause from the 1A {ts,tool,wall_ms,ok,campaign_id} sidecar (omitted when no sidecar).
+
+Stdlib + pytest only; self-contained synthetic transcripts. Run single-process:
+    uv run --directory servers/engine python -m pytest qa/test_story_readout_timing.py -p no:xdist
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+QA_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(QA_DIR))
+
+import story_readout as sr  # noqa: E402
+
+
+def _write_beat(d: Path, run: str, nanos: int, *, api_ms, tools, num_turns=2, duration_ms=None):
+    """A claude -p stream-json beat transcript carrying tool_use names + a terminal result."""
+    res = {"type": "result", "subtype": "success", "is_error": False,
+           "api_error_status": None, "num_turns": num_turns, "result": "prose",
+           "duration_api_ms": api_ms}
+    if duration_ms is not None:
+        res["duration_ms"] = duration_ms
+    lines = [json.dumps({"type": "system", "subtype": "init"})]
+    for name in tools:
+        lines.append(json.dumps({
+            "type": "assistant",
+            "message": {"role": "assistant",
+                        "content": [{"type": "tool_use", "name": name, "input": {}}]},
+        }))
+    lines.append(json.dumps({
+        "type": "assistant",
+        "message": {"role": "assistant", "content": [{"type": "text", "text": "The DM narrates."}]},
+    }))
+    lines.append(json.dumps(res))
+    p = d / f"{run}.dm.{nanos}.jsonl"
+    p.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return p
+
+
+def test_timing_stamp_per_kind_no_sidecar(tmp_path):
+    # cold open 240s, a combat beat 140s, a social beat 70s — no sidecar, so NO tool clause.
+    run = "duo-t"
+    _write_beat(tmp_path, run, 1000, api_ms=240000, tools=["mcp__engine__start_adventure"])
+    _write_beat(tmp_path, run, 2000, api_ms=140000,
+                tools=["mcp__engine__start_combat", "mcp__engine__attack"])
+    _write_beat(tmp_path, run, 3000, api_ms=70000, tools=["mcp__engine__social_check"])
+    line = sr.timing_stamp(str(tmp_path), run)
+    assert line.startswith("TIMING |")
+    assert "beat~" in line          # routine s_per_beat present
+    assert "cold~240s" in line
+    assert "combat~140s" in line
+    assert "social~70s" in line
+    assert "tool=" not in line      # graceful degrade: no sidecar → no tool clause
+    assert "slowest=" not in line
+
+
+def test_timing_stamp_with_tooltiming_sidecar(tmp_path):
+    run = "duo-t2"
+    _write_beat(tmp_path, run, 1000, api_ms=200000, tools=[], duration_ms=205000)
+    _write_beat(tmp_path, run, 2000, api_ms=100000,
+                tools=["mcp__engine__attack"], duration_ms=103000)
+    sc = tmp_path / "tools.jsonl"
+    with sc.open("w", encoding="utf-8") as fh:
+        for r in [
+            {"ts": 1.0, "tool": "scene_context", "wall_ms": 200.0, "ok": True, "campaign_id": "c"},
+            {"ts": 2.0, "tool": "scene_context", "wall_ms": 220.0, "ok": True, "campaign_id": "c"},
+            {"ts": 3.0, "tool": "attack", "wall_ms": 40.0, "ok": True, "campaign_id": "c"},
+        ]:
+            fh.write(json.dumps(r) + "\n")
+    line = sr.timing_stamp(str(tmp_path), run, tooltiming=str(sc))
+    assert "tool=" in line                    # the tool clause now appears
+    assert "slowest=scene_context" in line    # largest total wall_ms
+
+
+def test_timing_stamp_no_beat_data(tmp_path):
+    # An empty / non-matching run yields a stable placeholder, never a crash.
+    assert sr.timing_stamp(str(tmp_path), "no-such-run") == "TIMING | (no beat data)"
+    assert sr.timing_stamp(None, None) == "TIMING | (no beat data)"
+
+
+def test_main_prints_timing_next_to_coverage(tmp_path, capsys):
+    # The full readout (and --coverage-only) prints BOTH the COVERAGE and the TIMING line.
+    run = "duo-main"
+    _write_beat(tmp_path, run, 1000, api_ms=200000, tools=["mcp__engine__start_adventure"])
+    _write_beat(tmp_path, run, 2000, api_ms=90000, tools=["mcp__engine__attack"])
+    path = str(tmp_path / f"{run}.dm.2000.jsonl")
+    rc = sr.main([path, "--coverage-only"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "COVERAGE |" in out
+    assert "TIMING |" in out
+    assert "combat~90s" in out
+
+
+def test_main_full_render_carries_timing(tmp_path, capsys):
+    run = "duo-full"
+    _write_beat(tmp_path, run, 1000, api_ms=200000, tools=["mcp__engine__start_adventure"])
+    _write_beat(tmp_path, run, 2000, api_ms=80000, tools=["mcp__engine__social_check"])
+    path = str(tmp_path / f"{run}.dm.2000.jsonl")
+    rc = sr.main([path])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "TIMING |" in out
+    assert "social~80s" in out


### PR DESCRIPTION
## Wave-1 1B — timing attribution into the scoring ledger

Additive. Extends the existing latency pipeline so a finished run reports **where time goes**, and folds it into `scores_db` + the `story_readout` stamp.

### What
- **`qa/latency_rollup.py`** — two additive dimensions:
  - **Per-kind attribution (from transcripts, no sidecar needed):** classify each beat cold-open / combat / camp / social from its tool calls → `combat_s_per_beat`, `social_s_per_beat`, `camp_s_per_beat` (mean `duration_api_ms`). Combat outranks camp.
  - **Tool-exec split (best-effort, from the 1A sidecar via `--tooltiming`):** `mean_tool_call_ms`, `slowest_tool` (largest total wall_ms), `tool_exec_pct` (= sum tool wall_s / sum beat `duration_ms`, with a `tool_exec_pct_basis` stamp; falls back to `duration_api_ms` if needed). Degrades to `None` when no sidecar — existing outputs byte-identical.
- **`qa/scores_db.py`** — 6 additive columns (`combat_s_per_beat`, `social_s_per_beat`, `mean_tool_call_ms`, `slowest_tool`, `tool_exec_pct`, `duration_wall_s`); `--init` migrates via `ALTER TABLE ADD COLUMN`; old rows read NULL; rendered in the markdown ledger.
- **`qa/story_readout.py`** — a one-line `TIMING |` stamp next to `COVERAGE`, e.g. `TIMING | beat~102s cold~240s | combat~140s social~70s | tool=3% slowest=scene_context`. Tool clause omitted when no sidecar.

### Consumes the 1A contract
`{"ts","tool","wall_ms","ok","campaign_id"}` — reader is tolerant (missing file → `[]`; garbled lines skipped).

> Driver wiring (set `WORLDOS_TOOLTIMING_PATH` in the engine MCP env + pass `--tooltiming` to the rollup) lands as a separate single-owner commit to avoid a `run_duo.sh` merge race with the Wave-1 1C PR.

### Tests
122 passed single-process (all pre-existing tests for the 3 modules + new focused tests: per-kind means + precedence, sidecar slowest/mean/exec_pct both denominators + graceful-degrade, scores_db column roundtrip/NULL-on-old/ALTER-migration, story_readout TIMING with/without sidecar).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added beat-level performance categorization (combat, camp, social) based on tool usage, including per-kind generation timing.
  * Introduced optional tool-timing sidecar support to report mean tool call time, slowest tool, and tool execution percentages.
  * Updated story readout with a new timing stamp and expanded the timing ledger output with new Wave-1 1B columns (including percent formatting).

* **Tests**
  * Expanded latency rollup, database schema/markdown rendering, and story readout timing coverage, including graceful degradation when sidecar data is missing or malformed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->