### PR TITLE
feat(godot): render combat/zone tokens (all combatants, team-styled) (#1060)

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -142,6 +142,18 @@ jobs:
           grep -qE "\[ServedFinals\] RESULT served-atlas-applied=true resolver_cached=true anims=32" /tmp/served.log
           kill $STUB_PID 2>/dev/null || true
 
+      - name: Conformance — combat/zone tokens render for EVERY combatant (#1060)
+        run: |
+          set -euxo pipefail
+          # Drive an ACTIVE combat snapshot (fixtures/combat-surface-active.json: 2 allies
+          # + 3 foes at named zones) into WorldView and assert one team-tinted token per
+          # combat token, each at its zone anchor. The steady SurfaceClient path keeps
+          # combat-surface.json active:false (the exploration default), so the exploration
+          # party[0] path + the anims=32 conformance above stay untouched.
+          godot --headless --path godot --quit-after 180 -- --combat-tokens 2>&1 | tee /tmp/combat.log
+          # Five combatants -> five spawned tokens, each at its zone, foes tinted + allies neutral.
+          grep -qE "\[CombatTokens\] RESULT ok=true count=5/5 all_zoned=true team_tinted=true \(foes=true allies=true\)" /tmp/combat.log
+
       - name: Export validation — Web (single-threaded) + Linux
         working-directory: godot
         run: |

--- a/godot/fixtures/combat-surface-active.json
+++ b/godot/fixtures/combat-surface-active.json
@@ -1,0 +1,42 @@
+{
+  "_comment": "ACTIVE combat fixture for the #1060 combat-token conformance. Mirrors the REAL /combat-surface (viewer/server.py build_combat_surface -> _combat_tokens): active:true with a tokens[] roster (2 allies + 3 foes) at the SAME named zones as atlas-surface.json / render-profile.json. `zone` is the only spatial truth; x/y are a DERIVED render-hint (positionAuthority:'derived') the renderer IGNORES, re-deriving its own screen position from the named zone. Loaded directly by Main.gd's --combat-tokens mode (the steady SurfaceClient path keeps combat-surface.json active:false = the exploration default).",
+  "campaign_id": "bg-absolute-remnants",
+  "title": "Baldur's Gate — Absolute Remnants",
+  "world": "baldurs-gate",
+  "location": { "id": "loc-lower-city", "name": "Baldur's Gate — Lower City", "imageScope": "location:loc-lower-city" },
+  "encounter": { "active": true, "name": "Ambush in the Lower City", "summary": "Combat round 1", "round": 1, "warnings": [] },
+  "grid": { "mode": "zones", "cols": 16, "rows": 10 },
+  "active": true,
+  "round": 1,
+  "turn_index": 0,
+  "current_id": "char-aubree",
+  "zones": [
+    { "name": "the gate approach", "occupants": ["char-aubree"] },
+    { "name": "the market row", "occupants": ["char-companion-1", "npc-cultist-1"] },
+    { "name": "the alley mouth", "occupants": ["npc-cultist-2", "npc-ogre-1"] }
+  ],
+  "tokens": [
+    { "id": "char-aubree", "name": "Aubree", "initial": "A", "short": "A portrait", "team": "ally", "initiative": 18, "isCurrent": true, "reactionAvailable": true, "conditions": [], "zone": "the gate approach", "x": 0.5, "y": 0.58, "positionAuthority": "derived", "hpKnown": true, "health": "steady", "hp": 24, "hpMax": 30, "ac": 15 },
+    { "id": "char-companion-1", "name": "Shadowheart", "initial": "S", "short": "S portrait", "team": "ally", "initiative": 14, "isCurrent": false, "reactionAvailable": true, "conditions": [], "zone": "the market row", "x": 0.34, "y": 0.72, "positionAuthority": "derived", "hpKnown": true, "health": "wounded", "hp": 18, "hpMax": 22, "ac": 18 },
+    { "id": "npc-cultist-1", "name": "Cultist Acolyte", "initial": "C", "short": "C portrait", "team": "foe", "initiative": 12, "isCurrent": false, "reactionAvailable": true, "conditions": [], "zone": "the market row", "x": 0.38, "y": 0.7, "positionAuthority": "derived", "hpKnown": false, "health": "unknown" },
+    { "id": "npc-cultist-2", "name": "Cultist Zealot", "initial": "C", "short": "C portrait", "team": "foe", "initiative": 9, "isCurrent": false, "reactionAvailable": true, "conditions": ["prone"], "zone": "the alley mouth", "x": 0.72, "y": 0.8, "positionAuthority": "derived", "hpKnown": false, "health": "unknown" },
+    { "id": "npc-ogre-1", "name": "Ogre Enforcer", "initial": "O", "short": "O portrait", "team": "foe", "initiative": 6, "isCurrent": false, "reactionAvailable": true, "conditions": [], "zone": "the alley mouth", "x": 0.68, "y": 0.82, "positionAuthority": "derived", "hpKnown": false, "health": "unknown" }
+  ],
+  "initiative": [
+    { "id": "char-aubree", "name": "Aubree", "init": 18, "active": true, "team": "ally", "health": "steady", "reactionAvailable": true },
+    { "id": "char-companion-1", "name": "Shadowheart", "init": 14, "active": false, "team": "ally", "health": "wounded", "reactionAvailable": true },
+    { "id": "npc-cultist-1", "name": "Cultist Acolyte", "init": 12, "active": false, "team": "foe", "health": "unknown", "reactionAvailable": true },
+    { "id": "npc-cultist-2", "name": "Cultist Zealot", "init": 9, "active": false, "team": "foe", "health": "unknown", "reactionAvailable": true },
+    { "id": "npc-ogre-1", "name": "Ogre Enforcer", "init": 6, "active": false, "team": "foe", "health": "unknown", "reactionAvailable": true }
+  ],
+  "selectedTokenId": "char-aubree",
+  "actionEconomy": {},
+  "commandCenter": {},
+  "actionBar": [],
+  "battleLog": [],
+  "live": false,
+  "is_live_view": false,
+  "can_act": false,
+  "state_authority": "engine",
+  "write_lane": "/move"
+}

--- a/godot/scenes/CharacterToken.gd
+++ b/godot/scenes/CharacterToken.gd
@@ -35,6 +35,9 @@ var _anim: String = "idle"
 var _facing_order: Array = LOCKED_FACING_ORDER.duplicate()
 var _anchor: Vector2 = Vector2(64, 116)
 var _kind: String = "character"
+## #1060 — renderer-owned team modulate (WHITE = neutral/none). Re-applied after every
+## set_manifest (which rebuilds the sprite) so a served-atlas swap keeps the tint.
+var _team_tint: Color = Color(1, 1, 1, 1)
 
 var _sprite: AnimatedSprite2D
 var _frames: SpriteFrames
@@ -131,6 +134,8 @@ func set_manifest(manifest: Dictionary, sheet_texture: Texture2D) -> void:
 	_sprite.centered = false
 	# Place the cell so its anchor px lands on the node origin (feet at origin).
 	_sprite.offset = -_anchor
+	# #1060 — re-apply the team tint (this rebuilt the sprite; modulate would reset).
+	_sprite.modulate = _team_tint
 
 	# Default: idle at the profile default facing (fallback S).
 	var default_facing := RenderProfile.default_facing()
@@ -164,6 +169,21 @@ func facing() -> String:
 
 func anim() -> String:
 	return _anim
+
+
+## #1060 — apply a renderer-owned TEAM tint (modulate) to the sprite so foe vs ally
+## reads at a glance. This is PURE presentation (it owns no game state); the engine
+## ships only the `team` string and WorldView maps it to a Color. Persists across
+## set_anim/set_facing because it modulates the AnimatedSprite2D, not a single clip.
+func set_team_tint(tint: Color) -> void:
+	_team_tint = tint
+	if _sprite != null:
+		_sprite.modulate = tint
+
+
+## The team tint currently applied (WHITE == neutral/none). For validation.
+func team_tint() -> Color:
+	return _team_tint
 
 
 ## The SpriteFrames animation count (for validation: expect anim_count*facings = 32).

--- a/godot/scenes/Main.gd
+++ b/godot/scenes/Main.gd
@@ -96,6 +96,9 @@ func _on_snapshot(atlas: Dictionary, _combat: Dictionary, character: Dictionary)
 		if _has_arg("--served-finals-smoke"):
 			call_deferred("_run_served_finals_smoke")
 			return
+		if _has_arg("--combat-tokens"):
+			call_deferred("_run_combat_tokens")
+			return
 		if _has_arg("--demo-occlusion"):
 			call_deferred("_run_demo_occlusion")
 			return
@@ -206,6 +209,98 @@ func _run_served_finals_smoke() -> void:
 		str(all_ok), str(resolver_ok), anims])
 
 	call_deferred("_quit_clean")
+
+
+# ---------------------------------------------------------------------------
+# #1060 COMBAT-TOKENS: prove the iso view renders a token for EVERY combatant (party +
+# foes), each at its named ZONE, visually distinguished by TEAM. Drives an ACTIVE combat
+# snapshot (res://fixtures/combat-surface-active.json — the steady SurfaceClient path
+# keeps combat-surface.json active:false = the exploration default) straight into
+# WorldView.apply_snapshot, then asserts (a) one token per combat token, (b) each placed
+# at its zone's screen anchor, (c) foes carry the hostile team tint and allies do not.
+# Deterministic + headless (no window needed). Quits cleanly.
+# ---------------------------------------------------------------------------
+func _run_combat_tokens() -> void:
+	print("[Main] --combat-tokens: rendering an ACTIVE combat roster (party + foes)")
+
+	# Load the read-only surfaces directly (the active combat fixture + the standalone
+	# atlas/character fixtures), exactly the shape SurfaceClient emits to apply_snapshot.
+	var combat: Dictionary = _load_fixture_dict("combat-surface-active")
+	var atlas: Dictionary = _load_fixture_dict("atlas-surface")
+	var character: Dictionary = _load_fixture_dict("character-surface")
+	if combat.is_empty():
+		print("[CombatTokens] RESULT ok=false reason=missing-active-fixture")
+		call_deferred("_quit_clean")
+		return
+
+	# Project the ACTIVE combat snapshot into the world (the #1060 path under test).
+	# A token that PRE-EXISTED from the prior exploration snapshot (the lead party
+	# token) is reconciled with a short walk-tween to its combat zone rather than an
+	# instant snap; let that tween settle so the placement assertion reads the final
+	# position, not a mid-walk frame. (New tokens are placed instantly.)
+	_world.apply_snapshot(atlas, combat, character)
+	await get_tree().create_timer(CharacterToken.MOVE_TWEEN_SEC + 0.2).timeout
+
+	var tokens: Array = combat.get("tokens", []) if typeof(combat.get("tokens", [])) == TYPE_ARRAY else []
+	var expected: int = tokens.size()
+	var spawned: int = _world.token_count()
+	print("[CombatTokens] expected=%d spawned=%d" % [expected, spawned])
+
+	# (a) one token per combat token; (b) each at its named zone's anchor; (c) the team
+	# tint matches (foes = hostile wash != WHITE; allies = neutral WHITE).
+	var all_present := true
+	var all_zoned := true
+	var all_tinted := true
+	var foe_seen := false
+	var ally_seen := false
+	for entry in tokens:
+		if typeof(entry) != TYPE_DICTIONARY:
+			continue
+		var t: Dictionary = entry
+		var actor_id := String(t.get("id", ""))
+		var team := String(t.get("team", "ally"))
+		var zone := String(t.get("zone", ""))
+		var tok: CharacterToken = _world.token_for(actor_id)
+		var present := tok != null and is_instance_valid(tok)
+		all_present = all_present and present
+		if not present:
+			print("[CombatTokens] MISSING token actor=%s team=%s zone=%s" % [actor_id, team, zone])
+			continue
+		# (b) placement == the zone anchor (when the zone is known this tick).
+		var zone_pos: Vector2 = _world.zone_screen_pos(zone)
+		var at_zone := zone == "" or zone_pos == Vector2.ZERO or tok.position.distance_to(zone_pos) < 1.0
+		all_zoned = all_zoned and at_zone
+		# (c) team tint: foes must be tinted (non-white); allies stay neutral white.
+		var tint: Color = _world.team_tint_for(actor_id)
+		var is_white := tint.is_equal_approx(Color(1, 1, 1, 1))
+		if team == "foe":
+			foe_seen = true
+			all_tinted = all_tinted and not is_white
+		else:
+			ally_seen = true
+			all_tinted = all_tinted and is_white
+		print("[CombatTokens] actor=%s team=%s zone=%s at_zone=%s tint=(%.2f,%.2f,%.2f)" % [
+			actor_id, team, zone, str(at_zone), tint.r, tint.g, tint.b])
+
+	var count_ok: bool = spawned == expected and expected > 0
+	var all_ok: bool = count_ok and all_present and all_zoned and all_tinted and foe_seen and ally_seen
+	print("[CombatTokens] RESULT ok=%s count=%d/%d all_zoned=%s team_tinted=%s (foes=%s allies=%s)" % [
+		str(all_ok), spawned, expected, str(all_zoned), str(all_tinted), str(foe_seen), str(ally_seen)])
+
+	call_deferred("_quit_clean")
+
+
+## #1060 — load + parse a bundled res://fixtures/<name>.json into a Dictionary (or {}
+## on any missing/parse failure). Mirrors SurfaceClient's fixture loader so the
+## conformance drives apply_snapshot with the exact same shapes the transport emits.
+func _load_fixture_dict(name: String) -> Dictionary:
+	var path := "res://fixtures/%s.json" % name
+	if not FileAccess.file_exists(path):
+		push_warning("[Main] missing fixture: " + path)
+		return {}
+	var text := FileAccess.get_file_as_string(path)
+	var parsed: Variant = JSON.parse_string(text)
+	return parsed if typeof(parsed) == TYPE_DICTIONARY else {}
 
 
 # ---------------------------------------------------------------------------

--- a/godot/scenes/WorldView.gd
+++ b/godot/scenes/WorldView.gd
@@ -60,6 +60,18 @@ const PropActorScript := preload("res://scenes/PropActor.gd")
 ## so the standalone fixture run shows a real directional token, not just markers.
 const CHAR_ASSET_ROOT := "res://assets/characters/"
 const PILLAR_PROP_DIR := "res://assets/props/pillar/"
+## #1060 — the DEFAULT committed placeholder slug a combatant without its OWN committed
+## asset dir falls back to. Enemies/NPCs have no per-actor sheet (and no served atlas),
+## so they render with this real directional placeholder + a team tint (below). Always
+## present in the committed tree, so a combat token can ALWAYS be built.
+const DEFAULT_CHAR_SLUG := "aubree"
+
+## #1060 — renderer-owned TEAM tint (modulate) so foe vs ally reads at a glance. This is
+## pure presentation the renderer owns (the engine ships only the `team` string); it does
+## NOT touch state. Allies are left neutral (white = no tint); foes get a hostile red wash.
+const TEAM_TINT_ALLY := Color(1.0, 1.0, 1.0, 1.0)        ## neutral — committed sprite as-is
+const TEAM_TINT_FOE := Color(1.0, 0.55, 0.5, 1.0)        ## hostile red wash
+const TEAM_TINT_NEUTRAL := Color(0.92, 0.92, 1.0, 1.0)   ## faint cool for unknown/other teams
 
 @onready var _backdrop: Sprite2D = $BackdropPlane
 @onready var _floor_poly: Polygon2D = $WalkmaskLayer/FloorPolygon
@@ -84,9 +96,13 @@ var _pending_backdrop_scope: String = ""
 var _backdrop_is_resolved: bool = false
 
 ## #1054 — spawned tokens reconciled by engine_actor_id across ticks (no leaks).
-## actor_id -> CharacterToken. Today we only spawn party[0], but the dictionary
-## keeps the reconcile contract right for when the party grows.
+## actor_id -> CharacterToken. In exploration we spawn party[0]; in combat (#1060) we
+## spawn one token per combat token. Either way the dictionary keeps the reconcile
+## contract right (build once, reposition thereafter, free departed actors).
 var _tokens: Dictionary = {}
+## #1060 — last applied team modulate per spawned token (actor_id -> Color), so a
+## re-spawn / re-tint is idempotent and the conformance can read back the tint.
+var _token_team_tint: Dictionary = {}
 ## #1063 part 2 — sprite-atlas scope_key -> actor_id, so when ImageResolver emits
 ## texture_ready for a SERVED sprite atlas (/image?scope=sprite-<name>) we know which
 ## token to re-set_manifest. Distinct namespace from the backdrop scope (scene-*), so
@@ -154,9 +170,11 @@ func apply_snapshot(atlas: Dictionary, combat: Dictionary, character: Dictionary
 	_rebuild_zone_markers(zones, scope, vp, baseline)
 	_zone_count = zones.size()
 
-	# --- #1054: spawn/reconcile the lead party token + the static pillar prop into
-	# the Y-sorted layer (foot-anchored, so #1055's occlusion sorts by foot-y) ---
-	_reconcile_actors(character)
+	# --- #1054/#1060: spawn/reconcile actor tokens + the static pillar prop into the
+	# Y-sorted layer (foot-anchored, so #1055's occlusion sorts by foot-y). In COMBAT
+	# we render one token per combat token (team-tinted) at its zone; in exploration we
+	# render the lead party token — exactly today's behavior. ---
+	_reconcile_actors(character, combat, in_combat)
 	_place_pillar()
 
 	# DIAGNOSTIC (validation proof): location, zone-marker count, backdrop status.
@@ -230,6 +248,18 @@ func zone_screen_pos(zone_name: String) -> Vector2:
 ## to drive set_zone_target / set_facing on click. Exposed for validation too.
 func token_for(engine_actor_id: String) -> CharacterToken:
 	return _tokens.get(engine_actor_id, null)
+
+
+## #1060 — the count of currently-spawned actor tokens (party in exploration, the full
+## roster in combat). Exposed for the combat-tokens conformance assertion.
+func token_count() -> int:
+	return _tokens.size()
+
+
+## #1060 — the renderer-owned team modulate last applied to a token (WHITE if none).
+## Exposed so the conformance can assert foes carry the hostile wash and allies don't.
+func team_tint_for(engine_actor_id: String) -> Color:
+	return _token_team_tint.get(engine_actor_id, Color(1, 1, 1, 1))
 
 
 ## The static pillar prop (null until spawned). Exposed for #1055's occlusion test.
@@ -357,32 +387,29 @@ func _prop_contains(prop: PropActor, world_pos: Vector2) -> bool:
 # #1054 — actor tokens + the static pillar prop, in the Y-sorted layer.
 # ---------------------------------------------------------------------------
 
-## Spawn/reconcile ONE CharacterToken for character.party[0] (the lead actor),
-## keyed by engine_actor_id so it is built ONCE and only repositioned thereafter.
-## Tokens for actors no longer present are freed (reconcile = no leaks across ticks).
-## Placed at a FOREGROUND zone (the front-most marker) so it reads near the camera.
-func _reconcile_actors(character: Dictionary) -> void:
-	var lead := _lead_actor(character)
+## Spawn/reconcile actor tokens into the Y-sorted layer, keyed by engine_actor_id so
+## each is built ONCE and only repositioned/re-tinted thereafter. Tokens for actors no
+## longer present are freed (reconcile = no leaks across ticks).
+##   - COMBAT (#1060): one token PER combat token (the whole roster — party + foes),
+##     placed at its named ZONE's anchor, with a renderer-owned TEAM tint.
+##   - EXPLORATION (#1054, unchanged): ONE token for character.party[0] at the
+##     FOREGROUND zone. Empty combat == today's behavior exactly.
+## The combat-token x/y are IGNORED (positionAuthority:"derived"); the renderer derives
+## the screen position from the engine's named zone via zone_screen_pos(), staying the
+## sole owner of layout while the engine stays the sole owner of WHERE (the zone).
+func _reconcile_actors(character: Dictionary, combat: Dictionary, in_combat: bool) -> void:
 	var wanted: Dictionary = {}  # actor_id -> true (actors that should exist this tick)
 	# A location change since the last snapshot is a `travel` — reset facing to the
 	# rest/default facing rather than deriving a walk direction (ISO-PROJECTION.md).
 	var traveled := _prev_location_id != "" and _prev_location_id != _location_id
 
-	if not lead.is_empty():
-		var actor_id := String(lead.get("id", ""))
-		if actor_id != "":
-			wanted[actor_id] = true
-			var tok: CharacterToken = _tokens.get(actor_id, null)
-			var is_new := tok == null
-			if is_new:
-				tok = _spawn_token(actor_id)
-				if tok != null:
-					_tokens[actor_id] = tok
-			if tok != null:
-				var target_pos := _foreground_pos()
-				_reconcile_token_motion(tok, actor_id, target_pos, is_new, traveled)
+	var combat_tokens := _combat_token_list(combat) if in_combat else []
+	if not combat_tokens.is_empty():
+		_reconcile_combat_tokens(combat_tokens, wanted, traveled)
+	else:
+		_reconcile_exploration_token(character, wanted, traveled)
 
-	# Free tokens whose actor left the party (no leaks).
+	# Free tokens whose actor is no longer present (no leaks).
 	for existing_id in _tokens.keys():
 		if not wanted.has(existing_id):
 			var stale: CharacterToken = _tokens[existing_id]
@@ -390,10 +417,100 @@ func _reconcile_actors(character: Dictionary) -> void:
 				stale.queue_free()
 			_tokens.erase(existing_id)
 			_token_prev_pos.erase(existing_id)
+			_token_team_tint.erase(existing_id)
 			# Drop any served-atlas scope mapping pointing at the freed token (#1063).
 			for sc in _sheet_scope_actor.keys():
 				if String(_sheet_scope_actor[sc]) == String(existing_id):
 					_sheet_scope_actor.erase(sc)
+
+
+## #1054 (UNCHANGED behavior) — spawn/reconcile ONE token for character.party[0] at the
+## foreground zone. The exploration path; runs whenever combat is inactive/empty.
+func _reconcile_exploration_token(character: Dictionary, wanted: Dictionary, traveled: bool) -> void:
+	var lead := _lead_actor(character)
+	if lead.is_empty():
+		return
+	var actor_id := String(lead.get("id", ""))
+	if actor_id == "":
+		return
+	wanted[actor_id] = true
+	var tok: CharacterToken = _tokens.get(actor_id, null)
+	var is_new := tok == null
+	if is_new:
+		tok = _spawn_token(actor_id)
+		if tok != null:
+			_tokens[actor_id] = tok
+	if tok != null:
+		# Exploration tokens carry the neutral ally tint (no hostile wash).
+		_apply_team_tint(tok, actor_id, "ally")
+		var target_pos := _foreground_pos()
+		_reconcile_token_motion(tok, actor_id, target_pos, is_new, traveled)
+
+
+## #1060 — spawn/reconcile a token for EVERY combatant at its named zone, team-tinted.
+## Each token is keyed by its engine_actor_id (combat token `id`); foes render with the
+## committed placeholder (no per-actor atlas) plus a hostile tint so they read as enemies.
+func _reconcile_combat_tokens(combat_tokens: Array, wanted: Dictionary, traveled: bool) -> void:
+	for entry in combat_tokens:
+		if typeof(entry) != TYPE_DICTIONARY:
+			continue
+		var t: Dictionary = entry
+		var actor_id := String(t.get("id", ""))
+		if actor_id == "":
+			continue
+		wanted[actor_id] = true
+		var tok: CharacterToken = _tokens.get(actor_id, null)
+		var is_new := tok == null
+		if is_new:
+			tok = _spawn_token(actor_id)
+			if tok != null:
+				_tokens[actor_id] = tok
+		if tok == null:
+			continue
+		# Renderer-owned team tint (foe = hostile red wash, ally = neutral).
+		_apply_team_tint(tok, actor_id, String(t.get("team", "ally")))
+		# Derive the screen position from the engine's named ZONE (never the x/y hint).
+		var target_pos := _combat_token_pos(t)
+		_reconcile_token_motion(tok, actor_id, target_pos, is_new, traveled)
+
+
+## #1060 — the combat token list (combat.tokens[]) or [] if absent/empty/malformed.
+func _combat_token_list(combat: Dictionary) -> Array:
+	var toks: Variant = combat.get("tokens", [])
+	return toks if typeof(toks) == TYPE_ARRAY else []
+
+
+## #1060 — screen position for a combat token: its named zone's anchor (the derived,
+## projection-correct placement). Falls back to the foreground when the zone is unknown
+## this tick (e.g. a combatant in a zone the profile/atlas didn't declare), so a token
+## is never lost off-stage.
+func _combat_token_pos(token: Dictionary) -> Vector2:
+	var zone := String(token.get("zone", ""))
+	if zone != "" and _zone_screen.has(zone):
+		return _zone_screen[zone]
+	return _foreground_pos()
+
+
+## #1060 — apply the renderer-owned TEAM tint to a token's sprite (idempotent). Modulate
+## is pure presentation; it touches no game state. Cached so a re-tint is a no-op.
+func _apply_team_tint(tok: CharacterToken, actor_id: String, team: String) -> void:
+	var tint := _team_tint(team)
+	if _token_team_tint.get(actor_id, null) == tint:
+		return
+	tok.set_team_tint(tint)
+	_token_team_tint[actor_id] = tint
+
+
+## #1060 — map a team string to its modulate Color. foe → hostile red; ally → neutral;
+## anything else → a faint cool wash so unknown teams still read as "not an ally".
+func _team_tint(team: String) -> Color:
+	match team.to_lower():
+		"foe", "enemy", "monster", "hostile":
+			return TEAM_TINT_FOE
+		"ally", "pc", "companion", "friendly":
+			return TEAM_TINT_ALLY
+		_:
+			return TEAM_TINT_NEUTRAL
 
 
 ## #1055 — drive ONE token to its new screen position with renderer-derived facing.
@@ -580,7 +697,12 @@ func _resolve_character_sheet(actor_id: String) -> Dictionary:
 		var resolved := _load_sheet_dir(dir)
 		if not resolved.is_empty():
 			return resolved
-	return {}
+	# #1060 — FALLBACK-SAFE default: a combatant without its OWN committed asset dir
+	# (every foe/NPC today) renders with the shared committed placeholder. The team
+	# tint (_apply_team_tint) is what distinguishes it visually. Without this, foes
+	# would silently fail to spawn (_spawn_token returns null), losing the roster.
+	var default_dir: String = CHAR_ASSET_ROOT + DEFAULT_CHAR_SLUG + "/"
+	return _load_sheet_dir(default_dir)
 
 
 ## Ordered, de-duplicated slug candidates for an actor's committed asset dir.


### PR DESCRIPTION
## #1060 — render combat/zone tokens in the Godot iso view

Today `WorldView._reconcile_actors` spawns a `CharacterToken` only for `character.party[0]`. In combat, the iso view now renders a token for **every combatant** (party + foes/NPCs), each at its **named zone**, visually distinguished by **team**. Zone-based — NOT gated on the #461 grid.

### What changed (per file)
- **`godot/scenes/WorldView.gd`** — `_reconcile_actors(character, combat, in_combat)` now branches:
  - **Combat** (`combat.active` + non-empty `combat.tokens[]`): spawn/reconcile one token per combat token, keyed by `engine_actor_id` (the token `id`), placed at `zone_screen_pos(token.zone)` (foreground fallback if the zone is unknown this tick), with a renderer-owned **team tint**. The combat `x/y` are ignored (`positionAuthority:"derived"`) — placement is re-derived from the engine's named zone.
  - **Exploration** (combat inactive/empty): the original `party[0]` path, **exactly today's behavior**.
  - Reconciles cleanly by id (build once, reposition/re-tint thereafter, free departed combatants — no leaks); also clears the new team-tint cache + served-atlas scope map on free.
  - `_resolve_character_sheet` gains a **fallback** to the shared committed placeholder (`aubree`) so foes/NPCs — which have no per-actor committed sheet and no served atlas — still spawn. The team tint is what reads them as enemies. New accessors: `token_count()`, `team_tint_for(id)`.
- **`godot/scenes/CharacterToken.gd`** — `set_team_tint(Color)` modulates the sprite (pure presentation, owns no game state). Re-applied after `set_manifest` so a served-atlas swap (#1063) keeps the tint. `team_tint()` accessor for validation.
- **`godot/fixtures/combat-surface-active.json`** *(new)* — an **ACTIVE** combat surface (2 allies + 3 foes at the named zones `the gate approach` / `the market row` / `the alley mouth`) mirroring `build_combat_surface` → `_combat_tokens` shape (`id`/`name`/`team`/`zone`/`x`/`y`/`positionAuthority:"derived"`/`hp`/`conditions`). `combat-surface.json` is **unchanged** (`active:false` = the exploration default).
- **`.github/workflows/godot.yml`** — new `--combat-tokens` conformance step: loads the active fixture, asserts **N tokens spawned (5), each at its zone anchor, foes tinted + allies neutral**. Uses the existing headless pattern.
- **`godot/scenes/Main.gd`** — `--combat-tokens` mode driving the conformance (mirrors `--smoke-intent` / `--served-finals-smoke`).

### Invariants
- **Engine = sole writer** (untouched). **Facing is renderer-derived only.** Tint is renderer-owned presentation from the engine's `team` string.
- **ADDITIVE + FALLBACK-SAFE.** No combat tokens when combat is inactive (== today). Existing `anims=32` / occlusion / served-finals / frozen-vocab conformance untouched.

### Validation — Godot **4.6.3** local (== CI `GODOT_VERSION`)
- `--import` parse/compile: **clean**
- **combat-tokens: `RESULT ok=true count=5/5 all_zoned=true team_tinted=true (foes=true allies=true)`**
- Exploration default (combat inactive): **1 token** (`char-aubree` = party[0]) — unchanged
- `--smoke-intent` frozen-vocab: green · `--served-finals-smoke`: green · `--demo-occlusion`: behind+front **pass** (white ally tint preserves the green-body occlusion assertion)

Draft pending the `Godot GT2` CI run on the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Combat tokens now display team-based color tinting to visually distinguish allies from foes during active combat encounters, improving tactical clarity.

* **Tests**
  * Added CI conformance validation step that performs automated rendering verification in headless simulation, ensuring combat token placement and team tinting display correctly for all combatants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->