### PR TITLE
docs: occlusion model in CANONICAL.md + sprint-status update

### DIFF
--- a/docs/roadmap/ROOM-OCCLUSION-PATHING-SPRINTS.md
+++ b/docs/roadmap/ROOM-OCCLUSION-PATHING-SPRINTS.md
@@ -44,16 +44,25 @@
 
 - **Sprint 1 — occlusion cutaway (SHIPPED, #1213):** `cutNear` omits the −x wall + pilasters + coursing;
   no-ceiling guard. Proven: `renders/m1_combat_cutnear.png` (actors fully visible, clear floor).
-- **Sprint 2 — pathing-lane + door-zone schema + validator (THIS PR):** `SceneGrid.door_cells` +
-  `protected_lane_cells`; `door_zone_cells()` / `near_zone_cells()` / `validate_scene_grid()` in
-  `scene_grid.py`; prop-placement guard in the seeds; `qa/validate_scene_grid.py` + hard-fail wire into
-  `export_scene_grid.py`; tests.
-- **Sprint 3 — room-unit composition:** author multi-section spaces (e.g. crypt = stair + tomb) as room-units
-  linked at door cells; recipe entries; verify the plate-swap flips on crossing a door cell.
-- **Sprint 4 — stray-item control:** greybox depth pass + prop mask; regional ControlNet conditioning at the
-  Scenario img2img call; `stray_item_negative`; a post-gen mask-violation QA check.
+- **Sprint 1b — near-zone tall-prop rule (SHIPPED, #1219):** the cut-near handles the near WALL; tall
+  INTERIOR props (columns) in the camera-near band still occluded (the owner's "church near-left pillars",
+  verified on a re-render). Dev-start fix (the owner's "don't generate pillars there" — the per-prop fade
+  is the deferred Phase-2 layer): tall occluder props stay in the BACK HALF (r ≤ 5). Church + throne
+  colonnade pulled r=7→r=5. Proven painted: `renders/church_nearzone_stray_v{1,2}.png` (open foreground).
+- **Sprint 2 — pathing-lane + door-zone schema + validator (SHIPPED, #1214):** `SceneGrid.door_cells` +
+  `protected_lane_cells`; `door_zone_cells()` / `validate_scene_grid()` in `scene_grid.py` (no prop in a
+  door zone/lane, no disconnected floor pocket, no crunch); hard-fail wired into `export_scene_grid.py`;
+  `test_scene_grid_validate.py`.
+- **Sprint 3 — room-unit composition (OPEN, #1217):** author multi-section spaces (e.g. crypt = stair + tomb)
+  as room-units linked at door cells; recipe entries; verify the plate-swap flips on crossing a door cell.
+  NOTE: current single rooms already read SPACIOUS post-occlusion-fix (see church renders) — the crunch was
+  largely the near walls/pillars closing in the view; composition is for genuinely bigger multi-feature spaces.
+- **Sprint 4 — stray-item control (OPEN, #1218):** `stray_item_negative` SHIPPED (#1220 — suppresses
+  img2img-invented props like the lantern-on-a-pillar; proven no over-suppression on church renders);
+  REMAINING: greybox depth pass + prop-occupancy mask + regional conditioning so img2img only ENRICHES
+  authored props (note: our pipeline is img2img not controlnet — validate the regional-conditioning fit).
 - **Backlog (deferred, gated on observed need):** per-prop dithered alpha-clip fade for a near-side PROP that
-  still occludes an actor after Sprints 1–3.
+  still occludes an actor after the back-half rule (the owner's "transparency when you walk around them").
 
 ## Invariants (unchanged)
 

--- a/extensions/renderers/unity/CANONICAL.md
+++ b/extensions/renderers/unity/CANONICAL.md
@@ -11,6 +11,20 @@ Dimetric, orthographic, **elevation 30°** (asin .5 = true 2:1), **yaw 45** corn
 **cell_size 2.0**, **ortho_size 13**, grid **14×11**. `cellToWorld(c,r) = ((c-6.5)*2.0, 0, (5.0-r)*2.0)`.
 (The 06-23 `TavernTier1` used cell 5 / 14×10 — **DEPRECATED contract**; do not reuse it.)
 
+## Occlusion model (load-bearing — the room must work WITH actors; owner 2026-07-01)
+The camera is permanently fixed, so occlusion is solved at ART TIME by CUTAWAY, not a runtime fade.
+Camera sits at the **−x,−z near corner** → the near occluders are the **−x (left) + front** walls.
+- **CUT the near walls + NEVER build a ceiling.** `build_room_greybox.cs` `cutNear=true` omits WallLeft +
+  PilLeft + CrsLeftH; the +z/+x FAR walls stay as the backdrop. No roof geometry, ever, for interiors.
+  PROVEN: live combat with actors fully visible on open floor (`renders/m1_combat_cutnear.png`). [#1213]
+- **Keep tall INTERIOR occluder props (columns/pillars) in the BACK HALF (r ≤ 5 on an 11-row grid)** so
+  the camera-near third — where actors enter (r≈8-9) + fight — is never occluded by a foreground column.
+  Authored in the seeds (`seed_gfx_church.py`/`seed_gfx_bosshall.py` colonnade pulled r=7→r=5). PROVEN
+  in the painted output (`renders/church_nearzone_stray_v{1,2}.png` — open foreground). [#1219]
+- **DEFERRED Phase-2:** a per-prop "see-through on approach" alpha-clip fade, for any near-side PROP that
+  still occludes after the above (the owner's "sometimes the walls have transparency when you walk around
+  them"). Not built — only needed if a near interior prop is observed occluding despite the back-half rule.
+
 ## Current-best per surface (2026-06-28)
 | Surface | CURRENT-BEST asset | Build script | Best capture / score | Status |
 |---|---|---|---|---|


### PR DESCRIPTION
Records the occlusion model (cut-near walls + no ceiling + tall-props-back-half; per-prop fade deferred) as a load-bearing CANONICAL.md section, and marks Sprint 1b/2/4 shipped with proof renders. Docs-only. Part of #1215.