### PR TITLE
fix(qa): scorer-integrity — a scorer failure must not read as a valid no-score (WS0a)

### DIFF
--- a/qa/SCORING.md
+++ b/qa/SCORING.md
@@ -263,9 +263,26 @@ Scored by `qa/score.sh` (claude -p) or `qa/score_openclaw.sh` (gpt-5.4, off the 
 Default DM/player model = `sonnet` (`WORLDOS_DM_MODEL` / `WORLDOS_ACTOR_MODEL` env override; Opus for key structural-adherence runs).
 
 ## 5. Reading a result line
-`[duo] done. story-craft=X mechanical=Y angry-dm=Z behavioral=GREEN|RED`
+`[duo] done. story-craft=X mechanical=Y angry-dm=Z behavioral=GREEN|RED [status=unscorable]`
 - **RED** ⇒ X/Y/Z are RED-capped; read `$RUN.gate.txt` for the failed checks.
 - **GREEN** ⇒ real scores; compare against the North-Star targets and append via `qa/scores_db.py` `add_run(...)` (→ `scores_ledger.md`; `SCORECARD.md` is legacy).
+
+### A BLANK lens value = scorer FAILURE, not a valid no-score (WS0a)
+A lens value of `FAILED:<status>` (or, on an old build, a **BLANK** value — `story-craft= mechanical=`
+with nothing after the `=`) means **the scorer itself FAILED to produce a score**, NOT that the run
+legitimately has no score. This used to masquerade as a silent valid no-score: when `qa/score.sh`
+exhausted its retries on a generic failure it exited rc=1 **without writing the lens file**, so the
+result line's `jq -r '.overall//"?"'` printed BLANK while `behavioral=GREEN` still printed — a failed
+scoring read as a passing run (observed live: `story-craft= mechanical= angry-dm= behavioral=GREEN`).
+- `qa/score.sh` now **always** leaves the lens file as valid JSON: an `{"error":"scorer_failed",…}`
+  sentinel on generic retry-exhaustion, or `{"quota_exhausted":true,…}` on a 429.
+- `qa/run_duo.sh` validates all three lens files (`worldos_validate_lens_file`): a lens that is
+  missing / empty / non-JSON / a sentinel / non-numeric-`.overall` is **not** a score. Any such
+  lens marks the whole run **`status=unscorable`** — a DISTINCT status that is **neither GREEN
+  (passing) nor a blank no-score**. The lens prints as `FAILED:<missing|invalid|sentinel|nonnumeric>`.
+- **An `unscorable` run is an INFRA failure of the measurement, not a product measurement** — do
+  NOT record it in `scores_db`, do NOT read its (failed) lenses as quality signal. Re-run the
+  scoring (or the whole duo); inspect `$RUN.<lens>.json` for the `error`/`last_api_error` field.
 
 ## 6. Variance & noise floor
 The three LLM lenses are **stochastic graders**: re-scoring the *same comparable run* yields

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -1398,6 +1398,65 @@ json.dump(d, open(path, "w"), indent=2)
 PY
 }
 
+# SCORER-INTEGRITY (WS0a) — validate ONE lens scorecard file. A scorer FAILURE must never read
+# as a valid no-score: when qa/score.sh exhausts its retries it now writes an {error:scorer_failed}
+# sentinel (or, on a 429, {quota_exhausted}); a hard process kill could still leave the file
+# missing/empty. This helper is the single source of truth for "is this lens file a TRUSTWORTHY
+# numeric scorecard?" so run_duo.sh and the test agree by construction.
+# Echoes exactly ONE token on stdout:
+#   ok        — file exists, non-empty, valid JSON, has a NUMERIC .overall (a real scorecard)
+#   missing   — file absent or empty (claude wrote nothing / no sentinel was reachable)
+#   invalid   — present + non-empty but NOT parseable JSON
+#   sentinel  — valid JSON carrying a failure sentinel (.error=="scorer_failed" or .quota_exhausted)
+#   nonnumeric— valid JSON but .overall is absent/non-numeric (a malformed card, not a score)
+# Returns rc=0 ONLY for 'ok'; rc=1 for every NON-ok status so callers can `if worldos_validate_lens_file …`.
+worldos_validate_lens_file() {
+  local path="$1" status
+  if [ ! -s "$path" ]; then
+    echo missing
+    return 1
+  fi
+  # python via `-c` (single-quoted, no heredoc) so the verdict logic can be captured into a var
+  # with $(...) cleanly (a heredoc INSIDE $(...) is fragile across bash versions). $0 is unused;
+  # the lens path is $1.
+  status="$(python3 -c '
+import json, numbers, sys
+try:
+    with open(sys.argv[1]) as fh:
+        d = json.load(fh)
+except Exception:
+    print("invalid"); sys.exit(0)
+if not isinstance(d, dict):
+    print("invalid"); sys.exit(0)
+# A failure sentinel (scorer exhausted retries, or a 429 quota trip) is NOT a score.
+if d.get("error") == "scorer_failed" or d.get("quota_exhausted") is True:
+    print("sentinel"); sys.exit(0)
+ov = d.get("overall")
+# bool is a subclass of int — exclude it; a scorecard overall is a real number.
+if isinstance(ov, bool) or not isinstance(ov, numbers.Number):
+    print("nonnumeric"); sys.exit(0)
+print("ok")
+' "$path" 2>/dev/null)"
+  # A python crash / empty stdout (e.g. python3 missing) → treat as invalid, never silently 'ok'.
+  [ -n "$status" ] || status="invalid"
+  echo "$status"
+  [ "$status" = "ok" ]
+}
+
+# WS0a — render ONE lens's value for the human-facing result line. For a valid scorecard, echo the
+# numeric .overall; for ANYTHING else echo FAILED:<status> so a scorer failure can never print as a
+# BLANK that misreads as a valid no-score (the bug this whole change fixes). Single source of truth
+# for the print so it can't drift from worldos_validate_lens_file's verdict.
+worldos_lens_display() {
+  local path="$1" status
+  status="$(worldos_validate_lens_file "$path")"
+  if [ "$status" = "ok" ]; then
+    jq -r '.overall' "$path" 2>/dev/null
+  else
+    echo "FAILED:${status}"
+  fi
+}
+
 # Campaign Director advisory (#72): at the START of a beat, surface what the campaign OWES — an
 # untracked hook to add_quest, an NPC introduced but still silent, a due consequence to land — so
 # the DM is REMINDED structurally instead of relying on reach-for (the add_quest gap a QA run

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -533,6 +533,29 @@ for _scf in "$T/$RUN.tolkien.json" "$T/$RUN.score.json" "$T/$RUN.angrydm.json"; 
     exit 2
   fi
 done
+# SCORER-INTEGRITY (WS0a) — a scorer FAILURE must NOT read as GREEN/passing or as a blank no-score.
+# score.sh used to exit rc=1 on GENERIC retry-exhaustion WITHOUT writing anything, leaving the lens
+# file missing/empty → the line-~560 `jq -r '.overall//"?"'` printed BLANK with no failure marker, so
+# a failed scoring masqueraded as a silent valid no-score (observed live: 'story-craft= mechanical=
+# angry-dm= behavioral=GREEN'). score.sh now ALWAYS leaves a valid JSON lens file (an {error:scorer_failed}
+# sentinel on exhaustion; {quota_exhausted} on a 429 — the latter already short-circuited above). Here we
+# VALIDATE each of the 3 lens files (exists + non-empty + valid JSON + NUMERIC .overall, not a sentinel)
+# via the shared worldos_validate_lens_file helper, and mark the run a DISTINCT 'unscorable' status if
+# any lens is not a trustworthy numeric scorecard. 'unscorable' is NEITHER green nor a blank no-score.
+UNSCORABLE=0
+UNSCORABLE_DETAIL=""
+for _lens in "tolkien:$T/$RUN.tolkien.json" "mechanical:$T/$RUN.score.json" "angry-dm:$T/$RUN.angrydm.json"; do
+  _lname="${_lens%%:*}"; _lpath="${_lens#*:}"
+  _lstatus="$(worldos_validate_lens_file "$_lpath")"
+  if [ "$_lstatus" != "ok" ]; then
+    UNSCORABLE=1
+    UNSCORABLE_DETAIL="${UNSCORABLE_DETAIL}${UNSCORABLE_DETAIL:+, }${_lname}=${_lstatus}"
+    echo "[duo] SCORER FAILURE — lens '${_lname}' is NOT a valid scorecard (${_lstatus}): $(basename "$_lpath"). This run is UNSCORABLE (a scorer failure, NOT a valid no-score)." >&2
+  fi
+done
+if [ "$UNSCORABLE" = "1" ]; then
+  echo "[duo] RUN STATUS: unscorable — one or more lenses failed to score (${UNSCORABLE_DETAIL}). A blank/sentinel lens value is a scorer FAILURE, not a passing or no-score run." >&2
+fi
 # Behavioral gate — flip RED on a structurally broken run (treat it like software).
 python3 qa/assert_behavioral.py "$COMBINED" "$T/$RUN.state.json" "$T/$RUN.chat.jsonl" "$MOVES" | tee "$T/$RUN.gate.txt"; GATE=${PIPESTATUS[0]}
 # Honest scoring: a gate-RED (non-progressing/structurally broken) run must NOT display as 4.1.
@@ -557,5 +580,9 @@ if python3 qa/latency_rollup.py --dir "$T" --run "$RUN" --tooltiming "$TOOLTIMIN
 else
   LAT_SUMMARY="latency=unavailable"
 fi
-echo "[duo] done. story-craft=$(jq -r '.overall//"?"' "$T/$RUN.tolkien.json" 2>/dev/null) mechanical=$(jq -r '.overall//"?"' "$T/$RUN.score.json" 2>/dev/null) angry-dm=$(jq -r '.overall//"?"' "$T/$RUN.angrydm.json" 2>/dev/null) behavioral=$([ "$GATE" = 0 ] && echo GREEN || echo RED) ${LAT_SUMMARY:-}"
+# WS0a: print each lens via the shared validator so a scorer FAILURE shows as FAILED (not a blank
+# that misreads as a valid no-score). `worldos_lens_display` echoes the numeric .overall for a valid
+# card, else FAILED:<status> (missing|invalid|sentinel|nonnumeric). When ANY lens failed, the line
+# carries an explicit status=unscorable so a downstream reader / a human can never mistake it for GREEN.
+echo "[duo] done. story-craft=$(worldos_lens_display "$T/$RUN.tolkien.json") mechanical=$(worldos_lens_display "$T/$RUN.score.json") angry-dm=$(worldos_lens_display "$T/$RUN.angrydm.json") behavioral=$([ "$GATE" = 0 ] && echo GREEN || echo RED)$([ "$UNSCORABLE" = 1 ] && echo ' status=unscorable') ${LAT_SUMMARY:-}"
 exit $GATE

--- a/qa/score.sh
+++ b/qa/score.sh
@@ -86,6 +86,7 @@ if [ "${WORLDOS_SCORE_GUARD_ONLY:-}" = "1" ]; then
 fi
 
 attempt=0
+LAST_API_ERROR="unknown"   # WS0a: captured per-attempt; stamped into the scorer_failed sentinel below
 while [ "$attempt" -lt 3 ]; do
   attempt=$((attempt + 1))
   # The rubric+schema+transcript+state prompt is ~100-200KB. Passing it as a single
@@ -152,16 +153,40 @@ while [ "$attempt" -lt 3 ]; do
     # No envelope at all → claude itself never produced output (E2BIG, killed, exec fail).
     echo "[score] attempt $attempt: EMPTY output for $(basename "$OUT") — claude wrote NOTHING to stdout (E2BIG / killed / TIMED OUT at ${WORLDOS_SCORE_TIMEOUT:-600}s). Retrying. stderr tail:" >&2
     tail -n 20 "$ERR" >&2 2>/dev/null || echo "[score]   (no stderr captured at $ERR)" >&2
+    LAST_API_ERROR="empty_output (E2BIG / killed / timed out at ${WORLDOS_SCORE_TIMEOUT:-600}s)"
   elif [ -n "$api_err" ]; then
     # A real API-error envelope (e.g. 401 auth, 400, overload). Surface it — don't bury it.
     echo "[score] attempt $attempt: API ERROR ($api_err) for $(basename "$OUT"): $(jq -r '.result // "<no message>"' "$RAW" 2>/dev/null | head -1)" >&2
+    LAST_API_ERROR="$api_err: $(jq -r '.result // "<no message>"' "$RAW" 2>/dev/null | head -1)"
   else
     echo "[score] attempt $attempt: unparseable scorecard / missing .scores for $(basename "$OUT") (possibly transient); retrying…" >&2
+    LAST_API_ERROR="unparseable_scorecard / missing .scores"
   fi
   sleep 5
 done
 
 echo "[score] FAILED after $attempt attempts: $OUT — last stderr tail:" >&2
 tail -n 20 "$ERR" >&2 2>/dev/null || echo "[score]   (no stderr captured at $ERR)" >&2
+# SCORER-INTEGRITY (WS0a): on GENERIC retry-exhaustion (NOT a 429 — that already wrote a
+# {quota_exhausted} sentinel + exited rc=2 above) the old code exited rc=1 WITHOUT writing
+# anything to $OUT, so the lens file was MISSING/EMPTY. Downstream `jq -r '.overall//"?"'`
+# then printed BLANK with no failure indicator — a failed scoring masqueraded as a silent
+# valid no-score (observed live: 'story-craft= mechanical= angry-dm= behavioral=GREEN').
+# Mirror the 429 sentinel block: ALWAYS leave the lens file as valid JSON carrying an
+# explicit {error:"scorer_failed"} marker so run_duo.sh can detect the failure and mark the
+# run 'unscorable' instead of reading a blank as a pass. Use a python heredoc (NOT printf with
+# a raw $LAST_API_ERROR) so an error string with quotes/newlines can never produce invalid JSON.
+python3 - "$OUT" "$attempt" "${LAST_API_ERROR:-unknown}" <<'PY' 2>/dev/null || \
+  printf '{"error":"scorer_failed","attempts":%s,"last_api_error":"json_encode_failed"}\n' "$attempt" > "$OUT"
+import json, sys
+out, attempts, last = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    attempts_n = int(attempts)
+except ValueError:
+    attempts_n = attempts
+json.dump({"error": "scorer_failed", "attempts": attempts_n, "last_api_error": last},
+          open(out, "w"))
+open(out, "a").write("\n")
+PY
 rm -f "$RAW"
 exit 1

--- a/servers/engine/tests/test_scorer_integrity.py
+++ b/servers/engine/tests/test_scorer_integrity.py
@@ -1,0 +1,323 @@
+"""WS0a — scorer-integrity: a scorer FAILURE must never read as a valid no-score / GREEN.
+
+THE SEAM (diagnosed, not re-derived). ``qa/run_duo.sh`` printed each lens via
+``jq -r '.overall//"?"' "$T/$RUN.{tolkien,score,angrydm}.json"``. ``qa/score.sh`` writes a
+``{quota_exhausted}`` sentinel + exits rc=2 on a 429, but on a GENERIC retry-exhaustion it
+USED TO exit rc=1 WITHOUT writing anything — so the lens file was missing/empty, ``jq`` printed
+BLANK (not even ``"?"``), and ``behavioral=GREEN`` still printed. A failed scoring thus
+masqueraded as a silent valid no-score (observed live:
+``[duo] done. story-craft= mechanical= angry-dm= behavioral=GREEN``).
+
+The fix is additive, in three shell surfaces:
+  (1) qa/score.sh — on generic retry-exhaustion, write ``{"error":"scorer_failed",…}`` to its
+      OUT file BEFORE ``exit 1`` (mirroring the existing 429 ``{quota_exhausted}`` block) so the
+      lens file is ALWAYS valid JSON.
+  (2) qa/lib_beat_driver.sh — ``worldos_validate_lens_file`` is the single source of truth for
+      "is this lens a TRUSTWORTHY numeric scorecard?": ok | missing | invalid | sentinel |
+      nonnumeric. ``worldos_lens_display`` renders the numeric overall for a valid card, else
+      ``FAILED:<status>`` (never a blank). qa/run_duo.sh uses both to mark a failed run a
+      DISTINCT ``status=unscorable`` (NEITHER green nor a blank no-score).
+  (3) qa/SCORING.md — documents that a BLANK lens value is a scorer FAILURE.
+
+These tests are gateway-free / offline: they exercise the shared bash helpers directly (the
+same ``/bin/bash -c`` + source-the-lib pattern the play/QA wrappers use, and that
+test_dead_beat_classification.py uses), with deliberately-empty and ``{error:scorer_failed}``-
+sentinel lens fixtures, asserting the run is marked ``unscorable`` (NOT ``ok``/GREEN).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ENGINE_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = ENGINE_DIR.parents[1]
+LIB = REPO_ROOT / "qa" / "lib_beat_driver.sh"
+SCORE_SH = REPO_ROOT / "qa" / "score.sh"
+RUN_DUO = REPO_ROOT / "qa" / "run_duo.sh"
+SCORING_MD = REPO_ROOT / "qa" / "SCORING.md"
+
+
+def _bash(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["/bin/bash", "-c", script], capture_output=True, text=True, cwd=str(REPO_ROOT)
+    )
+
+
+def _hdr() -> str:
+    return f'set -u; . "{LIB}"\n'
+
+
+def _validate(path: Path) -> tuple[str, int]:
+    """Run worldos_validate_lens_file on a fixture; return (status-token, returncode)."""
+    r = _bash(_hdr() + f'worldos_validate_lens_file "{path}"\n')
+    assert r.stderr == "" or "warning" in r.stderr.lower(), r.stderr
+    return r.stdout.strip(), r.returncode
+
+
+def _display(path: Path) -> str:
+    r = _bash(_hdr() + f'worldos_lens_display "{path}"\n')
+    return r.stdout.strip()
+
+
+# ── valid scorecard ─────────────────────────────────────────────────────────────────────────
+
+
+def test_valid_scorecard_is_ok_and_displays_number(tmp_path):
+    f = tmp_path / "tolkien.json"
+    f.write_text(json.dumps({"overall": 4.3, "scores": {"a": 4}}), encoding="utf-8")
+    status, rc = _validate(f)
+    assert status == "ok" and rc == 0, status
+    assert _display(f) == "4.3"
+
+
+def test_integer_overall_is_ok(tmp_path):
+    f = tmp_path / "score.json"
+    f.write_text(json.dumps({"overall": 5, "scores": {}}), encoding="utf-8")
+    status, rc = _validate(f)
+    assert status == "ok" and rc == 0
+    assert _display(f) == "5"
+
+
+# ── the BUG cases: a scorer failure must NOT validate as ok ──────────────────────────────────
+
+
+def test_empty_lens_file_is_missing_not_ok(tmp_path):
+    """The exact bug: score.sh exited rc=1 leaving an EMPTY file → jq printed blank → read GREEN."""
+    f = tmp_path / "angrydm.json"
+    f.write_text("", encoding="utf-8")
+    status, rc = _validate(f)
+    assert status == "missing", f"empty lens must be 'missing', got {status!r}"
+    assert rc != 0, "an empty lens file must NOT return rc=0 (would read as a valid score)"
+    assert _display(f) == "FAILED:missing", "an empty lens must NEVER print a blank value"
+
+
+def test_absent_lens_file_is_missing_not_ok(tmp_path):
+    f = tmp_path / "never_written.json"
+    assert not f.exists()
+    status, rc = _validate(f)
+    assert status == "missing" and rc != 0
+    assert _display(f) == "FAILED:missing"
+
+
+def test_scorer_failed_sentinel_is_not_a_score(tmp_path):
+    """qa/score.sh's NEW generic-exhaustion sentinel must read as a FAILURE, not a valid card."""
+    f = tmp_path / "score.json"
+    f.write_text(
+        json.dumps({"error": "scorer_failed", "attempts": 3, "last_api_error": "401: bad key"}),
+        encoding="utf-8",
+    )
+    status, rc = _validate(f)
+    assert status == "sentinel", f"scorer_failed sentinel must be 'sentinel', got {status!r}"
+    assert rc != 0
+    assert _display(f) == "FAILED:sentinel"
+
+
+def test_quota_exhausted_sentinel_is_not_a_score(tmp_path):
+    """The pre-existing 429 sentinel must also be caught by the same validator (consistency)."""
+    f = tmp_path / "tolkien.json"
+    f.write_text(json.dumps({"quota_exhausted": True, "api_error_status": 429}), encoding="utf-8")
+    status, rc = _validate(f)
+    assert status == "sentinel" and rc != 0
+    assert _display(f) == "FAILED:sentinel"
+
+
+def test_unparseable_json_is_invalid_not_ok(tmp_path):
+    f = tmp_path / "score.json"
+    f.write_text("not json at all {{{ <<", encoding="utf-8")
+    status, rc = _validate(f)
+    assert status == "invalid" and rc != 0
+    assert _display(f) == "FAILED:invalid"
+
+
+def test_missing_overall_is_nonnumeric_not_ok(tmp_path):
+    """A scorecard whose .overall is absent is malformed, not a score."""
+    f = tmp_path / "score.json"
+    f.write_text(json.dumps({"scores": {"a": 4}}), encoding="utf-8")
+    status, rc = _validate(f)
+    assert status == "nonnumeric" and rc != 0
+    assert _display(f) == "FAILED:nonnumeric"
+
+
+def test_bool_overall_is_nonnumeric_not_ok(tmp_path):
+    """bool is an int subclass; True must NOT slip through as a numeric overall."""
+    f = tmp_path / "score.json"
+    f.write_text(json.dumps({"overall": True, "scores": {}}), encoding="utf-8")
+    status, rc = _validate(f)
+    assert status == "nonnumeric" and rc != 0
+
+
+def test_string_overall_is_nonnumeric_not_ok(tmp_path):
+    f = tmp_path / "score.json"
+    f.write_text(json.dumps({"overall": "?", "scores": {}}), encoding="utf-8")
+    status, rc = _validate(f)
+    assert status == "nonnumeric" and rc != 0
+
+
+# ── score.sh writes the generic-exhaustion sentinel (the NEW exit-1 path) ─────────────────────
+
+
+def test_score_sh_writes_scorer_failed_sentinel_block_present():
+    """score.sh must, BEFORE its final ``exit 1``, leave the OUT file as valid JSON carrying the
+    scorer_failed marker (mirrors the existing 429 quota-sentinel block) — pinned at the source so
+    the sentinel block can't be deleted without this test going RED."""
+    src = SCORE_SH.read_text(encoding="utf-8")
+    assert '"scorer_failed"' in src, "score.sh must write an {error:scorer_failed} sentinel"
+    # The sentinel write must come BEFORE the terminal exit 1 (not after — dead code).
+    idx_sentinel = src.find('"scorer_failed"')
+    idx_exit1 = src.rfind("\nexit 1")
+    assert 0 < idx_sentinel < idx_exit1, (
+        "the scorer_failed sentinel must be written BEFORE the final `exit 1`"
+    )
+
+
+def test_score_sh_generic_exhaustion_writes_valid_json_sentinel(tmp_path):
+    """End-to-end on the sentinel-writing snippet: feed a tricky error string (quotes + newline)
+    and assert the resulting OUT is VALID JSON the validator reads as a failure (never blank)."""
+    out = tmp_path / "lens.json"
+    # Mirror score.sh's exact python heredoc fallback contract.
+    script = f'''
+attempt=3
+LAST_API_ERROR='overloaded: "503" Service
+spanning a newline'
+OUT="{out}"
+python3 - "$OUT" "$attempt" "${{LAST_API_ERROR:-unknown}}" <<'PY' 2>/dev/null || \\
+  printf '{{"error":"scorer_failed","attempts":%s,"last_api_error":"json_encode_failed"}}\\n' "$attempt" > "$OUT"
+import json, sys
+out, attempts, last = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    attempts_n = int(attempts)
+except ValueError:
+    attempts_n = attempts
+json.dump({{"error": "scorer_failed", "attempts": attempts_n, "last_api_error": last}},
+          open(out, "w"))
+open(out, "a").write("\\n")
+PY
+. "{LIB}"
+worldos_validate_lens_file "$OUT"
+'''
+    r = _bash(script)
+    assert r.returncode != 0, "the validator must return non-zero for a sentinel"
+    assert r.stdout.strip() == "sentinel", r.stdout
+    d = json.loads(out.read_text(encoding="utf-8"))
+    assert d["error"] == "scorer_failed" and d["attempts"] == 3
+    assert "503" in d["last_api_error"], "the error string must round-trip into the sentinel"
+
+
+# ── run_duo.sh wires the validator + the distinct 'unscorable' status ─────────────────────────
+
+
+def test_run_duo_validates_lenses_and_marks_unscorable():
+    """run_duo.sh must call the shared validator on the 3 lens files and emit the DISTINCT
+    'unscorable' status — pinned at the source so the wiring can't silently regress to the old
+    blank-jq print."""
+    src = RUN_DUO.read_text(encoding="utf-8")
+    assert "worldos_validate_lens_file" in src, "run_duo.sh must validate each lens file"
+    assert "unscorable" in src, "run_duo.sh must mark a failed-scoring run 'unscorable'"
+    assert "worldos_lens_display" in src, (
+        "run_duo.sh must print lenses via worldos_lens_display (never the old blank `.overall//\"?\"`)"
+    )
+    # The old blank-prone print must be gone from the ACTUAL result-line echo (comments that
+    # quote the old pattern when explaining the fix are fine — only the live `[duo] done.` echo
+    # matters). Find the result-line echo and assert it no longer uses the blank-prone jq.
+    result_lines = [
+        ln for ln in src.splitlines()
+        if "[duo] done." in ln and not ln.lstrip().startswith("#")
+    ]
+    assert result_lines, "the `[duo] done.` result-line echo must exist"
+    for ln in result_lines:
+        assert ".overall//\"?\"" not in ln, (
+            "the result-line echo must NOT use `jq -r '.overall//\"?\"'` (it prints BLANK on a "
+            f"failed scorer, masquerading as a no-score): {ln!r}"
+        )
+        assert "worldos_lens_display" in ln, (
+            f"the result-line echo must render lenses via worldos_lens_display: {ln!r}"
+        )
+
+
+def test_run_duo_unscorable_branch_distinct_from_green(tmp_path):
+    """Drive run_duo.sh's lens-validation + print logic in isolation with one EMPTY lens and one
+    scorer_failed-SENTINEL lens (+ one good lens): the result line must NOT read as a clean GREEN —
+    it must surface FAILED lenses AND status=unscorable. This is the core anti-regression: a failed
+    scorer is NEITHER green nor a blank no-score."""
+    good = tmp_path / "good.json"
+    good.write_text(json.dumps({"overall": 4.2, "scores": {}}), encoding="utf-8")
+    empty = tmp_path / "empty.json"
+    empty.write_text("", encoding="utf-8")
+    sentinel = tmp_path / "sentinel.json"
+    sentinel.write_text(json.dumps({"error": "scorer_failed", "attempts": 3}), encoding="utf-8")
+
+    # Faithful extract of run_duo.sh's WS0a block + result print (the load-bearing logic).
+    script = f'''
+. "{LIB}"
+GATE=0
+UNSCORABLE=0
+UNSCORABLE_DETAIL=""
+for _lens in "story-craft:{good}" "mechanical:{empty}" "angry-dm:{sentinel}"; do
+  _lname="${{_lens%%:*}}"; _lpath="${{_lens#*:}}"
+  _lstatus="$(worldos_validate_lens_file "$_lpath")"
+  if [ "$_lstatus" != "ok" ]; then
+    UNSCORABLE=1
+    UNSCORABLE_DETAIL="${{UNSCORABLE_DETAIL}}${{UNSCORABLE_DETAIL:+, }}${{_lname}}=${{_lstatus}}"
+  fi
+done
+echo "[duo] done. story-craft=$(worldos_lens_display "{good}") mechanical=$(worldos_lens_display "{empty}") angry-dm=$(worldos_lens_display "{sentinel}") behavioral=$([ "$GATE" = 0 ] && echo GREEN || echo RED)$([ "$UNSCORABLE" = 1 ] && echo ' status=unscorable')"
+'''
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    line = r.stdout.strip()
+    assert "status=unscorable" in line, f"a failed-scorer run must be marked unscorable: {line!r}"
+    assert "mechanical=FAILED:missing" in line, f"the empty lens must print FAILED, not blank: {line!r}"
+    assert "angry-dm=FAILED:sentinel" in line, f"the sentinel lens must print FAILED: {line!r}"
+    assert "story-craft=4.2" in line, "the one good lens still shows its number"
+    # CRITICAL: the failed lenses must NOT print blank (the original masquerade).
+    assert "mechanical= " not in line and not line.rstrip().endswith("mechanical="), (
+        f"a failed lens must never print a BLANK value: {line!r}"
+    )
+
+
+def test_run_duo_all_good_lenses_not_unscorable(tmp_path):
+    """The happy path stays clean: 3 valid scorecards → numeric values, NO status=unscorable."""
+    paths = []
+    for i, name in enumerate(("a", "b", "c")):
+        p = tmp_path / f"{name}.json"
+        p.write_text(json.dumps({"overall": 4.0 + i * 0.1, "scores": {}}), encoding="utf-8")
+        paths.append(p)
+    script = f'''
+. "{LIB}"
+GATE=0
+UNSCORABLE=0
+for _p in "{paths[0]}" "{paths[1]}" "{paths[2]}"; do
+  [ "$(worldos_validate_lens_file "$_p")" != "ok" ] && UNSCORABLE=1
+done
+echo "[duo] done. story-craft=$(worldos_lens_display "{paths[0]}") mechanical=$(worldos_lens_display "{paths[1]}") angry-dm=$(worldos_lens_display "{paths[2]}") behavioral=$([ "$GATE" = 0 ] && echo GREEN || echo RED)$([ "$UNSCORABLE" = 1 ] && echo ' status=unscorable')"
+'''
+    r = _bash(script)
+    assert r.returncode == 0, r.stderr
+    line = r.stdout.strip()
+    assert "status=unscorable" not in line, f"all-valid run must NOT be unscorable: {line!r}"
+    assert "story-craft=4.0" in line and "mechanical=4.1" in line and "angry-dm=4.2" in line
+    assert "FAILED:" not in line
+
+
+# ── doc: SCORING.md documents the blank-lens semantics ───────────────────────────────────────
+
+
+def test_scoring_md_documents_blank_lens_is_scorer_failure():
+    md = SCORING_MD.read_text(encoding="utf-8")
+    assert "unscorable" in md, "SCORING.md must document the 'unscorable' status"
+    assert "scorer FAILURE" in md or "scorer failure" in md.lower(), (
+        "SCORING.md must document that a BLANK lens value is a scorer FAILURE, not a valid no-score"
+    )
+
+
+# ── hygiene: the touched shell surfaces stay /bin/bash -n clean (macOS bash 3.2) ──────────────
+
+
+@pytest.mark.parametrize("rel", ["qa/lib_beat_driver.sh", "qa/score.sh", "qa/run_duo.sh"])
+def test_touched_scripts_parse_under_bin_bash(rel):
+    r = subprocess.run(["/bin/bash", "-n", str(REPO_ROOT / rel)], capture_output=True, text=True)
+    assert r.returncode == 0, f"{rel} failed bash -n: {r.stderr}"


### PR DESCRIPTION
## WS0a — Scorer-integrity: fix the silent scorer no-score masquerade

### The seam
`qa/run_duo.sh` printed each lens via `jq -r '.overall//"?"' "$T/$RUN.{tolkien,score,angrydm}.json"`. `qa/score.sh` writes a `{quota_exhausted}` sentinel + `exit 2` on a **429**, but on **generic retry-exhaustion** it exited `rc=1` **without writing anything** — so the lens file was missing/empty, `jq` printed **BLANK** (not even `"?"`) with no failure indicator, while `behavioral=GREEN` still printed.

A failed scoring thus masqueraded as a silent valid no-score. Observed live:

```
[duo] done. story-craft= mechanical= angry-dm= behavioral=GREEN
```

### The fix (additive, default-on, each part independently removable)

**(1) `qa/score.sh`** — on generic retry-exhaustion, **before** `exit 1`, write `{"error":"scorer_failed","attempts":N,"last_api_error":"<msg>"}` to its OUT file (mirrors the existing 429 `{quota_exhausted}` sentinel block) so the lens file is **always valid JSON**. The last per-attempt error is captured into `LAST_API_ERROR` and JSON-encoded via a python heredoc (with a `printf` fallback) so quotes/newlines in the error string can never produce invalid JSON.

**(2) `qa/lib_beat_driver.sh`** — `worldos_validate_lens_file` is the single source of truth for "is this lens a trustworthy numeric scorecard?" → `ok | missing | invalid | sentinel | nonnumeric` (rc=0 only for `ok`). `worldos_lens_display` renders the numeric `.overall` for a valid card, else `FAILED:<status>` (never blank). `qa/run_duo.sh` validates all 3 lens files after the scoring wait and marks the run a **distinct `status=unscorable`** (neither green nor a blank no-score); the result line now prints via `worldos_lens_display`.

**(3) `qa/SCORING.md`** (section 5) — documents that a **BLANK lens value = scorer FAILURE**, not a valid no-score, and that an `unscorable` run is an INFRA failure (don't record in `scores_db`, don't read as quality signal).

### TDD
`servers/engine/tests/test_scorer_integrity.py` (19 tests). Empty, `{error:scorer_failed}`-sentinel, `{quota_exhausted}`-sentinel, invalid-JSON, missing-`overall`, bool/string-`overall` fixtures all assert the run is **NOT** `ok`/GREEN (marked `unscorable`). Plus source-pins on the score.sh sentinel block, the run_duo.sh wiring, and the doc.

### Verification
- `uv run --directory servers/engine python -m pytest tests/test_scorer_integrity.py -q -p no:xdist` → **19 passed**
- Existing lib/runner tests (`test_dead_beat_classification.py`, `test_dm_session_remint.py`, `test_lean_output_discipline.py`) → **51 passed**
- `bash qa/fast_gate.sh` → **T0 PASS (241 passed)**
- `bash -n` + `shellcheck -S error` clean on all 3 modified scripts (macOS bash 3.2)

### Invariants
Engine untouched (sole-writer preserved). Additive: a 429 still short-circuits to the existing quota path; a GREEN all-valid run is byte-equivalent in semantics (numeric lens values, no `status=unscorable`). QA-only, gateway-free, never touches Eva.