### PR TITLE
fix(engine): camp_overdue reachable by beats, not just day>=3 (WS-D)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -327,6 +327,14 @@ _LOG_EVENT_KINDS = frozenset({"narration", "dialogue", "roll", "system", "combat
 _ACT1_STALL_DAYS = 4
 _ACT1_STALL_BEATS = 8
 
+# camp_overdue beats-reach (WS-D). The DM rarely advances the in-world clock — 0 long_rest/downtime
+# across the QA corpus — so the original `day >= 3` camp gate was structurally UNREACHABLE and the
+# camp/companion-regard pillar (0/203 camp beats) never fired. Also cue camp once the party has
+# played ~8 beats with companions and no rest, mirroring act_one_stalled's beats_in_act reach, so the
+# pillar engages on a normal-length run instead of waiting for a day-advance that never comes. Tunable
+# from a duo A/B without touching the cue logic.
+_CAMP_OVERDUE_BEATS = 8
+
 
 def _validate_log_kind(kind: str) -> str:
     """Normalize + validate a DM-supplied beat kind against the whitelist (F07-6). Returns
@@ -11648,8 +11656,13 @@ def _compute_beat_obligations(c: Campaign) -> list[dict]:
 
     # 2. camp_overdue — the party has companions but nobody has rested (no camp beats land
     #    without a long_rest), or the last rest was 3+ in-world days ago. Camp is the pillar
-    #    where companion regard + arcs move; an overdue camp starves all of that.
-    if party_companions and day >= 3:
+    #    where companion regard + arcs move; an overdue camp starves all of that. Reachable by
+    #    in-world DAYS (the original signal, for runs that advance the clock) OR by BEATS played
+    #    (WS-D — the DM rarely advances time, so day>=3 alone never fired; cue camp after a long
+    #    stretch of play with companions and no rest).
+    _arc = getattr(c, "narrative_arc", None)
+    _beats_in_act = (getattr(_arc, "beats_in_act", 0) or 0) if _arc is not None else 0
+    if party_companions and (day >= 3 or _beats_in_act >= _CAMP_OVERDUE_BEATS):
         # NB: a value of 0 is a VALID rest day (rested on day 0), so coalesce only None, not
         # falsy-0 — `or -1` would wrongly read a day-0 rest as "never rested".
         def _rest_day(comp):

--- a/servers/engine/tests/test_beat_obligations.py
+++ b/servers/engine/tests/test_beat_obligations.py
@@ -113,6 +113,37 @@ def test_camp_overdue_when_last_rest_is_three_days_old():
     assert "camp_overdue" in _kinds(server._compute_beat_obligations(c))
 
 
+# --- WS-D: camp_overdue reachable by BEATS when the in-world clock never advances ---------------
+
+def test_camp_overdue_reachable_by_beats_when_clock_stuck_at_day_one():
+    """The DM rarely advances the in-world clock (0 long_rest/downtime across the QA corpus), so the
+    old day>=3 gate never fired and camp — the companion-regard pillar — stayed dead (0/203 camp
+    beats). A never-rested party with companions that has played >=_CAMP_OVERDUE_BEATS beats now
+    surfaces camp_overdue even at day 1."""
+    comp = _companion(likes=["mercy"], last_long_rest_day=-1)
+    c = _campaign_with(comp, day=1)            # clock stuck at day 1
+    c.narrative_arc.beats_in_act = server._CAMP_OVERDUE_BEATS
+    assert "camp_overdue" in _kinds(server._compute_beat_obligations(c))
+
+
+def test_camp_overdue_not_yet_owed_below_beats_threshold():
+    """Below the beats threshold (and below day 3) camp is not yet overdue — no false-early cue."""
+    comp = _companion(likes=["mercy"], last_long_rest_day=-1)
+    c = _campaign_with(comp, day=1)
+    c.narrative_arc.beats_in_act = server._CAMP_OVERDUE_BEATS - 1
+    assert "camp_overdue" not in _kinds(server._compute_beat_obligations(c))
+
+
+def test_camp_overdue_beats_path_silent_for_a_party_that_has_rested():
+    """The beats reach only surfaces a NEVER-rested (or stale-rested) party; a party that rested
+    recently is not overdue even with many beats and a stuck clock — the inner rest check still
+    holds (never_rested False, day-latest_rest == 0 < 3)."""
+    comp = _companion(likes=["mercy"], attitude=10, last_long_rest_day=1)
+    c = _campaign_with(comp, day=1)            # rested on day 1, clock stuck at day 1
+    c.narrative_arc.beats_in_act = server._CAMP_OVERDUE_BEATS + 4
+    assert "camp_overdue" not in _kinds(server._compute_beat_obligations(c))
+
+
 # --- camp_scene_skipped: rested TODAY but no camp scene landed --------------
 
 


### PR DESCRIPTION
## What
The camp / companion-regard pillar was **dead in real play** — 0/203 runs ever recorded a camp beat. Root cause: `camp_overdue` gated on `day >= 3`, but the DM almost never advances the in-world clock (**0 `long_rest`/`downtime` across 273 QA transcripts**), so the gate was structurally unreachable.

This makes `camp_overdue` reachable by **beats played** as well as days: a party with companions that has played `>= _CAMP_OVERDUE_BEATS` (8) beats with no rest now surfaces the cue even at day 1, mirroring `act_one_stalled`'s `beats_in_act` reach.

## Safety
- **Additive** — only *adds* firing opportunities (the `day >= 3` path is untouched); advisory obligation, no state change.
- The never-rested / stale-rest fire logic is unchanged, so a **freshly-rested party is still not flagged** (the beats reach only surfaces never-/stale-rested parties — verified by test).
- `+3` tests (beats-reachable at day 1; below-threshold silent; rested-party silent). Full engine suite **3015 passed**.

## Scope / follow-up
Scoped to the high-value, deterministic re-gate. The dedicated **stuck-clock time-advance cue** (the design's second leg, with an untuned K-window) is deferred to a VM-lane-tuned follow-up — `camp_overdue → long_rest` already advances the clock, so this captures the primary win cleanly.

Part of the story-engagement sprint (WS-D). WS0's `camp_downtime` engagement system will measure this landing on the next sweep. FPAD record: `worldos-session-notes/2026-06-18/story-engagement-sprint/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced camp obligation detection system to account for narrative progression alongside in-world calendar advancement. Rest reminders are now triggered by narrative beats in addition to day-based tracking, providing more responsive notifications when companions are actively present during extended campaigns.

* **Tests**
  * Added comprehensive test coverage validating the new camp obligation detection logic across various scenario conditions and narrative progression states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->