### PR TITLE
fix(combat): enforce action economy per-turn, not per-tool (#778)

### DIFF
--- a/qa/combat_smoke.py
+++ b/qa/combat_smoke.py
@@ -423,6 +423,12 @@ def _make_current(server, store_mod, cid, who):
     idx = next((i for i, cb in enumerate(c.combat.order) if cb.character_id == who), 0)
     c.combat.turn_index = idx
     c.combat.action_used = False
+    # #778: the action economy is now cross-tool (attack/cast/skip share the one action, keyed
+    # by casting time). Give each swept cast a genuinely fresh turn so the coverage sweep isn't
+    # rejected as a same-turn double-act — clear the full per-turn economy, not just action_used.
+    c.combat.action_purpose = ""
+    c.combat.bonus_action_used = False
+    c.combat.action_attacks_made = 0
     store_mod.save_campaign(c)
 
 

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1410,6 +1410,18 @@ class Combat(_StrictModel):
     order: list[Combatant] = Field(default_factory=list)  # sorted desc by initiative
     action_used: bool = False  # current turn's action economy
     bonus_action_used: bool = False
+    # #778: WHAT consumed the current turn's action (not just THAT one was consumed), so a
+    # cross-tool second act (cast→attack, attack→cast, cast→cast) is correctly rejected and a
+    # bonus-action spell (Healing Word) doesn't burn the action. "" == today's behaviour: no
+    # action taken, or an action taken by a pre-#778 path that didn't stamp a purpose. Old
+    # snapshots deserialize to "" and round-trip byte-for-byte. Resets every next_turn.
+    #  * ""     — action still available (or a legacy/unstamped action write)
+    #  * "cast" — the action was spent casting an action-cost spell
+    #  * "skip" — the turn was intentionally passed (use_action('skip'))
+    # The Attack action stamps action_used + action_attacks_made (its own budget) and leaves
+    # this "" so Extra-Attack multi-strikes stay unaffected; attack() reads this only to reject
+    # a strike AFTER a cast/skip already spent the action.
+    action_purpose: Literal["", "cast", "skip"] = ""
     # Attack-action economy for the CURRENT turn (additive; resets every next_turn):
     #  * action_attacks_made — how many attack() calls have resolved under the
     #    current combatant's Attack action(s) this turn. One Attack action grants

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4880,6 +4880,9 @@ def next_turn(campaign_id: str) -> dict:
         # recharges at the start of their turn.
         c.combat.action_used = False
         c.combat.bonus_action_used = False
+        # #778: clear WHAT spent the action so the new turn starts with a free action of any
+        # purpose (a cast/skip stamp from last turn must not block this turn's attack/cast).
+        c.combat.action_purpose = ""
         # Reset the per-turn attack-action economy too: a new turn starts with one
         # Attack action's worth of strikes and no Action Surge spent yet.
         c.combat.action_attacks_made = 0
@@ -5145,6 +5148,7 @@ def use_action(campaign_id: str, character_id: str, kind: str = "action") -> dic
                 ok, reason = False, "action already used this turn (already acted or skipped)"
             else:
                 c.combat.action_used = True
+                c.combat.action_purpose = "skip"  # #778: a strike/cast after a skip is rejected
         elif kind in ("action", "bonus"):
             if not is_current:
                 ok, reason = False, f"it is not {ch.name}'s turn (only a reaction acts off-turn)"
@@ -5537,6 +5541,24 @@ def attack(
                 # and Multiattack-aware for monsters with a stat-block entry). The
                 # named attack scopes the Multiattack budget to its composition
                 # (a Ghoul Claw is NOT part of its 'two Bite' Multiattack — cs F-3).
+                # #778: a strike after the action was already spent on a NON-attack purpose
+                # (a cast, or an intentional skip) is illegal — you get one action per turn,
+                # and check_action_attack only counts attacks (action_attacks_made==0 here, so
+                # it would wrongly permit this). Reject unless an Action Surge action remains
+                # (surge_actions>0), the escape hatch. action_purpose=="" (the Attack-action /
+                # legacy path) is unaffected — this only fires on cast/skip.
+                if (
+                    c.combat.action_purpose in ("cast", "skip")
+                    and c.combat.action_attacks_made == 0
+                    and c.combat.surge_actions <= 0
+                ):
+                    spent = "cast a spell" if c.combat.action_purpose == "cast" else "skipped"
+                    raise ValueError(
+                        f"{attacker.name} already {spent} this turn and cannot also attack — "
+                        f"one action per turn. Spend an Action Surge "
+                        f"(use_resource(resource='action_surge')) for a second action, or "
+                        f"advance with next_turn."
+                    )
                 ma = _attacker_multiattack_count(attacker, c, attack_name)
                 ok, reason = combat.check_action_attack(
                     is_current=True,
@@ -5736,6 +5758,18 @@ def attack(
                 attacker_cb.reaction_used = True
                 result["reaction_used"] = True
             else:
+                # #778: if this is the FIRST strike of an Attack action that FOLLOWS a prior
+                # cast/skip (the action was already spent, so this can only be legal via an
+                # Action Surge), consume that surge now — symmetrical with the cast path — so a
+                # later attack/cast can't reuse it. The purpose-guard above proved a surge was
+                # available. action_purpose=="" (a plain Attack action / legacy) never triggers
+                # this, leaving Extra-Attack multi-strike + Action-Surge behaviour byte-identical.
+                if (
+                    c.combat.action_purpose in ("cast", "skip")
+                    and c.combat.action_attacks_made == 0
+                    and c.combat.surge_actions > 0
+                ):
+                    c.combat.surge_actions -= 1
                 c.combat.action_used = True  # an Attack action consumes the turn's action
                 c.combat.action_attacks_made += 1
                 result["attacks_made_this_turn"] = c.combat.action_attacks_made
@@ -7494,6 +7528,47 @@ def cast_spell(
                         f"advance with next_turn so the order stays in sync."
                     )
                 cast_consumes_reaction = True
+        # ACTION ECONOMY BY CASTING TIME (#778). Resolve the spell's casting time into its
+        # action-economy bucket and gate the ON-TURN cast BEFORE any slot spend (a rejected
+        # cast changes nothing). Off-turn / reaction casts are governed by the reaction gate
+        # above and skip this (a reaction spell is not an action). Out of combat this is inert
+        # (caster_cb is None). Old snapshots: action_purpose defaults "" == today's behaviour.
+        #   * bonus    -> consumes bonus_action_used (NOT the action) — Healing Word then still
+        #                 leaves the action free (bonus-heal + action is a legal 5e turn);
+        #   * action   -> rejected if the action is already spent (cast/skip already stamped, an
+        #                 Attack action already begun, or action_used set) — UNLESS an Action
+        #                 Surge action is still available (surge_actions>0), the escape hatch;
+        #   * minute/hour -> refused in active combat (a 1-round is 6 seconds, not minutes).
+        # The reaction bucket needs no economy write here (handled by the reaction path).
+        cast_time_class = spells.casting_time_class(curated, srd)
+        if caster_cb is not None and not cast_consumes_reaction:
+            # is_current is True here (an off-turn cast set cast_consumes_reaction above).
+            if cast_time_class in ("minute", "hour"):
+                unit = "minutes" if cast_time_class == "minute" else "hours"
+                raise ValueError(
+                    f"cannot cast {canonical} during active combat — its casting time is "
+                    f"measured in {unit}, far longer than a 6-second combat round. Cast it "
+                    f"once combat ends."
+                )
+            if cast_time_class == "bonus":
+                if c.combat.bonus_action_used:
+                    raise ValueError(
+                        f"{ch.name} has already used its bonus action this turn and cannot "
+                        f"cast {canonical} (a bonus-action spell). Advance with next_turn."
+                    )
+            else:  # "action" (or an unrecognized string, defaulted strict)
+                action_spent = (
+                    c.combat.action_used
+                    or c.combat.action_purpose in ("cast", "skip")
+                    or c.combat.action_attacks_made > 0
+                )
+                if action_spent and c.combat.surge_actions <= 0:
+                    raise ValueError(
+                        f"{ch.name} has already used its action this turn and cannot cast "
+                        f"{canonical} (an action-cost spell). Only one action per turn — spend "
+                        f"an Action Surge (use_resource(resource='action_surge')) for a second, "
+                        f"or advance with next_turn."
+                    )
         # KNOWN / PREPARED GATE (F03-7 + F03-8). Compare CASE-INSENSITIVELY (F03-7): the
         # cast-side `canonical` is the proper-cased SRD name, but legacy snapshots may carry
         # raw-cased strings (learn_spells/prepare_spells now canonicalize on write, but old
@@ -7829,10 +7904,22 @@ def cast_spell(
         # is separate from the character, so the re-validation above didn't touch it).
         if cast_consumes_reaction and caster_cb is not None:
             caster_cb.reaction_used = True
-        # An on-turn cast consumes the combatant's action (mirrors attack()'s action_used
-        # bookkeeping). Required so next_turn's PC-skip guard recognises a spell as "acted".
+        # An on-turn cast spends the appropriate economy slot by casting time (#778). The
+        # gate above already proved it legal; record WHAT was spent so a cross-tool second act
+        # (cast→cast, cast→attack) is rejected and a bonus-action cast leaves the action free.
         elif caster_cb is not None and not cast_consumes_reaction:
-            c.combat.action_used = True
+            if cast_time_class == "bonus":
+                # A bonus-action spell consumes the bonus action ONLY — the action stays free
+                # (Healing Word then still allows use_action('action') / an action-cost cast).
+                c.combat.bonus_action_used = True
+            else:  # "action" (minute/hour were refused above)
+                # An action-cost cast spends the turn's action. If it used an Action Surge
+                # action (the action was already spent but a surge was available), consume that
+                # surge so the attack budget (attacks_allowed multiplies by 1+surge) drops back.
+                if c.combat.action_used and c.combat.surge_actions > 0:
+                    c.combat.surge_actions -= 1
+                c.combat.action_used = True
+                c.combat.action_purpose = "cast"
         save_campaign(c)
         updated = c.characters[character_id]
         result = {

--- a/servers/engine/spells.py
+++ b/servers/engine/spells.py
@@ -320,6 +320,46 @@ def parse_duration(duration: Optional[str]) -> Optional[dict]:
     return None
 
 
+def casting_time_class(*records: Optional[dict]) -> str:
+    """Classify a spell's casting time into the combat action-economy bucket the
+    engine gates on (#778). Reads the `casting_time` string off the first record
+    that carries one and normalizes across BOTH data sources — srd524 stores
+    "action" / "bonus-action" / "reaction" / "minute" / "hour"; curated records
+    store "1 action" / "1 bonus action". Returns one of:
+
+      * "action"   — an action-cost spell (default for anything unrecognized, so a
+                     new/odd string errs toward the strict once-per-turn gate);
+      * "bonus"    — a bonus-action spell (Healing Word) — consumes bonus_action_used;
+      * "reaction" — a reaction spell (Shield) — handled by the reaction path;
+      * "minute"   — a ritual-scale cast (Identify);
+      * "hour"     — an hour-scale cast (Ceremony).
+
+    Pass the records in the caller's precedence order (curated first, then srd);
+    the first with a non-empty casting_time wins. Pure data helper — no model dep."""
+    for rec in records:
+        if not rec:
+            continue
+        raw = rec.get("casting_time")
+        if not raw:
+            continue
+        text = str(raw).strip().lower()
+        # Order matters: match "bonus" before the bare "action" substring (a curated
+        # "1 bonus action" contains "action").
+        if "bonus" in text:
+            return "bonus"
+        if "reaction" in text:
+            return "reaction"
+        if "minute" in text or "min" in text:
+            return "minute"
+        if "hour" in text or "hr" in text:
+            return "hour"
+        if "action" in text:
+            return "action"
+        # An unrecognized non-empty string: fall through to the strict default below.
+        return "action"
+    return "action"
+
+
 # 5e condition names the engine tracks (mirrors models.Condition); used to spot which
 # condition a save-ends spell imposes. Kept here (not imported) so spells.py stays a
 # pure, I/O-light data helper with no model dependency.

--- a/servers/engine/tests/test_action_economy.py
+++ b/servers/engine/tests/test_action_economy.py
@@ -1,4 +1,8 @@
-"""Action economy tracker — action/bonus/reaction budget (P2.2)."""
+"""Action economy tracker — action/bonus/reaction budget (P2.2) + cross-tool
+per-TURN economy (#778): the action is a single per-turn resource shared across
+attack() / cast_spell() / use_action(), keyed by casting time, so a caster-martial
+turn can't double-act (cast+attack / attack+cast / double-cast) and a bonus-action
+spell (Healing Word) burns the BONUS action, not the action."""
 
 import pytest
 
@@ -16,6 +20,37 @@ def combat(tmp_path, monkeypatch):
     server.start_combat(cid, ids)
     return cid, ids, server.get_state(cid)["current_turn"]
 
+
+# --- caster-martial fixture (#778): a Wizard who is always first in initiative, ---
+# knows Healing Word (bonus), Fireball (action), Magic Missile (action), and has --
+# both L1 and L3 slots, plus a monster to round out the fight. --------------------
+@pytest.fixture
+def caster(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("AE778")["id"]
+    wiz = server.create_character(
+        cid, "Gale", kind="player", class_name="Wizard", apply_srd_defaults=True
+    )["id"]
+    # Deterministic turn order: the Wizard always wins initiative and is the current combatant.
+    server.update_character(cid, wiz, patch={"initiative_bonus": 100})
+    server.learn_spells(cid, wiz, ["Healing Word", "Fireball", "Magic Missile", "Fire Bolt"])
+    server.prepare_spells(cid, wiz, ["Healing Word", "Fireball", "Magic Missile"])
+    server.update_character(
+        cid, wiz, patch={"spell_slots": {"1": {"maximum": 4, "used": 0},
+                                         "3": {"maximum": 2, "used": 0}}}
+    )
+    goblin = server.create_character(cid, "Goblin", kind="monster", max_hp=20, armor_class=10)["id"]
+    server.start_combat(cid, [wiz, goblin])
+    assert server.get_state(cid)["current_turn"] == wiz, "fixture: Wizard must be current"
+    return cid, wiz, goblin
+
+
+def _cast(cid, caster_id, spell, **kw):
+    """cast_spell shorthand — we only exercise the ECONOMY, not spell resolution."""
+    return server.cast_spell(cid, caster_id, spell, **kw)
+
+
+# ============================ pre-#778 baseline ==============================
 
 def test_second_action_same_turn_is_flagged(combat):
     cid, _ids, cur = combat
@@ -46,3 +81,166 @@ def test_next_turn_refreshes_the_budget(combat):
     server.next_turn(cid)
     new_cur = server.get_state(cid)["current_turn"]
     assert server.use_action(cid, new_cur, "action")["ok"] is True  # fresh turn
+
+
+# ==================== #778 red-first: cross-tool double-act rejected =========
+
+def test_cast_then_cast_rejected(caster):
+    cid, wiz, gob = caster
+    _cast(cid, wiz, "Magic Missile", target_id=gob)  # action-cost cast spends the action
+    with pytest.raises(ValueError, match="already used its action"):
+        _cast(cid, wiz, "Fireball", target_id=gob)   # a 2nd action-cost cast is illegal
+
+
+def test_cast_then_attack_rejected(caster):
+    cid, wiz, gob = caster
+    _cast(cid, wiz, "Magic Missile", target_id=gob)  # action spent on the cast
+    with pytest.raises(ValueError, match="already cast a spell"):
+        server.attack(cid, wiz, gob, attack_bonus=5, damage_dice="1d10")
+
+
+def test_attack_then_cast_rejected(caster):
+    cid, wiz, gob = caster
+    server.attack(cid, wiz, gob, attack_bonus=5, damage_dice="1d10")  # Attack action spends it
+    with pytest.raises(ValueError, match="already used its action"):
+        _cast(cid, wiz, "Fireball", target_id=gob)
+
+
+# ==================== #778: the legitimate turns that must PASS ==============
+
+def test_healing_word_then_fireball_allowed(caster):
+    """Healing Word (bonus action) + Fireball (action) is a legal 5e turn: the
+    bonus-action heal must NOT burn the action."""
+    cid, wiz, gob = caster
+    hw = _cast(cid, wiz, "Healing Word", target_id=wiz)
+    assert hw["spell"] == "Healing Word"
+    fb = _cast(cid, wiz, "Fireball", target_id=gob)  # action still free -> allowed
+    assert fb["spell"] == "Fireball"
+
+
+def test_healing_word_then_use_action_allowed(caster):
+    """The bug the issue calls out: a bonus-action cast wrongly refused the follow-up
+    use_action('action'). It must be allowed."""
+    cid, wiz, _gob = caster
+    _cast(cid, wiz, "Healing Word", target_id=wiz)
+    out = server.use_action(cid, wiz, "action")
+    assert out["ok"] is True, "bonus-action cast must leave the action free"
+
+
+def test_healing_word_burns_only_bonus_action(caster):
+    cid, wiz, _gob = caster
+    _cast(cid, wiz, "Healing Word", target_id=wiz)
+    # Bonus is now spent; a second bonus-action verb is refused, the action untouched.
+    assert server.use_action(cid, wiz, "bonus")["ok"] is False
+    assert server.use_action(cid, wiz, "action")["ok"] is True
+
+
+def test_surge_actions_enable_a_second_cast(caster):
+    """Action Surge grants a fresh action, so a 2nd action-cost cast is legal after it."""
+    cid, wiz, gob = caster
+    server.update_character(
+        cid, wiz, patch={"class_resources": {"action_surge": {"max": 1, "used": 0}}}
+    )
+    _cast(cid, wiz, "Magic Missile", target_id=gob)  # 1st action-cost cast
+    server.use_resource(cid, wiz, "action_surge")     # grants a 2nd action this turn
+    fb = _cast(cid, wiz, "Fireball", target_id=gob)   # now allowed by the surge
+    assert fb["spell"] == "Fireball"
+    # The surge is spent: a THIRD action-cost cast is refused again.
+    with pytest.raises(ValueError, match="already used its action"):
+        _cast(cid, wiz, "Magic Missile", target_id=gob)
+
+
+def test_minute_and_hour_casts_refused_in_active_combat(caster):
+    cid, wiz, _gob = caster
+    server.learn_spells(cid, wiz, ["Identify"])   # casting time: 1 minute (ritual-scale)
+    server.prepare_spells(cid, wiz, ["Identify"])
+    with pytest.raises(ValueError, match="casting time"):
+        _cast(cid, wiz, "Identify", target_id=wiz)
+
+
+# ==================== #778: declared-action + Extra Attack stays green =======
+
+def test_declared_action_then_extra_attack_still_green(tmp_path, monkeypatch):
+    """A fighter with Extra Attack makes its two strikes under ONE Attack action —
+    action_purpose stays "" for the attack path, so #778 does not touch it."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("AE778x")["id"]
+    fighter = server.create_character(
+        cid, "Lae", kind="player", class_name="Fighter", apply_srd_defaults=True,
+        max_hp=30, armor_class=16,
+    )["id"]
+    server.update_character(cid, fighter, patch={"initiative_bonus": 100, "extra_attacks": 1})
+    gob = server.create_character(cid, "Goblin", kind="monster", max_hp=40, armor_class=5)["id"]
+    server.start_combat(cid, [fighter, gob])
+    assert server.get_state(cid)["current_turn"] == fighter
+    a1 = server.attack(cid, fighter, gob, attack_bonus=8, damage_dice="1d8+3")
+    a2 = server.attack(cid, fighter, gob, attack_bonus=8, damage_dice="1d8+3")  # Extra Attack
+    assert a1["attacks_made_this_turn"] == 1 and a2["attacks_made_this_turn"] == 2
+    # A THIRD strike (no surge, one Extra Attack) is over budget — the existing gate rejects it.
+    with pytest.raises(ValueError, match="already attacked|cannot attack"):
+        server.attack(cid, fighter, gob, attack_bonus=8, damage_dice="1d8+3")
+
+
+def test_declared_generic_action_then_attack_allowed(caster):
+    """use_action('action') declares a generic action with no purpose stamp; the
+    Attack action that follows (its concrete resolution) must still be legal — the
+    #778 guard only fires on a cast/skip purpose."""
+    cid, wiz, gob = caster
+    assert server.use_action(cid, wiz, "action")["ok"] is True
+    # action_purpose stays "" (generic), so an attack is NOT blocked by the cast/skip guard.
+    out = server.attack(cid, wiz, gob, attack_bonus=5, damage_dice="1d10")
+    assert out["attacks_made_this_turn"] == 1
+
+
+# ==================== #778: skip stamps a purpose too =======================
+
+def test_skip_then_attack_rejected(caster):
+    cid, wiz, gob = caster
+    server.use_action(cid, wiz, "skip")  # intentional pass — stamps action_purpose="skip"
+    with pytest.raises(ValueError, match="skipped this turn"):
+        server.attack(cid, wiz, gob, attack_bonus=5, damage_dice="1d10")
+
+
+def test_skip_then_cast_rejected(caster):
+    cid, wiz, gob = caster
+    server.use_action(cid, wiz, "skip")
+    with pytest.raises(ValueError, match="already used its action"):
+        _cast(cid, wiz, "Fireball", target_id=gob)
+
+
+# ==================== #778: next_turn clears the purpose ====================
+
+def test_next_turn_clears_action_purpose(caster):
+    cid, wiz, gob = caster
+    _cast(cid, wiz, "Magic Missile", target_id=gob)     # purpose="cast"
+    server.next_turn(cid)                                # -> goblin's turn
+    server.next_turn(cid)                                # -> back to the Wizard, fresh
+    assert server.get_state(cid)["current_turn"] == wiz
+    fb = _cast(cid, wiz, "Fireball", target_id=gob)      # a fresh action -> allowed
+    assert fb["spell"] == "Fireball"
+
+
+# ==================== #778: additive — old snapshots round-trip =============
+
+def test_old_snapshot_without_action_purpose_defaults_empty():
+    """A snapshot written before #778 has no `action_purpose` on Combat; the load
+    must deserialize it to "" (today's behaviour) and re-serialize identically."""
+    from models import Combat
+
+    legacy = {
+        "active": True,
+        "round": 2,
+        "turn_index": 1,
+        "order": [],
+        "action_used": True,
+        "bonus_action_used": False,
+        "action_attacks_made": 1,
+        "surge_actions": 0,
+        # NOTE: no `action_purpose` key — this is the pre-#778 shape.
+    }
+    loaded = Combat.model_validate(legacy)
+    assert loaded.action_purpose == "", "missing field must default to '' (today's behaviour)"
+    assert loaded.action_used is True and loaded.action_attacks_made == 1
+    # Round-trips: the field serializes back and reloads to the same value.
+    reloaded = Combat.model_validate(loaded.model_dump(mode="json"))
+    assert reloaded.action_purpose == ""


### PR DESCRIPTION
Fixes #778 (P1 engine bug, audit SYN-05 = F01-3 + F03-9).

## Problem
Action economy was enforced **per-tool, not per-turn**, live in both directions:
- **Too permissive:** every caster-martial turn could double-act — cast+attack, attack+cast, double-cast, skip→attack were all legal (`attack()` gated only on `action_attacks_made`; `cast_spell` set `action_used` unconditionally with no casting-time branch and never *read* it).
- **Too restrictive:** bonus-action spells (Healing Word) wrongly consumed the ACTION, so a follow-up `use_action('action')` was refused — blocking a legal 5e turn (bonus heal + action).

## Fix (additive, rejection-only)
New `Combat.action_purpose: Literal["", "cast", "skip"] = ""` records **what** consumed the turn's action, so the action is one shared per-turn resource across `cast_spell` / `attack` / `use_action`, resolved by casting time:
- **bonus** (Healing Word) → consumes `bonus_action_used`, **not** the action;
- **action** → rejects a same-turn 2nd act (`action_used` / `action_purpose in {cast,skip}` / `action_attacks_made > 0`), honoring `surge_actions` (Action Surge) as the escape hatch;
- **minute / hour** → refused in active combat;
- `attack()` symmetrically rejects a strike after a cast/skip (unless a surge remains);
- `next_turn` resets `action_purpose`.

`spells.casting_time_class()` normalizes both data sources (srd524 `action`/`bonus-action`/`reaction`/`minute`/`hour` **and** curated `1 action`/`1 bonus action`).

## Invariants honored
- **Additive / default-off:** old snapshots deserialize `action_purpose` to `""` == today's behavior (explicit round-trip test).
- **Engine = sole writer; engine-rolls untouched;** rejection-only (a refused verb spends nothing — no slot, no roll).
- **Attack path byte-identical** when `action_purpose == ""`: Extra-Attack multi-strike + Action-Surge behavior unchanged (the new guard only fires on a `cast`/`skip` purpose).

## Tests (`servers/engine/tests/test_action_economy.py` — 4 baseline + 14 new)
Red-first trio (`cast→cast`, `cast→attack`, `attack→cast` rejected) confirmed failing without the fix; plus Healing Word→Fireball allowed, Healing Word→`use_action('action')` allowed, surge enables a 2nd cast, minute/hour refused, declared-action + Extra-Attack still green, skip→attack/cast rejected, `next_turn` clears the purpose, and old-snapshot round-trip.

## Verification
- `uv run --directory servers/engine python -m pytest tests/test_action_economy.py -q -p no:xdist` → **18 passed**
- Full engine suite → **3242 passed**; integration → **7 passed / 19 skipped**
- `qa/fast_gate.sh` → **241 passed** (Tier 0 green)
- `scripts/license_check.py` → passed

One harness touch: `qa/combat_smoke.py::_make_current` (a test helper that already reset `action_used` for its multi-cast coverage sweep) now clears the full per-turn economy (`action_purpose` / `bonus_action_used` / `action_attacks_made`) so each swept cast is a genuinely fresh turn — the fast gate caught this and it is the correct fix.