### PR TITLE
fix(combat): greedy-v1 movement respects impassable/difficult (#1269)

### DIFF
--- a/servers/engine/combat_ai.py
+++ b/servers/engine/combat_ai.py
@@ -418,20 +418,53 @@ def _nearest_foe(view: CombatView) -> Optional[CombatantView]:
 def _step_toward(view: CombatView, target: CombatantView, reach_ft: int) -> Optional[tuple[int, int]]:
     """Pick the reachable cell (within this turn's movement budget) that gets the actor as
     close as possible to `target` — ideally into reach. Returns a cell or None (can't improve
-    / off-grid). Pure: combat_grid.reachable + Chebyshev distance, no state."""
+    / off-grid). Pure: combat_grid.reachable + Chebyshev distance, no state.
+
+    Terrain-aware (#1269): the fight's `blocking` (walls/props) and `difficult` cells are threaded
+    into the SAME terrain-aware Dijkstra the engine uses, so a greedy-v1 monster ROUTES AROUND walls
+    (impassable cells are never reachable) and, among equally-close cells, prefers a CHEAP clear route
+    over one through difficult ground (the routed-cost tie-break). On OPEN FLOOR (no walls / no
+    difficult — both sets empty) `reachable` degenerates to the flat-cost Dijkstra and the tie-break
+    stays `(distance, cell)` exactly as before — byte-identical to the pre-#1269 behaviour."""
     if not view.grid_enabled or view.actor_cell is None or target.cell is None:
         return None
     budget = combat_grid.movement_budget_cells(view.speed, view.cell_size, view.dashed)
     if budget <= 0:
         return None
     occupied = _occupied_cells(view) - {view.actor_cell}
-    reach = combat_grid.reachable(view.actor_cell, budget, occupied, view.grid_width, view.grid_height)
+    blocking = _blocking_set(view)
+    difficult = _difficult_set(view)
+    reach = combat_grid.reachable(
+        view.actor_cell, budget, occupied, view.grid_width, view.grid_height,
+        impassable=blocking, difficult=difficult,
+    )
     if not reach:
         return None
-    best = min(
-        reach,
-        key=lambda cell: (combat_grid.distance_ft(cell, target.cell, view.cell_size), cell),
-    )
+    if not blocking and not difficult:
+        # Open floor: the flat-cost path — key stays (distance, cell), byte-identical to pre-#1269.
+        best = min(
+            reach,
+            key=lambda cell: (combat_grid.distance_ft(cell, target.cell, view.cell_size), cell),
+        )
+    else:
+        # Walls/difficult terrain present: break distance ties by the terrain-aware ROUTED move cost
+        # (a same-distance CLEAR route beats one through difficult ground) — the same tie-break the
+        # tactical-v2 _terrain_step_toward uses, so v1-fallback routing matches the engine's picture.
+        def _routed_cost(cell: tuple[int, int]) -> int:
+            route = combat_grid.shortest_path(
+                view.actor_cell, cell, occupied, view.grid_width, view.grid_height,
+                impassable=blocking, difficult=difficult,
+            )
+            return combat_grid.path_cost_cells(view.actor_cell, cell, route, difficult=difficult)
+
+        best = min(
+            reach,
+            key=lambda cell: (
+                combat_grid.distance_ft(cell, target.cell, view.cell_size),
+                _routed_cost(cell),
+                cell,
+            ),
+        )
     cur = combat_grid.distance_ft(view.actor_cell, target.cell, view.cell_size)
     new = combat_grid.distance_ft(best, target.cell, view.cell_size)
     return best if new < cur else None
@@ -1155,8 +1188,12 @@ def pick_action(
             if threat is not None and view.grid_enabled and view.actor_cell is not None:
                 budget = combat_grid.movement_budget_cells(view.speed, view.cell_size, view.dashed)
                 occupied = _occupied_cells(view) - {view.actor_cell}
+                # Terrain-aware retreat (#1269): route the flee AROUND walls + difficult terrain via the
+                # SAME Dijkstra — a fleeing monster can't disengage THROUGH a wall. Empty sets (open floor)
+                # degenerate to the flat-cost reachable + the (distance, cell) flee key == byte-identical.
                 reach = combat_grid.reachable(
-                    view.actor_cell, budget, occupied, view.grid_width, view.grid_height
+                    view.actor_cell, budget, occupied, view.grid_width, view.grid_height,
+                    impassable=_blocking_set(view), difficult=_difficult_set(view),
                 )
                 if reach and threat.cell is not None:
                     flee_cell = max(

--- a/servers/engine/tests/test_combat_greedy_terrain.py
+++ b/servers/engine/tests/test_combat_greedy_terrain.py
@@ -1,0 +1,213 @@
+"""Greedy-v1 terrain-aware movement tests (#1269).
+
+Found during #1255/#1268: greedy-v1's movement helpers (`_step_toward` and the retreat-if-low
+`reachable` call) did NOT thread the fight's impassable/difficult cells, so a v1-policy monster on
+a WALLED grid could step toward/into a blocked cell (the engine's move_to_coords then refuses, or
+the loop picks an illegal-looking step). #1269 threads the SAME grid_impassable / grid_difficult
+sets the engine uses into those helpers, so a v1 monster ROUTES AROUND walls and prefers a cheap
+clear route over difficult ground.
+
+Two invariants, both asserted here:
+  * FIX — a v1 monster routes around a wall (was: stepped toward/into it); the retreat path respects
+    walls; difficult terrain is avoided when a same-cost clear path exists.
+  * BYTE-IDENTICAL — an OPEN-FLOOR fight (no walls, no difficult) is unchanged: the SAME seed/state
+    picks the SAME move cell as before the fix (the empty-set case degenerates to today).
+
+Pure + LLM-free: build a CombatView under the DEFAULT greedy-v1 policy, assert the Intent. No
+campaign, no lock, no I/O.
+"""
+from __future__ import annotations
+
+import combat_ai
+import combat_grid
+from combat_ai import AttackOption, CombatantView, CombatView, Intent
+
+
+# ── view builders (mirror test_combat_tactical) ──────────────────────────────────────
+
+def _view(actor_attacks, foes, *, actor_cell, grid=True, **kw) -> CombatView:
+    return CombatView(
+        actor_id="A",
+        actor_cell=actor_cell,
+        actor_zone="",
+        actor_side="enemy",
+        speed=kw.get("speed", 30),
+        dashed=False,
+        grid_enabled=grid,
+        grid_width=kw.get("w", 12),
+        grid_height=kw.get("h", 12),
+        cell_size=5,
+        foes=tuple(foes),
+        allies=tuple(kw.get("allies", ())),
+        attacks=tuple(actor_attacks),
+        spells=tuple(kw.get("spells", ())),
+        blocking=tuple(kw.get("blocking", ())),
+        difficult=tuple(kw.get("difficult", ())),
+    )
+
+
+def _foe(fid, hp=20, ac=12, cell=None, name=None):
+    return CombatantView(id=fid, name=name or fid, side="party",
+                         current_hp=hp, max_hp=hp, armor_class=ac, cell=cell)
+
+
+def _greedy(view) -> Intent:
+    return combat_ai.pick_action(actor=object(), combat_state=view, policy="greedy-v1")
+
+
+# ── FIX: greedy-v1 routes around a wall to reach its target ──────────────────────────
+
+def test_greedy_move_routes_around_wall():
+    """A v1 melee monster too far to strike, with a nearly-solid WALL column between it and the foe
+    (a gap only at the top): the move destination must be a cell the actor can LEGALLY reach by
+    routing AROUND the wall — never a cell reachable only by walking THROUGH the wall. Before #1269,
+    _step_toward's `reachable` ignored blocking, so it happily picked the straight-line cell just past
+    the wall (which has NO legal route this turn) — the illegal step the issue names."""
+    atks = [AttackOption(name="Claw", to_hit=5, damage_expr="1d6", reach_ft=5)]
+    foe = _foe("g1", cell=(8, 5))
+    # A vertical wall at column x=5 spanning rows 1..11 with a single gap at (5,0): the ONLY route to
+    # the foe's side is a long detour up-and-over, far beyond a 6-cell budget. Straight-line cells just
+    # past the wall (e.g. (6,5)) are UNREACHABLE this turn — old code picked one anyway.
+    wall = [(5, y) for y in range(1, 12)]
+    v = _view(atks, [foe], actor_cell=(2, 5), blocking=wall, speed=30)
+    intent = _greedy(v)
+    assert intent.kind == "move"
+    assert intent.to_cell is not None
+    assert intent.to_cell not in set(wall)
+    # The destination MUST be a terrain-aware reachable cell (no wall crossed / passed through).
+    budget = combat_grid.movement_budget_cells(v.speed, v.cell_size, v.dashed)
+    reach = combat_grid.reachable(
+        v.actor_cell, budget, set(), v.grid_width, v.grid_height,
+        impassable=set(wall),
+    )
+    assert intent.to_cell in reach
+    # And it may not be on the far (foe) side of the wall — there is no legal route there this turn.
+    assert intent.to_cell[0] < 5
+
+
+def test_greedy_move_never_targets_unreachable_cell_behind_wall():
+    """The cell closest to the foe sits behind a solid wall with no route this turn; greedy must NOT
+    pick it. Regression guard for the exact bug the issue names (moving toward a blocked cell)."""
+    atks = [AttackOption(name="Claw", to_hit=5, damage_expr="1d6", reach_ft=5)]
+    foe = _foe("g1", cell=(8, 5))
+    # A full-height wall at x=5 — no gap at all: the foe's side is wholly unreachable this turn.
+    wall = [(5, y) for y in range(0, 12)]
+    v = _view(atks, [foe], actor_cell=(2, 5), blocking=wall, speed=30)
+    intent = _greedy(v)
+    # With no cell getting strictly closer via a legal route, greedy must fall back (Dodge), NOT
+    # emit a move onto an unreachable far-side cell. Either way it must never target a wall / far side.
+    if intent.kind == "move":
+        assert intent.to_cell not in set(wall)
+        assert intent.to_cell[0] < 5
+    else:
+        assert intent.kind == "dodge"
+
+
+# ── FIX: retreat-if-low respects walls ───────────────────────────────────────────────
+
+def test_greedy_retreat_respects_walls(monkeypatch):
+    """With morale ON (RETREAT_FRACTION>0) and a low-HP actor, the disengage flee cell must be a
+    terrain-aware reachable cell (never a wall). Before #1269 the retreat `reachable` ignored
+    blocking and could flee THROUGH a wall."""
+    monkeypatch.setattr(combat_ai, "RETREAT_FRACTION", 0.5)
+
+    class _Actor:
+        max_hp = 20
+        current_hp = 4  # <= floor(20 * 0.5) => retreat triggers
+
+    atks = [AttackOption(name="Claw", to_hit=5, damage_expr="1d6", reach_ft=5)]
+    threat = _foe("g1", cell=(2, 5))
+    wall = [(5, y) for y in range(0, 9)]  # a full wall column to the actor's right
+    v = _view(atks, [threat], actor_cell=(4, 5), blocking=wall, speed=30)
+    intent = combat_ai.pick_action(actor=_Actor(), combat_state=v, policy="greedy-v1")
+    assert intent.kind == "disengage"
+    assert intent.to_cell is not None
+    assert intent.to_cell not in set(wall)
+    budget = combat_grid.movement_budget_cells(v.speed, v.cell_size, v.dashed)
+    reach = combat_grid.reachable(
+        v.actor_cell, budget, set(), v.grid_width, v.grid_height,
+        impassable=set(wall),
+    )
+    assert intent.to_cell in reach
+
+
+# ── FIX: difficult terrain avoided when a same-cost clear path exists ─────────────────
+
+def test_greedy_move_prefers_clear_ground_over_difficult():
+    """Two equally-CLOSE cells to the foe are reachable; one is reached only by crossing difficult
+    terrain, the other by clear ground. The terrain-aware routed-cost tie-break must pick the cheap
+    clear route (this is the whole point of threading `difficult` into _step_toward)."""
+    atks = [AttackOption(name="Claw", to_hit=5, damage_expr="1d6", reach_ft=5)]
+    foe = _foe("g1", cell=(6, 3))
+    # Actor at (2,3). Difficult terrain smeared across the straight-line row toward the foe, so
+    # the equal-Chebyshev-distance cell reached via the clear row above/below should win on cost.
+    difficult = [(3, 3), (4, 3), (3, 2), (4, 2)]
+    v = _view(atks, [foe], actor_cell=(2, 3), difficult=difficult, speed=30)
+    intent = _greedy(v)
+    assert intent.kind == "move"
+    assert intent.to_cell is not None
+    # The chosen destination must have the minimal ROUTED cost among cells at its distance-to-foe.
+    budget = combat_grid.movement_budget_cells(v.speed, v.cell_size, v.dashed)
+    diff = set(difficult)
+    reach = combat_grid.reachable(
+        v.actor_cell, budget, set(), v.grid_width, v.grid_height, difficult=diff
+    )
+
+    def routed_cost(cell):
+        route = combat_grid.shortest_path(
+            v.actor_cell, cell, set(), v.grid_width, v.grid_height, difficult=diff
+        )
+        return combat_grid.path_cost_cells(v.actor_cell, cell, route, difficult=diff)
+
+    chosen = intent.to_cell
+    chosen_dist = combat_grid.distance_ft(chosen, foe.cell, v.cell_size)
+    # No equally-close cell should have a strictly cheaper route than the one greedy chose.
+    same_dist = [
+        c for c in reach
+        if combat_grid.distance_ft(c, foe.cell, v.cell_size) == chosen_dist
+    ]
+    assert routed_cost(chosen) == min(routed_cost(c) for c in same_dist)
+
+
+# ── BYTE-IDENTICAL: open floor is unchanged (empty-set degenerates to today) ─────────
+
+def test_greedy_open_floor_move_byte_identical():
+    """No walls, no difficult terrain: greedy-v1's move pick must be EXACTLY what the pre-#1269
+    flat-cost `_step_toward` produced — the cell closest to the foe by (distance, cell). This is the
+    regression the issue mandates: the empty-set case is byte-identical to today."""
+    atks = [AttackOption(name="Claw", to_hit=5, damage_expr="1d6", reach_ft=5)]
+    foe = _foe("g1", cell=(9, 5))
+    v = _view(atks, [foe], actor_cell=(2, 5), speed=30)
+    intent = _greedy(v)
+    assert intent.kind == "move"
+    # Recompute the OLD flat-cost pick (no impassable/difficult, key=(distance, cell)) directly.
+    budget = combat_grid.movement_budget_cells(v.speed, v.cell_size, v.dashed)
+    reach = combat_grid.reachable(v.actor_cell, budget, set(), v.grid_width, v.grid_height)
+    expected = min(
+        reach,
+        key=lambda cell: (combat_grid.distance_ft(cell, foe.cell, v.cell_size), cell),
+    )
+    assert intent.to_cell == expected
+
+
+def test_greedy_open_floor_matches_flat_step_toward_helper():
+    """Belt-and-suspenders: on open floor the helper `_step_toward` returns the SAME cell as the
+    pre-#1269 flat-cost algorithm for a spread of actor positions (empty-set == today)."""
+    atks = [AttackOption(name="Claw", to_hit=5, damage_expr="1d6", reach_ft=5)]
+    foe = _foe("g1", cell=(9, 6))
+    for actor_cell in [(1, 1), (2, 6), (3, 9), (0, 6), (5, 0)]:
+        v = _view(atks, [foe], actor_cell=actor_cell, speed=30)
+        got = combat_ai._step_toward(v, foe, reach_ft=5)
+        budget = combat_grid.movement_budget_cells(v.speed, v.cell_size, v.dashed)
+        occupied = combat_ai._occupied_cells(v) - {v.actor_cell}
+        reach = combat_grid.reachable(
+            v.actor_cell, budget, occupied, v.grid_width, v.grid_height
+        )
+        best = min(
+            reach,
+            key=lambda cell: (combat_grid.distance_ft(cell, foe.cell, v.cell_size), cell),
+        )
+        cur = combat_grid.distance_ft(v.actor_cell, foe.cell, v.cell_size)
+        new = combat_grid.distance_ft(best, foe.cell, v.cell_size)
+        expected = best if new < cur else None
+        assert got == expected, f"open-floor _step_toward diverged at {actor_cell}"


### PR DESCRIPTION
## What

Threads the fight's `grid_impassable` (walls/props) and `grid_difficult` (terrain) sets into **greedy-v1's** movement helpers so a v1-policy monster routes AROUND walls and prefers cheap ground — using the existing terrain-aware `combat_grid` Dijkstra. **No new pathing code.**

Fixes #1269 (found during #1268 / #1255). Part of #1100 hygiene.

## Why

`greedy-v1`'s `_step_toward` and the retreat-if-low `combat_grid.reachable(...)` call did **not** pass `impassable`/`difficult`. On a walled grid fight, a v1-policy (or off-tactical) monster could step toward / into a blocked cell — the engine's `move_to_coords` then refuses, or the loop picks an illegal-looking step. The tactical-v2 layer (#1268) already routes terrain-aware, so the default LIVE path was covered; this closes the **v1 fallback**.

## Change

Both greedy-v1 movement sites in `servers/engine/combat_ai.py` now read the SAME authoritative `view.blocking` / `view.difficult` (`_build_view` already populates them for every fight from `combat.grid_impassable` / `combat.grid_difficult`, #1268) via the existing `_blocking_set` / `_difficult_set` helpers:

- **`_step_toward`** — passes `impassable`/`difficult` into `combat_grid.reachable`; when terrain exists, breaks distance ties by the terrain-aware **routed move cost** (same tie-break as tactical-v2's `_terrain_step_toward`).
- **retreat-if-low** — passes `impassable`/`difficult` into its `reachable` call so a fleeing monster can't disengage *through* a wall.

## Behavior note (bug fix, not byte-identical)

- **Open-floor fights (no walls / no difficult — both sets empty): BYTE-IDENTICAL.** The empty-set case degenerates to the flat-cost Dijkstra and the tie-break stays `(distance, cell)` exactly as before. A regression test recomputes the pre-fix flat-cost pick and asserts equality.
- **Walled fights: CHANGED** — from illegal-stepping (toward/into a blocked cell) to routed movement. That is the fix.

## Tests (red-first)

New `servers/engine/tests/test_combat_greedy_terrain.py` (6 cases; the 4 FIX cases were verified to **fail on pre-fix code**, the 2 byte-identical cases pass on both):

- v1 monster routes around a wall to reach its target (was: stepped toward/into an unreachable far-side cell)
- greedy never targets an unreachable cell behind a solid wall (falls back to Dodge)
- retreat-if-low flee cell respects walls
- difficult terrain avoided when a same-cost clear path exists
- open-floor move byte-identical to the pre-#1269 flat-cost pick (×2, incl. a spread of actor positions)

## Verification

- `tests/test_combat_greedy_terrain.py` — 6 passed (single-process `-p no:xdist`)
- combat suites (tactical / core / combat / obstacles / terrain / depth) — 292 passed
- **full engine suite** — 3357 passed
- `qa/fast_gate.sh` — PASS · `qa/combat_smoke.py` — OVERALL PASS
- `test_tool_schema_budget.py` — PASS (**schema delta 0**; no tool definitions touched)

Do NOT merge — orchestrator review.