### PR TITLE
fix(engine): CompanionQuestStage accepts per-stage description (un-RED-cap authored arcs)

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -378,6 +378,12 @@ class CompanionQuestStage(_StrictModel):
     location_id: str = ""
     quest_id: str = ""
     note: str = ""
+    # The DM authors a per-stage narrative description when it builds the arc via
+    # set_companion_quest_arc(arc={"stages":[{"title":..,"description":..}]}). The model is
+    # extra="forbid", so without this field that whole tool call was REJECTED (extra_forbidden
+    # ⇒ no_rejected_tool_calls FATAL ⇒ RED-cap — the cap-rate failure class). Additive + default
+    # empty: old snapshots round-trip; stages that omit it are unchanged.
+    description: str = ""
 
 
 class CompanionQuestArc(_StrictModel):

--- a/servers/engine/tests/test_companion_arc.py
+++ b/servers/engine/tests/test_companion_arc.py
@@ -470,6 +470,29 @@ def test_set_and_get_companion_quest_arc_by_companion_and_status(camp):
     assert server.get_companion_quest_arcs(cid, status="resolved")["count"] == 0
 
 
+def test_set_companion_quest_arc_accepts_per_stage_description(camp):
+    # Regression (the extra_forbidden RED-cap found on a live embergloom-pact golden-spine):
+    # the DM authors a per-stage `description` via set_companion_quest_arc(arc={"stages":[
+    # {"title":..,"description":..}]}). CompanionQuestStage is extra="forbid", so before this fix
+    # the whole tool call was REJECTED (3 validation errors → no_rejected_tool_calls FATAL →
+    # lenses RED-capped). The field is now accepted + persisted (additive).
+    cid, comp = camp
+    out = server.set_companion_quest_arc(cid, comp, {
+        "title": "Toll's Shame",
+        "status": "available",
+        "stages": [
+            {"title": "Confess the habit", "description": "Toll speaks aloud what shame made a habit."},
+            {"title": "Break the ward", "description": "Toll uses whatever wards remain to him."},
+        ],
+    })
+    stages = out["companion_quest_arc"]["stages"]
+    assert stages[0]["description"] == "Toll speaks aloud what shame made a habit."
+    assert stages[1]["description"] == "Toll uses whatever wards remain to him."
+    # persists + round-trips through get
+    got = server.get_companion_quest_arcs(cid, companion_id=comp)["companion_quest_arcs"][0]
+    assert got["stages"][0]["description"] == "Toll speaks aloud what shame made a habit."
+
+
 def test_personal_quest_gate_makes_linked_companion_quest_arc_available_once(camp):
     cid, comp = camp
     server.set_companion_quest_arc(cid, comp, {


### PR DESCRIPTION
Found on a live embergloom-pact golden-spine run: the DM calls `set_companion_quest_arc(arc={"stages":[{"title":..,"description":..}]})`, but `CompanionQuestStage` is `extra="forbid"` and had no `description` field → **3 `extra_forbidden` validation errors → `no_rejected_tool_calls` FATAL → lenses RED-capped** (the cap-rate failure class). A per-stage narrative `description` is reasonable DM metadata the engine should accept. **Additive** (`description:str=""`, old snapshots round-trip) + a regression test mirroring the real rejected args. 90 focused tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Companion quest stages now support custom descriptions, enabling personalized narrative content for individual quest milestones while maintaining compatibility with existing campaign data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->