### PR TITLE
gfx: combat occlusion + demo-cast orientation/idle

### DIFF
--- a/extensions/renderers/unity/scripts/paint_combat_v1.cs
+++ b/extensions/renderers/unity/scripts/paint_combat_v1.cs
@@ -113,7 +113,7 @@ if(toks==null||toks.Count==0) return "no tokens on surface";
 // COLLECT then destroy with null-checks: destroying an actor root also destroys its children still in the
 // FindObjectsByType array, so a single-loop destroy would access a destroyed child (Unity throws).
 { var _toKill=new System.Collections.Generic.List<GameObject>();
-  foreach(var g in UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None)){ if(g==null) continue; var gn=g.name; if(gn.StartsWith("Actor_")||gn.EndsWith("_AO")||gn.EndsWith("_Ring")||gn=="ImpactFX"||gn=="DmgNum") _toKill.Add(g); }
+  foreach(var g in UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None)){ if(g==null) continue; var gn=g.name; if(gn.StartsWith("Actor_")||gn.EndsWith("_AO")||gn.EndsWith("_Ring")||gn=="ImpactFX"||gn=="DmgNum"||gn.StartsWith("Occluder_")) _toKill.Add(g); }
   foreach(var g in _toKill){ if(g!=null) UnityEngine.Object.DestroyImmediate(g); } }
 // place an actor per token by SLOT (foe -> goblin template / ally -> hero template); cyan party / red foe ring (critic L5).
 var posByName=new System.Collections.Generic.Dictionary<string,Vector3>(); int spawned=0; string celldbg="";
@@ -150,6 +150,46 @@ foreach(var o in toks){ var t=o as System.Collections.Generic.Dictionary<string,
 }
 if(missingActor){ sb.AppendLine("ABORT capture — a required actor prefab was missing (no PNG written)"); return sb.ToString(); }
 sb.AppendLine("LIVE "+CID+": spawned "+spawned+" actors:"+celldbg);
+
+// OCCLUSION (owner: "can they move BEHIND columns / behind items?"). The surface `occluders` field carries the
+// engine-authored OCCLUDER props (footprint cells + height band). Place an INVISIBLE depth-only box at each
+// occluder cell (ColorMask 0 -> writes DEPTH, not color; queue Geometry-1 -> renders BEFORE actors). A 3D actor
+// that stands BEHIND a painted column (greater camera depth) then fails the depth test where they overlap and is
+// correctly HIDDEN by it. The box aligns with the PAINTED column because both derive from the SAME cell + the
+// SAME contract camera (the greybox column was built at cellToWorld(cell)). [] occluders -> today's behavior.
+{ var occRoot = root.ContainsKey("occluders") ? root["occluders"] as System.Collections.Generic.List<object> : null;
+  int occN=0;
+  if(occRoot!=null && occRoot.Count>0){
+    string occSrc =
+      "Shader \"WorldOS/OccluderDepth\" {\n"+
+      "  SubShader {\n"+
+      "    Tags { \"RenderType\"=\"Opaque\" \"Queue\"=\"Geometry-1\" }\n"+
+      "    Pass {\n"+
+      "      ColorMask 0\n      ZWrite On\n"+
+      "      CGPROGRAM\n      #pragma vertex vert\n      #pragma fragment frag\n      #include \"UnityCG.cginc\"\n"+
+      "      float4 vert(float4 v:POSITION):SV_POSITION { return UnityObjectToClipPos(v); }\n"+
+      "      fixed4 frag():SV_Target { return fixed4(0,0,0,0); }\n"+
+      "      ENDCG\n    }\n  }\n}\n";
+    var occShader=UnityEditor.ShaderUtil.CreateShaderAsset(occSrc);
+    var occMat=new Material(occShader);
+    System.Func<string,float> bandH=(b)=> b=="tall"?7.5f : (b=="low"?1.4f : 3.8f);
+    foreach(var oo in occRoot){ var od=oo as System.Collections.Generic.Dictionary<string,object>; if(od==null) continue;
+      string band=od.ContainsKey("band")?od["band"] as string:"mid"; float H=bandH(band);
+      var ocells=od.ContainsKey("cells")?od["cells"] as System.Collections.Generic.List<object>:null; if(ocells==null) continue;
+      foreach(var cc in ocells){ var cell=cc as System.Collections.Generic.List<object>; if(cell==null||cell.Count<2) continue;
+        int ccx=System.Convert.ToInt32(cell[0]); int ccy=System.Convert.ToInt32(cell[1]);
+        var wp=cellToWorld(ccx,ccy);
+        var box=GameObject.CreatePrimitive(PrimitiveType.Cube); box.name="Occluder_"+ccx+"_"+ccy;
+        UnityEngine.Object.DestroyImmediate(box.GetComponent<Collider>());
+        box.transform.position=new Vector3(wp.x, H*0.5f, wp.z);
+        box.transform.localScale=new Vector3(2.0f, H, 2.0f);
+        var br=box.GetComponent<Renderer>(); br.sharedMaterial=occMat; br.shadowCastingMode=UnityEngine.Rendering.ShadowCastingMode.Off; br.receiveShadows=false;
+        occN++;
+      }
+    }
+  }
+  sb.AppendLine("occluders: "+occN+" depth-proxy boxes");
+}
 // latest damage from the battleLog -> floating "-N" + impact burst over the struck token (skip if no recent hit).
 string dmgTarget=""; int dmgN=0; var blog=root.ContainsKey("battleLog")?(root["battleLog"] as System.Collections.Generic.List<object>):null;
 if(blog!=null){ foreach(var e in blog){ string tx=null; var ed=e as System.Collections.Generic.Dictionary<string,object>; if(ed!=null&&ed.ContainsKey("text")) tx=ed["text"] as string; else tx=e as string;

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -3345,6 +3345,42 @@ def _combat_doors(snapshot: dict) -> list[dict]:
     return out
 
 
+def _combat_occluders(snapshot: dict) -> list[dict]:
+    """The current location's OCCLUDER props (columns / statues / a sarcophagus) with their footprint
+    cells + height band, so the read-only renderer can place invisible depth-only occluder proxies —
+    a 3D actor that moves BEHIND a painted column is then correctly HIDDEN by it (the owner's "can they
+    move behind columns / behind items?"). Without this the actor always draws on top of the flat plate.
+
+    ADDITIVE / presentation-only: READS engine-owned ``scene_grid.props`` where ``occluder`` is true
+    (the engine is the sole writer of scene_grid; ``SceneProp`` carries ``cells``/``occluder``/
+    ``height_band``); never mutates. ``[]`` when the location has no occluder props (== today's shape).
+    Each entry: ``{cells:[[c,r],...], band:"low"|"mid"|"tall"}``."""
+    loc_id = _text(snapshot.get("current_location_id"))
+    locs = snapshot.get("locations")
+    loc = locs.get(loc_id) if isinstance(locs, dict) and loc_id else None
+    if not isinstance(loc, dict):
+        return []
+    sg = loc.get("scene_grid")
+    props = sg.get("props") if isinstance(sg, dict) else None
+    if not isinstance(props, list) or not props:
+        return []
+    out: list[dict] = []
+    for p in props:
+        if not isinstance(p, dict) or not p.get("occluder"):
+            continue
+        cells = p.get("cells")
+        if not isinstance(cells, list) or not cells:
+            continue
+        norm = [[int(c[0]), int(c[1])] for c in cells
+                if isinstance(c, (list, tuple)) and len(c) == 2]
+        if not norm:
+            continue
+        band = p.get("height_band")
+        band = band if band in ("low", "mid", "tall") else "mid"
+        out.append({"cells": norm, "band": band})
+    return out
+
+
 def build_combat_surface(
     snapshot: dict,
     *,
@@ -3418,6 +3454,10 @@ def build_combat_surface(
         # M-E room transition: the authored doorway cells + their destination room-unit, so the renderer
         # can mark the doorway and the UI can offer to cross. [] == no doors/connections (today's shape).
         "doors": _combat_doors(snapshot),
+        # Occlusion: OCCLUDER props (columns/statues) with footprint cells + height band, so the read-only
+        # renderer can place invisible depth-only proxies -> a 3D actor moving BEHIND a painted column is
+        # correctly hidden by it. READS engine-owned scene_grid.props (occluder=true); [] == none (today).
+        "occluders": _combat_occluders(snapshot),
         "tokens": tokens,
         "initiative": initiative,
         "zones": zones,

--- a/viewer/tests/test_combat_surface.py
+++ b/viewer/tests/test_combat_surface.py
@@ -336,5 +336,54 @@ class CombatSurfaceTests(unittest.TestCase):
                 self.assert_no_private_keys(child)
 
 
+class CombatOccludersTests(unittest.TestCase):
+    """The `occluders` combat-surface field (occlusion of actors behind painted props)."""
+
+    def test_surfaces_only_occluder_props_with_footprint_and_band(self):
+        snapshot = {
+            "current_location_id": "crypt",
+            "locations": {
+                "crypt": {
+                    "name": "Crypt",
+                    "scene_grid": {
+                        "props": [
+                            {"id": "col1", "kind": "column", "cells": [[3, 4]],
+                             "occluder": True, "height_band": "tall"},
+                            {"id": "sarc", "kind": "sarcophagus", "cells": [[6, 5], [7, 5]],
+                             "occluder": True, "height_band": "low"},
+                            {"id": "rug", "kind": "rug", "cells": [[2, 2]],
+                             "occluder": False, "height_band": "mid"},
+                        ],
+                    },
+                },
+            },
+        }
+        occ = server._combat_occluders(snapshot)
+        self.assertEqual(occ, [
+            {"cells": [[3, 4]], "band": "tall"},
+            {"cells": [[6, 5], [7, 5]], "band": "low"},
+        ])
+
+    def test_defaults_bad_band_to_mid_and_skips_empty_footprints(self):
+        snapshot = {
+            "current_location_id": "x",
+            "locations": {"x": {"scene_grid": {"props": [
+                {"id": "p1", "cells": [[1, 1]], "occluder": True, "height_band": "bogus"},
+                {"id": "p2", "cells": [], "occluder": True, "height_band": "tall"},
+            ]}}},
+        }
+        self.assertEqual(server._combat_occluders(snapshot), [{"cells": [[1, 1]], "band": "mid"}])
+
+    def test_empty_when_no_scene_grid_or_no_occluders(self):
+        self.assertEqual(server._combat_occluders({}), [])
+        self.assertEqual(
+            server._combat_occluders({"current_location_id": "x", "locations": {"x": {"name": "X"}}}),
+            [],
+        )
+        no_occ = {"current_location_id": "x",
+                  "locations": {"x": {"scene_grid": {"props": [{"cells": [[1, 1]], "occluder": False}]}}}}
+        self.assertEqual(server._combat_occluders(no_occ), [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Owner ask: "can they move behind columns? behind items?"

Before this, a 3D actor standing behind a painted column drew **on top of** it (the flat backdrop plate is far away, so the near actor always won the depth test) — breaking the illusion. This adds real occlusion.

### Viewer (additive, presentation-only — engine stays sole writer)
- `_combat_occluders(snapshot)` reads engine-owned `scene_grid.props` where `occluder` is true → surfaces `{cells, band}` per prop as a new `occluders` combat-surface field. `[]` == today's shape.
- Unit tests: only-occluders-surfaced / bad-band-defaults-to-mid / empty cases (`test_combat_surface.py`, all green).

### Renderer (`paint_combat_v1.cs`)
- For each occluder cell, place an **invisible depth-only box** (a `ColorMask 0` / `ZWrite On` shader created at runtime, queue `Geometry-1` so it renders before actors) at `cellToWorld(cell)`, height by band. A camera-far actor behind it fails the depth test and is hidden. The box aligns with the painted column because both derive from the **same cell + contract camera**.

### Verified on the box (A/B)
Crypt undercroft, Aldric moved to (4,3) behind the (3,4) tall column:

![occlusion A/B](../blob/gfx/combat-occlusion-props/... ) `renders/occlusion_AB_montage.png`

- **Control** (main renderer, no occluder code): Aldric draws on top of the column.
- **With occlusion**: Aldric correctly hidden behind the column.

Known follow-up (cosmetic): selection rings render before the occluder, so a hidden actor's ring still peeks out — occlude rings too.