### PR TITLE
feat(godot): render served sprite finals via /image (#1063 part 2)

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -93,27 +93,36 @@ jobs:
       - name: Conformance — SERVED sprite final renders via /image (#1063 part 2)
         run: |
           set -euxo pipefail
-          # Serve the committed REAL placeholder PNG as the "Meshy/Blender final" atlas
-          # for scope sprite-aubree-iso8 by writing the same wiki_ingest.json descriptor
-          # pack_sheet.py emits (#1078 serve-side), then start the real viewer /image
-          # bridge. The PNG MUST be a real decodable 24x8 sheet (it is — the committed
-          # placeholder), else /image serves nothing → the client MISSes → the smoke
-          # fails loudly (proving the served path actually drives the render).
-          WORLD="gt2-served-smoke"
-          SDIR="content/worlds/_private/${WORLD}/images/sprite-aubree-iso8"
-          mkdir -p "$SDIR"
-          cp godot/assets/characters/aubree/sheet.png "$SDIR/sheet.png"
-          ABS_PNG="$(cd "$SDIR" && pwd)/sheet.png"
-          DESC="$SDIR/wiki_ingest.json"
-          # Write the SAME descriptor shape pack_sheet.py --emit-descriptor emits (#1078).
-          python3 -c 'import json,sys,time; json.dump({"scope":"sprite-aubree-iso8","path":sys.argv[2],"mime_type":"image/png","source_url":"","license":"CC0-1.0","attribution":"GT2 served-finals CI smoke","ingested_at":time.time()}, open(sys.argv[1],"w"), indent=2)' "$DESC" "$ABS_PNG"
-          echo "[smoke] wrote descriptor -> $DESC"
-          # Start the real viewer /image bridge (bare python3 — no engine/LLM deps).
+          # Serve the committed REAL placeholder PNG as the SERVED Meshy/Blender "final"
+          # atlas for scope sprite-aubree-iso8 (the PNG is a real decodable 24x8 sheet, so
+          # a MISS can't pass). We use a tiny /image-ONLY stub (not the full viewer): it
+          # serves the PNG for /image?scope=... but 404s the SurfaceClient surface
+          # endpoints, so the client stays in FIXTURE snapshot mode (party[0]=char-aubree
+          # spawns the token) while ImageResolver fetches the SERVED atlas from the same
+          # base_url. Pointing at a gameLESS live viewer would empty the party (no token).
+          cp godot/assets/characters/aubree/sheet.png /tmp/served_atlas.png
+          cat > /tmp/image_stub.py <<'PY'
+          import sys, http.server
+          PNG = open("/tmp/served_atlas.png", "rb").read()
+          class H(http.server.BaseHTTPRequestHandler):
+              def log_message(self, *a): pass
+              def do_GET(self):
+                  if self.path.startswith("/image"):
+                      self.send_response(200)
+                      self.send_header("Content-Type", "image/png")
+                      self.send_header("Content-Length", str(len(PNG)))
+                      self.end_headers()
+                      self.wfile.write(PNG)
+                  else:
+                      # 404 the surface/events endpoints -> SurfaceClient falls to FIXTURE.
+                      self.send_response(404); self.end_headers()
+          http.server.ThreadingHTTPServer(("127.0.0.1", int(sys.argv[1])), H).serve_forever()
+          PY
           PORT=8799
-          python3 viewer/server.py "" "$PORT" > /tmp/viewer.log 2>&1 &
-          VIEWER_PID=$!
-          trap 'kill $VIEWER_PID 2>/dev/null || true' EXIT
-          # Wait until /image?scope=sprite-aubree-iso8 actually serves the PNG (200).
+          python3 /tmp/image_stub.py "$PORT" > /tmp/stub.log 2>&1 &
+          STUB_PID=$!
+          trap 'kill $STUB_PID 2>/dev/null || true' EXIT
+          # Wait until /image actually serves the PNG (200).
           for i in $(seq 1 50); do
             code=$(curl -s -o /tmp/served.png -w '%{http_code}' "http://127.0.0.1:${PORT}/image?scope=sprite-aubree-iso8" || true)
             if [ "$code" = "200" ]; then echo "[smoke] /image served 200 after ${i} tries"; break; fi
@@ -122,16 +131,16 @@ jobs:
           test "$code" = "200"   # the stub MUST serve a real PNG or the smoke is meaningless
           # The served PNG must decode (PNG magic) so the client doesn't silently MISS.
           head -c4 /tmp/served.png | od -An -tx1 | grep -qi "89 50 4e 47"
-          # Drive the Godot client against the live /image bridge. The snapshot still
-          # comes from the bundled fixture (party[0]=char-aubree), but ImageResolver
-          # fetches the SERVED atlas from this base_url and re-slices the token.
+          # The surface endpoints MUST 404 so the snapshot comes from the fixture.
+          test "$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:${PORT}/atlas-surface" || true)" = "404"
+          # Drive the Godot client: FIXTURE snapshot (party[0]=char-aubree) spawns the
+          # token; ImageResolver fetches the SERVED atlas from base_url and re-slices it.
           godot --headless --path godot --quit-after 300 -- --served-finals-smoke --base "http://127.0.0.1:${PORT}" 2>&1 | tee /tmp/served.log
           grep -q "resolver_cached=true" /tmp/served.log
           grep -q "served-atlas-applied=true" /tmp/served.log
           # Belt-and-suspenders: the served token still carries the full 32 anims.
           grep -qE "\[ServedFinals\] RESULT served-atlas-applied=true resolver_cached=true anims=32" /tmp/served.log
-          kill $VIEWER_PID 2>/dev/null || true
-          rm -rf "content/worlds/_private/${WORLD}"
+          kill $STUB_PID 2>/dev/null || true
 
       - name: Export validation — Web (single-threaded) + Linux
         working-directory: godot

--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -90,6 +90,49 @@ jobs:
           grep -q "move_to_zone-emitted=true" /tmp/smoke.log
           grep -q "illegal-kind blocked=true" /tmp/smoke.log
 
+      - name: Conformance — SERVED sprite final renders via /image (#1063 part 2)
+        run: |
+          set -euxo pipefail
+          # Serve the committed REAL placeholder PNG as the "Meshy/Blender final" atlas
+          # for scope sprite-aubree-iso8 by writing the same wiki_ingest.json descriptor
+          # pack_sheet.py emits (#1078 serve-side), then start the real viewer /image
+          # bridge. The PNG MUST be a real decodable 24x8 sheet (it is — the committed
+          # placeholder), else /image serves nothing → the client MISSes → the smoke
+          # fails loudly (proving the served path actually drives the render).
+          WORLD="gt2-served-smoke"
+          SDIR="content/worlds/_private/${WORLD}/images/sprite-aubree-iso8"
+          mkdir -p "$SDIR"
+          cp godot/assets/characters/aubree/sheet.png "$SDIR/sheet.png"
+          ABS_PNG="$(cd "$SDIR" && pwd)/sheet.png"
+          DESC="$SDIR/wiki_ingest.json"
+          # Write the SAME descriptor shape pack_sheet.py --emit-descriptor emits (#1078).
+          python3 -c 'import json,sys,time; json.dump({"scope":"sprite-aubree-iso8","path":sys.argv[2],"mime_type":"image/png","source_url":"","license":"CC0-1.0","attribution":"GT2 served-finals CI smoke","ingested_at":time.time()}, open(sys.argv[1],"w"), indent=2)' "$DESC" "$ABS_PNG"
+          echo "[smoke] wrote descriptor -> $DESC"
+          # Start the real viewer /image bridge (bare python3 — no engine/LLM deps).
+          PORT=8799
+          python3 viewer/server.py "" "$PORT" > /tmp/viewer.log 2>&1 &
+          VIEWER_PID=$!
+          trap 'kill $VIEWER_PID 2>/dev/null || true' EXIT
+          # Wait until /image?scope=sprite-aubree-iso8 actually serves the PNG (200).
+          for i in $(seq 1 50); do
+            code=$(curl -s -o /tmp/served.png -w '%{http_code}' "http://127.0.0.1:${PORT}/image?scope=sprite-aubree-iso8" || true)
+            if [ "$code" = "200" ]; then echo "[smoke] /image served 200 after ${i} tries"; break; fi
+            sleep 0.2
+          done
+          test "$code" = "200"   # the stub MUST serve a real PNG or the smoke is meaningless
+          # The served PNG must decode (PNG magic) so the client doesn't silently MISS.
+          head -c4 /tmp/served.png | od -An -tx1 | grep -qi "89 50 4e 47"
+          # Drive the Godot client against the live /image bridge. The snapshot still
+          # comes from the bundled fixture (party[0]=char-aubree), but ImageResolver
+          # fetches the SERVED atlas from this base_url and re-slices the token.
+          godot --headless --path godot --quit-after 300 -- --served-finals-smoke --base "http://127.0.0.1:${PORT}" 2>&1 | tee /tmp/served.log
+          grep -q "resolver_cached=true" /tmp/served.log
+          grep -q "served-atlas-applied=true" /tmp/served.log
+          # Belt-and-suspenders: the served token still carries the full 32 anims.
+          grep -qE "\[ServedFinals\] RESULT served-atlas-applied=true resolver_cached=true anims=32" /tmp/served.log
+          kill $VIEWER_PID 2>/dev/null || true
+          rm -rf "content/worlds/_private/${WORLD}"
+
       - name: Export validation — Web (single-threaded) + Linux
         working-directory: godot
         run: |

--- a/godot/autoload/RenderProfile.gd
+++ b/godot/autoload/RenderProfile.gd
@@ -22,6 +22,9 @@ extends Node
 
 ## Fallback default facing when the profile omits `renderer_profiles.godot.default_facing`.
 const DEFAULT_FACING := "S"
+## The locked dimetric facing order (ISO-PROJECTION.md) — the row layout a served
+## atlas is sliced by when the actor_sheet omits its own `facing_order`.
+const DEFAULT_FACING_ORDER := ["S", "SE", "E", "NE", "N", "NW", "W", "SW"]
 ## Default dimetric projection (matches the ISO-PROJECTION.md lock) when the
 ## profile omits `renderer_profiles.godot.projection`.
 const DEFAULT_PROJECTION := {"kind": "dimetric", "tile_ratio": "2:1", "angle_deg": 26.57}
@@ -106,6 +109,53 @@ func godot_actor_sheet(engine_actor_id: String) -> Dictionary:
 		return {}
 	var entry: Variant = (sheets as Dictionary).get(engine_actor_id, {})
 	return entry if typeof(entry) == TYPE_DICTIONARY else {}
+
+
+## Build the FULL slicing manifest for an engine actor's SERVED atlas, in the EXACT
+## shape CharacterToken.set_manifest() consumes (frame:{w,h}, facing_order, anchor:{x,y},
+## fps, animations:{<name>:{start,count,loop}}, kind, projection). The SERVED atlas is
+## ONLY a PNG (fetched via /image?scope=<sheet_scope_key>) — there is NO served sheet.json,
+## so the slicing layout MUST come from the render-profile actor_sheet here (#1063 part 2).
+## Returns {} when the actor is unmapped OR the actor_sheet carries no `animations` table
+## (an incomplete profile) — WorldView then keeps the committed res:// placeholder.
+func godot_served_manifest(engine_actor_id: String) -> Dictionary:
+	var meta := godot_actor_sheet(engine_actor_id)
+	if meta.is_empty():
+		return {}
+	var anims_v: Variant = meta.get("animations", {})
+	if typeof(anims_v) != TYPE_DICTIONARY or (anims_v as Dictionary).is_empty():
+		# Without an animations table we cannot slice — fall back to the committed sheet.
+		return {}
+
+	var cw := int(meta.get("cell_w", 128))
+	var ch := int(meta.get("cell_h", 128))
+
+	# facing_order: pass through if the profile declares it; else the locked default.
+	var fo_v: Variant = meta.get("facing_order", DEFAULT_FACING_ORDER)
+	var facing_order: Array = (fo_v as Array).duplicate() if typeof(fo_v) == TYPE_ARRAY and not (fo_v as Array).is_empty() else DEFAULT_FACING_ORDER.duplicate()
+
+	# anchor: profile carries [x, y]; CharacterToken wants {x, y}.
+	var ax := cw / 2.0
+	var ay := float(ch)
+	var anch_v: Variant = meta.get("anchor", null)
+	if typeof(anch_v) == TYPE_ARRAY and (anch_v as Array).size() >= 2:
+		var a: Array = anch_v
+		ax = float(a[0])
+		ay = float(a[1])
+
+	# animations: pass the table through verbatim (already {name:{start,count,loop}}).
+	var animations: Dictionary = anims_v
+
+	return {
+		"kind": String(meta.get("kind", "character")),
+		"projection": String(meta.get("projection", "dimetric-2to1")),
+		"image": "sheet.png",
+		"frame": {"w": cw, "h": ch},
+		"facing_order": facing_order,
+		"anchor": {"x": ax, "y": ay},
+		"fps": float(meta.get("fps", 10)),
+		"animations": animations,
+	}
 
 
 ## The dimetric projection block (kind/tile_ratio/angle_deg). Falls back to the

--- a/godot/fixtures/render-profile.json
+++ b/godot/fixtures/render-profile.json
@@ -40,14 +40,23 @@
       "actor_sheets": {
         "char-aubree": {
           "sheet_scope_key": "sprite-aubree-iso8",
+          "kind": "character",
+          "projection": "dimetric-2to1",
           "facings": 8,
           "facing_order": ["S", "SE", "E", "NE", "N", "NW", "W", "SW"],
-          "frames_per_facing": 8,
-          "cols": 8,
+          "frames_per_facing": 24,
+          "cols": 24,
           "rows": 8,
           "cell_w": 128,
           "cell_h": 128,
-          "anchor": [64, 116]
+          "fps": 10,
+          "anchor": [64, 109],
+          "animations": {
+            "idle": { "start": 0, "count": 4, "loop": true },
+            "walk": { "start": 4, "count": 8, "loop": true },
+            "attack": { "start": 12, "count": 6, "loop": false },
+            "cast": { "start": 18, "count": 6, "loop": false }
+          }
         }
       }
     }

--- a/godot/scenes/Main.gd
+++ b/godot/scenes/Main.gd
@@ -93,6 +93,9 @@ func _on_snapshot(atlas: Dictionary, _combat: Dictionary, character: Dictionary)
 		if _has_arg("--smoke-intent"):
 			call_deferred("_run_smoke_intent")
 			return
+		if _has_arg("--served-finals-smoke"):
+			call_deferred("_run_served_finals_smoke")
+			return
 		if _has_arg("--demo-occlusion"):
 			call_deferred("_run_demo_occlusion")
 			return
@@ -153,6 +156,54 @@ func _run_smoke_intent() -> void:
 	var is_move_to_zone := String(intent.get("kind", "")) == "move_to_zone"
 	var all_ok: bool = ok_kind and blocked.is_empty() and is_move_to_zone
 	print("[SmokeIntent] RESULT frozen-vocab-only=%s move_to_zone-emitted=%s" % [str(all_ok), str(is_move_to_zone)])
+
+	call_deferred("_quit_clean")
+
+
+# ---------------------------------------------------------------------------
+# #1063 part 2 SERVED-FINALS-SMOKE: prove a SERVED sprite atlas (fetched from a live
+# /image?scope=sprite-aubree-iso8 stub) is resolved by the ImageResolver AND swapped
+# onto the spawned token (re-sliced from the render-profile layout → 32 anims). The
+# token spawn already kicked an async resolve(); we await texture_ready (bounded), then
+# assert (a) the resolver cached the served atlas and (b) the token carries 32 anims
+# built from it. If NO atlas is served (the stub absent / 404), this is a clean MISS —
+# the committed placeholder still yields 32 anims, but cached==null flags the no-serve
+# case so the smoke FAILS LOUDLY rather than passing on the fallback.
+# ---------------------------------------------------------------------------
+func _run_served_finals_smoke() -> void:
+	var scope := "sprite-aubree-iso8"
+	print("[Main] --served-finals-smoke: awaiting SERVED atlas scope=%s" % scope)
+
+	# Bounded wait for the async fetch the token spawn already started. We poll the
+	# resolver cache each frame (the resolve coroutine emits texture_ready on success;
+	# the swap happens in WorldView._on_texture_ready). ~6s ceiling is generous for a
+	# localhost stub; a real 404 short-circuits to MISS immediately.
+	var cached: Texture2D = null
+	var waited := 0.0
+	var step := 0.1
+	while waited < 6.0:
+		cached = ImageResolver.get_cached(scope)
+		if cached != null or ImageResolver.is_missing(scope):
+			break
+		await get_tree().create_timer(step).timeout
+		waited += step
+
+	var resolver_ok := cached != null
+	print("[ServedFinals] resolver_cached=%s waited=%.1fs missing=%s" % [
+		str(resolver_ok), waited, str(ImageResolver.is_missing(scope))])
+
+	# Inspect the token: with the served atlas applied it must still carry the full
+	# 32 anims (4 anim-types x 8 facings), sliced from the served PNG via the profile.
+	var tok: CharacterToken = _world.token_for("char-aubree")
+	var token_present := tok != null and is_instance_valid(tok)
+	var anims := tok.animation_count() if token_present else 0
+	var anims_ok := anims == 32
+	print("[ServedFinals] token_present=%s anims=%d anims_ok=%s" % [
+		str(token_present), anims, str(anims_ok)])
+
+	var all_ok := resolver_ok and token_present and anims_ok
+	print("[ServedFinals] RESULT served-atlas-applied=%s resolver_cached=%s anims=%d" % [
+		str(all_ok), str(resolver_ok), anims])
 
 	call_deferred("_quit_clean")
 

--- a/godot/scenes/WorldView.gd
+++ b/godot/scenes/WorldView.gd
@@ -87,6 +87,11 @@ var _backdrop_is_resolved: bool = false
 ## actor_id -> CharacterToken. Today we only spawn party[0], but the dictionary
 ## keeps the reconcile contract right for when the party grows.
 var _tokens: Dictionary = {}
+## #1063 part 2 — sprite-atlas scope_key -> actor_id, so when ImageResolver emits
+## texture_ready for a SERVED sprite atlas (/image?scope=sprite-<name>) we know which
+## token to re-set_manifest. Distinct namespace from the backdrop scope (scene-*), so
+## the shared texture_ready handler dispatches by which map the scope is in.
+var _sheet_scope_actor: Dictionary = {}
 ## The single static pillar prop (spawned once, repositioned per tick).
 var _pillar: PropActor = null
 
@@ -385,6 +390,10 @@ func _reconcile_actors(character: Dictionary) -> void:
 				stale.queue_free()
 			_tokens.erase(existing_id)
 			_token_prev_pos.erase(existing_id)
+			# Drop any served-atlas scope mapping pointing at the freed token (#1063).
+			for sc in _sheet_scope_actor.keys():
+				if String(_sheet_scope_actor[sc]) == String(existing_id):
+					_sheet_scope_actor.erase(sc)
 
 
 ## #1055 — drive ONE token to its new screen position with renderer-derived facing.
@@ -440,6 +449,14 @@ func _walk_token_to(tok: CharacterToken, actor_id: String, from_pos: Vector2, to
 
 ## Build a CharacterToken for an actor: resolve its committed sheet (sheet.png +
 ## sheet.json), build it, add it to YSortLayer. Returns null if no sheet resolves.
+##
+## #1063 part 2 — ADDITIVE + FALLBACK-SAFE served-atlas layer: the token is ALWAYS
+## built from the committed res:// placeholder first (so a missing served atlas is
+## EXACTLY today's behavior). We THEN try the live engine's SERVED final atlas via
+## /image?scope=<sheet_scope_key>: if it is already cached, swap it in now; if it has
+## not been tried (and is not known-404), kick an async resolve() — _on_texture_ready
+## swaps it in later. The slicing layout for the served PNG comes from the
+## render-profile actor_sheet (there is NO served sheet.json), mirroring _swap_backdrop.
 func _spawn_token(actor_id: String) -> CharacterToken:
 	var resolved := _resolve_character_sheet(actor_id)
 	if resolved.is_empty():
@@ -450,7 +467,38 @@ func _spawn_token(actor_id: String) -> CharacterToken:
 	tok.name = "Token_" + actor_id
 	_ysort.add_child(tok)
 	tok.set_manifest(resolved["manifest"], resolved["texture"])
+	# Try to upgrade to the SERVED final atlas (no-op when none is served).
+	_try_serve_sprite_atlas(tok, actor_id)
 	return tok
+
+
+## #1063 part 2 — attempt to swap a token's committed placeholder for the SERVED final
+## atlas. Mirrors _swap_backdrop's cached/missing/resolve structure. The committed
+## token is already built; this only UPGRADES it when a served atlas exists. No-op when
+## the actor is unmapped, the profile lacks a slicing layout, or the scope is absent.
+func _try_serve_sprite_atlas(tok: CharacterToken, actor_id: String) -> void:
+	var meta := RenderProfile.godot_actor_sheet(actor_id)
+	var scope := String(meta.get("sheet_scope_key", ""))
+	if scope == "":
+		return
+	# The served PNG has no sheet.json — build the slicing manifest from the profile.
+	var served_manifest := RenderProfile.godot_served_manifest(actor_id)
+	if served_manifest.is_empty():
+		# Incomplete profile (no animations table) — keep the committed placeholder.
+		return
+	# Remember scope -> actor so _on_texture_ready can find the token to re-slice.
+	_sheet_scope_actor[scope] = actor_id
+
+	var cached := ImageResolver.get_cached(scope)
+	if cached != null:
+		# Already fetched — swap the served atlas in now (re-call set_manifest).
+		tok.set_manifest(served_manifest, cached)
+		return
+	if ImageResolver.is_missing(scope):
+		# Definitively absent (404) — keep the committed placeholder (today's behavior).
+		return
+	# Untried/loading: keep the placeholder now; _on_texture_ready upgrades it later.
+	ImageResolver.resolve(scope)
 
 
 ## Spawn (once) + position the static pillar prop at a MID-depth zone marker so
@@ -609,9 +657,42 @@ func _swap_backdrop(scope: String) -> void:
 
 
 func _on_texture_ready(scope: String, texture: Texture2D) -> void:
+	if texture == null:
+		return
+	# #1063 part 2 — a SERVED sprite atlas resolved: re-slice the token that asked for
+	# it from the render-profile layout (distinct scope namespace from the backdrop, so
+	# this branch and the backdrop branch never both fire for one scope).
+	if _sheet_scope_actor.has(scope):
+		_apply_served_sprite(scope, texture)
+		return
 	# Only swap if this is still the location we want (the snapshot may have moved on).
-	if scope == _pending_backdrop_scope and texture != null:
+	if scope == _pending_backdrop_scope:
 		_apply_texture_backdrop(texture)
+
+
+## #1063 part 2 — apply a resolved served sprite atlas to its token by re-building the
+## SpriteFrames from the render-profile slicing layout (set_manifest is re-callable: it
+## rebuilds _frames from scratch). No-op if the token was freed (actor left the party)
+## or the profile lost its layout — the committed placeholder simply stays.
+func _apply_served_sprite(scope: String, texture: Texture2D) -> void:
+	var actor_id := String(_sheet_scope_actor.get(scope, ""))
+	if actor_id == "":
+		return
+	var tok: CharacterToken = _tokens.get(actor_id, null)
+	if tok == null or not is_instance_valid(tok):
+		return
+	var served_manifest := RenderProfile.godot_served_manifest(actor_id)
+	if served_manifest.is_empty():
+		return
+	# Capture the current render state so the atlas swap is seamless (set_manifest
+	# resets to idle@default_facing otherwise).
+	var keep_facing := tok.facing()
+	var keep_anim := tok.anim()
+	tok.set_manifest(served_manifest, texture)
+	tok.set_facing(keep_facing)
+	tok.set_anim(keep_anim)
+	print("[CharacterToken] actor=%s SERVED atlas applied scope=%s anims=%d" % [
+		actor_id, scope, tok.animation_count()])
 
 
 ## Put a real texture on the BackdropPlane and scale/center it to fill the viewport.


### PR DESCRIPTION
## #1063 part 2 — render SERVED sprite finals in the Godot iso view (GT2)

Render-side companion to the just-merged serve-side **#1078** (`pack_sheet --emit-descriptor`). A character token's sprite atlas is now fetched from the live viewer via `/image?scope=<sheet_scope_key>` (the served Meshy/Blender final) when available, falling back to the committed `res://` CC0 placeholder when not. **Served atlas absent ⇒ exactly today's behavior (no regression).**

### Design
- The served atlas is **only a PNG** (no served `sheet.json`), so the slicing layout must come from the render-profile `actor_sheet`. The fixture's `actor_sheets.char-aubree` is now a **complete slicing manifest** matching the baked sheet.
- The fetch **mirrors `_swap_backdrop`'s** cached/missing/resolve structure — no parallel mechanism invented.
- Facing stays **100% renderer-derived**; the engine is untouched; no new engine state.

### Edits
1. **`godot/fixtures/render-profile.json`** — `actor_sheets.char-aubree` corrected to the real baked layout: `cols` 8→24, `frames_per_facing` 8→24, `anchor` `[64,116]`→`[64,109]` (matches `content/worlds/_private/.../sprite-aubree-iso8/sheet.json`), plus a full `animations` table (idle@0×4, walk@4×8, attack@12×6, cast@18×6) + `kind`/`projection`/`fps`. Now a complete slicing manifest.
2. **`godot/autoload/RenderProfile.gd`** — `godot_served_manifest(actor_id)` builds the full slicing layout (in the exact `CharacterToken.set_manifest` shape) from the `actor_sheet` meta, so a served manifest is built without a served `sheet.json`. Returns `{}` (→ keep placeholder) when unmapped or no `animations` table.
3. **`godot/scenes/WorldView.gd`** — `_spawn_token` builds the committed placeholder **first** (unchanged), then `_try_serve_sprite_atlas` (cached→swap now / 404→keep placeholder / untried→`resolve`). `_on_texture_ready` dispatches sprite scopes to `_apply_served_sprite` (re-`set_manifest`, preserving facing+anim). A small `_sheet_scope_actor` (scope→actor_id) map is kept and cleaned up when a token is freed.
4. **`.github/workflows/godot.yml`** — new **served-finals smoke** step: serves the committed real PNG through the real viewer `/image` bridge (same `wiki_ingest.json` descriptor #1078 emits), then runs a new `--served-finals-smoke` Main mode that asserts `ImageResolver.get_cached("sprite-aubree-iso8")` non-null AND a token re-sliced from the served atlas (anims=32). The fixture PNG is a real decodable 24×8 sheet, so a MISS fails the smoke loudly.

### Invariants
- ADDITIVE + FALLBACK-SAFE: served atlas absent ⇒ identical to today. The existing conformance (`anims=32`, committed placeholder) + `--demo-occlusion` jobs stay green — the token is always built from the placeholder before the async served fetch.
- Engine untouched; QA/CI gateway-free + no LLM keys (fixtures + a bare-python viewer); Eva never touched.

### Validation
- **Godot not on PATH locally** → the `godot.yml` CI is the validator (this PR opens draft to start it).
- **Serve-side half validated locally end-to-end**: the real `viewer/server.py` serves the descriptor'd PNG — `HTTP 200`, `X-Image-Outcome: served`, `Content-Type: image/png`, valid PNG magic, exact byte-match (66534 B). `viewer/server.py` imports + serves `/image` with **bare python3** (no engine/LLM deps) on `ubuntu-latest`.
- GDScript statically reviewed: tabs-only, balanced parens, `set_manifest` is re-callable (rebuilds `SpriteFrames` from scratch), `.keys()` snapshot makes the erase-during-iterate cleanup safe.

### Open risks
- **Anchor source-of-truth**: fixture uses the baked finals' `[64,109]` (the served atlas's anchor); the committed placeholder keeps its own `[64,116]` via its `sheet.json`. If the real served atlas's anchor differs, update the fixture to match the served sheet.
- **Async-rebuild edge cases**: covered — `_apply_served_sprite` no-ops on a freed token, preserves facing/anim across the swap, and the scope→actor map is cleaned on token free.

Draft so you review before merge.