### PR TITLE
gfx: keep tall occluder columns out of the camera-near zone (occlusion dev-start)

### DIFF
--- a/qa/seed_gfx_bosshall.py
+++ b/qa/seed_gfx_bosshall.py
@@ -20,7 +20,10 @@ import sys
 
 CID = "camp_gfxbosshall01"
 GRID_W, GRID_H = 14, 11
-COLUMNS = [[4, 4], [9, 4], [4, 7], [9, 7]]   # two rows flanking the central aisle (cols 5-8)
+# NEAR-ZONE OCCLUSION RULE (occlusion-sprint dev-start): tall columns stay in the BACK HALF (r<=5) so
+# the near approach (r>=6, where the hero enters at r=9) is clear of foreground occluders — the front
+# colonnade pair pulled from r=7 to r=5. See qa/seed_gfx_church.py for the rule rationale.
+COLUMNS = [[4, 3], [9, 3], [4, 5], [9, 5]]   # two rows flanking the central aisle (cols 5-8), back half
 DAIS = [[6, 1], [7, 1], [6, 2], [7, 2]]      # a raised 2x2 throne dais at the back-center
 OBSTACLES = COLUMNS + DAIS
 HERO_CELL = [6, 9]    # hall entrance

--- a/qa/seed_gfx_church.py
+++ b/qa/seed_gfx_church.py
@@ -22,7 +22,13 @@ import sys
 CID = "camp_gfxchurch01"
 GRID_W, GRID_H = 14, 11
 # a church nave: two rows of flanking COLUMNS + a 2-cell ALTAR at the back-center apse == the obstacles.
-COLUMNS = [[3, 3], [10, 3], [3, 7], [10, 7]]
+# NEAR-ZONE OCCLUSION RULE (the occlusion-sprint dev-start, owner 2026-07-01): tall occluder props
+# (columns/pillars) stay in the BACK HALF (r <= 5 on an 11-row grid) so the camera-near third (r>=6,
+# where actors enter + fight) is never occluded by a foreground column. The cut-near WALL (build_room_
+# greybox.cs cutNear) handles the near walls; this keeps tall INTERIOR props out of the near band too
+# (the per-prop "see-through on approach" fade is the deferred Phase-2 layer). So the front colonnade
+# pair is pulled from r=7 to r=5 — a 2-row colonnade in the mid/back nave, open near approach.
+COLUMNS = [[3, 3], [10, 3], [3, 5], [10, 5]]
 ALTAR = [[6, 1], [7, 1]]
 OBSTACLES = COLUMNS + ALTAR
 HERO_CELL = [6, 8]   # entrance end of the nave


### PR DESCRIPTION
## What
The cut-near WALL (#1213) opened the near walls so the camera sees the interior, but the **church + throne-hall** seeds still placed a flanking column pair at **r=7** — inside the camera-near band (actors enter at r=9). A re-render confirmed the owner's note: a **foreground column occludes the playfield** (the "church near-left pillars" case).

## Fix — the near-zone authoring rule (Sprint-1 completion)
The owner offered two options for near pillars: *see-through on approach* (a per-prop fade) **or** *"don't generate pillars there."* The fade is the deferred **Phase-2** layer; this PR ships the cheap dev-start: **tall occluder props stay in the BACK HALF (r ≤ 5 on an 11-row grid)** so the near third — where actors enter + fight — is never occluded by a foreground column.

- `seed_gfx_church.py`: front colonnade `r=7 → r=5`
- `seed_gfx_bosshall.py`: front colonnade `r=7 → r=5`
- crypt (`r=3`) + tavern (tall posts `r=4`) already comply — unchanged.

## Proof
- `church_greybox_nearzone.png` — the near foreground is now **open floor** (was a dominant front-left column).
- throne hall re-exports clean: 54 impassable, 5 props, no collision.

Part of the occlusion/pathing sprints (#1215). Content-only (seed authoring); engine = sole writer, no schema change.