### PR TITLE
gfx M-A: repeatable painterly-backdrop workflow (generate_room.py) + firelit crypt @ 7.4

### DIFF
--- a/extensions/renderers/godot/tools/generate_room.py
+++ b/extensions/renderers/godot/tools/generate_room.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""generate_room.py — the REPEATABLE painterly-backdrop workflow (gfx M-A).
+
+ONE command turns a camera-pinned base/greybox plate into a firelit PoE2-caliber
+painterly room plate, via Scenario img2img on model_z-image + our painterly LoRA.
+The recipe (model, LoRA, strength, steps, guidance, per-room prompts) lives in the
+committed manifest `extensions/renderers/shared/room_recipes.json` so any room is
+regeneratable on demand and the workflow is auditable.
+
+  # relight the crypt base plate (4 variants) into firelit chiaroscuro:
+  python3 generate_room.py --room crypt \
+      --base-plate ~/worldos-session-notes/scenario-assets/crypt_plate_v2_s50.png \
+      --out ~/worldos-session-notes/scenario-assets/crypt_gen
+
+  # refine an already-generated Scenario asset (low strength, protect composition):
+  python3 generate_room.py --room crypt --refine-from asset_XXXX --strength 0.30 --out <dir>
+
+  # inspect the resolved request without spending credits:
+  python3 generate_room.py --room crypt --base-plate <png> --dry-run
+
+Design notes:
+- The lever from L6 6.5 -> 8 is LIGHTING DRAMA (single warm key, deep blue-violet
+  shadows, hard cast shadows), NOT more texture. Keep `strength` low (~0.30-0.45) so
+  the camera-pinned composition (the contract camera's dimetric layout) does NOT drift.
+- Reuses scenario_gen.py's proven helpers (auth/upload/poll/download) — same account,
+  same endpoints. img2img rides the txt2img endpoint with an `image` + `strength` body.
+- Engine = sole writer; this is a generation/view-layer tool only. It never writes
+  engine state; it produces a PNG the renderer/registry later consume by slot.
+"""
+import argparse
+import json
+import os
+import sys
+
+# Reuse the proven Scenario plumbing (auth, upload, post, poll, download, meta).
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+from scenario_gen import (  # noqa: E402
+    API_BASE,
+    CONTROLNET_PATH,
+    _load_credentials,
+    _auth_headers,
+    _post_json,
+    _job_id_from_create,
+    _poll_job,
+    _download_job_assets,
+    _upload_image,
+    _write_meta,
+)
+
+RECIPE_PATH = os.path.normpath(
+    os.path.join(_HERE, "..", "..", "shared", "room_recipes.json")
+)
+
+
+def _load_recipe() -> dict:
+    if not os.path.isfile(RECIPE_PATH):
+        sys.exit("[generate_room] ERROR: recipe manifest not found: %s" % RECIPE_PATH)
+    with open(RECIPE_PATH, "r") as f:
+        return json.load(f)
+
+
+def _build_prompt(recipe: dict, room: str) -> tuple:
+    rooms = recipe.get("rooms", {})
+    if room not in rooms:
+        sys.exit(
+            "[generate_room] ERROR: unknown room '%s'. Known: %s"
+            % (room, ", ".join(sorted(rooms)))
+        )
+    rc = rooms[room]
+    positive = recipe["firelit_positive_template"].format(
+        room=room,
+        key_light=rc["key_light"],
+        shadow_casters=rc["shadow_casters"],
+        room_detail_tokens=rc["room_detail_tokens"],
+    )
+    return positive, recipe["washout_negative"]
+
+
+def main(argv=None) -> None:
+    recipe = _load_recipe()
+    d = recipe["defaults"]
+    ap = argparse.ArgumentParser(description="Repeatable painterly-backdrop workflow (gfx M-A)")
+    ap.add_argument("--room", required=True, help="room type key in room_recipes.json (crypt|tavern|church|...)")
+    ap.add_argument("--base-plate", default=None, help="local PNG path of the camera-pinned base/greybox plate to img2img from")
+    ap.add_argument("--refine-from", default=None, help="an existing Scenario asset_id to refine (skips upload)")
+    ap.add_argument("--out", default=None, help="output dir for the generated plates")
+    ap.add_argument("--strength", type=float, default=d["strength"], help="img2img denoise strength (low=protect composition)")
+    ap.add_argument("--steps", type=int, default=d["num_inference_steps"])
+    ap.add_argument("--guidance", type=float, default=d["guidance"])
+    ap.add_argument("--num-outputs", type=int, default=d["num_outputs"])
+    ap.add_argument("--width", type=int, default=d["width"])
+    ap.add_argument("--height", type=int, default=d["height"])
+    ap.add_argument("--seed", type=int, default=None)
+    ap.add_argument("--timeout", type=int, default=600)
+    ap.add_argument("--dry-run", action="store_true", help="print the resolved request without calling the API")
+    args = ap.parse_args(argv)
+
+    positive, negative = _build_prompt(recipe, args.room)
+    # Standalone base models (model_z-image) run img2img via POST /generate/custom/{modelId}
+    # with `image` + `strength` (the txt2img endpoint rejects standalone models). The base model
+    # is in the PATH; the painterly LoRA rides `loras`/`lorasScale` (string ids, per the proven job).
+    endpoint = API_BASE + CONTROLNET_PATH.format(model_id=recipe["base_model"])
+    body = {
+        "prompt": positive,
+        "negativePrompt": negative,
+        "image": None,  # filled below (asset id)
+        "strength": args.strength,
+        "numInferenceSteps": args.steps,
+        "guidance": args.guidance,
+        "numSamples": args.num_outputs,
+        "width": args.width,
+        "height": args.height,
+        "loras": [recipe["lora"]],
+        "lorasScale": [recipe["lora_scale"]],
+    }
+    if args.seed is not None:
+        body["seed"] = args.seed
+
+    if args.dry_run:
+        preview = dict(body)
+        preview["image"] = args.refine_from or ("<upload:%s>" % args.base_plate)
+        print("[generate_room] DRY-RUN img2img (%s)" % args.room)
+        print(json.dumps(preview, indent=2))
+        print("  endpoint  : %s" % endpoint)
+        print("  recipe    : %s" % RECIPE_PATH)
+        return
+
+    out_dir = args.out or os.path.join(os.getcwd(), "room_gen_%s" % args.room)
+    os.makedirs(out_dir, exist_ok=True)
+    key, secret = _load_credentials()
+    headers = _auth_headers(key, secret)
+
+    if args.refine_from:
+        image_ref = args.refine_from
+    elif args.base_plate:
+        image_ref = _upload_image(headers, os.path.expanduser(args.base_plate))
+    else:
+        sys.exit("[generate_room] ERROR: need --base-plate <png> or --refine-from <asset_id>.")
+    body["image"] = image_ref
+
+    res = _post_json(endpoint, headers, body)
+    job_id = _job_id_from_create(res, "img2img create")
+    print("[generate_room] %s img2img job submitted: %s (strength=%s)" % (args.room, job_id, args.strength))
+    job = _poll_job(headers, job_id, "img2img", args.timeout)
+    saved = _download_job_assets(headers, job, out_dir, "room_%s" % args.room)
+    _write_meta(out_dir, {
+        "room": args.room, "image_ref": image_ref, "strength": args.strength,
+        "steps": args.steps, "guidance": args.guidance, "num_outputs": args.num_outputs,
+        "model_id": recipe["base_model"], "lora": recipe["lora"], "lora_scale": recipe["lora_scale"],
+        "prompt": positive, "negative_prompt": negative, "job_id": job_id,
+        "assets": saved, "source": "generate_room-img2img",
+    })
+    print("[generate_room] OK — room=%s job=%s assets=%d -> %s" % (args.room, job_id, len(saved), out_dir))
+
+
+if __name__ == "__main__":
+    main()

--- a/extensions/renderers/godot/tools/generate_room.py
+++ b/extensions/renderers/godot/tools/generate_room.py
@@ -97,6 +97,12 @@ def main(argv=None) -> None:
     ap.add_argument("--dry-run", action="store_true", help="print the resolved request without calling the API")
     args = ap.parse_args(argv)
 
+    # Require EXACTLY ONE image source up front so an ambiguous/missing combo fails fast (incl. on --dry-run),
+    # not silently as "<upload:None>" or only at submit time.
+    src_count = (1 if args.base_plate else 0) + (1 if args.refine_from else 0)
+    if src_count != 1:
+        ap.error("provide EXACTLY ONE of --base-plate <png> or --refine-from <asset_id>")
+
     positive, negative = _build_prompt(recipe, args.room)
     # Standalone base models (model_z-image) run img2img via POST /generate/custom/{modelId}
     # with `image` + `strength` (the txt2img endpoint rejects standalone models). The base model

--- a/extensions/renderers/shared/room_recipes.json
+++ b/extensions/renderers/shared/room_recipes.json
@@ -1,0 +1,40 @@
+{
+  "_doc": "Committed recipe for the REPEATABLE painterly backdrop workflow (generate_room.py). The renderer/registry consume the GENERATED plate; this file is the source of truth for HOW a plate is generated, so any room is regeneratable on demand. Proven 2026-06-30: the crypt base plate (flat museum-lit, lighting 5/10, L6 6) re-lit via this img2img recipe into firelit chiaroscuro. Pipeline = Scenario img2img on model_z-image + our painterly LoRA. The lever from 6.5->8 is LIGHTING DRAMA, not more texture (drop ambient, single warm key, deep blue-violet shadows, hard cast shadows). Composition is camera-pinned and must NOT drift: strength stays low (~0.45) so the dimetric layout (pillars/sarcophagus/brazier/walls) holds while diffusion re-lights.",
+  "pipeline": "scenario-img2img",
+  "base_model": "model_z-image",
+  "lora": "model_MB22WaRCBLtfhi5R2CRpHoEL",
+  "lora_scale": 0.78,
+  "defaults": {
+    "strength": 0.45,
+    "num_inference_steps": 40,
+    "guidance": 7.5,
+    "num_outputs": 4,
+    "width": 1344,
+    "height": 768
+  },
+  "firelit_positive_template": "painterly isometric dimetric {room} interior background plate, Pillars of Eternity II Deadfire pre-rendered background quality, SINGLE warm {key_light} as the sole dramatic key light, dramatic chiaroscuro, steep warm-to-cool value falloff from a hot amber lit pool to near-black corners, deep blue-violet shadow pockets in the far corners and along the back and side walls, hard directional cast shadows thrown from {shadow_casters} across the floor, warm amber rim on edges facing the flame, cool blue bounce on shadow-side stone, low-key moody candlelit interior, {room_detail_tokens}, tactile hand-painted texture, rich oil-painted detail, atmospheric depth, fixed camera composition, cinematic torchlit interior",
+  "washout_negative": "flat even ambient light, overcast lighting, museum lighting, uniform gray floor, washed out, blown highlights, clipped white hotspot, pure white, overexposed, low contrast, hazy, milky, foggy bloom, pale watercolor wash, mushy smeared detail, neutral gray shadows, desaturated shadows, evenly lit, no shadows, flat shading, soft diffuse fill light, second light source, multiple key lights, daylight, characters, people, figures, text, watermark, blurry, low detail",
+  "rooms": {
+    "crypt": {
+      "key_light": "brazier firelight",
+      "shadow_casters": "the pillars, the sarcophagus, and the brazier legs",
+      "room_detail_tokens": "crisp painterly flagstone mortar lines, weathered cracked stone relief, grime moss and water-staining in the cracks, fluted pillar detail, carved sarcophagus relief",
+      "base_plate": "crypt_plate_v2_s50.png",
+      "status": "PROVEN 2026-06-30 (relit_v3)"
+    },
+    "tavern": {
+      "key_light": "hearth fire and hanging iron lanterns",
+      "shadow_casters": "the timber posts, the bar counter, and the tables",
+      "room_detail_tokens": "worn wooden plank floor, heavy timber roof beams, ale barrels and tankards, a stone hearth with glowing embers, candlelit tables, hanging dried herbs",
+      "base_plate": null,
+      "status": "TODO — needs a camera-pinned greybox/base plate (Unity render or txt2img at contract aspect)"
+    },
+    "church": {
+      "key_light": "altar candles and a shaft of stained-glass light",
+      "shadow_casters": "the carved columns, the altar, and the pews",
+      "room_detail_tokens": "stone nave flagstones, fluted carved columns, a stone altar, worn wooden pews, gothic pointed arches, dust motes suspended in the light shaft",
+      "base_plate": null,
+      "status": "TODO — needs a camera-pinned greybox/base plate"
+    }
+  }
+}

--- a/extensions/renderers/shared/room_recipes.json
+++ b/extensions/renderers/shared/room_recipes.json
@@ -12,7 +12,9 @@
     "width": 1344,
     "height": 768
   },
-  "firelit_positive_template": "painterly isometric dimetric {room} interior background plate, Pillars of Eternity II Deadfire pre-rendered background quality, SINGLE warm {key_light} as the sole dramatic key light, dramatic chiaroscuro, steep warm-to-cool value falloff from a hot amber lit pool to near-black corners, deep blue-violet shadow pockets in the far corners and along the back and side walls, hard directional cast shadows thrown from {shadow_casters} across the floor, warm amber rim on edges facing the flame, cool blue bounce on shadow-side stone, low-key moody candlelit interior, {room_detail_tokens}, tactile hand-painted texture, rich oil-painted detail, atmospheric depth, fixed camera composition, cinematic torchlit interior",
+  "firelit_positive_template": "painterly isometric dimetric {room} interior background plate, Pillars of Eternity II Deadfire pre-rendered background quality, SINGLE warm {key_light} as the sole dramatic key light, dramatic chiaroscuro tenebrism, steep warm-to-cool value falloff from a hot amber lit pool to near-black corners, DEEP saturated blue-violet shadows (not neutral grey) in the far corners and along the back and side walls, HARD-EDGED directional cast shadows thrown from {shadow_casters} across the floor, strong warm-key-to-cool-shadow contrast, warm amber rim on edges facing the flame, cool blue-violet bounce on shadow-side stone, low-key moody candlelit interior, {room_detail_tokens}, tactile hand-painted texture, rich oil-painted detail, atmospheric depth, fixed camera composition, cinematic torchlit interior",
+  "multipass_note": "Best result = base plate -> pass1 relight (strength 0.45) -> pass2 deep-shadow refine (strength 0.30, same prompt). Each pass low-strength to protect the camera-pinned composition (L1). generate_room.py --refine-from <asset_id> chains a pass.",
+  "ceiling_2026_06_30": "This pipeline tops out ~7.4/10 backdrop (crypt: lighting/registration/detail/washout all solved, L1=8). The L6>=8 BINDING gate is NOT cleared: PoE2-grade CARVED-STONE micro-craft (fluted pillars, chiseled relief, masonry coursing, sculpted sarcophagus) is beyond what this painterly LoRA + img2img renders from a SMOOTH-PRIMITIVE greybox. THE LEVER TO >=8: a greybox with carved geometry (so img2img has carved structure to preserve), or a crisper architectural model/LoRA. Tracked as the M-A->>=8 follow-up; the 7.4 firelit plate is adopted for the demo (the plate is swappable later with zero renderer/actor rework).",
   "washout_negative": "flat even ambient light, overcast lighting, museum lighting, uniform gray floor, washed out, blown highlights, clipped white hotspot, pure white, overexposed, low contrast, hazy, milky, foggy bloom, pale watercolor wash, mushy smeared detail, neutral gray shadows, desaturated shadows, evenly lit, no shadows, flat shading, soft diffuse fill light, second light source, multiple key lights, daylight, characters, people, figures, text, watermark, blurry, low detail",
   "rooms": {
     "crypt": {
@@ -20,7 +22,9 @@
       "shadow_casters": "the pillars, the sarcophagus, and the brazier legs",
       "room_detail_tokens": "crisp painterly flagstone mortar lines, weathered cracked stone relief, grime moss and water-staining in the cracks, fluted pillar detail, carved sarcophagus relief",
       "base_plate": "crypt_plate_v2_s50.png",
-      "status": "PROVEN 2026-06-30 (relit_v3)"
+      "canonical_plate": "crypt_firelit_v2.png",
+      "backdrop_score": 7.4,
+      "status": "ADOPTED 2026-06-30 — firelit chiaroscuro at 7.4 (L1=8, detail=7, no washout); deployed to box as Assets/painterly/backdrops/crypt_firelit_v2.png. >=8 needs the carved-greybox lever (see ceiling_2026_06_30)."
     },
     "tavern": {
       "key_light": "hearth fire and hanging iron lanterns",


### PR DESCRIPTION
Closes part of #1193 (gfx M-A).

## What
A **repeatable, one-command** painterly-backdrop workflow so any room is regeneratable on demand — the foundation piece of the PoE2 graphics engine.

- **`extensions/renderers/godot/tools/generate_room.py`** — `generate_room.py --room crypt --base-plate <png>` → firelit PoE2-style plate via Scenario img2img (model_z-image + painterly LoRA), reusing scenario_gen's proven auth/upload/poll/download. Standalone base models run img2img on `POST /generate/custom/{modelId}` with `image`+`strength` (txt2img rejects them). `--refine-from <asset_id>` chains a low-strength refine pass. Proven end-to-end.
- **`extensions/renderers/shared/room_recipes.json`** — committed recipe manifest (model/LoRA/strength/steps/guidance + per-room firelit prompts for crypt/tavern/church). Source of truth for HOW a plate is generated.

## Backdrop loop result (auto-scored via the visual-critic)
baseline **6.0** → relit **7.4** (lighting drama, washout, registration L1=8, detail=7 all solved). 

**Honest residual:** the pipeline **ceilings ~7.4** — PoE2-grade carved-stone micro-craft (fluted pillars, chiseled relief, masonry coursing) is beyond what the painterly LoRA renders from a *smooth-primitive* greybox. The lever to L6≥8 is a **greybox with carved geometry** (documented in the manifest `ceiling_2026_06_30`). The 7.4 firelit crypt (`crypt_firelit_v2.png`) is adopted for the demo — the plate is swappable later with zero renderer/actor rework (the modular-defaults invariant).

## Invariants
Generation/view-layer only; no engine state writes. Additive (two new files).