### PR TITLE
feat(combat-ui): cross-door affordance gating + tests (#1292)

### DIFF
--- a/viewer/openworlds/screen-combat.jsx
+++ b/viewer/openworlds/screen-combat.jsx
@@ -155,6 +155,9 @@ function ScreenCombat({ onNavigate, state }) {
   const crossDoor = async (door) => {
     if (busyRef.current || !Array.isArray(door?.cell)) return;
     busyRef.current = true;
+    // #1250-parity: drive busyAction so the door affordance disables (and any sibling door / action
+    // tile greys out) while the cross is in flight, mirroring postMove's in-flight lockout.
+    setBusyAction("cross-door");
     try {
       const response = await fetch("/move", {
         method: "POST",
@@ -168,6 +171,7 @@ function ScreenCombat({ onNavigate, state }) {
       toast({ kind: "danger", title: "Could not cross", body: error?.message || "The viewer could not reach /move." });
     } finally {
       busyRef.current = false;
+      setBusyAction("");
     }
   };
 
@@ -355,12 +359,26 @@ function ScreenCombat({ onNavigate, state }) {
           ) : (
             <React.Fragment>
               {doors.length ? (
-                <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
-                  {doors.map((d, i) => (
-                    <BrassButton key={i} size="sm" onClick={() => crossDoor(d)}>
-                      Cross to {d.toName || "the next room"} →
-                    </BrassButton>
-                  ))}
+                <div data-worldos-testid="cross-door-bar" style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 12 }}>
+                  {doors.map((d, i) => {
+                    // #1250-parity gating: a door tile is only ever offered when combat is RESOLVED (this
+                    // `!encounter.active` branch), and disables while any cross/move is in flight so a
+                    // double-click can't fire two crossings. `multi` marks a door with an ambiguous
+                    // destination (the server took a best-effort first connection) — surfaced in the hint.
+                    const crossing = Boolean(busyAction);
+                    return (
+                      <BrassButton
+                        key={i}
+                        size="sm"
+                        testId="cross-door"
+                        disabled={crossing || !Array.isArray(d?.cell)}
+                        title={crossing ? "Crossing…" : d.multi ? "Multiple exits — takes the first connection" : `Cross to ${d.toName || "the next room"}`}
+                        onClick={() => crossDoor(d)}
+                      >
+                        Cross to {d.toName || "the next room"} →
+                      </BrassButton>
+                    );
+                  })}
                 </div>
               ) : null}
               <CombatEmptyState status={surfaceStatus} onNavigate={onNavigate} />

--- a/viewer/tests/test_openworlds_static.py
+++ b/viewer/tests/test_openworlds_static.py
@@ -894,6 +894,31 @@ class OpenWorldsStaticRouteTests(unittest.TestCase):
         self.assertNotIn("TOKENS.map", source)
         self.assertNotIn("setTokens", source)
 
+    def test_openworlds_combat_screen_offers_cross_door_affordance(self):
+        # #1292: when the combat surface carries `doors` (the #1224 door_cells x connections payload,
+        # surfaced by _combat_doors), the resolved-encounter view renders a per-door "Cross to …" tile
+        # that POSTs the engine-resolved `cross_door` intent to the /move lane (the #1225 verb). The
+        # affordance mirrors #1250's action-tile gating: it lives only in the combat-RESOLVED branch and
+        # disables while a cross is in flight (busyAction) so a double-click can't fire two crossings.
+        status, ctype, body = self._get("/openworlds/screen-combat.jsx")
+
+        self.assertEqual(status, 200)
+        self.assertIn("text/babel", ctype)
+        source = body.decode("utf-8")
+        # Reads the server-surfaced doors payload (empty array default -> no affordance == today's shape).
+        self.assertIn("const doors = Array.isArray(surface?.doors) ? surface.doors : [];", source)
+        # The cross handler posts the exact engine-resolved payload the existing /move lane expects
+        # (kind:"cross_door" + the doorway cell x/y from door.cell) — no new engine tool / MCP param.
+        self.assertIn('kind: "cross_door", x: door.cell[0], y: door.cell[1]', source)
+        # The affordance renders per-door in the resolved-combat branch with a stable agent hook.
+        self.assertIn("doors.map(", source)
+        self.assertIn('data-worldos-testid="cross-door-bar"', source)
+        self.assertIn('testId="cross-door"', source)
+        self.assertIn("onClick={() => crossDoor(d)}", source)
+        # #1250-parity gating: busy lockout drives the disabled state so a double-click can't double-cross.
+        self.assertIn('setBusyAction("cross-door")', source)
+        self.assertIn("disabled={crossing || !Array.isArray(d?.cell)}", source)
+
     def test_openworlds_map_screen_binds_viewer_atlas_surface(self):
         status, ctype, body = self._get("/openworlds/screen-map.jsx")
 


### PR DESCRIPTION
Closes #1292.

## Context
The in-app cross-door affordance was **already shipped in #1228** (a per-door "Cross to …" button that POSTs the engine-resolved `cross_door` intent — the #1225 verb — through the existing `/move` lane, reading the #1224 `doors` payload). #1292 asked for the affordance + #1250-style gating; this PR **hardens the existing button to the #1250 action-tile idiom** and closes the **missing test coverage** (the client affordance had zero tests).

## Lane / payload (no new engine tool or MCP param)
- Reuses the existing `/move` `cross_door` lane: `viewer/server.py:9312` (`move.kind == "cross_door"` → `_resolve_cross_door` → `engine.cross_door`).
- Client posts the exact payload the lane expects: `{ kind: "cross_door", x: door.cell[0], y: door.cell[1] }` (`viewer/openworlds/screen-combat.jsx`).
- Pattern reused from #1250: `postMove` / `postZoneMove` in-flight lockout (`viewer/openworlds/screen-combat.jsx:174` and the `actionTile` `disabled={… || Boolean(busyAction)}` gating at `:316`).

## Changes
- `viewer/openworlds/screen-combat.jsx` — `crossDoor` now drives `busyAction` ("cross-door") so the door tiles disable while a cross is in flight (double-click can't double-cross); the door tile gains a `disabled` state (in-flight or malformed cell), a stable `testId` (`cross-door` / `cross-door-bar`), and a `title` carrying the disabled-reason / multi-exit hint. The affordance still lives only in the combat-**resolved** branch (the "not during the fight" gate).
- `viewer/tests/test_openworlds_static.py` — new `test_openworlds_combat_screen_offers_cross_door_affordance`: asserts the affordance renders from a doors-bearing surface and posts the correct `cross_door` payload, plus the #1250-parity busy gating.

## Verification
- Touched viewer tests, single-process: **103 passed, 26 subtests** (`test_openworlds_static.py`, `test_combat_grid_scene_grid.py`, `test_move_intents.py`; `-p no:xdist`).
- `qa/fast_gate.sh`: **PASS** (245 deterministic engine tests).

## ⚠ HELD — campaign merge freeze
Do **NOT** merge while the campaign freeze is active. Additive/presentation-only, no engine surface touched.