### PR TITLE
gfx: occlusion fix — cut the camera-near wall + no ceilings (you can SEE IN)

### DIFF
--- a/extensions/renderers/unity/scripts/build_room_greybox.cs
+++ b/extensions/renderers/unity/scripts/build_room_greybox.cs
@@ -91,11 +91,15 @@ System.Func<string,Vector3,Vector3,Color,GameObject> box=(nm,center,size,col)=>{
   for(int c=1;c<cols;c++){ float x=(c-cx0)*2.0f-1.0f; box("FloorGroutV"+c, new Vector3(x,gy,0f), new Vector3(gw,0.05f,rows*2.0f), grout); }
   for(int r=1;r<rows;r++){ float z=(cy0-r)*2.0f+1.0f; box("FloorGroutH"+r, new Vector3(0f,gy,z), new Vector3(cols*2.0f,0.05f,gw), grout); }
 }
-// enclosing walls — TALL back + sides so the room fills the upper frame (no black sky); NO front wall
-// (the corner-iso camera looks in over the open front edge). Heights tuned for the dimetric down-look.
+// enclosing walls — build only the FAR walls so the camera SEES IN (iso-CRPG cutaway). The camera sits at
+// the -x,-z near corner looking toward +x,+z, so the FAR walls are +z (back) and +x (right); the NEAR walls
+// are -x (left) and -z (front). The front (-z) was already open; now we also OMIT the near -x/LEFT wall so
+// it doesn't occlude the interior floor + the actors + the pathing (the owner's #1 fix: "the wall comes
+// down so you can fully see in"). A transparent-able near-wall LAYER is a later polish.
+bool cutNear = true;   // INDOOR default: omit the camera-near (-x/left) wall for full interior visibility.
 float backH=11f, sideH=9f;
 box("WallBack",  new Vector3(0f,backH/2f,(cy0+0.5f)*2.0f), new Vector3(cols*2.0f,backH,0.5f), new Color(0.5f,0.49f,0.48f));
-box("WallLeft",  new Vector3(-(cx0+0.5f)*2.0f,sideH/2f,0f), new Vector3(0.5f,sideH,rows*2.0f), new Color(0.46f,0.45f,0.44f));
+if(!cutNear) box("WallLeft",  new Vector3(-(cx0+0.5f)*2.0f,sideH/2f,0f), new Vector3(0.5f,sideH,rows*2.0f), new Color(0.46f,0.45f,0.44f));
 box("WallRight", new Vector3((cx0+0.5f)*2.0f,sideH/2f,0f), new Vector3(0.5f,sideH,rows*2.0f), new Color(0.44f,0.43f,0.42f));
 // CARVED wall relief — raised pilasters/buttresses every ~3 cells protruding INTO the room, plus a
 // header course band near the top. Walls fill most of the dimetric frame, so this carved architecture
@@ -105,7 +109,7 @@ box("WallRight", new Vector3((cx0+0.5f)*2.0f,sideH/2f,0f), new Vector3(0.5f,side
   for(int c=2;c<cols-1;c+=3){ float x=(c-cx0)*2.0f; box("PilBack"+c, new Vector3(x,backH*0.46f,(cy0+0.35f)*2.0f), new Vector3(pilW,backH*0.92f,pilD), pilC); }
   // side-wall pilasters
   for(int r=2;r<rows-1;r+=3){ float z=(cy0-r)*2.0f;
-    box("PilLeft"+r,  new Vector3(-(cx0+0.35f)*2.0f,sideH*0.46f,z), new Vector3(pilD,sideH*0.92f,pilW), pilC);
+    if(!cutNear) box("PilLeft"+r,  new Vector3(-(cx0+0.35f)*2.0f,sideH*0.46f,z), new Vector3(pilD,sideH*0.92f,pilW), pilC);
     box("PilRight"+r, new Vector3((cx0+0.35f)*2.0f, sideH*0.46f,z), new Vector3(pilD,sideH*0.92f,pilW), pilC); }
   // header course band along the back wall top (a cornice line for the LoRA)
   box("BackCornice", new Vector3(0f,backH*0.84f,(cy0+0.32f)*2.0f), new Vector3(cols*2.0f,0.7f,0.5f), bandC);
@@ -119,7 +123,7 @@ box("WallRight", new Vector3((cx0+0.5f)*2.0f,sideH/2f,0f), new Vector3(0.5f,side
   // horizontal courses on all three walls (the dominant masonry read)
   for(float yy=1.3f; yy<backH-0.7f; yy+=1.45f){ box("CrsBackH"+(int)(yy*10f), new Vector3(0f,yy,backZ), new Vector3(cols*2.0f,sw,0.14f), seamC); }
   for(float yy=1.3f; yy<sideH-0.7f; yy+=1.45f){
-    box("CrsLeftH"+(int)(yy*10f),  new Vector3(lX,yy,0f), new Vector3(0.14f,sw,rows*2.0f), seamC);
+    if(!cutNear) box("CrsLeftH"+(int)(yy*10f),  new Vector3(lX,yy,0f), new Vector3(0.14f,sw,rows*2.0f), seamC);
     box("CrsRightH"+(int)(yy*10f), new Vector3(rX,yy,0f), new Vector3(0.14f,sw,rows*2.0f), seamC); }
   // sparse vertical joints (running bond) on the back wall so courses break into blocks, not stripes
   for(int c=1;c<cols;c+=2){ float x=(c-cx0)*2.0f-1.0f; box("CrsBackV"+c, new Vector3(x,backH*0.42f,backZ), new Vector3(0.10f,backH*0.78f,0.14f), seamC); }

--- a/extensions/renderers/unity/scripts/build_room_greybox.cs
+++ b/extensions/renderers/unity/scripts/build_room_greybox.cs
@@ -91,6 +91,9 @@ System.Func<string,Vector3,Vector3,Color,GameObject> box=(nm,center,size,col)=>{
   for(int c=1;c<cols;c++){ float x=(c-cx0)*2.0f-1.0f; box("FloorGroutV"+c, new Vector3(x,gy,0f), new Vector3(gw,0.05f,rows*2.0f), grout); }
   for(int r=1;r<rows;r++){ float z=(cy0-r)*2.0f+1.0f; box("FloorGroutH"+r, new Vector3(0f,gy,z), new Vector3(cols*2.0f,0.05f,gw), grout); }
 }
+// ★ NO CEILING / NO ROOF GEOMETRY — EVER, for interior rooms (the universal iso-CRPG convention: PoE1/2,
+// Infinity Engine, Disco Elysium, Diablo all omit ceilings so the top-down camera sees the floor + actors).
+// Do NOT add a ceiling/roof box here to "enclose" a room — it would occlude the interior. (Guard tripwire.)
 // enclosing walls — build only the FAR walls so the camera SEES IN (iso-CRPG cutaway). The camera sits at
 // the -x,-z near corner looking toward +x,+z, so the FAR walls are +z (back) and +x (right); the NEAR walls
 // are -x (left) and -z (front). The front (-z) was already open; now we also OMIT the near -x/LEFT wall so


### PR DESCRIPTION
## What (the owner's #1 next-level fix)

The backdrops look great, but with actors added the **near walls / ceilings occlude the interior + the actors + the pathing**. iso-CRPG fix (PoE1/2, Infinity Engine, Disco Elysium, Diablo all do this): **static art-time cutaway** — omit the camera-facing walls + never build a ceiling. No runtime transparency shader needed because our camera is permanently fixed.

The camera sits at the −x,−z near corner (yaw 45), so the FAR walls are +z (back) + +x (right) and the NEAR walls are −x (left) + −z (front). The front was already open; this also omits the **−x/left wall** (+ its pilasters + coursing) via `cutNear=true`, so the room opens toward the camera. Plus a no-ceiling guard tripwire.

## Proven

`renders/m1_combat_cutnear.png` — live combat on the cut-near crypt: the floor is **fully open and visible**, both actors stand clearly in the room with their rings, generous clear pathing space, the carved-relief back-walls framing it. `renders/OCCLUSION_before_after.png` (walled vs cut-near).

## Invariants

Walls stay authored in the `scene_grid` as `impassable_cells` for PATHING — only the VISUAL wall mesh is omitted. Engine = SOLE WRITER unchanged; this is purely a render-time visibility decision.

## Context

This is Sprint 1 of a researched plan (an ultracode workflow grounded the decisions in real iso-CRPGs). Next sprints (separate PRs): door-zone/protected-lane schema + a pathing validator (the "no props blocking the path" fix), multi-room-unit composition (the "rooms feel crunched" fix is prop-density + margin, not raw grid size), and regional ControlNet conditioning (the stray-item fix). The transparency-on-approach layer is explicitly deferred until a near-side PROP (not a wall) is observed occluding an actor.