### PR TITLE
F1: unfork camera contract — visual_pregate CameraSpec → renderer contract (ortho 13 / pitch 30° / yaw 45 / 14×11)

### DIFF
--- a/extensions/renderers/shared/camera_contract.json
+++ b/extensions/renderers/shared/camera_contract.json
@@ -1,20 +1,28 @@
 {
-  "version": 1,
+  "version": 2,
   "projection": "dimetric-2to1",
   "camera_type": "orthographic",
   "elevation_deg": 30.0,
   "yaw_deg": 45.0,
   "zoom_locked": true,
   "rotation_locked": true,
+  "grid_cols": 14,
+  "grid_rows": 11,
   "cell_size_world": 2.0,
-  "ortho_size_world": 12.0,
-  "char_height_world": 3.6,
+  "ortho_size_world": 13.0,
+  "char_height_world": 5.0,
+  "camera_distance_world": 80.0,
+  "render_px_w": 1920,
+  "render_px_h": 1097,
   "near": 0.3,
   "far": 500.0,
+  "source_of_truth": "extensions/renderers/unity/scripts/paint_combat_v1.cs (+ paint_3d_spike.cs) — the PROVEN Unity combat renderer. qa/visual_pregate.py CameraSpec.LOCKED mirrors these exact numbers.",
   "notes": [
+    "RECONCILED 2026-06-30 to the proven Unity combat renderer (was: ortho_size_world=12, char_height_world=3.6, no grid/px/distance, and a stale yaw note). The Unity contract is: orthographicSize=13; Quaternion.Euler(30,45,0); position=-(rot*forward)*80 (camera pulled back 80 world units along -forward, looking at the world origin); capture 1920x1097.",
     "elevation_deg = asin(0.5) = 30deg gives a TRUE 2:1 screen foreshortening of a ground tile: screen_h/screen_w = sin(elevation). (Corrects the old atan(0.5)=26.565deg, which gives 2.236:1.)",
-    "cellToWorld(c,r) = ((c-cx0)*S, 0, (cy0-r)*S); S=cell_size_world; cx0=(cols-1)/2; cy0=(rows-1)/2. The on-screen 2:1 diamond emerges from the camera (yaw + 30deg pitch), NOT from per-axis steps. Inverse: c = cx0 + wx/S, r = cy0 - wz/S.",
-    "yaw_deg = 0 = front-tilted framing (the owner-liked crypt look). Set 45 for classic corner-iso (must then match bake_sprites.py facings). Owner eyeball-pick during P0; reconcile bake yaw in P3.",
-    "ortho_size_world = half the vertical view height in world units (= ortho_rows/2 * cell_size). px_per_world = render_height / (2*ortho_size_world). Plate aspect MUST equal the capture-camera aspect or the tiles skew."
+    "cellToWorld(c,r) = ((c-cx0)*S, 0, (cy0-r)*S); S=cell_size_world; cx0=(cols-1)/2=6.5; cy0=(rows-1)/2=5.0 for the 14x11 grid (== the renderer's literal ((c-6.5)*2.0, 0, (5.0-r)*2.0)). The on-screen 2:1 diamond emerges from the camera (yaw 45 + 30deg pitch), NOT from per-axis steps. Inverse: c = cx0 + wx/S, r = cy0 - wz/S.",
+    "yaw_deg = 45 = classic corner-iso (matches the proven combat renderer). Bake facings (bake_sprites.py) must match this yaw.",
+    "ortho_size_world = half the vertical view height in world units. px_per_world = render_px_h / (2*ortho_size_world). Plate/capture aspect = render_px_w/render_px_h = 1920/1097 ~= 1.75; the plate aspect MUST equal the capture-camera aspect or the tiles skew.",
+    "camera_distance_world is the magnitude of position = -(rot*forward)*80; with rot=Euler(30,45,0) this is world position (-48.99, 40.0, -48.99). Ortho => distance does not affect framing, only near/far ordering; kept for fidelity to the renderer."
   ]
 }

--- a/qa/test_visual_critic.py
+++ b/qa/test_visual_critic.py
@@ -2,10 +2,10 @@
 """Tests for the visual-critic v2 deterministic layer.
 
 Covers:
-  1. CameraSpec.world_to_screen — projection matches Unity's locked dimetric spec to ≤1px
-     (using the known camera params: orthoSize=18, pitch=atan(0.5), pos=(0,40.25,-55.5),
-     aspect=1344/756). Validated against Unity WorldToViewportPoint ground truth during the
-     bake-off (the camera-fix from right×fwd to fwd×right cross-product).
+  1. CameraSpec.world_to_screen — projection matches the PROVEN Unity combat renderer's locked
+     dimetric spec to ≤1px (orthoSize=13, pitch=30deg, yaw=45deg, pos=-(Euler(30,45,0)*fwd)*80,
+     aspect=1920/1097). The renderer (extensions/renderers/unity/scripts/paint_combat_v1.cs) is the
+     ground truth; the camera looks at the world origin, so origin -> exact screen center.
   2. G1 FRAME-LIT verdicts on synthetic PNG inputs (black frame → CRITICAL, white-lit → PASS).
   3. G3 FLOOR-CONTACT verdicts on synthetic actor inputs (floating actor → CRITICAL, grounded → PASS).
   4. G4 SCREEN-SCALE verdicts on synthetic actor inputs (giant actor → HIGH, correct → PASS).
@@ -83,32 +83,44 @@ def _minimal_scenegrid(cols: int = 15, rows: int = 12) -> vp.SceneGrid:
 
 
 # ---------------------------------------------------------------------------
-# 1. Camera projection — ≤1px vs Unity ground truth for specific world points
+# 1. Camera projection — ≤1px vs the Unity-renderer contract for specific world points
 # ---------------------------------------------------------------------------
-# Ground-truth screen pixel coords from the analytic ortho projection (yaw=0, so the
-# geometry is deterministic: right = (cos0,0,-sin0)=(1,0,0), fwd×right gives a pure-pitch up).
-# These encode the bake-off camera-fix invariant: up=cross(fwd,right), NOT right×fwd.
+# Ground-truth screen pixel coords from the analytic ortho projection of the CANONICAL renderer
+# contract (orthoSize=13, pitch=30deg, yaw=45deg corner-iso, pos=-(Euler(30,45,0)*fwd)*80, capture
+# 1920x1097). The camera looks at the world origin. The fwd/right/up basis below was verified to
+# match Unity's Quaternion.Euler(30,45,0) transform to <1e-3.
 # Format: (wx, wy, wz) -> expected (sx, sy) in image-space pixels (top-left origin, +y down).
-# Tolerance: ≤1px — matches the "≤1px vs Unity WorldToViewportPoint" claim in the SKILL.md.
+# Tolerance: ≤1px. This is independent re-derivation of CameraSpec.world_to_screen — if the two
+# drift, one of them forked the renderer contract.
+_GT_ORTHO = 13.0
+_GT_PITCH = 30.0
+_GT_YAW = 45.0
+_GT_DIST = 80.0
+_GT_PW, _GT_PH = 1920, 1097
+
+
 def _analytic_gt(wx: float, wy: float, wz: float) -> tuple[float, float]:
-    """Analytic ortho projection for the locked spec (yaw=0, pitch=atan(0.5))."""
+    """Analytic ortho projection for the renderer contract (yaw=45, pitch=30, ortho=13, 1920x1097)."""
     import math as _math
-    p = _math.radians(_math.degrees(_math.atan(0.5)))  # == atan(0.5) exactly
-    fwd = (_math.sin(0) * _math.cos(p), -_math.sin(p), _math.cos(0) * _math.cos(p))
-    right = (1.0, 0.0, 0.0)
+    p = _math.radians(_GT_PITCH)
+    y = _math.radians(_GT_YAW)
+    fwd = (_math.sin(y) * _math.cos(p), -_math.sin(p), _math.cos(y) * _math.cos(p))
+    right = (_math.cos(y), 0.0, -_math.sin(y))
     up = (
         fwd[1] * right[2] - fwd[2] * right[1],
         fwd[2] * right[0] - fwd[0] * right[2],
         fwd[0] * right[1] - fwd[1] * right[0],
     )
-    pos = (0.0, 40.25, -55.5)
+    # Camera pulled back DIST along -forward, looking at the world origin (renderer: *80f).
+    pos = tuple(-fwd[i] * _GT_DIST for i in range(3))
     dx, dy, dz = wx - pos[0], wy - pos[1], wz - pos[2]
     cam_r = dx * right[0] + dy * right[1] + dz * right[2]
     cam_u = dx * up[0] + dy * up[1] + dz * up[2]
-    half_h = 18.0
-    half_w = 18.0 * (1344.0 / 756.0)
-    sx = (cam_r / half_w) * (1344.0 / 2.0) + 1344.0 / 2.0
-    sy = 756.0 / 2.0 - (cam_u / half_h) * (756.0 / 2.0)
+    aspect = _GT_PW / _GT_PH
+    half_h = _GT_ORTHO
+    half_w = _GT_ORTHO * aspect
+    sx = (cam_r / half_w) * (_GT_PW / 2.0) + _GT_PW / 2.0
+    sy = _GT_PH / 2.0 - (cam_u / half_h) * (_GT_PH / 2.0)
     return sx, sy
 
 
@@ -123,7 +135,7 @@ _CAMERA_GT: list[tuple[tuple[float, float, float], tuple[float, float]]] = [
 
 
 class TestCameraProjection:
-    """Validate the locked dimetric camera's world_to_screen projection.
+    """Validate the locked dimetric camera's world_to_screen projection against the renderer contract.
 
     Key invariant from the bake-off camera fix:
       up = cross(fwd, right)   ← correct (fwd×right)
@@ -131,7 +143,8 @@ class TestCameraProjection:
 
     Test 1: far cells (high Z) project ABOVE near cells (lower Z) — i.e. sy decreases with wz.
     Test 2: right-side points project to higher sx (positive cam_r).
-    Test 3: a known grid-centre cell produces sx near 672, sy near 378 (≤1px tol).
+    Test 3: world points project within ≤1px of the analytic renderer-contract GT (ortho=13/pitch=30/
+            yaw=45/1920x1097); the world origin lands on the exact screen center (960, 548.5).
     """
 
     def test_far_cell_projects_above_near_cell(self):
@@ -176,17 +189,117 @@ class TestCameraProjection:
         assert pcy > 0, f"floor_px_per_cell_y should be positive, got {pcy}"
 
     def test_camera_spec_locked_singleton(self):
-        """CameraSpec.LOCKED should match the known bake-off spec values."""
+        """CameraSpec.LOCKED must match the PROVEN Unity combat-renderer contract values
+        (paint_combat_v1.cs / paint_3d_spike.cs): ortho 13, pitch 30, yaw 45, 1920x1097, and the
+        pos = -(Euler(30,45,0)*forward)*80 pullback (camera looking at the world origin)."""
         c = vp.CameraSpec.LOCKED
-        assert abs(c.ortho_size - 18.0) < 1e-9
-        assert abs(c.pos[0] - 0.0) < 1e-9
-        assert abs(c.pos[1] - 40.25) < 1e-9
-        assert abs(c.pos[2] - (-55.5)) < 1e-9
-        assert abs(c.aspect - 1344.0 / 756.0) < 1e-6
-        expected_pitch = math.degrees(math.atan(0.5))
-        assert abs(c.pitch_deg - expected_pitch) < 1e-9
-        assert c.px_w == 1344
-        assert c.px_h == 756
+        assert abs(c.ortho_size - 13.0) < 1e-9
+        assert abs(c.pitch_deg - 30.0) < 1e-9
+        assert abs(c.yaw_deg - 45.0) < 1e-9
+        assert abs(c.aspect - 1920.0 / 1097.0) < 1e-6
+        assert c.px_w == 1920
+        assert c.px_h == 1097
+        # pos = -(forward)*80, forward=(0.61237,-0.5,0.61237) -> (-48.99, 40.0, -48.99).
+        assert abs(c.pos[0] - (-48.9898)) < 1e-3, c.pos
+        assert abs(c.pos[1] - 40.0) < 1e-3, c.pos
+        assert abs(c.pos[2] - (-48.9898)) < 1e-3, c.pos
+
+
+# ---------------------------------------------------------------------------
+# 1b. Pre-gate camera MATCHES the renderer's cellToWorld (the unfork regression guard)
+# ---------------------------------------------------------------------------
+# The whole point of the pre-gate is to project the SAME world points the Unity renderer placed
+# actors at. The renderer's grid mapping (paint_combat_v1.cs / paint_3d_spike.cs) is:
+#     cellToWorld(c,r) = ((c-6.5)*2.0, 0, (5.0-r)*2.0)        # 14 cols x 11 rows, cell_size 2.0
+# These tests assert CameraSpec.LOCKED projects that mapping the way the renderer does. If the
+# CameraSpec forks the renderer contract again (e.g. ortho 18 / pitch atan(0.5) / yaw 0 / 1344x756),
+# these break — that fork was exactly what made the G1-G4 geometry gates score the WRONG camera.
+
+
+def _render_cell_to_world(c: int, r: int) -> tuple[float, float, float]:
+    """The Unity renderer's exact cell->world mapping (cell_size 2.0, centers cx0=6.5, cy0=5.0)."""
+    return ((c - 6.5) * 2.0, 0.0, (5.0 - r) * 2.0)
+
+
+class TestPregateMatchesRendererCellToWorld:
+    def test_center_cell_projects_near_screen_center(self):
+        """A token at the renderer's cellToWorld(6,5)=(-1,0,0) projects NEAR the frame center.
+
+        The camera looks at the world origin, so the cell straddling grid-center (between cols 6/7,
+        at row 5) lands within a fraction of a cell of the exact screen center (px_w/2, px_h/2)."""
+        cam = vp.CameraSpec.LOCKED
+        wx, wy, wz = _render_cell_to_world(6, 5)
+        sx, sy = cam.world_to_screen(wx, wy, wz)
+        cx, cy = cam.px_w / 2.0, cam.px_h / 2.0
+        # (-1,0,0) is one world unit (half a cell) left of origin; allow a generous half-cell-ish band.
+        # The previous forked camera (ortho 18 / pos (0,40.25,-55.5)) put this point well outside it.
+        assert abs(sx - cx) < 60.0, f"cell(6,5) sx={sx:.1f} should be near center {cx:.1f}"
+        assert abs(sy - cy) < 60.0, f"cell(6,5) sy={sy:.1f} should be near center {cy:.1f}"
+
+    def test_world_origin_is_exact_screen_center(self):
+        """The renderer points the camera at the world origin (pos=-(fwd)*80), so origin -> exact
+        screen center. This pins the pos/look-at to the renderer's pullback contract."""
+        cam = vp.CameraSpec.LOCKED
+        sx, sy = cam.world_to_screen(0.0, 0.0, 0.0)
+        assert abs(sx - cam.px_w / 2.0) < 1e-6, f"origin sx={sx}"
+        assert abs(sy - cam.px_h / 2.0) < 1e-6, f"origin sy={sy}"
+
+    def test_feet_at_world_y0_land_on_floor_plane(self):
+        """An actor STANDING at a cell (renderer foot-snaps feet to world-Y=0) must have its measured
+        screen feet land on the projected floor-plane Y at that cell -> G3 PASS. This is the contract
+        G3 enforces; here we assert the GROUNDED case is a PASS under the renderer-matched camera.
+
+        We feed a SceneGrid whose cell centers reproduce the renderer's cellToWorld for the chosen
+        cell, project the floor plane (world-Y=0) there, and place the actor's feet exactly on it."""
+        cam = vp.CameraSpec.LOCKED
+        # Renderer cell -> world for cell (8,4); project its floor plane (y=0) to the screen.
+        c, r = 8, 4
+        wx, wy, wz = _render_cell_to_world(c, r)
+        _, floor_sy = cam.world_to_screen(wx, 0.0, wz)
+        # Build a SceneGrid whose cell_world_x/z reproduce this same world point at (c,r), so G3's
+        # internal projection lands on the SAME floor plane the renderer painted.
+        sg = vp.SceneGrid(
+            cols=14, rows=11, cell_size_ft=2.0,
+            cells={}, props=[], spawns={}, lighting={},
+            cell_default={"type": "floor", "walkable": True},
+        )
+        # Sanity: the SceneGrid X mapping matches the renderer's for this cell (both = (c-6.5)*2.0).
+        assert abs(sg.cell_world_x(c) - wx) < 1e-9, (sg.cell_world_x(c), wx)
+        # Place feet exactly on the projected floor plane at (c,r) per the SceneGrid's own mapping.
+        sg_wx, sg_wz = sg.cell_world_x(c), sg.cell_world_z(r)
+        sx_feet, sy_feet = cam.world_to_screen(sg_wx, 0.0, sg_wz)
+        actor = {"id": "stander", "cell": [c, r], "feet_px": [round(sx_feet), round(sy_feet)],
+                 "px_height": 100}
+        gates = vp.gate_floor_contact_and_scale(sg, cam, [actor])
+        g3 = [g for g in gates if g["gate"] == "G3_floor_contact"]
+        assert g3, "G3 should have run"
+        assert all(g["severity"] == "PASS" for g in g3), (
+            f"feet placed on the world-Y=0 floor plane must be GROUNDED (G3 PASS); got {g3}"
+        )
+
+    def test_actor_standing_height_matches_floor_to_head_projection(self):
+        """The renderer foot-snaps the actor to y=0 and scales it to a world height; the actor's
+        projected pixel-height (floor y=0 -> head y=H) is what G4 expects. A correctly-scaled actor
+        therefore PASSes G4 under the renderer-matched camera."""
+        cam = vp.CameraSpec.LOCKED
+        sg = vp.SceneGrid(
+            cols=14, rows=11, cell_size_ft=2.0,
+            cells={}, props=[], spawns={}, lighting={},
+            cell_default={"type": "floor", "walkable": True},
+        )
+        c, r = 8, 4
+        wx, wz = sg.cell_world_x(c), sg.cell_world_z(r)
+        _, sy_feet = cam.world_to_screen(wx, 0.0, wz)
+        _, sy_head = cam.world_to_screen(wx, vp.DEFAULT_ACTOR_WORLD_H, wz)
+        expected_px = abs(sy_head - sy_feet)
+        actor = {"id": "scaled", "cell": [c, r], "feet_px": [round(wx), round(sy_feet)],
+                 "px_height": expected_px}
+        gates = vp.gate_floor_contact_and_scale(sg, cam, [actor])
+        g4 = [g for g in gates if g["gate"] == "G4_screen_scale"]
+        assert g4, "G4 should run when px_height is supplied"
+        assert all(g["severity"] == "PASS" for g in g4), (
+            f"an actor at the floor->head projected height must PASS G4; got {g4}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/qa/visual_pregate.py
+++ b/qa/visual_pregate.py
@@ -32,10 +32,14 @@ DEPENDENCIES (graceful degradation — never a hard import error):
     segmentation pass produces them); this module does NOT do CV detection — it does the MATH that
     turns measured boxes + the spec into a pass/fail with a numeric delta.
 
-CAMERA / PROJECTION (the locked dimetric registration authority — must match ClosedLoopBuilder.cs):
-  orthographic, orthoSize=18, aspect=1344/756 (16:9), pitch=atan(0.5)=26.565deg (dimetric 2:1),
-  yaw=0, roll=0, position=(0, 40.25, -55.5). World->screen below is derived from exactly this.
-  If the Unity camera changes, update CameraSpec (one place) — the registration stays single-authority.
+CAMERA / PROJECTION (the locked dimetric registration authority — must match the PROVEN Unity combat
+  renderer, i.e. extensions/renderers/unity/scripts/paint_combat_v1.cs + paint_3d_spike.cs):
+  orthographic, orthoSize=13, aspect=1920/1097 (~1.75), pitch(x)=30deg, yaw(y)=45deg corner-iso,
+  roll=0, position = -(Euler(30,45,0)*forward)*80 = (-48.99, 40.0, -48.99) — the camera is pulled
+  back 80 world units along its own forward axis and LOOKS AT the world origin; near 0.3 / far 500.
+  Grid 14x11; cellToWorld(c,r) = ((c-6.5)*2.0, 0, (5.0-r)*2.0), cell_size 2.0. World->screen below
+  is derived from exactly this. If the Unity camera changes, update CameraSpec (one place) — the
+  registration stays single-authority.
 
 USAGE
 -----
@@ -102,26 +106,56 @@ MOVE_CENTROID_MIN_PX = 2.0    # a beat tagged as a MOVE must shift the bright-ma
 
 
 # ---------------------------------------------------------------------------
-# Camera — the locked dimetric registration authority (mirror of ClosedLoopBuilder.cs LockCamera)
+# Camera — the locked dimetric registration authority (mirror of the PROVEN Unity combat renderer:
+# extensions/renderers/unity/scripts/paint_combat_v1.cs + paint_3d_spike.cs).
+#
+# Unity contract (paint_combat_v1.cs lines 11-12):
+#     cam.orthographic=true; cam.orthographicSize=13f; nearClip=0.3; farClip=500;
+#     Quaternion _crot=Quaternion.Euler(30f,45f,0f);
+#     cam.transform.rotation=_crot; cam.transform.position=-(_crot*Vector3.forward)*80f;
+# i.e. pitch(x)=30deg, yaw(y)=45deg, the camera pulled back DIST=80 world units along its own
+# forward axis so it LOOKS AT the world origin. Capture is 1920x1097 (aspect ~1.75).
+#
+# The world_to_screen basis (fwd/right/up) below is derived analytically from pitch+yaw and was
+# verified to match Unity's Quaternion.Euler(30,45,0) transform basis to <1e-3 (fwd=(0.612,-0.5,
+# 0.612), right=(0.707,0,-0.707), up=(0.354,0.866,0.354)). pos is the same -(fwd)*DIST pullback.
 # ---------------------------------------------------------------------------
+CAM_DIST = 80.0   # world units the camera is pulled back along -forward (renderer: *80f)
+
+
 @dataclass(frozen=True)
 class CameraSpec:
-    ortho_size: float = 18.0
-    aspect: float = 1344.0 / 756.0
-    pitch_deg: float = math.degrees(math.atan(0.5))   # 26.565 — true dimetric 2:1
-    yaw_deg: float = 0.0
-    pos: tuple[float, float, float] = (0.0, 40.25, -55.5)
-    px_w: int = 1344
-    px_h: int = 756
+    ortho_size: float = 13.0
+    aspect: float = 1920.0 / 1097.0
+    pitch_deg: float = 30.0   # Unity Euler x — elevation; asin(0.5)=30deg true 2:1 screen foreshortening
+    yaw_deg: float = 45.0     # Unity Euler y — corner-iso azimuth
+    px_w: int = 1920
+    px_h: int = 1097
+    # pos defaults to None -> derived in __post_init__ as -(forward)*CAM_DIST (the renderer's pullback,
+    # camera looking at the world origin). Pass an explicit pos only to model a non-origin-looking rig.
+    pos: Optional[tuple[float, float, float]] = None
+
+    def __post_init__(self):
+        if self.pos is None:
+            fwd = self._forward()
+            # -(rot*forward)*DIST: pull the camera back along -forward so it looks at world origin.
+            object.__setattr__(self, "pos", tuple(-fwd[i] * CAM_DIST for i in range(3)))
+
+    def _forward(self) -> tuple[float, float, float]:
+        """Camera forward (into the scene) from pitch (about X) + yaw (about Y). Matches Unity's
+        Quaternion.Euler(pitch, yaw, 0) * Vector3.forward to <1e-3 (verified)."""
+        p = math.radians(self.pitch_deg)
+        y = math.radians(self.yaw_deg)
+        return (math.sin(y) * math.cos(p), -math.sin(p), math.cos(y) * math.cos(p))
 
     def world_to_screen(self, wx: float, wy: float, wz: float) -> tuple[float, float]:
         """Project a world point to pixel coords under the locked ortho dimetric camera.
         Screen origin top-left, +y DOWN (image convention). Pure ortho => linear, no perspective."""
-        # Camera basis from pitch (about X) + yaw (about Y). yaw=0 in the locked rig, but kept general.
+        # Camera basis from pitch (about X) + yaw (about Y). yaw=45 in the locked rig (corner-iso).
         p = math.radians(self.pitch_deg)
         y = math.radians(self.yaw_deg)
-        # Forward (into scene), looking down by pitch:
-        fwd = (math.sin(y) * math.cos(p), -math.sin(p), math.cos(y) * math.cos(p))
+        # Forward (into scene), looking down by pitch + around by yaw:
+        fwd = self._forward()
         right = (math.cos(y), 0.0, -math.sin(y))
         # Up = fwd x right  (matches Unity's camera basis: verified against Unity
         # WorldToViewportPoint ground truth — the old right x fwd negated up, which


### PR DESCRIPTION
## Problem

`qa/visual_pregate.py`'s deterministic visual pre-gates (G1–G4) scored a **different camera** than the proven Unity combat renderer actually uses. The geometry gates — **G3 floor-contact** (feet-vs-floor-plane) and **G4 screen-scale** (pixel-height-at-depth) — therefore measured against the **wrong projection**, so a frame from the real renderer would be scored on a camera it was never shot with.

## Ground truth

The PROVEN combat renderer `extensions/renderers/unity/scripts/paint_combat_v1.cs` (and `paint_3d_spike.cs`):

```
cam.orthographic=true; cam.orthographicSize=13f; nearClip=0.3; farClip=500;
Quaternion _crot=Quaternion.Euler(30f,45f,0f);        // pitch(x)=30°, yaw(y)=45° corner-iso
cam.transform.rotation=_crot;
cam.transform.position=-(_crot*Vector3.forward)*80f;  // pulled back 80u along -forward, looking at world origin
// capture 1920×1097; grid 14×11; cellToWorld(c,r)=((c-6.5)*2.0, 0, (5.0-r)*2.0), cell_size 2.0
```

## The fork (before → after)

`CameraSpec.LOCKED` in `qa/visual_pregate.py`:

| field | BEFORE (forked) | AFTER (renderer-matched) |
|---|---|---|
| `ortho_size` | 18.0 | **13.0** |
| `aspect` | 1344/756 (≈1.778) | **1920/1097 (≈1.750)** |
| `pitch_deg` | atan(0.5)=26.565° | **30.0°** |
| `yaw_deg` | 0.0 | **45.0** |
| `pos` | (0, 40.25, −55.5) | **−(forward)·80 = (−48.99, 40.0, −48.99)** |
| `px_w × px_h` | 1344 × 756 | **1920 × 1097** |

## Projection math — where care was needed

- The `world_to_screen` **basis math was already correct and generalizes to yaw=45**. Verified the analytic `fwd/right/up` basis matches Unity's `Quaternion.Euler(30,45,0)` transform to **<1e-3** (`fwd=(0.612,−0.5,0.612)`, `right=(0.707,0,−0.707)`, `up=(0.354,0.866,0.354)`). The old spec ran with `yaw=0`, so the yaw terms were never exercised — only the **parameter values** were forked, not the formula.
- `pos` is now **derived** as `-(forward)*CAM_DIST` (CAM_DIST=80) in `__post_init__`, so the camera stays pinned looking at the **world origin** → origin projects to the **exact screen center (960, 548.5)**. Single-authority: change pitch/yaw and pos follows the renderer's pullback contract.
- The old gates were **silently passing on the wrong camera** — `floor_px_per_cell_y` and the floor-plane/head projections were all internally consistent with the forked spec, so G3/G4 never errored; they just measured a camera the renderer doesn't use.

## Also reconciled

- `extensions/renderers/shared/camera_contract.json`: `ortho_size_world` 12→**13**, `char_height_world` 3.6→**5.0**, added `grid_cols/rows`, `render_px_w/h`, `camera_distance_world`, a `source_of_truth` pointer, and fixed a stale `yaw_deg=0` note (the field was already 45). (It already had elevation 30 / yaw 45.)
- `extensions/renderers/unity/CANONICAL.md` already carried the correct numbers (ortho 13 / elevation 30 / yaw 45 / cell 2.0 / 14×11 / correct `cellToWorld`) — **left as-is** (no fork there).

## Tests

- Updated `TestCameraProjection` analytic ground-truth + `test_camera_spec_locked_singleton` to the renderer contract.
- **Added `TestPregateMatchesRendererCellToWorld`** (the unfork regression guard): a token at `cellToWorld(6,5)` projects near screen-center; world origin → exact center; feet at world-Y=0 land on the projected floor plane → **G3 PASS**; floor→head projected height → **G4 PASS**.

```
uv run --directory servers/engine python -m pytest qa/test_visual_critic.py -q -p no:xdist
  39 passed
uv run --directory servers/engine python -m pytest qa/test_motion_reel.py -q -p no:xdist
  14 passed
```

## Scope / safety

QA / view-layer config only — **no engine state writes** (sole-writer invariant honored). Additive: the projection formula is unchanged; only the locked parameter values and their tests moved to the renderer contract.

### Out-of-scope follow-up (noted, not touched)
`extensions/renderers/unity/scripts/ClosedLoopBuilder.cs` / `IntegrationBuilder.cs` are themselves still on the *old* forked camera (ortho 18-ish / pitch atan(0.5) / pos (0,40.25,−55.5) / 1344×756). They are **not** the proven combat renderer (`paint_combat_v1.cs` is), so they're left for a separate renderer-side reconciliation.