### PR TITLE
feat(qa): wire fact-fidelity to the recap consumer + CI (close written-but-never-read)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,9 @@ jobs:
             ../../qa/test_visual_regression_check.py \
             ../../qa/test_structural_coverage.py \
             ../../qa/test_story_readout_approval.py \
-            ../../qa/test_feature_engagement.py
+            ../../qa/test_feature_engagement.py \
+            ../../qa/test_fact_fidelity.py \
+            ../../qa/test_recap_fidelity.py
 
   server-contracts:
     # Phase-1 (DETERMINISTIC-2): deterministic cross-service MCP contract tests

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -336,3 +336,17 @@ live under the gitignored `/qa/transcripts/`, so the committed regression test
 (`qa/fact_inventories/sample_session.*`); an opt-in test reproduces the finding on the real
 `ow-combat-031717.md` when it is present locally. The committed `ow-combat-031717.facts.json` inventory
 re-derives the differential whenever that transcript is regenerated.
+
+**Wired consumer — the recap content-fidelity guard** (`qa/test_recap_fidelity.py`). The instrument is
+not "available but uncalled" (the VISION *written-but-never-read* pathology) — it guards a REAL lossy,
+player-facing surface: `recap.format_recap` (the DM's `previously_on`, read every resume) keeps only the
+most-recent `max_entries` story beats, soft-truncates each to `max_entry_chars`, and drops oldest-first
+under a `max_chars` budget — tunable knobs under active latency pressure (it's the latency-collapse path,
+`server.py`), with no other content-loss guard. The test asserts the recap of a reference session
+preserves its *critical* facts at the shipped defaults, and has TEETH: a leaned budget drops a critical
+fact and `critical_loss` catches it (adversarially verified — regressing the recap default to 40 chars
+turns the guard RED). **Use this pattern when leaning any lossy context knob** (`recap.py` budgets, the
+`scene_context` throttle constants in `server.py`): pin a reference + critical-fact inventory and assert
+the leaner derivation still clears `critical_loss=False` — the regression the 1–5 lens cannot see.
+**NOT** a per-run scored dimension: each fresh emergent run has no reference to diff against, so
+fact-fidelity is an opt-in regression guard (compression/lean A/Bs, recap continuity), never a lens.

--- a/qa/test_recap_fidelity.py
+++ b/qa/test_recap_fidelity.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Recap content-fidelity guard — wires qa/fact_fidelity.py to a REAL lossy consumer.
+
+`recap.format_recap` (the DM's "Previously on…" / `previously_on`, read every resume) is LOSSY by
+design and latency-pressured: it keeps only the most-recent `max_entries` story beats, soft-truncates
+each to `max_entry_chars`, and drops OLDEST-first under a `max_chars` byte budget. Those budgets are
+tunable knobs under active pressure to lean further for latency — and nothing guards them against
+silently dropping a CONTINUITY-CRITICAL fact (an antagonist, the central MacGuffin, the frame), the
+exact loss the 1–5 lens is blind to.
+
+This is that guard: the recap of a reference session must preserve its critical facts at the shipped
+defaults, and the test has TEETH — a leaned budget drops a critical fact and fact-fidelity catches it
+(if recap weren't lossy, or fact-fidelity couldn't detect a drop, the differential assertion fails).
+
+Run (single-process):
+    uv run --directory servers/engine python -m pytest qa/test_recap_fidelity.py -q -p no:xdist
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+QA_DIR = Path(__file__).resolve().parent
+if str(QA_DIR) not in sys.path:
+    sys.path.insert(0, str(QA_DIR))
+
+import fact_fidelity as ff  # noqa: E402
+from recap import format_recap  # noqa: E402  (engine module; on path under servers/engine)
+from models import SessionLogEntry  # noqa: E402
+
+
+def _beat(i: int, kind: str, text: str, speaker: str | None = None) -> SessionLogEntry:
+    return SessionLogEntry(t=float(i), kind=kind, text=text, speaker=speaker)
+
+
+# A reference session whose continuity-critical facts span the arc: the FRAME reveal is EARLY
+# (beat 2), the antagonist + MacGuffin are LATE. recap is recency-biased, so leaning max_entries
+# drops the early critical fact while keeping the late ones — a realistic latency-lean regression.
+def _reference_session() -> list[SessionLogEntry]:
+    return [
+        _beat(1, "narration", "Greyharbor docks, a cold grey morning. Sera Vey arrives chasing a stolen courier packet."),
+        _beat(2, "narration", "The seal on the recovered packet is her own Wardens mark. She is not the investigator — she is the frame."),
+        _beat(3, "dialogue", "You're holding something three parties want. We are the one not planning to take it.", speaker="Dob"),
+        _beat(4, "narration", "Wrapped beside the cipher is a Silverwatch officer's seal, the kind only a records clerk would hold."),
+        _beat(5, "narration", "One name sits in the clear where the code should be: Lady Ashryn."),
+        _beat(6, "dialogue", "The warehouse door opens and Veyl Marrow steps through — the architect who built the road.", speaker="Tomas"),
+        _beat(7, "narration", "The packet hid the Ledger of Thirty-One names — every Reach survivor and the Wardens who sheltered them."),
+        _beat(8, "narration", "Sera takes the ledger. The road to the Spindle is open."),
+    ]
+
+
+# The continuity-critical facts the recap must carry forward. critical = the spine the next session
+# cannot resume without.
+_CRITICAL_FACTS = [
+    ff.Fact(id="the_frame", desc="Sera is the frame, not the investigator", patterns=[r"the frame"], severity="critical"),
+    ff.Fact(id="antagonist_veyl", desc="the architect Veyl Marrow", patterns=[r"Veyl Marrow"], severity="critical"),
+    ff.Fact(id="macguffin_thirty_one", desc="the Ledger of Thirty-One names", patterns=[r"Thirty-One"], severity="critical"),
+    ff.Fact(id="silverwatch_seal", desc="the Silverwatch officer's seal", patterns=[r"Silverwatch"], severity="high"),
+]
+
+
+def test_recap_preserves_critical_facts_at_shipped_defaults():
+    recap = format_recap(_reference_session())
+    report = ff.score_fidelity(_CRITICAL_FACTS, recap)
+    assert not report.critical_loss, f"recap dropped critical fact(s) at defaults: {report.missing}"
+    assert report.fidelity == 1.0, report.missing
+
+
+def test_leaning_recap_budget_drops_a_critical_fact_and_fidelity_catches_it():
+    log = _reference_session()
+    full = ff.score_fidelity(_CRITICAL_FACTS, format_recap(log))
+    # simulate a latency-lean of the recap knob (keep only the most-recent 3 beats)
+    leaned = ff.score_fidelity(_CRITICAL_FACTS, format_recap(log, max_entries=3))
+    # the lean silently drops the EARLY 'frame' reveal — a continuity-critical fact the full recap kept
+    assert not full.critical_loss
+    assert leaned.critical_loss, "leaning the recap should drop a critical fact"
+    assert "the_frame" in leaned.missing
+    assert leaned.fidelity < full.fidelity


### PR DESCRIPTION
## Why

PR [#1065](https://github.com/electricsheephq/WorldOS/pull/1065) shipped the fact-fidelity instrument, but a follow-up `worldos-decide` review (Scorer + Red-team, anchored to `VISION.md`) found it was **written-but-never-read**: nothing in the loop called it, and its self-test wasn't even in CI's allowlist (`ci.yml` ran nowhere near it). VISION names that the *purest* pathology — and forbids leaving machinery whose read-seam nothing consumes.

The decision: **narrow Option B** — wire it to a *real, existing* lossy consumer, not a speculative convention. Both sub-agents rejected a per-run scored dimension (category error: fresh emergent runs have no reference) and a hand-maintained inventory convention (rots → false `critical_loss`; score-gaming). The red-team, tasked to defend status quo, couldn't above ~30% because `recap`/`scene_context` are demonstrably lossy, latency-pressured, unguarded production surfaces.

## What

- **`qa/test_recap_fidelity.py`** — guards `recap.format_recap` (the DM's `previously_on`, read **every resume**). It keeps only the most-recent `max_entries` beats, soft-truncates each to 400 chars, and drops oldest-first under a 6000-char budget — tunable knobs under active latency pressure, with **no prior content-loss guard**. The test asserts a reference session's **critical** facts survive at shipped defaults, and has **teeth**: a leaned budget drops a critical fact and `critical_loss` catches it.
- **`ci.yml`** — add `test_fact_fidelity.py` + `test_recap_fidelity.py` to the qa allowlist (the PR-1 self-test was running nowhere).
- **`SCORING.md` §8** — document the recap guard + the lean-knob A/B pattern; reiterate fact-fidelity is an **opt-in regression guard, never a per-run lens**.

## Adversarial verification (VISION dev-loop requirement)

Regressed `recap.py`'s default truncation `400 → 40` → `test_recap_preserves_critical_facts_at_shipped_defaults` went **RED** (`critical_loss=True`, fidelity 0.25, dropped `the_frame`/`antagonist_veyl`/`silverwatch_seal`); reverting restored **GREEN**. The guard genuinely tests recap content fidelity — not vacuous.

## Verification

- 9 passed + 1 skipped (the opt-in real-transcript test skips when the gitignored transcript is absent — the CI behavior), CI-style (`uv --directory servers/engine`).
- `license_check` ✓. Purely additive — no engine code touched (`recap.py` unchanged; the perturbation was reverted).

## Invariants

Additive, reads ground-truth (recap text vs grep patterns), engine sole-writer untouched, no wire change, Eva-safe. Explicitly **declined**: Option C (default dimension), the broad reference↔inventory convention, and an LLM inventory-derivation script — all speculative or score-gaming-risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new quality assurance test to validate recap content fidelity in the CI pipeline.

* **Documentation**
  * Updated QA scoring documentation with recap fidelity testing guidelines.

* **Chores**
  * Enhanced CI workflow with additional quality gate validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->