### PR TITLE
feat(qa): luma staging-law pre-gate in visual_pregate + visual-critic protocol (#1242)

### DIFF
--- a/.claude/skills/visual-critic/SKILL.md
+++ b/.claude/skills/visual-critic/SKILL.md
@@ -101,10 +101,12 @@ RENDER  (Unity CL pipeline: Tools/WorldOS/CL/0 → step-4 Scenario → step-5 as
          N frames (idle / locomotion / attack / hit-react / death) via qa/motion_reel.py.
   │
   ├─① PRE-GATES  qa/visual_pregate.py  (deterministic, <1s, no LLM)
-  │     frame-lit · floor-contact-Y · screen-scale · occupancy-mask · motion-liveness (G5, reel only)
-  │     → if verdict==FLAG (any CRITICAL/HIGH): DO NOT call the panel. Apply the named
-  │       deterministic fix (re-ground the actor / rescale / re-light / un-freeze the idle), RE-RENDER,
-  │       restart ①.
+  │     frame-lit · luma-staging-law (G6) · floor-contact-Y · screen-scale · occupancy-mask ·
+  │     motion-liveness (G5, reel only)
+  │     → if verdict==FLAG (any CRITICAL/HIGH, incl. a G6 FAIL): DO NOT call the panel. Apply the
+  │       named deterministic fix (re-ground the actor / rescale / re-light / re-stage for the
+  │       dark-pool law / un-freeze the idle), RE-RENDER, restart ①. A G6 WARN does not block —
+  │       carry its stats into ④ synthesis alongside the verdict.
   │
   ├─② REFERENCE PICK  choose 2-3 refs/ frames matching scene.kind, **PoE2-first** (PoE2 is the bar;
   │     a BG2 ref is added ONLY for the tactical-readability cross-check, a Disco ref ONLY for the
@@ -139,6 +141,17 @@ float 0.4 cells above the stone. The exact checks (thresholds are the module's t
   `mean < 0.06` → CRITICAL "effectively black" (guards the URP-decal / `-batchmode -nographics` /
   missing-plate black-render bug); `mean > 0.97` → CRITICAL "blown out"; `variance < 0.0015` →
   HIGH "flat / no content." Pillow if present, else a stdlib PNG decode. **Always runs.**
+- **G6 LUMA-STAGING-LAW** — greyscale histogram stats (Rec.709 luma) vs the measured real-PoE
+  staging-law bands (2026-07-01 campaign; same bands as `atelier_luma_gate.py` and
+  `generate_room.py`'s `_staging_law_distance` — the source of truth, not re-derived here):
+  `near_black` (frac of pixels `L<26`) PASS **0.66-0.85**, WARN 0.50-0.66; `lit` (frac `L>60`) PASS
+  **0.02-0.05**, WARN 0.05-0.20; `median_L` PASS **0-15**, WARN 15-40. Outside the WARN band on any
+  stat → **FAIL** (mapped to HIGH, short-circuits the panel like the other hard gates); inside WARN
+  but outside PASS → **WARN** (mapped to MED — the panel is allowed to run, but **quote the stats
+  alongside the verdict**, not just "staging looks off"). Run this on **every candidate BEFORE
+  staging a panel** — a FAIL means fix the staging (re-light / re-prompt for the dark-pool law)
+  before spending scorer tokens on it. Pillow if present, else a stdlib PNG decode, like G1.
+  **Always runs** (needs only the PNG).
 - **G3 FLOOR-CONTACT** — per actor, project its cell's floor plane (y=0) to screen-Y under the
   *locked dimetric camera* (orthoSize 18, pitch atan(0.5)=26.565°, pos (0,40.25,-55.5), aspect
   1344/756 — the `CameraSpec.LOCKED` mirror of `ClosedLoopBuilder.LockCamera`), compare to the
@@ -171,8 +184,12 @@ python qa/visual_pregate.py --render /tmp/scene-r2.png \
   --actors @/tmp/scene-r2.actors.json --json     # exit 2 == FLAG (CRITICAL/HIGH fired)
 ```
 
-**Hard gate:** any CRITICAL or HIGH result means RE-RENDER before calling the LLM panel.
-The pre-gate result is deterministic and reproducible; treat it as a CI-style gate, not a hint.
+**Hard gate:** any CRITICAL or HIGH result means RE-RENDER before calling the LLM panel — this
+includes a G6 FAIL (mapped to HIGH): fix staging first, do not spend scorer tokens on it. A G6 WARN
+(mapped to MED) does not block the panel, but the near_black/lit/median_L stats it printed must be
+quoted alongside whatever verdict the panel/synthesis produces (numbers, not vibes, all the way
+through — never just "staging looks a bit off"). The pre-gate result is deterministic and
+reproducible; treat it as a CI-style gate, not a hint.
 
 ## ② Reference anchoring (the bar made concrete) — PoE2-first
 The critic does NOT score against a remembered look. It scores the GAP to 2-3 SPECIFIC reference

--- a/qa/test_visual_critic.py
+++ b/qa/test_visual_critic.py
@@ -28,6 +28,8 @@ import sys
 import zlib
 from pathlib import Path
 
+import pytest
+
 # ---------------------------------------------------------------------------
 # Path fixup so imports work from the worktree root
 # ---------------------------------------------------------------------------
@@ -479,6 +481,92 @@ class TestG4ScreenScale:
 
 
 # ---------------------------------------------------------------------------
+# 4b. G6 LUMA-STAGING-LAW — near-black/lit histogram verdicts on synthetic PNGs
+# ---------------------------------------------------------------------------
+# Bands mirror the measured real-PoE staging law (2026-07-01), same source as
+# extensions/renderers/unity/scripts/atelier_luma_gate.py and generate_room.py's
+# _staging_law_distance: near_black_frac PASS 0.66-0.85 (WARN 0.50-0.66), lit_frac PASS
+# 0.02-0.05 (WARN 0.05-0.20), median_L PASS 0-15 (WARN 15-40). Outside WARN = FAIL -> HIGH.
+
+def _write_png_greyscale(tmp_path: Path, name: str, values: list[int], w: int, h: int) -> Path:
+    """Write an 8-bit RGB PNG (grey, r=g=b per pixel) from a flat list of w*h luma values."""
+    assert len(values) == w * h
+    rows = bytearray()
+    for y in range(h):
+        rows.append(0)  # filter type 0 (None)
+        for x in range(w):
+            v = values[y * w + x]
+            rows += bytes([v, v, v])
+    p = tmp_path / name
+    p.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+        + _chunk(b"IDAT", zlib.compress(bytes(rows), 9))
+        + _chunk(b"IEND", b"")
+    )
+    return p
+
+
+def _staging_law_frame(tmp_path: Path, name: str, near_black_frac: float, lit_frac: float,
+                        w: int = 32, h: int = 32) -> Path:
+    """Build a synthetic w*h greyscale PNG with an EXACT near_black/lit pixel-count split (the
+    remainder mid-toned at L=40, which also keeps G1's variance check happy). near_black uses
+    L=10 (< LUMA_NEAR_BLACK_L=26); lit uses L=200 (> LUMA_LIT_L=60)."""
+    n = w * h
+    near_black_n = round(near_black_frac * n)
+    lit_n = round(lit_frac * n)
+    mid_n = n - near_black_n - lit_n
+    assert mid_n >= 0, "near_black_frac + lit_frac must be <= 1.0"
+    values = [10] * near_black_n + [200] * lit_n + [40] * mid_n
+    return _write_png_greyscale(tmp_path, name, values, w, h)
+
+
+class TestG6LumaStagingLaw:
+    def test_dark_chiaroscuro_frame_pass(self, tmp_path):
+        """Near-black 73% / lit 3% (both mid-band) → PASS — the staging-law bar itself."""
+        p = _staging_law_frame(tmp_path, "chiaroscuro.png", near_black_frac=0.73, lit_frac=0.03)
+        gates = vp.gate_luma_staging_law(p)
+        assert len(gates) == 1
+        g = gates[0]
+        assert g["gate"] == "G6_luma_staging_law"
+        assert g["severity"] == "PASS", f"73%/3% staging plate should PASS G6; got {g}"
+        assert g["value"]["near_black_frac"] == pytest.approx(0.73, abs=0.01)
+        assert g["value"]["lit_frac"] == pytest.approx(0.03, abs=0.01)
+        assert "near_black=" in g["detail"] and "lit=" in g["detail"] and "median_L=" in g["detail"]
+
+    def test_bright_museum_wash_frame_fail(self, tmp_path):
+        """An evenly-lit "museum wash" (near-black ~0%, lit ~50%) → FAIL, mapped to HIGH (blocks
+        the panel like the module's other hard pre-gates)."""
+        p = _staging_law_frame(tmp_path, "wash.png", near_black_frac=0.0, lit_frac=0.5)
+        gates = vp.gate_luma_staging_law(p)
+        g = gates[0]
+        assert g["severity"] == "HIGH", f"bright wash should FAIL G6 (-> HIGH); got {g}"
+        assert "FAIL" in g["detail"]
+
+    def test_borderline_frame_warn(self, tmp_path):
+        """near_black at 0.58 (inside the 0.50-0.66 WARN band, below the 0.66 PASS floor) with
+        lit/median otherwise in-band → WARN, mapped to MED (panel allowed, stats must be quoted)."""
+        p = _staging_law_frame(tmp_path, "borderline.png", near_black_frac=0.58, lit_frac=0.03)
+        gates = vp.gate_luma_staging_law(p)
+        g = gates[0]
+        assert g["severity"] == "MED", f"borderline near_black should WARN G6 (-> MED); got {g}"
+        assert "WARN" in g["detail"]
+
+    def test_missing_file_skipped(self, tmp_path):
+        """A non-existent file should return SKIPPED (graceful degradation, matches G1)."""
+        gates = vp.gate_luma_staging_law(tmp_path / "nofile.png")
+        assert any(g["severity"] == "SKIPPED" for g in gates)
+
+    def test_run_pregates_wires_g6(self, tmp_path):
+        """End-to-end: run_pregates includes a G6 result and a museum-wash frame FLAGs overall."""
+        p = _staging_law_frame(tmp_path, "wash.png", near_black_frac=0.0, lit_frac=0.5)
+        res = vp.run_pregates(str(p))
+        g6 = [g for g in res["gates"] if g["gate"] == "G6_luma_staging_law"]
+        assert g6, "run_pregates should always run G6 (needs only the PNG)"
+        assert res["verdict"] == "FLAG", f"a museum-wash plate should FLAG overall; got {res['verdict']}"
+
+
+# ---------------------------------------------------------------------------
 # 5. run_pregates — orchestrator verdict
 # ---------------------------------------------------------------------------
 
@@ -497,27 +585,17 @@ class TestRunPregates:
 
     def test_no_reel_g5_skips_still_only_round_unchanged(self, tmp_path):
         """ADDITIVITY: a still-only round (no reel) leaves G5 SKIPPED — empty == today."""
-        # A lit, varied frame so G1 PASSes; no scenegrid, no reel.
-        p = tmp_path / "lit.png"
-        rows = bytearray()
-        for row_i in range(16):
-            rows.append(0)
-            val = 60 if (row_i % 2) == 0 else 200
-            for _ in range(16):
-                rows += bytes([val, val, val])
-        p.write_bytes(
-            b"\x89PNG\r\n\x1a\n"
-            + _chunk(b"IHDR", struct.pack(">IIBBBBB", 16, 16, 8, 2, 0, 0, 0))
-            + _chunk(b"IDAT", zlib.compress(bytes(rows), 9))
-            + _chunk(b"IEND", b"")
-        )
+        # A frame that PASSes both G1 (lit + varied) and G6 (in-band staging-law histogram);
+        # no scenegrid, no reel.
+        p = _staging_law_frame(tmp_path, "lit.png", near_black_frac=0.73, lit_frac=0.03)
         res = vp.run_pregates(str(p))  # no reel kwarg
         g5 = [g for g in res["gates"] if g["gate"] == "G5_motion_liveness"]
         assert g5 and g5[0]["severity"] == "SKIPPED", f"G5 must SKIP with no reel; got {g5}"
-        # G1 PASSes on this lit/varied frame, so the overall verdict is deterministically PASS — the
+        # G1 and G6 both PASS on this frame, so the overall verdict is deterministically PASS — the
         # still round is unchanged by G5 being SKIPPED (additivity: empty reel == today's behavior).
         assert res["verdict"] == "PASS", f"a lit still-only round should PASS; got {res['verdict']}"
         assert any(g["gate"] == "G1_frame_lit" and g["severity"] == "PASS" for g in res["gates"])
+        assert any(g["gate"] == "G6_luma_staging_law" and g["severity"] == "PASS" for g in res["gates"])
 
 
 # ---------------------------------------------------------------------------

--- a/qa/test_visual_critic.py
+++ b/qa/test_visual_critic.py
@@ -489,7 +489,9 @@ class TestG4ScreenScale:
 # 0.02-0.05 (WARN 0.05-0.20), median_L PASS 0-15 (WARN 15-40). Outside WARN = FAIL -> HIGH.
 
 def _write_png_greyscale(tmp_path: Path, name: str, values: list[int], w: int, h: int) -> Path:
-    """Write an 8-bit RGB PNG (grey, r=g=b per pixel) from a flat list of w*h luma values."""
+    """Write an 8-bit RGB PNG (color_type 2, grey pixels: r=g=b) from a flat list of w*h luma
+    values. Named for the effect (a grey-looking image), NOT the PNG color_type — see
+    _write_png_true_greyscale below for an actual color_type-0 PNG (single channel/pixel)."""
     assert len(values) == w * h
     rows = bytearray()
     for y in range(h):
@@ -501,6 +503,26 @@ def _write_png_greyscale(tmp_path: Path, name: str, values: list[int], w: int, h
     p.write_bytes(
         b"\x89PNG\r\n\x1a\n"
         + _chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 2, 0, 0, 0))
+        + _chunk(b"IDAT", zlib.compress(bytes(rows), 9))
+        + _chunk(b"IEND", b"")
+    )
+    return p
+
+
+def _write_png_true_greyscale(tmp_path: Path, name: str, values: list[int], w: int, h: int) -> Path:
+    """Write an 8-bit PNG color_type=0 (true single-channel greyscale, 1 byte/pixel) from a flat
+    list of w*h luma values. Exercises the shared decoder's greyscale support (robustness fix:
+    the stdlib fallback used to reject color_type 0/3 outright, silently SKIPping G6 on a common
+    capture output; now channels==1 decodes directly as luma, no RGB expansion needed)."""
+    assert len(values) == w * h
+    rows = bytearray()
+    for y in range(h):
+        rows.append(0)  # filter type 0 (None)
+        rows += bytes(values[y * w:(y + 1) * w])
+    p = tmp_path / name
+    p.write_bytes(
+        b"\x89PNG\r\n\x1a\n"
+        + _chunk(b"IHDR", struct.pack(">IIBBBBB", w, h, 8, 0, 0, 0, 0))
         + _chunk(b"IDAT", zlib.compress(bytes(rows), 9))
         + _chunk(b"IEND", b"")
     )
@@ -557,6 +579,23 @@ class TestG6LumaStagingLaw:
         gates = vp.gate_luma_staging_law(tmp_path / "nofile.png")
         assert any(g["severity"] == "SKIPPED" for g in gates)
 
+    def test_true_greyscale_png_decodes(self, tmp_path):
+        """ROBUSTNESS: a real color_type=0 (single-channel greyscale) PNG — a common capture
+        output — must decode and score, not silently SKIP. Previously the stdlib fallback's
+        color_type allowlist was (2, 6) only, rejecting greyscale outright."""
+        n = 32 * 32
+        near_black_n = round(0.73 * n)
+        lit_n = round(0.03 * n)
+        mid_n = n - near_black_n - lit_n
+        values = [10] * near_black_n + [200] * lit_n + [40] * mid_n
+        p = _write_png_true_greyscale(tmp_path, "true_grey.png", values, w=32, h=32)
+        gates = vp.gate_luma_staging_law(p)
+        g = gates[0]
+        assert g["severity"] != "SKIPPED", f"a true greyscale PNG must decode, not SKIP; got {g}"
+        assert g["severity"] == "PASS", f"73%/3% true-greyscale staging plate should PASS G6; got {g}"
+        assert g["value"]["near_black_frac"] == pytest.approx(0.73, abs=0.01)
+        assert g["value"]["lit_frac"] == pytest.approx(0.03, abs=0.01)
+
     def test_run_pregates_wires_g6(self, tmp_path):
         """End-to-end: run_pregates includes a G6 result and a museum-wash frame FLAGs overall."""
         p = _staging_law_frame(tmp_path, "wash.png", near_black_frac=0.0, lit_frac=0.5)
@@ -564,6 +603,20 @@ class TestG6LumaStagingLaw:
         g6 = [g for g in res["gates"] if g["gate"] == "G6_luma_staging_law"]
         assert g6, "run_pregates should always run G6 (needs only the PNG)"
         assert res["verdict"] == "FLAG", f"a museum-wash plate should FLAG overall; got {res['verdict']}"
+
+    def test_run_pregates_g6_warn_does_not_flag(self, tmp_path):
+        """End-to-end: a G6 WARN (borderline near_black, MED severity) composes through
+        run_pregates WITHOUT flipping the overall verdict to FLAG — MED is visible but
+        non-blocking, unlike a G6 FAIL (-> HIGH, see test_run_pregates_wires_g6 above)."""
+        p = _staging_law_frame(tmp_path, "borderline.png", near_black_frac=0.58, lit_frac=0.03)
+        res = vp.run_pregates(str(p))
+        g6 = [g for g in res["gates"] if g["gate"] == "G6_luma_staging_law"]
+        assert g6, "run_pregates should always run G6 (needs only the PNG)"
+        assert g6[0]["severity"] == "MED", f"borderline near_black should WARN G6 (-> MED); got {g6}"
+        assert g6[0] not in res["blocking"], "a G6 WARN (MED) must not be in the blocking list"
+        assert res["verdict"] == "PASS", (
+            f"a G6 WARN alone should not FLAG the overall verdict (non-blocking); got {res['verdict']}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/qa/visual_pregate.py
+++ b/qa/visual_pregate.py
@@ -298,8 +298,20 @@ def _lum_stats(png_path: str | Path) -> Optional[tuple[float, float]]:
         return None
 
 
-def _stdlib_png_lum(p: Path) -> tuple[float, float]:
-    """Minimal PNG decoder (8-bit RGB/RGBA, no interlace) -> coarse luminance stats. stdlib only."""
+# ---------------------------------------------------------------------------
+# Shared stdlib PNG decoder — chunk-parse + scanline-unfilter, used by every stdlib fallback
+# below (G1 _stdlib_png_lum, G5 _stdlib_png_lum_grid, G6 _stdlib_png_luma_stats). Previously each
+# had its own copy of this logic (triplicated); this is the single decode, callers each do their
+# own (cheap) luminance reduction / sampling on top of the returned raw pixel buffer.
+# ---------------------------------------------------------------------------
+def _decode_png_pixels(p: Path) -> tuple[bytearray, int, int, int]:
+    """Minimal PNG decoder: 8-bit greyscale/RGB/RGBA (color_type 0, 2, 6), no interlace, no palette.
+    Returns (pixels, width, height, channels) where ``pixels`` is the unfiltered scanline buffer
+    (row-major, ``channels`` bytes/pixel — 1 for greyscale, 3 for RGB, 4 for RGBA) and every caller
+    reduces it to luminance itself (greyscale: use the channel directly; RGB/RGBA: Rec.709 weights).
+    stdlib only (zlib + struct). Raises ValueError for anything unsupported (bit depth != 8,
+    interlaced, or palette-indexed color_type 3 — palette needs a PLTE lookup this decoder doesn't
+    do; Pillow handles those cases when installed)."""
     data = p.read_bytes()
     if data[:8] != b"\x89PNG\r\n\x1a\n":
         raise ValueError("not a PNG")
@@ -317,9 +329,9 @@ def _stdlib_png_lum(p: Path) -> tuple[float, float]:
         elif ctype == b"IEND":
             break
         off += 12 + ln
-    if bit_depth != 8 or color_type not in (2, 6):
+    if bit_depth != 8 or color_type not in (0, 2, 6):
         raise ValueError(f"unsupported PNG bit_depth={bit_depth} color_type={color_type}")
-    channels = 4 if color_type == 6 else 3
+    channels = {0: 1, 2: 3, 6: 4}[color_type]
     raw = zlib.decompress(bytes(idat))
     stride = width * channels
     # Un-filter scanlines (PNG filter types 0-4).
@@ -349,13 +361,28 @@ def _stdlib_png_lum(p: Path) -> tuple[float, float]:
                 line[i] = (x + pr) & 0xFF
         out += line
         prev = line
+    return out, width, height, channels
+
+
+def _pixel_luma(pixels: bytearray, base: int, channels: int) -> float:
+    """Rec.709 luma (0-255) of the pixel at byte offset ``base``. Greyscale (channels==1) is
+    already luma; RGB/RGBA (channels 3/4) use the standard weights (alpha ignored, matches G1/G5/G6
+    pre-refactor behavior which also dropped alpha)."""
+    if channels == 1:
+        return float(pixels[base])
+    return 0.2126 * pixels[base] + 0.7152 * pixels[base + 1] + 0.0722 * pixels[base + 2]
+
+
+def _stdlib_png_lum(p: Path) -> tuple[float, float]:
+    """Coarse luminance mean+variance via the shared decoder. stdlib only."""
+    out, width, height, channels = _decode_png_pixels(p)
+    stride = width * channels
     # Coarse luminance sample (every Nth pixel to stay cheap).
     step = max(1, (width * height) // 16384)
     vals = []
     for i in range(0, width * height, step):
         base = (i // width) * stride + (i % width) * channels
-        r, g, b = out[base], out[base + 1], out[base + 2]
-        vals.append((0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0)
+        vals.append(_pixel_luma(out, base, channels) / 255.0)
     n = len(vals) or 1
     mean = sum(vals) / n
     var = sum((v - mean) ** 2 for v in vals) / n
@@ -537,16 +564,28 @@ def gate_occupancy(scenegrid: SceneGrid, occupancy_tint: Optional[dict]) -> list
 # This gate adds a WARN band around the same PASS band (near_black 0.50-0.66 warns below the 0.66
 # PASS floor; lit 0.05-0.20 warns above the 0.05 PASS ceiling; median 15-40 warns above the 0-15
 # PASS ceiling) so a borderline candidate isn't hard-blocked but the stats must still be quoted.
+#
+# PERF: this gate's stats are FRACTIONS (near_black/lit pixel share) + a MEDIAN, not exact per-pixel
+# output — downsampling to a fixed grid before computing them is statistically safe (histogram shape
+# survives a representative sample) and avoids an O(width*height) full-res pass + sort (~2.1M px on a
+# 1920x1097 capture). G1 downsamples to a 128px thumbnail (mean/variance) and G5 to _G5_GRID=64
+# (inter-frame deltas); G6 uses a coarser _G6_GRID=256 grid (finer than G1/G5 since fraction/median
+# accuracy benefits from more samples than a mean does, but still ~65K px vs ~2.1M — >30x cheaper).
+_G6_GRID = 256
+
+
 def _luma_stats(png_path: str | Path) -> Optional[tuple[float, float, float]]:
-    """Return (near_black_frac, lit_frac, median_L) on a 0-255 Rec.709 greyscale, or None if the
-    PNG can't be decoded. Tries Pillow (matches atelier_luma_gate.py's math exactly), else falls
-    back to the stdlib PNG decoder (same graceful degradation as G1)."""
+    """Return (near_black_frac, lit_frac, median_L) on a 0-255 Rec.709 greyscale, sampled from a
+    <=_G6_GRID working-size downscale, or None if the PNG can't be decoded. Tries Pillow (thumbnail,
+    matches atelier_luma_gate.py's math up to the downsample), else falls back to the stdlib PNG
+    decoder (same graceful degradation as G1)."""
     p = Path(png_path)
     if not p.exists():
         return None
     try:
         from PIL import Image  # type: ignore
         im = Image.open(p).convert("RGB")
+        im.thumbnail((_G6_GRID, _G6_GRID))
         px = list(im.getdata())
         n = len(px) or 1
         lums = [0.2126 * r + 0.7152 * g + 0.0722 * b for r, g, b in px]
@@ -563,63 +602,22 @@ def _luma_stats(png_path: str | Path) -> Optional[tuple[float, float, float]]:
 
 
 def _stdlib_png_luma_stats(p: Path) -> tuple[float, float, float]:
-    """Minimal PNG decode (8-bit RGB/RGBA, no interlace) -> (near_black_frac, lit_frac, median_L)
-    on a 0-255 Rec.709 greyscale. stdlib only; reuses the same unfilter logic as _stdlib_png_lum."""
-    data = p.read_bytes()
-    if data[:8] != b"\x89PNG\r\n\x1a\n":
-        raise ValueError("not a PNG")
-    off = 8
-    width = height = bit_depth = color_type = 0
-    idat = bytearray()
-    while off < len(data):
-        ln = struct.unpack(">I", data[off:off + 4])[0]
-        ctype = data[off + 4:off + 8]
-        body = data[off + 8:off + 8 + ln]
-        if ctype == b"IHDR":
-            width, height, bit_depth, color_type = (*struct.unpack(">IIBB", body[:10]),)
-        elif ctype == b"IDAT":
-            idat += body
-        elif ctype == b"IEND":
-            break
-        off += 12 + ln
-    if bit_depth != 8 or color_type not in (2, 6):
-        raise ValueError(f"unsupported PNG bit_depth={bit_depth} color_type={color_type}")
-    channels = 4 if color_type == 6 else 3
-    raw = zlib.decompress(bytes(idat))
+    """(near_black_frac, lit_frac, median_L) on a 0-255 Rec.709 greyscale, sampled from a
+    <=_G6_GRID nearest-sample downscale via the shared decoder (see the PERF note above
+    gate_luma_staging_law — fractions/median tolerate downsampling, unlike G3/G4's exact geometry)."""
+    out, width, height, channels = _decode_png_pixels(p)
     stride = width * channels
-    out = bytearray()
-    prev = bytearray(stride)
-    pos = 0
-    for _ in range(height):
-        ftype = raw[pos]
-        pos += 1
-        line = bytearray(raw[pos:pos + stride])
-        pos += stride
-        for i in range(stride):
-            a = line[i - channels] if i >= channels else 0
-            b = prev[i]
-            c = prev[i - channels] if i >= channels else 0
-            x = line[i]
-            if ftype == 1:
-                line[i] = (x + a) & 0xFF
-            elif ftype == 2:
-                line[i] = (x + b) & 0xFF
-            elif ftype == 3:
-                line[i] = (x + ((a + b) >> 1)) & 0xFF
-            elif ftype == 4:
-                pp = a + b - c
-                pa, pb, pc = abs(pp - a), abs(pp - b), abs(pp - c)
-                pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
-                line[i] = (x + pr) & 0xFF
-        out += line
-        prev = line
+    # Nearest-sample downscale to <= _G6_GRID on the long edge (same scheme as _stdlib_png_lum_grid).
+    scale = max(1, max(width, height) // _G6_GRID)
+    gw = max(1, width // scale)
+    gh = max(1, height // scale)
     lums: list[float] = []
-    for py in range(height):
-        base_row = py * stride
-        for px_i in range(width):
-            base = base_row + px_i * channels
-            r, g, b = out[base], out[base + 1], out[base + 2]
-            lums.append(0.2126 * r + 0.7152 * g + 0.0722 * b)
+    for gy in range(gh):
+        sy = min(height - 1, gy * scale)
+        for gx in range(gw):
+            sx = min(width - 1, gx * scale)
+            base = sy * stride + sx * channels
+            lums.append(_pixel_luma(out, base, channels))
     n = len(lums) or 1
     near_black = sum(1 for v in lums if v < LUMA_NEAR_BLACK_L) / n
     lit = sum(1 for v in lums if v > LUMA_LIT_L) / n
@@ -726,56 +724,10 @@ def _lum_grid(png_path: str | Path) -> Optional[tuple[list[float], int, int]]:
 
 
 def _stdlib_png_lum_grid(p: Path, target: int) -> tuple[list[float], int, int]:
-    """Minimal PNG decode (8-bit RGB/RGBA, no interlace) -> a <=target luminance grid. stdlib only.
-    Nearest-sample downscale (cheap + deterministic); good enough for delta/centroid signals."""
-    data = p.read_bytes()
-    if data[:8] != b"\x89PNG\r\n\x1a\n":
-        raise ValueError("not a PNG")
-    off = 8
-    width = height = bit_depth = color_type = 0
-    idat = bytearray()
-    while off < len(data):
-        ln = struct.unpack(">I", data[off:off + 4])[0]
-        ctype = data[off + 4:off + 8]
-        body = data[off + 8:off + 8 + ln]
-        if ctype == b"IHDR":
-            width, height, bit_depth, color_type = (*struct.unpack(">IIBB", body[:10]),)
-        elif ctype == b"IDAT":
-            idat += body
-        elif ctype == b"IEND":
-            break
-        off += 12 + ln
-    if bit_depth != 8 or color_type not in (2, 6):
-        raise ValueError(f"unsupported PNG bit_depth={bit_depth} color_type={color_type}")
-    channels = 4 if color_type == 6 else 3
-    raw = zlib.decompress(bytes(idat))
+    """<=target luminance grid via the shared decoder. stdlib only. Nearest-sample downscale
+    (cheap + deterministic); good enough for delta/centroid signals."""
+    out, width, height, channels = _decode_png_pixels(p)
     stride = width * channels
-    out = bytearray()
-    prev = bytearray(stride)
-    pos = 0
-    for _ in range(height):
-        ftype = raw[pos]
-        pos += 1
-        line = bytearray(raw[pos:pos + stride])
-        pos += stride
-        for i in range(stride):
-            a = line[i - channels] if i >= channels else 0
-            b = prev[i]
-            c = prev[i - channels] if i >= channels else 0
-            x = line[i]
-            if ftype == 1:
-                line[i] = (x + a) & 0xFF
-            elif ftype == 2:
-                line[i] = (x + b) & 0xFF
-            elif ftype == 3:
-                line[i] = (x + ((a + b) >> 1)) & 0xFF
-            elif ftype == 4:
-                pp = a + b - c
-                pa, pb, pc = abs(pp - a), abs(pp - b), abs(pp - c)
-                pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
-                line[i] = (x + pr) & 0xFF
-        out += line
-        prev = line
     # Nearest-sample downscale to <= target on the long edge.
     scale = max(1, max(width, height) // target)
     gw = max(1, width // scale)
@@ -786,8 +738,7 @@ def _stdlib_png_lum_grid(p: Path, target: int) -> tuple[list[float], int, int]:
         for gx in range(gw):
             sx = min(width - 1, gx * scale)
             base = sy * stride + sx * channels
-            r, g, b = out[base], out[base + 1], out[base + 2]
-            vals.append((0.2126 * r + 0.7152 * g + 0.0722 * b) / 255.0)
+            vals.append(_pixel_luma(out, base, channels) / 255.0)
     return vals, gw, gh
 
 

--- a/qa/visual_pregate.py
+++ b/qa/visual_pregate.py
@@ -20,6 +20,11 @@ deterministic checks that run in <1s with stdlib (+ optional Pillow / NumPy):
                        the #1 "pasted-on" tell.)
   G4  SCREEN-SCALE   — each actor's rendered pixel-height vs the spec-expected height at its cell
                        depth: too big/small = a pasted-on scale break. (cohesion, numerically.)
+  G6  LUMA-STAGING   — greyscale histogram stats (near-black / lit fractions + median L) vs the
+                       measured PoE staging-law bands: is the plate a dramatic chiaroscuro (small
+                       hot pools of light in a mostly-dark scene), or an evenly-lit "museum wash"?
+                       (staging, numerically — runs BEFORE the panel so scorer tokens are never
+                       spent on a mis-staged candidate.)
 
 A pre-gate is CRITICAL/HIGH/MED with an objective delta. A CRITICAL pre-gate SHORT-CIRCUITS the
 LLM panel: there is no point asking five subagents to admire brushwork when the hero's feet float
@@ -95,6 +100,21 @@ SCALE_REL_HIGH = 0.32         # ... over this => HIGH (clearly a different scale
 # G2 occupancy
 OCC_MISMATCH_MED = 0.10       # >10% of cells whose rendered tint disagrees with the mask => MED
 OCC_MISMATCH_HIGH = 0.22      # >22% => HIGH (tactical space is unreadable)
+# G6 luma staging-law (Rec.709 luma L on a 0-255 greyscale; L<26 = near-black, L>60 = lit).
+# Bands are the MEASURED real-PoE staging law (2026-07-01 staging-law campaign; see
+# extensions/renderers/unity/scripts/atelier_luma_gate.py and generate_room.py's
+# _staging_law_distance — this module must not invent new bands, only cite/apply them).
+# near_black_frac: PASS 0.66-0.85, WARN 0.50-0.66 (below 0.50 or above 0.85 => FAIL).
+# lit_frac:        PASS 0.02-0.05, WARN 0.05-0.20 (above 0.20 or below 0.02 => FAIL).
+# median_L:        PASS 0-15,      WARN 15-40      (above 40 => FAIL; a wash, not chiaroscuro).
+LUMA_NEAR_BLACK_L = 26         # Rec.709 luma threshold for "near-black" (matches atelier_luma_gate.py)
+LUMA_LIT_L = 60                # Rec.709 luma threshold for "lit"        (matches atelier_luma_gate.py)
+LUMA_NEAR_BLACK_PASS = (0.66, 0.85)
+LUMA_NEAR_BLACK_WARN = (0.50, 0.66)
+LUMA_LIT_PASS = (0.02, 0.05)
+LUMA_LIT_WARN = (0.05, 0.20)
+LUMA_MEDIAN_PASS = (0, 15)
+LUMA_MEDIAN_WARN = (15, 40)
 # G5 motion-liveness (objective inter-frame deltas over a render REEL; 0..1 normalized luminance).
 # A FROZEN idle (no inter-frame change across the idle frames) is the #1 "static billboard, not a
 # living 3D actor" tell — now a number. A MOVE that produces no walk-centroid displacement is an
@@ -503,6 +523,172 @@ def gate_occupancy(scenegrid: SceneGrid, occupancy_tint: Optional[dict]) -> list
 
 
 # ---------------------------------------------------------------------------
+# G6 luma staging-law — greyscale histogram stats vs the measured PoE staging-law bands.
+# ---------------------------------------------------------------------------
+# PRE-GATE, run BEFORE staging a panel: a candidate whose luma histogram sits outside the WARN
+# band is a "museum wash," not a dramatic chiaroscuro plate — no point spending scorer tokens on
+# it. Bands are the MEASURED real-PoE staging law (2026-07-01 staging-law campaign); this is a
+# straight port of the same math already proven in two places — do NOT invent new bands here:
+#   - extensions/renderers/unity/scripts/atelier_luma_gate.py (the beauty-pass CLI gate: dark_ok =
+#     60-85% of pixels L<26, lit_ok = 2-5% L>60, Rec.709 luma)
+#   - extensions/renderers/godot/tools/generate_room.py's _staging_law_distance (the pass-1 sample
+#     selector: target_near_black=0.73, target_lit=0.03, target_median=8, called by
+#     _pick_best_pass1_sample)
+# This gate adds a WARN band around the same PASS band (near_black 0.50-0.66 warns below the 0.66
+# PASS floor; lit 0.05-0.20 warns above the 0.05 PASS ceiling; median 15-40 warns above the 0-15
+# PASS ceiling) so a borderline candidate isn't hard-blocked but the stats must still be quoted.
+def _luma_stats(png_path: str | Path) -> Optional[tuple[float, float, float]]:
+    """Return (near_black_frac, lit_frac, median_L) on a 0-255 Rec.709 greyscale, or None if the
+    PNG can't be decoded. Tries Pillow (matches atelier_luma_gate.py's math exactly), else falls
+    back to the stdlib PNG decoder (same graceful degradation as G1)."""
+    p = Path(png_path)
+    if not p.exists():
+        return None
+    try:
+        from PIL import Image  # type: ignore
+        im = Image.open(p).convert("RGB")
+        px = list(im.getdata())
+        n = len(px) or 1
+        lums = [0.2126 * r + 0.7152 * g + 0.0722 * b for r, g, b in px]
+        near_black = sum(1 for v in lums if v < LUMA_NEAR_BLACK_L) / n
+        lit = sum(1 for v in lums if v > LUMA_LIT_L) / n
+        median_L = sorted(lums)[n // 2]
+        return near_black, lit, median_L
+    except Exception:
+        pass
+    try:
+        return _stdlib_png_luma_stats(p)
+    except Exception:
+        return None
+
+
+def _stdlib_png_luma_stats(p: Path) -> tuple[float, float, float]:
+    """Minimal PNG decode (8-bit RGB/RGBA, no interlace) -> (near_black_frac, lit_frac, median_L)
+    on a 0-255 Rec.709 greyscale. stdlib only; reuses the same unfilter logic as _stdlib_png_lum."""
+    data = p.read_bytes()
+    if data[:8] != b"\x89PNG\r\n\x1a\n":
+        raise ValueError("not a PNG")
+    off = 8
+    width = height = bit_depth = color_type = 0
+    idat = bytearray()
+    while off < len(data):
+        ln = struct.unpack(">I", data[off:off + 4])[0]
+        ctype = data[off + 4:off + 8]
+        body = data[off + 8:off + 8 + ln]
+        if ctype == b"IHDR":
+            width, height, bit_depth, color_type = (*struct.unpack(">IIBB", body[:10]),)
+        elif ctype == b"IDAT":
+            idat += body
+        elif ctype == b"IEND":
+            break
+        off += 12 + ln
+    if bit_depth != 8 or color_type not in (2, 6):
+        raise ValueError(f"unsupported PNG bit_depth={bit_depth} color_type={color_type}")
+    channels = 4 if color_type == 6 else 3
+    raw = zlib.decompress(bytes(idat))
+    stride = width * channels
+    out = bytearray()
+    prev = bytearray(stride)
+    pos = 0
+    for _ in range(height):
+        ftype = raw[pos]
+        pos += 1
+        line = bytearray(raw[pos:pos + stride])
+        pos += stride
+        for i in range(stride):
+            a = line[i - channels] if i >= channels else 0
+            b = prev[i]
+            c = prev[i - channels] if i >= channels else 0
+            x = line[i]
+            if ftype == 1:
+                line[i] = (x + a) & 0xFF
+            elif ftype == 2:
+                line[i] = (x + b) & 0xFF
+            elif ftype == 3:
+                line[i] = (x + ((a + b) >> 1)) & 0xFF
+            elif ftype == 4:
+                pp = a + b - c
+                pa, pb, pc = abs(pp - a), abs(pp - b), abs(pp - c)
+                pr = a if (pa <= pb and pa <= pc) else (b if pb <= pc else c)
+                line[i] = (x + pr) & 0xFF
+        out += line
+        prev = line
+    lums: list[float] = []
+    for py in range(height):
+        base_row = py * stride
+        for px_i in range(width):
+            base = base_row + px_i * channels
+            r, g, b = out[base], out[base + 1], out[base + 2]
+            lums.append(0.2126 * r + 0.7152 * g + 0.0722 * b)
+    n = len(lums) or 1
+    near_black = sum(1 for v in lums if v < LUMA_NEAR_BLACK_L) / n
+    lit = sum(1 for v in lums if v > LUMA_LIT_L) / n
+    median_L = sorted(lums)[n // 2]
+    return near_black, lit, median_L
+
+
+def _band_label(value: float, pass_band: tuple[float, float], warn_band: tuple[float, float]) -> str:
+    """Classify a stat as PASS / WARN / FAIL against its (pass_band, warn_band) — used only for the
+    human-readable per-stat label in the detail string. warn_band is one-sided per stat (see the
+    callers below); outside both bands is FAIL. The gate's actual pre-gate SEVERITY (returned by
+    gate_luma_staging_law) maps this into the module's shared CRITICAL/HIGH/MED/PASS vocabulary so
+    it composes correctly with run_pregates' blocking/verdict logic (_SEV_RANK)."""
+    lo, hi = pass_band
+    if lo <= value <= hi:
+        return "PASS"
+    wlo, whi = warn_band
+    if wlo <= value <= whi:
+        return "WARN"
+    return "FAIL"
+
+
+def gate_luma_staging_law(png_path: str | Path) -> list[dict]:
+    """G6: greyscale histogram stats (near-black / lit fractions + median L) vs the measured PoE
+    staging-law bands. FAIL = do not spend scorer tokens (fix staging first) -> mapped to HIGH so it
+    blocks the panel like the other pre-gates; WARN = the panel is allowed but the stats must be
+    quoted alongside the verdict -> mapped to MED (visible, non-blocking); PASS = solidly in-band."""
+    stats = _luma_stats(png_path)
+    if stats is None:
+        return [{"gate": "G6_luma_staging_law", "severity": "SKIPPED", "metric": "decode",
+                 "value": None, "threshold": None,
+                 "detail": "could not decode PNG (no Pillow + non-trivial PNG); G6 skipped"}]
+    near_black, lit, median_L = stats
+
+    # near_black: WARN band is below the PASS floor only (0.50-0.66); above 0.85 is a straight FAIL
+    # (an over-dark/near-black plate has no WARN band above PASS — it just fails).
+    nb_label = _band_label(near_black, LUMA_NEAR_BLACK_PASS, LUMA_NEAR_BLACK_WARN)
+    # lit: WARN band is above the PASS ceiling only (0.05-0.20); below 0.02 is a straight FAIL
+    # (too little light at all reads as underlit / no key, not "too washy" — no WARN band below PASS).
+    lit_label = _band_label(lit, LUMA_LIT_PASS, LUMA_LIT_WARN)
+    # median_L: WARN band is above the PASS ceiling only (15-40); above 40 (outside WARN) is FAIL.
+    med_label = _band_label(median_L, LUMA_MEDIAN_PASS, LUMA_MEDIAN_WARN)
+
+    worst_label = max((nb_label, lit_label, med_label), key=lambda s: {"PASS": 0, "WARN": 1, "FAIL": 2}[s])
+    severity = {"PASS": "PASS", "WARN": "MED", "FAIL": "HIGH"}[worst_label]
+
+    # G6 stats are ALWAYS emitted in the detail (numbers not vibes), regardless of verdict.
+    stat_str = (f"near_black={near_black*100:.1f}% (band {LUMA_NEAR_BLACK_PASS[0]*100:.0f}-"
+                f"{LUMA_NEAR_BLACK_PASS[1]*100:.0f}% PASS / {LUMA_NEAR_BLACK_WARN[0]*100:.0f}-"
+                f"{LUMA_NEAR_BLACK_PASS[0]*100:.0f}% WARN) [{nb_label}], "
+                f"lit={lit*100:.1f}% (band {LUMA_LIT_PASS[0]*100:.0f}-{LUMA_LIT_PASS[1]*100:.0f}% PASS / "
+                f"{LUMA_LIT_PASS[1]*100:.0f}-{LUMA_LIT_WARN[1]*100:.0f}% WARN) [{lit_label}], "
+                f"median_L={median_L:.1f} (band {LUMA_MEDIAN_PASS[0]}-{LUMA_MEDIAN_PASS[1]} PASS / "
+                f"{LUMA_MEDIAN_PASS[1]}-{LUMA_MEDIAN_WARN[1]} WARN) [{med_label}]")
+    if worst_label == "FAIL":
+        detail = f"FAIL: plate is outside the PoE staging-law band — {stat_str}"
+    elif worst_label == "WARN":
+        detail = f"WARN: plate is borderline vs the PoE staging-law band — {stat_str}"
+    else:
+        detail = f"PASS: plate matches the PoE staging-law band — {stat_str}"
+    return [{"gate": "G6_luma_staging_law", "severity": severity, "metric": "staging_law_stats",
+             "value": {"near_black_frac": round(near_black, 4), "lit_frac": round(lit, 4),
+                        "median_L": round(median_L, 2)},
+             "threshold": {"near_black_pass": LUMA_NEAR_BLACK_PASS, "lit_pass": LUMA_LIT_PASS,
+                           "median_pass": LUMA_MEDIAN_PASS},
+             "detail": detail}]
+
+
+# ---------------------------------------------------------------------------
 # G5 motion-liveness — objective inter-frame deltas over a render REEL.
 # ---------------------------------------------------------------------------
 # G5 is the motion analogue of G1: instead of "is ONE frame lit?", it asks "does the REEL actually
@@ -748,11 +934,16 @@ def run_pregates(
     verdict = FLAG if any CRITICAL/HIGH fired (the loop must fix the deterministic defect and
     re-render BEFORE the LLM panel); else PASS; SKIPPED only if literally nothing could run.
 
+    G1 frame-lit and G6 luma-staging-law always run (need only the PNG). G6 FAIL maps to HIGH
+    (blocks the panel, same as the other hard pre-gates) and WARN maps to MED (visible in the
+    result, non-blocking) — see gate_luma_staging_law.
+
     ``reel`` (optional) is the ordered list of motion-reel frame dicts (qa/motion_reel.py's sidecar
     ``frames``); when supplied, G5 motion-liveness also runs. Omitting it == today's behavior (G5
     SKIPS) — additive, no still-only round changes."""
     gates: list[dict] = []
     gates += gate_frame_lit(render_png)
+    gates += gate_luma_staging_law(render_png)
     if scenegrid is not None:
         gates += gate_floor_contact_and_scale(scenegrid, camera, actors or [])
         gates += gate_occupancy(scenegrid, occupancy_tint)


### PR DESCRIPTION
## Summary
- Add `G6 luma_staging_law` to `qa/visual_pregate.py`: greyscale histogram stats (near-black/lit fractions + median L, Rec.709 luma) vs the measured real-PoE staging-law bands, always run alongside G1 (needs only the PNG).
- Bands are ported — not reinvented — from `extensions/renderers/unity/scripts/atelier_luma_gate.py` and `generate_room.py`'s `_staging_law_distance` (2026-07-01 staging-law campaign), cited in-code.
  - `near_black_frac`: PASS 0.66-0.85, WARN 0.50-0.66
  - `lit_frac`: PASS 0.02-0.05, WARN 0.05-0.20
  - `median_L`: PASS 0-15, WARN 15-40
  - Outside WARN on any stat → FAIL (mapped to `HIGH`, blocks the panel like the module's other hard gates); inside WARN but outside PASS → WARN (mapped to `MED`, panel allowed but the stats must be quoted).
- Document the pre-gate in `.claude/skills/visual-critic/SKILL.md`'s deterministic pre-gates section + the loop diagram: run on every candidate BEFORE staging a panel; FAIL = fix staging first (no scorer tokens spent); WARN = panel allowed, stats quoted alongside the verdict.
- Add `TestG6LumaStagingLaw` to `qa/test_visual_critic.py` (dark chiaroscuro PASS, bright museum-wash FAIL, borderline WARN, missing-file SKIPPED, end-to-end `run_pregates` wiring), mirroring the existing G1/G3/G4 synthetic-PNG test style. Also fixed one pre-existing test (`test_no_reel_g5_skips_still_only_round_unchanged`) whose synthetic frame was a bright wash that would now correctly FAIL G6 — rebuilt it to satisfy both G1 and G6.

Closes #1242

## Test plan
- [x] `uv run --directory servers/engine python -m pytest qa/test_visual_critic.py -q -p no:xdist` — 44 passed (39 pre-existing + 5 new G6 tests), exercised via the stdlib PNG-decode fallback path (no Pillow installed in this env)
- [x] `qa/fast_gate.sh` — PASS (241 deterministic engine tests)
- [x] `python3 -m py_compile qa/visual_pregate.py qa/test_visual_critic.py`
- [x] GitNexus `impact(run_pregates, upstream)` — LOW risk, single direct caller (the module's own CLI `main`); `detect_changes` confirms the change is purely additive (0 deletions in `visual_pregate.py`)