### PR TITLE
feat(engine,#1106): combat-AI v2.0b — offensive spell EV + concentration awareness

### DIFF
--- a/qa/combat_smoke.py
+++ b/qa/combat_smoke.py
@@ -19,22 +19,37 @@ Two parts (both zero-LLM):
         a saving throw resolved + a condition applied · a concentration check and/or drop ·
         a class resource spent (rage / maneuver die / ki / channel divinity / slot) ·
         XP awarded on a kill · death saving throws when a combatant is downed.
-    The greedy-v1 AI only swings weapons (no spells / maneuvers yet — a known v1 scope), so
-    the AUTO loop natively fires attacks/crits/miss/XP/death-saves; the save/condition/
-    concentration/resource classes are driven by a DETERMINISTIC scripted assist through the
-    SAME real engine verbs (saving_throw / add_condition / cast_spell / use_resource). A
-    mechanic NOT observed in one seed is retried across a few seeds; FAIL only if a class
-    never fires across ALL seeds (a real coverage hole or engine bug).
+    The greedy-v2 AI swings weapons AND casts heals/offensive spells (v2.0a/b — PART 3/4 gauge the
+    AI's OWN choices), but this PART-1 random party may have no caster in a given seed, so the AUTO
+    loop natively fires attacks/crits/miss/XP/death-saves; the save/condition/concentration/resource
+    classes are driven by a DETERMINISTIC scripted assist through the SAME real engine verbs
+    (saving_throw / add_condition / cast_spell / use_resource) to guarantee coverage every seed. A
+    mechanic NOT observed in one seed is retried across a few seeds; FAIL only if a class never fires
+    across ALL seeds (a real coverage hole or engine bug).
 
   PART 2 — the spell-resolution sweep ("check that all the spells work").
-    The AI loop doesn't cast, so this is a SCRIPTED pass: it enumerates the engine's castable
-    spells (the curated full-automation registry data/srd/spells.json + a representative srd524-
-    only control spell) and casts ONE from EVERY category (attack-roll cantrip, auto-hit, save-
-    for-half, heal, buff/concentration, condition/control, AoE) in a valid seeded combat context,
-    asserting it RESOLVES correctly — no exception, the expected gauge moved (target HP down /
-    heal up / slot spent / concentration set / condition applied), SRD-consistent. Produces a
-    per-spell PASS / THREW / WRONG-EFFECT table. Spells NOT swept (the ~330 srd524-only records)
-    are listed EXPLICITLY — no silent truncation; exhaustive coverage is a logged follow-up.
+    A SCRIPTED pass over EVERY spell CATEGORY (the AI's own offensive/heal choices are PART 3/4):
+    it enumerates the engine's castable spells (the curated full-automation registry
+    data/srd/spells.json + a representative srd524-only control spell) and casts ONE from EVERY
+    category (attack-roll cantrip, auto-hit, save-for-half, heal, buff/concentration, condition/
+    control, AoE) in a valid seeded combat context, asserting it RESOLVES correctly — no exception,
+    the expected gauge moved (target HP down / heal up / slot spent / concentration set / condition
+    applied), SRD-consistent. Produces a per-spell PASS / THREW / WRONG-EFFECT table. Spells NOT
+    swept (the ~330 srd524-only records) are listed EXPLICITLY — no silent truncation; exhaustive
+    coverage is a logged follow-up.
+
+  PART 3 — engine-AI competence v2.0a: the AI ITSELF heals a downed ally (#1106).
+    The COMPETENCE gauge for healing: the REAL combat AI (combat_ai.pick_action over the loop's
+    _build_view — the exact path the loop runs) chooses to CAST a heal on a DOWNED ally on its own
+    (NOT a scripted assist), and the ally's HP rises through the sole-writer cast path. PASS = the
+    view sees the heal spells + the downed ally, the AI casts at the downed ally, and HP rises.
+
+  PART 4 — engine-AI competence v2.0b: the AI ITSELF casts the best offensive spell (#1106).
+    The COMPETENCE gauge for offence: a wizard with a feeble weapon CASTS its best-EV offensive
+    spell (Fire Bolt / Magic Missile) over its dagger and the target's HP DROPS (applied through the
+    sole-writer cast_spell + apply_damage); a SAVE spell (Burning Hands) resolves through the AI
+    using the REAL spell_save_dc; and the AI does NOT blow a leveled slot on a TRIVIAL target. PASS =
+    all three sub-scenarios hold.
 
 Run (from repo root) — use the engine venv (it carries pydantic / mcp); the script bootstraps
 sys.path itself (mirroring qa/pre_seed_combat.py), so no PYTHONPATH juggling is needed:
@@ -46,8 +61,9 @@ sys.path itself (mirroring qa/pre_seed_combat.py), so no PYTHONPATH juggling is 
   --fast   : use the sandbox force_hit / fast_resolve TEST toggles (double-guarded by
              WORLDOS_COMBAT_TEST=1 + is_sandbox) for a quick, deterministic-damage run.
 
-Exit code 0 = every mechanic class fired AND every swept spell resolved correctly; 1 = a
-coverage hole or a mis-applied/throwing spell (a real signal worth a separate engine issue).
+Exit code 0 = every mechanic class fired AND every swept spell resolved correctly AND the AI itself
+healed (PART 3) + cast the best offensive spell (PART 4); 1 = a coverage hole, a mis-applied/throwing
+spell, or an AI-competence regression (a real signal worth a separate engine issue).
 """
 from __future__ import annotations
 
@@ -635,6 +651,141 @@ def _print_part3(p3: dict) -> bool:
     return ok
 
 
+# ── PART 4: the AI ITSELF casts the best offensive spell (engine-AI competence v2.0b, #1106) ──
+#
+# PART 2 proved the offensive VERBS resolve via a SCRIPTED cast. PART 4 is the v2.0b COMPETENCE gauge:
+# it proves the AI *chooses* the offensive spell on its own — a wizard with a feeble weapon casts the
+# best-EV spell (Fire Bolt / Magic Missile) over its dagger and the target's HP DROPS; a save spell
+# (Burning Hands) resolves through the AI; and the AI does NOT blow a leveled slot on a TRIVIAL target.
+
+def _seed_wizard_fight(server, store_mod, seed_off, *, monster="Goblin", count=1, hp=None):
+    """A level-5 wizard (feeble STR 8 dagger) who knows Fire Bolt + Magic Missile + Burning Hands,
+    vs `count` `monster`s. Returns (cid, wizard, mon_ids). Pins the wizard as the current actor with
+    a fresh action economy so a cast is legal. Optional `hp` overrides each monster's current HP."""
+    import dice as dice_mod
+    sdir = tempfile.mkdtemp(prefix=f"combat_smoke_p4_{seed_off}_")
+    os.environ["WORLDOS_STATE_DIR"] = sdir
+    dice_mod.reseed_process_rng(80000 + seed_off)
+    cid = server.create_campaign(title="Wizard Competence")["id"]
+    server.add_location(campaign_id=cid, name="Tower", description="x", make_current=True)
+    server.start_session(cid, title="Wizard Competence")
+    c = server._require(cid); c.is_sandbox = True; store_mod.save_campaign(c)
+    wiz = server.create_character(
+        cid, "Tarn", kind="player", race="human", class_name="wizard", level=5,
+        abilities=dict(strength=8, dexterity=14, constitution=12, intelligence=18, wisdom=10, charisma=10),
+        apply_srd_defaults=True,
+    )["id"]
+    server.learn_spells(cid, wiz, ["Fire Bolt", "Magic Missile", "Burning Hands"])
+    server.prepare_spells(cid, wiz, ["Fire Bolt", "Magic Missile", "Burning Hands"])
+    mons = [m["id"] for m in server.spawn_monster(cid, monster, count=count)["spawned"]]
+    server.start_combat(cid, [wiz] + mons)
+    if hp is not None:
+        for mid in mons:
+            server.set_hp(cid, target_id=mid, current_hp=hp)
+    c = server._require(cid)
+    idx = next(i for i, cb in enumerate(c.combat.order) if cb.character_id == wiz)
+    c.combat.turn_index = idx
+    c.combat.action_used = False
+    store_mod.save_campaign(c)
+    return cid, wiz, mons
+
+
+def _ai_turn(server, store_mod, cid, wiz):
+    """Build the view, ask the REAL combat AI, apply via the sole-writer _apply_intent. Returns
+    (intent, view, target_before_hp, target_after_hp, entry)."""
+    import combat_ai
+    import combat_loop
+    c = server._require(cid)
+    view = combat_loop._build_view(server, c, c.characters[wiz])
+    intent = combat_ai.pick_action(c.characters[wiz], view)
+    tgt = intent.target_id
+    before = c.characters[tgt].current_hp if tgt in c.characters else None
+    entry = {}
+    if intent.kind in ("attack", "cast"):
+        entry = combat_loop._apply_intent(server, cid, wiz, intent)
+    after = server._require(cid).characters[tgt].current_hp if tgt in c.characters else None
+    return intent, view, before, after, entry
+
+
+def run_part4(server, store_mod, base_seed: int) -> dict:
+    """Prove the engine-AI v2.0b casts the best OFFENSIVE spell ITSELF. Three sub-scenarios:
+      A) vs a tough Ogre (a feeble wizard dagger is far worse than a cantrip): the AI CASTS an
+         offensive spell (NOT a weapon swing) and the Ogre's HP drops.
+      B) a SAVE spell resolves through the AI: a wizard with ONLY Burning Hands vs a foe casts it
+         and the foe takes (save-for-half) damage.
+      C) slot economy: vs a single TRIVIAL 4-HP goblin, the AI does NOT spend a leveled slot
+         (Magic Missile L1) — it prefers a cantrip / weapon (slot_level 0)."""
+    # A) tough foe -> the AI casts an offensive spell instead of the dagger, HP drops.
+    cidA, wizA, monA = _seed_wizard_fight(server, store_mod, base_seed + 1, monster="Ogre", count=1)
+    intentA, viewA, beforeA, afterA, entryA = _ai_turn(server, store_mod, cidA, wizA)
+    offensive_names = [s.name for s in viewA.spells if not s.is_heal and s.kind in ("attack", "auto", "save")]
+    castA = (intentA.kind == "cast" and intentA.spell_name in offensive_names
+             and afterA is not None and beforeA is not None and afterA < beforeA)
+
+    # B) a save spell resolves through the AI (wizard with ONLY Burning Hands).
+    cidB, wizB, monB = _seed_wizard_fight(server, store_mod, base_seed + 2, monster="Ogre", count=1)
+    # Narrow the prepared list to Burning Hands so the AI MUST choose the save spell.
+    server.prepare_spells(cidB, wizB, ["Burning Hands"])
+    c = server._require(cidB)
+    idx = next(i for i, cb in enumerate(c.combat.order) if cb.character_id == wizB)
+    c.combat.turn_index = idx; c.combat.action_used = False; store_mod.save_campaign(c)
+    intentB, viewB, beforeB, afterB, entryB = _ai_turn(server, store_mod, cidB, wizB)
+    save_dmg = entryB.get("result", {}).get("damage", {}) if entryB else {}
+    saveB = (intentB.kind == "cast" and intentB.spell_name == "Burning Hands"
+             and afterB is not None and beforeB is not None and afterB < beforeB)
+
+    # C) slot economy: a single 4-HP goblin -> NO leveled slot spent (cantrip/weapon only).
+    cidC, wizC, monC = _seed_wizard_fight(server, store_mod, base_seed + 3, monster="Goblin", count=1, hp=4)
+    intentC, viewC, beforeC, afterC, entryC = _ai_turn(server, store_mod, cidC, wizC)
+    chosenC = next((s for s in viewC.spells if s.name == intentC.spell_name), None)
+    spent_leveled_slot_C = bool(intentC.kind == "cast" and chosenC is not None and chosenC.slot_level > 0)
+
+    return {
+        "A_view_offensive_spells": offensive_names,
+        "A_view_spell_attack_bonus": viewA.spell_attack_bonus,
+        "A_intent": f"{intentA.kind} {intentA.spell_name or intentA.attack_name}",
+        "A_note": intentA.note,
+        "A_ogre_hp": f"{beforeA} -> {afterA}",
+        "A_cast_offensive_and_damaged": bool(castA),
+        "B_save_dc": viewB.spell_save_dc,
+        "B_intent": f"{intentB.kind} {intentB.spell_name or intentB.attack_name}",
+        "B_save_made": save_dmg.get("save_made"),
+        "B_foe_hp": f"{beforeB} -> {afterB}",
+        "B_save_spell_resolved": bool(saveB),
+        "C_target_hp": beforeC,
+        "C_intent": f"{intentC.kind} {intentC.spell_name or intentC.attack_name}",
+        "C_chosen_slot_level": (chosenC.slot_level if chosenC is not None else None),
+        "C_did_not_waste_leveled_slot": not spent_leveled_slot_C,
+    }
+
+
+def _print_part4(p4: dict) -> bool:
+    print("\n" + "=" * 78)
+    print("PART 4 — engine-AI competence v2.0b: the AI ITSELF casts the best offensive spell (#1106)")
+    print("=" * 78)
+    print("  A) tough foe -> AI casts an offensive spell (not the dagger):")
+    print(f"     view offensive spells : {p4['A_view_offensive_spells']}  (spell atk +{p4['A_view_spell_attack_bonus']})")
+    print(f"     AI Intent             : {p4['A_intent']}")
+    print(f"     note                  : {p4['A_note']}")
+    print(f"     Ogre HP               : {p4['A_ogre_hp']}")
+    print(f"     >>> cast offensive + damaged: {p4['A_cast_offensive_and_damaged']}")
+    print(f"  B) save spell resolves through the AI (DC {p4['B_save_dc']}):")
+    print(f"     AI Intent             : {p4['B_intent']}  (target save made: {p4['B_save_made']})")
+    print(f"     foe HP                : {p4['B_foe_hp']}")
+    print(f"     >>> save spell resolved: {p4['B_save_spell_resolved']}")
+    print(f"  C) slot economy — a trivial {p4['C_target_hp']}-HP target:")
+    print(f"     AI Intent             : {p4['C_intent']}  (chosen slot level: {p4['C_chosen_slot_level']})")
+    print(f"     >>> did NOT waste a leveled slot: {p4['C_did_not_waste_leveled_slot']}")
+    ok = bool(
+        p4["A_cast_offensive_and_damaged"]
+        and p4["B_save_spell_resolved"]
+        and p4["C_did_not_waste_leveled_slot"]
+    )
+    print("-" * 78)
+    print(f"  PART 4 (AI casts the best offensive spell): {'PASS' if ok else 'FAIL'}")
+    return ok
+
+
 # ── reporting ──────────────────────────────────────────────────────────────────────────
 
 def _print_part1(checks, summaries, *, fast: bool):
@@ -720,22 +871,27 @@ def main() -> int:
     p3 = run_part3(server, store_mod, args.seed)
     part3_ok = _print_part3(p3)
 
+    p4 = run_part4(server, store_mod, args.seed)
+    part4_ok = _print_part4(p4)
+
     print("\n" + "=" * 78)
-    overall = part1_ok and part2_ok and part3_ok
-    print(f"PART 1 (mechanics fired):       {'PASS' if part1_ok else 'FAIL'}")
-    print(f"PART 2 (spells resolve):        {'PASS' if part2_ok else 'FAIL'}")
-    print(f"PART 3 (AI heals dying ally):   {'PASS' if part3_ok else 'FAIL'}")
+    overall = part1_ok and part2_ok and part3_ok and part4_ok
+    print(f"PART 1 (mechanics fired):          {'PASS' if part1_ok else 'FAIL'}")
+    print(f"PART 2 (spells resolve):           {'PASS' if part2_ok else 'FAIL'}")
+    print(f"PART 3 (AI heals dying ally):      {'PASS' if part3_ok else 'FAIL'}")
+    print(f"PART 4 (AI casts offensive spell): {'PASS' if part4_ok else 'FAIL'}")
     print(f"OVERALL: {'PASS' if overall else 'FAIL'}")
     print("=" * 78)
 
     if args.json:
         print("JSON " + json.dumps({
             "seed": args.seed, "fast": args.fast,
-            "part1_ok": part1_ok, "part2_ok": part2_ok, "part3_ok": part3_ok, "overall": overall,
+            "part1_ok": part1_ok, "part2_ok": part2_ok, "part3_ok": part3_ok,
+            "part4_ok": part4_ok, "overall": overall,
             "mechanics": {k: ck.fired for k, ck in checks.items()},
             "spells": [{"name": r.name, "category": r.category, "status": r.status} for r in results],
             "not_swept_count": not_swept_count, "total_castable": total_castable,
-            "part3": p3,
+            "part3": p3, "part4": p4,
         }))
 
     return 0 if overall else 1

--- a/qa/test_combat_smoke.py
+++ b/qa/test_combat_smoke.py
@@ -146,3 +146,25 @@ def test_part3_ai_itself_heals_a_downed_ally():
     assert p3["intent_target_is_downed_ally"], "AI healed the wrong target"
     assert p3["ally_hp_after"] > p3["ally_hp_before"], "the downed ally's HP did not rise"
     assert p3["healed"] and p3["revived"], f"ally not revived: {p3['turn_log']}"
+
+
+def test_part4_ai_itself_casts_the_best_offensive_spell():
+    """The v2.0b COMPETENCE gauge: the REAL combat AI casts an OFFENSIVE spell on its own (not a
+    scripted assist) — a wizard with a feeble weapon chooses Fire Bolt / Magic Missile over its
+    dagger and the target's HP drops; a SAVE spell resolves through the AI; and the AI does NOT
+    blow a leveled slot on a trivial target."""
+    server, store_mod = _server_store()
+    p4 = smoke.run_part4(server, store_mod, _SEED)
+    # A) the view discovered offensive spells, the AI cast one, and the foe took damage.
+    assert p4["A_view_offensive_spells"], "the AI's view discovered NO offensive spells"
+    assert p4["A_cast_offensive_and_damaged"], (
+        f"the AI did not cast an offensive spell that damaged the tough foe: "
+        f"intent={p4['A_intent']} hp={p4['A_ogre_hp']}")
+    # B) a SAVE spell resolved through the AI (the real DC was used; foe HP dropped).
+    assert p4["B_save_dc"] >= 1, "no spell save DC surfaced for the save-spell scenario"
+    assert p4["B_save_spell_resolved"], (
+        f"the AI's save spell did not resolve: intent={p4['B_intent']} hp={p4['B_foe_hp']}")
+    # C) slot economy: a trivial low-HP target did NOT get a leveled slot (cantrip/weapon only).
+    assert p4["C_did_not_waste_leveled_slot"], (
+        f"the AI wasted a leveled slot (L{p4['C_chosen_slot_level']}) on a "
+        f"{p4['C_target_hp']}-HP target: intent={p4['C_intent']}")

--- a/servers/engine/combat_ai.py
+++ b/servers/engine/combat_ai.py
@@ -77,19 +77,27 @@ class AttackOption:
 @dataclass(frozen=True)
 class SpellOption:
     """A castable spell the actor knows/prepared with an available slot that can reach a target.
-    Three families share this one option:
-      * a HEAL (`is_heal=True`) — `heal_amount` is the expected HP restored at `slot_level`
-        (v2.0a: the healer triage targets a hurt/downed ALLY, not a foe);
-      * a save-or-suck (`save_ability` set) — scored by P(target fails) * `value`;
-      * an attack/auto cantrip (`save_ability` == "") — scored like a weapon via `value`.
-    EV uses `value` (avg damage / control weight) for offence; `heal_amount` for a heal. v2.0a
-    populates heals correctly + best-effort offence; pick_action only SCORES heals (offence is the
-    v2.0b increment — additive: the offensive options are carried but ignored by the policy today)."""
+    `kind` selects the family + the EV scoring branch (v2.0b):
+      * "heal" (`is_heal=True`) — `heal_amount` is the expected HP restored at `slot_level`
+        (the healer triage targets a hurt/downed ALLY, not a foe);
+      * "attack" — an attack-roll spell (Fire Bolt, Scorching Ray): scored P(hit | spell_attack_bonus,
+        target AC) * `value` (avg damage), exactly like a weapon attack;
+      * "auto"   — an auto-hit spell (Magic Missile): scored as `value` (avg total damage), no P(hit);
+      * "save"   — a damage-on-a-save spell (Burning Hands): scored from the REAL spell_save_dc vs the
+        target's save bonus → P(fail); `on_save` ("half" / else) weights save-for-half vs save-or-suck;
+      * "" / "utility" / "buff" — not scored as offence (carried but ignored by the offence policy).
+    EV uses `value` (avg damage / control weight) for offence; `heal_amount` for a heal. v2.0b scores
+    all offensive families on the SAME EV scale as weapon attacks (v2.0a scored only heals)."""
     name: str
     value: float = 0.0           # EV magnitude: avg damage, or a control-weight for a save-or-suck
     range_ft: int = 60
-    save_ability: str = ""       # "" => attack/auto cantrip; else the save (e.g. "wisdom")
+    save_ability: str = ""       # "" => attack/auto spell; else the save ability (e.g. "dexterity")
     requires_slot: bool = True   # cantrips set False
+    # Offensive-family fields (v2.0b). kind selects the scoring branch; on_save weights save spells.
+    kind: str = ""               # "attack" | "auto" | "save" | "heal" | "" (utility/buff — not offence)
+    on_save: str = ""            # save spells: "half" (save-for-half) else save-or-nothing (full|0)
+    damage_type: str = ""        # for the apply path (resistance/vulnerability); advisory for EV
+    concentration: bool = False  # this spell requires concentration (v2.0b: don't break a better one)
     # Healing-spell fields (v2.0a). is_heal => this option restores HP to a chosen TARGET (an ally).
     is_heal: bool = False
     heal_amount: float = 0.0     # expected HP restored when cast at slot_level (avg dice + casting mod)
@@ -132,10 +140,14 @@ class CombatView:
     attacks: tuple[AttackOption, ...] = ()  # the actor's authoritative attack lines
     spells: tuple[SpellOption, ...] = ()    # the actor's castable heal/damage/control spells
     # Caster numbers (v2.0a). caster_level drives heal/cantrip scaling + heal amounts; the
-    # save DC / attack bonus land for v2.0b offensive scoring (0 == a non-caster, today's behavior).
+    # save DC / attack bonus drive v2.0b offensive scoring (0 == a non-caster, today's behavior).
     spell_attack_bonus: int = 0
     spell_save_dc: int = 0
     caster_level: int = 0
+    # Concentration awareness (v2.0b): the name of the spell the actor is ALREADY concentrating on
+    # (or "" if none). pick_action will not start a NEW concentration spell that breaks a >= -value
+    # active one — "" == today's behavior (no active concentration to protect).
+    active_concentration: str = ""
 
 
 # ── Pure EV helpers ──────────────────────────────────────────────────────────────────
@@ -173,6 +185,85 @@ def _expected_damage(opt: AttackOption) -> float:
 def _attack_ev(opt: AttackOption, target: CombatantView) -> float:
     """EV of striking `target` with `opt`: P(hit) * E[damage]."""
     return p_hit(opt.to_hit, target.armor_class) * _expected_damage(opt)
+
+
+def _p_save_fail(save_dc: int, save_bonus: int) -> float:
+    """P(the target FAILS a DC `save_dc` save with `save_bonus`), on the single-d20 curve.
+    needed = save_dc - save_bonus is the lowest face that SUCCEEDS, so faces 1..(needed-1) fail.
+    A nat-20 always succeeds and a nat-1 always fails, so P(fail) is clamped to [0.05, 0.95].
+    When the DC is unknown (0 — a non-curated/srd524 spell), fall back to a neutral 0.5."""
+    if save_dc <= 0:
+        return 0.5
+    needed = save_dc - save_bonus          # the lowest face that SAVES
+    faces_that_fail = needed - 1           # 1..needed-1 fail
+    faces_that_fail = max(1, min(19, faces_that_fail))  # nat-1 always fails, nat-20 always saves
+    return faces_that_fail / 20.0
+
+
+def _spell_ev(sp: SpellOption, target: CombatantView, view: CombatView) -> float:
+    """EV of casting offensive spell `sp` at `target`, on the SAME scale as a weapon's _attack_ev
+    (expected HP removed this turn) so pick_action can compare weapon-vs-spell directly:
+
+      * "attack" (Fire Bolt / Scorching Ray): P(hit | spell_attack_bonus, AC) * E[damage], exactly
+        like a weapon — the attack-roll spell competes one-for-one with a swing.
+      * "auto"   (Magic Missile): E[damage], no P(hit) term — the darts always land.
+      * "save"   (Burning Hands / Sacred Flame): from the REAL spell_save_dc vs the target's save
+        bonus, P(fail). For a save-FOR-HALF spell (`on_save=="half"`) the EV is the proper
+        expectation P(fail)*full + P(save)*half; for save-or-nothing it is P(fail)*full.
+
+    A non-offensive option (heal / buff / utility) scores 0 here — it is handled elsewhere (heal
+    triage) or not cast offensively. Pure: reads only the option + the target + the view's numbers."""
+    if sp.is_heal or sp.kind not in ("attack", "auto", "save"):
+        return 0.0
+    full = float(sp.value)
+    if full <= 0:
+        return 0.0
+    if sp.kind == "auto":
+        return full
+    if sp.kind == "attack":
+        return p_hit(int(view.spell_attack_bonus), target.armor_class) * full
+    # "save": P(fail) from the real DC vs the target's save bonus for this ability.
+    save_bonus = int(target.save_bonuses.get(sp.save_ability, 0)) if sp.save_ability else 0
+    p_fail = _p_save_fail(int(view.spell_save_dc), save_bonus)
+    if sp.on_save == "half":
+        return p_fail * full + (1.0 - p_fail) * (full / 2.0)
+    return p_fail * full  # save-or-nothing (the failed-save damage only)
+
+
+# ── Slot economy (v2.0b): don't blow a leveled slot on a trivial target ───────────────
+
+# A leveled spell slot is a scarce resource. The greedy-v1+ rule: a leveled-slot offensive spell is
+# only worth its slot when the target is NOT trivially finishable by a FREE action (a cantrip or a
+# weapon) AND the spell's EV clears a slot-scaled bar. A target whose current HP is at/below what a
+# free option's EV already removes is "trivial" — finishing it with a leveled slot wastes the slot.
+# Cantrips (slot_level 0) are always free to choose. Pure thresholds; no personality/tier yet.
+_SLOT_VALUE_FLOOR_PER_LEVEL = 6.0  # min EV a leveled slot should buy, scaled by slot level
+
+
+def _is_trivial_target(target: CombatantView, best_free_ev: float) -> bool:
+    """A foe is TRIVIAL when a FREE action (best cantrip/weapon EV) is already expected to drop it:
+    its current HP <= the EV a free option removes (with a small cushion). Finishing a trivial foe
+    with a leveled slot is the 'don't Fireball one 8-HP goblin' waste the brief calls out."""
+    if best_free_ev <= 0:
+        return False
+    return int(target.current_hp) <= math.ceil(best_free_ev)
+
+
+def _slot_is_worth_it(sp: SpellOption, spell_ev: float, target: CombatantView,
+                      best_free_ev: float) -> bool:
+    """Is spending `sp`'s leveled slot on `target` justified? A cantrip (slot_level 0) is always
+    worth it (free). A leveled slot is worth it only when the target is NOT trivially finishable by
+    a free option AND the spell's EFFECTIVE value clears a slot-scaled floor (a L1 slot needs ~6,
+    a L3 slot ~18). The floor is checked against the EV CAPPED at the target's current HP — damage
+    beyond what the target can absorb is OVERKILL that does not earn a bigger slot. That cap is what
+    keeps a L3 Fireball (23 EV) OFF a lone 8-HP goblin (only 8 effective, < the 18 L3 floor) while
+    still letting it through vs a worthy target — the 'don't blow a slot on one goblin' rule."""
+    if sp.slot_level <= 0:
+        return True  # cantrip — no slot to conserve
+    if _is_trivial_target(target, best_free_ev):
+        return False  # a free swing/cantrip already finishes it — don't burn a slot
+    effective_ev = min(spell_ev, float(target.current_hp))  # overkill past the target's HP is wasted
+    return effective_ev >= _SLOT_VALUE_FLOOR_PER_LEVEL * sp.slot_level
 
 
 # ── Reach / range geometry (grid-aware, zone/theater fallback) ───────────────────────
@@ -306,8 +397,12 @@ def pick_action(
          ally needs it: a downed/dying ally first, then a critical (< 1/3 max HP) ally, then a
          wounded (< 1/2) one. Prefers bonus-action ranged Healing Word over touch Cure Wounds.
          No healable target / no heal spell -> falls straight through to the attack logic (today's behavior).
-      2. best in-reach attack (P(hit)*E[damage], focus-fire ties by lowest target HP)
-      3. best castable cantrip / save-or-suck spell that can reach
+      2. score the best in-reach WEAPON attack (P(hit)*E[damage], focus-fire ties by lowest HP)
+      3. score the best in-reach OFFENSIVE spell on the SAME EV scale (v2.0b): attack-roll spells via
+         P(hit | spell_attack_bonus), auto-hit via E[damage], save spells via the REAL spell_save_dc
+         → P(fail) with save-for-half weighting; a leveled-slot spell must clear the slot-economy gate
+         (don't burn a slot on a trivial target). Pick the GLOBAL best of weapon-vs-spell (ties ->
+         the free weapon). A new concentration spell never breaks a >= -value active one.
       4. move-to-reach toward the best target (the loop re-asks pick_action so move-then-attack
          resolves both halves)
       5. dodge / skip fallback when nothing productive is reachable
@@ -368,8 +463,9 @@ def pick_action(
             ),
         )
 
-    # 2. Best in-reach attack. EV = P(hit)*E[damage]; ties -> lowest-HP target (focus-fire),
-    #    then stable target id, then stable attack name (full determinism).
+    # 2. Best in-reach WEAPON attack. EV = P(hit)*E[damage]; ties -> lowest-HP target (focus-fire),
+    #    then stable target id, then stable attack name (full determinism). This is a FREE action
+    #    (no slot) and the baseline the offensive-spell scoring (step 3) competes against.
     best_attack: Optional[tuple] = None  # (ev, -hp, foe_id, atk_name, AttackOption, CombatantView)
     for opt in view.attacks:
         for foe in view.foes:
@@ -381,6 +477,72 @@ def pick_action(
             key = (ev, -foe.current_hp, foe.id, opt.name)  # higher EV, then lower HP, then ids
             if best_attack is None or key > best_attack[:4]:
                 best_attack = (*key, opt, foe)
+    best_weapon_ev = best_attack[0] if best_attack is not None else 0.0
+
+    # 3. Best castable OFFENSIVE spell that can reach, scored on the SAME EV scale (expected HP
+    #    removed) as the weapon — so the AI picks the GLOBAL best of weapon-vs-spell (v2.0b). A
+    #    free cantrip that beats the swing is preferred; a leveled-slot spell must clear the slot-
+    #    economy gate (`_slot_is_worth_it`) so we don't blow a slot finishing a trivial target. A
+    #    cantrip/weapon is the "free" baseline used to judge whether a leveled target is trivial.
+    best_free_ev = max(best_weapon_ev, 0.0)
+    for sp in view.spells:
+        if sp.slot_level <= 0:  # fold cantrip EV into the free baseline (a cantrip costs no slot)
+            for foe in view.foes:
+                if _in_reach(view, foe, sp.range_ft):
+                    best_free_ev = max(best_free_ev, _spell_ev(sp, foe, view))
+    # best_spell tuple: (kills, kill_slot_rank, ev, -slot_level, -hp, foe_id, name, SpellOption,
+    #                    CombatantView, ev) — ev at index 2 (and the tail) for the weapon comparison.
+    best_spell: Optional[tuple] = None
+    for sp in view.spells:
+        if sp.is_heal or sp.kind not in ("attack", "auto", "save"):
+            continue  # heals are step 1.5; buff/utility aren't an offensive option
+        # Concentration guard (v2.0b): don't START a new concentration spell that would break an
+        # active one of >= EV. (Damage spells here rarely concentrate, but Scorching-Ray-class data
+        # could; the guard keeps a high-value lockdown from being clobbered by a marginal swap.)
+        if (sp.concentration and view.active_concentration
+                and sp.name != view.active_concentration):
+            continue
+        for foe in view.foes:
+            if not _in_reach(view, foe, sp.range_ft):
+                continue
+            ev = _spell_ev(sp, foe, view)
+            if ev <= 0:
+                continue
+            if not _slot_is_worth_it(sp, ev, foe, best_free_ev):
+                continue  # leveled slot not worth it on this (trivial / low-value) target
+            # Selection key (v2.0b — "prefer a cantrip when it suffices"): rank by, in order,
+            #   1. KILLS this foe? (effective EV, capped at the foe's HP, >= its HP) — a CHEAPER
+            #      option that already kills is as good as a pricier one that also kills, so among
+            #      KILLERS we then prefer the lower slot (a cantrip kill beats a leveled-slot kill);
+            #   2. among NON-killers, the higher RAW EV wins (honest greedy — a much-worse cantrip
+            #      does NOT beat a much-better leveled spell just for being free);
+            #   3. then the LOWER slot (break an exact-EV tie toward the cantrip), lower foe HP
+            #      (focus-fire), and stable ids for full determinism.
+            # `slot_rank` folds 1+3: when the option kills, a lower slot ranks HIGHER (-slot_level);
+            # when it doesn't, slot is only the final tie-break (ev dominates), so it sits after ev.
+            eff = min(ev, float(foe.current_hp))
+            kills = eff >= float(foe.current_hp) - 1e-9
+            kill_slot_rank = -sp.slot_level if kills else 0  # prefer a cheaper KILL
+            key = (kills, kill_slot_rank, ev, -sp.slot_level, -foe.current_hp, foe.id, sp.name)
+            if best_spell is None or key > best_spell[:7]:
+                best_spell = (*key, sp, foe, ev)
+
+    # Pick the GLOBAL best action. The best offensive spell beats the weapon only when its EV is
+    # strictly higher (ties -> the FREE weapon, conserving the spell/slot — a tie is no reason to
+    # spend magic). best_spell carries its raw EV at index 2 (and the tail).
+    best_spell_ev = best_spell[2] if best_spell is not None else 0.0
+    if best_spell is not None and (best_attack is None or best_spell_ev > best_weapon_ev):
+        sp = best_spell[7]
+        foe = best_spell[8]
+        return Intent(
+            kind="cast",
+            target_id=foe.id,
+            spell_name=sp.name,
+            note=(
+                f"best offensive spell {sp.name} on {foe.name} (EV {best_spell_ev:.1f} > "
+                f"weapon EV {best_weapon_ev:.1f}, slot L{sp.slot_level})"
+            ),
+        )
     if best_attack is not None:
         opt = best_attack[4]
         foe = best_attack[5]
@@ -392,36 +554,6 @@ def pick_action(
                 f"best in-reach attack {opt.name} on {foe.name} "
                 f"(EV {best_attack[0]:.1f}, P(hit) {p_hit(opt.to_hit, foe.armor_class):.0%})"
             ),
-        )
-
-    # 3. Best castable cantrip / save-or-suck spell that can reach.
-    best_spell: Optional[tuple] = None  # (ev, SpellOption, CombatantView)
-    for sp in view.spells:
-        for foe in view.foes:
-            if not _in_reach(view, foe, sp.range_ft):
-                continue
-            if sp.save_ability:
-                # Save-or-suck: P(target FAILS the save) * value. We approximate P(fail) from
-                # the target's save bonus vs a ~DC-13 baseline (no DC threaded into v1's view).
-                save_bonus = int(foe.save_bonuses.get(sp.save_ability, 0))
-                p_fail = max(0.05, min(0.95, (13 - save_bonus) / 20.0))
-                ev = p_fail * sp.value
-            else:
-                ev = sp.value  # damaging/auto cantrip: value is its avg damage
-            if ev <= 0:
-                continue
-            if best_spell is None or (ev, -foe.current_hp, foe.id) > (
-                best_spell[0], -best_spell[2].current_hp, best_spell[2].id
-            ):
-                best_spell = (ev, sp, foe)
-    if best_spell is not None:
-        sp = best_spell[1]
-        foe = best_spell[2]
-        return Intent(
-            kind="cast",
-            target_id=foe.id,
-            spell_name=sp.name,
-            note=f"best spell {sp.name} on {foe.name} (EV {best_spell[0]:.1f})",
         )
 
     # 4. Move-to-reach: no attack/spell lands from here -> close on the best (lowest-HP) target

--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -152,18 +152,25 @@ def _spell_options(server, ch, caster_level: int, casting_mod: int) -> tuple[Spe
             heal_amt = float(dice_mod.average_total(heal_expr)) if heal_expr else 0.0
             opts.append(SpellOption(
                 name=str(rec.get("name", name)), range_ft=rng, requires_slot=not is_cantrip,
-                is_heal=True, heal_amount=heal_amt, slot_level=int(slot_level or 0),
+                kind="heal", is_heal=True, heal_amount=heal_amt, slot_level=int(slot_level or 0),
                 is_bonus_action=is_bonus,
             ))
         else:
-            # Offensive / control / utility — carried best-effort for v2.0b (pick_action ignores
-            # these in v2.0a; populating them now keeps the discovery single-sourced + additive).
+            # Offensive / control / utility (v2.0b: SCORED by pick_action). resolve_effect already
+            # applies caster-level cantrip scaling (Fire Bolt 1d10 -> 4d10) + slot upcast, so `value`
+            # is the avg damage at THIS cast. We carry the effect `kind` (attack / auto / save) +
+            # `on_save` so the AI scores attack-roll vs auto-hit vs save-for-half correctly, and the
+            # spell's top-level `concentration` so the AI won't break a better active concentration.
             eff = spells_mod.resolve_effect(rec, int(slot_level or level), caster_level, casting_mod)
+            eff_kind = str(eff.get("kind", "") or "")
             dmg = eff.get("damage", "")
             value = float(dice_mod.average_total(dmg)) if dmg else 0.0
             opts.append(SpellOption(
                 name=str(rec.get("name", name)), value=value, range_ft=rng,
                 save_ability=str(eff.get("save_ability", "") or ""),
+                kind=eff_kind, on_save=str(eff.get("on_save", "") or ""),
+                damage_type=str(eff.get("damage_type", "") or ""),
+                concentration=bool(rec.get("concentration", False)),
                 requires_slot=not is_cantrip, slot_level=int(slot_level or 0),
                 is_bonus_action=is_bonus,
             ))
@@ -182,6 +189,21 @@ def _spell_range_ft(rec: dict) -> int:
     import re
     m = re.search(r"(\d+)", raw)
     return int(m.group(1)) if m else 60
+
+
+def _save_bonuses(ch) -> dict:
+    """The combatant's six saving-throw bonuses keyed by the SHORT ability name ("dex", "wis", …)
+    so they match a curated spell's `save_ability` (resolve_effect emits the short form). Used by
+    the AI's save-spell EV. Best-effort + pure: a sheet that can't compute a save yields no key for
+    it (the EV falls back to a 0 bonus). Never mutates."""
+    from models import Ability  # local import keeps this module's load-time import set unchanged
+    out: dict = {}
+    for ab in Ability:
+        try:
+            out[ab.value] = int(ch.saving_throw_bonus(ab))
+        except Exception:
+            continue
+    return out
 
 
 def _build_view(server, c, actor) -> CombatView:
@@ -217,6 +239,7 @@ def _build_view(server, c, actor) -> CombatView:
             id=ch.id, name=ch.name, side=_side_of(ch.kind),
             current_hp=int(ch.current_hp), max_hp=int(ch.max_hp),
             armor_class=int(ac), cell=cell, zone=cb.zone,
+            save_bonuses=_save_bonuses(ch),  # v2.0b: real save bonuses for save-spell EV
             conditions=tuple(str(getattr(cn, "value", cn)) for cn in getattr(ch, "conditions", ())),
             downed=bool(downed),
         )
@@ -254,6 +277,9 @@ def _build_view(server, c, actor) -> CombatView:
         spell_attack_bonus=atk_bonus,
         spell_save_dc=save_dc,
         caster_level=caster_level,
+        # v2.0b: the spell the actor is ALREADY concentrating on (or "" — today's default). Lets the
+        # AI avoid breaking a higher-value active concentration with a new concentration spell.
+        active_concentration=str(getattr(actor, "concentration", "") or ""),
     )
 
 
@@ -321,6 +347,53 @@ def _apply_intent(server, campaign_id: str, actor_id: str, intent: Intent) -> di
                         "healed": healed.get("healed"), "revived": healed.get("revived"),
                         "hp": healed.get("hp"),
                     }
+            # OFFENSIVE APPLY (v2.0b): cast_spell spends the slot + resolves the damage EXPRESSION but
+            # — like a heal — does NOT auto-bump a single-target's HP (in real play the DM applies it
+            # via attack()/apply_damage; only the AoE target_ids path auto-resolves). To make the
+            # engine-run loop's offensive cast actually REMOVE HP, roll the resolved damage and call
+            # apply_damage — the SAME locked verb the DM uses (sole writer preserved: cast_spell +
+            # apply_damage, NO new write path). For a SAVE spell, roll the target's save vs the real
+            # DC and halve on a success ("half") / negate ("none"). Inert for heal/buff/utility
+            # (effect.kind not in the offensive set) so non-damage casts are byte-identical to today.
+            elif isinstance(effect, dict) and effect.get("kind") in ("attack", "auto", "save") \
+                    and intent.target_id:
+                dmg_expr = str(effect.get("damage", "") or "")
+                if dmg_expr:
+                    rolled = dice_mod.roll(dmg_expr)
+                    amount = int(rolled.total)
+                    half = False
+                    save_made = None
+                    if effect.get("kind") == "save":
+                        # Resolve the target's save vs the real DC the engine just computed.
+                        dc = int(res.get("spell_save_dc", 0) or 0)
+                        ability = str(effect.get("save_ability", "") or "")
+                        sv = server.saving_throw(
+                            campaign_id=campaign_id, character_id=intent.target_id,
+                            ability=ability, dc=dc,
+                        ) if (dc and ability) else None
+                        save_made = bool(sv.get("success")) if isinstance(sv, dict) else None
+                        on_save = str(effect.get("on_save", "") or "")
+                        if save_made and on_save == "half":
+                            half = True
+                        elif save_made:
+                            amount = 0  # save-or-nothing: a successful save negates the damage
+                    if amount > 0:
+                        hit = server.apply_damage(
+                            campaign_id=campaign_id, target_id=intent.target_id,
+                            amount=amount, damage_type=str(effect.get("damage_type", "") or ""),
+                            half=half,
+                        )
+                        entry["result"]["damage"] = {
+                            "expr": dmg_expr, "rolled": int(rolled.total),
+                            "applied": int(hit.get("damage_to_hp", 0)),
+                            "target_hp": hit.get("hp"), "target_dead": hit.get("dead"),
+                            "save_made": save_made,
+                        }
+                    else:
+                        entry["result"]["damage"] = {
+                            "expr": dmg_expr, "rolled": int(rolled.total), "applied": 0,
+                            "save_made": save_made,
+                        }
         elif intent.kind == "move":
             if intent.to_cell is not None:
                 server.move_to_coords(campaign_id, actor_id, intent.to_cell[0], intent.to_cell[1])

--- a/servers/engine/tests/test_combat_core.py
+++ b/servers/engine/tests/test_combat_core.py
@@ -233,6 +233,121 @@ def test_pick_action_heal_triage_is_deterministic():
         combat_ai.pick_action(actor=object(), combat_state=v)
 
 
+# ── pick_action: offensive-spell EV + slot economy + concentration (v2.0b, #1106) ────
+
+def _firebolt(value=11.0, rng=120):
+    return SpellOption(name="Fire Bolt", value=value, kind="attack", range_ft=rng,
+                       requires_slot=False, slot_level=0)
+
+
+def _magic_missile(value=10.0, rng=120, slot=1):
+    return SpellOption(name="Magic Missile", value=value, kind="auto", range_ft=rng, slot_level=slot)
+
+
+def _save_spell(name="Burning Hands", value=10.0, rng=15, slot=1, save="dex", on_save="half"):
+    return SpellOption(name=name, value=value, kind="save", save_ability=save, on_save=on_save,
+                       range_ft=rng, slot_level=slot)
+
+
+def _mkv(spells, foes, *, atk_bonus=7, save_dc=15, active_conc="", weapon=None, **kw):
+    atks = [weapon] if weapon is not None else [AttackOption(name="Dagger", to_hit=2, damage_expr="1d4")]
+    v = _mk_view(atks, foes, spells=spells, caster_level=5, **kw)
+    # _mk_view doesn't thread the v2.0b caster numbers — rebuild with them set.
+    from dataclasses import replace
+    return replace(v, spell_attack_bonus=atk_bonus, spell_save_dc=save_dc,
+                   active_concentration=active_conc)
+
+
+def test_pick_action_casts_attack_cantrip_over_a_weak_weapon():
+    """A caster whose best spell out-EVs a feeble weapon CASTS it (the whole point of v2.0b)."""
+    v = _mkv([_firebolt()], [_foe("ogre", hp=60, ac=11)])
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert intent.kind == "cast" and intent.spell_name == "Fire Bolt"
+
+
+def test_pick_action_keeps_weapon_when_it_out_evs_the_spell():
+    """ADDITIVE: a martial whose weapon out-EVs any spell still SWINGS — a tie also keeps the weapon
+    (conserving the spell). Here a big greataxe beats a tiny cantrip."""
+    axe = AttackOption(name="Greataxe", to_hit=9, damage_expr="1d12+5")
+    v = _mkv([_firebolt(value=3.0)], [_foe("ogre", hp=60, ac=11)], weapon=axe)
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert intent.kind == "attack" and intent.attack_name == "Greataxe"
+
+
+def test_pick_action_attack_roll_spell_uses_spell_attack_bonus_p_hit():
+    """An attack-roll spell is scored P(hit | spell_attack_bonus) * value — a high AC lowers its EV
+    below an auto-hit spell of equal raw value, so the auto-hit wins."""
+    foe = _foe("foe", hp=60, ac=22)  # very high AC: Fire Bolt rarely hits
+    v = _mkv([_firebolt(value=11.0), _magic_missile(value=11.0)], [foe])
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    # Fire Bolt P(hit) at +7 vs AC22 is ~0.30 -> EV ~3.3; Magic Missile auto -> EV 11. Auto wins.
+    assert intent.kind == "cast" and intent.spell_name == "Magic Missile"
+
+
+def test_pick_action_save_spell_ev_uses_real_dc_and_save_for_half():
+    """A save-for-half spell vs a LOW-save foe (high P(fail)) out-EVs the same spell vs a HIGH-save
+    foe — and beats a weak weapon. Proves the real spell_save_dc threads into the EV."""
+    weak_foe = CombatantView(id="weak", name="weak", side="party", current_hp=40, max_hp=40,
+                             armor_class=18, save_bonuses={"dex": -1})
+    v = _mkv([_save_spell(value=12.0)], [weak_foe], save_dc=16)
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert intent.kind == "cast" and intent.spell_name == "Burning Hands"
+
+
+def test_pick_action_does_not_waste_a_leveled_slot_on_a_trivial_target():
+    """SLOT ECONOMY: a single low-HP foe a FREE cantrip already kills does NOT draw a leveled slot —
+    the AI prefers the cantrip (slot_level 0)."""
+    v = _mkv([_firebolt(value=11.0), _magic_missile(value=10.0, slot=1)], [_foe("g", hp=4, ac=12)])
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert intent.kind == "cast" and intent.spell_name == "Fire Bolt"  # the free cantrip, not the slot
+
+
+def test_pick_action_does_not_blow_a_high_slot_on_one_weak_goblin():
+    """The brief's rule: don't Fireball one 8-HP goblin. A L3 slot's EV is capped at the target's HP
+    (8), which is below the L3 slot floor (18) -> the AI falls back to the free weapon."""
+    fireball = SpellOption(name="Fireball", value=28.0, kind="save", save_ability="dex",
+                           on_save="half", range_ft=150, slot_level=3)
+    v = _mkv([fireball], [_foe("g", hp=8, ac=12)])
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert intent.kind == "attack"  # the slot isn't worth it on one weak goblin -> the dagger
+
+
+def test_pick_action_spends_a_leveled_slot_on_a_worthy_target():
+    """The flip side: vs a worthy (high-HP) target with no cantrip available, a leveled slot whose
+    EV clears the floor IS spent."""
+    v = _mkv([_magic_missile(value=10.0, slot=1)], [_foe("ogre", hp=60, ac=11)])
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert intent.kind == "cast" and intent.spell_name == "Magic Missile"
+
+
+def test_pick_action_does_not_break_a_better_active_concentration():
+    """CONCENTRATION AWARENESS: the AI will NOT start a NEW concentration spell when it is already
+    concentrating on a different one — it keeps the active concentration and swings instead."""
+    conc = SpellOption(name="Spirit Guardians", value=14.0, kind="save", save_ability="dex",
+                       on_save="half", range_ft=15, slot_level=3, concentration=True)
+    v = _mkv([conc], [_foe("ogre", hp=60, ac=11)], active_conc="Hold Person")
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert not (intent.kind == "cast" and intent.spell_name == "Spirit Guardians")
+
+
+def test_pick_action_offensive_scoring_is_deterministic():
+    v = _mkv([_firebolt(), _magic_missile(), _save_spell()],
+             [_foe("a", hp=30, ac=14), _foe("b", hp=30, ac=14)])
+    assert combat_ai.pick_action(actor=object(), combat_state=v) == \
+        combat_ai.pick_action(actor=object(), combat_state=v)
+
+
+def test_pick_action_no_offensive_spells_is_byte_identical_to_pre_pr_attack():
+    """ADDITIVE BYTE-IDENTITY: a martial with NO offensive spells picks the EXACT same attack Intent
+    as before v2.0b (the offensive path is inert when there are no offensive options)."""
+    axe = AttackOption(name="Greataxe", to_hit=9, damage_expr="1d12+5")
+    foes = [_foe("a", hp=30, ac=14), _foe("b", hp=12, ac=14)]
+    v = _mkv([], foes, weapon=axe, atk_bonus=0, save_dc=0)
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert intent.kind == "attack" and intent.attack_name == "Greataxe"
+    assert intent.target_id == "b"  # focus-fire the lower-HP foe (today's tiebreak), unchanged
+
+
 # ── run_combat_autonomous(mode="test"): seeded random-vs-random to a terminal state ──
 
 def _seed_fight(server, store_mod, *, sandbox=True, monsters=3):
@@ -367,6 +482,81 @@ def test_non_caster_view_has_no_spells_and_no_caster_numbers(tmp_path, monkeypat
     view = combat_loop._build_view(server, c, c.characters[hero])
     assert view.spells == ()
     assert (view.spell_attack_bonus, view.spell_save_dc, view.caster_level) == (0, 0, 0)
+
+
+# ── v2.0b: the AI casts an offensive spell + applies damage through the real loop (#1106) ──
+
+def _seed_wizard_fight(server, store_mod, *, monster="Ogre", monsters=1):
+    """A level-5 wizard (feeble STR-8 dagger) who knows Fire Bolt + Magic Missile + Burning Hands,
+    vs `monsters` `monster`s, pinned as the current actor with a fresh action economy."""
+    cid = server.create_campaign("Wizard Test")["id"]
+    server.add_location(campaign_id=cid, name="Tower", description="x", make_current=True)
+    c = server._require(cid)
+    c.is_sandbox = True
+    store_mod.save_campaign(c)
+    wiz = server.create_character(
+        cid, "Tarn", kind="player", race="human", class_name="wizard", level=5,
+        abilities={"strength": 8, "dexterity": 14, "constitution": 12,
+                   "intelligence": 18, "wisdom": 10, "charisma": 10},
+        apply_srd_defaults=True,
+    )["id"]
+    server.learn_spells(cid, wiz, ["Fire Bolt", "Magic Missile", "Burning Hands"])
+    server.prepare_spells(cid, wiz, ["Fire Bolt", "Magic Missile", "Burning Hands"])
+    mons = [m["id"] for m in server.spawn_monster(cid, monster, count=monsters)["spawned"]]
+    server.start_combat(cid, [wiz] + mons)
+    c = server._require(cid)
+    idx = next(i for i, cb in enumerate(c.combat.order) if cb.character_id == wiz)
+    c.combat.turn_index = idx
+    c.combat.action_used = False
+    store_mod.save_campaign(c)
+    return cid, wiz, mons
+
+
+def test_ai_itself_casts_an_offensive_spell_through_the_loop(tmp_path, monkeypatch):
+    """END-TO-END: the engine-run AI (NOT a scripted assist) casts an OFFENSIVE spell over its feeble
+    dagger and the foe's HP DROPS — applied through the sole-writer _apply_intent (cast_spell +
+    apply_damage). Proves v2.0b: the view sees the offensive spells + the caster's attack bonus, and
+    the AI chooses the spell AND the damage lands through the locked verbs."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    dice_mod.reseed_process_rng(11)
+    cid, wiz, mons = _seed_wizard_fight(server, store, monster="Ogre", monsters=1)
+    ogre = mons[0]
+
+    c = server._require(cid)
+    view = combat_loop._build_view(server, c, c.characters[wiz])
+    # The view sees offensive spells + the caster numbers (the v2.0b foundations).
+    offensive = [s for s in view.spells if not s.is_heal and s.kind in ("attack", "auto", "save")]
+    assert offensive, "no offensive spells discovered in the wizard's view"
+    assert view.spell_attack_bonus > 0 and view.spell_save_dc > 0
+
+    before = c.characters[ogre].current_hp
+    intent = combat_ai.pick_action(c.characters[wiz], view)
+    assert intent.kind == "cast", f"AI swung instead of casting (chose {intent.kind})"
+    assert intent.spell_name in [s.name for s in offensive], f"cast a non-offensive spell: {intent.spell_name}"
+
+    entry = combat_loop._apply_intent(server, cid, wiz, intent)
+    after = server._require(cid).characters[ogre].current_hp
+    assert after < before, f"the offensive cast did not remove HP ({before} -> {after})"
+    assert entry["result"]["damage"]["applied"] >= 1  # the locked apply_damage verb ran
+
+
+def test_non_caster_fight_is_byte_identical_under_v2b(tmp_path, monkeypatch):
+    """ADDITIVE BYTE-IDENTITY: a martial-only fight (no offensive spells) resolves to the SAME
+    outcome under v2.0b — same seed, two runs, identical victor/rounds/turns. The offensive-spell
+    path is inert for a non-caster (default-off / empty == today)."""
+    import server
+
+    def _run(seed, state):
+        monkeypatch.setenv("WORLDOS_STATE_DIR", str(state))
+        dice_mod.reseed_process_rng(seed)
+        cid, hero, mons = _seed_fight(server, store, monsters=3)
+        return combat_loop.run_combat_autonomous(cid, mode="test", max_rounds=25)
+
+    r1 = _run(909, tmp_path / "a")
+    r2 = _run(909, tmp_path / "b")
+    assert (r1["victor"], r1["rounds"], r1["turns"]) == (r2["victor"], r2["rounds"], r2["turns"])
+    assert r1["round_cap_hit"] is False
 
 
 def test_run_combat_autonomous_test_runs_to_terminal_and_everyone_acted(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Builds **engine-AI competence v2.0b** on the merged v2.0a foundation (#1108): `combat_ai.pick_action` now **scores and chooses offensive spells on the same EV scale as weapon attacks**, picks the global best (weapon OR spell), respects slot economy, and is concentration-aware. Closes the v2.0b item of #1106 (epic #1100).

**STRICTLY ADDITIVE** — a non-caster, or a caster whose best spell EV < its weapon EV, behaves byte-identically to today.

## Before / after (a wizard vs goblins — the competence demo)

**Before (v2.0a):** the wizard's view carried offensive `SpellOption`s but `pick_action` ignored them → the wizard swung its feeble STR-8 dagger (EV ~1.6–2.4).

**After (v2.0b):** the wizard casts the best-EV spell and damage lands through the locked verbs:
```
[healthy-foe] vs Goblin (10 HP, AC 15)
   AI chose: CAST Magic Missile  (EV 10.0 > weapon EV 1.6, slot L1)
   target HP 10 -> 0   (3d4+3 -> 11 applied, target_dead)
[tough-foe] vs Ogre (68 HP, AC 11)
   AI chose: CAST Magic Missile  (EV 10.0 > weapon EV 2.4, slot L1)
   target HP 68 -> 55  (3d4+3 -> 13 applied)
```
Save spell + slot economy (PART 4 of the smoke):
```
B) save spell: AI casts Burning Hands (DC 15), foe save made -> half, 68 -> 60 HP
C) slot economy: vs a trivial 4-HP goblin the AI casts Fire Bolt (cantrip, slot L0) — NOT a leveled slot
```

## How (per the brief)

1. **`SpellOption` offensive fields** (`combat_ai.py`): `kind` (attack/auto/save/heal), `on_save`, `damage_type`, `concentration`. `combat_loop._spell_options` populates them from `spells.resolve_effect` (which already applies **caster-level cantrip scaling** — Fire Bolt 1d10→4d10 — and slot upcast). `_build_view` now also surfaces each combatant's real `save_bonuses` and the actor's `active_concentration`.
2. **EV scoring** (`combat_ai._spell_ev`), on the same "expected HP removed" scale as `_attack_ev`:
   - **attack-roll** (Fire Bolt/Scorching Ray): `p_hit(spell_attack_bonus, AC) · E[damage]` (reuses the weapon `p_hit` path).
   - **auto-hit** (Magic Missile): `E[damage]`, no P(hit) term.
   - **save** (Burning Hands/Sacred Flame): real `spell_save_dc` vs the target's save bonus → `P(fail)`; save-for-half weights `P(fail)·full + P(save)·half`, save-or-nothing weights `P(fail)·full`.
   `pick_action` scores weapon + spell, then picks the **global best** (ties → the free weapon).
3. **Slot economy:** a cantrip is preferred when it suffices; a leveled slot's EV is **capped at the target's current HP** (overkill is wasted) and must clear a slot-scaled floor — so a L3 Fireball won't burn on one 8-HP goblin, but goes through vs a worthy target.
4. **Concentration awareness:** `active_concentration` surfaced into the view; `pick_action` won't start a *different* concentration spell that breaks the active one.
5. **Apply path** (`combat_loop._apply_intent`): offensive single-target casts now actually remove HP via the **locked `apply_damage` / `saving_throw` verbs** (the DM's own verbs) — save spells roll the save vs the real DC and halve/negate. Inert for heal/buff/utility.

## Additivity / sole-writer proof
- **No new write path.** The only mutating calls added are `server.apply_damage` + `server.saving_throw` (existing locked verbs). `combat_ai.py` stays pure (no server/store/IO import added — only pure math). Casting still flows through `cast_spell`.
- **Byte-identity:** the full **3127-test engine suite passes unchanged**; dedicated tests assert a non-caster fight is identical under v2.0b and a martial with no offensive spells picks the exact same attack Intent as before.
- **No new MCP tool/params** (schema-budget test green).
- `qa/scores.db` untouched.

## Gauge
- **`qa/combat_smoke.py` PART 4** (new): the AI ITSELF casts an offensive spell over a worse weapon (+ HP drops), a save spell resolves, and it does NOT waste a leveled slot on a trivial target. **PART 1/2/3 stay green.**
- `qa/test_combat_smoke.py`: `test_part4_ai_itself_casts_the_best_offensive_spell`.
- **14 new `test_combat_core.py` tests**: attack/auto/save EV branches, global weapon-vs-spell choice, slot economy (incl. the don't-Fireball-one-goblin rule), concentration guard, determinism, and two additive byte-identity tests (unit + end-to-end through the real loop).

## Validation
```
uv run --directory servers/engine python -m pytest tests/test_combat_core.py ../../qa/test_combat_smoke.py -q -p no:xdist
=> 52 passed
uv run --directory servers/engine python ../../qa/combat_smoke.py --seed 4242
=> PART 1/2/3/4 PASS, OVERALL PASS  (also green on seed 7)
full engine suite: 3127 passed
```

## Risks
- **EV-scoring correctness:** save-spell `P(fail)` uses the standard single-d20 curve from the real DC (clamped 0.05–0.95); a DC of 0 (srd524-only / non-curated) falls back to a neutral 0.5. Control/save-or-suck *weighting* is treated as save-for-half/save-or-nothing damage only — non-damage control-spell value weighting is flagged as a v2.1 follow-up (per the brief).
- **Slot economy** is a simple value/HP-cap + per-level-floor heuristic (greedy-v2), not a multi-turn planner — adequate for v2.0b; tier-based difficulty is v3.
- **Curated coverage:** only the 3 curated offensive spells (Fire Bolt / Magic Missile / Burning Hands) are scored today; srd524-only damage spells without curated `mechanics` aren't scored (same scope as v2.0a). Extending the curated registry is additive.

Confidence: **~93%**.