### PR TITLE
docs: adopt shared owned-repo policy pointers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,21 @@
+# Pull Request
+
 ## Summary
 
 Describe what changed and why.
+
+## Linked Issue
+
+Closes #
+
+## Tracker / Milestone
+
+- Tracker or milestone:
+- Required? yes/no and why:
+
+## Changes
+
+- <summary>
 
 ## Licensing / CLA
 
@@ -8,6 +23,40 @@ Describe what changed and why.
 - [ ] I have not included confidential information, private customer data, private imported content, or third-party-restricted material.
 - [ ] Any third-party material in this PR is clearly identified with source and license.
 
+## Review Thread State
+
+- Current-head unresolved review threads:
+- P0-P2 blocker count:
+- P3/advisory count:
+- Top-level bot comments requiring action:
+- Check annotations requiring action:
+- Bot rerun status:
+
 ## Validation
 
 List the checks you ran.
+
+## Release / WorldOS Proof Tier
+
+- [ ] Not release-affecting
+- [ ] Local or fast smoke only
+- [ ] Staging artifact proof
+- [ ] Release proof
+- [ ] Runtime/customer proof
+- [ ] WorldOS RRI/persona proof required
+
+## Release Notes / Changelog
+
+- Release-note impact:
+- Draft human-readable entry or no-impact rationale:
+- Verification/evidence tail needed? yes/no:
+
+## Safety / Rollback
+
+## Evidence
+
+- Evidence path:
+
+## Notes For Next Agent
+
+- Exact next action:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,15 @@
 - **Provisioning is COMPLETE** (verified on-box: the heavy part-B sweep lane, CUDA/local-AI, and the Unity 6000.5.1f1 + Unity-MCP render loop are all proven). GEX44 is now the **preferred** heavy-sweep + Unity/visual-renderer host (the 32 GB support VM is the fallback). Operational details + the connect/capture recipes live in `WorldOS-GUI-RUNBOOK.md` → "GPU-VM lane".
 - No customer data, no customer-VM bootstrap, no live Eva/customer runtime use on this host.
 
+## Shared Owned-Repo Policy
+
+- Use `100yenadmin/codex-operating-kit` for the shared issue/epic/milestone/sprint policy, PR review-thread lifecycle, and release changelog standard.
+- For meaningful GitHub work, create or reuse an issue before implementation, link PRs to the issue, and update the issue/tracker before handoff, merge, or pause.
+- Before merge, release, or readiness claims, query current-head review threads and separate resolvable review threads from top-level bot comments and check annotations.
+- P0-P2 current actionable review threads block merge/release unless fixed, proven false-positive, or explicitly escalated. P3/advisory threads still need terminal disposition.
+- Releases, prereleases, and release-affecting PRs must lead with human-readable user/operator outcomes and keep proof, evidence, artifact identity, and rollback details in a compact verification tail.
+- Keep WorldOS-specific RRI, persona proof, built-app, GPU/VM, private-art, and release-readiness gates in this repo's runbooks. The shared kit supplies the common operating spine only.
+
 ## GitHub And Reviews
 
 - Use branch prefix `codex/` for new branches unless instructed otherwise.
@@ -43,4 +52,3 @@
 - If a PR is part of the work, do not end while required checks, review-bot status, or current actionable review threads are unresolved unless the user explicitly asks to pause.
 - Keep up with CodeRabbit and GitHub review threads. Verify each comment against the code, fix valid issues, and rerun focused validation before pushing.
 - Treat generic warning-only bot suggestions as non-blocking unless they identify a real defect or the repository enforces them.
-


### PR DESCRIPTION
# Pull Request

## Summary

Adopts the shared owned-repo operating policy pointer in WorldOS and expands the PR template so future WorldOS PRs capture review-thread state, bot/check status, release-proof tier, release-note impact, evidence path, and next-agent notes.

## Linked Issue

Closes electricsheephq/WorldOS#1237

Shared rollout tracker: 100yenadmin/codex-operating-kit#5

## Tracker / Milestone

- Tracker or milestone: shared rollout tracker 100yenadmin/codex-operating-kit#5
- Required? yes, this is one repo in a multi-repo owned-policy rollout.

## Changes

- Added a short shared-policy pointer to `AGENTS.md`.
- Expanded `.github/pull_request_template.md` while preserving WorldOS CLA/licensing requirements.
- Kept WorldOS RRI/persona/proof gates repo-local.

## Review Thread State

- Current-head unresolved review threads: 0
- P0-P2 blocker count: 0
- P3/advisory count: 0
- Top-level bot comments requiring action: none; CodeRabbit completed
- Check annotations requiring action: none observed
- Bot rerun status: not needed; CodeRabbit review completed

## Validation

- [x] `git diff --check`
- [x] CodeRabbit completed
- [x] GitHub Actions, Socket, and Woodpecker checks passed except no-op/skipped CodeQL where reported

## Release / WorldOS Proof Tier

- [x] Not release-affecting
- [ ] Local or fast smoke only
- [ ] Staging artifact proof
- [ ] Release proof
- [ ] Runtime/customer proof
- [ ] WorldOS RRI/persona proof required

## Release Notes / Changelog

- Release-note impact: none; docs/template-only operating-policy rollout.
- Draft human-readable entry or no-impact rationale: No release-note entry needed because this does not change runtime, gameplay, release artifacts, or operator release behavior.
- Verification/evidence tail needed? no.

## Safety / Rollback

Revert this PR to restore the previous `AGENTS.md` and PR template text.

## Evidence

- Evidence path: `/Volumes/LEXAR/Codex/owned-repo-policy/2026-07-01/`

## Notes For Next Agent

- Exact next action: merged when this PR remains clean; continue rollout with LCO and the remaining prioritized repos.
