### PR TITLE
feat(godot): WorldView backdrop + renderer-owned walkmask + deterministic zone markers (#1053)

### DIFF
--- a/godot/autoload/RenderProfile.gd
+++ b/godot/autoload/RenderProfile.gd
@@ -1,0 +1,161 @@
+extends Node
+## RenderProfile — loads + parses the render-profile (core + the `godot` block).
+##
+## CONTRACT ROLE (mirrors the render-profile consumed by
+## viewer/openworlds/render/renderer-backdrop.js): the profile is the SOLE source
+## of art scope-keys, named zones, zone→screen anchors, the dimetric projection,
+## and per-actor sprite-sheet metadata. The engine never ships pixels or screen
+## coordinates — it ships LOCATION + ZONE names, and this profile maps those names
+## to presentation. (See ISO-PROJECTION.md: "Zone → screen placement is
+## data-driven from renderer_profiles.godot.backdrop_layout[scope].zone_anchors".)
+##
+## SLICE SOURCE (#1053): for now the profile is loaded from a bundled fixture
+## (res://fixtures/render-profile.json — a copy of
+## viewer/openworlds/render/render-profile.godot.example.json). A live engine /
+## per-game profile-injection path (window.WORLDOS_PROFILE-style) lands later; this
+## API does not change when it does.
+##
+## DEFAULTABLE BY DESIGN: every accessor returns a sane empty/default when the key
+## is absent, so a profile-less run (missing file, partial profile, unmapped
+## location) still renders — WorldView falls back to atlas zones + procedural
+## layout. Nothing here throws on a missing field.
+
+## Fallback default facing when the profile omits `renderer_profiles.godot.default_facing`.
+const DEFAULT_FACING := "S"
+## Default dimetric projection (matches the ISO-PROJECTION.md lock) when the
+## profile omits `renderer_profiles.godot.projection`.
+const DEFAULT_PROJECTION := {"kind": "dimetric", "tile_ratio": "2:1", "angle_deg": 26.57}
+
+const FIXTURE_PATH := "res://fixtures/render-profile.json"
+
+## The whole parsed profile document (or {} if none could be loaded).
+var _profile: Dictionary = {}
+
+
+func _ready() -> void:
+	_profile = _load_fixture()
+	var loc_count := 0
+	var core: Dictionary = _profile.get("core", {})
+	if typeof(core) == TYPE_DICTIONARY:
+		var locs: Variant = core.get("locations", [])
+		if typeof(locs) == TYPE_ARRAY:
+			loc_count = (locs as Array).size()
+	print("[RenderProfile] loaded=%s locations=%d" % [str(not _profile.is_empty()), loc_count])
+
+
+# ---------------------------------------------------------------------------
+# Core accessors (provider-agnostic part of the profile).
+# ---------------------------------------------------------------------------
+
+## Return the core location entry for an engine location id, as
+## {art:{scope_key}, zones:[...]} (the raw entry). Empty {} if absent — callers
+## then fall back to the atlas surface's own current_location/zones.
+func core_location(engine_location_id: String) -> Dictionary:
+	if engine_location_id == "":
+		return {}
+	var locs := _core_array("locations")
+	for entry in locs:
+		if typeof(entry) == TYPE_DICTIONARY and String(entry.get("engine_location_id", "")) == engine_location_id:
+			return entry
+	return {}
+
+
+## Convenience: the backdrop art scope-key for a location (e.g. "scene-lower-city"),
+## or "" if the location/art is unmapped.
+func core_location_scope(engine_location_id: String) -> String:
+	var loc := core_location(engine_location_id)
+	var art: Variant = loc.get("art", {})
+	if typeof(art) == TYPE_DICTIONARY:
+		return String((art as Dictionary).get("scope_key", ""))
+	return ""
+
+
+## Convenience: the named zones a location declares in the profile, or [] if absent.
+func core_location_zones(engine_location_id: String) -> Array:
+	var loc := core_location(engine_location_id)
+	var zones: Variant = loc.get("zones", [])
+	return zones if typeof(zones) == TYPE_ARRAY else []
+
+
+# ---------------------------------------------------------------------------
+# Godot renderer-profile accessors (renderer_profiles.godot.*).
+# ---------------------------------------------------------------------------
+
+## The per-backdrop layout block for an art scope-key:
+## {zone_anchors:{<zone>:[x,y]}, walk_polygon_ref, depth_baseline_y}. Empty {} if
+## the scope has no layout entry — WorldView then lays zones out procedurally and
+## uses a default depth baseline.
+func godot_backdrop_layout(scope_key: String) -> Dictionary:
+	if scope_key == "":
+		return {}
+	var layouts: Variant = _godot_block().get("backdrop_layout", {})
+	if typeof(layouts) != TYPE_DICTIONARY:
+		return {}
+	var entry: Variant = (layouts as Dictionary).get(scope_key, {})
+	return entry if typeof(entry) == TYPE_DICTIONARY else {}
+
+
+## The sprite-sheet metadata for an engine actor id (sheet_scope_key, facings,
+## facing_order, cols/rows, cell_w/h, anchor, ...). Empty {} if unmapped. Consumed
+## by #1054's CharacterToken — exposed here so the profile stays the single source.
+func godot_actor_sheet(engine_actor_id: String) -> Dictionary:
+	if engine_actor_id == "":
+		return {}
+	var sheets: Variant = _godot_block().get("actor_sheets", {})
+	if typeof(sheets) != TYPE_DICTIONARY:
+		return {}
+	var entry: Variant = (sheets as Dictionary).get(engine_actor_id, {})
+	return entry if typeof(entry) == TYPE_DICTIONARY else {}
+
+
+## The dimetric projection block (kind/tile_ratio/angle_deg). Falls back to the
+## ISO-PROJECTION.md lock if the profile omits it.
+func projection() -> Dictionary:
+	var proj: Variant = _godot_block().get("projection", {})
+	if typeof(proj) == TYPE_DICTIONARY and not (proj as Dictionary).is_empty():
+		return proj
+	return DEFAULT_PROJECTION.duplicate(true)
+
+
+## The default facing (rest/post-travel facing). Falls back to "S" (camera-facing).
+func default_facing() -> String:
+	var f: Variant = _godot_block().get("default_facing", "")
+	if typeof(f) == TYPE_STRING and String(f) != "":
+		return String(f)
+	return DEFAULT_FACING
+
+
+# ---------------------------------------------------------------------------
+# Internals.
+# ---------------------------------------------------------------------------
+
+## The renderer_profiles.godot block, or {} if absent.
+func _godot_block() -> Dictionary:
+	var profiles: Variant = _profile.get("renderer_profiles", {})
+	if typeof(profiles) != TYPE_DICTIONARY:
+		return {}
+	var godot: Variant = (profiles as Dictionary).get("godot", {})
+	return godot if typeof(godot) == TYPE_DICTIONARY else {}
+
+
+## A core sub-array (locations / actors), or [] if absent/malformed.
+func _core_array(key: String) -> Array:
+	var core: Variant = _profile.get("core", {})
+	if typeof(core) != TYPE_DICTIONARY:
+		return []
+	var arr: Variant = (core as Dictionary).get(key, [])
+	return arr if typeof(arr) == TYPE_ARRAY else []
+
+
+## Load + parse the bundled fixture. Returns {} on any missing/parse failure so a
+## profile-less run still renders.
+func _load_fixture() -> Dictionary:
+	if not FileAccess.file_exists(FIXTURE_PATH):
+		push_warning("[RenderProfile] missing fixture: " + FIXTURE_PATH)
+		return {}
+	var text := FileAccess.get_file_as_string(FIXTURE_PATH)
+	var parsed: Variant = JSON.parse_string(text)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		push_warning("[RenderProfile] unparseable fixture: " + FIXTURE_PATH)
+		return {}
+	return parsed

--- a/godot/autoload/RenderProfile.gd.uid
+++ b/godot/autoload/RenderProfile.gd.uid
@@ -1,0 +1,1 @@
+uid://ouskeei24oj4

--- a/godot/fixtures/render-profile.json
+++ b/godot/fixtures/render-profile.json
@@ -1,0 +1,55 @@
+{
+  "_comment": "Bundled render-profile fixture for the GT2 Godot renderer (#1053). A verbatim copy of viewer/openworlds/render/render-profile.godot.example.json so the renderer has a real core + `renderer_profiles.godot` block to consume standalone (backdrop scope `scene-lower-city`, zones, zone_anchors, projection). The `engine_location_id` (`loc-lower-city`) and its zones MATCH godot/fixtures/atlas-surface.json's `current_location`, so the data lines up out of the box. RenderProfile.gd is fully defaultable: a profile-less run still renders.",
+  "schema_version": 1,
+  "game_id": "bg-absolute-remnants-gt2-godot",
+  "title": "Baldur's Gate — Absolute Remnants (GT2 Godot painterly-isometric)",
+  "core": {
+    "scene_kind": "backdrop",
+    "positioning": "zone",
+    "locations": [
+      {
+        "engine_location_id": "loc-lower-city",
+        "art": { "scope_key": "scene-lower-city" },
+        "zones": ["the gate approach", "the market row", "the alley mouth"]
+      }
+    ],
+    "actors": [
+      { "engine_actor_id": "char-aubree", "art": { "scope_key": "portrait-aubree" } }
+    ],
+    "ai_disclosure": {
+      "generated_by": "worldos-ai-build-loop",
+      "model": "example",
+      "date": "2026-06-21"
+    }
+  },
+  "renderer_profiles": {
+    "godot": {
+      "projection": { "kind": "dimetric", "tile_ratio": "2:1", "angle_deg": 26.57 },
+      "default_facing": "S",
+      "backdrop_layout": {
+        "scene-lower-city": {
+          "walk_polygon_ref": "procedural",
+          "depth_baseline_y": 0.62,
+          "zone_anchors": {
+            "the gate approach": [0.5, 0.58],
+            "the market row": [0.34, 0.72],
+            "the alley mouth": [0.7, 0.8]
+          }
+        }
+      },
+      "actor_sheets": {
+        "char-aubree": {
+          "sheet_scope_key": "sprite-aubree-iso8",
+          "facings": 8,
+          "facing_order": ["S", "SE", "E", "NE", "N", "NW", "W", "SW"],
+          "frames_per_facing": 8,
+          "cols": 8,
+          "rows": 8,
+          "cell_w": 128,
+          "cell_h": 128,
+          "anchor": [64, 116]
+        }
+      }
+    }
+  }
+}

--- a/godot/project.godot
+++ b/godot/project.godot
@@ -20,9 +20,12 @@ config/features=PackedStringArray("4.6", "GL Compatibility")
 [autoload]
 
 ; Boot order matters: Config first (resolves base_url/campaign), then the
-; HTTP/transport singletons that read from it. All registered with a leading
-; "*" so they load as autoloaded singletons.
+; HTTP/transport singletons that read from it. RenderProfile loads the bundled
+; render-profile fixture (after Config so it can later read Config for a live
+; profile fetch). All registered with a leading "*" so they load as autoloaded
+; singletons.
 Config="*res://autoload/Config.gd"
+RenderProfile="*res://autoload/RenderProfile.gd"
 SurfaceClient="*res://autoload/SurfaceClient.gd"
 ImageResolver="*res://autoload/ImageResolver.gd"
 FacingResolver="*res://autoload/FacingResolver.gd"

--- a/godot/scenes/Hud.gd
+++ b/godot/scenes/Hud.gd
@@ -1,0 +1,86 @@
+extends CanvasLayer
+## Hud — read-only chrome OUTSIDE the world Y-sort (#1053).
+##
+## CONTRACT ROLE: a thin presentation overlay. It shows the transport mode
+## (LIVE/FIXTURE), the current location name, and a one-line party roster from
+## character.party — and NOTHING else. No interaction, no game state, no rules.
+## Living on a CanvasLayer keeps it above the Node2D world and excludes it from the
+## scene's Y-sort (it must never be depth-sorted with tokens).
+##
+## SCOPE (#1053): display only. Interactive chrome (click-to-travel exits, combat
+## initiative strip) is later work; this is the minimal readable status overlay.
+
+## Banner colors per transport mode (LIVE = healthy green-ish, FIXTURE = amber).
+const COLOR_LIVE := Color(0.53, 0.80, 0.53)
+const COLOR_FIXTURE := Color(0.80, 0.67, 0.40)
+const COLOR_NEUTRAL := Color(0.80, 0.88, 0.93)
+
+@onready var _mode_label: Label = $Panel/Mode
+@onready var _location_label: Label = $Panel/Location
+@onready var _party_label: Label = $Panel/Party
+
+var _mode: String = "?"
+var _location: String = "—"
+var _party_line: String = "—"
+
+
+func _ready() -> void:
+	_redraw()
+
+
+## Connected to SurfaceClient.transport_mode_changed by Main.
+func set_mode(mode: String) -> void:
+	_mode = mode
+	_redraw()
+
+
+## Connected to SurfaceClient.snapshot_updated by Main — pull the read-only display
+## facts (location name + party roster). Ignores all other surface fields.
+func apply_snapshot(atlas: Dictionary, _combat: Dictionary, character: Dictionary) -> void:
+	_location = _location_name(atlas)
+	_party_line = _party_roster(character)
+	_redraw()
+
+
+func _redraw() -> void:
+	if not is_instance_valid(_mode_label):
+		return
+	_mode_label.text = "transport: %s" % _mode
+	_mode_label.add_theme_color_override("font_color", _mode_color())
+	_location_label.text = "location: %s" % _location
+	_party_label.text = "party: %s" % _party_line
+
+
+func _mode_color() -> Color:
+	match _mode:
+		"LIVE":
+			return COLOR_LIVE
+		"FIXTURE":
+			return COLOR_FIXTURE
+		_:
+			return COLOR_NEUTRAL
+
+
+# ---------------------------------------------------------------------------
+# Read-only surface extraction (mirrors viewer/server.py surface shapes).
+# ---------------------------------------------------------------------------
+func _location_name(atlas: Dictionary) -> String:
+	var cur: Variant = atlas.get("current_location", null)
+	if typeof(cur) == TYPE_DICTIONARY and (cur as Dictionary).has("name"):
+		return String((cur as Dictionary)["name"])
+	if atlas.has("current_location_id"):
+		return String(atlas["current_location_id"])
+	return "—"
+
+
+func _party_roster(character: Dictionary) -> String:
+	var party: Variant = character.get("party", [])
+	if typeof(party) != TYPE_ARRAY:
+		return "—"
+	var names: PackedStringArray = PackedStringArray()
+	for member in party:
+		if typeof(member) == TYPE_DICTIONARY and (member as Dictionary).has("name"):
+			names.append(String((member as Dictionary)["name"]))
+	if names.is_empty():
+		return "<empty>"
+	return ", ".join(names)

--- a/godot/scenes/Hud.gd.uid
+++ b/godot/scenes/Hud.gd.uid
@@ -1,0 +1,1 @@
+uid://dickoep8up38a

--- a/godot/scenes/Hud.tscn
+++ b/godot/scenes/Hud.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=2 format=3 uid="uid://b1worldosgt2hud"]
+
+[ext_resource type="Script" path="res://scenes/Hud.gd" id="1_hud"]
+
+[node name="Hud" type="CanvasLayer"]
+script = ExtResource("1_hud")
+
+[node name="Panel" type="VBoxContainer" parent="."]
+offset_left = 16.0
+offset_top = 16.0
+offset_right = 616.0
+offset_bottom = 96.0
+
+[node name="Mode" type="Label" parent="Panel"]
+text = "transport: ?"
+
+[node name="Location" type="Label" parent="Panel"]
+text = "location: —"
+
+[node name="Party" type="Label" parent="Panel"]
+text = "party: —"

--- a/godot/scenes/Main.gd
+++ b/godot/scenes/Main.gd
@@ -1,44 +1,53 @@
 extends Node2D
-## Main — the #1052 boot smoke.
+## Main — the renderer root that wires the transport to the scene (#1053).
 ##
-## This is NOT the real scene graph (WorldView / CharacterToken / Y-sort /
-## click-to-move are #1053–#1055). Its only job is to prove the transport end to
-## end: connect to SurfaceClient, and on the FIRST snapshot print the current
-## location name, the party member names, and the transport mode. With no server
-## running, SurfaceClient falls back to bundled fixtures, so this smoke prints from
-## res://fixtures/* and exits cleanly.
+## ROLE: the composition root. It instances WorldView (the snapshot→scene
+## projection) + Hud (read-only chrome) and connects them to the SINGLE transport
+## boundary, SurfaceClient:
+##   - snapshot_updated  → WorldView.apply_snapshot + Hud.apply_snapshot
+##   - transport_mode_changed → Hud.set_mode
+##   - events_appended   → WorldView.enqueue_replay (a #1055/combat stub today)
+##
+## It owns NO game state and contains NO rules — it only routes signals. The
+## headless boot smoke (location + party + mode prints, then a clean quit) is
+## preserved here so CI / --headless validation stays observable end-to-end:
+## with no server running, SurfaceClient falls back to res://fixtures/* (FIXTURE
+## mode) and the scene projects those.
 
-@onready var _label: Label = $UI/SmokeLabel
+@onready var _world: Node2D = $WorldView
+@onready var _hud: CanvasLayer = $Hud
 
 var _got_first_snapshot: bool = false
 var _last_mode: String = "?"
 
 
 func _ready() -> void:
+	# Wire the transport → scene. WorldView projects the snapshot into the world;
+	# Hud mirrors the read-only display facts; replay is a stub for now.
 	SurfaceClient.transport_mode_changed.connect(_on_mode_changed)
 	SurfaceClient.snapshot_updated.connect(_on_snapshot)
+	SurfaceClient.snapshot_updated.connect(_world.apply_snapshot)
+	SurfaceClient.snapshot_updated.connect(_hud.apply_snapshot)
 	SurfaceClient.events_appended.connect(_on_events)
-	_set_label("WorldOS GT2 (Godot) — connecting…")
+	SurfaceClient.events_appended.connect(_world.enqueue_replay)
 
 
 func _on_mode_changed(mode: String) -> void:
 	_last_mode = mode
+	_hud.set_mode(mode)
 
 
 func _on_snapshot(atlas: Dictionary, _combat: Dictionary, character: Dictionary) -> void:
-	# Extract the smoke facts from the read-only surfaces (no client-side rules).
+	# Headless smoke: keep printing the transport facts (location + party + mode) so
+	# validation stays observable. The WorldView prints the projection facts itself
+	# (location, zone-marker count, backdrop status) in its own apply_snapshot.
 	var location_name := _location_name(atlas)
 	var party_names := _party_names(character)
 	var mode := SurfaceClient.mode()
 	if mode == "":
 		mode = _last_mode
-
 	var party_joined := ", ".join(party_names) if not party_names.is_empty() else "<empty>"
-	var line := "[%s] location=%s | party=%s" % [mode, location_name, party_joined]
-
-	# TRANSPORT SMOKE PROOF.
-	print("[Main] SMOKE ", line)
-	_set_label("WorldOS GT2 (Godot)\n%s\nlocation: %s\nparty: %s" % [mode, location_name, party_joined])
+	print("[Main] SMOKE [%s] location=%s | party=%s" % [mode, location_name, party_joined])
 
 	if not _got_first_snapshot:
 		_got_first_snapshot = true
@@ -54,8 +63,8 @@ func _on_events(records: Array) -> void:
 # ---------------------------------------------------------------------------
 func _location_name(atlas: Dictionary) -> String:
 	var cur: Variant = atlas.get("current_location", null)
-	if typeof(cur) == TYPE_DICTIONARY and cur.has("name"):
-		return String(cur["name"])
+	if typeof(cur) == TYPE_DICTIONARY and (cur as Dictionary).has("name"):
+		return String((cur as Dictionary)["name"])
 	if atlas.has("current_location_id"):
 		return String(atlas["current_location_id"])
 	return "<unknown>"
@@ -67,8 +76,8 @@ func _party_names(character: Dictionary) -> PackedStringArray:
 	if typeof(party) != TYPE_ARRAY:
 		return out
 	for member in party:
-		if typeof(member) == TYPE_DICTIONARY and member.has("name"):
-			out.append(String(member["name"]))
+		if typeof(member) == TYPE_DICTIONARY and (member as Dictionary).has("name"):
+			out.append(String((member as Dictionary)["name"]))
 	return out
 
 
@@ -80,15 +89,10 @@ func _maybe_quit() -> void:
 	var smoke_flag := OS.get_cmdline_user_args().has("--smoke")
 	var headless := DisplayServer.get_name() == "headless"
 	if smoke_flag or headless:
-		# Defer the quit one frame so the print/label flush before teardown.
+		# Defer the quit one frame so the prints flush before teardown.
 		call_deferred("_quit_clean")
 
 
 func _quit_clean() -> void:
 	print("[Main] smoke complete — quitting cleanly")
 	get_tree().quit()
-
-
-func _set_label(text: String) -> void:
-	if is_instance_valid(_label):
-		_label.text = text

--- a/godot/scenes/Main.tscn
+++ b/godot/scenes/Main.tscn
@@ -1,15 +1,12 @@
-[gd_scene load_steps=2 format=3 uid="uid://b1worldosgt2main"]
+[gd_scene load_steps=4 format=3 uid="uid://b1worldosgt2main"]
 
 [ext_resource type="Script" path="res://scenes/Main.gd" id="1_main"]
+[ext_resource type="PackedScene" path="res://scenes/WorldView.tscn" id="2_worldview"]
+[ext_resource type="PackedScene" path="res://scenes/Hud.tscn" id="3_hud"]
 
 [node name="Main" type="Node2D"]
 script = ExtResource("1_main")
 
-[node name="UI" type="CanvasLayer" parent="."]
+[node name="WorldView" parent="." instance=ExtResource("2_worldview")]
 
-[node name="SmokeLabel" type="Label" parent="UI"]
-offset_left = 16.0
-offset_top = 16.0
-offset_right = 616.0
-offset_bottom = 136.0
-text = "WorldOS GT2 (Godot) — booting…"
+[node name="Hud" parent="." instance=ExtResource("3_hud")]

--- a/godot/scenes/WorldView.gd
+++ b/godot/scenes/WorldView.gd
@@ -1,0 +1,400 @@
+extends Node2D
+## WorldView — the snapshot → scene projection (#1053).
+##
+## CONTRACT ROLE (mirrors viewer/openworlds/render/renderer-backdrop.js): a PURE
+## projection of ONE snapshot. Every tick it rebuilds the visible scene from the
+## read-only surfaces; it owns ZERO game state and persists nothing across ticks.
+## It IGNORES every surface `position.x/y` — all screen positions are DERIVED from
+## named ZONES via the render-profile's zone_anchors (or a deterministic procedural
+## fallback). This keeps the engine the sole writer of WHERE things are (zones),
+## and the renderer the sole owner of HOW that maps to pixels (the walkmask + the
+## projection — see ISO-PROJECTION.md and #444 walkmask-is-renderer-owned).
+##
+## SCOPE (#1053): backdrop + walkmask floor polygon + deterministic zone markers
+## ONLY. CharacterToken / sprite art is #1054 (it will populate the empty
+## YSortLayer created here); click-to-move / facing / Y-sort occlusion is #1055.
+##
+## NODE TREE (built in _ready):
+##   WorldView (Node2D)
+##   ├─ BackdropPlane (Sprite2D, z=-100, not y-sorted) — painted location art or a
+##   │                                                    procedural gradient fallback.
+##   ├─ WalkmaskLayer (Node2D, z=-50)
+##   │   ├─ FloorPolygon (Polygon2D) — the procedural perspective trapezoid (the
+##   │   │                             clickable walkable region in #1055).
+##   │   └─ ZoneMarkers (Node2D)      — one Marker2D + faint Label per named zone,
+##   │                                  laid out DETERMINISTICALLY.
+##   └─ YSortLayer (Node2D, y_sort_enabled) — EMPTY now; CharacterToken lands here (#1054).
+
+## Backdrop trapezoid geometry — mirrors renderer-backdrop.js floorPolygon():
+## the floor is inset at the horizon (narrow/far) and near-full-width at the bottom
+## (wide/near), reading as a dimetric stage. These are the same proportions as the
+## reference renderer (inset 0.22 of width; ~horizonY of height for the back edge).
+const FLOOR_INSET_FRAC := 0.22       ## horizontal inset of the back (far) edge
+const FLOOR_FRONT_MARGIN := 8.0      ## px margin so the front edge isn't flush to the viewport edge
+## Default depth baseline (fraction of viewport height where the floor's back edge
+## sits) when the profile omits `depth_baseline_y`. Matches renderer-backdrop.js
+## DEFAULT_HORIZON ≈ 0.45 used for the floor's top edge.
+const DEFAULT_DEPTH_BASELINE := 0.45
+## Deterministic depth bands zones step back→front along, mirroring
+## renderer-backdrop.js DEFAULT_DEPTH_BANDS. Used ONLY for the procedural fallback
+## (when the profile has no zone_anchors). Fractions of viewport height.
+const PROCEDURAL_DEPTH_BANDS := [0.55, 0.7, 0.85]
+
+## Cosmetic colors (kept faint — this is a presentation underlay, not chrome).
+const FLOOR_FILL := Color(0.23, 0.27, 0.345, 0.16)
+const FLOOR_OUTLINE := Color(0.56, 0.71, 0.85, 0.20)
+const ZONE_RING := Color(0.62, 0.71, 0.80, 0.30)
+const ZONE_LABEL := Color(0.68, 0.75, 0.81, 0.85)
+
+@onready var _backdrop: Sprite2D = $BackdropPlane
+@onready var _floor_poly: Polygon2D = $WalkmaskLayer/FloorPolygon
+@onready var _zone_markers: Node2D = $WalkmaskLayer/ZoneMarkers
+## Bound (though unused in #1053) to assert the empty YSortLayer exists — it is the
+## home CharacterToken lands in for #1054. Do not remove the node.
+@onready var _ysort: Node2D = $YSortLayer
+
+## Last-resolved facts, exposed for #1054/#1055.
+var _location_id: String = ""
+var _location_name: String = "<unknown>"
+var _zone_count: int = 0
+## zone name -> screen Vector2 (the deterministic anchor), for #1054 token placement
+## and #1055 click→zone snapping. Rebuilt every apply_snapshot.
+var _zone_screen: Dictionary = {}
+
+## The art scope we last asked the ImageResolver for, so the texture_ready signal
+## only swaps the backdrop when it is still the current location's art.
+var _pending_backdrop_scope: String = ""
+## True when the BackdropPlane currently shows a real resolved /image texture;
+## false when it shows the procedural gradient fallback. (For the diagnostic.)
+var _backdrop_is_resolved: bool = false
+
+
+func _ready() -> void:
+	# Art arrives asynchronously through the /image bridge; swap the backdrop the
+	# moment its scope resolves (if it is still the one we want).
+	ImageResolver.texture_ready.connect(_on_texture_ready)
+	# Draw an initial procedural backdrop so there is never an empty frame before
+	# the first snapshot lands.
+	_apply_procedural_backdrop()
+
+
+# ---------------------------------------------------------------------------
+# The one entry point: project a snapshot into the scene. Connected to
+# SurfaceClient.snapshot_updated by Main. Rebuilds deterministically by diff so no
+# nodes leak across ticks. IGNORES any position.x/y on the surfaces.
+# ---------------------------------------------------------------------------
+func apply_snapshot(atlas: Dictionary, combat: Dictionary, character: Dictionary) -> void:
+	var in_combat := bool(combat.get("active", false))
+
+	# --- current location (id + display name) from the read-only atlas ---
+	_location_id = _resolve_location_id(atlas)
+	_location_name = _resolve_location_name(atlas)
+
+	# --- backdrop: prefer profile art scope for this location, else atlas-implied ---
+	var scope := RenderProfile.core_location_scope(_location_id)
+	_swap_backdrop(scope)
+
+	# --- floor trapezoid (the walkmask), sized from the viewport + profile baseline ---
+	var vp := _viewport_size()
+	var baseline := _depth_baseline(scope)
+	_rebuild_floor(vp, baseline)
+
+	# --- deterministic zone markers ---
+	var zones := _current_zones(atlas, combat, in_combat)
+	_rebuild_zone_markers(zones, scope, vp, baseline)
+	_zone_count = zones.size()
+
+	# DIAGNOSTIC (validation proof): location, zone-marker count, backdrop status.
+	# Reports the RESOLVED art scope only when a real /image texture is in use;
+	# otherwise "fallback" (the procedural gradient — also the standalone case
+	# where the scope is mapped but no live engine serves the art).
+	var backdrop_status := "fallback"
+	if _backdrop_is_resolved and scope != "":
+		backdrop_status = scope
+	print("[WorldView] location=%s zones=%d markers placed; backdrop=%s" % [
+		_location_name, _zone_count, backdrop_status])
+
+
+# ---------------------------------------------------------------------------
+# Replay stub (#1055 / combat). Connected to SurfaceClient.events_appended by
+# Main. Real Action-Replay (combat token motion + facing from target_fk) is a
+# later issue — for now we accept and ignore so the signal interface is wired.
+# ---------------------------------------------------------------------------
+func enqueue_replay(records: Array) -> void:
+	# Intentionally a no-op for #1053. Kept so events_appended has a destination and
+	# the wiring is verifiable now (the count print stays in Main).
+	pass
+
+
+# ---------------------------------------------------------------------------
+# Public accessors for later issues / validation.
+# ---------------------------------------------------------------------------
+func current_location_name() -> String:
+	return _location_name
+
+
+func zone_marker_count() -> int:
+	return _zone_count
+
+
+## Screen position of a named zone's anchor (Vector2.ZERO if unknown). #1054 places
+## tokens here; #1055 snaps a floor click to the nearest of these.
+func zone_screen_pos(zone_name: String) -> Vector2:
+	return _zone_screen.get(zone_name, Vector2.ZERO)
+
+
+# ---------------------------------------------------------------------------
+# Backdrop.
+# ---------------------------------------------------------------------------
+
+## Ask the resolver for `scope`'s texture; if cached, swap now; if missing/empty,
+## draw the procedural gradient fallback so there is ALWAYS a backdrop.
+func _swap_backdrop(scope: String) -> void:
+	_pending_backdrop_scope = scope
+	if scope == "":
+		_apply_procedural_backdrop()
+		return
+	var cached := ImageResolver.get_cached(scope)
+	if cached != null:
+		_apply_texture_backdrop(cached)
+		return
+	if ImageResolver.is_missing(scope):
+		# Definitively absent (404) — commit to the procedural fallback.
+		_apply_procedural_backdrop()
+		return
+	# Untried/loading: show the fallback now; _on_texture_ready swaps it in later.
+	_apply_procedural_backdrop()
+	ImageResolver.resolve(scope)
+
+
+func _on_texture_ready(scope: String, texture: Texture2D) -> void:
+	# Only swap if this is still the location we want (the snapshot may have moved on).
+	if scope == _pending_backdrop_scope and texture != null:
+		_apply_texture_backdrop(texture)
+
+
+## Put a real texture on the BackdropPlane and scale/center it to fill the viewport.
+func _apply_texture_backdrop(texture: Texture2D) -> void:
+	_backdrop_is_resolved = true
+	_backdrop.texture = texture
+	_backdrop.centered = true
+	var vp := _viewport_size()
+	_backdrop.position = vp * 0.5
+	var tex_size := texture.get_size()
+	if tex_size.x > 0.0 and tex_size.y > 0.0:
+		# Fill (cover) the viewport: scale up to the larger axis ratio.
+		var sx := vp.x / tex_size.x
+		var sy := vp.y / tex_size.y
+		var s := maxf(sx, sy)
+		_backdrop.scale = Vector2(s, s)
+
+
+## Procedural painted-ish fallback backdrop: a vertical sky→ground GradientTexture2D
+## (mirrors renderer-backdrop.js _renderBackdrop's gradient path) so a missing/404
+## art scope still yields a coherent stage. Deterministic — no randomness.
+func _apply_procedural_backdrop() -> void:
+	_backdrop_is_resolved = false
+	var vp := _viewport_size()
+	var grad := Gradient.new()
+	# Deep dusk-blue sky (top) → dusk slate (horizon) → dark foreground (bottom),
+	# offsets roughly matching the reference sky/ground split at ~0.45.
+	grad.offsets = PackedFloat32Array([0.0, 0.42, 0.46, 1.0])
+	grad.colors = PackedColorArray([
+		Color(0.102, 0.153, 0.251),  # 0x1a2740 deep sky
+		Color(0.278, 0.314, 0.416),  # 0x47506a dusk horizon
+		Color(0.173, 0.165, 0.133),  # 0x2c2a22 lit ground band
+		Color(0.078, 0.086, 0.059),  # 0x14160f dark foreground
+	])
+	var tex := GradientTexture2D.new()
+	tex.gradient = grad
+	tex.fill = GradientTexture2D.FILL_LINEAR
+	tex.fill_from = Vector2(0.5, 0.0)  # top
+	tex.fill_to = Vector2(0.5, 1.0)    # bottom (vertical)
+	tex.width = maxi(int(vp.x), 1)
+	tex.height = maxi(int(vp.y), 1)
+	_backdrop.texture = tex
+	_backdrop.centered = true
+	_backdrop.position = vp * 0.5
+	_backdrop.scale = Vector2.ONE
+
+
+# ---------------------------------------------------------------------------
+# Walkmask floor polygon (the perspective trapezoid). Mirrors renderer-backdrop.js
+# floorPolygon(): narrow/inset at the back (far) edge, near-full-width at the front
+# (near) edge. The back edge sits at `baseline` (fraction of height); the front
+# edge is a small margin off the bottom. This is the walkable region (#1055 mask).
+# ---------------------------------------------------------------------------
+func _rebuild_floor(vp: Vector2, baseline: float) -> void:
+	var top := vp.y * baseline
+	var inset := vp.x * FLOOR_INSET_FRAC
+	# Quad corners in screen space, clockwise from back-left.
+	var pts := PackedVector2Array([
+		Vector2(inset, top),                                   # back-left  (far)
+		Vector2(vp.x - inset, top),                            # back-right (far)
+		Vector2(vp.x - FLOOR_FRONT_MARGIN, vp.y - FLOOR_FRONT_MARGIN),  # front-right (near)
+		Vector2(FLOOR_FRONT_MARGIN, vp.y - FLOOR_FRONT_MARGIN),         # front-left  (near)
+	])
+	_floor_poly.polygon = pts
+	_floor_poly.color = FLOOR_FILL
+
+
+# ---------------------------------------------------------------------------
+# Deterministic zone markers. Rebuilt by diff each tick (no node leaks, no
+# randomness/jitter between ticks). Placement precedence:
+#   1. profile backdrop_layout[scope].zone_anchors{<zone>:[x,y]} (normalized 0..1) →
+#      multiply by the viewport. This is the AUTHORED, projection-correct anchor.
+#   2. ELSE spread zones evenly across the floor trapezoid by a STABLE function of
+#      their sorted index (mirrors renderer-backdrop.js zoneMarker(): step back→front
+#      along depth bands, x-spread shrinks toward the horizon for perspective).
+# ---------------------------------------------------------------------------
+func _rebuild_zone_markers(zones: Array, scope: String, vp: Vector2, baseline: float) -> void:
+	# Clear previous tick's markers (diff = full rebuild; the set is tiny and the
+	# layout is a pure function of the inputs, so a clean rebuild can't leak/drift).
+	for child in _zone_markers.get_children():
+		child.queue_free()
+	_zone_screen.clear()
+
+	var layout := RenderProfile.godot_backdrop_layout(scope)
+	var anchors: Dictionary = layout.get("zone_anchors", {}) if typeof(layout.get("zone_anchors", {})) == TYPE_DICTIONARY else {}
+
+	# Stable ordering: sort by name so the procedural index is deterministic across
+	# ticks regardless of surface array order.
+	var names: Array = []
+	for z in zones:
+		var zn := _zone_name(z)
+		if zn != "":
+			names.append(zn)
+	names.sort()
+
+	var count := names.size()
+	for i in range(count):
+		var zn: String = names[i]
+		var pos: Vector2
+		if anchors.has(zn) and _is_xy(anchors[zn]):
+			# (1) authored anchor — normalized [x,y] of the backdrop → screen px.
+			var a: Array = anchors[zn]
+			pos = Vector2(float(a[0]) * vp.x, float(a[1]) * vp.y)
+		else:
+			# (2) procedural fallback — deterministic by sorted index.
+			pos = _procedural_zone_pos(i, count, vp, baseline)
+		_zone_screen[zn] = pos
+
+		var marker := Marker2D.new()
+		marker.name = "Zone_%d" % i
+		marker.position = pos
+		var label := Label.new()
+		label.text = zn
+		label.add_theme_color_override("font_color", ZONE_LABEL)
+		# Offset the label up-left of the anchor so it reads above the foot point.
+		label.position = Vector2(-40.0, -26.0)
+		marker.add_child(label)
+		_zone_markers.add_child(marker)
+
+
+## Deterministic procedural zone screen-position by sorted index, mirroring
+## renderer-backdrop.js zoneMarker(): zones step back→front along depth bands, and
+## the horizontal spread widens toward the front (perspective). `baseline` is the
+## floor's back-edge fraction (= "horizonY" in the reference).
+func _procedural_zone_pos(index: int, count: int, vp: Vector2, baseline: float) -> Vector2:
+	var band: float = PROCEDURAL_DEPTH_BANDS[index % PROCEDURAL_DEPTH_BANDS.size()]
+	var y := vp.y * band
+	# Horizontal position t in [0,1] across the zones, centered when only one.
+	var t := float(index) / float(count - 1) if count > 1 else 0.5
+	# Depth t: 0 at the floor's back edge (baseline), 1 at the front (bottom).
+	var span := maxf(vp.y - vp.y * baseline, 1.0)
+	var depth_t := clampf((y - vp.y * baseline) / span, 0.0, 1.0)
+	# Half-width of the spread grows with depth (wider near the camera).
+	var half_w := (0.30 + 0.18 * depth_t) * vp.x
+	var x := vp.x * 0.5 + (t - 0.5) * 2.0 * half_w
+	return Vector2(x, y)
+
+
+# ---------------------------------------------------------------------------
+# Read-only surface extraction (shapes mirror viewer/server.py surfaces). The
+# renderer derives EVERYTHING from names — never from any position.x/y field.
+# ---------------------------------------------------------------------------
+
+## Zone source: combat → combat.zones[]; exploration → atlas current_location zones,
+## else the RenderProfile core location zones, else a sane 3-zone default so the
+## stage is never empty.
+func _current_zones(atlas: Dictionary, combat: Dictionary, in_combat: bool) -> Array:
+	if in_combat:
+		var cz: Variant = combat.get("zones", [])
+		if typeof(cz) == TYPE_ARRAY and not (cz as Array).is_empty():
+			return cz
+	# Exploration: prefer the atlas's own zones for the current location.
+	var az: Variant = atlas.get("zones", [])
+	if typeof(az) == TYPE_ARRAY and not (az as Array).is_empty():
+		return az
+	# Else the render-profile's declared zones for this location.
+	var pz := RenderProfile.core_location_zones(_location_id)
+	if not pz.is_empty():
+		return pz
+	return ["the foreground", "the mid-ground", "the rear"]
+
+
+func _resolve_location_id(atlas: Dictionary) -> String:
+	var cur: Variant = atlas.get("current_location", null)
+	if typeof(cur) == TYPE_DICTIONARY:
+		var c: Dictionary = cur
+		if c.has("id"):
+			return String(c["id"])
+		if c.has("engine_location_id"):
+			return String(c["engine_location_id"])
+	if atlas.has("current_location_id"):
+		return String(atlas["current_location_id"])
+	return ""
+
+
+func _resolve_location_name(atlas: Dictionary) -> String:
+	var cur: Variant = atlas.get("current_location", null)
+	if typeof(cur) == TYPE_DICTIONARY and (cur as Dictionary).has("name"):
+		return String((cur as Dictionary)["name"])
+	if atlas.has("current_location_id"):
+		return String(atlas["current_location_id"])
+	return "<unknown>"
+
+
+## Normalize a zone entry (string OR {name:...}) to its name; "" if neither.
+func _zone_name(z: Variant) -> String:
+	if typeof(z) == TYPE_STRING:
+		return String(z)
+	if typeof(z) == TYPE_DICTIONARY and (z as Dictionary).has("name"):
+		return String((z as Dictionary)["name"])
+	return ""
+
+
+## True if v is a [x,y]-shaped array of two numbers.
+func _is_xy(v: Variant) -> bool:
+	if typeof(v) != TYPE_ARRAY:
+		return false
+	var a: Array = v
+	if a.size() < 2:
+		return false
+	var t0 := typeof(a[0])
+	var t1 := typeof(a[1])
+	return (t0 == TYPE_FLOAT or t0 == TYPE_INT) and (t1 == TYPE_FLOAT or t1 == TYPE_INT)
+
+
+## The floor's back-edge depth baseline (fraction of viewport height) for a
+## backdrop scope: the profile's `depth_baseline_y` if present, else the default.
+func _depth_baseline(scope: String) -> float:
+	var layout := RenderProfile.godot_backdrop_layout(scope)
+	var v: Variant = layout.get("depth_baseline_y", null)
+	if typeof(v) == TYPE_FLOAT or typeof(v) == TYPE_INT:
+		return clampf(float(v), 0.05, 0.95)
+	return DEFAULT_DEPTH_BASELINE
+
+
+## Current viewport size (px). Falls back to the project's window size if the
+## viewport isn't ready (e.g. very early headless boot).
+func _viewport_size() -> Vector2:
+	var vp := get_viewport()
+	if vp != null:
+		var r := vp.get_visible_rect().size
+		if r.x > 0.0 and r.y > 0.0:
+			return r
+	# Project default window size (headless: a sane non-zero stage).
+	return Vector2(
+		float(ProjectSettings.get_setting("display/window/size/viewport_width", 1152)),
+		float(ProjectSettings.get_setting("display/window/size/viewport_height", 648)))

--- a/godot/scenes/WorldView.gd.uid
+++ b/godot/scenes/WorldView.gd.uid
@@ -1,0 +1,1 @@
+uid://bccg26mr1cvby

--- a/godot/scenes/WorldView.tscn
+++ b/godot/scenes/WorldView.tscn
@@ -1,0 +1,21 @@
+[gd_scene load_steps=2 format=3 uid="uid://b1worldosgt2worldview"]
+
+[ext_resource type="Script" path="res://scenes/WorldView.gd" id="1_worldview"]
+
+[node name="WorldView" type="Node2D"]
+script = ExtResource("1_worldview")
+
+[node name="BackdropPlane" type="Sprite2D" parent="."]
+z_index = -100
+centered = true
+
+[node name="WalkmaskLayer" type="Node2D" parent="."]
+z_index = -50
+
+[node name="FloorPolygon" type="Polygon2D" parent="WalkmaskLayer"]
+color = Color(0.23, 0.27, 0.345, 0.16)
+
+[node name="ZoneMarkers" type="Node2D" parent="WalkmaskLayer"]
+
+[node name="YSortLayer" type="Node2D" parent="."]
+y_sort_enabled = true


### PR DESCRIPTION
Closes #1053. Sprint 1 of the GT2 Godot renderer (epic #1050); follows #1052.

## What
`WorldView` — the snapshot→scene projection. Pure projection rebuilt each tick; **ignores every surface `position.x/y`**, derives all positions from named **zones**.

- **`RenderProfile.gd`** (autoload) — parses a render-profile (core + the `godot` block); defaultable accessors. Loads `res://fixtures/render-profile.json`.
- **`WorldView.{tscn,gd}`** — `BackdropPlane` (z=-100; `/image?scope=` via `ImageResolver`, procedural gradient fallback) + `WalkmaskLayer` (perspective-trapezoid `FloorPolygon` mirroring `renderer-backdrop.js` + deterministic `ZoneMarkers` from `zone_anchors` else a stable spread) + an **empty `YSortLayer`** (the #1054 home). Exploration zones from atlas; combat from `combat.zones[]`.
- **`Hud.{tscn,gd}`** — LIVE/FIXTURE banner + location + party roster.
- **`Main`** rewired to route `SurfaceClient` signals into `WorldView` + `Hud`.

## Validation (local Godot 4.6.3 — the gate until the #1056 CI lane)
- `--headless --import` → exit 0, no script/parse errors.
- headless smoke (fixture fallback) → `[WorldView] location=Baldur's Gate — Lower City zones=3 markers placed; backdrop=fallback`, no errors/leaks.

Invariants: thin client, zero state; ignores surface x/y; renderer-owned walkmask. Next: #1054 (directional CharacterToken + sprite-sheet manifest v1 + CC0 scaffold art) lands in `YSortLayer`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added HUD overlay displaying current transport mode, active location name, and party roster information in a dedicated interface layer
- Introduced visual rendering system featuring game backdrops with fallback display, procedural walkmask floor visualization, and automatic zone marker positioning based on render profile data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->