### PR TITLE
ci: daily stuck-PR detector (surface-only; notifies owner + agents)

### DIFF
--- a/.claude/skills/worldos-dev/SKILL.md
+++ b/.claude/skills/worldos-dev/SKILL.md
@@ -186,7 +186,8 @@ Keep Python tests single-process unless the lane explicitly supports parallel ex
 
 ## THE MERGE GATE — CI + CodeRabbit (don't push-and-abandon)
 **Shepherd every PR to merge; never open-and-walk-away.** Stay engaged (or hand to a report-only
-watcher) until it lands. Merge only when ALL hold:
+watcher) until it lands. **Orphaned PRs** (whose driving agent died/abandoned them) surface daily in
+the open **`stuck-pr-report`** issue — when idle or resuming, check it and adopt one. Merge only when ALL hold:
 1. **CI green AND present** — all 5 required `ci.yml` contexts (`test`, `viewer-tests`,
    `qa-release-gate-tests`, `server-contracts`, `license-check`) have a check-run on THIS head and
    are SUCCESS. A *missing* context reads as no-status, not pass (strict=false + a job added to

--- a/.github/scripts/stuck_pr_report.sh
+++ b/.github/scripts/stuck_pr_report.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Stuck-PR detector (SURFACE-ONLY — no auto-fix). Flags open, non-draft PRs that are stuck —
+# a failing check, OR blocked/conflicting AND stale — then upserts a single living issue and
+# @mentions the owner (→ GitHub notification email), and optionally emails via Resend if a
+# RESEND_API_KEY is configured. Snooze a PR out of the report by labelling it `blocked`.
+#
+# Why surface-only: a scheduled workflow can't spawn an agent to fix the PR, so it makes the
+# orphan VISIBLE to both the owner (email) and any future agent (the issue is a shared queue).
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY:-electricsheephq/WorldOS}"
+OWNER_HANDLE="${OWNER_HANDLE:-100yenadmin}"
+STALE_HOURS="${STALE_HOURS:-24}"
+LABEL="stuck-pr-report"
+cutoff=$(( $(date -u +%s) - STALE_HOURS * 3600 ))
+ts=$(date -u +'%Y-%m-%d %H:%M')
+
+# A PR is "stuck" if it has >=1 failing check, OR it is BLOCKED/DIRTY and hasn't been
+# touched in >STALE_HOURS (so a PR merely mid-CI isn't flagged). Drafts and `blocked`-
+# labelled PRs are excluded.
+rows=$(gh pr list --repo "$REPO" --state open --limit 100 \
+  --json number,title,url,isDraft,mergeStateStatus,updatedAt,author,labels,statusCheckRollup \
+  | jq -r --argjson cutoff "$cutoff" '
+    def isfail(s): (s=="FAILURE" or s=="ERROR" or s=="TIMED_OUT" or s=="CANCELLED" or s=="ACTION_REQUIRED");
+    .[]
+    | select(.isDraft | not)
+    | select([.labels[].name] | index("blocked") | not)
+    | ([.statusCheckRollup[]? | select(isfail(.conclusion // .state // ""))] | length) as $fail
+    | ((.updatedAt | fromdateiso8601) < $cutoff) as $stale
+    | select($fail > 0 or ((.mergeStateStatus == "DIRTY" or .mergeStateStatus == "BLOCKED") and $stale))
+    | "- [#\(.number)](\(.url)) — \(.title) · `\(.mergeStateStatus)` · failing-checks: \($fail) · updated \(.updatedAt[0:10]) · @\(.author.login)"
+  ')
+
+if [ -z "$rows" ]; then
+  echo "No stuck PRs as of $ts UTC. Nothing to report."
+  exit 0
+fi
+count=$(printf '%s\n' "$rows" | grep -c '^- ' || true)
+
+# Single-quoted printf format → literal backticks (no command substitution); %s carries values.
+body=$(printf '🔧 **%s stuck PR(s)** as of %s UTC — each is failing a check, conflicting, or blocked & stale (>%sh). This report is **surface-only** (no auto-fix): pick one up, or label it `blocked` to snooze it out of this report.\n\n%s\n\n---\n_cc @%s · auto-maintained by `.github/workflows/stuck-pr-report.yml`. Agents: this issue is the shared queue of orphaned PRs — claim one and shepherd it through the worldos-dev merge gate._\n' \
+  "$count" "$ts" "$STALE_HOURS" "$rows" "$OWNER_HANDLE")
+
+# Upsert: keep ONE living issue (found by label), edit its body + add a dated comment to notify.
+existing=$(gh issue list --repo "$REPO" --state open --label "$LABEL" --limit 1 --json number --jq '.[0].number // empty')
+if [ -n "$existing" ]; then
+  gh issue edit "$existing" --repo "$REPO" --body "$body" >/dev/null
+  gh issue comment "$existing" --repo "$REPO" --body "↻ ${count} stuck PR(s) as of ${ts} UTC. cc @${OWNER_HANDLE}" >/dev/null
+  num="$existing"
+else
+  url=$(gh issue create --repo "$REPO" --title "🔧 Stuck PRs — daily report" --label "$LABEL" --body "$body")
+  num=$(printf '%s' "$url" | grep -oE '[0-9]+$')
+fi
+echo "Reported ${count} stuck PR(s) → issue #${num}."
+
+# Optional Resend email — fires only if all three are set (zero-setup default is the @mention above).
+if [ -n "${RESEND_API_KEY:-}" ] && [ -n "${RESEND_TO:-}" ] && [ -n "${RESEND_FROM:-}" ]; then
+  html=$(printf '%s' "$body" | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g; s/$/<br>/')
+  payload=$(jq -n --arg from "$RESEND_FROM" --arg to "$RESEND_TO" \
+    --arg subj "[WorldOS] ${count} stuck PR(s)" --arg html "$html" \
+    '{from:$from, to:[$to], subject:$subj, html:$html}')
+  if curl -fsS -X POST https://api.resend.com/emails \
+      -H "Authorization: Bearer ${RESEND_API_KEY}" -H "Content-Type: application/json" \
+      -d "$payload" >/dev/null; then
+    echo "Resend email sent to ${RESEND_TO}."
+  else
+    echo "::warning::Resend email failed (non-fatal)."
+  fi
+fi

--- a/.github/scripts/stuck_pr_report.sh
+++ b/.github/scripts/stuck_pr_report.sh
@@ -31,8 +31,18 @@ rows=$(gh pr list --repo "$REPO" --state open --limit 100 \
     | "- [#\(.number)](\(.url)) — \(.title) · `\(.mergeStateStatus)` · failing-checks: \($fail) · updated \(.updatedAt[0:10]) · @\(.author.login)"
   ')
 
+# Find the living report issue (prefer open; fall back to a closed one to reopen).
+open_num=$(gh issue list --repo "$REPO" --state open --label "$LABEL" --limit 1 --json number --jq '.[0].number // empty')
+
 if [ -z "$rows" ]; then
-  echo "No stuck PRs as of $ts UTC. Nothing to report."
+  echo "No stuck PRs as of $ts UTC."
+  # Clear the stale report so agents don't adopt already-resolved PRs: an OPEN report issue
+  # must mean "something is stuck right now". Edit to all-clear and close it.
+  if [ -n "$open_num" ]; then
+    gh issue edit "$open_num" --repo "$REPO" --body "✅ No stuck PRs as of ${ts} UTC. _(auto-maintained by \`.github/workflows/stuck-pr-report.yml\`)_" >/dev/null
+    gh issue close "$open_num" --repo "$REPO" --comment "✅ All previously-flagged PRs are resolved as of ${ts} UTC. Closing — reopens automatically when a PR gets stuck again." >/dev/null
+    echo "Cleared + closed stale report issue #${open_num}."
+  fi
   exit 0
 fi
 count=$(printf '%s\n' "$rows" | grep -c '^- ' || true)
@@ -41,12 +51,17 @@ count=$(printf '%s\n' "$rows" | grep -c '^- ' || true)
 body=$(printf '🔧 **%s stuck PR(s)** as of %s UTC — each is failing a check, conflicting, or blocked & stale (>%sh). This report is **surface-only** (no auto-fix): pick one up, or label it `blocked` to snooze it out of this report.\n\n%s\n\n---\n_cc @%s · auto-maintained by `.github/workflows/stuck-pr-report.yml`. Agents: this issue is the shared queue of orphaned PRs — claim one and shepherd it through the worldos-dev merge gate._\n' \
   "$count" "$ts" "$STALE_HOURS" "$rows" "$OWNER_HANDLE")
 
-# Upsert: keep ONE living issue (found by label), edit its body + add a dated comment to notify.
-existing=$(gh issue list --repo "$REPO" --state open --label "$LABEL" --limit 1 --json number --jq '.[0].number // empty')
-if [ -n "$existing" ]; then
-  gh issue edit "$existing" --repo "$REPO" --body "$body" >/dev/null
-  gh issue comment "$existing" --repo "$REPO" --body "↻ ${count} stuck PR(s) as of ${ts} UTC. cc @${OWNER_HANDLE}" >/dev/null
-  num="$existing"
+# Upsert ONE living issue: reuse the open one, else reopen the most recent closed one, else
+# create. Keeps a single canonical issue that toggles open⟺closed with the backlog.
+target="$open_num"
+if [ -z "$target" ]; then
+  target=$(gh issue list --repo "$REPO" --state closed --label "$LABEL" --limit 1 --json number --jq '.[0].number // empty')
+fi
+if [ -n "$target" ]; then
+  gh issue edit "$target" --repo "$REPO" --body "$body" >/dev/null
+  gh issue reopen "$target" --repo "$REPO" >/dev/null 2>&1 || true
+  gh issue comment "$target" --repo "$REPO" --body "↻ ${count} stuck PR(s) as of ${ts} UTC. cc @${OWNER_HANDLE}" >/dev/null
+  num="$target"
 else
   url=$(gh issue create --repo "$REPO" --title "🔧 Stuck PRs — daily report" --label "$LABEL" --body "$body")
   num=$(printf '%s' "$url" | grep -oE '[0-9]+$')

--- a/.github/workflows/stuck-pr-report.yml
+++ b/.github/workflows/stuck-pr-report.yml
@@ -1,0 +1,35 @@
+name: Stuck PR report
+
+# Daily safety-net for the "agents shepherd their own PRs" rule: catches PRs whose driving
+# agent died/abandoned them. SURFACE-ONLY — see .github/scripts/stuck_pr_report.sh.
+# Runs on a schedule + on demand; it is NOT a pull_request check (adds no merge gate).
+on:
+  schedule:
+    - cron: "23 15 * * *"   # ~15:23 UTC daily (~08:23 PT), off the hour to dodge the cron herd
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: stuck-pr-report
+  cancel-in-progress: false
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Detect and report stuck PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Override the @mention target with a repo variable if you like; defaults to the owner.
+          OWNER_HANDLE: ${{ vars.STUCK_PR_NOTIFY_HANDLE || '100yenadmin' }}
+          STALE_HOURS: "24"
+          # Optional real-email upgrade — set these (RESEND_API_KEY as a secret) to also email.
+          RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          RESEND_TO: ${{ vars.STUCK_PR_EMAIL_TO }}
+          RESEND_FROM: ${{ vars.STUCK_PR_EMAIL_FROM }}
+        run: bash .github/scripts/stuck_pr_report.sh

--- a/.github/workflows/stuck-pr-report.yml
+++ b/.github/workflows/stuck-pr-report.yml
@@ -12,6 +12,9 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
+  checks: read      # gh pr list --json statusCheckRollup reads check runs
+  statuses: read    # ...and commit statuses
+  actions: read     # ...and workflow-run data, under GITHUB_TOKEN
 
 concurrency:
   group: stuck-pr-report


### PR DESCRIPTION
## What
A daily safety-net for the *"agents shepherd their own PRs"* discipline — catches PRs whose driving agent died/abandoned them. **Surface-only** (a scheduled job can't spawn a fixer), routed to **both** audiences:
- **Owner** → upserts a single living issue + `@mention` (GitHub notification email), with an optional **Resend** real-email path if `RESEND_API_KEY` is set.
- **Agents** → it's a GitHub issue, so any future/idle agent can adopt the orphan (the `worldos-dev` skill now points them at the `stuck-pr-report` issue as the shared queue).

## Files
- `.github/scripts/stuck_pr_report.sh` — flags open non-draft PRs that have a **failing check**, OR are **blocked/conflicting AND stale** (>24h). Excludes drafts + `blocked`-labelled PRs (the snooze). Upserts one issue (found by label), edits its body + posts a dated `@mention` comment.
- `.github/workflows/stuck-pr-report.yml` — daily cron (`23 15 * * *`) + `workflow_dispatch`. **Not** a `pull_request` check, so it adds no merge gate.
- `worldos-dev` skill: one-line pointer so agents treat the report issue as the orphan-PR queue.

## Why
The "never push-and-abandon" rule is a behavioral promise that breaks when the agent dies. Live proof: **#1025** sat 3+ days BLOCKED with a red `qa-release-gate-tests` + 2 unresolved threads while ~40 PRs merged past it. Nothing was watching.

## Validated
Ran the script live against the repo → produced issue #1138 correctly flagging #1025 (and zero false-positives on the ~10 active PRs).

## Notes
- **Zero setup** to start (GitHub-notification email via the `@mention`). To get a guaranteed standalone email, set `RESEND_API_KEY` (secret) + `STUCK_PR_EMAIL_TO`/`STUCK_PR_EMAIL_FROM` (vars); the script fires Resend only if all three are present.
- Additive (new workflow/script + 1 doc line). No code/test/schema touched. Merging via `--squash --auto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)