### PR TITLE
feat(engine): grid-461 PR-3 — cover + line-of-sight (#1252)

### DIFF
--- a/servers/engine/combat_grid.py
+++ b/servers/engine/combat_grid.py
@@ -298,3 +298,200 @@ def line_cells(
         for w in range(-half, half + 1):
             cells.add((bx + px * w, by + py * w))
     return _clip(cells, grid_w, grid_h)
+
+
+# ── #1252 / PR-3: line-of-sight ray traversal + SRD cover ────────────────────────
+#
+# Pure geometry, no Campaign/lock/save — math over (x, y) cells + a set of BLOCKING
+# cells (the fight's grid_impassable: walls/props/obstacles). Two capabilities:
+#
+#   * `line_blockers(a, b, blocking)` — the supercover ray from cell `a` to cell `b`:
+#     every cell the straight segment between the two cell CENTRES passes through,
+#     EXCLUDING the two endpoints, intersected with `blocking`. This is the raw
+#     "what's between them" set that both LoS and cover read.
+#   * `has_line_of_effect(a, b, blocking)` — True iff that ray crosses NO blocking cell
+#     (an unobstructed straight shot). Used to cull AoE cells with no line of effect
+#     from the burst origin (#1257's deferred TODO) and to detect TOTAL cover.
+#   * `cover_between(a, b, blocking)` — the SRD 5.2 cover TIER a target at `b` has from
+#     an attacker at `a`, derived from the count of intervening blockers (below).
+#
+# RAY MODEL — supercover, permissive corner-graze tie-break:
+#   We march the exact segment between the two cell centres. When the segment passes
+#   through a cell FACE we enter that cell (it counts). When it passes exactly through a
+#   grid VERTEX (a "corner graze" — the ideal diagonal line of two aligned cells, or any
+#   line hitting a lattice point), the segment touches the four cells meeting at that
+#   corner only at a single point. SRD/tabletop LoS traces to a corner and treats a shot
+#   that merely grazes a blocker's corner as UNOBSTRUCTED. So the tie-break is:
+#
+#     A corner graze severs the ray ONLY IF BOTH cells on the ray's leading diagonal at
+#     that vertex are blockers (you cannot thread a line between two blockers that meet at
+#     a point). A single diagonal blocker (or a blocker touched only at its corner) does
+#     NOT block — the ray slips past its corner.
+#
+#   This is the standard permissive supercover rule and it makes LoS symmetric
+#   (`a`->`b` blocked iff `b`->`a` blocked) and additive (no blockers => never severed).
+
+
+def _supercover_cells(a: Cell, b: Cell) -> list[Cell]:
+    """The ordered list of cells the straight segment between the CENTRES of `a` and `b`
+    passes through, from `a` to `b` inclusive (a supercover line). A pure-diagonal or
+    axis-aligned segment yields the minimal staircase; an oblique segment yields every
+    cell whose interior the segment crosses. Deterministic; endpoints included (callers
+    strip them). This is the geometry both LoS and cover read."""
+    (x0, y0), (x1, y1) = a, b
+    if a == b:
+        return [a]
+    dx = x1 - x0
+    dy = y1 - y0
+    nx, ny = abs(dx), abs(dy)
+    sx = 1 if dx > 0 else -1
+    sy = 1 if dy > 0 else -1
+    cells: list[Cell] = [(x0, y0)]
+    x, y = x0, y0
+    # March by comparing the accumulated cross-products (ix/nx vs iy/ny as ix*ny vs iy*nx),
+    # stepping x, y, or BOTH (a diagonal step through a vertex). A simultaneous step is the
+    # corner-graze case — it visits the vertex without adding either shoulder cell.
+    ix = iy = 0
+    while ix < nx or iy < ny:
+        decision = (1 + 2 * ix) * ny - (1 + 2 * iy) * nx
+        if decision == 0:
+            # Exact corner graze: the segment passes through the lattice vertex. Step both
+            # axes diagonally — do NOT add the two shoulder cells (they are only touched at
+            # the corner point). The tie-break for blocking is applied by line_blockers.
+            x += sx
+            y += sy
+            ix += 1
+            iy += 1
+        elif decision < 0:
+            x += sx
+            ix += 1
+        else:
+            y += sy
+            iy += 1
+        cells.append((x, y))
+    return cells
+
+
+def _diagonal_corner_pairs(a: Cell, b: Cell) -> list[tuple[Cell, Cell]]:
+    """For each pure-diagonal step the supercover ray from `a` to `b` takes through a grid
+    VERTEX, the pair of SHOULDER cells that meet at that corner (the two cells the ray did
+    NOT enter, flanking the diagonal step). The corner-graze tie-break blocks the ray at a
+    step only when BOTH shoulders in a pair are blockers. Empty for a ray with no diagonal
+    vertex steps (axis-aligned or oblique face-crossing rays)."""
+    (x0, y0), (x1, y1) = a, b
+    if a == b:
+        return []
+    dx, dy = x1 - x0, y1 - y0
+    nx, ny = abs(dx), abs(dy)
+    sx = 1 if dx > 0 else -1
+    sy = 1 if dy > 0 else -1
+    pairs: list[tuple[Cell, Cell]] = []
+    x, y = x0, y0
+    ix = iy = 0
+    while ix < nx or iy < ny:
+        decision = (1 + 2 * ix) * ny - (1 + 2 * iy) * nx
+        if decision == 0:
+            # Diagonal step from (x,y) to (x+sx, y+sy): the two shoulders are the cells
+            # reached by stepping ONE axis only — (x+sx, y) and (x, y+sy).
+            pairs.append(((x + sx, y), (x, y + sy)))
+            x += sx
+            y += sy
+            ix += 1
+            iy += 1
+        elif decision < 0:
+            x += sx
+            ix += 1
+        else:
+            y += sy
+            iy += 1
+    return pairs
+
+
+def line_blockers(a: Cell, b: Cell, blocking: set[Cell]) -> set[Cell]:
+    """The BLOCKING cells strictly BETWEEN `a` and `b` on the supercover ray (endpoints
+    excluded). A cell the ray's interior crosses that is in `blocking` counts. A pure
+    corner graze contributes a blocker ONLY when both shoulder cells of that diagonal step
+    are blockers (the permissive tie-break above) — a lone diagonal blocker is slipped
+    past and is NOT included. Empty `blocking` (open floor) => always empty (additive)."""
+    if not blocking or a == b:
+        return set()
+    hit: set[Cell] = set()
+    interior = _supercover_cells(a, b)[1:-1]  # strip both endpoints
+    for cell in interior:
+        if cell in blocking:
+            hit.add(cell)
+    # Corner-graze severing: a diagonal vertex step is blocked only if BOTH shoulders are
+    # blockers. When it is, credit BOTH shoulder blockers (they jointly seal the corner);
+    # a half-open corner (one shoulder blocking) is NOT credited (the ray slips past).
+    for s1, s2 in _diagonal_corner_pairs(a, b):
+        if s1 in blocking and s2 in blocking:
+            if s1 != a and s1 != b:
+                hit.add(s1)
+            if s2 != a and s2 != b:
+                hit.add(s2)
+    return hit
+
+
+def has_line_of_effect(a: Cell, b: Cell, blocking: set[Cell]) -> bool:
+    """True iff the supercover ray from `a` to `b` crosses NO blocking cell — an
+    unobstructed straight shot (LoS / line-of-effect). Endpoints are never their own
+    blockers (a target standing in a doorway is still targetable). Open floor => always
+    True (additive: with no blockers nothing is ever culled)."""
+    return not line_blockers(a, b, blocking)
+
+
+# SRD 5.2 cover TIERS. The derivation is deliberately simple and documented: count the
+# DISTINCT blocking cells the attacker->target ray crosses (line_blockers), then:
+#   0 blockers  -> "none"            (clear shot; no AC/DEX bonus)
+#   1 blocker   -> "half"            (+2 AC / +2 DEX saves)
+#   >=2 blockers -> "three_quarters" (+5 AC / +5 DEX saves)
+#   ray fully severed (no line of effect at all, i.e. >=1 blocker) with the target
+#     UNREACHABLE by any traced corner -> "total" (can't be targeted directly).
+# A single ray can't distinguish "one thick wall" from "total" on its own, so total cover
+# is derived separately: a target has TOTAL cover when it has NO line of effect from ANY
+# of the traced corner rays (see cover_between). This mirrors the SRD "trace to a corner"
+# rule — half/three-quarters come from the best (least-obstructed) corner; total means no
+# corner has a clear line.
+_COVER_AC = {"none": 0, "half": 2, "three_quarters": 5, "total": 0}
+
+
+def cover_between(a: Cell, b: Cell, blocking: set[Cell]) -> str:
+    """The SRD 5.2 cover tier a target at cell `b` has from an attacker/origin at `a`,
+    given the fight's `blocking` cells. Derivation (documented, single-ray for PR-3's
+    1-cell tokens):
+
+      * count the distinct blockers on the centre-to-centre supercover ray (line_blockers);
+      * 0 -> "none", exactly 1 -> "half", 2+ -> "three_quarters";
+      * BUT if the ray has no line of effect AND no shoulder path threads past (total
+        occlusion — the blockers fully seal the corner between them), the tier is "total".
+
+    We approximate "total" as: the ray is severed by a corner-graze pair (both shoulders
+    blocking) AND every interior cell on the ray is a blocker with no open shoulder — i.e.
+    there is genuinely no gap. In practice, one blocker => half, two => three-quarters, and
+    a fully-walled ray (a solid line of blockers with no threadable corner) => total. Open
+    floor (`blocking` empty) or `a == b` => "none" (additive: no cover off the grid)."""
+    if not blocking or a == b:
+        return "none"
+    blockers = line_blockers(a, b, blocking)
+    n = len(blockers)
+    if n == 0:
+        return "none"
+    # TOTAL cover: no line of effect AND no threadable gap. A ray is TOTALLY severed when
+    # every step is sealed — the interior is a contiguous blocker wall AND any diagonal
+    # graze is a both-shoulders-blocked pair (no corner to slip through). For PR-3's
+    # single-cell tokens the practical rule: if the interior contains a blocker on EVERY
+    # cell the ray must cross (no open cell between attacker and target), the target is
+    # behind solid cover and can't be targeted directly => total.
+    interior = _supercover_cells(a, b)[1:-1]
+    if interior and all(cell in blocking for cell in interior):
+        return "total"
+    if n == 1:
+        return "half"
+    return "three_quarters"
+
+
+def cover_ac_bonus(tier: str) -> int:
+    """The AC / DEX-save bonus a cover `tier` grants (SRD 5.2): half=+2, three-quarters=+5,
+    none/total=0 (total cover isn't an AC bump — the target simply can't be targeted).
+    Unknown tier => 0 (defensive; additive)."""
+    return _COVER_AC.get(tier, 0)

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -5670,6 +5670,32 @@ def attack(
                     ranged_in_melee_grid = True
                     break
         dis = dis or ranged_in_melee_grid
+        # COVER (#1252 / PR-3): when on the grid AND both combatants are placed, derive the
+        # SRD 5.2 cover the target has from the attacker's line — half (+2 AC), three-quarters
+        # (+5 AC), or total (untargetable). Cover comes from intervening BLOCKING cells (the
+        # fight's grid_impassable walls/props) on the attacker->target ray; the tier is the
+        # count of blockers crossed (0=none, 1=half, 2+=three-quarters, a fully-walled ray =
+        # total). Total cover REFUSES the shot up front (before the roll) — SRD: a creature
+        # with total cover can't be targeted directly. ADDITIVE: off-grid or an unplaced end
+        # yields no cover (cover_ac_bonus 0, no key) == today's behaviour byte-for-byte.
+        cover_tier = "none"
+        cover_ac = 0
+        if c.combat.grid_enabled:
+            _acb = next((cb for cb in c.combat.order if cb.character_id == attacker_id), None)
+            _tcb = next((cb for cb in c.combat.order if cb.character_id == target_id), None)
+            _ac = _cell(_acb) if _acb is not None else None
+            _tc = _cell(_tcb) if _tcb is not None else None
+            if _ac is not None and _tc is not None:
+                blocking = {(int(bx), int(by)) for bx, by in (c.combat.grid_impassable or [])}
+                if blocking:
+                    cover_tier = combat_grid.cover_between(_ac, _tc, blocking)
+                    if cover_tier == "total":
+                        raise ValueError(
+                            f"{target.name} at {_tc} has TOTAL cover from {attacker.name} at "
+                            f"{_ac} (a wall fully blocks the line) and can't be targeted "
+                            f"directly — reposition for a clear shot. No attack was resolved."
+                        )
+                    cover_ac = combat_grid.cover_ac_bonus(cover_tier)
         # crit_min threads the attacker's expanded crit range (Champion Improved/Superior
         # Critical → 19/18; everyone else 20 = today's behavior) so a Champion's nat-19
         # actually flags atk.crit and crit_source() resolves "expanded_crit_range".
@@ -5688,6 +5714,9 @@ def attack(
         guided_bonus = atk_bonus_rider.amount if atk_bonus_rider is not None else 0
         atk_total = atk.total + rider_bonus + guided_bonus
         target_ac, target_ac_detail = _effective_armor_class(target)
+        # Fold grid cover (#1252) into the AC the attacker must beat — half=+2, three-quarters=+5
+        # (SRD 5.2). cover_ac is 0 off-grid / with no blocker between (additive: unchanged).
+        target_ac += cover_ac
         hit = atk.crit or (not atk.fumble and atk_total >= target_ac)
         # TEST-ONLY force_hit (Track 2b — DOUBLE-GUARDED): force the HIT BOOLEAN only so a
         # sandbox fight resolves to a terminal state without depending on the dice landing hits.
@@ -5754,6 +5783,17 @@ def attack(
             # disadvantage (folded into `dis` above), so the DM narrates it and the behavioral
             # gate / scorer see the rule actually fired on-grid (not announced-then-dropped).
             result["attack_roll"]["ranged_in_melee_disadvantage"] = True
+        if cover_ac > 0:
+            # #1252 grid (PR-3): surface the SRD cover the target enjoyed and the AC it added,
+            # so the DM narrates "the goblin ducks behind the pillar (+2 AC)" and the scorer /
+            # renderer see cover ACTUALLY applied to the hit math (not announced-then-dropped).
+            # `effective_ac` is the base AC the target beat WITH cover folded in. Free payload
+            # (no tool-schema param — derived from existing state). Absent when no cover (none).
+            result["cover"] = {
+                "tier": cover_tier,
+                "ac_bonus": cover_ac,
+                "effective_ac": target_ac,
+            }
         if rider_rolls:
             # The engine-rolled rider components (SYN-06), itemized so the DM narrates
             # "the blessing guides the blade (+3)" — and sees the buff actually counted.
@@ -7559,6 +7599,20 @@ def cast_spell(
             aim = (int(oc[0]), int(oc[1]))
             cells = _aoe_template_cells(c, ch, srd, aim)
             if cells is not None:
+                # LINE-OF-EFFECT cull (#1252 / PR-3): the template origin `aim` is the burst
+                # point (sphere) or the emitter's aim (cone/line). A cell with NO line of
+                # effect from that origin — a wall/prop between them severs the ray — is
+                # SHIELDED and drops out of the area (SRD 5.2: "a target has total cover ...
+                # can't be targeted; likewise a point of origin can't extend around corners").
+                # ADDITIVE: with no impassable cells the ray is never severed, so `cells` is
+                # unchanged byte-for-byte (open-floor AoE == PR-2 behaviour). The origin cell
+                # always has line of effect to itself and is retained.
+                blocking = {(int(bx), int(by)) for bx, by in (c.combat.grid_impassable or [])}
+                if blocking:
+                    cells = {
+                        cell for cell in cells
+                        if cell == aim or combat_grid.has_line_of_effect(aim, cell, blocking)
+                    }
                 affected_tile_coords = sorted([cx, cy] for (cx, cy) in cells)
                 # Every combatant standing in the template is caught — SRD 5.2: a creature in
                 # the area is affected, and the CASTER is not exempt (a Fireball centred on

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -6451,24 +6451,33 @@ def _aoe_template_cells(c: "Campaign", caster: "Character", srd, aim: tuple[int,
     a shape PR-2 doesn't map — cube/wall land in #1253+). Read-only geometry over
     combat_grid; the caller resolves occupants + damage. SRD sizes are in FEET; the grid's
     cell_size converts them. A sphere bursts AT `aim`; a cone/line is cast FROM the caster's
-    cell TOWARD `aim` (so the caster must be placed). Line-of-effect is DEFERRED (#1252)."""
+    cell TOWARD `aim` (so the caster must be placed).
+
+    Returns ``(cells, loe_origin)`` — `loe_origin` is the spell's SRD POINT OF ORIGIN, the
+    cell line-of-effect (#1252) is traced FROM when culling shielded cells: the AIM cell for
+    a sphere (the burst's own origin IS the aim), but the CASTER'S cell for a cone/line (their
+    origin is the emitter, not the target point — a cone aimed past a wall must not reach cells
+    the caster can't see). None (not a tuple) when there is no template."""
     shape = (srd or {}).get("shape_type")
     if not shape:
         return None
     w, h, cs = c.combat.grid_width, c.combat.grid_height, c.combat.grid_cell_size
     size = int((srd.get("shape_size") or 0))
     if shape == "sphere":
-        # A burst centred on the aim cell — origin-independent (no facing needed).
-        return combat_grid.sphere_cells(aim, size, w, h, cs)
+        # A burst centred on the aim cell — origin-independent (no facing needed); LoE is
+        # traced from the burst point itself (the aim cell).
+        return combat_grid.sphere_cells(aim, size, w, h, cs), aim
     cb = next((o for o in c.combat.order if o.character_id == caster.id), None)
     if cb is None or cb.x is None or cb.y is None:
         return None  # a cone/line needs a placed emitter to fix its facing
     src = (cb.x, cb.y)
     if shape == "cone":
-        return combat_grid.cone_cells(src, aim, size, w, h, cs)
+        # A cone emits FROM the caster: LoE is traced from `src`, not the aim cell.
+        return combat_grid.cone_cells(src, aim, size, w, h, cs), src
     if shape == "line":
         # SRD `line` shape_size is the WIDTH; length lives in prose -> use the default.
-        return combat_grid.line_cells(src, aim, _DEFAULT_LINE_LENGTH_FT, size, w, h, cs)
+        # The line emits FROM the caster: LoE is traced from `src`.
+        return combat_grid.line_cells(src, aim, _DEFAULT_LINE_LENGTH_FT, size, w, h, cs), src
     return None  # cube / other shapes: not a PR-2 template (deferred)
 
 
@@ -7597,21 +7606,23 @@ def cast_spell(
             if len(oc) != 2:
                 raise ValueError("cast_spell origin must be an [x, y] cell pair")
             aim = (int(oc[0]), int(oc[1]))
-            cells = _aoe_template_cells(c, ch, srd, aim)
-            if cells is not None:
-                # LINE-OF-EFFECT cull (#1252 / PR-3): the template origin `aim` is the burst
-                # point (sphere) or the emitter's aim (cone/line). A cell with NO line of
-                # effect from that origin — a wall/prop between them severs the ray — is
-                # SHIELDED and drops out of the area (SRD 5.2: "a target has total cover ...
-                # can't be targeted; likewise a point of origin can't extend around corners").
-                # ADDITIVE: with no impassable cells the ray is never severed, so `cells` is
-                # unchanged byte-for-byte (open-floor AoE == PR-2 behaviour). The origin cell
-                # always has line of effect to itself and is retained.
+            template = _aoe_template_cells(c, ch, srd, aim)
+            if template is not None:
+                cells, loe_origin = template
+                # LINE-OF-EFFECT cull (#1252 / PR-3): trace LoE from the spell's SRD POINT OF
+                # ORIGIN (`loe_origin`) — the burst point (aim) for a sphere, the CASTER'S cell
+                # for a cone/line (their origin is the emitter, so a cone aimed past a wall must
+                # not reach cells the caster can't see). A cell with NO line of effect from that
+                # origin — a wall/prop between them severs the ray — is SHIELDED and drops out of
+                # the area (SRD 5.2: a point of origin can't extend around corners; a target with
+                # total cover can't be caught). ADDITIVE: with no impassable cells the ray is
+                # never severed, so `cells` is unchanged byte-for-byte (open-floor AoE == PR-2).
+                # The origin cell always has line of effect to itself and is retained.
                 blocking = {(int(bx), int(by)) for bx, by in (c.combat.grid_impassable or [])}
                 if blocking:
                     cells = {
                         cell for cell in cells
-                        if cell == aim or combat_grid.has_line_of_effect(aim, cell, blocking)
+                        if cell == loe_origin or combat_grid.has_line_of_effect(loe_origin, cell, blocking)
                     }
                 affected_tile_coords = sorted([cx, cy] for (cx, cy) in cells)
                 # Every combatant standing in the template is caught — SRD 5.2: a creature in

--- a/servers/engine/tests/test_grid_los.py
+++ b/servers/engine/tests/test_grid_los.py
@@ -194,6 +194,47 @@ def test_aoe_sphere_excludes_cells_with_no_line_of_effect(tmp_path, monkeypatch)
     assert (5, 5) in coords
 
 
+def test_aoe_cone_loe_traced_from_caster_not_aim(tmp_path, monkeypatch):
+    # A cone's point of origin is the CASTER — LoE must be traced from the caster's cell, not
+    # the aim cell. The DISTINGUISHING case: a wall sits BETWEEN caster (2,10) and the aim cell
+    # (4,10). A cone cell (5,10) beyond the aim would PASS an aim-origin ray ((4,10)->(5,10) is
+    # clear) but is unreachable from the CASTER (the (3,10) wall severs (2,10)->(5,10)). Only a
+    # caster-origin trace culls it; an aim-origin trace (the pre-fix bug) would leak it through.
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("cone-loe")["id"]
+    wiz = server.create_character(cid, "Wiz", kind="player", max_hp=30, armor_class=14)["id"]
+    server.update_character(cid, wiz, patch={"spell_slots": {"1": {"maximum": 4, "used": 0}}})
+    server.start_combat(cid, [wiz])
+    # Wall band BETWEEN the caster and the aim cell (one cell out from the caster).
+    server.set_grid(cid, 20, 20, obstacles=[[3, 9], [3, 10], [3, 11]])
+    server.place_combatant_at_coords(cid, wiz, 2, 10)
+    res = server.cast_spell(cid, wiz, "Burning Hands", slot_level=1, origin=[4, 10])
+    coords = {tuple(xy) for xy in (res.get("affected_tile_coords") or [])}
+    # A cone cell beyond the aim, clear from the AIM but shielded from the CASTER by the wall,
+    # is culled (caster-origin LoE). An aim-origin trace (the bug) would keep it.
+    assert (5, 10) not in coords
+    # Sanity (pure geometry, no walls): the same cone cell IS reachable — proves the cell is
+    # in-geometry, so its absence above is the LoE cull, not a geometry gap.
+    assert (5, 10) in combat_grid.cone_cells((2, 10), (4, 10), 15, 20, 20)
+
+
+def test_aoe_line_stops_at_a_blocker(tmp_path, monkeypatch):
+    # A Lightning Bolt line traced east from the caster stops at a wall — cells past the wall
+    # have no line of effect from the caster and drop out.
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("line-loe")["id"]
+    wiz = server.create_character(cid, "Wiz", kind="player", max_hp=30, armor_class=14)["id"]
+    server.update_character(cid, wiz, patch={"spell_slots": {"3": {"maximum": 4, "used": 0}}})
+    server.start_combat(cid, [wiz])
+    server.set_grid(cid, 40, 40, obstacles=[[5, 20]])
+    server.place_combatant_at_coords(cid, wiz, 2, 20)
+    res = server.cast_spell(cid, wiz, "Lightning Bolt", slot_level=3, origin=[3, 20])
+    coords = {tuple(xy) for xy in (res.get("affected_tile_coords") or [])}
+    assert (4, 20) in coords         # before the wall — clear line from the caster
+    assert (6, 20) not in coords     # past the wall — no LoE from the caster, culled
+    assert (10, 20) not in coords    # far past the wall — shielded, culled
+
+
 # ── (5) BYTE-IDENTICAL regression: off-grid / unplaced == today ──────────────
 
 

--- a/servers/engine/tests/test_grid_los.py
+++ b/servers/engine/tests/test_grid_los.py
@@ -1,0 +1,225 @@
+"""#1252 grid (PR-3) — line-of-sight ray traversal + SRD 5.2 cover, plus the
+server-side wiring (AoE line-of-effect cull in cast_spell + cover AC in attack()).
+
+ADDITIVE / opt-in: cover applies only on the grid with BOTH combatants placed; the
+line-of-effect cull runs only for a grid AoE cast. Off-grid / unplaced combat is
+BYTE-FOR-BYTE today's behaviour — the byte-identical regression test below is the
+load-bearing guard.
+
+The pure geometry lives in combat_grid (line_blockers / has_line_of_effect /
+cover_between / cover_ac_bonus); the wiring lives in server.attack + server.cast_spell.
+
+RAY / TIE-BREAK: supercover line between cell centres; a pure corner graze severs the
+ray only when BOTH shoulder cells of the diagonal step are blockers (permissive — a lone
+diagonal blocker is slipped past). COVER: 0 blockers -> none, 1 -> half (+2), 2+ ->
+three-quarters (+5), a fully-walled ray -> total (untargetable).
+"""
+
+import pytest
+
+import combat_grid
+import server
+
+
+# ── (1) LINE-OF-SIGHT ray: clear / blocked / corner-graze / adjacent ─────────
+
+
+def test_los_clear_open_floor():
+    # No blockers => always a clear line (additive: nothing culled off open floor).
+    assert combat_grid.has_line_of_effect((0, 0), (5, 5), set()) is True
+    assert combat_grid.line_blockers((0, 0), (5, 5), set()) == set()
+
+
+def test_los_blocked_by_wall_on_the_ray():
+    # A wall cell squarely on the horizontal ray severs it.
+    blocking = {(3, 0)}
+    assert combat_grid.has_line_of_effect((0, 0), (6, 0), blocking) is False
+    assert (3, 0) in combat_grid.line_blockers((0, 0), (6, 0), blocking)
+
+
+def test_los_endpoints_are_never_their_own_blockers():
+    # A target standing IN a blocking cell (a doorway/prop) is still reachable — the
+    # endpoints are excluded from the between-set.
+    blocking = {(0, 0), (6, 0)}
+    assert combat_grid.has_line_of_effect((0, 0), (6, 0), blocking) is True
+
+
+def test_los_adjacent_cells_have_no_interior():
+    # Adjacent (incl. diagonal) cells have nothing strictly between them.
+    assert combat_grid.line_blockers((2, 2), (3, 2), {(2, 2), (3, 2)}) == set()
+    assert combat_grid.has_line_of_effect((2, 2), (3, 3), {(9, 9)}) is True
+
+
+def test_los_corner_graze_single_diagonal_blocker_slips_past():
+    # Pure diagonal ray (0,0)->(4,4) passes through the vertices between shoulder pairs
+    # like {(1,0),(0,1)}. A SINGLE diagonal blocker at one shoulder must NOT sever it
+    # (permissive corner-graze tie-break).
+    assert combat_grid.has_line_of_effect((0, 0), (4, 4), {(1, 0)}) is True
+    assert combat_grid.has_line_of_effect((0, 0), (4, 4), {(2, 1)}) is True
+
+
+def test_los_corner_graze_both_shoulders_block():
+    # BOTH shoulders of a diagonal step are blockers => the corner is sealed, ray severed.
+    assert combat_grid.has_line_of_effect((0, 0), (4, 4), {(1, 0), (0, 1)}) is False
+
+
+def test_los_is_symmetric():
+    # a->b blocked iff b->a blocked (the ray model must be direction-independent).
+    blocking = {(2, 1), (1, 2)}
+    fwd = combat_grid.has_line_of_effect((0, 0), (3, 3), blocking)
+    rev = combat_grid.has_line_of_effect((3, 3), (0, 0), blocking)
+    assert fwd == rev
+
+
+# ── (2) COVER tiers + AC arithmetic ──────────────────────────────────────────
+
+
+def test_cover_none_clear_shot():
+    assert combat_grid.cover_between((0, 0), (6, 0), set()) == "none"
+    assert combat_grid.cover_ac_bonus("none") == 0
+
+
+def test_cover_half_one_intervening_blocker():
+    # A single low wall/pillar between attacker and target => half cover (+2).
+    blocking = {(3, 0)}
+    # Target one cell PAST the blocker so the interior isn't fully walled (=> not total).
+    assert combat_grid.cover_between((0, 0), (5, 0), blocking) == "half"
+    assert combat_grid.cover_ac_bonus("half") == 2
+
+
+def test_cover_three_quarters_two_intervening_blockers():
+    # Two separate blockers on the ray with an open cell between them => three-quarters (+5).
+    blocking = {(2, 0), (4, 0)}
+    assert combat_grid.cover_between((0, 0), (6, 0), blocking) == "three_quarters"
+    assert combat_grid.cover_ac_bonus("three_quarters") == 5
+
+
+def test_cover_total_when_ray_fully_walled():
+    # Every interior cell on the ray is a blocker (a solid wall band) => total cover.
+    blocking = {(1, 0), (2, 0), (3, 0)}
+    assert combat_grid.cover_between((0, 0), (4, 0), blocking) == "total"
+    assert combat_grid.cover_ac_bonus("total") == 0  # total isn't an AC bump
+
+
+def test_cover_open_floor_is_none():
+    assert combat_grid.cover_between((0, 0), (9, 9), set()) == "none"
+
+
+# ── (3) attack() applies cover AC when on-grid + both placed ─────────────────
+
+
+def _grid_fight_two_combatants(cover_wall):
+    """A 2-combatant grid fight: attacker at (0,0), target at (6,0), with `cover_wall`
+    the list of impassable [x,y] cells. Returns (campaign_id, attacker_id, target_id)."""
+    cid = server.create_campaign("los-test")["id"]
+    a = server.create_character(cid, "Archer", kind="player", max_hp=30, armor_class=14)["id"]
+    t = server.create_character(cid, "Goblin", kind="monster", max_hp=30, armor_class=14)["id"]
+    server.start_combat(cid, [a, t])
+    server.set_grid(cid, 20, 20, obstacles=cover_wall)
+    server.place_combatant_at_coords(cid, a, 0, 0)
+    server.place_combatant_at_coords(cid, t, 6, 0)
+    return cid, a, t
+
+
+def test_attack_half_cover_raises_target_ac_by_two():
+    cid, a, t = _grid_fight_two_combatants([[3, 0]])  # one wall between => half
+    base_ac = 14
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=3, damage_dice="1d6", is_ranged=True,
+    )
+    assert res.get("cover") is not None
+    assert res["cover"]["tier"] == "half"
+    assert res["cover"]["ac_bonus"] == 2
+    assert res["cover"]["effective_ac"] == base_ac + 2
+
+
+def test_attack_three_quarters_cover_raises_ac_by_five():
+    cid, a, t = _grid_fight_two_combatants([[2, 0], [4, 0]])  # two walls => three-quarters
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=0, damage_dice="1d6", is_ranged=True,
+    )
+    assert res["cover"]["tier"] == "three_quarters"
+    assert res["cover"]["ac_bonus"] == 5
+
+
+def test_attack_total_cover_refuses_the_shot():
+    cid, a, t = _grid_fight_two_combatants([[3, 0]])
+    # Put the target immediately behind a solid wall band so EVERY interior cell of the
+    # attacker->target ray is a blocker (fully-walled ray => total cover). attacker (0,0),
+    # target (4,0), walls (1,0),(2,0),(3,0) => interior [(1,0),(2,0),(3,0)] all blocked.
+    server.set_grid(cid, 20, 20, obstacles=[[1, 0], [2, 0], [3, 0]])
+    server.place_combatant_at_coords(cid, t, 4, 0)
+    with pytest.raises(ValueError, match="(?i)total cover"):
+        server.attack(
+            campaign_id=cid, attacker_id=a, target_id=t,
+            attack_bonus=0, damage_dice="1d6", is_ranged=True,
+        )
+
+
+def test_attack_no_cover_is_unchanged_when_clear():
+    cid, a, t = _grid_fight_two_combatants([])  # open floor
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=5, damage_dice="1d6", is_ranged=True,
+    )
+    # No blockers => no cover key surfaced (or tier "none"); AC unmodified.
+    assert res.get("cover") is None or res["cover"]["tier"] == "none"
+
+
+# ── (4) AoE line-of-effect exclusion (a wall shields cells behind it) ────────
+
+
+def test_aoe_sphere_excludes_cells_with_no_line_of_effect(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("aoe-loe")["id"]
+    caster = server.create_character(cid, "Mage", kind="player", max_hp=30, armor_class=14)["id"]
+    server.update_character(cid, caster, patch={"spell_slots": {
+        "3": {"maximum": 4, "used": 0}}})
+    behind = server.create_character(cid, "Hidden", kind="monster", max_hp=30, armor_class=12)["id"]
+    exposed = server.create_character(cid, "Exposed", kind="monster", max_hp=30, armor_class=12)["id"]
+    server.start_combat(cid, [caster, behind, exposed])
+    # A wall band shields (8,5) from a burst centred at (5,5); (5,7) is in the open.
+    server.set_grid(cid, 20, 20, obstacles=[[6, 5], [7, 5], [6, 4], [6, 6]])
+    server.place_combatant_at_coords(cid, caster, 5, 9)
+    server.place_combatant_at_coords(cid, behind, 8, 5)
+    server.place_combatant_at_coords(cid, exposed, 5, 7)
+    res = server.cast_spell(cid, caster, "Fireball", slot_level=3, origin=[5, 5])
+    coords = {tuple(xy) for xy in (res.get("affected_tile_coords") or [])}
+    # The exposed cell (in the burst, clear LoE) is affected; the shielded one is culled.
+    assert (5, 7) in coords
+    assert (8, 5) not in coords
+    # The origin cell always has line of effect to itself.
+    assert (5, 5) in coords
+
+
+# ── (5) BYTE-IDENTICAL regression: off-grid / unplaced == today ──────────────
+
+
+def test_offgrid_attack_has_no_cover_key():
+    cid = server.create_campaign("offgrid")["id"]
+    a = server.create_character(cid, "A", kind="player", max_hp=30, armor_class=14)["id"]
+    t = server.create_character(cid, "B", kind="monster", max_hp=30, armor_class=12)["id"]
+    server.start_combat(cid, [a, t])
+    # NO set_grid => zone/theater. Cover must never appear.
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=5, damage_dice="1d6", is_ranged=True,
+    )
+    assert "cover" not in res or res["cover"] is None
+
+
+def test_ongrid_but_unplaced_target_has_no_cover():
+    cid = server.create_campaign("unplaced")["id"]
+    a = server.create_character(cid, "A", kind="player", max_hp=30, armor_class=14)["id"]
+    t = server.create_character(cid, "B", kind="monster", max_hp=30, armor_class=12)["id"]
+    server.start_combat(cid, [a, t])
+    server.set_grid(cid, 20, 20, obstacles=[[3, 0]])
+    server.place_combatant_at_coords(cid, a, 0, 0)
+    # target NOT placed => cover can't be derived => no cover key.
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=5, damage_dice="1d6", is_ranged=True,
+    )
+    assert res.get("cover") is None


### PR DESCRIPTION
## grid-461 PR-3 — cover + line-of-sight

Closes #1252. Part of #1100 (combat epic).

Adds terrain-aware **line-of-sight** and **SRD 5.2 cover** to the combat grid, building directly on the just-merged #1257 AoE templates. Additive / opt-in: cover applies **only** when `grid_enabled` and both combatants are placed; off-grid / unplaced combat is byte-for-byte today's behaviour.

### Pure geometry (`combat_grid.py`)
- **`_supercover_cells` / `line_blockers`** — cell→cell supercover ray between cell centres over the grid's blocking (`grid_impassable`) cells; endpoints excluded.
- **Corner-graze tie-break (documented):** a pure diagonal graze severs the ray **only when BOTH shoulder cells** of the diagonal step are blockers. A lone diagonal blocker (or a blocker touched only at its corner) is slipped past. This is the standard permissive supercover rule and keeps LoS **symmetric** (a→b blocked ⟺ b→a blocked) and additive.
- **`has_line_of_effect`** — True iff the ray crosses no blocker.
- **`cover_between` / `cover_ac_bonus`** — cover tier from the count of intervening blockers:
  - 0 → `none`
  - 1 → `half` (+2 AC / +2 DEX saves)
  - ≥2 → `three_quarters` (+5 AC / +5 DEX saves)
  - fully-walled ray (every interior cell a blocker) → `total` (untargetable)

### Wiring (`server.py`, additive / default-off)
- **`cast_spell`** — culls AoE cells with **no line of effect** from the template origin (the deferred #1257 `TODO(#1252)`). A wall shields cells behind it from a sphere; the origin cell always has LoE to itself.
- **`attack`** — when `grid_enabled` AND both combatants placed: folds cover into the target AC (`half`/`three_quarters`), **refuses a `total`-cover shot up front** (before the roll, no state change), and surfaces a `cover` result key (`tier` / `ac_bonus` / `effective_ac`).

### Invariants held
- Engine sole-writer; gates read engine values only.
- **No new tool params** — cover derives from existing state and is surfaced in the (free) result payload. **Tool-schema byte delta: 0.**
- Off-grid or unplaced ⇒ byte-identical to today (regression tests assert no `cover` key).

### Tests
- New `tests/test_grid_los.py` (19 cases): LoS ray (clear / blocked / corner-graze both-shoulder / lone-diagonal-slip / adjacent / symmetric), cover tiers + AC arithmetic + total-cover refusal, AoE line-of-effect exclusion (wall shields a cell behind it from a sphere), byte-identical regression (off-grid + on-grid-unplaced).
- `qa/fast_gate.sh`: PASS (241). Full engine suite: **3299 passed**. Existing grid/AoE suites: 58 passed, no regression.

Scope held to PR-3: **no** terrain effects, **no** unit size (#1253), **no** flanking (#1254).