### PR TITLE
feat(qa): gate check for Guiding Bolt advantage consumption (cs-wave2-val — engine already correct)

### DIFF
--- a/qa/BEHAVIORAL_GATE_TAXONOMY.json
+++ b/qa/BEHAVIORAL_GATE_TAXONOMY.json
@@ -266,6 +266,12 @@
       "retest": "bash qa/run_combat_sprint.sh sprint-retest",
       "hint": "A maneuver / to-hit rider (Battle Master superiority die, War-Domain Guided Strike) was spent via use_resource but the following attack did not fold the bonus in (the +Nd8 damage or +10 to-hit was dropped). Check the use_resource -> attack pending-bonus fold (server.py) + the DM's two-step maneuver usage. WARN only."
     },
+    "guiding_bolt_advantage_consumed": {
+      "category": "DM_ADHERENCE",
+      "likely_code_locations": ["servers/engine/server.py", "servers/engine/combat.py", "skills/dungeon-master/SKILL.md"],
+      "retest": "bash qa/run_combat_sprint.sh sprint-retest",
+      "hint": "A Guiding Bolt advantage rider LANDED on a target (attack -> on_hit_effect_applied: ['Guiding Bolt']) but the next attack against that same target did NOT carry advantage_source='Guiding Bolt' — the SRD 'next attack roll against it has Advantage' rider was dropped. The engine auto-grants + consumes it via combat.attack_modifiers + attack() (#194/#1033), so a miss means the engine attack() path was bypassed (the follow-up was narrated, not resolved through the tool) or the marker expired early. Check that the follow-up strike is resolved via attack() against the marked target within the caster's next-turn window. WARN only."
+    },
     "multiattack_budget_honored": {
       "category": "DM_ADHERENCE",
       "likely_code_locations": ["qa/rubric_angry_dm.md", "qa/play_prompt_combat_sprint.txt", "servers/engine/server.py"],

--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -1213,6 +1213,53 @@ def main() -> int:
             dangling_riders.append(f"{spender or '?'} spent a {kind} ({src}) but no following attack carried it")
     chk("maneuver_rider_consumed", not dangling_riders, "; ".join(dangling_riders), fatal=False)
 
+    # cs-wave2-val: a Guiding Bolt advantage rider, once it LANDS on a target, must auto-grant
+    # advantage to the NEXT attack against that target ("on a hit ... the next attack roll made
+    # against it ... has Advantage", SRD 5.2). The engine materializes the rider on a hit
+    # (attack -> on_hit_effect_applied: ["Guiding Bolt"]) and combat.attack_modifiers auto-grants
+    # + attack() consumes it (advantage_source == "Guiding Bolt"), with NO advantage= flag needed
+    # from the DM (#194/#1033). This catches the residual omission the Angry-DM scorer flagged:
+    # the rider was registered + narrated as landing, but the next attack on the marked target did
+    # not carry the advantage (the engine path was bypassed, or the marker silently dropped). We
+    # find each attack that MATERIALIZED the marker (on_hit_effect_applied), then check the FIRST
+    # subsequent attack against that SAME target (before any GB re-materialization on it) — it must
+    # report advantage_source == "Guiding Bolt". WARN, not FATAL — a single missed rider is a
+    # DM/path-adherence smell that should surface to the scorer, not RED-cap the whole run
+    # (graduate to FATAL after clean sweeps, per the gate-graduation discipline). Scope-guarded: a
+    # run that never lands a Guiding Bolt rider emits NOTHING (additive — byte-identical to today).
+    GB = "Guiding Bolt"
+    gb_unconsumed: list[str] = []
+    for i, (short, inp, obj, is_err, _t) in enumerate(evs):
+        if short != "attack" or is_err or not isinstance(obj, dict):
+            continue
+        if GB not in (obj.get("on_hit_effect_applied") or []):
+            continue  # this attack did not LAND a Guiding Bolt advantage marker — skip
+        marked = obj.get("target")  # the foe now carrying the "next attack has advantage" marker
+        if not marked:
+            continue
+        # The FIRST subsequent attack against this SAME target must carry the GB advantage. The
+        # attack that materialized the marker (this one, a GB spell attack) is NOT the consumer —
+        # the marker benefits the NEXT attack roll against the foe. A later GB re-cast on the same
+        # foe re-arms a fresh marker, so we stop the search there (the new marker owns its own
+        # window) and never charge this incident with a follow-up that belongs to the re-arm.
+        for short2, inp2, obj2, is_err2, _t2 in evs[i + 1:]:
+            if short2 != "attack" or is_err2 or not isinstance(obj2, dict):
+                continue
+            if obj2.get("target") != marked:
+                continue  # an attack on a different target neither consumes nor proves the marker
+            if GB in (obj2.get("on_hit_effect_applied") or []):
+                break  # a re-materialized GB marker on this foe — new window owns the next attack
+            ok = obj2.get("advantage_source") == GB or bool(obj2.get("advantage_consumed"))
+            if not ok:
+                attacker2 = obj2.get("attacker") or "?"
+                gb_unconsumed.append(
+                    f"{attacker2}->{marked}: a Guiding Bolt advantage marker was live on "
+                    f"{marked} but the next attack against it showed "
+                    f"advantage_source={obj2.get('advantage_source')!r} (expected 'Guiding Bolt')"
+                )
+            break  # only the FIRST subsequent attack on the marked foe is the marker's beneficiary
+    chk("guiding_bolt_advantage_consumed", not gb_unconsumed, "; ".join(gb_unconsumed), fatal=False)
+
     # ── #1040 scorer-opt: deterministic 5e-fidelity checks MIGRATED from the slow Angry-DM LLM
     # lens into the fast gate. Each is WARN-first (graduate to FATAL after clean sweeps) and
     # scope-guarded so a run lacking the feature/state emits NOTHING (additive: byte-identical).

--- a/qa/test_assert_behavioral.py
+++ b/qa/test_assert_behavioral.py
@@ -1367,3 +1367,97 @@ def test_signature_feature_passes_when_superiority_dice_used(tmp_path):
     rc, out = _run_gate(tmp_path, [], state)
     assert rc == 0, out
     assert "[PASS] signature_feature_exercised" in out, out
+
+
+# ── guiding_bolt_advantage_consumed: the GB advantage rider must benefit the next attack (cs-wave2-val) ──
+
+def _gb_landing_attack(tool_use_id: str, target: str = "Goblin") -> list:
+    """A Guiding Bolt SPELL attack that HITS and materializes the advantage marker on `target`
+    (engine: on_hit_effect_applied: ['Guiding Bolt']). This attack itself carries NO advantage
+    (none pre-existed) — it ARMS the marker for the NEXT attack."""
+    return [
+        _assistant_tool_use(tool_use_id, "mcp__engine__attack",
+                            {"attacker_id": "cleric", "target_id": "foe"}),
+        _user_tool_result(tool_use_id, json.dumps({
+            "attacker": "Pious", "target": target, "hit": True,
+            "advantage": False, "disadvantage": False,
+            "on_hit_effect_applied": ["Guiding Bolt"],
+        })),
+    ]
+
+
+def test_guiding_bolt_advantage_warns_when_next_attack_drops_it(tmp_path):
+    # GB lands its marker on the Goblin; the NEXT attack against the Goblin shows advantage=False
+    # and NO advantage_source — the SRD "next attack has Advantage" rider was dropped -> WARN
+    # (run stays GREEN; the smell surfaces to the scorer).
+    events = _gb_landing_attack("gb1") + [
+        _assistant_tool_use("a2", "mcp__engine__attack",
+                            {"attacker_id": "fighter", "target_id": "foe"}),
+        _user_tool_result("a2", json.dumps({
+            "attacker": "Brawn", "target": "Goblin", "hit": True,
+            "advantage": False, "disadvantage": False,  # <-- the rider was NOT auto-granted
+        })),
+    ]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out  # WARN never REDs the run
+    assert "[WARN] guiding_bolt_advantage_consumed" in out, out
+    assert "Goblin" in out and "Brawn" in out, out
+
+
+def test_guiding_bolt_advantage_passes_when_next_attack_carries_it(tmp_path):
+    # GB lands its marker; the next attack on the same target reports advantage_source='Guiding Bolt'
+    # + advantage_consumed=True (the engine auto-granted + consumed it) -> PASS.
+    events = _gb_landing_attack("gb2") + [
+        _assistant_tool_use("a3", "mcp__engine__attack",
+                            {"attacker_id": "fighter", "target_id": "foe"}),
+        _user_tool_result("a3", json.dumps({
+            "attacker": "Brawn", "target": "Goblin", "hit": True,
+            "advantage": True, "disadvantage": False,
+            "advantage_source": "Guiding Bolt", "advantage_consumed": True,
+        })),
+    ]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    assert "[PASS] guiding_bolt_advantage_consumed" in out, out
+
+
+def test_guiding_bolt_advantage_silent_when_marker_never_lands(tmp_path):
+    # A run that never materializes a Guiding Bolt marker (a plain attack, no on_hit_effect_applied)
+    # emits the check as a vacuous PASS — it never WARNs on the absence of the feature (scope-guard:
+    # additive / byte-identical to a non-GB run).
+    events = [
+        _assistant_tool_use("p1", "mcp__engine__attack",
+                            {"attacker_id": "fighter", "target_id": "foe"}),
+        _user_tool_result("p1", json.dumps({
+            "attacker": "Brawn", "target": "Goblin", "hit": True,
+            "advantage": False, "disadvantage": False,
+        })),
+    ]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    assert "[WARN] guiding_bolt_advantage_consumed" not in out, out
+    assert "[PASS] guiding_bolt_advantage_consumed" in out, out
+
+
+def test_guiding_bolt_advantage_ignores_attack_on_other_target(tmp_path):
+    # The marker is the Goblin's; an attack on a DIFFERENT (unmarked) target between the landing and
+    # the marked-target follow-up does not falsely consume/charge the marker — only the FIRST attack
+    # on the MARKED foe is judged, and here it correctly carries the advantage -> PASS.
+    events = _gb_landing_attack("gb3") + [
+        _assistant_tool_use("o1", "mcp__engine__attack",
+                            {"attacker_id": "fighter", "target_id": "rat"}),
+        _user_tool_result("o1", json.dumps({
+            "attacker": "Brawn", "target": "Rat", "hit": True,  # a different, unmarked target
+            "advantage": False, "disadvantage": False,
+        })),
+        _assistant_tool_use("o2", "mcp__engine__attack",
+                            {"attacker_id": "fighter", "target_id": "foe"}),
+        _user_tool_result("o2", json.dumps({
+            "attacker": "Brawn", "target": "Goblin", "hit": True,
+            "advantage": True, "disadvantage": False,
+            "advantage_source": "Guiding Bolt", "advantage_consumed": True,
+        })),
+    ]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    assert "[PASS] guiding_bolt_advantage_consumed" in out, out


### PR DESCRIPTION
## TL;DR — the scorer finding did NOT reproduce as an engine bug; the real gap was a missing deterministic gate

The cs-wave2-val Angry-DM scorer flagged **Guiding Bolt's advantage rider as never consumed**. Per the **validate-before-fixing** discipline, I reproduced against the engine FIRST — and the engine **already implements the rider correctly, end-to-end**. The genuine deliverable gap is that the fast behavioral gate had **no deterministic check** for it. This PR adds that check (WARN-first, scope-guarded, additive). **No engine code is touched** (engine = sole writer; it is already correct).

## srd524 validation
`data/srd/srd524/Spell.json` (pk `srd-2024_guiding-bolt`):
> "You hurl a bolt of light toward a creature within range. Make a ranged spell attack against the target. On a hit, it takes 4d6 Radiant damage, **and the next attack roll made against it before the end of your next turn has Advantage.**"

The engine wording, window ("before the end of your next turn"), and one-attack consumption all match SRD 5.2.

## Engine reproduction — the feature already works (10/10 GB tests green on origin/main)
`servers/engine/tests/test_effect_durations.py` already covers the full lifecycle, all passing on `origin/main` (SHA `2e9bd64`):
- `test_guiding_bolt_marker_auto_grants_advantage_to_next_attack_and_is_consumed` — **(a)** next attack on the marked target auto-carries `advantage=True` + `advantage_source='Guiding Bolt'` + `advantage_consumed=True`, with NO `advantage=` flag from the DM.
- `test_guiding_bolt_marker_expires_at_end_of_casters_next_turn_if_unused` — **(b)** the leak-guard: the rider expires at the end of the caster's next turn if unused.
- plus cross-round survival, caster-death orphan sweep, not-consumed-for-other-target, miss-discards-rider.

The mechanism (no change, documented for the reviewer):
- `cast_spell` records a `PendingOnHitRider` on the **caster** (defers, doesn't write to the target at cast time) — `server.py` ~7408.
- the caster's spell `attack()` on a HIT materializes an `ActiveEffect(grants_advantage=True, expires_end_of_turn_of=caster)` on the target — `server.py` ~5751-5790.
- `combat.attack_modifiers` auto-grants advantage when the target carries a `grants_advantage` rider — `combat.py` ~129-133; `attack()` captures (`adv_marker`, ~5379) and CONSUMES it (~5800-5805), surfacing `advantage_source` + `advantage_consumed`.
- turn-anchored leak-guard (`expires_end_of_turn_of`) is decremented only at the caster's turn-end + swept if the caster dies — `server.py` ~4805-4837 (#1033).

**Conclusion:** the scorer's class of finding is a *path-adherence omission* (the follow-up strike narrated, not resolved through the engine `attack()` against the marked target), not an engine defect.

## What this PR adds (the real gap)
1. **`qa/assert_behavioral.py`** — new deterministic check `guiding_bolt_advantage_consumed`: if an attack materialized a GB marker (`on_hit_effect_applied: ['Guiding Bolt']`), the FIRST subsequent attack against that same target must report `advantage_source='Guiding Bolt'` (or `advantage_consumed`); else WARN. **WARN-first, never FATAL**; scope-guarded (a run that never lands GB emits nothing — byte-identical to today). Stops at a GB re-cast on the same foe (the re-arm owns its own window) and ignores attacks on other targets. Mirrors the existing `maneuver_rider_consumed` (~1214).
2. **`qa/BEHAVIORAL_GATE_TAXONOMY.json`** — registers the new check (`DM_ADHERENCE`) so the `test_root_cause_analyzer` drift-guard stays green (this is how main went red before — every `chk()` name must be in the taxonomy).
3. **`qa/test_assert_behavioral.py`** — 4 focused tests: trips on a dropped rider (WARN, run stays GREEN), passes when honored, silent when no GB marker ever lands, and ignores an interleaved attack on an unmarked target.

## Validation
```
uv run --directory servers/engine python -m pytest tests/test_combat.py ../../qa/test_assert_behavioral.py ../../qa/test_root_cause_analyzer.py -q -p no:xdist
=> 260 passed
```
Plus `tests/test_effect_durations.py` (GB lifecycle) 10/10 green and the two taxonomy drift-guards green. `qa/scores.db` + `qa/scores_ledger.md` test side-effects restored before commit.

## Invariants
- ADDITIVE / WARN-first: no new FATAL gate; empty == today (a run with no GB rider is byte-identical).
- Engine untouched (sole writer; already correct).
- The gate reads only tool-return values from the transcript (`on_hit_effect_applied`, `advantage_source`, `advantage_consumed`) — never fiction.

## Open risks
- The gate keys the marked target by **name** (the attack result surfaces `attacker`/`target` as names, matching the existing `attacks` parsing in the gate). Two distinct combatants sharing a display name in one run could mis-attribute the follow-up — low risk; consistent with the file's existing name-based matching.
- WARN-only by design; graduate to FATAL only after clean sweeps confirm zero false positives on real transcripts (per the gate-graduation discipline).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation checks for Guiding Bolt's advantage-rider mechanic to ensure proper consumption on follow-up attacks.
  * Expanded test coverage for advantage-rider behavior, including targeting isolation and edge cases.

* **Chores**
  * Updated QA infrastructure with new behavioral gate taxonomy entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->