### PR TITLE
skills(worldos-dev): add Planning-a-new-subsystem section (research→design→batch→execute)

### DIFF
--- a/.claude/skills/worldos-dev/SKILL.md
+++ b/.claude/skills/worldos-dev/SKILL.md
@@ -113,6 +113,21 @@ pure harness-evidence plumbing. The corrected reference harness is checked in at
    agent): no gateway restart/reconfigure, no `doctor --fix`, no global `mcp set`, don't
    touch agents `main`/`operations`.
 
+## PLANNING A NEW SUBSYSTEM (research → design → batch → execute)
+For a NEW feature/subsystem (not a one-line fix), don't jump to code — this arc works:
+1. **Clarify** — if the request is vague, ask 2-3 questions that LOCK the load-bearing constraints
+   (delivery target, art/tech direction, scope) BEFORE researching. Wrong constraint → wrong research.
+2. **External research FIRST** (`deep-research`) — the outside question (libraries, techniques, prior
+   art) — before touching the repo.
+3. **Repo design SECOND** (parallel `Explore`/`Plan` agents or a design workflow) — find the
+   integration SEAM + what ALREADY EXISTS (the engine is usually 80-90% there — reuse before rebuild).
+4. **Verify contested claims against SOURCE before writing the plan** — agents and your own research
+   are wrong ~half the time on specifics; read the load-bearing file yourself to resolve disagreements
+   before committing to a plan (see [[feedback_validate_adversarial_subagent_findings]]).
+5. **Plan → file the epic + child issues in ONE batch script** (not one-at-a-time), labeled per the
+   repo's convention → execute each as a worktree PR via the dev loop below. Hand off with the
+   `sprint-handoff-doc` skill.
+
 ## THE DEV LOOP (exact)
 Test policy: **GitHub-CI-first for broad validation; focused local tests for fast feedback.**
 Keep Python tests single-process unless the lane explicitly supports parallel execution.


### PR DESCRIPTION
Per the design principle: a candidate that misses 95% *purely on overlap* belongs INSIDE an existing skill, not as a standalone. Folds the unique disciplines of `research-clarify-design-sprint` into **`worldos-dev`** (owned) — NOT a new skill (overlaps deep-research/writing-plans) and NOT `superpowers` (third-party plugin, not ours to edit). Adds: external-research-before-repo-exploration ordering, verify-contested-claims-against-source before the plan, batch-file the epic+issues in one script. Cross-links deep-research + sprint-handoff-doc + the subagent-false-positive memory.