### PR TITLE
feat(engine): grid-461 PR-4/5 — difficult terrain + creature size/reach (#1253)

### DIFF
--- a/servers/engine/combat_grid.py
+++ b/servers/engine/combat_grid.py
@@ -6,14 +6,48 @@ persistence and surface their results. ADDITIVE: nothing here runs unless a figh
 flips Combat.grid_enabled (set_grid); zone/theater combat never touches this module.
 
 PR-1 SCOPE is the movement spine only: Chebyshev distance, a speed→cells budget, an
-open-floor reachability flood, and a reach-leave opportunity-attack predicate. AoE,
-cover, line-of-sight, terrain, creature size/reach, and ranged-range gating are all
-DEFERRED to later PRs — every combatant here is a single 1-cell, 5ft-reach token.
+open-floor reachability flood, and a reach-leave opportunity-attack predicate. AoE
+(#1257), cover / line-of-sight (#1261), difficult terrain + creature size/reach (#1253)
+land in later PRs; ranged-range gating is still DEFERRED. The PR-1 helpers stay valid
+for the default case — a single 1-cell, 5ft-reach token on open floor.
 """
 
 from __future__ import annotations
 
 Cell = tuple[int, int]
+
+# ── #1253 / PR-5: creature SIZE → grid footprint ─────────────────────────────────
+# SRD 5.2 space: Tiny/Small/Medium occupy a 5ft square (1 cell); Large a 10ft square
+# (2×2 cells), Huge a 15ft square (3×3), Gargantuan a 20ft+ square (4×4). The engine
+# models a token by its side length in CELLS (`footprint_cells`). The stored (x, y) is
+# the token's anchor = its MIN-corner cell; the footprint spans [x, x+n) × [y, y+n).
+# ADDITIVE: an unknown / absent / Medium size => 1 cell => PR-1 behaviour byte-for-byte.
+_SIZE_CELLS = {
+    "tiny": 1, "small": 1, "medium": 1,
+    "large": 2, "huge": 3, "gargantuan": 4,
+}
+
+
+def footprint_cells(size: str) -> int:
+    """The side length in CELLS of a creature of the given SRD size category (default 1
+    for Medium/Small/Tiny, 2 for Large, 3 for Huge, 4 for Gargantuan). Case-insensitive;
+    an unknown or empty size falls back to 1 cell (Medium) — the PR-1 default."""
+    return _SIZE_CELLS.get((size or "").strip().lower(), 1)
+
+
+def footprint(anchor: Cell, size: str) -> set[Cell]:
+    """The set of cells a token of the given `size` occupies, anchored at `anchor` (its
+    MIN-corner cell). Medium (1 cell) => just {anchor}; Large => a 2×2 block, etc. Pure;
+    not clipped to the grid (the caller flags out-of-bounds like a 1-cell placement)."""
+    n = footprint_cells(size)
+    ax, ay = anchor
+    return {(ax + i, ay + j) for i in range(n) for j in range(n)}
+
+
+def footprints_overlap(a_anchor: Cell, a_size: str, b_anchor: Cell, b_size: str) -> bool:
+    """True if two tokens' footprints share any cell (a placement/movement collision).
+    For two Medium tokens this reduces to `a_anchor == b_anchor` (PR-1 occupancy)."""
+    return bool(footprint(a_anchor, a_size) & footprint(b_anchor, b_size))
 
 
 def chebyshev_cells(a: Cell, b: Cell) -> int:
@@ -39,9 +73,38 @@ def distance_ft(a: Cell, b: Cell, cell_size: int = 5) -> int:
 
 def in_melee_reach(a: Cell, b: Cell) -> bool:
     """True if two cells are within 5ft melee reach: Chebyshev distance <= 1 (the same
-    cell or any of the 8 neighbours). PR-1 has no creature-size/reach model — every
-    token is 1 cell with 5ft reach."""
+    cell or any of the 8 neighbours). This is the 1-cell (Medium) reach test; for larger
+    tokens use `footprint_distance_cells` / `in_melee_reach_sized` which measure from the
+    FOOTPRINT EDGE."""
     return chebyshev_cells(a, b) <= 1
+
+
+def footprint_distance_cells(
+    a_anchor: Cell, a_size: str, b_anchor: Cell, b_size: str
+) -> int:
+    """Chebyshev distance in CELLS between the two tokens' FOOTPRINT EDGES — the minimum
+    Chebyshev distance over every pair of (a-cell, b-cell) in the two footprints. For two
+    Medium (1-cell) tokens this is exactly `chebyshev_cells(a_anchor, b_anchor)` (PR-1),
+    so it's additive. Overlapping footprints => 0. This is how a Large+ creature reaches
+    an adjacent target from its NEAREST occupied cell, not its anchor."""
+    an, bn = footprint_cells(a_size), footprint_cells(b_size)
+    if an == 1 and bn == 1:
+        return chebyshev_cells(a_anchor, b_anchor)
+    (ax, ay), (bx, by) = a_anchor, b_anchor
+    # Per-axis edge gap between the two [anchor, anchor+n-1] cell intervals; a negative
+    # gap (overlap) clamps to 0. Chebyshev distance is the larger of the two axis gaps.
+    dx = max(bx - (ax + an - 1), ax - (bx + bn - 1), 0)
+    dy = max(by - (ay + an - 1), ay - (by + bn - 1), 0)
+    return max(dx, dy)
+
+
+def in_melee_reach_sized(
+    a_anchor: Cell, a_size: str, b_anchor: Cell, b_size: str, reach_cells: int = 1
+) -> bool:
+    """True if a token at `a_anchor` (size `a_size`) can melee-reach a token at `b_anchor`
+    (size `b_size`) — footprint-edge Chebyshev distance <= `reach_cells` (default 1 = 5ft).
+    Additive: two Medium tokens with the default reach reduce to `in_melee_reach`."""
+    return footprint_distance_cells(a_anchor, a_size, b_anchor, b_size) <= reach_cells
 
 
 def movement_budget_cells(speed: int, cell_size: int = 5, dashed: bool = False) -> int:
@@ -60,47 +123,50 @@ def reachable(
     width: int,
     height: int,
     impassable: set[Cell] = frozenset(),
+    difficult: set[Cell] = frozenset(),
 ) -> set[Cell]:
-    """Open-floor reachability: every in-bounds cell reachable from `start` within
-    `budget_cells` of movement, flooding over the 8-neighbourhood at a flat cost of 1
-    cell per step (Chebyshev movement). A move may PASS THROUGH nothing-blocks (PR-1
-    has no terrain) but may NOT END on an occupied cell, so `occupied` cells are
-    dropped from the result (and the start itself is excluded — you stay put for free,
-    it's not a "move to"). PR-1: flat cost, no terrain, no size.
+    """Reachability: every in-bounds cell reachable from `start` within `budget_cells`
+    of movement over the 8-neighbourhood. Each step costs 1 cell, DOUBLED (2) when the
+    step ENTERS a `difficult` cell (SRD 5.2 difficult terrain). A move may NOT END on
+    an occupied cell, so `occupied` cells are dropped from the result (and the start
+    itself is excluded — you stay put for free, it's not a "move to").
 
-    `occupied` should NOT include `start` (the mover doesn't block itself). Returns a
-    set of (x, y) cells. Pure Dijkstra/BFS over uniform cost; deterministic.
+    `occupied` should NOT include `start` (the mover doesn't block itself). `difficult`
+    empty (no terrain) => flat cost 1 (PR-1 behaviour, byte-for-byte). Returns a set of
+    (x, y) cells. Pure Dijkstra over per-step cost; deterministic.
     """
     if budget_cells <= 0:
         return set()
-    # BFS by ring: uniform cost 1 means a plain breadth-first expansion gives the
-    # minimal step count to each cell. Occupied cells can't be entered at all (PR-1
-    # treats a creature's cell as impassable — no moving through allies in this PR).
+    import heapq
+
+    # Dijkstra: costs are 1 or 2, so a priority queue gives the minimal-cost distance to
+    # each cell. Occupied/impassable cells can't be entered (a creature/wall blocks). The
+    # cost to ENTER a difficult cell is 2; open cells cost 1.
     dist: dict[Cell, int] = {start: 0}
-    frontier = [start]
-    while frontier:
-        nxt: list[Cell] = []
-        for (cx, cy) in frontier:
-            d = dist[(cx, cy)]
-            if d >= budget_cells:
-                continue
-            for dx in (-1, 0, 1):
-                for dy in (-1, 0, 1):
-                    if dx == 0 and dy == 0:
-                        continue
-                    nx, ny = cx + dx, cy + dy
-                    if not (0 <= nx < width and 0 <= ny < height):
-                        continue
-                    cell = (nx, ny)
-                    if cell in occupied:
-                        continue  # can't enter (and so can't pass through) a token
-                    if cell in impassable:
-                        continue  # terrain/wall/prop — can't enter or pass through (P1)
-                    if cell in dist:
-                        continue
-                    dist[cell] = d + 1
-                    nxt.append(cell)
-        frontier = nxt
+    pq: list[tuple[int, Cell]] = [(0, start)]
+    while pq:
+        d, (cx, cy) = heapq.heappop(pq)
+        if d > dist.get((cx, cy), d) or d >= budget_cells:
+            continue
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                if dx == 0 and dy == 0:
+                    continue
+                nx, ny = cx + dx, cy + dy
+                if not (0 <= nx < width and 0 <= ny < height):
+                    continue
+                cell = (nx, ny)
+                if cell in occupied:
+                    continue  # can't enter (and so can't pass through) a token
+                if cell in impassable:
+                    continue  # terrain/wall/prop — can't enter or pass through
+                step = 2 if cell in difficult else 1
+                nd = d + step
+                if nd > budget_cells:
+                    continue
+                if nd < dist.get(cell, nd + 1):
+                    dist[cell] = nd
+                    heapq.heappush(pq, (nd, cell))
     # Exclude the start cell (it's where you already are, not a destination).
     return {c for c in dist if c != start}
 
@@ -112,29 +178,37 @@ def shortest_path(
     width: int,
     height: int,
     impassable: set[Cell] = frozenset(),
+    difficult: set[Cell] = frozenset(),
 ) -> list[Cell] | None:
-    """P1: BFS shortest route from `start` to `goal` over the 8-neighbourhood, routing
-    AROUND cells that cannot be entered (`occupied` tokens + `impassable` terrain/walls/
-    props). Returns the list of step cells EXCLUDING `start` (so `path_cost_cells` sums its
-    Chebyshev hops = the routed distance), `[]` if already at the goal, or None if the goal
-    is itself blocked / out of bounds / unreachable without crossing a blocked cell. Uniform
-    cost 1/step; deterministic (neighbour order fixed). On OPEN floor this returns a straight
-    diagonal whose cost equals the old straight-line Chebyshev — so behaviour is unchanged
-    when there are no obstacles (additive)."""
+    """Cheapest route from `start` to `goal` over the 8-neighbourhood, routing AROUND
+    cells that cannot be entered (`occupied` tokens + `impassable` terrain/walls/props)
+    and preferring cheaper ground: each step costs 1, DOUBLED (2) to ENTER a `difficult`
+    cell. Returns the list of step cells EXCLUDING `start` (so `path_cost_cells` re-derives
+    the routed cost), `[]` if already at the goal, or None if the goal is itself blocked /
+    out of bounds / unreachable without crossing a blocked cell. Deterministic (a fixed
+    tie-break on equal-cost cells via the neighbour order). On OPEN floor with no difficult
+    terrain this returns a straight diagonal whose cost equals the straight-line Chebyshev —
+    behaviour is unchanged when there are no obstacles/terrain (additive)."""
     if start == goal:
         return []
     if not (0 <= goal[0] < width and 0 <= goal[1] < height):
         return None
     if goal in occupied or goal in impassable:
         return None
-    from collections import deque
+    import heapq
 
+    # Dijkstra over per-step cost (1, or 2 into difficult terrain). `seq` is a monotonic
+    # counter making the heap ordering total + deterministic when two cells tie on cost.
     prev: dict[Cell, Cell] = {start: start}
-    q: deque[Cell] = deque([start])
-    while q:
-        cur = q.popleft()
+    dist: dict[Cell, int] = {start: 0}
+    seq = 0
+    pq: list[tuple[int, int, Cell]] = [(0, 0, start)]
+    while pq:
+        d, _, cur = heapq.heappop(pq)
         if cur == goal:
             break
+        if d > dist.get(cur, d):
+            continue
         cx, cy = cur
         for dx in (-1, 0, 1):
             for dy in (-1, 0, 1):
@@ -144,10 +218,14 @@ def shortest_path(
                 if not (0 <= nx < width and 0 <= ny < height):
                     continue
                 cell = (nx, ny)
-                if cell in prev or cell in occupied or cell in impassable:
+                if cell in occupied or cell in impassable:
                     continue
-                prev[cell] = cur
-                q.append(cell)
+                nd = d + (2 if cell in difficult else 1)
+                if nd < dist.get(cell, nd + 1):
+                    dist[cell] = nd
+                    prev[cell] = cur
+                    seq += 1
+                    heapq.heappush(pq, (nd, seq, cell))
     if goal not in prev:
         return None
     route: list[Cell] = []
@@ -159,21 +237,37 @@ def shortest_path(
     return route
 
 
-def path_cost_cells(from_cell: Cell, to_cell: Cell, path: list[Cell] | None = None) -> int:
+def path_cost_cells(
+    from_cell: Cell,
+    to_cell: Cell,
+    path: list[Cell] | None = None,
+    difficult: set[Cell] = frozenset(),
+) -> int:
     """Measured movement cost in CELLS from `from_cell` to `to_cell`.
 
     If an explicit `path` (a list of waypoint cells the mover steps through, EXCLUDING
     the start) is given, the cost is the sum of the Chebyshev step between consecutive
-    cells (so a hand-routed path around an obstacle costs what it walked). With no path,
-    PR-1 assumes open floor and charges the straight-line Chebyshev distance (the
-    minimal open-floor cost). Pure; no occupancy check (the caller flags illegal ends).
-    """
+    cells, with each STEP DOUBLED when it enters a `difficult` cell (SRD 5.2). With no
+    path, open floor is assumed and the straight-line Chebyshev is charged — then, if any
+    intervening cell of that straight diagonal is difficult, those entries are surcharged
+    too (so a straight walk across difficult terrain still costs double per difficult cell).
+    `difficult` empty => the plain Chebyshev cost (PR-1 behaviour, byte-for-byte). Pure; no
+    occupancy check (the caller flags illegal ends)."""
     if not path:
-        return chebyshev_cells(from_cell, to_cell)
+        base = chebyshev_cells(from_cell, to_cell)
+        if not difficult:
+            return base
+        # Surcharge each difficult cell the straight diagonal ENTERS (endpoints handled:
+        # the start is never "entered"; the destination is if it's difficult).
+        entered = _supercover_cells(from_cell, to_cell)[1:]  # drop the start
+        return base + sum(1 for cell in entered if cell in difficult)
     total = 0
     prev = from_cell
     for step in path:
-        total += chebyshev_cells(prev, step)
+        hop = chebyshev_cells(prev, step)
+        total += hop
+        if difficult and step in difficult:
+            total += 1  # entering a difficult cell costs double (one extra per entry)
         prev = step
     return total
 
@@ -469,7 +563,14 @@ def cover_between(a: Cell, b: Cell, blocking: set[Cell]) -> str:
     blocking) AND every interior cell on the ray is a blocker with no open shoulder — i.e.
     there is genuinely no gap. In practice, one blocker => half, two => three-quarters, and
     a fully-walled ray (a solid line of blockers with no threadable corner) => total. Open
-    floor (`blocking` empty) or `a == b` => "none" (additive: no cover off the grid)."""
+    floor (`blocking` empty) or `a == b` => "none" (additive: no cover off the grid).
+
+    SIZE NOTE (#1253/#1255): this is a SINGLE anchor-to-anchor ray. SRD "trace to a corner"
+    for a Large+ token would trace from each of the attacker's / target's footprint corners
+    and take the BEST (least-obstructed) line; the design doc does not require corner-tracing
+    for big tokens, so PR-5 keeps the single-ray approximation. A large token whose anchor
+    ray is walled may report more cover than a corner trace would — DEFERRED to #1255 (AI/
+    tactics), which can consume the footprint corners if it needs the finer tier."""
     if not blocking or a == b:
         return "none"
     blockers = line_blockers(a, b, blocking)

--- a/servers/engine/models.py
+++ b/servers/engine/models.py
@@ -1383,6 +1383,12 @@ class Combatant(_StrictModel):
     # #461 grid (PR-1): took the Dash action this turn (doubles the movement budget).
     # Per-turn; reset with moved_cells_this_turn. Set via use_action(kind="dash").
     dashed: bool = False
+    # #461 grid (#1253/PR-5): SRD size category → grid FOOTPRINT. "medium" (default; also
+    # tiny/small) = a 1-cell token == PR-1 behaviour byte-for-byte. "large" = 2×2, "huge" =
+    # 3×3, "gargantuan" = 4×4, anchored at (x, y) (the MIN-corner cell). Drives occupancy
+    # for placement/movement and footprint-edge melee reach. Additive: old snapshots (and
+    # any all-Medium fight) deserialize with "medium" and behave identically.
+    size: str = "medium"
 
     @model_validator(mode="after")
     def _grid_coords_paired(self) -> "Combatant":
@@ -1456,6 +1462,12 @@ class Combat(_StrictModel):
     # open floor (PR-1 behaviour, byte-for-byte unchanged). `last_move_path` is the most-recent
     # routed path (incl. the from-cell) for the renderer to draw the detour — presentation only.
     grid_impassable: list[list[int]] = Field(default_factory=list)
+    # #461 grid (#1253/PR-4): DIFFICULT-TERRAIN cells (mud/rubble/undergrowth) — each costs
+    # DOUBLE movement to ENTER (SRD 5.2). Additive field, mirrors grid_impassable exactly;
+    # empty == open floor (PR-1 movement cost byte-for-byte unchanged). DM-set via set_grid
+    # (`difficult` arg). Distinct from grid_impassable: difficult cells are ENTERABLE (just
+    # costly); impassable cells are routed around entirely.
+    grid_difficult: list[list[int]] = Field(default_factory=list)
     last_move_path: list[list[int]] = Field(default_factory=list)
 
     @property

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -423,6 +423,12 @@ def _combat_view(c: Campaign) -> dict:
         if c.combat.grid_enabled and cb.x is not None and cb.y is not None:
             entry["x"] = cb.x
             entry["y"] = cb.y
+            # #1253: surface a >1-cell footprint side length only for Large+ tokens, so the
+            # renderer can draw the NxN token. Medium omits the key (byte-for-byte PR-1).
+            span = combat_grid.footprint_cells(_size(cb))
+            if span > 1:
+                entry["size"] = _size(cb)
+                entry["footprint"] = span
         order.append(entry)
     view = {
         "active": c.combat.active,
@@ -4370,31 +4376,72 @@ def _can_see(viewer: "Character") -> bool:
 
 
 def _cell(cb: "Combatant") -> tuple[int, int] | None:
-    """The (x, y) cell of a combatant, or None if it isn't placed on the grid."""
+    """The (x, y) anchor cell of a combatant, or None if it isn't placed on the grid."""
     if cb.x is None or cb.y is None:
         return None
     return (cb.x, cb.y)
 
 
+def _size(cb: "Combatant") -> str:
+    """A combatant's SRD size category (#1253). Defaults to "medium" (1-cell) for any
+    combatant / old snapshot without the field — the PR-1 behaviour byte-for-byte."""
+    return getattr(cb, "size", "medium") or "medium"
+
+
+def _footprint(cb: "Combatant") -> set[tuple[int, int]]:
+    """The set of cells a placed combatant OCCUPIES (its size footprint anchored at its
+    (x, y)), or an empty set if unplaced. Medium => a single {(x, y)} == PR-1 occupancy."""
+    anchor = _cell(cb)
+    if anchor is None:
+        return set()
+    return combat_grid.footprint(anchor, _size(cb))
+
+
+def _occupied_cells(c: "Campaign", exclude_id: str = "") -> set[tuple[int, int]]:
+    """Every grid cell occupied by a placed combatant's FOOTPRINT, excluding `exclude_id`
+    (the mover, who doesn't block itself). Medium tokens contribute their single cell —
+    byte-for-byte the PR-1 `{(o.x, o.y)}` set when all tokens are Medium."""
+    cells: set[tuple[int, int]] = set()
+    for o in c.combat.order:
+        if o.character_id == exclude_id:
+            continue
+        cells |= _footprint(o)
+    return cells
+
+
+def _difficult_set(c: "Campaign") -> set[tuple[int, int]]:
+    """The fight's DIFFICULT-TERRAIN cells (#1253) as a cell set. Empty == open floor
+    (PR-1 movement cost unchanged)."""
+    return {(int(dx), int(dy)) for dx, dy in (c.combat.grid_difficult or [])}
+
+
+def _coerce_cell_pairs(raw, label: str) -> list[list[int]]:
+    """Coerce a tool arg into a list of [x, y] int cell pairs (shared by set_grid's
+    `obstacles`/`difficult`). Raises on a malformed pair."""
+    out: list[list[int]] = []
+    for cellv in _coerce_list(raw):
+        if not isinstance(cellv, (list, tuple)) or len(cellv) != 2:
+            raise ValueError(f"set_grid {label} must be a list of [x, y] cell pairs")
+        out.append([int(cellv[0]), int(cellv[1])])
+    return out
+
+
 @mcp.tool()
 def set_grid(campaign_id: str, width: int, height: int, cell_size: int = 5,
-             diagonal_mode: str = "chebyshev", obstacles: ListArg = None) -> dict:
-    """#461 / P1: switch this fight to a coordinate grid (the only tool that sets grid mode).
+             diagonal_mode: str = "chebyshev", obstacles: ListArg = None,
+             difficult: ListArg = None) -> dict:
+    """#461: switch this fight to a coordinate grid (the only tool that sets grid mode).
     Optional; without it combat stays zone/theater. Sets extents (cells; cell_size ft);
-    idempotent; needs width/height>0. P1: `obstacles` is a list of [x,y] IMPASSABLE cells
-    (walls/props) that move_to_coords routes AROUND; omit == leave obstacles unchanged,
-    [] == clear them (open floor, PR-1 behaviour byte-for-byte unchanged)."""
+    idempotent; needs width/height>0. `obstacles` = [x,y] IMPASSABLE cells (walls/props)
+    move_to_coords routes AROUND; `difficult` (#1253) = [x,y] DIFFICULT-TERRAIN cells that
+    are enterable but cost DOUBLE movement. For each: omit == leave unchanged, [] == clear
+    (open floor, byte-for-byte unchanged)."""
     if width <= 0 or height <= 0:
         raise ValueError("set_grid needs width > 0 and height > 0")
     if diagonal_mode not in ("chebyshev", "five_ten_five"):
         raise ValueError("diagonal_mode must be 'chebyshev' or 'five_ten_five'")
-    imp: list[list[int]] | None = None
-    if obstacles is not None:
-        imp = []
-        for cellv in _coerce_list(obstacles):
-            if not isinstance(cellv, (list, tuple)) or len(cellv) != 2:
-                raise ValueError("set_grid obstacles must be a list of [x, y] cell pairs")
-            imp.append([int(cellv[0]), int(cellv[1])])
+    imp = _coerce_cell_pairs(obstacles, "obstacles") if obstacles is not None else None
+    dif = _coerce_cell_pairs(difficult, "difficult") if difficult is not None else None
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         c.combat.grid_enabled = True
@@ -4404,17 +4451,26 @@ def set_grid(campaign_id: str, width: int, height: int, cell_size: int = 5,
         c.combat.diagonal_mode = diagonal_mode  # type: ignore[assignment]
         if imp is not None:
             c.combat.grid_impassable = imp
+        if dif is not None:
+            c.combat.grid_difficult = dif
         save_campaign(c)
         return _combat_view(c)
 
 
 @mcp.tool()
-def place_combatant_at_coords(campaign_id: str, combatant_id: str, x: int, y: int) -> dict:
-    """#461: set a combatant's (x,y) cell — setup, NO opportunity-attack check (use
+def place_combatant_at_coords(campaign_id: str, combatant_id: str, x: int, y: int,
+                              size: str = "") -> dict:
+    """#461: set a combatant's (x,y) ANCHOR cell — setup, NO opportunity-attack check (use
     move_to_coords in combat). Needs set_grid first. Warns (never blocks) if out of
-    bounds/occupied."""
+    bounds/occupied. #1253: optional `size` (tiny/small/medium/large/huge/gargantuan) sets
+    the token's FOOTPRINT — Large=2×2, Huge=3×3, Gargantuan=4×4 anchored at (x,y); omit ==
+    keep the current size (default medium = a 1-cell token)."""
     if not combatant_id:
         raise ValueError("place_combatant_at_coords needs a combatant_id")
+    if size and size.strip().lower() not in combat_grid._SIZE_CELLS:
+        raise ValueError(
+            "size must be one of tiny/small/medium/large/huge/gargantuan (or omitted)"
+        )
     with campaign_lock(campaign_id):
         c = _require(campaign_id)
         if not c.combat.active:
@@ -4422,14 +4478,22 @@ def place_combatant_at_coords(campaign_id: str, combatant_id: str, x: int, y: in
         if not c.combat.grid_enabled:
             raise ValueError("this fight is not on a grid — call set_grid first (or use place_combatant for zones)")
         cb = _combatant(c, combatant_id)
+        if size:
+            cb.size = size.strip().lower()
         ch = c.characters.get(combatant_id)
         warnings: list[str] = []
-        if not (0 <= x < c.combat.grid_width and 0 <= y < c.combat.grid_height):
+        # #1253: a Large+ token occupies an NxN footprint anchored at (x, y), so bounds and
+        # occupancy check the WHOLE footprint. Medium (1-cell) reduces to the PR-1 checks.
+        my_fp = combat_grid.footprint((x, y), _size(cb))
+        span = combat_grid.footprint_cells(_size(cb))
+        if not (0 <= x and x + span <= c.combat.grid_width and 0 <= y and y + span <= c.combat.grid_height):
+            extent = f"{x}..{x + span - 1}, {y}..{y + span - 1}" if span > 1 else f"{x}, {y}"
             warnings.append(
-                f"({x}, {y}) is out of the {c.combat.grid_width}x{c.combat.grid_height} grid — placed anyway."
+                f"({extent}) is out of the {c.combat.grid_width}x{c.combat.grid_height} grid — placed anyway."
             )
         occupant = next(
-            (o for o in c.combat.order if o.character_id != combatant_id and (o.x, o.y) == (x, y)),
+            (o for o in c.combat.order
+             if o.character_id != combatant_id and (my_fp & _footprint(o))),
             None,
         )
         if occupant is not None:
@@ -4469,26 +4533,28 @@ def move_to_coords(campaign_id: str, combatant_id: str, x: int, y: int,
         mover = c.characters.get(combatant_id)
         from_cell = _cell(cb)
         cell_size = c.combat.grid_cell_size
+        mover_span = combat_grid.footprint_cells(_size(cb))
         warnings: list[str] = []
-        if not (0 <= x < c.combat.grid_width and 0 <= y < c.combat.grid_height):
+        if not (0 <= x and x + mover_span <= c.combat.grid_width
+                and 0 <= y and y + mover_span <= c.combat.grid_height):
             warnings.append(
                 f"({x}, {y}) is out of the {c.combat.grid_width}x{c.combat.grid_height} grid — moved anyway."
             )
 
         to_cell = (x, y)
-        # P1: route AROUND impassable terrain (walls/props) + other tokens. impassable/occupied
-        # empty == open floor (PR-1 behaviour byte-for-byte unchanged: straight-line Chebyshev).
+        # P1: route AROUND impassable terrain (walls/props) + other tokens; #1253: charge
+        # DOUBLE to enter difficult-terrain cells. impassable/occupied/difficult empty ==
+        # open floor (PR-1 behaviour byte-for-byte unchanged: straight-line Chebyshev).
         impassable = {(int(ix), int(iy)) for ix, iy in (c.combat.grid_impassable or [])}
-        occupied = {
-            (o.x, o.y) for o in c.combat.order
-            if o.character_id != combatant_id and o.x is not None and o.y is not None
-        }
+        occupied = _occupied_cells(c, exclude_id=combatant_id)
+        difficult = _difficult_set(c)
         if from_cell is None:
             cost = 0  # an unplaced combatant: this is effectively a placement, no cost
         else:
-            if path_cells is None and (impassable or occupied):
+            if path_cells is None and (impassable or occupied or difficult):
                 routed = combat_grid.shortest_path(
-                    from_cell, to_cell, occupied, c.combat.grid_width, c.combat.grid_height, impassable
+                    from_cell, to_cell, occupied, c.combat.grid_width, c.combat.grid_height,
+                    impassable, difficult,
                 )
                 if routed is None:
                     # P1: never walk onto/through a wall/prop (or into an occupied cell) — reject, stay put.
@@ -4507,7 +4573,13 @@ def move_to_coords(campaign_id: str, combatant_id: str, x: int, y: int,
                     return view
                 if routed:
                     path_cells = routed  # charge + draw the routed detour
-            cost = combat_grid.path_cost_cells(from_cell, to_cell, path_cells)
+            cost = combat_grid.path_cost_cells(from_cell, to_cell, path_cells, difficult)
+        # #1253: which difficult-terrain cells the move ENTERED (surfaced for the DM so the
+        # doubled cost is legible). The straight-diagonal step cells when no explicit path.
+        difficult_crossed: list[list[int]] = []
+        if from_cell is not None and difficult:
+            entered = path_cells if path_cells else combat_grid._supercover_cells(from_cell, to_cell)[1:]
+            difficult_crossed = [[int(sx), int(sy)] for (sx, sy) in entered if (sx, sy) in difficult]
         prior_used = cb.moved_cells_this_turn
         dashed = bool(dash) or bool(cb.dashed)
         budget = combat_grid.movement_budget_cells(mover.speed, cell_size, dashed) if mover else 0
@@ -4596,6 +4668,7 @@ def move_to_coords(campaign_id: str, combatant_id: str, x: int, y: int,
                 "provokers": provokers,
                 "disengaged": disengaged,
                 "movement_illegal": movement_illegal,
+                "difficult_crossed": difficult_crossed,
                 "warnings": list(warnings),
             },
             speaker=mover.name if mover else "",
@@ -4609,6 +4682,8 @@ def move_to_coords(campaign_id: str, combatant_id: str, x: int, y: int,
     view["opportunity_attack"] = bool(provokers)
     view["provokers"] = provokers
     view["warnings"] = warnings
+    if difficult_crossed:  # #1253: only when difficult terrain was actually entered
+        view["difficult_crossed"] = difficult_crossed
     if disengaged:
         view["disengaged"] = True
     if movement_illegal is not None:
@@ -5648,6 +5723,7 @@ def attack(
             acb = next((cb for cb in c.combat.order if cb.character_id == attacker_id), None)
             shooter_cell = _cell(acb) if acb is not None else None
             if shooter_cell is not None:
+                shooter_size = _size(acb)
                 ally_kinds = {"player", "companion"}
                 shooter_ally = attacker.kind in ally_kinds
                 for foe_cb in c.combat.order:
@@ -5661,8 +5737,11 @@ def attack(
                     foe_cell = _cell(foe_cb)
                     if foe_cell is None:
                         continue  # an unplaced foe threatens no cell
-                    if not combat_grid.in_melee_reach(shooter_cell, foe_cell):
-                        continue  # not within 5 ft (1 cell)
+                    # #1253: footprint-edge reach — a Large foe threatens from any of its cells.
+                    if not combat_grid.in_melee_reach_sized(
+                        shooter_cell, shooter_size, foe_cell, _size(foe_cb)
+                    ):
+                        continue  # not within 5 ft (1 cell edge-to-edge)
                     if combat.is_incapacitated(foe):
                         continue  # SRD: the enemy must NOT be Incapacitated
                     if not _can_see(foe):
@@ -5873,7 +5952,13 @@ def attack(
             ac = _cell(acb) if acb else None
             tc = _cell(tcb) if tcb else None
             if ac is not None and tc is not None:
-                feet = combat_grid.distance_ft(ac, tc, c.combat.grid_cell_size)
+                # #1253: measure FOOTPRINT-EDGE to footprint-edge so a Large attacker/target
+                # reaches from its nearest cell (a 2×2 ogre melees an adjacent target that is
+                # 2 anchor-cells away). Medium vs Medium == the PR-1 anchor Chebyshev.
+                edge_cells = combat_grid.footprint_distance_cells(
+                    ac, _size(acb), tc, _size(tcb)
+                )
+                feet = combat_grid.range_ft(edge_cells, c.combat.grid_cell_size)
                 if feet > 5:
                     result["range_warning"] = (
                         f"{attacker.name} at {ac} is {feet} ft from {target.name} at {tc} — "
@@ -7633,7 +7718,9 @@ def cast_spell(
                 for cb in c.combat.order:
                     if cb.x is None or cb.y is None:
                         continue
-                    if (cb.x, cb.y) in cells:
+                    # #1253: a Large+ token is caught if ANY of its footprint cells lies in
+                    # the template. Medium (1-cell) reduces to the PR-2 `(x, y) in cells`.
+                    if _footprint(cb) & cells:
                         tgt = c.characters.get(cb.character_id)
                         if tgt is not None:
                             aoe_targets.append(tgt)

--- a/servers/engine/tests/test_grid_terrain_size.py
+++ b/servers/engine/tests/test_grid_terrain_size.py
@@ -1,0 +1,256 @@
+"""#1253 grid (PR-4/PR-5) — difficult terrain (double move cost) + creature size/reach
+(>1-cell tokens). Pure geometry lives in combat_grid (footprint / footprint_distance_cells /
+weighted reachable/shortest_path/path_cost_cells); the wiring lives in server.set_grid,
+place_combatant_at_coords, move_to_coords, attack(), and cast_spell's AoE occupant loop.
+
+ADDITIVE / opt-in: with NO difficult-terrain cells and all-Medium tokens, everything is
+BYTE-FOR-BYTE the PR-1..PR-3 behaviour — the regression test at the bottom is the
+load-bearing guard.
+
+DIFFICULT TERRAIN (SRD 5.2): entering a difficult cell costs DOUBLE (2 cells).
+SIZE: Medium/Small/Tiny = 1 cell; Large = 2×2, Huge = 3×3, Gargantuan = 4×4, anchored at
+the stored (x, y) MIN-corner. Reach + occupancy + AoE measure over the whole footprint.
+"""
+
+import pytest
+
+import combat_grid
+import server
+
+
+# ── (1) PURE: difficult-terrain double cost ──────────────────────────────────
+
+
+def test_path_cost_open_floor_unchanged_without_difficult():
+    # No difficult terrain => plain straight-line Chebyshev (PR-1 byte-for-byte).
+    assert combat_grid.path_cost_cells((0, 0), (5, 0)) == 5
+    assert combat_grid.path_cost_cells((0, 0), (3, 3)) == 3
+
+
+def test_path_cost_straight_walk_across_difficult_costs_double_per_cell():
+    # Straight walk (0,0)->(4,0) entering two difficult cells (2,0),(3,0): base 4 + 2 = 6.
+    difficult = {(2, 0), (3, 0)}
+    assert combat_grid.path_cost_cells((0, 0), (4, 0), None, difficult) == 6
+
+
+def test_path_cost_explicit_path_surcharges_difficult_steps():
+    # An explicit step path across one difficult cell: 3 hops + 1 surcharge = 4.
+    path = [(1, 0), (2, 0), (3, 0)]
+    difficult = {(2, 0)}
+    assert combat_grid.path_cost_cells((0, 0), (3, 0), path, difficult) == 4
+
+
+def test_shortest_path_routes_around_expensive_difficult_terrain():
+    # A wall of difficult cells straight ahead makes the direct route cost 2/cell; a detour
+    # around it can be cheaper. The path THROUGH costs more than going AROUND.
+    difficult = {(1, 0), (1, 1), (1, 2)}
+    w = h = 6
+    routed = combat_grid.shortest_path((0, 0), (2, 0), set(), w, h, frozenset(), difficult)
+    assert routed is not None
+    cost = combat_grid.path_cost_cells((0, 0), (2, 0), routed, difficult)
+    # Straight-diagonal detour (0,0)->(1,-?) is off-grid; the cheapest legal route avoids the
+    # difficult column where possible. Cost must be < the 2-per-cell straight cost of 3 (enter
+    # (1,0)=2 + (2,0)=1) — the router should not pay double if a 1-cost detour exists.
+    straight_cost = combat_grid.path_cost_cells((0, 0), (2, 0), None, difficult)
+    assert straight_cost == 3  # (1,0) difficult doubles: 1(base to (1,0))+1 surcharge +1 = 3
+    assert cost <= straight_cost
+
+
+def test_reachable_difficult_shrinks_reach():
+    # A 2-cell budget reaches 2 open cells in a line, but only 1 into difficult terrain.
+    open_reach = combat_grid.reachable((0, 0), 2, set(), 10, 10)
+    assert (2, 0) in open_reach  # two open steps
+    hard = combat_grid.reachable((0, 0), 2, set(), 10, 10, frozenset(), {(1, 0), (2, 0)})
+    assert (1, 0) in hard        # entering (1,0) costs 2 == whole budget
+    assert (2, 0) not in hard    # (2,0) would cost 4 — out of a 2-cell budget
+
+
+# ── (2) SERVER: difficult-terrain move cost + short-stop advisory ────────────
+
+
+def _grid_fight(cid_name="terr", w=20, h=20, difficult=None, obstacles=None):
+    cid = server.create_campaign(cid_name)["id"]
+    a = server.create_character(cid, "Fighter", kind="player", max_hp=30, armor_class=14)["id"]
+    t = server.create_character(cid, "Goblin", kind="monster", max_hp=30, armor_class=14)["id"]
+    server.start_combat(cid, [a, t])
+    server.set_grid(cid, w, h, obstacles=obstacles, difficult=difficult)
+    return cid, a, t
+
+
+def test_move_forced_path_charges_double_through_difficult(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    # Fighter speed 30 => 6 cells budget. Difficult cells (1,0),(2,0). An EXPLICIT straight
+    # path through them: base 3, +2 for the two difficult entries = 5 cells, both surfaced.
+    cid, a, t = _grid_fight(difficult=[[1, 0], [2, 0]])
+    server.place_combatant_at_coords(cid, t, 10, 10)
+    server.place_combatant_at_coords(cid, a, 0, 0)
+    res = server.move_to_coords(cid, a, 3, 0, path=[[1, 0], [2, 0], [3, 0]])
+    assert res["cost_cells"] == 5
+    assert res.get("difficult_crossed") == [[1, 0], [2, 0]]
+
+
+def test_move_router_prefers_cheaper_route_around_difficult(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    # With no explicit path, the auto-router (Dijkstra) routes AROUND the difficult band to
+    # the cheapest arrival — a 3-cell open detour beats the 5-cell straight slog.
+    cid, a, t = _grid_fight(difficult=[[1, 0], [2, 0]])
+    server.place_combatant_at_coords(cid, t, 10, 10)
+    server.place_combatant_at_coords(cid, a, 0, 0)
+    res = server.move_to_coords(cid, a, 3, 0)
+    assert res["cost_cells"] == 3           # went around (open cells), not through
+    assert not res.get("difficult_crossed")  # no difficult cell entered
+
+
+def test_move_over_budget_shortstop_advisory_from_difficult(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    # Speed 30 => 6 cells. A full-width difficult band (no way around) forces the double
+    # cost; a long run blows the budget and trips the advisory note (never hard-blocks).
+    band = [[1, y] for y in range(20)] + [[2, y] for y in range(20)] + \
+           [[3, y] for y in range(20)] + [[4, y] for y in range(20)]
+    cid, a, t = _grid_fight(difficult=band)
+    server.place_combatant_at_coords(cid, t, 15, 15)
+    server.place_combatant_at_coords(cid, a, 0, 0)
+    res = server.move_to_coords(cid, a, 5, 0, path=[[1, 0], [2, 0], [3, 0], [4, 0], [5, 0]])
+    # base 5 + 4 difficult surcharges = 9 cells > 6 budget.
+    assert res["cost_cells"] == 9
+    assert res.get("movement_illegal") is not None
+    assert res["movement_illegal"]["budget_cells"] == 6
+
+
+def test_move_no_difficult_is_plain_chebyshev(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid, a, t = _grid_fight()
+    server.place_combatant_at_coords(cid, t, 15, 15)
+    server.place_combatant_at_coords(cid, a, 0, 0)
+    res = server.move_to_coords(cid, a, 3, 0)
+    assert res["cost_cells"] == 3
+    assert "difficult_crossed" not in res  # no key when no terrain crossed
+
+
+# ── (3) PURE: creature size footprint + reach ────────────────────────────────
+
+
+def test_footprint_medium_is_one_cell():
+    assert combat_grid.footprint_cells("medium") == 1
+    assert combat_grid.footprint((4, 4), "medium") == {(4, 4)}
+    # Tiny/small collapse to 1 cell; unknown => 1 (additive default).
+    assert combat_grid.footprint_cells("small") == 1
+    assert combat_grid.footprint_cells("") == 1
+    assert combat_grid.footprint_cells("bogus") == 1
+
+
+def test_footprint_large_is_two_by_two():
+    assert combat_grid.footprint_cells("large") == 2
+    assert combat_grid.footprint((3, 3), "large") == {(3, 3), (4, 3), (3, 4), (4, 4)}
+
+
+def test_footprint_huge_is_three_by_three():
+    assert combat_grid.footprint_cells("huge") == 3
+    assert len(combat_grid.footprint((0, 0), "huge")) == 9
+
+
+def test_footprints_overlap_detects_collision():
+    # A Large token at (3,3) (covers up to (4,4)) collides with a Medium at (4,4).
+    assert combat_grid.footprints_overlap((3, 3), "large", (4, 4), "medium") is True
+    # But not with a Medium two cells clear.
+    assert combat_grid.footprints_overlap((3, 3), "large", (6, 6), "medium") is False
+
+
+def test_footprint_edge_reach_large_adjacent_from_two_anchor_cells():
+    # A Large attacker anchored at (0,0) (covers to (1,1)) melees a Medium target at (2,1):
+    # anchor Chebyshev is 2, but the FOOTPRINT-EDGE distance is 1 (cell (1,1) is adjacent).
+    assert combat_grid.footprint_distance_cells((0, 0), "large", (2, 1), "medium") == 1
+    assert combat_grid.in_melee_reach_sized((0, 0), "large", (2, 1), "medium") is True
+    # Two medium tokens reduce to the PR-1 anchor Chebyshev.
+    assert combat_grid.footprint_distance_cells((0, 0), "medium", (2, 0), "medium") == 2
+    assert combat_grid.in_melee_reach_sized((0, 0), "medium", (2, 0), "medium") is False
+
+
+# ── (4) SERVER: size wiring — placement, reach, AoE ──────────────────────────
+
+
+def test_place_large_collision_warns_on_footprint_overlap(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid, a, t = _grid_fight()
+    # Place a Medium at (4,4), then a Large anchored at (3,3) — its 2×2 footprint covers
+    # (4,4), so the placement must WARN about the collision (never blocks).
+    server.place_combatant_at_coords(cid, t, 4, 4)
+    res = server.place_combatant_at_coords(cid, a, 3, 3, size="large")
+    assert any("occupied" in w for w in res["warnings"])
+
+
+def test_place_large_out_of_bounds_footprint_warns(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid, a, t = _grid_fight(w=5, h=5)
+    server.place_combatant_at_coords(cid, t, 0, 0)
+    # A Large token anchored at (4,4) on a 5×5 grid overflows to (5,5) — out of bounds warn.
+    res = server.place_combatant_at_coords(cid, a, 4, 4, size="large")
+    assert any("out of the" in w for w in res["warnings"])
+
+
+def test_large_attacker_reaches_from_footprint_edge(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid, a, t = _grid_fight()
+    # Large fighter anchored (0,0) covers to (1,1); target Medium at (2,1) is edge-adjacent.
+    server.place_combatant_at_coords(cid, a, 0, 0, size="large")
+    server.place_combatant_at_coords(cid, t, 2, 1)
+    res = server.attack(campaign_id=cid, attacker_id=a, target_id=t,
+                        attack_bonus=3, damage_dice="1d6")
+    # No out-of-reach range_warning: the footprint edge is within 5 ft.
+    assert "range_warning" not in res
+
+
+def test_medium_attacker_two_cells_away_warns(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid, a, t = _grid_fight()
+    server.place_combatant_at_coords(cid, a, 0, 0)  # medium
+    server.place_combatant_at_coords(cid, t, 2, 0)  # 10 ft away
+    res = server.attack(campaign_id=cid, attacker_id=a, target_id=t,
+                        attack_bonus=3, damage_dice="1d6")
+    assert "range_warning" in res
+
+
+def test_aoe_catches_large_creature_by_any_footprint_cell(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    cid = server.create_campaign("aoe-size")["id"]
+    caster = server.create_character(cid, "Wizard", kind="player", max_hp=20, armor_class=12)["id"]
+    server.update_character(cid, caster, patch={"spell_slots": {"3": {"maximum": 4, "used": 0}}})
+    ogre = server.create_character(cid, "Ogre", kind="monster", max_hp=40, armor_class=11)["id"]
+    server.start_combat(cid, [caster, ogre])
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, caster, 0, 0)
+    # Large ogre anchored at (7,5) covers (7,5),(8,5),(7,6),(8,6). A Fireball burst centred at
+    # (8,6) catches it via the (8,6) footprint cell even though its ANCHOR (7,5) is farther.
+    server.place_combatant_at_coords(cid, ogre, 7, 5, size="large")
+    res = server.cast_spell(cid, caster, "Fireball", slot_level=3, origin=[8, 6])
+    hit_ids = {row["character_id"] for row in res["aoe"]["targets"]}
+    assert ogre in hit_ids  # the large creature was caught by its (8,6) footprint cell
+
+
+# ── (5) BYTE-IDENTICAL REGRESSION: no difficult + all-Medium == PR-1..PR-3 ───
+
+
+def test_no_difficult_all_medium_is_byte_identical(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    # A fight with no difficult terrain and all-Medium tokens must produce the same
+    # move result as before this PR: plain Chebyshev cost, no difficult_crossed / size keys.
+    cid, a, t = _grid_fight()
+    server.place_combatant_at_coords(cid, t, 10, 0)
+    server.place_combatant_at_coords(cid, a, 0, 0)
+    res = server.move_to_coords(cid, a, 4, 4)
+    assert res["cost_cells"] == 4
+    assert "difficult_crossed" not in res
+    view = server._combat_view(server._require(cid))
+    for entry in view["order"]:
+        assert "size" not in entry        # Medium never surfaces a size key
+        assert "footprint" not in entry
+
+
+def test_pure_helpers_additive_defaults():
+    # Empty difficult / medium size preserve every PR-1..PR-3 pure result exactly.
+    assert combat_grid.reachable((0, 0), 6, set(), 20, 20) == \
+        combat_grid.reachable((0, 0), 6, set(), 20, 20, frozenset(), frozenset())
+    assert combat_grid.shortest_path((0, 0), (5, 5), set(), 20, 20) == \
+        combat_grid.shortest_path((0, 0), (5, 5), set(), 20, 20, frozenset(), frozenset())
+    assert combat_grid.in_melee_reach((2, 2), (3, 3)) is True
+    assert combat_grid.footprint_distance_cells((2, 2), "medium", (3, 3), "medium") == 1


### PR DESCRIPTION
Implements #1253 (grid-461 PR-4 terrain + PR-5 creature size/reach). Part of #1100.

## Scope
**PR-4 — difficult terrain.** Additive `Combat.grid_difficult` cell field (mirrors `grid_impassable` exactly). Each difficult cell costs DOUBLE movement to ENTER (SRD 5.2). Wired into weighted `reachable` / `shortest_path` (both promoted to Dijkstra) and `path_cost_cells`, so `move_to_coords`:
- auto-routes AROUND difficult terrain when a cheaper open detour exists (Dijkstra picks the least-cost arrival);
- charges the double cost when the route is forced through it (explicit `path`, or an unavoidable band);
- short-stops via the existing over-budget `movement_illegal` advisory (never hard-blocks);
- surfaces `difficult_crossed` (the entered difficult cells) in the move payload.

`set_grid` gains a `difficult` arg (same `[x,y]`-pairs shape as `obstacles`; omit = unchanged, `[]` = clear).

**PR-5 — creature size / reach.** Additive `Combatant.size` (default `"medium"` = 1 cell = byte-identical). Large = 2×2, Huge = 3×3, Gargantuan = 4×4, anchored at the stored `(x, y)` MIN-corner. Footprint-aware:
- occupancy / collision for placement and movement (`_occupied_cells` over full footprints);
- melee reach measured FOOTPRINT-EDGE to footprint-edge (`footprint_distance_cells`) — a 2×2 attacker reaches an adjacent target 2 anchor-cells away;
- ranged-in-melee disadvantage and AoE occupant resolution (a creature is caught if ANY footprint cell is in the template).

`place_combatant_at_coords` gains an optional `size` arg; `_combat_view` surfaces `size`/`footprint` for Large+ tokens only (Medium omits the keys).

**Cover for big tokens:** the design doc is silent on corner-tracing for large tokens, so per the packet PR-5 keeps the single anchor-to-anchor ray; `cover_between`'s docstring documents the approximation and defers corner-tracing to #1255. No flanking (#1254), no AI changes (#1255).

## Invariants
- **Additive / byte-identical:** no difficult cells + all-Medium == PR-1..PR-3 behaviour byte-for-byte (regression tests `test_no_difficult_all_medium_is_byte_identical`, `test_pure_helpers_additive_defaults`). Old snapshots round-trip (`grid_difficult` defaults `[]`, `size` defaults `"medium"`).
- Engine stays sole writer; gates read engine values only.
- **Schema delta: +449 bytes** (118,677 → 119,126; 156 tools unchanged) from the two new params + docstrings. `tests/test_tool_schema_budget.py` still passes.

## Tests
- New `servers/engine/tests/test_grid_terrain_size.py` — 21 tests (double-cost path-through vs router-around, budget short-stop, Large placement collision + OOB, footprint-edge reach, AoE catching a Large creature by a footprint cell, byte-identical regression).
- Existing grid suite (79) green; **full engine suite: 3322 passed, 0 failures** (single-process `-p no:xdist`).
- `qa/fast_gate.sh` T0 PASS (241 deterministic).

Do not merge — orchestrator review.