### PR TITLE
feat(qa): feature-engagement feedback loop — manifest + coverage scorer + forcing gate (WS0, all-WARN)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,8 @@ jobs:
             ../../qa/test_orchestrate_split_rri.py \
             ../../qa/test_visual_regression_check.py \
             ../../qa/test_structural_coverage.py \
-            ../../qa/test_story_readout_approval.py
+            ../../qa/test_story_readout_approval.py \
+            ../../qa/test_feature_engagement.py
 
   server-contracts:
     # Phase-1 (DETERMINISTIC-2): deterministic cross-service MCP contract tests

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -29,6 +29,67 @@ If the gate is RED, all three LLM scorecards are **capped to ≤ 2.5 / INVALID**
 annotated with the failed checks (`worldos_cap_score_red`). A dead/non-progressing scene
 can never display as 4.1 again. On a GREEN run, scores pass through untouched.
 
+## 1b. Feature-engagement coverage — the dead-system tracker (WS0)
+`qa/feature_engagement.py`
+
+**The gap this closes.** The behavioral gate + the three lenses grade *prose, dice, and a few
+structural floors*, but an entire authored subsystem (companion approval, camp downtime, faction
+questlines, the companion agenda, decisions) could be **100% inert** across a whole sweep and the
+RRI still scored 10/10 — *nothing was engagement-coverage*. A frozen-relationship run that
+narrated the companion but never moved a gauge passed; a run that seeded factions and never joined
+one passed.
+
+**The manifest.** `feature_engagement.SYSTEMS` is the reviewed list of the 10 authored story
+systems, each a `SystemSpec(id, precondition, detector, severity)`. A run is, per system:
+- **ENGAGED** — the detector is true (the engine state / DM tool counts prove the system fired).
+- **N/A** — the precondition is false (the run had no occasion: solo party, no factions seeded,
+  too short) **or unknown** (a beats-keyed precondition with no transcript beats count).
+- **INERT** — the precondition is **true** and the detector is **false**: the system was *owed*
+  and never fired. **This is the signal.**
+
+`engagement_coverage(state, tool_counts=None, session_beats=None)` returns
+`{coverage, engaged[], na[], inert[{id,why,severity}]}`. It is **PURE-READ over engine-mutated
+snapshot state** (`attitude_value`, `last_long_rest_day`, `faction.joined/standing`,
+`narrative_arc.act`, `consequence.fired/trigger_day`, the arc/agenda `fired` flags,
+`campaign.decisions/quests/factions/*_arcs`) **or DM tool-counts — never fiction/prose** (engine
+invariant #3). It REUSES `story_readout.structural_coverage_from_state` /
+`felt_shape_from_state` so the shared buckets never drift, and old snapshots round-trip (every
+predicate null-guards a missing collection / a `None` `narrative_arc`).
+
+**The forcing meta-test.** `servers/engine/tests/test_feature_engagement_manifest.py` mirrors
+`test_tool_schema_budget.py`: it asserts `{s.id for s in SYSTEMS} == REVIEWED_SYSTEM_IDS`, so
+adding/removing a tracked system is a **deliberate, visible diff** — the manifest can never
+silently drift out of coverage (the exact failure WS0 exists to prevent).
+
+**The deterministic RRI gate.** `qa/release_readiness.py` adds **one gate, `story_engagement`**
+(in `DETERMINISTIC_GATES` — no live LLM). It rolls each persona's `engagement_coverage`
+(merged into `score.json` by `qa/inject_structural_coverage.py`) up across the sweep: a system is
+owed if **any** persona owed it, engaged if **any** persona engaged it; **inert for the sweep**
+iff owed-by-≥1 **and** engaged-by-none. The gate **FAILS only on a FATAL inert system**. When
+**no** persona block carries `engagement_coverage` (a legacy corpus), it is an **evidence-gap
+SKIP** — excluded from `passed`/`total`, so RRI math stays **byte-identical** (mirrors the
+latency-gate skip). The `ENGAGEMENT` report section names every inert system + a fix hint.
+
+**Two N/A invariants (load-bearing — they keep the loop from ever false-RED-ing):**
+- `session_beats` lives in the **transcript, not the snapshot**, so the signature accepts it
+  explicitly and **every beats-keyed precondition defaults to N/A when it is `None`** (the inject
+  callsite passes `None` → those systems are N/A there — safe under-detect).
+- Under `WORLDOS_GATE_COMBAT_SPRINT`, all **FATAL** systems are **skipped** (mirrors
+  `assert_behavioral.py`) — a single pre-seeded fight exercises no story system.
+
+**WARN-first → FATAL graduation discipline.** Every system ships **`severity='warn'` this PR**, so
+the axis is **strictly additive**: it adds *zero* fatals to `assert_behavioral.py` and *cannot*
+flip a currently-green run RED. **Graduation to FATAL is a FUTURE, post-sweep PR** — after one
+real 5-persona sweep proves the inert/owed classification is calibrated (the same discipline as
+`flat_arc` / `caster_has_spellbook`). **Two systems are BLOCKED and stay WARN regardless** —
+`faction_arc` + `companion_quest_arc`: a snapshot-only precondition can't tell *seeded-but-locked*
+from *never-seeded* (a known open spike), so they must never graduate until that is resolved.
+
+**Where it surfaces.** `assert_behavioral.py` emits one `engagement_<id>` WARN per inert system
+(additive, after `structural_completeness`); `inject_structural_coverage.py` merges the block into
+each persona `score.json`; `scores_db.py` records `engagement_pct` + `engagement_inert`;
+`release_readiness.py` gates + reports it.
+
 ## 2. The three LLM lenses (1–5 each; run concurrently)
 Scored by `qa/score.sh` (claude -p) or `qa/score_openclaw.sh` (gpt-5.4, off the claude quota).
 

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -67,8 +67,10 @@ silently drift out of coverage (the exact failure WS0 exists to prevent).
 owed if **any** persona owed it, engaged if **any** persona engaged it; **inert for the sweep**
 iff owed-by-≥1 **and** engaged-by-none. The gate **FAILS only on a FATAL inert system**. When
 **no** persona block carries `engagement_coverage` (a legacy corpus), it is an **evidence-gap
-SKIP** — excluded from `passed`/`total`, so RRI math stays **byte-identical** (mirrors the
-latency-gate skip). The `ENGAGEMENT` report section names every inert system + a fix hint.
+SKIP** — excluded from `passed`/`total`, so the **RRI math** (`rri` / `gates_total` / `release_ready`)
+stays **byte-identical** (mirrors the latency-gate skip). The serialized `rri.json` still gains the
+additive `gate_detail.story_engagement` / `signals.engagement_*` keys (no value/verdict change). The
+`ENGAGEMENT` report section names every inert system + a fix hint.
 
 **Two N/A invariants (load-bearing — they keep the loop from ever false-RED-ing):**
 - `session_beats` lives in the **transcript, not the snapshot**, so the signature accepts it

--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -34,6 +34,13 @@ try:
 except Exception:  # pragma: no cover - defensive: never let an import break the gate
     coverage_from_tool_counts = None
     felt_shape_from_state = None
+# WS0 — the feature-engagement coverage scorer (manifest of authored story systems). Defensive
+# import on the SAME pattern: a missing module degrades the engagement block to a no-op, never
+# breaks the gate. All systems ship WARN, so this adds ZERO fatals (strictly additive).
+try:
+    from feature_engagement import engagement_coverage
+except Exception:  # pragma: no cover - defensive
+    engagement_coverage = None
 
 
 def _load_jsonl(p: str) -> list[dict]:
@@ -698,6 +705,24 @@ def main() -> int:
                 f"fetch-quest shape, not a felt setup→reversal→climax (land a real midpoint "
                 f"reversal + a late climax: record_decision the turn, complete_quest the spine late)",
                 fatal=False)
+
+    # ── WS0: FEATURE-ENGAGEMENT COVERAGE (the dead-system tracker; ALL-WARN this PR) ──────
+    # Today an entire authored subsystem (companion approval, camp downtime, faction questlines,
+    # …) can be 100% INERT across a whole run and every gate/lens still scores it 10/10 — no gate
+    # is engagement-coverage. This block reads the engine snapshot + the DM tool counts (the SAME
+    # ground-truth surfaces the structural_completeness floor uses — never fiction) and, for each
+    # system the run was OWED but never engaged, emits a chk. Severity rides the manifest: every
+    # system ships 'warn' this PR, so this adds ZERO fatals (every currently-green run stays
+    # green). FATAL graduation is a FUTURE, post-sweep PR. The combat-sprint env skip is honored
+    # inside engagement_coverage (mirrors the world-progression / structural floors above).
+    if engagement_coverage is not None:
+        try:
+            eng = engagement_coverage(state, dict(tools), session_beats)
+        except Exception:  # pragma: no cover - the engagement scorer must never break the gate
+            eng = {"inert": []}
+        for item in eng.get("inert", []):
+            chk(f"engagement_{item.get('id', '?')}", False, item.get("why", ""),
+                fatal=(item.get("severity") == "fatal"))
 
     # ── SECTION A: RESULT-SIDE + per-record state gates (audit-tests.md §A) ───────────────
     # These read artifacts the existing gates ignore: the tool_RESULT payloads (A1/A2/A8) and

--- a/qa/feature_engagement.py
+++ b/qa/feature_engagement.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+"""WS0 — the feature-engagement feedback loop: a MANIFEST of the authored story systems + a
+coverage scorer that distinguishes a system that was NEVER ENGAGED (inert) from one that was
+LEGITIMATELY OUT OF SCOPE (n/a) for the run.
+
+The keystone gap this closes: today an entire authored subsystem (companion approval, camp
+downtime, faction questlines, …) can be 100% inert across a whole sweep and every gate /
+lens still scores it 10/10 — because no gate is engagement-coverage. A frozen-relationship
+run that narrated the companion but never moved a gauge passed; a run that never camped
+passed; a run that seeded factions and never joined one passed. This module makes those
+"dead system" shapes a visible, queryable signal.
+
+DESIGN (load-bearing):
+  * PURE-READ over ENGINE-MUTATED snapshot state ONLY (attitude_value, last_long_rest_day,
+    faction.joined/standing, narrative_arc.act, consequence.fired/trigger_day, the arc/agenda
+    fired flags, campaign.decisions/quests/factions/*_arcs) or DM TOOL-COUNTS — NEVER fiction /
+    prose (engine invariant #3). Reuses story_readout.structural_coverage_from_state /
+    felt_shape_from_state so the shared buckets (recruit/camp/quest/acts) never drift.
+  * A system is ENGAGED if its detector is true; N/A if its precondition is false (the run
+    legitimately had no occasion to engage it — solo party, no factions seeded, too short);
+    INERT only when the precondition is TRUE and the detector is FALSE (the system was OWED
+    and never fired). INERT is the signal.
+  * session_beats lives in the TRANSCRIPT, not the snapshot — the signature accepts it
+    EXPLICITLY and every beats-keyed precondition DEFAULTS TO N/A when it is None (safe
+    under-detect: an inject callsite with no beats count can never false-RED a system).
+  * WORLDOS_GATE_COMBAT_SPRINT: under it, all FATAL systems are SKIPPED (mirrors
+    qa/assert_behavioral.py) — a single pre-seeded fight legitimately exercises no story
+    system. (All systems ship WARN this PR, so the skip is wired but currently a no-op for
+    coverage; it is the safe graduation hook.)
+  * ALL-WARN this PR (severity='warn' on every system). FATAL graduation is a FUTURE,
+    post-sweep PR — so this is strictly additive and cannot flip any currently-green run RED.
+
+Old/empty snapshots round-trip: every predicate null-guards a missing collection / a None
+narrative_arc, so a legacy snapshot yields all-N/A (or inert where the precondition is
+snapshot-only and true) and never raises.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Callable, NamedTuple, Optional
+
+# Reuse the shared structural buckets so this scorer and the story_readout stamp can never
+# drift. Defensive import (run as a script / imported from varied cwds, like the sibling tests).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+try:
+    from story_readout import (  # noqa: E402
+        structural_coverage_from_state,
+        felt_shape_from_state,
+    )
+except Exception:  # pragma: no cover - defensive; absence only degrades the shared buckets
+    structural_coverage_from_state = None  # type: ignore[assignment]
+    felt_shape_from_state = None  # type: ignore[assignment]
+
+
+# ── shape helpers (tolerant of dict- OR list-shaped engine collections, None, garbage) ───────
+
+def _as_list(coll) -> list:
+    if isinstance(coll, dict):
+        return list(coll.values())
+    if isinstance(coll, list):
+        return coll
+    return []
+
+
+def _characters(state: dict) -> list:
+    return [c for c in _as_list((state or {}).get("characters")) if isinstance(c, dict)]
+
+
+def _companions(state: dict) -> list:
+    return [c for c in _characters(state) if c.get("kind") == "companion"]
+
+
+def _int(v, default: int = 0) -> int:
+    try:
+        return int(v)
+    except (TypeError, ValueError):
+        return default
+
+
+def _narrative_arc(state: dict) -> dict:
+    """The engine narrative_arc cursor, null-guarded for absent-AND-None (reuses the same
+    degrade-to-empty-cursor guard felt_shape_from_state applies). Never raises."""
+    arc = (state or {}).get("narrative_arc")
+    return arc if isinstance(arc, dict) else {}
+
+
+def _struct(ctx_state: dict, tool_counts) -> dict:
+    """Shared structural-coverage buckets (recruit/camp/quest/acts/…). Reuses
+    story_readout.structural_coverage_from_state when importable; falls back to an empty dict
+    (every consumer below uses .get with a falsy default, so the absence only under-detects)."""
+    if structural_coverage_from_state is None:
+        return {}
+    try:
+        return structural_coverage_from_state(ctx_state or {}, tool_counts)
+    except Exception:  # pragma: no cover - defensive
+        return {}
+
+
+# ── the parsed context every predicate reads (engine-state predicates + tool counts) ─────────
+
+class Ctx(NamedTuple):
+    state: dict
+    tools: dict          # {short_tool_name: count}
+    session_beats: Optional[int]
+    struct: dict         # the shared structural_coverage block (may be {})
+    felt: dict           # the shared felt_shape block (may be {})
+
+
+def build_ctx(state: Optional[dict], tool_counts: Optional[dict],
+              session_beats: Optional[int]) -> Ctx:
+    """Parse the engine snapshot + DM tool counts into the Ctx every SystemSpec predicate
+    reads. session_beats is passed THROUGH unchanged (None ⇒ beats-keyed systems N/A)."""
+    state = state or {}
+    tools = {str(k): _int(v) for k, v in (tool_counts or {}).items()}
+    struct = _struct(state, tools or None)
+    felt = {}
+    if felt_shape_from_state is not None:
+        try:
+            felt = felt_shape_from_state(state, tools or None)
+        except Exception:  # pragma: no cover - defensive
+            felt = {}
+    sb = session_beats if isinstance(session_beats, int) else None
+    return Ctx(state=state, tools=tools, session_beats=sb, struct=struct, felt=felt)
+
+
+# ── small ctx predicates (all engine-state / tool-count, never fiction) ───────────────────────
+
+def _beats_at_least(ctx: Ctx, n: int) -> Optional[bool]:
+    """True/False when beats are known; None (⇒ N/A) when session_beats is None. Every
+    beats-keyed precondition routes through this so the None ⇒ N/A rule is uniform."""
+    if ctx.session_beats is None:
+        return None
+    return ctx.session_beats >= n
+
+
+def _companion_in_party(ctx: Ctx) -> bool:
+    return bool(ctx.struct.get("recruited")) or bool(_companions(ctx.state))
+
+
+def _final_day(ctx: Ctx) -> int:
+    return _int(ctx.state.get("day"), 0)
+
+
+def _tool(ctx: Ctx, name: str) -> int:
+    return _int(ctx.tools.get(name), 0)
+
+
+# ── the SystemSpec manifest ───────────────────────────────────────────────────────────────────
+
+class SystemSpec(NamedTuple):
+    id: str
+    # precondition: did the run have any OCCASION to engage this system? True ⇒ owed; False ⇒
+    # N/A; None ⇒ N/A (a beats-keyed precondition with no beats count — safe under-detect).
+    precondition: Callable[[Ctx], Optional[bool]]
+    # detector: did the engine state / tool counts prove the system actually fired?
+    detector: Callable[[Ctx], bool]
+    severity: str  # 'warn' | 'fatal' — ALL 'warn' this PR (graduation is a future PR)
+
+
+# ── the 10 systems ────────────────────────────────────────────────────────────────────────────
+# Each precondition reads ONLY engine-mutated snapshot fields / tool counts; each detector the
+# same. Where a precondition is beats-keyed it routes through _beats_at_least (None ⇒ N/A).
+
+# 1 companion_approval — a recruited companion + a substantial run ⇒ regard should have moved.
+def _pc_companion_approval(ctx: Ctx) -> Optional[bool]:
+    b = _beats_at_least(ctx, 10)
+    if b is None:
+        return None
+    return b and _companion_in_party(ctx)
+
+
+def _dt_companion_approval(ctx: Ctx) -> bool:
+    if any(_int(c.get("attitude_value")) != 0 for c in _companions(ctx.state)):
+        return True
+    if any(_as_list(c.get("approval_log")) for c in _companions(ctx.state)):
+        return True
+    if bool(ctx.struct.get("approval_moved")):
+        return True
+    return _tool(ctx, "adjust_attitude") > 0
+
+
+# 2 camp_downtime — a companion present + a multi-day arc ⇒ the party should have camped.
+def _pc_camp_downtime(ctx: Ctx) -> Optional[bool]:
+    b = _beats_at_least(ctx, 10)
+    if b is None:
+        return None
+    return b and _companion_in_party(ctx) and _final_day(ctx) > 1
+
+
+def _dt_camp_downtime(ctx: Ctx) -> bool:
+    if any(_int(c.get("last_long_rest_day"), -1) >= 0 for c in _characters(ctx.state)):
+        return True
+    if bool(ctx.struct.get("camped")):
+        return True
+    return (_tool(ctx, "camp_scene") + _tool(ctx, "record_camp_beat")
+            + _tool(ctx, "long_rest")) > 0
+
+
+# 3 quests_objectives — a quest exists + a moderate run ⇒ at least one objective/quest resolved.
+def _pc_quests_objectives(ctx: Ctx) -> Optional[bool]:
+    b = _beats_at_least(ctx, 6)
+    if b is None:
+        return None
+    return b and bool(_as_list(ctx.state.get("quests")))
+
+
+def _dt_quests_objectives(ctx: Ctx) -> bool:
+    quests = [q for q in _as_list(ctx.state.get("quests")) if isinstance(q, dict)]
+    if any(q.get("status") == "completed" for q in quests):
+        return True
+    if any(_as_list(q.get("completed_objectives")) for q in quests):
+        return True
+    if bool(ctx.struct.get("quest_resolved")):
+        return True
+    return (_tool(ctx, "complete_quest") + _tool(ctx, "complete_objective")) > 0
+
+
+# 4 acts_advance — a long run with an arc/act-tagged world ⇒ the arc should leave act 1.
+def _pc_acts_advance(ctx: Ctx) -> Optional[bool]:
+    b = _beats_at_least(ctx, 24)
+    if b is None:
+        return None
+    if not b:
+        return False
+    has_arc = bool(_narrative_arc(ctx.state))
+    tag_acts = _int(ctx.felt.get("acts_tag_reached"), 0)
+    return has_arc or tag_acts >= 2
+
+
+def _dt_acts_advance(ctx: Ctx) -> bool:
+    if _int(_narrative_arc(ctx.state).get("act"), 0) > 1:
+        return True
+    return _int(ctx.felt.get("acts_tag_reached"), 0) >= 2
+
+
+# 5 consequences_fired — a consequence owed strictly BEFORE the final day ⇒ it should have fired.
+def _consequences(ctx: Ctx) -> list:
+    return [c for c in _as_list(ctx.state.get("consequences")) if isinstance(c, dict)]
+
+
+def _owed_consequences(ctx: Ctx) -> list:
+    """Consequences whose trigger_day is STRICTLY < the final day. trigger_day == final_day is
+    WARN-not-owed (it may legitimately fire on the very last beat we didn't see); future-dated
+    is N/A (not yet due). Only a strictly-past-due consequence is OWED a fired flag."""
+    final = _final_day(ctx)
+    out = []
+    for c in _consequences(ctx):
+        td = c.get("trigger_day")
+        if td is None:
+            continue
+        if _int(td, default=final) < final:
+            out.append(c)
+    return out
+
+
+def _pc_consequences_fired(ctx: Ctx) -> Optional[bool]:
+    # Snapshot-only precondition (no beats key): owed iff a consequence is strictly past due.
+    return bool(_owed_consequences(ctx))
+
+
+def _dt_consequences_fired(ctx: Ctx) -> bool:
+    return all(bool(c.get("fired")) for c in _owed_consequences(ctx)) and bool(
+        _owed_consequences(ctx))
+
+
+# 6 factions_membership — a joinable faction seeded + a substantial run ⇒ should have joined.
+def _factions(ctx: Ctx) -> list:
+    return [f for f in _as_list(ctx.state.get("factions")) if isinstance(f, dict)]
+
+
+def _pc_factions_membership(ctx: Ctx) -> Optional[bool]:
+    b = _beats_at_least(ctx, 10)
+    if b is None:
+        return None
+    joinable = any(str(f.get("questline_arc_id") or "") for f in _factions(ctx))
+    return b and bool(_factions(ctx)) and joinable
+
+
+def _dt_factions_membership(ctx: Ctx) -> bool:
+    if any(bool(f.get("joined")) or _int(f.get("standing")) > 0 for f in _factions(ctx)):
+        return True
+    return _tool(ctx, "join_faction") > 0
+
+
+# 7 faction_arc — a faction arc seeded AND a faction joined ⇒ the arc should have unlocked/moved.
+# BLOCKED (stays WARN regardless): a snapshot-only precondition can't tell "seeded-but-locked"
+# from "never-seeded" beyond the joined latch — a known open spike. Detector is generous.
+def _faction_arcs(ctx: Ctx) -> list:
+    return [a for a in _as_list(ctx.state.get("faction_arcs")) if isinstance(a, dict)]
+
+
+def _pc_faction_arc(ctx: Ctx) -> Optional[bool]:
+    arcs = _faction_arcs(ctx)
+    joined = any(bool(f.get("joined")) for f in _factions(ctx))
+    return bool(arcs) and joined
+
+
+def _dt_faction_arc(ctx: Ctx) -> bool:
+    for a in _faction_arcs(ctx):
+        if str(a.get("status") or "locked") != "locked":
+            return True
+        for st in _as_list(a.get("stages")):
+            if isinstance(st, dict) and st.get("status") in ("available", "active", "resolved"):
+                return True
+    return _tool(ctx, "advance_faction_arc") > 0
+
+
+# 8 companion_quest_arc — a companion quest arc seeded + a substantial run ⇒ should have moved.
+# BLOCKED (stays WARN regardless): same seeded-but-locked vs never-seeded ambiguity as #7.
+def _companion_quest_arcs(ctx: Ctx) -> list:
+    return [a for a in _as_list(ctx.state.get("companion_quest_arcs")) if isinstance(a, dict)]
+
+
+def _pc_companion_quest_arc(ctx: Ctx) -> Optional[bool]:
+    b = _beats_at_least(ctx, 10)
+    if b is None:
+        return None
+    return b and bool(_companion_quest_arcs(ctx))
+
+
+def _dt_companion_quest_arc(ctx: Ctx) -> bool:
+    for a in _companion_quest_arcs(ctx):
+        if str(a.get("status") or "locked") != "locked":
+            return True
+        for st in _as_list(a.get("stages")):
+            if isinstance(st, dict) and st.get("status") in ("available", "active", "resolved"):
+                return True
+    return _tool(ctx, "advance_companion_quest_arc") > 0
+
+
+# 9 companion_agenda — a companion with an authored agenda + a substantial run ⇒ it should fire
+#   (or at least be evaluated). The agenda lives at character.arc.agenda.
+def _companions_with_agenda(ctx: Ctx) -> list:
+    out = []
+    for c in _companions(ctx.state):
+        arc = c.get("arc")
+        agenda = arc.get("agenda") if isinstance(arc, dict) else None
+        if isinstance(agenda, dict):
+            out.append(c)
+    return out
+
+
+def _pc_companion_agenda(ctx: Ctx) -> Optional[bool]:
+    b = _beats_at_least(ctx, 10)
+    if b is None:
+        return None
+    return b and bool(_companions_with_agenda(ctx))
+
+
+def _dt_companion_agenda(ctx: Ctx) -> bool:
+    for c in _companions_with_agenda(ctx):
+        agenda = c["arc"].get("agenda")
+        if isinstance(agenda, dict) and bool(agenda.get("fired")):
+            return True
+    return _tool(ctx, "check_companion_arc") > 0
+
+
+# 10 decisions_recorded — any substantial run ⇒ the party made a callback-worthy choice.
+def _pc_decisions_recorded(ctx: Ctx) -> Optional[bool]:
+    return _beats_at_least(ctx, 10)
+
+
+def _dt_decisions_recorded(ctx: Ctx) -> bool:
+    if bool(_as_list(ctx.state.get("decisions"))):
+        return True
+    return _tool(ctx, "record_decision") > 0
+
+
+SYSTEMS: tuple[SystemSpec, ...] = (
+    SystemSpec("companion_approval", _pc_companion_approval, _dt_companion_approval, "warn"),
+    SystemSpec("camp_downtime", _pc_camp_downtime, _dt_camp_downtime, "warn"),
+    SystemSpec("quests_objectives", _pc_quests_objectives, _dt_quests_objectives, "warn"),
+    SystemSpec("acts_advance", _pc_acts_advance, _dt_acts_advance, "warn"),
+    SystemSpec("consequences_fired", _pc_consequences_fired, _dt_consequences_fired, "warn"),
+    SystemSpec("factions_membership", _pc_factions_membership, _dt_factions_membership, "warn"),
+    SystemSpec("faction_arc", _pc_faction_arc, _dt_faction_arc, "warn"),
+    SystemSpec("companion_quest_arc", _pc_companion_quest_arc, _dt_companion_quest_arc, "warn"),
+    SystemSpec("companion_agenda", _pc_companion_agenda, _dt_companion_agenda, "warn"),
+    SystemSpec("decisions_recorded", _pc_decisions_recorded, _dt_decisions_recorded, "warn"),
+)
+
+# The REVIEWED manifest — the forcing meta-test asserts {s.id for s in SYSTEMS} == this set, so
+# adding/removing a system is a deliberate, visible diff (mirrors test_tool_schema_budget.py).
+REVIEWED_SYSTEM_IDS = frozenset(s.id for s in SYSTEMS)
+
+# Systems that BLOCK on a known snapshot-only ambiguity (seeded-but-locked vs never-seeded) and
+# must NEVER graduate past WARN until the spike is resolved. Documented so graduation can't miss
+# them. (Today every system is WARN; these two are the durable carve-out.)
+BLOCKED_SYSTEM_IDS = frozenset({"faction_arc", "companion_quest_arc"})
+
+
+def _combat_sprint_active() -> bool:
+    """Mirror qa/assert_behavioral.py: under WORLDOS_GATE_COMBAT_SPRINT a single pre-seeded
+    fight legitimately exercises no story system, so FATAL systems are skipped."""
+    return bool(os.environ.get("WORLDOS_GATE_COMBAT_SPRINT"))
+
+
+def engagement_coverage(state: Optional[dict], tool_counts: Optional[dict] = None,
+                        session_beats: Optional[int] = None) -> dict:
+    """Classify every system in the manifest for one run.
+
+    Returns::
+
+        {
+          "coverage": "engaged/expected",   # e.g. "2/4" — engaged over (engaged+inert)
+          "engaged":  [id, ...],            # detector true (precondition irrelevant once engaged)
+          "na":       [id, ...],            # precondition false / unknown ⇒ no occasion to engage
+          "inert":    [{"id","why","severity"}, ...],  # OWED (precondition true) but never fired
+        }
+
+    ENGAGED if detector true; N/A if precondition false-or-None; INERT iff precondition is TRUE
+    AND detector is FALSE. Under WORLDOS_GATE_COMBAT_SPRINT, FATAL systems are skipped entirely
+    (treated as N/A) — wired now for safe graduation; a no-op while every system is WARN."""
+    ctx = build_ctx(state, tool_counts, session_beats)
+    sprint = _combat_sprint_active()
+
+    engaged: list[str] = []
+    na: list[str] = []
+    inert: list[dict] = []
+
+    for spec in SYSTEMS:
+        if sprint and spec.severity == "fatal":
+            # Combat-sprint: a FATAL system is skipped (counted as N/A, never inert). WARN
+            # systems still report (they can't false-RED), matching assert_behavioral's split.
+            na.append(spec.id)
+            continue
+        try:
+            engaged_now = bool(spec.detector(ctx))
+        except Exception:  # pragma: no cover - a detector must never crash the scorer
+            engaged_now = False
+        if engaged_now:
+            engaged.append(spec.id)
+            continue
+        try:
+            pre = spec.precondition(ctx)
+        except Exception:  # pragma: no cover - a precondition must never crash the scorer
+            pre = None
+        if pre:  # precondition TRUE and detector FALSE ⇒ INERT (the signal)
+            inert.append({
+                "id": spec.id,
+                "why": _inert_why(spec, ctx),
+                "severity": spec.severity,
+            })
+        else:  # precondition False or None ⇒ N/A (no occasion / unknown beats)
+            na.append(spec.id)
+
+    expected = len(engaged) + len(inert)
+    return {
+        "coverage": f"{len(engaged)}/{expected}",
+        "engaged": engaged,
+        "na": na,
+        "inert": inert,
+    }
+
+
+_WHY = {
+    "companion_approval": "a recruited companion's regard never moved off 0 (no attitude_value, "
+                          "approval_log, or adjust_attitude) across a substantial run",
+    "camp_downtime": "no character ever long-rested and no camp beat fired in a multi-day run "
+                     "with a companion present",
+    "quests_objectives": "a quest was seeded but no objective/quest was ever completed",
+    "acts_advance": "the arc never left act 1 in a long run with an act-tagged world / engine arc",
+    "consequences_fired": "a consequence came due (trigger_day before the final day) but never fired",
+    "factions_membership": "a joinable faction was seeded but the party never joined "
+                           "(no joined latch, no standing, no join_faction)",
+    "faction_arc": "a faction arc exists and a faction was joined but no stage ever unlocked/moved "
+                   "[BLOCKED: snapshot can't tell seeded-but-locked from never-seeded — stays WARN]",
+    "companion_quest_arc": "a companion quest arc was seeded but no stage ever unlocked/moved "
+                           "[BLOCKED: snapshot can't tell seeded-but-locked from never-seeded — stays WARN]",
+    "companion_agenda": "a companion carries an authored agenda but it never fired and the arc was "
+                        "never evaluated (check_companion_arc)",
+    "decisions_recorded": "a substantial run recorded no callback-worthy decision",
+}
+
+
+def _inert_why(spec: SystemSpec, ctx: Ctx) -> str:
+    base = _WHY.get(spec.id, f"{spec.id} was owed but never engaged")
+    beats = "" if ctx.session_beats is None else f" (session_beats={ctx.session_beats})"
+    return base + beats
+
+
+# Snake_case id guard reused by the forcing meta-test (kept here so the rule lives with the data).
+_SNAKE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _is_snake(s: str) -> bool:
+    return bool(_SNAKE.match(s))
+
+
+def main(argv: list[str]) -> int:
+    """CLI: print the engagement-coverage block for a snapshot.json (no beats ⇒ beats-keyed
+    systems N/A). For ad-hoc inspection; the sweep wires this via inject_structural_coverage."""
+    import json
+    if not argv or argv[0] in ("-h", "--help"):
+        print(__doc__)
+        return 0
+    state = {}
+    try:
+        state = json.loads(Path(argv[0]).read_text(encoding="utf-8"))
+    except Exception as e:
+        print(f"could not read snapshot {argv[0]!r}: {e}", file=sys.stderr)
+        return 2
+    sb = int(argv[1]) if len(argv) > 1 and argv[1].isdigit() else None
+    block = engagement_coverage(state if isinstance(state, dict) else {}, None, sb)
+    print(json.dumps(block, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/qa/feature_engagement.py
+++ b/qa/feature_engagement.py
@@ -251,6 +251,13 @@ def _owed_consequences(ctx: Ctx) -> list:
         td = c.get("trigger_day")
         if td is None:
             continue
+        # Re-armed standing-thread (worldsim) consequences are NEVER "owed a fired flag": worldsim.tick
+        # rolls their trigger_day forward IN PLACE keeping fired=False forever, so a past-due unfired
+        # thread is the engine's EXPECTED state, not a dead system. The engine's own due/overdue
+        # contract excludes them in the same way (consequences.due reads `not c.thread_id`; scene_debt
+        # skips `if con.thread_id`). Match it, else a healthy living world false-INERTs consequences_fired.
+        if str(c.get("thread_id") or ""):
+            continue
         if _int(td, default=final) < final:
             out.append(c)
     return out
@@ -382,9 +389,26 @@ SYSTEMS: tuple[SystemSpec, ...] = (
     SystemSpec("decisions_recorded", _pc_decisions_recorded, _dt_decisions_recorded, "warn"),
 )
 
-# The REVIEWED manifest — the forcing meta-test asserts {s.id for s in SYSTEMS} == this set, so
-# adding/removing a system is a deliberate, visible diff (mirrors test_tool_schema_budget.py).
-REVIEWED_SYSTEM_IDS = frozenset(s.id for s in SYSTEMS)
+# The REVIEWED manifest — an INDEPENDENT hardcoded literal of the system ids a human has signed off
+# on. The forcing meta-test asserts {s.id for s in SYSTEMS} == this set, so adding/removing a system
+# in SYSTEMS is a deliberate, visible diff that ALSO must be reflected here (this literal is NOT
+# derived from SYSTEMS — a derived set would be a tautology that can never fail). NOTE: this guards
+# manifest DRIFT (an edit to SYSTEMS without updating the reviewed set); it does not yet auto-detect
+# a brand-new player-facing engine system that was never added to the manifest at all — that
+# stronger forcing (enumerate the live tool set and map each story-bearing tool to a system) is a
+# documented follow-up, since it needs a tool->system classification.
+REVIEWED_SYSTEM_IDS = frozenset({
+    "companion_approval",
+    "camp_downtime",
+    "quests_objectives",
+    "acts_advance",
+    "consequences_fired",
+    "factions_membership",
+    "faction_arc",
+    "companion_quest_arc",
+    "companion_agenda",
+    "decisions_recorded",
+})
 
 # Systems that BLOCK on a known snapshot-only ambiguity (seeded-but-locked vs never-seeded) and
 # must NEVER graduate past WARN until the spike is resolved. Documented so graduation can't miss

--- a/qa/inject_structural_coverage.py
+++ b/qa/inject_structural_coverage.py
@@ -136,8 +136,14 @@ def main(argv: list[str]) -> int:
         # Honest no-op: nothing to merge (no snapshot). Print nothing → the sweep note omits it.
         return 0
     # WS0 engagement block (additive, beside structural_coverage). Computed from the SAME
-    # snapshot/transcript; None only if the engagement scorer is unavailable.
-    engagement = compute_engagement(argv[1], argv[2] if len(argv) > 2 else None)
+    # snapshot/transcript; None only if the engagement scorer is unavailable. Guarded so an
+    # unforeseen scorer error can NEVER flip this inject step's exit code (mirrors the defensive
+    # callsite in assert_behavioral.py) — the structural-coverage injection must stay as reliable
+    # as it was before WS0.
+    try:
+        engagement = compute_engagement(argv[1], argv[2] if len(argv) > 2 else None)
+    except Exception:
+        engagement = None
     # Merge additively into score.json (leave every existing field untouched).
     if score_path.exists():
         try:

--- a/qa/inject_structural_coverage.py
+++ b/qa/inject_structural_coverage.py
@@ -32,6 +32,14 @@ try:
     from story_readout import structural_coverage_from_state
 except Exception:  # pragma: no cover - defensive
     structural_coverage_from_state = None  # type: ignore[assignment]
+# WS0 — the feature-engagement coverage scorer. No beats count is available at this callsite
+# (beats live in the transcript, not the snapshot), so it is passed session_beats=None → every
+# beats-keyed system reads N/A here (safe under-detect). Defensive import: a missing module just
+# omits the engagement block.
+try:
+    from feature_engagement import engagement_coverage
+except Exception:  # pragma: no cover - defensive
+    engagement_coverage = None  # type: ignore[assignment]
 
 
 def _largest_snapshot(store: Path) -> Path | None:
@@ -95,6 +103,28 @@ def compute(store_dir: str, transcript_path: str | None = None) -> dict | None:
     return structural_coverage_from_state(state, dict(counts) if counts else None)
 
 
+def compute_engagement(store_dir: str, transcript_path: str | None = None) -> dict | None:
+    """WS0 — the engagement-coverage block for a persona's play-state store, or None when the
+    snapshot is missing/unreadable. session_beats is None here (beats live in the transcript,
+    not the snapshot) → every beats-keyed system reads N/A (safe under-detect, never a
+    false-RED). Reuses the SAME snapshot + tool-counts resolution as compute()."""
+    if engagement_coverage is None:
+        return None
+    store = Path(store_dir)
+    snap = _largest_snapshot(store)
+    if snap is None:
+        return None
+    try:
+        state = json.loads(snap.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(state, dict) or not state:
+        return None
+    transcript = Path(transcript_path) if transcript_path else (store / "dm.combined.jsonl")
+    counts = _tool_counts(transcript)
+    return engagement_coverage(state, dict(counts) if counts else None, session_beats=None)
+
+
 def main(argv: list[str]) -> int:
     if len(argv) < 2:
         print("usage: inject_structural_coverage.py <score.json> <state-store-dir> "
@@ -105,6 +135,9 @@ def main(argv: list[str]) -> int:
     if block is None:
         # Honest no-op: nothing to merge (no snapshot). Print nothing → the sweep note omits it.
         return 0
+    # WS0 engagement block (additive, beside structural_coverage). Computed from the SAME
+    # snapshot/transcript; None only if the engagement scorer is unavailable.
+    engagement = compute_engagement(argv[1], argv[2] if len(argv) > 2 else None)
     # Merge additively into score.json (leave every existing field untouched).
     if score_path.exists():
         try:
@@ -114,6 +147,8 @@ def main(argv: list[str]) -> int:
         if not isinstance(score, dict):
             score = {}
         score["structural_coverage"] = block
+        if engagement is not None:
+            score["engagement_coverage"] = engagement
         score_path.write_text(json.dumps(score, indent=2), encoding="utf-8")
     # One-line summary to stdout for the sweep's per-persona note.
     print(block.get("summary", ""))

--- a/qa/release_readiness.py
+++ b/qa/release_readiness.py
@@ -99,8 +99,27 @@ DETERMINISTIC_GATES = (
     "ui_audit",
     "image_render",
     "palette_live",
+    # WS0: story_engagement is a DETERMINISTIC, snapshot-derived measurement (no live LLM) —
+    # it joins this set ONLY when engagement evidence is present (else an evidence-gap skip,
+    # never a deterministic fail), exactly like the latency gates.
+    "story_engagement",
 )
 LATENCY_GATES = ("latency_s_per_beat", "latency_coldopen")
+
+# WS0 — short fix hints printed beside each inert authored system in the ENGAGEMENT section
+# (which engine tool the DM should reach for to make the dead system fire in a real beat).
+_ENGAGEMENT_FIX_HINTS = {
+    "companion_approval": "move a companion's regard (record_decision approval_tags / adjust_attitude)",
+    "camp_downtime": "run a camp beat / long_rest in the multi-day arc (camp_scene / long_rest)",
+    "quests_objectives": "complete an objective or quest (complete_objective / complete_quest)",
+    "acts_advance": "advance the narrative arc past act 1 (drive the engine narrative_arc cursor)",
+    "consequences_fired": "let the due consequence fire (advance_time past its trigger_day)",
+    "factions_membership": "join the seeded faction (join_faction)",
+    "faction_arc": "advance the joined faction's arc (advance_faction_arc) [BLOCKED spike — stays WARN]",
+    "companion_quest_arc": "advance the companion quest arc (advance_companion_quest_arc) [BLOCKED spike — stays WARN]",
+    "companion_agenda": "evaluate/fire the companion agenda (check_companion_arc)",
+    "decisions_recorded": "record a callback-worthy choice (record_decision)",
+}
 
 # Default per-beat latency budget — overridden by qa/latency_baseline.json when present.
 # Healthy ledger figures (qa/scores_ledger.md) are ~78 s/beat and ~157 cold-open; these
@@ -829,6 +848,12 @@ def main() -> int:
             "part_a_failure_detail": (rj.get("part_a") or {}).get("failure_detail") or "",
             "part_b_failure_bucket": (rj.get("part_b") or {}).get("failure_bucket") or "",
             "part_b_failure_detail": (rj.get("part_b") or {}).get("failure_detail") or "",
+            # WS0 — the feature-engagement coverage block (inject_structural_coverage merges it
+            # into score.json). None when absent (a legacy corpus) → the story_engagement gate is
+            # an evidence-gap SKIP, never a fail (mirrors the latency-gate skip). Carried raw so
+            # the per-system owed/engaged roll-up below reads it.
+            "engagement_coverage": sc.get("engagement_coverage")
+            if isinstance(sc.get("engagement_coverage"), dict) else None,
         })
 
     if not expected_personas:
@@ -1115,6 +1140,45 @@ def main() -> int:
         f"budget={coldopen_s_budget}"
     )
 
+    # ---- WS0 ADDITIVE story_engagement gate (the dead-system tracker) ----
+    # Roll the per-persona feature-engagement blocks (qa/feature_engagement.engagement_coverage,
+    # merged into score.json by inject_structural_coverage) up across the sweep. A system is
+    # "owed" if ANY persona owed it (engaged OR inert), "engaged" if ANY persona engaged it;
+    # a system is INERT for the sweep iff it was owed by at least one persona AND no persona ever
+    # engaged it — the authored subsystem was dead across the WHOLE sweep. The gate FAILS only on
+    # a FATAL inert system; with WS0 all-WARN, a WARN-only inert set never fails the gate (it is
+    # reported, not gated) — strictly additive. EVIDENCE-GAP SKIP: if NO persona block carries
+    # engagement_coverage (a legacy corpus / a run before this stamping), the gate is SKIPPED, not
+    # failed, so RRI math stays byte-identical (mirrors the latency-gate skip).
+    engagement_blocks = [p["engagement_coverage"] for p in persona_scores
+                         if isinstance(p.get("engagement_coverage"), dict)]
+    engagement_evidence_present = bool(engagement_blocks)
+    sweep_engaged: set[str] = set()
+    sweep_owed: dict[str, str] = {}  # system id -> worst-seen severity ('fatal' beats 'warn')
+    for blk in engagement_blocks:
+        for sid in blk.get("engaged", []) or []:
+            sweep_engaged.add(str(sid))
+            sweep_owed.setdefault(str(sid), "warn")
+        for item in blk.get("inert", []) or []:
+            sid = str(item.get("id", ""))
+            if not sid:
+                continue
+            sev = "fatal" if item.get("severity") == "fatal" else "warn"
+            if sweep_owed.get(sid) != "fatal":
+                sweep_owed[sid] = sev
+    sweep_inert = sorted(sid for sid in sweep_owed if sid not in sweep_engaged)
+    sweep_inert_fatal = sorted(sid for sid in sweep_inert if sweep_owed.get(sid) == "fatal")
+    sweep_inert_warn = sorted(sid for sid in sweep_inert if sweep_owed.get(sid) != "fatal")
+    # PASS unless a FATAL system is inert across the whole sweep. (All-WARN ⇒ always passes when
+    # evidence is present; a WARN-only inert set is surfaced, not gated.)
+    story_engagement_ok = not sweep_inert_fatal
+    story_engagement_detail = (
+        f"inert_fatal={sweep_inert_fatal or 'none'}; inert_warn={sweep_inert_warn or 'none'}; "
+        f"engaged={sorted(sweep_engaged) or 'none'}"
+        if engagement_evidence_present
+        else "n/a (no engagement_coverage in any persona score.json — evidence gap)"
+    )
+
     # ---- the gate set (each evaluated gate contributes to RRI; all must hold for 10/10) ----
     gates = {
         "native_gate":        (native == "PASS" and not (evidence_gap_gates & native_evidence_gap_gates),
@@ -1140,6 +1204,7 @@ def main() -> int:
                                f"palette_live={args.palette_live or 'n/a'}"),
         "latency_s_per_beat": (latency_s_per_beat_ok, latency_s_per_beat_detail),
         "latency_coldopen":   (latency_coldopen_ok, latency_coldopen_detail),
+        "story_engagement":   (story_engagement_ok, story_engagement_detail),
     }
 
     # SKIPPED gates are excluded from passed / total_gates (never counted as pass OR fail):
@@ -1150,6 +1215,10 @@ def main() -> int:
         skipped_gates.append("latency_s_per_beat")
     if agg_coldopen_s is None:
         skipped_gates.append("latency_coldopen")
+    # WS0: no engagement evidence anywhere → the story_engagement gate is an evidence-gap skip
+    # (excluded from passed/total), so a legacy corpus's RRI is byte-identical (mirrors latency).
+    if not engagement_evidence_present:
+        skipped_gates.append("story_engagement")
     if args.deterministic_only:
         skipped_gates.extend(g for g in LLM_PERSONA_GATES if g not in skipped_gates)
     skipped_set = set(skipped_gates)
@@ -1302,6 +1371,13 @@ def main() -> int:
                 str(p["latency_source"]) for p in persona_scores
                 if p.get("latency_source") and p.get("latency_source") != "none"
             }),
+            # WS0 engagement signals. None/empty when no persona carried an engagement block
+            # (the story_engagement gate is then an evidence-gap skip, never a fabricated pass).
+            "engagement_evidence_present": engagement_evidence_present,
+            "engagement_engaged": sorted(sweep_engaged),
+            "engagement_inert": sweep_inert,
+            "engagement_inert_fatal": sweep_inert_fatal,
+            "engagement_inert_warn": sweep_inert_warn,
         },
         "gate_detail": {name: detail for name, (ok, detail) in gates.items()},
         "personas": persona_scores,
@@ -1335,6 +1411,21 @@ def main() -> int:
         print("  FAILED: " + ", ".join(details))
     if evidence_gaps:
         print("  EVIDENCE GAPS: " + "; ".join(f"{g['gate']} missing {g['missing']}" for g in evidence_gaps))
+
+    # WS0 ENGAGEMENT section — name each dead authored system across the sweep + a fix hint, so an
+    # all-inert subsystem (the failure WS0 exists to surface) is visible even while it is WARN-only.
+    if engagement_evidence_present:
+        if sweep_inert:
+            print("  ENGAGEMENT — INERT systems across the sweep (authored but never engaged):")
+            for sid in sweep_inert:
+                sev = sweep_owed.get(sid, "warn").upper()
+                hint = _ENGAGEMENT_FIX_HINTS.get(sid, "engage the system's engine tool in a real beat")
+                print(f"    [{sev}] {sid} — {hint}")
+            if not sweep_inert_fatal:
+                print("    (all WARN — reported, not gated; the story_engagement gate still PASSES)")
+        else:
+            print("  ENGAGEMENT — every owed authored system was engaged "
+                  f"({sorted(sweep_engaged)})")
 
     if args.scorecard_row:
         sha = (args.build_sha or "?")[:7]

--- a/qa/scores_db.py
+++ b/qa/scores_db.py
@@ -131,6 +131,13 @@ COLUMNS: tuple[str, ...] = (
     # (additive, migration-free). ---
     "acts_reached",       # max distinct authored act reached (1/2/3), NULL if not measured
     "structural_coverage",# one-line human roll-up, e.g. "acts 1/3 · recruit ✓ · camp · · quest-resolved ·"
+    # --- WS0 feature-engagement coverage (the dead-system tracker; manifest of authored story
+    # systems). engagement_pct = engaged/(engaged+inert) over the manifest (N/A systems excluded);
+    # engagement_inert = the comma-joined ids of systems that were OWED but never engaged. Derived
+    # from the engine snapshot + DM tool counts by qa/feature_engagement.engagement_coverage. NULL
+    # on rows recorded before this stamping (additive, migration-free). ---
+    "engagement_pct",     # engaged/(engaged+inert) fraction (0.0-1.0), NULL if not measured
+    "engagement_inert",   # comma-joined inert system ids, e.g. "companion_approval,camp_downtime"
     "pass",               # 1 (pass) / 0 (fail) / NULL (no pass/fail verdict)
     "source_path",        # where the evidence lives (file/dir, LEXAR or repo-relative)
     "notes",              # free-text context: what was under test, caveats, confidence flags
@@ -150,6 +157,8 @@ _REAL_COLS = {
     # Wave-1 1B per-kind + per-tool timing (seconds / ms / ratio → REAL; slowest_tool is TEXT)
     "combat_s_per_beat", "social_s_per_beat", "mean_tool_call_ms", "tool_exec_pct",
     "duration_wall_s",
+    # WS0 engagement coverage fraction (0.0-1.0 → REAL; engagement_inert is TEXT)
+    "engagement_pct",
 }
 _INT_COLS = {"critical_bugs", "pass", "is_canonical_baseline", "acts_reached"}
 
@@ -411,6 +420,8 @@ _MD_COLS = [
     ("slowest_tool", "slowest tool"),
     ("acts_reached", "Acts"),
     ("structural_coverage", "Structural coverage"),
+    ("engagement_pct", "Engagement"),
+    ("engagement_inert", "Inert systems"),
     ("pass", "Pass"),
     ("source_path", "Source"),
     ("notes", "Notes"),

--- a/qa/test_deterministic_rri_gate.py
+++ b/qa/test_deterministic_rri_gate.py
@@ -216,9 +216,15 @@ class DeterministicAndLatencyTests(unittest.TestCase):
             self.assertFalse(payload["deterministic_only"])
             self.assertTrue(payload["release_ready"])
             # ADDITIVE invariant: with no latency evidence the two latency gates are an
-            # evidence-gap skip, so gates_total stays the pre-Phase-3 count of 11 (byte-
-            # identical RRI math) — they are skipped, never failed, never counted.
-            self.assertEqual(set(payload["skipped_gates"]), set(LATENCY_GATES))
+            # evidence-gap skip, AND (WS0) with no engagement_coverage in any persona score.json
+            # the story_engagement gate is likewise an evidence-gap skip — so gates_total stays
+            # the pre-Phase-3 count of 11 (byte-identical RRI math). The evidence-gap-skipped gates
+            # are exactly {latency_s_per_beat, latency_coldopen, story_engagement}; none are
+            # failed or counted.
+            self.assertEqual(
+                set(payload["skipped_gates"]),
+                set(LATENCY_GATES) | {"story_engagement"},
+            )
             self.assertEqual(payload["gates_total"], 11)
             self.assertEqual(payload["rri"], 10.0)
 
@@ -353,6 +359,101 @@ class DeterministicAndLatencyTests(unittest.TestCase):
             # still no LLM gate failed
             for gate in LLM_PERSONA_GATES:
                 self.assertNotIn(gate, payload["failed_gates"])
+
+    # ---- (3) WS0 story_engagement gate ----
+
+    def _write_engagement_into_scores(self, runs: list[Path], block: dict) -> None:
+        """Merge an engagement_coverage block into every persona score.json (what
+        inject_structural_coverage does on a real sweep)."""
+        for run in runs:
+            sc = json.loads((run / "score.json").read_text(encoding="utf-8"))
+            sc["engagement_coverage"] = block
+            (run / "score.json").write_text(json.dumps(sc), encoding="utf-8")
+
+    def test_engagement_absent_is_evidence_gap_skip_not_a_fail(self):
+        # No engagement_coverage anywhere → story_engagement is an evidence-gap SKIP, never a
+        # fail; gates_total stays 11 (byte-identical), RRI 10.0, release_ready True.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            runs = self._five_runs(tmp)
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            rc, _t, payload = self.run_rri(
+                tmp, *self._common_args(runs, story, mech, behavioral, audit, palette))
+            self.assertEqual(rc, 0)
+            self.assertIn("story_engagement", payload["skipped_gates"])
+            self.assertNotIn("story_engagement", payload["failed_gates"])
+            self.assertEqual(payload["gates_total"], 11)
+            self.assertTrue(payload["release_ready"])
+            self.assertFalse(payload["signals"]["engagement_evidence_present"])
+
+    def test_engagement_present_all_warn_inert_passes_gate_but_reports(self):
+        # WS0 all-WARN: an inert system (warn severity) across the sweep is REPORTED but the gate
+        # still PASSES (no FATAL inert). gates_total becomes 12 (the gate is now evaluated), and
+        # the single passing gate keeps RRI at 10.0.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            runs = self._five_runs(tmp)
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            self._write_engagement_into_scores(runs, {
+                "coverage": "1/2",
+                "engaged": ["decisions_recorded"],
+                "na": ["factions_membership"],
+                "inert": [{"id": "companion_approval", "why": "regard never moved",
+                           "severity": "warn"}],
+            })
+            rc, text, payload = self.run_rri(
+                tmp, *self._common_args(runs, story, mech, behavioral, audit, palette))
+            self.assertEqual(rc, 0)
+            self.assertTrue(payload["release_ready"])
+            self.assertNotIn("story_engagement", payload["skipped_gates"])
+            self.assertNotIn("story_engagement", payload["failed_gates"])
+            self.assertEqual(payload["gates_total"], 12)  # gate now evaluated (evidence present)
+            self.assertEqual(payload["rri"], 10.0)        # all-WARN inert still PASSES
+            self.assertEqual(payload["signals"]["engagement_inert"], ["companion_approval"])
+            self.assertEqual(payload["signals"]["engagement_inert_fatal"], [])
+            self.assertIn("companion_approval", text)  # named in the ENGAGEMENT section
+
+    def test_engagement_owed_by_one_engaged_by_another_is_not_inert(self):
+        # Cross-persona roll-up: a system INERT for one persona but ENGAGED by another is engaged
+        # for the SWEEP (not inert) — the authored system fired SOMEWHERE.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            runs = self._five_runs(tmp)
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            for i, run in enumerate(runs):
+                sc = json.loads((run / "score.json").read_text(encoding="utf-8"))
+                if i == 0:
+                    sc["engagement_coverage"] = {
+                        "coverage": "0/1", "engaged": [], "na": [],
+                        "inert": [{"id": "camp_downtime", "why": "no camp", "severity": "warn"}]}
+                else:
+                    sc["engagement_coverage"] = {
+                        "coverage": "1/1", "engaged": ["camp_downtime"], "na": [], "inert": []}
+                (run / "score.json").write_text(json.dumps(sc), encoding="utf-8")
+            rc, _t, payload = self.run_rri(
+                tmp, *self._common_args(runs, story, mech, behavioral, audit, palette))
+            self.assertEqual(rc, 0)
+            self.assertIn("camp_downtime", payload["signals"]["engagement_engaged"])
+            self.assertNotIn("camp_downtime", payload["signals"]["engagement_inert"])
+
+    def test_engagement_fatal_inert_fails_gate(self):
+        # FORWARD-COMPAT (post-graduation): a FATAL inert system across the sweep FAILS the
+        # story_engagement gate. WS0 ships all-WARN, but the gate logic must already enforce this
+        # so graduation is a one-line manifest change, not a gate rewrite.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            runs = self._five_runs(tmp)
+            story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+            self._write_engagement_into_scores(runs, {
+                "coverage": "0/1", "engaged": [], "na": [],
+                "inert": [{"id": "quests_objectives", "why": "no quest resolved",
+                           "severity": "fatal"}]})
+            rc, _t, payload = self.run_rri(
+                tmp, *self._common_args(runs, story, mech, behavioral, audit, palette))
+            self.assertEqual(rc, 1)
+            self.assertIn("story_engagement", payload["failed_gates"])
+            self.assertEqual(payload["signals"]["engagement_inert_fatal"], ["quests_objectives"])
+            self.assertFalse(payload["release_ready"])
 
 
 if __name__ == "__main__":

--- a/qa/test_feature_engagement.py
+++ b/qa/test_feature_engagement.py
@@ -303,6 +303,21 @@ def test_consequence_due_and_fired_is_engaged():
     assert "consequences_fired" in _ids(block, "engaged")
 
 
+def test_threadtagged_past_due_consequence_is_na_not_inert():
+    """A re-armed worldsim standing-thread consequence (thread_id set) sits past-due with fired=False
+    FOREVER by design — worldsim.tick rolls its trigger_day forward IN PLACE — so the engine's own
+    due/overdue contract excludes threads (consequences.due `not c.thread_id`; scene_debt thread skip).
+    It must be N/A, never inert, else a perfectly healthy living world false-INERTs consequences_fired."""
+    state = _inert_state()
+    state["day"] = 10
+    state["consequences"] = [
+        {"trigger_day": 5, "fired": False, "thread_id": "thr_cult", "text": "the cult regroups"},
+    ]
+    block = fe.engagement_coverage(state, tool_counts={}, session_beats=12)
+    assert "consequences_fired" in _ids(block, "na")
+    assert "consequences_fired" not in _ids(block, "inert")
+
+
 # ── narrative_arc absent / None null-guard ────────────────────────────────────────────────────
 
 def test_narrative_arc_absent_does_not_crash_acts_advance():

--- a/qa/test_feature_engagement.py
+++ b/qa/test_feature_engagement.py
@@ -1,0 +1,344 @@
+"""WS0 behavior tests for qa/feature_engagement.engagement_coverage.
+
+The keystone is INERT-in-scope: a run that was OWED a system (precondition true) but never
+engaged it (detector false) must surface in `inert`. The CONDITIONAL N/A logic is the other
+half: a short run / a solo party / a factionless world / a combat-sprint must read those
+systems N/A — never inert — so the loop never false-flags a run that legitimately had no
+occasion to engage a system.
+
+Reuses the test_structural_coverage.py fixture SHAPE (engine-snapshot dicts) + the
+sys.path.insert(qa) import. Stdlib + pytest only; single-process:
+    uv run --directory servers/engine python -m pytest qa/test_feature_engagement.py -p no:xdist
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import feature_engagement as fe  # noqa: E402
+
+
+# ── fixtures (engine-snapshot shape, mirroring test_structural_coverage.py) ───────────────────
+
+def _inert_state() -> dict:
+    """A run OWED several systems that never fired: a companion in the party stuck at attitude 0
+    (with an authored agenda that never fired), nobody ever long-rested, a multi-location quest
+    left `active`, a joinable faction seeded but never joined, a companion-quest-arc seeded but
+    locked, a multi-day arc — the owner's dead-system failure shape."""
+    return {
+        "day": 6,
+        "party": ["pc1", "comp1"],
+        "characters": {
+            "pc1": {"name": "Dal", "kind": "player", "last_long_rest_day": -1},
+            "comp1": {"name": "Brother Toll", "kind": "companion",
+                      "attitude_value": 0, "last_long_rest_day": -1,
+                      "approval_log": [],
+                      "arc": {"arc_gates": [],
+                              "agenda": {"trigger": "attitude_below", "value": -20,
+                                         "fired": False}}},
+        },
+        "quests": {"q1": {"title": "The Embergloom Pact", "status": "active",
+                          "objectives": ["x"], "completed_objectives": []}},
+        "locations": {"a": {"name": "The Grove", "visited": True},
+                      "b": {"name": "The Road", "visited": True}},
+        "factions": {"f1": {"name": "The Order", "joined": False, "standing": 0,
+                            "questline_arc_id": "farc1"}},
+        "faction_arcs": {"farc1": {"faction_id": "f1", "title": "Rise", "status": "locked",
+                                   "stages": [{"title": "join", "status": "locked"}]}},
+        "companion_quest_arcs": {"cq1": {"companion_id": "comp1", "title": "Toll's Vow",
+                                         "status": "locked",
+                                         "stages": [{"title": "s1", "status": "locked"}]}},
+        "decisions": [],
+        "consequences": [],
+    }
+
+
+def _complete_state() -> dict:
+    """A COMPLETE run: companion approval moved + camped, quest completed, faction joined with
+    standing + its arc active, companion-quest-arc active, the agenda fired, a decision recorded,
+    a consequence that came due (trigger_day 10 < final day 20) actually fired, the engine arc
+    at act 3."""
+    return {
+        "day": 20,
+        "party": ["pc1", "comp1"],
+        "narrative_arc": {"act": 3},
+        "characters": {
+            "pc1": {"name": "Dal", "kind": "player", "last_long_rest_day": 5},
+            "comp1": {"name": "Karlach", "kind": "companion",
+                      "attitude_value": 40, "last_long_rest_day": 5,
+                      "approval_log": [{"day": 4, "cause": "mercy", "delta": 10, "new_value": 10}],
+                      "arc": {"arc_gates": [],
+                              "agenda": {"trigger": "attitude_below", "value": -20,
+                                         "fired": True}}},
+        },
+        "quests": {"q1": {"title": "The Embergloom Pact", "status": "completed",
+                          "objectives": ["x"], "completed_objectives": ["x"],
+                          "evolves_to": "the cult regroups"}},
+        "locations": {
+            "a": {"name": "The Emerald Grove (Act 1)", "visited": True},
+            "b": {"name": "Moonrise Towers (Act 2)", "visited": True},
+            "c": {"name": "The Lower City (Act 3)", "visited": True},
+        },
+        "factions": {"f1": {"name": "The Order", "joined": True, "standing": 5,
+                            "questline_arc_id": "farc1"}},
+        "faction_arcs": {"farc1": {"faction_id": "f1", "title": "Rise", "status": "active",
+                                   "stages": [{"title": "join", "status": "resolved"}]}},
+        "companion_quest_arcs": {"cq1": {"companion_id": "comp1", "title": "Karlach's Heart",
+                                         "status": "active",
+                                         "stages": [{"title": "s1", "status": "active"}]}},
+        "decisions": [{"day": 10, "summary": "spare the cultist", "approval_tags": ["mercy"]}],
+        "consequences": [{"trigger_day": 10, "fired": True, "text": "the cult regroups"}],
+    }
+
+
+def _solo_state() -> dict:
+    """A solo run (no companion): companion-keyed systems must be N/A, not inert."""
+    return {
+        "day": 6,
+        "party": ["pc1"],
+        "characters": {"pc1": {"name": "Dal", "kind": "player", "last_long_rest_day": -1}},
+        "quests": {},
+        "locations": {"a": {"name": "The Grove", "visited": True}},
+        "factions": {},
+        "decisions": [],
+        "consequences": [],
+    }
+
+
+def _ids(block: dict, key: str) -> set:
+    if key == "inert":
+        return {x["id"] for x in block["inert"]}
+    return set(block[key])
+
+
+# ── (keystone) INERT-in-scope ─────────────────────────────────────────────────────────────────
+
+def test_inert_in_scope_systems_are_listed_inert():
+    """The keystone: a substantial run that was OWED systems but never engaged them lists them
+    inert (not engaged, not N/A). companion_approval / camp_downtime / quests_objectives /
+    factions_membership / companion_agenda / decisions_recorded are all owed and dead here."""
+    block = fe.engagement_coverage(_inert_state(), tool_counts={}, session_beats=12)
+    inert = _ids(block, "inert")
+    for sid in ("companion_approval", "camp_downtime", "quests_objectives",
+                "factions_membership", "companion_agenda", "decisions_recorded"):
+        assert sid in inert, f"{sid} should be INERT in scope; block={block}"
+    # None of those leaked into engaged.
+    assert not (inert & _ids(block, "engaged"))
+    # coverage denominator = engaged + inert (N/A excluded).
+    eng, exp = block["coverage"].split("/")
+    assert int(exp) == len(block["engaged"]) + len(block["inert"])
+
+
+def test_inert_carries_why_and_severity_warn():
+    block = fe.engagement_coverage(_inert_state(), tool_counts={}, session_beats=12)
+    for item in block["inert"]:
+        assert item["severity"] == "warn", item  # ALL-WARN this PR
+        assert isinstance(item["why"], str) and item["why"]
+
+
+def test_blocked_systems_inert_in_scope_but_warn():
+    """faction_arc + companion_quest_arc CAN be inert (here the faction is unjoined so faction_arc
+    is N/A, but companion_quest_arc is seeded+beats-owed and locked ⇒ inert) — and stay WARN."""
+    block = fe.engagement_coverage(_inert_state(), tool_counts={}, session_beats=12)
+    inert = {x["id"]: x for x in block["inert"]}
+    # companion_quest_arc is seeded + beats>=10 ⇒ owed; locked ⇒ inert.
+    assert "companion_quest_arc" in inert
+    assert inert["companion_quest_arc"]["severity"] == "warn"
+    # faction_arc precondition needs a JOINED faction; here unjoined ⇒ N/A (not inert).
+    assert "faction_arc" in _ids(block, "na")
+
+
+# ── COMPLETE → engaged ────────────────────────────────────────────────────────────────────────
+
+def test_complete_run_engages_every_owed_system():
+    block = fe.engagement_coverage(
+        _complete_state(),
+        tool_counts={"start_combat": 1, "check_companion_arc": 2},
+        session_beats=30)
+    engaged = _ids(block, "engaged")
+    for sid in ("companion_approval", "camp_downtime", "quests_objectives", "acts_advance",
+                "consequences_fired", "factions_membership", "faction_arc",
+                "companion_quest_arc", "companion_agenda", "decisions_recorded"):
+        assert sid in engaged, f"{sid} should be ENGAGED; block={block}"
+    assert not block["inert"], block["inert"]
+    assert block["coverage"] == f"{len(engaged)}/{len(engaged)}"
+
+
+# ── CONDITIONAL N/A: short run (beats below threshold) ────────────────────────────────────────
+
+def test_short_run_beats_keyed_systems_are_na_not_inert():
+    """A 4-beat run is below every beats threshold (>=6/>=10/>=24): the beats-keyed systems must
+    be N/A, never inert — a smoke test had no occasion to engage them."""
+    block = fe.engagement_coverage(_inert_state(), tool_counts={}, session_beats=4)
+    na = _ids(block, "na")
+    for sid in ("companion_approval", "camp_downtime", "quests_objectives", "acts_advance",
+                "factions_membership", "companion_quest_arc", "companion_agenda",
+                "decisions_recorded"):
+        assert sid in na, f"{sid} should be N/A on a 4-beat run; block={block}"
+        assert sid not in _ids(block, "inert")
+
+
+# ── CONDITIONAL N/A: session_beats=None ⇒ beats-keyed systems N/A (the inject callsite) ───────
+
+def test_session_beats_none_makes_beats_keyed_systems_na():
+    """The inject callsite passes session_beats=None (beats live in the transcript, not the
+    snapshot). Every beats-keyed precondition must read N/A then — safe under-detect, never a
+    false-RED. consequences_fired (snapshot-only precondition) is unaffected."""
+    block = fe.engagement_coverage(_inert_state(), tool_counts=None, session_beats=None)
+    na = _ids(block, "na")
+    inert = _ids(block, "inert")
+    for sid in ("companion_approval", "camp_downtime", "quests_objectives", "acts_advance",
+                "factions_membership", "companion_quest_arc", "companion_agenda",
+                "decisions_recorded"):
+        assert sid in na, f"{sid} should be N/A when session_beats is None; block={block}"
+        assert sid not in inert
+    # consequences_fired has NO beats key — here there are no owed consequences ⇒ N/A.
+    assert "consequences_fired" in na
+
+
+# ── CONDITIONAL N/A: solo party (no companion) ────────────────────────────────────────────────
+
+def test_solo_party_companion_systems_na():
+    """A solo run: companion_approval / camp_downtime / companion_agenda have no companion to
+    engage ⇒ N/A. decisions_recorded is still owed (beats>=10) ⇒ inert."""
+    block = fe.engagement_coverage(_solo_state(), tool_counts={}, session_beats=12)
+    na = _ids(block, "na")
+    assert "companion_approval" in na
+    assert "camp_downtime" in na
+    assert "companion_agenda" in na
+    assert "companion_quest_arc" in na  # none seeded
+    assert "decisions_recorded" in _ids(block, "inert")
+
+
+# ── CONDITIONAL N/A: factionless world ────────────────────────────────────────────────────────
+
+def test_factionless_world_faction_systems_na():
+    """No factions seeded ⇒ factions_membership + faction_arc N/A (never inert)."""
+    block = fe.engagement_coverage(_solo_state(), tool_counts={}, session_beats=12)
+    na = _ids(block, "na")
+    assert "factions_membership" in na
+    assert "faction_arc" in na
+
+
+def test_faction_seeded_but_not_joinable_is_na():
+    """A faction with an EMPTY questline_arc_id is not joinable ⇒ factions_membership N/A."""
+    state = _inert_state()
+    state["factions"] = {"f1": {"name": "Townsfolk", "joined": False, "standing": 0,
+                                "questline_arc_id": ""}}
+    block = fe.engagement_coverage(state, tool_counts={}, session_beats=12)
+    assert "factions_membership" in _ids(block, "na")
+
+
+# ── CONDITIONAL N/A: combat-sprint (WORLDOS_GATE_COMBAT_SPRINT) ────────────────────────────────
+
+def test_combat_sprint_skips_fatal_systems(monkeypatch):
+    """Under WORLDOS_GATE_COMBAT_SPRINT, FATAL systems are skipped (→ N/A). With every system
+    WARN this PR it is a no-op for coverage, but the wiring must hold for safe graduation:
+    monkeypatch one system FATAL and confirm it goes N/A under the env, inert without it."""
+    spec = fe.SystemSpec("companion_approval", fe._pc_companion_approval,
+                         fe._dt_companion_approval, "fatal")
+    others = tuple(s for s in fe.SYSTEMS if s.id != "companion_approval")
+    monkeypatch.setattr(fe, "SYSTEMS", (spec, *others))
+
+    # Without the env, the FATAL system is owed-and-dead ⇒ inert.
+    monkeypatch.delenv("WORLDOS_GATE_COMBAT_SPRINT", raising=False)
+    block = fe.engagement_coverage(_inert_state(), tool_counts={}, session_beats=12)
+    assert "companion_approval" in _ids(block, "inert")
+
+    # Under the env, the FATAL system is SKIPPED ⇒ N/A (never inert).
+    monkeypatch.setenv("WORLDOS_GATE_COMBAT_SPRINT", "1")
+    block = fe.engagement_coverage(_inert_state(), tool_counts={}, session_beats=12)
+    assert "companion_approval" in _ids(block, "na")
+    assert "companion_approval" not in _ids(block, "inert")
+
+
+def test_combat_sprint_keeps_warn_systems_reporting(monkeypatch):
+    """WARN systems still report under the env (they can't false-RED) — matching
+    assert_behavioral's fatal/warn split. The all-WARN manifest is unchanged by the env."""
+    monkeypatch.setenv("WORLDOS_GATE_COMBAT_SPRINT", "1")
+    block = fe.engagement_coverage(_inert_state(), tool_counts={}, session_beats=12)
+    # decisions_recorded is WARN + owed + dead ⇒ still inert under the env.
+    assert "decisions_recorded" in _ids(block, "inert")
+
+
+# ── consequences: due-vs-future (STRICT < final day) ──────────────────────────────────────────
+
+def test_consequence_due_before_final_day_and_unfired_is_inert():
+    """A consequence whose trigger_day is STRICTLY < the final day but fired=False is OWED ⇒
+    inert."""
+    state = _inert_state()
+    state["day"] = 10
+    state["consequences"] = [{"trigger_day": 5, "fired": False, "text": "the cult regroups"}]
+    block = fe.engagement_coverage(state, tool_counts={}, session_beats=12)
+    assert "consequences_fired" in _ids(block, "inert")
+
+
+def test_consequence_on_final_day_is_warn_not_owed_so_na():
+    """trigger_day == final_day is WARN-not-owed (it may legitimately fire on the unseen last
+    beat) ⇒ the precondition is False ⇒ N/A, never inert."""
+    state = _inert_state()
+    state["day"] = 5
+    state["consequences"] = [{"trigger_day": 5, "fired": False}]
+    block = fe.engagement_coverage(state, tool_counts={}, session_beats=12)
+    assert "consequences_fired" in _ids(block, "na")
+    assert "consequences_fired" not in _ids(block, "inert")
+
+
+def test_future_dated_consequence_is_na():
+    """A future-dated consequence (trigger_day > final day) is not yet due ⇒ N/A."""
+    state = _inert_state()
+    state["day"] = 5
+    state["consequences"] = [{"trigger_day": 30, "fired": False}]
+    block = fe.engagement_coverage(state, tool_counts={}, session_beats=12)
+    assert "consequences_fired" in _ids(block, "na")
+
+
+def test_consequence_due_and_fired_is_engaged():
+    state = _inert_state()
+    state["day"] = 10
+    state["consequences"] = [{"trigger_day": 5, "fired": True}]
+    block = fe.engagement_coverage(state, tool_counts={}, session_beats=12)
+    assert "consequences_fired" in _ids(block, "engaged")
+
+
+# ── narrative_arc absent / None null-guard ────────────────────────────────────────────────────
+
+def test_narrative_arc_absent_does_not_crash_acts_advance():
+    """No narrative_arc key at all: acts_advance falls back to act-tags (none here on the inert
+    fixture's untagged world) and never raises. With a long run + no arc + <2 tag-acts ⇒ N/A."""
+    state = _inert_state()
+    state.pop("narrative_arc", None)
+    block = fe.engagement_coverage(state, tool_counts={}, session_beats=30)
+    # untagged world, no engine arc ⇒ no occasion ⇒ N/A (never inert, never a crash).
+    assert "acts_advance" in _ids(block, "na")
+
+
+def test_narrative_arc_explicit_none_null_guarded():
+    """narrative_arc explicitly None must degrade to the empty cursor (felt_shape_from_state's
+    guard), never raise."""
+    state = _inert_state()
+    state["narrative_arc"] = None
+    block = fe.engagement_coverage(state, tool_counts={}, session_beats=30)
+    assert isinstance(block["coverage"], str)  # computed without raising
+
+
+def test_empty_state_is_all_na_not_crash():
+    """An empty/legacy snapshot yields an all-N/A (or harmlessly-inert snapshot-only) block and
+    never raises — old snapshots round-trip."""
+    block = fe.engagement_coverage({}, tool_counts=None, session_beats=None)
+    assert isinstance(block["coverage"], str)
+    assert not block["engaged"]
+    assert not block["inert"]  # nothing owed in an empty snapshot with no beats
+
+
+# ── tool-count-only engagement (the detector reads counts when state is silent) ───────────────
+
+def test_tool_counts_alone_can_engage_a_system():
+    """A run whose snapshot is silent on a system but whose DM CALLED the engaging tool reads
+    engaged (the detector reads tool-counts as a fallback signal)."""
+    state = _inert_state()
+    # The DM joined the faction via the tool but the snapshot latch wasn't captured here.
+    block = fe.engagement_coverage(state, tool_counts={"join_faction": 1}, session_beats=12)
+    assert "factions_membership" in _ids(block, "engaged")

--- a/qa/test_release_readiness.py
+++ b/qa/test_release_readiness.py
@@ -2723,7 +2723,13 @@ class ReleaseReadinessContractTests(unittest.TestCase):
             self.assertTrue(payload["release_ready"])
             self.assertEqual(payload["evidence_gaps"], [])
             self.assertEqual(payload["gates_total"], 11)
-            self.assertEqual(sorted(payload["skipped_gates"]), ["latency_coldopen", "latency_s_per_beat"])
+            # WS0: with no engagement_coverage in any persona score.json the story_engagement gate
+            # is ALSO an evidence-gap skip (additive, like the latency gates) — gates_total stays
+            # 11 (byte-identical RRI math), it is skipped, never failed, never counted.
+            self.assertEqual(
+                sorted(payload["skipped_gates"]),
+                ["latency_coldopen", "latency_s_per_beat", "story_engagement"],
+            )
             self.assertIsNone(payload["signals"]["latency_s_per_beat"])
             self.assertIsNone(payload["signals"]["latency_coldopen_s"])
 
@@ -2784,8 +2790,10 @@ class ReleaseReadinessContractTests(unittest.TestCase):
         self.assertIn("latency_coldopen", payload["failed_gates"])
         self.assertEqual(payload["signals"]["latency_s_per_beat"], 300.0)
         self.assertEqual(payload["signals"]["latency_coldopen_s"], 500.0)
-        # the gate is now ACTIVE, not a dormant evidence-gap skip
-        self.assertEqual(payload["skipped_gates"], [])
+        # the LATENCY gates are now ACTIVE, not a dormant evidence-gap skip. (WS0: with no
+        # engagement_coverage in these fixtures, story_engagement remains an evidence-gap skip —
+        # so gates_total stays the pre-WS0 count of 13, byte-identical RRI math.)
+        self.assertEqual(payload["skipped_gates"], ["story_engagement"])
         self.assertEqual(payload["gates_total"], 13)
 
         # UNDER budget: cold open 150s (< 240), routine 80s/beat (< 120) -> PASS.

--- a/servers/engine/tests/test_feature_engagement_manifest.py
+++ b/servers/engine/tests/test_feature_engagement_manifest.py
@@ -1,0 +1,79 @@
+"""WS0 forcing meta-test — the engagement-system MANIFEST guard (mirrors
+test_tool_schema_budget.py's "enumerate the live set, assert it == a reviewed constant" pattern,
+so any addition/removal of a tracked story system is a deliberate, VISIBLE diff in review).
+
+The keystone discipline: qa/feature_engagement.SYSTEMS is the live manifest of authored story
+systems the engagement scorer covers; REVIEWED_SYSTEM_IDS is the frozenset a human signed off on.
+If someone adds a system without updating the reviewed set (or vice-versa), this test fails — the
+manifest can never silently drift out of coverage (the exact failure WS0 exists to prevent).
+
+Lives in servers/engine/tests (run with the engine suite) but imports the qa-side module via the
+sys.path.insert(qa) pattern the sibling qa tests use.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Import the qa-side module (it has no engine dependency — pure stdlib + story_readout).
+_QA = Path(__file__).resolve().parents[3] / "qa"
+sys.path.insert(0, str(_QA))
+
+import feature_engagement as fe  # noqa: E402
+
+
+def test_manifest_matches_reviewed_ids():
+    """The live SYSTEMS set must equal the human-reviewed REVIEWED_SYSTEM_IDS — adding or
+    removing a system without updating the reviewed constant is a failing, visible diff."""
+    live = {s.id for s in fe.SYSTEMS}
+    assert live == set(fe.REVIEWED_SYSTEM_IDS), (
+        "engagement-system manifest drifted from the reviewed set. "
+        f"only-in-SYSTEMS={sorted(live - set(fe.REVIEWED_SYSTEM_IDS))}; "
+        f"only-in-REVIEWED={sorted(set(fe.REVIEWED_SYSTEM_IDS) - live)}. "
+        "Update REVIEWED_SYSTEM_IDS deliberately when changing the manifest."
+    )
+
+
+def test_reviewed_ids_are_exactly_ten():
+    """WS0 ships the 10 reviewed systems. The count is pinned so a careless drop/add is loud
+    (raise this only with a justification, like the schema-budget guard)."""
+    assert len(fe.REVIEWED_SYSTEM_IDS) == 10, sorted(fe.REVIEWED_SYSTEM_IDS)
+    assert len(fe.SYSTEMS) == 10
+
+
+def test_every_severity_is_warn_or_fatal():
+    """Severity is a closed vocabulary; a typo'd severity must fail (the gate reads it to decide
+    fatal-ness)."""
+    bad = [(s.id, s.severity) for s in fe.SYSTEMS if s.severity not in ("fatal", "warn")]
+    assert not bad, f"systems with an out-of-vocabulary severity: {bad}"
+
+
+def test_ws0_ships_all_warn():
+    """WS0 invariant: EVERY system ships severity='warn' this PR (FATAL graduation is a future
+    post-sweep PR). An accidental 'fatal' here would add a new RED to a currently-green pipeline."""
+    fatal = [s.id for s in fe.SYSTEMS if s.severity == "fatal"]
+    assert not fatal, (
+        f"these systems are FATAL but WS0 ships all-WARN (graduation is a future PR): {fatal}"
+    )
+
+
+def test_blocked_systems_stay_warn():
+    """faction_arc + companion_quest_arc carry a known snapshot-only ambiguity (seeded-but-locked
+    vs never-seeded) and must NEVER be FATAL until that spike is resolved."""
+    by_id = {s.id: s for s in fe.SYSTEMS}
+    for sid in fe.BLOCKED_SYSTEM_IDS:
+        assert sid in by_id, f"blocked id {sid!r} is not in the manifest"
+        assert by_id[sid].severity == "warn", f"blocked system {sid!r} must stay WARN"
+
+
+def test_ids_unique_and_snake_case():
+    ids = [s.id for s in fe.SYSTEMS]
+    assert len(ids) == len(set(ids)), f"duplicate system ids: {ids}"
+    bad = [i for i in ids if not fe._is_snake(i)]
+    assert not bad, f"non snake_case system ids: {bad}"
+
+
+def test_precondition_and_detector_are_callable():
+    for s in fe.SYSTEMS:
+        assert callable(s.precondition), f"{s.id}.precondition is not callable"
+        assert callable(s.detector), f"{s.id}.detector is not callable"


### PR DESCRIPTION
## WS0 — the feature-engagement feedback loop (keystone of the sprint)

### The blind spot this closes
Today an entire authored story subsystem (companion approval, camp downtime, faction questlines, the companion agenda, recorded decisions) can be **100% inert across a 5-persona sweep and the RRI still scores 10/10** — because *no gate is engagement-coverage*. A frozen-relationship run that narrated the companion but never moved a gauge passed; a run that seeded factions and never joined one passed; a run that never camped passed. This PR makes those "dead system" shapes a visible, queryable, gated signal.

### All-WARN-first design (why this can't break the green pipeline)
Every system ships **`severity='warn'`**, so the axis is **strictly additive**:
- `assert_behavioral.py` emits `engagement_<id>` checks with `fatal=False` → **zero new fatals**; every currently-green run stays green.
- The new `release_readiness.py` `story_engagement` gate **FAILS only on a FATAL inert system** → all-WARN ⇒ it always **passes** when evidence is present (inert systems are *reported*, not gated).
- When no persona `score.json` carries `engagement_coverage` (a legacy corpus), the gate is an **evidence-gap SKIP** — excluded from `passed`/`total`, so RRI math is **byte-identical** (mirrors the latency-gate skip). `gates_total` stays 11 / RRI 10.0 on the existing fixtures.

### It would have caught the approval / camp deaths
The two proven failure shapes — a companion stuck at `attitude_value 0` all run, and a multi-day run where nobody ever `last_long_rest_day`'d — are now `companion_approval` / `camp_downtime` **inert-in-scope** (precondition true, detector false), surfaced per-run in the behavioral gate and rolled up in the `ENGAGEMENT` RRI section with a fix hint.

### The conditional N/A logic (keeps the loop from ever false-RED-ing)
A system is **N/A** (no occasion to engage) — never inert — when its precondition is false **or unknown**:
- `session_beats` lives in the **transcript, not the snapshot**, so the signature takes it explicitly and **every beats-keyed precondition defaults to N/A when it is `None`** (the inject callsite passes `None` → safe under-detect, never a false-RED).
- Solo party ⇒ companion systems N/A; factionless / non-joinable world ⇒ faction systems N/A; short run (below the per-system beats threshold) ⇒ N/A.
- `consequences_fired` is owed **only** when a consequence's `trigger_day` is **strictly < the final day**; `trigger_day == final_day` is WARN-not-owed (may fire on the unseen last beat) ⇒ N/A; future-dated ⇒ N/A.
- Under `WORLDOS_GATE_COMBAT_SPRINT`, all **FATAL** systems are skipped (mirrors `assert_behavioral.py`).

### Deterministic, snapshot-derived — engine state only, never fiction
Every predicate reads **only engine-mutated snapshot fields** (`attitude_value`, `last_long_rest_day`, `faction.joined/standing`, `narrative_arc.act`, `consequence.fired/trigger_day`, the arc/agenda `fired` flags, `campaign.decisions/quests/factions/*_arcs`) **or DM tool-counts** — never prose (engine invariant #3). It **reuses** `story_readout.structural_coverage_from_state` / `felt_shape_from_state` so the shared buckets never drift; old snapshots round-trip (null-guards throughout, incl. absent/`None` `narrative_arc`).

### The forcing meta-test
`servers/engine/tests/test_feature_engagement_manifest.py` mirrors `test_tool_schema_budget.py`: it asserts `{s.id for s in SYSTEMS} == REVIEWED_SYSTEM_IDS` (and severities/ids), so changing the tracked-system set is a **deliberate, visible diff** — the manifest can never silently drift out of coverage (the exact failure WS0 exists to prevent).

### Deferred FATAL graduation
**Graduation to FATAL is a FUTURE, post-sweep PR** — after one real 5-persona sweep calibrates the inert/owed classification (the same discipline as `flat_arc` / `caster_has_spellbook`). The gate logic *already* enforces FATAL-inert ⇒ fail (forward-compat test included), so graduation is a one-line manifest change, not a gate rewrite.

### 2 BLOCKED systems (stay WARN regardless)
`faction_arc` + `companion_quest_arc`: a snapshot-only precondition **can't tell *seeded-but-locked* from *never-seeded*** beyond the `joined` latch — a known open spike. They are pinned WARN by `BLOCKED_SYSTEM_IDS` and the manifest test, and must never graduate until the spike is resolved.

### The 10 tracked systems
companion_approval · camp_downtime · quests_objectives · acts_advance · consequences_fired · factions_membership · faction_arc* · companion_quest_arc* · companion_agenda · decisions_recorded  (*BLOCKED)

### Files
- **new** `qa/feature_engagement.py` — pure module (SystemSpec manifest + `engagement_coverage`).
- **new** `servers/engine/tests/test_feature_engagement_manifest.py` — forcing meta-test.
- **new** `qa/test_feature_engagement.py` — table-driven behavior tests.
- `qa/assert_behavioral.py` — additive `engagement_<id>` WARNs after `structural_completeness`.
- `qa/inject_structural_coverage.py` — merge `engagement_coverage` into `score.json` (beats=None).
- `qa/scores_db.py` — `engagement_pct` (REAL) + `engagement_inert` (TEXT); auto-ALTER backfills NULL.
- `qa/release_readiness.py` — the `story_engagement` deterministic gate + `ENGAGEMENT` report section + signals.
- `qa/SCORING.md` — documents the axis + WARN-first→FATAL discipline.
- `.github/workflows/ci.yml` — adds `test_feature_engagement.py` to the qa CI allowlist.
- `qa/test_deterministic_rri_gate.py` / `qa/test_release_readiness.py` — admit the additive evidence-gap skip; add WS0 gate behavior tests (absent⇒skip, all-WARN-inert⇒pass+report, cross-persona roll-up, FATAL⇒fail). `gates_total`/RRI invariants unchanged.

### Tests (single-process, `-p no:xdist`)
- `qa/test_feature_engagement.py` + `servers/engine/tests/test_feature_engagement_manifest.py` — **33 pass**.
- 299 targeted (engagement + structural + RRI + scores_db + behavioral + latency) — **green**.
- Full `servers/engine/tests/` — **3000 pass**.

**Do not merge — for review.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Story engagement quality gate now evaluates authored system engagement during narrative progression
  * Engagement coverage metrics are tracked in release scoring ledger

* **Tests**
  * Comprehensive engagement coverage test suite added with scenarios for solo parties, faction availability, and consequence timing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->