### PR TITLE
gfx: in-app player-triggered room crossing (cross_door intent + 'Cross' button) — M-E

### DIFF
--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -99,6 +99,8 @@ function ScreenCombat({ onNavigate, state }) {
   const zones = Array.isArray(surface?.zones) ? surface.zones : [];
   const battleLog = Array.isArray(surface?.battleLog) ? surface.battleLog : [];
   const encounter = surface?.encounter || { active: false, name: "No active encounter" };
+  // M-E room transition: authored doorways to linked room-units (door_cells x connections, server-surfaced).
+  const doors = Array.isArray(surface?.doors) ? surface.doors : [];
   // FIX A (combat scene backdrop): the servable scene scope the server projects on
   // the location block (`location:<id>`). Mirror the dialogue screen's sceneScope
   // fallback so an older surface without imageScope still resolves via location.id;
@@ -133,6 +135,27 @@ function ScreenCombat({ onNavigate, state }) {
     if (action.move?.name) return action.move.name;
     if (action.move?.kind) return action.move.kind;
     return action.available ? "ready" : "unavailable";
+  };
+
+  // M-E: cross an authored doorway to the linked room-unit. POSTs a cross_door intent (engine-resolved;
+  // the server gates on combat being RESOLVED). NOT gated on canAct — the cross happens AFTER the fight.
+  const crossDoor = async (door) => {
+    if (busyRef.current || !Array.isArray(door?.cell)) return;
+    busyRef.current = true;
+    try {
+      const response = await fetch("/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "cross_door", x: door.cell[0], y: door.cell[1], campaign: surface?.campaign_id || campaignId }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload.ok === false) throw new Error(payload.reason || `cross ${response.status}`);
+      await loadSurface();
+    } catch (error) {
+      toast({ kind: "danger", title: "Could not cross", body: error?.message || "The viewer could not reach /move." });
+    } finally {
+      busyRef.current = false;
+    }
   };
 
   const postMove = async (action) => {
@@ -268,7 +291,18 @@ function ScreenCombat({ onNavigate, state }) {
           {encounter.active ? (
             <CombatMap tokens={tokens} zones={zones} grid={surface?.grid} selected={selected?.id} onSelect={setSelectedToken} onCellMove={onCellMove} onAttack={onAttackToken} canAct={canAct} sceneScope={sceneScope} />
           ) : (
-            <CombatEmptyState status={surfaceStatus} onNavigate={onNavigate} />
+            <React.Fragment>
+              {doors.length ? (
+                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
+                  {doors.map((d, i) => (
+                    <BrassButton key={i} size="sm" onClick={() => crossDoor(d)}>
+                      Cross to {d.toName || "the next room"} →
+                    </BrassButton>
+                  ))}
+                </div>
+              ) : null}
+              <CombatEmptyState status={surfaceStatus} onNavigate={onNavigate} />
+            </React.Fragment>
           )}
         </Panel>
 

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -106,6 +106,7 @@ _OPENWORLDS_MIME_TYPES = {
 _MOVE_KINDS = {
     "say", "do", "check", "save", "combat", "attack", "cast", "use_item", "clarify",
     "travel", "inspect", "examine", "move_to_zone", "move_to_cell", "end_turn",
+    "cross_door",  # M-E: cross an authored doorway to the linked room-unit (engine-resolved)
 }
 # Kinds whose payload is carried by `target` alone (no free `text`/`name`) — the graphical
 # intents. Used to relax the "needs text or name" guard below for these click-driven moves.
@@ -172,6 +173,11 @@ def sanitize_move(raw: object) -> tuple[Optional[dict], str]:
     if kind == "move_to_cell":
         if not (isinstance(move.get("x"), int) and isinstance(move.get("y"), int)):
             return None, "'move_to_cell' needs integer 'x' and 'y' grid coordinates"
+        return move, ""
+    # `cross_door` is the engine-resolved M-E room-transition intent: carry the doorway cell (x,y).
+    if kind == "cross_door":
+        if not (isinstance(move.get("x"), int) and isinstance(move.get("y"), int)):
+            return None, "'cross_door' needs integer 'x' and 'y' (the doorway cell)"
         return move, ""
     # The graphical intents (travel/inspect/examine/move_to_zone) are carried by `target`;
     # everything else needs a `text` or `name` so the DM has something to act on. An `attack`
@@ -1426,6 +1432,31 @@ def _player_turn_lock(campaign_id: str) -> threading.Lock:
             lock = threading.Lock()
             _PLAYER_TURN_LOCKS[campaign_id] = lock
         return lock
+
+
+def _resolve_cross_door(campaign_id: str, move: dict) -> dict:
+    """Resolve a `cross_door` intent (M-E room transition): cross an authored doorway to the linked
+    room-unit via the engine's ``cross_door`` verb (which delegates to ``travel_to`` under the engine
+    lock — the engine stays the SOLE WRITER). Gated on combat being RESOLVED (finish the fight before
+    leaving the room). Returns ``{ok:True, crossed:[x,y]}`` so the client re-fetches /combat-surface and
+    swaps to the new room's plate; rejections (active combat / not a doorway / no connection) leave
+    NOTHING mutated and return ``{ok:False, reason}``. Mirrors the move_to_cell engine-resolved lane."""
+    engine = _load_engine_server()
+    if engine is None:
+        return {"ok": False, "reason": "engine unavailable"}
+    try:
+        snap = engine._require(campaign_id)
+    except Exception as exc:
+        return {"ok": False, "reason": f"could not read combat state: {exc}"}
+    if snap.combat.active:
+        return {"ok": False, "reason": "finish the fight before crossing the doorway"}
+    try:
+        result = engine.cross_door(campaign_id, int(move["x"]), int(move["y"]))
+    except ValueError as exc:
+        return {"ok": False, "reason": str(exc)}
+    except Exception as exc:  # noqa: BLE001 — surface any engine error as a clean rejection
+        return {"ok": False, "reason": f"cross failed: {exc}"}
+    return {"ok": True, "crossed": result.get("crossed_door")}
 
 
 def _resolve_player_combat_turn(campaign_id: str, move: dict, *, live: bool) -> dict:
@@ -9227,6 +9258,11 @@ class _Handler(BaseHTTPRequestHandler):
         # OAs, advances initiative, and we re-emit build_combat_surface. The campaign is bound to
         # the live run (the cross-campaign refusal above already ran). Every OTHER kind keeps the
         # append-only intent-log behavior (byte-identical to today).
+        # M-E ROOM-TRANSITION LANE: a `cross_door` is engine-resolved in-process (engine.cross_door ->
+        # travel_to under the engine lock), NOT appended for the DM. Gated on combat being resolved.
+        if move.get("kind") == "cross_door":
+            self._json(_resolve_cross_door(self.campaign_id, move))
+            return
         is_combat_cell = move.get("kind") in ("move_to_cell", "end_turn") or (
             move.get("kind") == "attack" and "target_id" in move
         )

--- a/viewer/tests/test_move_intents.py
+++ b/viewer/tests/test_move_intents.py
@@ -31,6 +31,18 @@ _SPEC.loader.exec_module(server)
 class MoveIntentVocabularyTests(unittest.TestCase):
     # ---- #429: the new graphical intents are accepted ----
 
+    def test_cross_door_intent_accepted_with_xy(self):
+        """M-E: cross_door carries the doorway cell (x,y), engine-resolved like move_to_cell."""
+        move, reason = server.sanitize_move({"kind": "cross_door", "x": 6, "y": 0})
+        self.assertEqual(reason, "")
+        self.assertEqual(move["kind"], "cross_door")
+        self.assertEqual((move["x"], move["y"]), (6, 0))
+
+    def test_cross_door_without_coords_is_rejected(self):
+        move, reason = server.sanitize_move({"kind": "cross_door"})
+        self.assertIsNone(move)
+        self.assertIn("x", reason.lower())
+
     def test_travel_intent_accepted_with_target(self):
         move, reason = server.sanitize_move({"kind": "travel", "target": "loc-lower-city"})
         self.assertEqual(reason, "")


### PR DESCRIPTION
Completes the player-triggered room transition's **backend**: a `cross_door` move kind (carries the doorway cell x,y) is engine-resolved in-process (`_resolve_cross_door` → `engine.cross_door` → `travel_to` under the engine lock; engine stays sole writer), NOT appended for the DM. Gated on combat being **resolved** ('finish the fight before crossing the doorway').

So the in-app UI can POST a doorway click and the party crosses to the linked room-unit; the client re-fetches /combat-surface and the renderer swaps to the new plate.

**Proven end-to-end** (live viewer + curl): cross_door mid-combat → rejected; after end_combat → `{ok:true, crossed:[6,0]}` and /combat-surface flips *Cathedral Nave → Crypt Undercroft*. sanitize tests in test_move_intents.py (37 viewer tests green). Pairs with doors-surface (#1224) + cross_door verb (#1225). NEXT: the jsx 'Cross to <room>' button. Part of #1217.