### PR TITLE
fix(engine): enforce BM superiority die + War Domain Guided Strike (cs-1040val)

### DIFF
--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -1164,6 +1164,49 @@ def main() -> int:
     if attacks:
         chk("ranged_disadvantage_in_melee", not ranged_flags, "; ".join(ranged_flags), fatal=False)
 
+    # cs-1040val (#1/#2): a class-feature rider spent via use_resource MUST be consumed by a
+    # following attack — a Battle Master superiority die appears in that attack's DAMAGE, and a
+    # War Domain Guided Strike's +10 in its attack ROLL. The engine now auto-folds the die and
+    # surfaces the +10, so this catches the residual "burned the resource but never attacked"
+    # sequencing miss (the exact cs-1040val omission: die/+10 spent, narrated as landing, but no
+    # attack carried it). The pending rider is consumed by the spender's FIRST subsequent attack,
+    # so we check that attack. WARN, not FATAL — a sequencing miss is a DM-adherence defect that
+    # should surface to the scorer, not RED-cap the whole run (graduate to FATAL after clean
+    # sweeps, per the gate-graduation discipline).
+    def _spender(inp_dict: dict) -> str:
+        return inp_dict.get("character_id") or inp_dict.get("actor_id") or ""
+
+    def _attacker_id(inp_dict: dict) -> str:
+        return (inp_dict.get("attacker_id") or inp_dict.get("character_id")
+                or inp_dict.get("npc_id") or "")
+
+    dangling_riders: list[str] = []
+    for i, (short, inp, obj, is_err, _t) in enumerate(evs):
+        if short != "use_resource" or is_err or not isinstance(obj, dict):
+            continue
+        sets_dmg = bool(obj.get("maneuver_damage") or obj.get("auto_folded"))
+        sets_hit = bool(obj.get("attack_bonus"))
+        if not (sets_dmg or sets_hit):
+            continue  # an ordinary resource spend (no pending attack rider) — nothing to track
+        spender = _spender(inp)
+        consumed = False
+        for short2, inp2, obj2, is_err2, _t2 in evs[i + 1:]:
+            # a later rider-setting spend by the same spender supersedes this one — stop here
+            if (short2 == "use_resource" and _spender(inp2) == spender
+                    and isinstance(obj2, dict)
+                    and (obj2.get("maneuver_damage") or obj2.get("auto_folded") or obj2.get("attack_bonus"))):
+                break
+            if short2 == "attack" and isinstance(obj2, dict) and _attacker_id(inp2) == spender:
+                ar = obj2.get("attack_roll") or {}
+                consumed = (sets_dmg and bool(obj2.get("maneuver_damage"))) or \
+                           (sets_hit and bool(ar.get("to_hit_bonus")))
+                break  # the FIRST attack consumes the pending rider, carried or not
+        if not consumed:
+            kind = "Guided Strike +10" if sets_hit else "superiority die"
+            src = obj.get("resource") or "?"
+            dangling_riders.append(f"{spender or '?'} spent a {kind} ({src}) but no following attack carried it")
+    chk("maneuver_rider_consumed", not dangling_riders, "; ".join(dangling_riders), fatal=False)
+
     fails = [c for c in checks if c[2] and not c[1]]
     warns = [c for c in checks if not c[2] and not c[1]]
     print("=== behavioral assertions ===")

--- a/qa/test_assert_behavioral.py
+++ b/qa/test_assert_behavioral.py
@@ -1026,3 +1026,89 @@ def test_narration_leak_clean_run_passes(tmp_path):
     events = _dm_text_turns(4) + [_dm_leak(t) for t in _CLEAN_NEARMISS]
     rc, out = _run_gate(tmp_path, events, _with_party({"leveling_mode": "milestone"}))
     assert "[PASS] narration_no_ooc_leak" in out, out
+
+
+# ── maneuver_rider_consumed (cs-1040val #1/#2) ──────────────────────────────────
+def _eng(tool: str) -> str:
+    return f"mcp__engine__{tool}"
+
+
+def test_maneuver_rider_consumed_superiority_die_folded(tmp_path):
+    # A superiority-die spend (auto-folded or named) followed by an attack carrying the die in
+    # damage is the correct chain -> PASS.
+    events = [
+        _assistant_tool_use("u1", _eng("use_resource"),
+                            {"character_id": "h", "resource": "superiority_dice"}),
+        _user_tool_result("u1", json.dumps(
+            {"ok": True, "resource": "superiority_dice", "auto_folded": "…",
+             "maneuver_damage": {"rolled": 6}})),
+        _assistant_tool_use("a1", _eng("attack"), {"attacker_id": "h", "target_id": "g"}),
+        _user_tool_result("a1", json.dumps(
+            {"attacker": "Hero", "target": "Goblin", "hit": True,
+             "attack_roll": {"total": 18}, "maneuver_damage": {"rolled": 6, "applied": True}})),
+    ]
+    rc, out = _run_gate(tmp_path, events, _with_party({}))
+    assert "[PASS] maneuver_rider_consumed" in out, out
+
+
+def test_maneuver_rider_consumed_guided_strike_plus10(tmp_path):
+    # A Guided Strike spend (channel_divinity -> +10) followed by an attack whose roll carries
+    # the to_hit_bonus is the correct chain -> PASS.
+    events = [
+        _assistant_tool_use("u1", _eng("use_resource"),
+                            {"character_id": "c", "resource": "channel_divinity", "maneuver": "Guided Strike"}),
+        _user_tool_result("u1", json.dumps(
+            {"ok": True, "resource": "channel_divinity",
+             "attack_bonus": {"option": "Guided Strike", "attack_bonus": 10}})),
+        _assistant_tool_use("a1", _eng("attack"), {"attacker_id": "c", "target_id": "g"}),
+        _user_tool_result("a1", json.dumps(
+            {"attacker": "Maren", "target": "Bandit", "hit": True,
+             "attack_roll": {"total": 18, "to_hit_bonus": {"amount": 10, "source": "Guided Strike"}}})),
+    ]
+    rc, out = _run_gate(tmp_path, events, _with_party({}))
+    assert "[PASS] maneuver_rider_consumed" in out, out
+
+
+def test_maneuver_rider_dangling_superiority_die_warns(tmp_path):
+    # A superiority die spent but NO following attack carries it (the cs-1040val omission) ->
+    # WARN (surfaced to the scorer), never RED-capping the run.
+    events = [
+        _assistant_tool_use("u1", _eng("use_resource"),
+                            {"character_id": "h", "resource": "superiority_dice"}),
+        _user_tool_result("u1", json.dumps(
+            {"ok": True, "resource": "superiority_dice", "auto_folded": "…",
+             "maneuver_damage": {"rolled": 6}})),
+        # … no attack by "h" after the spend.
+    ]
+    rc, out = _run_gate(tmp_path, events, _with_party({}))
+    assert "[WARN] maneuver_rider_consumed" in out, out
+    assert "[FAIL] maneuver_rider_consumed" not in out, out
+
+
+def test_maneuver_rider_dangling_guided_strike_warns(tmp_path):
+    # Guided Strike's +10 spent but the following attack did NOT carry the to_hit_bonus -> WARN.
+    events = [
+        _assistant_tool_use("u1", _eng("use_resource"),
+                            {"character_id": "c", "resource": "channel_divinity", "maneuver": "Guided Strike"}),
+        _user_tool_result("u1", json.dumps(
+            {"ok": True, "resource": "channel_divinity",
+             "attack_bonus": {"option": "Guided Strike", "attack_bonus": 10}})),
+        _assistant_tool_use("a1", _eng("attack"), {"attacker_id": "c", "target_id": "g"}),
+        _user_tool_result("a1", json.dumps(
+            {"attacker": "Maren", "target": "Bandit", "hit": False,
+             "attack_roll": {"total": 8}})),  # no to_hit_bonus — the +10 was dropped
+    ]
+    rc, out = _run_gate(tmp_path, events, _with_party({}))
+    assert "[WARN] maneuver_rider_consumed" in out, out
+
+
+def test_ordinary_resource_spend_not_tracked(tmp_path):
+    # A plain resource spend that sets NO pending attack rider (e.g. Second Wind) is ignored by
+    # the check -> PASS (no dangling-rider noise).
+    events = [
+        _assistant_tool_use("u1", _eng("use_resource"),
+                            {"character_id": "h", "resource": "second_wind"}),
+        _user_tool_result("u1", json.dumps({"ok": True, "resource": "second_wind", "remaining": 2})),
+    ]
+    rc, out = _run_gate(tmp_path, events, _with_party({}))
+    assert "[PASS] maneuver_rider_consumed" in out, out

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -758,6 +758,25 @@ class PendingDamageBonus(_StrictModel):
     damage_type: str = ""  # type of the added damage; "" == same type as the weapon strike
 
 
+class PendingAttackBonus(_StrictModel):
+    """A DECLARED-but-not-yet-applied flat bonus the NEXT attack ROLL folds in.
+
+    The War Domain Cleric's Channel Divinity: Guided Strike grants "+10 to one attack roll."
+    But spending the Channel Divinity and resolving the strike are two engine calls
+    (`use_resource(channel_divinity, maneuver='Guided Strike')` then `attack`), so — exactly
+    like PendingDamageBonus for a maneuver's damage die — the bonus is stashed HERE when the
+    resource is spent; the next `attack()` adds `amount` to that strike's attack-roll TOTAL
+    (before the hit check) and clears this record (consumed once, never double-applied).
+
+    ADDITIVE: `Character.pending_attack_bonus` defaults to None, so every existing snapshot
+    round-trips unchanged and any spend that ISN'T a recognized to-hit option never creates
+    one — a plain Channel Divinity spend behaves exactly as today."""
+
+    amount: int  # the flat bonus added to the next attack roll (Guided Strike: 10)
+    source: str = ""  # the option name (Guided Strike, …) for surfacing
+    resource: str = ""  # the pool it was spent from (e.g. "channel_divinity")
+
+
 class PendingOnHitRider(_StrictModel):
     """An attack-roll spell's ON-HIT rider effect that has NOT yet landed (#186).
 
@@ -865,6 +884,12 @@ class Character(_StrictModel):
     # attack() adds it to that strike's damage and clears it (see PendingDamageBonus, #213).
     # None == today's behavior; a maneuver-less use_resource never sets it.
     pending_damage_bonus: Optional[PendingDamageBonus] = None
+    # A DECLARED-but-not-yet-applied flat bonus the NEXT attack ROLL folds in — the War
+    # Domain Cleric's Channel Divinity: Guided Strike (+10 to one attack roll) is spent at
+    # use_resource(channel_divinity, maneuver='Guided Strike') time and stashed here; the
+    # next attack() adds it to that strike's attack-roll total and clears it (see
+    # PendingAttackBonus). None == today's behavior; a non-to-hit spend never sets it.
+    pending_attack_bonus: Optional[PendingAttackBonus] = None
     death_saves: DeathSaves = Field(default_factory=DeathSaves)
     dead: bool = False
     stable: bool = False  # stabilized at 0 HP; no longer rolling death saves

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -90,6 +90,7 @@ from models import (
     HouseRules,
     Item,
     Location,
+    PendingAttackBonus,
     PendingDamageBonus,
     PendingOnHitRider,
     Quest,
@@ -4567,15 +4568,18 @@ def _turn_brief(ch: "Character", c: "Campaign") -> dict:
                     "bloodied foe or land a second Attack action.")
             elif rid_l == "channel_divinity":
                 entry_r["suggested_when"] = (
-                    "Channel Divinity is available (e.g. War Domain Guided Strike: +10 to one "
-                    "attack roll) — spend it to turn a key miss into a hit.")
+                    "Channel Divinity is available — War Domain Guided Strike adds +10 to one "
+                    "attack roll: call use_resource(channel_divinity, maneuver='Guided Strike') "
+                    "then attack, and the engine folds +10 into that roll (turns a key miss "
+                    "into a hit).")
             elif rid_l == "superiority_dice":
                 entry_r["suggested_when"] = (
-                    "Battle Master maneuvers: to add this 1d8 to a strike, declare it ON the "
-                    "attack — attack(maneuver='Trip Attack', maneuver_resource='superiority_dice'). "
-                    "The engine spends the die only on a hit, folds +1d8 into damage, and "
-                    "crit-doubles it. Do NOT spend it via a bare use_resource — that burns the "
-                    "die for no bonus.")
+                    "Battle Master maneuvers: add this 1d8 to a strike by declaring it ON the "
+                    "attack — attack(maneuver='Trip Attack', maneuver_resource='superiority_dice') "
+                    "— so the engine spends the die only on a hit, folds +1d8 into damage, and "
+                    "crit-doubles it. A bare in-combat use_resource(superiority_dice) is now "
+                    "AUTO-FOLDED into your next attack's damage; still name the maneuver so the "
+                    "narration matches the die.")
             resources[rid] = entry_r
     brief["resources"] = resources
     # --- reactions (#A2): surface a monster's stat-block reaction (Parry) so the DM knows
@@ -4743,6 +4747,15 @@ def next_turn(campaign_id: str) -> dict:
         # Attack action's worth of strikes and no Action Surge spent yet.
         c.combat.action_attacks_made = 0
         c.combat.surge_actions = 0
+        # LEAK GUARD (cs-1040val): a maneuver die / Guided Strike bonus rides the attack you
+        # spent it on (SRD: "add it to that attack's roll/damage"). If the outgoing combatant
+        # spent one but never attacked this turn, clear the orphaned pending rider so it can't
+        # silently land on a LATER turn's strike. A rider consumed by an attack this turn is
+        # already None here, so this only nulls true orphans (additive, no behavior change to
+        # the spend→attack same-turn path).
+        if previous is not None:
+            previous.pending_damage_bonus = None
+            previous.pending_attack_bonus = None
         if cur is not None:
             for cb in order:
                 if cb.character_id == cur.id:
@@ -5377,6 +5390,14 @@ def attack(
         man_bonus = attacker.pending_damage_bonus
         if man_bonus is not None:
             attacker.pending_damage_bonus = None
+        # Capture + CLEAR any pending TO-HIT bonus (War Domain Guided Strike: +10 to one attack
+        # roll, #2/cs-1040val) the attacker declared via use_resource(channel_divinity,
+        # maneuver='Guided Strike'). Like the damage-maneuver above it's consumed by THIS one
+        # strike whatever the outcome (already spent) and folded into the attack-roll total
+        # below, BEFORE the hit check. None == no to-hit option spent (the default path).
+        atk_bonus_rider = attacker.pending_attack_bonus
+        if atk_bonus_rider is not None:
+            attacker.pending_attack_bonus = None
         # ATOMIC maneuver (#213/B): a maneuver declared ON this attack rolls + spends its
         # superiority die ONLY when the strike HITS (SRD: spent "when you hit"). Validate the
         # pool NOW (before the roll) so a bad pool surfaces cleanly without burning state, but
@@ -5415,7 +5436,11 @@ def attack(
         # advertises instead of tracking it as theater. Nat-20 auto-hit / nat-1 auto-miss
         # still read the natural die; no riders == atk.total exactly as before.
         rider_bonus, rider_rolls = _roll_effect_bonus_dice(attacker, "attack_bonus_dice")
-        atk_total = atk.total + rider_bonus
+        # Guided Strike (+10) and any other pending flat to-hit bonus fold into the roll total
+        # here — before the hit check — so the bonus can turn a near-miss into a hit. It does
+        # NOT change crit/fumble (those read the natural die), matching SRD Guided Strike.
+        guided_bonus = atk_bonus_rider.amount if atk_bonus_rider is not None else 0
+        atk_total = atk.total + rider_bonus + guided_bonus
         target_ac, target_ac_detail = _effective_armor_class(target)
         hit = atk.crit or (not atk.fumble and atk_total >= target_ac)
         # PARRY (#218): a defender with an available defensive reaction (+N AC vs one melee
@@ -5472,6 +5497,15 @@ def attack(
             # The engine-rolled rider components (SYN-06), itemized so the DM narrates
             # "the blessing guides the blade (+3)" — and sees the buff actually counted.
             result["attack_roll"]["bonus_dice"] = rider_rolls
+        if atk_bonus_rider is not None:
+            # Surface the consumed flat to-hit bonus (Guided Strike +10), folded into `total`
+            # above, so the DM narrates it AND the scorer sees the +10 actually landed on the
+            # roll instead of being announced-then-dropped (the cs-1040val omission).
+            result["attack_roll"]["to_hit_bonus"] = {
+                "amount": atk_bonus_rider.amount,
+                "source": atk_bonus_rider.source,
+                "resource": atk_bonus_rider.resource,
+            }
         if target_ac_detail is not None:
             result["target_ac_detail"] = target_ac_detail
         # Commit the action economy now — an attack spends its action/reaction whether
@@ -8602,6 +8636,14 @@ def long_rest(campaign_id: str, character_id: str, watch: str = "") -> dict:
         return out
 
 
+# Channel-Divinity-style options that grant a flat TO-HIT bonus to one attack roll (not a
+# damage die). Spent via use_resource(channel_divinity, maneuver=<name>) → a one-shot
+# PendingAttackBonus the next attack folds into its roll. Keyed lowercase. The War Domain
+# Cleric's Guided Strike is the canonical +10 (SRD 2014/2024 alike); extend as new subclass
+# to-hit options are modeled. SRD-only: the engine ships the mechanism, not non-SRD numbers.
+_TO_HIT_CHANNEL_OPTIONS = {"guided strike": 10}
+
+
 @mcp.tool()
 def use_resource(
     campaign_id: str,
@@ -8639,12 +8681,26 @@ def use_resource(
                 "remaining": remaining,
                 "max": res.max,
             }
-        # A DAMAGE maneuver adds the spent die to the next attack's damage — so the pool MUST
-        # roll a die. Refuse a maneuver against a point pool (no `size`) up front, BEFORE
-        # spending, so the DM gets a clean signal instead of a silently-wasted point with no
-        # bonus (and no phantom pending record gets written). Inert when `maneuver` is empty.
+        # A named maneuver/option folds into the NEXT attack one of two ways: a DAMAGE-die
+        # maneuver (Battle Master Trip/Menacing — adds the spent die to that attack's DAMAGE) or
+        # a flat TO-HIT option (War Domain Guided Strike — +10 to that attack's ROLL). Resolve
+        # the to-hit options FIRST: they ride a POINT pool (channel_divinity) and grant a flat
+        # bonus, so they must NOT trip the die-pool requirement below. Inert when empty.
         man = maneuver.strip()
-        if man and not res.size.strip():
+        to_hit = _TO_HIT_CHANNEL_OPTIONS.get(man.lower()) if man else None
+        # #1 (cs-1040val): a DIE pool (Superiority Dice) spent in active combat with NO
+        # maneuver= is the common Battle Master mistake — the die would burn for no bonus, and
+        # the turn_brief cue didn't stop it. AUTO-FOLD: treat a bare in-combat die spend as a
+        # generic damage maneuver so the rolled die lands on the next attack rather than relying
+        # on the DM to pass maneuver=. Out of combat / a point pool: inert (byte-identical).
+        auto_folded = False
+        if not man and to_hit is None and res.size.strip() and c.combat.active:
+            man = "Maneuver"
+            auto_folded = True
+        # A DAMAGE maneuver needs a DIE pool. A maneuver name that ISN'T a recognized to-hit
+        # option, against a point pool (no `size`), is refused up front — BEFORE spending — so
+        # the DM gets a clean signal instead of a silently-wasted point (no phantom pending).
+        if man and to_hit is None and not res.size.strip():
             return {
                 "ok": False,
                 "error": (
@@ -8657,7 +8713,19 @@ def use_resource(
             }
         res.used += amount
         man_damage = None
-        if man:
+        to_hit_rider = None
+        if to_hit is not None:
+            # A flat TO-HIT option (Guided Strike +10): stash a one-shot attack-roll bonus the
+            # next attack() folds into its roll BEFORE the hit check (engine-rolls-and-tells).
+            ch.pending_attack_bonus = PendingAttackBonus(
+                amount=int(to_hit), source=man, resource=resource,
+            )
+            to_hit_rider = {
+                "option": man,
+                "attack_bonus": int(to_hit),
+                "applies_to": "next attack roll",
+            }
+        elif man:
             # Roll the spent die(s) NOW (engine-rolls-and-tells, like an on-hit rider): one
             # source of truth — the result is fixed at declare time, and the next attack just
             # reads it. `amount` × the pool's die size (1 die per maneuver in 5e RAW, so this
@@ -8705,16 +8773,15 @@ def use_resource(
         }
         if man_damage is not None:
             out["maneuver_damage"] = man_damage
-        # FOOTGUN ADVISORY (#213 follow-up): a die-pool resource (Superiority Dice) spent in
-        # active combat WITHOUT maneuver= burns the die for no damage bonus — the common Battle
-        # Master mistake. ADVISORY ONLY: the spend already happened and is correct (you may
-        # legitimately spend a die for a non-damage maneuver the engine doesn't model), so we
-        # do NOT block — we only surface a steer toward the attack(maneuver=) path. Inert unless
-        # the pool has a die AND no maneuver was declared AND combat is live.
-        if res.size.strip() and not man and c.combat.active:
-            out["warning"] = (
-                f"{resource!r} is a die pool but no maneuver= was declared — this die added no "
-                "damage bonus. To fold +1d8 into a strike, declare it ON the attack instead: "
+        if to_hit_rider is not None:
+            out["attack_bonus"] = to_hit_rider
+        # #1 (cs-1040val): a bare in-combat die-pool spend was AUTO-FOLDED into the next attack
+        # as a generic damage maneuver (replacing the old advisory-only warning that the DM kept
+        # ignoring). Surface what happened so the DM can name the maneuver next time.
+        if auto_folded:
+            out["auto_folded"] = (
+                f"no maneuver= was declared — the engine auto-rolled this {resource} die and "
+                "folded it into your NEXT attack's damage. Name it next time, e.g. "
                 "attack(maneuver='Trip Attack', maneuver_resource='superiority_dice')."
             )
         return out

--- a/servers/engine/tests/test_class_resources.py
+++ b/servers/engine/tests/test_class_resources.py
@@ -289,10 +289,11 @@ def test_turn_brief_superiority_dice_suggests_maneuver_on_attack(cid):
     assert sd["label"].endswith("d8")  # the die is surfaced
 
 
-def test_use_resource_bare_superiority_die_in_combat_warns(cid):
-    """FOOTGUN ADVISORY: a die-pool spend (superiority_dice) in active combat with NO maneuver=
-    surfaces an advisory `warning` steering the DM to attack(maneuver=). Advisory only — the
-    spend still succeeds (it does not block)."""
+def test_use_resource_bare_superiority_die_in_combat_auto_folds(cid):
+    """#1 (cs-1040val): a die-pool spend (superiority_dice) in active combat with NO maneuver=
+    is the common Battle Master mistake. The engine no longer just warns (the DM ignored that)
+    — it AUTO-FOLDS: rolls the die and stashes a pending_damage_bonus the next attack folds in.
+    `auto_folded` is surfaced; the old `warning` key is gone."""
     fid = server.create_character(
         cid, "Aldric", kind="player", class_name="Fighter", level=3, apply_srd_defaults=True,
         abilities={"strength": 16, "constitution": 14},
@@ -300,8 +301,11 @@ def test_use_resource_bare_superiority_die_in_combat_warns(cid):
     server.set_class_resource(cid, fid, "superiority_dice", max=4, recharge="short", size="d8")
     server.start_combat(cid, [fid])
     out = server.use_resource(cid, fid, "superiority_dice")  # bare spend, in combat
-    assert out["ok"] is True and out["remaining"] == 3  # the spend SUCCEEDS (advisory, not block)
-    assert "warning" in out and "attack(maneuver=" in out["warning"]
+    assert out["ok"] is True and out["remaining"] == 3  # the spend SUCCEEDS
+    assert "warning" not in out
+    assert "auto_folded" in out and "maneuver_damage" in out  # the die was rolled + folded
+    # The rolled bonus is now pending on the character (consumed by the next attack).
+    assert server.get_character(cid, fid)["pending_damage_bonus"] is not None
 
 
 def test_use_resource_bare_superiority_die_out_of_combat_no_warning(cid):

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -2261,6 +2261,99 @@ def test_maneuver_on_point_pool_refused_no_spend(tmp_path, monkeypatch):
     assert sheet["pending_damage_bonus"] is None
 
 
+def test_bare_superiority_die_auto_folds_into_next_attack(tmp_path, monkeypatch):
+    # #1 (cs-1040val): a BARE in-combat superiority-die spend (no maneuver=) auto-folds — the
+    # engine rolls the die and the NEXT attack's damage strictly exceeds the weapon by it
+    # (weapon 7 + die 6 = 13), so the die is never burned for nothing.
+    import server
+    cid, hero, gob = _bm_combat(server, monkeypatch, tmp_path, die_total=6, weapon_total=7)
+    spent = server.use_resource(cid, hero, "superiority_dice")  # bare — no maneuver=
+    assert spent["ok"] is True and spent["remaining"] == 5
+    assert "auto_folded" in spent and "warning" not in spent
+    assert spent["maneuver_damage"]["rolled"] == 6  # the die WAS rolled
+    assert server.get_character(cid, hero)["pending_damage_bonus"]["amount"] == 6
+    res = server.attack(cid, hero, gob, attack_bonus=5, damage_dice="1d6+3", damage_type="slashing")
+    assert res["hit"] is True and res["damage"]["total"] == 13  # 7 weapon + 6 die, one hit
+    assert server.get_character(cid, gob)["current_hp"] == 27  # 40 - 13
+
+
+def _war_cleric_combat(server, monkeypatch, tmp_path, *, foe_ac: int, d20: int, weapon_total: int):
+    """A War-Domain-style cleric (Channel Divinity point pool) vs a foe, cleric current, with a
+    rigged roller: d20 -> `d20`, 1d8+3 -> `weapon_total`."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("War Cleric")["id"]
+    cleric = server.create_character(cid, "Maren", kind="player", max_hp=24, armor_class=16)["id"]
+    foe = server.create_character(cid, "Bandit", kind="monster", max_hp=20, armor_class=foe_ac)["id"]
+    server.set_class_resource(cid, cleric, "channel_divinity", max=2, recharge="short")  # point pool
+    server.start_combat(cid, [cleric, foe])
+    if server.get_state(cid)["current_turn"] != cleric:
+        server.next_turn(cid)
+    assert server.get_state(cid)["current_turn"] == cleric
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged_roller(d20, {"1d8+3": weapon_total}))
+    return cid, cleric, foe
+
+
+def test_guided_strike_sets_pending_attack_bonus(tmp_path, monkeypatch):
+    # #2: use_resource(channel_divinity, maneuver='Guided Strike') spends a use and stashes a
+    # +10 pending to-hit bonus on the cleric (a POINT pool is allowed for a to-hit option —
+    # it is NOT refused like a damage maneuver would be).
+    import server
+    cid, cleric, foe = _war_cleric_combat(server, monkeypatch, tmp_path, foe_ac=15, d20=8, weapon_total=6)
+    spent = server.use_resource(cid, cleric, "channel_divinity", maneuver="Guided Strike")
+    assert spent["ok"] is True and spent["remaining"] == 1
+    assert spent["attack_bonus"]["attack_bonus"] == 10 and spent["attack_bonus"]["option"] == "Guided Strike"
+    pab = server.get_character(cid, cleric)["pending_attack_bonus"]
+    assert pab is not None and pab["amount"] == 10 and pab["resource"] == "channel_divinity"
+
+
+def test_guided_strike_plus10_turns_miss_into_hit(tmp_path, monkeypatch):
+    # #2 the core fix: a roll of 8 vs AC 15 MISSES (8 < 15), but Guided Strike's +10 folds into
+    # the attack-roll total (18 >= 15) and turns the miss into a hit — the +10 actually lands.
+    import server
+    cid, cleric, foe = _war_cleric_combat(server, monkeypatch, tmp_path, foe_ac=15, d20=8, weapon_total=6)
+    server.use_resource(cid, cleric, "channel_divinity", maneuver="Guided Strike")
+    res = server.attack(cid, cleric, foe, attack_bonus=0, damage_dice="1d8+3", damage_type="bludgeoning")
+    assert res["target_ac"] == 15
+    assert res["attack_roll"]["total"] == 18  # 8 (roll) + 10 (Guided Strike)
+    assert res["attack_roll"]["to_hit_bonus"]["amount"] == 10
+    assert res["hit"] is True  # 18 >= 15 (would be a miss at 8 without the +10)
+    # Consumed once — the pending bonus is cleared and does not carry to a later strike.
+    assert server.get_character(cid, cleric)["pending_attack_bonus"] is None
+
+
+def test_channel_divinity_non_to_hit_maneuver_refused_no_spend(tmp_path, monkeypatch):
+    # REGRESSION: a DAMAGE maneuver name (not a recognized to-hit option) against the
+    # channel_divinity POINT pool is still refused cleanly — no spend, no pending of either kind.
+    import server
+    cid, cleric, foe = _war_cleric_combat(server, monkeypatch, tmp_path, foe_ac=15, d20=8, weapon_total=6)
+    out = server.use_resource(cid, cleric, "channel_divinity", maneuver="Trip Attack")
+    assert out["ok"] is False and "point pool" in out["error"]
+    sheet = server.get_character(cid, cleric)
+    assert sheet["class_resources"]["channel_divinity"]["used"] == 0  # nothing spent
+    assert sheet["pending_attack_bonus"] is None and sheet["pending_damage_bonus"] is None
+
+
+def test_orphaned_pending_riders_cleared_on_next_turn(tmp_path, monkeypatch):
+    # LEAK GUARD: a maneuver die / Guided Strike spent but never consumed by an attack this turn
+    # must NOT carry to a later turn. Use two monsters (their turn advance has no PC-skip guard)
+    # so we can end the spender's turn without attacking.
+    import server
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Leak")["id"]
+    m1 = server.create_character(cid, "Brute", kind="monster", max_hp=20, armor_class=12)["id"]
+    m2 = server.create_character(cid, "Thug", kind="monster", max_hp=20, armor_class=12)["id"]
+    server.set_class_resource(cid, m1, "superiority_dice", max=4, recharge="short", size="d8")
+    server.start_combat(cid, [m1, m2])
+    if server.get_state(cid)["current_turn"] != m1:
+        server.next_turn(cid)
+    assert server.get_state(cid)["current_turn"] == m1
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged_roller(25, {"1d8": 6}))
+    server.use_resource(cid, m1, "superiority_dice", maneuver="Trip Attack")  # pending set, no attack
+    assert server.get_character(cid, m1)["pending_damage_bonus"] is not None
+    server.next_turn(cid)  # m1's turn ends unused -> the orphaned rider is cleared
+    assert server.get_character(cid, m1)["pending_damage_bonus"] is None
+
+
 def test_maneuver_die_typed_damage_respects_resistance(tmp_path, monkeypatch):
     # A maneuver with an explicit damage_type lands as that type — and a resistant target
     # halves only the maneuver component (the weapon's type is untouched). Trip 'Attack' with


### PR DESCRIPTION
## What & why

The opus combat-sprint **cs-opus-1040val** (angrydm 3.2) surfaced two real seam-level omissions where a class-feature resource was *spent* but its bonus never *landed* — the classic felt-vs-scores **"surfacing info ≠ the DM using it"** pattern. The turn_brief *cue* for the Battle Master die was added in #1033, yet the post-#1033 run still mis-spent it, confirming a cue isn't enough. Both are now **ENFORCED in the engine**.

## Findings reconciliation (validated vs current main, 32 commits past the scored SHA)

| Finding | Status | Action |
|---|---|---|
| #1 BM superiority die not folded into damage | **REAL** | Auto-fold in engine |
| #2 War Domain Guided Strike (+10) consumed, never applied | **REAL** | Implement pending to-hit rider |
| #3 "no way to drop concentration" | **already on main** | `drop_concentration` (server.py) + target-release + cue + 6 tests — no change |
| Ghoul paralysis on a half-elf | **FALSE POSITIVE** | srd524 Claw exempts "Undead or **elf**"; half-elf ≠ elf → DM correct. Untouched |
| Second Wind max=3 at Fighter 4 | **FALSE POSITIVE** | srd524 Second Wind scales by the 2024 Fighter table → 3 at L4. Untouched |
| Ranged-in-melee disadvantage | engine-gated on #461 grid | Existing theater-of-mind WARN already covers; out of scope |

## Changes (additive)

**#1 — Battle Master superiority die AUTO-FOLD.** A bare in-combat `use_resource(superiority_dice)` (no `maneuver=`) used to only emit an advisory `warning` (which the DM ignored). It now auto-rolls the die and stashes a `pending_damage_bonus` the next `attack()` folds into damage. Out of combat / point pools: inert (byte-identical).

**#2 — War Domain Guided Strike (+10).** New one-shot `PendingAttackBonus` model (mirrors `PendingDamageBonus`). `use_resource(channel_divinity, maneuver='Guided Strike')` stashes +10; the next `attack()` folds it into the attack-roll **total before the hit check** (turns a key miss into a hit), surfaced as `attack_roll.to_hit_bonus`. Crit/fumble read the natural die (unchanged), matching SRD. +10 is the canonical value the engine already cited in the turn_brief cue. Reuses the existing `maneuver=` param → **zero new tool params**.

**Leak guard.** `next_turn` clears an outgoing combatant's orphaned pending rider so a die/+10 spent-but-not-attacked can't carry to a later turn.

**Behavioral gate.** `maneuver_rider_consumed` (**WARN**) flags a rider spent with no following attack that carried it — graduates to FATAL after clean sweeps (gate-graduation discipline; avoids RED-capping legit play).

**Cues.** turn_brief now names the exact calls for both features (runtime returns, not pinned schema).

## Invariants / budget
- Engine = sole writer; all new fields default `None` → old snapshots round-trip; each feature independently removable.
- **Schema budget unchanged: 119,765 B / 120,000** (no new tool params/tools; reuses `maneuver=`). `test_tool_schema_budget` green.

## Tests (single-process, `-p no:xdist`)
- **Engine 3065/3065** — incl. 5 new: bare-die auto-folds into next attack; Guided Strike sets pending + **+10 turns miss→hit**; channel_divinity non-to-hit maneuver still refused; orphaned rider cleared on next_turn; updated bare-superiority test → auto-fold.
- **qa gate + distill 97/97** — incl. 5 new `maneuver_rider_consumed` cases (consumed PASS for die + Guided Strike, dangling WARN for both, ordinary spend untracked).
- license_check passed.

## Not done
- A fresh opus combat-sprint to confirm the angrydm rise is **auth-blocked**: local `claude -p` returns 401 (token expired — owner-gated `claude setup-token`; I won't touch Eva/gateway auth). The engine fixes are deterministically proven by the new unit tests, which assert the die appears in the damage total and the +10 lands on the roll (i.e. they run the real engine attack-resolution surface). Recommend a fresh `qa/run_combat_sprint.sh` once auth is restored — the seed deterministically includes Aldric (BM) + Maren (War Cleric), so it exercises both fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * War Domain Guided Strike now properly applies a +10 to-hit bonus to the next attack roll.
  * Bare superiority die spends now automatically apply to the next attack without requiring manual maneuver selection.

* **Bug Fixes**
  * Enhanced validation to detect when combat resources (maneuver riders, attack bonuses) are spent but not applied to subsequent attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->