### PR TITLE
docs(contracts): add renderer_profiles.godot block + lock dimetric 2:1 ISO projection (#1051)

### DIFF
--- a/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
+++ b/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
@@ -46,7 +46,7 @@ lane. No renderer, no AI loop, no UGC tool ever becomes a second source of truth
 |----|-----------|--------|---------------|-------|
 | **GT0** | **Narrative dashboard** (the current OpenWorlds web UI) | **SHIPS TODAY** | React/JSX in WKWebView | The living-world DM + companion RPG; text/portrait-first. The proof that engine-as-authority + thin-client works. |
 | **GT1** | **SNES-style pixel turn-based** (JRPG / RPG-Maker-like feel) | Planned (MVP tier 1) | Phaser 3 (MIT), in the existing shell | Tilemap + sprite actors + 16-bit UI; zone-mode turn combat. |
-| **GT2** | **Pillars / BG1-2 isometric party cRPG** | Planned (MVP tier 2) | Phaser 3 (MVP look) → Godot 4 (premium native, optional) | Painted backdrop + token actors. **Branch A = the LOOK; Branch B = measured tactics (evidence-gated).** |
+| **GT2** | **Pillars / BG1-2 isometric party cRPG** | In progress (M5, pulled fwd) | **Godot 4 (web + native)** — Phaser GT2 **retired** 2026-06-21 | Painted backdrop + token actors. **Owner direction 2026-06-21:** Godot is the GT2 renderer for both web and native; the Phaser M2 backdrop renderer is retired (didn't deliver the experience). **Branch A = the LOOK; Branch B = measured tactics (evidence-gated).** See epic #1050. |
 | GT3+ | (future families — e.g. tactical-grid SRPG, top-down action) | Not scoped | TBD | Added only when a capability set + audience justify it. |
 
 **Rejected engines (recorded so they're not re-litigated):**
@@ -108,10 +108,14 @@ autonomy, ship/sell UGC)* layered on as the long-term plan proves out.
 2. **Phaser 3 (MIT) + PixiJS v8 (MIT) for the MVP, BOTH tiers**, in the existing React/WKWebView
    shell. One renderer, two render profiles (tilemap / backdrop). Godot 4 reserved for an
    optional *premium native desktop/Steam* GT2 client later (separate binary; MIT). Unity rejected.
+   **AMENDMENT 2026-06-21 (owner):** for **GT2 specifically** this is superseded — **Godot 4 is now
+   the GT2 renderer for both web and native**, and the **Phaser GT2 backdrop path is retired** (it
+   didn't deliver the experience). M5 is pulled forward (epic #1050). GT0 (React dashboard) and GT1
+   (Phaser pixel) are unchanged. The thin-client invariant + layered render-profile contract are unchanged.
 3. **Contract is LAYERED: core + per-renderer profiles.** Core (renderer-agnostic, all fields
    defaultable for the AI generator): `schema_version`, `scene_kind`, `positioning`, named
    `zones` (NOT x,y), engine FK ids, scope-key art, AI-disclosure. Optional blocks: `phaser{}`,
-   `rpgmaker{}` (reserved). Core-only conformance test gates it.
+   `godot{}` (GT2 painterly-iso; added 2026-06-21), `rpgmaker{}` (reserved). Core-only conformance test gates it.
 4. **Positions are presentation derived from engine zones** — already the shipped pattern
    (`viewer/server.py:_combat_row_positions`). Token x,y is an ephemeral render-hint, never state.
 5. **M0 freezes THREE contracts together:** render-profile · graphical move-intent vocabulary
@@ -144,12 +148,13 @@ autonomy, ship/sell UGC)* layered on as the long-term plan proves out.
 
 ### M2 — GT2: Pillars/BG1-2 backdrop-isometric MVP (Branch A = the LOOK)  *(C2=backdrop, C3=zone-band, C4=walkmask, C7=flat)*
 - **R2.1 Backdrop render profile + occlusion** (walkmask renderer-owned; destinations resolve to engine zones/locations) · **R2.2 T2 combat + polish** (pure replay; normal-map lighting deferred) · **R2.3 T2 QA gates**
+- **⚠ RETIRED 2026-06-21 (the Phaser implementation):** the GT2 *renderer* moved to Godot (M5, pulled forward — epic #1050); the Phaser backdrop renderer (`viewer/openworlds/render/backdrop.html`) is reference-only. The render-profile contract work (R2.1) stays valid — Godot consumes the same `core` + a `godot{}` block.
 
 ### M3 — Gated AI build-loop + UGC  *(C9=gated autonomy, C10=author→ship, C5 disclosure)*
 - **R3.1 Gated AI build-loop** (generate render-profile core from lore; resolve art; emit Phaser glue; gate each iter; human-gate queue for taste/story/contract) · **R3.2 UGC platform + licensing/compliance** (per-user ownership; AI-disclosure end-to-end [EU 2026-08-02, Steam survey]; MIT redistribution story) · **R3.3 Transport upgrade** (C8: websocket/SSE; swap behind SurfaceClient interface)
 
-### M5 — *(optional, post-M2)* GT2 premium: Godot desktop/Steam client (Branch B look: C7 normal-map lighting)
-- Godot thin client over the surfaces (HTTPRequest/WebSocketPeer; Light2D; NavigationRegion2D); consumes the `core` contract; GDScript headless-codegen harness (compile-error feedback + `.tscn` gen + `godot-mcp`).
+### M5 — GT2 Godot painterly-isometric renderer (web + native) — **PULLED FORWARD, IN PROGRESS** (epic #1050)
+- The GT2 renderer (Branch A = the LOOK now; Branch B = C7 normal-map lighting later). Godot 4 thin client over the surfaces (HTTPRequest/WebSocketPeer; Light2D; NavigationRegion2D); consumes the `core` contract + a `godot{}` renderer block; GDScript headless-codegen harness (`.tscn` gen + `godot-mcp`). **Owner direction 2026-06-21:** a SINGLE Godot client serves both web (HTML5 export, single-threaded) and native (standalone `.app`); Phaser GT2 retired. Sprint 1 = the vertical slice (#1051–#1056); ISO projection locked in `godot/ISO-PROJECTION.md`.
 
 ### M6 — *(optional, post-M1)* GT1 BYOL RPG Maker exploration export
 - Asset-clean (no RTP), exploration/dialogue only (battle-system mismatch is fatal), contract-taker; RTP legal guardrails + counsel review.

--- a/docs/roadmap/contracts/render-profile.md
+++ b/docs/roadmap/contracts/render-profile.md
@@ -35,6 +35,7 @@ render-profile
 │   └── ai_disclosure         { generated_by, model, date }
 └── renderer_profiles         ← OPTIONAL; a renderer reads core + its OWN block
     ├── phaser                { tileset/tile_size/ui_skin | backdrop_layout/walkmask/… }
+    ├── godot                 { projection | backdrop_layout(zone_anchors) | actor_sheets | default_facing }
     └── rpgmaker              (reserved / spec-only; deferred)
 ```
 
@@ -44,6 +45,31 @@ coordinate-, walkmask-, or sprite-sheet-layout-shaped lives in an optional per-r
 block. The **core-only conformance test (#428)** enforces this: a renderer using `core` +
 its own block must render every M0 scene. (The repo's existing SVG/React viewer is a free
 third "renderer" to validate that `core` stays renderer-agnostic.)
+
+### Godot renderer block (GT2 painterly-isometric)
+
+The `godot` block (added 2026-06-21; sibling of `phaser`/`rpgmaker`) carries the GT2 Godot
+client's presentation — and **only** presentation:
+
+- `projection` — the LOCKED dimetric 2:1 (~26.57°) isometric (see `godot/ISO-PROJECTION.md`,
+  the single source of truth both the renderer and the Blender bake cite). Irreversible once
+  finals bake.
+- `backdrop_layout[scope]` — renderer-owned `walk_polygon_ref` + `depth_baseline_y` +
+  `zone_anchors{<zone>:[x,y]}` (data-driven zone→screen placement + the Y-sort baseline) +
+  optional `normal_map_ref` (Branch B). Absent ⇒ procedural trapezoid fallback.
+- `actor_sheets[engine_actor_id]` — the directional sprite-sheet **layout** the renderer
+  slices (`facings`, `facing_order`, grid, foot `anchor`, `sheet_scope_key`). The atlas PNG
+  is served by the existing `/image` bridge unchanged; CC0 → AI-paintover → Blender-render
+  art is interchangeable behind one layout.
+- `default_facing` — the 8-facing fallback for a static/teleported token.
+
+**Facing is 100% renderer-DERIVED.** There is **no engine facing field, and one must never be
+added** — the engine is the sole writer of game *state*; facing is pure presentation (cf. the
+`positionAuthority:'derived'` rule below and the v1 `grid` exclusion). Out of combat the
+renderer snaps facing from the zone→zone screen-vector on a `move_to_zone` (reset to
+`default_facing` on a `travel`); in combat from actor-zone→target-zone (the Action-Replay
+envelope `target_fk`). Example instance:
+`viewer/openworlds/render/render-profile.godot.example.json`.
 
 ## Zones, not x,y (#427)
 

--- a/docs/roadmap/contracts/render-profile.schema.json
+++ b/docs/roadmap/contracts/render-profile.schema.json
@@ -109,6 +109,26 @@
             "free_positions": { "type": ["object", "null"] }
           }
         },
+        "godot": {
+          "type": "object",
+          "description": "Godot 4 client (GT2 painterly isometric; web + native). scene_kind=backdrop only. ALL presentation: the locked projection, per-scope backdrop_layout (renderer-owned walkmask + zone anchors + depth baseline + optional normal-map), per-actor directional sprite-sheet LAYOUT, and the renderer-DERIVED default facing. INVARIANTS: facing is 100% renderer-derived — NO engine facing field exists or may be added (the engine is the sole writer of game STATE; facing is pure presentation; cf. positionAuthority:'derived' and the v1 grid exclusion). walkmask is RENDERER-OWNED (the engine knows zone adjacency, not walkable pixels); pathfinding destinations still resolve to engine zones/locations.",
+          "additionalProperties": true,
+          "properties": {
+            "projection": {
+              "type": "object",
+              "description": "LOCKED isometric projection — advisory presentation metadata the renderer asserts its camera matches and every sprite manifest is baked to. Irreversible once finals bake. Owner lock 2026-06-21: dimetric 2:1 (~26.57deg). See godot/ISO-PROJECTION.md (single source of truth).",
+              "additionalProperties": false,
+              "properties": {
+                "kind": { "type": "string", "enum": ["dimetric", "isometric"], "description": "dimetric = 2:1 (~26.57deg, Diablo II / Infinity-Engine lineage); isometric = true 30deg." },
+                "tile_ratio": { "type": "string", "description": "e.g. '2:1'." },
+                "angle_deg": { "type": "number" }
+              }
+            },
+            "default_facing": { "type": "string", "description": "8-facing fallback when a token is static or on a teleport-travel (location change). Renderer-derived; NEVER read from the engine." },
+            "backdrop_layout": { "type": ["object", "null"], "description": "Keyed by a location art scope_key. Per-scene RENDERER-OWNED presentation: walk_polygon_ref ('procedural' or a scope/sibling ref), depth_baseline_y, zone_anchors {<zone>:[x,y]} (so zone->screen placement and the Y-sort baseline are data-driven, not hardcoded), optional normal_map_ref (Branch B lighting). Absent => procedural trapezoid fallback, like the Phaser block." },
+            "actor_sheets": { "type": ["object", "null"], "description": "Keyed by engine_actor_id. The directional sprite-sheet LAYOUT the renderer slices: {sheet_scope_key, facings, facing_order, frames_per_facing, cols, rows, cell_w, cell_h, anchor}. The atlas PNG is served via the existing /image bridge unchanged; this only declares how to slice it, so CC0 / AI-paintover / Blender-render source art is interchangeable behind one layout." }
+          }
+        },
         "rpgmaker": {
           "type": "object",
           "description": "RESERVED / spec-only. BYOL exploration-export tier, deferred post-M2 (#458-460). tilemap-only; never populated for scene_kind=backdrop. A contract-TAKER that consumes this frozen contract, never shapes it.",

--- a/godot/ISO-PROJECTION.md
+++ b/godot/ISO-PROJECTION.md
@@ -1,0 +1,26 @@
+# WorldOS GT2 — Isometric projection (LOCKED)
+
+> **Single source of truth** for the GT2 Godot renderer's projection. Both the **Blender
+> bake pipeline** (`godot/tools/bake_sprites.py`) and the **Godot renderer** (`WorldView.gd`,
+> `CharacterToken.gd`) cite this file, and every sprite-sheet manifest asserts
+> `projection: "dimetric-2to1"` against it. **This is irreversible once finals bake** — art
+> and zone→screen geometry must share one projection or they desync. Owner lock **2026-06-21**.
+
+## The lock
+
+| Property | Value | Notes |
+|----------|-------|-------|
+| **Projection** | **dimetric 2:1** | ~**26.57°** (`atan(0.5)`). The Diablo II / SimCity 2000 / Infinity-Engine "isometric" look (technically dimetric — two axes share a scale). NOT true 30° isometric. |
+| **Tile ratio** | width : height = **2 : 1** | A floor "cell" is twice as wide as it is tall on screen. |
+| **Facing count** | **8** | |
+| **Facing order** | `["S","SE","E","NE","N","NW","W","SW"]` | Index 0 = South (toward camera). Clockwise. Sprite-sheet rows follow this order. |
+| **Origin / anchor** | **foot point** | Each token/prop node origin is at the character's feet (the floor-contact point), so `global_position.y` IS the depth key. |
+| **Depth sort** | **Godot Y-sort** by foot-y | Greater screen-Y = nearer camera = drawn in front. No manual depth bands. |
+
+## Derived rules (do not re-derive ad hoc)
+- **Facing is renderer-DERIVED**, never from the engine (the engine has no facing field and must never gain one — sole-writer invariant). Out of combat: 8-way snap of the screen-space vector between the token's previous and new zone anchor on a `move_to_zone`; reset to `default_facing` on a `travel` (location change). In combat: 8-way snap of actor-zone-anchor → target-zone-anchor (from the Action-Replay envelope `target_fk`).
+- **`facing_strategy: "mirror4"`** is allowed: author/render only `S, SW, W, NW, N` and horizontal-flip for `SE, E, NE` — halves the art. The renderer applies the flip; the manifest declares the strategy.
+- **Zone → screen** placement is data-driven from `renderer_profiles.godot.backdrop_layout[scope].zone_anchors` (normalized `[x,y]` in 0..1 of the backdrop), computed at the **same** projection the backdrop art was baked/painted at.
+
+## Manifest assertion
+Every sprite-sheet manifest carries `"projection": "dimetric-2to1"`. The renderer **refuses** a manifest whose projection id does not match this lock, so a mis-baked sheet fails loudly instead of desyncing silently.

--- a/viewer/openworlds/render/render-profile.godot.example.json
+++ b/viewer/openworlds/render/render-profile.godot.example.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "../../../docs/roadmap/contracts/render-profile.schema.json",
+  "schema_version": 1,
+  "game_id": "bg-absolute-remnants-gt2-godot",
+  "title": "Baldur's Gate — Absolute Remnants (GT2 Godot painterly-isometric)",
+  "core": {
+    "scene_kind": "backdrop",
+    "positioning": "zone",
+    "locations": [
+      {
+        "engine_location_id": "loc-lower-city",
+        "art": { "scope_key": "scene-lower-city" },
+        "zones": ["the gate approach", "the market row", "the alley mouth"]
+      }
+    ],
+    "actors": [
+      { "engine_actor_id": "char-aubree", "art": { "scope_key": "portrait-aubree" } }
+    ],
+    "ai_disclosure": {
+      "generated_by": "worldos-ai-build-loop",
+      "model": "example",
+      "date": "2026-06-21"
+    }
+  },
+  "renderer_profiles": {
+    "godot": {
+      "projection": { "kind": "dimetric", "tile_ratio": "2:1", "angle_deg": 26.57 },
+      "default_facing": "S",
+      "backdrop_layout": {
+        "scene-lower-city": {
+          "walk_polygon_ref": "procedural",
+          "depth_baseline_y": 0.62,
+          "zone_anchors": {
+            "the gate approach": [0.5, 0.58],
+            "the market row": [0.34, 0.72],
+            "the alley mouth": [0.7, 0.8]
+          }
+        }
+      },
+      "actor_sheets": {
+        "char-aubree": {
+          "sheet_scope_key": "sprite-aubree-iso8",
+          "facings": 8,
+          "facing_order": ["S", "SE", "E", "NE", "N", "NW", "W", "SW"],
+          "frames_per_facing": 8,
+          "cols": 8,
+          "rows": 8,
+          "cell_w": 128,
+          "cell_h": 128,
+          "anchor": [64, 116]
+        }
+      }
+    }
+  }
+}

--- a/viewer/tests/test_render_profile_contract.py
+++ b/viewer/tests/test_render_profile_contract.py
@@ -87,3 +87,65 @@ def test_full_jsonschema_validation_when_available():
     schema = _load(_SCHEMA)
     ex = _load(_EXAMPLE)
     jsonschema.validate(ex, schema)
+
+
+# --- GT2 Godot renderer block (#1051) -------------------------------------------------------
+_GODOT_EXAMPLE = _REPO / "viewer" / "openworlds" / "render" / "render-profile.godot.example.json"
+_FACING_KEYS = {"facing", "direction", "orientation", "heading"}
+
+
+def test_schema_exposes_optional_godot_renderer_block():
+    """The Godot client (GT2) is a 4th renderer of the SAME contract. Adding it is a deliberate
+    edit to the closed renderer_profiles object (additionalProperties:false) — assert the block
+    exists as a sibling of phaser/rpgmaker and is OPTIONAL (renderer_profiles requires no block),
+    so Phaser-only profiles stay valid."""
+    schema = _load(_SCHEMA)
+    rp = schema["properties"]["renderer_profiles"]
+    assert {"phaser", "godot", "rpgmaker"} <= set(rp["properties"])
+    assert "required" not in rp, "renderer_profiles must not require any renderer block"
+    # the existing phaser-only example carries no godot block and must stay valid
+    assert "godot" not in _load(_EXAMPLE).get("renderer_profiles", {})
+
+
+def test_core_has_no_engine_facing_field():
+    """Facing is 100% renderer-DERIVED — the engine is the sole writer of game STATE and must
+    NEVER gain a facing field. Lock it at the contract: no facing/direction/orientation/heading
+    key may appear in core actor or location items (it lives only in the godot renderer block as
+    presentation layout)."""
+    core = _load(_SCHEMA)["properties"]["core"]["properties"]
+    act_props = set(core["actors"]["items"]["properties"])
+    loc_props = set(core["locations"]["items"]["properties"])
+    assert _FACING_KEYS.isdisjoint(act_props), f"engine facing leaked into core.actors: {act_props & _FACING_KEYS}"
+    assert _FACING_KEYS.isdisjoint(loc_props), f"engine facing leaked into core.locations: {loc_props & _FACING_KEYS}"
+
+
+def test_godot_example_is_strict_and_valid():
+    """The godot example profile (core + a godot renderer block) satisfies the same strict core
+    rules as every instance AND carries a well-formed godot block with the LOCKED projection +
+    a directional sprite-sheet layout keyed by engine_actor_id (the FK join)."""
+    ex = _load(_GODOT_EXAMPLE)
+    assert ex.get("schema_version") == 1
+    core = ex["core"]
+    assert core["scene_kind"] == "backdrop"
+    assert core["positioning"] in ("theater", "zone")
+    forbidden = {"x", "y", "col", "row", "grid_x", "grid_y", "coords", "position"}
+    for loc in core["locations"]:
+        assert "engine_location_id" in loc
+        assert forbidden.isdisjoint(loc)
+        for z in loc.get("zones", []):
+            assert isinstance(z, str) and z.strip()
+    for act in core["actors"]:
+        assert "engine_actor_id" in act
+        assert _FACING_KEYS.isdisjoint(act), "no facing on an actor instance (renderer-derived)"
+
+    godot = ex["renderer_profiles"]["godot"]
+    assert godot["projection"]["kind"] in ("dimetric", "isometric")
+    known_ids = {a["engine_actor_id"] for a in core["actors"]}
+    for actor_id, sheet in (godot.get("actor_sheets") or {}).items():
+        assert actor_id in known_ids, f"actor_sheets key {actor_id} is not a core engine_actor_id"
+        assert sheet["facings"] == len(sheet["facing_order"]), "facings count must match facing_order length"
+
+
+def test_godot_example_full_jsonschema_validation_when_available():
+    jsonschema = pytest.importorskip("jsonschema")
+    jsonschema.validate(_load(_GODOT_EXAMPLE), _load(_SCHEMA))


### PR DESCRIPTION
Closes #1051. First issue of the **GT2 Godot painterly-isometric renderer** epic (#1050), milestone *Graphics M5 — GT2 Godot painterly-isometric renderer*.

## What
Make the Godot renderer's config **contract-legal** and **lock the two irreversible art decisions before any art is produced**. Fully additive; **core is NOT bumped**; the Phaser/RPG-Maker renderers are unaffected.

- **`render-profile.schema.json`** — add `renderer_profiles.godot` (sibling of `phaser`/`rpgmaker`; the one deliberate edit to the closed `renderer_profiles` object). Carries `projection`, `backdrop_layout[scope]` (renderer-owned walkmask + `zone_anchors` + depth baseline + optional normal-map), `actor_sheets[engine_actor_id]` (directional sprite-sheet layout), `default_facing`.
- **`render-profile.md`** — document the godot block + the **facing-is-renderer-derived** invariant (no engine facing field, ever).
- **`godot/ISO-PROJECTION.md`** — LOCK **dimetric 2:1 (~26.57°)**, 8-facing order, foot-anchor origin, Y-sort = foot-y. Single source of truth cited by both the renderer and the Blender bake; every sprite manifest asserts `projection: "dimetric-2to1"` against it.
- **`render-profile.godot.example.json`** — example instance (core + a godot block).
- **`WORLDOS-GRAPHICS-ROADMAP.md`** — GT2 = **Godot (web + native)**; **Phaser GT2 retired** (owner direction 2026-06-21); **M5 pulled forward**. Dated amendments preserve the historical record.

## Invariants honored
- Engine = sole writer; renderer = thin client. No engine/surface/move-vocab change.
- `renderer_profiles` stays `additionalProperties:false`; the `godot` block is OPTIONAL (Phaser-only profiles stay valid).
- **No engine facing field** — locked by a conformance assertion (facing is presentation, derived from zone→zone screen-vectors / the Action-Replay envelope).

## Tests
- `viewer/tests/test_render_profile_contract.py` +4 assertions: godot block optional & Phaser-only example still valid; no facing/direction/orientation/heading key in `core`; the godot example is strict + (when `jsonschema` present) fully schema-valid.
- **Conformance test: 9 passed.** **Tier-0 fast gate: 228 passed.** `license_check`: passed.

Next in sprint 1: #1052 (scaffold `godot/` + `SurfaceClient` thin-client transport).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Godot 4 is now the primary renderer for GT2, supporting both web and native deployment.

* **Documentation**
  * Added formal specifications for the Godot 4 renderer, including projection parameters and configuration guide.
  * Updated graphics roadmap and added example renderer configuration files.

* **Tests**
  * Added validation tests to ensure renderer configuration compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->