### PR TITLE
gfx: surface doorway cells + destination in combat-surface (M-E player-triggered crossing)

### DIFF
--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3281,6 +3281,39 @@ def _combat_turn_token(snapshot: dict) -> str:
     return f"{rnd}:{ti}:{cur}"
 
 
+def _combat_doors(snapshot: dict) -> list[dict]:
+    """The current location's authored DOORWAY cells + their destination room-unit, so the renderer/UI
+    can mark a doorway and offer to cross into the linked room (the player-triggered room transition).
+
+    ADDITIVE / presentation-only: READS engine-owned ``scene_grid.door_cells`` (the #1214 schema) +
+    ``Location.connections`` (the engine is the sole writer); never mutates. ``[]`` when the location has
+    no door cells or no connections (== today). Each entry: ``{cell:[c,r], to:<loc_id>, toName, multi}``.
+    For a single-connection room-unit (the common case) every door cell leads to the one neighbour; a
+    multi-connection room would need an authored door->destination map, so ``multi=true`` flags the
+    ambiguity and the FIRST connection is surfaced as a best-effort default."""
+    loc_id = _text(snapshot.get("current_location_id"))
+    locs = snapshot.get("locations")
+    loc = locs.get(loc_id) if isinstance(locs, dict) and loc_id else None
+    if not isinstance(loc, dict):
+        return []
+    sg = loc.get("scene_grid")
+    door_cells = sg.get("door_cells") if isinstance(sg, dict) else None
+    if not isinstance(door_cells, list) or not door_cells:
+        return []
+    conns = [cid for cid in (loc.get("connections") or []) if isinstance(cid, str)]
+    if not conns:
+        return []
+    dest_id = conns[0]
+    dest = locs.get(dest_id) if isinstance(locs, dict) else None
+    dest_name = _text(dest.get("name")) if isinstance(dest, dict) else ""
+    out: list[dict] = []
+    for cell in door_cells:
+        if isinstance(cell, (list, tuple)) and len(cell) == 2:
+            out.append({"cell": [int(cell[0]), int(cell[1])], "to": dest_id,
+                        "toName": dest_name, "multi": len(conns) > 1})
+    return out
+
+
 def build_combat_surface(
     snapshot: dict,
     *,
@@ -3351,6 +3384,9 @@ def build_combat_surface(
         # read-only renderer can draw the detour around walls/props. Presentation-only; [] == none.
         "lastPath": (snapshot.get("combat") or {}).get("last_move_path") or [],
         "impassable": (snapshot.get("combat") or {}).get("grid_impassable") or [],
+        # M-E room transition: the authored doorway cells + their destination room-unit, so the renderer
+        # can mark the doorway and the UI can offer to cross. [] == no doors/connections (today's shape).
+        "doors": _combat_doors(snapshot),
         "tokens": tokens,
         "initiative": initiative,
         "zones": zones,

--- a/viewer/tests/test_combat_grid_scene_grid.py
+++ b/viewer/tests/test_combat_grid_scene_grid.py
@@ -91,5 +91,47 @@ class SceneGridBoardTests(unittest.TestCase):
         self.assertNotIn("cellDefault", grid)
 
 
+class CombatDoorsTests(unittest.TestCase):
+    """M-E room transition: build_combat_surface surfaces the current location's authored doorway
+    cells + their destination room-unit (scene_grid.door_cells x Location.connections)."""
+
+    def test_doors_empty_without_door_cells(self):
+        snap = {"current_location_id": "loc1",
+                "locations": {"loc1": {"name": "A", "connections": ["loc2"],
+                                       "scene_grid": {"grid": {"cols": 14, "rows": 11}}},
+                              "loc2": {"name": "B"}}}
+        self.assertEqual(_surface(snap)["doors"], [])
+
+    def test_doors_empty_without_connections(self):
+        snap = {"current_location_id": "loc1",
+                "locations": {"loc1": {"name": "Isolated",
+                                       "scene_grid": {"grid": {"cols": 14, "rows": 11}, "door_cells": [[6, 0]]}}}}
+        self.assertEqual(_surface(snap)["doors"], [])
+
+    def test_surfaces_door_cell_with_destination(self):
+        snap = {"current_location_id": "loc1",
+                "locations": {
+                    "loc1": {"name": "Crypt Stair", "connections": ["loc2"],
+                             "scene_grid": {"grid": {"cols": 14, "rows": 11}, "door_cells": [[6, 0]]}},
+                    "loc2": {"name": "Crypt Tomb", "connections": ["loc1"]}}}
+        doors = _surface(snap)["doors"]
+        self.assertEqual(len(doors), 1)
+        self.assertEqual(doors[0]["cell"], [6, 0])
+        self.assertEqual(doors[0]["to"], "loc2")
+        self.assertEqual(doors[0]["toName"], "Crypt Tomb")
+        self.assertFalse(doors[0]["multi"])
+
+    def test_multi_connection_flags_ambiguity_and_surfaces_first(self):
+        snap = {"current_location_id": "loc1",
+                "locations": {
+                    "loc1": {"name": "Hub", "connections": ["loc2", "loc3"],
+                             "scene_grid": {"grid": {"cols": 14, "rows": 11}, "door_cells": [[6, 0]]}},
+                    "loc2": {"name": "North"}, "loc3": {"name": "East"}}}
+        doors = _surface(snap)["doors"]
+        self.assertEqual(len(doors), 1)
+        self.assertTrue(doors[0]["multi"])
+        self.assertEqual(doors[0]["to"], "loc2")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What
`build_combat_surface` now emits a **`doors`** field — the current location's `scene_grid.door_cells` (#1214 schema) × `Location.connections`:

```json
"doors": [{"cell": [6, 0], "to": "loc_…", "toName": "Crypt Stair", "multi": false}]
```

This is the **data foundation for the player-triggered room transition**: the renderer can mark the doorway, and the UI can offer to cross into the linked room-unit (instead of the scripted `drive_room_transition.py`). Proven live: in the Crypt Tomb the door (6,0) surfaces → "Crypt Stair".

Single-connection room-units (the common case) map every door to the one neighbour; a multi-connection room flags `multi=true` + surfaces the first connection (an authored door→destination map is the follow-up).

ADDITIVE / presentation-only — engine = sole writer, `[]` == today's shape. 4 tests in `test_combat_grid_scene_grid.py` (all green).

Next: the renderer doorway marker + the `cross` action (party at a door + room clear → `travel_to`). Part of #1217.