### PR TITLE
feat: #835 Live Composition Increment 2 — enable-able follow-ups (still dark)

### DIFF
--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -725,6 +725,15 @@ worldos_stream_flag_arg() {
 # killer. Best-effort: a launch failure (missing python3 / missing script) never fails the beat —
 # the live stream simply doesn't appear and the canonical paths resolve normally.
 #   $1 = the DM $out stream-json path   $2 = $STATE_DIR
+#
+# #835 Increment 2 FIX B: the DM turn (dm_turn) runs inside a $(...) command-substitution SUBSHELL,
+# so WORLDOS_STREAM_TAILER_PID set here CANNOT escape to the parent shell where the EXIT/INT/TERM
+# cleanup trap runs (same subshell-isolation that forced .dm_last_result to be a FILE). On a clean
+# beat end worldos_stream_tailer_stop (called in the same subshell) kills it fine; but a SIGINT/
+# SIGTERM mid-beat skips that stop and would orphan the tailer with no PID visible to the parent.
+# So we ALSO persist the PID to $STATE_DIR/stream/tailer.pid, which the wrapper's signal trap reads
+# (worldos_stream_tailer_kill_pidfile) — a file survives the subshell boundary. The tailer's own
+# self-bounding caps (WORLDOS_STREAM_TAILER_MAX_S / idle) are the final backstop if even that is missed.
 worldos_stream_tailer_start() {
   WORLDOS_STREAM_TAILER_PID=""
   [ "$(worldos_env STREAM_BEATS 0)" = "1" ] || return 0
@@ -735,16 +744,40 @@ worldos_stream_tailer_start() {
   command -v python3 >/dev/null 2>&1 || return 0
   python3 "$script" "$out" "$state_dir/stream" >/dev/null 2>&1 &
   WORLDOS_STREAM_TAILER_PID="$!"
+  # Persist the PID across the subshell boundary for the signal-trap reaper (FIX B). Best-effort.
+  mkdir -p "$state_dir/stream" 2>/dev/null || true
+  printf '%s\n' "$WORLDOS_STREAM_TAILER_PID" > "$state_dir/stream/tailer.pid" 2>/dev/null || true
   return 0
 }
 
 # Kill the tailer launched by worldos_stream_tailer_start (no-op when none ran). Idempotent and
-# best-effort — a tailer that already exited is a benign no-op. Clears the PID after.
+# best-effort — a tailer that already exited is a benign no-op. Clears the PID (and the pidfile, so
+# a later signal-trap reaper doesn't kill a recycled PID) after.
 worldos_stream_tailer_stop() {
   local pid="${WORLDOS_STREAM_TAILER_PID:-}"
-  [ -n "$pid" ] || return 0
-  kill "$pid" >/dev/null 2>&1 || true
+  if [ -n "$pid" ]; then
+    kill "$pid" >/dev/null 2>&1 || true
+  fi
   WORLDOS_STREAM_TAILER_PID=""
+  # Clear the pidfile too (best-effort; $STATE_DIR is ambient in the harnesses but guard anyway).
+  [ -n "${STATE_DIR:-}" ] && rm -f "$STATE_DIR/stream/tailer.pid" 2>/dev/null || true
+  return 0
+}
+
+# Signal-trap reaper for the orphan-on-signal case (FIX B): kill whatever tailer PID was persisted
+# to $STATE_DIR/stream/tailer.pid by a (possibly subshell-isolated) worldos_stream_tailer_start,
+# then remove the pidfile. Called from the wrappers' EXIT/INT/TERM cleanup traps (which run in the
+# PARENT shell, where WORLDOS_STREAM_TAILER_PID is empty because dm_turn ran in a $(...) subshell).
+# No-op when streaming was OFF (no pidfile) or the tailer already exited. $1 = $STATE_DIR.
+worldos_stream_tailer_kill_pidfile() {
+  local state_dir="${1:-${STATE_DIR:-}}"
+  [ -n "$state_dir" ] || return 0
+  local pidfile="$state_dir/stream/tailer.pid" pid=""
+  [ -f "$pidfile" ] || return 0
+  pid="$(cat "$pidfile" 2>/dev/null)"
+  case "$pid" in ''|*[!0-9]*) pid="" ;; esac   # only a clean numeric PID is killable
+  [ -n "$pid" ] && kill "$pid" >/dev/null 2>&1 || true
+  rm -f "$pidfile" 2>/dev/null || true
   return 0
 }
 

--- a/qa/test_stream_tailer.py
+++ b/qa/test_stream_tailer.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from pathlib import Path
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
@@ -235,6 +236,82 @@ def test_persist_beat_recognized_but_not_streamed_increment1():
 
 
 # ---------------------------------------------------------------------------------------------
+# FIX D — text aliases: the engine's log_event accepts message/content/note as aliases for `text`
+# (normalized `text = text or message or content or note`), so a beat where the DM reaches for an
+# alias must stream just like the canonical `text`. A non-alias key (e.g. meta) is NOT prose.
+# ---------------------------------------------------------------------------------------------
+
+def test_alias_message_streams_like_text():
+    scene = "Rain hammers the slate roofs as you duck into the alley."
+    arg = json.dumps({"kind": "narration", "message": scene})
+    rows = [block_start(1, "log_event")] + [block_delta(1, c) for c in _chunks_of(arg, 7)] + [block_stop(1)]
+    assert _decode(rows) == scene
+
+
+def test_alias_content_streams_like_text():
+    scene = "The chandelier sways; dust sifts down through a shaft of grey light."
+    arg = json.dumps({"kind": "dialogue", "content": scene})
+    rows = [block_start(1, "log_event")] + [block_delta(1, c) for c in _chunks_of(arg, 9)] + [block_stop(1)]
+    assert _decode(rows) == scene
+
+
+def test_alias_note_streams_like_text():
+    scene = "A low bell tolls somewhere beyond the fog-bound wharf."
+    arg = json.dumps({"kind": "narration", "note": scene})
+    rows = [block_start(1, "log_event")] + [block_delta(1, c) for c in _chunks_of(arg, 5)] + [block_stop(1)]
+    assert _decode(rows) == scene
+
+
+def test_alias_value_before_kind_buffers_until_known():
+    """An alias appearing BEFORE kind must buffer-until-kind exactly like `text` does."""
+    scene = "Lanternlight gutters across the wet cobbles."
+    arg = json.dumps({"message": scene, "kind": "narration"})  # alias first, then kind
+    rows = [block_start(1, "log_event")] + [block_delta(1, c) for c in _chunks_of(arg, 4)] + [block_stop(1)]
+    assert _decode(rows) == scene
+
+
+def test_alias_with_nonprose_kind_never_streams():
+    """An alias carrying a non-prose kind (e.g. system) is never streamed — same gate as text."""
+    arg = json.dumps({"kind": "system", "note": "state grounded; closing turn."})
+    rows = [block_start(1, "log_event")] + [block_delta(1, c) for c in _chunks_of(arg, 6)] + [block_stop(1)]
+    assert _decode(rows) == ""
+
+
+def test_text_wins_over_alias_when_both_present():
+    """When both a literal `text` and an alias appear, `text` WINS (mirrors the engine's
+    `text or message or content or note` normalization). The SCANNER resolves its final captured
+    prose to the canonical `text` regardless of an earlier alias — asserted at the scanner level
+    because the streaming decoder can't retract chunks it already flushed for the lower-precedence
+    alias (a non-issue in practice: the DM uses exactly one prose key per call)."""
+    canonical = "The canonical scene the player should see."
+    arg = json.dumps({"kind": "narration", "note": "ignore me", "text": canonical})
+    sc = stream_tailer._PartialJsonScanner()
+    for c in _chunks_of(arg, 5):
+        sc.feed(c)
+    assert sc.text == canonical
+    assert sc.kind == "narration"
+    # And the alias-before-text precedence holds whole-fed too (no chunk artifacts).
+    sc2 = stream_tailer._PartialJsonScanner()
+    sc2.feed(arg)
+    assert sc2.text == canonical
+
+
+def test_non_alias_key_meta_is_not_captured():
+    """A non-alias top-level key (meta) must NEVER be captured as prose, even with a prose kind."""
+    arg = json.dumps({"kind": "narration", "meta": "internal bookkeeping value"})
+    rows = [block_start(1, "log_event")] + [block_delta(1, c) for c in _chunks_of(arg, 6)] + [block_stop(1)]
+    assert _decode(rows) == ""
+
+
+def test_nested_alias_does_not_masquerade_as_flat_prose():
+    """A nested message/content/note (depth>1, e.g. inside persist_beat's events) must not leak
+    as flat narration text — depth-1-only capture, same as the nested-`text` guard."""
+    arg = json.dumps({"events": [{"kind": "narration", "message": "nested scene"}]})
+    rows = [block_start(1, "persist_beat")] + [block_delta(1, c) for c in _chunks_of(arg, 5)] + [block_stop(1)]
+    assert _decode(rows) == ""
+
+
+# ---------------------------------------------------------------------------------------------
 # Row-shape tolerance: flat (non-nested) stream-json rows.
 # ---------------------------------------------------------------------------------------------
 
@@ -285,6 +362,71 @@ def test_tail_stream_driver_decodes_growing_file(tmp_path):
         if ln.strip()
     )
     assert decoded == scene
+
+
+def test_tail_stream_self_bounds_on_idle(tmp_path):
+    """FIX B self-bounding: with no new $out growth, the idle cap terminates the tailer even
+    when no stop() is provided — so a missed stop signal can't pin the sidecar open forever."""
+    out_path = tmp_path / "dm.jsonl"
+    out_path.write_text("", encoding="utf-8")  # exists, never grows
+    stream_path = tmp_path / "stream" / "current.jsonl"
+    t0 = time.time()
+    # Tiny idle cap + no lifetime cap: must return promptly via the idle path (no stop() at all).
+    written = stream_tailer.tail_stream(
+        str(out_path), str(stream_path),
+        poll_interval=0.001, max_idle_s=0.05, max_lifetime_s=None,
+    )
+    assert written == 0
+    assert time.time() - t0 < 5.0  # it self-terminated, did not hang
+
+
+def test_tail_stream_self_bounds_on_lifetime(tmp_path):
+    """FIX B self-bounding: the hard lifetime cap terminates the tailer even while $out keeps
+    GROWING (so a stuck-but-active stream can't pin it open past the ceiling)."""
+    out_path = tmp_path / "dm.jsonl"
+    # A line that does NOT decode to any prose (a non-target tool) but keeps the file growing so
+    # the idle cap never fires — only the lifetime cap can stop it.
+    out_path.write_text(json.dumps(block_start(0, "roll_dice")) + "\n", encoding="utf-8")
+    stream_path = tmp_path / "stream" / "current.jsonl"
+
+    appended = {"n": 0}
+
+    def stop():
+        # Side-effect: grow the file every pass so `progressed` stays True (idle cap can't fire).
+        appended["n"] += 1
+        with open(out_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(block_delta(0, "x")) + "\n")
+        return False  # never ask to stop via stop() — the lifetime cap must do it
+
+    t0 = time.time()
+    stream_tailer.tail_stream(
+        str(out_path), str(stream_path),
+        poll_interval=0.001, stop=stop, max_idle_s=None, max_lifetime_s=0.05,
+    )
+    assert time.time() - t0 < 5.0  # the lifetime cap stopped a still-growing stream
+
+
+def test_env_bound_parsing():
+    """FIX B: a positive override wins; 0/negative/garbage DISABLES (None); unset → default."""
+    import os as _os
+    name = "WORLDOS_STREAM_TAILER_MAX_S"
+    saved = _os.environ.get(name)
+    try:
+        _os.environ.pop(name, None)
+        assert stream_tailer._env_bound(name, 1800.0) == 1800.0   # unset → default
+        _os.environ[name] = "42"
+        assert stream_tailer._env_bound(name, 1800.0) == 42.0     # positive override
+        _os.environ[name] = "0"
+        assert stream_tailer._env_bound(name, 1800.0) is None     # 0 disables
+        _os.environ[name] = "-5"
+        assert stream_tailer._env_bound(name, 1800.0) is None     # negative disables
+        _os.environ[name] = "nonsense"
+        assert stream_tailer._env_bound(name, 1800.0) is None     # garbage disables
+    finally:
+        if saved is None:
+            _os.environ.pop(name, None)
+        else:
+            _os.environ[name] = saved
 
 
 def test_tail_stream_truncates_sink_on_start(tmp_path):

--- a/qa/test_stream_tailer_lifecycle.sh
+++ b/qa/test_stream_tailer_lifecycle.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# BEHAVIORAL TEST (no model call): proves the #835 Increment-2 FIX-B stream-tailer lifecycle
+# helpers in qa/lib_beat_driver.sh:
+#   (1) worldos_stream_tailer_start is a NO-OP when streaming is OFF (default WORLDOS_STREAM_BEATS=0)
+#       — no pidfile, no PID — so the feature stays dark by default;
+#   (2) when ON, start persists the bg PID to $STATE_DIR/stream/tailer.pid (the subshell-survivable
+#       handle the signal trap reads) and worldos_stream_tailer_stop removes it;
+#   (3) worldos_stream_tailer_kill_pidfile (the trap reaper) kills the persisted PID and removes the
+#       pidfile — even when WORLDOS_STREAM_TAILER_PID is empty in the calling shell (the orphan-on-
+#       signal case where the tailer was launched inside dm_turn's $(...) subshell);
+#   (4) the reaper is a benign no-op with no pidfile.
+#
+# It sources the REAL qa/lib_beat_driver.sh and uses a stub long-lived bg process as the "tailer"
+# via WORLDOS_STREAM_TAILER pointing at a sleeper script. Self-contained under mktemp; macOS-safe.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/qa/lib_beat_driver.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+STATE_DIR="$TMP/state"; mkdir -p "$STATE_DIR"
+OUT="$TMP/dm.jsonl"; : > "$OUT"
+
+# A stub "tailer": a long-lived PYTHON sleeper (the helper launches it as `python3 "$script"`, so the
+# stub must be valid python, not bash). Stands in for scripts/stream_tailer.py so the test never
+# depends on real DM output or python decode timing — only on the launch/persist/kill lifecycle.
+STUB="$TMP/fake_tailer.py"
+cat > "$STUB" <<'PY'
+import sys, time
+time.sleep(300)
+PY
+export WORLDOS_STREAM_TAILER="$STUB"
+
+fail=0
+chk() { if eval "$2"; then echo "PASS: $1"; else echo "FAIL: $1"; fail=1; fi; }
+alive() { kill -0 "$1" 2>/dev/null; }
+
+PIDFILE="$STATE_DIR/stream/tailer.pid"
+
+# (1) OFF by default: start is a no-op (no pidfile, empty PID).
+unset WORLDOS_STREAM_BEATS
+worldos_stream_tailer_start "$OUT" "$STATE_DIR"
+chk "OFF default: no PID set"        '[ -z "${WORLDOS_STREAM_TAILER_PID:-}" ]'
+chk "OFF default: no pidfile"        '[ ! -f "$PIDFILE" ]'
+
+# (2) ON: start launches the stub, sets the PID, and persists the pidfile.
+export WORLDOS_STREAM_BEATS=1
+worldos_stream_tailer_start "$OUT" "$STATE_DIR"
+sleep 0.2  # let python3 actually start so the liveness probe isn't racing the fork
+START_PID="${WORLDOS_STREAM_TAILER_PID:-}"
+chk "ON: PID is set"                 '[ -n "$START_PID" ]'
+chk "ON: process is alive"           'alive "$START_PID"'
+chk "ON: pidfile written"            '[ -f "$PIDFILE" ]'
+chk "ON: pidfile matches PID"        '[ "$(cat "$PIDFILE")" = "$START_PID" ]'
+
+# worldos_stream_tailer_stop kills the proc and removes the pidfile.
+worldos_stream_tailer_stop
+sleep 0.2
+chk "stop: process killed"           '! alive "$START_PID"'
+chk "stop: PID cleared"              '[ -z "${WORLDOS_STREAM_TAILER_PID:-}" ]'
+chk "stop: pidfile removed"          '[ ! -f "$PIDFILE" ]'
+
+# (3) Orphan-on-signal: start again, then simulate the subshell boundary by CLEARING the global
+# PID (as it would be in the parent shell) and reaping via the pidfile only.
+worldos_stream_tailer_start "$OUT" "$STATE_DIR"
+sleep 0.2
+ORPHAN_PID="${WORLDOS_STREAM_TAILER_PID:-}"
+chk "orphan: tailer alive pre-reap"  'alive "$ORPHAN_PID"'
+WORLDOS_STREAM_TAILER_PID=""          # the parent shell can't see the subshell's global
+worldos_stream_tailer_kill_pidfile "$STATE_DIR"
+sleep 0.2
+chk "orphan: reaper killed by pidfile" '! alive "$ORPHAN_PID"'
+chk "orphan: pidfile removed"          '[ ! -f "$PIDFILE" ]'
+
+# (4) Reaper is a benign no-op with no pidfile.
+worldos_stream_tailer_kill_pidfile "$STATE_DIR"
+chk "reaper no-op when no pidfile"   'true'
+
+if [ "$fail" -eq 0 ]; then echo "ALL PASS"; else echo "FAILURES"; fi
+exit "$fail"

--- a/scripts/play.sh
+++ b/scripts/play.sh
@@ -510,6 +510,13 @@ _play_cleanup() {
   declare -F worldos_release_launch_lock >/dev/null 2>&1 && worldos_release_launch_lock "$ROOT"
   kill "$SUP" 2>/dev/null
   [ -f "$VPID_FILE" ] && kill "$(cat "$VPID_FILE" 2>/dev/null)" 2>/dev/null
+  # #835 Increment 2 FIX B: a SIGINT/SIGTERM mid-beat (Ctrl-C, or a deadline killing the runner)
+  # bypasses the per-beat worldos_stream_tailer_stop, orphaning the live-composition tailer. The
+  # tailer was launched inside dm_turn's $(...) subshell, so WORLDOS_STREAM_TAILER_PID is empty in
+  # THIS parent shell — reap it from the pidfile the start helper persisted. No-op when streaming is
+  # OFF (no pidfile) or the tailer already exited (its own self-bounding caps cover a missed signal).
+  declare -F worldos_stream_tailer_kill_pidfile >/dev/null 2>&1 \
+    && worldos_stream_tailer_kill_pidfile "$STATE_DIR"
 }
 trap _play_cleanup EXIT
 trap '_play_cleanup; exit 130' INT TERM

--- a/scripts/play_party.sh
+++ b/scripts/play_party.sh
@@ -542,6 +542,13 @@ _party_cleanup() {
   declare -F worldos_release_launch_lock >/dev/null 2>&1 && worldos_release_launch_lock "$ROOT"
   kill "$SUP" 2>/dev/null
   [ -f "$VPID_FILE" ] && kill "$(cat "$VPID_FILE" 2>/dev/null)" 2>/dev/null
+  # #835 Increment 2 FIX B: a SIGINT/SIGTERM mid-beat (Ctrl-C, or a deadline killing the runner)
+  # bypasses the per-beat worldos_stream_tailer_stop, orphaning the live-composition tailer. The
+  # tailer was launched inside dm_turn's $(...) subshell, so WORLDOS_STREAM_TAILER_PID is empty in
+  # THIS parent shell — reap it from the pidfile the start helper persisted. No-op when streaming is
+  # OFF (no pidfile) or the tailer already exited (its own self-bounding caps cover a missed signal).
+  declare -F worldos_stream_tailer_kill_pidfile >/dev/null 2>&1 \
+    && worldos_stream_tailer_kill_pidfile "$STATE_DIR"
 }
 trap _party_cleanup EXIT
 trap '_party_cleanup; exit 130' INT TERM

--- a/scripts/stream_tailer.py
+++ b/scripts/stream_tailer.py
@@ -46,6 +46,13 @@ PROSE_TOOL_SUFFIXES = ("log_event", "persist_beat")
 # Only these `kind` values are player-safe prose. A log_event with any other kind (system, roll,
 # combat, ...) is NEVER streamed (its text is internal bookkeeping, not scene prose).
 PROSE_KINDS = frozenset({"narration", "dialogue"})
+# The engine's log_event accepts `text` (canonical) OR any of the aliases message/content/note as
+# the prose value, normalizing them as `text = text or message or content or note` (server.py)
+# — so a beat where the DM reaches for an alias still carries player-facing scene prose. The
+# scanner therefore treats all of these as text-equivalent. PRECEDENCE mirrors the engine: a
+# literal `text` value WINS over any alias when more than one appears in the same call (in
+# practice the DM uses exactly one). Ordered most-preferred-first.
+PROSE_TEXT_KEYS = ("text", "message", "content", "note")
 
 
 def _short_tool(name: object) -> str:
@@ -82,21 +89,22 @@ class _PartialJsonScanner:
         between two deltas decodes correctly;
       * emits only fully-decoded characters of the `text` value (never a half-formed escape).
 
-    It captures the decoded value of `kind` (small, completes fast) and the running decoded
-    prefix of `text`. The driver decides, using `kind`, whether to surface `text`.
-
     Robustness: the scanner only ever READS the buffer forward; it never needs the object to be
-    well-formed past the `text` value, and a malformed tail simply stops producing new decoded
+    well-formed past the prose value, and a malformed tail simply stops producing new decoded
     text (the beat still resolves via the canonical paths). Only top-level keys are tracked
     (depth-aware), so a nested object's `text` (e.g. inside persist_beat's events list) does not
-    masquerade as the flat narration text.
+    masquerade as the flat narration text — and likewise a nested `message`/`content`/`note`.
     """
 
     def __init__(self) -> None:
         # Decoded values captured so far.
         self.kind: Optional[str] = None       # decoded `kind` value once its string closes
-        self.text: str = ""                    # running decoded prefix of the `text` value
-        self._text_closed = False              # the `text` string has fully closed
+        self.text: str = ""                    # running decoded prefix of the prose value
+        # Which prose key (PROSE_TEXT_KEYS) currently OWNS self.text. None until the first prose
+        # value starts decoding. A later HIGHER-precedence key (e.g. a literal `text` after a
+        # `note`) takes over and resets self.text; a later lower/equal-precedence key is ignored.
+        self._text_key: Optional[str] = None
+        self._text_closed = False              # the OWNING prose string has fully closed
 
         # Lexer state.
         self._in_string = False
@@ -129,12 +137,46 @@ class _PartialJsonScanner:
             self._cur_key = (self._cur_key or "") + decoded
             return
         # A VALUE character.
-        if self._cur_val_key == "text" and not self._text_closed:
+        if self._cur_val_key in PROSE_TEXT_KEYS and self._prose_key_owns(self._cur_val_key):
             self.text += decoded
         # `kind` is captured on string close (it's short); no need to stream it char-by-char.
         elif self._cur_val_key == "kind":
             # Buffer kind chars in self.text? No — keep them separate.
             self._kind_acc = getattr(self, "_kind_acc", "") + decoded
+
+    def _prose_key_owns(self, key: str) -> bool:
+        """Does prose-key `key` own self.text right now (so its decoded chars append)? The owner
+        is the HIGHEST-precedence prose key seen so far (PROSE_TEXT_KEYS index 0 = highest). A
+        same-or-higher precedence key (incl. the current owner) appends; a strictly higher one
+        that just STARTED takes over (handled in _consume_structural on value-start, which resets
+        self.text); a lower-precedence key never displaces the owner. Once the owning string has
+        closed, no further appends (a stray later key can't extend a finished value)."""
+        if self._text_closed:
+            return False
+        owner = self._text_key
+        if owner is None:
+            return True
+        return PROSE_TEXT_KEYS.index(key) <= PROSE_TEXT_KEYS.index(owner)
+
+    def _on_prose_value_start(self, key: Optional[str]) -> None:
+        """A depth-1 value just STARTED for `key`. If it's a prose key (text or an alias) and
+        strictly higher-precedence than the current owner, it takes over: reset the accumulated
+        text and claim ownership — EVEN if the prior (lower-precedence) owner had already closed
+        (e.g. a literal `text` appearing after a complete `note` discards the note's value,
+        mirroring the engine's `text`-wins normalization). The common case — the FIRST prose key,
+        or the SAME owner re-entered — just claims/keeps ownership. Non-prose keys (kind, speaker,
+        …) are ignored here."""
+        if key not in PROSE_TEXT_KEYS:
+            return
+        owner = self._text_key
+        if owner is None:
+            self._text_key = key
+            return
+        if PROSE_TEXT_KEYS.index(key) < PROSE_TEXT_KEYS.index(owner):
+            # A higher-precedence prose key supersedes a previously-seen alias (closed or not).
+            self._text_key = key
+            self.text = ""
+            self._text_closed = False
 
     def _consume(self, ch: str) -> None:
         if self._in_string:
@@ -175,7 +217,8 @@ class _PartialJsonScanner:
                 if self._cur_val_key == "kind":
                     self.kind = getattr(self, "_kind_acc", "")
                     self._kind_acc = ""
-                elif self._cur_val_key == "text":
+                elif self._cur_val_key in PROSE_TEXT_KEYS and self._cur_val_key == self._text_key:
+                    # The OWNING prose value (text or the winning alias) closed → no more appends.
                     self._text_closed = True
                 self._cur_val_key = None
             self._is_key = False
@@ -194,6 +237,7 @@ class _PartialJsonScanner:
                 self._is_key = False
                 if self._expect_value and self._depth == 1:
                     self._cur_val_key = self._pending_key
+                    self._on_prose_value_start(self._cur_val_key)
                 self._expect_value = False
             return
         if ch == ":":
@@ -338,6 +382,13 @@ class StreamDecoder:
             return
         full = scanner.text
         already = st["emitted"]
+        if already > len(full):
+            # The scanner's prose ACCUMULATOR shrank — a higher-precedence prose key (text after
+            # an alias) reset it (engine `text`-wins normalization). We can't retract chunks
+            # already flushed downstream, but realign so the new owner's prose still streams from
+            # here (a non-issue in practice: the DM uses one prose key per call).
+            already = 0
+            st["emitted"] = 0
         if len(full) > already:
             delta = full[already:]
             st["emitted"] = len(full)
@@ -390,19 +441,35 @@ def _open_sink(stream_path: str):
     return open(stream_path, "w", encoding="utf-8")
 
 
+# SELF-BOUNDING DEFAULTS (#835 Increment 2, FIX B). The wrapper kills the tailer on a clean beat
+# end (worldos_stream_tailer_stop) AND on a signal-trap exit (the _cleanup/_party_cleanup traps),
+# but a stop signal can still be MISSED (a hard kill of the parent, a crashed wrapper, an orphan
+# left by a deadline-killed runner). So the tailer ALSO self-terminates: an absolute wall-clock
+# lifetime cap, and an idle cap (the target $out stopped growing for this long → the beat is over).
+# Either bound makes the sidecar incapable of running forever even if its stop signal never comes.
+DEFAULT_MAX_LIFETIME_S = 1800.0   # hard ceiling from tailer start (a DM beat is bounded well under this)
+DEFAULT_MAX_IDLE_S = 180.0        # no new $out growth for this long → the beat has ended; exit
+
+
 def tail_stream(
     out_path: str,
     stream_path: str,
     *,
     poll_interval: float = 0.25,
     stop: Optional[Callable[[], bool]] = None,
-    max_idle_s: Optional[float] = None,
+    max_idle_s: Optional[float] = DEFAULT_MAX_IDLE_S,
+    max_lifetime_s: Optional[float] = DEFAULT_MAX_LIFETIME_S,
 ) -> int:
     """Tail `out_path` (the DM stream-json file) and write decoded prose chunks to
     `stream_path` ($STATE_DIR/stream/current.jsonl), one JSON line per chunk. Returns the
     number of chunks written. Runs until `stop()` returns True (when provided) or the process
-    is killed by the wrapper at beat end. `max_idle_s` is a safety valve for tests/standalone
-    runs (stop after that long with no new file growth)."""
+    is killed by the wrapper at beat end — OR until a SELF-BOUNDING cap trips (FIX B), so a
+    missed stop signal can never leave the sidecar running forever:
+      * `max_idle_s` — stop after this long with no new $out growth (the beat is over). Default
+        DEFAULT_MAX_IDLE_S; pass None to disable.
+      * `max_lifetime_s` — a hard wall-clock ceiling from start. Default DEFAULT_MAX_LIFETIME_S;
+        pass None to disable.
+    Both are belt-and-suspenders to the wrapper's explicit kill, not a replacement for it."""
     state: dict = {"offset": 0, "tail": ""}
     seq = 0
     sink = _open_sink(stream_path)
@@ -415,10 +482,15 @@ def tail_stream(
         seq += 1
 
     decoder = StreamDecoder(emit)
-    last_progress = time.time()
+    started = time.time()
+    last_progress = started
     try:
         while True:
             if stop is not None and stop():
+                break
+            # Hard lifetime cap: trips regardless of activity (a stuck-but-growing $out can't pin
+            # the sidecar open past this). Checked first so it always wins.
+            if max_lifetime_s is not None and (time.time() - started) > max_lifetime_s:
                 break
             progressed = False
             for line in _iter_new_lines(out_path, state):
@@ -457,11 +529,34 @@ def main(argv: Optional[list] = None) -> int:
     else:
         stream_path = target
     poll = float(os.environ.get("WORLDOS_STREAM_POLL_S", "0.25"))
+    # FIX B self-bounding: env-overridable hard lifetime + idle caps so a tailer whose stop signal
+    # is missed (orphaned by a hard parent kill / deadline) still self-terminates. 0/negative or a
+    # non-numeric value DISABLES the respective cap (None). Defaults match tail_stream's.
+    max_lifetime = _env_bound("WORLDOS_STREAM_TAILER_MAX_S", DEFAULT_MAX_LIFETIME_S)
+    max_idle = _env_bound("WORLDOS_STREAM_TAILER_IDLE_S", DEFAULT_MAX_IDLE_S)
     try:
-        tail_stream(out_path, stream_path, poll_interval=poll)
+        tail_stream(
+            out_path, stream_path,
+            poll_interval=poll,
+            max_idle_s=max_idle,
+            max_lifetime_s=max_lifetime,
+        )
     except KeyboardInterrupt:
         pass
     return 0
+
+
+def _env_bound(name: str, default: float) -> Optional[float]:
+    """Resolve a seconds bound from env: a positive float overrides `default`; a 0/negative or
+    unparseable value DISABLES the bound (returns None); unset → `default`."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        val = float(raw)
+    except ValueError:
+        return None
+    return val if val > 0 else None
 
 
 if __name__ == "__main__":

--- a/viewer/openworlds/app.jsx
+++ b/viewer/openworlds/app.jsx
@@ -309,6 +309,11 @@ let __logSeq = 0;
 function nextLogSeq() { __logSeq += 1; return __logSeq; }
 
 function useLiveSession(state) {
+  // #835 Increment 2 FIX A: the server-visible mirror of WORLDOS_STREAM_BEATS (from
+  // /openworlds/campaigns.json). When the feature is OFF (the dark default) this is false and the
+  // /beat-stream poll below never arms — so the viewer fires ZERO /beat-stream requests. Only when
+  // the owner sets WORLDOS_STREAM_BEATS=1 server-side does the live-composition tail come alive.
+  const streamBeats = state?.streamBeats === true;
   const campaigns = Array.isArray(state?.campaigns) ? state.campaigns : [];
   const activeCampaign =
     campaigns.find((c) => openWorldsCampaignMatches(c, state?.activeCampaign)) ||
@@ -502,6 +507,15 @@ function useLiveSession(state) {
   // real narration beat regardless of this flag).
   const armPending = React.useCallback((text) => {
     clearTimers();
+    // #835 Increment 2 FIX C: reset the /beat-stream cursor (and the per-beat prose accumulator)
+    // when a NEW turn arms. The tailer truncates+rewrites current.jsonl PER BEAT, but the cursor
+    // previously reset only on RUN change — so a continuing beat inherited the prior beat's high
+    // line cursor and the new beat's first chunks (lines 0..cursor-1 of the freshly-truncated file)
+    // were skipped, dropping the opening of the live preview. Re-zeroing here means every armed turn
+    // reads its beat from line 0. (The server's truncation-reset guard catches the same on its side;
+    // this makes the client robust regardless of poll interleaving.)
+    beatStreamCursor.current = 0;
+    composingText.current = "";
     // #406: "first beat?" = no turn has RESOLVED on /chat yet (resolvedTurnsRef), NOT "no paragraph
     // has streamed" (dmBeatCountRef). So a retried cold-open — one paragraph streamed, then "Try
     // again" before the turn resolved — still gets the generous PENDING_RECOVERY_FIRST_MS window.
@@ -818,8 +832,12 @@ function useLiveSession(state) {
   //     drops it on turn resolution — zero duplication either way. notePendingProgress() flips the
   //     pending turn to `streaming` so the narrating affordance + latestStreamed preview light up.
   // Gated on `pendingRef`: it only does work mid-turn, so it never churns the chronicle at rest.
+  // #835 Increment 2 FIX A: ALSO gated on `streamBeats` (the server-visible WORLDOS_STREAM_BEATS
+  // mirror). When OFF (the default) the effect returns immediately — no interval, no fetch, no
+  // visibilitychange listener — so the viewer fires ZERO /beat-stream requests with the feature
+  // dark, instead of polling every ~500ms during every pending turn for a sidecar that never exists.
   React.useEffect(() => {
-    if (!campaignId) return undefined;
+    if (!campaignId || !streamBeats) return undefined;
     let cancelled = false;
     let timer = null;
     const pollOnce = async () => {
@@ -869,7 +887,7 @@ function useLiveSession(state) {
     document.addEventListener("visibilitychange", onVisibility);
     onVisibility();
     return () => { cancelled = true; stop(); document.removeEventListener("visibilitychange", onVisibility); };
-  }, [campaignId, source, runId, notePendingProgress]);
+  }, [campaignId, source, runId, notePendingProgress, streamBeats]);
 
   // #745: expose notePendingProgress so the live-progress signal is part of the hook's public surface
   // (consistent with armPending/clearPending; the /events poll calls the same ref). Purely additive —
@@ -976,6 +994,10 @@ function App() {
             ...s,
             campaigns: nextCampaigns,
             activeCampaign: requestedActiveId || (activeStillExists ? s.activeCampaign : preferred),
+            // #835 Increment 2 FIX A: mirror the server's WORLDOS_STREAM_BEATS lever so the
+            // /beat-stream poll in useLiveSession can stay fully inert when the feature is OFF
+            // (the default). Strict-equality to true so an absent/old field reads as OFF.
+            streamBeats: payload?.streamBeats === true,
             campaignCatalog: {
               loaded: true,
               total: payload?.total ?? nextCampaigns.length,

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -5974,7 +5974,20 @@ def _openworlds_campaigns(attached_campaign: str = "", *, move_sink_live: bool =
         "now": now,
         "state_authority": "engine",
         "write_lane": "/move",
+        # #835 Increment 2 FIX A: a server-visible mirror of WORLDOS_STREAM_BEATS so the OpenWorlds
+        # client can gate its /beat-stream poll. The viewer has no other knowledge of the wrapper's
+        # streaming lever; without this the client polled /beat-stream every ~500ms during ANY
+        # pending DM turn even when the feature is OFF server-side (the sidecar never exists →
+        # wasted requests). Defaults FALSE (env unset/0); the app polls /beat-stream ONLY when true.
+        "streamBeats": _stream_beats_enabled(),
     }
+
+
+def _stream_beats_enabled() -> bool:
+    """True IFF WORLDOS_STREAM_BEATS=1 (the #835 live-composition lever). Mirrors the wrapper's
+    worldos_env STREAM_BEATS gate so the viewer reports the SAME on/off the tailer launch keys off.
+    Anything other than the literal "1" (unset, "0", garbage) is OFF — the dark default."""
+    return (env_var("STREAM_BEATS", "0") or "0").strip() == "1"
 
 
 def _monitor_roots() -> list[tuple[str, Path]]:

--- a/viewer/tests/test_live_narration_stream.py
+++ b/viewer/tests/test_live_narration_stream.py
@@ -141,8 +141,29 @@ function makeReact() {
 const responses = { '/events': [], '/chat': [] };
 function enqueue(path, payload) { responses[path].push(payload); }
 function pathOf(url) { return String(url).split('?')[0]; }
+function sinceOf(url) {
+  const m = String(url).split('?')[1] || '';
+  const params = new URLSearchParams(m);
+  const v = parseInt(params.get('since') || '0', 10);
+  return Number.isFinite(v) ? v : 0;
+}
+let __beatStreamFetches = 0;   // #835 Inc-2 FIX A: count /beat-stream requests for the off-path assertion
+// #835 Inc-2: the /beat-stream sidecar is a single per-beat line buffer the client reads with a
+// `since` line cursor (the tailer TRUNCATES + rewrites it per beat). We model it `since`-aware so
+// FIX C (cursor reset on a new turn) is GENUINELY exercised: a stale cursor would slice past the
+// freshly-truncated buffer and drop the new beat's opening chunks. `seedBeatStream` resets it
+// (mirrors the per-beat truncation); the client's truncation-reset (since>len → 0) is honored too.
+let __beatStreamLines = [];
+function seedBeatStream(lines) { __beatStreamLines = (lines || []).slice(); }
 function fetchStub(url) {
   const p = pathOf(url);
+  if (p === '/beat-stream') {
+    __beatStreamFetches += 1;
+    let since = sinceOf(url);
+    if (since > __beatStreamLines.length) since = 0;   // truncation-reset guard (mirrors the server)
+    const chunks = __beatStreamLines.slice(since);
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ chunks, next: __beatStreamLines.length, complete: false }) });
+  }
   const q = responses[p];
   const payload = (q && q.length) ? q.shift() : {};   // empty when nothing scripted
   return Promise.resolve({ ok: true, json: () => Promise.resolve(payload) });
@@ -176,6 +197,8 @@ const sandbox = {
   // `new URLSearchParams()` threw, the poll's try/catch swallowed it, and no fetch ever fired.
   URLSearchParams, Promise, JSON, Set, Array, Object, String, Boolean, Number,
   console,
+  get __beatStreamFetches() { return __beatStreamFetches; },   // #835 Inc-2 FIX A: exposed to h.beatStreamFetchCount
+  seedBeatStream,                                              // #835 Inc-2: exposed to h.seedBeatStream
 };
 sandbox.window = sandbox;
 sandbox.Date = { now: () => NOW };
@@ -200,7 +223,10 @@ if (typeof useLiveSession !== 'function') throw new Error('useLiveSession not ex
 
 // Mount over a LIVE campaign so the polls run. The `state` ref is mutable so a test can switch
 // the bound run (campaignId change) to assert the dedup reset.
-const state = { activeCampaign: 'camp1', campaigns: [{ id: 'camp1', campaign_id: 'camp1' }] };
+// #835 Increment 2 FIX A: the /beat-stream poll is now gated on state.streamBeats (the server's
+// WORLDOS_STREAM_BEATS mirror). These tests exercise the streaming path, so the harness mounts with
+// the feature ON. (The OFF default — no poll fires — is asserted separately below.)
+const state = { activeCampaign: 'camp1', campaigns: [{ id: 'camp1', campaign_id: 'camp1' }], streamBeats: true };
 reactHost.mount(() => useLiveSession(state));
 
 // A microtask drain: the pollers are async (await fetch().json()); after firing them we must let
@@ -214,7 +240,14 @@ const h = {
   tick: async () => { await tickAll(); reactHost.commit(); },
   // switch the bound run: a fresh mount re-renders the (same-cell) hook so the campaignId-change
   // effect fires (resetting the cursor + dedup set), exactly like navigating into a new live run.
-  setCampaign: (id) => { state.activeCampaign = id; state.campaigns = [{ id, campaign_id: id }]; reactHost.mount(() => useLiveSession(state)); },
+  setCampaign: (id) => { state.activeCampaign = id; state.campaigns = [{ id, campaign_id: id }]; state.streamBeats = true; reactHost.mount(() => useLiveSession(state)); },
+  // #835 Increment 2 FIX A: flip the server's stream-beats lever (re-mount so the gated effect re-evaluates).
+  setStreamBeats: (on) => { state.streamBeats = !!on; reactHost.mount(() => useLiveSession(state)); },
+  // Count how many /beat-stream fetches have fired so far (the off-path inertness assertion).
+  beatStreamFetchCount: () => sandbox.__beatStreamFetches,
+  // #835 Inc-2: (re)seed the /beat-stream sidecar buffer (mirrors the tailer truncating + rewriting
+  // current.jsonl per beat). Each entry is one decoded chunk row {seq,text}.
+  seedBeatStream: (lines) => sandbox.seedBeatStream(lines),
   beats: () => (reactHost.api().chatBeats || []).map((b) => ({ kind: b.kind, text: b.text })),
   narrationTexts: () => (reactHost.api().chatBeats || []).filter((b) => b.kind === 'narration').map((b) => b.text),
   // #405: the FULLY-ASSEMBLED chronicle (recentEvents history band + live tail + echoes), ordered +
@@ -417,6 +450,70 @@ class LiveNarrationStreamTests(unittest.TestCase):
         self.assertTrue(out["first_streaming"], "the first turn streamed → it was marked streaming")
         self.assertFalse(out["second_streaming"],
                          "a newly-armed turn must reset `streaming` to falsy (no prose has streamed for it yet)")
+
+    # --- #835 Increment 2 FIX A: the /beat-stream live-composition tail (ON path) ----------------
+    # With streamBeats ON (the harness default), a pending turn polls /beat-stream and renders the
+    # decoded chunks as ONE transient composing row — the scene unfolds word-by-word.
+    def test_beat_stream_composing_row_renders_when_on(self):
+        out = self._run(
+            "h.arm('I push open the door');"
+            "h.seedBeatStream([{ seq: 0, text: 'The hinges ' }, { seq: 1, text: 'shriek.' }]);"
+            "await h.tick();"
+            "var beats = h.beats();"
+            "return ({ fetches: h.beatStreamFetchCount(), composing: beats.filter(function(b){return b.text && b.text.indexOf('hinges') !== -1;}).map(function(b){return b.text;}), pending: !!h.pending() });"
+        )
+        self.assertGreaterEqual(out["fetches"], 1, "the /beat-stream poll must fire while ON + pending")
+        self.assertEqual(out["composing"], ["The hinges shriek."],
+                         "the decoded chunks must accumulate into the live composing preview")
+        self.assertTrue(out["pending"], "the composing preview keeps the turn gated until /chat resolves it")
+
+    # --- #835 Increment 2 FIX A: OFF-path inertness — ZERO /beat-stream fetches when the feature is
+    # off. This is the keystone of FIX A: the viewer must not poll /beat-stream at all when the
+    # server has WORLDOS_STREAM_BEATS unset/0 (the sidecar never exists). Even with a pending turn
+    # (which is what previously triggered the ~500ms poll), no /beat-stream request may fire.
+    def test_beat_stream_inert_when_off(self):
+        out = self._run(
+            "h.setStreamBeats(false);"          # the dark default — server reports streamBeats:false
+            "h.arm('I push open the door');"    # a turn IS in flight (the old trigger condition)
+            "h.seedBeatStream([{ seq: 0, text: 'should never be read' }]);"
+            "await h.tick();"
+            "await h.tick();"
+            "return ({ fetches: h.beatStreamFetchCount(), texts: h.narrationTexts() });"
+        )
+        self.assertEqual(out["fetches"], 0,
+                         "with WORLDOS_STREAM_BEATS off, the viewer must fire ZERO /beat-stream requests")
+        self.assertEqual(out["texts"], [],
+                         "no composing row may appear when the feature is off (the poll never ran)")
+
+    # --- #835 Increment 2 FIX C: the beat-stream cursor resets PER TURN (not just per run) --------
+    # The tailer truncates+rewrites current.jsonl per beat, so each new turn's preview starts at
+    # line 0. armPending re-zeros beatStreamCursor, so a SECOND turn reads its first chunk (line 0)
+    # instead of inheriting the prior turn's high cursor (which would skip the new beat's opening).
+    def test_beat_stream_cursor_resets_on_new_turn(self):
+        out = self._run(
+            "h.arm('first move');"
+            # First beat: the sidecar holds two lines; the client reads them and advances its cursor to 2.
+            "h.seedBeatStream([{ seq: 0, text: 'First ' }, { seq: 1, text: 'beat.' }]);"
+            "await h.tick();"
+            "var firstTexts = h.beats().filter(function(b){return b.text && b.text.indexOf('First') !== -1;}).map(function(b){return b.text;});"
+            # Resolve the first turn, then arm a SECOND.
+            "h.enqueue('/chat', { items: [{ role: 'dm', text: 'First beat.' }], next: 1 });"
+            "await h.tick();"
+            "h.arm('second move');"
+            # The tailer TRUNCATES the sidecar for the new beat and rewrites it with THIS beat's
+            # chunks at line 0. Seed THREE lines so an INHERITED cursor (since=2 from the first beat)
+            # would read only the LAST line (chunks[2]) — silently dropping the opening 'Second beat '
+            # 'opens. ' — whereas the FIX-C reset (since=0) reads all three. This makes the test
+            # discriminating: it FAILS if armPending does not re-zero beatStreamCursor.
+            "h.seedBeatStream([{ seq: 0, text: 'Second beat ' }, { seq: 1, text: 'opens. ' }, { seq: 2, text: 'A door yawns.' }]);"
+            "await h.tick();"
+            "var secondTexts = h.beats().filter(function(b){return b.text && b.text.indexOf('Second') !== -1;}).map(function(b){return b.text;});"
+            "return ({ first: firstTexts, second: secondTexts });"
+        )
+        self.assertEqual(out["first"], ["First beat."], "the first beat streams its full prose")
+        self.assertEqual(out["second"], ["Second beat opens. A door yawns."],
+                         "FIX C: the second turn reads from line 0 (cursor reset on arm) — its opening "
+                         "chunks are NOT dropped by an inherited cross-beat cursor")
 
     # --- #393: the turn-END /chat line RESOLVES a turn whose prose already streamed --------------
     def test_chat_resolves_a_streamed_turn(self):

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -1317,6 +1317,10 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         catalog = json.loads(body.decode("utf-8"))
         self.assertEqual(catalog["state_authority"], "engine")
         self.assertEqual(catalog["write_lane"], "/move")
+        # #835 Increment 2 FIX A: the live-composition lever is DARK by default — the client gates
+        # its /beat-stream poll on this, so it must report False unless WORLDOS_STREAM_BEATS=1.
+        self.assertIn("streamBeats", catalog)
+        self.assertFalse(catalog["streamBeats"])
         self.assertEqual(catalog["total"], 1)
         campaign = catalog["campaigns"][0]
         self.assertEqual(campaign["id"], "play:state:camp_live")
@@ -1343,6 +1347,27 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertNotIn("hidden agenda", encoded)
         self.assertNotIn("private canon", encoded)
         self.assert_no_private_keys(json.loads(encoded))
+
+    def test_openworlds_campaigns_streambeats_reflects_env_flag(self):
+        """#835 Increment 2 FIX A: streamBeats mirrors WORLDOS_STREAM_BEATS — True only for '1'."""
+        import os
+        campaign_dir = self._tmp / "campaigns" / "camp_sb"
+        self._write_snapshot(campaign_dir, {"id": "camp_sb", "title": "T", "world_id": "w"})
+        _QuietHandler.campaign_id = "camp_sb"
+        server._HERE = self._tmp / "viewer"
+        saved = os.environ.get("WORLDOS_STREAM_BEATS")
+        try:
+            os.environ["WORLDOS_STREAM_BEATS"] = "1"
+            catalog = json.loads(self._get("/openworlds/campaigns.json")[2].decode("utf-8"))
+            self.assertTrue(catalog["streamBeats"])  # ON when the lever is set
+            os.environ["WORLDOS_STREAM_BEATS"] = "0"
+            catalog = json.loads(self._get("/openworlds/campaigns.json")[2].decode("utf-8"))
+            self.assertFalse(catalog["streamBeats"])  # OFF for '0'
+        finally:
+            if saved is None:
+                os.environ.pop("WORLDOS_STREAM_BEATS", None)
+            else:
+                os.environ["WORLDOS_STREAM_BEATS"] = saved
 
     def test_openworlds_campaigns_keeps_current_move_sink_run_live_after_recency_window(self):
         campaign_dir = self._tmp / "campaigns" / "camp_live"


### PR DESCRIPTION
The #1043 review's follow-ups, still **default OFF** (`WORLDOS_STREAM_BEATS=0`). **A:** frontend now truly inert when off — server exposes `streamBeats`, the React /beat-stream poll is gated on it (proven: 0 requests when off). **B:** tailer killed on SIGINT/SIGTERM via pidfile+trap reaper, plus a self-bounding max-lifetime/idle cap so it can't orphan. **C:** beat-stream cursor resets on `armPending` (no dropped first chunks per beat). **D:** tailer captures `message`/`content`/`note` aliases (text-wins), matching the engine's log_event normalization. 29 tailer + 759 viewer + 13 lifecycle tests pass; OFF-default verified inert.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Narration streaming now accepts `message`, `content`, and `note` fields as alternatives to `text`.
  * Live beat-stream feature is now environment-controlled for flexible enablement.

* **Bug Fixes**
  * Fixed orphaned stream-tailer processes when runs are interrupted.
  * Fixed live composition cursor not resetting between consecutive beats.

* **Tests**
  * Added comprehensive lifecycle and feature-flag test coverage for stream-tailer and beat-stream functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->