### PR TITLE
fix(qa): add Linux credential fallback to score.sh scorer auth

### DIFF
--- a/qa/score.sh
+++ b/qa/score.sh
@@ -143,11 +143,19 @@ while [ "$attempt" -lt 3 ]; do
   # Respects CLAUDE_CONFIG_DIR if the caller already points it somewhere non-default. This
   # branch never fires on Darwin (Keychain branch above wins there) and is a no-op if the
   # file is absent — falls through to the existing "Not logged in" retry/failure path.
+  #
+  # NOTE (CodeRabbit, PR #1279): gating derivation on ANTHROPIC_API_KEY being UNSET in the
+  # parent shell is wrong — the child invocation below unconditionally strips
+  # ANTHROPIC_API_KEY via `env -u ANTHROPIC_API_KEY` regardless of what the parent had. If a
+  # caller's shell happens to export ANTHROPIC_API_KEY (common on a shared VM), the old gate
+  # skipped derivation, the key was stripped anyway, and the child got NO auth at all — the
+  # exact "Not logged in" failure this fix exists to solve. Derivation must only be gated on
+  # whether we already HAVE a token (first clause), not on an env var the child never sees.
   _scorer_tok="${CLAUDE_CODE_OAUTH_TOKEN:-}"
-  if [ -z "$_scorer_tok" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] && [ "$(uname)" = "Darwin" ]; then
+  if [ -z "$_scorer_tok" ] && [ "$(uname)" = "Darwin" ]; then
     _scorer_tok="$(security find-generic-password -s 'Claude Code-credentials' -a "$USER" -w 2>/dev/null \
       | python3 -c 'import json,sys;print(json.load(sys.stdin).get("claudeAiOauth",{}).get("accessToken",""))' 2>/dev/null || true)"
-  elif [ -z "$_scorer_tok" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] && [ "$(uname)" != "Darwin" ]; then
+  elif [ -z "$_scorer_tok" ] && [ "$(uname)" != "Darwin" ]; then
     _scorer_creds_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json"
     if [ -s "$_scorer_creds_file" ]; then
       _scorer_tok="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("claudeAiOauth",{}).get("accessToken",""))' "$_scorer_creds_file" 2>/dev/null || true)"

--- a/qa/score.sh
+++ b/qa/score.sh
@@ -136,10 +136,22 @@ while [ "$attempt" -lt 3 ]; do
   # runner's auth block uses; measured to produce valid scorecards). The token is passed
   # via the child env only — never printed, never written. A caller-provided
   # CLAUDE_CODE_OAUTH_TOKEN / ANTHROPIC_API_KEY still wins (first clause).
+  # Linux fallback (VM sweep hosts, #1264/#1266 follow-up): there is no Keychain on Linux —
+  # login state instead lives in a plain ~/.claude/.credentials.json (the CLI writes it there
+  # after `claude login`/token refresh). Same shape as the Keychain blob
+  # ({"claudeAiOauth":{"accessToken":...}}), so reuse the identical jq/python extraction.
+  # Respects CLAUDE_CONFIG_DIR if the caller already points it somewhere non-default. This
+  # branch never fires on Darwin (Keychain branch above wins there) and is a no-op if the
+  # file is absent — falls through to the existing "Not logged in" retry/failure path.
   _scorer_tok="${CLAUDE_CODE_OAUTH_TOKEN:-}"
   if [ -z "$_scorer_tok" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] && [ "$(uname)" = "Darwin" ]; then
     _scorer_tok="$(security find-generic-password -s 'Claude Code-credentials' -a "$USER" -w 2>/dev/null \
       | python3 -c 'import json,sys;print(json.load(sys.stdin).get("claudeAiOauth",{}).get("accessToken",""))' 2>/dev/null || true)"
+  elif [ -z "$_scorer_tok" ] && [ -z "${ANTHROPIC_API_KEY:-}" ] && [ "$(uname)" != "Darwin" ]; then
+    _scorer_creds_file="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json"
+    if [ -s "$_scorer_creds_file" ]; then
+      _scorer_tok="$(python3 -c 'import json,sys;print(json.load(open(sys.argv[1])).get("claudeAiOauth",{}).get("accessToken",""))' "$_scorer_creds_file" 2>/dev/null || true)"
+    fi
   fi
   printf '%s' "$INPUT" | env -u ANTHROPIC_BASE_URL -u ANTHROPIC_API_KEY -u ANTHROPIC_AUTH_TOKEN \
     -u API_TIMEOUT_MS \


### PR DESCRIPTION
## Summary
- The #1260-chain isolated-`CLAUDE_CONFIG_DIR` scorer-auth fix (#1264/#1266) derived `CLAUDE_CODE_OAUTH_TOKEN` from the macOS Keychain only.
- On Linux (VM sweep hosts), there is no Keychain — login state lives in `~/.claude/.credentials.json` instead — so every scorer call there returns `"Not logged in"` and every run comes back `unscorable`.
- Discovered during VM 5-persona sweep preflight at frozen SHA `bed84ca7525c037364a069cb10a9cdaf064bf5dc`: engine/DM ran clean (22/22 behavioral assertions green), but all 3 scoring lenses failed auth.

## Change
Adds an `elif` branch in `qa/score.sh` that reads the same `claudeAiOauth.accessToken` shape from `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.credentials.json` when `uname != Darwin`. Byte-identical on macOS (existing Keychain branch still wins there); a no-op if the file is absent (falls through to the existing retry/failure path unchanged).

## Test plan
- [x] `bash -n qa/score.sh` — syntax valid
- [ ] Re-run `WORLDOS_SCORE_GUARD_ONLY=1 bash qa/score.sh` guard-only probe on the VM at this branch
- [ ] Re-run `qa/run_duo.sh vmsmoke-rri` smoke on the VM — confirm all 3 lenses produce valid scorecards (not `unscorable`)
- [ ] CI green