### PR TITLE
fix(engine): auto-seed default approval vocabulary so companions are gauge-able (WS-A)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1704,6 +1704,19 @@ def _seat_flat10_warnings(ch, class_label: str, where: str) -> list[str]:
     return [warn]
 
 
+# A near-universal DEFAULT approval vocabulary so a freshly-recruited companion is GAUGE-ABLE the
+# moment they join (WS-A). QA found companion approval moved in only ~1/200 runs because
+# recruited/generated companions shipped EMPTY likes/dislikes — so every approval tag the DM passes
+# (record_decision / persist_beat decision=approval_tags) matched nothing and the regard gauge stayed
+# frozen at 0. These keys are kept SMALL and personality-INVARIANT — the dimensions almost any party
+# member reacts to (reliability, loyalty to allies, courage) — deliberately EXCLUDING the contested
+# alignment axes (mercy/cruelty, law/survival) that are character-specific, so a default never
+# mis-seeds a ruthless or lawless companion. The DM enriches/overrides with the orthogonal,
+# character-specific causes via author_companion_gauges as the bond develops.
+_DEFAULT_APPROVAL_LIKES = ("kept_your_word", "protected_an_ally", "showed_courage")
+_DEFAULT_APPROVAL_DISLIKES = ("broke_your_word", "abandoned_an_ally", "showed_cowardice")
+
+
 def _seed_companion_operational_state(ch) -> None:
     """Seed a companion's ARC and DOSSIER if absent — the shared finisher every
     companion-creation path runs so the relationship system (camp_scene /
@@ -1751,6 +1764,17 @@ def _seed_companion_operational_state(ch) -> None:
         # the NPC's seeded hook / remembered facts make good, character-specific camp talk
         camp_prompts.extend(m.strip() for m in ch.memory if m.strip())
         ch.companion_dossier = CompanionDossier(camp_prompts=camp_prompts[:4])
+    # A companion also needs a GAUGE-ABLE approval vocabulary (WS-A): without it every approval tag
+    # the DM passes matches nothing and the regard gauge is frozen at 0 (the #1 reason companion
+    # approval moved in only ~1/200 runs). Seed the near-universal DEFAULT vocabulary ONLY when BOTH
+    # lists are empty — never overwrite an ending/canon/DM-authored vocabulary — so a freshly-
+    # recruited companion is move-able from the first beat. Applies whether the dossier was just
+    # synthesized above or was pre-seeded without causes (the canon/roster case). Additive: an
+    # already-authored vocabulary round-trips unchanged.
+    dossier = ch.companion_dossier
+    if dossier is not None and not (dossier.approval_likes or dossier.approval_dislikes):
+        dossier.approval_likes = list(_DEFAULT_APPROVAL_LIKES)
+        dossier.approval_dislikes = list(_DEFAULT_APPROVAL_DISLIKES)
 
 
 @mcp.tool()

--- a/servers/engine/tests/test_author_companion_gauges.py
+++ b/servers/engine/tests/test_author_companion_gauges.py
@@ -17,14 +17,22 @@ import store
 
 
 def _vocabless_companion(bg: str) -> str:
-    """Create a companion the LIVE way — it gets the minimal seeded dossier (empty approval vocab)
-    + the default loyalty arc, exactly like a freely-recruited one."""
+    """Create a companion the LIVE way, then EXPLICITLY strip its approval vocabulary so the test
+    can exercise the UN-GAUGED path. (A freely-recruited companion is now auto-seeded with a small
+    DEFAULT vocab by WS-A — _seed_companion_operational_state — so the empty-vocab state these tests
+    act on must be reconstructed by clearing it; the auto-seed itself is covered by its own tests.)"""
     out = server.create_character(
         bg, name="Garran the Free", kind="companion", race="Human",
         class_name="Fighter", level=2, max_hp=18,
         biography="A hired blade with a careful, transactional way about him.",
     )
-    return out["id"]
+    cid = out["id"]
+    c = store.load_campaign(bg)
+    d = c.characters[cid].companion_dossier
+    d.approval_likes = []
+    d.approval_dislikes = []
+    store.save_campaign(c)
+    return cid
 
 
 def test_vocabless_companion_then_gauged_after_authoring(tmp_path, monkeypatch):

--- a/servers/engine/tests/test_companion_dossier.py
+++ b/servers/engine/tests/test_companion_dossier.py
@@ -22,6 +22,7 @@ from pydantic import ValidationError
 
 import content
 import server
+import store
 from models import Campaign, Character, CompanionDossier
 
 
@@ -30,6 +31,60 @@ from models import Campaign, Character, CompanionDossier
 def test_character_dossier_defaults_none():
     ch = Character(name="Hero")
     assert ch.companion_dossier is None
+
+
+# --- WS-A: a freshly-seeded companion is GAUGE-ABLE (default approval vocabulary) -----------
+
+def test_seed_gives_default_approval_vocabulary():
+    """WS-A: the live seed gives a companion a small DEFAULT approval vocabulary, so the regard
+    gauge is move-able from the first beat (approval moved in only ~1/200 runs because recruited
+    companions shipped EMPTY likes/dislikes, so every tag matched nothing)."""
+    ch = Character(name="Garran", kind="companion")
+    server._seed_companion_operational_state(ch)
+    assert ch.companion_dossier is not None
+    assert ch.companion_dossier.approval_likes == list(server._DEFAULT_APPROVAL_LIKES)
+    assert ch.companion_dossier.approval_dislikes == list(server._DEFAULT_APPROVAL_DISLIKES)
+    assert ch.companion_dossier.approval_likes  # non-empty == gauge-able
+
+
+def test_seed_does_not_overwrite_authored_vocabulary():
+    """An ending/canon/DM-authored vocabulary is NEVER overwritten by the default seed (additive)."""
+    ch = Character(
+        name="Vael", kind="companion",
+        companion_dossier=CompanionDossier(approval_likes=["due_process"],
+                                           approval_dislikes=["summary_execution"]),
+    )
+    server._seed_companion_operational_state(ch)
+    assert ch.companion_dossier.approval_likes == ["due_process"]
+    assert ch.companion_dossier.approval_dislikes == ["summary_execution"]
+
+
+def test_seed_backfills_default_vocab_on_empty_preexisting_dossier():
+    """A pre-seeded dossier with camp_prompts but EMPTY vocab (the canon/roster case) gets the
+    default vocab backfilled — its camp_prompts preserved — so it too becomes gauge-able."""
+    ch = Character(name="Korrin", kind="companion",
+                   companion_dossier=CompanionDossier(camp_prompts=["a careful, transactional smile"]))
+    server._seed_companion_operational_state(ch)
+    assert ch.companion_dossier.camp_prompts == ["a careful, transactional smile"]  # preserved
+    assert ch.companion_dossier.approval_likes == list(server._DEFAULT_APPROVAL_LIKES)
+
+
+def test_seeded_companion_approval_moves_end_to_end(tmp_path, monkeypatch):
+    """The WHOLE point of WS-A: with a default vocab seeded, a matching approval tag on a recorded
+    decision MOVES the companion's attitude_value (it could not before — empty vocab matched nothing,
+    so the regard gauge stayed frozen at 0 in real play)."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    bg = server.start_world("baldurs-gate")["campaign_id"]
+    cid = server.create_character(
+        bg, name="Garran the Free", kind="companion", race="Human",
+        class_name="Fighter", level=2, max_hp=18, biography="A hired blade.",
+    )["id"]
+    before = store.load_campaign(bg).characters[cid].attitude_value
+    # tag a choice with one of the seeded default likes — the DM's normal approval path
+    server.record_decision(bg, summary="kept the bargain to the letter",
+                           approval_tags=[server._DEFAULT_APPROVAL_LIKES[0]])
+    after = store.load_campaign(bg).characters[cid].attitude_value
+    assert after > before, "a default-vocab companion's regard must move on a matching tag"
 
 
 def test_old_snapshot_without_dossier_field_deserializes_unchanged():


### PR DESCRIPTION
## The root cause
The never-called-tools investigation found companion approval moved in only **~1/203 real runs**. The reason (verified): recruited/generated companions ship with **empty** `approval_likes`/`approval_dislikes` — `_seed_companion_operational_state` deliberately left them for the DM to author — so every approval tag the DM passes (`record_decision` / `persist_beat decision=approval_tags`) matches nothing and the regard gauge stays frozen at 0. (And **0 of 16** `persist_beat` decisions ever carried tags anyway — that's WS-F.)

## The fix
Seed a small, **near-universal default approval vocabulary** so a freshly-recruited companion is *move-able from the first beat*:
```
likes:    kept_your_word, protected_an_ally, showed_courage
dislikes: broke_your_word, abandoned_an_ally, showed_cowardice
```
Deliberately **excludes** the contested alignment axes (mercy/cruelty, law/survival) that are character-specific — so a default never mis-seeds a ruthless or lawless companion. Seeded **only when both lists are empty**; the DM enriches/overrides with orthogonal causes via `author_companion_gauges`.

## Safety
- **Additive**: an ending/canon/DM-authored vocabulary is never overwritten; old snapshots round-trip.
- **models.py-free** (Phase C collision rule — leaves the approval/stance/Decision model fields for Phase C chains C/D).
- The `companion_gauge_unauthored` cue logic is untouched; it simply fires for fewer companions now (they're gauged). The `_vocabless_companion` test helper now explicitly strips vocab to keep exercising the un-gauged path.

## Tests
+4 (gauge-able seed; authored-vocab preserved; empty-dossier backfill; **end-to-end — `record_decision` now moves `attitude_value`**). Full engine suite **2997 passed**.

Part of the story-engagement sprint (WS-A, the dependency root). The WS0 engagement scorer will measure this landing as `companion_approval` going from 0/5 → live. FPAD record: `worldos-session-notes/2026-06-18/story-engagement-sprint/`.