### PR TITLE
F3: VISION.md graphics north star + scorecard + docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -31,7 +31,16 @@ scores, and rubric numbers are *measurement*, never the target — no score-gami
 3. **Deterministic correctness.** SRD 5.2, faithfully. The engine rolls and resolves; the DM is
    *told* the result and narrates it. No rules-cheating; fiction never overrides the dice.
 4. **It feels alive.** The screen always shows motion; the world responds promptly; no frozen,
-   ambiguous waits. Real art, not placeholders. The session has rhythm.
+   ambiguous waits. The session has rhythm. **Real art via a proven workflow — placeholders are the
+   PATH, not a violation.** The destination is real, PoE2-caliber art; the way there is to prove the
+   *generation workflow* once on throwaway assets (a demo cast, ~10 monsters, default VFX/sounds),
+   then swap them for the real ones through that same proven pipeline. A placeholder asset in the
+   playable combat demo is the workflow doing its job — it is NOT a vision violation, as long as the
+   pipeline that produced it is the one that will produce the polished asset later, and the
+   foundation underneath it (the painterly backdrop + pathing) already clears its quality bar. The
+   failure mode this pillar forbids is *shipping placeholders as the destination* and calling it done
+   (see "Graphics North Star (PoE2)" for the binding backdrop scorecard that separates the
+   foundation — held to the bar now — from the placeholder-OK actor/effect layer).
 5. **No-prior-knowledge accessible.** A first-timer is never lost, overwhelmed, or staring at jargon
    or a dead control. Onboarding teaches itself.
 
@@ -46,6 +55,13 @@ scores, and rubric numbers are *measurement*, never the target — no score-gami
 - **Engine rolls; the DM is told.** Wander/betrayal/variant rolls happen in-engine, surface in the
   tool return; the DM narrates. Probability proposes, the DM disposes.
 - **Viewer is read-only** on state — it posts move-intents; it never mutates.
+- **The renderer reads a registry by SLOT and resolves to a default on miss.** Every visual asset
+  (actor model, monster, VFX, sound) is addressed by a stable slot key; the renderer looks the slot
+  up in an asset registry and, on a miss, falls back to a default/template asset — it never hard-codes
+  an asset path and never fails because an asset is absent. **Swapping or regenerating ANY asset =
+  ZERO renderer edits.** This is the asset analogue of *engine = sole writer*: the registry is the
+  single source of truth for asset bindings, the renderer is a pure consumer, and the entire
+  placeholder→real-art transition is a registry change, not a code change.
 - **Never break wire contracts** — additive, keyword-only, defaulted; never reorder/rename/retype an
   existing param.
 - **QA is gateway-free and never touches Eva** (the owner's live agent) — no profile-sourcing, no
@@ -97,8 +113,78 @@ Tier-0/1 result as a release verdict):
   OOMs). Log every scored run to the ledger (`qa/scores_db.py`).
 
 **Release ladder:** Engine Excellent → **Player-Ready Beta** (a real built `.app`; a no-prior-
-knowledge dogfood arc with no "broken" moment; honest felt session) → **1.0 GA** (Beta + notarized +
-feature parity: companions felt, visual parity, story at the bar).
+knowledge dogfood arc with no "broken" moment; honest felt session) → **1.0 Playable Combat Demo**
+(a PLAYABLE, MODULAR combat scene rendered in-app on the PoE2 painterly stack — 2D camera-pinned
+backdrop + real 3D actors on the frozen dimetric camera — running on PLACEHOLDERS, i.e. a demo cast +
+~10 monsters with a default-on-miss registry, default VFX/sounds; the proof is that the *workflows*
+are repeatable and the **backdrop scorecard PASSES** for the demo room while actors/effects ride the
+placeholder-OK tier; see "Graphics North Star (PoE2)") → **1.0 GA** (the Demo's proven workflow
+applied to real, polished art + Beta's story/world bar + notarized + feature parity: companions felt,
+visual parity at the PoE2 bar, story at the bar).
+
+## Graphics North Star (PoE2)
+
+> The story/engine sections above are the *what-it-plays-like* bar. This is the *what-it-looks-like*
+> bar, with its own binding scorecard. The full self-driving plan lives in
+> `docs/roadmap/WORLDOS-GRAPHICS-ROADMAP-POE2.md`; this section is the load-bearing distillation that
+> `worldos-decide` and the `visual-critic` skill anchor against.
+
+**PoE2 = the single reference bar.** **Pillars of Eternity II: Deadfire** is the one named reference
+WorldOS's graphics are scored *against* — not "iso-CRPG in general," not BG2 (BG2 is a
+tactical-readability cross-check only), not Disco Elysium (a dark-pocket/mood cross-check only).
+Every render is scored as a **gap to specific PoE2 frames**, not on vibes.
+
+**The visual form:** **2D painterly plates + real 3D actors on a fixed dimetric camera.** The
+backdrop is a camera-pinned painterly *plate* (2D, hand-painted feel); the actors and monsters are
+**real 3D animated models** grounded and lit into that plate; the camera is **frozen dimetric**
+(orthographic, the one camera contract in `extensions/renderers/unity/CANONICAL.md` — elevation 30°,
+yaw 45° corner-iso, isotropic cells — *do not fork it*). The palette is **warm/cool firelit**:
+warm hearth/lantern key against cool fill, **blue-violet shadows (NEVER pure black)**,
+**atmospheric and moody — NOT flat-gray**. A washed-out, flat, gray, or pure-black-shadow frame
+fails the bar by definition.
+
+### The graphics scorecard (BACKDROP-BINDING)
+
+The graphics gate is **split into two tiers**, and the **backdrop tier is the binding one** — it is
+the reusable engine piece (a room's plate + its pathing is what every scene is built on), so it is
+held to the bar *now*. The actor/effect tier rides "default-if-missing" and is **placeholder-OK**
+until the polish phase. Lens names (`L1`–`L7`) are the `visual-critic` panel lenses, logged to
+`qa/scores_db.py` (`surface="visual"`); the deterministic checks are `qa/visual_pregate.py`.
+
+- **TIER-1 — BACKDROP (binding; the foundation; ALL must hold):**
+  - **L6 painterly-plate craft ≥ 8** (brush economy, atmospheric depth, PoE2-caliber art direction)
+    **AND**
+  - **L1 registration/cohesion ≥ 8** (the painted floor registers with the gameplay grid; actors
+    will plant on the same plane the engine reasons about) **AND**
+  - **detail ≥ 7** (no muddy / under-detailed plate) **AND**
+  - **0 / 3 washout** (the three deterministic illusion-breakers in `visual_pregate.py` — none may
+    trip; a washed-out plate is an automatic fail) **AND**
+  - **pathing-map-correct** (the walkmask / pathing map the renderer derives matches the painted
+    geometry — walkable floor is walkable, painted obstacles block, destinations resolve to engine
+    zones). A backdrop is not "done" until pathing reads correctly off it.
+- **TIER-2 — ACTOR / EFFECT (placeholder-OK now; polished much later):** the deterministic
+  **pre-gates PASS** (frame-lit · floor-contact · screen-scale · occupancy · motion-liveness —
+  numbers, not vibes) **AND** the integration lenses clear a **soft ≥ 5.0**:
+  - **L2 occlusion / grounding ≥ 5.0** (actor is PLANTED — a visible soft contact shadow, feet meet
+    the floor, not floating),
+  - **L3 scene-light coherence ≥ 5.0** (actor lit BY the scene's key light, not a foreign flat key),
+  - **L4 character integration ≥ 5.0** (a grounded, scene-lit **real-3D** actor reads as belonging in
+    the plate — the billboard/"pasted sticker" look is the LOW end; the L4 ceiling is a polish-phase
+    target, not a demo gate).
+  A placeholder demo-cast model that is grounded, lit, and screen-correct PASSES Tier-2 even though
+  it is not the final art. That is the point.
+- **Binary combat-FUN checklist (the demo must be *playable*, not just pretty):**
+  - [ ] A real engine attack drives the render (engine = sole writer; renderer replays `/events`).
+  - [ ] The hit shows a VFX (default-on-miss slash/impact is fine) AT the correct engine cell.
+  - [ ] A damage number + HP-bar drop is visible and matches the engine result.
+  - [ ] Actors face their heading; movement reads as turn-based motion (not a static tableau).
+  - [ ] Death/defeat resolves visibly (topple/fade) — no actor frozen after 0 HP.
+  - [ ] The whole exchange is legible at the dimetric camera (no occlusion guesswork; L5 readability OK).
+
+**Why the split:** the backdrop + pathing are **THE foundation** — the reusable, regenerate-and-reuse
+engine piece — so they clear the bar *before* a scene is built on them. Actors and effects are swapped
+through the proven pipeline (the registry-by-slot invariant), so they are legitimately placeholder
+until the polish phase. This is exactly the Pillar-4 reconciliation made measurable.
 
 ## How we build — the dev + decision loop
 

--- a/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP-POE2.md
+++ b/docs/roadmap/WORLDOS-GRAPHICS-ROADMAP-POE2.md
@@ -1,0 +1,176 @@
+# WorldOS Graphics Roadmap — PoE2 painterly CRPG (self-driving)
+
+> **The repo-homed self-driving graphics roadmap.** This is the in-repo home for the graphics/PoE2
+> goal: a *repeatable AI system* that generates a painterly Pillars-of-Eternity-II-caliber world and
+> drives a playable combat scene to the bar. It is the execution plan behind the **"Graphics North
+> Star (PoE2)"** section of [`VISION.md`](../../VISION.md) and is the in-repo distillation of the
+> operator plan (`~/.claude/plans/worldos-graphics-autonomous-goal.md`, owner-local — not committed).
+>
+> **Relationship to the other graphics roadmap.** [`WORLDOS-GRAPHICS-ROADMAP.md`](./WORLDOS-GRAPHICS-ROADMAP.md)
+> is the *taxonomy* roadmap — game-types (GT0/GT1/GT2) × capabilities (C1–C10), the Branch-A/Branch-B
+> matrix. THIS file is the *execution* roadmap for the **GT2 PoE2 painterly renderer specifically**:
+> the milestone ladder, the score-gates, and the asset-pipeline workflow that fill in GT2's column.
+> The taxonomy file says *what kinds of games*; this file says *how the PoE2 look gets built, scored,
+> and scaled*. Neither overwrites the other; this one is additive.
+>
+> **Single-writer discipline (mirrors the engine).** The Python engine is the **sole writer** of game
+> state. Every renderer, asset pipeline, and AI loop in this roadmap is a **read-only consumer** of the
+> engine read-models (`/atlas-surface`, `/character-surface`, `/combat-surface`, `/chat`, `/events`) +
+> the single `POST /move` intent lane. No renderer or gen-loop ever becomes a second source of truth.
+> The asset analogue: the renderer reads an **asset registry by SLOT** and resolves to a default on a
+> miss — swapping/regenerating any asset is **zero renderer edits** (the new VISION.md invariant).
+
+---
+
+## 0. The GOAL
+
+A **repeatable AI system that generates a painterly PoE2 world** and renders a playable combat scene
+to the bar — built so the same workflow scales from one room to a world:
+
+> **room → pathing → actors → playable → scale.**
+
+1. **room** — generate a camera-pinned painterly **backdrop plate** for a room.
+2. **pathing** — derive a correct **walkmask / pathing map** off that plate (walkable floor walkable,
+   painted obstacles block, destinations resolve to engine zones).
+3. **actors** — drop **real 3D animated actors** into the plate, grounded + scene-lit + readable.
+4. **playable** — wire a real engine attack → the renderer replays it (VFX + damage number + HP drop)
+   so the scene is *played*, not just looked at.
+5. **scale** — make the workflow **repeatable**: 1 room → 1 scene → larger scenes → a world, with a
+   part library + room-to-room transitions for cross-room consistency.
+
+The binding quality gate is the **BACKDROP scorecard** (see §3); actors/effects ride a
+**default-if-missing** registry and are **placeholder-OK** for the demo (polished much later). The
+demo cast is a handful of throwaway actors + ~10 monsters; the proof is that the **workflows are
+proven + repeatable**, not that the demo art is final.
+
+---
+
+## 1. The PoE2 layer stack (build it the way PoE2 layered it)
+
+PoE2 built its painterly world by layering rendered passes on a **2D side**. WorldOS mirrors that
+order — each layer is shippable on its own and is *added*, never a rewrite:
+
+| Layer | What it is | WorldOS form | Owned by | Bar |
+|------|-----------|--------------|----------|-----|
+| **L-stack 1** | **2D backdrop + 3D models** | Camera-pinned painterly plate (2D) + real 3D animated actors on the frozen dimetric camera | renderer (reads engine surfaces) | **TIER-1 backdrop scorecard PASS**; actors placeholder-OK |
+| **L-stack 2** | **A few 3D effects** | Default-on-miss VFX at the engine cell (slash/impact flash, one spell/projectile), hit-react, death | renderer (replays `/events`) | combat-FUN checklist; effects placeholder-OK |
+| **L-stack 3** | **Day/night + lighting** | Scene key-light direction/color; warm/cool firelit palette; blue-violet (never black) shadows; later normal-map dynamic lights (the PoE glow) | renderer | L3 scene-light coherence; atmospheric-moody not flat-gray |
+| **L-stack 4** | **Water** | Animated water / reflective surfaces, as PoE2 added on the 2D side | renderer | art-direction polish (post-demo) |
+
+The stack order is also the **risk order**: L-stack 1 (backdrop + grounded actors) is the foundation
+and gets the binding gate; L-stack 3/4 (lighting depth, water) are atmosphere layers added once the
+foundation holds. This matches PoE2's own production order — paint the plate, then light it, then add
+the moving water.
+
+---
+
+## 2. Scope progression — one workflow, growing scope
+
+The *same* generate→pathing→actors→playable workflow runs at every scope. Scaling is **repeating the
+proven workflow with a part library + transitions**, not building a new pipeline per scope.
+
+| Scope | What it is | What it proves |
+|------|-----------|----------------|
+| **1 room** | One detailed painterly room, pathing-mapped, with a playable combat exchange | the workflow exists end-to-end |
+| **1 scene** | The room as a real *playable* combat scene driven by the engine (multi-actor, VFX, death) | the workflow is *played*, not just rendered |
+| **larger scenes** | 2nd + 3rd UNIQUE detailed rooms; a camera-pinned **part library** (floor/wall/prop kit) for cross-room consistency; room-to-room transition (engine scene-swap on an edge cell) | the workflow is **repeatable + consistent** across rooms |
+| **a world** | Many rooms/scenes stitched into a traversable area at the PoE2 bar | the workflow **scales** to a world |
+
+---
+
+## 3. The graphics scorecard (the gate the milestones are measured against)
+
+The binding gate, lifted verbatim from VISION.md's **"Graphics North Star (PoE2)"** so the roadmap and
+the vision can never drift. Lenses `L1`–`L7` are the `visual-critic` panel lenses, logged to
+`qa/scores_db.py` (`surface="visual"`); the deterministic checks are `qa/visual_pregate.py`.
+
+- **TIER-1 — BACKDROP (binding; the foundation; ALL must hold):**
+  **L6 painterly-plate craft ≥ 8** AND **L1 registration/cohesion ≥ 8** AND **detail ≥ 7** AND
+  **0/3 washout** (no `visual_pregate.py` illusion-breaker trips) AND **pathing-map-correct** (the
+  derived walkmask matches the painted geometry).
+- **TIER-2 — ACTOR / EFFECT (placeholder-OK now; polished later):** deterministic **pre-gates PASS**
+  (frame-lit · floor-contact · screen-scale · occupancy · motion-liveness) AND **L2/L3/L4 ≥ 5.0**
+  (planted · scene-lit · grounded-real-3D-actor-reads-as-belonging). A grounded, lit, screen-correct
+  placeholder PASSES — that is intended.
+- **Binary combat-FUN checklist:** engine attack drives the render · VFX at the correct cell · damage
+  number + HP-bar drop matches the engine · actors face heading + read as turn-based motion · death
+  resolves visibly · the exchange is legible at the dimetric camera.
+
+> **North-star convergence target (whole combined scene):** visual-critic **overall ≥ 8.0 across 2
+> runs, every lens ≥ 6.5, 0 CRITICAL/HIGH, detail ≥ 7 (0 washout), all pre-gates PASS** — the gate the
+> self-driving loop drives toward. Brake a scene at its gate OR at a diminishing-returns ceiling
+> (no material gain across a pass ⇒ done-enough; log it and move on).
+
+---
+
+## 4. Milestones with score-gates
+
+Two tracks. **F-track** = the *foundation/plumbing* milestones that make the pipeline measurable and
+single-writer-clean (docs, camera, scorecard, GitHub). **M-track** = the *content/quality* milestones
+that drive renders to the bar. F-track lands first (it is what makes M-track scoreable); the
+visual-critic loop is the work-selector inside every M-milestone (render → pregate → 5–7-lens panel
+≥2 runs → fix the lowest lens / open CRITICAL → re-render → log scores_db).
+
+### Foundation track (F)
+
+| ID | Milestone | What "done" means | Gate |
+|----|-----------|-------------------|------|
+| **F1** | **camera-unfork** | ONE dimetric camera contract, declared canonical; the deprecated forked contract (e.g. the 06-23 `TavernTier1` cell-5 / 14×10) is retired and not reused | `extensions/renderers/unity/CANONICAL.md` "Camera contract (ONE — do not fork)" is the sole contract; no script forks it |
+| **F2** | **scorecard-split** | the graphics gate is split into binding TIER-1 backdrop vs placeholder-OK TIER-2 actor/effect, deterministic + lens-based | the split in §3 is implemented in `qa/visual_pregate.py` + the `visual-critic` panel + logged to `qa/scores_db.py` (`surface="visual"`) |
+| **F3** | **vision/docs** (this PR) | the graphics/PoE2 goal has a real home in the canonical docs; placeholder strategy reconciled with the vision | VISION.md "Graphics North Star (PoE2)" + backdrop scorecard + "1.0 Playable Combat Demo" rung + Pillar-4 reconciliation + registry-by-slot invariant; THIS roadmap filed |
+| **F4** | **github-map** | the M-track milestones are mapped to GitHub Milestones/Issues with `graphics` + `gt2` + `cap:*` labels so the plan is queryable + executable | each M-milestone below → a GitHub milestone; each unit → an issue, cross-linked from this file |
+
+### Content / quality track (M) — each is a visual-critic loop to its gate
+
+| ID | Milestone | Scope | Gate |
+|----|-----------|-------|------|
+| **M-A** | **repeatable-backdrop-workflow** | Generate painterly room plates via a *repeatable* pipeline (greybox → img2img → camera-pin) | **3 rooms each ≥ 8** on the TIER-1 backdrop gate (L6≥8, L1≥8, detail≥7, 0/3 washout) — proves the *workflow* is repeatable, not a one-off lucky plate |
+| **M-B** | **pathing-mapped-rooms** | Derive a correct walkmask / pathing map off each plate; destinations resolve to engine zones | **pathing-map-correct** on each M-A room (walkable floor walkable, painted obstacles block, edge cells transition) |
+| **M-C** | **3D-actors-grounded/lit/readable** | Drop real 3D animated actors (demo cast + monsters) into the plates | TIER-2 pre-gates PASS + **L2/L3/L4 ≥ 5.0**; actors grounded (contact shadow, feet on floor), scene-lit (key light), readable at the dimetric camera |
+| **M-D** | **playable-combat-in-app** | A real engine attack drives the render in-app; VFX + damage + HP + death | the **binary combat-FUN checklist** all-checked; engine = sole writer, renderer replays `/events`; this is the **1.0 Playable Combat Demo** rung |
+| **M-E** | **scale-to-a-world** | Part library (camera-pinned kit) + room-to-room transitions; many rooms stitched | ≥ N rooms at the TIER-1 bar with cross-room consistency; a traversable multi-room area at the PoE2 bar (north-star convergence target, §3) |
+
+**Dependency order:** F1→F2→F3→F4 (foundation), then M-A→M-B→M-C→M-D→M-E (each M depends on the
+prior; M-A/M-B can overlap once a plate exists). M-track gating presupposes F2 (the scorecard split)
+and F1 (the unforked camera) are in place — without them the scores aren't trustworthy.
+
+---
+
+## 5. The self-driving loop (how the M-track is executed)
+
+The graphics work is **work-selected by the visual-critic loop**, mirroring the engine's story/mech QA
+loop on the visual side:
+
+```
+render  →  qa/visual_pregate.py  →  (if FLAG: fix + re-render)
+        →  visual-critic 5–7-lens panel (≥2 runs)
+        →  fix the LOWEST lens / open CRITICAL
+        →  re-render
+        →  log every scored frame to qa/scores_db.py (surface="visual")
+        →  brake at the scene's gate OR a diminishing-returns ceiling
+```
+
+- **Engine = sole writer; renderer read-only.** The loop never mutates engine state; it consumes the
+  read-model surfaces + replays `/events`. A real engine attack is what drives the M-D render.
+- **Registry-by-slot.** Asset swaps/regenerations are registry changes, never renderer edits — this is
+  what makes placeholders cheap to replace and the scale step (M-E) a content task, not a code task.
+- **Commit each working unit.** Box git per render increment; PRs for any engine/viewer change. The
+  CANONICAL.md iteration discipline is binding (persist the build script, capture + score + log,
+  register the new current-best, mark the superseded one DEPRECATED).
+
+---
+
+## 6. Cross-references
+
+- **Vision anchor:** [`VISION.md`](../../VISION.md) → "Graphics North Star (PoE2)" (the binding
+  scorecard), Pillar 4 (the placeholder reconciliation), the release ladder's "1.0 Playable Combat
+  Demo" rung, and the registry-by-slot invariant.
+- **Taxonomy roadmap:** [`WORLDOS-GRAPHICS-ROADMAP.md`](./WORLDOS-GRAPHICS-ROADMAP.md) — GT2 is the
+  game-type this file executes; C2 (scene), C3 (combat), C4 (movement/pathing), C5 (assets), C7
+  (lighting) are the capabilities its milestones advance.
+- **Operator plan:** `~/.claude/plans/worldos-graphics-autonomous-goal.md` (owner-local; the live
+  self-driving run this roadmap is the committed distillation of).
+- **Renderer canonical state:** [`extensions/renderers/unity/CANONICAL.md`](../../extensions/renderers/unity/CANONICAL.md)
+  — the ONE camera contract (F1), the current-best-per-surface registry, and the iteration discipline.
+- **Visual scorer:** the `visual-critic` skill (the "Angry-DM for graphics") + `qa/visual_pregate.py`
+  (deterministic pre-gates) + `qa/scores_db.py` (`surface="visual"` regression ledger).


### PR DESCRIPTION
## F3 — vision/docs: give the graphics/PoE2 goal a real home + reconcile the placeholder strategy

Additive, **docs-only** (no code, no engine state). Gives the graphics/PoE2 goal a canonical home in `VISION.md` and files the repo-homed self-driving graphics roadmap.

### Strategy (owner-confirmed 2026-06-30)
WorldOS's first game is a painterly **PoE2** (Pillars of Eternity II: Deadfire) AI-DM CRPG — **2D camera-pinned painterly backdrops + real 3D animated actors** on a frozen dimetric camera. The current milestone is a **playable, modular combat demo built on PLACEHOLDERS** (demo cast + ~10 monsters, default-on-miss; default VFX/sounds) so the **workflows are proven + repeatable**. **Backdrops + pathing are THE foundation** — the reusable engine piece. The binding quality gate is the **BACKDROP scorecard**; actors/effects ride a default-if-missing registry and are placeholder-OK for now.

### Deliverable 1 — `VISION.md` (all additive; existing content preserved)
- **New section "Graphics North Star (PoE2)"** — PoE2 = the single reference bar; 2D painterly plates + 3D actors on a fixed dimetric camera; warm/cool firelit palette, blue-violet (never black) shadows, atmospheric-moody NOT flat-gray.
- **The BACKDROP-BINDING graphics scorecard** — TIER-1 backdrop (`L6≥8 AND L1≥8 AND detail≥7 AND 0/3 washout AND pathing-map-correct`) vs TIER-2 actor/effect (placeholder-OK; pre-gates PASS + `L2/L3/L4≥5.0`) + the binary combat-FUN checklist.
- **New "1.0 Playable Combat Demo" rung** in the release ladder (Player-Ready Beta → **Demo** → 1.0 GA).
- **Pillar-4 reconciliation** — "Real art, not placeholders" amended so placeholders are legitimized as the **PATH** (prove the workflow once with throwaway assets) and real-art-via-the-proven-workflow is the destination. Demo placeholders are **NOT** a vision violation.
- **New invariant** — the renderer reads a registry **by SLOT** and resolves to a default on miss; swapping/regenerating ANY asset = **ZERO renderer edits** (the asset analogue of *engine = sole writer*).

### Deliverable 2 — `docs/roadmap/WORLDOS-GRAPHICS-ROADMAP-POE2.md` (NEW)
The repo-homed self-driving graphics roadmap: the **GOAL** (room → pathing → actors → playable → scale), the **PoE2 layer stack** (2D backdrop + 3D models → a few 3D effects → day/night + lighting → water), the **scope progression** (1 room → 1 scene → larger scenes → a world), and the **milestones with score-gates** — F1 camera-unfork, F2 scorecard-split, F3 vision/docs, F4 github-map; M-A repeatable-backdrop-workflow (3 rooms each ≥8), M-B pathing-mapped-rooms, M-C 3D-actors-grounded/lit/readable, M-D playable-combat-in-app, M-E scale-to-a-world. Cross-references `VISION.md`, the operator plan, the GT/capability taxonomy roadmap, and the Unity `CANONICAL.md`.

### Filename note (important)
The target path `docs/roadmap/WORLDOS-GRAPHICS-ROADMAP.md` **already exists** as the canonical GT0/GT1/GT2 × C1–C10 capability-**taxonomy** roadmap (PR #424 era). To stay additive and avoid clobbering it, the new self-driving PoE2 **execution** roadmap is filed as **`WORLDOS-GRAPHICS-ROADMAP-POE2.md`**, and the two cross-reference each other (taxonomy = *what kinds of games*; this = *how the PoE2 look gets built/scored/scaled*).

### Verification
- Purely additive: the only 3 removed lines in `VISION.md` are the original Pillar-4 sentence + release-ladder tail, both expanded in-place — no content lost.
- All relative cross-reference links resolve (`../../VISION.md`, `./WORLDOS-GRAPHICS-ROADMAP.md`, `CANONICAL.md`, `qa/visual_pregate.py`, `qa/scores_db.py`).