### PR TITLE
feat(engine): SceneGrid emitter — engine sole-writer per-location spatial layout (A1)

### DIFF
--- a/docs/roadmap/contracts/render-profile.schema.json
+++ b/docs/roadmap/contracts/render-profile.schema.json
@@ -54,6 +54,48 @@
                 "type": "array",
                 "description": "Named tactical regions for this location, mirroring the engine's Zone vocabulary ('the dais', 'the rafters'). NOT coordinates.",
                 "items": { "type": "string" }
+              },
+              "scene_grid": {
+                "type": ["object", "null"],
+                "description": "ADDITIVE (A1 SceneGrid emitter). The engine-authored deterministic procedural spatial layout for this location (grid extents + per-cell floor/wall/prop map + props/occluders + zone_anchors + exits + spawns + lighting + a Tier-2 art cache slot). The Unity Tier-1 block-out renderer draws straight from it; the Tier-2 painterly upgrade conditions a Scenario ControlNet render on the SAME grid. Engine sole-writer; absent/null == today (the renderer falls back to its default grid). UNLIKE core's named-zone positioning, scene_grid DOES carry authoritative cell coordinates — this is the always-present generalization of the combat #461 x/y carve-out, NOT a change to the v1 named-zone combat positioning. Shape mirrors servers/engine/scene_grid.py:SceneGrid; additionalProperties:true keeps the contract forward-compatible as the emitter grows per-kind fields.",
+                "additionalProperties": true,
+                "properties": {
+                  "scene_id": { "type": "string", "description": "Deterministic key '<world_id>:<location_id>'." },
+                  "location_id": { "type": "string", "description": "FK to the engine Location id." },
+                  "kind": { "type": "string", "description": "tavern|dungeon|forest|town|cave|road|interior|..." },
+                  "biome": { "type": "string", "description": "Material/mood hint for the painterly gen." },
+                  "seed": { "type": "integer", "description": "Deterministic seed derived from (world_id, location_id)." },
+                  "grid": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "properties": {
+                      "cols": { "type": "integer" },
+                      "rows": { "type": "integer" },
+                      "cell_size_ft": { "type": "integer" },
+                      "projection": { "type": "string" }
+                    }
+                  },
+                  "cell_default": { "type": "object", "additionalProperties": true },
+                  "cells": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+                  "props": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+                  "zone_anchors": { "type": "object", "additionalProperties": true },
+                  "exits": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+                  "spawns": { "type": "object", "additionalProperties": true },
+                  "lighting": { "type": "object", "additionalProperties": true },
+                  "art": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Tier-2 painterly cache slot, filled async. status: tier1_blockout|tier2_pending|tier2_ready.",
+                    "properties": {
+                      "layout_hash": { "type": "string" },
+                      "backdrop_ref": { "type": ["string", "null"] },
+                      "depth_ref": { "type": ["string", "null"] },
+                      "walkmask_ref": { "type": ["string", "null"] },
+                      "status": { "type": "string" },
+                      "critic_score": { "type": ["number", "null"] }
+                    }
+                  }
+                }
               }
             }
           }

--- a/servers/engine/content.py
+++ b/servers/engine/content.py
@@ -43,6 +43,7 @@ from models import (
     WorldGraphNode,
     WorldState,
 )
+from scene_grid import ensure_scene_grid  # A1 SceneGrid emitter (engine sole-writer)
 from store import safe_path_segment  # path-containment guard for world/adventure ids
 
 
@@ -2187,5 +2188,15 @@ def seed_world(world: dict, start_at: str = "", ending: str = "") -> Campaign:
     # goal_ref binding. Additive + degrade-not-abort: a world with no anchors yields an empty
     # backlog (today's behavior); `last_tick_day` is set to c.day so the first advance owes nothing.
     _seed_campaign_backlog(c, world)
+
+    # A1 — the SceneGrid emitter (engine sole-writer): emit a deterministic procedural
+    # spatial layout per seeded location, so the Unity Tier-1 block-out renderer has a
+    # grid to draw the moment the world exists. GUARDED (ensure_scene_grid skips any
+    # location that already has one) + ADDITIVE (each grid is seeded off (world_id,
+    # location_id), isolated from the global combat dice stream; an old snapshot lacking
+    # the field round-trips to None and behaves exactly as today). Runs LAST, after every
+    # region/area is seeded above, and BEFORE the caller saves the campaign.
+    for loc in c.locations.values():
+        ensure_scene_grid(c.world_id, loc)
 
     return c

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1156,6 +1156,17 @@ class Location(_StrictModel):
     # Spatial "walk-time" context (fables-style) — ADDITIVE; empty = today's behavior.
     region: str = ""  # the parent zone this location nests in ("South West Odrun Fell")
     travel_times: dict[str, int] = Field(default_factory=dict)  # connected location id -> walk minutes
+    # The engine-authored SceneGrid for this location (the A1 SceneGrid emitter) — ADDITIVE.
+    # A deterministic procedural floor/wall/prop layout the Unity Tier-1 block-out renderer
+    # draws straight from (and the Tier-2 painterly upgrade conditions on). The engine is the
+    # SOLE WRITER: emitted at location creation (seed_world / travel_to / add_location), seeded
+    # off (world_id, location_id) so it is reproducible, and isolated from the global combat
+    # dice stream. Default None == today's behavior EXACTLY: an old snapshot lacking the field
+    # round-trips to None, the viewer falls back to its legacy 16x10 default grid, and nothing
+    # in the engine reads this field (it only enriches the snapshot the renderer consumes). The
+    # model lives in scene_grid.py (imported + the forward-ref rebuilt at the foot of this file
+    # to keep models.py the foundational, dependency-free module). See scene_grid.py.
+    scene_grid: Optional["SceneGrid"] = None
 
 
 class WorldGraphNode(_StrictModel):
@@ -2107,3 +2118,22 @@ class Campaign(_StrictModel):
     # get_campaign_director. Resolved debts are marked in-place (resolved=True) by
     # resolve_scene_debt and then preserved here as an audit trail.
     scene_debts: list[SceneDebt] = Field(default_factory=list)
+
+
+# ── Deferred import: resolve the Location.scene_grid forward reference ────────────────
+# scene_grid.py imports _StrictModel from THIS module, so the dependency points one way
+# (scene_grid -> models). We import it at the FOOT of models.py — after every model above
+# is defined — and rebuild Location so its ``Optional["SceneGrid"]`` forward annotation
+# resolves. This keeps models.py the foundational module (no top-level dependency on
+# scene_grid) while letting Location carry a fully-typed, strictly-validated SceneGrid.
+from scene_grid import (  # noqa: E402  (deliberate end-of-module import to break the cycle)
+    SceneArt,
+    SceneCell,
+    SceneCellDefault,
+    SceneGrid,
+    SceneGridSpec,
+    SceneLighting,
+    SceneProp,
+)
+
+Location.model_rebuild()

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -15,7 +15,14 @@ from enum import Enum
 from typing import Annotated, Any, Literal, Optional
 from uuid import uuid4
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, model_validator
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    model_serializer,
+    model_validator,
+)
 
 
 def _coerce_list(v):
@@ -1167,6 +1174,31 @@ class Location(_StrictModel):
     # model lives in scene_grid.py (imported + the forward-ref rebuilt at the foot of this file
     # to keep models.py the foundational, dependency-free module). See scene_grid.py.
     scene_grid: Optional["SceneGrid"] = None
+
+    @model_serializer(mode="wrap")
+    def _ser_omit_none_scene_grid(self, handler):
+        """OMIT ``scene_grid`` from the dump when it is None so a grid-less Location
+        serializes BYTE-IDENTICALLY to a pre-A1 snapshot (which never carried the key).
+
+        Why this matters (and why it is narrowly scoped to ONE key, NOT a blanket
+        ``exclude_none``): the store's F08-2 dirty-skip (store.py:135-148) byte-compares
+        the candidate ``campaign.model_dump_json()`` to disk so a pure load->save with no
+        mutation is a no-op that does NOT bump ``updated_at`` / steal the #640
+        "most-recently-updated == live" pointer. With ``scene_grid`` defaulting to None,
+        an unconditional Pydantic dump emits ``"scene_grid": null`` for EVERY (incl.
+        grid-less) location — a key an un-migrated on-disk snapshot lacks — so the
+        candidate no longer matches disk, the dirty-skip is defeated, and a cross-campaign
+        inspect (check_*/world_tick/scene_context) silently rewrites + re-stamps the file.
+
+        This wrap serializer runs through BOTH model_dump and model_dump_json and through
+        nested serialization (Location lives inside Campaign.locations), preserving ALL
+        other keys, order, and every other ``Optional=None`` field (e.g. ``hex``) exactly
+        as before — it only drops ``scene_grid`` when it is None. A grid-FUL Location
+        serializes ``scene_grid`` normally."""
+        data = handler(self)
+        if self.scene_grid is None:
+            data.pop("scene_grid", None)
+        return data
 
 
 class WorldGraphNode(_StrictModel):

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -2158,14 +2158,6 @@ class Campaign(_StrictModel):
 # is defined — and rebuild Location so its ``Optional["SceneGrid"]`` forward annotation
 # resolves. This keeps models.py the foundational module (no top-level dependency on
 # scene_grid) while letting Location carry a fully-typed, strictly-validated SceneGrid.
-from scene_grid import (  # noqa: E402  (deliberate end-of-module import to break the cycle)
-    SceneArt,
-    SceneCell,
-    SceneCellDefault,
-    SceneGrid,
-    SceneGridSpec,
-    SceneLighting,
-    SceneProp,
-)
+from scene_grid import SceneGrid  # noqa: E402  (deliberate end-of-module import to break the cycle — only SceneGrid needed to resolve Location's Optional["SceneGrid"] forward ref; nested types are concrete within scene_grid.py and need not be in models' namespace)
 
 Location.model_rebuild()

--- a/servers/engine/scene_grid.py
+++ b/servers/engine/scene_grid.py
@@ -1,0 +1,381 @@
+"""SceneGrid — the engine-authored, deterministic per-location spatial layout (A1).
+
+The Python engine is the SOLE WRITER of a ``SceneGrid``: a procedural floor/wall/prop
+layout per location, emitted at location-creation time (seed_world / travel_to /
+add_location) and persisted on ``Location.scene_grid``. The Unity Tier-1 block-out
+renderer draws straight from it; the Tier-2 painterly upgrade conditions a Scenario
+ControlNet render on the same grid (see the contract at
+worldos-session-notes/2026-06-22-unity-pivot/scene-grid-contract.md and the validated
+fixture LEXAR/WorldOS-Unity-spike/fixtures/tavern.scenegrid.json).
+
+LOAD-BEARING INVARIANTS (honored here):
+  * **Additive-by-default.** ``Location.scene_grid`` defaults to ``None`` — an old
+    snapshot round-trips to ``None`` and behaves exactly as today. Empty == today.
+  * **_StrictModel (extra="forbid").** Every model below rejects unknown fields, so a
+    typo'd field raises instead of silently vanishing.
+  * **Deterministic.** The layout is generated from a LOCAL ``random.Random`` seeded off
+    ``f"{world_id}:{location_id}"`` (the same string-seed pattern seed_world already uses
+    for quest variants / questgen). It NEVER touches the global combat dice stream
+    (``dice.reseed_process_rng``), so "the engine rolls combat" stays untouched.
+  * **Disjoint from the #461 combat grid.** ``combat_grid.py`` (zone-based combat
+    positioning, the authoritative x/y carve-out) is not imported or modified here; a
+    SceneGrid is set-dressing/presentation DATA, not combat positioning.
+
+This module is pure (no I/O, no MCP, no campaign lock). The emit hooks in content.py /
+travel.py / server.py wrap ``emit_scene_grid`` and persist via the existing save path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import random
+from typing import Literal, Optional
+
+from pydantic import Field
+
+from models import _StrictModel
+
+# Coordinate convention (matches the fixture): [col, row], col 0..cols-1 left->right,
+# row 0..rows-1 back->front. Any in-bounds cell NOT listed in ``cells`` is ``cell_default``.
+Cell = tuple[int, int]
+
+
+class SceneGridSpec(_StrictModel):
+    """Grid extents + projection. Mirrors the fixture's ``grid`` block."""
+
+    cols: int = Field(0, ge=0)
+    rows: int = Field(0, ge=0)
+    cell_size_ft: int = Field(5, ge=1)
+    projection: str = "dimetric-2to1"
+
+
+class SceneCellDefault(_StrictModel):
+    """The default fill for any in-bounds cell not explicitly listed in ``cells``."""
+
+    type: str = "floor"
+    walkable: bool = True
+    cost: int = Field(1, ge=0)
+
+
+class SceneCell(_StrictModel):
+    """A single explicitly-typed cell. ``type`` is a free string (the renderer maps it):
+    floor|wall|door|prop|water|void|low_wall|..."""
+
+    c: int = Field(..., ge=0)
+    r: int = Field(..., ge=0)
+    type: str = "floor"
+    walkable: bool = True
+    cost: int = Field(1, ge=0)
+    elevation: int = 0
+    prop_ref: Optional[str] = None
+
+
+class SceneProp(_StrictModel):
+    """Set dressing + occluder. ``cells`` are the footprint; ``anchor_cell`` is where the
+    renderer pins the sprite/proxy. ``occluder``/``height_band`` drive the Tier-2 depth
+    occluder-proxies (so they stay load-bearing per the contract's ★ CORRECTION)."""
+
+    id: str
+    kind: str
+    cells: list[Cell] = Field(default_factory=list)
+    anchor_cell: Optional[Cell] = None
+    occluder: bool = False
+    height_band: Literal["low", "mid", "tall"] = "mid"
+    silhouette: str = ""
+
+
+class SceneLighting(_StrictModel):
+    """Feeds BOTH the painterly-gen prompt AND the Unity actor-relight (so actors match
+    the scene key light). ``key_dir_deg`` is the key-light azimuth in degrees."""
+
+    key_dir_deg: int = 0
+    key_color: str = "#ffffff"
+    ambient_color: str = "#3a3f55"
+    mood: str = ""
+
+
+class SceneArt(_StrictModel):
+    """Tier-2 cache slot, filled async by the painterly-upgrade workflow. The engine sets
+    ``status="tier1_blockout"`` + ``layout_hash`` at emit time; the async pipeline fills
+    the *_ref scope keys + ``critic_score`` and flips ``status`` to tier2_pending/ready."""
+
+    layout_hash: str = ""
+    backdrop_ref: Optional[str] = None
+    depth_ref: Optional[str] = None
+    walkmask_ref: Optional[str] = None
+    status: Literal["tier1_blockout", "tier2_pending", "tier2_ready"] = "tier1_blockout"
+    critic_score: Optional[float] = None
+
+
+class SceneGrid(_StrictModel):
+    """The engine-authored spatial layout for ONE location. Additive: present only when
+    the engine has emitted one; absent (``Location.scene_grid is None``) == today."""
+
+    scene_id: str
+    location_id: str
+    kind: str = "interior"
+    biome: str = ""
+    seed: int = 0
+    grid: SceneGridSpec = Field(default_factory=SceneGridSpec)
+    cell_default: SceneCellDefault = Field(default_factory=SceneCellDefault)
+    cells: list[SceneCell] = Field(default_factory=list)
+    props: list[SceneProp] = Field(default_factory=list)
+    zone_anchors: dict[str, Cell] = Field(default_factory=dict)
+    exits: list[dict] = Field(default_factory=list)
+    spawns: dict[str, list[Cell]] = Field(default_factory=dict)
+    lighting: SceneLighting = Field(default_factory=SceneLighting)
+    art: SceneArt = Field(default_factory=SceneArt)
+
+
+# ── Deterministic seed derivation ───────────────────────────────────────────────────
+
+
+def derive_seed(world_id: str, location_id: str) -> int:
+    """A stable non-negative 31-bit int derived from (world_id, location_id) via SHA-256.
+
+    Used as the SceneGrid's ``seed`` field AND the seed of the LOCAL ``random.Random``
+    that draws the layout. Deterministic + reproducible (same inputs -> same int -> same
+    layout) and salt-free, so it survives process restarts and a re-emit on the same
+    location is byte-identical. Does NOT touch the global dice stream."""
+    h = hashlib.sha256(f"{world_id}:{location_id}".encode("utf-8")).hexdigest()
+    return int(h[:8], 16) % (2**31)
+
+
+def _layout_hash(grid: SceneGrid) -> str:
+    """A short content hash over the structural layout (grid + cells + props) — the Tier-2
+    cache key + invalidation handle. Excludes the async ``art`` block (it would otherwise
+    invalidate itself). Deterministic ordering: cells/props are emitted in a fixed order."""
+    payload = grid.model_dump(
+        mode="json",
+        include={"grid", "cell_default", "cells", "props", "spawns", "exits", "zone_anchors", "lighting"},
+    )
+    blob = repr(payload).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:16]
+
+
+# ── Per-kind procedural generators ──────────────────────────────────────────────────
+
+
+def _gen_tavern(scene_id: str, location_id: str, seed: int, rng: random.Random) -> SceneGrid:
+    """A procedural tavern matching the fixture's SHAPE: perimeter walls, a bar along the
+    back-left, a lit stone hearth (the warm key light) on the back-right, a couple of
+    tables, a stack of barrels, party spawns by the entrance + a couple of foe spawns
+    inside, warm candlelit lighting. Deterministic from ``rng`` (size + a little jitter)."""
+    # Modest size jitter so taverns aren't all identical, but always large enough for the
+    # fixture's furniture + walkable interior (>= the fixture's 14x10).
+    cols = 14 + rng.randint(0, 2)   # 14..16
+    rows = 10 + rng.randint(0, 2)   # 10..12
+
+    cells: list[SceneCell] = []
+    walls: set[Cell] = set()
+
+    # Perimeter walls on the three back/side runs (the front row is the open entrance wall
+    # with a door gap), matching the fixture: full back wall (row 0) + left/right columns.
+    for c in range(cols):
+        walls.add((c, 0))
+    for r in range(1, rows - 1):
+        walls.add((0, r))
+        walls.add((cols - 1, r))
+    for (c, r) in sorted(walls):
+        cells.append(SceneCell(c=c, r=r, type="wall", walkable=False))
+
+    props: list[SceneProp] = []
+
+    def _place_prop(pid: str, kind: str, footprint: list[Cell], band: str,
+                    silhouette: str, occluder: bool = True) -> None:
+        anchor = footprint[0]
+        props.append(SceneProp(
+            id=pid, kind=kind, cells=footprint, anchor_cell=anchor,
+            occluder=occluder, height_band=band, silhouette=silhouette,
+        ))
+        for (c, r) in footprint:
+            cells.append(SceneCell(c=c, r=r, type="prop", walkable=False, prop_ref=pid))
+
+    # The bar: a 4-cell counter along the back-left interior (row 1).
+    bar_cells = [(c, 1) for c in range(1, 5)]
+    _place_prop("bar", "bar_counter", bar_cells, "tall",
+                "long waist-high wooden counter with bottles/shelf behind")
+
+    # The hearth: 2 cells on the back-right interior (row 1) — the warm key light source.
+    hearth_cells = [(cols - 3, 1), (cols - 2, 1)]
+    _place_prop("hearth", "stone_hearth", hearth_cells, "tall",
+                "large stone fireplace, fire lit (the warm key light source)")
+
+    # Two tables in the mid-floor, jittered within safe interior bounds.
+    t1_c = 3 + rng.randint(0, 1)
+    t1_r = 4
+    table1_cells = [(t1_c, t1_r), (t1_c + 1, t1_r)]
+    _place_prop("table1", "round_table", table1_cells, "mid",
+                "round wooden table with stools, mugs")
+
+    t2_c = (cols // 2) + 1 + rng.randint(0, 1)
+    t2_r = 5
+    table2_cells = [(t2_c, t2_r), (t2_c + 1, t2_r)]
+    _place_prop("table2", "long_table", table2_cells, "mid",
+                "long trestle table with benches")
+
+    # A barrel stack low against the left, a couple rows up from the entrance.
+    barrel_cell = (2, rows - 3)
+    _place_prop("barrels", "barrels", [barrel_cell], "low",
+                "stacked ale barrels", occluder=True)
+
+    # De-dup any accidental overlap (jitter could in theory collide a table with a wall):
+    # keep the FIRST cell entry for any (c,r) and drop later duplicates so the cell list
+    # stays a clean single-typed map (deterministic — input order is fixed above).
+    seen: set[Cell] = set()
+    deduped: list[SceneCell] = []
+    for sc in cells:
+        key = (sc.c, sc.r)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(sc)
+    cells = deduped
+
+    # Zone anchors for engine zone positioning + DM narration hooks (mirrors the fixture).
+    mid_c = cols // 2
+    zone_anchors: dict[str, Cell] = {
+        "the bar": (3, 2),
+        "the hearth": (cols - 3, 2),
+        "the entrance": (mid_c, rows - 1),
+        "center floor": (mid_c, rows // 2),
+    }
+
+    # The door + party/foe spawns near the entrance (front), foes a couple cells inside.
+    exits = [{"cell": [mid_c, rows - 1], "to_location_id": "", "label": "the door to the street"}]
+    spawns = {
+        "party": [(mid_c - 1, rows - 2), (mid_c, rows - 2), (mid_c + 1, rows - 2)],
+        "foes": [(mid_c - 1, 2), (mid_c + 1, 3)],
+    }
+
+    lighting = SceneLighting(
+        key_dir_deg=210,
+        key_color="#ff9a45",
+        ambient_color="#3a3f55",
+        mood="warm candlelit, firelight from the right-side hearth, cool shadow fill",
+    )
+
+    grid = SceneGrid(
+        scene_id=scene_id,
+        location_id=location_id,
+        kind="tavern",
+        biome="warm candlelit stone-and-timber tavern interior",
+        seed=seed,
+        grid=SceneGridSpec(cols=cols, rows=rows, cell_size_ft=5, projection="dimetric-2to1"),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=cells,
+        props=props,
+        zone_anchors=zone_anchors,
+        exits=exits,
+        spawns=spawns,
+        lighting=lighting,
+    )
+    grid.art.layout_hash = _layout_hash(grid)
+    grid.art.status = "tier1_blockout"
+    return grid
+
+
+def _gen_default(scene_id: str, location_id: str, kind: str, seed: int,
+                 rng: random.Random) -> SceneGrid:
+    """A safe generic interior for any kind we don't yet have a bespoke generator for:
+    a perimeter-walled room with a door gap, no props, party spawns at the entrance. This
+    keeps the emitter total (every location gets a valid, walkable Tier-1 block-out) while
+    we add richer per-kind generators incrementally."""
+    cols = 12 + rng.randint(0, 2)
+    rows = 9 + rng.randint(0, 2)
+
+    cells: list[SceneCell] = []
+    for c in range(cols):
+        cells.append(SceneCell(c=c, r=0, type="wall", walkable=False))
+    for r in range(1, rows - 1):
+        cells.append(SceneCell(c=0, r=r, type="wall", walkable=False))
+        cells.append(SceneCell(c=cols - 1, r=r, type="wall", walkable=False))
+
+    mid_c = cols // 2
+    zone_anchors = {
+        "the entrance": (mid_c, rows - 1),
+        "center floor": (mid_c, rows // 2),
+    }
+    exits = [{"cell": [mid_c, rows - 1], "to_location_id": "", "label": "the way out"}]
+    spawns = {"party": [(mid_c - 1, rows - 2), (mid_c, rows - 2), (mid_c + 1, rows - 2)]}
+
+    grid = SceneGrid(
+        scene_id=scene_id,
+        location_id=location_id,
+        kind=kind or "interior",
+        biome="",
+        seed=seed,
+        grid=SceneGridSpec(cols=cols, rows=rows, cell_size_ft=5, projection="dimetric-2to1"),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=cells,
+        zone_anchors=zone_anchors,
+        exits=exits,
+        spawns=spawns,
+    )
+    grid.art.layout_hash = _layout_hash(grid)
+    grid.art.status = "tier1_blockout"
+    return grid
+
+
+# Registry of per-kind generators. Add a bespoke generator here as each kind is authored;
+# anything not listed falls back to the generic interior.
+_GENERATORS = {
+    "tavern": _gen_tavern,
+}
+
+
+def _infer_kind(name: str, notes: str) -> str:
+    """Best-effort scene KIND from a Location's free text (name + notes/tags). The engine
+    has no explicit per-location ``kind`` field, so we infer one for the generator pick.
+    Conservative: only the kinds we have a bespoke generator for are matched; everything
+    else falls through to the generic interior."""
+    text = f"{name} {notes}".lower()
+    if any(w in text for w in ("tavern", "inn", "alehouse", "pub", "taproom")):
+        return "tavern"
+    return "interior"
+
+
+def emit_scene_grid(
+    world_id: str,
+    location_id: str,
+    *,
+    name: str = "",
+    notes: str = "",
+    kind: str = "",
+) -> SceneGrid:
+    """Emit a deterministic ``SceneGrid`` for one location (the engine's sole-writer hook).
+
+    The layout is generated from a LOCAL ``random.Random`` seeded off
+    ``derive_seed(world_id, location_id)`` — deterministic, reproducible, and isolated from
+    the global combat dice stream. ``kind`` is taken as given, else inferred from name/notes.
+    Callers (content.seed_world / travel.travel_to / server.add_location) GUARD re-entry
+    (skip if ``Location.scene_grid`` is already present) and persist via the existing save
+    path; this function itself is pure (no I/O, no mutation of campaign state)."""
+    seed = derive_seed(world_id, location_id)
+    rng = random.Random(seed)
+    scene_id = f"{world_id}:{location_id}"
+    resolved_kind = kind.strip() or _infer_kind(name, notes)
+    generator = _GENERATORS.get(resolved_kind, None)
+    if generator is not None:
+        return generator(scene_id, location_id, seed, rng)
+    return _gen_default(scene_id, location_id, resolved_kind, seed, rng)
+
+
+def ensure_scene_grid(world_id: str, location) -> bool:
+    """Emit + attach a ``SceneGrid`` onto ``location`` IFF it doesn't already have one.
+
+    The shared GUARDED entry point for the three emit hooks (seed_world / travel_to /
+    add_location). Re-entry guard: if ``location.scene_grid`` is already present it is a
+    no-op (returns False) — so a re-visit / re-seed / re-emit never clobbers an existing
+    grid (and so an async Tier-2 ``art`` fill is preserved). Returns True iff it attached
+    a fresh grid. The caller persists via the existing save path; this only mutates the
+    passed Location in memory. Pure-deterministic via ``emit_scene_grid``."""
+    if getattr(location, "scene_grid", None) is not None:
+        return False
+    location.scene_grid = emit_scene_grid(
+        world_id,
+        location.id,
+        name=getattr(location, "name", "") or "",
+        notes=getattr(location, "notes", "") or "",
+    )
+    return True

--- a/servers/engine/scene_grid.py
+++ b/servers/engine/scene_grid.py
@@ -28,6 +28,7 @@ travel.py / server.py wrap ``emit_scene_grid`` and persist via the existing save
 from __future__ import annotations
 
 import hashlib
+import json
 import random
 from typing import Literal, Optional
 
@@ -149,7 +150,7 @@ def _layout_hash(grid: SceneGrid) -> str:
         mode="json",
         include={"grid", "cell_default", "cells", "props", "spawns", "exits", "zone_anchors", "lighting"},
     )
-    blob = repr(payload).encode("utf-8")
+    blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(blob).hexdigest()[:16]
 
 

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -51,6 +51,7 @@ import spells
 import srd_tables
 import director
 import scene_debt as _scene_debt_mod
+import scene_grid as scene_grid_mod
 import travel
 import wander
 import worldsim
@@ -1172,6 +1173,13 @@ def add_location(
                 f"location {loc.id!r} has NO connections — it is unreachable; call add_location "
                 f"again with connections=[an existing location id] to wire it into the map"
             )
+        # A1 — the SceneGrid emitter (engine sole-writer): a newly added/live-gen location
+        # gets a deterministic Tier-1 spatial layout to render. GUARDED (no-op when the
+        # location already carries a scene_grid — an update-existing add_location never
+        # re-rolls) + deterministic (seeded off (world_id, location_id), isolated from the
+        # combat dice stream). Additive: an old snapshot round-trips to None. Runs BEFORE
+        # save so the emitted grid is persisted in the same atomic write.
+        scene_grid_mod.ensure_scene_grid(c.world_id, loc)
         save_campaign(c)
     result = {
         "id": loc.id,

--- a/servers/engine/tests/test_scene_grid.py
+++ b/servers/engine/tests/test_scene_grid.py
@@ -240,3 +240,91 @@ def test_emit_hooks_do_not_clobber_existing_grid():
     server.travel_to(cid, dest)
     grid_after = server._require(cid).locations[dest].scene_grid.model_dump_json()
     assert grid_after == grid_before
+
+
+# ── SERIALIZATION (omit-when-None) — the store dirty-skip / byte-identity contract ────
+# scene_grid defaults to None; an unconditional Pydantic dump would emit "scene_grid":null
+# for EVERY grid-less location — a key a pre-A1 on-disk snapshot never carried. That breaks
+# byte-identity with old snapshots AND defeats the store's F08-2 dirty-skip (store.py:135-148),
+# so a pure cross-campaign inspect (check_*/world_tick/scene_context) would silently rewrite +
+# re-stamp the file and could flip the #640 "most-recently-updated == live" pointer. The
+# Location wrap serializer OMITS scene_grid when it is None (only that one key).
+
+
+def test_grid_less_location_omits_scene_grid_key():
+    """(a) A grid-less Location dump contains NO scene_grid key (json + dict), while OTHER
+    Optional=None fields (e.g. hex) are STILL emitted — i.e. we omit ONLY scene_grid, not
+    every None field (no blanket exclude_none)."""
+    loc = Location(id="loc_a", name="Bare Room")
+    dj = loc.model_dump_json()
+    dd = loc.model_dump()
+    assert "scene_grid" not in dj
+    assert "scene_grid" not in dd
+    # The other additive Optional[...]=None field is unaffected (still serialized as null).
+    assert '"hex":null' in dj
+    assert "hex" in dd and dd["hex"] is None
+    # And it still round-trips back to a valid grid-less Location.
+    again = Location.model_validate_json(dj)
+    assert again.scene_grid is None and again.name == "Bare Room"
+
+
+def test_grid_ful_location_serializes_scene_grid_and_round_trips():
+    """(b) A Location WITH an emitted grid DOES serialize scene_grid (not null, not omitted)
+    and is byte-stable across load -> dump."""
+    loc = Location(id="loc_b", name="The Yawning Portal", notes="tavern")
+    loc.scene_grid = emit_scene_grid("baldurs-gate", "tavern_lower_city",
+                                     name="The Yawning Portal Tavern")
+    dumped = loc.model_dump_json()
+    assert '"scene_grid":' in dumped and '"scene_grid":null' not in dumped
+    assert "scene_grid" in loc.model_dump()
+    reloaded = Location.model_validate_json(dumped)
+    assert isinstance(reloaded.scene_grid, SceneGrid)
+    assert reloaded.model_dump_json() == dumped  # byte-identical (save -> load -> save)
+
+
+def test_pure_inspect_of_pre_a1_snapshot_is_a_no_op(tmp_path, monkeypatch):
+    """(c) THE DIRTY-SKIP REGRESSION (the real hazard): a real Campaign with a grid-less
+    Location, persisted then STRIPPED of any scene_grid keys on disk to mimic a pre-A1
+    snapshot, must survive a pure load -> save (NO mutation) BYTE-IDENTICALLY with NO
+    updated_at bump — otherwise an un-migrated campaign gets silently rewritten + can steal
+    the #640 live pointer. This is the exact reviewer reproduction; it must now PASS."""
+    import json
+    import re
+
+    import store
+
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+
+    # A real Campaign with a grid-less Location, written through the store's save path.
+    cid = server.create_campaign("dirty-skip pre-A1")["id"]
+    c = server._require(cid)
+    c.locations["loc_pre"] = Location(id="loc_pre", name="A Pre-A1 Room")
+    assert c.locations["loc_pre"].scene_grid is None
+    path = store.save_campaign(c)
+
+    # Strip ANY residual "scene_grid":... fragments from the on-disk JSON to mimic a snapshot
+    # written before A1 ever existed (belt-and-suspenders: the omit-serializer already drops
+    # grid-less ones, so this only removes a grid-ful key if some location carried one).
+    on_disk = path.read_text(encoding="utf-8")
+    stripped = re.sub(r',?\s*"scene_grid":\s*(?:null|\{.*?\})', "", on_disk, flags=re.DOTALL)
+    # Sanity: the stripped bytes carry NO scene_grid key and still parse as a Campaign snapshot.
+    assert "scene_grid" not in stripped
+    json.loads(stripped)  # still valid JSON
+    path.write_text(stripped, encoding="utf-8")
+
+    before_bytes = path.read_text(encoding="utf-8")
+    before_mtime = path.stat().st_mtime_ns
+    before_updated_at = json.loads(before_bytes)["updated_at"]
+
+    # The hazard path: a pure load -> (no mutation) -> save. Must be a NO-OP.
+    loaded = store.load_campaign(cid)
+    assert loaded is not None
+    assert loaded.locations["loc_pre"].scene_grid is None
+    store.save_campaign(loaded)
+
+    after_bytes = path.read_text(encoding="utf-8")
+    after_updated_at = json.loads(after_bytes)["updated_at"]
+
+    assert after_bytes == before_bytes, "pure inspect of a pre-A1 snapshot REWROTE the file"
+    assert after_updated_at == before_updated_at, "pure inspect bumped updated_at (#640 risk)"
+    assert path.stat().st_mtime_ns == before_mtime, "the snapshot file was rewritten on disk"

--- a/servers/engine/tests/test_scene_grid.py
+++ b/servers/engine/tests/test_scene_grid.py
@@ -29,10 +29,13 @@ def test_old_location_without_scene_grid_loads_to_none():
     legacy = '{"id":"loc_legacy","name":"Old Room","description":"a room"}'
     loc = Location.model_validate_json(legacy)
     assert loc.scene_grid is None
-    # ...and re-serializing leaves the place otherwise intact.
+    # ...and re-serializing keeps the legacy shape (no forced scene_grid materialization).
     again = Location.model_validate_json(loc.model_dump_json())
     assert again.scene_grid is None
     assert again.name == "Old Room"
+    # Byte-identical additive contract: scene_grid key must be ABSENT from the dump,
+    # not merely None. A pre-A1 snapshot that round-trips must stay key-for-key identical.
+    assert "scene_grid" not in again.model_dump(exclude_none=True)
 
 
 def test_location_default_scene_grid_is_none():
@@ -173,12 +176,23 @@ def test_ensure_scene_grid_guards_re_entry():
 def test_emitter_does_not_touch_global_dice_stream():
     """Invariant #4 — the engine rolls combat. Emitting a SceneGrid must NOT activate or
     advance the global process RNG (it uses a LOCAL random.Random), so a later un-seeded
-    combat roll stays on its pre-existing mechanism."""
+    combat roll stays on its pre-existing mechanism.
+
+    Two probes: (a) the seed-gate flag must be unchanged, and (b) the underlying RNG
+    state must be identical before vs after — even without flipping the flag, a stream
+    advance would corrupt later combat rolls."""
     import dice
 
     before_active = dice._SEED_ACTIVE
+    process_rng = getattr(dice, "_PROCESS_RNG", None)
+    before_state = process_rng.getstate() if process_rng is not None else None
+
     emit_scene_grid("baldurs-gate", "tav", name="A Tavern")
+
     assert dice._SEED_ACTIVE == before_active  # the emitter never flipped the seed gate
+    after_rng = getattr(dice, "_PROCESS_RNG", None)
+    after_state = after_rng.getstate() if after_rng is not None else None
+    assert after_state == before_state  # RNG stream was NOT advanced by the emit
 
 
 # ── EMIT HOOKS (integration through the real server/content/travel paths) ─────────────

--- a/servers/engine/tests/test_scene_grid.py
+++ b/servers/engine/tests/test_scene_grid.py
@@ -1,0 +1,242 @@
+"""A1 — the SceneGrid emitter (engine sole-writer).
+
+Pins the load-bearing contract for the engine-authored per-location spatial layout:
+  * ADDITIVE — an old snapshot WITHOUT scene_grid loads -> scene_grid is None, byte-identical.
+  * ROUND-TRIP — a Location carrying a scene_grid serializes -> deserializes byte-identical.
+  * DETERMINISTIC — same (world_id, location_id) -> identical SceneGrid (reproducible).
+  * GENERATOR VALIDITY — the tavern generator emits a valid SceneGrid (perimeter walls,
+    walkable interior, the required props, party + foe spawns).
+  * EMIT HOOKS — seed_world / travel_to / add_location attach a grid (guarded re-entry).
+  * ISOLATION — the emitter never touches the global combat dice stream (invariant #4).
+
+Engine-only; additive. Does NOT touch the #461 combat grid (combat_grid.py).
+"""
+
+from __future__ import annotations
+
+import content
+import server
+from models import Location, SceneGrid
+from scene_grid import derive_seed, emit_scene_grid, ensure_scene_grid
+
+
+# ── ADDITIVITY: an old snapshot (no scene_grid) loads to None, unchanged ──────────────
+
+
+def test_old_location_without_scene_grid_loads_to_none():
+    """A Location JSON lacking the scene_grid key round-trips to scene_grid=None — proving
+    the field is additive (empty == today; old snapshots behave exactly as before)."""
+    legacy = '{"id":"loc_legacy","name":"Old Room","description":"a room"}'
+    loc = Location.model_validate_json(legacy)
+    assert loc.scene_grid is None
+    # ...and re-serializing leaves the place otherwise intact.
+    again = Location.model_validate_json(loc.model_dump_json())
+    assert again.scene_grid is None
+    assert again.name == "Old Room"
+
+
+def test_location_default_scene_grid_is_none():
+    """A freshly constructed Location defaults scene_grid to None (no auto-emit at the
+    model layer — only the explicit engine hooks emit)."""
+    assert Location(name="Bare").scene_grid is None
+
+
+# ── ROUND-TRIP: a Location WITH a scene_grid serializes byte-identical ────────────────
+
+
+def test_location_with_scene_grid_round_trips_byte_identical():
+    loc = Location(name="The Yawning Portal", notes="tavern")
+    loc.scene_grid = emit_scene_grid("baldurs-gate", "tavern_lower_city",
+                                     name="The Yawning Portal Tavern")
+    dumped = loc.model_dump_json()
+    reloaded = Location.model_validate_json(dumped)
+    assert reloaded.scene_grid is not None
+    assert isinstance(reloaded.scene_grid, SceneGrid)
+    # Byte-identical serialization (save -> load -> save).
+    assert reloaded.model_dump_json() == dumped
+
+
+def test_scene_grid_is_strict_model():
+    """SceneGrid (and its sub-models) inherit extra='forbid' — a typo'd field raises."""
+    import pytest
+    from pydantic import ValidationError
+
+    g = emit_scene_grid("w", "loc1").model_dump()
+    g["bogus_field"] = 1
+    with pytest.raises(ValidationError):
+        SceneGrid.model_validate(g)
+
+
+# ── DETERMINISM: same inputs -> identical grid ────────────────────────────────────────
+
+
+def test_emit_is_deterministic_same_inputs():
+    a = emit_scene_grid("baldurs-gate", "tavern_lower_city", name="A Tavern")
+    b = emit_scene_grid("baldurs-gate", "tavern_lower_city", name="A Tavern")
+    assert a.model_dump_json() == b.model_dump_json()
+    # The derived seed is stable + non-negative + bounded.
+    s = derive_seed("baldurs-gate", "tavern_lower_city")
+    assert s == a.seed
+    assert 0 <= s < 2**31
+
+
+def test_different_locations_get_different_layouts():
+    """A different location id yields a different deterministic layout (the seed varies)."""
+    a = emit_scene_grid("baldurs-gate", "tavern_one", name="Tavern One")
+    b = emit_scene_grid("baldurs-gate", "tavern_two", name="Tavern Two")
+    assert a.seed != b.seed
+    # scene_id encodes the deterministic key.
+    assert a.scene_id == "baldurs-gate:tavern_one"
+    assert b.scene_id == "baldurs-gate:tavern_two"
+
+
+# ── GENERATOR VALIDITY: the tavern matches the fixture's SHAPE ────────────────────────
+
+
+def _cells_by_coord(grid: SceneGrid) -> dict[tuple[int, int], object]:
+    return {(c.c, c.r): c for c in grid.cells}
+
+
+def test_tavern_generator_emits_valid_scenegrid():
+    g = emit_scene_grid("baldurs-gate", "tav", name="The Elfsong Tavern")
+    assert g.kind == "tavern"
+    assert g.grid.cols >= 14 and g.grid.rows >= 10
+    assert g.grid.projection == "dimetric-2to1"
+    assert g.art.status == "tier1_blockout"
+    assert g.art.layout_hash  # a non-empty cache key
+
+    cells = _cells_by_coord(g)
+
+    # Perimeter: the full back wall (row 0) + the left/right interior columns are walls.
+    for c in range(g.grid.cols):
+        cell = cells.get((c, 0))
+        assert cell is not None and cell.type == "wall" and cell.walkable is False, \
+            f"back-wall cell ({c},0) must be a non-walkable wall"
+    for r in range(1, g.grid.rows - 1):
+        for c in (0, g.grid.cols - 1):
+            cell = cells.get((c, r))
+            assert cell is not None and cell.type == "wall" and cell.walkable is False, \
+                f"side-wall cell ({c},{r}) must be a non-walkable wall"
+
+    # Walkable interior: the center floor is walkable (unlisted cells default to floor).
+    mid = (g.grid.cols // 2, g.grid.rows // 2)
+    assert mid not in cells or cells[mid].walkable  # default floor is walkable
+    assert g.cell_default.type == "floor" and g.cell_default.walkable is True
+
+    # Required props present (bar + hearth + two tables + barrels), each an occluder.
+    prop_ids = {p.id for p in g.props}
+    assert {"bar", "hearth", "table1", "table2", "barrels"}.issubset(prop_ids)
+    hearth = next(p for p in g.props if p.id == "hearth")
+    assert hearth.occluder and hearth.height_band == "tall"
+
+    # Every prop's footprint cells are non-walkable prop cells tagged with its id.
+    for p in g.props:
+        for (c, r) in p.cells:
+            cell = cells.get((c, r))
+            assert cell is not None and cell.type == "prop" and not cell.walkable
+            assert cell.prop_ref == p.id
+
+    # Spawns: party (≥1) near the entrance + foes inside.
+    assert g.spawns.get("party") and len(g.spawns["party"]) >= 1
+    assert g.spawns.get("foes") and len(g.spawns["foes"]) >= 1
+
+    # Warm lighting (the hearth key).
+    assert g.lighting.mood and g.lighting.key_color == "#ff9a45"
+
+
+def test_non_tavern_falls_back_to_valid_default_interior():
+    g = emit_scene_grid("baldurs-gate", "crypt1", name="The Crypt", notes="dungeon")
+    assert g.kind == "interior"  # no bespoke dungeon generator yet -> generic interior
+    assert g.grid.cols > 0 and g.grid.rows > 0
+    cells = _cells_by_coord(g)
+    # Perimeter walls + a walkable center, even with no props.
+    assert cells[(0, 0)].type == "wall"
+    assert g.cell_default.walkable is True
+    assert g.art.status == "tier1_blockout"
+
+
+# ── GUARD: ensure_scene_grid is a no-op when one already exists ───────────────────────
+
+
+def test_ensure_scene_grid_guards_re_entry():
+    loc = Location(name="Tavern", notes="tavern")
+    assert ensure_scene_grid("w", loc) is True          # first emit attaches
+    first = loc.scene_grid
+    assert first is not None
+    assert ensure_scene_grid("w", loc) is False         # second is a no-op
+    assert loc.scene_grid is first                       # untouched (preserves async art)
+
+
+# ── ISOLATION: the emitter never perturbs the global combat dice stream ───────────────
+
+
+def test_emitter_does_not_touch_global_dice_stream():
+    """Invariant #4 — the engine rolls combat. Emitting a SceneGrid must NOT activate or
+    advance the global process RNG (it uses a LOCAL random.Random), so a later un-seeded
+    combat roll stays on its pre-existing mechanism."""
+    import dice
+
+    before_active = dice._SEED_ACTIVE
+    emit_scene_grid("baldurs-gate", "tav", name="A Tavern")
+    assert dice._SEED_ACTIVE == before_active  # the emitter never flipped the seed gate
+
+
+# ── EMIT HOOKS (integration through the real server/content/travel paths) ─────────────
+
+
+def test_seed_world_emits_scene_grids_for_every_location():
+    world = {
+        "id": "test-scenegrid-world",
+        "name": "SceneGrid Test World",
+        "premise": "a world for testing the emitter",
+        "regions": [
+            {"id": "tavern_loc", "name": "The Roadside Tavern", "tags": ["tavern"]},
+            {"id": "field_loc", "name": "An Open Field", "connections": ["tavern_loc"]},
+        ],
+    }
+    c = content.seed_world(world)
+    for loc in c.locations.values():
+        assert loc.scene_grid is not None, f"{loc.id} should have a scene_grid"
+        assert loc.scene_grid.scene_id == f"test-scenegrid-world:{loc.id}"
+    # The tavern region was inferred as a tavern kind; the field is the generic interior.
+    assert c.locations["tavern_loc"].scene_grid.kind == "tavern"
+    assert c.locations["field_loc"].scene_grid.kind == "interior"
+
+
+def test_add_location_emits_scene_grid():
+    cid = server.create_campaign("scenegrid add_location")["id"]
+    res = server.add_location(cid, "The Singing Kettle Tavern")
+    loc = server._require(cid).locations[res["id"]]
+    assert loc.scene_grid is not None
+    assert loc.scene_grid.kind == "tavern"
+    assert loc.scene_grid.location_id == loc.id
+
+
+def test_travel_to_emits_scene_grid_on_arrival():
+    cid = server.create_campaign("scenegrid travel")["id"]
+    # First place becomes current (and gets a grid via add_location's own hook).
+    start = server.add_location(cid, "Harbor Start")["id"]
+    dest = server.add_location(cid, "The Anchor Tavern", connections=[start])["id"]
+    # Clear the destination's grid to prove travel_to's hook (re-)emits on arrival.
+    c = server._require(cid)
+    c.locations[dest].scene_grid = None
+    server.save_campaign(c)
+    server.travel_to(cid, dest)
+    arrived = server._require(cid).locations[dest]
+    assert arrived.scene_grid is not None
+    assert arrived.scene_grid.location_id == dest
+
+
+def test_emit_hooks_do_not_clobber_existing_grid():
+    """A re-visit / re-add must NOT re-roll a location that already has a grid (guard)."""
+    cid = server.create_campaign("scenegrid guard")["id"]
+    start = server.add_location(cid, "Harbor Start")["id"]
+    dest = server.add_location(cid, "The Anchor Tavern", connections=[start])["id"]
+    c = server._require(cid)
+    grid_before = c.locations[dest].scene_grid.model_dump_json()
+    # Travel away and back; the existing grid must be preserved verbatim.
+    server.travel_to(cid, dest)
+    server.travel_to(cid, start)
+    server.travel_to(cid, dest)
+    grid_after = server._require(cid).locations[dest].scene_grid.model_dump_json()
+    assert grid_after == grid_before

--- a/servers/engine/travel.py
+++ b/servers/engine/travel.py
@@ -22,6 +22,7 @@ import difflib
 from collections import deque
 
 from models import Campaign, Location
+from scene_grid import ensure_scene_grid  # A1 SceneGrid emitter (engine sole-writer)
 
 # The in-world day, in order. Travel advances along this cycle; passing the end
 # rolls over into the next day.
@@ -161,6 +162,14 @@ def travel_to(campaign: Campaign, destination_id: str, advance_time: bool = Fals
     first_visit = not dest.visited
     dest.visited = True
     campaign.current_location_id = destination_id
+
+    # A1 — the SceneGrid emitter (engine sole-writer): the party is arriving at `dest`, so
+    # make sure it has a Tier-1 spatial layout to render. GUARDED (no-op if dest already
+    # carries a scene_grid — a re-visit never re-rolls) + deterministic (seeded off
+    # (world_id, location_id), isolated from the combat dice stream). Additive: a world
+    # with no world_id still emits a deterministic grid; an old snapshot round-trips. The
+    # MCP wrapper in server.py save_campaigns the mutated campaign after this returns.
+    ensure_scene_grid(campaign.world_id, dest)
 
     if advance_time:
         advance_clock(campaign, 1)

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1707,6 +1707,51 @@ def _session_location(snapshot: dict) -> dict:
     }
 
 
+# The pre-A1 default combat board extents. Used as the fallback whenever the current
+# location has no engine-authored SceneGrid (an old snapshot, or a location the emitter
+# hasn't reached) — so the board renders byte-identically to today in that case.
+_DEFAULT_GRID_COLS = 16
+_DEFAULT_GRID_ROWS = 10
+
+
+def _scene_grid_block(snapshot: dict, mode: str) -> dict:
+    """The combat board's grid extents (A1). When the party's current location carries an
+    engine-authored ``scene_grid``, use ITS extents + cells; otherwise fall back to the
+    legacy 16x10 default so an old snapshot (scene_grid absent) renders exactly as before.
+
+    ADDITIVE / presentation-only: this READS the engine-owned snapshot (the engine is the
+    sole writer of scene_grid) and never mutates it. ``mode`` is preserved unchanged. When a
+    scene_grid is present we surface its ``cells`` (the floor/wall/prop map the Tier-1 block-
+    out draws), ``cellDefault``, and ``sceneId`` so the client can tint walkable vs blocked
+    cells; absent/malformed scene_grid yields only ``{mode, cols, rows}`` — today's shape."""
+    block: dict = {"mode": mode, "cols": _DEFAULT_GRID_COLS, "rows": _DEFAULT_GRID_ROWS}
+    loc_id = _text(snapshot.get("current_location_id"))
+    locs = snapshot.get("locations")
+    loc = locs.get(loc_id) if isinstance(locs, dict) and loc_id else None
+    sg = loc.get("scene_grid") if isinstance(loc, dict) else None
+    if not isinstance(sg, dict):
+        return block
+    grid = sg.get("grid")
+    if not isinstance(grid, dict):
+        return block
+    cols = grid.get("cols")
+    rows = grid.get("rows")
+    if not (isinstance(cols, int) and isinstance(rows, int) and cols > 0 and rows > 0):
+        return block  # degrade to the default extents on a malformed grid
+    block["cols"] = cols
+    block["rows"] = rows
+    sid = sg.get("scene_id")
+    if isinstance(sid, str) and sid:
+        block["sceneId"] = sid
+    cells = sg.get("cells")
+    if isinstance(cells, list):
+        block["cells"] = cells
+    cell_default = sg.get("cell_default")
+    if isinstance(cell_default, dict):
+        block["cellDefault"] = cell_default
+    return block
+
+
 def _session_party_cards(snapshot: dict) -> list[dict]:
     chars = snapshot.get("characters")
     party = snapshot.get("party")
@@ -2964,7 +3009,7 @@ def build_combat_surface(
             "round": combat_view.get("round") if combat_active else None,
             "warnings": combat_view.get("warnings", []),
         },
-        "grid": {"mode": mode, "cols": 16, "rows": 10},
+        "grid": _scene_grid_block(snapshot, mode),
         "tokens": tokens,
         "initiative": initiative,
         "zones": zones,

--- a/viewer/tests/test_combat_grid_scene_grid.py
+++ b/viewer/tests/test_combat_grid_scene_grid.py
@@ -1,0 +1,88 @@
+"""A1 — the combat board's grid block consumes the location's engine-authored SceneGrid.
+
+build_combat_surface previously hardcoded {mode, cols:16, rows:10}. With the SceneGrid
+emitter, the board now uses the current location's scene_grid extents/cells when present,
+and falls back to the old 16x10 default when absent (ADDITIVE — an old snapshot renders
+byte-identically). Presentation-only: the viewer READS the engine-owned snapshot.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server", _SERVER_PATH)
+assert _SPEC is not None
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(server)
+
+
+def _surface(snapshot: dict) -> dict:
+    return server.build_combat_surface(
+        snapshot, campaign_id="c", live=False, is_live_view=False, recent_events=[]
+    )
+
+
+class SceneGridBoardTests(unittest.TestCase):
+    def test_falls_back_to_default_extents_when_no_scene_grid(self):
+        """An old snapshot whose current location has no scene_grid renders the legacy
+        16x10 board (byte-identical to pre-A1)."""
+        snap = {
+            "current_location_id": "loc1",
+            "locations": {"loc1": {"name": "A Room"}},
+        }
+        grid = _surface(snap)["grid"]
+        self.assertEqual(grid["cols"], 16)
+        self.assertEqual(grid["rows"], 10)
+        self.assertIn("mode", grid)  # mode is preserved from the combat-tokens derivation
+        # No scene_grid -> the block carries ONLY the legacy keys (no cells/sceneId).
+        self.assertNotIn("cells", grid)
+        self.assertNotIn("sceneId", grid)
+
+    def test_uses_scene_grid_extents_and_cells_when_present(self):
+        snap = {
+            "current_location_id": "loc1",
+            "locations": {
+                "loc1": {
+                    "name": "The Tavern",
+                    "scene_grid": {
+                        "scene_id": "w:loc1",
+                        "location_id": "loc1",
+                        "kind": "tavern",
+                        "grid": {"cols": 14, "rows": 10, "cell_size_ft": 5,
+                                 "projection": "dimetric-2to1"},
+                        "cell_default": {"type": "floor", "walkable": True, "cost": 1},
+                        "cells": [
+                            {"c": 0, "r": 0, "type": "wall", "walkable": False, "cost": 1},
+                        ],
+                    },
+                }
+            },
+        }
+        grid = _surface(snap)["grid"]
+        self.assertEqual(grid["cols"], 14)
+        self.assertEqual(grid["rows"], 10)
+        self.assertEqual(grid["sceneId"], "w:loc1")
+        self.assertEqual(grid["cellDefault"], {"type": "floor", "walkable": True, "cost": 1})
+        self.assertEqual(len(grid["cells"]), 1)
+        self.assertEqual(grid["cells"][0]["type"], "wall")
+        # mode is preserved from the combat-tokens derivation (no active combat -> theater).
+        self.assertIn("mode", grid)
+
+    def test_malformed_scene_grid_degrades_to_default(self):
+        """A scene_grid with a missing/bad grid block must NOT crash — degrade to 16x10."""
+        snap = {
+            "current_location_id": "loc1",
+            "locations": {"loc1": {"name": "Broken", "scene_grid": {"grid": {"cols": 0}}}},
+        }
+        grid = _surface(snap)["grid"]
+        self.assertEqual(grid["cols"], 16)
+        self.assertEqual(grid["rows"], 10)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_combat_grid_scene_grid.py
+++ b/viewer/tests/test_combat_grid_scene_grid.py
@@ -74,7 +74,10 @@ class SceneGridBoardTests(unittest.TestCase):
         self.assertIn("mode", grid)
 
     def test_malformed_scene_grid_degrades_to_default(self):
-        """A scene_grid with a missing/bad grid block must NOT crash — degrade to 16x10."""
+        """A scene_grid with a missing/bad grid block must NOT crash — degrade to 16x10.
+
+        The fallback must mirror the full legacy key-shape: ONLY {mode, cols, rows} — no
+        partial sceneId / cells / cellDefault leak that would cause UI regressions."""
         snap = {
             "current_location_id": "loc1",
             "locations": {"loc1": {"name": "Broken", "scene_grid": {"grid": {"cols": 0}}}},
@@ -82,6 +85,10 @@ class SceneGridBoardTests(unittest.TestCase):
         grid = _surface(snap)["grid"]
         self.assertEqual(grid["cols"], 16)
         self.assertEqual(grid["rows"], 10)
+        # Full legacy key-shape: no scene-grid-specific keys must leak through.
+        self.assertNotIn("cells", grid)
+        self.assertNotIn("sceneId", grid)
+        self.assertNotIn("cellDefault", grid)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## A1 — the engine SceneGrid emitter

Makes the Python engine the **SOLE WRITER** of a deterministic procedural `SceneGrid` per location, emitted at location-creation time. The visual pipeline already PROVED this field set end-to-end (a hand-authored fixture drove a registered painterly Unity scene; the parameterized renderer consumed grid/props/spawns/lighting with no new field). This lands the engine side.

Contract: `worldos-session-notes/2026-06-22-unity-pivot/scene-grid-contract.md` (v1 + the ★ CORRECTION). Validated fixture: `LEXAR/WorldOS-Unity-spike/fixtures/tavern.scenegrid.json`.

## What changed
- **`servers/engine/scene_grid.py`** (new): `SceneGrid` + sub-models (`SceneGridSpec`/`SceneCell`/`SceneProp`/`SceneLighting`/`SceneArt`), all `_StrictModel` (`extra="forbid"`). A **deterministic** emitter seeded off a LOCAL `random.Random(derive_seed(world_id, location_id))` (SHA-256 → 31-bit int) — it NEVER touches the global combat dice stream (`dice.reseed_process_rng`/`_PROCESS_RNG`), so "the engine rolls combat" (invariant #4) is untouched. A procedural **tavern** generator matching the fixture SHAPE (perimeter walls, a bar, a lit stone hearth as the warm key, two tables, barrels, party/foe spawns, warm candlelit lighting) + a generic interior fallback for other kinds. Sets `art.status="tier1_blockout"` + `art.layout_hash`. Pure (no I/O); `ensure_scene_grid()` is the shared GUARDED hook.
- **`servers/engine/models.py`**: `Location.scene_grid: Optional[SceneGrid] = None` (ADDITIVE). Deferred import of `scene_grid` + `Location.model_rebuild()` at the foot of the module to break the cycle (dependency points one way: `scene_grid → models`).
- **Emit hooks** (guarded re-entry — skip if `scene_grid` already present; BEFORE save): `content.seed_world` (every seeded location), `travel.travel_to` (on arrival), `server.add_location`.
- **`docs/roadmap/contracts/render-profile.schema.json`**: `core.locations[].scene_grid` (ADDITIVE; `schema_version` stays **1**).
- **`viewer/server.py`**: `build_combat_surface` grid block now uses the current location's `scene_grid` extents/cells when present, falling back to the legacy `{cols:16, rows:10}` default when absent (byte-identical for old snapshots).

## Invariants honored
- **Engine sole-writer** — only the engine emits/attaches; the viewer READS the snapshot, never mutates it.
- **Additive-by-default** — empty == today: an old snapshot lacking `scene_grid` loads to `None`, the viewer falls back to 16×10, nothing in the engine reads the field. Old snapshots round-trip byte-identically.
- **`_StrictModel` (extra=forbid)** on every new model.
- **Tolerant load** unaffected — `scene_grid` is a NESTED `Location` field, not a top-level key; Pydantic round-trips it.
- **Disjoint from the #461 combat grid** — `combat_grid.py` (zone-based combat positioning) is not imported or modified. SceneGrid is set-dressing/presentation DATA, the always-present generalization of the combat x/y carve-out — NOT a change to v1 named-zone combat positioning.

## Tests (focused, single-process `-p no:xdist`)
- `servers/engine/tests/test_scene_grid.py` (14): additivity (old snapshot → `None`), round-trip (byte-identical), determinism (same inputs → identical grid; different locations differ), tavern-generator validity (perimeter walls / walkable interior / required props / spawns / warm light), strict-model rejection, guard re-entry, **dice-stream isolation** (`_SEED_ACTIVE` untouched), and the three emit hooks via the real server/content/travel paths.
- `viewer/tests/test_combat_grid_scene_grid.py` (3): default-extents fallback (no scene_grid), scene_grid extents/cells consumed, malformed-grid degrade.

Verification run locally (this branch):
- `qa/fast_gate.sh` (Tier-0): **241 passed**.
- engine store/snapshot/content/travel/add_location slices: all green.
- full `viewer/tests`: **774 passed, 2 skipped**; render-profile contract + render tests: **58 passed**.
- cross-service MCP contract tests (`servers/integration_tests`): **7 passed, 19 skipped** (torch/rules-online-gated).
- `scripts/license_check.py`: passed.

## For the orchestrator's adversarial-invariant-verify
Please skeptically REFUTE, in a review worktree:
1. **Additive / byte-identical** — an old `snapshot.json` (no `scene_grid` anywhere) loads → every `Location.scene_grid is None`, and save→load→save is byte-identical; the viewer combat board for such a snapshot is byte-identical to pre-PR (`{mode, cols:16, rows:10}`).
2. **Deterministic + reproducible across a process restart** — `emit_scene_grid(w, loc)` in two FRESH interpreters yields identical JSON (the seed is SHA-256-derived, salt-free — not `hash()`-randomized).
3. **Dice-stream isolation (invariant #4)** — emitting a SceneGrid must NOT flip `dice._SEED_ACTIVE` or advance `dice._PROCESS_RNG`; a subsequent un-seeded combat roll stays on its pre-existing mechanism. (Confirm the emitter uses a LOCAL `random.Random`, never `reseed_process_rng`.)
4. **Sole-writer** — the viewer (`_scene_grid_block`) only READS the snapshot; no engine state mutation on the read path. The three emit hooks are the only writers, all under the existing `campaign_lock` + `save_campaign`.
5. **Guard re-entry** — a re-visit / re-seed / re-add must NOT clobber an existing `scene_grid` (so an async Tier-2 `art` fill is preserved).
6. **Does NOT touch `combat_grid.py` / #461** — no import, no behavior change to zone-based combat positioning.

DO NOT merge — handing to the orchestrator for adversarial-invariant-verify + merge.