### PR TITLE
Asset pipeline: fix Tripo+Meshy wrappers to live API + rig/animate + provider-router runbooks

### DIFF
--- a/.claude/skills/asset-gen/MESHY_PIPELINE.md
+++ b/.claude/skills/asset-gen/MESHY_PIPELINE.md
@@ -1,0 +1,66 @@
+# Meshy pipeline runbook (text-to-3d → rig → animate)
+
+The full headless recipe for a **rigged + animated HUMANOID** via Meshy. **Live-tested 2026-06-28.**
+The CLI wrapper `extensions/renderers/godot/tools/meshy_gen.py` implements this — prefer it.
+
+> **Meshy is HUMANOID ONLY.** Rigging 422s on non-humanoid meshes ("Pose estimation failed").
+> For creatures use `tripo_gen.py`. Meshy's edge for humanoids: the 5-credit rig **includes free
+> walk + run clips**, so a usable animated PC costs ~5 cr (vs Tripo's ~100).
+
+## Auth + conventions
+- Base `https://api.meshy.ai`, header `Authorization: Bearer msy_<key>` (key in `~/.worldos/meshy.key`, env `WORLDOS_MESHY_API_KEY`).
+- **Version split (footgun):** text-to-3d = `/openapi/v2`; **rigging + animation = `/openapi/v1`**.
+- Every POST returns `{"result":"<task-uuid>"}`. Poll `GET <path>/{id}`. Status:
+  `PENDING → IN_PROGRESS → SUCCEEDED` (or `FAILED`; `consumed_credits:0` on FAILED = auto-refund).
+- Output URLs are short-lived signed `assets.meshy.ai` links — download promptly.
+- Balance: `GET /openapi/v1/balance` → `{"balance": N}`.
+
+## CLI (the easy path)
+```bash
+# generate a humanoid, rig it (+ free walk/run), add Idle(0) and Attack(4)
+meshy_gen.py --prompt "a human elf ranger, leather armor, hooded cloak, game-ready" \
+  --out /tmp/ranger --rig --animate 0 4
+
+# rig an EXISTING Meshy model task (skip generation)
+meshy_gen.py --rig-from-task <meshy_model_task_id> --out /tmp/x --animate 0
+meshy_gen.py --test-key            # auth smoke (no spend)
+meshy_gen.py --prompt "..." --out /tmp/x --dry-run
+```
+
+## Raw REST steps
+
+### 1. Text-to-3D — `POST /openapi/v2/text-to-3d` (two stages)
+- **preview** (geometry): `{"mode":"preview","prompt":"<=600 chars","ai_model":"meshy-5","model_type":"standard","pose_mode":"t-pose","target_formats":["glb"],"should_remesh":true,"topology":"triangle","target_polycount":30000,"auto_size":true,"origin_at":"bottom"}` → `{"result":"<preview_id>"}`.
+- **refine** (PBR texture): `{"mode":"refine","preview_task_id":"<preview_id>","enable_pbr":true,"target_formats":["glb"]}` → `<refine_id>`.
+- Poll `GET /openapi/v2/text-to-3d/{id}` → `model_urls.{glb,fbx,...}`.
+
+### 2. Rigging — `POST /openapi/v1/rigging` (~5 cr, HUMANOID only)
+```json
+{ "input_task_id": "<refine_id or model task>", "height_meters": 1.7 }
+```
+- One source: `input_task_id` (a prior Meshy task; ≤300k faces) **or** `model_url` (public `.glb`).
+- Poll `GET /openapi/v1/rigging/{id}` → `result` has:
+  - `rigged_character_fbx_url`, `rigged_character_glb_url`
+  - **`basic_animations.{walking,running}_{glb,fbx}_url`** — free walk + run, no extra call.
+- Non-humanoid → **422** "Pose estimation failed". (Mesh *generation* is unrestricted; only
+  rig/animate are humanoid-locked.)
+
+### 3. Animation — `POST /openapi/v1/animations` (~3 cr each)
+```json
+{ "rig_task_id": "<rigging_id>", "action_id": 0 }
+```
+- `action_id` is an **integer** from the animation library (no REST list endpoint; scrape/cache the
+  id→name map from docs). Examples: `0`=Idle, `4`=Attack, `14`=Run_02, `125`=Charged_Spell_Cast.
+- Poll `GET /openapi/v1/animations/{id}` → `result.{animation_fbx_url, animation_glb_url}`.
+- All actions are biped-only (inherits the humanoid constraint).
+
+## Credits (measured / published)
+- text-to-3d preview 5–20 cr, refine 10 cr; **rigging 5 cr** (incl. free walk/run); **animation 3 cr** each.
+- A usable animated humanoid (rig + 1 clip) ≈ **8 cr** + generation.
+
+## Unity consumption (critical)
+- Import the rigged FBX as **`animationType = Generic`, NOT Humanoid** — the Meshy bone names don't
+  auto-map to Unity's Humanoid avatar, so Humanoid import **silently drops the clips**. Generic
+  preserves them (verified: Idle clip 4.00 s, 26-joint skeleton).
+- The **Unity-plugin "Bridge to Unity" is GUI-only / not agent-automatable** — bypass it; drive the
+  REST API and import the FBX yourself (CoplayDev unity-mcp on the GEX44 box).

--- a/.claude/skills/asset-gen/SKILL.md
+++ b/.claude/skills/asset-gen/SKILL.md
@@ -11,22 +11,57 @@ are wired as MCPs; all four have CLI wrappers (or a stub). Renderer lanes read o
 `extensions/renderers/godot/HANDOFF.md` §4.6, so any source drops in at the same `scope_key`
 with zero renderer change.
 
-## Which tool for which job
+## ★ WorldOS Painterly LoRA — the PERSISTENT consistent style (2026-06-27)
+The locked WorldOS visual style is a TRAINED Scenario LoRA: **`model_MB22WaRCBLtfhi5R2CRpHoEL` "WorldOS Painterly"**
+(zimage-lora, trained on 6 original moody-painterly assets; Scenario project `proj_sd4w3ozsJaBHYnHS4mP1S2Pw`). Generate ALL
+game art THROUGH it for one cohesive BG/PoE/Disco-caliber painted look — characters, enemies, props, scenes. Proven: a
+skeleton (NOT in the dataset) rendered in the exact style; ~6 CU/gen (8× cheaper than GPT Image 2).
 
-| Job | Tool | How |
-|---|---|---|
-| **3D character / NPC / companion** | **Meshy** or **Tripo H3.1** | `meshy_gen.py` (text→3D, preview→refine) or `tripo_gen.py text` |
-| **Rigged + animated character** (GT2 #1091) | **Tripo** | `tripo_gen.py rig` → rig-check → rig(`spec=mixamo`) → retarget `[walk,idle,run,attack,cast]` → animated GLB |
-| **Low-poly prop / dungeon dressing** | **Tripo P1** | `tripo_gen.py text --lowpoly` (~10s) |
-| **Painterly background / diorama** (GT2 #1089) | **Scenario** | `scenario_gen.py generate --model-id <id>` (train a style model once → consistent backdrops) |
-| **Engine 2D image-gen, non-Eva** | **Scenario provider** | `WORLDOS_IMAGE_PROVIDER=scenario` (see below) |
-| **Pixel sprites / tilesets** | **PixelLab** | **GT1 FUTURE only** — MCP `pixellab`; `pixellab_gen.py` is a stub |
+**On-demand asset recipe (the repeatable workflow):**
+1. **Generate** (scenario MCP, MAIN session — the LoRA CANNOT be invoked by its own id; run the base + loras):
+   `model_run model_id=model_z-image parameters={ prompt:"<subject>, moody hand-painted painterly, dramatic chiaroscuro,
+   dark earthy palette, warm firelight rim vs cool shadow, isolated and centered on a plain flat dark neutral background,
+   full body, feet visible", loras:["model_MB22WaRCBLtfhi5R2CRpHoEL"], lorasScale:[0.9], width:1024,
+   height:1536 (chars) | 1024 (props), numOutputs:1-2, guidance:5 }`  — use `wait:false` (z-image LoRA cold-start >180s) + poll `job_check`.
+2. **Cut out:** `model_run model_id=model_bria-remove-background parameters={ image:<asset_id>, preserveAlpha:true }` → clean RGBA (~3 CU).
+3. **Download:** `asset_download` → `curl -L` → box `Assets/painterly/sprites/<id>_idle.png`.
+4. **Integrate:** ARM-1A `WorldOS/SpriteBillboard` (quad localEuler (0,180,0), scale ACTOR_TARGET_H×sprite-aspect, feet grounded) —
+   see `scratchpad/swap_render.cs`. Engine = SOLE WRITER; sprites are renderer-local view only.
+**★ COPYRIGHT GUARD:** NEVER train on / feed the BG/PoE/Disco reference frames (calibration-only). Bootstrap original datasets via text-gen.
+**Retrain/extend the LoRA:** `model_create(data.type="zimage-lora")` → `train(action=upload_images, images=[asset_ids])` → `train(action=start)`. ~576 CU / ~40 min for 6 imgs, 5–15 recommended.
 
-The 3D path always ends at the bake: **`tripo_gen.py`/`meshy_gen.py` →
-`extensions/renderers/godot/tools/bake_sprites.py` (8 facings @ dimetric 2:1, see
-`extensions/renderers/godot/ISO-PROJECTION.md`) →
-`extensions/renderers/godot/tools/pack_sheet.py`** (manifest v1:
-rows=8 facings, cols=24 idle4/walk8/attack6/cast6, 128px, foot-anchor).
+## ★ The router — which tool for which job (decide in this order)
+
+Pick the FIRST rule that matches. Full step-by-step recipes: **[TRIPO_PIPELINE.md](TRIPO_PIPELINE.md)**
+and **[MESHY_PIPELINE.md](MESHY_PIPELINE.md)** (both live-verified 2026-06-28).
+
+1. **Painterly 2D backdrop / diorama / engine image** → **Scenario** (through the WorldOS Painterly
+   LoRA above). `scenario_gen.py` or the `scenario` MCP, or the engine provider `WORLDOS_IMAGE_PROVIDER=scenario`.
+2. **Pixel sprite / tileset** → **PixelLab** (GT1-future; `pixellab` MCP).
+3. **3D rigged + animated, HUMANOID (biped)** → **Meshy** (cheapest: ~5 cr rig **includes free
+   walk/run**, +3 cr/clip) — `meshy_gen.py --rig --animate ...`. **Fallback: Tripo** (richer preset
+   set, same code path as creatures) — `tripo_gen.py text --rig`.
+4. **3D rigged + animated, CREATURE (quadruped/avian/serpentine/…)** → **Tripo ONLY** — Meshy 422s on
+   non-humanoids. `tripo_gen.py text --rig` (rig-check auto-detects the rig_type). **No fallback.**
+5. **3D static / low-poly prop** → **Tripo `--lowpoly` (P1)** or Meshy `model_type=lowpoly`.
+
+*(A programmatic `asset_router.py` is intentionally deferred — selection is an agent decision today;
+this numbered tree IS the router. The 2D-image-gen router that DOES exist is `servers/engine/imagegen.py`,
+`WORLDOS_IMAGE_PROVIDER` — Tripo/Meshy/PixelLab are 3D/sprite, not in it.)*
+
+## ★ Unity consumption (the live renderer lane — read before importing a rigged FBX)
+
+The shipping in-repo renderer is **Godot 2D** (it BAKES a GLB to 8-facing sprite PNGs via
+`bake_sprites.py` → `pack_sheet.py`; that path is **reference/quarantined** and does NOT use rig
+or animation data). The **live lane is Unity-direct 3D actors** on the GEX44 box (PoE2 pivot, M1.0)
+— that is what rig+animate feeds. Two load-bearing import facts (verified 2026-06-28):
+
+- **Import the rigged FBX as `animationType = Generic`, NOT Humanoid.** Tripo/Meshy bone names don't
+  auto-map to Unity's Humanoid avatar, so a Humanoid import **silently drops the animation clips**.
+  Generic preserves them.
+- Prefer **FBX output** (Tripo `--out-format fbx`, Meshy returns FBX) — Unity-ready directly, **no
+  Blender**. The box has no Blender; if you must convert a GLB, do it Mac-side. FBX imports untextured
+  → assign the albedo separately (the M1.0 pale-albedo step).
 
 ## Keys (NEVER commit; NEVER print)
 Stored mode-600 OUTSIDE the repo in `~/.worldos/`: `meshy.key`, `tripo3d.key`, `scenario.key` +
@@ -42,9 +77,9 @@ in each service dashboard when convenient, then update the `~/.worldos/*.key` fi
 4. Verify auth: `python3 extensions/renderers/godot/tools/<svc>_gen.py --test-key` (e.g. `meshy_gen.py --test-key`).
 
 ## CLI wrappers (`extensions/renderers/godot/tools/`, urllib-only, mirror `meshy_gen.py`)
-- **`tripo_gen.py`** — `text|image|rig` subcommands; `--lowpoly` (P1); `--test-key`; `--dry-run` (credit est). Polls `GET /v3/task/{id}` ≥2s; **downloads GLB immediately (URLs expire ~5 min)**. Output → gitignored `content/worlds/_private/<world>/images/<scope>/`.
+- **`tripo_gen.py`** — `text|image|rig` subcommands; `--rig` (rig-check→rig→retarget), `--out-format glb|fbx`, `--animations`, `--lowpoly` (P1), `--test-key`, `--dry-run`. Rigs **humanoids AND creatures** (rig_type auto-detected). Polls `GET /v3/tasks/{id}` (plural) ≥3s; **downloads immediately (URLs expire ~5 min)**. Full recipe + verified API facts in **[TRIPO_PIPELINE.md](TRIPO_PIPELINE.md)**.
 - **`scenario_gen.py`** — `generate|list-models|upscale`; `--model-id`; `--test-key`; `--dry-run`. HTTP Basic; async job → asset download. Scenario has TWO interfaces — REST `https://api.cloud.scenario.com/v1` (Basic, used by `scenario_gen.py`) AND MCP `https://mcp.scenario.com/mcp` (for direct agent tool calls). Both work.
-- **`meshy_gen.py`** — text→3D, `--prompt --out`; `--test-key`; `--dry-run`. The wrapper uses `POST /openapi/v2/text-to-3d` (preview→refine PBR) at `https://api.meshy.ai`. (Meshy's API also exposes `/v1/rigging` + `/v1/animations`, but `meshy_gen.py` does **text-to-3d only** — use **Tripo** for rig→animate.)
+- **`meshy_gen.py`** — text→3D (`--prompt --out`, preview→refine PBR) **plus rig+animate** (`--rig` / `--rig-from-task <id>` / `--animate <action_id...>`, HUMANOID only — Meshy 422s on creatures). The 5-cr rig **includes free walk/run**. `--test-key`, `--dry-run`. Full recipe in **[MESHY_PIPELINE.md](MESHY_PIPELINE.md)**.
 - **`pixellab_gen.py`** — STUB for GT1; `--test-key` only.
 Always run `--test-key` first to confirm auth.
 
@@ -64,16 +99,17 @@ its own tool list; the wrappers always work regardless.
 **without** the `openclaw` provider (which rides Eva's gateway — the invariant blocker). It degrades to
 null when unconfigured/offline; the default provider stays null.
 
-## Verified API facts (live-probed — some differ from public docs)
-- **Meshy**: Bearer, `https://api.meshy.ai/openapi`. text/image→3D + `/v1/rigging` + `/v1/animations` + `/v1/text-to-image`.
-- **Tripo**: Bearer, `https://openapi.tripo3d.ai/v3`. `/generation/text|image-to-model`; rig chain `/animations/{rig-check,rig,retarget}` (`rig_type=biped`, `spec=mixamo`, presets `preset:walk|idle|run|attack|cast`). Poll `GET /v3/task/{id}` ≥2s; envelope `{"code":0,"data":{...}}`; model URLs expire ~5 min.
-- **Scenario**: **HTTP Basic (key:secret)**, base **`https://api.cloud.scenario.com/v1`** (NOT `api.scenario.com`, NOT Bearer). `POST /v1/generate/txt2img` → `{"job":{"jobId"}}` → poll `GET /v1/jobs/{id}` → `GET /v1/assets/{id}` for the URL. `GET /v1/models`. **Account currently has 0 trained models → `generate` needs a `--model-id` (train/import one in the Scenario UI, or use a public modelId).**
-- **PixelLab**: MCP-first, Bearer, `https://api.pixellab.ai/mcp` (JSON-RPC, returns **SSE** `text/event-stream`). REST `/balance` is 404.
+## Verified API facts (LIVE-TESTED 2026-06-28 — these differ from public docs; trust these)
+- **Meshy**: Bearer `msy_*`, `https://api.meshy.ai`. text/image→3D on `/openapi/v2`; **rigging + animation on `/openapi/v1`** (`/openapi/v1/{rigging,animations,balance}`). Rig 5 cr (+free walk/run), anim 3 cr. HUMANOID-only rig/animate. Full spec → [MESHY_PIPELINE.md](MESHY_PIPELINE.md).
+- **Tripo**: Bearer, `https://openapi.tripo3d.ai/v3`. Gen `POST /generation/text-to-model {prompt, model}` (no `type`; the old `/generation/text` 404s). **Model ids are DATE-STAMPED** (`P1-20260311`, `v3.1-20260211`; friendly names rejected). Rig chain `/animations/{rig-check,rig,retarget}`: rig `model=v2.5-20260210` (biped+creatures), rig_type from rig-check, presets **namespaced `preset:<rig_type>:<name>`** (`preset:biped:walk`), **ONE per call**. Poll `GET /v3/tasks/{id}` (**plural**) ≥3s; output at `data.output.model_url`, expires ~5 min. Full spec → [TRIPO_PIPELINE.md](TRIPO_PIPELINE.md).
+- **Scenario**: **HTTP Basic (key:secret)**, base **`https://api.cloud.scenario.com/v1`** (NOT `api.scenario.com`, NOT Bearer). `POST /v1/generate/txt2img` → `{"job":{"jobId"}}` → poll `GET /v1/jobs/{id}` → `GET /v1/assets/{id}` for the URL. The WorldOS Painterly LoRA `model_MB22WaRCBLtfhi5R2CRpHoEL` is the trained style model (see top); run it via the base `model_z-image` + `loras:[...]`.
+- **PixelLab**: MCP-first, Bearer, `https://api.pixellab.ai/mcp` (JSON-RPC, returns **SSE** `text/event-stream`). REST `/balance` is 404. ~50 tools (pixel chars 4/8-dir, animation, tilesets). GT1-future.
 
 ## Rate limits / cost / gotchas
 Meshy ~200/day; Tripo enforces ~1 req/s — the wrapper polls at ≥3s to stay under it (else 429); Scenario 50–100/s + 10–30 min model training; PixelLab async queue. No hard spend caps — use `--dry-run` for a credit estimate + check balance before bulk. Download asset URLs immediately (finite TTL). Pin seeds / prefer Scenario trained models for consistency. Validate bakes (frame dims + foot-anchor) before trusting a sheet.
 
 ## What this unblocks
-- **#1089 painterly backdrops** → Scenario (train a style model → `scenario_gen.py generate` or the `scenario` MCP), served via the engine's `/image` from `_private` (no Eva).
-- **#1091 real rigged animation** → Tripo `rig`→`retarget` → animated GLB → `bake_sprites.py`.
-- **GT1 (future)** → PixelLab tilesets + pixel sprites; not wired into GT2.
+- **Painterly backdrops** → Scenario (the WorldOS Painterly LoRA → `scenario_gen.py generate` or the `scenario` MCP), served via the engine's `/image` from `_private` (no Eva).
+- **Real rigged + animated 3D actors (Unity-direct lane)** → Meshy (humanoid: `--rig --animate`) or Tripo (creatures, or humanoid fallback: `text --rig --out-format fbx`) → FBX → Unity import as `animationType=Generic`. Validated end-to-end 2026-06-28 (walk cycle rendered on GEX44).
+- **Godot 2D sprite bake** (`bake_sprites.py`→`pack_sheet.py`) → reference/quarantined; does not consume rig/animation data.
+- **GT1 (future)** → PixelLab tilesets + pixel sprites.

--- a/.claude/skills/asset-gen/TRIPO_PIPELINE.md
+++ b/.claude/skills/asset-gen/TRIPO_PIPELINE.md
@@ -11,7 +11,7 @@ implements exactly this recipe — prefer it; drop to raw curl only when debuggi
 
 ## Auth + conventions
 - Base `https://openapi.tripo3d.ai/v3`. Header `Authorization: Bearer <key>` (key in `~/.worldos/tripo3d.key`, env `WORLDOS_TRIPO_API_KEY`).
-- Every POST returns `{"code":0,"data":{"task_id":"..."}}`. Poll `GET /tasks/{id}` (**plural** — `/task/{id}` 404s) at **≥3 s** (1 req/s limit → 429).
+- **Task-creating** POSTs (`/generation/*`, `/animations/*`) return `{"code":0,"data":{"task_id":"..."}}`. (The one exception is the upload step `POST /files`, which returns `data.file_token`, not a task.) Poll `GET /tasks/{id}` (**plural** — `/task/{id}` 404s) at **≥3 s** (1 req/s limit → 429).
 - Success output URL is `data.output.model_url` and **expires ~5 min** — download immediately.
 - Status flow: `queued → running → success` (or `failed`).
 - Balance: `GET https://api.tripo3d.ai/v2/openapi/user/balance` → `data.balance`.

--- a/.claude/skills/asset-gen/TRIPO_PIPELINE.md
+++ b/.claude/skills/asset-gen/TRIPO_PIPELINE.md
@@ -1,0 +1,91 @@
+# Tripo3D v3 pipeline runbook (text/image → model → rig → animate)
+
+The full headless recipe for a **rigged + animated 3D character or creature** via Tripo3D.
+**Every fact here was live-tested 2026-06-28** against the real API; where it differs from the
+public docs, trust this file. The CLI wrapper `extensions/renderers/godot/tools/tripo_gen.py`
+implements exactly this recipe — prefer it; drop to raw curl only when debugging.
+
+> **When to use Tripo (vs Meshy):** Tripo is the **only** provider that rigs **creatures**
+> (quadruped/avian/serpentine/aquatic). For humanoids, Tripo and Meshy are interchangeable —
+> Meshy is cheaper (see the decision tree in `SKILL.md`).
+
+## Auth + conventions
+- Base `https://openapi.tripo3d.ai/v3`. Header `Authorization: Bearer <key>` (key in `~/.worldos/tripo3d.key`, env `WORLDOS_TRIPO_API_KEY`).
+- Every POST returns `{"code":0,"data":{"task_id":"..."}}`. Poll `GET /tasks/{id}` (**plural** — `/task/{id}` 404s) at **≥3 s** (1 req/s limit → 429).
+- Success output URL is `data.output.model_url` and **expires ~5 min** — download immediately.
+- Status flow: `queued → running → success` (or `failed`).
+- Balance: `GET https://api.tripo3d.ai/v2/openapi/user/balance` → `data.balance`.
+
+## CLI (the easy path)
+```bash
+# one-shot: generate a HUMANOID, rig it, and emit Unity-ready FBX clips
+tripo_gen.py text --prompt "a human elf ranger, leather armor, hooded cloak, A-pose, game-ready" \
+  --out /tmp/ranger --rig --out-format fbx --animations walk idle run slash
+
+# CREATURE (only Tripo can): rig_type is auto-detected by rig-check
+tripo_gen.py text --prompt "a dire wolf, quadruped, on all fours, game-ready" \
+  --out /tmp/wolf --rig --out-format fbx --animations walk
+
+# rig an EXISTING generation task (skip regen)
+tripo_gen.py rig --task <generation_task_id> --out /tmp/x --out-format fbx
+tripo_gen.py --test-key          # auth smoke (no spend)
+tripo_gen.py text ... --dry-run  # plan + est credits, no API call
+```
+
+## Raw REST steps (what the wrapper does)
+
+### 1. Generate — `POST /generation/text-to-model`
+```json
+{ "prompt": "<text>", "model": "P1-20260311" }
+```
+- **No `type` field** (the old `/generation/text` 404s now).  Field is `model`, **not** `model_version`.
+- **Model ids are DATE-STAMPED** — friendly names (`tripo-p1`, `v3.1`) are **rejected**. Current set
+  (a 400 error lists the live set when one expires): `P1-20260311` (game/low-poly, best for characters),
+  `v3.1-20260211` (default hi-precision), `v3.0-20250812`, `v2.5-20250123`. **Pin the id** in production.
+- Image path: upload via `POST /files` (multipart) → `data.file_token`, then
+  `POST /generation/image-to-model {"model": "...", "file": {"type":"image","file_token":"..."}}`.
+- Poll → `output.model_url` (a `.glb`).
+
+### 2. Rig-check — `POST /animations/rig-check` (FREE, 0 credits)
+```json
+{ "input": "<generation_task_id>" }
+```
+- Returns `output.{riggable, rig_type}`. **`rig_type` is recommended by the API** — read it, don't
+  hardcode. Enum: `biped, quadruped, hexapod, octopod, avian, serpentine, aquatic`. (Humanoid→`biped`,
+  wolf→`quadruped`, both confirmed.) Abort if `riggable:false`.
+
+### 3. Rig — `POST /animations/rig`
+```json
+{ "input":"<gen_task_id>", "model":"v2.5-20260210", "rig_type":"<from rig-check>",
+  "spec":"mixamo", "out_format":"fbx" }
+```
+- **`model` MUST be `v2.5-20260210`** — it rigs **both** bipeds and creatures. The server default
+  (`v2.5-20250123`) is **rejected**; `v1.0-20240301` rigs but its **retarget then fails** — avoid it.
+- `spec`: `mixamo` for biped (Unity-friendly bone names), `tripo` for creatures.
+- `out_format`: `fbx` → Unity-ready directly (**no Blender**); `glb` otherwise.
+- Poll → `output.model_url` = the rigged model.
+
+### 4. Retarget (apply animations) — `POST /animations/retarget`
+```json
+{ "input":"<rigged_task_id>", "animations":["preset:biped:walk"], "out_format":"fbx" }
+```
+- **Presets are NAMESPACED by rig_type: `preset:<rig_type>:<name>`.** `preset:biped:walk`,
+  `preset:quadruped:walk`. **Bare `preset:walk` FAILS** (the docs showing bare names are wrong).
+- **ONE preset per call.** Multi-preset `animations` arrays **fail** (even with individually-valid
+  names) — loop, one retarget task per clip.
+- Verified biped names: `walk`, `idle`, `run`, `slash`. Quadruped: `walk` (creatures support far fewer).
+  An unsupported name fails that one task (the wrapper treats per-clip failures as non-fatal).
+- Poll → `output.model_url` = the animated model (one clip).
+
+## Credits / timing (measured)
+- Full humanoid gen→rig→1 retarget ≈ **~100 credits, ~3 min**. rig-check is free. The whole
+  humanoid+creature validation run cost **215 credits**.
+
+## Unity consumption (critical — see also the Unity section of `SKILL.md`)
+- Import the rigged/animated FBX as **`animationType = Generic`, NOT Humanoid.** Tripo's bone names
+  (`tripo::Spine_0`, …) don't auto-map to Unity's Humanoid avatar, so a **Humanoid import silently
+  drops the animation clips** (`clipAnims=0`). Generic preserves them (verified: walk clip 2.33 s).
+- FBX imports **untextured** (flat) — assign the albedo separately (the M1.0 pale-albedo gotcha;
+  Tripo embeds texture in the GLB, not always the FBX). Rig + animation are unaffected.
+- The box (GEX44) has **no Blender** — if you ever need GLB→FBX, convert Mac-side. For Tripo, prefer
+  `out_format=fbx` and skip Blender entirely.

--- a/extensions/renderers/godot/tools/meshy_gen.py
+++ b/extensions/renderers/godot/tools/meshy_gen.py
@@ -400,6 +400,12 @@ def main() -> None:
         ap.error("--out is required (unless --test-key).")
     if not args.rig_from_task and not args.prompt:
         ap.error("--prompt is required (unless --test-key or --rig-from-task).")
+    if args.action_ids:
+        # Reject duplicate ids: each clip writes anim_action_<id>.* + meta["animation_files"][id],
+        # so a repeat would bill twice and silently clobber the earlier output.
+        deduped = list(dict.fromkeys(args.action_ids))
+        if len(deduped) != len(args.action_ids):
+            ap.error("--animate action IDs must be unique.")
 
     if args.dry_run:
         _cmd_dry_run(args)
@@ -419,12 +425,15 @@ def main() -> None:
 
     key = _load_api_key()
     headers = _auth_headers(key)
-    meta: dict = {"ai_model": "meshy-5", "source": "meshy-text-to-3d-v2"}
+    # Provenance is set per-branch — don't stamp text-to-3d defaults onto a reused task.
+    meta: dict = {}
 
     if args.rig_from_task:
-        # Rig an EXISTING Meshy model task — skip generation entirely.
+        # Rig an EXISTING Meshy model task — skip generation entirely. Its origin (which model /
+        # whether image-to-3d) is unknown here, so record only the rigging-reuse provenance.
         model_task_id = args.rig_from_task
         meta["model_task_id"] = model_task_id
+        meta["source"] = "meshy-rigging-existing-task"
         print("[meshy_gen] rigging existing model task %s (generation skipped)." % model_task_id)
     else:
         # ---- preview ----
@@ -457,16 +466,19 @@ def main() -> None:
             or final_task.get("credits")
             or preview_task.get("consumed_credits")
         )
+        # Rigging consumes the textured model (refine) when present, else the preview geometry.
+        model_task_id = refine_id or preview_id
         meta.update({
+            "ai_model": "meshy-5",
+            "source": "meshy-text-to-3d-v2",
             "prompt": args.prompt,
             "preview_task_id": preview_id,
             "refine_task_id": refine_id,
+            "model_task_id": model_task_id,
             "refined": not args.no_refine,
             "glb_bytes": size,
             "consumed_credits": consumed,
         })
-        # Rigging consumes the textured model (refine) when present, else the preview geometry.
-        model_task_id = refine_id or preview_id
 
     # ---- rig + animate (HUMANOID only) ----
     if do_rig:

--- a/extensions/renderers/godot/tools/meshy_gen.py
+++ b/extensions/renderers/godot/tools/meshy_gen.py
@@ -21,10 +21,19 @@ Flow (per the verified Meshy v2 text-to-3d contract):
 The API key is read from ~/.worldos/meshy.key or $MESHY_API_KEY. It is NEVER printed and
 NEVER written into any repo file.
 
+Rig + animate (HUMANOID only — Meshy cannot rig creatures; use tripo_gen.py for those):
+  6. POST /openapi/v1/rigging {input_task_id, height_meters} -> rigged fbx+glb + FREE walk/run clips
+  7. POST /openapi/v1/animations {rig_task_id, action_id}    -> one library clip (3 cr each)
+  Import the rigged FBX into Unity as animationType=GENERIC (not Humanoid — the Meshy bone names
+  don't auto-map to Unity's Humanoid avatar, which silently drops the clips). Verified 2026-06-28.
+
 Usage:
     python3 meshy_gen.py --prompt "a stylized fantasy human ranger ..." --out <dir>
     python3 meshy_gen.py --prompt "..." --out <dir> --no-refine   # geometry only (no texture)
     python3 meshy_gen.py --prompt "..." --out <dir> --force        # re-generate even if model.glb exists
+    python3 meshy_gen.py --prompt "..." --out <dir> --rig          # gen -> rig (+ free walk/run)
+    python3 meshy_gen.py --prompt "..." --out <dir> --rig --animate 0 4   # + Idle(0) + Attack(4)
+    python3 meshy_gen.py --rig-from-task <meshy_model_task_id> --out <dir> --animate 0  # rig an existing model
 """
 
 from __future__ import annotations
@@ -40,6 +49,11 @@ import urllib.request
 API_BASE = "https://api.meshy.ai"
 CREATE_PATH = "/openapi/v2/text-to-3d"
 POLL_TEMPLATE = "/openapi/v2/text-to-3d/{task_id}"
+# Rigging + animation live on /openapi/v1 (the version split is a Meshy footgun).
+RIGGING_PATH = "/openapi/v1/rigging"
+RIGGING_POLL = "/openapi/v1/rigging/{task_id}"
+ANIM_PATH = "/openapi/v1/animations"
+ANIM_POLL = "/openapi/v1/animations/{task_id}"
 
 # Polling cadence + ceilings.
 POLL_INTERVAL_SEC = 8
@@ -183,9 +197,14 @@ def _create_refine(headers: dict, preview_task_id: str) -> str:
     return task_id
 
 
-def _poll(headers: dict, task_id: str, label: str, timeout_sec: int) -> dict:
-    """Poll a task until SUCCEEDED. Exits on FAILED / timeout. Returns the final task dict."""
-    url = API_BASE + POLL_TEMPLATE.format(task_id=task_id)
+def _poll(headers: dict, task_id: str, label: str, timeout_sec: int,
+          poll_template: str = POLL_TEMPLATE) -> dict:
+    """Poll a task until SUCCEEDED. Exits on FAILED / timeout. Returns the final task dict.
+
+    poll_template selects the endpoint family: v2 text-to-3d (default), or the v1 rigging /
+    animation templates. All share the same SUCCEEDED/FAILED/progress status model.
+    """
+    url = API_BASE + poll_template.format(task_id=task_id)
     deadline = time.time() + timeout_sec
     last_progress = -1
     while True:
@@ -219,6 +238,79 @@ def _glb_url(task: dict) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Rigging + animation (HUMANOID only). Mirrors tripo_gen.py's rig pipeline shape.
+# ---------------------------------------------------------------------------
+def _create_rigging(headers: dict, model_task_id: str, height_meters: float) -> str:
+    # input_task_id = a prior SUCCEEDED Meshy text-to-3d/image-to-3d task. Humanoid only (else 422).
+    body = {"input_task_id": model_task_id, "height_meters": height_meters}
+    res = _post_json(API_BASE + RIGGING_PATH, headers, body)
+    task_id = res.get("result")
+    if not task_id:
+        sys.exit("[meshy_gen] ERROR: rigging create returned no task id: %s" % json.dumps(res))
+    print("[meshy_gen] rigging task submitted: %s" % task_id)
+    return task_id
+
+
+def _create_animation(headers: dict, rig_task_id: str, action_id: int) -> str:
+    # action_id is an integer from the Meshy animation library (0=Idle, 4=Attack, 14=Run_02, ...).
+    body = {"rig_task_id": rig_task_id, "action_id": int(action_id)}
+    res = _post_json(API_BASE + ANIM_PATH, headers, body)
+    task_id = res.get("result")
+    if not task_id:
+        sys.exit("[meshy_gen] ERROR: animation create returned no task id: %s" % json.dumps(res))
+    print("[meshy_gen] animation task submitted: %s (action_id=%d)" % (task_id, int(action_id)))
+    return task_id
+
+
+def _download_pairs(result: dict, out_dir: str, pairs: list) -> dict:
+    """Download a set of (result-key, dest-filename) URLs that are present; return {name: bytes}.
+
+    Prefers FBX for Unity (Mecanim). Missing keys are skipped (e.g. armature-only variants).
+    """
+    saved: dict = {}
+    for key, fname in pairs:
+        url = result.get(key)
+        if isinstance(url, str) and url:
+            size = _download(url, os.path.join(out_dir, fname))
+            saved[fname] = size
+            print("[meshy_gen] downloaded %s (%d bytes)" % (fname, size))
+    return saved
+
+
+def _run_rig_and_animate(headers: dict, model_task_id: str, out_dir: str, height: float,
+                         action_ids: list, timeout: int, meta: dict) -> None:
+    """rig the model (humanoid) -> download rigged FBX/GLB + free walk/run -> optional library clips."""
+    rig_id = _create_rigging(headers, model_task_id, height)
+    rig_task = _poll(headers, rig_id, "rigging", timeout, poll_template=RIGGING_POLL)
+    result = rig_task.get("result", {}) or {}
+    rig_files = _download_pairs(result, out_dir, [
+        ("rigged_character_fbx_url", "rigged.fbx"),
+        ("rigged_character_glb_url", "rigged.glb"),
+    ])
+    basic = result.get("basic_animations", {}) or {}
+    basic_files = _download_pairs(basic, out_dir, [
+        ("walking_fbx_url", "anim_walking.fbx"),
+        ("running_fbx_url", "anim_running.fbx"),
+    ])
+    meta["rig_task_id"] = rig_id
+    meta["rig_files"] = rig_files
+    meta["basic_animation_files"] = basic_files
+
+    anim_files: dict = {}
+    for aid in action_ids or []:
+        an_id = _create_animation(headers, rig_id, aid)
+        an_task = _poll(headers, an_id, "animation:%s" % aid, timeout, poll_template=ANIM_POLL)
+        an_result = an_task.get("result", {}) or {}
+        files = _download_pairs(an_result, out_dir, [
+            ("animation_fbx_url", "anim_action_%d.fbx" % int(aid)),
+            ("animation_glb_url", "anim_action_%d.glb" % int(aid)),
+        ])
+        anim_files[str(int(aid))] = dict(task_id=an_id, **files)
+    if action_ids:
+        meta["animation_files"] = anim_files
+
+
+# ---------------------------------------------------------------------------
 # --test-key (cheap auth probe) and --dry-run (no API call).
 # ---------------------------------------------------------------------------
 # Rough per-stage credit estimates (for --dry-run only; the API is the source of truth).
@@ -249,16 +341,24 @@ def _cmd_test_key() -> None:
 def _cmd_dry_run(args) -> None:
     """Print the generation plan + estimated credits and exit — NO API call, NO key needed."""
     out_dir = os.path.abspath(args.out)
-    print("[meshy_gen] DRY-RUN text-to-3d (NO API call)")
-    print("  prompt     : %s" % args.prompt)
+    print("[meshy_gen] DRY-RUN (NO API call)")
     print("  out dir    : %s" % out_dir)
-    if args.no_refine:
+    if args.rig_from_task:
+        print("  plan       : rig existing model task %s (no generation)" % args.rig_from_task)
+    elif args.no_refine:
+        print("  prompt     : %s" % args.prompt)
         print("  plan       : preview only (untextured geometry; --no-refine)")
         print("  est credits: preview %s" % CREDIT_EST["preview"])
     else:
+        print("  prompt     : %s" % args.prompt)
         print("  plan       : preview -> refine (PBR-textured)")
         print("  est credits: preview %s + refine %s (API is source of truth)" % (
             CREDIT_EST["preview"], CREDIT_EST["refine"]))
+    if args.rig or args.rig_from_task or args.action_ids:
+        print("  rig        : YES (HUMANOID only) height=%.2fm -> rigged fbx/glb + free walk/run (~5 cr)"
+              % args.rig_height)
+        if args.action_ids:
+            print("  animate    : action_ids %s (~3 cr each)" % " ".join(str(a) for a in args.action_ids))
 
 
 # ---------------------------------------------------------------------------
@@ -277,6 +377,14 @@ def main() -> None:
                     help="stop after preview (untextured geometry only)")
     ap.add_argument("--force", action="store_true",
                     help="regenerate even if <out>/model.glb already exists")
+    ap.add_argument("--rig", action="store_true",
+                    help="after generation, auto-rig the model (HUMANOID only) + download free walk/run")
+    ap.add_argument("--rig-from-task", dest="rig_from_task",
+                    help="skip generation; rig an EXISTING Meshy model task id (implies --rig)")
+    ap.add_argument("--rig-height", dest="rig_height", type=float, default=1.7,
+                    help="character height in meters for rigging (default 1.7)")
+    ap.add_argument("--animate", dest="action_ids", nargs="+", type=int, metavar="ACTION_ID",
+                    help="library action_id(s) to apply after rigging (e.g. 0=Idle 4=Attack); implies --rig")
     ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SEC,
                     help="per-stage poll timeout in seconds (default %d)" % DEFAULT_TIMEOUT_SEC)
     args = ap.parse_args()
@@ -285,8 +393,13 @@ def main() -> None:
         _cmd_test_key()
         return
 
-    if not args.prompt or not args.out:
-        ap.error("--prompt and --out are required (unless --test-key).")
+    do_rig = bool(args.rig or args.rig_from_task or args.action_ids)
+
+    # --rig-from-task operates on an existing model; otherwise --prompt is required to generate.
+    if not args.out:
+        ap.error("--out is required (unless --test-key).")
+    if not args.rig_from_task and not args.prompt:
+        ap.error("--prompt is required (unless --test-key or --rig-from-task).")
 
     if args.dry_run:
         _cmd_dry_run(args)
@@ -298,62 +411,75 @@ def main() -> None:
     thumb_path = os.path.join(out_dir, "thumbnail.png")
     meta_path = os.path.join(out_dir, "meshy_meta.json")
 
-    if os.path.exists(model_path) and not args.force:
+    # Only the no-rig generation path short-circuits on an existing model.glb; rig paths must proceed
+    # (they need a live task id, which --rig-from-task supplies and a fresh gen produces).
+    if os.path.exists(model_path) and not args.force and not do_rig:
         print("[meshy_gen] %s already exists; skipping (use --force to regenerate)." % model_path)
         return
 
     key = _load_api_key()
     headers = _auth_headers(key)
+    meta: dict = {"ai_model": "meshy-5", "source": "meshy-text-to-3d-v2"}
 
-    # ---- preview ----
-    preview_id = _create_preview(headers, args.prompt)
-    preview_task = _poll(headers, preview_id, "preview", args.timeout)
-
-    final_task = preview_task
-    refine_id = None
-    if args.no_refine:
-        print("[meshy_gen] --no-refine: keeping the untextured preview model.")
+    if args.rig_from_task:
+        # Rig an EXISTING Meshy model task — skip generation entirely.
+        model_task_id = args.rig_from_task
+        meta["model_task_id"] = model_task_id
+        print("[meshy_gen] rigging existing model task %s (generation skipped)." % model_task_id)
     else:
-        # ---- refine (adds PBR texture) ----
-        refine_id = _create_refine(headers, preview_id)
-        final_task = _poll(headers, refine_id, "refine", args.timeout)
+        # ---- preview ----
+        preview_id = _create_preview(headers, args.prompt)
+        preview_task = _poll(headers, preview_id, "preview", args.timeout)
+        final_task = preview_task
+        refine_id = None
+        if args.no_refine:
+            print("[meshy_gen] --no-refine: keeping the untextured preview model.")
+        else:
+            # ---- refine (adds PBR texture) ----
+            refine_id = _create_refine(headers, preview_id)
+            final_task = _poll(headers, refine_id, "refine", args.timeout)
 
-    # ---- download ----
-    glb_url = _glb_url(final_task)
-    size = _download(glb_url, model_path)
-    print("[meshy_gen] downloaded model.glb (%d bytes) -> %s" % (size, model_path))
+        # ---- download base model ----
+        glb_url = _glb_url(final_task)
+        size = _download(glb_url, model_path)
+        print("[meshy_gen] downloaded model.glb (%d bytes) -> %s" % (size, model_path))
 
-    thumb_url = final_task.get("thumbnail_url")
-    if thumb_url:
-        try:
-            tsize = _download(thumb_url, thumb_path)
-            print("[meshy_gen] downloaded thumbnail.png (%d bytes)" % tsize)
-        except SystemExit:
-            print("[meshy_gen] (thumbnail download failed; continuing — non-fatal)")
+        thumb_url = final_task.get("thumbnail_url")
+        if thumb_url:
+            try:
+                tsize = _download(thumb_url, thumb_path)
+                print("[meshy_gen] downloaded thumbnail.png (%d bytes)" % tsize)
+            except SystemExit:
+                print("[meshy_gen] (thumbnail download failed; continuing — non-fatal)")
 
-    # consumed-credits: Meshy reports per-task usage on some plans.
-    consumed = (
-        final_task.get("consumed_credits")
-        or final_task.get("credits")
-        or preview_task.get("consumed_credits")
-    )
+        consumed = (
+            final_task.get("consumed_credits")
+            or final_task.get("credits")
+            or preview_task.get("consumed_credits")
+        )
+        meta.update({
+            "prompt": args.prompt,
+            "preview_task_id": preview_id,
+            "refine_task_id": refine_id,
+            "refined": not args.no_refine,
+            "glb_bytes": size,
+            "consumed_credits": consumed,
+        })
+        # Rigging consumes the textured model (refine) when present, else the preview geometry.
+        model_task_id = refine_id or preview_id
 
-    meta = {
-        "prompt": args.prompt,
-        "preview_task_id": preview_id,
-        "refine_task_id": refine_id,
-        "refined": not args.no_refine,
-        "glb_bytes": size,
-        "consumed_credits": consumed,
-        "ai_model": "meshy-5",
-        "source": "meshy-text-to-3d-v2",
-    }
+    # ---- rig + animate (HUMANOID only) ----
+    if do_rig:
+        _run_rig_and_animate(headers, model_task_id, out_dir, args.rig_height,
+                             args.action_ids, args.timeout, meta)
+
     with open(meta_path, "w") as f:
         json.dump(meta, f, indent=2)
         f.write("\n")
-
-    print("[meshy_gen] OK — preview=%s refine=%s glb_bytes=%d consumed_credits=%s" % (
-        preview_id, refine_id, size, consumed))
+    summary = {k: meta[k] for k in
+               ("preview_task_id", "refine_task_id", "model_task_id", "rig_task_id")
+               if meta.get(k)}
+    print("[meshy_gen] OK — %s" % json.dumps(summary))
     print("[meshy_gen] meta -> %s" % meta_path)
 
 

--- a/extensions/renderers/godot/tools/tripo_gen.py
+++ b/extensions/renderers/godot/tools/tripo_gen.py
@@ -106,6 +106,15 @@ DEFAULT_CREATURE_ANIMATIONS = ["walk"]   # cross-rig-safe; the only clip verifie
 # Back-compat alias (the biped set is what callers historically referenced).
 DEFAULT_ANIMATIONS = DEFAULT_BIPED_ANIMATIONS
 
+# Map the bake-manifest's friendly clip names -> real Tripo preset leaf names, so callers/columns
+# that say "attack"/"cast" still resolve (Tripo has no attack/cast preset). Applied to the LEAF
+# name before namespacing -> e.g. attack -> preset:biped:slash. (Grafted from the v2 wrapper.)
+ANIM_ALIAS = {"attack": "slash", "cast": "shoot"}
+
+# Supported image-to-model input extensions (jpeg normalizes to jpg). Used to fail fast on an
+# unsupported image before spending an upload round-trip.
+IMAGE_EXT_TO_TYPE = {".jpg": "jpg", ".jpeg": "jpg", ".png": "png", ".webp": "webp"}
+
 # Polling cadence + ceilings. >= 2s honors the documented 1 req/s rate limit (else 429).
 POLL_INTERVAL_SEC = 3
 DEFAULT_TIMEOUT_SEC = 600
@@ -148,7 +157,9 @@ def _post_json(url: str, headers: dict, body: dict) -> dict:
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=60) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+            res = json.loads(resp.read().decode("utf-8"))
+            _check_api_code(res, "POST " + url)
+            return res
     except urllib.error.HTTPError as e:
         _explain_http(e.code, _read_error(e), "POST " + url)
     except urllib.error.URLError as e:
@@ -159,7 +170,9 @@ def _get_json(url: str, headers: dict) -> dict:
     req = urllib.request.Request(url, headers=headers, method="GET")
     try:
         with urllib.request.urlopen(req, timeout=60) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+            res = json.loads(resp.read().decode("utf-8"))
+            _check_api_code(res, "GET " + url)
+            return res
     except urllib.error.HTTPError as e:
         _explain_http(e.code, _read_error(e), "GET " + url)
     except urllib.error.URLError as e:
@@ -191,7 +204,9 @@ def _post_multipart(url: str, key: str, file_path: str) -> dict:
     )
     try:
         with urllib.request.urlopen(req, timeout=120) as resp:
-            return json.loads(resp.read().decode("utf-8"))
+            res = json.loads(resp.read().decode("utf-8"))
+            _check_api_code(res, "POST(multipart) " + url)
+            return res
     except urllib.error.HTTPError as e:
         _explain_http(e.code, _read_error(e), "POST(multipart) " + url)
     except urllib.error.URLError as e:
@@ -205,7 +220,35 @@ def _read_error(e: urllib.error.HTTPError) -> str:
         return "<no body>"
 
 
+def _check_api_code(res: dict, what: str) -> None:
+    """Tripo returns a non-zero `code` (with a human `message`) for BUSINESS errors even on
+    HTTP 200 — e.g. code 2010 = insufficient credit, code 1004 = invalid model. Without this,
+    such a body is treated as success and crashes later with a confusing "no task id"/"no model
+    URL". A missing/zero `code` (or a non-envelope payload) passes through as success.
+    """
+    if not isinstance(res, dict):
+        return
+    code = res.get("code")
+    if code in (None, 0):
+        return
+    msg = res.get("message") or ""
+    if code == 2010 or "credit" in msg.lower():
+        sys.exit(
+            "[tripo_gen] ERROR: insufficient Tripo credits on %s (code=%s). Top up at "
+            "https://platform.tripo3d.ai/ ; art was NOT generated. Detail: %s"
+            % (what, code, json.dumps(res))
+        )
+    sys.exit("[tripo_gen] ERROR: Tripo API error code=%s on %s. Detail: %s"
+             % (code, what, json.dumps(res)))
+
+
 def _explain_http(code: int, detail: str, what: str) -> None:
+    # Insufficient credit (code 2010) is returned with HTTP 403 on some paths.
+    if "2010" in detail or "enough credit" in detail.lower() or '"credit"' in detail.lower():
+        sys.exit(
+            "[tripo_gen] ERROR: insufficient Tripo credits on %s. Top up at "
+            "https://platform.tripo3d.ai/ ; art was NOT generated. Detail: %s" % (what, detail)
+        )
     if code == 401:
         sys.exit(
             "[tripo_gen] ERROR 401 unauthorized on %s — bad/expired API key. Detail: %s"
@@ -269,11 +312,26 @@ def _create_text(headers: dict, prompt: str, model: str) -> str:
     return task_id
 
 
-def _create_image(headers: dict, file_token: str, model: str) -> str:
-    # v3 canonical: {model, file:{type:"image", file_token}} (no top-level `type`/`model_version`).
+def _image_file_type(image_path: str) -> str:
+    """Derive the image file.type from the extension (jpeg->jpg). Reject unsupported types so we
+    never silently mislabel a file and waste an upload round-trip. (Grafted from the v2 wrapper.)"""
+    ext = os.path.splitext(image_path)[1].lower()
+    file_type = IMAGE_EXT_TO_TYPE.get(ext)
+    if not file_type:
+        sys.exit(
+            "[tripo_gen] ERROR: unsupported image type %r for %s — supported: %s"
+            % (ext or "<none>", os.path.basename(image_path),
+               ", ".join(sorted(set(IMAGE_EXT_TO_TYPE.values()))))
+        )
+    return file_type
+
+
+def _create_image(headers: dict, file_token: str, model: str, file_type: str) -> str:
+    # NOTE: the image-to-3D path is NOT live-tested on v3 (only text-to-model was). Body mirrors the
+    # SDK contract: file.type is the extension-derived type (jpg/png/webp), not a literal "image".
     body = {
         "model": model,
-        "file": {"type": "image", "file_token": file_token},
+        "file": {"type": file_type, "file_token": file_token},
     }
     res = _post_json(API_BASE + CREATE_IMAGE_PATH, headers, body)
     task_id = _task_id_from_create(res, "image-to-3D create")
@@ -341,8 +399,9 @@ def _rig(headers: dict, task_id: str, rig_type: str, out_format: str = "glb") ->
 def _retarget(headers: dict, rigged_task_id: str, rig_type: str, animation: str,
               out_format: str = "glb") -> str:
     # Presets are namespaced by rig_type and applied ONE per call (batches fail). e.g.
-    # "preset:biped:walk", "preset:quadruped:walk".
-    preset = "preset:%s:%s" % (rig_type, animation)
+    # "preset:biped:walk", "preset:quadruped:walk". Alias friendly names (attack->slash, cast->shoot).
+    leaf = ANIM_ALIAS.get(animation, animation)
+    preset = "preset:%s:%s" % (rig_type, leaf)
     body = {"input": rigged_task_id, "animations": [preset], "out_format": out_format}
     res = _post_json(API_BASE + RETARGET_PATH, headers, body)
     rt_task = _task_id_from_create(res, "retarget create")
@@ -562,10 +621,11 @@ def _cmd_image(args) -> None:
     if os.path.exists(model_path) and not args.force:
         print("[tripo_gen] %s exists; skipping (use --force)." % model_path)
         return
+    file_type = _image_file_type(args.image)  # fail fast on an unsupported image before uploading
     key = _load_api_key()
     headers = _auth_headers(key)
     token = _upload_image(key, args.image)
-    task_id = _create_image(headers, token, model)
+    task_id = _create_image(headers, token, model, file_type)
     task = _poll(headers, task_id, "image-to-3D", args.timeout)
     size = _download(_model_url(task), model_path)
     print("[tripo_gen] downloaded model.glb (%d bytes) -> %s" % (size, model_path))

--- a/extensions/renderers/godot/tools/tripo_gen.py
+++ b/extensions/renderers/godot/tools/tripo_gen.py
@@ -40,8 +40,9 @@ public docs AND the prior version of this wrapper; the corrections below are wha
                           Presets are NAMESPACED by rig_type: "preset:biped:walk", "preset:quadruped:walk"
                           (bare "preset:walk" FAILS). ONE preset per call — multi-preset batches FAIL.
                           out_format=fbx -> a Unity-ready FBX directly (no Blender needed).
-  * Each create returns a TASK ID. Poll GET /task/{id} at >= 3s (1 req/s limit -> 429). Output URL is
-    at data.output.model_url and EXPIRES ~5 min -> download immediately on success.
+  * Each create returns a TASK ID. Poll GET /tasks/{id} (PLURAL — singular /task/{id} 404s) at
+    >= 3s (1 req/s limit -> 429). Output URL is at data.output.model_url and EXPIRES ~5 min ->
+    download immediately on success.
 
 The API key is read from ~/.worldos/tripo3d.key or $WORLDOS_TRIPO_API_KEY. It is NEVER
 printed/logged and NEVER written into any repo file.
@@ -96,10 +97,14 @@ MODEL_LOWPOLY = "P1-20260311"
 # default (v2.5-20250123) is REJECTED, and v1.0-20240301's retarget fails — so pin this one.
 RIG_MODEL = "v2.5-20260210"
 
-# Default retarget clips (biped names live-verified: walk/idle/run/slash succeed individually).
-# Presets are namespaced per rig_type at call time -> "preset:<rig_type>:<name>". Per-clip failures
-# are non-fatal (e.g. a quadruped only supports `walk`), so an unsupported name just warns + skips.
-DEFAULT_ANIMATIONS = ["walk", "idle", "run", "slash"]
+# Default retarget clips, chosen by rig_type AFTER rig-check (so a quadruped doesn't queue failing
+# biped-only clips). Names live-verified per rig_type; presets namespaced at call time as
+# "preset:<rig_type>:<name>". `--animations` overrides these for any rig_type. Per-clip failures
+# are non-fatal (warn + skip) for the rare unsupported name.
+DEFAULT_BIPED_ANIMATIONS = ["walk", "idle", "run", "slash"]
+DEFAULT_CREATURE_ANIMATIONS = ["walk"]   # cross-rig-safe; the only clip verified for non-bipeds
+# Back-compat alias (the biped set is what callers historically referenced).
+DEFAULT_ANIMATIONS = DEFAULT_BIPED_ANIMATIONS
 
 # Polling cadence + ceilings. >= 2s honors the documented 1 req/s rate limit (else 429).
 POLL_INTERVAL_SEC = 3
@@ -298,13 +303,22 @@ def _rig_check(headers: dict, task_id: str) -> str:
     print("[tripo_gen] rig-check submitted: %s" % check_task)
     final = _poll(headers, check_task, "rig-check", DEFAULT_TIMEOUT_SEC)
     out = final.get("output") or {}
-    riggable = out.get("riggable", out.get("rig_ready", True))
-    if riggable is False:
+    # Treat riggable + rig_type as REQUIRED. Defaulting them (riggable=True, rig_type=biped) would
+    # turn an upstream contract break into a wrong-skeleton run (mixamo spec + preset:biped:* on a
+    # creature) that burns a full rig/retarget cycle — fail fast instead.
+    riggable = out.get("riggable", out.get("rig_ready"))
+    if riggable is not True:
         sys.exit(
-            "[tripo_gen] ERROR: model is NOT riggable per rig-check (%s). "
+            "[tripo_gen] ERROR: rig-check did not confirm riggable=true (got %s). "
             "Rigging aborted." % json.dumps(out)
         )
-    rig_type = out.get("rig_type") or "biped"
+    rig_type = out.get("rig_type")
+    valid_types = ("biped", "quadruped", "hexapod", "octopod", "avian", "serpentine", "aquatic")
+    if rig_type not in valid_types:
+        sys.exit(
+            "[tripo_gen] ERROR: rig-check returned no/unknown rig_type (%s); expected one of %s. "
+            "Rigging aborted." % (json.dumps(out), ", ".join(valid_types))
+        )
     print("[tripo_gen] rig-check OK — riggable, rig_type=%s." % rig_type)
     return rig_type
 
@@ -417,17 +431,20 @@ def _resolve_out(args) -> str:
 # --------------------------------------------------------------------------- #
 # Sub-command bodies.
 # --------------------------------------------------------------------------- #
-def _do_rig_pipeline(headers: dict, source_task_id: str, animations: list,
-                     out_dir: str, timeout: int, meta: dict, out_format: str = "glb") -> None:
+def _do_rig_pipeline(headers: dict, source_task_id: str, animations, out_dir: str,
+                     timeout: int, meta: dict, out_format: str = "glb") -> None:
     """rig-check -> rig -> retarget (ONE preset per call); download rigged + per-clip animated files.
 
     rig-check returns the recommended rig_type (biped/quadruped/...), which drives the rig spec and
-    the namespaced retarget presets. Per-clip retargets are non-fatal so one unsupported preset
-    (e.g. a creature that only supports `walk`) just warns and skips. out_format glb|fbx (fbx is
-    Unity-ready directly, no Blender).
+    the namespaced retarget presets. When `animations` is None, the clip set is chosen by rig_type
+    (a biped set vs the cross-rig-safe creature set) so non-bipeds don't queue failing biped-only
+    clips. Per-clip retargets are non-fatal so an unsupported preset just warns and skips.
+    out_format glb|fbx (fbx is Unity-ready directly, no Blender).
     """
     ext = "fbx" if out_format == "fbx" else "glb"
     rig_type = _rig_check(headers, source_task_id)
+    if animations is None:  # pick defaults now that rig_type is known
+        animations = DEFAULT_BIPED_ANIMATIONS if rig_type == "biped" else DEFAULT_CREATURE_ANIMATIONS
     rig_task_id = _rig(headers, source_task_id, rig_type, out_format)
     rigged = _poll(headers, rig_task_id, "rig", timeout)
     rigged_path = os.path.join(out_dir, "rigged.%s" % ext)
@@ -488,14 +505,15 @@ def _cmd_text(args) -> None:
     model = MODEL_LOWPOLY if args.lowpoly else MODEL_DEFAULT
     out_dir = _resolve_out(args)
     if args.dry_run:
+        anims = args.animations or DEFAULT_BIPED_ANIMATIONS  # actual set is rig_type-chosen at run time
         est = CREDIT_EST["text"] + (
-            CREDIT_EST["rig"] + CREDIT_EST["retarget_each"] * len(args.animations)
+            CREDIT_EST["rig"] + CREDIT_EST["retarget_each"] * len(anims)
             if args.rig else 0
         )
         print("[tripo_gen] DRY-RUN text-to-3D")
         print("  prompt    : %s" % args.prompt)
         print("  model     : %s" % model)
-        print("  rig+anim  : %s (%s)" % (args.rig, ",".join(args.animations) if args.rig else "-"))
+        print("  rig+anim  : %s (%s)" % (args.rig, ",".join(anims) if args.rig else "-"))
         print("  out dir   : %s" % out_dir)
         print("  est credits: ~%d (API is source of truth)" % est)
         return
@@ -525,14 +543,15 @@ def _cmd_image(args) -> None:
     model = MODEL_LOWPOLY if args.lowpoly else MODEL_DEFAULT
     out_dir = _resolve_out(args)
     if args.dry_run:
+        anims = args.animations or DEFAULT_BIPED_ANIMATIONS  # actual set is rig_type-chosen at run time
         est = CREDIT_EST["image"] + (
-            CREDIT_EST["rig"] + CREDIT_EST["retarget_each"] * len(args.animations)
+            CREDIT_EST["rig"] + CREDIT_EST["retarget_each"] * len(anims)
             if args.rig else 0
         )
         print("[tripo_gen] DRY-RUN image-to-3D")
         print("  image     : %s" % args.image)
         print("  model     : %s" % model)
-        print("  rig+anim  : %s (%s)" % (args.rig, ",".join(args.animations) if args.rig else "-"))
+        print("  rig+anim  : %s (%s)" % (args.rig, ",".join(anims) if args.rig else "-"))
         print("  out dir   : %s" % out_dir)
         print("  est credits: ~%d (API is source of truth)" % est)
         return
@@ -564,10 +583,12 @@ def _cmd_image(args) -> None:
 def _cmd_rig(args) -> None:
     out_dir = _resolve_out(args)
     if args.dry_run:
-        est = CREDIT_EST["rig"] + CREDIT_EST["retarget_each"] * len(args.animations)
+        anims = args.animations or DEFAULT_BIPED_ANIMATIONS  # actual set is rig_type-chosen at run time
+        est = CREDIT_EST["rig"] + CREDIT_EST["retarget_each"] * len(anims)
         print("[tripo_gen] DRY-RUN rig pipeline (rig-check -> rig -> retarget, one preset/call)")
         print("  source task: %s" % args.task)
-        print("  animations : %s" % ",".join(args.animations))
+        print("  animations : %s (biped default shown; non-biped uses %s)"
+              % (",".join(anims), ",".join(DEFAULT_CREATURE_ANIMATIONS)))
         print("  out format : %s" % args.out_format)
         print("  out dir    : %s" % out_dir)
         print("  est credits: ~%d (API is source of truth)" % est)
@@ -593,9 +614,10 @@ def _add_common(sp) -> None:
                     help="use the P1 low-poly / game-ready model instead of v3.1")
     sp.add_argument("--rig", action="store_true",
                     help="after generation, run rig-check -> rig(spec=mixamo) -> retarget")
-    sp.add_argument("--animations", nargs="+", default=list(DEFAULT_ANIMATIONS),
-                    help="retarget clip names, namespaced per rig_type at call time "
-                         "(default: %s)" % " ".join(DEFAULT_ANIMATIONS))
+    sp.add_argument("--animations", nargs="+", default=None,
+                    help="retarget clip names, namespaced per rig_type at call time. Default depends "
+                         "on rig_type: biped=[%s], non-biped=[%s]."
+                         % (" ".join(DEFAULT_BIPED_ANIMATIONS), " ".join(DEFAULT_CREATURE_ANIMATIONS)))
     sp.add_argument("--out-format", choices=("glb", "fbx"), default="glb", dest="out_format",
                     help="rig/retarget output format; fbx is Unity-ready directly (no Blender)")
     sp.add_argument("--force", action="store_true", help="regenerate even if model.glb exists")

--- a/extensions/renderers/godot/tools/tripo_gen.py
+++ b/extensions/renderers/godot/tools/tripo_gen.py
@@ -20,17 +20,28 @@ Downstream contract (the manifest this output ultimately feeds):
 This tool is WorldOS-ORIGINAL code; the ART it downloads (model.glb + animated GLBs) is
 NOT committed — it lives under content/worlds/_private/ (gitignored, owner-licensed).
 
-VERIFIED Tripo3D contract (some details differ from public docs — confirmed live):
+VERIFIED Tripo3D v3 contract (LIVE-TESTED 2026-06-28 — several details differ from BOTH the
+public docs AND the prior version of this wrapper; the corrections below are what actually works):
   * Auth: Bearer  ``Authorization: Bearer <key>``  (NOT x-api-key).
   * Base: https://openapi.tripo3d.ai/v3
-  * Create text-to-3D:    POST /generation/text          (prompt; model default v3.1, or P1 low-poly)
-  * Create image-to-3D:   POST /generation/image-to-model
-  * Upload an image/glb:  POST /upload                    (multipart)
-  * Rig pre-check:        POST /animations/rig-check      (input=task_id, rig_type=biped)  -- run FIRST
-  * Rig:                  POST /animations/rig            (input=task_id, rig_type=biped, spec=mixamo)
-  * Retarget animations:  POST /animations/retarget       (input=rigged_task_id, animations=[preset:*])
-  * Each create returns a TASK ID. Poll GET /task/{id} at >= 2s intervals (1 req/s limit -> 429).
-  * The model download URL EXPIRES ~5 min -> download immediately on success.
+  * Create text-to-3D:    POST /generation/text-to-model  body {prompt, model}  (NO `type` field;
+                          the old /generation/text now 404s. `model` NOT `model_version`.)
+  * Create image-to-3D:   POST /generation/image-to-model body {model, file:{type:"image",file_token}}
+  * Upload an image/glb:  POST /files                     (multipart) -> data.file_token
+  * Model ids are DATE-STAMPED (friendly names like "tripo-p1"/"v3.1" are REJECTED):
+       P1-20260311 (game/low-poly), v3.1-20260211 (default hi-precision), v3.0-20250812, v2.5-20250123.
+  * Rig pre-check:        POST /animations/rig-check      body {input}  -- run FIRST; it RETURNS the
+                          recommended rig_type (biped|quadruped|avian|...). DON'T hardcode biped.
+  * Rig:                  POST /animations/rig            body {input, model, rig_type, spec, out_format}
+                          model MUST be v2.5-20260210 (biped AND creatures; the server default
+                          v2.5-20250123 is REJECTED; v1.0-20240301 rigs but its retarget fails).
+                          spec=mixamo for biped, tripo for creatures. out_format glb|fbx.
+  * Retarget animations:  POST /animations/retarget       body {input:<rigged_id>, animations:[preset], out_format}
+                          Presets are NAMESPACED by rig_type: "preset:biped:walk", "preset:quadruped:walk"
+                          (bare "preset:walk" FAILS). ONE preset per call — multi-preset batches FAIL.
+                          out_format=fbx -> a Unity-ready FBX directly (no Blender needed).
+  * Each create returns a TASK ID. Poll GET /task/{id} at >= 3s (1 req/s limit -> 429). Output URL is
+    at data.output.model_url and EXPIRES ~5 min -> download immediately on success.
 
 The API key is read from ~/.worldos/tripo3d.key or $WORLDOS_TRIPO_API_KEY. It is NEVER
 printed/logged and NEVER written into any repo file.
@@ -67,20 +78,28 @@ import urllib.request
 import uuid
 
 API_BASE = "https://openapi.tripo3d.ai/v3"
-CREATE_TEXT_PATH = "/generation/text"
+CREATE_TEXT_PATH = "/generation/text-to-model"   # was /generation/text (now 404s)
 CREATE_IMAGE_PATH = "/generation/image-to-model"
-UPLOAD_PATH = "/upload"
+UPLOAD_PATH = "/files"                            # was /upload; returns data.file_token
 RIG_CHECK_PATH = "/animations/rig-check"
 RIG_PATH = "/animations/rig"
 RETARGET_PATH = "/animations/retarget"
-TASK_PATH = "/task/{task_id}"
+TASK_PATH = "/tasks/{task_id}"   # PLURAL — the singular /task/{id} 404s in v3
 
-# Models: H3.1 (default, high quality) vs P1 (low-poly / game-ready).
-MODEL_DEFAULT = "v3.1"
-MODEL_LOWPOLY = "P1-low-poly"
+# Generation model ids are DATE-STAMPED (live-verified 2026-06-28; friendly names are rejected).
+# Bump these when Tripo deprecates a date (a 400 "invalid model ... allowed values: ..." names the
+# current set). P1 = game/low-poly, v3.1 = default high-precision.
+MODEL_DEFAULT = "v3.1-20260211"
+MODEL_LOWPOLY = "P1-20260311"
 
-# The 5 retarget presets that align with the bake manifest's idle/walk/attack/cast columns.
-DEFAULT_ANIMATIONS = ["walk", "idle", "run", "attack", "cast"]
+# The rig model. v2.5-20260210 rigs BOTH bipeds and creatures (quadruped/avian/...). The server
+# default (v2.5-20250123) is REJECTED, and v1.0-20240301's retarget fails — so pin this one.
+RIG_MODEL = "v2.5-20260210"
+
+# Default retarget clips (biped names live-verified: walk/idle/run/slash succeed individually).
+# Presets are namespaced per rig_type at call time -> "preset:<rig_type>:<name>". Per-clip failures
+# are non-fatal (e.g. a quadruped only supports `walk`), so an unsupported name just warns + skips.
+DEFAULT_ANIMATIONS = ["walk", "idle", "run", "slash"]
 
 # Polling cadence + ceilings. >= 2s honors the documented 1 req/s rate limit (else 429).
 POLL_INTERVAL_SEC = 3
@@ -237,7 +256,8 @@ def _task_id_from_create(res: dict, what: str) -> str:
 
 
 def _create_text(headers: dict, prompt: str, model: str) -> str:
-    body = {"type": "text_to_model", "prompt": prompt, "model_version": model}
+    # v3 canonical: field is `model` (not `model_version`); no `type` field. Live-verified.
+    body = {"prompt": prompt, "model": model}
     res = _post_json(API_BASE + CREATE_TEXT_PATH, headers, body)
     task_id = _task_id_from_create(res, "text-to-3D create")
     print("[tripo_gen] text-to-3D task submitted: %s (model=%s)" % (task_id, model))
@@ -245,10 +265,10 @@ def _create_text(headers: dict, prompt: str, model: str) -> str:
 
 
 def _create_image(headers: dict, file_token: str, model: str) -> str:
+    # v3 canonical: {model, file:{type:"image", file_token}} (no top-level `type`/`model_version`).
     body = {
-        "type": "image_to_model",
+        "model": model,
         "file": {"type": "image", "file_token": file_token},
-        "model_version": model,
     }
     res = _post_json(API_BASE + CREATE_IMAGE_PATH, headers, body)
     task_id = _task_id_from_create(res, "image-to-3D create")
@@ -266,9 +286,13 @@ def _upload_image(key: str, image_path: str) -> str:
     return token
 
 
-def _rig_check(headers: dict, task_id: str) -> dict:
-    """Pre-flight rigging check — MUST pass before /animations/rig."""
-    body = {"input": task_id, "rig_type": "biped"}
+def _rig_check(headers: dict, task_id: str) -> str:
+    """Pre-flight rigging check — MUST pass before /animations/rig.
+
+    Body is just {input}; rig-check RETURNS the recommended rig_type (biped|quadruped|avian|...).
+    Returns that rig_type so the caller can pick the rig spec + retarget preset namespace.
+    """
+    body = {"input": task_id}
     res = _post_json(API_BASE + RIG_CHECK_PATH, headers, body)
     check_task = _task_id_from_create(res, "rig-check create")
     print("[tripo_gen] rig-check submitted: %s" % check_task)
@@ -280,29 +304,44 @@ def _rig_check(headers: dict, task_id: str) -> dict:
             "[tripo_gen] ERROR: model is NOT riggable per rig-check (%s). "
             "Rigging aborted." % json.dumps(out)
         )
-    print("[tripo_gen] rig-check OK — model is riggable.")
-    return final
+    rig_type = out.get("rig_type") or "biped"
+    print("[tripo_gen] rig-check OK — riggable, rig_type=%s." % rig_type)
+    return rig_type
 
 
-def _rig(headers: dict, task_id: str) -> str:
-    body = {"input": task_id, "rig_type": "biped", "spec": "mixamo"}
+def _rig(headers: dict, task_id: str, rig_type: str, out_format: str = "glb") -> str:
+    # model MUST be RIG_MODEL (v2.5-20260210); spec=mixamo gives Unity-friendly biped bone names,
+    # `tripo` for non-biped creatures. rig_type comes from rig-check.
+    spec = "mixamo" if rig_type == "biped" else "tripo"
+    body = {
+        "input": task_id, "model": RIG_MODEL, "rig_type": rig_type,
+        "spec": spec, "out_format": out_format,
+    }
     res = _post_json(API_BASE + RIG_PATH, headers, body)
     rig_task = _task_id_from_create(res, "rig create")
-    print("[tripo_gen] rig task submitted: %s (spec=mixamo)" % rig_task)
+    print("[tripo_gen] rig task submitted: %s (model=%s rig_type=%s spec=%s)"
+          % (rig_task, RIG_MODEL, rig_type, spec))
     return rig_task
 
 
-def _retarget(headers: dict, rigged_task_id: str, animations: list) -> str:
-    presets = ["preset:%s" % a for a in animations]
-    body = {"input": rigged_task_id, "animations": presets}
+def _retarget(headers: dict, rigged_task_id: str, rig_type: str, animation: str,
+              out_format: str = "glb") -> str:
+    # Presets are namespaced by rig_type and applied ONE per call (batches fail). e.g.
+    # "preset:biped:walk", "preset:quadruped:walk".
+    preset = "preset:%s:%s" % (rig_type, animation)
+    body = {"input": rigged_task_id, "animations": [preset], "out_format": out_format}
     res = _post_json(API_BASE + RETARGET_PATH, headers, body)
     rt_task = _task_id_from_create(res, "retarget create")
-    print("[tripo_gen] retarget task submitted: %s (animations=%s)" % (rt_task, ",".join(animations)))
+    print("[tripo_gen] retarget task submitted: %s (%s)" % (rt_task, preset))
     return rt_task
 
 
-def _poll(headers: dict, task_id: str, label: str, timeout_sec: int) -> dict:
-    """Poll GET /task/{id} until success. >= POLL_INTERVAL_SEC between calls (rate limit)."""
+def _poll(headers: dict, task_id: str, label: str, timeout_sec: int, fatal: bool = True):
+    """Poll GET /task/{id} until success. >= POLL_INTERVAL_SEC between calls (rate limit).
+
+    On failure/timeout: sys.exit when fatal (the default), else print a warning and return None
+    (used for per-clip retargets, where one unsupported preset must not kill the whole run).
+    """
     url = API_BASE + TASK_PATH.format(task_id=task_id)
     deadline = time.time() + timeout_sec
     last_progress = -1
@@ -316,23 +355,26 @@ def _poll(headers: dict, task_id: str, label: str, timeout_sec: int) -> dict:
             last_progress = progress
         if status in ("success", "succeeded", "completed"):
             return task
-        if status in ("failed", "error"):
-            sys.exit("[tripo_gen] ERROR: %s task FAILED: %s" % (label, json.dumps(task)))
-        if status in ("cancelled", "canceled", "expired", "banned", "unknown"):
-            sys.exit("[tripo_gen] ERROR: %s task %s: %s" % (label, status, json.dumps(task)))
-        if time.time() > deadline:
-            sys.exit(
-                "[tripo_gen] ERROR: %s task timed out after %ds (last status=%s progress=%d%%). "
-                "Art was NOT completed." % (label, timeout_sec, status, progress)
-            )
+        terminal_bad = (
+            status in ("failed", "error", "cancelled", "canceled", "expired", "banned", "unknown")
+        )
+        timed_out = time.time() > deadline
+        if terminal_bad or timed_out:
+            why = ("FAILED: %s" % json.dumps(task)) if terminal_bad else (
+                "timed out after %ds (last status=%s progress=%d%%)" % (timeout_sec, status, progress))
+            if fatal:
+                sys.exit("[tripo_gen] ERROR: %s task %s" % (label, why))
+            print("[tripo_gen] WARN: %s task %s — skipping." % (label, why))
+            return None
         time.sleep(POLL_INTERVAL_SEC)
 
 
 def _model_url(task: dict) -> str:
     """Pull the downloadable GLB URL out of a succeeded task (URL expires ~5 min)."""
     out = task.get("output") or {}
-    # Tripo exposes the model under several keys across endpoints/versions.
-    for k in ("pbr_model", "model", "rigged_model", "animation_model", "base_model"):
+    # Tripo exposes the model under several keys across endpoints/versions. `model_url` is the
+    # live v3 key for generation/rig/retarget output (verified 2026-06-28).
+    for k in ("model_url", "pbr_model", "model", "rigged_model", "animation_model", "base_model"):
         v = out.get(k)
         if isinstance(v, str) and v:
             return v
@@ -348,26 +390,6 @@ def _model_url(task: dict) -> str:
         if isinstance(v, str) and v:
             return v
     sys.exit("[tripo_gen] ERROR: succeeded task has no downloadable model URL: %s" % json.dumps(out))
-
-
-def _animation_urls(task: dict) -> dict:
-    """Return {anim_name: url} for retarget output, best-effort across response shapes."""
-    out = task.get("output") or {}
-    anims = out.get("animations") or out.get("animation_models") or {}
-    result: dict = {}
-    if isinstance(anims, dict):
-        for name, v in anims.items():
-            url = v.get("url") if isinstance(v, dict) else v
-            if url:
-                result[name] = url
-    elif isinstance(anims, list):
-        for i, v in enumerate(anims):
-            if isinstance(v, dict):
-                name = v.get("name") or v.get("type") or "anim_%d" % i
-                url = v.get("url") or v.get("model")
-                if url:
-                    result[name] = url
-    return result
 
 
 # --------------------------------------------------------------------------- #
@@ -396,36 +418,39 @@ def _resolve_out(args) -> str:
 # Sub-command bodies.
 # --------------------------------------------------------------------------- #
 def _do_rig_pipeline(headers: dict, source_task_id: str, animations: list,
-                     out_dir: str, timeout: int, meta: dict) -> None:
-    """rig-check -> rig (spec=mixamo) -> retarget [presets]; download rigged + animated GLBs."""
-    _rig_check(headers, source_task_id)
-    rig_task_id = _rig(headers, source_task_id)
-    rigged = _poll(headers, rig_task_id, "rig", timeout)
-    rigged_path = os.path.join(out_dir, "rigged.glb")
-    rsize = _download(_model_url(rigged), rigged_path)
-    print("[tripo_gen] downloaded rigged.glb (%d bytes) -> %s" % (rsize, rigged_path))
-    meta["rig_task_id"] = rig_task_id
-    meta["rigged_glb_bytes"] = rsize
+                     out_dir: str, timeout: int, meta: dict, out_format: str = "glb") -> None:
+    """rig-check -> rig -> retarget (ONE preset per call); download rigged + per-clip animated files.
 
-    rt_task_id = _retarget(headers, rig_task_id, animations)
-    animated = _poll(headers, rt_task_id, "retarget", timeout)
-    anim_urls = _animation_urls(animated)
-    downloaded = {}
-    if anim_urls:
-        for name, url in anim_urls.items():
-            safe = _safe_scope(name)
-            dpath = os.path.join(out_dir, "anim_%s.glb" % safe)
-            dsize = _download(url, dpath)
-            downloaded[name] = {"path": dpath, "bytes": dsize}
-            print("[tripo_gen] downloaded anim_%s.glb (%d bytes)" % (safe, dsize))
-    else:
-        # Some plans return one combined animated GLB instead of per-clip files.
-        dpath = os.path.join(out_dir, "animated.glb")
+    rig-check returns the recommended rig_type (biped/quadruped/...), which drives the rig spec and
+    the namespaced retarget presets. Per-clip retargets are non-fatal so one unsupported preset
+    (e.g. a creature that only supports `walk`) just warns and skips. out_format glb|fbx (fbx is
+    Unity-ready directly, no Blender).
+    """
+    ext = "fbx" if out_format == "fbx" else "glb"
+    rig_type = _rig_check(headers, source_task_id)
+    rig_task_id = _rig(headers, source_task_id, rig_type, out_format)
+    rigged = _poll(headers, rig_task_id, "rig", timeout)
+    rigged_path = os.path.join(out_dir, "rigged.%s" % ext)
+    rsize = _download(_model_url(rigged), rigged_path)
+    print("[tripo_gen] downloaded rigged.%s (%d bytes) -> %s" % (ext, rsize, rigged_path))
+    meta["rig_type"] = rig_type
+    meta["rig_task_id"] = rig_task_id
+    meta["rigged_bytes"] = rsize
+
+    downloaded: dict = {}
+    for anim in animations:
+        rt_task_id = _retarget(headers, rig_task_id, rig_type, anim, out_format)
+        animated = _poll(headers, rt_task_id, "retarget:%s" % anim, timeout, fatal=False)
+        if animated is None:
+            downloaded[anim] = {"skipped": True}
+            continue
+        safe = _safe_scope(anim)
+        dpath = os.path.join(out_dir, "anim_%s.%s" % (safe, ext))
         dsize = _download(_model_url(animated), dpath)
-        downloaded["combined"] = {"path": dpath, "bytes": dsize}
-        print("[tripo_gen] downloaded animated.glb (%d bytes, combined)" % dsize)
-    meta["retarget_task_id"] = rt_task_id
+        downloaded[anim] = {"path": dpath, "bytes": dsize, "task_id": rt_task_id}
+        print("[tripo_gen] downloaded anim_%s.%s (%d bytes)" % (safe, ext, dsize))
     meta["animations"] = animations
+    meta["out_format"] = ext
     meta["animation_files"] = downloaded
 
 
@@ -490,7 +515,8 @@ def _cmd_text(args) -> None:
         "glb_bytes": size, "source": "tripo3d-text-to-model",
     }
     if args.rig:
-        _do_rig_pipeline(headers, task_id, args.animations, out_dir, args.timeout, meta)
+        _do_rig_pipeline(headers, task_id, args.animations, out_dir, args.timeout, meta,
+                         out_format=args.out_format)
     _write_meta(out_dir, meta)
     print("[tripo_gen] OK — generation=%s glb_bytes=%d" % (task_id, size))
 
@@ -529,7 +555,8 @@ def _cmd_image(args) -> None:
         "generation_task_id": task_id, "glb_bytes": size, "source": "tripo3d-image-to-model",
     }
     if args.rig:
-        _do_rig_pipeline(headers, task_id, args.animations, out_dir, args.timeout, meta)
+        _do_rig_pipeline(headers, task_id, args.animations, out_dir, args.timeout, meta,
+                         out_format=args.out_format)
     _write_meta(out_dir, meta)
     print("[tripo_gen] OK — generation=%s glb_bytes=%d" % (task_id, size))
 
@@ -538,9 +565,10 @@ def _cmd_rig(args) -> None:
     out_dir = _resolve_out(args)
     if args.dry_run:
         est = CREDIT_EST["rig"] + CREDIT_EST["retarget_each"] * len(args.animations)
-        print("[tripo_gen] DRY-RUN rig pipeline (rig-check -> rig spec=mixamo -> retarget)")
+        print("[tripo_gen] DRY-RUN rig pipeline (rig-check -> rig -> retarget, one preset/call)")
         print("  source task: %s" % args.task)
         print("  animations : %s" % ",".join(args.animations))
+        print("  out format : %s" % args.out_format)
         print("  out dir    : %s" % out_dir)
         print("  est credits: ~%d (API is source of truth)" % est)
         return
@@ -548,7 +576,8 @@ def _cmd_rig(args) -> None:
     key = _load_api_key()
     headers = _auth_headers(key)
     meta = {"generation_task_id": args.task, "source": "tripo3d-rig-retarget"}
-    _do_rig_pipeline(headers, args.task, args.animations, out_dir, args.timeout, meta)
+    _do_rig_pipeline(headers, args.task, args.animations, out_dir, args.timeout, meta,
+                     out_format=args.out_format)
     _write_meta(out_dir, meta)
     print("[tripo_gen] OK — rigged+animated from %s" % args.task)
 
@@ -565,7 +594,10 @@ def _add_common(sp) -> None:
     sp.add_argument("--rig", action="store_true",
                     help="after generation, run rig-check -> rig(spec=mixamo) -> retarget")
     sp.add_argument("--animations", nargs="+", default=list(DEFAULT_ANIMATIONS),
-                    help="retarget preset animations (default: %s)" % " ".join(DEFAULT_ANIMATIONS))
+                    help="retarget clip names, namespaced per rig_type at call time "
+                         "(default: %s)" % " ".join(DEFAULT_ANIMATIONS))
+    sp.add_argument("--out-format", choices=("glb", "fbx"), default="glb", dest="out_format",
+                    help="rig/retarget output format; fbx is Unity-ready directly (no Blender)")
     sp.add_argument("--force", action="store_true", help="regenerate even if model.glb exists")
     sp.add_argument("--dry-run", action="store_true", help="print plan + est credits, make NO API calls")
     sp.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SEC,

--- a/extensions/renderers/godot/tools/tripo_gen.py
+++ b/extensions/renderers/godot/tools/tripo_gen.py
@@ -504,6 +504,18 @@ def _do_rig_pipeline(headers: dict, source_task_id: str, animations, out_dir: st
     rig_type = _rig_check(headers, source_task_id)
     if animations is None:  # pick defaults now that rig_type is known
         animations = DEFAULT_BIPED_ANIMATIONS if rig_type == "biped" else DEFAULT_CREATURE_ANIMATIONS
+    else:
+        # Dedup by the ALIAS-RESOLVED leaf (attack/slash both -> slash) so we don't double-bill a
+        # retarget or clobber a per-clip output file. Preserve first-occurrence order.
+        seen, deduped = set(), []
+        for anim in animations:
+            leaf = ANIM_ALIAS.get(anim, anim)
+            if leaf in seen:
+                print("[tripo_gen] WARN: %r resolves to %r already requested — skipping." % (anim, leaf))
+                continue
+            seen.add(leaf)
+            deduped.append(anim)
+        animations = deduped
     rig_task_id = _rig(headers, source_task_id, rig_type, out_format)
     rigged = _poll(headers, rig_task_id, "rig", timeout)
     rigged_path = os.path.join(out_dir, "rigged.%s" % ext)
@@ -572,7 +584,9 @@ def _cmd_text(args) -> None:
         print("[tripo_gen] DRY-RUN text-to-3D")
         print("  prompt    : %s" % args.prompt)
         print("  model     : %s" % model)
-        print("  rig+anim  : %s (%s)" % (args.rig, ",".join(anims) if args.rig else "-"))
+        anim_note = "" if (not args.rig or args.animations) else \
+            " — biped default; a non-biped rig uses only %s" % ",".join(DEFAULT_CREATURE_ANIMATIONS)
+        print("  rig+anim  : %s (%s)%s" % (args.rig, ",".join(anims) if args.rig else "-", anim_note))
         print("  out dir   : %s" % out_dir)
         print("  est credits: ~%d (API is source of truth)" % est)
         return
@@ -610,7 +624,9 @@ def _cmd_image(args) -> None:
         print("[tripo_gen] DRY-RUN image-to-3D")
         print("  image     : %s" % args.image)
         print("  model     : %s" % model)
-        print("  rig+anim  : %s (%s)" % (args.rig, ",".join(anims) if args.rig else "-"))
+        anim_note = "" if (not args.rig or args.animations) else \
+            " — biped default; a non-biped rig uses only %s" % ",".join(DEFAULT_CREATURE_ANIMATIONS)
+        print("  rig+anim  : %s (%s)%s" % (args.rig, ",".join(anims) if args.rig else "-", anim_note))
         print("  out dir   : %s" % out_dir)
         print("  est credits: ~%d (API is source of truth)" % est)
         return


### PR DESCRIPTION
## Tripo + Meshy pipelines: live-tested wrappers, rig/animate, provider-router runbooks

Drove both platforms' full pipelines live end-to-end (own keys, real renders on GEX44), fixed the
wrappers to what actually works, extended Meshy with rig/animate, and turned the `asset-gen` skill
into a provider-router + two runbooks. All facts verified 2026-06-28.

### ✅ v2-vs-v3 reconciliation with #1176 — RESOLVED (this branch now merges origin/main)
PR #1176 ported Tripo to a **v2** transport on the premise "v3 is dead." I tested that empirically:
- **v3 retargets end-to-end** (rendered a walking elf; re-confirmed live during reconciliation).
- **v2 `animate_retarget` FAILS in every form** — bare `preset:walk`, namespaced `preset:biped:walk`,
  singular/list field, with/without the rig model, even the exact SDK-v0.4.1 shape. The SDK *defines*
  the v2 contract but its retarget endpoint does not actually animate for us.
- Root insight: the retarget preset **namespace differs by transport** — v2 uses bare `preset:walk`,
  v3 uses `preset:biped:walk` — which is why my earlier cross-tests looked contradictory.

**Resolution:** v3 is the base (proven). #1176's v2 transport is superseded for the animation path,
but its **error-handling had real value and is grafted in** (commit `44f1a50`):
- `_check_api_code()` — catch Tripo business errors (`code!=0` on HTTP 200: 2010 credit / 1004 invalid
  model) so they fail clearly instead of crashing later as "no task id". *(Was the v3 wrapper's biggest hole.)*
- credit-error-as-HTTP-403 → "top up" message
- `ANIM_ALIAS` (attack→slash, cast→shoot) applied before namespacing, so the bake-manifest vocabulary
  keeps resolving (verified live: `attack` → `preset:biped:slash`)
- `_image_file_type()` fail-fast on unsupported image extensions
The non-grafted v2 bits (`_animation_urls`, combined-GLB fallback, SDK scalar/list split) are artifacts
of v2's batch design and don't apply to v3's verified one-preset-per-call model.

### Changes
- **`tripo_gen.py`** — corrected to the live v3 surface (`/generation/text-to-model`, date-stamped model
  ids, `/tasks/{id}` poll, rig `model=v2.5-20260210`, `rig_type` from rig-check incl. **creatures**,
  namespaced one-per-call presets, `model_url` key, `--out-format fbx`) + the #1176 grafts above.
- **`meshy_gen.py`** — adds `--rig` / `--rig-from-task` / `--animate` (humanoid rig + free walk/run +
  library clips). Live-validated.
- **docs(asset-gen)** — provider-router decision tree + `TRIPO_PIPELINE.md` + `MESHY_PIPELINE.md`.
  ★ Load-bearing Unity finding: import rigged FBX as **`animationType=Generic`** (Humanoid silently
  drops the clips). Prefer FBX (no Blender).

### Validation
Both wrappers run end-to-end live (Tripo humanoid + creature; Meshy rig + animate). Tripo-rigged elf
rendered mid-stride on GEX44 (non-black). All 6 CodeRabbit findings addressed (commit `e3911d9`). ruff
clean; both modules import; `--test-key`/`--dry-run` pass.