### PR TITLE
gfx(atelier spike): staging-law gate, 4-pass buffer capture, recomposite, Synty assembly (tools + findings; lane parked)

### DIFF
--- a/extensions/renderers/unity/scripts/atelier_luma_gate.py
+++ b/extensions/renderers/unity/scripts/atelier_luma_gate.py
@@ -3,10 +3,13 @@
 import sys
 import numpy as np
 from PIL import Image
-p = sys.argv[1] if len(sys.argv) > 1 else "atelier_beauty.png"
+p = sys.argv[1] if len(sys.argv) > 1 else "atelier_beauty_v4.png"
 im = Image.open(p).convert("RGB")
 arr = np.asarray(im, dtype=np.float64)
 n = arr.shape[0] * arr.shape[1]
+if n == 0:
+    print(f"{p}: empty image, cannot compute luma gate")
+    sys.exit(1)
 L = 0.2126 * arr[:, :, 0] + 0.7152 * arr[:, :, 1] + 0.0722 * arr[:, :, 2]
 dark = int(np.count_nonzero(L < 26))
 lit = int(np.count_nonzero(L > 60))

--- a/extensions/renderers/unity/scripts/atelier_luma_gate.py
+++ b/extensions/renderers/unity/scripts/atelier_luma_gate.py
@@ -1,20 +1,16 @@
 #!/usr/bin/env python3
 # Staging-law luma gate on the beauty pass. Gate: 60-85% of pixels L<26, 2-5% L>60 (Rec.709 luma).
 import sys
+import numpy as np
 from PIL import Image
 p = sys.argv[1] if len(sys.argv) > 1 else "atelier_beauty.png"
 im = Image.open(p).convert("RGB")
-px = im.getdata()
-n = len(px)
-dark = lit = 0
-tot = 0
-for r, g, b in px:
-    L = 0.2126 * r + 0.7152 * g + 0.0722 * b
-    tot += L
-    if L < 26:
-        dark += 1
-    if L > 60:
-        lit += 1
+arr = np.asarray(im, dtype=np.float64)
+n = arr.shape[0] * arr.shape[1]
+L = 0.2126 * arr[:, :, 0] + 0.7152 * arr[:, :, 1] + 0.0722 * arr[:, :, 2]
+dark = int(np.count_nonzero(L < 26))
+lit = int(np.count_nonzero(L > 60))
+tot = float(L.sum())
 pd = 100.0 * dark / n
 pl = 100.0 * lit / n
 mean = tot / n

--- a/extensions/renderers/unity/scripts/atelier_luma_gate.py
+++ b/extensions/renderers/unity/scripts/atelier_luma_gate.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+# Staging-law luma gate on the beauty pass. Gate: 60-85% of pixels L<26, 2-5% L>60 (Rec.709 luma).
+import sys
+from PIL import Image
+p = sys.argv[1] if len(sys.argv) > 1 else "atelier_beauty.png"
+im = Image.open(p).convert("RGB")
+px = im.getdata()
+n = len(px)
+dark = lit = 0
+tot = 0
+for r, g, b in px:
+    L = 0.2126 * r + 0.7152 * g + 0.0722 * b
+    tot += L
+    if L < 26:
+        dark += 1
+    if L > 60:
+        lit += 1
+pd = 100.0 * dark / n
+pl = 100.0 * lit / n
+mean = tot / n
+dark_ok = 60.0 <= pd <= 85.0
+lit_ok = 2.0 <= pl <= 5.0
+print(f"{p}: pixels={n} mean_L={mean:.2f}")
+print(f"  DARK L<26 : {pd:.2f}%  (gate 60-85%)  {'OK' if dark_ok else 'FAIL'}")
+print(f"  LIT  L>60 : {pl:.2f}%  (gate 2-5%)    {'OK' if lit_ok else 'FAIL'}")
+print(f"  VERDICT: {'PASS' if dark_ok and lit_ok else 'FAIL'}")

--- a/extensions/renderers/unity/scripts/atelier_recomposite.py
+++ b/extensions/renderers/unity/scripts/atelier_recomposite.py
@@ -29,6 +29,9 @@ def load_lin(path, size=None):
     return srgb_to_lin(np.asarray(im, dtype=np.float64)), im.size
 
 def main():
+    if len(sys.argv) < 5:
+        print(__doc__)
+        sys.exit(1)
     beauty_p, albedo_p, painted_p, out_p = sys.argv[1:5]
     gain = float(sys.argv[5]) if len(sys.argv) > 5 else 1.0
     beauty, size = load_lin(beauty_p)
@@ -39,9 +42,10 @@ def main():
     # clamp transport to sane range (specular/emissive can exceed 1; runaway where albedo~0)
     transport = np.clip(transport, 0.0, 6.0)
     out = np.clip(painted * transport * gain, 0.0, 1.0)
-    Image.fromarray(lin_to_srgb(out).astype(np.uint8)).save(out_p)
+    out_img = Image.fromarray(lin_to_srgb(out).astype(np.uint8))
+    out_img.save(out_p)
     # value-structure stats of the result (the staging-law gate)
-    L = np.asarray(Image.fromarray(lin_to_srgb(out).astype(np.uint8)).convert('L'), dtype=np.float64)
+    L = np.asarray(out_img.convert('L'), dtype=np.float64)
     print(f"recomposite -> {out_p}  {size[0]}x{size[1]}")
     print(f"stats: near-black(L<26)={np.mean(L<26)*100:.0f}%  lit(L>60)={np.mean(L>60)*100:.1f}%  "
           f"high(L>120)={np.mean(L>120)*100:.1f}%  median={np.median(L):.0f}  [PoE: 66-80% / 2-4% / ~0-0.5% / 0-15]")

--- a/extensions/renderers/unity/scripts/atelier_recomposite.py
+++ b/extensions/renderers/unity/scripts/atelier_recomposite.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Albedo-swap recomposite: transfer the 3D render's light transport onto a painted albedo.
+
+    final = painted_albedo * (beauty / albedo)        (all in LINEAR space)
+
+`beauty / albedo` isolates the scene's light transport (direct + shadows + falloff) from the
+render; multiplying the PAINTED albedo by it re-lights the painterly surface with the real
+3D lighting — the PoE recipe's compositing step. Epsilon-guarded where albedo ~ 0.
+
+Usage: recomposite.py <beauty.png> <albedo.png> <painted_albedo.png> <out.png> [gain]
+The painted albedo is resized to the beauty's dims if needed.
+"""
+import sys
+import numpy as np
+from PIL import Image
+
+def srgb_to_lin(x):
+    x = x / 255.0
+    return np.where(x <= 0.04045, x / 12.92, ((x + 0.055) / 1.055) ** 2.4)
+
+def lin_to_srgb(x):
+    x = np.clip(x, 0.0, 1.0)
+    return np.where(x <= 0.0031308, x * 12.92, 1.055 * (x ** (1 / 2.4)) - 0.055) * 255.0
+
+def load_lin(path, size=None):
+    im = Image.open(path).convert('RGB')
+    if size and im.size != size:
+        im = im.resize(size, Image.LANCZOS)
+    return srgb_to_lin(np.asarray(im, dtype=np.float64)), im.size
+
+def main():
+    beauty_p, albedo_p, painted_p, out_p = sys.argv[1:5]
+    gain = float(sys.argv[5]) if len(sys.argv) > 5 else 1.0
+    beauty, size = load_lin(beauty_p)
+    albedo, _ = load_lin(albedo_p, size)
+    painted, _ = load_lin(painted_p, size)
+    eps = 0.004
+    transport = beauty / np.maximum(albedo, eps)
+    # clamp transport to sane range (specular/emissive can exceed 1; runaway where albedo~0)
+    transport = np.clip(transport, 0.0, 6.0)
+    out = np.clip(painted * transport * gain, 0.0, 1.0)
+    Image.fromarray(lin_to_srgb(out).astype(np.uint8)).save(out_p)
+    # value-structure stats of the result (the staging-law gate)
+    L = np.asarray(Image.fromarray(lin_to_srgb(out).astype(np.uint8)).convert('L'), dtype=np.float64)
+    n = L.size
+    print(f"recomposite -> {out_p}  {size[0]}x{size[1]}")
+    print(f"stats: near-black(L<26)={np.mean(L<26)*100:.0f}%  lit(L>60)={np.mean(L>60)*100:.1f}%  "
+          f"high(L>120)={np.mean(L>120)*100:.1f}%  median={np.median(L):.0f}  [PoE: 66-80% / 2-4% / ~0-0.5% / 0-15]")
+
+if __name__ == '__main__':
+    main()

--- a/extensions/renderers/unity/scripts/atelier_recomposite.py
+++ b/extensions/renderers/unity/scripts/atelier_recomposite.py
@@ -42,7 +42,6 @@ def main():
     Image.fromarray(lin_to_srgb(out).astype(np.uint8)).save(out_p)
     # value-structure stats of the result (the staging-law gate)
     L = np.asarray(Image.fromarray(lin_to_srgb(out).astype(np.uint8)).convert('L'), dtype=np.float64)
-    n = L.size
     print(f"recomposite -> {out_p}  {size[0]}x{size[1]}")
     print(f"stats: near-black(L<26)={np.mean(L<26)*100:.0f}%  lit(L>60)={np.mean(L>60)*100:.1f}%  "
           f"high(L>120)={np.mean(L>120)*100:.1f}%  median={np.median(L):.0f}  [PoE: 66-80% / 2-4% / ~0-0.5% / 0-15]")

--- a/extensions/renderers/unity/scripts/build_atelier_crypt.cs
+++ b/extensions/renderers/unity/scripts/build_atelier_crypt.cs
@@ -97,6 +97,17 @@ if(pTomb==null) pTomb=loadPrefab("SM_Prop_Tomb_01");
 var pLid   = loadPrefab("SM_Prop_Tomb_Royal_Lid_01");       // v2 fix 5: lid so the tomb reads CLOSED/solid
 if(pLid==null) pLid=loadPrefab("SM_Prop_Tomb_Lid_01");
 LOG("prefabs: Wall="+(pWall!=null)+" Floor="+(pFloor!=null)+" Pillar01="+(pPil1!=null)+" Pillar02="+(pPil2!=null)+" Tomb="+(pTomb!=null)+" Lid="+(pLid!=null));
+var missingRequired=new System.Collections.Generic.List<string>();
+if(pWall==null) missingRequired.Add("SM_Bld_Base_Wall_01");
+if(pFloor==null) missingRequired.Add("SM_Bld_Base_Floor_01");
+if(pPil1==null) missingRequired.Add("SM_Bld_Base_Pillar_01");
+if(pPil2==null) missingRequired.Add("SM_Bld_Base_Pillar_02");
+if(pTomb==null) missingRequired.Add("SM_Prop_Tomb_Royal_01/SM_Prop_Tomb_01");
+if(missingRequired.Count>0){
+  LOG("FAIL missing required prefabs: "+string.Join(", ", missingRequired));
+  System.IO.File.WriteAllText("/home/unity/worldos-unity/atelier_report.txt", sb.ToString());
+  return "FAIL atelier: missing required prefabs: "+string.Join(", ", missingRequired);
+}
 
 // --- MEASURE native bounds of each modular piece (report the Synty pivot/size gotchas) ---
 System.Func<GameObject,string,string> measure=(pf,label)=>{
@@ -149,6 +160,11 @@ if(wallCells!=null) foreach(var wo in wallCells){ var wc=wo as System.Collection
   // dedupe the shared far corner (cols-1,0): count it once as back.
   if(isBack){ placeWall("WallBack_"+c, new Vector3(w.x, 0, w.z+CELL*0.5f), 0f); }   // yaw 0: face -z inward
   else if(isRight){ placeWall("WallRight_"+r, new Vector3(w.x+CELL*0.5f, 0, w.z), 90f); } // yaw 90: face -x inward
+}
+if(wallCells==null || nWall==0){
+  LOG("FAIL missing/empty wall geometry (geo[\"walls\"] absent or produced 0 placed walls)");
+  System.IO.File.WriteAllText("/home/unity/worldos-unity/atelier_report.txt", sb.ToString());
+  return "FAIL atelier: missing/empty wall geometry";
 }
 
 // --- PILLARS (v3 fix 1): HEROIC load-bearing columns, two DIFFERENT variants (anti-clone).
@@ -322,15 +338,27 @@ cam.clearFlags=CameraClearFlags.SolidColor; cam.backgroundColor=new Color(0f,0f,
 int W=1344,Hh=768;
 
 // capture helper: render current cam to a PNG (respects lit scene or a replacement shader).
+// Render/readback state (targetTexture/aspect/RenderTexture.active) is restored via try/finally so a
+// throw mid-capture (render, readback, encode, or file write) never leaves the camera/RT state dangling.
 System.Action<string,Shader> capture=(fname,replShader)=>{
   var rt=new RenderTexture(W,Hh,24,RenderTextureFormat.ARGB32); rt.Create();
-  float pa=cam.aspect; var pt2=cam.targetTexture; cam.targetTexture=rt; cam.aspect=(float)W/Hh;
-  if(replShader!=null) cam.RenderWithShader(replShader,""); else cam.Render();
-  var pAct=RenderTexture.active; RenderTexture.active=rt; var t2=new Texture2D(W,Hh,TextureFormat.RGB24,false);
-  t2.ReadPixels(new Rect(0,0,W,Hh),0,0); t2.Apply(); RenderTexture.active=pAct; cam.targetTexture=pt2; cam.aspect=pa;
-  System.IO.Directory.CreateDirectory("/home/unity/worldos-unity/Captures-Durable");
-  System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/"+fname, t2.EncodeToPNG());
-  UnityEngine.Object.DestroyImmediate(t2); rt.Release(); UnityEngine.Object.DestroyImmediate(rt);
+  float pa=cam.aspect; var pt2=cam.targetTexture;
+  Texture2D t2=null;
+  try{
+    cam.targetTexture=rt; cam.aspect=(float)W/Hh;
+    if(replShader!=null) cam.RenderWithShader(replShader,""); else cam.Render();
+    var pAct=RenderTexture.active;
+    try{
+      RenderTexture.active=rt; t2=new Texture2D(W,Hh,TextureFormat.RGB24,false);
+      t2.ReadPixels(new Rect(0,0,W,Hh),0,0); t2.Apply();
+    } finally { RenderTexture.active=pAct; }
+    System.IO.Directory.CreateDirectory("/home/unity/worldos-unity/Captures-Durable");
+    System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/"+fname, t2.EncodeToPNG());
+  } finally {
+    cam.targetTexture=pt2; cam.aspect=pa;
+    if(t2!=null) UnityEngine.Object.DestroyImmediate(t2);
+    rt.Release(); UnityEngine.Object.DestroyImmediate(rt);
+  }
 };
 
 // (a) BEAUTY — normal lit render
@@ -357,10 +385,14 @@ RenderSettings.ambientMode=savedAmbMode; RenderSettings.ambientLight=savedAmb;
   Shader.SetGlobalFloat("_WOSDepthNear", mn); Shader.SetGlobalFloat("_WOSDepthFar", mx);
   var shRemap=Shader.Find("WOS/LinDepthRemap"); var shDepth=Shader.Find("WOS/LinDepth"); var shNorm=Shader.Find("WOS/ViewNormal");
   LOG("depth remap near="+mn.ToString("F2")+" far="+mx.ToString("F2")+" (Remap="+(shRemap!=null)+" LinDepth="+(shDepth!=null)+" ViewNormal="+(shNorm!=null)+")");
+  if((shRemap==null && shDepth==null) || shNorm==null){
+    LOG("FAIL missing required buffer shaders: Depth(Remap|LinDepth)="+(shRemap!=null||shDepth!=null)+" ViewNormal="+(shNorm!=null));
+    System.IO.File.WriteAllText("/home/unity/worldos-unity/atelier_report.txt", sb.ToString());
+    return "FAIL atelier: missing required buffer shaders";
+  }
   if(shRemap!=null) capture("atelier_depth_v4.png", shRemap);
-  else if(shDepth!=null){ capture("atelier_depth_v4.png", shDepth); LOG("  WARN: remap shader missing -> used hardcoded /80 WOS/LinDepth"); }
-  else LOG("  MISSING both depth shaders");
-  if(shNorm!=null) capture("atelier_normal_v4.png", shNorm); else LOG("  MISSING WOS/ViewNormal");
+  else { capture("atelier_depth_v4.png", shDepth); LOG("  WARN: remap shader missing -> used hardcoded /80 WOS/LinDepth"); }
+  capture("atelier_normal_v4.png", shNorm);
 }
 
 LOG("BUILT floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp+" plinth/steps="+nPlinth);

--- a/extensions/renderers/unity/scripts/build_atelier_crypt.cs
+++ b/extensions/renderers/unity/scripts/build_atelier_crypt.cs
@@ -120,9 +120,10 @@ var wallCells=geo.ContainsKey("walls")?geo["walls"] as System.Collections.Generi
 int nWall=0;
 // Wall placer: scale the wall's LOCAL long axis (x, pre-yaw) so its footprint spans one 2.0 cell edge,
 // keep thickness+height native, THEN yaw so the face points inward, then seat base on floor (y=0) at edgePos.
-// v2 fix 1: MONUMENTAL walls. Scale local long axis (x) to one 2.0-cell edge, scale Y by heightScale
-// (~2.2x -> ~6.6 world units tall from native 3.01), keep thickness native, THEN yaw + seat on floor.
-float WALL_H=2.2f;   // v2: walls ~6.6 world units tall (native 3.01 * 2.2)
+// v3 fix 1: HEROIC walls. Scale local long axis (x) to one 2.0-cell edge, scale Y by heightScale
+// (~3.5x -> ~10.5 world units tall from native 3.01 — PoE interiors are deliberately over-scaled so the
+// walls DOMINATE the frame, not read as low fins), keep thickness native, THEN yaw + seat on floor.
+float WALL_H=3.5f;   // v3: HEROIC walls ~10.5 world units tall (native 3.01 * 3.5)
 System.Action<string,Vector3,float> placeWall=(name,edgePos,yaw)=>{
   if(pWall==null){ LOG("  MISSING Wall prefab"); return; }
   var inst=(GameObject)PrefabUtility.InstantiatePrefab(pWall); inst.name=name; inst.transform.SetParent(root.transform,true);
@@ -148,21 +149,21 @@ if(wallCells!=null) foreach(var wo in wallCells){ var wc=wo as System.Collection
   else if(isRight){ placeWall("WallRight_"+r, new Vector3(w.x+CELL*0.5f, 0, w.z), 90f); } // yaw 90: face -x inward
 }
 
-// --- PILLARS (v2 fix 1): MONUMENTAL load-bearing columns, two DIFFERENT variants (anti-clone).
-// Native ~0.43 wide x 3.02 tall -> XZ x3.5 (~1.5 wide), Y x1.9 (~5.7 tall). Anti-clone: B a touch
-// beefier + yawed 45 so the two columns don't read identical.
+// --- PILLARS (v3 fix 1): HEROIC load-bearing columns, two DIFFERENT variants (anti-clone).
+// Native ~0.43 wide x 3.02 tall -> XZ x4.9 (~2.1 wide), Y x3.0 (~9.0 tall) so they read as massive
+// stone columns against the 10.5u walls. Anti-clone: B a touch beefier + yawed 45.
 int nPil=0;
-{ var w=cellToWorld(4,4); if(placeScaled(pPil1,"Pillar_A",new Vector3(w.x,0,w.z), new Vector3(3.5f,1.9f,3.5f), 0f)!=null) nPil++; }
-{ var w=cellToWorld(9,4); if(placeScaled(pPil2,"Pillar_B",new Vector3(w.x,0,w.z), new Vector3(3.8f,2.0f,3.8f), 45f)!=null) nPil++; }
+{ var w=cellToWorld(4,4); if(placeScaled(pPil1,"Pillar_A",new Vector3(w.x,0,w.z), new Vector3(4.9f,3.0f,4.9f), 0f)!=null) nPil++; }
+{ var w=cellToWorld(9,4); if(placeScaled(pPil2,"Pillar_B",new Vector3(w.x,0,w.z), new Vector3(5.2f,3.05f,5.2f), 45f)!=null) nPil++; }
 
-// --- SARCOPHAGUS (v2 fix 1c + 5): royal tomb spanning cells (6,5)-(7,5), the monumental HERO prop.
+// --- SARCOPHAGUS (v3 fix 1 + 5): royal tomb spanning cells (6,5)-(7,5), the HEROIC monument.
 // Native ~1.05 x 0.63 x 2.43 (long axis Z). yaw 90 lays the long axis along X (cells 6,7 adjacent in X);
-// uniform x1.6 makes it monumental. A ROYAL LID placed on top makes it read CLOSED/solid, not an open tray.
+// uniform x2.2 makes it a hero monument. A ROYAL LID placed on top makes it read CLOSED/solid, not an open tray.
 int nSarc=0;
 { var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
-  float TOMB_S=1.6f;
+  float TOMB_S=2.2f;
   var inst=placeScaled(pTomb,"Sarcophagus",new Vector3(mid.x,0,mid.z), new Vector3(TOMB_S,TOMB_S,TOMB_S), 90f);
-  if(inst!=null){ nSarc++; LOG("sarcophagus: SM_Prop_Tomb_Royal_01 yaw90 x1.6 spanning (6,5)-(7,5)");
+  if(inst!=null){ nSarc++; LOG("sarcophagus: SM_Prop_Tomb_Royal_01 yaw90 x"+TOMB_S.ToString("F1")+" spanning (6,5)-(7,5)");
     var tb=worldBounds(inst);   // measure the placed tomb so the lid sits ON its top face
     if(pLid!=null){
       var lid=(GameObject)PrefabUtility.InstantiatePrefab(pLid); lid.name="SarcophagusLid"; lid.transform.SetParent(root.transform,true);
@@ -176,14 +177,15 @@ int nSarc=0;
   else LOG("sarcophagus: NO tomb prefab found -> using scaled Base piece note");
 }
 
-// --- SET-DRESSING (v2 fix 4): DENSITY x3, 15-20 props, edges only (pathing-safe), ANTI-CLONE jitter.
-// PolygonDungeonMap is a library/study pack (bookcases, knight-stands, globe, book piles) — a crypt-library.
+// --- SET-DRESSING (v3 fix 1+4): DENSITY x3 (19 props), edges only (pathing-safe), ANTI-CLONE jitter,
+// scaled UP x1.65 base so bookcases read ~4u tall against the 10.5u HEROIC walls (they were dwarfed at v2).
 // Each prop gets a per-instance yaw jitter (+-10 deg) and scale jitter (0.95-1.10) so no two read identical.
+float DRESS_S=1.65f;   // v3: heroic-scale base multiplier for all dressing
 int nProp=0; int jseed=0;
 System.Func<string,int,int,float,bool> dress=(prefabNm,c,r,baseYaw)=>{
   var pf=loadPrefab(prefabNm); if(pf==null){ LOG("  MISSING dressing "+prefabNm); return false; }
   // deterministic jitter from an incrementing seed (repeatable renders)
-  jseed++; float jy=((jseed*37)%21)-10f; float js=0.95f+(((jseed*53)%16)/100f);   // yaw +-10, scale 0.95-1.10
+  jseed++; float jy=((jseed*37)%21)-10f; float js=DRESS_S*(0.95f+(((jseed*53)%16)/100f));   // yaw +-10, scale x1.65 * 0.95-1.10
   var w=cellToWorld(c,r);
   var i=placeScaled(pf,"Dress_"+prefabNm+"_"+c+"_"+r,new Vector3(w.x,0,w.z), new Vector3(js,js,js), baseYaw+jy);
   return i!=null;
@@ -212,6 +214,36 @@ if(dress("SM_Prop_Book_Stand_02", 8,8, -20f)) nProp++;
 if(dress("SM_Prop_Bookcase_Small_01", 5,1, 180f)) nProp++;
 if(dress("SM_Prop_Papers_01",     7,9, 30f)) nProp++;
 
+// --- PLINTH + STEPS (v3 fix 2): the room floor sits on a raised platform ~1.4u tall. Add platform SIDE
+// faces (skirt) along the two CUT/NEAR edges (-x/left col and -z/front row) so the bottom of frame reads
+// as platform edge, NOT black void triangles; plus a 3-4 step staircase descending toward the camera at
+// the near-left. Simple scaled cubes with the stone material (normalized below via the "Plinth"/"Step" prefix).
+// Crib: build_room_greybox.cs uses primitive cubes for greybox; here they're the platform skirt + steps.
+int nPlinth=0; float PLINTH_H=1.4f;
+System.Func<string,Vector3,Vector3,GameObject> plbox=(nm,center,size)=>{
+  var b=GameObject.CreatePrimitive(PrimitiveType.Cube); b.name=nm; UnityEngine.Object.DestroyImmediate(b.GetComponent<Collider>());
+  b.transform.SetParent(root.transform,true); b.transform.position=center; b.transform.localScale=size; return b; };
+{ float roomW=cols*CELL, roomD=rows*CELL;
+  float leftX = -(cx0+0.5f)*CELL;   // -x near edge (world x of the left room boundary)
+  float frontZ= -(cy0+0.5f)*CELL;   // -z near edge (world z of the front room boundary)
+  float skirtT=0.6f;                 // skirt thickness (into the platform)
+  // LEFT (-x) skirt: a slab hanging from y=0 down to y=-PLINTH_H along the whole left edge
+  plbox("Plinth_Left",  new Vector3(leftX+skirtT*0.5f, -PLINTH_H*0.5f, 0f), new Vector3(skirtT, PLINTH_H, roomD)); nPlinth++;
+  // FRONT (-z) skirt: same along the whole front edge
+  plbox("Plinth_Front", new Vector3(0f, -PLINTH_H*0.5f, frontZ+skirtT*0.5f), new Vector3(roomW, PLINTH_H, skirtT)); nPlinth++;
+  // a solid corner block so the -x/-z corner isn't a gap
+  plbox("Plinth_Corner", new Vector3(leftX+skirtT*0.5f, -PLINTH_H*0.5f, frontZ+skirtT*0.5f), new Vector3(skirtT, PLINTH_H, skirtT)); nPlinth++;
+  // STAIRCASE at the near-left corner descending toward the camera (-x,-z direction). 4 steps, each drops
+  // 0.35u and steps out 0.7u from the platform's -x face, centred near the front-left.
+  int nSteps=4; float stepDrop=PLINTH_H/nSteps, stepRun=0.8f, stepW=5.0f;
+  float sz = frontZ + roomD*0.28f;   // steps centred toward the front-left of the left edge
+  for(int i2=0;i2<nSteps;i2++){
+    float topY=-(i2)*stepDrop; float sx=leftX - (i2+0.5f)*stepRun; // march out in -x, each lower
+    plbox("Step_"+i2, new Vector3(sx, topY-stepDrop*0.5f, sz), new Vector3(stepRun+0.02f, (PLINTH_H-i2*stepDrop), stepW));
+    nPlinth++;
+  }
+}
+
 // ================= MATERIAL NORMALIZATION (geometry spike) =================
 // The box's Synty import is PARTIAL: PolygonDungeonMap prefab renderers have NULL materials (missing
 // material/texture refs) -> Unity renders them MAGENTA; and some PolygonGeneric materials (e.g. the pillar's
@@ -233,6 +265,7 @@ Color colFloor=new Color(0.30f,0.29f,0.28f), colWall=new Color(0.28f,0.275f,0.26
     Color c=colProp; float g=0.05f;
     if(nm3.StartsWith("Floor_")) c=colFloor; else if(nm3.StartsWith("Wall")) c=colWall;
     else if(nm3.StartsWith("Pillar")) { c=colPillar; g=0.08f; } else if(nm3.StartsWith("Sarcophagus")) { c=colTomb; g=0.10f; }
+    else if(nm3.StartsWith("Plinth")||nm3.StartsWith("Step")) c=colWall;  // platform skirt + steps = stone
     else if(nm3=="AK_RimFill") continue;  // keep the emissive rim material
     int slots=r.sharedMaterials.Length; var arr=new Material[slots]; var one=stoneMat(c,g); for(int i=0;i<slots;i++) arr[i]=one; r.sharedMaterials=arr; nm2++;
   }
@@ -275,17 +308,26 @@ Vector3 rightX_edge=new Vector3((cx0+0.5f)*CELL,0f,0f); // x of the visible righ
 // iteration 5 (v2): the wall-torch near-field cores stay >L60 regardless of wall albedo (it's the LIGHT,
 // not the surface), so cut wall-torch intensity hard — the wall still catches a warm MIDTONE wash (fix 3
 // satisfied: walls are lit, not void fins) but the core no longer blows past L60. Tomb pool trimmed too.
-// iteration 6 (v2, TRUE baseline after the light-leak fix): re-tune up from a clean zero.
+// v3 (TRUE baseline continued): HEROIC 10.5u walls -> raise the hero pool + wall torches to y~6.5-7 so the
+// warm pools climb the tall wall faces (they'd only touch the base at y~4.8). THREE wall torches now
+// (back-left, back-right, right) so each big wall face carries a warm pool. Ranges 14-16 for the tall walls.
+// v3 iteration 2: the tomb HERO pool (cols5-7/rows2-3 = ~80% lit) dominates the LIT budget, so cut it
+// hard (intensity + range); trim the 3 wall pools; DARK has headroom (~70%) so this stays in-band.
+// v3 iteration 3: iter2 overcut (1.4% lit); bump the hero pool + wall pools back up to land ~3-4% lit.
 { var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
-  pt("AK_TorchSarc", new Vector3(mid.x, 3.8f, mid.z), 14f, 5.0f, warm, true); }       // hero pool over the tomb
+  pt("AK_TorchSarc", new Vector3(mid.x, 5.2f, mid.z), 14f, 4.4f, warm, true); }        // hero pool over the tomb
 // FIX 2: cool RIM point behind/above the tomb (replaces the dead emissive quad)
 { var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
-  pt("AK_RimCool", new Vector3(mid.x, 4.2f, mid.z+1.8f), 10f, 1.6f, new Color(0.30f,0.45f,0.70f), false); }
-// FIX 3: two warm WALL-TORCH points ~1.2 off a wall FACE — warm midtone wash up the wall (walls catch light).
-{ var wc=cellToWorld(4,1); pt("AK_TorchBackWall", new Vector3(wc.x, 4.8f, backZ_edge.z-1.2f), 11f, 3.0f, warm, false); }
-{ var wc=cellToWorld(12,4); pt("AK_TorchRightWall", new Vector3(rightX_edge.x-1.2f, 4.8f, wc.z), 11f, 3.0f, warm, false); }
+  pt("AK_RimCool", new Vector3(mid.x, 5.4f, mid.z+2.0f), 11f, 1.5f, new Color(0.30f,0.45f,0.70f), false); }
+// FIX 3: THREE warm WALL-TORCH points ~1.3 off a wall FACE at y~6.7 so each washes a warm pool UP the tall wall.
+// back wall LEFT (over the back-left bookcases / pillar A region):
+{ var wc=cellToWorld(3,1);  pt("AK_TorchBackL", new Vector3(wc.x, 6.7f, backZ_edge.z-1.3f), 14f, 2.9f, warm, false); }
+// back wall RIGHT (over the back-right bookcases):
+{ var wc=cellToWorld(10,1); pt("AK_TorchBackR", new Vector3(wc.x, 6.7f, backZ_edge.z-1.3f), 14f, 2.6f, warm, false); }
+// right wall (mid, washing the +x wall + knight stands):
+{ var wc=cellToWorld(12,4); pt("AK_TorchRight", new Vector3(rightX_edge.x-1.3f, 6.7f, wc.z), 14f, 2.9f, warm, false); }
 // faint archway/void point near the back-center door:
-{ var wa=cellToWorld(6,0); pt("AK_ArchVoid",  new Vector3(wa.x, 4.2f, wa.z+1.0f), 12f, 2.2f, new Color(1f,0.5f,0.2f), false); }
+{ var wa=cellToWorld(6,0); pt("AK_ArchVoid",  new Vector3(wa.x, 5.0f, wa.z+1.0f), 13f, 2.0f, new Color(1f,0.5f,0.2f), false); }
 
 // ================= CONTRACT CAMERA (byte-identical) =================
 cam.orthographic=true; cam.orthographicSize=13f; cam.nearClipPlane=0.3f; cam.farClipPlane=500f;
@@ -306,7 +348,7 @@ System.Action<string,Shader> capture=(fname,replShader)=>{
 };
 
 // (a) BEAUTY — normal lit render
-capture("atelier_beauty_v2.png", null);
+capture("atelier_beauty_v3.png", null);
 
 // (b) ALBEDO — all lights off + flat white ambient (so URP/Lit shows base color unlit-ish).
 var allLights=UnityEngine.Object.FindObjectsByType<Light>(FindObjectsSortMode.None);
@@ -314,7 +356,7 @@ var savedEnabled=new System.Collections.Generic.Dictionary<Light,bool>();
 foreach(var L in allLights){ savedEnabled[L]=L.enabled; L.enabled=false; }
 var savedAmbMode=RenderSettings.ambientMode; var savedAmb=RenderSettings.ambientLight;
 RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat; RenderSettings.ambientLight=Color.white;
-capture("atelier_albedo_v2.png", null);
+capture("atelier_albedo_v3.png", null);
 // restore lights + ambient
 foreach(var kv in savedEnabled) if(kv.Key!=null) kv.Key.enabled=kv.Value;
 RenderSettings.ambientMode=savedAmbMode; RenderSettings.ambientLight=savedAmb;
@@ -329,13 +371,13 @@ RenderSettings.ambientMode=savedAmbMode; RenderSettings.ambientLight=savedAmb;
   Shader.SetGlobalFloat("_WOSDepthNear", mn); Shader.SetGlobalFloat("_WOSDepthFar", mx);
   var shRemap=Shader.Find("WOS/LinDepthRemap"); var shDepth=Shader.Find("WOS/LinDepth"); var shNorm=Shader.Find("WOS/ViewNormal");
   LOG("depth remap near="+mn.ToString("F2")+" far="+mx.ToString("F2")+" (Remap="+(shRemap!=null)+" LinDepth="+(shDepth!=null)+" ViewNormal="+(shNorm!=null)+")");
-  if(shRemap!=null) capture("atelier_depth_v2.png", shRemap);
-  else if(shDepth!=null){ capture("atelier_depth_v2.png", shDepth); LOG("  WARN: remap shader missing -> used hardcoded /80 WOS/LinDepth"); }
+  if(shRemap!=null) capture("atelier_depth_v3.png", shRemap);
+  else if(shDepth!=null){ capture("atelier_depth_v3.png", shDepth); LOG("  WARN: remap shader missing -> used hardcoded /80 WOS/LinDepth"); }
   else LOG("  MISSING both depth shaders");
-  if(shNorm!=null) capture("atelier_normal_v2.png", shNorm); else LOG("  MISSING WOS/ViewNormal");
+  if(shNorm!=null) capture("atelier_normal_v3.png", shNorm); else LOG("  MISSING WOS/ViewNormal");
 }
 
-LOG("BUILT floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp);
-LOG("captures -> Captures-Durable/atelier_{beauty,albedo,depth,normal}_v2.png");
+LOG("BUILT floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp+" plinth/steps="+nPlinth);
+LOG("captures -> Captures-Durable/atelier_{beauty,albedo,depth,normal}_v3.png");
 System.IO.File.WriteAllText("/home/unity/worldos-unity/atelier_report.txt", sb.ToString());
-return "OK atelier v2: floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp+" (report -> atelier_report.txt)";
+return "OK atelier v3: floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp+" plinth="+nPlinth+" (report -> atelier_report.txt)";

--- a/extensions/renderers/unity/scripts/build_atelier_crypt.cs
+++ b/extensions/renderers/unity/scripts/build_atelier_crypt.cs
@@ -20,8 +20,9 @@ string GEO="/home/unity/worldos-unity/room_geometry.json";
 if(!System.IO.File.Exists(GEO)) return "no geometry json: "+GEO;
 var geo=MiniJson.Parse(System.IO.File.ReadAllText(GEO)) as System.Collections.Generic.Dictionary<string,object>;
 if(geo==null) return "geometry parse failed";
-int cols=geo.ContainsKey("cols")?System.Convert.ToInt32(geo["cols"]):14;
-int rows=geo.ContainsKey("rows")?System.Convert.ToInt32(geo["rows"]):11;
+object colsObj, rowsObj;
+int cols=geo.TryGetValue("cols", out colsObj)?System.Convert.ToInt32(colsObj):14;
+int rows=geo.TryGetValue("rows", out rowsObj)?System.Convert.ToInt32(rowsObj):11;
 float cx0=(cols-1)/2.0f, cy0=(rows-1)/2.0f, CELL=2.0f;
 System.Func<int,int,Vector3> cellToWorld=(c,r)=> new Vector3((c-cx0)*CELL, 0f, (cy0-r)*CELL);
 
@@ -116,7 +117,8 @@ for(int r=0;r<rows;r++) for(int c=0;c<cols;c++){ var w=cellToWorld(c,r); if(plac
 // Read the grid's perimeter walls and keep ONLY the far ones so the camera sees the interior.
 // A wall piece spans one 2.0 cell edge; face inward. Wall_01's face lies in a plane — we scale its
 // footprint span to 2.0 along the edge axis and yaw it so its outward normal points AWAY from the room.
-var wallCells=geo.ContainsKey("walls")?geo["walls"] as System.Collections.Generic.List<object>:null;
+object wallsObj;
+var wallCells=geo.TryGetValue("walls", out wallsObj)?wallsObj as System.Collections.Generic.List<object>:null;
 int nWall=0;
 // Wall placer: scale the wall's LOCAL long axis (x, pre-yaw) so its footprint spans one 2.0 cell edge,
 // keep thickness+height native, THEN yaw so the face points inward, then seat base on floor (y=0) at edgePos.
@@ -261,7 +263,7 @@ System.Func<Color,float,Material> stoneMat=(col,gloss)=>{ var m=new Material(Sha
 // albedo there floods the LIT budget. Floor kept low for the same reason.
 Color colFloor=new Color(0.30f,0.29f,0.28f), colWall=new Color(0.28f,0.275f,0.265f), colPillar=new Color(0.42f,0.41f,0.39f), colTomb=new Color(0.52f,0.50f,0.47f), colProp=new Color(0.34f,0.32f,0.30f);
 { int nm2=0;
-  foreach(var r in root.GetComponentsInChildren<Renderer>(true)){ if(r==null) continue; string tn=r.transform.root==null?r.name:"";
+  foreach(var r in root.GetComponentsInChildren<Renderer>(true)){ if(r==null) continue;
     // classify by the top-of-root instance name (walk up to the AtelierCrypt direct child)
     var t=r.transform; while(t.parent!=null && t.parent!=root.transform) t=t.parent; string nm3=t.name;
     Color c=colProp; float g=0.05f;

--- a/extensions/renderers/unity/scripts/build_atelier_crypt.cs
+++ b/extensions/renderers/unity/scripts/build_atelier_crypt.cs
@@ -25,9 +25,12 @@ int rows=geo.ContainsKey("rows")?System.Convert.ToInt32(geo["rows"]):11;
 float cx0=(cols-1)/2.0f, cy0=(rows-1)/2.0f, CELL=2.0f;
 System.Func<int,int,Vector3> cellToWorld=(c,r)=> new Vector3((c-cx0)*CELL, 0f, (cy0-r)*CELL);
 
-// --- idempotent: delete any prior AtelierCrypt root + its lights ---
+// --- idempotent: delete any prior AtelierCrypt root + ALL prior AK_* rig lights (prefix match, NOT a
+// fixed name list — a stale list silently LEAKS renamed lights across runs, which double-counts LIT). ---
 { var prev=GameObject.Find("AtelierCrypt"); if(prev!=null) UnityEngine.Object.DestroyImmediate(prev);
-  foreach(var ln in new[]{"AK_MoonKey","AK_TorchSarc","AK_TorchWall","AK_ArchVoid","AK_RimFill"}){ var o=GameObject.Find(ln); if(o!=null) UnityEngine.Object.DestroyImmediate(o); } }
+  var _stale=new System.Collections.Generic.List<GameObject>();
+  foreach(var g in UnityEngine.Object.FindObjectsByType<GameObject>(FindObjectsSortMode.None)){ if(g!=null && g.name.StartsWith("AK_")) _stale.Add(g); }
+  foreach(var g in _stale){ if(g!=null) UnityEngine.Object.DestroyImmediate(g); } }
 var root=new GameObject("AtelierCrypt");
 
 // --- prefab loader by asset name (verify exact names via AssetDatabase.FindAssets) ---
@@ -72,13 +75,27 @@ System.Func<GameObject,string,Vector3,float,float,float,GameObject> place=(prefa
   return inst;
 };
 
+// v2: explicit-scale placer — apply a localScale vector, then re-measure and seat base on floor at worldXZ.
+// Used for the monumental pillars (non-uniform XZ vs Y) and the uniformly-scaled hero tomb.
+System.Func<GameObject,string,Vector3,Vector3,float,GameObject> placeScaled=(prefab,name,worldXZ,scale,yaw)=>{
+  if(prefab==null){ LOG("  MISSING prefab for "+name); return null; }
+  var inst=(GameObject)PrefabUtility.InstantiatePrefab(prefab); inst.name=name; inst.transform.SetParent(root.transform,true);
+  inst.transform.position=Vector3.zero; inst.transform.rotation=Quaternion.Euler(0f,yaw,0f); inst.transform.localScale=scale;
+  var b1=worldBounds(inst);
+  Vector3 pivotOffset=inst.transform.position - b1.center; float baseY=b1.min.y;
+  inst.transform.position=new Vector3(worldXZ.x+pivotOffset.x, pivotOffset.y-baseY, worldXZ.z+pivotOffset.z);
+  return inst;
+};
+
 var pWall  = loadPrefab("SM_Bld_Base_Wall_01");
 var pFloor = loadPrefab("SM_Bld_Base_Floor_01");
 var pPil1  = loadPrefab("SM_Bld_Base_Pillar_01");
 var pPil2  = loadPrefab("SM_Bld_Base_Pillar_02");
 var pTomb  = loadPrefab("SM_Prop_Tomb_Royal_01");            // sarcophagus (royal tomb, spans two cells)
 if(pTomb==null) pTomb=loadPrefab("SM_Prop_Tomb_01");
-LOG("prefabs: Wall="+(pWall!=null)+" Floor="+(pFloor!=null)+" Pillar01="+(pPil1!=null)+" Pillar02="+(pPil2!=null)+" Tomb="+(pTomb!=null));
+var pLid   = loadPrefab("SM_Prop_Tomb_Royal_Lid_01");       // v2 fix 5: lid so the tomb reads CLOSED/solid
+if(pLid==null) pLid=loadPrefab("SM_Prop_Tomb_Lid_01");
+LOG("prefabs: Wall="+(pWall!=null)+" Floor="+(pFloor!=null)+" Pillar01="+(pPil1!=null)+" Pillar02="+(pPil2!=null)+" Tomb="+(pTomb!=null)+" Lid="+(pLid!=null));
 
 // --- MEASURE native bounds of each modular piece (report the Synty pivot/size gotchas) ---
 System.Func<GameObject,string,string> measure=(pf,label)=>{
@@ -103,15 +120,17 @@ var wallCells=geo.ContainsKey("walls")?geo["walls"] as System.Collections.Generi
 int nWall=0;
 // Wall placer: scale the wall's LOCAL long axis (x, pre-yaw) so its footprint spans one 2.0 cell edge,
 // keep thickness+height native, THEN yaw so the face points inward, then seat base on floor (y=0) at edgePos.
+// v2 fix 1: MONUMENTAL walls. Scale local long axis (x) to one 2.0-cell edge, scale Y by heightScale
+// (~2.2x -> ~6.6 world units tall from native 3.01), keep thickness native, THEN yaw + seat on floor.
+float WALL_H=2.2f;   // v2: walls ~6.6 world units tall (native 3.01 * 2.2)
 System.Action<string,Vector3,float> placeWall=(name,edgePos,yaw)=>{
   if(pWall==null){ LOG("  MISSING Wall prefab"); return; }
   var inst=(GameObject)PrefabUtility.InstantiatePrefab(pWall); inst.name=name; inst.transform.SetParent(root.transform,true);
   inst.transform.position=Vector3.zero; inst.transform.rotation=Quaternion.identity; inst.transform.localScale=Vector3.one;
   var b0=worldBounds(inst);
-  // long axis of the wall in local space (Synty base walls run along X). Scale x so long axis == CELL.
   float longAxis=Mathf.Max(b0.size.x,b0.size.z);
   float s = longAxis>1e-4f ? CELL/longAxis : 1f;
-  inst.transform.localScale=new Vector3(s,1f,1f); // scale only the footprint long axis (x); keep height+thickness native
+  inst.transform.localScale=new Vector3(s,WALL_H,1f); // long axis -> 2.0 cell; Y -> monumental; thickness native
   inst.transform.rotation=Quaternion.Euler(0f,yaw,0f);
   var b1=worldBounds(inst);
   Vector3 pivotOffset=inst.transform.position - b1.center; float baseY=b1.min.y;
@@ -129,40 +148,69 @@ if(wallCells!=null) foreach(var wo in wallCells){ var wc=wo as System.Collection
   else if(isRight){ placeWall("WallRight_"+r, new Vector3(w.x+CELL*0.5f, 0, w.z), 90f); } // yaw 90: face -x inward
 }
 
-// --- PILLARS: two DIFFERENT variants (anti-clone) at (4,4) and (9,4), native footprint, base on floor ---
+// --- PILLARS (v2 fix 1): MONUMENTAL load-bearing columns, two DIFFERENT variants (anti-clone).
+// Native ~0.43 wide x 3.02 tall -> XZ x3.5 (~1.5 wide), Y x1.9 (~5.7 tall). Anti-clone: B a touch
+// beefier + yawed 45 so the two columns don't read identical.
 int nPil=0;
-{ var w=cellToWorld(4,4); if(place(pPil1,"Pillar_A",new Vector3(w.x,0,w.z),0f,0f,0f)!=null) nPil++; }
-{ var w=cellToWorld(9,4); if(place(pPil2,"Pillar_B",new Vector3(w.x,0,w.z),0f,0f,0f)!=null) nPil++; }
+{ var w=cellToWorld(4,4); if(placeScaled(pPil1,"Pillar_A",new Vector3(w.x,0,w.z), new Vector3(3.5f,1.9f,3.5f), 0f)!=null) nPil++; }
+{ var w=cellToWorld(9,4); if(placeScaled(pPil2,"Pillar_B",new Vector3(w.x,0,w.z), new Vector3(3.8f,2.0f,3.8f), 45f)!=null) nPil++; }
 
-// --- SARCOPHAGUS: royal tomb spanning cells (6,5)-(7,5). Center between the two cells; span 2 cells in X. ---
+// --- SARCOPHAGUS (v2 fix 1c + 5): royal tomb spanning cells (6,5)-(7,5), the monumental HERO prop.
+// Native ~1.05 x 0.63 x 2.43 (long axis Z). yaw 90 lays the long axis along X (cells 6,7 adjacent in X);
+// uniform x1.6 makes it monumental. A ROYAL LID placed on top makes it read CLOSED/solid, not an open tray.
 int nSarc=0;
 { var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
-  // GOTCHA: SM_Prop_Tomb_Royal_01 native LONG axis is Z (size ~1.05 x 0.63 x 2.43). The sarcophagus
-  // spans cells (6,5)-(7,5) which are adjacent in X, so yaw 90 to lay the long axis along X, then the
-  // post-yaw footprint's long axis (now X) is scaled to span ~2 cells; keep it low (native ~0.63 tall).
-  // With yaw, place()'s spanX applies to world-X (the long axis after rotation) and spanZ to world-Z.
-  var inst=place(pTomb,"Sarcophagus",new Vector3(mid.x,0,mid.z), CELL*2f*0.9f, CELL*0.82f, 90f);
-  if(inst!=null){ nSarc++; LOG("sarcophagus: SM_Prop_Tomb_Royal_01 yaw90 spanning (6,5)-(7,5)"); }
+  float TOMB_S=1.6f;
+  var inst=placeScaled(pTomb,"Sarcophagus",new Vector3(mid.x,0,mid.z), new Vector3(TOMB_S,TOMB_S,TOMB_S), 90f);
+  if(inst!=null){ nSarc++; LOG("sarcophagus: SM_Prop_Tomb_Royal_01 yaw90 x1.6 spanning (6,5)-(7,5)");
+    var tb=worldBounds(inst);   // measure the placed tomb so the lid sits ON its top face
+    if(pLid!=null){
+      var lid=(GameObject)PrefabUtility.InstantiatePrefab(pLid); lid.name="SarcophagusLid"; lid.transform.SetParent(root.transform,true);
+      lid.transform.position=Vector3.zero; lid.transform.rotation=Quaternion.Euler(0f,90f,0f); lid.transform.localScale=new Vector3(TOMB_S,TOMB_S,TOMB_S);
+      var lb=worldBounds(lid); Vector3 lpo=lid.transform.position-lb.center;
+      // center the lid on the tomb XZ, seat its base on the tomb's top (tb.max.y)
+      lid.transform.position=new Vector3(tb.center.x+lpo.x, (lpo.y - lb.min.y) + tb.max.y - 0.02f, tb.center.z+lpo.z);
+      LOG("sarcophagus lid: "+(pLid.name)+" seated on tomb top y="+tb.max.y.ToString("F2"));
+    } else LOG("sarcophagus lid: NO lid prefab -> tomb reads as open tray");
+  }
   else LOG("sarcophagus: NO tomb prefab found -> using scaled Base piece note");
 }
 
-// --- SET-DRESSING props along walls/corners (pathing-safe: edges only, never interior lanes) ---
+// --- SET-DRESSING (v2 fix 4): DENSITY x3, 15-20 props, edges only (pathing-safe), ANTI-CLONE jitter.
 // PolygonDungeonMap is a library/study pack (bookcases, knight-stands, globe, book piles) — a crypt-library.
-int nProp=0;
-System.Func<string,int,int,float,float,float,bool> dress=(prefabNm,c,r,spanX,spanZ,yaw)=>{
+// Each prop gets a per-instance yaw jitter (+-10 deg) and scale jitter (0.95-1.10) so no two read identical.
+int nProp=0; int jseed=0;
+System.Func<string,int,int,float,bool> dress=(prefabNm,c,r,baseYaw)=>{
   var pf=loadPrefab(prefabNm); if(pf==null){ LOG("  MISSING dressing "+prefabNm); return false; }
-  var w=cellToWorld(c,r); var i=place(pf,"Dress_"+prefabNm+"_"+c+"_"+r,new Vector3(w.x,0,w.z),spanX,spanZ,yaw);
+  // deterministic jitter from an incrementing seed (repeatable renders)
+  jseed++; float jy=((jseed*37)%21)-10f; float js=0.95f+(((jseed*53)%16)/100f);   // yaw +-10, scale 0.95-1.10
+  var w=cellToWorld(c,r);
+  var i=placeScaled(pf,"Dress_"+prefabNm+"_"+c+"_"+r,new Vector3(w.x,0,w.z), new Vector3(js,js,js), baseYaw+jy);
   return i!=null;
 };
-// along the back wall (r=1, just inside) — bookcases facing -z (into room)
-if(dress("SM_Prop_Bookcase_Grand_01",2,1,0f,0f,180f)) nProp++;
-if(dress("SM_Prop_Bookcase_01",       11,1,0f,0f,180f)) nProp++;
-// right wall (c=12, just inside) — knight stands facing -x
-if(dress("SM_Prop_KnightStand_Royal_01",12,3,0f,0f,-90f)) nProp++;
-if(dress("SM_Prop_KnightStand_01",       12,7,0f,0f,-90f)) nProp++;
-// corners / floor near edges — globe + book piles (small footprint, edge cells)
-if(dress("SM_Prop_Globe_01",     2,8,0f,0f,45f)) nProp++;
-if(dress("SM_Prop_Book_Pile_01", 11,8,0f,0f,-30f)) nProp++;
+// ROW of bookcases along the back wall (r=1, facing -z into room) — 4 across, varied yaw/scale via jitter
+if(dress("SM_Prop_Bookcase_Grand_01", 2,1, 180f)) nProp++;
+if(dress("SM_Prop_Bookcase_01",        4,1, 180f)) nProp++;
+if(dress("SM_Prop_Bookcase_02",        8,1, 180f)) nProp++;
+if(dress("SM_Prop_Bookcase_Grand_02", 11,1, 180f)) nProp++;
+// right wall (c=12, facing -x) — a row of knight stands + a broken one
+if(dress("SM_Prop_KnightStand_Royal_01", 12,2, -90f)) nProp++;
+if(dress("SM_Prop_KnightStand_01",       12,5, -90f)) nProp++;
+if(dress("SM_Prop_KnightStand_Broken_01",12,8, -90f)) nProp++;
+// KNIGHT STANDS flanking the tomb approach (the -z open side of the tomb, cells r=7 either side of x)
+if(dress("SM_Prop_KnightStand_01",       4,7, 0f)) nProp++;
+if(dress("SM_Prop_KnightStand_Royal_01", 9,7, 0f)) nProp++;
+// book piles + globes scattered at WALL BASES (back wall r=1 gaps, right wall c=12 gaps) + a couple corners
+if(dress("SM_Prop_Globe_01",      2,8, 45f)) nProp++;
+if(dress("SM_Prop_Book_Pile_01",  6,1, -30f)) nProp++;
+if(dress("SM_Prop_Book_Pile_02", 10,1, 20f)) nProp++;
+if(dress("SM_Prop_Book_Pile_03",  2,4, 60f)) nProp++;
+if(dress("SM_Prop_Book_Pile_01", 12,3, -90f)) nProp++;
+if(dress("SM_Prop_Book_Pile_02", 11,8, -120f)) nProp++;
+if(dress("SM_Prop_Book_Stand_01", 3,9, 15f)) nProp++;
+if(dress("SM_Prop_Book_Stand_02", 8,8, -20f)) nProp++;
+if(dress("SM_Prop_Bookcase_Small_01", 5,1, 180f)) nProp++;
+if(dress("SM_Prop_Papers_01",     7,9, 30f)) nProp++;
 
 // ================= MATERIAL NORMALIZATION (geometry spike) =================
 // The box's Synty import is PARTIAL: PolygonDungeonMap prefab renderers have NULL materials (missing
@@ -174,7 +222,10 @@ if(dress("SM_Prop_Book_Pile_01", 11,8,0f,0f,-30f)) nProp++;
 // carved geometric detail (fluted pillars, royal tomb, bookcases); only the surface is swapped to a
 // value-correct matte stone so the beauty/albedo/depth/normal passes are crisp.
 System.Func<Color,float,Material> stoneMat=(col,gloss)=>{ var m=new Material(Shader.Find("Standard")); m.color=col; m.SetFloat("_Glossiness",gloss); m.SetFloat("_Metallic",0f); return m; };
-Color colFloor=new Color(0.32f,0.31f,0.30f), colWall=new Color(0.40f,0.39f,0.38f), colPillar=new Color(0.46f,0.45f,0.43f), colTomb=new Color(0.52f,0.50f,0.47f), colProp=new Color(0.36f,0.34f,0.32f);
+// v2: walls darkened (0.40->0.28) so the wall-torch wash reads as a warm MIDTONE glow (fix 3: walls catch
+// light) rather than a blown L>60 highlight — the tall walls are big camera-facing surfaces, so a bright
+// albedo there floods the LIT budget. Floor kept low for the same reason.
+Color colFloor=new Color(0.30f,0.29f,0.28f), colWall=new Color(0.28f,0.275f,0.265f), colPillar=new Color(0.42f,0.41f,0.39f), colTomb=new Color(0.52f,0.50f,0.47f), colProp=new Color(0.34f,0.32f,0.30f);
 { int nm2=0;
   foreach(var r in root.GetComponentsInChildren<Renderer>(true)){ if(r==null) continue; string tn=r.transform.root==null?r.name:"";
     // classify by the top-of-root instance name (walk up to the AtelierCrypt direct child)
@@ -199,42 +250,42 @@ int hidLight=0; foreach(var ll in UnityEngine.Object.FindObjectsByType<Light>(Fi
   if(ll==null) continue; if(ll.gameObject.name.StartsWith("AK_")) continue; if(ll.enabled){ ll.enabled=false; hidLight++; } }
 LOG("isolation: hid "+hidRend+" foreign renderers, "+hidLight+" foreign lights");
 
-// ================= STAGING-LAW LIGHT RIG (the law: frame 66-80% near-black, 2-4% lit) =================
-// ambient nearly void (a hair above void so the walls/pillars aren't pure crush; tuned in the gate loop)
+// ================= STAGING-LAW LIGHT RIG v2 (the law: frame 60-85% L<26, 2-5% L>60) =================
+// v2: bigger walls eat more light -> point intensities raised ~1.5x vs v1. Emissive rim quad REMOVED
+// (builtin has no realtime GI -> it contributed 0 light and rendered as a glowing rectangle artifact);
+// replaced with a real cool rim POINT light behind/above the tomb. Added 2 warm wall-torch points sitting
+// ~0.5 units OFF a wall FACE so each throws a visible pool UP the wall surface (walls were reading as void fins).
 RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat;
-RenderSettings.ambientLight=new Color(0.058f,0.062f,0.080f);
+RenderSettings.ambientLight=new Color(0.068f,0.072f,0.092f);
 RenderSettings.reflectionIntensity=0f;
 // NO bright directional — a faint cool moon key only
 { var g=new GameObject("AK_MoonKey"); var L=g.AddComponent<Light>(); L.type=LightType.Directional;
-  L.color=new Color(0.5f,0.6f,0.9f); L.intensity=0.24f; L.shadows=LightShadows.Soft; L.shadowStrength=0.85f;
+  L.color=new Color(0.5f,0.6f,0.9f); L.intensity=0.30f; L.shadows=LightShadows.Soft; L.shadowStrength=0.85f;
   g.transform.rotation=Quaternion.Euler(55f,40f,0f); }
-// 2-3 TIGHT warm point lights (range 8-14, warm 1,0.55,0.25). Values tuned in the gate loop.
-System.Action<string,Vector3,float,float,Color> pt=(nm,pos,rng,inten,col)=>{
+System.Action<string,Vector3,float,float,Color,bool> pt=(nm,pos,rng,inten,col,shadow)=>{
   var g=new GameObject(nm); var L=g.AddComponent<Light>(); L.type=LightType.Point; L.color=col;
-  L.range=rng; L.intensity=inten; L.shadows=LightShadows.Soft; L.shadowStrength=0.7f; g.transform.position=pos; };
+  L.range=rng; L.intensity=inten; L.shadows=shadow?LightShadows.Soft:LightShadows.None; L.shadowStrength=0.7f; g.transform.position=pos; };
 Color warm=new Color(1f,0.55f,0.25f);
-// spread over peaky: wider range + lower peak intensity pushes pixels into the 26-60 MIDTONE band
-// (neither dark nor lit), so the visible floor lifts above L=26 without the bright cores exceeding the 5% lit cap.
-// spread over peaky: wide range lifts the floor midtones (dark% down); modest peak keeps bright cores
-// under the 5% lit cap. Raising each light a bit HIGHER also softens the near-source hotspot.
+Vector3 backZ_edge=new Vector3(0f,0f,(cy0+0.5f)*CELL);  // z of the visible back(+z) wall face
+Vector3 rightX_edge=new Vector3((cx0+0.5f)*CELL,0f,0f); // x of the visible right(+x) wall face
+// iteration 4 (v2): the LIT budget is dominated by (a) the wall-torch near-field HOTSPOTS on the wall
+// surface (a point 0.5 off the face burns a bright core via steep inverse-square) and (b) a broad mid-floor
+// warm wash tipping over L=60. Fixes: push each wall torch ~1.1 off the face (softer near-field), drop
+// intensity, and tighten the tomb pool so the surrounding floor sits in the 26-60 MIDTONE band, not lit.
+// iteration 5 (v2): the wall-torch near-field cores stay >L60 regardless of wall albedo (it's the LIGHT,
+// not the surface), so cut wall-torch intensity hard — the wall still catches a warm MIDTONE wash (fix 3
+// satisfied: walls are lit, not void fins) but the core no longer blows past L60. Tomb pool trimmed too.
+// iteration 6 (v2, TRUE baseline after the light-leak fix): re-tune up from a clean zero.
 { var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
-  pt("AK_TorchSarc", new Vector3(mid.x, 3.4f, mid.z), 15f, 3.7f, warm); }          // over the sarcophagus
-{ var wl=cellToWorld(4,4); pt("AK_TorchWall", new Vector3(wl.x-1.4f, 4.0f, wl.z), 14f, 3.0f, warm); } // wall torch by pillar A
-{ var wa=cellToWorld(6,0); pt("AK_ArchVoid",  new Vector3(wa.x, 4.0f, wa.z+1.2f), 13f, 2.1f, new Color(1f,0.5f,0.2f)); } // faint archway/void
-// ONE emissive-plane rim-fill (PoE recipe): a thin quad with an emissive URP material behind/above the
-// sarcophagus as a COOL rim (does NOT cast — it's just emissive geometry).
+  pt("AK_TorchSarc", new Vector3(mid.x, 3.8f, mid.z), 14f, 5.0f, warm, true); }       // hero pool over the tomb
+// FIX 2: cool RIM point behind/above the tomb (replaces the dead emissive quad)
 { var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
-  var q=GameObject.CreatePrimitive(PrimitiveType.Quad); q.name="AK_RimFill"; UnityEngine.Object.DestroyImmediate(q.GetComponent<Collider>());
-  q.transform.SetParent(root.transform,true);
-  q.transform.position=new Vector3(mid.x, 3.2f, mid.z+1.6f);   // behind (+z) and above the sarcophagus
-  q.transform.rotation=Quaternion.Euler(18f,180f,0f); q.transform.localScale=new Vector3(4.5f,2.2f,1f);
-  // Runtime pipeline is BUILTIN here (GraphicsSettings.currentRenderPipeline==null; URP/Lit is NOT
-  // Shader.Find-able) — use the Standard shader with emission, matching build_room_greybox.cs.
-  var lit=Shader.Find("Standard"); var m=new Material(lit);
-  m.EnableKeyword("_EMISSION"); m.globalIlluminationFlags=UnityEngine.MaterialGlobalIlluminationFlags.RealtimeEmissive;
-  m.SetColor("_EmissionColor", new Color(0.30f,0.42f,0.62f)*1.05f);
-  m.SetColor("_Color", new Color(0.02f,0.03f,0.05f)); m.SetFloat("_Glossiness",0f);
-  q.GetComponent<Renderer>().sharedMaterial=m; }
+  pt("AK_RimCool", new Vector3(mid.x, 4.2f, mid.z+1.8f), 10f, 1.6f, new Color(0.30f,0.45f,0.70f), false); }
+// FIX 3: two warm WALL-TORCH points ~1.2 off a wall FACE — warm midtone wash up the wall (walls catch light).
+{ var wc=cellToWorld(4,1); pt("AK_TorchBackWall", new Vector3(wc.x, 4.8f, backZ_edge.z-1.2f), 11f, 3.0f, warm, false); }
+{ var wc=cellToWorld(12,4); pt("AK_TorchRightWall", new Vector3(rightX_edge.x-1.2f, 4.8f, wc.z), 11f, 3.0f, warm, false); }
+// faint archway/void point near the back-center door:
+{ var wa=cellToWorld(6,0); pt("AK_ArchVoid",  new Vector3(wa.x, 4.2f, wa.z+1.0f), 12f, 2.2f, new Color(1f,0.5f,0.2f), false); }
 
 // ================= CONTRACT CAMERA (byte-identical) =================
 cam.orthographic=true; cam.orthographicSize=13f; cam.nearClipPlane=0.3f; cam.farClipPlane=500f;
@@ -255,7 +306,7 @@ System.Action<string,Shader> capture=(fname,replShader)=>{
 };
 
 // (a) BEAUTY — normal lit render
-capture("atelier_beauty.png", null);
+capture("atelier_beauty_v2.png", null);
 
 // (b) ALBEDO — all lights off + flat white ambient (so URP/Lit shows base color unlit-ish).
 var allLights=UnityEngine.Object.FindObjectsByType<Light>(FindObjectsSortMode.None);
@@ -263,18 +314,28 @@ var savedEnabled=new System.Collections.Generic.Dictionary<Light,bool>();
 foreach(var L in allLights){ savedEnabled[L]=L.enabled; L.enabled=false; }
 var savedAmbMode=RenderSettings.ambientMode; var savedAmb=RenderSettings.ambientLight;
 RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat; RenderSettings.ambientLight=Color.white;
-capture("atelier_albedo.png", null);
+capture("atelier_albedo_v2.png", null);
 // restore lights + ambient
 foreach(var kv in savedEnabled) if(kv.Key!=null) kv.Key.enabled=kv.Value;
 RenderSettings.ambientMode=savedAmbMode; RenderSettings.ambientLight=savedAmb;
 
-// (c) DEPTH + (d) NORMAL via the existing replacement shaders
-var shDepth=Shader.Find("WOS/LinDepth"); var shNorm=Shader.Find("WOS/ViewNormal");
-LOG("shaders: LinDepth="+(shDepth!=null)+" ViewNormal="+(shNorm!=null));
-if(shDepth!=null) capture("atelier_depth.png", shDepth); else LOG("  MISSING WOS/LinDepth");
-if(shNorm!=null)  capture("atelier_normal.png", shNorm); else LOG("  MISSING WOS/ViewNormal");
+// (c) DEPTH (v2 fix 6: PER-SCENE near/far remap) + (d) NORMAL via replacement shaders.
+// Measure the scene's view-space depth range at the contract camera, then feed it to WOS/LinDepthRemap
+// via global uniforms so the depth pass has a usable full-range gradient (WOS/LinDepth's hardcoded /80
+// saturates this ~64-96 scene to near-white). Fall back to WOS/LinDepth if the remap shader isn't present.
+{ var mv=cam.worldToCameraMatrix; float mn=1e9f, mx=-1e9f;
+  foreach(var r in root.GetComponentsInChildren<Renderer>()){ var b=r.bounds; for(int i=0;i<8;i++){ Vector3 c=new Vector3((i&1)==0?b.min.x:b.max.x,(i&2)==0?b.min.y:b.max.y,(i&4)==0?b.min.z:b.max.z); float d=-(mv.MultiplyPoint(c)).z; if(d<mn)mn=d; if(d>mx)mx=d; } }
+  float pad=(mx-mn)*0.04f; mn-=pad; mx+=pad;   // small margin so extremes don't clip to pure 0/1
+  Shader.SetGlobalFloat("_WOSDepthNear", mn); Shader.SetGlobalFloat("_WOSDepthFar", mx);
+  var shRemap=Shader.Find("WOS/LinDepthRemap"); var shDepth=Shader.Find("WOS/LinDepth"); var shNorm=Shader.Find("WOS/ViewNormal");
+  LOG("depth remap near="+mn.ToString("F2")+" far="+mx.ToString("F2")+" (Remap="+(shRemap!=null)+" LinDepth="+(shDepth!=null)+" ViewNormal="+(shNorm!=null)+")");
+  if(shRemap!=null) capture("atelier_depth_v2.png", shRemap);
+  else if(shDepth!=null){ capture("atelier_depth_v2.png", shDepth); LOG("  WARN: remap shader missing -> used hardcoded /80 WOS/LinDepth"); }
+  else LOG("  MISSING both depth shaders");
+  if(shNorm!=null) capture("atelier_normal_v2.png", shNorm); else LOG("  MISSING WOS/ViewNormal");
+}
 
 LOG("BUILT floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp);
-LOG("captures -> Captures-Durable/atelier_{beauty,albedo,depth,normal}.png");
+LOG("captures -> Captures-Durable/atelier_{beauty,albedo,depth,normal}_v2.png");
 System.IO.File.WriteAllText("/home/unity/worldos-unity/atelier_report.txt", sb.ToString());
-return "OK atelier: floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp+" (report -> atelier_report.txt)";
+return "OK atelier v2: floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp+" (report -> atelier_report.txt)";

--- a/extensions/renderers/unity/scripts/build_atelier_crypt.cs
+++ b/extensions/renderers/unity/scripts/build_atelier_crypt.cs
@@ -1,0 +1,280 @@
+// build_atelier_crypt.cs — ATELIER-KIT SPIKE: assemble a REAL 3D crypt from Synty modular prefabs at the
+// authored scene_grid, light it with a PoE2 "staging-law" rig, and capture a 4-pass buffer set (beauty /
+// albedo / depth / normal) at the byte-identical CONTRACT camera. This is the graphics spike scaffold — the
+// beauty pass needs crisp GEOMETRY + correct staging-law VALUE STRUCTURE, not a painterly surface (that comes
+// from a later LoRA albedo paint-over). Run:  python3 /tmp/mcprun.py --file /tmp/build_atelier_crypt.cs
+//
+// Reads /home/unity/worldos-unity/room_geometry.json (14x11 crypt: walls perimeter, pillars (4,4)/(9,4),
+// sarcophagus (6,5)-(7,5)). CONTRACT cell->world (cx0=(cols-1)/2, cy0=(rows-1)/2, cell 2.0) — the SAME map
+// the combat renderer uses. Writes a bounded report to /home/unity/worldos-unity/atelier_report.txt (mcprun
+// truncates stdout) and the 4 PNGs to Captures-Durable/.
+// NB: run as a roslyn method BODY (execute_code) — NO top-level `using` directives; use fully-qualified names.
+var sb = new System.Text.StringBuilder();
+System.Action<string> LOG = (s)=>{ sb.AppendLine(s); };
+
+Camera cam = Camera.main; if(cam==null && Camera.allCameras.Length>0) cam=Camera.allCameras[0];
+if(cam==null){ var cg=new GameObject("AtelierCam"); cam=cg.AddComponent<Camera>(); cg.tag="MainCamera"; }
+
+// --- read the authored geometry ---
+string GEO="/home/unity/worldos-unity/room_geometry.json";
+if(!System.IO.File.Exists(GEO)) return "no geometry json: "+GEO;
+var geo=MiniJson.Parse(System.IO.File.ReadAllText(GEO)) as System.Collections.Generic.Dictionary<string,object>;
+if(geo==null) return "geometry parse failed";
+int cols=geo.ContainsKey("cols")?System.Convert.ToInt32(geo["cols"]):14;
+int rows=geo.ContainsKey("rows")?System.Convert.ToInt32(geo["rows"]):11;
+float cx0=(cols-1)/2.0f, cy0=(rows-1)/2.0f, CELL=2.0f;
+System.Func<int,int,Vector3> cellToWorld=(c,r)=> new Vector3((c-cx0)*CELL, 0f, (cy0-r)*CELL);
+
+// --- idempotent: delete any prior AtelierCrypt root + its lights ---
+{ var prev=GameObject.Find("AtelierCrypt"); if(prev!=null) UnityEngine.Object.DestroyImmediate(prev);
+  foreach(var ln in new[]{"AK_MoonKey","AK_TorchSarc","AK_TorchWall","AK_ArchVoid","AK_RimFill"}){ var o=GameObject.Find(ln); if(o!=null) UnityEngine.Object.DestroyImmediate(o); } }
+var root=new GameObject("AtelierCrypt");
+
+// --- prefab loader by asset name (verify exact names via AssetDatabase.FindAssets) ---
+System.Func<string,GameObject> loadPrefab=(nm)=>{
+  var guids=AssetDatabase.FindAssets(nm+" t:Prefab");
+  foreach(var g in guids){ var pth=AssetDatabase.GUIDToAssetPath(g);
+    if(System.IO.Path.GetFileNameWithoutExtension(pth)==nm) return AssetDatabase.LoadAssetAtPath<GameObject>(pth); }
+  // fall back to first match if no exact filename hit
+  if(guids.Length>0) return AssetDatabase.LoadAssetAtPath<GameObject>(AssetDatabase.GUIDToAssetPath(guids[0]));
+  return null;
+};
+// world-space renderer bounds of an instantiated prefab (Synty pivots are often corner/base-based —
+// MEASURE, never assume). Returns (bounds, hasBounds).
+System.Func<GameObject,Bounds> worldBounds=(go)=>{
+  var rends=go.GetComponentsInChildren<Renderer>(); if(rends.Length==0) return new Bounds(go.transform.position,Vector3.zero);
+  var b=rends[0].bounds; for(int i=1;i<rends.Length;i++) b.Encapsulate(rends[i].bounds); return b;
+};
+
+// place a prefab centered at worldXZ, sitting on the floor (min.y -> 0), optionally scaled so its
+// footprint spans `spanX x spanZ` world units (0 = keep native), with a yaw. Returns the instance.
+System.Func<GameObject,string,Vector3,float,float,float,GameObject> place=(prefab,name,worldXZ,spanX,spanZ,yaw)=>{
+  if(prefab==null){ LOG("  MISSING prefab for "+name); return null; }
+  var inst=(GameObject)PrefabUtility.InstantiatePrefab(prefab); inst.name=name; inst.transform.SetParent(root.transform,true);
+  inst.transform.position=Vector3.zero; inst.transform.rotation=Quaternion.Euler(0f,yaw,0f); inst.transform.localScale=Vector3.one;
+  var b0=worldBounds(inst);
+  // scale to requested footprint. spanX/spanZ==0 => keep that axis native.
+  //  - BOTH given (props/floor): scale x,z to fit; y = mean of the two ratios (keeps proportions sane).
+  //  - ONE given (walls): scale ONLY the edge axis to the span; keep thickness + height native (scale 1).
+  if(spanX>0f && b0.size.x>1e-4f && spanZ>0f && b0.size.z>1e-4f){
+    float sx=spanX/b0.size.x, sz=spanZ/b0.size.z;
+    inst.transform.localScale=new Vector3(sx, (sx+sz)*0.5f, sz);
+  } else if(spanX>0f && b0.size.x>1e-4f){
+    float sx=spanX/b0.size.x; inst.transform.localScale=new Vector3(sx,1f,1f);
+  } else if(spanZ>0f && b0.size.z>1e-4f){
+    float sz=spanZ/b0.size.z; inst.transform.localScale=new Vector3(1f,1f,sz);
+  }
+  // re-measure after scale, then position: center on worldXZ, base on floor (y=0)
+  var b1=worldBounds(inst);
+  Vector3 pivotOffset=inst.transform.position - b1.center;         // pivot relative to bounds center
+  float baseY=b1.min.y;                                            // current world min.y
+  inst.transform.position=new Vector3(worldXZ.x + pivotOffset.x, pivotOffset.y - baseY, worldXZ.z + pivotOffset.z);
+  return inst;
+};
+
+var pWall  = loadPrefab("SM_Bld_Base_Wall_01");
+var pFloor = loadPrefab("SM_Bld_Base_Floor_01");
+var pPil1  = loadPrefab("SM_Bld_Base_Pillar_01");
+var pPil2  = loadPrefab("SM_Bld_Base_Pillar_02");
+var pTomb  = loadPrefab("SM_Prop_Tomb_Royal_01");            // sarcophagus (royal tomb, spans two cells)
+if(pTomb==null) pTomb=loadPrefab("SM_Prop_Tomb_01");
+LOG("prefabs: Wall="+(pWall!=null)+" Floor="+(pFloor!=null)+" Pillar01="+(pPil1!=null)+" Pillar02="+(pPil2!=null)+" Tomb="+(pTomb!=null));
+
+// --- MEASURE native bounds of each modular piece (report the Synty pivot/size gotchas) ---
+System.Func<GameObject,string,string> measure=(pf,label)=>{
+  if(pf==null) return label+"=<null>";
+  var t=(GameObject)PrefabUtility.InstantiatePrefab(pf); t.transform.position=Vector3.zero; t.transform.rotation=Quaternion.identity; t.transform.localScale=Vector3.one;
+  var b=worldBounds(t); var piv=t.transform.position; string s=label+" size=("+b.size.x.ToString("F2")+","+b.size.y.ToString("F2")+","+b.size.z.ToString("F2")+") min=("+b.min.x.ToString("F2")+","+b.min.y.ToString("F2")+","+b.min.z.ToString("F2")+") pivot=("+piv.x.ToString("F2")+","+piv.y.ToString("F2")+","+piv.z.ToString("F2")+")";
+  UnityEngine.Object.DestroyImmediate(t); return s;
+};
+LOG(measure(pWall,"Wall_01")); LOG(measure(pFloor,"Floor_01")); LOG(measure(pPil1,"Pillar_01")); LOG(measure(pPil2,"Pillar_02")); LOG(measure(pTomb,"Tomb"));
+
+// --- FLOOR: one Floor_01 tiled per interior cell (spans 2.0x2.0), base on y=0 ---
+int nFloor=0;
+for(int r=0;r<rows;r++) for(int c=0;c<cols;c++){ var w=cellToWorld(c,r); if(place(pFloor,"Floor_"+c+"_"+r,new Vector3(w.x,0,w.z),CELL,CELL,0f)!=null) nFloor++; }
+
+// --- WALLS: CUTAWAY iso-CRPG rule. Camera sits at the -x,-z near corner looking toward +x,+z.
+//   FAR (visible) walls  = +z BACK row (grid r==0)  and  +x RIGHT col (grid c==cols-1).
+//   NEAR (omitted) walls = -z FRONT row (grid r==rows-1) and -x LEFT col (grid c==0).
+// Read the grid's perimeter walls and keep ONLY the far ones so the camera sees the interior.
+// A wall piece spans one 2.0 cell edge; face inward. Wall_01's face lies in a plane — we scale its
+// footprint span to 2.0 along the edge axis and yaw it so its outward normal points AWAY from the room.
+var wallCells=geo.ContainsKey("walls")?geo["walls"] as System.Collections.Generic.List<object>:null;
+int nWall=0;
+// Wall placer: scale the wall's LOCAL long axis (x, pre-yaw) so its footprint spans one 2.0 cell edge,
+// keep thickness+height native, THEN yaw so the face points inward, then seat base on floor (y=0) at edgePos.
+System.Action<string,Vector3,float> placeWall=(name,edgePos,yaw)=>{
+  if(pWall==null){ LOG("  MISSING Wall prefab"); return; }
+  var inst=(GameObject)PrefabUtility.InstantiatePrefab(pWall); inst.name=name; inst.transform.SetParent(root.transform,true);
+  inst.transform.position=Vector3.zero; inst.transform.rotation=Quaternion.identity; inst.transform.localScale=Vector3.one;
+  var b0=worldBounds(inst);
+  // long axis of the wall in local space (Synty base walls run along X). Scale x so long axis == CELL.
+  float longAxis=Mathf.Max(b0.size.x,b0.size.z);
+  float s = longAxis>1e-4f ? CELL/longAxis : 1f;
+  inst.transform.localScale=new Vector3(s,1f,1f); // scale only the footprint long axis (x); keep height+thickness native
+  inst.transform.rotation=Quaternion.Euler(0f,yaw,0f);
+  var b1=worldBounds(inst);
+  Vector3 pivotOffset=inst.transform.position - b1.center; float baseY=b1.min.y;
+  inst.transform.position=new Vector3(edgePos.x+pivotOffset.x, pivotOffset.y-baseY, edgePos.z+pivotOffset.z);
+  nWall++;
+};
+if(wallCells!=null) foreach(var wo in wallCells){ var wc=wo as System.Collections.Generic.List<object>; if(wc==null||wc.Count<2) continue;
+  int c=System.Convert.ToInt32(wc[0]), r=System.Convert.ToInt32(wc[1]);
+  bool isBack = (r==0);            // +z far row  (grid r==0 -> +z, the visible back wall)
+  bool isRight= (c==cols-1);       // +x far col  (grid c==cols-1 -> +x, the visible right wall)
+  if(!(isBack||isRight)) continue; // OMIT -z near row (r==rows-1) and -x left col (c==0) => cutaway
+  var w=cellToWorld(c,r);
+  // dedupe the shared far corner (cols-1,0): count it once as back.
+  if(isBack){ placeWall("WallBack_"+c, new Vector3(w.x, 0, w.z+CELL*0.5f), 0f); }   // yaw 0: face -z inward
+  else if(isRight){ placeWall("WallRight_"+r, new Vector3(w.x+CELL*0.5f, 0, w.z), 90f); } // yaw 90: face -x inward
+}
+
+// --- PILLARS: two DIFFERENT variants (anti-clone) at (4,4) and (9,4), native footprint, base on floor ---
+int nPil=0;
+{ var w=cellToWorld(4,4); if(place(pPil1,"Pillar_A",new Vector3(w.x,0,w.z),0f,0f,0f)!=null) nPil++; }
+{ var w=cellToWorld(9,4); if(place(pPil2,"Pillar_B",new Vector3(w.x,0,w.z),0f,0f,0f)!=null) nPil++; }
+
+// --- SARCOPHAGUS: royal tomb spanning cells (6,5)-(7,5). Center between the two cells; span 2 cells in X. ---
+int nSarc=0;
+{ var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
+  // GOTCHA: SM_Prop_Tomb_Royal_01 native LONG axis is Z (size ~1.05 x 0.63 x 2.43). The sarcophagus
+  // spans cells (6,5)-(7,5) which are adjacent in X, so yaw 90 to lay the long axis along X, then the
+  // post-yaw footprint's long axis (now X) is scaled to span ~2 cells; keep it low (native ~0.63 tall).
+  // With yaw, place()'s spanX applies to world-X (the long axis after rotation) and spanZ to world-Z.
+  var inst=place(pTomb,"Sarcophagus",new Vector3(mid.x,0,mid.z), CELL*2f*0.9f, CELL*0.82f, 90f);
+  if(inst!=null){ nSarc++; LOG("sarcophagus: SM_Prop_Tomb_Royal_01 yaw90 spanning (6,5)-(7,5)"); }
+  else LOG("sarcophagus: NO tomb prefab found -> using scaled Base piece note");
+}
+
+// --- SET-DRESSING props along walls/corners (pathing-safe: edges only, never interior lanes) ---
+// PolygonDungeonMap is a library/study pack (bookcases, knight-stands, globe, book piles) — a crypt-library.
+int nProp=0;
+System.Func<string,int,int,float,float,float,bool> dress=(prefabNm,c,r,spanX,spanZ,yaw)=>{
+  var pf=loadPrefab(prefabNm); if(pf==null){ LOG("  MISSING dressing "+prefabNm); return false; }
+  var w=cellToWorld(c,r); var i=place(pf,"Dress_"+prefabNm+"_"+c+"_"+r,new Vector3(w.x,0,w.z),spanX,spanZ,yaw);
+  return i!=null;
+};
+// along the back wall (r=1, just inside) — bookcases facing -z (into room)
+if(dress("SM_Prop_Bookcase_Grand_01",2,1,0f,0f,180f)) nProp++;
+if(dress("SM_Prop_Bookcase_01",       11,1,0f,0f,180f)) nProp++;
+// right wall (c=12, just inside) — knight stands facing -x
+if(dress("SM_Prop_KnightStand_Royal_01",12,3,0f,0f,-90f)) nProp++;
+if(dress("SM_Prop_KnightStand_01",       12,7,0f,0f,-90f)) nProp++;
+// corners / floor near edges — globe + book piles (small footprint, edge cells)
+if(dress("SM_Prop_Globe_01",     2,8,0f,0f,45f)) nProp++;
+if(dress("SM_Prop_Book_Pile_01", 11,8,0f,0f,-30f)) nProp++;
+
+// ================= MATERIAL NORMALIZATION (geometry spike) =================
+// The box's Synty import is PARTIAL: PolygonDungeonMap prefab renderers have NULL materials (missing
+// material/texture refs) -> Unity renders them MAGENTA; and some PolygonGeneric materials (e.g. the pillar's
+// Generic_Concrete) compile "supported" yet still render magenta in the builtin forward path while the floor's
+// Generic_Wood (same Synty/Generic_Basic shader) renders fine. This is a CLEAN GEOMETRY / VALUE-STRUCTURE
+// spike (the painterly SURFACE comes from a later LoRA albedo paint-over), so assign a clean Standard stone
+// material to EVERY renderer under AtelierCrypt, per-kind tinted. The Synty MESHES still supply all the
+// carved geometric detail (fluted pillars, royal tomb, bookcases); only the surface is swapped to a
+// value-correct matte stone so the beauty/albedo/depth/normal passes are crisp.
+System.Func<Color,float,Material> stoneMat=(col,gloss)=>{ var m=new Material(Shader.Find("Standard")); m.color=col; m.SetFloat("_Glossiness",gloss); m.SetFloat("_Metallic",0f); return m; };
+Color colFloor=new Color(0.32f,0.31f,0.30f), colWall=new Color(0.40f,0.39f,0.38f), colPillar=new Color(0.46f,0.45f,0.43f), colTomb=new Color(0.52f,0.50f,0.47f), colProp=new Color(0.36f,0.34f,0.32f);
+{ int nm2=0;
+  foreach(var r in root.GetComponentsInChildren<Renderer>(true)){ if(r==null) continue; string tn=r.transform.root==null?r.name:"";
+    // classify by the top-of-root instance name (walk up to the AtelierCrypt direct child)
+    var t=r.transform; while(t.parent!=null && t.parent!=root.transform) t=t.parent; string nm3=t.name;
+    Color c=colProp; float g=0.05f;
+    if(nm3.StartsWith("Floor_")) c=colFloor; else if(nm3.StartsWith("Wall")) c=colWall;
+    else if(nm3.StartsWith("Pillar")) { c=colPillar; g=0.08f; } else if(nm3.StartsWith("Sarcophagus")) { c=colTomb; g=0.10f; }
+    else if(nm3=="AK_RimFill") continue;  // keep the emissive rim material
+    int slots=r.sharedMaterials.Length; var arr=new Material[slots]; var one=stoneMat(c,g); for(int i=0;i<slots;i++) arr[i]=one; r.sharedMaterials=arr; nm2++;
+  }
+  LOG("materials: normalized "+nm2+" renderers to Standard stone");
+}
+
+// ================= SCENE ISOLATION =================
+// The box scene carries leftover combat objects (a painterly backdrop plate, Hero3D/Goblin3D/FIGHTER
+// actors, Occluder_* boxes, brazier/combat lights). This is a CLEAN GEOMETRY spike — hide every renderer
+// NOT under AtelierCrypt and disable every light NOT in our AK_ rig, so only our crypt + rig is captured.
+// (Scene is not saved, so no restore is needed.)
+int hidRend=0; foreach(var rr in UnityEngine.Object.FindObjectsByType<Renderer>(FindObjectsSortMode.None)){
+  if(rr==null) continue; if(rr.transform.IsChildOf(root.transform)) continue; if(rr.enabled){ rr.enabled=false; hidRend++; } }
+int hidLight=0; foreach(var ll in UnityEngine.Object.FindObjectsByType<Light>(FindObjectsSortMode.None)){
+  if(ll==null) continue; if(ll.gameObject.name.StartsWith("AK_")) continue; if(ll.enabled){ ll.enabled=false; hidLight++; } }
+LOG("isolation: hid "+hidRend+" foreign renderers, "+hidLight+" foreign lights");
+
+// ================= STAGING-LAW LIGHT RIG (the law: frame 66-80% near-black, 2-4% lit) =================
+// ambient nearly void (a hair above void so the walls/pillars aren't pure crush; tuned in the gate loop)
+RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat;
+RenderSettings.ambientLight=new Color(0.058f,0.062f,0.080f);
+RenderSettings.reflectionIntensity=0f;
+// NO bright directional — a faint cool moon key only
+{ var g=new GameObject("AK_MoonKey"); var L=g.AddComponent<Light>(); L.type=LightType.Directional;
+  L.color=new Color(0.5f,0.6f,0.9f); L.intensity=0.24f; L.shadows=LightShadows.Soft; L.shadowStrength=0.85f;
+  g.transform.rotation=Quaternion.Euler(55f,40f,0f); }
+// 2-3 TIGHT warm point lights (range 8-14, warm 1,0.55,0.25). Values tuned in the gate loop.
+System.Action<string,Vector3,float,float,Color> pt=(nm,pos,rng,inten,col)=>{
+  var g=new GameObject(nm); var L=g.AddComponent<Light>(); L.type=LightType.Point; L.color=col;
+  L.range=rng; L.intensity=inten; L.shadows=LightShadows.Soft; L.shadowStrength=0.7f; g.transform.position=pos; };
+Color warm=new Color(1f,0.55f,0.25f);
+// spread over peaky: wider range + lower peak intensity pushes pixels into the 26-60 MIDTONE band
+// (neither dark nor lit), so the visible floor lifts above L=26 without the bright cores exceeding the 5% lit cap.
+// spread over peaky: wide range lifts the floor midtones (dark% down); modest peak keeps bright cores
+// under the 5% lit cap. Raising each light a bit HIGHER also softens the near-source hotspot.
+{ var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
+  pt("AK_TorchSarc", new Vector3(mid.x, 3.4f, mid.z), 15f, 3.7f, warm); }          // over the sarcophagus
+{ var wl=cellToWorld(4,4); pt("AK_TorchWall", new Vector3(wl.x-1.4f, 4.0f, wl.z), 14f, 3.0f, warm); } // wall torch by pillar A
+{ var wa=cellToWorld(6,0); pt("AK_ArchVoid",  new Vector3(wa.x, 4.0f, wa.z+1.2f), 13f, 2.1f, new Color(1f,0.5f,0.2f)); } // faint archway/void
+// ONE emissive-plane rim-fill (PoE recipe): a thin quad with an emissive URP material behind/above the
+// sarcophagus as a COOL rim (does NOT cast — it's just emissive geometry).
+{ var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
+  var q=GameObject.CreatePrimitive(PrimitiveType.Quad); q.name="AK_RimFill"; UnityEngine.Object.DestroyImmediate(q.GetComponent<Collider>());
+  q.transform.SetParent(root.transform,true);
+  q.transform.position=new Vector3(mid.x, 3.2f, mid.z+1.6f);   // behind (+z) and above the sarcophagus
+  q.transform.rotation=Quaternion.Euler(18f,180f,0f); q.transform.localScale=new Vector3(4.5f,2.2f,1f);
+  // Runtime pipeline is BUILTIN here (GraphicsSettings.currentRenderPipeline==null; URP/Lit is NOT
+  // Shader.Find-able) — use the Standard shader with emission, matching build_room_greybox.cs.
+  var lit=Shader.Find("Standard"); var m=new Material(lit);
+  m.EnableKeyword("_EMISSION"); m.globalIlluminationFlags=UnityEngine.MaterialGlobalIlluminationFlags.RealtimeEmissive;
+  m.SetColor("_EmissionColor", new Color(0.30f,0.42f,0.62f)*1.05f);
+  m.SetColor("_Color", new Color(0.02f,0.03f,0.05f)); m.SetFloat("_Glossiness",0f);
+  q.GetComponent<Renderer>().sharedMaterial=m; }
+
+// ================= CONTRACT CAMERA (byte-identical) =================
+cam.orthographic=true; cam.orthographicSize=13f; cam.nearClipPlane=0.3f; cam.farClipPlane=500f;
+{ Quaternion crot=Quaternion.Euler(30f,45f,0f); cam.transform.rotation=crot; cam.transform.position=-(crot*Vector3.forward)*80f; }
+cam.clearFlags=CameraClearFlags.SolidColor; cam.backgroundColor=new Color(0f,0f,0f,1f);
+int W=1344,Hh=768;
+
+// capture helper: render current cam to a PNG (respects lit scene or a replacement shader).
+System.Action<string,Shader> capture=(fname,replShader)=>{
+  var rt=new RenderTexture(W,Hh,24,RenderTextureFormat.ARGB32); rt.Create();
+  float pa=cam.aspect; var pt2=cam.targetTexture; cam.targetTexture=rt; cam.aspect=(float)W/Hh;
+  if(replShader!=null) cam.RenderWithShader(replShader,""); else cam.Render();
+  var pAct=RenderTexture.active; RenderTexture.active=rt; var t2=new Texture2D(W,Hh,TextureFormat.RGB24,false);
+  t2.ReadPixels(new Rect(0,0,W,Hh),0,0); t2.Apply(); RenderTexture.active=pAct; cam.targetTexture=pt2; cam.aspect=pa;
+  System.IO.Directory.CreateDirectory("/home/unity/worldos-unity/Captures-Durable");
+  System.IO.File.WriteAllBytes("/home/unity/worldos-unity/Captures-Durable/"+fname, t2.EncodeToPNG());
+  UnityEngine.Object.DestroyImmediate(t2); rt.Release(); UnityEngine.Object.DestroyImmediate(rt);
+};
+
+// (a) BEAUTY — normal lit render
+capture("atelier_beauty.png", null);
+
+// (b) ALBEDO — all lights off + flat white ambient (so URP/Lit shows base color unlit-ish).
+var allLights=UnityEngine.Object.FindObjectsByType<Light>(FindObjectsSortMode.None);
+var savedEnabled=new System.Collections.Generic.Dictionary<Light,bool>();
+foreach(var L in allLights){ savedEnabled[L]=L.enabled; L.enabled=false; }
+var savedAmbMode=RenderSettings.ambientMode; var savedAmb=RenderSettings.ambientLight;
+RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat; RenderSettings.ambientLight=Color.white;
+capture("atelier_albedo.png", null);
+// restore lights + ambient
+foreach(var kv in savedEnabled) if(kv.Key!=null) kv.Key.enabled=kv.Value;
+RenderSettings.ambientMode=savedAmbMode; RenderSettings.ambientLight=savedAmb;
+
+// (c) DEPTH + (d) NORMAL via the existing replacement shaders
+var shDepth=Shader.Find("WOS/LinDepth"); var shNorm=Shader.Find("WOS/ViewNormal");
+LOG("shaders: LinDepth="+(shDepth!=null)+" ViewNormal="+(shNorm!=null));
+if(shDepth!=null) capture("atelier_depth.png", shDepth); else LOG("  MISSING WOS/LinDepth");
+if(shNorm!=null)  capture("atelier_normal.png", shNorm); else LOG("  MISSING WOS/ViewNormal");
+
+LOG("BUILT floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp);
+LOG("captures -> Captures-Durable/atelier_{beauty,albedo,depth,normal}.png");
+System.IO.File.WriteAllText("/home/unity/worldos-unity/atelier_report.txt", sb.ToString());
+return "OK atelier: floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp+" (report -> atelier_report.txt)";

--- a/extensions/renderers/unity/scripts/build_atelier_crypt.cs
+++ b/extensions/renderers/unity/scripts/build_atelier_crypt.cs
@@ -195,13 +195,15 @@ if(dress("SM_Prop_Bookcase_Grand_01", 2,1, 180f)) nProp++;
 if(dress("SM_Prop_Bookcase_01",        4,1, 180f)) nProp++;
 if(dress("SM_Prop_Bookcase_02",        8,1, 180f)) nProp++;
 if(dress("SM_Prop_Bookcase_Grand_02", 11,1, 180f)) nProp++;
-// right wall (c=12, facing -x) — a row of knight stands + a broken one
-if(dress("SM_Prop_KnightStand_Royal_01", 12,2, -90f)) nProp++;
-if(dress("SM_Prop_KnightStand_01",       12,5, -90f)) nProp++;
-if(dress("SM_Prop_KnightStand_Broken_01",12,8, -90f)) nProp++;
-// KNIGHT STANDS flanking the tomb approach (the -z open side of the tomb, cells r=7 either side of x)
+// right wall (c=12, facing -x) — v4 DRESSING FIX: the 3 identical knight statuettes read as literal
+// clones, so keep ONE knight and replace the other two with DIFFERENT PolygonDungeonMap props (a leaning
+// ladder + a globe) for distinct silhouettes. Varied yaw/scale preserved via the jitter.
+if(dress("SM_Prop_KnightStand_Royal_01", 12,2, -90f)) nProp++;   // the one kept knight (royal)
+if(dress("SM_Prop_Ladder_01",            12,5, -90f)) nProp++;   // was KnightStand_01 -> leaning ladder
+if(dress("SM_Prop_Globe_01",             12,8, -90f)) nProp++;   // was KnightStand_Broken -> globe
+// tomb-flanking props (the -z open side, cells r=7 either side of x): one knight + one lectern-ish stand
 if(dress("SM_Prop_KnightStand_01",       4,7, 0f)) nProp++;
-if(dress("SM_Prop_KnightStand_Royal_01", 9,7, 0f)) nProp++;
+if(dress("SM_Prop_Book_Stand_01",        9,7, 0f)) nProp++;      // was 2nd knight -> book stand (distinct)
 // book piles + globes scattered at WALL BASES (back wall r=1 gaps, right wall c=12 gaps) + a couple corners
 if(dress("SM_Prop_Globe_01",      2,8, 45f)) nProp++;
 if(dress("SM_Prop_Book_Pile_01",  6,1, -30f)) nProp++;
@@ -283,51 +285,33 @@ int hidLight=0; foreach(var ll in UnityEngine.Object.FindObjectsByType<Light>(Fi
   if(ll==null) continue; if(ll.gameObject.name.StartsWith("AK_")) continue; if(ll.enabled){ ll.enabled=false; hidLight++; } }
 LOG("isolation: hid "+hidRend+" foreign renderers, "+hidLight+" foreign lights");
 
-// ================= STAGING-LAW LIGHT RIG v2 (the law: frame 60-85% L<26, 2-5% L>60) =================
-// v2: bigger walls eat more light -> point intensities raised ~1.5x vs v1. Emissive rim quad REMOVED
-// (builtin has no realtime GI -> it contributed 0 light and rendered as a glowing rectangle artifact);
-// replaced with a real cool rim POINT light behind/above the tomb. Added 2 warm wall-torch points sitting
-// ~0.5 units OFF a wall FACE so each throws a visible pool UP the wall surface (walls were reading as void fins).
+// ================= LIGHT RIG v4 — COMMITTED KEY + 3 POOLS (aim near-black 68-78%, lit 2.5-4.5%) ==========
+// Panel verdict on v3: the 5-6 pools read as a FLAT WASH — floor lit almost uniformly, wall-top rim read as
+// a baked-AO strip, NO committed key, NO true-black anchor. v4 reverses that: ONE strong warm DIRECTIONAL
+// KEY from the upper-left raking toward camera IS the main light (long legible cast shadows from the piers/
+// tomb/bookcases across the floor), ambient DOWN so the corners fall to legible near-black, and only THREE
+// pools (hero + one back-wall torch + arch ember). MoonKey / RimCool / the other 2 wall torches DELETED.
 RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat;
-RenderSettings.ambientLight=new Color(0.068f,0.072f,0.092f);
+RenderSettings.ambientLight=new Color(0.040f,0.043f,0.056f);   // v4: ambient DOWN — key + pools carry the frame (tuned)
 RenderSettings.reflectionIntensity=0f;
-// NO bright directional — a faint cool moon key only
-{ var g=new GameObject("AK_MoonKey"); var L=g.AddComponent<Light>(); L.type=LightType.Directional;
-  L.color=new Color(0.5f,0.6f,0.9f); L.intensity=0.30f; L.shadows=LightShadows.Soft; L.shadowStrength=0.85f;
-  g.transform.rotation=Quaternion.Euler(55f,40f,0f); }
+// FIX 1: COMMITTED KEY — one strong warm directional from the upper-left, raking across the room toward the
+// camera, SHADOWS ON (soft, strong) so the piers/tomb/bookcases throw long legible cast shadows on the floor.
+{ var g=new GameObject("AK_Key"); var L=g.AddComponent<Light>(); L.type=LightType.Directional;
+  L.color=new Color(1.0f,0.72f,0.45f); L.intensity=0.86f; L.shadows=LightShadows.Soft; L.shadowStrength=0.85f;
+  g.transform.rotation=Quaternion.Euler(50f,205f,0f); }
 System.Action<string,Vector3,float,float,Color,bool> pt=(nm,pos,rng,inten,col,shadow)=>{
   var g=new GameObject(nm); var L=g.AddComponent<Light>(); L.type=LightType.Point; L.color=col;
   L.range=rng; L.intensity=inten; L.shadows=shadow?LightShadows.Soft:LightShadows.None; L.shadowStrength=0.7f; g.transform.position=pos; };
 Color warm=new Color(1f,0.55f,0.25f);
 Vector3 backZ_edge=new Vector3(0f,0f,(cy0+0.5f)*CELL);  // z of the visible back(+z) wall face
-Vector3 rightX_edge=new Vector3((cx0+0.5f)*CELL,0f,0f); // x of the visible right(+x) wall face
-// iteration 4 (v2): the LIT budget is dominated by (a) the wall-torch near-field HOTSPOTS on the wall
-// surface (a point 0.5 off the face burns a bright core via steep inverse-square) and (b) a broad mid-floor
-// warm wash tipping over L=60. Fixes: push each wall torch ~1.1 off the face (softer near-field), drop
-// intensity, and tighten the tomb pool so the surrounding floor sits in the 26-60 MIDTONE band, not lit.
-// iteration 5 (v2): the wall-torch near-field cores stay >L60 regardless of wall albedo (it's the LIGHT,
-// not the surface), so cut wall-torch intensity hard — the wall still catches a warm MIDTONE wash (fix 3
-// satisfied: walls are lit, not void fins) but the core no longer blows past L60. Tomb pool trimmed too.
-// v3 (TRUE baseline continued): HEROIC 10.5u walls -> raise the hero pool + wall torches to y~6.5-7 so the
-// warm pools climb the tall wall faces (they'd only touch the base at y~4.8). THREE wall torches now
-// (back-left, back-right, right) so each big wall face carries a warm pool. Ranges 14-16 for the tall walls.
-// v3 iteration 2: the tomb HERO pool (cols5-7/rows2-3 = ~80% lit) dominates the LIT budget, so cut it
-// hard (intensity + range); trim the 3 wall pools; DARK has headroom (~70%) so this stays in-band.
-// v3 iteration 3: iter2 overcut (1.4% lit); bump the hero pool + wall pools back up to land ~3-4% lit.
+// FIX 2: THREE pools only.
+// hero pool over the tomb (shadowed):
 { var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
-  pt("AK_TorchSarc", new Vector3(mid.x, 5.2f, mid.z), 14f, 4.4f, warm, true); }        // hero pool over the tomb
-// FIX 2: cool RIM point behind/above the tomb (replaces the dead emissive quad)
-{ var w6=cellToWorld(6,5); var w7=cellToWorld(7,5); Vector3 mid=(w6+w7)*0.5f;
-  pt("AK_RimCool", new Vector3(mid.x, 5.4f, mid.z+2.0f), 11f, 1.5f, new Color(0.30f,0.45f,0.70f), false); }
-// FIX 3: THREE warm WALL-TORCH points ~1.3 off a wall FACE at y~6.7 so each washes a warm pool UP the tall wall.
-// back wall LEFT (over the back-left bookcases / pillar A region):
-{ var wc=cellToWorld(3,1);  pt("AK_TorchBackL", new Vector3(wc.x, 6.7f, backZ_edge.z-1.3f), 14f, 2.9f, warm, false); }
-// back wall RIGHT (over the back-right bookcases):
-{ var wc=cellToWorld(10,1); pt("AK_TorchBackR", new Vector3(wc.x, 6.7f, backZ_edge.z-1.3f), 14f, 2.6f, warm, false); }
-// right wall (mid, washing the +x wall + knight stands):
-{ var wc=cellToWorld(12,4); pt("AK_TorchRight", new Vector3(rightX_edge.x-1.3f, 6.7f, wc.z), 14f, 2.9f, warm, false); }
-// faint archway/void point near the back-center door:
-{ var wa=cellToWorld(6,0); pt("AK_ArchVoid",  new Vector3(wa.x, 5.0f, wa.z+1.0f), 13f, 2.0f, new Color(1f,0.5f,0.2f), false); }
+  pt("AK_TorchSarc", new Vector3(mid.x, 5.2f, mid.z), 11f, 2.8f, warm, true); }
+// ONE back-wall torch (washes the back wall face):
+{ var wc=cellToWorld(4,1); pt("AK_TorchBack", new Vector3(wc.x, 6.5f, backZ_edge.z-1.3f), 13f, 2.4f, warm, false); }
+// arch-void ember near the back-center door:
+{ var wa=cellToWorld(6,0); pt("AK_ArchVoid",  new Vector3(wa.x, 5.0f, wa.z+1.0f), 13f, 1.8f, new Color(1f,0.5f,0.2f), false); }
 
 // ================= CONTRACT CAMERA (byte-identical) =================
 cam.orthographic=true; cam.orthographicSize=13f; cam.nearClipPlane=0.3f; cam.farClipPlane=500f;
@@ -348,7 +332,7 @@ System.Action<string,Shader> capture=(fname,replShader)=>{
 };
 
 // (a) BEAUTY — normal lit render
-capture("atelier_beauty_v3.png", null);
+capture("atelier_beauty_v4.png", null);
 
 // (b) ALBEDO — all lights off + flat white ambient (so URP/Lit shows base color unlit-ish).
 var allLights=UnityEngine.Object.FindObjectsByType<Light>(FindObjectsSortMode.None);
@@ -356,7 +340,7 @@ var savedEnabled=new System.Collections.Generic.Dictionary<Light,bool>();
 foreach(var L in allLights){ savedEnabled[L]=L.enabled; L.enabled=false; }
 var savedAmbMode=RenderSettings.ambientMode; var savedAmb=RenderSettings.ambientLight;
 RenderSettings.ambientMode=UnityEngine.Rendering.AmbientMode.Flat; RenderSettings.ambientLight=Color.white;
-capture("atelier_albedo_v3.png", null);
+capture("atelier_albedo_v4.png", null);
 // restore lights + ambient
 foreach(var kv in savedEnabled) if(kv.Key!=null) kv.Key.enabled=kv.Value;
 RenderSettings.ambientMode=savedAmbMode; RenderSettings.ambientLight=savedAmb;
@@ -371,13 +355,13 @@ RenderSettings.ambientMode=savedAmbMode; RenderSettings.ambientLight=savedAmb;
   Shader.SetGlobalFloat("_WOSDepthNear", mn); Shader.SetGlobalFloat("_WOSDepthFar", mx);
   var shRemap=Shader.Find("WOS/LinDepthRemap"); var shDepth=Shader.Find("WOS/LinDepth"); var shNorm=Shader.Find("WOS/ViewNormal");
   LOG("depth remap near="+mn.ToString("F2")+" far="+mx.ToString("F2")+" (Remap="+(shRemap!=null)+" LinDepth="+(shDepth!=null)+" ViewNormal="+(shNorm!=null)+")");
-  if(shRemap!=null) capture("atelier_depth_v3.png", shRemap);
-  else if(shDepth!=null){ capture("atelier_depth_v3.png", shDepth); LOG("  WARN: remap shader missing -> used hardcoded /80 WOS/LinDepth"); }
+  if(shRemap!=null) capture("atelier_depth_v4.png", shRemap);
+  else if(shDepth!=null){ capture("atelier_depth_v4.png", shDepth); LOG("  WARN: remap shader missing -> used hardcoded /80 WOS/LinDepth"); }
   else LOG("  MISSING both depth shaders");
-  if(shNorm!=null) capture("atelier_normal_v3.png", shNorm); else LOG("  MISSING WOS/ViewNormal");
+  if(shNorm!=null) capture("atelier_normal_v4.png", shNorm); else LOG("  MISSING WOS/ViewNormal");
 }
 
 LOG("BUILT floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp+" plinth/steps="+nPlinth);
-LOG("captures -> Captures-Durable/atelier_{beauty,albedo,depth,normal}_v3.png");
+LOG("captures -> Captures-Durable/atelier_{beauty,albedo,depth,normal}_v4.png");
 System.IO.File.WriteAllText("/home/unity/worldos-unity/atelier_report.txt", sb.ToString());
-return "OK atelier v3: floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp+" plinth="+nPlinth+" (report -> atelier_report.txt)";
+return "OK atelier v4: floor="+nFloor+" walls="+nWall+" pillars="+nPil+" sarc="+nSarc+" props="+nProp+" plinth="+nPlinth+" (report -> atelier_report.txt)";

--- a/extensions/renderers/unity/shaders/WOSLinDepthRemap.shader
+++ b/extensions/renderers/unity/shaders/WOSLinDepthRemap.shader
@@ -1,0 +1,23 @@
+// WOSLinDepthRemap — linear view-space depth normalized over a PER-SCENE near/far range (material props
+// _Near/_Far) instead of the hardcoded /80 of WOS/LinDepth. The atelier scene's view depth spans ~64-96
+// at the contract camera, so /80 saturates near-white with no usable gradient; remapping over the measured
+// [_Near,_Far] gives a full 0..1 gradient for the paint-over structure lock. Near=0 (white) .. far=1 (black)
+// is inverted here so foreground reads bright, matching typical depth-guide conventions; flip if needed.
+// _WOSDepthNear/_WOSDepthFar are GLOBAL uniforms (not in a Properties block) so RenderWithShader picks
+// them up from Shader.SetGlobalFloat(...) — per-material props would not bind under replacement rendering.
+Shader "WOS/LinDepthRemap" {
+  SubShader {
+    Tags { "RenderType"="Opaque" }
+    Pass {
+      CGPROGRAM
+      #pragma vertex vert
+      #pragma fragment frag
+      #include "UnityCG.cginc"
+      float _WOSDepthNear; float _WOSDepthFar;
+      struct v2f { float4 pos:SV_POSITION; float d:TEXCOORD0; };
+      v2f vert(appdata_base v){ v2f o; o.pos=UnityObjectToClipPos(v.vertex); o.d = -mul(UNITY_MATRIX_MV, v.vertex).z; return o; }
+      fixed4 frag(v2f i):SV_Target { float t=saturate((i.d-_WOSDepthNear)/max(1e-3,(_WOSDepthFar-_WOSDepthNear))); float g=1.0-t; return fixed4(g,g,g,1); }
+      ENDCG
+    }
+  }
+}


### PR DESCRIPTION
## What
The Atelier-Kit spike's reusable tools, preserved on main after the lane PARKED at its pre-committed panel gate (best composite 5.4 vs img2img anchor 5.8 — see #1241 for the full verdict + unpark conditions).

**Tools (all proven working):**
- `build_atelier_crypt.cs` — deterministic scene_grid→Synty assembly at the contract camera + staging-law light rig + 4-pass buffer capture (beauty/albedo/depth/normal); 4 iterations of measured gotchas encoded (Synty edge/corner pivots, AK_* light cleanup, builtin-vs-URP).
- `atelier_luma_gate.py` — deterministic value-structure gate from measured PoE plate statistics (66-80% near-black / 2-4% lit).
- `atelier_recomposite.py` — albedo-swap light-transport recomposite (painted_albedo × beauty/albedo, linear space, surround handler).
- `WOSLinDepthRemap.shader` — per-scene near/far depth normalization (usable gradient for structure-locked painting).

## Why merge a parked lane's tools
The staging law + luma gate apply to the CURRENT img2img pipeline immediately (lighting 6.8 project-best when applied); the buffer capture + recomposite are the PoE-faithful machinery any future content-density unpark builds on. No behavior change to any existing pipeline; additive scripts/shaders only.