### PR TITLE
feat(combat): browser grid combat-with-movement + grid-extent fix (#10)

### DIFF
--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -495,6 +495,14 @@ function CombatGridBoard({ tokens, grid, selected, onSelect, onCellMove, onAttac
     const x = Number(t.x), y = Number(t.y);
     if (Number.isInteger(x) && Number.isInteger(y)) at[`${x},${y}`] = t;
   });
+  // #10 terrain: cells the engine marks non-walkable (walls/props, `{c,r,walkable:false}`) must NOT be
+  // move targets — any in-bounds cell not listed in grid.cells is the cellDefault (walkable by default).
+  const blocked = {};
+  ((grid && Array.isArray(grid.cells)) ? grid.cells : []).forEach((c) => {
+    if (c && Number.isInteger(c.c) && Number.isInteger(c.r) && c.walkable === false) blocked[`${c.c},${c.r}`] = true;
+  });
+  const defaultWalkable = !(grid && grid.cellDefault && grid.cellDefault.walkable === false);
+  const isWalkable = (x, y) => (blocked[`${x},${y}`] ? false : defaultWalkable);
   const curId = ((tokens || []).find((t) => t.isCurrent) || {}).id || "";
   const cells = [];
   for (let y = 0; y < rows; y++) for (let x = 0; x < cols; x++) cells.push({ x, y, t: at[`${x},${y}`] });
@@ -520,16 +528,31 @@ function CombatGridBoard({ tokens, grid, selected, onSelect, onCellMove, onAttac
       }}>
         {cells.map(({ x, y, t }) => {
           const isFoe = t && t.team === "foe";
-          const clickable = canAct && (!t || isFoe);
+          const walkable = isWalkable(x, y);
+          // Selecting a token is ALWAYS allowed (inspect on any turn); move/attack gate on can_act.
+          const onActivate = t
+            ? () => { if (isFoe && canAct) onAttack(t.id); else onSelect(t.id); }
+            : () => { if (canAct && walkable) onCellMove(x, y); };
+          const actionable = t ? true : (canAct && walkable);   // gets button semantics + keyboard
+          const hoverBg = t ? (isFoe && canAct ? "rgba(197,64,64,0.22)" : "rgba(244,210,123,0.10)") : "rgba(244,210,123,0.12)";
+          const title = t ? `${t.name}${isFoe && canAct ? " — attack" : ""}` : (walkable ? `move → (${x}, ${y})` : "blocked");
+          const restBox = walkable ? "inset 0 0 0 0.5px rgba(176,141,87,0.10)" : "inset 0 0 0 0.5px rgba(80,40,30,0.5)";
           return (
             <div key={`${x},${y}`}
-              title={t ? `${t.name}${isFoe ? " — attack" : ""}` : `move → (${x}, ${y})`}
-              onClick={() => { if (!canAct) return; if (t) { isFoe ? onAttack(t.id) : onSelect(t.id); } else { onCellMove(x, y); } }}
-              onMouseEnter={(e) => { if (clickable) e.currentTarget.style.background = t ? "rgba(197,64,64,0.22)" : "rgba(244,210,123,0.12)"; }}
+              title={title} aria-label={title}
+              role={actionable ? "button" : undefined}
+              tabIndex={actionable ? 0 : -1}
+              onClick={onActivate}
+              onKeyDown={(e) => { if (actionable && (e.key === "Enter" || e.key === " ")) { e.preventDefault(); onActivate(); } }}
+              onMouseEnter={(e) => { if (actionable) e.currentTarget.style.background = hoverBg; }}
               onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+              onFocus={(e) => { if (actionable) e.currentTarget.style.boxShadow = "inset 0 0 0 1.5px var(--gold-glow)"; }}
+              onBlur={(e) => { e.currentTarget.style.boxShadow = restBox; }}
               style={{
-                position: "relative", boxShadow: "inset 0 0 0 0.5px rgba(176,141,87,0.10)",
-                cursor: clickable ? "pointer" : "default", transition: "background 0.08s",
+                position: "relative", boxShadow: restBox,
+                background: walkable ? "transparent" : "rgba(20,10,6,0.45)",
+                cursor: actionable ? "pointer" : "default", outline: "none",
+                transition: "background 0.08s, box-shadow 0.08s",
                 display: "flex", alignItems: "center", justifyContent: "center",
               }}>
               {t ? <GridCellToken t={t} selected={selected === t.id} isCurrent={t.id === curId} /> : null}

--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -171,6 +171,49 @@ function ScreenCombat({ onNavigate, state }) {
     }
   };
 
+  // Grid-combat player-turn intents (move_to_cell / on-turn attack). POST /move with the turnToken
+  // echoed for idempotency; the grid lane returns the REFRESHED surface in {ok,arbiter,combat}, so we
+  // apply it directly (no extra GET). The engine stays the sole writer — this only posts an intent.
+  const postCombatIntent = async (move, label) => {
+    if (!canAct) {
+      toast({ kind: "danger", eyebrow: "Combat", title: `${label} unavailable`, body: "Not your turn, or read-only surface." });
+      return;
+    }
+    if (busyRef.current) return; // synchronous double-click guard
+    busyRef.current = true;
+    setBusyAction(label);
+    try {
+      const body = { ...move, turn_token: surface?.turnToken || "", campaign: surface?.campaign_id || campaignId };
+      const response = await fetch("/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.reason || `move ${response.status}`);
+      }
+      setLocalLog((rows) => [
+        ...rows,
+        {
+          event: "player-intent",
+          title: `Player ${label}`,
+          text: move.kind === "move_to_cell" ? `→ cell (${move.x}, ${move.y})` : "attack",
+          meta: [{ label: "lane", value: "/move" }],
+        },
+      ]);
+      if (payload.combat) { setSurface(payload.combat); setSurfaceStatus("ready"); }
+      else await loadSurface();
+    } catch (error) {
+      toast({ kind: "danger", title: `${label} not sent`, body: error?.message || "The viewer could not reach /move." });
+    } finally {
+      busyRef.current = false;
+      setBusyAction("");
+    }
+  };
+  const onCellMove = (x, y) => postCombatIntent({ kind: "move_to_cell", x, y }, "move");
+  const onAttackToken = (targetId) => postCombatIntent({ kind: "attack", target_id: targetId }, "attack");
+
   const actionTile = (id, fallbackIcon, fallbackLabel) => {
     const action = actionById(id);
     return (
@@ -218,7 +261,7 @@ function ScreenCombat({ onNavigate, state }) {
           </div>
 
           {encounter.active ? (
-            <CombatMap tokens={tokens} zones={zones} selected={selected?.id} onSelect={setSelectedToken} sceneScope={sceneScope} />
+            <CombatMap tokens={tokens} zones={zones} grid={surface?.grid} selected={selected?.id} onSelect={setSelectedToken} onCellMove={onCellMove} onAttack={onAttackToken} canAct={canAct} sceneScope={sceneScope} />
           ) : (
             <CombatEmptyState status={surfaceStatus} onNavigate={onNavigate} />
           )}
@@ -439,6 +482,90 @@ function CombatEmptyState({ status, onNavigate }) {
   );
 }
 
+/* Grid combat board (#10/#461): when the engine sends authoritative cell coordinates
+   (grid.mode==="grid", tokens positionAuthority:"engine"), render a real cols×rows tactical board.
+   Tokens sit at their (x,y) cell; an EMPTY-cell click posts move_to_cell, a FOE click posts attack,
+   an ALLY click selects. The engine validates reach/budget/OA and re-emits the surface (it is the
+   sole writer) — this board only POSTS intents and renders what comes back. */
+function CombatGridBoard({ tokens, grid, selected, onSelect, onCellMove, onAttack, canAct, sceneScope }) {
+  const cols = Math.max(1, Number(grid && grid.cols) || 16);
+  const rows = Math.max(1, Number(grid && grid.rows) || 10);
+  const at = {};
+  (tokens || []).forEach((t) => {
+    const x = Number(t.x), y = Number(t.y);
+    if (Number.isInteger(x) && Number.isInteger(y)) at[`${x},${y}`] = t;
+  });
+  const curId = ((tokens || []).find((t) => t.isCurrent) || {}).id || "";
+  const cells = [];
+  for (let y = 0; y < rows; y++) for (let x = 0; x < cols; x++) cells.push({ x, y, t: at[`${x},${y}`] });
+  return (
+    <div style={{
+      position: "relative", width: "100%", height: "calc(100% - 50px)", overflow: "hidden",
+      background:
+        `radial-gradient(ellipse at 50% 40%, rgba(60,30,10,0.2), transparent 70%),
+         linear-gradient(135deg, #3a2418 0%, #25160e 100%)`,
+      boxShadow: "inset 0 0 0 1px var(--w-500), inset 0 0 60px rgba(0,0,0,0.6)",
+      display: "flex", alignItems: "center", justifyContent: "center", padding: 12,
+    }}>
+      {sceneScope ? (
+        <Img scope={sceneScope} label="scene · battlefield" w="100%" h="100%" fit="cover"
+          style={{ position: "absolute", inset: 0, zIndex: 0, opacity: 0.9 }} />
+      ) : null}
+      <div style={{
+        position: "relative", zIndex: 1,
+        display: "grid",
+        gridTemplateColumns: `repeat(${cols}, 1fr)`, gridTemplateRows: `repeat(${rows}, 1fr)`,
+        gap: 1, aspectRatio: `${cols} / ${rows}`, height: "100%", maxWidth: "100%", width: "auto",
+        boxShadow: "inset 0 0 0 1px rgba(176,141,87,0.25)",
+      }}>
+        {cells.map(({ x, y, t }) => {
+          const isFoe = t && t.team === "foe";
+          const clickable = canAct && (!t || isFoe);
+          return (
+            <div key={`${x},${y}`}
+              title={t ? `${t.name}${isFoe ? " — attack" : ""}` : `move → (${x}, ${y})`}
+              onClick={() => { if (!canAct) return; if (t) { isFoe ? onAttack(t.id) : onSelect(t.id); } else { onCellMove(x, y); } }}
+              onMouseEnter={(e) => { if (clickable) e.currentTarget.style.background = t ? "rgba(197,64,64,0.22)" : "rgba(244,210,123,0.12)"; }}
+              onMouseLeave={(e) => { e.currentTarget.style.background = "transparent"; }}
+              style={{
+                position: "relative", boxShadow: "inset 0 0 0 0.5px rgba(176,141,87,0.10)",
+                cursor: clickable ? "pointer" : "default", transition: "background 0.08s",
+                display: "flex", alignItems: "center", justifyContent: "center",
+              }}>
+              {t ? <GridCellToken t={t} selected={selected === t.id} isCurrent={t.id === curId} /> : null}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/* A token sized to its grid cell: circle + team tint + isCurrent ring + tiny HP pip. */
+function GridCellToken({ t, selected, isCurrent }) {
+  const isFoe = t.team === "foe";
+  const ratio = healthRatio(t);
+  const ring = isCurrent
+    ? "0 0 0 2px var(--gold-glow), 0 0 16px rgba(244,210,123,0.7)"
+    : (selected ? "0 0 0 2px rgba(244,210,123,0.6)" : "none");
+  return (
+    <div style={{ width: "84%", height: "84%", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 2 }}>
+      <div style={{
+        width: "72%", aspectRatio: "1", borderRadius: "50%",
+        background: isFoe
+          ? "radial-gradient(circle at 35% 30%, #d35a5a, #7a1414 70%, #3a0a0a)"
+          : "radial-gradient(circle at 35% 30%, var(--p-100, #e8d6a8), var(--p-300, #b08d57) 70%, #4a3618)",
+        boxShadow: `${ring}, inset 0 -2px 4px rgba(0,0,0,0.4)`,
+        display: "flex", alignItems: "center", justifyContent: "center",
+        color: isFoe ? "#fff" : "#2a1c08", fontFamily: "var(--f-display)", fontWeight: 700, fontSize: "min(2.4vmin, 17px)",
+      }}>{t.initial || (t.name || "?").slice(0, 1)}</div>
+      <div style={{ width: "72%", height: 3, background: "rgba(0,0,0,0.5)", boxShadow: "inset 0 0 0 0.5px rgba(0,0,0,0.6)" }}>
+        <div style={{ width: `${Math.round(ratio * 100)}%`, height: "100%", background: hpBarFill(t, isFoe) }} />
+      </div>
+    </div>
+  );
+}
+
 /* HONEST RENDERING (graphics #432 / #438): the engine's combat is GRIDLESS / named-zone. A
    token's x/y are DERIVED render-hints (positionAuthority:"derived"), never authoritative — so
    we must NOT draw a measured VTT grid and place tokens by x/y. The previous board did exactly
@@ -450,7 +577,17 @@ function CombatEmptyState({ status, onNavigate }) {
    A real measured-tile grid (range/LoS/flanking) is the evidence-gated #461 future: it requires
    the engine to gain authoritative coordinates (positionAuthority:"engine" + grid.mode==="grid").
    When that lands, a grid board plugs in here behind that flag; until then, zones are the truth. */
-function CombatMap({ tokens, zones, selected, onSelect, sceneScope }) {
+function CombatMap({ tokens, zones, grid, selected, onSelect, onCellMove, onAttack, canAct, sceneScope }) {
+  // #10/#461: when the engine sends authoritative cell coords (grid.mode==="grid"), render a real
+  // tactical board (the slot this comment-block reserved). Otherwise fall back to the zone bands.
+  if (grid && grid.mode === "grid" && Number(grid.cols) > 0 && Number(grid.rows) > 0) {
+    return (
+      <CombatGridBoard
+        tokens={tokens} grid={grid} selected={selected} onSelect={onSelect}
+        onCellMove={onCellMove} onAttack={onAttack} canAct={canAct} sceneScope={sceneScope}
+      />
+    );
+  }
   const named = (zones || []).map((z) => (typeof z === "string" ? z : z && z.name)).filter(Boolean);
   const FIELD = "The Field";
   let zoneNames = named.slice();

--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -495,14 +495,20 @@ function CombatGridBoard({ tokens, grid, selected, onSelect, onCellMove, onAttac
     const x = Number(t.x), y = Number(t.y);
     if (Number.isInteger(x) && Number.isInteger(y)) at[`${x},${y}`] = t;
   });
-  // #10 terrain: cells the engine marks non-walkable (walls/props, `{c,r,walkable:false}`) must NOT be
-  // move targets — any in-bounds cell not listed in grid.cells is the cellDefault (walkable by default).
-  const blocked = {};
+  // #10 terrain: honor the engine's per-cell walkability override (`{c,r,walkable:bool}`) — record BOTH
+  // true and false, so a cellDefault.walkable=false scene with explicit walkable floors works too. Any
+  // in-bounds cell NOT listed in grid.cells falls back to cellDefault (walkable unless it says otherwise).
+  const walkability = {};
   ((grid && Array.isArray(grid.cells)) ? grid.cells : []).forEach((c) => {
-    if (c && Number.isInteger(c.c) && Number.isInteger(c.r) && c.walkable === false) blocked[`${c.c},${c.r}`] = true;
+    if (c && Number.isInteger(c.c) && Number.isInteger(c.r) && typeof c.walkable === "boolean") {
+      walkability[`${c.c},${c.r}`] = c.walkable;
+    }
   });
   const defaultWalkable = !(grid && grid.cellDefault && grid.cellDefault.walkable === false);
-  const isWalkable = (x, y) => (blocked[`${x},${y}`] ? false : defaultWalkable);
+  const isWalkable = (x, y) => {
+    const key = `${x},${y}`;
+    return Object.prototype.hasOwnProperty.call(walkability, key) ? walkability[key] : defaultWalkable;
+  };
   const curId = ((tokens || []).find((t) => t.isCurrent) || {}).id || "";
   const cells = [];
   for (let y = 0; y < rows; y++) for (let x = 0; x < cols; x++) cells.push({ x, y, t: at[`${x},${y}`] });

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -1994,26 +1994,34 @@ def _scene_grid_block(snapshot: dict, mode: str) -> dict:
     locs = snapshot.get("locations")
     loc = locs.get(loc_id) if isinstance(locs, dict) and loc_id else None
     sg = loc.get("scene_grid") if isinstance(loc, dict) else None
-    if not isinstance(sg, dict):
-        return block
-    grid = sg.get("grid")
-    if not isinstance(grid, dict):
-        return block
-    cols = grid.get("cols")
-    rows = grid.get("rows")
-    if not (isinstance(cols, int) and isinstance(rows, int) and cols > 0 and rows > 0):
-        return block  # degrade to the default extents on a malformed grid
-    block["cols"] = cols
-    block["rows"] = rows
-    sid = sg.get("scene_id")
-    if isinstance(sid, str) and sid:
-        block["sceneId"] = sid
-    cells = sg.get("cells")
-    if isinstance(cells, list):
-        block["cells"] = cells
-    cell_default = sg.get("cell_default")
-    if isinstance(cell_default, dict):
-        block["cellDefault"] = cell_default
+    grid = sg.get("grid") if isinstance(sg, dict) else None
+    if isinstance(grid, dict):
+        cols = grid.get("cols")
+        rows = grid.get("rows")
+        if isinstance(cols, int) and isinstance(rows, int) and cols > 0 and rows > 0:
+            block["cols"] = cols
+            block["rows"] = rows
+        sid = sg.get("scene_id")
+        if isinstance(sid, str) and sid:
+            block["sceneId"] = sid
+        cells = sg.get("cells")
+        if isinstance(cells, list):
+            block["cells"] = cells
+        cell_default = sg.get("cell_default")
+        if isinstance(cell_default, dict):
+            block["cellDefault"] = cell_default
+    # #10 — the combat TACTICAL grid is the authority for the board EXTENT: combatant tokens are
+    # placed at its grid_width/grid_height coords (see _combat_tokens), so the rendered board MUST
+    # contain them or a token lands off-board (a 20x20 fight reported a 16x10 board pre-fix). Override
+    # cols/rows when combat declares an explicit grid; any scene_grid cells/sceneId set above stay.
+    # Additive: no explicit combat grid ⇒ unchanged (empty == today).
+    combat = snapshot.get("combat")
+    if isinstance(combat, dict):
+        cgw = combat.get("grid_width")
+        cgh = combat.get("grid_height")
+        if isinstance(cgw, int) and isinstance(cgh, int) and cgw > 0 and cgh > 0:
+            block["cols"] = cgw
+            block["rows"] = cgh
     return block
 
 

--- a/viewer/tests/test_move_intents.py
+++ b/viewer/tests/test_move_intents.py
@@ -234,5 +234,35 @@ class GridOriginPositionTests(unittest.TestCase):
         self.assertEqual((hero["x"], hero["y"]), (18, 17))
 
 
+class SceneGridBlockExtentTests(unittest.TestCase):
+    """#10 — the surface board EXTENT must follow the COMBAT tactical grid (where _combat_tokens
+    places tokens), not a hardcoded 16x10 default, else a token on a larger grid lands off the
+    rendered board. Additive: no explicit combat grid ⇒ today's 16x10 default is unchanged."""
+
+    def test_default_when_no_combat_grid(self):
+        block = server._scene_grid_block({}, "grid")
+        self.assertEqual((block["cols"], block["rows"]), (16, 10))  # unchanged legacy default
+
+    def test_combat_grid_sets_board_extent(self):
+        block = server._scene_grid_block({"combat": {"grid_width": 14, "grid_height": 10}}, "grid")
+        self.assertEqual((block["cols"], block["rows"]), (14, 10))
+
+    def test_combat_grid_larger_than_default_not_clipped(self):
+        # the pre-fix bug: a 20x20 fight reported a 16x10 board → tokens at >16,>10 fell off-board.
+        block = server._scene_grid_block({"combat": {"grid_width": 20, "grid_height": 20}}, "grid")
+        self.assertEqual((block["cols"], block["rows"]), (20, 20))
+
+    def test_malformed_combat_grid_degrades_to_default(self):
+        for bad in ({"grid_width": 0, "grid_height": 10}, {"grid_width": "x", "grid_height": 10},
+                    {"grid_width": -5, "grid_height": 5}, {"grid_width": 14}):
+            with self.subTest(bad=bad):
+                block = server._scene_grid_block({"combat": bad}, "grid")
+                self.assertEqual((block["cols"], block["rows"]), (16, 10))
+
+    def test_mode_preserved(self):
+        block = server._scene_grid_block({"combat": {"grid_width": 14, "grid_height": 10}}, "zones")
+        self.assertEqual(block["mode"], "zones")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/viewer/tests/test_move_intents.py
+++ b/viewer/tests/test_move_intents.py
@@ -263,6 +263,26 @@ class SceneGridBlockExtentTests(unittest.TestCase):
         block = server._scene_grid_block({"combat": {"grid_width": 14, "grid_height": 10}}, "zones")
         self.assertEqual(block["mode"], "zones")
 
+    def test_combat_grid_wins_extent_but_scene_grid_metadata_survives(self):
+        # Mixed source: a location scene_grid (10x8 + cells/sceneId/cellDefault) AND an explicit combat
+        # grid (14x10). Combat owns cols/rows (where tokens live); the scene_grid's cells/sceneId/
+        # cellDefault (the floor/wall map for tinting) are PRESERVED, not overwritten by its own 10x8.
+        snap = {
+            "current_location_id": "loc-tavern",
+            "locations": {"loc-tavern": {"scene_grid": {
+                "scene_id": "fixture:tavern",
+                "grid": {"cols": 10, "rows": 8},
+                "cells": [{"c": 0, "r": 0, "type": "wall", "walkable": False}],
+                "cell_default": {"type": "floor", "walkable": True},
+            }}},
+            "combat": {"grid_width": 14, "grid_height": 10},
+        }
+        block = server._scene_grid_block(snap, "grid")
+        self.assertEqual((block["cols"], block["rows"]), (14, 10))   # combat owns the extent
+        self.assertEqual(block["sceneId"], "fixture:tavern")          # scene_grid metadata survives
+        self.assertEqual(block["cells"], [{"c": 0, "r": 0, "type": "wall", "walkable": False}])
+        self.assertEqual(block["cellDefault"], {"type": "floor", "walkable": True})
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
**Lane A of the S2 plan — OBJECTIVE-1's functional core (turn-based combat WITH MOVEMENT), on the reliable web path.** Builds on the merged keystone (#1171): the player-turn arbiter already resolves `move_to_cell`/on-turn `attack` over `/move`; this adds the **grid board that consumes it** + a board-extent fix so tokens never fall off-board.

- **`viewer/server.py` `_scene_grid_block` (#10):** the rendered board EXTENT now follows the combat tactical grid (`combat.grid_width/grid_height`) when combat declares one, so a token placed on a >16×10 grid isn't clipped off-board (a 20×20 fight previously reported a 16×10 board). Additive — no explicit combat grid ⇒ today's 16×10 default / scene_grid extent. **+5 unit tests.**
- **`viewer/openworlds/screen-combat.jsx`:** render a real `cols×rows` tactical board when the engine sends authoritative cells (`grid.mode==="grid"`) — the slot the existing `CombatMap` comment explicitly reserved. Click an **empty cell** → POST `move_to_cell`; click a **foe** → POST `attack` (echo `turnToken`, gate on `can_act`); apply the **refreshed surface** the grid `/move` lane returns. The engine stays the **SOLE WRITER** — the board only posts intents; zones render unchanged for non-grid surfaces.

## Validation
End-to-end in the browser preview against a live 14×10 combat-on-tavern demo:
- click an empty cell → the hero **walks there** (engine-resolved, movement-budget-validated);
- click the adjacent goblin → **attack resolves** ("Rolan misses Goblin Cutter"), turn advances, the enemy auto-runs, the round advances.
- `curl` cross-check: surface reports the correct **14×10** grid; `move_to_cell` moves the token.
- **Full viewer suite 786 passed**, Tier-0 GREEN.
- `/move` sole-writer path unchanged (this adds a client + a presentation-only extent read, not a write path).

## Licensing / CLA
Source-available WorldOS; additive change, no new deps.