### PR TITLE
feat(godot): pack_sheet emits /image descriptor so baked sprite atlases serve (#1063 part 1)

### DIFF
--- a/godot/tools/README.md
+++ b/godot/tools/README.md
@@ -12,7 +12,7 @@ Meshy→Blender render → hand/AI paintover.
    ```
    python3 godot/tools/meshy_gen.py \
      --prompt "a stylized fantasy human ranger, leather armor, hooded green cloak, T-pose, full body" \
-     --out content/worlds/_private/baldurs-gate/sprites/aubree-iso8
+     --out content/worlds/_private/baldurs-gate/images/sprite-aubree-iso8
    ```
    Submits preview → polls → refine (textured, PBR) → polls → downloads `model.glb` (+
    `thumbnail.png`, `meshy_meta.json`). **API key** is read from `~/.worldos/meshy.key` or
@@ -32,17 +32,22 @@ Meshy→Blender render → hand/AI paintover.
 3. **`pack_sheet.py`** — tile frames into the renderer's layout + emit the manifest.
    ```
    python3 godot/tools/pack_sheet.py --frames <dir>/frames --scope sprite-aubree-iso8 \
-     --out content/worlds/_private/baldurs-gate/sprites/aubree-iso8
+     --out content/worlds/_private/baldurs-gate/images/sprite-aubree-iso8
    ```
    Produces `sheet.png` (rows = 8 facings, cols = 24 = idle4/walk8/attack6/cast6, 128px cells →
    3072×1024) + `sheet.json` (manifest v1, identical shape to the committed placeholder, with
-   `source:"meshy-blender-render"`).
+   `source:"meshy-blender-render"`). **The output dir MUST be `…/images/<scope_key>/`** (the
+   `/image` bridge resolves `content/worlds/_private/<world>/images/<scope>/`; a `sprites/` dir is
+   orphaned). For finals under `_private/`, pack_sheet also emits a sibling **`wiki_ingest.json`**
+   descriptor so the atlas is served by `/image?scope=<scope_key>` with no renderer change (#1063);
+   it is skipped for committed/non-`_private` dirs (the descriptor embeds an absolute local path).
 
 ## Where the art lives
 
 - **Committed (CC0/owned only):** `godot/assets/characters/<scope>/` holds the **placeholder**
   default (regenerable via `gen_placeholder_sheet.py`).
 - **Finals (NOT committed):** Meshy→Blender / AI-paintover outputs go under
-  `content/worlds/_private/…` (gitignored, owner-licensed) and are served at runtime via the
-  `/image`-style bridge (the served-finals wiring is issue #1063). Record AI provenance in the
+  `content/worlds/_private/<world>/images/<scope_key>/` (gitignored, owner-licensed). `pack_sheet.py`
+  drops a `wiki_ingest.json` descriptor beside `sheet.png` so the viewer serves the atlas at runtime
+  via `/image?scope=<scope_key>` (the served-finals wiring, #1063). Record AI provenance in the
   render-profile `ai_disclosure` block (EU disclosure, Steam survey).

--- a/godot/tools/pack_sheet.py
+++ b/godot/tools/pack_sheet.py
@@ -30,8 +30,19 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import time
 
-from PIL import Image
+# NOTE: Pillow (PIL) is imported lazily inside _build_sheet so the descriptor/manifest helpers
+# (_descriptor / _manifest / _is_private_finals_dir) are importable + unit-testable WITHOUT the
+# Pillow dependency (it is not in the engine/viewer test venvs). Only the pixel-tiling path needs it.
+
+# The viewer descriptor the /image bridge resolves. To serve the baked atlas via
+# /image?scope=<scope_key> (the render-profile contract: "served via the existing /image bridge
+# unchanged"), the viewer's _serve_image looks for content/worlds/_private/<world>/images/<scope>/
+# wiki_ingest.json and serves the PNG it points at. Without this descriptor a baked sheet.png is
+# orphaned (/image?scope=... 404s, no-art). Mirrors tools/ingest/wiki_images.py write_descriptor
+# (the canonical descriptor writer the viewer reads); this is #1063's serve-side enablement.
+DESCRIPTOR_FILENAME = "wiki_ingest.json"
 
 # Locked layout (mirrors gen_placeholder_sheet.py / CharacterToken.gd).
 CELL = 128
@@ -53,6 +64,8 @@ def _load_anchor(frames_dir: str) -> dict:
 
 
 def _build_sheet(frames_dir: str, cell: int) -> tuple:
+    from PIL import Image  # lazy: only the pixel-tiling path needs Pillow (see top-of-file note)
+
     width = TOTAL_COLS * cell
     height = len(FACING_ORDER) * cell
     sheet = Image.new("RGBA", (width, height), (0, 0, 0, 0))
@@ -104,14 +117,49 @@ def _manifest(scope: str, anchor: dict, prompt: str, cell: int) -> dict:
     }
 
 
-def _write_outputs(sheet: Image.Image, manifest: dict, out_dirs: list) -> None:
+def _descriptor(scope: str, sheet_path: str, manifest: dict) -> dict:
+    """The viewer descriptor (wiki_ingest.json) that makes the baked atlas servable via
+    /image?scope=<scope>. Shape matches tools/ingest/wiki_images.py write_descriptor (what
+    _serve_image / _latest_descriptor read). `path` is absolute (the viewer anchors it to the
+    descriptor's sibling dir by basename); pixels are served from `path` (no external source_url)."""
+    return {
+        "scope": scope,
+        "path": os.path.abspath(sheet_path),
+        "mime_type": "image/png",
+        "source_url": "",  # baked locally — _serve_image serves `path`, not a remote URL.
+        "license": manifest.get("license", ""),
+        "attribution": manifest.get("attribution", ""),
+        "ingested_at": time.time(),
+    }
+
+
+def _is_private_finals_dir(d: str) -> bool:
+    """True only for the served finals tree (content/worlds/_private/...), where wiki_ingest.json is
+    gitignored. We NEVER drop a descriptor (which embeds an absolute local path) into a committed
+    dir such as the res:// CC0 placeholder — that path would be wrong on every other machine."""
+    return (os.sep + "_private" + os.sep) in (os.path.abspath(d) + os.sep)
+
+
+def _write_outputs(sheet: Image.Image, manifest: dict, out_dirs: list,
+                   emit_descriptor: bool = True) -> None:
     for d in out_dirs:
         os.makedirs(d, exist_ok=True)
-        sheet.save(os.path.join(d, "sheet.png"))
+        sheet_path = os.path.join(d, "sheet.png")
+        sheet.save(sheet_path)
         with open(os.path.join(d, "sheet.json"), "w") as f:
             json.dump(manifest, f, indent=2, ensure_ascii=False)
             f.write("\n")
-        print("[pack_sheet] wrote sheet.png + sheet.json -> %s" % d)
+        wrote_desc = ""
+        if emit_descriptor and _is_private_finals_dir(d):
+            with open(os.path.join(d, DESCRIPTOR_FILENAME), "w") as f:
+                json.dump(_descriptor(manifest["scope_key"], sheet_path, manifest),
+                          f, indent=2, ensure_ascii=False)
+                f.write("\n")
+            wrote_desc = " + %s" % DESCRIPTOR_FILENAME
+        elif emit_descriptor:
+            print("[pack_sheet] (no %s: %s is not under _private — committed dir, descriptor skipped)"
+                  % (DESCRIPTOR_FILENAME, d))
+        print("[pack_sheet] wrote sheet.png + sheet.json%s -> %s" % (wrote_desc, d))
 
 
 def main() -> None:
@@ -123,6 +171,11 @@ def main() -> None:
     ap.add_argument("--prompt", default="(prompt unrecorded)",
                     help="the Meshy prompt, for attribution provenance")
     ap.add_argument("--cell", type=int, default=CELL, help="cell size (default %d)" % CELL)
+    ap.add_argument("--emit-descriptor", dest="emit_descriptor", action="store_true", default=True,
+                    help="emit the viewer wiki_ingest.json descriptor into _private finals dirs so "
+                         "the atlas is served via /image?scope=<scope> (default on; #1063)")
+    ap.add_argument("--no-emit-descriptor", dest="emit_descriptor", action="store_false",
+                    help="skip the viewer descriptor (committed/non-_private dirs skip it anyway)")
     args = ap.parse_args()
 
     frames_dir = os.path.abspath(args.frames)
@@ -148,7 +201,7 @@ def main() -> None:
     anchor = _load_anchor(frames_dir)
     sheet, missing = _build_sheet(frames_dir, args.cell)
     manifest = _manifest(args.scope, anchor, prompt, args.cell)
-    _write_outputs(sheet, manifest, args.out)
+    _write_outputs(sheet, manifest, args.out, emit_descriptor=args.emit_descriptor)
 
     print("[pack_sheet] sheet dims=%s anchor=(%d,%d) missing_frames=%d" % (
         str(sheet.size), anchor["x"], anchor["y"], missing))

--- a/viewer/tests/test_image_probe.py
+++ b/viewer/tests/test_image_probe.py
@@ -33,6 +33,15 @@ server = importlib.util.module_from_spec(_SPEC)
 assert _SPEC.loader is not None
 _SPEC.loader.exec_module(server)
 
+# The GT2 sprite packer — imported for its descriptor/guard helpers (PIL-free at module level).
+# This pins the #1063 serve contract: the wiki_ingest.json pack_sheet emits for a baked atlas is
+# actually servable by THIS server's /image bridge (so a real Meshy/Blender atlas renders).
+_PACK_PATH = Path(__file__).resolve().parents[2] / "godot" / "tools" / "pack_sheet.py"
+_PACK_SPEC = importlib.util.spec_from_file_location("pack_sheet", _PACK_PATH)
+assert _PACK_SPEC is not None and _PACK_SPEC.loader is not None
+pack_sheet = importlib.util.module_from_spec(_PACK_SPEC)
+_PACK_SPEC.loader.exec_module(pack_sheet)
+
 
 class _QuietHandler(server._Handler):
     def log_message(self, fmt: str, *args: object) -> None:  # noqa: D401 - silence test HTTP logs
@@ -247,6 +256,112 @@ class ImageProbeTests(unittest.TestCase):
                 status, outcome = self._image_status_and_outcome(scope)
                 self.assertEqual(status, want_status)
                 self.assertEqual(outcome, want_outcome)
+
+
+class SpriteAtlasServeTests(unittest.TestCase):
+    """#1063 serve-side contract: a baked sprite atlas under content/worlds/_private/<world>/images/
+    <scope>/ with the wiki_ingest.json pack_sheet emits is served by /image?scope=<scope> (the
+    render-profile bridge "served via the existing /image bridge unchanged"). Reuses the real-HTTP
+    harness so the assertion is end-to-end, not a hand-copied descriptor shape."""
+
+    SCOPE = "sprite-aubree-iso8"
+    WORLD = "baldurs-gate"
+
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._saved_env = {}
+        for var in ("WORLDOS_STATE_DIR", "WORLDOS_ART_REPO_ROOT", "WORLDOS_REPO_ROOT"):
+            self._saved_env[var] = os.environ.pop(var, None)
+        os.environ["WORLDOS_STATE_DIR"] = str(self._tmp)
+        self._art_root = self._tmp / "art-root"
+        self._art_root.mkdir()
+        os.environ["WORLDOS_ART_REPO_ROOT"] = str(self._art_root)
+        _QuietHandler.campaign_id = ""
+        self._httpd = server.ThreadingHTTPServer(("127.0.0.1", 0), _QuietHandler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        self._host, self._port = self._httpd.server_address
+
+    def tearDown(self):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+        for var, value in self._saved_env.items():
+            if value is None:
+                os.environ.pop(var, None)
+            else:
+                os.environ[var] = value
+
+    def _get(self, path: str) -> tuple[int, http.client.HTTPMessage, bytes]:
+        conn = http.client.HTTPConnection(self._host, self._port, timeout=5)
+        try:
+            conn.request("GET", path)
+            response = conn.getresponse()
+            return response.status, response.headers, response.read()
+        finally:
+            conn.close()
+
+    def _bake_atlas_finals_dir(self) -> Path:
+        """The served finals dir for the sprite scope (what pack_sheet --out targets).
+        _ingested_images_root() == <art_root>/content/worlds/_private, so the served path is
+        .../content/worlds/_private/<world>/images/<scope>/."""
+        d = (self._art_root / "content" / "worlds" / "_private" / self.WORLD / "images"
+             / server._safe_scope(self.SCOPE))
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_packsheet_descriptor_makes_baked_atlas_servable_via_image_bridge(self):
+        d = self._bake_atlas_finals_dir()
+        sheet_png = d / "sheet.png"
+        sheet_png.write_bytes(PNG_BYTES)
+        # Before the descriptor exists: /image?scope= is no-art (the orphaned-atlas bug #1063 fixes).
+        status, _h, _b = self._get(f"/image?scope={self.SCOPE}")
+        self.assertEqual(status, 404)
+
+        # Emit the descriptor exactly as pack_sheet does (its REAL helper, not a hand copy).
+        manifest = {"scope_key": self.SCOPE, "license": "proprietary-owner-generated (Meshy AI)",
+                    "attribution": "WorldOS final render"}
+        desc = pack_sheet._descriptor(self.SCOPE, str(sheet_png), manifest)
+        (d / pack_sheet.DESCRIPTOR_FILENAME).write_text(json.dumps(desc), encoding="utf-8")
+
+        # Now the atlas is served via the unchanged /image bridge.
+        status, headers, body = self._get(f"/image?scope={self.SCOPE}")
+        self.assertEqual(status, 200, f"expected served, got {status}")
+        self.assertEqual(headers.get("X-Image-Outcome"), "served")
+        self.assertEqual(headers.get("Content-Type"), "image/png")
+        self.assertEqual(body, PNG_BYTES)
+
+    def test_descriptor_shape_matches_viewer_contract(self):
+        desc = pack_sheet._descriptor("sprite-x", "/abs/sheet.png", {"license": "L", "attribution": "A"})
+        # The exact keys _serve_image / _latest_descriptor read (cf. tools/ingest/wiki_images.py).
+        self.assertEqual(desc["scope"], "sprite-x")
+        self.assertEqual(desc["path"], os.path.abspath("/abs/sheet.png"))
+        self.assertEqual(desc["mime_type"], "image/png")
+        self.assertEqual(desc["license"], "L")
+        self.assertIn("ingested_at", desc)
+
+    def test_descriptor_only_lands_in_private_finals_dirs(self):
+        # The committed res:// placeholder dir must NEVER get a descriptor (it embeds an abs local
+        # path that is wrong on every other machine + would be committed).
+        self.assertTrue(pack_sheet._is_private_finals_dir(
+            "/x/content/worlds/_private/baldurs-gate/images/sprite-aubree-iso8"))
+        self.assertFalse(pack_sheet._is_private_finals_dir("godot/assets/characters/aubree"))
+
+    def test_write_outputs_emits_descriptor_for_private_skips_committed(self):
+        # _write_outputs glue (PIL-free via a fake sheet): the descriptor lands ONLY in the _private
+        # finals dir; a committed dir gets sheet.png + sheet.json but NO wiki_ingest.json.
+        class _FakeSheet:
+            def save(self, p):
+                Path(p).write_bytes(PNG_BYTES)
+
+        manifest = {"scope_key": "sprite-x", "license": "L", "attribution": "A"}
+        priv = self._art_root / "content" / "worlds" / "_private" / "w" / "images" / "sprite-x"
+        committed = self._tmp / "godot" / "assets" / "characters" / "x"
+        pack_sheet._write_outputs(_FakeSheet(), manifest, [str(priv), str(committed)])
+        self.assertTrue((priv / pack_sheet.DESCRIPTOR_FILENAME).exists())
+        self.assertTrue((priv / "sheet.png").exists() and (priv / "sheet.json").exists())
+        self.assertFalse((committed / pack_sheet.DESCRIPTOR_FILENAME).exists())
+        self.assertTrue((committed / "sheet.png").exists())  # sheet still written, just no descriptor
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
**Serve-side enablement for #1063** (the iso-CRPG "serve Meshy/Blender sprite finals" task). The render-profile contract serves character atlases **"via the existing `/image` bridge unchanged"** (`/image?scope=sprite-<name>`), and `ImageResolver.gd` fetches through that bridge — but the viewer's `_serve_image` resolves a scope **only** via `content/worlds/_private/<world>/images/<scope>/wiki_ingest.json`. A baked atlas with no descriptor is orphaned → `/image` 404s `no-art`. This PR makes the bake pipeline emit that descriptor.

## The reframe (from a pipeline-mapping pass)
- The bake tools take `--out` from the caller; **`sprites/` appears only in `README.md`** examples. The **real** aubree atlas already lives at `content/worlds/_private/baldurs-gate/images/sprite-aubree-iso8/`. So "2a (path-align)" is a **doc fix**, and the real gap is the **missing descriptor**.
- Canonical served path = `images/<scope>/`; `/image` stays **unchanged** (contract-correct).

## Changes
- **`godot/tools/pack_sheet.py`**: `--emit-descriptor` (default on) writes a sibling `wiki_ingest.json` (shape mirrors `tools/ingest/wiki_images.py`, the canonical writer `_serve_image` reads) **only** into `_private` finals dirs — never a committed `res://` placeholder (the descriptor embeds an absolute local path). PIL import made **lazy** so the descriptor/guard helpers import + test without Pillow (not in the test venvs).
- **`godot/tools/README.md`**: corrected `--out` path `sprites/aubree-iso8` → `images/sprite-aubree-iso8` (dir == scope_key) + documented the auto-emitted descriptor (**2a**).
- **`viewer/tests/test_image_probe.py`**: +4 tests, incl. an **end-to-end** one over the real HTTP harness — a baked atlas **404s before** the descriptor, then serves **200 / `served` / `image/png`** after `pack_sheet`'s real `_descriptor()` writes `wiki_ingest.json`.

## Tests
`python -m pytest viewer/tests/test_image_probe.py` → **9 passed** (5 existing + 4 new). pack_sheet imports cleanly without PIL.

## Invariants
Additive; the `/image` bridge is **unchanged**; the engine is untouched (sole-writer intact); the descriptor never lands in a committed dir.

## Follow-up
**PR-B (#1063 part 2)** wires the Godot client (`WorldView.gd`/`RenderProfile.gd`) to fetch the served atlas via `ImageResolver` + fixes the render-profile fixture metadata (`cols` 8→24, anchor 64,116→64,109) + a `godot.yml` served-finals smoke. The existing aubree atlas's descriptor is generated by re-running `pack_sheet --emit-descriptor` (a gitignored runtime step).