### PR TITLE
fix(qa): bash 5.3 multibyte-identifier crash in run_duo.sh/run_qa.sh

### DIFF
--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -354,7 +354,7 @@ WORLDOS_PLAYER_MAX_ATTEMPTS="${WORLDOS_PLAYER_MAX_ATTEMPTS:-3}"
 PMSG=""
 _pintro_attempt=1
 while [ -z "$PMSG" ] && [ "$_pintro_attempt" -le "$WORLDOS_PLAYER_MAX_ATTEMPTS" ]; do
-  [ "$_pintro_attempt" -gt 1 ] && echo "[duo] player produced no intro — retry $_pintro_attempt/$WORLDOS_PLAYER_MAX_ATTEMPTS…" >&2
+  [ "$_pintro_attempt" -gt 1 ] && echo "[duo] player produced no intro — retry $_pintro_attempt/${WORLDOS_PLAYER_MAX_ATTEMPTS}…" >&2
   PMSG="$(player_move 1 "$PLAYER_INTRO_PROMPT")"
   _pintro_attempt=$((_pintro_attempt + 1))
 done

--- a/qa/run_qa.sh
+++ b/qa/run_qa.sh
@@ -46,7 +46,7 @@ cfg["mcpServers"]["worldos-engine"]["env"]["WORLDOS_STATE_DIR"] = state_dir
 json.dump(cfg, open(out, "w"))
 PY
 
-echo "[qa] playing (claude --plugin-dir, $WORLDOS_DM_MODEL) prompt=$PROMPT_FILE…"
+echo "[qa] playing (claude --plugin-dir, $WORLDOS_DM_MODEL) prompt=${PROMPT_FILE}…"
 claude -p "$(cat "$PROMPT_FILE")" \
   --plugin-dir "$ROOT" \
   --mcp-config "$MCP_CONFIG" --strict-mcp-config \


### PR DESCRIPTION
## What
`"$VAR…"` (variable expansion with a multibyte char glued to the name) crashes on bash 5.3 in UTF-8 locales: the parser absorbs the multibyte bytes into the identifier, yielding `VAR…: unbound variable` under `set -u`. Homebrew now ships bash 5.3.15, so `qa/run_duo.sh` aborts at beat 0 on updated Macs (hit live on `glm-smoke-0702`).

Repro: `set -u; V=3; echo "$V…"` → bash 5.3.15 = unbound variable; bash ≤5.2 / `LC_ALL=C` = fine.

## Fix
Brace the only two glued expansions repo-wide (`grep -rPn '\$[A-Za-z_][A-Za-z0-9_]*[^\x00-\x7F]' --include='*.sh'`):
- `qa/run_duo.sh:357` → `${WORLDOS_PLAYER_MAX_ATTEMPTS}…`
- `qa/run_qa.sh:49` → `${PROMPT_FILE}…`

`bash -n` clean on both. No behavior change on any bash version.