### PR TITLE
feat(godot,#1061): iso scene-preview harness + NavOverlay A* grid

### DIFF
--- a/godot/autoload/RenderProfile.gd
+++ b/godot/autoload/RenderProfile.gd
@@ -197,6 +197,18 @@ func _core_array(key: String) -> Array:
 	return arr if typeof(arr) == TYPE_ARRAY else []
 
 
+## Inject an inline profile dict (e.g. from a --preview-scene spec) instead of the
+## bundled fixture. Additive: the normal _ready() fixture load is UNCHANGED; this
+## method replaces _profile for callers that supply their own profile dictionary so a
+## preview can inject a profile without the bundled fixture. No-op if called with an
+## empty dict (falls back to the already-loaded fixture).
+func load_inline(profile: Dictionary) -> void:
+	if profile.is_empty():
+		return
+	_profile = profile
+	print("[RenderProfile] load_inline: profile injected (top-level keys=%d)" % _profile.size())
+
+
 ## Load + parse the bundled fixture. Returns {} on any missing/parse failure so a
 ## profile-less run still renders.
 func _load_fixture() -> Dictionary:

--- a/godot/scenes/Main.gd
+++ b/godot/scenes/Main.gd
@@ -108,6 +108,9 @@ func _on_snapshot(atlas: Dictionary, _combat: Dictionary, character: Dictionary)
 		if _has_arg("--demo-occlusion"):
 			call_deferred("_run_demo_occlusion")
 			return
+		if _has_arg("--preview-scene"):
+			call_deferred("_run_preview_scene")
+			return
 		_maybe_quit()
 
 
@@ -624,6 +627,160 @@ func _maybe_quit() -> void:
 	if smoke_flag or headless:
 		# Defer the quit one frame so the prints flush before teardown.
 		call_deferred("_quit_clean")
+
+
+## Return the value that follows `flag` in the post-`--` user args (or "").
+## E.g. for args ["--spec", "/tmp/scene.json"] returns "/tmp/scene.json" when
+## flag=="--spec".
+func _arg_value(flag: String) -> String:
+	var args := OS.get_cmdline_user_args()
+	var idx := args.find(flag)
+	if idx < 0 or idx + 1 >= args.size():
+		return ""
+	return args[idx + 1]
+
+
+# ---------------------------------------------------------------------------
+# --preview-scene: scene-preview harness (additive, non-interactive).
+#
+# Spec format (/tmp/scene.json):
+#   {
+#     "backdrop": "/tmp/art/tavern.png",          // local PNG path, optional
+#     "nav": {
+#       "cols": 12, "rows": 8,                    // grid dimensions
+#       "cell_w_px": 72,                          // screen diamond width
+#       "origin_px": [512, 300],                  // screen coords of cell(0,0) center
+#       "blocked": [[3,3],[8,2],[6,5]]            // solid (unwalkable) cells
+#     },
+#     "actors": [                                 // optional actor overlays
+#       {"id":"pc",  "cell":[1,4], "facing":"E"},
+#       {"id":"foe", "cell":[10,4],"facing":"W"}
+#     ],
+#     "path_probe": {"from":[1,4], "to":[10,4]}, // A* probe (full overlay mode)
+#     "camera": {"zoom": 1.0}                     // reserved, not yet wired
+#   }
+#
+# Args:
+#   --spec  <path>   JSON spec file (required)
+#   --shot  <path>   output PNG (default /tmp/scene.png)
+#   --overlay <none|grid|full>  (default full)
+#
+# Output:
+#   <shot>.png              — viewport capture with grid/path overlay
+#   <shot>.nav.json         — {"path_found":bool,"path":[[c,r],...],"blocked_count":int,...}
+#
+# Usage (qa/preview_scene.sh wraps this):
+#   godot --path godot --quit-after 300 -- \
+#     --preview-scene --spec /tmp/scene.json --shot /tmp/scene.png --overlay full
+# ---------------------------------------------------------------------------
+func _run_preview_scene() -> void:
+	print("[Main] --preview-scene: scene-preview harness")
+
+	var spec_path := _arg_value("--spec")
+	if spec_path == "":
+		push_warning("[PreviewScene] --spec not supplied — aborting")
+		print("[PreviewScene] RESULT ok=false reason=missing_spec")
+		call_deferred("_quit_clean")
+		return
+
+	var shot_path := _arg_value("--shot")
+	if shot_path == "":
+		shot_path = "/tmp/scene.png"
+
+	var overlay_mode := _arg_value("--overlay")
+	if overlay_mode == "" or (overlay_mode != "none" and overlay_mode != "grid" and overlay_mode != "full"):
+		overlay_mode = "full"
+
+	# Parse spec JSON.
+	if not FileAccess.file_exists(spec_path):
+		push_warning("[PreviewScene] spec file not found: " + spec_path)
+		print("[PreviewScene] RESULT ok=false reason=spec_not_found path=%s" % spec_path)
+		call_deferred("_quit_clean")
+		return
+
+	var text := FileAccess.get_file_as_string(spec_path)
+	var parsed: Variant = JSON.parse_string(text)
+	if typeof(parsed) != TYPE_DICTIONARY:
+		push_warning("[PreviewScene] spec JSON parse failed: " + spec_path)
+		print("[PreviewScene] RESULT ok=false reason=spec_parse_error")
+		call_deferred("_quit_clean")
+		return
+
+	var spec: Dictionary = parsed
+
+	# Detach the live SurfaceClient feed so the fixture poll doesn't stomp our overlay.
+	_detach_live_feed()
+
+	# 1. Apply backdrop — local path first (no HTTP, no scope resolution).
+	var backdrop_path: String = String(spec.get("backdrop", ""))
+	if backdrop_path != "":
+		var ok: bool = _world.apply_local_backdrop(backdrop_path)
+		if not ok:
+			print("[PreviewScene] backdrop load failed for path=%s — using procedural fallback" % backdrop_path)
+	else:
+		print("[PreviewScene] no backdrop specified — using procedural fallback")
+
+	# 2. Build and attach the NavOverlay.
+	var nav_block: Dictionary = {}
+	var nav_v: Variant = spec.get("nav", {})
+	if typeof(nav_v) == TYPE_DICTIONARY:
+		nav_block = nav_v
+
+	var actors_arr: Array = []
+	var actors_v: Variant = spec.get("actors", [])
+	if typeof(actors_v) == TYPE_ARRAY:
+		actors_arr = actors_v
+
+	var path_probe: Dictionary = {}
+	var probe_v: Variant = spec.get("path_probe", {})
+	if typeof(probe_v) == TYPE_DICTIONARY:
+		path_probe = probe_v
+
+	# Zone anchors from the nav spec (optional "zones" key: [[x,y],...] in screen px).
+	var zone_anchors: Array = []
+	var zones_v: Variant = nav_block.get("zones", [])
+	if typeof(zones_v) == TYPE_ARRAY:
+		for z in (zones_v as Array):
+			if typeof(z) == TYPE_ARRAY and (z as Array).size() >= 2:
+				zone_anchors.append(Vector2(float((z as Array)[0]), float((z as Array)[1])))
+
+	var nav_overlay := preload("res://scenes/NavOverlay.gd").new()
+	nav_overlay.name = "NavOverlay"
+	nav_overlay.setup(nav_block, actors_arr, path_probe, zone_anchors, overlay_mode)
+	_world.add_child(nav_overlay)
+
+	# 3. Settle a few frames so the rendering pipeline flushes, then capture.
+	await _settle_frames(3)
+	await get_tree().create_timer(0.05).timeout
+	await _settle_frames(2)
+
+	var img := _capture_viewport()
+	if img != null:
+		img.save_png(shot_path)
+		print("[PreviewScene] screenshot: %s (%dx%d)" % [shot_path, img.get_width(), img.get_height()])
+	else:
+		print("[PreviewScene] no image captured (headless?) — run WITHOUT --headless for a real frame")
+
+	# 4. Write <shot>.nav.json.
+	var nav_result: Dictionary = nav_overlay.nav_result()
+	var nav_json_path := shot_path + ".nav.json"
+	# strip ".png.nav.json" and replace with ".nav.json"
+	if shot_path.ends_with(".png"):
+		nav_json_path = shot_path.substr(0, shot_path.length() - 4) + ".nav.json"
+
+	var nav_json := JSON.stringify(nav_result, "\t")
+	var f := FileAccess.open(nav_json_path, FileAccess.WRITE)
+	if f != null:
+		f.store_string(nav_json)
+		f.close()
+		print("[PreviewScene] nav.json: %s path_found=%s" % [nav_json_path, str(nav_result.get("path_found", false))])
+	else:
+		push_warning("[PreviewScene] could not write nav.json to " + nav_json_path)
+
+	print("[PreviewScene] RESULT ok=%s overlay=%s path_found=%s shot=%s" % [
+		str(img != null), overlay_mode, str(nav_result.get("path_found", false)), shot_path])
+
+	call_deferred("_quit_clean")
 
 
 func _quit_clean() -> void:

--- a/godot/scenes/NavOverlay.gd
+++ b/godot/scenes/NavOverlay.gd
@@ -1,0 +1,267 @@
+extends Node2D
+## NavOverlay — draws the tactical/nav grid over a backdrop in preview mode.
+##
+## ROLE: a read-only visual diagnostic tool. Given a nav spec block (from the
+## --preview-scene JSON), it draws the dimetric 2:1 diamond grid, walkable/blocked
+## cell tints, zone-anchor rings, a solved A* path, and actor foot-dots + facing
+## arrows. It is ADDITIVE — only ever added as a child of WorldView in preview mode;
+## the normal gameplay path never instantiates it.
+##
+## SPEC format (nav block inside /tmp/scene.json):
+##   {
+##     "cols": 12,            // grid width in cells
+##     "rows": 8,             // grid height in cells
+##     "cell_w_px": 72,       // screen width of one diamond cell in pixels
+##     "origin_px": [512, 300],  // screen position of cell (0,0) center
+##     "blocked": [[3,3],[8,2]]  // list of [col, row] blocked cells
+##   }
+##
+## GRID TRANSFORM (ISO-PROJECTION.md dimetric 2:1):
+##   cell (c, r) center in screen pixels:
+##     x = origin_px.x + (c - r) * cell_w_px / 2
+##     y = origin_px.y + (c + r) * cell_w_px / 4
+##   (cell_w_px/2 is the half-width; cell_h_px = cell_w_px/2 for 2:1 ratio)
+##
+## OVERLAY MODES (--overlay arg):
+##   none  — nothing drawn (no-op)
+##   grid  — diamond outlines only (no tints/path/actors)
+##   full  — everything (default): grid + tints + path + actors
+
+## Visual style constants (keep subtle — this is a debug overlay, not UI chrome).
+const COLOR_WALKABLE   := Color(0.2,  0.9,  0.3,  0.18)  ## green tint for walkable cells
+const COLOR_BLOCKED    := Color(0.9,  0.2,  0.2,  0.28)  ## red tint for blocked cells
+const COLOR_GRID       := Color(0.8,  0.8,  1.0,  0.35)  ## diamond outline
+const COLOR_GRID_EDGE  := Color(0.6,  0.6,  0.8,  0.20)  ## faint outer cells
+const COLOR_PATH       := Color(1.0,  0.9,  0.1,  0.90)  ## bright yellow path polyline
+const COLOR_PATH_START := Color(0.2,  1.0,  0.2,  1.0)   ## green endpoint marker
+const COLOR_PATH_END   := Color(1.0,  0.35, 0.1,  1.0)   ## orange endpoint marker
+const COLOR_ZONE_RING  := Color(0.6,  0.9,  1.0,  0.55)  ## zone anchor ring
+const COLOR_ACTOR_DOT  := Color(1.0,  1.0,  1.0,  0.9)   ## actor foot dot
+const COLOR_ACTOR_FACE := Color(1.0,  0.85, 0.2,  0.85)  ## actor facing arrow
+
+const LINE_WIDTH := 1.5
+const PATH_LINE_WIDTH := 3.0
+
+## Parsed from the spec block.
+var _cols: int = 0
+var _rows: int = 0
+var _cell_w: float = 64.0
+var _origin: Vector2 = Vector2.ZERO
+var _blocked: Array = []        # Array of Vector2i (col, row)
+
+## Resolved path (from _solve_astar).
+var _path: Array = []           # Array of Vector2i
+var _path_found: bool = false
+
+## Actor data for drawing.
+var _actors: Array = []         # Array of {cell: Vector2i, facing: String}
+
+## Zone anchors (optional, "full" mode only).
+var _zone_anchors: Array = []   # Array of Vector2 (screen positions)
+
+## Overlay mode: "none", "grid", "full"
+var _mode: String = "full"
+
+## Facing string -> unit direction for the 8 facing arrows (dimetric 2:1 space).
+## E/W are horizontal, N/S are vertical in screen space; diagonals follow the
+## 2:1 tile geometry (dx=1, dy=0.5 for SE).
+const FACING_DIRS := {
+	"N":  Vector2( 0.0, -1.0),
+	"NE": Vector2( 0.7, -0.35),
+	"E":  Vector2( 1.0,  0.0),
+	"SE": Vector2( 0.7,  0.35),
+	"S":  Vector2( 0.0,  1.0),
+	"SW": Vector2(-0.7,  0.35),
+	"W":  Vector2(-1.0,  0.0),
+	"NW": Vector2(-0.7, -0.35),
+}
+
+
+## Apply the nav spec from the preview JSON. Call before add_child so data is ready
+## when _draw() fires.
+func setup(nav: Dictionary, actors: Array, path_probe: Dictionary, zone_anchors: Array, mode: String) -> void:
+	_mode = mode
+	if _mode == "none":
+		return
+
+	_cols = int(nav.get("cols", 0))
+	_rows = int(nav.get("rows", 0))
+	_cell_w = float(nav.get("cell_w_px", 64))
+	var orig: Variant = nav.get("origin_px", [0, 0])
+	if typeof(orig) == TYPE_ARRAY and (orig as Array).size() >= 2:
+		_origin = Vector2(float((orig as Array)[0]), float((orig as Array)[1]))
+
+	var blocked_raw: Variant = nav.get("blocked", [])
+	if typeof(blocked_raw) == TYPE_ARRAY:
+		for b in (blocked_raw as Array):
+			if typeof(b) == TYPE_ARRAY and (b as Array).size() >= 2:
+				_blocked.append(Vector2i(int((b as Array)[0]), int((b as Array)[1])))
+
+	# Build actor list.
+	for a in actors:
+		if typeof(a) != TYPE_DICTIONARY:
+			continue
+		var cell_v: Variant = (a as Dictionary).get("cell", [0, 0])
+		if typeof(cell_v) == TYPE_ARRAY and (cell_v as Array).size() >= 2:
+			var c := Vector2i(int((cell_v as Array)[0]), int((cell_v as Array)[1]))
+			var facing := String((a as Dictionary).get("facing", "S"))
+			_actors.append({"cell": c, "facing": facing})
+
+	_zone_anchors = zone_anchors
+
+	if _mode == "full":
+		_solve_astar(path_probe)
+
+	queue_redraw()
+
+
+## Solve A* from path_probe.from -> path_probe.to using AStarGrid2D.
+## Stores result in _path / _path_found.
+func _solve_astar(probe: Dictionary) -> void:
+	if _cols <= 0 or _rows <= 0:
+		return
+	var from_v: Variant = probe.get("from", null)
+	var to_v: Variant = probe.get("to", null)
+	if from_v == null or to_v == null:
+		return
+	if typeof(from_v) != TYPE_ARRAY or typeof(to_v) != TYPE_ARRAY:
+		return
+	var from_a := from_v as Array
+	var to_a := to_v as Array
+	if from_a.size() < 2 or to_a.size() < 2:
+		return
+
+	var from := Vector2i(int(from_a[0]), int(from_a[1]))
+	var to   := Vector2i(int(to_a[0]),   int(to_a[1]))
+
+	var grid := AStarGrid2D.new()
+	grid.region = Rect2i(0, 0, _cols, _rows)
+	# For dimetric 2:1 we allow diagonal movement when at least one neighbour walkable.
+	grid.diagonal_mode = AStarGrid2D.DIAGONAL_MODE_AT_LEAST_ONE_WALKABLE
+	# AStarGrid2D defaults to square cells; the dimetric aspect is handled in the
+	# screen-space draw, not in the pathfinding itself (grid topology is square).
+	grid.cell_shape = AStarGrid2D.CELL_SHAPE_SQUARE
+	grid.update()
+
+	for b in _blocked:
+		grid.set_point_solid(b, true)
+
+	# If the to-cell is solid, the path is trivially unreachable.
+	if grid.is_point_solid(to):
+		_path_found = false
+		print("[NavOverlay] A* to=%s is blocked -> path_found=false" % str(to))
+		return
+
+	var id_path: PackedVector2Array = grid.get_id_path(from, to)
+	if id_path.is_empty():
+		_path_found = false
+		print("[NavOverlay] A* from=%s to=%s -> no path" % [str(from), str(to)])
+		return
+
+	_path_found = true
+	for p in id_path:
+		_path.append(Vector2i(int(p.x), int(p.y)))
+	print("[NavOverlay] A* path_found=true length=%d" % _path.size())
+
+
+## Convert a grid cell (c, r) to screen position using the ISO-PROJECTION.md transform:
+##   x = origin.x + (c - r) * cell_w / 2
+##   y = origin.y + (c + r) * cell_w / 4
+func _cell_to_screen(c: int, r: int) -> Vector2:
+	var half_w := _cell_w * 0.5
+	var quarter_w := _cell_w * 0.25
+	return Vector2(
+		_origin.x + float(c - r) * half_w,
+		_origin.y + float(c + r) * quarter_w
+	)
+
+
+## The four screen-space corners of a dimetric diamond for cell (c, r).
+## Clockwise from top: top, right, bottom, left.
+func _diamond_points(c: int, r: int) -> PackedVector2Array:
+	var ctr := _cell_to_screen(c, r)
+	var hw := _cell_w * 0.5   # half diamond width
+	var hh := _cell_w * 0.25  # half diamond height (2:1 ratio)
+	return PackedVector2Array([
+		ctr + Vector2(0.0, -hh),   # top
+		ctr + Vector2(hw,  0.0),   # right
+		ctr + Vector2(0.0,  hh),   # bottom
+		ctr + Vector2(-hw, 0.0),   # left
+	])
+
+
+func _draw() -> void:
+	if _mode == "none" or _cols <= 0 or _rows <= 0:
+		return
+
+	var blocked_set := {}
+	for b in _blocked:
+		blocked_set[b] = true
+
+	# --- Draw cell tints (full mode only, under the grid lines). ---
+	# draw_polygon(points, colors) takes a per-vertex PackedColorArray (Godot 4 CanvasItem API).
+	if _mode == "full":
+		for r in range(_rows):
+			for c in range(_cols):
+				var cell := Vector2i(c, r)
+				var pts := _diamond_points(c, r)
+				var tint: Color = COLOR_BLOCKED if blocked_set.has(cell) else COLOR_WALKABLE
+				draw_polygon(pts, PackedColorArray([tint, tint, tint, tint]))
+
+	# --- Draw grid diamond outlines. ---
+	for r in range(_rows):
+		for c in range(_cols):
+			var pts := _diamond_points(c, r)
+			# Close the polygon by appending the first point.
+			var closed := PackedVector2Array(pts)
+			closed.append(pts[0])
+			draw_polyline(closed, COLOR_GRID, LINE_WIDTH, true)
+
+	if _mode != "full":
+		return
+
+	# --- Zone anchor rings (full mode). ---
+	for anchor in _zone_anchors:
+		draw_arc(anchor, 10.0, 0.0, TAU, 20, COLOR_ZONE_RING, 2.0, true)
+
+	# --- A* path polyline + endpoints (full mode). ---
+	if _path_found and _path.size() >= 2:
+		var screen_pts := PackedVector2Array()
+		for cell in _path:
+			screen_pts.append(_cell_to_screen(cell.x, cell.y))
+		draw_polyline(screen_pts, COLOR_PATH, PATH_LINE_WIDTH, true)
+		# Start marker (green circle).
+		draw_circle(_cell_to_screen(_path[0].x, _path[0].y), 6.0, COLOR_PATH_START)
+		# End marker (orange circle).
+		var last: Vector2i = _path[_path.size() - 1]
+		draw_circle(_cell_to_screen(last.x, last.y), 6.0, COLOR_PATH_END)
+
+	# --- Actor foot dots + facing arrows (full mode). ---
+	for actor in _actors:
+		var cell: Vector2i = actor["cell"]
+		var facing: String = actor["facing"]
+		var foot := _cell_to_screen(cell.x, cell.y)
+		# Foot dot.
+		draw_circle(foot, 5.0, COLOR_ACTOR_DOT)
+		# Facing arrow: draw a line from the foot in the facing direction.
+		var dir: Vector2 = FACING_DIRS.get(facing, Vector2(0.0, 1.0))
+		var arrow_tip := foot + dir * 18.0
+		draw_line(foot, arrow_tip, COLOR_ACTOR_FACE, 2.0, true)
+		# Arrow head (two short lines branching from the tip).
+		var perp := Vector2(-dir.y, dir.x) * 5.0
+		draw_line(arrow_tip, arrow_tip - dir * 6.0 + perp, COLOR_ACTOR_FACE, 1.5, true)
+		draw_line(arrow_tip, arrow_tip - dir * 6.0 - perp, COLOR_ACTOR_FACE, 1.5, true)
+
+
+## Export nav results as a Dictionary for writing to <shot>.nav.json.
+func nav_result() -> Dictionary:
+	var path_arr := []
+	for cell in _path:
+		path_arr.append([cell.x, cell.y])
+	return {
+		"path_found": _path_found,
+		"path": path_arr,
+		"blocked_count": _blocked.size(),
+		"cols": _cols,
+		"rows": _rows,
+	}

--- a/godot/scenes/NavOverlay.gd.uid
+++ b/godot/scenes/NavOverlay.gd.uid
@@ -1,0 +1,1 @@
+uid://m1tg08gdd2rn

--- a/godot/scenes/WorldView.gd
+++ b/godot/scenes/WorldView.gd
@@ -1100,6 +1100,29 @@ func _apply_served_sprite(scope: String, texture: Texture2D) -> void:
 		actor_id, scope, tok.animation_count()])
 
 
+## Load a backdrop directly from a local filesystem path (e.g. /tmp/art/tavern.png)
+## and apply it as the BackdropPlane texture. This lets the --preview-scene harness
+## point at a freshly-generated PNG in /tmp with zero HTTP/serving overhead.
+## Returns true on success, false on load failure (logs a warning and leaves the
+## current backdrop unchanged so the procedural fallback stays visible).
+func apply_local_backdrop(path: String) -> bool:
+	if path == "":
+		push_warning("[WorldView] apply_local_backdrop: empty path")
+		return false
+	var img := Image.new()
+	var err := img.load(path)
+	if err != OK:
+		push_warning("[WorldView] apply_local_backdrop: Image.load failed for path=%s err=%d" % [path, err])
+		return false
+	var tex := ImageTexture.create_from_image(img)
+	if tex == null:
+		push_warning("[WorldView] apply_local_backdrop: ImageTexture.create_from_image returned null for path=%s" % path)
+		return false
+	_apply_texture_backdrop(tex)
+	print("[WorldView] apply_local_backdrop: ok path=%s size=%dx%d" % [path, img.get_width(), img.get_height()])
+	return true
+
+
 ## Put a real texture on the BackdropPlane and scale/center it to fill the viewport.
 func _apply_texture_backdrop(texture: Texture2D) -> void:
 	_backdrop_is_resolved = true

--- a/qa/preview_scene.sh
+++ b/qa/preview_scene.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# qa/preview_scene.sh — scene-preview harness wrapper.
+#
+# Runs the Godot --preview-scene entrypoint, which:
+#   1. Loads a JSON spec (backdrop path + nav grid + actors + path probe)
+#   2. Renders the scene with the dimetric diamond grid overlay drawn by NavOverlay.gd
+#   3. Saves a viewport screenshot PNG (real window — NOT --headless, which skips the GPU)
+#   4. Writes a nav.json sidecar with A* path results
+#
+# USAGE:
+#   qa/preview_scene.sh <spec.json> [shot.png] [overlay]
+#
+#   spec.json  — path to the scene spec JSON (required). Example format:
+#     {
+#       "backdrop": "/tmp/art/tavern.png",
+#       "nav": {"cols":12,"rows":8,"cell_w_px":72,"origin_px":[512,300],"blocked":[[3,3],[8,2],[6,5]]},
+#       "actors": [{"id":"pc","cell":[1,4],"facing":"E"},{"id":"foe","cell":[10,4],"facing":"W"}],
+#       "path_probe": {"from":[1,4],"to":[10,4]},
+#       "camera": {"zoom":1.0}
+#     }
+#
+#   shot.png   — output PNG path (default: /tmp/scene.png)
+#   overlay    — none | grid | full (default: full)
+#
+# OUTPUT:
+#   <shot.png>          — viewport screenshot with grid/path drawn
+#   <shot>.nav.json     — {"path_found":bool,"path":[[c,r],...],"blocked_count":int,...}
+#
+# EXAMPLES:
+#   # Simple corridor path (proof A):
+#   qa/preview_scene.sh /tmp/spec_clearpath.json /tmp/preview_clearpath.png full
+#
+#   # Blocked destination (proof B):
+#   qa/preview_scene.sh /tmp/spec_nopath.json /tmp/preview_nopath.png full
+#
+#   # Grid overlay only (no path or actor overlay):
+#   qa/preview_scene.sh /tmp/spec.json /tmp/scene.png grid
+#
+# CI NOTE: on a headless CI box use xvfb:
+#   xvfb-run -a -s "-screen 0 1280x720x24" qa/preview_scene.sh /tmp/spec.json
+#
+# GODOT BINARY: looks for godot at /Applications/Godot.app/Contents/MacOS/Godot on
+# macOS, then falls back to `godot` on $PATH (Linux CI, xvfb lane).
+
+set -euo pipefail
+
+SPEC="${1:-}"
+SHOT="${2:-/tmp/scene.png}"
+OVERLAY="${3:-full}"
+
+if [[ -z "$SPEC" ]]; then
+    echo "[preview_scene] ERROR: spec path required" >&2
+    echo "Usage: $0 <spec.json> [shot.png] [overlay]" >&2
+    exit 1
+fi
+
+if [[ ! -f "$SPEC" ]]; then
+    echo "[preview_scene] ERROR: spec file not found: $SPEC" >&2
+    exit 1
+fi
+
+# Locate Godot binary.
+GODOT_MAC="/Applications/Godot.app/Contents/MacOS/Godot"
+if [[ -x "$GODOT_MAC" ]]; then
+    GODOT="$GODOT_MAC"
+elif command -v godot &>/dev/null; then
+    GODOT="godot"
+else
+    echo "[preview_scene] ERROR: godot binary not found (tried $GODOT_MAC and \$PATH)" >&2
+    exit 1
+fi
+
+# Locate the godot/ project directory relative to this script (qa/ is one level up).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GODOT_PROJECT="$REPO_ROOT/godot"
+
+if [[ ! -f "$GODOT_PROJECT/project.godot" ]]; then
+    echo "[preview_scene] ERROR: godot project not found at $GODOT_PROJECT" >&2
+    exit 1
+fi
+
+echo "[preview_scene] spec=$SPEC shot=$SHOT overlay=$OVERLAY"
+echo "[preview_scene] godot=$GODOT project=$GODOT_PROJECT"
+
+# Run Godot with a real window (NOT --headless — viewport capture needs the GPU).
+# --quit-after 300 is a safety timeout (~5s at 60fps); the harness quits itself after capture.
+"$GODOT" --path "$GODOT_PROJECT" --quit-after 300 \
+    -- --preview-scene --spec "$SPEC" --shot "$SHOT" --overlay "$OVERLAY" 2>&1 \
+    | tee /tmp/preview_scene.log
+
+# Report outcome.
+NAV_JSON="${SHOT%.png}.nav.json"
+if [[ "${SHOT}" == *.png ]]; then
+    NAV_JSON="${SHOT%.png}.nav.json"
+else
+    NAV_JSON="${SHOT}.nav.json"
+fi
+
+if [[ -f "$SHOT" ]]; then
+    echo "[preview_scene] RESULT ok=true shot=$SHOT"
+else
+    echo "[preview_scene] RESULT ok=false shot_missing=$SHOT"
+fi
+
+if [[ -f "$NAV_JSON" ]]; then
+    PATH_FOUND=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('path_found', False))" "$NAV_JSON" 2>/dev/null || echo "unknown")
+    echo "[preview_scene] nav.json=$NAV_JSON path_found=$PATH_FOUND"
+else
+    echo "[preview_scene] nav.json not written: $NAV_JSON"
+fi


### PR DESCRIPTION
## Summary

Implements the Godot iteration harness (#1061) — the `--preview-scene` entrypoint that turns a JSON spec into a rendered PNG with a dimetric grid overlay and A* path in seconds. Four additive pieces, zero changes to existing demo handlers or the contract schema.

**Pieces added:**
- `godot/scenes/NavOverlay.gd` (new `Node2D`) — `_draw()` renders: dimetric 2:1 diamond grid lattice, walkable (green) / blocked (red) cell tints, zone-anchor rings, solved A* path polyline + endpoint markers via `AStarGrid2D`, actor foot-dots + facing arrows
- `godot/scenes/Main.gd` — `_run_preview_scene()` + `_arg_value()` helper; dispatched via `--preview-scene` flag in the `_on_snapshot` arg block (additive, leaves all existing handlers untouched)
- `godot/autoload/RenderProfile.gd` — `load_inline(profile: Dictionary)` so a preview can inject a profile dict without the bundled fixture
- `godot/scenes/WorldView.gd` — `apply_local_backdrop(path: String) -> bool` for zero-HTTP local PNG loading via `Image.load()` → `ImageTexture`
- `qa/preview_scene.sh` — bash wrapper; locates the Godot binary, runs the harness, echoes the PNG path and `path_found` from the nav.json sidecar

**Spec format** (documented in `NavOverlay.gd` + `qa/preview_scene.sh`):
```json
{
  "backdrop": "/tmp/art/tavern.png",
  "nav": {"cols":12,"rows":8,"cell_w_px":72,"origin_px":[512,300],"blocked":[[3,3],[8,2],[6,5]]},
  "actors": [{"id":"pc","cell":[1,4],"facing":"E"},{"id":"foe","cell":[10,4],"facing":"W"}],
  "path_probe": {"from":[1,4],"to":[10,4]},
  "camera": {"zoom":1.0}
}
```

**Grid transform** (ISO-PROJECTION.md dimetric 2:1):
`screen_x = origin.x + (c−r)*cell_w/2`, `screen_y = origin.y + (c+r)*cell_w/4`

## Verification (both run locally, real window, Apple M4)

**Proof A — clear corridor (`path_found=true`):**
```
qa/preview_scene.sh /tmp/spec_clearpath.json /tmp/preview_clearpath.png full
# nav.json: path_found=true, path length=10 (row-4 corridor from [1,4] to [10,4])
```

**Proof B — walled column (`path_found=false`):**
```
qa/preview_scene.sh /tmp/spec_nopath.json /tmp/preview_nopath.png full
# nav.json: path_found=false, path=[], blocked_count=6
```

Existing headless conformance unchanged (`--smoke-intent`, `--combat-tokens`, `--combat-replay`, `--served-finals-smoke` all intact).

## Test plan

- [ ] CI `godot-gt2` job passes (import + all existing conformance checks)
- [ ] `qa/preview_scene.sh /tmp/spec_clearpath.json` → `path_found=True` in nav.json
- [ ] `qa/preview_scene.sh /tmp/spec_nopath.json` → `path_found=False` in nav.json
- [ ] Visual review: green/red diamond tints + yellow path polyline visible on the backdrop