### PR TITLE
Combat-gate prep: CombatActor animator builder + SaveScene persistence

### DIFF
--- a/extensions/renderers/unity/scripts/WorldOsAutoArmBridge.cs
+++ b/extensions/renderers/unity/scripts/WorldOsAutoArmBridge.cs
@@ -1,0 +1,55 @@
+// WorldOsAutoArmBridge.cs — headless auto-arm for the CoplayDev MCP-For-Unity HTTP bridge.
+// WHY: a fresh editor does NOT arm itself (the AutoStartOnLoad pref defaults false AND issue #1121
+// means the pref check in InitializeOnLoad runs before EditorPrefs is initialized, so it never fires).
+// This script bypasses the pref entirely: on every domain reload, it polls (via EditorApplication.update,
+// so services + the local server are ready) and calls MCPServiceLocator.Bridge.StartAsync() ONCE —
+// the exact method the panel's "Connect" button uses. Reflection avoids an asmdef reference.
+// Place under Assets/Editor/. Idempotent + self-detaching. Remove if/when CoplayDev #1121 lands upstream.
+using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+[InitializeOnLoad]
+public static class WorldOsAutoArmBridge
+{
+    static double _deadline = 0;
+    static bool _done = false;
+
+    static WorldOsAutoArmBridge()
+    {
+        EditorApplication.update += Tick;
+    }
+
+    static void Tick()
+    {
+        if (_done) { EditorApplication.update -= Tick; return; }
+        if (_deadline == 0) _deadline = EditorApplication.timeSinceStartup + 45.0;
+        if (EditorApplication.timeSinceStartup > _deadline) { _done = true; EditorApplication.update -= Tick; return; }
+
+        try
+        {
+            Type locator = null;
+            foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                var t = a.GetType("MCPForUnity.Editor.Services.MCPServiceLocator");
+                if (t != null) { locator = t; break; }
+            }
+            if (locator == null) return; // plugin assembly not loaded yet; keep polling
+
+            var bridge = locator.GetProperty("Bridge", BindingFlags.Public | BindingFlags.Static)?.GetValue(null);
+            if (bridge == null) return;
+
+            bool running = (bool)bridge.GetType().GetProperty("IsRunning").GetValue(bridge);
+            if (running) { Debug.Log("[WorldOS-autoarm] bridge already armed"); _done = true; return; }
+
+            bridge.GetType().GetMethod("StartAsync").Invoke(bridge, null); // fire-and-forget Task<bool>
+            Debug.Log("[WorldOS-autoarm] StartAsync invoked -> arming HTTP bridge");
+            _done = true; // arm once; if it fails, fall back to manual Connect
+        }
+        catch (Exception e)
+        {
+            Debug.LogWarning("[WorldOS-autoarm] " + e.Message);
+        }
+    }
+}

--- a/extensions/renderers/unity/scripts/build_combat_animator.cs
+++ b/extensions/renderers/unity/scripts/build_combat_animator.cs
@@ -1,0 +1,63 @@
+// build_combat_animator.cs — import the 9-clip Meshy moveset (as Generic) + build the CombatActor Animator.
+// Run on the GEX44 box: unity-mcp code execute --no-safety-checks -f build_combat_animator.cs
+// Expects the moveset clips deployed at Assets/painterly/models/moveset/anim_<name>.fbx
+// (from `meshy_gen.py --rig-from-task <hero> --moveset`). Built-in pipeline; runs via the CoplayDev bridge.
+// Source patterns: Besty0728 AnimatorSkills (see unity-editor-patterns-m1-combat.md). CANONICAL.md discipline.
+using System.Linq;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.Animations;
+using UnityEngine;
+
+var sb = new System.Text.StringBuilder();
+const string DIR = "Assets/painterly/models/moveset/";
+const string CTRL = "Assets/Animations/CombatActor.controller";
+var moves = new[] { "idle", "walk", "run", "attack", "cast", "block", "dodge", "hit", "death" };
+
+// 1) import each clip FBX as Generic — Humanoid SILENTLY DROPS Meshy/Tripo clips (load-bearing gotcha).
+int imported = 0;
+foreach (var m in moves) {
+    string fbx = DIR + "anim_" + m + ".fbx";
+    var imp = AssetImporter.GetAtPath(fbx) as ModelImporter;
+    if (imp == null) { sb.AppendLine("MISSING " + fbx); continue; }
+    if (imp.animationType != ModelImporterAnimationType.Generic) { imp.animationType = ModelImporterAnimationType.Generic; imp.SaveAndReimport(); }
+    imported++;
+}
+AssetDatabase.Refresh();
+
+// 2) build the controller: 9 states + a trigger per verb + Any-State transitions; idempotent (rebuilds clean).
+System.IO.Directory.CreateDirectory("Assets/Animations");
+var ctrl = AssetDatabase.LoadAssetAtPath<AnimatorController>(CTRL) ?? AnimatorController.CreateAnimatorControllerAtPath(CTRL);
+foreach (var p in ctrl.parameters.ToArray()) ctrl.RemoveParameter(p.name);
+var sm = ctrl.layers[0].stateMachine;
+foreach (var cs in sm.states.ToArray()) sm.RemoveState(cs.state);
+
+System.Func<string, AnimationClip> clipOf = (m) =>
+    AssetDatabase.LoadAllAssetsAtPath(DIR + "anim_" + m + ".fbx").OfType<AnimationClip>().FirstOrDefault(c => !c.name.StartsWith("__"));
+
+var states = new Dictionary<string, AnimatorState>();
+foreach (var m in moves) {
+    string trig = "to" + char.ToUpper(m[0]) + m.Substring(1);
+    ctrl.AddParameter(trig, AnimatorControllerParameterType.Trigger);
+    var st = sm.AddState(m);
+    st.motion = clipOf(m);
+    states[m] = st;
+    if (st.motion == null) sb.AppendLine("WARN no clip in anim_" + m + ".fbx");
+}
+sm.defaultState = states["idle"];
+
+foreach (var m in moves) {
+    if (m == "idle") continue;
+    string trig = "to" + char.ToUpper(m[0]) + m.Substring(1);
+    var anyT = sm.AddAnyStateTransition(states[m]);
+    anyT.AddCondition(AnimatorConditionMode.If, 0, trig);
+    anyT.duration = 0.10f; anyT.canTransitionToSelf = false;
+    // one-shot verbs return to idle; locomotion + death hold
+    if (m != "walk" && m != "run" && m != "death") {
+        var back = states[m].AddTransition(states["idle"]);
+        back.hasExitTime = true; back.exitTime = 0.9f; back.duration = 0.25f;
+    }
+}
+AssetDatabase.SaveAssets();
+sb.AppendLine("CombatActor.controller: imported=" + imported + "/9 states=" + sm.states.Length + " params=" + ctrl.parameters.Length);
+return sb.ToString();

--- a/extensions/renderers/unity/scripts/build_combat_animator.cs
+++ b/extensions/renderers/unity/scripts/build_combat_animator.cs
@@ -46,7 +46,8 @@ System.Func<string, UnityEngine.AnimationClip> clipOf = (m) => {
 
 var states = new System.Collections.Generic.Dictionary<string, UnityEditor.Animations.AnimatorState>();
 foreach (var m in moves) {
-    string trig = "to" + char.ToUpper(m[0]) + m.Substring(1);
+    // CombatBeatDriver.cs fires SetTrigger("doAttack") for the attack verb — match that name, not "toAttack".
+    string trig = (m == "attack") ? "doAttack" : "to" + char.ToUpper(m[0]) + m.Substring(1);
     ctrl.AddParameter(trig, UnityEngine.AnimatorControllerParameterType.Trigger);
     var st = sm.AddState(m);
     st.motion = clipOf(m);
@@ -54,10 +55,13 @@ foreach (var m in moves) {
     if (st.motion == null) sb.AppendLine("WARN no clip in anim_" + m + ".fbx");
 }
 sm.defaultState = states["idle"];
+// CombatBeatDriver.cs drives locomotion via SetBool("IsWalking", …); declare it so those calls aren't silent no-ops.
+// (walk/run STATES still await Blender-cleaned clips — the bool is wired ahead of the locomotion states.)
+ctrl.AddParameter("IsWalking", UnityEngine.AnimatorControllerParameterType.Bool);
 
 foreach (var m in moves) {
     if (m == "idle") continue;
-    string trig = "to" + char.ToUpper(m[0]) + m.Substring(1);
+    string trig = (m == "attack") ? "doAttack" : "to" + char.ToUpper(m[0]) + m.Substring(1);
     var anyT = sm.AddAnyStateTransition(states[m]);
     anyT.AddCondition(UnityEditor.Animations.AnimatorConditionMode.If, 0, trig);
     anyT.duration = 0.10f; anyT.canTransitionToSelf = false;
@@ -67,5 +71,5 @@ foreach (var m in moves) {
     }
 }
 UnityEditor.AssetDatabase.SaveAssets();
-sb.AppendLine("CombatActor.controller: imported=" + imported + "/7 states=" + sm.states.Length + " params=" + ctrl.parameters.Length);
+sb.AppendLine("CombatActor.controller: imported=" + imported + "/" + moves.Length + " states=" + sm.states.Length + " params=" + ctrl.parameters.Length);
 return sb.ToString();

--- a/extensions/renderers/unity/scripts/build_combat_animator.cs
+++ b/extensions/renderers/unity/scripts/build_combat_animator.cs
@@ -1,44 +1,53 @@
-// build_combat_animator.cs — import the 9-clip Meshy moveset (as Generic) + build the CombatActor Animator.
+// build_combat_animator.cs — import the moveset (Generic) + build the CombatActor Animator controller.
 // Run on the GEX44 box: unity-mcp code execute --no-safety-checks -f build_combat_animator.cs
-// Expects the moveset clips deployed at Assets/painterly/models/moveset/anim_<name>.fbx
-// (from `meshy_gen.py --rig-from-task <hero> --moveset`). Built-in pipeline; runs via the CoplayDev bridge.
-// Source patterns: Besty0728 AnimatorSkills (see unity-editor-patterns-m1-combat.md). CANONICAL.md discipline.
-using System.Linq;
-using System.Collections.Generic;
-using UnityEditor;
-using UnityEditor.Animations;
-using UnityEngine;
-
+// NO top-level `using` — `code execute` wraps the snippet in a method body where `using` is illegal
+// (the proven paint_3d_spike.cs works precisely because it fully-qualifies everything). No LINQ either.
+// Expects the moveset clips at Assets/painterly/models/moveset/anim_<name>.fbx (imported as Generic).
 var sb = new System.Text.StringBuilder();
-const string DIR = "Assets/painterly/models/moveset/";
-const string CTRL = "Assets/Animations/CombatActor.controller";
-var moves = new[] { "idle", "walk", "run", "attack", "cast", "block", "dodge", "hit", "death" };
+string DIR = "Assets/painterly/models/moveset/";
+string CTRL = "Assets/Animations/CombatActor.controller";
+// walk/run deferred (no .glb to Blender-clean); combat needs idle/attack/cast/block/dodge/hit/death.
+var moves = new string[] { "idle", "attack", "cast", "block", "dodge", "hit", "death" };
+
+UnityEditor.AssetDatabase.Refresh();
 
 // 1) import each clip FBX as Generic — Humanoid SILENTLY DROPS Meshy/Tripo clips (load-bearing gotcha).
 int imported = 0;
 foreach (var m in moves) {
     string fbx = DIR + "anim_" + m + ".fbx";
-    var imp = AssetImporter.GetAtPath(fbx) as ModelImporter;
+    var imp = UnityEditor.AssetImporter.GetAtPath(fbx) as UnityEditor.ModelImporter;
     if (imp == null) { sb.AppendLine("MISSING " + fbx); continue; }
-    if (imp.animationType != ModelImporterAnimationType.Generic) { imp.animationType = ModelImporterAnimationType.Generic; imp.SaveAndReimport(); }
+    if (imp.animationType != UnityEditor.ModelImporterAnimationType.Generic) {
+        imp.animationType = UnityEditor.ModelImporterAnimationType.Generic;
+        imp.SaveAndReimport();
+    }
     imported++;
 }
-AssetDatabase.Refresh();
+UnityEditor.AssetDatabase.Refresh();
 
-// 2) build the controller: 9 states + a trigger per verb + Any-State transitions; idempotent (rebuilds clean).
+// 2) build the controller: states + a trigger per verb + Any-State transitions; idempotent (rebuilds clean).
 System.IO.Directory.CreateDirectory("Assets/Animations");
-var ctrl = AssetDatabase.LoadAssetAtPath<AnimatorController>(CTRL) ?? AnimatorController.CreateAnimatorControllerAtPath(CTRL);
-foreach (var p in ctrl.parameters.ToArray()) ctrl.RemoveParameter(p.name);
+var ctrl = UnityEditor.AssetDatabase.LoadAssetAtPath<UnityEditor.Animations.AnimatorController>(CTRL);
+if (ctrl == null) ctrl = UnityEditor.Animations.AnimatorController.CreateAnimatorControllerAtPath(CTRL);
+var paramsCopy = ctrl.parameters;
+foreach (var p in paramsCopy) ctrl.RemoveParameter(p.name);
 var sm = ctrl.layers[0].stateMachine;
-foreach (var cs in sm.states.ToArray()) sm.RemoveState(cs.state);
+var statesCopy = sm.states;
+foreach (var cs in statesCopy) sm.RemoveState(cs.state);
 
-System.Func<string, AnimationClip> clipOf = (m) =>
-    AssetDatabase.LoadAllAssetsAtPath(DIR + "anim_" + m + ".fbx").OfType<AnimationClip>().FirstOrDefault(c => !c.name.StartsWith("__"));
+System.Func<string, UnityEngine.AnimationClip> clipOf = (m) => {
+    var assets = UnityEditor.AssetDatabase.LoadAllAssetsAtPath(DIR + "anim_" + m + ".fbx");
+    foreach (var a in assets) {
+        var ac = a as UnityEngine.AnimationClip;
+        if (ac != null && !ac.name.StartsWith("__")) return ac;
+    }
+    return null;
+};
 
-var states = new Dictionary<string, AnimatorState>();
+var states = new System.Collections.Generic.Dictionary<string, UnityEditor.Animations.AnimatorState>();
 foreach (var m in moves) {
     string trig = "to" + char.ToUpper(m[0]) + m.Substring(1);
-    ctrl.AddParameter(trig, AnimatorControllerParameterType.Trigger);
+    ctrl.AddParameter(trig, UnityEngine.AnimatorControllerParameterType.Trigger);
     var st = sm.AddState(m);
     st.motion = clipOf(m);
     states[m] = st;
@@ -50,14 +59,13 @@ foreach (var m in moves) {
     if (m == "idle") continue;
     string trig = "to" + char.ToUpper(m[0]) + m.Substring(1);
     var anyT = sm.AddAnyStateTransition(states[m]);
-    anyT.AddCondition(AnimatorConditionMode.If, 0, trig);
+    anyT.AddCondition(UnityEditor.Animations.AnimatorConditionMode.If, 0, trig);
     anyT.duration = 0.10f; anyT.canTransitionToSelf = false;
-    // one-shot verbs return to idle; locomotion + death hold
-    if (m != "walk" && m != "run" && m != "death") {
+    if (m != "death") {  // one-shot verbs return to idle; death holds (terminal)
         var back = states[m].AddTransition(states["idle"]);
         back.hasExitTime = true; back.exitTime = 0.9f; back.duration = 0.25f;
     }
 }
-AssetDatabase.SaveAssets();
-sb.AppendLine("CombatActor.controller: imported=" + imported + "/9 states=" + sm.states.Length + " params=" + ctrl.parameters.Length);
+UnityEditor.AssetDatabase.SaveAssets();
+sb.AppendLine("CombatActor.controller: imported=" + imported + "/7 states=" + sm.states.Length + " params=" + ctrl.parameters.Length);
 return sb.ToString();

--- a/extensions/renderers/unity/scripts/paint_3d_spike.cs
+++ b/extensions/renderers/unity/scripts/paint_3d_spike.cs
@@ -55,4 +55,6 @@ System.IO.Directory.CreateDirectory("/home/unity/worldos-unity/Captures-Durable"
 System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/m10_spike.png", t2.EncodeToPNG());
 UnityEngine.Object.DestroyImmediate(t2); rt.Release(); UnityEngine.Object.DestroyImmediate(rt);
 sb.AppendLine("captured "+W+"x"+Hh+" -> m10_spike.png hidden="+hidden);
+// PERSIST the built scene (anti render-and-forget — CANONICAL.md discipline). Best-effort Save-As.
+try { var _scn=UnityEngine.SceneManagement.SceneManager.GetActiveScene(); System.IO.Directory.CreateDirectory("Assets/Scenes"); UnityEditor.SceneManagement.EditorSceneManager.SaveScene(_scn, "Assets/Scenes/CombatCrypt_canonical.unity"); sb.AppendLine("scene SAVED -> Assets/Scenes/CombatCrypt_canonical.unity"); } catch(System.Exception _e){ sb.AppendLine("SaveScene FAILED: "+_e.Message); }
 return sb.ToString();

--- a/extensions/renderers/unity/scripts/paint_combat_scene.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_scene.cs
@@ -1,0 +1,104 @@
+// paint_combat_scene.cs — M1 combat render: crypt plate + animated 3D hero (attack pose) + goblin,
+// gold/red selection rings, contact shadows, a spell/impact VFX flash, and a floating damage number.
+// Extends the PROVEN paint_3d_spike (crypt + textured/lit/grounded 3D hero). Targets the visual-critic
+// levers that capped the old render: L4 (lit grounded 3D actor), L5 (rings + VFX + 2 readable actors),
+// L2 (contact shadow). Run on the box via: unity-mcp code execute --no-safety-checks -f paint_combat_scene.cs
+// DEPENDS ON: Assets/painterly/models/{hero.fbx OR rigged.fbx, hero_albedo.png}, the CombatActor controller
+// (build_combat_animator.cs), and optionally Assets/painterly/models/goblin.fbx (+ goblin_albedo.png).
+// NOTE: untested off-box — expect 1-2 iterations live (poses/ring scale/VFX placement).
+using System.Linq;
+AssetDatabase.Refresh();
+var sb = new System.Text.StringBuilder();
+Camera cam = Camera.main; if (cam == null && Camera.allCameras.Length > 0) cam = Camera.allCameras[0]; if (cam == null) return "no cam";
+
+// --- frozen dimetric contract camera (cell 2.0, 14x11, elev30 yaw45 ortho13) ---
+cam.orthographic = true; cam.orthographicSize = 13f; cam.nearClipPlane = 0.3f; cam.farClipPlane = 500f;
+{ Quaternion r = Quaternion.Euler(30f, 45f, 0f); cam.transform.rotation = r; cam.transform.position = -(r * Vector3.forward) * 80f; }
+cam.clearFlags = CameraClearFlags.SolidColor; cam.backgroundColor = new Color(0.02f, 0.02f, 0.03f);
+int hidden = 0; foreach (var r in UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None)) { if (r.enabled) { r.enabled = false; hidden++; } }
+System.Func<int, int, Vector3> cellToWorld = (cx, cy) => new Vector3((cx - 6.5f) * 2.0f, 0f, (5.0f - cy) * 2.0f);
+
+// --- painted crypt plate ---
+var bdTex = AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/backdrops/crypt_pinned_v1.png"); if (bdTex == null) return "no plate";
+var oldBd = GameObject.Find("PaintedBackdrop"); if (oldBd != null) UnityEngine.Object.DestroyImmediate(oldBd);
+var bd = GameObject.CreatePrimitive(PrimitiveType.Quad); bd.name = "PaintedBackdrop"; UnityEngine.Object.DestroyImmediate(bd.GetComponent<Collider>());
+bd.transform.SetParent(cam.transform, false); float texAsp = (float)bdTex.width / bdTex.height; float oh = cam.orthographicSize * 2f; float ow = oh * texAsp;
+bd.transform.localPosition = new Vector3(0, 0, 160f); bd.transform.localScale = new Vector3(ow, oh, 1f);
+{ var bm = new Material(Shader.Find("Unlit/Texture")); bm.mainTexture = bdTex; bm.renderQueue = 1900; var bdr = bd.GetComponent<Renderer>(); bdr.sharedMaterial = bm; bdr.enabled = true; bdr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off; bdr.receiveShadows = false; }
+
+// --- PoE2 lighting rig (warm key + cool fill + cool ambient + 2 brazier point lights) ---
+foreach (var ln in new[] { "KeyLight", "FillLight", "BrazierL", "BrazierR" }) { var o = GameObject.Find(ln); if (o != null) UnityEngine.Object.DestroyImmediate(o); }
+{ var lg = new GameObject("KeyLight"); var L = lg.AddComponent<Light>(); L.type = LightType.Directional; L.color = new Color(1f, 0.73f, 0.44f); L.intensity = 1.35f; L.shadows = LightShadows.Soft; L.shadowStrength = 0.8f; lg.transform.rotation = Quaternion.Euler(48f, 35f, 0f); }
+{ var fg = new GameObject("FillLight"); var F = fg.AddComponent<Light>(); F.type = LightType.Directional; F.color = new Color(0.36f, 0.44f, 0.64f); F.intensity = 0.55f; F.shadows = LightShadows.None; fg.transform.rotation = Quaternion.Euler(34f, 215f, 0f); }
+RenderSettings.ambientMode = UnityEngine.Rendering.AmbientMode.Flat; RenderSettings.ambientLight = new Color(0.24f, 0.28f, 0.40f);
+System.Action<string, int, int> brazier = (nm, cx, cy) => { var bg = new GameObject(nm); var B = bg.AddComponent<Light>(); B.type = LightType.Point; B.color = new Color(1f, 0.48f, 0.18f); B.range = 7.5f; B.intensity = 3.6f; var wp = cellToWorld(cx, cy); bg.transform.position = new Vector3(wp.x, 1.7f, wp.z); };
+brazier("BrazierL", 4, 1); brazier("BrazierR", 9, 1);
+
+// --- helper: spawn a textured 3D actor (FBX) at a cell, stand-up + scale-MULTIPLY + foot-snap + albedo ---
+System.Func<string, string, string, int, int, float, GameObject> spawnActor = (fbxPath, albedoPath, nm, cx, cy, targetH) => {
+    var pf = AssetDatabase.LoadAssetAtPath<GameObject>(fbxPath); if (pf == null) { sb.AppendLine("MISSING " + fbxPath); return null; }
+    var old = GameObject.Find(nm); if (old != null) UnityEngine.Object.DestroyImmediate(old);
+    var go = (GameObject)UnityEngine.Object.Instantiate(pf); go.name = nm;
+    go.transform.rotation = Quaternion.Euler(-90f, cam.transform.eulerAngles.y + 180f, 0f); // stand the lying Z-up upright + face cam
+    var rends = go.GetComponentsInChildren<Renderer>();
+    foreach (var r in rends) { r.enabled = true; r.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.On; r.receiveShadows = true; }
+    System.Func<Bounds> measure = () => { Bounds b = new Bounds(go.transform.position, Vector3.zero); bool a = false; foreach (var r in rends) { if (!a) { b = r.bounds; a = true; } else b.Encapsulate(r.bounds); } return b; };
+    Bounds bb = measure(); float curH = bb.size.y > 0.001f ? bb.size.y : 1f; go.transform.localScale = go.transform.localScale * (targetH / curH);
+    var p = cellToWorld(cx, cy); go.transform.position = p; bb = measure(); go.transform.position += new Vector3(0f, -bb.min.y, 0f);
+    var alb = AssetDatabase.LoadAssetAtPath<Texture2D>(albedoPath);
+    if (alb != null) { var m = new Material(Shader.Find("Standard")); m.mainTexture = alb; m.SetFloat("_Glossiness", 0.2f); m.SetFloat("_Metallic", 0f); foreach (var r in rends) r.sharedMaterial = m; }
+    return go;
+};
+
+// --- contact-shadow AO blob under feet ---
+var blobT = new Texture2D(256, 256, TextureFormat.RGBA32, false); blobT.wrapMode = TextureWrapMode.Clamp;
+{ var px = new Color[256 * 256]; float c = 127.5f; for (int y = 0; y < 256; y++) for (int x = 0; x < 256; x++) { float d = Mathf.Clamp01(Mathf.Sqrt((x - c) * (x - c) + (y - c) * (y - c)) / c); px[y * 256 + x] = new Color(0.02f, 0.02f, 0.03f, Mathf.Pow(1f - d, 0.9f)); } blobT.SetPixels(px); blobT.Apply(); }
+System.Action<string, int, int, float> aoBlob = (nm, cx, cy, sz) => { var ao = GameObject.CreatePrimitive(PrimitiveType.Quad); ao.name = nm; UnityEngine.Object.DestroyImmediate(ao.GetComponent<Collider>()); var wp = cellToWorld(cx, cy); ao.transform.position = new Vector3(wp.x, 0.05f, wp.z); ao.transform.localEulerAngles = new Vector3(90f, 0f, 0f); ao.transform.localScale = new Vector3(sz, sz * 0.62f, 1f); var aom = new Material(Shader.Find("Unlit/Transparent")); aom.mainTexture = blobT; aom.renderQueue = 1950; var aor = ao.GetComponent<Renderer>(); aor.sharedMaterial = aom; aor.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off; };
+
+// --- selection ring (gold ally / red foe), flat ~2:1 ellipse concentric with the cell ---
+System.Action<string, int, int, Color> ring = (nm, cx, cy, col) => { var q = GameObject.CreatePrimitive(PrimitiveType.Quad); q.name = nm; UnityEngine.Object.DestroyImmediate(q.GetComponent<Collider>()); var wp = cellToWorld(cx, cy); q.transform.position = new Vector3(wp.x, 0.06f, wp.z); q.transform.localEulerAngles = new Vector3(90f, 0f, 0f); q.transform.localScale = new Vector3(2.6f, 2.6f * 0.6f, 1f);
+    // ring texture: a soft annulus
+    var rt = new Texture2D(128, 128, TextureFormat.RGBA32, false); rt.wrapMode = TextureWrapMode.Clamp; var rp = new Color[128 * 128]; float cc = 63.5f; for (int y = 0; y < 128; y++) for (int x = 0; x < 128; x++) { float d = Mathf.Sqrt((x - cc) * (x - cc) + (y - cc) * (y - cc)) / cc; float a = Mathf.Clamp01(1f - Mathf.Abs(d - 0.82f) / 0.16f); rp[y * 128 + x] = new Color(col.r, col.g, col.b, a * 0.9f); } rt.SetPixels(rp); rt.Apply();
+    var rm = new Material(Shader.Find("Unlit/Transparent")); rm.mainTexture = rt; rm.renderQueue = 1960; var rr = q.GetComponent<Renderer>(); rr.sharedMaterial = rm; rr.shadowCastingMode = UnityEngine.Rendering.ShadowCastingMode.Off; };
+
+// === spawn HERO (attack pose) + GOBLIN (recoil) ===
+int hx = 6, hy = 6, gx = 8, gy = 5;
+string heroFbx = System.IO.File.Exists("/home/unity/worldos-unity/Assets/painterly/models/rigged.fbx") ? "Assets/painterly/models/rigged.fbx" : "Assets/painterly/models/hero.fbx";
+var hero = spawnActor(heroFbx, "Assets/painterly/models/hero_albedo.png", "Hero3D", hx, hy, 5.0f);
+// sample the ATTACK clip onto the hero (static mid-attack pose) if the CombatActor controller exists
+if (hero != null) {
+    var ctrl = AssetDatabase.LoadAssetAtPath<UnityEditor.Animations.AnimatorController>("Assets/Animations/CombatActor.controller");
+    var atkClip = AssetDatabase.LoadAllAssetsAtPath("Assets/painterly/models/moveset/anim_attack.fbx").OfType<AnimationClip>().FirstOrDefault(c => !c.name.StartsWith("__"));
+    if (atkClip != null) { atkClip.SampleAnimation(hero, atkClip.length * 0.45f); sb.AppendLine("sampled attack pose t=" + (atkClip.length * 0.45f).ToString("F2")); }
+    else sb.AppendLine("no attack clip (idle pose)");
+}
+aoBlob("HeroAO", hx, hy, 2.4f); ring("HeroRing", hx, hy, new Color(1f, 0.80f, 0.42f));
+
+var goblin = spawnActor("Assets/painterly/models/goblin.fbx", "Assets/painterly/models/goblin_albedo.png", "Goblin3D", gx, gy, 4.2f);
+if (goblin != null) { aoBlob("GoblinAO", gx, gy, 2.0f); ring("GoblinRing", gx, gy, new Color(0.88f, 0.28f, 0.30f)); }
+else sb.AppendLine("goblin.fbx not present -> hero-only (clean+deploy goblin for the full combat read)");
+
+// === impact VFX flash at the goblin (Hovl prefab if available; else an additive slash quad) ===
+{ var wp = cellToWorld(gx, gy); Object vpf = null;
+  foreach (var g in AssetDatabase.FindAssets("t:GameObject impact").Take(1)) { vpf = AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath(g)); }
+  if (vpf != null) { var v = (GameObject)UnityEngine.Object.Instantiate(vpf); v.name = "ImpactVFX"; v.transform.position = new Vector3(wp.x, 1.6f, wp.z); sb.AppendLine("Hovl impact VFX placed"); }
+  else { var fl = GameObject.CreatePrimitive(PrimitiveType.Quad); fl.name = "SlashVFX"; UnityEngine.Object.DestroyImmediate(fl.GetComponent<Collider>()); fl.transform.position = new Vector3(wp.x, 1.7f, wp.z); fl.transform.rotation = cam.transform.rotation; fl.transform.localScale = Vector3.one * 2.2f;
+    var ft = new Texture2D(128, 128, TextureFormat.RGBA32, false); var fp = new Color[128 * 128]; float fc = 63.5f; for (int y = 0; y < 128; y++) for (int x = 0; x < 128; x++) { float d = Mathf.Sqrt((x - fc) * (x - fc) + (y - fc) * (y - fc)) / fc; fp[y * 128 + x] = new Color(1f, 0.6f, 0.2f, Mathf.Clamp01(1f - d) * 0.85f); } ft.SetPixels(fp); ft.Apply();
+    var fm = new Material(Shader.Find("Unlit/Transparent")); fm.mainTexture = ft; fm.renderQueue = 3000; fl.GetComponent<Renderer>().sharedMaterial = fm; sb.AppendLine("fallback slash VFX placed"); } }
+
+// === floating damage number "-8" over the goblin (white, outlined-ish via a dark backing quad) ===
+// (kept simple: a TextMesh billboarded to the camera)
+{ var dn = new GameObject("DmgNumber"); var tm = dn.AddComponent<TextMesh>(); tm.text = "-8"; tm.fontSize = 64; tm.characterSize = 0.18f; tm.anchor = TextAnchor.MiddleCenter; tm.color = Color.white; tm.fontStyle = FontStyle.Bold; var wp = cellToWorld(gx, gy); dn.transform.position = new Vector3(wp.x + 0.8f, 3.6f, wp.z); dn.transform.rotation = cam.transform.rotation; dn.GetComponent<Renderer>().sharedMaterial.renderQueue = 4000; }
+
+// === capture (1920-wide, plate aspect) ===
+int W = 1920, Hh = Mathf.RoundToInt(1920f * (float)bdTex.height / bdTex.width); var rtex = new RenderTexture(W, Hh, 24, RenderTextureFormat.ARGB32); rtex.Create();
+float pa = cam.aspect; var pt = cam.targetTexture; cam.targetTexture = rtex; cam.aspect = (float)W / Hh; cam.Render();
+var pAct = RenderTexture.active; RenderTexture.active = rtex; var t2 = new Texture2D(W, Hh, TextureFormat.RGB24, false); t2.ReadPixels(new Rect(0, 0, W, Hh), 0, 0); t2.Apply(); RenderTexture.active = pAct; cam.targetTexture = pt; cam.aspect = pa;
+System.IO.Directory.CreateDirectory("/home/unity/worldos-unity/Captures-Durable");
+System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/m1_combat_v1.png", t2.EncodeToPNG());
+UnityEngine.Object.DestroyImmediate(t2); rtex.Release(); UnityEngine.Object.DestroyImmediate(rtex);
+sb.AppendLine("captured " + W + "x" + Hh + " -> m1_combat_v1.png");
+
+// === PERSIST the scene (anti render-and-forget — CANONICAL.md discipline) ===
+try { var scn = UnityEngine.SceneManagement.SceneManager.GetActiveScene(); System.IO.Directory.CreateDirectory("Assets/Scenes"); UnityEditor.SceneManagement.EditorSceneManager.SaveScene(scn, "Assets/Scenes/M1Combat_canonical.unity"); sb.AppendLine("scene SAVED"); } catch (System.Exception e) { sb.AppendLine("SaveScene failed: " + e.Message); }
+return sb.ToString();

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -44,7 +44,9 @@ System.Func<string,string,string,int,int,float,Color,string,Vector3> spawn=(fbxP
   var rends=go.GetComponentsInChildren<Renderer>(); foreach(var r in rends){ r.enabled=true; r.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.On; r.receiveShadows=true; }
   System.Func<Bounds> measure=()=>{ Bounds b=new Bounds(go.transform.position,Vector3.zero); bool a=false; foreach(var r in rends){ if(!a){b=r.bounds;a=true;} else b.Encapsulate(r.bounds);} return b; };
   Bounds bb=measure(); float curH=bb.size.y>0.001f?bb.size.y:1f; float s=height/curH; go.transform.localScale=go.transform.localScale*s;
-  var p=cellToWorld(cx,cy); go.transform.position=p; bb=measure(); go.transform.position+=new Vector3(0f,-bb.min.y,0f);
+  // ground + CENTER on the cell: snap feet to Y=0 AND align bounds-center X/Z to the cell (fixes the critic's
+  // "actor decoupled from its ring" — meshes whose geometry is offset from their transform origin drifted off-ring).
+  var p=cellToWorld(cx,cy); go.transform.position=p; bb=measure(); Vector3 ctr=bb.center; go.transform.position+=new Vector3(p.x-ctr.x,-bb.min.y,p.z-ctr.z);
   if(albedoPath!=null){ var al=AssetDatabase.LoadAssetAtPath<Texture2D>(albedoPath); if(al!=null){ var mm=new Material(Shader.Find("Standard")); mm.mainTexture=al; mm.SetFloat("_Glossiness",0.2f); mm.SetFloat("_Metallic",0f); foreach(var r in rends) r.sharedMaterial=mm; } }
   var oldAo=GameObject.Find(nm+"_AO"); if(oldAo!=null) UnityEngine.Object.DestroyImmediate(oldAo);
   var oldRg=GameObject.Find(nm+"_Ring"); if(oldRg!=null) UnityEngine.Object.DestroyImmediate(oldRg);

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -33,10 +33,11 @@ var blobT=new Texture2D(256,256,TextureFormat.RGBA32,false); blobT.wrapMode=Text
 var ringT=new Texture2D(256,256,TextureFormat.RGBA32,false); ringT.wrapMode=TextureWrapMode.Clamp; { var px=new Color[256*256]; float c=127.5f; for(int y=0;y<256;y++)for(int x=0;x<256;x++){ float d=Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c; float a=(d>0.70f&&d<0.96f)?Mathf.Clamp01(1f-Mathf.Abs(d-0.83f)/0.13f):0f; px[y*256+x]=new Color(1f,1f,1f,a); } ringT.SetPixels(px); ringT.Apply(); }
 
 // actor spawner (generalizes the spike's hero block): load fbx, stand up, scale to height, place at cell, foot-snap, albedo, AO, ring.
-System.Func<string,string,int,int,float,Color,string,Vector3> spawn=(fbxPath,albedoPath,cx,cy,height,ringCol,nm)=>{
+System.Func<string,string,string,int,int,float,Color,string,Vector3> spawn=(fbxPath,albedoPath,poseClipPath,cx,cy,height,ringCol,nm)=>{
   var prefab=AssetDatabase.LoadAssetAtPath<GameObject>(fbxPath); if(prefab==null){ sb.AppendLine("MISSING "+fbxPath); return cellToWorld(cx,cy); }
   var old=GameObject.Find(nm); if(old!=null) UnityEngine.Object.DestroyImmediate(old);
   var go=(GameObject)UnityEngine.Object.Instantiate(prefab); go.name=nm;
+  if(poseClipPath!=null){ var pas=AssetDatabase.LoadAllAssetsAtPath(poseClipPath); foreach(var clipAsset in pas){ var clip=clipAsset as AnimationClip; if(clip!=null && !clip.name.StartsWith("__")){ clip.SampleAnimation(go, clip.length*0.45f); sb.AppendLine(nm+" posed by "+clip.name); break; } } }
   go.transform.rotation=Quaternion.Euler(-90f, cam.transform.eulerAngles.y+180f, 0f);
   var rends=go.GetComponentsInChildren<Renderer>(); foreach(var r in rends){ r.enabled=true; r.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.On; r.receiveShadows=true; }
   System.Func<Bounds> measure=()=>{ Bounds b=new Bounds(go.transform.position,Vector3.zero); bool a=false; foreach(var r in rends){ if(!a){b=r.bounds;a=true;} else b.Encapsulate(r.bounds);} return b; };
@@ -49,8 +50,10 @@ System.Func<string,string,int,int,float,Color,string,Vector3> spawn=(fbxPath,alb
   return go.transform.position;
 };
 
-var heroPos=spawn("Assets/painterly/models/hero.fbx","Assets/painterly/models/hero_albedo.png",6,6,5.0f,new Color(1f,0.82f,0.4f,1f),"Hero3D");
-var gobPos=spawn("Assets/chars_v2/goblin/goblin.fbx",null,9,5,4.2f,new Color(0.92f,0.32f,0.30f,1f),"Goblin3D");
+// NOTE: rigged.fbx's UVs don't match hero_albedo (white) and its rig orientation doesn't compose with the
+// stand-up rotation (collapses). Use the proven textured hero.fbx (T-pose) until a correct rig+retarget lands.
+var heroPos=spawn("Assets/painterly/models/hero.fbx","Assets/painterly/models/hero_albedo.png",null,6,6,5.0f,new Color(1f,0.82f,0.4f,1f),"Hero3D");
+var gobPos=spawn("Assets/chars_v2/goblin/goblin.fbx","Assets/chars_v2/goblin/albedo.png",null,9,5,4.2f,new Color(1f,0.24f,0.20f,1f),"Goblin3D");
 
 // impact VFX burst at the goblin (additive orange radial), billboarded
 var fx=GameObject.CreatePrimitive(PrimitiveType.Quad); fx.name="ImpactFX"; UnityEngine.Object.DestroyImmediate(fx.GetComponent<Collider>()); fx.transform.position=gobPos+new Vector3(0f,2.0f,0f); fx.transform.rotation=cam.transform.rotation; fx.transform.localScale=new Vector3(3.4f,3.4f,1f);

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -1,0 +1,72 @@
+// paint_combat_v1.cs — P0 FIRST multi-actor combat frame: hero + goblin on the painterly crypt plate,
+// gold/red selection rings, contact AO, an impact VFX burst + a floating "-8" damage number.
+// Built off the PROVEN paint_3d_spike.cs (same unqualified UnityEngine/UnityEditor style the wrapper injects).
+// NO AnimatorController (its assembly isn't referenced by code-execute); actors are placed (pose-sampling = v2).
+// Run: unity-mcp code execute --no-safety-checks -f paint_combat_v1.cs
+AssetDatabase.Refresh();
+var sb=new System.Text.StringBuilder();
+Camera cam=Camera.main; if(cam==null && Camera.allCameras.Length>0) cam=Camera.allCameras[0]; if(cam==null) return "no cam";
+cam.orthographic=true; cam.orthographicSize=13f; cam.nearClipPlane=0.3f; cam.farClipPlane=500f;
+{ Quaternion _crot=Quaternion.Euler(30f,45f,0f); cam.transform.rotation=_crot; cam.transform.position=-(_crot*Vector3.forward)*80f; }
+cam.clearFlags=CameraClearFlags.SolidColor; cam.backgroundColor=new Color(0.02f,0.02f,0.03f);
+int hidden=0; foreach(var r in UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None)){ if(r.enabled){r.enabled=false;hidden++;} }
+
+var bdTex=AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/backdrops/crypt_pinned_v1.png"); if(bdTex==null) return "no plate";
+var oldBd=GameObject.Find("PaintedBackdrop"); if(oldBd!=null) UnityEngine.Object.DestroyImmediate(oldBd);
+var bd=GameObject.CreatePrimitive(PrimitiveType.Quad); bd.name="PaintedBackdrop"; UnityEngine.Object.DestroyImmediate(bd.GetComponent<Collider>());
+bd.transform.SetParent(cam.transform,false); float texAsp=(float)bdTex.width/bdTex.height; float oh=cam.orthographicSize*2f; float ow=oh*texAsp;
+bd.transform.localPosition=new Vector3(0,0,160f); bd.transform.localScale=new Vector3(ow,oh,1f);
+var bm=new Material(Shader.Find("Unlit/Texture")); bm.mainTexture=bdTex; bm.renderQueue=1900; var bdr=bd.GetComponent<Renderer>(); bdr.sharedMaterial=bm; bdr.enabled=true; bdr.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; bdr.receiveShadows=false;
+
+System.Func<int,int,Vector3> cellToWorld=(cx,cy)=> new Vector3((cx-6.5f)*2.0f,0f,(5.0f-cy)*2.0f);
+
+// PoE2 lighting rig (from spike)
+foreach(var ln in new[]{"KeyLight","FillLight","BrazierL","BrazierR"}){ var o=GameObject.Find(ln); if(o!=null) UnityEngine.Object.DestroyImmediate(o); }
+var lg=new GameObject("KeyLight"); var L=lg.AddComponent<Light>(); L.type=LightType.Directional; L.color=new Color(1f,0.73f,0.44f); L.intensity=1.35f; L.shadows=LightShadows.Soft; L.shadowStrength=0.75f; lg.transform.rotation=Quaternion.Euler(48f,35f,0f);
+var fg=new GameObject("FillLight"); var F=fg.AddComponent<Light>(); F.type=LightType.Directional; F.color=new Color(0.36f,0.44f,0.64f); F.intensity=0.55f; F.shadows=LightShadows.None; fg.transform.rotation=Quaternion.Euler(34f,215f,0f);
+RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat; RenderSettings.ambientLight=new Color(0.24f,0.28f,0.40f);
+System.Action<string,int,int,bool> brazier=(nm,cx,cy,sh)=>{ var bg=new GameObject(nm); var B=bg.AddComponent<Light>(); B.type=LightType.Point; B.color=new Color(1f,0.48f,0.18f); B.range=7.5f; B.intensity=3.6f; B.shadows=sh?LightShadows.Soft:LightShadows.None; var wp=cellToWorld(cx,cy); bg.transform.position=new Vector3(wp.x,1.7f,wp.z); };
+brazier("BrazierL",4,1,true); brazier("BrazierR",9,1,false);
+
+// shared AO blob + ring textures
+var blobT=new Texture2D(256,256,TextureFormat.RGBA32,false); blobT.wrapMode=TextureWrapMode.Clamp; { var px=new Color[256*256]; float c=127.5f; for(int y=0;y<256;y++)for(int x=0;x<256;x++){ float d=Mathf.Clamp01(Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c); px[y*256+x]=new Color(0.02f,0.02f,0.03f,Mathf.Pow(1f-d,0.9f)); } blobT.SetPixels(px); blobT.Apply(); }
+var ringT=new Texture2D(256,256,TextureFormat.RGBA32,false); ringT.wrapMode=TextureWrapMode.Clamp; { var px=new Color[256*256]; float c=127.5f; for(int y=0;y<256;y++)for(int x=0;x<256;x++){ float d=Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c; float a=(d>0.70f&&d<0.96f)?Mathf.Clamp01(1f-Mathf.Abs(d-0.83f)/0.13f):0f; px[y*256+x]=new Color(1f,1f,1f,a); } ringT.SetPixels(px); ringT.Apply(); }
+
+// actor spawner (generalizes the spike's hero block): load fbx, stand up, scale to height, place at cell, foot-snap, albedo, AO, ring.
+System.Func<string,string,int,int,float,Color,string,Vector3> spawn=(fbxPath,albedoPath,cx,cy,height,ringCol,nm)=>{
+  var prefab=AssetDatabase.LoadAssetAtPath<GameObject>(fbxPath); if(prefab==null){ sb.AppendLine("MISSING "+fbxPath); return cellToWorld(cx,cy); }
+  var old=GameObject.Find(nm); if(old!=null) UnityEngine.Object.DestroyImmediate(old);
+  var go=(GameObject)UnityEngine.Object.Instantiate(prefab); go.name=nm;
+  go.transform.rotation=Quaternion.Euler(-90f, cam.transform.eulerAngles.y+180f, 0f);
+  var rends=go.GetComponentsInChildren<Renderer>(); foreach(var r in rends){ r.enabled=true; r.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.On; r.receiveShadows=true; }
+  System.Func<Bounds> measure=()=>{ Bounds b=new Bounds(go.transform.position,Vector3.zero); bool a=false; foreach(var r in rends){ if(!a){b=r.bounds;a=true;} else b.Encapsulate(r.bounds);} return b; };
+  Bounds bb=measure(); float curH=bb.size.y>0.001f?bb.size.y:1f; float s=height/curH; go.transform.localScale=go.transform.localScale*s;
+  var p=cellToWorld(cx,cy); go.transform.position=p; bb=measure(); go.transform.position+=new Vector3(0f,-bb.min.y,0f);
+  if(albedoPath!=null){ var al=AssetDatabase.LoadAssetAtPath<Texture2D>(albedoPath); if(al!=null){ var mm=new Material(Shader.Find("Standard")); mm.mainTexture=al; mm.SetFloat("_Glossiness",0.2f); mm.SetFloat("_Metallic",0f); foreach(var r in rends) r.sharedMaterial=mm; } }
+  var ao=GameObject.CreatePrimitive(PrimitiveType.Quad); ao.name=nm+"_AO"; UnityEngine.Object.DestroyImmediate(ao.GetComponent<Collider>()); ao.transform.position=new Vector3(p.x,0.04f,p.z); ao.transform.localEulerAngles=new Vector3(90f,0f,0f); ao.transform.localScale=new Vector3(2.2f,1.4f,1f); var aom=new Material(Shader.Find("Unlit/Transparent")); aom.mainTexture=blobT; aom.renderQueue=1950; ao.GetComponent<Renderer>().sharedMaterial=aom; ao.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
+  var rg=GameObject.CreatePrimitive(PrimitiveType.Quad); rg.name=nm+"_Ring"; UnityEngine.Object.DestroyImmediate(rg.GetComponent<Collider>()); rg.transform.position=new Vector3(p.x,0.06f,p.z); rg.transform.localEulerAngles=new Vector3(90f,0f,0f); rg.transform.localScale=new Vector3(2.7f,1.7f,1f); var rgm=new Material(Shader.Find("Unlit/Transparent")); rgm.mainTexture=ringT; rgm.color=ringCol; rgm.renderQueue=1955; rg.GetComponent<Renderer>().sharedMaterial=rgm; rg.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
+  sb.AppendLine(nm+" x"+s.ToString("F2")+" @cell("+cx+","+cy+") rends="+rends.Length);
+  return go.transform.position;
+};
+
+var heroPos=spawn("Assets/painterly/models/hero.fbx","Assets/painterly/models/hero_albedo.png",6,6,5.0f,new Color(1f,0.82f,0.4f,1f),"Hero3D");
+var gobPos=spawn("Assets/chars_v2/goblin/goblin.fbx",null,9,5,4.2f,new Color(0.92f,0.32f,0.30f,1f),"Goblin3D");
+
+// impact VFX burst at the goblin (additive orange radial), billboarded
+var fx=GameObject.CreatePrimitive(PrimitiveType.Quad); fx.name="ImpactFX"; UnityEngine.Object.DestroyImmediate(fx.GetComponent<Collider>()); fx.transform.position=gobPos+new Vector3(0f,2.0f,0f); fx.transform.rotation=cam.transform.rotation; fx.transform.localScale=new Vector3(3.4f,3.4f,1f);
+var fxT=new Texture2D(128,128,TextureFormat.RGBA32,false); { var px=new Color[128*128]; float c=63.5f; for(int y=0;y<128;y++)for(int x=0;x<128;x++){ float d=Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c; float a=Mathf.Clamp01(1f-d); px[y*128+x]=new Color(1f,0.62f,0.16f,a*a); } fxT.SetPixels(px); fxT.Apply(); }
+var fxm=new Material(Shader.Find("Unlit/Transparent")); fxm.mainTexture=fxT; fxm.color=new Color(1f,1f,1f,0.92f); fxm.renderQueue=3000; fx.GetComponent<Renderer>().sharedMaterial=fxm; fx.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
+
+// floating "-8" damage number above the goblin (billboarded TextMesh)
+var oldD=GameObject.Find("DmgNum"); if(oldD!=null) UnityEngine.Object.DestroyImmediate(oldD);
+var dmgGo=new GameObject("DmgNum"); dmgGo.transform.position=gobPos+new Vector3(0f,3.7f,0f); dmgGo.transform.rotation=cam.transform.rotation; var tm=dmgGo.AddComponent<TextMesh>(); tm.text="-8"; tm.fontSize=90; tm.characterSize=0.22f; tm.anchor=TextAnchor.MiddleCenter; tm.alignment=TextAlignment.Center; tm.color=new Color(1f,0.95f,0.45f,1f); var tmr=dmgGo.GetComponent<MeshRenderer>(); if(tmr!=null && tmr.sharedMaterial!=null) tmr.sharedMaterial.renderQueue=3100;
+
+// capture
+int W=1920,Hh=Mathf.RoundToInt(1920f*(float)bdTex.height/bdTex.width); var rt=new RenderTexture(W,Hh,24,RenderTextureFormat.ARGB32); rt.Create();
+float pa=cam.aspect; var pt=cam.targetTexture; cam.targetTexture=rt; cam.aspect=(float)W/Hh; cam.Render();
+var pAct=RenderTexture.active; RenderTexture.active=rt; var t2=new Texture2D(W,Hh,TextureFormat.RGB24,false); t2.ReadPixels(new Rect(0,0,W,Hh),0,0); t2.Apply(); RenderTexture.active=pAct; cam.targetTexture=pt; cam.aspect=pa;
+System.IO.Directory.CreateDirectory("/home/unity/worldos-unity/Captures-Durable");
+System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/m1_combat_v1.png", t2.EncodeToPNG());
+UnityEngine.Object.DestroyImmediate(t2); rt.Release(); UnityEngine.Object.DestroyImmediate(rt);
+sb.AppendLine("captured "+W+"x"+Hh+" -> m1_combat_v1.png hidden="+hidden);
+return sb.ToString();

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -89,4 +89,9 @@ System.IO.Directory.CreateDirectory("/home/unity/worldos-unity/Captures-Durable"
 System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/m1_combat_v1.png", t2.EncodeToPNG());
 UnityEngine.Object.DestroyImmediate(t2); rt.Release(); UnityEngine.Object.DestroyImmediate(rt);
 sb.AppendLine("captured "+W+"x"+Hh+" -> m1_combat_v1.png hidden="+hidden);
+// Persist the combat frame (anti render-and-forget — a documented WorldOS regression cause) to a DEDICATED
+// scene file, mirroring paint_3d_spike.cs. Safe vs the paint_combat_scene.cs:18 corruption class: the
+// renderer-hide above is idempotent (only disables already-enabled renderers) and we save to a dedicated
+// M1CombatV1 scene, never overwriting a shared/source scene, so reruns don't compound-corrupt canonical state.
+try { var _scn=UnityEngine.SceneManagement.SceneManager.GetActiveScene(); System.IO.Directory.CreateDirectory("Assets/Scenes"); UnityEditor.SceneManagement.EditorSceneManager.SaveScene(_scn, "Assets/Scenes/M1CombatV1_canonical.unity"); sb.AppendLine("scene SAVED -> Assets/Scenes/M1CombatV1_canonical.unity"); } catch(System.Exception _e){ sb.AppendLine("SaveScene FAILED: "+_e.Message); }
 return sb.ToString();

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -4,10 +4,13 @@
 // NO AnimatorController (its assembly isn't referenced by code-execute); actors are placed (pose-sampling = v2).
 // Run: unity-mcp code execute --no-safety-checks -f paint_combat_v1.cs
 AssetDatabase.Refresh();
+// New backdrop plates default to NPOT=ToNearest, which square-distorts a 1344x768 plate and breaks the
+// camera-pin aspect. Force NPOT=None so the plate keeps native dims (idempotent — only reimports if needed).
+{ var _ti=AssetImporter.GetAtPath("Assets/painterly/backdrops/crypt_firelit_v2.png") as TextureImporter; if(_ti!=null && _ti.npotScale!=TextureImporterNPOTScale.None){ _ti.npotScale=TextureImporterNPOTScale.None; _ti.maxTextureSize=2048; _ti.SaveAndReimport(); } }
 var sb=new System.Text.StringBuilder();
 Camera cam=Camera.main; if(cam==null && Camera.allCameras.Length>0) cam=Camera.allCameras[0]; if(cam==null) return "no cam";
 // validate the plate BEFORE mutating camera/renderers — a missing plate must not leave the editor scene corrupted.
-var bdTex=AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/backdrops/crypt_pinned_v1.png"); if(bdTex==null) return "no plate";
+var bdTex=AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/backdrops/crypt_firelit_v2.png"); if(bdTex==null) return "no plate";
 cam.orthographic=true; cam.orthographicSize=13f; cam.nearClipPlane=0.3f; cam.farClipPlane=500f;
 { Quaternion _crot=Quaternion.Euler(30f,45f,0f); cam.transform.rotation=_crot; cam.transform.position=-(_crot*Vector3.forward)*80f; }
 cam.clearFlags=CameraClearFlags.SolidColor; cam.backgroundColor=new Color(0.02f,0.02f,0.03f);
@@ -25,13 +28,17 @@ System.Func<int,int,Vector3> cellToWorld=(cx,cy)=> new Vector3((cx-6.5f)*2.0f,0f
 foreach(var ln in new[]{"KeyLight","FillLight","BrazierL","BrazierR"}){ var o=GameObject.Find(ln); if(o!=null) UnityEngine.Object.DestroyImmediate(o); }
 var lg=new GameObject("KeyLight"); var L=lg.AddComponent<Light>(); L.type=LightType.Directional; L.color=new Color(1f,0.73f,0.44f); L.intensity=1.35f; L.shadows=LightShadows.Soft; L.shadowStrength=0.75f; lg.transform.rotation=Quaternion.Euler(48f,35f,0f);
 var fg=new GameObject("FillLight"); var F=fg.AddComponent<Light>(); F.type=LightType.Directional; F.color=new Color(0.36f,0.44f,0.64f); F.intensity=0.55f; F.shadows=LightShadows.None; fg.transform.rotation=Quaternion.Euler(34f,215f,0f);
-RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat; RenderSettings.ambientLight=new Color(0.24f,0.28f,0.40f);
-System.Action<string,int,int,bool> brazier=(nm,cx,cy,sh)=>{ var bg=new GameObject(nm); var B=bg.AddComponent<Light>(); B.type=LightType.Point; B.color=new Color(1f,0.48f,0.18f); B.range=7.5f; B.intensity=3.6f; B.shadows=sh?LightShadows.Soft:LightShadows.None; var wp=cellToWorld(cx,cy); bg.transform.position=new Vector3(wp.x,1.7f,wp.z); };
+// warm-neutral ambient (was cool 0.24,0.28,0.40) so the 3D actors read FIRELIT, not cool-studio-lit (critic L3/L4).
+RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat; RenderSettings.ambientLight=new Color(0.30f,0.25f,0.21f);
+// brazier range 7.5->18 so the firelight actually REACHES the combatants (they sit ~11 units from a brazier).
+System.Action<string,int,int,bool> brazier=(nm,cx,cy,sh)=>{ var bg=new GameObject(nm); var B=bg.AddComponent<Light>(); B.type=LightType.Point; B.color=new Color(1f,0.48f,0.18f); B.range=18f; B.intensity=3.6f; B.shadows=sh?LightShadows.Soft:LightShadows.None; var wp=cellToWorld(cx,cy); bg.transform.position=new Vector3(wp.x,1.7f,wp.z); };
 brazier("BrazierL",4,1,true); brazier("BrazierR",9,1,false);
+// a warm combat key above center so actors take a strong firelight rim (they were reading net-cool).
+{ var ck=new GameObject("CombatKey"); var CK=ck.AddComponent<Light>(); CK.type=LightType.Point; CK.color=new Color(1f,0.6f,0.32f); CK.range=26f; CK.intensity=2.2f; CK.shadows=LightShadows.None; ck.transform.position=new Vector3(0f,8f,3f); }
 
 // shared AO blob + ring textures
 var blobT=new Texture2D(256,256,TextureFormat.RGBA32,false); blobT.wrapMode=TextureWrapMode.Clamp; { var px=new Color[256*256]; float c=127.5f; for(int y=0;y<256;y++)for(int x=0;x<256;x++){ float d=Mathf.Clamp01(Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c); px[y*256+x]=new Color(0.02f,0.02f,0.03f,Mathf.Pow(1f-d,0.9f)); } blobT.SetPixels(px); blobT.Apply(); }
-var ringT=new Texture2D(256,256,TextureFormat.RGBA32,false); ringT.wrapMode=TextureWrapMode.Clamp; { var px=new Color[256*256]; float c=127.5f; for(int y=0;y<256;y++)for(int x=0;x<256;x++){ float d=Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c; float a=(d>0.70f&&d<0.96f)?Mathf.Clamp01(1f-Mathf.Abs(d-0.83f)/0.13f):0f; px[y*256+x]=new Color(1f,1f,1f,a); } ringT.SetPixels(px); ringT.Apply(); }
+var ringT=new Texture2D(256,256,TextureFormat.RGBA32,false); ringT.wrapMode=TextureWrapMode.Clamp; { var px=new Color[256*256]; float c=127.5f; for(int y=0;y<256;y++)for(int x=0;x<256;x++){ float d=Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c; float a=(d>0.78f&&d<0.93f)?1f:0f; px[y*256+x]=new Color(1f,1f,1f,a); } ringT.SetPixels(px); ringT.Apply(); }
 
 // actor spawner (generalizes the spike's hero block): load fbx, stand up, scale to height, place at cell, foot-snap, albedo, AO, ring.
 bool missingActor=false;
@@ -58,8 +65,9 @@ System.Func<string,string,string,int,int,float,Color,string,Vector3> spawn=(fbxP
 
 // NOTE: rigged.fbx's UVs don't match hero_albedo (white) and its rig orientation doesn't compose with the
 // stand-up rotation (collapses). Use the proven textured hero.fbx (T-pose) until a correct rig+retarget lands.
-var heroPos=spawn("Assets/painterly/models/hero.fbx","Assets/painterly/models/hero_albedo.png",null,6,6,5.0f,new Color(1f,0.82f,0.4f,1f),"Hero3D");
-var gobPos=spawn("Assets/chars_v2/goblin/goblin.fbx","Assets/chars_v2/goblin/albedo.png",null,9,5,4.2f,new Color(1f,0.24f,0.20f,1f),"Goblin3D");
+// ring colors: cyan party / saturated-red foe (gold was camouflaged on the warm flagstone — critic L5).
+var heroPos=spawn("Assets/painterly/models/hero.fbx","Assets/painterly/models/hero_albedo.png",null,6,6,5.0f,new Color(0.4f,0.95f,1f,1f),"Hero3D");
+var gobPos=spawn("Assets/chars_v2/goblin/goblin.fbx","Assets/chars_v2/goblin/albedo.png",null,9,5,4.2f,new Color(1f,0.13f,0.10f,1f),"Goblin3D");
 // fail fast: never write a "successful" durable frame that's missing a required actor.
 if(missingActor){ sb.AppendLine("ABORT capture — a required actor prefab was missing (no PNG written)"); return sb.ToString(); }
 

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -6,12 +6,13 @@
 AssetDatabase.Refresh();
 var sb=new System.Text.StringBuilder();
 Camera cam=Camera.main; if(cam==null && Camera.allCameras.Length>0) cam=Camera.allCameras[0]; if(cam==null) return "no cam";
+// validate the plate BEFORE mutating camera/renderers — a missing plate must not leave the editor scene corrupted.
+var bdTex=AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/backdrops/crypt_pinned_v1.png"); if(bdTex==null) return "no plate";
 cam.orthographic=true; cam.orthographicSize=13f; cam.nearClipPlane=0.3f; cam.farClipPlane=500f;
 { Quaternion _crot=Quaternion.Euler(30f,45f,0f); cam.transform.rotation=_crot; cam.transform.position=-(_crot*Vector3.forward)*80f; }
 cam.clearFlags=CameraClearFlags.SolidColor; cam.backgroundColor=new Color(0.02f,0.02f,0.03f);
 int hidden=0; foreach(var r in UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None)){ if(r.enabled){r.enabled=false;hidden++;} }
 
-var bdTex=AssetDatabase.LoadAssetAtPath<Texture2D>("Assets/painterly/backdrops/crypt_pinned_v1.png"); if(bdTex==null) return "no plate";
 var oldBd=GameObject.Find("PaintedBackdrop"); if(oldBd!=null) UnityEngine.Object.DestroyImmediate(oldBd);
 var bd=GameObject.CreatePrimitive(PrimitiveType.Quad); bd.name="PaintedBackdrop"; UnityEngine.Object.DestroyImmediate(bd.GetComponent<Collider>());
 bd.transform.SetParent(cam.transform,false); float texAsp=(float)bdTex.width/bdTex.height; float oh=cam.orthographicSize*2f; float ow=oh*texAsp;
@@ -33,8 +34,9 @@ var blobT=new Texture2D(256,256,TextureFormat.RGBA32,false); blobT.wrapMode=Text
 var ringT=new Texture2D(256,256,TextureFormat.RGBA32,false); ringT.wrapMode=TextureWrapMode.Clamp; { var px=new Color[256*256]; float c=127.5f; for(int y=0;y<256;y++)for(int x=0;x<256;x++){ float d=Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c; float a=(d>0.70f&&d<0.96f)?Mathf.Clamp01(1f-Mathf.Abs(d-0.83f)/0.13f):0f; px[y*256+x]=new Color(1f,1f,1f,a); } ringT.SetPixels(px); ringT.Apply(); }
 
 // actor spawner (generalizes the spike's hero block): load fbx, stand up, scale to height, place at cell, foot-snap, albedo, AO, ring.
+bool missingActor=false;
 System.Func<string,string,string,int,int,float,Color,string,Vector3> spawn=(fbxPath,albedoPath,poseClipPath,cx,cy,height,ringCol,nm)=>{
-  var prefab=AssetDatabase.LoadAssetAtPath<GameObject>(fbxPath); if(prefab==null){ sb.AppendLine("MISSING "+fbxPath); return cellToWorld(cx,cy); }
+  var prefab=AssetDatabase.LoadAssetAtPath<GameObject>(fbxPath); if(prefab==null){ sb.AppendLine("MISSING "+fbxPath); missingActor=true; return cellToWorld(cx,cy); }
   var old=GameObject.Find(nm); if(old!=null) UnityEngine.Object.DestroyImmediate(old);
   var go=(GameObject)UnityEngine.Object.Instantiate(prefab); go.name=nm;
   if(poseClipPath!=null){ var pas=AssetDatabase.LoadAllAssetsAtPath(poseClipPath); foreach(var clipAsset in pas){ var clip=clipAsset as AnimationClip; if(clip!=null && !clip.name.StartsWith("__")){ clip.SampleAnimation(go, clip.length*0.45f); sb.AppendLine(nm+" posed by "+clip.name); break; } } }
@@ -44,6 +46,8 @@ System.Func<string,string,string,int,int,float,Color,string,Vector3> spawn=(fbxP
   Bounds bb=measure(); float curH=bb.size.y>0.001f?bb.size.y:1f; float s=height/curH; go.transform.localScale=go.transform.localScale*s;
   var p=cellToWorld(cx,cy); go.transform.position=p; bb=measure(); go.transform.position+=new Vector3(0f,-bb.min.y,0f);
   if(albedoPath!=null){ var al=AssetDatabase.LoadAssetAtPath<Texture2D>(albedoPath); if(al!=null){ var mm=new Material(Shader.Find("Standard")); mm.mainTexture=al; mm.SetFloat("_Glossiness",0.2f); mm.SetFloat("_Metallic",0f); foreach(var r in rends) r.sharedMaterial=mm; } }
+  var oldAo=GameObject.Find(nm+"_AO"); if(oldAo!=null) UnityEngine.Object.DestroyImmediate(oldAo);
+  var oldRg=GameObject.Find(nm+"_Ring"); if(oldRg!=null) UnityEngine.Object.DestroyImmediate(oldRg);
   var ao=GameObject.CreatePrimitive(PrimitiveType.Quad); ao.name=nm+"_AO"; UnityEngine.Object.DestroyImmediate(ao.GetComponent<Collider>()); ao.transform.position=new Vector3(p.x,0.04f,p.z); ao.transform.localEulerAngles=new Vector3(90f,0f,0f); ao.transform.localScale=new Vector3(2.2f,1.4f,1f); var aom=new Material(Shader.Find("Unlit/Transparent")); aom.mainTexture=blobT; aom.renderQueue=1950; ao.GetComponent<Renderer>().sharedMaterial=aom; ao.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
   var rg=GameObject.CreatePrimitive(PrimitiveType.Quad); rg.name=nm+"_Ring"; UnityEngine.Object.DestroyImmediate(rg.GetComponent<Collider>()); rg.transform.position=new Vector3(p.x,0.06f,p.z); rg.transform.localEulerAngles=new Vector3(90f,0f,0f); rg.transform.localScale=new Vector3(2.7f,1.7f,1f); var rgm=new Material(Shader.Find("Unlit/Transparent")); rgm.mainTexture=ringT; rgm.color=ringCol; rgm.renderQueue=1955; rg.GetComponent<Renderer>().sharedMaterial=rgm; rg.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
   sb.AppendLine(nm+" x"+s.ToString("F2")+" @cell("+cx+","+cy+") rends="+rends.Length);
@@ -54,8 +58,11 @@ System.Func<string,string,string,int,int,float,Color,string,Vector3> spawn=(fbxP
 // stand-up rotation (collapses). Use the proven textured hero.fbx (T-pose) until a correct rig+retarget lands.
 var heroPos=spawn("Assets/painterly/models/hero.fbx","Assets/painterly/models/hero_albedo.png",null,6,6,5.0f,new Color(1f,0.82f,0.4f,1f),"Hero3D");
 var gobPos=spawn("Assets/chars_v2/goblin/goblin.fbx","Assets/chars_v2/goblin/albedo.png",null,9,5,4.2f,new Color(1f,0.24f,0.20f,1f),"Goblin3D");
+// fail fast: never write a "successful" durable frame that's missing a required actor.
+if(missingActor){ sb.AppendLine("ABORT capture — a required actor prefab was missing (no PNG written)"); return sb.ToString(); }
 
 // impact VFX burst at the goblin (additive orange radial), billboarded
+var oldFx=GameObject.Find("ImpactFX"); if(oldFx!=null) UnityEngine.Object.DestroyImmediate(oldFx);
 var fx=GameObject.CreatePrimitive(PrimitiveType.Quad); fx.name="ImpactFX"; UnityEngine.Object.DestroyImmediate(fx.GetComponent<Collider>()); fx.transform.position=gobPos+new Vector3(0f,2.0f,0f); fx.transform.rotation=cam.transform.rotation; fx.transform.localScale=new Vector3(3.4f,3.4f,1f);
 var fxT=new Texture2D(128,128,TextureFormat.RGBA32,false); { var px=new Color[128*128]; float c=63.5f; for(int y=0;y<128;y++)for(int x=0;x<128;x++){ float d=Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c; float a=Mathf.Clamp01(1f-d); px[y*128+x]=new Color(1f,0.62f,0.16f,a*a); } fxT.SetPixels(px); fxT.Apply(); }
 var fxm=new Material(Shader.Find("Unlit/Transparent")); fxm.mainTexture=fxT; fxm.color=new Color(1f,1f,1f,0.92f); fxm.renderQueue=3000; fx.GetComponent<Renderer>().sharedMaterial=fxm; fx.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;


### PR DESCRIPTION
Drive-phase prep for the M1.0 combat gate, built on the now-canonical crypt + 3D-hero foundation (CANONICAL.md).

- `build_combat_animator.cs` — imports the `meshy --moveset` clips as **Generic** (Humanoid silently drops them) + builds the 9-state **CombatActor** controller (idle/walk/run/attack/cast/block/dodge/hit/death) with a per-verb trigger + Any-State transitions. Sourced from the Besty0728 AnimatorSkills patterns.
- `paint_3d_spike.cs` — now `SaveScene`s `CombatCrypt_canonical.unity` after capture (kills render-and-forget — the root cause of the week regression).

Additive renderer scripts only. The hero 9-clip moveset is generating now (meshy --moveset on the existing hero refine task); next: deploy clips → run this builder → build the combat scene (hero + goblin + rings + VFX) → render → score.