### PR TITLE
fix(engine,#1106): enforce the bonus-action spell rule — no double Healing Word/turn

### DIFF
--- a/servers/engine/combat_ai.py
+++ b/servers/engine/combat_ai.py
@@ -225,6 +225,13 @@ class CombatView:
     # so a fresh turn behaves as today. Action Surge needs the action; Second Wind the bonus.
     action_available: bool = True
     bonus_action_available: bool = True
+    # 5e RAW bonus-action-spell rule (#1106): if a LEVELED spell was already cast as this turn's BONUS
+    # action (Healing Word / Spiritual Weapon / …), the ACTION this turn may cast ONLY a CANTRIP — never
+    # a second leveled spell. The loop sets this True (replace(view, bonus_spell_used=True)) once its
+    # per-turn bonus action was a slot-spending cast; pick_action then refuses a leveled main-action cast
+    # (heal-triage OR offence). False/default == no leveled bonus spell this turn (today's behavior): the
+    # main action is unconstrained. A cantrip / Second Wind / Rage bonus does NOT set this (no slot spent).
+    bonus_spell_used: bool = False
 
 
 # ── Pure EV helpers ──────────────────────────────────────────────────────────────────
@@ -425,13 +432,22 @@ def _heal_priority(ally: CombatantView) -> Optional[int]:
     return None
 
 
-def _pick_heal(view: CombatView) -> Optional[tuple[CombatantView, SpellOption]]:
+def _pick_heal(view: CombatView, *, action_only: bool = False) -> Optional[tuple[CombatantView, SpellOption]]:
     """The (ally, heal-spell) the actor should cast THIS turn, or None when no heal is warranted
     or possible. Only fires when the actor HAS a heal option AND an ally needs one. Picks the most
     urgent ally (downed > critical > wounded; ties -> most missing HP, then stable id), then prefers
     the BONUS-ACTION ranged heal (Healing Word — the classic save) over a touch heal (Cure Wounds)
-    that needs an adjacent target, and a lower-slot heal over a higher one (cheap first). Pure."""
+    that needs an adjacent target, and a lower-slot heal over a higher one (cheap first). Pure.
+
+    `action_only` (#1106): when True, a BONUS-action-only heal (Healing Word, casting time "1 bonus
+    action") is NOT a candidate — that spell is the bonus channel's job (pick_bonus_action), and the
+    MAIN-action heal-triage must use only an ACTION-castable heal (Cure Wounds). Default False keeps
+    the bonus channel's behavior (it filters to bonus heals itself after this call) byte-identical."""
     heals = [sp for sp in view.spells if sp.is_heal and sp.heal_amount > 0]
+    if action_only:
+        # The MAIN action can't cast a bonus-action-only spell (Healing Word) — drop those candidates
+        # so the action-heal can only ever be an action-castable heal (Cure Wounds).
+        heals = [sp for sp in heals if not sp.is_bonus_action]
     if not heals:
         return None
     # The neediest healable ally: lowest triage rank, then most missing HP, then stable id.
@@ -768,7 +784,17 @@ def pick_action(
     #     through to today's attack logic UNCHANGED (additive: a non-caster / no-hurt-ally party is
     #     byte-identical). Returns a `cast` Intent targeting the ally (the loop's cast_spell ->
     #     apply_healing sole-writer path applies it).
-    heal = _pick_heal(view)
+    #
+    #     #1106 RAW gates: (a) `action_only=True` — the MAIN-action heal can NEVER be a bonus-action-
+    #     only spell (Healing Word); that's the bonus channel's job, so a main-action heal uses only an
+    #     ACTION-castable heal (Cure Wounds). (b) When a LEVELED spell was already cast as this turn's
+    #     bonus action (`bonus_spell_used`), the action may cast ONLY a cantrip — so a LEVELED main-
+    #     action heal (Cure Wounds is a leveled spell) is forbidden; skip the heal-triage entirely and
+    #     fall through to a cantrip/weapon. (Heal cantrips don't exist in SRD, so this skips heals.)
+    if not view.bonus_spell_used:
+        heal = _pick_heal(view, action_only=True)
+    else:
+        heal = None
     if heal is not None:
         ally, sp = heal
         return Intent(
@@ -816,6 +842,12 @@ def pick_action(
     for sp in view.spells:
         if sp.is_heal or sp.kind not in ("attack", "auto", "save"):
             continue  # heals are step 1.5; buff/utility aren't an offensive option
+        # #1106 RAW: after a LEVELED bonus-action spell this turn, the ACTION may cast ONLY a cantrip —
+        # a leveled offensive cast is forbidden. A cantrip (slot_level 0) is still allowed, so the
+        # caster can follow Healing Word with Sacred Flame / Fire Bolt. (Empty view.bonus_spell_used
+        # == today: no constraint, every leveled offensive cast is still a candidate.)
+        if view.bonus_spell_used and sp.slot_level > 0:
+            continue
         # Concentration guard (v2.0b): don't START a new concentration spell that would break an
         # active one of >= EV. (Damage spells here rarely concentrate, but Scorching-Ray-class data
         # could; the guard keeps a high-value lockdown from being clobbered by a marginal swap.)

--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -595,6 +595,27 @@ def _apply_intent(server, campaign_id: str, actor_id: str, intent: Intent) -> di
 _view_cache: dict = {}
 
 
+def _bonus_was_leveled_spell(bonus_intent: Optional[Intent], view: CombatView) -> bool:
+    """Did this turn's BONUS action cast a LEVELED spell (a slot-spender — Healing Word, Spiritual
+    Weapon, …)? 5e RAW (#1106): casting a leveled bonus-action spell forbids a SECOND leveled spell as
+    the same turn's ACTION (only a cantrip may follow). This is the per-turn detector run_combat_round
+    uses to set `view.bonus_spell_used` on the MAIN-action view.
+
+    True ONLY for a `cast` Intent whose spell resolves (by name, in the view the bonus was decided over)
+    to a LEVELED slot (slot_level > 0). A cantrip cast (slot_level 0), a Second Wind / Rage `use_resource`
+    spend, a None bonus (non-caster), or an unrecognized spell -> False (no constraint; today's behavior).
+    Pure: reads only the Intent + the view's already-discovered SpellOptions; no state, no I/O."""
+    if bonus_intent is None or bonus_intent.kind != "cast":
+        return False
+    name = str(bonus_intent.spell_name or "").strip().lower()
+    if not name:
+        return False
+    for sp in view.spells:
+        if str(sp.name or "").strip().lower() == name:
+            return int(sp.slot_level) > 0  # a leveled bonus spell triggers the rule; a cantrip does not
+    return False
+
+
 # ── The rounds ───────────────────────────────────────────────────────────────────────
 
 def run_combat_round(campaign_id: str, mode: str = "live", max_turns: int = 60) -> dict:
@@ -654,6 +675,11 @@ def run_combat_round(campaign_id: str, mode: str = "live", max_turns: int = 60) 
         # HP lands before the swings. Returns None for a non-martial actor -> byte-identical (no
         # bonus call). The _apply_intent marks the bonus economy spent so it fires at most once.
         bonus_intent = combat_ai.pick_bonus_action(actor, view)
+        # #1106: a LEVELED bonus-action spell (Healing Word, …) forbids a SECOND leveled spell as this
+        # turn's ACTION — only a cantrip may follow. Detect it here (over the view the bonus was decided
+        # on) and thread it onto every MAIN-action view this turn so pick_action refuses a leveled cast.
+        # A cantrip / Second Wind / Rage bonus leaves this False == today (no constraint).
+        bonus_spell_used = _bonus_was_leveled_spell(bonus_intent, view)
         if bonus_intent is not None:
             digest.append(_apply_intent(server, campaign_id, actor.id, bonus_intent))
             acted = True
@@ -677,6 +703,11 @@ def run_combat_round(campaign_id: str, mode: str = "live", max_turns: int = 60) 
             if sneak_used and view.sneak_attack is not None:
                 # 5e RAW: Sneak Attack once per turn — already dealt this turn, never re-tag a later strike.
                 view = replace(view, sneak_attack=None)
+            if bonus_spell_used and not view.bonus_spell_used:
+                # #1106: re-thread the leveled-bonus-spell rule onto every freshly-built main-action
+                # view this turn (_build_view doesn't know the loop already cast a leveled bonus spell),
+                # so pick_action refuses a SECOND leveled cast (no double Healing Word / leveled+leveled).
+                view = replace(view, bonus_spell_used=True)
             _view_cache[actor.id] = view.attacks
             # ACTION SURGE (v2.0c): when the normal strikes are spent but the fight is still hot,
             # the fighter can spend Action Surge for a FRESH Attack action. Spend it ONCE, then keep

--- a/servers/engine/tests/test_combat_core.py
+++ b/servers/engine/tests/test_combat_core.py
@@ -48,6 +48,7 @@ def _mk_view(actor_attacks, foes, grid=False, actor_cell=None, **kw) -> CombatVi
         action_available=bool(kw.get("action_available", True)),
         bonus_action_available=bool(kw.get("bonus_action_available", True)),
         is_raging=bool(kw.get("is_raging", False)),
+        bonus_spell_used=bool(kw.get("bonus_spell_used", False)),  # #1106 bonus-action-spell rule
     )
 
 
@@ -174,24 +175,31 @@ def test_pick_action_is_deterministic():
 
 # ── pick_action: heal-the-dying-ally triage (v2.0a, #1106) ───────────────────────────
 
+def _cure(name="Cure Wounds", amount=8.0, rng=5, slot=1):
+    """An ACTION-castable heal (Cure Wounds, casting time '1 action') — the spell the MAIN-action
+    heal-triage may legally cast (#1106: a bonus-action-only Healing Word is the bonus channel's job)."""
+    return _heal(name=name, amount=amount, rng=rng, slot=slot, bonus=False)
+
+
 def test_pick_action_heals_downed_ally_before_attacking():
-    """A healer with a heal spell + a slot heals a DOWNED ally instead of swinging at a foe."""
+    """A healer with an ACTION heal + a slot heals a DOWNED ally instead of swinging at a foe (#1106:
+    the MAIN action uses an action-castable heal — Cure Wounds — not the bonus-only Healing Word)."""
     atks = [AttackOption(name="Mace", to_hit=5, damage_expr="1d6+3")]
     v = _mk_view(atks, [_foe("goblin", hp=7, ac=12)],
                  allies=[_ally("garrick", hp=0, max_hp=40, downed=True)],
-                 spells=[_heal()], caster_level=5)
+                 spells=[_cure()], caster_level=5)
     intent = combat_ai.pick_action(actor=object(), combat_state=v)
     assert intent.kind == "cast"
-    assert intent.spell_name == "Healing Word"
+    assert intent.spell_name == "Cure Wounds"
     assert intent.target_id == "garrick"   # the downed ally, NOT the foe
 
 
 def test_pick_action_heals_critical_ally_under_one_third():
-    """An ally below 1/3 max HP (but not downed) is healed before attacking."""
+    """An ally below 1/3 max HP (but not downed) is healed before attacking (action-castable heal)."""
     atks = [AttackOption(name="Mace", to_hit=5, damage_expr="1d6+3")]
     v = _mk_view(atks, [_foe("goblin", hp=7, ac=12)],
                  allies=[_ally("hurt", hp=10, max_hp=40)],  # 25% < 1/3
-                 spells=[_heal()], caster_level=5)
+                 spells=[_cure()], caster_level=5)
     intent = combat_ai.pick_action(actor=object(), combat_state=v)
     assert intent.kind == "cast" and intent.target_id == "hurt"
 
@@ -202,13 +210,15 @@ def test_pick_action_prefers_downed_over_merely_wounded():
     v = _mk_view(atks, [_foe("goblin", hp=7, ac=12)],
                  allies=[_ally("wounded", hp=12, max_hp=40),  # < 1/2, not critical
                          _ally("down", hp=0, max_hp=40, downed=True)],
-                 spells=[_heal()], caster_level=5)
+                 spells=[_cure()], caster_level=5)
     intent = combat_ai.pick_action(actor=object(), combat_state=v)
     assert intent.kind == "cast" and intent.target_id == "down"
 
 
-def test_pick_action_prefers_bonus_action_healing_word_over_touch_cure_wounds():
-    """With both a bonus-action ranged heal and a touch heal available, prefer Healing Word."""
+def test_pick_action_main_heal_skips_bonus_only_healing_word_uses_cure_wounds():
+    """#1106: the MAIN-action heal-triage must NOT select a bonus-action-only spell (Healing Word) —
+    that's the bonus channel's job. With both a bonus Healing Word and a touch Cure Wounds available,
+    pick_action (the ACTION) casts Cure Wounds. (The bonus channel separately fires Healing Word.)"""
     atks = [AttackOption(name="Mace", to_hit=5, damage_expr="1d6+3")]
     v = _mk_view(atks, [_foe("goblin", hp=7, ac=12)],
                  allies=[_ally("down", hp=0, max_hp=40, downed=True)],
@@ -217,7 +227,60 @@ def test_pick_action_prefers_bonus_action_healing_word_over_touch_cure_wounds():
                      _heal("Healing Word", amount=6.0, rng=60, slot=1, bonus=True),
                  ], caster_level=5)
     intent = combat_ai.pick_action(actor=object(), combat_state=v)
-    assert intent.kind == "cast" and intent.spell_name == "Healing Word"
+    assert intent.kind == "cast" and intent.spell_name == "Cure Wounds"
+
+
+def test_pick_bonus_action_prefers_bonus_action_healing_word():
+    """The BONUS channel is where the bonus-action ranged heal (Healing Word) lives: pick_bonus_action
+    fires Healing Word on a downed ally (the v2.0a triage restricted to bonus-action heals)."""
+    atks = [AttackOption(name="Mace", to_hit=5, damage_expr="1d6+3")]
+    v = _mk_view(atks, [_foe("goblin", hp=7, ac=12)],
+                 allies=[_ally("down", hp=0, max_hp=40, downed=True)],
+                 spells=[
+                     _heal("Cure Wounds", amount=8.0, rng=5, slot=1, bonus=False),
+                     _heal("Healing Word", amount=6.0, rng=60, slot=1, bonus=True),
+                 ], caster_level=5)
+    bonus = combat_ai.pick_bonus_action(object(), v)
+    assert bonus is not None and bonus.kind == "cast" and bonus.spell_name == "Healing Word"
+
+
+def test_pick_action_with_bonus_spell_used_does_not_cast_a_leveled_spell():
+    """#1106 UNIT: when a LEVELED bonus-action spell was already cast this turn (bonus_spell_used=True),
+    pick_action's ACTION may NOT be a leveled cast — neither a leveled heal nor a leveled offensive
+    spell. It falls through to a CANTRIP or a weapon attack (RAW: a cantrip action may follow a bonus
+    spell)."""
+    atks = [AttackOption(name="Mace", to_hit=5, damage_expr="1d6+3")]
+    # A leveled heal (Cure Wounds) AND a leveled offensive spell (Magic Missile) are both on offer, plus
+    # a downed ally + a foe — yet with bonus_spell_used the action can cast NEITHER leveled spell.
+    v = _mk_view(atks, [_foe("goblin", hp=30, ac=12)],
+                 allies=[_ally("down", hp=0, max_hp=40, downed=True)],
+                 spells=[
+                     _heal("Cure Wounds", amount=8.0, rng=5, slot=1, bonus=False),
+                     SpellOption(name="Magic Missile", value=10.0, kind="auto",
+                                 range_ft=120, slot_level=1),
+                 ], caster_level=5, bonus_spell_used=True)
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    # No leveled `cast` — only a cantrip cast or a weapon attack is allowed.
+    assert not (intent.kind == "cast" and intent.spell_name in ("Cure Wounds", "Magic Missile"))
+    assert intent.kind in ("attack", "cast")
+    if intent.kind == "cast":
+        # any cast that slipped through MUST be a cantrip (slot_level 0)
+        sp = next(s for s in v.spells if s.name == intent.spell_name)
+        assert sp.slot_level == 0
+
+
+def test_pick_action_with_bonus_spell_used_still_allows_a_cantrip():
+    """#1106: a cantrip action MAY follow a leveled bonus spell (RAW). With bonus_spell_used=True and an
+    attack cantrip that out-EVs the weapon, pick_action still casts the CANTRIP (slot_level 0)."""
+    weak = AttackOption(name="Dagger", to_hit=2, damage_expr="1d4")
+    v = _mk_view([weak], [_foe("ogre", hp=60, ac=11)],
+                 spells=[SpellOption(name="Fire Bolt", value=11.0, kind="attack",
+                                     range_ft=120, requires_slot=False, slot_level=0)],
+                 caster_level=5, bonus_spell_used=True)
+    from dataclasses import replace
+    v = replace(v, spell_attack_bonus=7)
+    intent = combat_ai.pick_action(actor=object(), combat_state=v)
+    assert intent.kind == "cast" and intent.spell_name == "Fire Bolt"  # cantrip OK after a bonus spell
 
 
 def test_pick_action_does_not_heal_healthy_allies():
@@ -583,7 +646,9 @@ def test_ai_itself_heals_a_downed_ally_through_the_loop(tmp_path, monkeypatch):
 
     intent = combat_ai.pick_action(c.characters[cleric], view)
     assert intent.kind == "cast" and intent.target_id == fighter
-    assert intent.spell_name == "Healing Word"   # bonus-action ranged save preferred
+    # #1106: the MAIN-action heal-triage uses the ACTION-castable heal (Cure Wounds), NOT the bonus-
+    # action-only Healing Word (which is the bonus channel's job — see run_combat_round below).
+    assert intent.spell_name == "Cure Wounds"
 
     entry = combat_loop._apply_intent(server, cid, cleric, intent)
     after = server._require(cid).characters[fighter]
@@ -591,6 +656,78 @@ def test_ai_itself_heals_a_downed_ally_through_the_loop(tmp_path, monkeypatch):
     assert entry["result"]["heal"]["revived"] is True
     # The heal went through the locked verbs (slot spent by cast_spell, HP by apply_healing).
     assert server._require(cid).characters[cleric].spell_slots[1].used >= 1
+
+
+def test_no_double_healing_word_in_one_turn_through_the_loop(tmp_path, monkeypatch):
+    """#1106 REGRESSION GAUGE (the bug a capstone demo caught): a War/Life cleric with a DOWNED ally,
+    driven through run_combat_round, must cast Healing Word EXACTLY ONCE that turn — not twice. Before
+    the fix the cleric cast Healing Word as the BONUS action (pick_bonus_action) AND again as the MAIN
+    action (pick_action heal-triage), spending TWO L1 slots. 5e RAW forbids two leveled spells in a
+    turn when one is a bonus-action spell. The fix threads bonus_spell_used through the loop so the
+    main action can only be a CANTRIP / weapon — so exactly ONE L1 slot is spent on the bonus heal."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    dice_mod.reseed_process_rng(7)
+    cid, cleric, fighter, mons = _seed_healer_fight(server, store)
+
+    # Down the fighter to 0 HP (dying), then pin the CLERIC's turn with a fresh action economy.
+    server.set_hp(cid, target_id=fighter, current_hp=0)
+    c = server._require(cid)
+    idx = next(i for i, cb in enumerate(c.combat.order) if cb.character_id == cleric)
+    c.combat.turn_index = idx
+    c.combat.action_used = False
+    c.combat.bonus_action_used = False
+    # Record the L1 slot usage BEFORE the cleric's turn so we measure the per-turn delta.
+    slots_before = c.characters[cleric].spell_slots[1].used
+    store.save_campaign(c)
+
+    # Run ONE round in TEST mode (auto-runs everyone). The cleric's turn fires its bonus + main action.
+    combat_loop.run_combat_round(cid, mode="test")
+
+    c = server._require(cid)
+    cleric_ch = c.characters[cleric]
+    slots_after = cleric_ch.spell_slots[1].used
+    # EXACTLY ONE L1 slot was spent this turn (the bonus Healing Word) — NOT two (the old double-heal).
+    assert slots_after - slots_before == 1, (
+        f"expected exactly ONE L1 slot spent (the single Healing Word), got "
+        f"{slots_after - slots_before} (used {slots_before}->{slots_after}) — the double-heal bug"
+    )
+
+
+def test_loop_marks_bonus_spell_used_and_main_action_is_not_a_leveled_heal(tmp_path, monkeypatch):
+    """#1106: the SAME repro, asserted at the digest level — the cleric's turn contains EXACTLY ONE
+    `cast Healing Word` (the bonus channel) and its MAIN action that turn is NOT a second leveled heal
+    (Healing Word / Cure Wounds). Proves the loop threaded the bonus-action-spell rule into pick_action."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+    dice_mod.reseed_process_rng(7)
+    cid, cleric, fighter, mons = _seed_healer_fight(server, store)
+
+    server.set_hp(cid, target_id=fighter, current_hp=0)
+    c = server._require(cid)
+    idx = next(i for i, cb in enumerate(c.combat.order) if cb.character_id == cleric)
+    c.combat.turn_index = idx
+    c.combat.action_used = False
+    c.combat.bonus_action_used = False
+    store.save_campaign(c)
+
+    rr = combat_loop.run_combat_round(cid, mode="test")
+    cleric_entries = [e for e in rr["round_digest"] if e.get("actor_id") == cleric]
+    casts = [e for e in cleric_entries
+             if e.get("kind") == "cast" and (e.get("result") or {}).get("spell")]
+    healing_word_casts = [e for e in casts
+                          if str((e.get("result") or {}).get("spell", "")).lower() == "healing word"]
+    # Exactly ONE Healing Word cast this turn (the bonus action) — never two.
+    assert len(healing_word_casts) == 1, (
+        f"expected exactly ONE Healing Word cast, got {len(healing_word_casts)}: {healing_word_casts}"
+    )
+    # No SECOND leveled heal cast as the action (Cure Wounds is the only other action-castable heal here).
+    leveled_heal_casts = [e for e in casts
+                          if str((e.get("result") or {}).get("spell", "")).lower()
+                          in ("healing word", "cure wounds")]
+    assert len(leveled_heal_casts) == 1, (
+        f"the cleric cast more than one leveled heal this turn (double-heal): {leveled_heal_casts}"
+    )
 
 
 def test_no_healable_ally_byte_identical_to_pre_pr_fight(tmp_path, monkeypatch):


### PR DESCRIPTION
## The bug (reproduced — a capstone demo caught it)

In ONE turn, a **War/Life cleric** (L5) with a downed ally cast **Healing Word TWICE**:
once as the BONUS action (`combat_ai.pick_bonus_action`, the v2.0c channel) AND again as
the MAIN action (`combat_ai.pick_action` heal-triage, the v2.0a path) — both via
`cast_spell`, spending **TWO L1 slots**.

This violates 5e RAW: (a) at most ONE bonus-action spell per turn; (b) if you cast a
bonus-action spell, your ACTION that turn may cast only a **cantrip** (casting time 1
action), never another leveled spell.

### Proven before → after (through `run_combat_round`, the real loop)

```
BEFORE (origin/main):
  cast  Healing Word   bonus-action heal Healing Word on Garrick (0/49 HP, DOWNED)
  cast  Healing Word   heal Garrick (5/49) with Healing Word (~6 HP, L1, bonus action)
  L1 spell-slot used : 0 -> 2   (delta this turn = 2)   ← THE BUG

AFTER (this PR):
  cast  Healing Word   bonus-action heal Healing Word on Garrick (0/49 HP, DOWNED)
  attack Weapon        best in-reach attack Weapon on Goblin (EV 3.0, P(hit) 50%)
  L1 spell-slot used : 0 -> 1   (delta this turn = 1)   ← Healing Word ONCE, then acts
```

## The fix (ADDITIVE — only changes which action the AI PICKS; no engine verb change)

| File | Change |
|---|---|
| `combat_ai.py` `CombatView` | + `bonus_spell_used: bool = False` (additive field). |
| `combat_loop.py` `run_combat_round` | After the per-turn bonus action, `_bonus_was_leveled_spell(...)` detects a slot-spending `cast` (Healing Word/Spiritual Weapon — a cantrip / Second Wind / Rage does NOT count). When true, `replace(view, bonus_spell_used=True)` is threaded onto every MAIN-action view that turn. |
| `combat_ai.py` `pick_action` | When `view.bonus_spell_used`: the heal-triage is skipped AND any **leveled** offensive cast is dropped — only a CANTRIP / weapon / move is allowed (a cantrip action MAY follow a bonus spell, per RAW). |
| `combat_ai.py` heal-triage (`_pick_heal`) | New `action_only=True` for the MAIN-action call: a **bonus-action-only** spell (Healing Word) is never a main-action candidate — only an **action-castable** heal (Cure Wounds). The bonus channel keeps Healing Word. |

**Net effect:** a cleric with a downed ally → bonus Healing Word (heals) + main action =
a weapon attack / cantrip (NOT a second heal). A cleric with only Cure Wounds + no bonus
heal → main-action Cure Wounds, no bonus heal.

## Invariants

- **ADDITIVE / byte-identical:** `bonus_spell_used` defaults False; a non-caster / a turn
  with no leveled bonus spell never sets it → the `replace` no-ops → view is byte-identical
  to today. The whole martial+caster byte-identity test set stays green.
- **Sole-writer preserved:** `server.py` is **untouched** — no new write path, no engine
  verb change. The loop still applies every mutation through the existing `cast_spell` /
  `attack` / `apply_healing` verbs.
- **No new MCP tool / params** (120 KB schema budget intact — `combat_loop` is a direct
  Python entry-point, never MCP-exposed).
- **`policy=` seam intact** (unchanged).
- **PURE:** `_bonus_was_leveled_spell` + the `_pick_heal` filter read only the Intent +
  the view's already-discovered `SpellOption`s — no state, no I/O, deterministic.

## Tests / validation

- `tests/test_combat_core.py` — updated the 5 tests that encoded the OLD double-heal
  behavior (main-action triage was asserting Healing Word; now asserts the action-castable
  Cure Wounds), moved the bonus-action-preference assertion to a `pick_bonus_action` test,
  and added:
  - `test_no_double_healing_word_in_one_turn_through_the_loop` — the regression gauge:
    exactly **1** L1 slot spent that turn (not 2).
  - `test_loop_marks_bonus_spell_used_and_main_action_is_not_a_leveled_heal` — digest-level:
    exactly one `cast Healing Word`, no second leveled heal.
  - `test_pick_action_with_bonus_spell_used_does_not_cast_a_leveled_spell` (unit) +
    `..._still_allows_a_cantrip` — a cantrip MAY follow a bonus spell.
- **Full engine suite + combat smoke: `3151 passed`** (`pytest tests/ ../../qa/test_combat_smoke.py -q -p no:xdist`).
- **Fast-gate T0: PASS** (241 deterministic). `qa/scores.db` not mutated.

Closes #1106 (epic #1100).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * AI now correctly enforces action economy rules during combat, preventing invalid spell combinations when multiple spells are cast in a single turn.

* **Tests**
  * Updated and expanded combat tests to validate spell-casting constraints and prevent unintended healing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->