### PR TITLE
perf(qa): --effort low for the heavy Angry-DM scorer lens (#1040 — 2.2x faster)

### DIFF
--- a/qa/score.sh
+++ b/qa/score.sh
@@ -48,6 +48,21 @@ INPUT="$(printf '%s\n\n# ===== OUTPUT FORMAT =====\nRespond with ONLY a single J
 ERR="${OUT%.json}.err"
 RAW="${OUT%.json}.raw.json"   # raw claude --output-format json envelope (kept for the guard)
 
+# --- (c) Scorer EFFORT (#1040 latency). The Angry-DM 5e-fidelity lens is the HEAVY one (~32 KB rubric);
+# at default effort it ran ~400s — far too long for a GRADING call. Scoring is checklist-application, not
+# generation, so LOW effort holds quality while cutting wall-clock ~2.2x (measured on csmed-1: 402s -> 179s,
+# a valid full scorecard). Auto-apply low effort to the angrydm lens BY RUBRIC NAME; the story (tolkien)
+# lens — quality-critical AND already fast (~60-150s) — stays at default. Override per call with
+# WORLDOS_SCORER_EFFORT (low|medium|high|max, or empty "" to force NO flag). Uses `-` (not `:-`) so an
+# explicit empty override means "no --effort", while unset uses the per-rubric default.
+case "$RUBRIC" in
+  *angry_dm*) _EFFORT_DEFAULT="low" ;;
+  *)          _EFFORT_DEFAULT="" ;;
+esac
+SCORER_EFFORT="${WORLDOS_SCORER_EFFORT-$_EFFORT_DEFAULT}"
+EFFORT_ARG=""
+[ -n "$SCORER_EFFORT" ] && EFFORT_ARG="--effort $SCORER_EFFORT"
+
 # stamp_prompt_hash <json-file>: merge the prompt_construction_hash into a score JSON in place.
 stamp_prompt_hash() {
   local f="$1" tmp
@@ -104,7 +119,7 @@ while [ "$attempt" -lt 3 ]; do
   # so it gets full API throughput and lands near the ~400s baseline rather than slower under contention.
   printf '%s' "$INPUT" | env -u ANTHROPIC_BASE_URL -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN \
     -u API_TIMEOUT_MS -u CLAUDE_CONFIG_DIR timeout "${WORLDOS_SCORE_TIMEOUT:-600}" claude -p \
-    --model "$SCORER_MODEL" --permission-mode bypassPermissions \
+    --model "$SCORER_MODEL" --permission-mode bypassPermissions $EFFORT_ARG \
     --max-budget-usd "$BUDGET" \
     --output-format json > "$RAW" 2> "$ERR"
 


### PR DESCRIPTION
## What
The Angry-DM 5e-fidelity lens (`rubric_angry_dm.md`, ~32KB) ran **~400s** at default effort — far too long for a **grading** call (checklist application, not generation). This is one half of the #1040 scorer-optimization (the other half — migrating deterministic checks into the gate + shrinking the rubric — is a sibling PR).

## Measurement (the lever, isolated)
A direct `claude -p` re-score of csmed-1's angrydm input: **default 402s → `--effort low` 179s (2.2× faster)**, still a valid full scorecard (`scores`/`defects`/`verdict`, single-turn, ~7KB).

## Change (surgical)
`score.sh` auto-applies `--effort low` **only to the angrydm lens** (case-match on `*angry_dm*` in the rubric path). The **story (tolkien) lens — quality-critical and already fast (~60–150s) — stays at default**, as does the compact mechanical lens. Override per call with `WORLDOS_SCORER_EFFORT` (`low|medium|high|max`, or empty `""` to force no flag; uses `${VAR-default}` so an explicit-empty disables).

## Why it's safe
- Default behavior for tolkien/mechanical is **unchanged** (no `--effort` flag).
- The override is the escape hatch (revert to default or bump to `medium` if needed).
- The low-effort scorecard is structurally valid (full scores/defects/verdict).

## Tests
`bash -n` + the effort-detection logic verified (angrydm→`--effort low`; tolkien/mechanical→none; `WORLDOS_SCORER_EFFORT=""`→none; `=medium`→`--effort medium`).

## Validation
Combines with the rubric-shrink PR for the full **~400s → ~60–90s** target. The precise **score-parity A/B** (does low effort hold the angrydm score within ±0.3 + keep the judgment findings) is validated on a fresh opus combat-sprint in Wave 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced QA scoring to support per-rubric “effort” tuning, improving grading performance and consistency.
  * Automatically selects a lower effort for specific rubric matches while using default behavior for others.
  * Added environment variable controls to override grading effort, including the ability to disable it entirely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->