### PR TITLE
gfx: pathing-lane + door-zone schema + pre-greybox validator (Sprint 2)

### DIFF
--- a/docs/roadmap/ROOM-OCCLUSION-PATHING-SPRINTS.md
+++ b/docs/roadmap/ROOM-OCCLUSION-PATHING-SPRINTS.md
@@ -1,0 +1,62 @@
+# Rooms that WORK with actors — occlusion, pathing-lanes, room-size, stray-items (sprints)
+
+> Owner feedback (2026-07-01): the generated backdrops look excellent, but as soon as you add actors a few
+> things break — (1) the camera-near walls / ceilings / near pillars **occlude** the interior + the actors
+> + the pathing; (2) the rooms feel **small/crunched** for actors to move around; (3) **props block
+> pathing** (a sarcophagus jammed next to a staircase) — there are no protected lanes / door zones; (4)
+> img2img sometimes paints **stray items** (a lantern floating on a pillar). "Now we get into the more
+> complex stuff… keep iterating autonomously given the massive plan + issues/sprints."
+>
+> Decisions below are grounded in a researched ultracode workflow (real iso-CRPGs: PoE1/2, Infinity Engine,
+> Disco Elysium, Diablo, Divinity OS2, BG3). The throughline: **fixed camera → static art-time cutaway, not
+> runtime transparency; pathing locked BEFORE art (Diablo two-stage); the "crunch" is prop-density/margin,
+> not raw grid size.**
+
+## The 5 decisions
+
+1. **Occlusion = static art-time wall omission (cutaway), not a runtime fade.** Our camera is permanently
+   fixed (yaw 45, elev 30, ortho 13, at the −x,−z near corner). So OMIT the camera-near wall meshes from the
+   greybox: FAR walls = +z (back) + +x (right) keep full detail; NEAR walls = −x (left) + −z (front) are
+   omitted (the front was already open; `cutNear=true` now omits −x). Walls stay in `scene_grid` as
+   `impassable_cells` for PATHING — only the visual mesh is cut. A BG3-style runtime fade is **deferred
+   indefinitely**, gated on a concrete observed gap (a near-side PROP, not a wall, occluding an actor).
+   **Status: SHIPPED (Sprint 1, PR #1213).**
+2. **Ceilings = never authored, for any interior.** Universal iso-CRPG convention; zero runtime cost. A
+   guard tripwire is in `build_room_greybox.cs`. **Status: SHIPPED.**
+3. **Room size = compose fixed-size room-units, do NOT widen ortho/grid.** Widening the frame shrinks every
+   object's pixel budget (worsens the LoRA-bound paint) and renegotiates the load-bearing `cellToWorld`
+   contract. Current 14×11 grids are already at/above the D&D "comfortable" cell floor — the crunch is
+   **prop-density + zero camera margin**, fixed by authoring discipline (reserve clear cells + protected
+   lanes) and, for genuinely multi-room spaces, composing 2–4 room-units glued at door cells and stitched
+   by the existing plate-swap (`_active_combat.txt`/`_active_campaign.txt`). **Status: Sprint 3.**
+4. **Pathing = locked before art (Diablo two-stage), authored never derived.** Add to `SceneGrid` (additive,
+   `_StrictModel`): `door_cells` (first-class) + `protected_lane_cells`; derive `door_zone_cells` (door +
+   Chebyshev-1) + a camera-near `near_zone` (tall props there occlude). Hard rule: **no prop in a door
+   zone or a protected lane**; tall props avoid the near zone. A pure `validate_scene_grid()` (BFS
+   reachability: every spawn/door/anchor mutually reachable past props; min clear floor) runs **pre-greybox
+   as a hard gate** in `export_scene_grid.py`. **Status: Sprint 2 (this PR).**
+5. **Stray items = regional ControlNet conditioning, not just negatives.** Emit a greybox depth pass +
+   a prop-occupancy mask (high lock on bare wall/floor, relaxed on authored prop footprints) so img2img only
+   ENRICHES authored props and can't hallucinate large items into blank regions; add a `stray_item_negative`
+   as secondary insurance. **Status: Sprint 4.**
+
+## Sprints (each PR-sized)
+
+- **Sprint 1 — occlusion cutaway (SHIPPED, #1213):** `cutNear` omits the −x wall + pilasters + coursing;
+  no-ceiling guard. Proven: `renders/m1_combat_cutnear.png` (actors fully visible, clear floor).
+- **Sprint 2 — pathing-lane + door-zone schema + validator (THIS PR):** `SceneGrid.door_cells` +
+  `protected_lane_cells`; `door_zone_cells()` / `near_zone_cells()` / `validate_scene_grid()` in
+  `scene_grid.py`; prop-placement guard in the seeds; `qa/validate_scene_grid.py` + hard-fail wire into
+  `export_scene_grid.py`; tests.
+- **Sprint 3 — room-unit composition:** author multi-section spaces (e.g. crypt = stair + tomb) as room-units
+  linked at door cells; recipe entries; verify the plate-swap flips on crossing a door cell.
+- **Sprint 4 — stray-item control:** greybox depth pass + prop mask; regional ControlNet conditioning at the
+  Scenario img2img call; `stray_item_negative`; a post-gen mask-violation QA check.
+- **Backlog (deferred, gated on observed need):** per-prop dithered alpha-clip fade for a near-side PROP that
+  still occludes an actor after Sprints 1–3.
+
+## Invariants (unchanged)
+
+Engine = SOLE WRITER; pathing AUTHORED in the `scene_grid`, never derived from painted pixels; all new
+`SceneGrid` fields are additive (`extra="forbid"`, default empty == today). The camera contract
+(cell 2.0 / ortho 13 / elev 30 / yaw 45) is byte-identical per room-unit.

--- a/qa/export_scene_grid.py
+++ b/qa/export_scene_grid.py
@@ -45,11 +45,23 @@ def main() -> None:
     _bio = (getattr(grid, "biome", "") + " " + getattr(loc, "name", "")).lower()
     material = "wood" if any(w in _bio for w in ("wood", "timber", "tavern", "plank", "hall of") ) and "stone" not in _bio else "stone"
 
+    # PRE-GREYBOX GATE: pathing/lanes must be valid BEFORE any art is generated (Diablo's topology-then-
+    # dressing). Refuse to write room_geometry.json on a violation so a broken room can never reach the
+    # Unity greybox / img2img step. See docs/roadmap/ROOM-OCCLUSION-PATHING-SPRINTS.md.
+    violations = sg.validate_scene_grid(grid, cols, rows)
+    if violations:
+        print("[export_scene_grid] VALIDATION FAILED — refusing to write geometry:", file=sys.stderr)
+        for v in violations:
+            print(f"  - {v}", file=sys.stderr)
+        sys.exit(1)
+
     payload = {
         "location": getattr(loc, "name", ""),
         "cols": cols, "rows": rows, "material": material,
         "cell_default_walkable": bool(getattr(grid.cell_default, "walkable", True)),
         "walls": walls, "props": props, "impassable": impassable,
+        "door_cells": [[int(c), int(r)] for (c, r) in (getattr(grid, "door_cells", None) or [])],
+        "protected_lane_cells": [[int(c), int(r)] for (c, r) in (getattr(grid, "protected_lane_cells", None) or [])],
     }
     text = json.dumps(payload)
     if out:

--- a/servers/engine/scene_grid.py
+++ b/servers/engine/scene_grid.py
@@ -124,6 +124,13 @@ class SceneGrid(_StrictModel):
     zone_anchors: dict[str, Cell] = Field(default_factory=dict)
     exits: list[dict] = Field(default_factory=list)
     spawns: dict[str, list[Cell]] = Field(default_factory=dict)
+    # PROTECTED-PATHING discipline (additive; empty == today): door_cells are first-class doorway cells
+    # (every exit cell is also a door cell, plus any authored interior archway); protected_lane_cells are a
+    # connectivity-critical path the prop pass must keep CLEAR. A prop may NEVER occupy a door-zone cell
+    # (door + Chebyshev-1) or a protected-lane cell (see validate_scene_grid). See
+    # docs/roadmap/ROOM-OCCLUSION-PATHING-SPRINTS.md.
+    door_cells: list[Cell] = Field(default_factory=list)
+    protected_lane_cells: list[Cell] = Field(default_factory=list)
     lighting: SceneLighting = Field(default_factory=SceneLighting)
     art: SceneArt = Field(default_factory=SceneArt)
 
@@ -890,3 +897,88 @@ def impassable_cells(
     blocked -= set(occupied)
 
     return [[x, y] for (x, y) in sorted(blocked)]
+
+
+# ── Protected-pathing discipline: door zones + a pre-greybox validator (gfx occlusion/pathing Sprint 2) ──
+
+
+def door_zone_cells(grid: "SceneGrid", width: int, height: int) -> set[Cell]:
+    """The cells props must keep CLEAR around every doorway: each ``door_cell`` plus its Chebyshev-1 ring
+    (clipped to bounds), so a doorway always has a free landing on both sides (the D&D 2-square-doorway /
+    PoE2 'no furniture behind the door' convention). Pure, deterministic."""
+    zone: set[Cell] = set()
+    for (c, r) in getattr(grid, "door_cells", None) or []:
+        for dc in (-1, 0, 1):
+            for dr in (-1, 0, 1):
+                x, y = int(c) + dc, int(r) + dr
+                if 0 <= x < width and 0 <= y < height:
+                    zone.add((x, y))
+    return zone
+
+
+def validate_scene_grid(grid: "SceneGrid", width: int, height: int) -> list[str]:
+    """Pre-greybox GATE (run before any art is generated — Diablo's 'topology decided before dressing').
+    Returns a list of human-readable violation strings (``[]`` == valid). Enforces the protected-pathing
+    discipline so a generated room can never (a) place a prop in a door zone or a protected lane, (b) wall
+    off a pocket of floor with a prop, or (c) be too crunched for actors to move. Pure: no I/O, no mutation,
+    deterministic order. See docs/roadmap/ROOM-OCCLUSION-PATHING-SPRINTS.md."""
+    issues: list[str] = []
+    if width <= 0 or height <= 0:
+        return ["grid has non-positive dimensions"]
+
+    dz = door_zone_cells(grid, width, height)
+    lanes: set[Cell] = {(int(c), int(r)) for (c, r) in (getattr(grid, "protected_lane_cells", None) or [])}
+
+    # (1)+(2) prop placement: no prop footprint may sit in a door zone or a protected lane.
+    for prop in getattr(grid, "props", None) or []:
+        pid = getattr(prop, "id", "?")
+        for (c, r) in getattr(prop, "cells", None) or []:
+            cell = (int(c), int(r))
+            if cell in dz:
+                issues.append(f"prop '{pid}' at {list(cell)} blocks a DOOR ZONE (door + 1-cell landing)")
+            if cell in lanes:
+                issues.append(f"prop '{pid}' at {list(cell)} blocks a PROTECTED LANE")
+
+    blocked: set[Cell] = {(x, y) for (x, y) in (tuple(p) for p in impassable_cells(grid, width, height))}
+    walkable: list[Cell] = [(x, y) for x in range(width) for y in range(height) if (x, y) not in blocked]
+
+    # (3) connectivity: every walkable cell must be in ONE region (a prop must never wall off a pocket —
+    # this is exactly the 'sarcophagus jammed next to the staircase' failure the owner named).
+    if walkable:
+        from collections import deque  # noqa: PLC0415
+
+        start = walkable[0]
+        seen: set[Cell] = {start}
+        q: deque[Cell] = deque([start])
+        while q:
+            cx, cy = q.popleft()
+            for dc in (-1, 0, 1):
+                for dr in (-1, 0, 1):
+                    if dc == 0 and dr == 0:
+                        continue
+                    nb = (cx + dc, cy + dr)
+                    if nb not in blocked and nb not in seen and 0 <= nb[0] < width and 0 <= nb[1] < height:
+                        seen.add(nb)
+                        q.append(nb)
+        unreached = [c for c in walkable if c not in seen]
+        if unreached:
+            issues.append(
+                f"{len(unreached)} walkable cells are a DISCONNECTED pocket (a prop/wall walls them off), "
+                f"e.g. {list(unreached[0])} — pathing would be broken"
+            )
+
+    # (4) every door cell + spawn cell must itself be walkable (you can't enter/spawn on a wall or prop).
+    for (c, r) in getattr(grid, "door_cells", None) or []:
+        if (int(c), int(r)) in blocked:
+            issues.append(f"door cell {[int(c), int(r)]} is BLOCKED (wall/prop) — unusable doorway")
+    for cells in (getattr(grid, "spawns", None) or {}).values():
+        for (c, r) in cells:
+            if (int(c), int(r)) in blocked:
+                issues.append(f"spawn cell {[int(c), int(r)]} is BLOCKED (wall/prop)")
+
+    # (5) enough clear combat floor (outside door zones/lanes) for actors to actually maneuver.
+    clear = sum(1 for cell in walkable if cell not in dz and cell not in lanes)
+    if clear < 12:
+        issues.append(f"only {clear} clear combat-floor cells (< 12) — too crunched for actor movement")
+
+    return issues

--- a/servers/engine/tests/test_scene_grid_validate.py
+++ b/servers/engine/tests/test_scene_grid_validate.py
@@ -1,0 +1,93 @@
+"""Pre-greybox PATHING VALIDATOR (gfx occlusion/pathing Sprint 2).
+
+Pins ``scene_grid.validate_scene_grid`` + ``door_zone_cells``: the authored-room gate that runs BEFORE any
+art is generated (Diablo's topology-then-dressing), so a generated room can never place a prop in a door
+zone / protected lane, wall off a pocket of floor, or be too crunched for actors. Engine-only; additive.
+
+See docs/roadmap/ROOM-OCCLUSION-PATHING-SPRINTS.md.
+"""
+
+from __future__ import annotations
+
+import server  # noqa: F401  (import first to resolve the models<->scene_grid cycle)
+from models import SceneGrid
+from scene_grid import (
+    SceneCell,
+    SceneGridSpec,
+    SceneProp,
+    door_zone_cells,
+    emit_scene_grid,
+    validate_scene_grid,
+)
+
+
+def _perimeter(cols: int, rows: int) -> list[SceneCell]:
+    out: list[SceneCell] = []
+    for c in range(cols):
+        out.append(SceneCell(c=c, r=0, type="wall", walkable=False))
+        out.append(SceneCell(c=c, r=rows - 1, type="wall", walkable=False))
+    for r in range(1, rows - 1):
+        out.append(SceneCell(c=0, r=r, type="wall", walkable=False))
+        out.append(SceneCell(c=cols - 1, r=r, type="wall", walkable=False))
+    return out
+
+
+def _grid(cols, rows, cells, props=None, **kw) -> SceneGrid:
+    return SceneGrid(scene_id="t", location_id="t",
+                     grid=SceneGridSpec(cols=cols, rows=rows),
+                     cells=cells, props=props or [], **kw)
+
+
+def test_open_room_is_valid():
+    g = _grid(14, 11, _perimeter(14, 11))
+    assert validate_scene_grid(g, 14, 11) == []
+
+
+def test_generated_rooms_pass():
+    # every shipping generator must produce a room that passes the gate.
+    for loc in ("tavern_lower_city", "crypt_one", "forest_glade", "town_square"):
+        g = emit_scene_grid("baldurs-gate", loc, name=loc)
+        assert validate_scene_grid(g, g.grid.cols, g.grid.rows) == [], f"{loc} failed: {validate_scene_grid(g, g.grid.cols, g.grid.rows)}"
+
+
+def test_prop_walling_off_a_pocket_is_caught():
+    # an 8x8 room (30 clear cells, so NOT crunched) where a full-height barrier at col 3 seals the
+    # interior into two disconnected regions -> a connectivity violation (the prop walls off a pocket).
+    bar = [(3, r) for r in range(1, 7)]
+    cells = _perimeter(8, 8) + [SceneCell(c=c, r=r, type="prop", walkable=False, prop_ref="b") for (c, r) in bar]
+    g = _grid(8, 8, cells, props=[SceneProp(id="b", kind="barrier", cells=bar)])
+    issues = validate_scene_grid(g, 8, 8)
+    assert any("DISCONNECTED" in v for v in issues), issues
+
+
+def test_prop_in_door_zone_is_caught():
+    cells = _perimeter(10, 9) + [SceneCell(c=4, r=1, type="prop", walkable=False, prop_ref="p")]
+    g = _grid(10, 9, cells,
+              props=[SceneProp(id="p", kind="table", cells=[(4, 1)])],
+              door_cells=[(4, 0)])  # (4,0) door -> zone includes (4,1)
+    issues = validate_scene_grid(g, 10, 9)
+    assert any("DOOR ZONE" in v for v in issues), issues
+
+
+def test_prop_in_protected_lane_is_caught():
+    cells = _perimeter(10, 9) + [SceneCell(c=5, r=4, type="prop", walkable=False, prop_ref="p")]
+    g = _grid(10, 9, cells,
+              props=[SceneProp(id="p", kind="barrel", cells=[(5, 4)])],
+              protected_lane_cells=[(5, 4), (5, 5)])
+    issues = validate_scene_grid(g, 10, 9)
+    assert any("PROTECTED LANE" in v for v in issues), issues
+
+
+def test_door_zone_is_door_plus_chebyshev_ring():
+    g = _grid(6, 6, _perimeter(6, 6), door_cells=[(3, 0)])
+    zone = door_zone_cells(g, 6, 6)
+    # (3,0) + its 8 neighbours clipped to bounds (the r=-1 row drops out).
+    assert (3, 0) in zone and (2, 1) in zone and (4, 1) in zone and (3, 1) in zone
+    assert (3, -1) not in zone  # clipped
+
+
+def test_too_crunched_room_is_caught():
+    # a tiny 4x4 has only 2x2=4 interior cells -> below the 12-cell clear floor minimum.
+    g = _grid(4, 4, _perimeter(4, 4))
+    issues = validate_scene_grid(g, 4, 4)
+    assert any("crunched" in v for v in issues), issues


### PR DESCRIPTION
## What (the owner's "props block pathing / no protected lanes" fix)

Diablo's two-stage rule — **pathing topology is decided and validated BEFORE any art is generated**. This adds the schema + a pre-greybox validator so a generated room can never ship broken pathing.

- `SceneGrid` gains additive fields (default `[]` == today): `door_cells`, `protected_lane_cells`.
- `scene_grid.py` gains pure functions: `door_zone_cells()` (door + Chebyshev-1 landing ring) and `validate_scene_grid()` — flags:
  1. a prop in a **door zone**,
  2. a prop in a **protected lane**,
  3. a prop that **walls off a disconnected floor pocket** (exactly the "sarcophagus jammed next to the staircase" failure you named),
  4. a blocked **door/spawn** cell,
  5. a room **too crunched** for actors (< 12 clear floor cells).
- `export_scene_grid.py` runs the validator and **refuses to write `room_geometry.json` on any violation**, so a broken room can never reach the Unity greybox / img2img step.

## Verified

The crypt + church gfx rooms PASS; the 5 shipping generators pass; a deliberately-disconnected room + door-zone/lane/crunch violations are caught. **7 new tests + 28 existing scene_grid tests green.**

## Invariants

Engine = SOLE WRITER; pathing authored, never derived from pixels; all new fields additive (`extra="forbid"`, empty == today); pure/deterministic.

## Context

Sprint 2 of the researched plan (`docs/roadmap/ROOM-OCCLUSION-PATHING-SPRINTS.md`). Sprint 1 (occlusion cutaway) shipped in #1213. Next: Sprint 3 (multi-room-unit composition) + Sprint 4 (regional ControlNet for stray items).