### PR TITLE
feat(#461): grid coordinate-authority PR-1 — measured movement + grid OA + melee-reach (additive, opt-in)

### DIFF
--- a/docs/roadmap/grid-461-design.md
+++ b/docs/roadmap/grid-461-design.md
@@ -1,0 +1,61 @@
+# #461 — Grid / Coordinate Authority (design + PR ladder)
+
+Status: PR-1 landed (movement spine). Additive, opt-in, no default behavior change.
+
+## The additive model
+
+The engine gains a SECOND positional model — a coordinate grid — that coexists with
+the existing zone/theater model. Neither replaces the other:
+
+- **Theater-of-the-mind** (no zones, no grid) — today's default; unchanged.
+- **Zones** (S2.7) — named regions + adjacency; `move_to_zone` / `combatants_in_zone`
+  stay LITERALLY unchanged (signature + docstring + behavior). A permanent first-class
+  fallback.
+- **Grid** (#461) — `(x, y)` cells, `grid_cell_size` ft each. Engaged ONLY by `set_grid`
+  (the sole tool that flips `Combat.grid_enabled`).
+
+All new state is sub-model fields with TODAY's-behavior defaults:
+
+- `Combat`: `grid_enabled=False`, `grid_width=0`, `grid_height=0`, `grid_cell_size=5`,
+  `diagonal_mode='chebyshev'`.
+- `Combatant`: `x=None`, `y=None`, `moved_cells_this_turn=0`, `dashed=False`.
+
+`grid_enabled=False` ⇒ zone/theater combat is BYTE-FOR-BYTE today's behavior (the grid
+code paths are all guarded on the flag; `_combat_view` emits zero key delta off-grid).
+No new TOP-LEVEL Campaign key, so `store.py`'s tolerant-load top-level strip is untouched
+and old snapshots round-trip. A half-set `x`/`y` pair WARNs (never raises) so a tolerant
+load can't crash on a malformed snapshot.
+
+## PR ladder
+
+| PR | Scope |
+|----|-------|
+| **PR-1** (this) | Movement spine: grid model + `set_grid` / `place_combatant_at_coords` / `move_to_coords`; Chebyshev distance; speed→cells budget; Dash; open-floor reachability; reach-leave opportunity-attack predicate (with the two SRD gates the zone loop omits — one Reaction/round, can't-see); measured-melee advisory in `attack()`; `_combat_view` grid block. |
+| **PR-1.5** | The two renderer-facing read-only tools `measure_range` and `grid_reachable` (deferred from PR-1 purely for tool-schema budget — they are for the renderer, not core combat). Land alongside a deliberate schema-budget reclamation. |
+| PR-2 | Area-of-effect templates + line-of-effect (`affected_tile_coords`). |
+| PR-3 | Terrain (difficult terrain cost, blockers) + line-of-sight / cover. |
+| PR-4 | Creature size + reach (>1-cell tokens, reach weapons). |
+| PR-5 | Ranged-weapon range gating (normal/long range, disadvantage at long). |
+| PR-6 | Movement modes (fly/swim/climb/burrow, half-cost climb). |
+| PR-7 | Flanking (advantage from opposite-side allies — optional rule). |
+| PR-8 | `five_ten_five` diagonal mode (the variant 5e diagonal rule; the model field is already reserved). |
+
+## Additivity + fallback guarantee
+
+- The grid never blocks. Over-budget, out-of-range, Speed-0, out-of-bounds, occupied —
+  all surface as ADVISORY notes in the return (`movement_illegal`, `warnings`,
+  `range_warning`), mirroring the zone model's posture. The DM adjudicates.
+- The engine stays the SOLE WRITER. The read-only renderer helpers (PR-1.5) never call
+  `save_campaign` or mutate state.
+- Zone/theater is a permanent fallback — a DM can run any fight without ever touching the
+  grid, and a grid fight degrades gracefully (unplaced combatants threaten/cost nothing).
+
+## Downstream surface contract (renderer)
+
+PR-1 carries position on the wire; the renderer consumes it in later increments:
+
+- **render-profile v2**: `positioning: "grid"` (alongside the existing zone profile).
+- **`/combat-surface`**: per-combatant `grid_x` / `grid_y`, plus `movement_available`
+  (from `grid_reachable`, PR-1.5) and `affected_tile_coords` (AoE, PR-2).
+- `_combat_view` already emits a `grid` block (`width`/`height`/`cell_size`/
+  `diagonal_mode`) and per-order-entry `x`/`y` when on-grid — the minimal positional feed.

--- a/servers/engine/combat_grid.py
+++ b/servers/engine/combat_grid.py
@@ -1,0 +1,130 @@
+"""#461 grid (PR-1): pure, I/O-free coordinate-authority helpers.
+
+Mirrors combat.py's pure-helper style — no Campaign, no lock, no save: just math
+over (x, y) cells. The MCP tools in server.py wrap these with the lock +
+persistence and surface their results. ADDITIVE: nothing here runs unless a fight
+flips Combat.grid_enabled (set_grid); zone/theater combat never touches this module.
+
+PR-1 SCOPE is the movement spine only: Chebyshev distance, a speed→cells budget, an
+open-floor reachability flood, and a reach-leave opportunity-attack predicate. AoE,
+cover, line-of-sight, terrain, creature size/reach, and ranged-range gating are all
+DEFERRED to later PRs — every combatant here is a single 1-cell, 5ft-reach token.
+"""
+
+from __future__ import annotations
+
+Cell = tuple[int, int]
+
+
+def chebyshev_cells(a: Cell, b: Cell) -> int:
+    """Chebyshev (king-move) distance in CELLS between two (x, y) cells: the larger
+    of the column and row deltas. This is 5e's default diagonal rule (a diagonal step
+    costs the same as an orthogonal one), so the count from a cell to any of its 8
+    neighbours is 1."""
+    (ax, ay), (bx, by) = a, b
+    return max(abs(ax - bx), abs(ay - by))
+
+
+def range_ft(cells: int, cell_size: int = 5) -> int:
+    """Convert a CELL distance to feet. cells is the count-from-adjacent distance —
+    the origin cell is NOT counted — so two cells one step apart are `cell_size` feet,
+    matching the SRD ("a creature's space ... count[ing] from the edge")."""
+    return cells * cell_size
+
+
+def distance_ft(a: Cell, b: Cell, cell_size: int = 5) -> int:
+    """Chebyshev distance between two cells, in feet (origin cell not counted)."""
+    return range_ft(chebyshev_cells(a, b), cell_size)
+
+
+def in_melee_reach(a: Cell, b: Cell) -> bool:
+    """True if two cells are within 5ft melee reach: Chebyshev distance <= 1 (the same
+    cell or any of the 8 neighbours). PR-1 has no creature-size/reach model — every
+    token is 1 cell with 5ft reach."""
+    return chebyshev_cells(a, b) <= 1
+
+
+def movement_budget_cells(speed: int, cell_size: int = 5, dashed: bool = False) -> int:
+    """Movement budget in CELLS for a turn: floor(speed / cell_size), doubled if the
+    creature Dashed. Speed 30 / 5ft cells -> 6 cells (12 with Dash)."""
+    if cell_size <= 0:
+        return 0
+    base = speed // cell_size
+    return base * 2 if dashed else base
+
+
+def reachable(
+    start: Cell,
+    budget_cells: int,
+    occupied: set[Cell],
+    width: int,
+    height: int,
+) -> set[Cell]:
+    """Open-floor reachability: every in-bounds cell reachable from `start` within
+    `budget_cells` of movement, flooding over the 8-neighbourhood at a flat cost of 1
+    cell per step (Chebyshev movement). A move may PASS THROUGH nothing-blocks (PR-1
+    has no terrain) but may NOT END on an occupied cell, so `occupied` cells are
+    dropped from the result (and the start itself is excluded — you stay put for free,
+    it's not a "move to"). PR-1: flat cost, no terrain, no size.
+
+    `occupied` should NOT include `start` (the mover doesn't block itself). Returns a
+    set of (x, y) cells. Pure Dijkstra/BFS over uniform cost; deterministic.
+    """
+    if budget_cells <= 0:
+        return set()
+    # BFS by ring: uniform cost 1 means a plain breadth-first expansion gives the
+    # minimal step count to each cell. Occupied cells can't be entered at all (PR-1
+    # treats a creature's cell as impassable — no moving through allies in this PR).
+    dist: dict[Cell, int] = {start: 0}
+    frontier = [start]
+    while frontier:
+        nxt: list[Cell] = []
+        for (cx, cy) in frontier:
+            d = dist[(cx, cy)]
+            if d >= budget_cells:
+                continue
+            for dx in (-1, 0, 1):
+                for dy in (-1, 0, 1):
+                    if dx == 0 and dy == 0:
+                        continue
+                    nx, ny = cx + dx, cy + dy
+                    if not (0 <= nx < width and 0 <= ny < height):
+                        continue
+                    cell = (nx, ny)
+                    if cell in occupied:
+                        continue  # can't enter (and so can't pass through) a token
+                    if cell in dist:
+                        continue
+                    dist[cell] = d + 1
+                    nxt.append(cell)
+        frontier = nxt
+    # Exclude the start cell (it's where you already are, not a destination).
+    return {c for c in dist if c != start}
+
+
+def path_cost_cells(from_cell: Cell, to_cell: Cell, path: list[Cell] | None = None) -> int:
+    """Measured movement cost in CELLS from `from_cell` to `to_cell`.
+
+    If an explicit `path` (a list of waypoint cells the mover steps through, EXCLUDING
+    the start) is given, the cost is the sum of the Chebyshev step between consecutive
+    cells (so a hand-routed path around an obstacle costs what it walked). With no path,
+    PR-1 assumes open floor and charges the straight-line Chebyshev distance (the
+    minimal open-floor cost). Pure; no occupancy check (the caller flags illegal ends).
+    """
+    if not path:
+        return chebyshev_cells(from_cell, to_cell)
+    total = 0
+    prev = from_cell
+    for step in path:
+        total += chebyshev_cells(prev, step)
+        prev = step
+    return total
+
+
+def provokes_on_leave(prev_cell: Cell, new_cell: Cell, threat_cell: Cell) -> bool:
+    """Reach-leave opportunity-attack predicate: a mover provokes an OA from a threat
+    if it WAS within the threat's 5ft melee reach at `prev_cell` AND is OUT of that
+    reach at `new_cell` (it left the threatened area). Staying within reach (a 5ft
+    side-step) does NOT provoke; never being in reach does not provoke. PR-1 reach is a
+    flat 5ft (Chebyshev <= 1) for every threatener."""
+    return in_melee_reach(prev_cell, threat_cell) and not in_melee_reach(new_cell, threat_cell)

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1285,6 +1285,30 @@ class Combatant(_StrictModel):
     # reaction_used). Set via use_action(kind="disengage"); read by move_to_zone to suppress
     # provokers. Additive: existing combats deserialize with False (today's behaviour).
     disengaged: bool = False
+    # #461 grid (PR-1): cell coordinates when the fight runs on a coordinate grid
+    # (Combat.grid_enabled). None == not on the grid (zone/theater fallback unchanged).
+    # Both x and y are set together (a half-set pair is a bug — warned, never raised).
+    x: Optional[int] = None
+    y: Optional[int] = None
+    # #461 grid (PR-1): cells moved this turn (budget = floor(speed/cell) cells; doubled
+    # by Dash). Reset to 0 at the start of the combatant's turn (with reaction_used).
+    moved_cells_this_turn: int = 0
+    # #461 grid (PR-1): took the Dash action this turn (doubles the movement budget).
+    # Per-turn; reset with moved_cells_this_turn. Set via use_action(kind="dash").
+    dashed: bool = False
+
+    @model_validator(mode="after")
+    def _grid_coords_paired(self) -> "Combatant":
+        # ADVISORY (never raise): exactly one of x/y set is almost always a bug, but a
+        # half-set pair must round-trip a tolerant load rather than crash a snapshot.
+        if (self.x is None) != (self.y is None):
+            import warnings as _w
+            _w.warn(
+                f"Combatant {self.character_id!r}: exactly one of x/y is set "
+                f"(x={self.x}, y={self.y}) — grid coords should be set as a pair.",
+                stacklevel=2,
+            )
+        return self
 
 
 class Zone(_StrictModel):
@@ -1318,6 +1342,17 @@ class Combat(_StrictModel):
     # Tactical regions for THIS fight (S2.7). Empty = theater-of-the-mind: range/
     # movement gating is inert and nothing changes. Additive default.
     zones: list[Zone] = Field(default_factory=list)
+    # #461 grid (PR-1): coordinate-authority mode. False (default) == zone/theater
+    # combat is BYTE-FOR-BYTE unchanged — nothing on the grid path runs. Flipped True
+    # ONLY by set_grid, which also sets the extents. Cells are grid_cell_size feet each
+    # (5e default 5). diagonal_mode picks the distance metric (PR-1 ships chebyshev;
+    # five_ten_five is reserved for PR-8). The grid is a SECOND positional model that
+    # coexists with zones — neither replaces the other.
+    grid_enabled: bool = False
+    grid_width: int = 0
+    grid_height: int = 0
+    grid_cell_size: int = 5
+    diagonal_mode: Literal["chebyshev", "five_ten_five"] = "chebyshev"
 
     @property
     def current_combatant_id(self) -> Optional[str]:

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -26,6 +26,7 @@ from mcp.server.fastmcp import FastMCP
 
 import bestiary
 import combat
+import combat_grid
 import companion
 import companion_banter
 import companion_arc
@@ -406,6 +407,10 @@ def _combat_view(c: Campaign) -> dict:
         }
         if cb.zone:  # only surface position when zones are in play (S2.7)
             entry["zone"] = cb.zone
+        # #461 grid: surface cell coords only when the combatant is placed on the grid.
+        if c.combat.grid_enabled and cb.x is not None and cb.y is not None:
+            entry["x"] = cb.x
+            entry["y"] = cb.y
         order.append(entry)
     view = {
         "active": c.combat.active,
@@ -416,6 +421,13 @@ def _combat_view(c: Campaign) -> dict:
     }
     if c.combat.zones:  # theater-of-the-mind fights omit this entirely
         view["zones"] = [z.model_dump() for z in c.combat.zones]
+    if c.combat.grid_enabled:  # zero key delta when the grid is off
+        view["grid"] = {
+            "width": c.combat.grid_width,
+            "height": c.combat.grid_height,
+            "cell_size": c.combat.grid_cell_size,
+            "diagonal_mode": c.combat.diagonal_mode,
+        }
     return view
 
 
@@ -4237,6 +4249,221 @@ def combatants_in_zone(campaign_id: str, zone: str) -> dict:
     return {"zone": zone, "count": len(occupants), "combatants": occupants}
 
 
+def _can_see(viewer: "Character") -> bool:
+    """#461 grid (PR-1): can `viewer` see (a precondition for taking an opportunity
+    attack)? PR-1 = NOT Blinded and NOT Unconscious. Later PRs add LoS/obscurement."""
+    conds = set(viewer.conditions)
+    return Condition.BLINDED not in conds and Condition.UNCONSCIOUS not in conds
+
+
+def _cell(cb: "Combatant") -> tuple[int, int] | None:
+    """The (x, y) cell of a combatant, or None if it isn't placed on the grid."""
+    if cb.x is None or cb.y is None:
+        return None
+    return (cb.x, cb.y)
+
+
+@mcp.tool()
+def set_grid(campaign_id: str, width: int, height: int, cell_size: int = 5,
+             diagonal_mode: str = "chebyshev") -> dict:
+    """#461: switch this fight to a coordinate grid (the only tool that sets grid mode).
+    Optional; without it combat stays zone/theater. Sets extents (cells; cell_size ft);
+    idempotent; needs width/height>0."""
+    if width <= 0 or height <= 0:
+        raise ValueError("set_grid needs width > 0 and height > 0")
+    if diagonal_mode not in ("chebyshev", "five_ten_five"):
+        raise ValueError("diagonal_mode must be 'chebyshev' or 'five_ten_five'")
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        c.combat.grid_enabled = True
+        c.combat.grid_width = width
+        c.combat.grid_height = height
+        c.combat.grid_cell_size = cell_size
+        c.combat.diagonal_mode = diagonal_mode  # type: ignore[assignment]
+        save_campaign(c)
+        return _combat_view(c)
+
+
+@mcp.tool()
+def place_combatant_at_coords(campaign_id: str, combatant_id: str, x: int, y: int) -> dict:
+    """#461: set a combatant's (x,y) cell — setup, NO opportunity-attack check (use
+    move_to_coords in combat). Needs set_grid first. Warns (never blocks) if out of
+    bounds/occupied."""
+    if not combatant_id:
+        raise ValueError("place_combatant_at_coords needs a combatant_id")
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        if not c.combat.active:
+            raise ValueError("no active combat")
+        if not c.combat.grid_enabled:
+            raise ValueError("this fight is not on a grid — call set_grid first (or use place_combatant for zones)")
+        cb = _combatant(c, combatant_id)
+        ch = c.characters.get(combatant_id)
+        warnings: list[str] = []
+        if not (0 <= x < c.combat.grid_width and 0 <= y < c.combat.grid_height):
+            warnings.append(
+                f"({x}, {y}) is out of the {c.combat.grid_width}x{c.combat.grid_height} grid — placed anyway."
+            )
+        occupant = next(
+            (o for o in c.combat.order if o.character_id != combatant_id and (o.x, o.y) == (x, y)),
+            None,
+        )
+        if occupant is not None:
+            other = c.characters.get(occupant.character_id)
+            warnings.append(f"({x}, {y}) is already occupied by {other.name if other else occupant.character_id} — placed anyway.")
+        cb.x = x
+        cb.y = y
+        save_campaign(c)
+        view = _combat_view(c)
+    view["placed"] = {"id": combatant_id, "name": ch.name if ch else "?", "x": x, "y": y}
+    view["warnings"] = warnings
+    return view
+
+
+@mcp.tool()
+def move_to_coords(campaign_id: str, combatant_id: str, x: int, y: int,
+                   path: ListArg = None, dash: bool = False) -> dict:
+    """#461: move a combatant to cell (x,y) in combat (grid twin of move_to_zone). Charges
+    measured cost (Chebyshev, or sum `path`); budget floor(speed/cell), x2 Dash. Returns
+    opportunity_attack + provokers (foes whose 5ft reach was left, minus reaction-spent/can't-
+    see/disengaged/grappler). Over-budget/Speed-0 -> advisory movement_illegal (never blocks)."""
+    if not combatant_id:
+        raise ValueError("move_to_coords needs a combatant_id")
+    path_cells = None
+    if path:
+        path_cells = []
+        for step in _coerce_list(path):
+            pr = list(step) if isinstance(step, (list, tuple)) else step
+            path_cells.append((int(pr[0]), int(pr[1])))
+    with campaign_lock(campaign_id):
+        c = _require(campaign_id)
+        if not c.combat.active:
+            raise ValueError("no active combat")
+        if not c.combat.grid_enabled:
+            raise ValueError("this fight is not on a grid — call set_grid first (or use move_to_zone for zones)")
+        cb = _combatant(c, combatant_id)
+        mover = c.characters.get(combatant_id)
+        from_cell = _cell(cb)
+        cell_size = c.combat.grid_cell_size
+        warnings: list[str] = []
+        if not (0 <= x < c.combat.grid_width and 0 <= y < c.combat.grid_height):
+            warnings.append(
+                f"({x}, {y}) is out of the {c.combat.grid_width}x{c.combat.grid_height} grid — moved anyway."
+            )
+
+        to_cell = (x, y)
+        # Measured movement cost (PR-1: open floor — straight Chebyshev, or the summed
+        # explicit path). Accumulates across a broken-up move this turn.
+        if from_cell is None:
+            cost = 0  # an unplaced combatant: this is effectively a placement, no cost
+        else:
+            cost = combat_grid.path_cost_cells(from_cell, to_cell, path_cells)
+        prior_used = cb.moved_cells_this_turn
+        dashed = bool(dash) or bool(cb.dashed)
+        budget = combat_grid.movement_budget_cells(mover.speed, cell_size, dashed) if mover else 0
+
+        # Opportunity attacks: REUSE move_to_zone's side classification + disengage/grapple
+        # suppression, PLUS the Chebyshev reach-leave test and the two SRD gates the zone
+        # loop omits (one reaction/round, and can't-see). Only when actually changing cells.
+        provokers: list[dict] = []
+        disengaged = bool(getattr(cb, "disengaged", False))
+        grappler_id = getattr(mover, "grappled_by", None) if mover is not None else None
+        if from_cell is not None and to_cell != from_cell and mover is not None and not disengaged:
+            ally_kinds = {"player", "companion"}
+            mover_ally = mover.kind in ally_kinds
+            for other_cb in c.combat.order:
+                if other_cb.character_id == combatant_id:
+                    continue
+                if other_cb.character_id == grappler_id:
+                    continue  # the grappler can't OA the creature it holds
+                other = c.characters.get(other_cb.character_id)
+                if other is None or other.dead:
+                    continue
+                if (other.kind in ally_kinds) == mover_ally:
+                    continue  # same side -> no OA
+                threat_cell = _cell(other_cb)
+                if threat_cell is None:
+                    continue  # an unplaced foe threatens no cell
+                if not combat_grid.provokes_on_leave(from_cell, to_cell, threat_cell):
+                    continue  # didn't leave this foe's reach
+                # SRD gates the zone loop lacks:
+                if other_cb.reaction_used:
+                    continue  # one Reaction per round, already spent
+                if not _can_see(other):
+                    continue  # can't see the mover -> no OA (PR-1: Blinded/Unconscious)
+                provokers.append({"id": other.id, "name": other.name})
+
+        # Advisory movement-illegal note: Speed-0 (Grappled/Restrained) OR over budget.
+        # Never hard-blocks — mirror move_to_zone's posture; the move still lands.
+        movement_illegal: dict | None = None
+        if mover is not None and from_cell is not None and to_cell != from_cell:
+            speed_zero = [
+                cn.value for cn in (Condition.GRAPPLED, Condition.RESTRAINED)
+                if cn in mover.conditions
+            ]
+            if speed_zero:
+                movement_illegal = {
+                    "mover": mover.name,
+                    "conditions": speed_zero,
+                    "reason": (
+                        f"{mover.name} is {', '.join(speed_zero)} (Speed 0) and cannot normally "
+                        "move — escape the grapple / end the restraint first. Moved anyway (advisory)."
+                    ),
+                }
+            elif prior_used + cost > budget:
+                movement_illegal = {
+                    "mover": mover.name,
+                    "cost_cells": cost,
+                    "used_cells": prior_used,
+                    "budget_cells": budget,
+                    "reason": (
+                        f"{mover.name} would move {prior_used + cost} cells this turn "
+                        f"({range_helper(prior_used + cost, cell_size)} ft) but the budget is "
+                        f"{budget} cells ({range_helper(budget, cell_size)} ft){' (with Dash)' if dashed else ''}. "
+                        "Moved anyway (advisory) — Dash or rule otherwise."
+                    ),
+                }
+
+        cb.x = x
+        cb.y = y
+        cb.moved_cells_this_turn = prior_used + cost
+        _log_combat_event(
+            c,
+            f"{mover.name if mover else combatant_id} moves to ({x}, {y}).",
+            {
+                "event": "grid_movement",
+                "actor": _combatant_ref(mover) if mover else {"id": combatant_id, "name": "?"},
+                "from": list(from_cell) if from_cell else None,
+                "to": [x, y],
+                "cost_cells": cost,
+                "opportunity_attack": bool(provokers),
+                "provokers": provokers,
+                "disengaged": disengaged,
+                "movement_illegal": movement_illegal,
+                "warnings": list(warnings),
+            },
+            speaker=mover.name if mover else "",
+        )
+        save_campaign(c)
+        view = _combat_view(c)
+    view["from"] = list(from_cell) if from_cell else None
+    view["to"] = [x, y]
+    view["cost_cells"] = cost
+    view["opportunity_attack"] = bool(provokers)
+    view["provokers"] = provokers
+    view["warnings"] = warnings
+    if disengaged:
+        view["disengaged"] = True
+    if movement_illegal is not None:
+        view["movement_illegal"] = movement_illegal
+    return view
+
+
+def range_helper(cells: int, cell_size: int) -> int:
+    """Cells -> feet (origin cell not counted). Thin wrapper over combat_grid.range_ft."""
+    return combat_grid.range_ft(cells, cell_size)
+
+
 def _turn_brief(ch: "Character", c: "Campaign") -> dict:
     """Build the per-turn brief for the combatant whose turn it just became.
 
@@ -4521,6 +4748,8 @@ def next_turn(campaign_id: str) -> dict:
                 if cb.character_id == cur.id:
                     cb.reaction_used = False
                     cb.disengaged = False  # F01-8: Disengage is per-turn — clear at turn start
+                    cb.moved_cells_this_turn = 0  # #461: fresh movement budget for the new turn
+                    cb.dashed = False  # #461: Dash is per-turn — clear at turn start
                     break
         # Tick round/minute-scale timed effects ONCE per new round (a "10 rounds"
         # effect lasts 10 rounds, not 10 turns) and auto-expire those that hit 0.
@@ -4704,17 +4933,16 @@ def next_turn(campaign_id: str) -> dict:
 @mcp.tool()
 def use_action(campaign_id: str, character_id: str, kind: str = "action") -> dict:
     """Track a combatant's action economy. kind: action | bonus | reaction | free | skip
-    | disengage. `action`/`bonus` are legal only on the creature's OWN turn and once each
-    per turn; `reaction` is once per round (refreshes at the start of its turn); `free`/
-    movement isn't rate-limited. `skip` (a.k.a. pass) declares a do-nothing turn (Dodge/
-    Dash/Ready/pass) — sets action_used so next_turn's PC-skip guard is satisfied.
-    `disengage` (F01-8) spends the action AND sets a per-turn `disengaged` flag so a
-    following move_to_zone provokes NO opportunity attacks. Returns {ok, reason,
-    action_available, bonus_available, reaction_available, disengaged}. NOTE: multiattack
-    is ONE action — declare a single `action`, then make several attack() calls under it."""
+    | disengage | dash. `action`/`bonus`: own turn, once each; `reaction`: once per round
+    (refreshes at turn start); `free`/movement: unlimited. `skip` (pass) declares a do-nothing
+    turn (sets action_used so next_turn's PC-skip guard passes). `disengage` (F01-8) spends the
+    action and sets a per-turn `disengaged` flag so a following move provokes NO opportunity
+    attacks. `dash` (#461) spends the action and DOUBLES the grid move budget (inert off-grid).
+    Returns {ok, reason, action_available, bonus_available, reaction_available, disengaged}.
+    NOTE: multiattack is ONE action — declare a single `action`, then several attack() calls."""
     kind = kind.lower()
-    if kind not in ("action", "bonus", "reaction", "free", "movement", "skip", "disengage"):
-        raise ValueError("kind must be action | bonus | reaction | free | skip | disengage")
+    if kind not in ("action", "bonus", "reaction", "free", "movement", "skip", "disengage", "dash"):
+        raise ValueError("kind must be action | bonus | reaction | free | skip | disengage | dash")
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         if not c.combat.active:
@@ -4729,7 +4957,7 @@ def use_action(campaign_id: str, character_id: str, kind: str = "action") -> dic
         ok, reason = True, ""
         # SRD: an incapacitated creature (incl. stunned/paralyzed/petrified/unconscious) can take
         # NO actions, bonus actions, or reactions. Block before consuming the budget.
-        if combat.is_incapacitated(ch) and kind in ("action", "bonus", "reaction", "disengage"):
+        if combat.is_incapacitated(ch) and kind in ("action", "bonus", "reaction", "disengage", "dash"):
             ok, reason = False, (
                 f"{ch.name} is incapacitated ("
                 f"{', '.join(c.value for c in ch.conditions if c in combat.INCAPACITATING)}) "
@@ -4745,6 +4973,17 @@ def use_action(campaign_id: str, character_id: str, kind: str = "action") -> dic
             else:
                 c.combat.action_used = True
                 combatant.disengaged = True
+        elif kind == "dash":
+            # #461: the Dash ACTION — spend the action (own turn, once) and set the per-turn
+            # dashed flag so a subsequent move_to_coords gets the doubled grid budget. Inert
+            # in zone/theater (move_to_zone ignores it); a grid move reads cb.dashed.
+            if not is_current:
+                ok, reason = False, f"it is not {ch.name}'s turn — dash must be declared on your own turn"
+            elif c.combat.action_used:
+                ok, reason = False, "action already used this turn (dash is an action)"
+            else:
+                c.combat.action_used = True
+                combatant.dashed = True
         elif kind == "skip":
             # Declare an intentional pass: satisfies the PC-skip guard in next_turn so
             # the DM can advance the turn without the combatant attacking or casting.
@@ -5045,15 +5284,11 @@ def attack(
     is_ranged=True so a prone target gives disadvantage rather than advantage) and
     combined with the explicit flags (they cancel if both apply).
 
-    Battle Master DAMAGE maneuvers (#213/B): pass ``maneuver`` (e.g. 'Trip Attack') to
-    declare one atomically — the engine spends ONE ``maneuver_resource`` die (default
-    'superiority_dice') ONLY on a hit, folds it into the damage, and crit-doubles it; a miss
-    spends nothing. ``maneuver_damage_type`` overrides the bonus's type. Empty ``maneuver``
-    == today's behavior.
-
-    ``attack_name`` (e.g. 'Claw'): for a Multiattack creature, scopes the per-turn budget to
-    that named attack — one NOT in the Multiattack (the Ghoul's Claw vs its 'two Bite'
-    Multiattack) is a single Attack action, not granted the Multiattack count. Empty == today."""
+    Battle Master DAMAGE maneuvers (#213/B): pass ``maneuver`` (e.g. 'Trip Attack') to declare
+    one atomically — the engine spends ONE ``maneuver_resource`` die (default 'superiority_dice')
+    only on a hit, folds it into the damage, and crit-doubles it; a miss spends nothing.
+    ``maneuver_damage_type`` overrides its type. ``attack_name`` (e.g. 'Claw') scopes a
+    Multiattack creature's per-turn budget to that named attack. Empty values == today."""
     # Coalesce intuitive arg-name aliases to the canonical ids. The ATTACKER is the acting
     # character (alias `character_id`); the TARGET is the thing struck (aliases `npc_id`/`id`).
     # Canonical names win. (target_id ⇄ character_id is intentionally NOT done — `character_id`
@@ -5282,6 +5517,22 @@ def attack(
             warn = combat.melee_range_warning(c.combat.zones, attacker, target, az, tz)
             if warn:
                 result["range_warning"] = warn
+        # #461 grid: measured-MELEE advisory. When on a grid AND both ends are placed AND
+        # the attack is non-ranged, a Chebyshev distance > 5ft is out of melee reach.
+        # Advisory only (mirror the zone warning); NO ranged-range gating in PR-1.
+        if not is_ranged and c.combat.grid_enabled:
+            acb = next((cb for cb in c.combat.order if cb.character_id == attacker_id), None)
+            tcb = next((cb for cb in c.combat.order if cb.character_id == target_id), None)
+            ac = _cell(acb) if acb else None
+            tc = _cell(tcb) if tcb else None
+            if ac is not None and tc is not None:
+                feet = combat_grid.distance_ft(ac, tc, c.combat.grid_cell_size)
+                if feet > 5:
+                    result["range_warning"] = (
+                        f"{attacker.name} at {ac} is {feet} ft from {target.name} at {tc} — "
+                        f"a melee attack normally needs 5 ft (close the distance first). "
+                        f"Advisory; the attack was still resolved."
+                    )
         # F3-6: capture the target's concentration BEFORE damage may down it (combat.apply_damage*
         # clears it but is Character-pure and can't free the victim) — see the release after.
         was_conc_target = target.concentration
@@ -9901,25 +10152,15 @@ def author_companion_gauges(
     character_id: str = "",
 ) -> dict:
     """Author a companion's APPROVAL VOCABULARY (and, optionally, a betrayal agenda) so their
-    relationship gauge can MOVE on the player's choices.
+    relationship gauge can MOVE on the player's choices. A recruited/generated companion seeds
+    with an EMPTY vocabulary, so record_decision(approval_tags=…) can't match it and the engine
+    skips them (regard stays narrated-not-gauged); call this once when they join.
 
-    A freely-recruited or live-generated companion is seeded with an operational dossier but an
-    EMPTY approval vocabulary (approval_likes/dislikes) — so ``record_decision(approval_tags=…)``
-    has nothing to match and the engine SKIPS them (their regard stays narrated-not-gauged, the
-    arc never turns). The hand-authored campaign companions (Brother Toll, Sergeant Ondine) only
-    work because content authored these lists for them. Call this once when a companion joins to
-    give a recruited/generated companion the same SOUL the engine can gauge.
-
-    ``approval_likes``/``approval_dislikes`` are the lowercase cause-keys you'll tag choices with
-    (e.g. ``"free_the_bonded"``, ``"refuse_a_bribe"``) — pick a few that fit WHO THIS COMPANION
-    IS; ``values``/``wants``/``fears`` are the short moral-spine tags behind them. Pass
-    ``betrayal_threshold`` (an attitude_value such as ``-30``) to ALSO arm an ``attitude_below``
-    agenda so the bond can BREAK if the player drives their regard below it — optionally gated on
-    a recorded ``betrayal_decision_flag``; omit it and the companion can deepen but never turn.
-
-    ADDITIVE + engine-sole-writer: only the fields you pass are written; the dossier's
-    ``camp_prompts`` and any existing arc gates are preserved. Identify the companion via
-    ``companion_id`` (canonical) or the aliases ``companion``/``character_id``."""
+    approval_likes/approval_dislikes are lowercase cause-keys you tag choices with (e.g.
+    "free_the_bonded"); values/wants/fears are the moral-spine tags behind them. betrayal_threshold
+    (a NEGATIVE attitude_value, e.g. -30) arms an attitude_below agenda so the bond can BREAK,
+    optionally gated on betrayal_decision_flag. ADDITIVE + sole-writer: only passed fields are
+    written. Identify via companion_id (canonical) or the aliases companion/character_id."""
     companion_id = companion_id or companion or character_id
     if not companion_id:
         raise ValueError("author_companion_gauges needs a companion id (`companion_id` or an alias)")
@@ -11084,20 +11325,15 @@ def record_decision(
     approval_tags: ListArg = None,
     targets_companion: str = "",
 ) -> dict:
-    """Record a party decision so the DM and companions can call back to it later
-    ('last time we trusted Grett...'). Capture the choice after a deliberation:
-    `summary` (the decision; pass as `summary` (canonical) or `decision` (alias) —
-    `summary` wins if both given), `options` (what was on the table), `chosen`, why
-    (`rationale`), and who weighed in (`actor_ids`). Returns the decision id.
+    """Record a party decision so the DM and companions can call back to it later. Capture
+    after a deliberation: `summary` (canonical; `decision` is an alias), `options`, `chosen`,
+    `rationale`, `actor_ids`. Returns the decision id.
 
-    `approval_tags` (optional) MOVES companion approval on a moral choice — pass the
-    lowercase_snake cause-keys it aligns with (e.g. `["mercy", "cruelty"]`, or
-    `[{"key": "power", "delta": 25}]` for an explicit swing). For each party companion whose
-    dossier `approval_likes`/`approval_dislikes` match, the engine moves `attitude_value`
-    (±10 default, clamped ±100) and reports `approval_results` — the DM tags the cause, the
-    engine owns the number. `targets_companion` (optional) names the companion sided
-    with/against, so other companions whose dossier.stance lists them as ally/rival feel a
-    smaller secondary ripple (±5). Omit either (default) for a choice no companion weighs."""
+    `approval_tags` (optional) MOVES companion approval — lowercase_snake cause-keys (e.g.
+    ["mercy"], or [{"key":"power","delta":25}] for an explicit swing). For each party companion
+    whose dossier approval_likes/dislikes match, the engine moves attitude_value (±10 default,
+    clamp ±100) and reports approval_results. `targets_companion` (optional) names who the choice
+    sided with/against, rippling ±5 onto their dossier-listed allies/rivals."""
     summary = summary if summary else decision  # `decision` is an accepted alias for `summary`
     if not summary:
         raise ValueError("record_decision needs a summary (pass `summary` or its alias `decision`)")

--- a/servers/engine/tests/test_grid.py
+++ b/servers/engine/tests/test_grid.py
@@ -1,0 +1,327 @@
+"""#461 grid (PR-1) — coordinate-authority movement spine.
+
+ADDITIVE / opt-in: a fight is on the grid ONLY after set_grid (grid_enabled=True).
+With grid_enabled=False, zone/theater combat is BYTE-FOR-BYTE today's behaviour —
+the round-trip + zero-key-delta tests below are the load-bearing guards for that.
+
+PR-1 scope is the movement spine: Chebyshev distance, speed->cells budget, Dash,
+open-floor reachability, and the reach-leave opportunity-attack predicate (with the
+two SRD gates the zone loop omits: one Reaction/round, and can't-see). AoE, cover,
+LoS, terrain, size/reach and ranged-range gating are DEFERRED to later PRs.
+"""
+
+import json
+
+import pytest
+
+import combat_grid
+import server
+import store
+from models import Combat, Combatant, Condition
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def fight(tmp_path, monkeypatch):
+    """A hero (player, speed 30) + a goblin (monster) in active combat.
+    Returns (campaign_id, hero_id, goblin_id)."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Grid 461")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30, armor_class=14)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=15, armor_class=12)["id"]
+    server.start_combat(cid, [hero, gob])
+    return cid, hero, gob
+
+
+def _snapshot_bytes(cid: str) -> bytes:
+    """Raw on-disk snapshot bytes (for the read-only-discipline test)."""
+    import store as _store
+    path = _store._campaign_dir(cid) / "snapshot.json" if hasattr(_store, "_campaign_dir") else None
+    # Fall back to scanning the state dir for the snapshot.
+    if path is None or not path.exists():
+        import os
+        for root, _dirs, files in os.walk(os.environ["WORLDOS_STATE_DIR"]):
+            if "snapshot.json" in files and cid in root:
+                path = __import__("pathlib").Path(root) / "snapshot.json"
+                break
+    return path.read_bytes()
+
+
+# ── (1) ROUND-TRIP: pre-grid snapshot loads with grid fields absent → defaults ─
+
+
+def test_pregrid_snapshot_roundtrips_to_defaults(fight):
+    """A snapshot written before the grid fields existed (we simulate by deleting them)
+    loads with grid_enabled=False and x/y=None — and re-validates clean."""
+    cid, hero, gob = fight
+    c = store.load_campaign(cid)
+    raw = json.loads(c.model_dump_json())
+    # Simulate a pre-grid snapshot: strip every grid key that didn't used to exist.
+    for k in ("grid_enabled", "grid_width", "grid_height", "grid_cell_size", "diagonal_mode"):
+        raw["combat"].pop(k, None)
+    for cb in raw["combat"]["order"]:
+        for k in ("x", "y", "moved_cells_this_turn", "dashed"):
+            cb.pop(k, None)
+    from models import Campaign
+    reloaded = Campaign.model_validate(raw)
+    assert reloaded.combat.grid_enabled is False
+    assert reloaded.combat.grid_width == 0 and reloaded.combat.grid_height == 0
+    assert reloaded.combat.grid_cell_size == 5
+    assert reloaded.combat.diagonal_mode == "chebyshev"
+    for cb in reloaded.combat.order:
+        assert cb.x is None and cb.y is None
+        assert cb.moved_cells_this_turn == 0
+        assert cb.dashed is False
+
+
+def test_grid_off_zone_transcript_byte_identical(tmp_path, monkeypatch):
+    """With grid_enabled=False, a ZONE transcript produces the SAME engine outputs as a
+    clean run with no grid code present (the grid path must be wholly inert)."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path / "a"))
+    cid = server.create_campaign("Z")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=20, armor_class=12)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=15, armor_class=10)["id"]
+    server.start_combat(cid, [hero, gob])
+    server.set_zones(cid, [{"name": "hall", "adjacent": ["dais"]}, {"name": "dais", "adjacent": ["hall"]}])
+    server.place_combatant(cid, hero, "hall")
+    server.place_combatant(cid, gob, "hall")
+    move = server.move_to_zone(cid, hero, "dais")
+    # The zone move surfaces NO grid keys at all (grid is off).
+    assert "grid" not in move
+    view = server._combat_view(store.load_campaign(cid))
+    assert "grid" not in view
+    assert all("x" not in e and "y" not in e for e in view["order"])
+
+
+def test_grid_off_theater_transcript_clean(fight):
+    """grid_enabled=False, no zones: theater-of-the-mind move surfaces no grid keys."""
+    cid, hero, _gob = fight
+    res = server.move_to_zone(cid, hero, "over there")
+    assert "grid" not in res
+    view = server._combat_view(store.load_campaign(cid))
+    assert "grid" not in view
+
+
+# ── (2) Chebyshev math ───────────────────────────────────────────────────────
+
+
+def test_chebyshev_pure_diagonal_is_one_cell():
+    assert combat_grid.chebyshev_cells((0, 0), (1, 1)) == 1
+    assert combat_grid.chebyshev_cells((0, 0), (3, 3)) == 3
+
+
+def test_chebyshev_orthogonal_equals_diagonal():
+    # 3 east == 3 diagonal under Chebyshev (5e default diagonal rule).
+    assert combat_grid.chebyshev_cells((0, 0), (3, 0)) == combat_grid.chebyshev_cells((0, 0), (3, 3))
+
+
+def test_range_ft_origin_not_counted():
+    # adjacent (1 cell) == 5ft; the origin cell is not counted.
+    assert combat_grid.range_ft(0) == 0
+    assert combat_grid.range_ft(1) == 5
+    assert combat_grid.range_ft(3) == 15
+    assert combat_grid.distance_ft((0, 0), (0, 0)) == 0  # same cell, 0ft
+
+
+# ── (3) speed → budget ───────────────────────────────────────────────────────
+
+
+def test_speed_to_budget_cells():
+    assert combat_grid.movement_budget_cells(30) == 6
+    assert combat_grid.movement_budget_cells(25) == 5  # floor(25/5)
+    assert combat_grid.movement_budget_cells(30, dashed=True) == 12
+
+
+def test_over_budget_move_is_advisory_but_still_moves(fight):
+    cid, hero, _gob = fight
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, hero, 0, 0)
+    # speed 30 -> 6 cells; a 7-cell move is over budget.
+    res = server.move_to_coords(cid, hero, 7, 0)
+    assert res["movement_illegal"]["reason"] if isinstance(res.get("movement_illegal"), dict) else True
+    assert "movement_illegal" in res
+    c = store.load_campaign(cid)
+    cb = server._combatant(c, hero)
+    assert cb.x == 7 and cb.y == 0  # moved anyway (advisory, never hard-blocks)
+
+
+def test_moved_cells_accumulate_across_a_broken_up_move(fight):
+    cid, hero, _gob = fight
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, hero, 0, 0)
+    server.move_to_coords(cid, hero, 3, 0)  # 3 cells
+    res = server.move_to_coords(cid, hero, 5, 0)  # +2 cells
+    c = store.load_campaign(cid)
+    cb = server._combatant(c, hero)
+    assert cb.moved_cells_this_turn == 5
+    assert "movement_illegal" not in res  # 5 <= 6 budget
+
+
+# ── (4) Dash ─────────────────────────────────────────────────────────────────
+
+
+def test_use_action_dash_accepted_and_sets_dashed(fight):
+    cid, hero, _gob = fight
+    server.set_grid(cid, 20, 20)
+    cur = server.get_state(cid)["current_turn"]
+    res = server.use_action(cid, cur, "dash")  # must NOT raise
+    assert res["ok"] is True
+    c = store.load_campaign(cid)
+    cb = server._combatant(c, cur)
+    assert cb.dashed is True
+
+
+def test_dash_doubles_budget(fight):
+    cid, hero, gob = fight
+    # ensure hero is current so dash is legal
+    if server.get_state(cid)["current_turn"] != hero:
+        server.next_turn(cid)
+    cid_cur = server.get_state(cid)["current_turn"]
+    server.set_grid(cid, 30, 30)
+    server.place_combatant_at_coords(cid, cid_cur, 0, 0)
+    server.use_action(cid, cid_cur, "dash")
+    res = server.move_to_coords(cid, cid_cur, 10, 0)  # 10 cells <= 12 dashed budget
+    assert "movement_illegal" not in res
+
+
+def test_dash_then_move_still_provokes(fight):
+    """Dash does NOT suppress opportunity attacks (only Disengage does)."""
+    cid, hero, gob = fight
+    if server.get_state(cid)["current_turn"] != hero:
+        server.next_turn(cid)
+    cur = server.get_state(cid)["current_turn"]
+    other = gob if cur == hero else hero
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, cur, 0, 0)
+    server.place_combatant_at_coords(cid, other, 1, 0)  # adjacent threatener
+    server.use_action(cid, cur, "dash")
+    res = server.move_to_coords(cid, cur, 5, 0)  # leaves the threatener's reach
+    assert res["opportunity_attack"] is True
+    assert [p["id"] for p in res["provokers"]] == [other]
+
+
+def test_disengage_then_move_no_provokers(fight):
+    cid, hero, gob = fight
+    if server.get_state(cid)["current_turn"] != hero:
+        server.next_turn(cid)
+    cur = server.get_state(cid)["current_turn"]
+    other = gob if cur == hero else hero
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, cur, 0, 0)
+    server.place_combatant_at_coords(cid, other, 1, 0)
+    server.use_action(cid, cur, "disengage")
+    res = server.move_to_coords(cid, cur, 5, 0)
+    assert res["opportunity_attack"] is False
+    assert res["provokers"] == []
+
+
+# ── (5) Grid OA reach-leave ──────────────────────────────────────────────────
+
+
+def test_reach_leave_provokes():
+    assert combat_grid.provokes_on_leave((0, 0), (5, 0), (1, 0)) is True
+
+
+def test_staying_in_reach_does_not_provoke():
+    # side-step from (0,0) to (0,1), threat at (1,0): still adjacent at the new cell.
+    assert combat_grid.provokes_on_leave((0, 0), (0, 1), (1, 0)) is False
+
+
+def test_never_in_reach_does_not_provoke():
+    assert combat_grid.provokes_on_leave((0, 0), (3, 0), (9, 9)) is False
+
+
+# ── (6) Grid OA SRD gates (the zone loop lacks these) ────────────────────────
+
+
+def test_threatener_with_reaction_used_is_not_a_provoker(fight):
+    cid, hero, gob = fight
+    if server.get_state(cid)["current_turn"] != hero:
+        server.next_turn(cid)
+    cur, other = hero, gob
+    if server.get_state(cid)["current_turn"] != hero:
+        cur, other = gob, hero
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, cur, 0, 0)
+    server.place_combatant_at_coords(cid, other, 1, 0)
+    # Spend the threatener's reaction (one Reaction/round).
+    c = store.load_campaign(cid)
+    server._combatant(c, other).reaction_used = True
+    store.save_campaign(c)
+    res = server.move_to_coords(cid, cur, 5, 0)
+    assert res["opportunity_attack"] is False
+    assert res["provokers"] == []
+
+
+@pytest.mark.parametrize("cond", [Condition.BLINDED, Condition.UNCONSCIOUS])
+def test_blind_or_unconscious_threatener_is_not_a_provoker(fight, cond):
+    cid, hero, gob = fight
+    if server.get_state(cid)["current_turn"] != hero:
+        server.next_turn(cid)
+    cur, other = hero, gob
+    if server.get_state(cid)["current_turn"] != hero:
+        cur, other = gob, hero
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, cur, 0, 0)
+    server.place_combatant_at_coords(cid, other, 1, 0)
+    c = store.load_campaign(cid)
+    other_ch = c.characters[other]
+    other_ch.conditions.append(cond)
+    store.save_campaign(c)
+    res = server.move_to_coords(cid, cur, 5, 0)
+    assert res["opportunity_attack"] is False
+
+
+# ── (7) next_turn reset scope ────────────────────────────────────────────────
+
+
+def test_next_turn_resets_only_starting_combatants_movement(fight):
+    cid, hero, gob = fight
+    server.set_grid(cid, 20, 20)
+    # Satisfy next_turn's PC-skip guard for the outgoing combatant.
+    server.use_action(cid, server.get_state(cid)["current_turn"], "skip")
+    # Give BOTH combatants nonzero movement + dashed.
+    c = store.load_campaign(cid)
+    for cb in c.combat.order:
+        cb.moved_cells_this_turn = 3
+        cb.dashed = True
+    store.save_campaign(c)
+    nxt = server.next_turn(cid)
+    new_cur = nxt["current"]
+    c = store.load_campaign(cid)
+    for cb in c.combat.order:
+        if cb.character_id == new_cur:
+            assert cb.moved_cells_this_turn == 0 and cb.dashed is False
+        else:
+            assert cb.moved_cells_this_turn == 3 and cb.dashed is True
+
+
+def test_next_turn_does_not_double_reset_disengaged(fight):
+    # Sanity: disengaged is reset exactly once in the cur-only block (no new reset added).
+    cid, hero, gob = fight
+    server.set_grid(cid, 20, 20)
+    cur = server.get_state(cid)["current_turn"]
+    if cur == hero:  # a PC must act/skip before next_turn (PC-skip guard)
+        server.use_action(cid, cur, "skip")
+    nxt = server.next_turn(cid)
+    new_cur = nxt["current"]
+    c = store.load_campaign(cid)
+    cb = server._combatant(c, new_cur)
+    assert cb.disengaged is False
+
+
+# ── (8) read-only discipline (set_grid path stays sole-writer; the deferred ──
+#         read-only helpers are PR-1.5 — assert measured-range math is pure here)
+
+
+def test_measure_math_is_pure_no_state_dir():
+    # Pure helpers never touch state — exercised directly (the read-only TOOLS that
+    # wrap these are deferred to PR-1.5 for schema-budget reasons; the math is here).
+    assert combat_grid.distance_ft((0, 0), (3, 4)) == 20  # max(3,4)=4 cells * 5
+    assert combat_grid.in_melee_reach((0, 0), (1, 1)) is True
+    assert combat_grid.in_melee_reach((0, 0), (2, 0)) is False
+
+
+# ── (9) schema budget stays green is enforced by test_tool_schema_budget.py ──


### PR DESCRIPTION
## What
PR-1 (spine) of the #461 measured-grid tactical layer — **fully additive + opt-in** (`Combat.grid_enabled=False` ⇒ zone/theater combat is byte-for-byte today). First-principles-designed (adversarially reviewed, 0.9 confidence, no blockers).

- **models.py**: `Combat` += `grid_enabled/grid_width/grid_height/grid_cell_size/diagonal_mode`; `Combatant` += `x/y/moved_cells_this_turn/dashed` + advisory `model_validator` (WARNs, never raises, on a half-set x/y). All defaulted to today; no new top-level Campaign key (snapshots round-trip).
- **combat_grid.py** (new, pure/I-O-free): Chebyshev distance, speed→cells budget (×2 Dash), open-floor reachability, reach-leave OA predicate, range/reach helpers.
- **server.py**: 3 new tools `set_grid` / `place_combatant_at_coords` / `move_to_coords` (advisory-not-blocking: over-budget/Speed-0/out-of-bounds → notes); `move_to_coords` reuses `move_to_zone`'s side-classification + disengage/grapple suppression **and adds the two SRD OA gates the zone loop omits** (one Reaction/round; can't-see = Blinded/Unconscious). `use_action` accepts `kind='dash'`; `next_turn` resets `moved_cells_this_turn/dashed` in the cur-only block; `attack()` gains a measured-melee advisory (no ranged gating). `_combat_view` adds a grid block + per-entry x/y (zero key delta off-grid). `move_to_zone`/`combatants_in_zone` literally unchanged.
- **docs/roadmap/grid-461-design.md**: additive model + the PR-1→PR-8 ladder + additivity/fallback guarantee + downstream surface-contract notes.
- **tests/test_grid.py** (22): round-trip (zone+theater byte-identical, grid off), Chebyshev math, speed→budget, Dash (incl. Dash-still-provokes / Disengage-suppresses), reach-leave OA + the two SRD gates, next_turn reset scope, pure-math discipline.

## SRD 5.2 correctness
Chebyshev default (5-10-5 is a reserved `diagonal_mode` flag, off). No flanking (SRD-optional). Reach-leave OA honors *see* + *reaction-once/round*. Size/reach (PR-4), AoE/LoE (PR-2), terrain/cover (PR-3), ranged-range (PR-5) are deferred — every token is 1-cell/5ft-reach here.

## ⚠ Schema budget (reviewer note)
Clean `test_tool_schema_budget` headroom was **912 B**. To fit: deferred the 2 read-only renderer tools (`measure_range`, `grid_reachable`) to **PR-1.5**; kept new docstrings terse; applied the **sanctioned docstring diet** to 4 tools (`use_action/attack/record_decision/author_companion_gauges`) — params/behavior/first-sentence all preserved (budget test's reach-for assertion green); trimmed guidance also lives in the DM SKILL.md. Final headroom **235 B**. **The grid PR ladder will keep hitting the 120 KB cap → the slab/on-demand tool-loading work (`feat/slab-phase1-tiering`) should land before PR-1.5/PR-2 so we stop dieting behavioral tools.**

## Tests
Full engine suite **3064 passed** (no regressions); `test_grid.py` 22 passed (6× re-run, deterministic); viewer combat-surface/render-profile/move-intents 23 passed/1 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional grid-based combat positioning system that coexists with the existing zone-based combat mode
  * Place characters on coordinate grids with configurable battlefield dimensions and cell sizes
  * Movement budgeting system with Dash action support; track movement consumption per turn
  * Grid-aware distance and range calculations for attacks
  * Opportunity attack detection based on character positioning and movement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->