### PR TITLE
test(qa): wire 16 dead-weight qa tests into CI (+ fix 4 import conventions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,23 @@ jobs:
             ../../qa/test_story_readout_approval.py \
             ../../qa/test_feature_engagement.py \
             ../../qa/test_fact_fidelity.py \
-            ../../qa/test_recap_fidelity.py
+            ../../qa/test_recap_fidelity.py \
+            ../../qa/test_assert_behavioral.py \
+            ../../qa/test_distill.py \
+            ../../qa/test_story_readout_coverage.py \
+            ../../qa/test_story_readout_outcome.py \
+            ../../qa/test_story_readout_timing.py \
+            ../../qa/test_latency_rollup.py \
+            ../../qa/test_stream_tailer.py \
+            ../../qa/test_collect_findings.py \
+            ../../qa/test_dm_beat_mark.py \
+            ../../qa/test_export_app_evidence.py \
+            ../../qa/test_macos_app_static.py \
+            ../../qa/test_ui_playtest_app_buckets.py \
+            ../../qa/test_app_failure_buckets.py \
+            ../../qa/test_app_handoff_gate.py \
+            ../../qa/test_app_smoke_scripted.py \
+            ../../qa/test_support_vm_preflight.py
 
   server-contracts:
     # Phase-1 (DETERMINISTIC-2): deterministic cross-service MCP contract tests

--- a/qa/test_app_failure_buckets.py
+++ b/qa/test_app_failure_buckets.py
@@ -1,8 +1,13 @@
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-from qa.app_failure_buckets import (
+QA_DIR = Path(__file__).resolve().parent
+if str(QA_DIR) not in sys.path:
+    sys.path.insert(0, str(QA_DIR))
+
+from app_failure_buckets import (
     APP_FAILURE_BUCKETS,
     classify_browser_probe,
     classify_native_failure,

--- a/qa/test_app_handoff_gate.py
+++ b/qa/test_app_handoff_gate.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-from qa import app_handoff_gate as gate
+QA_DIR = Path(__file__).resolve().parent
+if str(QA_DIR) not in sys.path:
+    sys.path.insert(0, str(QA_DIR))
+
+import app_handoff_gate as gate
 
 
 class AppHandoffGateTests(unittest.TestCase):

--- a/qa/test_app_smoke_scripted.py
+++ b/qa/test_app_smoke_scripted.py
@@ -1,9 +1,14 @@
 import json
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
-from qa import app_smoke_scripted as smoke
+QA_DIR = Path(__file__).resolve().parent
+if str(QA_DIR) not in sys.path:
+    sys.path.insert(0, str(QA_DIR))
+
+import app_smoke_scripted as smoke
 
 
 class AppSmokeScriptedTests(unittest.TestCase):

--- a/qa/test_support_vm_preflight.py
+++ b/qa/test_support_vm_preflight.py
@@ -1,11 +1,16 @@
 import json
 import os
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest import mock
 
-import qa.support_vm_preflight as preflight
+QA_DIR = Path(__file__).resolve().parent
+if str(QA_DIR) not in sys.path:
+    sys.path.insert(0, str(QA_DIR))
+
+import support_vm_preflight as preflight
 
 
 class FakeRunner:


### PR DESCRIPTION
## Why

After [#1068](https://github.com/electricsheephq/WorldOS/pull/1068) found `test_fact_fidelity.py` ran in no CI lane, I swept **all** `qa/test_*.py` against every workflow + runner. `qa/` is an **explicit allowlist** (unlike `servers/engine/tests`, which CI auto-discovers via `testpaths`), so anything unlisted runs **nowhere** — the written-but-never-read pathology, at scale.

**16 `qa/test_*.py` files were invoked by no CI job and no runner**, including:
- **`test_assert_behavioral` (57 tests)** — the unit suite for the behavioral gate itself, the most load-bearing deterministic floor.
- **`test_distill`** — the lossy transcript transform that feeds the scorer.
- **`test_story_readout_{coverage,outcome,timing}`** — story_readout feeds the gate's structural-coverage; only `approval` was wired.
- latency_rollup, stream_tailer (the live DM-beat sidecar), collect_findings, dm_beat_mark, export_app_evidence, macos_app_static, ui_playtest_app_buckets, and the 4 app/VM tests below.

## What

- **12 passed clean** (189 tests, no env) → wired into the qa allowlist as-is.
- **4 errored on collection** (`No module named 'qa'`) — a package-style `from qa import X` vs the repo's standard `sys.path.insert(QA_DIR)` + bare-import convention (the 14 working qa tests). Refactored those 4 to the convention → 65 passed. The underlying modules self-insert repo-root for their own `qa.*` imports (left untouched — working code).
- `ci.yml`: all 16 added to the existing QA pytest allowlist.

## Verification

- All 16 green together under the **exact CI invocation** (`uv run --directory servers/engine --group dev python -m pytest …`): **254 passed, 3 subtests, 4.5s**.
- `ci.yml` parses as valid YAML; `license_check` ✓.
- Purely additive: only `ci.yml` + the 4 import-fixed test files. No engine/product code touched; no committed-state churn.

## Notes

These were all **passing** tests (no rot) — so this is pure coverage recovery, not bug-hunting. Engine/rules/voice/viewer/integration suites are unaffected (auto-discovered, already run). No deletions: each guards a distinct, real QA module; none were redundant enough to drop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded QA test coverage in continuous integration pipeline

* **Chores**
  * Updated test infrastructure for improved execution flexibility and import handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->