### PR TITLE
gfx M-C: asset registry — slot resolves to a default template on miss (modular-defaults invariant)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,10 @@ venv/
 .coverage.*
 servers/*/.coverage
 .qa-archive/
+
+# Asset registry (gfx M-C, #1195): ONLY the manifest (registry.json) is committed.
+# Any co-located binary assets (.fbx/.glb/.png/.wav/...) are regenerable via the
+# gen_recipe rows and live on the Unity box's Assets/ tree, never in git.
+/data/asset-registry/**
+!/data/asset-registry/
+!/data/asset-registry/registry.json

--- a/data/asset-registry/registry.json
+++ b/data/asset-registry/registry.json
@@ -1,0 +1,109 @@
+{
+  "_doc": "WorldOS asset registry (gfx milestone M-C, issue #1195). The renderer NEVER names a literal asset path; it names a SLOT (asset_id + kind) and asks the registry, which ALWAYS returns a guaranteed-non-null ref dict — the real asset OR a default template. This is the asset analogue of engine=sole-writer: swapping/regenerating ANY asset is ZERO renderer edits. Resolution rule: exact -> alias -> defaults[kind] -> defaults['__any__']. The Python twin is viewer/asset_registry.py; the Unity twin is extensions/renderers/unity/scripts/AssetRegistry.cs. Binary assets (.fbx/.png/...) referenced here are gitignored under the box's Unity Assets/ tree; only this manifest is committed. kind in {character, monster, room, effect, sound}.",
+  "version": 1,
+  "schema": {
+    "asset_row": ["kind", "model_ref", "albedo_ref", "anim_ref", "gen_recipe", "version", "critic_score", "default_used"]
+  },
+  "defaults": {
+    "character": "template_human",
+    "monster": "template_demon",
+    "room": "template_room_crypt",
+    "effect": "fx_default_slash",
+    "sound": "snd_default_hit",
+    "__any__": "template_human"
+  },
+  "aliases": {
+    "hero": "fighter",
+    "pc": "fighter",
+    "wizard": "mage",
+    "goblin_grunt": "goblin"
+  },
+  "assets": {
+    "fighter": {
+      "kind": "character",
+      "model_ref": "Assets/painterly/models/hero.fbx",
+      "albedo_ref": "Assets/painterly/models/hero_albedo.png",
+      "anim_ref": "Assets/painterly/models/hero@moveset.fbx",
+      "gen_recipe": "meshy:humanoid moveset (9-clip) + scenario painterly albedo",
+      "version": "1.0.0",
+      "critic_score": 7.4,
+      "default_used": false
+    },
+    "mage": {
+      "kind": "character",
+      "model_ref": "Assets/painterly/models/hero.fbx",
+      "albedo_ref": "Assets/painterly/models/hero_albedo.png",
+      "anim_ref": "Assets/painterly/models/hero@moveset.fbx",
+      "gen_recipe": "meshy:humanoid moveset (9-clip) + scenario painterly albedo (mage robe tint pending)",
+      "version": "0.9.0",
+      "critic_score": 7.0,
+      "default_used": false
+    },
+    "goblin": {
+      "kind": "monster",
+      "model_ref": "Assets/chars_v2/goblin/goblin.fbx",
+      "albedo_ref": "Assets/chars_v2/goblin/albedo.png",
+      "anim_ref": "Assets/chars_v2/goblin/goblin@moveset.fbx",
+      "gen_recipe": "meshy:humanoid moveset (9-clip) + baked albedo",
+      "version": "1.0.0",
+      "critic_score": 7.1,
+      "default_used": false
+    },
+
+    "template_human": {
+      "kind": "character",
+      "model_ref": "Assets/painterly/models/hero.fbx",
+      "albedo_ref": "Assets/painterly/models/hero_albedo.png",
+      "anim_ref": "Assets/painterly/models/hero@moveset.fbx",
+      "gen_recipe": "DEFAULT TEMPLATE: any character without a model resolves here.",
+      "version": "1.0.0",
+      "critic_score": 7.4,
+      "default_used": false,
+      "is_template": true
+    },
+    "template_demon": {
+      "kind": "monster",
+      "model_ref": "Assets/chars_v2/goblin/goblin.fbx",
+      "albedo_ref": "Assets/chars_v2/goblin/albedo.png",
+      "anim_ref": "Assets/chars_v2/goblin/goblin@moveset.fbx",
+      "gen_recipe": "DEFAULT TEMPLATE: any monster without a model resolves here (demon template; goblin mesh stands in until a dedicated demon model is generated).",
+      "version": "1.0.0",
+      "critic_score": 7.1,
+      "default_used": false,
+      "is_template": true
+    },
+    "template_room_crypt": {
+      "kind": "room",
+      "model_ref": "Assets/painterly/backdrops/crypt_pinned_v1.png",
+      "albedo_ref": "Assets/painterly/backdrops/crypt_pinned_v1.png",
+      "anim_ref": null,
+      "gen_recipe": "DEFAULT TEMPLATE: any room without a backdrop resolves here (crypt_firelit recipe, critic 7.4).",
+      "version": "2.0.0",
+      "critic_score": 7.4,
+      "default_used": false,
+      "is_template": true
+    },
+    "fx_default_slash": {
+      "kind": "effect",
+      "model_ref": "Assets/painterly/vfx/vfx_slash.png",
+      "albedo_ref": "Assets/painterly/vfx/vfx_slash.png",
+      "anim_ref": null,
+      "gen_recipe": "DEFAULT TEMPLATE: any effect without an asset resolves here (generic slash impact).",
+      "version": "1.0.0",
+      "critic_score": 6.5,
+      "default_used": false,
+      "is_template": true
+    },
+    "snd_default_hit": {
+      "kind": "sound",
+      "model_ref": null,
+      "albedo_ref": null,
+      "anim_ref": "Assets/audio/sfx/hit_default.wav",
+      "gen_recipe": "DEFAULT TEMPLATE: any sound without an asset resolves here (generic hit).",
+      "version": "1.0.0",
+      "critic_score": 6.0,
+      "default_used": false,
+      "is_template": true
+    }
+  }
+}

--- a/extensions/renderers/unity/scripts/AssetRegistry.cs
+++ b/extensions/renderers/unity/scripts/AssetRegistry.cs
@@ -1,0 +1,222 @@
+// AssetRegistry.cs — Unity twin of viewer/asset_registry.py (gfx M-C, issue #1195).
+//
+// The renderer NEVER names a literal asset path. It names a SLOT (an assetId
+// plus a kind) and asks this registry, which ALWAYS returns a guaranteed
+// non-null ref (the real asset OR a default template). This is the asset
+// analogue of engine=SOLE-WRITER: swapping/regenerating ANY asset is ZERO
+// renderer edits, because the renderer only ever knows slots.
+//
+// Resolution rule (FIRST hit wins; IDENTICAL to the Python twin):
+//     exact -> alias -> defaults[kind] -> defaults["__any__"]   (the "floor")
+//
+// Guarantees: Resolve() ALWAYS returns a non-null Ref (with defaultUsed and
+// resolvedVia set) and NEVER throws (a missing/corrupt registry degrades to an
+// in-code hardcoded floor template). VIEW LAYER only — reads, never writes.
+//
+// JSON parsing: uses the repo's existing MiniJson.cs (extensions/renderers/
+// unity/scripts/MiniJson.cs — Parse-only, object -> Dictionary<string,object>).
+// No new dependency needed; JsonUtility was NOT used because the registry is a
+// map-of-maps (arbitrary asset_id keys) which JsonUtility cannot model.
+//
+// -------------------------------------------------------------------------
+// INTENDED CALL SITE (DO NOT WIRE YET — paint_combat_v1.cs lives on the
+// unmerged branch feat/combat-animator-prep, PR #1180). After #1180 merges,
+// the renderer's spawn() should resolve by SLOT instead of a literal load:
+//
+//     // BEFORE (literal path — the anti-pattern this registry removes):
+//     // var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(
+//     //     "Assets/painterly/models/hero.fbx");
+//
+//     // AFTER (slot -> registry -> guaranteed non-null ref):
+//     AssetRegistry.Ref a = AssetRegistry.Resolve(actor.assetId, actor.kind);
+//     var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(a.modelRef);
+//     // a.defaultUsed / a.resolvedVia let the renderer log/telemeter misses
+//     // (e.g. badge a placeholder) without ever crashing on a missing asset.
+//
+// Regenerating or swapping hero.fbx => edit registry.json ONLY; spawn() unchanged.
+// -------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+public static class AssetRegistry
+{
+    /// <summary>Resolved asset ref. modelRef/albedoRef/animRef may individually
+    /// be null for kinds that don't use them, but the Ref itself is never null.</summary>
+    public class Ref
+    {
+        public string assetId;
+        public string kind;
+        public string modelRef;
+        public string albedoRef;
+        public string animRef;
+        public string genRecipe;
+        public string version;
+        public bool defaultUsed;
+        public string resolvedVia; // "exact" | "alias" | "default:<kind>" | "floor"
+    }
+
+    // Cached parsed registry (loaded lazily, once).
+    static bool _loaded;
+    static readonly object _lock = new object();
+    static Dictionary<string, object> _assets = new Dictionary<string, object>();
+    static Dictionary<string, object> _defaults = new Dictionary<string, object>();
+    static Dictionary<string, object> _aliases = new Dictionary<string, object>();
+
+    // In-code hardcoded floor — used ONLY if registry.json is missing/corrupt
+    // and no usable default exists. Keeps the never-null / never-throw contract.
+    static Ref HardcodedFloor(string kind)
+    {
+        return new Ref
+        {
+            assetId = "__floor__",
+            kind = string.IsNullOrEmpty(kind) ? "character" : kind,
+            modelRef = "Assets/painterly/models/hero.fbx",
+            albedoRef = "Assets/painterly/models/hero_albedo.png",
+            animRef = "Assets/painterly/models/hero@moveset.fbx",
+            genRecipe = "in-code hardcoded floor (registry.json missing or unreadable)",
+            version = "0.0.0",
+            defaultUsed = true,
+            resolvedVia = "floor",
+        };
+    }
+
+    /// <summary>Locate data/asset-registry/registry.json. Honors the
+    /// WORLDOS_ASSET_REGISTRY env override, else walks up from the Unity project
+    /// dir (Application.dataPath's parent at runtime; here we walk from CWD).</summary>
+    static string FindRegistryPath()
+    {
+        string env = Environment.GetEnvironmentVariable("WORLDOS_ASSET_REGISTRY");
+        if (!string.IsNullOrEmpty(env) && File.Exists(env)) return env;
+
+        // Walk up from the current directory looking for the repo-root marker.
+        // (At Editor runtime the Unity project is a sibling of the WorldOS repo
+        // checkout; the env override is the robust path for the box.)
+        string cur = Directory.GetCurrentDirectory();
+        for (int i = 0; i < 10 && !string.IsNullOrEmpty(cur); i++)
+        {
+            string candidate = Path.Combine(cur, "data", "asset-registry", "registry.json");
+            if (File.Exists(candidate)) return candidate;
+            DirectoryInfo parent = Directory.GetParent(cur);
+            if (parent == null) break;
+            cur = parent.FullName;
+        }
+        return null;
+    }
+
+    static void EnsureLoaded()
+    {
+        if (_loaded) return;
+        lock (_lock)
+        {
+            if (_loaded) return;
+            try
+            {
+                string path = FindRegistryPath();
+                if (!string.IsNullOrEmpty(path))
+                {
+                    string text = File.ReadAllText(path);
+                    var root = MiniJson.Parse(text) as Dictionary<string, object>;
+                    if (root != null)
+                    {
+                        _assets = AsDict(root, "assets");
+                        _defaults = AsDict(root, "defaults");
+                        _aliases = AsDict(root, "aliases");
+                    }
+                }
+            }
+            catch
+            {
+                // Missing / unreadable / corrupt -> degrade to floor at resolve time.
+            }
+            _loaded = true;
+        }
+    }
+
+    /// <summary>Resolve a SLOT to a guaranteed-non-null Ref. NEVER throws.
+    /// Rule: exact -> alias -> defaults[kind] -> defaults["__any__"] -> floor.</summary>
+    public static Ref Resolve(string assetId, string kind)
+    {
+        try
+        {
+            EnsureLoaded();
+            string aid = (assetId ?? "").Trim();
+
+            // 1) exact
+            if (aid.Length > 0 && _assets.ContainsKey(aid))
+                return Row(aid, false, "exact");
+
+            // 2) alias -> asset_id
+            if (aid.Length > 0 && _aliases.ContainsKey(aid))
+            {
+                string target = AsString(_aliases[aid]);
+                if (!string.IsNullOrEmpty(target) && _assets.ContainsKey(target))
+                    return Row(target, true, "alias");
+            }
+
+            // 3) defaults[kind]
+            string k = (kind ?? "").Trim();
+            if (k.Length > 0 && _defaults.ContainsKey(k))
+            {
+                string target = AsString(_defaults[k]);
+                if (!string.IsNullOrEmpty(target) && _assets.ContainsKey(target))
+                    return Row(target, true, "default:" + k);
+            }
+
+            // 4) defaults["__any__"]  (the floor)
+            if (_defaults.ContainsKey("__any__"))
+            {
+                string target = AsString(_defaults["__any__"]);
+                if (!string.IsNullOrEmpty(target) && _assets.ContainsKey(target))
+                    return Row(target, true, "floor");
+            }
+
+            // 5) in-code hardcoded floor
+            return HardcodedFloor(kind);
+        }
+        catch
+        {
+            return HardcodedFloor(kind);
+        }
+    }
+
+    static Ref Row(string assetId, bool defaultUsed, string resolvedVia)
+    {
+        var row = _assets.ContainsKey(assetId) ? _assets[assetId] as Dictionary<string, object> : null;
+        row = row ?? new Dictionary<string, object>();
+        return new Ref
+        {
+            assetId = assetId,
+            kind = AsString(Get(row, "kind")),
+            modelRef = AsString(Get(row, "model_ref")),
+            albedoRef = AsString(Get(row, "albedo_ref")),
+            animRef = AsString(Get(row, "anim_ref")),
+            genRecipe = AsString(Get(row, "gen_recipe")),
+            version = AsString(Get(row, "version")),
+            defaultUsed = defaultUsed,
+            resolvedVia = resolvedVia,
+        };
+    }
+
+    // -- MiniJson dict helpers (MiniJson yields Dictionary<string,object>) ----
+    static Dictionary<string, object> AsDict(Dictionary<string, object> parent, string key)
+    {
+        if (parent != null && parent.ContainsKey(key))
+        {
+            var d = parent[key] as Dictionary<string, object>;
+            if (d != null) return d;
+        }
+        return new Dictionary<string, object>();
+    }
+
+    static object Get(Dictionary<string, object> d, string key)
+    {
+        return (d != null && d.ContainsKey(key)) ? d[key] : null;
+    }
+
+    static string AsString(object o)
+    {
+        return o == null ? null : o as string;
+    }
+}

--- a/viewer/asset_registry.py
+++ b/viewer/asset_registry.py
@@ -1,0 +1,218 @@
+"""WorldOS asset registry resolver (VIEW layer) — gfx milestone M-C, issue #1195.
+
+The renderer NEVER names a literal asset path. It names a SLOT (an ``asset_id``
+plus a ``kind``) and asks this registry, which ALWAYS returns a guaranteed
+non-null ref dict — the real asset OR a default template. This is the asset
+analogue of the engine=SOLE-WRITER invariant: swapping or regenerating ANY
+asset is ZERO renderer edits, because the renderer only ever knows slots.
+
+Resolution rule (in order; the FIRST hit wins):
+
+    exact -> alias -> defaults[kind] -> defaults["__any__"]   (the "floor")
+
+Invariants this module guarantees:
+  * ``resolve()`` ALWAYS returns a non-null ``dict`` (never ``None``).
+  * ``resolve()`` NEVER raises — a missing/corrupt registry degrades to an
+    in-code hardcoded floor template, not an exception.
+  * On any fallback the returned dict has ``default_used=True`` and a
+    ``resolved_via`` field of "exact" | "alias" | "default:<kind>" | "floor".
+    (Exact hits set ``default_used=False`` and ``resolved_via="exact"``.)
+
+VIEW-LAYER PURITY: this module imports NOTHING from ``servers/engine`` (only
+the stdlib). It reads, never writes — it is presentation/data only and is not
+a second writer of game state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Any, Dict, Optional
+
+# Slot kinds the registry understands. Anything else still resolves (via the
+# "__any__" floor) — this list is documentation, not a gate.
+KINDS = ("character", "monster", "room", "effect", "sound")
+
+# Last-resort floor used ONLY if the registry file is missing/corrupt AND the
+# requested kind has no usable default. Keeps the never-null / never-throw
+# guarantee even with no data on disk. Points at the proven hero template paths.
+_HARDCODED_FLOOR: Dict[str, Any] = {
+    "kind": "character",
+    "model_ref": "Assets/painterly/models/hero.fbx",
+    "albedo_ref": "Assets/painterly/models/hero_albedo.png",
+    "anim_ref": "Assets/painterly/models/hero@moveset.fbx",
+    "gen_recipe": "in-code hardcoded floor (registry.json missing or unreadable)",
+    "version": "0.0.0",
+    "critic_score": None,
+}
+
+
+def _find_registry_path() -> Optional[str]:
+    """Locate ``data/asset-registry/registry.json`` robustly.
+
+    Order: explicit env override -> walk up from this file's dir looking for a
+    repo-root marker (``data/asset-registry/registry.json`` itself, or a
+    ``.git`` entry) -> ``None`` if nothing is found (caller falls to the floor).
+    """
+    override = os.environ.get("WORLDOS_ASSET_REGISTRY")
+    if override and os.path.isfile(override):
+        return override
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    # viewer/ is one level under the repo root; walk up a few levels to be safe
+    # regardless of where a worktree/checkout puts us.
+    cur = here
+    for _ in range(8):
+        candidate = os.path.join(cur, "data", "asset-registry", "registry.json")
+        if os.path.isfile(candidate):
+            return candidate
+        parent = os.path.dirname(cur)
+        if parent == cur:
+            break
+        cur = parent
+    return None
+
+
+class AssetRegistry:
+    """Resolve an asset SLOT to a guaranteed-non-null ref dict.
+
+    Construct once and reuse; loading is lazy + cached and never raises. Pass an
+    explicit ``path`` to point at a specific registry file (tests do this);
+    otherwise it is auto-discovered relative to the repo root.
+    """
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self._explicit_path = path
+        self._lock = threading.Lock()
+        self._loaded = False
+        self._assets: Dict[str, Any] = {}
+        self._defaults: Dict[str, str] = {}
+        self._aliases: Dict[str, str] = {}
+
+    # -- loading -----------------------------------------------------------
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        with self._lock:
+            if self._loaded:
+                return
+            path = self._explicit_path or _find_registry_path()
+            data: Dict[str, Any] = {}
+            if path:
+                try:
+                    with open(path, "r", encoding="utf-8") as fh:
+                        data = json.load(fh) or {}
+                except (OSError, ValueError):
+                    # Missing / unreadable / corrupt JSON -> degrade to floor.
+                    data = {}
+            self._assets = data.get("assets") or {}
+            self._defaults = data.get("defaults") or {}
+            self._aliases = data.get("aliases") or {}
+            self._loaded = True
+
+    # -- resolution --------------------------------------------------------
+    def resolve(self, asset_id: Optional[str], kind: Optional[str] = None) -> Dict[str, Any]:
+        """Resolve ``asset_id`` (a slot) to a non-null ref dict. Never raises.
+
+        Rule: exact -> alias -> defaults[kind] -> defaults["__any__"] -> floor.
+        The returned dict is a COPY (callers may freely mutate it) carrying
+        ``default_used`` (bool) and ``resolved_via`` (str). On an exact hit
+        ``default_used`` is False; on every fallback it is True.
+        """
+        try:
+            self._ensure_loaded()
+            aid = (asset_id or "").strip()
+
+            # 1) exact
+            if aid and aid in self._assets:
+                return self._row(aid, default_used=False, resolved_via="exact")
+
+            # 2) alias -> asset_id
+            if aid and aid in self._aliases:
+                target = self._aliases[aid]
+                if target in self._assets:
+                    return self._row(target, default_used=True, resolved_via="alias")
+
+            # 3) defaults[kind]
+            k = (kind or "").strip()
+            if k and k in self._defaults:
+                target = self._defaults[k]
+                if target in self._assets:
+                    return self._row(target, default_used=True, resolved_via="default:%s" % k)
+
+            # 4) defaults["__any__"]  (the floor)
+            any_default = self._defaults.get("__any__")
+            if any_default and any_default in self._assets:
+                return self._row(any_default, default_used=True, resolved_via="floor")
+
+            # 5) in-code hardcoded floor (registry empty/corrupt)
+            return self._floor_row(kind)
+        except Exception:
+            # Absolute belt-and-suspenders: the never-throw / never-null contract
+            # holds even if something above is unexpectedly broken.
+            return self._floor_row(kind)
+
+    # -- helpers -----------------------------------------------------------
+    def _row(self, asset_id: str, *, default_used: bool, resolved_via: str) -> Dict[str, Any]:
+        row = dict(self._assets.get(asset_id) or {})
+        row["asset_id"] = asset_id
+        row["default_used"] = default_used
+        row["resolved_via"] = resolved_via
+        # Guarantee the ref keys exist (non-null contract is about the dict, but
+        # downstream code reads these by name).
+        for key in ("kind", "model_ref", "albedo_ref", "anim_ref"):
+            row.setdefault(key, None)
+        return row
+
+    def _floor_row(self, kind: Optional[str]) -> Dict[str, Any]:
+        row = dict(_HARDCODED_FLOOR)
+        if kind:
+            row["kind"] = kind
+        row["asset_id"] = "__floor__"
+        row["default_used"] = True
+        row["resolved_via"] = "floor"
+        return row
+
+
+# Module-level singleton + convenience function for callers that don't want to
+# manage an instance (the typical renderer-side call).
+_DEFAULT_REGISTRY: Optional[AssetRegistry] = None
+_DEFAULT_LOCK = threading.Lock()
+
+
+def get_registry() -> AssetRegistry:
+    global _DEFAULT_REGISTRY
+    if _DEFAULT_REGISTRY is None:
+        with _DEFAULT_LOCK:
+            if _DEFAULT_REGISTRY is None:
+                _DEFAULT_REGISTRY = AssetRegistry()
+    return _DEFAULT_REGISTRY
+
+
+def resolve(asset_id: Optional[str], kind: Optional[str] = None) -> Dict[str, Any]:
+    """Module-level convenience: resolve via the shared singleton registry."""
+    return get_registry().resolve(asset_id, kind)
+
+
+if __name__ == "__main__":
+    # Self-contained smoke (no pytest needed):
+    #   python3 viewer/asset_registry.py
+    reg = AssetRegistry()
+    checks = [
+        ("fighter", "character"),     # exact
+        ("hero", "character"),        # alias -> fighter
+        ("nobody", "character"),      # default:character -> template_human
+        ("kraken", "monster"),        # default:monster -> template_demon
+        ("mystery", "tarot"),         # unknown kind -> __any__ floor
+        (None, None),                 # null slot -> __any__ floor
+    ]
+    for aid, knd in checks:
+        r = reg.resolve(aid, knd)
+        assert r is not None, "resolve returned None"
+        assert r.get("model_ref") is not None or r.get("anim_ref") is not None, "null ref"
+        print(
+            "%-10s %-10s -> %-16s via=%-18s default_used=%s model=%s"
+            % (aid, knd, r.get("asset_id"), r.get("resolved_via"), r.get("default_used"), r.get("model_ref"))
+        )
+    print("OK: resolve() never returned None and never threw.")

--- a/viewer/tests/test_asset_registry.py
+++ b/viewer/tests/test_asset_registry.py
@@ -1,0 +1,145 @@
+"""Hot-swap conformance test for the view-layer asset registry (gfx M-C, #1195).
+
+This is the LOGIC-level guarantee behind the modular-defaults invariant: the
+renderer names a SLOT and the registry ALWAYS hands back a non-null ref — the
+real asset on a hit, a default template on a miss — so swapping/regenerating
+any asset is ZERO renderer edits.
+
+The resolver is VIEW-LAYER and stdlib-only, so this runs in the viewer-tests CI
+lane (`python -m pytest viewer/tests -q -p no:xdist`) with no engine deps.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+_VIEWER = Path(__file__).resolve().parents[1]  # .../viewer
+if str(_VIEWER) not in sys.path:
+    sys.path.insert(0, str(_VIEWER))
+
+import asset_registry  # noqa: E402
+from asset_registry import AssetRegistry  # noqa: E402
+
+_REGISTRY_JSON = (
+    _VIEWER.parent / "data" / "asset-registry" / "registry.json"
+)
+
+
+class AssetRegistryConformanceTests(unittest.TestCase):
+    """exact -> alias -> defaults[kind] -> defaults['__any__'] -> floor."""
+
+    def setUp(self):
+        # Pin to the committed registry so the test is hermetic regardless of any
+        # WORLDOS_ASSET_REGISTRY env override in the runner.
+        self.assertTrue(
+            _REGISTRY_JSON.is_file(),
+            "committed registry.json missing at %s" % _REGISTRY_JSON,
+        )
+        self.reg = AssetRegistry(path=str(_REGISTRY_JSON))
+
+    # -- exact hit: real ref, default_used False --------------------------
+    def test_exact_hit_returns_real_ref_no_default(self):
+        r = self.reg.resolve("fighter", "character")
+        self.assertEqual(r["asset_id"], "fighter")
+        self.assertEqual(r["resolved_via"], "exact")
+        self.assertFalse(r["default_used"])
+        self.assertEqual(r["model_ref"], "Assets/painterly/models/hero.fbx")
+        self.assertEqual(r["albedo_ref"], "Assets/painterly/models/hero_albedo.png")
+
+    def test_goblin_exact_hit_is_monster_real_ref(self):
+        r = self.reg.resolve("goblin", "monster")
+        self.assertEqual(r["asset_id"], "goblin")
+        self.assertEqual(r["resolved_via"], "exact")
+        self.assertFalse(r["default_used"])
+        self.assertEqual(r["model_ref"], "Assets/chars_v2/goblin/goblin.fbx")
+
+    # -- alias hit: resolves to target asset, default_used True -----------
+    def test_alias_resolves_to_target_asset(self):
+        r = self.reg.resolve("hero", "character")  # alias -> fighter
+        self.assertEqual(r["asset_id"], "fighter")
+        self.assertEqual(r["resolved_via"], "alias")
+        self.assertTrue(r["default_used"])
+        self.assertEqual(r["model_ref"], "Assets/painterly/models/hero.fbx")
+
+    # -- miss on a character -> template_human, default:character ---------
+    def test_character_miss_falls_to_template_human(self):
+        r = self.reg.resolve("nonexistent_npc", "character")
+        self.assertEqual(r["asset_id"], "template_human")
+        self.assertEqual(r["resolved_via"], "default:character")
+        self.assertTrue(r["default_used"])
+        self.assertIsNotNone(r["model_ref"])
+
+    # -- miss on a monster -> template_demon -----------------------------
+    def test_monster_miss_falls_to_template_demon(self):
+        r = self.reg.resolve("kraken", "monster")
+        self.assertEqual(r["asset_id"], "template_demon")
+        self.assertEqual(r["resolved_via"], "default:monster")
+        self.assertTrue(r["default_used"])
+        self.assertIsNotNone(r["model_ref"])
+
+    def test_room_and_effect_and_sound_defaults(self):
+        self.assertEqual(self.reg.resolve("x", "room")["asset_id"], "template_room_crypt")
+        self.assertEqual(self.reg.resolve("x", "effect")["asset_id"], "fx_default_slash")
+        self.assertEqual(self.reg.resolve("x", "sound")["asset_id"], "snd_default_hit")
+
+    # -- unknown kind -> __any__ floor -----------------------------------
+    def test_unknown_kind_falls_to_any_default(self):
+        r = self.reg.resolve("mystery", "tarot")  # 'tarot' is not a known kind
+        self.assertEqual(r["asset_id"], "template_human")  # __any__ -> template_human
+        self.assertEqual(r["resolved_via"], "floor")
+        self.assertTrue(r["default_used"])
+        self.assertIsNotNone(r["model_ref"])
+
+    def test_no_kind_falls_to_any_default(self):
+        r = self.reg.resolve("mystery")  # kind omitted
+        self.assertEqual(r["asset_id"], "template_human")
+        self.assertEqual(r["resolved_via"], "floor")
+        self.assertTrue(r["default_used"])
+
+    # -- NEVER throws, NEVER returns None --------------------------------
+    def test_resolve_never_throws_never_none(self):
+        wild_inputs = [
+            (None, None),
+            ("", ""),
+            (None, "character"),
+            ("fighter", None),
+            ("   ", "monster"),
+            (" weird", "room"),
+            ("a" * 5000, "effect"),
+            (123, 456),  # wrong types — must still degrade gracefully
+        ]
+        for aid, kind in wild_inputs:
+            r = self.reg.resolve(aid, kind)  # must not raise
+            self.assertIsNotNone(r, "resolve(%r,%r) returned None" % (aid, kind))
+            self.assertIsInstance(r, dict)
+            # at least one usable ref so the renderer never spawns nothing
+            self.assertTrue(
+                r.get("model_ref") is not None or r.get("anim_ref") is not None,
+                "resolve(%r,%r) returned a ref with no usable asset" % (aid, kind),
+            )
+
+    # -- missing/corrupt registry -> in-code floor, still non-null -------
+    def test_missing_registry_degrades_to_floor(self):
+        reg = AssetRegistry(path="/nonexistent/path/registry.json")
+        r = reg.resolve("anything", "character")
+        self.assertIsNotNone(r)
+        self.assertEqual(r["resolved_via"], "floor")
+        self.assertTrue(r["default_used"])
+        self.assertIsNotNone(r["model_ref"])
+
+    # -- module-level convenience uses the same rule ---------------------
+    def test_module_level_resolve(self):
+        os.environ["WORLDOS_ASSET_REGISTRY"] = str(_REGISTRY_JSON)
+        try:
+            # fresh singleton path: just assert it returns a valid dict
+            r = asset_registry.resolve("fighter", "character")
+            self.assertIsNotNone(r)
+            self.assertIn("default_used", r)
+            self.assertIn("resolved_via", r)
+        finally:
+            os.environ.pop("WORLDOS_ASSET_REGISTRY", None)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## gfx milestone M-C — asset registry (issue #1195)

The renderer **NEVER names a literal asset path**. It names a **SLOT** (`asset_id` + `kind`) and asks the registry, which **ALWAYS returns a guaranteed-non-null ref** — the real asset on a hit, a **default template** on a miss. This is the asset analogue of **engine = SOLE WRITER**: swapping or regenerating ANY asset is **ZERO renderer edits**, because the renderer only ever knows slots.

Owner requirement satisfied: *"any character without a model pulls a default template; any monster defaults to a demon template."*

### Resolution rule (first hit wins — IDENTICAL in both twins)
```
exact -> alias -> defaults[kind] -> defaults["__any__"]   (the "floor")
```
- `character` miss -> `template_human` (`resolved_via="default:character"`, `default_used=True`)
- `monster` miss -> `template_demon`
- `room`/`effect`/`sound` miss -> `template_room_crypt` / `fx_default_slash` / `snd_default_hit`
- unknown kind -> `__any__` -> `template_human` (`resolved_via="floor"`)
- registry missing/corrupt -> in-code hardcoded floor (still non-null, still no throw)

### Files (additive; view-layer/data only)
- **`data/asset-registry/registry.json`** — committed manifest. 8 assets (incl. the `template_*` rows so defaults resolve to real refs), 6 defaults, 4 aliases. Seed rows reference the box paths in use (`Assets/painterly/models/hero.fbx`+`hero_albedo.png`; `Assets/chars_v2/goblin/goblin.fbx`+`albedo.png`). Schema per row: `kind, model_ref, albedo_ref, anim_ref, gen_recipe, version, critic_score, default_used`. **Binary assets are gitignored** (`/data/asset-registry/**` with `registry.json` un-ignored); only the manifest is tracked.
- **`viewer/asset_registry.py`** — Python resolver (VIEW layer). `class AssetRegistry` + module-level `resolve()`. ALWAYS returns a non-null dict, NEVER throws, sets `default_used` + `resolved_via` on fallback. **Imports nothing from `servers/engine`** — stdlib only, so it runs in the existing `viewer-tests` CI lane. Robust repo-root discovery (`WORLDOS_ASSET_REGISTRY` env override -> walk up for `data/asset-registry/registry.json`).
- **`extensions/renderers/unity/scripts/AssetRegistry.cs`** — Unity twin, **identical rule**. Parses via the repo's existing **`MiniJson.cs`** (map-of-maps; `JsonUtility` can't model arbitrary `asset_id` keys). `static Resolve(assetId, kind)` -> `Ref { modelRef, albedoRef, animRef, defaultUsed, resolvedVia, ... }`. **Not wired into `paint_combat_v1.cs`** (that renderer is on the unmerged `feat/combat-animator-prep` branch, #1180) — the intended `spawn()` call site (slot -> `Resolve()` instead of literal `LoadAssetAtPath`) is documented in the header comment.
- **`viewer/tests/test_asset_registry.py`** — hot-swap conformance test, 11 cases (all green locally, `python -m pytest viewer/tests/test_asset_registry.py -q -p no:xdist`): exact hit -> real ref + `default_used=False`; alias; character-miss -> `template_human`/`default:character`; monster-miss -> `template_demon`; room/effect/sound defaults; unknown kind -> `__any__`; never-throws/never-None over wild inputs (None, wrong types, 5000-char id); missing-registry floor.

### Invariants honored
- **engine = SOLE WRITER** — this is presentation/data only; reads, never writes game state.
- **Additive** — no existing file changed except `.gitignore` (new asset-registry rule).
- **Resolver imports nothing from `servers/engine`.**

### Follow-up (after #1180 merges)
Wire `paint_combat_v1.cs`'s `spawn()` to resolve by slot via `AssetRegistry.Resolve(actor.assetId, actor.kind)` instead of the literal `AssetDatabase.LoadAssetAtPath(...)`. The exact before/after is in the `AssetRegistry.cs` header comment.

Refs #1195.