### PR TITLE
feat(qa): dm_advanced_time WARN guard — unmask a frozen DM the soft-tick hid (WS-E)

### DIFF
--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -580,6 +580,20 @@ def main() -> int:
         chk("world_advanced_time", day > 1 or (tod not in ("", "morning")),
             f"day={day} time_of_day={tod or '?'} after {session_beats} beats — the clock never moved "
             f"(advance_time / travel_to(advance_time=True) / long_rest)")
+        # dm_advanced_time (WS-E) — WARN-only. world_advanced_time above passes on ANY clock movement,
+        # INCLUDING the qa worldos_soft_tick backstop that auto-advances the clock every idle beat —
+        # which MASKS a DM that never rests or advances time itself (0 long_rest/downtime across the
+        # corpus, yet the soft-tick made day>1 so the floor stayed GREEN). This surfaces that mask
+        # without failing the run: a DM-ISSUED advance_time / long_rest / short_rest / downtime in the
+        # tool stream. The DM moving time itself is what feeds companion regard + camp + every
+        # day-gated system. (travel_to(advance_time=True) also advances time but isn't separately
+        # tallied here, so a rare travel-only run may WARN — it's advisory, never fatal.)
+        dm_time_tools = (tools["advance_time"] + tools["long_rest"]
+                         + tools["short_rest"] + tools["downtime"])
+        chk("dm_advanced_time", dm_time_tools > 0,
+            f"the DM never issued a time-advance tool in {session_beats} beats — only the harness "
+            f"soft-tick moved the clock, so companion regard / camp / day-gated systems stay starved; "
+            f"call long_rest / advance_time / downtime", fatal=False)
         locs = state.get("locations", {}) or {}
         visited = sum(1 for l in locs.values() if isinstance(l, dict) and l.get("visited"))
         # IN-PLACE PROGRESSION EXCEPTION (#623 false-cap): a multi-beat arc that genuinely

--- a/qa/test_assert_behavioral.py
+++ b/qa/test_assert_behavioral.py
@@ -810,6 +810,34 @@ def test_party_traveled_still_red_on_frozen_run(tmp_path):
     assert rc == 1, out
 
 
+# ── WS-E: dm_advanced_time — unmask a frozen DM whose clock the harness soft-tick moved ────────
+
+def test_dm_advanced_time_warns_when_clock_moved_but_no_dm_time_tool(tmp_path):
+    """The state day advanced (day=3) — but the DM issued NO time-advance tool, so only the harness
+    worldos_soft_tick moved the clock. world_advanced_time PASSES (it sees day>1), yet the DM never
+    rested/advanced time itself, starving companion regard / camp / day-gated systems. WS-E surfaces
+    this as a WARN (the run stays GREEN — advisory, not fatal)."""
+    events = _dm_text_turns(9)                       # session_beats=9 (>= MIN_BEATS), no time tool
+    state = _single_scene_state(day=3, quest_completed=True, visited_count=2)
+    rc, out = _run_gate(tmp_path, events, state)
+    assert "[WARN] dm_advanced_time" in out, out
+    assert "[FAIL] dm_advanced_time" not in out, out  # WARN-only, never fatal
+    assert rc == 0, out                               # the run is still GREEN
+
+
+def test_dm_advanced_time_passes_when_dm_issues_long_rest(tmp_path):
+    """A DM that actually issues a time-advance tool (long_rest) is not flagged."""
+    events = _dm_text_turns(9) + [
+        _assistant_tool_use("lr1", "mcp__worldos-engine__long_rest", {"campaign_id": "c"}),
+        _user_tool_result("lr1", json.dumps({"ok": True})),
+    ]
+    state = _single_scene_state(day=3, quest_completed=True, visited_count=2)
+    rc, out = _run_gate(tmp_path, events, state)
+    assert "[PASS] dm_advanced_time" in out, out
+    assert "[WARN] dm_advanced_time" not in out, out
+    assert rc == 0, out
+
+
 def test_party_traveled_still_red_when_clock_advanced_but_arc_unresolved(tmp_path):
     # Guard against broadening to clock-only: day advanced but NO completed quest → the AND
     # still fails (arc_resolved False) → party_traveled stays RED.


### PR DESCRIPTION
## What
`world_advanced_time` passes on **any** clock movement — including the QA `worldos_soft_tick` backstop that auto-advances the clock every idle beat. So a DM that **never rests or advances time itself** (0 `long_rest`/`downtime` across 273 transcripts) still scored GREEN, because the *harness* moved the clock for it. That mask is why "the DM never advances time" stayed invisible.

This adds an additive, **WARN-only** `dm_advanced_time` check: it asserts a **DM-issued** `advance_time`/`long_rest`/`short_rest`/`downtime` appears in the tool stream — surfacing the mask without failing the run. The DM moving time itself is what feeds companion regard + camp + every day-gated system, so this makes "the DM isn't doing it" visible on the next sweep.

## Safety
- **Additive + WARN-only** — never flips a GREEN run RED (only `fatal=True` checks fail the run).
- Honors the same `MIN_BEATS` + `WORLDOS_GATE_COMBAT_SPRINT` skip as `world_advanced_time`; reuses the existing `_tally` tool counts.
- `+2` tests (state day moved by the harness but no DM tool → WARN, run still GREEN; DM `long_rest` → PASS). qa corpus **40** + engine suite **3015** green.

## Deferred to the VM lane
The `run_party.sh` soft-tick **parity** fix (it lacks the backstop the other 4 runners have, so party runs have a fully frozen clock) is deferred to the VM lane where it's run-verifiable — a misplaced `worldos_soft_tick` would corrupt party-lane time, and it can't be unit-tested.

Part of the story-engagement sprint (WS-E). FPAD record: `worldos-session-notes/2026-06-18/story-engagement-sprint/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added behavioral validation to ensure time progression is properly tracked during game sessions.
  * Added test coverage for time advancement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->