### PR TITLE
Combat moveset in one command (meshy --moveset) + headless mixamo_gen.py + skills-review verdict

### DIFF
--- a/.claude/skills/asset-gen/COMBAT_MOVESET.md
+++ b/.claude/skills/asset-gen/COMBAT_MOVESET.md
@@ -32,7 +32,22 @@ mixamo_gen.py moveset --out <dir>             # the same 9 named anim_<name>.fbx
 mixamo_gen.py search "sword slash"            # explore the library
 ```
 - ⚠ Mixamo's API is **unofficial** and Adobe has signaled a sunset — always `--test-key` first.
-- The token **expires (~hours)** — re-extract when `--test-key` reports unauthorized.
+  (Live-confirmed working 2026-06-28: token + search + export + download all functional.)
+- The token **expires (~hours)** — when `--test-key`/any call returns 401, refresh it (next section).
+
+### Token refresh — the agent procedure (when `--test-key` says unauthorized)
+Mixamo is browser-login only, so the token is extracted from a **logged-in mixamo.com browser tab on
+the Mac** via Claude-in-Chrome. A Mac-side agent can do this fully autonomously (no human needed) as
+long as a Mixamo session is logged in:
+1. `list_connected_browsers` → `select_browser` (the local macOS Chrome).
+2. `tabs_context_mcp{createIfEmpty:true}` → `navigate` an MCP tab to `https://www.mixamo.com/`
+   (localStorage is shared per-origin with the logged-in session).
+3. `javascript_tool`: trigger a Blob **download** of `localStorage.getItem('access_token')` (keeps the
+   raw token OUT of the transcript) — `new Blob([t]) → a.download='mixamo_token.txt' → a.click()`.
+4. `mv ~/Downloads/mixamo_token*.txt ~/.worldos/mixamo.token && chmod 600` it; re-run `--test-key`.
+5. If `mixamo_gen.py` runs on the GEX44 box, `scp ~/.worldos/mixamo.token` to the box's `~/.worldos/`.
+This is safe to automate: it's the user's own short-lived token for their own tool. If NO logged-in
+Mixamo tab exists, that's the one human gate — ask the owner to log in, then refresh.
 - Mixamo clips ride Mixamo's skeleton, which matches our `spec:"mixamo"` rigs, so they retarget onto
   Meshy/Tripo actors. Default export is clip-only (no skin) for retargeting; `--skin` for a base.
 - **When to use which:** Meshy = the per-actor baseline for the filler-first loop (keep it primary);

--- a/.claude/skills/asset-gen/COMBAT_MOVESET.md
+++ b/.claude/skills/asset-gen/COMBAT_MOVESET.md
@@ -1,0 +1,63 @@
+# WorldOS combat moveset — the canonical "agent adds animations to a model" process
+
+The repeatable recipe for giving a humanoid actor its full combat moveset, then wiring + scoring it.
+The engine stays the SOLE WRITER — clips + Animator are renderer-local view only; the engine drives
+state *selection* over the bridge, it never owns the Animator as game state.
+
+## The 9-clip canonical moveset
+`idle · walk · run · attack · cast · block · dodge · hit · death`
+(grounded in the engine's combat verbs + `anim_hint`s + the bake-manifest columns.)
+
+## Feeder A — Meshy (DEFAULT: zero-touch, headless, proven)
+**One command** gives a humanoid the entire named moveset:
+```bash
+meshy_gen.py --prompt "an elf ranger ..." --out <dir> --moveset
+# or onto an existing Meshy model:  meshy_gen.py --rig-from-task <id> --out <dir> --moveset
+```
+- Rig (~5 cr) **includes free walk + run**; `--moveset` adds the other 7 by action_id (~21 cr total).
+- Clips land as **named** `anim_<name>.fbx` (anim_attack.fbx, anim_cast.fbx, …) — agent-readable.
+- The map (all live-verified 2026-06-28 — each id generated a real clip): `idle=0, attack=4, cast=125,
+  block=138, dodge=156, hit=178, death=8` (`WORLDOS_MOVESET` in `meshy_gen.py`).
+- **Humanoid-only.** Creatures → Tripo (`tripo_gen.py text --rig`, `spec:"mixamo"`).
+
+## Feeder B — Mixamo (UPGRADE: larger/higher-quality human mocap)
+The `unity-mcp-mixamo` MCP does **not** fit WorldOS (Windows-only `.exe`, GUI-bound, can't run on the
+headless GEX44 Linux box). Instead use **`mixamo_gen.py`** — a headless urllib wrapper that drives
+Mixamo's internal REST API with the owner's OAuth token (no browser, no Unity, no `.exe`):
+```bash
+# one-time: log in at mixamo.com -> DevTools console -> copy(localStorage.access_token)
+#           -> save to ~/.worldos/mixamo.token (chmod 600)
+mixamo_gen.py --test-key                      # confirm token + that the (unofficial) API is still live
+mixamo_gen.py moveset --out <dir>             # the same 9 named anim_<name>.fbx
+mixamo_gen.py search "sword slash"            # explore the library
+```
+- ⚠ Mixamo's API is **unofficial** and Adobe has signaled a sunset — always `--test-key` first.
+- The token **expires (~hours)** — re-extract when `--test-key` reports unauthorized.
+- Mixamo clips ride Mixamo's skeleton, which matches our `spec:"mixamo"` rigs, so they retarget onto
+  Meshy/Tripo actors. Default export is clip-only (no skin) for retargeting; `--skin` for a base.
+- **When to use which:** Meshy = the per-actor baseline for the filler-first loop (keep it primary);
+  Mixamo = a richer *shared* pack the owner harvests once and we retarget onto many actors.
+
+## The shared tail (identical for both feeders)
+1. **Import on the GEX44 box** as **`animationType = Generic`, NOT Humanoid.** Tripo/Meshy/Mixamo bone
+   names don't auto-map to Unity's Humanoid avatar → a Humanoid import **silently drops the clips**.
+   Generic preserves them. Strip the redundant mesh, keep the `AnimationClip`. (Load-bearing — see
+   `MESHY_PIPELINE.md` / `TRIPO_PIPELINE.md`.)
+2. **Assemble the Animator** over the CoplayDev unity-mcp bridge (or `unity-scene-bootstrapper` if
+   trialed): states idle/walk/run/attack/cast/block/dodge/hit/death + the locomotion blend; the engine
+   selects state via the bridge, never owning the controller's logic.
+3. **Camera** — drive a fixed dimetric VCam + combat framing with **Cinemachine** (ADOPTED, see below).
+4. **Render** on GEX44 (`gex44-unity-host` skill: bring-up, capture, non-black gate).
+5. **Score** the motion with the `visual-critic` skill's **L7 MOTION lens** (from a render reel) vs the
+   PoE2 painterly bar; feed defects back → re-animate/re-import until it converges.
+
+## Adopted Unity-agent tools (from the 2026-06-28 skills review; most of the ~30 were SKIP)
+- **ADOPT — Cinemachine** (Besty0728/Unity-Skills bundle): the only camera tool that fits — fixed
+  dimetric pin + combat framing, render-pipeline-agnostic (works on our built-in pipeline), driven
+  headlessly. Add `com.unity.cinemachine` to the box project; drive VCam setup via the existing bridge.
+- **TRIAL — unity-compile-fixer + unity-test-runner** (Dev-GOM `unity-dev-toolkit` plugin): headless
+  compile-error auto-fix loop + batchmode test runner for the C# glue. Repoint compile-fixer's
+  diagnostics from OmniSharp to the CoplayDev compile output before relying on it.
+- **SKIP** (architecture-mismatch): ECS/DOTS (fights the Python sole-writer fence), URP-specialist
+  (URP deferred), rival editor bridges (akiojin/hatayama — fork the CoplayDev bridge), addressables,
+  input-system (input routes through the engine). Full scorecard: session 2026-06-28.

--- a/.claude/skills/asset-gen/SKILL.md
+++ b/.claude/skills/asset-gen/SKILL.md
@@ -39,8 +39,9 @@ and **[MESHY_PIPELINE.md](MESHY_PIPELINE.md)** (both live-verified 2026-06-28).
    LoRA above). `scenario_gen.py` or the `scenario` MCP, or the engine provider `WORLDOS_IMAGE_PROVIDER=scenario`.
 2. **Pixel sprite / tileset** → **PixelLab** (GT1-future; `pixellab` MCP).
 3. **3D rigged + animated, HUMANOID (biped)** → **Meshy** (cheapest: ~5 cr rig **includes free
-   walk/run**, +3 cr/clip) — `meshy_gen.py --rig --animate ...`. **Fallback: Tripo** (richer preset
-   set, same code path as creatures) — `tripo_gen.py text --rig`.
+   walk/run**, +3 cr/clip) — `meshy_gen.py --rig --animate ...`, or **`--moveset`** for the full
+   WorldOS combat set in one command. **Fallback: Tripo** (`tripo_gen.py text --rig`). Richer human
+   mocap → **`mixamo_gen.py moveset`** (headless Mixamo). Full process → **[COMBAT_MOVESET.md](COMBAT_MOVESET.md)**.
 4. **3D rigged + animated, CREATURE (quadruped/avian/serpentine/…)** → **Tripo ONLY** — Meshy 422s on
    non-humanoids. `tripo_gen.py text --rig` (rig-check auto-detects the rig_type). **No fallback.**
 5. **3D static / low-poly prop** → **Tripo `--lowpoly` (P1)** or Meshy `model_type=lowpoly`.
@@ -79,7 +80,8 @@ in each service dashboard when convenient, then update the `~/.worldos/*.key` fi
 ## CLI wrappers (`extensions/renderers/godot/tools/`, urllib-only, mirror `meshy_gen.py`)
 - **`tripo_gen.py`** — `text|image|rig` subcommands; `--rig` (rig-check→rig→retarget), `--out-format glb|fbx`, `--animations`, `--lowpoly` (P1), `--test-key`, `--dry-run`. Rigs **humanoids AND creatures** (rig_type auto-detected). Polls `GET /v3/tasks/{id}` (plural) ≥3s; **downloads immediately (URLs expire ~5 min)**. Full recipe + verified API facts in **[TRIPO_PIPELINE.md](TRIPO_PIPELINE.md)**.
 - **`scenario_gen.py`** — `generate|list-models|upscale`; `--model-id`; `--test-key`; `--dry-run`. HTTP Basic; async job → asset download. Scenario has TWO interfaces — REST `https://api.cloud.scenario.com/v1` (Basic, used by `scenario_gen.py`) AND MCP `https://mcp.scenario.com/mcp` (for direct agent tool calls). Both work.
-- **`meshy_gen.py`** — text→3D (`--prompt --out`, preview→refine PBR) **plus rig+animate** (`--rig` / `--rig-from-task <id>` / `--animate <action_id...>`, HUMANOID only — Meshy 422s on creatures). The 5-cr rig **includes free walk/run**. `--test-key`, `--dry-run`. Full recipe in **[MESHY_PIPELINE.md](MESHY_PIPELINE.md)**.
+- **`meshy_gen.py`** — text→3D (`--prompt --out`, preview→refine PBR) **plus rig+animate** (`--rig` / `--rig-from-task <id>` / `--animate <action_id...>`, HUMANOID only — Meshy 422s on creatures). The 5-cr rig **includes free walk/run**; **`--moveset`** = the full WorldOS combat set in one command (named `anim_<name>.fbx`). `--test-key`, `--dry-run`. Recipe: **[MESHY_PIPELINE.md](MESHY_PIPELINE.md)** + **[COMBAT_MOVESET.md](COMBAT_MOVESET.md)**.
+- **`mixamo_gen.py`** — headless Mixamo (the richer free human-mocap library) via the owner's OAuth token (no browser/Unity/.exe; the `unity-mcp-mixamo` MCP is Windows/GUI-only and doesn't fit). `search` / `download <name>` / **`moveset`** → named `anim_<name>.fbx`. Token in `~/.worldos/mixamo.token`; `--test-key` first (unofficial API, Adobe-sunset risk; token expires ~hours). HUMANOID only.
 - **`pixellab_gen.py`** — STUB for GT1; `--test-key` only.
 Always run `--test-key` first to confirm auth.
 

--- a/extensions/renderers/godot/tools/meshy_gen.py
+++ b/extensions/renderers/godot/tools/meshy_gen.py
@@ -33,7 +33,8 @@ Usage:
     python3 meshy_gen.py --prompt "..." --out <dir> --force        # re-generate even if model.glb exists
     python3 meshy_gen.py --prompt "..." --out <dir> --rig          # gen -> rig (+ free walk/run)
     python3 meshy_gen.py --prompt "..." --out <dir> --rig --animate 0 4   # + Idle(0) + Attack(4)
-    python3 meshy_gen.py --rig-from-task <meshy_model_task_id> --out <dir> --animate 0  # rig an existing model
+    python3 meshy_gen.py --prompt "..." --out <dir> --moveset             # FULL WorldOS combat moveset, one command
+    python3 meshy_gen.py --rig-from-task <meshy_model_task_id> --out <dir> --moveset  # moveset onto an existing model
 """
 
 from __future__ import annotations
@@ -53,6 +54,14 @@ POLL_TEMPLATE = "/openapi/v2/text-to-3d/{task_id}"
 RIGGING_PATH = "/openapi/v1/rigging"
 RIGGING_POLL = "/openapi/v1/rigging/{task_id}"
 ANIM_PATH = "/openapi/v1/animations"
+
+# ★ The canonical WorldOS combat moveset → Meshy animation-library action_ids (ALL live-verified
+# 2026-06-28: each id generated a real clip on a rigged elf). walk + run come FREE with the rig
+# (basic_animations), so `--moveset` only spends 3 cr/clip on these 7 library actions.
+# Source of ids: Meshy's animation library (no REST list endpoint — cache from the docs).
+WORLDOS_MOVESET = {
+    "idle": 0, "attack": 4, "cast": 125, "block": 138, "dodge": 156, "hit": 178, "death": 8,
+}
 ANIM_POLL = "/openapi/v1/animations/{task_id}"
 
 # Polling cadence + ceilings.
@@ -278,8 +287,13 @@ def _download_pairs(result: dict, out_dir: str, pairs: list) -> dict:
 
 
 def _run_rig_and_animate(headers: dict, model_task_id: str, out_dir: str, height: float,
-                         action_ids: list, timeout: int, meta: dict) -> None:
-    """rig the model (humanoid) -> download rigged FBX/GLB + free walk/run -> optional library clips."""
+                         action_ids: list, timeout: int, meta: dict, clip_names: dict = None) -> None:
+    """rig the model (humanoid) -> download rigged FBX/GLB + free walk/run -> optional library clips.
+
+    clip_names maps action_id -> friendly name (e.g. {4: "attack"}); when present, clips are saved as
+    anim_<name>.fbx (not anim_action_<id>.fbx) so the moveset lands as named, agent-readable files.
+    """
+    names = clip_names or {}
     rig_id = _create_rigging(headers, model_task_id, height)
     rig_task = _poll(headers, rig_id, "rigging", timeout, poll_template=RIGGING_POLL)
     result = rig_task.get("result", {}) or {}
@@ -289,8 +303,8 @@ def _run_rig_and_animate(headers: dict, model_task_id: str, out_dir: str, height
     ])
     basic = result.get("basic_animations", {}) or {}
     basic_files = _download_pairs(basic, out_dir, [
-        ("walking_fbx_url", "anim_walking.fbx"),
-        ("running_fbx_url", "anim_running.fbx"),
+        ("walking_fbx_url", "anim_walk.fbx"),    # the rig's FREE locomotion clips, named for the moveset
+        ("running_fbx_url", "anim_run.fbx"),
     ])
     meta["rig_task_id"] = rig_id
     meta["rig_files"] = rig_files
@@ -298,14 +312,15 @@ def _run_rig_and_animate(headers: dict, model_task_id: str, out_dir: str, height
 
     anim_files: dict = {}
     for aid in action_ids or []:
+        label = names.get(int(aid), "action_%d" % int(aid))
         an_id = _create_animation(headers, rig_id, aid)
-        an_task = _poll(headers, an_id, "animation:%s" % aid, timeout, poll_template=ANIM_POLL)
+        an_task = _poll(headers, an_id, "animation:%s" % label, timeout, poll_template=ANIM_POLL)
         an_result = an_task.get("result", {}) or {}
         files = _download_pairs(an_result, out_dir, [
-            ("animation_fbx_url", "anim_action_%d.fbx" % int(aid)),
-            ("animation_glb_url", "anim_action_%d.glb" % int(aid)),
+            ("animation_fbx_url", "anim_%s.fbx" % label),
+            ("animation_glb_url", "anim_%s.glb" % label),
         ])
-        anim_files[str(int(aid))] = dict(task_id=an_id, **files)
+        anim_files[label] = dict(action_id=int(aid), task_id=an_id, **files)
     if action_ids:
         meta["animation_files"] = anim_files
 
@@ -357,7 +372,10 @@ def _cmd_dry_run(args) -> None:
     if args.rig or args.rig_from_task or args.action_ids:
         print("  rig        : YES (HUMANOID only) height=%.2fm -> rigged fbx/glb + free walk/run (~5 cr)"
               % args.rig_height)
-        if args.action_ids:
+        if args.moveset:
+            print("  moveset    : WorldOS combat set %s (~%d cr) -> named anim_<name>.fbx"
+                  % (",".join(WORLDOS_MOVESET), 3 * len(WORLDOS_MOVESET)))
+        elif args.action_ids:
             print("  animate    : action_ids %s (~3 cr each)" % " ".join(str(a) for a in args.action_ids))
 
 
@@ -385,6 +403,9 @@ def main() -> None:
                     help="character height in meters for rigging (default 1.7)")
     ap.add_argument("--animate", dest="action_ids", nargs="+", type=int, metavar="ACTION_ID",
                     help="library action_id(s) to apply after rigging (e.g. 0=Idle 4=Attack); implies --rig")
+    ap.add_argument("--moveset", action="store_true",
+                    help="apply the full WorldOS combat moveset (rig + walk/run free + %s); "
+                         "clips land as named anim_<name>.fbx" % "/".join(WORLDOS_MOVESET))
     ap.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SEC,
                     help="per-stage poll timeout in seconds (default %d)" % DEFAULT_TIMEOUT_SEC)
     args = ap.parse_args()
@@ -392,6 +413,14 @@ def main() -> None:
     if args.test_key:
         _cmd_test_key()
         return
+
+    # --moveset = the canonical combat set, saved under friendly names.
+    clip_names = None
+    if args.moveset:
+        if args.action_ids:
+            ap.error("--moveset and --animate are mutually exclusive.")
+        args.action_ids = list(WORLDOS_MOVESET.values())
+        clip_names = {v: k for k, v in WORLDOS_MOVESET.items()}
 
     do_rig = bool(args.rig or args.rig_from_task or args.action_ids)
 
@@ -483,7 +512,7 @@ def main() -> None:
     # ---- rig + animate (HUMANOID only) ----
     if do_rig:
         _run_rig_and_animate(headers, model_task_id, out_dir, args.rig_height,
-                             args.action_ids, args.timeout, meta)
+                             args.action_ids, args.timeout, meta, clip_names=clip_names)
 
     with open(meta_path, "w") as f:
         json.dump(meta, f, indent=2)

--- a/extensions/renderers/godot/tools/mixamo_gen.py
+++ b/extensions/renderers/godot/tools/mixamo_gen.py
@@ -70,6 +70,8 @@ def _load_token() -> str:
         return tok
     path = os.path.expanduser("~/.worldos/mixamo.token")
     if os.path.isfile(path):
+        if os.stat(path).st_mode & 0o077:  # the token is a credential — warn if group/other-readable
+            sys.stderr.write("[mixamo_gen] WARN: %s is not mode 600; run `chmod 600 %s`.\n" % (path, path))
         with open(path) as f:
             tok = f.read().strip()
         if tok:
@@ -139,10 +141,20 @@ def _explain(code: int, detail: str, what: str) -> None:
     sys.exit("[mixamo_gen] ERROR HTTP %d on %s. Detail: %s" % (code, what, detail))
 
 
+_ALLOWED_DL_HOSTS = ("mixamo.com", "adobe.com", "adobe.io", "akamaihd.net", "cloudfront.net", "amazonaws.com")
+
+
 def _download(url: str, dest: str) -> int:
+    # The export job_result URL comes from Mixamo's API; still validate the host (cheap SSRF guard)
+    # and require https before fetching.
+    parsed = urllib.parse.urlparse(url)
+    host = parsed.hostname or ""
+    if parsed.scheme != "https" or not any(host == h or host.endswith("." + h) for h in _ALLOWED_DL_HOSTS):
+        sys.exit("[mixamo_gen] ERROR: refusing to download from unexpected host %r (%s)." % (host, url))
+    tmp = dest + ".part"   # write atomically: a partial/interrupted fetch never leaves a corrupt FBX
     req = urllib.request.Request(url, method="GET")
     try:
-        with urllib.request.urlopen(req, timeout=300) as resp, open(dest, "wb") as out:
+        with urllib.request.urlopen(req, timeout=300) as resp, open(tmp, "wb") as out:
             total = 0
             while True:
                 chunk = resp.read(65536)
@@ -150,8 +162,13 @@ def _download(url: str, dest: str) -> int:
                     break
                 out.write(chunk)
                 total += len(chunk)
-            return total
+        os.replace(tmp, dest)
+        return total
     except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        try:
+            os.remove(tmp)
+        except OSError:
+            pass
         sys.exit("[mixamo_gen] ERROR downloading %s -> %s: %s" % (url, dest, e))
 
 
@@ -195,8 +212,8 @@ def _resolve_animation(headers: dict, name_or_id: str) -> dict:
     sys.exit("[mixamo_gen] ERROR: no Mixamo animation matches %r." % name_or_id)
 
 
-def _gms_hash(headers: dict, animation_id: str, character_id: str) -> dict:
-    """Fetch product details and build the export gms_hash (params array -> comma string)."""
+def _gms_hash(headers: dict, animation_id: str, character_id: str) -> tuple:
+    """Fetch product details and build the export gms_hash; returns (gms_hash, product_name)."""
     details = _get(BASE_URL + "/products/%s" % animation_id, headers,
                    params={"similar": 0, "character_id": character_id})
     gms = (details.get("details") or {}).get("gms_hash") or {}
@@ -252,7 +269,9 @@ def _cmd_test_key() -> None:
     """Validate the token + confirm the (unofficial, sunset-risk) API is still live."""
     headers = _headers(_load_token())
     cid = _pick_character_id(_get(BASE_URL + "/characters", headers))
-    print("Mixamo Auth OK" + (" (character %s)" % cid if cid else " (no character uploaded yet)"))
+    if not cid:
+        sys.exit("[mixamo_gen] ERROR: token valid but no usable Mixamo character — exports can't run.")
+    print("Mixamo Auth OK (character %s)" % cid)
 
 
 def _cmd_search(args) -> None:
@@ -284,8 +303,12 @@ def _cmd_moveset(args) -> None:
             done[name] = _fetch_clip(headers, cid, query, path, skin, args.timeout)
         except SystemExit as e:
             print("[mixamo_gen] WARN: %s (%r) skipped — %s" % (name, query, e))
-    print("[mixamo_gen] moveset OK — %d/%d clips: %s"
-          % (len(done), len(WORLDOS_MOVESET), ", ".join(done)))
+    print("[mixamo_gen] moveset %s — %d/%d clips: %s"
+          % ("OK" if len(done) == len(WORLDOS_MOVESET) else "INCOMPLETE",
+             len(done), len(WORLDOS_MOVESET), ", ".join(done)))
+    if len(done) != len(WORLDOS_MOVESET):
+        missing = [n for n in WORLDOS_MOVESET if n not in done]
+        sys.exit("[mixamo_gen] ERROR: moveset incomplete — missing %s." % ", ".join(missing))
 
 
 def main(argv=None) -> None:

--- a/extensions/renderers/godot/tools/mixamo_gen.py
+++ b/extensions/renderers/godot/tools/mixamo_gen.py
@@ -52,7 +52,7 @@ WORLDOS_MOVESET = {
     "attack": "sword and shield slash",
     "cast": "standing 2h magic attack 01",
     "block": "sword and shield block",
-    "dodge": "sword and shield dodge",
+    "dodge": "standing dodge right",
     "hit": "standing react large from right",
     "death": "standing death backward 01",
 }

--- a/extensions/renderers/godot/tools/mixamo_gen.py
+++ b/extensions/renderers/godot/tools/mixamo_gen.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""mixamo_gen.py — headless Mixamo animation downloader for the WorldOS asset pipeline.
+
+A sibling of meshy_gen.py / tripo_gen.py. Mixamo has NO official public API and NO Linux/headless
+MCP (the `unity-mcp-mixamo` project ships a Windows-only .exe + a GUI-bound Unity package). But the
+Mixamo WEBSITE drives an internal REST API with a user OAuth token — so this wrapper replicates that
+exact flow (search -> product details -> export -> poll monitor -> download FBX) with urllib only,
+runs anywhere (Linux/macOS), and drops named FBX clips into the pipeline. NO browser, NO Unity, NO .exe.
+
+The API surface was reverse-engineered from the working `HaD0Yun/unity-mcp-mixamo` Python client
+(Server/src/mixamo_mcp/client.py) + gnuton/mixamo_anims_downloader. It is UNOFFICIAL and Adobe has
+signaled a Mixamo sunset — run `--test-key` first to confirm it's still live before a batch.
+
+WHY Mixamo at all: it's the largest free HUMAN mocap library, richer than Meshy's preset set. Meshy
+(`meshy_gen.py --moveset`) stays the zero-touch DEFAULT; Mixamo is the quality/variety upgrade. Clips
+come on Mixamo's skeleton, which matches our Meshy/Tripo `spec:"mixamo"` rigs, so they retarget onto
+our generated actors. Import the FBX in Unity as animationType=Generic (NOT Humanoid — Humanoid
+silently drops clips on non-standard bone names; see the asset-gen skill).
+
+AUTH (Mixamo is browser-login only): log in at mixamo.com, open DevTools console, run
+`copy(localStorage.access_token)`, and save it to `~/.worldos/mixamo.token` (mode 600) or
+`$WORLDOS_MIXAMO_TOKEN`. The token EXPIRES (~hours) — re-extract when `--test-key` says unauthorized.
+
+Usage:
+    python3 mixamo_gen.py --test-key                       # validate the token (GET /characters)
+    python3 mixamo_gen.py search "sword slash"             # list matching animations
+    python3 mixamo_gen.py download "Sword And Shield Slash" --out /tmp/clips
+    python3 mixamo_gen.py moveset --out /tmp/clips          # the full WorldOS combat moveset, named FBX
+    python3 mixamo_gen.py moveset --out /tmp/clips --skin   # include the mesh (first base download)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+BASE_URL = "https://www.mixamo.com/api/v1"
+
+# The canonical WorldOS combat moveset -> a Mixamo SEARCH QUERY per clip (we take the top result).
+# Names are the OUTPUT filenames (anim_<name>.fbx), matching meshy_gen.py's --moveset naming so both
+# feeders land identically. Mixamo's library is huge; these queries hit a strong canonical clip.
+WORLDOS_MOVESET = {
+    "idle": "idle",
+    "walk": "walking",
+    "run": "running",
+    "attack": "sword and shield slash",
+    "cast": "standing 2h magic attack 01",
+    "block": "sword and shield block",
+    "dodge": "sword and shield dodge",
+    "hit": "standing react large from right",
+    "death": "standing death backward 01",
+}
+
+POLL_INTERVAL_SEC = 2
+DEFAULT_TIMEOUT_SEC = 120
+
+
+# --------------------------------------------------------------------------- #
+# Token (NEVER print/log; NEVER write to a repo file).
+# --------------------------------------------------------------------------- #
+def _load_token() -> str:
+    tok = os.environ.get("WORLDOS_MIXAMO_TOKEN", "").strip()
+    if tok:
+        return tok
+    path = os.path.expanduser("~/.worldos/mixamo.token")
+    if os.path.isfile(path):
+        with open(path) as f:
+            tok = f.read().strip()
+        if tok:
+            return tok
+    sys.exit(
+        "[mixamo_gen] ERROR: no Mixamo token. Log in at mixamo.com, run "
+        "`copy(localStorage.access_token)` in the DevTools console, and save it to "
+        "~/.worldos/mixamo.token (chmod 600) or $WORLDOS_MIXAMO_TOKEN."
+    )
+
+
+def _headers(token: str) -> dict:
+    # X-Api-Key 'mixamo2' is the website's public key; required alongside the user Bearer token.
+    return {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "X-Requested-With": "XMLHttpRequest",
+        "X-Api-Key": "mixamo2",
+        "Authorization": "Bearer %s" % token,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# HTTP (urllib only).
+# --------------------------------------------------------------------------- #
+def _get(url: str, headers: dict, params: dict = None) -> dict:
+    if params:
+        url = url + "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        _explain(e.code, _read_err(e), "GET " + url)
+    except urllib.error.URLError as e:
+        sys.exit("[mixamo_gen] ERROR: network failure on GET %s: %s" % (url, e.reason))
+
+
+def _post(url: str, headers: dict, body: dict) -> dict:
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        _explain(e.code, _read_err(e), "POST " + url)
+    except urllib.error.URLError as e:
+        sys.exit("[mixamo_gen] ERROR: network failure on POST %s: %s" % (url, e.reason))
+
+
+def _read_err(e: urllib.error.HTTPError) -> str:
+    try:
+        return e.read().decode("utf-8")[:500]
+    except Exception:
+        return "<no body>"
+
+
+def _explain(code: int, detail: str, what: str) -> None:
+    if code in (401, 403):
+        sys.exit(
+            "[mixamo_gen] ERROR %d on %s — the Mixamo token is missing/expired. Re-extract "
+            "localStorage.access_token from a logged-in mixamo.com tab. Detail: %s" % (code, what, detail)
+        )
+    if code == 404:
+        sys.exit("[mixamo_gen] ERROR 404 on %s — Mixamo may have sunset this endpoint. Detail: %s"
+                 % (what, detail))
+    sys.exit("[mixamo_gen] ERROR HTTP %d on %s. Detail: %s" % (code, what, detail))
+
+
+def _download(url: str, dest: str) -> int:
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=300) as resp, open(dest, "wb") as out:
+            total = 0
+            while True:
+                chunk = resp.read(65536)
+                if not chunk:
+                    break
+                out.write(chunk)
+                total += len(chunk)
+            return total
+    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+        sys.exit("[mixamo_gen] ERROR downloading %s -> %s: %s" % (url, dest, e))
+
+
+# --------------------------------------------------------------------------- #
+# Mixamo API flow (search -> details -> export -> monitor -> download).
+# --------------------------------------------------------------------------- #
+def _primary_character_id(headers: dict) -> str:
+    """Mixamo retargets onto a character; export needs the account's character_id."""
+    data = _get(BASE_URL + "/characters", headers)
+    cid = data.get("primary_character_id")
+    if cid:
+        return cid
+    results = data.get("results") or []
+    if results:
+        cid = results[0].get("character_id") or results[0].get("id")
+        if cid:
+            return cid
+    sys.exit("[mixamo_gen] ERROR: no character in the Mixamo account; upload one at mixamo.com first.")
+
+
+def _search(headers: dict, query: str, limit: int = 12) -> list:
+    data = _get(BASE_URL + "/products", headers, params={
+        "page": 1, "limit": min(limit, 24), "order": "", "query": query, "type": "Motion,MotionPack",
+    })
+    return data.get("results", []) or []
+
+
+def _resolve_animation(headers: dict, name_or_id: str) -> dict:
+    """Find the animation product by exact id or by best search match on the name."""
+    hits = _search(headers, name_or_id, limit=24)
+    for h in hits:
+        if h.get("id") == name_or_id or (h.get("name", "").lower() == name_or_id.lower()):
+            return h
+    if hits:
+        return hits[0]   # best match
+    sys.exit("[mixamo_gen] ERROR: no Mixamo animation matches %r." % name_or_id)
+
+
+def _gms_hash(headers: dict, animation_id: str, character_id: str) -> dict:
+    """Fetch product details and build the export gms_hash (params array -> comma string)."""
+    details = _get(BASE_URL + "/products/%s" % animation_id, headers,
+                   params={"similar": 0, "character_id": character_id})
+    gms = (details.get("details") or {}).get("gms_hash") or {}
+    if not gms:
+        sys.exit("[mixamo_gen] ERROR: animation %s has no gms_hash (not exportable)." % animation_id)
+    out = dict(gms)
+    params = gms.get("params", [])
+    if isinstance(params, list):
+        out["params"] = ",".join(str(p[1]) for p in params if isinstance(p, (list, tuple)) and len(p) > 1) or "0"
+    else:
+        out["params"] = str(params) if params else "0"
+    return out, details.get("description") or details.get("name") or animation_id
+
+
+def _export_and_download(headers: dict, character_id: str, gms: dict, product_name: str,
+                         dest: str, skin: bool, timeout: int) -> int:
+    body = {
+        "character_id": character_id,
+        "gms_hash": [gms],
+        "preferences": {"format": "fbx7_2019", "skin": "true" if skin else "false",
+                        "fps": "30", "reducekf": "0"},
+        "product_name": product_name,
+        "type": "Motion",
+    }
+    _post(BASE_URL + "/animations/export", headers, body)
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        time.sleep(POLL_INTERVAL_SEC)
+        mon = _get(BASE_URL + "/characters/%s/monitor" % character_id, headers)
+        status = str(mon.get("status", "")).lower()
+        if status in ("completed", "succeeded"):
+            url = mon.get("job_result")
+            if not url:
+                sys.exit("[mixamo_gen] ERROR: export completed but no job_result URL: %s" % json.dumps(mon))
+            return _download(url, dest)
+        if status in ("failed", "error"):
+            sys.exit("[mixamo_gen] ERROR: Mixamo export failed: %s" % mon.get("message", json.dumps(mon)))
+    sys.exit("[mixamo_gen] ERROR: export timed out after %ds." % timeout)
+
+
+def _fetch_clip(headers: dict, character_id: str, query: str, out_path: str,
+                skin: bool, timeout: int) -> int:
+    anim = _resolve_animation(headers, query)
+    gms, product_name = _gms_hash(headers, anim["id"], character_id)
+    print("[mixamo_gen] export %r (%s) -> %s" % (anim.get("name", query), anim["id"], out_path))
+    return _export_and_download(headers, character_id, gms, product_name, out_path, skin, timeout)
+
+
+# --------------------------------------------------------------------------- #
+# Commands.
+# --------------------------------------------------------------------------- #
+def _cmd_test_key() -> None:
+    """Validate the token + confirm the (unofficial, sunset-risk) API is still live."""
+    headers = _headers(_load_token())
+    data = _get(BASE_URL + "/characters", headers)
+    cid = data.get("primary_character_id") or (data.get("results") or [{}])[0].get("character_id")
+    print("Mixamo Auth OK" + (" (character %s)" % cid if cid else " (no character uploaded yet)"))
+
+
+def _cmd_search(args) -> None:
+    headers = _headers(_load_token())
+    for h in _search(headers, args.query, limit=args.limit):
+        print("  %-40s  id=%s" % (h.get("name", "")[:40], h.get("id")))
+
+
+def _cmd_download(args) -> None:
+    headers = _headers(_load_token())
+    cid = _primary_character_id(headers)
+    os.makedirs(args.out, exist_ok=True)
+    safe = "".join(c if (c.isalnum() or c in "-_") else "_" for c in args.name)[:64]
+    size = _fetch_clip(headers, cid, args.name, os.path.join(args.out, "anim_%s.fbx" % safe),
+                       args.skin, args.timeout)
+    print("[mixamo_gen] downloaded anim_%s.fbx (%d bytes)" % (safe, size))
+
+
+def _cmd_moveset(args) -> None:
+    headers = _headers(_load_token())
+    cid = _primary_character_id(headers)
+    os.makedirs(args.out, exist_ok=True)
+    done = {}
+    for i, (name, query) in enumerate(WORLDOS_MOVESET.items()):
+        # first clip carries the skin (a base mesh) if --skin; the rest are clip-only for retargeting.
+        skin = args.skin and i == 0
+        path = os.path.join(args.out, "anim_%s.fbx" % name)
+        try:
+            done[name] = _fetch_clip(headers, cid, query, path, skin, args.timeout)
+        except SystemExit as e:
+            print("[mixamo_gen] WARN: %s (%r) skipped — %s" % (name, query, e))
+    print("[mixamo_gen] moveset OK — %d/%d clips: %s"
+          % (len(done), len(WORLDOS_MOVESET), ", ".join(done)))
+
+
+def main(argv=None) -> None:
+    ap = argparse.ArgumentParser(description="Headless Mixamo animation downloader for WorldOS.")
+    ap.add_argument("--test-key", action="store_true", help="validate the Mixamo token + API liveness")
+    sub = ap.add_subparsers(dest="command")
+
+    sp_s = sub.add_parser("search", help="list animations matching a query")
+    sp_s.add_argument("query")
+    sp_s.add_argument("--limit", type=int, default=12)
+
+    sp_d = sub.add_parser("download", help="download one animation by name/id")
+    sp_d.add_argument("name")
+    sp_d.add_argument("--out", required=True)
+    sp_d.add_argument("--skin", action="store_true", help="include the character mesh (default: clip only)")
+    sp_d.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SEC)
+
+    sp_m = sub.add_parser("moveset", help="download the full WorldOS combat moveset as named FBX")
+    sp_m.add_argument("--out", required=True)
+    sp_m.add_argument("--skin", action="store_true", help="include the mesh on the FIRST clip (a base)")
+    sp_m.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT_SEC)
+
+    args = ap.parse_args(argv)
+    if args.test_key:
+        _cmd_test_key()
+        return
+    if args.command == "search":
+        _cmd_search(args)
+    elif args.command == "download":
+        _cmd_download(args)
+    elif args.command == "moveset":
+        _cmd_moveset(args)
+    else:
+        ap.print_help()
+        sys.exit("\n[mixamo_gen] ERROR: a subcommand (search|download|moveset) or --test-key is required.")
+
+
+if __name__ == "__main__":
+    main()

--- a/extensions/renderers/godot/tools/mixamo_gen.py
+++ b/extensions/renderers/godot/tools/mixamo_gen.py
@@ -158,18 +158,23 @@ def _download(url: str, dest: str) -> int:
 # --------------------------------------------------------------------------- #
 # Mixamo API flow (search -> details -> export -> monitor -> download).
 # --------------------------------------------------------------------------- #
+def _pick_character_id(data) -> str:
+    """GET /characters returns a LIST of {uuid,name,type,source} (system chars + any user upload).
+    Export retargets onto a character; for GENERIC clips any works. Prefer a user-uploaded character,
+    else the first system one. (Also tolerate a dict shape just in case the API changes.)"""
+    chars = data if isinstance(data, list) else (data.get("results") or [])
+    if not chars:
+        return ""
+    user = next((c for c in chars if c.get("type") == "user" or c.get("source") == "user"), None)
+    chosen = user or chars[0]
+    return chosen.get("uuid") or chosen.get("character_id") or chosen.get("id") or ""
+
+
 def _primary_character_id(headers: dict) -> str:
-    """Mixamo retargets onto a character; export needs the account's character_id."""
-    data = _get(BASE_URL + "/characters", headers)
-    cid = data.get("primary_character_id")
-    if cid:
-        return cid
-    results = data.get("results") or []
-    if results:
-        cid = results[0].get("character_id") or results[0].get("id")
-        if cid:
-            return cid
-    sys.exit("[mixamo_gen] ERROR: no character in the Mixamo account; upload one at mixamo.com first.")
+    cid = _pick_character_id(_get(BASE_URL + "/characters", headers))
+    if not cid:
+        sys.exit("[mixamo_gen] ERROR: no usable character returned by Mixamo /characters.")
+    return cid
 
 
 def _search(headers: dict, query: str, limit: int = 12) -> list:
@@ -246,8 +251,7 @@ def _fetch_clip(headers: dict, character_id: str, query: str, out_path: str,
 def _cmd_test_key() -> None:
     """Validate the token + confirm the (unofficial, sunset-risk) API is still live."""
     headers = _headers(_load_token())
-    data = _get(BASE_URL + "/characters", headers)
-    cid = data.get("primary_character_id") or (data.get("results") or [{}])[0].get("character_id")
+    cid = _pick_character_id(_get(BASE_URL + "/characters", headers))
     print("Mixamo Auth OK" + (" (character %s)" % cid if cid else " (no character uploaded yet)"))
 
 


### PR DESCRIPTION
## What & why
Turns "an agent gives a humanoid its full combat moveset" into a **single command**, adds the richer
**Mixamo** library headlessly, and records the verdict of the 2026-06-28 Unity-skills/MCP review.

## meshy_gen.py — `--moveset` (the headline)
```bash
meshy_gen.py --prompt "an elf ranger ..." --out <dir> --moveset
```
- `WORLDOS_MOVESET = idle/attack/cast/block/dodge/hit/death` → Meshy action_ids, **all live-verified** (each generated a real clip on a rigged elf). walk+run come free with the rig.
- Clips land as **named** `anim_<name>.fbx` (not `anim_action_<id>`) — agent-readable.
- **Proven end-to-end:** 9 named clips, each a real `AnimationClip` (Attack, Block1, Charged_Spell_Cast, Dead, Stand_Dodge, Hit_Reaction, Idle, walk, run). ~21 cr + rig.

## mixamo_gen.py — NEW headless Mixamo wrapper
The `unity-mcp-mixamo` MCP **can't run on WorldOS** (Windows-only `.exe`, GUI-bound, no headless). So this replicates Mixamo's internal REST flow with **urllib + the owner's OAuth token** — no browser, no Unity, no `.exe`. Reverse-engineered faithfully from that project's Python client:
`/products` (search) → `/products/{id}` (gms_hash) → `/animations/export {preferences:fbx7_2019}` → poll `/characters/{id}/monitor` → download FBX. Subcommands: `search` / `download` / `moveset` (same 9 named clips).
- Token in `~/.worldos/mixamo.token`; **`--test-key` first** (unofficial API, Adobe-sunset risk; token expires ~hours).
- ⚠️ **Needs the owner's Mixamo token to run live** — compiles + lints + gives clear token-extraction guidance; not yet validated against the live API (no token in this environment).

## docs
- **COMBAT_MOVESET.md** — the canonical process: both feeders (Meshy default / Mixamo upgrade) → import as **`animationType=Generic`** → Animator over the CoplayDev bridge → **Cinemachine** → **visual-critic L7 motion** score.
- **SKILL.md** — decision-tree + wrapper list updated; records the skills-review verdict: **ADOPT Cinemachine; TRIAL compile-fixer + test-runner; SKIP** ECS/URP/rival-bridges/addressables/input-system as architecture-mismatched (engine is sole writer, built-in pipeline, one bridge).

## Validation
`meshy --moveset` proven live (9 named real clips). Both wrappers compile + ruff-clean + smoke-test (`--test-key`/`--dry-run`/guards). `mixamo_gen.py` grounded in the real API but needs the owner's token to run end-to-end.