### PR TITLE
feat(qa): clean model-profile switching — no GLM leak into Claude, switch-back safe, product always Claude

### DIFF
--- a/qa/glm_profile.sh
+++ b/qa/glm_profile.sh
@@ -5,9 +5,17 @@
 #
 # CONTRACT (the load-bearing guarantee):
 #   • GLM-ONLY. If NEITHER $WORLDOS_DM_MODEL NOR $WORLDOS_ACTOR_MODEL starts with
-#     "glm", worldos_apply_glm_profile is a TOTAL no-op (`return 0` before it
-#     touches a single var or env). A Claude run is therefore byte-for-byte
-#     unchanged — this file must never alter a Claude default.
+#     "glm", worldos_apply_glm_profile does NOT apply the GLM profile. On that Claude
+#     path it does ONE defensive thing before returning: it SCRUBS any stray GLM-injected
+#     env (ANTHROPIC_BASE_URL / ANTHROPIC_AUTH_TOKEN / API_TIMEOUT_MS / a GLM
+#     CLAUDE_CONFIG_DIR, and a GLM-looking ANTHROPIC_API_KEY) so switching back to Opus is
+#     always clean even if a stray GLM export leaked from the interactive shell. The scrub
+#     is a NO-OP when nothing is set, so a normal Claude run with a clean env is byte-for-
+#     byte unchanged — this file still never alters a Claude default value.
+#   • MIXED-MODEL GUARD. If EXACTLY ONE role is GLM (a half-GLM/half-Claude config, almost
+#     always a mistake), it warns to stderr and NORMALIZES both roles to the GLM profile so
+#     the run can never silently route one role to z.ai and the other to Anthropic over the
+#     shared process env.
 #   • When GLM IS the DM/actor model it:
 #       - sources the GLM credentials/endpoint from ~/.openclaw/secrets/glm.env
 #         (ANTHROPIC_BASE_URL / API key / CLAUDE_CONFIG_DIR) if that file exists;
@@ -32,13 +40,129 @@ _worldos_is_glm_model() {
   esac
 }
 
-# Apply the GLM-only profile. No-op for Claude (see the CONTRACT above).
+# The z.ai endpoint the GLM profile injects (glm.env's ANTHROPIC_BASE_URL). Used by the
+# Claude-path defensive unset below to recognize a STRAY GLM base URL in the ambient env
+# (so the API-key unset can be conditional on "this really is z.ai"). Kept here as the ONE
+# place the host appears in this file; it is the public endpoint host, not a secret.
+_WORLDOS_GLM_BASE_URL_HOST="api.z.ai"
+
+# Scrub any GLM-injected endpoint/credential vars from THIS process so a Claude run is clean
+# EVEN IF a stray GLM export leaked in from the interactive shell. Called on the Claude (no-GLM)
+# path BEFORE worldos_apply_glm_profile returns — the load-bearing "switching back to Opus is
+# always clean" guarantee.
+#
+# DESIGN PRINCIPLE — scrub GLM, never a legitimate Claude/Anthropic value. The owner contract is
+# that a Claude run with NO *GLM* env present is byte-identical to today. So every unset here is
+# GLM-CONDITIONAL: we strip a var ONLY when we can positively tie it to GLM (a z.ai base URL, or
+# a byte-match against glm.env's own value). A user who legitimately exports ANTHROPIC_BASE_URL=
+# https://api.anthropic.com (the live harness does exactly this), a corporate Anthropic-compatible
+# proxy, a real Claude API key, or their own CLAUDE_CONFIG_DIR is left UNTOUCHED. An unconditional
+# unset would have been "clean" but would also clobber those legitimate values and break the
+# byte-identical guarantee — so we deliberately do NOT do that.
+#
+# UNSET POLICY (per var):
+#   • ANTHROPIC_BASE_URL  — unset ONLY when it names the GLM (z.ai) host. A non-z.ai base URL
+#     (api.anthropic.com, a user's proxy) is a legitimate Claude value → left as-is.
+#   • ANTHROPIC_AUTH_TOKEN — unset when the base URL was z.ai (the whole GLM set leaked together)
+#     OR when it byte-matches glm.env's token (a token leaked with the URL already cleared).
+#     A Claude subscription run does not set this, so a GLM-matched token is always leakage.
+#   • API_TIMEOUT_MS — unset when the base URL was z.ai OR it byte-matches glm.env's value
+#     (3000000). Otherwise (e.g. the harness's own 900000) it is a legitimate user knob → kept.
+#   • CLAUDE_CONFIG_DIR — unset ONLY when it points at GLM's fresh config dir (/tmp/glm-claude-
+#     config from glm.env). Any other value is a user's own config dir → kept.
+#   • ANTHROPIC_API_KEY — unset ONLY when the base URL was z.ai OR the key byte-matches glm.env's
+#     key. A real Claude API key is left intact — we never clear a key we can't tie to GLM.
+_worldos_scrub_glm_env() {
+  local base_url="${ANTHROPIC_BASE_URL:-}" url_is_glm=0
+  case "$base_url" in
+    *"$_WORLDOS_GLM_BASE_URL_HOST"*) url_is_glm=1 ;;
+  esac
+
+  # Read glm.env's own values (WITHOUT printing them) so the remaining vars can be matched by
+  # byte-equality even when the z.ai base URL was already stripped. Secrets stay in locals.
+  local _glm_key="" _glm_token="" _glm_timeout=""
+  local glm_env="${WORLDOS_GLM_ENV:-$HOME/.openclaw/secrets/glm.env}"
+  if [ -f "$glm_env" ]; then
+    _glm_key="$(_worldos_glm_env_val ANTHROPIC_API_KEY "$glm_env")"
+    _glm_token="$(_worldos_glm_env_val ANTHROPIC_AUTH_TOKEN "$glm_env")"
+    _glm_timeout="$(_worldos_glm_env_val API_TIMEOUT_MS "$glm_env")"
+  fi
+
+  # ANTHROPIC_BASE_URL — only the GLM host.
+  [ "$url_is_glm" = "1" ] && unset ANTHROPIC_BASE_URL
+  # ANTHROPIC_AUTH_TOKEN — GLM URL present, or a glm.env byte-match.
+  if [ -n "${ANTHROPIC_AUTH_TOKEN:-}" ]; then
+    if [ "$url_is_glm" = "1" ] || { [ -n "$_glm_token" ] && [ "$ANTHROPIC_AUTH_TOKEN" = "$_glm_token" ]; }; then
+      unset ANTHROPIC_AUTH_TOKEN
+    fi
+  fi
+  # API_TIMEOUT_MS — GLM URL present, or a glm.env byte-match (never a user's own value).
+  if [ -n "${API_TIMEOUT_MS:-}" ]; then
+    if [ "$url_is_glm" = "1" ] || { [ -n "$_glm_timeout" ] && [ "$API_TIMEOUT_MS" = "$_glm_timeout" ]; }; then
+      unset API_TIMEOUT_MS
+    fi
+  fi
+  # CLAUDE_CONFIG_DIR — only GLM's fresh config dir.
+  case "${CLAUDE_CONFIG_DIR:-}" in
+    */glm-claude-config|*/glm-claude-config/) unset CLAUDE_CONFIG_DIR ;;
+  esac
+  # ANTHROPIC_API_KEY — GLM URL present, or a glm.env byte-match. Never an unrelated Claude key.
+  if [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+    if [ "$url_is_glm" = "1" ] || { [ -n "$_glm_key" ] && [ "$ANTHROPIC_API_KEY" = "$_glm_key" ]; }; then
+      unset ANTHROPIC_API_KEY
+    fi
+  fi
+  unset _glm_key _glm_token _glm_timeout
+  return 0
+}
+
+# Read one VAR=value from glm.env, stripping optional `export ` and surrounding quotes. Echoes
+# the raw value (callers keep it in a local and NEVER print it). $1=var name $2=glm.env path.
+_worldos_glm_env_val() {
+  local _v
+  _v="$(sed -n "s/^[[:space:]]*\(export[[:space:]]*\)\{0,1\}$1=//p" "$2" | head -n1)"
+  _v="${_v%\"}"; _v="${_v#\"}"
+  _v="${_v%\'}"; _v="${_v#\'}"
+  printf '%s' "$_v"
+}
+
+# Apply the GLM-only profile. No-op for Claude (see the CONTRACT above) EXCEPT that the
+# Claude path still scrubs any stray GLM env so a switch-back-to-Opus run is always clean.
 worldos_apply_glm_profile() {
-  # Detect GLM from EITHER role. If neither is GLM this returns immediately and
-  # nothing below runs — the Claude path is byte-for-byte unchanged.
-  if ! _worldos_is_glm_model "${WORLDOS_DM_MODEL:-}" \
-    && ! _worldos_is_glm_model "${WORLDOS_ACTOR_MODEL:-}"; then
+  # Detect GLM from EITHER role.
+  local dm_glm=0 actor_glm=0
+  _worldos_is_glm_model "${WORLDOS_DM_MODEL:-}" && dm_glm=1
+  _worldos_is_glm_model "${WORLDOS_ACTOR_MODEL:-}" && actor_glm=1
+
+  # ── Claude path (NEITHER role GLM) ────────────────────────────────────────────────────
+  # Scrub any stray GLM-injected env FIRST (the load-bearing "switch back to Opus is always
+  # clean" guarantee — see _worldos_scrub_glm_env), THEN return. The scrub is a NO-OP when
+  # nothing is set, so a normal Claude run with a clean env is byte-for-byte unchanged. The
+  # unset MUST run here — do not let an early return skip it.
+  if [ "$dm_glm" = "0" ] && [ "$actor_glm" = "0" ]; then
+    _worldos_scrub_glm_env
     return 0
+  fi
+
+  # ── MIXED-MODEL GUARD ─────────────────────────────────────────────────────────────────
+  # EXACTLY ONE role is GLM (a half-GLM/half-Claude config) — almost always a mistake: a
+  # GLM-DM + Claude-actor (or vice versa) run would route the two roles to DIFFERENT providers
+  # over the SAME process env (ANTHROPIC_BASE_URL is a process-global, not per-role), so the
+  # "Claude" half would silently inherit z.ai too. Refuse the accidental mix: warn loudly and
+  # NORMALIZE BOTH roles to the GLM profile so the whole run is coherently GLM (never a leaky
+  # half-and-half). An operator who truly wants a split must set BOTH roles explicitly.
+  if [ "$dm_glm" != "$actor_glm" ]; then
+    echo "[glm_profile] WARNING: MIXED model config — WORLDOS_DM_MODEL='${WORLDOS_DM_MODEL:-}' / " \
+         "WORLDOS_ACTOR_MODEL='${WORLDOS_ACTOR_MODEL:-}'. Exactly one role is GLM; the other " \
+         "would silently inherit the GLM (z.ai) endpoint over the shared process env. " \
+         "NORMALIZING BOTH roles to the GLM profile so the run is coherently GLM." >&2
+    # Pin whichever role is NOT already GLM onto the GLM one so downstream model selection is
+    # coherent. We keep the actual glm-* model id (the GLM role's value) for both.
+    if [ "$dm_glm" = "1" ]; then
+      export WORLDOS_ACTOR_MODEL="$WORLDOS_DM_MODEL"
+    else
+      export WORLDOS_DM_MODEL="$WORLDOS_ACTOR_MODEL"
+    fi
   fi
 
   # ── GLM detected ──────────────────────────────────────────────────────────

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -24,6 +24,24 @@
 #   WORLDOS_PLAY_MAX_TURNS        hard cap on DM turns                  (default 40)
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
+# PRODUCT PLAY IS CLAUDE-QUALITY — force-neutralize any ambient GLM env before any `claude -p`.
+# The .app DM must run Claude (Opus) quality; it must NEVER inherit the GLM (z.ai) endpoint just
+# because a user happened to export GLM vars in their interactive shell (e.g. after a QA run).
+# QA uses GLM ONLY via qa/glm_profile.sh; the product play path never does and never opts in.
+# We neutralize CONDITIONALLY so we strip GLM but never a legitimate Claude value: a GLM env is
+# recognized by the z.ai base URL — when present we drop the WHOLE GLM set (endpoint + auth token
+# + API key + auth token + timeout) since glm.env always exports them together; the GLM
+# CLAUDE_CONFIG_DIR (/tmp/glm-claude-config) is dropped by its own path match. A non-z.ai
+# ANTHROPIC_BASE_URL (api.anthropic.com, a corporate proxy) and an unrelated CLAUDE_CONFIG_DIR are
+# left UNTOUCHED — so a normal clean launch (and a legit Anthropic-env launch) is byte-identical to
+# today. We MUST drop ANTHROPIC_API_KEY too: leaving the GLM key behind while clearing the z.ai URL
+# would make the product DM hit api.anthropic.com with a z.ai key → auth-failed dead cold-open.
+case "${ANTHROPIC_BASE_URL:-}" in
+  *api.z.ai*) unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN API_TIMEOUT_MS ;;
+esac
+case "${CLAUDE_CONFIG_DIR:-}" in
+  */glm-claude-config|*/glm-claude-config/) unset CLAUDE_CONFIG_DIR ;;
+esac
 COMMON="$ROOT/scripts/launch_common.sh"
 if [ -f "$COMMON" ]; then
   # shellcheck source=launch_common.sh

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -46,6 +46,24 @@
 #   WORLDOS_PLAY_MAX_TURNS        hard cap on agent turns (DM + companions)(default 40)
 set -uo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"; cd "$ROOT" || exit 1
+# PRODUCT PLAY IS CLAUDE-QUALITY — force-neutralize any ambient GLM env before any `claude -p`.
+# The .app DM (and the companion actors) must run Claude quality; they must NEVER inherit the GLM
+# (z.ai) endpoint just because a user exported GLM vars in their interactive shell (e.g. after a
+# QA run). QA uses GLM ONLY via qa/glm_profile.sh; the product play path never does and never opts
+# in. The solo branch below execs play.sh (which re-applies this same scrub); doing it HERE too
+# covers the ensemble path (which does not exec play.sh). We neutralize CONDITIONALLY so we strip
+# GLM but never a legitimate Claude value: a GLM env is recognized by the z.ai base URL — when
+# present we drop the WHOLE GLM set (endpoint + API key + auth token + timeout, exported together by
+# glm.env — dropping ANTHROPIC_API_KEY too is REQUIRED: a leftover GLM key against api.anthropic.com
+# is a dead auth cold-open); the GLM CLAUDE_CONFIG_DIR is dropped by its own path match. A non-z.ai
+# ANTHROPIC_BASE_URL and an unrelated CLAUDE_CONFIG_DIR are left UNTOUCHED — so a normal/legit-
+# Anthropic launch is byte-identical to today.
+case "${ANTHROPIC_BASE_URL:-}" in
+  *api.z.ai*) unset ANTHROPIC_BASE_URL ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN API_TIMEOUT_MS ;;
+esac
+case "${CLAUDE_CONFIG_DIR:-}" in
+  */glm-claude-config|*/glm-claude-config/) unset CLAUDE_CONFIG_DIR ;;
+esac
 COMMON="$ROOT/scripts/launch_common.sh"
 if [ -f "$COMMON" ]; then
   # shellcheck source=launch_common.sh


### PR DESCRIPTION
Phase-1 of the post-24h reorient. Makes model-switching **clean**: one choice flows coherently, a Claude/Opus run can never accidentally use GLM, and switching back is safe — even if a stray GLM export is sitting in the shell after a QA run.

## Changes
1. **`glm_profile.sh` — defensive unset on Claude-mode.** On the no-op (neither role GLM) path, *before* returning, scrub any stray GLM env (`ANTHROPIC_BASE_URL`/key/token/`API_TIMEOUT_MS` + a `/tmp/glm-claude-config` `CLAUDE_CONFIG_DIR`) — by **byte-match to the GLM values** so a legitimate `sk-ant-` key + `api.anthropic.com` are never touched. This is the "switch back to Opus is always clean" guarantee (the unset runs *on* the Claude path, not skipped by the early return).
2. **`glm_profile.sh` — mixed-model guard.** If exactly one of `WORLDOS_DM_MODEL`/`WORLDOS_ACTOR_MODEL` is GLM (a half-GLM/half-Claude config — almost always a mistake that would route the "Claude" half to z.ai over the shared process env), warn + **normalize both** to the GLM model. No silent mixed run.
3. **`play.sh` + `play_party.sh` — product is ALWAYS clean Claude.** Near the top, before any `claude -p`, conditionally neutralize ambient GLM env (recognized by the z.ai base URL). Product `.app` play never opts into GLM (QA uses GLM only via `glm_profile.sh`).

## Adversarial verify (+ the fix it found)
The verifier confirmed: Claude-path scrub works (incl. API_KEY by byte-match), GLM path still sources `glm.env` + raises timeouts, mixed-model guarded, **no over-reach** (a real `sk-ant-` key + `api.anthropic.com` + harness timeouts preserved). It caught a real bug — the product scrub dropped the z.ai URL but **left the GLM `ANTHROPIC_API_KEY`** → a dead-auth product cold-open. **Fixed**: the product scrub now drops the full GLM set (key included). Env-trace proof: stray z.ai base+key → both UNSET; a legit Anthropic env → untouched. (One verifier flag, "deleted score.sh isolation," was a pre-rebase base-staleness artifact — resolved by rebasing onto current `main`; this branch never touches `score.sh`.)

`bash -n` clean; product/Claude paths byte-identical when no GLM env is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced environment configuration handling to prevent unintended cross-provider model routing conflicts.
  * Improved isolation of model-specific settings across different execution paths to ensure proper configuration independence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->