### PR TITLE
Document GEX44 GPU persistence lane

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@
 
 - Internal GPU compute host `evaos-gpu-gex44-1` (Hetzner GEX44, RTX 4000 SFF Ada / 64 GB / Ubuntu 24.04) — NOT a customer VM. Supabase source of truth is `fleet_nodes` with `role = gpu_compute`; do not create or use a `gpu_vms` inventory table for this host.
 - Operator access is operator-only (outside tracked docs): key `~/.openclaw/secrets/evaos-gpu-gex44-1-key`, connection refs in `~/.openclaw/secrets/gex44.env`.
-- **Provisioning is COMPLETE (2026-06-26):** the heavy part-B sweep lane, CUDA/local-AI, and the Unity 6000.5.1f1 + Unity-MCP render loop are all proven on the box. GEX44 is now the **preferred** heavy-sweep + Unity/visual-renderer host (the 32 GB support VM is the fallback). Operational details + the connect/capture recipes live in `WorldOS-GUI-RUNBOOK.md` → "GPU-VM lane".
+- **Provisioning is COMPLETE** (verified on-box: the heavy part-B sweep lane, CUDA/local-AI, and the Unity 6000.5.1f1 + Unity-MCP render loop are all proven). GEX44 is now the **preferred** heavy-sweep + Unity/visual-renderer host (the 32 GB support VM is the fallback). Operational details + the connect/capture recipes live in `WorldOS-GUI-RUNBOOK.md` → "GPU-VM lane".
 - No customer data, no customer-VM bootstrap, no live Eva/customer runtime use on this host.
 
 ## GitHub And Reviews

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,13 @@
 - The VM cannot prove Mac-only surfaces. `WorldOS.app` build/launch, native #356, and built-app UI play evidence stay on this Mac or macOS CI.
 - VM artifacts can feed RRI only when `run.json`, `score.json`, `session_surface.final.json`, network/image evidence, palette-live evidence, and build SHA are explicit. Otherwise the result remains partial/harness-contaminated.
 
+## GEX44 GPU host (evaos-gpu-gex44-1)
+
+- Internal GPU compute host `evaos-gpu-gex44-1` (Hetzner GEX44, RTX 4000 SFF Ada / 64 GB / Ubuntu 24.04) — NOT a customer VM. Supabase source of truth is `fleet_nodes` with `role = gpu_compute`; do not create or use a `gpu_vms` inventory table for this host.
+- Operator access is operator-only (outside tracked docs): key `~/.openclaw/secrets/evaos-gpu-gex44-1-key`, connection refs in `~/.openclaw/secrets/gex44.env`.
+- **Provisioning is COMPLETE (2026-06-26):** the heavy part-B sweep lane, CUDA/local-AI, and the Unity 6000.5.1f1 + Unity-MCP render loop are all proven on the box. GEX44 is now the **preferred** heavy-sweep + Unity/visual-renderer host (the 32 GB support VM is the fallback). Operational details + the connect/capture recipes live in `WorldOS-GUI-RUNBOOK.md` → "GPU-VM lane".
+- No customer data, no customer-VM bootstrap, no live Eva/customer runtime use on this host.
+
 ## GitHub And Reviews
 
 - Use branch prefix `codex/` for new branches unless instructed otherwise.

--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -376,7 +376,7 @@ SSH key, or the VNC password in this tracked doc (same convention as the Support
    tunnel and register it:
    ```bash
    ssh -N -L 8080:127.0.0.1:8080 root@<gex44>   # host in gex44.env (8080 is localhost-only on the box)
-   claude mcp add --transport http unity http://127.0.0.1:8080/mcp
+   claude mcp add --scope user --transport http unity http://127.0.0.1:8080/mcp
    ```
    43 tools (manage_camera / manage_scene / execute_code / …). **HIGH-QUALITY captures (agents MUST do this):**
    `manage_camera action=screenshot screenshot_super_size=2` (→ 5120×2880; use 3–4 for the visual-critic) —

--- a/WorldOS-GUI-RUNBOOK.md
+++ b/WorldOS-GUI-RUNBOOK.md
@@ -367,15 +367,20 @@ SSH key, or the VNC password in this tracked doc (same convention as the Support
    skill → "VM GATE SWEEP — exact procedure"). Drop `qa/vm/sweep_v2.sh` → `/root/worldos-qa/sweep_v2.sh` and
    run it; results roll up into the RRI exactly as the Support VM lane does. Private art is rsynced to
    `content/worlds/_private` (NOT top-level `_private`).
-2. **Unity 6 + Unity-MCP host** — Unity `6000.5.0f1` + the project at `/home/unity/worldos-unity`, run as the
-   **`unity` user** (NOT root — Electron/Hub refuses root). Renders on **GPU display `:0` with real GL** — launch
-   the Editor WITHOUT `-nographics` or captures come back blank. Bring up the Editor + MCP server with
-   `sudo -u unity /usr/local/bin/unity-mcp-up.sh`, then reach the MCP HTTP endpoint (8080) from the Mac over an
-   SSH tunnel and register it:
+2. **Unity 6 + Unity-MCP renderer (PROVEN end-to-end)** — Unity `6000.5.1f1` + the project at
+   `/home/unity/worldos-unity`, run as the **`unity` user** (NOT root — Electron/Hub refuses root). Renders on
+   **GPU display `:0` with real GL** (OpenGL 4.5) — launch the Editor WITHOUT `-nographics` or captures come back
+   blank. The standalone `mcp-for-unity --transport http` server OWNS **:8080** (run it from a clean cwd —
+   pydantic reads `./.env` and 500s if the cwd is unreadable); the editor's **MCP For Unity** panel
+   (Transport=HTTP Local → **Start Server**) bridges to it → "Session Active". Reach it from the Mac over an SSH
+   tunnel and register it:
    ```bash
    ssh -N -L 8080:127.0.0.1:8080 root@<gex44>   # host in gex44.env (8080 is localhost-only on the box)
    claude mcp add --transport http unity http://127.0.0.1:8080/mcp
    ```
+   43 tools (manage_camera / manage_scene / execute_code / …). **HIGH-QUALITY captures (agents MUST do this):**
+   `manage_camera action=screenshot screenshot_super_size=2` (→ 5120×2880; use 3–4 for the visual-critic) —
+   default super_size=1 reads soft. Frames land in `<proj>/Assets/Screenshots/`.
 
 **RRI rollup is unchanged** — this box supplies the **part-B** persona/behavior/score evidence; the **Mac still
 owns native Part-A** (the built `dist/WorldOS.app` handoff) at the **SAME SHA**, because Linux cannot build the
@@ -391,10 +396,17 @@ Support VM lane's RRI rollup rule above).
   auto-refresh → re-copy on the first 401** (the standing Keychain-copy method is in the `worldos-dev` notes).
 - **Personas stay sequential** — parallel runs trip the 4× quota 429.
 - **The GPU does NOT speed the sweep** — it is LLM-bound; the GPU is for the Unity / visual-critic lanes only.
-- **Unity 6 Personal is hardware-bound** → the one human-gated step: a **one-time interactive Hub login on the
-  box** via a tunneled VNC (`ssh -N -L 5900:127.0.0.1:5900 root@<gex44>` → VNC `localhost:5900`, sign in,
-  activate Personal, open the project once). After that the MCP render loop works headlessly. The VNC host +
-  password are in `gex44.env`.
+- **Unity setup is human-gated ONCE (via the Hub):** Personal license is hardware-bound (one-time Hub sign-in on
+  the box) AND the per-version **Software-Terms EULA must be accepted in the Hub** — a headless CLI editor launch
+  HANGS forever on the unaccepted EULA modal (`Selected window backend: (null)` is a RED HERRING, NOT a
+  window-backend bug). Once accepted for the version, launches proceed. Open the Hub via the remote desktop, add
+  the project from disk, open it, accept the terms.
+- **Human remote VIEW = NoMachine (port 4000), NOT macOS Screen Sharing / x11vnc:5900** — RFB over the WAN is
+  dog-slow (the box sits idle; it is the transport, not the box). `ssh -N -L 4000:127.0.0.1:4000 root@<gex44>` →
+  NoMachine client → `localhost:4000` (login `unity`). The agent drives Unity via the MCP (no display needed); the
+  desktop is only for occasional human inspection. VNC/NoMachine hosts + passwords are in `gex44.env`.
+- **Supabase source of truth for this host = `fleet_nodes` (`role = gpu_compute`)** — do NOT create/use a
+  `gpu_vms` inventory table. Internal GPU compute node, not a customer VM.
 
 ## Release (when RRI = 10/10 on a fresh .app build)
 Bump `.claude-plugin/plugin.json` → 1.0.4, tag `v1.0.4`, GitHub release + CHANGELOG. Then MAINTAIN:


### PR DESCRIPTION
## Summary
- documents GEX44 as the future internal GPU sweep/Unity/local-AI lane while Claude owns provisioning
- records that Supabase source of truth remains `fleet_nodes.role = gpu_compute`, not a new `gpu_vms` table
- points future agents at operator-local key/env refs without storing secrets in tracked docs

Closes #1162

## Test Plan
- `git diff --check`
- `rg -n "gpu_vms|customer_vms" AGENTS.md WorldOS-GUI-RUNBOOK.md` (only explicit no-gpu_vms guidance returned)
- `rg -n "fleet_nodes|gpu_compute|evaos-gpu-gex44-1|evaos-gpu-gex44-1-key" AGENTS.md WorldOS-GUI-RUNBOOK.md`
- `rg -n "BEGIN OPENSSH PRIVATE KEY|b3BlbnNzaC1rZXktdjE" <edited docs and local persistence artifacts>` (no matches)
- Supabase readback saved under `/Volumes/LEXAR/Codex/evidence/gex44-persistence-20260625/` confirms `fleet_nodes.role=gpu_compute` and `vm_health_snapshots.restart_blocked_reason=role_not_restartable`

## Boundaries
- no server provisioning, package install, CUDA/Unity setup, SSH workload run, sweep, or Supabase schema change
- local-only files changed outside this PR: `~/.openclaw/secrets/evaos-gpu-gex44-1-key.pub`, `~/.openclaw/secrets/gex44.env`, `~/.openclaw/secrets/SECRETS-INDEX.md`