### PR TITLE
feat(qa): --waive-image-render for VM-only RED-by-construction sweeps (#843)

### DIFF
--- a/qa/release_readiness.py
+++ b/qa/release_readiness.py
@@ -33,6 +33,16 @@ image_render gate sources (signals.image_render_source):
                     health.image_probe_ok:true + the private art root across every
                     required handoff gate. This is a representative built-app image
                     probe, NOT a render rate — weaker but real Mac evidence.
+  - "waived"      : (#843, opt-in --waive-image-render + --waive-image-render-reason) the
+                    gate was RED-BY-CONSTRUCTION on a VM-only sweep (minted-scope /image 404s
+                    the resolver cannot answer + no imagegen gateway) and has been explicitly
+                    WAIVED-WITH-REASON so the RRI is HONEST, NOT a silent fail. Deliberately
+                    narrow: engages ONLY when source would be "none" AND there are NO KNOWN
+                    unexpected 404s — a recorded vm-network rate or a blocking unexpected-404
+                    gap stays authoritative and hard-fails the gate even with the flag set
+                    (the #762 invariant: a waiver never papers over genuine failure evidence).
+                    The waiver is recorded in signals.image_render_waived/_reason and as a
+                    waived=True annotation in the displayed evidence_gaps.
   - "none"        : neither source -> the gate stays a HARD FAIL with an evidence gap.
 
 A score.json image_404s count with no success denominator is an EVIDENCE GAP, never a
@@ -744,6 +754,15 @@ def main() -> int:
     ap.add_argument("--palette-source", default="", help="path or label for the palette-live evidence source")
     ap.add_argument("--handoff-json", default="", help="Mac app handoff gate JSON proving built-app smoke/play evidence")
     ap.add_argument("--support-preflight-json", default="", help="Support VM preflight JSON proving same-SHA heavy-lane readiness")
+    ap.add_argument("--waive-image-render", dest="waive_image_render", action="store_true",
+                    help="(#843) waive image_render for a VM-only sweep where it is RED-BY-CONSTRUCTION "
+                    "(minted-scope /image 404s the resolver cannot answer + no imagegen gateway), so the "
+                    "RRI is HONEST (image_render = waived-with-reason, NOT a silent fail). REQUIRES "
+                    "--waive-image-render-reason. NEVER papers over GENUINE failure evidence: a recorded "
+                    "vm-network render rate OR a KNOWN unexpected-404 evidence gap still hard-fails the gate.")
+    ap.add_argument("--waive-image-render-reason", dest="waive_image_render_reason", default="",
+                    help="mandatory reason recorded with a --waive-image-render waiver (e.g. 'VM-only "
+                    "sweep: minted-scope 404s by construction (#843); render proven on the Mac handoff lane')")
     ap.add_argument("--build-sha", dest="build_sha", default="")
     ap.add_argument("--abort-marker", default="", help="path to a sweep QUOTA_ABORT marker; if it "
                     "exists the rollup is forced to an ABORTED status (infra abort, not a product RRI)")
@@ -1122,6 +1141,56 @@ def main() -> int:
         image_render_ok = image_evidence_complete and img_rate >= 0.95 and "image_render" not in evidence_gap_gates
         image_render_detail = f"source={image_render_source}; rate={img_rate:.2%}; denominator={total_image_denominator}"
 
+    # ---- #843 image_render WAIVER (VM-only RED-by-construction escape) ----
+    # On the VM lane the UI requests minted-scope /image ids the resolver cannot answer (0
+    # location_* dirs ingested + a null provider + no imagegen gateway), so image_render is
+    # RED-BY-CONSTRUCTION and the #762 mac-handoff escape can never fire. --waive-image-render
+    # marks the gate WAIVED-WITH-REASON so a VM-only sweep RRI is HONEST (waived, not a silent
+    # fail). The waive is DELIBERATELY narrow — it NEVER papers over GENUINE failure evidence:
+    #   * it engages ONLY when the gate is failing purely by-construction: source=="none"
+    #     (no VM denominator, no valid mac-handoff) AND no KNOWN unexpected-404 gap; and
+    #   * a recorded vm-network render rate (source=="vm-network") or a blocking unexpected-404
+    #     evidence gap stays AUTHORITATIVE and hard-fails the gate even with the flag set.
+    # It REQUIRES a non-empty reason; a bare flag is not a valid honest waiver (the gate stays
+    # failed with a "reason required" gap). Default-off → every pre-existing RRI is byte-identical.
+    image_render_waived = False
+    image_render_waive_reason = ""
+    waived_image_render_gaps: list[dict] = []
+    if args.waive_image_render and not image_render_ok:
+        reason = (args.waive_image_render_reason or "").strip()
+        # A waive may only neutralize a PURELY by-construction failure: no VM render rate
+        # (source!="vm-network"), no valid mac-handoff carrying the gate (source!="mac-handoff"),
+        # and no recorded KNOWN unexpected 404s (blocking_image_gap_personas) — those are real
+        # render-failure evidence the #762 invariant forbids any escape from papering over.
+        waivable = image_render_source == "none" and not blocking_image_gap_personas
+        if not reason:
+            evidence_gaps.append({
+                "gate": "image_render",
+                "missing": "--waive-image-render-reason",
+                "detail": "--waive-image-render requires a non-empty --waive-image-render-reason "
+                          "(a waiver with no recorded reason is not honest)",
+            })
+            evidence_gap_gates = {gap["gate"] for gap in evidence_gaps}
+        elif waivable:
+            image_render_waived = True
+            image_render_waive_reason = reason
+            # Pull the by-construction image_render gaps OUT of the BLOCKING list and re-file
+            # them as a WAIVED annotation (stamped waived=True + reason) so the RRI carries the
+            # waiver in its evidence trail WITHOUT blocking release_ready. Other gates' gaps stay.
+            for gap in evidence_gaps:
+                if gap.get("gate") == "image_render":
+                    waived_image_render_gaps.append({**gap, "waived": True, "waive_reason": reason})
+            evidence_gaps = [gap for gap in evidence_gaps if gap.get("gate") != "image_render"]
+            evidence_gap_gates = {gap["gate"] for gap in evidence_gaps}
+            image_render_ok = True
+            image_render_source = "waived"
+            image_render_detail = (
+                "source=waived (#843 VM-only RED-by-construction: minted-scope 404s the resolver "
+                f"cannot answer + no imagegen gateway); reason={reason!r}"
+            )
+        # else: not waivable (vm-network rate or known unexpected 404s) → leave the hard fail
+        # in place; the genuine failure evidence is authoritative (the #762 invariant).
+
     # ---- ADDITIVE latency gates (Phase-3) ----
     # s_per_beat / coldopen are HARD gates ONLY when latency evidence is present AND over
     # budget; ABSENT latency -> the gate is SKIPPED with a documented evidence gap, never a
@@ -1301,7 +1370,12 @@ def main() -> int:
         "missing_personas": missing_personas,
         "missing_release_personas": missing_release_personas,
         "harness_failures": harness_failures,
-        "evidence_gaps": evidence_gaps,
+        # The DISPLAYED evidence trail surfaces any #843 WAIVED image_render gaps (stamped
+        # waived=True + reason) alongside the BLOCKING gaps — an honest record that the gate was
+        # waived, never silently dropped. The waived entries do NOT count toward release_ready /
+        # partial / harness_contaminated (those read the blocking list), so a clean VM-only sweep
+        # with a valid waiver can be release_ready while still showing the waiver in evidence_gaps.
+        "evidence_gaps": evidence_gaps + waived_image_render_gaps,
         "handoff_evidence": {
             **handoff_proof,
             "evidence_gaps": handoff_evidence_gaps,
@@ -1359,6 +1433,13 @@ def main() -> int:
             "image_404_personas_without_denominator": [
                 str(p["persona"]) for p in image_gap_personas
             ],
+            # #843 — honest record of a VM-only image_render WAIVER. image_render_waived is True
+            # ONLY when the gate was failing purely by-construction (source=="none", no known
+            # unexpected 404s) and a valid --waive-image-render-reason was supplied; False (and the
+            # reason empty) in every other case, including when a waive was REFUSED for genuine
+            # failure evidence. Default-off → byte-identical for every pre-existing RRI.
+            "image_render_waived": image_render_waived,
+            "image_render_waive_reason": image_render_waive_reason,
             "palette_live": args.palette_live,
             "run_build_shas": build_shas,
             # ADDITIVE latency signals (Phase-3). None when no persona recorded latency
@@ -1411,6 +1492,9 @@ def main() -> int:
         print("  FAILED: " + ", ".join(details))
     if evidence_gaps:
         print("  EVIDENCE GAPS: " + "; ".join(f"{g['gate']} missing {g['missing']}" for g in evidence_gaps))
+    if image_render_waived:
+        print(f"  IMAGE_RENDER WAIVED (#843): {image_render_waive_reason} "
+              f"— VM-only RED-by-construction; NOT a silent pass (recorded in evidence_gaps as waived).")
 
     # WS0 ENGAGEMENT section — name each dead authored system across the sweep + a fix hint, so an
     # all-inert subsystem (the failure WS0 exists to surface) is visible even while it is WARN-only.

--- a/qa/test_release_readiness.py
+++ b/qa/test_release_readiness.py
@@ -2834,6 +2834,175 @@ class ReleaseReadinessContractTests(unittest.TestCase):
                 self.assertNotIn(gate, payload["failed_gates"])
             self.assertEqual(payload["deterministic_failed_gates"], [])
 
+    # ---- #843: --waive-image-render (VM-only sweep RED-by-construction escape) ----
+    # On the VM lane the UI requests minted-scope ids that 404 by construction (the
+    # resolver exact-matches only canonical ingested keys, 0 location_* dirs ingested,
+    # no imagegen gateway). When those 404s are recorded as UNEXPECTED (the viewer
+    # cannot distinguish minted-scope-unanswerable from a real render failure), the
+    # #762 mac-handoff escape can NEVER fire — image_render is RED-by-construction.
+    # --waive-image-render lets a VM-only sweep be HONEST: image_render = waived-with-
+    # reason, NOT a silent fail. It NEVER papers over GENUINE failure evidence.
+
+    def _waive_release_args(self, tmp, runs, personas):
+        story, mech, behavioral, audit, palette = self.write_release_inputs(tmp)
+        return [
+            "--runs", ",".join(str(r) for r in runs),
+            "--expected-personas", ",".join(personas),
+            "--story", str(story), "--mech", str(mech),
+            "--behavioral", "GREEN", "--behavioral-path", str(behavioral),
+            "--ui-audit", "PASS", "--ui-audit-log", str(audit),
+            "--palette-live", "true", "--palette-source", str(palette),
+            "--build-sha", "deadbee",
+        ]
+
+    def test_waive_image_render_lets_vm_only_sweep_be_release_ready(self):
+        # A VM-only sweep that recorded zero image traffic (the gitignored _private
+        # art / minted-scope case) → image_render_source is "none" → RED-by-construction.
+        # --waive-image-render with a reason waives it WITH an evidence annotation, so the
+        # gate passes and a five-persona VM-only RRI can be release_ready.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(tmp, persona, include_image_traffic=False)
+                for persona in personas
+            ]
+            rc, _text, payload = self.run_rri(
+                tmp,
+                *self._waive_release_args(tmp, runs, personas),
+                "--waive-image-render",
+                "--waive-image-render-reason",
+                "VM-only sweep: minted-scope 404s by construction (#843); render proven separately",
+            )
+
+            self.assertEqual(rc, 0)
+            self.assertTrue(payload["release_ready"])
+            self.assertNotIn("image_render", payload["failed_gates"])
+            self.assertEqual(payload["signals"]["image_render_source"], "waived")
+            self.assertTrue(payload["signals"]["image_render_waived"])
+            self.assertIn("#843", payload["signals"]["image_render_waive_reason"])
+            # The waive is HONEST: an evidence_gap annotation records waived=True + reason,
+            # so the RRI carries the waiver in its evidence trail (not a silent pass).
+            waive_gaps = [g for g in payload["evidence_gaps"] if g["gate"] == "image_render"]
+            self.assertTrue(waive_gaps, "expected a waived image_render evidence annotation")
+            self.assertTrue(all(g.get("waived") is True for g in waive_gaps))
+            self.assertIn("waived", payload["gate_detail"]["image_render"])
+
+    def test_waive_image_render_does_not_paper_over_genuine_unexpected_404s(self):
+        # The #762 invariant: a waive must NEVER paper over RECORDED unexpected image
+        # 404s (real render-failure evidence). Even WITH --waive-image-render, a sweep
+        # that recorded known unexpected 404s still FAILS image_render.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(
+                    tmp,
+                    persona,
+                    include_image_traffic=False,
+                    extra_score_fields={
+                        "image_404s": 3,
+                        "image_404s_designed": 1,
+                        "image_404s_unexpected": 2,
+                    },
+                )
+                for persona in personas
+            ]
+            rc, _text, payload = self.run_rri(
+                tmp,
+                *self._waive_release_args(tmp, runs, personas),
+                "--waive-image-render",
+                "--waive-image-render-reason",
+                "trying to waive a genuine failure (must be refused)",
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertIn("image_render", payload["failed_gates"])
+            self.assertNotEqual(payload["signals"]["image_render_source"], "waived")
+            self.assertFalse(payload["signals"]["image_render_waived"])
+            gap_details = [
+                g["detail"] for g in payload["evidence_gaps"] if g["gate"] == "image_render"
+            ]
+            self.assertTrue(
+                any("unexpected image 404s" in d for d in gap_details),
+                f"expected an unexpected-404 evidence gap, got: {gap_details}",
+            )
+
+    def test_waive_image_render_with_vm_network_failures_is_refused(self):
+        # A waive must NOT paper over a real vm-network render rate below threshold —
+        # the VM DID record /image traffic with unexpected 404s, so image_render_source
+        # is "vm-network" and the real rate is authoritative even with the waive flag.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(tmp, persona, image_status=404)
+                for persona in personas
+            ]
+            rc, _text, payload = self.run_rri(
+                tmp,
+                *self._waive_release_args(tmp, runs, personas),
+                "--waive-image-render",
+                "--waive-image-render-reason",
+                "should not paper over recorded vm-network failures",
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertIn("image_render", payload["failed_gates"])
+            self.assertEqual(payload["signals"]["image_render_source"], "vm-network")
+            self.assertFalse(payload["signals"]["image_render_waived"])
+
+    def test_waive_image_render_requires_a_reason(self):
+        # A bare --waive-image-render with no reason is not a valid honest waiver: the
+        # gate stays failed with a clear "reason required" evidence gap.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(tmp, persona, include_image_traffic=False)
+                for persona in personas
+            ]
+            rc, _text, payload = self.run_rri(
+                tmp,
+                *self._waive_release_args(tmp, runs, personas),
+                "--waive-image-render",
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertIn("image_render", payload["failed_gates"])
+            self.assertFalse(payload["signals"]["image_render_waived"])
+            gap_details = [
+                g["detail"] for g in payload["evidence_gaps"] if g["gate"] == "image_render"
+            ]
+            self.assertTrue(
+                any("reason" in d.lower() for d in gap_details),
+                f"expected a 'reason required' evidence gap, got: {gap_details}",
+            )
+
+    def test_no_waive_flag_keeps_vm_only_sweep_red_by_construction(self):
+        # Control: WITHOUT the waive flag a VM-only sweep with no image evidence stays a
+        # hard image_render fail (the RED-by-construction status quo is byte-identical).
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            personas = ("newbie", "veteran", "adversarial", "narrative", "optimizer")
+            runs = [
+                self.write_persona_run(tmp, persona, include_image_traffic=False)
+                for persona in personas
+            ]
+            rc, _text, payload = self.run_rri(
+                tmp,
+                *self._waive_release_args(tmp, runs, personas),
+            )
+
+            self.assertEqual(rc, 1)
+            self.assertFalse(payload["release_ready"])
+            self.assertIn("image_render", payload["failed_gates"])
+            self.assertEqual(payload["signals"]["image_render_source"], "none")
+            self.assertFalse(payload["signals"]["image_render_waived"])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What & why (closes #843)

`image_render` is **RED-by-construction** on the VM-only sweep lane. The UI requests minted-scope `/image` ids the viewer resolver cannot answer (0 `location_*` dirs ingested, null image provider, no imagegen gateway), so every recorded request 404s by construction. When those 404s are recorded as UNEXPECTED, the #762 same-SHA Mac-handoff escape can **never** fire — the gate fails regardless of product quality, making any VM-only RRI dishonest about image_render.

Per the issue, this PR is the **conservative, gate-plumbing-only fix (b)**: an explicit opt-in waiver so a VM-only sweep RRI is HONEST (image_render = waived-with-reason, not a silent fail-by-construction). Fix (a) was rejected as out-of-scope — distinguishing minted-scope-unanswerable 404s from genuine ones lives in the viewer's render layer (`X-Image-Outcome`), which a separate graphics agent owns; doing it in the gate would mean the gate *guessing* which 404s are unanswerable, which is exactly the unsafe paper-over #762 forbids.

## The change (additive, default-off)

New CLI flags on `qa/release_readiness.py`:
- `--waive-image-render` (opt-in) + `--waive-image-render-reason <reason>` (mandatory).

When set, the gate is marked **WAIVED-WITH-REASON**:
- `signals.image_render_source = "waived"`, `signals.image_render_waived = true`, `signals.image_render_waive_reason = <reason>`.
- The by-construction image_render evidence gaps are re-filed as a `waived: true` annotation in the displayed `evidence_gaps` (honest record), and excluded from the **blocking** list so a clean VM-only sweep can be `release_ready`.

### Deliberately narrow — never papers over genuine failure (the #762 invariant)
The waive engages **only** when the gate is failing *purely by-construction*:
- `image_render_source == "none"` (no VM denominator, no valid mac-handoff), **and**
- no KNOWN unexpected-404 evidence gap (`blocking_image_gap_personas`).

A recorded **vm-network** render rate or a blocking unexpected-404 gap stays authoritative and **hard-fails** the gate even with the flag set. A bare flag with no reason is **refused** (gate stays failed with a "reason required" gap).

## Invariants
- **Additive / default-off:** every pre-existing RRI is byte-identical (47 pre-existing tests still pass unchanged).
- **Scope:** touches only the gate-plumbing/handoff layer (`qa/release_readiness.py`). Does **not** touch viewer/Godot/Unity render code.

## TDD (test-first) — `qa/test_release_readiness.py`
5 new tests:
1. VM-only sweep with no image evidence + valid waiver → `release_ready`, source `waived`, waived annotation present.
2. Genuine recorded **unexpected 404s** → waive **refused**, gate still fails.
3. Recorded **vm-network** 404 rate → waive **refused**, source stays `vm-network`.
4. Bare `--waive-image-render` with no reason → **refused** with a "reason required" gap.
5. Control: no flag → VM-only sweep stays RED-by-construction (byte-identical status quo).

## Verification
- `python3 -m pytest qa/test_release_readiness.py -q -p no:xdist` → **52 passed** (47 pre-existing + 5 new).
- `bash qa/fast_gate.sh` → **PASS** (241 deterministic engine tests).