### PR TITLE
fix(qa): register maneuver_rider_consumed in the gate taxonomy (un-red main, #1081 follow-up)

### DIFF
--- a/qa/BEHAVIORAL_GATE_TAXONOMY.json
+++ b/qa/BEHAVIORAL_GATE_TAXONOMY.json
@@ -260,6 +260,12 @@
       "retest": "bash qa/run_combat_sprint.sh sprint-retest",
       "hint": "A Fighter took >25% HP but ended with Second Wind unused — a tactical-adherence smell. Reinforce 'use signature class features when warranted' in the DM/angry-DM guidance. WARN only."
     },
+    "maneuver_rider_consumed": {
+      "category": "DM_ADHERENCE",
+      "likely_code_locations": ["servers/engine/server.py", "qa/rubric_angry_dm.md", "skills/dungeon-master/SKILL.md"],
+      "retest": "bash qa/run_combat_sprint.sh sprint-retest",
+      "hint": "A maneuver / to-hit rider (Battle Master superiority die, War-Domain Guided Strike) was spent via use_resource but the following attack did not fold the bonus in (the +Nd8 damage or +10 to-hit was dropped). Check the use_resource -> attack pending-bonus fold (server.py) + the DM's two-step maneuver usage. WARN only."
+    },
     "signature_feature_exercised": {
       "category": "DM_ADHERENCE",
       "likely_code_locations": ["qa/play_prompt_combat_sprint.txt", "qa/rubric_angry_dm.md", "servers/engine/combat.py"],


### PR DESCRIPTION
## Why main is red
#1081 added the `maneuver_rider_consumed` `chk()` to `qa/assert_behavioral.py` (the Battle Master superiority-die / War-Domain Guided-Strike rider check) but did **not** register it in `qa/BEHAVIORAL_GATE_TAXONOMY.json`. The drift-guard `test_root_cause_analyzer::test_taxonomy_matches_real_gate_check_names` fails → **main's `qa-release-gate` has been RED since `797b93e`**, blocking every PR.

## Fix
Add the one missing `DM_ADHERENCE` taxonomy entry (surgical, 6-line diff). Verified: JSON valid; `test_root_cause_analyzer` 19 passed.

(Follow-up: the in-flight #1083 adds 4 more gate checks — those get their taxonomy entries in that PR.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new behavioral-gate validation check to enhance quality assurance testing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->