### PR TITLE
feat(engine): engine-run combat core — monster-AI pick_action + auto-loop + sandbox test toggles (Track 2b/2c/2e)

### DIFF
--- a/servers/engine/combat_ai.py
+++ b/servers/engine/combat_ai.py
@@ -1,27 +1,43 @@
-"""Engine-run combat: the monster-AI contract (Track 2a — DESIGN STUB).
+"""Engine-run combat: the monster-AI contract + greedy-v1 policy (Track 2b).
 
 See docs/roadmap/engine-combat-loop-design.md for the full ADR. This module is the
-load-bearing CONTRACT for the auto-sequencing combat loop; PR-A implements the
-greedy-v1 policy. It is intentionally a STUB: no logic, no behavior, nothing imports
-it yet (so it cannot change a single byte of live combat).
+monster-AI for the auto-sequencing combat loop. PR-A implements the greedy-v1
+expected-value policy.
 
 Posture (mirrors combat_grid.py): PURE — no Campaign mutation, no lock, no save, no
 LLM, no I/O. `pick_action` is a deterministic decision over a read-only snapshot, so
 the same state + same dice-seed always yields the same Intent. That purity is what
-makes the engine-only combat smoke (qa/combat_smoke.py) reproducible and lets the AI
-be unit-tested in isolation — feed a CombatView, assert the Intent — without standing
-up a campaign. The MCP-facing loop in server.py is the SOLE WRITER: it translates an
-Intent into the existing write verbs (attack / cast_spell / move_to_* / use_action /
-next_turn), never a parallel resolution path.
+makes the engine-only combat smoke reproducible and lets the AI be unit-tested in
+isolation — feed a CombatView, assert the Intent — without standing up a campaign.
+The MCP-facing loop in server.py is the SOLE WRITER: it translates an Intent into the
+existing write verbs (attack / cast_spell / move_to_* / use_action / next_turn), never
+a parallel resolution path.
+
+The only imports are pure-math helpers (dice.average_total, combat_grid distance/
+reachability). No engine state, no server, no filesystem — keeping this module I/O-free
+is what guarantees determinism and isolated testability.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Optional
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal, Optional
+
+import combat_grid
+import dice as dice_mod
 
 if TYPE_CHECKING:  # avoid any runtime import coupling — this module stays I/O-free
     from models import Character
+
+
+# ── Policy constants (one readable home; the greedy-v1 policy is one function) ────────
+# Owner-decided (ADR open-Q 5): v1 monsters FIGHT TO THE DEATH by default (RETREAT_FRACTION
+# 0.0 == no morale), with the retreat hook present for a future morale policy. Set >0 (e.g.
+# 0.25) to make a monster disengage+flee when below that fraction of max HP. Owner-decided
+# (the brief): "Monster v1 = greedy retreat-if-low (no full morale)" — the hook is wired and
+# tested; the default value keeps today's fight-to-the-death behaviour until a fight opts in.
+RETREAT_FRACTION = 0.0
 
 
 # A monster/NPC's declared intent for its turn. The loop maps `kind` to one or more
@@ -31,28 +47,297 @@ if TYPE_CHECKING:  # avoid any runtime import coupling — this module stays I/O
 class Intent:
     kind: Literal["attack", "cast", "move", "dash", "disengage", "dodge", "skip"]
     target_id: str = ""           # attack / single-target cast
-    attack_name: str = ""         # scopes a Multiattack budget (server.py _attacker_multiattack_count)
+    attack_name: str = ""         # scopes a Multiattack budget (server._attacker_multiattack_count)
     spell_name: str = ""          # cast
     to_cell: Optional[tuple[int, int]] = None  # move (grid / #461)
     to_zone: str = ""             # move (zone / S2.7)
     note: str = ""                # human-readable rationale for the digest / debugging
 
 
-def pick_action(actor: "Character", combat_state: Any) -> Intent:
+# ── The read-only CombatView the loop assembles per turn (no new persistent model) ───
+# Plain frozen dataclasses the loop builds from the live Combat + the actor's authoritative
+# attack lines (server._monster_combat_entry). pick_action reads ONLY these — never the live
+# Campaign — so it cannot mutate state and is trivially unit-testable.
+
+@dataclass(frozen=True)
+class AttackOption:
+    """One authoritative weapon/natural attack from the actor's stat block (or PC sheet).
+    Numbers come straight from the engine — the AI never invents a bonus. `damage_expr` is the
+    single-component dice for EV; `damage_rolls` (if multi-type) is carried verbatim so the
+    loop passes it to attack(damage_rolls=...)."""
+    name: str
+    to_hit: int
+    damage_expr: str = ""
+    damage_type: str = ""
+    damage_rolls: tuple = ()  # tuple of {"dice","type"} dicts (frozen-safe); () == single-type
+    reach_ft: int = 5         # melee 5ft default; ranged attacks set a longer reach
+    is_ranged: bool = False
+
+
+@dataclass(frozen=True)
+class SpellOption:
+    """A castable damaging-cantrip or save-or-suck spell the actor knows with an available
+    slot. `save_ability` set => a save spell scored by P(target fails) * value; else an
+    attack/auto cantrip scored like a weapon. EV uses `value` (avg damage, or a control weight)."""
+    name: str
+    value: float                 # EV magnitude: avg damage, or a control-weight for a save-or-suck
+    range_ft: int = 60
+    save_ability: str = ""       # "" => attack/auto cantrip; else the save (e.g. "wisdom")
+    requires_slot: bool = True   # cantrips set False
+
+
+@dataclass(frozen=True)
+class CombatantView:
+    """A living combatant the AI reasons about: position + the numbers needed for EV."""
+    id: str
+    name: str
+    side: str                    # "party" (player/companion) or "enemy" (monster/npc)
+    current_hp: int
+    max_hp: int
+    armor_class: int
+    cell: Optional[tuple[int, int]] = None   # grid position, or None (zone/theater)
+    zone: str = ""
+    save_bonuses: dict = field(default_factory=dict)  # ability -> save bonus, for save-spell EV
+
+
+@dataclass(frozen=True)
+class CombatView:
+    """The read-only snapshot pick_action decides over. Built by the loop each turn."""
+    actor_id: str
+    actor_cell: Optional[tuple[int, int]]
+    actor_zone: str
+    actor_side: str
+    speed: int
+    dashed: bool
+    grid_enabled: bool
+    grid_width: int = 0
+    grid_height: int = 0
+    cell_size: int = 5
+    foes: tuple[CombatantView, ...] = ()    # living opposite-side combatants
+    allies: tuple[CombatantView, ...] = ()  # living same-side combatants (for occupancy)
+    attacks: tuple[AttackOption, ...] = ()  # the actor's authoritative attack lines
+    spells: tuple[SpellOption, ...] = ()    # the actor's castable damaging/control spells
+
+
+# ── Pure EV helpers ──────────────────────────────────────────────────────────────────
+
+def p_hit(to_hit: int, target_ac: int) -> float:
+    """P(a d20+to_hit lands vs target_ac), on the standard single-d20 curve. A natural 1
+    always misses and a natural 20 always hits, so the chance is clamped to [0.05, 0.95]
+    (1/20 each end). needed = AC - to_hit is the lowest face that hits; faces needed..20 hit."""
+    needed = target_ac - to_hit
+    faces_that_hit = 21 - needed  # needed<=1 -> 20 faces; needed>=20 -> 1 face
+    # nat-1 ALWAYS misses (so at most 19/20 hit) and nat-20 ALWAYS hits (so at least 1/20).
+    faces_that_hit = max(1, min(19, faces_that_hit))
+    return faces_that_hit / 20.0
+
+
+def _expected_damage(opt: AttackOption) -> float:
+    """E[damage] for an attack option: sum of every component's average. Pure math via
+    dice.average_total so the term grammar stays single-sourced. A malformed expr scores 0
+    (the AI degrades rather than raising — combat is advisory-not-block)."""
+    total = 0.0
+    specs = opt.damage_rolls or (
+        ({"dice": opt.damage_expr, "type": opt.damage_type},) if opt.damage_expr else ()
+    )
+    for spec in specs:
+        expr = str(spec.get("dice", "") or "")
+        if not expr:
+            continue
+        try:
+            total += float(dice_mod.average_total(expr))
+        except (ValueError, TypeError):
+            continue
+    return total
+
+
+def _attack_ev(opt: AttackOption, target: CombatantView) -> float:
+    """EV of striking `target` with `opt`: P(hit) * E[damage]."""
+    return p_hit(opt.to_hit, target.armor_class) * _expected_damage(opt)
+
+
+# ── Reach / range geometry (grid-aware, zone/theater fallback) ───────────────────────
+
+def _in_reach(view: CombatView, target: CombatantView, reach_ft: int) -> bool:
+    """Is `target` within `reach_ft` of the actor? On the grid, measured Chebyshev distance;
+    off-grid (zone/theater) every foe is treated as reachable (the engine/DM gates range),
+    which keeps v1 from refusing to act in a theater fight that has no coordinates."""
+    if not view.grid_enabled or view.actor_cell is None or target.cell is None:
+        return True
+    return combat_grid.distance_ft(view.actor_cell, target.cell, view.cell_size) <= reach_ft
+
+
+def _occupied_cells(view: CombatView) -> set:
+    cells = set()
+    for c in list(view.foes) + list(view.allies):
+        if c.cell is not None:
+            cells.add(c.cell)
+    return cells
+
+
+def _nearest_foe(view: CombatView) -> Optional[CombatantView]:
+    if not view.foes:
+        return None
+    if not view.grid_enabled or view.actor_cell is None:
+        # No geometry — "nearest" is the lowest-HP foe (the focus-fire target), id-tiebroken.
+        return min(view.foes, key=lambda f: (f.current_hp, f.id))
+    return min(
+        view.foes,
+        key=lambda f: (
+            combat_grid.distance_ft(view.actor_cell, f.cell, view.cell_size)
+            if f.cell is not None else 10**6,
+            f.current_hp,
+            f.id,
+        ),
+    )
+
+
+def _step_toward(view: CombatView, target: CombatantView, reach_ft: int) -> Optional[tuple[int, int]]:
+    """Pick the reachable cell (within this turn's movement budget) that gets the actor as
+    close as possible to `target` — ideally into reach. Returns a cell or None (can't improve
+    / off-grid). Pure: combat_grid.reachable + Chebyshev distance, no state."""
+    if not view.grid_enabled or view.actor_cell is None or target.cell is None:
+        return None
+    budget = combat_grid.movement_budget_cells(view.speed, view.cell_size, view.dashed)
+    if budget <= 0:
+        return None
+    occupied = _occupied_cells(view) - {view.actor_cell}
+    reach = combat_grid.reachable(view.actor_cell, budget, occupied, view.grid_width, view.grid_height)
+    if not reach:
+        return None
+    best = min(
+        reach,
+        key=lambda cell: (combat_grid.distance_ft(cell, target.cell, view.cell_size), cell),
+    )
+    cur = combat_grid.distance_ft(view.actor_cell, target.cell, view.cell_size)
+    new = combat_grid.distance_ft(best, target.cell, view.cell_size)
+    return best if new < cur else None
+
+
+# ── The greedy-v1 policy ─────────────────────────────────────────────────────────────
+
+def pick_action(
+    actor: "Character",
+    combat_state: CombatView,
+    policy: str = "greedy-v1",
+) -> Intent:
     """Choose the highest-expected-value action for a non-PC combatant's turn.
 
-    DESIGN STUB — implemented in PR-A (greedy-v1 EV policy; see ADR §2). Pure and
-    deterministic: reads only `actor` (read-only Character) and `combat_state` (a
-    read-only CombatView snapshot the loop builds from the live Combat plus the
-    actor's authoritative attack lines via server._monster_combat_entry). Returns an
-    Intent; the loop is the sole writer that applies it.
+    Greedy-v1 (ADR §2), in priority order:
+      1. retreat-if-low (disengage+move from the nearest threat) — only when RETREAT_FRACTION>0
+      2. best in-reach attack (P(hit)*E[damage], focus-fire ties by lowest target HP)
+      3. best castable cantrip / save-or-suck spell that can reach
+      4. move-to-reach toward the best target (the loop re-asks pick_action so move-then-attack
+         resolves both halves)
+      5. dodge / skip fallback when nothing productive is reachable
 
-    The v1 policy, in priority order: retreat-if-low → best in-reach attack
-    (P(hit)*E[damage], focus-fire ties) → best cantrip/save-spell → move-to-reach →
-    dodge/skip fallback. The Intent/`policy=` seam keeps a future BG3-tactical-v2
-    additive.
+    PURE + deterministic: reads only `actor` (read-only Character) and `combat_state` (a
+    read-only CombatView). Returns an Intent; the loop is the sole writer that applies it.
+    `policy` is a seam for a future BG3-tactical-v2 (additive; unknown policy falls back to v1).
     """
-    raise NotImplementedError(
-        "combat_ai.pick_action is a design stub (Track 2a). "
-        "See docs/roadmap/engine-combat-loop-design.md §2; implemented in PR-A."
-    )
+    view = combat_state
+
+    # No foes left -> nothing to do (the loop ends the fight; the AI just skips).
+    if not view.foes:
+        return Intent(kind="skip", note="no living foes")
+
+    # 1. Retreat-if-low (morale hook; OFF by default — RETREAT_FRACTION 0.0 == fight to the death).
+    if RETREAT_FRACTION > 0.0:
+        max_hp = max(1, int(getattr(actor, "max_hp", 1)))
+        cur_hp = int(getattr(actor, "current_hp", max_hp))
+        if cur_hp <= math.floor(max_hp * RETREAT_FRACTION):
+            threat = _nearest_foe(view)
+            if threat is not None and view.grid_enabled and view.actor_cell is not None:
+                budget = combat_grid.movement_budget_cells(view.speed, view.cell_size, view.dashed)
+                occupied = _occupied_cells(view) - {view.actor_cell}
+                reach = combat_grid.reachable(
+                    view.actor_cell, budget, occupied, view.grid_width, view.grid_height
+                )
+                if reach and threat.cell is not None:
+                    flee_cell = max(
+                        reach,
+                        key=lambda cell: (
+                            combat_grid.distance_ft(cell, threat.cell, view.cell_size), cell
+                        ),
+                    )
+                    return Intent(
+                        kind="disengage",
+                        to_cell=flee_cell,
+                        note=f"retreat-if-low: {cur_hp}/{max_hp} HP, disengage from {threat.name}",
+                    )
+
+    # 2. Best in-reach attack. EV = P(hit)*E[damage]; ties -> lowest-HP target (focus-fire),
+    #    then stable target id, then stable attack name (full determinism).
+    best_attack: Optional[tuple] = None  # (ev, -hp, foe_id, atk_name, AttackOption, CombatantView)
+    for opt in view.attacks:
+        for foe in view.foes:
+            if not _in_reach(view, foe, opt.reach_ft):
+                continue
+            ev = _attack_ev(opt, foe)
+            if ev <= 0:
+                continue
+            key = (ev, -foe.current_hp, foe.id, opt.name)  # higher EV, then lower HP, then ids
+            if best_attack is None or key > best_attack[:4]:
+                best_attack = (*key, opt, foe)
+    if best_attack is not None:
+        opt = best_attack[4]
+        foe = best_attack[5]
+        return Intent(
+            kind="attack",
+            target_id=foe.id,
+            attack_name=opt.name,
+            note=(
+                f"best in-reach attack {opt.name} on {foe.name} "
+                f"(EV {best_attack[0]:.1f}, P(hit) {p_hit(opt.to_hit, foe.armor_class):.0%})"
+            ),
+        )
+
+    # 3. Best castable cantrip / save-or-suck spell that can reach.
+    best_spell: Optional[tuple] = None  # (ev, SpellOption, CombatantView)
+    for sp in view.spells:
+        for foe in view.foes:
+            if not _in_reach(view, foe, sp.range_ft):
+                continue
+            if sp.save_ability:
+                # Save-or-suck: P(target FAILS the save) * value. We approximate P(fail) from
+                # the target's save bonus vs a ~DC-13 baseline (no DC threaded into v1's view).
+                save_bonus = int(foe.save_bonuses.get(sp.save_ability, 0))
+                p_fail = max(0.05, min(0.95, (13 - save_bonus) / 20.0))
+                ev = p_fail * sp.value
+            else:
+                ev = sp.value  # damaging/auto cantrip: value is its avg damage
+            if ev <= 0:
+                continue
+            if best_spell is None or (ev, -foe.current_hp, foe.id) > (
+                best_spell[0], -best_spell[2].current_hp, best_spell[2].id
+            ):
+                best_spell = (ev, sp, foe)
+    if best_spell is not None:
+        sp = best_spell[1]
+        foe = best_spell[2]
+        return Intent(
+            kind="cast",
+            target_id=foe.id,
+            spell_name=sp.name,
+            note=f"best spell {sp.name} on {foe.name} (EV {best_spell[0]:.1f})",
+        )
+
+    # 4. Move-to-reach: no attack/spell lands from here -> close on the best (lowest-HP) target
+    #    so next turn (the loop re-asks pick_action) the strike resolves. Needs the grid.
+    if view.attacks or view.spells:
+        best_reach = max(
+            [a.reach_ft for a in view.attacks] + [s.range_ft for s in view.spells] + [5]
+        )
+        target = _nearest_foe(view)
+        if target is not None:
+            cell = _step_toward(view, target, best_reach)
+            if cell is not None:
+                return Intent(
+                    kind="move",
+                    target_id=target.id,
+                    to_cell=cell,
+                    note=f"move toward {target.name} to get in reach",
+                )
+
+    # 5. Fallback: nothing productive reachable -> Dodge (defensive) rather than waste the turn.
+    return Intent(kind="dodge", note="no productive action reachable; Dodge")

--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -1,0 +1,407 @@
+"""Engine-run combat: the auto-sequencing loop (Track 2c/2e).
+
+See docs/roadmap/engine-combat-loop-design.md §3. This is the orchestrator that drives a
+fight by repeatedly asking the pure monster-AI (combat_ai.pick_action) what an actor wants,
+then applying that Intent through the EXISTING engine write verbs (server.attack /
+cast_spell / move_to_* / use_action / next_turn). It is NOT exposed as an MCP tool (to stay
+inside the 120 KB tool-schema budget — see qa/.../test_tool_schema_budget.py); it is a
+Python entry-point the engine-only combat smoke and tests call directly.
+
+SOLE-WRITER INVARIANT (load-bearing): this module introduces NO new write path. Every state
+change goes through one of server.py's existing verbs, each of which takes its own
+campaign_lock + save_campaign. The loop holds no lock and never mutates the Campaign — it
+only READS a snapshot to build the CombatView, and the verbs are the single mutating path.
+
+TWO MODES (owner-decided):
+  - mode="live": auto-run ONLY hostile (opposite-team) monster/NPC turns; STOP at the first
+    PC/companion turn and hand a per-round digest back to the DM. Companions + PCs stay
+    DM/agent-driven live.
+  - mode="test": run EVERYONE (random PCs + monsters) with no LLM, to a terminal state — the
+    trustworthy mechanical signal independent of the LLM scorer.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import combat_ai
+from combat_ai import AttackOption, CombatantView, CombatView, Intent
+
+# The two "sides". Party = the player-aligned team (PCs + companions); Enemy = monsters/NPCs.
+_PARTY_KINDS = ("player", "companion")
+_ENEMY_KINDS = ("monster", "npc")
+# In LIVE mode the loop auto-runs ONLY these kinds and STOPS at any other turn.
+_LIVE_AUTORUN_KINDS = _ENEMY_KINDS
+
+
+def _side_of(kind: str) -> str:
+    return "party" if kind in _PARTY_KINDS else "enemy"
+
+
+def _alive(ch) -> bool:
+    """A combatant still IN the fight: not dead and above 0 HP. A downed-but-not-dead PC at 0
+    HP is not 'alive' for victory detection (it can't act), matching the ADR's 'no living
+    combatants' terminal condition."""
+    return (not getattr(ch, "dead", False)) and int(getattr(ch, "current_hp", 0)) > 0
+
+
+def _living_sides(c) -> set:
+    """The set of sides ({'party','enemy'}) that still have a living combatant in the order."""
+    sides = set()
+    for cb in c.combat.order:
+        ch = c.characters.get(cb.character_id)
+        if ch is not None and _alive(ch):
+            sides.add(_side_of(ch.kind))
+    return sides
+
+
+# ── Build the read-only CombatView the AI decides over ───────────────────────────────
+
+def _pc_attack_options(server, ch) -> tuple[AttackOption, ...]:
+    """Synthesize a generic weapon strike for a PC/companion (TEST mode runs everyone). PCs
+    have no stat-block attack line, so we use the sheet-derived melee numbers (proficiency +
+    STR/finesse) and a longsword-equivalent 1d8 — enough to drive a TEST fight to a terminal
+    state and exercise the real attack() resolution path. (LIVE mode never auto-runs PCs.)"""
+    nums = server._combat_numbers(ch)
+    atk_bonus = int(nums.get("melee_attack_bonus", 0))
+    dmg_mod = int(nums.get("melee_damage_mod", 0))
+    expr = f"1d8{'+' + str(dmg_mod) if dmg_mod >= 0 else str(dmg_mod)}" if dmg_mod else "1d8"
+    return (AttackOption(name="Weapon", to_hit=atk_bonus, damage_expr=expr,
+                         damage_type="slashing", reach_ft=5),)
+
+
+def _monster_attack_options(server, ch, c) -> tuple[AttackOption, ...]:
+    """The actor's AUTHORITATIVE attack lines from its bestiary stat block (the same data the
+    DM sees), via server._monster_combat_entry. Falls back to the PC-style synthesis if no
+    stat block resolves, so a custom monster still acts."""
+    entry = server._monster_combat_entry(ch, c)
+    if entry is None or not entry.get("attacks"):
+        return _pc_attack_options(server, ch)
+    opts: list[AttackOption] = []
+    for a in entry["attacks"]:
+        rolls = tuple(a.get("damage_rolls") or ())
+        opts.append(AttackOption(
+            name=str(a.get("name", "Attack")),
+            to_hit=int(a.get("to_hit", 0)),
+            damage_expr=str(a.get("damage", "") or ""),
+            damage_type=str(a.get("damage_type", "") or ""),
+            damage_rolls=rolls,
+            reach_ft=5,  # PR-1 reach model: 5ft tokens (ranged gating is a later PR)
+        ))
+    return tuple(opts) if opts else _pc_attack_options(server, ch)
+
+
+def _build_view(server, c, actor) -> CombatView:
+    """Assemble the read-only CombatView for `actor` from the live Combat. READ-ONLY — touches
+    no state; the loop never mutates here."""
+    actor_side = _side_of(actor.kind)
+    actor_cb = next((cb for cb in c.combat.order if cb.character_id == actor.id), None)
+    actor_cell = (actor_cb.x, actor_cb.y) if (
+        actor_cb is not None and actor_cb.x is not None and actor_cb.y is not None
+    ) else None
+    actor_zone = actor_cb.zone if actor_cb is not None else ""
+
+    foes: list[CombatantView] = []
+    allies: list[CombatantView] = []
+    for cb in c.combat.order:
+        ch = c.characters.get(cb.character_id)
+        if ch is None or ch.id == actor.id or not _alive(ch):
+            continue
+        cell = (cb.x, cb.y) if (cb.x is not None and cb.y is not None) else None
+        ac, _ = server._effective_armor_class(ch)
+        cv = CombatantView(
+            id=ch.id, name=ch.name, side=_side_of(ch.kind),
+            current_hp=int(ch.current_hp), max_hp=int(ch.max_hp),
+            armor_class=int(ac), cell=cell, zone=cb.zone,
+        )
+        (foes if cv.side != actor_side else allies).append(cv)
+
+    if actor.kind in _ENEMY_KINDS:
+        attacks = _monster_attack_options(server, actor, c)
+    else:
+        attacks = _pc_attack_options(server, actor)
+
+    return CombatView(
+        actor_id=actor.id,
+        actor_cell=actor_cell,
+        actor_zone=actor_zone,
+        actor_side=actor_side,
+        speed=int(getattr(actor, "speed", 30)),
+        dashed=bool(actor_cb.dashed) if actor_cb is not None else False,
+        grid_enabled=bool(c.combat.grid_enabled),
+        grid_width=int(c.combat.grid_width),
+        grid_height=int(c.combat.grid_height),
+        cell_size=int(c.combat.grid_cell_size),
+        foes=tuple(foes),
+        allies=tuple(allies),
+        attacks=tuple(attacks),
+        spells=(),  # v1: weapon/natural attacks only; spell EV is a later increment
+    )
+
+
+# ── Apply an Intent via the EXISTING write verbs (the only mutating path) ────────────
+
+def _apply_intent(server, campaign_id: str, actor_id: str, intent: Intent) -> dict:
+    """Translate one Intent into existing-verb calls (sole writer). Degrades to a skip on any
+    engine refusal (out of reach / no slot / illegal) — the advisory-not-block posture the rest
+    of combat uses, so a bad Intent never crashes the loop. Returns a compact digest entry."""
+    entry: dict = {"actor_id": actor_id, "kind": intent.kind, "note": intent.note}
+    try:
+        if intent.kind == "attack":
+            opt = next(
+                (o for o in _view_cache.get(actor_id, ()) if o.name == intent.attack_name), None
+            )
+            kwargs = dict(
+                campaign_id=campaign_id, attacker_id=actor_id, target_id=intent.target_id,
+                attack_name=intent.attack_name,
+            )
+            if opt is not None and opt.damage_rolls:
+                kwargs["damage_rolls"] = [dict(r) for r in opt.damage_rolls]
+                kwargs["attack_bonus"] = opt.to_hit
+            elif opt is not None:
+                kwargs["attack_bonus"] = opt.to_hit
+                kwargs["damage_dice"] = opt.damage_expr or "1d4"
+                kwargs["damage_type"] = opt.damage_type
+            else:
+                # No cached option (defensive) — a minimal legal strike so the turn resolves.
+                kwargs["attack_bonus"] = 0
+                kwargs["damage_dice"] = "1d4"
+            res = server.attack(**kwargs)
+            dmg = res.get("damage")
+            dmg_applied = None
+            if isinstance(dmg, dict):
+                # multi-component surfaces applied_total; single-type surfaces total.
+                dmg_applied = dmg.get("applied_total", dmg.get("total"))
+            entry["result"] = {
+                "target": res.get("target"), "hit": res.get("hit"), "crit": res.get("crit"),
+                "damage": dmg_applied,
+                "target_state": res.get("target_state"),
+            }
+        elif intent.kind == "cast":
+            res = server.cast_spell(
+                campaign_id=campaign_id, character_id=actor_id,
+                spell_name=intent.spell_name, target_id=intent.target_id,
+            )
+            entry["result"] = {"spell": intent.spell_name, "target_id": intent.target_id}
+        elif intent.kind == "move":
+            if intent.to_cell is not None:
+                server.move_to_coords(campaign_id, actor_id, intent.to_cell[0], intent.to_cell[1])
+            elif intent.to_zone:
+                server.move_to_zone(campaign_id, combatant_id=actor_id, zone=intent.to_zone)
+            entry["result"] = {"to_cell": intent.to_cell, "to_zone": intent.to_zone}
+        elif intent.kind == "disengage":
+            server.use_action(campaign_id, actor_id, kind="disengage")
+            if intent.to_cell is not None:
+                server.move_to_coords(campaign_id, actor_id, intent.to_cell[0], intent.to_cell[1])
+            elif intent.to_zone:
+                server.move_to_zone(campaign_id, combatant_id=actor_id, zone=intent.to_zone)
+        elif intent.kind == "dash":
+            server.use_action(campaign_id, actor_id, kind="dash")
+        elif intent.kind == "dodge":
+            # No dedicated Dodge verb; spend the action as a 'skip' so the turn is legally used
+            # (the defensive benefit is narrative in v1). Keeps next_turn's PC-skip guard happy.
+            server.use_action(campaign_id, actor_id, kind="skip")
+        else:  # "skip"
+            server.use_action(campaign_id, actor_id, kind="skip")
+    except Exception as exc:  # advisory-not-block: degrade to a skip, record why
+        entry["error"] = str(exc)
+        try:
+            server.use_action(campaign_id, actor_id, kind="skip")
+        except Exception:
+            pass
+    return entry
+
+
+# Per-turn cache of the actor's attack options so _apply_intent can recover the damage spec
+# for the chosen attack_name without re-deriving. Set by run_combat_round before applying.
+_view_cache: dict = {}
+
+
+# ── The rounds ───────────────────────────────────────────────────────────────────────
+
+def run_combat_round(campaign_id: str, mode: str = "live", max_turns: int = 60) -> dict:
+    """Sequence combatants from the current turn to the end of the round.
+
+    mode="test": run EVERYONE via pick_action + the existing verbs.
+    mode="live": run ONLY hostile (monster/npc) turns; STOP at the first PC/companion turn and
+                 return {round_digest, awaiting_pc: <id>} so the DM resolves it.
+
+    Sole writer: every mutation goes through server.attack/cast_spell/move_to_*/use_action/
+    next_turn. The loop holds no lock. max_turns is a safety rail against a non-advancing order.
+    """
+    import server  # lazy: avoid a server->combat_loop import cycle at module load
+
+    if mode not in ("live", "test"):
+        raise ValueError("mode must be 'live' or 'test'")
+
+    digest: list[dict] = []
+    awaiting_pc: Optional[str] = None
+    start_round = None
+
+    for _ in range(max_turns):
+        c = server._require(campaign_id)
+        if not c.combat.active or not c.combat.order:
+            break
+        if start_round is None:
+            start_round = c.combat.round
+        # Stop once the round has advanced past the one we started (one round per call).
+        if c.combat.round > start_round and start_round is not None:
+            break
+
+        cur_id = c.combat.current_combatant_id
+        if cur_id is None:
+            break
+        actor = c.characters.get(cur_id)
+        if actor is None:
+            server.next_turn(campaign_id)
+            continue
+
+        # LIVE: stop at the first PC/companion turn — never auto-play them.
+        if mode == "live" and actor.kind not in _LIVE_AUTORUN_KINDS:
+            awaiting_pc = actor.id
+            break
+
+        # Dead/downed current combatant -> just advance.
+        if not _alive(actor):
+            server.next_turn(campaign_id)
+            continue
+
+        # One full turn for `actor`: ask the AI, apply, repeat for a Multiattack budget.
+        view = _build_view(server, c, actor)
+        _view_cache[actor.id] = view.attacks
+        # Multiattack budget: how many attack() strikes this actor's Attack action grants.
+        ma = max(1, server._attacker_multiattack_count(actor, c))
+        strikes_left = ma
+        acted = False
+        # Re-ask pick_action per granted strike (move-then-attack, or several strikes).
+        for _strike in range(max(1, ma) + 2):  # +2 headroom for a move then attacks
+            c = server._require(campaign_id)
+            actor = c.characters.get(cur_id)
+            if actor is None or not _alive(actor) or not c.combat.active:
+                break
+            if not _living_sides(c) or len(_living_sides(c)) < 2:
+                break  # fight is decided; stop issuing this actor's strikes
+            view = _build_view(server, c, actor)
+            _view_cache[actor.id] = view.attacks
+            intent = combat_ai.pick_action(actor, view)
+            entry = _apply_intent(server, campaign_id, actor.id, intent)
+            digest.append(entry)
+            acted = True
+            if intent.kind == "attack":
+                strikes_left -= 1
+                if strikes_left <= 0:
+                    break
+            elif intent.kind in ("skip", "dodge", "disengage"):
+                break
+            elif intent.kind == "move":
+                continue  # let the next iteration try to attack from the new cell
+            else:  # cast / dash
+                break
+
+        # Advance the turn (auto-resolves end-of-turn repeat saves). If the actor never acted,
+        # mark a skip first so next_turn's PC-skip guard (companions count) is satisfied.
+        c = server._require(campaign_id)
+        if c.combat.active and c.combat.current_combatant_id == cur_id:
+            if not acted:
+                try:
+                    server.use_action(campaign_id, cur_id, kind="skip")
+                except Exception:
+                    pass
+            try:
+                server.next_turn(campaign_id)
+            except Exception:
+                break
+        _view_cache.pop(cur_id, None)
+
+        # Stop the round if the fight is decided.
+        c = server._require(campaign_id)
+        if not c.combat.active or len(_living_sides(c)) < 2:
+            break
+
+    c = server._require(campaign_id)
+    living = _living_sides(c)
+    return {
+        "mode": mode,
+        "round": c.combat.round,
+        "round_digest": digest,
+        "awaiting_pc": awaiting_pc,
+        "combat_active": c.combat.active,
+        "living_sides": sorted(living),
+    }
+
+
+def run_combat_autonomous(campaign_id: str, mode: str = "test", max_rounds: int = 20) -> dict:
+    """Drive run_combat_round repeatedly to a terminal state (victory / defeat / round-cap).
+
+    mode="live": advance the fight up to the NEXT PC decision, then hand control back to the DM
+                 (returns the digest + awaiting_pc). Never auto-plays a PC.
+    mode="test": run the whole fight to a terminal state with no LLM (reproducible under
+                 WORLDOS_COMBAT_SEED).
+
+    Returns a rollup: {rounds, turns, victor, per-round digests, every combatant that acted,
+    round_cap_hit}. The round-cap is a safety rail against a non-terminating fight; it ends the
+    fight as a draw and flags round_cap_hit. Sole writer (only the round's verbs mutate)."""
+    import server  # lazy
+
+    if mode not in ("live", "test"):
+        raise ValueError("mode must be 'live' or 'test'")
+
+    rounds: list[dict] = []
+    actors_acted: set = set()
+    victor: Optional[str] = None
+    round_cap_hit = False
+    awaiting_pc: Optional[str] = None
+    turns = 0
+
+    for _ in range(max_rounds):
+        c = server._require(campaign_id)
+        if not c.combat.active:
+            break
+        living = _living_sides(c)
+        if len(living) < 2:
+            victor = next(iter(living)) if living else "draw"
+            break
+
+        rr = run_combat_round(campaign_id, mode)
+        rounds.append(rr)
+        for e in rr["round_digest"]:
+            actors_acted.add(e["actor_id"])
+            turns += 1
+
+        if mode == "live" and rr.get("awaiting_pc"):
+            awaiting_pc = rr["awaiting_pc"]
+            break
+
+        c = server._require(campaign_id)
+        living = _living_sides(c)
+        if not c.combat.active or len(living) < 2:
+            victor = next(iter(living)) if living else "draw"
+            break
+    else:
+        round_cap_hit = True
+
+    # Resolve a final victor read if we exited via a terminal side condition.
+    c = server._require(campaign_id)
+    living = _living_sides(c)
+    if victor is None and not awaiting_pc:
+        victor = next(iter(living)) if len(living) == 1 else ("draw" if round_cap_hit else None)
+
+    # TEST mode runs the fight to a terminal state -> close out combat so XP/cleanup fire.
+    ended = None
+    if mode == "test" and victor is not None and victor != "draw":
+        try:
+            ended = server.end_combat(campaign_id, resolution=f"{victor} victorious (engine-run test)")
+        except Exception as exc:
+            ended = {"error": str(exc)}
+
+    return {
+        "mode": mode,
+        "rounds": len(rounds),
+        "turns": turns,
+        "victor": victor,
+        "awaiting_pc": awaiting_pc,
+        "round_cap_hit": round_cap_hit,
+        "actors_acted": sorted(actors_acted),
+        "round_digests": rounds,
+        "end_combat": ended,
+    }

--- a/servers/engine/dice.py
+++ b/servers/engine/dice.py
@@ -8,11 +8,45 @@ reproducible for tests and replay.
 
 from __future__ import annotations
 
+import os
 import random
 import re
 from dataclasses import dataclass, field
 
 _TERM = re.compile(r"(\d*)d(\d+)(kh\d+|kl\d+)?$")
+
+# ── Process-level RNG (Track 2b — deterministic combat seed) ─────────────────────────
+# A SINGLE module-level random.Random the engine draws from whenever roll() is called
+# WITHOUT an explicit per-call `seed`. This is the correct way to make a *sequence* of
+# rolls reproducible: a per-call seed would re-seed before every roll and collapse every
+# draw to the same constant (a degenerate fight). One shared stream, seeded once, means
+# "same seed -> same fight" while each individual roll is still a fresh draw.
+#
+# ADDITIVE / default-off: when WORLDOS_COMBAT_SEED is unset, the stream is seeded from
+# random.Random(None) — i.e. OS entropy, byte-identical to today's non-deterministic
+# random.Random(seed=None) behaviour. The env seed is a TEST affordance only (the TEST
+# combat loop sets it); it does NOT need the sandbox guard because a deterministic seed in
+# a live game is harmless — it only fixes WHICH dice come up, it never bends an outcome.
+def _initial_seed() -> int | None:
+    raw = os.environ.get("WORLDOS_COMBAT_SEED")
+    if raw is None or raw == "":
+        return None
+    try:
+        return int(raw)
+    except ValueError:
+        # A non-integer seed is hashed to a stable int so any string still seeds reproducibly.
+        return abs(hash(raw)) % (2**31)
+
+
+_PROCESS_RNG = random.Random(_initial_seed())
+
+
+def reseed_process_rng(seed: int | None) -> None:
+    """Reseed the shared process-level dice stream (TEST affordance). Passing an int makes
+    the subsequent sequence of un-seeded rolls reproducible; passing None reseeds from OS
+    entropy. Used by the engine-only combat smoke / TEST loop to fix a whole fight. No effect
+    on any roll that passes an explicit per-call `seed`."""
+    _PROCESS_RNG.seed(seed)
 
 # Bounds on a single dice term. Real D&D never needs more (a high-level fireball is
 # ~20d6; d100 is the largest standard die), so these never affect legitimate rolls —
@@ -53,7 +87,11 @@ def roll(
     if advantage and disadvantage:
         advantage = disadvantage = False
 
-    rng = random.Random(seed)
+    # An explicit per-call seed keeps its old meaning (a self-contained reproducible single
+    # roll — used by unit tests). With NO per-call seed, draw from the shared process-level
+    # stream so a *sequence* of rolls is reproducible under WORLDOS_COMBAT_SEED without every
+    # roll collapsing to a constant. Unset env -> _PROCESS_RNG is OS-entropy seeded == today.
+    rng = random.Random(seed) if seed is not None else _PROCESS_RNG
     expr = expression.replace(" ", "").lower().replace("d%", "d100")
     if not expr:
         raise ValueError("empty dice expression")
@@ -138,3 +176,52 @@ def roll(
         crit=crit,
         fumble=fumble,
     )
+
+
+def average_total(expression: str) -> int:
+    """The deterministic EXPECTED average total of a dice expression, rounded to nearest int.
+
+    Each NdM term contributes N*(M+1)/2 (the mean of N dM dice); flat modifiers add as-is.
+    keep-highest/lowest (khN/klN) terms fall back to the per-die mean over the kept count
+    (an approximation — the engine never crit-doubles a keep term, so this is only ever hit by
+    a plain damage expression). Pure / I/O-free. Used by the TEST-only fast_resolve path so a
+    sandbox fight resolves in a predictable number of rounds; never on a live game (guarded).
+
+    Mirrors roll()'s term grammar exactly so the two stay in lockstep; raises the same
+    ValueErrors on a malformed/oversized expression so fast_resolve can't smuggle a bad expr."""
+    expr = expression.replace(" ", "").lower().replace("d%", "d100")
+    if not expr:
+        raise ValueError("empty dice expression")
+    if len(expr) > _MAX_EXPRESSION_CHARS:
+        raise ValueError(f"dice expression must be <= {_MAX_EXPRESSION_CHARS} characters")
+    terms = re.findall(r"[+-]?[^+-]+", expr)
+    total = 0.0
+    for term in terms:
+        sign = -1 if term.startswith("-") else 1
+        body = term.lstrip("+-")
+        m = _TERM.fullmatch(body)
+        if m:
+            n = int(m.group(1) or 1)
+            sides = int(m.group(2))
+            keep = m.group(3)
+            if n == 0:
+                raise ValueError(f"die count must be >= 1: {term!r}")
+            if n > _MAX_DICE:
+                raise ValueError(f"die count must be <= {_MAX_DICE}: {term!r}")
+            if sides < 1 or sides > _MAX_SIDES:
+                raise ValueError(f"die sides must be 1..{_MAX_SIDES}: {term!r}")
+            per_die = (sides + 1) / 2.0
+            count = n
+            if keep:
+                k = int(keep[2:])
+                if k > n:
+                    raise ValueError(f"cannot keep {k} of {n} dice: {term!r}")
+                count = k  # approximate: mean per die over the kept count
+            total += sign * per_die * count
+        else:
+            try:
+                val = int(body)
+            except ValueError as exc:
+                raise ValueError(f"bad dice term: {term!r}") from exc
+            total += sign * val
+    return int(round(total))

--- a/servers/engine/dice.py
+++ b/servers/engine/dice.py
@@ -16,17 +16,19 @@ from dataclasses import dataclass, field
 _TERM = re.compile(r"(\d*)d(\d+)(kh\d+|kl\d+)?$")
 
 # ── Process-level RNG (Track 2b — deterministic combat seed) ─────────────────────────
-# A SINGLE module-level random.Random the engine draws from whenever roll() is called
-# WITHOUT an explicit per-call `seed`. This is the correct way to make a *sequence* of
-# rolls reproducible: a per-call seed would re-seed before every roll and collapse every
-# draw to the same constant (a degenerate fight). One shared stream, seeded once, means
-# "same seed -> same fight" while each individual roll is still a fresh draw.
+# When a deterministic seed is ACTIVE (WORLDOS_COMBAT_SEED set at import, or reseed_process_rng(int)
+# called by the engine-only combat smoke / TEST loop), roll() draws every un-seeded roll from a
+# SINGLE module-level stream so a *sequence* of rolls is reproducible — "same seed -> same fight".
+# (A per-call seed would re-seed before every roll and collapse every draw to a constant, so the
+# shared stream is the correct mechanism for sequence-reproducibility.)
 #
-# ADDITIVE / default-off: when WORLDOS_COMBAT_SEED is unset, the stream is seeded from
-# random.Random(None) — i.e. OS entropy, byte-identical to today's non-deterministic
-# random.Random(seed=None) behaviour. The env seed is a TEST affordance only (the TEST
-# combat loop sets it); it does NOT need the sandbox guard because a deterministic seed in
-# a live game is harmless — it only fixes WHICH dice come up, it never bends an outcome.
+# ADDITIVE / default-off (LOAD-BEARING — "empty == today"): when NO seed is active — i.e.
+# WORLDOS_COMBAT_SEED is unset and reseed_process_rng(int) was never called — roll() WITHOUT a
+# per-call seed falls back to a fresh random.Random() PER CALL, byte-identical to the pre-Track-2b
+# behaviour (each roll independently OS-entropy seeded). The shared stream is never touched in a
+# normal live game; it exists only when a TEST explicitly activates a seed. (A deterministic seed
+# needs no sandbox guard — it only fixes WHICH dice come up, never an outcome — but it must not
+# silently change the production RNG mechanism, hence the _SEED_ACTIVE gate below.)
 def _initial_seed() -> int | None:
     raw = os.environ.get("WORLDOS_COMBAT_SEED")
     if raw is None or raw == "":
@@ -39,13 +41,19 @@ def _initial_seed() -> int | None:
 
 
 _PROCESS_RNG = random.Random(_initial_seed())
+# True only when a deterministic seed is in effect (env set at import, or reseed_process_rng(int)).
+# When False (the live-game default), un-seeded rolls use a fresh per-call RNG == pre-Track-2b.
+_SEED_ACTIVE = _initial_seed() is not None
 
 
 def reseed_process_rng(seed: int | None) -> None:
-    """Reseed the shared process-level dice stream (TEST affordance). Passing an int makes
-    the subsequent sequence of un-seeded rolls reproducible; passing None reseeds from OS
-    entropy. Used by the engine-only combat smoke / TEST loop to fix a whole fight. No effect
-    on any roll that passes an explicit per-call `seed`."""
+    """Reseed the shared process-level dice stream (TEST affordance). Passing an int ACTIVATES the
+    deterministic stream and makes the subsequent sequence of un-seeded rolls reproducible; passing
+    None DEACTIVATES it (un-seeded rolls return to fresh per-call OS entropy — the live default, so a
+    seeded TEST never leaks determinism into a later un-seeded run). Used by the engine-only combat
+    smoke / TEST loop to fix a whole fight. No effect on any roll that passes an explicit per-call `seed`."""
+    global _SEED_ACTIVE
+    _SEED_ACTIVE = seed is not None
     _PROCESS_RNG.seed(seed)
 
 # Bounds on a single dice term. Real D&D never needs more (a high-level fireball is
@@ -87,11 +95,11 @@ def roll(
     if advantage and disadvantage:
         advantage = disadvantage = False
 
-    # An explicit per-call seed keeps its old meaning (a self-contained reproducible single
-    # roll — used by unit tests). With NO per-call seed, draw from the shared process-level
-    # stream so a *sequence* of rolls is reproducible under WORLDOS_COMBAT_SEED without every
-    # roll collapsing to a constant. Unset env -> _PROCESS_RNG is OS-entropy seeded == today.
-    rng = random.Random(seed) if seed is not None else _PROCESS_RNG
+    # An explicit per-call seed keeps its old meaning (a self-contained reproducible single roll —
+    # used by unit tests). With NO per-call seed: if a deterministic seed is ACTIVE (a TEST), draw
+    # from the shared process-level stream so a *sequence* is reproducible without collapsing to a
+    # constant; otherwise (the live default) use a fresh per-call RNG == pre-Track-2b behaviour.
+    rng = random.Random(seed) if seed is not None else (_PROCESS_RNG if _SEED_ACTIVE else random.Random())
     expr = expression.replace(" ", "").lower().replace("d%", "d100")
     if not expr:
         raise ValueError("empty dice expression")

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1545,6 +1545,20 @@ class HouseRules(_StrictModel):
     # with enforce_sell_cap, rejected). SRD has no buy-back economy, so this is a sanity
     # rail, not a rule: 1.0× = list price. Default 2.0 catches gross fat-finger overprices.
     sell_cap_multiple: float = 2.0
+    # ── TEST-ONLY combat toggles (Track 2b — engine-run combat core) ─────────────────
+    # Both are GUARDED in attack(): they fire ONLY when the process is in combat-test mode
+    # (env WORLDOS_COMBAT_TEST=1 AND Campaign.is_sandbox). Outside that double guard they are
+    # DEAD CODE — byte-identical to today — so they can NEVER affect a live (non-sandbox) game.
+    # See docs/roadmap/engine-combat-loop-design.md §4. Additive: an old snapshot loads both False.
+    #
+    # force_hit forces the HIT BOOLEAN only (the natural die is still rolled + read, so crit/
+    # fumble/crit-doubling stay honest — it is NOT a synthesized nat-20). This makes a TEST fight
+    # resolve to a terminal state without depending on the dice landing hits.
+    force_hit: bool = False  # TEST-ONLY (sandbox-guarded): the attack roll auto-hits
+    # fast_resolve averages the (post-crit-doubled) damage dice instead of rolling them, so a TEST
+    # fight resolves in a predictable number of rounds. Only changes damage MAGNITUDE, never
+    # whether a hit lands or whether a crit happened.
+    fast_resolve: bool = False  # TEST-ONLY (sandbox-guarded): damage = average instead of rolled
 
 
 class SeedParams(_StrictModel):
@@ -1963,6 +1977,14 @@ class Campaign(_StrictModel):
     # "what engine version was this campaign last written by". Pairs with the #165 tolerant load.
     schema_version: int = 1
     engine_sha: str = ""
+
+    # ── TEST-ONLY sandbox flag (Track 2b — engine-run combat core) ───────────────────
+    # The structural half of the combat-test DOUBLE GUARD (env WORLDOS_COMBAT_TEST=1 AND this
+    # flag). Set ONLY by the engine-only combat-smoke pre-seed (a sandbox campaign), NEVER by any
+    # live-play tool — so the force_hit/fast_resolve TEST toggles are structurally unreachable in a
+    # real game even if the env happened to be set. Additive default False == today; an old
+    # snapshot round-trips to False. See docs/roadmap/engine-combat-loop-design.md §4a.
+    is_sandbox: bool = False
 
     current_location_id: Optional[str] = None
     day: int = 1  # in-world day counter

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -11857,7 +11857,20 @@ def set_house_rules(campaign_id: str, patch: dict) -> dict:
     flanking_advantage, slow_natural_healing, feats_allowed, multiclass_allowed,
     dm_can_fudge, wandering_encounters, enforce_sell_cap, sell_cap_multiple (F09-9:
     when enforce_sell_cap is on, sell_item rejects a price above sell_cap_multiple× the
-    item's listed cost). Unknown keys are rejected."""
+    item's listed cost). Unknown keys are rejected. The TEST-only combat toggles
+    (force_hit, fast_resolve) are ALSO rejected here — they are settable only by the
+    engine-only combat smoke / TEST loop (behind the WORLDOS_COMBAT_TEST + sandbox guard),
+    never via this live-play tool."""
+    # Defense-in-depth: force_hit/fast_resolve are real HouseRules fields, so Pydantic's
+    # extra="forbid" does NOT reject them on this patch path. Reject them explicitly so the
+    # documented whitelist is enforced and a live tool can never even *persist* a TEST toggle.
+    _test_only = {"force_hit", "fast_resolve"}
+    blocked = sorted(_test_only.intersection(patch or {}))
+    if blocked:
+        raise ValueError(
+            f"house-rule key(s) {blocked} are TEST-only and cannot be set via set_house_rules; "
+            "they apply only under the engine-only combat smoke."
+        )
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         data = c.house_rules.model_dump()

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -5269,6 +5269,40 @@ def _effective_armor_class(ch: Character) -> tuple[int, dict | None]:
     return ac, detail
 
 
+def _combat_test_mode_enabled(c: "Campaign") -> bool:
+    """The DOUBLE GUARD for the TEST-ONLY combat toggles (force_hit / fast_resolve).
+
+    Returns True ONLY when BOTH halves hold: the env opt-in WORLDOS_COMBAT_TEST=1 AND the
+    campaign carries Campaign.is_sandbox. Either alone is not enough — a production deployment
+    never sets the env, and a real campaign never carries the sandbox flag (it is set only by
+    the engine-only combat-smoke pre-seed). When this returns False the toggles are DEAD CODE:
+    `if hr.force_hit and _combat_test_mode_enabled(c)` short-circuits, so a force_hit/fast_resolve
+    value on a live (non-sandbox) campaign changes NOTHING. See the ADR §4a; the dead-code-when-off
+    invariant is proven by tests/test_combat_core.py. Belt-and-suspenders by design — the headline
+    risk is force_hit corrupting a real game, so the guard is STRUCTURAL, not merely defaulted off."""
+    return os.environ.get("WORLDOS_COMBAT_TEST") == "1" and bool(getattr(c, "is_sandbox", False))
+
+
+def _resolve_damage_roll(expression: str, fast_resolve: bool) -> "dice_mod.DiceRoll":
+    """Resolve a DAMAGE expression to a DiceRoll. The default path rolls it (today's behavior).
+    When `fast_resolve` is True (TEST-only, already double-guarded by the caller), it returns a
+    synthetic DiceRoll whose total is the deterministic AVERAGE of the expression instead of a
+    random draw — so a sandbox fight resolves in a predictable number of rounds. The expression
+    passed in is ALREADY crit-doubled when the strike crit (the caller doubles the dice first),
+    so averaging preserves the crit-doubling magnitude. Average only changes the damage NUMBER;
+    it never changes whether a hit landed or whether a crit happened. Reuses dice.average_total
+    so the term grammar stays single-sourced with roll()."""
+    if not fast_resolve:
+        return dice_mod.roll(expression)
+    avg = dice_mod.average_total(expression)
+    return dice_mod.DiceRoll(
+        expression=expression,
+        total=avg,
+        rolls=[],
+        detail=f"{expression} = {avg} (avg, fast_resolve)",
+    )
+
+
 @mcp.tool()
 def attack(
     campaign_id: str,
@@ -5477,6 +5511,16 @@ def attack(
         atk_total = atk.total + rider_bonus + guided_bonus
         target_ac, target_ac_detail = _effective_armor_class(target)
         hit = atk.crit or (not atk.fumble and atk_total >= target_ac)
+        # TEST-ONLY force_hit (Track 2b — DOUBLE-GUARDED): force the HIT BOOLEAN only so a
+        # sandbox fight resolves to a terminal state without depending on the dice landing hits.
+        # CRUCIALLY this does NOT touch the natural die: `is_crit`/`crit_source`/crit-doubling
+        # below still read atk.crit/atk.natural, so a forced hit on a natural non-20 stays a
+        # NORMAL hit (it is not a synthesized nat-20) and crit/damage accounting stays honest.
+        # DEAD CODE outside the guard — a force_hit value on a live (non-sandbox) campaign, or
+        # with the env unset, changes nothing here. Parry/auto-crit-vs-helpless run unchanged
+        # afterwards (a defender may still legitimately spend a reaction to turn the blow aside).
+        if c.house_rules.force_hit and _combat_test_mode_enabled(c):
+            hit = True
         # PARRY (#218): a defender with an available defensive reaction (+N AC vs one melee
         # attack it can see) turns the blow aside — but ONLY when doing so FLIPS this hit to a
         # miss. The engine never wastes the reaction on a crit it can't stop or a blow that
@@ -5650,6 +5694,12 @@ def attack(
                     "amount": man_total,
                     "type": man_bonus.damage_type or damage_type,
                 }
+            # TEST-ONLY fast_resolve (Track 2b — DOUBLE-GUARDED): average the damage dice
+            # instead of rolling, so a sandbox fight resolves in a predictable number of rounds.
+            # DEAD CODE outside the guard (a fast_resolve value on a live campaign / env unset
+            # leaves the random roll path exactly as today). Computed once; threaded into the
+            # per-component and single-type damage rolls below via _resolve_damage_roll.
+            _fast_resolve = c.house_rules.fast_resolve and _combat_test_mode_enabled(c)
             if damage_rolls or man_part is not None:
                 # MULTI-COMPONENT (#210): roll + crit-double EACH component on its own
                 # dice, then apply per-type resistance/immunity/vulnerability per
@@ -5669,7 +5719,7 @@ def attack(
                     if not cd:
                         continue
                     cexpr = combat.double_dice(cd) if is_crit else cd
-                    cdmg = dice_mod.roll(cexpr)
+                    cdmg = _resolve_damage_roll(cexpr, _fast_resolve)
                     ctotal = max(0, cdmg.total)
                     comp_results.append(
                         {"type": ct, "total": ctotal, "expr": cexpr, "detail": cdmg.detail}
@@ -5709,7 +5759,7 @@ def attack(
                 }
             else:
                 expr = combat.double_dice(damage_dice) if is_crit else damage_dice
-                dmg = dice_mod.roll(expr)
+                dmg = _resolve_damage_roll(expr, _fast_resolve)
                 outcome = combat.apply_damage(target, max(0, dmg.total), crit=is_crit, damage_type=damage_type)
                 result["damage"] = {"total": max(0, dmg.total), "type": damage_type, "expr": expr, "detail": dmg.detail}
             if man_bonus is not None:

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -11857,10 +11857,8 @@ def set_house_rules(campaign_id: str, patch: dict) -> dict:
     flanking_advantage, slow_natural_healing, feats_allowed, multiclass_allowed,
     dm_can_fudge, wandering_encounters, enforce_sell_cap, sell_cap_multiple (F09-9:
     when enforce_sell_cap is on, sell_item rejects a price above sell_cap_multiple× the
-    item's listed cost). Unknown keys are rejected. The TEST-only combat toggles
-    (force_hit, fast_resolve) are ALSO rejected here — they are settable only by the
-    engine-only combat smoke / TEST loop (behind the WORLDOS_COMBAT_TEST + sandbox guard),
-    never via this live-play tool."""
+    item's listed cost). Unknown keys are rejected, as are the TEST-only
+    toggles force_hit/fast_resolve."""
     # Defense-in-depth: force_hit/fast_resolve are real HouseRules fields, so Pydantic's
     # extra="forbid" does NOT reject them on this patch path. Reject them explicitly so the
     # documented whitelist is enforced and a live tool can never even *persist* a TEST toggle.

--- a/servers/engine/tests/test_combat_core.py
+++ b/servers/engine/tests/test_combat_core.py
@@ -360,3 +360,53 @@ def test_new_fields_default_off_and_round_trip(tmp_path, monkeypatch):
     reloaded = server._require(cid)
     assert reloaded.is_sandbox is False
     assert reloaded.house_rules.force_hit is False
+
+
+def test_unseeded_live_rolls_do_not_consume_the_shared_stream(monkeypatch):
+    """Default-off / 'empty == today' (LOAD-BEARING): with NO active seed — the live-game default —
+    an un-seeded roll uses a fresh per-call RNG and must NOT advance the shared process stream. This
+    pins the additive invariant (a production game's dice mechanism is byte-identical to pre-Track-2b)
+    AND guarantees a seeded TEST cannot leak determinism into a later un-seeded (live) run."""
+    monkeypatch.delenv("WORLDOS_COMBAT_SEED", raising=False)
+    dice_mod.reseed_process_rng(None)               # deactivate -> live default
+    assert dice_mod._SEED_ACTIVE is False
+    before = dice_mod._PROCESS_RNG.getstate()
+    for _ in range(20):
+        dice_mod.roll("1d20")                       # un-seeded, live-default rolls
+    assert dice_mod._PROCESS_RNG.getstate() == before   # the shared stream was NOT consumed
+
+
+def test_active_seed_consumes_shared_stream_and_is_reproducible():
+    """When a seed is ACTIVE (a TEST), un-seeded rolls DRAW from the shared stream and the sequence
+    is reproducible — the Track-2b feature. Restores the live default at the end so no later test
+    inherits an active seed."""
+    try:
+        dice_mod.reseed_process_rng(777)
+        assert dice_mod._SEED_ACTIVE is True
+        before = dice_mod._PROCESS_RNG.getstate()
+        dice_mod.roll("1d20")
+        assert dice_mod._PROCESS_RNG.getstate() != before   # active -> the shared stream advances
+        dice_mod.reseed_process_rng(777)
+        a = [dice_mod.roll("1d20").total for _ in range(8)]
+        dice_mod.reseed_process_rng(777)
+        b = [dice_mod.roll("1d20").total for _ in range(8)]
+        assert a == b
+    finally:
+        dice_mod.reseed_process_rng(None)           # restore the live default
+
+
+def test_set_house_rules_rejects_test_only_toggles(tmp_path, monkeypatch):
+    """Defense-in-depth: the live set_house_rules tool REJECTS the TEST-only combat toggles
+    (force_hit/fast_resolve) — real HouseRules fields that Pydantic's extra='forbid' would otherwise
+    accept — so a live tool can never even persist a TEST toggle. A normal house rule still applies."""
+    import pytest
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    cid = server.create_campaign("HR")["id"]
+    for bad in ({"force_hit": True}, {"fast_resolve": True}, {"difficulty": "hard", "force_hit": True}):
+        with pytest.raises(ValueError, match="TEST-only"):
+            server.set_house_rules(cid, bad)
+    # the rejected patches never persisted; a normal patch still works and the toggles stay OFF
+    hr = server.set_house_rules(cid, {"difficulty": "hard"})
+    assert hr["difficulty"] == "hard"
+    assert hr.get("force_hit") is False and hr.get("fast_resolve") is False

--- a/servers/engine/tests/test_combat_core.py
+++ b/servers/engine/tests/test_combat_core.py
@@ -1,0 +1,362 @@
+"""Engine-run combat CORE tests (Track 2b/2c/2e).
+
+Covers the four net-new pieces of the engine-run combat loop:
+  - combat_ai.pick_action: the pure greedy-v1 EV policy returns sane Intents.
+  - combat_loop.run_combat_autonomous(mode="test"): a seeded random-vs-random fight runs to a
+    terminal state and EVERY combatant acted.
+  - combat_loop.run_combat_round/autonomous(mode="live"): auto-runs ONLY hostiles, STOPS at the
+    first PC/companion turn, never auto-plays a PC.
+  - the TEST toggles (force_hit / fast_resolve) are DEAD CODE outside the double guard, force the
+    HIT BOOLEAN without corrupting crit/damage accounting, and the dice-seed is deterministic.
+
+All of this is LLM-free, so it runs in the fast deterministic lane. Default-off is asserted: a
+non-sandbox campaign with no env behaves exactly as today.
+"""
+from __future__ import annotations
+
+import dice as dice_mod
+import combat_ai
+from combat_ai import AttackOption, CombatantView, CombatView, Intent, p_hit
+import combat_loop
+import store
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────────────
+
+def _mk_view(actor_attacks, foes, grid=False, actor_cell=None, **kw) -> CombatView:
+    return CombatView(
+        actor_id="A",
+        actor_cell=actor_cell,
+        actor_zone="",
+        actor_side="enemy",
+        speed=kw.get("speed", 30),
+        dashed=False,
+        grid_enabled=grid,
+        grid_width=kw.get("w", 10),
+        grid_height=kw.get("h", 10),
+        cell_size=5,
+        foes=tuple(foes),
+        allies=(),
+        attacks=tuple(actor_attacks),
+        spells=tuple(kw.get("spells", ())),
+    )
+
+
+def _foe(fid, hp=10, ac=12, cell=None, name=None):
+    return CombatantView(id=fid, name=name or fid, side="party",
+                         current_hp=hp, max_hp=hp, armor_class=ac, cell=cell)
+
+
+# ── p_hit / EV math ────────────────────────────────────────────────────────────────
+
+def test_p_hit_curve_and_clamps():
+    assert p_hit(5, 15) == 0.55          # need 10+, 11 faces hit
+    assert p_hit(0, 25) == 0.05          # impossible but for the nat-20 floor
+    assert p_hit(20, 5) == 0.95          # auto but for the nat-1 ceiling (NOT 1.0)
+    # monotone: a higher bonus never lowers the chance
+    assert p_hit(7, 15) >= p_hit(5, 15)
+
+
+def test_average_total_matches_expected():
+    assert dice_mod.average_total("2d8+3") == 12      # 2*4.5 + 3
+    assert dice_mod.average_total("1d6") == 4          # round(3.5)
+    assert dice_mod.average_total("5") == 5            # flat
+    assert dice_mod.average_total("2d6") == 7
+
+
+# ── pick_action: greedy-v1 returns sane Intents ──────────────────────────────────────
+
+def test_pick_action_attacks_best_in_reach_target():
+    # Two foes; the AI should focus-fire the LOWER-HP one on an EV tie (same AC).
+    atks = [AttackOption(name="Claw", to_hit=5, damage_expr="2d6+3", damage_type="slashing")]
+    view = _mk_view(atks, [_foe("lo", hp=5, ac=12), _foe("hi", hp=40, ac=12)])
+    intent = combat_ai.pick_action(actor=object(), combat_state=view)
+    assert intent.kind == "attack"
+    assert intent.target_id == "lo"            # focus-fire the weaker foe
+    assert intent.attack_name == "Claw"
+
+
+def test_pick_action_prefers_higher_ev_attack():
+    # Big-damage low-accuracy vs small-damage high-accuracy against one foe (AC 15).
+    atks = [
+        AttackOption(name="Heavy", to_hit=0, damage_expr="4d6", damage_type="b"),    # P~0.30 * 14
+        AttackOption(name="Quick", to_hit=10, damage_expr="1d6", damage_type="b"),   # P~0.80 * 4
+    ]
+    view = _mk_view(atks, [_foe("t", hp=30, ac=15)])
+    intent = combat_ai.pick_action(actor=object(), combat_state=view)
+    assert intent.kind == "attack"
+    # Heavy EV ~ 0.30*14 = 4.2 ; Quick EV ~ 0.80*3.5 = 2.8 -> Heavy wins.
+    assert intent.attack_name == "Heavy"
+
+
+def test_pick_action_skips_when_no_foes():
+    intent = combat_ai.pick_action(actor=object(), combat_state=_mk_view([], []))
+    assert intent.kind == "skip"
+
+
+def test_pick_action_moves_to_reach_on_grid_when_out_of_range():
+    # On the grid, a melee attacker far from its foe should MOVE toward it (not attack).
+    atks = [AttackOption(name="Bite", to_hit=4, damage_expr="1d8", reach_ft=5)]
+    view = _mk_view(atks, [_foe("t", cell=(8, 0))], grid=True, actor_cell=(0, 0))
+    intent = combat_ai.pick_action(actor=object(), combat_state=view)
+    assert intent.kind == "move"
+    assert intent.to_cell is not None
+    # the chosen cell is strictly closer to the foe than the start
+    import combat_grid
+    assert combat_grid.distance_ft(intent.to_cell, (8, 0)) < combat_grid.distance_ft((0, 0), (8, 0))
+
+
+def test_pick_action_attacks_in_reach_on_grid():
+    atks = [AttackOption(name="Bite", to_hit=4, damage_expr="1d8", reach_ft=5)]
+    view = _mk_view(atks, [_foe("t", cell=(1, 0))], grid=True, actor_cell=(0, 0))
+    intent = combat_ai.pick_action(actor=object(), combat_state=view)
+    assert intent.kind == "attack"
+    assert intent.target_id == "t"
+
+
+def test_pick_action_dodges_when_nothing_reachable_no_grid_path():
+    # Grid, foe far, but speed 0 -> cannot move, cannot reach -> Dodge fallback.
+    atks = [AttackOption(name="Bite", to_hit=4, damage_expr="1d8", reach_ft=5)]
+    view = _mk_view(atks, [_foe("t", cell=(9, 9))], grid=True, actor_cell=(0, 0), speed=0)
+    intent = combat_ai.pick_action(actor=object(), combat_state=view)
+    assert intent.kind == "dodge"
+
+
+def test_pick_action_is_deterministic():
+    atks = [AttackOption(name="Claw", to_hit=5, damage_expr="2d6+3")]
+    foes = [_foe("a", hp=10, ac=12), _foe("b", hp=10, ac=12)]
+    v = _mk_view(atks, foes)
+    i1 = combat_ai.pick_action(actor=object(), combat_state=v)
+    i2 = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert i1 == i2   # same state -> same Intent (frozen dataclass equality)
+
+
+# ── run_combat_autonomous(mode="test"): seeded random-vs-random to a terminal state ──
+
+def _seed_fight(server, store_mod, *, sandbox=True, monsters=3):
+    cid = server.create_campaign("Core Test")["id"]
+    server.add_location(campaign_id=cid, name="Pit", description="x", make_current=True)
+    c = server._require(cid)
+    c.is_sandbox = sandbox
+    store_mod.save_campaign(c)
+    hero = server.create_character(
+        cid, "Hero", kind="player", race="human", class_name="fighter", level=4,
+        abilities={"strength": 18, "dexterity": 14, "constitution": 16,
+                   "intelligence": 10, "wisdom": 12, "charisma": 10},
+        apply_srd_defaults=True,
+    )["id"]
+    mons = [m["id"] for m in server.spawn_monster(cid, "Goblin", count=monsters)["spawned"]]
+    server.start_combat(cid, [hero] + mons)
+    return cid, hero, mons
+
+
+def test_run_combat_autonomous_test_runs_to_terminal_and_everyone_acted(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    dice_mod.reseed_process_rng(4242)
+    cid, hero, mons = _seed_fight(server, store)
+    res = combat_loop.run_combat_autonomous(cid, mode="test", max_rounds=25)
+    # terminal: a victor or a draw (never left mid-fight in test mode)
+    assert res["victor"] in ("party", "enemy", "draw")
+    assert res["round_cap_hit"] is False
+    # EVERY combatant got at least one turn
+    assert set(res["actors_acted"]) == set([hero] + mons), res["actors_acted"]
+    # combat closed out (end_combat fired on a decisive result)
+    assert res["turns"] > 0
+
+
+def test_dice_seed_is_deterministic(tmp_path, monkeypatch):
+    """Same seed -> byte-identical fight outcome; the seed fixes the whole sequence."""
+    import server
+
+    def _run(seed):
+        dice_mod.reseed_process_rng(seed)
+        cid, hero, mons = _seed_fight(server, store)
+        return combat_loop.run_combat_autonomous(cid, mode="test", max_rounds=25)
+
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path / "a"))
+    r1 = _run(909)
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path / "b"))
+    r2 = _run(909)
+    assert (r1["victor"], r1["rounds"], r1["turns"]) == (r2["victor"], r2["rounds"], r2["turns"])
+
+
+def test_unset_seed_is_nondeterministic_path(tmp_path, monkeypatch):
+    """An unset seed reseeds from OS entropy (today's behavior). We can't assert two fights
+    DIFFER (they might coincide), but we CAN assert reseed(None) draws fresh entropy: two
+    long roll sequences after reseed(None) are extremely unlikely to be identical."""
+    dice_mod.reseed_process_rng(None)
+    seq_a = [dice_mod.roll("1d20").natural for _ in range(50)]
+    dice_mod.reseed_process_rng(None)
+    seq_b = [dice_mod.roll("1d20").natural for _ in range(50)]
+    assert seq_a != seq_b  # OS entropy -> distinct streams (P(collision) ~ 20^-50)
+
+
+# ── LIVE mode: auto-run hostiles, STOP at the first PC/companion turn ─────────────────
+
+def test_live_mode_stops_at_pc_and_never_autoplays_pc(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    # Force the PC to act first by giving it an absurd initiative bonus via a high DEX is
+    # unreliable; instead just assert the invariant over any initiative order.
+    dice_mod.reseed_process_rng(11)
+    cid, hero, mons = _seed_fight(server, store, monsters=2)
+    res = combat_loop.run_combat_autonomous(cid, mode="live", max_rounds=25)
+    # The PC is NEVER in actors_acted in live mode (only hostiles auto-run).
+    assert hero not in res["actors_acted"]
+    # Live mode hands control back at a PC turn (awaiting_pc set) OR the hostiles all died
+    # before the PC's first turn (a clean enemy wipe). Either is valid; the PC never auto-ran.
+    if res["awaiting_pc"] is not None:
+        assert res["awaiting_pc"] == hero
+
+
+def test_live_round_returns_digest_and_awaiting(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    dice_mod.reseed_process_rng(3)
+    cid, hero, mons = _seed_fight(server, store, monsters=2)
+    rr = combat_loop.run_combat_round(cid, mode="live")
+    assert "round_digest" in rr and isinstance(rr["round_digest"], list)
+    assert rr["mode"] == "live"
+    # no PC entry in the digest
+    assert all(e["actor_id"] != hero for e in rr["round_digest"])
+
+
+# ── TEST toggles: dead code when unguarded; force the hit boolean only ────────────────
+
+def _one_attack(server, store_mod, cid, attacker, target, *, attack_bonus=0,
+                damage_dice="1d6", **hr):
+    """Configure house_rules + run a single attack vs the target, return the result. Pins the
+    attacker as the CURRENT combatant and clears its action budget so each call is a legal
+    on-turn strike (a test convenience — we drive many attacks without advancing the round)."""
+    c = server._require(cid)
+    for k, v in hr.items():
+        setattr(c.house_rules, k, v)
+    # Make `attacker` the current combatant and give it a fresh action economy.
+    idx = next((i for i, cb in enumerate(c.combat.order) if cb.character_id == attacker), 0)
+    c.combat.turn_index = idx
+    c.combat.action_attacks_made = 0
+    c.combat.action_used = False
+    for cb in c.combat.order:
+        if cb.character_id == attacker:
+            cb.reaction_used = False
+    store_mod.save_campaign(c)
+    r = server.attack(cid, attacker_id=attacker, target_id=target,
+                      attack_bonus=attack_bonus, damage_dice=damage_dice)
+    return r
+
+
+def test_force_hit_is_dead_code_without_env(tmp_path, monkeypatch):
+    """force_hit set, campaign IS sandbox, but WORLDOS_COMBAT_TEST unset -> the toggle is dead:
+    a high-AC target is still missed (only the genuine nat-20 floor hits). This proves the
+    double guard — force_hit can NEVER fire in a live (non-test-env) game."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("WORLDOS_COMBAT_TEST", raising=False)
+    import server
+    dice_mod.reseed_process_rng(None)
+    cid = server.create_campaign("Guard")["id"]
+    server.add_location(campaign_id=cid, name="P", description="x", make_current=True)
+    c = server._require(cid)
+    c.is_sandbox = True  # sandbox half of the guard is TRUE
+    store.save_campaign(c)
+    a = server.create_character(cid, "A", kind="player", max_hp=30, armor_class=10)["id"]
+    t = server.create_character(cid, "T", kind="monster", max_hp=300, armor_class=30)["id"]
+    server.start_combat(cid, [a, t])
+    hits = sum(
+        1 for _ in range(40)
+        if _one_attack(server, store, cid, a, t, force_hit=True)["hit"]
+    )
+    # vs AC 30 with +0, only natural 20s hit (~5%). NOT ~40. So force_hit is DEAD here.
+    assert hits <= 6, f"force_hit leaked without the env guard: {hits}/40 hits"
+
+
+def test_force_hit_forces_hit_under_guard_without_faking_crits(tmp_path, monkeypatch):
+    """With BOTH guard halves on (env + sandbox), force_hit makes every roll hit — but it does
+    NOT synthesize a nat-20, so crits stay rare (only genuine nat-20s). This is the crit-honesty
+    invariant: the smoke can still distinguish 'crits double dice' from 'force_hit faked a crit'."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("WORLDOS_COMBAT_TEST", "1")
+    import server
+    dice_mod.reseed_process_rng(None)
+    cid = server.create_campaign("Guard2")["id"]
+    server.add_location(campaign_id=cid, name="P", description="x", make_current=True)
+    c = server._require(cid)
+    c.is_sandbox = True
+    store.save_campaign(c)
+    a = server.create_character(cid, "A", kind="player", max_hp=30, armor_class=10)["id"]
+    t = server.create_character(cid, "T", kind="monster", max_hp=999, armor_class=30)["id"]
+    server.start_combat(cid, [a, t])
+    n = 80
+    results = [_one_attack(server, store, cid, a, t, force_hit=True) for _ in range(n)]
+    hits = sum(1 for r in results if r["hit"])
+    crits = sum(1 for r in results if r["crit"])
+    assert hits == n, f"force_hit must force ALL hits: {hits}/{n}"
+    # crits are ONLY genuine nat-20s (~5%) — force_hit did NOT fake them.
+    assert crits < n * 0.5, f"force_hit fabricated crits ({crits}/{n}) — crit accounting corrupted"
+
+
+def test_fast_resolve_averages_damage_under_guard(tmp_path, monkeypatch):
+    """fast_resolve (guarded) makes damage the deterministic AVERAGE: a 2d6+3 strike always
+    applies 10 (2*3.5+3 -> round) regardless of the roll. Outside the guard it would vary."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    monkeypatch.setenv("WORLDOS_COMBAT_TEST", "1")
+    import server
+    dice_mod.reseed_process_rng(None)
+    cid = server.create_campaign("Fast")["id"]
+    server.add_location(campaign_id=cid, name="P", description="x", make_current=True)
+    c = server._require(cid)
+    c.is_sandbox = True
+    c.house_rules.force_hit = True       # guarantee the hit so damage always rolls
+    c.house_rules.fast_resolve = True
+    store.save_campaign(c)
+    a = server.create_character(cid, "A", kind="player", max_hp=30, armor_class=10)["id"]
+    t = server.create_character(cid, "T", kind="monster", max_hp=999, armor_class=5)["id"]
+    server.start_combat(cid, [a, t])
+    totals = set()
+    for _ in range(20):
+        r = _one_attack(server, store, cid, a, t, attack_bonus=10, damage_dice="2d6+3",
+                        force_hit=True, fast_resolve=True)
+        # only count non-crit strikes (a crit doubles the dice -> different average)
+        if not r["crit"]:
+            totals.add(r["damage"]["total"])
+    # every non-crit strike applied the SAME averaged total (10), not a random spread.
+    assert totals == {10}, f"fast_resolve did not average damage deterministically: {totals}"
+
+
+def test_combat_test_mode_guard_requires_both_halves(tmp_path, monkeypatch):
+    """The double guard predicate is True ONLY when env==1 AND campaign.is_sandbox."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    cid = server.create_campaign("G")["id"]
+    c = server._require(cid)
+    # neither half
+    monkeypatch.delenv("WORLDOS_COMBAT_TEST", raising=False)
+    c.is_sandbox = False
+    assert server._combat_test_mode_enabled(c) is False
+    # env only
+    monkeypatch.setenv("WORLDOS_COMBAT_TEST", "1")
+    assert server._combat_test_mode_enabled(c) is False
+    # both
+    c.is_sandbox = True
+    assert server._combat_test_mode_enabled(c) is True
+    # sandbox only
+    monkeypatch.delenv("WORLDOS_COMBAT_TEST", raising=False)
+    assert server._combat_test_mode_enabled(c) is False
+
+
+# ── additive / default-off: a non-sandbox campaign behaves as today ──────────────────
+
+def test_new_fields_default_off_and_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    from models import Campaign, HouseRules
+    assert Campaign(title="x").is_sandbox is False
+    assert HouseRules().force_hit is False
+    assert HouseRules().fast_resolve is False
+    # an OLD snapshot lacking the new keys loads fine (tolerant of absence) and round-trips
+    cid = server.create_campaign("RT")["id"]
+    c = server._require(cid)
+    store.save_campaign(c)
+    reloaded = server._require(cid)
+    assert reloaded.is_sandbox is False
+    assert reloaded.house_rules.force_hit is False


### PR DESCRIPTION
## What

Implements the **CORE** of the just-merged engine-run-combat ADR
(`docs/roadmap/engine-combat-loop-design.md`, #1097): the pure monster-AI, the
auto-sequencing loop, and the double-guarded TEST-only toggles. Tracks **2b** (toggles +
dice-seed), **2c** (`pick_action`), **2e** (auto-loop). PR-D (tactical-v2) and the
`qa/combat_smoke.py` CI harness (PR-B's CI wiring) are deliberately out of scope.

**Strictly additive + default-off** (a non-sandbox campaign with no env behaves
byte-identically to today) and **sole-writer-preserving** (the loop calls ONLY the existing
combat verbs — it adds no second state writer).

## Per-file

- **`servers/engine/models.py`** — `Campaign.is_sandbox: bool=False` +
  `HouseRules.force_hit/fast_resolve: bool=False`. All additive; `_StrictModel` round-trips;
  an old snapshot loads all three as False (tolerant-load drops only unknown *top-level* keys —
  these are new *defaulted* fields, so they load clean).
- **`servers/engine/dice.py`** — a **process-level** `random.Random` (`_PROCESS_RNG`) seeded
  once from `WORLDOS_COMBAT_SEED`. `roll()` draws from it when no explicit per-call seed is
  given, so a *sequence* of rolls is reproducible (seed S → the same fight) without per-call
  seeds collapsing every roll to a constant. Unset env == OS entropy == today. Plus
  `reseed_process_rng()` (TEST affordance) and a pure `average_total()` for `fast_resolve`.
- **`servers/engine/server.py`** — `_combat_test_mode_enabled(c)` = the **double guard** (env
  `WORLDOS_COMBAT_TEST=1` **AND** `campaign.is_sandbox`). `force_hit` hooks at the single hit
  decision and forces the **hit boolean only** (NOT a synthesized nat-20 — `is_crit`/crit-double
  still read the genuine natural die, so crit/damage accounting stays honest). `fast_resolve`
  averages the (already-crit-doubled) damage dice via `_resolve_damage_roll`. Both are dead code
  outside the guard.
- **`servers/engine/combat_ai.py`** — pure `pick_action(actor, combat_state, policy=)` greedy-v1
  EV policy: retreat-if-low (morale hook, off by default) → best in-reach attack
  (`P(hit)·E[damage]`, focus-fire ties by lowest target HP then stable id) → best save/cantrip
  spell → move-to-reach → dodge/skip. Frozen `Intent` + read-only `CombatView`/`CombatantView`/
  `AttackOption` dataclasses. No LLM, no I/O, deterministic. `policy=` seam for a future v2.
- **`servers/engine/combat_loop.py`** — `run_combat_round(campaign_id, mode)` +
  `run_combat_autonomous(campaign_id, mode, max_rounds=20)`. `mode='test'` runs ALL combatants;
  `mode='live'` auto-runs ONLY hostile (monster/npc) turns and **stops at the first PC/companion
  turn**, returning `{round_digest, awaiting_pc}`. **Python entry-point, no new MCP tool**, to
  respect the 120 KB tool-schema budget (`test_tool_schema_budget.py` stays green).
- **`servers/engine/tests/test_combat_core.py`** — the focused suite (below).

## Sole-writer + the double-guard (how they're preserved)

- **Sole-writer:** `combat_loop` holds NO lock and never mutates the Campaign. It reads a snapshot
  to build the `CombatView`, then applies the `Intent` *exclusively* through the existing verbs
  (`attack`/`cast_spell`/`move_to_*`/`use_action`/`next_turn`/`end_combat`), each of which keeps
  its own `campaign_lock` + `save_campaign`. There is exactly one mutating path, unchanged.
- **Double guard:** `force_hit`/`fast_resolve` fire *only* when `_combat_test_mode_enabled(c)`
  (env `WORLDOS_COMBAT_TEST=1` **and** `is_sandbox`). `is_sandbox` is set only by a test pre-seed,
  never by any live-play tool — so the toggles are *structurally* unreachable in a real game.

## Dead-code-when-off proof

`test_force_hit_is_dead_code_without_env`: `force_hit=True` + `is_sandbox=True` but the env
**unset** → 40 attacks vs AC 30 with +0 land only the genuine nat-20s (≤6/40), i.e. exactly
today's behavior. `test_combat_test_mode_guard_requires_both_halves` asserts the predicate is
True only with BOTH halves.

## Sample `run_combat_autonomous('test')`

Seeded random-vs-random (Fighter L4 vs 2 Goblins, `WORLDOS_COMBAT_SEED=12345`):
`victor=party, rounds=3, turns=6, actors_acted=3/3, round_cap_hit=False, end_combat fired`.
Focus-fire visible in the digest (`best in-reach attack Weapon on Goblin Warrior 2 (EV 4.8, P(hit) 60%)`).
Seed determinism: seed 777 → identical fight (`enemy, 3 rounds, 10 turns`) across two separate
processes. `force_hit` guarded-on: 60/60 hits forced but only ~2 genuine nat-20 crits.

## Tests

`test_combat_core.py` (19 tests) covers: `pick_action` sanity (focus-fire, higher-EV pick, no-foes
skip, move-to-reach, dodge fallback, determinism); seeded `run_combat_autonomous('test')` to a
terminal state with every combatant acting; LIVE stops-at-PC + never-auto-plays-PC; the toggles
dead-code-when-unguarded; `force_hit` forces hit without faking crits; `fast_resolve` averaging;
dice-seed determinism (set ⇒ reproducible, unset ⇒ fresh entropy); additive default-off round-trip.

- `tests/test_combat_core.py tests/test_combat.py tests/test_grid.py` → **208 passed**.
- Full engine suite → **3092 passed** (no regressions).
- `test_tool_schema_budget.py` green (no new MCP tools). `license_check` passed.

## Status

**DRAFT** — engine-run combat CORE. Out of scope (later PRs in the ladder): the LIVE digest→DM
narration surface wiring (PR-C), the `qa/combat_smoke.py` CI job (PR-B), and the tactical-v2
policy (PR-D). No live behavior changes; safe to land additively behind the default-off guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Deterministic automated combat decision-making with configurable behavior policies
* Seeded random number generation mode enabling reproducible combat sequences
* Sandbox test mode with optional force-hit and fast-damage-resolution toggles for sandbox campaigns
* Combat auto-play orchestration supporting both live (user-controlled) and test (fully autonomous) modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->