### PR TITLE
gfx: live door-crossing room transition (Sprint 3 / M-E scene gate) — PROVEN

### DIFF
--- a/qa/drive_room_transition.py
+++ b/qa/drive_room_transition.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""drive_room_transition.py — the LIVE door-crossing transition (occlusion/pathing Sprint 3, M-E scene gate).
+
+Drives the party from the STAIR room-unit to the TOMB room-unit of the 2-room crypt
+(qa/seed_gfx_crypt_2room.py):
+
+  win the stair fight -> end_combat -> travel_to(Crypt Tomb)  [engine co-locates the whole party]
+  -> a NEW fight in the tomb (a skeleton ambush) -> place the cast on the tomb's OWN authored pathing.
+
+The renderer is then pointed at the tomb plate (deploy_room.sh crypt2room_tomb.png) and re-run, so the
+SAME hero renders in the tomb unit. transition_00_stair.png vs transition_01_tomb.png IS the live room
+transition — one campaign, two linked room-units, the party crossing the shared (6,0) doorway.
+
+  WORLDOS_STATE_DIR=<sd> uv run --directory servers/engine python "$PWD/qa/drive_room_transition.py" <sd>
+
+Engine = SOLE WRITER (mutates only via server.*). One-source pathing: the tomb obstacles are the tomb
+scene_grid's impassable_cells (NOT re-derived from pixels).
+"""
+import json
+import os
+import sys
+
+CID = "camp_gfxcrypt2room01"
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("usage: drive_room_transition.py <state_dir>", file=sys.stderr)
+        sys.exit(2)
+    sd = sys.argv[1]
+    os.environ["WORLDOS_STATE_DIR"] = sd
+    sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "servers", "engine"))
+    import server  # noqa: PLC0415
+    from scene_grid import impassable_cells  # noqa: PLC0415
+
+    c = server._require(CID)
+    tomb = next(loc for loc in c.locations.values() if loc.name == "Crypt Tomb")
+    tomb_id = tomb.id
+    hero_id = next(cid for cid, ch in c.characters.items() if getattr(ch, "kind", "") == "player")
+
+    # 1) the stair fight is won -> end combat (so the party can travel).
+    if c.combat.active:
+        server.end_combat(CID, resolution="The party cuts down the goblin in the stair hall.")
+
+    # 2) CROSS THE DOORWAY: travel to the linked tomb unit. travel_to co-locates the whole party
+    #    (current_location_id + each member's location_id) — the engine half of the room transition.
+    tr = server.travel_to(CID, tomb_id)
+
+    # 3) a NEW encounter in the tomb: a skeleton rises from the sarcophagus -> a fresh fight.
+    sk = server.spawn_monster(CID, name="Skeleton", count=1)
+    skel_id = sk["spawned"][0]["id"]
+    server.start_combat(CID, [hero_id, skel_id], surpriser_ids=[skel_id])
+
+    # 4) place the cast on the TOMB's OWN authored pathing (one source: the tomb scene_grid).
+    c = server._require(CID)
+    tomb = c.locations[tomb_id]
+    imp = impassable_cells(tomb.scene_grid, 14, 11)
+    server.set_grid(CID, width=14, height=11, obstacles=imp)
+    server.place_combatant_at_coords(CID, hero_id, 6, 9)   # hero enters at the tomb mouth
+    server.place_combatant_at_coords(CID, skel_id, 6, 5)   # skeleton mid-tomb
+
+    print(json.dumps({
+        "crossed_to": tomb.name, "current_location": c.current_location_id, "is_tomb": c.current_location_id == tomb_id,
+        "hero": hero_id, "skeleton": skel_id, "tomb_impassable": len(imp),
+        "party_relocated": tr.get("party_relocated"), "combat_active": c.combat.active,
+    }))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What — the live room transition works end-to-end
The party crosses from the **stair** room-unit to the linked **tomb** room-unit of the 2-room crypt (#1222's `seed_gfx_crypt_2room.py`):

```
[Crypt Stair fight]  --end_combat--> --travel_to(Crypt Tomb)--> [Crypt Tomb fight]
   hero + goblin            engine co-locates the party            same hero + skeleton
```

`qa/drive_room_transition.py` drives it; then the renderer is pointed at the tomb plate (`deploy_room.sh`) and re-run, so the **same hero (Aldric)** renders in the tomb. One campaign, two linked room-units (`Location.connections`), the party crossing the shared (6,0) doorway, the room-agnostic renderer following via the plate-swap. Engine = sole writer; one-source pathing (tomb obstacles = the tomb scene_grid's `impassable_cells`).

## Proof
- `transition_00_stair.png` — hero + goblin in the stair hall (descending stairs + arched doorways)
- `transition_01_tomb.png` — the **same hero** + a skeleton in the tomb chamber (sarcophagus + pillars + figural relief)
- `TRANSITION_stair_to_tomb.png` — before/after montage

## Findings (this live run surfaced these, per the owner's "discover bugs + improve workflows")
1. **Viewer re-read** — the viewer needed a restart to pick up the post-travel state; a smoother live loop wants the viewer to re-read `snapshot.json` per `/combat-surface` request. *(Next increment.)*
2. **Player-triggered crossing** — the transition is currently scripted; the real game flow is the party *reaching the door cell* auto-travelling to the connected room. *(The meaningful M-E next step.)*
3. Skeleton rendered as the default monster template (no skeleton model) — asset-registry default-on-miss, placeholder-OK.
4. `crypt_stair` painted stairs across the whole floor (walkable flavor, pathing-fine) — a recipe/obstacle visual decoupling note.

QA tooling (a new driver); engine = sole writer, no engine change. Part of #1217.