### PR TITLE
gfx(Phase A): G-buffer capture + deferred relight shaders (PoE2 layered pipeline)

### DIFF
--- a/extensions/renderers/godot/tools/derive_gbuffer.py
+++ b/extensions/renderers/godot/tools/derive_gbuffer.py
@@ -1,0 +1,23 @@
+# Derive a depth + view-space normal map FROM an image (Depth-Anything-V2), matching the diffuse by construction
+# → no structure-drift artifacts, works on a frame-filling high-Q diffuse. Output encoding matches WOSRelight.shader.
+import sys, numpy as np
+from PIL import Image
+from transformers import pipeline
+inp, out_depth, out_normal = sys.argv[1], sys.argv[2], sys.argv[3]
+pipe = pipeline("depth-estimation", model="depth-anything/Depth-Anything-V2-Small-hf")
+img = Image.open(inp).convert("RGB")
+res = pipe(img)
+d = np.array(res["depth"], dtype=np.float32)
+d = (d - d.min()) / (d.max() - d.min() + 1e-6)   # 0..1, near=1 (Depth-Anything: larger=closer)
+# depth png (grayscale) — scaled so nearer=smaller lin (invert to match greybox LinDepth where near=small)
+depth_lin = 1.0 - d                               # near -> small (matches greybox -view.z/80 near-small)
+Image.fromarray((depth_lin*255).astype(np.uint8)).convert("RGB").save(out_depth)
+# normal from depth gradient (Sobel-ish). z toward camera (view space), rgb = n*0.5+0.5
+gy, gx = np.gradient(d.astype(np.float32))
+STR = 6.0
+nx, ny, nz = -gx*STR, gy*STR, np.ones_like(d)
+ln = np.sqrt(nx*nx + ny*ny + nz*nz) + 1e-6
+nx, ny, nz = nx/ln, ny/ln, nz/ln
+nrm = np.stack([nx*0.5+0.5, ny*0.5+0.5, nz*0.5+0.5], axis=-1)
+Image.fromarray((nrm*255).astype(np.uint8)).save(out_normal)
+print("DERIVED", out_depth, out_normal, "shape", d.shape)

--- a/extensions/renderers/unity/scripts/build_room_greybox.cs
+++ b/extensions/renderers/unity/scripts/build_room_greybox.cs
@@ -178,6 +178,21 @@ float pa=cam.aspect; var pt=cam.targetTexture; cam.targetTexture=rt; cam.aspect=
 var pAct=RenderTexture.active; RenderTexture.active=rt; var t2=new Texture2D(W,Hh,TextureFormat.RGB24,false); t2.ReadPixels(new Rect(0,0,W,Hh),0,0); t2.Apply(); RenderTexture.active=pAct; cam.targetTexture=pt; cam.aspect=pa;
 System.IO.Directory.CreateDirectory("/home/unity/worldos-unity/Captures-Durable");
 System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/room_greybox.png", t2.EncodeToPNG());
+// ★ G-buffer passes (PoE2-faithful, Phase A): render the greybox's view-space NORMAL + linear DEPTH at the SAME
+// contract camera. The greybox is a real 3D scene, so these are FREE (like PoE2's Maya depth/normal passes) — they
+// let a FLAT-lit painterly diffuse be relit IN-ENGINE (deferred lighting) + give per-pixel occlusion. Additive:
+// room_greybox.png (the img2img control) is unchanged; these are extra sidecar layers.
+System.Action<string,string> _capPass=(shaderName,outName)=>{
+  var sh=Shader.Find(shaderName); if(sh==null){ sb.AppendLine("MISSING shader "+shaderName); return; }
+  var _prt=cam.targetTexture; var _pa=cam.aspect; cam.targetTexture=rt; cam.aspect=(float)W/Hh;
+  cam.RenderWithShader(sh, "");
+  var _pa2=RenderTexture.active; RenderTexture.active=rt; var _tp=new Texture2D(W,Hh,TextureFormat.RGB24,false); _tp.ReadPixels(new Rect(0,0,W,Hh),0,0); _tp.Apply(); RenderTexture.active=_pa2;
+  cam.targetTexture=_prt; cam.aspect=_pa;
+  System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/"+outName, _tp.EncodeToPNG());
+  UnityEngine.Object.DestroyImmediate(_tp);
+};
+_capPass("WOS/ViewNormal","room_greybox_normal.png");
+_capPass("WOS/LinDepth","room_greybox_depth.png");
 UnityEngine.Object.DestroyImmediate(t2); rt.Release(); UnityEngine.Object.DestroyImmediate(rt);
 // CLEANUP (capture is done; the greybox is transient + the scene is NOT saved): destroy this run's GB_*
 // GameObjects + their per-box Materials + the shared procedural stone Textures, so repeated invocations

--- a/extensions/renderers/unity/shaders/WOSLinDepth.shader
+++ b/extensions/renderers/unity/shaders/WOSLinDepth.shader
@@ -1,0 +1,15 @@
+Shader "WOS/LinDepth" {
+  SubShader {
+    Tags { "RenderType"="Opaque" }
+    Pass {
+      CGPROGRAM
+      #pragma vertex vert
+      #pragma fragment frag
+      #include "UnityCG.cginc"
+      struct v2f { float4 pos:SV_POSITION; float d:TEXCOORD0; };
+      v2f vert(appdata_base v){ v2f o; o.pos=UnityObjectToClipPos(v.vertex); o.d = -mul(UNITY_MATRIX_MV, v.vertex).z; return o; }
+      fixed4 frag(v2f i):SV_Target { float d=saturate(i.d/80.0); return fixed4(d,d,d,1); }
+      ENDCG
+    }
+  }
+}

--- a/extensions/renderers/unity/shaders/WOSRelight.shader
+++ b/extensions/renderers/unity/shaders/WOSRelight.shader
@@ -1,9 +1,5 @@
 Shader "WOS/Relight" {
-  Properties {
-    _MainTex ("Diffuse", 2D) = "white" {}
-    _NormalTex ("ViewNormal", 2D) = "white" {}
-    _DepthTex ("Depth", 2D) = "black" {}
-  }
+  Properties { _MainTex("Diffuse",2D)="white"{} _NormalTex("ViewNormal",2D)="white"{} _DepthTex("Depth",2D)="black"{} }
   SubShader {
     Tags { "Queue"="Geometry" "RenderType"="Opaque" }
     Pass {
@@ -13,26 +9,27 @@ Shader "WOS/Relight" {
       #pragma fragment frag
       #include "UnityCG.cginc"
       sampler2D _MainTex; sampler2D _NormalTex; sampler2D _DepthTex;
-      float3 _KeyDir; float3 _KeyCol; float3 _FillDir; float3 _FillCol; float3 _Amb;
-      float4 _OrthoExt;              // x=halfW, y=halfH, z=depthScale, w=unused (ortho view reconstruction)
-      float4 _P0; float3 _P0Col;     // brazier 0: view pos xyz, range w
-      float4 _P1; float3 _P1Col;     // brazier 1
-      float4 _P2; float3 _P2Col;     // combat key
+      float3 _KeyDir; float3 _KeyCol; float3 _FillDir; float3 _FillCol;
+      float3 _SkyAmb; float3 _GroundAmb; float _Bounce;
+      float4 _OrthoExt;
+      float4 _P0; float3 _P0Col; float4 _P1; float3 _P1Col; float4 _P2; float3 _P2Col;
       struct v2f { float4 pos:SV_POSITION; float2 uv:TEXCOORD0; };
       v2f vert(appdata_full v){ v2f o; o.pos=UnityObjectToClipPos(v.vertex); o.uv=v.texcoord; return o; }
       float3 pointLit(float3 P, float3 N, float4 L, float3 col){
-        float3 d=L.xyz-P; float dist=length(d); float atten=saturate(1.0-dist/max(L.w,0.001)); atten=atten*atten;
+        float3 d=L.xyz-P; float dist=length(d);
+        float atten=smoothstep(L.w, L.w*0.15, dist);          // smooth falloff (no hard ring seam)
         return col*atten*saturate(dot(N, normalize(d)));
       }
       fixed4 frag(v2f i):SV_Target {
         float3 diff=tex2D(_MainTex,i.uv).rgb;
         float3 N=tex2D(_NormalTex,i.uv).rgb*2.0-1.0;
-        if(dot(N,N)<0.01) return fixed4(diff*_Amb,1);   // background (no geometry) -> ambient only
+        // hemisphere ambient + a fraction of the diffuse itself as bounce GI (PoE2 plate-GI; keeps corners alive)
+        float3 amb=lerp(_GroundAmb, _SkyAmb, saturate(N.y*0.5+0.5)) + diff*_Bounce;
+        if(dot(N,N)<0.02){ return fixed4(diff*(_GroundAmb+_SkyAmb)*0.5 + diff*_Bounce, 1); } // bg: ambient only, soft
         N=normalize(N);
-        // reconstruct view-space position (orthographic): xy from uv, z from depth
         float lin=tex2D(_DepthTex,i.uv).r * _OrthoExt.z;
-        float3 P=float3((i.uv.x-0.5)*2.0*_OrthoExt.x, (i.uv.y-0.5)*2.0*_OrthoExt.y, -lin);
-        float3 lit=_Amb;
+        float3 P=float3((i.uv.x-0.5)*2.0*_OrthoExt.x, (i.uv.y-0.5)*2.0*_OrthoExt.y, -(_OrthoExt.w + tex2D(_DepthTex,i.uv).r*_OrthoExt.z));
+        float3 lit=amb;
         lit += _KeyCol * saturate(dot(N, normalize(_KeyDir)));
         lit += _FillCol * saturate(dot(N, normalize(_FillDir)));
         lit += pointLit(P,N,_P0,_P0Col);

--- a/extensions/renderers/unity/shaders/WOSRelight.shader
+++ b/extensions/renderers/unity/shaders/WOSRelight.shader
@@ -1,0 +1,46 @@
+Shader "WOS/Relight" {
+  Properties {
+    _MainTex ("Diffuse", 2D) = "white" {}
+    _NormalTex ("ViewNormal", 2D) = "white" {}
+    _DepthTex ("Depth", 2D) = "black" {}
+  }
+  SubShader {
+    Tags { "Queue"="Geometry" "RenderType"="Opaque" }
+    Pass {
+      ZWrite On
+      CGPROGRAM
+      #pragma vertex vert
+      #pragma fragment frag
+      #include "UnityCG.cginc"
+      sampler2D _MainTex; sampler2D _NormalTex; sampler2D _DepthTex;
+      float3 _KeyDir; float3 _KeyCol; float3 _FillDir; float3 _FillCol; float3 _Amb;
+      float4 _OrthoExt;              // x=halfW, y=halfH, z=depthScale, w=unused (ortho view reconstruction)
+      float4 _P0; float3 _P0Col;     // brazier 0: view pos xyz, range w
+      float4 _P1; float3 _P1Col;     // brazier 1
+      float4 _P2; float3 _P2Col;     // combat key
+      struct v2f { float4 pos:SV_POSITION; float2 uv:TEXCOORD0; };
+      v2f vert(appdata_full v){ v2f o; o.pos=UnityObjectToClipPos(v.vertex); o.uv=v.texcoord; return o; }
+      float3 pointLit(float3 P, float3 N, float4 L, float3 col){
+        float3 d=L.xyz-P; float dist=length(d); float atten=saturate(1.0-dist/max(L.w,0.001)); atten=atten*atten;
+        return col*atten*saturate(dot(N, normalize(d)));
+      }
+      fixed4 frag(v2f i):SV_Target {
+        float3 diff=tex2D(_MainTex,i.uv).rgb;
+        float3 N=tex2D(_NormalTex,i.uv).rgb*2.0-1.0;
+        if(dot(N,N)<0.01) return fixed4(diff*_Amb,1);   // background (no geometry) -> ambient only
+        N=normalize(N);
+        // reconstruct view-space position (orthographic): xy from uv, z from depth
+        float lin=tex2D(_DepthTex,i.uv).r * _OrthoExt.z;
+        float3 P=float3((i.uv.x-0.5)*2.0*_OrthoExt.x, (i.uv.y-0.5)*2.0*_OrthoExt.y, -lin);
+        float3 lit=_Amb;
+        lit += _KeyCol * saturate(dot(N, normalize(_KeyDir)));
+        lit += _FillCol * saturate(dot(N, normalize(_FillDir)));
+        lit += pointLit(P,N,_P0,_P0Col);
+        lit += pointLit(P,N,_P1,_P1Col);
+        lit += pointLit(P,N,_P2,_P2Col);
+        return fixed4(diff*lit, 1);
+      }
+      ENDCG
+    }
+  }
+}

--- a/extensions/renderers/unity/shaders/WOSViewNormal.shader
+++ b/extensions/renderers/unity/shaders/WOSViewNormal.shader
@@ -1,0 +1,15 @@
+Shader "WOS/ViewNormal" {
+  SubShader {
+    Tags { "RenderType"="Opaque" }
+    Pass {
+      CGPROGRAM
+      #pragma vertex vert
+      #pragma fragment frag
+      #include "UnityCG.cginc"
+      struct v2f { float4 pos:SV_POSITION; float3 vn:TEXCOORD0; };
+      v2f vert(appdata_base v){ v2f o; o.pos=UnityObjectToClipPos(v.vertex); o.vn=mul((float3x3)UNITY_MATRIX_IT_MV, v.normal); return o; }
+      fixed4 frag(v2f i):SV_Target { float3 n=normalize(i.vn); return fixed4(n*0.5+0.5, 1); }
+      ENDCG
+    }
+  }
+}


### PR DESCRIPTION
Proves the **core reframe** of the approved layered-scene R&D plan (`~/.claude/plans/…`): PoE2 rendered **diffuse + depth + normal** and did all dramatic lighting **in-engine** (deferred), rather than baking it into one plate. Our greybox is already a real 3D scene at the fixed camera, so its depth+normal are **free**.

## What this adds (additive, renderer-only)
- **`build_room_greybox.cs`** — 2 extra `RenderWithShader` passes capturing the greybox's **view-space normal** + **linear depth** at the same contract camera → `room_greybox_{normal,depth}.png` sidecars. The color control plate is unchanged.
- **`shaders/WOSViewNormal.shader` + `WOSLinDepth.shader`** — the capture shaders.
- **`shaders/WOSRelight.shader`** — per-pixel deferred lighting on a flat-diffuse quad (dir key+fill + 3 point lights, orthographic view-pos reconstruction from depth).

## Proven on the box
A **flat-lit** painterly diffuse + the greybox depth/normal + the in-engine rig → dramatic PoE2 **warm/cool wall chiaroscuro + a warm firelit floor pool + per-prop shading**, all at runtime (`renders/gbuf/relit_hell_locked.png`; montage `renders/PHASE_A_gbuffer_relight.png`). This directly attacks the ~6.3 **washout** ceiling by moving lighting off the AI plate and into the engine (where it's also shared with the 3D actors' lights → auto-integration + free depth-occlusion).

**Key requirement found:** the diffuse must match the G-buffer. A structure-locked diffuse (z-image str 0.5) matches → clean relight; high-Q Gemini drifts → mismatch. Resolution (next): derive depth+normal **from** the high-Q diffuse (Marigold/Depth-Anything), or use a carved greybox.

The relight is still a `/tmp` PoC; it folds into `paint_combat_v1.cs` in Phase C. No engine/pathing changes; camera contract byte-identical.