### PR TITLE
gfx M-B: auto-derive combat obstacles from scene_grid walls/props (rooms now have pathing)

### DIFF
--- a/servers/engine/scene_grid.py
+++ b/servers/engine/scene_grid.py
@@ -813,3 +813,80 @@ def ensure_scene_grid(world_id: str, location) -> bool:
         kind=explicit_kind,
     )
     return True
+
+
+# ── SceneGrid → combat-grid obstacle derivation (gfx M-B) ─────────────────────────────
+
+
+def impassable_cells(
+    grid: "SceneGrid",
+    width: int,
+    height: int,
+    *,
+    occupied: set[Cell] = frozenset(),
+) -> list[list[int]]:
+    """Derive the IMPASSABLE combat-grid cells (walls + prop footprints) from a SceneGrid,
+    so a fight bound to a painted room routes movement around its geometry.
+
+    Returns a sorted list of ``[x, y]`` pairs in the exact shape ``Combat.grid_impassable``
+    expects (the same shape ``set_grid(obstacles=...)`` produces), ready to assign directly.
+
+    Coordinate mapping (the alignment care-point): a SceneGrid cell is ``(c, r)`` = (col, row),
+    cols along +x and rows along +y (see the ``_gen_*`` generators), and the combat grid is
+    ``(x, y)`` with ``grid_width == cols`` and ``grid_height == rows``. So the mapping is the
+    identity ``c -> x``, ``r -> y`` — both are 0-indexed and ``cell_size_ft`` matches the combat
+    ``grid_cell_size`` default of 5. We still CLIP every derived cell to ``0 <= x < width`` and
+    ``0 <= y < height`` so a grid sized smaller than the scene (or vice-versa) never emits an
+    out-of-bounds obstacle.
+
+    A cell is impassable if EITHER:
+      * an explicit ``SceneCell`` lists it with ``walkable=False`` (walls/props/water/void), OR
+      * it falls inside any ``SceneProp.cells`` footprint (belt-and-suspenders: props already
+        emit ``walkable=False`` cells, but a footprint cell missing from ``cells`` is still a
+        solid object), OR
+      * ``cell_default.walkable`` is False (a fully-solid default — every UNLISTED in-bounds
+        cell is then a wall; rare, but honored).
+
+    ``occupied`` cells (where a combatant already stands at fight-start) are EXCLUDED from the
+    result so nobody is trapped on a cell the router would treat as a wall — a placement on a
+    prop cell stays legal and movable. Pure: no I/O, no mutation, deterministic order.
+    """
+    if width <= 0 or height <= 0:
+        return []
+
+    blocked: set[Cell] = set()
+
+    # A fully-solid default makes every in-bounds cell a wall unless an explicit cell overrides
+    # it to walkable below. (Default is walkable=True for every authored generator, so this
+    # branch is inert in practice — empty == today — but it keeps the derivation total.)
+    default_walkable = True
+    cd = getattr(grid, "cell_default", None)
+    if cd is not None:
+        default_walkable = bool(getattr(cd, "walkable", True))
+    if not default_walkable:
+        for x in range(width):
+            for y in range(height):
+                blocked.add((x, y))
+
+    # Explicit cells: a walkable cell CLEARS the default-solid fill; a non-walkable cell BLOCKS.
+    for sc in getattr(grid, "cells", None) or []:
+        cell = (int(sc.c), int(sc.r))
+        if not (0 <= cell[0] < width and 0 <= cell[1] < height):
+            continue
+        if getattr(sc, "walkable", True):
+            blocked.discard(cell)
+        else:
+            blocked.add(cell)
+
+    # Prop footprints: every cell a prop sits on is solid (occluder or not). Props already emit
+    # walkable=False cells, but honor the footprint directly in case a cell was elided.
+    for prop in getattr(grid, "props", None) or []:
+        for (c, r) in getattr(prop, "cells", None) or []:
+            cell = (int(c), int(r))
+            if 0 <= cell[0] < width and 0 <= cell[1] < height:
+                blocked.add(cell)
+
+    # Never trap a combatant: a cell someone already stands on is walkable for this fight.
+    blocked -= set(occupied)
+
+    return [[x, y] for (x, y) in sorted(blocked)]

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -3911,6 +3911,42 @@ def _gate_combat_verb(c: "Campaign", actor: "Character", *, verb: str, consumes:
         )
 
 
+def _derive_grid_from_scene(c: Campaign) -> None:
+    """gfx M-B (#1194): if the campaign's CURRENT location carries a SceneGrid, switch the
+    just-started fight onto that grid and auto-derive its impassable cells (walls + prop
+    footprints) — so movement routes around the painted geometry with no manual set_grid call.
+
+    SOLE-WRITER-safe: this IS the engine writing its own combat state from its own scene data.
+    ADDITIVE: a no-op when there's no current location or it has no scene_grid (grid_enabled
+    stays False → zone/theater combat unchanged, byte-for-byte). Mutates ``c.combat`` in place
+    via the SAME fields ``set_grid`` writes (grid_enabled / extents / grid_impassable); the caller
+    persists. It NEVER clobbers a grid the DM already set up — if the fight is already grid-enabled
+    (an explicit set_grid ran first), we leave it alone."""
+    if c.combat.grid_enabled:
+        return  # the DM/engine already configured this fight's grid — don't override it
+    loc = c.locations.get(c.current_location_id) if c.current_location_id else None
+    grid = getattr(loc, "scene_grid", None) if loc is not None else None
+    if grid is None:
+        return  # no painted room → today's zone/theater combat, unchanged
+    width = int(grid.grid.cols)
+    height = int(grid.grid.rows)
+    if width <= 0 or height <= 0:
+        return
+    # Exclude any cell a combatant already stands on (defensive: combatants are unplaced at
+    # start_combat, but a fixture may carry x/y) so a placement is never trapped on a prop.
+    occupied = {
+        (cb.x, cb.y)
+        for cb in c.combat.order
+        if getattr(cb, "x", None) is not None and getattr(cb, "y", None) is not None
+    }
+    imp = scene_grid_mod.impassable_cells(grid, width, height, occupied=occupied)
+    c.combat.grid_enabled = True
+    c.combat.grid_width = width
+    c.combat.grid_height = height
+    c.combat.grid_cell_size = int(grid.grid.cell_size_ft) or 5
+    c.combat.grid_impassable = imp
+
+
 @mcp.tool()
 def start_combat(
     campaign_id: str,
@@ -3953,6 +3989,14 @@ def start_combat(
             ch = c.characters.get(cid)
             if ch is not None and getattr(ch, "kind", "") == "monster":
                 _bump_intel(c, getattr(ch, "creature_slug", ""), 2)
+        # gfx M-B (#1194): a fight bound to a painted room AUTO-derives its combat obstacles
+        # from the location's SceneGrid (walls + prop footprints), so movement routes around
+        # the painted geometry without anyone hand-calling set_grid(obstacles=...). Reuses the
+        # EXISTING grid plumbing internally (flips grid_enabled + sets extents + grid_impassable,
+        # exactly what set_grid does) — NO new tool/param on the public surface. Purely additive:
+        # absent when the current location has no scene_grid (grid_enabled stays False == today's
+        # zone/theater combat, byte-for-byte unchanged).
+        _derive_grid_from_scene(c)
         save_campaign(c)
         view = _combat_view(c)
         # Surface the surprise edge in the runtime view so the DM resolves the opener

--- a/servers/engine/tests/test_combat_scene_obstacles.py
+++ b/servers/engine/tests/test_combat_scene_obstacles.py
@@ -1,0 +1,198 @@
+"""gfx M-B (#1194): a fight bound to a painted room AUTO-derives its combat obstacles from
+the location's SceneGrid (walls + prop footprints), so movement routes around the painted
+geometry without anyone hand-calling set_grid(obstacles=...).
+
+ADDITIVE: a fight with no scene_grid keeps zone/theater combat byte-for-byte (grid_enabled
+stays False == today) — pinned by test_no_scene_grid_combat_unchanged. Reuses the P1 patterns
+in test_grid_walkability_p1.py (route-around-wall, reject-onto-wall).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import server  # imported FIRST: resolves the models<->scene_grid import cycle in the right order
+import combat_grid
+import scene_grid as scene_grid_mod
+from scene_grid import (
+    SceneGrid,
+    SceneGridSpec,
+    SceneCell,
+    SceneCellDefault,
+    SceneProp,
+)
+
+
+# ── pure derivation: impassable_cells(scene_grid, w, h) ───────────────────────────────
+
+
+def _grid_with_wall_column() -> SceneGrid:
+    """A 4x3 scene with a solid wall down the middle column x=1 (rows 0..2) and a 1-cell
+    prop at (3, 0). Cols->x, rows->y. The wall splits left (x=0) from right (x>=2)."""
+    cells = [SceneCell(c=1, r=r, type="wall", walkable=False) for r in range(3)]
+    props = [SceneProp(id="crate", kind="crates", cells=[(3, 0)], anchor_cell=(3, 0))]
+    # prop footprint cells are also emitted as non-walkable cells (mirrors the generators)
+    cells.append(SceneCell(c=3, r=0, type="prop", walkable=False, prop_ref="crate"))
+    return SceneGrid(
+        scene_id="w:loc", location_id="loc", kind="dungeon",
+        grid=SceneGridSpec(cols=4, rows=3, cell_size_ft=5),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=cells, props=props,
+    )
+
+
+def test_impassable_cells_collects_walls_and_props():
+    g = _grid_with_wall_column()
+    imp = scene_grid_mod.impassable_cells(g, 4, 3)
+    # the full x=1 column + the (3,0) prop cell, [x, y] pairs, sorted
+    assert imp == [[1, 0], [1, 1], [1, 2], [3, 0]]
+
+
+def test_impassable_cells_clips_to_grid_bounds():
+    # a scene bigger than the combat grid: cells outside [0,w)x[0,h) are dropped
+    g = _grid_with_wall_column()  # has a cell at (3,0) and wall col x=1
+    imp = scene_grid_mod.impassable_cells(g, 2, 2)  # only x<2, y<2 survive
+    assert imp == [[1, 0], [1, 1]]  # (1,2) out of y-bounds, (3,0) out of x-bounds
+
+
+def test_impassable_cells_excludes_occupied_so_nobody_is_trapped():
+    g = _grid_with_wall_column()
+    # a combatant standing on the prop cell (3,0) must NOT be walled in
+    imp = scene_grid_mod.impassable_cells(g, 4, 3, occupied={(3, 0)})
+    assert [3, 0] not in imp
+    assert [1, 0] in imp  # the wall column is still impassable
+
+
+def test_impassable_cells_empty_when_all_walkable():
+    # an all-floor scene (no walls/props) -> no obstacles (empty == open floor == today)
+    g = SceneGrid(
+        scene_id="w:open", location_id="open",
+        grid=SceneGridSpec(cols=5, rows=5),
+        cell_default=SceneCellDefault(walkable=True),
+        cells=[], props=[],
+    )
+    assert scene_grid_mod.impassable_cells(g, 5, 5) == []
+
+
+# ── integration: start_combat on a painted room auto-populates grid_impassable ────────
+
+
+def _hand_room() -> SceneGrid:
+    """A deterministic 5x5 room with a 3-tall solid wall column at x=2 (rows 1,2,3) that
+    SPLITS the room left/right — a barrier that genuinely lengthens a left->right path (you
+    must go up and over the top of the wall at y=0). Floor everywhere else. This isolates the
+    route-around proof from procedural-room layout variance."""
+    cells = [SceneCell(c=2, r=r, type="wall", walkable=False) for r in (1, 2, 3)]
+    return SceneGrid(
+        scene_id="w:hand", location_id="hand", kind="dungeon",
+        grid=SceneGridSpec(cols=5, rows=5, cell_size_ft=5),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=cells, props=[],
+    )
+
+
+@pytest.fixture
+def fight_in_room(tmp_path, monkeypatch):
+    """A campaign whose CURRENT location carries a deterministic SceneGrid (the _hand_room
+    wall-split), with a Hero + a Goblin in a started fight. start_combat should have
+    auto-derived the grid + obstacles from the painted walls."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("M-B painted room")["id"]
+    # add_location makes the first location current AND emits a procedural scene_grid; we
+    # OVERWRITE it with the deterministic hand-room so the wall geometry is known + stable.
+    loc_id = server.add_location(cid, "The Split Chamber")["id"]
+    c = server._require(cid)
+    c.locations[loc_id].scene_grid = _hand_room()
+    server.save_campaign(c)
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30, armor_class=14)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=15, armor_class=12)["id"]
+    server.start_combat(cid, [hero, gob])
+    return cid, hero, gob
+
+
+# The wall column the _hand_room paints (x=2, rows 1..3).
+HAND_WALL = {(2, 1), (2, 2), (2, 3)}
+
+
+def test_start_combat_auto_enables_grid_from_scene(fight_in_room):
+    cid, _hero, _gob = fight_in_room
+    c = server._require(cid)
+    loc = c.locations[c.current_location_id]
+    assert loc.scene_grid is not None
+    # the fight was switched ONTO the grid automatically (no manual set_grid)
+    assert c.combat.grid_enabled is True
+    assert c.combat.grid_width == 5 and c.combat.grid_height == 5
+    # obstacles were derived from the room's walls — exactly the painted wall column
+    derived = {(x, y) for x, y in c.combat.grid_impassable}
+    assert derived == HAND_WALL
+    # every derived obstacle is in-bounds and matches a non-walkable scene cell
+    solid = {(sc.c, sc.r) for sc in loc.scene_grid.cells if not sc.walkable}
+    for x, y in derived:
+        assert 0 <= x < c.combat.grid_width and 0 <= y < c.combat.grid_height
+        assert (x, y) in solid
+
+
+def test_move_routes_around_a_painted_wall(fight_in_room):
+    """The load-bearing proof: a move from the LEFT of the wall column to the RIGHT routes
+    AROUND it (over the top at y=0), costs MORE than the straight-line Chebyshev (which would
+    cut through the wall), and never steps onto an impassable cell."""
+    cid, hero, gob = fight_in_room
+    c = server._require(cid)
+    start, goal = (1, 2), (3, 2)  # straight across is blocked by the wall at (2,2)
+    server.place_combatant_at_coords(cid, hero, *start)
+    server.place_combatant_at_coords(cid, gob, 4, 4)  # parked far away
+    res = server.move_to_coords(cid, hero, *goal)
+
+    path = res.get("path") or []
+    assert path, "expected a routed path around the wall"
+    assert all(tuple(s) not in HAND_WALL for s in path)  # never steps onto a wall
+    assert res["to"] == [3, 2]                            # reached the far side
+    # straight Chebyshev (1,2)->(3,2) is 2 cells (would cut through the wall); the routed
+    # detour over the top costs strictly MORE — proves it walked around the painted geometry.
+    assert res["cost_cells"] > combat_grid.chebyshev_cells(start, goal)
+
+
+def test_move_onto_a_painted_wall_is_rejected(fight_in_room):
+    cid, hero, gob = fight_in_room
+    server.place_combatant_at_coords(cid, hero, 1, 2)   # free, just left of the wall
+    server.place_combatant_at_coords(cid, gob, 4, 4)
+    res = server.move_to_coords(cid, hero, 2, 2)        # straight onto the wall cell
+    assert res.get("move_blocked")        # rejected, not landed
+    assert res["to"] == [1, 2]            # stayed put
+
+
+# ── ADDITIVITY: a fight with NO scene_grid is byte-for-byte unchanged ─────────────────
+
+
+def test_no_scene_grid_combat_unchanged(tmp_path, monkeypatch):
+    """A campaign whose current location has NO scene_grid (or no location at all) keeps
+    zone/theater combat: grid_enabled stays False, grid_impassable empty == today."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("M-B no room")["id"]
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30, armor_class=14)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=15, armor_class=12)["id"]
+    server.start_combat(cid, [hero, gob])  # no current location -> no scene_grid
+    c = server._require(cid)
+    assert c.combat.grid_enabled is False
+    assert c.combat.grid_impassable == []
+
+
+def test_explicit_set_grid_is_not_overridden(tmp_path, monkeypatch):
+    """If the DM/engine already called set_grid (grid_enabled True) before start_combat would
+    derive, the explicit grid wins — auto-derivation never clobbers a configured fight."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("M-B explicit grid")["id"]
+    server.add_location(cid, "The Elfsong Tavern")
+    hero = server.create_character(cid, "Hero", kind="player", max_hp=30, armor_class=14)["id"]
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=15, armor_class=12)["id"]
+    server.start_combat(cid, [hero, gob])
+    # start_combat already derived from the scene; now prove the guard by simulating the
+    # reverse order via a fresh fight: end, set_grid first, then a re-derive call is a no-op.
+    server.end_combat(cid)
+    server.start_combat(cid, [hero, gob])
+    c = server._require(cid)
+    c.combat.grid_enabled = True
+    c.combat.grid_impassable = [[9, 9]]  # a hand-set obstacle
+    scene_grid_mod_obstacles_before = list(c.combat.grid_impassable)
+    server._derive_grid_from_scene(c)  # must be a no-op (already enabled)
+    assert c.combat.grid_impassable == scene_grid_mod_obstacles_before


### PR DESCRIPTION
## What

Closes the gfx M-B gap (#1194): **rooms now have pathing**. Today the combat grid does not read `scene_grid`, so "rooms have pathing" is false — a combatant can path straight through a painted wall. This wires the room's painted walls/props into combat pathing so movement turns route around them, **automatically**, with no manual `set_grid(obstacles=...)` call.

## How (additive, reuses the P1 plumbing)

At combat start, if the campaign's **current location** carries a `SceneGrid`, the engine switches the fight onto that grid and derives the impassable set from the scene's painted geometry. Movement then routes around it via the existing P1 `combat_grid.shortest_path` machinery (PR #1174) — `move_to_coords` already routes around `Combat.grid_impassable` and rejects ending on it.

- **`servers/engine/scene_grid.py`** — new pure helper `impassable_cells(grid, width, height, *, occupied=...)`: returns `[[x,y], ...]` (the exact `grid_impassable` shape) for every cell that is a wall (`walkable=False`, incl. a solid `cell_default`) ∪ every prop footprint cell, **clipped to grid bounds**, **minus** any cell a combatant already stands on (so nobody is trapped). No I/O, deterministic order.
- **`servers/engine/server.py`** — new private helper `_derive_grid_from_scene(c)`, called inside **`start_combat`** right after the `Combat` is built. It populates `grid_enabled` / `grid_width` / `grid_height` / `grid_cell_size` / `grid_impassable` via the **same fields `set_grid` writes** — internally, so there is **NO new tool or tool-parameter on the public surface** (tool-schema budget untouched).

## Coordinate mapping (the care-point)

A `SceneGrid` cell is `(c, r)` = (col, row), cols along +x / rows along +y (per the `_gen_*` generators). The combat grid is `(x, y)` with `grid_width == cols`, `grid_height == rows`. The mapping is the **identity** `c→x, r→y` — both 0-indexed, both default 5ft cells. Every derived cell is still clipped to `0 <= x < width`, `0 <= y < height`.

## Invariants honored

- **Engine = sole writer** — this is the engine writing its own combat state from its own scene data.
- **Additive / empty == today** — a fight with no current location or no `scene_grid` leaves `grid_enabled` False → zone/theater combat is byte-for-byte unchanged (pinned by `test_no_scene_grid_combat_unchanged`). Old snapshots round-trip.
- **Never clobbers a configured fight** — if `grid_enabled` is already True (the DM/engine called `set_grid` first), `_derive_grid_from_scene` is a no-op (`test_explicit_set_grid_is_not_overridden`).
- `_StrictModel` `extra="forbid"` untouched; no new fields.

## Tests — `servers/engine/tests/test_combat_scene_obstacles.py` (9, reuses the P1 patterns)

- `test_impassable_cells_*` — pure derivation: collects walls + prop footprints, clips to bounds, excludes occupied cells, empty when all-walkable.
- **`test_move_routes_around_a_painted_wall`** — the load-bearing proof: a fight auto-seeded on a room with a 3-tall wall column at x=2; a move from `(1,2)` to `(3,2)` (straight line blocked) **routes around** (cost > straight Chebyshev), the path never steps on a wall, and it reaches the far side.
- `test_move_onto_a_painted_wall_is_rejected` — a straight move onto a wall cell is rejected; combatant stays put.
- `test_start_combat_auto_enables_grid_from_scene` — `grid_enabled` flips, extents match the scene, `grid_impassable == the painted wall column`.
- `test_no_scene_grid_combat_unchanged` / `test_explicit_set_grid_is_not_overridden` — additivity + no-clobber.

```
tests/test_combat_scene_obstacles.py ......... 9 passed
grid + scene + combat suites ............... 75 + 329 passed
qa/fast_gate.sh (Tier 0) ................... 241 passed ✅
```

Refs #1194.