### PR TITLE
QA: PoE2-anchored visual-critic + motion scoring (3D-actor pivot recalibration)

### DIFF
--- a/.claude/skills/visual-critic/SKILL.md
+++ b/.claude/skills/visual-critic/SKILL.md
@@ -3,17 +3,56 @@ name: visual-critic
 description: >-
   The "Angry-DM for graphics" — WorldOS's recursive self-improving VISUAL feedback loop.
   Use to SCORE/critique any WorldOS render (a frame from the Unity closed-loop pipeline, the
-  archived Godot extension, or a still) against the BG1/2 + Pillars of Eternity + Disco Elysium painterly
-  bar, and to drive the render→pre-gate→panel→fix→re-render loop until a scene CONVERGES to that
+  archived Godot extension, or a still) against the **Pillars of Eternity II: Deadfire** painterly
+  bar (BG2 = a tactical-readability cross-check only; Disco Elysium = a dark-pocket/mood cross-check
+  only), and to drive the render→pre-gate→panel→fix→re-render loop until a scene CONVERGES to that
   bar instead of plateauing. v2: REFERENCE-ANCHORED (the critic scores the GAP to specific named
-  reference frames), a DIVERSE 5-6 lens PANEL (parallel subagents), DETERMINISTIC pre-gates
-  (frame-lit + floor-contact + screen-scale + occupancy, numbers not vibes), and REGRESSION-TRACKED
-  in scores_db (surface="visual"). Invoke whenever you produce a render and need an honest
-  gap-to-bar score + concrete defects + machine-actionable fixes WITHOUT burning the main agent's
-  context on pixels. Mirrors the engine's story/mech QA loop, for the visual side.
+  reference frames), a DIVERSE 5-7 lens PANEL (parallel subagents), DETERMINISTIC pre-gates
+  (frame-lit + floor-contact + screen-scale + occupancy + motion-liveness, numbers not vibes), and
+  REGRESSION-TRACKED in scores_db (surface="visual"). v3 re-anchor: PoE2-as-sole-bar; L4 rewarded
+  for a GROUNDED real-3D actor (not a painterly sprite); an L7 MOTION lens scored from a render REEL.
+  Invoke whenever you produce a render and need an honest gap-to-bar score + concrete defects +
+  machine-actionable fixes WITHOUT burning the main agent's context on pixels. Mirrors the engine's
+  story/mech QA loop, for the visual side.
 ---
 
 # Visual Critic v2 — the reference-anchored convergent visual-feedback loop
+
+## ★ Art-direction bar — Pillars of Eternity II: Deadfire is the SOLE reference (v3 re-anchor)
+WorldOS's art direction is **Pillars of Eternity II: Deadfire** — pre-rendered painterly 2D
+backgrounds composited with **real-time 3D animated characters**. PoE2 is the bar for EVERY lens.
+The old "BG1/2 + PoE + Disco, equal-weight" muddle is dropped: BG2 and Disco are now narrow
+CROSS-CHECKS, not co-equal targets.
+
+- **PoE2 = the sole bar (every lens scores the GAP to PoE2).** What to look for, and weave into
+  every lens prompt:
+  - **Vibrant tropical-gothic palette** — saturated teals/jades, warm sandstone + amber lamplight,
+    deep maritime blues; never the desaturated grey-brown "mud" of a cheap render.
+  - **Warm/cool contrast in EVERY frame** — a warm key (hearth / lantern / sun) played against a
+    cool fill/ambient (sky / shadow / water). If the frame is monochrome-warm or monochrome-cool,
+    it is below the bar.
+  - **Chroma lives in the lights and magic** — fire, spells, glows, stained glass carry the most
+    saturated hues; they are colored light, not white blobs.
+  - **Blue-violet shadows, NEVER pure black** — PoE2 shadows are tinted toward the cool ambient
+    (blue/violet/teal). A pure #000 shadow is a tell that the deferred ambient is missing.
+  - **Layered deferred lighting** — warm key + cool fill at roughly a **3:1** key:fill ratio +
+    deferred point lights for fire/spells + **ambient-from-the-plate GI** (the 3D actor must pick
+    up bounce color from the painted background, not sit under a neutral studio light).
+  - **Painterly BUT architecturally precise plates** — visible brush economy and atmospheric depth,
+    yet the perspective/architecture is crisp and correct (not smeared or warped).
+  - **Mildly-stylized 3D actors with soft blue contact shadows** — the characters are real 3D,
+    slightly stylized (not photoreal), and PLANTED by a soft, cool-tinted contact shadow.
+- **BG2 = tactical-readability cross-check ONLY.** Consult BG2EE refs solely for "is walkable vs
+  blocked + party formation legible?" (L5). Do NOT score palette / lighting / brushwork against BG2.
+- **Disco Elysium = dark-pocket / mood cross-check ONLY.** Consult Disco refs solely for "do dark
+  zones still read with chroma in the shadow, and does the frame carry mood?" Do NOT score
+  grounding / scale / tactical clarity against Disco.
+
+**Character pivot (load-bearing for L2 + L4):** WorldOS is moving characters from FLAT BILLBOARDS to
+**real 3D animated actors**. The critic must therefore CREDIT real-3D grounding and integration — a
+flat billboard is now the LOW end of L4, a scene-lit grounded 3D actor is the HIGH end (see L4/L2
+below). The v2 critic OVER-penalized billboards as "pasted stickers" (a validated false-negative: it
+scored "zero contact shadow" on a frame whose feet-crop clearly showed the shadow). v3 fixes this.
 
 ## Why this exists (and why v1 plateaued at 4/10)
 Images are expensive in the main agent's context, so image review is delegated to CRITIC
@@ -24,7 +63,7 @@ and the v2 fix for each:
 
 | v1 plateau cause | v2 fix |
 |---|---|
-| **No concrete bar.** The critic scored against its *memory* of "BG/PoE/Disco look," which is vague, drifts, and inflates. There was nothing to measure the GAP against. | **Reference-anchored scoring.** The critic is handed 2-3 specific reference frames (`refs/`) matched to the scene kind, and scores the GAP to *those exact images* per dimension. "Lighting 4/10" becomes "lighting 4/10 — `poe2_tavern` wraps a warm hearth key around the character's right side and rim-lights the silhouette; here the actor is flat-white front-lit." |
+| **No concrete bar.** The critic scored against its *memory* of "BG/PoE/Disco look," which is vague, drifts, and inflates. There was nothing to measure the GAP against. | **Reference-anchored scoring against the PoE2 bar.** The critic is handed 2-3 specific reference frames (`refs/`, **PoE2-first**) matched to the scene kind, and scores the GAP to *those exact images* per dimension. "Lighting 4/10" becomes "lighting 4/10 — `poe2_tavern` wraps a warm hearth key around the character's right side, rim-lights the silhouette, and tints the shadow blue-violet; here the actor is flat-white front-lit with a pure-black shadow." |
 | **Lenses too soft / holistic.** One critic scoring seven blended dimensions averages into a mushy mid-score and never isolates the single worst illusion-breaker. | **Diverse 5-6 lens PANEL.** Independent parallel subagents, each with ONE obsession (registration, occlusion/grounding, light-coherence, character-integration, tactical-readability, painterly-vs-reference). A specialist scores its axis 2-3 points harsher than a generalist. Synthesis picks the single highest-leverage fix. |
 | **No algorithmic grounding.** "Pasted on" / "floating" / "wrong scale" are geometric facts the eye estimates and an LLM rounds off — they never became NUMBERS, so they weren't gated or regression-tracked. | **Deterministic pre-gates** (`qa/visual_pregate.py`): frame-lit (luminance mean+variance), per-actor floor-contact-Y delta (cells), screen-scale relative error, occupancy-mask match. A CRITICAL pre-gate SHORT-CIRCUITS the panel — fix the measurable defect first. |
 | **fix_actions too vague to move the needle.** "Improve lighting" can't be executed; the next render looked the same; the score didn't move; the loop gave up. | Every defect carries a **parameterized fix_action** (target + action + exact params: hex, scale, cell, shader keyword, prompt delta) AND names which Unity menu / `scenario_gen.py` flag / shader uniform applies it. |
@@ -50,35 +89,41 @@ real geometric defects (floating actors, wrong scale) as numbers. These lessons 
    reproducible, numbers not vibes, and short-circuits the panel when it fires.
 
 The goal is **"build the system that builds the system"** — a loop the orchestrator runs itself
-to drive a scene to BG/PoE/Disco caliber, with the convergence and regression evidence in the
-same ledger as story/mech.
+to drive a scene to **PoE2 caliber** (BG2/Disco only as the narrow cross-checks above), with the
+convergence and regression evidence in the same ledger as story/mech.
 
 ## The loop (one cycle)
 
 ```plaintext
 RENDER  (Unity CL pipeline: Tools/WorldOS/CL/0 → step-4 Scenario → step-5 assemble → screenshot;
          or an explicit archived-Godot extension proof; or a still)  →  /tmp/<scene>-r<N>.png  (+ measured actor boxes from the
-         render side, + the scenegrid fixture)
+         render side, + the scenegrid fixture). For the MOTION lens (L7), ALSO render a REEL of
+         N frames (idle / locomotion / attack / hit-react / death) via qa/motion_reel.py.
   │
   ├─① PRE-GATES  qa/visual_pregate.py  (deterministic, <1s, no LLM)
-  │     frame-lit · floor-contact-Y · screen-scale · occupancy-mask
+  │     frame-lit · floor-contact-Y · screen-scale · occupancy-mask · motion-liveness (G5, reel only)
   │     → if verdict==FLAG (any CRITICAL/HIGH): DO NOT call the panel. Apply the named
-  │       deterministic fix (re-ground the actor / rescale / re-light), RE-RENDER, restart ①.
+  │       deterministic fix (re-ground the actor / rescale / re-light / un-freeze the idle), RE-RENDER,
+  │       restart ①.
   │
-  ├─② REFERENCE PICK  choose 2-3 refs/ frames matching scene.kind (tavern→poe2_tavern +
-  │     bg2ee_temple_combat + disco_cafeteria; outdoor→bg2ee_forest + poe2_cliff; dark→bg2ee_cavern
-  │     + poe2_market). See refs/INDEX.md "How to use in the critic."
+  ├─② REFERENCE PICK  choose 2-3 refs/ frames matching scene.kind, **PoE2-first** (PoE2 is the bar;
+  │     a BG2 ref is added ONLY for the tactical-readability cross-check, a Disco ref ONLY for the
+  │     dark-pocket/mood cross-check): tavern→poe2_tavern (+bg2ee_temple for L5, +disco_cafeteria
+  │     for dark-pocket); outdoor→poe2_cliff (+bg2ee_forest for L5); dark→poe2_market
+  │     (+disco_office for mood, +bg2ee_cavern for L5). See refs/INDEX.md "How to use in the critic."
   │
-  ├─③ PANEL  fan out 5-6 LENS SUBAGENTS in parallel (Agent tool, model opus, run_in_background ok).
-  │     Each gets: the render path, the SAME 2-3 ref paths, the scene_spec, the pre-gate JSON, and
+  ├─③ PANEL  fan out 6-7 LENS SUBAGENTS in parallel (Agent tool, model opus, run_in_background ok;
+  │     L7 MOTION runs only when a reel was rendered). Each gets: the render path (L7 gets the reel
+  │     contact-sheet + sidecar), the SAME 2-3 ref paths, the scene_spec, the pre-gate JSON, and
   │     its ONE-lens prompt. Each returns TEXT-only per-lens JSON (gap-to-ref score + defects + fix).
   │
   ├─④ SYNTHESIZE  (this skill, no pixels) → overall (0-10), the merged defect list (CRITICAL first),
   │     and the SINGLE highest-leverage fix_action.
   │
   ├─⑤ LOG  scores_db.add_run(surface="visual", visual_scene, visual_backend, visual_round=N,
-  │     visual_overall, visual_dims_json={6 lenses}, visual_pregate, visual_blocking) ;
-  │     then qa/visual_regression.py --candidate <run_id>  (worse-vs-baseline guard).
+  │     visual_overall, visual_dims_json={6 still lenses}, visual_pregate, visual_blocking,
+  │     + motion_overall, motion_dims_json={L7 sub-scores}, motion_reel_ref, milestone) ;
+  │     then qa/visual_regression.py --candidate <run_id>  (worse-vs-baseline guard, still + motion).
   │
   └─⑥ if overall ≥7.5 AND no CRITICAL/HIGH (target ≥8): CONVERGED → set_canonical_baseline once,
         stop. else: apply fix_action[0], RE-RENDER, repeat. Cap N=5 rounds, then report the
@@ -108,6 +153,12 @@ float 0.4 cells above the stone. The exact checks (thresholds are the module's t
 - **G2 OCCUPANCY** (only when the render draws a walkable/blocked overlay, e.g. tactical mode) —
   compare the rendered per-cell tint to the SceneGrid walk-mask; `>22%` cells mismatch → HIGH
   "tactical space unreadable"; `>10%` → MED.
+- **G5 MOTION-LIVENESS** (only when a render REEL is supplied — `qa/motion_reel.py` builds it; when
+  no reel is passed, G5 SKIPS == today's behavior) — objective inter-frame deltas over the reel:
+  a FROZEN idle (no inter-frame pixel delta across the idle frames — the actor is a static
+  billboard, not a living 3D actor) → CRITICAL; NO walk-centroid displacement when the reel's
+  metadata says a MOVE occurred (the actor teleports / slides without locomotion) → HIGH. Pure
+  numbers (mean abs pixel delta + centroid drift), Pillow-or-stdlib, like G1.
 
 Inputs the render side must emit for G2/G3/G4 (G1 needs only the PNG): the `*.scenegrid.json`
 fixture, and per-actor measured boxes `{id, cell:[c,r], feet_px:[x,y], px_height, world_height_ft?}`.
@@ -123,26 +174,43 @@ python qa/visual_pregate.py --render /tmp/scene-r2.png \
 **Hard gate:** any CRITICAL or HIGH result means RE-RENDER before calling the LLM panel.
 The pre-gate result is deterministic and reproducible; treat it as a CI-style gate, not a hint.
 
-## ② Reference anchoring (the bar made concrete)
-The critic does NOT score against a remembered "BG look." It scores the GAP to 2-3 SPECIFIC
-reference frames it is shown alongside the render. References live at
+## ② Reference anchoring (the bar made concrete) — PoE2-first
+The critic does NOT score against a remembered look. It scores the GAP to 2-3 SPECIFIC reference
+frames it is shown alongside the render, with **PoE2 as the bar** and BG2/Disco only as the narrow
+cross-checks (see the §★ art-direction bar at the top). References live at
 `/Volumes/LEXAR/WorldOS-Unity-spike/refs/` (13 calibration frames, see `refs/INDEX.md`).
-Pick by scene kind (the INDEX's "How to use in the critic" table):
-- **tavern / interior**: `poe2_tavern_interior_combat_02` (prime tavern: warm hearth key, cool
-  room ambient, grounded contact shadows on plank floor) + `bg2ee_temple_combat_lighting_04` +
-  `disco_cafeteria_bar_interior_03`.
-- **outdoor / wilderness**: `bg2ee_forest_party_tactical_01` + `poe2_cliff_party_brushwork_03`.
-- **dark zone / cavern / dungeon**: `bg2ee_cavern_darkzone_lighting_03` + `poe2_market_interior_lighting_04`.
-- **best single light-coherence anchors** (for the light lens, any scene): `disco_office_interior_lighting_04`,
-  `poe2_market_interior_lighting_04`.
+Pick by scene kind (PoE2 ref ALWAYS leads; the bracketed cross-check ref is added only for its
+narrow lens):
+- **tavern / interior**: `poe2_tavern_interior_combat_02` (the bar: warm hearth key, cool room
+  ambient at ~3:1, blue-violet shadows, grounded soft contact shadows on plank floor)
+  [+ `bg2ee_temple_combat_lighting_04` for L5 tactical-readability; + `disco_cafeteria_bar_interior_03`
+  for the dark-pocket/mood cross-check].
+- **outdoor / wilderness**: `poe2_cliff_party_brushwork_03` (the bar) [+ `bg2ee_forest_party_tactical_01`
+  for L5 tactical-readability].
+- **dark zone / cavern / dungeon**: `poe2_market_interior_lighting_04` (the bar: chroma surviving
+  into shadow) [+ `disco_office_interior_lighting_04` for the dark-pocket/mood cross-check;
+  + `bg2ee_cavern_darkzone_lighting_03` for L5 blocked-cells-in-shadow readability].
+- **best single light-coherence anchor** (for L3, any scene): `poe2_market_interior_lighting_04`
+  (warm-key + cool-fill + colored deferred lights, the PoE2 deferred look).
 These are INTERNAL calibration references only (not redistributed/reproduced/served, never a
 generation input).
 
-## ③ The PANEL — 5-6 diverse lens subagents (parallel)
+## ③ The PANEL — 6-7 diverse lens subagents (parallel)
 Spawn each as its own subagent (Agent tool, model **opus** for the quality read, `run_in_background`
 ok). Give each the render path, the SAME 2-3 ref paths, the `scene_spec`, the pre-gate JSON, and
 its single-lens prompt. Each returns TEXT-only JSON. **A specialist obsessed with one axis scores
-it 2-3 points harsher than a generalist — that harshness is the point.**
+it 2-3 points harsher than a generalist — that harshness is the point.** L1–L6 score a STILL; **L7
+(MOTION) scores a REEL** and runs only when a reel was rendered.
+
+> ★ **GROUNDING auto-downgrade (the billboard false-negative fix).** The deterministic G3
+> floor-contact gate is MEASURED truth; an LLM lens guessing "the actor is a pasted sticker with no
+> contact shadow" is a PRIOR. **Rule: if an L2 or L4 lens raises a CRITICAL whose claim CONTRADICTS
+> a deterministic G3 floor-contact PASS (e.g. "floating / no contact shadow / not grounded" when G3
+> says feet-on-floor PASS), auto-DOWNGRADE that defect by one severity (CRITICAL→HIGH→MED) and tag
+> it `downgraded:contradicts-G3-PASS`.** Pass the G3 result into the L2/L4 prompts and tell the lens
+> NOT to claim "floating / ungrounded / no shadow" when G3 PASSed — credit the measured grounding
+> first, and only flag a SUBTLER integration tell (shadow too hard-edged, wrong shadow color, etc.).
+> This is what stops the v2 "billboard = sticker" prior from overriding measured grounding.
 
 Common preamble (prepend to every lens prompt):
 > You are ONE lens of a harsh visual-critic PANEL for WorldOS. Score ONLY your assigned dimension —
@@ -164,24 +232,59 @@ The lenses (one subagent each):
 1. **L1 registration / cohesion** — does the painted floor register with the gameplay grid under
    the locked camera? Does the whole frame read as ONE coherent space (no double-perspective, no
    plate seam, no mirrored asymmetry)? Gap to the ref's unified space.
-2. **L2 occlusion / grounding** — are actors PLANTED (contact shadow reads, feet meet the floor,
-   they pass BEHIND props they should)? Build on the pre-gate's floor-contact numbers. Gap to how
-   the ref's figures sit in the scene. (No "actor standing on the table.")
-3. **L3 scene-light coherence** — are actors lit BY the scene's key light (warm hearth right / cool
-   fill left per the spec `lighting`), with rim light and matching shadow direction? Or flat,
-   front-lit, "studio-lit cutout"? This is the dimension that most often tanks — gap to
-   `poe2_tavern` / `disco_office` warm-key wrap + rim.
-4. **L4 character integration** — the decisive "painted vs pasted-3D" call. Brushwork/edge/texture/
-   palette match between actor and backdrop; does the actor look hand-painted into the plate or
-   like a clean 3D model composited on top? Gap to the ref's figures (which are 2D sprites painted
-   to match). Name the specific tells (too-clean edges, too-high specular, saturation mismatch,
-   no atmospheric desaturation with depth).
+2. **L2 occlusion / grounding** — are actors PLANTED (a visible soft contact shadow, feet meet the
+   floor, they pass BEHIND props they should)? **Build on the pre-gate's G3 floor-contact numbers
+   FIRST — if G3 PASSed, the actor IS grounded; CREDIT that.** When a contact shadow is visibly
+   rendered (check the feet-crop), score it as PRESENT — do NOT report "zero contact shadow" on a
+   frame whose feet clearly show one (the v2 validated false-negative). Only then flag the SUBTLER
+   tell vs the PoE2 ref: is the contact shadow soft + blue-violet-tinted (PoE2) or hard-edged /
+   pure-black / wrong-direction? Subject to the §③ auto-downgrade rule (an L2 CRITICAL that
+   contradicts a G3 PASS is downgraded). (No "actor standing on the table.") Gap to how the PoE2
+   ref's figures sit in the scene with soft cool contact shadows.
+3. **L3 scene-light coherence** — are actors lit BY the scene's key light (warm hearth/lantern key,
+   cool fill at ~3:1 per the spec `lighting`), with rim light, matching shadow direction, AND
+   PoE2's blue-violet (never pure-black) shadows + ambient-from-plate bounce on the actor? Or flat,
+   front-lit, "studio-lit cutout" with a black shadow? This is the dimension that most often tanks —
+   gap to `poe2_market` / `poe2_tavern` warm-key wrap + cool fill + colored deferred lights.
+4. **L4 character integration** — the decisive "grounded scene-lit REAL-3D actor vs pasted billboard"
+   call. **WorldOS targets real 3D animated actors, NOT painterly sprites — so a clean, well-formed
+   3D model that is GROUNDED (G3 PASS), scene-lit (picks up the plate's warm key + cool fill +
+   ambient bounce, casts a soft blue contact shadow), and mildly stylized to sit in the painterly
+   world scores HIGH.** A FLAT BILLBOARD (a 2D cutout that doesn't turn, no real volume, lit
+   independently of the scene, hard/absent contact shadow) scores LOW. Do NOT penalize an actor for
+   "looking 3D / too clean-edged / not hand-painted" — that is the GOAL now; the old "painted-vs-
+   pasted-sprite" framing is REVERSED. Score the GAP to the PoE2 ref's mildly-stylized 3D actors:
+   the tells that LOWER the score are now *flatness / billboard-ness / scene-light mismatch /
+   missing-or-wrong contact shadow / saturation that ignores the plate's palette*, not "it reads as
+   3D." Subject to the §③ auto-downgrade rule (an L4 CRITICAL contradicting a G3 PASS is downgraded).
 5. **L5 tactical readability** — is walkable vs blocked legible? Party formation / focal actor
    clear? Do dark zones still read (blocked cells visible in shadow)? Gap to the ref's readable
    tactical space.
 6. **L6 painterly-vs-reference** — pure art-direction craft of the BACKDROP plate: brush economy,
-   value structure, color harmony, atmospheric depth, NO decorative-frieze/border artifact (a
-   known Scenario failure). Gap to the ref's painterly quality.
+   value structure, color harmony (vibrant tropical-gothic PoE2 palette: saturated teals/jades +
+   warm sandstone/amber), warm/cool contrast, atmospheric depth, NO decorative-frieze/border
+   artifact (a known Scenario failure). Gap to the PoE2 ref's painterly quality.
+7. **L7 MOTION** (scored from a render REEL, NOT a single still — runs only when a reel was rendered).
+   **This lens is fed the reel contact-sheet PNG + the JSON sidecar** (`qa/motion_reel.py` builds
+   both: a grid of the N reel frames in order + per-frame metadata {frame_idx, beat/anim label,
+   actor centroid, t_ms, engine event}). Score how ALIVE and WEIGHTED the actor's animation is —
+   the real-time-3D half of the PoE2 look — across these sub-dimensions:
+   - **idle life** — does the idle breathe/sway, or is it a frozen statue? (a frozen idle is the
+     G5 CRITICAL; the lens scores how *natural* a non-frozen idle is.)
+   - **locomotion weight** — does the walk/run read with weight, footplant, and believable speed,
+     or does the actor slide/skate (centroid moves but legs don't, per the sidecar)?
+   - **attack anticipation / impact / follow-through** — a readable wind-up, a crisp impact frame,
+     and a settle — or a single popped pose with no arc?
+   - **hit-react** — does a struck actor flinch/recoil readably?
+   - **death** — does the death animation read as a fall/collapse with weight, not a vanish?
+   - **timing-sync to engine events** — do the anim beats line up with the engine events in the
+     sidecar (the impact frame at the engine's `attack_lands` t_ms, the recoil at `damage_taken`)?
+   - **turn-to-face** — does the actor rotate to face its target/move-direction (proving it is a
+     real 3D actor, not a fixed billboard)?
+   Return per-sub-dim scores + an L7 motion overall; build on the G5 pre-gate numbers (frozen-idle /
+   no-walk-displacement) rather than re-estimating them. Gap to PoE2's mildly-stylized but weighty
+   real-time-3D character motion. (See §⑤ — L7 logs to the `motion_*` scores_db columns, separate
+   from the L1–L6 `visual_*` columns.)
 
 ## ④ Synthesis (this skill, no pixels)
 Merge the six lens JSONs:
@@ -199,15 +302,23 @@ Merge the six lens JSONs:
   Prefer a fix that multiple lenses flagged (it moves multiple dimensions at once).
 
 ## ⑤ Log + regression-track — `scores_db` (surface="visual")
-Every round is one `visual` row (see `qa/scores_db_visual_patch.md` for the additive schema):
+Every round is one `visual` row (see `qa/scores_db_visual_patch.md` for the additive schema). The
+L1–L6 STILL scores go in the `visual_*` columns; the L7 MOTION scores go in the additive `motion_*`
+columns (`motion_overall` 0-10, `motion_dims_json` = the L7 sub-scores, `motion_reel_ref` = the reel
+path/id) + the `milestone` tag (e.g. "M1.0"|"M1.2"). All `motion_*`/`milestone` are NULL on a
+still-only round (empty == today):
 ```python
 from qa.scores_db import add_run, set_canonical_baseline
 add_run(run_id=f"vc-{scene}-r{N}-{sha8}", surface="visual", scorer_model="opus",
-        methodology=f"vc-panel-6lens round={N}", build_sha=sha8,
+        methodology=f"vc-panel-7lens round={N}", build_sha=sha8, milestone="M1.2",
         visual_scene=scene_id, visual_backend="unity-cl", visual_round=N,
         visual_overall=overall, visual_dims_json={ "registration":L1, "occlusion_grounding":L2,
           "scene_light_coherence":L3, "character_integration":L4, "tactical_readability":L5,
           "painterly_vs_reference":L6 },
+        # L7 MOTION (only on a reel round; omit/None on a still-only round):
+        motion_overall=L7_overall, motion_reel_ref=reel_contact_sheet_path,
+        motion_dims_json={ "idle_life":..., "locomotion_weight":..., "attack_arc":...,
+          "hit_react":..., "death":..., "timing_sync":..., "turn_to_face":... },
         visual_pregate=pregate_verdict, visual_blocking="<open CRITICAL/HIGH ids>",
         source_path=render_png, notes="<refs used + caveats>")
 ```
@@ -257,8 +368,11 @@ Filler-first: ONE hero + ONE monster animating well before any roster.
 ## Cross-refs
 - References + per-dimension map: `/Volumes/LEXAR/WorldOS-Unity-spike/refs/INDEX.md`.
 - Render pipeline: `/Volumes/LEXAR/WorldOS-Unity-spike/CLOSED-LOOP-PIPELINE.md` (the CL menu + Scenario step).
-- `qa/visual_pregate.py` (deterministic gates), `qa/visual_regression.py` (worse-vs-baseline),
-  `qa/scores_db.py` (the ledger, now includes `visual` surface + `visual_*` columns).
+- `qa/visual_pregate.py` (deterministic gates G1–G5; G5 = motion-liveness), `qa/motion_reel.py`
+  (build the L7 motion reel contact-sheet + JSON sidecar — MODE A engine-state reel / MODE B
+  timeline reel), `qa/visual_regression.py` (worse-vs-baseline, still + motion arms),
+  `qa/scores_db.py` (the ledger, now includes `visual` surface + `visual_*` + `motion_*` + `milestone`
+  columns).
 - `asset-gen` (the gen pipeline fix_actions drive), the archived Godot dev skill at
   `extensions/renderers/godot/skills/godot-dev/SKILL.md` when explicitly reopened,
   `worldos-decide` (gate big calls at 95%), the engine story/mech QA loop in `worldos-dev` (the

--- a/.claude/skills/visual-critic/SKILL.md
+++ b/.claude/skills/visual-critic/SKILL.md
@@ -202,15 +202,19 @@ its single-lens prompt. Each returns TEXT-only JSON. **A specialist obsessed wit
 it 2-3 points harsher than a generalist — that harshness is the point.** L1–L6 score a STILL; **L7
 (MOTION) scores a REEL** and runs only when a reel was rendered.
 
-> ★ **GROUNDING auto-downgrade (the billboard false-negative fix).** The deterministic G3
-> floor-contact gate is MEASURED truth; an LLM lens guessing "the actor is a pasted sticker with no
-> contact shadow" is a PRIOR. **Rule: if an L2 or L4 lens raises a CRITICAL whose claim CONTRADICTS
-> a deterministic G3 floor-contact PASS (e.g. "floating / no contact shadow / not grounded" when G3
-> says feet-on-floor PASS), auto-DOWNGRADE that defect by one severity (CRITICAL→HIGH→MED) and tag
-> it `downgraded:contradicts-G3-PASS`.** Pass the G3 result into the L2/L4 prompts and tell the lens
-> NOT to claim "floating / ungrounded / no shadow" when G3 PASSed — credit the measured grounding
-> first, and only flag a SUBTLER integration tell (shadow too hard-edged, wrong shadow color, etc.).
-> This is what stops the v2 "billboard = sticker" prior from overriding measured grounding.
+> ★ **GROUNDING auto-DROP (the billboard false-negative fix).** The deterministic G3 floor-contact
+> gate is MEASURED truth; an LLM lens guessing "the actor is a pasted sticker with no contact
+> shadow" is a PRIOR. **Rule: if an L2 or L4 lens raises a defect whose claim CONTRADICTS a
+> deterministic G3 floor-contact PASS (e.g. "floating / no contact shadow / not grounded" when G3
+> says feet-on-floor PASS), DROP that defect entirely BEFORE synthesis — or, if you want to retain
+> a paper trail, cap it to LOW and tag it `dropped:contradicts-G3-PASS`. Do NOT merely demote it one
+> notch (CRITICAL→HIGH): a HIGH still caps `overall` at synthesis (§④), so a one-notch demotion just
+> re-creates the billboard false-negative as a re-render loop.** A G3-contradicted grounding claim
+> must NOT feed the synthesis severity caps at all. Pass the G3 result into the L2/L4 prompts and
+> tell the lens NOT to claim "floating / ungrounded / no shadow" when G3 PASSed — credit the
+> measured grounding first, and only flag a SUBTLER integration tell (shadow too hard-edged, wrong
+> shadow color, etc.), which is a separate (non-dropped) defect on its own merits. This is what stops
+> the v2 "billboard = sticker" prior from overriding measured grounding.
 
 Common preamble (prepend to every lens prompt):
 > You are ONE lens of a harsh visual-critic PANEL for WorldOS. Score ONLY your assigned dimension —
@@ -305,17 +309,19 @@ Merge the six lens JSONs:
 Every round is one `visual` row (see `qa/scores_db_visual_patch.md` for the additive schema). The
 L1–L6 STILL scores go in the `visual_*` columns; the L7 MOTION scores go in the additive `motion_*`
 columns (`motion_overall` 0-10, `motion_dims_json` = the L7 sub-scores, `motion_reel_ref` = the reel
-path/id) + the `milestone` tag (e.g. "M1.0"|"M1.2"). All `motion_*`/`milestone` are NULL on a
-still-only round (empty == today):
+path/id). **`milestone` is an INDEPENDENT grouping tag (e.g. "M1.0"|"M1.2") — set it on EVERY visual
+round, reel or not**, so a milestone's rounds group regardless of whether a reel was scored. Only
+the three `motion_*` columns are NULL/omitted on a still-only round (empty == today):
 ```python
 from qa.scores_db import add_run, set_canonical_baseline
 add_run(run_id=f"vc-{scene}-r{N}-{sha8}", surface="visual", scorer_model="opus",
-        methodology=f"vc-panel-7lens round={N}", build_sha=sha8, milestone="M1.2",
+        methodology=f"vc-panel-7lens round={N}", build_sha=sha8,
+        milestone="M1.2",                       # ALWAYS set — independent of reel availability
         visual_scene=scene_id, visual_backend="unity-cl", visual_round=N,
         visual_overall=overall, visual_dims_json={ "registration":L1, "occlusion_grounding":L2,
           "scene_light_coherence":L3, "character_integration":L4, "tactical_readability":L5,
           "painterly_vs_reference":L6 },
-        # L7 MOTION (only on a reel round; omit/None on a still-only round):
+        # L7 MOTION — these three only on a reel round; omit/None on a still-only round:
         motion_overall=L7_overall, motion_reel_ref=reel_contact_sheet_path,
         motion_dims_json={ "idle_life":..., "locomotion_weight":..., "attack_arc":...,
           "hit_react":..., "death":..., "timing_sync":..., "turn_to_face":... },

--- a/qa/motion_reel.py
+++ b/qa/motion_reel.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+"""Build a MOTION REEL — a contact-sheet PNG + a JSON sidecar — for the visual-critic L7 motion lens.
+
+WHY THIS EXISTS
+---------------
+The visual-critic v2 scored a single STILL. But WorldOS is pivoting characters from flat billboards
+to real-time 3D animated actors, and a still cannot tell you whether the actor is ALIVE: a
+beautiful frozen pose and a beautiful walk both score the same on a still. The L7 MOTION lens (see
+.claude/skills/visual-critic/SKILL.md) and the deterministic G5 motion-liveness pre-gate
+(qa/visual_pregate.py) both score a REEL — an ordered sequence of frames spanning idle / locomotion
+/ attack / hit-react / death. This module assembles that reel into:
+
+  1. a CONTACT-SHEET PNG  — the N frames laid out left-to-right, top-to-bottom in a grid, in order,
+     so one image (cheap to hand to an opus lens) shows the whole motion at a glance; and
+  2. a JSON SIDECAR       — per-frame metadata {frame_idx, label/anim, actor centroid, t_ms, engine
+     event, is_move, the frame's own PNG path} that G5 and the L7 lens read.
+
+TWO MODES
+---------
+* MODE A "engine-state reel" — given a campaign id + a list of N beats, fetch successive combat-
+  surface states from the engine and render each via the existing Unity render path, then assemble.
+  The ENGINE-FETCH and the UNITY-CAPTURE are clearly-marked HOOKS (the real wiring is a TODO; the
+  engine is the SOLE WRITER and Unity is the renderer — this module never writes game state). The
+  reel ASSEMBLY (contact-sheet + sidecar) from the produced PNG list is REAL and tested.
+* MODE B "timeline reel" — given a directory of already-rendered animation frame PNGs (e.g. a
+  Meshy/PixelLab/Unity timeline export), assemble the contact-sheet + sidecar directly. Fully real.
+
+The contact-sheet uses Pillow when available (clean compositing); when Pillow is absent it falls
+back to a pure-stdlib PNG tiler so the reel still assembles in the engine's uv env (which has no
+Pillow). stdlib-first, no engine import, no game-state writes.
+
+USAGE
+-----
+    # MODE B — assemble a reel from a directory of frame PNGs:
+    python qa/motion_reel.py --mode timeline --frames-dir /tmp/walk_frames \
+        --out /tmp/hero_walk_reel.png --label walk --move
+
+    # MODE B — explicit ordered frames with per-frame labels (a JSON manifest):
+    python qa/motion_reel.py --mode timeline --frames @/tmp/frames.json --out /tmp/reel.png
+
+    # MODE A — engine-state reel (interface documented; capture is a TODO hook):
+    python qa/motion_reel.py --mode engine --campaign demo-crypt --beats 6 --out /tmp/beat_reel.png
+
+    # From Python:
+    from motion_reel import build_timeline_reel, build_engine_reel
+    res = build_timeline_reel(["/tmp/f0.png", "/tmp/f1.png"], out_png="/tmp/reel.png",
+                              labels=["idle", "idle"])
+    print(res["contact_sheet"], res["sidecar"])
+
+The sidecar JSON shape (also the `--reel` input qa/visual_pregate.py G5 reads — it accepts either
+this whole object, keyed on `frames`, or a bare list of the frame dicts):
+    {
+      "schema": "worldos.motion-reel.v1",
+      "mode": "timeline" | "engine",
+      "scene": "<scene/campaign id or null>",
+      "contact_sheet": "<path to the assembled grid PNG>",
+      "cols": int, "rows": int, "cell_w": int, "cell_h": int,
+      "frames": [
+        {"frame_idx": 0, "frame": "<png path>", "label": "idle", "is_move": false,
+         "t_ms": 0, "engine_event": null, "centroid_px": [x, y] | null}, ...
+      ]
+    }
+
+Exit codes: 0 = reel built, 2 = nothing to assemble (no frames / unreadable inputs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import sys
+import zlib
+from pathlib import Path
+from typing import Optional
+
+SCHEMA = "worldos.motion-reel.v1"
+
+# Labels that count as a MOVE for the G5 displacement check + the L7 locomotion sub-dim.
+MOVE_LABELS = ("walk", "run", "move", "locomot", "step", "approach", "charge")
+
+
+# ===========================================================================
+# PNG decode / encode — Pillow-first, stdlib fallback (mirrors qa/visual_pregate.py).
+# ===========================================================================
+def _read_rgb(path: str | Path) -> Optional[tuple[bytearray, int, int]]:
+    """Read a PNG into (rgb_bytes, width, height) as packed 8-bit RGB (3 bytes/px). Tries Pillow,
+    else a stdlib PNG decode (8-bit RGB/RGBA, non-interlaced). None if it can't be decoded."""
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        from PIL import Image  # type: ignore
+        im = Image.open(p).convert("RGB")
+        w, h = im.size
+        return bytearray(im.tobytes()), w, h
+    except Exception:
+        pass
+    try:
+        return _stdlib_decode_rgb(p)
+    except Exception:
+        return None
+
+
+def _stdlib_decode_rgb(p: Path) -> tuple[bytearray, int, int]:
+    """Minimal PNG decoder (8-bit RGB/RGBA, no interlace) -> packed RGB. stdlib only."""
+    data = p.read_bytes()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError("not a PNG")
+    off = 8
+    width = height = bit_depth = color_type = 0
+    idat = bytearray()
+    while off < len(data):
+        ln = struct.unpack(">I", data[off:off + 4])[0]
+        ctype = data[off + 4:off + 8]
+        body = data[off + 8:off + 8 + ln]
+        if ctype == b"IHDR":
+            width, height, bit_depth, color_type = (*struct.unpack(">IIBB", body[:10]),)
+        elif ctype == b"IDAT":
+            idat += body
+        elif ctype == b"IEND":
+            break
+        off += 12 + ln
+    if bit_depth != 8 or color_type not in (2, 6):
+        raise ValueError(f"unsupported PNG bit_depth={bit_depth} color_type={color_type}")
+    channels = 4 if color_type == 6 else 3
+    raw = zlib.decompress(bytes(idat))
+    stride = width * channels
+    out = bytearray()
+    prev = bytearray(stride)
+    pos = 0
+    for _ in range(height):
+        ftype = raw[pos]; pos += 1
+        line = bytearray(raw[pos:pos + stride]); pos += stride
+        for i in range(stride):
+            a = line[i - channels] if i >= channels else 0
+            b = prev[i]
+            c = prev[i - channels] if i >= channels else 0
+            x = line[i]
+            if ftype == 1:
+                line[i] = (x + a) & 0xFF
+            elif ftype == 2:
+                line[i] = (x + b) & 0xFF
+            elif ftype == 3:
+                line[i] = (x + ((a + b) >> 1)) & 0xFF
+            elif ftype == 4:
+                pp = a + b - c
+                pa, pb, pc = abs(pp - a), abs(pp - b), abs(pp - c)
+                pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
+                line[i] = (x + pr) & 0xFF
+        out += line
+        prev = line
+    # Strip alpha to packed RGB if needed.
+    if channels == 3:
+        return out, width, height
+    rgb = bytearray(width * height * 3)
+    for px in range(width * height):
+        rgb[px * 3:px * 3 + 3] = out[px * 4:px * 4 + 3]
+    return rgb, width, height
+
+
+def _write_png_rgb(path: str | Path, rgb: bytes, w: int, h: int) -> None:
+    """Write packed 8-bit RGB to a PNG (filter type 0 rows). stdlib only."""
+    stride = w * 3
+    raw = bytearray()
+    for y in range(h):
+        raw.append(0)  # filter: None
+        raw += rgb[y * stride:(y + 1) * stride]
+    comp = zlib.compress(bytes(raw), 6)
+
+    def _chunk(tag: bytes, body: bytes) -> bytes:
+        return (struct.pack(">I", len(body)) + tag + body
+                + struct.pack(">I", zlib.crc32(tag + body) & 0xFFFFFFFF))
+
+    ihdr = struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0)
+    Path(path).write_bytes(
+        b"\x89PNG\r\n\x1a\n" + _chunk(b"IHDR", ihdr) + _chunk(b"IDAT", comp) + _chunk(b"IEND", b"")
+    )
+
+
+def _nearest_resize(src: bytearray, sw: int, sh: int, dw: int, dh: int) -> bytearray:
+    """Nearest-neighbour resize of packed RGB. Cheap + dependency-free; good enough for a contact
+    sheet thumbnail (the lens reads the motion, not pixel-perfect fidelity)."""
+    dst = bytearray(dw * dh * 3)
+    for dy in range(dh):
+        sy = min(sh - 1, dy * sh // dh)
+        for dx in range(dw):
+            sx = min(sw - 1, dx * sw // dw)
+            s = (sy * sw + sx) * 3
+            d = (dy * dw + dx) * 3
+            dst[d:d + 3] = src[s:s + 3]
+    return dst
+
+
+def _centroid(rgb: bytearray, w: int, h: int) -> Optional[list[float]]:
+    """Luminance-weighted bright-mass centroid (x,y) in source px, or None if no bright mass.
+    Records the actor's screen position per frame so G5/L7 can read displacement across a move."""
+    total = 0.0
+    sx = 0.0
+    sy = 0.0
+    for i in range(w * h):
+        r, g, b = rgb[i * 3], rgb[i * 3 + 1], rgb[i * 3 + 2]
+        lum = 0.2126 * r + 0.7152 * g + 0.0722 * b
+        total += lum
+        sx += lum * (i % w)
+        sy += lum * (i // w)
+    if total <= 0:
+        return None
+    return [round(sx / total, 2), round(sy / total, 2)]
+
+
+# ===========================================================================
+# Reel assembly — the REAL, tested core (contact-sheet grid + JSON sidecar).
+# ===========================================================================
+def _grid_dims(n: int) -> tuple[int, int]:
+    """Choose a near-square grid (cols, rows) for n cells (cols >= rows; row-major fill)."""
+    if n <= 0:
+        return 0, 0
+    cols = 1
+    while cols * cols < n:
+        cols += 1
+    rows = (n + cols - 1) // cols
+    return cols, rows
+
+
+def assemble_contact_sheet(
+    frame_paths: list[str | Path],
+    out_png: str | Path,
+    *,
+    cell_max: int = 256,
+    bg: tuple[int, int, int] = (24, 24, 28),
+) -> dict:
+    """Tile the ordered frame PNGs into ONE contact-sheet PNG (row-major, near-square grid).
+
+    Each frame is read, resized to fit a <= cell_max box (aspect-preserved, centered in its cell on
+    a dark bg), and pasted in order. Returns {contact_sheet, cols, rows, cell_w, cell_h, centroids,
+    sizes} — centroids[i] is the per-frame bright-mass centroid in CELL px (used by the sidecar).
+    Raises ValueError if no frame is decodable (the caller maps that to exit 2)."""
+    decoded: list[tuple[bytearray, int, int]] = []
+    for fp in frame_paths:
+        d = _read_rgb(fp)
+        if d is None:
+            raise ValueError(f"motion_reel: cannot decode frame {fp}")
+        decoded.append(d)
+    if not decoded:
+        raise ValueError("motion_reel: no frames to assemble")
+
+    # Cell size = the largest fit-box across all frames, capped at cell_max.
+    cell_w = min(cell_max, max(w for _, w, _ in decoded))
+    cell_h = min(cell_max, max(h for _, _, h in decoded))
+    cols, rows = _grid_dims(len(decoded))
+    sheet_w = cols * cell_w
+    sheet_h = rows * cell_h
+    sheet = bytearray(bytes(bg) * (sheet_w * sheet_h))
+
+    centroids: list[Optional[list[float]]] = []
+    sizes: list[list[int]] = []
+    for idx, (rgb, w, h) in enumerate(decoded):
+        # Fit into the cell, aspect-preserved.
+        scale = min(cell_w / w, cell_h / h, 1.0) if (w and h) else 1.0
+        tw = max(1, int(w * scale))
+        th = max(1, int(h * scale))
+        thumb = _nearest_resize(rgb, w, h, tw, th) if (tw != w or th != h) else rgb
+        sizes.append([tw, th])
+        # Centroid of the thumbnail (cell-px space — the space G5 compares displacement in).
+        centroids.append(_centroid(thumb, tw, th))
+        # Top-left of this cell + centering offset.
+        gx = (idx % cols) * cell_w + (cell_w - tw) // 2
+        gy = (idx // cols) * cell_h + (cell_h - th) // 2
+        for ty in range(th):
+            dst = ((gy + ty) * sheet_w + gx) * 3
+            src = ty * tw * 3
+            sheet[dst:dst + tw * 3] = thumb[src:src + tw * 3]
+
+    _write_png_rgb(out_png, bytes(sheet), sheet_w, sheet_h)
+    return {
+        "contact_sheet": str(out_png),
+        "cols": cols, "rows": rows,
+        "cell_w": cell_w, "cell_h": cell_h,
+        "centroids": centroids,
+        "sizes": sizes,
+    }
+
+
+def _frame_meta(
+    idx: int,
+    frame_path: str,
+    *,
+    label: str,
+    is_move: Optional[bool],
+    t_ms: Optional[int],
+    engine_event: Optional[str],
+    centroid: Optional[list[float]],
+) -> dict:
+    """One sidecar frame record. is_move defaults to True when the label is a move label."""
+    if is_move is None:
+        is_move = any(m in label.lower() for m in MOVE_LABELS)
+    return {
+        "frame_idx": idx,
+        "frame": frame_path,
+        "label": label,
+        "is_move": bool(is_move),
+        "t_ms": t_ms,
+        "engine_event": engine_event,
+        "centroid_px": centroid,
+    }
+
+
+def write_sidecar(sidecar: dict, out_path: str | Path) -> str:
+    Path(out_path).write_text(json.dumps(sidecar, indent=2) + "\n", encoding="utf-8")
+    return str(out_path)
+
+
+# ---------------------------------------------------------------------------
+# MODE B — timeline reel (a directory or explicit list of frame PNGs). Fully real.
+# ---------------------------------------------------------------------------
+def build_timeline_reel(
+    frames: list,
+    out_png: str | Path,
+    *,
+    labels: Optional[list[str]] = None,
+    moves: Optional[list[bool]] = None,
+    t_ms: Optional[list[int]] = None,
+    events: Optional[list[Optional[str]]] = None,
+    scene: Optional[str] = None,
+    cell_max: int = 256,
+) -> dict:
+    """Assemble a reel from an ordered list of frame PNGs (MODE B).
+
+    ``frames`` is either a list of path strings, or a list of dicts
+    ``{"frame"/"path": str, "label"?: str, "is_move"?: bool, "t_ms"?: int, "engine_event"?: str}``.
+    Explicit ``labels``/``moves``/``t_ms``/``events`` lists (when given) override / supply per-frame
+    metadata positionally. Writes the contact-sheet to ``out_png`` and the sidecar to
+    ``out_png`` with a ``.json`` suffix; returns the sidecar dict (with ``contact_sheet`` + ``sidecar``)."""
+    # Normalize frames -> (path, meta-overrides) pairs.
+    norm: list[tuple[str, dict]] = []
+    for i, fr in enumerate(frames):
+        if isinstance(fr, dict):
+            path = fr.get("frame") or fr.get("path")
+            if not path:
+                raise ValueError(f"motion_reel: frame {i} dict has no 'frame'/'path' key")
+            norm.append((str(path), fr))
+        else:
+            norm.append((str(fr), {}))
+    if not norm:
+        raise ValueError("motion_reel: no frames provided")
+
+    paths = [p for p, _ in norm]
+    sheet = assemble_contact_sheet(paths, out_png, cell_max=cell_max)
+
+    frame_records: list[dict] = []
+    for i, (path, meta) in enumerate(norm):
+        label = (labels[i] if labels and i < len(labels) else None) or meta.get("label") or meta.get("anim") or "frame"
+        is_move = (moves[i] if moves and i < len(moves) else None)
+        if is_move is None:
+            is_move = meta.get("is_move")
+        tm = (t_ms[i] if t_ms and i < len(t_ms) else None)
+        if tm is None:
+            tm = meta.get("t_ms")
+        ev = (events[i] if events and i < len(events) else None) or meta.get("engine_event")
+        frame_records.append(_frame_meta(
+            i, path, label=str(label), is_move=is_move, t_ms=tm, engine_event=ev,
+            centroid=sheet["centroids"][i] if i < len(sheet["centroids"]) else None,
+        ))
+
+    sidecar = {
+        "schema": SCHEMA,
+        "mode": "timeline",
+        "scene": scene,
+        "contact_sheet": sheet["contact_sheet"],
+        "cols": sheet["cols"], "rows": sheet["rows"],
+        "cell_w": sheet["cell_w"], "cell_h": sheet["cell_h"],
+        "frames": frame_records,
+    }
+    sidecar_path = str(Path(out_png).with_suffix(".json"))
+    write_sidecar(sidecar, sidecar_path)
+    sidecar["sidecar"] = sidecar_path
+    return sidecar
+
+
+def _frames_from_dir(frames_dir: str | Path) -> list[str]:
+    """All *.png in a directory, sorted by name (the natural frame order for an exported sequence)."""
+    d = Path(frames_dir)
+    return [str(p) for p in sorted(d.glob("*.png"))]
+
+
+# ---------------------------------------------------------------------------
+# MODE A — engine-state reel. Interface documented; capture is a clearly-marked hook.
+# ---------------------------------------------------------------------------
+def fetch_combat_surface_states(campaign_id: str, beats: int) -> list[dict]:
+    """HOOK (TODO): fetch ``beats`` successive combat-surface states for ``campaign_id`` from the
+    engine. The engine is the SOLE WRITER of game state — this is READ-ONLY (it pulls snapshots,
+    never mutates). The real wiring reads the same combat-surface the Unity renderer consumes (the
+    snapshot.json / engine MCP combat-surface state per beat). Returns one state dict per beat.
+
+    Until wired, this returns ``beats`` placeholder state stubs so the interface + the reel-assembly
+    path are exercisable; the assembly itself is what this module guarantees is real + tested."""
+    # TODO(worldos): replace with the real engine read (e.g. snapshot per beat via the engine MCP /
+    # play-state dir). MUST stay read-only — never write game state from the QA/reel side.
+    return [{"campaign_id": campaign_id, "beat": i, "_stub": True} for i in range(beats)]
+
+
+def render_state_via_unity(state: dict, out_png: str | Path) -> Optional[str]:
+    """HOOK (TODO): render ONE combat-surface state to ``out_png`` via the existing Unity render
+    path (the closed-loop pipeline / CoplayDev MCP capture on the GEX44 Unity host — see the
+    gex44-unity-host skill). Returns the PNG path on success, or None if the capture path is not
+    available in this environment (the common case off the GPU box).
+
+    This is intentionally a stub here: wiring the live Unity capture is out of scope for the
+    reel-assembly module (it requires the GPU box + a live editor). The contract is: produce a PNG
+    per state; build_engine_reel then assembles whatever PNGs were produced."""
+    # TODO(worldos): call the Unity capture (manage_camera / CL screenshot) for `state` here.
+    return None
+
+
+def build_engine_reel(
+    campaign_id: str,
+    beats: int,
+    out_png: str | Path,
+    *,
+    cell_max: int = 256,
+    frame_dir: Optional[str | Path] = None,
+    _states: Optional[list[dict]] = None,
+    _renderer=None,
+) -> dict:
+    """Assemble an engine-state reel (MODE A): fetch N combat-surface states, render each via Unity,
+    then assemble the produced PNGs into a contact-sheet + sidecar.
+
+    The ENGINE-FETCH (:func:`fetch_combat_surface_states`) and the UNITY-CAPTURE
+    (:func:`render_state_via_unity`) are HOOKS — the live wiring is a TODO (it needs the GPU box +
+    a running editor + the engine read). What is REAL here is the orchestration + the assembly: when
+    renders ARE produced (live, or supplied via ``frame_dir`` of pre-rendered per-beat PNGs, or via
+    the ``_renderer`` injection in tests), this builds the same contact-sheet + sidecar as MODE B,
+    one frame per beat, labelled ``beat<N>`` and carrying the beat index as t_ms-equivalent ordering.
+
+    Returns the sidecar dict (with ``contact_sheet`` + ``sidecar``), or a dict with
+    ``{"status": "no_render", ...}`` when no frames could be produced (exit 2 at the CLI)."""
+    states = _states if _states is not None else fetch_combat_surface_states(campaign_id, beats)
+    renderer = _renderer or render_state_via_unity
+
+    produced: list[str] = []
+    out_dir = Path(out_png).parent
+    for i, st in enumerate(states):
+        # Prefer a supplied pre-rendered per-beat PNG (frame_dir/beat_<i>.png) if present.
+        png_path: Optional[str] = None
+        if frame_dir is not None:
+            cand = Path(frame_dir) / f"beat_{i}.png"
+            if cand.exists():
+                png_path = str(cand)
+        if png_path is None:
+            tgt = out_dir / f"_engine_beat_{i}.png"
+            png_path = renderer(st, tgt)
+        if png_path and Path(png_path).exists():
+            produced.append(png_path)
+
+    if not produced:
+        return {
+            "schema": SCHEMA, "mode": "engine", "scene": campaign_id,
+            "status": "no_render",
+            "detail": ("no frames were produced — the Unity capture hook returned no PNG and no "
+                       "pre-rendered frame_dir/beat_<i>.png was supplied. Wire render_state_via_unity "
+                       "(GPU box) or pass --frame-dir of per-beat PNGs."),
+            "frames": [],
+        }
+
+    # Assemble exactly like MODE B, with engine-beat labels.
+    labels = [f"beat{i}" for i in range(len(produced))]
+    sidecar = build_timeline_reel(
+        produced, out_png, labels=labels, scene=campaign_id, cell_max=cell_max,
+        # beat ordering doubles as a coarse t_ms so timing-sync has a monotonic axis.
+        t_ms=[i * 1000 for i in range(len(produced))],
+    )
+    sidecar["mode"] = "engine"
+    # Re-write the sidecar with the corrected mode tag.
+    write_sidecar({k: v for k, v in sidecar.items() if k != "sidecar"}, sidecar["sidecar"])
+    return sidecar
+
+
+# ===========================================================================
+# CLI
+# ===========================================================================
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description="Build a motion REEL (contact-sheet + sidecar) for the visual-critic L7 lens")
+    ap.add_argument("--mode", choices=("timeline", "engine"), required=True,
+                    help="timeline = assemble from rendered frame PNGs; engine = fetch+render N beats (capture is a TODO hook)")
+    ap.add_argument("--out", required=True, help="output contact-sheet PNG path (sidecar is <out>.json)")
+    ap.add_argument("--cell-max", type=int, default=256, help="max per-cell thumbnail edge (default 256)")
+    # MODE B
+    ap.add_argument("--frames-dir", help="(timeline) directory of *.png frames, sorted by name")
+    ap.add_argument("--frames", help="(timeline) explicit frames: JSON list of paths/dicts, or @file.json")
+    ap.add_argument("--label", default=None, help="(timeline) apply this label to every frame (e.g. idle/walk/attack)")
+    ap.add_argument("--move", action="store_true", help="(timeline) mark every frame as a MOVE beat (for the G5 displacement check)")
+    ap.add_argument("--scene", default=None, help="scene/campaign id stamped into the sidecar")
+    # MODE A
+    ap.add_argument("--campaign", help="(engine) campaign id to fetch combat-surface states for")
+    ap.add_argument("--beats", type=int, default=4, help="(engine) number of beats to reel (default 4)")
+    ap.add_argument("--frame-dir", help="(engine) directory of pre-rendered per-beat PNGs (beat_<i>.png) to use instead of the live capture hook")
+    args = ap.parse_args(argv)
+
+    if args.mode == "timeline":
+        if args.frames:
+            raw = Path(args.frames[1:]).read_text() if args.frames.startswith("@") else args.frames
+            frames = json.loads(raw)
+        elif args.frames_dir:
+            frames = _frames_from_dir(args.frames_dir)
+        else:
+            print("motion_reel: timeline mode needs --frames-dir or --frames", file=sys.stderr)
+            return 2
+        if not frames:
+            print("motion_reel: no frames found to assemble", file=sys.stderr)
+            return 2
+        labels = [args.label] * len(frames) if args.label else None
+        moves = [True] * len(frames) if args.move else None
+        try:
+            res = build_timeline_reel(frames, args.out, labels=labels, moves=moves,
+                                      scene=args.scene, cell_max=args.cell_max)
+        except ValueError as exc:
+            print(f"motion_reel: {exc}", file=sys.stderr)
+            return 2
+        print(json.dumps({"contact_sheet": res["contact_sheet"], "sidecar": res["sidecar"],
+                          "frames": len(res["frames"]), "cols": res["cols"], "rows": res["rows"]}, indent=2))
+        return 0
+
+    # engine mode
+    if not args.campaign:
+        print("motion_reel: engine mode needs --campaign", file=sys.stderr)
+        return 2
+    res = build_engine_reel(args.campaign, args.beats, args.out,
+                            cell_max=args.cell_max, frame_dir=args.frame_dir)
+    if res.get("status") == "no_render":
+        print(json.dumps(res, indent=2), file=sys.stderr)
+        return 2
+    print(json.dumps({"contact_sheet": res["contact_sheet"], "sidecar": res["sidecar"],
+                      "frames": len(res["frames"]), "mode": res["mode"]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/qa/motion_reel.py
+++ b/qa/motion_reel.py
@@ -68,6 +68,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import struct
 import sys
 import zlib
@@ -130,8 +131,10 @@ def _stdlib_decode_rgb(p: Path) -> tuple[bytearray, int, int]:
     prev = bytearray(stride)
     pos = 0
     for _ in range(height):
-        ftype = raw[pos]; pos += 1
-        line = bytearray(raw[pos:pos + stride]); pos += stride
+        ftype = raw[pos]
+        pos += 1
+        line = bytearray(raw[pos:pos + stride])
+        pos += stride
         for i in range(stride):
             a = line[i - channels] if i >= channels else 0
             b = prev[i]
@@ -378,10 +381,18 @@ def build_timeline_reel(
     return sidecar
 
 
+def _natural_key(name: str) -> list:
+    """Natural-sort key: split on digit runs so '2.png' sorts before '10.png' (a plain string sort
+    would order '10' before '2'). Digit chunks compare as ints, text chunks as lowercase strings."""
+    return [int(tok) if tok.isdigit() else tok.lower()
+            for tok in re.split(r"(\d+)", name) if tok != ""]
+
+
 def _frames_from_dir(frames_dir: str | Path) -> list[str]:
-    """All *.png in a directory, sorted by name (the natural frame order for an exported sequence)."""
+    """All *.png in a directory in NATURAL frame order (so an unpadded export — frame2, frame10 —
+    assembles as 2,10 not 10,2). Sorts by the file name's natural key."""
     d = Path(frames_dir)
-    return [str(p) for p in sorted(d.glob("*.png"))]
+    return [str(p) for p in sorted(d.glob("*.png"), key=lambda p: _natural_key(p.name))]
 
 
 # ---------------------------------------------------------------------------

--- a/qa/scores_db.py
+++ b/qa/scores_db.py
@@ -163,6 +163,16 @@ COLUMNS: tuple[str, ...] = (
     "visual_backend",     # render backend: "unity-cl" | "godot" | "still" (the SKILL's render source)
     "visual_pregate",     # the deterministic pre-gate verdict for this frame: PASS|FLAG|SKIPPED
     "visual_blocking",    # comma-joined CRITICAL/HIGH defect ids still open at this round (NULL = none)
+    # --- L7 MOTION lens (the "PoE2 + motion" recalibration; scored from a render REEL, not a still).
+    # The still-frame quality stays in visual_* above; the MOTION quality lives here so a frozen-but-
+    # pretty render and a moving-but-ugly render are distinguishable. NULL on every still-only row and
+    # on every non-visual row (additive, migration-free; empty == today). ---
+    "motion_overall",     # 0-10 holistic L7 motion score (idle life + locomotion weight + attack arc
+                          # + hit-react + death + timing-sync + turn-to-face), NULL if no reel scored
+    "motion_dims_json",   # JSON {idle_life, locomotion_weight, attack_arc, hit_react, death,
+                          #       timing_sync, turn_to_face} — the L7 sub-scores (auto-JSON-encoded)
+    "motion_reel_ref",    # path/id of the scored motion reel (the qa/motion_reel.py contact-sheet)
+    "milestone",          # coarse art-milestone tag, e.g. "M1.0" | "M1.2" (groups rounds by milestone)
 )
 
 # Numeric columns get REAL; pass is an INTEGER bool; the rest TEXT.
@@ -178,6 +188,8 @@ _REAL_COLS = {
     "engagement_pct",
     # visual-critic loop (0-10 gap-to-reference score → REAL)
     "visual_overall",
+    # L7 motion lens (0-10 holistic motion score → REAL)
+    "motion_overall",
 }
 _INT_COLS = {"critical_bugs", "pass", "is_canonical_baseline", "acts_reached", "visual_round"}
 
@@ -228,9 +240,9 @@ def add_run(
     """Append (or replace) ONE run row in the canonical ledger.
 
     Pass ``run_id`` plus any subset of :data:`COLUMNS` as keyword args. Unknown keys raise
-    (so a typo is caught, not silently dropped). ``per_persona_json`` and ``visual_dims_json``
-    may be passed as dicts and are JSON-encoded automatically. ``surface`` is validated against
-    :data:`SURFACES`. ``ts`` defaults to now (UTC, ISO8601) if omitted.
+    (so a typo is caught, not silently dropped). ``per_persona_json``, ``visual_dims_json``, and
+    ``motion_dims_json`` may be passed as dicts and are JSON-encoded automatically. ``surface`` is
+    validated against :data:`SURFACES`. ``ts`` defaults to now (UTC, ISO8601) if omitted.
     """
     unknown = set(fields) - set(COLUMNS)
     if unknown:
@@ -279,9 +291,9 @@ def add_run(
                     f"another run's ruler, cite its run_id, not its hash)"
                 )
 
-    # JSON-encode structured payloads (per_persona_json and visual_dims_json may be passed as
-    # dicts and are auto-encoded to avoid sqlite3.ProgrammingError on non-string values).
-    for _jcol in ("per_persona_json", "visual_dims_json"):
+    # JSON-encode structured payloads (per_persona_json, visual_dims_json, and motion_dims_json may
+    # be passed as dicts and are auto-encoded to avoid sqlite3.ProgrammingError on non-string values).
+    for _jcol in ("per_persona_json", "visual_dims_json", "motion_dims_json"):
         _jv = fields.get(_jcol)
         if _jv is not None and not isinstance(_jv, str):
             fields[_jcol] = json.dumps(_jv, ensure_ascii=False, sort_keys=True)

--- a/qa/test_motion_reel.py
+++ b/qa/test_motion_reel.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Tests for qa/motion_reel.py — the L7 motion-reel contact-sheet + sidecar builder.
+
+Covers:
+  1. MODE B (timeline) — assemble a reel from a list of frame PNGs: the contact-sheet PNG is
+     written, decodable, and laid out in a near-square grid; the sidecar JSON has one record per
+     frame with the documented shape (frame_idx / label / is_move / centroid_px).
+  2. MODE B from a directory of PNGs (sorted by name).
+  3. is_move inference from a move label (walk -> is_move True; idle -> False).
+  4. The sidecar round-trips into qa/visual_pregate.py G5 (the reel the critic actually consumes).
+  5. MODE A (engine) — orchestration with an INJECTED renderer (the live Unity capture is a TODO
+     hook): produced frames assemble into the same contact-sheet + sidecar with engine-beat labels;
+     no produced frames -> a clean "no_render" status (not a crash).
+
+Run (single-process; NEVER xdist):
+    uv run --directory servers/engine python -m pytest qa/test_motion_reel.py -q -p no:xdist
+
+Pure stdlib PNGs in tmp_path; no Pillow required, no engine import, no game-state writes.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+QA_DIR = Path(__file__).resolve().parent
+if str(QA_DIR) not in sys.path:
+    sys.path.insert(0, str(QA_DIR))
+
+import motion_reel as mr  # noqa: E402
+import visual_pregate as vp  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helper — a tiny valid 8-bit RGB PNG with a bright block at (bx,by) so the centroid moves.
+# ---------------------------------------------------------------------------
+def _chunk(tag: bytes, data: bytes) -> bytes:
+    return (struct.pack(">I", len(data)) + tag + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF))
+
+
+def _png(path: Path, w: int, h: int, *, bright_at: tuple[int, int] | None = None,
+         block: int = 4, base: int = 10) -> Path:
+    """A w×h dark PNG with an optional bright block whose top-left is bright_at (moves the centroid)."""
+    rows = bytearray()
+    for y in range(h):
+        rows.append(0)  # filter None
+        for x in range(w):
+            v = base
+            if bright_at is not None:
+                bx, by = bright_at
+                if bx <= x < bx + block and by <= y < by + block:
+                    v = 240
+            rows += bytes([v, v, v])
+    path.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+        + _chunk(b"IDAT", zlib.compress(bytes(rows), 6))
+        + _chunk(b"IEND", b"")
+    )
+    return path
+
+
+# ---------------------------------------------------------------------------
+# 1. MODE B — assemble from an explicit frame list
+# ---------------------------------------------------------------------------
+class TestTimelineReel:
+    def test_contact_sheet_and_sidecar_built(self, tmp_path):
+        frames = [
+            _png(tmp_path / "f0.png", 16, 16, bright_at=(2, 6)),
+            _png(tmp_path / "f1.png", 16, 16, bright_at=(6, 6)),
+            _png(tmp_path / "f2.png", 16, 16, bright_at=(10, 6)),
+        ]
+        out = tmp_path / "reel.png"
+        res = mr.build_timeline_reel([str(f) for f in frames], out,
+                                     labels=["walk", "walk", "walk"], scene="fixture:tavern")
+        # contact sheet exists + is a decodable PNG
+        assert Path(res["contact_sheet"]).exists()
+        decoded = mr._read_rgb(res["contact_sheet"])
+        assert decoded is not None, "the assembled contact sheet must be a decodable PNG"
+        # sidecar exists + has the documented shape
+        sc = json.loads(Path(res["sidecar"]).read_text())
+        assert sc["schema"] == mr.SCHEMA
+        assert sc["mode"] == "timeline"
+        assert sc["scene"] == "fixture:tavern"
+        assert len(sc["frames"]) == 3
+        f0 = sc["frames"][0]
+        assert f0["frame_idx"] == 0
+        assert f0["label"] == "walk"
+        assert f0["is_move"] is True  # "walk" is a move label
+        assert "centroid_px" in f0
+        # near-square grid for 3 frames -> cols 2, rows 2
+        assert sc["cols"] == 2 and sc["rows"] == 2
+
+    def test_centroid_moves_across_walk_frames(self, tmp_path):
+        """The bright block slides right -> the recorded per-frame centroid x increases."""
+        frames = [
+            _png(tmp_path / "a.png", 32, 16, bright_at=(2, 6)),
+            _png(tmp_path / "b.png", 32, 16, bright_at=(24, 6)),
+        ]
+        out = tmp_path / "reel.png"
+        res = mr.build_timeline_reel([str(f) for f in frames], out, labels=["walk", "walk"])
+        cs = [fr["centroid_px"] for fr in res["frames"]]
+        assert cs[0] is not None and cs[1] is not None
+        assert cs[1][0] > cs[0][0], f"centroid x should increase as the block slides right: {cs}"
+
+    def test_idle_label_is_not_move(self, tmp_path):
+        f = _png(tmp_path / "idle.png", 16, 16, bright_at=(6, 6))
+        out = tmp_path / "reel.png"
+        res = mr.build_timeline_reel([str(f)], out, labels=["idle"])
+        assert res["frames"][0]["is_move"] is False
+
+    def test_frames_from_dir_sorted(self, tmp_path):
+        d = tmp_path / "seq"
+        d.mkdir()
+        _png(d / "frame_02.png", 16, 16, bright_at=(8, 6))
+        _png(d / "frame_00.png", 16, 16, bright_at=(2, 6))
+        _png(d / "frame_01.png", 16, 16, bright_at=(5, 6))
+        paths = mr._frames_from_dir(d)
+        assert [Path(p).name for p in paths] == ["frame_00.png", "frame_01.png", "frame_02.png"]
+
+    def test_no_frames_raises(self, tmp_path):
+        import pytest
+        with pytest.raises(ValueError):
+            mr.build_timeline_reel([], tmp_path / "x.png")
+
+    def test_undecodable_frame_raises(self, tmp_path):
+        bad = tmp_path / "bad.png"
+        bad.write_bytes(b"not a png")
+        import pytest
+        with pytest.raises(ValueError):
+            mr.build_timeline_reel([str(bad)], tmp_path / "x.png")
+
+
+# ---------------------------------------------------------------------------
+# 2. The sidecar feeds qa/visual_pregate.py G5 (the integration the loop relies on)
+# ---------------------------------------------------------------------------
+class TestSidecarFeedsG5:
+    def test_frozen_idle_reel_fires_g5_critical(self, tmp_path):
+        """Two IDENTICAL idle frames -> G5 frozen-idle CRITICAL when fed the reel sidecar."""
+        f0 = _png(tmp_path / "i0.png", 16, 16, bright_at=(6, 6))
+        f1 = _png(tmp_path / "i1.png", 16, 16, bright_at=(6, 6))  # identical
+        out = tmp_path / "reel.png"
+        res = mr.build_timeline_reel([str(f0), str(f1)], out, labels=["idle", "idle"])
+        sidecar = json.loads(Path(res["sidecar"]).read_text())
+        gates = vp.gate_motion_liveness(sidecar["frames"])
+        crit = [g for g in gates if g["severity"] == "CRITICAL"]
+        assert crit, f"identical idle frames should fire G5 frozen-idle CRITICAL; got {gates}"
+
+    def test_moving_idle_reel_passes_g5(self, tmp_path):
+        """Two DIFFERENT idle frames (the idle breathes) -> G5 idle PASS."""
+        f0 = _png(tmp_path / "i0.png", 16, 16, bright_at=(6, 6))
+        f1 = _png(tmp_path / "i1.png", 16, 16, bright_at=(7, 7))  # shifted -> non-zero delta
+        out = tmp_path / "reel.png"
+        res = mr.build_timeline_reel([str(f0), str(f1)], out, labels=["idle", "idle"])
+        sidecar = json.loads(Path(res["sidecar"]).read_text())
+        gates = vp.gate_motion_liveness(sidecar["frames"])
+        assert any(g["severity"] == "PASS" and g["metric"] == "idle_interframe_delta" for g in gates), \
+            f"a breathing idle should PASS G5 idle check; got {gates}"
+
+    def test_static_move_reel_fires_g5_high(self, tmp_path):
+        """Two identical MOVE frames (engine said move, render didn't displace) -> G5 HIGH."""
+        f0 = _png(tmp_path / "m0.png", 16, 16, bright_at=(6, 6))
+        f1 = _png(tmp_path / "m1.png", 16, 16, bright_at=(6, 6))  # identical -> no centroid shift
+        out = tmp_path / "reel.png"
+        res = mr.build_timeline_reel([str(f0), str(f1)], out, labels=["walk", "walk"], moves=[True, True])
+        sidecar = json.loads(Path(res["sidecar"]).read_text())
+        gates = vp.gate_motion_liveness(sidecar["frames"])
+        high = [g for g in gates if g["severity"] == "HIGH" and g["metric"] == "move_centroid_px"]
+        assert high, f"a non-displacing MOVE should fire G5 HIGH; got {gates}"
+
+
+# ---------------------------------------------------------------------------
+# 3. MODE A — engine reel orchestration with an injected renderer (capture is a TODO hook)
+# ---------------------------------------------------------------------------
+class TestEngineReel:
+    def test_engine_reel_with_injected_renderer(self, tmp_path):
+        """MODE A assembles the same contact-sheet + sidecar when a renderer produces per-beat PNGs."""
+        produced_dir = tmp_path / "renders"
+        produced_dir.mkdir()
+
+        def fake_renderer(state, out_png):
+            # one bright block sliding right per beat -> a believable engine reel
+            beat = state["beat"]
+            return str(_png(Path(out_png), 24, 16, bright_at=(2 + beat * 4, 6)))
+
+        res = mr.build_engine_reel("demo-crypt", 3, tmp_path / "engine_reel.png",
+                                   _renderer=fake_renderer)
+        assert res["mode"] == "engine"
+        assert res["scene"] == "demo-crypt"
+        assert Path(res["contact_sheet"]).exists()
+        sc = json.loads(Path(res["sidecar"]).read_text())
+        assert sc["mode"] == "engine"
+        assert len(sc["frames"]) == 3
+        assert [f["label"] for f in sc["frames"]] == ["beat0", "beat1", "beat2"]
+
+    def test_engine_reel_no_render_status(self, tmp_path):
+        """With the default stub renderer (returns None) and no frame_dir -> clean no_render status."""
+        res = mr.build_engine_reel("demo-crypt", 2, tmp_path / "reel.png")
+        assert res.get("status") == "no_render"
+        assert res["frames"] == []
+
+    def test_engine_reel_uses_prerendered_frame_dir(self, tmp_path):
+        """A directory of beat_<i>.png is used in place of the live capture hook."""
+        fdir = tmp_path / "beats"
+        fdir.mkdir()
+        _png(fdir / "beat_0.png", 16, 16, bright_at=(2, 6))
+        _png(fdir / "beat_1.png", 16, 16, bright_at=(8, 6))
+        res = mr.build_engine_reel("c1", 2, tmp_path / "reel.png", frame_dir=fdir)
+        assert res["mode"] == "engine"
+        assert len(res["frames"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# 4. CLI smoke (MODE B) — proves the __main__ path assembles end-to-end
+# ---------------------------------------------------------------------------
+class TestCli:
+    def test_cli_timeline_from_dir(self, tmp_path, capsys):
+        d = tmp_path / "seq"
+        d.mkdir()
+        _png(d / "0.png", 16, 16, bright_at=(2, 6))
+        _png(d / "1.png", 16, 16, bright_at=(8, 6))
+        out = tmp_path / "reel.png"
+        rc = mr.main(["--mode", "timeline", "--frames-dir", str(d), "--out", str(out), "--label", "walk", "--move"])
+        assert rc == 0
+        assert out.exists()
+        assert (tmp_path / "reel.json").exists()
+
+    def test_cli_timeline_missing_input_returns_2(self, tmp_path):
+        rc = mr.main(["--mode", "timeline", "--out", str(tmp_path / "x.png")])
+        assert rc == 2

--- a/qa/test_motion_reel.py
+++ b/qa/test_motion_reel.py
@@ -44,7 +44,7 @@ def _chunk(tag: bytes, data: bytes) -> bytes:
 
 def _png(path: Path, w: int, h: int, *, bright_at: tuple[int, int] | None = None,
          block: int = 4, base: int = 10) -> Path:
-    """A w×h dark PNG with an optional bright block whose top-left is bright_at (moves the centroid)."""
+    """A w x h dark PNG with an optional bright block whose top-left is bright_at (moves the centroid)."""
     rows = bytearray()
     for y in range(h):
         rows.append(0)  # filter None
@@ -124,14 +124,14 @@ class TestTimelineReel:
 
     def test_no_frames_raises(self, tmp_path):
         import pytest
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="no frames provided"):
             mr.build_timeline_reel([], tmp_path / "x.png")
 
     def test_undecodable_frame_raises(self, tmp_path):
         bad = tmp_path / "bad.png"
         bad.write_bytes(b"not a png")
         import pytest
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="cannot decode frame"):
             mr.build_timeline_reel([str(bad)], tmp_path / "x.png")
 
 
@@ -187,8 +187,11 @@ class TestEngineReel:
             beat = state["beat"]
             return str(_png(Path(out_png), 24, 16, bright_at=(2 + beat * 4, 6)))
 
+        # Inject explicit states so the test does not depend on the default fetch hook (which is a
+        # TODO stub) — fake_renderer is then fully deterministic over these beats.
+        states = [{"beat": 0}, {"beat": 1}, {"beat": 2}]
         res = mr.build_engine_reel("demo-crypt", 3, tmp_path / "engine_reel.png",
-                                   _renderer=fake_renderer)
+                                   _states=states, _renderer=fake_renderer)
         assert res["mode"] == "engine"
         assert res["scene"] == "demo-crypt"
         assert Path(res["contact_sheet"]).exists()

--- a/qa/test_scores_db.py
+++ b/qa/test_scores_db.py
@@ -674,3 +674,63 @@ def test_render_includes_1b_timing_columns(tmp_path):
     assert "slowest tool" in md
     assert "scene_context" in md
     assert "3%" in md                      # tool_exec_pct rendered as a percentage
+
+
+# --- L7 MOTION columns (the "PoE2 + motion" recalibration: motion_overall / motion_dims_json /
+#     motion_reel_ref / milestone) ---
+
+def test_motion_columns_registered_with_right_types():
+    """The four motion columns exist; motion_overall is REAL, the rest are TEXT."""
+    for col in ("motion_overall", "motion_dims_json", "motion_reel_ref", "milestone"):
+        assert col in scores_db.COLUMNS, f"{col} missing from COLUMNS"
+    assert scores_db._coltype("motion_overall") == "REAL"
+    assert scores_db._coltype("motion_dims_json") == "TEXT"
+    assert scores_db._coltype("motion_reel_ref") == "TEXT"
+    assert scores_db._coltype("milestone") == "TEXT"
+
+
+def test_motion_columns_roundtrip_with_dict_dims(tmp_path):
+    """add_run accepts motion fields; motion_dims_json may be a dict and is auto-JSON-encoded."""
+    db = tmp_path / "t.db"
+    dims = {"idle_life": 7, "locomotion_weight": 6, "attack_arc": 8, "hit_react": 5,
+            "death": 6, "timing_sync": 7, "turn_to_face": 9}
+    scores_db.add_run(
+        "vc-tavern-r3", db_path=db, surface="visual", scorer_model="opus",
+        visual_scene="fixture:tavern", visual_backend="unity-cl", visual_round=3,
+        visual_overall=7.6, motion_overall=6.8, motion_dims_json=dims,
+        motion_reel_ref="/tmp/tavern_reel.png", milestone="M1.2",
+    )
+    row = scores_db.fetch_rows(db)[0]
+    assert row["motion_overall"] == 6.8
+    assert json.loads(row["motion_dims_json"]) == dims
+    assert row["motion_reel_ref"] == "/tmp/tavern_reel.png"
+    assert row["milestone"] == "M1.2"
+
+
+def test_motion_columns_read_null_on_still_only_row(tmp_path):
+    """ADDITIVITY: a still-only visual row (no motion fields) reads back NULL for all four — and an
+    old non-visual row is likewise unaffected (empty == today)."""
+    db = tmp_path / "t.db"
+    scores_db.add_run("vc-still", db_path=db, surface="visual", visual_overall=7.0,
+                      visual_scene="fixture:tavern", visual_backend="unity-cl")
+    row = scores_db.fetch_rows(db)[0]
+    for col in ("motion_overall", "motion_dims_json", "motion_reel_ref", "milestone"):
+        assert row[col] is None, f"{col} should read NULL on a still-only row"
+
+
+def test_motion_columns_alter_into_an_old_db(tmp_path):
+    """A db created before the motion columns gets all four ALTER-added on connect (migration-free)."""
+    db = tmp_path / "old.db"
+    conn = sqlite3.connect(db)
+    conn.execute('CREATE TABLE runs ("run_id" TEXT PRIMARY KEY, "surface" TEXT, "visual_overall" REAL)')
+    conn.execute('INSERT INTO runs ("run_id","surface","visual_overall") VALUES (?,?,?)',
+                 ("legacy-visual", "visual", 6.5))
+    conn.commit()
+    conn.close()
+    rows = scores_db.fetch_rows(db)  # connect() ALTERs in the new columns
+    cols = set(rows[0].keys())
+    assert {"motion_overall", "motion_dims_json", "motion_reel_ref", "milestone"} <= cols
+    legacy = {r["run_id"]: r for r in rows}["legacy-visual"]
+    # the pre-existing row reads NULL for the new columns + keeps its old value
+    assert legacy["visual_overall"] == 6.5
+    assert legacy["motion_overall"] is None

--- a/qa/test_scores_db.py
+++ b/qa/test_scores_db.py
@@ -694,16 +694,17 @@ def test_motion_columns_roundtrip_with_dict_dims(tmp_path):
     db = tmp_path / "t.db"
     dims = {"idle_life": 7, "locomotion_weight": 6, "attack_arc": 8, "hit_react": 5,
             "death": 6, "timing_sync": 7, "turn_to_face": 9}
+    reel_ref = str(tmp_path / "tavern_reel.png")  # a stored ref-string (never opened); use tmp_path
     scores_db.add_run(
         "vc-tavern-r3", db_path=db, surface="visual", scorer_model="opus",
         visual_scene="fixture:tavern", visual_backend="unity-cl", visual_round=3,
         visual_overall=7.6, motion_overall=6.8, motion_dims_json=dims,
-        motion_reel_ref="/tmp/tavern_reel.png", milestone="M1.2",
+        motion_reel_ref=reel_ref, milestone="M1.2",
     )
     row = scores_db.fetch_rows(db)[0]
     assert row["motion_overall"] == 6.8
     assert json.loads(row["motion_dims_json"]) == dims
-    assert row["motion_reel_ref"] == "/tmp/tavern_reel.png"
+    assert row["motion_reel_ref"] == reel_ref
     assert row["milestone"] == "M1.2"
 
 
@@ -731,6 +732,7 @@ def test_motion_columns_alter_into_an_old_db(tmp_path):
     cols = set(rows[0].keys())
     assert {"motion_overall", "motion_dims_json", "motion_reel_ref", "milestone"} <= cols
     legacy = {r["run_id"]: r for r in rows}["legacy-visual"]
-    # the pre-existing row reads NULL for the new columns + keeps its old value
+    # the pre-existing row reads NULL for ALL four new columns + keeps its old value
     assert legacy["visual_overall"] == 6.5
-    assert legacy["motion_overall"] is None
+    for col in ("motion_overall", "motion_dims_json", "motion_reel_ref", "milestone"):
+        assert legacy[col] is None, f"{col} should read NULL on a pre-migration row after _ensure_schema()"

--- a/qa/test_visual_critic.py
+++ b/qa/test_visual_critic.py
@@ -382,6 +382,96 @@ class TestRunPregates:
         res = vp.run_pregates(str(tmp_path / "missing.png"))
         assert res["verdict"] == "SKIPPED"
 
+    def test_no_reel_g5_skips_still_only_round_unchanged(self, tmp_path):
+        """ADDITIVITY: a still-only round (no reel) leaves G5 SKIPPED — empty == today."""
+        # A lit, varied frame so G1 PASSes; no scenegrid, no reel.
+        p = tmp_path / "lit.png"
+        rows = bytearray()
+        for row_i in range(16):
+            rows.append(0)
+            val = 60 if (row_i % 2) == 0 else 200
+            for _ in range(16):
+                rows += bytes([val, val, val])
+        p.write_bytes(
+            b"\x89PNG\r\n\x1a\n"
+            + _chunk(b"IHDR", struct.pack(">IIBBBBB", 16, 16, 8, 2, 0, 0, 0))
+            + _chunk(b"IDAT", zlib.compress(bytes(rows), 9))
+            + _chunk(b"IEND", b"")
+        )
+        res = vp.run_pregates(str(p))  # no reel kwarg
+        g5 = [g for g in res["gates"] if g["gate"] == "G5_motion_liveness"]
+        assert g5 and g5[0]["severity"] == "SKIPPED", f"G5 must SKIP with no reel; got {g5}"
+        assert res["verdict"] in ("PASS", "SKIPPED")  # the still round is unchanged
+
+
+# ---------------------------------------------------------------------------
+# 5b. G5 MOTION-LIVENESS — frozen-idle CRITICAL + no-displacement HIGH on synthetic reels
+# ---------------------------------------------------------------------------
+
+class TestG5MotionLiveness:
+    def _reel(self, tmp_path, specs: list[tuple[str, tuple[int, int], bool]]) -> list[dict]:
+        """specs: list of (label, bright_top_left, is_move). Writes PNGs + returns reel frame dicts."""
+        frames = []
+        for i, (label, (bx, by), is_move) in enumerate(specs):
+            p = tmp_path / f"r{i}.png"
+            rows = bytearray()
+            for y in range(16):
+                rows.append(0)
+                for x in range(16):
+                    v = 240 if (bx <= x < bx + 4 and by <= y < by + 4) else 10
+                    rows += bytes([v, v, v])
+            p.write_bytes(
+                b"\x89PNG\r\n\x1a\n"
+                + _chunk(b"IHDR", struct.pack(">IIBBBBB", 16, 16, 8, 2, 0, 0, 0))
+                + _chunk(b"IDAT", zlib.compress(bytes(rows), 9))
+                + _chunk(b"IEND", b"")
+            )
+            frames.append({"frame": str(p), "label": label, "is_move": is_move})
+        return frames
+
+    def test_no_reel_skipped(self):
+        gates = vp.gate_motion_liveness(None)
+        assert any(g["severity"] == "SKIPPED" for g in gates)
+
+    def test_frozen_idle_critical(self, tmp_path):
+        """Two identical idle frames → frozen-idle CRITICAL."""
+        reel = self._reel(tmp_path, [("idle", (6, 6), False), ("idle", (6, 6), False)])
+        gates = vp.gate_motion_liveness(reel)
+        crit = [g for g in gates if g["severity"] == "CRITICAL"]
+        assert crit, f"identical idle frames should fire CRITICAL; got {gates}"
+        assert "frozen" in crit[0]["detail"].lower()
+
+    def test_breathing_idle_passes(self, tmp_path):
+        """Two differing idle frames → idle PASS (the idle is alive)."""
+        reel = self._reel(tmp_path, [("idle", (6, 6), False), ("idle", (7, 7), False)])
+        gates = vp.gate_motion_liveness(reel)
+        assert any(g["severity"] == "PASS" and g["metric"] == "idle_interframe_delta" for g in gates), \
+            f"a moving idle should PASS; got {gates}"
+
+    def test_static_move_high(self, tmp_path):
+        """A MOVE beat whose centroid does not displace → HIGH (slide/teleport)."""
+        reel = self._reel(tmp_path, [("walk", (6, 6), True), ("walk", (6, 6), True)])
+        gates = vp.gate_motion_liveness(reel)
+        high = [g for g in gates if g["severity"] == "HIGH" and g["metric"] == "move_centroid_px"]
+        assert high, f"a non-displacing move should be HIGH; got {gates}"
+
+    def test_real_move_passes(self, tmp_path):
+        """A MOVE beat that displaces the centroid >= threshold → move PASS."""
+        reel = self._reel(tmp_path, [("walk", (1, 6), True), ("walk", (11, 6), True)])
+        gates = vp.gate_motion_liveness(reel)
+        assert any(g["severity"] == "PASS" and g["metric"] == "move_centroid_px" for g in gates), \
+            f"a displacing move should PASS; got {gates}"
+
+    def test_run_pregates_frozen_idle_flags(self, tmp_path):
+        """End-to-end: a frozen-idle reel makes run_pregates verdict FLAG."""
+        # G1 needs a real render png too (use a lit one).
+        lit = _write_png(tmp_path, "lit.png", 120, 120, 120, w=16, h=16)
+        reel = self._reel(tmp_path, [("idle", (6, 6), False), ("idle", (6, 6), False)])
+        res = vp.run_pregates(str(lit), reel=reel)
+        assert res["verdict"] == "FLAG", f"frozen idle reel should FLAG; got {res['verdict']}"
+        assert any(g["gate"] == "G5_motion_liveness" and g["severity"] == "CRITICAL"
+                   for g in res["gates"])
+
 
 # ---------------------------------------------------------------------------
 # 6. visual_regression.detect_visual_regression — verdict logic (no DB, stub rows)
@@ -486,3 +576,37 @@ class TestDetectVisualRegression:
         assert res["verdict"] in ("WITHIN_NOISE", "IMPROVED"), (
             f"Same pre-existing blocking should not trigger REGRESSED; got {res['verdict']}: {res}"
         )
+
+    # --- L7 motion-regression arm (mirrors the still arm; motion_overall drop > 0.7) ---
+
+    def test_motion_overall_regression(self):
+        """A motion_overall drop >0.7 → REGRESSED even when the still overall holds."""
+        dims = {"registration": 7}
+        base = self._baseline(7.5, dims)
+        base["motion_overall"] = 8.0
+        cand = self._candidate(7.5, dims)   # still overall flat
+        cand["motion_overall"] = 6.5        # motion drops 1.5 > 0.7
+        res = self._run(cand, base)
+        assert res["verdict"] == "REGRESSED", f"motion drop should REGRESS; got {res['verdict']}: {res}"
+        assert res["motion_overall"]["classification"] == "REGRESSED"
+
+    def test_motion_overall_within_noise(self):
+        """A motion_overall drop ≤0.7 with no still regression → WITHIN_NOISE."""
+        dims = {"registration": 7}
+        base = self._baseline(7.5, dims)
+        base["motion_overall"] = 8.0
+        cand = self._candidate(7.5, dims)
+        cand["motion_overall"] = 7.5        # -0.5, within the 0.7 floor
+        res = self._run(cand, base)
+        assert res["verdict"] == "WITHIN_NOISE", f"got {res['verdict']}: {res}"
+        assert res["motion_overall"]["classification"] == "WITHIN_NOISE"
+
+    def test_motion_no_data_when_still_only(self):
+        """ADDITIVITY: a still-only candidate/baseline (no motion_overall) leaves motion NO_DATA and
+        never falsely flags — the still arm is unchanged."""
+        dims = {"registration": 7}
+        base = self._baseline(7.5, dims)
+        cand = self._candidate(7.5, dims)   # neither carries motion_overall
+        res = self._run(cand, base)
+        assert res["motion_overall"]["classification"] == "NO_DATA"
+        assert res["verdict"] in ("WITHIN_NOISE", "IMPROVED")  # unaffected by motion arm

--- a/qa/test_visual_critic.py
+++ b/qa/test_visual_critic.py
@@ -401,7 +401,10 @@ class TestRunPregates:
         res = vp.run_pregates(str(p))  # no reel kwarg
         g5 = [g for g in res["gates"] if g["gate"] == "G5_motion_liveness"]
         assert g5 and g5[0]["severity"] == "SKIPPED", f"G5 must SKIP with no reel; got {g5}"
-        assert res["verdict"] in ("PASS", "SKIPPED")  # the still round is unchanged
+        # G1 PASSes on this lit/varied frame, so the overall verdict is deterministically PASS — the
+        # still round is unchanged by G5 being SKIPPED (additivity: empty reel == today's behavior).
+        assert res["verdict"] == "PASS", f"a lit still-only round should PASS; got {res['verdict']}"
+        assert any(g["gate"] == "G1_frame_lit" and g["severity"] == "PASS" for g in res["gates"])
 
 
 # ---------------------------------------------------------------------------
@@ -606,7 +609,9 @@ class TestDetectVisualRegression:
         never falsely flags — the still arm is unchanged."""
         dims = {"registration": 7}
         base = self._baseline(7.5, dims)
-        cand = self._candidate(7.5, dims)   # neither carries motion_overall
+        cand = self._candidate(7.5, dims)   # identical still metrics; neither carries motion_overall
         res = self._run(cand, base)
         assert res["motion_overall"]["classification"] == "NO_DATA"
-        assert res["verdict"] in ("WITHIN_NOISE", "IMPROVED")  # unaffected by motion arm
+        # identical still overall + dims => no regression AND no improvement => deterministically
+        # WITHIN_NOISE (the motion arm contributes nothing when both rows lack motion_overall).
+        assert res["verdict"] == "WITHIN_NOISE", f"identical still metrics should be WITHIN_NOISE; got {res['verdict']}"

--- a/qa/visual_pregate.py
+++ b/qa/visual_pregate.py
@@ -273,8 +273,10 @@ def _stdlib_png_lum(p: Path) -> tuple[float, float]:
     prev = bytearray(stride)
     pos = 0
     for _ in range(height):
-        ftype = raw[pos]; pos += 1
-        line = bytearray(raw[pos:pos + stride]); pos += stride
+        ftype = raw[pos]
+        pos += 1
+        line = bytearray(raw[pos:pos + stride])
+        pos += stride
         for i in range(stride):
             a = line[i - channels] if i >= channels else 0
             b = prev[i]
@@ -532,8 +534,10 @@ def _stdlib_png_lum_grid(p: Path, target: int) -> tuple[list[float], int, int]:
     prev = bytearray(stride)
     pos = 0
     for _ in range(height):
-        ftype = raw[pos]; pos += 1
-        line = bytearray(raw[pos:pos + stride]); pos += stride
+        ftype = raw[pos]
+        pos += 1
+        line = bytearray(raw[pos:pos + stride])
+        pos += stride
         for i in range(stride):
             a = line[i - channels] if i >= channels else 0
             b = prev[i]
@@ -572,7 +576,8 @@ def _mean_abs_delta(a: list[float], b: list[float]) -> Optional[float]:
     grids differ in length (mismatched frame sizes — can't compare)."""
     if not a or not b or len(a) != len(b):
         return None
-    return sum(abs(x - y) for x, y in zip(a, b)) / len(a)
+    # lengths are guaranteed equal here (guarded above) -> strict=True is safe + correct.
+    return sum(abs(x - y) for x, y in zip(a, b, strict=True)) / len(a)
 
 
 def _bright_centroid(vals: list[float], w: int, h: int) -> Optional[tuple[float, float]]:
@@ -649,29 +654,39 @@ def gate_motion_liveness(reel: Optional[list[dict]]) -> list[dict]:
                               "detail": f"idle is alive (mean inter-frame delta {mean_delta:.6f} >= {FROZEN_IDLE_DELTA})"})
 
     # --- NO LOCOMOTION DISPLACEMENT: a MOVE beat must shift the bright-mass centroid. ---
-    # A frame is a MOVE if is_move is truthy OR its label is in the move set. We compare the FIRST
-    # and LAST move frame's centroids (the net displacement of the move beat).
+    # A frame is a MOVE if is_move is truthy OR its label is in the move set. We use the centroid
+    # SPREAD — the MAX pairwise displacement across ALL move frames — NOT just first-vs-last net
+    # displacement. A valid out-and-back move (A->B->A) nets ~0 first-vs-last but clearly travels;
+    # spread captures that the actor reached B. Only frames whose grid size matches the first move
+    # frame's are compared (the frame-size guard); centroid-less frames (no bright mass) are skipped.
     moves = [(g, fr) for g, fr in decoded
              if fr.get("is_move") or any(m in _label(fr) for m in _MOVE_LABELS)]
     if len(moves) >= 2:
-        (ga, wa, ha), _ = moves[0][0], moves[0][1]
-        (gb, wb, hb) = moves[-1][0]
-        ca = _bright_centroid(ga, wa, ha)
-        cb = _bright_centroid(gb, wb, hb)
-        if ca is not None and cb is not None and (wa, ha) == (wb, hb):
-            disp = math.hypot(cb[0] - ca[0], cb[1] - ca[1])
+        (g0, w0, h0) = moves[0][0]
+        centroids: list[tuple[float, float]] = []
+        for (gi, wi, hi), _ in moves:
+            if (wi, hi) != (w0, h0):
+                continue  # frame-size guard: only compare same-size frames
+            ci = _bright_centroid(gi, wi, hi)
+            if ci is not None:
+                centroids.append((ci[0], ci[1]))
+        if len(centroids) >= 2:
+            # Max pairwise displacement (spread). Cheap O(n^2) — reels are short (a handful of frames).
+            disp = max(math.hypot(cx2 - cx1, cy2 - cy1)
+                       for i, (cx1, cy1) in enumerate(centroids)
+                       for (cx2, cy2) in centroids[i + 1:])
             if disp < MOVE_CENTROID_MIN_PX:
                 gates.append({"gate": "G5_motion_liveness", "severity": "HIGH",
                               "metric": "move_centroid_px", "value": round(disp, 3),
                               "threshold": MOVE_CENTROID_MIN_PX,
-                              "detail": (f"a MOVE beat displaced the bright-mass centroid only {disp:.2f}px "
+                              "detail": (f"a MOVE beat's bright-mass centroid spread only {disp:.2f}px "
                                          f"(< {MOVE_CENTROID_MIN_PX}px) across {len(moves)} move frames — the "
                                          "actor slides/teleports without locomotion; check the walk cycle / root motion")})
             else:
                 gates.append({"gate": "G5_motion_liveness", "severity": "PASS",
                               "metric": "move_centroid_px", "value": round(disp, 3),
                               "threshold": MOVE_CENTROID_MIN_PX,
-                              "detail": f"move beat displaced the actor {disp:.2f}px (>= {MOVE_CENTROID_MIN_PX}px)"})
+                              "detail": f"move beat displaced the actor {disp:.2f}px (>= {MOVE_CENTROID_MIN_PX}px, max spread)"})
 
     if not gates:
         gates.append({"gate": "G5_motion_liveness", "severity": "SKIPPED", "metric": "beats",

--- a/qa/visual_pregate.py
+++ b/qa/visual_pregate.py
@@ -91,6 +91,14 @@ SCALE_REL_HIGH = 0.32         # ... over this => HIGH (clearly a different scale
 # G2 occupancy
 OCC_MISMATCH_MED = 0.10       # >10% of cells whose rendered tint disagrees with the mask => MED
 OCC_MISMATCH_HIGH = 0.22      # >22% => HIGH (tactical space is unreadable)
+# G5 motion-liveness (objective inter-frame deltas over a render REEL; 0..1 normalized luminance).
+# A FROZEN idle (no inter-frame change across the idle frames) is the #1 "static billboard, not a
+# living 3D actor" tell — now a number. A MOVE that produces no walk-centroid displacement is an
+# actor sliding/teleporting without locomotion.
+FROZEN_IDLE_DELTA = 0.0005    # mean abs inter-frame luminance delta below this over the idle frames
+                              # => CRITICAL "frozen idle" (the reel is static; nothing is animating)
+MOVE_CENTROID_MIN_PX = 2.0    # a beat tagged as a MOVE must shift the bright-mass centroid at least
+                              # this many px between its frames; below => HIGH "no locomotion displacement"
 
 
 # ---------------------------------------------------------------------------
@@ -459,6 +467,221 @@ def gate_occupancy(scenegrid: SceneGrid, occupancy_tint: Optional[dict]) -> list
 
 
 # ---------------------------------------------------------------------------
+# G5 motion-liveness — objective inter-frame deltas over a render REEL.
+# ---------------------------------------------------------------------------
+# G5 is the motion analogue of G1: instead of "is ONE frame lit?", it asks "does the REEL actually
+# MOVE?" It reads a small downscaled luminance grid from each reel frame (Pillow if present, else a
+# stdlib PNG decode — same graceful degradation as G1) and computes two objective signals:
+#   * mean abs inter-frame luminance delta over the IDLE frames -> a FROZEN idle is CRITICAL.
+#   * bright-mass centroid displacement over a frame-pair tagged as a MOVE -> no shift is HIGH.
+# When no reel is supplied (the common still-only round), G5 SKIPS — additive, empty == today.
+
+# Downscale target for the per-frame luminance grid (cheap; matches G1's 128px thumbnail budget).
+_G5_GRID = 64
+
+
+def _lum_grid(png_path: str | Path) -> Optional[tuple[list[float], int, int]]:
+    """Return (luminance[], width, height) of a downscaled (<= _G5_GRID) luminance grid in 0..1,
+    or None if the PNG can't be decoded. Tries Pillow (fast), else reuses the stdlib PNG decoder.
+    Used by G5 for inter-frame delta + centroid math (G1 only needs the scalar stats)."""
+    p = Path(png_path)
+    if not p.exists():
+        return None
+    try:
+        from PIL import Image  # type: ignore
+        im = Image.open(p).convert("L")
+        im.thumbnail((_G5_GRID, _G5_GRID))
+        w, h = im.size
+        vals = [v / 255.0 for v in im.tobytes()]
+        return vals, w, h
+    except Exception:
+        pass
+    # stdlib fallback: decode the full PNG, then box-sample down to a coarse grid.
+    try:
+        return _stdlib_png_lum_grid(p, _G5_GRID)
+    except Exception:
+        return None
+
+
+def _stdlib_png_lum_grid(p: Path, target: int) -> tuple[list[float], int, int]:
+    """Minimal PNG decode (8-bit RGB/RGBA, no interlace) -> a <=target luminance grid. stdlib only.
+    Nearest-sample downscale (cheap + deterministic); good enough for delta/centroid signals."""
+    data = p.read_bytes()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError("not a PNG")
+    off = 8
+    width = height = bit_depth = color_type = 0
+    idat = bytearray()
+    while off < len(data):
+        ln = struct.unpack(">I", data[off:off + 4])[0]
+        ctype = data[off + 4:off + 8]
+        body = data[off + 8:off + 8 + ln]
+        if ctype == b"IHDR":
+            width, height, bit_depth, color_type = (*struct.unpack(">IIBB", body[:10]),)
+        elif ctype == b"IDAT":
+            idat += body
+        elif ctype == b"IEND":
+            break
+        off += 12 + ln
+    if bit_depth != 8 or color_type not in (2, 6):
+        raise ValueError(f"unsupported PNG bit_depth={bit_depth} color_type={color_type}")
+    channels = 4 if color_type == 6 else 3
+    raw = zlib.decompress(bytes(idat))
+    stride = width * channels
+    out = bytearray()
+    prev = bytearray(stride)
+    pos = 0
+    for _ in range(height):
+        ftype = raw[pos]; pos += 1
+        line = bytearray(raw[pos:pos + stride]); pos += stride
+        for i in range(stride):
+            a = line[i - channels] if i >= channels else 0
+            b = prev[i]
+            c = prev[i - channels] if i >= channels else 0
+            x = line[i]
+            if ftype == 1:
+                line[i] = (x + a) & 0xFF
+            elif ftype == 2:
+                line[i] = (x + b) & 0xFF
+            elif ftype == 3:
+                line[i] = (x + ((a + b) >> 1)) & 0xFF
+            elif ftype == 4:
+                pp = a + b - c
+                pa, pb, pc = abs(pp - a), abs(pp - b), abs(pp - c)
+                pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
+                line[i] = (x + pr) & 0xFF
+        out += line
+        prev = line
+    # Nearest-sample downscale to <= target on the long edge.
+    scale = max(1, max(width, height) // target)
+    gw = max(1, width // scale)
+    gh = max(1, height // scale)
+    vals: list[float] = []
+    for gy in range(gh):
+        sy = min(height - 1, gy * scale)
+        for gx in range(gw):
+            sx = min(width - 1, gx * scale)
+            base = sy * stride + sx * channels
+            r, g, b = out[base], out[base + 1], out[base + 2]
+            vals.append((0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0)
+    return vals, gw, gh
+
+
+def _mean_abs_delta(a: list[float], b: list[float]) -> Optional[float]:
+    """Mean absolute per-pixel luminance delta between two equal-length grids (0..1). None if the
+    grids differ in length (mismatched frame sizes — can't compare)."""
+    if not a or not b or len(a) != len(b):
+        return None
+    return sum(abs(x - y) for x, y in zip(a, b)) / len(a)
+
+
+def _bright_centroid(vals: list[float], w: int, h: int) -> Optional[tuple[float, float]]:
+    """Luminance-weighted centroid (x,y) in grid px of the bright mass, or None if the frame has no
+    bright mass. Used to detect whether a MOVE actually displaced the actor."""
+    total = sum(vals)
+    if total <= 0:
+        return None
+    cx = sum(vals[i] * (i % w) for i in range(len(vals))) / total
+    cy = sum(vals[i] * (i // w) for i in range(len(vals))) / total
+    return cx, cy
+
+
+def gate_motion_liveness(reel: Optional[list[dict]]) -> list[dict]:
+    """G5: objective inter-frame deltas over a render REEL.
+
+    ``reel`` is an ordered list of frame dicts (the qa/motion_reel.py sidecar's ``frames``):
+        [{"frame": "<png path>", "label": "idle"|"walk"|"attack"|..., "is_move": bool, ...}, ...]
+    Each frame must carry a decodable PNG ``frame`` path. ``label`` (or ``anim``) classifies the
+    beat; a frame with ``is_move`` true (or label in the MOVE set) participates in the displacement
+    check. SKIPPED when no reel is supplied (additive — the still-only round is unchanged).
+
+    Checks:
+      * FROZEN IDLE (CRITICAL) — over the IDLE frames (label/anim contains "idle"), the mean abs
+        inter-frame luminance delta < FROZEN_IDLE_DELTA. Nothing is animating: a static billboard.
+      * NO LOCOMOTION DISPLACEMENT (HIGH) — for a MOVE pair, the bright-mass centroid shifts <
+        MOVE_CENTROID_MIN_PX. The engine said the actor moved but the render didn't displace it.
+    """
+    if not reel:
+        return [{"gate": "G5_motion_liveness", "severity": "SKIPPED", "metric": "reel",
+                 "value": None, "threshold": None,
+                 "detail": "no render reel supplied; G5 skipped (only meaningful with a motion reel — "
+                           "build one with qa/motion_reel.py and pass its frames)"}]
+
+    # Decode each frame's grid once (graceful: undecodable frames are dropped + noted).
+    grids: list[tuple[Optional[tuple[list[float], int, int]], dict]] = []
+    for fr in reel:
+        path = fr.get("frame") or fr.get("path")
+        grids.append((_lum_grid(path) if path else None, fr))
+    decoded = [(g, fr) for g, fr in grids if g is not None]
+    if len(decoded) < 2:
+        return [{"gate": "G5_motion_liveness", "severity": "SKIPPED", "metric": "frames",
+                 "value": len(decoded), "threshold": 2,
+                 "detail": f"reel has <2 decodable frames ({len(decoded)}); G5 needs >=2 to measure motion"}]
+
+    def _label(fr: dict) -> str:
+        return str(fr.get("label") or fr.get("anim") or "").lower()
+
+    _MOVE_LABELS = ("walk", "run", "move", "locomot", "step", "approach", "charge")
+
+    gates: list[dict] = []
+
+    # --- FROZEN IDLE: mean abs inter-frame delta across consecutive IDLE frames. ---
+    idle = [(g, fr) for g, fr in decoded if "idle" in _label(fr)]
+    if len(idle) >= 2:
+        deltas = []
+        for (ga, _), (gb, _) in zip(idle, idle[1:]):
+            d = _mean_abs_delta(ga[0], gb[0])
+            if d is not None:
+                deltas.append(d)
+        if deltas:
+            mean_delta = sum(deltas) / len(deltas)
+            if mean_delta < FROZEN_IDLE_DELTA:
+                gates.append({"gate": "G5_motion_liveness", "severity": "CRITICAL",
+                              "metric": "idle_interframe_delta", "value": round(mean_delta, 6),
+                              "threshold": FROZEN_IDLE_DELTA,
+                              "detail": (f"FROZEN idle: mean inter-frame luminance delta {mean_delta:.6f} "
+                                         f"< {FROZEN_IDLE_DELTA} over {len(idle)} idle frames — the actor is "
+                                         "a static billboard, not a living 3D actor; animate the idle BEFORE scoring")})
+            else:
+                gates.append({"gate": "G5_motion_liveness", "severity": "PASS",
+                              "metric": "idle_interframe_delta", "value": round(mean_delta, 6),
+                              "threshold": FROZEN_IDLE_DELTA,
+                              "detail": f"idle is alive (mean inter-frame delta {mean_delta:.6f} >= {FROZEN_IDLE_DELTA})"})
+
+    # --- NO LOCOMOTION DISPLACEMENT: a MOVE beat must shift the bright-mass centroid. ---
+    # A frame is a MOVE if is_move is truthy OR its label is in the move set. We compare the FIRST
+    # and LAST move frame's centroids (the net displacement of the move beat).
+    moves = [(g, fr) for g, fr in decoded
+             if fr.get("is_move") or any(m in _label(fr) for m in _MOVE_LABELS)]
+    if len(moves) >= 2:
+        (ga, wa, ha), _ = moves[0][0], moves[0][1]
+        (gb, wb, hb) = moves[-1][0]
+        ca = _bright_centroid(ga, wa, ha)
+        cb = _bright_centroid(gb, wb, hb)
+        if ca is not None and cb is not None and (wa, ha) == (wb, hb):
+            disp = math.hypot(cb[0] - ca[0], cb[1] - ca[1])
+            if disp < MOVE_CENTROID_MIN_PX:
+                gates.append({"gate": "G5_motion_liveness", "severity": "HIGH",
+                              "metric": "move_centroid_px", "value": round(disp, 3),
+                              "threshold": MOVE_CENTROID_MIN_PX,
+                              "detail": (f"a MOVE beat displaced the bright-mass centroid only {disp:.2f}px "
+                                         f"(< {MOVE_CENTROID_MIN_PX}px) across {len(moves)} move frames — the "
+                                         "actor slides/teleports without locomotion; check the walk cycle / root motion")})
+            else:
+                gates.append({"gate": "G5_motion_liveness", "severity": "PASS",
+                              "metric": "move_centroid_px", "value": round(disp, 3),
+                              "threshold": MOVE_CENTROID_MIN_PX,
+                              "detail": f"move beat displaced the actor {disp:.2f}px (>= {MOVE_CENTROID_MIN_PX}px)"})
+
+    if not gates:
+        gates.append({"gate": "G5_motion_liveness", "severity": "SKIPPED", "metric": "beats",
+                      "value": len(decoded), "threshold": None,
+                      "detail": "reel decoded but no idle pair / move beat to measure; tag frames with "
+                                "label='idle' and/or is_move=true (or a walk/run label) to enable G5 checks"})
+    return gates
+
+
+# ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
 _SEV_RANK = {"CRITICAL": 4, "HIGH": 3, "MED": 2, "LOW": 1, "PASS": 0, "SKIPPED": 0}
@@ -470,15 +693,21 @@ def run_pregates(
     camera: CameraSpec = CameraSpec.LOCKED,  # type: ignore[attr-defined]
     actors: Optional[list[dict]] = None,
     occupancy_tint: Optional[dict] = None,
+    reel: Optional[list[dict]] = None,
 ) -> dict:
     """Run all available pre-gates. Returns {verdict, blocking, gates[]}.
     verdict = FLAG if any CRITICAL/HIGH fired (the loop must fix the deterministic defect and
-    re-render BEFORE the LLM panel); else PASS; SKIPPED only if literally nothing could run."""
+    re-render BEFORE the LLM panel); else PASS; SKIPPED only if literally nothing could run.
+
+    ``reel`` (optional) is the ordered list of motion-reel frame dicts (qa/motion_reel.py's sidecar
+    ``frames``); when supplied, G5 motion-liveness also runs. Omitting it == today's behavior (G5
+    SKIPS) — additive, no still-only round changes."""
     gates: list[dict] = []
     gates += gate_frame_lit(render_png)
     if scenegrid is not None:
         gates += gate_floor_contact_and_scale(scenegrid, camera, actors or [])
         gates += gate_occupancy(scenegrid, occupancy_tint)
+    gates += gate_motion_liveness(reel)
     worst = max((_SEV_RANK[g["severity"]] for g in gates), default=0)
     blocking = [g for g in gates if g["severity"] in ("CRITICAL", "HIGH")]
     ran = [g for g in gates if g["severity"] not in ("SKIPPED",)]
@@ -514,12 +743,27 @@ def _load_actors(arg: Optional[str]) -> list[dict]:
     return json.loads(arg)
 
 
+def _load_reel(arg: Optional[str]) -> Optional[list[dict]]:
+    """Load the motion-reel frames for G5. Accepts a bare list of frame dicts OR a motion_reel.py
+    sidecar object with a top-level 'frames' key. Returns None on empty/unrecognized input."""
+    if not arg:
+        return None
+    raw = Path(arg[1:]).read_text() if arg.startswith("@") else arg
+    obj = json.loads(raw)
+    if isinstance(obj, dict):
+        obj = obj.get("frames")
+    return obj if isinstance(obj, list) else None
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     ap = argparse.ArgumentParser(description="Deterministic visual pre-gates for the visual-critic loop")
     ap.add_argument("--render", required=True, help="path to the rendered PNG")
     ap.add_argument("--scenegrid", help="path to the *.scenegrid.json (enables G2/G3/G4)")
     ap.add_argument("--actors", help="measured actor boxes JSON or @file.json")
     ap.add_argument("--occupancy", help="rendered occupancy tint JSON or @file.json")
+    ap.add_argument("--reel", help="motion-reel frames JSON or @file.json (enables G5); accepts a "
+                                   "bare list of frame dicts OR a qa/motion_reel.py sidecar object "
+                                   "with a top-level 'frames' key")
     ap.add_argument("--json", action="store_true", help="emit JSON")
     args = ap.parse_args(argv)
 
@@ -530,7 +774,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         import sys as _sys
         print(f"WARNING: --occupancy input is not a dict (got {type(occ).__name__}); G2 will be SKIPPED", file=_sys.stderr)
         occ = None
-    res = run_pregates(args.render, scenegrid=sg, actors=actors, occupancy_tint=occ)
+    reel = _load_reel(args.reel) if args.reel else None
+    res = run_pregates(args.render, scenegrid=sg, actors=actors, occupancy_tint=occ, reel=reel)
     if args.json:
         print(json.dumps(res, indent=2))
     else:

--- a/qa/visual_regression.py
+++ b/qa/visual_regression.py
@@ -20,9 +20,12 @@ NOISE FLOOR (visual scores are 0-10, panel-synthesized; coarser than the engine 
   overall : +/-0.7  (an LLM panel re-scores a fixed frame within ~0.5; 0.7 is a safe floor)
   per-dim : +/-1.0  (single-lens scores are noisier; only a >=1.0 drop is a real per-dim regression)
 
-VERDICT: REGRESSED if overall drops below -0.7 OR any dim drops >=1.0 OR a new CRITICAL/HIGH
-defect appears that the baseline did not have; IMPROVED if overall rises >+0.7 and nothing
-regressed; WITHIN_NOISE otherwise; NO_BASELINE when the scene has no canonical baseline yet.
+VERDICT: REGRESSED if (still) overall drops below -0.7 OR motion_overall drops below -0.7 OR any
+dim drops >=1.0 OR a new CRITICAL/HIGH defect appears that the baseline did not have; IMPROVED if
+overall (or motion_overall) rises >+0.7 and nothing regressed; WITHIN_NOISE otherwise; NO_BASELINE
+when the scene has no canonical baseline yet. The motion arm only participates when BOTH the
+candidate and the baseline carry a motion_overall (a still-only round leaves it NO_DATA — additive,
+never falsely flags).
 
 USAGE
 -----
@@ -55,6 +58,9 @@ import scores_db  # noqa: E402
 
 OVERALL_FLOOR = 0.7
 DIM_FLOOR = 1.0
+# Motion (L7) regression floor — mirrors the still-overall floor; a >0.7 motion_overall drop
+# vs the scene baseline is a real motion regression (the panel re-scores a fixed reel within ~0.5).
+MOTION_OVERALL_FLOOR = 0.7
 # Comparability key: a scene's baseline is keyed on (visual_scene, visual_backend).
 # Cross-scene comparison is intentionally refused (a tavern frame is not a baseline for a dungeon).
 _EXIT = {"IMPROVED": 0, "WITHIN_NOISE": 0, "REGRESSED": 2, "NO_BASELINE": 3, "NO_DATA": 3}
@@ -107,6 +113,9 @@ def detect_visual_regression(candidate: dict, db_path: Path | str = scores_db.DB
         "overall": {"candidate": candidate.get("visual_overall"),
                     "baseline": baseline.get("visual_overall") if baseline else None,
                     "delta": None, "floor": OVERALL_FLOOR, "classification": "NO_DATA"},
+        "motion_overall": {"candidate": candidate.get("motion_overall"),
+                           "baseline": baseline.get("motion_overall") if baseline else None,
+                           "delta": None, "floor": MOTION_OVERALL_FLOOR, "classification": "NO_DATA"},
         "per_dim": [],
         "new_blocking": [],
     }
@@ -120,7 +129,7 @@ def detect_visual_regression(candidate: dict, db_path: Path | str = scores_db.DB
         )
         return result
 
-    # Overall.
+    # Overall (still — the L1-L6 visual_overall).
     cv, bv = candidate.get("visual_overall"), baseline.get("visual_overall")
     regressed = False
     improved = False
@@ -130,6 +139,17 @@ def detect_visual_regression(candidate: dict, db_path: Path | str = scores_db.DB
         result["overall"].update(delta=d, classification=cls)
         regressed |= cls == "REGRESSED"
         improved |= cls == "IMPROVED"
+
+    # Motion overall (L7 — mirrors the still arm, only when BOTH rows carry a motion_overall; a
+    # still-only baseline or candidate leaves this NO_DATA and never falsely flags).
+    mcv, mbv = candidate.get("motion_overall"), baseline.get("motion_overall")
+    if mcv is not None and mbv is not None:
+        md = round(float(mcv) - float(mbv), 3)
+        mcls = ("REGRESSED" if md < -MOTION_OVERALL_FLOOR
+                else ("IMPROVED" if md > MOTION_OVERALL_FLOOR else "WITHIN_NOISE"))
+        result["motion_overall"].update(delta=md, classification=mcls)
+        regressed |= mcls == "REGRESSED"
+        improved |= mcls == "IMPROVED"
 
     # Per-dim.
     cd, bd = _dims(candidate), _dims(baseline)
@@ -166,6 +186,10 @@ def _summary(r: dict) -> str:
     if o["delta"] is not None:
         sign = "+" if o["delta"] >= 0 else ""
         lines.append(f"  overall {o['baseline']} -> {o['candidate']} ({sign}{o['delta']}, floor +/-{o['floor']}) {o['classification']}")
+    mo = r.get("motion_overall") or {}
+    if mo.get("delta") is not None:
+        msign = "+" if mo["delta"] >= 0 else ""
+        lines.append(f"  motion  {mo['baseline']} -> {mo['candidate']} ({msign}{mo['delta']}, floor +/-{mo['floor']}) {mo['classification']}")
     for p in r["per_dim"]:
         if p["delta"] is None:
             lines.append(f"  {p['dim']:24s} no-data")


### PR DESCRIPTION
## What
Recalibrates the WorldOS visual-critic + QA to **Pillars of Eternity II: Deadfire as the SOLE art-direction bar**, and prepares it for the **billboards → real 3D animated actors** pivot. All ADDITIVE, default-off (empty==today), **no engine/viewer-server writes** (sole-writer invariant intact).

## Why
The adversarial critic was anchored to a BG2/PoE2/Disco muddle and **over-penalized flat billboards** as "pasted stickers" (a validated false-negative — it scored "zero contact shadow" on a frame whose feet-crop showed the shadow rendering). The project is pivoting characters to real 3D actors (PoE2's pre-rendered-2D-BG + 3D-actor architecture), so the critic must (a) anchor to PoE2, (b) credit real 3D grounding, (c) gain a motion lens.

## Changes
- **`.claude/skills/visual-critic/SKILL.md`** — PoE2 = sole bar (BG2 → tactical cross-check, Disco → dark-pocket cross-check); **L4 FLIPPED** (grounded scene-lit 3D scores high, flat billboard low); **L2 grounding false-negative fix** + auto-downgrade an L2/L4 CRITICAL that contradicts a deterministic G3 floor-contact PASS; **new L7 MOTION lens** (reel-scored).
- **`qa/visual_pregate.py`** — new **G5_motion_liveness** pre-gate (frozen idle = CRITICAL; no move-centroid displacement = HIGH); SKIPS without a reel.
- **`qa/scores_db.py`** — additive `motion_overall` / `motion_dims_json` / `motion_reel_ref` / `milestone` columns (default NULL, ALTER-migrated, old rows + calls round-trip).
- **`qa/visual_regression.py`** — parallel motion-regression arm (motion_overall drop > 0.7 → REGRESSED; NO_DATA when absent).
- **`qa/motion_reel.py`** (new) — MODE A engine-state reel + MODE B timeline reel → contact-sheet PNG + JSON sidecar (the L7/G5 input). Live Unity capture is a clearly-marked read-only hook.

## Tests
`116 passed, 2 skipped` (pre-existing Pillow-path skips), single-process (`-p no:xdist`): new G5 (frozen/displacement/breathing/move), motion-regression (REGRESSED/WITHIN_NOISE/NO_DATA), scores_db motion columns (register/round-trip/NULL/ALTER), motion_reel (MODE A+B+CLI+G5-integration). Direct MODE B run assembled a valid contact-sheet + sidecar; centroid tracked the moving block; fed back through `visual_pregate --reel` → G5 PASS.

Part of the PoE2-pivot plan (step 1: land the scoring recalibration so the 3D-actor proof is judged on the right bar). Provenance: 5-architect design workflow.