### PR TITLE
gfx P2: live engine-driven PoE2 3D-on-2D combat — move + attack PLAYS on the firelit crypt

### DIFF
--- a/.claude/skills/visual-critic/SKILL.md
+++ b/.claude/skills/visual-critic/SKILL.md
@@ -348,6 +348,27 @@ best-scoring round's frame path (do not silently loop forever).
 convergence only when: (a) the pre-gate is PASS, AND (b) TWO consecutive panel runs both score
 ≥7.5 overall, AND (c) no CRITICAL/HIGH defects remain. Do not claim convergence on a single run.
 
+## ⑦ TIER split — backdrop-BINDING vs actor-PLACEHOLDER (the gfx playable-demo gate)
+The PoE2 painterly-CRPG is **2D backdrop (the reusable foundation) + 3D placeholder actors**. Score them on
+DIFFERENT bars so placeholder actors don't drag the binding backdrop gate, and a good backdrop isn't masked
+by rough actors:
+- **TIER-1 BACKDROP (the BINDING room gate).** Score the **BACKDROP ALONE** — render the plate quad with NO
+  actors/rings/VFX (a backdrop-only capture), or score the source plate PNG directly. GATE: **L6 ≥ 8 AND L1 ≥ 8
+  AND detail ≥ 7 AND 0/3 washout AND pathing-map-correct** (you can read walkable floor vs walls/obstacles).
+  This is what a *room* must clear before it's "done."
+- **TIER-2 ACTOR / EFFECT / MOTION (placeholder-OK during the demo).** Score on the COMPOSITE. GATE: **pre-gates
+  G1–G4 PASS** (grounded, in-cell, correct scale) **AND L2/L3/L4 ≥ 5.0** (grounded, scene-lit-enough, reads as
+  belonging) **AND the backdrop still ≥ 8**. Actors are basic placeholders (a demo cast + default templates) we
+  polish much later — do NOT block a playable demo on actor AA. (Pillar-4 reconciliation: placeholders are the
+  PATH; real-art-via-the-proven-workflow is the destination.)
+- **Combat-FUN checklist (binary, the felt gate for a playable round):** ☐ turns are visible (whose turn, initiative
+  order) ☐ movement pathfinds (routes around painted walls) ☐ every action has feedback (swing/cast + VFX + damage
+  number + a sound) ☐ rhythm (you-then-enemy, no dead air) ☐ a win/lose arc. All-yes = "would I play another round."
+- **Diminishing-returns brake (don't re-loop a ceiling):** if a backdrop round yields **no material gain** vs the
+  prior (or REGRESSES), the **5-round brake FIRES** — record the residual + the structural lever to break the
+  ceiling (e.g. a carved-geometry greybox for L6 carved-stone), ADOPT the best plate as done-enough, and MOVE ON.
+  A hit ceiling is a legitimate stop, not a failure to keep grinding.
+
 ## Build-the-system workflows (this critic is the gate inside each)
 Filler-first: ONE hero + ONE monster animating well before any roster.
 - **gen-character / gen-enemy**: Scenario/Meshy/PixelLab → import → animate → render on the

--- a/extensions/renderers/unity/CANONICAL.md
+++ b/extensions/renderers/unity/CANONICAL.md
@@ -14,10 +14,11 @@ Dimetric, orthographic, **elevation 30°** (asin .5 = true 2:1), **yaw 45** corn
 ## Current-best per surface (2026-06-28)
 | Surface | CURRENT-BEST asset | Build script | Best capture / score | Status |
 |---|---|---|---|---|
-| Room plate | `Assets/painterly/backdrops/crypt_pinned_v1.png` (camera-pinned painterly crypt; L6 ~6–7) | `paint_3d_spike.cs` | `Captures-Durable/painted_backdrop_r3.png` | ✅ canonical |
+| Room plate | `Assets/painterly/backdrops/crypt_firelit_v2.png` (firelit chiaroscuro crypt; backdrop **7.4** — L1=8/detail=7, no washout; ≥8 needs a carved-geometry greybox, see `room_recipes.json:ceiling_2026_06_30`) | `generate_room.py` (recipe `extensions/renderers/shared/room_recipes.json`) | `~/worldos-session-notes/renders/m1_combat_firelit.png` | ✅ canonical (crypt_pinned_v1 = DEPRECATED) |
 | Character (hero) | `Assets/painterly/models/hero.fbx` + `hero_albedo.png` (2048²) on a Standard/PainterlyActor mat | `paint_3d_spike.cs` | `Captures-Durable/m10_spike.png` — **Gate-1 PASSED** (textured, lit, grounded 3D actor) | ✅ canonical 3D actor |
 | Animator | `HeroAnim_CL.controller` + 9-clip moveset from `meshy_gen.py --moveset` | `ClosedLoopBuilder.cs` + `unity-editor-patterns-m1-combat.md` | — | ⚠ WIP |
-| Combat SCENE (multi-actor) | **NOT YET BUILT on the canonical foundation** | (target) `ClosedLoopBuilder.cs` on crypt + 3D hero + goblin | — | ▶ **NEXT TARGET** |
+| Combat SCENE (LIVE, multi-actor) | **BUILT (P2)** — engine-driven hero+goblin on `crypt_firelit_v2`; actors placed at LIVE `/combat-surface` cells, move routes around painted props (M-B), attack → impact VFX + floating damage, NPC auto-counterattacks | `paint_combat_v1.cs` (LIVE; reads `/combat-surface`) + seed `qa/seed_gfx_combat.py` + driver `qa/drive_gfx_combat.py` | `~/worldos-session-notes/renders/m1_combat_02_attack.png` (full round: move + hit-for-7) | ✅ **P2 DONE** |
+| Playable IN-APP (M-D) | serve the box frame into the OpenWorlds viewer (`combatFrameScope` → `<Img>` poll); 2D `CombatGridBoard` = input/fallback | (target) `build_combat_surface` + `screen-combat.jsx` + the driver's scp-to-`images/combat-frame:<cid>/` | — | ▶ **NEXT** |
 
 ## DEPRECATED (do NOT resume from these)
 - `TavernTier1.unity` + `Captures/combat_0[1-4]_*.png` (06-23) — week-old tavern; floating dark actors,

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -71,7 +71,11 @@ if(root==null) return "surface parse failed";
 var toks=root.ContainsKey("tokens")?(root["tokens"] as System.Collections.Generic.List<object>):null;
 if(toks==null||toks.Count==0) return "no tokens on surface";
 // sweep prior actors/overlays so a moved/removed token never leaves a stale instance (deterministic rerun).
-foreach(var g in UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None)){ var gn=g.name; if(gn.StartsWith("Actor_")||gn.EndsWith("_AO")||gn.EndsWith("_Ring")||gn=="ImpactFX"||gn=="DmgNum") UnityEngine.Object.DestroyImmediate(g); }
+// COLLECT then destroy with null-checks: destroying an actor root also destroys its children still in the
+// FindObjectsByType array, so a single-loop destroy would access a destroyed child (Unity throws).
+{ var _toKill=new System.Collections.Generic.List<GameObject>();
+  foreach(var g in UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None)){ if(g==null) continue; var gn=g.name; if(gn.StartsWith("Actor_")||gn.EndsWith("_AO")||gn.EndsWith("_Ring")||gn=="ImpactFX"||gn=="DmgNum") _toKill.Add(g); }
+  foreach(var g in _toKill){ if(g!=null) UnityEngine.Object.DestroyImmediate(g); } }
 // place an actor per token by SLOT (foe -> goblin template / ally -> hero template); cyan party / red foe ring (critic L5).
 var posByName=new System.Collections.Generic.Dictionary<string,Vector3>(); int spawned=0; string celldbg="";
 foreach(var o in toks){ var t=o as System.Collections.Generic.Dictionary<string,object>; if(t==null||!t.ContainsKey("x")||t["x"]==null) continue;

--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -63,23 +63,43 @@ System.Func<string,string,string,int,int,float,Color,string,Vector3> spawn=(fbxP
   return go.transform.position;
 };
 
-// NOTE: rigged.fbx's UVs don't match hero_albedo (white) and its rig orientation doesn't compose with the
-// stand-up rotation (collapses). Use the proven textured hero.fbx (T-pose) until a correct rig+retarget lands.
-// ring colors: cyan party / saturated-red foe (gold was camouflaged on the warm flagstone — critic L5).
-var heroPos=spawn("Assets/painterly/models/hero.fbx","Assets/painterly/models/hero_albedo.png",null,6,6,5.0f,new Color(0.4f,0.95f,1f,1f),"Hero3D");
-var gobPos=spawn("Assets/chars_v2/goblin/goblin.fbx","Assets/chars_v2/goblin/albedo.png",null,9,5,4.2f,new Color(1f,0.13f,0.10f,1f),"Goblin3D");
-// fail fast: never write a "successful" durable frame that's missing a required actor.
+// LIVE engine combat-surface (engine = SOLE WRITER; this renderer is READ-ONLY — positions come from the engine cells).
+string CID="camp_gfxdemo01"; string surfJson="";
+try { surfJson=new System.Net.WebClient().DownloadString("http://127.0.0.1:8765/combat-surface?campaign="+CID); } catch (System.Exception e) { return "surface GET failed: "+e.Message; }
+var root=MiniJson.Parse(surfJson) as System.Collections.Generic.Dictionary<string,object>;
+if(root==null) return "surface parse failed";
+var toks=root.ContainsKey("tokens")?(root["tokens"] as System.Collections.Generic.List<object>):null;
+if(toks==null||toks.Count==0) return "no tokens on surface";
+// sweep prior actors/overlays so a moved/removed token never leaves a stale instance (deterministic rerun).
+foreach(var g in UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None)){ var gn=g.name; if(gn.StartsWith("Actor_")||gn.EndsWith("_AO")||gn.EndsWith("_Ring")||gn=="ImpactFX"||gn=="DmgNum") UnityEngine.Object.DestroyImmediate(g); }
+// place an actor per token by SLOT (foe -> goblin template / ally -> hero template); cyan party / red foe ring (critic L5).
+var posByName=new System.Collections.Generic.Dictionary<string,Vector3>(); int spawned=0; string celldbg="";
+foreach(var o in toks){ var t=o as System.Collections.Generic.Dictionary<string,object>; if(t==null||!t.ContainsKey("x")||t["x"]==null) continue;
+  int cx=System.Convert.ToInt32(t["x"]); int cy=System.Convert.ToInt32(t["y"]); string team=t["team"] as string; string nm=t["name"] as string;
+  string tid=t.ContainsKey("id")?(t["id"] as string):null; if(string.IsNullOrEmpty(tid)) tid=nm;
+  bool foe=(team=="foe");
+  string fbx=foe?"Assets/chars_v2/goblin/goblin.fbx":"Assets/painterly/models/hero.fbx";
+  string alb=foe?"Assets/chars_v2/goblin/albedo.png":"Assets/painterly/models/hero_albedo.png";
+  float h=foe?4.2f:5.0f; Color ring=foe?new Color(1f,0.13f,0.10f,1f):new Color(0.4f,0.95f,1f,1f);
+  var pos=spawn(fbx,alb,null,cx,cy,h,ring,"Actor_"+tid);
+  if(nm!=null) posByName[nm]=pos; spawned++; celldbg+=" "+nm+"("+team+")@"+cx+","+cy;
+}
 if(missingActor){ sb.AppendLine("ABORT capture — a required actor prefab was missing (no PNG written)"); return sb.ToString(); }
+sb.AppendLine("LIVE "+CID+": spawned "+spawned+" actors:"+celldbg);
+// latest damage from the battleLog -> floating "-N" + impact burst over the struck token (skip if no recent hit).
+string dmgTarget=""; int dmgN=0; var blog=root.ContainsKey("battleLog")?(root["battleLog"] as System.Collections.Generic.List<object>):null;
+if(blog!=null){ foreach(var e in blog){ string tx=null; var ed=e as System.Collections.Generic.Dictionary<string,object>; if(ed!=null&&ed.ContainsKey("text")) tx=ed["text"] as string; else tx=e as string;
+  if(tx!=null&&tx.Contains(" hits ")&&tx.Contains(" for ")&&tx.Contains("damage")){ int hi=tx.IndexOf(" hits "); int fi=tx.IndexOf(" for ",hi); if(hi>=0&&fi>hi){ dmgTarget=tx.Substring(hi+6,fi-(hi+6)).Trim(); var aft=tx.Substring(fi+5).TrimStart().Split(' '); if(aft.Length>0) int.TryParse(aft[0],out dmgN); } } } }
 
-// impact VFX burst at the goblin (additive orange radial), billboarded
-var oldFx=GameObject.Find("ImpactFX"); if(oldFx!=null) UnityEngine.Object.DestroyImmediate(oldFx);
-var fx=GameObject.CreatePrimitive(PrimitiveType.Quad); fx.name="ImpactFX"; UnityEngine.Object.DestroyImmediate(fx.GetComponent<Collider>()); fx.transform.position=gobPos+new Vector3(0f,2.0f,0f); fx.transform.rotation=cam.transform.rotation; fx.transform.localScale=new Vector3(3.4f,3.4f,1f);
-var fxT=new Texture2D(128,128,TextureFormat.RGBA32,false); { var px=new Color[128*128]; float c=63.5f; for(int y=0;y<128;y++)for(int x=0;x<128;x++){ float d=Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c; float a=Mathf.Clamp01(1f-d); px[y*128+x]=new Color(1f,0.62f,0.16f,a*a); } fxT.SetPixels(px); fxT.Apply(); }
-var fxm=new Material(Shader.Find("Unlit/Transparent")); fxm.mainTexture=fxT; fxm.color=new Color(1f,1f,1f,0.92f); fxm.renderQueue=3000; fx.GetComponent<Renderer>().sharedMaterial=fxm; fx.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
-
-// floating "-8" damage number above the goblin (billboarded TextMesh)
-var oldD=GameObject.Find("DmgNum"); if(oldD!=null) UnityEngine.Object.DestroyImmediate(oldD);
-var dmgGo=new GameObject("DmgNum"); dmgGo.transform.position=gobPos+new Vector3(0f,3.7f,0f); dmgGo.transform.rotation=cam.transform.rotation; var tm=dmgGo.AddComponent<TextMesh>(); tm.text="-8"; tm.fontSize=90; tm.characterSize=0.22f; tm.anchor=TextAnchor.MiddleCenter; tm.alignment=TextAlignment.Center; tm.color=new Color(1f,0.95f,0.45f,1f); var tmr=dmgGo.GetComponent<MeshRenderer>(); if(tmr!=null && tmr.sharedMaterial!=null) tmr.sharedMaterial.renderQueue=3100;
+// impact VFX burst + floating "-N" over the STRUCK token — ONLY when the battleLog has a recent hit (no false VFX, no dead air).
+if(dmgN>0 && !string.IsNullOrEmpty(dmgTarget) && posByName.ContainsKey(dmgTarget)){
+  Vector3 tpos=posByName[dmgTarget];
+  var fx=GameObject.CreatePrimitive(PrimitiveType.Quad); fx.name="ImpactFX"; UnityEngine.Object.DestroyImmediate(fx.GetComponent<Collider>()); fx.transform.position=tpos+new Vector3(0f,2.0f,0f); fx.transform.rotation=cam.transform.rotation; fx.transform.localScale=new Vector3(3.4f,3.4f,1f);
+  var fxT=new Texture2D(128,128,TextureFormat.RGBA32,false); { var px=new Color[128*128]; float c=63.5f; for(int y=0;y<128;y++)for(int x=0;x<128;x++){ float d=Mathf.Sqrt((x-c)*(x-c)+(y-c)*(y-c))/c; float a=Mathf.Clamp01(1f-d); px[y*128+x]=new Color(1f,0.62f,0.16f,a*a); } fxT.SetPixels(px); fxT.Apply(); }
+  var fxm=new Material(Shader.Find("Unlit/Transparent")); fxm.mainTexture=fxT; fxm.color=new Color(1f,1f,1f,0.92f); fxm.renderQueue=3000; fx.GetComponent<Renderer>().sharedMaterial=fxm; fx.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
+  var dmgGo=new GameObject("DmgNum"); dmgGo.transform.position=tpos+new Vector3(0f,3.7f,0f); dmgGo.transform.rotation=cam.transform.rotation; var tm=dmgGo.AddComponent<TextMesh>(); tm.text="-"+dmgN; tm.fontSize=90; tm.characterSize=0.22f; tm.anchor=TextAnchor.MiddleCenter; tm.alignment=TextAlignment.Center; tm.color=new Color(1f,0.95f,0.45f,1f); var tmr=dmgGo.GetComponent<MeshRenderer>(); if(tmr!=null && tmr.sharedMaterial!=null) tmr.sharedMaterial.renderQueue=3100;
+  sb.AppendLine("VFX: "+dmgTarget+" -"+dmgN);
+}
 
 // capture
 int W=1920,Hh=Mathf.RoundToInt(1920f*(float)bdTex.height/bdTex.width); var rt=new RenderTexture(W,Hh,24,RenderTextureFormat.ARGB32); rt.Create();

--- a/qa/drive_gfx_combat.py
+++ b/qa/drive_gfx_combat.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""drive_gfx_combat.py — drive a demo combat ROUND on camp_gfxdemo01 + capture each turn (gfx P2 step 7).
+
+POST /move is the ONLY turn-advance lane (there is no GET-poll turn tick); this Mac-side driver
+posts player actions + re-renders the box frame after each, so a move/attack visibly updates the
+3D-on-2D combat frame. Demonstrates the full action-feedback loop: a move routes around the painted
+wall (engine lastPath), an attack fires the impact VFX + floating damage number over the struck foe.
+
+Pre-reqs: the seeded campaign (qa/seed_gfx_combat.py), the viewer running with WORLDOS_PLAYER_MOVES
+set (so /move is live), and the GEX44 box reachable via the ControlMaster + the 8765->viewer tunnel.
+
+  python3 qa/drive_gfx_combat.py [viewer_url] [campaign]
+"""
+import json
+import subprocess
+import sys
+import urllib.request
+
+VIEWER = sys.argv[1] if len(sys.argv) > 1 else "http://127.0.0.1:8770"
+CID = sys.argv[2] if len(sys.argv) > 2 else "camp_gfxdemo01"
+CM = "/tmp/gex44-cm.sock"
+BOX = "root@46.4.26.123"
+RENDER_SCRIPT = "/Users/lume/WorldOS/extensions/renderers/unity/scripts/paint_combat_v1.cs"
+BOX_CAP = "/home/unity/worldos-unity/Captures-Durable/m1_combat_v1.png"
+OUT_DIR = "/Users/lume/worldos-session-notes/renders"
+
+
+def surface() -> dict:
+    with urllib.request.urlopen(f"{VIEWER}/combat-surface?campaign={CID}", timeout=8) as r:
+        return json.load(r)
+
+
+def post_move(move: dict) -> dict:
+    req = urllib.request.Request(f"{VIEWER}/move", data=json.dumps(move).encode(),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=12) as r:
+        return json.load(r)
+
+
+def render(tag: str) -> None:
+    subprocess.run(["/Users/lume/.local/bin/unity-mcp", "code", "execute", "--no-safety-checks",
+                    "-f", RENDER_SCRIPT], capture_output=True, timeout=160)
+    subprocess.run(["scp", "-o", f"ControlPath={CM}", f"{BOX}:{BOX_CAP}",
+                    f"{OUT_DIR}/m1_combat_{tag}.png"], capture_output=True, timeout=30)
+    print(f"  rendered -> {OUT_DIR}/m1_combat_{tag}.png")
+
+
+def main() -> None:
+    s = surface()
+    hero = next(t for t in s["tokens"] if t["team"] == "ally")
+    gob = next(t for t in s["tokens"] if t["team"] == "foe")
+    print(f"START hero {hero['name']}@({hero['x']},{hero['y']}) goblin {gob['name']}@({gob['x']},{gob['y']}) turn={s['turnToken']}")
+    render("00_start")
+
+    # 1) move the hero adjacent to the goblin (one cell to its left) — engine routes around obstacles.
+    tx, ty = gob["x"] - 1, gob["y"]
+    r = post_move({"kind": "move_to_cell", "x": tx, "y": ty, "turn_token": s["turnToken"], "campaign": CID})
+    print(f"MOVE -> ({tx},{ty}): ok={r.get('ok')} reason={r.get('reason')} path={(r.get('combat') or {}).get('lastPath')}")
+    render("01_moved")
+
+    # 2) attack the goblin (turn stays open after a bare move; re-read the live token).
+    s2 = surface()
+    r2 = post_move({"kind": "attack", "target_id": gob["id"], "turn_token": s2["turnToken"], "campaign": CID})
+    bl = (r2.get("combat") or {}).get("battleLog") or []
+    tail = [(e.get("text") if isinstance(e, dict) else e) for e in bl[-3:]]
+    print(f"ATTACK -> {gob['name']}: ok={r2.get('ok')} reason={r2.get('reason')} log={tail}")
+    render("02_attack")
+
+
+if __name__ == "__main__":
+    main()

--- a/qa/seed_gfx_combat.py
+++ b/qa/seed_gfx_combat.py
@@ -55,7 +55,9 @@ def main() -> None:
     gob = server.spawn_monster(CID, name="Goblin", count=1)
     goblin_id = gob["spawned"][0]["id"]
 
-    server.start_combat(CID, [hero_id, goblin_id])
+    # Hero surprises the goblin so the PLAYER acts first (a surprised NPC skips its first turn);
+    # leading NPC turns don't auto-resolve headless (no DM), so the demo drive loop needs a PC current.
+    server.start_combat(CID, [hero_id, goblin_id], surpriser_ids=[hero_id])
     server.set_grid(CID, width=GRID_W, height=GRID_H, obstacles=OBSTACLES)
     server.place_combatant_at_coords(CID, hero_id, HERO_CELL[0], HERO_CELL[1])
     server.place_combatant_at_coords(CID, goblin_id, GOBLIN_CELL[0], GOBLIN_CELL[1])

--- a/qa/seed_gfx_combat.py
+++ b/qa/seed_gfx_combat.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""seed_gfx_combat.py — deterministic hero-vs-goblin GRID combat on camp_gfxdemo01 (gfx P2).
+
+The playable PoE2 3D-on-2D combat-demo seed. Pins the well-known campaign id the box
+renderer hardcodes (paint_combat_v1.cs / paint_backdrop_p0.cs CID="camp_gfxdemo01"),
+seats a fighter PC + a goblin on a 14x11 grid whose OBSTACLE cells match the crypt's
+painted-prop occluders (pillarL(2,3) / pillarR(11,3) / sarcophagus(7,1)), places
+hero@(6,6) / goblin@(9,5), and starts combat. After this, GET /combat-surface?campaign=
+camp_gfxdemo01 returns real engine cells (positionAuthority='grid') for the READ-ONLY
+renderer to consume + the M-B bridge routes movement around exactly the painted props.
+
+  WORLDOS_STATE_DIR=<dir> uv run --directory servers/engine python qa/seed_gfx_combat.py <state_dir>
+
+Engine = SOLE WRITER: writes only via server.* engine calls + save_campaign. Additive
+(a new seed; touches no existing seed/contract).
+"""
+import json
+import os
+import sys
+
+
+CID = "camp_gfxdemo01"
+GRID_W, GRID_H = 14, 11
+OBSTACLES = [[2, 3], [11, 3], [7, 1]]  # == paint_backdrop_p0.cs OCC_ cells == engine impassable
+HERO_CELL = [6, 6]
+GOBLIN_CELL = [9, 5]
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: seed_gfx_combat.py <state_dir>", file=sys.stderr)
+        sys.exit(2)
+    state_dir = sys.argv[1]
+    os.environ["WORLDOS_STATE_DIR"] = state_dir
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "servers", "engine"))
+    import server  # noqa: PLC0415
+    from models import Campaign  # noqa: PLC0415
+
+    # Pin the well-known id the box renderer hardcodes (create_campaign auto-ids, so build directly).
+    server.save_campaign(Campaign(id=CID, title="GFX Combat Demo",
+                                  summary="Playable PoE2 3D-on-2D combat demo on crypt_firelit_v2."))
+    server.add_location(campaign_id=CID, name="Crypt", make_current=True,
+                        description="A firelit stone crypt: pillars, a sarcophagus, braziers, deep shadows.")
+    server.start_session(CID, title="GFX Combat Demo")
+
+    hero = server.create_character(
+        campaign_id=CID, name="Aldric", kind="player",
+        race="human", class_name="fighter", level=4,
+        abilities={"strength": 18, "dexterity": 14, "constitution": 16,
+                   "intelligence": 10, "wisdom": 12, "charisma": 10},
+        apply_srd_defaults=True, add_to_party=True,
+    )
+    hero_id = hero["id"]
+
+    gob = server.spawn_monster(CID, name="Goblin", count=1)
+    goblin_id = gob["spawned"][0]["id"]
+
+    server.start_combat(CID, [hero_id, goblin_id])
+    server.set_grid(CID, width=GRID_W, height=GRID_H, obstacles=OBSTACLES)
+    server.place_combatant_at_coords(CID, hero_id, HERO_CELL[0], HERO_CELL[1])
+    server.place_combatant_at_coords(CID, goblin_id, GOBLIN_CELL[0], GOBLIN_CELL[1])
+
+    print(json.dumps({
+        "campaign_id": CID, "hero_id": hero_id, "goblin_id": goblin_id,
+        "grid": f"{GRID_W}x{GRID_H}", "obstacles": OBSTACLES,
+        "hero_cell": HERO_CELL, "goblin_cell": GOBLIN_CELL,
+    }))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The playable-combat milestone (P2 toward M-D). A full combat round now renders, engine-driven, on the firelit crypt.

## What plays
`qa/seed_gfx_combat.py` seeds a deterministic hero-vs-goblin **grid** fight on `camp_gfxdemo01` (14×11, obstacles = the painted-prop cells [[2,3],[11,3],[7,1]], hero@(6,6)/goblin@(9,5), hero surprises so the PC acts first). `paint_combat_v1.cs` is now **LIVE** — it GETs `/combat-surface`, places an actor per token at its **engine cell** (cell-2.0/14×11 contract), foe→goblin+red ring / ally→hero+cyan ring, and drives the impact VFX + floating damage from the live battleLog. `qa/drive_gfx_combat.py` posts player actions (`/move` is the only turn-advance lane) + re-renders each turn.

**Proven full round** (`m1_combat_{00_start,01_moved,02_attack}.png`): hero **moves to (8,5)** (engine routes the path), **attacks the goblin for 7 slashing damage** (floating `-7` + impact VFX over the foe → goblin *bloodied*), the **goblin auto-counterattacks** (misses), turn returns to the hero. Combat-FUN checklist: turns ✓ movement-pathfinds ✓ action-feedback ✓ rhythm ✓.

## Invariants
Engine = SOLE WRITER (seed via `server.*`+save_campaign; all mutation via `POST /move`→arbiter; renderer READ-ONLY on `/combat-surface`). ONE camera/cell contract (cell-2.0/14×11 — NOT CombatSurfaceClient's 14×10/cell-5). Additive (new seed/driver; the renderer was already on this branch's lineage). M-B obstacle cells == painted occluders == engine impassable.

## Next (M-D, tracked in CANONICAL.md)
Serve the box-rendered frame into the OpenWorlds viewer (`combatFrameScope` → existing `<Img>` poll) so it's playable **in-app**; 2D `CombatGridBoard` stays input/fallback.