### PR TITLE
ci(codeql): advanced setup — scope Swift autobuild to macos/** + weekly

### DIFF
--- a/.github/workflows/codeql-swift.yml
+++ b/.github/workflows/codeql-swift.yml
@@ -1,0 +1,46 @@
+name: CodeQL Swift
+
+# The EXPENSIVE half of CodeQL: Swift requires autobuilding the macOS app (minutes on a
+# macos-latest runner). Scoped so it runs ONLY when the Swift app actually changes (macos/**)
+# or on a weekly schedule — so the app still gets periodic security scanning even without
+# macos/ churn — but NOT on every pure-Python/QA PR. The non-Swift languages live in codeql.yml.
+#
+# REQUIRED: GitHub default CodeQL setup must be DISABLED (see codeql.yml header) for this to run.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'macos/**'
+      - '.github/workflows/codeql-swift.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'macos/**'
+      - '.github/workflows/codeql-swift.yml'
+  schedule:
+    - cron: '41 3 * * 1'  # weekly, Monday 03:41 UTC
+
+jobs:
+  analyze-swift:
+    name: Analyze (swift)
+    runs-on: macos-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: swift
+          build-mode: autobuild
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:swift"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+# Advanced CodeQL setup (replaces GitHub "default setup"). The non-Swift languages are
+# interpreted / build-free, so they scan cheaply on every PR + push + weekly. Swift — which
+# requires autobuilding the macOS app and is the slow/expensive job — is split out into
+# codeql-swift.yml, scoped to macos/** changes + a weekly schedule, so a pure-Python/QA PR no
+# longer pays the Swift-autobuild tax on every run.
+#
+# REQUIRED ONE-TIME TOGGLE (repo owner): GitHub default CodeQL setup must be DISABLED for these
+# committed workflows to run — Settings -> Code security and analysis -> Code scanning ->
+# "CodeQL analysis" -> switch from "Default" to "Advanced". Until that toggle is flipped,
+# github/codeql-action/init fails by design (default + advanced cannot both run).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '27 3 * * 1'  # weekly, Monday 03:27 UTC
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What & why
`Analyze (swift)` runs on **every PR** (including pure-Python/QA ones) because CodeQL is on GitHub **default setup**, which autobuilds the macOS Swift app per-language with no path filter — the slow/expensive job. This replaces default setup with committed **advanced** workflows that keep full language coverage but scope the Swift autobuild to when it actually matters.

- **`codeql.yml`** — `python` + `javascript-typescript` + `actions` on `ubuntu-latest`, `build-mode: none` (build-free), every PR/push to main + weekly. Same coverage, cheap.
- **`codeql-swift.yml`** — `swift` on `macos-latest`, `build-mode: autobuild`, scoped to `paths: macos/**` (+ the workflow file) **and** a weekly schedule — so the app still gets periodic scanning, but a Python/QA PR no longer pays the Swift-autobuild tax.

## ⚠️ Required one-time toggle (owner)
Default CodeQL setup and advanced setup **cannot both run** — `codeql-action/init` fails by design while default is enabled. After merging, flip:

> **Settings → Code security and analysis → Code scanning → "CodeQL analysis" → switch from "Default" to "Advanced"**

Until that toggle is flipped, these workflows will show red (init refuses). Recommend flipping it right at merge.

## Coverage parity
Default setup analyzed: `actions`, `javascript-typescript`, `python`, `swift`. This keeps all four — only the **trigger** for `swift` changes (scoped vs every-PR). No security coverage is dropped.