### PR TITLE
skills: wire-external-api-service + sprint-handoff-doc + worldos-dev/godot-dev gotchas

### DIFF
--- a/.claude/skills/godot-dev/SKILL.md
+++ b/.claude/skills/godot-dev/SKILL.md
@@ -38,3 +38,13 @@ Next: **#1090** (narration/dialogue in-view) → **#1089** (painterly backdrop, 
 ## Dev loop
 Worktree off `origin/main` → additive change → local Godot validate → PR → squash-merge → prune.
 Multi-session repo: never branch-flip the shared checkout; `godot/`-only PRs skip CodeQL.
+
+## Gotchas (cost real time — see HANDOFF.md §8)
+- **`export_presets.cfg` is in Godot's default `.gitignore`, but `godot --headless --export` fails
+  "no preset named X" without it.** Remove it from `.gitignore` and commit minimal Web + Linux
+  presets. Validate a preset locally *without* templates by checking the error is *"export template
+  not found"* (preset OK) vs *"no preset named X"* (preset wrong).
+- **Asset bake output is gitignored — destroyed on `git worktree remove`.** Run the bake
+  (`meshy_gen`/`tripo_gen` → `bake_sprites.py` → `pack_sheet.py`) so finals land in the **canonical**
+  repo's `content/worlds/_private/.../images/<scope>/`, never inside a `WorldOS-worktrees/wt-*/` worktree.
+- Art generation → the **`asset-gen`** skill; integrating a new gen service → **`wire-external-api-service`**.

--- a/.claude/skills/sprint-handoff-doc/SKILL.md
+++ b/.claude/skills/sprint-handoff-doc/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: sprint-handoff-doc
+description: Write a rich handoff / status doc that genuinely transfers knowledge when a multi-PR sprint on a new subsystem will be picked up by a different agent or after a compaction. Use when finishing a sprint, handing off a subsystem, or asked "are we handoff-ready / is this documented for a fresh agent." Produces a HANDOFF.md (diagrams + knowledge base + gotchas + backlog) AND cross-links it from the entry-point docs so it is actually discoverable.
+---
+
+# Sprint handoff / knowledge-transfer doc
+
+A status list is NOT a handoff. The goal is that a cold agent (or post-compaction you) becomes
+productive **without re-deriving the hard-won knowledge**. Put it at `<subsystem>/HANDOFF.md`.
+
+## Structure (8 parts)
+1. **TL;DR** — what's done vs NOT, in one honest paragraph. Don't let a diagram imply "shipped" when
+   it's "planned."
+2. **Status table** — done-vs-open with issue numbers + PR links.
+3. **Architecture diagrams** — Mermaid (renders on GitHub): the build pipeline, the runtime data
+   flow, the component/scene/layer stack. Plus a **diagram-vs-reality** caveat list — every place the
+   diagram over-promises vs what's actually built (this is where cold agents get misled).
+4. **Run / validate** — the EXACT commands to run + validate it, with expected output.
+5. **Knowledge base** — the research facts that took effort to learn and are NOT reproducible from the
+   code (the "why", the lineage, external-tool findings). Cite sources.
+6. **Gotchas** — things that cost real time and aren't obvious from source.
+7. **Prioritized backlog** — the next 3 issues with rationale, then the rest.
+8. **References** — research runs, primary sources.
+
+## The mandatory close step (the discoverability gate — do not skip)
+A handoff doc that isn't reachable from the main entry points **doesn't count**. Before declaring done:
+```
+grep -ciE '<subsystem>|HANDOFF' WorldOS-RUNBOOK.md README.md docs/GETTING_STARTED.md .claude/skills/worldos-dev/SKILL.md
+```
+If any count is **0**, add a one-line pointer there. Also create or point a dev skill (`godot-dev`-style)
+so the skill matcher auto-surfaces the subsystem for a fresh agent.
+
+> Validated 2026-06-21: this structure took fresh-agent onboarding to ~95% — a lean status-only first
+> draft scored ~72% (the work was invisible from the entry points). The rich version + the cross-link
+> close step is what closed the gap.

--- a/.claude/skills/wire-external-api-service/SKILL.md
+++ b/.claude/skills/wire-external-api-service/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: wire-external-api-service
+description: Wire a new external AI/API service (and its MCP) so future agents can reliably use it — secure keys, a CLI wrapper, an optional engine provider, and a service skill. Use when integrating ANY new external generation / API / MCP service (image, 3D, audio, data) that agents will call — storing credentials, registering an MCP, building a wrapper, or adding an image/asset provider. Encodes the probe-auth-first discipline, the key-security pattern, and the subagent-MCP-inheritance gap.
+---
+
+# Wire an external API / MCP service for agents
+
+The repeatable recipe (used to add Meshy / Tripo3D / Scenario / PixelLab in one pass). Three
+non-obvious facts up front — each one saved or would have saved real time:
+
+1. **Probe auth BEFORE building.** Public docs *and your own research* are wrong roughly half the
+   time on the auth scheme and base URL. `curl` a cheap endpoint with each plausible scheme and
+   trust only what returns `200`/`404` (vs `401`/`403`). *(Real catch this session: Scenario is HTTP
+   **Basic** at `api.cloud.scenario.com`, not Bearer at `api.scenario.com`.)*
+2. **Keys live OUTSIDE the repo.** `~/.worldos/<service>.key` (mode 600), never committed; env
+   fallback `WORLDOS_<SERVICE>_API_KEY`. ⚠ if a key was pasted into a chat, flag it for rotation.
+3. **A subagent does NOT inherit user-scope MCPs.** A freshly-spawned agent can't rely on
+   `claude mcp add` registrations, so the **CLI wrapper is the portable path**. (Corollary:
+   adversarial subagents will falsely report "MCP not registered" — a context artifact; verify in
+   the main session with `claude mcp list`.)
+
+## The 8 steps
+1. **Probe auth** — `curl -s -o /dev/null -w "%{http_code}"` with `-H "Authorization: Bearer …"` AND
+   `-u key:secret` AND no-auth, against a cheap GET. Nail base URL + endpoint + scheme first.
+2. **Store the key** — `printf %s '<key>' > ~/.worldos/<svc>.key && chmod 600 ~/.worldos/<svc>.key`
+   (+ a `.secret` file if the service needs two). Confirm mode 600. Never echo the key into a
+   committed file or a log.
+3. **CLI wrapper** — mirror an existing one (`godot/tools/meshy_gen.py`): urllib (no `requests`
+   dependency), key from `~/.worldos/` or `WORLDOS_<SVC>_API_KEY`, async create → poll → download,
+   atomic write to a **gitignored** output dir. MUST have `--test-key` (live auth probe → "Auth OK")
+   and `--dry-run` (plan + est. cost, no call).
+4. **Flag parity** — every service wrapper gets the SAME `--test-key` / `--dry-run` (don't leave one
+   the odd-one-out — fresh agents expect uniformity).
+5. **Register the MCP at USER scope** (if the service has one) — `claude mcp add --scope user
+   --transport http <name> <url> --header "Authorization: <scheme>"`. It lands in `~/.claude.json`
+   (NOT the project `.mcp.json`, which is the runtime plugin's engine/rules/voice servers). Confirm
+   `claude mcp list` → ✔ connected.
+6. **Engine provider (optional)** — if the engine has a provider Protocol
+   (`servers/engine/imagegen.py` `ImageProvider`), add a `<Svc>Provider`: implement `configured()`,
+   register in `_HOSTED`, **degrade to null** on unconfigured/offline (never raise), select via the
+   env switch, keep the default null. (This is how you get a real provider that doesn't touch Eva's
+   gateway.)
+7. **Secret-scan the diff** — `git diff --cached | grep -iE '<key-prefixes>'` MUST be empty before commit.
+8. **Document it in a service skill** — the routing (which service for which job), the VERIFIED API
+   facts (scheme, base URL, endpoints, cost), key locations, wrapper + MCP usage. For WorldOS asset
+   services this is the **`asset-gen`** skill — extend it rather than making a new one.
+
+## Verify
+Each wrapper's `--test-key` (live) → "Auth OK"; `claude mcp list` shows the new MCP connected;
+secret-scan clean. A cold agent should reach the service via the CLI wrapper with zero setup beyond
+the key file.
+
+> Generalizes beyond WorldOS — promote to a global skill (`~/.claude/skills/`) if you integrate APIs across repos.

--- a/.claude/skills/worldos-dev/SKILL.md
+++ b/.claude/skills/worldos-dev/SKILL.md
@@ -142,6 +142,24 @@ Keep Python tests single-process unless the lane explicitly supports parallel ex
    git worktree remove --force <worktree> && git branch -D <branch> && git worktree prune
    ```
 
+### Multi-session / worktree gotchas (learned the hard way — these cost real time)
+- **`fetch`-not-`pull` leaves the canonical checkout STALE.** Building every PR in worktrees off
+  `origin/main` + merging on GitHub means `/Users/lume/WorldOS` is only ever `fetch`ed — its working
+  tree silently falls behind and files look "not there." After a merge batch:
+  `git -C /Users/lume/WorldOS pull --ff-only`.
+- **Merge race.** `gh pr merge --squash --admin` can fail "base branch was modified" when a parallel
+  session's PR lands mid-flight — and your LOCAL branch may get cleaned even though the PR stayed
+  OPEN. Verify with `gh pr view <n> --json state` and **retry** the merge on any still-open PR.
+- **A worktree's gitignored files are DESTROYED on `git worktree remove`.** Generated/uncommitted
+  output written into a worktree's `_private` (or any gitignored path) is gone on cleanup — write
+  durable generated artifacts into the **canonical** repo, not a worktree.
+- **Secret-scan the diff before every commit** — `git diff --cached | grep -iE '<key-prefixes>'` must
+  be empty. Keys live in `~/.worldos/*.key` (mode 600), never the tree.
+- **CI-only-validatable changes:** watch CI to conclusion (`gh run watch`) before merging. `godot/`-only
+  PRs skip CodeQL (the deterministic lanes + the `godot.yml` lane gate them), so squash-`--admin` is fine once green.
+- **New-subsystem skills:** **`godot-dev`** (GT2 Godot renderer), **`asset-gen`** (Meshy/Tripo/Scenario/
+  PixelLab art), **`wire-external-api-service`** (integrate a new API/MCP), **`sprint-handoff-doc`** (hand off a sprint).
+
 ## QA STRATEGY — pick the TIER (don't run the 90-min sweep to iterate)
 **Match the test to the change + your confidence — run a MIX, not all-or-nothing.** The full 5-persona
 sweep is the MILESTONE verdict, not the inner loop. Design + the honest signal accounting (the


### PR DESCRIPTION
Skill-mining analysis of this session (workflow `wf_08e1bfce-b44`: 3 mining lenses + a strict 95% curation judge over 20 candidates) → the genuine reusable gaps, gated hard to avoid matcher bloat.

## NEW skills
- **`wire-external-api-service`** — the recipe used 4× (Meshy/Tripo/Scenario/PixelLab): probe-auth-first (docs wrong ~50% of the time), keys in `~/.worldos/` (600, never committed), CLI wrapper w/ `--test-key`/`--dry-run`, user-scope MCP, degrade-to-null provider, secret-scan. Captures the **subagent-MCP-inheritance gap** (CLI wrapper = portable path).
- **`sprint-handoff-doc`** — the rich HANDOFF template + the **mandatory entry-point cross-link close step** (validated: lean draft 72% → rich+cross-linked ~95% onboarding).

## UPDATES
- **`worldos-dev`** — fetch-not-pull staleness, the merge race (`gh pr view` + retry), worktree-removal destroying gitignored output, secret-scan the diff, watch-CI-for-CI-only, + cross-links.
- **`godot-dev`** — `export_presets.cfg` gotcha (+ the template-vs-preset error tell) + bake-into-canonical-`_private`.

## Curation
18 candidates → 2 new + 2 updates created; rest REJECT (already in asset-gen/godot-dev/HANDOFF/global CLAUDE.md/memories). Skipped `research-clarify-design-sprint` (overlaps existing superpowers); the adversarial-subagent-false-positive lesson goes to a feedback memory (not the global `adversarial-pr-sweep` skill). Frontmatter valid; secret-scan clean.