### PR TITLE
feat(engine,#1106): combat-AI v2.0c — martial class abilities + bonus-action economy

### DIFF
--- a/qa/combat_smoke.py
+++ b/qa/combat_smoke.py
@@ -786,6 +786,251 @@ def _print_part4(p4: dict) -> bool:
     return ok
 
 
+# ── PART 5: the AI ITSELF uses martial class abilities (engine-AI competence v2.0c, #1106) ──
+#
+# PART 1's table proved the ability VERBS resolve via a SCRIPTED assist. PART 5 is the v2.0c
+# COMPETENCE gauge: the REAL combat AI (combat_ai over combat_loop, the exact loop path) *chooses*
+# the martial ability itself. Five sub-scenarios, each a different ability the AI fires on its own:
+#   A) Second Wind  — a HURT fighter uses its bonus-action self-heal; HP rises via the AI's choice.
+#   B) Action Surge — a fighter with a finishable foe spends Action Surge for an EXTRA Attack action
+#      (the loop grants more strikes than the base budget).
+#   C) Maneuver     — a Battle Master declares a Trip-Attack maneuver on a worthy attack (die folds in).
+#   D) Sneak Attack — a rogue with an ally adjacent to the target TAGS the strike with its sneak dice.
+#   E) Guided Strike — a War cleric spends Channel Divinity (+10) on a likely-MISS key attack.
+# Bar: each ability is CHOSEN BY THE AI (not scripted) and APPLIED through the locked verbs.
+
+def _p5_seed(server, store_mod, tag, seed_off):
+    """A fresh sandboxed campaign + current-location + combat scaffold for a PART-5 scenario."""
+    import dice as dice_mod
+    sdir = tempfile.mkdtemp(prefix=f"combat_smoke_p5_{tag}_{seed_off}_")
+    os.environ["WORLDOS_STATE_DIR"] = sdir
+    dice_mod.reseed_process_rng(90000 + seed_off)
+    cid = server.create_campaign(title=f"Martial {tag}")["id"]
+    server.add_location(campaign_id=cid, name="Arena", description="x", make_current=True)
+    server.start_session(cid, title=f"Martial {tag}")
+    c = server._require(cid); c.is_sandbox = True; store_mod.save_campaign(c)
+    return cid
+
+
+def _p5_make_current(server, store_mod, cid, who):
+    """Pin `who` as the current combatant with a fresh action economy so its turn is legal."""
+    c = server._require(cid)
+    idx = next(i for i, cb in enumerate(c.combat.order) if cb.character_id == who)
+    c.combat.turn_index = idx
+    c.combat.action_used = False
+    c.combat.bonus_action_used = False
+    c.combat.action_attacks_made = 0
+    c.combat.surge_actions = 0
+    store_mod.save_campaign(c)
+
+
+def _p5_fighter(server, cid, level=5, subclass=None):
+    kw = dict(subclass=subclass) if subclass else {}
+    return server.create_character(
+        cid, "Garrick", kind="player", race="human", class_name="fighter", level=level,
+        abilities=dict(strength=18, dexterity=14, constitution=16, intelligence=10, wisdom=12, charisma=10),
+        apply_srd_defaults=True, **kw,
+    )["id"]
+
+
+def run_part5(server, store_mod, base_seed: int) -> dict:
+    """Prove the engine-AI v2.0c uses MARTIAL class abilities ITSELF (no scripted assist)."""
+    import combat_ai
+    import combat_loop
+    import dice as dice_mod
+
+    out: dict = {}
+
+    # A) SECOND WIND — a hurt fighter self-heals via its own bonus action.
+    cid = _p5_seed(server, store_mod, "sw", base_seed + 1)
+    ft = _p5_fighter(server, cid, level=5)
+    gob = [m["id"] for m in server.spawn_monster(cid, "Goblin", count=1)["spawned"]]
+    server.start_combat(cid, [ft] + gob)
+    c = server._require(cid)
+    server.set_hp(cid, target_id=ft, current_hp=max(1, c.characters[ft].max_hp // 3))
+    _p5_make_current(server, store_mod, cid, ft)
+    c = server._require(cid)
+    view = combat_loop._build_view(server, c, c.characters[ft])
+    sw_ability = any(a.kind == "second_wind" for a in view.abilities)
+    bonus = combat_ai.pick_bonus_action(c.characters[ft], view)
+    sw_before = c.characters[ft].current_hp
+    sw_after = sw_before
+    if bonus is not None and bonus.kind == "use_resource" and bonus.resource == "second_wind":
+        combat_loop._apply_intent(server, cid, ft, bonus)
+        sw_after = server._require(cid).characters[ft].current_hp
+    out["A_second_wind"] = {
+        "ability_in_view": sw_ability,
+        "chose_second_wind": bool(bonus is not None and bonus.resource == "second_wind"),
+        "hp": f"{sw_before} -> {sw_after}",
+        "healed": sw_after > sw_before,
+        "ok": bool(sw_ability and bonus is not None and bonus.resource == "second_wind"
+                   and sw_after > sw_before),
+    }
+
+    # B) ACTION SURGE — exercise the REAL LOOP (not an isolated should_action_surge call, which would
+    #    miss that attack() sets action_used before the surge decision). A level-5 fighter (Extra
+    #    Attack: base 2 strikes) vs finishable goblins runs ONE loop round; we assert the loop spent
+    #    Action Surge AND the fighter made MORE than its base-budget strikes (the surge granted them).
+    cid = _p5_seed(server, store_mod, "as", base_seed + 2)
+    ft = _p5_fighter(server, cid, level=5)
+    gobs = [m["id"] for m in server.spawn_monster(cid, "Goblin", count=4)["spawned"]]
+    server.start_combat(cid, [ft] + gobs)
+    _p5_make_current(server, store_mod, cid, ft)
+    c = server._require(cid)
+    view = combat_loop._build_view(server, c, c.characters[ft])
+    as_ability = any(a.kind == "action_surge" for a in view.abilities)
+    base_budget = max(1, server._attacker_multiattack_count(c.characters[ft], c))
+    surge_uses_before = (c.characters[ft].class_resources["action_surge"].max
+                         - c.characters[ft].class_resources["action_surge"].used)
+    rr = combat_loop.run_combat_round(cid, mode="test")
+    ft_entries = [e for e in rr["round_digest"] if e["actor_id"] == ft]
+    surge_spent = any(
+        e["kind"] == "use_resource" and e.get("result", {}).get("resource") == "action_surge"
+        and e.get("result", {}).get("ok") for e in ft_entries
+    )
+    strikes = sum(1 for e in ft_entries if e["kind"] == "attack")
+    c2 = server._require(cid)
+    surge_uses_after = (c2.characters[ft].class_resources["action_surge"].max
+                        - c2.characters[ft].class_resources["action_surge"].used)
+    out["B_action_surge"] = {
+        "ability_in_view": as_ability,
+        "base_strike_budget": base_budget,
+        "strikes_made": strikes,
+        "surge_spent_in_loop": surge_spent,
+        "surge_uses": f"{surge_uses_before} -> {surge_uses_after}",
+        # The bar: the LOOP spent Action Surge AND it bought extra strikes beyond the base budget.
+        "ok": bool(as_ability and surge_spent and strikes > base_budget),
+    }
+
+    # C) BATTLE MASTER MANEUVER — declare a Trip-Attack maneuver on a worthy attack; the die lands.
+    cid = _p5_seed(server, store_mod, "bm", base_seed + 3)
+    bm = _p5_fighter(server, cid, level=5, subclass="Battle Master")
+    server.set_class_resource(cid, bm, resource="superiority_dice", max=4, recharge="short", size="d8")
+    ogre = [m["id"] for m in server.spawn_monster(cid, "Ogre", count=1)["spawned"]]
+    server.start_combat(cid, [bm] + ogre)
+    _p5_make_current(server, store_mod, cid, bm)
+    c = server._require(cid)
+    view = combat_loop._build_view(server, c, c.characters[bm])
+    bm_ability = any(a.kind == "maneuver" for a in view.abilities)
+    intent = combat_ai.pick_action(c.characters[bm], view)
+    dice_before = (c.characters[bm].class_resources["superiority_dice"].max
+                   - c.characters[bm].class_resources["superiority_dice"].used)
+    entry = combat_loop._apply_intent(server, cid, bm, intent) if intent.kind == "attack" else {}
+    c2 = server._require(cid)
+    dice_after = (c2.characters[bm].class_resources["superiority_dice"].max
+                  - c2.characters[bm].class_resources["superiority_dice"].used)
+    out["C_maneuver"] = {
+        "ability_in_view": bm_ability,
+        "declared_maneuver": intent.maneuver if intent.kind == "attack" else "",
+        "dice": f"{dice_before} -> {dice_after}",
+        # The maneuver die is spent only ON A HIT (the attack() rider) — a miss spends nothing, so the
+        # competence bar is "the AI DECLARED the maneuver on its attack" (the spend is hit-gated RAW).
+        "ok": bool(bm_ability and intent.kind == "attack" and intent.maneuver),
+    }
+
+    # D) SNEAK ATTACK — a rogue with an ally adjacent to the target tags the strike with sneak dice.
+    cid = _p5_seed(server, store_mod, "sa", base_seed + 4)
+    rogue = server.create_character(
+        cid, "Astra", kind="player", race="halfling", class_name="rogue", level=5,
+        abilities=dict(strength=10, dexterity=18, constitution=14, intelligence=12, wisdom=12, charisma=12),
+        apply_srd_defaults=True,
+    )["id"]
+    ally = _p5_fighter(server, cid, level=3)
+    gob = [m["id"] for m in server.spawn_monster(cid, "Goblin", count=1)["spawned"]]
+    server.start_combat(cid, [rogue, ally] + gob)
+    c = server._require(cid)
+    # Grid: rogue at (0,0), goblin at (1,0), ally at (2,0) — the ally is within 5 ft of the goblin.
+    c.combat.grid_enabled = True
+    c.combat.grid_width = 10; c.combat.grid_height = 10; c.combat.grid_cell_size = 5
+    for cb in c.combat.order:
+        if cb.character_id == rogue:
+            cb.x, cb.y = 0, 0
+        elif cb.character_id == gob[0]:
+            cb.x, cb.y = 1, 0
+        elif cb.character_id == ally:
+            cb.x, cb.y = 2, 0
+    store_mod.save_campaign(c)
+    _p5_make_current(server, store_mod, cid, rogue)
+    c = server._require(cid)
+    view = combat_loop._build_view(server, c, c.characters[rogue])
+    sa_in_view = view.sneak_attack is not None
+    intent = combat_ai.pick_action(c.characters[rogue], view)
+    foe_before = c.characters[gob[0]].current_hp
+    entry = combat_loop._apply_intent(server, cid, rogue, intent) if intent.kind == "attack" else {}
+    out["D_sneak_attack"] = {
+        "sneak_in_view": sa_in_view,
+        "tagged_sneak": bool(intent.kind == "attack" and intent.sneak_attack),
+        "sneak_dice": (intent.sneak_attack[0].get("dice") if intent.sneak_attack else ""),
+        "ok": bool(sa_in_view and intent.kind == "attack" and intent.sneak_attack),
+    }
+
+    # E) GUIDED STRIKE — a War cleric spends Channel Divinity (+10 to hit) on a likely-MISS attack.
+    cid = _p5_seed(server, store_mod, "gs", base_seed + 5)
+    cler = server.create_character(
+        cid, "Sera", kind="player", race="human", class_name="cleric", level=5, subclass="War Domain",
+        abilities=dict(strength=14, dexterity=10, constitution=14, intelligence=10, wisdom=18, charisma=12),
+        apply_srd_defaults=True,
+    )["id"]
+    foe = [m["id"] for m in server.spawn_monster(cid, "Goblin", count=1)["spawned"]]
+    server.start_combat(cid, [cler] + foe)
+    c = server._require(cid)
+    c.characters[foe[0]].armor_class = 22  # a high-AC foe → the cleric's weapon is a likely miss
+    store_mod.save_campaign(c)
+    _p5_make_current(server, store_mod, cid, cler)
+    c = server._require(cid)
+    view = combat_loop._build_view(server, c, c.characters[cler])
+    gs_in_view = any(a.kind == "guided_strike" for a in view.abilities)
+    intent = combat_ai.pick_action(c.characters[cler], view)
+    cd_before = (c.characters[cler].class_resources["channel_divinity"].max
+                 - c.characters[cler].class_resources["channel_divinity"].used)
+    entry = combat_loop._apply_intent(server, cid, cler, intent) if intent.kind == "attack" else {}
+    c2 = server._require(cid)
+    cd_after = (c2.characters[cler].class_resources["channel_divinity"].max
+                - c2.characters[cler].class_resources["channel_divinity"].used)
+    out["E_guided_strike"] = {
+        "ability_in_view": gs_in_view,
+        "declared_channel": intent.channel if intent.kind == "attack" else "",
+        "channel_divinity": f"{cd_before} -> {cd_after}",
+        "channel_spent": cd_after < cd_before,
+        "ok": bool(gs_in_view and intent.kind == "attack" and intent.channel and cd_after < cd_before),
+    }
+
+    out["abilities_used"] = sum(
+        1 for k in ("A_second_wind", "B_action_surge", "C_maneuver", "D_sneak_attack", "E_guided_strike")
+        if out[k]["ok"]
+    )
+    return out
+
+
+def _print_part5(p5: dict) -> bool:
+    print("\n" + "=" * 78)
+    print("PART 5 — engine-AI competence v2.0c: the AI ITSELF uses martial class abilities (#1106)")
+    print("=" * 78)
+    a = p5["A_second_wind"]
+    print(f"  A) Second Wind  : chose={a['chose_second_wind']} HP {a['hp']} -> {'PASS' if a['ok'] else 'FAIL'}")
+    b = p5["B_action_surge"]
+    print(f"  B) Action Surge : spent_in_loop={b['surge_spent_in_loop']} "
+          f"strikes={b['strikes_made']} (base {b['base_strike_budget']}) uses {b['surge_uses']} "
+          f"-> {'PASS' if b['ok'] else 'FAIL'}")
+    cc = p5["C_maneuver"]
+    print(f"  C) Maneuver     : declared={cc['declared_maneuver']!r} dice {cc['dice']} "
+          f"-> {'PASS' if cc['ok'] else 'FAIL'}")
+    d = p5["D_sneak_attack"]
+    print(f"  D) Sneak Attack : tagged={d['tagged_sneak']} dice={d['sneak_dice']!r} "
+          f"-> {'PASS' if d['ok'] else 'FAIL'}")
+    e = p5["E_guided_strike"]
+    print(f"  E) Guided Strike: declared={e['declared_channel']!r} CD {e['channel_divinity']} "
+          f"-> {'PASS' if e['ok'] else 'FAIL'}")
+    # The owner bar: the AI itself uses >= 2 martial abilities. We assert ALL FIVE wired here, but the
+    # PASS gate is >= 2 (the brief's floor) so a single-ability harness hiccup doesn't red the gate.
+    used = p5["abilities_used"]
+    ok = used >= 2
+    print("-" * 78)
+    print(f"  abilities the AI used on its own: {used}/5  (bar: >= 2)")
+    print(f"  PART 5 (AI uses martial abilities): {'PASS' if ok else 'FAIL'}")
+    return ok
+
+
 # ── reporting ──────────────────────────────────────────────────────────────────────────
 
 def _print_part1(checks, summaries, *, fast: bool):
@@ -874,12 +1119,16 @@ def main() -> int:
     p4 = run_part4(server, store_mod, args.seed)
     part4_ok = _print_part4(p4)
 
+    p5 = run_part5(server, store_mod, args.seed)
+    part5_ok = _print_part5(p5)
+
     print("\n" + "=" * 78)
-    overall = part1_ok and part2_ok and part3_ok and part4_ok
+    overall = part1_ok and part2_ok and part3_ok and part4_ok and part5_ok
     print(f"PART 1 (mechanics fired):          {'PASS' if part1_ok else 'FAIL'}")
     print(f"PART 2 (spells resolve):           {'PASS' if part2_ok else 'FAIL'}")
     print(f"PART 3 (AI heals dying ally):      {'PASS' if part3_ok else 'FAIL'}")
     print(f"PART 4 (AI casts offensive spell): {'PASS' if part4_ok else 'FAIL'}")
+    print(f"PART 5 (AI uses martial abilities):{'PASS' if part5_ok else 'FAIL'}")
     print(f"OVERALL: {'PASS' if overall else 'FAIL'}")
     print("=" * 78)
 
@@ -887,11 +1136,11 @@ def main() -> int:
         print("JSON " + json.dumps({
             "seed": args.seed, "fast": args.fast,
             "part1_ok": part1_ok, "part2_ok": part2_ok, "part3_ok": part3_ok,
-            "part4_ok": part4_ok, "overall": overall,
+            "part4_ok": part4_ok, "part5_ok": part5_ok, "overall": overall,
             "mechanics": {k: ck.fired for k, ck in checks.items()},
             "spells": [{"name": r.name, "category": r.category, "status": r.status} for r in results],
             "not_swept_count": not_swept_count, "total_castable": total_castable,
-            "part3": p3, "part4": p4,
+            "part3": p3, "part4": p4, "part5": p5,
         }))
 
     return 0 if overall else 1

--- a/qa/test_combat_smoke.py
+++ b/qa/test_combat_smoke.py
@@ -168,3 +168,42 @@ def test_part4_ai_itself_casts_the_best_offensive_spell():
     assert p4["C_did_not_waste_leveled_slot"], (
         f"the AI wasted a leveled slot (L{p4['C_chosen_slot_level']}) on a "
         f"{p4['C_target_hp']}-HP target: intent={p4['C_intent']}")
+
+
+# ── PART 5: the AI ITSELF uses martial class abilities (engine-AI competence v2.0c, #1106) ──
+
+def test_part5_ai_itself_uses_martial_abilities():
+    """The v2.0c COMPETENCE gauge: the REAL combat AI uses MARTIAL class abilities on its own (not a
+    scripted assist). The brief's bar is the AI itself uses >= 2 abilities; this asserts the floor AND
+    each individually-wired ability (Second Wind / Action Surge / Battle Master maneuver / Sneak
+    Attack / Guided Strike), so a regression in any ONE is caught even while the >= 2 gate stays green."""
+    server, store_mod = _server_store()
+    p5 = smoke.run_part5(server, store_mod, _SEED)
+    # The owner floor: the AI used at least 2 martial abilities entirely on its own.
+    assert p5["abilities_used"] >= 2, (
+        f"the AI used < 2 martial abilities on its own: {p5['abilities_used']}/5")
+    # A) Second Wind — a hurt fighter self-healed via its own bonus action.
+    a = p5["A_second_wind"]
+    assert a["ability_in_view"], "Second Wind not surfaced in the fighter's view"
+    assert a["ok"], f"the AI did not self-heal via Second Wind: {a}"
+    # B) Action Surge — the REAL LOOP spent the surge AND it bought strikes beyond the base budget
+    #    (this exercises the loop path, which would catch the action_used-blocks-surge regression).
+    b = p5["B_action_surge"]
+    assert b["ability_in_view"], "Action Surge not surfaced in the fighter's view"
+    assert b["surge_spent_in_loop"], f"the loop did not spend Action Surge: {b}"
+    assert b["strikes_made"] > b["base_strike_budget"], (
+        f"Action Surge did not grant extra strikes: {b['strikes_made']} <= base "
+        f"{b['base_strike_budget']}")
+    assert b["ok"], f"Action Surge competence gauge failed: {b}"
+    # C) Battle Master maneuver — the AI declared a maneuver ON a worthy attack.
+    cc = p5["C_maneuver"]
+    assert cc["ability_in_view"], "the maneuver (superiority_dice) was not surfaced in the BM's view"
+    assert cc["ok"], f"the AI did not declare a Battle Master maneuver: {cc}"
+    # D) Sneak Attack — the rogue tagged its strike when an ally was adjacent to the target.
+    d = p5["D_sneak_attack"]
+    assert d["sneak_in_view"], "Sneak Attack dice not surfaced in the rogue's view"
+    assert d["ok"], f"the AI did not tag a Sneak Attack when eligible: {d}"
+    # E) Guided Strike — the War cleric spent Channel Divinity (+10) on a likely-miss attack.
+    e = p5["E_guided_strike"]
+    assert e["ability_in_view"], "Guided Strike not surfaced in the War cleric's view"
+    assert e["ok"], f"the AI did not spend Guided Strike on a likely-miss attack: {e}"

--- a/servers/engine/combat_ai.py
+++ b/servers/engine/combat_ai.py
@@ -494,7 +494,8 @@ def _sneak_attack_eligible(view: CombatView, target: CombatantView,
     """Is the rogue's Sneak Attack rider TRIGGERED on `target` this strike (5e RAW, no disadvantage
     branch — the engine's loop doesn't pass disadvantage here)? Either the attack has ADVANTAGE, OR
     an ALLY of the rogue is within 5 ft of the target (a flanking-style trigger). Pure geometry +
-    the advantage flag. The once-per-turn cap is enforced by the loop (it tags ONE strike)."""
+    the advantage flag. The once-per-turn cap (5e RAW) is enforced by run_combat_round, which nulls
+    view.sneak_attack for the rest of the actor's turn once a Sneak Attack LANDS (a miss doesn't)."""
     if view.sneak_attack is None:
         return False
     if attack_has_advantage:

--- a/servers/engine/combat_ai.py
+++ b/servers/engine/combat_ai.py
@@ -43,15 +43,35 @@ RETREAT_FRACTION = 0.0
 # A monster/NPC's declared intent for its turn. The loop maps `kind` to one or more
 # existing write verbs (a Multiattack re-asks pick_action per granted strike). DECLARATIVE
 # only — it names WHAT the actor wants; it never mutates state. See ADR §2.
+#
+# v2.0c martial riders (ALL additive — empty/None == today's Intent byte-for-byte):
+#   * `use_resource` + `resource` — a class-resource spend (Action Surge / Rage) the loop
+#     applies via the locked server.use_resource verb. `kind="use_resource"` is the new
+#     dedicated intent for a bare resource spend (Rage entry, Action Surge);
+#   * on an `attack` Intent, `maneuver` / `maneuver_resource` declare a Battle Master damage
+#     maneuver, `channel` declares a flat to-hit option (Guided Strike), and `sneak_attack`
+#     (a damage_rolls component dict) tags a Sneak Attack — all consumed by the existing
+#     attack() riders. A plain attack leaves every one empty == today.
 @dataclass(frozen=True)
 class Intent:
-    kind: Literal["attack", "cast", "move", "dash", "disengage", "dodge", "skip"]
+    kind: Literal[
+        "attack", "cast", "move", "dash", "disengage", "dodge", "skip", "use_resource"
+    ]
     target_id: str = ""           # attack / single-target cast
     attack_name: str = ""         # scopes a Multiattack budget (server._attacker_multiattack_count)
     spell_name: str = ""          # cast
     to_cell: Optional[tuple[int, int]] = None  # move (grid / #461)
     to_zone: str = ""             # move (zone / S2.7)
     note: str = ""                # human-readable rationale for the digest / debugging
+    # v2.0c riders (additive; default empty == today). The loop folds these into the
+    # SAME locked verbs (use_resource / attack riders) — no new write path.
+    resource: str = ""            # use_resource: the pool to spend (e.g. "action_surge", "rage")
+    amount: int = 1               # use_resource: how much to spend (default 1)
+    maneuver: str = ""            # attack: a Battle Master damage maneuver name (Trip Attack, …)
+    maneuver_resource: str = "superiority_dice"  # attack: the die pool the maneuver spends
+    channel: str = ""             # attack: a flat to-hit option (Guided Strike) declared via use_resource
+    channel_resource: str = ""    # attack: the pool the channel option spends (channel_divinity)
+    sneak_attack: tuple = ()      # attack: a damage_rolls component dict for Sneak Attack ({} == none)
 
 
 # ── The read-only CombatView the loop assembles per turn (no new persistent model) ───
@@ -106,6 +126,42 @@ class SpellOption:
 
 
 @dataclass(frozen=True)
+class AbilityOption:
+    """A MARTIAL class ability the actor can spend a class-resource on this turn (v2.0c). The view
+    surfaces it from the actor's `class_resources` (the loop reads the authoritative pool); the AI
+    decides WHEN to spend and the loop applies it via the locked `use_resource` / attack-rider verbs.
+
+    `kind` selects the decision branch + how the loop applies it:
+      * "second_wind"  — fighter BONUS-action self-heal (1d10+level); `heal_amount` is the EV. The
+        bonus-action channel fires it when the fighter is hurt.
+      * "action_surge" — fighter: a fresh Attack action this turn. Spent via use_resource; the loop's
+        re-ask grants the extra strike. Worth it when the fight is hot / it converts to a likely kill.
+      * "maneuver"     — Battle Master: a superiority die added to an attack's damage (Trip/Menacing).
+        Declared ON a worthy attack via the attack() maneuver rider. `size` is the die (e.g. "d8").
+      * "guided_strike" — War-cleric Channel Divinity: +10 to one attack roll. Declared on a key
+        likely-to-miss attack via use_resource(channel_divinity, maneuver='Guided Strike').
+      * "rage"         — barbarian: enter rage (the obvious on when meleeing). A bare use_resource spend.
+    `resource` is the pool id `use_resource` spends; `remaining` is what's left (>0 to be usable)."""
+    kind: str                     # "second_wind" | "action_surge" | "maneuver" | "guided_strike" | "rage"
+    resource: str                 # the class_resources pool id (e.g. "second_wind", "action_surge")
+    remaining: int = 0            # uses left in the pool (>0 == usable)
+    is_bonus_action: bool = False  # consumes the BONUS action (Second Wind) vs the action / a rider
+    heal_amount: float = 0.0      # second_wind: expected HP restored (1d10 + fighter level)
+    size: str = ""                # maneuver: the die the pool rolls (e.g. "d8"), for the EV note
+    name: str = ""                # the human ability name (Trip Attack / Guided Strike / Rage / …)
+
+
+@dataclass(frozen=True)
+class SneakAttackOption:
+    """The actor's Sneak Attack rider (rogue, v2.0c). `dice` is the sheet's Sneak-Attack dice (e.g.
+    "3d6"); the AI TAGS an eligible attack with it as a damage_rolls component, and the existing
+    attack() multi-component path rolls + crit-doubles it. `value` is the EV (avg of the dice) so the
+    AI can note the magnitude. None on the view == not a rogue / no sneak dice (byte-identical)."""
+    dice: str                     # e.g. "3d6" (the rogue's Sneak Attack dice from the sheet)
+    value: float = 0.0            # avg damage of `dice`, for the rationale note
+
+
+@dataclass(frozen=True)
 class CombatantView:
     """A combatant the AI reasons about: position + the numbers needed for EV. For an ALLY the
     healer triage also reads `current_hp`/`max_hp` + `downed` (0 HP / dying) to decide who to heal."""
@@ -148,6 +204,27 @@ class CombatView:
     # (or "" if none). pick_action will not start a NEW concentration spell that breaks a >= -value
     # active one — "" == today's behavior (no active concentration to protect).
     active_concentration: str = ""
+    # ── Martial class abilities + bonus-action economy (v2.0c) ───────────────────────────
+    # The actor's own HP, surfaced so the Second-Wind / Action-Surge thresholds read from the
+    # view (not getattr(actor)) — a non-martial actor never looks at these (byte-identical).
+    actor_current_hp: int = 0
+    actor_max_hp: int = 0
+    # The actor's spendable MARTIAL abilities this turn (Second Wind / Action Surge / Battle
+    # Master maneuver / Guided Strike / Rage). Empty == a non-martial actor (today's behavior):
+    # pick_action / pick_bonus_action skip every ability branch and the fight is unchanged.
+    abilities: tuple[AbilityOption, ...] = ()
+    # Whether the barbarian is ALREADY raging this fight (the loop tracks rage-entry per fight, since
+    # the engine has no active-rage state — see the v2.0d flag in combat_loop). True suppresses a
+    # second Rage spend (don't drain the pool). False/default == not yet raging.
+    is_raging: bool = False
+    # The rogue's Sneak Attack rider (or None == not a rogue / no sneak dice). When present the AI
+    # TAGS an eligible attack (advantage OR an ally within 5 ft of the target, no disadvantage).
+    sneak_attack: Optional[SneakAttackOption] = None
+    # Whether the actor still has its ACTION / BONUS action this turn. The bonus-action channel
+    # (pick_bonus_action) only fires a bonus ability when bonus_action_available; both default True
+    # so a fresh turn behaves as today. Action Surge needs the action; Second Wind the bonus.
+    action_available: bool = True
+    bonus_action_available: bool = True
 
 
 # ── Pure EV helpers ──────────────────────────────────────────────────────────────────
@@ -382,6 +459,241 @@ def _pick_heal(view: CombatView) -> Optional[tuple[CombatantView, SpellOption]]:
     return target, chosen
 
 
+# ── Martial class abilities (v2.0c) — pure detectors + decision helpers ──────────────
+#
+# Each helper reads ONLY the view (the loop already surfaced the authoritative pool + numbers)
+# and returns whether/which ability to spend. A view with no `abilities` short-circuits every
+# one of these to None/False, so a non-martial actor is byte-identical to today.
+
+# Second Wind fires when the fighter is meaningfully hurt — at/below this fraction of max HP. 1/2
+# matches the brief ("< ~1/2 HP"); pure constant (a future tier could lower it for a cautious AI).
+_SECOND_WIND_FRACTION = 0.5
+# Action Surge is a NOVA button: don't waste it round 1 vs trivial foes. Spend it when the fight is
+# HOT — the actor is hurt, OR the action's extra attack is likely to CONVERT a worthy foe to a kill.
+# A foe whose current HP is within this multiple of one attack's EV is "finishable" by the surge.
+_SURGE_FINISH_MULT = 2.0
+# A Battle Master spends a die on an attack worth boosting — a foe that's a real threat (not a sliver
+# a plain swing already kills). Spend when the foe's HP is above the plain-attack EV (the +die matters)
+# AND the strike has a reasonable chance to land (the die only adds damage on a hit).
+_MANEUVER_MIN_PHIT = 0.4
+# Guided Strike (+10 to hit) is best spent on a KEY attack that would OTHERWISE likely MISS — its
+# whole value is turning a miss into a hit. Spend when the best attack's P(hit) is at/below this.
+_GUIDED_STRIKE_MAX_PHIT = 0.6
+
+
+def _ability(view: CombatView, kind: str) -> Optional[AbilityOption]:
+    """The first usable (remaining > 0) ability of `kind` on the view, or None. Pure lookup."""
+    for ab in view.abilities:
+        if ab.kind == kind and ab.remaining > 0:
+            return ab
+    return None
+
+
+def _sneak_attack_eligible(view: CombatView, target: CombatantView,
+                           attack_has_advantage: bool) -> bool:
+    """Is the rogue's Sneak Attack rider TRIGGERED on `target` this strike (5e RAW, no disadvantage
+    branch — the engine's loop doesn't pass disadvantage here)? Either the attack has ADVANTAGE, OR
+    an ALLY of the rogue is within 5 ft of the target (a flanking-style trigger). Pure geometry +
+    the advantage flag. The once-per-turn cap is enforced by the loop (it tags ONE strike)."""
+    if view.sneak_attack is None:
+        return False
+    if attack_has_advantage:
+        return True
+    # An ally within 5 ft of the target (the "another enemy of the target is within 5 ft" trigger,
+    # here read as one of the rogue's own-side allies adjacent to the foe). On the grid, Chebyshev
+    # distance; off-grid we can't prove adjacency, so require the explicit advantage path only.
+    if not view.grid_enabled or target.cell is None:
+        return False
+    for ally in view.allies:
+        if ally.cell is None or not _alive_for_flank(ally):
+            continue
+        if combat_grid.distance_ft(ally.cell, target.cell, view.cell_size) <= 5:
+            return True
+    return False
+
+
+def _alive_for_flank(ally: CombatantView) -> bool:
+    """An ally that can actually threaten a foe for the Sneak-Attack adjacency trigger: not downed
+    and above 0 HP. (A downed ally on the floor doesn't menace the target.)"""
+    return (not ally.downed) and int(ally.current_hp) > 0
+
+
+def _target_advantage(view: CombatView, target: CombatantView) -> bool:
+    """Does the actor have ADVANTAGE attacking `target` from condition? A foe that's prone /
+    restrained / stunned / paralyzed / unconscious grants advantage to melee attackers. Pure read
+    of the target's surfaced conditions (the engine's attack() recomputes the real advantage; this
+    is the AI's pre-check for the Sneak-Attack trigger so the rider is only TAGGED when warranted)."""
+    adv_conditions = {"prone", "restrained", "stunned", "paralyzed", "unconscious", "incapacitated"}
+    return bool(adv_conditions & {str(cn).lower() for cn in target.conditions})
+
+
+def _enrich_attack_intent(view: CombatView, opt: AttackOption, foe: CombatantView,
+                          base_ev: float) -> Intent:
+    """Build the `attack` Intent for `opt` on `foe`, folding in the v2.0c martial ON-ATTACK riders
+    when warranted (Sneak Attack / Guided Strike / Battle Master maneuver). A non-martial actor (no
+    sneak_attack, no abilities) gets a PLAIN attack Intent byte-identical to v2.0b — every rider
+    branch is gated on a surfaced ability/dice, so empty == today. The riders are mutually compatible
+    where 5e allows (a maneuver + a sneak attack can ride the same strike); Guided Strike is reserved
+    for a likely-MISS attack (its value is the to-hit, not extra damage). All consumed by the
+    EXISTING attack() riders — the loop adds no new write path. Pure: reads only the view + the foe."""
+    phit = p_hit(opt.to_hit, foe.armor_class)
+    note_bits = [
+        f"best in-reach attack {opt.name} on {foe.name} (EV {base_ev:.1f}, P(hit) {phit:.0%})"
+    ]
+    # SNEAK ATTACK (rogue): tag the strike when the trigger is met (advantage OR an ally within 5 ft
+    # of the target). The engine rolls + crit-doubles the extra dice via the multi-component path.
+    sneak_rider: tuple = ()
+    has_adv = _target_advantage(view, foe)
+    if view.sneak_attack is not None and _sneak_attack_eligible(view, foe, has_adv):
+        sneak_rider = ({"dice": view.sneak_attack.dice,
+                        "type": opt.damage_type or "piercing"},)
+        note_bits.append(
+            f"+ Sneak Attack {view.sneak_attack.dice} (~{view.sneak_attack.value:.0f}, "
+            f"{'advantage' if has_adv else 'ally adjacent'})"
+        )
+    # GUIDED STRIKE (War cleric Channel Divinity, +10 to hit): reserve it for a KEY attack that
+    # would OTHERWISE likely MISS — its whole value is turning a miss into a hit. Spend only when the
+    # plain P(hit) is at/below the bar AND the foe is a real (non-trivial) threat worth the channel.
+    channel = ""
+    channel_resource = ""
+    gs = _ability(view, "guided_strike")
+    if (gs is not None and phit <= _GUIDED_STRIKE_MAX_PHIT
+            and int(foe.current_hp) > math.ceil(base_ev)):
+        channel = gs.name or "Guided Strike"
+        channel_resource = gs.resource or "channel_divinity"
+        note_bits.append(f"+ {channel} (+10 to hit; P(hit) was {phit:.0%})")
+    # BATTLE MASTER MANEUVER (superiority die -> +damage on a hit): spend on a worthy strike — a foe
+    # that's a real threat (HP above what a plain swing removes) and a strike likely to LAND (the die
+    # only adds damage on a hit). Skip Guided-Strike turns (don't double-spend two resources on one
+    # marginal swing) and trivial foes (a plain swing already finishes them).
+    maneuver = ""
+    maneuver_resource = "superiority_dice"
+    man = _ability(view, "maneuver")
+    if (man is not None and not channel and phit >= _MANEUVER_MIN_PHIT
+            and int(foe.current_hp) > math.ceil(base_ev)):
+        maneuver = man.name or "Trip Attack"
+        maneuver_resource = man.resource or "superiority_dice"
+        note_bits.append(f"+ maneuver {maneuver} ({man.size or 'die'} on hit)")
+    return Intent(
+        kind="attack",
+        target_id=foe.id,
+        attack_name=opt.name,
+        sneak_attack=sneak_rider,
+        channel=channel,
+        channel_resource=channel_resource,
+        maneuver=maneuver,
+        maneuver_resource=maneuver_resource,
+        note="; ".join(note_bits),
+    )
+
+
+def should_action_surge(combat_state: CombatView) -> Optional[Intent]:
+    """Decide whether the fighter should spend Action Surge for an EXTRA Attack action this turn
+    (v2.0c), or None. Called by the loop AFTER the actor's normal strikes resolve — Action Surge is a
+    NOVA button, so it's gated to a HOT moment so it isn't wasted round 1 on a trivial foe:
+      * the actor is HURT (<= 1/2 max HP — surging to end the fight faster is worth it), OR
+      * a worthy foe is FINISHABLE — the best in-reach attack's EV is within `_SURGE_FINISH_MULT` of
+        a living foe's current HP, so the extra action is likely to convert to a KILL.
+    Returns a `use_resource` Intent for action_surge (the loop applies it via the locked verb, then
+    re-runs the strike budget which now sees the granted surge action). A non-fighter / no-surge /
+    no-foes view returns None == today (the loop never surges). Pure: reads only the view.
+
+    NOTE: this does NOT gate on `action_available` — Action Surge's whole purpose is to grant a FRESH
+    action AFTER the turn's normal Attack action is already spent (attack() sets action_used), so the
+    loop calls this once the normal strikes are exhausted. The loop's own `surged` guard prevents a
+    second surge in the same turn (don't drain the pool)."""
+    view = combat_state
+    surge = _ability(view, "action_surge")
+    if surge is None or not view.foes:
+        return None
+    # Best in-reach single-attack EV (the per-strike value a surged action would add again).
+    best_ev = 0.0
+    for opt in view.attacks:
+        for foe in view.foes:
+            if _in_reach(view, foe, opt.reach_ft):
+                best_ev = max(best_ev, _attack_ev(opt, foe))
+    if best_ev <= 0:
+        return None  # nothing to swing at from here — a surged action would do nothing
+    hurt = view.actor_max_hp > 0 and (view.actor_current_hp / max(1, view.actor_max_hp)) <= 0.5
+    finishable = any(
+        int(foe.current_hp) <= math.ceil(best_ev * _SURGE_FINISH_MULT) for foe in view.foes
+    )
+    if not (hurt or finishable):
+        return None
+    why = "hurt — surge to end it" if hurt else "a foe is finishable with an extra action"
+    return Intent(
+        kind="use_resource",
+        resource=surge.resource,
+        amount=1,
+        note=f"Action Surge: extra Attack action ({why})",
+    )
+
+
+def pick_bonus_action(actor: "Character", combat_state: CombatView) -> Optional[Intent]:
+    """Choose a worthwhile BONUS action for the actor THIS turn, or None (v2.0c). Separate from
+    pick_action so the bonus-action ECONOMY is a clean, removable channel: the loop calls this ONCE
+    per turn (alongside the main action), and a non-martial / no-bonus actor returns None so the turn
+    is byte-identical to today. Priority:
+      1. Second Wind (fighter) — self-heal when hurt (< ~1/2 HP) and a use remains.
+      2. a BONUS-ACTION heal (Healing Word) on a downed/critical ally — the classic save, when the
+         actor has a bonus-action heal spell + a needy ally (reuses the v2.0a heal triage).
+    Returns a `use_resource` Intent (Second Wind) or a bonus `cast` Intent (Healing Word). PURE."""
+    view = combat_state
+    if not view.bonus_action_available:
+        return None
+    if not view.foes:  # the fight is over — no bonus action worth spending
+        return None
+    # 1. Second Wind — a fighter's bonus-action self-heal. Fire when meaningfully hurt.
+    sw = _ability(view, "second_wind")
+    if sw is not None and view.actor_max_hp > 0:
+        frac = view.actor_current_hp / max(1, view.actor_max_hp)
+        if frac <= _SECOND_WIND_FRACTION:
+            return Intent(
+                kind="use_resource",
+                resource=sw.resource,
+                amount=1,
+                note=(
+                    f"Second Wind (bonus action): self-heal ~{sw.heal_amount:.0f} HP at "
+                    f"{view.actor_current_hp}/{view.actor_max_hp}"
+                ),
+            )
+    # 2. Rage (barbarian) — the obvious bonus-action "on" when meleeing. Enter ONCE per fight (the
+    #    is_raging flag, which the loop tracks since the engine has no active-rage state). Only when a
+    #    foe is within MELEE reach (rage benefits melee), and a use remains. FLAG (v2.0d): the engine
+    #    models the rage POOL but not its +damage / resistance — entering rage drains a use and is
+    #    narrated; the mechanical bonus is deferred. Gated so it can't burn the pool turn after turn.
+    rage = _ability(view, "rage")
+    if rage is not None and not view.is_raging:
+        in_melee = any(
+            _in_reach(view, foe, opt.reach_ft)
+            for opt in view.attacks if not opt.is_ranged
+            for foe in view.foes
+        )
+        if in_melee:
+            return Intent(
+                kind="use_resource",
+                resource=rage.resource,
+                amount=1,
+                note="Rage (bonus action): enter rage — a foe is in melee reach",
+            )
+    # 3. A bonus-action heal (Healing Word) on a downed/critical ally — reuse the v2.0a triage but
+    #    restricted to BONUS-action heals so it rides the bonus channel alongside the main action.
+    heal = _pick_heal(view)
+    if heal is not None:
+        ally, sp = heal
+        if sp.is_bonus_action:
+            return Intent(
+                kind="cast",
+                target_id=ally.id,
+                spell_name=sp.name,
+                note=(
+                    f"bonus-action heal {sp.name} on {ally.name} "
+                    f"({ally.current_hp}/{ally.max_hp} HP{', DOWNED' if ally.downed else ''})"
+                ),
+            )
+    return None
+
+
 # ── The greedy-v1 policy ─────────────────────────────────────────────────────────────
 
 def pick_action(
@@ -406,6 +718,13 @@ def pick_action(
       4. move-to-reach toward the best target (the loop re-asks pick_action so move-then-attack
          resolves both halves)
       5. dodge / skip fallback when nothing productive is reachable
+
+    MARTIAL on-attack riders (v2.0c): the chosen weapon attack is enriched (`_enrich_attack_intent`)
+    with Sneak Attack (rogue, when the trigger is met), Guided Strike (War cleric, on a likely-MISS
+    key attack), and a Battle Master maneuver (on a worthy hit) — all via the EXISTING attack()
+    riders, gated on a surfaced ability/dice so a non-martial actor's attack is byte-identical to
+    v2.0b. The BONUS action (Second Wind / bonus heal / Rage) and Action Surge are decided by the
+    sibling `pick_bonus_action` / `should_action_surge`, which the loop calls alongside this.
 
     PURE + deterministic: reads only `actor` (read-only Character) and `combat_state` (a
     read-only CombatView). Returns an Intent; the loop is the sole writer that applies it.
@@ -546,15 +865,7 @@ def pick_action(
     if best_attack is not None:
         opt = best_attack[4]
         foe = best_attack[5]
-        return Intent(
-            kind="attack",
-            target_id=foe.id,
-            attack_name=opt.name,
-            note=(
-                f"best in-reach attack {opt.name} on {foe.name} "
-                f"(EV {best_attack[0]:.1f}, P(hit) {p_hit(opt.to_hit, foe.armor_class):.0%})"
-            ),
-        )
+        return _enrich_attack_intent(view, opt, foe, best_attack[0])
 
     # 4. Move-to-reach: no attack/spell lands from here -> close on the best (lowest-HP) target
     #    so next turn (the loop re-asks pick_action) the strike resolves. Needs the grid.

--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -23,6 +23,7 @@ TWO MODES (owner-decided):
 from __future__ import annotations
 
 from typing import Optional
+from dataclasses import replace
 
 import combat_ai
 import dice as dice_mod
@@ -663,6 +664,7 @@ def run_combat_round(campaign_id: str, mode: str = "live", max_turns: int = 60) 
         ma = max(1, server._attacker_multiattack_count(actor, c)) if actor is not None else 1
         strikes_left = ma
         surged = False  # Action Surge spent this turn? (one extra Attack action, v2.0c)
+        sneak_used = False  # Sneak Attack is once-per-turn (5e RAW): suppress after the first LANDS
         # Re-ask pick_action per granted strike (move-then-attack, or several strikes).
         for _strike in range(max(1, ma) + 4):  # +4 headroom: a move, the strikes, an Action Surge
             c = server._require(campaign_id)
@@ -672,6 +674,9 @@ def run_combat_round(campaign_id: str, mode: str = "live", max_turns: int = 60) 
             if not _living_sides(c) or len(_living_sides(c)) < 2:
                 break  # fight is decided; stop issuing this actor's strikes
             view = _build_view(server, c, actor)
+            if sneak_used and view.sneak_attack is not None:
+                # 5e RAW: Sneak Attack once per turn — already dealt this turn, never re-tag a later strike.
+                view = replace(view, sneak_attack=None)
             _view_cache[actor.id] = view.attacks
             # ACTION SURGE (v2.0c): when the normal strikes are spent but the fight is still hot,
             # the fighter can spend Action Surge for a FRESH Attack action. Spend it ONCE, then keep
@@ -691,6 +696,8 @@ def run_combat_round(campaign_id: str, mode: str = "live", max_turns: int = 60) 
             digest.append(entry)
             acted = True
             if intent.kind == "attack":
+                if intent.sneak_attack and (entry.get("result") or {}).get("hit"):
+                    sneak_used = True  # Sneak Attack DEALT — a miss does NOT consume the once-per-turn
                 strikes_left -= 1
                 if strikes_left <= 0 and surged:
                     break  # already surged once; don't loop forever

--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -27,7 +27,15 @@ from typing import Optional
 import combat_ai
 import dice as dice_mod
 import spells as spells_mod
-from combat_ai import AttackOption, CombatantView, CombatView, Intent, SpellOption
+from combat_ai import (
+    AbilityOption,
+    AttackOption,
+    CombatantView,
+    CombatView,
+    Intent,
+    SneakAttackOption,
+    SpellOption,
+)
 
 # The two "sides". Party = the player-aligned team (PCs + companions); Enemy = monsters/NPCs.
 _PARTY_KINDS = ("player", "companion")
@@ -206,6 +214,88 @@ def _save_bonuses(ch) -> dict:
     return out
 
 
+# ── Martial class abilities + Sneak Attack discovery (v2.0c) ──────────────────────────
+
+# The barbarians who have ENTERED rage this fight (keyed by character id). The engine has no
+# active-rage state (rage is a pool decrement only), so the loop tracks rage-entry here to stop
+# the AI re-spending Rage every turn. Cleared whenever a fresh combat starts (no rage spent yet).
+# This is loop-local bookkeeping, NOT campaign state — it never touches the snapshot (additive).
+_raged_this_fight: set = set()
+
+
+def _fighter_level(actor) -> int:
+    """The actor's FIGHTER class level (for the Second Wind heal EV = 1d10 + fighter level). Falls
+    back to total level for a single-class sheet / a stub. Pure read."""
+    for cl in getattr(actor, "classes", ()) or ():
+        if str(getattr(cl, "name", "")).strip().lower() == "fighter":
+            return int(getattr(cl, "level", 0)) or 1
+    return int(getattr(actor, "total_level", 1)) or 1
+
+
+def _ability_options(server, actor) -> tuple[AbilityOption, ...]:
+    """Surface the actor's spendable MARTIAL class abilities (v2.0c) from its authoritative
+    `class_resources` pools (the SAME pools `use_resource` spends). Empty == a non-martial actor or
+    a fully-spent pool, so the view is byte-identical to today. Maps a known resource id -> the AI's
+    AbilityOption `kind`; Second Wind carries its heal EV (1d10 + fighter level). PURE — reads the
+    sheet only, never mutates. The AI decides WHEN to spend; the loop applies via the locked verbs."""
+    out: list[AbilityOption] = []
+    res = getattr(actor, "class_resources", {}) or {}
+    for rid, pool in res.items():
+        remaining = int(getattr(pool, "max", 0)) - int(getattr(pool, "used", 0))
+        if remaining <= 0:
+            continue
+        rid_l = str(rid).lower()
+        if rid_l == "second_wind":
+            lvl = _fighter_level(actor)
+            heal_amt = float(dice_mod.average_total(f"1d10+{lvl}"))
+            out.append(AbilityOption(kind="second_wind", resource=rid, remaining=remaining,
+                                     is_bonus_action=True, heal_amount=heal_amt, name="Second Wind"))
+        elif rid_l == "action_surge":
+            out.append(AbilityOption(kind="action_surge", resource=rid, remaining=remaining,
+                                     name="Action Surge"))
+        elif rid_l == "channel_divinity":
+            # War Domain Guided Strike (+10 to one attack roll) rides channel_divinity. Surface it as
+            # a guided_strike option only for a War-Domain cleric (the SRD subclass that grants it);
+            # other channel uses aren't a flat to-hit option the engine models, so we don't claim them.
+            if _has_war_domain(actor):
+                out.append(AbilityOption(kind="guided_strike", resource=rid, remaining=remaining,
+                                         name="Guided Strike"))
+        elif rid_l == "superiority_dice":
+            out.append(AbilityOption(kind="maneuver", resource=rid, remaining=remaining,
+                                     size=str(getattr(pool, "size", "") or "d8"), name="Trip Attack"))
+        elif rid_l == "rage":
+            out.append(AbilityOption(kind="rage", resource=rid, remaining=remaining,
+                                     is_bonus_action=True, name="Rage"))
+    return tuple(out)
+
+
+def _has_war_domain(actor) -> bool:
+    """Is `actor` a War-Domain cleric (the SRD subclass whose Channel Divinity is Guided Strike)?
+    Checks the subclass tag on the sheet / its cleric ClassLevel. Conservative: only a clear War
+    Domain match returns True, so a non-War cleric's channel_divinity is NOT claimed as Guided Strike."""
+    sub = str(getattr(actor, "subclass", "") or "").lower()
+    if "war" in sub:
+        return True
+    for cl in getattr(actor, "classes", ()) or ():
+        if str(getattr(cl, "name", "")).strip().lower() == "cleric":
+            if "war" in str(getattr(cl, "subclass", "") or "").lower():
+                return True
+    return False
+
+
+def _sneak_attack_option(actor) -> "SneakAttackOption | None":
+    """The actor's Sneak Attack rider (rogue) — the sheet's `sneak_attack_dice` + its avg value, or
+    None for a non-rogue / no sneak dice (byte-identical). PURE read."""
+    dice = str(getattr(actor, "sneak_attack_dice", "") or "").strip()
+    if not dice:
+        return None
+    try:
+        value = float(dice_mod.average_total(dice))
+    except (ValueError, TypeError):
+        value = 0.0
+    return SneakAttackOption(dice=dice, value=value)
+
+
 def _build_view(server, c, actor) -> CombatView:
     """Assemble the read-only CombatView for `actor` from the live Combat. READ-ONLY — touches
     no state; the loop never mutates here."""
@@ -259,6 +349,17 @@ def _build_view(server, c, actor) -> CombatView:
         casting_mod = 0
     spells = _spell_options(server, actor, caster_level, casting_mod)
 
+    # Martial abilities + Sneak Attack (v2.0c). Empty/None for a non-martial actor == today.
+    abilities = _ability_options(server, actor)
+    sneak = _sneak_attack_option(actor)
+    # The action economy this turn — meaningful only when `actor` is the CURRENT combatant (the
+    # engine tracks action_used / bonus_action_used on c.combat for the current turn). When the
+    # actor isn't current, default both to available (the AI's bonus channel only fires on the
+    # actor's own turn anyway, and an out-of-combat view stays as today).
+    is_current = bool(c.combat.active and c.combat.current_combatant_id == actor.id)
+    action_available = (not c.combat.action_used) if is_current else True
+    bonus_action_available = (not c.combat.bonus_action_used) if is_current else True
+
     return CombatView(
         actor_id=actor.id,
         actor_cell=actor_cell,
@@ -280,6 +381,16 @@ def _build_view(server, c, actor) -> CombatView:
         # v2.0b: the spell the actor is ALREADY concentrating on (or "" — today's default). Lets the
         # AI avoid breaking a higher-value active concentration with a new concentration spell.
         active_concentration=str(getattr(actor, "concentration", "") or ""),
+        # v2.0c: martial abilities + Sneak Attack + the actor's HP + this turn's action economy +
+        # whether the barbarian is already raging this fight. All default to today's behavior so a
+        # non-martial actor's view is byte-identical (empty abilities, None sneak, fresh economy).
+        actor_current_hp=int(getattr(actor, "current_hp", 0)),
+        actor_max_hp=int(getattr(actor, "max_hp", 0)),
+        abilities=abilities,
+        sneak_attack=sneak,
+        action_available=action_available,
+        bonus_action_available=bonus_action_available,
+        is_raging=actor.id in _raged_this_fight,
     )
 
 
@@ -299,8 +410,14 @@ def _apply_intent(server, campaign_id: str, actor_id: str, intent: Intent) -> di
                 campaign_id=campaign_id, attacker_id=actor_id, target_id=intent.target_id,
                 attack_name=intent.attack_name,
             )
-            if opt is not None and opt.damage_rolls:
-                kwargs["damage_rolls"] = [dict(r) for r in opt.damage_rolls]
+            # SNEAK ATTACK (v2.0c): a tagged rider is a damage_rolls component. Fold it in WITH the
+            # weapon's components so the engine rolls + crit-doubles both via the multi-component
+            # path. When there's no sneak rider the path is byte-identical to v2.0b.
+            sneak_components = [dict(r) for r in (intent.sneak_attack or ())]
+            if opt is not None and (opt.damage_rolls or sneak_components):
+                weapon_rolls = ([dict(r) for r in opt.damage_rolls] if opt.damage_rolls
+                                else [{"dice": opt.damage_expr or "1d4", "type": opt.damage_type}])
+                kwargs["damage_rolls"] = weapon_rolls + sneak_components
                 kwargs["attack_bonus"] = opt.to_hit
             elif opt is not None:
                 kwargs["attack_bonus"] = opt.to_hit
@@ -310,6 +427,23 @@ def _apply_intent(server, campaign_id: str, actor_id: str, intent: Intent) -> di
                 # No cached option (defensive) — a minimal legal strike so the turn resolves.
                 kwargs["attack_bonus"] = 0
                 kwargs["damage_dice"] = "1d4"
+                if sneak_components:
+                    kwargs.pop("damage_dice", None)
+                    kwargs["damage_rolls"] = [{"dice": "1d4", "type": "piercing"}] + sneak_components
+            # BATTLE MASTER MANEUVER (v2.0c): declared ON the attack — the engine spends the die only
+            # on a hit and folds it into the damage (the attack() maneuver rider). Empty == today.
+            if intent.maneuver:
+                kwargs["maneuver"] = intent.maneuver
+                kwargs["maneuver_resource"] = intent.maneuver_resource or "superiority_dice"
+            # GUIDED STRIKE (v2.0c): a flat +10-to-hit option is a SEPARATE use_resource declared
+            # BEFORE the attack (it stashes a pending_attack_bonus the next attack folds in). Spend
+            # it via the locked verb; if the pool refuses we just lose the bonus (the strike lands).
+            if intent.channel:
+                ch_res = intent.channel_resource or "channel_divinity"
+                gs = server.use_resource(
+                    campaign_id, actor_id, resource=ch_res, maneuver=intent.channel,
+                )
+                entry["channel"] = {"option": intent.channel, "ok": bool(gs.get("ok"))}
             res = server.attack(**kwargs)
             dmg = res.get("damage")
             dmg_applied = None
@@ -321,6 +455,10 @@ def _apply_intent(server, campaign_id: str, actor_id: str, intent: Intent) -> di
                 "damage": dmg_applied,
                 "target_state": res.get("target_state"),
             }
+            if intent.sneak_attack:
+                entry["result"]["sneak_attack"] = intent.sneak_attack[0].get("dice")
+            if intent.maneuver:
+                entry["result"]["maneuver"] = res.get("maneuver_damage") or intent.maneuver
         elif intent.kind == "cast":
             res = server.cast_spell(
                 campaign_id=campaign_id, character_id=actor_id,
@@ -406,6 +544,34 @@ def _apply_intent(server, campaign_id: str, actor_id: str, intent: Intent) -> di
                 server.move_to_coords(campaign_id, actor_id, intent.to_cell[0], intent.to_cell[1])
             elif intent.to_zone:
                 server.move_to_zone(campaign_id, combatant_id=actor_id, zone=intent.to_zone)
+        elif intent.kind == "use_resource":
+            # A class-resource spend (v2.0c): Second Wind / Rage (bonus action) or Action Surge (a
+            # fresh Action grantor). The locked use_resource verb deducts the pool; Action Surge bumps
+            # c.combat.surge_actions so the loop's re-ask gets an extra Attack action. For a BONUS-
+            # action ability (Second Wind / Rage), also mark the bonus action spent + apply Second
+            # Wind's heal via the locked apply_healing (the pool spend alone doesn't raise HP). Rage
+            # entry is tracked per-fight so the AI won't re-spend it (see _raged_this_fight).
+            rr = server.use_resource(campaign_id, actor_id, resource=intent.resource,
+                                     amount=max(1, int(intent.amount)))
+            entry["result"] = {"resource": intent.resource, "ok": bool(rr.get("ok")),
+                               "remaining": rr.get("remaining")}
+            rid_l = str(intent.resource).lower()
+            if rr.get("ok") and rid_l == "second_wind":
+                # Second Wind heals 1d10 + fighter level — apply via the SAME locked verb the DM uses.
+                actor = server._require(campaign_id).characters.get(actor_id)
+                lvl = _fighter_level(actor) if actor is not None else 1
+                rolled = dice_mod.roll(f"1d10+{lvl}")
+                healed = server.apply_healing(campaign_id=campaign_id, target_id=actor_id,
+                                              amount=int(rolled.total))
+                entry["result"]["heal"] = {"amount": int(rolled.total), "hp": healed.get("hp")}
+            if rr.get("ok") and rid_l == "rage":
+                _raged_this_fight.add(actor_id)
+            # Mark the BONUS action consumed for a bonus-action ability so the loop doesn't re-issue it.
+            if rr.get("ok") and rid_l in ("second_wind", "rage"):
+                try:
+                    server.use_action(campaign_id, actor_id, kind="bonus")
+                except Exception:
+                    pass
         elif intent.kind == "dash":
             server.use_action(campaign_id, actor_id, kind="dash")
         elif intent.kind == "dodge":
@@ -480,12 +646,25 @@ def run_combat_round(campaign_id: str, mode: str = "live", max_turns: int = 60) 
         # One full turn for `actor`: ask the AI, apply, repeat for a Multiattack budget.
         view = _build_view(server, c, actor)
         _view_cache[actor.id] = view.attacks
-        # Multiattack budget: how many attack() strikes this actor's Attack action grants.
-        ma = max(1, server._attacker_multiattack_count(actor, c))
-        strikes_left = ma
         acted = False
+
+        # BONUS ACTION (v2.0c): fire a worthwhile bonus action ALONGSIDE the main action (Second
+        # Wind self-heal / Rage entry / bonus-action Healing Word). Resolved FIRST so Second Wind's
+        # HP lands before the swings. Returns None for a non-martial actor -> byte-identical (no
+        # bonus call). The _apply_intent marks the bonus economy spent so it fires at most once.
+        bonus_intent = combat_ai.pick_bonus_action(actor, view)
+        if bonus_intent is not None:
+            digest.append(_apply_intent(server, campaign_id, actor.id, bonus_intent))
+            acted = True
+
+        # Multiattack budget: how many attack() strikes this actor's Attack action grants.
+        c = server._require(campaign_id)
+        actor = c.characters.get(cur_id)
+        ma = max(1, server._attacker_multiattack_count(actor, c)) if actor is not None else 1
+        strikes_left = ma
+        surged = False  # Action Surge spent this turn? (one extra Attack action, v2.0c)
         # Re-ask pick_action per granted strike (move-then-attack, or several strikes).
-        for _strike in range(max(1, ma) + 2):  # +2 headroom for a move then attacks
+        for _strike in range(max(1, ma) + 4):  # +4 headroom: a move, the strikes, an Action Surge
             c = server._require(campaign_id)
             actor = c.characters.get(cur_id)
             if actor is None or not _alive(actor) or not c.combat.active:
@@ -494,19 +673,32 @@ def run_combat_round(campaign_id: str, mode: str = "live", max_turns: int = 60) 
                 break  # fight is decided; stop issuing this actor's strikes
             view = _build_view(server, c, actor)
             _view_cache[actor.id] = view.attacks
+            # ACTION SURGE (v2.0c): when the normal strikes are spent but the fight is still hot,
+            # the fighter can spend Action Surge for a FRESH Attack action. Spend it ONCE, then keep
+            # swinging (the engine's surge_actions grants the extra strikes). Only a fighter with the
+            # surge ability + a hot moment surges (should_action_surge gates it); else None == today.
+            if strikes_left <= 0 and not surged:
+                surge_intent = combat_ai.should_action_surge(view)
+                if surge_intent is not None:
+                    digest.append(_apply_intent(server, campaign_id, actor.id, surge_intent))
+                    surged = True
+                    strikes_left = ma  # the surged action grants another Attack action's strikes
+                    acted = True
+                    continue
+                break  # no surge — the actor's attacks are done
             intent = combat_ai.pick_action(actor, view)
             entry = _apply_intent(server, campaign_id, actor.id, intent)
             digest.append(entry)
             acted = True
             if intent.kind == "attack":
                 strikes_left -= 1
-                if strikes_left <= 0:
-                    break
+                if strikes_left <= 0 and surged:
+                    break  # already surged once; don't loop forever
             elif intent.kind in ("skip", "dodge", "disengage"):
                 break
             elif intent.kind == "move":
                 continue  # let the next iteration try to attack from the new cell
-            else:  # cast / dash
+            else:  # cast / dash / use_resource
                 break
 
         # Advance the turn (auto-resolves end-of-turn repeat saves). If the actor never acted,
@@ -556,6 +748,11 @@ def run_combat_autonomous(campaign_id: str, mode: str = "test", max_rounds: int 
 
     if mode not in ("live", "test"):
         raise ValueError("mode must be 'live' or 'test'")
+
+    # v2.0c: this is a FRESH fight from the AI's perspective — clear the per-fight rage tracker so a
+    # barbarian can enter rage again (a new fight, rested or not, is a new rage decision). Loop-local
+    # bookkeeping only; never touches the snapshot.
+    _raged_this_fight.clear()
 
     rounds: list[dict] = []
     actors_acted: set = set()

--- a/servers/engine/tests/test_combat_core.py
+++ b/servers/engine/tests/test_combat_core.py
@@ -989,3 +989,24 @@ def test_set_house_rules_rejects_test_only_toggles(tmp_path, monkeypatch):
     hr = server.set_house_rules(cid, {"difficulty": "hard"})
     assert hr["difficulty"] == "hard"
     assert hr.get("force_hit") is False and hr.get("fast_resolve") is False
+
+
+def test_v2c_sneak_attack_is_once_per_turn_in_the_loop(tmp_path, monkeypatch):
+    """5e RAW: Sneak Attack is ONCE PER TURN. run_combat_round tracks `sneak_used` and, after a Sneak
+    Attack LANDS, nulls view.sneak_attack for the rest of the actor's turn — so a multi-strike rogue
+    can't re-tag it (the bug: the strike loop rebuilt the view each strike with sneak still populated →
+    6d6 instead of 3d6). This pins the suppression MECHANISM the loop applies: an eligible view tags
+    sneak; the SAME view with sneak_attack nulled (what the loop does after a landed sneak) does NOT."""
+    from dataclasses import replace
+    dagger = AttackOption(name="Dagger", to_hit=7, damage_expr="1d4+4", reach_ft=5)
+    sneak = SneakAttackOption(dice="3d6", value=10.0)
+    ally = CombatantView(id="ally", name="ally", side="enemy", current_hp=20, max_hp=20,
+                         armor_class=15, cell=(2, 0))
+    eligible = _mk_view([dagger], [_foe("t", hp=20, ac=13, cell=(1, 0))], grid=True, actor_cell=(0, 0),
+                        sneak_attack=sneak, allies=(ally,))
+    # Strike 1: sneak is available + the adjacency trigger fires -> tagged (3d6).
+    i1 = combat_ai.pick_action(object(), eligible)
+    assert i1.kind == "attack" and i1.sneak_attack and i1.sneak_attack[0]["dice"] == "3d6"
+    # After it LANDS the loop nulls view.sneak_attack -> a second strike THAT SAME TURN does NOT re-tag.
+    i2 = combat_ai.pick_action(object(), replace(eligible, sneak_attack=None))
+    assert i2.kind == "attack" and i2.sneak_attack == (), "Sneak re-tagged after it was used this turn"

--- a/servers/engine/tests/test_combat_core.py
+++ b/servers/engine/tests/test_combat_core.py
@@ -40,6 +40,14 @@ def _mk_view(actor_attacks, foes, grid=False, actor_cell=None, **kw) -> CombatVi
         attacks=tuple(actor_attacks),
         spells=tuple(kw.get("spells", ())),
         caster_level=int(kw.get("caster_level", 0)),
+        # v2.0c martial fields (all default to today's behavior when omitted).
+        actor_current_hp=int(kw.get("actor_current_hp", 0)),
+        actor_max_hp=int(kw.get("actor_max_hp", 0)),
+        abilities=tuple(kw.get("abilities", ())),
+        sneak_attack=kw.get("sneak_attack", None),
+        action_available=bool(kw.get("action_available", True)),
+        bonus_action_available=bool(kw.get("bonus_action_available", True)),
+        is_raging=bool(kw.get("is_raging", False)),
     )
 
 
@@ -57,6 +65,27 @@ def _ally(aid, hp=10, max_hp=10, cell=None, name=None, downed=False):
 def _heal(name="Healing Word", amount=6.0, rng=60, slot=1, bonus=True):
     return SpellOption(name=name, range_ft=rng, requires_slot=True,
                        is_heal=True, heal_amount=amount, slot_level=slot, is_bonus_action=bonus)
+
+
+import contextlib  # noqa: E402
+
+
+@contextlib.contextmanager
+def _seeded_ids(seed: int):
+    """Install a SEEDED entity-id generator (models._new_id) for the duration, then restore it. A
+    seeded `seed` makes the WHOLE fight reproducible — character ids feed the AI's focus-fire and
+    v2.0c ability tie-breaks, so RANDOM ids would let the round count drift even at a fixed dice seed
+    (the richer martial behavior — Action Surge / Second Wind — surfaced this: which-goblin-dies-when
+    becomes id-order-sensitive). Mirrors qa/combat_smoke._install_deterministic_ids."""
+    import random as _r
+    import models
+    orig = models._new_id
+    rng = _r.Random(0xC0FFEE ^ int(seed))
+    models._new_id = lambda prefix: f"{prefix}_{rng.getrandbits(48):012x}"
+    try:
+        yield
+    finally:
+        models._new_id = orig
 
 
 # ── p_hit / EV math ────────────────────────────────────────────────────────────────
@@ -348,6 +377,135 @@ def test_pick_action_no_offensive_spells_is_byte_identical_to_pre_pr_attack():
     assert intent.target_id == "b"  # focus-fire the lower-HP foe (today's tiebreak), unchanged
 
 
+# ── pick_action / pick_bonus_action / should_action_surge: martial abilities (v2.0c, #1106) ──
+
+from combat_ai import AbilityOption, SneakAttackOption  # noqa: E402
+
+
+def _ability(kind, resource, **kw):
+    return AbilityOption(kind=kind, resource=resource, remaining=kw.pop("remaining", 1), **kw)
+
+
+def test_v2c_no_abilities_attack_is_byte_identical():
+    """ADDITIVE BYTE-IDENTITY (v2.0c): an actor with NO abilities + NO sneak dice picks the EXACT
+    same plain attack Intent as before v2.0c — every rider field is empty (no maneuver/channel/sneak),
+    so the loop applies a byte-identical strike. The whole martial layer is inert when nothing is set."""
+    axe = AttackOption(name="Greataxe", to_hit=9, damage_expr="1d12+5")
+    v = _mk_view([axe], [_foe("a", hp=30, ac=14)])
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert intent.kind == "attack" and intent.attack_name == "Greataxe"
+    assert intent.maneuver == "" and intent.channel == "" and intent.sneak_attack == ()
+
+
+def test_v2c_no_abilities_bonus_and_surge_are_none():
+    """A view with no abilities yields NO bonus action and NO Action Surge (the channels are inert)."""
+    axe = AttackOption(name="Sword", to_hit=5, damage_expr="1d8+3")
+    v = _mk_view([axe], [_foe("a", hp=20, ac=12)])
+    assert combat_ai.pick_bonus_action(object(), v) is None
+    assert combat_ai.should_action_surge(v) is None
+
+
+def test_v2c_second_wind_fires_when_hurt_only():
+    """Second Wind is a bonus-action self-heal that fires ONLY when the fighter is hurt (<= 1/2 HP)."""
+    axe = AttackOption(name="Sword", to_hit=5, damage_expr="1d8+3")
+    sw = _ability("second_wind", "second_wind", is_bonus_action=True, heal_amount=10.0, name="Second Wind")
+    foes = [_foe("a", hp=20, ac=12)]
+    # Healthy: no Second Wind.
+    healthy = _mk_view([axe], foes, abilities=(sw,), actor_current_hp=40, actor_max_hp=40)
+    assert combat_ai.pick_bonus_action(object(), healthy) is None
+    # Hurt (<= 1/2): Second Wind fires as a use_resource bonus Intent.
+    hurt = _mk_view([axe], foes, abilities=(sw,), actor_current_hp=15, actor_max_hp=40)
+    bi = combat_ai.pick_bonus_action(object(), hurt)
+    assert bi is not None and bi.kind == "use_resource" and bi.resource == "second_wind"
+
+
+def test_v2c_action_surge_only_when_hot():
+    """Action Surge is a NOVA button: NOT spent vs a full-HP lone foe round 1, but spent when a foe
+    is finishable (HP within ~2x one attack's EV) or the fighter is hurt."""
+    axe = AttackOption(name="Sword", to_hit=8, damage_expr="2d6+4")  # EV ~ 0.85 * 11 ~ 9.4
+    surge = _ability("action_surge", "action_surge", name="Action Surge")
+    # A tough full-HP foe, healthy fighter -> don't waste the surge.
+    cold = _mk_view([axe], [_foe("a", hp=80, ac=12)], abilities=(surge,),
+                    actor_current_hp=50, actor_max_hp=50)
+    assert combat_ai.should_action_surge(cold) is None
+    # A finishable foe (HP ~ one attack's EV) -> surge for the kill.
+    hot = _mk_view([axe], [_foe("a", hp=10, ac=12)], abilities=(surge,),
+                   actor_current_hp=50, actor_max_hp=50)
+    si = combat_ai.should_action_surge(hot)
+    assert si is not None and si.resource == "action_surge"
+
+
+def test_v2c_battle_master_maneuver_declared_on_a_worthy_attack():
+    """A Battle Master declares a maneuver on a worthy (non-trivial, likely-to-hit) attack."""
+    sword = AttackOption(name="Sword", to_hit=8, damage_expr="1d8+4")
+    man = _ability("maneuver", "superiority_dice", size="d8", name="Trip Attack")
+    v = _mk_view([sword], [_foe("a", hp=40, ac=12)], abilities=(man,))
+    intent = combat_ai.pick_action(object(), v)
+    assert intent.kind == "attack" and intent.maneuver == "Trip Attack"
+    assert intent.maneuver_resource == "superiority_dice"
+
+
+def test_v2c_maneuver_not_wasted_on_a_trivial_foe():
+    """A maneuver is NOT spent on a foe a plain swing already finishes (HP <= the attack EV)."""
+    sword = AttackOption(name="Sword", to_hit=12, damage_expr="2d8+5")  # EV ~ 14
+    man = _ability("maneuver", "superiority_dice", size="d8", name="Trip Attack")
+    v = _mk_view([sword], [_foe("a", hp=3, ac=10)], abilities=(man,))
+    intent = combat_ai.pick_action(object(), v)
+    assert intent.kind == "attack" and intent.maneuver == ""  # trivial foe — conserve the die
+
+
+def test_v2c_sneak_attack_tagged_when_ally_adjacent():
+    """A rogue tags Sneak Attack when an ALLY is within 5 ft of the target (the flanking trigger)."""
+    dagger = AttackOption(name="Dagger", to_hit=7, damage_expr="1d4+4", reach_ft=5)
+    sneak = SneakAttackOption(dice="3d6", value=10.0)
+    # Grid: rogue at (0,0), foe at (1,0), ally at (2,0) — the ally is adjacent to the foe.
+    ally = CombatantView(id="ally", name="ally", side="enemy", current_hp=20, max_hp=20,
+                         armor_class=15, cell=(2, 0))
+    v = _mk_view([dagger], [_foe("t", hp=20, ac=13, cell=(1, 0))], grid=True, actor_cell=(0, 0),
+                 sneak_attack=sneak, allies=(ally,))
+    intent = combat_ai.pick_action(object(), v)
+    assert intent.kind == "attack" and intent.sneak_attack
+    assert intent.sneak_attack[0]["dice"] == "3d6"
+
+
+def test_v2c_sneak_attack_not_tagged_without_a_trigger():
+    """No advantage and no adjacent ally -> the Sneak Attack rider is NOT tagged (no free sneak)."""
+    dagger = AttackOption(name="Dagger", to_hit=7, damage_expr="1d4+4", reach_ft=5)
+    sneak = SneakAttackOption(dice="3d6", value=10.0)
+    # Lone rogue on the grid, no ally near the foe.
+    v = _mk_view([dagger], [_foe("t", hp=20, ac=13, cell=(1, 0))], grid=True, actor_cell=(0, 0),
+                 sneak_attack=sneak)
+    intent = combat_ai.pick_action(object(), v)
+    assert intent.kind == "attack" and intent.sneak_attack == ()
+
+
+def test_v2c_guided_strike_only_on_a_likely_miss():
+    """Guided Strike (+10) is reserved for a likely-MISS key attack; a likely-HIT strike doesn't burn it."""
+    gs = _ability("guided_strike", "channel_divinity", name="Guided Strike")
+    # High AC -> low P(hit) -> Guided Strike fires.
+    weak = AttackOption(name="Mace", to_hit=4, damage_expr="1d6+2")
+    miss = _mk_view([weak], [_foe("a", hp=20, ac=20)], abilities=(gs,))
+    i1 = combat_ai.pick_action(object(), miss)
+    assert i1.kind == "attack" and i1.channel == "Guided Strike"
+    # Low AC -> high P(hit) -> the channel is conserved (no point spending +10 on a sure hit).
+    strong = AttackOption(name="Mace", to_hit=10, damage_expr="1d6+2")
+    hit = _mk_view([strong], [_foe("a", hp=20, ac=8)], abilities=(gs,))
+    i2 = combat_ai.pick_action(object(), hit)
+    assert i2.kind == "attack" and i2.channel == ""
+
+
+def test_v2c_rage_enters_once_when_meleeing():
+    """Rage fires as a bonus action when a foe is in melee reach and the barbarian isn't yet raging;
+    once raging (is_raging=True) it does NOT re-enter (don't drain the pool)."""
+    axe = AttackOption(name="Greataxe", to_hit=7, damage_expr="1d12+4", reach_ft=5)
+    rage = _ability("rage", "rage", is_bonus_action=True, name="Rage")
+    not_raging = _mk_view([axe], [_foe("a", hp=20, ac=13)], abilities=(rage,), is_raging=False)
+    bi = combat_ai.pick_bonus_action(object(), not_raging)
+    assert bi is not None and bi.kind == "use_resource" and bi.resource == "rage"
+    already = _mk_view([axe], [_foe("a", hp=20, ac=13)], abilities=(rage,), is_raging=True)
+    assert combat_ai.pick_bonus_action(object(), already) is None
+
+
 # ── run_combat_autonomous(mode="test"): seeded random-vs-random to a terminal state ──
 
 def _seed_fight(server, store_mod, *, sandbox=True, monsters=3):
@@ -542,16 +700,18 @@ def test_ai_itself_casts_an_offensive_spell_through_the_loop(tmp_path, monkeypat
 
 
 def test_non_caster_fight_is_byte_identical_under_v2b(tmp_path, monkeypatch):
-    """ADDITIVE BYTE-IDENTITY: a martial-only fight (no offensive spells) resolves to the SAME
-    outcome under v2.0b — same seed, two runs, identical victor/rounds/turns. The offensive-spell
-    path is inert for a non-caster (default-off / empty == today)."""
+    """ADDITIVE BYTE-IDENTITY: a martial-only fight resolves to the SAME outcome on a re-run — same
+    seed, two runs, identical victor/rounds/turns. Seeds BOTH the dice RNG and the entity-id
+    generator so the WHOLE fight is reproducible (character ids feed the AI's focus-fire / v2.0c
+    ability tie-breaks; random ids would let the round count drift at a fixed dice seed)."""
     import server
 
     def _run(seed, state):
         monkeypatch.setenv("WORLDOS_STATE_DIR", str(state))
-        dice_mod.reseed_process_rng(seed)
-        cid, hero, mons = _seed_fight(server, store, monsters=3)
-        return combat_loop.run_combat_autonomous(cid, mode="test", max_rounds=25)
+        with _seeded_ids(seed):
+            dice_mod.reseed_process_rng(seed)
+            cid, hero, mons = _seed_fight(server, store, monsters=3)
+            return combat_loop.run_combat_autonomous(cid, mode="test", max_rounds=25)
 
     r1 = _run(909, tmp_path / "a")
     r2 = _run(909, tmp_path / "b")
@@ -562,26 +722,36 @@ def test_non_caster_fight_is_byte_identical_under_v2b(tmp_path, monkeypatch):
 def test_run_combat_autonomous_test_runs_to_terminal_and_everyone_acted(tmp_path, monkeypatch):
     monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
     import server
-    dice_mod.reseed_process_rng(4242)
-    cid, hero, mons = _seed_fight(server, store)
-    res = combat_loop.run_combat_autonomous(cid, mode="test", max_rounds=25)
+    with _seeded_ids(4242):  # seed ids too so the fight is fully reproducible (v2.0c tie-breaks)
+        dice_mod.reseed_process_rng(4242)
+        cid, hero, mons = _seed_fight(server, store)
+        res = combat_loop.run_combat_autonomous(cid, mode="test", max_rounds=25)
     # terminal: a victor or a draw (never left mid-fight in test mode)
     assert res["victor"] in ("party", "enemy", "draw")
     assert res["round_cap_hit"] is False
-    # EVERY combatant got at least one turn
-    assert set(res["actors_acted"]) == set([hero] + mons), res["actors_acted"]
+    # The hero acted, and EVERY actor that acted is a real combatant (a valid subset of the order).
+    # NOTE (v2.0c): "everyone acts" is no longer guaranteed — a stronger martial AI (Action Surge /
+    # maneuvers) can drop a monster BEFORE its turn comes up, so a foe may die without acting. The
+    # loop's contract is "sequence each combatant that still has a turn", not "force a dead foe to
+    # act"; so we assert the acted set is a non-empty subset including the hero, not a strict equality.
+    acted = set(res["actors_acted"])
+    all_combatants = set([hero] + mons)
+    assert acted, "no combatant acted"
+    assert hero in acted, "the hero never took a turn"
+    assert acted <= all_combatants, f"a non-combatant acted: {acted - all_combatants}"
     # combat closed out (end_combat fired on a decisive result)
     assert res["turns"] > 0
 
 
 def test_dice_seed_is_deterministic(tmp_path, monkeypatch):
-    """Same seed -> byte-identical fight outcome; the seed fixes the whole sequence."""
+    """Same seed -> byte-identical fight outcome; the seed fixes the whole sequence (dice AND ids)."""
     import server
 
     def _run(seed):
-        dice_mod.reseed_process_rng(seed)
-        cid, hero, mons = _seed_fight(server, store)
-        return combat_loop.run_combat_autonomous(cid, mode="test", max_rounds=25)
+        with _seeded_ids(seed):
+            dice_mod.reseed_process_rng(seed)
+            cid, hero, mons = _seed_fight(server, store)
+            return combat_loop.run_combat_autonomous(cid, mode="test", max_rounds=25)
 
     monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path / "a"))
     r1 = _run(909)


### PR DESCRIPTION
## What

Engine-AI competence **v2.0c** (epic #1100, issue #1106): surface MARTIAL class resources/abilities into the `CombatView` and have the engine-run AI **use** them. Builds directly on the merged v2.0a (heal-the-dying-ally) + v2.0b (offensive spell EV) foundation — same `pick_action` EV core, same `policy=` seam, same sole-writer loop.

**STRICTLY ADDITIVE:** an actor with no usable ability (a commoner / a pure caster / a plain monster) produces a **byte-identical** fight to today. Every new view field defaults to today's behavior; every ability branch is gated on a surfaced ability/dice.

## Abilities wired (the AI chooses them ITSELF)

| Ability | Class | Channel | Trigger the AI uses |
|---|---|---|---|
| **Second Wind** | Fighter | bonus action | self-heal (1d10+lvl) when ≤ ½ HP |
| **Action Surge** | Fighter | extra action | spend after the normal strikes when hurt OR a foe is finishable (gated so it isn't wasted round 1) |
| **Battle Master maneuver** | Battle Master | attack rider | Trip-Attack-class die on a worthy (non-trivial, likely-hit) strike |
| **Sneak Attack** | Rogue | attack rider | tag the strike when advantage OR an ally is within 5 ft of the target |
| **Guided Strike** | War cleric | attack rider | +10 to hit on a likely-MISS key attack (its whole value is the to-hit) |

**Bonus-action economy channel:** new `pick_bonus_action` fires Second Wind / Rage / a bonus-action Healing Word ALONGSIDE the main action; `should_action_surge` decides the surge after the normal strikes.

## DEFERRED to v2.0d (flagged, not force-fixed)
- **Rage** — entry is wired (`use_resource("rage")`, once per fight, only when meleeing), but the engine models the rage POOL only, **not** its +damage / resistance. Entering rage drains a use + is narrated; the mechanical bonus is deferred (no engine state to apply it cleanly).
- **Divine Smite / Ki** — no clean AI-declared-use verb; deferred.

## Before / after (full-loop demo: Battle Master fighter + rogue vs 4 goblins, fighter hurt to 18 HP)
```
VICTOR=party rounds=5 turns=24
  [second_wind] Second Wind (bonus action): self-heal ~10 HP at 18/49
  [attack-rider] best in-reach attack on Goblin 3 (EV 5.2, P(hit) 65%); + maneuver Trip Attack (d8 on hit)
  [action_surge] Action Surge: extra Attack action (a foe is finishable with an extra action)
  [attack-rider] ... + maneuver Trip Attack ...   (×4 more)
MARTIAL ABILITIES THE AI USED ON ITS OWN: ['action_surge', 'maneuver', 'second_wind']
```
**Before v2.0c:** the same fighter would only swing its weapon — Second Wind / Action Surge / maneuvers never fired (the view didn't carry them). PART 5 (below) proves all five fire 5/5 with the right setups.

## Gauge — `qa/combat_smoke.py` PART 5 (the competence bar)
```
PART 5 — engine-AI competence v2.0c: the AI ITSELF uses martial class abilities (#1106)
  A) Second Wind  : chose=True HP 16 -> 26 -> PASS
  B) Action Surge : spent_in_loop=True strikes=2 (base 1) uses 1 -> 0 -> PASS
  C) Maneuver     : declared='Trip Attack' dice 4 -> 4 -> PASS
  D) Sneak Attack : tagged=True dice='3d6' -> PASS
  E) Guided Strike: declared='Guided Strike' CD 2 -> 1 -> PASS
  abilities the AI used on its own: 5/5  (bar: >= 2)   PART 5: PASS
```
Action Surge B exercises the **real loop** (not an isolated call) — this caught a real bug: `attack()` sets `action_used`, so an early `action_available` gate would have silently blocked the surge in real play. Fixed (surge correctly acts AFTER the action is spent).

## Per-file
- **`servers/engine/combat_ai.py`** — `AbilityOption` + `SneakAttackOption` view types; `CombatView` gains `abilities` / `sneak_attack` / actor HP / action+bonus availability / `is_raging` (all default to today). `pick_action` enriches the chosen attack (`_enrich_attack_intent`). New `pick_bonus_action` + `should_action_surge`.
- **`servers/engine/combat_loop.py`** — `_build_view` surfaces the abilities/sneak/economy from `class_resources` (read-only). `_apply_intent` applies the new `use_resource` Intent + the attack riders. Per-turn: bonus action + Action Surge channels. Per-fight rage tracker (loop-local; never touches the snapshot).
- **`qa/combat_smoke.py` + `qa/test_combat_smoke.py`** — PART 5 + its pytest.
- **`servers/engine/tests/test_combat_core.py`** — v2.0c unit tests (byte-identity + each ability + only-when-warranted gates). Seeded the entity-id generator in the determinism / byte-identity / everyone-acted tests so the richer behavior is reproducible (random ids made the round count id-order-sensitive).

## Invariants
- **Additive / byte-identity:** `test_v2c_no_abilities_attack_is_byte_identical` + `test_v2c_no_abilities_bonus_and_surge_are_none` + the seeded-id determinism/byte-identity tests. Empty abilities + None sneak == today.
- **Sole writer preserved:** every mutation goes through an EXISTING locked verb (`use_resource` / `attack` riders / `apply_healing` / `apply_damage` / `use_action`). No new write path (verified: only existing `server.*` verbs called).
- **`policy=` seam intact**; **no new MCP tool/params** (`test_tool_schema_budget` green — 120 KB budget untouched).
- `qa/scores.db` not mutated.

## Tests
```
uv run --directory servers/engine python -m pytest tests/ ../../qa/test_combat_smoke.py -q -p no:xdist
→ 3145 passed in 51.58s
```
- combat core + smoke run **5×** stably (no flakiness after the seeded-id fix).
- Tier-0 fast gate: PASS (241 deterministic engine tests).

Closes part B of #1106 (engine-AI competence v2 — martial abilities + bonus-action economy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced combat AI now autonomously uses martial class abilities during fights, including Second Wind for tactical healing, Action Surge for bonus attacks, Battle Master maneuvers, Sneak Attacks, and Guided Strikes based on combat conditions.

* **Tests**
  * Added comprehensive test coverage for martial ability selection, application, and validation during combat encounters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->