### PR TITLE
fix(engine): per-named-action Multiattack budget + PC Action-Surge label (cs-timing F-2/F-3)

### DIFF
--- a/qa/distill.py
+++ b/qa/distill.py
@@ -97,11 +97,23 @@ def _audit_fields(res) -> list[str]:
     allowed = data.get("attacks_allowed_this_turn")
     made = data.get("attacks_made_this_turn")
     if isinstance(allowed, int) and allowed > 1 and isinstance(made, int):
-        # The engine surfaces ``multiattack_grants`` (the stat-block Multiattack count) only
-        # when the budget IS a monster Multiattack; its absence means the budget came from
-        # Extra Attack / Action Surge (a PC). Label accordingly — never guess "Multiattack"
-        # for a PC's Extra Attack.
-        kind = "Multiattack" if isinstance(data.get("multiattack_grants"), int) else "Extra Attack"
+        # Label the budget SOURCE from engine-surfaced fields — never guess (cs-timing F-2).
+        #   * ``multiattack_grants`` (int) → a monster's stat-block Multiattack.
+        #   * else a PC: the engine surfaces ``extra_attacks`` / ``surge_actions`` so distill
+        #     distinguishes the Extra Attack FEATURE from an Action-Surge second action. A
+        #     Fighter L4 (Extra Attack is L5: extra_attacks=0) who spent Action Surge MUST read
+        #     "(Action Surge)", never "(Extra Attack)" — the feature it does not yet have.
+        if isinstance(data.get("multiattack_grants"), int):
+            kind = "Multiattack"
+        else:
+            parts = []
+            if isinstance(data.get("extra_attacks"), int) and data["extra_attacks"] > 0:
+                parts.append("Extra Attack")
+            if isinstance(data.get("surge_actions"), int) and data["surge_actions"] > 0:
+                parts.append("Action Surge")
+            # Fallback only when the engine surfaced no source (legacy/synthetic data); a
+            # KNOWN extra_attacks=0 never falls here, so it can never be mislabeled "Extra Attack".
+            kind = " + ".join(parts) if parts else "Extra Attack"
         actor = data.get("attacker", "the attacker")  # always present on an attack() return
         out.append(
             f"    `↳ attack-budget: {actor} {made}/{allowed} attacks this turn ({kind})`"

--- a/qa/test_distill.py
+++ b/qa/test_distill.py
@@ -120,7 +120,8 @@ def test_audit_fields_surfaces_multiattack_budget():
 def test_audit_fields_labels_pc_extra_attack_budget_not_multiattack():
     # A PC's multi-strike turn comes from Extra Attack / Action Surge, NOT Multiattack —
     # the engine omits multiattack_grants, so distill must label it "(Extra Attack)" and
-    # never miscredit a PC with a monster Multiattack.
+    # never miscredit a PC with a monster Multiattack. The engine surfaces extra_attacks
+    # so the source is tool-sourced (a genuine Extra-Attack fighter: extra_attacks=1).
     res = json.dumps(
         {
             "attacker": "Fighter",
@@ -128,11 +129,54 @@ def test_audit_fields_labels_pc_extra_attack_budget_not_multiattack():
             "hit": True,
             "attacks_made_this_turn": 1,
             "attacks_allowed_this_turn": 2,
+            "extra_attacks": 1,
+            "surge_actions": 0,
         }
     )
     lines = distill._audit_fields(res)
     assert len(lines) == 1
     assert "attack-budget: Fighter 1/2 attacks this turn (Extra Attack)" in lines[0]
+
+
+def test_audit_fields_labels_action_surge_budget_not_extra_attack():
+    # cs-timing F-2: Aldric (Fighter L4, extra_attacks=0) spent Action Surge for a 2nd swing.
+    # The budget came from Action Surge, NOT the Extra Attack feature (which is L5). distill
+    # must read "(Action Surge)" — and a character with extra_attacks:0 must NEVER get an
+    # "Extra Attack" annotation (the finding's CI assert).
+    res = json.dumps(
+        {
+            "attacker": "Aldric",
+            "target": "Ghoul",
+            "hit": True,
+            "attacks_made_this_turn": 2,
+            "attacks_allowed_this_turn": 2,
+            "extra_attacks": 0,
+            "surge_actions": 1,
+        }
+    )
+    lines = distill._audit_fields(res)
+    assert len(lines) == 1
+    assert "attack-budget: Aldric 2/2 attacks this turn (Action Surge)" in lines[0]
+    assert "Extra Attack" not in lines[0]  # extra_attacks:0 => never mislabeled the feature
+
+
+def test_audit_fields_labels_extra_attack_plus_action_surge():
+    # A high-level fighter with BOTH Extra Attack (extra_attacks=1) AND a spent Action Surge
+    # reads both sources, in order.
+    res = json.dumps(
+        {
+            "attacker": "Bron",
+            "target": "Ogre",
+            "hit": True,
+            "attacks_made_this_turn": 1,
+            "attacks_allowed_this_turn": 4,
+            "extra_attacks": 1,
+            "surge_actions": 1,
+        }
+    )
+    lines = distill._audit_fields(res)
+    assert len(lines) == 1
+    assert "attack-budget: Bron 1/4 attacks this turn (Extra Attack + Action Surge)" in lines[0]
 
 
 def test_audit_fields_suppresses_single_attack_budget():

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -3747,11 +3747,21 @@ def _monster_combat_entry(ch: "Character", c: "Campaign") -> dict | None:
     return entry
 
 
-def _attacker_multiattack_count(ch: "Character", c: "Campaign") -> int:
+def _attacker_multiattack_count(ch: "Character", c: "Campaign", attack_name: str = "") -> int:
     """Return the number of attacks a combatant may make via Multiattack (0 for PCs
     and monsters without a Multiattack stat-block entry). Reuses _monster_combat_entry
     so the lookup path is identical to what the DM sees in the combat view. Returns 0
-    on any lookup failure so the caller degrades to normal Extra-Attack behaviour."""
+    on any lookup failure so the caller degrades to normal Extra-Attack behaviour.
+
+    ``attack_name`` (default "") scopes the budget to a NAMED attack (cs-timing F-3): a
+    Multiattack grants its count ONLY to the attacks that COMPOSE it. A named attack the
+    creature has that is NOT part of its Multiattack — the Ghoul's Claw vs its 'two Bite
+    attacks' Multiattack — is a single Attack action and does NOT inherit the Multiattack
+    ceiling, so this returns 0 for it (the caller then caps it at extra_attacks+1 = 1).
+    Empty attack_name (today's callers) keeps the count for ANY attack: byte-identical.
+    Only restricts when the resolved composition is KNOWN (entry['multiattack']); an
+    unparsed composition degrades to the count (conservative — never tightens a budget we
+    cannot justify from the stat block)."""
     try:
         entry = _monster_combat_entry(ch, c)
         if entry is None:
@@ -3759,7 +3769,20 @@ def _attacker_multiattack_count(ch: "Character", c: "Campaign") -> int:
         apt = entry.get("attacks_per_turn", 1)
         # attacks_per_turn=1 is also the fallback for monsters WITHOUT Multiattack;
         # only counts > 1 represent a real Multiattack action in the stat block.
-        return int(apt) if int(apt) > 1 else 0
+        if int(apt) <= 1:
+            return 0
+        name = attack_name.strip().lower()
+        if name:
+            ma_info = entry.get("multiattack")
+            if isinstance(ma_info, dict):
+                names = {
+                    str(s.get("name", "")).strip().lower()
+                    for s in ma_info.get("sequence", [])
+                    if isinstance(s, dict)
+                }
+                if names and name not in names:
+                    return 0
+        return int(apt)
     except Exception:
         return 0
 
@@ -4912,6 +4935,7 @@ def attack(
     disadvantage: bool = False,
     is_ranged: bool = False,
     is_reaction: bool = False,
+    attack_name: str = "",
     damage_rolls: list[dict] | None = None,
     maneuver: str = "",
     maneuver_resource: str = "superiority_dice",
@@ -4931,7 +4955,11 @@ def attack(
     declare one atomically — the engine spends ONE ``maneuver_resource`` die (default
     'superiority_dice') ONLY on a hit, folds it into the damage, and crit-doubles it; a miss
     spends nothing. ``maneuver_damage_type`` overrides the bonus's type. Empty ``maneuver``
-    == today's behavior."""
+    == today's behavior.
+
+    ``attack_name`` (e.g. 'Claw'): for a Multiattack creature, scopes the per-turn budget to
+    that named attack — one NOT in the Multiattack (the Ghoul's Claw vs its 'two Bite'
+    Multiattack) is a single Attack action, not granted the Multiattack count. Empty == today."""
     # Coalesce intuitive arg-name aliases to the canonical ids. The ATTACKER is the acting
     # character (alias `character_id`); the TARGET is the thing struck (aliases `npc_id`/`id`).
     # Canonical names win. (target_id ⇄ character_id is intentionally NOT done — `character_id`
@@ -4993,8 +5021,10 @@ def attack(
             else:
                 # An attack as the current combatant's ACTION: enforce one Attack
                 # action's worth of strikes (Extra Attack / Action Surge aware,
-                # and Multiattack-aware for monsters with a stat-block entry).
-                ma = _attacker_multiattack_count(attacker, c)
+                # and Multiattack-aware for monsters with a stat-block entry). The
+                # named attack scopes the Multiattack budget to its composition
+                # (a Ghoul Claw is NOT part of its 'two Bite' Multiattack — cs F-3).
+                ma = _attacker_multiattack_count(attacker, c, attack_name)
                 ok, reason = combat.check_action_attack(
                     is_current=True,
                     attacks_made=c.combat.action_attacks_made,
@@ -5120,19 +5150,28 @@ def attack(
                 c.combat.action_used = True  # an Attack action consumes the turn's action
                 c.combat.action_attacks_made += 1
                 result["attacks_made_this_turn"] = c.combat.action_attacks_made
-                result["attacks_allowed_this_turn"] = combat.attacks_allowed(
+                allowed_now = combat.attacks_allowed(
                     getattr(attacker, "extra_attacks", 0),
                     c.combat.surge_actions,
                     ma,
                 )
+                result["attacks_allowed_this_turn"] = allowed_now
                 # When the budget comes from a stat-block Multiattack (ma>0), surface the
                 # grant explicitly so the distilled transcript reads the ceiling tool-sourced
                 # (F01-1 / csmed-4: a monster narrated "a Multiattack that doesn't exist" was
                 # the DM running past a ceiling the engine HAD enforced — invisible because the
-                # attack result truncates in qa/distill.py). Absent for PCs (ma=0), so Extra
-                # Attack / Action Surge budgets stay labelled as themselves; purely additive.
+                # attack result truncates in qa/distill.py).
                 if ma > 0:
                     result["multiattack_grants"] = ma
+                elif allowed_now > 1:
+                    # PC multi-strike (cs-timing F-2): surface WHY the budget exceeds one swing
+                    # so distill never mis-credits the Extra Attack FEATURE when the second
+                    # action came from Action Surge — Aldric (Fighter L4, Extra Attack is L5)
+                    # spent Action Surge: extra_attacks=0, surge=1 → 2 strikes, but NOT the
+                    # feature. Additive: only on a genuine multi-attack turn; single swings
+                    # stay byte-identical (these keys absent).
+                    result["extra_attacks"] = int(getattr(attacker, "extra_attacks", 0))
+                    result["surge_actions"] = int(c.combat.surge_actions)
         # Zone-aware range (S2.7): a MELEE attack needs attacker & target in the same
         # or an adjacent zone; ranged reaches any zone. Advisory only — surface a
         # warning, never hard-block. Inert when no zones are declared. Position lives

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -1771,6 +1771,121 @@ def test_multiattack_zero_path_unchanged(tmp_path, monkeypatch):
 
 
 # =========================================================================
+# cs-timing F-3: per-named-action Multiattack budget (Ghoul Claw vs two-Bite)
+# =========================================================================
+# The Ghoul's Multiattack is "two Bite attacks"; Claw is a SEPARATE action, NOT
+# part of the Multiattack. The engine must scope the Multiattack budget to the
+# named attack: a Bite gets the count (2), a Claw is a single Attack action (1).
+
+
+def test_attacker_multiattack_count_scoped_to_named_action(tmp_path, monkeypatch):
+    """Unit: _attacker_multiattack_count grants the Ghoul's count (2) ONLY to attacks that
+    compose its Multiattack. 'Bite' is in the 'two Bite attacks' composition → 2; 'Claw' is a
+    separate action not in it → 0 (the caller then caps it at the single-Attack-action ceiling).
+    No name (today's callers) keeps the count for any attack: byte-identical."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    import store
+
+    cid = server.create_campaign("ghoul named budget")["id"]
+    gid = server.spawn_monster(cid, "Ghoul")["spawned"][0]["id"]
+    c = store.load_campaign(cid)
+    gch = c.characters[gid]
+    assert server._attacker_multiattack_count(gch, c, "") == 2       # back-compat: any attack
+    assert server._attacker_multiattack_count(gch, c, "Bite") == 2   # composes the Multiattack
+    assert server._attacker_multiattack_count(gch, c, "claw") == 0   # NOT in Multiattack (case-insensitive)
+    # The Ghoul's Claw budget is never > 1 (the finding's CI assert).
+    claw_budget = combat.attacks_allowed(
+        extra_attacks=0, surge_actions=0,
+        multiattack=server._attacker_multiattack_count(gch, c, "Claw"),
+    )
+    assert claw_budget == 1
+
+
+def test_ghoul_claw_is_single_attack_action_not_multiattack(tmp_path, monkeypatch):
+    """End-to-end (cs-timing F-3): a Ghoul attacking with its Claw (attack_name='Claw') is a
+    single Attack action — budget 1, NO multiattack_grants, and a 2nd Claw is rejected. A Bite
+    (attack_name='Bite') still gets the two-Bite Multiattack budget. Fixes the distilled
+    annotation that read 'Ghoul 1/2 attacks this turn (Multiattack)' for a non-Multiattack Claw."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    import pytest as _pytest
+
+    cid = server.create_campaign("ghoul claw F-3")["id"]
+    pc = server.create_character(cid, "Hero", kind="player", max_hp=60)["id"]
+    gid = server.spawn_monster(cid, "Ghoul")["spawned"][0]["id"]
+    server.start_combat(cid, [pc, gid])
+    if server.get_state(cid)["current_turn"] == pc:
+        server.use_action(cid, pc, "skip")
+        server.next_turn(cid)
+    assert server.get_state(cid)["current_turn"] == gid
+
+    # Claw: NOT part of the 'two Bite' Multiattack -> single Attack action.
+    rc = server.attack(cid, gid, pc, attack_bonus=4, damage_dice="1d4+2", attack_name="Claw")
+    assert rc["attacks_allowed_this_turn"] == 1
+    assert "multiattack_grants" not in rc  # never mislabel a Claw as a Multiattack swing
+    with _pytest.raises(ValueError, match="already attacked this turn"):
+        server.attack(cid, gid, pc, attack_bonus=4, damage_dice="1d4+2", attack_name="Claw")
+
+
+def test_ghoul_bite_still_gets_two_bite_multiattack_budget(tmp_path, monkeypatch):
+    """Regression guard for F-3: a named Bite — which DOES compose the Ghoul's Multiattack —
+    keeps the count-2 budget and surfaces multiattack_grants, unchanged from before."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    import pytest as _pytest
+
+    cid = server.create_campaign("ghoul bite F-3")["id"]
+    pc = server.create_character(cid, "Hero", kind="player", max_hp=60)["id"]
+    gid = server.spawn_monster(cid, "Ghoul")["spawned"][0]["id"]
+    server.start_combat(cid, [pc, gid])
+    if server.get_state(cid)["current_turn"] == pc:
+        server.use_action(cid, pc, "skip")
+        server.next_turn(cid)
+    r1 = server.attack(cid, gid, pc, attack_bonus=4, damage_dice="1d6", attack_name="Bite")
+    r2 = server.attack(cid, gid, pc, attack_bonus=4, damage_dice="1d6", attack_name="Bite")
+    assert r1["attacks_allowed_this_turn"] == 2 and r1["multiattack_grants"] == 2
+    assert r2["attacks_made_this_turn"] == 2
+    with _pytest.raises(ValueError, match="Multiattack grants 2 attack"):
+        server.attack(cid, gid, pc, attack_bonus=4, damage_dice="1d6", attack_name="Bite")
+
+
+# =========================================================================
+# cs-timing F-2: PC attack-budget SOURCE (Action Surge vs Extra Attack feature)
+# =========================================================================
+# A Fighter L4 has NO Extra Attack (it is L5); a second swing comes from Action
+# Surge. The engine surfaces extra_attacks / surge_actions so distill labels the
+# budget source correctly instead of mis-crediting the Extra Attack feature.
+
+
+def test_action_surge_second_attack_surfaces_surge_source_not_extra_attack(tmp_path, monkeypatch):
+    """cs-timing F-2: Aldric (Fighter L4, extra_attacks=0) spends Action Surge for a 2nd
+    attack. The result must surface surge_actions>0 with extra_attacks=0 (NOT multiattack_grants)
+    so a downstream label reads the budget as Action Surge, never the Extra Attack feature he
+    does not yet have. A genuine Extra-Attack fighter (extra_attacks=1) surfaces extra_attacks."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    import pytest as _pytest
+
+    cid, cur, other, _ids = _combat_with_known_current(server)
+    server.set_class_resource(cid, cur, "action_surge", max=1, recharge="short")
+    server.attack(cid, cur, other, attack_bonus=5, damage_dice="1d6")  # 1st
+    server.use_resource(cid, cur, "action_surge")
+    a2 = server.attack(cid, cur, other, attack_bonus=5, damage_dice="1d6")  # 2nd via surge
+    assert a2["attacks_allowed_this_turn"] == 2
+    assert a2.get("extra_attacks") == 0          # he has no Extra Attack feature (L5)
+    assert a2.get("surge_actions") == 1          # the budget came from Action Surge
+    assert "multiattack_grants" not in a2        # PCs never carry a monster Multiattack grant
+
+    # Contrast: a real Extra-Attack fighter surfaces extra_attacks>0, surge=0.
+    cid2, cur2, other2, _ = _combat_with_known_current(server)
+    server.update_character(cid2, cur2, {"extra_attacks": 1})
+    server.attack(cid2, cur2, other2, attack_bonus=5, damage_dice="1d6")
+    b2 = server.attack(cid2, cur2, other2, attack_bonus=5, damage_dice="1d6")
+    assert b2.get("extra_attacks") == 1 and b2.get("surge_actions") == 0
+
+
+# =========================================================================
 # Issue #160/#166: Round-1 turn-skip enforcement in next_turn
 # =========================================================================
 # next_turn must BLOCK advancing past a PC/companion who can act but has not


### PR DESCRIPTION
## Summary

Two SRD-fidelity defects from the combat-sprint Angry-DM scorer (`cs-timing`, 2026-06-18), **validated against the deterministic engine before fixing** (per the project's validate-before-fixing rule — the LLM scorer mis-attributes root cause).

### ✅ F-3 — Ghoul Claw mis-budgeted as Multiattack (REAL — fixed)
The Ghoul's Multiattack is *"two Bite attacks"* (composition `['Bite','Bite']`); **Claw is a separate action, not part of the Multiattack.** `_attacker_multiattack_count` applied the count (2) to *any* attack, so a Claw got a Multiattack ceiling of 2 — over-permitting a 2nd Claw and producing the distilled annotation `Ghoul 1/2 attacks this turn (Multiattack)` for a non-Multiattack swing.

**Fix:** `attack()` gains an optional `attack_name`. A named attack **not** in the creature's Multiattack composition is a single Attack action and does **not** inherit the Multiattack ceiling. Empty `attack_name` == today (byte-identical); only restricts when the composition is **known** (conservative — never tightens a budget we can't justify from the stat block).

### ✅ F-2 — Action-Surge budget mislabeled "Extra Attack" (REAL — fixed)
A Fighter L4 (Extra Attack is **L5**, so `extra_attacks=0`) who spends Action Surge makes 2 strikes; `qa/distill.py` labeled that `(Extra Attack)` — crediting a feature he doesn't have. The two sources are indistinguishable from `attacks_allowed` alone (`extra=0,surge=1` and `extra=1,surge=0` both → 2).

**Fix:** the engine surfaces `extra_attacks`/`surge_actions` on a multi-attack swing; distill labels the source correctly (`Action Surge` / `Extra Attack` / `Extra Attack + Action Surge`). A known `extra_attacks=0` can **never** read "Extra Attack".

## NOT fixed — validated as scorer misattribution / out of engine scope (flagged, not force-fixed)
- **Second Wind max=3 @ Fighter L4** — **CORRECT** for SRD 5.2. The 2024 Fighter table grants 2/3/4 uses at L1/4/10 (confirmed vs in-repo `data/srd/srd524/ClassFeature.json`). No over-pooling. Scorer anchored on 2014 rules (Second Wind = once/rest).
- **Ranged-in-melee disadvantage (theater-of-mind)** — the engine has no distance model without zones (documented in `combat.py`). Not additively fixable; the DM passes `disadvantage=True` (engine honors it).
- **"concentration breaks" narration nuance** — DM prose governed by the DM skill files, not the engine. Engine distill already uses ENDS/saved/held for repeat-saves and "concentration-save" only for the caster.

## Invariants
Additive-by-default: optional param + new result fields only on genuine multi-attack turns; single swings and no-`attack_name` callers are byte-identical. Engine stays sole writer (result-dict additions + a budget-ceiling refinement, no new state writes). Tool-schema budget (SYN-02): **118,755 B < 120,000 B**.

## Tests (local gate — CI degraded repo-wide, reconciles post-merge)
- `test_combat.py` +4: named-action scoping unit (`_attacker_multiattack_count`: Bite→2, Claw→0, no-name→2), Ghoul Claw e2e (budget 1, no `multiattack_grants`, 2nd Claw rejected), Ghoul Bite regression (count-2 budget intact), Action-Surge source surfacing.
- `test_distill.py` +2/updated 1: Action-Surge label + **the CI assert that `extra_attacks:0` never reads "Extra Attack"**; combined Extra Attack + Action Surge.
- **Full engine suite: 3001 passed** · **fast_gate: 226 passed** · schema-budget gate green.