### PR TITLE
feat(combat): surprise/ambush gate (#1271)

### DIFF
--- a/qa/BEHAVIORAL_GATE_TAXONOMY.json
+++ b/qa/BEHAVIORAL_GATE_TAXONOMY.json
@@ -92,6 +92,12 @@
       "retest": "bash qa/run_combat_sprint.sh sprint-retest",
       "hint": ">=3 attacks but start_combat never called — a fight ran entirely outside initiative, so turn-order/action-economy gates were inert. The engine surfaces a combat_not_active nudge per out-of-combat attack; reinforce 'call start_combat at the top of any real encounter' in the DM prompt. WARN only."
     },
+    "ambush_ran_surprise_gate": {
+      "category": "DM_ADHERENCE",
+      "likely_code_locations": ["skills/dungeon-master/reference/combat.md", "servers/engine/server.py"],
+      "retest": "bash qa/run_combat_sprint.sh sprint-retest",
+      "hint": "DM narration staged an ambush (lunge from the shadows / sprung trap / 'never saw it coming') but start_combat ran with no surprise evaluation — no surpriser_ids and no `surprise` key in the return — so the passive-Perception-vs-Stealth gate was skipped and the ambush had no mechanical effect (#1271). Reinforce 'pass surpriser_ids=[attacker id(s)] for any narrated ambush' in the DM combat runbook; the engine rolls Stealth vs passive Perception and applies SRD-5.2 initiative disadvantage to the surprised set. WARN only."
+    },
     "party_location_coherence": {
       "category": "ENGINE_INVARIANT",
       "likely_code_locations": ["servers/engine/travel.py", "servers/engine/server.py", "servers/engine/models.py"],

--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -112,6 +112,21 @@ _NARRATION_LEAK = [
 ]
 _NARRATION_LEAK_RE = [re.compile(p, re.I) for p in _NARRATION_LEAK]
 
+# AMBUSH SIGNALS (#1271) — DM narration that plainly stages a surprise attack. When these fire
+# but start_combat ran with NO surprise evaluation (no surpriser_ids passed, no `surprise` key
+# in any return), the fight skipped the passive-Perception-vs-Stealth gate entirely — the exact
+# "narrated an ambush but ran straight to initiative" omission #1271 was filed on. High-confidence,
+# ambush-only phrasings (a clean pitched-battle beat scores 0 and can never false-fire).
+_AMBUSH_SIGNAL = [
+    r"\b(?:lunge|lunges|leap|leaps|spring|springs|burst|bursts|strike|strikes) (?:out )?from the shadows\b",
+    r"\bfrom the shadows\b.{0,40}\b(?:attack|strike|lunge|pounce|ambush)\w*",
+    r"\bcatch(?:es)? (?:them|you|him|her|the \w+) (?:by surprise|off[- ]guard|unaware|flat[- ]footed)\b",
+    r"\bnever (?:saw|see|sees) (?:it|you|them|the \w+) coming\b",
+    r"\b(?:spring|springs|sprung|lay|laid|set|sets) (?:the |an |a )?(?:ambush|trap)\b",
+    r"\bambush(?:es|ed)?\b",
+]
+_AMBUSH_SIGNAL_RE = [re.compile(p, re.I) for p in _AMBUSH_SIGNAL]
+
 
 def _tool_events(events: list[dict]) -> list[tuple[str, dict, object, bool, str]]:
     """Ordered (short_name, input, result_obj_or_None, is_error, raw_text).
@@ -850,6 +865,32 @@ def main() -> int:
     evs = _tool_events(events)
     chars_all = state.get("characters", {}) or {}
     party_ids = state.get("party", []) or []
+
+    # AMBUSH-WITHOUT-SURPRISE-GATE (#1271, WARN). The DM narrated an ambush ("lunge from the
+    # shadows", a sprung trap, "never saw it coming") but start_combat ran with NO surprise
+    # evaluation — no surpriser_ids on any start_combat call AND no `surprise` key in any return —
+    # so the passive-Perception-vs-Stealth gate never ran and the ambush lost its mechanical teeth.
+    # Only meaningful when a fight actually STARTED (start_combat>0); a purely-narrative ambush the
+    # player talks/sneaks past never reaches combat and correctly does not fire. WARN, never fatal —
+    # an ambush-flavored word in prose is a soft signal, and the engine may legitimately find nobody
+    # was surprised (but then surpriser_ids WAS passed → `surprise` key present → this doesn't fire).
+    _sc_calls = [(inp, r) for (n, inp, r, err, _t) in evs if n == "start_combat" and not err]
+    if _sc_calls:
+        _ambush_narrated = any(
+            any(rx.search(t) for rx in _AMBUSH_SIGNAL_RE) for t in _dm_narration_texts(events)
+        )
+        _surprise_evaluated = any(
+            (inp.get("surpriser_ids") or (isinstance(r, dict) and r.get("surprise")))
+            for inp, r in _sc_calls
+        )
+        chk("ambush_ran_surprise_gate", not (_ambush_narrated and not _surprise_evaluated),
+            "DM narration staged an ambush but start_combat ran with no surprise evaluation "
+            "(no surpriser_ids, no `surprise` in the return) — the passive-Perception-vs-Stealth "
+            "gate was skipped, so the ambush had no mechanical effect. Pass "
+            "surpriser_ids=[the attacker id(s)] on start_combat for any narrated ambush; the engine "
+            "rolls Stealth vs passive Perception and applies SRD-5.2 initiative disadvantage to the "
+            "surprised set.",
+            fatal=False)
 
     def _quest_reward_already_awarded(q: dict) -> bool:
         return any(bool(q.get(k)) for k in ("milestone_awarded", "awarded", "rewarded", "xp_awarded"))

--- a/qa/test_assert_behavioral.py
+++ b/qa/test_assert_behavioral.py
@@ -1572,3 +1572,98 @@ def test_unresolved_spell_attack_not_fired_for_automated_spell(tmp_path):
     rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
     assert rc == 0, out
     assert "unresolved_spell_attack" not in out, out
+
+
+# ── ambush_ran_surprise_gate (WARN, #1271) ─────────────────────────────────────
+# The DM narrated an ambush but start_combat ran with no surprise evaluation (no
+# surpriser_ids, no `surprise` key in the return) — the passive-Perception-vs-Stealth
+# gate was skipped. WARN, never fatal. Fixtures run a COMPLETE clean fight (start →
+# attack → end_combat, foe dead) so only the ambush check is under test — every other
+# combat-integrity gate is satisfied and can't mask the result.
+
+def _assistant_text(text: str) -> dict:
+    return {"type": "assistant", "message": {"content": [{"type": "text", "text": text}]}}
+
+
+def _clean_fight(sc_input: dict, sc_result: dict) -> list[dict]:
+    """A start_combat (with the given input/result) + a resolving attack + end_combat, so the
+    combat_resolved / combat_ended / xp gates all pass and only the ambush check is exercised."""
+    return [
+        _assistant_tool_use("s1", "mcp__engine__start_combat", sc_input),
+        _user_tool_result("s1", json.dumps(sc_result)),
+        _assistant_tool_use("a1", "mcp__engine__attack", {"attacker_id": "pc1", "target_id": "m1"}),
+        _user_tool_result("a1", json.dumps({"hit": True, "damage": {"total": 12}})),
+        _assistant_tool_use("e1", "mcp__engine__end_combat", {}),
+        _user_tool_result("e1", json.dumps({"ok": True, "xp_awarded": 50})),
+    ]
+
+
+_FIGHT_STATE = {
+    "leveling_mode": "milestone",
+    "combat": {"active": False},
+    "party": ["pc1"],
+    "characters": {
+        "pc1": {"name": "Dal", "kind": "player", "current_hp": 18, "max_hp": 18},
+        "m1": {"name": "Bandit", "kind": "monster", "current_hp": 0, "dead": True},
+    },
+    "events": [],
+}
+
+
+def test_ambush_narrated_but_no_surprise_eval_warns(tmp_path):
+    """Ambush prose + start_combat WITHOUT surpriser_ids and no `surprise` key ⇒ WARN."""
+    events = [
+        _assistant_text("The bandits lunge from the shadows before anyone can react!"),
+        *_clean_fight({"combatant_ids": ["pc1", "m1"]},
+                      {"active": True, "order": [{"id": "pc1"}, {"id": "m1"}]}),
+    ]
+    rc, out = _run_gate(tmp_path, events, dict(_FIGHT_STATE))
+    assert rc == 0, out  # WARN, not RED
+    assert "[WARN] ambush_ran_surprise_gate" in out, out
+
+
+def test_ambush_with_surpriser_ids_passes(tmp_path):
+    """Ambush prose + start_combat WITH surpriser_ids ⇒ the gate ran; check PASSES."""
+    events = [
+        _assistant_text("They spring the ambush from the shadows!"),
+        *_clean_fight({"combatant_ids": ["pc1", "m1"], "surpriser_ids": ["m1"]},
+                      {"active": True, "surprise": {"surprisers": ["m1"], "surprised": ["pc1"]}}),
+    ]
+    rc, out = _run_gate(tmp_path, events, dict(_FIGHT_STATE))
+    assert rc == 0, out
+    assert "[WARN] ambush_ran_surprise_gate" not in out, out
+    assert "[PASS] ambush_ran_surprise_gate" in out, out
+
+
+def test_ambush_with_surprise_key_in_return_passes(tmp_path):
+    """Even without surpriser_ids in the input, a `surprise` key in the return proves the gate
+    ran (belt-and-suspenders) ⇒ the check PASSES."""
+    events = [
+        _assistant_text("An ambush! They never saw it coming."),
+        *_clean_fight({"combatant_ids": ["pc1", "m1"]},
+                      {"active": True, "surprise": {"surprisers": ["pc1"], "surprised": ["m1"]}}),
+    ]
+    rc, out = _run_gate(tmp_path, events, dict(_FIGHT_STATE))
+    assert rc == 0, out
+    assert "[WARN] ambush_ran_surprise_gate" not in out, out
+
+
+def test_no_ambush_prose_does_not_fire(tmp_path):
+    """A clean pitched-battle start_combat with no ambush prose ⇒ check PASSES (no false-WARN)."""
+    events = [
+        _assistant_text("The two lines close and steel meets steel in the open square."),
+        *_clean_fight({"combatant_ids": ["pc1", "m1"]},
+                      {"active": True, "order": [{"id": "pc1"}, {"id": "m1"}]}),
+    ]
+    rc, out = _run_gate(tmp_path, events, dict(_FIGHT_STATE))
+    assert rc == 0, out
+    assert "[WARN] ambush_ran_surprise_gate" not in out, out
+
+
+def test_ambush_prose_but_no_start_combat_does_not_fire(tmp_path):
+    """Ambush prose but the fight never started (talked/sneaked past) ⇒ the check is not even
+    registered (start_combat==0), so no WARN — it only fires when a fight actually began."""
+    events = [_assistant_text("They lunge from the shadows — but you slip away before the trap closes.")]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    assert "ambush_ran_surprise_gate" not in out, out

--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -4015,7 +4015,9 @@ def start_combat(
 ) -> dict:
     """Begin combat: roll initiative (1d20 + initiative_bonus) for each combatant
     and build the turn order (desc, ties broken by DEX modifier then input order).
-    Pass the character ids of everyone in the fight."""
+    Pass the character ids of everyone in the fight. For an ambush pass
+    surpriser_ids=[attackers]: the engine rolls Stealth vs passive Perception; the
+    surprised roll initiative with Disadvantage (SRD 5.2). See `surprise` in the return."""
     if not combatant_ids:
         raise ValueError("combatant_ids must be non-empty")
     surpriser_ids = [sid for sid in (surpriser_ids or []) if sid in combatant_ids]
@@ -4024,10 +4026,36 @@ def start_combat(
         if c.combat.active:
             raise ValueError("combat already active; call end_combat first")
         c.last_combat_resolution = ""  # a fresh fight -> any prior disposition no longer applies
+        # #1271 surprise gate: when the DM passes the ambushers (surpriser_ids), the engine
+        # DETERMINES who is surprised — each non-surpriser whose passive Perception (10 +
+        # Perception skill mod) is beaten by the BEST surpriser's engine-rolled Stealth check
+        # (1d20 + stealth mod) failed to notice the ambush. Those defenders are surprised. Per
+        # SRD 5.2 (data/srd/srd524/Rule.json, Rule[19] "**Surprise.**": "that combatant has
+        # Disadvantage on their Initiative roll") the 5.2 model is initiative DISADVANTAGE — NOT
+        # the 2014 lost-turn — so the engine rolls the surprised set's initiative with
+        # disadvantage. Purely additive: no surpriser_ids -> empty surprised set -> byte-identical
+        # to today's roll. "Engine rolls; the DM is told" — the result surfaces in view["surprise"].
+        surprised_ids: list[str] = []
+        surprise_detail: dict = {}
+        if surpriser_ids:
+            best_stealth = None
+            for sid in surpriser_ids:
+                sr = dice_mod.roll(f"1d20+{_char(c, sid).skill_bonus('stealth')}").total
+                if best_stealth is None or sr > best_stealth:
+                    best_stealth = sr
+            for cid in combatant_ids:
+                if cid in surpriser_ids:
+                    continue
+                passive_perc = 10 + _char(c, cid).skill_bonus("perception")
+                if best_stealth is not None and best_stealth > passive_perc:
+                    surprised_ids.append(cid)
+            surprise_detail = {"stealth": best_stealth}
+        surprised_set = set(surprised_ids)
         rolled = []
         for cid in combatant_ids:
             ch = _char(c, cid)
-            r = dice_mod.roll(f"1d20+{ch.initiative_bonus}")
+            # SRD 5.2: a surprised combatant rolls Initiative with Disadvantage.
+            r = dice_mod.roll(f"1d20+{ch.initiative_bonus}", disadvantage=cid in surprised_set)
             rolled.append((cid, r.total, ch.ability_modifier(Ability.DEX)))
         indexed = sorted(enumerate(rolled), key=lambda t: (-t[1][1], -t[1][2], t[0]))
         # Surprise ordering: surprisers go first (in their relative rolled order),
@@ -4065,12 +4093,23 @@ def start_combat(
             surpriser_names = [
                 c.characters[sid].name for sid in surpriser_ids if sid in c.characters
             ]
+            # #1271: the engine-determined surprised set (defenders who failed passive
+            # Perception vs the surprisers' Stealth) rolled initiative with disadvantage per
+            # SRD 5.2; surface who they are so the DM narrates the ambush landing.
+            surprised_names = [
+                c.characters[sid].name for sid in surprised_ids if sid in c.characters
+            ]
             view["surprise"] = {
                 "surprisers": surpriser_ids,
                 "surpriser_names": surpriser_names,
+                "surprised": surprised_ids,
+                "surprised_names": surprised_names,
+                "stealth_check": surprise_detail.get("stealth"),
                 "note": (
                     "opening attack has advantage; the target's AC still applies — "
-                    "call attack(advantage=True) for the opener. NO auto-kill."
+                    "call attack(advantage=True) for the opener. NO auto-kill. Surprised "
+                    "defenders (Stealth beat their passive Perception) rolled Initiative "
+                    "with Disadvantage per SRD 5.2 — narrate the ambush catching them flat-footed."
                 ),
             }
         # Reminder: surface anyone with Extra Attack so the DM makes the right number of attacks

--- a/servers/engine/tests/test_combat.py
+++ b/servers/engine/tests/test_combat.py
@@ -915,6 +915,150 @@ def test_start_combat_unknown_surpriser_id_is_skipped_gracefully(tmp_path, monke
     assert "surprise" not in view
 
 
+# =========================================================================
+# #1271: surprise GATE — engine rolls Stealth vs passive Perception and applies
+# the SRD-5.2 effect (Disadvantage on the surprised set's Initiative roll).
+# SRD source: data/srd/srd524/Rule.json, Rule[19] "**Surprise.**": "If a combatant
+# is surprised by combat starting, that combatant has Disadvantage on their Initiative
+# roll." (5.2 = initiative disadvantage, NOT the 2014 lost-turn model.)
+# =========================================================================
+
+
+def _rig_surprise_rolls(monkeypatch, server, stealth_total):
+    """Deterministic-roll harness for the surprise gate. start_combat rolls Stealth for each
+    surpriser FIRST (before the initiative loop), so the first N `1d20` rolls are the surprisers'
+    Stealth checks (forced to `stealth_total`) and the rest are initiative rolls. Records every
+    (expression, disadvantage) pair so a test can assert which initiative rolls carried
+    Disadvantage. One surpriser per fixture below ⇒ the FIRST roll is the Stealth check."""
+    calls: list[tuple[str, bool]] = []
+    state = {"stealth_rolls_left": 1}  # fixtures use exactly one surpriser
+    _orig = server.dice_mod.roll
+
+    def _rigged(expression, **kwargs):
+        calls.append((expression, bool(kwargs.get("disadvantage"))))
+        if state["stealth_rolls_left"] > 0:
+            state["stealth_rolls_left"] -= 1
+            return DiceRoll(expression=expression, total=stealth_total,
+                            rolls=[stealth_total], is_d20=True, natural=20)
+        return _orig(expression, **kwargs)
+
+    monkeypatch.setattr(server.dice_mod, "roll", _rigged)
+    return calls
+
+
+def _init_calls(calls):
+    """The initiative rolls = every recorded 1d20 roll AFTER the leading Stealth roll(s)."""
+    return calls[1:]  # one surpriser ⇒ drop the single leading Stealth check
+
+
+def test_start_combat_surprised_set_from_stealth_vs_passive_perception(tmp_path, monkeypatch):
+    """The engine determines the surprised set: a defender whose passive Perception is beaten
+    by the surpriser's Stealth check is surprised; a keen-eyed defender is NOT."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Surprise Gate Test")["id"]
+    attacker = server.create_character(cid, "Ambusher", kind="player", max_hp=10)["id"]
+    # Oblivious: WIS 10 → passive Perception 10 < 25 (the forced Stealth) ⇒ surprised.
+    oblivious = server.create_character(
+        cid, "Oblivious", kind="monster", max_hp=10,
+        abilities={"str": 10, "dex": 10, "con": 10, "int": 10, "wis": 10, "cha": 10},
+    )["id"]
+    # Keen-eyed: WIS 40 (mod +15) → passive Perception 25; 25 is NOT > 25 ⇒ NOT surprised
+    # (the surpriser must strictly BEAT passive Perception).
+    keen = server.create_character(
+        cid, "Keen", kind="monster", max_hp=10,
+        abilities={"str": 10, "dex": 10, "con": 10, "int": 10, "wis": 40, "cha": 10},
+    )["id"]
+
+    _rig_surprise_rolls(monkeypatch, server, stealth_total=25)
+
+    view = server.start_combat(cid, [attacker, oblivious, keen], surpriser_ids=[attacker])
+
+    assert "surprise" in view
+    surprised = set(view["surprise"]["surprised"])
+    assert oblivious in surprised, "low-passive-Perception defender must be surprised"
+    assert keen not in surprised, "keen-eyed defender (passive Perception >= Stealth) is NOT surprised"
+    assert attacker not in surprised, "the surpriser is never in the surprised set"
+    assert view["surprise"]["stealth_check"] == 25
+
+
+def test_start_combat_surprised_rolls_initiative_with_disadvantage_srd52(tmp_path, monkeypatch):
+    """SRD 5.2 effect: the surprised combatant's Initiative is rolled with Disadvantage; the
+    surpriser's roll is NOT.
+
+    Cite: data/srd/srd524/Rule.json Rule[19] '**Surprise.** ... that combatant has Disadvantage
+    on their Initiative roll.' (This asserts the 5.2 model the repo data encodes — initiative
+    disadvantage — NOT a 2014-style lost turn.)"""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Surprise Disadv Test")["id"]
+    attacker = server.create_character(cid, "Ambusher", kind="player", max_hp=10)["id"]
+    oblivious = server.create_character(
+        cid, "Oblivious", kind="monster", max_hp=10,
+        abilities={"str": 10, "dex": 10, "con": 10, "int": 10, "wis": 10, "cha": 10},
+    )["id"]
+
+    calls = _rig_surprise_rolls(monkeypatch, server, stealth_total=25)
+
+    server.start_combat(cid, [attacker, oblivious], surpriser_ids=[attacker])
+
+    init = _init_calls(calls)
+    disadvantaged = [e for (e, dis) in init if dis]
+    not_disadvantaged = [e for (e, dis) in init if not dis]
+    assert len(disadvantaged) == 1, f"exactly the surprised set rolls with disadvantage: {init}"
+    assert len(not_disadvantaged) == 1, "the surpriser rolls initiative normally (no disadvantage)"
+
+
+def test_start_combat_surpriser_ids_but_nobody_surprised(tmp_path, monkeypatch):
+    """surpriser_ids passed but the Stealth check fails to beat every defender's passive
+    Perception ⇒ empty surprised set, no initiative rolled with disadvantage, but the
+    `surprise` key is still present (surprisers were declared)."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("Nobody Surprised Test")["id"]
+    attacker = server.create_character(cid, "Ambusher", kind="player", max_hp=10)["id"]
+    keen = server.create_character(
+        cid, "Keen", kind="monster", max_hp=10,
+        abilities={"str": 10, "dex": 10, "con": 10, "int": 10, "wis": 40, "cha": 10},
+    )["id"]
+
+    calls = _rig_surprise_rolls(monkeypatch, server, stealth_total=5)  # a whiffed Stealth check
+
+    view = server.start_combat(cid, [attacker, keen], surpriser_ids=[attacker])
+
+    assert view["surprise"]["surprised"] == [], "no defender beaten ⇒ empty surprised set"
+    assert not any(dis for (_e, dis) in _init_calls(calls)), \
+        "nobody surprised ⇒ no disadvantaged initiative roll"
+
+
+def test_start_combat_no_surpriser_ids_no_disadvantage_byte_identical(tmp_path, monkeypatch):
+    """The default (no surpriser_ids) path rolls ZERO initiative with disadvantage and surfaces
+    no `surprise` key — byte-identical to today's behaviour."""
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(tmp_path))
+    import server
+
+    cid = server.create_campaign("No Surprise Byte-Identical")["id"]
+    a = server.create_character(cid, "A", kind="player", max_hp=10)["id"]
+    b = server.create_character(cid, "B", kind="monster", max_hp=10)["id"]
+
+    calls: list[tuple[str, bool]] = []
+    _orig = server.dice_mod.roll
+
+    def _rec(expression, **kwargs):
+        calls.append((expression, bool(kwargs.get("disadvantage"))))
+        return _orig(expression, **kwargs)
+
+    monkeypatch.setattr(server.dice_mod, "roll", _rec)
+
+    view = server.start_combat(cid, [a, b])
+
+    assert "surprise" not in view
+    assert not any(dis for (_e, dis) in calls), "no surpriser_ids ⇒ no disadvantaged roll (unchanged)"
+
+
 # --- monster_combat surfacing (issue #157: Bandit Captain Multiattack) ---------
 
 

--- a/skills/dungeon-master/reference/combat.md
+++ b/skills/dungeon-master/reference/combat.md
@@ -60,11 +60,13 @@ This is **not** "every tense scene is a brawl." A parley, a threat the player *t
 
 ## SURPRISE / combat-initiation mechanics — ambushes, betrayals, attacks on unready targets
 
-When a player or companion **declares an attack on an unready or non-hostile target** — an ambush opener, a betrayal, an attack on a guard who hasn't drawn — do **NOT** narrate the outcome. Treat it as combat initiation with a surprise edge:
+When a player or companion **declares an attack on an unready or non-hostile target** — an ambush opener, a betrayal, an attack on a guard who hasn't drawn — OR the fiction plainly stages an ambush ("they lunge from the shadows", "the patrol never sees you coming", a laid trap sprung) — do **NOT** narrate the outcome and do **NOT** run straight to a flat initiative. Treat it as combat initiation with a surprise edge and let the ENGINE adjudicate who is caught off guard:
 
-1. **Call `start_combat([...all combatants...], surpriser_ids=[the attacker's id])`.**  The surpriser(s) are placed FIRST in the turn order (they struck before anyone could react). The return carries a `surprise` key confirming this.
+1. **Call `start_combat([...all combatants...], surpriser_ids=[the attacker id(s)])`.**  The surpriser(s) are placed FIRST in the turn order. **The engine now runs the surprise gate for you** — it rolls each surpriser's **Stealth vs each defender's passive Perception** and, per **SRD 5.2**, rolls the *surprised* defenders' initiative with **Disadvantage** (5.2's surprise = initiative disadvantage, NOT a lost 2014-style turn). The return's `surprise` key lists `surprised` / `surprised_names` (who failed to notice) and the `stealth_check` that beat them — narrate the ambush landing on exactly those defenders.
 2. **Resolve the opener with `attack(advantage=True)`** — surprise = going first + advantage; the target's AC still applies and the attack can miss. **NO auto-kill, no narrative "they didn't stand a chance".** Let the dice speak.
-3. **Continue through normal initiative** for all subsequent turns. The surprise edge was the first-turn advantage; from round 2 onward everyone acts in rolled order.
+3. **Continue through normal initiative** for all subsequent turns. The surprise edge was the first-turn advantage + the surprised set's initiative disadvantage; from round 2 onward everyone acts in rolled order.
+
+**Always pass `surpriser_ids` when the fiction is an ambush** — if you narrated "they strike from the shadows" but called `start_combat` with no `surpriser_ids`, you skipped the passive-Perception-vs-Stealth check entirely and robbed the ambush of its mechanical teeth (the exact omission #1271 was filed on). An unclear case (was anyone actually hidden?) is still a surpriser call — the engine rolls it out and may find nobody was surprised, which is the correct, deterministic answer.
 
 This is also the **companion BETRAYAL opener** (issue #142): when `check_companion_arc` fires an agenda betrayal and the companion's move is `[attack]`, use this same path — `start_combat` with `surpriser_ids=[companion_id]`, then `attack(advantage=True)` for the opening blow. The engine makes the treachery real; you dramatize the fallout.
 


### PR DESCRIPTION
Closes #1271.

## What
A pre-combat **surprise gate**: when the DM calls `start_combat` with `surpriser_ids=[the attackers]`, the engine now **determines who is surprised** (engine-rolled Stealth vs each defender's passive Perception) and applies the **SRD-5.2 effect** to that set. The DM is told the result and narrates.

## Which SRD model was found + implemented
The repo's SRD data encodes the **2024/5.2 model**, NOT 2014. Verified in source:

> `data/srd/srd524/Rule.json`, Rule[19] `**Surprise.**`: *"If a combatant is surprised by combat starting, that combatant has **Disadvantage on their Initiative roll**. For example, if an ambusher starts combat while hidden from a foe who is unaware that combat is starting, that foe is surprised."*

So the mechanical effect implemented is **Disadvantage on the surprised set's Initiative roll** — NOT a lost 2014-style first turn (per the Angry-DM edition-false-positives lesson: do not import 2014 semantics when the repo data is 5.2). Tests assert THIS model with a comment citing the source line.

## Surprise determination (engine-computed, "engine rolls, DM narrates")
- The engine rolls each surpriser's **Stealth** (`1d20 + stealth mod`) and takes the best.
- Each non-surpriser whose **passive Perception** (`10 + Perception skill mod`) is strictly **beaten** by that Stealth check is **surprised**.
- The surprised set rolls initiative with **disadvantage** (`dice.roll(..., disadvantage=True)`).
- The set + the stealth check surface under `view["surprise"]` (`surprised`, `surprised_names`, `stealth_check`) for the DM to narrate. Not persisted; old snapshots round-trip.

## Tool surface + schema delta
**Zero new params / zero new tools** — reuses the EXISTING `surpriser_ids` on `start_combat`. The only wire-schema growth is the tool description (docstring): **119,126 → 119,319 bytes (+193 B)**, all description text, well under the 120 KB `alwaysLoad` budget (`test_tool_schema_budget.py` green). This is ~43 B over the ~150 B soft target flagged in the dispatch packet — the sentence is load-bearing (the DM must know `surpriser_ids` now triggers an engine Stealth/Perception roll, not the old advantage-only flavor).

## Additivity
No `surpriser_ids` == today, **byte-identical**: empty surprised set, zero initiative rolls with disadvantage, no `surprise` key. Backward-compatible with the existing "surprisers act first + `attack(advantage=True)` opener" affordance (#153) — that ordering + advantage edge is preserved; this ADDS the 5.2 initiative-disadvantage mechanic on top.

## DM nudge + behavioral WARN
- **`skills/dungeon-master/reference/combat.md`** — the SURPRISE section now tells the DM the engine runs the passive-Perception-vs-Stealth gate and to ALWAYS pass `surpriser_ids` for any narrated ambush (the exact omission #1271 was filed on: "narrated an ambush but ran straight to initiative").
- **`qa/assert_behavioral.py`** — new WARN `ambush_ran_surprise_gate`: fires when DM narration stages an ambush (lunge-from-the-shadows / sprung trap / "never saw it coming") but `start_combat` ran with no surprise evaluation (no `surpriser_ids`, no `surprise` in the return). WARN-only, null/scope-guarded (only when a fight actually started). Taxonomy entry added; the drift test (`test_taxonomy_matches_real_gate_check_names`) is green.

## Tests (red-first)
- `servers/engine/tests/test_combat.py` (+5): surprised set from Stealth-vs-passive-Perception; **initiative rolled with Disadvantage** (5.2, source-cited); surpriser_ids-but-nobody-surprised; no-surpriser byte-identical (zero disadvantaged rolls).
- `qa/test_assert_behavioral.py` (+5): WARN fires on ambush-without-eval; passes with `surpriser_ids`; passes with `surprise` in return; no false-fire on pitched-battle prose; not registered when no fight started.

## Verification (all green, single-process)
- `tests/test_combat*.py` — 237 passed
- behavioral + taxonomy suites — 140 passed
- `test_tool_schema_budget.py` — 2 passed
- `qa/fast_gate.sh` (Tier 0) — 245 passed ✅
- **full engine suite** — **3355 passed** (0 failures)