### PR TITLE
feat(engine): #806 Stage 2 — equipment-owned AC with provenance flag

### DIFF
--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -857,6 +857,13 @@ class Character(_StrictModel):
 
     # vitals
     armor_class: int = 10
+    # #806 stage 2 — AC ownership provenance. Records WHO last wrote armor_class so
+    # the equip path knows whether it may recompute it: "equipment" (engine wrote it
+    # from worn armor/shield on equip), "manual" (a DM update_character(armor_class=...)
+    # override — equip must NOT clobber it), "" (legacy/unknown — treated manual-safe, so
+    # equip never silently overwrites an AC baked into an old snapshot). Empty == today's
+    # behavior; old snapshots round-trip (additive, default "").
+    armor_ac_source: str = ""
     max_hp: int = 1
     current_hp: int = 1
     temp_hp: int = 0

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -8443,16 +8443,40 @@ def _catalog_item_stats(rec: dict | None) -> dict | None:
     }
 
 
+def _unarmored_defense_base(ch: Character, dex_mod: int) -> int:
+    """#806 stage 2 — the no-body-armor base AC, mirroring _finish_seat_sheet's
+    Unarmored Defense (server.py ~1479-1483): Barbarian = 10 + DEX + CON, Monk =
+    10 + DEX + WIS; everyone else = the plain 10 + DEX baseline. Class-derived, not a
+    flat table value — so a barb/monk that re-derives with no armor keeps its class AC
+    instead of silently dropping to 10 + DEX. Matches the seat path's SINGLE rule set
+    (it computes the ability formula only; the shield is added by the caller, per the
+    barb-allows-shield / monk-forbids-shield SRD split)."""
+    classes = {(cl.name or "").lower() for cl in ch.classes}
+    if "barbarian" in classes:
+        return 10 + dex_mod + ch.ability_modifier(Ability.CON)
+    if "monk" in classes:
+        return 10 + dex_mod + ch.ability_modifier(Ability.WIS)
+    return 10 + dex_mod
+
+
 def _derive_worn_ac_from_equipped(ch: Character) -> int:
     """#806 stage 2 — recompute the worn-armor base AC purely from the character's
     currently-equipped catalog armor + shields, using the same SRD DEX-mod rules as
     _equip_mechanics (light = base+DEX, medium = base+min(DEX,cap), heavy = flat,
     shield = +bonus). Effect-CLEAN: this is the base scalar only; Mage Armor / Shield
-    of Faith still layer on at read time via _effective_armor_class. No equipped armor
-    == unarmored 10 + DEX baseline. This is the re-derive path that hands AC ownership
-    back to equipment (update_character rederive_ac=true)."""
+    of Faith still layer on at read time via _effective_armor_class. This is the
+    re-derive path that hands AC ownership back to equipment (rederive_ac=true) AND the
+    equip-path recompute — computing the FULL base from current inventory (not an
+    incremental delta) so it is order-independent and idempotent.
+
+    No BODY armor == Unarmored Defense (Barbarian 10+DEX+CON, Monk 10+DEX+WIS, else
+    10+DEX); a worn body armor OVERRIDES Unarmored Defense per the normal armor rule.
+    A shield adds its +bonus on top — EXCEPT a monk's Unarmored Defense requires no
+    shield (SRD), so a shield is dropped only for a monk who is relying on Unarmored
+    Defense (no body armor); a barbarian keeps it, and any body-armored character keeps
+    it."""
     dex_mod = ch.ability_modifier(Ability.DEX)
-    base = 10 + dex_mod  # unarmored baseline
+    body_armor_base = None  # None == no body armor worn (fall back to Unarmored Defense)
     shield_bonus = 0
     for it in ch.inventory:
         if not it.equipped:
@@ -8466,14 +8490,21 @@ def _derive_worn_ac_from_equipped(ch: Character) -> int:
         elif rec.get("ac"):
             armor_base = int(rec["ac"])
             if category == "light":
-                base = armor_base + dex_mod
+                body_armor_base = armor_base + dex_mod
             elif category == "medium":
-                base = armor_base + min(dex_mod, int(rec.get("ac_dex_cap") or 2))
+                body_armor_base = armor_base + min(dex_mod, int(rec.get("ac_dex_cap") or 2))
             elif category == "heavy":
-                base = armor_base
+                body_armor_base = armor_base
             else:
-                base = armor_base  # unknown/homebrew flat AC
-    return base + shield_bonus
+                body_armor_base = armor_base  # unknown/homebrew flat AC
+    if body_armor_base is None:
+        # A monk's Unarmored Defense feature is VOID while using a shield (SRD) — the monk
+        # may still wield the shield (its +bonus applies), but loses the WIS term, dropping
+        # to the plain 10 + DEX baseline. A barbarian keeps Unarmored Defense WITH a shield.
+        monk_with_shield = shield_bonus and "monk" in {(cl.name or "").lower() for cl in ch.classes}
+        base = (10 + dex_mod) if monk_with_shield else _unarmored_defense_base(ch, dex_mod)
+        return base + shield_bonus
+    return body_armor_base + shield_bonus
 
 
 def _equip_mechanics(ch: Character, item_name: str, equipped: bool) -> Optional[dict]:
@@ -8495,18 +8526,17 @@ def _equip_mechanics(ch: Character, item_name: str, equipped: bool) -> Optional[
     if rec.get("kind") == "armor" and (rec.get("ac") or rec.get("ac_bonus")):
         dex_mod = ch.ability_modifier(Ability.DEX)
         category = rec.get("armor_category")
-        # #806 stage 2: the value the engine WRITES into the WORN-ARMOR base scalar
-        # (ch.armor_class) is EFFECT-CLEAN — for a shield it moves the raw stored base
-        # by ±bonus, NOT the effect-inclusive current_ac (writing current_ac would bake
-        # Mage Armor / Shield-of-Faith into the base and double-count it at read time).
-        # For a fresh worn-armor equip base_write == suggested (both effect-independent).
-        base_write = None
+        # #806 stage 2: `suggested`/`ac_delta` below are ADVISORY only (the numbers the DM
+        # sees). The engine-owned WRITE does NOT use them — it FULLY recomputes the base from
+        # the (already-updated) inventory via _derive_worn_ac_from_equipped, so the stored
+        # base is order-independent + idempotent (an incremental ±delta drifts across
+        # ordering: armor-then-shield, double-equip, unequip-with-shield-on). The recompute
+        # is also effect-clean, so Mage Armor / Shield of Faith never bake into the base.
         if category == "shield" or (category is None and "shield" in rec["name"].lower()):
             # F09-6: a shield is a +N BONUS on top of the wearer's AC, not a base AC.
             # The SRD smuggles the bonus in as ac_base=2; prefer the structured ac_bonus.
             bonus = int(rec.get("ac_bonus") or rec.get("ac") or 2)
             suggested = current_ac + bonus if equipped else current_ac - bonus
-            base_write = int(ch.armor_class) + bonus if equipped else int(ch.armor_class) - bonus
             basis = f"shield {'+' if equipped else '-'}{bonus}"
         elif equipped:
             # F09-6: apply the armor's DEX-mod rule to derive the worn AC directly —
@@ -8527,18 +8557,17 @@ def _equip_mechanics(ch: Character, item_name: str, equipped: bool) -> Optional[
                 # Unknown/homebrew flat AC — keep today's behavior (bare base AC).
                 suggested = base
                 basis = f"base AC {base}; apply the armor's DEX-mod rule on top"
-            base_write = suggested  # worn-armor base is already effect-independent
         else:
             suggested = 10 + dex_mod
             basis = "unarmored baseline 10 + DEX"
-            base_write = suggested
         # #806 stage 2: WRITE the worn-armor base unless a DM manual override owns it, or
         # a legacy/unknown "" value is present (treated manual-safe — never auto-clobbered).
-        # When we own it, stamp source="equipment" and report applied=True; otherwise stay
-        # advisory (applied=False) and keep surfacing the delta so the DM can reconcile.
+        # When we own it, FULL-recompute the base from current inventory (order-independent,
+        # idempotent) and report applied=True; otherwise stay advisory (applied=False) and
+        # keep surfacing the delta so the DM can reconcile.
         engine_owns_base = ch.armor_ac_source == "equipment"
         if engine_owns_base:
-            ch.armor_class = base_write
+            ch.armor_class = _derive_worn_ac_from_equipped(ch)
             ch.armor_ac_source = "equipment"
             return {
                 "applied": True,
@@ -8546,7 +8575,7 @@ def _equip_mechanics(ch: Character, item_name: str, equipped: bool) -> Optional[
                 "suggested_ac": suggested,
                 "ac_delta": suggested - current_ac,
                 "note": (
-                    f"AC updated to {base_write} ({basis}); equipment owns this "
+                    f"AC updated to {ch.armor_class} ({basis}); equipment owns this "
                     f"character's armor class"
                 ),
             }

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -3357,6 +3357,15 @@ def update_character(campaign_id: str, character_id: str = "", patch: dict = Non
         # leave. Omitted -> membership untouched (byte-identical to today). The mutation is applied
         # AFTER the validated sheet is stored below, so a rejected patch never strands membership.
         in_party_intent = data.pop("in_party", None)
+        # #806 stage 2: `rederive_ac` is a computed INTENT (not a Character field) — pop it
+        # BEFORE model_validate (else extra="forbid" trips) and translate below into an
+        # equipment-owned AC recompute. Truthy -> hand AC ownership back to equipment and
+        # recompute armor_class from the equipped items; omitted/falsey -> untouched.
+        rederive_ac_intent = bool(data.pop("rederive_ac", None))
+        # #806 stage 2: did this patch write armor_class directly? That is a DM manual
+        # override — stamp source="manual" below so the equip path won't clobber it (unless
+        # the same call also asked to re-derive, in which case equipment wins).
+        patch_wrote_ac = "armor_class" in (patch or {})
         # F14-11: a genuine type/typo error inside the model is wrapped into ONE bounded, readable
         # line (no errors.pydantic.dev wall) so the DM can fix it in the next call instead of
         # freehanding. STILL raises a ValueError, so the strict typo-forbid guard stays load-bearing.
@@ -3416,6 +3425,16 @@ def update_character(campaign_id: str, character_id: str = "", patch: dict = Non
             hp_delta = con_delta * new_ch.total_level
             new_ch.max_hp = max(1, new_ch.max_hp + hp_delta)
             new_ch.current_hp = max(1, min(new_ch.current_hp, new_ch.max_hp))
+        # #806 stage 2: resolve AC ownership. Re-derive wins if requested — recompute the
+        # worn base from equipped items and hand ownership to equipment. Otherwise, a patch
+        # that wrote armor_class is a DM manual override (source="manual"), which the equip
+        # path must not clobber. A patch that touched neither leaves the source flag as-is
+        # (byte-identical to today for every non-AC patch).
+        if rederive_ac_intent:
+            new_ch.armor_class = _derive_worn_ac_from_equipped(new_ch)
+            new_ch.armor_ac_source = "equipment"
+        elif patch_wrote_ac:
+            new_ch.armor_ac_source = "manual"
         c.characters[character_id] = new_ch
         # F14-11 (#812): apply the translated party-membership intent AFTER the validated sheet is
         # stored (a rejected patch never reaches here). Mirrors recruit_companion / dismiss: a
@@ -8424,14 +8443,51 @@ def _catalog_item_stats(rec: dict | None) -> dict | None:
     }
 
 
+def _derive_worn_ac_from_equipped(ch: Character) -> int:
+    """#806 stage 2 — recompute the worn-armor base AC purely from the character's
+    currently-equipped catalog armor + shields, using the same SRD DEX-mod rules as
+    _equip_mechanics (light = base+DEX, medium = base+min(DEX,cap), heavy = flat,
+    shield = +bonus). Effect-CLEAN: this is the base scalar only; Mage Armor / Shield
+    of Faith still layer on at read time via _effective_armor_class. No equipped armor
+    == unarmored 10 + DEX baseline. This is the re-derive path that hands AC ownership
+    back to equipment (update_character rederive_ac=true)."""
+    dex_mod = ch.ability_modifier(Ability.DEX)
+    base = 10 + dex_mod  # unarmored baseline
+    shield_bonus = 0
+    for it in ch.inventory:
+        if not it.equipped:
+            continue
+        rec = itemcatalog.resolve(it.name)
+        if rec is None or rec.get("kind") != "armor":
+            continue
+        category = rec.get("armor_category")
+        if category == "shield" or (category is None and "shield" in rec["name"].lower()):
+            shield_bonus += int(rec.get("ac_bonus") or rec.get("ac") or 2)
+        elif rec.get("ac"):
+            armor_base = int(rec["ac"])
+            if category == "light":
+                base = armor_base + dex_mod
+            elif category == "medium":
+                base = armor_base + min(dex_mod, int(rec.get("ac_dex_cap") or 2))
+            elif category == "heavy":
+                base = armor_base
+            else:
+                base = armor_base  # unknown/homebrew flat AC
+    return base + shield_bonus
+
+
 def _equip_mechanics(ch: Character, item_name: str, equipped: bool) -> Optional[dict]:
-    """F09-5 stage 1 — TELL, don't enforce: report the mechanical consequences of
-    an equip/unequip so the DM can apply them through the existing writer paths.
-    The engine deliberately does NOT auto-write armor_class here: AC effects (e.g.
-    Mage Armor) flow through update_character today, and a silent equip-side write
-    would fight that path (stage 2 / #806 owns the AC-ownership design). Returns
-    None for items with no catalog mechanics (free-text gear) so the response stays
-    exactly the pre-existing payload."""
+    """#806 stage 2 — equipment-owned AC. On armor/shield equip/unequip the engine
+    now WRITES ch.armor_class with the worn AC it computes (light/medium/heavy DEX
+    rule + shield ±bonus) — but ONLY when the base AC isn't a DM manual override
+    (ch.armor_ac_source != "manual") and not a legacy/unknown "" value. When the
+    engine writes, it stamps armor_ac_source="equipment" and returns applied=True;
+    when the DM owns the base ("manual") or it's a manual-safe legacy "", it leaves
+    armor_class untouched and keeps surfacing the delta advisorily (applied=False)
+    so the DM can reconcile — engine computes, DM disposes. AC effects (Mage Armor,
+    Shield of Faith) still layer on top at read time via _effective_armor_class; the
+    equip write only owns the WORN-ARMOR base scalar. Returns None for items with no
+    catalog mechanics (free-text gear) so that response stays the pre-existing payload."""
     rec = itemcatalog.resolve(item_name)
     if rec is None:
         return None
@@ -8439,11 +8495,18 @@ def _equip_mechanics(ch: Character, item_name: str, equipped: bool) -> Optional[
     if rec.get("kind") == "armor" and (rec.get("ac") or rec.get("ac_bonus")):
         dex_mod = ch.ability_modifier(Ability.DEX)
         category = rec.get("armor_category")
+        # #806 stage 2: the value the engine WRITES into the WORN-ARMOR base scalar
+        # (ch.armor_class) is EFFECT-CLEAN — for a shield it moves the raw stored base
+        # by ±bonus, NOT the effect-inclusive current_ac (writing current_ac would bake
+        # Mage Armor / Shield-of-Faith into the base and double-count it at read time).
+        # For a fresh worn-armor equip base_write == suggested (both effect-independent).
+        base_write = None
         if category == "shield" or (category is None and "shield" in rec["name"].lower()):
             # F09-6: a shield is a +N BONUS on top of the wearer's AC, not a base AC.
             # The SRD smuggles the bonus in as ac_base=2; prefer the structured ac_bonus.
             bonus = int(rec.get("ac_bonus") or rec.get("ac") or 2)
             suggested = current_ac + bonus if equipped else current_ac - bonus
+            base_write = int(ch.armor_class) + bonus if equipped else int(ch.armor_class) - bonus
             basis = f"shield {'+' if equipped else '-'}{bonus}"
         elif equipped:
             # F09-6: apply the armor's DEX-mod rule to derive the worn AC directly —
@@ -8464,9 +8527,29 @@ def _equip_mechanics(ch: Character, item_name: str, equipped: bool) -> Optional[
                 # Unknown/homebrew flat AC — keep today's behavior (bare base AC).
                 suggested = base
                 basis = f"base AC {base}; apply the armor's DEX-mod rule on top"
+            base_write = suggested  # worn-armor base is already effect-independent
         else:
             suggested = 10 + dex_mod
             basis = "unarmored baseline 10 + DEX"
+            base_write = suggested
+        # #806 stage 2: WRITE the worn-armor base unless a DM manual override owns it, or
+        # a legacy/unknown "" value is present (treated manual-safe — never auto-clobbered).
+        # When we own it, stamp source="equipment" and report applied=True; otherwise stay
+        # advisory (applied=False) and keep surfacing the delta so the DM can reconcile.
+        engine_owns_base = ch.armor_ac_source == "equipment"
+        if engine_owns_base:
+            ch.armor_class = base_write
+            ch.armor_ac_source = "equipment"
+            return {
+                "applied": True,
+                "current_ac": current_ac,
+                "suggested_ac": suggested,
+                "ac_delta": suggested - current_ac,
+                "note": (
+                    f"AC updated to {base_write} ({basis}); equipment owns this "
+                    f"character's armor class"
+                ),
+            }
         return {
             "applied": False,
             "current_ac": current_ac,
@@ -8475,6 +8558,8 @@ def _equip_mechanics(ch: Character, item_name: str, equipped: bool) -> Optional[
             "note": (
                 f"AC does not change on its own ({basis}): call "
                 f"update_character(armor_class={suggested}) to apply it"
+                + (" — or update_character(rederive_ac=true) to hand AC ownership to "
+                   "equipment" if ch.armor_ac_source == "manual" else "")
             ),
         }
     if rec.get("damage"):
@@ -8619,21 +8704,29 @@ def remove_item(campaign_id: str, character_id: str, name: str, quantity: int = 
 
 @mcp.tool()
 def equip_item(campaign_id: str, character_id: str, name: str, equipped: bool = True) -> dict:
-    """Equip an item (or unequip with equipped=False). Equipping is ADVISORY for
-    mechanics: for catalog-recognized armor/shields/weapons the response carries a
-    `mechanics` block ({suggested_ac, ac_delta, note} or {damage, damage_type,
-    note}) — the engine does NOT change armor_class or attacks on its own, so
-    apply the AC via update_character(armor_class=...) and pass weapon stats to
-    attack()."""
+    """Equip an item (or unequip with equipped=False). For catalog-recognized
+    armor/shields the response carries a `mechanics` block ({suggested_ac, ac_delta,
+    applied, note}); weapons carry {damage, damage_type, note}.
+
+    AC ownership (#806 stage 2): when equipment owns the character's armor class
+    (armor_ac_source=="equipment", e.g. after update_character(rederive_ac=true)),
+    the engine WRITES armor_class from the worn armor's DEX rule + shield bonus and
+    reports applied=true. When a DM manual override owns it (armor_ac_source=="manual")
+    or it's a legacy/unknown "" base, the engine leaves armor_class untouched and stays
+    ADVISORY (applied=false) — apply it via update_character(armor_class=...), or hand
+    ownership to equipment with update_character(rederive_ac=true). Weapon stats are
+    never auto-applied: pass damage_dice/attack_bonus to attack()."""
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         ch = _char(c, character_id)
         it = inventory.set_equipped(ch, name, equipped)
-        save_campaign(c)
         out = it.model_dump()
         mech = _equip_mechanics(ch, it.name, equipped)
         if mech is not None:
             out["mechanics"] = mech
+        # Persist AFTER _equip_mechanics: when equipment owns AC it writes ch.armor_class
+        # (#806 stage 2), so the save must follow the mechanics pass, not precede it.
+        save_campaign(c)
         return out
 
 

--- a/servers/engine/tests/test_equip_ac_ownership.py
+++ b/servers/engine/tests/test_equip_ac_ownership.py
@@ -173,3 +173,139 @@ def test_manual_ac_not_touched_by_unrelated_patch(hero):
     server.update_character(cid, h, patch={"max_hp": 30})       # unrelated
     assert _ch(cid, h).armor_ac_source == "manual"
     assert _ch(cid, h).armor_class == 18
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 (review) — FULL-recompute write is order-independent + idempotent
+# ---------------------------------------------------------------------------
+
+def _equipment_owned(cid, h):
+    # Put the character into equipment-owned AC state with a clean recomputed base.
+    server.update_character(cid, h, patch={"rederive_ac": True})
+
+
+def test_armor_then_shield_and_shield_then_armor_converge(hero):
+    # Both equip orderings must land the SAME stored base — the incremental write
+    # dropped the shield bonus when armor was equipped after the shield.
+    cid, h = hero
+    server.update_character(cid, h, patch={"abilities": {"dexterity": 10}})  # +0
+    _equipment_owned(cid, h)
+    server.add_item(cid, h, item_name="Chain Mail")  # heavy 16
+    server.add_item(cid, h, item_name="Shield")      # +2
+
+    # order A: armor then shield
+    server.equip_item(cid, h, "Chain Mail")
+    server.equip_item(cid, h, "Shield")
+    ac_a = _ch(cid, h).armor_class
+    assert ac_a == 18  # 16 + 2
+
+    # reset to the same equipment-owned clean state, then order B: shield then armor
+    server.equip_item(cid, h, "Chain Mail", equipped=False)
+    server.equip_item(cid, h, "Shield", equipped=False)
+    server.equip_item(cid, h, "Shield")
+    server.equip_item(cid, h, "Chain Mail")
+    ac_b = _ch(cid, h).armor_class
+    assert ac_b == 18 == ac_a  # convergent regardless of order
+
+
+def test_double_equip_of_equipped_shield_is_idempotent(hero):
+    # Re-running the mechanics pass on an already-equipped shield must NOT drift +2/call
+    # — the full recompute reads actual equipped inventory, so it is stable.
+    cid, h = hero
+    server.update_character(cid, h, patch={"abilities": {"dexterity": 10}})
+    _equipment_owned(cid, h)  # base 10
+    server.add_item(cid, h, item_name="Shield")
+    server.equip_item(cid, h, "Shield")
+    assert _ch(cid, h).armor_class == 12
+    before = _ch(cid, h).armor_class
+    server._equip_mechanics(_ch(cid, h), "Shield", True)  # direct re-run of the pass
+    assert _ch(cid, h).armor_class == before  # no per-call drift
+
+
+def test_unequip_armor_with_shield_on_keeps_shield_bonus(hero):
+    # Unequip body armor while the shield stays equipped: base must fall to the
+    # unarmored baseline PLUS the still-worn shield, not lose the shield.
+    cid, h = hero
+    server.update_character(cid, h, patch={"abilities": {"dexterity": 10}})  # +0
+    _equipment_owned(cid, h)
+    server.add_item(cid, h, item_name="Chain Mail")
+    server.add_item(cid, h, item_name="Shield")
+    server.equip_item(cid, h, "Chain Mail")
+    server.equip_item(cid, h, "Shield")
+    assert _ch(cid, h).armor_class == 18  # 16 + 2
+
+    server.equip_item(cid, h, "Chain Mail", equipped=False)
+    # Shield still on -> 10 (unarmored) + 2 (shield) = 12, NOT 10.
+    assert _ch(cid, h).armor_class == 12
+    # And a subsequent shield unequip lands cleanly at the unarmored baseline.
+    server.equip_item(cid, h, "Shield", equipped=False)
+    assert _ch(cid, h).armor_class == 10
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 (review) — Unarmored Defense preserved on re-derive (barb / monk)
+# ---------------------------------------------------------------------------
+
+def test_barbarian_rederive_no_armor_keeps_unarmored_defense(hero):
+    # Barbarian Unarmored Defense = 10 + DEX + CON (mirrors _finish_seat_sheet).
+    cid, h = hero
+    server.update_character(cid, h, patch={
+        "classes": [{"name": "Barbarian", "level": 3}],
+        "abilities": {"dexterity": 14, "constitution": 16},  # +2 DEX, +3 CON
+    })
+    out = server.update_character(cid, h, patch={"rederive_ac": True})
+    assert out["armor_class"] == 15  # 10 + 2 + 3
+    assert _ch(cid, h).armor_ac_source == "equipment"
+
+
+def test_barbarian_unarmored_defense_allows_shield(hero):
+    # SRD: a barbarian's Unarmored Defense still permits a shield's +2.
+    cid, h = hero
+    server.update_character(cid, h, patch={
+        "classes": [{"name": "Barbarian", "level": 3}],
+        "abilities": {"dexterity": 14, "constitution": 16},
+    })
+    server.add_item(cid, h, item_name="Shield")
+    server.update_character(cid, h, patch={"rederive_ac": True})
+    server.equip_item(cid, h, "Shield")
+    assert _ch(cid, h).armor_class == 17  # 15 + 2 shield
+
+
+def test_monk_rederive_no_armor_keeps_unarmored_defense(hero):
+    # Monk Unarmored Defense = 10 + DEX + WIS (mirrors _finish_seat_sheet).
+    cid, h = hero
+    server.update_character(cid, h, patch={
+        "classes": [{"name": "Monk", "level": 3}],
+        "abilities": {"dexterity": 16, "wisdom": 14},  # +3 DEX, +2 WIS
+    })
+    out = server.update_character(cid, h, patch={"rederive_ac": True})
+    assert out["armor_class"] == 15  # 10 + 3 + 2
+    assert _ch(cid, h).armor_ac_source == "equipment"
+
+
+def test_monk_unarmored_defense_voided_by_shield(hero):
+    # SRD: a monk's Unarmored Defense does not function with a shield equipped.
+    cid, h = hero
+    server.update_character(cid, h, patch={
+        "classes": [{"name": "Monk", "level": 3}],
+        "abilities": {"dexterity": 16, "wisdom": 14},
+    })
+    server.add_item(cid, h, item_name="Shield")
+    server.update_character(cid, h, patch={"rederive_ac": True})
+    server.equip_item(cid, h, "Shield")
+    # Monk Unarmored Defense VOID with a shield: the WIS term drops (plain 10 + DEX(+3)),
+    # but the monk may still wield the shield so its +2 applies -> 10 + 3 + 2 = 15.
+    assert _ch(cid, h).armor_class == 15
+
+
+def test_body_armor_overrides_unarmored_defense_for_barbarian(hero):
+    # Equipping body armor uses the normal armor rule, NOT Unarmored Defense.
+    cid, h = hero
+    server.update_character(cid, h, patch={
+        "classes": [{"name": "Barbarian", "level": 3}],
+        "abilities": {"dexterity": 14, "constitution": 16},
+    })
+    server.add_item(cid, h, item_name="Chain Mail")  # heavy 16, no DEX
+    server.update_character(cid, h, patch={"rederive_ac": True})
+    server.equip_item(cid, h, "Chain Mail")
+    assert _ch(cid, h).armor_class == 16  # normal heavy rule, not 10+DEX+CON

--- a/servers/engine/tests/test_equip_ac_ownership.py
+++ b/servers/engine/tests/test_equip_ac_ownership.py
@@ -1,0 +1,175 @@
+"""#806 stage 2 — equipment-owned AC with a provenance flag (armor_ac_source).
+
+The equip path used to be advisory only (stage 1, #831): it computed a suggested_ac
+but never wrote armor_class. Stage 2 lets EQUIPMENT own the worn-armor base scalar —
+but only when the DM hasn't manually overridden it, and never for a legacy "" base.
+Ownership is tracked by Character.armor_ac_source ("" | "equipment" | "manual") and
+handed back to equipment via update_character(rederive_ac=true).
+
+Invariants under test:
+  * equip WRITES armor_class only when armor_ac_source == "equipment" (applied=True);
+  * a manual update_character(armor_class=...) override stamps "manual" and BLOCKS the
+    equip write (stays advisory, applied=False);
+  * a legacy/unknown "" base is manual-safe — equip never clobbers it;
+  * rederive_ac=true clears the manual flag and recomputes from equipped items;
+  * Mage Armor still layers on at read time regardless of who owns the base.
+"""
+
+import pytest
+
+import itemcatalog
+import server
+from models import Character
+
+
+@pytest.fixture
+def hero(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("ACOwnership")["id"]
+    h = server.create_character(cid, "Warden", kind="player")["id"]
+    return cid, h
+
+
+def _ch(cid, hid):
+    return server._require(cid).characters[hid]
+
+
+# ---------------------------------------------------------------------------
+# Provenance flag defaults + additive round-trip
+# ---------------------------------------------------------------------------
+
+def test_new_field_defaults_empty_and_round_trips():
+    # Additive: a bare model has "" and an old snapshot without the key round-trips.
+    assert Character(name="X").armor_ac_source == ""
+    revived = Character.model_validate({"name": "Old", "armor_class": 15})
+    assert revived.armor_ac_source == ""
+    assert revived.armor_class == 15  # legacy AC preserved exactly
+
+
+# ---------------------------------------------------------------------------
+# Legacy "" base is manual-safe — equip stays advisory, never clobbers
+# ---------------------------------------------------------------------------
+
+def test_legacy_empty_source_equip_is_advisory_and_never_clobbers(hero):
+    cid, h = hero
+    assert _ch(cid, h).armor_ac_source == ""  # fresh character is legacy-safe
+    server.add_item(cid, h, item_name="Chain Mail")
+    out = server.equip_item(cid, h, "Chain Mail")
+    assert out["mechanics"]["applied"] is False
+    assert out["mechanics"]["suggested_ac"] == 16  # heavy, flat
+    # The legacy base (10) is untouched and the source stays "".
+    assert _ch(cid, h).armor_class == 10
+    assert _ch(cid, h).armor_ac_source == ""
+
+
+# ---------------------------------------------------------------------------
+# update_character(armor_class=...) is a manual override -> stamps "manual"
+# ---------------------------------------------------------------------------
+
+def test_manual_ac_write_stamps_manual_source(hero):
+    cid, h = hero
+    server.update_character(cid, h, patch={"armor_class": 17})
+    assert _ch(cid, h).armor_class == 17
+    assert _ch(cid, h).armor_ac_source == "manual"
+
+
+def test_manual_override_blocks_equip_write(hero):
+    cid, h = hero
+    server.update_character(cid, h, patch={"armor_class": 20})  # DM houserule
+    server.add_item(cid, h, item_name="Leather Armor")
+    out = server.equip_item(cid, h, "Leather Armor")
+    # Advisory only: the DM's 20 wins, equip does NOT clobber it.
+    assert out["mechanics"]["applied"] is False
+    assert _ch(cid, h).armor_class == 20
+    assert _ch(cid, h).armor_ac_source == "manual"
+    # The advisory note points the DM at the re-derive affordance.
+    assert "rederive_ac" in out["mechanics"]["note"]
+
+
+# ---------------------------------------------------------------------------
+# Re-derive hands ownership back to equipment and recomputes from equipped items
+# ---------------------------------------------------------------------------
+
+def test_rederive_clears_manual_and_recomputes_from_equipped(hero):
+    cid, h = hero
+    server.update_character(cid, h, patch={"abilities": {"dexterity": 10}})
+    server.add_item(cid, h, item_name="Chain Mail")   # heavy, base 16
+    server.equip_item(cid, h, "Chain Mail")            # advisory (source "")
+    server.update_character(cid, h, patch={"armor_class": 99})  # manual override
+    assert _ch(cid, h).armor_ac_source == "manual"
+
+    out = server.update_character(cid, h, patch={"rederive_ac": True})
+    assert out["armor_class"] == 16                    # recomputed from Chain Mail
+    assert _ch(cid, h).armor_ac_source == "equipment"
+
+
+def test_rederive_with_no_equipped_armor_is_unarmored_baseline(hero):
+    cid, h = hero
+    server.update_character(cid, h, patch={"abilities": {"dexterity": 14}})  # +2
+    out = server.update_character(cid, h, patch={"rederive_ac": True})
+    assert out["armor_class"] == 12                    # 10 + DEX(+2)
+    assert _ch(cid, h).armor_ac_source == "equipment"
+
+
+# ---------------------------------------------------------------------------
+# Once equipment owns AC, equip WRITES it (applied=True)
+# ---------------------------------------------------------------------------
+
+def test_equip_writes_when_equipment_owns_base(hero):
+    cid, h = hero
+    server.update_character(cid, h, patch={"abilities": {"dexterity": 14}})  # +2
+    server.update_character(cid, h, patch={"rederive_ac": True})  # -> "equipment"
+    assert _ch(cid, h).armor_ac_source == "equipment"
+
+    server.add_item(cid, h, item_name="Studded Leather Armor")  # light, base 12
+    out = server.equip_item(cid, h, "Studded Leather Armor")
+    assert out["mechanics"]["applied"] is True
+    assert _ch(cid, h).armor_class == 14               # 12 + DEX(+2)
+    assert _ch(cid, h).armor_ac_source == "equipment"
+
+
+def test_shield_add_and_remove_round_trip_when_equipment_owned(hero):
+    cid, h = hero
+    server.update_character(cid, h, patch={"abilities": {"dexterity": 10}})
+    server.update_character(cid, h, patch={"rederive_ac": True})  # base 10, equipment
+    assert _ch(cid, h).armor_class == 10
+
+    server.add_item(cid, h, item_name="Shield")
+    on = server.equip_item(cid, h, "Shield")
+    assert on["mechanics"]["applied"] is True
+    assert _ch(cid, h).armor_class == 12               # +2 shield
+
+    off = server.equip_item(cid, h, "Shield", equipped=False)
+    assert off["mechanics"]["applied"] is True
+    assert _ch(cid, h).armor_class == 10               # back to base
+
+
+# ---------------------------------------------------------------------------
+# Mage Armor still layers at read time regardless of who owns the base
+# ---------------------------------------------------------------------------
+
+def test_mage_armor_layers_over_equipment_owned_base(hero):
+    cid, h = hero
+    server.update_character(cid, h, patch={"abilities": {"dexterity": 14}})  # +2
+    server.update_character(cid, h, patch={"rederive_ac": True})  # base 12 (10+DEX)
+    ch = _ch(cid, h)
+    # Mage Armor: 13 + DEX = 15 > base 12, so it wins at read time WITHOUT touching
+    # the stored base scalar (the resolver is untouched by stage 2).
+    from models import ActiveEffect
+    ch.active_effects.append(ActiveEffect(name="Mage Armor", armor_formula_ac=13 + 2))
+    eff_ac, detail = server._effective_armor_class(ch)
+    assert eff_ac == 15
+    assert detail is not None and detail["source"] == "Mage Armor" and detail["applied"] is True
+    # The equipment-owned base scalar is unchanged by the read-time layer.
+    assert ch.armor_class == 12
+    assert ch.armor_ac_source == "equipment"
+
+
+def test_manual_ac_not_touched_by_unrelated_patch(hero):
+    # A patch that never mentions armor_class must leave the source flag alone
+    # (byte-identical to today for every non-AC patch).
+    cid, h = hero
+    server.update_character(cid, h, patch={"armor_class": 18})  # -> manual
+    server.update_character(cid, h, patch={"max_hp": 30})       # unrelated
+    assert _ch(cid, h).armor_ac_source == "manual"
+    assert _ch(cid, h).armor_class == 18


### PR DESCRIPTION
## #806 Stage 2 — equipment-owned AC (implements the DECIDED design)

Implements **option (c) — derived worn-AC with an explicit provenance flag** from the closed architectural gate: [issue #806 decision comment](https://github.com/electricsheephq/WorldOS/issues/806#issuecomment-4864027913). Stage 1 (advisory equip TELL, #831) shipped; this closes Stage 2.

### What changed
- **`models.py`** — additive `Character.armor_ac_source: str = ""` (`""` legacy/unknown → manual-safe, `"equipment"`, `"manual"`). Old snapshots round-trip; `""` is byte-identical to today.
- **`server.py` `_equip_mechanics`** — on armor/shield equip/unequip the engine now WRITES `ch.armor_class` from the worn AC it already computes (light/medium/heavy DEX rule + shield ±bonus) **only when `armor_ac_source == "equipment"`** (`applied=True`). A `"manual"` override or a legacy `""` base is never clobbered — the block stays advisory (`applied=False`) and keeps surfacing the delta. The shield/armor **base write is effect-clean** (moves the raw stored base, not the effect-inclusive `current_ac`) so Mage Armor / Shield of Faith never double-count into the base scalar.
- **`server.py` `update_character`** — a patch that writes `armor_class` stamps `armor_ac_source="manual"`.
- **Re-derive affordance** — `update_character(patch={"rederive_ac": true})` clears the manual flag and recomputes the base from equipped items via new `_derive_worn_ac_from_equipped`. Reuses the existing `patch` dict (popped like `in_party`) — **no new tool-schema param** (engine schema budget is tight, ~235B headroom).
- **`equip_item`** — persists AFTER `_equip_mechanics` so the equipment-owned write lands.

### Re-derive mechanism chosen — and why
`update_character(patch={"rederive_ac": true})` over a new equip-tool param: it adds **zero** bytes to any tool's JSON schema (the sentinel rides inside the already-freeform `patch` dict and is popped before `model_validate`, exactly like the existing `in_party` intent), respecting the tight engine tool-schema budget the decision flagged. `armor_class=null` was rejected because the field is `int` and `_deep_update`+`model_validate` would raise on `None`, forcing a looser model — `rederive_ac` is cleaner and self-documenting.

### Not touched (per decision)
Mage Armor cast snapshot, `_effective_armor_class` resolver, `_finish_seat_sheet` Unarmored Defense / Defense-style. Effects keep layering at read time.

### Invariants held
Engine sole-writer (the write happens inside the engine tool); additive-by-default (one defaulted field, `""` preserves today exactly); gates read only `_effective_armor_class`.

### Tests
- New: `tests/test_equip_ac_ownership.py` — 10 tests (equip writes when equipment-owned; manual override blocks; legacy `""` never clobbered; re-derive clears + recomputes; shield add/remove round-trip; Mage Armor layers unchanged; additive round-trip).
- Green (single-process, no xdist): `test_equip_ac_ownership` (10), `test_armor_props_fold` + `test_combat` + `test_economy_stress` (310), `test_engine` (20), `qa/fast_gate.sh` (241, PASS).

Refs #806. Do not merge without review.