### PR TITLE
feat(qa): qa/closeout.py — emit the standardized closeout from the scores ledger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
             ../../qa/test_release_readiness_scope.py \
             ../../qa/test_scores_db_comparability.py \
             ../../qa/test_scores_db.py \
+            ../../qa/test_closeout.py \
             ../../qa/test_release_gate_static.py \
             ../../qa/test_ui_playtest_score_image_outcomes.py \
             ../../qa/test_claude_auth_isolation.py \

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -1,7 +1,7 @@
 # WorldOS QA Scoring System — standardized reference
 
 > Source of truth for HOW we measure a playtest. Current as of 2026-06-19 (post-24h reorient).
-> The running results ledger is `qa/scores_db.py` (SQLite) → `qa/scores_ledger.md` (`add_run()` / `--render`); `qa/SCORECARD.md` is LEGACY narrative.
+> The running results ledger is `qa/scores_db.py` (SQLite) → `qa/scores_ledger.md` (`add_run()` / `--render`); `qa/SCORECARD.md` is LEGACY narrative. Emit the standardized closeout block for a scored run with `python3 qa/closeout.py <run-id>` (ruler-fenced Δ-vs-last-comparable, flags non-opus DM).
 > For the current app/native handoff tools and RRI routing, start with `qa/QA_TOOLS.md` and
 > `WorldOS-GUI-RUNBOOK.md`; this file describes the story/mechanical scoring model.
 

--- a/qa/closeout.py
+++ b/qa/closeout.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Emit the WorldOS standardized closeout block from the scores ledger.
+
+WHY THIS EXISTS
+---------------
+After every scored run/sweep the owner wants a standardized closeout block (RUN / MODEL /
+UNIVERSE / RULER / SCORES + Δ-vs-last-comparable / COVERAGE / VERDICT / CAVEATS). It used to
+be assembled by hand — inconsistent format, and the "Δ vs last comparable" was eyeballed (so
+the wrong prior run, or a cross-ruler / cross-surface comparison, was easy to cite). This tool
+reads the curated ledger (``qa/scores.db`` via :mod:`scores_db`) and prints that exact block for
+a given run-id, with the Δ computed against the most-recent PRIOR run sharing the SAME
+comparability fence (surface + dm_model + scoring_config_version + lens_config_version) — the
+ruler-fence, so a number is NEVER compared across a rubric/gate change or a different surface.
+
+It is a PURE READER over the ledger (never writes the db). It reuses :func:`scores_db.fetch_rows`
+and the canonical :data:`scores_db.COLUMNS` mapping — no hand-rolled SQL.
+
+USAGE
+-----
+    python3 qa/closeout.py <run-id>            # print the closeout block for that run
+    python3 qa/closeout.py --db /tmp/x.db <id> # read from an alternate ledger
+    python3 qa/closeout.py --list              # list recent run-ids and exit
+    python3 qa/closeout.py --help
+
+The OPUS-DM default is load-bearing (sonnet under-drives authored campaigns): a non-opus DM run
+is flagged with ``⚠ NON-OPUS DM`` on the MODEL line so a non-default measurement is never cited
+as the production signal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any, Optional
+
+# Reuse the canonical ledger module (connection/row helpers + the column contract). Import it the
+# same tolerant way the rest of qa/ does (works whether invoked from repo root or as a package).
+QA_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(QA_DIR))
+import scores_db  # noqa: E402
+
+# Quality bar (the owner's standing closeout bar — story >= 4.3, mech >= 4.5).
+STORY_BAR = 4.3
+MECH_BAR = 4.5
+
+# The ruler-fence: the axes a number must share to be DIRECTLY comparable. This is intentionally
+# STRICTER than scores_db's canonical-baseline key (which keys on methodology + lens) — the
+# closeout Δ must never cross a SURFACE (engine-duo vs GUI), a DM MODEL (opus vs sonnet under-drive),
+# OR a RULER (full scoring_config_version AND lens_config_version), since any of those moves the
+# number with no change in play quality. methodology is deliberately NOT fenced here (the spec asks
+# only for surface + dm_model + ruler) so an 8-beat duo and a 24-beat duo on the same surface/model/
+# ruler still compare — the methodology shows in the run rows for the reader to judge.
+COMPARE_FENCE: tuple[str, ...] = (
+    "surface", "dm_model", "scoring_config_version", "lens_config_version",
+)
+
+
+# ---------------------------------------------------------------------------
+# small formatting helpers
+# ---------------------------------------------------------------------------
+def _s(v: Any, *, missing: str = "?") -> str:
+    """Render a scalar for the block; None/empty -> ``missing`` (the spec's graceful '?')."""
+    if v is None:
+        return missing
+    if isinstance(v, float):
+        # scores read best as one decimal (e.g. 4.2, 3.0).
+        return f"{v:.1f}"
+    s = str(v).strip()
+    return s if s else missing
+
+
+def _num(v: Any) -> Optional[float]:
+    """Coerce a ledger value to float, or None if absent / non-numeric."""
+    if v is None:
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _delta(cur: Any, prev: Any) -> str:
+    """Signed Δ string (``+0.3`` / ``-0.2`` / ``+0.0``), or ``?`` if either side is missing."""
+    a, b = _num(cur), _num(prev)
+    if a is None or b is None:
+        return "?"
+    return f"{a - b:+.1f}"
+
+
+def _is_nonopus(dm_model: Any) -> bool:
+    """True when the DM model is set AND is not opus (the under-drive flag).
+
+    A NULL/blank dm_model is NOT flagged — we only warn when we positively know it's non-opus
+    (an unstamped row is 'unknown', not 'non-opus'; flagging it would cry wolf).
+    """
+    if dm_model is None:
+        return False
+    return str(dm_model).strip().lower() != "opus"
+
+
+# ---------------------------------------------------------------------------
+# ledger lookups (pure readers over scores_db.fetch_rows)
+# ---------------------------------------------------------------------------
+def find_run(rows: list[dict], run_id: str) -> Optional[dict]:
+    for r in rows:
+        if r.get("run_id") == run_id:
+            return r
+    return None
+
+
+def last_comparable(rows: list[dict], run: dict) -> Optional[dict]:
+    """The most-recent PRIOR run sharing the run's ruler-fence (surface+dm_model+both ruler hashes).
+
+    ``rows`` is scores_db.fetch_rows order (newest-first). 'Prior' is by the same ordering: among
+    rows that match the fence and are not the run itself, the FIRST one that appears AFTER the run
+    in newest-first order (i.e. older). Fence values are matched exactly, including None==None, so a
+    run with an unstamped ruler only compares to other unstamped-same-surface/model runs.
+    """
+    key = tuple(run.get(c) for c in COMPARE_FENCE)
+    seen_self = False
+    for r in rows:
+        if r.get("run_id") == run.get("run_id"):
+            seen_self = True
+            continue
+        if not seen_self:
+            continue  # newer than the run — not a PRIOR run
+        if tuple(r.get(c) for c in COMPARE_FENCE) == key:
+            return r
+    return None
+
+
+# ---------------------------------------------------------------------------
+# coverage derivation (from whatever coverage columns exist)
+# ---------------------------------------------------------------------------
+# The ledger has no per-flag boolean columns; the human roll-up lives in `structural_coverage`
+# (free text with ✓ / · markers and tokens like "recruit", "camp", "combat", "quest-resolved",
+# "betrayal", "acts n/3") and `acts_reached` (int). We parse the roll-up for the closeout COVERAGE
+# line and prefer the explicit acts_reached int for the acts count.
+_COVERAGE_TOKENS = ("recruit", "travel", "combat", "quest-resolved", "betrayal")
+
+
+def _coverage_line(run: dict) -> str:
+    """Build the COVERAGE line from structural_coverage + acts_reached (graceful when absent)."""
+    sc = run.get("structural_coverage")
+    acts = run.get("acts_reached")
+    text = (sc or "").lower()
+    parts: list[str] = []
+
+    for tok in _COVERAGE_TOKENS:
+        if not sc:
+            mark = "?"
+        elif tok in text:
+            # token present: a '·' immediately after the token means not-done; otherwise ✓.
+            # This mirrors the story_readout '<tok> ✓/·' stamp convention.
+            idx = text.find(tok)
+            after = text[idx + len(tok): idx + len(tok) + 3]
+            mark = "·" if "·" in after else "✓"
+        else:
+            mark = "·"
+        parts.append(f"{tok} {mark}")
+
+    # acts: prefer the explicit int; fall back to an "acts n/3" token in the roll-up; else ?
+    if acts is not None:
+        acts_str = f"acts {int(acts)}/3"
+    elif sc and "acts" in text:
+        idx = text.find("acts")
+        acts_str = sc[idx: idx + 8].strip()
+    else:
+        acts_str = "acts ?/3"
+
+    # spec ordering: recruit · travel · acts n/3 · combat · quest-resolved · betrayal
+    out = [parts[0], parts[1], acts_str] + parts[2:]
+    return " · ".join(out)
+
+
+def _structural_status(run: dict) -> str:
+    """Map the ledger to PASS/WARN/FAIL for the SCORES line's `structural` field.
+
+    The ledger has no dedicated structural-status column; the closest signals are the `pass`
+    verdict (1/0) + whether structure was measured at all (acts_reached / structural_coverage).
+    Convention: pass==1 -> PASS, pass==0 -> FAIL, and if there's NO pass verdict but structure WAS
+    measured we report WARN (structure observed, no hard verdict); fully unmeasured -> '?'.
+    """
+    p = run.get("pass")
+    if p is not None:
+        try:
+            return "PASS" if int(p) else "FAIL"
+        except (TypeError, ValueError):
+            pass
+    if run.get("acts_reached") is not None or run.get("structural_coverage"):
+        return "WARN"
+    return "?"
+
+
+def _beats_from_methodology(methodology: Any) -> str:
+    """Best-effort beats count out of a methodology string (e.g. '3-lens duo 8-beat' -> 8)."""
+    if not methodology:
+        return "?"
+    m = re.search(r"(\d+)\s*-?\s*beat", str(methodology).lower())
+    return m.group(1) if m else "?"
+
+
+def _verdict_line(run: dict) -> str:
+    story = _num(run.get("story_overall"))
+    mech = _num(run.get("mech_overall"))
+    # pass/fail vs the bar (story >= 4.3 AND mech >= 4.5). If either is unmeasured we can't claim a
+    # clean pass — report 'inconclusive' rather than a false verdict.
+    if story is None or mech is None:
+        verdict, read = "inconclusive", "story or mech unmeasured — cannot judge vs the bar"
+    elif story >= STORY_BAR and mech >= MECH_BAR:
+        verdict = "pass"
+        read = f"story {story:.1f}≥{STORY_BAR} and mech {mech:.1f}≥{MECH_BAR}"
+    else:
+        verdict = "fail"
+        misses = []
+        if story < STORY_BAR:
+            misses.append(f"story {story:.1f}<{STORY_BAR}")
+        if mech < MECH_BAR:
+            misses.append(f"mech {mech:.1f}<{MECH_BAR}")
+        read = " and ".join(misses)
+    return f"VERDICT: {verdict} vs bar story≥{STORY_BAR} mech≥{MECH_BAR} — {read}"
+
+
+# ---------------------------------------------------------------------------
+# the block
+# ---------------------------------------------------------------------------
+def render_block(run: dict, prior: Optional[dict]) -> str:
+    rid = _s(run.get("run_id"))
+    date = _s(run.get("build_date") or run.get("ts"))
+    surface = _s(run.get("surface"))
+
+    dm = _s(run.get("dm_model"))
+    actor = _s(run.get("actor_model"))
+    scorer = _s(run.get("scorer_model"))
+    model_line = f"MODEL: DM={dm} · actor={actor} · scorer={scorer}"
+    if _is_nonopus(run.get("dm_model")):
+        model_line += "     ⚠ NON-OPUS DM"
+
+    # UNIVERSE: the ledger has no explicit world/campaign column; methodology is the closest human
+    # description of what was played (e.g. "authored-spine-fulldepth"). beats from that text.
+    universe = _s(run.get("methodology"))
+    beats = _beats_from_methodology(run.get("methodology"))
+
+    ruler = f"{_s(run.get('scoring_config_version'))}/{_s(run.get('lens_config_version'))}"
+
+    story = _s(run.get("story_overall"))
+    mech = _s(run.get("mech_overall"))
+    angry = _s(run.get("angrydm_overall"))
+    behav = _s(run.get("behavioral"))
+    structural = _structural_status(run)
+    sat = _s(run.get("cross_persona_sat"))
+
+    if prior is not None:
+        d_story = _delta(run.get("story_overall"), prior.get("story_overall"))
+        d_mech = _delta(run.get("mech_overall"), prior.get("mech_overall"))
+        delta_line = (
+            f"  Δ vs last comparable (same surface+dm_model+ruler) "
+            f"{_s(prior.get('run_id'))}: story {d_story} mech {d_mech}"
+        )
+    else:
+        delta_line = "  Δ vs last comparable: no comparable prior run"
+
+    lines = [
+        f"RUN: {rid} | {date} | {surface}",
+        model_line,
+        f"UNIVERSE: {universe} · {beats} beats",
+        f"RULER: {ruler}            (compare ONLY within the same ruler)",
+        (f"SCORES: story {story} · mech {mech} · angrydm {angry} · "
+         f"behavioral {behav} · structural {structural} · sat {sat}"),
+        delta_line,
+        f"COVERAGE: <{_coverage_line(run)}>",
+        _verdict_line(run),
+        f"CAVEATS: {_s(run.get('notes'), missing='—')}",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def build_closeout(run_id: str, db_path: Path | str = scores_db.DB_PATH) -> str:
+    """Return the closeout block for ``run_id``, or raise KeyError if it's absent."""
+    rows = scores_db.fetch_rows(db_path)
+    run = find_run(rows, run_id)
+    if run is None:
+        raise KeyError(run_id)
+    prior = last_comparable(rows, run)
+    return render_block(run, prior)
+
+
+def _recent_ids(db_path: Path | str, n: int = 20) -> list[str]:
+    return [r.get("run_id") for r in scores_db.fetch_rows(db_path)[:n]]
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("run_id", nargs="?", help="the run-id to emit a closeout block for")
+    p.add_argument("--db", default=str(scores_db.DB_PATH), help="path to scores.db")
+    p.add_argument("--list", action="store_true",
+                   help="list recent run-ids (newest first) and exit")
+    args = p.parse_args(argv)
+
+    if args.list:
+        for rid in _recent_ids(args.db):
+            print(rid)
+        return 0
+
+    if not args.run_id:
+        p.print_help()
+        return 2
+
+    try:
+        print(build_closeout(args.run_id, db_path=args.db))
+    except KeyError:
+        recent = _recent_ids(args.db)
+        print(f"error: run-id {args.run_id!r} not found in {args.db}", file=sys.stderr)
+        if recent:
+            print("recent run-ids (newest first):", file=sys.stderr)
+            for rid in recent:
+                print(f"  {rid}", file=sys.stderr)
+        else:
+            print("(the ledger has no runs)", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/test_closeout.py
+++ b/qa/test_closeout.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Tests for qa/closeout.py — the standardized closeout-block emitter.
+
+Pure-stdlib (sqlite3 via scores_db + json); imports neither the engine nor the viewer. EVERY test
+seeds its own TEMP scores.db (``tmp_path``) — the committed ``qa/scores.db`` is NEVER touched. Run:
+
+    uv run --directory servers/engine --group dev python -m pytest ../../qa/test_closeout.py -q -p no:xdist
+or simply:
+    python3 -m pytest qa/test_closeout.py -q
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+QA_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(QA_DIR))
+
+import scores_db  # noqa: E402
+import closeout  # noqa: E402
+
+# A fixed ruler pair for the "comparable" runs, and a DIFFERENT pair for the ruler-fence test.
+RULER_A = ("sc_aaaaaaaaaaaa", "lc_aaaaaaaaaaaa")
+RULER_B = ("sc_bbbbbbbbbbbb", "lc_bbbbbbbbbbbb")
+
+
+def _seed(db):
+    """Seed a temp ledger: two comparable opus engine-duo runs (older=base, newer=current) under
+    RULER_A, plus one different-ruler run (RULER_B) on the same surface+model (the fence must
+    EXCLUDE it), plus one non-opus GUI run (the ⚠ flag test)."""
+    # older comparable (the expected Δ baseline)
+    scores_db.add_run(
+        "duo-base", db_path=db, ts="2026-06-10T08:00:00+00:00", build_date="2026-06-10",
+        surface="engine-duo", dm_model="opus", actor_model="sonnet", scorer_model="claude",
+        methodology="3-lens duo 8-beat", story_overall=4.0, mech_overall=3.5, angrydm_overall=2.5,
+        behavioral="GREEN", acts_reached=2,
+        structural_coverage="recruit ✓ travel ✓ combat ✓ quest-resolved · betrayal ·",
+        scoring_config_version=RULER_A[0], lens_config_version=RULER_A[1],
+        notes="older comparable baseline", **{"pass": 0},
+    )
+    # newer comparable (the run under test) — SAME surface+dm_model+ruler -> compares to duo-base
+    scores_db.add_run(
+        "duo-current", db_path=db, ts="2026-06-17T08:00:00+00:00", build_date="2026-06-17",
+        surface="engine-duo", dm_model="opus", actor_model="sonnet", scorer_model="claude",
+        methodology="3-lens duo 8-beat", story_overall=4.3, mech_overall=3.9, angrydm_overall=2.8,
+        behavioral="GREEN", acts_reached=3,
+        structural_coverage="recruit ✓ travel ✓ combat ✓ quest-resolved ✓ betrayal ·",
+        scoring_config_version=RULER_A[0], lens_config_version=RULER_A[1],
+        notes="run under test", **{"pass": 1},
+    )
+    # a DIFFERENT-ruler run, NEWER than duo-current but on the same surface+model. The fence must
+    # NOT pick this as duo-current's comparable (different ruler), and this run itself has no prior
+    # comparable in the seed.
+    scores_db.add_run(
+        "duo-diff-ruler", db_path=db, ts="2026-06-18T08:00:00+00:00", build_date="2026-06-18",
+        surface="engine-duo", dm_model="opus", actor_model="sonnet", scorer_model="claude",
+        methodology="3-lens duo 8-beat", story_overall=4.9, mech_overall=4.6,
+        behavioral="GREEN", acts_reached=3,
+        scoring_config_version=RULER_B[0], lens_config_version=RULER_B[1],
+        notes="different ruler — must be fenced out", **{"pass": 1},
+    )
+    # a NON-OPUS GUI run (the ⚠ flag).
+    scores_db.add_run(
+        "gui-sonnet", db_path=db, ts="2026-06-16T08:00:00+00:00", build_date="2026-06-16",
+        surface="GUI-headless-proxy", dm_model="sonnet", actor_model="sonnet", scorer_model="claude",
+        methodology="5-persona part-B", story_overall=4.2, mech_overall=3.5,
+        behavioral="GREEN", cross_persona_sat=7.0, rri=6.4, critical_bugs=0,
+        scoring_config_version=RULER_A[0], lens_config_version=RULER_A[1],
+        notes="sonnet GUI sweep", **{"pass": 0},
+    )
+
+
+def test_block_has_core_lines(tmp_path):
+    db = tmp_path / "t.db"
+    _seed(db)
+    block = closeout.build_closeout("duo-current", db_path=db)
+    assert "RUN: duo-current | 2026-06-17 | engine-duo" in block
+    assert "MODEL: DM=opus · actor=sonnet · scorer=claude" in block
+    # opus DM -> NO non-opus flag
+    assert "NON-OPUS DM" not in block
+    assert "RULER: sc_aaaaaaaaaaaa/lc_aaaaaaaaaaaa" in block
+    assert "SCORES: story 4.3 · mech 3.9 · angrydm 2.8 · behavioral GREEN" in block
+    assert "structural PASS" in block  # pass==1 -> PASS
+    assert "UNIVERSE: 3-lens duo 8-beat · 8 beats" in block  # beats parsed from methodology
+
+
+def test_delta_vs_correct_prior(tmp_path):
+    db = tmp_path / "t.db"
+    _seed(db)
+    block = closeout.build_closeout("duo-current", db_path=db)
+    # Δ must be computed vs duo-base (the prior comparable), NOT duo-diff-ruler.
+    assert "duo-base" in block
+    assert "duo-diff-ruler" not in block
+    # story 4.3 - 4.0 = +0.3 ; mech 3.9 - 3.5 = +0.4
+    assert "story +0.3 mech +0.4" in block
+
+
+def test_ruler_fence_excludes_different_ruler(tmp_path):
+    db = tmp_path / "t.db"
+    _seed(db)
+    rows = scores_db.fetch_rows(db)
+    cur = closeout.find_run(rows, "duo-current")
+    prior = closeout.last_comparable(rows, cur)
+    assert prior is not None and prior["run_id"] == "duo-base"
+    # the different-ruler run itself has no comparable prior in the seed (only run under its ruler).
+    diff = closeout.find_run(rows, "duo-diff-ruler")
+    assert closeout.last_comparable(rows, diff) is None
+    diff_block = closeout.build_closeout("duo-diff-ruler", db_path=db)
+    assert "no comparable prior run" in diff_block
+
+
+def test_nonopus_dm_flagged(tmp_path):
+    db = tmp_path / "t.db"
+    _seed(db)
+    block = closeout.build_closeout("gui-sonnet", db_path=db)
+    assert "⚠ NON-OPUS DM" in block
+    assert "DM=sonnet" in block
+
+
+def test_surface_fence_excludes_other_surface(tmp_path):
+    """A run only compares within its OWN surface — the engine-duo runs must not be the GUI run's
+    comparable even though they share dm_model is moot (different surface AND model here)."""
+    db = tmp_path / "t.db"
+    _seed(db)
+    rows = scores_db.fetch_rows(db)
+    gui = closeout.find_run(rows, "gui-sonnet")
+    assert closeout.last_comparable(rows, gui) is None  # no other GUI-sonnet run
+
+
+def test_missing_run_raises_and_cli_errors(tmp_path):
+    db = tmp_path / "t.db"
+    _seed(db)
+    with pytest.raises(KeyError):
+        closeout.build_closeout("nope", db_path=db)
+    # CLI returns non-zero and does not crash.
+    rc = closeout.main(["--db", str(db), "nope"])
+    assert rc == 1
+
+
+def test_cli_list(tmp_path, capsys):
+    db = tmp_path / "t.db"
+    _seed(db)
+    rc = closeout.main(["--db", str(db), "--list"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    for rid in ("duo-current", "duo-base", "duo-diff-ruler", "gui-sonnet"):
+        assert rid in out
+
+
+def test_verdict_pass_when_both_bars_met(tmp_path):
+    db = tmp_path / "t.db"
+    scores_db.add_run(
+        "duo-clean", db_path=db, surface="engine-duo", dm_model="opus",
+        story_overall=4.5, mech_overall=4.6, methodology="duo 12-beat",
+        scoring_config_version=RULER_A[0], lens_config_version=RULER_A[1], **{"pass": 1},
+    )
+    block = closeout.build_closeout("duo-clean", db_path=db)
+    assert "VERDICT: pass vs bar" in block
+
+
+def test_verdict_inconclusive_when_unmeasured(tmp_path):
+    db = tmp_path / "t.db"
+    scores_db.add_run(
+        "duo-nomech", db_path=db, surface="engine-duo", dm_model="opus",
+        story_overall=4.5, methodology="duo 6-beat",
+        scoring_config_version=RULER_A[0], lens_config_version=RULER_A[1],
+    )
+    block = closeout.build_closeout("duo-nomech", db_path=db)
+    assert "VERDICT: inconclusive" in block
+    assert "mech ?" in block  # missing mech renders as ?
+
+
+def test_coverage_line_parses_tokens(tmp_path):
+    db = tmp_path / "t.db"
+    _seed(db)
+    block = closeout.build_closeout("duo-current", db_path=db)
+    # explicit-token roll-up: recruit/travel/combat/quest-resolved ✓, betrayal ·, acts 3/3.
+    cov = [ln for ln in block.splitlines() if ln.startswith("COVERAGE:")][0]
+    assert "recruit ✓" in cov and "quest-resolved ✓" in cov
+    assert "betrayal ·" in cov
+    assert "acts 3/3" in cov
+
+
+def test_committed_db_untouched_by_import(tmp_path):
+    """Guard: closeout is a pure reader — building a block from a temp db must not write the
+    committed qa/scores.db (defends the 'never mutate the committed ledger' rule)."""
+    committed = QA_DIR / "scores.db"
+    before = committed.stat().st_mtime_ns if committed.exists() else None
+    db = tmp_path / "t.db"
+    _seed(db)
+    closeout.build_closeout("duo-current", db_path=db)
+    after = committed.stat().st_mtime_ns if committed.exists() else None
+    assert before == after  # mtime unchanged (or both None)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q", "-p", "no:xdist"]))


### PR DESCRIPTION
## Why
After every scored run/sweep we emit a standardized closeout block (RUN / MODEL / UNIVERSE / RULER / SCORES + Δ-vs-last-comparable / COVERAGE / VERDICT / CAVEATS) — currently by hand. This automates it so the format is consistent and the Δ-vs-last-comparable is **computed, not eyeballed**.

## What
New read-only helper **`qa/closeout.py <run-id>`** that reads the curated ledger (`qa/scores.db` via `scores_db.fetch_rows` — reuses the canonical row helpers, no hand-rolled SQL) and prints the exact block.

- **Ruler-fenced Δ:** computed vs the most-recent **PRIOR** run sharing the SAME fence — `surface + dm_model + scoring_config_version + lens_config_version` — so a number is never compared across a rubric/gate change or a different surface. `no comparable prior run` when none exists.
- **Non-opus DM flag:** `⚠ NON-OPUS DM` on the MODEL line (sonnet under-drives authored campaigns; never cite a non-default measurement as the production signal).
- **Graceful column mapping:** missing fields render `?` (or `—` for caveats). `structural` PASS/WARN/FAIL is derived from `pass` / structure-measured signals (no dedicated column exists); COVERAGE is parsed from the `structural_coverage` roll-up + `acts_reached`; CAVEATS = `notes`; UNIVERSE/beats from `methodology`.
- **Pure reader** — never writes the db. Absent run-id → clear stderr error + the recent run-ids; `--list` and `--help`.

## Column mapping (block field → ledger column)
| Block field | Ledger column(s) |
|---|---|
| RUN id / date / surface | `run_id` / `build_date`→`ts` / `surface` |
| MODEL DM·actor·scorer | `dm_model` / `actor_model` / `scorer_model` |
| UNIVERSE · beats | `methodology` (beats regex-parsed from it) |
| RULER | `scoring_config_version`/`lens_config_version` |
| SCORES story·mech·angrydm·behavioral·structural·sat | `story_overall`/`mech_overall`/`angrydm_overall`/`behavioral`/(derived from `pass`+structure)/`cross_persona_sat` |
| COVERAGE | `structural_coverage` tokens + `acts_reached` |
| VERDICT | `story_overall`/`mech_overall` vs bar (story≥4.3, mech≥4.5) |
| CAVEATS | `notes` |

## Sample (real ledger row `gs-ledger-deep`)
```
RUN: gs-ledger-deep | 2026-06-17 | engine-duo
MODEL: DM=opus · actor=sonnet · scorer=claude
UNIVERSE: authored-spine-fulldepth · ? beats
RULER: sc_d5011ee20801/lc_ec48e53a4726            (compare ONLY within the same ruler)
SCORES: story 4.8 · mech 3.9 · angrydm 2.6 · behavioral GREEN · structural PASS · sat ?
  Δ vs last comparable (same surface+dm_model+ruler) gs-ember-deep: story +0.0 mech +0.1
COVERAGE: <recruit · · travel · · acts 3/3 · combat · · quest-resolved · · betrayal ·>
VERDICT: fail vs bar story≥4.3 mech≥4.5 — mech 3.9<4.5
CAVEATS: BG golden spine 'The Ledger of Mercy' full-depth proof (24b): ... structural PASS. story 4.8.
```

## Tests
`qa/test_closeout.py` — 11 tests, each seeds its **own temp db** (committed `qa/scores.db` is never touched): core lines, ruler-fence + surface-fence exclusion, Δ-vs-correct-prior, non-opus flag, verdict pass/inconclusive, coverage parse, CLI error/list, and a guard that building a block never mutates the committed db.

```
uv run --directory servers/engine --group dev python -m pytest ../../qa/test_closeout.py -q -p no:xdist
# 11 passed in 0.06s
```

Wired into the CI `qa-release-gate-tests` job so it can't rot. One-line pointer added to `qa/SCORING.md`.

## Scope / invariants
NEW file + test only; the sole edits to existing files are one CI test-list line and one SCORING.md doc line. No engine/gate/scorer changes. Additive, read-only on the ledger.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to generate standardized closeout reports for test runs, including run metadata, scores, coverage analysis, and verdict determination.

* **Tests**
  * Added comprehensive test suite validating closeout report generation, metadata accuracy, and proper handling of edge cases.

* **Chores**
  * Updated CI pipeline to run new test suite.
  * Updated QA documentation with closeout tool usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->