### PR TITLE
ci: add Woodpecker WorldOS Linux gates

### DIFF
--- a/.claude/skills/godot-dev/SKILL.md
+++ b/.claude/skills/godot-dev/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: godot-dev
-description: Develop / test / debug the WorldOS GT2 Godot painterly-isometric renderer (the `godot/` project). Use when working on the isometric view — GDScript (`.gd`) or scenes (`.tscn`), the `SurfaceClient`/`WorldView`/`CharacterToken`/`InputController`, the render-profile contract, sprite sheets, click-to-move/Y-sort, or the Godot CI lane. Encodes the thin-client invariants, the dimetric-2:1 projection, how to run/validate locally, and points at the full knowledge base.
+description: Develop / test / debug the WorldOS GT2 Godot painterly-isometric reference/extension renderer (the `godot/` project). Use only for explicit `godot/` work or a renderer-migration issue that reopens Godot; current isometric/visual-renderer work routes through the Unity/current-renderer and visual-critic lane instead. Encodes the thin-client invariants, the dimetric-2:1 projection, how to run/validate locally, and points at the full knowledge base.
 ---
 
-# WorldOS GT2 Godot renderer — dev skill
+# WorldOS GT2 Godot reference renderer — dev skill
 
-The GT2 renderer is a **stateless thin client** over the zone-based WorldOS engine. **Read
-`godot/HANDOFF.md` first** — it is the full knowledge base (architecture diagrams, the
-isometric/painterly/Pillars research, gotchas, the prioritized backlog). Companions:
-`godot/ISO-PROJECTION.md` (the locked projection), `godot/tools/README.md` (asset pipeline).
+The GT2 renderer is a **stateless thin client** over the zone-based WorldOS engine, kept as
+reference/extension material while the current renderer lane is Unity/current-renderer plus
+deterministic SceneGrid/visual-critic checks. **Read `godot/HANDOFF.md` first** — it is the full
+Godot knowledge base (architecture diagrams, the isometric/painterly/Pillars research, gotchas,
+the prioritized backlog). Companions: `godot/ISO-PROJECTION.md` (the locked projection),
+`godot/tools/README.md` (asset pipeline).
 
 ## The non-negotiables (full list in HANDOFF.md §7)
 - Engine = **sole writer**; the renderer owns ZERO state but the `/events` cursor.
@@ -36,8 +38,9 @@ Next: **#1090** (narration/dialogue in-view) → **#1089** (painterly backdrop, 
 (real rigged animation, via `asset-gen`/Tripo). Delivery: #1057–#1059. Epic **#1050**.
 
 ## Dev loop
-Worktree off `origin/main` → additive change → local Godot validate → PR → squash-merge → prune.
-Multi-session repo: never branch-flip the shared checkout; `godot/`-only PRs skip CodeQL.
+Only use this loop for explicit `godot/` reference/extension work. Worktree off `origin/main` →
+additive change → local Godot validate → PR → squash-merge → prune. Multi-session repo: never
+branch-flip the shared checkout; `godot/`-only PRs skip CodeQL.
 
 ## Gotchas (cost real time — see HANDOFF.md §8)
 - **`export_presets.cfg` is in Godot's default `.gitignore`, but `godot --headless --export` fails

--- a/.github/workflows/godot.yml
+++ b/.github/workflows/godot.yml
@@ -1,6 +1,8 @@
 name: Godot GT2
 
-# Deterministic, model-key-free CI lane for the GT2 Godot renderer (#1056). Proves the project
+# Reference/extension CI lane for the quarantined GT2 Godot prototype (#1056, #1165).
+# This workflow is intentionally not branch-protection-required and is not ported to
+# Woodpecker in the emergency CI recovery. Proves the project
 # parses/compiles, renders the slice from the bundled fixtures (core + the godot render-profile
 # block), only emits the FROZEN /move vocabulary, and exports cleanly to Web (single-threaded)
 # + Linux. Best-effort screenshot artifact via xvfb. NEVER touches a live engine/provider —

--- a/.woodpecker/license-check.yml
+++ b/.woodpecker/license-check.yml
@@ -6,6 +6,16 @@ steps:
     image: python:3.12-slim
     commands:
       - apt-get update
-      - apt-get install -y --no-install-recommends git
+      - apt-get install -y --no-install-recommends bash git
       - rm -rf /var/lib/apt/lists/*
+      - >-
+        bash -lc 'set -euo pipefail;
+        if [ "${CI_PIPELINE_EVENT:-}" = "pull_request" ]; then
+          _ref="${CI_COMMIT_REF:-}";
+          if [ -z "$_ref" ] && [ -n "${CI_COMMIT_PULL_REQUEST:-}" ]; then _ref="refs/pull/${CI_COMMIT_PULL_REQUEST}/merge"; fi;
+          case "$_ref" in
+            refs/pull/*/merge) git fetch --no-tags --depth=1 origin "$_ref"; git checkout --force FETCH_HEAD; echo "checked out $_ref at $(git rev-parse HEAD)" ;;
+            *) echo "pull_request event without merge ref: ${_ref:-empty}"; exit 1 ;;
+          esac;
+        fi'
       - python3 scripts/license_check.py

--- a/.woodpecker/license-check.yml
+++ b/.woodpecker/license-check.yml
@@ -1,0 +1,11 @@
+when:
+  - event: [push, pull_request, manual]
+
+steps:
+  - name: license-check
+    image: python:3.12-slim
+    commands:
+      - apt-get update
+      - apt-get install -y --no-install-recommends git
+      - rm -rf /var/lib/apt/lists/*
+      - python3 scripts/license_check.py

--- a/.woodpecker/qa-release-gate-tests.yml
+++ b/.woodpecker/qa-release-gate-tests.yml
@@ -1,0 +1,57 @@
+when:
+  - event: [push, pull_request, manual]
+
+steps:
+  - name: qa-release-gate-tests
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm
+    environment:
+      WORLDOS_RULES_OFFLINE: "1"
+    commands:
+      # Intentionally adds deterministic current-renderer coverage to the parity set.
+      - >-
+        bash -lc 'set -euo pipefail;
+        uv run --directory servers/engine --group dev python -m pytest -q -p no:xdist
+        ../../qa/test_release_readiness.py
+        ../../qa/test_release_readiness_scope.py
+        ../../qa/test_scores_db_comparability.py
+        ../../qa/test_scores_db.py
+        ../../qa/test_closeout.py
+        ../../qa/test_release_gate_static.py
+        ../../qa/test_ui_playtest_score_image_outcomes.py
+        ../../qa/test_claude_auth_isolation.py
+        ../../qa/test_snapshot_world_state.py
+        ../../qa/test_score_determinism.py
+        ../../qa/test_lens_variance.py
+        ../../qa/test_detect_regression.py
+        ../../qa/test_root_cause_analyzer.py
+        ../../qa/test_evidence_audit.py
+        ../../qa/test_triage_failure.py
+        ../../qa/test_behavioral_gate_corpus.py
+        ../../qa/test_deterministic_rri_gate.py
+        ../../qa/test_orchestrate_split_rri.py
+        ../../qa/test_visual_regression_check.py
+        ../../qa/test_visual_critic.py
+        ../../qa/test_structural_coverage.py
+        ../../qa/test_story_readout_approval.py
+        ../../qa/test_feature_engagement.py
+        ../../qa/test_fact_fidelity.py
+        ../../qa/test_recap_fidelity.py
+        ../../qa/test_assert_behavioral.py
+        ../../qa/test_distill.py
+        ../../qa/test_story_readout_coverage.py
+        ../../qa/test_story_readout_outcome.py
+        ../../qa/test_story_readout_timing.py
+        ../../qa/test_latency_rollup.py
+        ../../qa/test_stream_tailer.py
+        ../../qa/test_collect_findings.py
+        ../../qa/test_dm_beat_mark.py
+        ../../qa/test_export_app_evidence.py
+        ../../qa/test_macos_app_static.py
+        ../../qa/test_ui_playtest_app_buckets.py
+        ../../qa/test_app_failure_buckets.py
+        ../../qa/test_app_handoff_gate.py
+        ../../qa/test_app_smoke_scripted.py
+        ../../qa/test_support_vm_preflight.py
+        ../../qa/test_version_consistency.py
+        ../../qa/test_generate_release_notes.py
+        ../../qa/test_combat_smoke.py'

--- a/.woodpecker/qa-release-gate-tests.yml
+++ b/.woodpecker/qa-release-gate-tests.yml
@@ -7,7 +7,17 @@ steps:
     environment:
       WORLDOS_RULES_OFFLINE: "1"
     commands:
-      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends jq; rm -rf /var/lib/apt/lists/*'
+      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends git jq; rm -rf /var/lib/apt/lists/*'
+      - >-
+        bash -lc 'set -euo pipefail;
+        if [ "${CI_PIPELINE_EVENT:-}" = "pull_request" ]; then
+          _ref="${CI_COMMIT_REF:-}";
+          if [ -z "$_ref" ] && [ -n "${CI_COMMIT_PULL_REQUEST:-}" ]; then _ref="refs/pull/${CI_COMMIT_PULL_REQUEST}/merge"; fi;
+          case "$_ref" in
+            refs/pull/*/merge) git fetch --no-tags --depth=1 origin "$_ref"; git checkout --force FETCH_HEAD; echo "checked out $_ref at $(git rev-parse HEAD)" ;;
+            *) echo "pull_request event without merge ref: ${_ref:-empty}"; exit 1 ;;
+          esac;
+        fi'
       # Intentionally adds deterministic current-renderer coverage to the parity set.
       - >-
         bash -lc 'set -euo pipefail;

--- a/.woodpecker/qa-release-gate-tests.yml
+++ b/.woodpecker/qa-release-gate-tests.yml
@@ -7,6 +7,7 @@ steps:
     environment:
       WORLDOS_RULES_OFFLINE: "1"
     commands:
+      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends jq; rm -rf /var/lib/apt/lists/*'
       # Intentionally adds deterministic current-renderer coverage to the parity set.
       - >-
         bash -lc 'set -euo pipefail;

--- a/.woodpecker/server-contracts.yml
+++ b/.woodpecker/server-contracts.yml
@@ -7,5 +7,6 @@ steps:
     environment:
       WORLDOS_RULES_OFFLINE: "1"
     commands:
+      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends jq; rm -rf /var/lib/apt/lists/*'
       - bash -lc 'set -euo pipefail; uv sync --directory servers/rules'
       - bash -lc 'set -euo pipefail; uv run --directory servers/engine --group dev python -m pytest -q -p no:xdist ../../servers/integration_tests'

--- a/.woodpecker/server-contracts.yml
+++ b/.woodpecker/server-contracts.yml
@@ -7,6 +7,16 @@ steps:
     environment:
       WORLDOS_RULES_OFFLINE: "1"
     commands:
-      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends jq; rm -rf /var/lib/apt/lists/*'
+      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends git jq; rm -rf /var/lib/apt/lists/*'
+      - >-
+        bash -lc 'set -euo pipefail;
+        if [ "${CI_PIPELINE_EVENT:-}" = "pull_request" ]; then
+          _ref="${CI_COMMIT_REF:-}";
+          if [ -z "$_ref" ] && [ -n "${CI_COMMIT_PULL_REQUEST:-}" ]; then _ref="refs/pull/${CI_COMMIT_PULL_REQUEST}/merge"; fi;
+          case "$_ref" in
+            refs/pull/*/merge) git fetch --no-tags --depth=1 origin "$_ref"; git checkout --force FETCH_HEAD; echo "checked out $_ref at $(git rev-parse HEAD)" ;;
+            *) echo "pull_request event without merge ref: ${_ref:-empty}"; exit 1 ;;
+          esac;
+        fi'
       - bash -lc 'set -euo pipefail; uv sync --directory servers/rules'
       - bash -lc 'set -euo pipefail; uv run --directory servers/engine --group dev python -m pytest -q -p no:xdist ../../servers/integration_tests'

--- a/.woodpecker/server-contracts.yml
+++ b/.woodpecker/server-contracts.yml
@@ -1,0 +1,11 @@
+when:
+  - event: [push, pull_request, manual]
+
+steps:
+  - name: server-contracts
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm
+    environment:
+      WORLDOS_RULES_OFFLINE: "1"
+    commands:
+      - bash -lc 'set -euo pipefail; uv sync --directory servers/rules'
+      - bash -lc 'set -euo pipefail; uv run --directory servers/engine --group dev python -m pytest -q -p no:xdist ../../servers/integration_tests'

--- a/.woodpecker/test.yml
+++ b/.woodpecker/test.yml
@@ -1,0 +1,20 @@
+when:
+  - event: [push, pull_request, manual]
+
+steps:
+  - name: test
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm
+    commands:
+      - bash -lc 'set -euo pipefail; uv run --directory servers/engine --group dev pytest -q --cov=. --cov-report=term-missing'
+      - bash -lc 'set -euo pipefail; WORLDOS_RULES_OFFLINE=1 uv run --directory servers/rules --group dev pytest -q --cov=. --cov-report=term-missing'
+      - bash -lc 'set -euo pipefail; uv run --directory servers/voice --group dev pytest -q --cov=. --cov-report=term-missing'
+      - bash -lc 'set -euo pipefail; bash qa/test_play_party_single_flight.sh'
+      - bash -lc 'set -euo pipefail; bash qa/test_velocity_gates.sh'
+      - bash -lc 'set -euo pipefail; bash qa/test_dry_run_gate_fix.sh'
+      - bash -lc 'set -euo pipefail; bash qa/test_run_duo_retry_robustness.sh'
+      - bash -lc 'set -euo pipefail; bash qa/test_play_party_actor_timeout.sh'
+      - bash -lc 'set -euo pipefail; bash qa/test_provider_status_claude_lanes.sh'
+      - bash -lc 'set -euo pipefail; bash qa/test_run_duo_dm_timeout.sh'
+      - bash -lc 'set -euo pipefail; bash qa/test_stream_tailer_lifecycle.sh'
+      - bash -lc 'set -euo pipefail; bash qa/test_ui_playtest_heartbeat.sh'
+      - bash -lc 'set -euo pipefail; uv run --directory servers/engine --group dev python ../../qa/smoke_pre_seed_combat.py'

--- a/.woodpecker/test.yml
+++ b/.woodpecker/test.yml
@@ -5,6 +5,7 @@ steps:
   - name: test
     image: ghcr.io/astral-sh/uv:python3.12-bookworm
     commands:
+      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends jq; rm -rf /var/lib/apt/lists/*'
       - bash -lc 'set -euo pipefail; uv run --directory servers/engine --group dev pytest -q --cov=. --cov-report=term-missing'
       - bash -lc 'set -euo pipefail; WORLDOS_RULES_OFFLINE=1 uv run --directory servers/rules --group dev pytest -q --cov=. --cov-report=term-missing'
       - bash -lc 'set -euo pipefail; uv run --directory servers/voice --group dev pytest -q --cov=. --cov-report=term-missing'

--- a/.woodpecker/test.yml
+++ b/.woodpecker/test.yml
@@ -5,7 +5,17 @@ steps:
   - name: test
     image: ghcr.io/astral-sh/uv:python3.12-bookworm
     commands:
-      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends jq; rm -rf /var/lib/apt/lists/*'
+      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends git jq; rm -rf /var/lib/apt/lists/*'
+      - >-
+        bash -lc 'set -euo pipefail;
+        if [ "${CI_PIPELINE_EVENT:-}" = "pull_request" ]; then
+          _ref="${CI_COMMIT_REF:-}";
+          if [ -z "$_ref" ] && [ -n "${CI_COMMIT_PULL_REQUEST:-}" ]; then _ref="refs/pull/${CI_COMMIT_PULL_REQUEST}/merge"; fi;
+          case "$_ref" in
+            refs/pull/*/merge) git fetch --no-tags --depth=1 origin "$_ref"; git checkout --force FETCH_HEAD; echo "checked out $_ref at $(git rev-parse HEAD)" ;;
+            *) echo "pull_request event without merge ref: ${_ref:-empty}"; exit 1 ;;
+          esac;
+        fi'
       - bash -lc 'set -euo pipefail; uv run --directory servers/engine --group dev pytest -q --cov=. --cov-report=term-missing'
       - bash -lc 'set -euo pipefail; WORLDOS_RULES_OFFLINE=1 uv run --directory servers/rules --group dev pytest -q --cov=. --cov-report=term-missing'
       - bash -lc 'set -euo pipefail; uv run --directory servers/voice --group dev pytest -q --cov=. --cov-report=term-missing'

--- a/.woodpecker/viewer-tests.yml
+++ b/.woodpecker/viewer-tests.yml
@@ -5,7 +5,7 @@ steps:
   - name: viewer-tests
     image: node:20-bookworm
     commands:
-      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends ca-certificates curl python3 python3-venv; rm -rf /var/lib/apt/lists/*'
+      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends ca-certificates curl jq python3 python3-venv; rm -rf /var/lib/apt/lists/*'
       - bash -lc 'set -euo pipefail; curl -LsSf https://astral.sh/uv/install.sh | sh'
       - bash -lc 'set -euo pipefail; export PATH="$HOME/.local/bin:$PATH"; uv venv .venv-viewer --python 3.12'
       - bash -lc 'set -euo pipefail; export PATH="$HOME/.local/bin:$PATH"; uv pip install --python .venv-viewer pydantic pytest'

--- a/.woodpecker/viewer-tests.yml
+++ b/.woodpecker/viewer-tests.yml
@@ -5,8 +5,18 @@ steps:
   - name: viewer-tests
     image: node:20-bookworm
     commands:
-      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends ca-certificates curl jq python3 python3-venv; rm -rf /var/lib/apt/lists/*'
-      - bash -lc 'set -euo pipefail; curl -LsSf https://astral.sh/uv/install.sh | sh'
-      - bash -lc 'set -euo pipefail; export PATH="$HOME/.local/bin:$PATH"; uv venv .venv-viewer --python 3.12'
-      - bash -lc 'set -euo pipefail; export PATH="$HOME/.local/bin:$PATH"; uv pip install --python .venv-viewer pydantic pytest'
+      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends ca-certificates git jq python3 python3-venv; rm -rf /var/lib/apt/lists/*'
+      - >-
+        bash -lc 'set -euo pipefail;
+        if [ "${CI_PIPELINE_EVENT:-}" = "pull_request" ]; then
+          _ref="${CI_COMMIT_REF:-}";
+          if [ -z "$_ref" ] && [ -n "${CI_COMMIT_PULL_REQUEST:-}" ]; then _ref="refs/pull/${CI_COMMIT_PULL_REQUEST}/merge"; fi;
+          case "$_ref" in
+            refs/pull/*/merge) git fetch --no-tags --depth=1 origin "$_ref"; git checkout --force FETCH_HEAD; echo "checked out $_ref at $(git rev-parse HEAD)" ;;
+            *) echo "pull_request event without merge ref: ${_ref:-empty}"; exit 1 ;;
+          esac;
+        fi'
+      - bash -lc 'set -euo pipefail; python3 -m venv .venv-uv; .venv-uv/bin/python -m pip install --disable-pip-version-check --no-input "uv==0.11.24"'
+      - bash -lc 'set -euo pipefail; .venv-uv/bin/uv venv .venv-viewer --python 3.12'
+      - bash -lc 'set -euo pipefail; .venv-uv/bin/uv pip install --python .venv-viewer pydantic pytest'
       - bash -lc 'set -euo pipefail; export VIRTUAL_ENV="$PWD/.venv-viewer"; export PATH="$PWD/.venv-viewer/bin:$PATH"; python -m pytest viewer/tests -q -p no:xdist'

--- a/.woodpecker/viewer-tests.yml
+++ b/.woodpecker/viewer-tests.yml
@@ -1,0 +1,12 @@
+when:
+  - event: [push, pull_request, manual]
+
+steps:
+  - name: viewer-tests
+    image: node:20-bookworm
+    commands:
+      - bash -lc 'set -euo pipefail; apt-get update; apt-get install -y --no-install-recommends ca-certificates curl python3 python3-venv; rm -rf /var/lib/apt/lists/*'
+      - bash -lc 'set -euo pipefail; curl -LsSf https://astral.sh/uv/install.sh | sh'
+      - bash -lc 'set -euo pipefail; export PATH="$HOME/.local/bin:$PATH"; uv venv .venv-viewer --python 3.12'
+      - bash -lc 'set -euo pipefail; export PATH="$HOME/.local/bin:$PATH"; uv pip install --python .venv-viewer pydantic pytest'
+      - bash -lc 'set -euo pipefail; export VIRTUAL_ENV="$PWD/.venv-viewer"; export PATH="$PWD/.venv-viewer/bin:$PATH"; python -m pytest viewer/tests -q -p no:xdist'

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -120,8 +120,10 @@ every NPC; a voiced AI companion adventures alongside you with its own sheet and
 The viewer has multiple render paths:
 
 - **GT0 — OpenWorlds React** (default; ships today): the `viewer/openworlds/` app above.
-- **GT2 — Godot 4 painterly-isometric** (in-progress; the new GT2 renderer): a stateless thin
-  client over the engine read-models. **See `godot/HANDOFF.md` + invoke the `godot-dev` skill.**
+- **GT2 — Unity 6 / Unity-MCP visual renderer** (current direction): a stateless thin
+  client over the engine read-models. The GPU-VM lane in `WorldOS-GUI-RUNBOOK.md` owns
+  current visual renderer proof. `godot/` remains reference/extension material only; see
+  #1165 before moving or deleting it.
 - **GT1 — pixel** (future).
 
 For **AI art generation** (3D characters, rigging, painterly backdrops, sprites/tilesets):

--- a/WorldOS-RUNBOOK.md
+++ b/WorldOS-RUNBOOK.md
@@ -193,6 +193,18 @@ change must respect them.
    silently skipped. (This bit us on #185.) Check the exit / the returned PR URL.
 4. **Merge only after checks pass.** Use the standard PR merge flow once GitHub CI
    and required review gates are green.
+   - During the GitHub Actions billing outage, the Linux replacement gates are the Woodpecker
+     **pull_request** contexts only:
+     `ci/woodpecker/pr/test`, `ci/woodpecker/pr/viewer-tests`,
+     `ci/woodpecker/pr/qa-release-gate-tests`, `ci/woodpecker/pr/server-contracts`, and
+     `ci/woodpecker/pr/license-check`. Do not require the matching `ci/woodpecker/push/*`
+     contexts for PR merges.
+   - These Woodpecker gates are checks-only: no deploy, release, registry publish, production
+     database mutation, or server move belongs in this lane.
+   - Rollback if Woodpecker server/agent health regresses: remove only those five Woodpecker PR
+     contexts from required status checks (or restore the previous five GitHub Actions contexts
+     after Actions billing recovers), leave review/thread/deletion/force-push protections intact,
+     and do not upgrade or move the Woodpecker server as part of the emergency rollback.
 5. **Sync + clean up:**
    ```bash
    git pull --ff-only origin main

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -61,7 +61,9 @@ dist/WorldOS.app
 
 Use the native app when you need to prove the release surface: provider settings, app launch, private/public art loading, native window behavior, and provider process startup.
 
-To develop the Godot isometric renderer or generate art, see `godot/HANDOFF.md` and the `godot-dev` / `asset-gen` skills.
+For current visual renderer work, use the Unity 6 / Unity-MCP GPU-VM lane described in
+`WorldOS-GUI-RUNBOOK.md`. `godot/HANDOFF.md` is now historical/reference material only;
+see #1165 before moving, deleting, or reviving `godot/`.
 
 ## Pick A Provider
 

--- a/docs/qa/TEST_MATRIX.md
+++ b/docs/qa/TEST_MATRIX.md
@@ -36,7 +36,8 @@ largely gone — GLM is a fine DM for nearly all QA.
 | **story / arcs / companions / quests** | **arc smoke** → a 3-act full run (`run_arc_smoke`, then a ≥24-beat run; **GLM/Opus, never the Sonnet default**) |
 | **scoring / rubrics / gates** | `fast_gate` + `qa/test_lens_variance.py` + `test_score_determinism` → **re-version the ruler** (`scoring_config_version.py --label/--lens`, stamp `sc_`/`lc_` + CHANGELOG) |
 | **viewer / OpenWorlds UI** | `qa/ui_playtest.sh` (blind persona) + the viewer tests; for combat UI, `qa/preview_combat.sh` + watch `#battle` |
-| **Godot renderer** | `godot --headless --path godot --import` + the conformance/screenshot lane (#1056) |
+| **Unity/current visual renderer** | GPU-VM Unity/visual-critic proof for renderer work; keep Linux CI to deterministic SceneGrid/render-contract tests unless a PR intentionally changes renderer-host code. |
+| **Godot reference/extension material** | Optional/manual only: `godot --headless --path godot --import` + the conformance/screenshot lane when touching `godot/`. Do not make it a required merge gate; see #1165. |
 | **a RELEASE** (not just a tag) | the FULL round: `combat_smoke` + beat smoke + a 3-act run + **5-persona VM sweep + RRI** + the Mac native part-A |
 
 ## Tags vs releases

--- a/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
+++ b/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md
@@ -46,16 +46,15 @@ lane. No renderer, no AI loop, no UGC tool ever becomes a second source of truth
 |----|-----------|--------|---------------|-------|
 | **GT0** | **Narrative dashboard** (the current OpenWorlds web UI) | **SHIPS TODAY** | React/JSX in WKWebView | The living-world DM + companion RPG; text/portrait-first. The proof that engine-as-authority + thin-client works. |
 | **GT1** | **SNES-style pixel turn-based** (JRPG / RPG-Maker-like feel) | Planned (MVP tier 1) | Phaser 3 (MIT), in the existing shell | Tilemap + sprite actors + 16-bit UI; zone-mode turn combat. |
-| **GT2** | **Pillars / BG1-2 isometric party cRPG** | In progress (M5, pulled fwd) | **Godot 4 (web + native)** — Phaser GT2 **retired** 2026-06-21 | Painted backdrop + token actors. **Owner direction 2026-06-21:** Godot is the GT2 renderer for both web and native; the Phaser M2 backdrop renderer is retired (didn't deliver the experience). **Branch A = the LOOK; Branch B = measured tactics (evidence-gated).** See epic #1050. |
+| **GT2** | **Pillars / BG1-2 isometric party cRPG** | In progress (Unity pivot; Godot quarantined 2026-06-25) | **Unity 6 / Unity-MCP** on the GPU-VM lane | Painted backdrop + token actors. **Owner direction 2026-06-25:** Unity is now the current renderer direction; `godot/` stays as reference/extension material until #1165 decides its archive/extension shape. **Branch A = the LOOK; Branch B = measured tactics (evidence-gated).** |
 | GT3+ | (future families — e.g. tactical-grid SRPG, top-down action) | Not scoped | TBD | Added only when a capability set + audience justify it. |
 
 **Rejected engines (recorded so they're not re-litigated):**
 - **RPG Maker MZ** — EULA refutes multi-tenant UGC (Authorized-User-only; RTP welded to its
   editor; corporate use excluded). At most a deferred, asset-clean, exploration-only BYOL
   export for GT1. NOT a T2/isometric option (orthogonal-tile-locked).
-- **Unity** — no macOS Unity-as-a-Library (can't embed in the WKWebView shell → separate
-  binary); cRPG toolkits assume Unity owns the rules (conflicts with engine-authority);
-  weakest AI-buildability (35/100); licensing drag for UGC vs MIT.
+- **Unity as engine owner** — rejected. Unity may be the visual renderer/client, but it
+  must remain a thin client over the Python engine read-models and `/move` intent lane.
 - **GemRB** — GPL-2.0 (viral), C++ native, IE-data-bound. Reference for the look only.
 - **Custom WebGL/WebGPU engine** — reject for the foreseeable roadmap.
 
@@ -74,7 +73,7 @@ Each capability is a dial. Branch A is the first shippable level; Branch B is th
 | **C4** | **Movement / travel** | menu travel · click-to-zone · walkmask click-to-move (renderer-owned mask) | measured per-turn movement budget (with C1-B) | A = none; B = with C1-B |
 | **C5** | **Asset pipeline** | portraits (exists) · AI pixel sprites · tilesets · painted backdrops · audio | curated per-race/scene sets; user uploads | renderer/content; AI-disclosure metadata mandatory |
 | **C6** | **Input intents** (`/move` palette) | `say/do/check/save/combat/attack/cast/use_item/clarify` (today) **+ `travel`, `inspect`, `move_to_zone`** | drag-to-zone gestures; ability-bar verbs (Shove/Dash/Hide) | **contract change — freeze in M0**, roll across viewer+DM+facade together |
-| **C7** | **Lighting** | flat-lit backdrops | normal-map dynamic lights (Godot-native; Phaser custom) | renderer-owned |
+| **C7** | **Lighting** | flat-lit backdrops | normal-map dynamic lights (Unity/current renderer lane) | renderer-owned |
 | **C8** | **Transport** | 3s poll (today) | WebSocket/SSE push (same payload shapes) | additive engine surface (anytime after M0) |
 | **C9** | **AI build-loop autonomy** | manual scaffold + human review | gated unattended scaffold (~70-80%) w/ screenshot-critic + blind-playtester gates | tooling; loop never mutates the contract |
 | **C10** | **UGC** | none → author scenes | author whole games → ship/sell (MIT-clean stack) | per-user games persist as engine-owned data |
@@ -95,7 +94,7 @@ autonomy, ship/sell UGC)* layered on as the long-term plan proves out.
 | C4 movement | menu | click-to-zone | walkmask click-to-move |
 | C5 assets | portraits | sprites+tilesets | backdrops+tokens |
 | C6 input | full palette+travel | +target/move_to_zone | +target/move_to_zone |
-| C7 lighting | n/a | flat | flat → normal-map (B, Godot) |
+| C7 lighting | n/a | flat | flat → normal-map (B, Unity-current renderer lane) |
 | C8 transport | poll → ws | poll → ws | poll → ws |
 | C9 autonomy | manual | gated loop | gated loop |
 | C10 UGC | none | author→ship (B) | author→ship (B) |
@@ -107,15 +106,19 @@ autonomy, ship/sell UGC)* layered on as the long-term plan proves out.
 1. **Renderer = thin client; engine = sole writer.** (The invariant.)
 2. **Phaser 3 (MIT) + PixiJS v8 (MIT) for the MVP, BOTH tiers**, in the existing React/WKWebView
    shell. One renderer, two render profiles (tilemap / backdrop). Godot 4 reserved for an
-   optional *premium native desktop/Steam* GT2 client later (separate binary; MIT). Unity rejected.
-   **AMENDMENT 2026-06-21 (owner):** for **GT2 specifically** this is superseded — **Godot 4 is now
-   the GT2 renderer for both web and native**, and the **Phaser GT2 backdrop path is retired** (it
-   didn't deliver the experience). M5 is pulled forward (epic #1050). GT0 (React dashboard) and GT1
-   (Phaser pixel) are unchanged. The thin-client invariant + layered render-profile contract are unchanged.
+   optional *premium native desktop/Steam* GT2 client later (separate binary; MIT).
+   **AMENDMENT 2026-06-21 (owner):** for **GT2 specifically** this was superseded by Godot.
+   **AMENDMENT 2026-06-25 (owner):** Godot is now quarantined as reference/extension material,
+   and Unity 6 / Unity-MCP is the current visual renderer direction on the GPU-VM lane. GT0
+   (React dashboard) and GT1 (Phaser pixel) are unchanged. The thin-client invariant + layered
+   render-profile contract are unchanged.
 3. **Contract is LAYERED: core + per-renderer profiles.** Core (renderer-agnostic, all fields
    defaultable for the AI generator): `schema_version`, `scene_kind`, `positioning`, named
-   `zones` (NOT x,y), engine FK ids, scope-key art, AI-disclosure. Optional blocks: `phaser{}`,
-   `godot{}` (GT2 painterly-iso; added 2026-06-21), `rpgmaker{}` (reserved). Core-only conformance test gates it.
+   `zones` (NOT x,y), engine FK ids, scope-key art, AI-disclosure. Optional blocks currently
+   checked into the schema include `phaser{}`, `godot{}` (reference/extension material; added
+   2026-06-21), and `rpgmaker{}` (reserved). Unity-current work consumes `core`/SceneGrid today;
+   a formal `unity{}` renderer block is not yet checked into the contract. Core-only conformance
+   test gates it.
 4. **Positions are presentation derived from engine zones** — already the shipped pattern
    (`viewer/server.py:_combat_row_positions`). Token x,y is an ephemeral render-hint, never state.
 5. **M0 freezes THREE contracts together:** render-profile · graphical move-intent vocabulary
@@ -148,13 +151,13 @@ autonomy, ship/sell UGC)* layered on as the long-term plan proves out.
 
 ### M2 — GT2: Pillars/BG1-2 backdrop-isometric MVP (Branch A = the LOOK)  *(C2=backdrop, C3=zone-band, C4=walkmask, C7=flat)*
 - **R2.1 Backdrop render profile + occlusion** (walkmask renderer-owned; destinations resolve to engine zones/locations) · **R2.2 T2 combat + polish** (pure replay; normal-map lighting deferred) · **R2.3 T2 QA gates**
-- **⚠ RETIRED 2026-06-21 (the Phaser implementation):** the GT2 *renderer* moved to Godot (M5, pulled forward — epic #1050); the Phaser backdrop renderer (`viewer/openworlds/render/backdrop.html`) is reference-only. The render-profile contract work (R2.1) stays valid — Godot consumes the same `core` + a `godot{}` block.
+- **⚠ RETIRED 2026-06-21 (the Phaser implementation):** the GT2 *renderer* moved out of Phaser (M5, pulled forward — epic #1050); the Phaser backdrop renderer (`viewer/openworlds/render/backdrop.html`) is reference-only. **2026-06-25 owner update:** Unity is the current renderer direction; Godot is quarantined as reference/extension material until #1165 resolves. The render-profile contract work (R2.1) stays valid — renderers consume the same `core` plus renderer-specific optional blocks.
 
 ### M3 — Gated AI build-loop + UGC  *(C9=gated autonomy, C10=author→ship, C5 disclosure)*
 - **R3.1 Gated AI build-loop** (generate render-profile core from lore; resolve art; emit Phaser glue; gate each iter; human-gate queue for taste/story/contract) · **R3.2 UGC platform + licensing/compliance** (per-user ownership; AI-disclosure end-to-end [EU 2026-08-02, Steam survey]; MIT redistribution story) · **R3.3 Transport upgrade** (C8: websocket/SSE; swap behind SurfaceClient interface)
 
-### M5 — GT2 Godot painterly-isometric renderer (web + native) — **PULLED FORWARD, IN PROGRESS** (epic #1050)
-- The GT2 renderer (Branch A = the LOOK now; Branch B = C7 normal-map lighting later). Godot 4 thin client over the surfaces (HTTPRequest/WebSocketPeer; Light2D; NavigationRegion2D); consumes the `core` contract + a `godot{}` renderer block; GDScript headless-codegen harness (`.tscn` gen + `godot-mcp`). **Owner direction 2026-06-21:** a SINGLE Godot client serves both web (HTML5 export, single-threaded) and native (standalone `.app`); Phaser GT2 retired. Sprint 1 = the vertical slice (#1051–#1056); ISO projection locked in `godot/ISO-PROJECTION.md`.
+### M5 — GT2 Unity painterly-isometric renderer (web + native) — **PULLED FORWARD, IN PROGRESS** (epic #1050)
+- The GT2 renderer (Branch A = the LOOK now; Branch B = C7 normal-map lighting later). Unity is the current thin-client direction over the surfaces; it consumes the `core`/SceneGrid contract today. **2026-06-25 owner update:** Godot is quarantined as reference/extension material, not the current required renderer or emergency CI path; preserve the useful projection/contract notes until #1165 decides archive vs extension placement. A formal Unity renderer-profile block remains a future contract change, not part of this emergency CI recovery.
 
 ### M6 — *(optional, post-M1)* GT1 BYOL RPG Maker exploration export
 - Asset-clean (no RTP), exploration/dialogue only (battle-system mismatch is fatal), contract-taker; RTP legal guardrails + counsel review.
@@ -172,5 +175,5 @@ autonomy, ship/sell UGC)* layered on as the long-term plan proves out.
 
 ## 7. Open decisions deferred to owner (genuinely need you)
 1. Self-hosted open image model vs commercially-indemnified API for UGC assets (affects M3).
-2. GT2 MVP: flat-lit backdrops first (recommended) — confirmed; normal-map lighting = Branch B / Godot.
+2. GT2 MVP: flat-lit backdrops first (recommended) — confirmed; normal-map lighting = Branch B / Unity-current renderer lane.
 3. Does the AI build-loop become a user-facing surface ("watch it build") or an internal authoring tool? (shapes M3 UX.)

--- a/docs/roadmap/contracts/render-profile.md
+++ b/docs/roadmap/contracts/render-profile.md
@@ -8,10 +8,11 @@
 
 ## What it is
 
-The render-profile is the **single, versioned, layered contract** that every renderer
-(Phaser web today; an optional Godot desktop client and an optional RPG Maker exploration
-adapter later) and the AI build-loop consume to draw a WorldOS game. It is **presentation
-that joins to engine state by id** — it never holds game state.
+The render-profile is the **single, versioned, layered contract** that renderers and the
+AI build-loop consume to draw a WorldOS game. The current renderer lane consumes the
+engine-agnostic `core`/SceneGrid contracts; the Phaser, Godot, and RPG Maker blocks are
+optional reference/extension surfaces unless a follow-up renderer issue explicitly promotes
+one of them. It is **presentation that joins to engine state by id** — it never holds game state.
 
 ## The one invariant
 
@@ -33,7 +34,7 @@ render-profile
 │   ├── locations[]           { engine_location_id (FK), art.scope_key, zones[] }
 │   ├── actors[]              { engine_actor_id (FK), art.scope_key }
 │   └── ai_disclosure         { generated_by, model, date }
-└── renderer_profiles         ← OPTIONAL; a renderer reads core + its OWN block
+└── renderer_profiles         ← OPTIONAL reference/extension blocks
     ├── phaser                { tileset/tile_size/ui_skin | backdrop_layout/walkmask/… }
     ├── godot                 { projection | backdrop_layout(zone_anchors) | actor_sheets | default_facing }
     └── rpgmaker              (reserved / spec-only; deferred)
@@ -46,10 +47,11 @@ block. The **core-only conformance test (#428)** enforces this: a renderer using
 its own block must render every M0 scene. (The repo's existing SVG/React viewer is a free
 third "renderer" to validate that `core` stays renderer-agnostic.)
 
-### Godot renderer block (GT2 painterly-isometric)
+### Godot reference/extension block (GT2 painterly-isometric)
 
-The `godot` block (added 2026-06-21; sibling of `phaser`/`rpgmaker`) carries the GT2 Godot
-client's presentation — and **only** presentation:
+The `godot` block (added 2026-06-21; sibling of `phaser`/`rpgmaker`) is retained as a
+checked-in reference/extension contract. It is **not** the current required renderer lane.
+It carries the GT2 Godot client's presentation — and **only** presentation:
 
 - `projection` — the LOCKED dimetric 2:1 (~26.57°) isometric (see `godot/ISO-PROJECTION.md`,
   the single source of truth both the renderer and the Blender bake cite). Irreversible once

--- a/godot/HANDOFF.md
+++ b/godot/HANDOFF.md
@@ -1,10 +1,16 @@
-# GT2 Godot painterly-isometric renderer — HANDOFF / KNOWLEDGE BASE
+# GT2 Godot painterly-isometric renderer — QUARANTINED REFERENCE / KNOWLEDGE BASE
 
-> The single source of truth for the GT2 Godot renderer (epic **#1050**, milestone *Graphics M5
-> — GT2 Godot painterly-isometric renderer*). Built to make a cold agent productive without
-> re-deriving the research. Companions: `ISO-PROJECTION.md` (locked projection), `tools/README.md`
-> (asset pipeline), `docs/roadmap/contracts/render-profile.md` (the contract),
-> `docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md` (where GT2 sits). Last updated 2026-06-21.
+> **Quarantine note (2026-06-25):** this is historical/reference material for the Godot
+> prototype, not the current GT2 renderer path or a required merge gate. Owner direction moved
+> GT2 visual renderer work to the Unity 6 / Unity-MCP GPU-VM lane; #1165 owns the decision about
+> archiving, moving, or converting `godot/` into an extension lane. Keep the engine-agnostic
+> projection, SceneGrid, render-profile, and conformance lessons, but do not route new current
+> renderer work here unless #1165 explicitly reopens that path.
+>
+> Built to make a cold agent productive without re-deriving the research. Companions:
+> `ISO-PROJECTION.md` (locked projection), `tools/README.md` (asset pipeline),
+> `docs/roadmap/contracts/render-profile.md` (the contract),
+> `docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md` (where GT2 sits). Last updated 2026-06-25.
 
 ## Contents
 1. [TL;DR](#tldr)
@@ -22,11 +28,12 @@
 <a name="tldr"></a>
 ## 1. TL;DR
 
-The **foundation is done and CI-gated; the renderer is NOT yet feature-complete or shipped.** A
+The **prototype foundation was done and CI-gated; the renderer is NOT current, feature-complete, or shipped.** A
 vertical slice works: a directional character (real Meshy→Blender art) on **live engine state**,
 **click-to-move** on the frozen `/move` vocab, correct **Y-sort occlusion** — validated locally
 and in CI. The "looks-like-Pillars, fully-playable, shipped-to-web+native" end state is backlog
-(see §2, §9). The architecture diagram is the *plan*; ~half is built (§3 marks what's real).
+(see §2, §9), but that backlog is now reference material pending #1165. The architecture diagram
+is the *historical plan*; ~half is built (§3 marks what's real).
 
 The deepest thing to internalize: **the renderer is a stateless thin client over a zone-based
 engine, and the sprite-sheet manifest + render-profile contract — not the pixels — is the durable
@@ -34,8 +41,9 @@ product.** Art swaps `CC0 → AI → Meshy/Blender` at the same `scope_key` with
 Proven this session (placeholder green-oval → a real rendered ranger, no code change).
 
 > **Note:** Phaser 3 was the original GT2 MVP renderer; **retired 2026-06-21** (didn't deliver the
-> painterly-iso look) — Godot 4 is now the ONLY GT2 path. Decision record:
-> `docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md` §4.
+> painterly-iso look). Godot 4 then became the GT2 path, but **2026-06-25 owner direction
+> quarantines Godot as reference/extension material** and moves current visual renderer work to
+> Unity 6 / Unity-MCP. Decision record: `docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md` §4 and #1165.
 
 <a name="status"></a>
 ## 2. Status — done vs open
@@ -214,7 +222,11 @@ with zero renderer change**. Proven.
   render-profile `ai_disclosure` block for shipped AI content.
 
 <a name="run"></a>
-## 5. How to run / validate (local)
+## 5. How to run / validate (optional historical/reference lane)
+These commands are optional proof for changes under `godot/`; they are not the current GT2
+renderer proof path and must not be made branch-protection-required during the Woodpecker
+emergency recovery.
+
 **Prerequisites** (install these first): **Godot 4.6.3** (godotengine.org → `/Applications/Godot.app`;
 verify `godot --version`), **Blender 5.1.2** (`brew install blender`), and `uv`/Python (already required
 by the engine). For the asset-pipeline API keys, see §6.
@@ -223,7 +235,7 @@ by the engine). For the asset-pipeline API keys, see §6.
 - Parse/compile: `godot --headless --path godot --import`
 - Logic smoke: `godot --headless --path godot --quit-after 180 -- --smoke-intent`
 - Visual proof (real window): `godot --path godot --demo-occlusion --quit-after 300` → `/tmp/wos_godot_occlusion_{behind,front}.png`
-- CI: `.github/workflows/godot.yml` runs all of the above + Web/Linux export on every `godot/**` change — deterministic, **no model keys**.
+- CI: `.github/workflows/godot.yml` runs all of the above + Web/Linux export on every `godot/**` change — deterministic, **no model keys**. It is a reference/extension lane only, not part of required Linux CI replacement.
 
 <a name="assets"></a>
 ## 6. Asset pipeline — Meshy → Blender → sprite sheet
@@ -282,7 +294,7 @@ python3 godot/tools/pack_sheet.py --frames <dir>/frames \
 - **After a merge batch**, refresh GitNexus once: `gitnexus analyze /Users/lume/WorldOS --name worldos --embeddings --index-only`.
 
 <a name="backlog"></a>
-## 9. The full issue backlog (prioritized)
+## 9. The historical issue backlog (reference only until #1165 resolves)
 **Story / visual (look + play like Pillars):**
 - **#1090 — narration + dialogue in-view.** *Biggest gap:* the Godot view shows zero story text; prose
   only appears in the React dashboard. Wire `/events` + `/chat` into an in-view panel + a `say`/`clarify` affordance.

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -34,7 +34,7 @@ for _wos_rmvol_k in $(env | awk -F= '$2 ~ /^\/Volumes\// {print $1}'); do
   # awk emit a bogus "key", and `unset` on a non-identifier errors — which would abort a future
   # sourcer that runs `set -e`. (Today's sourcers use `set -uo pipefail` only, so this is belt-and-
   # suspenders to keep the shared lib safe regardless of the caller's shell options.)
-  case "$_wos_rmvol_k" in WORLDOS_*|WORLDOS_*|""|[0-9]*|*[!A-Za-z0-9_]*) continue ;; esac
+  case "$_wos_rmvol_k" in PATH|WORLDOS_*|WORLDOS_*|""|[0-9]*|*[!A-Za-z0-9_]*) continue ;; esac
   unset "$_wos_rmvol_k"
 done
 unset _wos_rmvol_k

--- a/servers/engine/tests/test_scorer_integrity.py
+++ b/servers/engine/tests/test_scorer_integrity.py
@@ -299,7 +299,10 @@ echo "[duo] done. story-craft=$(worldos_lens_display "{paths[0]}") mechanical=$(
     assert r.returncode == 0, r.stderr
     line = r.stdout.strip()
     assert "status=unscorable" not in line, f"all-valid run must NOT be unscorable: {line!r}"
-    assert "story-craft=4.0" in line and "mechanical=4.1" in line and "angry-dm=4.2" in line
+    values = dict(part.split("=", 1) for part in line.split() if "=" in part)
+    assert values.get("story-craft") in {"4", "4.0"}
+    assert values.get("mechanical") == "4.1"
+    assert values.get("angry-dm") == "4.2"
     assert "FAILED:" not in line
 
 


### PR DESCRIPTION
## Summary

Refs #1166.
Refs #1165.

This PR adds the Woodpecker-side Linux CI definitions for the five currently required WorldOS branch-protection gates:

- `test`
- `viewer-tests`
- `qa-release-gate-tests`
- `server-contracts`
- `license-check`

It keeps GitHub Actions workflows in place for now. Branch protection should not be changed until Woodpecker runs on this PR head and GitHub receives the exact replacement status contexts.

## Renderer cleanup

- Quarantines the Godot lane as reference/extension material instead of current required renderer work.
- Keeps `.github/workflows/godot.yml` as a reference/extension workflow, not a required emergency Woodpecker gate.
- Updates onboarding/runbook/roadmap language to point current visual renderer work at the Unity 6 / Unity-MCP GPU-VM lane.
- Leaves the actual `render-profile.schema.json` contract unchanged; Unity-current work consumes `core`/SceneGrid today, and a formal `unity{}` block remains a future contract change.

## Validation

- `git diff --check`
- Parsed all `.woodpecker/*.yml` with PyYAML.
- `python3 scripts/license_check.py`
- Read-only adversarial review:
  - Fixed missing `git` in the `python:3.12-slim` license-check container.
  - Fixed stale Godot onboarding/source-of-truth language.
  - Documented `qa/test_visual_critic.py` as an intentional deterministic current-renderer addition to the parity set.

## Known rollout blocker

Woodpecker activation for `electricsheephq/WorldOS` is still blocked before this PR can prove statuses:

- WorldOS is visible in Woodpecker but inactive.
- `POST /api/repos?forge_remote_id=1246787955` returned `could not create webhook in forge`.
- Existing branch protection still requires the old GitHub Actions app-scoped contexts: `test`, `viewer-tests`, `qa-release-gate-tests`, `server-contracts`, `license-check`.

No branch-protection change is included in this PR. The next safe step is to repair Woodpecker forge/webhook activation, run these workflows on the PR SHA, capture the exact GitHub status contexts, and only then update required checks.
