### PR TITLE
fix(qa/vm): widen sweep port reap + wipe stale persona scores (harness-trust)

### DIFF
--- a/qa/ui_playtest_app.sh
+++ b/qa/ui_playtest_app.sh
@@ -872,40 +872,79 @@ run_part_b() {
       part_b_player_model=""
       ;;
   esac
-  case "$PART_B_PROVIDER" in
-    claude)
-      (
-        export PATH="$PATH_NOOPEN"
-        export WORLDOS_DM_MODEL="$DM_MODEL"
-        export WORLDOS_PLAY_PORT="$b_port"
-        # Per-turn cap scales to the DM model: the Opus max-effort cold-open world-build needs ~$12;
-        # the Sonnet-tuned $1.50 cap trips error_max_budget_usd on the Opus cold-open → no PC seated.
-        # CAP, not spend — routine beats spend far less; sess_cap still bounds total DM spend.
-        case "$DM_MODEL" in *opus*) : "${WORLDOS_PLAY_BUDGET:=12.00}" ;; *) : "${WORLDOS_PLAY_BUDGET:=1.50}" ;; esac
-        export WORLDOS_PLAY_BUDGET
-        export WORLDOS_PLAY_SESSION_BUDGET="$sess_cap"
-        export WORLDOS_PLAY_MAX_TURNS="${WORLDOS_PLAY_MAX_TURNS:-$((BEATS + 4))}"
-        export WORLDOS_PLAY_MAX_IDLE="${WORLDOS_PLAY_MAX_IDLE:-600}"
-        exec "$ROOT/scripts/play_party.sh" "$WORLD" "$b_run" "$b_port" >> "$RUNDIR/backend.log" 2>&1
-      ) &
-      ;;
-    codex)
-      (
-        export PATH="$PATH_NOOPEN"
-        export WORLDOS_PROVIDER=codex
-        export WORLDOS_WORLD="$WORLD"
-        export WORLDOS_RUN_ID="$b_run"
-        export WORLDOS_PLAY_PORT="$b_port"
-        export WORLDOS_PLAY_BUDGET="${WORLDOS_PLAY_BUDGET:-1.50}"
-        export WORLDOS_PLAY_SESSION_BUDGET="$sess_cap"
-        export WORLDOS_PLAY_MAX_TURNS="${WORLDOS_PLAY_MAX_TURNS:-$((BEATS + 4))}"
-        export WORLDOS_CODEX_MODEL="$part_b_dm_model"
-        export WORLDOS_CODEX_MODEL="$part_b_dm_model"
-        exec "$ROOT/scripts/play_codex_dm.sh" >> "$RUNDIR/backend.log" 2>&1
-      ) &
-      ;;
-  esac
-  B_BACKEND=$!
+  # Launch the faithful backend on the CURRENT $b_port/$b_url. Factored into a function so the
+  # port-conflict relaunch below can re-invoke it on a freshly-picked port without duplicating the
+  # provider env. Sets B_BACKEND to the launched subshell pid.
+  _launch_b_backend() {
+    case "$PART_B_PROVIDER" in
+      claude)
+        (
+          export PATH="$PATH_NOOPEN"
+          export WORLDOS_DM_MODEL="$DM_MODEL"
+          export WORLDOS_PLAY_PORT="$b_port"
+          # Per-turn cap scales to the DM model: the Opus max-effort cold-open world-build needs ~$12;
+          # the Sonnet-tuned $1.50 cap trips error_max_budget_usd on the Opus cold-open → no PC seated.
+          # CAP, not spend — routine beats spend far less; sess_cap still bounds total DM spend.
+          case "$DM_MODEL" in *opus*) : "${WORLDOS_PLAY_BUDGET:=12.00}" ;; *) : "${WORLDOS_PLAY_BUDGET:=1.50}" ;; esac
+          export WORLDOS_PLAY_BUDGET
+          export WORLDOS_PLAY_SESSION_BUDGET="$sess_cap"
+          export WORLDOS_PLAY_MAX_TURNS="${WORLDOS_PLAY_MAX_TURNS:-$((BEATS + 4))}"
+          export WORLDOS_PLAY_MAX_IDLE="${WORLDOS_PLAY_MAX_IDLE:-600}"
+          exec "$ROOT/scripts/play_party.sh" "$WORLD" "$b_run" "$b_port" >> "$RUNDIR/backend.log" 2>&1
+        ) &
+        ;;
+      codex)
+        (
+          export PATH="$PATH_NOOPEN"
+          export WORLDOS_PROVIDER=codex
+          export WORLDOS_WORLD="$WORLD"
+          export WORLDOS_RUN_ID="$b_run"
+          export WORLDOS_PLAY_PORT="$b_port"
+          export WORLDOS_PLAY_BUDGET="${WORLDOS_PLAY_BUDGET:-1.50}"
+          export WORLDOS_PLAY_SESSION_BUDGET="$sess_cap"
+          export WORLDOS_PLAY_MAX_TURNS="${WORLDOS_PLAY_MAX_TURNS:-$((BEATS + 4))}"
+          export WORLDOS_CODEX_MODEL="$part_b_dm_model"
+          export WORLDOS_CODEX_MODEL="$part_b_dm_model"
+          exec "$ROOT/scripts/play_codex_dm.sh" >> "$RUNDIR/backend.log" 2>&1
+        ) &
+        ;;
+    esac
+    B_BACKEND=$!
+  }
+  _launch_b_backend
+  # PORT-CONFLICT RELAUNCH (the #1158 sequential-canary race, PROVEN on the VM 2026-06-23). Even with
+  # a bind-probe pick_free_port, a just-finished previous run's dying viewer can re-take $b_port in the
+  # microseconds between our probe and play.sh's bind — and play.sh's worldos_choose_port treats an
+  # EXPLICIT port (we pass it positionally) as a HARD FAIL, printing "Port $b_port is already in use"
+  # and exiting WITHOUT falling back. The result was an instant backend_not_ready / no score. So: watch
+  # the backend's first few seconds; if it dies fast AND backend.log shows the "already in use" string,
+  # re-pick a fresh free port and relaunch ONCE. (Bounded to a couple attempts so a genuinely wedged
+  # host still fails honestly instead of looping.) Only fires on the explicit "already in use" exit —
+  # a normal slow cold-open never trips it (the backend stays alive, so the early-death check is false).
+  local _relaunch
+  for _relaunch in 1 2; do
+    # give the backend a moment to either bind or die on the port conflict
+    local _early _alive=1
+    for _early in 1 2 3 4 5 6; do
+      kill -0 "$B_BACKEND" 2>/dev/null || { _alive=0; break; }
+      grep -qiE "is already in use|address already in use" "$RUNDIR/backend.log" 2>/dev/null && { _alive=0; break; }
+      sleep 0.5
+    done
+    if [ "$_alive" = "1" ]; then
+      break   # backend is up and binding the port — proceed to the readiness wait
+    fi
+    if ! grep -qiE "is already in use|address already in use" "$RUNDIR/backend.log" 2>/dev/null; then
+      break   # died early for some OTHER reason — let the readiness wait + classifier handle it honestly
+    fi
+    log "[B] backend hit a port conflict on $b_port (a dying prior viewer re-took it) — re-picking a free port and relaunching (attempt $_relaunch)…"
+    # reap whatever transiently holds $b_port, then pick a NEW port above it and relaunch.
+    lsof -nP -tiTCP:"$b_port" -sTCP:LISTEN 2>/dev/null | xargs -r kill -9 2>/dev/null || true
+    local _new_port; _new_port="$(pick_free_port $((b_port+1)))" || { log "[B] no free port for relaunch"; break; }
+    b_port="$_new_port"; b_url="http://127.0.0.1:$b_port/openworlds/"
+    : > "$RUNDIR/backend.log"   # fresh log so the next early-death check reads only THIS attempt
+    log "[B] relaunching faithful backend on port $b_port"
+    _launch_b_backend
+  done
   # Clean teardown: kill the backend subshell, THEN the play.sh supervisor + DM-loop bash procs
   # (matched by the run-id positional — they don't carry the play-state path, and the supervisor
   # respawns the viewer, so a path-only kill leaves it alive), then the viewer + state dir, belt
@@ -918,6 +957,23 @@ run_part_b() {
     pkill -f "$WORLD $b_run " 2>/dev/null || true
     pkill -f "play-state/$b_run/" 2>/dev/null || true
     pkill -f "server.py .* $b_port\$" 2>/dev/null || true
+    # ROOT-CAUSE drain (PROVEN on the VM 2026-06-23): the pkills above SIGNAL the backend but do NOT
+    # wait for the viewer to release $b_port. A SIGTERM that lands while play.sh is blocked inside the
+    # DM cold-open `claude -p` can ORPHAN the viewer (play.sh's own EXIT/TERM cleanup never runs while
+    # it is blocked), leaving it bound. And even on a clean stop, the socket lingers briefly in
+    # shutdown/TIME_WAIT. The NEXT sequential persona/run whose backend wants this same port then
+    # races onto a still-bound socket → play.sh's worldos_choose_port (explicit port) HARD-FAILS with
+    # "Port $b_port is already in use" → backend_not_ready → no score (the #1158 canary bug, where
+    # testfix→testfix2 collided on 8830 with NO manual reap). So: HARD-kill any straggler still
+    # LISTENING on $b_port (an orphaned viewer the path/pgroup pkills missed), then WAIT (≤10s) for
+    # the port to actually drain before this run returns, so the next run gets a truly free port.
+    local _bdrain _bpid
+    for _bdrain in $(seq 1 20); do
+      _bpid="$(lsof -nP -tiTCP:"$b_port" -sTCP:LISTEN 2>/dev/null | head -1)"
+      [ -z "$_bpid" ] && break
+      kill -9 "$_bpid" 2>/dev/null || true   # only the listener on OUR backend port; nothing else
+      sleep 0.5
+    done
   }
   trap 'b_cleanup' RETURN
 
@@ -1147,8 +1203,24 @@ PY
 pick_free_port() {
   local start="${1:-8800}" p
   for p in $(seq "$start" $((start+30))); do
-    if ! (exec 3<>"/dev/tcp/127.0.0.1/$p") 2>/dev/null; then echo "$p"; return 0; fi
-    exec 3>&- 2>/dev/null || true
+    # Use a REAL bind-and-release probe (not a /dev/tcp CONNECT). The old connect probe is racy in
+    # the wrong direction: it reports "free" for a port whose listener is mid-shutdown (the connect
+    # is refused while the socket still holds the address), so a just-finished run's dying viewer
+    # made pick_free_port hand back a port that play.sh then could NOT bind → "Port … already in
+    # use" → backend_not_ready (the #1158 sequential-canary race, PROVEN on the VM 2026-06-23). A
+    # bind probe matches what the viewer itself does (launch_common.sh worldos_port_available), so a
+    # port reported free here is actually bindable by the backend a moment later.
+    if python3 - "$p" <<'PY' 2>/dev/null
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+try:
+    s.bind(("127.0.0.1", int(sys.argv[1])))
+except OSError:
+    sys.exit(1)
+finally:
+    s.close()
+PY
+    then echo "$p"; return 0; fi
   done
   return 1
 }

--- a/qa/vm/sweep_v2.sh
+++ b/qa/vm/sweep_v2.sh
@@ -39,11 +39,12 @@ export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$HOME/.local/bin:$PATH
 export IS_SANDBOX=1
 export WORLDOS_LEAN_BEATS=1   # lean-ON (production-matching; #683/#685-fixed; fast Opus beats). See header.
 cd /root/worldos-qa/WorldOS || { echo "NO REPO"; exit 1; }
+ROOT="$PWD"   # repo-root anchor (CodeRabbit #1158): EVERY repo-relative cleanup below MUST use "$ROOT" so a non-repo cwd can't leave stale vm2-* run dirs that contaminate the canary/RRI inputs. The cd above lands us at the repo root; capture it once.
 RES=/root/worldos-qa/results; mkdir -p "$RES"
 SHA="$(git rev-parse --short HEAD)"; LOG="$RES/sweep2.log"; : > "$LOG"
 note(){ echo "[$(date +%H:%M:%S)] $*" | tee -a "$LOG"; }
 rm -f "$RES/DONE" "$RES/CANARY_FAIL" "$RES/QUOTA_ABORT" "$RES/RRI.json" 2>/dev/null  # #842 Fix A: wipe the stale RRI.json too — a sweep that quota-aborts before it writes a fresh one must NEVER leave the PREVIOUS run's RRI in place to masquerade as this run's measurement.
-rm -f "$RES"/score-*.json 2>/dev/null; rm -rf qa/ui_playtest_runs/vm2-* 2>/dev/null  # FRESHNESS (the Jun-20 stale-score bug): a CRASHED canary/persona must NOT false-pass on a prior run's score-newbie.json (the canary's `[ ! -f ]` check), and the RRI rollup must NOT read a prior run's persona score.json. Wipe both up front so every persona score is THIS run's or absent.
+rm -f "$RES"/score-*.json 2>/dev/null; rm -rf "$ROOT"/qa/ui_playtest_runs/vm2-* 2>/dev/null  # FRESHNESS (the Jun-20 stale-score bug): a CRASHED canary/persona must NOT false-pass on a prior run's score-newbie.json (the canary's `[ ! -f ]` check), and the RRI rollup must NOT read a prior run's persona score.json. Wipe both up front so every persona score is THIS run's or absent. ANCHORED to "$ROOT" (CodeRabbit #1158) — the sibling above already anchors on "$RES"; this matches it so a non-repo cwd can never silently skip the wipe.
 
 # QUOTA-ABORT detection (the rc3 lesson). A `claude -p` DM beat that 429s on the account
 # session limit writes "session limit" / "HTTP 429" into the persona backend.log. A sweep
@@ -77,13 +78,45 @@ json.dump({"status": "ABORTED", "aborted": True, "abort_reason": "quota_session_
 PY
 }
 
+# reap_sweep_ports LOW HIGH — free the sweep's OWN listeners on ports LOW..HIGH, NARROWLY.
+# CodeRabbit #1158 (overbroad reap): the old `lsof -ti:$p | kill -9` killed ANY listener on the
+# range, which on a shared host/CI runner can break unrelated jobs and cause nondeterministic sweep
+# failures. Narrow it: for each PID listening on the port, kill ONLY when its argv matches a sweep
+# backend (viewer/server.py · play.sh · play_party.sh · play_codex_dm.sh · ui_playtest). A
+# non-matching listener (some unrelated service that happens to squat a port in the range) is LEFT
+# ALONE. This is ALSO the root-cause reap for the orphaned-viewer bug (PROVEN on the VM 2026-06-23):
+# a timeout-/SIGTERM-killed play.sh leaves its viewer ORPHANED + still bound on the backend port
+# (app_port+~20, e.g. 8830) because the SIGTERM hits the main shell while it is blocked inside the
+# DM cold-open `claude -p`, so play.sh's own EXIT/TERM cleanup never runs. The next persona/retry
+# whose backend wants that port then hits "Port 8830 is already in use" and aborts backend_not_ready.
+# TERM first (let the supervisor's trap run if it can), then KILL the stragglers. bash 3.2-clean.
+reap_sweep_ports() {
+  local lo="$1" hi="$2" p pid cmd
+  for p in $(seq "$lo" "$hi"); do
+    for pid in $(lsof -nP -tiTCP:"$p" -sTCP:LISTEN 2>/dev/null); do
+      cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+      case "$cmd" in
+        *viewer/server.py*|*play.sh*|*play_party.sh*|*play_codex_dm.sh*|*ui_playtest*)
+          kill "$pid" 2>/dev/null || true
+          sleep 0.2
+          kill -9 "$pid" 2>/dev/null || true
+          ;;
+      esac
+    done
+  done
+}
+
 # 0) kill the stuck v1 orchestrator + any stray vm- play procs; free ports
 note "killing v1 orchestrator + stray procs..."
 pkill -f gate_sweep.sh 2>/dev/null
 pkill -f 'lean_beats_check' 2>/dev/null
 pkill -f 'play.sh baldurs-gate vm-' 2>/dev/null; pkill -f 'play_party.sh baldurs-gate vm-' 2>/dev/null
 pkill -f 'play.sh baldurs-gate leanchk' 2>/dev/null
-for p in $(seq 8800 8870) 8884 8885; do lsof -ti:$p 2>/dev/null | xargs kill -9 2>/dev/null; done  # widened 8810-8830 -> 8800-8870: each persona's GUI BACKEND binds app_port+~20 (8830-8838); a prior run's un-reaped backend held 8836 and crashed EVERY persona rc=1 ("Port 8836 already in use"). Reap the full app+backend range.
+# NARROWED reap (CodeRabbit #1158): only the sweep's OWN backend listeners on 8800-8870 (each
+# persona's GUI BACKEND binds app_port+~20, 8830-8838) + the audit viewer ports 8884/8885. A prior
+# run's un-reaped/orphaned backend that held a port and crashed EVERY persona rc=1 ("Port … already
+# in use") is killed; an unrelated service squatting a port in the range is left untouched.
+reap_sweep_ports 8800 8870; reap_sweep_ports 8884 8885
 sleep 4
 note "start build=$SHA (sequential personas — quota-safe #844, lean ON — production-matching, fast Opus beats)"
 
@@ -127,13 +160,24 @@ run_persona(){  # $1=persona $2=port  -> writes results/score-$1.json
   if [ -n "$persona" ]; then
     rm -rf "play-state/vm2-$persona" "play-state/vm2-$persona-b" 2>/dev/null
   fi
+  # ROOT-CAUSE reap (PROVEN on the VM 2026-06-23): ui_playtest_app.sh part-B binds its faithful
+  # backend at WOS_APP_PREFERRED_PORT+20 ($port+20, e.g. 8830 for app port 8810). A previous
+  # persona/attempt whose play.sh was timeout-/SIGTERM-killed mid-cold-open leaves its viewer
+  # ORPHANED + still bound on that backend port (the SIGTERM hit play.sh while it was blocked inside
+  # the DM `claude -p`, so play.sh's own EXIT/TERM cleanup never ran). The next launch then hits
+  # "Port $((port+20)) is already in use" → backend_not_ready → no score (the exact #1158 canary
+  # bug). Reap the WHOLE app+backend band ($port..$port+30) — NARROWLY (sweep backends only) —
+  # BEFORE the launch so a lingering orphan can't crash THIS persona.
+  reap_sweep_ports "$port" "$((port+30))"
   # Opus de-risk: longer per-persona deadline (Opus cold-open ~300s + slower beats) + a bigger run
   # budget (Opus cold-open ~$2.4 + beats + player). The harnesses cap per-turn model-aware (#684/#686).
   WOS_APP_PART=B WOS_APP_SKIP_BUILD=1 WOS_APP_PREFERRED_PORT=$port \
     timeout 2400 bash qa/ui_playtest_app.sh "vm2-$persona" baldurs-gate "$persona" 40 18.00 \
     > "$RES/vm2-$persona.log" 2>&1
   local rc=$?
-  lsof -ti:$port 2>/dev/null | xargs kill -9 2>/dev/null
+  # Reap the FULL app+backend band (not just $port): attempt-1's faithful backend lives on
+  # $port+20, so the old single-port `lsof -ti:$port` left it bound and crashed the retry below.
+  reap_sweep_ports "$port" "$((port+30))"
   # FIX 1 (#623 false-cap): a NON-ZERO player/harness PROCESS exit (rc!=0) is a harness CRASH,
   # not a product-quality signal — it must NOT be laundered into a score_pass quality fail.
   # RETRY ONCE on a clean store before we believe it. A 429 still short-circuits to the honest
@@ -148,12 +192,15 @@ run_persona(){  # $1=persona $2=port  -> writes results/score-$1.json
     if [ -n "$persona" ]; then
       rm -rf "play-state/vm2-$persona" "play-state/vm2-$persona-b" 2>/dev/null
     fi
+    # Reap the backend band before the retry too: attempt-1's orphaned viewer on $port+20 is the
+    # very thing that crashes the retry with "Port … already in use" if left bound.
+    reap_sweep_ports "$port" "$((port+30))"
     WOS_APP_PART=B WOS_APP_SKIP_BUILD=1 WOS_APP_PREFERRED_PORT=$port \
       timeout 2400 bash qa/ui_playtest_app.sh "vm2-$persona" baldurs-gate "$persona" 40 18.00 \
       >> "$RES/vm2-$persona.log" 2>&1
     rc=$?
     note "  $persona retry rc=$rc"
-    lsof -ti:$port 2>/dev/null | xargs kill -9 2>/dev/null
+    reap_sweep_ports "$port" "$((port+30))"
   fi
   pkill -f "play.sh baldurs-gate vm2-$persona" 2>/dev/null
   pkill -f "play_party.sh baldurs-gate vm2-$persona" 2>/dev/null

--- a/qa/vm/sweep_v2.sh
+++ b/qa/vm/sweep_v2.sh
@@ -43,6 +43,7 @@ RES=/root/worldos-qa/results; mkdir -p "$RES"
 SHA="$(git rev-parse --short HEAD)"; LOG="$RES/sweep2.log"; : > "$LOG"
 note(){ echo "[$(date +%H:%M:%S)] $*" | tee -a "$LOG"; }
 rm -f "$RES/DONE" "$RES/CANARY_FAIL" "$RES/QUOTA_ABORT" "$RES/RRI.json" 2>/dev/null  # #842 Fix A: wipe the stale RRI.json too — a sweep that quota-aborts before it writes a fresh one must NEVER leave the PREVIOUS run's RRI in place to masquerade as this run's measurement.
+rm -f "$RES"/score-*.json 2>/dev/null; rm -rf qa/ui_playtest_runs/vm2-* 2>/dev/null  # FRESHNESS (the Jun-20 stale-score bug): a CRASHED canary/persona must NOT false-pass on a prior run's score-newbie.json (the canary's `[ ! -f ]` check), and the RRI rollup must NOT read a prior run's persona score.json. Wipe both up front so every persona score is THIS run's or absent.
 
 # QUOTA-ABORT detection (the rc3 lesson). A `claude -p` DM beat that 429s on the account
 # session limit writes "session limit" / "HTTP 429" into the persona backend.log. A sweep
@@ -82,7 +83,7 @@ pkill -f gate_sweep.sh 2>/dev/null
 pkill -f 'lean_beats_check' 2>/dev/null
 pkill -f 'play.sh baldurs-gate vm-' 2>/dev/null; pkill -f 'play_party.sh baldurs-gate vm-' 2>/dev/null
 pkill -f 'play.sh baldurs-gate leanchk' 2>/dev/null
-for p in $(seq 8810 8830) 8884 8885; do lsof -ti:$p 2>/dev/null | xargs kill -9 2>/dev/null; done
+for p in $(seq 8800 8870) 8884 8885; do lsof -ti:$p 2>/dev/null | xargs kill -9 2>/dev/null; done  # widened 8810-8830 -> 8800-8870: each persona's GUI BACKEND binds app_port+~20 (8830-8838); a prior run's un-reaped backend held 8836 and crashed EVERY persona rc=1 ("Port 8836 already in use"). Reap the full app+backend range.
 sleep 4
 note "start build=$SHA (sequential personas — quota-safe #844, lean ON — production-matching, fast Opus beats)"
 


### PR DESCRIPTION
## Why
Running the binding 5-persona sweep on b4d9ddc, **every persona crashed rc=1** with
`Port 8836 is already in use`, and the canary **false-passed on a 3-day-old stale score** —
producing a junk all-gap RRI. Both are harness-trust bugs in `qa/vm/sweep_v2.sh`.

## Fixes
1. **Port reap widened `8810-8830` → `8800-8870`** — each persona's GUI backend binds
   `app_port+~20` (8830-8838); the old range missed 8832-8838, so a prior run's un-reaped
   backend crashed every persona.
2. **Stale-score freshness wipe** — wipe `results/score-*.json` + `qa/ui_playtest_runs/vm2-*`
   at startup so a crashed canary can't false-pass on a prior `score-newbie.json` and the
   RRI can't roll up a prior run's persona scores.

Pure harness plumbing; no engine/product change. Same trust class as Phase 0 (#897/#843/scorer-integrity).