### PR TITLE
ci(security): Dependabot + advisory dependency-review (non-blocking SCA)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+# Dependabot — version + security updates (ADVISORY; not a required merge gate).
+# Security updates surface vulnerable direct/transitive deps; version updates keep the
+# lockfiles current. Public repo, so no GHAS is required. If the `uv` ecosystem is ever
+# rejected for a directory, fall back to `pip` for that entry.
+version: 2
+updates:
+  # --- Python services (uv) ---
+  - package-ecosystem: "uv"
+    directory: "/servers/engine"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "uv"
+    directory: "/servers/rules"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "uv"
+    directory: "/servers/voice"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # --- Playwright QA harness (npm) ---
+  - package-ecosystem: "npm"
+    directory: "/qa/playwright"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+
+  # --- GitHub Actions ---
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+name: Dependency Review
+
+# ADVISORY PR check: flags NEW high/critical dependency vulnerabilities a PR would introduce.
+# It is NOT added as a required branch-protection context, so it surfaces a signal (and a PR
+# comment on failure) WITHOUT blocking the `--squash --auto` merge path. The existing alert
+# backlog is unaffected — dependency-review only inspects the PR's own dependency diff.
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
## What
Adds **non-blocking** software-composition-analysis to the merge loop (Bucket 3 from the 2026-06-21 PR-process adversarial review).

- **`.github/dependabot.yml`** — weekly version + security updates for the 3 `uv` Python services (`servers/engine|rules|voice`), the npm Playwright harness (`qa/playwright`), and `github-actions`.
- **`.github/workflows/dependency-review.yml`** — advisory PR check that fails **only on NEW** high/critical dependency vulns (and comments a summary on failure).

## Why
Public repo with **23 HIGH/critical CodeQL + 13 HIGH/critical Dependabot alerts** open and nothing in the merge loop watching deps. Mostly dormant today (stdio MCP servers, localhost viewer) but live exposure once **WorldOS Web Phase 2 — Hosted Runtime** ships on the same `starlette`/`hono` deps.

## Design choices
- **Advisory, not gating.** `dependency-review` is intentionally **not** a required branch-protection context — it surfaces a signal + PR comment without blocking the `--squash --auto` path (avoids the deadlock/non-determinism risk the review flagged for required security checks).
- **"Fail only on NEW"** — dependency-review inspects only the PR's dependency diff, so the existing alert backlog is untouched. That backlog is triaged in a separate issue.
- Skipped a bespoke "fail-on-new-CodeQL-alert" gate — marginal over the existing `codeql.yml`.

## Safety
Additive config only — no code/test/schema. Cannot break or gate existing PRs. Merging via `--squash --auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)