### PR TITLE
chore(godot): scaffold project + Config/SurfaceClient thin-client transport + bundled fixtures (#1052)

### DIFF
--- a/godot/.gitignore
+++ b/godot/.gitignore
@@ -1,0 +1,29 @@
+# Godot 4 editor cache + generated artifacts.
+# https://docs.godotengine.org/en/stable/tutorials/best_practices/version_control.html
+
+# Editor + import cache (regenerated on open / --import). Never commit.
+.godot/
+
+# Per-asset import metadata (regenerated from source + the importer settings).
+*.import
+
+# Export build outputs (binaries / web bundles / packs).
+/export/
+/build/
+*.pck
+*.zip
+*.dmg
+*.app
+*.exe
+*.wasm
+
+# Mono/.NET build dirs (unused here, but harmless to guard).
+.mono/
+data_*/
+
+# export_presets.cfg is intentionally NOT committed in #1052 — exports are a
+# later issue, and the file embeds machine-local export-template paths.
+export_presets.cfg
+
+# OS noise
+.DS_Store

--- a/godot/autoload/Config.gd
+++ b/godot/autoload/Config.gd
@@ -1,0 +1,131 @@
+extends Node
+## Config — boot-time resolution of the engine endpoint + campaign id.
+##
+## CONTRACT ROLE: the single place that decides WHERE the renderer talks to the
+## engine. Every other singleton reads `Config.base_url` / `Config.campaign`;
+## NOTHING else hardcodes a host or port. The only literal port in the whole
+## project lives here (DEFAULT_PORT), and it is the last-resort default.
+##
+## Resolution precedence (highest wins):
+##   1. env WORLDOS_PLAY_PORT       -> http://127.0.0.1:<port>   (play.sh launch)
+##   2. CLI user args --port/--campaign/--base   (OS.get_cmdline_user_args)
+##   3. web export ?port=&campaign=&base=  (page query string via JavaScriptBridge)
+##   4. default http://127.0.0.1:<DEFAULT_PORT>
+
+const DEFAULT_HOST := "http://127.0.0.1"
+const DEFAULT_PORT := 8765  ## the ONLY hardcoded port in the project
+
+## Transport cadence + reconnect backoff (read by SurfaceClient).
+const POLL_CADENCE_SEC := 2.0
+const BACKOFF_BASE_SEC := 1.0
+const BACKOFF_CAP_SEC := 15.0
+## How fast the very first fetch fires after boot, so the smoke print lands
+## within ~0.1s instead of waiting a full cadence.
+const FIRST_FETCH_DELAY_SEC := 0.1
+
+var base_url: String = ""
+var campaign: String = ""
+
+
+func _ready() -> void:
+	_resolve()
+	print("[Config] base_url=%s campaign=%s" % [base_url, campaign if campaign != "" else "<none>"])
+
+
+func _resolve() -> void:
+	# Start from the default; each higher-precedence source overrides below.
+	var host := DEFAULT_HOST
+	var port := DEFAULT_PORT
+	var port_set := false
+
+	# (3) lowest of the explicit sources: web export query string.
+	if OS.has_feature("web"):
+		var q := _web_query()
+		if q.has("base") and String(q["base"]) != "":
+			base_url = _trim_trailing_slash(String(q["base"]))
+		if q.has("port") and String(q["port"]) != "":
+			var p := String(q["port"]).to_int()
+			if p > 0:
+				port = p
+				port_set = true
+		if q.has("campaign"):
+			campaign = String(q["campaign"])
+
+	# (2) CLI user args (everything after `--` on the command line).
+	var cli := _parse_cli(OS.get_cmdline_user_args())
+	if cli.has("base") and cli["base"] != "":
+		base_url = _trim_trailing_slash(cli["base"])
+	if cli.has("port") and cli["port"] != "":
+		var cp := String(cli["port"]).to_int()
+		if cp > 0:
+			port = cp
+			port_set = true
+	if cli.has("campaign"):
+		campaign = cli["campaign"]
+
+	# (1) highest precedence: the play.sh-injected env var.
+	var env_port := OS.get_environment("WORLDOS_PLAY_PORT")
+	if env_port != "":
+		var ep := env_port.to_int()
+		if ep > 0:
+			port = ep
+			port_set = true
+
+	# If no explicit --base/?base= won, compose host:port. (An explicit base_url
+	# is honored verbatim; a port from any source still recomposes it.)
+	if base_url == "" or port_set:
+		base_url = "%s:%d" % [host, port]
+
+
+## Parse CLI user args into a flag map. Accepts `--flag value` and `--flag=value`.
+func _parse_cli(args: PackedStringArray) -> Dictionary:
+	var out: Dictionary = {}
+	var i := 0
+	while i < args.size():
+		var a := args[i]
+		if a.begins_with("--"):
+			var body := a.substr(2)
+			if body.contains("="):
+				var bits := body.split("=", false, 1)
+				out[bits[0]] = bits[1] if bits.size() > 1 else ""
+			else:
+				# value is the next token if present and not another flag
+				var val := ""
+				if i + 1 < args.size() and not args[i + 1].begins_with("--"):
+					val = args[i + 1]
+					i += 1
+				out[body] = val
+		i += 1
+	return out
+
+
+## Read the browser page's query string on a web export. Guarded by callers with
+## OS.has_feature("web"); JavaScriptBridge does not exist on native builds.
+func _web_query() -> Dictionary:
+	var out: Dictionary = {}
+	if not OS.has_feature("web"):
+		return out
+	# JavaScriptBridge.eval returns the raw query (without the leading "?").
+	var raw_variant: Variant = JavaScriptBridge.eval("window.location.search.replace(/^\\?/, '')", true)
+	var raw := String(raw_variant) if raw_variant != null else ""
+	if raw == "":
+		return out
+	for pair in raw.split("&", false):
+		var kv := pair.split("=", false, 1)
+		if kv.size() == 0:
+			continue
+		var k := kv[0].uri_decode()
+		var v := kv[1].uri_decode() if kv.size() > 1 else ""
+		out[k] = v
+	return out
+
+
+func _trim_trailing_slash(s: String) -> String:
+	return s.trim_suffix("/")
+
+
+## Build a "?campaign=<id>" query suffix (URL-encoded), or "" when no campaign.
+func campaign_query() -> String:
+	if campaign == "":
+		return ""
+	return "?campaign=" + campaign.uri_encode()

--- a/godot/autoload/Config.gd.uid
+++ b/godot/autoload/Config.gd.uid
@@ -1,0 +1,1 @@
+uid://dj1gc2oyrxvcc

--- a/godot/autoload/FacingResolver.gd
+++ b/godot/autoload/FacingResolver.gd
@@ -1,0 +1,54 @@
+extends Node
+## FacingResolver — derives an 8-way facing name from a screen-space vector.
+##
+## MINIMAL STUB for #1052. The full derivation (move_to_zone previous→new anchor
+## snapping, travel-resets-to-default, combat actor→target_fk snapping, mirror4
+## strategy) is #1055. This stub provides only the pure geometry primitive that
+## the later issue builds on.
+##
+## CONTRACT NOTE (ISO-PROJECTION.md): facing is RENDERER-DERIVED, never from the
+## engine (the engine has no facing field — the sole-writer invariant forbids one).
+## Facing order is the locked dimetric 8-way: ["S","SE","E","NE","N","NW","W","SW"],
+## index 0 = South (toward camera), clockwise. This resolver stays PURE — no engine
+## calls, no node lookups — so it is trivially unit-testable.
+
+## Default facing when no motion vector exists (e.g. just after a `travel` location
+## change). Matches the render-profile's `default_facing`.
+var default_facing := "S"
+
+
+## Snap the screen-space vector (from_pos -> to_pos) to one of the facing names in
+## `order`, treating `order` as evenly-spaced compass octants beginning at the
+## first entry pointing "toward camera" (screen-down, +Y) and proceeding clockwise.
+##
+## `order` is the render-profile's `facing_order` (e.g.
+## ["S","SE","E","NE","N","NW","W","SW"]). A zero-length vector returns the first
+## entry of `order` (its natural "default"/rest facing), or default_facing if the
+## order is empty.
+func octant(from_pos: Vector2, to_pos: Vector2, order: PackedStringArray) -> String:
+	if order.is_empty():
+		return default_facing
+	var delta := to_pos - from_pos
+	if delta.length_squared() == 0.0:
+		return order[0]
+
+	var n := order.size()
+	# Screen space: +X is right, +Y is DOWN. Index 0 of `order` ("S") faces the
+	# camera (screen-down). We measure the clockwise angle starting from +Y so
+	# octant 0 centers on straight-down, then step clockwise (toward -X / "W"-ish)
+	# the way the locked facing order rotates.
+	#
+	# Clockwise-from-down angle: down=(0,1)->0; right=(1,0)->? We want the order
+	# S,SE,E,NE,N,NW,W,SW to map increasing index to clockwise rotation. With +Y
+	# down, "clockwise on screen" goes S -> SW -> W ... visually, but the LOCKED
+	# order is S,SE,E... (the other rotational sense). So we measure the angle in
+	# the sense that makes index increase match the order: start at +Y, rotate
+	# toward +X (screen-right) first.
+	var ang := atan2(delta.x, delta.y)  # 0 at +Y(down); +pi/2 at +X(right)
+	if ang < 0.0:
+		ang += TAU
+	var step := TAU / float(n)
+	# Round to nearest octant center (offset by half a step so each name owns a
+	# symmetric wedge), then wrap into range.
+	var idx := int(round(ang / step)) % n
+	return order[idx]

--- a/godot/autoload/FacingResolver.gd.uid
+++ b/godot/autoload/FacingResolver.gd.uid
@@ -1,0 +1,1 @@
+uid://bbvscye7ntie3

--- a/godot/autoload/ImageResolver.gd
+++ b/godot/autoload/ImageResolver.gd
@@ -1,0 +1,131 @@
+extends Node
+## ImageResolver — the /image?scope=<scope> bridge.
+##
+## CONTRACT ROLE: art is fetched lazily, by SCOPE KEY, from the engine's image
+## endpoint (the same scope keys the render-profile declares, e.g.
+## "scene-lower-city", "portrait-aubree", "sprite-aubree-iso8"). The resolver is
+## the only thing that turns a scope into a Texture2D, and it caches the result so
+## a scope is fetched at most once.
+##
+## STATES per scope: untried -> loading -> ok | miss.
+##   - HTTP 200  -> build a Texture2D from the bytes, cache it, emit texture_ready.
+##   - HTTP 404  -> mark "miss" and NEVER retry, so a PROCEDURAL fallback (a flat
+##                  colored quad / placeholder token) can stand in deterministically
+##                  instead of the resolver hammering a known-absent scope.
+##
+## Never blocks a frame: every fetch is async (await http.request_completed).
+## Owns no game state — purely an art cache keyed by scope.
+
+signal texture_ready(scope: String, texture: Texture2D)
+
+enum State { UNTRIED, LOADING, OK, MISS }
+
+var _state: Dictionary = {}     # scope -> State
+var _textures: Dictionary = {}  # scope -> Texture2D (only when State.OK)
+var _http_pool: Array[HTTPRequest] = []  # idle reusable request nodes
+
+
+## Kick off (or no-op) a fetch for `scope`. Idempotent: a scope already loading,
+## ok, or missed will not re-fetch.
+func resolve(scope: String) -> void:
+	if scope == "":
+		return
+	var st: int = _state.get(scope, State.UNTRIED)
+	if st == State.LOADING or st == State.OK or st == State.MISS:
+		return
+	_state[scope] = State.LOADING
+	_do_fetch(scope)  # fire-and-forget coroutine; never blocks the frame
+
+
+func _do_fetch(scope: String) -> void:
+	var http := _acquire_http()
+	var url := Config.base_url + "/image?scope=" + scope.uri_encode()
+	if Config.campaign != "":
+		url += "&campaign=" + Config.campaign.uri_encode()
+
+	var err := http.request(url)
+	if err != OK:
+		# Transport couldn't even start — treat as untried so a later resolve()
+		# can retry once the host is reachable (NOT a 404 "miss").
+		_state[scope] = State.UNTRIED
+		_release_http(http)
+		return
+
+	var resp: Array = await http.request_completed
+	_release_http(http)
+	var result: int = resp[0]
+	var code: int = resp[1]
+	var body: PackedByteArray = resp[3]
+
+	if code == 404:
+		# Definitive absence — mark miss and never retry.
+		_state[scope] = State.MISS
+		return
+	if result != HTTPRequest.RESULT_SUCCESS or code != 200:
+		# Transient (timeout, host down, 5xx) — allow a future retry.
+		_state[scope] = State.UNTRIED
+		return
+
+	var tex := _texture_from_bytes(body)
+	if tex == null:
+		# Got bytes but couldn't decode them — treat as a miss so a fallback stands.
+		_state[scope] = State.MISS
+		return
+
+	_textures[scope] = tex
+	_state[scope] = State.OK
+	emit_signal("texture_ready", scope, tex)
+
+
+## Return the cached Texture2D for `scope`, or null if it isn't loaded/ok.
+func get_cached(scope: String) -> Texture2D:
+	if _state.get(scope, State.UNTRIED) == State.OK:
+		return _textures.get(scope, null)
+	return null
+
+
+## True once a scope has been definitively found absent (404). Lets callers commit
+## to a procedural fallback without re-asking.
+func is_missing(scope: String) -> bool:
+	return _state.get(scope, State.UNTRIED) == State.MISS
+
+
+# ---------------------------------------------------------------------------
+# Decode bytes -> Texture2D. Detect format by content (PNG magic), then fall back
+# to letting Image sniff WEBP/JPG. Returns null if nothing decodes.
+# ---------------------------------------------------------------------------
+func _texture_from_bytes(body: PackedByteArray) -> Texture2D:
+	if body.size() == 0:
+		return null
+	var img := Image.new()
+	var ok := false
+	# PNG magic: 89 50 4E 47
+	if body.size() >= 4 and body[0] == 0x89 and body[1] == 0x50 and body[2] == 0x4E and body[3] == 0x47:
+		ok = img.load_png_from_buffer(body) == OK
+	else:
+		# Try JPG then WEBP; whichever succeeds wins.
+		ok = img.load_jpg_from_buffer(body) == OK
+		if not ok:
+			ok = img.load_webp_from_buffer(body) == OK
+		if not ok:
+			# Last resort: PNG anyway (some servers send PNG without us sniffing).
+			ok = img.load_png_from_buffer(body) == OK
+	if not ok:
+		return null
+	return ImageTexture.create_from_image(img)
+
+
+# ---------------------------------------------------------------------------
+# Small pool of reusable HTTPRequest nodes (single-flight each). We grow it only
+# when all are busy so concurrent scope fetches never share a node.
+# ---------------------------------------------------------------------------
+func _acquire_http() -> HTTPRequest:
+	if not _http_pool.is_empty():
+		return _http_pool.pop_back()
+	var http := HTTPRequest.new()
+	add_child(http)
+	return http
+
+
+func _release_http(http: HTTPRequest) -> void:
+	_http_pool.push_back(http)

--- a/godot/autoload/ImageResolver.gd.uid
+++ b/godot/autoload/ImageResolver.gd.uid
@@ -1,0 +1,1 @@
+uid://ca8grn4dgca37

--- a/godot/autoload/SurfaceClient.gd
+++ b/godot/autoload/SurfaceClient.gd
@@ -1,0 +1,301 @@
+extends Node
+## SurfaceClient — THE ONLY HTTP boundary in the Godot renderer.
+##
+## CONTRACT ROLE (mirrors viewer/openworlds/render/surface-client.js): proves the
+## "renderer is a thin client; engine is sole writer" model.
+##   - READ:  GET the read-model surfaces (/atlas-surface, /character-surface,
+##            /combat-surface) every Config.POLL_CADENCE_SEC, plus /events with a
+##            `${sid}:${seq}` cursor. The renderer owns ZERO game state — it
+##            re-fetches every tick; the ONLY thing cached across ticks is the
+##            /events cursor.
+##   - WRITE: the renderer's ONLY write is an INTENT via POST /move. It never
+##            mutates world state; it asks the engine to.
+##
+## TRANSPORT FALLBACK: on any unreachable host / non-200, this is treated as a
+## TRANSIENT failure — capped exponential backoff on the live host AND an
+## immediate fall back to the bundled res://fixtures so the project renders
+## standalone with no server. A real 200 flips back to LIVE.
+##
+## SWAPPABLE TRANSPORT: polling is the path today. `_try_sse()` is a marked stub
+## for the StreamPeer SSE upgrade on /surface-stream (see TODO below); when it
+## lands it slots in behind this same signal interface with identical payloads,
+## so Main / WorldView never change.
+
+signal snapshot_updated(atlas: Dictionary, combat: Dictionary, character: Dictionary)
+signal events_appended(records: Array)
+signal transport_mode_changed(mode: String)  ## mode in {"LIVE", "FIXTURE"}
+
+const MODE_LIVE := "LIVE"
+const MODE_FIXTURE := "FIXTURE"
+
+## HTTPRequest is single-flight (one in-flight request per node), so we keep a
+## small pool — one node per concurrent surface GET — plus a dedicated node for
+## /events and one for POST /move.
+const _SURFACES := ["atlas-surface", "character-surface", "combat-surface"]
+
+var _mode: String = ""  ## "" until the first tick decides; then LIVE or FIXTURE
+var _poll_timer: Timer
+var _backoff_sec: float = 0.0
+var _consecutive_failures: int = 0
+
+## /events cursor — the SOLE piece of state cached across ticks. `_since` is the
+## integer line cursor the engine's /events route advances via its `next` field;
+## `_sid` is the active session id used to compose the globally-unique
+## `${sid}:${seq}` dedup/order key (see server.py /events BUG2 note).
+var _since: int = 0
+var _sid: String = ""
+
+## Pool of reusable HTTPRequest child nodes, keyed by purpose.
+var _http_surface: Dictionary = {}  # surface name -> HTTPRequest
+var _http_events: HTTPRequest
+var _http_move: HTTPRequest
+
+var _ticking: bool = false  ## guard against overlapping ticks if one runs long
+
+
+func _ready() -> void:
+	# Build the HTTPRequest pool (one per concurrent GET; Godot's HTTPRequest is
+	# single-flight so concurrent surfaces each need their own node).
+	for surface in _SURFACES:
+		var http := HTTPRequest.new()
+		http.name = "http_" + surface
+		add_child(http)
+		_http_surface[surface] = http
+	_http_events = HTTPRequest.new()
+	_http_events.name = "http_events"
+	add_child(_http_events)
+	_http_move = HTTPRequest.new()
+	_http_move.name = "http_move"
+	add_child(_http_move)
+
+	# Steady-cadence poll timer.
+	_poll_timer = Timer.new()
+	_poll_timer.name = "poll_timer"
+	_poll_timer.wait_time = Config.POLL_CADENCE_SEC
+	_poll_timer.one_shot = false
+	_poll_timer.timeout.connect(_on_poll_tick)
+	add_child(_poll_timer)
+
+	# Prefer SSE if available; otherwise poll. (_try_sse is a stub today.)
+	if not _try_sse():
+		# Fire the FIRST fetch fast (so a headless smoke prints within ~0.1s),
+		# then start the steady cadence.
+		_poll_timer.start()
+		var first := get_tree().create_timer(Config.FIRST_FETCH_DELAY_SEC)
+		first.timeout.connect(_on_poll_tick)
+
+
+# ---------------------------------------------------------------------------
+# SSE transport upgrade — STUB.
+# ---------------------------------------------------------------------------
+## TODO(#455 transport-upgrade): full StreamPeer-based SSE on /surface-stream.
+## When implemented, subscribe to the push channel that emits the SAME
+## {atlas, combat, character} payloads the GET surfaces return, emit
+## snapshot_updated on each frame, and fall back to polling if no frame ever
+## arrives. Returning false here keeps POLLING as the active path for #1052.
+func _try_sse() -> bool:
+	return false
+
+
+# ---------------------------------------------------------------------------
+# Polling tick: fetch all surfaces + the /events delta, emit signals.
+# ---------------------------------------------------------------------------
+func _on_poll_tick() -> void:
+	if _ticking:
+		return
+	_ticking = true
+	await _tick()
+	_ticking = false
+
+
+func _tick() -> void:
+	# Fetch the three surfaces, each on its own pooled HTTPRequest node (Godot
+	# HTTPRequest is single-flight, so the per-surface pool is what lets a future
+	# transport overlap them). We await each in turn here — correct and simple for
+	# the #1052 smoke; an overlapped-fetch optimization can layer in later without
+	# changing this signal interface.
+	var results: Dictionary = {}
+	var any_live := false
+	var any_failed := false
+
+	for surface in _SURFACES:
+		var res: Dictionary = await _fetch_surface(surface)
+		results[surface] = res["data"]
+		if res["live"]:
+			any_live = true
+		else:
+			any_failed = true
+
+	# Decide transport mode for this tick. If even one real 200 came back, we are
+	# LIVE; if every surface failed, we are FIXTURE (and back off the live host).
+	if any_live:
+		_set_mode(MODE_LIVE)
+		_consecutive_failures = 0
+		_backoff_sec = 0.0
+	else:
+		_set_mode(MODE_FIXTURE)
+		_bump_backoff()
+
+	emit_signal(
+		"snapshot_updated",
+		results.get("atlas-surface", {}),
+		results.get("combat-surface", {}),
+		results.get("character-surface", {})
+	)
+
+	# /events delta — only meaningful against a live host; in fixture mode we read
+	# the bundled events.json once-ish so the smoke has a shaped payload.
+	var records := await _fetch_events()
+	if not records.is_empty():
+		emit_signal("events_appended", records)
+
+
+## Fetch a single surface. Returns {data: Dictionary, live: bool}. On any
+## unreachable host / non-200 / parse error, falls back to the bundled fixture
+## and reports live=false.
+func _fetch_surface(surface: String) -> Dictionary:
+	# If we are already backing off the live host, skip the network attempt this
+	# tick and serve fixtures directly (avoids hammering a dead host).
+	if _mode == MODE_FIXTURE and _backoff_sec > 0.0 and not _backoff_elapsed():
+		return {"data": _load_fixture(surface), "live": false}
+
+	var http: HTTPRequest = _http_surface[surface]
+	var url := Config.base_url + "/" + surface + Config.campaign_query()
+	var err := http.request(url)
+	if err != OK:
+		return {"data": _load_fixture(surface), "live": false}
+
+	var resp: Array = await http.request_completed
+	# request_completed(result, response_code, headers, body)
+	var result: int = resp[0]
+	var code: int = resp[1]
+	var body: PackedByteArray = resp[3]
+	if result != HTTPRequest.RESULT_SUCCESS or code != 200:
+		return {"data": _load_fixture(surface), "live": false}
+
+	var parsed: Variant = JSON.parse_string(body.get_string_from_utf8())
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return {"data": _load_fixture(surface), "live": false}
+	return {"data": parsed, "live": true}
+
+
+## Fetch the /events delta and advance the `${sid}:${seq}` cursor. Returns the
+## list of new event records (possibly empty). In fixture mode it returns the
+## bundled events once (it never advances a real cursor against a dead host).
+func _fetch_events() -> Array:
+	if _mode == MODE_FIXTURE:
+		# Standalone: surface the bundled events.json so listeners get a shaped
+		# payload. We do NOT keep advancing a cursor against fixtures.
+		var fx: Variant = _load_fixture_raw("events")
+		if typeof(fx) == TYPE_DICTIONARY and fx.has("entries"):
+			return fx["entries"]
+		if typeof(fx) == TYPE_ARRAY:
+			return fx
+		return []
+
+	var url := Config.base_url + "/events?since=" + str(_since)
+	if Config.campaign != "":
+		url += "&campaign=" + Config.campaign.uri_encode()
+	var err := _http_events.request(url)
+	if err != OK:
+		return []
+	var resp: Array = await _http_events.request_completed
+	if resp[0] != HTTPRequest.RESULT_SUCCESS or resp[1] != 200:
+		return []
+	var parsed: Variant = JSON.parse_string((resp[3] as PackedByteArray).get_string_from_utf8())
+	if typeof(parsed) != TYPE_DICTIONARY:
+		return []
+
+	# Advance the cursor: `next` is the new `since`, `sid` keys the dedup space.
+	if parsed.has("next"):
+		_since = int(parsed["next"])
+	if parsed.has("sid") and typeof(parsed["sid"]) == TYPE_STRING:
+		_sid = parsed["sid"]
+	var entries: Variant = parsed.get("entries", [])
+	return entries if typeof(entries) == TYPE_ARRAY else []
+
+
+# ---------------------------------------------------------------------------
+# The renderer's ONLY write: POST /move — a constrained INTENT, never a
+# world-assertion. Returns {ok: bool, reason: String}.
+# ---------------------------------------------------------------------------
+func move(intent: Dictionary) -> Dictionary:
+	# Carry the campaign with every intent (the engine scopes the move to it).
+	var payload := intent.duplicate(true)
+	payload["campaign"] = Config.campaign
+
+	if _mode == MODE_FIXTURE:
+		# Standalone: there is no engine to accept the intent. Echo a benign ok so
+		# UI flows don't dead-end, and log what WOULD have been POSTed.
+		print("[SurfaceClient] FIXTURE mode — would POST /move: ", payload)
+		return {"ok": true, "reason": "fixture"}
+
+	var headers := ["Content-Type: application/json"]
+	var err := _http_move.request(
+		Config.base_url + "/move",
+		headers,
+		HTTPClient.METHOD_POST,
+		JSON.stringify(payload)
+	)
+	if err != OK:
+		return {"ok": false, "reason": "request_failed"}
+	var resp: Array = await _http_move.request_completed
+	var result: int = resp[0]
+	var code: int = resp[1]
+	var body: PackedByteArray = resp[3]
+	if result != HTTPRequest.RESULT_SUCCESS:
+		return {"ok": false, "reason": "transport_error"}
+	var parsed: Variant = JSON.parse_string(body.get_string_from_utf8())
+	var data: Dictionary = parsed if typeof(parsed) == TYPE_DICTIONARY else {}
+	var ok: bool = code == 200 and data.get("ok", true) != false
+	var reason: String = String(data.get("reason", "")) if data.has("reason") else ("http_%d" % code)
+	return {"ok": ok, "reason": reason}
+
+
+# ---------------------------------------------------------------------------
+# Mode / backoff helpers.
+# ---------------------------------------------------------------------------
+func _set_mode(mode: String) -> void:
+	if _mode == mode:
+		return
+	_mode = mode
+	emit_signal("transport_mode_changed", mode)
+
+
+func mode() -> String:
+	return _mode
+
+
+func _bump_backoff() -> void:
+	_consecutive_failures += 1
+	# Capped exponential: base * 2^(n-1), clamped to the cap.
+	var raw := Config.BACKOFF_BASE_SEC * pow(2.0, float(_consecutive_failures - 1))
+	_backoff_sec = minf(raw, Config.BACKOFF_CAP_SEC)
+	_backoff_started_ms = Time.get_ticks_msec()
+
+
+var _backoff_started_ms: int = 0
+
+
+func _backoff_elapsed() -> bool:
+	if _backoff_sec <= 0.0:
+		return true
+	var elapsed_ms := Time.get_ticks_msec() - _backoff_started_ms
+	return float(elapsed_ms) / 1000.0 >= _backoff_sec
+
+
+# ---------------------------------------------------------------------------
+# Bundled fixtures (res://fixtures/*.json) — the standalone fallback.
+# ---------------------------------------------------------------------------
+func _load_fixture(surface: String) -> Dictionary:
+	var v: Variant = _load_fixture_raw(surface)
+	return v if typeof(v) == TYPE_DICTIONARY else {}
+
+
+func _load_fixture_raw(name: String) -> Variant:
+	var path := "res://fixtures/%s.json" % name
+	if not FileAccess.file_exists(path):
+		push_warning("[SurfaceClient] missing fixture: " + path)
+		return null
+	var text := FileAccess.get_file_as_string(path)
+	return JSON.parse_string(text)

--- a/godot/autoload/SurfaceClient.gd.uid
+++ b/godot/autoload/SurfaceClient.gd.uid
@@ -1,0 +1,1 @@
+uid://cq64dqfrl1d03

--- a/godot/fixtures/atlas-surface.json
+++ b/godot/fixtures/atlas-surface.json
@@ -1,0 +1,15 @@
+{
+  "_comment": "Fixture mirroring the REAL /atlas-surface (viewer/server.py _atlas_* builders). Lets the Godot renderer boot standalone with no live engine. SurfaceClient prefers a live host and falls back to this.",
+  "campaign_id": "bg-absolute-remnants",
+  "current_location": { "id": "loc-lower-city", "name": "Baldur's Gate — Lower City" },
+  "current_location_id": "loc-lower-city",
+  "zones": ["the gate approach", "the market row", "the alley mouth"],
+  "known_locations": [
+    { "id": "loc-lower-city", "name": "Baldur's Gate — Lower City", "tags": ["hub", "city"], "discovered": true, "visited": true },
+    { "id": "loc-upper-city", "name": "Baldur's Gate — Upper City", "tags": ["city", "intrigue"], "discovered": true, "visited": false }
+  ],
+  "travel_options": [
+    { "to": "loc-upper-city", "name": "Baldur's Gate — Upper City", "available": true, "move": { "kind": "travel", "target": "loc-upper-city" } }
+  ],
+  "can_act": true
+}

--- a/godot/fixtures/character-surface.json
+++ b/godot/fixtures/character-surface.json
@@ -1,0 +1,7 @@
+{
+  "_comment": "Fixture mirroring the REAL /character-surface (viewer/server.py build_character_surface). The party panel reads ONLY these fields; zero client-side rules.",
+  "party": [
+    { "id": "char-aubree", "name": "Aubree", "kind": "pc", "race": "Human", "class": "Ranger", "hp": 24, "hpMax": 30, "ac": 15, "level": 4 },
+    { "id": "char-companion-1", "name": "Shadowheart", "kind": "companion", "race": "Half-Elf", "class": "Cleric", "hp": 18, "hpMax": 22, "ac": 18, "level": 4 }
+  ]
+}

--- a/godot/fixtures/combat-surface.json
+++ b/godot/fixtures/combat-surface.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Fixture mirroring the REAL /combat-surface (viewer/server.py build_combat_surface). active:false = out-of-combat exploration, the #1052 default. When active, `zone` is truth and the renderer re-derives x,y itself (renderer owns layout).",
+  "active": false,
+  "round": 0,
+  "turn_index": 0,
+  "current_id": null,
+  "zones": [],
+  "initiative": []
+}

--- a/godot/fixtures/events.json
+++ b/godot/fixtures/events.json
@@ -1,0 +1,14 @@
+{
+  "_comment": "Fixture mirroring the REAL /events response (viewer/server.py /events route): {entries, next, sid}. Each entry is a {kind, text, label?, seq?, sid?} record. One harmless narration row so listeners get a shaped payload standalone.",
+  "entries": [
+    {
+      "kind": "narration",
+      "label": "DM",
+      "text": "The Lower City breathes around you — gulls wheel over the harbor, and the gate guards wave the party through.",
+      "seq": 0,
+      "sid": "fixture-session"
+    }
+  ],
+  "next": 1,
+  "sid": "fixture-session"
+}

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -1,0 +1,42 @@
+; Engine configuration file.
+; WorldOS GT2 (Godot) renderer — scaffold for issue #1052.
+;
+; This is a hand-authored project.godot (config_version=5, Godot 4.6). It is
+; intentionally minimal: a bootable thin-client whose SurfaceClient proves the
+; transport by driving a smoke Main. The real scene graph (WorldView /
+; CharacterToken / Y-sort / click-to-move) is #1053–#1055.
+;
+; Format docs: https://docs.godotengine.org/en/stable/classes/class_projectsettings.html
+
+config_version=5
+
+[application]
+
+config/name="WorldOS GT2 (Godot)"
+config/description="Thin-client Godot 4 renderer for the WorldOS D&D engine. Polls read-only HTTP surfaces and POSTs player intents; owns ZERO game state."
+run/main_scene="res://scenes/Main.tscn"
+config/features=PackedStringArray("4.6", "GL Compatibility")
+
+[autoload]
+
+; Boot order matters: Config first (resolves base_url/campaign), then the
+; HTTP/transport singletons that read from it. All registered with a leading
+; "*" so they load as autoloaded singletons.
+Config="*res://autoload/Config.gd"
+SurfaceClient="*res://autoload/SurfaceClient.gd"
+ImageResolver="*res://autoload/ImageResolver.gd"
+FacingResolver="*res://autoload/FacingResolver.gd"
+
+[display]
+
+; "canvas_items" stretch keeps 2D content crisp across resolutions; "keep"
+; aspect preserves the dimetric backdrop's proportions (no zone→screen desync).
+window/stretch/mode="canvas_items"
+window/stretch/aspect="keep"
+
+[rendering]
+
+; gl_compatibility = widest reach (web export + older native GPUs). The GT2
+; renderer is 2D/painterly-isometric, so the Forward+ pipeline buys nothing here.
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"

--- a/godot/scenes/Main.gd
+++ b/godot/scenes/Main.gd
@@ -1,0 +1,94 @@
+extends Node2D
+## Main — the #1052 boot smoke.
+##
+## This is NOT the real scene graph (WorldView / CharacterToken / Y-sort /
+## click-to-move are #1053–#1055). Its only job is to prove the transport end to
+## end: connect to SurfaceClient, and on the FIRST snapshot print the current
+## location name, the party member names, and the transport mode. With no server
+## running, SurfaceClient falls back to bundled fixtures, so this smoke prints from
+## res://fixtures/* and exits cleanly.
+
+@onready var _label: Label = $UI/SmokeLabel
+
+var _got_first_snapshot: bool = false
+var _last_mode: String = "?"
+
+
+func _ready() -> void:
+	SurfaceClient.transport_mode_changed.connect(_on_mode_changed)
+	SurfaceClient.snapshot_updated.connect(_on_snapshot)
+	SurfaceClient.events_appended.connect(_on_events)
+	_set_label("WorldOS GT2 (Godot) — connecting…")
+
+
+func _on_mode_changed(mode: String) -> void:
+	_last_mode = mode
+
+
+func _on_snapshot(atlas: Dictionary, _combat: Dictionary, character: Dictionary) -> void:
+	# Extract the smoke facts from the read-only surfaces (no client-side rules).
+	var location_name := _location_name(atlas)
+	var party_names := _party_names(character)
+	var mode := SurfaceClient.mode()
+	if mode == "":
+		mode = _last_mode
+
+	var party_joined := ", ".join(party_names) if not party_names.is_empty() else "<empty>"
+	var line := "[%s] location=%s | party=%s" % [mode, location_name, party_joined]
+
+	# TRANSPORT SMOKE PROOF.
+	print("[Main] SMOKE ", line)
+	_set_label("WorldOS GT2 (Godot)\n%s\nlocation: %s\nparty: %s" % [mode, location_name, party_joined])
+
+	if not _got_first_snapshot:
+		_got_first_snapshot = true
+		_maybe_quit()
+
+
+func _on_events(records: Array) -> void:
+	print("[Main] events_appended: %d record(s)" % records.size())
+
+
+# ---------------------------------------------------------------------------
+# Read-only surface extraction (shapes mirror viewer/server.py surfaces).
+# ---------------------------------------------------------------------------
+func _location_name(atlas: Dictionary) -> String:
+	var cur: Variant = atlas.get("current_location", null)
+	if typeof(cur) == TYPE_DICTIONARY and cur.has("name"):
+		return String(cur["name"])
+	if atlas.has("current_location_id"):
+		return String(atlas["current_location_id"])
+	return "<unknown>"
+
+
+func _party_names(character: Dictionary) -> PackedStringArray:
+	var out := PackedStringArray()
+	var party: Variant = character.get("party", [])
+	if typeof(party) != TYPE_ARRAY:
+		return out
+	for member in party:
+		if typeof(member) == TYPE_DICTIONARY and member.has("name"):
+			out.append(String(member["name"]))
+	return out
+
+
+# ---------------------------------------------------------------------------
+# Headless / smoke quit. Quit after the first snapshot when running headless or
+# when launched with a --smoke user arg, so CI can boot-and-check cleanly.
+# ---------------------------------------------------------------------------
+func _maybe_quit() -> void:
+	var smoke_flag := OS.get_cmdline_user_args().has("--smoke")
+	var headless := DisplayServer.get_name() == "headless"
+	if smoke_flag or headless:
+		# Defer the quit one frame so the print/label flush before teardown.
+		call_deferred("_quit_clean")
+
+
+func _quit_clean() -> void:
+	print("[Main] smoke complete — quitting cleanly")
+	get_tree().quit()
+
+
+func _set_label(text: String) -> void:
+	if is_instance_valid(_label):
+		_label.text = text

--- a/godot/scenes/Main.gd.uid
+++ b/godot/scenes/Main.gd.uid
@@ -1,0 +1,1 @@
+uid://lk80h1qtdecx

--- a/godot/scenes/Main.tscn
+++ b/godot/scenes/Main.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=2 format=3 uid="uid://b1worldosgt2main"]
+
+[ext_resource type="Script" path="res://scenes/Main.gd" id="1_main"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1_main")
+
+[node name="UI" type="CanvasLayer" parent="."]
+
+[node name="SmokeLabel" type="Label" parent="UI"]
+offset_left = 16.0
+offset_top = 16.0
+offset_right = 616.0
+offset_bottom = 136.0
+text = "WorldOS GT2 (Godot) — booting…"


### PR DESCRIPTION
Closes #1052. Sprint 1 of the **GT2 Godot painterly-isometric renderer** epic (#1050). Follows #1051 (the `godot` contract block + locked projection).

## What
A NEW top-level **`godot/`** project (sibling of `macos/`, `viewer/`, `servers/`) — the thin-client foundation. **Additive**: no engine/viewer/contract changes. Mirrors `viewer/openworlds/render/surface-client.js`.

- **`project.godot`** — Godot 4.6, `gl_compatibility` (widest web+native), `canvas_items`/`keep` stretch, autoloads `Config` → `SurfaceClient` → `ImageResolver` → `FacingResolver`.
- **`Config.gd`** — `base_url`/`campaign` discovery: `WORLDOS_PLAY_PORT` → CLI `--port/--campaign/--base` → web query string → `127.0.0.1:8765` default (the only place a port is named).
- **`SurfaceClient.gd`** — the ONLY HTTP boundary. Polls `/atlas|/character|/combat` + `/events?since=` (`{sid}:{seq}` cursor); `move(intent)` POSTs `/move` (carries `campaign`) → `{ok,reason}`; HTTPRequest pool; capped exponential backoff; **fixture fallback + LIVE/FIXTURE mode**; `_try_sse()` stub (TODO #455). Owns ZERO state but the events cursor.
- **`ImageResolver.gd`** — `/image?scope=` bridge: lazy/idempotent (untried/loading/ok/miss), bytes→`Texture2D` cache, never retries a 404.
- **`FacingResolver.gd`** — pure 8-way octant snap (full derivation in #1055).
- **`scenes/Main.{tscn,gd}`** — boot smoke (prints location + party + transport mode; quits cleanly headless).
- **`fixtures/*.json`** — shaped to the real surfaces; the standalone fallback.

## Validation
The Godot CI lane lands in **#1056**, so GitHub CI here only runs the existing (non-`godot/`) lanes. The real gate is **local Godot 4.6.3**:
- `--headless --import` → clean (no script/parse errors).
- headless smoke (no server → fixture fallback) →
  `[Main] SMOKE [FIXTURE] location=Baldur's Gate — Lower City | party=Aubree, Shadowheart`

## Invariants
Engine = sole writer; renderer = thin client (zero state but the `/events` cursor); ignores any surface `x/y`; writes only the frozen `/move` vocab. `.gd.uid` files tracked (Godot 4.4+); `.godot/` cache ignored.

Next: #1053 (WorldView backdrop + renderer-owned walkmask + deterministic zone markers).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable engine endpoint and campaign support via environment variables, CLI flags, or query string parameters
  * Added async image loading and caching system
  * Added HTTP transport with automatic fallback to fixture data for offline mode
  * Added boot harness for connection validation and transport mode reporting

* **Chores**
  * Added Godot project configuration and development `.gitignore`
  * Added fixture data for offline operation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->