### PR TITLE
gfx: fix combat-render bugs — oval selection ring + floating skinned actors

### DIFF
--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -68,10 +68,19 @@ System.Func<string,string,string,int,int,float,Color,string,Vector3> spawn=(fbxP
   var prefab=AssetDatabase.LoadAssetAtPath<GameObject>(fbxPath); if(prefab==null){ sb.AppendLine("MISSING "+fbxPath); missingActor=true; return cellToWorld(cx,cy); }
   var old=GameObject.Find(nm); if(old!=null) UnityEngine.Object.DestroyImmediate(old);
   var go=(GameObject)UnityEngine.Object.Instantiate(prefab); go.name=nm;
-  if(poseClipPath!=null){ var pas=AssetDatabase.LoadAllAssetsAtPath(poseClipPath); foreach(var clipAsset in pas){ var clip=clipAsset as AnimationClip; if(clip!=null && !clip.name.StartsWith("__")){ clip.SampleAnimation(go, clip.length*0.45f); sb.AppendLine(nm+" posed by "+clip.name); break; } } }
+  // Pose to a NEUTRAL IDLE stance before measuring/grounding. A skinned actor with no clip sampled sits in its FBX
+  // bind pose, which for gen'd meshes (Meshy goblin) is often a dynamic action pose -> reads as "unstable/floating"
+  // even when grounded (owner-observed). PREFER a clip named 'idle' (fall back to the first real clip); sample at
+  // mid-clip for a settled frame. Static meshes (hero.fbx, no clips) are untouched. Grounding re-measures AFTER this.
+  if(poseClipPath!=null){ var pas=AssetDatabase.LoadAllAssetsAtPath(poseClipPath); AnimationClip pick=null; foreach(var clipAsset in pas){ var clip=clipAsset as AnimationClip; if(clip==null||clip.name.StartsWith("__")) continue; if(clip.name.ToLower().Contains("idle")){ pick=clip; break; } if(pick==null) pick=clip; } if(pick!=null){ pick.SampleAnimation(go, 0f); sb.AppendLine(nm+" posed by "+pick.name+"@f0"); } }
   go.transform.rotation=Quaternion.Euler(-90f, cam.transform.eulerAngles.y+180f, 0f);
   var rends=go.GetComponentsInChildren<Renderer>(); foreach(var r in rends){ r.enabled=true; r.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.On; r.receiveShadows=true; }
-  System.Func<Bounds> measure=()=>{ Bounds b=new Bounds(go.transform.position,Vector3.zero); bool a=false; foreach(var r in rends){ if(!a){b=r.bounds;a=true;} else b.Encapsulate(r.bounds);} return b; };
+  // Grounding uses TRUE posed geometry. SkinnedMeshRenderer.bounds is a conservative/inflated culling AABB whose
+  // min.y sits BELOW the real feet -> grounding to min.y=0 leaves the actor FLOATING (owner-observed "goblin walking
+  // in the air"). BakeMesh snapshots the ACTUAL posed verts (renderer-local space); transform by localToWorldMatrix
+  // for an exact world min.y/center. Plain MeshRenderer.bounds are already accurate, so pass those through.
+  System.Func<Renderer,Bounds> worldBounds=(r)=>{ var smr=r as SkinnedMeshRenderer; if(smr==null) return r.bounds; var bk=new Mesh(); smr.BakeMesh(bk); var vs=bk.vertices; if(vs.Length==0){ UnityEngine.Object.DestroyImmediate(bk); return r.bounds; } var m=smr.transform.localToWorldMatrix; var wb=new Bounds(m.MultiplyPoint3x4(vs[0]),Vector3.zero); for(int i=1;i<vs.Length;i++) wb.Encapsulate(m.MultiplyPoint3x4(vs[i])); UnityEngine.Object.DestroyImmediate(bk); return wb; };
+  System.Func<Bounds> measure=()=>{ Bounds b=new Bounds(go.transform.position,Vector3.zero); bool a=false; foreach(var r in rends){ var rb=worldBounds(r); if(!a){b=rb;a=true;} else b.Encapsulate(rb);} return b; };
   Bounds bb=measure(); float curH=bb.size.y>0.001f?bb.size.y:1f; float s=height/curH; go.transform.localScale=go.transform.localScale*s;
   // ground + CENTER on the cell: snap feet to Y=0 AND align bounds-center X/Z to the cell (fixes the critic's
   // "actor decoupled from its ring" — meshes whose geometry is offset from their transform origin drifted off-ring).
@@ -79,8 +88,13 @@ System.Func<string,string,string,int,int,float,Color,string,Vector3> spawn=(fbxP
   if(albedoPath!=null){ var al=AssetDatabase.LoadAssetAtPath<Texture2D>(albedoPath); if(al!=null){ var mm=new Material(Shader.Find("Standard")); mm.mainTexture=al; mm.SetFloat("_Glossiness",0.2f); mm.SetFloat("_Metallic",0f); foreach(var r in rends) r.sharedMaterial=mm; } }
   var oldAo=GameObject.Find(nm+"_AO"); if(oldAo!=null) UnityEngine.Object.DestroyImmediate(oldAo);
   var oldRg=GameObject.Find(nm+"_Ring"); if(oldRg!=null) UnityEngine.Object.DestroyImmediate(oldRg);
-  var ao=GameObject.CreatePrimitive(PrimitiveType.Quad); ao.name=nm+"_AO"; UnityEngine.Object.DestroyImmediate(ao.GetComponent<Collider>()); ao.transform.position=new Vector3(p.x,0.04f,p.z); ao.transform.localEulerAngles=new Vector3(90f,0f,0f); ao.transform.localScale=new Vector3(2.2f,1.4f,1f); var aom=new Material(Shader.Find("Unlit/Transparent")); aom.mainTexture=blobT; aom.renderQueue=1950; ao.GetComponent<Renderer>().sharedMaterial=aom; ao.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
-  var rg=GameObject.CreatePrimitive(PrimitiveType.Quad); rg.name=nm+"_Ring"; UnityEngine.Object.DestroyImmediate(rg.GetComponent<Collider>()); rg.transform.position=new Vector3(p.x,0.06f,p.z); rg.transform.localEulerAngles=new Vector3(90f,0f,0f); rg.transform.localScale=new Vector3(2.7f,1.7f,1f); var rgm=new Material(Shader.Find("Unlit/Transparent")); rgm.mainTexture=ringT; rgm.color=ringCol; rgm.renderQueue=1955; rg.GetComponent<Renderer>().sharedMaterial=rgm; rg.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
+  // AO blob + selection ring are UNIFORM ground circles (equal X/Z), laid FLAT on the ground plane; the orthographic
+  // 30deg-pitch / 45deg-yaw camera foreshortens a true circle into the correct clean 2:1 dimetric ellipse aligned to
+  // the view. (Prior code pre-squished them anisotropically in WORLD X/Z (2.7x1.7); because the camera is yawed 45deg
+  // its foreshortening runs along the world DIAGONAL, so a world-axis pre-squish produced the skewed oval that did not
+  // match the view -- owner-observed "the ring is off, like an oval, not matching the camera". Let the camera do it.)
+  var ao=GameObject.CreatePrimitive(PrimitiveType.Quad); ao.name=nm+"_AO"; UnityEngine.Object.DestroyImmediate(ao.GetComponent<Collider>()); ao.transform.position=new Vector3(p.x,0.04f,p.z); ao.transform.localEulerAngles=new Vector3(90f,0f,0f); ao.transform.localScale=new Vector3(2.0f,2.0f,1f); var aom=new Material(Shader.Find("Unlit/Transparent")); aom.mainTexture=blobT; aom.renderQueue=1950; ao.GetComponent<Renderer>().sharedMaterial=aom; ao.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
+  var rg=GameObject.CreatePrimitive(PrimitiveType.Quad); rg.name=nm+"_Ring"; UnityEngine.Object.DestroyImmediate(rg.GetComponent<Collider>()); rg.transform.position=new Vector3(p.x,0.06f,p.z); rg.transform.localEulerAngles=new Vector3(90f,0f,0f); rg.transform.localScale=new Vector3(2.6f,2.6f,1f); var rgm=new Material(Shader.Find("Unlit/Transparent")); rgm.mainTexture=ringT; rgm.color=ringCol; rgm.renderQueue=1955; rg.GetComponent<Renderer>().sharedMaterial=rgm; rg.GetComponent<Renderer>().shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off;
   sb.AppendLine(nm+" x"+s.ToString("F2")+" @cell("+cx+","+cy+") rends="+rends.Length);
   return go.transform.position;
 };
@@ -127,6 +141,10 @@ foreach(var o in toks){ var t=o as System.Collections.Generic.Dictionary<string,
   string kind=foe?"monster":"character";
   var aref=resolveAsset(slugify(nm),kind); string fbx=aref[0]; string alb=aref[1];
   float h=foe?4.2f:5.0f; Color ring=foe?new Color(1f,0.13f,0.10f,1f):new Color(0.4f,0.95f,1f,1f);
+  // poseClip: pass the fbx to auto-pose to a NEUTRAL IDLE (spawn prefers an 'idle' clip). Left null for the current
+  // Meshy placeholder cast whose idle/bind clips are non-neutral (crouch/lean) + inflate the height-normalized scale;
+  // the bind pose is the most PROPORTIONATE placeholder here. A properly-rigged demo-cast actor (owner-greenlit) with
+  // a clean idle should pass its fbx/clip so this poses it standing. (Grounding via BakeMesh is correct either way.)
   var pos=spawn(fbx,alb,null,cx,cy,h,ring,"Actor_"+tid);
   if(nm!=null) posByName[nm]=pos; spawned++; celldbg+=" "+nm+"("+team+")@"+cx+","+cy;
 }


### PR DESCRIPTION
## Owner-observed rendering bugs (validated + fixed on the box)

The owner flagged two concrete bugs in the live combat frame. Both root-caused,
fixed, and **verified by re-render** on the GEX44 box (crypt undercroft:
skeleton→goblin-template vs Aldric).

### 1. Unit ring read as a skewed oval, not matching the camera
The AO blob + selection ring were pre-squished anisotropically in **world** X/Z
(`2.7×1.7`). The camera is yawed 45°, so its foreshortening runs along the world
**diagonal** — a world-axis pre-squish therefore produced a skewed oval that
didn't align to the view.
**Fix:** uniform ground circles (equal X/Z) laid flat on the ground; let the
orthographic 30°-pitch camera foreshorten a true circle into the correct clean
2:1 dimetric ellipse (standard CRPG selection-circle). ✅ rings now render round.

### 2. Floating skinned actors ("goblin walking in the air")
Grounding shifts by `-bb.min.y`, but `measure()` used `Renderer.bounds`; for a
**SkinnedMeshRenderer** that's a conservative/inflated culling AABB whose `min.y`
sits *below* the true feet → the actor was lifted ~2.75 world-units off the floor.
**Evidence (diagnostic):** goblin `r.bounds.min.y = -1.216` vs true
`BakeMesh min.y = -0.497`. The hero is a static MeshRenderer (accurate bounds),
which is why it never floated.
**Fix:** measure true posed geometry via `SkinnedMeshRenderer.BakeMesh` (plain
MeshRenderer.bounds passed through). ✅ skinned foe now grounds feet-on-floor.

### Also
`spawn()` now prefers an `idle` clip when a pose source is passed — ready for the
demo-cast assets — but left `null` for the current Meshy placeholder, whose
idle/bind clips are non-neutral (crouch/lean) and inflate the height-normalized
scale. **A clean neutral idle is a demo-cast asset requirement, not a renderer
concern.**

Renderer-only, read-only on engine state (engine = sole writer). Renders:
`renders/ringground_fix_v{1,3}.png`.