### PR TITLE
feat(qa): GLM-only timeout/retry profile + bounded player-intro retry (Wave-1 1C)

### DIFF
--- a/qa/glm_profile.sh
+++ b/qa/glm_profile.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# qa/glm_profile.sh — a model-keyed settings profile for running the WorldOS QA
+# duo against GLM (z.ai's GLM 5.2, served over an Anthropic-compatible endpoint)
+# INSTEAD of Claude. Sourced by qa/run_duo.sh right after the model vars resolve.
+#
+# CONTRACT (the load-bearing guarantee):
+#   • GLM-ONLY. If NEITHER $WORLDOS_DM_MODEL NOR $WORLDOS_ACTOR_MODEL starts with
+#     "glm", worldos_apply_glm_profile is a TOTAL no-op (`return 0` before it
+#     touches a single var or env). A Claude run is therefore byte-for-byte
+#     unchanged — this file must never alter a Claude default.
+#   • When GLM IS the DM/actor model it:
+#       - sources the GLM credentials/endpoint from ~/.openclaw/secrets/glm.env
+#         (ANTHROPIC_BASE_URL / API key / CLAUDE_CONFIG_DIR) if that file exists;
+#         warns to stderr and continues if it does not (the caller may have set
+#         them another way). NEVER hardcodes or prints the key — only sources it.
+#       - RAISES the cold-open / per-beat timeouts and the DM+player retry ceilings
+#         (GLM is slower than Opus/Sonnet and can return an empty intro at beat 0
+#         even with no timeout), using ${VAR:-default} so an explicit override
+#         from the environment still wins.
+#   • Idempotent + safe to source and call more than once.
+#
+# It NEVER changes Claude defaults: the timeout/retry tiers in lib_beat_driver.sh
+# and the Opus budget floor in run_duo.sh are untouched for a Claude run.
+
+# True when $1 names a GLM model (case-insensitive "glm" prefix), false otherwise.
+# Kept tiny + bash-3.2-clean (no associative arrays / ${var,,} would also work on
+# 3.2's bash but we stay conservative with a case glob on a lowercased copy).
+_worldos_is_glm_model() {
+  case "$1" in
+    glm*|GLM*|Glm*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Apply the GLM-only profile. No-op for Claude (see the CONTRACT above).
+worldos_apply_glm_profile() {
+  # Detect GLM from EITHER role. If neither is GLM this returns immediately and
+  # nothing below runs — the Claude path is byte-for-byte unchanged.
+  if ! _worldos_is_glm_model "${WORLDOS_DM_MODEL:-}" \
+    && ! _worldos_is_glm_model "${WORLDOS_ACTOR_MODEL:-}"; then
+    return 0
+  fi
+
+  # ── GLM detected ──────────────────────────────────────────────────────────
+  # Source the GLM endpoint + credentials (ANTHROPIC_BASE_URL, the API key/token,
+  # CLAUDE_CONFIG_DIR) from OUTSIDE the repo. NEVER committed or printed here — we
+  # only `.` the file so its exports land in this process. Idempotent: sourcing a
+  # second time just re-exports the same values.
+  local glm_env="${WORLDOS_GLM_ENV:-$HOME/.openclaw/secrets/glm.env}"
+  if [ -f "$glm_env" ]; then
+    # shellcheck disable=SC1090  # path is resolved at runtime, not a static include
+    . "$glm_env"
+  else
+    echo "[glm_profile] WARNING: GLM model selected but $glm_env not found — " \
+         "assuming ANTHROPIC_BASE_URL / API key / CLAUDE_CONFIG_DIR were set " \
+         "another way; continuing." >&2
+  fi
+
+  # Raise the timeouts. ${VAR:-default} means an explicit caller/env override still
+  # wins; we only fill in the GLM-appropriate floor when the knob is unset. These
+  # mirror the names lib_beat_driver.sh's worldos_dm_timeout resolves (via
+  # worldos_env COLDOPEN_TIMEOUT / BEAT_TIMEOUT) — by exporting WORLDOS_* here the
+  # existing tiers pick up the raised values without any change to that file.
+  export WORLDOS_COLDOPEN_TIMEOUT="${WORLDOS_COLDOPEN_TIMEOUT:-900}"
+  export WORLDOS_BEAT_TIMEOUT="${WORLDOS_BEAT_TIMEOUT:-600}"
+
+  # Raise the retry ceilings. GLM's slower turns make a transient empty turn (and
+  # an empty beat-0 intro) more likely, so give the DM-turn retry loop and the new
+  # player-intro retry more attempts. Both honor an explicit override (:-).
+  export WORLDOS_DM_MAX_ATTEMPTS="${WORLDOS_DM_MAX_ATTEMPTS:-5}"
+  export WORLDOS_PLAYER_MAX_ATTEMPTS="${WORLDOS_PLAYER_MAX_ATTEMPTS:-5}"
+
+  # Effort is intentionally LEFT to the existing model-aware tiers in
+  # lib_beat_driver.sh (worldos_dm_effort_arg). There is no GLM-specific effort need
+  # today, and the cold-open/routine split already does the right thing; keeping the
+  # profile minimal avoids a second source of truth for effort.
+
+  return 0
+}

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -59,6 +59,17 @@ case "$WORLDOS_DM_MODEL" in
   *opus*) if awk "BEGIN{exit !($BUDGET < 4.0)}"; then echo "[duo] opus: flooring per-turn budget \$$BUDGET -> \$4.00 (cold-open headroom)"; BUDGET=4.00; fi ;;
 esac
 
+# GLM-only settings profile (Wave-1 1C). Sourced AFTER the model vars resolve and
+# BEFORE any timeout/budget/retry knob is consumed below, mirroring how
+# lib_beat_driver.sh is sourced above. For a Claude run (the default) this is a
+# TOTAL no-op — worldos_apply_glm_profile returns immediately when neither role is
+# GLM, so the shipped Claude path stays byte-for-byte unchanged. For a GLM run it
+# sources ~/.openclaw/secrets/glm.env and raises the cold-open/beat timeouts +
+# DM/player retry ceilings (GLM is slower than Opus/Sonnet). See qa/glm_profile.sh.
+# shellcheck source=glm_profile.sh
+. "$ROOT/qa/glm_profile.sh"
+worldos_apply_glm_profile
+
 # --- Lean-per-beat context (PERF, default OFF → byte-identical to today). --------------
 # MIRRORS scripts/play.sh exactly (and shares its ONE implementation via the
 # worldos_dm_lean_args helper in qa/lib_beat_driver.sh). With WORLDOS_LEAN_BEATS=1, the DM's
@@ -310,11 +321,28 @@ player_move() {
 # exactly that — it ALSO mis-diagnosed the real beat-0 blocker, which is `IS_SANDBOX=1`: on a root QA
 # host claude refuses `--dangerously-skip-permissions` → empty turn → "player produced no intro". The
 # root guard above enforces that, so the say()-based intro lands cleanly and stays a tagged move.
-PMSG="$(player_move 1 "$PLAYER_BRIEF
+# BOUNDED player-intro retry (Wave-1 1C). player_move already nudges ONCE inside a
+# single turn if the facade produced no move-tool call; but a slower model (GLM) can
+# still return an empty intro at beat 0 even with no timeout. Rather than hard-abort
+# on the first empty intro, retry the whole say()-tagged intro up to
+# WORLDOS_PLAYER_MAX_ATTEMPTS (default 3, raised to 5 by the GLM profile) times, and
+# only abort if STILL empty after the last attempt. The intro stays a say()-tagged
+# move through player_move (NOT raw prose) so the behavioral gate
+# `player_turns_structured` still sees a structured first turn (a raw-text intro caps
+# all G5 lenses ≤2.5 — see the say()-vs-prose note below).
+PLAYER_INTRO_PROMPT="$PLAYER_BRIEF
 
-This is the very start — the world isn't built and the scene isn't set yet. Introduce your character with a SINGLE say(\"…\"): who they are and what they want. Do NOT do()/attack/cast yet — wait for the DM to open the scene. One say(), nothing else.")"
+This is the very start — the world isn't built and the scene isn't set yet. Introduce your character with a SINGLE say(\"…\"): who they are and what they want. Do NOT do()/attack/cast yet — wait for the DM to open the scene. One say(), nothing else."
+WORLDOS_PLAYER_MAX_ATTEMPTS="${WORLDOS_PLAYER_MAX_ATTEMPTS:-3}"
+PMSG=""
+_pintro_attempt=1
+while [ -z "$PMSG" ] && [ "$_pintro_attempt" -le "$WORLDOS_PLAYER_MAX_ATTEMPTS" ]; do
+  [ "$_pintro_attempt" -gt 1 ] && echo "[duo] player produced no intro — retry $_pintro_attempt/$WORLDOS_PLAYER_MAX_ATTEMPTS…" >&2
+  PMSG="$(player_move 1 "$PLAYER_INTRO_PROMPT")"
+  _pintro_attempt=$((_pintro_attempt + 1))
+done
 echo "[duo] player intro: ${PMSG:0:120}…"
-[ -z "$PMSG" ] && { echo "[duo] player produced no intro — aborting" >&2; exit 1; }
+[ -z "$PMSG" ] && { echo "[duo] player produced no intro after $WORLDOS_PLAYER_MAX_ATTEMPTS attempts — aborting" >&2; exit 1; }
 chatlog player "$PMSG"
 
 # D1: DM spins up the world and opens the scene around the player's concept. Golden-spine mode


### PR DESCRIPTION
## Wave-1 1C — GLM as a cheap heavy-lifting test model (Claude defaults untouched)

Harness-only. Lets the QA duo run on GLM 5.2 (z.ai, Anthropic-compatible endpoint) with its own tuned settings, **without changing any Claude default**, and fixes the beat-0 abort that blocked a clean GLM score.

### What
- **NEW `qa/glm_profile.sh`** — `worldos_apply_glm_profile()`:
  - **GLM-only / Claude no-op:** if neither `WORLDOS_DM_MODEL` nor `WORLDOS_ACTOR_MODEL` starts with `glm`, `return 0` before touching anything — a Claude run is byte-for-byte unchanged.
  - When GLM is selected: sources `~/.openclaw/secrets/glm.env` (endpoint/key/`CLAUDE_CONFIG_DIR`) if present (warns + continues if not) — **only `.`-sources, never prints/commits the key**; raises `WORLDOS_COLDOPEN_TIMEOUT=900`, `WORLDOS_BEAT_TIMEOUT=600`, `WORLDOS_DM_MAX_ATTEMPTS=5`, `WORLDOS_PLAYER_MAX_ATTEMPTS=5` via `${VAR:-default}` (explicit overrides still win). Idempotent; bash-3.2-clean.
- **`qa/run_duo.sh`** — sources the profile after model-resolve / before timeouts; converts the **single** player-intro attempt into a bounded retry (`WORLDOS_PLAYER_MAX_ATTEMPTS`, default 3 / 5 under GLM). The intro stays a `say()`-tagged move (behavioral gate `player_turns_structured` intact); only aborts after the last attempt.

### Why the retry
The clean GLM re-run aborted at `run_duo.sh` — a hard `exit 1` with **no retry** when the *player* agent returns an empty intro (GLM's actor did, with zero timeouts). DM turns already retry; players didn't.

### Proof
- Claude no-op: `WORLDOS_DM_MODEL=opus` → timeouts/attempts stay unset; `ANTHROPIC_BASE_URL` unchanged. `WORLDOS_DM_MODEL=glm-5.2` → 900/600, attempts 5/5.
- Player retry: succeeds-on-1 (no retry), recovers-on-3, aborts at the cap with `…after N attempts`.
- `bash -n` + `shellcheck -x qa/glm_profile.sh` clean; only pre-existing informational findings on `run_duo.sh`. Secret-scan confirms the key appears in neither changed file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GLM model support for QA testing with automatic configuration and credential management.
  * Enhanced player introduction with retry logic to ensure non-empty character messages.

* **Chores**
  * Improved QA test robustness and flexibility for different model configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->