### PR TITLE
feat(qa): differential fact-fidelity — the content-loss measure the 1–5 lens is blind to

### DIFF
--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -295,3 +295,44 @@ one-line `TIMING |` readout next to `COVERAGE`, e.g.
 a beat** — routine beats are ~90–100% **generation/decode-bound** (Opus more so, extended thinking), so
 when a combat turn feels slow it's the *model thinking*, not the tools. Everything degrades to `None`
 without a sidecar, leaving the rest of the rollup byte-identical.
+
+## 8. Differential fact-fidelity — the content-loss measure the 1–5 lens is BLIND to
+`qa/fact_fidelity.py` · inventories under `qa/fact_inventories/`
+
+**The gap this closes (the 2026-06-21 lens-blindness finding).** The three 1–5 LLM lenses grade
+*prose / plot-gist*, not *arc-completeness*. Proven on the combat transcript `ow-combat-031717.md`,
+uncapped scorer: deleting the **entire** climax+resolution (antagonist reveal, the "43 names"
+MacGuffin, all end-session XP/reputation mechanics) moved story `4.0 → 4.0` (identical) and mech
+`3.6 → 4.1` — *higher*, **non-monotonic** (fewer beats ⇒ fewer SRD errors to find). Cutting to the
+first 25% only dropped story to `3.7` (inside the 0.40 noise floor). **The lens scores a whole story,
+a gutted one, and a mangled digest ~alike.** This is partly by design — the lens grades quality *above*
+the deterministic floor (§1); structural brokenness is the floor's job — but nothing read the
+*transcript itself* for content fidelity, so a compressed / truncated / narration-incomplete candidate
+was uncertifiable.
+
+**The instrument.** A **fact inventory** is a committed list of discrete, grep-able facts extracted
+from a reference transcript — each `{id, desc, patterns[], severity}` (`patterns` are case-insensitive
+regexes, ANY-of; `severity` ∈ `critical|high|normal`). `score_fidelity(facts, candidate_text)` reports
+the fraction preserved (flat + severity-weighted), the dropped-fact ids, and `critical_loss` (any
+dropped `critical` fact — an antagonist reveal, the central MacGuffin, an end-session mechanic). The
+CHECK is **fully deterministic — no LLM** (so it never inherits the lens blindness it measures), which
+is exactly why it is the **sensitive** measure for regression detection (compression A/B,
+candidate-vs-baseline), NOT a prose-quality grader.
+
+**Authoring gotcha (load-bearing).** A transcript's tool-call **tally** lists tool *names*
+(`end_session`, `award_xp`, `adjust_reputation`…), so a fact keyed on a tool name survives truncation
+via the tally. End-session-mechanic facts therefore match the **call RESULT** (`"xp": 350`,
+`"reputation": 6`, `"ended": "session-…"`), never the tool name.
+
+**Sensitivity (reproduced, same `ow-combat-031717.md`, 27-fact inventory):** baseline **100%** →
+climax-deleted **59%** (`critical_loss=True`) → first-25% **33%** (`critical_loss=True`) — monotonic,
+tracking the owner's grep-verified 45-fact differential (100% / 53% / 27%). The measure separates
+gutted from whole where the lens could not.
+
+**Usage.** `python qa/fact_fidelity.py <inventory.json> <candidate.md> [--min-fidelity F] [--json]`
+→ exit 0 if the candidate clears the floor with **no critical loss**, else 1. Raw playtest transcripts
+live under the gitignored `/qa/transcripts/`, so the committed regression test
+(`qa/test_fact_fidelity.py`) runs on a small synthetic fixture
+(`qa/fact_inventories/sample_session.*`); an opt-in test reproduces the finding on the real
+`ow-combat-031717.md` when it is present locally. The committed `ow-combat-031717.facts.json` inventory
+re-derives the differential whenever that transcript is regenerated.

--- a/qa/fact_fidelity.py
+++ b/qa/fact_fidelity.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Differential fact-fidelity — the SENSITIVE, deterministic content-loss measure.
+
+The three 1–5 LLM lenses (``qa/score.sh``) grade prose/plot-gist and are demonstrably
+BLIND to content degradation: deleting a transcript's entire climax+resolution moved the
+lens ``overall`` by ~0.0 (within the 0.40 noise floor), and the mechanical lens even scored
+a gutted transcript HIGHER than the intact one (fewer beats ⇒ fewer SRD errors to find).
+A grep-verified 45-fact differential on the SAME variants read 100% / 53% / 27% — i.e. the
+real, massive content loss the lens could not see.
+
+This module is that grep-verified differential, as a reusable instrument:
+
+  - A **fact inventory** is a committed list of discrete, grep-able facts extracted from a
+    REFERENCE transcript (each: an id, a human description, one-or-more match patterns, a
+    severity). Authored once per reference; the CHECK is fully deterministic (no LLM).
+  - ``score_fidelity(facts, candidate_text)`` reports what fraction of the reference's facts
+    survive in a candidate transcript. A truncated / compressed / degraded candidate drops
+    monotonically; a dropped CRITICAL fact (an antagonist reveal, the central MacGuffin, an
+    end-session mechanic) is flagged regardless of the headline percentage.
+
+Used for regression detection (compression A/B, candidate-vs-baseline), NOT as a prose-quality
+grader — it answers "did this candidate preserve the reference's facts?", which the lens cannot.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Fact:
+    """One discrete, grep-able fact from a reference transcript.
+
+    ``patterns`` are case-insensitive regexes; the fact is PRESENT in a candidate when ANY
+    pattern matches (so a fact can be spelled several equivalent ways).
+    """
+
+    id: str
+    desc: str
+    patterns: list[str] = field(default_factory=list)
+    severity: str = "normal"  # "critical" | "high" | "normal"
+
+
+# A dropped CRITICAL fact (an antagonist reveal, the central MacGuffin, an end-session
+# mechanic) must dominate the headline number, so severity weights the fidelity.
+SEVERITY_WEIGHT: dict[str, float] = {"critical": 3.0, "high": 2.0, "normal": 1.0}
+
+
+@dataclass
+class FidelityReport:
+    fidelity: float          # unweighted fraction of facts preserved (0.0–1.0)
+    weighted: float          # severity-weighted fraction preserved (0.0–1.0)
+    present: list[str]       # ids of preserved facts
+    missing: list[str]       # ids of dropped facts
+    critical_loss: bool      # True iff any severity="critical" fact was dropped
+
+
+def load_inventory(path: str | Path) -> list[Fact]:
+    """Parse a committed fact-inventory JSON file into ``Fact`` objects.
+
+    Schema: ``{"reference": <name>, "facts": [{"id","desc","patterns":[...],"severity"?}, …]}``.
+    ``severity`` defaults to "normal" when omitted.
+    """
+    data = json.loads(Path(path).read_text(encoding="utf-8"))
+    return [
+        Fact(
+            id=f["id"],
+            desc=f.get("desc", ""),
+            patterns=list(f.get("patterns", [])),
+            severity=f.get("severity", "normal"),
+        )
+        for f in data.get("facts", [])
+    ]
+
+
+def _fact_present(fact: Fact, text: str) -> bool:
+    return any(re.search(p, text, re.IGNORECASE) for p in fact.patterns)
+
+
+def _weight(fact: Fact) -> float:
+    return SEVERITY_WEIGHT.get(fact.severity, 1.0)
+
+
+def score_fidelity(facts: list[Fact], candidate_text: str) -> FidelityReport:
+    present: list[str] = []
+    missing: list[str] = []
+    present_weight = 0.0
+    total_weight = 0.0
+    critical_loss = False
+    for f in facts:
+        total_weight += _weight(f)
+        if _fact_present(f, candidate_text):
+            present.append(f.id)
+            present_weight += _weight(f)
+        else:
+            missing.append(f.id)
+            if f.severity == "critical":
+                critical_loss = True
+    fidelity = len(present) / len(facts) if facts else 1.0
+    weighted = present_weight / total_weight if total_weight else 1.0
+    return FidelityReport(
+        fidelity=fidelity,
+        weighted=weighted,
+        present=present,
+        missing=missing,
+        critical_loss=critical_loss,
+    )
+
+
+def passed(report: FidelityReport, min_fidelity: float = 0.95, fail_on_critical: bool = True) -> bool:
+    """Gate verdict: a candidate PASSES when its fidelity clears ``min_fidelity`` and (unless
+    disabled) no CRITICAL fact was dropped. A dropped critical fact fails regardless of the
+    headline percentage — that is the whole point (the 1–5 lens missed exactly that)."""
+    if fail_on_critical and report.critical_loss:
+        return False
+    return report.fidelity >= min_fidelity
+
+
+def report_dict(report: FidelityReport, facts: list[Fact] | None = None) -> dict:
+    """JSON-serializable view of a report. When ``facts`` is supplied, missing facts carry their
+    severity + description so a CLI/regression log names WHAT was lost, not just an id."""
+    by_id = {f.id: f for f in (facts or [])}
+    return {
+        "fidelity": round(report.fidelity, 4),
+        "weighted": round(report.weighted, 4),
+        "critical_loss": report.critical_loss,
+        "present": list(report.present),
+        "missing": [
+            {
+                "id": mid,
+                "severity": by_id[mid].severity if mid in by_id else None,
+                "desc": by_id[mid].desc if mid in by_id else None,
+            }
+            for mid in report.missing
+        ],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: score a candidate transcript against a committed fact inventory.
+
+    Usage: fact_fidelity.py <inventory.json> <candidate.md> [--min-fidelity F] [--json]
+    Exit 0 if the candidate clears the floor with no critical loss, else 1.
+    """
+    ap = argparse.ArgumentParser(description="Differential fact-fidelity check for QA transcripts.")
+    ap.add_argument("inventory", help="path to the fact-inventory JSON")
+    ap.add_argument("candidate", help="path to the candidate transcript (.md)")
+    ap.add_argument("--min-fidelity", type=float, default=0.95,
+                    help="minimum fraction of facts that must survive (default 0.95)")
+    ap.add_argument("--no-fail-on-critical", action="store_true",
+                    help="do not fail solely because a critical fact was dropped")
+    ap.add_argument("--json", action="store_true", help="emit the report as JSON")
+    args = ap.parse_args(argv)
+
+    facts = load_inventory(args.inventory)
+    text = Path(args.candidate).read_text(encoding="utf-8")
+    report = score_fidelity(facts, text)
+    ok = passed(report, min_fidelity=args.min_fidelity,
+                fail_on_critical=not args.no_fail_on_critical)
+
+    if args.json:
+        out = report_dict(report, facts)
+        out["passed"] = ok
+        out["min_fidelity"] = args.min_fidelity
+        print(json.dumps(out, indent=2, ensure_ascii=False))
+    else:
+        verdict = "PASS" if ok else "FAIL"
+        print(f"[fact-fidelity] {verdict}  fidelity={report.fidelity*100:.1f}%  "
+              f"weighted={report.weighted*100:.1f}%  critical_loss={report.critical_loss}")
+        if report.missing:
+            by_id = {f.id: f for f in facts}
+            print(f"  dropped {len(report.missing)} fact(s):")
+            for mid in report.missing:
+                sev = by_id[mid].severity if mid in by_id else "?"
+                desc = by_id[mid].desc if mid in by_id else ""
+                print(f"    - [{sev}] {mid}: {desc}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/qa/fact_inventories/ow-combat-031717.facts.json
+++ b/qa/fact_inventories/ow-combat-031717.facts.json
@@ -1,0 +1,35 @@
+{
+  "reference": "ow-combat-031717.md",
+  "note": "Fact inventory for the canonical evidence transcript (the 2026-06-21 lens-blindness finding). The raw transcript is gitignored (/qa/transcripts/); this inventory is committed so the differential reproduces when the transcript is regenerated locally. Three tiers: OPENING (survives any truncation), MID (lost when only the first quarter is kept), CLIMAX+RESOLUTION (lost when the back half is cut). Climax-mechanic facts match CALL RESULTS, never the tool names in the tally. Severity: critical = antagonist reveal / central MacGuffin / end-session mechanic.",
+  "facts": [
+    {"id": "dal_identity", "desc": "PC is Dal Lightspark, a Dwarf Wizard, level 5", "patterns": ["Dal Lightspark", "Dwarf"], "severity": "high"},
+    {"id": "dal_harper_agent", "desc": "Dal's background: Harper Agent", "patterns": ["Harper Agent"], "severity": "normal"},
+    {"id": "companion_minsc", "desc": "Companion: Minsc and Boo", "patterns": ["Minsc and Boo"], "severity": "high"},
+    {"id": "npc_withers", "desc": "NPC Withers, the ledger-keeper", "patterns": ["Withers"], "severity": "normal"},
+    {"id": "courier_perrin", "desc": "The dead courier Perrin", "patterns": ["Perrin"], "severity": "high"},
+    {"id": "copper_pin", "desc": "The old-design copper Harper pin (moon harp)", "patterns": ["copper", "moon harp"], "severity": "normal"},
+    {"id": "setting_candle_lane", "desc": "Setting: Candle Lane, Lower City", "patterns": ["Candle Lane"], "severity": "normal"},
+    {"id": "setting_elfsong", "desc": "The Elfsong tavern / back-room drop", "patterns": ["Elfsong"], "severity": "normal"},
+    {"id": "netherbrain_scar", "desc": "The Netherbrain scar in the city", "patterns": ["Netherbrain"], "severity": "normal"},
+
+    {"id": "name_jaheira", "desc": "MID: the name Jaheira in plaintext in the cipher", "patterns": ["Jaheira"], "severity": "high"},
+    {"id": "steel_watch_pin", "desc": "MID: a Steel Watch insignia pin in the bundle", "patterns": ["Steel Watch insignia"], "severity": "high"},
+    {"id": "voss_guild", "desc": "MID: Voss, Nine-Fingers' Guild fixer", "patterns": ["Nine-Fingers", "\\bVoss\\b"], "severity": "normal"},
+    {"id": "trooper_eitha", "desc": "MID: Eitha, the honest Flaming Fist trooper", "patterns": ["Eitha"], "severity": "normal"},
+    {"id": "intimidation_nat1", "desc": "MID: the natural-1 intimidation roll at the bridge", "patterns": ["\"natural\": 1,"], "severity": "high"},
+    {"id": "dock_landing", "desc": "MID: the East Bank Miller's Landing dock", "patterns": ["East Bank Miller's Landing"], "severity": "normal"},
+    {"id": "frame_seal", "desc": "MID reveal: the packet is sealed with Dal's own mark — Dal is the frame", "patterns": ["your stamp", "seal is yours", "your authorization mark"], "severity": "high"},
+
+    {"id": "antagonist_liora", "desc": "CLIMAX: the architect Liora is revealed", "patterns": ["Liora"], "severity": "critical"},
+    {"id": "macguffin_43_names", "desc": "CLIMAX: the MacGuffin — the 43 names", "patterns": ["[Ff]orty-three", "43 Names"], "severity": "critical"},
+    {"id": "grove_survivors", "desc": "CLIMAX: the 43 are Emerald Grove survivors", "patterns": ["Grove survivors"], "severity": "high"},
+    {"id": "rolph_auvin", "desc": "CLIMAX: Rolph Auvin, the Steel Watch records clerk", "patterns": ["Rolph Auvin"], "severity": "high"},
+    {"id": "resolution_candlekeep", "desc": "RESOLUTION: the path to Jaheira runs through Candlekeep", "patterns": ["Candlekeep"], "severity": "high"},
+    {"id": "xp_award_dal", "desc": "END-SESSION: Dal awarded 350 XP", "patterns": ["\"xp\": 350"], "severity": "critical"},
+    {"id": "xp_award_minsc", "desc": "END-SESSION: Minsc awarded 250 XP", "patterns": ["\"xp\": 250"], "severity": "high"},
+    {"id": "guild_reputation_6", "desc": "END-SESSION: +6 Guild reputation", "patterns": ["\"reputation\": 6"], "severity": "high"},
+    {"id": "quest_43_names", "desc": "END-SESSION: quest 'The 43 Names' opened", "patterns": ["\"title\": \"The 43 Names\""], "severity": "normal"},
+    {"id": "consequence_clock", "desc": "END-SESSION: Liora's one-week deadline scheduled", "patterns": ["Liora's deadline", "\"trigger_day\": 10"], "severity": "normal"},
+    {"id": "session_closed", "desc": "END-SESSION: the session is formally closed", "patterns": ["\"ended\": \"session-39310c7c\"", "Session 1 — closed"], "severity": "critical"}
+  ]
+}

--- a/qa/fact_inventories/sample_session.facts.json
+++ b/qa/fact_inventories/sample_session.facts.json
@@ -1,0 +1,26 @@
+{
+  "reference": "sample_session.reference.md",
+  "note": "Fact inventory for the committed synthetic fixture (qa/test_fact_fidelity.py). Three tiers: OPENING (survives any truncation), MID (lost when only the opening is kept), CLIMAX+RESOLUTION (lost when the back half is cut). Climax-mechanic facts match CALL RESULTS, never the tool names in the tally. Severity: critical = antagonist reveal / central MacGuffin / end-session mechanic.",
+  "facts": [
+    {"id": "hero_identity", "desc": "Hero is Sera Vey, a Half-Elf Ranger, level 4", "patterns": ["Sera Vey", "Half-Elf Ranger"], "severity": "high"},
+    {"id": "companion_tomas", "desc": "Companion: Brother Tomas, a cleric", "patterns": ["Brother Tomas"], "severity": "high"},
+    {"id": "archivist_hessa", "desc": "Old Hessa, the harbor archivist", "patterns": ["Old Hessa"], "severity": "normal"},
+    {"id": "courier_coren", "desc": "The dead courier Coren", "patterns": ["\\bCoren\\b"], "severity": "high"},
+    {"id": "setting_greyharbor", "desc": "Setting: Greyharbor docks", "patterns": ["Greyharbor"], "severity": "normal"},
+    {"id": "wardens_token", "desc": "An old copper Wardens token", "patterns": ["Wardens token", "copper token"], "severity": "normal"},
+
+    {"id": "cipher_ashryn", "desc": "MID: the name Lady Ashryn left in plaintext in the cipher", "patterns": ["Lady Ashryn"], "severity": "high"},
+    {"id": "silverwatch_seal", "desc": "MID: a Silverwatch officer's seal recovered", "patterns": ["Silverwatch"], "severity": "high"},
+    {"id": "fixer_dob_combine", "desc": "MID: the fixer Dob, who runs errands for the Combine", "patterns": ["\\bDob\\b", "the Combine"], "severity": "normal"},
+    {"id": "the_frame", "desc": "MID reveal: the packet's seal is the hero's own — she is the frame", "patterns": ["HER seal", "She is the frame"], "severity": "high"},
+
+    {"id": "antagonist_veyl", "desc": "CLIMAX: the architect Veyl Marrow is revealed", "patterns": ["Veyl Marrow"], "severity": "critical"},
+    {"id": "macguffin_thirty_one", "desc": "CLIMAX: the MacGuffin — the Ledger of Thirty-One names", "patterns": ["Thirty-One"], "severity": "critical"},
+    {"id": "resolution_spindle", "desc": "RESOLUTION: the list goes to the Spindle", "patterns": ["the Spindle"], "severity": "high"},
+    {"id": "xp_award_sera", "desc": "END-SESSION: Sera awarded 400 XP", "patterns": ["\"xp\": 400"], "severity": "critical"},
+    {"id": "xp_award_tomas", "desc": "END-SESSION: Tomas awarded 300 XP", "patterns": ["\"xp\": 300"], "severity": "high"},
+    {"id": "reputation_plus7", "desc": "END-SESSION: +7 Wardens reputation", "patterns": ["\"reputation\": 7"], "severity": "high"},
+    {"id": "quest_thirty_one", "desc": "END-SESSION: quest 'The Thirty-One Names' opened", "patterns": ["\"title\": \"The Thirty-One Names\""], "severity": "normal"},
+    {"id": "session_closed", "desc": "END-SESSION: the session is formally closed", "patterns": ["\"ended\": \"session-greyharbor-1\"", "Session 1 — closed"], "severity": "critical"}
+  ]
+}

--- a/qa/fact_inventories/sample_session.reference.md
+++ b/qa/fact_inventories/sample_session.reference.md
@@ -1,0 +1,57 @@
+# Playtest transcript: sample_session (committed fact-fidelity fixture)
+
+# Fictional, self-contained reference for qa/test_fact_fidelity.py — NOT a real playtest and
+# NOT derived from any world content. Raw transcripts live under the gitignored /qa/transcripts/;
+# this small synthetic log is committed so the regression test is CI-safe. Three tiers by design:
+# OPENING facts (survive any truncation), MID facts (lost when only the opening is kept), and
+# CLIMAX+RESOLUTION facts (lost the moment the back half is cut) — incl. end-session mechanics,
+# matched on their CALL RESULTS, never the tool names in the tally below.
+
+## Tool-call tally
+  speak: 9
+  skill_check: 5
+  award_xp: 2
+  adjust_reputation: 1
+  add_quest: 1
+  record_decision: 1
+  end_session: 1
+
+## Play log
+
+OPENING — Greyharbor docks, a cold grey morning. The hero arrives chasing a stolen courier packet.
+
+The hero is Sera Vey, a Half-Elf Ranger, level 4, sworn to the Wardens of the Reach.
+Beside her walks Brother Tomas, a quiet cleric who has seen too many winters.
+At the customs shed waits Old Hessa, the harbor archivist, who keeps a ledger of every ship.
+
+Hessa speaks first: "The courier you want is Coren. Was Coren. They pulled him from the tide two nights past."
+She slides a copper token across the counter — an old Wardens token, the kind they stopped minting years ago.
+  - `skill_check(insight, dc 13)` -> roll 18, success
+Sera reads the token's wear and knows it is genuine. Coren carried it. Coren is dead.
+
+MID — the cipher and the seal.
+
+Tomas unfolds the recovered cipher sheet. One name sits in the clear where the code should be: Lady Ashryn.
+Wrapped beside it, a Silverwatch officer's seal — the kind only a records clerk would hold.
+A dockside fixer named Dob, who runs errands for the Combine, steps from the fog with terms.
+  - `skill_check(investigation, dc 14)` -> roll 16, success
+Sera examines the wax. The seal on the packet is HER seal — the Wardens mark she carries in her coat.
+Someone built this trail and put her name at the end of it. She is not the investigator. She is the frame.
+
+CLIMAX — the warehouse, and the one who built the road.
+
+The warehouse door opens and Veyl Marrow steps through. The architect. Tomas whispers: "This is the hand."
+Veyl lays it bare: the packet hid the Ledger of Thirty-One names — every Reach survivor and the Wardens who sheltered them.
+"If that ledger reaches the Spindle, every patron who profited starts burning evidence." She does the arithmetic without flinching.
+  - `record_decision(...)` -> {"chosen": "Take the ledger to the Spindle quietly; let Veyl name the rest in one week."}
+
+RESOLUTION — the close.
+
+Sera takes the Ledger of Thirty-One. Veyl walks free with seven days to name the patrons.
+  - `award_xp(Sera, 400)` -> {"xp": 400, "current_level": 4, "reason": "Traced the packet, broke the frame, secured the Thirty-One"}
+  - `award_xp(Tomas, 300)` -> {"xp": 300, "current_level": 4, "reason": "Held the line; read the trap"}
+  - `adjust_reputation(fac-wardens, +7)` -> {"reputation": 7, "reason": "Recovered the ledger without a body"}
+  - `add_quest("The Thirty-One Names")` -> {"title": "The Thirty-One Names", "status": "active"}
+  - `end_session(...)` -> {"ended": "session-greyharbor-1", "number": 1}
+
+**Session 1 — closed.** Sera Vey came for a stolen packet. The packet was never the point. The road to the Spindle is open.

--- a/qa/test_fact_fidelity.py
+++ b/qa/test_fact_fidelity.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Tests for qa/fact_fidelity.py — the differential fact-fidelity QA instrument.
+
+The 1–5 LLM lens scorer is BLIND to content degradation (it reads plot-gist, not
+arc-completeness): deleting the climax+resolution from a transcript moved the lens
+score by ~0.0. This deterministic, grep-based instrument is the SENSITIVE measure —
+it asserts a candidate transcript preserves a reference's discrete facts, and a
+truncated/compressed candidate's fidelity drops monotonically.
+
+Run (single-process):
+    uv run --directory servers/engine python -m pytest qa/test_fact_fidelity.py -q -p no:xdist
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+QA_DIR = Path(__file__).resolve().parent
+if str(QA_DIR) not in sys.path:
+    sys.path.insert(0, str(QA_DIR))
+
+import fact_fidelity as ff  # noqa: E402
+
+
+def test_fidelity_is_fraction_of_facts_preserved():
+    facts = [
+        ff.Fact(id="present_one", desc="appears", patterns=[r"Dwarf"]),
+        ff.Fact(id="absent_one", desc="does not appear", patterns=[r"Tiefling"]),
+    ]
+    report = ff.score_fidelity(facts, "Dal Lightspark is a Dwarf wizard, level 5.")
+    assert report.fidelity == 0.5
+    assert report.present == ["present_one"]
+    assert report.missing == ["absent_one"]
+
+
+def test_dropped_critical_fact_flags_critical_loss_and_weights_harder():
+    facts = [
+        ff.Fact(id="climax", desc="antagonist reveal", patterns=[r"Liora"], severity="critical"),
+        ff.Fact(id="detail", desc="a minor detail", patterns=[r"candle"], severity="normal"),
+    ]
+    # the candidate keeps the minor detail but drops the CRITICAL climax fact
+    report = ff.score_fidelity(facts, "The candle gutters low in the dark room.")
+    assert report.critical_loss is True
+    assert "climax" in report.missing
+    # a heavy fact carries more weight than a normal one, so the weighted score punishes the
+    # critical miss harder than the flat fraction (0.5) does
+    assert report.weighted < report.fidelity
+
+
+def test_load_inventory_parses_committed_json(tmp_path):
+    p = tmp_path / "inv.json"
+    p.write_text(json.dumps({
+        "reference": "demo",
+        "facts": [
+            {"id": "a", "desc": "first", "patterns": ["foo", "f00"], "severity": "critical"},
+            {"id": "b", "desc": "second", "patterns": ["bar"]},
+        ],
+    }))
+    facts = ff.load_inventory(p)
+    assert [f.id for f in facts] == ["a", "b"]
+    assert facts[0].patterns == ["foo", "f00"]
+    assert facts[0].severity == "critical"
+    assert facts[1].severity == "normal"  # default when omitted
+
+
+# Committed, CI-safe fixture (raw transcripts under /qa/transcripts/ are gitignored).
+SAMPLE_REFERENCE = QA_DIR / "fact_inventories" / "sample_session.reference.md"
+SAMPLE_INVENTORY = QA_DIR / "fact_inventories" / "sample_session.facts.json"
+
+
+def _cut_before(text: str, marker: str) -> str:
+    """Drop everything from ``marker`` onward — the deterministic analogue of the manual
+    truncation that fooled the 1–5 lens (cut at 'CLIMAX —' deletes the climax+resolution;
+    cut at 'MID —' keeps only the opening)."""
+    idx = text.index(marker)
+    return text[:idx]
+
+
+def test_cutting_climax_resolution_drops_fidelity_and_flags_critical_loss():
+    facts = ff.load_inventory(SAMPLE_INVENTORY)
+    full = SAMPLE_REFERENCE.read_text(encoding="utf-8")
+    through_mid = _cut_before(full, "CLIMAX — ")   # antagonist reveal, MacGuffin, end-session mechanics deleted
+    opening_only = _cut_before(full, "MID — ")      # only the opening kept
+
+    r_full = ff.score_fidelity(facts, full)
+    r_mid = ff.score_fidelity(facts, through_mid)
+    r_open = ff.score_fidelity(facts, opening_only)
+
+    # the intact reference preserves ~all of its own facts (a faithful inventory)
+    assert r_full.fidelity >= 0.97, r_full.missing
+    assert not r_full.critical_loss
+    # deleting the climax+resolution is a LARGE, visible drop — the exact loss the lens rated ~0.0
+    assert r_mid.fidelity <= r_full.fidelity - 0.30
+    # monotonic: keeping even less (only the opening) drops it further
+    assert r_open.fidelity < r_mid.fidelity
+    # the dropped facts include CRITICAL ones (the antagonist reveal, the MacGuffin, end_session)
+    assert r_mid.critical_loss and r_open.critical_loss
+
+
+@pytest.mark.skipif(
+    not (QA_DIR / "transcripts" / "ow-combat-031717.md").exists(),
+    reason="raw transcript is gitignored / local-only; reproduces the owner's exact evidence when present",
+)
+def test_real_combat_transcript_reproduces_finding():
+    """Reproduce the owner's 2026-06-21 finding on the actual evidence transcript when it is
+    present locally: line-fraction truncation (0.58 / 0.25, as in the original experiment) tanks
+    fidelity monotonically and trips critical_loss — the loss the 1–5 lens scored ~flat (4.0/4.0/3.7)."""
+    inv = QA_DIR / "fact_inventories" / "ow-combat-031717.facts.json"
+    facts = ff.load_inventory(inv)
+    full = (QA_DIR / "transcripts" / "ow-combat-031717.md").read_text(encoding="utf-8")
+    lines = full.splitlines(keepends=True)
+
+    def frac(f: float) -> str:
+        return "".join(lines[: max(1, int(len(lines) * f))])
+
+    r_full = ff.score_fidelity(facts, full)
+    r_58 = ff.score_fidelity(facts, frac(0.58))   # climax+resolution deleted
+    r_25 = ff.score_fidelity(facts, frac(0.25))   # only the first quarter kept
+
+    assert r_full.fidelity >= 0.95, r_full.missing
+    assert r_58.fidelity <= r_full.fidelity - 0.30
+    assert r_25.fidelity < r_58.fidelity
+    assert r_58.critical_loss and r_25.critical_loss
+
+
+def test_passed_gates_on_min_fidelity_and_critical_loss():
+    facts = [
+        ff.Fact(id="c", desc="crit", patterns=[r"alpha"], severity="critical"),
+        ff.Fact(id="n", desc="norm", patterns=[r"beta"], severity="normal"),
+    ]
+    # both present, above floor -> pass
+    assert ff.passed(ff.score_fidelity(facts, "alpha beta"), min_fidelity=0.9) is True
+    # a dropped CRITICAL fact fails even though fidelity (0.5) might clear a lax floor
+    assert ff.passed(ff.score_fidelity(facts, "beta only"), min_fidelity=0.4) is False
+    # below the fidelity floor fails even with no critical loss
+    only_norm = [ff.Fact(id=f"n{i}", desc="", patterns=[r"zzz"]) for i in range(10)]
+    assert ff.passed(ff.score_fidelity(only_norm, "nothing here"), min_fidelity=0.9) is False
+
+
+def test_report_dict_enriches_missing_with_severity_and_desc():
+    facts = [
+        ff.Fact(id="kept", desc="present one", patterns=[r"alpha"], severity="normal"),
+        ff.Fact(id="lost", desc="the antagonist reveal", patterns=[r"omega"], severity="critical"),
+    ]
+    d = ff.report_dict(ff.score_fidelity(facts, "alpha only"), facts)
+    assert d["critical_loss"] is True
+    assert d["present"] == ["kept"]
+    assert d["missing"] == [{"id": "lost", "severity": "critical", "desc": "the antagonist reveal"}]
+
+
+def test_cli_main_exit_codes(tmp_path, capsys):
+    full = SAMPLE_REFERENCE.read_text(encoding="utf-8")
+    # intact candidate passes
+    intact = tmp_path / "intact.md"
+    intact.write_text(full)
+    assert ff.main([str(SAMPLE_INVENTORY), str(intact), "--min-fidelity", "0.9"]) == 0
+    # climax-deleted candidate fails (critical loss)
+    gutted = tmp_path / "gutted.md"
+    gutted.write_text(full[: full.index("CLIMAX — ")])
+    assert ff.main([str(SAMPLE_INVENTORY), str(gutted), "--min-fidelity", "0.9"]) == 1


### PR DESCRIPTION
## Why

The 1–5 LLM lens scorer (`qa/score.sh`) grades **prose / plot-gist**, not **arc-completeness**, so it cannot tell a complete session from a gutted one. Reproduced on the combat transcript `ow-combat-031717.md` (uncapped scorer):

| variant | story (Tolkien) | mech | 
|---|---|---|
| baseline (full) | 4.0 | 3.6 |
| **climax+resolution deleted** (antagonist reveal, the "43 names" MacGuffin, all end-session XP/reputation) | **4.0** (identical) | **4.1** (↑ — non-monotonic) |
| only first 25% kept | 3.7 (within the 0.40 noise floor) | 3.9 |

The deterministic behavioral floor (`assert_behavioral.py`) reads engine-mutated **state**, not the transcript — so it can't certify transcript-content fidelity either (compression / truncation / incomplete narration with intact state). Nothing did.

## What

A deterministic, grep-based **differential fact-fidelity** instrument — the same measure the owner's 45-fact grep check proved sensitive. **No LLM**, so it never inherits the blindness it measures. Fully additive (new files + one doc append).

- **`qa/fact_fidelity.py`** — `Fact` / `score_fidelity` (flat + severity-weighted fidelity, `critical_loss`) / `load_inventory` / `passed` (gate verdict) / `report_dict` / CLI `main`.
- **`qa/fact_inventories/sample_session.{reference.md,facts.json}`** — committed CI-safe synthetic fixture (raw transcripts under `/qa/transcripts/` are gitignored).
- **`qa/fact_inventories/ow-combat-031717.facts.json`** — committed 27-fact inventory for the real evidence transcript.
- **`qa/test_fact_fidelity.py`** — 8 tests (TDD), incl. an opt-in reproduction on the real transcript (skipped when absent).
- **`qa/SCORING.md` §8**.

## Reproduced ($0, deterministic)

baseline **100%** → climax-deleted **59%** (`critical_loss=True`) → first-25% **33%** (`critical_loss=True`) — monotonic, tracking the owner's grep-verified 100% / 53% / 27%. Dropped facts are exactly the right ones (Liora, the 43 names, grove survivors, every end-session mechanic).

CLI: `python qa/fact_fidelity.py <inventory.json> <candidate.md> [--min-fidelity F] [--json]` → exit 0 if the candidate clears the floor with no critical loss, else 1.

## Authoring gotcha (encoded)

A transcript's tool-call **tally** lists tool *names* (`end_session`, `award_xp`…), so a fact keyed on a tool name survives truncation via the tally. End-session-mechanic facts match the **call RESULT** (`"xp": 350`, `"reputation": 6`, `"ended": "session-…"`), never the tool name. The synthetic fixture includes a tally to exercise this.

## Verification

- `qa/test_fact_fidelity.py` 8 passed; adjacent qa tests (`detect_regression`, `lens_variance`) still green.
- `scripts/license_check.py` ✓. Purely additive — diff touches no existing code file (only the SCORING.md doc append).

## Invariants

Honors #3 (engine teeth on ground-truth, never prose — the check is over committed grep patterns, deterministic) and #2 (additive; old behavior unchanged; independently removable). Deliberately NOT an LLM rubric "completeness" dimension — the finding proves the lens can't judge completeness, so a new LLM dimension would inherit the same blindness.

Follow-up (separate PR): validate whether a real state-visible coverage hole exists in `assert_behavioral.py` (short/solo runs under the `flat_arc` ≥24-beat threshold) and add a surgical WARN→FATAL clause only if confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added deterministic transcript validation metric using fact inventories to detect content loss and flag critical information gaps.

* **Documentation**
  * Added differential fact-fidelity QA methodology documentation with inventory structure, severity tiers, and CLI usage examples.

* **Tests**
  * Added comprehensive test suite for transcript fidelity scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->