### PR TITLE
gfx: renderer auto-picks plate by current location — cross_door auto-swap (closes #1230)

### DIFF
--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -7,7 +7,24 @@ AssetDatabase.Refresh();
 // Room-agnostic plate: read the active room's plate filename from a box config (written by the seed/driver);
 // default = the crypt. Lets the SAME renderer play combat on ANY generated room (tavern/church/...) by swapping
 // the plate with no code edit — the modular-room analogue of the asset registry.
-string PLATE="crypt_firelit_v2.png"; { var _abs="/home/unity/worldos-unity/Assets/painterly/backdrops/_active_combat.txt"; if(System.IO.File.Exists(_abs)){ var _n=System.IO.File.ReadAllText(_abs).Trim(); if(_n.Length>0) PLATE=_n; } }
+// #1230: pick the plate by the CURRENT engine location (a per-location plate map written by deploy_room.sh),
+// so cross_door AUTO-SWAPS the rendered room with no manual re-deploy. Reads the current location.id off the
+// SAME /combat-surface the renderer uses for tokens; ANY failure (no map, tunnel down, parse) falls back to
+// _active_combat.txt -> today's single-room behavior (back-compat, additive). The per-location fetch is as
+// reliable as the token fetch below (same endpoint).
+string PLATE="crypt_firelit_v2.png"; string _locPlate="";
+try {
+  var _cidF="/home/unity/worldos-unity/Assets/painterly/backdrops/_active_campaign.txt";
+  string _cid="camp_gfxdemo01"; if(System.IO.File.Exists(_cidF)){ var _c=System.IO.File.ReadAllText(_cidF).Trim(); if(_c.Length>0) _cid=_c; }
+  var _sj=new System.Net.WebClient().DownloadString("http://127.0.0.1:8765/combat-surface?campaign="+_cid);
+  var _r=MiniJson.Parse(_sj) as System.Collections.Generic.Dictionary<string,object>;
+  var _loc=(_r!=null && _r.ContainsKey("location"))?_r["location"] as System.Collections.Generic.Dictionary<string,object>:null;
+  var _lid=(_loc!=null && _loc.ContainsKey("id"))?_loc["id"] as string:null;
+  var _mapF="/home/unity/worldos-unity/Assets/painterly/backdrops/_location_plates.json";
+  if(!string.IsNullOrEmpty(_lid) && System.IO.File.Exists(_mapF)){ var _m=MiniJson.Parse(System.IO.File.ReadAllText(_mapF)) as System.Collections.Generic.Dictionary<string,object>; if(_m!=null && _m.ContainsKey(_lid)) _locPlate=_m[_lid] as string; }
+} catch {}
+if(!string.IsNullOrEmpty(_locPlate)) PLATE=_locPlate;
+else { var _abs="/home/unity/worldos-unity/Assets/painterly/backdrops/_active_combat.txt"; if(System.IO.File.Exists(_abs)){ var _n=System.IO.File.ReadAllText(_abs).Trim(); if(_n.Length>0) PLATE=_n; } }
 string PLATE_PATH="Assets/painterly/backdrops/"+PLATE;
 // New backdrop plates default to NPOT=ToNearest, which square-distorts a 1344x768 plate and breaks the
 // camera-pin aspect. Force NPOT=None so the plate keeps native dims (idempotent — only reimports if needed).

--- a/qa/deploy_room.sh
+++ b/qa/deploy_room.sh
@@ -7,7 +7,10 @@
 # This deploys a local plate PNG to the box and points the renderer at it (+ optionally at a campaign id).
 # Combat then plays on the new room (crypt / tavern / church / ...).
 #
-#   qa/deploy_room.sh <local_plate.png> [box_plate_name.png] [campaign_id]
+#   qa/deploy_room.sh <local_plate.png> [box_plate_name.png] [campaign_id] [location_id]
+#
+# Pass a <location_id> for a MULTI-ROOM dungeon: it records {loc_id: plate} in _location_plates.json so the
+# renderer auto-picks the right plate by the CURRENT engine location (cross_door auto-swap, #1230).
 #
 # Pre-req: the GEX44 ControlMaster at /tmp/gex44-cm.sock (gex44-unity-host skill).
 set -euo pipefail
@@ -15,6 +18,7 @@ set -euo pipefail
 LOCAL_PLATE="${1:?usage: deploy_room.sh <local_plate.png> [box_plate_name.png] [campaign_id]}"
 BOX_NAME="${2:-$(basename "$LOCAL_PLATE")}"
 CAMPAIGN="${3:-}"
+LOC_ID="${4:-}"
 CM="/tmp/gex44-cm.sock"
 BOX="root@46.4.26.123"
 BDIR="/home/unity/worldos-unity/Assets/painterly/backdrops"
@@ -28,5 +32,11 @@ ssh -o ControlPath="$CM" "$BOX" \
 if [ -n "$CAMPAIGN" ]; then
   ssh -o ControlPath="$CM" "$BOX" "printf '%s' '$CAMPAIGN' | sudo -u unity tee $BDIR/_active_campaign.txt"
   echo "[deploy_room] active campaign -> $CAMPAIGN"
+fi
+# #1230: per-location plate map -> the renderer auto-picks the plate by current location (cross_door auto-swap).
+if [ -n "$LOC_ID" ]; then
+  PYMERGE="import json,os; f='$BDIR/_location_plates.json'; d=json.load(open(f)) if os.path.exists(f) else {}; d['$LOC_ID']='$BOX_NAME'; json.dump(d,open(f,'w'))"
+  ssh -o ControlPath="$CM" "$BOX" "sudo -u unity python3 -c \"$PYMERGE\""
+  echo "[deploy_room] location $LOC_ID -> plate $BOX_NAME (per-location map)"
 fi
 echo "[deploy_room] active combat room -> $BOX_NAME (render paint_combat_v1.cs to see it)"


### PR DESCRIPTION
Fixes the gap discovered while building the dungeon generator: in-app `cross_door` (#1228) changed the engine location but the renderer read one `_active_combat.txt` → the new room rendered on the **old** plate.

`paint_combat_v1.cs` now reads the **current** `location.id` off the same `/combat-surface` it uses for tokens → looks it up in a per-location map `_location_plates.json` (written by `deploy_room.sh <plate> <name> <campaign> <location_id>`) → uses that plate, **falling back to `_active_combat.txt`** on any miss/failure (additive, back-compat).

**Proven end-to-end** (church+crypt, with `_active_combat.txt` deliberately set to the undercroft):
- party in the **nave** → renders the **cathedral** (`test_perloc_nave.png`) — the map overrides `_active_combat`;
- `cross_door` → **no manual re-deploy** → renders the **crypt undercroft** (`test_perloc_undercroft.png`) — auto-swapped by location.

Compiles clean. Completes the in-app player-triggered transition + enables a hands-off one-command multi-room dungeon. Closes #1230.