### PR TITLE
feat(combat): engine player-turn combat arbiter (S1 keystone)

### DIFF
--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -989,8 +989,11 @@ def resolve_player_turn(
     if turn_should_end and not consumed_action:
         try:
             server.use_action(campaign_id, actor.id, kind="skip")
-        except Exception:
-            pass
+        except Exception as exc:
+            # Advisory + best-effort: declaring the skip can fail harmlessly (e.g. the action was
+            # already spent). next_turn's PC-skip guard still legally ends a do-nothing-action turn,
+            # so we tolerate it but record it for diagnostics rather than masking it silently.
+            resolved.setdefault("skip_declare_error", str(exc))
 
     if not turn_should_end:
         # The turn is still the PC's (a bare move, or advance=False introspection). Do NOT touch
@@ -1019,7 +1022,6 @@ def resolve_player_turn(
     # awaiting_pc (it can wrap to a PC at the top of the next round). So loop until the current
     # combatant is a PC/companion (the next decision) or the fight ends — bounded by a turn cap.
     enemy_digest: list[dict] = []
-    c = server._require(campaign_id)
     for _ in range(64):  # safety rail against a non-advancing order
         c = server._require(campaign_id)
         if not c.combat.active or len(_living_sides(c)) < 2:

--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -1011,20 +1011,20 @@ def resolve_player_turn(
     # mutated) instead of silently degrading to a skip inside _apply_intent.
     if intent.kind == "attack" and not intent.target_id:
         return {"ok": False, "reason": "an attack needs a target_id"}
-    if intent.kind == "move":
-        if intent.to_cell is None and not intent.to_zone:
-            return {"ok": False, "reason": "a move needs a to_cell (x,y) or a to_zone"}
-        # Validate the to_cell shape up front: a 2-tuple/list of ints. A malformed cell
-        # (wrong arity, non-int) would otherwise raise deep inside move_to_coords AFTER the
-        # turn-ownership gate — reject it here so nothing is mutated and the UI gets a clear why.
-        if intent.to_cell is not None:
-            tc = intent.to_cell
-            if not (
-                isinstance(tc, (tuple, list))
-                and len(tc) == 2
-                and all(isinstance(coord, int) and not isinstance(coord, bool) for coord in tc)
-            ):
-                return {"ok": False, "reason": f"to_cell must be an (x, y) pair of ints, got {tc!r}"}
+    # ANY intent carrying a to_cell must carry a well-formed one — an (x,y) int pair — not just
+    # `move`. The public arbiter admits every action-consuming kind (the bridge only ever sends
+    # move/attack/skip, but harden the contract): a malformed cell on e.g. a disengage would
+    # otherwise raise deep inside a verb AFTER the turn-ownership gate. Reject here so nothing is
+    # mutated and the UI gets a clear why.
+    tc = intent.to_cell
+    if tc is not None and not (
+        isinstance(tc, (tuple, list))
+        and len(tc) == 2
+        and all(isinstance(coord, int) and not isinstance(coord, bool) for coord in tc)
+    ):
+        return {"ok": False, "reason": f"to_cell must be an (x, y) pair of ints, got {tc!r}"}
+    if intent.kind == "move" and intent.to_cell is None and not intent.to_zone:
+        return {"ok": False, "reason": "a move needs a to_cell (x,y) or a to_zone"}
 
     # Prime the per-turn attack-option cache the way run_combat_round does, so an `attack`
     # Intent's damage spec resolves from the actor's authoritative attack lines (a PC gets the

--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -851,3 +851,212 @@ def run_combat_autonomous(campaign_id: str, mode: str = "test", max_rounds: int 
         "round_digests": rounds,
         "end_combat": ended,
     }
+
+
+# ── The PLAYER-TURN ARBITER (S1 keystone) ────────────────────────────────────────────
+# The one path by which a HUMAN/UI-authored Intent is resolved on the player's combat turn.
+# It is the mirror of the AI loop's `awaiting_pc` branch: where `run_combat_round(mode="live")`
+# STOPS at a PC turn and hands a digest to the DM, THIS entry-point accepts the PC's own
+# Intent (the cell to move to / the target to strike), resolves it through the SAME
+# `_apply_intent` mapping the AI uses, advances the turn, then auto-runs the following enemy
+# turns up to the next PC decision.
+#
+# SOLE-WRITER INVARIANT (unchanged): like the rest of this module, the arbiter holds NO lock
+# and introduces NO new write path — every mutation goes through an existing server.py verb
+# (move_to_coords / attack / next_turn), each of which takes its own campaign_lock +
+# save_campaign. The arbiter only READS a snapshot to validate turn-ownership + prime the
+# attack-option cache, then delegates to the locked verbs.
+#
+# TURN-OWNERSHIP is load-bearing: move_to_coords() does NOT gate on whose turn it is (it
+# charges the named mover's own budget regardless), so a wrong-turn move would otherwise
+# silently mutate the board. The arbiter REJECTS (mutating nothing) unless the actor is the
+# current combatant AND a PC/companion. (attack() additionally self-guards turn-ownership,
+# but we gate up front so BOTH kinds reject identically and nothing is half-applied.)
+
+# A PC/companion player Intent the arbiter accepts. Mirrors _LIVE_AUTORUN_KINDS' complement:
+# only a party actor (player/companion) is ever "awaiting" in a live fight.
+_PLAYER_TURN_KINDS = _PARTY_KINDS
+
+
+# Intent kinds that CONSUME the turn's action economy (so next_turn's PC-skip guard passes and
+# the turn legally ends). A bare `move` consumes NO action (5e: you may move AND act), so it
+# leaves the turn OPEN for a following action — the arbiter does NOT auto-advance on a bare move.
+_ACTION_CONSUMING_KINDS = frozenset({"attack", "cast", "dash", "disengage", "dodge", "skip", "use_resource"})
+
+
+def resolve_player_turn(
+    campaign_id: str,
+    actor_id: str,
+    intent: Intent,
+    *,
+    advance: bool = True,
+    end_turn: bool = False,
+) -> dict:
+    """Resolve ONE player/companion combat action from an injected Intent (S1 keystone).
+
+    This is the player-control mirror of run_combat_round(mode="live")'s `awaiting_pc` stop:
+    the loop hands a PC turn back to the human/UI; the UI POSTs the PC's chosen Intent (move
+    to a cell, or attack a target); THIS function validates it is that actor's turn, resolves
+    it through the EXISTING `_apply_intent` (the same Intent->locked-verb mapping the AI loop
+    uses), and — when the turn is actually OVER — advances initiative + auto-runs the following
+    enemy turns to the next PC decision.
+
+    TURN MODEL (5e-correct): a bare `move` consumes NO action — the player may move AND then act
+    — so a move-to-cell DOES NOT end the turn; the turn stays OPEN (awaiting_pc == actor) for a
+    following action. An action-consuming intent (attack / cast / dash / disengage / dodge /
+    skip) ends the turn → the arbiter advances. A move-then-end-without-acting is requested via
+    `end_turn=True` (the UI's explicit "End Turn"): the arbiter declares a skip and advances.
+
+    Args:
+      campaign_id: the live campaign.
+      actor_id:    the combatant declaring the action — MUST be the current combatant AND a
+                   player/companion, or the call is rejected with nothing mutated.
+      intent:      a `move` (to_cell set) or `attack` (target_id set) Intent. Other kinds are
+                   resolvable too (cast/skip/dodge/disengage) via the shared mapping.
+      advance:     master switch (default True). When False, resolve the intent only and never
+                   touch initiative (test-introspection); the turn stays open.
+      end_turn:    when True, end the turn after resolving even if the intent did not consume an
+                   action (move-then-End-Turn) — the arbiter declares a skip so next_turn's
+                   PC-skip guard passes, then advances.
+
+    Returns (NEVER raises for a normal rejection):
+      {ok: False, reason}                              — rejected; NOTHING mutated.
+      {ok: True, resolved, advanced, turn_open,        — resolved. `turn_open` True == the PC may
+       awaiting_pc, combat_active, round}                still act this turn (a bare move); when
+                                                         the turn ended, `awaiting_pc` is whose
+                                                         turn it is next (None if the fight ended).
+
+    Sole writer: only the verbs `_apply_intent`/next_turn/run_combat_round invoke mutate; the
+    arbiter holds no lock. Additive: a campaign that never calls this is byte-identical to today.
+    """
+    import server  # lazy: avoid a server->combat_loop import cycle at module load
+
+    if intent is None or not isinstance(intent, Intent):
+        return {"ok": False, "reason": "resolve_player_turn needs an Intent"}
+
+    c = server._require(campaign_id)
+    if not c.combat.active or not c.combat.order:
+        return {"ok": False, "reason": "no active combat"}
+
+    cur_id = c.combat.current_combatant_id
+    if cur_id is None:
+        return {"ok": False, "reason": "no current combatant"}
+
+    # TURN-OWNERSHIP GATE (load-bearing — move_to_coords does not self-gate). Reject a move by
+    # anyone other than the current combatant, BEFORE any verb runs, so nothing is mutated.
+    if actor_id != cur_id:
+        cur = c.characters.get(cur_id)
+        cur_name = cur.name if cur is not None else cur_id
+        return {"ok": False, "reason": f"not {actor_id}'s turn — it is {cur_name}'s ({cur_id}) turn"}
+
+    actor = c.characters.get(actor_id)
+    if actor is None:
+        return {"ok": False, "reason": f"unknown combatant {actor_id!r}"}
+    # Only a PC/companion is ever the "awaiting" actor; refuse to drive a monster/NPC turn
+    # through the player lane (those are the AI loop's / the DM's to run).
+    if actor.kind not in _PLAYER_TURN_KINDS:
+        return {"ok": False, "reason": f"{actor.name} is a {actor.kind}, not a player-controlled combatant"}
+    if not _alive(actor):
+        return {"ok": False, "reason": f"{actor.name} cannot act (downed/dead)"}
+
+    # Per-kind required-field validation, so an ill-formed Intent REJECTS cleanly (with nothing
+    # mutated) instead of silently degrading to a skip inside _apply_intent.
+    if intent.kind == "attack" and not intent.target_id:
+        return {"ok": False, "reason": "an attack needs a target_id"}
+    if intent.kind == "move" and intent.to_cell is None and not intent.to_zone:
+        return {"ok": False, "reason": "a move needs a to_cell (x,y) or a to_zone"}
+
+    # Prime the per-turn attack-option cache the way run_combat_round does, so an `attack`
+    # Intent's damage spec resolves from the actor's authoritative attack lines (a PC gets the
+    # synthesized weapon line). A pure move ignores the cache; priming is harmless either way.
+    view = _build_view(server, c, actor)
+    _view_cache[actor.id] = view.attacks
+    try:
+        resolved = _apply_intent(server, campaign_id, actor.id, intent)
+    finally:
+        _view_cache.pop(actor.id, None)
+
+    # Decide whether the TURN is over. A bare `move` consumes no action -> the turn stays OPEN
+    # (the PC may still act). An action-consuming intent ends it. `end_turn=True` ends a
+    # move-only turn on explicit request (the arbiter declares the skip so the guard passes).
+    # If _apply_intent itself degraded an action-consuming intent to a skip on a refusal, it
+    # already called use_action(skip) -> the guard is satisfied and the turn legally ends.
+    consumed_action = intent.kind in _ACTION_CONSUMING_KINDS
+    turn_should_end = advance and (consumed_action or end_turn)
+
+    # If the player is ENDING the turn but resolved only a move (no action consumed), declare an
+    # explicit skip so next_turn's PC-skip guard passes (a do-nothing-action turn is legal).
+    if turn_should_end and not consumed_action:
+        try:
+            server.use_action(campaign_id, actor.id, kind="skip")
+        except Exception:
+            pass
+
+    if not turn_should_end:
+        # The turn is still the PC's (a bare move, or advance=False introspection). Do NOT touch
+        # initiative — return turn_open so the UI keeps the action bar live for this actor.
+        c = server._require(campaign_id)
+        return {
+            "ok": True,
+            "resolved": resolved,
+            "advanced": False,
+            "turn_open": bool(c.combat.active and c.combat.current_combatant_id == actor.id),
+            "awaiting_pc": cur_id,
+            "combat_active": c.combat.active,
+            "round": c.combat.round,
+        }
+
+    # Advance the turn (the locked next_turn enforces the PC-skip guard + end-of-turn saves).
+    c = server._require(campaign_id)
+    if c.combat.active and c.combat.current_combatant_id == actor.id:
+        try:
+            server.next_turn(campaign_id)
+        except Exception as exc:  # advisory: report, don't crash the turn
+            resolved.setdefault("error", str(exc))
+
+    # Auto-run the following ENEMY turns to the next PC decision — the existing live loop.
+    # run_combat_round is ONE round per call and breaks at a round boundary WITHOUT reporting
+    # awaiting_pc (it can wrap to a PC at the top of the next round). So loop until the current
+    # combatant is a PC/companion (the next decision) or the fight ends — bounded by a turn cap.
+    enemy_digest: list[dict] = []
+    c = server._require(campaign_id)
+    for _ in range(64):  # safety rail against a non-advancing order
+        c = server._require(campaign_id)
+        if not c.combat.active or len(_living_sides(c)) < 2:
+            break
+        cur = c.characters.get(c.combat.current_combatant_id)
+        if cur is not None and cur.kind in _PLAYER_TURN_KINDS and _alive(cur):
+            break  # reached the next PC decision — stop auto-running
+        rr = run_combat_round(campaign_id, mode="live")
+        enemy_digest.extend(rr.get("round_digest") or [])
+        # If the round produced no progress (no digest AND the current combatant is unchanged),
+        # bail to avoid spinning (defensive — run_combat_round always advances or stops).
+        if not rr.get("round_digest") and rr.get("awaiting_pc") is None:
+            # nudge past a stuck non-PC current via next_turn, else break
+            c2 = server._require(campaign_id)
+            if c2.combat.active and c2.combat.current_combatant_id == (cur.id if cur else None):
+                try:
+                    server.next_turn(campaign_id)
+                except Exception:
+                    break
+    if enemy_digest:
+        resolved.setdefault("enemy_digest", enemy_digest)
+
+    # The next PC decision == the current combatant IF it is now a living PC/companion.
+    awaiting_pc: Optional[str] = None
+    c = server._require(campaign_id)
+    if c.combat.active:
+        cur = c.characters.get(c.combat.current_combatant_id)
+        if cur is not None and cur.kind in _PLAYER_TURN_KINDS and _alive(cur):
+            awaiting_pc = cur.id
+
+    return {
+        "ok": True,
+        "resolved": resolved,
+        "advanced": True,
+        "turn_open": False,
+        "awaiting_pc": awaiting_pc,
+        "combat_active": c.combat.active,
+        "round": c.combat.round,
+        "living_sides": sorted(_living_sides(c)),
+    }

--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -1030,6 +1030,13 @@ def resolve_player_turn(
     # Intent's damage spec resolves from the actor's authoritative attack lines (a PC gets the
     # synthesized weapon line). A pure move ignores the cache; priming is harmless either way.
     view = _build_view(server, c, actor)
+    # A player /move attack carries only a target_id (no attack_name), so default it to the PC's
+    # authoritative first attack option — otherwise _apply_intent fails the name match and falls
+    # back to the defensive +0/1d4 strike instead of the real weapon/to-hit profile.
+    if intent.kind == "attack" and not intent.attack_name:
+        if not view.attacks:
+            return {"ok": False, "reason": f"{actor.name} has no available attack option"}
+        intent = replace(intent, attack_name=view.attacks[0].name)
     _view_cache[actor.id] = view.attacks
     try:
         resolved = _apply_intent(server, campaign_id, actor.id, intent)
@@ -1134,8 +1141,17 @@ def resolve_player_turn(
         if not c.combat.active or len(_living_sides(c)) < 2:
             break
         cur = c.characters.get(c.combat.current_combatant_id)
-        if cur is not None and cur.kind in _PLAYER_TURN_KINDS and _alive(cur):
-            break  # reached the next PC decision — stop auto-running
+        if cur is not None and cur.kind in _PLAYER_TURN_KINDS:
+            if _alive(cur):
+                break  # reached the next PC decision — stop auto-running
+            # A DOWNED PC/companion: run_combat_round(mode="live") would STOP here without acting,
+            # so this loop would spin to its 64-turn cap and return no actionable awaiting_pc.
+            # Advance past it ourselves toward the next decision (or terminal state).
+            try:
+                server.next_turn(campaign_id)
+            except Exception:
+                break
+            continue
         rr = run_combat_round(campaign_id, mode="live")
         enemy_digest.extend(rr.get("round_digest") or [])
         # If the round produced no progress (no digest AND the current combatant is unchanged),

--- a/servers/engine/combat_loop.py
+++ b/servers/engine/combat_loop.py
@@ -883,6 +883,25 @@ _PLAYER_TURN_KINDS = _PARTY_KINDS
 # leaves the turn OPEN for a following action — the arbiter does NOT auto-advance on a bare move.
 _ACTION_CONSUMING_KINDS = frozenset({"attack", "cast", "dash", "disengage", "dodge", "skip", "use_resource"})
 
+# The intent kinds the PLAYER lane will resolve through _apply_intent: the action-consuming kinds
+# plus a bare `move` (which keeps the turn open). Any other kind is rejected by the arbiter up
+# front (defense-in-depth) so a malformed/unknown intent never reaches _apply_intent's skip
+# fallback and burns the PC's turn.
+_PLAYER_INTENT_KINDS = _ACTION_CONSUMING_KINDS | {"move"}
+
+
+def turn_token(c) -> str:
+    """A stable identity for the CURRENT turn slot: round + turn_index + current combatant.
+
+    The UI reads this off build_combat_surface and echoes it on its next player-turn POST; the
+    arbiter rejects a POST whose token != the live slot (idempotency). A double-click reuses the
+    SAME token (the client read the surface once), so the second, now-stale POST rejects instead
+    of burning a second PC turn — while a genuine NEXT turn carries a FRESH token (the client
+    re-read the surface) and is accepted. Empty string when there's no active combat."""
+    if not c.combat.active or not c.combat.order:
+        return ""
+    return f"{c.combat.round}:{c.combat.turn_index}:{c.combat.current_combatant_id or ''}"
+
 
 def resolve_player_turn(
     campaign_id: str,
@@ -891,6 +910,7 @@ def resolve_player_turn(
     *,
     advance: bool = True,
     end_turn: bool = False,
+    expected_turn_token: str = "",
 ) -> dict:
     """Resolve ONE player/companion combat action from an injected Intent (S1 keystone).
 
@@ -918,6 +938,10 @@ def resolve_player_turn(
       end_turn:    when True, end the turn after resolving even if the intent did not consume an
                    action (move-then-End-Turn) — the arbiter declares a skip so next_turn's
                    PC-skip guard passes, then advances.
+      expected_turn_token: OPTIONAL idempotency token (see turn_token()). When non-empty, the
+                   call is rejected unless it matches the LIVE turn slot — so a double-click /
+                   stale retry (which echoes the token the client read once) rejects instead of
+                   burning a second PC turn. Empty (default) == today's behavior (no token check).
 
     Returns (NEVER raises for a normal rejection):
       {ok: False, reason}                              — rejected; NOTHING mutated.
@@ -942,6 +966,22 @@ def resolve_player_turn(
     if cur_id is None:
         return {"ok": False, "reason": "no current combatant"}
 
+    # IDEMPOTENCY / TURN-SLOT GUARD (dedup): when the caller supplies a token, it must match the
+    # LIVE turn slot. A double-click / stale retry echoes the token the client read ONCE off the
+    # surface; after the first POST resolves + the order advances, the slot token changes, so the
+    # second (stale-token) POST rejects here — NOTHING mutated — instead of being accepted as a
+    # second legitimate PC turn. A genuine next turn carries a FRESH token (the client re-read the
+    # surface) and passes. Empty token (default) == no check (today's behavior / tests).
+    if expected_turn_token:
+        live_token = turn_token(c)
+        if expected_turn_token != live_token:
+            return {
+                "ok": False,
+                "reason": "stale turn — the board advanced since this action was chosen (re-read and retry)",
+                "expected_turn_token": expected_turn_token,
+                "live_turn_token": live_token,
+            }
+
     # TURN-OWNERSHIP GATE (load-bearing — move_to_coords does not self-gate). Reject a move by
     # anyone other than the current combatant, BEFORE any verb runs, so nothing is mutated.
     if actor_id != cur_id:
@@ -959,12 +999,32 @@ def resolve_player_turn(
     if not _alive(actor):
         return {"ok": False, "reason": f"{actor.name} cannot act (downed/dead)"}
 
+    # KIND ALLOWLIST (defense-in-depth): only resolve the intent kinds the player lane supports.
+    # An unsupported/unknown kind REJECTS cleanly (nothing mutated) rather than slipping into
+    # _apply_intent, whose `else` branch silently degrades to a skip (which would burn the PC's
+    # turn on a malformed request). Mirrors the engine's "reject the illegal action outright"
+    # posture. The set is the union of the action-consuming kinds + the bare `move`.
+    if intent.kind not in _PLAYER_INTENT_KINDS:
+        return {"ok": False, "reason": f"unsupported player intent kind {intent.kind!r}"}
+
     # Per-kind required-field validation, so an ill-formed Intent REJECTS cleanly (with nothing
     # mutated) instead of silently degrading to a skip inside _apply_intent.
     if intent.kind == "attack" and not intent.target_id:
         return {"ok": False, "reason": "an attack needs a target_id"}
-    if intent.kind == "move" and intent.to_cell is None and not intent.to_zone:
-        return {"ok": False, "reason": "a move needs a to_cell (x,y) or a to_zone"}
+    if intent.kind == "move":
+        if intent.to_cell is None and not intent.to_zone:
+            return {"ok": False, "reason": "a move needs a to_cell (x,y) or a to_zone"}
+        # Validate the to_cell shape up front: a 2-tuple/list of ints. A malformed cell
+        # (wrong arity, non-int) would otherwise raise deep inside move_to_coords AFTER the
+        # turn-ownership gate — reject it here so nothing is mutated and the UI gets a clear why.
+        if intent.to_cell is not None:
+            tc = intent.to_cell
+            if not (
+                isinstance(tc, (tuple, list))
+                and len(tc) == 2
+                and all(isinstance(coord, int) and not isinstance(coord, bool) for coord in tc)
+            ):
+                return {"ok": False, "reason": f"to_cell must be an (x, y) pair of ints, got {tc!r}"}
 
     # Prime the per-turn attack-option cache the way run_combat_round does, so an `attack`
     # Intent's damage spec resolves from the actor's authoritative attack lines (a PC gets the
@@ -986,14 +1046,46 @@ def resolve_player_turn(
 
     # If the player is ENDING the turn but resolved only a move (no action consumed), declare an
     # explicit skip so next_turn's PC-skip guard passes (a do-nothing-action turn is legal).
+    # FAIL CLOSED: use_action(kind="skip") reports a REJECTED pass via ok=False (it does NOT
+    # raise) — e.g. the actor is no longer current, or the action was already spent (state drift /
+    # a racing call). If the skip did not succeed we must NOT advance into next_turn (whose PC-skip
+    # guard would then raise, or which would advance an out-of-sync turn): return a clean
+    # not-advanced result with the reason and keep the turn OPEN. A genuine raise is handled the
+    # same way. (When the action WAS already consumed, the skip's "already used" rejection is
+    # benign — the guard is already satisfied — so we only bail when the turn is still ACTABLE.)
     if turn_should_end and not consumed_action:
+        skip_failed_reason: Optional[str] = None
         try:
-            server.use_action(campaign_id, actor.id, kind="skip")
+            skip_res = server.use_action(campaign_id, actor.id, kind="skip")
+            if isinstance(skip_res, dict) and not skip_res.get("ok"):
+                skip_failed_reason = str(skip_res.get("reason") or "skip rejected")
         except Exception as exc:
-            # Advisory + best-effort: declaring the skip can fail harmlessly (e.g. the action was
-            # already spent). next_turn's PC-skip guard still legally ends a do-nothing-action turn,
-            # so we tolerate it but record it for diagnostics rather than masking it silently.
-            resolved.setdefault("skip_declare_error", str(exc))
+            skip_failed_reason = str(exc)
+        if skip_failed_reason is not None:
+            # Re-read: only bail if the turn is genuinely NOT yet endable (the actor is still
+            # current AND hasn't acted). If the skip was rejected merely because the action was
+            # already spent, the PC-skip guard is already satisfied and we proceed to advance.
+            c = server._require(campaign_id)
+            cur = c.combat.current_combatant_id if c.combat.active else None
+            already_acted = (
+                c.combat.action_used
+                or c.combat.action_attacks_made > 0
+                or c.combat.bonus_action_used
+            ) if c.combat.active else False
+            if cur == actor.id and not already_acted:
+                return {
+                    "ok": True,
+                    "resolved": resolved,
+                    "advanced": False,
+                    "turn_open": True,
+                    "skip_declare_error": skip_failed_reason,
+                    "awaiting_pc": actor.id,
+                    "combat_active": c.combat.active,
+                    "round": c.combat.round,
+                }
+            # Otherwise the guard is satisfiable (already acted, or the actor is no longer
+            # current) — record the benign rejection and proceed to advance.
+            resolved.setdefault("skip_declare_error", skip_failed_reason)
 
     if not turn_should_end:
         # The turn is still the PC's (a bare move, or advance=False introspection). Do NOT touch
@@ -1010,12 +1102,27 @@ def resolve_player_turn(
         }
 
     # Advance the turn (the locked next_turn enforces the PC-skip guard + end-of-turn saves).
+    # If next_turn RAISES (e.g. the PC-skip guard refuses because the action didn't register),
+    # the turn did NOT advance — the actor is STILL current. Returning advanced=True here would
+    # be a lie the UI acts on (it would stop showing this PC's action bar though the engine still
+    # awaits its turn). So on a raise we return a clean NOT-advanced result with the reason; the
+    # action the player took (the resolved move/attack) still landed via the locked verb.
     c = server._require(campaign_id)
     if c.combat.active and c.combat.current_combatant_id == actor.id:
         try:
             server.next_turn(campaign_id)
-        except Exception as exc:  # advisory: report, don't crash the turn
-            resolved.setdefault("error", str(exc))
+        except Exception as exc:
+            c = server._require(campaign_id)
+            return {
+                "ok": True,
+                "resolved": resolved,
+                "advanced": False,
+                "turn_open": bool(c.combat.active and c.combat.current_combatant_id == actor.id),
+                "advance_error": str(exc),
+                "awaiting_pc": actor.id if c.combat.active else None,
+                "combat_active": c.combat.active,
+                "round": c.combat.round,
+            }
 
     # Auto-run the following ENEMY turns to the next PC decision — the existing live loop.
     # run_combat_round is ONE round per call and breaks at a round boundary WITHOUT reporting

--- a/servers/engine/tests/test_player_turn_arbiter.py
+++ b/servers/engine/tests/test_player_turn_arbiter.py
@@ -1,0 +1,186 @@
+"""S1 keystone — the ENGINE PLAYER-TURN COMBAT ARBITER (combat_loop.resolve_player_turn).
+
+The arbiter is the single path by which a HUMAN/UI-authored Intent is resolved on the
+player's grid-combat turn. It mirrors run_combat_round(mode="live")'s `awaiting_pc` stop:
+the loop hands a PC turn to the UI; the UI POSTs the PC's chosen Intent (a cell to move to /
+a target to strike); the arbiter validates turn-ownership, resolves it through the SAME
+`_apply_intent` mapping the AI uses (so the engine rolls), advances initiative, then auto-runs
+the following enemy turns to the next PC decision.
+
+Load-bearing invariants exercised here:
+  * TURN-OWNERSHIP: a wrong-turn / non-PC / no-combat move REJECTS with NOTHING mutated
+    (move_to_coords does not self-gate, so this gate is the only guard).
+  * SOLE WRITER: every mutation goes through the existing locked verbs (move_to_coords /
+    attack / next_turn) — the arbiter holds no lock and adds no write path.
+  * ADDITIVE: a campaign that never calls the arbiter is byte-identical to today (covered by
+    the existing test_grid round-trip + the move-budget tests; here we assert the new path
+    only TOUCHES state via the locked verbs).
+"""
+
+import pytest
+
+import combat_loop
+import server
+from combat_ai import Intent
+
+
+@pytest.fixture
+def grid_fight(tmp_path, monkeypatch):
+    """A hero (player, speed 30) FIRST in initiative + a goblin (monster), on a 20x20 grid.
+
+    The hero is passed as a surpriser so it deterministically leads the order (no dice flake),
+    so resolve_player_turn's current-combatant == the PC from the start."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("Arbiter")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30, armor_class=14)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=15, armor_class=12)["id"]
+    server.start_combat(cid, [hero, gob], surpriser_ids=[hero])  # hero acts first
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, hero, 0, 0)
+    server.place_combatant_at_coords(cid, gob, 10, 0)
+    return cid, hero, gob
+
+
+def _cell(cid: str, who: str):
+    c = server._require(cid)
+    cb = next(o for o in c.combat.order if o.character_id == who)
+    return (cb.x, cb.y)
+
+
+# ── HAPPY PATH: a player move-to-cell on the PC's turn resolves + advances ────────────
+
+
+def test_bare_move_keeps_turn_open(grid_fight):
+    """5e: a move consumes no action. A bare move-to-cell resolves the move but DOES NOT end the
+    turn — the PC may still act (turn_open True, initiative unchanged)."""
+    cid, hero, gob = grid_fight
+    assert server._require(cid).combat.current_combatant_id == hero
+    assert _cell(cid, hero) == (0, 0)
+
+    out = combat_loop.resolve_player_turn(cid, hero, Intent(kind="move", to_cell=(3, 0)))
+    assert out["ok"] is True, out
+    # The token moved (engine charged the budget via the locked verb).
+    assert _cell(cid, hero) == (3, 0)
+    # The turn is STILL the hero's — a move alone never advances initiative.
+    assert out["advanced"] is False
+    assert out["turn_open"] is True
+    assert server._require(cid).combat.current_combatant_id == hero
+
+
+def test_move_then_end_turn_advances(grid_fight):
+    """A move followed by end_turn=True ends the move-only turn (the arbiter declares the skip),
+    advances initiative, and auto-runs the enemy turn to the next PC decision."""
+    cid, hero, gob = grid_fight
+    out = combat_loop.resolve_player_turn(
+        cid, hero, Intent(kind="move", to_cell=(3, 0)), end_turn=True
+    )
+    assert out["ok"] is True, out
+    assert _cell(cid, hero) == (3, 0)
+    assert out["advanced"] is True
+    assert out["turn_open"] is False
+    c = server._require(cid)
+    if c.combat.active:
+        assert out["awaiting_pc"] == hero  # back to the hero after the goblin auto-ran
+        assert c.combat.current_combatant_id == hero
+
+
+def test_attack_ends_turn_and_advances(grid_fight):
+    """An attack CONSUMES the action -> the turn ends and the arbiter advances + auto-runs the
+    enemy, without an explicit end_turn."""
+    cid, hero, gob = grid_fight
+    server.place_combatant_at_coords(cid, gob, 1, 0)  # adjacent so the strike is in reach
+    out = combat_loop.resolve_player_turn(
+        cid, hero, Intent(kind="attack", target_id=gob, attack_name="Weapon")
+    )
+    assert out["ok"] is True, out
+    assert out["advanced"] is True
+    assert out["turn_open"] is False
+
+
+def test_move_to_cell_charges_movement_budget(grid_fight):
+    cid, hero, gob = grid_fight
+    combat_loop.resolve_player_turn(cid, hero, Intent(kind="move", to_cell=(4, 0)), advance=False)
+    c = server._require(cid)
+    cb = next(o for o in c.combat.order if o.character_id == hero)
+    assert cb.moved_cells_this_turn == 4  # Chebyshev 0,0 -> 4,0 == 4 cells charged
+
+
+def test_attack_on_turn_rolls_via_engine(grid_fight):
+    cid, hero, gob = grid_fight
+    # Place the goblin adjacent so a melee strike is in reach, then attack it on the PC's turn.
+    server.place_combatant_at_coords(cid, gob, 1, 0)
+    out = combat_loop.resolve_player_turn(
+        cid, hero, Intent(kind="attack", target_id=gob, attack_name="Weapon"), advance=False
+    )
+    assert out["ok"] is True, out
+    # The arbiter delegated to the locked attack() verb — the digest entry records a resolution.
+    assert out["resolved"]["kind"] == "attack"
+    assert "result" in out["resolved"]
+
+
+# ── TURN-OWNERSHIP: wrong turn / non-PC / no combat all REJECT with nothing mutated ──
+
+
+def test_wrong_turn_move_is_rejected_and_mutates_nothing(grid_fight):
+    cid, hero, gob = grid_fight
+    # It is the HERO's turn; a move declared for the GOBLIN must be refused.
+    before = _cell(cid, gob)
+    out = combat_loop.resolve_player_turn(cid, gob, Intent(kind="move", to_cell=(5, 0)))
+    assert out["ok"] is False
+    assert "turn" in out["reason"].lower()
+    assert _cell(cid, gob) == before  # NOTHING moved
+    # The hero is still the current combatant (initiative did not advance).
+    assert server._require(cid).combat.current_combatant_id == hero
+
+
+def test_monster_cannot_be_driven_through_player_lane(grid_fight):
+    cid, hero, gob = grid_fight
+    # Even if it WERE the goblin's turn, a monster is not a player-controlled combatant. Advance
+    # to the goblin's turn first, then try to drive it through the player arbiter.
+    server.use_action(cid, hero, kind="skip")
+    server.next_turn(cid)  # now the goblin's turn
+    assert server._require(cid).combat.current_combatant_id == gob
+    out = combat_loop.resolve_player_turn(cid, gob, Intent(kind="move", to_cell=(5, 0)))
+    assert out["ok"] is False
+    assert "monster" in out["reason"].lower() or "player-controlled" in out["reason"].lower()
+
+
+def test_attack_without_target_rejected(grid_fight):
+    cid, hero, gob = grid_fight
+    out = combat_loop.resolve_player_turn(cid, hero, Intent(kind="attack", target_id=""))
+    assert out["ok"] is False
+    assert "target" in out["reason"].lower()
+    # Still the hero's turn — nothing resolved.
+    assert server._require(cid).combat.current_combatant_id == hero
+
+
+def test_no_active_combat_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("NoFight")["id"]
+    hero = server.create_character(cid, "Hero", kind="player")["id"]
+    out = combat_loop.resolve_player_turn(cid, hero, Intent(kind="move", to_cell=(1, 1)))
+    assert out["ok"] is False
+    assert "combat" in out["reason"].lower()
+
+
+def test_double_resolve_does_not_desync_initiative(grid_fight):
+    """A second move POSTed for the hero AFTER its turn already advanced must reject (it is no
+    longer the hero's turn) — proving the arbiter can't double-resolve / desync the order."""
+    cid, hero, gob = grid_fight
+    out1 = combat_loop.resolve_player_turn(
+        cid, hero, Intent(kind="move", to_cell=(2, 0)), end_turn=True
+    )
+    assert out1["ok"] is True and out1["advanced"] is True
+    c = server._require(cid)
+    if not c.combat.active:
+        pytest.skip("fight ended in one exchange")
+    # The hero's turn was resolved + advanced; the enemy auto-ran; it is the hero's turn again
+    # in a NEW round with a FRESH movement budget. A repeat of the SAME (now-stale) intent is
+    # legal again (new turn) — so to prove no-desync we instead assert the order is coherent:
+    # exactly one current combatant, and it is a real, living party actor.
+    cur = c.combat.current_combatant_id
+    assert cur in (hero, gob)
+    # And a move declared for the NON-current actor still rejects (turn-ownership intact).
+    other = gob if cur == hero else hero
+    out2 = combat_loop.resolve_player_turn(cid, other, Intent(kind="move", to_cell=(7, 0)))
+    assert out2["ok"] is False

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -36,6 +36,7 @@ import binascii
 import hashlib
 import importlib.util
 import json
+import math
 import mimetypes
 import os
 import re
@@ -112,7 +113,7 @@ _TARGET_ONLY_KINDS = {"travel", "inspect", "examine", "move_to_zone"}
 # Grid-combat player-turn kinds (move_to_cell / on-turn attack / end_turn) are resolved by the
 # ENGINE in-process (not the DM agent): carried by x/y and/or target_id, with the per-kind checks
 # below relaxing the "needs text or name" guard for them.
-_MOVE_FIELDS = ("text", "name", "skill", "target", "weapon", "dc", "x", "y", "target_id", "end_turn")
+_MOVE_FIELDS = ("text", "name", "skill", "target", "weapon", "dc", "x", "y", "target_id", "end_turn", "turn_token")
 _MOVE_MAXLEN = 2000
 
 
@@ -134,11 +135,22 @@ def sanitize_move(raw: object) -> tuple[Optional[dict], str]:
             # `end_turn` is the only boolean field — preserved verbatim (ends a move-only turn).
             if isinstance(v, bool):
                 move[f] = v
+        elif f in ("x", "y"):
+            # Grid coordinates: accept an int, or a FINITE INTEGRAL float (a UI may send 3.0).
+            # REJECT NaN/Inf (a blind int() raises on those) and a fractional float like 3.9
+            # (a blind int() would silently truncate to 3 -> the wrong cell). A bad value is
+            # left UNSET so the move_to_cell guard below rejects with a clear reason. (bool is
+            # an int subclass -> excluded explicitly so True/False is never read as cell 1/0.)
+            if isinstance(v, bool):
+                continue
+            if isinstance(v, int):
+                move[f] = v
+            elif isinstance(v, float) and math.isfinite(v) and v.is_integer():
+                move[f] = int(v)
         elif isinstance(v, str) and v.strip():
             move[f] = v.strip()[:_MOVE_MAXLEN]
         elif isinstance(v, (int, float)) and not isinstance(v, bool):
-            # x/y are grid integers — coerce a float cell to int (a UI may send 3.0).
-            move[f] = int(v) if f in ("x", "y") else v
+            move[f] = v
     # A bare `end_turn` passes the turn — no other field required.
     if kind == "end_turn":
         move["end_turn"] = True
@@ -801,13 +813,27 @@ def _load_combat_loop():
     if _COMBAT_LOOP_MOD is not None:
         return _COMBAT_LOOP_MOD
     # Loading the engine server registers servers/engine on sys.path + installs the FastMCP shim.
-    if _load_engine_server() is None:
+    engine = _load_engine_server()
+    if engine is None:
         _COMBAT_LOOP_IMPORT_ERROR = _ENGINE_IMPORT_ERROR or "engine server unavailable"
         return None
     engine_dir = (_HERE.parent / "servers" / "engine").resolve()
     try:
         if str(engine_dir) not in sys.path:
             sys.path.insert(0, str(engine_dir))
+        # combat_loop.resolve_player_turn does a lazy `import server`. The bridge loaded the
+        # engine under an aliased module name (_worldos_engine_server_for_viewer), so a bare
+        # `import server` would load a SECOND copy of the ~10k-line engine module with its own
+        # globals. State stays correct EITHER WAY (every verb is file-backed: _require ->
+        # load_campaign re-reads snapshot.json under a cross-process flock; there is NO in-memory
+        # campaign cache — verified), but a redundant second instance is wasteful and makes the
+        # correctness depend implicitly on "no module ever adds a cache". Bind `import server` to
+        # the SAME engine instance the bridge already loaded by registering it under the canonical
+        # name `server` — UNLESS something already owns that name (don't clobber a real engine
+        # process's own `server`). This makes the single-instance guarantee EXPLICIT.
+        existing = sys.modules.get("server")
+        if existing is None:
+            sys.modules["server"] = engine
         spec = importlib.util.spec_from_file_location(
             "_worldos_combat_loop_for_viewer", engine_dir / "combat_loop.py"
         )
@@ -1414,6 +1440,9 @@ def _resolve_player_combat_turn_locked(campaign_id: str, move: dict, *, live: bo
     kind = str(move.get("kind") or "")
     # `end_turn` (optional bool on a move_to_cell, or a bare end_turn kind) ends a move-only turn.
     end_turn = bool(move.get("end_turn"))
+    # Optional idempotency token the client echoed off the surface (turnToken). When present, a
+    # double-click / stale retry rejects (the slot advanced). Absent == no check (back-compat).
+    expected_turn_token = str(move.get("turn_token") or "")
     try:
         Intent = loop.Intent
         if kind == "move_to_cell":
@@ -1433,7 +1462,9 @@ def _resolve_player_combat_turn_locked(campaign_id: str, move: dict, *, live: bo
     except (KeyError, ValueError, TypeError) as exc:
         return {"ok": False, "reason": f"malformed combat move: {exc}"}
 
-    verdict = loop.resolve_player_turn(campaign_id, actor_id, intent, end_turn=end_turn)
+    verdict = loop.resolve_player_turn(
+        campaign_id, actor_id, intent, end_turn=end_turn, expected_turn_token=expected_turn_token
+    )
     if not isinstance(verdict, dict) or not verdict.get("ok"):
         return verdict if isinstance(verdict, dict) else {"ok": False, "reason": "arbiter error"}
 
@@ -3157,6 +3188,28 @@ def _combat_command_center(
     }
 
 
+def _combat_turn_token(snapshot: dict) -> str:
+    """The current turn-slot token (round:turn_index:current_combatant_id), mirroring the engine's
+    combat_loop.turn_token so the surface and the arbiter agree byte-for-byte. The client echoes
+    this on its next player-turn POST; the arbiter rejects a stale token (a double-click / retry),
+    deduplicating the player turn. "" when there's no active combat."""
+    combat = snapshot.get("combat") if isinstance(snapshot, dict) else None
+    if not isinstance(combat, dict) or not combat.get("active"):
+        return ""
+    order = combat.get("order")
+    if not isinstance(order, list) or not order:
+        return ""
+    rnd = combat.get("round")
+    ti = combat.get("turn_index")
+    rnd = rnd if isinstance(rnd, int) and not isinstance(rnd, bool) else 0
+    ti = ti if isinstance(ti, int) and not isinstance(ti, bool) else 0
+    # Mirror models.Combat.current_combatant_id EXACTLY (it indexes order[turn_index % len]) so
+    # the surface token equals combat_loop.turn_token byte-for-byte.
+    row = order[ti % len(order)]
+    cur = _text(row.get("character_id")) if isinstance(row, dict) else ""
+    return f"{rnd}:{ti}:{cur}"
+
+
 def build_combat_surface(
     snapshot: dict,
     *,
@@ -3201,6 +3254,10 @@ def build_combat_surface(
 
     return {
         "campaign_id": campaign_id,
+        # The current turn-slot token (round:turn_index:current) — the client echoes it on its
+        # next player-turn POST so a double-click / stale retry rejects (idempotency). Mirrors
+        # combat_loop.turn_token; "" when no active combat. (Placed first for stable key order.)
+        "turnToken": _combat_turn_token(snapshot) if combat_active else "",
         "title": _text(snapshot.get("title"), campaign_id or "Open Worlds"),
         "world": _text(snapshot.get("world_id"), "unknown"),
         "dayLabel": _openworlds_day_label(snapshot),

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -91,14 +91,28 @@ _OPENWORLDS_MIME_TYPES = {
 # world-assertions): the renderer emits them on click; the DM reads them from the moves
 # file and resolves them through the engine, exactly like say/do. They reuse the existing
 # `target` field — no new field, so the anti-injection field-allowlist is untouched.
+#
+# GRID-COMBAT player-turn intents (S1 keystone — the player-turn combat arbiter): `move_to_cell`
+# (step the PC's token to grid cell x,y on its initiative turn). These are PLAYER intents that
+# the ENGINE resolves DETERMINISTICALLY (not the DM agent): do_POST routes them straight to
+# combat_loop.resolve_player_turn via the in-process engine bridge (the SAME sole-writer-
+# preserving path /save-slot uses), which validates turn-ownership, charges the movement
+# budget, runs opportunity attacks, advances initiative, then re-emits build_combat_surface.
+# `attack` (already a kind) gains the same on-turn lane when it carries a `target_id`. They add
+# x/y/target_id to the field-allowlist (keyword, defaulted; the existing fields are untouched,
+# so the anti-injection allowlist only WIDENS).
 _MOVE_KINDS = {
     "say", "do", "check", "save", "combat", "attack", "cast", "use_item", "clarify",
-    "travel", "inspect", "examine", "move_to_zone",
+    "travel", "inspect", "examine", "move_to_zone", "move_to_cell", "end_turn",
 }
 # Kinds whose payload is carried by `target` alone (no free `text`/`name`) — the graphical
 # intents. Used to relax the "needs text or name" guard below for these click-driven moves.
 _TARGET_ONLY_KINDS = {"travel", "inspect", "examine", "move_to_zone"}
-_MOVE_FIELDS = ("text", "name", "skill", "target", "weapon", "dc")
+# Grid-combat player-turn kinds the ENGINE resolves in-process (not the DM agent). Carried by
+# x/y (move_to_cell) and/or target_id (attack on turn); `end_turn` passes the turn. Relaxes the
+# "needs text or name" guard.
+_COMBAT_CELL_KINDS = {"move_to_cell", "attack", "end_turn"}
+_MOVE_FIELDS = ("text", "name", "skill", "target", "weapon", "dc", "x", "y", "target_id", "end_turn")
 _MOVE_MAXLEN = 2000
 
 
@@ -116,15 +130,35 @@ def sanitize_move(raw: object) -> tuple[Optional[dict], str]:
     move: dict = {"role": "player", "kind": kind}
     for f in _MOVE_FIELDS:
         v = raw.get(f)
-        if isinstance(v, str) and v.strip():
+        if f == "end_turn":
+            # `end_turn` is the only boolean field — preserved verbatim (ends a move-only turn).
+            if isinstance(v, bool):
+                move[f] = v
+        elif isinstance(v, str) and v.strip():
             move[f] = v.strip()[:_MOVE_MAXLEN]
         elif isinstance(v, (int, float)) and not isinstance(v, bool):
-            move[f] = v
+            # x/y are grid integers — coerce a float cell to int (a UI may send 3.0).
+            move[f] = int(v) if f in ("x", "y") else v
+    # A bare `end_turn` passes the turn — no other field required.
+    if kind == "end_turn":
+        move["end_turn"] = True
+        return move, ""
+    # `move_to_cell` is the grid-combat player-turn intent the ENGINE resolves: it needs a
+    # numeric x AND y cell (carried alongside, never text). Validated here so a malformed
+    # cell rejects before it reaches the engine bridge.
+    if kind == "move_to_cell":
+        if not (isinstance(move.get("x"), int) and isinstance(move.get("y"), int)):
+            return None, "'move_to_cell' needs integer 'x' and 'y' grid coordinates"
+        return move, ""
     # The graphical intents (travel/inspect/examine/move_to_zone) are carried by `target`;
-    # everything else needs a `text` or `name` so the DM has something to act on.
+    # everything else needs a `text` or `name` so the DM has something to act on. An `attack`
+    # that carries a `target_id` is the on-turn engine-resolved lane (no text/name required);
+    # an `attack` with text/name stays the existing DM-resolved free-text lane.
     if kind in _TARGET_ONLY_KINDS:
         if "target" not in move:
             return None, f"{kind!r} move needs a 'target'"
+    elif kind == "attack" and "target_id" in move:
+        pass  # on-turn engine attack: target_id is enough
     elif "text" not in move and "name" not in move:
         return None, "move needs a 'text' or 'name'"
     return move, ""
@@ -751,6 +785,45 @@ def _engine_server():
     return _load_engine_server()
 
 
+_COMBAT_LOOP_MOD = None
+_COMBAT_LOOP_IMPORT_ERROR = ""
+
+
+def _load_combat_loop():
+    """Load the engine's combat_loop module in-process (the player-turn arbiter lives there).
+
+    Same in-process bridge contract as _load_engine_server: the viewer NEVER writes campaign
+    state itself — combat_loop.resolve_player_turn delegates to the engine's locked verbs
+    (move_to_coords / attack / next_turn), each of which takes its own campaign_lock +
+    save_campaign, so the engine stays the SOLE WRITER. Loading the engine server first puts
+    servers/engine on sys.path so `combat_loop` (and its `import server`) resolve."""
+    global _COMBAT_LOOP_MOD, _COMBAT_LOOP_IMPORT_ERROR
+    if _COMBAT_LOOP_MOD is not None:
+        return _COMBAT_LOOP_MOD
+    # Loading the engine server registers servers/engine on sys.path + installs the FastMCP shim.
+    if _load_engine_server() is None:
+        _COMBAT_LOOP_IMPORT_ERROR = _ENGINE_IMPORT_ERROR or "engine server unavailable"
+        return None
+    engine_dir = (_HERE.parent / "servers" / "engine").resolve()
+    try:
+        if str(engine_dir) not in sys.path:
+            sys.path.insert(0, str(engine_dir))
+        spec = importlib.util.spec_from_file_location(
+            "_worldos_combat_loop_for_viewer", engine_dir / "combat_loop.py"
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError("could not load combat_loop module")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        _COMBAT_LOOP_MOD = module
+        _COMBAT_LOOP_IMPORT_ERROR = ""
+        return module
+    except Exception as exc:
+        _COMBAT_LOOP_IMPORT_ERROR = str(exc)
+        return None
+
+
 def _clean_character_id(character_id: Optional[str]) -> Optional[str]:
     if not isinstance(character_id, str):
         return None
@@ -1275,6 +1348,70 @@ def _save_load_slot_response(action: str, campaign_id: Optional[str], slot: Opti
     if isinstance(result, dict):
         return result
     return {"ok": True, "campaign_id": safe_campaign, "slot": safe_slot}
+
+
+def _resolve_player_combat_turn(campaign_id: str, move: dict, *, live: bool) -> dict:
+    """Resolve a grid-combat player-turn move (`move_to_cell` / on-turn `attack`) DETERMINISTICALLY
+    through the engine's player-turn arbiter, then re-emit the combat surface (S1 keystone).
+
+    Mirrors /save-slot's in-process bridge EXACTLY: the viewer never writes campaign state; it
+    builds the engine's Intent and calls combat_loop.resolve_player_turn, which validates
+    turn-ownership and delegates to the engine's locked verbs (move_to_coords / attack /
+    next_turn) under the engine's own campaign_lock + save_campaign — so the engine stays the
+    SOLE WRITER. On success returns the arbiter verdict PLUS a freshly-read build_combat_surface
+    so the client (browser / Unity) re-renders from authoritative state without a second GET.
+
+    Rejections (wrong turn, no combat, bad cell) return {ok:False, reason} with NOTHING mutated."""
+    loop = _load_combat_loop()
+    if loop is None:
+        return {"ok": False, "reason": f"combat arbiter unavailable: {_COMBAT_LOOP_IMPORT_ERROR}"}
+    # The actor is the live PC/companion whose turn it is. The arbiter is the authority on
+    # turn-ownership; the viewer does not pre-resolve "who" — it reads current_combatant_id
+    # from the engine snapshot and lets the arbiter reject a non-current actor.
+    try:
+        engine = _load_engine_server()
+        snap = engine._require(campaign_id) if engine is not None else None
+        actor_id = snap.combat.current_combatant_id if snap is not None and snap.combat.active else None
+    except Exception as exc:
+        return {"ok": False, "reason": f"could not read combat state: {exc}"}
+    if not actor_id:
+        return {"ok": False, "reason": "no active combat / no current combatant"}
+
+    kind = str(move.get("kind") or "")
+    # `end_turn` (optional bool on a move_to_cell, or a bare end_turn kind) ends a move-only turn.
+    end_turn = bool(move.get("end_turn"))
+    try:
+        Intent = loop.Intent
+        if kind == "move_to_cell":
+            x, y = int(move["x"]), int(move["y"])
+            intent = Intent(kind="move", to_cell=(x, y), note="player move (UI)")
+        elif kind == "attack":
+            target_id = str(move.get("target_id") or "")
+            if not target_id:
+                return {"ok": False, "reason": "an on-turn attack needs a target_id"}
+            intent = Intent(kind="attack", target_id=target_id, note="player attack (UI)")
+        elif kind == "end_turn":
+            # Pass the turn without moving/acting: a skip Intent, force the advance.
+            intent = Intent(kind="skip", note="player end-turn (UI)")
+            end_turn = True
+        else:
+            return {"ok": False, "reason": f"{kind!r} is not a grid-combat player-turn move"}
+    except (KeyError, ValueError, TypeError) as exc:
+        return {"ok": False, "reason": f"malformed combat move: {exc}"}
+
+    verdict = loop.resolve_player_turn(campaign_id, actor_id, intent, end_turn=end_turn)
+    if not isinstance(verdict, dict) or not verdict.get("ok"):
+        return verdict if isinstance(verdict, dict) else {"ok": False, "reason": "arbiter error"}
+
+    # Re-emit the authoritative surface from the freshly-written snapshot so the client renders
+    # the moved token / new initiative without a follow-up read. Read-only projection.
+    raw_snap = _read_snapshot(campaign_id)
+    if not isinstance(raw_snap, dict):
+        raw_snap = {}
+    surface = build_combat_surface(
+        raw_snap, campaign_id=campaign_id, live=bool(live), is_live_view=bool(live)
+    )
+    return {"ok": True, "arbiter": verdict, "combat": surface}
 
 
 def _display_location(snapshot: dict) -> str:
@@ -2322,10 +2459,30 @@ def _combat_display_position(
     idx: int,
     zones: list[dict],
     zone_offsets: dict[str, int],
+    grid_extents: tuple[int, int] | None = None,
 ) -> tuple[int, int, str]:
-    x = _num(row.get("x") or row.get("col") or row.get("grid_x"))
-    y = _num(row.get("y") or row.get("row") or row.get("grid_y"))
+    # Read the engine's authoritative grid coords. Use a None-coalesce (NOT `or`): a cell of 0
+    # is a VALID coordinate (origin column/row), and `x or col` would treat 0 as missing and
+    # silently fall through to the synthesized zone layout — corrupting the board for any token
+    # on row/column 0 (the S1 grid-combat arbiter surfaces real engine cells, incl. 0).
+    def _first_coord(*keys):
+        for k in keys:
+            v = _num(row.get(k))
+            if v is not None:
+                return v
+        return None
+    x = _first_coord("x", "col", "grid_x")
+    y = _first_coord("y", "row", "grid_y")
     if x is not None and y is not None:
+        # Clamp to the ENGINE grid extents (not the fixed 16x10 zone-display grid), preserving
+        # cell 0 — the surface must report the true engine cell so the client renders the moved
+        # token where the engine actually placed it. Fall back to the legacy 16x10 clamp only
+        # when the engine grid extents are unknown (keeps old grid-source snapshots stable).
+        if grid_extents is not None:
+            gw, gh = grid_extents
+            cx = max(0, min(gw - 1, int(x))) if gw > 0 else int(x)
+            cy = max(0, min(gh - 1, int(y))) if gh > 0 else int(y)
+            return cx, cy, "grid"
         return max(1, min(16, int(x))), max(1, min(10, int(y))), "grid"
     zone_name = _text(row.get("zone"))
     zone_index = next((i for i, z in enumerate(zones) if z.get("name") == zone_name), idx)
@@ -2343,6 +2500,16 @@ def _combat_tokens(snapshot: dict, combat_view: dict) -> tuple[list[dict], list[
     zones = [dict(z) for z in combat_view.get("zones", []) if isinstance(z, dict)]
     zone_occupants: dict[str, list[str]] = {z.get("name", ""): [] for z in zones}
     zone_offsets: dict[str, int] = {}
+    # Engine grid extents (S1): when the fight is on a grid the token clamp must respect the
+    # ENGINE grid size (e.g. 20x20), not the fixed 16x10 zone-display grid, and must preserve
+    # cell 0. None when there's no engine grid -> the zone-display fallback clamp applies.
+    _combat_blk = snapshot.get("combat") if isinstance(snapshot, dict) else None
+    grid_extents: tuple[int, int] | None = None
+    if isinstance(_combat_blk, dict) and _combat_blk.get("grid_enabled"):
+        gw = _num(_combat_blk.get("grid_width"))
+        gh = _num(_combat_blk.get("grid_height"))
+        if isinstance(gw, int) and isinstance(gh, int) and gw > 0 and gh > 0:
+            grid_extents = (gw, gh)
     tokens: list[dict] = []
     initiative: list[dict] = []
     position_sources: set[str] = set()
@@ -2373,7 +2540,9 @@ def _combat_tokens(snapshot: dict, combat_view: dict) -> tuple[list[dict], list[
             token["zone"] = zone
             if zone in zone_occupants:
                 zone_occupants[zone].append(cid)
-        x, y, source = _combat_display_position(raw, idx=idx, zones=zones, zone_offsets=zone_offsets)
+        x, y, source = _combat_display_position(
+            raw, idx=idx, zones=zones, zone_offsets=zone_offsets, grid_extents=grid_extents
+        )
         token["x"] = x
         token["y"] = y
         # #432 (graphics M0): x/y here are a DERIVED render-hint, never authoritative state.
@@ -8842,6 +9011,19 @@ class _Handler(BaseHTTPRequestHandler):
         move, why = sanitize_move(payload)
         if move is None:
             self._json({"ok": False, "reason": why})
+            return
+        # GRID-COMBAT PLAYER-TURN LANE (S1 keystone): a `move_to_cell` (or an on-turn `attack`
+        # carrying a target_id) is resolved DETERMINISTICALLY by the engine's player-turn arbiter
+        # in-process (the SAME sole-writer-preserving bridge /save-slot uses), NOT appended for
+        # the DM agent to narrate. The arbiter validates turn-ownership, charges the budget, runs
+        # OAs, advances initiative, and we re-emit build_combat_surface. The campaign is bound to
+        # the live run (the cross-campaign refusal above already ran). Every OTHER kind keeps the
+        # append-only intent-log behavior (byte-identical to today).
+        is_combat_cell = move.get("kind") in ("move_to_cell", "end_turn") or (
+            move.get("kind") == "attack" and "target_id" in move
+        )
+        if is_combat_cell:
+            self._json(_resolve_player_combat_turn(self.campaign_id, move, live=True))
             return
         try:
             dest.parent.mkdir(parents=True, exist_ok=True)

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -109,10 +109,9 @@ _MOVE_KINDS = {
 # Kinds whose payload is carried by `target` alone (no free `text`/`name`) — the graphical
 # intents. Used to relax the "needs text or name" guard below for these click-driven moves.
 _TARGET_ONLY_KINDS = {"travel", "inspect", "examine", "move_to_zone"}
-# Grid-combat player-turn kinds the ENGINE resolves in-process (not the DM agent). Carried by
-# x/y (move_to_cell) and/or target_id (attack on turn); `end_turn` passes the turn. Relaxes the
-# "needs text or name" guard.
-_COMBAT_CELL_KINDS = {"move_to_cell", "attack", "end_turn"}
+# Grid-combat player-turn kinds (move_to_cell / on-turn attack / end_turn) are resolved by the
+# ENGINE in-process (not the DM agent): carried by x/y and/or target_id, with the per-kind checks
+# below relaxing the "needs text or name" guard for them.
 _MOVE_FIELDS = ("text", "name", "skill", "target", "weapon", "dc", "x", "y", "target_id", "end_turn")
 _MOVE_MAXLEN = 2000
 

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1492,10 +1492,13 @@ def _resolve_player_combat_turn_locked(campaign_id: str, move: dict, *, live: bo
         if _engine_mod is not None:
             sys.modules["server"] = _engine_mod
         try:
-            verdict = loop.resolve_player_turn(
-                campaign_id, actor_id, intent, end_turn=end_turn,
-                expected_turn_token=expected_turn_token,
-            )
+            try:
+                verdict = loop.resolve_player_turn(
+                    campaign_id, actor_id, intent, end_turn=end_turn,
+                    expected_turn_token=expected_turn_token,
+                )
+            except Exception as exc:  # never leak a raw 500 from /move — degrade to the bridge's
+                verdict = {"ok": False, "reason": f"combat arbiter failed: {exc}"}  # JSON shape
         finally:
             if _saved_server_mod is not None:
                 sys.modules["server"] = _saved_server_mod

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -131,7 +131,18 @@ def sanitize_move(raw: object) -> tuple[Optional[dict], str]:
     move: dict = {"role": "player", "kind": kind}
     for f in _MOVE_FIELDS:
         v = raw.get(f)
-        if f == "end_turn":
+        if f == "turn_token":
+            # The surface emits the idempotency token as `turnToken` (camelCase). Accept the field
+            # the client actually received (turnToken) OR the snake_case name, normalized to
+            # turn_token. WITHOUT this, a client echoing `turnToken` loses the token ->
+            # expected_turn_token="" -> the dedup guard never fires (a stale/double submit could
+            # advance again after initiative wraps).
+            tok = raw.get("turn_token")
+            if not (isinstance(tok, str) and tok.strip()):
+                tok = raw.get("turnToken")
+            if isinstance(tok, str) and tok.strip():
+                move[f] = tok.strip()[:_MOVE_MAXLEN]
+        elif f == "end_turn":
             # `end_turn` is the only boolean field — preserved verbatim (ends a move-only turn).
             if isinstance(v, bool):
                 move[f] = v

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -777,30 +777,40 @@ def _install_fastmcp_shim() -> None:
     sys.modules["mcp.server.fastmcp"] = fastmcp_mod
 
 
+_ENGINE_SERVER_LOAD_LOCK = threading.Lock()
+
+
 def _load_engine_server():
     global _ENGINE_SERVER, _ENGINE_IMPORT_ERROR
     if _ENGINE_SERVER is not None:
         return _ENGINE_SERVER
-    engine_dir = (_HERE.parent / "servers" / "engine").resolve()
-    try:
+    with _ENGINE_SERVER_LOAD_LOCK:
+        if _ENGINE_SERVER is not None:  # double-check: another thread loaded it while we waited
+            return _ENGINE_SERVER
+        engine_dir = (_HERE.parent / "servers" / "engine").resolve()
         try:
-            from mcp.server.fastmcp import FastMCP as _FastMCP  # noqa: F401
-        except ModuleNotFoundError:
-            _install_fastmcp_shim()
-        if str(engine_dir) not in sys.path:
-            sys.path.insert(0, str(engine_dir))
-        spec = importlib.util.spec_from_file_location("_worldos_engine_server_for_viewer", engine_dir / "server.py")
-        if spec is None or spec.loader is None:
-            raise RuntimeError("could not load engine server module")
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[spec.name] = module
-        spec.loader.exec_module(module)
-        _ENGINE_SERVER = module
-        _ENGINE_IMPORT_ERROR = ""
-        return module
-    except Exception as exc:  # import/dependency failures become explicit JSON degradation
-        _ENGINE_IMPORT_ERROR = str(exc)
-        return None
+            try:
+                from mcp.server.fastmcp import FastMCP as _FastMCP  # noqa: F401
+            except ModuleNotFoundError:
+                _install_fastmcp_shim()
+            if str(engine_dir) not in sys.path:
+                sys.path.insert(0, str(engine_dir))
+            spec = importlib.util.spec_from_file_location("_worldos_engine_server_for_viewer", engine_dir / "server.py")
+            if spec is None or spec.loader is None:
+                raise RuntimeError("could not load engine server module")
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = module
+            try:
+                spec.loader.exec_module(module)
+            except Exception:
+                sys.modules.pop(spec.name, None)  # don't leave a half-initialized module published
+                raise
+            _ENGINE_SERVER = module
+            _ENGINE_IMPORT_ERROR = ""
+            return module
+        except Exception as exc:  # import/dependency failures become explicit JSON degradation
+            _ENGINE_IMPORT_ERROR = str(exc)
+            return None
 
 
 def _engine_server():
@@ -1497,8 +1507,22 @@ def _resolve_player_combat_turn_locked(campaign_id: str, move: dict, *, live: bo
                     campaign_id, actor_id, intent, end_turn=end_turn,
                     expected_turn_token=expected_turn_token,
                 )
-            except Exception as exc:  # never leak a raw 500 from /move — degrade to the bridge's
-                verdict = {"ok": False, "reason": f"combat arbiter failed: {exc}"}  # JSON shape
+            except Exception:
+                # The arbiter may have MUTATED combat (via _apply_intent) before a later step (the
+                # enemy auto-resolution) raised. Don't return a bare {ok:false} that hides the
+                # already-advanced board + invites blind retries — return the REFRESHED surface so
+                # the client renders the real post-mutation state. (The outer finally still restores
+                # sys.modules; build_combat_surface does not `import server`.)
+                _raw = _read_snapshot(campaign_id)
+                if not isinstance(_raw, dict):
+                    _raw = {}
+                return {
+                    "ok": False,
+                    "reason": "combat arbiter failed; state may have changed",
+                    "combat": build_combat_surface(
+                        _raw, campaign_id=campaign_id, live=bool(live), is_live_view=bool(live)
+                    ),
+                }
         finally:
             if _saved_server_mod is not None:
                 sys.modules["server"] = _saved_server_mod

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -41,6 +41,7 @@ import os
 import re
 import subprocess
 import sys
+import threading
 import time
 import types
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -1350,6 +1351,30 @@ def _save_load_slot_response(action: str, campaign_id: Optional[str], slot: Opti
     return {"ok": True, "campaign_id": safe_campaign, "slot": safe_slot}
 
 
+# Per-campaign in-process serialization for the grid-combat player-turn lane. The arbiter reads
+# current_combatant_id, validates, then drives the locked verbs — but the engine's campaign_lock
+# is PER-VERB (it does not span the read->validate->advance sequence) and is NOT re-entrant (a
+# nested flock on a new fd in the same process DEADLOCKS), so we cannot wrap the arbiter in it.
+# Two concurrent POSTs on the ThreadingHTTPServer (a double-click / client retry) would otherwise
+# both pass the turn-ownership gate before either advances, double-advancing initiative and
+# silently consuming an enemy turn (a TOCTOU caught by adversarial-invariant-verify). This
+# in-process lock serializes the player-turn lane PER CAMPAIGN within the viewer process — the
+# only place concurrent player-turn POSTs originate. It does NOT touch the engine's sole-writer
+# campaign_lock (the cross-process DM-vs-viewer case is already handled by that flock); it only
+# closes the same-process double-POST window.
+_PLAYER_TURN_LOCKS: dict[str, threading.Lock] = {}
+_PLAYER_TURN_LOCKS_GUARD = threading.Lock()
+
+
+def _player_turn_lock(campaign_id: str) -> threading.Lock:
+    with _PLAYER_TURN_LOCKS_GUARD:
+        lock = _PLAYER_TURN_LOCKS.get(campaign_id)
+        if lock is None:
+            lock = threading.Lock()
+            _PLAYER_TURN_LOCKS[campaign_id] = lock
+        return lock
+
+
 def _resolve_player_combat_turn(campaign_id: str, move: dict, *, live: bool) -> dict:
     """Resolve a grid-combat player-turn move (`move_to_cell` / on-turn `attack`) DETERMINISTICALLY
     through the engine's player-turn arbiter, then re-emit the combat surface (S1 keystone).
@@ -1361,7 +1386,17 @@ def _resolve_player_combat_turn(campaign_id: str, move: dict, *, live: bool) -> 
     SOLE WRITER. On success returns the arbiter verdict PLUS a freshly-read build_combat_surface
     so the client (browser / Unity) re-renders from authoritative state without a second GET.
 
+    The whole read->validate->resolve->advance->re-emit sequence runs under a PER-CAMPAIGN
+    in-process lock so two concurrent POSTs can't double-advance initiative (the engine's
+    per-verb campaign_lock does not span this sequence and is not re-entrant — see
+    _player_turn_lock). The engine remains the sole WRITER; this lock only serializes the lane.
+
     Rejections (wrong turn, no combat, bad cell) return {ok:False, reason} with NOTHING mutated."""
+    with _player_turn_lock(campaign_id):
+        return _resolve_player_combat_turn_locked(campaign_id, move, live=live)
+
+
+def _resolve_player_combat_turn_locked(campaign_id: str, move: dict, *, live: bool) -> dict:
     loop = _load_combat_loop()
     if loop is None:
         return {"ok": False, "reason": f"combat arbiter unavailable: {_COMBAT_LOOP_IMPORT_ERROR}"}

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1389,6 +1389,13 @@ def _save_load_slot_response(action: str, campaign_id: Optional[str], slot: Opti
 # closes the same-process double-POST window.
 _PLAYER_TURN_LOCKS: dict[str, threading.Lock] = {}
 _PLAYER_TURN_LOCKS_GUARD = threading.Lock()
+# Process-wide lock guarding the brief `sys.modules["server"]` swap in
+# _resolve_player_combat_turn_locked. combat_loop does a lazy `import server` that MUST resolve to
+# the ENGINE module, but the viewer process also legitimately owns the name `server` (so the
+# load-time "bind only if unowned" can't win). We bind it to the engine for the duration of the
+# arbiter call and restore after; this lock serializes the swap so a concurrent different-campaign
+# call can never observe `server` mid-swap. Acquired ONLY inside the per-campaign lock (one order).
+_ENGINE_SERVER_BIND_LOCK = threading.Lock()
 
 
 def _player_turn_lock(campaign_id: str) -> threading.Lock:
@@ -1462,9 +1469,27 @@ def _resolve_player_combat_turn_locked(campaign_id: str, move: dict, *, live: bo
     except (KeyError, ValueError, TypeError) as exc:
         return {"ok": False, "reason": f"malformed combat move: {exc}"}
 
-    verdict = loop.resolve_player_turn(
-        campaign_id, actor_id, intent, end_turn=end_turn, expected_turn_token=expected_turn_token
-    )
+    # combat_loop.resolve_player_turn (and the run_combat_round it auto-runs) do a lazy
+    # `import server` that must resolve to the ENGINE — but the viewer process also owns the name
+    # `server`. Bind it to the engine module for the duration of the arbiter call (serialized
+    # process-wide so a concurrent different-campaign call can't observe the swap mid-flight),
+    # then restore. State stays sole-writer-correct regardless (every verb is file-backed); this
+    # only fixes WHICH module object the lazy import resolves to.
+    _engine_mod = _load_engine_server()
+    with _ENGINE_SERVER_BIND_LOCK:
+        _saved_server_mod = sys.modules.get("server")
+        if _engine_mod is not None:
+            sys.modules["server"] = _engine_mod
+        try:
+            verdict = loop.resolve_player_turn(
+                campaign_id, actor_id, intent, end_turn=end_turn,
+                expected_turn_token=expected_turn_token,
+            )
+        finally:
+            if _saved_server_mod is not None:
+                sys.modules["server"] = _saved_server_mod
+            else:
+                sys.modules.pop("server", None)
     if not isinstance(verdict, dict) or not verdict.get("ok"):
         return verdict if isinstance(verdict, dict) else {"ok": False, "reason": "arbiter error"}
 

--- a/viewer/tests/test_move_intents.py
+++ b/viewer/tests/test_move_intents.py
@@ -90,6 +90,54 @@ class MoveIntentVocabularyTests(unittest.TestCase):
         self.assertNotIn("narration", move)               # extra field dropped
 
 
+class GridCombatMoveKindTests(unittest.TestCase):
+    """S1 keystone — the grid-combat player-turn kinds the ENGINE resolves (move_to_cell /
+    on-turn attack). Pure sanitize_move checks: the new kinds validate x/y/target_id, the
+    existing kinds + invariants are byte-identical (additive)."""
+
+    def test_move_to_cell_accepted_with_int_xy(self):
+        move, reason = server.sanitize_move({"kind": "move_to_cell", "x": 3, "y": 7})
+        self.assertEqual(reason, "")
+        self.assertEqual(move["kind"], "move_to_cell")
+        self.assertEqual((move["x"], move["y"]), (3, 7))
+        self.assertEqual(move["role"], "player")  # role still forced
+
+    def test_move_to_cell_coerces_float_cell_to_int(self):
+        move, reason = server.sanitize_move({"kind": "move_to_cell", "x": 4.0, "y": 0.0})
+        self.assertEqual(reason, "")
+        self.assertIsInstance(move["x"], int)
+        self.assertEqual((move["x"], move["y"]), (4, 0))
+
+    def test_move_to_cell_without_xy_rejected(self):
+        for bad in ({"kind": "move_to_cell"}, {"kind": "move_to_cell", "x": 2},
+                    {"kind": "move_to_cell", "text": "go there"}):
+            with self.subTest(payload=bad):
+                move, reason = server.sanitize_move(bad)
+                self.assertIsNone(move)
+                self.assertIn("x", reason)
+
+    def test_on_turn_attack_accepted_with_target_id(self):
+        move, reason = server.sanitize_move({"kind": "attack", "target_id": "mon-goblin-1"})
+        self.assertEqual(reason, "")
+        self.assertEqual(move["kind"], "attack")
+        self.assertEqual(move["target_id"], "mon-goblin-1")
+
+    def test_legacy_freetext_attack_still_works(self):
+        # The existing DM-resolved attack lane (name/target, no target_id) is untouched.
+        move, reason = server.sanitize_move({"kind": "attack", "name": "Longsword", "target": "goblin"})
+        self.assertEqual(reason, "")
+        self.assertEqual(move["name"], "Longsword")
+        self.assertNotIn("target_id", move)
+
+    def test_move_to_cell_drops_unknown_fields_and_forces_role(self):
+        move, reason = server.sanitize_move(
+            {"kind": "move_to_cell", "x": 1, "y": 1, "role": "dm", "narration": "boom"}
+        )
+        self.assertEqual(reason, "")
+        self.assertEqual(move["role"], "player")
+        self.assertNotIn("narration", move)
+
+
 class DerivedPositionAuthorityTests(unittest.TestCase):
     """#432: zone-derived token x/y must be flagged positionAuthority='derived'."""
 
@@ -128,6 +176,52 @@ class DerivedPositionAuthorityTests(unittest.TestCase):
                 # the authoritative spatial field is the named zone
                 self.assertIn(tk["zone"], ("the market row", "the alley mouth"))
         self.assertEqual(mode, "zones")  # no engine coords → zone mode, not grid
+
+
+class GridOriginPositionTests(unittest.TestCase):
+    """S1 keystone regression — _combat_display_position must report the ENGINE grid cell
+    faithfully, including the origin (cell 0). The pre-fix `x or col` coalesce treated a 0
+    coordinate as missing and fell through to the synthesized zone layout, corrupting any token
+    on row/column 0 — exactly the cells the grid-combat arbiter places PCs at."""
+
+    def _grid_snapshot(self, hx, hy):
+        return {
+            "combat": {
+                "active": True,
+                "grid_enabled": True, "grid_width": 20, "grid_height": 20,
+                "order": [
+                    {"id": "hero", "character_id": "hero", "name": "Hero", "kind": "player",
+                     "x": hx, "y": hy, "is_current": True, "hp": {"current": 30, "max": 30}},
+                    {"id": "gob", "character_id": "gob", "name": "Goblin", "kind": "monster",
+                     "x": 12, "y": 5, "hp": {"current": 15, "max": 15}},
+                ],
+            },
+            "characters": {"hero": {"id": "hero", "kind": "player"},
+                           "gob": {"id": "gob", "kind": "monster"}},
+        }
+
+    def test_origin_cell_reported_faithfully_as_grid(self):
+        # cell (0,0) must surface as (0,0) with positionAuthority='engine' (not a zone synth).
+        snap = self._grid_snapshot(0, 0)
+        tokens, _i, _z, _s, mode = server._combat_tokens(snap, snap["combat"])
+        self.assertEqual(mode, "grid")
+        hero = next(t for t in tokens if t["id"] == "hero")
+        self.assertEqual((hero["x"], hero["y"]), (0, 0))
+        self.assertEqual(hero["positionAuthority"], "engine")
+
+    def test_grid_cell_on_row_zero_not_synthesized(self):
+        # (3,0) — y is the falsy-0 that the old `or` dropped. Must surface exactly (3,0).
+        snap = self._grid_snapshot(3, 0)
+        tokens, *_rest = server._combat_tokens(snap, snap["combat"])
+        hero = next(t for t in tokens if t["id"] == "hero")
+        self.assertEqual((hero["x"], hero["y"]), (3, 0))
+
+    def test_grid_clamps_to_engine_extents_not_16x10(self):
+        # A 20x20 engine grid must allow a cell beyond the legacy 16x10 display clamp.
+        snap = self._grid_snapshot(18, 17)
+        tokens, *_rest = server._combat_tokens(snap, snap["combat"])
+        hero = next(t for t in tokens if t["id"] == "hero")
+        self.assertEqual((hero["x"], hero["y"]), (18, 17))
 
 
 if __name__ == "__main__":

--- a/viewer/tests/test_move_intents.py
+++ b/viewer/tests/test_move_intents.py
@@ -108,6 +108,16 @@ class GridCombatMoveKindTests(unittest.TestCase):
         self.assertIsInstance(move["x"], int)
         self.assertEqual((move["x"], move["y"]), (4, 0))
 
+    def test_turn_token_accepts_camelcase_echo_and_snake(self):
+        # #2: the surface emits the idempotency token as `turnToken`; a client echoing that exact
+        # field must NOT lose it (else expected_turn_token="" and the dedup guard never fires).
+        # sanitize_move accepts the camelCase echo OR the snake name, normalized to turn_token.
+        camel, r1 = server.sanitize_move({"kind": "move_to_cell", "x": 1, "y": 2, "turnToken": "3:0:c1"})
+        self.assertEqual(r1, "")
+        self.assertEqual(camel["turn_token"], "3:0:c1")
+        snake, _ = server.sanitize_move({"kind": "move_to_cell", "x": 1, "y": 2, "turn_token": "3:0:c1"})
+        self.assertEqual(snake["turn_token"], "3:0:c1")
+
     def test_move_to_cell_without_xy_rejected(self):
         for bad in ({"kind": "move_to_cell"}, {"kind": "move_to_cell", "x": 2},
                     {"kind": "move_to_cell", "text": "go there"}):

--- a/viewer/tests/test_player_turn_bridge_concurrency.py
+++ b/viewer/tests/test_player_turn_bridge_concurrency.py
@@ -90,7 +90,10 @@ class PlayerTurnBridgeTests(unittest.TestCase):
 
         t1 = threading.Thread(target=fire)
         t2 = threading.Thread(target=fire)
-        t1.start(); t2.start(); t1.join(); t2.join()
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
 
         self.assertEqual(len(results), 2)
         advanced = [r for r in results if r.get("ok") and r["arbiter"].get("advanced")]

--- a/viewer/tests/test_player_turn_bridge_concurrency.py
+++ b/viewer/tests/test_player_turn_bridge_concurrency.py
@@ -1,0 +1,119 @@
+"""S1 keystone — the grid-combat player-turn bridge + its concurrency guard.
+
+The viewer resolves a grid-combat player-turn move (move_to_cell / on-turn attack) DETERMINISTICALLY
+through the engine arbiter via the in-process bridge, then re-emits build_combat_surface. The
+adversarial-invariant-verify pass found a TOCTOU: the arbiter reads current_combatant_id without a
+lock and the engine's campaign_lock is per-verb (doesn't span read->validate->advance), so two
+concurrent POSTs on the ThreadingHTTPServer could both pass the turn-ownership gate and double-
+advance initiative — silently consuming an enemy turn. _resolve_player_combat_turn now serializes
+the lane per campaign with an in-process lock. This test PROVES exactly one of two concurrent
+player-turn resolutions advances the turn (the other rejects), so initiative never double-advances.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+
+
+_SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+_SPEC = importlib.util.spec_from_file_location("viewer_server_ptconc", _SERVER_PATH)
+server = importlib.util.module_from_spec(_SPEC)
+assert _SPEC and _SPEC.loader
+_SPEC.loader.exec_module(server)
+
+
+class PlayerTurnBridgeTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = Path(self.enterContext(tempfile.TemporaryDirectory()))
+        self._old_state = os.environ.get("WORLDOS_STATE_DIR")
+        os.environ["WORLDOS_STATE_DIR"] = str(self._tmp)
+
+    def tearDown(self):
+        if self._old_state is None:
+            os.environ.pop("WORLDOS_STATE_DIR", None)
+        else:
+            os.environ["WORLDOS_STATE_DIR"] = self._old_state
+
+    def _in_combat_grid(self):
+        eng = server._engine_server()
+        cid = eng.create_campaign("PTConc")["id"]
+        hero = eng.create_character(cid, "Hero", kind="player", max_hp=30, armor_class=14)["id"]
+        gob = eng.create_character(cid, "Goblin", kind="monster", max_hp=40, armor_class=18)["id"]
+        eng.start_combat(cid, [hero, gob], surpriser_ids=[hero])  # hero leads, deterministic
+        eng.set_grid(cid, 20, 20)
+        eng.place_combatant_at_coords(cid, hero, 0, 0)
+        eng.place_combatant_at_coords(cid, gob, 12, 0)
+        assert eng._require(cid).combat.current_combatant_id == hero
+        return eng, cid, hero, gob
+
+    def test_bridge_move_resolves_and_re_emits_surface(self):
+        eng, cid, hero, gob = self._in_combat_grid()
+        out = server._resolve_player_combat_turn(
+            cid, {"kind": "move_to_cell", "x": 3, "y": 0}, live=True
+        )
+        self.assertTrue(out["ok"], out)
+        self.assertFalse(out["arbiter"]["advanced"])      # bare move keeps the turn open
+        self.assertTrue(out["arbiter"]["turn_open"])
+        surf = out["combat"]
+        self.assertEqual(surf["state_authority"], "engine")
+        ht = next(t for t in surf["tokens"] if t["id"] == hero)
+        self.assertEqual((ht["x"], ht["y"]), (3, 0))      # the moved cell, faithfully
+
+    def test_concurrent_double_post_serializes_no_skipped_enemy_turn(self):
+        """The TOCTOU harm the in-process lock prevents: two concurrent on-turn attacks (a
+        double-click) must not INTERLEAVE such that the enemy's turn is silently consumed without
+        the enemy acting. With the per-campaign lock the two resolutions SERIALIZE: each PC turn
+        that advances is followed by a real enemy turn (the goblin acts every round), and the
+        round count increases by exactly one PER resolved PC turn — never two PC turns sharing one
+        enemy turn (the desync). We assert: (a) every advancing result carries a non-empty
+        enemy_digest (the goblin was NOT skipped), and (b) the round delta equals the number of
+        advancing PC turns (initiative did not double-step)."""
+        eng, cid, hero, gob = self._in_combat_grid()
+        eng.place_combatant_at_coords(cid, gob, 1, 0)  # adjacent so the strike is in reach
+        start_round = eng._require(cid).combat.round
+
+        results: list[dict] = []
+        barrier = threading.Barrier(2)
+
+        def fire():
+            barrier.wait()  # maximize the race: both threads enter together
+            results.append(
+                server._resolve_player_combat_turn(
+                    cid, {"kind": "attack", "target_id": gob}, live=True
+                )
+            )
+
+        t1 = threading.Thread(target=fire)
+        t2 = threading.Thread(target=fire)
+        t1.start(); t2.start(); t1.join(); t2.join()
+
+        self.assertEqual(len(results), 2)
+        advanced = [r for r in results if r.get("ok") and r["arbiter"].get("advanced")]
+        # Each advancing PC turn must have run the enemy (a non-empty enemy_digest) — the goblin
+        # was never silently skipped. THIS is the TOCTOU harm: a double-advance consumes the
+        # goblin's turn with no digest.
+        for r in advanced:
+            self.assertTrue(
+                r["arbiter"]["resolved"].get("enemy_digest"),
+                f"a PC turn advanced WITHOUT the enemy acting — skipped enemy turn: {r['arbiter']}",
+            )
+        # The round advanced by exactly one per resolved PC turn (each PC turn + the goblin's turn
+        # wraps the order once). A double-step (two PC turns sharing one goblin turn) would make
+        # the round delta exceed the number of advancing turns.
+        c = eng._require(cid)
+        if c.combat.active:
+            round_delta = c.combat.round - start_round
+            self.assertEqual(
+                round_delta, len(advanced),
+                f"initiative double-stepped: round_delta={round_delta} but advanced={len(advanced)}",
+            )
+            self.assertIn(c.combat.current_combatant_id, (hero, gob))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/viewer/tests/test_player_turn_bridge_concurrency.py
+++ b/viewer/tests/test_player_turn_bridge_concurrency.py
@@ -77,6 +77,16 @@ class PlayerTurnBridgeTests(unittest.TestCase):
         eng.place_combatant_at_coords(cid, gob, 1, 0)  # adjacent so the strike is in reach
         start_round = eng._require(cid).combat.round
 
+        # The idempotency token. _resolve_player_combat_turn reads the snake_case `turn_token`
+        # directly (sanitize_move normalizes the client's camelCase `turnToken` -> turn_token in
+        # the /move route — that mapping is unit-tested separately in test_move_intents). Both
+        # duplicate submits carry the SAME token; the first advances + invalidates it, the second
+        # MUST reject — it cannot slip through as a fresh turn after the order wraps back to the hero.
+        token = server.build_combat_surface(
+            server._read_snapshot(cid), campaign_id=cid, live=True, is_live_view=True
+        )["turnToken"]
+        self.assertTrue(token)  # an active combat emits a non-empty turn token
+
         results: list[dict] = []
         barrier = threading.Barrier(2)
 
@@ -84,7 +94,7 @@ class PlayerTurnBridgeTests(unittest.TestCase):
             barrier.wait()  # maximize the race: both threads enter together
             results.append(
                 server._resolve_player_combat_turn(
-                    cid, {"kind": "attack", "target_id": gob}, live=True
+                    cid, {"kind": "attack", "target_id": gob, "turn_token": token}, live=True
                 )
             )
 
@@ -97,24 +107,21 @@ class PlayerTurnBridgeTests(unittest.TestCase):
 
         self.assertEqual(len(results), 2)
         advanced = [r for r in results if r.get("ok") and r["arbiter"].get("advanced")]
-        # Each advancing PC turn must have run the enemy (a non-empty enemy_digest) — the goblin
-        # was never silently skipped. THIS is the TOCTOU harm: a double-advance consumes the
-        # goblin's turn with no digest.
-        for r in advanced:
-            self.assertTrue(
-                r["arbiter"]["resolved"].get("enemy_digest"),
-                f"a PC turn advanced WITHOUT the enemy acting — skipped enemy turn: {r['arbiter']}",
-            )
-        # The round advanced by exactly one per resolved PC turn (each PC turn + the goblin's turn
-        # wraps the order once). A double-step (two PC turns sharing one goblin turn) would make
-        # the round delta exceed the number of advancing turns.
+        rejected = [r for r in results if not r.get("ok")]
+        # The dedup invariant: EXACTLY one advance + one reject (the stale duplicate). Without the
+        # turn-token guard (or with the token silently stripped) BOTH would advance as two full
+        # rounds — the post-wrap double-advance.
+        self.assertEqual(len(advanced), 1, f"expected exactly one advance: {results}")
+        self.assertEqual(len(rejected), 1, f"expected exactly one reject (stale token): {results}")
+        # The one advancing PC turn ran the enemy (a non-empty enemy_digest) — the goblin was NOT
+        # silently skipped — and initiative advanced by exactly one round (PC turn + goblin wraps).
+        self.assertTrue(
+            advanced[0]["arbiter"]["resolved"].get("enemy_digest"),
+            f"the advancing PC turn did not run the enemy: {advanced[0]['arbiter']}",
+        )
         c = eng._require(cid)
         if c.combat.active:
-            round_delta = c.combat.round - start_round
-            self.assertEqual(
-                round_delta, len(advanced),
-                f"initiative double-stepped: round_delta={round_delta} but advanced={len(advanced)}",
-            )
+            self.assertEqual(c.combat.round - start_round, 1, "initiative double-stepped")
             self.assertIn(c.combat.current_combatant_id, (hero, gob))
 
 


### PR DESCRIPTION
## The keystone: player CONTROL of combat-with-movement

The grid math + locked write-verbs (`move_to_coords` / `attack` / `next_turn`) existed, but there was **NO player-control path**. `combat_loop` is AI-only — it pulls every actor's intent from `combat_ai` and STOPS at the first PC turn (`awaiting_pc`), handing a digest to the DM. The player `/move` log feeds the **DM agent**, a separate pipeline with no cell resolution. So a human/UI could not actually move a token or attack on the player's grid-combat turn through the engine.

This PR adds the missing arbiter — the single deterministic path by which a human/UI-authored Intent is resolved on a PC's combat turn.

## First-principles decision: extend `combat_loop` (Option A), not a parallel handler

Decision doc was written before any code (`/tmp/decision-player-turn-arbiter.md`). **Option A — extend `combat_loop` with a validating player-turn wrapper that reuses the existing `_apply_intent` mapping** — over Option B (a parallel handler that re-calls the verbs directly). Rationale:
- **Reuse over rebuild** — `_apply_intent` already maps `move`→`move_to_coords` and `attack`→`attack`; the player Intent goes through the SAME path the AI uses, so player + AI resolution are byte-identical and rules are never re-implemented.
- **Chains the enemy turns for free** — after the PC's turn the existing live loop auto-runs enemies to the next PC decision.
- **Sole-writer trivially preserved** — `combat_loop`'s module invariant ("no new write path; every mutation goes through a server.py verb").
- The strongest pro-B argument (clean player-facing error semantics) is satisfied by a **validating wrapper IN FRONT OF** `_apply_intent`, not by cloning resolution.

## The additive change

**Engine (`servers/engine/combat_loop.py`)** — `resolve_player_turn(campaign_id, actor_id, intent, *, advance=True, end_turn=False)`:
- Validates **turn-ownership** (current combatant AND a PC/companion AND alive AND required fields) — rejects with **nothing mutated** (`move_to_coords` does NOT self-gate turn-ownership, so this gate is load-bearing).
- Resolves via the existing `_apply_intent` (engine rolls; no rules re-implemented).
- **5e turn model:** a bare `move` consumes no action → the turn stays OPEN (`turn_open`); an `attack`/`cast` or explicit `end_turn=True` ends it → advances initiative + auto-runs enemy turns to the next PC decision.
- Holds **no lock**; adds **no new write path**.

**Viewer (`viewer/server.py`)** — additive wire:
- `_MOVE_KINDS` += `move_to_cell`, `end_turn`; `_MOVE_FIELDS` += `x`, `y`, `target_id`, `end_turn` (appended, defaulted; **no existing field reordered/renamed/retyped**; role still forced to `player`; unknown fields still dropped).
- `do_POST /move` routes a grid-combat player-turn move through the **in-process engine bridge** (the SAME sole-writer-preserving path `/save-slot` uses) → `resolve_player_turn` → re-emit `build_combat_surface`. **Every other kind keeps the append-only intent-log behavior (byte-identical to today).**

**Bonus pre-existing bugfix (surfaced by the curl-prove):** `_combat_display_position` used `x or col`, which treats coordinate **0 as missing**, dropping the whole grid projection for any token on row/column 0 and corrupting it into a synthesized zone position. Now None-coalesces + clamps to the **engine grid extents** (not the fixed 16×10 zone-display grid), preserving cell 0. Zone/theater path is byte-identical.

## Curl-proven END-TO-END over HTTP (no Unity)

A live in-combat grid campaign + the real `viewer/server.py`, then POSTs to `/move`:
- **C1** bare `move_to_cell` (0,0)→(3,0): engine moved the token to the exact cell; turn stays OPEN; surface re-emitted live + non-empty (tokens + initiative populated).
- **C2** `move_to_cell` + `end_turn`: budget charged, **initiative ADVANCED** (round 2), **enemy auto-ran**, surface re-emitted.
- **D** a current-monster `move_to_cell` **REJECTED** (turn-ownership: "G is a monster, not a player-controlled combatant").
- **E** malformed cell rejected at the palette.
- **F** combat moves **bypass the append-only DM lane** (0 lines appended — engine-resolved in-process).

## Adversarial-invariant-verify (4 skeptics)

- **Additive / byte-identical** — SAFE. Legacy kinds byte-identical; zone path byte-identical; only-appended palette; no new persisted field.
- **Sole-writer** — SAFE. Zero direct field writes / `save_campaign` in the arbiter; every mutation goes through an existing locked verb; viewer only reads-to-route + re-reads; `campaign_lock` is a cross-process flock.
- **No reordered/renamed/retyped wire param** — SAFE. `server.py` diff empty; `combat_loop.py` added-only; `Intent` untouched; palette only widens.
- **No desync / double-resolve** — **REFUTED → FIXED.** A real TOCTOU: the arbiter reads `current_combatant_id` without a lock and the engine's `campaign_lock` is per-verb (doesn't span read→validate→advance) and NOT re-entrant (a nested flock deadlocks — verified). Two concurrent POSTs on the `ThreadingHTTPServer` could double-advance and silently consume an enemy turn. **Fix:** a per-campaign in-process `threading.Lock` serializes the player-turn lane within the viewer process (does not touch the engine's sole-writer lock). **Revert-checked:** disabling the lock makes the concurrency test RED on every run.

## Tests + gates

- Engine arbiter (`tests/test_player_turn_arbiter.py`, 10): happy-path move/attack, turn-open semantics, move-then-end-turn, turn-ownership rejections (wrong-turn / monster / no-combat / no-target), no-desync.
- Viewer palette + grid-origin regression (`tests/test_move_intents.py`) + bridge concurrency (`tests/test_player_turn_bridge_concurrency.py`, revert-checked).
- **Tier-0 `qa/fast_gate.sh` GREEN** (241 deterministic engine tests).

## Seam note for S2 (Unity)
`build_combat_surface` already declares `state_authority="engine"`, `write_lane="/move"` and emits tokens/initiative/round/grid. Unity sends `{"kind":"move_to_cell","x","y"[,"end_turn"]}` or `{"kind":"attack","target_id"[,...]}` to `POST /move` and re-reads the returned `combat` surface — no new contract surface needed.

**Do NOT merge — opened for review.**