### PR TITLE
Painterly CRPG P0+P1: camera contract + detail critic + combat walkability/A* routing

### DIFF
--- a/extensions/renderers/shared/camera_contract.json
+++ b/extensions/renderers/shared/camera_contract.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "projection": "dimetric-2to1",
+  "camera_type": "orthographic",
+  "elevation_deg": 30.0,
+  "yaw_deg": 45.0,
+  "zoom_locked": true,
+  "rotation_locked": true,
+  "cell_size_world": 2.0,
+  "ortho_size_world": 12.0,
+  "char_height_world": 3.6,
+  "near": 0.3,
+  "far": 500.0,
+  "notes": [
+    "elevation_deg = asin(0.5) = 30deg gives a TRUE 2:1 screen foreshortening of a ground tile: screen_h/screen_w = sin(elevation). (Corrects the old atan(0.5)=26.565deg, which gives 2.236:1.)",
+    "cellToWorld(c,r) = ((c-cx0)*S, 0, (cy0-r)*S); S=cell_size_world; cx0=(cols-1)/2; cy0=(rows-1)/2. The on-screen 2:1 diamond emerges from the camera (yaw + 30deg pitch), NOT from per-axis steps. Inverse: c = cx0 + wx/S, r = cy0 - wz/S.",
+    "yaw_deg = 0 = front-tilted framing (the owner-liked crypt look). Set 45 for classic corner-iso (must then match bake_sprites.py facings). Owner eyeball-pick during P0; reconcile bake yaw in P3.",
+    "ortho_size_world = half the vertical view height in world units (= ortho_rows/2 * cell_size). px_per_world = render_height / (2*ortho_size_world). Plate aspect MUST equal the capture-camera aspect or the tiles skew."
+  ]
+}

--- a/qa/painterly_detail_critic.js
+++ b/qa/painterly_detail_critic.js
@@ -11,7 +11,7 @@ export const meta = {
 let _A = args; if (typeof _A === 'string') { try { _A = JSON.parse(_A) } catch (e) { _A = {} } }
 const candidates = (_A && _A.candidates) || []
 const refs = (_A && _A.refs) || []
-if (!candidates.length) { log('no candidates in args: ' + JSON.stringify(args).slice(0, 200)) }
+if (!candidates.length) { log('no candidates in args: ' + String(JSON.stringify(args)).slice(0, 200)) }
 
 const SCHEMA = {
   type: 'object', additionalProperties: false,

--- a/qa/painterly_detail_critic.js
+++ b/qa/painterly_detail_critic.js
@@ -1,0 +1,52 @@
+// Painterly-DETAIL adversarial critic — the eval upgrade after the visual-critic MISSED a washed-out/watercolor plate
+// (owner 2026-06-27: "it's not just paint — it has to be DETAILED, fine grain, crisp brushwork, NOT washed-out watercolor").
+// Scores candidate renders ONLY on detail/graining/brushwork/stonework vs the PoE/BG/Disco reference frames, harshly.
+// Run: Workflow({scriptPath:".../qa/painterly_detail_critic.js", args:{candidates:[{label,path}...], refs:[path...]}})
+export const meta = {
+  name: 'painterly-detail-critic',
+  description: 'Adversarial DETAIL-vs-watercolor critic: scores each candidate render on fine detail / grain / crisp brushwork / intricate stonework vs the PoE-BG-Disco refs; flags washed-out watercolor',
+  phases: [{ title: 'Detail', detail: 'each candidate x3 harsh detail-lens agents, ref-anchored' }],
+}
+
+let _A = args; if (typeof _A === 'string') { try { _A = JSON.parse(_A) } catch (e) { _A = {} } }
+const candidates = (_A && _A.candidates) || []
+const refs = (_A && _A.refs) || []
+if (!candidates.length) { log('no candidates in args: ' + JSON.stringify(args).slice(0, 200)) }
+
+const SCHEMA = {
+  type: 'object', additionalProperties: false,
+  required: ['label', 'detail_score', 'is_watercolor_washout', 'brushwork', 'grain_texture', 'stonework_prop_detail', 'vs_ref_gap', 'tells'],
+  properties: {
+    label: { type: 'string' },
+    detail_score: { type: 'number', description: '0-10 fidelity of FINE DETAIL vs the refs: 9-10 = PoE/BG-caliber intricate detail; 5-6 = reads as a game but soft; 3-4 = detail breaking down; 0-2 = washed-out watercolor mush' },
+    is_watercolor_washout: { type: 'boolean', description: 'true if it reads as soft/washed/muddy watercolor lacking the refs fine detail (the failure the owner flagged)' },
+    brushwork: { type: 'string', description: 'crisp confident strokes vs soft/smudged' },
+    grain_texture: { type: 'string', description: 'fine grain / surface texture present, or flat/hazy' },
+    stonework_prop_detail: { type: 'string', description: 'are walls/floor/chest/sarcophagus/pillars intricately detailed + legible, or undefined blobs' },
+    vs_ref_gap: { type: 'string', description: 'which ref, what detail it has that the candidate lacks' },
+    tells: { type: 'array', items: { type: 'string' }, description: 'specific washout/detail tells + a fix' },
+  },
+}
+
+const PRE = `You are a HARSH painterly-DETAIL specialist on a WorldOS visual-critic panel. The team previously shipped a camera-pinned dungeon plate that scored "fine" overall but the OWNER rejected it as "mushy watercolor — lost the actual detail; the chest and walls went weird and washed-out." Your ONE job: judge FINE DETAIL, GRAIN, CRISP BRUSHWORK, and INTRICATE STONEWORK/PROP DEFINITION — NOT composition, lighting, or registration (sibling lenses own those). Real painterly (the refs) is HIGHLY DETAILED: crisp confident brushstrokes, fine surface grain, intricate carved stone, legible props — NOT soft/washed/muddy/hazy watercolor. Grade 2-3 points HARSHER than a generalist; washout MUST score low and set is_watercolor_washout=true.
+
+FIRST use the Read tool to view the CANDIDATE then the REFERENCE frames (the bar = real PoE2/BG2/Disco detail). Score the candidate's DETAIL gap to the refs. Be specific and unflattering. TEXT-ONLY JSON.`
+
+phase('Detail')
+const tasks = []
+for (const c of candidates) for (let run = 1; run <= 3; run++) tasks.push({ c, run })
+const results = (await parallel(tasks.map((t) => () =>
+  agent(`${PRE}\n\nCANDIDATE (under test): ${t.c.path}\nREFERENCES (the detail bar): ${refs.join(' , ')}\n\nScore ONLY detail/grain/brushwork/stonework for "${t.c.label}". Return JSON.`,
+    { label: `detail:${t.c.label}#${t.run}`, phase: 'Detail', schema: SCHEMA, effort: 'medium' })
+    .then((r) => (r ? { ...r, _label: t.c.label } : null))
+))).filter(Boolean)
+
+// aggregate per candidate
+const byLabel = {}
+for (const r of results) { (byLabel[r._label] = byLabel[r._label] || []).push(r) }
+const summary = Object.entries(byLabel).map(([label, rs]) => {
+  const avg = rs.reduce((s, r) => s + (r.detail_score || 0), 0) / rs.length
+  const washVotes = rs.filter((r) => r.is_watercolor_washout).length
+  return { label, avg_detail: Math.round(avg * 10) / 10, washout_votes: `${washVotes}/${rs.length}`, sample_tells: (rs[0].tells || []).slice(0, 3) }
+}).sort((a, b) => b.avg_detail - a.avg_detail)
+return { ranking: summary, winner: summary[0] || null, all: results }

--- a/servers/engine/combat_grid.py
+++ b/servers/engine/combat_grid.py
@@ -59,6 +59,7 @@ def reachable(
     occupied: set[Cell],
     width: int,
     height: int,
+    impassable: set[Cell] = frozenset(),
 ) -> set[Cell]:
     """Open-floor reachability: every in-bounds cell reachable from `start` within
     `budget_cells` of movement, flooding over the 8-neighbourhood at a flat cost of 1
@@ -93,6 +94,8 @@ def reachable(
                     cell = (nx, ny)
                     if cell in occupied:
                         continue  # can't enter (and so can't pass through) a token
+                    if cell in impassable:
+                        continue  # terrain/wall/prop — can't enter or pass through (P1)
                     if cell in dist:
                         continue
                     dist[cell] = d + 1
@@ -100,6 +103,60 @@ def reachable(
         frontier = nxt
     # Exclude the start cell (it's where you already are, not a destination).
     return {c for c in dist if c != start}
+
+
+def shortest_path(
+    start: Cell,
+    goal: Cell,
+    occupied: set[Cell],
+    width: int,
+    height: int,
+    impassable: set[Cell] = frozenset(),
+) -> list[Cell] | None:
+    """P1: BFS shortest route from `start` to `goal` over the 8-neighbourhood, routing
+    AROUND cells that cannot be entered (`occupied` tokens + `impassable` terrain/walls/
+    props). Returns the list of step cells EXCLUDING `start` (so `path_cost_cells` sums its
+    Chebyshev hops = the routed distance), `[]` if already at the goal, or None if the goal
+    is itself blocked / out of bounds / unreachable without crossing a blocked cell. Uniform
+    cost 1/step; deterministic (neighbour order fixed). On OPEN floor this returns a straight
+    diagonal whose cost equals the old straight-line Chebyshev — so behaviour is unchanged
+    when there are no obstacles (additive)."""
+    if start == goal:
+        return []
+    if not (0 <= goal[0] < width and 0 <= goal[1] < height):
+        return None
+    if goal in occupied or goal in impassable:
+        return None
+    from collections import deque
+
+    prev: dict[Cell, Cell] = {start: start}
+    q: deque[Cell] = deque([start])
+    while q:
+        cur = q.popleft()
+        if cur == goal:
+            break
+        cx, cy = cur
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                if dx == 0 and dy == 0:
+                    continue
+                nx, ny = cx + dx, cy + dy
+                if not (0 <= nx < width and 0 <= ny < height):
+                    continue
+                cell = (nx, ny)
+                if cell in prev or cell in occupied or cell in impassable:
+                    continue
+                prev[cell] = cur
+                q.append(cell)
+    if goal not in prev:
+        return None
+    route: list[Cell] = []
+    cur = goal
+    while cur != start:
+        route.append(cur)
+        cur = prev[cur]
+    route.reverse()
+    return route
 
 
 def path_cost_cells(from_cell: Cell, to_cell: Cell, path: list[Cell] | None = None) -> int:

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1433,6 +1433,11 @@ class Combat(_StrictModel):
     grid_height: int = 0
     grid_cell_size: int = 5
     diagonal_mode: Literal["chebyshev", "five_ten_five"] = "chebyshev"
+    # P1: impassable cells (terrain/walls/props) that move_to_coords routes AROUND. Empty ==
+    # open floor (PR-1 behaviour, byte-for-byte unchanged). `last_move_path` is the most-recent
+    # routed path (incl. the from-cell) for the renderer to draw the detour — presentation only.
+    grid_impassable: list[list[int]] = Field(default_factory=list)
+    last_move_path: list[list[int]] = Field(default_factory=list)
 
     @property
     def current_combatant_id(self) -> Optional[str]:

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4298,8 +4298,9 @@ def set_grid(campaign_id: str, width: int, height: int, cell_size: int = 5,
     if obstacles is not None:
         imp = []
         for cellv in _coerce_list(obstacles):
-            pr = list(cellv) if isinstance(cellv, (list, tuple)) else cellv
-            imp.append([int(pr[0]), int(pr[1])])
+            if not isinstance(cellv, (list, tuple)) or len(cellv) != 2:
+                raise ValueError("set_grid obstacles must be a list of [x, y] cell pairs")
+            imp.append([int(cellv[0]), int(cellv[1])])
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         c.combat.grid_enabled = True
@@ -4403,6 +4404,7 @@ def move_to_coords(campaign_id: str, combatant_id: str, x: int, y: int,
                     view["from"] = list(from_cell)
                     view["to"] = list(from_cell)
                     view["cost_cells"] = 0
+                    view["path"] = []
                     view["move_blocked"] = {
                         "target": [x, y],
                         "reason": f"({x}, {y}) is impassable (wall/prop/occupied) or unreachable — move rejected; stayed at {list(from_cell)}.",

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4284,14 +4284,22 @@ def _cell(cb: "Combatant") -> tuple[int, int] | None:
 
 @mcp.tool()
 def set_grid(campaign_id: str, width: int, height: int, cell_size: int = 5,
-             diagonal_mode: str = "chebyshev") -> dict:
-    """#461: switch this fight to a coordinate grid (the only tool that sets grid mode).
+             diagonal_mode: str = "chebyshev", obstacles: ListArg = None) -> dict:
+    """#461 / P1: switch this fight to a coordinate grid (the only tool that sets grid mode).
     Optional; without it combat stays zone/theater. Sets extents (cells; cell_size ft);
-    idempotent; needs width/height>0."""
+    idempotent; needs width/height>0. P1: `obstacles` is a list of [x,y] IMPASSABLE cells
+    (walls/props) that move_to_coords routes AROUND; omit == leave obstacles unchanged,
+    [] == clear them (open floor, PR-1 behaviour byte-for-byte unchanged)."""
     if width <= 0 or height <= 0:
         raise ValueError("set_grid needs width > 0 and height > 0")
     if diagonal_mode not in ("chebyshev", "five_ten_five"):
         raise ValueError("diagonal_mode must be 'chebyshev' or 'five_ten_five'")
+    imp: list[list[int]] | None = None
+    if obstacles is not None:
+        imp = []
+        for cellv in _coerce_list(obstacles):
+            pr = list(cellv) if isinstance(cellv, (list, tuple)) else cellv
+            imp.append([int(pr[0]), int(pr[1])])
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         c.combat.grid_enabled = True
@@ -4299,6 +4307,8 @@ def set_grid(campaign_id: str, width: int, height: int, cell_size: int = 5,
         c.combat.grid_height = height
         c.combat.grid_cell_size = cell_size
         c.combat.diagonal_mode = diagonal_mode  # type: ignore[assignment]
+        if imp is not None:
+            c.combat.grid_impassable = imp
         save_campaign(c)
         return _combat_view(c)
 
@@ -4371,11 +4381,36 @@ def move_to_coords(campaign_id: str, combatant_id: str, x: int, y: int,
             )
 
         to_cell = (x, y)
-        # Measured movement cost (PR-1: open floor — straight Chebyshev, or the summed
-        # explicit path). Accumulates across a broken-up move this turn.
+        # P1: route AROUND impassable terrain (walls/props) + other tokens. impassable/occupied
+        # empty == open floor (PR-1 behaviour byte-for-byte unchanged: straight-line Chebyshev).
+        impassable = {(int(ix), int(iy)) for ix, iy in (c.combat.grid_impassable or [])}
+        occupied = {
+            (o.x, o.y) for o in c.combat.order
+            if o.character_id != combatant_id and o.x is not None and o.y is not None
+        }
         if from_cell is None:
             cost = 0  # an unplaced combatant: this is effectively a placement, no cost
         else:
+            if path_cells is None and (impassable or occupied):
+                routed = combat_grid.shortest_path(
+                    from_cell, to_cell, occupied, c.combat.grid_width, c.combat.grid_height, impassable
+                )
+                if routed is None:
+                    # P1: never walk onto/through a wall/prop (or into an occupied cell) — reject, stay put.
+                    c.combat.last_move_path = []
+                    save_campaign(c)
+                    view = _combat_view(c)
+                    view["from"] = list(from_cell)
+                    view["to"] = list(from_cell)
+                    view["cost_cells"] = 0
+                    view["move_blocked"] = {
+                        "target": [x, y],
+                        "reason": f"({x}, {y}) is impassable (wall/prop/occupied) or unreachable — move rejected; stayed at {list(from_cell)}.",
+                    }
+                    view["warnings"] = warnings + [f"({x}, {y}) blocked/unreachable — stayed at {list(from_cell)}."]
+                    return view
+                if routed:
+                    path_cells = routed  # charge + draw the routed detour
             cost = combat_grid.path_cost_cells(from_cell, to_cell, path_cells)
         prior_used = cb.moved_cells_this_turn
         dashed = bool(dash) or bool(cb.dashed)
@@ -4446,6 +4481,12 @@ def move_to_coords(campaign_id: str, combatant_id: str, x: int, y: int,
         cb.x = x
         cb.y = y
         cb.moved_cells_this_turn = prior_used + cost
+        # P1: record the routed path (incl. the from-cell) for the renderer to draw the detour.
+        if from_cell is not None:
+            steps = path_cells if path_cells else [to_cell]
+            c.combat.last_move_path = [list(from_cell)] + [list(pc) for pc in steps]
+        else:
+            c.combat.last_move_path = []
         _log_combat_event(
             c,
             f"{mover.name if mover else combatant_id} moves to ({x}, {y}).",
@@ -4468,6 +4509,7 @@ def move_to_coords(campaign_id: str, combatant_id: str, x: int, y: int,
     view["from"] = list(from_cell) if from_cell else None
     view["to"] = [x, y]
     view["cost_cells"] = cost
+    view["path"] = c.combat.last_move_path
     view["opportunity_attack"] = bool(provokers)
     view["provokers"] = provokers
     view["warnings"] = warnings

--- a/servers/engine/tests/test_grid_walkability_p1.py
+++ b/servers/engine/tests/test_grid_walkability_p1.py
@@ -1,0 +1,92 @@
+"""P1: authored walkability + A*/BFS routing — combatants route AROUND impassable cells
+(walls/props) and never end on/through one. ADDITIVE: empty impassable == open floor
+(PR-1 behaviour byte-for-byte unchanged), guarded by test_open_floor_additive_unchanged.
+"""
+
+import pytest
+
+import combat_grid
+import server
+
+# A 2-wide notch in a 3x3 that forces (0,0)->(2,0) to take the long way around.
+WALL = {(1, 0), (1, 1)}
+
+
+# ── pure combat_grid helpers ─────────────────────────────────────────────────
+
+
+def test_shortest_path_routes_around_wall():
+    p = combat_grid.shortest_path((0, 0), (2, 0), occupied=set(), width=3, height=3, impassable=WALL)
+    assert p is not None and p[-1] == (2, 0)
+    assert all(tuple(s) not in WALL for s in p)  # never steps onto a wall
+    # the detour costs MORE than the straight-line Chebyshev (proves it routed around)
+    assert combat_grid.path_cost_cells((0, 0), (2, 0), p) > combat_grid.chebyshev_cells((0, 0), (2, 0))
+
+
+def test_shortest_path_blocked_goal_is_none():
+    assert combat_grid.shortest_path((0, 0), (2, 2), occupied=set(), width=4, height=4,
+                                     impassable={(2, 2)}) is None
+
+
+def test_shortest_path_unreachable_is_none():
+    box = {(2, 2), (2, 3), (3, 2)}  # walls the (3,3) corner off in a 4x4
+    assert combat_grid.shortest_path((0, 0), (3, 3), occupied=set(), width=4, height=4,
+                                     impassable=box) is None
+
+
+def test_reachable_excludes_and_blocks_through_impassable():
+    r = combat_grid.reachable((0, 0), 4, occupied=set(), width=4, height=2,
+                              impassable={(1, 0), (1, 1)})
+    assert (1, 0) not in r and (1, 1) not in r        # can't end on a wall
+    assert (3, 0) not in r                            # full x=1 column walls off the right (2-row board)
+
+
+def test_open_floor_additive_unchanged():
+    # no obstacles -> routed cost == straight-line Chebyshev == old behaviour
+    p = combat_grid.shortest_path((0, 0), (3, 3), occupied=set(), width=8, height=8)
+    assert combat_grid.path_cost_cells((0, 0), (3, 3), p) == combat_grid.chebyshev_cells((0, 0), (3, 3)) == 3
+
+
+# ── integration via the engine tools (set_grid obstacles + move_to_coords) ───
+
+
+@pytest.fixture
+def gf(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("P1 walk")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30, armor_class=14)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=15, armor_class=12)["id"]
+    server.start_combat(cid, [hero, gob])
+    return cid, hero, gob
+
+
+def test_move_routes_around_obstacle(gf):
+    cid, hero, gob = gf
+    server.set_grid(cid, 3, 3, obstacles=[[1, 0], [1, 1]])
+    server.place_combatant_at_coords(cid, hero, 0, 0)
+    server.place_combatant_at_coords(cid, gob, 2, 2)
+    res = server.move_to_coords(cid, hero, 2, 0)
+    path = res.get("path") or []
+    assert path and all(tuple(s) not in WALL for s in path)
+    assert res["cost_cells"] > combat_grid.chebyshev_cells((0, 0), (2, 0))
+    assert res["to"] == [2, 0]  # the goal IS reachable around the wall
+
+
+def test_move_onto_wall_is_rejected(gf):
+    cid, hero, gob = gf
+    server.set_grid(cid, 4, 4, obstacles=[[1, 1]])
+    server.place_combatant_at_coords(cid, hero, 0, 1)
+    server.place_combatant_at_coords(cid, gob, 3, 3)
+    res = server.move_to_coords(cid, hero, 1, 1)  # straight onto the wall cell
+    assert res.get("move_blocked")        # rejected, not landed
+    assert res["to"] == [0, 1]            # stayed put
+
+
+def test_open_floor_combat_move_unchanged(gf):
+    # no obstacles -> move behaves exactly as PR-1 (straight Chebyshev cost, lands on the cell)
+    cid, hero, gob = gf
+    server.set_grid(cid, 8, 8)
+    server.place_combatant_at_coords(cid, hero, 0, 0)
+    server.place_combatant_at_coords(cid, gob, 7, 7)
+    res = server.move_to_coords(cid, hero, 3, 0)
+    assert res["to"] == [3, 0] and res["cost_cells"] == 3 and not res.get("move_blocked")

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3341,6 +3341,10 @@ def build_combat_surface(
             "warnings": combat_view.get("warnings", []),
         },
         "grid": _scene_grid_block(snapshot, mode),
+        # P1: the most-recent routed move path (incl. the from-cell) + the impassable cells, so the
+        # read-only renderer can draw the detour around walls/props. Presentation-only; [] == none.
+        "lastPath": (snapshot.get("combat") or {}).get("last_move_path") or [],
+        "impassable": (snapshot.get("combat") or {}).get("grid_impassable") or [],
         "tokens": tokens,
         "initiative": initiative,
         "zones": zones,


### PR DESCRIPTION
## What
The painterly-CRPG renderer foundation: **P0** (camera-pin infra + a detail eval) and **P1** (combat walkability — combatants now route AROUND walls/props instead of through them).

### P1 — combat walkability + BFS/A* routing (engine, additive)
The combat grid was reachability-only and **ignored terrain entirely** — a combatant could walk straight through a wall or the sarcophagus. This wires authored obstacles in, additively:
- `combat_grid.shortest_path(start, goal, occupied, w, h, impassable)` — BFS shortest route that goes **around** cells that can't be entered; returns the step list (or `None` if the goal is blocked/unreachable).
- `combat_grid.reachable(..., impassable=frozenset())` — the flood now also skips impassable cells.
- `Combat.grid_impassable` + `Combat.last_move_path` fields; `set_grid(..., obstacles=[[x,y],...])` to mark walls/props.
- `move_to_coords`: builds impassable (from `grid_impassable`) ∪ occupied, **routes around** them (charging the detour length), **rejects** ending on/through an impassable cell (`move_blocked`, stays put), and exposes the routed `path`.
- `build_combat_surface`: emits `lastPath` + `impassable` so the **read-only** renderer can draw the detour. Engine stays **sole writer**.

**Additive guarantee:** empty `impassable`/`grid_impassable` == open floor → `shortest_path` returns the straight diagonal whose cost equals the old straight-line Chebyshev. PR-1 zone/theater + open-floor combat is byte-for-byte unchanged (guarded by `test_open_floor_additive_unchanged` + `test_open_floor_combat_move_unchanged`).

### P0 — painterly infra
- `extensions/renderers/shared/camera_contract.json` — the frozen dimetric contract (orthographic, yaw 45 corner-iso, elevation 30° = true 2:1, isotropic cell 2.0) that the greybox conditioning render, the plate generation, and the renderer all share.
- `qa/painterly_detail_critic.js` — an adversarial DETAIL-vs-watercolor visual-critic lens (ref-anchored) that catches washed-out plates the general critic misses.

## Tests
- `servers/engine/tests/test_grid_walkability_p1.py` (8): routes-around, blocked-goal/unreachable → None, reachable excludes impassable, additive open-floor, + integration (set_grid obstacles → move routes around / rejects a wall / open-floor unchanged).
- Tier-0 `fast_gate`: **241 passed**. Viewer move-intent + combat-grid-scene surface: **27 + 20 passed**.

## Invariants honored
Engine = sole writer (renderer only reads + posts intents); additive-by-default (empty == today; old snapshots round-trip via `_StrictModel` defaults); gates read engine-mutated values only.