### PR TITLE
feat(qa): scoring hardening — one-decimal lenses + operationalize fact-fidelity + ruler discipline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ WorldOS is source-available commercial software; world seeds are licensed separa
 
 ## [Unreleased]
 
+- **Scoring hardening — one-decimal lens precision + ruler-versioning discipline.** The three lens
+  schemas (`qa/score_schema.json` / `score_schema_tolkien.json` / `score_schema_angry_dm.json`, plus the
+  Tolkien per-act `score`) now type each per-dimension score `number` in `[1,5]` (was `integer 1–5`), and
+  the four rubrics (`rubric.md` / `rubric_tolkien.md` / `rubric_angry_dm.src.md` → regenerated
+  `rubric_angry_dm.md`) instruct "score each dimension 1.0–5.0 to one decimal." (`multipleOf: 0.1` was
+  deliberately NOT used — it's an IEEE-754 footgun that rejects legitimate values like 4.3; the rubric
+  text carries the one-decimal expectation, the schema just permits non-integers.) **No range, threshold,
+  cap, or weighting changed** (story ≥4.3, mech ≥4.5 unchanged) — a *precision* re-version, not a
+  stringency one. This re-versions the ruler: **`sc_cf47d34e219e` → `sc_f283fdce1d24`**,
+  **`lc_e06a888f7c08` → `lc_e52028b6acd3`**. Documented in `qa/SCORING.md` (Ruler history + the new
+  mechanical re-versioning discipline: after any rubric/schema/gate edit, run
+  `python3 qa/scoring_config_version.py --label` / `--lens`, confirm the hash moved, re-stamp the history +
+  this CHANGELOG). Operationalized the differential fact-fidelity guard (`qa/fact_fidelity.py`, #1065/#1068)
+  with an explicit ≥90% critical-fact assertion against the committed `ow-combat-031717` inventory
+  (`qa/test_fact_fidelity.py` — drop a critical fact → RED, intact → GREEN). Feature-engagement coverage
+  stays WARN (FATAL graduation remains VM-sweep-gated).
 - Gameplay toward the RRI bar (story ≥4.3, mechanical ≥4.5) — the GA work, now built on the
   honest, un-gamed measurement that 1.0.5-rc1 established.
 

--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -32,7 +32,25 @@ quality regression.** Expect current numbers to read below historic numbers; tha
 scorer exists to drive autonomous build-and-improve.
 
 ### Ruler history
-- **`sc_d4b93982763a` / `lc_d7fcfddd5bf7` — current (2026-06 cycle → `v1.0.5-rc1`).** Materially
+- **`sc_f283fdce1d24` / `lc_e52028b6acd3` — current (2026-06 scoring-hardening).** Re-versioned ONLY
+  by the **one-decimal lens precision** change: the per-dimension score type in all three lens schemas
+  (and the Tolkien per-act `score`) went `integer 1–5` → `number, minimum 1, maximum 5`, and the four
+  rubric files now instruct "score each dimension 1.0–5.0 to one decimal." **No range, threshold, cap,
+  or weighting changed** (story ≥ 4.3, mech ≥ 4.5 unchanged) — the bands are identical, the grader can
+  just register *where within a band* a dimension lands instead of rounding to a whole number. This is a
+  **precision** re-version, not a stringency one: a given session should read at the *same* overall ±
+  the rounding it no longer has to do.
+  - **Why not `multipleOf: 0.1`?** It looks like the natural "one decimal" constraint but is an
+    IEEE-754 footgun — under a real validator `4.3` is *not* a multiple of `0.1` (`4.3/0.1 = 42.9999…`
+    in binary float), so `multipleOf: 0.1` would REJECT legitimate one-decimal scores. The pipeline feeds
+    the schema to the LLM as advisory *text* (no runtime `jsonschema.validate()` on scorecards), so the
+    one-decimal expectation is carried by the **rubric instruction**, and the schema stays a plain
+    `number` in `[1,5]` — accepts `4.3`, still rejects `5.5` / `0.5` / a string. Do not "tighten" it back
+    to `multipleOf: 0.1`.
+  - Was `sc_cf47d34e219e` / `lc_e06a888f7c08` on origin/main pre-change; the older `sc_d4b93982763a` line
+    below was already stale — PRs #1040/#1081/#1083/#1086 had re-versioned the ruler since it was written,
+    the exact silent-drift this stamping discipline exists to catch.
+- **`sc_d4b93982763a` / `lc_d7fcfddd5bf7` — the 2026-06 cycle → `v1.0.5-rc1` ruler.** Materially
   STRICTER than the v1.0.4 rulers. Adds: the **feature-engagement coverage scorer + forcing gate**
   (#1018 — every *owed* authored system narrated-but-not-gauged is now a coverage miss); the
   **acts-engine felt-shape scorer + flat-arc gate** (#1001/#1002 — a flat, act-less arc is penalized);
@@ -47,6 +65,25 @@ scorer exists to drive autonomous build-and-improve.
 To compare a historic run to today honestly, **re-score its transcript under the current ruler**
 (`qa/score.sh <transcript.md> <state.json> <rubric> <schema> <out> [budget]`), then compare `sc_`-equal
 rows only.
+
+### Re-versioning discipline — the MECHANICAL rule (run it after ANY rubric/schema/gate edit)
+The hashes above silently re-version themselves the instant any ruler file changes (a rubric anchor, a
+schema, a behavioral/RRI gate). That is the point — but a stale "current" line in this doc (which is
+exactly what `sc_d4b93982763a` had become) means a reader trusts the wrong hash. So after **any** edit to
+a file in `SCORING_CONFIG_FILES` (`python3 qa/scoring_config_version.py --files` lists them), the
+mechanical, do-not-skip steps are:
+
+1. **Recompute** both hashes — `python3 qa/scoring_config_version.py --label` (the FULL `sc_…` ruler) and
+   `python3 qa/scoring_config_version.py --lens` (the `lc_…` lens ruler).
+2. **Confirm the hash changed** vs the previous "current" entry. If it did NOT change but you edited a
+   ruler file, the file is not in `SCORING_CONFIG_FILES` (a real gap — add it) or your edit was a no-op.
+3. **Re-stamp** the new `sc_…` / `lc_…` as a fresh top entry in the *Ruler history* above (1 line on WHAT
+   changed and whether it was a *precision* / *stringency* / *RRI-only* re-version), and add a 1-line
+   note to `CHANGELOG.md` under `[Unreleased]` with both hashes.
+
+This keeps the ledger's `scoring_config_version` / `lens_config_version` columns trustworthy and the doc's
+"current" marker honest. (`--label` exists today; there is no auto-restamp — re-stamping is the deliberate
+human step that records the *why*.)
 
 ## 1. Behavioral gate — HARD pass/fail (`qa/assert_behavioral.py`)
 LLM scorers grade prose and can't be trusted to flip RED on a structurally broken run,

--- a/qa/rubric.md
+++ b/qa/rubric.md
@@ -10,7 +10,9 @@ The whole premise of WorldOS is that **the world is consistent and fair because
 mechanics come from deterministic tools, never from the model's imagination.**
 Weight your judgment accordingly: hallucinated mechanics are the worst defect.
 
-Score each criterion 1–5 (5 = excellent, 1 = broken). Be skeptical; reserve 5s.
+Score each criterion **1.0–5.0 to one decimal** (5 = excellent, 1 = broken; e.g. 4.3,
+3.7). Use the decimal to register *where in a band* the play lands — don't round to whole
+numbers. Be skeptical; reserve 4.5+.
 
 1. **tool_sourced** — Were ALL dice rolls, rule/spell/monster lookups, HP/condition
    changes, attacks, XP, and state writes performed via worldos tools? Any number

--- a/qa/rubric_angry_dm.md
+++ b/qa/rubric_angry_dm.md
@@ -118,7 +118,8 @@ this run.
      short slice. ~6+ beats is the threshold for "substantial enough to expect breadth."
 
 ## OUTPUT — JSON ONLY, conforming to the schema you are given. No prose, no code fences.
-  - `scores` (each integer 1–5, 5 = a veteran DM nods):
+  - `scores` (each **1.0–5.0 to one decimal**, 5 = a veteran DM nods; e.g. 4.4, 3.8 — use the
+    decimal to register where in a band the table lands, don't round to whole numbers):
       - `rules_as_written` — correctness of the mechanics that WERE invoked.
       - `mechanical_completeness` — were required DM-owned mechanics invoked at all, or
         skipped (the seams above)?

--- a/qa/rubric_angry_dm.src.md
+++ b/qa/rubric_angry_dm.src.md
@@ -122,7 +122,8 @@ this run.
      short slice. ~6+ beats is the threshold for "substantial enough to expect breadth."
 
 ## OUTPUT — JSON ONLY, conforming to the schema you are given. No prose, no code fences.
-  - `scores` (each integer 1–5, 5 = a veteran DM nods):
+  - `scores` (each **1.0–5.0 to one decimal**, 5 = a veteran DM nods; e.g. 4.4, 3.8 — use the
+    decimal to register where in a band the table lands, don't round to whole numbers):
       - `rules_as_written` — correctness of the mechanics that WERE invoked.
       - `mechanical_completeness` — were required DM-owned mechanics invoked at all, or
         skipped (the seams above)?

--- a/qa/rubric_tolkien.md
+++ b/qa/rubric_tolkien.md
@@ -49,7 +49,11 @@ or a climax from a setup scene. So FIRST judge the arc, THEN the beats:
    `assessment` of the beat it delivered or missed, and a 1–5. Only the acts present — don't invent
    ones a slice doesn't reach.
 
-## Score each 1–5
+## Score each 1.0–5.0 (one decimal)
+Score every dimension below **1.0–5.0 to one decimal** (e.g. 4.3, 3.7) — and the per-act
+`score` likewise. Use the decimal to register *where in a band* a scene lands rather than
+rounding to a whole number; it does not change any band boundary or cap (the caps below still
+bind exactly as written).
 - **scene_craft** *(playability — the one we were missing)* — Does this read like a PLAYED scene you could step INTO, or a recap of one? In-the-moment and immersive; **NPCs SPEAK in real quoted dialogue** (not "X reveals/explains…"); the **protagonist visibly ACTS and CHOOSES**; each beat hands back an open moment + a choice. A third-person after-action summary, described-not-spoken NPCs, or no felt choice ⇒ **2 or below**. This is what catches "I couldn't actually play this."
 - **grandeur** — Epic scope *felt in the present*: the vast/ancient/mythic pressing on the local scene as concrete detail, not backstory. (5 = the local crisis clearly belongs to a looming epic; 2 = small, self-contained.)
 - **character_depth** — Layered, contradictory adult humans (companion + NPCs) with wants/wounds/secrets that can surprise — vs quest-dispensers. (5 = a character you'd ache for; 1 = cardboard.)
@@ -95,7 +99,7 @@ matter how lovely the writing — and the HARD CAP below then binds `overall ≤
 `scope` = the arc scope this transcript represents (`setup-slice` | `one-shot` | `short-3act` | `campaign-arc`). Label honestly — do NOT call a long, gone-nowhere session a `setup-slice`.
 `progressed` = boolean — did the world MOVE over the session (clock advanced AND/OR the party traveled to a new place AND/OR a new named face entered)? `false` for a session long enough to have moved that stayed frozen in one Act-1 scene; `true` otherwise (a genuinely short slice that simply hasn't reached travel yet is `true` — it isn't a *failure*, it just hasn't gotten there). When `false`, the failure-to-progress cap binds.
 `acts` = the per-act breakdown — ONLY the acts actually present — each `{act, present, assessment, score}`.
-`scores` = the **7** dims above (1–5), judged ACT-RELATIVE per the arc section.
+`scores` = the **7** dims above (each 1.0–5.0 to one decimal), judged ACT-RELATIVE per the arc section.
 `overall` = an honest weighted average that **rewards PLAYABLE epic** — weight
 **scene_craft, grandeur, dramatic_momentum, and memorability** most (the "is this a game
 worth playing?" core); character_depth + thematic_resonance next; prose_atmosphere last.

--- a/qa/score_schema.json
+++ b/qa/score_schema.json
@@ -17,14 +17,14 @@
         "robustness"
       ],
       "properties": {
-        "tool_sourced": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "rules_correctness": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "state_integrity": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "companion_agency": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "player_agency": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "exploration": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "narrative_pacing": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "robustness": { "type": "integer", "minimum": 1, "maximum": 5 }
+        "tool_sourced": { "type": "number", "minimum": 1, "maximum": 5 },
+        "rules_correctness": { "type": "number", "minimum": 1, "maximum": 5 },
+        "state_integrity": { "type": "number", "minimum": 1, "maximum": 5 },
+        "companion_agency": { "type": "number", "minimum": 1, "maximum": 5 },
+        "player_agency": { "type": "number", "minimum": 1, "maximum": 5 },
+        "exploration": { "type": "number", "minimum": 1, "maximum": 5 },
+        "narrative_pacing": { "type": "number", "minimum": 1, "maximum": 5 },
+        "robustness": { "type": "number", "minimum": 1, "maximum": 5 }
       }
     },
     "overall": { "type": "number", "minimum": 1, "maximum": 5 },

--- a/qa/score_schema_angry_dm.json
+++ b/qa/score_schema_angry_dm.json
@@ -16,13 +16,13 @@
         "coverage"
       ],
       "properties": {
-        "rules_as_written": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "mechanical_completeness": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "tool_fidelity": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "action_economy": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "combat_resolution": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "conditions_and_effects": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "coverage": { "type": "integer", "minimum": 1, "maximum": 5 }
+        "rules_as_written": { "type": "number", "minimum": 1, "maximum": 5 },
+        "mechanical_completeness": { "type": "number", "minimum": 1, "maximum": 5 },
+        "tool_fidelity": { "type": "number", "minimum": 1, "maximum": 5 },
+        "action_economy": { "type": "number", "minimum": 1, "maximum": 5 },
+        "combat_resolution": { "type": "number", "minimum": 1, "maximum": 5 },
+        "conditions_and_effects": { "type": "number", "minimum": 1, "maximum": 5 },
+        "coverage": { "type": "number", "minimum": 1, "maximum": 5 }
       }
     },
     "overall": { "type": "number", "minimum": 1, "maximum": 5 },

--- a/qa/score_schema_tolkien.json
+++ b/qa/score_schema_tolkien.json
@@ -16,13 +16,13 @@
         "memorability"
       ],
       "properties": {
-        "scene_craft": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "grandeur": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "character_depth": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "prose_atmosphere": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "dramatic_momentum": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "thematic_resonance": { "type": "integer", "minimum": 1, "maximum": 5 },
-        "memorability": { "type": "integer", "minimum": 1, "maximum": 5 }
+        "scene_craft": { "type": "number", "minimum": 1, "maximum": 5 },
+        "grandeur": { "type": "number", "minimum": 1, "maximum": 5 },
+        "character_depth": { "type": "number", "minimum": 1, "maximum": 5 },
+        "prose_atmosphere": { "type": "number", "minimum": 1, "maximum": 5 },
+        "dramatic_momentum": { "type": "number", "minimum": 1, "maximum": 5 },
+        "thematic_resonance": { "type": "number", "minimum": 1, "maximum": 5 },
+        "memorability": { "type": "number", "minimum": 1, "maximum": 5 }
       }
     },
     "overall": { "type": "number", "minimum": 1, "maximum": 5 },
@@ -55,7 +55,7 @@
           "act": { "type": "string" },
           "present": { "type": "boolean" },
           "assessment": { "type": "string" },
-          "score": { "type": "integer", "minimum": 1, "maximum": 5 }
+          "score": { "type": "number", "minimum": 1, "maximum": 5 }
         }
       }
     }

--- a/qa/test_fact_fidelity.py
+++ b/qa/test_fact_fidelity.py
@@ -161,3 +161,72 @@ def test_cli_main_exit_codes(tmp_path, capsys):
     gutted = tmp_path / "gutted.md"
     gutted.write_text(full[: full.index("CLIMAX — ")])
     assert ff.main([str(SAMPLE_INVENTORY), str(gutted), "--min-fidelity", "0.9"]) == 1
+
+
+# ---------------------------------------------------------------------------------------
+# The ≥90% critical-fact guard, pinned to the COMMITTED evidence inventory. This makes the
+# operational contract — "a new run vs the reference must preserve ≥90% of facts, RED on loss"
+# — a named, load-bearing assertion against the canonical `ow-combat-031717` inventory (not
+# only the synthetic sample): the inventory is faithful (clears its own ≥90% bar), and dropping
+# a single CRITICAL fact (the antagonist reveal) trips the guard RED at that 0.90 floor.
+# ---------------------------------------------------------------------------------------
+COMBAT_INVENTORY = QA_DIR / "fact_inventories" / "ow-combat-031717.facts.json"
+MIN_FIDELITY_GUARD = 0.90  # the operational floor: ≥90% of the reference's facts must survive
+
+
+def _synthesize_candidate(facts: list, drop_ids: set[str]) -> str:
+    """Build a candidate transcript that contains a literal token matching every fact's FIRST
+    pattern EXCEPT the dropped ids — a deterministic stand-in for 'a fresh run that preserved
+    (or lost) these facts', independent of the gitignored raw transcript.
+
+    Inventories legitimately overlap (e.g. a 'consequence' fact may name the antagonist), so a
+    dropped fact's token can re-appear in another fact's literal. After assembling the candidate
+    we SCRUB every pattern of every dropped fact from the text, guaranteeing the drop is real."""
+    import re as _re
+
+    def _to_literal(pattern: str) -> str:
+        lit = _re.sub(r"\\b|[\^\$]", "", pattern)
+        return lit.replace("\\", "")
+
+    chunks: list[str] = []
+    for f in facts:
+        if f.id in drop_ids or not f.patterns:
+            continue
+        chunks.append(_to_literal(f.patterns[0]))
+    text = " ; ".join(chunks)
+    # SCRUB any residual occurrence of a dropped fact's patterns (handles inventory overlap)
+    for f in facts:
+        if f.id in drop_ids:
+            for p in f.patterns:
+                text = _re.sub(p, "", text, flags=_re.IGNORECASE)
+    return text
+
+
+def test_committed_inventory_is_faithful_and_clears_the_90pct_guard():
+    """A faithful candidate (every fact present) clears the ≥90% operational floor with no
+    critical loss — the GREEN baseline for 'a new run vs the reference'."""
+    facts = ff.load_inventory(COMBAT_INVENTORY)
+    assert len(facts) >= 20, "the committed evidence inventory should carry ~20-30 facts"
+    candidate = _synthesize_candidate(facts, drop_ids=set())
+    report = ff.score_fidelity(facts, candidate)
+    assert report.fidelity >= MIN_FIDELITY_GUARD, report.missing
+    assert not report.critical_loss
+    assert ff.passed(report, min_fidelity=MIN_FIDELITY_GUARD) is True
+
+
+def test_dropping_a_critical_fact_trips_the_90pct_guard_red():
+    """Deleting ONE critical fact (the antagonist reveal) from an otherwise-faithful run trips
+    the guard RED — even though the flat fidelity (>90%) alone would clear the floor. This is
+    the content-loss the 1–5 lens is blind to, caught deterministically."""
+    facts = ff.load_inventory(COMBAT_INVENTORY)
+    crit_ids = [f.id for f in facts if f.severity == "critical"]
+    assert crit_ids, "inventory must carry at least one critical fact"
+    dropped = crit_ids[0]
+    candidate = _synthesize_candidate(facts, drop_ids={dropped})
+    report = ff.score_fidelity(facts, candidate)
+    # the flat fraction stays high (one fact of ~25 dropped), so ONLY the critical-loss rule
+    # catches it — proving the guard isn't satisfied by a high headline percentage alone.
+    assert report.fidelity > MIN_FIDELITY_GUARD
+    assert report.critical_loss is True
+    assert dropped in report.missing
+    assert ff.passed(report, min_fidelity=MIN_FIDELITY_GUARD) is False


### PR DESCRIPTION
## What & why

Scoring hardening, **additive**, READ-ONLY on `qa/scores.db`. Keeps the 1–5 lenses + ONE DECIMAL + the deterministic layer (NOT a 0–100 rescale). No threshold/bar/cap/weighting changed (story ≥4.3, mech ≥4.5 unchanged).

### 1. One-decimal lens precision
- All three lens score schemas (`qa/score_schema.json`, `score_schema_tolkien.json`, `score_schema_angry_dm.json`) — plus the Tolkien per-act `score` — now type each per-dimension score as `number` in `[1,5]` (was `integer 1–5`).
- The four rubrics (`rubric.md`, `rubric_tolkien.md`, `rubric_angry_dm.src.md` → regenerated `rubric_angry_dm.md` via `build_angry_dm_card.py`) now instruct **"score each dimension 1.0–5.0 to one decimal."**
- **`multipleOf: 0.1` deliberately NOT used** — it's an IEEE-754 footgun: under a real validator `4.3` is *not* a multiple of `0.1` (`4.3/0.1 = 42.9999…`), so it would reject legitimate one-decimal scores. The pipeline feeds the schema to the LLM as advisory **text** (no runtime `jsonschema.validate()` on scorecards), so the one-decimal expectation lives in the rubric instruction; the schema stays a plain `number` that accepts `4.3` and still rejects `5.5`/`0.5`/strings.
- `overall` was already `number`; nothing recomputes it from the dimensions (the LLM emits it).

### 2. Fact-fidelity guard operationalized
The instrument (`qa/fact_fidelity.py`), the committed inventories (`sample_session`, `ow-combat-031717`), and the wired recap consumer (`qa/test_recap_fidelity.py`) already shipped in #1065/#1068. This PR adds an **explicit ≥90% critical-fact guard** tying the operational contract to the committed evidence inventory:
- `test_committed_inventory_is_faithful_and_clears_the_90pct_guard` — a faithful run clears the 0.90 floor GREEN, no critical loss.
- `test_dropping_a_critical_fact_trips_the_90pct_guard_red` — dropping ONE critical fact trips `critical_loss` RED *even though the flat fidelity stays above the floor* (the content-loss the 1–5 lens is blind to, caught deterministically).

### 3. Ruler-versioning discipline
- `qa/SCORING.md` gains the **mechanical post-edit rule** (after any rubric/schema/gate edit: run `python3 qa/scoring_config_version.py --label` / `--lens`, confirm the hash moved, re-stamp the Ruler-history entry + a `CHANGELOG` line) and a fresh Ruler-history entry. Also corrected a **stale "current" hash** in the doc (`sc_d4b93982763a` had already drifted on origin/main — PRs #1040/#1081/#1083/#1086 re-versioned the ruler since it was written).
- `CHANGELOG.md` `[Unreleased]` note with both new hashes.

**Ruler re-versioned (expected):**
- FULL: `sc_cf47d34e219e` → **`sc_f283fdce1d24`**
- LENS: `lc_e06a888f7c08` → **`lc_e52028b6acd3`**

### 4. Feature-engagement coverage — left WARN
Not graduated WARN→FATAL this pass — that's gated on a calibration 5-persona VM sweep (graduating early would false-RED combat-only / no-companion runs). VM-gated follow-up.

## Validation
- `qa/fast_gate.sh` — **233 passed** (Tier-0 deterministic).
- `test_lens_variance.py` + `test_assert_behavioral.py` + `test_fact_fidelity.py` + `test_recap_fidelity.py` + `test_collect_findings.py` + `test_score_determinism.py` — **121 passed, 2 skipped** (skips: local-only raw-transcript + live-scorer paths).
- All three schemas valid JSON; plain-`number` validation confirmed to accept `4.3` and reject `5.5`/`0.5`.
- `qa/scores.db` untouched (reverted the test-run mutation per the READ-ONLY invariant).

## Risk
- **Score MEANING:** unchanged. This is a *precision* re-version, not a stringency one — same bands, same caps, same weighting; the grader just registers *where within a band* a dimension lands instead of rounding. A given session should read at the same `overall` ± the rounding it no longer does. Cross-ruler comparison discipline (compare `sc_`-equal rows only) already covers the re-version.
- The new `sc_`/`lc_` hashes mean future scored rows are stamped under the new ruler; historic rows stay comparable only among themselves (existing SCORING.md §0 rule).