### PR TITLE
feat(godot): click-to-move + FacingResolver + Y-sort occlusion — VERTICAL SLICE (#1055)

### DIFF
--- a/godot/scenes/FxLayer.gd
+++ b/godot/scenes/FxLayer.gd
@@ -1,0 +1,68 @@
+extends Node2D
+class_name FxLayer
+## FxLayer — transient, self-freeing click feedback above the world (#1055).
+##
+## CONTRACT ROLE: PURE presentation. It owns ZERO game state and never asserts a
+## world position. Its only job is the OPTIMISTIC click ping: a brief expanding
+## ring + flash at the click point, drawn on its own high z-index so it floats over
+## the Y-sorted actors. The ping is feedback ONLY — it does NOT move any token. The
+## engine owns the destination (the next authoritative snapshot moves the token);
+## the renderer owns the path/feedback.
+##
+## Every ping is a transient node that tweens then queue_free()s itself, so the
+## layer never accumulates nodes across clicks (no leaks).
+
+## Draw above the world (YSortLayer actors sit at the default z=0..; the backdrop is
+## z=-100). A high z keeps the ping visually on top regardless of foot-y.
+const FX_Z_INDEX := 1000
+
+## Ping look + timing (deterministic — no randomness).
+const PING_DURATION_SEC := 0.45
+const PING_START_RADIUS := 6.0
+const PING_END_RADIUS := 30.0
+const PING_COLOR := Color(0.78, 0.90, 1.0, 0.85)
+const PING_WIDTH := 3.0
+
+
+func _ready() -> void:
+	z_index = FX_Z_INDEX
+	z_as_relative = false
+
+
+## Spawn an optimistic click ping at `world_pos` (a brief expanding, fading ring).
+## The ping is a child Node2D that animates itself and frees on completion, so the
+## FxLayer never holds onto nodes between clicks. Returns the spawned ping node
+## (mainly for tests/validation — callers can ignore it).
+func ping(world_pos: Vector2) -> Node2D:
+	var p := _Ping.new()
+	p.position = world_pos
+	add_child(p)
+	p.animate()
+	return p
+
+
+# ---------------------------------------------------------------------------
+# The transient ping node. A small _draw()-based ring whose radius/alpha are driven
+# by a single tween of a 0..1 progress value; it queue_free()s itself on finish.
+# ---------------------------------------------------------------------------
+class _Ping extends Node2D:
+	var _t: float = 0.0  ## 0..1 animation progress
+
+	func _draw() -> void:
+		var radius: float = lerpf(FxLayer.PING_START_RADIUS, FxLayer.PING_END_RADIUS, _t)
+		var col := FxLayer.PING_COLOR
+		col.a = FxLayer.PING_COLOR.a * (1.0 - _t)  # fade out as it expands
+		# Antialiased ring + a faint solid core dot for the initial flash.
+		draw_arc(Vector2.ZERO, radius, 0.0, TAU, 32, col, FxLayer.PING_WIDTH, true)
+		var core := col
+		core.a *= 0.5
+		draw_circle(Vector2.ZERO, FxLayer.PING_START_RADIUS * (1.0 - _t), core)
+
+	func animate() -> void:
+		var tween := create_tween()
+		tween.tween_method(_set_progress, 0.0, 1.0, FxLayer.PING_DURATION_SEC)
+		tween.tween_callback(queue_free)
+
+	func _set_progress(v: float) -> void:
+		_t = v
+		queue_redraw()

--- a/godot/scenes/FxLayer.gd.uid
+++ b/godot/scenes/FxLayer.gd.uid
@@ -1,0 +1,1 @@
+uid://befgvkpw3y34h

--- a/godot/scenes/InputController.gd
+++ b/godot/scenes/InputController.gd
@@ -1,0 +1,173 @@
+extends Node
+class_name InputController
+## InputController — turns a left-click in the world into a CONSTRAINED move INTENT
+## (#1055). It is the renderer's ONLY write gesture.
+##
+## CONTRACT ROLE: the renderer NEVER asserts world state — it asks the engine to,
+## via a `/move` intent whose `kind` is on the FROZEN allowlist
+## (docs/roadmap/contracts/move-intents.md). This node emits ONLY the three
+## graphical kinds: `move_to_zone`, `travel`, `inspect`. It refuses to emit anything
+## else (frozen-vocab guard) and it NEVER fabricates a world coordinate — a click
+## outside the walkmask is ignored.
+##
+## RESPONSIBILITY SPLIT (the load-bearing invariant): the engine owns the
+## DESTINATION (the next authoritative snapshot moves the token); the renderer owns
+## the PATH + the optimistic feedback. So a click shows an immediate FxLayer ping at
+## the click point but DOES NOT move the token — only the next snapshot does.
+##
+## HIT-TEST PRECEDENCE (most specific → least): actor/prop pick (inspect) → travel
+## affordance (travel) → walkmask floor (move_to_zone) → ignore (outside the mask).
+
+## The ONLY kinds this controller may emit. Asserted before every emit so a coding
+## error can never widen the frozen /move vocabulary from the renderer side.
+const ALLOWED_KINDS := ["move_to_zone", "travel", "inspect"]
+
+## Emitted with the constrained intent Dictionary {kind, target}. Main routes it to
+## SurfaceClient.move(). Listeners must treat it as a REQUEST, never a fact.
+signal intent_requested(intent: Dictionary)
+
+## Wired by Main at composition time. `_world` is the WorldView projection (the
+## hit-test + zone-snap surface); `_fx` is the optimistic-ping layer; `_surface`
+## is the transport (only used to know we are in FIXTURE mode for the log note).
+var _world: Node = null      # WorldView
+var _fx: Node = null         # FxLayer (optional — ping is skipped if null)
+var _surface: Node = null    # SurfaceClient
+
+
+## Composition-root wiring. Main calls this after instancing.
+func setup(world: Node, fx: Node, surface: Node) -> void:
+	_world = world
+	_fx = fx
+	_surface = surface
+
+
+# ---------------------------------------------------------------------------
+# Live input → intent. _unhandled_input so HUD/UI controls can consume clicks
+# first; only world clicks reach here.
+# ---------------------------------------------------------------------------
+func _unhandled_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton:
+		var mb := event as InputEventMouseButton
+		if mb.button_index == MOUSE_BUTTON_LEFT and mb.pressed:
+			# The FloorPolygon points are WorldView-local; WorldView is untransformed
+			# at the scene root, so the viewport click pos maps 1:1 to world-local.
+			var world_pos := _to_world(mb.position)
+			handle_click(world_pos)
+			get_viewport().set_input_as_handled()
+
+
+## Map a viewport (screen) point to WorldView-local coordinates. WorldView is an
+## untransformed Node2D at the scene root, so this is its inverse transform (the
+## identity today, but routed through the node so a future camera/offset is honored).
+func _to_world(viewport_pos: Vector2) -> Vector2:
+	if _world != null and _world is Node2D:
+		return (_world as Node2D).get_global_transform().affine_inverse() * viewport_pos
+	return viewport_pos
+
+
+# ---------------------------------------------------------------------------
+# The decision: classify a world-space click into one frozen intent (or ignore).
+# Returns the emitted intent Dictionary, or {} if the click was ignored.
+# ---------------------------------------------------------------------------
+func handle_click(world_pos: Vector2) -> Dictionary:
+	if _world == null:
+		return {}
+
+	# (1) Most specific: a click on an actor/prop body → inspect.
+	var picked := String(_world.pick_actor_at(world_pos))
+	if picked != "":
+		return _emit({"kind": "inspect", "target": picked}, world_pos,
+			"hit actor/prop -> inspect")
+
+	# (2) A click on a travel affordance → that option's verbatim `move`, else a
+	# {kind:travel, target:<engine_location_id>}. (No affordance is RENDERED in this
+	# slice, so this returns {} live; reachable via simulate_travel_click for tests.)
+	var travel := _travel_intent_at(world_pos)
+	if not travel.is_empty():
+		return _emit(travel, world_pos, "hit travel affordance -> travel")
+
+	# (3) Inside the walkmask → snap to the nearest zone → move_to_zone.
+	if _world.is_walkable(world_pos):
+		var zone := String(_world.nearest_zone(world_pos))
+		if zone == "":
+			print("[InputController] click@(%.0f,%.0f) inside-walkmask but no zones — ignored" % [world_pos.x, world_pos.y])
+			return {}
+		print("[InputController] click@(%.0f,%.0f) inside-walkmask -> {kind:move_to_zone, target:\"%s\"}" % [world_pos.x, world_pos.y, zone])
+		return _emit({"kind": "move_to_zone", "target": zone}, world_pos, "")
+
+	# (4) Outside the walkmask + no affordance → ignore. NEVER assert a coordinate.
+	print("[InputController] click@(%.0f,%.0f) outside-walkmask — ignored (no coordinate asserted)" % [world_pos.x, world_pos.y])
+	return {}
+
+
+## Build the travel intent for a click, if it lands on a known travel affordance.
+## Today no affordance node is rendered, so this returns {}; the VERBATIM-vs-wrapped
+## emit logic lives here so a rendered chip later just needs a hit-test. Tests reach
+## the travel path via simulate_travel_click(option).
+func _travel_intent_at(_world_pos: Vector2) -> Dictionary:
+	# No rendered travel-exit affordance in this slice → nothing to hit.
+	return {}
+
+
+# ---------------------------------------------------------------------------
+# Deterministic simulation entry points (for the --smoke-intent path + tests).
+# They drive the SAME handle_click decision logic as a live click.
+# ---------------------------------------------------------------------------
+
+## Simulate a left click at a WorldView-local point (e.g. a zone's screen anchor).
+func simulate_click(world_pos: Vector2) -> Dictionary:
+	return handle_click(world_pos)
+
+
+## Simulate clicking a travel affordance for a given atlas travel_option Dictionary.
+## Emits the option's VERBATIM `move` intent if present (must survive unchanged), else
+## wraps {to|target} into {kind:travel, target:<engine_location_id>}.
+func simulate_travel_click(option: Dictionary) -> Dictionary:
+	var intent := _option_to_travel_intent(option)
+	if intent.is_empty():
+		return {}
+	# Use the WorldView's anchor for the option's destination if known, else center.
+	return _emit(intent, Vector2.ZERO, "simulated travel affordance")
+
+
+## Turn a travel_option into a travel intent. VERBATIM `move` wins; else wrap the
+## destination id. Returns {} if neither a move nor a destination id is present.
+func _option_to_travel_intent(option: Dictionary) -> Dictionary:
+	var mv: Variant = option.get("move", null)
+	if typeof(mv) == TYPE_DICTIONARY and (mv as Dictionary).has("kind"):
+		# Emit verbatim — the engine authored this exact intent.
+		return (mv as Dictionary).duplicate(true)
+	var dest := String(option.get("target", option.get("to", "")))
+	if dest != "":
+		return {"kind": "travel", "target": dest}
+	return {}
+
+
+# ---------------------------------------------------------------------------
+# Emit (with the frozen-vocab guard + optimistic ping). Single choke point so EVERY
+# intent is validated and EVERY click gets feedback.
+# ---------------------------------------------------------------------------
+func _emit(intent: Dictionary, ping_pos: Vector2, note: String) -> Dictionary:
+	var kind := String(intent.get("kind", ""))
+	# FROZEN-VOCAB GUARD: refuse to widen the /move allowlist from the renderer.
+	if not ALLOWED_KINDS.has(kind):
+		push_error("[InputController] BLOCKED non-frozen intent kind '%s' (allowed: %s)" % [kind, str(ALLOWED_KINDS)])
+		return {}
+
+	# Live-writable guard: only emit when the view says we may act. In FIXTURE mode
+	# the atlas has no can_act/is_live_view (or can_act:true) so this passes and the
+	# demo works — but we do NOT pretend it reached an engine (SurfaceClient logs
+	# FIXTURE on the actual POST attempt).
+	if _world != null and _world.has_method("is_live_writable") and not _world.is_live_writable():
+		print("[InputController] view not live-writable — intent suppressed: ", intent)
+		return {}
+
+	# OPTIMISTIC feedback ONLY — the ping marks the click; it does NOT move a token.
+	# The next authoritative snapshot moves the token (engine owns the destination).
+	if _fx != null and _fx.has_method("ping") and ping_pos != Vector2.ZERO:
+		_fx.ping(ping_pos)
+
+	if note != "":
+		print("[InputController] emit %s (%s)" % [str(intent), note])
+	emit_signal("intent_requested", intent)
+	return intent

--- a/godot/scenes/InputController.gd.uid
+++ b/godot/scenes/InputController.gd.uid
@@ -1,0 +1,1 @@
+uid://c2pbnsds1wfhm

--- a/godot/scenes/Main.gd
+++ b/godot/scenes/Main.gd
@@ -1,12 +1,18 @@
 extends Node2D
-## Main — the renderer root that wires the transport to the scene (#1053).
+## Main — the renderer root that wires the transport to the scene (#1053 + #1055).
 ##
 ## ROLE: the composition root. It instances WorldView (the snapshot→scene
 ## projection) + Hud (read-only chrome) and connects them to the SINGLE transport
 ## boundary, SurfaceClient:
 ##   - snapshot_updated  → WorldView.apply_snapshot + Hud.apply_snapshot
 ##   - transport_mode_changed → Hud.set_mode
-##   - events_appended   → WorldView.enqueue_replay (a #1055/combat stub today)
+##   - events_appended   → WorldView.enqueue_replay (zone_move facing beats; #1055)
+##
+## #1055 ALSO wires the renderer's ONLY write gesture: an InputController that turns
+## a left-click into a constrained move INTENT, an FxLayer for the optimistic click
+## ping, and routes InputController.intent_requested → SurfaceClient.move(). The
+## engine owns the destination (the next snapshot moves the token); the renderer
+## owns the path + feedback.
 ##
 ## It owns NO game state and contains NO rules — it only routes signals. The
 ## headless boot smoke (location + party + mode prints, then a clean quit) is
@@ -14,16 +20,37 @@ extends Node2D
 ## with no server running, SurfaceClient falls back to res://fixtures/* (FIXTURE
 ## mode) and the scene projects those.
 
+const FxLayerScene := preload("res://scenes/FxLayer.gd")
+const InputControllerScene := preload("res://scenes/InputController.gd")
+
 @onready var _world: Node2D = $WorldView
 @onready var _hud: CanvasLayer = $Hud
+
+var _input: InputController = null
+var _fx: FxLayer = null
 
 var _got_first_snapshot: bool = false
 var _last_mode: String = "?"
 
 
 func _ready() -> void:
+	# #1055: build the optimistic-ping layer (above the world) + the input
+	# controller (the only write gesture), then wire the transport → scene.
+	_fx = FxLayerScene.new()
+	_fx.name = "FxLayer"
+	# Parent to WorldView so the ping shares the WorldView-local coord space the
+	# clicks are resolved in; its absolute z_index keeps it above the Y-sorted actors.
+	_world.add_child(_fx)
+
+	_input = InputControllerScene.new()
+	_input.name = "InputController"
+	add_child(_input)
+	_input.setup(_world, _fx, SurfaceClient)
+	# The renderer's ONLY write: route the constrained intent to POST /move.
+	_input.intent_requested.connect(_on_intent_requested)
+
 	# Wire the transport → scene. WorldView projects the snapshot into the world;
-	# Hud mirrors the read-only display facts; replay is a stub for now.
+	# Hud mirrors the read-only display facts; replay carries zone_move facing beats.
 	SurfaceClient.transport_mode_changed.connect(_on_mode_changed)
 	SurfaceClient.snapshot_updated.connect(_on_snapshot)
 	SurfaceClient.snapshot_updated.connect(_world.apply_snapshot)
@@ -35,6 +62,15 @@ func _ready() -> void:
 func _on_mode_changed(mode: String) -> void:
 	_last_mode = mode
 	_hud.set_mode(mode)
+
+
+## The renderer's only write. InputController already enforced the frozen-vocab
+## allowlist; here we just hand the intent to the transport (FIXTURE mode echoes a
+## benign ok + logs what WOULD have been POSTed — it does NOT pretend to reach a
+## live engine).
+func _on_intent_requested(intent: Dictionary) -> void:
+	var res: Dictionary = await SurfaceClient.move(intent)
+	print("[Main] /move intent=%s -> ok=%s reason=%s" % [str(intent), str(res.get("ok", false)), str(res.get("reason", ""))])
 
 
 func _on_snapshot(atlas: Dictionary, _combat: Dictionary, character: Dictionary) -> void:
@@ -51,11 +87,184 @@ func _on_snapshot(atlas: Dictionary, _combat: Dictionary, character: Dictionary)
 
 	if not _got_first_snapshot:
 		_got_first_snapshot = true
+		# #1055 deterministic validation paths run AFTER the scene is built. The flags
+		# may arrive before OR after the `--` user-args separator, so check both arg
+		# lists (the spec invokes `--demo-occlusion` without a `--` separator).
+		if _has_arg("--smoke-intent"):
+			call_deferred("_run_smoke_intent")
+			return
+		if _has_arg("--demo-occlusion"):
+			call_deferred("_run_demo_occlusion")
+			return
 		_maybe_quit()
+
+
+## True if `flag` appears in either the engine args or the post-`--` user args.
+func _has_arg(flag: String) -> bool:
+	return OS.get_cmdline_user_args().has(flag) or OS.get_cmdline_args().has(flag)
 
 
 func _on_events(records: Array) -> void:
 	print("[Main] events_appended: %d record(s)" % records.size())
+
+
+# ---------------------------------------------------------------------------
+# #1055 SMOKE-INTENT: simulate a floor click at a known zone's screen anchor and
+# print the emitted intent + the derived facing, asserting ONLY frozen kinds. This
+# is the headless logic proof (no window needed). Runs deterministically then quits.
+# ---------------------------------------------------------------------------
+func _run_smoke_intent() -> void:
+	print("[Main] --smoke-intent: simulating a floor click at a known zone anchor")
+
+	# Pick two zones so we can prove (a) a click→move_to_zone intent and (b) a
+	# renderer-DERIVED facing from one zone's anchor to another. The fixtures expose
+	# "the gate approach", "the market row", "the alley mouth".
+	var from_zone := "the gate approach"
+	var to_zone := "the market row"
+	var to_pos: Vector2 = _world.zone_screen_pos(to_zone)
+	var from_pos: Vector2 = _world.zone_screen_pos(from_zone)
+
+	# (1) Simulate a click AT the destination zone's floor anchor → expect a
+	# move_to_zone intent snapped to that zone.
+	var intent: Dictionary = _input.simulate_click(to_pos)
+	var ok_kind := InputController.ALLOWED_KINDS.has(String(intent.get("kind", "")))
+	print("[SmokeIntent] intent=%s frozen_kind=%s" % [str(intent), str(ok_kind)])
+
+	# (2) Derive the facing for a move from `from_zone`'s anchor to `to_zone`'s
+	# anchor — the same FacingResolver call WorldView makes on a zone change.
+	var facing := FacingResolver.octant(from_pos, to_pos, _world.FACING_ORDER)
+	print("[Facing] move %s->%s => %s" % [from_zone, to_zone, facing])
+
+	# (3) Assert ONLY frozen kinds can be emitted: try an illegal kind and confirm
+	# the controller refuses it (returns {}). Proves the renderer cannot widen the
+	# frozen /move vocabulary.
+	var blocked: Dictionary = _input._emit({"kind": "teleport", "target": "x"}, Vector2.ZERO, "illegal")
+	print("[SmokeIntent] illegal-kind blocked=%s" % str(blocked.is_empty()))
+
+	# (4) Also exercise the travel path with a verbatim option `move` (from the
+	# atlas travel_options) to prove travel is emitted VERBATIM + frozen.
+	var topts: Array = _world.travel_options()
+	if not topts.is_empty() and typeof(topts[0]) == TYPE_DICTIONARY:
+		var t_intent: Dictionary = _input.simulate_travel_click(topts[0])
+		var t_frozen := InputController.ALLOWED_KINDS.has(String(t_intent.get("kind", "")))
+		print("[SmokeIntent] travel intent=%s frozen_kind=%s" % [str(t_intent), str(t_frozen)])
+
+	# Final assertion summary line for the validation grep.
+	var is_move_to_zone := String(intent.get("kind", "")) == "move_to_zone"
+	var all_ok: bool = ok_kind and blocked.is_empty() and is_move_to_zone
+	print("[SmokeIntent] RESULT frozen-vocab-only=%s move_to_zone-emitted=%s" % [str(all_ok), str(is_move_to_zone)])
+
+	call_deferred("_quit_clean")
+
+
+# ---------------------------------------------------------------------------
+# #1055 DEMO-OCCLUSION: the visual Y-sort occlusion proof. Run WITHOUT --headless
+# (a real window) so rendering is real. Positions the party token behind, then in
+# front of, the pillar (by relative foot-Y), renders a frame each, screenshots to
+# /tmp, and programmatically asserts the occlusion by sampling the overlap column.
+# ---------------------------------------------------------------------------
+func _run_demo_occlusion() -> void:
+	print("[Main] --demo-occlusion: Y-sort occlusion proof (behind then front)")
+	var tok: CharacterToken = _world.token_for("char-aubree")
+	var pillar: PropActor = _world.pillar_prop()
+	if tok == null or pillar == null:
+		print("[DEMO] cannot run — token or pillar missing (token=%s pillar=%s)" % [str(tok != null), str(pillar != null)])
+		call_deferred("_quit_clean")
+		return
+
+	# Anchor the token on the pillar's COLUMN (same screen-x) so they overlap, and
+	# face the camera (S) so the body fills the overlap column. The pillar foot-Y is
+	# the depth pivot: token foot-Y above → behind; below → in front.
+	var px := pillar.position.x
+	var py := pillar.position.y
+	tok.set_facing("S")
+	tok.set_anim("idle")
+
+	# --- BEHIND: token foot-Y ABOVE the pillar foot-Y (smaller Y = farther) ---
+	tok.place_at(Vector2(px, py - 40.0))
+	await _settle_frames(3)
+	var behind_img := _capture_viewport()
+	if behind_img != null:
+		behind_img.save_png("/tmp/wos_godot_occlusion_behind.png")
+	var behind_pass := _assert_occlusion(behind_img, tok, pillar, true)
+
+	# --- FRONT: token foot-Y BELOW the pillar foot-Y (larger Y = nearer) ---
+	tok.place_at(Vector2(px, py + 40.0))
+	await _settle_frames(3)
+	var front_img := _capture_viewport()
+	if front_img != null:
+		front_img.save_png("/tmp/wos_godot_occlusion_front.png")
+	var front_pass := _assert_occlusion(front_img, tok, pillar, false)
+
+	print("[DEMO] occlusion behind=%s front=%s" % [
+		"pass" if behind_pass else "fail",
+		"pass" if front_pass else "fail"])
+	print("[DEMO] screenshots: /tmp/wos_godot_occlusion_behind.png /tmp/wos_godot_occlusion_front.png")
+	call_deferred("_quit_clean")
+
+
+## Wait `n` post-draw frames so the viewport texture is actually rendered before we
+## read it back (RenderingServer.frame_post_draw fires after each draw).
+func _settle_frames(n: int) -> void:
+	for _i in range(n):
+		await RenderingServer.frame_post_draw
+
+
+## Read the current viewport back to a CPU Image (null in headless / no real frame).
+func _capture_viewport() -> Image:
+	var vp := get_viewport()
+	if vp == null:
+		return null
+	var tex := vp.get_texture()
+	if tex == null:
+		return null
+	return tex.get_image()
+
+
+## Sample the token/pillar overlap column and decide who won the overlap pixels.
+## `expect_pillar_wins` true == the "behind" case (the pillar should occlude the
+## token); false == the "front" case (the token should occlude the pillar).
+##
+## The placeholder token is a GREEN body (g > r and g > b; see
+## gen_placeholder_sheet.py); the pillar is a NEUTRAL grey column (r≈g≈b). So in the
+## overlap column the WINNER is unambiguous by hue: green-dominant ⇒ the token is in
+## front; neutral-grey ⇒ the pillar is in front. We sample a band that is inside
+## BOTH bodies (just above the HIGHER of the two feet) and classify by greenness.
+## Returns true iff the rendered pixels match the expected occluder.
+func _assert_occlusion(img: Image, tok: CharacterToken, pillar: PropActor, expect_pillar_wins: bool) -> bool:
+	if img == null:
+		print("[DEMO] no image captured (headless?) — skipping pixel assertion")
+		return false
+	var iw := img.get_width()
+	var ih := img.get_height()
+	# The overlap column is the shared screen-x (token sits on the pillar column).
+	var col := clampi(int(round(pillar.position.x)), 0, iw - 1)
+	# Sample just ABOVE the higher foot (smaller Y) so we are inside BOTH body cells
+	# (both sprites still extend well above this Y). 30px clears the foot/AA edge.
+	var sample_y := clampi(int(round(minf(tok.position.y, pillar.position.y) - 30.0)), 0, ih - 1)
+
+	# Average a small vertical band in the overlap column for AA robustness.
+	var acc := Color(0, 0, 0, 0)
+	var n := 0
+	for dy in range(-8, 9, 4):
+		acc += img.get_pixel(col, clampi(sample_y + dy, 0, ih - 1))
+		n += 1
+	var avg := acc / float(max(n, 1))
+
+	# Greenness: how much the green channel exceeds the red/blue average. The token
+	# body is clearly green-positive; the grey pillar is ~0. A small threshold keeps
+	# the dark backdrop (≈0) on the pillar/neutral side.
+	var greenness := avg.g - (avg.r + avg.b) * 0.5
+	var token_won := greenness > 0.06
+	var pillar_won := not token_won
+
+	print("[DEMO] overlap@(%d,%d) avg=%s greenness=%.3f token_won=%s pillar_won=%s (expect_pillar=%s)" % [
+		col, sample_y, _fmt(avg), greenness, str(token_won), str(pillar_won), str(expect_pillar_wins)])
+	return pillar_won == expect_pillar_wins
+
+
+func _fmt(c: Color) -> String:
+	return "(%.2f,%.2f,%.2f)" % [c.r, c.g, c.b]
 
 
 # ---------------------------------------------------------------------------

--- a/godot/scenes/WorldView.gd
+++ b/godot/scenes/WorldView.gd
@@ -90,6 +90,24 @@ var _tokens: Dictionary = {}
 ## The single static pillar prop (spawned once, repositioned per tick).
 var _pillar: PropActor = null
 
+## #1055 — the FACING-derivation locked order (ISO-PROJECTION.md). Passed to
+## FacingResolver.octant() when a token's zone changes between snapshots / on a
+## zone_move beat. Facing is 100% renderer-derived (the engine has no facing field).
+## Typed PackedStringArray so it slots straight into octant(order: PackedStringArray).
+const FACING_ORDER: PackedStringArray = ["S", "SE", "E", "NE", "N", "NW", "W", "SW"]
+
+## #1055 — last KNOWN screen position per token (actor_id -> Vector2), captured on
+## each placement, so the NEXT placement can derive the move vector for facing.
+## Distinct from the live node `position` (which the tween animates mid-move).
+var _token_prev_pos: Dictionary = {}
+## #1055 — last engine location id we projected, to distinguish a `travel` (location
+## change → reset facing to default) from an in-scene `move_to_zone` (derive facing).
+var _prev_location_id: String = ""
+## #1055 — the raw atlas dict from the latest snapshot, so InputController can read
+## travel_options / the live-writable guard (can_act / is_live_view) WITHOUT the
+## renderer caching any game state of its own.
+var _atlas_cache: Dictionary = {}
+
 
 func _ready() -> void:
 	# Art arrives asynchronously through the /image bridge; swap the backdrop the
@@ -108,7 +126,12 @@ func _ready() -> void:
 func apply_snapshot(atlas: Dictionary, combat: Dictionary, character: Dictionary) -> void:
 	var in_combat := bool(combat.get("active", false))
 
+	# Cache the raw atlas so InputController can read travel_options + the
+	# live-writable guard without the renderer holding any game state of its own.
+	_atlas_cache = atlas
+
 	# --- current location (id + display name) from the read-only atlas ---
+	_prev_location_id = _location_id
 	_location_id = _resolve_location_id(atlas)
 	_location_name = _resolve_location_name(atlas)
 
@@ -166,9 +189,19 @@ func apply_snapshot(atlas: Dictionary, combat: Dictionary, character: Dictionary
 # later issue — for now we accept and ignore so the signal interface is wired.
 # ---------------------------------------------------------------------------
 func enqueue_replay(records: Array) -> void:
-	# Intentionally a no-op for #1053. Kept so events_appended has a destination and
-	# the wiring is verifiable now (the count print stays in Main).
-	pass
+	# #1055: honor `zone_move` beats for facing derivation (renderer-derived). Full
+	# Action-Replay (combat token motion + facing from target_fk) is still a later
+	# issue; everything else is accepted-and-ignored so the wiring stays verifiable.
+	for rec in records:
+		if typeof(rec) != TYPE_DICTIONARY:
+			continue
+		var r: Dictionary = rec
+		if String(r.get("kind", "")) != "zone_move":
+			continue
+		var actor_id := String(r.get("actor", r.get("actor_id", "")))
+		var zone_name := String(r.get("zone", r.get("target", "")))
+		if actor_id != "" and zone_name != "":
+			apply_zone_move(actor_id, zone_name)
 
 
 # ---------------------------------------------------------------------------
@@ -200,6 +233,122 @@ func pillar_prop() -> PropActor:
 
 
 # ---------------------------------------------------------------------------
+# #1055 — input-facing query surface (consumed by InputController). All of these
+# are PURE reads of the already-projected scene; none mutate or assert state.
+# ---------------------------------------------------------------------------
+
+## True if `world_pos` (WorldView-local px) is inside the walkmask floor polygon.
+## InputController NEVER asserts a coordinate outside this region.
+func is_walkable(world_pos: Vector2) -> bool:
+	if _floor_poly == null:
+		return false
+	var poly := _floor_poly.polygon
+	if poly.size() < 3:
+		return false
+	# FloorPolygon is positioned at the WalkmaskLayer origin (untransformed in the
+	# scene), so its `polygon` points are already in WorldView-local space.
+	return Geometry2D.is_point_in_polygon(world_pos, poly)
+
+
+## The NEAREST named zone to `world_pos` by squared distance to its anchor, or ""
+## if there are no zones this tick. The #1055 click→zone snap.
+func nearest_zone(world_pos: Vector2) -> String:
+	var best := ""
+	var best_d := INF
+	for zn in _zone_screen.keys():
+		var p: Vector2 = _zone_screen[zn]
+		var d := world_pos.distance_squared_to(p)
+		if d < best_d:
+			best_d = d
+			best = zn
+	return best
+
+
+## The atlas `travel_options` array from the latest snapshot (or [] if absent).
+## Each option is a Dictionary; it MAY carry a verbatim `move` intent the renderer
+## must emit unchanged, else {to/target} the renderer wraps into a `travel` intent.
+func travel_options() -> Array:
+	var t: Variant = _atlas_cache.get("travel_options", [])
+	return t if typeof(t) == TYPE_ARRAY else []
+
+
+## True when the current view is LIVE-WRITABLE per the atlas (`can_act` /
+## `is_live_view`). If neither field is present, treat absent as writable (the
+## FIXTURE/standalone case so the demo works) — InputController separately knows it
+## did not reach a real engine (SurfaceClient is in FIXTURE mode).
+func is_live_writable() -> bool:
+	if _atlas_cache.has("can_act"):
+		return bool(_atlas_cache["can_act"])
+	if _atlas_cache.has("is_live_view"):
+		return bool(_atlas_cache["is_live_view"])
+	return true
+
+
+## The id of the actor/prop whose pick body contains `world_pos`, or "" if none.
+## Front-most (largest foot-y) wins so a click on overlapping bodies selects the
+## one nearest the camera. Used for the #1055 inspect-click.
+func pick_actor_at(world_pos: Vector2) -> String:
+	var hit_id := ""
+	var hit_y := -INF
+	for actor_id in _tokens.keys():
+		var tok: CharacterToken = _tokens[actor_id]
+		if not is_instance_valid(tok):
+			continue
+		if _token_contains(tok, world_pos) and tok.position.y > hit_y:
+			hit_id = actor_id
+			hit_y = tok.position.y
+	if _pillar != null and is_instance_valid(_pillar):
+		if _prop_contains(_pillar, world_pos) and _pillar.position.y > hit_y:
+			hit_id = _pillar.prop_id
+			hit_y = _pillar.position.y
+	return hit_id
+
+
+## #1055 — apply a `zone_move` events beat for ONE actor (facing-derive + walk to the
+## named zone's anchor). Renderer-derived facing; no engine facing. Called from the
+## events-replay path; a no-op if the actor/zone is unknown this tick.
+func apply_zone_move(actor_id: String, zone_name: String) -> void:
+	var tok: CharacterToken = _tokens.get(actor_id, null)
+	if tok == null or not is_instance_valid(tok):
+		return
+	var dest: Vector2 = _zone_screen.get(zone_name, Vector2.ZERO)
+	if dest == Vector2.ZERO and not _zone_screen.has(zone_name):
+		return
+	var from_pos: Vector2 = _token_prev_pos.get(actor_id, tok.position)
+	_walk_token_to(tok, actor_id, from_pos, dest)
+
+
+## Hit-test a CharacterToken's Area2D pick body against a WorldView-local point.
+func _token_contains(tok: CharacterToken, world_pos: Vector2) -> bool:
+	var picker := tok.get_node_or_null("Picker") as Area2D
+	if picker == null:
+		return false
+	var shape_node := picker.get_node_or_null("PickerShape") as CollisionShape2D
+	if shape_node == null or shape_node.shape == null:
+		return false
+	var rect := shape_node.shape as RectangleShape2D
+	if rect == null:
+		return false
+	# Convert the world point into the shape's local frame (token pos + shape pos).
+	var local := world_pos - tok.position - shape_node.position
+	var half := rect.size * 0.5
+	return absf(local.x) <= half.x and absf(local.y) <= half.y
+
+
+## Hit-test the pillar prop's body cell against a WorldView-local point. The prop
+## origin is its foot; the body cell spans -anchor..(-anchor+frame) from origin.
+func _prop_contains(prop: PropActor, world_pos: Vector2) -> bool:
+	var sprite := prop.get_node_or_null("Sprite") as Sprite2D
+	if sprite == null or sprite.texture == null:
+		return false
+	var sz := sprite.texture.get_size()
+	# sprite.offset == -anchor, so the cell top-left (relative to origin) is offset.
+	var top_left := prop.position + sprite.offset
+	return world_pos.x >= top_left.x and world_pos.x <= top_left.x + sz.x \
+		and world_pos.y >= top_left.y and world_pos.y <= top_left.y + sz.y
+
+
+# ---------------------------------------------------------------------------
 # #1054 — actor tokens + the static pillar prop, in the Y-sorted layer.
 # ---------------------------------------------------------------------------
 
@@ -210,18 +359,23 @@ func pillar_prop() -> PropActor:
 func _reconcile_actors(character: Dictionary) -> void:
 	var lead := _lead_actor(character)
 	var wanted: Dictionary = {}  # actor_id -> true (actors that should exist this tick)
+	# A location change since the last snapshot is a `travel` — reset facing to the
+	# rest/default facing rather than deriving a walk direction (ISO-PROJECTION.md).
+	var traveled := _prev_location_id != "" and _prev_location_id != _location_id
 
 	if not lead.is_empty():
 		var actor_id := String(lead.get("id", ""))
 		if actor_id != "":
 			wanted[actor_id] = true
 			var tok: CharacterToken = _tokens.get(actor_id, null)
-			if tok == null:
+			var is_new := tok == null
+			if is_new:
 				tok = _spawn_token(actor_id)
 				if tok != null:
 					_tokens[actor_id] = tok
 			if tok != null:
-				tok.place_at(_foreground_pos())
+				var target_pos := _foreground_pos()
+				_reconcile_token_motion(tok, actor_id, target_pos, is_new, traveled)
 
 	# Free tokens whose actor left the party (no leaks).
 	for existing_id in _tokens.keys():
@@ -230,6 +384,58 @@ func _reconcile_actors(character: Dictionary) -> void:
 			if is_instance_valid(stale):
 				stale.queue_free()
 			_tokens.erase(existing_id)
+			_token_prev_pos.erase(existing_id)
+
+
+## #1055 — drive ONE token to its new screen position with renderer-derived facing.
+## Decision table (facing is 100% renderer-derived; the engine has no facing field):
+##   - new token        → place instantly at default facing, idle (no walk-in).
+##   - traveled (loc Δ) → place instantly, reset to default_facing, idle.
+##   - same position    → hold last facing, stay idle (static).
+##   - zone moved       → derive facing = octant(prev→new) via FacingResolver, play
+##                        `walk` during the set_zone_target tween, return to `idle`
+##                        on arrival. Y updates progressively so Y-sort re-orders.
+func _reconcile_token_motion(tok: CharacterToken, actor_id: String, target_pos: Vector2, is_new: bool, traveled: bool) -> void:
+	var prev_pos: Vector2 = _token_prev_pos.get(actor_id, target_pos)
+
+	if is_new:
+		tok.place_at(target_pos)
+		tok.set_facing(FacingResolver.default_facing)
+		tok.set_anim("idle")
+		_token_prev_pos[actor_id] = target_pos
+		return
+
+	if traveled:
+		# Location change → snap into the new scene at the rest facing.
+		tok.place_at(target_pos)
+		tok.set_facing(FacingResolver.default_facing)
+		tok.set_anim("idle")
+		_token_prev_pos[actor_id] = target_pos
+		return
+
+	if prev_pos.distance_squared_to(target_pos) < 0.5:
+		# No zone change — hold the last facing, stay idle (static).
+		_token_prev_pos[actor_id] = target_pos
+		return
+
+	# Zone changed within the scene → derive an 8-way facing and walk there.
+	_walk_token_to(tok, actor_id, prev_pos, target_pos)
+
+
+## Derive facing from prev→new, play `walk` for the tween, return to `idle` on
+## arrival. Shared by the snapshot reconcile and the `zone_move` events beat.
+func _walk_token_to(tok: CharacterToken, actor_id: String, from_pos: Vector2, to_pos: Vector2) -> void:
+	var facing := FacingResolver.octant(from_pos, to_pos, FACING_ORDER)
+	tok.set_facing(facing)
+	tok.set_anim("walk")
+	tok.set_zone_target(to_pos)
+	# Return to idle when the move-tween finishes (tween length == MOVE_TWEEN_SEC).
+	var idle_timer := get_tree().create_timer(CharacterToken.MOVE_TWEEN_SEC)
+	idle_timer.timeout.connect(func():
+		if is_instance_valid(tok):
+			tok.set_anim("idle"))
+	_token_prev_pos[actor_id] = to_pos
+	print("[Facing] move %s => %s" % [actor_id, facing])
 
 
 ## Build a CharacterToken for an actor: resolve its committed sheet (sheet.png +


### PR DESCRIPTION
Closes #1055. **The capstone vertical slice** of sprint 1 (epic #1050). Live snapshot → directional character → click-to-move intent → correct depth occlusion.

## What
- **`InputController.gd`** — left click → constrained `/move` intent. Precedence: actor/prop → `inspect`; travel affordance → `travel` (verbatim `move` else wrapped); walkmask floor (`Geometry2D.is_point_in_polygon`) → nearest `ZoneMarker` → `move_to_zone`; outside → ignored (never asserts a coordinate). **Frozen-vocab guard** refuses anything outside `[move_to_zone,travel,inspect]`. Optimistic `FxLayer` click ping, but the token is moved by the **next authoritative snapshot**, not the click.
- **`WorldView`** — `FacingResolver` wired into token reconcile: zone change → 8-way `octant(prev→new)` facing + `walk` during the tween, `idle` on arrival; `travel` → `default_facing`; honors `/events` `zone_move` beats. 100% renderer-derived (no engine facing).
- **`Main`** — routes `intent_requested → SurfaceClient.move`; adds `--smoke-intent` + `--demo-occlusion`.

## Validation (local Godot 4.6.3)
- `--import` clean.
- `--smoke-intent`: `click → {move_to_zone "the market row"}`; facing gate→market = **SW**; illegal `teleport` **blocked**; travel emitted verbatim; **frozen-vocab-only**.
- `--demo-occlusion` (real window): **behind=pass** (pillar occludes the token) / **front=pass** (token occludes the pillar) via foot-anchored Y-sort — pixel-asserted + screenshots captured.

This completes the slice: a directional character driven by live engine state, click-to-move on the frozen vocab, correct depth occlusion both ways. Backdrop is the procedural fallback; painterly art drops in at the same `scope_key`. Next: **#1056** — the headless-Godot CI lane (export validation + fixture conformance + screenshot artifact) so all of this is gated in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Click-to-move system enabling zone-based character navigation with travel options
  * Visual feedback effect renders at click points for interaction indication
  * Characters automatically face and animate in their movement direction

* **Tests**
  * Added validation routines for testing game intents and verifying visual occlusion behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->