### PR TITLE
feat(engine): grid-461 PR-7 — wire flanking advantage (#1254)

### DIFF
--- a/servers/engine/combat_grid.py
+++ b/servers/engine/combat_grid.py
@@ -107,6 +107,53 @@ def in_melee_reach_sized(
     return footprint_distance_cells(a_anchor, a_size, b_anchor, b_size) <= reach_cells
 
 
+def _footprint_center2(anchor: Cell, size: str) -> tuple[int, int]:
+    """The token's footprint CENTRE, expressed in HALF-cell units (doubled) so it stays an
+    integer for odd- and even-sized footprints alike. A 1-cell token at (x, y) centres on
+    (2x+1, 2y+1); a 2×2 Large token at anchor (x, y) spans [x, x+2)×[y, y+2) and centres on
+    (2x+2, 2y+2). Doubling keeps the flanking geometry exact (a Large token's centre falls on
+    a cell corner, not a cell centre) without floats."""
+    n = footprint_cells(size)
+    ax, ay = anchor
+    return (2 * ax + n, 2 * ay + n)
+
+
+def flanking(
+    a_anchor: Cell, a_size: str,
+    ally_anchor: Cell, ally_size: str,
+    t_anchor: Cell, t_size: str,
+) -> bool:
+    """True if an attacker (at `a_anchor`) and an ALLY (at `ally_anchor`) FLANK the target
+    (at `t_anchor`) per the common DMG-style optional rule — they are on OPPOSITE SIDES of
+    the target's space.
+
+    CONVENTION (line-through-centres, footprint-aware): draw the vector from the target's
+    footprint centre to the attacker's centre and the vector to the ally's centre; the two
+    creatures flank when those vectors point in SUBSTANTIALLY OPPOSING directions — i.e. the
+    ally is across the target from the attacker. Formally: on each axis where the attacker is
+    off-centre from the target, the ally must be on the OPPOSITE side (or centred), and the
+    ally must be off-centre from the target on at least one such axis (otherwise it is beside,
+    not across). This admits the two standard flanking geometries — DIRECTLY opposite (same
+    row/column, target between) and DIAGONALLY opposite (opposite corners) — and rejects
+    same-side / adjacent-but-not-across allies. Reach is NOT checked here (the caller confirms
+    both threateners are within melee reach of the target); this is the pure OPPOSITE-SIDES
+    geometry. ADDITIVE / pure: all-Medium tokens reduce to opposite-cell adjacency about the
+    target cell."""
+    tcx, tcy = _footprint_center2(t_anchor, t_size)
+    acx, acy = _footprint_center2(a_anchor, a_size)
+    ecx, ecy = _footprint_center2(ally_anchor, ally_size)
+    dax, day = acx - tcx, acy - tcy        # attacker offset from target centre
+    dex, dey = ecx - tcx, ecy - tcy        # ally offset from target centre
+    # On every axis the attacker leans off-centre, the ally must not lean the SAME way
+    # (product > 0 == same side => not across). Centred (0) on an axis is neutral.
+    if dax * dex > 0 or day * dey > 0:
+        return False
+    # And the ally must actually be ACROSS on some axis where the attacker is off-centre —
+    # a purely perpendicular ally (beside the target) does not flank.
+    return (dax != 0 and dex != 0 and (dax > 0) != (dex > 0)) or \
+           (day != 0 and dey != 0 and (day > 0) != (dey > 0))
+
+
 def movement_budget_cells(speed: int, cell_size: int = 5, dashed: bool = False) -> int:
     """Movement budget in CELLS for a turn: floor(speed / cell_size), doubled if the
     creature Dashed. Speed 30 / 5ft cells -> 6 cells (12 with Dash)."""

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -5749,6 +5749,67 @@ def attack(
                     ranged_in_melee_grid = True
                     break
         dis = dis or ranged_in_melee_grid
+        # FLANKING (#1254 / PR-7): the common DMG-style OPTIONAL rule (SRD 5.2 core has no
+        # flanking) — a MELEE attacker gains ADVANTAGE when a conscious ALLY threatens the
+        # target from the OPPOSITE SIDE. OFF by default: only fires when the house rule
+        # `flanking_advantage` is enabled AND the fight is on a grid; otherwise this whole
+        # block is skipped and behaviour is byte-identical. Engine sole-writer: computed
+        # purely from existing Combatant positions/sizes — no new state, no new tool param.
+        flanking_grid = False
+        if (
+            not is_ranged
+            and c.house_rules.flanking_advantage
+            and c.combat.grid_enabled
+        ):
+            f_acb = next(
+                (cb for cb in c.combat.order if cb.character_id == attacker_id), None
+            )
+            f_tcb = next(
+                (cb for cb in c.combat.order if cb.character_id == target_id), None
+            )
+            atk_cell = _cell(f_acb) if f_acb is not None else None
+            tgt_cell = _cell(f_tcb) if f_tcb is not None else None
+            if atk_cell is not None and tgt_cell is not None:
+                atk_size = _size(f_acb)
+                tgt_size = _size(f_tcb)
+                ally_kinds = {"player", "companion"}
+                attacker_ally = attacker.kind in ally_kinds
+                # The attacker must itself be in melee reach of the target (a flanker has to
+                # be threatening it). An out-of-reach attacker can't flank even with an ally
+                # across — mirrors the ranged-in-melee reach check above.
+                if combat_grid.in_melee_reach_sized(
+                    atk_cell, atk_size, tgt_cell, tgt_size
+                ):
+                    for mate_cb in c.combat.order:
+                        mate_id = mate_cb.character_id
+                        if mate_id in (attacker_id, target_id):
+                            continue
+                        mate = c.characters.get(mate_id)
+                        if mate is None or mate.dead or mate.current_hp <= 0:
+                            continue
+                        # Only a same-side ally flanks WITH the attacker.
+                        if (mate.kind in ally_kinds) != attacker_ally:
+                            continue
+                        # SRD-consistent: an Incapacitated ally isn't a threatening flanker
+                        # (the optional rule requires a conscious, threatening ally).
+                        if combat.is_incapacitated(mate):
+                            continue
+                        mate_cell = _cell(mate_cb)
+                        if mate_cell is None:
+                            continue  # an unplaced ally can't flank
+                        mate_size = _size(mate_cb)
+                        # The ally must also be in melee reach of the target...
+                        if not combat_grid.in_melee_reach_sized(
+                            mate_cell, mate_size, tgt_cell, tgt_size
+                        ):
+                            continue
+                        # ...and on the OPPOSITE side (footprint-aware geometry).
+                        if combat_grid.flanking(
+                            atk_cell, atk_size, mate_cell, mate_size, tgt_cell, tgt_size
+                        ):
+                            flanking_grid = True
+                            break
+        adv = adv or flanking_grid
         # COVER (#1252 / PR-3): when on the grid AND both combatants are placed, derive the
         # SRD 5.2 cover the target has from the attacker's line — half (+2 AC), three-quarters
         # (+5 AC), or total (untargetable). Cover comes from intervening BLOCKING cells (the
@@ -5862,6 +5923,13 @@ def attack(
             # disadvantage (folded into `dis` above), so the DM narrates it and the behavioral
             # gate / scorer see the rule actually fired on-grid (not announced-then-dropped).
             result["attack_roll"]["ranged_in_melee_disadvantage"] = True
+        if flanking_grid:
+            # #1254 grid (PR-7): surface that the engine AUTO-APPLIED the optional flanking
+            # ADVANTAGE (folded into `adv` above), so the DM narrates "you and your ally have
+            # the ogre pinned between you" and the behavioral gate / scorer see the rule
+            # actually fired on-grid. Free payload (no tool-schema param — derived from
+            # existing positions + the house-rule flag). Absent when flanking didn't apply.
+            result["attack_roll"]["flanking_advantage"] = True
         if cover_ac > 0:
             # #1252 grid (PR-3): surface the SRD cover the target enjoyed and the AC it added,
             # so the DM narrates "the goblin ducks behind the pillar (+2 AC)" and the scorer /

--- a/servers/engine/tests/test_grid_flanking.py
+++ b/servers/engine/tests/test_grid_flanking.py
@@ -1,0 +1,142 @@
+"""#1254 grid (PR-7) — flanking ADVANTAGE from an opposite-side ally (the common DMG-style
+OPTIONAL rule; SRD 5.2 core has no flanking). Pure geometry lives in combat_grid.flanking
+(opposite-sides, footprint-aware); the wiring lives in server.attack() — it consults the
+existing `HouseRules.flanking_advantage` flag + the grid positions and folds the resulting
+advantage into the roll, surfacing `attack_roll.flanking_advantage: True` in the payload.
+
+ADDITIVE / opt-in: with the house rule OFF (its default) NOTHING in attack() changes — the
+disabled-rule regression test is the load-bearing byte-identical guard. Only fires when
+`flanking_advantage=True` AND the fight is on a grid.
+
+CONVENTION (documented in combat_grid.flanking): attacker + a conscious ally are on OPPOSITE
+SIDES of the target (line-through-centres) — directly opposite (same row/column with the
+target between) OR diagonally opposite corners. Footprint-aware for Large+ tokens.
+"""
+
+import combat_grid
+import server
+
+
+# ── (1) PURE geometry: combat_grid.flanking ──────────────────────────────────
+
+
+def test_flanking_directly_opposite_medium():
+    # target (5,5); attacker directly left, ally directly right => flank.
+    assert combat_grid.flanking((4, 5), "medium", (6, 5), "medium", (5, 5), "medium")
+    # vertically opposite too (above/below).
+    assert combat_grid.flanking((5, 4), "medium", (5, 6), "medium", (5, 5), "medium")
+
+
+def test_flanking_diagonally_opposite_corners_medium():
+    # opposite corners across the target => flank (standard grid convention).
+    assert combat_grid.flanking((4, 4), "medium", (6, 6), "medium", (5, 5), "medium")
+
+
+def test_same_side_allies_do_not_flank():
+    # both attacker and ally on the target's LEFT => not across => no flank.
+    assert not combat_grid.flanking((4, 5), "medium", (4, 4), "medium", (5, 5), "medium")
+    # attacker left, ally directly ABOVE (perpendicular, beside not across) => no flank.
+    assert not combat_grid.flanking((4, 5), "medium", (5, 4), "medium", (5, 5), "medium")
+
+
+def test_flanking_footprint_aware_large_attacker():
+    # A LARGE (2×2) attacker anchored at (3,4) spans [3,5)×[4,6): footprint centre (8,10)
+    # in half-cell units => sits to the LEFT of the target at (6,5) (centre (13,11)). A
+    # Medium ally directly to the RIGHT at (7,5) flanks WITH the large attacker.
+    assert combat_grid.flanking((3, 4), "large", (7, 5), "medium", (6, 5), "medium")
+    # And a same-side (also-left) large placement does NOT flank with the left attacker.
+    assert not combat_grid.flanking((3, 4), "large", (4, 5), "medium", (6, 5), "medium")
+
+
+# ── (2) SERVER wiring: attack() folds flanking into advantage ────────────────
+
+
+def _flank_fight(flanking=True, ally_kind="companion"):
+    """A grid fight: attacker (player) at (4,5), target (monster) at (5,5), ally at (6,5)
+    — attacker + ally on OPPOSITE sides of the target. Returns (cid, attacker, target, ally).
+    `flanking` toggles the house rule; `ally_kind` lets a test place an incapacitated ally."""
+    cid = server.create_campaign("flank")["id"]
+    a = server.create_character(cid, "Fighter", kind="player", max_hp=30, armor_class=14)["id"]
+    t = server.create_character(cid, "Ogre", kind="monster", max_hp=40, armor_class=14)["id"]
+    ally = server.create_character(cid, "Ally", kind=ally_kind, max_hp=30, armor_class=14)["id"]
+    server.start_combat(cid, [a, t, ally])
+    if flanking:
+        server.set_house_rules(cid, {"flanking_advantage": True})
+    server.set_grid(cid, 20, 20)
+    server.place_combatant_at_coords(cid, a, 4, 5)
+    server.place_combatant_at_coords(cid, t, 5, 5)
+    server.place_combatant_at_coords(cid, ally, 6, 5)
+    return cid, a, t, ally
+
+
+def test_flanking_grants_advantage_opposite_sides():
+    cid, a, t, ally = _flank_fight(flanking=True)
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=3, damage_dice="1d8",
+    )
+    assert res["advantage"] is True
+    assert res["attack_roll"].get("flanking_advantage") is True
+
+
+def test_same_side_ally_does_not_grant_advantage():
+    cid, a, t, ally = _flank_fight(flanking=True)
+    # Move the ally to the SAME side as the attacker (also left of the target).
+    server.place_combatant_at_coords(cid, ally, 4, 6)  # left/below, not across
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=3, damage_dice="1d8",
+    )
+    assert res["attack_roll"].get("flanking_advantage") is None
+    # No other advantage source in this fixture, so the roll is not advantaged by flanking.
+    assert res["advantage"] is False
+
+
+def test_flanking_disabled_house_rule_is_byte_identical():
+    cid, a, t, ally = _flank_fight(flanking=False)  # rule OFF (default)
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=3, damage_dice="1d8",
+    )
+    # Same opposite-side geometry, but the rule is off => no advantage, no payload key.
+    assert res["advantage"] is False
+    assert res["attack_roll"].get("flanking_advantage") is None
+
+
+def test_incapacitated_ally_does_not_flank():
+    cid, a, t, ally = _flank_fight(flanking=True)
+    server.add_condition(cid, character_id=ally, condition="incapacitated")
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=3, damage_dice="1d8",
+    )
+    # An incapacitated ally is not a threatening flanker (SRD-consistent).
+    assert res["attack_roll"].get("flanking_advantage") is None
+    assert res["advantage"] is False
+
+
+def test_flanking_advantage_and_disadvantage_cancel():
+    # Flanking gives advantage; pass an explicit disadvantage in the same attack. Standard
+    # 5e adv/dis folding: one of each => a straight roll (neither adv nor dis on the die).
+    cid, a, t, ally = _flank_fight(flanking=True)
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=3, damage_dice="1d8", disadvantage=True,
+    )
+    # The flanking source still fires (surfaced), but the die roll is normal (adv & dis both
+    # set => dice_mod rolls straight). The result flags reflect both inputs were present.
+    assert res["attack_roll"].get("flanking_advantage") is True
+    assert res["advantage"] is True
+    assert res["disadvantage"] is True
+    # Straight roll: the recorded natural die equals a single d20 (no adv/dis pick pair).
+    assert 1 <= res["attack_roll"]["natural"] <= 20
+
+
+def test_ranged_attack_never_flanks():
+    # Flanking is a MELEE-only rule; a ranged attack from a flanking position doesn't get it.
+    cid, a, t, ally = _flank_fight(flanking=True)
+    res = server.attack(
+        campaign_id=cid, attacker_id=a, target_id=t,
+        attack_bonus=3, damage_dice="1d6", is_ranged=True,
+    )
+    assert res["attack_roll"].get("flanking_advantage") is None


### PR DESCRIPTION
## grid-461 PR-7 — wire flanking advantage

Wires the **dead** `HouseRules.flanking_advantage` field (`servers/engine/models.py:1609`) — settable via `set_house_rules` but never consulted in `attack()` until now.

### What it does
On a grid, a **melee** attacker whose conscious **ally** threatens the target from the **opposite side** gains **advantage** — the common DMG-style optional rule (SRD 5.2 core has no flanking). Folded into `attack()`'s existing adv/dis resolution as one more advantage SOURCE, and surfaced as `result["attack_roll"]["flanking_advantage"] = True` (mirrors `ranged_in_melee_disadvantage`) so the DM narrates it and scorers see it fire.

### Opposite-sides convention (documented in `combat_grid.flanking`)
Line-through-centres, **footprint-aware**: draw the vector from the target's footprint centre to the attacker's centre and to the ally's centre; they flank when those vectors point in **substantially opposing directions** (ally across the target). Admits the two standard geometries — **directly opposite** (same row/column, target between) and **diagonally opposite corners** — and rejects same-side / perpendicular-beside allies. Centres are computed in half-cell units so Large+ even-footprint centres stay exact integers.

### Invariants
- **Additive / default-OFF**: fires only when `flanking_advantage=True` AND `grid_enabled`. Off => `attack()` is byte-identical (regression test `test_flanking_disabled_house_rule_is_byte_identical`).
- **Engine sole-writer**: computed purely from existing Combatant positions/sizes + the existing house-rule flag. No new write path.
- **0 schema bytes**: no new tool/param; derived from grid state, surfaced in the result payload only. `qa/schema_mass.py` → 156 tools / 119126 bytes (unchanged); `test_tool_schema_budget.py` green.
- **Melee-only** (ranged never flanks); **incapacitated allies don't flank** (SRD-consistent — requires a conscious threatening ally).
- Adv/dis folding unchanged: flanking + an explicit disadvantage cancel to a straight roll (existing `dice_mod.roll` handles it).

### Tests (red-first, `test_grid_flanking.py`)
Pure geometry (directly/diagonally opposite, same-side reject, Large footprint-aware) + server wiring (grants advantage on opposite sides; same-side no; disabled = byte-identical; incapacitated ally no; adv/dis cancel; ranged never flanks).

- New tests: **10 passed**
- Grid + house-rule suites (`test_grid*`, `test_blitz_tools`): **98 passed**
- `qa/fast_gate.sh`: **241 passed**
- Full engine suite (`-p no:xdist`): **3332 passed**

Part of #1100. Closes #1254.