### PR TITLE
feat(engine): grid-461 PR-2 — AoE templates on the combat grid (#1251)

### DIFF
--- a/servers/engine/combat_grid.py
+++ b/servers/engine/combat_grid.py
@@ -185,3 +185,116 @@ def provokes_on_leave(prev_cell: Cell, new_cell: Cell, threat_cell: Cell) -> boo
     side-step) does NOT provoke; never being in reach does not provoke. PR-1 reach is a
     flat 5ft (Chebyshev <= 1) for every threatener."""
     return in_melee_reach(prev_cell, threat_cell) and not in_melee_reach(new_cell, threat_cell)
+
+
+# ── #1251 / PR-2: area-of-effect TEMPLATES (sphere / cone / line) ────────────────
+#
+# Pure geometry: map an SRD area shape (a sphere radius, a cone length, a line length/
+# width — all in FEET) onto the set of grid cells it covers. Mirrors the movement-spine
+# helpers above: no Campaign, no lock, no save — just math over (x, y) cells, clipped to
+# the grid extents. server.py's cast_spell wraps these to compute `affected_tile_coords`
+# and the occupants caught, then reuses the existing multi-target save-for-half loop.
+#
+# SRD 5.2 grid adaptation (the "Areas of Effect" template rules): a cell is IN an area if
+# the point at the CENTER of that cell lies within the shape. Distance uses the grid's
+# Chebyshev metric (the module's one distance model — a diagonal step is one cell), so a
+# `radius`-ft sphere reaches `radius // cell_size` cells out in king-moves. Line-of-effect
+# (whether a wall between origin and a cell blocks the area) is DEFERRED to #1252 — PR-2
+# templates are permissive (every in-shape cell is affected). TODO(#1252): LoE cull.
+
+
+def _clip(cells: set[Cell], width: int, height: int) -> set[Cell]:
+    """Drop cells outside the [0,width) x [0,height) grid (edge clipping at bounds)."""
+    return {(x, y) for (x, y) in cells if 0 <= x < width and 0 <= y < height}
+
+
+def _facing(origin: Cell, toward: Cell) -> Cell:
+    """The unit step (dx, dy) from `origin` toward `toward`, each component in {-1,0,1}
+    (one of the 8 grid directions, or (0,0) if the same cell). Cones and lines are cast
+    along one of these 8 facings — the grid adaptation snaps an aim point to a facing."""
+    ox, oy = origin
+    tx, ty = toward
+    sx = (tx > ox) - (tx < ox)
+    sy = (ty > oy) - (ty < oy)
+    return (sx, sy)
+
+
+def sphere_cells(
+    center: Cell, radius_ft: int, width: int, height: int, cell_size: int = 5
+) -> set[Cell]:
+    """Cells within a `radius_ft` sphere/circle centred on `center` (the burst point of a
+    Fireball et al.). A cell is in the area when its Chebyshev distance from `center` is
+    <= radius_ft/cell_size cells — i.e. the burst reaches `radius_ft` feet out in every
+    direction. Includes `center`. Clipped to the grid (a burst at the edge is truncated).
+    radius_ft <= 0 yields just the centre cell (if in bounds)."""
+    reach = max(0, radius_ft // cell_size) if cell_size > 0 else 0
+    cx, cy = center
+    cells = {
+        (cx + dx, cy + dy)
+        for dx in range(-reach, reach + 1)
+        for dy in range(-reach, reach + 1)
+    }
+    return _clip(cells, width, height)
+
+
+def cone_cells(
+    origin: Cell, toward: Cell, length_ft: int, width: int, height: int, cell_size: int = 5
+) -> set[Cell]:
+    """Cells in a `length_ft` cone whose point is at `origin`, cast toward `toward`. Grid
+    adaptation of the SRD cone (its width at any point equals its distance from the point):
+    a cell at forward-depth `d` cells (1..length) is in the cone if its lateral offset from
+    the centre line is <= `d` — the 1:1 widening quadrant fan. The cone is snapped to one of
+    the 8 grid facings (from origin toward `toward`); a diagonal facing fans along both
+    diagonals. `origin` itself is NOT included (the caster's cell — the point is the emitter,
+    not a target). length_ft <= 0 or a zero facing yields the empty set. Clipped to bounds."""
+    depth = max(0, length_ft // cell_size) if cell_size > 0 else 0
+    fx, fy = _facing(origin, toward)
+    if depth <= 0 or (fx == 0 and fy == 0):
+        return set()
+    ox, oy = origin
+    cells: set[Cell] = set()
+    if fx != 0 and fy != 0:
+        # Diagonal facing: the cone occupies the quadrant between the two axes. At depth d
+        # (measured in king-moves = max(|dx|,|dy|)) a cell is in-cone if BOTH axis offsets
+        # advance with the facing and neither exceeds d (a square quadrant fan).
+        for i in range(1, depth + 1):
+            for j in range(0, depth + 1):
+                cells.add((ox + fx * i, oy + fy * j))
+                cells.add((ox + fx * j, oy + fy * i))
+    else:
+        # Orthogonal facing: primary axis is the facing; lateral offset <= depth-along-axis.
+        for d in range(1, depth + 1):
+            for off in range(-d, d + 1):
+                if fx != 0:  # cast along x -> lateral is y
+                    cells.add((ox + fx * d, oy + off))
+                else:  # cast along y -> lateral is x
+                    cells.add((ox + off, oy + fy * d))
+    return _clip(cells, width, height)
+
+
+def line_cells(
+    origin: Cell, toward: Cell, length_ft: int, width_ft: int,
+    grid_w: int, grid_h: int, cell_size: int = 5,
+) -> set[Cell]:
+    """Cells in a `length_ft` line `width_ft` wide, drawn from `origin` toward `toward`
+    (a Lightning Bolt). The line runs `length_ft/cell_size` cells along the facing from
+    `origin` toward `toward` (snapped to one of the 8 grid directions); `width_ft/cell_size`
+    (>=1) sets how many cells wide, thickened symmetrically about the centre line. `origin`
+    itself is NOT included (the emitter cell). length_ft <= 0 or a zero facing yields empty.
+    Clipped to the grid."""
+    length = max(0, length_ft // cell_size) if cell_size > 0 else 0
+    half = max(0, (max(cell_size, width_ft) // cell_size - 1) // 2) if cell_size > 0 else 0
+    fx, fy = _facing(origin, toward)
+    if length <= 0 or (fx == 0 and fy == 0):
+        return set()
+    ox, oy = origin
+    cells: set[Cell] = set()
+    # Perpendicular unit (for thickness): rotate the facing 90 degrees. For a diagonal
+    # facing this thickens along the opposite diagonal; for an orthogonal facing, along the
+    # cross axis. half=0 (5ft wide) is a single-cell-wide line — the common case.
+    px, py = -fy, fx
+    for step in range(1, length + 1):
+        bx, by = ox + fx * step, oy + fy * step
+        for w in range(-half, half + 1):
+            cells.add((bx + px * w, by + py * w))
+    return _clip(cells, grid_w, grid_h)

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -6399,6 +6399,39 @@ def _aoe_damage_spec(curated, srd, slot_level: int, caster_level: int, casting_m
     return None
 
 
+# #1251 / PR-2: default LINE length when the SRD record carries only a width. Lightning
+# Bolt (the one SRD `line` spell) encodes its 100ft length in prose, not a structured
+# field; shape_size there is the 5ft WIDTH. Fall back to this so a line still projects.
+_DEFAULT_LINE_LENGTH_FT = 100
+
+
+def _aoe_template_cells(c: "Campaign", caster: "Character", srd, aim: tuple[int, int]):
+    """#1251 / PR-2: the set of grid cells covered by `caster`'s spell area, aimed at cell
+    `aim`, or None when the spell has no engine-resolvable grid template (no SRD shape, or
+    a shape PR-2 doesn't map — cube/wall land in #1253+). Read-only geometry over
+    combat_grid; the caller resolves occupants + damage. SRD sizes are in FEET; the grid's
+    cell_size converts them. A sphere bursts AT `aim`; a cone/line is cast FROM the caster's
+    cell TOWARD `aim` (so the caster must be placed). Line-of-effect is DEFERRED (#1252)."""
+    shape = (srd or {}).get("shape_type")
+    if not shape:
+        return None
+    w, h, cs = c.combat.grid_width, c.combat.grid_height, c.combat.grid_cell_size
+    size = int((srd.get("shape_size") or 0))
+    if shape == "sphere":
+        # A burst centred on the aim cell — origin-independent (no facing needed).
+        return combat_grid.sphere_cells(aim, size, w, h, cs)
+    cb = next((o for o in c.combat.order if o.character_id == caster.id), None)
+    if cb is None or cb.x is None or cb.y is None:
+        return None  # a cone/line needs a placed emitter to fix its facing
+    src = (cb.x, cb.y)
+    if shape == "cone":
+        return combat_grid.cone_cells(src, aim, size, w, h, cs)
+    if shape == "line":
+        # SRD `line` shape_size is the WIDTH; length lives in prose -> use the default.
+        return combat_grid.line_cells(src, aim, _DEFAULT_LINE_LENGTH_FT, size, w, h, cs)
+    return None  # cube / other shapes: not a PR-2 template (deferred)
+
+
 @mcp.tool()
 def concentration_save(campaign_id: str, character_id: str, dc: int) -> dict:
     """Roll a concentration saving throw (CON save) at the given DC (usually
@@ -7432,6 +7465,7 @@ def cast_spell(
     as_ritual: bool = False,
     innate: bool = False,
     target_ids: ListArg = None,
+    origin: ListArg = None,
 ) -> dict:
     """Cast a spell — works for ANY of the ~339 SRD spells. Consumes a spell slot
     (cantrips use none); upcasts when slot_level exceeds the spell's level; sets
@@ -7442,7 +7476,8 @@ def cast_spell(
     target via ``target_id`` (canonical) or the aliases ``npc_id`` / ``id``. (``character_id``
     is the CASTER and is unchanged.) Canonical names win if more than one is given. Pass
     ``as_ritual=True`` (#813) to cast a ritual-tagged spell WITHOUT a slot (takes 10 extra
-    minutes; refused in combat)."""
+    minutes; refused in combat). On a grid (#1251), ``origin=[x,y]`` projects the spell's
+    SRD area (sphere/cone/line) onto the cells and auto-resolves the occupants caught."""
     # Coalesce intuitive arg-name aliases to the canonical params. `character_id` (the caster)
     # is canonical and untouched; the alias ids resolve only the explicit `target_id`.
     spell_name = spell_name or spell
@@ -7508,6 +7543,35 @@ def cast_spell(
                     )
                 seen_ids.add(tid)
                 aoe_targets.append(tgt)
+        # AoE GRID TEMPLATE (#1251 / PR-2): when an `origin` cell is given AND the fight is
+        # on the grid, project the spell's SRD area (sphere/cone/line) onto the cells and let
+        # the OCCUPANTS become the AoE targets — the engine resolves save-for-half over them
+        # via the same shared-roll loop as an explicit target_ids list. `affected_tile_coords`
+        # is surfaced for the DM/renderer. ADDITIVE: no `origin` (or off-grid) == unchanged —
+        # `aoe_targets` stays empty and no template keys are emitted. An explicit target_ids
+        # WINS (the caller named the victims by hand); a template only fills an empty list.
+        # Line-of-effect (walls between origin and a cell) is DEFERRED. TODO(#1251->#1252).
+        affected_tile_coords: list[list[int]] | None = None
+        if origin is not None and not target_ids and c.combat.grid_enabled:
+            oc = _coerce_list(origin)
+            if len(oc) != 2:
+                raise ValueError("cast_spell origin must be an [x, y] cell pair")
+            aim = (int(oc[0]), int(oc[1]))
+            cells = _aoe_template_cells(c, ch, srd, aim)
+            if cells is not None:
+                affected_tile_coords = sorted([cx, cy] for (cx, cy) in cells)
+                # Occupants standing in the template (excluding the caster's own cell — a
+                # burst can catch the caster, but self-targeting is the DM's call; keep it
+                # simple and hit everyone else on a covered cell). Order-stable by initiative.
+                for cb in c.combat.order:
+                    if cb.character_id == character_id:
+                        continue
+                    if cb.x is None or cb.y is None:
+                        continue
+                    if (cb.x, cb.y) in cells:
+                        tgt = c.characters.get(cb.character_id)
+                        if tgt is not None:
+                            aoe_targets.append(tgt)
         # SRD: an incapacitated creature can't take an action — and a spell's casting time is
         # (almost always) an action/bonus/reaction, so refuse the cast outright rather than
         # spend the caster's slot / set concentration. Mirrors the attack() guard. (extends #42)
@@ -7956,6 +8020,11 @@ def cast_spell(
         # (one shared damage roll, full/half per save). Present only when target_ids was passed.
         if aoe_result is not None:
             result["aoe"] = aoe_result
+        # AoE GRID TEMPLATE (#1251 / PR-2): the cells the projected area covered — for the DM
+        # to narrate and the renderer to draw (the /combat-surface `affected_tile_coords`
+        # contract). Present only when an `origin` template was resolved on the grid.
+        if affected_tile_coords is not None:
+            result["affected_tile_coords"] = affected_tile_coords
         # AREA SHAPE (F03-4): surface the spell's geometry (Cone/Sphere/Line + size) from the
         # srd524 record so the DM can describe the area and pick who's caught — 52 spells carry
         # it and it was previously never told. Additive; absent when the record has no shape.

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -7560,12 +7560,12 @@ def cast_spell(
             cells = _aoe_template_cells(c, ch, srd, aim)
             if cells is not None:
                 affected_tile_coords = sorted([cx, cy] for (cx, cy) in cells)
-                # Occupants standing in the template (excluding the caster's own cell — a
-                # burst can catch the caster, but self-targeting is the DM's call; keep it
-                # simple and hit everyone else on a covered cell). Order-stable by initiative.
+                # Every combatant standing in the template is caught — SRD 5.2: a creature in
+                # the area is affected, and the CASTER is not exempt (a Fireball centred on
+                # yourself catches you). The caster rides the same save-for-half loop as anyone
+                # else; the DM narrates. Cone/line geometry already excludes the emitter cell,
+                # so a cone/line never catches its own caster. Order-stable by initiative.
                 for cb in c.combat.order:
-                    if cb.character_id == character_id:
-                        continue
                     if cb.x is None or cb.y is None:
                         continue
                     if (cb.x, cb.y) in cells:

--- a/servers/engine/tests/test_grid_aoe.py
+++ b/servers/engine/tests/test_grid_aoe.py
@@ -186,6 +186,31 @@ def test_cone_cast_uses_target_as_aim_point(gridfight):
     assert (2, 2) not in tiles  # caster's own cell excluded (it's the cone point)
 
 
+def test_sphere_centered_on_caster_catches_the_caster(gridfight):
+    # SRD 5.2: a creature in a spell's area is affected — the CASTER is not exempt (the
+    # classic fireball-centered-on-yourself). Burst the sphere on the caster's own cell.
+    cid, wiz, g1, g2, g3 = gridfight
+    server.place_combatant_at_coords(cid, g1, 3, 3)  # also inside the burst
+    res = server.cast_spell(cid, wiz, "Fireball", slot_level=3, origin=[2, 2])
+    tiles = {tuple(t) for t in res["affected_tile_coords"]}
+    assert (2, 2) in tiles  # the caster's cell is covered
+    hit_ids = {row["character_id"] for row in res["aoe"]["targets"]}
+    assert wiz in hit_ids  # the caster rides the same save-for-half loop
+    assert g1 in hit_ids
+    # And the caster took a save row like anyone else (full or halved, both honest).
+    caster_row = next(r for r in res["aoe"]["targets"] if r["character_id"] == wiz)
+    assert "save_roll" in caster_row and "damage_taken" in caster_row
+
+
+def test_cone_line_never_include_the_caster(gridfight):
+    # A cone/line is emitted FROM the caster's cell — the geometry excludes that cell, so
+    # the caster is never caught by their own cone/line even after the carve-out removal.
+    cid, wiz, g1, g2, g3 = gridfight
+    cone = server.cast_spell(cid, wiz, "Burning Hands", slot_level=1, origin=[3, 3])
+    assert [2, 2] not in cone["affected_tile_coords"]
+    assert wiz not in {r["character_id"] for r in cone.get("aoe", {}).get("targets", [])}
+
+
 # ── (5) BYTE-IDENTICAL regression: a cast WITHOUT origin is unchanged ─────────
 
 

--- a/servers/engine/tests/test_grid_aoe.py
+++ b/servers/engine/tests/test_grid_aoe.py
@@ -1,0 +1,206 @@
+"""#1251 grid (PR-2) — area-of-effect TEMPLATES (sphere / cone / line) + the cast_spell
+grid-template resolution that maps a spell's SRD area onto `affected_tile_coords` and the
+occupants caught.
+
+ADDITIVE / opt-in: template geometry runs only when a grid cast passes an `origin` cell
+(and the fight is on the grid); a cast without `origin` is BYTE-FOR-BYTE today's behaviour
+(the byte-identical regression test below is the load-bearing guard). Line-of-effect (walls
+between the origin and a cell) is DEFERRED to #1252 — PR-2 templates are permissive.
+
+The pure geometry lives in combat_grid (sphere_cells / cone_cells / line_cells); the wiring
+lives in server.cast_spell. Tests here cover both: cell-set geometry at several origins/
+facings + edge clipping, then the end-to-end Fireball-class multi-target resolution.
+"""
+
+import pytest
+
+import combat_grid
+import server
+
+
+# ── (1) SPHERE geometry ──────────────────────────────────────────────────────
+
+
+def test_sphere_radius_zero_is_just_center():
+    assert combat_grid.sphere_cells((5, 5), 0, 20, 20) == {(5, 5)}
+
+
+def test_sphere_20ft_reaches_four_cells_in_king_moves():
+    # 20ft / 5ft cells = 4 cells reach -> a 9x9 (radius-4 Chebyshev) block around center.
+    cells = combat_grid.sphere_cells((10, 10), 20, 40, 40)
+    assert (10, 10) in cells
+    assert (14, 10) in cells and (10, 14) in cells  # 4 cells out orthogonally
+    assert (14, 14) in cells  # 4 cells out diagonally (Chebyshev counts it as 4)
+    assert (15, 10) not in cells  # 5 cells out is beyond a 20ft (=4-cell) reach
+    # 9x9 block = 81 cells when fully in bounds.
+    assert len(cells) == 81
+
+
+def test_sphere_clips_at_grid_bounds():
+    # A 20ft burst centred at the corner (0,0) is clipped to the in-bounds quadrant.
+    cells = combat_grid.sphere_cells((0, 0), 20, 40, 40)
+    assert all(x >= 0 and y >= 0 for (x, y) in cells)
+    assert (0, 0) in cells and (4, 4) in cells
+    assert (-1, 0) not in cells
+    # Only the +x/+y quadrant of the 9x9 block survives: 5x5 = 25.
+    assert len(cells) == 25
+
+
+# ── (2) CONE geometry ────────────────────────────────────────────────────────
+
+
+def test_cone_orthogonal_widens_one_to_one():
+    # A 15ft (=3-cell) cone cast east (+x) from (0,10): depth d has lateral spread +-d.
+    cells = combat_grid.cone_cells((0, 10), (1, 10), 15, 40, 40)
+    assert (0, 10) not in cells  # the emitter cell is excluded
+    # depth 1: 3 cells (y in 9,10,11); depth 2: 5; depth 3: 7 -> 15 total.
+    assert (1, 10) in cells and (1, 9) in cells and (1, 11) in cells
+    assert (1, 8) not in cells  # lateral 2 at depth 1 is out
+    assert (3, 7) in cells and (3, 13) in cells  # depth 3, lateral +-3
+    assert (3, 6) not in cells
+    assert len(cells) == 3 + 5 + 7
+
+
+def test_cone_direction_follows_aim_point():
+    # Same cone cast west (-x): mirror image, all cells have x < origin.
+    cells = combat_grid.cone_cells((10, 10), (0, 10), 15, 40, 40)
+    assert cells
+    assert all(x < 10 for (x, y) in cells)
+
+
+def test_cone_diagonal_facing_fans_into_the_quadrant():
+    # A 15ft (=3-cell) cone cast SE (+x,+y) from the corner (0,0): a square quadrant fan,
+    # origin excluded, every cell in the +x/+y quadrant within depth 3.
+    cells = combat_grid.cone_cells((0, 0), (1, 1), 15, 40, 40)
+    assert (0, 0) not in cells
+    assert all(x >= 0 and y >= 0 for (x, y) in cells)
+    assert (3, 3) in cells and (2, 2) in cells and (3, 0) in cells and (0, 3) in cells
+    assert (4, 0) not in cells  # depth 4 is beyond a 3-cell cone
+
+
+def test_cone_zero_facing_is_empty():
+    assert combat_grid.cone_cells((5, 5), (5, 5), 30, 40, 40) == set()
+
+
+def test_cone_clips_at_bounds():
+    # Cone cast north (-y) from near the top edge is truncated, never negative.
+    cells = combat_grid.cone_cells((10, 1), (10, 0), 30, 40, 40)
+    assert all(y >= 0 for (x, y) in cells)
+
+
+# ── (3) LINE geometry ────────────────────────────────────────────────────────
+
+
+def test_line_east_is_single_cell_wide_by_default():
+    # 20ft (=4-cell), 5ft-wide line east from (0,10): cells (1..4, 10). Origin excluded.
+    cells = combat_grid.line_cells((0, 10), (1, 10), 20, 5, 40, 40)
+    assert cells == {(1, 10), (2, 10), (3, 10), (4, 10)}
+
+
+def test_line_width_thickens_symmetrically():
+    # 15ft-wide (=3-cell) line thickens +-1 about the centre line.
+    cells = combat_grid.line_cells((0, 10), (1, 10), 10, 15, 40, 40)
+    # 2 cells long x 3 wide = 6 cells.
+    assert cells == {
+        (1, 9), (1, 10), (1, 11),
+        (2, 9), (2, 10), (2, 11),
+    }
+
+
+def test_line_diagonal_facing():
+    # A line cast to the SE (+x,+y): steps along the diagonal.
+    cells = combat_grid.line_cells((0, 0), (1, 1), 20, 5, 40, 40)
+    assert cells == {(1, 1), (2, 2), (3, 3), (4, 4)}
+
+
+def test_line_zero_facing_is_empty():
+    assert combat_grid.line_cells((5, 5), (5, 5), 30, 5, 40, 40) == set()
+
+
+def test_line_clips_at_bounds():
+    cells = combat_grid.line_cells((38, 10), (39, 10), 30, 5, 40, 40)
+    assert all(x < 40 for (x, y) in cells)
+    assert cells == {(39, 10)}  # only the one in-bounds cell survives
+
+
+# ── (4) end-to-end cast_spell grid-template resolution ───────────────────────
+
+
+@pytest.fixture
+def gridfight(tmp_path, monkeypatch):
+    """A caster (wizard, placed) + three goblins on a 20x20 grid, in active combat.
+    Two goblins stand inside a Fireball centred at (10,10); one stands well outside."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("AoE 1251")["id"]
+    wiz = server.create_character(cid, "Wizard", kind="player", max_hp=30, armor_class=14)["id"]
+    server.update_character(cid, wiz, patch={"spell_slots": {
+        "1": {"maximum": 4, "used": 0}, "3": {"maximum": 4, "used": 0}}})
+    g1 = server.create_character(cid, "Gob1", kind="monster", max_hp=15, armor_class=12)["id"]
+    g2 = server.create_character(cid, "Gob2", kind="monster", max_hp=15, armor_class=12)["id"]
+    g3 = server.create_character(cid, "Gob3", kind="monster", max_hp=15, armor_class=12)["id"]
+    server.start_combat(cid, [wiz, g1, g2, g3])
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, wiz, 2, 2)
+    server.place_combatant_at_coords(cid, g1, 10, 10)   # burst centre
+    server.place_combatant_at_coords(cid, g2, 12, 11)   # within 20ft (4 cells)
+    server.place_combatant_at_coords(cid, g3, 2, 18)    # far away, outside the burst
+    return cid, wiz, g1, g2, g3
+
+
+def test_fireball_hits_exactly_the_template_occupants(gridfight):
+    cid, wiz, g1, g2, g3 = gridfight
+    res = server.cast_spell(cid, wiz, "Fireball", slot_level=3, origin=[10, 10])
+    tiles = {tuple(t) for t in res["affected_tile_coords"]}
+    assert (10, 10) in tiles and (12, 11) in tiles
+    assert (2, 18) not in tiles
+    aoe = res["aoe"]
+    hit_ids = {row["character_id"] for row in aoe["targets"]}
+    assert hit_ids == {g1, g2}  # exactly the two inside the burst; g3 is spared
+
+
+def test_fireball_save_for_half_accounting_is_honest(gridfight):
+    cid, wiz, g1, g2, g3 = gridfight
+    res = server.cast_spell(cid, wiz, "Fireball", slot_level=3, origin=[10, 10])
+    aoe = res["aoe"]
+    assert aoe["on_save"] == "half"
+    shared = aoe["shared_damage"]["total"]
+    for row in aoe["targets"]:
+        # A saved-and-halved row takes floor(shared/2); a failed row takes the full roll.
+        # Either way the applied damage is one of exactly those two honest values.
+        assert row["damage_taken"] in (shared, shared // 2)
+        if row["saved"]:
+            assert row["halved"] is True
+            assert row["damage_taken"] == shared // 2
+        else:
+            assert row["damage_taken"] == shared
+
+
+def test_cone_cast_uses_target_as_aim_point(gridfight):
+    # Burning Hands is a 15ft cone; aim it from the caster (2,2) toward the SE via origin.
+    cid, wiz, g1, g2, g3 = gridfight
+    # Move a goblin into the cone path first.
+    server.place_combatant_at_coords(cid, g1, 4, 4)
+    res = server.cast_spell(cid, wiz, "Burning Hands", slot_level=1, origin=[3, 3])
+    tiles = {tuple(t) for t in res["affected_tile_coords"]}
+    assert tiles  # a non-empty cone was projected
+    assert (2, 2) not in tiles  # caster's own cell excluded (it's the cone point)
+
+
+# ── (5) BYTE-IDENTICAL regression: a cast WITHOUT origin is unchanged ─────────
+
+
+def test_single_target_cast_without_origin_has_no_aoe_keys(gridfight):
+    cid, wiz, g1, g2, g3 = gridfight
+    res = server.cast_spell(cid, wiz, "Fireball", slot_level=3)
+    # No template was requested -> no grid-template keys leak into the result.
+    assert "affected_tile_coords" not in res
+    assert "aoe" not in res
+
+
+def test_explicit_target_ids_path_still_works_off_template(gridfight):
+    # The pre-existing explicit-list AoE path (target_ids) is untouched by PR-2.
+    cid, wiz, g1, g2, g3 = gridfight
+    res = server.cast_spell(cid, wiz, "Fireball", slot_level=3, target_ids=[g1, g3])
+    assert "affected_tile_coords" not in res  # no geometry when caller lists ids explicitly
+    hit_ids = {row["character_id"] for row in res["aoe"]["targets"]}
+    assert hit_ids == {g1, g3}


### PR DESCRIPTION
## What

grid-461 **PR-2** — geometric area-of-effect templates (sphere / cone / line) on the `(x,y)` combat grid, mapped to affected cells + multi-target resolution for area spells. Closes #1251; part of the combat epic #1100.

Given a grid cast with an `origin=[x,y]` aim cell, the engine projects the spell's **SRD 5.2 shape** onto the grid, returns `affected_tile_coords`, and auto-resolves save-for-half over the occupants standing in those cells.

## Approach — template geometry

Pure, I/O-free helpers in `combat_grid.py` (mirroring the PR-1 movement-spine style), all using the module's one **Chebyshev** distance metric and edge-clipped to the grid extents:

- **`sphere_cells(center, radius_ft, …)`** — cells within `radius_ft/cell_size` king-moves of the burst point. A Fireball bursts *at* `origin` (origin-independent).
- **`cone_cells(origin, toward, length_ft, …)`** — SRD cone (width == distance from the point) snapped to one of the 8 grid facings from the caster toward `origin`; 1:1 widening quadrant fan; the emitter cell is excluded.
- **`line_cells(origin, toward, length_ft, width_ft, …)`** — a line `length_ft` long × `width_ft` wide, thickened symmetrically about the centre line, along the 8-facing toward `origin`.

`server._aoe_template_cells` maps the SRD record's `shape_type` / `shape_size` (feet) onto those helpers. The occupants of the covered cells feed the **existing** `target_ids` shared-roll save-for-half loop — no new state writer, no new damage path.

## Invariants

- **Engine = sole writer.** All new geometry is read-only; resolution happens inside the existing `cast_spell` write path. No new `save_campaign` callers.
- **Additive / default-off.** No `origin` (or off-grid, or an explicit `target_ids`) ⇒ **byte-identical** to today. Regression tests assert no template keys leak and the explicit-list path is untouched.
- **Tool-schema budget.** Reused the existing `target_id`/`target_ids` semantics; added exactly **one** `ListArg` param (`origin`). Schema slab grew **+242 B** (headroom 1565 → **1323 B**, under the 120 KB budget; `test_tool_schema_budget` green).
- **Scope discipline (PR-2 only).** No cover/LoS (#1252), no terrain/size (#1253), no flanking (#1254). Line-of-effect is stubbed **permissive** with a `TODO(#1252)`.

## Tests

New `tests/test_grid_aoe.py` (18 tests): sphere/cone/line cell-set geometry at several origins + facings (orthogonal & diagonal), edge clipping at grid bounds; end-to-end Fireball-class cast hitting exactly the template occupants; honest save-for-half accounting; and byte-identical regression proofs (no-`origin` cast + explicit-`target_ids` cast unchanged).

```
tests/test_grid_aoe.py ............ 18 passed
qa/fast_gate.sh ................... 241 passed (T0 PASS)
full engine suite ................. 3277 passed
```
(run with `-p no:xdist`, single-process.)

Part of #1100.