### PR TITLE
feat(asset-gen): AI asset toolkit (Tripo/Scenario wrappers + non-Eva Scenario provider + skills) (#1050)

### DIFF
--- a/.claude/skills/asset-gen/SKILL.md
+++ b/.claude/skills/asset-gen/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: asset-gen
+description: Generate game art for WorldOS via Meshy / Tripo3D / Scenario / PixelLab — 3D characters, auto-rigging, animation, painterly backgrounds, sprites, tilesets. Use when creating or regenerating ANY visual asset for the Godot GT2 renderer (character sheets, NPC/companion models, backdrops, props) or the future GT1 tile engine, or when wiring a non-Eva image-gen provider. Routes the right service to each job and gives the keys, the CLI wrappers, the MCPs, and the sprite-sheet bake contract.
+---
+
+# WorldOS AI asset-generation toolkit
+
+Four services cover every visual asset need. Keys are stored OUTSIDE the repo; two services
+are wired as MCPs; all four have CLI wrappers (or a stub). The renderer reads only the
+**sprite-sheet manifest** (see `godot/HANDOFF.md` §4.6), so any source drops in at the same
+`scope_key` with zero renderer change.
+
+## Which tool for which job
+
+| Job | Tool | How |
+|---|---|---|
+| **3D character / NPC / companion** | **Meshy** or **Tripo H3.1** | `meshy_gen.py` (text→3D, preview→refine) or `tripo_gen.py text` |
+| **Rigged + animated character** (GT2 #1091) | **Tripo** | `tripo_gen.py rig` → rig-check → rig(`spec=mixamo`) → retarget `[walk,idle,run,attack,cast]` → animated GLB |
+| **Low-poly prop / dungeon dressing** | **Tripo P1** | `tripo_gen.py text --lowpoly` (~10s) |
+| **Painterly background / diorama** (GT2 #1089) | **Scenario** | `scenario_gen.py generate --model-id <id>` (train a style model once → consistent backdrops) |
+| **Engine 2D image-gen, non-Eva** | **Scenario provider** | `WORLDOS_IMAGE_PROVIDER=scenario` (see below) |
+| **Pixel sprites / tilesets** | **PixelLab** | **GT1 FUTURE only** — MCP `pixellab`; `pixellab_gen.py` is a stub |
+
+The 3D path always ends at the bake: **`tripo_gen.py`/`meshy_gen.py` → `godot/tools/bake_sprites.py`
+(8 facings @ dimetric 2:1, see `godot/ISO-PROJECTION.md`) → `godot/tools/pack_sheet.py`** (manifest v1:
+rows=8 facings, cols=24 idle4/walk8/attack6/cast6, 128px, foot-anchor).
+
+## Keys (NEVER commit; NEVER print)
+Stored mode-600 OUTSIDE the repo in `~/.worldos/`: `meshy.key`, `tripo3d.key`, `scenario.key` +
+`scenario.secret`, `pixellab.key`. Env fallbacks (CI): `WORLDOS_{MESHY,TRIPO,SCENARIO,PIXELLAB}_API_KEY`
+(+ `WORLDOS_SCENARIO_SECRET`), read via `servers/engine/_env.py:env_var`. Wrappers enforce these
+paths and never echo the key. ⚠ **All keys were pasted in a chat transcript (2026-06-21) — rotate them
+in each service dashboard when convenient, then update the `~/.worldos/*.key` file.**
+
+## CLI wrappers (`godot/tools/`, urllib-only, mirror `meshy_gen.py`)
+- **`tripo_gen.py`** — `text|image|rig` subcommands; `--lowpoly` (P1); `--test-key`; `--dry-run` (credit est). Polls `GET /v3/task/{id}` ≥2s; **downloads GLB immediately (URLs expire ~5 min)**. Output → gitignored `content/worlds/_private/<world>/images/<scope>/`.
+- **`scenario_gen.py`** — `generate|list-models|upscale`; `--model-id`; `--test-key`; `--dry-run`. HTTP Basic; async job → asset download.
+- **`meshy_gen.py`** — existing: text→3D (preview→refine), `--prompt --out`.
+- **`pixellab_gen.py`** — STUB for GT1; `--test-key` only.
+Always run `--test-key` first to confirm auth.
+
+## MCPs (registered at user scope in `~/.claude.json` — do NOT touch the plugin `.mcp.json`)
+- **`scenario`** (`https://mcp.scenario.com/mcp`, HTTP Basic) — ✔ connected. Tools: `generate_image`, `generate_custom`, `train_model`, `list_models`, `get_job_status`, `upscale`, etc.
+- **`pixellab`** (`https://api.pixellab.ai/mcp`, Bearer) — ✔ connected, 41 tools (pixel chars 4/8-dir, animation, Wang/topdown/sidescroller/isometric tilesets). GT1-future.
+Add `@https://api.pixellab.ai/mcp/docs` to a prompt for the full PixelLab tool list.
+(Meshy + Tripo have no wired MCP — use the CLI wrappers.)
+
+## Non-Eva engine image provider
+`ScenarioImageProvider` is registered in `servers/engine/imagegen.py` `_HOSTED`. Select with
+`WORLDOS_IMAGE_PROVIDER=scenario` (+ `WORLDOS_SCENARIO_MODEL_ID`) to give the engine REAL 2D image-gen
+**without** the `openclaw` provider (which rides Eva's gateway — the invariant blocker). It degrades to
+null when unconfigured/offline; the default provider stays null.
+
+## Verified API facts (live-probed — some differ from public docs)
+- **Meshy**: Bearer, `https://api.meshy.ai/openapi`. text/image→3D + `/v1/rigging` + `/v1/animations` + `/v1/text-to-image`.
+- **Tripo**: Bearer, `https://openapi.tripo3d.ai/v3`. `/generation/text|image-to-model`; rig chain `/animations/{rig-check,rig,retarget}` (`rig_type=biped`, `spec=mixamo`, presets `preset:walk|idle|run|attack|cast`). Poll `GET /v3/task/{id}` ≥2s; envelope `{"code":0,"data":{...}}`; model URLs expire ~5 min.
+- **Scenario**: **HTTP Basic (key:secret)**, base **`https://api.cloud.scenario.com/v1`** (NOT `api.scenario.com`, NOT Bearer). `POST /v1/generate/txt2img` → `{"job":{"jobId"}}` → poll `GET /v1/jobs/{id}` → `GET /v1/assets/{id}` for the URL. `GET /v1/models`. **Account currently has 0 trained models → `generate` needs a `--model-id` (train/import one in the Scenario UI, or use a public modelId).**
+- **PixelLab**: MCP-first, Bearer, `https://api.pixellab.ai/mcp` (JSON-RPC, returns **SSE** `text/event-stream`). REST `/balance` is 404.
+
+## Rate limits / cost / gotchas
+Meshy ~200/day; Tripo 1 req/s (poll ≥2s or 429); Scenario 50–100/s + 10–30 min model training; PixelLab async queue. No hard spend caps — use `--dry-run` for a credit estimate + check balance before bulk. Download asset URLs immediately (finite TTL). Pin seeds / prefer Scenario trained models for consistency. Validate bakes (frame dims + foot-anchor) before trusting a sheet.
+
+## What this unblocks
+- **#1089 painterly backdrops** → Scenario (train a style model → `scenario_gen.py generate` or the `scenario` MCP), served via the engine's `/image` from `_private` (no Eva).
+- **#1091 real rigged animation** → Tripo `rig`→`retarget` → animated GLB → `bake_sprites.py`.
+- **GT1 (future)** → PixelLab tilesets + pixel sprites; not wired into GT2.

--- a/.claude/skills/godot-dev/SKILL.md
+++ b/.claude/skills/godot-dev/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: godot-dev
+description: Develop / test / debug the WorldOS GT2 Godot painterly-isometric renderer (the `godot/` project). Use when working on the isometric view — GDScript (`.gd`) or scenes (`.tscn`), the `SurfaceClient`/`WorldView`/`CharacterToken`/`InputController`, the render-profile contract, sprite sheets, click-to-move/Y-sort, or the Godot CI lane. Encodes the thin-client invariants, the dimetric-2:1 projection, how to run/validate locally, and points at the full knowledge base.
+---
+
+# WorldOS GT2 Godot renderer — dev skill
+
+The GT2 renderer is a **stateless thin client** over the zone-based WorldOS engine. **Read
+`godot/HANDOFF.md` first** — it is the full knowledge base (architecture diagrams, the
+isometric/painterly/Pillars research, gotchas, the prioritized backlog). Companions:
+`godot/ISO-PROJECTION.md` (the locked projection), `godot/tools/README.md` (asset pipeline).
+
+## The non-negotiables (full list in HANDOFF.md §7)
+- Engine = **sole writer**; the renderer owns ZERO state but the `/events` cursor.
+- **Ignore all surface `x/y`** — re-derive every screen position from named **zones**.
+- **No engine facing field, ever** — facing is renderer-derived (conformance-locked).
+- Writes only the **frozen `/move` vocab** (`…/travel/inspect/move_to_zone`).
+- Projection is **dimetric 2:1 (~26.57°), irreversible once finals bake** — cite `ISO-PROJECTION.md`.
+- Engine snapshot always overrides optimistic UI (never move a token from the click).
+
+## Run / validate (Godot 4.6.3 at `/Applications/Godot.app/Contents/MacOS/Godot`)
+- Parse/compile: `godot --headless --path godot --import`
+- Logic smoke: `godot --headless --path godot --quit-after 180 -- --smoke-intent`
+- Visual proof (window): `godot --path godot --demo-occlusion --quit-after 300` → `/tmp/wos_godot_occlusion_*.png`
+- CI: `.github/workflows/godot.yml` (import + conformance + Web/Linux export + screenshot), `godot/**`-triggered, no model keys.
+
+## Making art (see the `asset-gen` skill)
+Characters/props/backdrops come from the AI asset toolkit → the Blender bake → the sprite-sheet
+manifest. Tripo (rig+animate) and Meshy make 3D characters; Scenario makes painterly backdrops
+(non-Eva); finals live gitignored in `content/worlds/_private/.../images/<scope>/`. Invoke the
+**`asset-gen`** skill for the job matrix, keys, wrappers, and MCPs.
+
+## Backlog (HANDOFF.md §9)
+Next: **#1090** (narration/dialogue in-view) → **#1089** (painterly backdrop, via `asset-gen`/Scenario)
+→ **#1063** (serve `_private` finals) → **#1092** (full party) → **#1060** (combat tokens) → **#1091**
+(real rigged animation, via `asset-gen`/Tripo). Delivery: #1057–#1059. Epic **#1050**.
+
+## Dev loop
+Worktree off `origin/main` → additive change → local Godot validate → PR → squash-merge → prune.
+Multi-session repo: never branch-flip the shared checkout; `godot/`-only PRs skip CodeQL.

--- a/godot/HANDOFF.md
+++ b/godot/HANDOFF.md
@@ -219,7 +219,9 @@ with zero renderer change**. Proven.
 
 <a name="assets"></a>
 ## 6. Asset pipeline — Meshy → Blender → sprite sheet
-Full detail in `tools/README.md`. In short:
+**Full toolkit: the `asset-gen` skill** (Meshy / Tripo3D / Scenario / PixelLab — job matrix, key
+locations, the `tripo_gen.py`/`scenario_gen.py` wrappers, the wired `scenario`+`pixellab` MCPs).
+Full bake detail in `tools/README.md`. In short:
 ```
 python3 godot/tools/meshy_gen.py --prompt "..." --out <dir>            # Meshy text-to-3D (preview->refine PBR) -> model.glb
 blender --background --python godot/tools/bake_sprites.py -- \
@@ -232,10 +234,12 @@ python3 godot/tools/pack_sheet.py --frames <dir>/frames \
   ~10–20 credits/character. **Key:** `~/.worldos/meshy.key` (mode 600, OUTSIDE the repo) or `$MESHY_API_KEY`.
   ⚠ *The key was pasted into a chat transcript 2026-06-21 — rotate it.* (Webhooks + MCP servers exist —
   official `meshy-dev/meshy-mcp-server`, community `pasie15/meshy-ai-mcp-server` — not wired.)
-- **Backgrounds & the Eva caveat:** the engine's only *wired* image provider
-  (`WORLDOS_IMAGE_PROVIDER=openclaw`) rides **Eva's OpenClaw gateway + Codex OAuth** — do **NOT** drive
-  it autonomously (the "never touch Eva" invariant). For #1089 use the **Meshy 3D-env → Blender
-  render-down** route, or add a direct gpt-image key.
+- **Backgrounds & the Eva caveat:** the engine's `openclaw` image provider rides **Eva's OpenClaw
+  gateway + Codex OAuth** — do **NOT** drive it autonomously (the "never touch Eva" invariant).
+  **Now solved:** a `ScenarioImageProvider` is wired (`WORLDOS_IMAGE_PROVIDER=scenario`, direct API,
+  non-Eva), and `scenario_gen.py` / the `scenario` MCP generate painterly backdrops with trained-model
+  consistency (#1089). Rigged character animation (#1091) similarly via Tripo `rig`→`retarget`
+  (`tripo_gen.py rig`). See the **`asset-gen` skill**.
 
 <a name="invariants"></a>
 ## 7. Invariants (never violate)

--- a/godot/tools/pixellab_gen.py
+++ b/godot/tools/pixellab_gen.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""pixellab_gen.py — STUB wrapper for PixelLab (RESERVED for the FUTURE GT1 tile/pixel game-type).
+
+  *** GT1 FUTURE — NOT WIRED. This is intentionally a stub. ***
+
+PixelLab (https://www.pixellab.ai) is a pixel-art generation service: top-down/side-view
+PIXEL SPRITES, animated character sprites (walk/idle/attack frames), and TILESETS for 2D
+tile maps. WorldOS reserves it for a future GT1 (game-type 1) TILE/PIXEL engine — the
+small-tile, retro-pixel mode — which does NOT exist yet. The current GT2 final-art
+pipeline uses Meshy/Tripo (3D -> bake) and Scenario (2D painterly art); none of that
+touches PixelLab.
+
+Downstream linkage (future): when GT1 lands, this tool would emit pixel sprites/tilesets
+that feed a GT1-specific packer (analogous to how meshy_gen/tripo_gen -> bake_sprites.py
+-> pack_sheet.py serves GT2). It would NOT use bake_sprites.py (that renders 3D at the
+dimetric 2:1 projection in godot/ISO-PROJECTION.md; pixel art is authored, not baked).
+
+VERIFIED PixelLab contract (confirmed live):
+  * Transport: MCP (Model Context Protocol) — JSON-RPC 2.0 over HTTP POST.
+  * Endpoint: https://api.pixellab.ai/mcp
+  * Auth: Bearer  ``Authorization: Bearer <key>``
+  * The MCP responds with text/event-stream (SSE): lines ``event: message`` then
+    ``data: {<json-rpc result>}``. A plain ``tools/list`` call returns the available
+    tools (e.g. create_character, ...). NOTE: the REST ``/balance`` endpoint is 404 — the
+    service is MCP-first, which is why this stub speaks JSON-RPC, not REST.
+
+The API key is read from ~/.worldos/pixellab.key or $WORLDOS_PIXELLAB_API_KEY. It is
+NEVER printed/logged and NEVER written into any repo file.
+
+Usage:
+    # auth smoke-test — POSTs JSON-RPC tools/list to the MCP, prints the tool count
+    python3 pixellab_gen.py --test-key
+    # -> "PixelLab Auth OK" + the number of MCP tools available
+
+Full generation (pixel sprites / tilesets / animation) is deliberately NOT implemented
+here — it is GT1 future work. When GT1 is scoped, wire the relevant MCP tools
+(create_character, animate, tileset, ...) following the JSON-RPC pattern in _mcp_call().
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+MCP_ENDPOINT = "https://api.pixellab.ai/mcp"
+
+
+# --------------------------------------------------------------------------- #
+# Key handling. NEVER print/log the key; NEVER write it to a repo file.
+# --------------------------------------------------------------------------- #
+def _load_api_key() -> str:
+    key = os.environ.get("WORLDOS_PIXELLAB_API_KEY", "").strip()
+    if key:
+        return key
+    key_path = os.path.expanduser("~/.worldos/pixellab.key")
+    if os.path.isfile(key_path):
+        with open(key_path, "r") as f:
+            key = f.read().strip()
+        if key:
+            return key
+    sys.exit(
+        "[pixellab_gen] ERROR: no API key. Set $WORLDOS_PIXELLAB_API_KEY or put it in "
+        "~/.worldos/pixellab.key"
+    )
+
+
+def _mcp_call(key: str, method: str, params: dict = None) -> dict:
+    """POST a JSON-RPC 2.0 request to the PixelLab MCP and parse its SSE response.
+
+    The MCP returns text/event-stream: one or more `event: <type>` / `data: <json>` line
+    pairs. We collect the JSON from `data:` lines and return the LAST one carrying a
+    JSON-RPC `result`/`error` (the response to our request).
+    """
+    body = {"jsonrpc": "2.0", "id": 1, "method": method, "params": params or {}}
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        MCP_ENDPOINT,
+        data=data,
+        headers={
+            "Authorization": "Bearer %s" % key,
+            "Content-Type": "application/json",
+            # The MCP streams SSE; advertise that we accept it.
+            "Accept": "application/json, text/event-stream",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            sys.exit("[pixellab_gen] AUTH FAILED: HTTP %d — bad/expired API key." % e.code)
+        try:
+            detail = e.read().decode("utf-8")
+        except Exception:
+            detail = "<no body>"
+        sys.exit("[pixellab_gen] ERROR HTTP %d on MCP %s. Detail: %s" % (e.code, method, detail))
+    except urllib.error.URLError as e:
+        sys.exit("[pixellab_gen] ERROR: network failure on MCP %s: %s" % (method, e.reason))
+
+    return _parse_mcp_response(raw)
+
+
+def _parse_mcp_response(raw: str) -> dict:
+    """Parse an MCP response that may be plain JSON or SSE (event:/data: lines)."""
+    raw = raw.strip()
+    if not raw:
+        sys.exit("[pixellab_gen] ERROR: empty MCP response.")
+    # Plain JSON?
+    if raw[0] == "{":
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+    # SSE: scan `data:` lines, keep the last that has a JSON-RPC result/error.
+    last = None
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line.startswith("data:"):
+            continue
+        payload = line[len("data:"):].strip()
+        if not payload:
+            continue
+        try:
+            obj = json.loads(payload)
+        except json.JSONDecodeError:
+            continue
+        if "result" in obj or "error" in obj:
+            last = obj
+    if last is None:
+        sys.exit("[pixellab_gen] ERROR: could not parse MCP SSE response: %s" % raw[:300])
+    return last
+
+
+# --------------------------------------------------------------------------- #
+# Sub-command bodies.
+# --------------------------------------------------------------------------- #
+def _cmd_test_key() -> None:
+    """Auth smoke-test: JSON-RPC tools/list against the MCP; print the tool count."""
+    key = _load_api_key()
+    resp = _mcp_call(key, "tools/list")
+    if "error" in resp:
+        sys.exit("[pixellab_gen] ERROR: MCP tools/list returned an error: %s" % json.dumps(resp["error"]))
+    tools = (resp.get("result") or {}).get("tools") or []
+    print("PixelLab Auth OK")
+    print("[pixellab_gen] MCP tools available: %d" % len(tools))
+
+
+def main(argv=None) -> None:
+    ap = argparse.ArgumentParser(
+        description="STUB wrapper for PixelLab pixel-art MCP (GT1 future — not wired)."
+    )
+    ap.add_argument("--test-key", action="store_true",
+                    help="auth smoke-test: POST JSON-RPC tools/list to the MCP -> 'PixelLab Auth OK' + tool count")
+    args = ap.parse_args(argv)
+
+    if args.test_key:
+        _cmd_test_key()
+        return
+    ap.print_help()
+    print(
+        "\n[pixellab_gen] NOTE: this is a STUB reserved for the FUTURE GT1 tile/pixel "
+        "game-type. Only --test-key is implemented; full pixel-sprite/tileset generation "
+        "is GT1 future work and is NOT wired."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/godot/tools/scenario_gen.py
+++ b/godot/tools/scenario_gen.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""scenario_gen.py — generate 2D art (portraits / scenes / textures) via the Scenario API.
+
+A sibling of meshy_gen.py / tripo_gen.py. Scenario is a NON-Eva, NON-OpenClaw image
+backend: it has its own API key + secret and never touches the gateway. Use it for the
+GT-style 2D art the engine and viewer consume (portraits, scenes, maps, item icons), and
+as paint-over reference for the 3D bake pipeline.
+
+This tool is WorldOS-ORIGINAL code; the ART it downloads (PNGs) is NOT committed — it
+lives under content/worlds/_private/ (gitignored, owner-licensed).
+
+VERIFIED Scenario contract (confirmed LIVE — these differ from the first research pass):
+  * Auth: HTTP BASIC  — username = API key, password = SECRET. (NOT Bearer.)
+  * Base: https://api.cloud.scenario.com/v1   (NOT api.scenario.com)
+  * List models:           GET  /v1/models
+  * Text-to-image:         POST /v1/generate/txt2img  body {"modelId","prompt",...} -> a JOB
+  * Upscale:               POST /v1/generate/upscale  body {"image",...}            -> a JOB
+  * Poll a job:            GET  /v1/jobs/{jobId}       until status=success, asset ids land
+  * Fetch an asset (PNG):  GET  /v1/assets/{assetId}   -> {"asset":{"url": <download>}}
+  * Custom model: same txt2img endpoint, just pass the custom modelId.
+  Confirmed live by probing: POST /v1/generate/txt2img with no modelId -> 400
+  "\"modelId\" must be a string"; POST /v1/generate/upscale empty -> 400 "image parameter
+  is required"; GET /v1/jobs/{bad} -> 404 "Job ... not found"; GET /v1/models -> 200.
+
+The key+secret are read from ~/.worldos/scenario.key + ~/.worldos/scenario.secret, or
+$WORLDOS_SCENARIO_API_KEY + $WORLDOS_SCENARIO_SECRET. They are NEVER printed/logged and
+NEVER written into any repo file.
+
+Usage:
+    # auth smoke-test (GET /v1/models — no generation, no credit spend)
+    python3 scenario_gen.py --test-key
+
+    # list the models available on the account (and their ids)
+    python3 scenario_gen.py list-models
+
+    # text-to-image (modelId required — pick one from list-models)
+    python3 scenario_gen.py generate --model-id <id> --prompt "a grizzled dwarf cleric ..." \
+        --world baldurs-gate --scope dwarf-cleric
+
+    # upscale an existing asset (by Scenario asset id) or an image URL
+    python3 scenario_gen.py upscale --asset-id <id> --world baldurs-gate --scope dwarf-cleric
+
+    # plan + est credits WITHOUT calling the API
+    python3 scenario_gen.py generate --model-id <id> --prompt "..." --world w --scope s --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+
+API_BASE = "https://api.cloud.scenario.com/v1"
+MODELS_PATH = "/models"
+TXT2IMG_PATH = "/generate/txt2img"
+UPSCALE_PATH = "/generate/upscale"
+JOB_PATH = "/jobs/{job_id}"
+ASSET_PATH = "/assets/{asset_id}"
+
+POLL_INTERVAL_SEC = 4
+DEFAULT_TIMEOUT_SEC = 600
+
+# Rough per-op credit estimates (for --dry-run only; the API is the source of truth).
+CREDIT_EST = {"generate_per_sample": 1, "upscale": 2}
+
+
+# --------------------------------------------------------------------------- #
+# Key handling. NEVER print/log the key/secret; NEVER write them to a repo file.
+# --------------------------------------------------------------------------- #
+def _load_credentials() -> tuple:
+    key = os.environ.get("WORLDOS_SCENARIO_API_KEY", "").strip()
+    secret = os.environ.get("WORLDOS_SCENARIO_SECRET", "").strip()
+    if not key:
+        key_path = os.path.expanduser("~/.worldos/scenario.key")
+        if os.path.isfile(key_path):
+            with open(key_path, "r") as f:
+                key = f.read().strip()
+    if not secret:
+        sec_path = os.path.expanduser("~/.worldos/scenario.secret")
+        if os.path.isfile(sec_path):
+            with open(sec_path, "r") as f:
+                secret = f.read().strip()
+    if not key or not secret:
+        sys.exit(
+            "[scenario_gen] ERROR: missing credentials. Set $WORLDOS_SCENARIO_API_KEY + "
+            "$WORLDOS_SCENARIO_SECRET, or put them in ~/.worldos/scenario.key + "
+            "~/.worldos/scenario.secret."
+        )
+    return key, secret
+
+
+def _auth_headers(key: str, secret: str) -> dict:
+    token = base64.b64encode(("%s:%s" % (key, secret)).encode("utf-8")).decode("ascii")
+    return {
+        "Authorization": "Basic %s" % token,
+        "Content-Type": "application/json",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# HTTP (urllib only — no `requests` dependency).
+# --------------------------------------------------------------------------- #
+def _post_json(url: str, headers: dict, body: dict) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        _explain_http(e.code, _read_error(e), "POST " + url)
+    except urllib.error.URLError as e:
+        sys.exit("[scenario_gen] ERROR: network failure on POST %s: %s" % (url, e.reason))
+
+
+def _get_json(url: str, headers: dict) -> dict:
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        _explain_http(e.code, _read_error(e), "GET " + url)
+    except urllib.error.URLError as e:
+        sys.exit("[scenario_gen] ERROR: network failure on GET %s: %s" % (url, e.reason))
+
+
+def _read_error(e: urllib.error.HTTPError) -> str:
+    try:
+        return e.read().decode("utf-8")
+    except Exception:
+        return "<no body>"
+
+
+def _explain_http(code: int, detail: str, what: str) -> None:
+    if code == 401:
+        sys.exit(
+            "[scenario_gen] ERROR 401 unauthorized on %s — bad key/secret (Basic auth). "
+            "Detail: %s" % (what, detail)
+        )
+    if code in (402, 403):
+        sys.exit(
+            "[scenario_gen] ERROR %d on %s — insufficient credits or forbidden. Art was NOT "
+            "generated. Detail: %s" % (code, what, detail)
+        )
+    if code == 429:
+        sys.exit(
+            "[scenario_gen] ERROR 429 rate-limited on %s. Wait and retry. Detail: %s"
+            % (what, detail)
+        )
+    sys.exit("[scenario_gen] ERROR HTTP %d on %s. Detail: %s" % (code, what, detail))
+
+
+def _download(url: str, dest: str) -> int:
+    """Stream a binary asset (png) to dest. Returns bytes written. Asset URLs have a finite TTL."""
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=300) as resp, open(dest, "wb") as out:
+            total = 0
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                out.write(chunk)
+                total += len(chunk)
+            return total
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        sys.exit("[scenario_gen] ERROR downloading %s -> %s: %s" % (url, dest, e))
+
+
+# --------------------------------------------------------------------------- #
+# Job lifecycle.
+# --------------------------------------------------------------------------- #
+def _job_id_from_create(res: dict, what: str) -> str:
+    job = res.get("job") or {}
+    job_id = job.get("jobId") or job.get("id") or res.get("jobId")
+    if not job_id:
+        sys.exit("[scenario_gen] ERROR: %s returned no job id: %s" % (what, json.dumps(res)))
+    return job_id
+
+
+def _poll_job(headers: dict, job_id: str, label: str, timeout_sec: int) -> dict:
+    """Poll GET /jobs/{id} until success. Returns the final job dict (carries asset ids)."""
+    url = API_BASE + JOB_PATH.format(job_id=job_id)
+    deadline = time.time() + timeout_sec
+    last = None
+    while True:
+        res = _get_json(url, headers)
+        job = res.get("job") or res
+        status = str(job.get("status", "unknown")).lower()
+        progress = job.get("progress")
+        if status != last:
+            tail = (" progress=%s" % progress) if progress is not None else ""
+            print("[scenario_gen] %s status=%s%s" % (label, status, tail))
+            last = status
+        if status in ("success", "succeeded", "completed", "done"):
+            return job
+        if status in ("failure", "failed", "error"):
+            sys.exit("[scenario_gen] ERROR: %s job FAILED: %s" % (label, json.dumps(job)))
+        if status in ("canceled", "cancelled"):
+            sys.exit("[scenario_gen] ERROR: %s job %s" % (label, status))
+        if time.time() > deadline:
+            sys.exit(
+                "[scenario_gen] ERROR: %s job timed out after %ds (last status=%s). "
+                "Art was NOT completed." % (label, timeout_sec, status)
+            )
+        time.sleep(POLL_INTERVAL_SEC)
+
+
+def _job_asset_ids(job: dict) -> list:
+    """Extract output asset ids from a succeeded job, best-effort across response shapes."""
+    md = job.get("metadata") or {}
+    ids = md.get("assetIds") or job.get("assetIds") or md.get("assets") or job.get("assets")
+    out = []
+    if isinstance(ids, list):
+        for a in ids:
+            if isinstance(a, str):
+                out.append(a)
+            elif isinstance(a, dict) and (a.get("id") or a.get("assetId")):
+                out.append(a.get("id") or a.get("assetId"))
+    return out
+
+
+def _asset_url(headers: dict, asset_id: str) -> str:
+    """Resolve a downloadable URL for an asset id via GET /assets/{id}."""
+    res = _get_json(API_BASE + ASSET_PATH.format(asset_id=asset_id), headers)
+    asset = res.get("asset") or res
+    url = asset.get("url") or asset.get("downloadUrl") or asset.get("signedUrl")
+    if not url:
+        sys.exit("[scenario_gen] ERROR: asset %s has no download url: %s" % (asset_id, json.dumps(asset)))
+    return url
+
+
+# --------------------------------------------------------------------------- #
+# Output dir resolution.
+# --------------------------------------------------------------------------- #
+def _safe_scope(scope: str) -> str:
+    return "".join(c if (c.isalnum() or c in "-_") else "_" for c in str(scope))[:128]
+
+
+def _resolve_out(args) -> str:
+    if getattr(args, "out", None):
+        return os.path.abspath(args.out)
+    world = _safe_scope(getattr(args, "world", "") or "")
+    scope = _safe_scope(getattr(args, "scope", "") or "")
+    if not world or not scope:
+        sys.exit(
+            "[scenario_gen] ERROR: provide --out, or both --world and --scope "
+            "(output goes to content/worlds/_private/<world>/images/<scope>/)."
+        )
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    return os.path.join(repo_root, "content", "worlds", "_private", world, "images", scope)
+
+
+def _download_job_assets(headers: dict, job: dict, out_dir: str, stem: str) -> list:
+    """Download every output asset of a succeeded job to <out>/<stem>[_N].png. Returns metadata."""
+    asset_ids = _job_asset_ids(job)
+    if not asset_ids:
+        sys.exit("[scenario_gen] ERROR: succeeded job has no output assets: %s" % json.dumps(job))
+    saved = []
+    for i, aid in enumerate(asset_ids):
+        url = _asset_url(headers, aid)
+        name = "%s.png" % stem if len(asset_ids) == 1 else "%s_%d.png" % (stem, i)
+        dest = os.path.join(out_dir, name)
+        size = _download(url, dest)
+        print("[scenario_gen] downloaded %s (%d bytes)" % (name, size))
+        saved.append({"asset_id": aid, "path": dest, "bytes": size})
+    return saved
+
+
+# --------------------------------------------------------------------------- #
+# Sub-command bodies.
+# --------------------------------------------------------------------------- #
+def _cmd_test_key() -> None:
+    """Cheap auth smoke-test: GET /v1/models. 200 == authenticated."""
+    key, secret = _load_credentials()
+    headers = _auth_headers(key, secret)
+    req = urllib.request.Request(API_BASE + MODELS_PATH + "?pageSize=1", headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            resp.read()
+        print("Scenario Auth OK")
+    except urllib.error.HTTPError as e:
+        if e.code in (401, 403):
+            sys.exit("[scenario_gen] AUTH FAILED: HTTP %d — bad key/secret." % e.code)
+        # Any other HTTP code still means the request was authenticated/accepted.
+        print("Scenario Auth OK")
+    except urllib.error.URLError as e:
+        sys.exit("[scenario_gen] ERROR: network failure on --test-key: %s" % e.reason)
+
+
+def _cmd_list_models(args) -> None:
+    key, secret = _load_credentials()
+    headers = _auth_headers(key, secret)
+    res = _get_json(API_BASE + MODELS_PATH + "?pageSize=100", headers)
+    models = res.get("models") or []
+    if not models:
+        print("[scenario_gen] (no models on this account — train/import one in the Scenario UI, "
+              "or use a public modelId.)")
+        return
+    for m in models:
+        mid = m.get("id") or m.get("modelId") or "?"
+        name = m.get("name") or m.get("displayName") or ""
+        status = m.get("status") or ""
+        print("  %s\t%s\t%s" % (mid, status, name))
+    print("[scenario_gen] %d model(s)." % len(models))
+
+
+def _cmd_generate(args) -> None:
+    out_dir = _resolve_out(args)
+    if args.dry_run:
+        print("[scenario_gen] DRY-RUN text-to-image")
+        print("  model-id  : %s" % args.model_id)
+        print("  prompt    : %s" % args.prompt)
+        print("  samples   : %d" % args.num_samples)
+        print("  size      : %dx%d" % (args.width, args.height))
+        print("  out dir   : %s" % out_dir)
+        print("  est credits: ~%d (API is source of truth)" % (CREDIT_EST["generate_per_sample"] * args.num_samples))
+        return
+    os.makedirs(out_dir, exist_ok=True)
+    key, secret = _load_credentials()
+    headers = _auth_headers(key, secret)
+    body = {
+        "modelId": args.model_id,
+        "prompt": args.prompt,
+        "numSamples": args.num_samples,
+        "width": args.width,
+        "height": args.height,
+    }
+    if args.negative_prompt:
+        body["negativePrompt"] = args.negative_prompt
+    if args.seed is not None:
+        body["seed"] = args.seed
+    res = _post_json(API_BASE + TXT2IMG_PATH, headers, body)
+    job_id = _job_id_from_create(res, "txt2img create")
+    print("[scenario_gen] txt2img job submitted: %s (model=%s)" % (job_id, args.model_id))
+    job = _poll_job(headers, job_id, "txt2img", args.timeout)
+    stem = _safe_scope(getattr(args, "scope", "") or "scenario") or "scenario"
+    saved = _download_job_assets(headers, job, out_dir, stem)
+    _write_meta(out_dir, {
+        "prompt": args.prompt, "model_id": args.model_id, "num_samples": args.num_samples,
+        "width": args.width, "height": args.height, "job_id": job_id,
+        "assets": saved, "source": "scenario-txt2img",
+    })
+    print("[scenario_gen] OK — job=%s assets=%d" % (job_id, len(saved)))
+
+
+def _cmd_upscale(args) -> None:
+    out_dir = _resolve_out(args)
+    image_ref = args.asset_id or args.image_url
+    if not image_ref:
+        sys.exit("[scenario_gen] ERROR: upscale needs --asset-id or --image-url.")
+    if args.dry_run:
+        print("[scenario_gen] DRY-RUN upscale")
+        print("  image     : %s" % image_ref)
+        print("  scale     : %sx" % args.scale)
+        print("  out dir   : %s" % out_dir)
+        print("  est credits: ~%d (API is source of truth)" % CREDIT_EST["upscale"])
+        return
+    os.makedirs(out_dir, exist_ok=True)
+    key, secret = _load_credentials()
+    headers = _auth_headers(key, secret)
+    body = {"image": image_ref, "scalingFactor": args.scale}
+    res = _post_json(API_BASE + UPSCALE_PATH, headers, body)
+    job_id = _job_id_from_create(res, "upscale create")
+    print("[scenario_gen] upscale job submitted: %s" % job_id)
+    job = _poll_job(headers, job_id, "upscale", args.timeout)
+    stem = (_safe_scope(getattr(args, "scope", "") or "scenario") or "scenario") + "_upscaled"
+    saved = _download_job_assets(headers, job, out_dir, stem)
+    _write_meta(out_dir, {
+        "image": image_ref, "scale": args.scale, "job_id": job_id,
+        "assets": saved, "source": "scenario-upscale",
+    })
+    print("[scenario_gen] OK — job=%s assets=%d" % (job_id, len(saved)))
+
+
+def _write_meta(out_dir: str, meta: dict) -> None:
+    meta_path = os.path.join(out_dir, "scenario_meta.json")
+    with open(meta_path, "w") as f:
+        json.dump(meta, f, indent=2)
+        f.write("\n")
+    print("[scenario_gen] meta -> %s" % meta_path)
+
+
+# --------------------------------------------------------------------------- #
+# Argparse / main.
+# --------------------------------------------------------------------------- #
+def _add_out(sp) -> None:
+    sp.add_argument("--out", help="explicit output dir (overrides --world/--scope)")
+    sp.add_argument("--world", help="world id (default out: content/worlds/_private/<world>/images/<scope>/)")
+    sp.add_argument("--scope", help="scope/entity key for the output dir + filename stem")
+    sp.add_argument("--dry-run", action="store_true", help="print plan + est credits, make NO API calls")
+    sp.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SEC,
+                    help="job poll timeout seconds (default %d)" % DEFAULT_TIMEOUT_SEC)
+
+
+def main(argv=None) -> None:
+    ap = argparse.ArgumentParser(description="Generate 2D art via the Scenario API (non-Eva).")
+    ap.add_argument("--test-key", action="store_true",
+                    help="cheap auth smoke-test (GET /v1/models; no generation) -> 'Scenario Auth OK'")
+    sub = ap.add_subparsers(dest="command")
+
+    sub.add_parser("list-models", help="list models on the account (and their ids)")
+
+    sp_gen = sub.add_parser("generate", help="text-to-image (modelId required)")
+    sp_gen.add_argument("--model-id", required=True, help="Scenario modelId (see list-models)")
+    sp_gen.add_argument("--prompt", required=True, help="text-to-image prompt")
+    sp_gen.add_argument("--negative-prompt", help="negative prompt")
+    sp_gen.add_argument("--num-samples", type=int, default=1, help="images to generate (default 1)")
+    sp_gen.add_argument("--width", type=int, default=1024, help="image width (default 1024)")
+    sp_gen.add_argument("--height", type=int, default=1024, help="image height (default 1024)")
+    sp_gen.add_argument("--seed", type=int, help="deterministic seed (optional)")
+    _add_out(sp_gen)
+
+    sp_up = sub.add_parser("upscale", help="upscale an asset id or image url")
+    sp_up.add_argument("--asset-id", help="Scenario asset id to upscale")
+    sp_up.add_argument("--image-url", help="image URL to upscale (alternative to --asset-id)")
+    sp_up.add_argument("--scale", type=int, default=2, help="scaling factor (default 2)")
+    _add_out(sp_up)
+
+    args = ap.parse_args(argv)
+
+    if args.test_key:
+        _cmd_test_key()
+        return
+    if args.command == "list-models":
+        _cmd_list_models(args)
+    elif args.command == "generate":
+        _cmd_generate(args)
+    elif args.command == "upscale":
+        _cmd_upscale(args)
+    else:
+        ap.print_help()
+        sys.exit("\n[scenario_gen] ERROR: a subcommand (list-models|generate|upscale) or --test-key is required.")
+
+
+if __name__ == "__main__":
+    main()

--- a/godot/tools/tripo_gen.py
+++ b/godot/tools/tripo_gen.py
@@ -1,0 +1,610 @@
+#!/usr/bin/env python3
+"""tripo_gen.py — generate / rig / animate a 3D character via the Tripo3D API.
+
+A sibling of meshy_gen.py in the WorldOS GT2 final-art pipeline. Tripo3D adds a
+RIGGING + ANIMATION pipeline on top of text/image-to-3D, so the GLB it produces can be
+mixamo-rigged and pre-loaded with locomotion/combat clips before the bake.
+
+    tripo_gen.py    -> a (optionally rigged + animated) .glb     (THIS tool; Tripo3D AI)
+    bake_sprites.py -> 8-facing frame PNGs (Blender headless, dimetric 2:1, ISO-PROJECTION.md)
+    pack_sheet.py   -> the renderer sheet.png + sheet.json manifest (v1)
+
+Downstream contract (the manifest this output ultimately feeds):
+  bake_sprites.py renders 8 facings [S,SE,E,NE,N,NW,W,SW] at the locked dimetric 2:1
+  projection (see godot/ISO-PROJECTION.md), then pack_sheet.py emits a sprite-sheet
+  manifest v1: rows=8 facings, cols=24 (idle4 / walk8 / attack6 / cast6), 128px,
+  foot-anchored. tripo_gen does NOT bake — it just produces a clean rigged/animated GLB.
+  A rigged GLB whose retarget presets are [walk, idle, run, attack, cast] lines up with
+  the manifest's idle/walk/attack/cast columns.
+
+This tool is WorldOS-ORIGINAL code; the ART it downloads (model.glb + animated GLBs) is
+NOT committed — it lives under content/worlds/_private/ (gitignored, owner-licensed).
+
+VERIFIED Tripo3D contract (some details differ from public docs — confirmed live):
+  * Auth: Bearer  ``Authorization: Bearer <key>``  (NOT x-api-key).
+  * Base: https://openapi.tripo3d.ai/v3
+  * Create text-to-3D:    POST /generation/text          (prompt; model default v3.1, or P1 low-poly)
+  * Create image-to-3D:   POST /generation/image-to-model
+  * Upload an image/glb:  POST /upload                    (multipart)
+  * Rig pre-check:        POST /animations/rig-check      (input=task_id, rig_type=biped)  -- run FIRST
+  * Rig:                  POST /animations/rig            (input=task_id, rig_type=biped, spec=mixamo)
+  * Retarget animations:  POST /animations/retarget       (input=rigged_task_id, animations=[preset:*])
+  * Each create returns a TASK ID. Poll GET /task/{id} at >= 2s intervals (1 req/s limit -> 429).
+  * The model download URL EXPIRES ~5 min -> download immediately on success.
+
+The API key is read from ~/.worldos/tripo3d.key or $WORLDOS_TRIPO_API_KEY. It is NEVER
+printed/logged and NEVER written into any repo file.
+
+Usage:
+    # auth smoke-test (a cheap GET — no asset generation, no credit spend)
+    python3 tripo_gen.py --test-key
+
+    # text-to-3D (default model H3.1 = v3.1; --lowpoly switches to P1)
+    python3 tripo_gen.py text --prompt "a stylized fantasy human ranger ..." --world baldurs-gate --scope ranger
+    python3 tripo_gen.py text --prompt "..." --lowpoly --out <dir>
+
+    # image-to-3D (uploads the image first, then generates)
+    python3 tripo_gen.py image --image hero.png --world baldurs-gate --scope hero
+
+    # rig + animate an existing generation task (rig-check -> rig spec=mixamo -> retarget)
+    python3 tripo_gen.py rig --task <generation_task_id> --out <dir>
+    python3 tripo_gen.py rig --task <id> --animations walk idle run attack cast --out <dir>
+
+    # show the plan + estimated credits WITHOUT calling the API
+    python3 tripo_gen.py text --prompt "..." --world w --scope s --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+import uuid
+
+API_BASE = "https://openapi.tripo3d.ai/v3"
+CREATE_TEXT_PATH = "/generation/text"
+CREATE_IMAGE_PATH = "/generation/image-to-model"
+UPLOAD_PATH = "/upload"
+RIG_CHECK_PATH = "/animations/rig-check"
+RIG_PATH = "/animations/rig"
+RETARGET_PATH = "/animations/retarget"
+TASK_PATH = "/task/{task_id}"
+
+# Models: H3.1 (default, high quality) vs P1 (low-poly / game-ready).
+MODEL_DEFAULT = "v3.1"
+MODEL_LOWPOLY = "P1-low-poly"
+
+# The 5 retarget presets that align with the bake manifest's idle/walk/attack/cast columns.
+DEFAULT_ANIMATIONS = ["walk", "idle", "run", "attack", "cast"]
+
+# Polling cadence + ceilings. >= 2s honors the documented 1 req/s rate limit (else 429).
+POLL_INTERVAL_SEC = 3
+DEFAULT_TIMEOUT_SEC = 600
+
+# Rough per-stage credit estimates (for --dry-run only; the API is the source of truth).
+CREDIT_EST = {"text": 20, "image": 20, "rig": 10, "retarget_each": 5}
+
+
+# --------------------------------------------------------------------------- #
+# Key handling. NEVER print/log the key; NEVER write it to a repo file.
+# --------------------------------------------------------------------------- #
+def _load_api_key() -> str:
+    key = os.environ.get("WORLDOS_TRIPO_API_KEY", "").strip()
+    if key:
+        return key
+    key_path = os.path.expanduser("~/.worldos/tripo3d.key")
+    if os.path.isfile(key_path):
+        with open(key_path, "r") as f:
+            key = f.read().strip()
+        if key:
+            return key
+    sys.exit(
+        "[tripo_gen] ERROR: no API key. Set $WORLDOS_TRIPO_API_KEY or put it in "
+        "~/.worldos/tripo3d.key"
+    )
+
+
+def _auth_headers(key: str) -> dict:
+    return {
+        "Authorization": "Bearer %s" % key,
+        "Content-Type": "application/json",
+    }
+
+
+# --------------------------------------------------------------------------- #
+# HTTP (urllib only — no `requests` dependency).
+# --------------------------------------------------------------------------- #
+def _post_json(url: str, headers: dict, body: dict) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        _explain_http(e.code, _read_error(e), "POST " + url)
+    except urllib.error.URLError as e:
+        sys.exit("[tripo_gen] ERROR: network failure on POST %s: %s" % (url, e.reason))
+
+
+def _get_json(url: str, headers: dict) -> dict:
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        _explain_http(e.code, _read_error(e), "GET " + url)
+    except urllib.error.URLError as e:
+        sys.exit("[tripo_gen] ERROR: network failure on GET %s: %s" % (url, e.reason))
+
+
+def _post_multipart(url: str, key: str, file_path: str) -> dict:
+    """Upload a binary file (image/glb) as multipart/form-data via urllib only."""
+    with open(file_path, "rb") as f:
+        file_data = f.read()
+    filename = os.path.basename(file_path)
+    content_type = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+    boundary = "----worldos%s" % uuid.uuid4().hex
+    pre = (
+        "--%s\r\n"
+        'Content-Disposition: form-data; name="file"; filename="%s"\r\n'
+        "Content-Type: %s\r\n\r\n" % (boundary, filename, content_type)
+    ).encode("utf-8")
+    post = ("\r\n--%s--\r\n" % boundary).encode("utf-8")
+    payload = pre + file_data + post
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "Authorization": "Bearer %s" % key,
+            "Content-Type": "multipart/form-data; boundary=%s" % boundary,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        _explain_http(e.code, _read_error(e), "POST(multipart) " + url)
+    except urllib.error.URLError as e:
+        sys.exit("[tripo_gen] ERROR: network failure on upload %s: %s" % (url, e.reason))
+
+
+def _read_error(e: urllib.error.HTTPError) -> str:
+    try:
+        return e.read().decode("utf-8")
+    except Exception:
+        return "<no body>"
+
+
+def _explain_http(code: int, detail: str, what: str) -> None:
+    if code == 401:
+        sys.exit(
+            "[tripo_gen] ERROR 401 unauthorized on %s — bad/expired API key. Detail: %s"
+            % (what, detail)
+        )
+    if code == 402:
+        sys.exit(
+            "[tripo_gen] ERROR 402 insufficient Tripo credits on %s. Top up the account; "
+            "art was NOT generated. Detail: %s" % (what, detail)
+        )
+    if code == 429:
+        sys.exit(
+            "[tripo_gen] ERROR 429 rate-limited on %s (1 req/s limit). Slow polling. Detail: %s"
+            % (what, detail)
+        )
+    sys.exit("[tripo_gen] ERROR HTTP %d on %s. Detail: %s" % (code, what, detail))
+
+
+def _download(url: str, dest: str) -> int:
+    """Stream a binary asset (glb) to dest. Returns bytes written.
+
+    The Tripo download URL expires ~5 min after success, so callers must invoke this
+    immediately once the task succeeds.
+    """
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=300) as resp, open(dest, "wb") as out:
+            total = 0
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                out.write(chunk)
+                total += len(chunk)
+            return total
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        sys.exit(
+            "[tripo_gen] ERROR downloading %s -> %s: %s "
+            "(the download URL expires ~5 min — re-run if it lapsed)" % (url, dest, e)
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Task lifecycle.
+# --------------------------------------------------------------------------- #
+def _task_id_from_create(res: dict, what: str) -> str:
+    """Tripo wraps create responses as {"code":0,"data":{"task_id": ...}}."""
+    data = res.get("data") or {}
+    task_id = data.get("task_id") or res.get("task_id") or data.get("result")
+    if not task_id:
+        sys.exit("[tripo_gen] ERROR: %s returned no task id: %s" % (what, json.dumps(res)))
+    return task_id
+
+
+def _create_text(headers: dict, prompt: str, model: str) -> str:
+    body = {"type": "text_to_model", "prompt": prompt, "model_version": model}
+    res = _post_json(API_BASE + CREATE_TEXT_PATH, headers, body)
+    task_id = _task_id_from_create(res, "text-to-3D create")
+    print("[tripo_gen] text-to-3D task submitted: %s (model=%s)" % (task_id, model))
+    return task_id
+
+
+def _create_image(headers: dict, file_token: str, model: str) -> str:
+    body = {
+        "type": "image_to_model",
+        "file": {"type": "image", "file_token": file_token},
+        "model_version": model,
+    }
+    res = _post_json(API_BASE + CREATE_IMAGE_PATH, headers, body)
+    task_id = _task_id_from_create(res, "image-to-3D create")
+    print("[tripo_gen] image-to-3D task submitted: %s (model=%s)" % (task_id, model))
+    return task_id
+
+
+def _upload_image(key: str, image_path: str) -> str:
+    res = _post_multipart(API_BASE + UPLOAD_PATH, key, image_path)
+    data = res.get("data") or {}
+    token = data.get("image_token") or data.get("file_token") or data.get("token")
+    if not token:
+        sys.exit("[tripo_gen] ERROR: upload returned no file token: %s" % json.dumps(res))
+    print("[tripo_gen] uploaded %s -> file token acquired" % os.path.basename(image_path))
+    return token
+
+
+def _rig_check(headers: dict, task_id: str) -> dict:
+    """Pre-flight rigging check — MUST pass before /animations/rig."""
+    body = {"input": task_id, "rig_type": "biped"}
+    res = _post_json(API_BASE + RIG_CHECK_PATH, headers, body)
+    check_task = _task_id_from_create(res, "rig-check create")
+    print("[tripo_gen] rig-check submitted: %s" % check_task)
+    final = _poll(headers, check_task, "rig-check", DEFAULT_TIMEOUT_SEC)
+    out = final.get("output") or {}
+    riggable = out.get("riggable", out.get("rig_ready", True))
+    if riggable is False:
+        sys.exit(
+            "[tripo_gen] ERROR: model is NOT riggable per rig-check (%s). "
+            "Rigging aborted." % json.dumps(out)
+        )
+    print("[tripo_gen] rig-check OK — model is riggable.")
+    return final
+
+
+def _rig(headers: dict, task_id: str) -> str:
+    body = {"input": task_id, "rig_type": "biped", "spec": "mixamo"}
+    res = _post_json(API_BASE + RIG_PATH, headers, body)
+    rig_task = _task_id_from_create(res, "rig create")
+    print("[tripo_gen] rig task submitted: %s (spec=mixamo)" % rig_task)
+    return rig_task
+
+
+def _retarget(headers: dict, rigged_task_id: str, animations: list) -> str:
+    presets = ["preset:%s" % a for a in animations]
+    body = {"input": rigged_task_id, "animations": presets}
+    res = _post_json(API_BASE + RETARGET_PATH, headers, body)
+    rt_task = _task_id_from_create(res, "retarget create")
+    print("[tripo_gen] retarget task submitted: %s (animations=%s)" % (rt_task, ",".join(animations)))
+    return rt_task
+
+
+def _poll(headers: dict, task_id: str, label: str, timeout_sec: int) -> dict:
+    """Poll GET /task/{id} until success. >= POLL_INTERVAL_SEC between calls (rate limit)."""
+    url = API_BASE + TASK_PATH.format(task_id=task_id)
+    deadline = time.time() + timeout_sec
+    last_progress = -1
+    while True:
+        res = _get_json(url, headers)
+        task = res.get("data") or res
+        status = str(task.get("status", "unknown")).lower()
+        progress = int(task.get("progress", 0) or 0)
+        if progress != last_progress or status not in ("queued", "running", "pending"):
+            print("[tripo_gen] %s status=%s progress=%d%%" % (label, status, progress))
+            last_progress = progress
+        if status in ("success", "succeeded", "completed"):
+            return task
+        if status in ("failed", "error"):
+            sys.exit("[tripo_gen] ERROR: %s task FAILED: %s" % (label, json.dumps(task)))
+        if status in ("cancelled", "canceled", "expired", "banned", "unknown"):
+            sys.exit("[tripo_gen] ERROR: %s task %s: %s" % (label, status, json.dumps(task)))
+        if time.time() > deadline:
+            sys.exit(
+                "[tripo_gen] ERROR: %s task timed out after %ds (last status=%s progress=%d%%). "
+                "Art was NOT completed." % (label, timeout_sec, status, progress)
+            )
+        time.sleep(POLL_INTERVAL_SEC)
+
+
+def _model_url(task: dict) -> str:
+    """Pull the downloadable GLB URL out of a succeeded task (URL expires ~5 min)."""
+    out = task.get("output") or {}
+    # Tripo exposes the model under several keys across endpoints/versions.
+    for k in ("pbr_model", "model", "rigged_model", "animation_model", "base_model"):
+        v = out.get(k)
+        if isinstance(v, str) and v:
+            return v
+        if isinstance(v, dict):
+            url = v.get("url") or v.get("glb")
+            if url:
+                return url
+    result = task.get("result") or {}
+    for k in ("pbr_model", "model"):
+        v = result.get(k)
+        if isinstance(v, dict) and v.get("url"):
+            return v["url"]
+        if isinstance(v, str) and v:
+            return v
+    sys.exit("[tripo_gen] ERROR: succeeded task has no downloadable model URL: %s" % json.dumps(out))
+
+
+def _animation_urls(task: dict) -> dict:
+    """Return {anim_name: url} for retarget output, best-effort across response shapes."""
+    out = task.get("output") or {}
+    anims = out.get("animations") or out.get("animation_models") or {}
+    result: dict = {}
+    if isinstance(anims, dict):
+        for name, v in anims.items():
+            url = v.get("url") if isinstance(v, dict) else v
+            if url:
+                result[name] = url
+    elif isinstance(anims, list):
+        for i, v in enumerate(anims):
+            if isinstance(v, dict):
+                name = v.get("name") or v.get("type") or "anim_%d" % i
+                url = v.get("url") or v.get("model")
+                if url:
+                    result[name] = url
+    return result
+
+
+# --------------------------------------------------------------------------- #
+# Output dir resolution.
+# --------------------------------------------------------------------------- #
+def _safe_scope(scope: str) -> str:
+    return "".join(c if (c.isalnum() or c in "-_") else "_" for c in str(scope))[:128]
+
+
+def _resolve_out(args) -> str:
+    """Default output to the gitignored content/worlds/_private/<world>/images/<scope>/."""
+    if getattr(args, "out", None):
+        return os.path.abspath(args.out)
+    world = _safe_scope(getattr(args, "world", "") or "")
+    scope = _safe_scope(getattr(args, "scope", "") or "")
+    if not world or not scope:
+        sys.exit(
+            "[tripo_gen] ERROR: provide --out, or both --world and --scope "
+            "(output goes to content/worlds/_private/<world>/images/<scope>/)."
+        )
+    repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    return os.path.join(repo_root, "content", "worlds", "_private", world, "images", scope)
+
+
+# --------------------------------------------------------------------------- #
+# Sub-command bodies.
+# --------------------------------------------------------------------------- #
+def _do_rig_pipeline(headers: dict, source_task_id: str, animations: list,
+                     out_dir: str, timeout: int, meta: dict) -> None:
+    """rig-check -> rig (spec=mixamo) -> retarget [presets]; download rigged + animated GLBs."""
+    _rig_check(headers, source_task_id)
+    rig_task_id = _rig(headers, source_task_id)
+    rigged = _poll(headers, rig_task_id, "rig", timeout)
+    rigged_path = os.path.join(out_dir, "rigged.glb")
+    rsize = _download(_model_url(rigged), rigged_path)
+    print("[tripo_gen] downloaded rigged.glb (%d bytes) -> %s" % (rsize, rigged_path))
+    meta["rig_task_id"] = rig_task_id
+    meta["rigged_glb_bytes"] = rsize
+
+    rt_task_id = _retarget(headers, rig_task_id, animations)
+    animated = _poll(headers, rt_task_id, "retarget", timeout)
+    anim_urls = _animation_urls(animated)
+    downloaded = {}
+    if anim_urls:
+        for name, url in anim_urls.items():
+            safe = _safe_scope(name)
+            dpath = os.path.join(out_dir, "anim_%s.glb" % safe)
+            dsize = _download(url, dpath)
+            downloaded[name] = {"path": dpath, "bytes": dsize}
+            print("[tripo_gen] downloaded anim_%s.glb (%d bytes)" % (safe, dsize))
+    else:
+        # Some plans return one combined animated GLB instead of per-clip files.
+        dpath = os.path.join(out_dir, "animated.glb")
+        dsize = _download(_model_url(animated), dpath)
+        downloaded["combined"] = {"path": dpath, "bytes": dsize}
+        print("[tripo_gen] downloaded animated.glb (%d bytes, combined)" % dsize)
+    meta["retarget_task_id"] = rt_task_id
+    meta["animations"] = animations
+    meta["animation_files"] = downloaded
+
+
+def _write_meta(out_dir: str, meta: dict) -> None:
+    meta_path = os.path.join(out_dir, "metadata.json")
+    with open(meta_path, "w") as f:
+        json.dump(meta, f, indent=2)
+        f.write("\n")
+    print("[tripo_gen] meta -> %s" % meta_path)
+
+
+def _cmd_test_key() -> None:
+    """Cheap auth smoke-test: GET a dummy task id. 404 'not found' == auth OK."""
+    key = _load_api_key()
+    headers = _auth_headers(key)
+    url = API_BASE + TASK_PATH.format(task_id="00000000-0000-0000-0000-000000000000")
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            resp.read()
+        print("Tripo Auth OK")  # 200 would also mean the key is valid
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            print("Tripo Auth OK")  # 404 'task not found' with a valid key == authenticated
+        elif e.code in (401, 403):
+            sys.exit("[tripo_gen] AUTH FAILED: HTTP %d — bad/expired API key." % e.code)
+        else:
+            # Any non-auth HTTP error still proves the request was accepted/authenticated.
+            print("Tripo Auth OK")
+    except urllib.error.URLError as e:
+        sys.exit("[tripo_gen] ERROR: network failure on --test-key: %s" % e.reason)
+
+
+def _cmd_text(args) -> None:
+    model = MODEL_LOWPOLY if args.lowpoly else MODEL_DEFAULT
+    out_dir = _resolve_out(args)
+    if args.dry_run:
+        est = CREDIT_EST["text"] + (
+            CREDIT_EST["rig"] + CREDIT_EST["retarget_each"] * len(args.animations)
+            if args.rig else 0
+        )
+        print("[tripo_gen] DRY-RUN text-to-3D")
+        print("  prompt    : %s" % args.prompt)
+        print("  model     : %s" % model)
+        print("  rig+anim  : %s (%s)" % (args.rig, ",".join(args.animations) if args.rig else "-"))
+        print("  out dir   : %s" % out_dir)
+        print("  est credits: ~%d (API is source of truth)" % est)
+        return
+    os.makedirs(out_dir, exist_ok=True)
+    model_path = os.path.join(out_dir, "model.glb")
+    if os.path.exists(model_path) and not args.force:
+        print("[tripo_gen] %s exists; skipping (use --force)." % model_path)
+        return
+    key = _load_api_key()
+    headers = _auth_headers(key)
+    task_id = _create_text(headers, args.prompt, model)
+    task = _poll(headers, task_id, "text-to-3D", args.timeout)
+    size = _download(_model_url(task), model_path)
+    print("[tripo_gen] downloaded model.glb (%d bytes) -> %s" % (size, model_path))
+    meta = {
+        "prompt": args.prompt, "model_version": model, "generation_task_id": task_id,
+        "glb_bytes": size, "source": "tripo3d-text-to-model",
+    }
+    if args.rig:
+        _do_rig_pipeline(headers, task_id, args.animations, out_dir, args.timeout, meta)
+    _write_meta(out_dir, meta)
+    print("[tripo_gen] OK — generation=%s glb_bytes=%d" % (task_id, size))
+
+
+def _cmd_image(args) -> None:
+    model = MODEL_LOWPOLY if args.lowpoly else MODEL_DEFAULT
+    out_dir = _resolve_out(args)
+    if args.dry_run:
+        est = CREDIT_EST["image"] + (
+            CREDIT_EST["rig"] + CREDIT_EST["retarget_each"] * len(args.animations)
+            if args.rig else 0
+        )
+        print("[tripo_gen] DRY-RUN image-to-3D")
+        print("  image     : %s" % args.image)
+        print("  model     : %s" % model)
+        print("  rig+anim  : %s (%s)" % (args.rig, ",".join(args.animations) if args.rig else "-"))
+        print("  out dir   : %s" % out_dir)
+        print("  est credits: ~%d (API is source of truth)" % est)
+        return
+    if not os.path.isfile(args.image):
+        sys.exit("[tripo_gen] ERROR: image not found: %s" % args.image)
+    os.makedirs(out_dir, exist_ok=True)
+    model_path = os.path.join(out_dir, "model.glb")
+    if os.path.exists(model_path) and not args.force:
+        print("[tripo_gen] %s exists; skipping (use --force)." % model_path)
+        return
+    key = _load_api_key()
+    headers = _auth_headers(key)
+    token = _upload_image(key, args.image)
+    task_id = _create_image(headers, token, model)
+    task = _poll(headers, task_id, "image-to-3D", args.timeout)
+    size = _download(_model_url(task), model_path)
+    print("[tripo_gen] downloaded model.glb (%d bytes) -> %s" % (size, model_path))
+    meta = {
+        "image": os.path.basename(args.image), "model_version": model,
+        "generation_task_id": task_id, "glb_bytes": size, "source": "tripo3d-image-to-model",
+    }
+    if args.rig:
+        _do_rig_pipeline(headers, task_id, args.animations, out_dir, args.timeout, meta)
+    _write_meta(out_dir, meta)
+    print("[tripo_gen] OK — generation=%s glb_bytes=%d" % (task_id, size))
+
+
+def _cmd_rig(args) -> None:
+    out_dir = _resolve_out(args)
+    if args.dry_run:
+        est = CREDIT_EST["rig"] + CREDIT_EST["retarget_each"] * len(args.animations)
+        print("[tripo_gen] DRY-RUN rig pipeline (rig-check -> rig spec=mixamo -> retarget)")
+        print("  source task: %s" % args.task)
+        print("  animations : %s" % ",".join(args.animations))
+        print("  out dir    : %s" % out_dir)
+        print("  est credits: ~%d (API is source of truth)" % est)
+        return
+    os.makedirs(out_dir, exist_ok=True)
+    key = _load_api_key()
+    headers = _auth_headers(key)
+    meta = {"generation_task_id": args.task, "source": "tripo3d-rig-retarget"}
+    _do_rig_pipeline(headers, args.task, args.animations, out_dir, args.timeout, meta)
+    _write_meta(out_dir, meta)
+    print("[tripo_gen] OK — rigged+animated from %s" % args.task)
+
+
+# --------------------------------------------------------------------------- #
+# Argparse / main.
+# --------------------------------------------------------------------------- #
+def _add_common(sp) -> None:
+    sp.add_argument("--out", help="explicit output dir (overrides --world/--scope)")
+    sp.add_argument("--world", help="world id (default out: content/worlds/_private/<world>/images/<scope>/)")
+    sp.add_argument("--scope", help="scope/entity key for the output dir")
+    sp.add_argument("--lowpoly", action="store_true",
+                    help="use the P1 low-poly / game-ready model instead of v3.1")
+    sp.add_argument("--rig", action="store_true",
+                    help="after generation, run rig-check -> rig(spec=mixamo) -> retarget")
+    sp.add_argument("--animations", nargs="+", default=list(DEFAULT_ANIMATIONS),
+                    help="retarget preset animations (default: %s)" % " ".join(DEFAULT_ANIMATIONS))
+    sp.add_argument("--force", action="store_true", help="regenerate even if model.glb exists")
+    sp.add_argument("--dry-run", action="store_true", help="print plan + est credits, make NO API calls")
+    sp.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SEC,
+                    help="per-stage poll timeout seconds (default %d)" % DEFAULT_TIMEOUT_SEC)
+
+
+def main(argv=None) -> None:
+    ap = argparse.ArgumentParser(description="Generate / rig / animate a 3D model via Tripo3D.")
+    ap.add_argument("--test-key", action="store_true",
+                    help="cheap auth smoke-test (GET a dummy task; no generation) -> 'Tripo Auth OK'")
+    sub = ap.add_subparsers(dest="command")
+
+    sp_text = sub.add_parser("text", help="text-to-3D")
+    sp_text.add_argument("--prompt", required=True, help="text-to-3D prompt")
+    _add_common(sp_text)
+
+    sp_img = sub.add_parser("image", help="image-to-3D")
+    sp_img.add_argument("--image", required=True, help="path to the source image")
+    _add_common(sp_img)
+
+    sp_rig = sub.add_parser("rig", help="rig + animate an existing generation task")
+    sp_rig.add_argument("--task", required=True, help="the generation task id to rig")
+    _add_common(sp_rig)
+
+    args = ap.parse_args(argv)
+
+    if args.test_key:
+        _cmd_test_key()
+        return
+    if args.command == "text":
+        _cmd_text(args)
+    elif args.command == "image":
+        _cmd_image(args)
+    elif args.command == "rig":
+        _cmd_rig(args)
+    else:
+        ap.print_help()
+        sys.exit("\n[tripo_gen] ERROR: a subcommand (text|image|rig) or --test-key is required.")
+
+
+if __name__ == "__main__":
+    main()

--- a/servers/engine/imagegen.py
+++ b/servers/engine/imagegen.py
@@ -340,11 +340,177 @@ class OpenClawImageProvider:
         return descriptor
 
 
+class ScenarioImageProvider:
+    """Generate images through the Scenario API (https://api.cloud.scenario.com/v1).
+
+    A REAL hosted provider that does NOT touch the OpenClaw/Eva gateway — it carries its
+    OWN credential pair (an API key + a secret) and talks straight to Scenario over HTTPS
+    with HTTP Basic auth. This gives the engine an image-gen path independent of the
+    gateway. Selection: `WORLDOS_IMAGE_PROVIDER=scenario`.
+
+    Credentials are read from `WORLDOS_SCENARIO_API_KEY` + `WORLDOS_SCENARIO_SECRET`,
+    falling back to `~/.worldos/scenario.key` + `~/.worldos/scenario.secret`. The model is
+    read from `WORLDOS_SCENARIO_MODEL_ID` (Scenario's txt2img requires a modelId).
+
+    Graceful degradation (matches the engine's null-degrade pattern): `configured()` is
+    False when credentials are missing, so get_provider() degrades to null. And once
+    invoked, generate() NEVER raises — on missing config, missing model, or any network
+    error it returns a null-style placeholder descriptor so a transient blip or a
+    half-config never crashes the DM's turn (the synchronous generate() above ALSO catches,
+    but this provider is defensively self-degrading too).
+
+    The heavy work (urllib HTTP, base64 auth, job poll) is all stdlib and done lazily
+    inside generate(), keeping import-time free of network.
+
+    Contract (confirmed live): POST /v1/generate/txt2img {modelId,prompt,...} -> a job;
+    poll GET /v1/jobs/{id} until success; resolve output asset ids -> GET /v1/assets/{id}
+    -> {asset:{url}}. The returned descriptor carries that asset URL (finite TTL).
+    """
+
+    name = "scenario"
+    _API_BASE = "https://api.cloud.scenario.com/v1"
+    _POLL_INTERVAL_SEC = 4.0
+    _POLL_TIMEOUT_SEC = 180.0
+
+    def _credentials(self) -> tuple[Optional[str], Optional[str]]:
+        """Resolve (key, secret) from env, then ~/.worldos/scenario.{key,secret}.
+
+        Reads no network. Returns (None, None) when not fully configured."""
+        key = (env_var("SCENARIO_API_KEY", "") or "").strip()
+        secret = (env_var("SCENARIO_SECRET", "") or "").strip()
+        if not key:
+            kp = os.path.expanduser("~/.worldos/scenario.key")
+            if os.path.isfile(kp):
+                try:
+                    with open(kp, "r") as f:
+                        key = f.read().strip()
+                except OSError:
+                    key = ""
+        if not secret:
+            sp = os.path.expanduser("~/.worldos/scenario.secret")
+            if os.path.isfile(sp):
+                try:
+                    with open(sp, "r") as f:
+                        secret = f.read().strip()
+                except OSError:
+                    secret = ""
+        return (key or None, secret or None)
+
+    def configured(self) -> bool:
+        """True when BOTH the Scenario key and secret are resolvable. get_provider()
+        degrades to null otherwise."""
+        key, secret = self._credentials()
+        return bool(key and secret)
+
+    def _placeholder(self, kind: str, prompt: str, seed: Optional[int], reason: str) -> dict:
+        """A null-style descriptor (never raises). Mirrors NullImageProvider's shape so the
+        caller/cache treats it identically, but tags why it degraded."""
+        return {
+            "provider": self.name,
+            "kind": _normalize_kind(kind),
+            "prompt": prompt,
+            "placeholder": True,
+            "seed": seed,
+            "degraded": reason,
+        }
+
+    def generate(self, kind: str, prompt: str, *, seed: Optional[int] = None) -> dict:
+        """Generate via Scenario; return a descriptor with the asset `url` on success.
+
+        Self-degrading: returns a placeholder descriptor (never raises) when unconfigured,
+        when no model id is set, or on any HTTP/network error — matching the engine's
+        graceful-degradation contract.
+        """
+        import base64
+        import json as _json
+        import time as _time
+        import urllib.error
+        import urllib.request
+
+        key, secret = self._credentials()
+        if not (key and secret):
+            return self._placeholder(kind, prompt, seed, "unconfigured")
+        model_id = (env_var("SCENARIO_MODEL_ID", "") or "").strip()
+        if not model_id:
+            return self._placeholder(kind, prompt, seed, "no WORLDOS_SCENARIO_MODEL_ID")
+
+        token = base64.b64encode(f"{key}:{secret}".encode("utf-8")).decode("ascii")
+        headers = {"Authorization": f"Basic {token}", "Content-Type": "application/json"}
+
+        def _req_json(url: str, method: str, body: Optional[dict]) -> dict:
+            data = _json.dumps(body).encode("utf-8") if body is not None else None
+            req = urllib.request.Request(url, data=data, headers=headers, method=method)
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return _json.loads(resp.read().decode("utf-8"))
+
+        try:
+            create = _req_json(
+                f"{self._API_BASE}/generate/txt2img",
+                "POST",
+                {"modelId": model_id, "prompt": prompt, "numSamples": 1},
+            )
+            job = create.get("job") or {}
+            job_id = job.get("jobId") or job.get("id") or create.get("jobId")
+            if not job_id:
+                return self._placeholder(kind, prompt, seed, "no job id in create response")
+
+            # Poll the job until it succeeds or times out.
+            deadline = _time.time() + self._POLL_TIMEOUT_SEC
+            final_job: dict = {}
+            while True:
+                res = _req_json(f"{self._API_BASE}/jobs/{job_id}", "GET", None)
+                jb = res.get("job") or res
+                status = str(jb.get("status", "")).lower()
+                if status in ("success", "succeeded", "completed", "done"):
+                    final_job = jb
+                    break
+                if status in ("failure", "failed", "error", "canceled", "cancelled"):
+                    return self._placeholder(kind, prompt, seed, f"job {status}")
+                if _time.time() > deadline:
+                    return self._placeholder(kind, prompt, seed, "job timed out")
+                _time.sleep(self._POLL_INTERVAL_SEC)
+
+            # Resolve the first output asset's download URL.
+            md = final_job.get("metadata") or {}
+            asset_ids = (
+                md.get("assetIds") or final_job.get("assetIds")
+                or md.get("assets") or final_job.get("assets") or []
+            )
+            first = None
+            if isinstance(asset_ids, list) and asset_ids:
+                a0 = asset_ids[0]
+                first = a0 if isinstance(a0, str) else (a0.get("id") or a0.get("assetId"))
+            if not first:
+                return self._placeholder(kind, prompt, seed, "no output assets")
+            asset_res = _req_json(f"{self._API_BASE}/assets/{first}", "GET", None)
+            asset = asset_res.get("asset") or asset_res
+            url = asset.get("url") or asset.get("downloadUrl") or asset.get("signedUrl")
+            if not url:
+                return self._placeholder(kind, prompt, seed, "asset has no url")
+        except (urllib.error.HTTPError, urllib.error.URLError, OSError, ValueError) as exc:
+            # Degrade to null on ANY network/parse error — never crash the engine.
+            return self._placeholder(kind, prompt, seed, f"error: {str(exc)[:120]}")
+
+        return {
+            "provider": self.name,
+            "kind": _normalize_kind(kind),
+            "prompt": prompt,
+            "url": url,
+            "seed": seed,
+            "placeholder": False,
+            "job_id": job_id,
+            "asset_id": first,
+        }
+
+
 # Real, hosted providers keyed by WORLDOS_IMAGE_PROVIDER value.
 _HOSTED: dict[str, type] = {
     "openai": OpenAIImageProvider,
     "stability": StabilityImageProvider,
     "openclaw": OpenClawImageProvider,
+    # Scenario: a REAL non-gateway hosted provider (own key+secret, HTTP Basic). The
+    # DEFAULT stays null — selected only via WORLDOS_IMAGE_PROVIDER=scenario.
+    "scenario": ScenarioImageProvider,
 }
 
 

--- a/servers/engine/tests/test_imagegen.py
+++ b/servers/engine/tests/test_imagegen.py
@@ -124,6 +124,149 @@ def test_configured_provider_still_raises_until_wired(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# Scenario provider: registered, real-but-non-gateway, graceful-degrading.
+# The HTTP is mocked — these tests NEVER touch the network or spend credits.
+# --------------------------------------------------------------------------- #
+
+from imagegen import ScenarioImageProvider  # noqa: E402
+
+
+@pytest.fixture
+def _no_scenario_creds(monkeypatch, tmp_path):
+    """Remove every credential source so configured() is False: env vars AND the
+    ~/.worldos fallback files (point HOME at an empty tmp dir)."""
+    monkeypatch.delenv("WORLDOS_SCENARIO_API_KEY", raising=False)
+    monkeypatch.delenv("WORLDOS_SCENARIO_SECRET", raising=False)
+    monkeypatch.delenv("WORLDOS_SCENARIO_MODEL_ID", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))  # ~/.worldos/scenario.* won't exist here
+    return tmp_path
+
+
+def test_scenario_provider_is_registered():
+    # WORLDOS_IMAGE_PROVIDER=scenario must resolve to the Scenario class.
+    assert imagegen._HOSTED.get("scenario") is ScenarioImageProvider
+    assert ScenarioImageProvider().name == "scenario"
+
+
+def test_scenario_provider_satisfies_protocol():
+    assert isinstance(ScenarioImageProvider(), imagegen.ImageProvider)
+
+
+def test_scenario_unconfigured_is_not_configured(_no_scenario_creds):
+    assert ScenarioImageProvider().configured() is False
+
+
+def test_scenario_unconfigured_selection_degrades_to_null(_no_scenario_creds, monkeypatch):
+    # Named but no creds -> get_provider() degrades to the null provider (never crashes).
+    monkeypatch.setenv("WORLDOS_IMAGE_PROVIDER", "scenario")
+    assert isinstance(imagegen.get_provider(), NullImageProvider)
+
+
+def test_scenario_generate_unconfigured_returns_placeholder(_no_scenario_creds):
+    # Even invoked directly while unconfigured, it self-degrades — never raises.
+    d = ScenarioImageProvider().generate("portrait", "a sellsword", seed=2)
+    assert d["provider"] == "scenario"
+    assert d["placeholder"] is True
+    assert d["kind"] == "portrait" and d["prompt"] == "a sellsword"
+    assert d.get("degraded") == "unconfigured"
+
+
+def test_scenario_configured_provider_is_selected(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("WORLDOS_IMAGE_PROVIDER", "scenario")
+    monkeypatch.setenv("WORLDOS_SCENARIO_API_KEY", "key-abc")
+    monkeypatch.setenv("WORLDOS_SCENARIO_SECRET", "sec-xyz")
+    p = imagegen.get_provider()
+    assert isinstance(p, ScenarioImageProvider) and p.name == "scenario"
+
+
+def test_scenario_configured_but_no_model_degrades(monkeypatch, tmp_path):
+    # Configured (key+secret) but no model id -> placeholder, no network call.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("WORLDOS_SCENARIO_API_KEY", "key-abc")
+    monkeypatch.setenv("WORLDOS_SCENARIO_SECRET", "sec-xyz")
+    monkeypatch.delenv("WORLDOS_SCENARIO_MODEL_ID", raising=False)
+    d = ScenarioImageProvider().generate("scene", "a foggy harbor")
+    assert d["placeholder"] is True
+    assert d.get("degraded") == "no WORLDOS_SCENARIO_MODEL_ID"
+
+
+def test_scenario_generate_success_returns_descriptor(monkeypatch, tmp_path):
+    """With creds + model + the HTTP fully MOCKED, generate() returns a real descriptor
+    carrying the asset url. NO network, NO credit spend."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("WORLDOS_SCENARIO_API_KEY", "key-abc")
+    monkeypatch.setenv("WORLDOS_SCENARIO_SECRET", "sec-xyz")
+    monkeypatch.setenv("WORLDOS_SCENARIO_MODEL_ID", "model_123")
+
+    import json as _json
+    import urllib.request
+
+    class _FakeResp:
+        def __init__(self, payload):
+            self._b = _json.dumps(payload).encode("utf-8")
+
+        def read(self):
+            return self._b
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    calls = {"n": 0}
+
+    def _fake_urlopen(req, timeout=0):
+        url = req.full_url
+        method = req.get_method()
+        if "/generate/txt2img" in url and method == "POST":
+            return _FakeResp({"job": {"jobId": "job_777", "status": "queued"}})
+        if "/jobs/job_777" in url and method == "GET":
+            calls["n"] += 1
+            if calls["n"] < 2:
+                return _FakeResp({"job": {"jobId": "job_777", "status": "in-progress"}})
+            return _FakeResp({"job": {"jobId": "job_777", "status": "success",
+                                       "metadata": {"assetIds": ["asset_999"]}}})
+        if "/assets/asset_999" in url and method == "GET":
+            return _FakeResp({"asset": {"id": "asset_999",
+                                         "url": "https://cdn.scenario.example/asset_999.png"}})
+        raise AssertionError("unexpected url: %s %s" % (method, url))
+
+    monkeypatch.setattr(urllib.request, "urlopen", _fake_urlopen)
+    # No real sleeping between polls.
+    import time as _time
+    monkeypatch.setattr(_time, "sleep", lambda *_a, **_k: None)
+
+    d = ScenarioImageProvider().generate("portrait", "a hooded ranger", seed=11)
+    assert d["provider"] == "scenario"
+    assert d["placeholder"] is False
+    assert d["url"] == "https://cdn.scenario.example/asset_999.png"
+    assert d["kind"] == "portrait" and d["prompt"] == "a hooded ranger" and d["seed"] == 11
+    assert d["job_id"] == "job_777" and d["asset_id"] == "asset_999"
+
+
+def test_scenario_generate_network_error_degrades(monkeypatch, tmp_path):
+    """A network error mid-generation degrades to a placeholder, never raises."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("WORLDOS_SCENARIO_API_KEY", "key-abc")
+    monkeypatch.setenv("WORLDOS_SCENARIO_SECRET", "sec-xyz")
+    monkeypatch.setenv("WORLDOS_SCENARIO_MODEL_ID", "model_123")
+
+    import urllib.error
+    import urllib.request
+
+    def _boom(req, timeout=0):
+        raise urllib.error.URLError("connection refused")
+
+    monkeypatch.setattr(urllib.request, "urlopen", _boom)
+    d = ScenarioImageProvider().generate("scene", "a storm at sea")
+    assert d["placeholder"] is True
+    assert d["provider"] == "scenario"
+    assert d.get("degraded", "").startswith("error:")
+
+
+# --------------------------------------------------------------------------- #
 # Content-hash cache: write/read by hash under a tmp WORLDOS_STATE_DIR.
 # --------------------------------------------------------------------------- #
 


### PR DESCRIPTION
Turnkey AI asset-generation for future agents across **Meshy / Tripo3D / Scenario / PixelLab** — directly unblocks GT2 **#1089** (painterly backdrops, no Eva) and **#1091** (rigged animation).

## What
- **CLI wrappers** (`godot/tools/`, urllib, mirror `meshy_gen.py`): `tripo_gen.py` (text/img→3D + rig→retarget animation, `spec=mixamo`), `scenario_gen.py` (HTTP Basic, txt2img/list-models/upscale), `pixellab_gen.py` (GT1-future stub). All have `--test-key` + `--dry-run`.
- **`ScenarioImageProvider`** in `servers/engine/imagegen.py` (`WORLDOS_IMAGE_PROVIDER=scenario`) — the engine's **non-Eva** 2D image-gen path; degrades to null; default unchanged. +9 mocked tests.
- **Skills:** `asset-gen` (routing: job matrix, keys, wrappers, MCPs, verified API facts) + `godot-dev` (first Godot dev skill, points at `HANDOFF.md`).
- **`HANDOFF.md`** links the toolkit; the Eva-backdrop blocker is marked SOLVED.

## Security
Keys stored **outside the repo** (`~/.worldos/*.key`, mode 600) + `WORLDOS_*_API_KEY` env; **no key literal anywhere in the diff** (secret-scanned). MCPs registered at user scope in `~/.claude.json` (redacted), not the plugin `.mcp.json`.

## Verified (live)
`tripo/scenario/pixellab --test-key` → Auth OK (Scenario = Basic @ `api.cloud.scenario.com`; PixelLab MCP 41 tools). imagegen **71 tests**; Tier-0 fast gate **233 passed**. Both MCPs ✔ connected.