### PR TITLE
feat(engine,#461): grid-mode ranged-in-melee auto-disadvantage (PR-5 increment)

### DIFF
--- a/qa/BEHAVIORAL_GATE_TAXONOMY.json
+++ b/qa/BEHAVIORAL_GATE_TAXONOMY.json
@@ -310,9 +310,9 @@
     },
     "ranged_disadvantage_in_melee": {
       "category": "DM_ADHERENCE",
-      "likely_code_locations": ["qa/rubric_angry_dm.md", "qa/play_dm_duo.txt", "servers/engine/combat.py"],
+      "likely_code_locations": ["qa/rubric_angry_dm.md", "qa/play_dm_duo.txt", "servers/engine/combat.py", "servers/engine/server.py"],
       "retest": "bash qa/run_combat_sprint.sh sprint-retest",
-      "hint": "A ranged shot fired in melee (mutual-melee proxy => adjacency) without disadvantage. Reinforce the ranged-in-melee disadvantage rule in the DM/angry-DM guidance; the proxy can mis-fire on a genuine gap. WARN only."
+      "hint": "A ranged shot fired in melee (mutual-melee proxy => adjacency) without disadvantage. OFF-grid (theater-of-mind) this is a DM-adherence WARN — reinforce the ranged-in-melee disadvantage rule in the DM/angry-DM guidance; the proxy can mis-fire on a genuine gap. ON a grid (#461 PR-5) the engine AUTO-APPLIES the rule in server.py attack() and surfaces attack_roll.ranged_in_melee_disadvantage; the check reads that field so a grid run passes by construction. WARN only."
     }
   }
 }

--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -1137,8 +1137,24 @@ def main() -> int:
     # so the structural proxy is a MUTUAL melee exchange: if `victim` also meleed `shooter`
     # (a clearly-melee attack: slashing/bludgeoning damage), they were adjacent, so the shooter's
     # ranged shot needed disadvantage. WARN — the proxy can mis-fire on a genuine 10-ft gap.
+    #
+    # #461 grid (PR-5): on a GRID the engine HAS positions and AUTO-APPLIES the rule, surfacing
+    # attack_roll.ranged_in_melee_disadvantage=True (and folding disadvantage into the roll). For
+    # those engine-ruled attacks the brittle theater proxy is moot — the engine already decided
+    # authoritatively. We READ the new field: an attack that carries it is definitively clean
+    # (the rule fired), and it does not need the mutual-melee heuristic. (An on-grid ranged shot
+    # with NO field is the engine ruling "no adjacent hostile" — also authoritative, not a miss.)
     attacks = [(i, inp, r) for i, (n, inp, r, err, _) in enumerate(evs)
                if n == "attack" and isinstance(r, dict)]
+
+    def _grid_ranged_ruled(res: dict) -> bool:
+        """True if the engine AUTO-APPLIED the on-grid ranged-in-melee disadvantage to this
+        attack (the surfaced result field). On-grid the engine is authoritative on adjacency,
+        so such an attack is clean by construction — never a proxy false-flag."""
+        ar = res.get("attack_roll") or {}
+        return bool(isinstance(ar, dict) and ar.get("ranged_in_melee_disadvantage"))
+
+    grid_auto_applied = sum(1 for (_i, _inp, r) in attacks if _grid_ranged_ruled(r))
 
     def _melee_damage(inp_dict: dict, res: dict) -> bool:
         """A clearly-MELEE attack: its damage type is slashing/bludgeoning (a sword/club), not
@@ -1149,8 +1165,8 @@ def main() -> int:
 
     ranged_flags = []
     for ai, (idx_a, inp_a, ra) in enumerate(attacks):
-        if ra.get("disadvantage"):
-            continue  # already applied → clean
+        if ra.get("disadvantage") or _grid_ranged_ruled(ra):
+            continue  # disadvantage already applied (incl. on-grid auto-apply) → clean
         shooter, victim = ra.get("attacker"), ra.get("target")
         if not shooter or not victim:
             continue
@@ -1168,7 +1184,14 @@ def main() -> int:
         if mutual_melee and shooter_also_meleed and not _melee_damage(inp_a, ra):
             ranged_flags.append(f"{shooter}->{victim} ranged w/o disadvantage (mutual melee exchange ⇒ adjacent)")
     if attacks:
-        chk("ranged_disadvantage_in_melee", not ranged_flags, "; ".join(ranged_flags), fatal=False)
+        # On a grid run the engine auto-applies the rule (grid_auto_applied attacks above);
+        # the theater proxy only ever fires off-grid. Either way the check PASSES when no
+        # un-disadvantaged adjacent shot remains; the detail notes the grid auto-applies so a
+        # green grid run is legible (not a silent pass).
+        detail = "; ".join(ranged_flags)
+        if not ranged_flags and grid_auto_applied:
+            detail = f"grid: engine auto-applied ranged-in-melee disadvantage on {grid_auto_applied} shot(s)"
+        chk("ranged_disadvantage_in_melee", not ranged_flags, detail, fatal=False)
 
     # cs-1040val (#1/#2): a class-feature rider spent via use_resource MUST be consumed by a
     # following attack — a Battle Master superiority die appears in that attack's DAMAGE, and a

--- a/qa/test_assert_behavioral.py
+++ b/qa/test_assert_behavioral.py
@@ -416,6 +416,64 @@ def test_a2_parry_monster_hit_no_reaction_warns(tmp_path):
     assert "parry_reaction_considered" in out
 
 
+# ── ranged_disadvantage_in_melee: grid auto-apply vs theater proxy (WARN) ──────
+# #461 PR-5: on a GRID the engine auto-applies the rule and surfaces
+# attack_roll.ranged_in_melee_disadvantage; the gate reads that field so a grid run
+# passes by construction. Off-grid the mutual-melee proxy still WARNs.
+
+
+def _melee_back(uid, attacker, target):
+    """A clearly-MELEE attack event (slashing damage) — feeds the mutual-melee proxy."""
+    return [
+        _assistant_tool_use(uid, "mcp__engine__attack", {"attacker_id": attacker, "target_id": target}),
+        _user_tool_result(uid, json.dumps({"attacker": attacker, "target": target, "hit": True,
+                                           "damage": {"type": "slashing", "total": 6}})),
+    ]
+
+
+def test_ranged_in_melee_theater_proxy_warns_without_disadvantage(tmp_path):
+    """OFF-grid control: a both-meleed-and-ranged mutual exchange with NO disadvantage on the
+    ranged shot trips the theater proxy → WARN (the pre-existing behaviour, unchanged)."""
+    events = []
+    # Shooter rangedly attacks Foe with no disadvantage, AND both melee each other.
+    events += [
+        _assistant_tool_use("r1", "mcp__engine__attack",
+                            {"attacker_id": "Shooter", "target_id": "Foe", "is_ranged": True}),
+        _user_tool_result("r1", json.dumps({"attacker": "Shooter", "target": "Foe", "hit": True,
+                                            "disadvantage": False,
+                                            "damage": {"type": "piercing", "total": 5}})),
+    ]
+    events += _melee_back("m1", "Shooter", "Foe")   # shooter also meleed the foe
+    events += _melee_back("m2", "Foe", "Shooter")   # foe meleed back ⇒ adjacency proxy
+    state = {"leveling_mode": "milestone"}
+    rc, out = _run_gate(tmp_path, events, state)
+    assert rc == 0, out  # WARN, not RED
+    assert "[WARN] ranged_disadvantage_in_melee" in out
+
+
+def test_ranged_in_melee_grid_auto_applied_passes(tmp_path):
+    """ON-grid: the SAME mutual-melee pattern, but the ranged shot carries the engine's
+    auto-applied field (attack_roll.ranged_in_melee_disadvantage=True) → the gate reads it
+    and PASSES (no WARN), because the engine ruled adjacency authoritatively."""
+    events = []
+    events += [
+        _assistant_tool_use("r1", "mcp__engine__attack",
+                            {"attacker_id": "Shooter", "target_id": "Foe", "is_ranged": True}),
+        _user_tool_result("r1", json.dumps({"attacker": "Shooter", "target": "Foe", "hit": True,
+                                            "disadvantage": True,
+                                            "attack_roll": {"total": 9, "natural": 9,
+                                                            "ranged_in_melee_disadvantage": True},
+                                            "damage": {"type": "piercing", "total": 5}})),
+    ]
+    events += _melee_back("m1", "Shooter", "Foe")
+    events += _melee_back("m2", "Foe", "Shooter")
+    state = {"leveling_mode": "milestone"}
+    rc, out = _run_gate(tmp_path, events, state)
+    assert rc == 0, out
+    assert "[WARN] ranged_disadvantage_in_melee" not in out
+    assert "[PASS] ranged_disadvantage_in_melee" in out
+
+
 # ── regression: the existing 17 gates still load / a clean run stays GREEN ──────
 
 def test_clean_minimal_run_is_green(tmp_path):

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -5424,6 +5424,40 @@ def attack(
         cadv, cdis = combat.attack_modifiers(attacker, target, is_ranged=is_ranged)
         adv = advantage or cadv
         dis = disadvantage or cdis
+        # #461 grid (PR-5 increment): RANGED-IN-MELEE auto-disadvantage. SRD 5.24 "Ranged
+        # Attacks in Close Combat": Disadvantage on a ranged attack roll if you are within
+        # 5 ft of an enemy who can SEE you and is NOT Incapacitated. Off-grid (theater-of-
+        # mind) the engine has no positions, so this stays a DM-surfaced NUDGE below; ON a
+        # grid the engine HAS positions and AUTO-APPLIES it — folded into `dis` here so it
+        # actually bends the roll, and disadvantage doesn't stack (one dis flag). Only when
+        # the attacker is placed; an unplaced shooter can't be reasoned about positionally.
+        ranged_in_melee_grid = False
+        if is_ranged and c.combat.grid_enabled:
+            acb = next((cb for cb in c.combat.order if cb.character_id == attacker_id), None)
+            shooter_cell = _cell(acb) if acb is not None else None
+            if shooter_cell is not None:
+                ally_kinds = {"player", "companion"}
+                shooter_ally = attacker.kind in ally_kinds
+                for foe_cb in c.combat.order:
+                    if foe_cb.character_id == attacker_id:
+                        continue
+                    foe = c.characters.get(foe_cb.character_id)
+                    if foe is None or foe.dead or foe.current_hp <= 0:
+                        continue
+                    if (foe.kind in ally_kinds) == shooter_ally:
+                        continue  # same side — an adjacent ally is not a threat
+                    foe_cell = _cell(foe_cb)
+                    if foe_cell is None:
+                        continue  # an unplaced foe threatens no cell
+                    if not combat_grid.in_melee_reach(shooter_cell, foe_cell):
+                        continue  # not within 5 ft (1 cell)
+                    if combat.is_incapacitated(foe):
+                        continue  # SRD: the enemy must NOT be Incapacitated
+                    if not _can_see(foe):
+                        continue  # SRD: the enemy must be able to SEE you
+                    ranged_in_melee_grid = True
+                    break
+        dis = dis or ranged_in_melee_grid
         # crit_min threads the attacker's expanded crit range (Champion Improved/Superior
         # Critical → 19/18; everyone else 20 = today's behavior) so a Champion's nat-19
         # actually flags atk.crit and crit_source() resolves "expanded_crit_range".
@@ -5493,6 +5527,11 @@ def attack(
             "target_base_ac": target.armor_class,
             "damage": None,
         }
+        if ranged_in_melee_grid:
+            # #461 grid (PR-5): surface that the engine AUTO-APPLIED the SRD ranged-in-melee
+            # disadvantage (folded into `dis` above), so the DM narrates it and the behavioral
+            # gate / scorer see the rule actually fired on-grid (not announced-then-dropped).
+            result["attack_roll"]["ranged_in_melee_disadvantage"] = True
         if rider_rolls:
             # The engine-rolled rider components (SYN-06), itemized so the DM narrates
             # "the blessing guides the blade (+3)" — and sees the buff actually counted.
@@ -5823,7 +5862,15 @@ def attack(
             # exact pattern that needs disadvantage if a foe is within 5 ft. Conservative: a
             # nudge to re-issue, never a block, honoring theater-of-mind (the foe MAY be 10 ft
             # away). Only when the attacker is a combatant and didn't already flag adv/dis.
-            if is_ranged and not adv and not dis and attacker_cb is not None:
+            # #461 grid (PR-5): on a grid the engine ALREADY ruled authoritatively above
+            # (auto-applied dis if adjacent, none if not) for a PLACED shooter — so the
+            # guess-nudge would be noise/contradiction; suppress it there. The nudge still
+            # fires for an UNPLACED on-grid shooter (no cell ⇒ no positional ruling) and for
+            # every off-grid (theater) attack exactly as before.
+            attacker_on_grid_placed = bool(
+                c.combat.grid_enabled and attacker_cb is not None and _cell(attacker_cb) is not None
+            )
+            if is_ranged and not adv and not dis and attacker_cb is not None and not attacker_on_grid_placed:
                 opp = "monster" if attacker.kind in ("player", "companion") else "player"
                 foes_live = any(
                     (h := c.characters.get(cb.character_id)) is not None

--- a/servers/engine/tests/test_grid.py
+++ b/servers/engine/tests/test_grid.py
@@ -324,4 +324,155 @@ def test_measure_math_is_pure_no_state_dir():
     assert combat_grid.in_melee_reach((0, 0), (2, 0)) is False
 
 
+# ── (9) GRID ranged-in-melee auto-disadvantage (PR-5 increment, SRD 5.24) ─────
+#   SRD "Ranged Attacks in Close Combat": Disadvantage on a ranged attack roll if
+#   within 5 ft of an enemy who can SEE you and is NOT Incapacitated. On the GRID the
+#   engine HAS positions, so it AUTO-APPLIES the rule (theater-of-mind keeps the nudge).
+
+
+def _make_current(cid, who, other):
+    """Ensure `who` is the current combatant (so attack()'s turn-ownership gate passes)."""
+    if server.get_state(cid)["current_turn"] != who:
+        server.next_turn(cid)
+    return server.get_state(cid)["current_turn"]
+
+
+def test_grid_ranged_in_melee_auto_disadvantage(fight):
+    """On-grid: a RANGED attack while a hostile is within 5 ft (1 cell) → the engine
+    auto-applies disadvantage and surfaces ranged_in_melee_disadvantage=True."""
+    cid, hero, gob = fight
+    cur = _make_current(cid, hero, gob)
+    shooter, foe = (hero, gob) if cur == hero else (gob, hero)
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, shooter, 0, 0)
+    server.place_combatant_at_coords(cid, foe, 1, 0)  # adjacent (5 ft)
+    res = server.attack(cid, attacker_id=shooter, target_id=foe,
+                        attack_bonus=5, damage_dice="1d6", is_ranged=True)
+    assert res["disadvantage"] is True
+    assert res["attack_roll"].get("ranged_in_melee_disadvantage") is True
+
+
+def test_grid_ranged_not_in_melee_no_disadvantage(fight):
+    """On-grid: a RANGED attack with the nearest hostile 10 ft away (2 cells) → no
+    auto-disadvantage, and the new field is absent (today's behaviour preserved)."""
+    cid, hero, gob = fight
+    cur = _make_current(cid, hero, gob)
+    shooter, foe = (hero, gob) if cur == hero else (gob, hero)
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, shooter, 0, 0)
+    server.place_combatant_at_coords(cid, foe, 2, 0)  # 10 ft — out of melee reach
+    res = server.attack(cid, attacker_id=shooter, target_id=foe,
+                        attack_bonus=5, damage_dice="1d6", is_ranged=True)
+    assert res["disadvantage"] is False
+    assert "ranged_in_melee_disadvantage" not in res["attack_roll"]
+
+
+def test_grid_ranged_in_melee_incapacitated_foe_no_disadvantage(fight):
+    """On-grid: an adjacent foe that is INCAPACITATED (unconscious) does not impose the
+    penalty (SRD: the enemy must NOT have the Incapacitated condition)."""
+    cid, hero, gob = fight
+    cur = _make_current(cid, hero, gob)
+    shooter, foe = (hero, gob) if cur == hero else (gob, hero)
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, shooter, 0, 0)
+    server.place_combatant_at_coords(cid, foe, 1, 0)
+    c = store.load_campaign(cid)
+    c.characters[foe].conditions.append(Condition.UNCONSCIOUS)
+    store.save_campaign(c)
+    res = server.attack(cid, attacker_id=shooter, target_id=foe,
+                        attack_bonus=5, damage_dice="1d6", is_ranged=True)
+    assert res["disadvantage"] is False
+    assert "ranged_in_melee_disadvantage" not in res["attack_roll"]
+
+
+def test_grid_ranged_in_melee_blind_foe_no_disadvantage(fight):
+    """On-grid: an adjacent foe that is BLINDED (can't see the shooter) does not impose
+    the penalty (SRD: the enemy must be able to SEE you)."""
+    cid, hero, gob = fight
+    cur = _make_current(cid, hero, gob)
+    shooter, foe = (hero, gob) if cur == hero else (gob, hero)
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, shooter, 0, 0)
+    server.place_combatant_at_coords(cid, foe, 1, 0)
+    c = store.load_campaign(cid)
+    c.characters[foe].conditions.append(Condition.BLINDED)
+    store.save_campaign(c)
+    res = server.attack(cid, attacker_id=shooter, target_id=foe,
+                        attack_bonus=5, damage_dice="1d6", is_ranged=True)
+    assert res["disadvantage"] is False
+    assert "ranged_in_melee_disadvantage" not in res["attack_roll"]
+
+
+def test_grid_ranged_in_melee_only_hostile_counts(fight):
+    """On-grid: an adjacent ALLY is not a threat — only a HOSTILE (opposite team) within
+    5 ft imposes the penalty. Monster shooter + adjacent same-team ally + distant foe."""
+    cid, hero, gob = fight
+    # Add a second monster so the monster shooter has an adjacent same-team ally.
+    ally = server.create_character(cid, "Goblin2", kind="monster", max_hp=15, armor_class=12)["id"]
+    server.end_combat(cid)  # the fixture already started a 2-combatant fight
+    server.start_combat(cid, [hero, gob, ally])
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, gob, 0, 0)
+    server.place_combatant_at_coords(cid, ally, 1, 0)   # adjacent ALLY (same team)
+    server.place_combatant_at_coords(cid, hero, 5, 5)   # distant foe
+    # Seat the monster `gob` as the current combatant directly (avoid the PC-skip guard):
+    # current_combatant_id derives from turn_index, so point turn_index at gob's slot.
+    c = store.load_campaign(cid)
+    c.combat.turn_index = next(
+        i for i, cb in enumerate(c.combat.order) if cb.character_id == gob
+    )
+    store.save_campaign(c)
+    assert server.get_state(cid)["current_turn"] == gob
+    res = server.attack(cid, attacker_id=gob, target_id=hero,
+                        attack_bonus=5, damage_dice="1d6", is_ranged=True)
+    assert res["disadvantage"] is False
+    assert "ranged_in_melee_disadvantage" not in res["attack_roll"]
+
+
+def test_grid_ranged_in_melee_advantage_cancels(fight):
+    """On-grid: an explicit advantage + the auto ranged-in-melee disadvantage CANCEL
+    (5e: adv+dis ⇒ neither). The field still records that the rule fired."""
+    cid, hero, gob = fight
+    cur = _make_current(cid, hero, gob)
+    shooter, foe = (hero, gob) if cur == hero else (gob, hero)
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, shooter, 0, 0)
+    server.place_combatant_at_coords(cid, foe, 1, 0)
+    res = server.attack(cid, attacker_id=shooter, target_id=foe,
+                        attack_bonus=5, damage_dice="1d6", is_ranged=True, advantage=True)
+    # adv + the auto-dis BOTH read True (the d20 roller normalizes the cancel); the
+    # field records that the rule fired so the DM/scorer can see it.
+    assert res["disadvantage"] is True
+    assert res["advantage"] is True
+    assert res["attack_roll"].get("ranged_in_melee_disadvantage") is True
+
+
+def test_grid_ranged_in_melee_no_double_apply_when_dm_flagged(fight):
+    """On-grid: if the DM already passed disadvantage=True, the engine still surfaces the
+    rule but does not 'double' anything (disadvantage doesn't stack)."""
+    cid, hero, gob = fight
+    cur = _make_current(cid, hero, gob)
+    shooter, foe = (hero, gob) if cur == hero else (gob, hero)
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, shooter, 0, 0)
+    server.place_combatant_at_coords(cid, foe, 1, 0)
+    res = server.attack(cid, attacker_id=shooter, target_id=foe,
+                        attack_bonus=5, damage_dice="1d6", is_ranged=True, disadvantage=True)
+    assert res["disadvantage"] is True
+    assert res["attack_roll"].get("ranged_in_melee_disadvantage") is True
+
+
+def test_theater_ranged_in_melee_unchanged_nudge_only(fight):
+    """Theater-of-mind (NO grid): the engine has no positions → it must NOT auto-apply
+    disadvantage; the ranged_in_melee_check NUDGE stays (today's behaviour)."""
+    cid, hero, gob = fight
+    cur = _make_current(cid, hero, gob)
+    shooter, foe = (hero, gob) if cur == hero else (gob, hero)
+    res = server.attack(cid, attacker_id=shooter, target_id=foe,
+                        attack_bonus=5, damage_dice="1d6", is_ranged=True)
+    assert res["disadvantage"] is False  # no auto-apply off-grid
+    assert "ranged_in_melee_disadvantage" not in res["attack_roll"]
+    assert "ranged_in_melee_check" in res  # the DM-surfaced nudge remains
+
+
 # ── (9) schema budget stays green is enforced by test_tool_schema_budget.py ──


### PR DESCRIPTION
## What

On a **grid** (`grid_enabled=True`) the engine now **auto-applies** the SRD 5.24
*"Ranged Attacks in Close Combat"* rule. A ranged `attack()` gets **Disadvantage** when
the attacker is within 5 ft (Chebyshev ≤ 1 cell) of a **hostile** creature that **can see**
it and is **not Incapacitated**.

- Folded into the attack's `dis` (so it actually bends the d20 roll; disadvantage doesn't stack).
- Surfaced as `result["attack_roll"]["ranged_in_melee_disadvantage"] = true` so the DM narrates
  it and the behavioral gate / scorer see the rule fired (not announced-then-dropped).

This is the **#461 PR-5 increment** — the position-based attack penalty the grid model enables.

## srd524 validation

`data/srd/srd524/Rule.json` → *"Ranged Attacks in Close Combat"*:
> "When you make a ranged attack roll with a weapon, a spell, or some other means, you have
> Disadvantage on the roll **if you are within 5 feet of an enemy who can see you and doesn't
> have the Incapacitated condition**."

Conditions implemented exactly: ranged + hostile within 5 ft (1 cell) + can see (not Blinded/Unconscious)
+ not Incapacitated (Stunned/Paralyzed/Petrified/Unconscious/Incapacitated).

## Additive / invariant-safe

- **Grid-gated:** the whole block is guarded by `is_ranged and c.combat.grid_enabled`.
  `grid_enabled=False` (the default) ⇒ **byte-for-byte today's behavior** — the new field is
  absent and the theater-of-mind DM **nudge** (`ranged_in_melee_check`) is unchanged.
- The nudge is suppressed **only** for a *placed* on-grid shooter (the engine already ruled
  authoritatively); an *unplaced* on-grid shooter still gets the nudge.
- **Engine = sole writer.** No new tool, **no tool-schema change** (no schema-budget impact).
- **Reused** helpers: `_cell`, `_can_see`, `combat.is_incapacitated`, `combat_grid.in_melee_reach`,
  and the established `{player, companion}` side-classification.

## Behavioral gate (`assert_behavioral.py`)

`ranged_disadvantage_in_melee` now reads the new result field: an on-grid attack carrying
`ranged_in_melee_disadvantage` is clean **by construction** (the engine ruled adjacency).
The theater mutual-melee proxy still WARNs **off-grid**. Same check name (no new `chk()` key, so
no `test_root_cause_analyzer` drift); taxonomy hint updated.

## Reproduce (RED → GREEN)

Before: an on-grid ranged attack with an adjacent hostile returned `disadvantage=false`
(engine did **not** auto-apply). After: `disadvantage=true` + the surfaced field.

## Tests

- `servers/engine/tests/test_grid.py` (+8): in-melee → auto-disadvantage + field; not-in-melee
  (10 ft) → none; incapacitated foe → none; blind foe → none; adjacent ally-only → none;
  adv + this-dis → both flags + field (cancel handled by the d20 roller); DM already flagged
  `disadvantage=True` → no double-apply; **theater (no grid)** → nudge only, no auto-apply.
- `qa/test_assert_behavioral.py` (+2): off-grid mutual-melee → WARN (unchanged); on-grid same
  pattern with the field → PASS.

## Validation

```
uv run --directory servers/engine python -m pytest \
  tests/test_combat.py tests/test_grid.py \
  qa/test_assert_behavioral.py qa/test_root_cause_analyzer.py -q -p no:xdist
# 292 passed
# full engine suite: 3073 passed
```

Status: **DRAFT** — engine/QA lane PR-5 increment for #461.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ranged attacks made against adjacent enemies on tactical grids now automatically apply disadvantage penalties. Attack results include clear notation when disadvantage was auto-applied by the engine, ensuring consistent rule enforcement across grid and theater-of-mind modes.

* **Testing**
  * Expanded test coverage for ranged-in-melee disadvantage scenarios in both grid-based and theater-of-mind modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->