### PR TITLE
fix(combat-ui): wire Cast/Item/Move ActionTiles to existing move-kinds

### DIFF
--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -40,6 +40,12 @@ function ScreenCombat({ onNavigate, state }) {
   const [selectedToken, setSelectedToken] = React.useState("");
   const [localLog, setLocalLog] = React.useState([]);
   const [busyAction, setBusyAction] = React.useState("");
+  // #598: the Move tile posts `move_to_zone`, a _TARGET_ONLY_KIND (viewer/server.py sanitize_move)
+  // whose `target` is a zone NAME the server can't supply statically (unlike Attack/Cast/Item,
+  // which are one static payload). Clicking Move arms "pick a destination zone"; the next zone
+  // click (existing CombatMap zone-band affordance, extended below) completes the POST. Mirrors
+  // move_to_cell's client-fills-the-coordinate pattern, just for zone mode instead of grid mode.
+  const [pickingZone, setPickingZone] = React.useState(false);
   // #robustness: synchronous in-flight lock. setBusyAction is async (state read at the disabled
   // check is stale), so two rapid clicks before re-render both pass — the adversarial's "Attack
   // dies on double-click" / double-submit vector. busyRef gates synchronously.
@@ -128,6 +134,13 @@ function ScreenCombat({ onNavigate, state }) {
     }
   }, [surface?.selectedTokenId, selectedToken, tokens]);
 
+  // #598: disarm the Move tile's "pick a zone" mode the instant the surface says the actor can no
+  // longer act (turn advanced, action spent, surface went read-only) — otherwise a stale refresh
+  // could leave a zone band armed after a POST already ended the turn.
+  React.useEffect(() => {
+    if (!canAct && pickingZone) setPickingZone(false);
+  }, [canAct, pickingZone]);
+
   const actionById = (id) => actions.find((a) => a.id === id) || {};
   const actionHint = (action) => {
     if (!action) return "unavailable";
@@ -168,6 +181,14 @@ function ScreenCombat({ onNavigate, state }) {
       });
       return;
     }
+    // #598: `move_to_zone` (the Move tile) has no static target — the server can't guess which
+    // zone the player wants. Arm "pick a destination zone" instead of posting immediately; the
+    // zone-band click below (onZoneMoveTarget) fills `target` and completes the POST. Re-clicking
+    // Move while armed disarms it (an escape hatch if the player changes their mind).
+    if (action.move.kind === "move_to_zone") {
+      setPickingZone((was) => !was);
+      return;
+    }
     if (busyRef.current) return; // already submitting — drop the rapid double-click / double-Enter
     busyRef.current = true;
     setBusyAction(action.id);
@@ -196,6 +217,44 @@ function ScreenCombat({ onNavigate, state }) {
     } finally {
       busyRef.current = false;
       setBusyAction("");
+    }
+  };
+
+  // #598: completes the Move tile's armed "pick a destination zone" — posts move_to_zone with the
+  // clicked zone as `target` (sanitize_move's _TARGET_ONLY_KINDS requirement). Same /move lane +
+  // busyRef double-submit guard as postMove; disarms picking mode whether it lands or fails.
+  const postZoneMove = async (targetZone) => {
+    const action = actionById("move");
+    if (!pickingZone || !action?.available || !canAct || !targetZone) return;
+    if (busyRef.current) return;
+    busyRef.current = true;
+    setBusyAction("move");
+    try {
+      const response = await fetch("/move", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ kind: "move_to_zone", target: targetZone, campaign: surface?.campaign_id || campaignId }),
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || payload.ok === false) {
+        throw new Error(payload.reason || `move ${response.status}`);
+      }
+      setLocalLog((rows) => [
+        ...rows,
+        {
+          event: "player-intent",
+          title: "Player intent sent",
+          text: `move → ${targetZone}`,
+          meta: [{ label: "lane", value: "/move" }],
+        },
+      ]);
+      await loadSurface();
+    } catch (error) {
+      toast({ kind: "danger", title: "Move not sent", body: error?.message || "The viewer could not reach /move." });
+    } finally {
+      busyRef.current = false;
+      setBusyAction("");
+      setPickingZone(false);
     }
   };
 
@@ -244,13 +303,16 @@ function ScreenCombat({ onNavigate, state }) {
 
   const actionTile = (id, fallbackIcon, fallbackLabel) => {
     const action = actionById(id);
+    // #598: the Move tile stays visually "active" while armed (pickingZone), even though no
+    // request is in flight — it's waiting on a zone click, not a busyAction id match.
+    const isMoveArmed = id === "move" && pickingZone;
     return (
       <ActionTile
         key={id}
         icon={action.icon || fallbackIcon}
         label={action.label || fallbackLabel}
-        hint={actionHint(action)}
-        active={busyAction === id}
+        hint={isMoveArmed ? "Pick a zone" : actionHint(action)}
+        active={busyAction === id || isMoveArmed}
         disabled={!action.available || !action.move || !canAct || Boolean(busyAction)}
         onClick={() => postMove(action)}
       />
@@ -289,7 +351,7 @@ function ScreenCombat({ onNavigate, state }) {
           </div>
 
           {encounter.active ? (
-            <CombatMap tokens={tokens} zones={zones} grid={surface?.grid} selected={selected?.id} onSelect={setSelectedToken} onCellMove={onCellMove} onAttack={onAttackToken} canAct={canAct} sceneScope={sceneScope} />
+            <CombatMap tokens={tokens} zones={zones} grid={surface?.grid} selected={selected?.id} onSelect={setSelectedToken} onCellMove={onCellMove} onAttack={onAttackToken} canAct={canAct} sceneScope={sceneScope} pickingZone={pickingZone} onZoneMoveTarget={postZoneMove} />
           ) : (
             <React.Fragment>
               {doors.length ? (
@@ -645,7 +707,7 @@ function GridCellToken({ t, selected, isCurrent }) {
    A real measured-tile grid (range/LoS/flanking) is the evidence-gated #461 future: it requires
    the engine to gain authoritative coordinates (positionAuthority:"engine" + grid.mode==="grid").
    When that lands, a grid board plugs in here behind that flag; until then, zones are the truth. */
-function CombatMap({ tokens, zones, grid, selected, onSelect, onCellMove, onAttack, canAct, sceneScope }) {
+function CombatMap({ tokens, zones, grid, selected, onSelect, onCellMove, onAttack, canAct, sceneScope, pickingZone, onZoneMoveTarget }) {
   // #10/#461: when the engine sends authoritative cell coords (grid.mode==="grid"), render a real
   // tactical board (the slot this comment-block reserved). Otherwise fall back to the zone bands.
   if (grid && grid.mode === "grid" && Number(grid.cols) > 0 && Number(grid.rows) > 0) {
@@ -703,22 +765,35 @@ function CombatMap({ tokens, zones, grid, selected, onSelect, onCellMove, onAtta
           pointerEvents: "none",
         }} />
       ) : null}
-      {zoneNames.map((zn) => (
+      {zoneNames.map((zn) => {
+        // #598: while the Move tile is armed (pickingZone), the zone header becomes the
+        // "pick a destination" affordance — click a zone band to POST move_to_zone with that
+        // zone as `target`. Mirrors CombatGridBoard's walkable-cell-click pattern, just for
+        // zone mode. Disabled/inert otherwise (existing zone-label behavior is unchanged).
+        const armed = Boolean(pickingZone && canAct);
+        return (
         <div key={zn} style={{
           flex: 1, minWidth: 0,
           // FIX A: sit the zone bands above the absolute backdrop + scrim (zIndex 0).
           position: "relative", zIndex: 1,
           display: "flex", flexDirection: "column",
           background: "rgba(30,18,10,0.30)",
-          boxShadow: "inset 0 0 0 1px rgba(176,141,87,0.18)",
+          boxShadow: armed ? "inset 0 0 0 1px var(--gold-glow, rgba(244,210,123,0.6))" : "inset 0 0 0 1px rgba(176,141,87,0.18)",
         }}>
-          <div title={zn} style={{
-            padding: "5px 8px",
-            fontFamily: "var(--f-display)", fontSize: 9, letterSpacing: "0.12em",
-            textTransform: "uppercase", color: "rgba(244, 210, 123, 0.75)",
-            borderBottom: "1px solid rgba(176,141,87,0.18)",
-            overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
-          }}>{zn}</div>
+          <div
+            title={armed ? `Move here (${zn})` : zn}
+            role={armed ? "button" : undefined}
+            tabIndex={armed ? 0 : -1}
+            onClick={armed ? () => onZoneMoveTarget(zn) : undefined}
+            onKeyDown={armed ? (e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onZoneMoveTarget(zn); } } : undefined}
+            style={{
+              padding: "5px 8px",
+              fontFamily: "var(--f-display)", fontSize: 9, letterSpacing: "0.12em",
+              textTransform: "uppercase", color: armed ? "var(--gold-glow, #f4d27b)" : "rgba(244, 210, 123, 0.75)",
+              borderBottom: "1px solid rgba(176,141,87,0.18)",
+              overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+              cursor: armed ? "pointer" : "default",
+            }}>{zn}{armed ? " →" : ""}</div>
           <div style={{
             flex: 1, display: "flex", flexWrap: "wrap", gap: 12,
             alignContent: "flex-start", justifyContent: "center",
@@ -731,7 +806,8 @@ function CombatMap({ tokens, zones, grid, selected, onSelect, onCellMove, onAtta
               : <div className="body-sm" style={{ color: "rgba(212,185,122,0.35)", alignSelf: "center" }}>empty</div>}
           </div>
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/viewer/server.py
+++ b/viewer/server.py
@@ -2802,30 +2802,22 @@ def _combat_action_bar(action_model: dict, combat_active: bool) -> list[dict]:
     if end_reason is None:
         end_turn["move"] = {"kind": "combat", "name": "End Turn"}
 
+    # #598: Move/Cast/Item were dead stubs (`available: False` no matter what). They now
+    # route through `from_model`, the SAME by_id lookup Attack/Bonus/Reaction already use —
+    # `build_action_model`'s "combat" group supplies the `move` payload + availability, this
+    # function only decorates icon/fallback. Cast/Item mirror Attack's free-text DM-resolved
+    # lane (kind+name, no target_id — `cast`/`use_item` are NOT in combat_loop's on-turn Intent
+    # branch, so they must ride the moves-file lane the DM agent resolves, exactly like the
+    # existing "Bonus"/"Reaction" tiles do today). Move mirrors the grid: `move_to_cell` (click
+    # a cell on the tactical board) is already live via CombatGridBoard/onCellMove; the Move
+    # TILE is the zone-mode equivalent and gates on the same action-economy reason so it greys
+    # out exactly when Attack does. No new fields, no engine writes — additive per #116.
     return [
-        {
-            "id": "move",
-            "label": "Move",
-            "icon": "↗",
-            "available": False,
-            "disabled_reason": "movement destinations not projected yet",
-        },
+        from_model("move", "Move", "↗", base_reason()),
         from_model("attack", "Attack", "⚔", base_reason()),
-        {
-            "id": "cast",
-            "label": "Cast",
-            "icon": "✦",
-            "available": False,
-            "disabled_reason": "spell choices not projected yet",
-        },
+        from_model("cast", "Cast", "✦", base_reason()),
         from_model("bonus-action", "Bonus", "◈", base_reason()),
-        {
-            "id": "item",
-            "label": "Item",
-            "icon": "◊",
-            "available": False,
-            "disabled_reason": "inventory combat actions not projected yet",
-        },
+        from_model("item", "Item", "◊", base_reason()),
         from_model("reaction", "Reaction", "✺", base_reason()),
         end_turn,
     ]
@@ -7311,8 +7303,25 @@ def build_action_model(snapshot: dict, *, live: bool, is_live_view: bool) -> dic
                 "id": "combat",
                 "label": "Combat",
                 "actions": [
+                    # #598: Move/Cast/Item wired to the SAME action-economy reasons Attack already
+                    # uses (turn_action_reason("action")) — all four spend the actor's action slot,
+                    # so they enable/disable together, exactly the way the "action spent" greying
+                    # already worked for Attack. Cast/Item ride the free-text DM-resolved lane
+                    # (kind+name, sanitize_move's "everything else needs text or name" branch —
+                    # see viewer/server.py:189) — the SAME lane Bonus/Reaction use today, not the
+                    # engine on-turn Intent branch (which only knows move_to_cell / on-turn attack /
+                    # end_turn). Move carries only `kind` (no `name`/`target`) because
+                    # `move_to_zone` is a _TARGET_ONLY_KIND — sanitize_move requires a `target`
+                    # zone name sanitize_move can't guess server-side; the client fills `target`
+                    # from the zone the player clicks (mirrors the CombatGridBoard cell-click
+                    # pattern) before POSTing, same as move_to_cell fills x/y client-side. This is
+                    # a WIRE of an already-whitelisted kind (_MOVE_KINDS has carried
+                    # "cast"/"use_item"/"move_to_zone" since before #598), not a new verb.
+                    _action_item("move", "Move", kind="move_to_zone", detail="Move to another zone", disabled_reason=turn_action_reason("action")),
                     _action_item("attack", "Attack", kind="attack", name="Attack", detail="Strike a foe", disabled_reason=turn_action_reason("action")),
+                    _action_item("cast", "Cast", kind="cast", name="Cast a Spell", detail="Channel magic", disabled_reason=turn_action_reason("action")),
                     _action_item("bonus-action", "Bonus", kind="combat", name="Bonus Action", detail="Quick extra move", disabled_reason=turn_action_reason("bonus")),
+                    _action_item("item", "Item", kind="use_item", name="Use an Item", detail="Use inventory item", disabled_reason=turn_action_reason("action")),
                     _action_item("reaction", "Reaction", kind="combat", name="Reaction", detail="Respond fast", disabled_reason=reaction_reason()),
                 ],
             },

--- a/viewer/tests/test_action_model.py
+++ b/viewer/tests/test_action_model.py
@@ -116,6 +116,112 @@ class ActionModelTests(unittest.TestCase):
         self.assertEqual(_action(model, "combat", "attack")["disabled_reason"], "not current turn")
         self.assertIsNone(_action(model, "combat", "reaction")["disabled_reason"])
 
+    # ---- #598: Move / Cast / Item wired to the SAME action-economy reason Attack already
+    # uses, carrying the correct already-whitelisted _MOVE_KINDS payload (move_to_zone / cast /
+    # use_item) instead of the old permanent `available: False` stub. ----
+
+    def _live_current_turn_snapshot(self, *, action_used=False):
+        return {
+            "party": ["pc"],
+            "characters": {
+                "pc": {"id": "pc", "name": "Vela", "kind": "player"},
+                "gob": {"id": "gob", "name": "Goblin", "kind": "monster"},
+            },
+            "combat": {
+                "active": True,
+                "round": 1,
+                "turn_index": 0,
+                "action_used": action_used,
+                "bonus_action_used": False,
+                "order": [
+                    {"character_id": "pc", "initiative": 18, "reaction_used": False},
+                    {"character_id": "gob", "initiative": 9},
+                ],
+            },
+        }
+
+    def test_move_cast_item_available_on_current_turn_with_action_unspent(self):
+        model = server.build_action_model(
+            self._live_current_turn_snapshot(action_used=False), live=True, is_live_view=True
+        )
+
+        move = _action(model, "combat", "move")
+        cast = _action(model, "combat", "cast")
+        item = _action(model, "combat", "item")
+
+        for action, expected_kind in ((move, "move_to_zone"), (cast, "cast"), (item, "use_item")):
+            self.assertTrue(action["available"], action)
+            self.assertIsNone(action["disabled_reason"])
+            self.assertEqual(action["move"]["kind"], expected_kind)
+
+    def test_move_cast_item_grey_out_with_attack_when_action_spent(self):
+        # #598 requirement 3: the tiles disable/grey when the engine's action-economy state
+        # says the action is spent — same "action spent" reason Attack already surfaces.
+        model = server.build_action_model(
+            self._live_current_turn_snapshot(action_used=True), live=True, is_live_view=True
+        )
+
+        for action_id in ("move", "attack", "cast", "item"):
+            action = _action(model, "combat", action_id)
+            self.assertFalse(action["available"], action_id)
+            self.assertEqual(action["disabled_reason"], "action spent", action_id)
+
+    def test_move_cast_item_disabled_reason_matches_attack_outside_combat(self):
+        model = server.build_action_model({}, live=True, is_live_view=True)
+
+        expected = _action(model, "combat", "attack")["disabled_reason"]
+        for action_id in ("move", "cast", "item"):
+            self.assertEqual(_action(model, "combat", action_id)["disabled_reason"], expected, action_id)
+
+    def test_move_kind_carries_no_static_target(self):
+        # move_to_zone is a _TARGET_ONLY_KIND — the server cannot supply the destination zone
+        # statically, so the wired action's `move` payload deliberately omits `target`/`name`;
+        # the client fills `target` from the zone the player clicks before POSTing.
+        model = server.build_action_model(
+            self._live_current_turn_snapshot(action_used=False), live=True, is_live_view=True
+        )
+        move_payload = _action(model, "combat", "move")["move"]
+        self.assertNotIn("target", move_payload)
+        self.assertNotIn("name", move_payload)
+
+
+class MoveCastItemMoveIntentTests(unittest.TestCase):
+    """Server-side floor per the #598 dispatch packet: POST the three wired kinds through
+    sanitize_move (the same gate /move applies) and assert acceptance with the exact payload
+    shape the wired tiles now send."""
+
+    def test_cast_accepted_with_name(self):
+        # Cast/Item ride the free-text DM-resolved lane (kind+name) — the SAME shape Bonus/
+        # Reaction already use, mirrored by the wired Cast tile (_action_item kind="cast",
+        # name="Cast a Spell").
+        move, reason = server.sanitize_move({"kind": "cast", "name": "Cast a Spell"})
+        self.assertEqual(reason, "")
+        self.assertEqual(move["kind"], "cast")
+        self.assertEqual(move["name"], "Cast a Spell")
+        self.assertEqual(move["role"], "player")
+
+    def test_use_item_accepted_with_name(self):
+        move, reason = server.sanitize_move({"kind": "use_item", "name": "Use an Item"})
+        self.assertEqual(reason, "")
+        self.assertEqual(move["kind"], "use_item")
+        self.assertEqual(move["name"], "Use an Item")
+
+    def test_move_to_zone_accepted_with_client_filled_target(self):
+        # The Move tile's client fills `target` from the clicked zone band before POSTing
+        # (server.py cannot supply a static zone name) — assert that completed shape is
+        # accepted, mirroring the existing move_to_zone coverage in test_move_intents.py.
+        move, reason = server.sanitize_move({"kind": "move_to_zone", "target": "the rafters"})
+        self.assertEqual(reason, "")
+        self.assertEqual(move["kind"], "move_to_zone")
+        self.assertEqual(move["target"], "the rafters")
+
+    def test_cast_and_use_item_reject_with_neither_text_nor_name(self):
+        for kind in ("cast", "use_item"):
+            with self.subTest(kind=kind):
+                move, reason = server.sanitize_move({"kind": kind})
+                self.assertIsNone(move)
+                self.assertIn("text", reason)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Wires the three combat-screen ActionTiles that rendered but posted nothing — Cast, Item, Move — to the already-whitelisted, engine-consumed move kinds (`cast`, `use_item`, `move_to_zone`). This is a WIRE, not a new verb: `_MOVE_KINDS` in `viewer/server.py` has carried all three since before this issue.

Refs #598, parent epic #116 (Wave 2).

## What changed
- `viewer/server.py` — `build_action_model`'s `combat` group now emits real `move` payloads for `move`/`cast`/`item` (previously `_combat_action_bar` hardcoded them to `available: False` no matter what). All three gate on the same `turn_action_reason("action")` disabled-reason Attack already uses, so they enable/disable together with Attack.
  - Cast → `{kind: "cast", name: "Cast a Spell"}` — free-text DM-resolved lane, same shape as the existing Bonus/Reaction tiles (not the engine's on-turn `Intent` branch, which only knows `move_to_cell`/on-turn-`attack`/`end_turn`).
  - Item → `{kind: "use_item", name: "Use an Item"}` — same free-text lane.
  - Move → `{kind: "move_to_zone"}` — deliberately omits `target`/`name`. `move_to_zone` is a `_TARGET_ONLY_KIND`; the destination zone name can't be supplied statically server-side.
- `viewer/openworlds/screen-combat.jsx` — Cast/Item post immediately via the existing `postMove` lane. Move arms a "pick a destination zone" mode (`pickingZone` state); clicking a zone band (existing `CombatMap` zone-mode affordance, now click-enabled while armed) fills `target` and completes the POST via a new `postZoneMove`, mirroring how grid-mode's `move_to_cell` already fills `x`/`y` from a cell click. Grid-mode movement (click-to-cell) was already fully wired and is untouched.
- `viewer/tests/test_action_model.py` — new coverage: the three tiles are available/gated identically to Attack (including greying out together when `action_used`), carry the correct `move.kind`, Move's payload correctly omits `target`, and `sanitize_move` accepts `cast`/`use_item` (mirroring the existing `move_to_zone` coverage in `test_move_intents.py`).

Engine stays sole writer throughout — this only lets the tiles append structured `/move` intents; no schema changes, no engine writes.

## Test plan
- [x] `qa/fast_gate.sh` — PASS (241 passed, Tier 0 deterministic).
- [x] `uv run --directory servers/engine python -m pytest ../../viewer/tests -q -p no:xdist` — 819 passed, 1 skipped, 86 subtests passed, **3 pre-existing failures** in `test_nav_chronicle_resilience.py` (`AttributeError: module 'server' has no attribute '_session_recent_events'`, an order-dependent `sys.modules["server"]` collision). Verified these reproduce identically on a clean `origin/main` checkout (same 3 failures, same 811-passed baseline before this PR's +13 new tests) — pre-existing and unrelated to this change, not touched here per dispatch-packet guidance ("if many tests break, flag don't force-fix"; this is 3, pre-existing, and flagged).
- [x] New `viewer/tests/test_action_model.py` tests pass in isolation (13 passed, 2 subtests).

Do not merge — for review.