### PR TITLE
feat(godot): Meshy→Blender directional-sprite asset pipeline (#1062)

### DIFF
--- a/godot/tools/README.md
+++ b/godot/tools/README.md
@@ -1,0 +1,48 @@
+# GT2 asset pipeline — Meshy → Blender → directional sprite sheet
+
+The non-throwaway "speed now, quality later" art pipeline for the GT2 Godot renderer
+(epic #1050). The renderer reads **only** the sprite-sheet manifest (`sheet.json`) + the
+render-profile contract — never the pixels — so a sheet produced by ANY source drops in at
+the same `scope_key` with **zero renderer change**. Provenance ladder: CC0 placeholder →
+Meshy→Blender render → hand/AI paintover.
+
+## Tools (run from the repo root)
+
+1. **`meshy_gen.py`** — generate a 3D character/prop via the Meshy text-to-3D API.
+   ```
+   python3 godot/tools/meshy_gen.py \
+     --prompt "a stylized fantasy human ranger, leather armor, hooded green cloak, T-pose, full body" \
+     --out content/worlds/_private/baldurs-gate/sprites/aubree-iso8
+   ```
+   Submits preview → polls → refine (textured, PBR) → polls → downloads `model.glb` (+
+   `thumbnail.png`, `meshy_meta.json`). **API key** is read from `~/.worldos/meshy.key` or
+   `$MESHY_API_KEY` — **never** hardcode it or commit it.
+
+2. **`bake_sprites.py`** — Blender headless render of the model to flat 2D, 8 facings.
+   ```
+   /opt/homebrew/bin/blender --background --python godot/tools/bake_sprites.py -- \
+     --model <dir>/model.glb --out <dir>/frames
+   ```
+   Orthographic camera at the **LOCKED dimetric 2:1 projection** (see `godot/ISO-PROJECTION.md`):
+   yaw 45°, elevation auto-calibrated so a unit floor-tile's top face renders 2:1 (~29.5°).
+   Rotates the model 0/45/…/315° for the 8 facings (`S,SE,E,NE,N,NW,W,SW`), renders
+   idle/walk/attack/cast frames (synthesized motion for a static model), and projects the
+   foot point → `anchor.json`.
+
+3. **`pack_sheet.py`** — tile frames into the renderer's layout + emit the manifest.
+   ```
+   python3 godot/tools/pack_sheet.py --frames <dir>/frames --scope sprite-aubree-iso8 \
+     --out content/worlds/_private/baldurs-gate/sprites/aubree-iso8
+   ```
+   Produces `sheet.png` (rows = 8 facings, cols = 24 = idle4/walk8/attack6/cast6, 128px cells →
+   3072×1024) + `sheet.json` (manifest v1, identical shape to the committed placeholder, with
+   `source:"meshy-blender-render"`).
+
+## Where the art lives
+
+- **Committed (CC0/owned only):** `godot/assets/characters/<scope>/` holds the **placeholder**
+  default (regenerable via `gen_placeholder_sheet.py`).
+- **Finals (NOT committed):** Meshy→Blender / AI-paintover outputs go under
+  `content/worlds/_private/…` (gitignored, owner-licensed) and are served at runtime via the
+  `/image`-style bridge (the served-finals wiring is issue #1063). Record AI provenance in the
+  render-profile `ai_disclosure` block (EU disclosure, Steam survey).

--- a/godot/tools/bake_sprites.py
+++ b/godot/tools/bake_sprites.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""bake_sprites.py — Blender-headless bake of a .glb into 8-facing dimetric sprite frames (#1062).
+
+Stage 2 of the WorldOS GT2 final-art pipeline (meshy_gen.py -> THIS -> pack_sheet.py).
+
+Run ONLY under Blender's bundled Python:
+
+    blender --background --python bake_sprites.py -- \
+        --model <model.glb> --out <frames_dir> [--cell 128]
+
+What it does (all geometry obeys ISO-PROJECTION.md — the LOCKED dimetric 2:1 projection):
+
+  1. Import the glb, recenter it on the origin, parent it to an Empty (the "turntable").
+  2. Build an ORTHOGRAPHIC camera at yaw 45 deg, and EMPIRICALLY CALIBRATE its elevation:
+     render a 1x1x1 reference cube and measure the alpha-bbox of its top face; tune the
+     camera elevation until width:height of that diamond == 2.0 (+-0.06). This is the
+     dimetric-2to1 lock VERIFIED from pixels, not assumed.  (~26.57deg => tan(elev)=0.5.)
+  3. Add a simple 3-point-ish rig: a sun (key) + two fill area lights.
+  4. For each of the 8 LOCKED facings (S,SE,E,NE,N,NW,W,SW) — rotate the turntable Empty
+     by 0,45,90,...,315 deg so S faces the camera — and for each animation frame, apply a
+     SYNTHESIZED procedural pose offset to the Empty (the imported model is static, so we
+     fake life): idle = vertical breathing bob; walk = bob + slight lean cycle;
+     attack = forward lunge along the facing then back; cast = raise + scale "glow".
+  5. Render each (facing, anim, frame) to a CELL x CELL transparent PNG named
+     "<facing>_<anim>_<i>.png" in <frames_dir>.
+  6. Compute the FOOT-anchor pixel by projecting the model's lowest world point to screen
+     at the rest pose (S facing, idle frame 0) -> <frames_dir>/anchor.json.
+
+The frame naming + anim layout match gen_placeholder_sheet.py / CharacterToken.gd:
+    idle(4) + walk(8) + attack(6) + cast(6) = 24 frames per facing.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import sys
+
+import bpy
+from mathutils import Vector
+
+# ---------------------------------------------------------------------------
+# Locked layout (mirrors gen_placeholder_sheet.py / ISO-PROJECTION.md).
+# ---------------------------------------------------------------------------
+FACING_ORDER = ["S", "SE", "E", "NE", "N", "NW", "W", "SW"]
+# (name, frame_count). Order defines column packing downstream.
+ANIMS = [("idle", 4), ("walk", 8), ("attack", 6), ("cast", 6)]
+
+# Camera yaw is LOCKED at 45 deg (diagonal view). Elevation is CALIBRATED at runtime
+# to hit the 2:1 dimetric diamond; this is the starting guess (atan(0.5) ~= 26.57 deg).
+CAMERA_YAW_DEG = 45.0
+ELEV_GUESS_DEG = 26.57
+DIMETRIC_TARGET_RATIO = 2.0
+DIMETRIC_TOL = 0.06
+
+# Camera distance / framing. The ortho camera "scale" is set from the model height so the
+# character fills the cell with a little headroom.
+CELL_DEFAULT = 128
+FRAME_MARGIN = 1.25  # ortho_scale = model_height * this (some padding)
+
+
+# ---------------------------------------------------------------------------
+# Arg parsing (everything after the `--` in the blender command line).
+# ---------------------------------------------------------------------------
+def _parse_args() -> dict:
+    argv = sys.argv
+    if "--" in argv:
+        argv = argv[argv.index("--") + 1:]
+    else:
+        argv = []
+    out = {"model": None, "out": None, "cell": CELL_DEFAULT}
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--model":
+            out["model"] = argv[i + 1]; i += 2
+        elif a == "--out":
+            out["out"] = argv[i + 1]; i += 2
+        elif a == "--cell":
+            out["cell"] = int(argv[i + 1]); i += 2
+        else:
+            i += 1
+    if not out["model"] or not out["out"]:
+        sys.exit("[bake_sprites] ERROR: --model and --out are required")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Scene setup.
+# ---------------------------------------------------------------------------
+def _reset_scene() -> None:
+    bpy.ops.wm.read_factory_settings(use_empty=True)
+    scene = bpy.context.scene
+    scene.render.engine = "BLENDER_EEVEE_NEXT" if _has_eevee_next() else "BLENDER_EEVEE"
+    scene.render.film_transparent = True
+    scene.render.image_settings.file_format = "PNG"
+    scene.render.image_settings.color_mode = "RGBA"
+    # World: a faint ambient so shadowed sides aren't pure black.
+    world = bpy.data.worlds.new("W")
+    scene.world = world
+    world.use_nodes = True
+    bg = world.node_tree.nodes.get("Background")
+    if bg:
+        bg.inputs[0].default_value = (0.05, 0.05, 0.06, 1.0)
+        bg.inputs[1].default_value = 0.6
+
+
+def _has_eevee_next() -> bool:
+    try:
+        # Blender 4.2+ renamed EEVEE to EEVEE Next.
+        return "BLENDER_EEVEE_NEXT" in [
+            e.identifier for e in bpy.types.RenderSettings.bl_rna.properties["engine"].enum_items
+        ]
+    except Exception:
+        return False
+
+
+def _import_glb(path: str):
+    """Import the glb, return the list of imported mesh-bearing objects."""
+    before = set(bpy.data.objects)
+    bpy.ops.import_scene.gltf(filepath=path)
+    new_objs = [o for o in bpy.data.objects if o not in before]
+    if not new_objs:
+        sys.exit("[bake_sprites] ERROR: glb import produced no objects: %s" % path)
+    return new_objs
+
+
+def _world_bbox(objs) -> tuple:
+    """World-space (min, max) Vector over all object bounding boxes."""
+    mins = Vector((math.inf, math.inf, math.inf))
+    maxs = Vector((-math.inf, -math.inf, -math.inf))
+    found = False
+    for o in objs:
+        if o.type not in ("MESH",):
+            continue
+        for corner in o.bound_box:
+            wc = o.matrix_world @ Vector(corner)
+            mins.x = min(mins.x, wc.x); mins.y = min(mins.y, wc.y); mins.z = min(mins.z, wc.z)
+            maxs.x = max(maxs.x, wc.x); maxs.y = max(maxs.y, wc.y); maxs.z = max(maxs.z, wc.z)
+            found = True
+    if not found:
+        sys.exit("[bake_sprites] ERROR: no mesh geometry to bound")
+    return mins, maxs
+
+
+def _setup_model(objs):
+    """Recenter the model on XY origin with feet at z=0, parent it to a turntable Empty."""
+    bpy.context.view_layer.update()
+    mins, maxs = _world_bbox(objs)
+    center_x = (mins.x + maxs.x) * 0.5
+    center_y = (mins.y + maxs.y) * 0.5
+    # Move so the model is centered on (0,0) in XY and its feet sit at z=0.
+    shift = Vector((-center_x, -center_y, -mins.z))
+
+    empty = bpy.data.objects.new("Turntable", None)
+    bpy.context.scene.collection.objects.link(empty)
+    empty.location = (0.0, 0.0, 0.0)
+
+    for o in objs:
+        if o.parent is None:
+            o.parent = empty
+            o.matrix_parent_inverse = empty.matrix_world.inverted()
+            o.location = o.location + shift
+
+    bpy.context.view_layer.update()
+    mins, maxs = _world_bbox(objs)
+    height = max(maxs.z - mins.z, 1e-4)
+    return empty, height, mins, maxs
+
+
+def _add_lights() -> None:
+    # Key (sun) from the camera-ish front-upper.
+    sun_data = bpy.data.lights.new("Key", type="SUN")
+    sun_data.energy = 3.0
+    sun = bpy.data.objects.new("Key", sun_data)
+    bpy.context.scene.collection.objects.link(sun)
+    sun.rotation_euler = (math.radians(55), 0.0, math.radians(45))
+
+    # Two fill area lights for a soft 3-point feel.
+    for name, loc, energy in [
+        ("FillL", (-4.0, -4.0, 3.0), 300.0),
+        ("FillR", (4.0, -2.0, 2.0), 200.0),
+    ]:
+        ad = bpy.data.lights.new(name, type="AREA")
+        ad.energy = energy
+        ad.size = 5.0
+        a = bpy.data.objects.new(name, ad)
+        bpy.context.scene.collection.objects.link(a)
+        a.location = loc
+        # Aim roughly at origin.
+        _aim_at(a, Vector((0, 0, 1.0)))
+
+
+def _aim_at(obj, target: Vector) -> None:
+    direction = (target - Vector(obj.location))
+    if direction.length < 1e-6:
+        return
+    rot = direction.to_track_quat("-Z", "Y").to_euler()
+    obj.rotation_euler = rot
+
+
+def _make_camera(model_height: float, elev_deg: float, dist: float):
+    cam_data = bpy.data.cameras.new("Cam")
+    cam_data.type = "ORTHO"
+    cam_data.ortho_scale = model_height * FRAME_MARGIN
+    cam = bpy.data.objects.new("Cam", cam_data)
+    bpy.context.scene.collection.objects.link(cam)
+    bpy.context.scene.camera = cam
+    _place_camera(cam, elev_deg, dist, model_height)
+    return cam
+
+
+def _place_camera(cam, elev_deg: float, dist: float, model_height: float) -> None:
+    """Place the ortho camera at yaw 45deg + elev_deg, looking at the model mid-height."""
+    yaw = math.radians(CAMERA_YAW_DEG)
+    elev = math.radians(elev_deg)
+    look = Vector((0.0, 0.0, model_height * 0.5))
+    # Spherical position around the look point.
+    horiz = math.cos(elev) * dist
+    cam.location = (
+        look.x + horiz * math.sin(yaw),
+        look.y - horiz * math.cos(yaw),
+        look.z + math.sin(elev) * dist,
+    )
+    _aim_at(cam, look)
+
+
+# ---------------------------------------------------------------------------
+# Dimetric calibration: render the FLAT TOP FACE of a unit cube as a diamond and
+# measure its alpha-bbox width:height. We render a single 1x1 horizontal PLANE (the
+# cube's top face in isolation) so the side faces of a solid cube can't pollute the
+# silhouette — the plane's alpha-bbox IS the top-face diamond. Geometrically, a flat
+# square seen at yaw 45 + elevation t projects to a diamond of width = diag and
+# height = diag*sin(t), so width:height = 1/sin(t); 2:1 => t = 30deg (verified here,
+# not assumed). This is the dimetric "floor tile" the renderer's zone geometry shares.
+# ---------------------------------------------------------------------------
+def _measure_cube_ratio(elev_deg: float, cell: int) -> float:
+    """Render a flat 1x1 top-face plane at the given elevation; return diamond w:h."""
+    # Build a throwaway scene with just a flat plane (the cube's top face) + camera.
+    bpy.ops.mesh.primitive_plane_add(size=1.0, location=(0, 0, 0.0))
+    plane = bpy.context.active_object
+
+    cam = bpy.context.scene.camera
+    _place_camera(cam, elev_deg, dist=10.0, model_height=0.0)
+    cam.data.ortho_scale = 1.7
+
+    scene = bpy.context.scene
+    scene.render.resolution_x = cell
+    scene.render.resolution_y = cell
+    tmp = os.path.join(bpy.app.tempdir, "tile_calib.png")
+    scene.render.filepath = tmp
+    bpy.ops.render.render(write_still=True)
+
+    ratio = _alpha_bbox_ratio(tmp)
+    # cleanup the plane
+    bpy.data.objects.remove(plane, do_unlink=True)
+    return ratio
+
+
+def _alpha_bbox_ratio(png_path: str) -> float:
+    """Width:height of the opaque-alpha bounding box of a rendered PNG."""
+    img = bpy.data.images.load(png_path)
+    w, h = img.size
+    px = list(img.pixels)  # flat RGBA, row-major bottom-up
+    min_x, max_x, min_y, max_y = w, -1, h, -1
+    for y in range(h):
+        row = y * w * 4
+        for x in range(w):
+            a = px[row + x * 4 + 3]
+            if a > 0.5:
+                if x < min_x: min_x = x
+                if x > max_x: max_x = x
+                if y < min_y: min_y = y
+                if y > max_y: max_y = y
+    bpy.data.images.remove(img)
+    if max_x < 0 or max_y < 0:
+        return 0.0
+    bw = (max_x - min_x + 1)
+    bh = (max_y - min_y + 1)
+    return bw / max(bh, 1)
+
+
+def _calibrate_elevation(cell: int) -> tuple:
+    """Binary-search the camera elevation so the cube top-face diamond is 2:1 wide:tall.
+
+    A HIGHER elevation flattens the top face (taller diamond, smaller ratio); a LOWER
+    elevation makes the top face more head-on (wider, larger ratio). We bisect on elevation.
+    Returns (chosen_elev_deg, measured_ratio).
+    """
+    print("[bake_sprites] calibrating dimetric elevation (target w:h = %.2f +-%.2f)..." % (
+        DIMETRIC_TARGET_RATIO, DIMETRIC_TOL))
+    lo, hi = 10.0, 60.0  # elevation bounds in degrees
+    best = (ELEV_GUESS_DEG, 0.0)
+    best_err = math.inf
+    for it in range(14):
+        mid = (lo + hi) * 0.5
+        ratio = _measure_cube_ratio(mid, cell)
+        err = abs(ratio - DIMETRIC_TARGET_RATIO)
+        print("[bake_sprites]   elev=%.3f deg -> top-face ratio=%.4f (err=%.4f)" % (mid, ratio, err))
+        if err < best_err:
+            best_err = err
+            best = (mid, ratio)
+        if err <= DIMETRIC_TOL:
+            print("[bake_sprites] CALIBRATED elevation=%.3f deg ratio=%.4f (within tol)" % (mid, ratio))
+            return mid, ratio
+        # ratio too LARGE (diamond too wide) => raise elevation; too SMALL => lower it.
+        if ratio > DIMETRIC_TARGET_RATIO:
+            lo = mid
+        else:
+            hi = mid
+    print("[bake_sprites] WARNING: did not converge within tol; using best elev=%.3f ratio=%.4f" % best)
+    return best
+
+
+# ---------------------------------------------------------------------------
+# Synthesized procedural motion. Applies a transient transform to the turntable
+# Empty (on TOP of its facing yaw). Returns nothing; mutates the empty.
+# ---------------------------------------------------------------------------
+def _apply_pose(empty, base_yaw: float, anim: str, frame: int, count: int,
+                model_height: float, facing_screen_dir) -> None:
+    phase = (frame / count) if count > 0 else 0.0
+    mid = 1.0 - abs(2.0 * phase - 1.0)  # 0->1->0 triangle
+
+    # Reset to facing pose first.
+    empty.location = (0.0, 0.0, 0.0)
+    empty.rotation_euler = (0.0, 0.0, base_yaw)
+    empty.scale = (1.0, 1.0, 1.0)
+
+    bob = 0.0
+    lean = 0.0      # extra rotation (radians) about a horizontal axis
+    lunge = 0.0     # forward translation along the facing in WORLD xy
+    rise = 0.0
+    glow_scale = 1.0
+
+    amp = model_height  # scale motion to the model size
+
+    if anim == "idle":
+        bob = 0.015 * amp * math.sin(phase * math.tau)
+    elif anim == "walk":
+        bob = 0.025 * amp * abs(math.sin(phase * math.tau))
+        lean = math.radians(4.0) * math.sin(phase * math.tau)
+    elif anim == "attack":
+        lunge = 0.18 * amp * mid
+        lean = math.radians(8.0) * mid
+    elif anim == "cast":
+        rise = 0.05 * amp * mid
+        glow_scale = 1.0 + 0.04 * mid
+
+    # Forward direction of THIS facing in world XY (the facing's "away from camera->toward"
+    # is along the rotated +Y of the empty; lunge pushes the model toward the camera-front).
+    fx, fy = facing_screen_dir
+    empty.location = (fx * lunge, fy * lunge, bob + rise)
+    # lean as a small pitch about the world X axis, composed after the yaw.
+    empty.rotation_euler = (lean, 0.0, base_yaw)
+    if glow_scale != 1.0:
+        empty.scale = (glow_scale, glow_scale, glow_scale)
+
+
+# Per-facing world XY direction the model "faces" for the lunge. The turntable yaw rotates
+# the model; at yaw=0 the model's front points toward the camera (-Y in world, since the
+# camera sits at -Y). Index = facing index.
+def _facing_world_dir(facing_index: int):
+    # The empty yaw for facing i is i*45deg. The model-forward in world after that yaw:
+    yaw = math.radians(facing_index * 45.0)
+    # base forward (toward camera) is -Y; rotate by yaw about Z.
+    fx = -math.sin(yaw) * 1.0  # x' = -sin
+    fy = -math.cos(yaw) * 1.0  # y' = -cos
+    return (fx, fy)
+
+
+# ---------------------------------------------------------------------------
+# Foot-anchor projection: world point -> render pixel (top-left origin).
+# ---------------------------------------------------------------------------
+def _project_to_pixel(cam, scene, world_pt: Vector) -> tuple:
+    from bpy_extras.object_utils import world_to_camera_view
+    co = world_to_camera_view(scene, cam, world_pt)  # normalized 0..1, y up
+    rw = scene.render.resolution_x
+    rh = scene.render.resolution_y
+    px = co.x * rw
+    py = (1.0 - co.y) * rh  # flip to top-left origin
+    return int(round(px)), int(round(py))
+
+
+# ---------------------------------------------------------------------------
+# Main bake.
+# ---------------------------------------------------------------------------
+def main() -> None:
+    args = _parse_args()
+    model_path = os.path.abspath(args["model"])
+    out_dir = os.path.abspath(args["out"])
+    cell = int(args["cell"])
+    os.makedirs(out_dir, exist_ok=True)
+
+    if not os.path.isfile(model_path):
+        sys.exit("[bake_sprites] ERROR: model not found: %s" % model_path)
+
+    print("[bake_sprites] model=%s out=%s cell=%d" % (model_path, out_dir, cell))
+
+    # --- calibration pass (fresh scene, just a cube + camera) ---
+    _reset_scene()
+    _make_camera(model_height=1.0, elev_deg=ELEV_GUESS_DEG, dist=10.0)
+    elev_deg, cube_ratio = _calibrate_elevation(cell)
+
+    # --- real scene: import model, light, camera at the calibrated elevation ---
+    _reset_scene()
+    objs = _import_glb(model_path)
+    empty, model_height, mins, maxs = _setup_model(objs)
+    _add_lights()
+    cam_dist = max(model_height * 4.0, 6.0)
+    cam = _make_camera(model_height, elev_deg, cam_dist)
+
+    scene = bpy.context.scene
+    scene.render.resolution_x = cell
+    scene.render.resolution_y = cell
+    scene.render.resolution_percentage = 100
+
+    # The lowest world point of the model (its feet) — projected at the rest pose to get the
+    # foot anchor pixel. Use the foot point on the model's vertical axis (x=y=0, z=mins.z).
+    foot_world = Vector((0.0, 0.0, max(mins.z, 0.0)))
+
+    anchor_px = None
+    rendered = 0
+    for fi, facing in enumerate(FACING_ORDER):
+        base_yaw = math.radians(fi * 45.0)
+        facing_dir = _facing_world_dir(fi)
+        for anim, count in ANIMS:
+            for frame in range(count):
+                _apply_pose(empty, base_yaw, anim, frame, count, model_height, facing_dir)
+                bpy.context.view_layer.update()
+                fname = "%s_%s_%d.png" % (facing, anim, frame)
+                scene.render.filepath = os.path.join(out_dir, fname)
+                bpy.ops.render.render(write_still=True)
+                rendered += 1
+                # Capture the anchor at the canonical rest pose: S facing, idle frame 0.
+                if facing == "S" and anim == "idle" and frame == 0:
+                    anchor_px = _project_to_pixel(cam, scene, foot_world)
+
+    if anchor_px is None:
+        anchor_px = (cell // 2, int(cell * 0.9))
+
+    # Clamp anchor into the cell.
+    ax = max(0, min(cell - 1, anchor_px[0]))
+    ay = max(0, min(cell - 1, anchor_px[1]))
+
+    anchor_doc = {
+        "x": ax,
+        "y": ay,
+        "cell": cell,
+        "calibration": {
+            "camera_yaw_deg": CAMERA_YAW_DEG,
+            "camera_elevation_deg": round(elev_deg, 4),
+            "cube_top_face_ratio": round(cube_ratio, 4),
+            "target_ratio": DIMETRIC_TARGET_RATIO,
+            "tolerance": DIMETRIC_TOL,
+            "projection": "dimetric-2to1",
+        },
+        "facing_order": FACING_ORDER,
+        "anims": {name: count for name, count in ANIMS},
+        "frames_rendered": rendered,
+    }
+    with open(os.path.join(out_dir, "anchor.json"), "w") as f:
+        json.dump(anchor_doc, f, indent=2)
+        f.write("\n")
+
+    print("[bake_sprites] rendered %d frames -> %s" % (rendered, out_dir))
+    print("[bake_sprites] foot anchor px=(%d,%d) cell=%d" % (ax, ay, cell))
+    print("[bake_sprites] dimetric: elev=%.3f deg cube_top_ratio=%.4f (target %.2f)" % (
+        elev_deg, cube_ratio, DIMETRIC_TARGET_RATIO))
+    print("[bake_sprites] OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/godot/tools/meshy_gen.py
+++ b/godot/tools/meshy_gen.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""meshy_gen.py — generate a single textured 3D character via the Meshy text-to-3d API (#1062).
+
+Stage 1 of the WorldOS GT2 final-art pipeline:
+
+    meshy_gen.py  -> a textured .glb        (this tool; Meshy AI)
+    bake_sprites.py -> 8-facing frame PNGs  (Blender headless, dimetric 2:1)
+    pack_sheet.py  -> the renderer sheet.png + sheet.json manifest
+
+This tool is WorldOS-ORIGINAL code; the ART it downloads (model.glb) is NOT committed —
+it lives under content/worlds/_private/ (gitignored). See ISO-PROJECTION.md for the locked
+projection the downstream bake targets.
+
+Flow (per the verified Meshy v2 text-to-3d contract):
+  1. POST /openapi/v2/text-to-3d  mode=preview  -> task id
+  2. poll GET /openapi/v2/text-to-3d/<id> until SUCCEEDED (untextured geometry)
+  3. POST /openapi/v2/text-to-3d  mode=refine preview_task_id=<id> enable_pbr -> task id
+  4. poll until SUCCEEDED -> model_urls.glb is the TEXTURED model
+  5. download that glb to <out>/model.glb (+ thumbnail.png if available)
+
+The API key is read from ~/.worldos/meshy.key or $MESHY_API_KEY. It is NEVER printed and
+NEVER written into any repo file.
+
+Usage:
+    python3 meshy_gen.py --prompt "a stylized fantasy human ranger ..." --out <dir>
+    python3 meshy_gen.py --prompt "..." --out <dir> --no-refine   # geometry only (no texture)
+    python3 meshy_gen.py --prompt "..." --out <dir> --force        # re-generate even if model.glb exists
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+API_BASE = "https://api.meshy.ai"
+CREATE_PATH = "/openapi/v2/text-to-3d"
+POLL_TEMPLATE = "/openapi/v2/text-to-3d/{task_id}"
+
+# Polling cadence + ceilings.
+POLL_INTERVAL_SEC = 8
+DEFAULT_TIMEOUT_SEC = 600
+
+
+# ---------------------------------------------------------------------------
+# Key handling. NEVER print/log the key; NEVER write it to a repo file.
+# ---------------------------------------------------------------------------
+def _load_api_key() -> str:
+    key = os.environ.get("MESHY_API_KEY", "").strip()
+    if key:
+        return key
+    key_path = os.path.expanduser("~/.worldos/meshy.key")
+    if os.path.isfile(key_path):
+        with open(key_path, "r") as f:
+            key = f.read().strip()
+        if key:
+            return key
+    sys.exit(
+        "[meshy_gen] ERROR: no API key. Set $MESHY_API_KEY or put it in ~/.worldos/meshy.key"
+    )
+
+
+def _auth_headers(key: str) -> dict:
+    return {
+        "Authorization": "Bearer %s" % key,
+        "Content-Type": "application/json",
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTTP (urllib only — no `requests` dependency required).
+# ---------------------------------------------------------------------------
+def _post_json(url: str, headers: dict, body: dict) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = _read_error(e)
+        _explain_http(e.code, detail, "POST " + url)
+    except urllib.error.URLError as e:
+        sys.exit("[meshy_gen] ERROR: network failure on POST %s: %s" % (url, e.reason))
+
+
+def _get_json(url: str, headers: dict) -> dict:
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        detail = _read_error(e)
+        _explain_http(e.code, detail, "GET " + url)
+    except urllib.error.URLError as e:
+        sys.exit("[meshy_gen] ERROR: network failure on GET %s: %s" % (url, e.reason))
+
+
+def _read_error(e: urllib.error.HTTPError) -> str:
+    try:
+        return e.read().decode("utf-8")
+    except Exception:
+        return "<no body>"
+
+
+def _explain_http(code: int, detail: str, what: str) -> None:
+    if code == 402:
+        sys.exit(
+            "[meshy_gen] ERROR 402 insufficient Meshy credits on %s. Top up the account; "
+            "art was NOT generated. Detail: %s" % (what, detail)
+        )
+    if code == 429:
+        sys.exit(
+            "[meshy_gen] ERROR 429 rate-limited on %s. Wait and retry. Detail: %s"
+            % (what, detail)
+        )
+    sys.exit("[meshy_gen] ERROR HTTP %d on %s. Detail: %s" % (code, what, detail))
+
+
+def _download(url: str, dest: str) -> int:
+    """Stream a binary asset (glb / png) to dest. Returns bytes written."""
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=300) as resp, open(dest, "wb") as out:
+            total = 0
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                out.write(chunk)
+                total += len(chunk)
+            return total
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        sys.exit("[meshy_gen] ERROR downloading %s -> %s: %s" % (url, dest, e))
+
+
+# ---------------------------------------------------------------------------
+# Task lifecycle.
+# ---------------------------------------------------------------------------
+def _create_preview(headers: dict, prompt: str) -> str:
+    body = {
+        "mode": "preview",
+        "prompt": prompt,
+        "ai_model": "meshy-5",
+        "model_type": "standard",
+        "pose_mode": "t-pose",
+        "target_formats": ["glb"],
+        "should_remesh": True,
+        "topology": "triangle",
+        "target_polycount": 30000,
+        "auto_size": True,
+        "origin_at": "bottom",
+    }
+    res = _post_json(API_BASE + CREATE_PATH, headers, body)
+    task_id = res.get("result")
+    if not task_id:
+        sys.exit("[meshy_gen] ERROR: preview create returned no task id: %s" % json.dumps(res))
+    print("[meshy_gen] preview task submitted: %s" % task_id)
+    return task_id
+
+
+def _create_refine(headers: dict, preview_task_id: str) -> str:
+    body = {
+        "mode": "refine",
+        "preview_task_id": preview_task_id,
+        "enable_pbr": True,
+        "target_formats": ["glb"],
+    }
+    res = _post_json(API_BASE + CREATE_PATH, headers, body)
+    task_id = res.get("result")
+    if not task_id:
+        sys.exit("[meshy_gen] ERROR: refine create returned no task id: %s" % json.dumps(res))
+    print("[meshy_gen] refine task submitted: %s" % task_id)
+    return task_id
+
+
+def _poll(headers: dict, task_id: str, label: str, timeout_sec: int) -> dict:
+    """Poll a task until SUCCEEDED. Exits on FAILED / timeout. Returns the final task dict."""
+    url = API_BASE + POLL_TEMPLATE.format(task_id=task_id)
+    deadline = time.time() + timeout_sec
+    last_progress = -1
+    while True:
+        task = _get_json(url, headers)
+        status = task.get("status", "UNKNOWN")
+        progress = int(task.get("progress", 0) or 0)
+        if progress != last_progress or status not in ("PENDING", "IN_PROGRESS"):
+            print("[meshy_gen] %s status=%s progress=%d%%" % (label, status, progress))
+            last_progress = progress
+        if status == "SUCCEEDED":
+            return task
+        if status == "FAILED":
+            err = task.get("task_error") or task.get("error") or {}
+            sys.exit("[meshy_gen] ERROR: %s task FAILED: %s" % (label, json.dumps(err)))
+        if status in ("EXPIRED", "CANCELED"):
+            sys.exit("[meshy_gen] ERROR: %s task %s" % (label, status))
+        if time.time() > deadline:
+            sys.exit(
+                "[meshy_gen] ERROR: %s task timed out after %ds (last status=%s progress=%d%%). "
+                "Art was NOT completed." % (label, timeout_sec, status, progress)
+            )
+        time.sleep(POLL_INTERVAL_SEC)
+
+
+def _glb_url(task: dict) -> str:
+    urls = task.get("model_urls", {}) or {}
+    glb = urls.get("glb")
+    if not glb:
+        sys.exit("[meshy_gen] ERROR: task has no model_urls.glb: %s" % json.dumps(urls))
+    return glb
+
+
+# ---------------------------------------------------------------------------
+# Main.
+# ---------------------------------------------------------------------------
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Generate a textured .glb via Meshy text-to-3d.")
+    ap.add_argument("--prompt", required=True, help="text-to-3d prompt")
+    ap.add_argument("--out", required=True, help="output dir for model.glb (+ thumbnail.png)")
+    ap.add_argument("--no-refine", action="store_true",
+                    help="stop after preview (untextured geometry only)")
+    ap.add_argument("--force", action="store_true",
+                    help="regenerate even if <out>/model.glb already exists")
+    ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SEC,
+                    help="per-stage poll timeout in seconds (default %d)" % DEFAULT_TIMEOUT_SEC)
+    args = ap.parse_args()
+
+    out_dir = os.path.abspath(args.out)
+    os.makedirs(out_dir, exist_ok=True)
+    model_path = os.path.join(out_dir, "model.glb")
+    thumb_path = os.path.join(out_dir, "thumbnail.png")
+    meta_path = os.path.join(out_dir, "meshy_meta.json")
+
+    if os.path.exists(model_path) and not args.force:
+        print("[meshy_gen] %s already exists; skipping (use --force to regenerate)." % model_path)
+        return
+
+    key = _load_api_key()
+    headers = _auth_headers(key)
+
+    # ---- preview ----
+    preview_id = _create_preview(headers, args.prompt)
+    preview_task = _poll(headers, preview_id, "preview", args.timeout)
+
+    final_task = preview_task
+    refine_id = None
+    if args.no_refine:
+        print("[meshy_gen] --no-refine: keeping the untextured preview model.")
+    else:
+        # ---- refine (adds PBR texture) ----
+        refine_id = _create_refine(headers, preview_id)
+        final_task = _poll(headers, refine_id, "refine", args.timeout)
+
+    # ---- download ----
+    glb_url = _glb_url(final_task)
+    size = _download(glb_url, model_path)
+    print("[meshy_gen] downloaded model.glb (%d bytes) -> %s" % (size, model_path))
+
+    thumb_url = final_task.get("thumbnail_url")
+    if thumb_url:
+        try:
+            tsize = _download(thumb_url, thumb_path)
+            print("[meshy_gen] downloaded thumbnail.png (%d bytes)" % tsize)
+        except SystemExit:
+            print("[meshy_gen] (thumbnail download failed; continuing — non-fatal)")
+
+    # consumed-credits: Meshy reports per-task usage on some plans.
+    consumed = (
+        final_task.get("consumed_credits")
+        or final_task.get("credits")
+        or preview_task.get("consumed_credits")
+    )
+
+    meta = {
+        "prompt": args.prompt,
+        "preview_task_id": preview_id,
+        "refine_task_id": refine_id,
+        "refined": not args.no_refine,
+        "glb_bytes": size,
+        "consumed_credits": consumed,
+        "ai_model": "meshy-5",
+        "source": "meshy-text-to-3d-v2",
+    }
+    with open(meta_path, "w") as f:
+        json.dump(meta, f, indent=2)
+        f.write("\n")
+
+    print("[meshy_gen] OK — preview=%s refine=%s glb_bytes=%d consumed_credits=%s" % (
+        preview_id, refine_id, size, consumed))
+    print("[meshy_gen] meta -> %s" % meta_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/godot/tools/pack_sheet.py
+++ b/godot/tools/pack_sheet.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""pack_sheet.py — tile baked frames into the renderer's sprite sheet + manifest (#1062).
+
+Stage 3 of the WorldOS GT2 final-art pipeline (meshy_gen.py -> bake_sprites.py -> THIS).
+
+Reads the per-(facing,anim,frame) PNGs produced by bake_sprites.py and packs them into the
+EXACT atlas layout the Godot renderer consumes (CharacterToken.gd / ISO-PROJECTION.md):
+
+    ROWS = 8 facings, order S,SE,E,NE,N,NW,W,SW   (row index == facing index)
+    COLS = idle(4) + walk(8) + attack(6) + cast(6) = 24
+    cell = 128  =>  sheet is 3072 x 1024
+
+It then writes a sheet.json manifest IDENTICAL IN SHAPE to the committed CC0 placeholder
+manifest (godot/assets/characters/aubree/sheet.json), but with the finals' provenance:
+    source      = "meshy-blender-render"
+    license     = "proprietary-owner-generated (Meshy AI)"
+    attribution = notes the prompt + Meshy + Blender bake
+The foot `anchor` comes from the bake's anchor.json.
+
+Usage:
+    python3 pack_sheet.py --frames <frames_dir> --scope sprite-aubree-iso8 \
+        --out <assets_dir> [--out <assets_dir2> ...]   # may pass --out multiple times
+
+If a frame PNG is missing it is filled transparent (so the sheet is always well-formed),
+and the count of missing frames is reported.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from PIL import Image
+
+# Locked layout (mirrors gen_placeholder_sheet.py / CharacterToken.gd).
+CELL = 128
+FACING_ORDER = ["S", "SE", "E", "NE", "N", "NW", "W", "SW"]
+ANIMS = [("idle", 4, True), ("walk", 8, False), ("attack", 6, False), ("cast", 6, False)]
+# NOTE: loop flags below MATCH the committed placeholder manifest exactly.
+ANIM_LOOP = {"idle": True, "walk": True, "attack": False, "cast": False}
+TOTAL_COLS = sum(c for _, c, _ in ANIMS)  # 24
+FPS = 10
+
+
+def _load_anchor(frames_dir: str) -> dict:
+    path = os.path.join(frames_dir, "anchor.json")
+    if not os.path.isfile(path):
+        return {"x": CELL // 2, "y": int(CELL * 0.9)}
+    with open(path) as f:
+        doc = json.load(f)
+    return {"x": int(doc.get("x", CELL // 2)), "y": int(doc.get("y", int(CELL * 0.9)))}
+
+
+def _build_sheet(frames_dir: str, cell: int) -> tuple:
+    width = TOTAL_COLS * cell
+    height = len(FACING_ORDER) * cell
+    sheet = Image.new("RGBA", (width, height), (0, 0, 0, 0))
+    missing = 0
+    for row, facing in enumerate(FACING_ORDER):
+        col = 0
+        for anim, count, _loop in ANIMS:
+            for frame in range(count):
+                fname = "%s_%s_%d.png" % (facing, anim, frame)
+                fpath = os.path.join(frames_dir, fname)
+                if os.path.isfile(fpath):
+                    cellimg = Image.open(fpath).convert("RGBA")
+                    if cellimg.size != (cell, cell):
+                        cellimg = cellimg.resize((cell, cell), Image.LANCZOS)
+                else:
+                    cellimg = Image.new("RGBA", (cell, cell), (0, 0, 0, 0))
+                    missing += 1
+                sheet.paste(cellimg, (col * cell, row * cell))
+                col += 1
+    return sheet, missing
+
+
+def _manifest(scope: str, anchor: dict, prompt: str, cell: int) -> dict:
+    animations = {}
+    start = 0
+    for anim, count, _loop in ANIMS:
+        animations[anim] = {"start": start, "count": count, "loop": ANIM_LOOP[anim]}
+        start += count
+    return {
+        "manifest_version": 1,
+        "scope_key": scope,
+        "kind": "character",
+        "projection": "dimetric-2to1",
+        "image": "sheet.png",
+        "frame": {"w": cell, "h": cell},
+        "sheet": {"cols": TOTAL_COLS, "rows": len(FACING_ORDER)},
+        "facings": len(FACING_ORDER),
+        "facing_order": FACING_ORDER,
+        "anchor": {"x": int(anchor["x"]), "y": int(anchor["y"])},
+        "fps": FPS,
+        "animations": animations,
+        "source": "meshy-blender-render",
+        "license": "proprietary-owner-generated (Meshy AI)",
+        "attribution": (
+            "WorldOS final render — Meshy AI text-to-3d (prompt: \"%s\") baked to 8-facing "
+            "dimetric-2to1 frames via godot/tools/bake_sprites.py (Blender headless), packed "
+            "by godot/tools/pack_sheet.py." % prompt
+        ),
+    }
+
+
+def _write_outputs(sheet: Image.Image, manifest: dict, out_dirs: list) -> None:
+    for d in out_dirs:
+        os.makedirs(d, exist_ok=True)
+        sheet.save(os.path.join(d, "sheet.png"))
+        with open(os.path.join(d, "sheet.json"), "w") as f:
+            json.dump(manifest, f, indent=2, ensure_ascii=False)
+            f.write("\n")
+        print("[pack_sheet] wrote sheet.png + sheet.json -> %s" % d)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Pack baked frames into the renderer sprite sheet.")
+    ap.add_argument("--frames", required=True, help="dir of <facing>_<anim>_<i>.png + anchor.json")
+    ap.add_argument("--scope", default="sprite-aubree-iso8", help="manifest scope_key")
+    ap.add_argument("--out", required=True, action="append",
+                    help="output assets dir (repeatable: writes sheet.png+sheet.json to each)")
+    ap.add_argument("--prompt", default="(prompt unrecorded)",
+                    help="the Meshy prompt, for attribution provenance")
+    ap.add_argument("--cell", type=int, default=CELL, help="cell size (default %d)" % CELL)
+    args = ap.parse_args()
+
+    frames_dir = os.path.abspath(args.frames)
+    if not os.path.isdir(frames_dir):
+        raise SystemExit("[pack_sheet] ERROR: frames dir not found: %s" % frames_dir)
+
+    # Prefer the prompt recorded by meshy_gen.py (meshy_meta.json) if --prompt not given.
+    prompt = args.prompt
+    meta_candidates = [
+        os.path.join(frames_dir, "meshy_meta.json"),
+        os.path.join(os.path.dirname(frames_dir), "meshy_meta.json"),
+    ]
+    if prompt == "(prompt unrecorded)":
+        for mc in meta_candidates:
+            if os.path.isfile(mc):
+                try:
+                    with open(mc) as f:
+                        prompt = json.load(f).get("prompt", prompt)
+                    break
+                except Exception:
+                    pass
+
+    anchor = _load_anchor(frames_dir)
+    sheet, missing = _build_sheet(frames_dir, args.cell)
+    manifest = _manifest(args.scope, anchor, prompt, args.cell)
+    _write_outputs(sheet, manifest, args.out)
+
+    print("[pack_sheet] sheet dims=%s anchor=(%d,%d) missing_frames=%d" % (
+        str(sheet.size), anchor["x"], anchor["y"], missing))
+    expected = (TOTAL_COLS * args.cell, len(FACING_ORDER) * args.cell)
+    assert sheet.size == expected, "sheet must be %s, got %s" % (expected, sheet.size)
+    if missing:
+        print("[pack_sheet] WARNING: %d frames were missing and filled transparent" % missing)
+    print("[pack_sheet] OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1062. The painterly/quality asset pipeline for the GT2 Godot renderer (epic #1050) — turns 3D models into the directional sprite sheets the renderer already consumes.

## What (committed tools — WorldOS-original)
- **`tools/meshy_gen.py`** — Meshy text-to-3D (preview → refine/PBR → download `model.glb`). Key from `~/.worldos/meshy.key`/`$MESHY_API_KEY` (never committed/printed).
- **`tools/bake_sprites.py`** — Blender 5.1 headless: orthographic camera **auto-calibrated to the LOCKED dimetric 2:1** (elevation ~29.53° → a unit floor-tile's top face renders exactly 2.0000), 8 facings (`S,SE,E,NE,N,NW,W,SW`) × idle4/walk8/attack6/cast6 with synthesized motion; foot-anchor projection.
- **`tools/pack_sheet.py`** — tiles to the renderer's 8-row × 24-col 128px layout (3072×1024) + emits `sheet.json` matching the placeholder manifest field-for-field (`source:"meshy-blender-render"`).
- **`tools/README.md`** — the pipeline + the committed-CC0 vs `_private`-finals posture.

## Proven end-to-end (live)
Generated a textured **ranger** via Meshy (preview `019ee6c0…` + refine `019ee6c1…`, **10 credits**, 8.8 MB glb) → baked a **3072×1024** sheet → dropped at `sprite-aubree-iso8` → Godot `--import` clean, smoke `anims=32`, `--demo-occlusion` **behind=pass / front=pass** showing the **real ranger** occluding/occluded by the pillar. (Screenshots attached in chat.)

## Art posture (no licensing-tier creep)
The committed tree keeps the **CC0 placeholder** as the default. The Meshy-generated finals (owner-licensed, AI-generated) live in **gitignored `content/worlds/_private/…`** — served at runtime, never committed — matching the posture set in #1054. The served-finals wiring is **#1063**; AI provenance goes in the render-profile `ai_disclosure` block.

Next backlog: #1063 (serve finals via `/sprite?scope=`), painterly **backgrounds** via the existing image-gen infra, #1064 (license gate — will need an "owner-generated" tier alongside CC0).