### PR TITLE
feat(godot): iso tactical scene interactive A* walk + --walk-demo

### DIFF
--- a/godot/scenes/Main.gd
+++ b/godot/scenes/Main.gd
@@ -111,6 +111,9 @@ func _on_snapshot(atlas: Dictionary, _combat: Dictionary, character: Dictionary)
 		if _has_arg("--preview-scene"):
 			call_deferred("_run_preview_scene")
 			return
+		if _has_arg("--walk-demo"):
+			call_deferred("_run_walk_demo")
+			return
 		_maybe_quit()
 
 
@@ -763,6 +766,19 @@ func _run_preview_scene() -> void:
 	if overlay_mode == "full" and not actors_arr.is_empty():
 		_spawn_preview_sprites(nav_block, actors_arr, spec)
 
+	# Wire the nav data to WorldView so interactive clicks / --walk-demo can walk the grid.
+	if not nav_block.is_empty():
+		_world.setup_nav(nav_block)
+		# The first non-foe actor in the spec is the "active" token for click-to-walk.
+		var first_actor: Dictionary = _first_party_actor(actors_arr)
+		if not first_actor.is_empty():
+			var a_id := String(first_actor.get("id", ""))
+			var a_cell_v: Variant = first_actor.get("cell", [0, 0])
+			var a_cell := Vector2i(0, 0)
+			if typeof(a_cell_v) == TYPE_ARRAY and (a_cell_v as Array).size() >= 2:
+				a_cell = Vector2i(int((a_cell_v as Array)[0]), int((a_cell_v as Array)[1]))
+			_world.set_active_preview_actor(a_id, a_cell)
+
 	# 3. Settle a few frames so the rendering pipeline flushes, then capture.
 	await _settle_frames(3)
 	await get_tree().create_timer(0.05).timeout
@@ -905,6 +921,219 @@ func _spawn_preview_sprites(nav: Dictionary, actors: Array, _spec: Dictionary) -
 		spawned += 1
 
 	print("[PreviewScene] spawned %d preview sprite(s)" % spawned)
+
+
+## Return the first non-foe actor from an actors array (i.e., a party/pc actor).
+## Used to designate the "active" walk token in --preview-scene and --walk-demo.
+func _first_party_actor(actors: Array) -> Dictionary:
+	for a_v in actors:
+		if typeof(a_v) != TYPE_DICTIONARY:
+			continue
+		var a: Dictionary = a_v
+		var id_lower := String(a.get("id", "")).to_lower()
+		if not id_lower.begins_with("foe") and not id_lower.begins_with("enemy"):
+			return a
+	return {}
+
+
+# ---------------------------------------------------------------------------
+# --walk-demo: interactive A* walk visual proof. Loads the tavern milestone spec
+# (from /tmp/tavern_milestone.json or a built-in inline fallback), spawns the
+# preview sprites, then SCRIPTS a click at a far cell whose straight-line path
+# crosses the blocked table cells (forcing an A* detour). Captures screenshots
+# at start, mid-walk, and end to /tmp/walk_{start,mid,end}.png, then quits.
+# ---------------------------------------------------------------------------
+func _run_walk_demo() -> void:
+	print("[Main] --walk-demo: scripted A* walk visual proof")
+
+	# Load the spec — prefer /tmp/tavern_milestone.json, else use an inline default
+	# with table-blocking cells that force a detour.
+	var spec: Dictionary = {}
+	var spec_candidates := ["/tmp/tavern_milestone.json", "/tmp/scene.json"]
+	for sp in spec_candidates:
+		if FileAccess.file_exists(sp):
+			var txt := FileAccess.get_file_as_string(sp)
+			var parsed: Variant = JSON.parse_string(txt)
+			if typeof(parsed) == TYPE_DICTIONARY:
+				spec = parsed
+				print("[WalkDemo] loaded spec from %s" % sp)
+				break
+	if spec.is_empty():
+		# Inline fallback: a 10×7 grid with a table-block cluster at [4,3],[5,3],[4,4]
+		# so a walk from [1,4] to [8,2] must arc around it rather than going straight.
+		spec = {
+			"nav": {
+				"cols": 10, "rows": 7, "cell_w_px": 56,
+				"origin_px": [548, 405],
+				"blocked": [[4,3],[5,3],[4,4],[6,2],[7,2]]
+			},
+			"actors": [
+				{"id": "pc1", "cell": [1,4], "facing": "SE"},
+				{"id": "foe1", "cell": [9,3], "facing": "W"}
+			],
+			"path_probe": {"from": [1,4], "to": [8,2]}
+		}
+		print("[WalkDemo] using inline fallback spec (no /tmp/tavern_milestone.json)")
+
+	# Detach the live feed so the fixture poll does not stomp our preview.
+	_detach_live_feed()
+
+	# Apply backdrop if the spec has one.
+	var backdrop_path: String = String(spec.get("backdrop", ""))
+	if backdrop_path != "" and FileAccess.file_exists(backdrop_path):
+		var ok: bool = _world.apply_local_backdrop(backdrop_path)
+		if not ok:
+			print("[WalkDemo] backdrop load failed — using procedural fallback")
+	else:
+		print("[WalkDemo] no backdrop or not found — using procedural fallback")
+
+	# Spawn the preview sprites.
+	var nav_block: Dictionary = {}
+	var nav_v: Variant = spec.get("nav", {})
+	if typeof(nav_v) == TYPE_DICTIONARY:
+		nav_block = nav_v
+
+	var actors_arr: Array = []
+	var actors_v: Variant = spec.get("actors", [])
+	if typeof(actors_v) == TYPE_ARRAY:
+		actors_arr = actors_v
+
+	var path_probe: Dictionary = {}
+	var probe_v: Variant = spec.get("path_probe", {})
+	if typeof(probe_v) == TYPE_DICTIONARY:
+		path_probe = probe_v
+
+	var zone_anchors: Array = []
+	var zones_v: Variant = nav_block.get("zones", [])
+	if typeof(zones_v) == TYPE_ARRAY:
+		for z in (zones_v as Array):
+			if typeof(z) == TYPE_ARRAY and (z as Array).size() >= 2:
+				zone_anchors.append(Vector2(float((z as Array)[0]), float((z as Array)[1])))
+
+	# Add a NavOverlay so the grid + solved A* path are visible.
+	var nav_overlay := preload("res://scenes/NavOverlay.gd").new()
+	nav_overlay.name = "NavOverlay"
+	nav_overlay.z_index = -5
+	nav_overlay.setup(nav_block, actors_arr, path_probe, zone_anchors, "full")
+	_world.add_child(nav_overlay)
+
+	# Spawn sprites.
+	if not actors_arr.is_empty():
+		_spawn_preview_sprites(nav_block, actors_arr, spec)
+
+	# Wire nav to WorldView.
+	if not nav_block.is_empty():
+		_world.setup_nav(nav_block)
+		var first_actor: Dictionary = _first_party_actor(actors_arr)
+		if not first_actor.is_empty():
+			var a_id := String(first_actor.get("id", ""))
+			var a_cell_v: Variant = first_actor.get("cell", [0, 0])
+			var a_cell := Vector2i(0, 0)
+			if typeof(a_cell_v) == TYPE_ARRAY and (a_cell_v as Array).size() >= 2:
+				a_cell = Vector2i(int((a_cell_v as Array)[0]), int((a_cell_v as Array)[1]))
+			_world.set_active_preview_actor(a_id, a_cell)
+
+	# Settle so the scene is fully rendered before the first screenshot.
+	await _settle_frames(3)
+	await get_tree().create_timer(0.1).timeout
+	await _settle_frames(2)
+
+	# SCREENSHOT 1 — START: the token is at its initial cell.
+	var start_img := _capture_viewport()
+	if start_img != null:
+		start_img.save_png("/tmp/walk_start.png")
+		print("[WalkDemo] screenshot: /tmp/walk_start.png (%dx%d)" % [start_img.get_width(), start_img.get_height()])
+
+	# Build the click target: the path_probe "to" cell in screen coords.
+	# This walk crosses the blocked table cells, so A* must detour.
+	var target_cell := Vector2i(8, 2)  # default far cell
+	var to_v: Variant = path_probe.get("to", null)
+	if typeof(to_v) == TYPE_ARRAY and (to_v as Array).size() >= 2:
+		target_cell = Vector2i(int((to_v as Array)[0]), int((to_v as Array)[1]))
+
+	# Verify the target is not itself blocked (sanity check).
+	var blocked_set: Dictionary = {}
+	for b in (_nav_blocked_from_spec(nav_block)):
+		blocked_set[b] = true
+	if blocked_set.has(target_cell):
+		print("[WalkDemo] target cell (%d,%d) is blocked — adjusting to (8,1)" % [target_cell.x, target_cell.y])
+		target_cell = Vector2i(8, 1)
+
+	print("[WalkDemo] scripted click target_cell=(%d,%d)" % [target_cell.x, target_cell.y])
+
+	# Compute screen position of the target cell and pass it to WorldView as a click.
+	var cell_w := float(nav_block.get("cell_w_px", 64))
+	var orig := Vector2.ZERO
+	var orig_v_2: Variant = nav_block.get("origin_px", [0, 0])
+	if typeof(orig_v_2) == TYPE_ARRAY and (orig_v_2 as Array).size() >= 2:
+		orig = Vector2(float((orig_v_2 as Array)[0]), float((orig_v_2 as Array)[1]))
+	var target_screen := Vector2(
+		orig.x + float(target_cell.x - target_cell.y) * cell_w * 0.5,
+		orig.y + float(target_cell.x + target_cell.y) * cell_w * 0.25
+	)
+
+	# Trigger the walk by calling _handle_floor_click directly (no real mouse needed).
+	print("[WalkDemo] calling _handle_floor_click at screen=(%.0f,%.0f)" % [target_screen.x, target_screen.y])
+	_world._handle_floor_click(target_screen)
+
+	# SCREENSHOT 2 — MID: wait ~half the total walk time then capture mid-walk.
+	# The walk is cell-by-cell; each step is MOVE_TWEEN_SEC = 0.45s.
+	# Estimate path length (A* on the grid); capture after roughly half the steps.
+	# We wait a fixed time since we can't easily introspect the path length here.
+	var half_walk_wait := CharacterToken.MOVE_TWEEN_SEC * 2.5  # ~2-3 steps in
+	await get_tree().create_timer(half_walk_wait).timeout
+	await _settle_frames(2)
+	var mid_img := _capture_viewport()
+	if mid_img != null:
+		mid_img.save_png("/tmp/walk_mid.png")
+		print("[WalkDemo] screenshot: /tmp/walk_mid.png (%dx%d)" % [mid_img.get_width(), mid_img.get_height()])
+
+	# SCREENSHOT 3 — END: wait for the walk to complete (generous ceiling 15s).
+	var waited := 0.0
+	while bool(_world._walking) and waited < 15.0:
+		await get_tree().create_timer(0.1).timeout
+		waited += 0.1
+	await _settle_frames(3)
+	var end_img := _capture_viewport()
+	if end_img != null:
+		end_img.save_png("/tmp/walk_end.png")
+		print("[WalkDemo] screenshot: /tmp/walk_end.png (%dx%d)" % [end_img.get_width(), end_img.get_height()])
+
+	var final_cell: Vector2i = _world._active_cell
+	print("[WalkDemo] RESULT walk_complete=%s final_cell=(%d,%d) target_cell=(%d,%d) match=%s" % [
+		str(not bool(_world._walking)),
+		final_cell.x, final_cell.y, target_cell.x, target_cell.y,
+		str(final_cell == target_cell)
+	])
+
+	# Also test blocked-cell rejection: attempt a walk to a known blocked cell.
+	var blocked_arr: Array = _nav_blocked_from_spec(nav_block)
+	if not blocked_arr.is_empty():
+		var blocked_cell: Vector2i = blocked_arr[0]
+		var b_screen := Vector2(
+			orig.x + float(blocked_cell.x - blocked_cell.y) * cell_w * 0.5,
+			orig.y + float(blocked_cell.x + blocked_cell.y) * cell_w * 0.25
+		)
+		print("[WalkDemo] testing blocked-cell rejection at cell=(%d,%d)" % [blocked_cell.x, blocked_cell.y])
+		_world._handle_floor_click(b_screen)
+		await get_tree().create_timer(0.1).timeout
+		var still_idle := not bool(_world._walking)
+		print("[WalkDemo] blocked-cell click is_noop=%s (expected true)" % str(still_idle))
+
+	call_deferred("_quit_clean")
+
+
+## Extract blocked cells from a nav spec block as Array of Vector2i. Helper for
+## _run_walk_demo to validate the target cell and test blocked-click rejection.
+func _nav_blocked_from_spec(nav: Dictionary) -> Array:
+	var out: Array = []
+	var blocked_v: Variant = nav.get("blocked", [])
+	if typeof(blocked_v) != TYPE_ARRAY:
+		return out
+	for b in (blocked_v as Array):
+		if typeof(b) == TYPE_ARRAY and (b as Array).size() >= 2:
+			out.append(Vector2i(int((b as Array)[0]), int((b as Array)[1])))
+	return out
 
 
 func _quit_clean() -> void:

--- a/godot/scenes/WorldView.gd
+++ b/godot/scenes/WorldView.gd
@@ -551,6 +551,210 @@ func reset_replay() -> void:
 
 
 # ---------------------------------------------------------------------------
+# Interactive grid-walk (#iso-interactive-walk). Store the nav spec loaded by
+# the --preview-scene harness so _unhandled_input can convert a floor click →
+# grid cell → A* path → cell-by-cell animated walk for the active token.
+# ---------------------------------------------------------------------------
+
+## The nav spec block most recently loaded via setup_nav (called from Main after
+## _run_preview_scene parses the spec JSON). Stored here so _unhandled_input can
+## access the grid transform + blocked cells without coupling to NavOverlay.
+var _nav_cols: int = 0
+var _nav_rows: int = 0
+var _nav_cell_w: float = 64.0
+var _nav_origin: Vector2 = Vector2.ZERO
+var _nav_blocked: Array = []   ## Array of Vector2i
+
+## The current cell of the ACTIVE token (the one that moves on click). Updated on
+## each successful walk step so the next click starts from the right cell.
+var _active_cell: Vector2i = Vector2i(0, 0)
+
+## True while a cell-by-cell walk coroutine is running (so a second click does not
+## start a second concurrent walk — it is ignored until the current one finishes).
+var _walking: bool = false
+
+## The actor id that is the "active" token for interactive walk (default = first party
+## actor in the spec, set by Main after spawning preview sprites via set_active_preview_actor).
+var _active_preview_actor_id: String = ""
+
+
+## Called by Main after parsing the spec JSON so WorldView knows the grid geometry.
+## Stores the nav data so _unhandled_input can invert the transform and do A*.
+func setup_nav(nav: Dictionary) -> void:
+	_nav_cols = int(nav.get("cols", 0))
+	_nav_rows = int(nav.get("rows", 0))
+	_nav_cell_w = float(nav.get("cell_w_px", 64))
+	var orig_v: Variant = nav.get("origin_px", [0, 0])
+	if typeof(orig_v) == TYPE_ARRAY and (orig_v as Array).size() >= 2:
+		_nav_origin = Vector2(float((orig_v as Array)[0]), float((orig_v as Array)[1]))
+	_nav_blocked.clear()
+	var blocked_v: Variant = nav.get("blocked", [])
+	if typeof(blocked_v) == TYPE_ARRAY:
+		for b in (blocked_v as Array):
+			if typeof(b) == TYPE_ARRAY and (b as Array).size() >= 2:
+				_nav_blocked.append(Vector2i(int((b as Array)[0]), int((b as Array)[1])))
+	print("[NavWalk] setup_nav cols=%d rows=%d cell_w=%.0f blocked=%d" % [
+		_nav_cols, _nav_rows, _nav_cell_w, _nav_blocked.size()])
+
+
+## Set which actor is the "active" one for interactive walk, and what cell it starts on.
+func set_active_preview_actor(actor_id: String, start_cell: Vector2i) -> void:
+	_active_preview_actor_id = actor_id
+	_active_cell = start_cell
+	print("[NavWalk] active actor=%s start_cell=(%d,%d)" % [actor_id, start_cell.x, start_cell.y])
+
+
+## Convert a screen position (WorldView-local px) to a grid cell using the inverse
+## of the dimetric 2:1 transform from ISO-PROJECTION.md:
+##   dx = sx - origin.x,  dy = sy - origin.y
+##   c  = ( (2*dx/cell_w) + (4*dy/cell_w) ) / 2
+##   r  = ( (4*dy/cell_w) - (2*dx/cell_w) ) / 2
+## Returns Vector2i(-1,-1) if the result is out of grid bounds.
+func _screen_to_cell(screen_pos: Vector2) -> Vector2i:
+	if _nav_cols <= 0 or _nav_rows <= 0 or _nav_cell_w <= 0.0:
+		return Vector2i(-1, -1)
+	var dx := screen_pos.x - _nav_origin.x
+	var dy := screen_pos.y - _nav_origin.y
+	var c := int(round(((2.0 * dx / _nav_cell_w) + (4.0 * dy / _nav_cell_w)) / 2.0))
+	var r := int(round(((4.0 * dy / _nav_cell_w) - (2.0 * dx / _nav_cell_w)) / 2.0))
+	if c < 0 or c >= _nav_cols or r < 0 or r >= _nav_rows:
+		return Vector2i(-1, -1)
+	return Vector2i(c, r)
+
+
+## Convert a grid cell (c, r) to screen position — same as NavOverlay._cell_to_screen.
+func _cell_to_screen_nav(c: int, r: int) -> Vector2:
+	return Vector2(
+		_nav_origin.x + float(c - r) * _nav_cell_w * 0.5,
+		_nav_origin.y + float(c + r) * _nav_cell_w * 0.25
+	)
+
+
+## Build an AStarGrid2D for the current nav spec (same settings as NavOverlay._solve_astar).
+func _build_nav_grid() -> AStarGrid2D:
+	var grid := AStarGrid2D.new()
+	grid.region = Rect2i(0, 0, _nav_cols, _nav_rows)
+	grid.diagonal_mode = AStarGrid2D.DIAGONAL_MODE_AT_LEAST_ONE_WALKABLE
+	grid.cell_shape = AStarGrid2D.CELL_SHAPE_SQUARE
+	grid.update()
+	for b in _nav_blocked:
+		grid.set_point_solid(b, true)
+	return grid
+
+
+## Handle a left floor click: convert to grid cell, solve A*, walk the active token
+## along the path cell-by-cell. Called from _unhandled_input.
+func _handle_floor_click(screen_pos: Vector2) -> void:
+	if _active_preview_actor_id == "" or _nav_cols <= 0:
+		return
+	if _walking:
+		print("[NavWalk] ignoring click — walk already in progress")
+		return
+
+	# Convert screen → cell.
+	var target_cell := _screen_to_cell(screen_pos)
+	if target_cell.x < 0:
+		print("[NavWalk] click out of grid bounds — no move")
+		return
+
+	# Reject blocked cells.
+	for b in _nav_blocked:
+		if b == target_cell:
+			print("[NavWalk] click on blocked cell (%d,%d) — no move" % [target_cell.x, target_cell.y])
+			return
+
+	# Build the grid and solve the path.
+	var grid := _build_nav_grid()
+	var id_path := grid.get_id_path(_active_cell, target_cell)
+	if id_path.is_empty():
+		print("[NavWalk] no A* path from (%d,%d) to (%d,%d) — no move" % [
+			_active_cell.x, _active_cell.y, target_cell.x, target_cell.y])
+		return
+
+	# Convert PackedVector2Array → Array of Vector2i (grid ids).
+	var path: Array = []
+	for p in id_path:
+		path.append(Vector2i(int(p.x), int(p.y)))
+
+	print("[NavWalk] walking actor=%s path_len=%d from=(%d,%d) to=(%d,%d)" % [
+		_active_preview_actor_id, path.size(),
+		_active_cell.x, _active_cell.y, target_cell.x, target_cell.y])
+
+	# Walk the token along the path.
+	_walk_along_path(path)
+
+
+## Coroutine: walk the active preview token along a grid path, one cell at a time.
+## Each step: set facing (octant of segment), set walk anim, tween to next cell,
+## await; on arrival set idle.
+func _walk_along_path(path: Array) -> void:
+	_walking = true
+	var tok: CharacterToken = _get_active_preview_token()
+	if tok == null:
+		_walking = false
+		return
+
+	# Skip the first cell (it is the current position).
+	for i in range(1, path.size()):
+		tok = _get_active_preview_token()
+		if tok == null:
+			break
+		var from_cell: Vector2i = path[i - 1]
+		var to_cell: Vector2i = path[i]
+		var from_screen := _cell_to_screen_nav(from_cell.x, from_cell.y)
+		var to_screen := _cell_to_screen_nav(to_cell.x, to_cell.y)
+
+		# Derive 8-way facing for this segment.
+		var facing := FacingResolver.octant(from_screen, to_screen, FACING_ORDER)
+		tok.set_facing(facing)
+		tok.set_anim("walk")
+
+		# Tween to the next cell's screen position.
+		tok.set_zone_target(to_screen)
+		_token_prev_pos[_active_preview_actor_id] = to_screen
+		_active_cell = to_cell
+
+		# Await the tween duration.
+		await get_tree().create_timer(CharacterToken.MOVE_TWEEN_SEC).timeout
+
+	# Arrived — return to idle.
+	tok = _get_active_preview_token()
+	if tok != null:
+		tok.set_anim("idle")
+		print("[NavWalk] walk complete, actor=%s final_cell=(%d,%d)" % [
+			_active_preview_actor_id, _active_cell.x, _active_cell.y])
+
+	_walking = false
+
+
+## Return the active preview token (or null if not found / freed).
+func _get_active_preview_token() -> CharacterToken:
+	var ysort := get_node_or_null("YSortLayer") as Node2D
+	if ysort == null:
+		return null
+	var node_name := "PreviewToken_" + _active_preview_actor_id
+	var tok := ysort.get_node_or_null(node_name) as CharacterToken
+	if tok == null or not is_instance_valid(tok):
+		return null
+	return tok
+
+
+## Handle unhandled input for interactive walk (only active when nav is configured).
+func _unhandled_input(event: InputEvent) -> void:
+	if _nav_cols <= 0 or _active_preview_actor_id == "":
+		return
+	if not (event is InputEventMouseButton):
+		return
+	var mb := event as InputEventMouseButton
+	if mb.button_index != MOUSE_BUTTON_LEFT or not mb.pressed:
+		return
+	# Convert the global mouse position to WorldView-local coordinates.
+	var local_pos := to_local(mb.global_position)
+	_handle_floor_click(local_pos)
+	get_viewport().set_input_as_handled()
+
+
+# ---------------------------------------------------------------------------
 # #1055 — input-facing query surface (consumed by InputController). All of these
 # are PURE reads of the already-projected scene; none mutate or assert state.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Click-to-walk on the iso grid**: `WorldView._unhandled_input` converts a left-click to a grid cell (inverse dimetric-2:1 transform), builds an `AStarGrid2D` with the loaded nav spec, solves the path, and walks the active token **cell-by-cell** with the walk animation and correct 8-way facing (via `FacingResolver.octant`) per segment. A click on a blocked or out-of-bounds cell is a silent no-op.
- **`--walk-demo` flag** (additive, like `--demo-occlusion`): loads `/tmp/tavern_milestone.json`, spawns the preview sprites, scripts a click at cell `(8,2)` whose straight-line path crosses the blocked table cluster `([4,3],[5,3],[4,4])`, walks the token, captures three screenshots (`/tmp/walk_start.png`, `/tmp/walk_mid.png`, `/tmp/walk_end.png`), tests blocked-cell rejection, then quits.

## Key changes

**`godot/scenes/WorldView.gd`** (204 lines added):
- `setup_nav(nav)` — stores grid geometry (cols/rows/cell_w/origin/blocked) from the spec block
- `set_active_preview_actor(id, cell)` — designates the click-movable token + its starting cell
- `_screen_to_cell(pos)` — inverse of the dimetric 2:1 transform (`c = ((2dx/w)+(4dy/w))/2`, etc.)
- `_build_nav_grid()` — `AStarGrid2D` with `DIAGONAL_MODE_AT_LEAST_ONE_WALKABLE` (mirrors `NavOverlay._solve_astar`)
- `_walk_along_path(path)` — coroutine: per step set facing, set walk anim, tween to next cell, await; idle on arrival
- `_unhandled_input(event)` — left-click → `_handle_floor_click()`, ignored while `_walking == true`

**`godot/scenes/Main.gd`** (229 lines added):
- `_run_preview_scene`: wires `setup_nav` + `set_active_preview_actor` after spawning sprites (so `--preview-scene` is interactive too)
- `_run_walk_demo()` — the scripted visual proof with 3 screenshots + blocked-cell rejection test
- `_first_party_actor()`, `_nav_blocked_from_spec()` — small helpers

## Test plan

- [x] `godot --headless --path godot --import` succeeds (no GDScript parse errors)
- [x] `--walk-demo` ran: `walk_complete=true`, `final_cell=(8,2)==target_cell`, `blocked-cell click is_noop=true`
- [x] `/tmp/walk_start.png` — pc1 token at start cell `(1,4)`, lower-left
- [x] `/tmp/walk_mid.png` — token visibly mid-path, multiple cells right/up from start
- [x] `/tmp/walk_end.png` — token arrived at `(8,2)` beside foe1, path visibly arcs around the table block cluster (red cells)
- [x] Additive: no existing conformance/demo flags broken; `--preview-scene` / `--demo-occlusion` / `--combat-replay` unchanged