### PR TITLE
fix(engine): coerce string/comma-string → list on hot tool args (kills the model-agnostic RED-cap)

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -12,10 +12,55 @@ from __future__ import annotations
 import time
 import warnings
 from enum import Enum
-from typing import Any, Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
+
+
+def _coerce_list(v):
+    """Pydantic BEFORE-validator: coerce a string (or comma-string) into a list, so a
+    list-typed tool arg / model field accepts the value the DM model reaches for.
+
+    FastMCP validates tool args against the function type hints with Pydantic BEFORE the
+    function body runs. A model (Claude OR GLM, proven on both) routinely passes a bare
+    string (``"honest_dealing"``) or a comma-string (``"id1,id2"``) where a list is
+    expected; the list-type check then rejects it ("Input should be a valid list"), which
+    trips the FATAL ``no_rejected_tool_calls`` behavioral gate and caps every lens — a
+    model-AGNOSTIC false-cap on ~30% of runs. Running this coercion as a BEFORE-validator
+    fixes it at the validation layer (the function body never sees the reject) WITHOUT
+    changing the emitted JSON wire schema — the param stays a plain ``array`` (a
+    BeforeValidator is invisible to ``json_schema()``), so the pinned-schema byte budget
+    (test_tool_schema_budget) does not regress. Mirrors the spirit of the existing
+    ``AbilityScores._accept_5e_shorthand`` defensive-shorthand coercion.
+
+    Behavior (ADDITIVE — correct callers are untouched):
+      * ``None`` -> ``None``           (passes through; the default / "omitted" case)
+      * a real ``list`` -> unchanged   (the correct caller's path; element validation still runs)
+      * ``""`` (empty/whitespace) -> ``[]``
+      * ``"foo"`` -> ``["foo"]``
+      * ``"a,b , c"`` -> ``["a", "b", "c"]``  (split on comma, each token stripped, blanks dropped)
+      * anything else (int, float, dict, ...) -> returned AS-IS so Pydantic STILL rejects it
+        loudly with the genuine ``list_type`` error (we never silently swallow a real type bug)."""
+    if v is None or isinstance(v, list):
+        return v
+    if isinstance(v, str):
+        s = v.strip()
+        if s == "":
+            return []
+        return [t.strip() for t in s.split(",") if t.strip()] if "," in s else [s]
+    return v
+
+
+# Reusable coercing type aliases — one ``_coerce_list`` helper, applied per element-type so
+# each param/field keeps its EXACT wire schema (untyped ``array`` vs ``array of string``).
+# Use these in place of the bare list hints on high-traffic DM-called tool args + nested
+# model fields. A BeforeValidator does not alter ``json_schema()``, so swapping these in is
+# byte-budget-neutral (verified against test_tool_schema_budget).
+ListArg = Annotated[Optional[list], BeforeValidator(_coerce_list)]          # Optional[list]      (untyped items)
+ReqListArg = Annotated[list, BeforeValidator(_coerce_list)]                 # list                (required, untyped items)
+StrListArg = Annotated[list[str], BeforeValidator(_coerce_list)]           # list[str]           (required)
+OptStrListArg = Annotated[Optional[list[str]], BeforeValidator(_coerce_list)]  # list[str] | None
 
 
 def _new_id(prefix: str) -> str:
@@ -347,7 +392,9 @@ class CompanionQuestArc(_StrictModel):
     title: str
     status: CompanionQuestStatus = "locked"
     stages: list[CompanionQuestStage] = Field(default_factory=list)
-    quest_ids: list[str] = Field(default_factory=list)
+    # quest_ids accepts a bare id-string / comma-string (the DM passes `"q1,q2"` or `"q1"`)
+    # since set_companion_quest_arc builds this model from a raw `arc` dict. Wire-neutral.
+    quest_ids: Annotated[list[str], BeforeValidator(_coerce_list)] = Field(default_factory=list)
     note: str = ""
 
     @model_validator(mode="after")
@@ -506,13 +553,16 @@ class CompanionDossier(_StrictModel):
     # The defining hurt that shapes the companion — kept to a clause, not a chapter.
     wound: str = ""
     # What the companion is pulling toward / pushing away from — short goal/aversion tags.
-    wants: list[str] = Field(default_factory=list)
-    fears: list[str] = Field(default_factory=list)
+    # The string-list vocabulary fields carry the BEFORE-validator so a dossier built via
+    # model_validate from a raw dict (author_companion_gauges' merge path) tolerates a bare
+    # string / comma-string per field. Wire-neutral; default [] untouched.
+    wants: Annotated[list[str], BeforeValidator(_coerce_list)] = Field(default_factory=list)
+    fears: Annotated[list[str], BeforeValidator(_coerce_list)] = Field(default_factory=list)
     # The moral spine the approval system rewards against ("mercy", "duty", "freedom").
-    values: list[str] = Field(default_factory=list)
+    values: Annotated[list[str], BeforeValidator(_coerce_list)] = Field(default_factory=list)
     # Concrete causes that move the approval gauge — what wins/loses this companion's regard.
-    approval_likes: list[str] = Field(default_factory=list)
-    approval_dislikes: list[str] = Field(default_factory=list)
+    approval_likes: Annotated[list[str], BeforeValidator(_coerce_list)] = Field(default_factory=list)
+    approval_dislikes: Annotated[list[str], BeforeValidator(_coerce_list)] = Field(default_factory=list)
     # Themes the (future) deterministic banter scheduler draws on, so camp talk isn't generic.
     banter_tags: list[str] = Field(default_factory=list)
     # Seed prompts the DM can voice at camp — terse situational hooks, not authored prose.
@@ -1307,10 +1357,14 @@ class Decision(_StrictModel):
     t: float = Field(default_factory=_now)
     day: int = 1
     summary: str  # the decision in one line
-    options: list[str] = Field(default_factory=list)  # what was on the table
+    # `options` / `actor_ids` / `approval_tags` carry a BEFORE-validator so a nested decision
+    # dict (persist_beat's `decision=`, or a future direct Decision build) accepts a bare
+    # string / comma-string the same way the standalone record_decision args do — the model
+    # path coerces too. Wire schema (array of string) is unchanged; default [] is untouched.
+    options: Annotated[list[str], BeforeValidator(_coerce_list)] = Field(default_factory=list)  # what was on the table
     chosen: str = ""  # what the party went with
     rationale: str = ""  # why
-    actor_ids: list[str] = Field(default_factory=list)  # who weighed in / decided
+    actor_ids: Annotated[list[str], BeforeValidator(_coerce_list)] = Field(default_factory=list)  # who weighed in / decided
     # The companion-approval causes this choice carried (lowercase_snake keys the DM tagged,
     # matched against each party companion's dossier approval_likes/dislikes when the decision
     # was recorded). Stored for RECALL — so the chronicle remembers WHY a companion's regard
@@ -1318,7 +1372,7 @@ class Decision(_StrictModel):
     # no `approval_tags` round-trips unchanged (the engine never infers a tag from prose; the
     # gauge move happened once, at record time, on the DM-supplied tags). The KEY vocabulary
     # lives in CONTENT (the companion dossiers), never in engine code.
-    approval_tags: list[str] = Field(default_factory=list)
+    approval_tags: Annotated[list[str], BeforeValidator(_coerce_list)] = Field(default_factory=list)
     # The companion this decision SIDES WITH / AGAINST (E2 ENSEMBLE) — an explicit companion id
     # the DM names so the inter-companion SECONDARY approval delta can ripple onto that
     # companion's allies/rivals. Stored for RECALL. ADDITIVE default "": an old snapshot with no

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -57,6 +57,11 @@ import wrapper_progress as _wrapper_progress_mod
 import _env
 from pydantic import ValidationError
 from models import (
+    ListArg,
+    OptStrListArg,
+    ReqListArg,
+    StrListArg,
+    _coerce_list,
     SKILL_ABILITIES,
     Ability,
     AbilityScores,
@@ -1800,7 +1805,7 @@ def create_character(
     background: str = "",
     subclass: Optional[str] = None,
     apply_srd_defaults: bool = False,
-    skills: Optional[list] = None,
+    skills: ListArg = None,
     location_id: str = "",
     add_to_party: bool = True,
     met: bool = False,
@@ -1920,7 +1925,7 @@ def start_character(
     abilities: Optional[dict] = None,
     background: str = "",
     subclass: Optional[str] = None,
-    skills: Optional[list] = None,
+    skills: ListArg = None,
     voice_id: str = "narrator-dm",
 ) -> dict:
     """Build the PLAYER character via a chosen ORIGIN, and add them to the party."""
@@ -2197,7 +2202,7 @@ def recruit_companion(
     max_hp: int = 0,
     armor_class: int = 0,
     apply_srd_defaults: bool = True,
-    skills: Optional[list] = None,
+    skills: ListArg = None,
     character_id: str = "",
     companion_id: str = "",
     id: str = "",
@@ -2314,7 +2319,7 @@ def reroll_character(
     abilities: Optional[dict] = None,
     background: str = "",
     subclass: Optional[str] = None,
-    skills: Optional[list] = None,
+    skills: ListArg = None,
     voice_id: str = "narrator-dm",
     level: Optional[int] = None,
 ) -> dict:
@@ -3867,8 +3872,8 @@ def _gate_combat_verb(c: "Campaign", actor: "Character", *, verb: str, consumes:
 @mcp.tool()
 def start_combat(
     campaign_id: str,
-    combatant_ids: list[str],
-    surpriser_ids: list[str] | None = None,
+    combatant_ids: StrListArg,
+    surpriser_ids: OptStrListArg = None,
 ) -> dict:
     """Begin combat: roll initiative (1d20 + initiative_bonus) for each combatant
     and build the turn order (desc, ties broken by DEX modifier then input order).
@@ -6751,7 +6756,7 @@ def cast_spell(
     id: str = "",
     as_ritual: bool = False,
     innate: bool = False,
-    target_ids: Optional[list] = None,
+    target_ids: ListArg = None,
 ) -> dict:
     """Cast a spell — works for ANY of the ~339 SRD spells. Consumes a spell slot
     (cantrips use none); upcasts when slot_level exceeds the spell's level; sets
@@ -8435,7 +8440,7 @@ def _canonicalize_spell_list(spells_list: list, existing: list, mode: str) -> li
 
 
 @mcp.tool()
-def learn_spells(campaign_id: str, character_id: str, spells_list: list,
+def learn_spells(campaign_id: str, character_id: str, spells_list: ReqListArg,
                  mode: str = "replace") -> dict:
     """Set a character's KNOWN spells. Each name is VALIDATED + CANONICALIZED (F03-7): an
     unknown spell (typo, non-SRD) is rejected listing the offenders, and any casing you pass
@@ -8453,7 +8458,7 @@ def learn_spells(campaign_id: str, character_id: str, spells_list: list,
 
 
 @mcp.tool()
-def prepare_spells(campaign_id: str, character_id: str, spells_list: list,
+def prepare_spells(campaign_id: str, character_id: str, spells_list: ReqListArg,
                    mode: str = "replace") -> dict:
     """Set a character's PREPARED spells. Each name is VALIDATED + CANONICALIZED (F03-7) like
     learn_spells. With a non-empty prepared list, cast_spell now enforces preparation for
@@ -8834,7 +8839,7 @@ def generate_parley_options(
     actor_id: str = "",
     situation: str = "",
     difficulty: str = "",
-    skills: Optional[list[str]] = None,
+    skills: OptStrListArg = None,
     include_alignment: bool = True,
     event_id: str = "",
     npc_id: str = "",
@@ -8967,7 +8972,7 @@ def _resolve_monster_xps(
 def encounter_outlook(
     campaign_id: str,
     monster_xps: Optional[list[int]] = None,
-    monster_ids: Optional[list[str]] = None,
+    monster_ids: OptStrListArg = None,
 ) -> dict:
     """Call this BEFORE staging a fight to see how over-matched it is against the LIVING
     party: it makes the SRD over-match math legible so the balancing doctrine is followable.
@@ -9220,9 +9225,9 @@ def _compact_camp_beat_records(c: Campaign) -> None:
 def record_camp_beat(
     campaign_id: str,
     beat_id: str,
-    companion_ids: Optional[list] = None,
+    companion_ids: ListArg = None,
     kind: str = "",
-    tags: Optional[list] = None,
+    tags: ListArg = None,
     note: str = "",
     resolved: bool = False,
 ) -> dict:
@@ -9479,7 +9484,7 @@ def session_recap(campaign_id: str) -> dict:
 
 
 @mcp.tool()
-def recall(campaign_id: str, query: str, kinds: Optional[list] = None, limit: int = 8) -> dict:
+def recall(campaign_id: str, query: str, kinds: ListArg = None, limit: int = 8) -> dict:
     """Search the WHOLE campaign's history (the memory ledger) — events, dialogue,
     decisions, NPC facts, quest milestones, consequences — ranked by relevance.
     The DM and companions use this to stay consistent and call back to the past
@@ -9767,11 +9772,11 @@ def set_companion_arc(campaign_id: str, companion_id: str = "", arc: dict = None
 def author_companion_gauges(
     campaign_id: str,
     companion_id: str = "",
-    approval_likes: Optional[list] = None,
-    approval_dislikes: Optional[list] = None,
-    values: Optional[list] = None,
-    wants: Optional[list] = None,
-    fears: Optional[list] = None,
+    approval_likes: ListArg = None,
+    approval_dislikes: ListArg = None,
+    values: ListArg = None,
+    wants: ListArg = None,
+    fears: ListArg = None,
     betrayal_threshold: Optional[int] = None,
     betrayal_decision_flag: str = "",
     companion: str = "",
@@ -10079,7 +10084,7 @@ def add_quest(
     description: str = "",
     giver_id: str = "",
     location_id: str = "",
-    objectives: Optional[list] = None,
+    objectives: ListArg = None,
 ) -> dict:
     """Add a quest, optionally linked to the NPC who gave it (giver_id) and the
     location it's anchored to (location_id), so the dashboard and DM can trace
@@ -10951,14 +10956,14 @@ def _apply_approval_tags(
 def record_decision(
     campaign_id: str,
     summary: str = "",
-    options: Optional[list] = None,
+    options: ListArg = None,
     chosen: str = "",
     rationale: str = "",
-    actor_ids: Optional[list] = None,
+    actor_ids: ListArg = None,
     sets_flag: str = "",
     decision: str = "",
     *,
-    approval_tags: Optional[list] = None,
+    approval_tags: ListArg = None,
     targets_companion: str = "",
 ) -> dict:
     """Record a party decision so the DM and companions can call back to it later
@@ -12574,14 +12579,19 @@ def persist_beat(
                 # `approval_tags` the standalone record_decision accepts (flat keys OR
                 # {key,delta}). Absent key == today's behavior (no move). Normalized keys are
                 # stored on the Decision for recall; the gauge move is applied in PHASE 2.
-                decision_approval_tags = decision.get("approval_tags")
+                # _coerce_list: a NESTED decision dict can carry a bare string / comma-string
+                # ("free,sell") on a list field, exactly like the standalone record_decision
+                # args do. Coerce here (BEFORE list()/_normalize_approval_tags, which would
+                # otherwise iterate the string char-by-char into ['f','r','e','e',...]); a real
+                # list / None is untouched, mirroring the Decision-model field validators.
+                decision_approval_tags = _coerce_list(decision.get("approval_tags"))
                 planned_decision = Decision(
                     day=c.day,
                     summary=decision.get("summary") or "",
-                    options=list(decision.get("options") or []),
+                    options=list(_coerce_list(decision.get("options")) or []),
                     chosen=decision.get("chosen") or "",
                     rationale=decision.get("rationale") or "",
-                    actor_ids=list(decision.get("actor_ids") or []),
+                    actor_ids=list(_coerce_list(decision.get("actor_ids")) or []),
                     approval_tags=[k for k, _ in _normalize_approval_tags(decision_approval_tags)],
                 )
                 decision_flag = str(decision.get("sets_flag") or "").strip()

--- a/servers/engine/tests/test_list_arg_coercion.py
+++ b/servers/engine/tests/test_list_arg_coercion.py
@@ -1,0 +1,231 @@
+"""LIST-ARG COERCION: a string / comma-string passed where a list is expected is coerced
+to a list at the Pydantic VALIDATION layer, instead of tripping the FATAL
+``no_rejected_tool_calls`` behavioral gate and capping every lens.
+
+THE BUG (model-AGNOSTIC, proven on Claude baseline-rc1 + cue-thaw AND GLM): FastMCP
+validates a tool's args against the function type hints with Pydantic BEFORE the function
+body runs. When the DM model passes ``approval_tags="honest_dealing"`` (a bare string) or
+``actor_ids="id1,id2"`` (a comma-string) where a ``list`` is expected, Pydantic raised
+``Input should be a valid list [type=list_type, ...]`` -> the rejected tool call flipped
+the release-gate ``no_rejected_tool_calls`` FATAL check RED -> all three lenses capped to
+<= 2.5 on an otherwise-coherent session (the ~30%-of-runs false-cap).
+
+THE FIX: a Pydantic ``BeforeValidator`` (models._coerce_list, exposed as the ListArg /
+ReqListArg / StrListArg / OptStrListArg aliases) coerces a string -> list BEFORE the
+list-type check, on the high-traffic DM-called list args. It is ADDITIVE — a real list
+and ``None`` pass through untouched, and a genuinely-wrong type (int/dict) is STILL
+rejected loudly (we never silently swallow a real type bug). It is wire-NEUTRAL — a
+BeforeValidator is invisible to ``json_schema()``, so the param stays a plain ``array``
+and the pinned-schema byte budget (test_tool_schema_budget) does not regress.
+
+These tests exercise the REAL rejection surface — the MCP tool manager, which builds +
+validates the auto-generated pydantic args model — NOT a direct ``server.fn(...)`` kwargs
+call (that bypasses the validator entirely). So they would RED pre-fix on the string cases
+and they prove the wrong-type cases still reject.
+"""
+
+import asyncio
+
+import pytest
+
+import server
+from models import (
+    ListArg,
+    OptStrListArg,
+    ReqListArg,
+    StrListArg,
+    _coerce_list,
+)
+from pydantic import BeforeValidator, TypeAdapter
+
+
+@pytest.fixture
+def campaign(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    return server.create_campaign("Coerce")["id"]
+
+
+def _call(name: str, args: dict):
+    """Invoke a registered MCP tool through the tool manager — the path the DM agent uses,
+    which builds + validates the auto-generated pydantic args model. This is the EXACT layer
+    that raised the ``list_type`` rejection pre-fix (a direct server.fn(...) call bypasses it)."""
+    return asyncio.run(server.mcp._tool_manager.call_tool(name, args))
+
+
+def _struct(res):
+    """The tool manager returns a ``(content, structured)`` shape across mcp versions; pull the
+    structured result dict the tool actually returns."""
+    if isinstance(res, tuple):
+        for part in res:
+            if isinstance(part, dict):
+                return part.get("result", part)
+        return res[-1]
+    return res
+
+
+# ---------------------------------------------------------------------------------------------
+# 1. The pure helper / alias behavior (the unit-level contract every alias shares).
+# ---------------------------------------------------------------------------------------------
+
+def test_coerce_list_helper_contract():
+    # string -> single-element list
+    assert _coerce_list("honest_dealing") == ["honest_dealing"]
+    # comma-string -> split + per-token strip + blank-drop
+    assert _coerce_list("id1,id2") == ["id1", "id2"]
+    assert _coerce_list(" id1 , id2 ,") == ["id1", "id2"]
+    # empty / whitespace string -> []
+    assert _coerce_list("") == []
+    assert _coerce_list("   ") == []
+    # a real list passes through UNCHANGED (correct caller's path)
+    real = ["a", "b"]
+    assert _coerce_list(real) == ["a", "b"]
+    # None passes through (the omitted / default case)
+    assert _coerce_list(None) is None
+    # a genuinely-wrong type is returned AS-IS so Pydantic still rejects it loudly
+    assert _coerce_list(5) == 5
+    assert _coerce_list({"a": 1}) == {"a": 1}
+
+
+@pytest.mark.parametrize("alias", [ListArg, ReqListArg, StrListArg, OptStrListArg])
+def test_alias_wire_schema_is_plain_array(alias):
+    """Each coercing alias emits the SAME json_schema as its un-annotated base type — a
+    BeforeValidator is invisible to the wire schema, so the pinned byte budget can't regress."""
+    coerced = TypeAdapter(alias).json_schema()
+    # strip the BeforeValidator and re-derive the base schema
+    base_type = alias.__args__[0]
+    plain = TypeAdapter(base_type).json_schema()
+    assert coerced == plain
+    # and the emitted shape is an array (anyOf for the Optional variants)
+    assert "array" in str(coerced)
+
+
+# ---------------------------------------------------------------------------------------------
+# 2. record_decision — THE proven culprit (approval_tags / actor_ids / options).
+#    Exercised through the validated tool-manager path.
+# ---------------------------------------------------------------------------------------------
+
+def test_record_decision_string_approval_tags_coerces_not_rejected(campaign):
+    # THE REPRO: pre-fix this raised `Input should be a valid list [type=list_type ...]`
+    # through the tool manager and tripped the FATAL no_rejected_tool_calls gate.
+    res = _struct(_call("record_decision", {
+        "campaign_id": campaign, "summary": "kept the bargain",
+        "approval_tags": "honest_dealing",
+    }))
+    assert isinstance(res, dict) and "id" in res
+    d = server._require(campaign).decisions[-1]
+    assert d.approval_tags == ["honest_dealing"]
+
+
+def test_record_decision_comma_actor_ids_coerces(campaign):
+    res = _struct(_call("record_decision", {
+        "campaign_id": campaign, "summary": "split the watch",
+        "actor_ids": "id1,id2",
+    }))
+    assert isinstance(res, dict) and "id" in res
+    d = server._require(campaign).decisions[-1]
+    assert d.actor_ids == ["id1", "id2"]
+
+
+def test_record_decision_comma_options_coerces(campaign):
+    _struct(_call("record_decision", {
+        "campaign_id": campaign, "summary": "which road",
+        "options": "north,south,wait",
+    }))
+    d = server._require(campaign).decisions[-1]
+    assert d.options == ["north", "south", "wait"]
+
+
+def test_record_decision_real_list_unchanged(campaign):
+    # ADDITIVE: a correct caller passing a real list is untouched (no double-wrap, no split).
+    _struct(_call("record_decision", {
+        "campaign_id": campaign, "summary": "real list",
+        "approval_tags": ["mercy", "cruelty"], "actor_ids": ["pc_1", "pc_2"],
+    }))
+    d = server._require(campaign).decisions[-1]
+    assert d.approval_tags == ["mercy", "cruelty"]
+    assert d.actor_ids == ["pc_1", "pc_2"]
+
+
+def test_record_decision_none_is_default(campaign):
+    # None / omitted -> the additive no-op (empty lists), exactly as before the fix.
+    _struct(_call("record_decision", {"campaign_id": campaign, "summary": "bare"}))
+    d = server._require(campaign).decisions[-1]
+    assert d.approval_tags == []
+    assert d.actor_ids == []
+    assert d.options == []
+
+
+def test_record_decision_int_approval_tags_still_rejected(campaign):
+    # A genuinely-wrong type must STILL be rejected loudly — we never swallow a real type bug.
+    with pytest.raises(Exception) as ei:
+        _call("record_decision", {
+            "campaign_id": campaign, "summary": "bad type", "approval_tags": 5,
+        })
+    assert "list_type" in str(ei.value) or "valid list" in str(ei.value)
+
+
+def test_record_decision_dict_actor_ids_still_rejected(campaign):
+    with pytest.raises(Exception) as ei:
+        _call("record_decision", {
+            "campaign_id": campaign, "summary": "bad type", "actor_ids": {"a": 1},
+        })
+    assert "list_type" in str(ei.value) or "valid list" in str(ei.value)
+
+
+# ---------------------------------------------------------------------------------------------
+# 3. Nested model path — persist_beat's decision=dict builds a Decision whose list FIELDS
+#    coerce too (the field-level BeforeValidator), so a string inside the nested dict is safe.
+# ---------------------------------------------------------------------------------------------
+
+def test_persist_beat_nested_decision_string_fields_coerce(campaign):
+    res = _struct(_call("persist_beat", {
+        "campaign_id": campaign,
+        "decision": {
+            "summary": "freed the bonded",
+            "options": "free,sell",          # comma-string in the NESTED dict
+            "actor_ids": "pc_1",             # bare string in the NESTED dict
+            "approval_tags": "free_the_bonded",
+        },
+    }))
+    assert isinstance(res, dict)
+    d = server._require(campaign).decisions[-1]
+    assert d.options == ["free", "sell"]
+    assert d.actor_ids == ["pc_1"]
+    assert d.approval_tags == ["free_the_bonded"]
+
+
+# ---------------------------------------------------------------------------------------------
+# 4. A combat id-list tool — start_combat.combatant_ids (required list[str]).
+# ---------------------------------------------------------------------------------------------
+
+def test_start_combat_comma_combatant_ids_coerces(campaign):
+    a = server.create_character(campaign, "Hero", kind="player")["id"]
+    b = server.create_character(campaign, "Goblin", kind="npc")["id"]
+    res = _struct(_call("start_combat", {
+        "campaign_id": campaign, "combatant_ids": f"{a},{b}",  # comma-string of ids
+    }))
+    assert isinstance(res, dict)
+    c = server._require(campaign)
+    assert c.combat.active
+    ids = {cb.character_id for cb in c.combat.order}
+    assert {a, b} <= ids
+
+
+# ---------------------------------------------------------------------------------------------
+# 5. author_companion_gauges — the char-split footgun: a bare string used to iterate
+#    char-by-char into ['m','e','r','c','y']; the param coercion makes it ['mercy'].
+# ---------------------------------------------------------------------------------------------
+
+def test_author_companion_gauges_string_approval_likes_coerces(campaign):
+    npc = server.create_character(campaign, "Toll", kind="npc")["id"]
+    server.recruit_companion(campaign, npc_id=npc, class_name="Cleric", level=2,
+                             abilities={"str": 10, "dex": 12, "con": 12, "int": 10,
+                                        "wis": 14, "cha": 10})
+    _struct(_call("author_companion_gauges", {
+        "campaign_id": campaign, "companion_id": npc,
+        "approval_likes": "mercy",          # bare string — pre-fix -> ['m','e','r','c','y']
+        "approval_dislikes": "cruelty,greed",
+    }))
+    ch = server._char(server._require(campaign), npc)
+    assert ch.companion_dossier.approval_likes == ["mercy"]
+    assert ch.companion_dossier.approval_dislikes == ["cruelty", "greed"]


### PR DESCRIPTION
## The model-agnostic RED-cap root cause
Engine tools take list args (`record_decision(approval_tags, actor_ids, options)` + ~131 list-arg sites). FastMCP validates args via Pydantic **before** the function runs, so a model passing a **string** (`approval_tags="honest_dealing"`) or **comma-string** (`actor_ids="id1,id2"`) where a list is expected → `Input should be a valid list` → the FATAL `no_rejected_tool_calls` gate → **all 3 lenses capped to ≤2.5**.

**This is model-agnostic** — the CLAUDE baseline transcripts (`baseline-rc1`, `cue-thaw`) hit the *same* rejection. It deflated ~30% of both GLM and Claude runs; the GLM "cap rate" was largely this.

## Fix — coerce at the validation layer (a `BeforeValidator`)
A reusable `_coerce_list` + aliases in `models.py` (next to the existing `_accept_5e_shorthand` defensive coercion): `None`/`list` pass through; `str → [s]`; comma-`str → split+strip+drop-blanks`; anything else returned unchanged so Pydantic **still rejects** genuinely-wrong types (int/dict) loudly. A `BeforeValidator` runs before the list-type check and is **invisible to the wire schema** (params stay `"array"`).

Applied to the hot tools: `record_decision` (options/actor_ids/approval_tags), `author_companion_gauges` (likes/dislikes/values/wants/fears), `start_combat` (combatant_ids/surpriser_ids), `cast_spell` (target_ids), + the `persist_beat` nested-decision path.

## Verified
Adversarial verifier: **SHIP** (correct coercion, no over-coercion, rejects preserved, schema clean). `qa/fast_gate.sh` **226 passed**; new `test_list_arg_coercion.py` + byte-budget **17 passed**. Additive; real lists/None unchanged. Phase-1 of the post-24h reorient — precondition for the honest GLM-vs-Claude re-measure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Tool functions now accept list-type parameters as comma-separated strings or plain text in addition to traditional list format, improving ease of use across character management, combat, spellcasting, and social features.

**Tests**
* Added comprehensive test coverage validating flexible list input handling across multiple tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->