### PR TITLE
feat(godot,#645): combat Action-Replay animation — attack/cast/damage/heal/death beats on the iso tiles

### DIFF
--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -154,6 +154,19 @@ jobs:
           # Five combatants -> five spawned tokens, each at its zone, foes tinted + allies neutral.
           grep -qE "\[CombatTokens\] RESULT ok=true count=5/5 all_zoned=true team_tinted=true \(foes=true allies=true\)" /tmp/combat.log
 
+      - name: Conformance — combat Action-Replay animates each beat (#645)
+        run: |
+          set -euxo pipefail
+          # Spawn the ACTIVE combat roster, then play the COMBAT beats from
+          # fixtures/events.json (the #645 Action-Replay envelope: attack/cast/damage/
+          # heal/condition/death/move_to_zone) through the SAME enqueue_replay the live
+          # /events poll uses, and assert the ENGINE-DECIDED beats were SHOWN: the death
+          # beat freed the dying token, a heal raised the target HP bar to the engine's
+          # 16/22, the attacker faced its target (renderer-derived facing), queue drained.
+          # 1200 frames (~20s headless) covers the boot-drain settle + the ~4.4s exchange.
+          godot --headless --path godot --quit-after 1200 -- --combat-replay 2>&1 | tee /tmp/replay.log
+          grep -qE "\[CombatReplay\] RESULT ok=true death-freed=true heal-hp-raised=true attack-faced=true drained=true" /tmp/replay.log
+
       - name: Export validation — Web (single-threaded) + Linux
         working-directory: godot
         run: |
@@ -174,8 +187,12 @@ jobs:
           mkdir -p ci-artifacts
           cp /tmp/wos_godot_occlusion_*.png ci-artifacts/ 2>/dev/null || true
           grep -E "\[DEMO\] occlusion" /tmp/demo.log || echo "demo: no occlusion line (software-GL may be unavailable on the runner)"
+          # #645 — a combat Action-Replay beat animating on the iso tiles (best-effort).
+          xvfb-run -a -s "-screen 0 1280x720x24" godot --path godot --demo-combat --quit-after 1200 2>&1 | tee /tmp/demo_combat.log || true
+          cp /tmp/wos_godot_combat_replay.png ci-artifacts/ 2>/dev/null || true
+          grep -E "\[DemoCombat\] screenshot" /tmp/demo_combat.log || echo "demo-combat: no screenshot line (software-GL may be unavailable on the runner)"
 
-      - name: Upload occlusion screenshots
+      - name: Upload occlusion + combat-replay screenshots
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/godot/fixtures/events.json
+++ b/godot/fixtures/events.json
@@ -1,14 +1,105 @@
 {
-  "_comment": "Fixture mirroring the REAL /events response (viewer/server.py /events route): {entries, next, sid}. Each entry is a {kind, text, label?, seq?, sid?} record. One harmless narration row so listeners get a shaped payload standalone.",
+  "_comment": "Fixture mirroring the REAL /events response (viewer/server.py /events route): {entries, next, sid}. Entry 0 is a harmless narration row (the #1055 exploration smoke). Entries 1..N are an Action-Replay COMBAT sequence in the #645 envelope shape {seq, actor_fk, verb, target_fk, result, anim_hint} (docs/roadmap/contracts/action-replay-envelope.md) referencing the actor ids in combat-surface-active.json. Driven by Main.gd's --combat-replay mode (which first spawns the combat roster from the active combat snapshot, then plays these beats). In a plain exploration boot only on-stage actors animate; off-stage combatants are accept-and-ignored (no crash), and the narrate verb is accept-and-ignored too.",
   "entries": [
     {
       "kind": "narration",
+      "verb": "narrate",
       "label": "DM",
       "text": "The Lower City breathes around you — gulls wheel over the harbor, and the gate guards wave the party through.",
       "seq": 0,
       "sid": "fixture-session"
+    },
+    {
+      "seq": 1,
+      "actor_fk": "char-aubree",
+      "verb": "move_to_zone",
+      "target_fk": "the market row",
+      "result": { "outcome": "moved", "zone": "the market row" },
+      "anim_hint": "zone_move",
+      "sid": "fixture-session"
+    },
+    {
+      "seq": 2,
+      "actor_fk": "char-aubree",
+      "verb": "attack",
+      "target_fk": "npc-cultist-1",
+      "result": { "outcome": "hit", "roll": { "d20": 17, "total": 21 } },
+      "anim_hint": "melee_swing",
+      "sid": "fixture-session"
+    },
+    {
+      "seq": 3,
+      "actor_fk": "char-aubree",
+      "verb": "damage",
+      "target_fk": "npc-cultist-1",
+      "result": { "outcome": "hit", "damage": { "total": 8, "type": "slashing" }, "hp_after": 6, "hp_max": 14 },
+      "anim_hint": "damage_flinch",
+      "sid": "fixture-session"
+    },
+    {
+      "seq": 4,
+      "actor_fk": "npc-cultist-1",
+      "verb": "condition",
+      "target_fk": "npc-cultist-1",
+      "result": { "outcome": "bloodied", "hp_after": 6, "hp_max": 14 },
+      "anim_hint": "status_apply",
+      "sid": "fixture-session"
+    },
+    {
+      "seq": 5,
+      "actor_fk": "npc-ogre-1",
+      "verb": "attack",
+      "target_fk": "char-companion-1",
+      "result": { "outcome": "hit", "roll": { "d20": 14, "total": 19 } },
+      "anim_hint": "melee_swing",
+      "sid": "fixture-session"
+    },
+    {
+      "seq": 6,
+      "actor_fk": "npc-ogre-1",
+      "verb": "damage",
+      "target_fk": "char-companion-1",
+      "result": { "outcome": "hit", "damage": { "total": 11, "type": "bludgeoning" }, "hp_after": 7, "hp_max": 22 },
+      "anim_hint": "damage_flinch",
+      "sid": "fixture-session"
+    },
+    {
+      "seq": 7,
+      "actor_fk": "char-companion-1",
+      "verb": "cast",
+      "target_fk": "char-companion-1",
+      "result": { "outcome": "heal", "amount": 9, "hp_after": 16, "hp_max": 22 },
+      "anim_hint": "heal_pulse",
+      "sid": "fixture-session"
+    },
+    {
+      "seq": 8,
+      "actor_fk": "char-aubree",
+      "verb": "attack",
+      "target_fk": "npc-cultist-1",
+      "result": { "outcome": "hit", "roll": { "d20": 19, "total": 23 } },
+      "anim_hint": "melee_swing",
+      "sid": "fixture-session"
+    },
+    {
+      "seq": 9,
+      "actor_fk": "char-aubree",
+      "verb": "damage",
+      "target_fk": "npc-cultist-1",
+      "result": { "outcome": "hit", "damage": { "total": 7, "type": "slashing" }, "hp_after": 0, "hp_max": 14 },
+      "anim_hint": "damage_flinch",
+      "sid": "fixture-session"
+    },
+    {
+      "seq": 10,
+      "actor_fk": "npc-cultist-1",
+      "verb": "death",
+      "target_fk": "npc-cultist-1",
+      "result": { "outcome": "dead", "hp_after": 0 },
+      "anim_hint": "death_fall",
+      "sid": "fixture-session"
     }
   ],
-  "next": 1,
+  "next": 11,
   "sid": "fixture-session"
 }

--- a/godot/scenes/CharacterToken.gd
+++ b/godot/scenes/CharacterToken.gd
@@ -25,6 +25,28 @@ const PROJECTION_LOCK := "dimetric-2to1"
 ## How long set_zone_target's position tween runs (seconds). #1055 may override.
 const MOVE_TWEEN_SEC := 0.45
 
+## #1060 combat Action-Replay timings (deterministic + FRAME-BOUNDED — no unbounded
+## tweens; every beat resolves inside a known wall-clock so the replay queue always
+## drains). Kept short so a multi-beat exchange reads as one brisk animated turn.
+const ATTACK_ANIM_SEC := 0.5    ## attack/cast clip dwell before returning to idle
+const FLASH_SEC := 0.3          ## damage red / condition flash (each direction)
+const HEAL_PULSE_SEC := 0.35    ## heal green/gold pulse (each direction)
+const DEATH_FADE_SEC := 0.5     ## death fade-to-transparent before queue_free
+
+## #1060 — renderer-owned flash/pulse modulate targets (pure presentation; the engine
+## ships only the resolved beat, the renderer chooses the color cue).
+const DAMAGE_FLASH_COLOR := Color(1.0, 0.25, 0.2, 1.0)     ## hostile red wash on a hit
+const HEAL_PULSE_COLOR := Color(0.5, 1.0, 0.6, 1.0)        ## restorative green/gold pulse
+const CONDITION_FLASH_COLOR := Color(0.82, 0.7, 1.0, 1.0)  ## arcane violet status flash
+
+## #1060 — HP bar geometry (a slim renderer-owned overlay above the head). Only shown
+## when the engine surfaces hp/hpMax on a beat; otherwise the token has no bar.
+const HP_BAR_W := 44.0
+const HP_BAR_H := 5.0
+const HP_BAR_BG := Color(0.06, 0.06, 0.08, 0.85)
+const HP_BAR_FILL := Color(0.4, 0.85, 0.45, 0.95)
+const HP_BAR_LOW := Color(0.9, 0.4, 0.35, 0.95)  ## fill turns red when wounded (<35%)
+
 ## The engine actor this token stands for (e.g. "char-aubree"). Exposed for #1055
 ## inspect-click selection + reconcile-by-id in WorldView.
 var engine_actor_id: String = ""
@@ -44,6 +66,15 @@ var _frames: SpriteFrames
 var _picker: Area2D
 var _picker_shape: CollisionShape2D
 var _move_tween: Tween
+## #1060 — combat-beat tweens/timers, tracked so a new beat cancels the prior one
+## cleanly (a beat is frame-bounded: it never leaves the sprite mid-flash forever).
+var _fx_tween: Tween
+var _anim_timer: SceneTreeTimer
+## #1060 — true once death has been applied (so a stray later beat can't re-show it).
+var _dead: bool = false
+## #1060 — the slim HP bar (built lazily the first time HP is surfaced on a beat).
+var _hp_bar: Node2D = null
+var _hp_frac: float = -1.0  ## 0..1 when known; <0 == no bar drawn yet
 
 
 func _ready() -> void:
@@ -233,6 +264,114 @@ func set_zone_target(world_pos: Vector2) -> void:
 
 
 # ---------------------------------------------------------------------------
+# #1060 — combat Action-Replay beat presentation. Each returns the beat's bounded
+# duration (seconds) so WorldView's replay queue can serialize beats deterministically
+# (it waits the returned duration before playing the next beat). All effects are
+# RENDERER-OWNED presentation — none touch game state; the engine ships the resolved
+# beat and the token only chooses how to SHOW it. A dead token ignores further beats.
+# ---------------------------------------------------------------------------
+
+## True once death has been applied (a freed/dying token plays no more beats).
+func is_dead() -> bool:
+	return _dead
+
+## Play a one-shot clip (attack/cast), then auto-return to idle after ATTACK_ANIM_SEC.
+## Non-looping clips (attack/cast in the manifest) hold their last frame; the timer
+## restores idle so the token never freezes mid-swing. Returns the bounded duration.
+func play_oneshot(clip_name: String) -> float:
+	if _dead:
+		return 0.0
+	set_anim(clip_name)
+	_arm_idle_return(ATTACK_ANIM_SEC)
+	return ATTACK_ANIM_SEC
+
+## Flash the sprite toward `color` then tween back to the team tint. Used for the
+## damage red flash + the condition status flash. Returns the bounded duration.
+func flash(color: Color, dur: float = FLASH_SEC) -> float:
+	if _dead:
+		return 0.0
+	_start_fx_tween()
+	_sprite.modulate = color
+	_fx_tween.tween_property(_sprite, "modulate", _team_tint, dur)
+	return dur
+
+## A heal pulse: tween UP to the heal color then back to the team tint (so it reads as
+## a restorative glow, not a hit flash). Returns the bounded duration.
+func heal_pulse() -> float:
+	if _dead:
+		return 0.0
+	_start_fx_tween()
+	_fx_tween.tween_property(_sprite, "modulate", HEAL_PULSE_COLOR, HEAL_PULSE_SEC)
+	_fx_tween.tween_property(_sprite, "modulate", _team_tint, HEAL_PULSE_SEC)
+	return HEAL_PULSE_SEC * 2.0
+
+## Set the renderer-owned HP bar to `frac` in [0,1] (clamped). Builds the bar lazily on
+## first call. A no-op-equivalent when frac is unknown (caller passes <0). The bar is
+## pure presentation — it shows the engine-decided hp/hpMax, never recomputes it.
+func set_hp_fraction(frac: float) -> void:
+	if frac < 0.0:
+		return
+	_hp_frac = clampf(frac, 0.0, 1.0)
+	_ensure_hp_bar()
+	if _hp_bar != null:
+		_hp_bar.queue_redraw()
+
+## The HP fraction last surfaced (0..1), or <0 if no HP has been shown yet. For validation.
+func hp_fraction() -> float:
+	return _hp_frac
+
+## Fade the sprite to transparent over DEATH_FADE_SEC, then queue_free the whole token
+## (so a dead combatant leaves the stage). Marks the token dead so no later beat shows
+## it. Returns the bounded duration; the token frees itself when the fade completes.
+func fade_out_and_free() -> float:
+	if _dead:
+		return 0.0
+	_dead = true
+	_cancel_anim_timer()
+	_start_fx_tween()
+	_fx_tween.tween_property(_sprite, "modulate:a", 0.0, DEATH_FADE_SEC)
+	_fx_tween.tween_callback(queue_free)
+	return DEATH_FADE_SEC
+
+
+# --- combat-fx internals ----------------------------------------------------
+
+## (Re)create the single fx tween, killing any prior one so beats never stack.
+func _start_fx_tween() -> void:
+	if _fx_tween != null and _fx_tween.is_valid():
+		_fx_tween.kill()
+	# Restore a clean modulate baseline before the new effect so a cancelled flash
+	# can't leave the sprite stuck on a transient color.
+	if _sprite != null:
+		_sprite.modulate = _team_tint
+	_fx_tween = create_tween()
+
+## Arm a one-shot timer to return to idle after `sec`, cancelling any prior one.
+func _arm_idle_return(sec: float) -> void:
+	_cancel_anim_timer()
+	_anim_timer = get_tree().create_timer(sec)
+	_anim_timer.timeout.connect(func():
+		if is_instance_valid(self) and not _dead:
+			set_anim("idle"))
+
+func _cancel_anim_timer() -> void:
+	# SceneTreeTimers can't be cancelled directly; we just drop our reference and the
+	# guarded callback (is_instance_valid + not _dead) makes a stale fire harmless.
+	_anim_timer = null
+
+## Build the slim HP bar above the head once (a _draw()-based Node2D child).
+func _ensure_hp_bar() -> void:
+	if _hp_bar != null and is_instance_valid(_hp_bar):
+		return
+	_hp_bar = _HpBar.new()
+	_hp_bar.name = "HpBar"
+	_hp_bar.token = self
+	# Sit above the head: the cell top is at -_anchor.y from the foot origin.
+	_hp_bar.position = Vector2(0.0, -_anchor.y - 10.0)
+	add_child(_hp_bar)
+
+
+# ---------------------------------------------------------------------------
 # Inspect-click picker (#1055). Size the Area2D's shape to the body cell so a click
 # anywhere on the token selects it. No input is handled here yet.
 # ---------------------------------------------------------------------------
@@ -256,3 +395,27 @@ func _resize_picker() -> void:
 	# Center the shape over the body: the node origin is at the feet (anchor), so
 	# the cell center is at (-anchor + cell/2) relative to origin.
 	_picker_shape.position = Vector2(-_anchor.x + w * 0.5, -_anchor.y + h * 0.5)
+
+
+# ---------------------------------------------------------------------------
+# #1060 — the slim renderer-owned HP bar (a _draw()-based child centered above the
+# head). It reads the parent token's _hp_frac (engine-decided hp/hpMax); it computes
+# nothing. Drawn centered on the token's screen-x so it tracks the body.
+# ---------------------------------------------------------------------------
+class _HpBar extends Node2D:
+	var token: CharacterToken = null
+
+	func _draw() -> void:
+		if token == null:
+			return
+		var frac: float = token._hp_frac
+		if frac < 0.0:
+			return
+		var w := CharacterToken.HP_BAR_W
+		var h := CharacterToken.HP_BAR_H
+		var x0 := -w * 0.5
+		# Background track.
+		draw_rect(Rect2(x0, 0.0, w, h), CharacterToken.HP_BAR_BG, true)
+		# Filled portion (red when wounded, green otherwise).
+		var fill_col := CharacterToken.HP_BAR_LOW if frac < 0.35 else CharacterToken.HP_BAR_FILL
+		draw_rect(Rect2(x0, 0.0, w * frac, h), fill_col, true)

--- a/godot/scenes/FxLayer.gd
+++ b/godot/scenes/FxLayer.gd
@@ -23,6 +23,15 @@ const PING_END_RADIUS := 30.0
 const PING_COLOR := Color(0.78, 0.90, 1.0, 0.85)
 const PING_WIDTH := 3.0
 
+## #1060 — floating combat number (damage/heal) look + timing. A label that rises a
+## short distance and fades out, then frees itself (no leaks). RENDERER-OWNED
+## presentation of the engine-decided number — it shows it, never recomputes it.
+const FLOAT_DURATION_SEC := 0.7
+const FLOAT_RISE_PX := 34.0
+const FLOAT_FONT_SIZE := 22
+const FLOAT_DAMAGE_COLOR := Color(1.0, 0.5, 0.42, 1.0)  ## red-orange for damage
+const FLOAT_HEAL_COLOR := Color(0.55, 1.0, 0.62, 1.0)   ## green for heals
+
 
 func _ready() -> void:
 	z_index = FX_Z_INDEX
@@ -39,6 +48,19 @@ func ping(world_pos: Vector2) -> Node2D:
 	add_child(p)
 	p.animate()
 	return p
+
+
+## #1060 — float a combat number (e.g. "8" damage, "+7" heal) up from `world_pos`. The
+## label rises FLOAT_RISE_PX while fading, then frees itself. `is_heal` picks the green
+## heal color (else the red damage color). Returns the spawned node (for validation).
+func float_number(world_pos: Vector2, text: String, is_heal: bool = false) -> Node2D:
+	var f := _FloatNumber.new()
+	f.position = world_pos
+	f.text = text
+	f.color = FLOAT_HEAL_COLOR if is_heal else FLOAT_DAMAGE_COLOR
+	add_child(f)
+	f.animate()
+	return f
 
 
 # ---------------------------------------------------------------------------
@@ -66,3 +88,34 @@ class _Ping extends Node2D:
 	func _set_progress(v: float) -> void:
 		_t = v
 		queue_redraw()
+
+
+# ---------------------------------------------------------------------------
+# #1060 — the transient floating combat number. A Label that rises and fades, then
+# frees itself. Pure presentation of an engine-decided value (damage/heal amount).
+# ---------------------------------------------------------------------------
+class _FloatNumber extends Node2D:
+	var text: String = ""
+	var color: Color = Color.WHITE
+	var _label: Label = null
+	var _base_y: float = 0.0
+
+	func _ready() -> void:
+		_base_y = position.y
+		_label = Label.new()
+		_label.text = text
+		_label.add_theme_color_override("font_color", color)
+		_label.add_theme_font_size_override("font_size", FxLayer.FLOAT_FONT_SIZE)
+		# Center the text roughly over the anchor point.
+		_label.position = Vector2(-18.0, -FxLayer.FLOAT_FONT_SIZE)
+		add_child(_label)
+
+	func animate() -> void:
+		var tween := create_tween()
+		tween.set_parallel(true)
+		# Rise.
+		tween.tween_property(self, "position:y", _base_y - FxLayer.FLOAT_RISE_PX, FxLayer.FLOAT_DURATION_SEC)
+		# Fade (modulate alpha on the whole node).
+		tween.tween_property(self, "modulate:a", 0.0, FxLayer.FLOAT_DURATION_SEC)
+		# Free after the (parallel) effects finish.
+		tween.chain().tween_callback(queue_free)

--- a/godot/scenes/Main.gd
+++ b/godot/scenes/Main.gd
@@ -99,6 +99,12 @@ func _on_snapshot(atlas: Dictionary, _combat: Dictionary, character: Dictionary)
 		if _has_arg("--combat-tokens"):
 			call_deferred("_run_combat_tokens")
 			return
+		if _has_arg("--combat-replay"):
+			call_deferred("_run_combat_replay")
+			return
+		if _has_arg("--demo-combat"):
+			call_deferred("_run_demo_combat")
+			return
 		if _has_arg("--demo-occlusion"):
 			call_deferred("_run_demo_occlusion")
 			return
@@ -288,6 +294,178 @@ func _run_combat_tokens() -> void:
 		str(all_ok), spawned, expected, str(all_zoned), str(all_tinted), str(foe_seen), str(ally_seen)])
 
 	call_deferred("_quit_clean")
+
+
+# ---------------------------------------------------------------------------
+# #1060 COMBAT-REPLAY: prove the Action-Replay envelope ANIMATES on the iso tiles.
+# Spawns the ACTIVE combat roster (so every actor/target_fk is on stage), then feeds
+# the COMBAT beats from fixtures/events.json (the envelope shape) into the SAME
+# enqueue_replay entry point the live /events poll uses, and awaits the serial drain.
+# Asserts the ENGINE-DECIDED outcomes were SHOWN (not recomputed):
+#   - attack/cast played + the actor faced its target (renderer-derived facing),
+#   - damage flashed + the target HP bar dropped to the engine's hp_after/hp_max,
+#   - a heal pulsed + raised the target's HP bar,
+#   - the death beat faded + FREED the dying token (it left the stage).
+# Deterministic + headless (no window). Quits cleanly.
+# ---------------------------------------------------------------------------
+func _run_combat_replay() -> void:
+	print("[Main] --combat-replay: animating the Action-Replay envelope on the iso tiles")
+
+	# Detach the steady FIXTURE auto-poll so it can't (a) re-apply the exploration
+	# (active:false) snapshot and reconcile away the spawned combat roster, or (b)
+	# double-feed events.json into the replay queue. We drive the surfaces + beats
+	# DELIBERATELY below. (The live path never does this — this is a conformance harness.)
+	_detach_live_feed()
+
+	# The standalone FIXTURE boot-poll may already be draining events.json against the
+	# (pre-roster) exploration stage. Let that in-flight drain FULLY finish, then RESET
+	# the replay cursor — BEFORE we spawn the roster — so no stale boot-drain beat (e.g.
+	# the seq-10 death) can touch a freshly-spawned token.
+	var settle := 0.0
+	while bool(_world.is_replaying()) and settle < 6.0:
+		await get_tree().create_timer(0.1).timeout
+		settle += 0.1
+	_world.reset_replay()
+
+	# (1) Spawn the roster from the ACTIVE combat snapshot (same path as --combat-tokens).
+	var combat: Dictionary = _load_fixture_dict("combat-surface-active")
+	var atlas: Dictionary = _load_fixture_dict("atlas-surface")
+	var character: Dictionary = _load_fixture_dict("character-surface")
+	if combat.is_empty():
+		print("[CombatReplay] RESULT ok=false reason=missing-active-fixture")
+		call_deferred("_quit_clean")
+		return
+	_world.apply_snapshot(atlas, combat, character)
+	await get_tree().create_timer(CharacterToken.MOVE_TWEEN_SEC + 0.1).timeout
+
+	# Capture pre-replay facts on the actors the beats touch.
+	var cultist: CharacterToken = _world.token_for("npc-cultist-1")
+	var companion: CharacterToken = _world.token_for("char-companion-1")
+	var aubree: CharacterToken = _world.token_for("char-aubree")
+	var roster_ok := cultist != null and companion != null and aubree != null
+	print("[CombatReplay] roster cultist=%s companion=%s aubree=%s" % [
+		str(cultist != null), str(companion != null), str(aubree != null)])
+
+	# (2) Load the COMBAT beats from events.json (skip the narrate row) and play them
+	# through the real enqueue_replay → serial drain.
+	var beats := _load_combat_event_beats()
+	print("[CombatReplay] beats=%d (combat verbs from events.json)" % beats.size())
+	_world.enqueue_replay(beats)
+
+	# (3) Await the serial drain. Bound generously: the queue length * the longest beat
+	# (heal pulse is 2*0.35 + the move 0.45 + attack 0.5 ...) — ~6s ceiling is ample.
+	var waited := 0.0
+	while bool(_world.is_replaying()) and waited < 8.0:
+		await get_tree().create_timer(0.1).timeout
+		waited += 0.1
+
+	# (4) Assertions — the engine-decided beats were SHOWN.
+	# (a) the dying cultist token was freed (left the stage) by the death beat.
+	var cultist_freed := not is_instance_valid(cultist)
+	# (b) the healed companion's HP bar rose to the engine's 16/22 (~0.727).
+	var companion_hp := companion.hp_fraction() if is_instance_valid(companion) else -1.0
+	var companion_hp_ok := absf(companion_hp - (16.0 / 22.0)) < 0.02
+	# (c) aubree faced her target during the attack exchange (a real 8-way facing).
+	var aubree_facing := aubree.facing() if is_instance_valid(aubree) else "?"
+	var aubree_facing_ok := aubree_facing in ["S", "SE", "E", "NE", "N", "NW", "W", "SW"]
+	# (d) the replay queue fully drained (no beats left stuck).
+	var drained: bool = not bool(_world.is_replaying())
+
+	print("[CombatReplay] cultist_freed=%s companion_hp=%.3f (ok=%s) aubree_facing=%s drained=%s waited=%.1fs" % [
+		str(cultist_freed), companion_hp, str(companion_hp_ok), aubree_facing, str(drained), waited])
+
+	var all_ok := roster_ok and cultist_freed and companion_hp_ok and aubree_facing_ok and drained
+	print("[CombatReplay] RESULT ok=%s death-freed=%s heal-hp-raised=%s attack-faced=%s drained=%s" % [
+		str(all_ok), str(cultist_freed), str(companion_hp_ok), str(aubree_facing_ok), str(drained)])
+
+	call_deferred("_quit_clean")
+
+
+## #1060 — the COMBAT beats from fixtures/events.json (the envelope rows; the leading
+## `narrate`/exploration rows are skipped). Returns the entries that carry a combat verb,
+## so _run_combat_replay drives the exact same shape the live /events poll would.
+func _load_combat_event_beats() -> Array:
+	var fx: Dictionary = _load_fixture_dict("events")
+	var entries: Variant = fx.get("entries", [])
+	if typeof(entries) != TYPE_ARRAY:
+		return []
+	var combat_verbs := ["attack", "cast", "damage", "heal", "condition", "death", "move_to_zone", "zone_move"]
+	var out: Array = []
+	for e in entries:
+		if typeof(e) != TYPE_DICTIONARY:
+			continue
+		var verb := String((e as Dictionary).get("verb", (e as Dictionary).get("kind", "")))
+		if combat_verbs.has(verb):
+			out.append(e)
+	return out
+
+
+# ---------------------------------------------------------------------------
+# #1060 DEMO-COMBAT: the VISUAL combat-beat proof. Run WITHOUT --headless (a real
+# window) so rendering is real. Spawns the combat roster, plays a couple of beats
+# (an attack swing + a damage flash/float on a foe), settles a frame, and screenshots
+# the animating beat to /tmp so a reviewer can SEE the action-replay on the iso tiles.
+# ---------------------------------------------------------------------------
+func _run_demo_combat() -> void:
+	print("[Main] --demo-combat: visual combat Action-Replay screenshot")
+	var combat: Dictionary = _load_fixture_dict("combat-surface-active")
+	var atlas: Dictionary = _load_fixture_dict("atlas-surface")
+	var character: Dictionary = _load_fixture_dict("character-surface")
+	if combat.is_empty():
+		print("[DemoCombat] cannot run — missing active combat fixture")
+		call_deferred("_quit_clean")
+		return
+	# Detach the steady auto-poll (see _run_combat_replay), let any in-flight boot-poll
+	# replay finish, and reset — BEFORE spawning the roster — so no stale beat touches it.
+	_detach_live_feed()
+	var settle := 0.0
+	while bool(_world.is_replaying()) and settle < 6.0:
+		await get_tree().create_timer(0.1).timeout
+		settle += 0.1
+	_world.reset_replay()
+	_world.apply_snapshot(atlas, combat, character)
+	await get_tree().create_timer(CharacterToken.MOVE_TWEEN_SEC + 0.1).timeout
+
+	# Play a mid-exchange beat pair so the screenshot catches motion: aubree swings at a
+	# cultist, the cultist flashes + a damage number floats.
+	var beats: Array = [
+		{ "seq": 100, "actor_fk": "char-aubree", "verb": "attack", "target_fk": "npc-cultist-1",
+		  "result": { "outcome": "hit" }, "anim_hint": "melee_swing" },
+		{ "seq": 101, "actor_fk": "char-aubree", "verb": "damage", "target_fk": "npc-cultist-1",
+		  "result": { "damage": { "total": 8 }, "hp_after": 6, "hp_max": 14 }, "anim_hint": "damage_flinch" },
+	]
+	_world.enqueue_replay(beats)
+
+	# Let the attack swing + the damage flash play, then capture mid-beat.
+	await _settle_frames(3)
+	await get_tree().create_timer(0.25).timeout
+	await _settle_frames(2)
+	var img := _capture_viewport()
+	if img != null:
+		img.save_png("/tmp/wos_godot_combat_replay.png")
+		print("[DemoCombat] screenshot: /tmp/wos_godot_combat_replay.png (%dx%d)" % [img.get_width(), img.get_height()])
+	else:
+		print("[DemoCombat] no image captured (headless?) — run WITHOUT --headless for a real frame")
+
+	# Let the rest of the beats drain before quitting.
+	var waited := 0.0
+	while bool(_world.is_replaying()) and waited < 4.0:
+		await get_tree().create_timer(0.1).timeout
+		waited += 0.1
+	print("[DemoCombat] done drained=%s" % str(not bool(_world.is_replaying())))
+	call_deferred("_quit_clean")
+
+
+## #1060 — detach the steady SurfaceClient auto-poll from WorldView so a deliberate
+## conformance/visual harness can drive apply_snapshot + enqueue_replay itself without
+## the FIXTURE poll re-applying the (active:false) exploration snapshot mid-replay
+## (which would reconcile away the spawned combat roster). Disconnects the two WorldView
+## sinks; Hud + the SMOKE print stay wired (harmless). Idempotent. NOT a live-path action.
+func _detach_live_feed() -> void:
+	if SurfaceClient.snapshot_updated.is_connected(_world.apply_snapshot):
+		SurfaceClient.snapshot_updated.disconnect(_world.apply_snapshot)
+	if SurfaceClient.events_appended.is_connected(_world.enqueue_replay):
+		SurfaceClient.events_appended.disconnect(_world.enqueue_replay)
 
 
 ## #1060 — load + parse a bundled res://fixtures/<name>.json into a Dictionary (or {}

--- a/godot/scenes/WorldView.gd
+++ b/godot/scenes/WorldView.gd
@@ -129,6 +129,20 @@ var _prev_location_id: String = ""
 ## renderer caching any game state of its own.
 var _atlas_cache: Dictionary = {}
 
+## #1060 — Action-Replay beat queue. Beats arrive from /events (via Main →
+## enqueue_replay) and must play in `seq` order, ONE AT A TIME, each frame-bounded
+## (no overlapping unbounded tweens). We append parsed beats here, sort by seq, and
+## drain them serially in _drain_replay (await each beat's bounded duration). The
+## renderer NEVER computes a result — it only chooses how to SHOW the engine-decided
+## beat. Owns no game state: this is a transient presentation queue, cleared as it drains.
+var _replay_queue: Array = []
+## True while _drain_replay is running, so a second enqueue_replay just appends to the
+## queue rather than starting a second concurrent drain (keeps beats totally ordered).
+var _draining: bool = false
+## #1060 — the last `seq` we have already enqueued, so re-fetched/duplicate beats (the
+## envelope's idempotent-replay guarantee) are dropped rather than animated twice.
+var _last_replayed_seq: int = -1
+
 
 func _ready() -> void:
 	# Art arrives asynchronously through the /image bridge; swap the backdrop the
@@ -207,24 +221,277 @@ func apply_snapshot(atlas: Dictionary, combat: Dictionary, character: Dictionary
 
 
 # ---------------------------------------------------------------------------
-# Replay stub (#1055 / combat). Connected to SurfaceClient.events_appended by
-# Main. Real Action-Replay (combat token motion + facing from target_fk) is a
-# later issue — for now we accept and ignore so the signal interface is wired.
+# Action-Replay (#1060 / the #645 envelope). Connected to SurfaceClient.events_appended
+# by Main. Each /events record is one animated COMBAT beat in the Action-Replay-envelope
+# shape `{ seq, actor_fk, verb, target_fk, result, anim_hint }`
+# (docs/roadmap/contracts/action-replay-envelope.md). The renderer plays each beat in
+# `seq` order, ONE AT A TIME, frame-bounded — it never decides WHAT happened, only HOW
+# to show it. It also stays backward-compatible with the #1055 `zone_move` stub shape
+# (`{kind, actor, zone}`) so the earlier wiring keeps working.
+#
+# CONTRACT (the one invariant): the engine is the sole writer; this is a pure projection
+# of committed engine truth. The renderer reads `result` to choose numbers/states to show
+# and NEVER recomputes them. Unknown verbs are accepted-and-ignored (a generic no-op) so a
+# new envelope verb never crashes an old renderer (additive/back-compat, §Versioning).
 # ---------------------------------------------------------------------------
 func enqueue_replay(records: Array) -> void:
-	# #1055: honor `zone_move` beats for facing derivation (renderer-derived). Full
-	# Action-Replay (combat token motion + facing from target_fk) is still a later
-	# issue; everything else is accepted-and-ignored so the wiring stays verifiable.
+	# Parse + append every recognizable beat, then (re)start the serial drain. We sort
+	# by seq so beats animate in the engine's authoritative order regardless of arrival
+	# order (the envelope's total-order-via-seq guarantee).
 	for rec in records:
 		if typeof(rec) != TYPE_DICTIONARY:
 			continue
-		var r: Dictionary = rec
-		if String(r.get("kind", "")) != "zone_move":
+		var beat := _parse_replay_beat(rec)
+		if beat.is_empty():
 			continue
-		var actor_id := String(r.get("actor", r.get("actor_id", "")))
-		var zone_name := String(r.get("zone", r.get("target", "")))
-		if actor_id != "" and zone_name != "":
-			apply_zone_move(actor_id, zone_name)
+		# Drop duplicates (idempotent re-fetch): a beat we've already enqueued by seq is
+		# not animated twice. Beats with no seq (the #1055 stub) always pass (seq == -1).
+		var seq := int(beat.get("seq", -1))
+		if seq >= 0 and seq <= _last_replayed_seq:
+			continue
+		if seq >= 0:
+			_last_replayed_seq = seq
+		_replay_queue.append(beat)
+
+	if _replay_queue.is_empty():
+		return
+	# Stable sort by seq (beats without a seq keep arrival order at the front).
+	_replay_queue.sort_custom(func(a, b): return int(a.get("seq", -1)) < int(b.get("seq", -1)))
+
+	if not _draining:
+		_drain_replay()
+
+
+## Normalize one /events record into a beat Dictionary the dispatcher understands, or {}
+## if it carries no actor/verb we can animate. Accepts BOTH:
+##   - the Action-Replay envelope: {seq, actor_fk, verb, target_fk, result, anim_hint}
+##   - the #1055 stub:             {kind, actor/actor_id, zone/target}
+## so the new combat path and the old zone_move wiring share one entry point.
+func _parse_replay_beat(r: Dictionary) -> Dictionary:
+	# verb (envelope) takes precedence; fall back to the stub `kind`.
+	var verb := String(r.get("verb", r.get("kind", "")))
+	if verb == "":
+		return {}
+	var actor := String(r.get("actor_fk", r.get("actor", r.get("actor_id", ""))))
+	var target := String(r.get("target_fk", r.get("target", r.get("zone", ""))))
+	var result: Dictionary = r.get("result", {}) if typeof(r.get("result", {})) == TYPE_DICTIONARY else {}
+	var hint := String(r.get("anim_hint", ""))
+	var seq := int(r.get("seq", -1)) if (typeof(r.get("seq", null)) == TYPE_FLOAT or typeof(r.get("seq", null)) == TYPE_INT) else -1
+	return {"seq": seq, "verb": verb, "actor": actor, "target": target, "result": result, "anim_hint": hint}
+
+
+## Drain the replay queue serially: pop the front beat, play it, await its bounded
+## duration, repeat until empty. Each beat returns its own frame-bounded length, so the
+## whole exchange is deterministic and never blocks forever. A new enqueue_replay while
+## draining just appends (the guard keeps a single ordered drain).
+func _drain_replay() -> void:
+	_draining = true
+	while not _replay_queue.is_empty():
+		var beat: Dictionary = _replay_queue.pop_front()
+		var dur := _play_beat(beat)
+		print("[Replay] beat seq=%d verb=%s actor=%s target=%s dur=%.2f" % [
+			int(beat.get("seq", -1)), String(beat.get("verb", "")),
+			String(beat.get("actor", "")), String(beat.get("target", "")), dur])
+		if dur > 0.0:
+			await get_tree().create_timer(dur).timeout
+	_draining = false
+
+
+## Dispatch ONE beat to its per-verb handler and return the beat's bounded duration
+## (seconds the drain waits before the next beat). Unknown verbs are accepted-and-ignored
+## (return 0 — a generic no-op). The verb vocabulary mirrors the envelope contract's
+## closed `verb` set: attack/cast/damage/condition/death/save/check/move_to_zone/travel/narrate.
+func _play_beat(beat: Dictionary) -> float:
+	var verb := String(beat.get("verb", ""))
+	match verb:
+		"attack":
+			return _beat_attack(beat)
+		"cast":
+			return _beat_cast(beat)
+		"damage":
+			return _beat_damage(beat)
+		"heal":
+			# Not an envelope verb on its own (heals ride a `cast`/`condition` result),
+			# but accepted for fixtures/forward-compat: pulse the target green.
+			return _beat_heal(beat)
+		"condition":
+			return _beat_condition(beat)
+		"death":
+			return _beat_death(beat)
+		"move_to_zone", "zone_move":
+			return _beat_move(beat)
+		_:
+			# Unknown / non-animated verb (save/check/travel/narrate or a future verb):
+			# accept-and-ignore so the wiring never crashes (envelope §Versioning).
+			return 0.0
+
+
+# --- per-verb beat handlers (#1060). Each is RENDERER-OWNED presentation of the
+# engine-decided beat; none touch game state. ----------------------------------
+
+## attack: the actor faces its target (facing derived from actor→target zone anchors,
+## ISO-PROJECTION.md combat rule) and plays the one-shot attack clip, then auto-returns
+## to idle. A following `damage` beat (its own seq) flashes/floats on the target.
+func _beat_attack(beat: Dictionary) -> float:
+	var tok := _replay_token(String(beat.get("actor", "")))
+	if tok == null:
+		return 0.0
+	_face_token_at_target(tok, String(beat.get("actor", "")), String(beat.get("target", "")))
+	return tok.play_oneshot("attack")
+
+
+## cast: the actor plays the cast clip. If the result is a heal (anim_hint heal_pulse or
+## result.outcome == "heal"), the TARGET gets a green pulse + (if hp surfaced) an HP-bar
+## update + a floating "+N" — the heal is shown on the target in the same beat.
+func _beat_cast(beat: Dictionary) -> float:
+	var tok := _replay_token(String(beat.get("actor", "")))
+	if tok == null:
+		return 0.0
+	_face_token_at_target(tok, String(beat.get("actor", "")), String(beat.get("target", "")))
+	var dur := tok.play_oneshot("cast")
+	# A cast that resolves to a heal also pulses the target (the result is engine-decided).
+	var result: Dictionary = beat.get("result", {})
+	var hint := String(beat.get("anim_hint", ""))
+	if hint == "heal_pulse" or String(result.get("outcome", "")) == "heal":
+		_apply_heal_to_target(beat)
+	return dur
+
+
+## damage: HP applied to the target — flash the target red + float the damage number +
+## (if hp surfaced) update its HP bar. The amount/hp come straight from the engine result.
+func _beat_damage(beat: Dictionary) -> float:
+	var target_tok := _replay_token(String(beat.get("target", "")))
+	if target_tok == null:
+		return 0.0
+	var result: Dictionary = beat.get("result", {})
+	var amount := _result_amount(result, ["damage", "amount", "total"])
+	if amount != "":
+		_float_on_token(target_tok, amount, false)
+	_apply_hp_from_result(target_tok, result)
+	return target_tok.flash(CharacterToken.DAMAGE_FLASH_COLOR)
+
+
+## heal (explicit verb / fixture): pulse the target green + float "+N" + update HP bar.
+func _beat_heal(beat: Dictionary) -> float:
+	return _apply_heal_to_target(beat)
+
+
+## condition: a status changed (bloodied, prone, downed, blessed…). Brief violet flash on
+## the target + (if hp surfaced, e.g. bloodied carries hp_after) an HP-bar update.
+func _beat_condition(beat: Dictionary) -> float:
+	var target_tok := _replay_token(String(beat.get("target", "")))
+	if target_tok == null:
+		return 0.0
+	var result: Dictionary = beat.get("result", {})
+	_apply_hp_from_result(target_tok, result)
+	return target_tok.flash(CharacterToken.CONDITION_FLASH_COLOR)
+
+
+## death: the target drops — fade it out and free the token (it leaves the stage). The
+## actor_fk on a death beat is usually the dier; we resolve target first, then actor.
+func _beat_death(beat: Dictionary) -> float:
+	var who := String(beat.get("target", ""))
+	if who == "" or _tokens.get(who, null) == null:
+		who = String(beat.get("actor", ""))
+	var tok := _replay_token(who)
+	if tok == null:
+		return 0.0
+	return tok.fade_out_and_free()
+
+
+## move_to_zone / zone_move: the actor walks to a named zone (renderer-derived facing).
+## Reuses the existing #1055 walk path exactly.
+func _beat_move(beat: Dictionary) -> float:
+	var actor := String(beat.get("actor", ""))
+	# Envelope move_to_zone carries the zone in target_fk; the stub carried it in zone.
+	var zone := String(beat.get("target", ""))
+	if actor == "" or zone == "":
+		return 0.0
+	apply_zone_move(actor, zone)
+	# The walk tween is MOVE_TWEEN_SEC long; bound the beat to it so the next beat waits.
+	return CharacterToken.MOVE_TWEEN_SEC
+
+
+# --- replay helpers ---------------------------------------------------------
+
+## The spawned CharacterToken for an actor id, or null if not on stage / already dead.
+func _replay_token(actor_id: String) -> CharacterToken:
+	if actor_id == "":
+		return null
+	var tok: CharacterToken = _tokens.get(actor_id, null)
+	if tok == null or not is_instance_valid(tok) or tok.is_dead():
+		return null
+	return tok
+
+
+## Face `tok` toward `target_id`'s zone anchor (combat facing = actor-zone → target-zone,
+## ISO-PROJECTION.md). Uses each token's CURRENT screen position (their zone anchor) so the
+## facing is derived, never engine-supplied. A no-op if the target isn't on stage.
+func _face_token_at_target(tok: CharacterToken, actor_id: String, target_id: String) -> void:
+	var target_tok: CharacterToken = _tokens.get(target_id, null)
+	if target_tok == null or not is_instance_valid(target_tok):
+		return
+	var from_pos: Vector2 = _token_prev_pos.get(actor_id, tok.position)
+	var to_pos: Vector2 = target_tok.position
+	var facing := FacingResolver.octant(from_pos, to_pos, FACING_ORDER)
+	tok.set_facing(facing)
+
+
+## Apply a heal beat's result to its TARGET: green pulse + float "+N" + HP-bar update.
+## Shared by `cast→heal` and the explicit `heal` verb. Returns the pulse's bounded length.
+func _apply_heal_to_target(beat: Dictionary) -> float:
+	var target_tok := _replay_token(String(beat.get("target", "")))
+	if target_tok == null:
+		return 0.0
+	var result: Dictionary = beat.get("result", {})
+	var amount := _result_amount(result, ["amount", "heal", "total"])
+	if amount != "":
+		_float_on_token(target_tok, "+" + amount, true)
+	_apply_hp_from_result(target_tok, result)
+	return target_tok.heal_pulse()
+
+
+## If the engine result surfaced hp (hp_after + an hp_max, or an explicit fraction),
+## push it to the token's HP bar. Pure projection — the renderer never recomputes hp.
+func _apply_hp_from_result(tok: CharacterToken, result: Dictionary) -> void:
+	if result.is_empty():
+		return
+	# Prefer hp_after + a max (hpMax / hp_max / max); else an explicit hp_frac.
+	var has_after := result.has("hp_after") or result.has("hp")
+	if has_after:
+		var hp := float(result.get("hp_after", result.get("hp", 0)))
+		var hp_max := float(result.get("hp_max", result.get("hpMax", result.get("max", 0))))
+		if hp_max > 0.0:
+			tok.set_hp_fraction(hp / hp_max)
+			return
+	if result.has("hp_frac"):
+		tok.set_hp_fraction(float(result["hp_frac"]))
+
+
+## Stringify the first present numeric field in `keys` from the result (or a nested
+## {damage:{total}} / {amount} shape). "" if none — the renderer floats nothing then.
+func _result_amount(result: Dictionary, keys: Array) -> String:
+	for k in keys:
+		if result.has(k):
+			var v: Variant = result[k]
+			# {damage:{total:8}} nested shape (the envelope example).
+			if typeof(v) == TYPE_DICTIONARY and (v as Dictionary).has("total"):
+				return str(int((v as Dictionary)["total"]))
+			if typeof(v) == TYPE_FLOAT or typeof(v) == TYPE_INT:
+				return str(int(v))
+	return ""
+
+
+## Float a combat number above a token via the FxLayer (Main parents it to WorldView as
+## the child "FxLayer"). Positioned over the token's head. A no-op if no FxLayer exists
+## (e.g. a bare conformance harness that drives apply-only without the input/fx layer).
+func _float_on_token(tok: CharacterToken, text: String, is_heal: bool) -> void:
+	var fx := get_node_or_null("FxLayer")
+	if fx == null:
+		return
+	# Above the head: the token origin is its feet; lift by ~110px to clear the body.
+	var at := tok.position + Vector2(0.0, -110.0)
+	fx.call("float_number", at, text, is_heal)
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +532,22 @@ func team_tint_for(engine_actor_id: String) -> Color:
 ## The static pillar prop (null until spawned). Exposed for #1055's occlusion test.
 func pillar_prop() -> PropActor:
 	return _pillar
+
+
+## #1060 — true while the Action-Replay queue is draining (a beat is mid-play or queued).
+## Exposed so a conformance/visual harness can await the full exchange before asserting.
+func is_replaying() -> bool:
+	return _draining or not _replay_queue.is_empty()
+
+
+## #1060 — clear the replay queue + dedup cursor so a fresh sequence replays from scratch.
+## For a conformance/visual harness that drives beats DELIBERATELY (after the standalone
+## FIXTURE auto-poll already consumed events.json once against the exploration stage).
+## NOT used on the live path — there the cursor advances monotonically and never resets.
+func reset_replay() -> void:
+	_replay_queue.clear()
+	_last_replayed_seq = -1
+	_draining = false
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extend `godot/scenes/WorldView.gd::enqueue_replay` — the single Action-Replay entry point, previously **`zone_move`-only** (it accepted-and-ignored every combat verb) — into a **verb/kind dispatcher** that plays the **#645 Action-Replay envelope** (`{seq, actor_fk, verb, target_fk, result, anim_hint}`, per `docs/roadmap/contracts/action-replay-envelope.md`) as discrete, **seq-ordered, frame-bounded** animated beats on the painterly iso tiles. A combat scenario now *plays out* (HANDOFF §9, the #645 / #1060 series). Stays backward-compatible with the #1055 `{kind, actor, zone}` stub shape.

## Verbs animated (renderer-owned presentation; the engine stays sole writer)

| verb | what animates |
|------|---------------|
| `attack` | actor **faces the target** (FacingResolver: actor-zone → target-zone) + one-shot `attack` clip (~0.5s) → `idle` |
| `cast` | one-shot `cast` clip; a **heal** result (`anim_hint:heal_pulse` or `result.outcome:heal`) green-pulses the target + raises its HP bar + floats `+N` |
| `damage` | **red flash** on the target + **floating damage number** + HP-bar drop to the engine `hp_after/hp_max` |
| `heal` | green pulse + floating `+N` + HP-bar raise |
| `condition` | brief violet status flash (+ HP update if surfaced, e.g. `bloodied`) |
| `death` | **fade-to-transparent then free** the token (it leaves the stage) |
| `move_to_zone` / `zone_move` | the existing #1055 walk path (renderer-derived facing) |
| unknown / `save`/`check`/`travel`/`narrate` | **accept-and-ignore** (no crash — the envelope is additive/forward-compatible) |

## Handler approach
- Beats drain through a **deterministic, frame-bounded queue** (`_drain_replay`): pop front → `_play_beat` (verb dispatch) → `await` the beat's bounded duration → repeat. No unbounded tweens. Sorted by `seq`; **deduped by `seq`** (the envelope's idempotent-replay guarantee). The renderer **reads** `result` (damage/heal/hp), **never recomputes** it.
- New presentation primitives (pure, own no game state):
  - `CharacterToken`: `play_oneshot` / `flash` / `heal_pulse` / `fade_out_and_free` + a slim **HP bar** that shows engine-decided `hp/hpMax` only.
  - `FxLayer`: `float_number` (rising, fading damage/heal numbers).

## Fixture-driven (testable without a live engine)
- `godot/fixtures/events.json` gains a **10-beat combat exchange** in the envelope shape (move → attack → damage → condition → ogre attack → companion self-heal → killing blow → death), referencing the `combat-surface-active.json` roster.
- `Main --combat-replay` headless conformance: spawns the active roster, plays the beats through the **same `enqueue_replay`** the live `/events` poll uses, and asserts the engine-decided beats were **shown** — death freed the token, the heal raised the target HP bar to 16/22, the attacker faced its target, the queue drained.
- `Main --demo-combat`: a real-window **screenshot** of a combat beat animating.

## Validation (local, Godot 4.6.3) — all green
- `--import` parse gate: clean
- boot slice (`location=` + `anims=32`): pass
- `--smoke-intent` (frozen vocab / illegal blocked): pass
- `--combat-tokens` (5/5 roster, team-tinted): pass
- `--combat-replay`: `RESULT ok=true death-freed=true heal-hp-raised=true attack-faced=true drained=true`
- Screenshot: `/tmp/wos_godot_combat_replay.png` — Aubree (green ally) facing her cultist target, foes red-tinted at their zones, on the dimetric stage.

CI (`.github/workflows/godot.yml`): adds the `--combat-replay` conformance gate + a combat-replay screenshot artifact, alongside the existing import/anims=32/smoke-intent/combat-tokens/export checks.

## Deferred (clearly out of scope)
- **The live `/events` emission** — the viewer-side projection of the engine combat log into Action-Replay envelope records (`viewer/server.py`) is the follow-up. This PR is **Godot-only + the fixture**; no engine/viewer change.

## Invariants held
Additive. Thin-client / **sole-writer** (the renderer never writes engine state — replay only reads `result` and animates), **zone-positioning** (facing is renderer-derived via FacingResolver; all surface `x/y` ignored), **dimetric-2:1**. Unknown verbs never crash the renderer.