### PR TITLE
chore(qa): clear ruff E741/E702 lint in qa/combat_smoke.py

### DIFF
--- a/qa/combat_smoke.py
+++ b/qa/combat_smoke.py
@@ -465,7 +465,7 @@ def run_part2(server, store_mod, base_seed: int):
             tid = targs.get("target_id") or (targs.get("target_ids") or [None])[0]
             before_hp = c.characters[tid].current_hp if tid and tid in c.characters else None
             caster_ch = c.characters[caster]
-            before_slots = {l: s.maximum - s.used for l, s in caster_ch.spell_slots.items()}
+            before_slots = {lvl: s.maximum - s.used for lvl, s in caster_ch.spell_slots.items()}
 
             _make_current(server, store_mod, cid, caster)
             res = server.cast_spell(cid, caster, spell_name=name, **targs)
@@ -474,7 +474,7 @@ def run_part2(server, store_mod, base_seed: int):
             c2 = server._require(cid)
             after_hp = c2.characters[tid].current_hp if tid and tid in c2.characters else None
             caster2 = c2.characters[caster]
-            after_slots = {l: s.maximum - s.used for l, s in caster2.spell_slots.items()}
+            after_slots = {lvl: s.maximum - s.used for lvl, s in caster2.spell_slots.items()}
 
             ok, why = _assert_spell_effect(category, name, res, before_hp, after_hp,
                                            before_slots, after_slots, c2, caster, tid)
@@ -497,7 +497,7 @@ def _assert_spell_effect(category, name, res, before_hp, after_hp, before_slots,
     """SRD-consistent gauge assertion per category. Returns (ok, why)."""
     # A leveled spell must have spent a slot; a cantrip spends none (slot_used None).
     slot_used = res.get("slot_used")
-    spent_a_slot = any(after_slots.get(l, 0) < before_slots.get(l, 0) for l in before_slots)
+    spent_a_slot = any(after_slots.get(lvl, 0) < before_slots.get(lvl, 0) for lvl in before_slots)
 
     if category in ("attack-cantrip", "auto-hit", "save-for-half"):
         # Damage spell: cast_spell returns the resolution; for a single attack/auto/save target the
@@ -669,7 +669,9 @@ def _seed_wizard_fight(server, store_mod, seed_off, *, monster="Goblin", count=1
     cid = server.create_campaign(title="Wizard Competence")["id"]
     server.add_location(campaign_id=cid, name="Tower", description="x", make_current=True)
     server.start_session(cid, title="Wizard Competence")
-    c = server._require(cid); c.is_sandbox = True; store_mod.save_campaign(c)
+    c = server._require(cid)
+    c.is_sandbox = True
+    store_mod.save_campaign(c)
     wiz = server.create_character(
         cid, "Tarn", kind="player", race="human", class_name="wizard", level=5,
         abilities=dict(strength=8, dexterity=14, constitution=12, intelligence=18, wisdom=10, charisma=10),
@@ -728,7 +730,9 @@ def run_part4(server, store_mod, base_seed: int) -> dict:
     server.prepare_spells(cidB, wizB, ["Burning Hands"])
     c = server._require(cidB)
     idx = next(i for i, cb in enumerate(c.combat.order) if cb.character_id == wizB)
-    c.combat.turn_index = idx; c.combat.action_used = False; store_mod.save_campaign(c)
+    c.combat.turn_index = idx
+    c.combat.action_used = False
+    store_mod.save_campaign(c)
     intentB, viewB, beforeB, afterB, entryB = _ai_turn(server, store_mod, cidB, wizB)
     save_dmg = entryB.get("result", {}).get("damage", {}) if entryB else {}
     saveB = (intentB.kind == "cast" and intentB.spell_name == "Burning Hands"


### PR DESCRIPTION
## What

Clears all ruff lint errors in `qa/combat_smoke.py`. `ruff check qa/combat_smoke.py` reported **7 errors**; this brings it to **clean**.

| Rule | Count | Lines | Fix |
|------|-------|-------|-----|
| E741 ambiguous variable name `l` | 3 | 468, 477, 500 | rename loop/key var `l` → `lvl` in the `before_slots`/`after_slots` spell-slot comprehensions |
| E702 multiple statements on one line | 4 | 672, 731 | split `a; b; c` semicolon lines onto their own lines |

## Why

Long-standing lint debt, not gated by CI, but worth cleaning up. The original request scoped only the 3 E741 errors, but ruff also flags 4 E702 errors on the same file — fixing both is what actually makes `ruff check` clean, so this PR clears all 7.

## Safety

- **Lint-only / behavior-preserving.** The E741 renames touch only local comprehension key/loop variables. The E702 splits preserve identical statement order and indentation.
- No engine, content, or test *logic* changed — this is the QA smoke-runner script (`run_part2` / `_seed_wizard_fight` / `run_part4`).
- Additive and independently revertible.

## Verification

\`\`\`
$ uv run --directory servers/engine ruff check ../../qa/combat_smoke.py
All checks passed!
\`\`\`

`python3 -m py_compile qa/combat_smoke.py` also passes.