### PR TITLE
Unity renderer: canonical-state registry + version-control build scripts (fix regression)

### DIFF
--- a/extensions/renderers/unity/CANONICAL.md
+++ b/extensions/renderers/unity/CANONICAL.md
@@ -1,0 +1,50 @@
+# WorldOS Unity renderer — CANONICAL STATE (read this FIRST on resume)
+
+> The single source of truth for the **current-best** room / character / combat-scene + how to rebuild it.
+> **An iteration is NOT done until this file is updated.** NEVER grab a "recent" capture PNG as if it's
+> current — it may be a deprecated room. This file exists because exactly that regression happened
+> 2026-06-28: a **week-old tavern** (`combat_0N`, 06-23) was mistaken for current combat work and almost
+> got iterated on, while the real current-best (the 06-28 crypt 3D-hero spike) sat unregistered.
+
+## Camera contract (ONE — do not fork)
+Dimetric, orthographic, **elevation 30°** (asin .5 = true 2:1), **yaw 45** corner-iso, isotropic
+**cell_size 2.0**, **ortho_size 13**, grid **14×11**. `cellToWorld(c,r) = ((c-6.5)*2.0, 0, (5.0-r)*2.0)`.
+(The 06-23 `TavernTier1` used cell 5 / 14×10 — **DEPRECATED contract**; do not reuse it.)
+
+## Current-best per surface (2026-06-28)
+| Surface | CURRENT-BEST asset | Build script | Best capture / score | Status |
+|---|---|---|---|---|
+| Room plate | `Assets/painterly/backdrops/crypt_pinned_v1.png` (camera-pinned painterly crypt; L6 ~6–7) | `paint_3d_spike.cs` | `Captures-Durable/painted_backdrop_r3.png` | ✅ canonical |
+| Character (hero) | `Assets/painterly/models/hero.fbx` + `hero_albedo.png` (2048²) on a Standard/PainterlyActor mat | `paint_3d_spike.cs` | `Captures-Durable/m10_spike.png` — **Gate-1 PASSED** (textured, lit, grounded 3D actor) | ✅ canonical 3D actor |
+| Animator | `HeroAnim_CL.controller` + 9-clip moveset from `meshy_gen.py --moveset` | `ClosedLoopBuilder.cs` + `unity-editor-patterns-m1-combat.md` | — | ⚠ WIP |
+| Combat SCENE (multi-actor) | **NOT YET BUILT on the canonical foundation** | (target) `ClosedLoopBuilder.cs` on crypt + 3D hero + goblin | — | ▶ **NEXT TARGET** |
+
+## DEPRECATED (do NOT resume from these)
+- `TavernTier1.unity` + `Captures/combat_0[1-4]_*.png` (06-23) — week-old tavern; floating dark actors,
+  no rings/VFX/goblin. Visual-critic 2026-06-28: **L5=3.5 CRITICAL, L2=4.5/L1=5.5 HIGH (~overall 4-5)**.
+  Superseded by the crypt 3D-actor pipeline.
+- 8-facing **billboard** hero sprites (`Assets/painterly/sprites/hero/hero_*.png`) — the billboard approach
+  (capped ~4/10 "pasted sticker"); superseded by the real 3D actor (the PoE2 pivot).
+
+## Rebuild the current-best (deterministic)
+```bash
+# on the GEX44 box (gex44-unity-host skill); scripts live in this dir, deploy then:
+~/.local/bin/unity-mcp code execute --no-safety-checks -f paint_3d_spike.cs
+#   -> /home/unity/worldos-unity/Captures-Durable/m10_spike.png  (crypt + textured/lit/grounded 3D hero)
+```
+
+## ITERATION DISCIPLINE — an iteration is NOT done until ALL of these
+1. **Persist:** the build script ends with `EditorSceneManager.SaveScene(...)` (not render-and-forget) AND
+   is committed here in `extensions/renderers/unity/scripts/`.
+2. **Capture + score:** durable PNG in `Captures-Durable/` + logged to `qa/scores_db.py` (surface=visual, milestone).
+3. **Register:** update THIS file — add the new current-best row, mark the superseded one DEPRECATED.
+4. **Save off-box:** commit to the WorldOS repo (version control) + periodic box tarball
+   (`worldos-unity-SAVE-<date>.tgz`, excl. Library/Temp).
+5. **On RESUME:** read THIS file FIRST. Never infer "current" from a recent capture PNG.
+
+## Build-script inventory (`extensions/renderers/unity/scripts/`)
+- **canonical:** `paint_3d_spike.cs` (crypt 3D-hero spike), `paint_backdrop_p0.cs` (camera-pinned plate),
+  `ClosedLoopBuilder.cs` (combat scene builder), `CombatSurfaceDemo.cs` (engine-cell positioning + rings/shadow),
+  `CombatBeatDriver.cs` (beat sequencer), `RTCapture.cs` (render capture), `SetupPainterlyScene.cs`.
+- **deprecated/proof (billboard-era or one-off):** `IsoSpriteRenderer.cs`, `IsoHeroRender.cs`, `AnimProof.cs`,
+  `DungeonPathingProof.cs`, `PathingTestDriver.cs`, `TavernTier1Builder.cs`, `CharsV3Import.cs`, `AddWalkState.cs`.

--- a/extensions/renderers/unity/scripts/AddWalkState.cs
+++ b/extensions/renderers/unity/scripts/AddWalkState.cs
@@ -1,0 +1,96 @@
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.Animations;
+
+/// <summary>
+/// One-shot editor utility: adds Walk state + IsWalking bool param to HeroAnim_CL
+/// and GoblinAnim_CL so GridPathController can drive walk animation.
+/// Run via: Tools/WorldOS/Add Walk State to Hero+Goblin
+/// </summary>
+public static class AddWalkState
+{
+    [MenuItem("Tools/WorldOS/Add Walk State to Hero+Goblin")]
+    public static void Run()
+    {
+        SetupChar("HeroFighter",     "HeroAnim_CL",   "Assets/chars_v3/hero/glb/walk.fbx");
+        SetupChar("MonsterGoblin",   "GoblinAnim_CL", "Assets/chars_v3/goblin/glb/walk.fbx");
+    }
+
+    static void SetupChar(string goName, string controllerName, string walkFbxPath)
+    {
+        var go = GameObject.Find(goName);
+        if (go == null) { Debug.LogWarning("[AddWalk] GameObject not found: " + goName); return; }
+        var anim = go.GetComponentInChildren<Animator>();
+        if (anim == null) { Debug.LogWarning("[AddWalk] No Animator on " + goName); return; }
+        var ac = anim.runtimeAnimatorController as AnimatorController;
+        if (ac == null) { Debug.LogWarning("[AddWalk] Not an AnimatorController on " + goName); return; }
+
+        // ── 1. Add IsWalking bool param ──────────────────────────────────────
+        bool hasParam = false;
+        foreach (var p in ac.parameters)
+            if (p.name == "IsWalking") { hasParam = true; break; }
+        if (!hasParam)
+            ac.AddParameter("IsWalking", AnimatorControllerParameterType.Bool);
+
+        // ── 2. Add Walk state ─────────────────────────────────────────────────
+        var sm = ac.layers[0].stateMachine;
+        AnimatorState walkState = null;
+        AnimatorState idleState = null;
+        foreach (var cs in sm.states)
+        {
+            if (cs.state.name == "Walk") walkState = cs.state;
+            if (cs.state.name == "Idle") idleState = cs.state;
+        }
+
+        if (walkState == null)
+        {
+            var walkClip = AssetDatabase.LoadAssetAtPath<AnimationClip>(walkFbxPath);
+            if (walkClip == null)
+            {
+                // Try sub-assets
+                var objs = AssetDatabase.LoadAllAssetRepresentationsAtPath(walkFbxPath);
+                foreach (var o in objs)
+                    if (o is AnimationClip c) { walkClip = c; break; }
+            }
+            walkState = sm.AddState("Walk");
+            walkState.motion = walkClip;
+            walkState.speed = 1f;
+            Debug.Log("[AddWalk] Created Walk state for " + goName +
+                      " clip=" + (walkClip != null ? walkClip.name : "NULL"));
+        }
+
+        // ── 3. Idle → Walk (IsWalking true) ──────────────────────────────────
+        if (idleState != null)
+        {
+            bool hasIToW = false;
+            foreach (var tr in idleState.transitions)
+                if (tr.destinationState == walkState) { hasIToW = true; break; }
+            if (!hasIToW)
+            {
+                var t = idleState.AddTransition(walkState);
+                t.hasExitTime = false;
+                t.duration = 0.10f;
+                t.AddCondition(AnimatorConditionMode.If, 0f, "IsWalking");
+            }
+        }
+
+        // ── 4. Walk → Idle (IsWalking false) ─────────────────────────────────
+        if (idleState != null)
+        {
+            bool hasWToI = false;
+            foreach (var tr in walkState.transitions)
+                if (tr.destinationState == idleState) { hasWToI = true; break; }
+            if (!hasWToI)
+            {
+                var t = walkState.AddTransition(idleState);
+                t.hasExitTime = false;
+                t.duration = 0.10f;
+                t.AddCondition(AnimatorConditionMode.IfNot, 0f, "IsWalking");
+            }
+        }
+
+        EditorUtility.SetDirty(ac);
+        AssetDatabase.SaveAssets();
+        Debug.Log("[AddWalk] Done for " + goName + " — IsWalking param + Walk state wired.");
+    }
+}

--- a/extensions/renderers/unity/scripts/AnimFrameCapture.cs
+++ b/extensions/renderers/unity/scripts/AnimFrameCapture.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using UnityEditor;
+public static class AnimFrameCapture {
+  static int frameIdx = 0;
+  static float[] nTs = {0.04f,0.12f,0.21f,0.29f,0.37f,0.46f,0.54f,0.62f,0.71f,0.79f,0.87f,0.96f};
+  static Animator hA, gA;
+  [MenuItem("Tools/Start Anim Capture")]
+  public static void Start() {
+    frameIdx=0;
+    var h=GameObject.Find("HeroFighter"); hA=h?.GetComponentInChildren<Animator>();
+    var g=GameObject.Find("MonsterGoblin"); gA=g?.GetComponentInChildren<Animator>();
+    EditorApplication.update+=OnTick;
+    UnityEngine.Debug.Log("CAPTURE: started");
+  }
+  static void OnTick() {
+    if(frameIdx>=nTs.Length){EditorApplication.update-=OnTick;UnityEngine.Debug.Log("CAPTURE: done");return;}
+    float nt=nTs[frameIdx];
+    if(hA!=null){hA.Play("Attack",-1,nt);hA.Update(0f);}
+    if(gA!=null){gA.Play("Attack",-1,(nt+0.1f)%1f);gA.Update(0f);}
+    ScreenCapture.CaptureScreenshot("/Volumes/LEXAR/WorldOS-Unity-spike/Captures/anim_seq_"+(frameIdx+1).ToString("D2")+".png");
+    UnityEngine.Debug.Log("CAPTURE frame "+(frameIdx+1)+" nT="+nt);
+    frameIdx++;
+  }
+}

--- a/extensions/renderers/unity/scripts/AnimProof.cs
+++ b/extensions/renderers/unity/scripts/AnimProof.cs
@@ -1,0 +1,115 @@
+using UnityEngine;
+using UnityEditor;
+using UnityEditor.Animations;
+using System.IO;
+
+/// <summary>
+/// Animation proof for ARM 1B (winner): wire the Mecanim Idle clip (looping) onto the in-scene
+/// hero + goblin via an AnimatorController, then capture two frames at different clip times to
+/// prove the rig actually animates (the silhouette/limbs change between frames).
+/// </summary>
+public static class AnimProof
+{
+    // Build a looping AnimatorController whose default state plays the FBX's Idle clip.
+    static AnimatorController BuildIdleController(string fbxPath, string ctrlPath)
+    {
+        AnimationClip idle = null;
+        foreach (var o in AssetDatabase.LoadAllAssetsAtPath(fbxPath))
+        {
+            var cl = o as AnimationClip;
+            if (cl != null && !cl.name.StartsWith("__preview") && cl.name.Contains("Idle")) { idle = cl; break; }
+        }
+        if (idle == null) { Debug.LogError("[AnimProof] no Idle clip in " + fbxPath); return null; }
+        var ctrl = AnimatorController.CreateAnimatorControllerAtPath(ctrlPath);
+        var sm = ctrl.layers[0].stateMachine;
+        var st = sm.AddState("Idle");
+        st.motion = idle;
+        sm.defaultState = st;
+        Debug.Log("[AnimProof] controller " + ctrlPath + " -> Idle clip '" + idle.name + "' (loop=" + idle.isLooping + ")");
+        return ctrl;
+    }
+
+    [MenuItem("Tools/WorldOS/CL/B Wire Mecanim Idle (winner)")]
+    public static void WireIdle()
+    {
+        foreach (var pair in new[] {
+            new[]{"HeroFighter",HeroFbx(),"Assets/HeroIdle.controller"},
+            new[]{"MonsterGoblin",GobFbx(),"Assets/GoblinIdle.controller"} })
+        {
+            var go = GameObject.Find(pair[0]);
+            if (go == null) { Debug.LogError("[AnimProof] not found: " + pair[0]); continue; }
+            // the FBX is the child (wrapper holds placement); the Animator goes on the FBX root
+            var fbx = go.transform.childCount > 0 ? go.transform.GetChild(0).gameObject : go;
+            var anim = fbx.GetComponent<Animator>();
+            if (anim == null) anim = fbx.AddComponent<Animator>();
+            var avatar = AssetDatabase.LoadAllAssetsAtPath(pair[1]);
+            foreach (var o in avatar) { if (o is Avatar) { anim.avatar = (Avatar)o; break; } }
+            anim.runtimeAnimatorController = BuildIdleController(pair[1], pair[2]);
+            anim.applyRootMotion = false;
+            anim.cullingMode = AnimatorCullingMode.AlwaysAnimate;
+            Debug.Log("[AnimProof] wired Animator on " + pair[0] + " (avatar=" + (anim.avatar != null) + ")");
+        }
+        UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(
+            UnityEngine.SceneManagement.SceneManager.GetActiveScene());
+    }
+
+    // Edit-mode proof: sample the hero Idle at two times and capture, so the limbs differ.
+    [MenuItem("Tools/WorldOS/CL/B2 Capture Idle Frames (proof)")]
+    public static void CaptureIdleFrames()
+    {
+        var cam = Camera.main;
+        var hero = GameObject.Find("HeroFighter");
+        var gob = GameObject.Find("MonsterGoblin");
+        var heroFbx = hero.transform.GetChild(0).gameObject;
+        var gobFbx = gob.transform.GetChild(0).gameObject;
+        AnimationClip heroIdle = FindClip(HeroFbx(), "Idle");
+        AnimationClip gobIdle = FindClip(GobFbx(), "Idle");
+        AnimationClip heroWalk = FindClip(HeroFbx(), "Walk");
+
+        float[] times = { 0.15f, 0.55f };   // two distinct Idle phases (loop)
+        for (int i = 0; i < times.Length; i++)
+        {
+            float t = times[i] * (heroIdle != null ? heroIdle.length : 1f);
+            if (heroIdle != null) heroIdle.SampleAnimation(heroFbx, t);
+            float tg = times[i] * (gobIdle != null ? gobIdle.length : 1f);
+            if (gobIdle != null) gobIdle.SampleAnimation(gobFbx, tg);
+            Capture(cam, "/tmp/1B_idle_frame" + i + ".png");
+        }
+        // a Walk frame too (prove Walk clip)
+        if (heroWalk != null) heroWalk.SampleAnimation(heroFbx, 0.4f * heroWalk.length);
+        Capture(cam, "/tmp/1B_walk_frame.png");
+        // restore Idle pose
+        if (heroIdle != null) heroIdle.SampleAnimation(heroFbx, 0.4f * heroIdle.length);
+        if (gobIdle != null) gobIdle.SampleAnimation(gobFbx, 0.4f * gobIdle.length);
+        Debug.Log("[AnimProof] captured /tmp/1B_idle_frame0.png, frame1.png, walk_frame.png");
+    }
+
+    static AnimationClip FindClip(string fbx, string name)
+    {
+        // chars_v3 emits one FBX per clip -> search the whole char folder (ClosedLoopBuilder helper).
+        return ClosedLoopBuilder.FindClipInDir(fbx, name);
+    }
+
+    // resolve the active mesh-source FBX per character (chars_v3 idle.fbx when UseV3, else chars_v2).
+    static string HeroFbx() { return ClosedLoopBuilder.UseV3 ? "Assets/chars_v3/hero/glb/idle.fbx" : "Assets/chars_v2/hero/hero.fbx"; }
+    static string GobFbx()  { return ClosedLoopBuilder.UseV3 ? "Assets/chars_v3/goblin/glb/idle.fbx" : "Assets/chars_v2/goblin/goblin.fbx"; }
+
+    static void Capture(Camera cam, string outPath)
+    {
+        var rt = new RenderTexture(1344, 756, 24, RenderTextureFormat.ARGB32);
+        rt.Create();
+        var prev = cam.targetTexture;
+        cam.targetTexture = rt;
+        cam.Render();
+        var pa = RenderTexture.active;
+        RenderTexture.active = rt;
+        var tex = new Texture2D(1344, 756, TextureFormat.RGB24, false);
+        tex.ReadPixels(new Rect(0, 0, 1344, 756), 0, 0);
+        tex.Apply();
+        File.WriteAllBytes(outPath, tex.EncodeToPNG());
+        RenderTexture.active = pa;
+        cam.targetTexture = prev;
+        rt.Release();
+        Object.DestroyImmediate(tex);
+    }
+}

--- a/extensions/renderers/unity/scripts/CharsV3Import.cs
+++ b/extensions/renderers/unity/scripts/CharsV3Import.cs
@@ -1,0 +1,81 @@
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+
+/// <summary>
+/// Configure the chars_v3 (Meshy hi-tier: meshy-6, 300K->140K remeshed, 4K hd_texture,
+/// remove_lighting) rigged FBXs for Unity: import as HUMANOID, name each animation FBX's single
+/// take to Idle/Walk/Attack, set Idle+Walk to loop, copy the avatar from the rigged FBX so all
+/// clips share one Humanoid avatar (retargetable). The Meshy rig+animation API emits SEPARATE FBX
+/// files per clip (rigged/idle/walk/attack) — unlike chars_v2's single multi-take hero.fbx — so the
+/// scene code now searches the whole char folder for a named clip (see ClosedLoopBuilder.FindClipInDir).
+/// </summary>
+public static class CharsV3Import
+{
+    static readonly string[] Chars = { "hero", "goblin" };
+
+    [MenuItem("Tools/WorldOS/CL/V3 Configure chars_v3 FBX (Humanoid + clips)")]
+    public static void Configure()
+    {
+        foreach (var who in Chars)
+        {
+            string dir = "Assets/chars_v3/" + who + "/glb";
+            // 1) rigged.fbx = the avatar SOURCE (Create From This Model), Humanoid.
+            ConfigureFbx(dir + "/rigged.fbx", null, false, true, null);
+            // 2) animation FBXs: Humanoid avatar COPIED from rigged.fbx; rename the take.
+            string riggedAvatar = dir + "/rigged.fbx";
+            ConfigureFbx(dir + "/idle.fbx",   "Idle",   true,  false, riggedAvatar);
+            ConfigureFbx(dir + "/walk.fbx",   "Walk",   true,  false, riggedAvatar);
+            ConfigureFbx(dir + "/attack.fbx", "Attack", false, false, riggedAvatar);
+        }
+        AssetDatabase.Refresh();
+        Debug.Log("[V3] Configured chars_v3 FBX importers (Humanoid + named clips). Reimporting...");
+    }
+
+    static void ConfigureFbx(string path, string clipName, bool loop, bool createAvatar, string copyAvatarFrom)
+    {
+        if (!File.Exists(path)) { Debug.LogWarning("[V3] missing " + path); return; }
+        var imp = AssetImporter.GetAtPath(path) as ModelImporter;
+        if (imp == null) { Debug.LogWarning("[V3] not a model: " + path); return; }
+
+        imp.animationType = ModelImporterAnimationType.Human;
+        imp.importAnimation = true;
+        imp.importBlendShapes = false;
+        imp.materialImportMode = ModelImporterMaterialImportMode.ImportStandard;
+        imp.materialLocation = ModelImporterMaterialLocation.InPrefab;
+
+        if (createAvatar)
+        {
+            imp.avatarSetup = ModelImporterAvatarSetup.CreateFromThisModel;
+        }
+        else if (!string.IsNullOrEmpty(copyAvatarFrom))
+        {
+            var src = AssetDatabase.LoadAssetAtPath<Avatar>(copyAvatarFrom);
+            if (src == null)
+            {
+                foreach (var o in AssetDatabase.LoadAllAssetsAtPath(copyAvatarFrom))
+                    if (o is Avatar) { src = (Avatar)o; break; }
+            }
+            if (src != null)
+            {
+                imp.avatarSetup = ModelImporterAvatarSetup.CopyFromOther;
+                imp.sourceAvatar = src;
+            }
+        }
+
+        // name the single take + loop
+        if (!string.IsNullOrEmpty(clipName))
+        {
+            var clips = imp.defaultClipAnimations;
+            if (clips != null && clips.Length > 0)
+            {
+                clips[0].name = clipName;
+                clips[0].loopTime = loop;
+                imp.clipAnimations = clips;
+            }
+        }
+        EditorUtility.SetDirty(imp);
+        imp.SaveAndReimport();
+        Debug.Log("[V3] configured " + path + (clipName != null ? " clip=" + clipName + " loop=" + loop : " (avatar src)"));
+    }
+}

--- a/extensions/renderers/unity/scripts/ClosedLoopBuilder.cs
+++ b/extensions/renderers/unity/scripts/ClosedLoopBuilder.cs
@@ -1,0 +1,1336 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using System.IO;
+
+/// <summary>
+/// CLOSED-LOOP painterly pipeline — WorldOS Unity sprint.
+///
+/// REPEATABLE / FIXTURE-PARAMETERIZED. The whole pipeline is driven from a
+/// SceneGrid fixture JSON (see fixtures/*.scenegrid.json). The game CAMERA is the
+/// single registration authority; the next scene is a button-press pointed at a
+/// different fixture.
+///
+///   1. Load fixture -> grid (cols/rows/cell), props (occluders+bands), spawns,
+///      lighting. (LoadFixture)
+///   2. Lock camera (ortho, dimetric pitch atan(0.5)=26.565deg, fixed 16:9). (LockCamera)
+///   3. Render blockout THROUGH that camera -> off-screen 16:9 DEPTH + SEG (+CANNY
+///      structure) targets = the ControlNet conditioning. (CaptureConditioning / CaptureStructure)
+///   4. (external) Scenario ControlNet paints the plate FROM those captures
+///      (tavern_plate_cl.png). See CLOSED-LOOP-PIPELINE.md for exact model+params.
+///   5. Display the plate as a CAMERA-LOCKED full-frame quad filling the frustum at
+///      the camera's aspect (painted floor lands on grid floor); hide blockout; place
+///      invisible depth-only occluder proxies at prop cells; place actors by spawn cell
+///      with SCENE-LIT painterly faction mats + soft contact shadows. (AssembleFinal)
+///   6. Critic-panel gate (external 3-lens adversarial panel).
+///
+/// ONE-BUTTON ENTRY: Tools/WorldOS/CL/0 Build Closed-Loop Scene (fixture) runs
+/// LockCamera -> CaptureConditioning -> CaptureStructure -> AssembleFinal in order.
+/// </summary>
+public static class ClosedLoopBuilder
+{
+    // ==================================================================
+    // FIXTURE — single source of truth. Point this at any *.scenegrid.json.
+    // ==================================================================
+    public const string FixturePath = "/home/unity/worldos-unity/fixtures/tavern.scenegrid.json";
+
+    // ---- camera authority (constant across scenes) ----
+    const int   CAP_W = 1344;          // 16:9
+    const int   CAP_H = 756;
+    const float ORTHO = 18f;
+    static readonly Vector3 CAM_POS = new Vector3(0f, 40.25f, -55.5f);
+
+    // ---- segmentation palette (constant) ----
+    static readonly Color SEG_FLOOR = new Color(0.20f, 0.55f, 0.25f);
+    static readonly Color SEG_WALL  = new Color(0.30f, 0.35f, 0.55f);
+    static readonly Color SEG_PROP  = new Color(0.85f, 0.55f, 0.20f);
+    static readonly Color SEG_ACTOR = new Color(0.90f, 0.10f, 0.40f);
+    static readonly Color SEG_BACK  = new Color(0.04f, 0.04f, 0.06f);
+
+    // height bands (world units)
+    const float TALL_H = 3.0f, MID_H = 1.8f, LOW_H = 1.0f;
+
+    // ---- actor render tuning (round-1 fixes: belong-in-scene) ----
+    const float ACTOR_TARGET_H = 9.6f;   // r11 L4 (BOTH runs, CRITICAL): on the wider v3 plate the actors
+                                         // read as thumbnails dwarfed by the hall = "props, not dramatis
+                                         // personae". Bump so the hero occupies a PoE2-like fraction of frame
+                                         // height (face/armor masses read). Sidecar emits the real world-height
+                                         // so the pregate G4 (measured-vs-expected px) re-validates at the new scale.
+
+    // ==================================================================
+    // FIXTURE MODEL — parsed from the SceneGrid JSON.
+    // ==================================================================
+    public class PropDef { public string id; public string band="mid"; public bool occluder=true;
+                           public int minC, maxC, minR, maxR; }
+    public class Fixture
+    {
+        public string sceneId="scene";
+        public int cols=14, rows=10; public float cell=5f;
+        public float OriginX { get { return -(cols * cell) / 2f; } }
+        public float OriginZ = 0f;
+        public List<PropDef> props = new List<PropDef>();
+        // walls: cells flagged type=="wall" (for the enclosure line-art); we derive
+        // the room rectangle from grid bounds, so we only need props + spawns + lighting.
+        public List<int[]> party = new List<int[]>();   // [c,r]
+        public List<int[]> foes  = new List<int[]>();
+        public Color keyColor = new Color(1.000f, 0.604f, 0.271f, 1f);     // #ff9a45
+        public Color ambientColor = new Color(0.227f, 0.247f, 0.333f, 1f); // #3a3f55
+        public float keyDirDeg = 210f;
+    }
+
+    static Fixture _fx;
+    public static Fixture Fx { get { if (_fx == null) _fx = LoadFixture(FixturePath); return _fx; } }
+
+    public static Fixture LoadFixture(string path)
+    {
+        var fx = new Fixture();
+        if (!File.Exists(path)) { Debug.LogError("[CL] fixture not found: " + path); return fx; }
+        var root = MiniJson.Parse(File.ReadAllText(path)) as Dictionary<string, object>;
+        if (root == null) { Debug.LogError("[CL] fixture parse failed: " + path); return fx; }
+
+        fx.sceneId = Str(root, "scene_id", "scene");
+        if (root.TryGetValue("grid", out var go) && go is Dictionary<string, object> grid)
+        {
+            fx.cols = (int)Num(grid, "cols", 14);
+            fx.rows = (int)Num(grid, "rows", 10);
+            fx.cell = (float)Num(grid, "cell_size_ft", 5);
+        }
+        // props: each has id, height_band, occluder, and a cells[] of [c,r]
+        if (root.TryGetValue("props", out var po) && po is List<object> plist)
+        {
+            foreach (var pe in plist)
+            {
+                if (pe is Dictionary<string, object> pd)
+                {
+                    var def = new PropDef { id = Str(pd, "id", "prop"),
+                                           band = Str(pd, "height_band", "mid"),
+                                           occluder = Bool(pd, "occluder", true) };
+                    int minC=int.MaxValue,maxC=int.MinValue,minR=int.MaxValue,maxR=int.MinValue;
+                    if (pd.TryGetValue("cells", out var co) && co is List<object> cells)
+                    {
+                        foreach (var ce in cells)
+                            if (ce is List<object> cr && cr.Count >= 2)
+                            {
+                                int c = (int)System.Convert.ToDouble(cr[0]);
+                                int r = (int)System.Convert.ToDouble(cr[1]);
+                                minC=Mathf.Min(minC,c); maxC=Mathf.Max(maxC,c);
+                                minR=Mathf.Min(minR,r); maxR=Mathf.Max(maxR,r);
+                            }
+                    }
+                    def.minC=minC; def.maxC=maxC; def.minR=minR; def.maxR=maxR;
+                    if (minC != int.MaxValue) fx.props.Add(def);
+                }
+            }
+        }
+        // spawns
+        if (root.TryGetValue("spawns", out var so) && so is Dictionary<string, object> spawns)
+        {
+            fx.party = CellList(spawns, "party");
+            fx.foes  = CellList(spawns, "foes");
+        }
+        // lighting
+        if (root.TryGetValue("lighting", out var lo) && lo is Dictionary<string, object> lit)
+        {
+            fx.keyDirDeg = (float)Num(lit, "key_dir_deg", 210);
+            fx.keyColor = HexColor(Str(lit, "key_color", "#ff9a45"), fx.keyColor);
+            fx.ambientColor = HexColor(Str(lit, "ambient_color", "#3a3f55"), fx.ambientColor);
+        }
+        Debug.Log("[CL] Loaded fixture '" + fx.sceneId + "': grid " + fx.cols + "x" + fx.rows +
+                  " cell " + fx.cell + ", props " + fx.props.Count + ", party " + fx.party.Count +
+                  ", foes " + fx.foes.Count + ", keyDir " + fx.keyDirDeg);
+        return fx;
+    }
+
+    static List<int[]> CellList(Dictionary<string, object> d, string key)
+    {
+        var outl = new List<int[]>();
+        if (d.TryGetValue(key, out var o) && o is List<object> list)
+            foreach (var e in list)
+                if (e is List<object> cr && cr.Count >= 2)
+                    outl.Add(new[] { (int)System.Convert.ToDouble(cr[0]), (int)System.Convert.ToDouble(cr[1]) });
+        return outl;
+    }
+    static string Str(Dictionary<string, object> d, string k, string def)
+        => d.TryGetValue(k, out var v) && v != null ? v.ToString() : def;
+    static double Num(Dictionary<string, object> d, string k, double def)
+        => d.TryGetValue(k, out var v) && v != null ? System.Convert.ToDouble(v) : def;
+    static bool Bool(Dictionary<string, object> d, string k, bool def)
+        => d.TryGetValue(k, out var v) && v is bool b ? b : def;
+    static Color HexColor(string hex, Color def)
+        => ColorUtility.TryParseHtmlString(hex, out var c) ? c : def;
+
+    // convenience accessors (fixture-driven)
+    static int   COLS      { get { return Fx.cols; } }
+    static int   ROWS      { get { return Fx.rows; } }
+    static float CELL_SIZE { get { return Fx.cell; } }
+    static float OriginX   { get { return Fx.OriginX; } }
+    static float OriginZ   { get { return Fx.OriginZ; } }
+
+    // ---- grid -> world helpers (R2 fix: the Scenario plate paints the BACK wall
+    // (row 0: bar/hearth/door) at the TOP of the frame, so row 0 must map to the
+    // FAR Z (top) and the entrance row (rows-1) to the NEAR Z (bottom/front near
+    // camera). Earlier code mapped row 0 -> near Z, inverting actors+occluders
+    // relative to the painted plate. CellX is unchanged; CellZ is flipped. ----
+    static float CellX(float col) { return OriginX + (col + 0.5f) * CELL_SIZE; }
+    static float CellZ(float row) { return OriginZ + (ROWS - row - 0.5f) * CELL_SIZE; }
+    // span-center for a multi-cell prop (min..max inclusive), flipped on Z
+    static float PropCenterX(PropDef p) { return OriginX + (p.minC + p.maxC + 1) * CELL_SIZE * 0.5f; }
+    static float PropCenterZ(PropDef p) { return OriginZ + (ROWS - (p.minR + p.maxR + 1) * 0.5f) * CELL_SIZE; }
+
+    // ==================================================================
+    // ARM toggle (bake-off) — sets which actor pipeline AssembleFinal uses.
+    // ==================================================================
+    [MenuItem("Tools/WorldOS/CL/Arm 1B (live 3D)")]
+    public static void SetArm1B() { Arm = "1B"; Debug.Log("[CL] Arm = 1B (live rigged 3D actors)"); }
+    [MenuItem("Tools/WorldOS/CL/Arm 1A (sprite)")]
+    public static void SetArm1A() { Arm = "1A"; Debug.Log("[CL] Arm = 1A (painterly sprite billboards)"); }
+
+    // ==================================================================
+    // ONE-BUTTON ENTRY POINT — full pipeline from the fixture.
+    // ==================================================================
+    [MenuItem("Tools/WorldOS/CL/0 Build Closed-Loop Scene (fixture)")]
+    public static void BuildClosedLoopScene()
+    {
+        _fx = LoadFixture(FixturePath);
+        BuildBlockout();        // fixture-driven blockout (walls + props as boxes)
+        LockCamera();
+        CaptureConditioning();
+        CaptureStructure();
+        AssembleFinal();
+        EditorUtility.SetDirty(GameObject.Find("BlockoutRoot_" + Fx.sceneId) ?? new GameObject());
+        UnityEditor.SceneManagement.EditorSceneManager.SaveCurrentModifiedScenesIfUserWantsTo();
+        Debug.Log("[CL] One-button build complete for fixture '" + Fx.sceneId +
+                  "'. (Plate must be (re)generated by Scenario from the captures for a painted result.)");
+    }
+
+    // ==================================================================
+    // BUILD BLOCKOUT from fixture — walls + floor + prop boxes
+    // Creates "BlockoutRoot_<scene_id>" (replaces any prior blockout).
+    // CaptureConditioning searches for this root OR the legacy "TavernTier1".
+    // ==================================================================
+    [MenuItem("Tools/WorldOS/CL/0a Build Blockout Only (fixture)")]
+    public static void BuildBlockout()
+    {
+        var f = Fx;
+        string rootName = "BlockoutRoot_" + f.sceneId;
+        var old = GameObject.Find(rootName);
+        if (old != null) Object.DestroyImmediate(old);
+
+        var root = new GameObject(rootName);
+
+        // Floor material (flat grey floor)
+        var floorMat = AssetDatabase.LoadAssetAtPath<Material>("Assets/FloorMat_T1.mat")
+                       ?? new Material(Shader.Find("Standard"));
+        // Wall material
+        var wallMat  = AssetDatabase.LoadAssetAtPath<Material>("Assets/WallMat_T1.mat")
+                       ?? new Material(Shader.Find("Standard"));
+        // Prop material
+        var propMat  = new Material(Shader.Find("Standard"));
+        propMat.color = new Color(0.60f, 0.48f, 0.30f);
+
+        float wallH = TALL_H;
+        float floorThick = 0.05f;
+
+        // 1. Floor plane — one big quad at y=0
+        var floor = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        floor.name = "Floor";
+        floor.transform.SetParent(root.transform, false);
+        Object.DestroyImmediate(floor.GetComponent<Collider>());
+        float floorW = f.cols * f.cell;
+        float floorD = f.rows * f.cell;
+        floor.transform.localPosition = new Vector3(0f, -floorThick * 0.5f, floorD * 0.5f + f.OriginZ);
+        floor.transform.localScale = new Vector3(floorW, floorThick, floorD);
+        floor.GetComponent<Renderer>().sharedMaterial = floorMat;
+
+        // 2. Perimeter walls — derive from cells flagged wall (or use the fixture border)
+        // We parse the full fixture JSON for wall cells.
+        var wallParent = new GameObject("Walls");
+        wallParent.transform.SetParent(root.transform, false);
+
+        string rawJson = File.ReadAllText(FixturePath);
+        var parsed = MiniJson.Parse(rawJson) as System.Collections.Generic.Dictionary<string, object>;
+        if (parsed != null && parsed.TryGetValue("cells", out var co) && co is System.Collections.Generic.List<object> cellList)
+        {
+            foreach (var ce in cellList)
+            {
+                if (ce is System.Collections.Generic.Dictionary<string, object> cd)
+                {
+                    string typ = cd.TryGetValue("type", out var tv) ? tv?.ToString() : "floor";
+                    if (typ != "wall") continue;
+                    int c = (int)System.Convert.ToDouble(cd.TryGetValue("c", out var cv) ? cv : 0);
+                    int r = (int)System.Convert.ToDouble(cd.TryGetValue("r", out var rv) ? rv : 0);
+                    float wx = f.OriginX + (c + 0.5f) * f.cell;
+                    float wz = f.OriginZ + (f.rows - r - 0.5f) * f.cell;
+                    var wall = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                    wall.name = "Wall_" + c + "_" + r;
+                    wall.transform.SetParent(wallParent.transform, false);
+                    Object.DestroyImmediate(wall.GetComponent<Collider>());
+                    wall.transform.localPosition = new Vector3(wx, wallH * 0.5f, wz);
+                    wall.transform.localScale = new Vector3(f.cell * 0.98f, wallH, f.cell * 0.98f);
+                    wall.GetComponent<Renderer>().sharedMaterial = wallMat;
+                }
+            }
+        }
+
+        // 3. Prop boxes from fixture props
+        var propParent = new GameObject("Props");
+        propParent.transform.SetParent(root.transform, false);
+        foreach (var p in f.props)
+        {
+            float hh = Band(p.band);
+            float spanX = (p.maxC - p.minC + 1) * f.cell * 0.85f;
+            float spanZ = (p.maxR - p.minR + 1) * f.cell * 0.85f;
+            float cx = PropCenterX(p);
+            float cz = PropCenterZ(p);
+            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            go.name = "Prop_" + p.id;
+            go.transform.SetParent(propParent.transform, false);
+            Object.DestroyImmediate(go.GetComponent<Collider>());
+            go.transform.localPosition = new Vector3(cx, hh * 0.5f, cz);
+            go.transform.localScale = new Vector3(spanX, hh, spanZ);
+            var pmat = new Material(Shader.Find("Standard"));
+            // colour by kind: brazier=orange, pillar=grey, rubble=brown, sarcophagus=light stone
+            Color pc = p.id.Contains("brazier") ? new Color(0.8f, 0.4f, 0.1f)
+                     : p.id.Contains("pillar")  ? new Color(0.55f, 0.52f, 0.48f)
+                     : p.id.Contains("rubble")  ? new Color(0.42f, 0.38f, 0.30f)
+                     : p.id.Contains("sarcophagus") ? new Color(0.70f, 0.65f, 0.55f)
+                     : new Color(0.50f, 0.45f, 0.35f);
+            pmat.color = pc;
+            go.GetComponent<Renderer>().sharedMaterial = pmat;
+        }
+
+        // Mark dirty + save
+        EditorUtility.SetDirty(root);
+        UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(
+            UnityEngine.SceneManagement.SceneManager.GetActiveScene());
+        AssetDatabase.Refresh();
+        Debug.Log("[CL] BuildBlockout: '" + rootName + "' walls=" + wallParent.transform.childCount +
+                  " props=" + propParent.transform.childCount);
+    }
+
+    // ==================================================================
+    // CAMERA LOCK
+    // ==================================================================
+    static Camera LockCamera()
+    {
+        var cam = Camera.main;
+        if (cam == null)
+        {
+            var go = new GameObject("Main Camera");
+            go.tag = "MainCamera";
+            cam = go.AddComponent<Camera>();
+        }
+        cam.orthographic = true;
+        cam.orthographicSize = ORTHO;
+        float pitch = Mathf.Rad2Deg * Mathf.Atan(0.5f); // 26.565 (dimetric 2:1)
+        cam.transform.position = CAM_POS;
+        cam.transform.eulerAngles = new Vector3(pitch, 0f, 0f);
+        cam.nearClipPlane = 0.1f;
+        cam.farClipPlane  = 200f;
+        cam.aspect = (float)CAP_W / CAP_H;
+        return cam;
+    }
+
+    // ==================================================================
+    // STEP 3 — render conditioning maps THROUGH the camera
+    // ==================================================================
+    [MenuItem("Tools/WorldOS/CL/1 Capture Conditioning (depth+seg)")]
+    public static void CaptureConditioning()
+    {
+        var cam = LockCamera();
+        // Find the blockout root — fixture-parameterized name first, legacy TavernTier1 fallback.
+        var t1 = GameObject.Find("BlockoutRoot_" + Fx.sceneId)
+                 ?? GameObject.Find("TavernTier1");
+        if (t1 == null) { Debug.LogError("[CL] Blockout root not found (run 'Build Blockout Only' first)."); return; }
+
+        var rends = t1.GetComponentsInChildren<Renderer>(true);
+        var prevEnabled = new Dictionary<Renderer, bool>();
+        var prevMats = new Dictionary<Renderer, Material[]>();
+        foreach (var r in rends) { prevEnabled[r] = r.enabled; prevMats[r] = r.sharedMaterials; }
+
+        var bd = GameObject.Find("Backdrop_DepthBlit");
+        bool bdPrev = false; Renderer bdR = null;
+        if (bd != null) { bdR = bd.GetComponent<Renderer>(); if (bdR != null) { bdPrev = bdR.enabled; bdR.enabled = false; } }
+        var intRoot = GameObject.Find("IntegrationRoot");
+        bool intPrev = false; if (intRoot != null) { intPrev = intRoot.activeSelf; intRoot.SetActive(false); }
+
+        var rt = new RenderTexture(CAP_W, CAP_H, 24, RenderTextureFormat.ARGB32);
+        rt.Create();
+        var prevTgt = cam.targetTexture; var prevCF = cam.clearFlags; var prevBG = cam.backgroundColor;
+        cam.clearFlags = CameraClearFlags.SolidColor;
+        cam.targetTexture = rt;
+
+        var segSh = Shader.Find("WorldOS/CaptureSeg");
+        var mFloor = new Material(segSh); mFloor.SetColor("_SegColor", SEG_FLOOR);
+        var mWall  = new Material(segSh); mWall.SetColor("_SegColor", SEG_WALL);
+        var mProp  = new Material(segSh); mProp.SetColor("_SegColor", SEG_PROP);
+        var mActor = new Material(segSh); mActor.SetColor("_SegColor", SEG_ACTOR);
+        ApplyCategoryMaterials(rends, mFloor, mWall, mProp, mActor);
+        cam.backgroundColor = SEG_BACK;
+        cam.Render();
+        SaveRT(rt, "Assets/painterly/cap_seg.png");
+
+        var depthSh = Shader.Find("WorldOS/CaptureDepth");
+        var mDepth = new Material(depthSh);
+        mDepth.SetFloat("_NearD", 38f);
+        mDepth.SetFloat("_FarD", 92f);
+        ApplyUniformMaterial(rends, mDepth);
+        cam.backgroundColor = Color.black;
+        cam.Render();
+        SaveRT(rt, "Assets/painterly/cap_depth.png");
+
+        cam.targetTexture = prevTgt; cam.clearFlags = prevCF; cam.backgroundColor = prevBG;
+        rt.Release();
+        foreach (var r in rends) { r.enabled = prevEnabled[r]; r.sharedMaterials = prevMats[r]; }
+        if (bdR != null) bdR.enabled = bdPrev;
+        if (intRoot != null) intRoot.SetActive(intPrev);
+        AssetDatabase.Refresh();
+        Debug.Log("[CL] Captured cap_depth.png + cap_seg.png at " + CAP_W + "x" + CAP_H + " (16:9).");
+    }
+
+    // ==================================================================
+    // STRUCTURE capture — bright dimetric floor lattice + prop/wall edges
+    // on black, for CANNY ControlNet. Floor lattice now extends to the
+    // FRAME-BOTTOM cells so the painted floor is continuous (R1 L1 fix).
+    // ==================================================================
+    [MenuItem("Tools/WorldOS/CL/1b Capture Structure (canny line-art)")]
+    public static void CaptureStructure()
+    {
+        var cam = LockCamera();
+
+        var tmp = new GameObject("__StructCap");
+        var lineSh = Shader.Find("WorldOS/CaptureSeg");
+        var lineMat = new Material(lineSh);
+        lineMat.SetColor("_SegColor", Color.white);
+
+        for (int c = 0; c <= COLS; c++)
+        {
+            float x = OriginX + c * CELL_SIZE;
+            AddLine(tmp, lineMat, new Vector3(x, 0.02f, OriginZ),
+                    new Vector3(x, 0.02f, OriginZ + ROWS * CELL_SIZE), 0.10f);
+        }
+        for (int r = 0; r <= ROWS; r++)
+        {
+            float z = OriginZ + r * CELL_SIZE;
+            AddLine(tmp, lineMat, new Vector3(OriginX, 0.02f, z),
+                    new Vector3(OriginX + COLS * CELL_SIZE, 0.02f, z), 0.10f);
+        }
+        foreach (var p in Fx.props)
+        {
+            float hh = Band(p.band);
+            float x0 = OriginX + p.minC * CELL_SIZE, x1 = OriginX + (p.maxC + 1) * CELL_SIZE;
+            float z0 = OriginZ + p.minR * CELL_SIZE, z1 = OriginZ + (p.maxR + 1) * CELL_SIZE;
+            AddBoxEdges(tmp, lineMat, x0, x1, z0, z1, hh, 0.14f);
+        }
+        float wx0 = OriginX, wx1 = OriginX + COLS * CELL_SIZE;
+        float wz0 = OriginZ, wz1 = OriginZ + ROWS * CELL_SIZE;
+        float wh = TALL_H;
+        AddLine(tmp, lineMat, new Vector3(wx0, wh, wz0), new Vector3(wx1, wh, wz0), 0.18f);
+        AddLine(tmp, lineMat, new Vector3(wx0, 0, wz0), new Vector3(wx0, wh, wz0), 0.18f);
+        AddLine(tmp, lineMat, new Vector3(wx1, 0, wz0), new Vector3(wx1, wh, wz0), 0.18f);
+        AddLine(tmp, lineMat, new Vector3(wx0, wh, wz0), new Vector3(wx0, wh, wz1), 0.18f);
+        AddLine(tmp, lineMat, new Vector3(wx1, wh, wz0), new Vector3(wx1, wh, wz1), 0.18f);
+
+        var t1 = GameObject.Find("BlockoutRoot_" + Fx.sceneId) ?? GameObject.Find("TavernTier1");
+        var rends = t1 != null ? t1.GetComponentsInChildren<Renderer>(true) : new Renderer[0];
+        var prev = new Dictionary<Renderer, bool>();
+        foreach (var r in rends) { prev[r] = r.enabled; r.enabled = false; }
+        var intRoot = GameObject.Find("IntegrationRoot");
+        bool ip = false; if (intRoot != null) { ip = intRoot.activeSelf; intRoot.SetActive(false); }
+        var clRoot = GameObject.Find("ClosedLoopRoot");
+        bool cp = false; if (clRoot != null) { cp = clRoot.activeSelf; clRoot.SetActive(false); }
+
+        var rt = new RenderTexture(CAP_W, CAP_H, 24, RenderTextureFormat.ARGB32);
+        rt.Create();
+        var pT = cam.targetTexture; var pCF = cam.clearFlags; var pBG = cam.backgroundColor;
+        cam.clearFlags = CameraClearFlags.SolidColor;
+        cam.backgroundColor = Color.black;
+        cam.targetTexture = rt;
+        cam.Render();
+        SaveRT(rt, "Assets/painterly/cap_struct.png");
+
+        cam.targetTexture = pT; cam.clearFlags = pCF; cam.backgroundColor = pBG;
+        rt.Release();
+        foreach (var r in rends) r.enabled = prev[r];
+        if (intRoot != null) intRoot.SetActive(ip);
+        if (clRoot != null) clRoot.SetActive(cp);
+        Object.DestroyImmediate(tmp);
+        AssetDatabase.Refresh();
+        Debug.Log("[CL] Captured cap_struct.png (dimetric lattice + prop/wall edges) for canny.");
+    }
+
+    static void AddLine(GameObject parent, Material m, Vector3 a, Vector3 b, float w)
+    {
+        var go = new GameObject("ln");
+        go.transform.SetParent(parent.transform, false);
+        var lr = go.AddComponent<LineRenderer>();
+        lr.useWorldSpace = true;
+        lr.sharedMaterial = m;
+        lr.startWidth = w; lr.endWidth = w;
+        lr.positionCount = 2;
+        lr.SetPosition(0, a); lr.SetPosition(1, b);
+        lr.numCapVertices = 0;
+        lr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+    }
+
+    static void AddBoxEdges(GameObject parent, Material m, float x0, float x1, float z0, float z1, float h, float w)
+    {
+        AddLine(parent, m, new Vector3(x0, 0.03f, z0), new Vector3(x1, 0.03f, z0), w);
+        AddLine(parent, m, new Vector3(x1, 0.03f, z0), new Vector3(x1, 0.03f, z1), w);
+        AddLine(parent, m, new Vector3(x1, 0.03f, z1), new Vector3(x0, 0.03f, z1), w);
+        AddLine(parent, m, new Vector3(x0, 0.03f, z1), new Vector3(x0, 0.03f, z0), w);
+        AddLine(parent, m, new Vector3(x0, h, z0), new Vector3(x1, h, z0), w);
+        AddLine(parent, m, new Vector3(x1, h, z0), new Vector3(x1, h, z1), w);
+        AddLine(parent, m, new Vector3(x1, h, z1), new Vector3(x0, h, z1), w);
+        AddLine(parent, m, new Vector3(x0, h, z1), new Vector3(x0, h, z0), w);
+        AddLine(parent, m, new Vector3(x0, 0.03f, z0), new Vector3(x0, h, z0), w);
+        AddLine(parent, m, new Vector3(x1, 0.03f, z0), new Vector3(x1, h, z0), w);
+        AddLine(parent, m, new Vector3(x1, 0.03f, z1), new Vector3(x1, h, z1), w);
+        AddLine(parent, m, new Vector3(x0, 0.03f, z1), new Vector3(x0, h, z1), w);
+    }
+
+    static string CatOf(Renderer r)
+    {
+        var t = r.transform;
+        while (t != null)
+        {
+            string n = t.name.ToLower();
+            if (n.Contains("backdrop")) return "back";
+            if (n.Contains("floor")) return "floor";
+            if (n.Contains("wall")) return "wall";
+            if (n.Contains("prop")) return "prop";
+            if (n.Contains("hero") || n.Contains("monster") || n.Contains("party") ||
+                n.Contains("foe") || n.Contains("actor")) return "actor";
+            t = t.parent;
+        }
+        return "floor";
+    }
+
+    static void ApplyCategoryMaterials(Renderer[] rends, Material f, Material w, Material p, Material a)
+    {
+        foreach (var r in rends)
+        {
+            string c = CatOf(r);
+            if (c == "back") { r.enabled = false; continue; }
+            r.enabled = true;
+            Material m = c == "wall" ? w : c == "prop" ? p : c == "actor" ? a : f;
+            var arr = new Material[r.sharedMaterials.Length];
+            for (int i = 0; i < arr.Length; i++) arr[i] = m;
+            r.sharedMaterials = arr;
+        }
+    }
+
+    static void ApplyUniformMaterial(Renderer[] rends, Material m)
+    {
+        foreach (var r in rends)
+        {
+            if (CatOf(r) == "back") { r.enabled = false; continue; }
+            r.enabled = true;
+            var arr = new Material[r.sharedMaterials.Length];
+            for (int i = 0; i < arr.Length; i++) arr[i] = m;
+            r.sharedMaterials = arr;
+        }
+    }
+
+    static void SaveRT(RenderTexture rt, string path)
+    {
+        var prev = RenderTexture.active;
+        RenderTexture.active = rt;
+        var tex = new Texture2D(rt.width, rt.height, TextureFormat.RGB24, false);
+        tex.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
+        tex.Apply();
+        File.WriteAllBytes(path, tex.EncodeToPNG());
+        RenderTexture.active = prev;
+        Object.DestroyImmediate(tex);
+    }
+
+    // ==================================================================
+    // STEP 5-6 — assemble the final closed-loop frame (fixture-driven)
+    // ==================================================================
+    [MenuItem("Tools/WorldOS/CL/2 Assemble Final Frame")]
+    public static void AssembleFinal()
+    {
+        var cam = LockCamera();
+
+        var oldRoot = GameObject.Find("ClosedLoopRoot");
+        if (oldRoot != null) Object.DestroyImmediate(oldRoot);
+        var legacy = GameObject.Find("IntegrationRoot");
+        if (legacy != null) legacy.SetActive(false);
+
+        var root = new GameObject("ClosedLoopRoot");
+
+        // Hide both the legacy TavernTier1 blockout and any fixture-parameterized blockout root.
+        foreach (string bname in new[] { "TavernTier1", "BlockoutRoot_" + Fx.sceneId })
+        {
+            var bt = GameObject.Find(bname);
+            if (bt != null)
+                foreach (var r in bt.GetComponentsInChildren<Renderer>(true))
+                    r.enabled = false;
+        }
+
+        BuildCameraLockedPlate(root, cam);
+        BuildOccluderProxies(root);
+        SetupLighting(); // lights BEFORE actors so the relit material samples them
+        PlaceActors(root);
+
+        EditorUtility.SetDirty(root);
+        UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(
+            UnityEngine.SceneManagement.SceneManager.GetActiveScene());
+        Debug.Log("[CL] Final frame assembled — camera-locked plate + occluders + scene-lit actors.");
+    }
+
+    // ---- camera-locked full-frame plate ----
+    static void BuildCameraLockedPlate(GameObject root, Camera cam)
+    {
+        // Load the scene-specific plate (e.g. dungeon_plate_cl.png), fallback to tavern, then cap_seg.
+        string sceneId = Fx.sceneId.Replace("world-multiscene:", "").Replace(":", "_");
+        Texture2D tex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/" + sceneId + "_plate_cl.png");
+        if (tex == null) tex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/tavern_plate_cl.png");
+        if (tex == null) tex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/cap_seg.png");
+
+        // LEVER 2 — paint the plate with the SAME painterly recipe as the actors (kuwahara flatten +
+        // soft value-posterize + matched directional brush-grain + palette-snap) so the floor and the
+        // figures read as ONE painting, not "posterized actors on a flat photo floor". Falls back to
+        // the flat BackdropUnlit if the painterly shader fails to compile.
+        var sh = Shader.Find("WorldOS/PainterlyBackdrop");
+        bool painterlyPlate = (sh != null && sh.isSupported);
+        if (!painterlyPlate) { sh = Shader.Find("WorldOS/BackdropUnlit"); Debug.LogWarning("[CL] PainterlyBackdrop unavailable; flat plate fallback."); }
+        var mat = new Material(sh);
+        if (tex != null) mat.mainTexture = tex;
+        if (painterlyPlate)
+        {
+            // Matched to PainterlyActor's plate-side numbers but LOWER strength (the plate already has
+            // Scenario paint DNA — we add brush tooth + value masses, not a full repaint).
+            // R5 L6 CRITICAL: kuwahara 1.4 still read as "plastic mush, no brush hierarchy" -> drop to 0.9
+            // (stop the blob-melt, keep crisp form edges); the directional grain carries the stroke read.
+            mat.SetFloat("_Kuwahara",       0.9f);
+            mat.SetFloat("_Posterize",      14.0f);  // R5 L6: more planes so a MID value tier survives (masses)
+            mat.SetFloat("_PosterStrength", 0.32f);  // R5 L6: lighter mix so mids aren't collapsed
+            mat.SetFloat("_BrushStrength",  0.18f);  // R5 L6: a bit more directional stroke read
+            mat.SetFloat("_BrushScale",     52.0f);
+            mat.SetFloat("_PaletteSnap",    0.14f);
+            mat.SetFloat("_Contrast",       1.08f);
+            mat.SetFloat("_Saturation",     1.08f);
+            // R5 L5/L6 TONAL REPAIR (stronger cool counterpoint + broader floor lift):
+            mat.SetFloat("_Exposure",       1.40f);  // keep the playable floor; -0.02 to ease the blown center
+            mat.SetFloat("_ShadowLift",     0.075f); // R5 L5: lift the PERIMETER void more (was crushed at edges)
+            mat.SetColor("_ShadowTint",     new Color(0.22f, 0.34f, 0.46f, 1f)); // R5 L6: real desaturated TEAL/SLATE (was near-neutral)
+            mat.SetFloat("_ShadowTintAmt",  0.78f);  // R5 L6 CRITICAL: much stronger cool to BREAK the monochrome amber
+        }
+        mat.renderQueue = 900;
+        AssetDatabase.DeleteAsset("Assets/BackdropMat_CL.mat");
+        AssetDatabase.CreateAsset(mat, "Assets/BackdropMat_CL.mat");
+
+        var plate = GameObject.CreatePrimitive(PrimitiveType.Quad);
+        plate.name = "Plate_CL";
+        Object.DestroyImmediate(plate.GetComponent<Collider>());
+        plate.transform.SetParent(root.transform, false);
+        var rend = plate.GetComponent<Renderer>();
+        rend.sharedMaterial = mat;
+        rend.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        rend.receiveShadows = false;
+
+        // CAMERA-LOCKED: parent to camera, size to exactly fill the ortho frustum.
+        plate.transform.SetParent(cam.transform, false);
+        float dist = 80f;
+        float h = 2f * cam.orthographicSize;
+        float w = h * cam.aspect;
+        plate.transform.localPosition = new Vector3(0f, 0f, dist);
+        plate.transform.localScale = new Vector3(w, h, 1f);
+        plate.transform.localRotation = Quaternion.Euler(0f, 180f, 0f); // textured face -> camera
+        mat.mainTextureScale = new Vector2(-1f, 1f);
+        mat.mainTextureOffset = new Vector2(1f, 0f);
+
+        Debug.Log("[CL] Camera-locked plate: " + (tex != null ? tex.name : "NONE") +
+                  " size=(" + w.ToString("F1") + "," + h.ToString("F1") + ") dist=" + dist);
+    }
+
+    // ---- invisible depth-only occluder proxies (fixture props) ----
+    static void BuildOccluderProxies(GameObject root)
+    {
+        var sh = Shader.Find("WorldOS/OccluderDepthOnly");
+        Material mat;
+        if (sh != null && sh.isSupported)
+        {
+            mat = new Material(sh);
+            mat.renderQueue = 1999;
+            Debug.Log("[CL] Occluders: depth-only shader OK.");
+        }
+        else
+        {
+            mat = new Material(Shader.Find("Standard"));
+            mat.color = new Color(0.05f, 0.04f, 0.03f, 1f);
+            mat.renderQueue = 1999;
+            Debug.LogWarning("[CL] Occluders: depth-only shader unavailable; visible boxes.");
+        }
+        AssetDatabase.DeleteAsset("Assets/OccluderMat.mat");
+        AssetDatabase.CreateAsset(mat, "Assets/OccluderMat.mat");
+
+        var parent = new GameObject("OccluderProxies");
+        parent.transform.SetParent(root.transform, false);
+        foreach (var p in Fx.props)
+        {
+            if (!p.occluder) continue;
+            float hh = Band(p.band);
+            float spanX = (p.maxC - p.minC + 1) * CELL_SIZE * 0.92f;
+            float spanZ = (p.maxR - p.minR + 1) * CELL_SIZE * 0.92f;
+            float cx = PropCenterX(p);
+            float cz = PropCenterZ(p);
+            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            go.name = "Occluder_" + p.id;
+            go.transform.SetParent(parent.transform, false);
+            go.transform.localPosition = new Vector3(cx, hh * 0.5f, cz);
+            go.transform.localScale = new Vector3(spanX, hh, spanZ);
+            var r = go.GetComponent<Renderer>();
+            r.sharedMaterial = mat;
+            r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            r.receiveShadows = false;
+            Object.DestroyImmediate(go.GetComponent<BoxCollider>());
+        }
+        Debug.Log("[CL] Built occluder proxies (" + Fx.props.Count + " props).");
+    }
+
+    // ---- ARM SELECTOR — 1B (live 3D rigged actors) vs 1A (painterly sprite billboards) ----
+    // Set via EditorPrefs "CL.Arm" ("1B" default | "1A"); the bake-off drives this.
+    public static string Arm { get { return EditorPrefs.GetString("CL.Arm", "1B"); } set { EditorPrefs.SetString("CL.Arm", value); } }
+
+    // R3 LEVER 1 — use the chars_v3 hi-tier Meshy mesh (default ON). Toggle for A/B vs chars_v2.
+    public static bool UseV3 { get { return EditorPrefs.GetBool("CL.UseV3", true); } set { EditorPrefs.SetBool("CL.UseV3", value); } }
+    [MenuItem("Tools/WorldOS/CL/Use chars_v3 (hi-tier mesh) ON")]
+    public static void SetV3On() { UseV3 = true; Debug.Log("[CL] UseV3 = true (chars_v3 hi-tier)"); }
+    [MenuItem("Tools/WorldOS/CL/Use chars_v2 (legacy mesh) OFF")]
+    public static void SetV3Off() { UseV3 = false; Debug.Log("[CL] UseV3 = false (chars_v2 legacy)"); }
+
+    // sidecar accumulator (per-actor measured boxes for the pre-gate G2/G3/G4)
+    static List<Dictionary<string, object>> _sidecar;
+
+    // ---- actors (fixture spawns) ----
+    static void PlaceActors(GameObject root)
+    {
+        var parent = new GameObject("Actors");
+        parent.transform.SetParent(root.transform, false);
+        _sidecar = new List<Dictionary<string, object>>();
+
+        int[] heroCell = Fx.party.Count > 0 ? Fx.party[0] : new[] { 6, 8 };
+        int[] foeCell  = Fx.foes.Count  > 0 ? Fx.foes[0]  : new[] { 6, 2 };
+
+        if (Arm == "1A")
+        {
+            // ARM 1A — painterly stylized billboards (3D->sprite). Sprites at:
+            //   Assets/painterly/sprites/<id>_idle.png  (Scenario-stylized, transparent bg)
+            PlaceSpriteActor(parent, "HeroFighter", "Assets/painterly/sprites/hero_idle.png",
+                             heroCell[0], heroCell[1], true);
+            PlaceSpriteActor(parent, "MonsterGoblin", "Assets/painterly/sprites/goblin_idle.png",
+                             foeCell[0], foeCell[1], false);
+        }
+        else
+        {
+            // ARM 1B — live rigged 3D, posed to Idle, scene-lit with PainterlyActor.
+            // R3 LEVER 1: swap to chars_v3 (Meshy hi-tier: meshy-6, 4K hd_texture, remove_lighting,
+            // 140K remeshed mesh). The mesh source is idle.fbx (has mesh + Idle clip); Walk/Attack live
+            // in sibling FBXs (folder-wide clip search). 4K base_color is the actor albedo.
+            // v3b = same hi-tier geometry/UVs but BAKED-LIGHTING 4K texture (remove_lighting:False) so
+            // the albedo carries form for the relight to read. The rig is on the v3 mesh (same preview
+            // UVs => the v3b texture maps correctly onto the v3 rigged FBX).
+            string heroFbx = UseV3 ? "Assets/chars_v3/hero/glb/idle.fbx"   : "Assets/chars_v2/hero/hero.fbx";
+            string heroTex = UseV3 ? "Assets/chars_v3b/hero/tex0_base_color.png" : "Assets/chars_v2/hero/albedo.png";
+            string gobFbx  = UseV3 ? "Assets/chars_v3/goblin/glb/idle.fbx" : "Assets/chars_v2/goblin/goblin.fbx";
+            string gobTex  = UseV3 ? "Assets/chars_v3b/goblin/tex0_base_color.png" : "Assets/chars_v2/goblin/albedo.png";
+            PlaceActor(parent, "HeroFighter", heroFbx, heroTex, heroCell[0], heroCell[1], true);
+            PlaceActor(parent, "MonsterGoblin", gobFbx, gobTex, foeCell[0], foeCell[1], false);
+        }
+
+        WriteSidecar();
+    }
+
+    // ---- project a world point through the LOCKED camera to pixel coords (top-left origin,
+    // +y DOWN), at the sidecar's CAP_W x CAP_H resolution. Mirror of visual_pregate.CameraSpec. ----
+    static float[] WorldToScreenPx(Vector3 w)
+    {
+        var cam = LockCamera();
+        // Unity viewport: (0,0) bottom-left .. (1,1) top-left; z = world dist.
+        Vector3 vp = cam.WorldToViewportPoint(w);
+        float sx = vp.x * CAP_W;
+        float sy = (1f - vp.y) * CAP_H;   // flip to top-left origin (image convention)
+        return new[] { sx, sy };
+    }
+
+    static void RecordActor(string id, int c, int r, Bounds worldBounds)
+    {
+        // feet = bottom-center of the world bounds; head = top-center.
+        Vector3 feetW = new Vector3(worldBounds.center.x, worldBounds.min.y, worldBounds.center.z);
+        Vector3 headW = new Vector3(worldBounds.center.x, worldBounds.max.y, worldBounds.center.z);
+        var feetPx = WorldToScreenPx(feetW);
+        var headPx = WorldToScreenPx(headW);
+        float pxH = Mathf.Abs(feetPx[1] - headPx[1]);
+        var d = new Dictionary<string, object>();
+        d["id"] = id;
+        d["cell"] = new object[] { c, r };
+        d["feet_px"] = new object[] { Mathf.Round(feetPx[0]), Mathf.Round(feetPx[1]) };
+        d["head_px"] = new object[] { Mathf.Round(headPx[0]), Mathf.Round(headPx[1]) };
+        d["px_height"] = Mathf.Round(pxH);
+        d["world_height_ft"] = worldBounds.size.y;
+        if (_sidecar != null) _sidecar.Add(d);
+        Debug.Log("[CL] sidecar " + id + " cell[" + c + "," + r + "] feet_px(" +
+                  feetPx[0].ToString("F0") + "," + feetPx[1].ToString("F0") + ") px_h=" + pxH.ToString("F0"));
+    }
+
+    static void WriteSidecar()
+    {
+        if (_sidecar == null) return;
+        var sb = new System.Text.StringBuilder();
+        sb.Append("[\n");
+        for (int i = 0; i < _sidecar.Count; i++)
+        {
+            var d = _sidecar[i];
+            var cell = (object[])d["cell"];
+            var fp = (object[])d["feet_px"];
+            var hp = (object[])d["head_px"];
+            sb.Append("  {\"id\":\"" + d["id"] + "\",\"cell\":[" + cell[0] + "," + cell[1] + "],");
+            sb.Append("\"feet_px\":[" + fp[0] + "," + fp[1] + "],");
+            sb.Append("\"head_px\":[" + hp[0] + "," + hp[1] + "],");
+            sb.Append("\"px_height\":" + d["px_height"] + ",");
+            sb.Append("\"world_height_ft\":" + ((float)d["world_height_ft"]).ToString("F2") + "}");
+            sb.Append(i < _sidecar.Count - 1 ? ",\n" : "\n");
+        }
+        sb.Append("]\n");
+        string outPath = "Assets/painterly/final_cl.actors.json";
+        File.WriteAllText(outPath, sb.ToString());
+        AssetDatabase.Refresh();
+        Debug.Log("[CL] Wrote actor sidecar -> " + outPath + " (" + _sidecar.Count + " actors)");
+    }
+
+    // ---- ARM 1A: painterly stylized billboard (sprite quad) at a spawn cell ----
+    static void PlaceSpriteActor(GameObject parent, string label, string spritePath, int c, int r, bool isHero)
+    {
+        var tex = AssetDatabase.LoadAssetAtPath<Texture2D>(spritePath);
+        if (tex == null) { Debug.LogError("[CL] sprite not found: " + spritePath); return; }
+
+        var go = GameObject.CreatePrimitive(PrimitiveType.Quad);
+        go.name = label;
+        Object.DestroyImmediate(go.GetComponent<Collider>());
+        go.transform.SetParent(parent.transform, false);
+
+        // species height in world units (hero ~5.2u; goblin shorter). Quad sized to the
+        // sprite aspect so the painted figure isn't squashed.
+        float speciesH = isHero ? ACTOR_TARGET_H : ACTOR_TARGET_H * 0.78f;
+        float aspect = tex.height > 0 ? (float)tex.width / tex.height : 0.5f;
+        float worldH = speciesH;
+        float worldW = worldH * aspect;
+
+        // WORLD-VERTICAL billboard tilted to FACE the dimetric camera (pitch back so the flat
+        // sprite is perpendicular to the camera ray, not lying toward the floor). The quad's
+        // textured face normal is -Z (Unity Quad), so to face the camera (which looks +Z, pitched
+        // down) we point the quad's normal back along the camera ray: rotate +pitch about X so the
+        // sprite leans toward the camera and the feet (texture v=0, bottom edge) sit on the floor.
+        // WORLD-VERTICAL camera-facing billboard (standard iso-CRPG sprite). Quad textured face
+        // normal is -Z; yaw 180 turns it to face the camera (which looks +Z). NO pitch tilt, so the
+        // bottom edge (feet, texture v=0) plants flat on the floor cell and projects to exactly the
+        // floor point — no float. The dimetric camera naturally foreshortens it.
+        go.transform.localEulerAngles = new Vector3(0f, 180f, 0f);
+        go.transform.localScale = new Vector3(worldW, worldH, 1f);
+
+        float wx = CellX(c);
+        float wz = CellZ(r);
+        go.transform.position = new Vector3(wx, worldH * 0.5f, wz); // center; bottom edge -> y=0
+        var preBounds = Bounds(go);
+        if (Mathf.Abs(preBounds.min.y) > 0.02f)
+            go.transform.position += new Vector3(0f, -preBounds.min.y, 0f); // plant feet exactly on y=0
+
+        // ALPHA-BLENDED unlit billboard (the sprite is pre-lit by Scenario). WorldOS/SpriteBillboard
+        // honors the PNG alpha + applies a SUBTLE scene-key/ambient tint + depth exposure so it sits
+        // in the room's light without double-lighting.
+        float depth01b = Mathf.InverseLerp(0f, ROWS - 1, r);  // 0 back .. 1 front
+        var sh = Shader.Find("WorldOS/SpriteBillboard");
+        Material mat;
+        if (sh != null && sh.isSupported)
+        {
+            mat = new Material(sh);
+            mat.SetTexture("_MainTex", tex);
+            mat.SetColor("_KeyColor", Fx.keyColor);
+            mat.SetColor("_AmbientColor", Fx.ambientColor);
+            mat.SetFloat("_KeyTint", 0.18f);
+            mat.SetFloat("_AmbientTint", Mathf.Lerp(0.16f, 0.06f, depth01b)); // back cooler
+            mat.SetFloat("_Exposure", Mathf.Lerp(0.78f, 1.08f, depth01b));    // front brighter focal
+            mat.SetFloat("_Desat", Mathf.Lerp(0.22f, 0.04f, depth01b));        // back hazier
+            mat.SetFloat("_Cutoff", 0.35f);
+        }
+        else { mat = new Material(Shader.Find("Sprites/Default")); mat.SetTexture("_MainTex", tex); }
+        mat.renderQueue = 2100;
+        var rend = go.GetComponent<Renderer>();
+        rend.sharedMaterial = mat;
+        rend.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        rend.receiveShadows = false;
+
+        float depth01 = Mathf.InverseLerp(0f, ROWS - 1, r);
+        var sb2 = Bounds(go);
+        BuildContactShadow(parent, label + "_Shadow", c, r, sb2, isHero, depth01);
+        RecordActor(label, c, r, sb2);
+        Debug.Log("[CL] Placed SPRITE " + label + " @(" + c + "," + r + ") worldH=" + worldH.ToString("F1"));
+    }
+
+    static void PlaceActor(GameObject parent, string label, string path, string albedoPath,
+                           int c, int r, bool isHero)
+    {
+        var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+        if (prefab == null) { Debug.LogError("[CL] FBX not found: " + path); return; }
+        // WRAPPER controls placement + scale + FACING. The FBX is a child so that
+        // PoseToClip's SampleAnimation (which bakes the Idle clip's ROOT rotation onto the FBX
+        // root, clobbering any yaw we set on it) does NOT override our facing — the wrapper yaw
+        // is applied OUTSIDE the clip's root track. (R7c: this was the back-facing bug.)
+        var wrap = new GameObject(label);
+        wrap.transform.SetParent(parent.transform, false);
+        var go = (GameObject)PrefabUtility.InstantiatePrefab(prefab);
+        go.name = label + "_fbx";
+        go.transform.SetParent(wrap.transform, false);
+
+        // POSE the FBX into the Idle clip first (reads/clobbers its own root); facing is the wrapper's.
+        PoseToClip(go, path, "Idle", 0.4f);
+
+        // Face the actor TOWARD the game camera. Verified empirically below the clip bake:
+        // the model's FRONT ends up facing +Z after the Idle bake, and the camera (z=-55.5,
+        // looking +Z) sees the -Z side, so wrapper yaw 180 turns the FACE to the camera.
+        // Gentle 3/4 offset so the two figures angle at each other.
+        wrap.transform.localEulerAngles = new Vector3(0f, 180f + (isHero ? 18f : -18f), 0f);
+        wrap.transform.position = new Vector3(9999f, 0f, 9999f);
+
+        var b = Bounds(wrap);
+        float curH = b.size.y > 0.01f ? b.size.y : 2f;
+        // mild ortho depth-read scale: front-of-room actors a touch bigger so the eye
+        // reads depth even though the ortho camera keeps true size constant.
+        float depth01 = Mathf.InverseLerp(0f, ROWS - 1, r);          // 0 back .. 1 front
+        float depthScale = Mathf.Lerp(0.88f, 1.05f, depth01);        // front (depth01->1) bigger
+        // species height: a goblin is shorter than a human fighter. Hero -> ACTOR_TARGET_H, goblin 0.78x.
+        // GRAPHICS-FORK R6 (L5 critic): the goblin read too SMALL/hard-to-find (the #1 residual). Bump it
+        // ~1.2x (0.78 -> 0.94) so its silhouette is large enough to separate from the prop mass.
+        float speciesH = isHero ? ACTOR_TARGET_H : ACTOR_TARGET_H * 0.94f;
+        float mult = (speciesH / curH) * depthScale;
+        var es = wrap.transform.localScale;
+        wrap.transform.localScale = new Vector3(es.x * mult, es.y * mult, es.z * mult);
+
+        float wx = CellX(c);
+        float wz = CellZ(r);
+        var staging = Bounds(wrap);                            // bounds at the (9999) staging pos
+        float floorY = staging.min.y < -0.05f ? -staging.min.y : 0f; // feet -> floor plane (Y only)
+        wrap.transform.position = new Vector3(wx, floorY, wz);
+        var sb = Bounds(wrap);                                // RE-READ after final placement
+        // safety: plant feet exactly on y=0
+        if (Mathf.Abs(sb.min.y) > 0.02f)
+        {
+            wrap.transform.position += new Vector3(0f, -sb.min.y, 0f);
+            sb = Bounds(wrap);
+        }
+
+        // TEXTURED + SCENE-LIT painterly material. Back-of-room actors are exposed
+        // LOWER so they recede into the dark mid-plane (R3 L3: goblin was too hot for
+        // its depth); the front hero gets a brighter key so it reads as the focal token.
+        ApplyActorMaterial(go, albedoPath, isHero, depth01);
+
+        BuildContactShadow(parent, label + "_Shadow", c, r, sb, isHero, depth01);
+        RecordActor(label, c, r, sb);   // sidecar (post-scale, post-place world bounds)
+        Debug.Log("[CL] Placed " + label + " at (" + c + "," + r + ") mult=" + mult.ToString("F2") +
+                  " floorY=" + floorY.ToString("F2") + " facing=" + wrap.transform.localEulerAngles.y.ToString("F0"));
+    }
+
+    // ---- pose a rigged FBX instance into one of its imported clips (edit-mode sampling) ----
+    static void PoseToClip(GameObject go, string fbxPath, string clipName, float time)
+    {
+        AnimationClip clip = FindClipInDir(fbxPath, clipName);
+        if (clip == null) { Debug.LogWarning("[CL] clip '" + clipName + "' not found near " + fbxPath + " (bind pose)."); return; }
+        // SampleAnimation poses the hierarchy at `time` without an Animator/play-mode.
+        clip.SampleAnimation(go, time);
+        Debug.Log("[CL] Posed " + go.name + " -> clip '" + clip.name + "' @ t=" + time + "s");
+    }
+
+    // Find an animation clip by name, first in the given FBX, then across sibling FBXs in the same
+    // folder (chars_v3 emits one FBX per clip: idle.fbx/walk.fbx/attack.fbx). Public so AnimProof reuses it.
+    public static AnimationClip FindClipInDir(string fbxPath, string clipName)
+    {
+        // 1) inside the given fbx (chars_v2 single multi-take fbx)
+        foreach (var o in AssetDatabase.LoadAllAssetsAtPath(fbxPath))
+        {
+            var cl = o as AnimationClip;
+            if (cl != null && !cl.name.StartsWith("__preview") && cl.name.Contains(clipName)) return cl;
+        }
+        // 2) sibling fbxs in the same folder (chars_v3 per-clip fbx)
+        string dir = System.IO.Path.GetDirectoryName(fbxPath).Replace('\\', '/');
+        foreach (var guid in AssetDatabase.FindAssets("t:AnimationClip", new[] { dir }))
+        {
+            string p = AssetDatabase.GUIDToAssetPath(guid);
+            foreach (var o in AssetDatabase.LoadAllAssetsAtPath(p))
+            {
+                var cl = o as AnimationClip;
+                if (cl != null && !cl.name.StartsWith("__preview") && cl.name.Contains(clipName)) return cl;
+            }
+        }
+        return null;
+    }
+
+    static void ApplyActorMaterial(GameObject go, string albedoPath, bool isHero, float depth01)
+    {
+        var tex = AssetDatabase.LoadAssetAtPath<Texture2D>(albedoPath);
+        if (tex == null) Debug.LogWarning("[CL] albedo not found: " + albedoPath + " (will look flat).");
+        var sh = Shader.Find("WorldOS/PainterlyActor");
+        Material fmat;
+        if (sh != null && sh.isSupported)
+        {
+            fmat = new Material(sh);
+            if (tex != null) fmat.SetTexture("_MainTex", tex);
+            fmat.SetColor("_BaseColor", Color.white);
+            fmat.SetColor("_KeyColor", Fx.keyColor);
+            fmat.SetColor("_AmbientColor", Fx.ambientColor);
+            // GRAPHICS-FORK R4b (2026-06-23): ★ the plate display is DETERMINISTIC = un-mirrored (the 180°
+            // quad rotation + mainTextureScale=(-1,1) cancel). Verified over 3 re-assembles: the active plate
+            // (gen_dim_r3/controlnet_1, raw hearth LEFT) DISPLAYS hearth LEFT consistently (R-B warmth left-third
+            // 53 vs right -4). (The one hearth-RIGHT frame earlier was a transient stale-material read before the
+            // reimport settled — ignore it.) So the warm KEY comes from screen-LEFT (-X) to face the displayed
+            // fire. RECIPE: after any plate swap, render once it has SETTLED, measure displayed warmth L-vs-R,
+            // set _KeyDir.x sign to match (negative=hearth-left, positive=hearth-right).
+            // GRAPHICS-FORK R6/R7 (2026-06-23): the new depth-controlnet plate (gen_dim_r6/depth_2, raw hearth
+            // on the LEFT) DISPLAYS hearth-LEFT once the texture import SETTLES — because the camera-locked
+            // U-flip (180deg quad + mainTextureScale=(-1,1)) cancels, same as the r3 plate. A transient
+            // PRE-settle read showed hearth-RIGHT and I briefly flipped _KeyDir.x +0.92; the SETTLED frame
+            // measured L-third R-B +118 vs R-third -15 => hearth-LEFT. So _KeyDir.x stays NEGATIVE (warm key
+            // from screen-LEFT, facing the fire). ★ LESSON: render -> let import SETTLE -> measure L-vs-R
+            // -> THEN set _KeyDir.x sign. Never trust the first post-swap read.
+            Vector3 keyDir = new Vector3(-0.92f, 0.22f, 0.10f).normalized;
+            fmat.SetVector("_KeyDir", keyDir);
+            // R10/r6: the NEW plate's forge is genuinely the brightest source (p99~215 vs hero ~125),
+            // so there's headroom to lift the hero key for focal readability without out-glowing it.
+            float key = isHero ? Mathf.Lerp(1.35f, 1.55f, depth01) : 1.2f;
+            fmat.SetFloat("_KeyStrength", key);
+            fmat.SetFloat("_RimStrength", isHero ? 0.16f : 0.20f);  // r3: rim hotspot on head/shoulders was the last "lantern" tell — cut hard
+            fmat.SetFloat("_Desat", isHero ? 0.24f : 0.36f);        // match the muted plate; goblin hazier (depth)
+            // warm floor bounce on the lower body (L4: actors stand between fires, legs should warm).
+            fmat.SetFloat("_BounceStrength", Mathf.Lerp(0.10f, 0.22f, depth01));
+            // ---- v2 HYBRID real-time painterly pass (the L4 maquette-ceiling breaker) ----
+            // Kuwahara flattens CG micro-detail; posterize -> brushy value steps; brush-grain ->
+            // visible strokes; edge-feather dissolves the razor silhouette; palette-snap pulls sat
+            // into the plate range; ambient-lift keeps the shadow side a matte painted value (not
+            // 3D black). Goblin gets a hazier/softer treatment (depth) per L4 depth-desaturation.
+            // r9 L4: small kuwahara fragmented the figure into "same-value pebbles" + grain on the SMALL
+            // goblin "amplified noise" (disintegrated it). Fix: BIGGER kuwahara (merge into 3-4 BROAD
+            // value masses), FEWER posterize levels, and a screen-SIZE LOD — the goblin (far/small) gets
+            // a much bigger kuwahara + near-ZERO grain so it stays a SOLID simplified shape, not noise.
+            // r10 L4: the 6.5/9 kuwahara + 4-plane RGB posterize made a "mosaic checker"; with the new
+            // value-only soft-posterize, a MODERATE kuwahara + a touch more planes reads as smooth broad
+            // masses. Goblin: bigger kuwahara + grain OFF so it stays a solid simplified shape.
+            fmat.SetFloat("_Kuwahara",      isHero ? 4.0f : 5.5f);
+            fmat.SetFloat("_Posterize",     isHero ? 5.0f : 4.0f);   // soft-posterize => a couple more planes is fine now
+            fmat.SetFloat("_BrushStrength", isHero ? 0.22f : 0.04f); // goblin grain ~off
+            fmat.SetFloat("_BrushScale",    isHero ? 15.0f : 11.0f);
+            fmat.SetFloat("_EdgeSoften",    isHero ? 0.22f : 0.30f); // r3: wide feather let the plate's warm floor-pool bleed THROUGH the silhouette as a false halo; keep edges mostly opaque with a thin feather
+            fmat.SetFloat("_PaletteSnap",   isHero ? 0.42f : 0.55f); // pull actor sat INTO the plate range (L4)
+            fmat.SetFloat("_PaintLift",     0.06f);
+            fmat.SetFloat("_AmbientLift",   isHero ? 0.16f : 0.20f); // no pure-black mass; matte the shadow plane
+            // r2 CONSENSUS CRITICAL: clamp actor luma below the hearth (actor must not be brightest in frame).
+            fmat.SetFloat("_MaxLuma",       isHero ? 0.78f : 0.56f); // r6: new plate's forge p99~0.84 gives headroom; lift hero for focal read, still below forge
+            fmat.SetFloat("_TermSharp",     isHero ? 0.30f : 0.30f); // r10 L3: hard seam read as a 2-tone mask; SOFTEN the wrap
+            // ATMOSPHERIC DEPTH WASH (R2 L4 CRITICAL): the back goblin held full foreground sat/contrast
+            // = the #1 "pasted sprite" tell. Drive _AtmDepth by row depth: front hero ~0 (untouched),
+            // back goblin washes toward the ambient. depth01: 0 back .. 1 front -> wash = (1-depth01).
+            float atm = Mathf.Clamp01((1f - depth01) * 0.85f);   // back actors get up to ~0.85 wash
+            fmat.SetFloat("_AtmDepth", isHero ? atm * 0.35f : atm);   // hero barely washed; goblin fully
+            fmat.SetColor("_AtmColor", Fx.ambientColor * 1.4f);      // the room's cool ambient fog
+
+            // R3 LEVER 1 — hi-tier (v3) re-tune: the 4K meshy-6 albedo is DARKER (mean ~0.20 vs v2 0.27)
+            // and carries FINE detail. The v2-tuned posterize/palette-snap/MaxLuma under-exposed it to mud
+            // (A/B crop proved it). For v3: (a) LIFT exposure/key + raise MaxLuma so the detail reads,
+            // (b) SOFTEN posterize + palette-snap + kuwahara so the 4K detail isn't smeared into flat
+            // masses, (c) crush specular harder. Keeps the painterly family but lets the hi-tier detail show.
+            if (UseV3)
+            {
+                // R5 L3 dual-CRITICAL: the hero was under-lit + face-dark, RECEDING against the lit floor.
+                // Push the key HARD so mid-body luma lands ~0.30-0.38 (clearly above the 0.207 floor) and
+                // the head/face catches warm light; keep MaxLuma below the forge so it doesn't out-glow.
+                // R4 L4 (hero_value_too_hot_vs_plate): the hero was the brightest object after the fire —
+                // pull the key DOWN ~25% and cap MaxLuma lower so the actor sits INSIDE the plate's value
+                // envelope, not studio-lit above it. Still clearly above the lit floor for focal read.
+                // GRAPHICS-FORK R5 (L4 value-compress): the hero was still a HIGH-KEY ISLAND on a mid-dark
+                // floor (the contrast cliff, not the geometric edge, popped him out as a cutout). Compress his
+                // dynamic range INTO the local plate envelope: drop the key further, cap MaxLuma to ~0.68 (no
+                // out-glowing the floor), and LIFT the shadow floor (AmbientLift up + PaintLift up) so the
+                // hero's darkest value >= the local floor value. Keep a clear terminator (chiaroscuro on the
+                // form) but within a compressed range.
+                fmat.SetFloat("_KeyStrength", isHero ? Mathf.Lerp(1.30f, 1.50f, depth01) : 1.6f);
+                fmat.SetFloat("_MaxLuma",     isHero ? 0.68f : 0.58f);  // R5: clamp below the floor highlights so no high-key island
+                fmat.SetFloat("_PaintLift",   0.18f);                   // R5: lift the darkest hero value off black into the floor band
+                fmat.SetFloat("_AmbientLift", isHero ? 0.40f : 0.34f);  // R5: hero shadow side >= local floor value (kill the contrast cliff)
+                fmat.SetFloat("_TermSharp",   0.40f);                   // R5 L3: a clear warm-to-cool terminator across the form
+                // R5 L4 CRITICAL: the actor painterly post was NOT engaging (hero read photoreal-baked while
+                // the plate was stylized => the #1 paste-on tell). RESTORE a real painterly treatment so the
+                // hero shares the plate's brush vocabulary — but balanced to keep the hi-tier detail:
+                // GRAPHICS-FORK R3 (L4 CRITICAL hero_specular_plastic + hero_edge_too_crisp): push the
+                // painterly flatten HARDER so the actor's brush vocabulary matches the loose oil plate.
+                // This custom shader has NO specular term — the "plastic 3D" read is smooth gradients +
+                // razor edges, killed by bigger kuwahara (broad value masses), fewer posterize planes
+                // (painted value steps), a WIDER edge feather (fray the silhouette like the backdrop),
+                // and a stronger palette-snap + desat (pull into the plate palette).
+                // GRAPHICS-FORK R4 (L4 panel-corrected): the R3 posterize REDUCTION backfired (fewer planes
+                // left smooth interpolated gradients between them = plastic read). The L4 specialist's exact
+                // levers: (a) MORE posterize planes (~7) so values land in deliberate painted STEPS not a
+                // smooth gradient; (b) MUCH wider edge-feather (~0.60) to break the razor 3D silhouette (the
+                // #1 CRITICAL pasted-on tell); (c) keep kuwahara moderate; (d) strong palette-snap + graded desat.
+                fmat.SetFloat("_Kuwahara",    isHero ? 3.5f : 4.5f);    // moderate flatten -> broad masses
+                fmat.SetFloat("_Posterize",   isHero ? 7.0f : 6.0f);    // R4 REVERSE: MORE tight value steps kill the smooth gradient (painted planes)
+                fmat.SetFloat("_PaletteSnap", isHero ? 0.60f : 0.68f);  // pull actor sat INTO the scene palette (L4 mismatch)
+                fmat.SetFloat("_Desat",       isHero ? 0.32f : 0.50f);  // depth-graded: hero near 0.32, goblin far 0.50
+                fmat.SetFloat("_BrushStrength", isHero ? 0.40f : 0.14f);// R8 L4: a touch more visible stroke so the hero shares the floor's brush language (was 0.34, mild "plasticky" residual)
+                fmat.SetFloat("_BrushScale",  isHero ? 16.0f : 12.0f);
+                fmat.SetFloat("_EdgeSoften",  isHero ? 0.60f : 0.56f);  // R4 L4 CRITICAL: break the razor silhouette much harder (frayed painted edge)
+
+                // ============================================================================
+                // GRAPHICS-FORK R2 (2026-06-23) — actor LIGHTING/INTEGRATION cluster fix.
+                // Against the NEW dimetric+even-lit plate the panel (L2/L3/L4) said the actor still
+                // reads COOL-GREY pasted onto a WARM floor: (a) shadow side crushes to cold near-black
+                // (want warm-chromatic), (b) NO warm hearth RIM on the right silhouette, (c) palette
+                // divorced from the warm plate. These are all the shader-faked relight — fix here.
+                // ----------------------------------------------------------------------------
+                // (a) shadow side warm, not black: lift the ambient floor harder + warmer so the
+                //     left/shade side reads a painted warm-grey (firelit interior), never 3D-black.
+                fmat.SetFloat("_AmbientLift", isHero ? 0.42f : 0.40f);  // L3/L4: off pure black, warm-chromatic shade
+                // (b) HEARTH RIM: a warm kicker on the hearth-facing silhouette fuses the figure into the
+                //     lit room (every ref has it). The shader rims on the KEY-facing side, and _KeyDir is now
+                //     flipped to screen-LEFT (the hearth), so the rim now correctly lands on the LEFT edge.
+                fmat.SetFloat("_RimStrength", isHero ? 0.78f : 0.45f);  // R4 L3 HIGH: stronger warm hearth rim on the hearth-facing (left) silhouette (the "lit by the scene" cue)
+                // (c) warm floor bounce (L4 "palette divorced"): warm the lower body from the lit floor.
+                //     (PaletteSnap is set HARDER above in the R3 painterly cluster; don't weaken it here.)
+                fmat.SetFloat("_BounceStrength", Mathf.Lerp(0.24f, 0.42f, depth01)); // L4: warm floor bounce on legs
+                // (d) GRAPHICS-FORK R3 (L4 CRITICAL goblin_no_atmospheric_depth + L2 goblin_floating_cutout):
+                //     the far goblin sits in the COOL archway and must RECEDE — push the atmospheric wash much
+                //     harder toward the cool doorway ambient, desaturate + value-compress, drop the key, and
+                //     soften its edges more than the hero so it reads as a far body, not a saturated cutout.
+                if (!isHero)
+                {
+                    // GRAPHICS-FORK R6 (L5 critic CRITICAL — goblin value-camouflaged, "have to hunt for it"):
+                    // it was crushed so dark (MaxLuma 0.46, key 1.10) it merged into the dim props. LIFT its
+                    // value enough to read as a distinct COOL mass against the warm scene (the cool body vs warm
+                    // floor is itself the separation), and strengthen the silhouette rim so its edge catches a
+                    // cool counter-light. Still kept clearly below the hero + the hearth (focal hierarchy).
+                    // R8 (L5 critic: r7 goblin over-corrected to chalky/ghost): pull the midtone back ~15%
+                    // and re-introduce a COOL local skin hue so it reads as a creature-mass, not a pale prop.
+                    // Still readable (bigger now) + clearly below the hero/hearth.
+                    fmat.SetFloat("_KeyStrength", 1.20f);               // R8: was 1.32 (too hot/chalky) -> midground
+                    fmat.SetFloat("_MaxLuma",     0.52f);              // R8: was 0.60 -> pull the value down ~15% (off ghost-white)
+                    fmat.SetColor("_BaseColor",   new Color(0.74f, 0.82f, 0.90f, 1f)); // R8: cool blue-grey skin tint = creature hue, breaks the chalky read
+                    fmat.SetFloat("_Desat",       0.46f);             // R8: less desat so the cool hue actually reads as color, not grey
+                    fmat.SetFloat("_AtmDepth",    0.66f);             // R8: ease the wash a touch more so the form holds
+                    fmat.SetColor("_AtmColor",    new Color(0.32f, 0.44f, 0.60f, 1f) * 1.22f); // cool archway ambient (separation from warm scene)
+                    fmat.SetFloat("_AmbientLift", 0.34f);             // R8: lower slightly with the value pull-down
+                    fmat.SetFloat("_RimStrength", 0.80f);             // strong silhouette rim = the cool edge that pops it from the props
+                    fmat.SetFloat("_EdgeSoften",  0.46f);             // crisp enough that the bigger goblin holds a readable shape
+                    fmat.SetFloat("_TermSharp",   0.24f);             // firmer wrap -> internal value planes (creature form, not a flat blob)
+                }
+            }
+        }
+        else
+        {
+            fmat = new Material(Shader.Find("Standard"));
+            if (tex != null) fmat.mainTexture = tex;
+            fmat.SetFloat("_Glossiness", 0.12f);
+            fmat.SetFloat("_Metallic", 0f);
+            Debug.LogWarning("[CL] PainterlyActor shader unavailable; Standard fallback.");
+        }
+        foreach (var rend in go.GetComponentsInChildren<Renderer>())
+        {
+            var arr = new Material[rend.sharedMaterials.Length];
+            for (int i = 0; i < arr.Length; i++) arr[i] = fmat;
+            rend.sharedMaterials = arr;
+        }
+    }
+
+    static Bounds Bounds(GameObject go)
+    {
+        var rs = go.GetComponentsInChildren<Renderer>();
+        if (rs.Length == 0) return new Bounds(Vector3.zero, Vector3.one * 1.8f);
+        var b = rs[0].bounds;
+        for (int i = 1; i < rs.Length; i++) b.Encapsulate(rs[i].bounds);
+        return b;
+    }
+
+    // ---- soft elliptical contact shadow directly under feet (R1/R2/R3 L2 fix) ----
+    static void BuildContactShadow(GameObject parent, string name, int c, int r, Bounds actorBounds, bool isHero, float depth01)
+    {
+        var go = GameObject.CreatePrimitive(PrimitiveType.Quad);
+        go.name = name;
+        go.transform.SetParent(parent.transform, false);
+        Object.DestroyImmediate(go.GetComponent<Collider>());
+
+        // DIRECTIONAL CAST SHADOW (v2 L3/L2): the prior centered ellipse read as a detached radial
+        // "self-pool" under the actor (the L3 critic's loudest tell). A real shadow is cast AWAY from
+        // the hearth key. Compute the floor direction from the hearth (back-right) to the actor and
+        // EXTEND the shadow along it (elongated), anchored at the feet, so it reads as the body's own
+        // shadow thrown by the firelight rather than a glow pool the actor emits.
+        float ax = CellX(c), az = CellZ(r);
+        // GRAPHICS-FORK R6/R7: the new depth_2 plate DISPLAYS hearth on screen-LEFT (settled) = world -X.
+        // The cast shadow is thrown AWAY from the hearth = toward screen-RIGHT (world +X). Anchor the hearth
+        // at a back-LEFT cell (col ~1.5) so `away = actor - hearth` points +X. (Matches _KeyDir.x negative.)
+        float hx = CellX(1.5f), hz = CellZ(1.0f);
+        Vector3 away = new Vector3(ax - hx, 0f, az - hz);
+        if (away.sqrMagnitude < 0.0001f) away = new Vector3(1f, 0f, 0.3f);
+        away.Normalize();
+        float footX = Mathf.Clamp(actorBounds.size.x * 1.0f, 1.8f, 3.4f);
+        float castLen = footX * 1.7f;                       // shadow elongated along the cast axis
+        float footZ = footX * 0.55f;
+        // orient the ellipse so its long axis points along `away` (rotate the flat quad around Y)
+        float yaw = Mathf.Atan2(away.x, away.z) * Mathf.Rad2Deg;
+        go.transform.localScale = new Vector3(footZ * 1.05f, castLen, 1f);   // quad: x=width, y=length(pre-rot)
+        // anchor at the feet, shifted half the cast length DOWN the away axis so the shadow starts at
+        // the feet and stretches outward (not centered on the body).
+        // r9 L2: a big offset left a GAP of lit floor between the soles and the shadow (= floating). Pull
+        // the cast ellipse back so its NEAR end fuses with the feet (offset only ~0.18*len, and the AO
+        // below sits right at the soles to read as the dark contact core the cast grows out of).
+        Vector3 footPos = new Vector3(ax, 0.02f, az - 0.3f);
+        Vector3 shadowCenter = footPos + away * (castLen * 0.18f);
+        go.transform.localPosition = shadowCenter;
+        go.transform.localEulerAngles = new Vector3(90f, yaw, 0f); // flat on floor, long axis along `away`
+
+        // soft radial-gradient blob composited via WorldOS/ContactShadow (ZTest Always
+        // so it reliably darkens the camera-locked plate; queue 1000 = after the plate
+        // (900) but BEFORE the actors (2000) so the actor's feet draw ON TOP of it).
+        // R4 L2: a Sprites/Default quad measured ZERO darkening under the feet; this
+        // dedicated alpha-composite shader forces the contact shadow to actually land.
+        float alpha = Mathf.Lerp(0.82f, 0.72f, depth01); // firm contact, slightly softer than pure black
+        var tex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/soft_shadow.png");
+        var sh = Shader.Find("WorldOS/ContactShadow");
+        var mat = new Material(sh != null ? sh : Shader.Find("Sprites/Default"));
+        // r2 L2: warm-tinted shadow (not pure black) so it sits in the firelit ambient like a painted
+        // shadow, not a black decal. A deep warm-brown reads as firelight occlusion.
+        Color shadowCol = new Color(0.05f, 0.03f, 0.02f, alpha);
+        mat.SetColor("_Color", shadowCol);
+        mat.color = shadowCol;
+        if (tex != null) mat.mainTexture = tex;
+        mat.renderQueue = 1000;
+        var rr = go.GetComponent<Renderer>();
+        rr.sharedMaterial = mat;
+        rr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        rr.receiveShadows = false;
+
+        // TIGHT CONTACT-AO directly under the soles (r2 L2 HIGH: grounding reads from the dark where
+        // foot meets floor; the directional cast alone left the plant point ambiguous + the seam washed
+        // bright). A small, high-opacity, near-circular dark spot anchored at the feet, drawn UNDER the
+        // directional cast — this is the ambient-occlusion "weight" that locks the figure to the stone.
+        var ao = GameObject.CreatePrimitive(PrimitiveType.Quad);
+        ao.name = name + "_AO";
+        ao.transform.SetParent(parent.transform, false);
+        Object.DestroyImmediate(ao.GetComponent<Collider>());
+        float aoR = Mathf.Clamp(actorBounds.size.x * 0.52f, 0.9f, 1.8f); // r9 L2: TIGHTER = a dark contact CORE
+        ao.transform.localScale = new Vector3(aoR, aoR * 0.55f, 1f);      // depth-squashed circle
+        ao.transform.localPosition = new Vector3(ax, 0.015f, az - 0.3f);  // right at the soles
+        ao.transform.localEulerAngles = new Vector3(90f, 0f, 0f);
+        float aoAlpha = Mathf.Lerp(0.92f, 0.78f, depth01);               // r9 L2: DARKER core so weight reads
+        var aoMat = new Material(sh != null ? sh : Shader.Find("Sprites/Default"));
+        Color aoCol = new Color(0.04f, 0.025f, 0.015f, aoAlpha);  // deep warm-brown AO, not pure black
+        aoMat.SetColor("_Color", aoCol);
+        aoMat.color = aoCol;
+        if (tex != null) aoMat.mainTexture = tex;
+        aoMat.renderQueue = 1001;   // after the directional cast (1000), still before actors
+        var aor = ao.GetComponent<Renderer>();
+        aor.sharedMaterial = aoMat;
+        aor.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        aor.receiveShadows = false;
+
+        // R2 L2 CRITICAL — GROUNDING HALO for low-ambient (back/dark) actors. The goblin sits in the
+        // dark doorway where the AO is dark-on-dark => NO value break => it reads as floating. Draw a
+        // slightly LIGHTER warm ring of floor value JUST OUTSIDE the AO core so a contact value-break
+        // exists even on a near-black floor (the "is it on the floor?" cue is a value EDGE, not darkness).
+        // Only for back actors (depth01 < ~0.45, i.e. dim cells); the lit front hero already has contrast.
+        if (depth01 < 0.45f)
+        {
+            // R5 L2: the symmetric warm ring "read as a glow emitter, not contact." Make it a directional
+            // crescent biased to the HEARTH-LIT side + push the AO core DARKER + tighter so a HARD near-edge
+            // value-break exists at the feet (that hard break is what reads as floor contact, per L2).
+            var halo = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            halo.name = name + "_Halo";
+            halo.transform.SetParent(parent.transform, false);
+            Object.DestroyImmediate(halo.GetComponent<Collider>());
+            float haloR = aoR * 1.7f;
+            // shift the warm patch toward the hearth (screen-LEFT/-X for the depth_2 plate) so it's an
+            // ASYMMETRIC crescent on the lit side, not a symmetric ring; the AO core then sits as a dark
+            // spot on its near (camera) edge. R7: hearth is screen-LEFT now -> bias -X.
+            halo.transform.localScale = new Vector3(haloR * 1.15f, haloR * 0.5f, 1f);
+            halo.transform.localPosition = new Vector3(ax - aoR * 0.35f, 0.012f, az - 0.3f); // biased -X (hearth side, screen-left)
+            halo.transform.localEulerAngles = new Vector3(90f, 0f, 0f);
+            var haloMat = new Material(sh != null ? sh : Shader.Find("Sprites/Default"));
+            // R8 (L2 top fix): the goblin's contact read faint (dark-on-dark). STRONGEN the warm crescent
+            // value-break just outside the dark AO core so a HARD contact edge reads even on the dim back floor.
+            float haloA = Mathf.Lerp(0.62f, 0.34f, depth01 / 0.45f);     // R8: was 0.50..0.28 -> brighter break
+            Color haloCol = new Color(0.30f, 0.20f, 0.11f, haloA);       // R8: a touch warmer/brighter dim floor glow, hearth side only
+            haloMat.SetColor("_Color", haloCol);
+            haloMat.color = haloCol;
+            if (tex != null) haloMat.mainTexture = tex;
+            haloMat.renderQueue = 999;
+            var hr = halo.GetComponent<Renderer>();
+            hr.sharedMaterial = haloMat;
+            hr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            hr.receiveShadows = false;
+
+            // a SECOND tight, very-dark AO core for back actors so the contact value-break is unmistakable
+            // against the warm halo (the hard near-edge L2 demanded). Drawn last (over the halo + base AO).
+            var ao2 = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            ao2.name = name + "_AO2";
+            ao2.transform.SetParent(parent.transform, false);
+            Object.DestroyImmediate(ao2.GetComponent<Collider>());
+            float ao2R = aoR * 0.7f;
+            ao2.transform.localScale = new Vector3(ao2R, ao2R * 0.5f, 1f);
+            ao2.transform.localPosition = new Vector3(ax, 0.018f, az - 0.32f);  // right at the soles, near edge
+            ao2.transform.localEulerAngles = new Vector3(90f, 0f, 0f);
+            var ao2Mat = new Material(sh != null ? sh : Shader.Find("Sprites/Default"));
+            Color ao2Col = new Color(0.02f, 0.012f, 0.008f, 0.95f);   // near-black hard contact core
+            ao2Mat.SetColor("_Color", ao2Col); ao2Mat.color = ao2Col;
+            if (tex != null) ao2Mat.mainTexture = tex;
+            ao2Mat.renderQueue = 1002;
+            var ao2r = ao2.GetComponent<Renderer>();
+            ao2r.sharedMaterial = ao2Mat;
+            ao2r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            ao2r.receiveShadows = false;
+        }
+    }
+
+    static void SetupLighting()
+    {
+        var lightGO = GameObject.Find("Directional Light");
+        if (lightGO == null) { lightGO = new GameObject("Directional Light"); lightGO.AddComponent<Light>().type = LightType.Directional; }
+        var lt = lightGO.GetComponent<Light>();
+        lt.color = Fx.keyColor;
+        lt.intensity = 1.6f;
+        lt.shadows = LightShadows.Soft;
+        lt.shadowStrength = 0.5f;
+        // key from the hearth side (key_dir_deg), tilted down
+        lightGO.transform.eulerAngles = new Vector3(42f, Fx.keyDirDeg + 5f, 0f);
+
+        RenderSettings.ambientMode = UnityEngine.Rendering.AmbientMode.Flat;
+        RenderSettings.ambientLight = Fx.ambientColor;
+        RenderSettings.ambientIntensity = 0.46f;  // R2 L5: lift actor/occluder ambient to match the brighter plate
+        Debug.Log("[CL] Lighting: key " + ColorUtility.ToHtmlStringRGB(Fx.keyColor) +
+                  " int1.6 dir" + Fx.keyDirDeg + ", ambient " + ColorUtility.ToHtmlStringRGB(Fx.ambientColor) + ".");
+    }
+
+    static float Band(string b)
+    {
+        if (b == "tall") return TALL_H;
+        if (b == "low") return LOW_H;
+        return MID_H;
+    }
+
+    // ==================================================================
+    // capture final frame at 16:9
+    // ==================================================================
+    [MenuItem("Tools/WorldOS/CL/3 Capture Final Frame")]
+    public static void CaptureFinal()
+    {
+        var cam = LockCamera();
+        var rt = new RenderTexture(CAP_W, CAP_H, 24, RenderTextureFormat.ARGB32);
+        rt.Create();
+        var prevTgt = cam.targetTexture;
+        cam.targetTexture = rt;
+        cam.Render();
+        SaveRT(rt, "Assets/painterly/final_cl.png");
+        cam.targetTexture = prevTgt;
+        rt.Release();
+        AssetDatabase.Refresh();
+        Debug.Log("[CL] Final frame captured -> Assets/painterly/final_cl.png");
+    }
+}
+
+// graphics-fork: force-reload bump 1782210117

--- a/extensions/renderers/unity/scripts/CombatBeatDriver.cs
+++ b/extensions/renderers/unity/scripts/CombatBeatDriver.cs
@@ -1,0 +1,332 @@
+using UnityEngine;
+using System.Collections;
+
+/// <summary>
+/// CombatBeatDriver — WorldOS Unity spike (2026-06-24).
+///
+/// Plays a scripted 3-phase combat beat entirely as PRESENTATION:
+///   Phase 1 — Hero paths (A*) to a cell adjacent to the goblin (walk-animated).
+///   Phase 2 — Hero faces goblin, plays Attack animation (doAttack trigger on HeroAnim_CL).
+///   Phase 3 — Goblin reacts: plays its own Attack clip as a "hit-flinch" (doAttack trigger on
+///              GoblinAnim_CL), then a brief tilt/knockback impulse, then goblin topples.
+/// Optional second strike: hero attacks again → goblin death-topple (scale-squish fade).
+///
+/// Captures a hi-res screenshot at: approach mid-walk, attack-pose, goblin-react.
+///
+/// Attach to any persistent GO in the scene (e.g. PathManager).
+/// Requires GridPathController on the same or another GO.
+/// </summary>
+public class CombatBeatDriver : MonoBehaviour
+{
+    [Header("References (auto-detected if blank)")]
+    public Transform Hero;
+    public Transform Goblin;
+    public GridPathController GPC;
+
+    [Header("Beat Config")]
+    [Tooltip("Hero stops at this many cells away from goblin (adjacent).")]
+    public float StopDistance = 1.5f;   // grid cells
+
+    [Tooltip("Wait after arrival before attack.")]
+    public float PreAttackPause = 0.4f;
+
+    [Tooltip("Duration of the attack animation before goblin reacts.")]
+    public float AttackAnimDuration = 0.8f;
+
+    [Tooltip("Duration of goblin's flinch reaction.")]
+    public float FlinchDuration = 0.7f;
+
+    [Tooltip("How far goblin knocks back during flinch (world units).")]
+    public float KnockbackDist = 1.2f;
+
+    [Tooltip("Enable second hero attack + goblin death topple.")]
+    public bool DoSecondAttack = true;
+
+    [Tooltip("Duration between first and second attack.")]
+    public float SecondAttackDelay = 0.6f;
+
+    [Header("Capture")]
+    public string CaptureFolder = "Captures";
+    public string CapturePrefix  = "combat_fix_";
+    public int    SuperSize       = 6;   // 6× game-view resolution (~3840px at 640 base)
+
+    [Header("Auto-run")]
+    public bool AutoRun = true;
+    public float StartDelay = 1.2f;
+
+    // ── private state ─────────────────────────────────────────────────────────
+    Animator _heroAnim;
+    Animator _goblinAnim;
+    Vector3  _goblinStartPos;
+    Quaternion _goblinStartRot;
+    int      _captureIdx = 1;
+
+    // ── Grid config (mirrors GridPathController) ──────────────────────────────
+    const int   COLS      = 15;
+    const int   ROWS      = 12;
+    const float CELL_SIZE = 5f;
+    float OriginX => -(COLS * CELL_SIZE) / 2f;
+
+    Vector3 CellToWorld(int col, int row)
+    {
+        float x = OriginX + (col + 0.5f) * CELL_SIZE;
+        float z = (ROWS - row - 0.5f) * CELL_SIZE;
+        return new Vector3(x, 0f, z);
+    }
+
+    bool WorldToCell(Vector3 w, out int col, out int row)
+    {
+        float fx = (w.x - OriginX) / CELL_SIZE - 0.5f;
+        float fz = ROWS - w.z / CELL_SIZE - 0.5f;
+        col = Mathf.RoundToInt(fx);
+        row = Mathf.RoundToInt(fz);
+        return col >= 0 && col < COLS && row >= 0 && row < ROWS;
+    }
+
+    // ── Unity lifecycle ───────────────────────────────────────────────────────
+    void Start()
+    {
+        Resolve();
+        if (AutoRun && _heroAnim != null && _goblinAnim != null && GPC != null)
+            StartCoroutine(RunBeat());
+        else
+            Debug.LogWarning("[CombatBeat] Missing refs — hero=" + (_heroAnim!=null) +
+                             " goblin=" + (_goblinAnim!=null) + " GPC=" + (GPC!=null));
+    }
+
+    void Resolve()
+    {
+        if (Hero == null)
+        {
+            var go = GameObject.Find("HeroFighter");
+            if (go != null) Hero = go.transform;
+        }
+        if (Goblin == null)
+        {
+            var go = GameObject.Find("MonsterGoblin");
+            if (go != null) Goblin = go.transform;
+        }
+        if (GPC == null)
+        {
+            GPC = GetComponent<GridPathController>();
+            if (GPC == null) GPC = FindObjectOfType<GridPathController>();
+        }
+
+        if (Hero   != null) _heroAnim   = Hero.GetComponentInChildren<Animator>(true);
+        if (Goblin != null) _goblinAnim = Goblin.GetComponentInChildren<Animator>(true);
+
+        if (_heroAnim   == null && Hero   != null) Debug.LogWarning("[CombatBeat] No Animator on Hero!");
+        if (_goblinAnim == null && Goblin != null) Debug.LogWarning("[CombatBeat] No Animator on Goblin!");
+
+        if (Goblin != null)
+        {
+            _goblinStartPos = Goblin.position;
+            _goblinStartRot = Goblin.rotation;
+        }
+    }
+
+    // ── MAIN BEAT COROUTINE ───────────────────────────────────────────────────
+    IEnumerator RunBeat()
+    {
+        Debug.Log("[CombatBeat] Beat starting in " + StartDelay + "s…");
+        yield return new WaitForSeconds(StartDelay);
+
+        // ── Phase 0: compute adjacent cell to goblin ──────────────────────────
+        WorldToCell(Goblin.position, out int goblinCol, out int goblinRow);
+        // Hero approaches from the side (offset column) so both characters are
+        // clearly visible as two distinct combatants with a visible gap.
+        // Goblin is at [8,4] (center floor). Hero paths to [9,5] (1 col right,
+        // 1 row south) — diagonal adjacent, both fully visible, no overlap.
+        int targetCol = Mathf.Clamp(goblinCol + 1, 1, COLS - 2);  // 1 col to the right
+        int targetRow = Mathf.Clamp(goblinRow + 1, 1, ROWS - 2);  // 1 row south
+
+        Debug.Log("[CombatBeat] Goblin cell=[" + goblinCol + "," + goblinRow +
+                  "] Hero target=[" + targetCol + "," + targetRow + "]");
+
+        // ── Phase 1: HERO APPROACHES ──────────────────────────────────────────
+        Debug.Log("[CombatBeat] Phase 1: Hero approaching.");
+        GPC.MoveToCell(targetCol, targetRow);
+
+        // Wait a frame so _moving flips
+        yield return null; yield return null; yield return null;
+
+        // Mid-walk capture (a few seconds in)
+        float walkTimer = 0f;
+        bool capturedMidWalk = false;
+        while (GPC.IsMoving)
+        {
+            walkTimer += Time.deltaTime;
+            if (!capturedMidWalk && walkTimer > 1.2f)
+            {
+                Capture("mid_walk");
+                capturedMidWalk = true;
+            }
+            yield return null;
+        }
+        if (!capturedMidWalk) Capture("mid_walk");
+
+        // ── Phase 2: HERO ATTACKS ─────────────────────────────────────────────
+        Debug.Log("[CombatBeat] Phase 2: Attack.");
+        yield return new WaitForSeconds(PreAttackPause);
+
+        // Face goblin
+        FaceTarget(Hero, Goblin.position);
+        // Have goblin face hero so both look at each other
+        FaceTarget(Goblin, Hero.position);
+
+        // Trigger hero attack animation
+        _heroAnim.SetTrigger("doAttack");
+        _heroAnim.SetBool("IsWalking", false);
+
+        yield return new WaitForSeconds(AttackAnimDuration * 0.4f);  // capture at swing
+        Capture("hero_attack");
+
+        yield return new WaitForSeconds(AttackAnimDuration * 0.6f);  // finish swing
+
+        // ── Phase 3: GOBLIN REACTS (flinch) ──────────────────────────────────
+        Debug.Log("[CombatBeat] Phase 3: Goblin flinches.");
+        // Trigger goblin's attack clip as flinch + apply knockback tween
+        _goblinAnim.SetTrigger("doAttack");
+        StartCoroutine(GoblinKnockback(FlinchDuration, KnockbackDist));
+
+        yield return new WaitForSeconds(FlinchDuration * 0.5f);
+        Capture("goblin_react");
+
+        yield return new WaitForSeconds(FlinchDuration * 0.5f);
+
+        // ── Optional Phase 4: SECOND ATTACK + DEATH ──────────────────────────
+        if (DoSecondAttack)
+        {
+            Debug.Log("[CombatBeat] Phase 4: Second strike.");
+            yield return new WaitForSeconds(SecondAttackDelay);
+            FaceTarget(Hero, Goblin.position);
+            _heroAnim.SetTrigger("doAttack");
+            yield return new WaitForSeconds(AttackAnimDuration * 0.5f);
+            StartCoroutine(GoblinDeath(0.9f));
+            yield return new WaitForSeconds(AttackAnimDuration * 0.5f);
+            yield return new WaitForSeconds(0.3f);
+            Capture("goblin_death");
+        }
+
+        Debug.Log("[CombatBeat] BEAT COMPLETE. Captures saved to " + CaptureFolder + "/");
+    }
+
+    // ── GOBLIN KNOCKBACK COROUTINE ────────────────────────────────────────────
+    IEnumerator GoblinKnockback(float duration, float dist)
+    {
+        // Direction away from hero (XZ only)
+        Vector3 dir = Goblin.position - Hero.position;
+        dir.y = 0f;
+        if (dir.sqrMagnitude < 0.001f) dir = Vector3.back;
+        dir = dir.normalized;
+
+        Vector3 startPos = Goblin.position;
+        Vector3 endPos   = startPos + dir * dist;
+        endPos.y = startPos.y;
+
+        // Also add a tilt (rotate goblin around Z axis briefly, then back)
+        Quaternion startRot = Goblin.rotation;
+        Quaternion tiltRot  = startRot * Quaternion.Euler(0f, 0f, 25f);
+
+        float elapsed = 0f;
+        while (elapsed < duration)
+        {
+            float t = elapsed / duration;
+            // Knockback: quick forward then settle
+            float posT = Mathf.SmoothStep(0f, 1f, Mathf.Clamp01(t * 2f));
+            Goblin.position = Vector3.Lerp(startPos, endPos, posT);
+
+            // Tilt: spike at t=0.2 then revert
+            float tiltT = Mathf.Clamp01(Mathf.PingPong(t * 3f, 1f));
+            Goblin.rotation = Quaternion.Slerp(startRot, tiltRot, tiltT);
+
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+        Goblin.position = endPos;
+        Goblin.rotation = startRot;
+    }
+
+    // ── GOBLIN DEATH TOPPLE ───────────────────────────────────────────────────
+    IEnumerator GoblinDeath(float duration)
+    {
+        Vector3    startPos   = Goblin.position;
+        Quaternion startRot   = Goblin.rotation;
+        // Topple: rotate 90° forward (pitch), drift down slightly
+        Vector3 toppleAxis = Vector3.Cross(Vector3.up, (Goblin.position - Hero.position).normalized);
+        if (toppleAxis.sqrMagnitude < 0.001f) toppleAxis = Vector3.right;
+        Quaternion deathRot = startRot * Quaternion.AngleAxis(90f, toppleAxis);
+
+        // Also shrink on Y slightly (squish)
+        Vector3 startScale = Goblin.localScale;
+        Vector3 deadScale  = new Vector3(startScale.x, startScale.y * 0.1f, startScale.z);
+
+        float elapsed = 0f;
+        while (elapsed < duration)
+        {
+            float t = Mathf.SmoothStep(0f, 1f, elapsed / duration);
+            Goblin.rotation   = Quaternion.Slerp(startRot, deathRot, t);
+            Goblin.localScale = Vector3.Lerp(startScale, deadScale, t);
+            Goblin.position   = Vector3.Lerp(startPos,
+                                             startPos + Vector3.down * 0.5f, t);
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+        Goblin.rotation   = deathRot;
+        Goblin.localScale = deadScale;
+
+        // Fade out the mesh
+        StartCoroutine(FadeOut(Goblin, 0.4f));
+    }
+
+    IEnumerator FadeOut(Transform root, float duration)
+    {
+        var renderers = root.GetComponentsInChildren<Renderer>(true);
+        // Cache original colors / enable alpha
+        float elapsed = 0f;
+        while (elapsed < duration)
+        {
+            float alpha = 1f - elapsed / duration;
+            foreach (var r in renderers)
+            {
+                foreach (var mat in r.materials)
+                {
+                    if (mat.HasProperty("_Color"))
+                    {
+                        var c = mat.color; c.a = alpha; mat.color = c;
+                    }
+                    else if (mat.HasProperty("_BaseColor"))
+                    {
+                        var c = mat.GetColor("_BaseColor"); c.a = alpha;
+                        mat.SetColor("_BaseColor", c);
+                    }
+                }
+            }
+            elapsed += Time.deltaTime;
+            yield return null;
+        }
+        root.gameObject.SetActive(false);
+    }
+
+    // ── HELPERS ───────────────────────────────────────────────────────────────
+    void FaceTarget(Transform self, Vector3 target)
+    {
+        Vector3 dir = target - self.position;
+        dir.y = 0f;
+        if (dir.sqrMagnitude > 0.001f)
+            self.rotation = Quaternion.LookRotation(dir, Vector3.up);
+    }
+
+    void Capture(string label)
+    {
+        // Ensure capture folder exists
+        if (!System.IO.Directory.Exists(CaptureFolder))
+            System.IO.Directory.CreateDirectory(CaptureFolder);
+
+        string path = CaptureFolder + "/" + CapturePrefix + _captureIdx.ToString("D2")
+                      + "_" + label + ".png";
+        ScreenCapture.CaptureScreenshot(path, SuperSize);
+        Debug.Log("[CombatBeat] Captured: " + path);
+        _captureIdx++;
+    }
+}

--- a/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceClient.cs
@@ -1,0 +1,226 @@
+using System.Collections;
+using UnityEngine;
+using UnityEngine.Networking;
+
+/// <summary>
+/// CombatSurfaceClient (S2/A4) — renders the ENGINE's combat surface on the painterly tavern.
+///
+/// READ-ONLY on game state: it GETs build_combat_surface and positions the scene's existing rigged
+/// actors (HeroFighter / MonsterGoblin) at the engine's authoritative cells — the engine stays the
+/// SOLE WRITER. A click (or the public DoMove/DoAttack, for headless/programmatic driving) POSTs a
+/// move_to_cell / attack INTENT to /move; the engine validates + resolves it (movement budget, OA,
+/// initiative) and returns the refreshed surface, which we re-render. Cell<->world mirrors
+/// ClosedLoopBuilder / GridPathController exactly (14x10, cell 5, row-flipped) so a token lands on
+/// the painted floor.
+/// </summary>
+public class CombatSurfaceClient : MonoBehaviour
+{
+    [Header("Viewer (reverse-tunnel to the Mac engine)")]
+    public string ViewerUrl = "http://127.0.0.1:8765";
+    public string CampaignId = "";
+    public float PollInterval = 1.5f;
+
+    [Header("Grid — mirror ClosedLoopBuilder (14x10, cell 5)")]
+    public int Cols = 14;
+    public int Rows = 10;
+    public float CellSize = 5f;
+    public float FloorY = 0f;
+
+    Transform _hero, _goblin;
+    string _turnToken = "";
+    string _goblinId = "";
+    int _goblinX = -1, _goblinY = -1;
+    bool _busy = false;
+
+    [System.Serializable] public class Tok { public string id; public string name; public string team; public int x; public int y; public bool isCurrent; }
+    [System.Serializable] public class Surf { public string turnToken; public bool can_act; public Tok[] tokens; }
+    [System.Serializable] public class MoveResp { public bool ok; public string reason; public Surf combat; }
+
+    float OriginX { get { return -(Cols * CellSize) / 2f; } }
+    const float OriginZ = 0f;
+    Vector3 CellToWorld(int c, int r) { return new Vector3(OriginX + (c + 0.5f) * CellSize, FloorY, OriginZ + (Rows - r - 0.5f) * CellSize); }
+    bool WorldToCell(Vector3 w, out int c, out int r)
+    {
+        c = Mathf.RoundToInt((w.x - OriginX) / CellSize - 0.5f);
+        r = Mathf.RoundToInt(Rows - (w.z - OriginZ) / CellSize - 0.5f);
+        return c >= 0 && c < Cols && r >= 0 && r < Rows;
+    }
+
+    void Start()
+    {
+        _hero = Find("HeroFighter");
+        _goblin = Find("MonsterGoblin");
+        Debug.Log("[CSC] start: hero=" + (_hero != null) + " goblin=" + (_goblin != null) + " campaign=" + CampaignId + " url=" + ViewerUrl);
+        StartCoroutine(PollLoop());
+    }
+    Transform Find(string n) { var go = GameObject.Find(n); return go ? go.transform : null; }
+
+    IEnumerator PollLoop()
+    {
+        while (true)
+        {
+            if (!_busy) yield return Fetch();
+            yield return new WaitForSeconds(PollInterval);
+        }
+    }
+
+    static bool Ok(UnityWebRequest r)
+    {
+#if UNITY_2020_2_OR_NEWER
+        return r.result == UnityWebRequest.Result.Success;
+#else
+        return !r.isNetworkError && !r.isHttpError;
+#endif
+    }
+
+    IEnumerator Fetch()
+    {
+        using (var req = UnityWebRequest.Get(ViewerUrl + "/combat-surface?campaign=" + CampaignId))
+        {
+            req.timeout = 6;
+            yield return req.SendWebRequest();
+            if (!Ok(req)) { Debug.LogWarning("[CSC] GET failed: " + req.error); yield break; }
+            ApplyJson(req.downloadHandler.text);
+        }
+    }
+
+    void ApplyJson(string json)
+    {
+        Surf s = null;
+        try { s = JsonUtility.FromJson<Surf>(json); }
+        catch (System.Exception e) { Debug.LogWarning("[CSC] parse: " + e.Message); return; }
+        ApplySurf(s);
+    }
+
+    void ApplySurf(Surf s)
+    {
+        if (s == null || s.tokens == null) return;
+        _turnToken = s.turnToken;
+        foreach (var t in s.tokens)
+        {
+            bool foe = (t.team == "foe");
+            if (foe) { _goblinId = t.id; _goblinX = t.x; _goblinY = t.y; }
+            Transform a = foe ? _goblin : _hero;
+            if (a != null)
+            {
+                var w = CellToWorld(t.x, t.y);
+                Vector3 old = a.position;
+                a.position = new Vector3(w.x, a.position.y, w.z);  // keep the rig's Y (feet grounded)
+                Vector3 d = new Vector3(w.x - old.x, 0f, w.z - old.z);
+                MoveShadow(a.name, d);     // contact shadow follows the actor (orphaning fix)
+                EnsureRing(a, foe);        // BG/PoE selection ring (gold ally / red enemy)
+            }
+        }
+    }
+
+    // The build-time contact shadow + AO are siblings of the actor; move them by the same delta so
+    // they stay under the feet when the engine repositions the actor (else the shadow is orphaned).
+    void MoveShadow(string actorName, Vector3 delta)
+    {
+        foreach (var nm in new[] { actorName + "_Shadow", actorName + "_Shadow_AO" })
+        {
+            var g = GameObject.Find(nm);
+            if (g != null) g.transform.position += delta;
+        }
+    }
+
+    // Find-or-create a BG/PoE floor selection ring under the actor (gold ally / red enemy), placed at the cell.
+    void EnsureRing(Transform actor, bool foe)
+    {
+        string nm = actor.name + "_Ring";
+        var ring = GameObject.Find(nm);
+        if (ring == null)
+        {
+            var sh = Shader.Find("WorldOS/SelectionRing");
+            if (sh == null) return;
+            var q = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            q.name = nm;
+            Destroy(q.GetComponent<Collider>());
+            q.transform.SetParent(actor.parent, false);   // sibling under Actors (no actor scale inheritance)
+            q.transform.localEulerAngles = new Vector3(90f, 0f, 0f);
+            q.transform.localScale = new Vector3(foe ? 5f : 6f, foe ? 5f : 6f, 1f);
+            var m = new Material(sh);
+            m.SetColor("_Color", foe ? new Color(0.88f, 0.28f, 0.30f, 1f) : new Color(1.0f, 0.80f, 0.42f, 1f));
+            m.SetFloat("_Alpha", foe ? 0.80f : 0.85f);
+            m.renderQueue = 1100;          // after contact shadow (1000), before actors (2000)
+            var rr = q.GetComponent<Renderer>();
+            rr.sharedMaterial = m;
+            rr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            rr.receiveShadows = false;
+            ring = q;
+        }
+        // Snap to the actor's VISUAL center + size the ring to its footprint (a fixed ring around the
+        // small goblin read as decoupled — panel L2). Also clamp the atmospheric wash so a back-row
+        // combatant stays SOLID/findable (panel L4/L5: the goblin was a washed-out ghost). Combat must
+        // read the enemy — visibility overrides the static-tavern depth styling for combatants.
+        var rs = actor.GetComponentsInChildren<Renderer>();
+        Vector3 fc = actor.position; float fw = foe ? 5f : 6f;
+        if (rs.Length > 0)
+        {
+            var b = rs[0].bounds;
+            foreach (var rn in rs)
+            {
+                b.Encapsulate(rn.bounds);
+                var mm = rn.sharedMaterial;
+                if (mm != null && mm.HasProperty("_AtmDepth") && mm.GetFloat("_AtmDepth") > 0.35f) mm.SetFloat("_AtmDepth", 0.35f);
+            }
+            fc = b.center;
+            fw = Mathf.Clamp(Mathf.Max(b.size.x, b.size.z) * 2.0f, 3f, 7f);
+        }
+        ring.transform.localScale = new Vector3(fw, fw, 1f);
+        ring.transform.position = new Vector3(fc.x, 0.05f, fc.z);
+    }
+
+    void Update()
+    {
+        if (_busy) return;
+        if (Input.GetMouseButtonDown(0)) HandleClick();
+    }
+
+    void HandleClick()
+    {
+        var cam = Camera.main; if (cam == null) return;
+        Ray ray = cam.ScreenPointToRay(Input.mousePosition);
+        if (Mathf.Abs(ray.direction.y) < 1e-4f) return;
+        float tt = (FloorY - ray.origin.y) / ray.direction.y; if (tt < 0) return;
+        Vector3 hit = ray.origin + ray.direction * tt;
+        if (!WorldToCell(hit, out int c, out int r)) return;
+        if (c == _goblinX && r == _goblinY && _goblinId.Length > 0) StartCoroutine(PostAttack());
+        else StartCoroutine(PostMove(c, r));
+    }
+
+    // ---- public, for headless/programmatic driving (the box has no mouse) ----
+    public void DoMove(int x, int y) { if (!_busy) StartCoroutine(PostMove(x, y)); }
+    public void DoAttack() { if (!_busy && _goblinId.Length > 0) StartCoroutine(PostAttack()); }
+
+    IEnumerator PostMove(int x, int y)
+    {
+        _busy = true;
+        yield return Post("{\"kind\":\"move_to_cell\",\"x\":" + x + ",\"y\":" + y + ",\"turn_token\":\"" + _turnToken + "\",\"campaign\":\"" + CampaignId + "\"}");
+        _busy = false;
+    }
+    IEnumerator PostAttack()
+    {
+        _busy = true;
+        yield return Post("{\"kind\":\"attack\",\"target_id\":\"" + _goblinId + "\",\"turn_token\":\"" + _turnToken + "\",\"campaign\":\"" + CampaignId + "\"}");
+        _busy = false;
+    }
+
+    IEnumerator Post(string body)
+    {
+        using (var req = new UnityWebRequest(ViewerUrl + "/move", "POST"))
+        {
+            req.uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(body));
+            req.downloadHandler = new DownloadHandlerBuffer();
+            req.SetRequestHeader("Content-Type", "application/json");
+            req.timeout = 8;
+            yield return req.SendWebRequest();
+            if (!Ok(req)) { Debug.LogWarning("[CSC] /move failed: " + req.error + " body=" + req.downloadHandler.text); yield break; }
+            MoveResp resp = null;
+            try { resp = JsonUtility.FromJson<MoveResp>(req.downloadHandler.text); }
+            catch (System.Exception e) { Debug.LogWarning("[CSC] move parse: " + e.Message); yield break; }
+            if (resp != null && resp.ok && resp.combat != null) { Debug.Log("[CSC] move ok -> re-render"); ApplySurf(resp.combat); }
+            else Debug.LogWarning("[CSC] move rejected: " + (resp != null ? resp.reason : "null"));
+        }
+    }
+}

--- a/extensions/renderers/unity/scripts/CombatSurfaceDemo.cs
+++ b/extensions/renderers/unity/scripts/CombatSurfaceDemo.cs
@@ -1,0 +1,119 @@
+using UnityEngine;
+using UnityEditor;
+using System.Net;
+using System.IO;
+
+/// <summary>
+/// CombatSurfaceDemo (A4/B2 demo) — an EDIT-MODE menu item that GETs the engine combat surface
+/// (synchronously, no Play mode) and positions the painterly scene's rigged actors at the engine's
+/// authoritative cells. It also owns the COMBAT-OVERLAY visuals that belong to the combat renderer
+/// (not the static tavern build): each actor's contact shadow FOLLOWS it (fixes the orphaning bug
+/// where moving an actor left its build-time shadow behind), and each actor gets a BG/PoE-style floor
+/// SELECTION RING (gold ally / red enemy) — the visual-critic panel flagged the missing rings as a
+/// cross-lens CRITICAL (L5 findability + L1/L2 grounding). Cell&lt;-&gt;world mirrors ClosedLoopBuilder
+/// (14x10, cell 5, row-flip). The rings/shadow moves are renderer-local VIEW only (engine stays sole writer).
+/// </summary>
+public static class CombatSurfaceDemo
+{
+    const string ViewerUrl = "http://127.0.0.1:8765";
+    const string CampaignId = "camp_6ee62cf998fe";
+    const int Cols = 14, Rows = 10;
+    const float CellSize = 5f, FloorY = 0f;
+
+    static float OriginX { get { return -(Cols * CellSize) / 2f; } }
+    const float OriginZ = 0f;
+    static Vector3 CellToWorld(int c, int r) { return new Vector3(OriginX + (c + 0.5f) * CellSize, FloorY, OriginZ + (Rows - r - 0.5f) * CellSize); }
+
+    [System.Serializable] class Tok { public string id; public string name; public string team; public int x; public int y; }
+    [System.Serializable] class Surf { public string turnToken; public Tok[] tokens; }
+
+    [MenuItem("Tools/WorldOS/Combat/Position Actors From Surface")]
+    public static void PositionFromSurface()
+    {
+        string json;
+        try
+        {
+            var req = (HttpWebRequest)WebRequest.Create(ViewerUrl + "/combat-surface?campaign=" + CampaignId);
+            req.Timeout = 6000;
+            using (var resp = (HttpWebResponse)req.GetResponse())
+            using (var sr = new StreamReader(resp.GetResponseStream()))
+                json = sr.ReadToEnd();
+        }
+        catch (System.Exception e) { Debug.LogError("[CSD] GET failed: " + e.Message); return; }
+
+        var s = JsonUtility.FromJson<Surf>(json);
+        if (s == null || s.tokens == null) { Debug.LogError("[CSD] no tokens in surface"); return; }
+        foreach (var t in s.tokens)
+        {
+            bool foe = (t.team == "foe");
+            string name = foe ? "MonsterGoblin" : "HeroFighter";
+            var go = GameObject.Find(name);
+            if (go == null) { Debug.LogWarning("[CSD] actor not found: " + name); continue; }
+            var w = CellToWorld(t.x, t.y);
+            Vector3 old = go.transform.position;
+            go.transform.position = new Vector3(w.x, go.transform.position.y, w.z);  // keep rig Y
+            Vector3 d = new Vector3(w.x - old.x, 0f, w.z - old.z);
+            MoveShadow(name, d);          // shadow follows the actor (orphaning fix)
+            EnsureRing(go.transform, foe);
+            Debug.Log("[CSD] " + name + " (" + t.team + ") -> cell (" + t.x + "," + t.y + ")");
+        }
+        SceneView.RepaintAll();
+    }
+
+    // Move the actor's build-time contact shadow + AO by the same delta so they stay under the feet.
+    static void MoveShadow(string actorName, Vector3 delta)
+    {
+        foreach (var nm in new[] { actorName + "_Shadow", actorName + "_Shadow_AO" })
+        {
+            var g = GameObject.Find(nm);
+            if (g != null) g.transform.position += delta;
+        }
+    }
+
+    // Find-or-create the BG/PoE selection ring under the actor (gold ally / red enemy) and place it at the cell.
+    static void EnsureRing(Transform actor, bool foe)
+    {
+        string nm = actor.name + "_Ring";
+        var ring = GameObject.Find(nm);
+        if (ring == null)
+        {
+            var sh = Shader.Find("WorldOS/SelectionRing");
+            if (sh == null) { Debug.LogWarning("[CSD] SelectionRing shader missing"); return; }
+            var q = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            q.name = nm;
+            UnityEngine.Object.DestroyImmediate(q.GetComponent<Collider>());
+            q.transform.SetParent(actor.parent, false);   // sibling under Actors (no actor scale inheritance)
+            q.transform.localEulerAngles = new Vector3(90f, 0f, 0f);
+            q.transform.localScale = new Vector3(foe ? 5f : 6f, foe ? 5f : 6f, 1f);
+            var m = new Material(sh);
+            m.SetColor("_Color", foe ? new Color(0.88f, 0.28f, 0.30f, 1f) : new Color(1.0f, 0.80f, 0.42f, 1f));
+            m.SetFloat("_Alpha", foe ? 0.80f : 0.85f);
+            m.renderQueue = 1100;          // after contact shadow (1000), before actors (2000)
+            var rr = q.GetComponent<Renderer>();
+            rr.sharedMaterial = m;
+            rr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            rr.receiveShadows = false;
+            ring = q;
+        }
+        // Snap to the actor's VISUAL center + size the ring to its footprint (a fixed ring around the
+        // small goblin read as decoupled — panel L2). Also clamp the atmospheric wash so a back-row
+        // combatant stays SOLID/findable (panel L4/L5: the goblin was a washed-out ghost). Combat must
+        // read the enemy — visibility overrides the static-tavern depth styling for combatants.
+        var rs = actor.GetComponentsInChildren<Renderer>();
+        Vector3 fc = actor.position; float fw = foe ? 5f : 6f;
+        if (rs.Length > 0)
+        {
+            var b = rs[0].bounds;
+            foreach (var rn in rs)
+            {
+                b.Encapsulate(rn.bounds);
+                var mm = rn.sharedMaterial;
+                if (mm != null && mm.HasProperty("_AtmDepth") && mm.GetFloat("_AtmDepth") > 0.35f) mm.SetFloat("_AtmDepth", 0.35f);
+            }
+            fc = b.center;
+            fw = Mathf.Clamp(Mathf.Max(b.size.x, b.size.z) * 2.0f, 3f, 7f);
+        }
+        ring.transform.localScale = new Vector3(fw, fw, 1f);
+        ring.transform.position = new Vector3(fc.x, 0.05f, fc.z);
+    }
+}

--- a/extensions/renderers/unity/scripts/DungeonPathingProof.cs
+++ b/extensions/renderers/unity/scripts/DungeonPathingProof.cs
@@ -1,0 +1,166 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using System.IO;
+
+/// <summary>
+/// DungeonPathingProof — WorldOS Unity spike (2026-06-24).
+///
+/// Editor-mode A* pathfinding proof on the dungeon SceneGrid.
+/// No play mode required. Menu: Tools/WorldOS/Prove Dungeon Pathing (A*)
+/// Logs the grid size, blocked-cell count, and 4 routed paths that dodge obstacles.
+/// </summary>
+public static class DungeonPathingProof
+{
+    const string FIXTURE = "/Volumes/LEXAR/WorldOS-Unity-spike/fixtures/dungeon.scenegrid.json";
+
+    // ── A* INLINE (copy of GridPathController logic, editor-mode) ──────────
+    static bool[,] _blocked;
+    static int _cols, _rows;
+    static float _cell;
+
+    [MenuItem("Tools/WorldOS/Prove Dungeon Pathing (A*)")]
+    public static void ProvePathing()
+    {
+        // 1. Load fixture + build blocked grid
+        if (!File.Exists(FIXTURE)) { Debug.LogError("[DungeonProof] Fixture not found: " + FIXTURE); return; }
+        string json = File.ReadAllText(FIXTURE);
+
+        // Parse grid dimensions
+        var root = MiniJson.Parse(json) as Dictionary<string, object>;
+        if (root == null) { Debug.LogError("[DungeonProof] Parse failed."); return; }
+        _cols = _rows = 0; _cell = 5f;
+        if (root.TryGetValue("grid", out var go) && go is Dictionary<string, object> grid)
+        {
+            _cols = (int)System.Convert.ToDouble(grid.TryGetValue("cols", out var cv) ? cv : 14);
+            _rows = (int)System.Convert.ToDouble(grid.TryGetValue("rows", out var rv) ? rv : 10);
+            _cell = (float)System.Convert.ToDouble(grid.TryGetValue("cell_size_ft", out var csz) ? csz : 5.0);
+        }
+
+        _blocked = new bool[_cols, _rows];
+        int blockedCount = 0;
+
+        // Mark wall + prop cells
+        if (root.TryGetValue("cells", out var co) && co is List<object> cellList)
+        {
+            foreach (var ce in cellList)
+            {
+                if (ce is Dictionary<string, object> cd)
+                {
+                    bool walkable = true;
+                    if (cd.TryGetValue("walkable", out var wv))
+                    {
+                        if (wv is bool b) walkable = b;
+                        else if (wv != null) bool.TryParse(wv.ToString(), out walkable);
+                    }
+                    if (!walkable)
+                    {
+                        int c = (int)System.Convert.ToDouble(cd.TryGetValue("c", out var ccv) ? ccv : 0);
+                        int r = (int)System.Convert.ToDouble(cd.TryGetValue("r", out var rr) ? rr : 0);
+                        if (c >= 0 && c < _cols && r >= 0 && r < _rows)
+                        { _blocked[c, r] = true; blockedCount++; }
+                    }
+                }
+            }
+        }
+
+        Debug.Log("[DungeonProof] Grid: " + _cols + "x" + _rows + " (cell " + _cell + "ft) — " +
+                  blockedCount + " blocked cells, " + (_cols * _rows - blockedCount) + " walkable.");
+
+        // 2. Four pathing tests that route around blocked cells
+        var tests = new (int sc, int sr, int gc, int gr, string label)[]
+        {
+            (6, 9,  7, 6,  "center walk (south→mid)"),
+            (7, 6,  11, 6, "right corridor (cross dungeon)"),
+            (11, 6, 11, 3, "north approach near right pillar [12,2]"),
+            (11, 3,  3, 3, "long cross — around both pillars + sarcophagus"),
+        };
+
+        bool allOk = true;
+        foreach (var (sc, sr, gc, gr, label) in tests)
+        {
+            var path = AStar(sc, sr, gc, gr);
+            if (path == null || path.Count == 0)
+            {
+                Debug.LogError("[DungeonProof] FAIL — no path for '" + label +
+                               "' [" + sc + "," + sr + "] → [" + gc + "," + gr + "]");
+                allOk = false;
+                continue;
+            }
+
+            // Verify no blocked cell in path
+            bool clean = true;
+            foreach (var step in path)
+                if (_blocked[step.x, step.y]) { clean = false; break; }
+
+            string pathStr = "";
+            foreach (var s in path) pathStr += "[" + s.x + "," + s.y + "]→";
+            pathStr = pathStr.TrimEnd('→');
+
+            if (clean)
+                Debug.Log("[DungeonProof] OK  '" + label + "' — " + path.Count + " cells: " + pathStr);
+            else
+            {
+                Debug.LogError("[DungeonProof] FAIL  '" + label + "' — path traverses a BLOCKED cell!");
+                allOk = false;
+            }
+        }
+
+        Debug.Log("[DungeonProof] === RESULT: " + (allOk ? "ALL 4 PATHS ROUTED CLEANLY ✓" : "FAILURES DETECTED ✗") + " ===");
+    }
+
+    // ── A* (Manhattan heuristic, 4-directional) ───────────────────────────
+    static List<Vector2Int> AStar(int startC, int startR, int goalC, int goalR)
+    {
+        var open   = new SortedList<float, Vector2Int>();
+        var gScore = new Dictionary<Vector2Int, float>();
+        var parent = new Dictionary<Vector2Int, Vector2Int>();
+        var closed = new HashSet<Vector2Int>();
+        var start  = new Vector2Int(startC, startR);
+        var goal   = new Vector2Int(goalC, goalR);
+
+        gScore[start] = 0;
+        float h0 = H(start, goal);
+        while (open.ContainsKey(h0)) h0 += 0.0001f;
+        open.Add(h0, start);
+
+        int[] dc = {-1,1,0,0};
+        int[] dr = {0,0,-1,1};
+
+        while (open.Count > 0)
+        {
+            var cur = open.Values[0]; open.RemoveAt(0);
+            if (cur == goal) return Reconstruct(parent, start, goal);
+            if (closed.Contains(cur)) continue;
+            closed.Add(cur);
+
+            for (int d = 0; d < 4; d++)
+            {
+                int nc = cur.x + dc[d], nr = cur.y + dr[d];
+                if (nc < 0 || nc >= _cols || nr < 0 || nr >= _rows) continue;
+                var nb = new Vector2Int(nc, nr);
+                if (closed.Contains(nb) || _blocked[nc, nr]) continue;
+                float ng = (gScore.ContainsKey(cur) ? gScore[cur] : float.MaxValue) + 1f;
+                if (!gScore.ContainsKey(nb) || ng < gScore[nb])
+                {
+                    gScore[nb] = ng; parent[nb] = cur;
+                    float fv = ng + H(nb, goal);
+                    while (open.ContainsKey(fv)) fv += 0.0001f;
+                    open.Add(fv, nb);
+                }
+            }
+        }
+        return null;
+    }
+
+    static float H(Vector2Int a, Vector2Int b) => Mathf.Abs(a.x - b.x) + Mathf.Abs(a.y - b.y);
+
+    static List<Vector2Int> Reconstruct(Dictionary<Vector2Int, Vector2Int> parent,
+                                         Vector2Int start, Vector2Int goal)
+    {
+        var path = new List<Vector2Int>();
+        var cur = goal;
+        while (cur != start) { path.Add(cur); cur = parent[cur]; }
+        path.Add(start); path.Reverse(); return path;
+    }
+}

--- a/extensions/renderers/unity/scripts/GridPathController.cs
+++ b/extensions/renderers/unity/scripts/GridPathController.cs
@@ -1,0 +1,478 @@
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+
+/// <summary>
+/// GridPathController — WorldOS Unity spike (2026-06-23).
+///
+/// Click-to-move A* pathing on the tavern SceneGrid.
+/// Cell↔world transform mirrors ClosedLoopBuilder exactly:
+///   CellX(col) = OriginX + (col + 0.5) * CELL_SIZE
+///   CellZ(row) = OriginZ + (ROWS - row - 0.5) * CELL_SIZE
+///   where OriginX = -(COLS * CELL_SIZE) / 2f,  OriginZ = 0f
+///
+/// Usage (Play mode):
+///   Left-click anywhere on the floor → hero walks there via A*.
+///   Blocked/unreachable cell → no-op.
+///
+/// Drop this MonoBehaviour onto any persistent GameObject (e.g. "Main Camera"
+/// or a new empty "PathManager"). Set the Hero field in Inspector, or leave
+/// blank for auto-detect ("HeroFighter" by name).
+/// </summary>
+public class GridPathController : MonoBehaviour
+{
+    // ── INSPECTOR FIELDS ─────────────────────────────────────────────────────
+    [Header("Scene References")]
+    [Tooltip("The hero to move. Auto-detected from name 'HeroFighter' if blank.")]
+    public Transform Hero;
+
+    [Header("Grid Config (mirrors ClosedLoopBuilder)")]
+    public int   Cols     = 15;
+    public int   Rows     = 12;
+    public float CellSize = 5f;
+
+    [Header("Movement")]
+    [Tooltip("Walk speed in world units per second.")]
+    public float WalkSpeed = 12f;
+    [Tooltip("Rotation speed (degrees/sec) while turning to face movement dir.")]
+    public float TurnSpeed = 360f;
+    [Tooltip("Floor plane Y for grounding.")]
+    public float FloorY = 0f;
+
+    [Header("Animator Params (must match clips)")]
+    public string AnimBoolWalk = "IsWalking";
+
+    [Header("Fixture path (auto-loaded)")]
+    public string FixturePath = "/home/unity/worldos-unity/fixtures/tavern.scenegrid.json";
+
+    // ── RUNTIME STATE ─────────────────────────────────────────────────────────
+    bool[,] _blocked;   // [col, row] — true = blocked
+    bool    _gridLoaded;
+
+    Animator _anim;
+    bool     _moving;
+
+    // Current cell (for spawn detection) — dungeon fixture party spawn: [6,9]
+    int _heroCol = 6, _heroRow = 9;  // fixture party spawn default
+
+    // ── PUBLIC API (for test driver) ──────────────────────────────────────────
+    public bool IsMoving => _moving;
+    public int  HeroCol  => _heroCol;
+    public int  HeroRow  => _heroRow;
+
+    /// <summary>Programmatic move — same as clicking a cell. Safe to call in Play mode.</summary>
+    public void MoveToCell(int col, int row)
+    {
+        if (!_gridLoaded) { Debug.LogWarning("[GridPath] Grid not loaded yet."); return; }
+        if (_moving)      { Debug.LogWarning("[GridPath] Already moving, ignoring MoveToCell."); return; }
+
+        int targetCol = col, targetRow = row;
+        if (targetCol < 0 || targetCol >= Cols || targetRow < 0 || targetRow >= Rows)
+        { Debug.LogWarning("[GridPath] MoveToCell: out of bounds ["+col+","+row+"]"); return; }
+
+        if (_blocked[targetCol, targetRow])
+        {
+            if (!FindNearestWalkable(targetCol, targetRow, out targetCol, out targetRow))
+            { Debug.LogWarning("[GridPath] No walkable cell near ["+col+","+row+"]"); return; }
+        }
+
+        var path = AStar(_heroCol, _heroRow, targetCol, targetRow);
+        if (path == null || path.Count == 0)
+        { Debug.LogWarning("[GridPath] No path to ["+targetCol+","+targetRow+"]"); return; }
+
+        Debug.Log("[GridPath] MoveToCell ["+col+","+row+"] — path "+path.Count+" cells.");
+        StartCoroutine(WalkPath(path));
+    }
+
+    // ── CELL↔WORLD TRANSFORM (exact mirror of ClosedLoopBuilder) ─────────────
+    float OriginX => -(Cols * CellSize) / 2f;   // = -35 for 14×5
+    const float OriginZ = 0f;
+
+    Vector3 CellToWorld(int col, int row)
+    {
+        float x = OriginX + (col + 0.5f) * CellSize;
+        float z = OriginZ  + (Rows - row - 0.5f) * CellSize;
+        return new Vector3(x, FloorY, z);
+    }
+
+    bool WorldToCell(Vector3 world, out int col, out int row)
+    {
+        // Inverse of CellToWorld
+        float fx = (world.x - OriginX) / CellSize - 0.5f;
+        float fz = Rows - (world.z - OriginZ) / CellSize - 0.5f;
+        col = Mathf.RoundToInt(fx);
+        row = Mathf.RoundToInt(fz);
+        return (col >= 0 && col < Cols && row >= 0 && row < Rows);
+    }
+
+    // ── UNITY LIFECYCLE ───────────────────────────────────────────────────────
+    void Start()
+    {
+        LoadGrid();
+        FindHero();
+    }
+
+    void Update()
+    {
+        if (!_gridLoaded) return;
+        if (_moving)      return;   // ignore clicks while walking
+
+        // If there's an active CombatSurfaceClient in the scene, it is responsible for handling clicks/movement authoritative-sync.
+        var csc = FindObjectOfType<CombatSurfaceClient>();
+        if (csc != null && csc.enabled) return;
+
+        if (Input.GetMouseButtonDown(0))
+            HandleClick();
+    }
+
+    // ── GRID LOAD ─────────────────────────────────────────────────────────────
+    void LoadGrid()
+    {
+        _blocked = new bool[Cols, Rows];
+
+        string actualPath = FixturePath;
+        if (!File.Exists(actualPath))
+        {
+            // Try relative path from project root
+            string projectRoot = Path.GetDirectoryName(Application.dataPath);
+            string relativePath = Path.Combine(projectRoot, "fixtures", "tavern.scenegrid.json");
+            if (File.Exists(relativePath))
+            {
+                actualPath = relativePath;
+            }
+        }
+
+        if (!File.Exists(actualPath))
+        {
+            Debug.LogError("[GridPath] Fixture not found: " + FixturePath + " — using prop-only blocking.");
+            _gridLoaded = true;
+            return;
+        }
+
+        string json = File.ReadAllText(actualPath);
+
+        // Simple hand-parse: look for "walkable":false in each cell entry.
+        // We rely on the pattern "c":N,"r":M,"type":"...","walkable":false
+        // and "cells" prop entries to mark blocked.
+        // Primary: parse "cells" array entries with walkable:false
+        // Fallback: mark prop cells from "props"
+
+        // Parse the full JSON via MiniJson if available, else regex-free manual parse.
+        // We use a simple state-machine to extract c,r,walkable triples.
+        ParseCellsFromJson(json);
+        _gridLoaded = true;
+        int blocked = 0;
+        for (int c = 0; c < Cols; c++)
+            for (int r = 0; r < Rows; r++)
+                if (_blocked[c, r]) blocked++;
+        Debug.Log("[GridPath] Grid loaded " + Cols + "x" + Rows +
+                  " — " + blocked + " blocked cells.");
+    }
+
+    void ParseCellsFromJson(string json)
+    {
+        // Walk the "cells" array: each entry is {"c":N,"r":M,"type":"...","walkable":false,...}
+        // We scan for entries containing "walkable":false (or walkable:false without space).
+        int idx = json.IndexOf("\"cells\"");
+        if (idx < 0) { Debug.LogWarning("[GridPath] No 'cells' key in fixture."); return; }
+        int arrStart = json.IndexOf('[', idx);
+        int arrEnd   = json.IndexOf(']', arrStart);
+        if (arrStart < 0 || arrEnd < 0) return;
+
+        string cellsBlock = json.Substring(arrStart, arrEnd - arrStart + 1);
+
+        // Split by object boundaries: find each {...} within the array
+        int pos = 0;
+        while (pos < cellsBlock.Length)
+        {
+            int ob = cellsBlock.IndexOf('{', pos);
+            if (ob < 0) break;
+            int cb = cellsBlock.IndexOf('}', ob);
+            if (cb < 0) break;
+            string entry = cellsBlock.Substring(ob, cb - ob + 1);
+            pos = cb + 1;
+
+            // Check walkable — handle both "walkable":false and "walkable": false (with space)
+            bool walkable = !entry.Contains("\"walkable\":false") && !entry.Contains("\"walkable\": false");
+            if (walkable) continue;  // walkable=true is the default; skip
+
+            int c = ExtractInt(entry, "\"c\":");
+            int r = ExtractInt(entry, "\"r\":");
+            if (c >= 0 && c < Cols && r >= 0 && r < Rows)
+                _blocked[c, r] = true;
+        }
+    }
+
+    int ExtractInt(string s, string key)
+    {
+        int ki = s.IndexOf(key);
+        if (ki < 0) return -1;
+        int vi = ki + key.Length;
+        while (vi < s.Length && (s[vi] == ' ')) vi++;
+        int end = vi;
+        while (end < s.Length && (char.IsDigit(s[end]) || s[end] == '-')) end++;
+        if (end == vi) return -1;
+        return int.Parse(s.Substring(vi, end - vi));
+    }
+
+    // ── HERO FIND ─────────────────────────────────────────────────────────────
+    void FindHero()
+    {
+        if (Hero == null)
+        {
+            var go = GameObject.Find("HeroFighter");
+            if (go != null) Hero = go.transform;
+        }
+        if (Hero == null)
+        {
+            Debug.LogError("[GridPath] HeroFighter not found in scene! Drag it into Inspector.");
+            return;
+        }
+        _anim = Hero.GetComponentInChildren<Animator>();
+        if (_anim == null)
+            Debug.LogWarning("[GridPath] No Animator found on HeroFighter or children.");
+
+        // Snap to nearest grid cell
+        WorldToCell(Hero.position, out _heroCol, out _heroRow);
+        Debug.Log("[GridPath] Hero found at cell [" + _heroCol + "," + _heroRow +
+                  "] world=" + Hero.position.ToString("F1"));
+    }
+
+    // ── MOUSE CLICK HANDLER ───────────────────────────────────────────────────
+    void HandleClick()
+    {
+        var cam = Camera.main;
+        if (cam == null) return;
+
+        // Raycast to the floor plane (Y = FloorY)
+        Ray ray = cam.ScreenPointToRay(Input.mousePosition);
+        // Intersect with y = FloorY plane
+        if (Mathf.Abs(ray.direction.y) < 0.0001f) return;
+        float t = (FloorY - ray.origin.y) / ray.direction.y;
+        if (t < 0) return;
+        Vector3 hitWorld = ray.origin + ray.direction * t;
+
+        if (!WorldToCell(hitWorld, out int targetCol, out int targetRow))
+        {
+            Debug.Log("[GridPath] Click out of grid bounds.");
+            return;
+        }
+
+        if (_blocked[targetCol, targetRow])
+        {
+            Debug.Log("[GridPath] Click on blocked cell [" + targetCol + "," + targetRow + "] — finding nearest walkable.");
+            if (!FindNearestWalkable(targetCol, targetRow, out targetCol, out targetRow))
+            {
+                Debug.Log("[GridPath] No walkable neighbor found.");
+                return;
+            }
+        }
+
+        List<Vector2Int> path = AStar(_heroCol, _heroRow, targetCol, targetRow);
+        if (path == null || path.Count == 0)
+        {
+            Debug.Log("[GridPath] No path to [" + targetCol + "," + targetRow + "].");
+            return;
+        }
+
+        Debug.Log("[GridPath] Path found: " + path.Count + " cells → target [" + targetCol + "," + targetRow + "]");
+        StartCoroutine(WalkPath(path));
+    }
+
+    bool FindNearestWalkable(int col, int row, out int outCol, out int outRow)
+    {
+        // BFS outward from the blocked cell
+        var visited = new HashSet<Vector2Int>();
+        var queue = new Queue<Vector2Int>();
+        queue.Enqueue(new Vector2Int(col, row));
+        visited.Add(new Vector2Int(col, row));
+        int[] dc = {-1,1,0,0};
+        int[] dr = {0,0,-1,1};
+        while (queue.Count > 0)
+        {
+            var cur = queue.Dequeue();
+            for (int d = 0; d < 4; d++)
+            {
+                int nc = cur.x + dc[d], nr = cur.y + dr[d];
+                var nv = new Vector2Int(nc, nr);
+                if (nc < 0 || nc >= Cols || nr < 0 || nr >= Rows) continue;
+                if (visited.Contains(nv)) continue;
+                if (!_blocked[nc, nr]) { outCol = nc; outRow = nr; return true; }
+                visited.Add(nv);
+                queue.Enqueue(nv);
+            }
+        }
+        outCol = col; outRow = row; return false;
+    }
+
+    // ── A* PATHFINDER ─────────────────────────────────────────────────────────
+    List<Vector2Int> AStar(int startC, int startR, int goalC, int goalR)
+    {
+        var open   = new SortedList<float, Vector2Int>();
+        var gScore = new Dictionary<Vector2Int, float>();
+        var parent = new Dictionary<Vector2Int, Vector2Int>();
+        var closed = new HashSet<Vector2Int>();
+
+        var start = new Vector2Int(startC, startR);
+        var goal  = new Vector2Int(goalC, goalR);
+
+        gScore[start] = 0;
+        float h0 = Heuristic(start, goal);
+        // SortedList doesn't allow duplicate keys; append small epsilon
+        float fStart = h0;
+        while (open.ContainsKey(fStart)) fStart += 0.0001f;
+        open.Add(fStart, start);
+
+        int[] dc4 = {-1,1,0,0};
+        int[] dr4 = {0,0,-1,1};
+
+        while (open.Count > 0)
+        {
+            // Pop lowest f
+            var first = open.Keys[0];
+            var cur = open.Values[0];
+            open.RemoveAt(0);
+
+            if (cur == goal)
+                return ReconstructPath(parent, start, goal);
+
+            if (closed.Contains(cur)) continue;
+            closed.Add(cur);
+
+            for (int d = 0; d < 4; d++)
+            {
+                int nc = cur.x + dc4[d], nr = cur.y + dr4[d];
+                if (nc < 0 || nc >= Cols || nr < 0 || nr >= Rows) continue;
+                var nb = new Vector2Int(nc, nr);
+                if (closed.Contains(nb)) continue;
+                if (_blocked[nc, nr]) continue;
+
+                float ng = (gScore.ContainsKey(cur) ? gScore[cur] : float.MaxValue) + 1f;
+                if (!gScore.ContainsKey(nb) || ng < gScore[nb])
+                {
+                    gScore[nb] = ng;
+                    parent[nb] = cur;
+                    float fVal = ng + Heuristic(nb, goal);
+                    while (open.ContainsKey(fVal)) fVal += 0.0001f;
+                    open.Add(fVal, nb);
+                }
+            }
+        }
+        return null;  // no path
+    }
+
+    float Heuristic(Vector2Int a, Vector2Int b)
+        => Mathf.Abs(a.x - b.x) + Mathf.Abs(a.y - b.y);
+
+    List<Vector2Int> ReconstructPath(Dictionary<Vector2Int, Vector2Int> parent,
+                                     Vector2Int start, Vector2Int goal)
+    {
+        var path = new List<Vector2Int>();
+        var cur = goal;
+        while (cur != start)
+        {
+            path.Add(cur);
+            cur = parent[cur];
+        }
+        path.Add(start);
+        path.Reverse();
+        return path;
+    }
+
+    // ── WALK COROUTINE ────────────────────────────────────────────────────────
+    IEnumerator WalkPath(List<Vector2Int> path)
+    {
+        _moving = true;
+        SetWalking(true);
+
+        float heroY = Hero.position.y;   // preserve original Y throughout (rig is above floor)
+
+        // Skip the first cell (hero's current cell)
+        for (int i = 1; i < path.Count; i++)
+        {
+            var cell = path[i];
+            // Target on the XZ plane only; hero Y stays fixed (rig height above floor)
+            Vector3 targetXZ = CellToWorld(cell.x, cell.y);
+            targetXZ.y = heroY;
+
+            // Face direction (XZ only)
+            Vector3 dir = targetXZ - Hero.position;
+            dir.y = 0;
+
+            // Walk until we reach the target (XZ distance only)
+            float xzDist = new Vector2(Hero.position.x - targetXZ.x,
+                                       Hero.position.z - targetXZ.z).magnitude;
+            while (xzDist > 0.08f)
+            {
+                // Smooth turn toward movement direction
+                if (dir.sqrMagnitude > 0.001f)
+                {
+                    Quaternion targetRot = Quaternion.LookRotation(dir, Vector3.up);
+                    Hero.rotation = Quaternion.RotateTowards(Hero.rotation, targetRot,
+                                                             TurnSpeed * Time.deltaTime);
+                }
+                // Move with fixed Y
+                var curXZ = new Vector3(Hero.position.x, heroY, Hero.position.z);
+                var newPos = Vector3.MoveTowards(curXZ, targetXZ, WalkSpeed * Time.deltaTime);
+                Hero.position = newPos;
+
+                // Update direction and distance
+                dir = targetXZ - Hero.position; dir.y = 0;
+                xzDist = new Vector2(Hero.position.x - targetXZ.x,
+                                     Hero.position.z - targetXZ.z).magnitude;
+                yield return null;
+            }
+
+            // Snap to cell centre (keep Y)
+            Hero.position = new Vector3(targetXZ.x, heroY, targetXZ.z);
+            _heroCol = cell.x;
+            _heroRow = cell.y;
+        }
+
+        SetWalking(false);
+        _moving = false;
+        Debug.Log("[GridPath] Arrived at cell [" + _heroCol + "," + _heroRow + "].");
+    }
+
+    void SetWalking(bool walking)
+    {
+        if (_anim == null) return;
+        // Try bool parameter first, then try triggers
+        if (_anim.parameters.Length > 0)
+        {
+            foreach (var p in _anim.parameters)
+            {
+                if (p.name == AnimBoolWalk && p.type == AnimatorControllerParameterType.Bool)
+                {
+                    _anim.SetBool(AnimBoolWalk, walking);
+                    return;
+                }
+                if (p.name == AnimBoolWalk && p.type == AnimatorControllerParameterType.Trigger)
+                {
+                    if (walking) _anim.SetTrigger(AnimBoolWalk);
+                    return;
+                }
+            }
+        }
+        // No matching param — log once
+        if (walking)
+            Debug.Log("[GridPath] Animator has no '" + AnimBoolWalk + "' param — walk anim not driven.");
+    }
+
+    // ── DEBUG GIZMOS ─────────────────────────────────────────────────────────
+    void OnDrawGizmos()
+    {
+        if (!_gridLoaded) return;
+        for (int c = 0; c < Cols; c++)
+            for (int r = 0; r < Rows; r++)
+            {
+                Vector3 ctr = CellToWorld(c, r);
+                ctr.y = FloorY + 0.05f;
+                Gizmos.color = _blocked[c, r]
+                    ? new Color(1f, 0.2f, 0.2f, 0.35f)
+                    : new Color(0.2f, 1f, 0.4f, 0.18f);
+                Gizmos.DrawCube(ctr, new Vector3(CellSize * 0.9f, 0.05f, CellSize * 0.9f));
+            }
+    }
+}

--- a/extensions/renderers/unity/scripts/IntegrationBuilder.cs
+++ b/extensions/renderers/unity/scripts/IntegrationBuilder.cs
@@ -1,0 +1,587 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+
+/// <summary>
+/// INTEGRATION STEP — WorldOS Unity sprint, 2026-06-22
+/// Combines WS-B block-out with WS-C painterly assets:
+///   1. Painted backdrop fills the scene
+///   2. Invisible occluder proxies at fixture prop cells
+///   3. GLB hero_fighter + monster_goblin actors at spawn cells
+///   4. Tactical grid overlay on the painted floor
+///   5. Correct warm-key lighting
+/// Run via: Tools → WorldOS → Build Integration Frame
+/// </summary>
+public class IntegrationBuilder
+{
+    // ── fixture constants (matches TavernTier1Builder) ─────────────────────
+    const int   COLS      = 14;
+    const int   ROWS      = 10;
+    const float CELL_SIZE = 5f;
+
+    static float OriginX => -(COLS * CELL_SIZE) / 2f;  // = -35
+    const float OriginZ  = 0f;
+
+    // height bands
+    const float TALL_H = 3.0f;
+    const float MID_H  = 1.8f;
+    const float LOW_H  = 1.0f;
+    const float ACTOR_SCALE = 0.82f;
+
+    // ── fixture props (anchor_cell + height_band) ──────────────────────────
+    struct PropProxy
+    {
+        public string id;
+        public int minC, maxC, minR, maxR;
+        public string height_band;
+    }
+
+    static readonly PropProxy[] PropProxies = new PropProxy[]
+    {
+        new PropProxy { id="bar",     minC=1,maxC=4,  minR=1,maxR=1, height_band="tall" },
+        new PropProxy { id="hearth",  minC=11,maxC=12,minR=1,maxR=1, height_band="tall" },
+        new PropProxy { id="table1",  minC=4,maxC=5,  minR=4,maxR=4, height_band="mid"  },
+        new PropProxy { id="table2",  minC=8,maxC=9,  minR=5,maxR=5, height_band="mid"  },
+        new PropProxy { id="barrels", minC=2,maxC=2,  minR=7,maxR=7, height_band="low"  },
+    };
+
+    // ── spawns ─────────────────────────────────────────────────────────────
+    static readonly (int c, int r) PartySpawn0 = (6, 8);   // HERO
+    static readonly (int c, int r) FoeSpawn0   = (6, 2);   // MONSTER (near bar — behind bar for occlusion test)
+
+    // ── lighting ──────────────────────────────────────────────────────────
+    static readonly Color KEY_COLOR     = new Color(1.000f, 0.604f, 0.271f, 1f); // #ff9a45
+    static readonly Color AMBIENT_COLOR = new Color(0.227f, 0.247f, 0.333f, 1f); // #3a3f55
+
+    // ─────────────────────────────────────────────────────────────────────
+    [MenuItem("Tools/WorldOS/Build Integration Frame")]
+    public static void Build()
+    {
+        // ── 1. Tear down previous integration root if any ─────────────────
+        var oldRoot = GameObject.Find("IntegrationRoot");
+        if (oldRoot != null) Object.DestroyImmediate(oldRoot);
+
+        // ── 2. Find TavernTier1 B-workstream children ─────────────────────
+        // Hide visible primitives: Walls, Floor_Grid, and primitive Props/Actors
+        // KEEP the Backdrop_DepthBlit (has the painterly texture) — we'll replace its
+        // material with Unlit/Texture since depth-blit NO-OPs on Metal TBDR.
+        HidePrimitiveBGeometry();
+
+        // ── 3. Fix up backdrop: Unlit/Texture, full-screen quad ───────────
+        FixBackdrop();
+
+        // ── 4. Create integration root ────────────────────────────────────
+        var root = new GameObject("IntegrationRoot");
+
+        // ── 5. Invisible occluder proxies ─────────────────────────────────
+        BuildOccluderProxies(root);
+
+        // ── 6. Place GLB actors ───────────────────────────────────────────
+        PlaceActors(root);
+
+        // ── 7. Tactical grid overlay ──────────────────────────────────────
+        BuildGridOverlay(root);
+
+        // ── 8. Lighting ───────────────────────────────────────────────────
+        SetupLighting();
+
+        // ── 9. Flush ──────────────────────────────────────────────────────
+        EditorUtility.SetDirty(root);
+        UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(
+            UnityEngine.SceneManagement.SceneManager.GetActiveScene());
+
+        Debug.Log("[Integration] Build complete — painterly backdrop + occluders + GLB actors + grid.");
+    }
+
+    // ── HIDE B primitive geometry ─────────────────────────────────────────
+    static void HidePrimitiveBGeometry()
+    {
+        var t1Root = GameObject.Find("TavernTier1");
+        if (t1Root == null) { Debug.LogWarning("[Integration] TavernTier1 not found."); return; }
+
+        // Disable renderers on Walls, Floor_Grid, Props, Actors children
+        string[] hideNames = { "Floor_Grid", "Walls", "Props", "Actors" };
+        foreach (string n in hideNames)
+        {
+            var child = t1Root.transform.Find(n);
+            if (child == null) continue;
+            foreach (var r in child.GetComponentsInChildren<Renderer>())
+                r.enabled = false;
+        }
+        Debug.Log("[Integration] Hidden B primitive geometry (Floor/Walls/Props/Actors).");
+    }
+
+    // ── FIX BACKDROP: switch from depth-blit (TBDR no-op) to Unlit/Texture ─
+    static void FixBackdrop()
+    {
+        // The B workstream placed a Backdrop_DepthBlit quad; we reuse it.
+        // Switch material to Unlit/Texture + correct sizing/positioning.
+        var t1Root = GameObject.Find("TavernTier1");
+        GameObject bdGO = null;
+        if (t1Root != null)
+        {
+            var bdChild = t1Root.transform.Find("Backdrop_DepthBlit");
+            if (bdChild != null) bdGO = bdChild.gameObject;
+        }
+        if (bdGO == null) bdGO = GameObject.Find("Backdrop_DepthBlit");
+
+        if (bdGO == null)
+        {
+            // Create a new backdrop quad
+            bdGO = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            bdGO.name = "Backdrop_DepthBlit";
+            var t1 = GameObject.Find("TavernTier1");
+            if (t1 != null) bdGO.transform.SetParent(t1.transform, false);
+            Debug.LogWarning("[Integration] Backdrop_DepthBlit not found; created new quad.");
+        }
+
+        // Build unlit material with painterly texture
+        Texture2D tex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/tavern_backdrop.png");
+        if (tex == null) tex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/tavern_backdrop.png");
+
+        // Use BackdropUnlit shader: ZWrite=Off, ZTest=Always — no depth blocking of actors
+        var backdropShader = Shader.Find("WorldOS/BackdropUnlit");
+        if (backdropShader == null) backdropShader = Shader.Find("Unlit/Texture");
+        var mat = new Material(backdropShader);
+        if (tex != null)
+        {
+            mat.mainTexture = tex;
+            Debug.Log("[Integration] Painterly backdrop texture loaded: " + tex.width + "x" + tex.height + " shader=" + backdropShader.name);
+        }
+        else
+        {
+            Debug.LogError("[Integration] Could not load tavern_backdrop.png!");
+        }
+        // Render before geometry (sky/backdrop layer); ZWrite=Off ensures actors render on top
+        mat.renderQueue = 900;
+        AssetDatabase.DeleteAsset("Assets/BackdropMat_T1.mat");
+        AssetDatabase.CreateAsset(mat, "Assets/BackdropMat_T1.mat");
+
+        var rend = bdGO.GetComponent<Renderer>();
+        rend.sharedMaterial = mat;
+        rend.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        rend.receiveShadows = false;
+
+        // ── Reposition: the backdrop is a camera-facing full-screen quad.
+        // Camera: ortho, pitch 26.565°, position (0, ~40.25, -55.2) looking at grid centre.
+        // The backdrop should be placed at the back of the scene (z≈0) tilted to face camera
+        // so its face is perpendicular to the view direction.
+        // 
+        // 1024×1024 texture on a dimetric grid that's 14×10 cells @ 5 ft.
+        // The backdrop was generated from the fixture plate at these grid proportions.
+        // We want it to cover the full camera viewport.
+        //
+        // STRATEGY: place a large quad at the back wall (z=-5), tilt it to face the camera
+        // (pitch = 90 - 26.565 = 63.435°), and scale it to fill the ortho viewport.
+        // OrthoSize=18 means ±18 units tall in screen-space.
+        // Camera aspect ~ 16:9 (game view), so ±32 wide.
+        // We need the quad to be larger to avoid cropping.
+        //
+        // But 1024² is square; the grid's dimetric frame as seen by the camera has a
+        // specific aspect. We scale the quad so the PAINTING fills the camera frustum.
+        // 
+        // The painterly image was generated FROM the 2:1 dimetric plate, so the painted
+        // room occupies the full 1024×1024. The camera's ortho view has aspect ~16:9 but
+        // orthoSize=18 → half-height=18 units in projected space.
+        // 
+        // In world space the backdrop quad scales map to projected screen extents.
+        // Scale X = 2 * orthoSize * aspect (full width at ortho projection)
+        // Scale Y = 2 * orthoSize (full height)
+        // But since the quad is tilted 63.435°, its worldspace Y needs to be larger:
+        // worldH = screenH / cos(63.435°)   ... the foreshortening factor.
+        // cos(63.435°) ≈ 0.4472 → worldH ≈ screenH / 0.4472
+        //
+        // orthoSize = 18 → screenH = 36 units.
+        // worldH = 36 / 0.4472 ≈ 80.5
+        // screenW ~ 36 * (16/9) = 64 units. (assume 16:9 game view)
+        // worldW = 64 (no tilt in X)
+        //
+        // But the painterly image is 1024×1024 (square), so if worldW=64 and worldH=80.5,
+        // the image will look stretched vertically. 
+        //
+        // CORRECT APPROACH: the backdrop captures the full scene in the camera's 2:1 view.
+        // The texture IS what the camera sees in a flat-2D sense (it's basically a 
+        // pre-rendered frame). So we want it to fill the CAMERA FRUSTUM exactly.
+        // Scale the quad to match the camera's near-clip projected rectangle,
+        // PERPENDICULAR TO THE CAMERA VIEW DIRECTION.
+        //
+        // Simpler: scale worldW = gameViewAspect * 2*orthoSize * 1.1 (10% bleed)
+        //          worldH = 2*orthoSize / cos(tiltRad) * 1.1
+        // Position: at z of back wall, Y raised to centre of scene.
+        //
+        // Actually simplest for this spike: just set transform to fill screen.
+        // We'll position it in world space so it's behind all geometry.
+
+        float pitchRad = Mathf.Atan(0.5f);   // 26.565°
+        float tiltDeg  = 90f - Mathf.Rad2Deg * pitchRad;  // 63.435°
+        float tiltRad  = Mathf.Deg2Rad * tiltDeg;
+
+        float orthoSize    = 18f;
+        float gameAspect   = 16f / 9f;  // approximate; will fill in any case
+        float screenHWorld = 2f * orthoSize;
+        float screenWWorld = screenHWorld * gameAspect;
+
+        // World-space scale of the tilted quad to cover screen:
+        // X: no foreshortening → match screen width + bleed
+        // Y: foreshortened by cos(tiltDeg); divide to compensate
+        float quadW = screenWWorld * 1.15f;
+        float quadH = (screenHWorld / Mathf.Cos(tiltRad)) * 1.15f;
+
+        // But texture is 1024×1024 — if we distort aspect, painting looks wrong.
+        // The painted room fills the frame correctly at the grid's dimetric aspect.
+        // The dimetric view of a 14×10 grid has a NATURAL aspect ratio:
+        //   projected width  = 14 * cos(30°) * CELL  (2:1 dimetric, 30° hex angle)
+        //   Actually 2:1 dimetric: each cell projects at 2:1 so the grid appears as
+        //   a 2*(14)*1 : (10)*1 = 28:10 = 2.8:1 horizontal.
+        // The scene from the camera IS roughly 16:9 but let's just use the quad's
+        // scale to match the camera frustum width and accept the image fills it.
+        // 
+        // 1024×1024 → if worldW != worldH in screen-projected pixels, the image stretches.
+        // For now: make quad aspect match screen aspect (16:9 if game view is 16:9).
+        // Alignment will be approximate; owner will calibrate.
+
+        // Grid centre in world: X=0, Z=25 (half of ROWS*CELL_SIZE)
+        // Camera pulls back 90 units from grid centre.
+        // Backdrop z: at the back wall z = 0 - 2 = -2 (behind row 0 wall).
+        float backdropZ = -2f;
+        // Y position: the backdrop's world Y = some value so it appears centred.
+        // In camera space the quad centre should be at Y that maps to screen centre.
+        // Camera points at (0, 0, 25) in world space... but with pitchDeg = 26.565°
+        // and position at (0, ~40, -55), the view ray hits the grid at Y~0.
+        // The backdrop's visual centre in screen-space is at roughly the scene mid-point.
+        // The upper half of the backdrop should show the back wall/ceiling of the painting.
+        // Empirically, raising the quad Y to ~ ROWS*CELL*0.6 = 30 puts the painted
+        // floor in the lower portion, painted wall in the upper — matching what the 
+        // camera sees of the block-out.
+        float backdropY = ROWS * CELL_SIZE * 0.55f;  // ~27.5
+
+        bdGO.transform.localPosition   = new Vector3(0f, backdropY, backdropZ);
+        bdGO.transform.localEulerAngles = new Vector3(tiltDeg, 0f, 0f);
+        bdGO.transform.localScale       = new Vector3(quadW, quadH, 1f);
+
+        Debug.Log($"[Integration] Backdrop: pos=(0,{backdropY:F1},{backdropZ}), rot=({tiltDeg:F1},0,0), scale=({quadW:F1},{quadH:F1},1)");
+    }
+
+    // ── OCCLUDER PROXIES ──────────────────────────────────────────────────
+    static void BuildOccluderProxies(GameObject root)
+    {
+        // Depth-write only (colour mask = 0) material so proxies write to Z-buffer
+        // but are invisible. Actors behind a proxy will be z-rejected.
+        // On Metal TBDR, depth writes from opaque pass (queue < 2500) ARE retained.
+        // We use an opaque shader with ColorMask 0 via a custom material tweak.
+        //
+        // Since we can't inline HLSL here, we use Standard with full alpha=1 black,
+        // renderQueue=2499, and set ColorMask via SetInt. The key is it must be
+        // in the opaque queue so TBDR's depth tile is NOT discarded.
+        //
+        // Actually the simplest TBDR-safe occluder: Standard material, black color,
+        // renderQueue = 1500 (before geometry), ZWrite On, ColorMask 0.
+        // In Built-in RP: set material.SetInt("_ColorMask", 0) disables color writes.
+        
+        // Prefer depth-only shader (invisible + ZWrite=On). Falls back to disabled renderer.
+        var depthShader = Shader.Find("WorldOS/OccluderDepthOnly");
+        Material occluderMat;
+        bool useDepthShader = (depthShader != null);
+        if (useDepthShader)
+        {
+            occluderMat = new Material(depthShader);
+            occluderMat.renderQueue = 1999;  // just before actors (2000)
+            Debug.Log("[Integration] Using depth-only occluder shader.");
+        }
+        else
+        {
+            // Fallback: standard opaque black -- will be visible but provides depth for actors
+            occluderMat = new Material(Shader.Find("Standard"));
+            occluderMat.color = new Color(0.05f, 0.04f, 0.03f, 1f);  // near-black
+            occluderMat.SetFloat("_Metallic", 0f);
+            occluderMat.SetFloat("_Glossiness", 0f);
+            occluderMat.renderQueue = 1999;
+            Debug.LogWarning("[Integration] Depth-only shader unavailable; occluders will be visible as dark boxes.");
+        }
+        AssetDatabase.DeleteAsset("Assets/OccluderMat.mat");
+        AssetDatabase.CreateAsset(occluderMat, "Assets/OccluderMat.mat");
+
+        var occParent = new GameObject("OccluderProxies");
+        occParent.transform.SetParent(root.transform, false);
+
+        foreach (var p in PropProxies)
+        {
+            float h = HeightFromBand(p.height_band);
+            float spanX = (p.maxC - p.minC + 1) * CELL_SIZE * 0.92f;
+            float spanZ = (p.maxR - p.minR + 1) * CELL_SIZE * 0.92f;
+            float cx = OriginX + (p.minC + p.maxC + 1) * CELL_SIZE * 0.5f;
+            float cz = OriginZ + (p.minR + p.maxR + 1) * CELL_SIZE * 0.5f;
+
+            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            go.name = $"Occluder_{p.id}";
+            go.transform.SetParent(occParent.transform, false);
+            go.transform.localPosition = new Vector3(cx, h * 0.5f, cz);
+            go.transform.localScale    = new Vector3(spanX, h, spanZ);
+
+            var r = go.GetComponent<Renderer>();
+            r.sharedMaterial = occluderMat;
+            r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            r.receiveShadows    = false;
+
+            // Verify: remove collider (not needed)
+            Object.DestroyImmediate(go.GetComponent<BoxCollider>());
+        }
+
+        Debug.Log($"[Integration] Built {PropProxies.Length} occluder proxies.");
+    }
+
+    // ── PLACE GLB ACTORS ──────────────────────────────────────────────────
+    static void PlaceActors(GameObject root)
+    {
+        var actorParent = new GameObject("GLBActors");
+        actorParent.transform.SetParent(root.transform, false);
+
+        // Hero fighter — party spawn 0 = (6, 8)
+        PlaceGLBAt(actorParent, "HeroFighter",
+            "Assets/painterly/hero_fighter/model.fbx",
+            PartySpawn0.c, PartySpawn0.r,
+            KEY_COLOR, AMBIENT_COLOR, isHero: true);
+
+        // Monster goblin — foe spawn 0 = (6, 2)  → this cell is NEAR the bar occluder at row 1
+        // → useful occlusion test: monster partially behind bar
+        PlaceGLBAt(actorParent, "MonsterGoblin",
+            "Assets/painterly/monster_goblin/model.fbx",
+            FoeSpawn0.c, FoeSpawn0.r,
+            KEY_COLOR, AMBIENT_COLOR, isHero: false);
+
+        Debug.Log("[Integration] Placed GLB actors.");
+    }
+
+    static void PlaceGLBAt(GameObject parent, string label, string glbPath,
+                            int c, int r, Color keyColor, Color ambColor, bool isHero)
+    {
+        var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(glbPath);
+        if (prefab == null)
+        {
+            Debug.LogError($"[Integration] GLB not found: {glbPath}");
+            return;
+        }
+
+        var go = (GameObject)PrefabUtility.InstantiatePrefab(prefab);
+        go.name = label;
+        go.transform.SetParent(parent.transform, false);
+
+        // Scale: actor should read as ~human height in the painted tavern.
+        // Grid cell = 5 ft. A human is ~6 ft = 6 units.
+        // FBX models from Meshy/Blender export embed a root scale of 100 (cm→m).
+        // We want world height ≈ 4.5 units.
+        // Strategy: measure current world bounds at the FBX prefab's natural scale,
+        // then MULTIPLY the existing localScale to reach targetHeight.
+        float targetHeight = 4.5f;
+        // Temporarily place far away to measure bounds at natural scale
+        go.transform.position = new Vector3(9999f, 0f, 9999f);
+        var bounds = GetBoundsLocal(go);
+        float currentH = bounds.size.y > 0.01f ? bounds.size.y : 2.0f;
+        float scaleMult = targetHeight / currentH;
+        // MULTIPLY existing localScale (don't override — FBX root may already have scale)
+        var existing = go.transform.localScale;
+        go.transform.localScale = new Vector3(existing.x * scaleMult,
+                                               existing.y * scaleMult,
+                                               existing.z * scaleMult);
+
+        // Position: cell centre, sit bottom on floor (Y=0)
+        float wx = OriginX + (c + 0.5f) * CELL_SIZE;
+        float wz = OriginZ + (r + 0.5f) * CELL_SIZE;
+        // Re-measure bounds after scale applied to get the floor Y offset
+        var scaledBounds = GetBoundsLocal(go);
+        float floorY = scaledBounds.min.y < -0.1f ? -scaledBounds.min.y : 0f;
+        go.transform.position = new Vector3(wx, floorY, wz);
+
+        // Face camera (roughly): rotate 180° so front faces -Z (camera direction)
+        // Rotate to stand upright: Blender GLB→FBX has Z-up, Unity expects Y-up
+        go.transform.localEulerAngles = new Vector3(-90f, 180f, 0f);
+
+        // Warm lighting via material tint on all renderers
+        // (directional key light already lit them; boost cohesion with a slight tint)
+        foreach (var rend in go.GetComponentsInChildren<Renderer>())
+        {
+            foreach (var m in rend.sharedMaterials)
+            {
+                if (m == null) continue;
+                // Nudge base color toward key for cohesion (don't overwrite if Standard)
+                if (m.HasProperty("_Color"))
+                {
+                    Color orig = m.color;
+                    // Subtle warm tint: lerp 15% toward key light color
+                    m.color = Color.Lerp(orig, keyColor, isHero ? 0.12f : 0.08f);
+                }
+            }
+        }
+
+        // Contact shadow disc under actor
+        BuildContactShadow(parent, label + "_Shadow", c, r,
+            scaleMult * 0.9f, scaleMult * 0.65f);
+
+        Debug.Log($"[Integration] Placed {label} at ({c},{r}) scaleMult={scaleMult:F2} h={currentH:F2}");
+    }
+
+    static Bounds GetBoundsLocal(GameObject go)
+    {
+        var renderers = go.GetComponentsInChildren<Renderer>();
+        if (renderers.Length == 0) return new Bounds(Vector3.zero, Vector3.one * 1.8f);
+        var b = renderers[0].bounds;
+        for (int i = 1; i < renderers.Length; i++)
+            b.Encapsulate(renderers[i].bounds);
+        return b;
+    }
+
+    static void BuildContactShadow(GameObject parent, string name, int c, int r, float rx, float rz)
+    {
+        var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        go.name = name;
+        go.transform.SetParent(parent.transform, false);
+        go.transform.localScale    = new Vector3(rx * 2f, 0.04f, rz * 2f);
+        go.transform.localPosition = new Vector3(
+            OriginX + (c + 0.5f) * CELL_SIZE,
+            0.02f,
+            OriginZ + (r + 0.5f) * CELL_SIZE);
+        Object.DestroyImmediate(go.GetComponent<SphereCollider>());
+
+        var mat = new Material(Shader.Find("Standard"));
+        mat.color = new Color(0f, 0f, 0f, 0.55f);
+        mat.SetFloat("_Mode", 3f);
+        mat.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+        mat.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+        mat.SetInt("_ZWrite", 0);
+        mat.DisableKeyword("_ALPHATEST_ON");
+        mat.EnableKeyword("_ALPHABLEND_ON");
+        mat.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+        mat.renderQueue = 3000;
+        go.GetComponent<Renderer>().sharedMaterial = mat;
+        go.GetComponent<Renderer>().shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        go.GetComponent<Renderer>().receiveShadows    = false;
+    }
+
+    // ── TACTICAL GRID OVERLAY ─────────────────────────────────────────────
+    static void BuildGridOverlay(GameObject root)
+    {
+        // Draw walkable dimetric grid lines on the floor using LineRenderer objects.
+        // Colour: semi-transparent warm yellow, thin lines.
+        // Toggle-able: we parent them under "GridOverlay" which can be enabled/disabled.
+        var gridRoot = new GameObject("GridOverlay");
+        gridRoot.transform.SetParent(root.transform, false);
+
+        Color walkableColor = new Color(0.9f, 0.75f, 0.3f, 0.35f); // semi-transparent gold
+        float lineW = 0.12f;
+        float yFloor = 0.05f; // just above floor
+
+        // Build a set of blocked cells from fixture
+        var blocked = new HashSet<(int, int)>();
+        // Walls (row 0 full, column 0 and 13 rows 1-8)
+        for (int c2 = 0; c2 < COLS; c2++) blocked.Add((c2, 0));
+        for (int r2 = 1; r2 <= 8; r2++) { blocked.Add((0, r2)); blocked.Add((13, r2)); }
+        // Props
+        foreach (var p in PropProxies)
+            for (int c2 = p.minC; c2 <= p.maxC; c2++)
+                for (int r2 = p.minR; r2 <= p.maxR; r2++)
+                    blocked.Add((c2, r2));
+
+        int lineIdx = 0;
+        // Draw a small diamond/square at each WALKABLE cell centre
+        for (int col = 0; col < COLS; col++)
+        {
+            for (int row = 0; row < ROWS; row++)
+            {
+                if (blocked.Contains((col, row))) continue;
+                DrawCellMarker(gridRoot, col, row, yFloor, lineW, walkableColor, ref lineIdx);
+            }
+        }
+        Debug.Log($"[Integration] Grid overlay: {lineIdx} cell markers.");
+    }
+
+    static void DrawCellMarker(GameObject parent, int c, int r, float y,
+                                float lw, Color col, ref int idx)
+    {
+        // Draw a small cross at the cell centre (like a tactical grid tile indicator)
+        float cx = OriginX + (c + 0.5f) * CELL_SIZE;
+        float cz = OriginZ + (r + 0.5f) * CELL_SIZE;
+        float size = CELL_SIZE * 0.35f;  // half-size of tick marks
+
+        // Horizontal tick
+        var goH = new GameObject($"GridTick_{idx}_H");
+        goH.transform.SetParent(parent.transform, false);
+        var lrH = goH.AddComponent<LineRenderer>();
+        lrH.useWorldSpace = true;
+        lrH.startWidth = lw; lrH.endWidth = lw;
+        lrH.material = GridLineMat(col);
+        lrH.startColor = col; lrH.endColor = col;
+        lrH.positionCount = 2;
+        lrH.SetPosition(0, new Vector3(cx - size, y, cz));
+        lrH.SetPosition(1, new Vector3(cx + size, y, cz));
+        lrH.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        lrH.receiveShadows    = false;
+
+        // Vertical tick (Z axis)
+        var goV = new GameObject($"GridTick_{idx}_V");
+        goV.transform.SetParent(parent.transform, false);
+        var lrV = goV.AddComponent<LineRenderer>();
+        lrV.useWorldSpace = true;
+        lrV.startWidth = lw; lrV.endWidth = lw;
+        lrV.material = GridLineMat(col);
+        lrV.startColor = col; lrV.endColor = col;
+        lrV.positionCount = 2;
+        lrV.SetPosition(0, new Vector3(cx, y, cz - size));
+        lrV.SetPosition(1, new Vector3(cx, y, cz + size));
+        lrV.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        lrV.receiveShadows    = false;
+
+        idx++;
+    }
+
+    static Material _gridMat;
+    static Material GridLineMat(Color c)
+    {
+        if (_gridMat != null) return _gridMat;
+        _gridMat = new Material(Shader.Find("Sprites/Default"));
+        _gridMat.color = c;
+        return _gridMat;
+    }
+
+    // ── LIGHTING ──────────────────────────────────────────────────────────
+    static void SetupLighting()
+    {
+        var lightGO = GameObject.Find("Directional Light");
+        if (lightGO == null)
+        {
+            lightGO = new GameObject("Directional Light");
+            lightGO.AddComponent<Light>().type = LightType.Directional;
+        }
+        var lt = lightGO.GetComponent<Light>();
+        lt.color     = KEY_COLOR;
+        lt.intensity = 1.2f;
+        lt.shadows   = LightShadows.Soft;
+        lt.shadowStrength = 0.55f;
+        lt.shadowBias = 0.04f;
+        lightGO.transform.eulerAngles = new Vector3(38f, 30f, 0f);
+
+        RenderSettings.ambientMode      = UnityEngine.Rendering.AmbientMode.Flat;
+        RenderSettings.ambientLight     = AMBIENT_COLOR;
+        RenderSettings.ambientIntensity = 0.9f;
+
+        Debug.Log("[Integration] Lighting set: key=#ff9a45, ambient=#3a3f55.");
+    }
+
+    // ── HELPERS ───────────────────────────────────────────────────────────
+    static float HeightFromBand(string band) => band switch
+    {
+        "tall" => TALL_H,
+        "mid"  => MID_H,
+        "low"  => LOW_H,
+        _      => MID_H,
+    };
+
+    // ── SCREENSHOT HELPER ─────────────────────────────────────────────────
+    [MenuItem("Tools/WorldOS/Capture Integration Frame")]
+    public static void CaptureFrame()
+    {
+        System.IO.Directory.CreateDirectory("Captures");
+        string fname = "unity_integration_frame";
+        ScreenCapture.CaptureScreenshot($"Captures/{fname}.png", 2);
+        Debug.Log($"[Integration] Screenshot saved: Captures/{fname}.png");
+    }
+}

--- a/extensions/renderers/unity/scripts/IsoHeroRender.cs
+++ b/extensions/renderers/unity/scripts/IsoHeroRender.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+
+// Render the in-scene HERO actor in ISOLATION (no plate, no goblin, no shadow) against a neutral
+// background, framed tight, for the OFFLINE Scenario img2img paint-pass (ceiling-proof evidence).
+public static class IsoHeroRender
+{
+    [MenuItem("Tools/WorldOS/CL/Z Render Hero Isolated")]
+    public static void RenderHeroIso()
+    {
+        var root = GameObject.Find("ClosedLoopRoot");
+        if (root == null) { Debug.LogError("[ISO] no ClosedLoopRoot"); return; }
+        Transform hero = null;
+        foreach (var t in root.GetComponentsInChildren<Transform>(true))
+            if (t.name == "HeroFighter") { hero = t; break; }
+        if (hero == null) { Debug.LogError("[ISO] no HeroFighter"); return; }
+
+        var cam = Camera.main;
+        var all = root.GetComponentsInChildren<Renderer>(true);
+        var prev = new Dictionary<Renderer, bool>();
+        foreach (var r in all) { prev[r] = r.enabled; r.enabled = false; }
+        foreach (var r in hero.GetComponentsInChildren<Renderer>(true)) r.enabled = true;
+
+        // frame the hero: temporarily reposition an ISOLATED camera (don't disturb the locked one).
+        var isoGO = new GameObject("IsoCam");
+        var iso = isoGO.AddComponent<Camera>();
+        iso.orthographic = true;
+        var hb = new Bounds(hero.position, Vector3.one * 0.1f);
+        foreach (var r in hero.GetComponentsInChildren<Renderer>()) hb.Encapsulate(r.bounds);
+        // Start from the LOCKED main camera (which correctly frames the room), then DOLLY along the
+        // camera's local right/up so the hero's world-center projects to the frame center, and shrink
+        // orthoSize to fill. An ortho camera's projection is position-invariant in depth, so sliding it
+        // in its own right/up plane just recomposes — the dimetric pitch is preserved.
+        iso.transform.position = cam.transform.position;
+        iso.transform.rotation = cam.transform.rotation;     // same dimetric pitch
+        iso.orthographic = true;
+        iso.orthographicSize = Mathf.Max(2.5f, hb.size.y * 0.66f);
+        iso.aspect = 768f / 1024f;
+        // shift camera so hero center is centered: project hero center to viewport, move by the delta.
+        Vector3 vp = iso.WorldToViewportPoint(hb.center);
+        Vector3 right = iso.transform.right;
+        Vector3 up = iso.transform.up;
+        float worldH = iso.orthographicSize * 2f;
+        float worldW = worldH * iso.aspect;
+        iso.transform.position += right * ((vp.x - 0.5f) * worldW) + up * ((vp.y - 0.5f) * worldH);
+        iso.clearFlags = CameraClearFlags.SolidColor;
+        iso.backgroundColor = new Color(0.5f, 0.5f, 0.52f, 1f);
+        iso.nearClipPlane = 0.1f; iso.farClipPlane = 200f;
+        iso.aspect = 768f / 1024f;
+
+        var rt = new RenderTexture(768, 1024, 24, RenderTextureFormat.ARGB32); rt.Create();
+        iso.targetTexture = rt;
+        iso.Render();
+        var t2 = new Texture2D(768, 1024, TextureFormat.RGB24, false);
+        RenderTexture.active = rt; t2.ReadPixels(new Rect(0, 0, 768, 1024), 0, 0); t2.Apply(); RenderTexture.active = null;
+        System.IO.File.WriteAllBytes("/Volumes/LEXAR/WorldOS-Unity-spike/Assets/painterly/hero_iso.png", t2.EncodeToPNG());
+        iso.targetTexture = null; rt.Release();
+        float oszLog = iso.orthographicSize;
+        Object.DestroyImmediate(isoGO);
+        foreach (var r in all) if (prev.ContainsKey(r)) r.enabled = prev[r];
+        AssetDatabase.Refresh();
+        Debug.Log("[ISO] hero_iso.png written (orthoSize " + oszLog.ToString("F2") + ")");
+    }
+}

--- a/extensions/renderers/unity/scripts/IsoSpriteRenderer.cs
+++ b/extensions/renderers/unity/scripts/IsoSpriteRenderer.cs
@@ -1,0 +1,122 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+using System.IO;
+
+/// <summary>
+/// ARM 1A helper: render each in-scene rigged actor (posed to Idle) from the LOCKED
+/// dimetric angle (pitch atan(0.5)=26.565deg) to a transparent-bg high-res PNG, for
+/// Scenario painterly img2img stylization. Output: Assets/painterly/sprites/&lt;id&gt;_raw.png.
+/// </summary>
+public static class IsoSpriteRenderer
+{
+    [MenuItem("Tools/WorldOS/CL/A0 Yaw Probe (hero)")]
+    public static void YawProbe()
+    {
+        var go = GameObject.Find("HeroFighter");
+        if (go == null) { Debug.LogError("[YawProbe] no hero"); return; }
+        var prevE = go.transform.localEulerAngles;
+        float pitch = Mathf.Rad2Deg * Mathf.Atan(0.5f);
+        var allRends = Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None);
+        var rs = go.GetComponentsInChildren<Renderer>();
+        float[] yaws = { 0f, 90f, 180f, 270f };
+        foreach (var yaw in yaws)
+        {
+            go.transform.localEulerAngles = new Vector3(prevE.x, yaw, prevE.z);
+            var b = rs[0].bounds; for (int i = 1; i < rs.Length; i++) b.Encapsulate(rs[i].bounds);
+            var camGO = new GameObject("__P"); var cam = camGO.AddComponent<Camera>();
+            cam.orthographic = true; cam.orthographicSize = b.size.y * 0.62f;
+            cam.clearFlags = CameraClearFlags.SolidColor; cam.backgroundColor = new Color(0.3f, 0.3f, 0.35f, 1f);
+            Vector3 cd = Quaternion.Euler(pitch, 0, 0) * Vector3.forward;
+            camGO.transform.position = b.center - cd * 50f; camGO.transform.rotation = Quaternion.Euler(pitch, 0, 0);
+            var prev = new Dictionary<Renderer, bool>();
+            foreach (var rr in allRends) { prev[rr] = rr.enabled; bool mine = false; foreach (var m in rs) if (m == rr) mine = true; if (!mine) rr.enabled = false; }
+            var rt = new RenderTexture(256, 384, 24); rt.Create(); cam.aspect = 256f / 384f; cam.targetTexture = rt; cam.Render();
+            var pr = RenderTexture.active; RenderTexture.active = rt; var tex = new Texture2D(256, 384, TextureFormat.RGB24, false);
+            tex.ReadPixels(new Rect(0, 0, 256, 384), 0, 0); tex.Apply();
+            File.WriteAllBytes("/tmp/yaw_" + yaw.ToString("F0") + ".png", tex.EncodeToPNG());
+            RenderTexture.active = pr; cam.targetTexture = null; rt.Release(); Object.DestroyImmediate(tex);
+            foreach (var rr in allRends) rr.enabled = prev[rr]; Object.DestroyImmediate(camGO);
+        }
+        go.transform.localEulerAngles = prevE;
+        Debug.Log("[YawProbe] wrote /tmp/yaw_{0,90,180,270}.png");
+    }
+
+    [MenuItem("Tools/WorldOS/CL/A Render Iso Sprites (raw)")]
+    public static void RenderIsoSprites()
+    {
+        string dir = "Assets/painterly/sprites";
+        if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+        float pitch = Mathf.Rad2Deg * Mathf.Atan(0.5f);
+        string[] names = { "HeroFighter", "MonsterGoblin" };
+        string[] outs = { "hero_idle", "goblin_idle" };
+
+        var allRends = Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None);
+        for (int k = 0; k < names.Length; k++)
+        {
+            var go = GameObject.Find(names[k]);
+            if (go == null) { Debug.LogError("[IsoSprite] not found: " + names[k]); continue; }
+
+            // Face the actor TOWARD the camera for a 3/4 FRONT sprite (the in-scene pose
+            // yaws ~180 = facing away; the player wants the face). Hero angled camera-left,
+            // goblin camera-right so a future composite can angle them at each other.
+            var prevEuler = go.transform.localEulerAngles;
+            // VERIFIED via yaw-probe: yaw 180 turns the FACE toward the iso cam (yaw 0 = back).
+            // Gentle 3/4 offset keeps the face visible while breaking dead face-on symmetry.
+            float frontYaw = 180f + ((k == 0) ? -15f : 15f);   // hero right-3/4, goblin left-3/4
+            go.transform.localEulerAngles = new Vector3(prevEuler.x, frontYaw, prevEuler.z);
+
+            var rs = go.GetComponentsInChildren<Renderer>();
+            var b = rs[0].bounds;
+            for (int i = 1; i < rs.Length; i++) b.Encapsulate(rs[i].bounds);
+
+            var camGO = new GameObject("__IsoCam");
+            var cam = camGO.AddComponent<Camera>();
+            cam.orthographic = true;
+            cam.orthographicSize = b.size.y * 0.62f;
+            cam.clearFlags = CameraClearFlags.SolidColor;
+            cam.backgroundColor = new Color(0f, 0f, 0f, 0f);
+            cam.nearClipPlane = 0.01f;
+            cam.farClipPlane = 200f;
+            Vector3 camDir = Quaternion.Euler(pitch, 0f, 0f) * Vector3.forward;
+            camGO.transform.position = b.center - camDir * 50f;
+            camGO.transform.rotation = Quaternion.Euler(pitch, 0f, 0f);
+
+            // isolate this actor (transparent cutout)
+            var prevEnabled = new Dictionary<Renderer, bool>();
+            foreach (var rr in allRends)
+            {
+                prevEnabled[rr] = rr.enabled;
+                bool mine = false;
+                foreach (var m in rs) if (m == rr) mine = true;
+                if (!mine) rr.enabled = false;
+            }
+
+            int H = 1024;
+            int W = Mathf.Clamp(Mathf.RoundToInt(H * (b.size.x * 1.3f) / (cam.orthographicSize * 2f)), 256, 1024);
+            cam.aspect = (float)W / H;
+            var rt = new RenderTexture(W, H, 24, RenderTextureFormat.ARGB32);
+            rt.antiAliasing = 4;
+            rt.Create();
+            cam.targetTexture = rt;
+            cam.Render();
+            var prevRT = RenderTexture.active;
+            RenderTexture.active = rt;
+            var tex = new Texture2D(W, H, TextureFormat.RGBA32, false);
+            tex.ReadPixels(new Rect(0, 0, W, H), 0, 0);
+            tex.Apply();
+            File.WriteAllBytes(dir + "/" + outs[k] + "_raw.png", tex.EncodeToPNG());
+            RenderTexture.active = prevRT;
+            cam.targetTexture = null;
+            rt.Release();
+            Object.DestroyImmediate(tex);
+
+            foreach (var rr in allRends) rr.enabled = prevEnabled[rr];
+            Object.DestroyImmediate(camGO);
+            go.transform.localEulerAngles = prevEuler;   // restore in-scene pose
+            Debug.Log("[IsoSprite] " + outs[k] + " rendered " + W + "x" + H + " boundsH=" + b.size.y.ToString("F2"));
+        }
+        AssetDatabase.Refresh();
+        Debug.Log("[IsoSprite] done -> " + dir);
+    }
+}

--- a/extensions/renderers/unity/scripts/MiniJson.cs
+++ b/extensions/renderers/unity/scripts/MiniJson.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+/// <summary>
+/// Minimal JSON parser (object -> Dictionary&lt;string,object&gt;, array -> List&lt;object&gt;,
+/// number -> double, string/bool/null as expected). Public-domain-style, trimmed for the
+/// closed-loop fixture loader. Parse only (no serialize). Editor-only use.
+/// </summary>
+public static class MiniJson
+{
+    public static object Parse(string json)
+    {
+        if (string.IsNullOrEmpty(json)) return null;
+        int i = 0;
+        var v = ParseValue(json, ref i);
+        return v;
+    }
+
+    static object ParseValue(string s, ref int i)
+    {
+        SkipWs(s, ref i);
+        if (i >= s.Length) return null;
+        char c = s[i];
+        switch (c)
+        {
+            case '{': return ParseObject(s, ref i);
+            case '[': return ParseArray(s, ref i);
+            case '"': return ParseString(s, ref i);
+            case 't': case 'f': return ParseBool(s, ref i);
+            case 'n': i += 4; return null; // null
+            default:  return ParseNumber(s, ref i);
+        }
+    }
+
+    static Dictionary<string, object> ParseObject(string s, ref int i)
+    {
+        var o = new Dictionary<string, object>();
+        i++; // {
+        while (true)
+        {
+            SkipWs(s, ref i);
+            if (i >= s.Length) break;
+            if (s[i] == '}') { i++; break; }
+            if (s[i] == ',') { i++; continue; }
+            string key = ParseString(s, ref i);
+            SkipWs(s, ref i);
+            if (i < s.Length && s[i] == ':') i++;
+            object val = ParseValue(s, ref i);
+            o[key] = val;
+        }
+        return o;
+    }
+
+    static List<object> ParseArray(string s, ref int i)
+    {
+        var a = new List<object>();
+        i++; // [
+        while (true)
+        {
+            SkipWs(s, ref i);
+            if (i >= s.Length) break;
+            if (s[i] == ']') { i++; break; }
+            if (s[i] == ',') { i++; continue; }
+            a.Add(ParseValue(s, ref i));
+        }
+        return a;
+    }
+
+    static string ParseString(string s, ref int i)
+    {
+        var sb = new StringBuilder();
+        i++; // opening "
+        while (i < s.Length)
+        {
+            char c = s[i++];
+            if (c == '"') break;
+            if (c == '\\' && i < s.Length)
+            {
+                char e = s[i++];
+                switch (e)
+                {
+                    case '"': sb.Append('"'); break;
+                    case '\\': sb.Append('\\'); break;
+                    case '/': sb.Append('/'); break;
+                    case 'b': sb.Append('\b'); break;
+                    case 'f': sb.Append('\f'); break;
+                    case 'n': sb.Append('\n'); break;
+                    case 'r': sb.Append('\r'); break;
+                    case 't': sb.Append('\t'); break;
+                    case 'u':
+                        if (i + 4 <= s.Length)
+                        {
+                            int code = int.Parse(s.Substring(i, 4), NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+                            sb.Append((char)code);
+                            i += 4;
+                        }
+                        break;
+                    default: sb.Append(e); break;
+                }
+            }
+            else sb.Append(c);
+        }
+        return sb.ToString();
+    }
+
+    static object ParseBool(string s, ref int i)
+    {
+        if (s[i] == 't') { i += 4; return true; }
+        i += 5; return false;
+    }
+
+    static object ParseNumber(string s, ref int i)
+    {
+        int start = i;
+        while (i < s.Length && (char.IsDigit(s[i]) || s[i] == '-' || s[i] == '+' || s[i] == '.' || s[i] == 'e' || s[i] == 'E'))
+            i++;
+        string num = s.Substring(start, i - start);
+        double d;
+        if (double.TryParse(num, NumberStyles.Any, CultureInfo.InvariantCulture, out d)) return d;
+        return 0.0;
+    }
+
+    static void SkipWs(string s, ref int i)
+    {
+        while (i < s.Length && char.IsWhiteSpace(s[i])) i++;
+    }
+}

--- a/extensions/renderers/unity/scripts/PathingTestDriver.cs
+++ b/extensions/renderers/unity/scripts/PathingTestDriver.cs
@@ -1,0 +1,112 @@
+using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+
+/// <summary>
+/// PathingTestDriver — WorldOS Unity spike (2026-06-23).
+///
+/// Programmatically exercises GridPathController to prove click-to-move pathing
+/// without requiring mouse input. Issues 4 sequential move commands that
+/// exercise the grid and route around blocked cells.
+///
+/// Attach to any persistent GO in the scene (or "PathManager").
+/// Starts automatically in Play mode via Start().
+/// </summary>
+public class PathingTestDriver : MonoBehaviour
+{
+    [Header("Test sequence — cell targets [col, row]")]
+    public bool AutoRun = true;
+    public float DelayBetweenMoves = 0.5f;
+    public string CaptureBaseName = "Captures/dungeon_path_";
+
+    GridPathController _gpc;
+
+    // DUNGEON pathing test moves (15×12 grid, hero starts at [6,9]):
+    // Blocked cells of note:
+    //   Perimeter walls: row 0, row 11, col 0, col 14 (all blocked)
+    //   Pillars: [2,2] and [12,2]    Rubble: [2,6]
+    //   Sarcophagus: [6,1] and [7,1]  Braziers: [4,1] and [9,1]
+    //
+    // 1. [6,9]  → [7,6]  : walk toward center (open floor, proves basic move)
+    // 2. [7,6]  → [11,6] : walk right across dungeon (avoids rubble [2,6])
+    // 3. [11,6] → [11,3] : walk toward N-E pillar at [12,2], A* must route clear
+    // 4. [11,3] → [3,3]  : long cross-dungeon walk — routes around both pillars
+    //                       ([2,2] and [12,2]), sarcophagus [6,1][7,1], braziers
+    static readonly (int c, int r)[] TestTargets = {
+        (7,  6),   // center floor (open)
+        (11, 6),   // right side open corridor
+        (11, 3),   // near right pillar at [12,2] — A* routes around it
+        (3,  3),   // long left-crossing — around both pillars + sarcophagus
+    };
+
+    void Start()
+    {
+        _gpc = GetComponent<GridPathController>();
+        if (_gpc == null) _gpc = FindObjectOfType<GridPathController>();
+        if (_gpc == null) { Debug.LogError("[TestDriver] No GridPathController in scene!"); return; }
+
+        if (AutoRun)
+            StartCoroutine(RunTestSequence());
+    }
+
+    IEnumerator RunTestSequence()
+    {
+        Debug.Log("[TestDriver] Starting DUNGEON pathing test sequence — " + TestTargets.Length + " moves.");
+        yield return new WaitForSeconds(0.8f); // let Start() settle
+
+        int captureIdx = 1;
+
+        for (int i = 0; i < TestTargets.Length; i++)
+        {
+            var (tc, tr) = TestTargets[i];
+            Debug.Log("[TestDriver] Move " + (i+1) + "/" + TestTargets.Length +
+                      " → target cell [" + tc + "," + tr + "]");
+
+            // Issue the move by calling GridPathController's public API
+            _gpc.MoveToCell(tc, tr);
+
+            // Wait 3 frames so the WalkPath coroutine has time to start + set _moving=true
+            yield return null;
+            yield return null;
+            yield return null;
+
+            // Wait until movement completes (or timeout)
+            float timeout = 60f;
+            float elapsed = 0f;
+            while (_gpc.IsMoving && elapsed < timeout)
+            {
+                elapsed += Time.deltaTime;
+                yield return null;
+            }
+            // Additional wait if not moving (coroutine may have completed very fast or not started)
+            if (!_gpc.IsMoving && elapsed < 1f)
+                yield return new WaitForSeconds(0.5f);  // give time for async move
+
+            if (elapsed >= timeout)
+                Debug.LogWarning("[TestDriver] Move " + (i+1) + " timed out!");
+
+            // Capture a screenshot at arrival
+            yield return new WaitForSeconds(0.2f);
+            string capPath = CaptureBaseName + captureIdx.ToString("D2") + ".png";
+            CaptureScreenshot(capPath);
+            Debug.Log("[TestDriver] Captured: " + capPath);
+            captureIdx++;
+
+            yield return new WaitForSeconds(DelayBetweenMoves);
+        }
+
+        Debug.Log("[TestDriver] Test sequence COMPLETE. Hero at cell [" +
+                  _gpc.HeroCol + "," + _gpc.HeroRow + "].");
+    }
+
+    void CaptureScreenshot(string path)
+    {
+        // Ensure Captures dir exists
+        string dir = System.IO.Path.GetDirectoryName(path);
+        if (!System.IO.Directory.Exists(dir))
+            System.IO.Directory.CreateDirectory(dir);
+
+        // High-res capture: superSize=4 for ~5120px wide (4× the game view)
+        ScreenCapture.CaptureScreenshot(path, 4);
+    }
+}

--- a/extensions/renderers/unity/scripts/RTCapture.cs
+++ b/extensions/renderers/unity/scripts/RTCapture.cs
@@ -1,0 +1,45 @@
+using UnityEngine;
+using UnityEditor;
+using System.IO;
+
+public static class RTCapture
+{
+    [MenuItem("Tools/RT Capture Frames")]
+    public static void CaptureFrames()
+    {
+        var camGO = GameObject.Find("Main Camera");
+        if (camGO == null) { Debug.LogError("No Main Camera"); return; }
+        var cam = camGO.GetComponent<Camera>();
+        var heroGO = GameObject.Find("HeroFighter");
+        var heroAnim = heroGO != null ? heroGO.GetComponentInChildren<Animator>() : null;
+        var gobGO = GameObject.Find("MonsterGoblin");
+        var gobAnim = gobGO != null ? gobGO.GetComponentInChildren<Animator>() : null;
+        int w = 1280, h = 720;
+        var rt = new RenderTexture(w, h, 24, RenderTextureFormat.ARGB32);
+        rt.antiAliasing = 1;
+        rt.Create();
+        var origTarget = cam.targetTexture;
+        cam.targetTexture = rt;
+        float[] nTs = { 0.04f, 0.20f, 0.37f, 0.54f, 0.71f, 0.87f };
+        for (int i = 0; i < nTs.Length; i++)
+        {
+            float nt = nTs[i];
+            if (heroAnim != null) { heroAnim.Play("Attack", -1, nt); heroAnim.Update(0f); }
+            if (gobAnim != null) { gobAnim.Play("Attack", -1, (nt + 0.15f) % 1f); gobAnim.Update(0f); }
+            cam.Render();
+            RenderTexture.active = rt;
+            var tex = new Texture2D(w, h, TextureFormat.RGB24, false);
+            tex.ReadPixels(new Rect(0, 0, w, h), 0, 0);
+            tex.Apply();
+            RenderTexture.active = null;
+            string path = "/Volumes/LEXAR/WorldOS-Unity-spike/Captures/rt_f" + (i+1).ToString("D2") + ".png";
+            File.WriteAllBytes(path, tex.EncodeToPNG());
+            Object.DestroyImmediate(tex);
+            Debug.Log("RT captured frame " + (i+1) + " nT=" + nt);
+        }
+        cam.targetTexture = origTarget;
+        rt.Release();
+        Object.DestroyImmediate(rt);
+        Debug.Log("RT capture DONE");
+    }
+}

--- a/extensions/renderers/unity/scripts/SetupPainterlyScene.cs
+++ b/extensions/renderers/unity/scripts/SetupPainterlyScene.cs
@@ -1,0 +1,133 @@
+using UnityEngine;
+using UnityEditor;
+
+/// <summary>
+/// Editor script - run via Tools > Setup Painterly Scene
+/// Sets up the fake-3D tavern scene with correct materials and camera.
+/// </summary>
+public class SetupPainterlyScene : MonoBehaviour
+{
+    [MenuItem("Tools/Setup Painterly Scene")]
+    public static void Setup()
+    {
+        // --- CAMERA ---
+        var camGO = GameObject.Find("Main Camera");
+        if (camGO != null)
+        {
+            var cam = camGO.GetComponent<Camera>();
+            // Orthographic dimetric: size controls how much world fits vertically
+            cam.orthographic = false; // perspective gives more natural feel for 3D props
+            cam.fieldOfView = 35f;    // narrow FOV = less distortion, closer to ortho look
+            cam.farClipPlane = 100f;
+            cam.nearClipPlane = 0.1f;
+            cam.backgroundColor = new Color(0.05f, 0.04f, 0.03f, 1f); // dark tavern
+            cam.clearFlags = CameraClearFlags.SolidColor;
+            
+            // Position: high back, angled 30° down
+            camGO.transform.position = new Vector3(0f, 5f, -6f);
+            camGO.transform.eulerAngles = new Vector3(28f, 0f, 0f);
+        }
+
+        // --- DIRECTIONAL LIGHT (warm amber candlelight) ---
+        var lightGO = GameObject.Find("Directional Light");
+        if (lightGO != null)
+        {
+            var lt = lightGO.GetComponent<Light>();
+            lt.color = new Color(1.0f, 0.72f, 0.35f, 1f);
+            lt.intensity = 1.1f;
+            lt.shadows = LightShadows.Soft;
+            lt.shadowStrength = 0.6f;
+            lt.shadowBias = 0.05f;
+            lightGO.transform.eulerAngles = new Vector3(35f, -45f, 0f);
+        }
+
+        // --- BACKDROP QUAD: Unlit/Texture so painting renders without lighting tint ---
+        var backdropGO = GameObject.Find("Backdrop");
+        if (backdropGO != null)
+        {
+            backdropGO.transform.position = new Vector3(0f, 3.5f, 9f);
+            backdropGO.transform.eulerAngles = Vector3.zero;
+            backdropGO.transform.localScale = new Vector3(18f, 10.5f, 1f);
+
+            var tex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/tavern_backdrop.png");
+            if (tex != null)
+            {
+                // Built-in pipeline: Unlit/Texture shows painting without lighting
+                var mat = new Material(Shader.Find("Unlit/Texture"));
+                mat.mainTexture = tex;
+                mat.renderQueue = 900; // render before geometry
+                AssetDatabase.CreateAsset(mat, "Assets/BackdropMat.mat");
+                backdropGO.GetComponent<Renderer>().material = mat;
+                var r = backdropGO.GetComponent<Renderer>();
+                r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+                r.receiveShadows = false;
+            }
+            else
+            {
+                Debug.LogWarning("SetupPainterlyScene: tavern_backdrop.png not found in Assets");
+            }
+        }
+
+        // --- ACTOR: Standard lit, muted purple-grey ---
+        var actorGO = GameObject.Find("Actor");
+        if (actorGO != null)
+        {
+            actorGO.transform.position = new Vector3(0f, 1.0f, 3f);
+            actorGO.transform.localScale = new Vector3(0.55f, 1.0f, 0.55f);
+
+            var mat = new Material(Shader.Find("Standard"));
+            mat.color = new Color(0.52f, 0.44f, 0.62f, 1f);
+            mat.SetFloat("_Metallic", 0f);
+            mat.SetFloat("_Glossiness", 0.2f);
+            AssetDatabase.CreateAsset(mat, "Assets/ActorMat.mat");
+            actorGO.GetComponent<Renderer>().material = mat;
+
+            var r = actorGO.GetComponent<Renderer>();
+            r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
+            r.receiveShadows = true;
+        }
+
+        // --- TABLE: dark wood brown, z=1.2 (between camera and actor at z=3) ---
+        var tableGO = GameObject.Find("ForegroundTable");
+        if (tableGO != null)
+        {
+            tableGO.transform.position = new Vector3(0f, 0.45f, 1.2f);
+            tableGO.transform.localScale = new Vector3(3.2f, 0.85f, 1.1f);
+
+            var mat = new Material(Shader.Find("Standard"));
+            mat.color = new Color(0.38f, 0.24f, 0.10f, 1f);
+            mat.SetFloat("_Metallic", 0f);
+            mat.SetFloat("_Glossiness", 0.15f);
+            AssetDatabase.CreateAsset(mat, "Assets/TableMat.mat");
+            tableGO.GetComponent<Renderer>().material = mat;
+
+            var r = tableGO.GetComponent<Renderer>();
+            r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
+            r.receiveShadows = true;
+        }
+
+        // --- FLOOR: dark stone ---
+        var floorGO = GameObject.Find("Floor");
+        if (floorGO != null)
+        {
+            floorGO.transform.position = new Vector3(0f, 0f, 3.5f);
+            floorGO.transform.localScale = new Vector3(3.5f, 1f, 3f);
+
+            var mat = new Material(Shader.Find("Standard"));
+            mat.color = new Color(0.22f, 0.20f, 0.18f, 1f);
+            mat.SetFloat("_Metallic", 0f);
+            mat.SetFloat("_Glossiness", 0.05f);
+            AssetDatabase.CreateAsset(mat, "Assets/FloorMat.mat");
+            floorGO.GetComponent<Renderer>().material = mat;
+
+            var r = floorGO.GetComponent<Renderer>();
+            r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            r.receiveShadows = true;
+        }
+
+        // Refresh
+        AssetDatabase.SaveAssets();
+        AssetDatabase.Refresh();
+        Debug.Log("SetupPainterlyScene: DONE - BuiltIn pipeline, Unlit backdrop");
+    }
+}

--- a/extensions/renderers/unity/scripts/TavernTier1Builder.cs
+++ b/extensions/renderers/unity/scripts/TavernTier1Builder.cs
@@ -1,0 +1,569 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+
+/// <summary>
+/// Workstream B — WorldOS Unity Spike, 2026-06-22
+///
+/// Builds the Tier-1 dimetric block-out from fixture: tavern.scenegrid.json (14×10).
+/// Run via:  Tools → WorldOS → Build Tier-1 Tavern Block-out
+///           Tools → WorldOS → Clear Tier-1 Scene
+///
+/// DESIGN:
+///   • Floor plane: 14×10 cells @ cell_size=5 ft. In Unity units we use 1 unit = 1 ft.
+///   • Grid lies flat at Y=0. Camera is NOT above the grid (spike "grid floats" fix).
+///   • Wall cells: thin dark-stone cubes (h=0.15, tinted dark blue-grey).
+///   • Prop cells: boxes sized by height_band (tall=3.0, mid=1.8, low=1.0 units),
+///     coloured by kind.
+///   • Actor tokens: HERO = Capsule (warm amber, scale 0.82); MONSTER = Sphere+Cube
+///     stack (muted red-violet). Both at spawn cells, Y offset so they sit on floor.
+///   • Elliptical contact shadow: a flattened dark disc under each actor.
+///   • 2:1 Dimetric camera: orthographic, positioned high-back, rotation ~26.57° pitch.
+///   • Lighting: warm key light from ~210° (hearth side) + ambient tinted #3a3f55.
+///   • Backdrop quad: uses existing tavern_backdrop.png with DepthBlitBackdrop shader
+///     for Tier-2 depth-blit; falls back to Unlit/Texture if shader not compiled yet.
+///   • All GameObjects are parented under a root "TavernTier1" for clean tear-down.
+/// </summary>
+public class TavernTier1Builder : MonoBehaviour
+{
+    // ── fixture constants ──────────────────────────────────────────────────
+    const int   COLS      = 14;
+    const int   ROWS      = 10;
+    const float CELL_SIZE = 5f;   // 1 Unity unit = 1 ft, cell = 5 ft square
+
+    // height bands (Y scale in units)
+    const float TALL_H = 3.0f;
+    const float MID_H  = 1.8f;
+    const float LOW_H  = 1.0f;
+    const float WALL_H = 4.0f;   // walls: tall enough to be visible above props
+
+    // actor scale vs props
+    const float ACTOR_SCALE = 0.82f;
+
+    // Grid origin: we centre the grid so x ∈ [-COLS/2*CELL … +COLS/2*CELL], z ∈ [0…ROWS*CELL]
+    // (camera looks from -Z toward +Z)
+    static float OriginX => -(COLS * CELL_SIZE) / 2f;
+    static float OriginZ = 0f;
+
+    // ── wall cells (hand-parsed from fixture) ─────────────────────────────
+    static readonly HashSet<(int c, int r)> WallCells = new HashSet<(int, int)>
+    {
+        // Row 0 — full top wall
+        (0,0),(1,0),(2,0),(3,0),(4,0),(5,0),(6,0),(7,0),(8,0),(9,0),(10,0),(11,0),(12,0),(13,0),
+        // Side walls
+        (0,1),(13,1),(0,2),(13,2),(0,3),(13,3),(0,4),(13,4),(0,5),(13,5),
+        (0,6),(13,6),(0,7),(13,7),(0,8),(13,8),
+    };
+
+    // ── prop definitions (from fixture) ───────────────────────────────────
+    struct PropDef
+    {
+        public string id;
+        public string kind;
+        public (int c, int r)[] cells;
+        public string height_band;
+    }
+
+    static readonly PropDef[] Props = new PropDef[]
+    {
+        new PropDef { id="bar",    kind="bar_counter",   cells=new[]{(1,1),(2,1),(3,1),(4,1)},   height_band="tall" },
+        new PropDef { id="hearth", kind="stone_hearth",  cells=new[]{(11,1),(12,1)},              height_band="tall" },
+        new PropDef { id="table1", kind="round_table",   cells=new[]{(4,4),(5,4)},                height_band="mid"  },
+        new PropDef { id="table2", kind="long_table",    cells=new[]{(8,5),(9,5)},                height_band="mid"  },
+        new PropDef { id="barrels",kind="barrels",       cells=new[]{(2,7)},                      height_band="low"  },
+    };
+
+    // ── spawn cells ───────────────────────────────────────────────────────
+    static readonly (int c, int r)[] PartySpawns = { (6,8),(7,8),(8,8) };
+    static readonly (int c, int r)[] FoeSpawns   = { (6,2),(8,3) };
+
+    // ── lighting ──────────────────────────────────────────────────────────
+    static readonly Color KEY_COLOR     = new Color(1.000f, 0.604f, 0.271f, 1f); // #ff9a45
+    static readonly Color AMBIENT_COLOR = new Color(0.227f, 0.247f, 0.333f, 1f); // #3a3f55
+
+    // ─────────────────────────────────────────────────────────────────────
+    [MenuItem("Tools/WorldOS/Build Tier-1 Tavern Block-out")]
+    public static void Build()
+    {
+        // Tear down any previous build
+        var existing = GameObject.Find("TavernTier1");
+        if (existing != null) DestroyImmediate(existing);
+
+        var root = new GameObject("TavernTier1");
+
+        BuildFloor(root);
+        BuildWalls(root);
+        BuildProps(root);
+        BuildActors(root);
+        SetupCamera();
+        SetupLighting();
+        BuildBackdrop(root);
+
+        // Flush
+        EditorUtility.SetDirty(root);
+        UnityEditor.SceneManagement.EditorSceneManager.MarkSceneDirty(
+            UnityEngine.SceneManagement.SceneManager.GetActiveScene());
+
+        Debug.Log("[Tier-1] Build complete — floor/walls/props/actors/camera/lighting/backdrop.");
+    }
+
+    [MenuItem("Tools/WorldOS/Clear Tier-1 Scene")]
+    public static void Clear()
+    {
+        var existing = GameObject.Find("TavernTier1");
+        if (existing != null)
+        {
+            DestroyImmediate(existing);
+            Debug.Log("[Tier-1] Cleared TavernTier1 root.");
+        }
+        else
+        {
+            Debug.Log("[Tier-1] Nothing to clear.");
+        }
+    }
+
+    // ── FLOOR ─────────────────────────────────────────────────────────────
+    static void BuildFloor(GameObject root)
+    {
+        var go = GameObject.CreatePrimitive(PrimitiveType.Plane);
+        go.name = "Floor_Grid";
+        go.transform.SetParent(root.transform, false);
+
+        // Plane primitive is 10×10 by default (10 Unity units).
+        // We want COLS*CELL_SIZE × ROWS*CELL_SIZE = 70×50.
+        // Scale: Plane 10 units → scale 7 in X, 5 in Z.
+        go.transform.localPosition = new Vector3(0f, 0f, (ROWS * CELL_SIZE) / 2f);
+        go.transform.localScale = new Vector3(COLS * CELL_SIZE / 10f, 1f, ROWS * CELL_SIZE / 10f);
+
+        var mat = new Material(Shader.Find("Standard"));
+        // Dark stone floor with faint grid tint
+        mat.color = new Color(0.20f, 0.18f, 0.16f, 1f);
+        mat.SetFloat("_Metallic", 0f);
+        mat.SetFloat("_Glossiness", 0.06f);
+        go.GetComponent<Renderer>().material = mat;
+        var r = go.GetComponent<Renderer>();
+        r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        r.receiveShadows = true;
+
+        // Save material
+        AssetDatabase.CreateAsset(mat, "Assets/FloorMat_T1.mat");
+    }
+
+    // ── WALLS ─────────────────────────────────────────────────────────────
+    static void BuildWalls(GameObject root)
+    {
+        var wallParent = new GameObject("Walls");
+        wallParent.transform.SetParent(root.transform, false);
+
+        var mat = MakeMat("WallMat_T1",
+            new Color(0.18f, 0.17f, 0.22f, 1f), // dark blue-grey stone
+            metallic: 0f, smoothness: 0.05f);
+
+        foreach (var (c, r) in WallCells)
+        {
+            var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            go.name = $"Wall_{c}_{r}";
+            go.transform.SetParent(wallParent.transform, false);
+            go.transform.localPosition = CellCenter(c, r, WALL_H);
+            go.transform.localScale = new Vector3(CELL_SIZE * 0.98f, WALL_H, CELL_SIZE * 0.98f);
+            go.GetComponent<Renderer>().sharedMaterial = mat;
+            // Walls cast no shadow (they're thin markers)
+            go.GetComponent<Renderer>().shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+            go.GetComponent<Renderer>().receiveShadows = false;
+        }
+    }
+
+    // ── PROPS ─────────────────────────────────────────────────────────────
+    static void BuildProps(GameObject root)
+    {
+        var propParent = new GameObject("Props");
+        propParent.transform.SetParent(root.transform, false);
+
+        foreach (var prop in Props)
+        {
+            float h = HeightFromBand(prop.height_band);
+            Color col = PropColor(prop.kind);
+            var mat = MakeMat($"PropMat_{prop.id}", col, metallic: 0.05f, smoothness: 0.15f);
+
+            // Build a single merged box spanning all cells of the prop
+            if (prop.cells.Length == 1)
+            {
+                var (c, r) = prop.cells[0];
+                var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                go.name = $"Prop_{prop.id}";
+                go.transform.SetParent(propParent.transform, false);
+                go.transform.localPosition = CellCenter(c, r, h);
+                go.transform.localScale = new Vector3(CELL_SIZE * 0.88f, h, CELL_SIZE * 0.88f);
+                go.GetComponent<Renderer>().sharedMaterial = mat;
+                go.GetComponent<Renderer>().shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
+                go.GetComponent<Renderer>().receiveShadows = true;
+            }
+            else
+            {
+                // Span a bounding box across all cells
+                int minC = int.MaxValue, maxC = int.MinValue;
+                int minR = int.MaxValue, maxR = int.MinValue;
+                foreach (var (cc, rr) in prop.cells)
+                {
+                    if (cc < minC) minC = cc; if (cc > maxC) maxC = cc;
+                    if (rr < minR) minR = rr; if (rr > maxR) maxR = rr;
+                }
+                float spanX = (maxC - minC + 1) * CELL_SIZE * 0.90f;
+                float spanZ = (maxR - minR + 1) * CELL_SIZE * 0.90f;
+                float cx = OriginX + (minC + maxC + 1) * CELL_SIZE * 0.5f;
+                float cz = OriginZ + (minR + maxR + 1) * CELL_SIZE * 0.5f;
+
+                var go = GameObject.CreatePrimitive(PrimitiveType.Cube);
+                go.name = $"Prop_{prop.id}";
+                go.transform.SetParent(propParent.transform, false);
+                go.transform.localPosition = new Vector3(cx, h * 0.5f, cz);
+                go.transform.localScale = new Vector3(spanX, h, spanZ);
+                go.GetComponent<Renderer>().sharedMaterial = mat;
+                go.GetComponent<Renderer>().shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
+                go.GetComponent<Renderer>().receiveShadows = true;
+            }
+        }
+    }
+
+    // ── ACTORS ────────────────────────────────────────────────────────────
+    static void BuildActors(GameObject root)
+    {
+        var actorParent = new GameObject("Actors");
+        actorParent.transform.SetParent(root.transform, false);
+
+        // HERO: warm amber capsule (party spawns 0..2)
+        // Add emission so faction is clear under flat ambient lighting
+        var heroMat = MakeMatWithEmission("HeroMat_T1",
+            LerpTowardKey(new Color(0.52f, 0.44f, 0.62f), KEY_COLOR, 0.45f),
+            emissionColor: new Color(0.5f, 0.3f, 0.0f) * 0.4f,  // warm amber glow
+            metallic: 0f, smoothness: 0.25f, "HeroMat_T1.mat");
+
+        for (int i = 0; i < PartySpawns.Length; i++)
+        {
+            var (c, r) = PartySpawns[i];
+            string label = i == 0 ? "HERO" : $"Party_{i}";
+            BuildCapsuleActor(actorParent, label, c, r, heroMat, isHero: true);
+        }
+
+        // MONSTER: muted red-violet, cool emission to contrast with warm heroes
+        var foeMat = MakeMatWithEmission("FoeMat_T1",
+            LerpTowardAmbient(new Color(0.72f, 0.25f, 0.25f), AMBIENT_COLOR, 0.3f),
+            emissionColor: new Color(0.1f, 0.1f, 0.4f) * 0.4f,  // cool blue-violet glow
+            metallic: 0f, smoothness: 0.20f, "FoeMat_T1.mat");
+
+        for (int i = 0; i < FoeSpawns.Length; i++)
+        {
+            var (c, r) = FoeSpawns[i];
+            string label = i == 0 ? "MONSTER" : $"Foe_{i}";
+            BuildSphereActor(actorParent, label, c, r, foeMat);
+        }
+    }
+
+    static void BuildCapsuleActor(GameObject parent, string name, int c, int r, Material mat, bool isHero)
+    {
+        var go = GameObject.CreatePrimitive(PrimitiveType.Capsule);
+        go.name = name;
+        go.transform.SetParent(parent.transform, false);
+
+        float s = CELL_SIZE * ACTOR_SCALE * 0.28f;
+        float capH = s * 2.2f;  // capsule is 2 units tall by default; scale accordingly
+        go.transform.localScale = new Vector3(s, s * 1.1f, s);
+        float yCenter = capH * 0.5f;  // sit on floor
+        go.transform.localPosition = new Vector3(
+            OriginX + (c + 0.5f) * CELL_SIZE,
+            yCenter,
+            OriginZ + (r + 0.5f) * CELL_SIZE);
+
+        go.GetComponent<Renderer>().sharedMaterial = mat;
+        go.GetComponent<Renderer>().shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
+        go.GetComponent<Renderer>().receiveShadows = true;
+
+        // Elliptical contact shadow disc
+        BuildContactShadow(parent, name + "_Shadow", c, r, s * 1.4f, s * 0.8f);
+    }
+
+    static void BuildSphereActor(GameObject parent, string name, int c, int r, Material mat)
+    {
+        // Monster = sphere on a thin cube "body"
+        var body = new GameObject(name);
+        body.transform.SetParent(parent.transform, false);
+
+        float s = CELL_SIZE * ACTOR_SCALE * 0.26f;
+        float yBase = 0f;
+
+        // Cube body
+        var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        cube.name = name + "_Body";
+        cube.transform.SetParent(body.transform, false);
+        cube.transform.localScale = new Vector3(s, s * 1.5f, s * 0.9f);
+        cube.transform.localPosition = new Vector3(0f, s * 0.75f, 0f);
+        cube.GetComponent<Renderer>().sharedMaterial = mat;
+        cube.GetComponent<Renderer>().shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
+
+        // Sphere head
+        var sphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        sphere.name = name + "_Head";
+        sphere.transform.SetParent(body.transform, false);
+        sphere.transform.localScale = new Vector3(s * 0.85f, s * 0.85f, s * 0.85f);
+        sphere.transform.localPosition = new Vector3(0f, s * 1.8f, 0f);
+        sphere.GetComponent<Renderer>().sharedMaterial = mat;
+        sphere.GetComponent<Renderer>().shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On;
+
+        body.transform.localPosition = new Vector3(
+            OriginX + (c + 0.5f) * CELL_SIZE,
+            yBase,
+            OriginZ + (r + 0.5f) * CELL_SIZE);
+
+        // Contact shadow
+        BuildContactShadow(parent, name + "_Shadow", c, r, s * 1.3f, s * 0.65f);
+    }
+
+    static void BuildContactShadow(GameObject parent, string name, int c, int r, float rx, float rz)
+    {
+        // Flattened sphere (ovaloid) just above the floor — NOT a big circular blob.
+        var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        go.name = name;
+        go.transform.SetParent(parent.transform, false);
+
+        // Keep ry tiny so it's a flat ellipse, not a blob sphere
+        go.transform.localScale = new Vector3(rx * 2f, 0.04f, rz * 2f);
+        go.transform.localPosition = new Vector3(
+            OriginX + (c + 0.5f) * CELL_SIZE,
+            0.01f,   // just above floor plane Y=0
+            OriginZ + (r + 0.5f) * CELL_SIZE);
+
+        var mat = new Material(Shader.Find("Standard"));
+        mat.color = new Color(0.0f, 0.0f, 0.0f, 0.55f);
+        mat.SetFloat("_Mode", 3f);             // Transparent blend mode
+        mat.SetInt("_SrcBlend", (int)UnityEngine.Rendering.BlendMode.SrcAlpha);
+        mat.SetInt("_DstBlend", (int)UnityEngine.Rendering.BlendMode.OneMinusSrcAlpha);
+        mat.SetInt("_ZWrite", 0);
+        mat.DisableKeyword("_ALPHATEST_ON");
+        mat.EnableKeyword("_ALPHABLEND_ON");
+        mat.DisableKeyword("_ALPHAPREMULTIPLY_ON");
+        mat.renderQueue = 3000;
+
+        go.GetComponent<Renderer>().sharedMaterial = mat;
+        go.GetComponent<Renderer>().shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        go.GetComponent<Renderer>().receiveShadows = false;
+    }
+
+    // ── CAMERA — 2:1 Dimetric ─────────────────────────────────────────────
+    static void SetupCamera()
+    {
+        var camGO = GameObject.Find("Main Camera");
+        if (camGO == null)
+        {
+            camGO = new GameObject("Main Camera");
+            camGO.AddComponent<Camera>();
+            camGO.tag = "MainCamera";
+        }
+
+        var cam = camGO.GetComponent<Camera>();
+
+        // 2:1 dimetric = ~26.57° pitch (atan(0.5))
+        // Orthographic projection gives exact dimetric ratios.
+        cam.orthographic = true;
+
+        // Grid world bounds:
+        //   X: OriginX = -35 to +35 (70 units wide)
+        //   Z: 0 to 50  (10 rows × 5)
+        //   Camera looks from -Z toward +Z, pitched down 26.57°.
+        //
+        // CRITICAL: viewport rect must be full-screen to avoid letterbox.
+        cam.rect = new Rect(0, 0, 1, 1);
+
+        // OrthoSize: half the projected grid height.
+        // Grid depth (Z) projected onto screen height with 26.57° pitch:
+        //   50 * cos(26.57°) ≈ 44.7; half = 22.3 → use 18 for tight framing.
+        cam.orthographicSize = 18f;
+
+        cam.nearClipPlane = 0.5f;
+        cam.farClipPlane  = 400f;
+
+        // 2:1 dimetric pitch = atan(0.5) ≈ 26.565°
+        float pitchDeg = Mathf.Rad2Deg * Mathf.Atan(0.5f);  // 26.565°
+        float pitchRad = Mathf.Atan(0.5f);
+
+        // Grid centre in world: (0, 0, 25). Camera pulls back 90 units:
+        float pullBack = 90f;
+        float gridCentreZ = ROWS * CELL_SIZE * 0.5f;   // = 25
+
+        float camY = pullBack * Mathf.Sin(pitchRad);
+        float camZ = gridCentreZ - pullBack * Mathf.Cos(pitchRad);
+
+        camGO.transform.position     = new Vector3(0f, camY, camZ);
+        camGO.transform.eulerAngles  = new Vector3(pitchDeg, 0f, 0f);
+
+        // Background: dark tavern (backdrop quad covers most of this)
+        cam.backgroundColor = new Color(0.06f, 0.05f, 0.07f, 1f);
+        cam.clearFlags = CameraClearFlags.SolidColor;
+    }
+
+    // ── LIGHTING ──────────────────────────────────────────────────────────
+    static void SetupLighting()
+    {
+        // Key light: warm amber from the hearth side (key_dir_deg=210 → from left-back)
+        var lightGO = GameObject.Find("Directional Light");
+        if (lightGO == null)
+        {
+            lightGO = new GameObject("Directional Light");
+            lightGO.AddComponent<Light>().type = LightType.Directional;
+        }
+        var lt = lightGO.GetComponent<Light>();
+        lt.color = KEY_COLOR;
+        lt.intensity = 1.2f;
+        lt.shadows = LightShadows.Soft;
+        lt.shadowStrength = 0.55f;
+        lt.shadowBias = 0.04f;
+        // 210° from North in scene = azimuth rotated: pitch ~35°, yaw +210° (or -150°)
+        lightGO.transform.eulerAngles = new Vector3(38f, 210f - 180f, 0f); // pitch 38°, yaw 30°
+
+        // Ambient: cool purple-blue fill
+        RenderSettings.ambientMode = UnityEngine.Rendering.AmbientMode.Flat;
+        RenderSettings.ambientLight = AMBIENT_COLOR;
+        RenderSettings.ambientIntensity = 0.9f;
+    }
+
+    // ── BACKDROP ──────────────────────────────────────────────────────────
+    static void BuildBackdrop(GameObject root)
+    {
+        // Remove the old floating Backdrop if it exists
+        var old = GameObject.Find("Backdrop");
+        if (old != null) DestroyImmediate(old);
+
+        var go = GameObject.CreatePrimitive(PrimitiveType.Quad);
+        go.name = "Backdrop_DepthBlit";
+        go.transform.SetParent(root.transform, false);
+
+        // The backdrop needs to be visible through the camera — it should fill the upper
+        // portion of the screen (behind the floor and props, acting as wall+ceiling).
+        //
+        // Strategy: tilt the backdrop quad to be PERPENDICULAR TO THE CAMERA VIEW DIRECTION.
+        // Camera pitch = 26.565° (atan 0.5). Backdrop should pitch by (90° - 26.565°) = 63.435°
+        // so its face is parallel to the camera image plane → it fills the screen properly.
+        //
+        // Position: at the back of the grid (z≈0), centred in X, raised in Y so it
+        // covers the wall area and above:
+        float pitchRad = Mathf.Atan(0.5f);  // 26.565°
+        float backdropTiltDeg = 90f - Mathf.Rad2Deg * pitchRad; // 63.435° — face toward camera
+
+        // Place it at the back wall (z=0) centered vertically
+        float backdropZ = -2f;  // slightly behind back wall (row 0)
+        float backdropW = COLS * CELL_SIZE * 1.2f;  // 84 units wide
+        float backdropH = ROWS * CELL_SIZE * 1.4f;  // 70 units tall
+        float backdropY = backdropH * 0.5f - 5f;   // centred, slightly lowered
+        go.transform.localPosition = new Vector3(0f, backdropY, backdropZ);
+        go.transform.localEulerAngles = new Vector3(backdropTiltDeg, 0f, 0f); // tilt to face camera
+        go.transform.localScale    = new Vector3(backdropW, backdropH, 1f);
+
+        // Try the depth-blit shader first; fall back to Unlit/Texture
+        var shader = Shader.Find("WorldOS/DepthBlitBackdrop");
+        Material mat;
+        bool depthBlitAvailable = (shader != null);
+
+        if (depthBlitAvailable)
+        {
+            mat = new Material(shader);
+            mat.SetFloat("_NearClip", 0.1f);
+            mat.SetFloat("_FarClip",  400f);
+            Debug.Log("[Tier-1] DepthBlitBackdrop shader FOUND — Tier-2 path active.");
+        }
+        else
+        {
+            mat = new Material(Shader.Find("Unlit/Texture"));
+            Debug.LogWarning("[Tier-1] DepthBlitBackdrop shader not yet compiled — using Unlit/Texture fallback. Real-3D box props provide occlusion.");
+        }
+
+        // Load backdrop texture (spike's existing or painterly/)
+        Texture2D backdropTex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/tavern_backdrop.png");
+        if (backdropTex == null)
+            backdropTex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/tavern_backdrop.png");
+        if (backdropTex != null)
+        {
+            mat.mainTexture = tex2DSlot(mat, backdropTex, depthBlitAvailable ? "_BackdropTex" : "_MainTex");
+        }
+        else
+        {
+            Debug.LogWarning("[Tier-1] No backdrop texture found. Assign Assets/painterly/tavern_backdrop.png.");
+        }
+
+        // Render before all geometry so depth-blit populates the Z-buffer first
+        mat.renderQueue = depthBlitAvailable ? 999 : 900;
+        AssetDatabase.CreateAsset(mat, "Assets/BackdropMat_T1.mat");
+
+        var r = go.GetComponent<Renderer>();
+        r.sharedMaterial = mat;
+        r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off;
+        r.receiveShadows = false;
+    }
+
+    // Helper: set texture by property name (handles both shader paths)
+    static Texture2D tex2DSlot(Material m, Texture2D tex, string prop)
+    {
+        if (m.HasProperty(prop)) m.SetTexture(prop, tex);
+        else m.mainTexture = tex;
+        return tex;
+    }
+
+    // ── HELPERS ───────────────────────────────────────────────────────────
+    static Vector3 CellCenter(int c, int r, float h)
+    {
+        float x = OriginX + (c + 0.5f) * CELL_SIZE;
+        float z = OriginZ + (r + 0.5f) * CELL_SIZE;
+        return new Vector3(x, h * 0.5f, z);
+    }
+
+    static float HeightFromBand(string band) => band switch
+    {
+        "tall" => TALL_H,
+        "mid"  => MID_H,
+        "low"  => LOW_H,
+        _      => MID_H,
+    };
+
+    static Color PropColor(string kind) => kind switch
+    {
+        "bar_counter"  => new Color(0.42f, 0.28f, 0.14f, 1f),  // dark oak
+        "stone_hearth" => new Color(0.50f, 0.44f, 0.40f, 1f),  // stone grey-tan
+        "round_table"  => new Color(0.48f, 0.32f, 0.16f, 1f),  // mid wood
+        "long_table"   => new Color(0.44f, 0.30f, 0.14f, 1f),  // mid wood
+        "barrels"      => new Color(0.38f, 0.26f, 0.12f, 1f),  // dark wood
+        _              => new Color(0.45f, 0.35f, 0.25f, 1f),
+    };
+
+    // Tint a colour toward the key light colour (cohesion pass)
+    static Color LerpTowardKey(Color base_, Color key, float t) =>
+        Color.Lerp(base_, key, t);
+
+    // Tint a colour toward ambient (shadow-side cohesion)
+    static Color LerpTowardAmbient(Color base_, Color amb, float t) =>
+        Color.Lerp(base_, amb, t);
+
+    static Material MakeMat(string assetName, Color col, float metallic, float smoothness, string filename = null)
+    {
+        var mat = new Material(Shader.Find("Standard"));
+        mat.color = col;
+        mat.SetFloat("_Metallic", metallic);
+        mat.SetFloat("_Glossiness", smoothness);
+        string path = $"Assets/{filename ?? assetName + ".mat"}";
+        AssetDatabase.DeleteAsset(path);
+        AssetDatabase.CreateAsset(mat, path);
+        return mat;
+    }
+
+    static Material MakeMatWithEmission(string assetName, Color col, Color emissionColor,
+                                         float metallic, float smoothness, string filename = null)
+    {
+        var mat = new Material(Shader.Find("Standard"));
+        mat.color = col;
+        mat.SetFloat("_Metallic", metallic);
+        mat.SetFloat("_Glossiness", smoothness);
+        mat.EnableKeyword("_EMISSION");
+        mat.SetColor("_EmissionColor", emissionColor);
+        string path = $"Assets/{filename ?? assetName + ".mat"}";
+        AssetDatabase.DeleteAsset(path);
+        AssetDatabase.CreateAsset(mat, path);
+        return mat;
+    }
+}

--- a/extensions/renderers/unity/scripts/paint_3d_spike.cs
+++ b/extensions/renderers/unity/scripts/paint_3d_spike.cs
@@ -1,0 +1,58 @@
+// M1.0 SPIKE — the make-or-break: a REAL 3D hero (FBX), scene-lit + grounded, over the painterly crypt plate.
+// Question: does a lit, dimensional 3D actor read as BELONGING in the painting (vs a flat pasted billboard)?
+AssetDatabase.Refresh();
+var sb=new System.Text.StringBuilder();
+Camera cam=Camera.main; if(cam==null && Camera.allCameras.Length>0) cam=Camera.allCameras[0]; if(cam==null) return "no cam";
+// frozen dimetric contract camera (same as the billboard renderer)
+cam.orthographic=true; cam.orthographicSize=13f; cam.nearClipPlane=0.3f; cam.farClipPlane=500f;
+{ Quaternion _crot=Quaternion.Euler(30f,45f,0f); cam.transform.rotation=_crot; cam.transform.position=-(_crot*Vector3.forward)*80f; }
+cam.clearFlags=CameraClearFlags.SolidColor; cam.backgroundColor=new Color(0.02f,0.02f,0.03f);
+int hidden=0; foreach(var r in UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None)){ if(r.enabled){r.enabled=false;hidden++;} }
+
+var bdTex=AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/backdrops/crypt_pinned_v1.png"); if(bdTex==null) return "no plate";
+var oldBd=GameObject.Find("PaintedBackdrop"); if(oldBd!=null) UnityEngine.Object.DestroyImmediate(oldBd);
+var bd=GameObject.CreatePrimitive(PrimitiveType.Quad); bd.name="PaintedBackdrop"; UnityEngine.Object.DestroyImmediate(bd.GetComponent<Collider>());
+bd.transform.SetParent(cam.transform,false); float texAsp=(float)bdTex.width/bdTex.height; float oh=cam.orthographicSize*2f; float ow=oh*texAsp;
+bd.transform.localPosition=new Vector3(0,0,160f); bd.transform.localScale=new Vector3(ow,oh,1f);
+var bm=new Material(Shader.Find("Unlit/Texture")); bm.mainTexture=bdTex; bm.renderQueue=1900; var bdr=bd.GetComponent<Renderer>(); bdr.sharedMaterial=bm; bdr.enabled=true; bdr.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; bdr.receiveShadows=false;
+
+System.Func<int,int,Vector3> cellToWorld=(cx,cy)=> new Vector3((cx-6.5f)*2.0f,0f,(5.0f-cy)*2.0f);
+
+// PoE2 LIGHTING RIG (Phase 1.1): warm key + cool fill + cool ambient + warm brazier point lights at the painted braziers (warm/cool contrast; warm uplight near the fire)
+foreach(var ln in new[]{"KeyLight","FillLight","BrazierL","BrazierR"}){ var o=GameObject.Find(ln); if(o!=null) UnityEngine.Object.DestroyImmediate(o); }
+var lg=new GameObject("KeyLight"); var L=lg.AddComponent<Light>(); L.type=LightType.Directional; L.color=new Color(1f,0.73f,0.44f); L.intensity=1.35f; L.shadows=LightShadows.Soft; L.shadowStrength=0.75f; lg.transform.rotation=Quaternion.Euler(48f,35f,0f);
+var fg=new GameObject("FillLight"); var F=fg.AddComponent<Light>(); F.type=LightType.Directional; F.color=new Color(0.36f,0.44f,0.64f); F.intensity=0.55f; F.shadows=LightShadows.None; fg.transform.rotation=Quaternion.Euler(34f,215f,0f);
+RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat; RenderSettings.ambientLight=new Color(0.24f,0.28f,0.40f);  // cool fill ambient (blue-violet, never black)
+System.Action<string,int,int,bool> brazier=(nm,cx,cy,sh)=>{ var bg=new GameObject(nm); var B=bg.AddComponent<Light>(); B.type=LightType.Point; B.color=new Color(1f,0.48f,0.18f); B.range=7.5f; B.intensity=3.6f; B.shadows=sh?LightShadows.Soft:LightShadows.None; var wp=cellToWorld(cx,cy); bg.transform.position=new Vector3(wp.x,1.7f,wp.z); };
+brazier("BrazierL",4,1,true); brazier("BrazierR",9,1,false);
+
+// REAL 3D hero
+var heroPrefab=AssetDatabase.LoadAssetAtPath<GameObject>("Assets/painterly/models/hero.fbx"); if(heroPrefab==null) return "no hero.fbx (import failed?)";
+var oldH=GameObject.Find("Hero3D"); if(oldH!=null) UnityEngine.Object.DestroyImmediate(oldH);
+var hero=(GameObject)UnityEngine.Object.Instantiate(heroPrefab); hero.name="Hero3D";
+hero.transform.rotation=Quaternion.Euler(-90f, cam.transform.eulerAngles.y+180f, 0f);  // stand the lying Z-up T-pose UPRIGHT + face the camera
+var rends=hero.GetComponentsInChildren<Renderer>();
+foreach(var r in rends){ r.enabled=true; r.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.On; r.receiveShadows=true; }
+System.Func<Bounds> measure=()=>{ Bounds b=new Bounds(hero.transform.position,Vector3.zero); bool a=false; foreach(var r in rends){ if(!a){b=r.bounds;a=true;} else b.Encapsulate(r.bounds);} return b; };
+Bounds bb=measure(); float curH=bb.size.y>0.001f?bb.size.y:1f; float s=5.0f/curH; hero.transform.localScale=hero.transform.localScale*s;  // MULTIPLY (preserve FBX import scale); 5.0 = more combat-readable presence (was 3.7=contract)
+var p=cellToWorld(7,6); hero.transform.position=p; bb=measure(); hero.transform.position+=new Vector3(0f,-bb.min.y,0f);  // feet to y=0
+sb.AppendLine("Hero3D x"+s.ToString("F2")+" @"+p.ToString("F1")+" standH(preScale)="+curH.ToString("F2")+" rends="+rends.Length);
+// Phase 1.3: the FBX import dropped the GLB textures (white hero) -> assign the extracted albedo on a Standard material
+var heroAlbedo=AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/models/hero_albedo.png");
+if(heroAlbedo!=null){ var hmat=new Material(Shader.Find("Standard")); hmat.mainTexture=heroAlbedo; hmat.SetFloat("_Glossiness",0.2f); hmat.SetFloat("_Metallic",0f); foreach(var r in rends) r.sharedMaterial=hmat; sb.AppendLine("albedo ASSIGNED "+heroAlbedo.width); } else sb.AppendLine("NO albedo found");
+
+// grounding AO blob under the feet
+var blobT=new Texture2D(256,256,TextureFormat.RGBA32,false); blobT.wrapMode=TextureWrapMode.Clamp; { var px=new Color[256*256]; float c=127.5f; for(int y=0;y<256;y++)for(int x=0;x<256;x++){ float d=Mathf.Clamp01(Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c); px[y*256+x]=new Color(0.02f,0.02f,0.03f,Mathf.Pow(1f-d,0.9f)); } blobT.SetPixels(px); blobT.Apply(); }
+var ao=GameObject.CreatePrimitive(PrimitiveType.Quad); ao.name="HeroAO"; UnityEngine.Object.DestroyImmediate(ao.GetComponent<Collider>()); ao.transform.position=new Vector3(p.x,0.05f,p.z); ao.transform.localEulerAngles=new Vector3(90f,0f,0f); ao.transform.localScale=new Vector3(2.4f,1.5f,1f);
+var aom=new Material(Shader.Find("Unlit/Transparent")); aom.mainTexture=blobT; aom.renderQueue=1950; var aor=ao.GetComponent<Renderer>(); aor.sharedMaterial=aom; aor.enabled=true; aor.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
+
+bb=measure(); sb.AppendLine("HERO final bbox size="+bb.size.ToString("F2")+" center="+bb.center.ToString("F2")+" matShader="+(rends.Length>0&&rends[0].sharedMaterial!=null?rends[0].sharedMaterial.shader.name:"NULL"));
+
+int W=1920,Hh=Mathf.RoundToInt(1920f*(float)bdTex.height/bdTex.width); var rt=new RenderTexture(W,Hh,24,RenderTextureFormat.ARGB32); rt.Create();
+float pa=cam.aspect; var pt=cam.targetTexture; cam.targetTexture=rt; cam.aspect=(float)W/Hh; cam.Render();
+var pAct=RenderTexture.active; RenderTexture.active=rt; var t2=new Texture2D(W,Hh,TextureFormat.RGB24,false); t2.ReadPixels(new Rect(0,0,W,Hh),0,0); t2.Apply(); RenderTexture.active=pAct; cam.targetTexture=pt; cam.aspect=pa;
+System.IO.Directory.CreateDirectory("/home/unity/worldos-unity/Captures-Durable");
+System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/m10_spike.png", t2.EncodeToPNG());
+UnityEngine.Object.DestroyImmediate(t2); rt.Release(); UnityEngine.Object.DestroyImmediate(rt);
+sb.AppendLine("captured "+W+"x"+Hh+" -> m10_spike.png hidden="+hidden);
+return sb.ToString();

--- a/extensions/renderers/unity/scripts/paint_backdrop_p0.cs
+++ b/extensions/renderers/unity/scripts/paint_backdrop_p0.cs
@@ -1,0 +1,215 @@
+// paint_backdrop_render.cs — Unity painted-backdrop renderer (r3: scene-relight).
+// Built-in pipeline. Backdrop quad + dimetric billboards relit by WorldOS/PaintedSpriteScene
+// (UV-based scene key/fill/rim/edge-dissolve/atm) + perspective ground rings + darker contact shadows.
+AssetDatabase.Refresh();   // M2/M3: import freshly-deployed goblin/ally facings + vfx before LoadAssetAtPath
+float KEYFROMLEFT = 1f;   // billboard is now UN-flipped (identity rot) so texture-left = screen-left = hearth side
+var sb = new System.Text.StringBuilder();
+Camera cam = Camera.main; if (cam==null && Camera.allCameras.Length>0) cam=Camera.allCameras[0];
+if (cam==null) return "no camera";
+// P0 contract camera: orthographic, elevation 30deg (asin .5 -> true 2:1), yaw 45 corner-iso. MUST match the greybox that conditioned the plate.
+cam.orthographic=true; cam.orthographicSize=13f; cam.nearClipPlane=0.3f; cam.farClipPlane=500f;
+{ Quaternion _crot=Quaternion.Euler(30f,45f,0f); cam.transform.rotation=_crot; cam.transform.position=-(_crot*Vector3.forward)*80f; }
+var bdTex   = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/backdrops/crypt_pinned_v1.png");
+var heroTex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/sprites/hero_idle.png");
+var gobTex  = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/sprites/goblin_idle.png");
+var allyTex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/sprites/ally_idle.png");
+// M2: 8-facing painterly hero turnaround (sliced) — the renderer picks the facing by movement direction
+var heroFacings=new System.Collections.Generic.Dictionary<string,Texture2D>();
+foreach(var fc in new[]{"S","SE","E","NE","N","NW","W","SW"}){ var ft=AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/sprites/hero/hero_"+fc+".png"); if(ft!=null) heroFacings[fc]=ft; }
+// M3: combat VFX (on-black -> additive). slash/impact = melee, bolt = magic, blood = death.
+var vfxImpact=AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/vfx/vfx_impact.png");
+var vfxSlash =AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/vfx/vfx_slash.png");
+var vfxBolt  =AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/vfx/vfx_bolt.png");
+var vfxBlood =AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/vfx/vfx_blood.png");
+if (bdTex==null||heroTex==null||gobTex==null) return "TEX MISSING";
+
+int hidden=0;
+foreach (var r in UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None)) { if (r.enabled){ r.enabled=false; hidden++; } }
+var hf=GameObject.Find("HeroFighter"); var mg=GameObject.Find("MonsterGoblin");
+// LIVE engine combat-surface (engine = SOLE WRITER; this renderer is READ-ONLY — positions come from the engine cells)
+string CID="camp_gfxdemo01"; string surfJson="";
+try { surfJson=new System.Net.WebClient().DownloadString("http://127.0.0.1:8765/combat-surface?campaign="+CID); } catch (System.Exception e) { return "surface GET failed: "+e.Message; }
+var root=MiniJson.Parse(surfJson) as System.Collections.Generic.Dictionary<string,object>;
+if (root==null) return "surface parse failed";
+var toks=root["tokens"] as System.Collections.Generic.List<object>;
+System.Func<int,int,Vector3> cellToWorld=(cx,cy)=> new Vector3((cx-6.5f)*2.0f, 0f, (5.0f-cy)*2.0f);  // P0 contract: isotropic cell 2.0; cols14 rows11 -> cx0=6.5 cy0=5
+System.Func<string,float> labelFrac=(h)=>{ if(string.IsNullOrEmpty(h)) return 1f; h=h.ToLower();
+  if(h.Contains("dead")||h.Contains("dying")||h.Contains("critical")) return 0.10f;
+  if(h.Contains("badly")||h.Contains("heavily")) return 0.25f;
+  if(h.Contains("bloodied")) return 0.40f;
+  if(h.Contains("wounded")||h.Contains("hurt")) return 0.62f;
+  if(h.Contains("scratched")||h.Contains("grazed")) return 0.82f;
+  return 0.95f; };  // healthy/steady/unhurt
+var actors=new System.Collections.Generic.List<object[]>(); var actorPos=new System.Collections.Generic.Dictionary<string,Vector3>(); var actorTop=new System.Collections.Generic.Dictionary<string,float>(); string celldbg="";
+foreach (var o in toks){ var t=o as System.Collections.Generic.Dictionary<string,object>; if(t==null||!t.ContainsKey("x")||t["x"]==null) continue;
+  int cx=System.Convert.ToInt32(t["x"]); int cy=System.Convert.ToInt32(t["y"]); string team=t["team"] as string; string nm=t["name"] as string;
+  float frac; if(t.ContainsKey("hp")&&t["hp"]!=null&&t.ContainsKey("hpMax")&&t["hpMax"]!=null){ double hp=System.Convert.ToDouble(t["hp"]); double hpm=System.Convert.ToDouble(t["hpMax"]); frac=(hpm>0)?(float)(hp/hpm):1f; } else { frac=labelFrac(t.ContainsKey("health")?t["health"] as string:null); }
+  actors.Add(new object[]{nm, team, cellToWorld(cx,cy), frac}); celldbg+=" "+nm+"("+team+")@"+cx+","+cy+" hp"+frac.ToString("F2"); }
+// latest damage from the battleLog -> floating "-N" above the target
+string dmgTarget=""; int dmgN=0; var blog=root.ContainsKey("battleLog")?root["battleLog"] as System.Collections.Generic.List<object>:null;
+if(blog!=null){ foreach(var e in blog){ string tx=null; var ed=e as System.Collections.Generic.Dictionary<string,object>; if(ed!=null&&ed.ContainsKey("text")) tx=ed["text"] as string; else tx=e as string;
+  if(tx!=null&&tx.Contains(" hits ")&&tx.Contains(" for ")&&tx.Contains("damage")){ int hi=tx.IndexOf(" hits "); int fi=tx.IndexOf(" for ",hi); if(hi>=0&&fi>hi){ dmgTarget=tx.Substring(hi+6,fi-(hi+6)).Trim(); var aft=tx.Substring(fi+5).TrimStart().Split(' '); if(aft.Length>0) int.TryParse(aft[0],out dmgN); } } } }
+sb.AppendLine("LIVE surface cells:"+celldbg);
+
+// backdrop quad (native plate aspect)
+var oldBd=GameObject.Find("PaintedBackdrop"); if (oldBd!=null) UnityEngine.Object.DestroyImmediate(oldBd);
+var bd=GameObject.CreatePrimitive(PrimitiveType.Quad); bd.name="PaintedBackdrop"; UnityEngine.Object.DestroyImmediate(bd.GetComponent<Collider>());
+bd.transform.SetParent(cam.transform,false);
+float texAsp=(float)bdTex.width/bdTex.height; float oh=cam.orthographicSize*2f; float ow=oh*texAsp;
+bd.transform.localPosition=new Vector3(0,0,160f); bd.transform.localRotation=Quaternion.identity; bd.transform.localScale=new Vector3(ow,oh,1f);
+var bm=new Material(Shader.Find("Unlit/Texture")); bm.mainTexture=bdTex; bm.renderQueue=1900;
+var bdr=bd.GetComponent<Renderer>(); bdr.sharedMaterial=bm; bdr.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; bdr.receiveShadows=false;
+// P2 OCCLUSION: invisible depth-only boxes at the painted props (queue 1950: after the backdrop 1900, before
+// the rings/billboards) -> characters behind a pillar/sarcophagus are occluded by the (painted) prop. Dims match
+// the greybox that conditioned the plate, so the depth box aligns with the painted prop.
+var occMat=new Material(Shader.Find("WorldOS/DepthMask")); occMat.renderQueue=1950;
+System.Action<string,Vector3,Vector3> occ=(nm,center,size)=>{ var o=GameObject.Find(nm); if(o!=null) UnityEngine.Object.DestroyImmediate(o); var g=GameObject.CreatePrimitive(PrimitiveType.Cube); g.name=nm; UnityEngine.Object.DestroyImmediate(g.GetComponent<Collider>()); g.transform.position=center; g.transform.localScale=size; var rr=g.GetComponent<Renderer>(); rr.sharedMaterial=occMat; rr.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; rr.receiveShadows=false; };
+occ("OCC_pillarL", cellToWorld(2,3)+new Vector3(0,4f,0),    new Vector3(1.4f,8f,1.4f));
+occ("OCC_pillarR", cellToWorld(11,3)+new Vector3(0,4f,0),   new Vector3(1.4f,8f,1.4f));
+occ("OCC_sarc",    cellToWorld(7,1)+new Vector3(-1f,1.5f,0),new Vector3(4f,3f,2f));
+occ("OCC_brazL",   cellToWorld(4,1)+new Vector3(0,1.2f,0),  new Vector3(0.9f,2.4f,0.9f));
+occ("OCC_brazR",   cellToWorld(9,1)+new Vector3(0,1.2f,0),  new Vector3(0.9f,2.4f,0.9f));
+
+// procedural ground textures
+System.Func<int,Color,Texture2D> mkRing=(size,col)=>{
+  var t=new Texture2D(size,size,TextureFormat.RGBA32,false); t.wrapMode=TextureWrapMode.Clamp; var px=new Color[size*size]; float c=(size-1)/2f, ro=c*0.96f, ri=c*0.80f;
+  for(int y=0;y<size;y++)for(int x=0;x<size;x++){ float d=Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c)); float a=0f; if(d<=ro&&d>=ri){ float e=Mathf.Min(ro-d,d-ri); a=Mathf.Clamp01(e/4f);} px[y*size+x]=new Color(col.r,col.g,col.b,a*col.a);} t.SetPixels(px); t.Apply(); return t; };
+System.Func<Texture2D> mkBlob=()=>{ int size=256; var t=new Texture2D(size,size,TextureFormat.RGBA32,false); t.wrapMode=TextureWrapMode.Clamp; var px=new Color[size*size]; float c=(size-1)/2f;
+  for(int y=0;y<size;y++)for(int x=0;x<size;x++){ float d=Mathf.Clamp01(Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c); float a=Mathf.Pow(1f-d,0.85f)*1.0f; px[y*size+x]=new Color(0.02f,0.015f,0.01f,a);} t.SetPixels(px); t.Apply(); return t; };  // L2: slower falloff + full alpha = a darker, wider contact pool that reads beyond the figure
+var ringHero=mkRing(256,new Color(1f,0.80f,0.43f,0.72f)); var ringGob=mkRing(256,new Color(0.90f,0.27f,0.29f,0.72f)); var blob=mkBlob();  // L2: dimmer rings so the contact shadow reads as the ground anchor (ring = highlight on top)
+// P1: a soft gold DOT for the routed-path breadcrumbs (the engine's detour around props)
+System.Func<Color,Texture2D> mkDot=(col)=>{ int s=96; var t=new Texture2D(s,s,TextureFormat.RGBA32,false); t.wrapMode=TextureWrapMode.Clamp; var px=new Color[s*s]; float cc=(s-1)/2f; for(int yy=0;yy<s;yy++)for(int xx=0;xx<s;xx++){ float d=Mathf.Sqrt((xx-cc)*(xx-cc)+(yy-cc)*(yy-cc))/cc; float a=d<0.62f?col.a:(d<1f?col.a*(1f-(d-0.62f)/0.38f):0f); px[yy*s+xx]=new Color(col.r,col.g,col.b,a);} t.SetPixels(px); t.Apply(); return t; };
+var dotTex=mkDot(new Color(1f,0.82f,0.35f,0.9f));
+var lpath = root.ContainsKey("lastPath") ? root["lastPath"] as System.Collections.Generic.List<object> : null;
+// M2: pick the hero's facing from its last move direction (world heading -> 8-way bake facing). PHI0/OOFF = calibration.
+string[] FORDER={"S","SE","E","NE","N","NW","W","SW"}; float PHI0=0f; int OOFF=0; string heroFace="S";
+if(lpath!=null && lpath.Count>=2){
+  var pcA=lpath[lpath.Count-2] as System.Collections.Generic.List<object>; var pcB=lpath[lpath.Count-1] as System.Collections.Generic.List<object>;
+  if(pcA!=null && pcB!=null){ var wa=cellToWorld(System.Convert.ToInt32(pcA[0]),System.Convert.ToInt32(pcA[1])); var wb=cellToWorld(System.Convert.ToInt32(pcB[0]),System.Convert.ToInt32(pcB[1]));
+    float hdx=wb.x-wa.x, hdz=wb.z-wa.z; float hd=Mathf.Atan2(hdx,hdz)*Mathf.Rad2Deg; int hk=Mathf.RoundToInt((hd-PHI0)/45f); hk=((hk%8)+8)%8; heroFace=FORDER[(hk+OOFF)%8]; }
+}
+Texture2D heroFacingTex = heroFacings.ContainsKey(heroFace)?heroFacings[heroFace]:heroTex;
+sb.AppendLine("HERO facing="+heroFace+" (facings loaded="+heroFacings.Count+")");
+
+System.Func<string,float,float,Texture2D,float,float,int,GameObject> ground=(nm,wx,wz,tex,dx,dz,q)=>{
+  var old=GameObject.Find(nm); if(old!=null) UnityEngine.Object.DestroyImmediate(old);
+  var g=GameObject.CreatePrimitive(PrimitiveType.Quad); g.name=nm; UnityEngine.Object.DestroyImmediate(g.GetComponent<Collider>());
+  g.transform.position=new Vector3(wx,0.05f,wz); g.transform.localEulerAngles=new Vector3(90f,0f,0f); g.transform.localScale=new Vector3(dx,dz,1f);
+  var m=new Material(Shader.Find("Unlit/Transparent")); m.mainTexture=tex; m.renderQueue=q;
+  var r=g.GetComponent<Renderer>(); r.sharedMaterial=m; r.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; r.receiveShadows=false; return g; };
+
+// ground-projected directional CAST shadow: a dark elongated ellipse raking DOWN-RIGHT (away from the upper-left hearth)
+System.Action<string,float,float,float,int> projShadow=(nm,wx,wz,sz,q)=>{
+  var old=GameObject.Find(nm); if(old!=null) UnityEngine.Object.DestroyImmediate(old);
+  var g=GameObject.CreatePrimitive(PrimitiveType.Quad); g.name=nm; UnityEngine.Object.DestroyImmediate(g.GetComponent<Collider>());
+  Vector3 away=new Vector3(0.7f,0f,-0.7f);                                                       // hearth upper-left -> shadow rakes down-right
+  g.transform.rotation=Quaternion.AngleAxis(135f,Vector3.up)*Quaternion.AngleAxis(90f,Vector3.right);  // flat on ground, long axis -> away
+  g.transform.localScale=new Vector3(sz*0.85f, sz*2.1f, 1f);                                     // narrow + long elongated rake
+  g.transform.position=new Vector3(wx,0.025f,wz)+away*(sz*0.75f);
+  var m=new Material(Shader.Find("Unlit/Transparent")); m.mainTexture=blob; m.renderQueue=q;
+  var r=g.GetComponent<Renderer>(); r.sharedMaterial=m; r.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; r.receiveShadows=false; };
+
+// swap actors -> scene-relit billboards (PaintedSpriteScene) + per-depth scale + ring + darker shadow
+// world-space HP BAR above an actor (engine surface hp; faces cam, draws over everything)
+System.Action<string,float,float,float,float,Color> hpbar=(pfx,wx,wz,topY,frac,col)=>{
+  foreach (var n2 in new[]{pfx+"_hudbg",pfx+"_hudfill"}){ var ex=GameObject.Find(n2); if(ex!=null) UnityEngine.Object.DestroyImmediate(ex); }
+  float bw=3.4f, bh=0.5f;
+  var b2=GameObject.CreatePrimitive(PrimitiveType.Quad); b2.name=pfx+"_hudbg"; UnityEngine.Object.DestroyImmediate(b2.GetComponent<Collider>());
+  b2.transform.position=new Vector3(wx,topY,wz); b2.transform.localEulerAngles=Vector3.zero; b2.transform.localScale=new Vector3(bw,bh,1f);
+  var mb=new Material(Shader.Find("Unlit/Color")); mb.color=new Color(0.05f,0.05f,0.06f,1f); mb.renderQueue=4000; b2.GetComponent<Renderer>().sharedMaterial=mb;
+  float fw=bw*Mathf.Clamp01(frac);
+  var fl=GameObject.CreatePrimitive(PrimitiveType.Quad); fl.name=pfx+"_hudfill"; UnityEngine.Object.DestroyImmediate(fl.GetComponent<Collider>());
+  fl.transform.position=new Vector3(wx-bw/2f+fw/2f,topY,wz-0.02f); fl.transform.localEulerAngles=Vector3.zero; fl.transform.localScale=new Vector3(Mathf.Max(0.001f,fw),bh*0.64f,1f);
+  var mf=new Material(Shader.Find("Unlit/Color")); mf.color=col; mf.renderQueue=4001; fl.GetComponent<Renderer>().sharedMaterial=mf;
+};
+// world-space TEXT label (nameplate / damage number) — TextMesh, faces cam, over everything
+Font fnt=Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
+System.Action<string,string,float,float,float,Color,float> textLabel=(objn,txt,wx,wy,wz,col,sz)=>{
+  var ex=GameObject.Find(objn); if(ex!=null) UnityEngine.Object.DestroyImmediate(ex);
+  var g=new GameObject(objn); g.transform.position=new Vector3(wx,wy,wz); g.transform.localEulerAngles=Vector3.zero;
+  var tm=g.AddComponent<TextMesh>(); tm.text=txt; tm.font=fnt; tm.fontSize=72; tm.characterSize=sz; tm.anchor=TextAnchor.MiddleCenter; tm.alignment=TextAlignment.Center; tm.color=col;
+  var mr=g.GetComponent<MeshRenderer>(); var tmat=new Material(fnt.material); tmat.renderQueue=4003; mr.sharedMaterial=tmat;
+};
+var shd=Shader.Find("WorldOS/PaintedSpriteScene"); if (shd==null) return "PaintedSpriteScene shader missing";
+float ATH=6.0f;   // L4: bigger actors (was 4.7) so the painterly figure reads as a character (silhouette/weapon) at combat zoom, per critic "roughly double scale"
+// spawn ONE actor -> scene-relit billboard at its engine cell + ring(team) + cast shadow + AO + HP bar + nameplate.
+// N-TOKEN + data-driven (no scene GameObject): sprite by name (Hero/Goblin/else->ally), ring/bar color by team.
+System.Action<string,string,Vector3,float> spawnActor=(nm,team,p,frac)=>{
+  bool foe=(team=="foe"||team=="enemy"||team=="monster");
+  Texture2D tex=(nm=="Goblin"||foe)?gobTex:(nm=="Hero"?heroFacingTex:(allyTex!=null?allyTex:heroTex));
+  Texture2D ring=foe?ringGob:ringHero;
+  float keyStr=foe?0.72f:0.68f; float atm=foe?0.08f:0.06f; float exp=foe?1.62f:1.45f; if(frac<=0.06f) exp*=0.45f;  // L3/L4: strong warm torch key + brighter exposure so figures read as the brightest warm elements over the brazier (not dim cutouts)
+  string pfx="AC_"+nm;
+  var old=GameObject.Find(pfx+"_S"); if (old!=null) UnityEngine.Object.DestroyImmediate(old);
+  var go=GameObject.CreatePrimitive(PrimitiveType.Quad); go.name=pfx+"_S"; UnityEngine.Object.DestroyImmediate(go.GetComponent<Collider>());
+  float depth01=Mathf.Clamp01((p.z-14f)/10f);
+  float sH=ATH*(foe?0.88f:1.0f)*(1f-0.15f*depth01); float asp=tex.height>0?(float)tex.width/tex.height:0.667f;
+  go.transform.rotation=Quaternion.Euler(0f, cam.transform.eulerAngles.y, 0f); go.transform.localScale=new Vector3(sH*asp,sH,1f);   // face the yaw-45 contract camera
+  go.transform.position=new Vector3(p.x,sH*0.5f,p.z);
+  var bb=go.GetComponent<Renderer>().bounds; if (Mathf.Abs(bb.min.y)>0.02f) go.transform.position+=new Vector3(0f,-bb.min.y,0f);
+  go.transform.position+=new Vector3(0f,-0.18f,0f);  // L2: seat feet slightly INTO the floor so they read as planted (kills the perceived air-gap)
+  if(frac<=0.06f){ go.transform.rotation=Quaternion.Euler(80f, cam.transform.eulerAngles.y, 0f); go.transform.position=new Vector3(p.x,0.25f,p.z); }  // M3: death = toppled to the ground
+  var m=new Material(shd); m.SetTexture("_MainTex",tex);
+  m.SetColor("_KeyColor",new Color(1f,0.62f,0.30f)); m.SetColor("_CoolColor",new Color(0.30f,0.36f,0.50f)); m.SetColor("_AtmColor",new Color(0.13f,0.13f,0.16f));
+  m.SetFloat("_KeyStrength",keyStr); m.SetFloat("_CoolStrength",0.22f); m.SetFloat("_KeyFromLeft",KEYFROMLEFT);
+  m.SetFloat("_RimStrength",1.35f); m.SetFloat("_EdgeW",0.24f); m.SetFloat("_GrainAmt",0.32f); m.SetFloat("_GrainScale",30f);  // L4: warm rim so figures pop off the floor
+  m.SetFloat("_AtmDepth",atm); m.SetFloat("_MaxLuma",0.80f); m.SetFloat("_Exposure",exp); m.SetFloat("_Cutoff",0.30f);
+  m.renderQueue=2100; var r=go.GetComponent<Renderer>(); r.sharedMaterial=m; r.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; r.receiveShadows=false;
+  float fr=(foe?2.8f:3.2f)*(1f-0.12f*depth01);
+  projShadow(pfx+"_Cast", p.x, p.z, fr, 2008);                                   // directional cast shadow raking away from the hearth
+  ground(pfx+"_Shadow", p.x, p.z, blob, fr*1.7f, fr*1.05f, 2010);                // L2 CRITICAL: large dark AO contact pool centered under the feet — the #1 grounding cue
+  ground(pfx+"_Ring",   p.x, p.z, ring, fr*1.5f, fr*1.5f, 2030);                 // team ground ring (ally gold, foe red)
+  float top=go.GetComponent<Renderer>().bounds.max.y+0.7f;
+  actorPos[nm]=new Vector3(p.x,0f,p.z); actorTop[nm]=top;
+  hpbar(pfx, p.x, p.z, top, frac, foe?new Color(0.90f,0.27f,0.27f,1f):new Color(0.30f,0.85f,0.32f,1f));
+  float npY=top+0.5f+(Mathf.Abs(Mathf.RoundToInt(p.x/2f+6.5f))%2)*0.9f;
+  { var teth=GameObject.Find(pfx+"_teth"); if(teth!=null) UnityEngine.Object.DestroyImmediate(teth); var tq=GameObject.CreatePrimitive(PrimitiveType.Quad); tq.name=pfx+"_teth"; UnityEngine.Object.DestroyImmediate(tq.GetComponent<Collider>()); tq.transform.rotation=Quaternion.Euler(0f,cam.transform.eulerAngles.y,0f); tq.transform.position=new Vector3(p.x,(top+npY)/2f,p.z); tq.transform.localScale=new Vector3(0.05f,Mathf.Max(0.01f,npY-top),1f); var tmth=new Material(Shader.Find("Unlit/Color")); tmth.color=foe?new Color(1f,0.42f,0.38f,0.5f):new Color(1f,0.85f,0.42f,0.5f); tmth.renderQueue=3999; var tr=tq.GetComponent<Renderer>(); tr.sharedMaterial=tmth; tr.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; }  // L5: team-colored tether line so each nameplate unambiguously belongs to its actor
+  textLabel(pfx+"_name", nm, p.x, npY, p.z, foe?new Color(1f,0.42f,0.38f,1f):new Color(1f,0.85f,0.42f,1f), 0.30f);  // L5: team-color (foe RED / ally GOLD) + cell-parity stagger
+  sb.AppendLine(pfx+" @"+go.transform.position.ToString("F1")+" h="+sH.ToString("F2")+" tex="+(tex==heroTex?"hero":tex==gobTex?"gob":"ally"));
+};
+// N-TOKEN render loop: one fully-decorated billboard per engine token (party scales to any count)
+foreach (var a in actors){ spawnActor((string)a[0],(string)a[1],(Vector3)a[2],(float)a[3]); }
+// P1: draw the routed path as gold breadcrumb dots on the floor (the detour AROUND the pillar)
+if(lpath!=null){ for(int i=0;i<lpath.Count;i++){ var pc=lpath[i] as System.Collections.Generic.List<object>; if(pc==null||pc.Count<2) continue; int pcx=System.Convert.ToInt32(pc[0]); int pcy=System.Convert.ToInt32(pc[1]); var wp=cellToWorld(pcx,pcy); ground("PathDot"+i, wp.x, wp.z, dotTex, 0.85f, 0.85f, 2034); } sb.AppendLine("PATH dots="+lpath.Count); }
+// floating damage number above the hit target (from the battleLog)
+var dnum=GameObject.Find("DmgNum"); if(dnum!=null) UnityEngine.Object.DestroyImmediate(dnum);
+if(dmgN>0 && actorPos.ContainsKey(dmgTarget)){ var tp=actorPos[dmgTarget]; float tt=actorTop.ContainsKey(dmgTarget)?actorTop[dmgTarget]:7f; float dny=ATH*0.6f+1.9f; textLabel("DmgNumBg","-"+dmgN,tp.x+0.08f,dny-0.08f,tp.z,new Color(0.04f,0f,0f,1f),0.5f); textLabel("DmgNum","-"+dmgN,tp.x,dny,tp.z,new Color(1f,0.96f,0.9f,1f),0.5f); }  // L5: damage number rises from the target's UPPER BODY (~burst height), not the tall billboard top / frame edge
+sb.AppendLine("HUD actors="+actors.Count+" dmg "+dmgTarget+" -"+dmgN);
+// DM NARRATION bar (bottom, cam-anchored) — the latest combat-action line from the engine battleLog
+string narrLine="";
+if(blog!=null){ foreach(var e in blog){ var ed=e as System.Collections.Generic.Dictionary<string,object>; string tx=(ed!=null&&ed.ContainsKey("text"))?ed["text"] as string:e as string; if(!string.IsNullOrEmpty(tx)&&(tx.Contains("hits")||tx.Contains("damage")||tx.Contains("strikes")||tx.Contains("attacks")||tx.Contains("misses"))) narrLine=tx; }
+  if(narrLine==""&&blog.Count>0){ var ed=blog[blog.Count-1] as System.Collections.Generic.Dictionary<string,object>; narrLine=(ed!=null&&ed.ContainsKey("text"))?ed["text"] as string:blog[blog.Count-1] as string; } }
+if(string.IsNullOrEmpty(narrLine)) narrLine="The battle is joined.";
+{ var ob=GameObject.Find("NarrBar"); if(ob!=null) UnityEngine.Object.DestroyImmediate(ob); var ot=GameObject.Find("NarrText"); if(ot!=null) UnityEngine.Object.DestroyImmediate(ot);
+  var bar=GameObject.CreatePrimitive(PrimitiveType.Quad); bar.name="NarrBar"; UnityEngine.Object.DestroyImmediate(bar.GetComponent<Collider>());
+  bar.transform.SetParent(cam.transform,false); bar.transform.localPosition=new Vector3(0,-15.6f,40f); bar.transform.localRotation=Quaternion.identity; bar.transform.localScale=new Vector3(cam.orthographicSize*2f*texAsp,4.2f,1f);
+  var bm2=new Material(Shader.Find("Unlit/Color")); bm2.color=new Color(0.03f,0.03f,0.05f,1f); bm2.renderQueue=4005; bar.GetComponent<Renderer>().sharedMaterial=bm2;
+  var tg=new GameObject("NarrText"); tg.transform.SetParent(cam.transform,false); tg.transform.localPosition=new Vector3(0,-15.6f,39.6f); tg.transform.localRotation=Quaternion.identity;
+  var tm2=tg.AddComponent<TextMesh>(); tm2.text=narrLine; tm2.font=fnt; tm2.fontSize=72; tm2.characterSize=0.34f; tm2.anchor=TextAnchor.MiddleCenter; tm2.alignment=TextAlignment.Center; tm2.color=new Color(0.93f,0.91f,0.83f,1f);
+  var tmat2=new Material(fnt.material); tmat2.renderQueue=4006; tg.GetComponent<MeshRenderer>().sharedMaterial=tmat2; }
+sb.AppendLine("NARR: "+narrLine);
+
+// M3: combat VFX flash at the hit target (additive painterly overlay; on-black sprites). melee=slash+impact, magic=bolt, death=blood.
+foreach(var n3 in new[]{"VFX_impact","VFX_slash","VFX_bolt","VFX_blood"}){ var ex=GameObject.Find(n3); if(ex!=null) UnityEngine.Object.DestroyImmediate(ex); }
+Shader vfxSh=Shader.Find("Legacy Shaders/Particles/Additive"); if(vfxSh==null) vfxSh=Shader.Find("Particles/Additive"); if(vfxSh==null) vfxSh=Shader.Find("Mobile/Particles/Additive"); if(vfxSh==null) vfxSh=Shader.Find("Unlit/Transparent");
+System.Action<string,Texture2D,float,float,float,float> vfxAt=(nm,tex,wx,wy,wz,sz)=>{ if(tex==null) return; var g=GameObject.CreatePrimitive(PrimitiveType.Quad); g.name=nm; UnityEngine.Object.DestroyImmediate(g.GetComponent<Collider>()); g.transform.position=new Vector3(wx,wy,wz); g.transform.rotation=Quaternion.Euler(0f,cam.transform.eulerAngles.y,0f); float asp=tex.height>0?(float)tex.width/tex.height:1f; g.transform.localScale=new Vector3(sz*asp,sz,1f); var m=new Material(vfxSh); m.mainTexture=tex; m.renderQueue=2200; var r=g.GetComponent<Renderer>(); r.sharedMaterial=m; r.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; r.receiveShadows=false; };
+string vfxDbg="none";
+if(dmgN>0 && actorPos.ContainsKey(dmgTarget)){ var tp=actorPos[dmgTarget]; float ch=ATH*0.55f; string nl=(narrLine==null?"":narrLine).ToLower();
+  bool magic=nl.Contains("bolt")||nl.Contains("fire")||nl.Contains("flame")||nl.Contains("magic")||nl.Contains("eldritch")||nl.Contains("ray")||nl.Contains("spell")||nl.Contains("arcane")||nl.Contains("scorch");
+  bool death=nl.Contains("dies")||nl.Contains("falls")||nl.Contains("slain")||nl.Contains("drops")||nl.Contains("collapses")||nl.Contains("crumples");
+  if(magic){ vfxAt("VFX_bolt",vfxBolt,tp.x,ch,tp.z,4.2f); vfxDbg="bolt"; }
+  else { vfxAt("VFX_impact",vfxImpact,tp.x,ch,tp.z,3.6f); vfxAt("VFX_slash",vfxSlash,tp.x,ch+0.5f,tp.z,4.4f); vfxDbg="slash+impact"; }
+  if(death){ vfxAt("VFX_blood",vfxBlood,tp.x,1.0f,tp.z,3.2f); vfxDbg+="+blood"; }  // L5: smaller VFX so it doesn't swallow the actor + team ring
+}
+sb.AppendLine("VFX@"+dmgTarget+"="+vfxDbg);
+
+// capture (native plate aspect)
+int W=1920,Hh=Mathf.RoundToInt(1920f*(float)bdTex.height/bdTex.width); var rt=new RenderTexture(W,Hh,24,RenderTextureFormat.ARGB32); rt.Create();
+float pa=cam.aspect; var pt=cam.targetTexture; cam.targetTexture=rt; cam.aspect=(float)W/Hh; cam.Render();
+var pAct=RenderTexture.active; RenderTexture.active=rt; var t2=new Texture2D(W,Hh,TextureFormat.RGB24,false);
+t2.ReadPixels(new Rect(0,0,W,Hh),0,0); t2.Apply(); RenderTexture.active=pAct; cam.targetTexture=pt; cam.aspect=pa;
+System.IO.Directory.CreateDirectory("/home/unity/worldos-unity/Captures-Durable");
+System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/painted_backdrop_r3.png", t2.EncodeToPNG());
+UnityEngine.Object.DestroyImmediate(t2); rt.Release(); UnityEngine.Object.DestroyImmediate(rt);
+sb.AppendLine("hidden="+hidden+" KEYFROMLEFT="+KEYFROMLEFT+" captured "+W+"x"+Hh+" -> painted_backdrop_r3.png");
+return sb.ToString();


### PR DESCRIPTION
## Why
Owner caught a **week-of-work regression**: combat work was being resumed from a week-old tavern room (`combat_0N`, 06-23) instead of the current 06-28 crypt 3D-hero spike. Visual-critic confirmed the old room scores **L5=3.5 CRITICAL** (floating dark actor, no goblin/rings/VFX) — i.e. iterating on it was *backwards* motion.

## Root cause (5 gaps)
1. Best work is **render-and-forget** — runtime `code execute -f` → PNG, scene never `SaveScene`'d → only saved scene is the week-old tavern.
2. **No off-box version control** — box Unity git has no remote, no `.gitignore`; `Assets/painterly/` (rooms, 3D hero, sprites) untracked (77 dirty).
3. **Build scripts not in the repo** (0) — only on the box (uncommitted) + local notes.
4. **No canonical registry** — nothing declares latest-best → resume grabs a random recent PNG.
5. **Asset scatter** — hero as billboards + 3D FBX + material; rooms as tavern + crypt; 2 capture dirs.

## This PR
- `extensions/renderers/unity/CANONICAL.md` — the **latest-best registry** (current room/character/animator + rebuild cmd + best score + the DEPRECATED list) and the **iteration discipline** (read-first-on-resume; an iteration isn't done until persisted + scored + registered + committed).
- `extensions/renderers/unity/scripts/` — the **20 box build scripts, committed off-box for the first time**.

## Follow-ups (next)
- Box `.gitignore` (exclude Library/Temp/packs) + commit the box painterly assets; periodic off-box tarball (a fresh full backup was taken 2026-06-28).
- `gex44-unity-host` skill: point at CANONICAL.md + the discipline.
- Make build scripts `SaveScene` (stop render-and-forget).

Additive infra only — no engine/content/test changes.