### PR TITLE
gfx: cross_door engine primitive (M-E player-triggered room crossing)

### DIFF
--- a/qa/drive_room_transition.py
+++ b/qa/drive_room_transition.py
@@ -42,9 +42,10 @@ def main() -> None:
     if c.combat.active:
         server.end_combat(CID, resolution="The party cuts down the goblin in the stair hall.")
 
-    # 2) CROSS THE DOORWAY: travel to the linked tomb unit. travel_to co-locates the whole party
-    #    (current_location_id + each member's location_id) — the engine half of the room transition.
-    tr = server.travel_to(CID, tomb_id)
+    # 2) CROSS THE DOORWAY via the authored door primitive: cross_door validates (6,0) is a door cell
+    #    of the current (stair) room + finds the linked unit from Location.connections, then travel_to
+    #    co-locates the whole party. (6,0) = the shared back-wall doorway authored in seed_gfx_crypt_2room.
+    tr = server.cross_door(CID, 6, 0)
 
     # 3) a NEW encounter in the tomb: a skeleton rises from the sarcophagus -> a fresh fight.
     sk = server.spawn_monster(CID, name="Skeleton", count=1)

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -1265,6 +1265,37 @@ def travel_to(campaign_id: str, destination_id: str = "", advance_time: bool = F
         return result
 
 
+def cross_door(campaign_id: str, x: int, y: int) -> dict:
+    """Cross an authored DOORWAY to the linked room-unit (M-E room transition).
+
+    ``(x, y)`` must be a ``door_cell`` of the current location's ``scene_grid`` (the #1214 schema);
+    the party then travels to the location's connected room-unit. A thin gameplay primitive over
+    ``travel_to`` (which holds the campaign lock + co-locates the whole party). For a single-connection
+    room-unit (the common case) the door leads to the one neighbour; a multi-connection room needs an
+    authored door->destination map, so the FIRST connection is taken as a best-effort default and
+    surfaced via ``multi_connection``.
+
+    The gameplay GATE (party is at the door, the room is resolved) is the caller's responsibility —
+    this verb does NOT force-end an active combat. Raises if (x,y) is not a doorway or there is no
+    connected room. Additive INTERNAL verb (NOT an MCP tool — protects the tool-schema budget), called
+    by the renderer/driver, mirroring ``place_combatant_at_coords``. Engine stays sole writer."""
+    c = _require(campaign_id)
+    loc = c.locations.get(c.current_location_id) if c.current_location_id else None
+    sg = getattr(loc, "scene_grid", None) if loc is not None else None
+    if sg is None:
+        raise ValueError("no current location with a scene_grid to cross from")
+    door_cells = {(int(a), int(b)) for (a, b) in (getattr(sg, "door_cells", None) or [])}
+    if (int(x), int(y)) not in door_cells:
+        raise ValueError(f"({x},{y}) is not a doorway cell of {getattr(loc, 'name', '')!r}")
+    conns = [cid for cid in (getattr(loc, "connections", None) or []) if isinstance(cid, str)]
+    if not conns:
+        raise ValueError(f"{getattr(loc, 'name', '')!r} has no connected room to cross to")
+    result = travel_to(campaign_id, conns[0])
+    result["crossed_door"] = [int(x), int(y)]
+    result["multi_connection"] = len(conns) > 1
+    return result
+
+
 # Class -> the 5e ability PRIORITY order (highest stat first) for the standard array.
 # The standard array is [15, 14, 13, 12, 10, 8]; we assign its values down this list, so
 # index 0 gets the 15, index 1 the 14, and so on. This is the canonical "what does a level-1

--- a/servers/engine/tests/test_cross_door.py
+++ b/servers/engine/tests/test_cross_door.py
@@ -1,0 +1,67 @@
+"""cross_door — the M-E room-transition gameplay primitive.
+
+server.cross_door(cid, x, y) crosses an authored doorway (a scene_grid.door_cell) to the linked
+room-unit (Location.connections), delegating the party move to travel_to. Additive INTERNAL verb.
+"""
+import pytest
+
+import server  # noqa: PLC0415  (conftest puts servers/engine on the path; import-first per the
+from scene_grid import SceneGrid, SceneGridSpec, SceneCellDefault  # models<->scene_grid circular note)
+
+
+def _author_grid(cid, loc_id, door_cells):
+    c = server._require(cid)
+    c.locations[loc_id].scene_grid = SceneGrid(
+        scene_id=f"{cid}:{loc_id}", location_id=loc_id, kind="dungeon", biome="test crypt",
+        grid=SceneGridSpec(cols=14, rows=11, cell_size_ft=5, projection="dimetric-2to1"),
+        cell_default=SceneCellDefault(type="floor", walkable=True, cost=1),
+        cells=[], props=[], door_cells=[tuple(d) for d in door_cells],
+    )
+    server.save_campaign(c)
+
+
+@pytest.fixture
+def two_room(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("cross-door")["id"]
+    a = server.add_location(campaign_id=cid, name="Room A", make_current=True)["id"]
+    b = server.add_location(campaign_id=cid, name="Room B", connections=[a])["id"]
+    _author_grid(cid, a, [[6, 0]])
+    return cid, a, b
+
+
+def test_cross_door_travels_to_the_connected_room(two_room):
+    cid, a, b = two_room
+    assert server._require(cid).current_location_id == a
+    res = server.cross_door(cid, 6, 0)
+    assert server._require(cid).current_location_id == b  # crossed into the linked unit
+    assert res["crossed_door"] == [6, 0]
+    assert res["multi_connection"] is False
+
+
+def test_cross_door_rejects_a_non_doorway_cell(two_room):
+    cid, a, b = two_room
+    with pytest.raises(ValueError):
+        server.cross_door(cid, 3, 3)
+    assert server._require(cid).current_location_id == a  # did not move
+
+
+def test_cross_door_raises_when_no_connected_room(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("isolated")["id"]
+    a = server.add_location(campaign_id=cid, name="Lonely", make_current=True)["id"]
+    _author_grid(cid, a, [[6, 0]])  # a door, but no connection
+    with pytest.raises(ValueError):
+        server.cross_door(cid, 6, 0)
+
+
+def test_cross_door_flags_multi_connection_and_takes_first(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("hub")["id"]
+    a = server.add_location(campaign_id=cid, name="Hub", make_current=True)["id"]
+    b = server.add_location(campaign_id=cid, name="North", connections=[a])["id"]
+    server.add_location(campaign_id=cid, name="East", connections=[a])
+    _author_grid(cid, a, [[6, 0]])
+    res = server.cross_door(cid, 6, 0)
+    assert res["multi_connection"] is True
+    assert server._require(cid).current_location_id == b  # best-effort: the first connection


### PR DESCRIPTION
Adds `server.cross_door(cid, x, y)` — cross an authored doorway (a `scene_grid.door_cell`, #1214) to the linked room-unit (`Location.connections`), delegating the party move to `travel_to`. The gameplay primitive behind the player-triggered transition (pairs with the doors-surface data in #1224). Additive INTERNAL verb (not an MCP tool — protects the tool-schema budget); raises on a non-doorway / no-connection; multi-connection rooms flag `multi_connection` + take the first. `drive_room_transition.py` now crosses via `cross_door(6,0)`. 4 tests. Verified end-to-end (stair→tomb). Part of #1217.