### PR TITLE
renderer: templatize layered pass2/3 prompts per-room + bosshall recipe

### DIFF
--- a/extensions/renderers/godot/tools/generate_room.py
+++ b/extensions/renderers/godot/tools/generate_room.py
@@ -66,7 +66,8 @@ def _load_recipe() -> dict:
         return json.load(f)
 
 
-def _render_pass_prompt(recipe: dict, room: str, pass_spec: dict, slot_key: str) -> str:
+def _render_pass_prompt(recipe: dict, room: str, pass_spec: dict, slot_key: str,
+                          slot_block: str = "layered") -> str:
     """Fill a layered-pipeline pass2/pass3 prompt TEMPLATE with the active room's slot values.
 
     Fixes the tavern-turned-crypt defect: pass2_detail_populate.prompt_template and
@@ -74,6 +75,10 @@ def _render_pass_prompt(recipe: dict, room: str, pass_spec: dict, slot_key: str)
     {room_*} placeholders instead of hardcoded crypt nouns. Each room supplies its own values
     under rooms.<room>.layered.<slot_key> (pass2_slots|pass3_slots). Falls back to the legacy
     unrendered "prompt" key (pre-templatization schema) if present, for forward compatibility.
+
+    `slot_block` selects which per-room block to read slots from: "layered" (night, default)
+    or "layered_day" (#1291 G5a day-state variant — only pass3_slots exists there; pass2 is
+    shared with the night "layered" block since detail/populate craft is lighting-agnostic).
     """
     template = pass_spec.get("prompt_template")
     if template is None:
@@ -81,21 +86,21 @@ def _render_pass_prompt(recipe: dict, room: str, pass_spec: dict, slot_key: str)
         return pass_spec["prompt"]
     rooms = recipe.get("rooms", {})
     rc = rooms.get(room, {})
-    layered_rc = rc.get("layered", {})
-    slots = layered_rc.get(slot_key)
+    block_rc = rc.get(slot_block, {})
+    slots = block_rc.get(slot_key)
     if not slots:
         sys.exit(
             "[generate_room] ERROR: --layered requested for room '%s' but room_recipes.json has "
-            "no rooms.%s.layered.%s slot values (needed to fill the %s prompt template). "
-            "Add a `layered` block for this room (see rooms.crypt.layered for the pattern)."
-            % (room, room, slot_key, slot_key)
+            "no rooms.%s.%s.%s slot values (needed to fill the %s prompt template). "
+            "Add a `%s` block for this room (see rooms.crypt.layered for the pattern)."
+            % (room, room, slot_block, slot_key, slot_key, slot_block)
         )
     try:
         return template.format(**slots)
     except KeyError as e:
         sys.exit(
-            "[generate_room] ERROR: rooms.%s.layered.%s is missing slot %s required by the "
-            "%s prompt template." % (room, slot_key, e, slot_key)
+            "[generate_room] ERROR: rooms.%s.%s.%s is missing slot %s required by the "
+            "%s prompt template." % (room, slot_block, slot_key, e, slot_key)
         )
 
 
@@ -244,8 +249,18 @@ def main(argv=None) -> None:
                     help="OPTIONAL 3-pass pipeline: after the img2img layout pass, chain a Gemini "
                          "detail/populate pass then a Gemini staging-last pass (room_recipes.json:"
                          "layered_pipeline_2026_07_02). Default OFF; no flag = identical single-pass behavior.")
+    ap.add_argument("--day", action="store_true",
+                    help="DAY-STATE variant of --layered (#1291 G5a). Implies --lighting daylight for pass1; "
+                         "pass2 (detail/populate) is unchanged/shared with the night recipe; pass3 (staging) "
+                         "uses the DAY staging law (room_recipes.json:layered_pipeline_day_2026_07_03 / "
+                         "rooms.<room>.layered_day.pass3_slots) instead of the night chiaroscuro staging law. "
+                         "No effect without --layered (day/night only differs in the layered pipeline's "
+                         "staging pass + pass1 lighting).")
     ap.add_argument("--dry-run", action="store_true", help="print the resolved request without calling the API")
     args = ap.parse_args(argv)
+
+    if args.day:
+        args.lighting = "daylight"
 
     # Require EXACTLY ONE image source up front so an ambiguous/missing combo fails fast (incl. on --dry-run),
     # not silently as "<upload:None>" or only at submit time.
@@ -283,14 +298,29 @@ def main(argv=None) -> None:
         print("  recipe    : %s" % RECIPE_PATH)
         if args.layered:
             layered = recipe.get("layered_pipeline_2026_07_02", {})
-            print("[generate_room] DRY-RUN --layered: would additionally chain pass2 (detail/populate) "
-                  "then pass3 (staging-last) via %s" % layered.get("pass2_detail_populate", {}).get("model", "?"))
-            pass2_prompt = _render_pass_prompt(recipe, args.room, layered.get("pass2_detail_populate", {}), "pass2_slots")
-            pass3_prompt = _render_pass_prompt(recipe, args.room, layered.get("pass3_staging_last", {}), "pass3_slots")
-            print("  pass2 prompt (rendered for room=%s, room_recipes.json:layered_pipeline_2026_07_02.pass2_detail_populate):" % args.room)
-            print("    %s" % pass2_prompt[:160] + " ...")
-            print("  pass3 prompt (rendered for room=%s, room_recipes.json:layered_pipeline_2026_07_02.pass3_staging_last):" % args.room)
-            print("    %s" % pass3_prompt[:160] + " ...")
+            if args.day:
+                layered_day = recipe.get("layered_pipeline_day_2026_07_03", {})
+                pass2_spec = layered_day.get("pass2_detail_populate_day", {})
+                pass3_spec = layered_day.get("pass3_staging_last_day", {})
+                print("[generate_room] DRY-RUN --layered --day: would additionally chain pass2 (detail/populate, "
+                      "day variant) then pass3 (staging-last, DAY law) via %s" % pass2_spec.get("model", "?"))
+                pass2_prompt = _render_pass_prompt(recipe, args.room, pass2_spec, "pass2_slots")
+                pass3_prompt = _render_pass_prompt(recipe, args.room, pass3_spec, "pass3_slots", slot_block="layered_day")
+                print("  pass2 prompt [DAY] (rendered for room=%s, room_recipes.json:layered_pipeline_day_2026_07_03.pass2_detail_populate_day):" % args.room)
+                print("    %s" % pass2_prompt[:160] + " ...")
+                print("  pass3 prompt [DAY] (rendered for room=%s, room_recipes.json:layered_pipeline_day_2026_07_03.pass3_staging_last_day):" % args.room)
+                print("    %s" % pass3_prompt[:160] + " ...")
+            else:
+                pass2_spec = layered.get("pass2_detail_populate", {})
+                pass3_spec = layered.get("pass3_staging_last", {})
+                print("[generate_room] DRY-RUN --layered: would additionally chain pass2 (detail/populate) "
+                      "then pass3 (staging-last) via %s" % pass2_spec.get("model", "?"))
+                pass2_prompt = _render_pass_prompt(recipe, args.room, pass2_spec, "pass2_slots")
+                pass3_prompt = _render_pass_prompt(recipe, args.room, pass3_spec, "pass3_slots")
+                print("  pass2 prompt (rendered for room=%s, room_recipes.json:layered_pipeline_2026_07_02.pass2_detail_populate):" % args.room)
+                print("    %s" % pass2_prompt[:160] + " ...")
+                print("  pass3 prompt (rendered for room=%s, room_recipes.json:layered_pipeline_2026_07_02.pass3_staging_last):" % args.room)
+                print("    %s" % pass3_prompt[:160] + " ...")
         return
 
     out_dir = args.out or os.path.join(os.getcwd(), "room_gen_%s" % args.room)
@@ -338,33 +368,57 @@ def main(argv=None) -> None:
         # Render each pass's prompt TEMPLATE with the active room's slot values (fixes the
         # tavern-turned-crypt defect — pass2/pass3 previously ran the crypt-hardcoded prompt
         # unconditionally regardless of --room). See _render_pass_prompt + rooms.<room>.layered.
-        pass2_prompt = _render_pass_prompt(recipe, args.room, layered["pass2_detail_populate"], "pass2_slots")
-        pass3_prompt = _render_pass_prompt(recipe, args.room, layered["pass3_staging_last"], "pass3_slots")
+        # pass2 SLOT VALUES are shared between day and night (#1291 G5a) — the craft/de-clone/
+        # populate TARGETS are lighting-agnostic — but the pass2 PROMPT TEMPLATE branches on
+        # --day (the night template explicitly protects dark chiaroscuro, which fights a
+        # daylit pass1 base); pass3 (staging) also fully branches on --day.
+        if args.day:
+            layered_day = recipe.get("layered_pipeline_day_2026_07_03")
+            if not layered_day:
+                sys.exit("[generate_room] ERROR: --day requested but recipe manifest has no "
+                          "layered_pipeline_day_2026_07_03 entry: %s" % RECIPE_PATH)
+            pass2_spec = layered_day["pass2_detail_populate_day"]
+            pass2_prompt = _render_pass_prompt(recipe, args.room, pass2_spec, "pass2_slots")
+            pass3_spec = layered_day["pass3_staging_last_day"]
+            pass3_prompt = _render_pass_prompt(recipe, args.room, pass3_spec, "pass3_slots", slot_block="layered_day")
+            pass3_recipe_entry = "layered_pipeline_day_2026_07_03"
+        else:
+            pass2_spec = layered["pass2_detail_populate"]
+            pass2_prompt = _render_pass_prompt(recipe, args.room, pass2_spec, "pass2_slots")
+            pass3_spec = layered["pass3_staging_last"]
+            pass3_prompt = _render_pass_prompt(recipe, args.room, pass3_spec, "pass3_slots")
+            pass3_recipe_entry = "layered_pipeline_2026_07_02"
 
+        pass2_stem = "room_%s_pass2_detail_day" % args.room if args.day else "room_%s_pass2_detail" % args.room
         pass2_job, pass2_saved = _run_gemini_pass(
-            headers, layered["pass2_detail_populate"], pass1_ref, out_dir,
-            "room_%s_pass2_detail" % args.room, args.timeout, pass2_prompt)
+            headers, pass2_spec, pass1_ref, out_dir,
+            pass2_stem, args.timeout, pass2_prompt)
         if not pass2_saved:
-            sys.exit("[generate_room] ERROR: --layered pass2 (detail/populate) produced no assets")
+            sys.exit("[generate_room] ERROR: --layered pass2 (detail/populate%s) produced no assets"
+                      % (" day" if args.day else ""))
         # Feed pass3 the REMOTE 2K asset (full resolution, no re-upload, no lossy round-trip);
         # only the FINAL pass output is downscaled to the plate contract below.
         pass2_ref = pass2_saved[0]["asset_id"]
 
+        pass3_stem = "room_%s_pass3_staging_day" % args.room if args.day else "room_%s_pass3_staging" % args.room
         pass3_job, pass3_saved = _run_gemini_pass(
-            headers, layered["pass3_staging_last"], pass2_ref, out_dir,
-            "room_%s_pass3_staging" % args.room, args.timeout, pass3_prompt)
+            headers, pass3_spec, pass2_ref, out_dir,
+            pass3_stem, args.timeout, pass3_prompt)
         if not pass3_saved:
-            sys.exit("[generate_room] ERROR: --layered pass3 (staging-last) produced no assets")
+            sys.exit("[generate_room] ERROR: --layered pass3 (staging-last%s) produced no assets"
+                      % (" day" if args.day else ""))
         _downscale_to_plate(pass3_saved[0]["path"], args.width, args.height)
 
         meta["layered"] = {
+            "day": args.day,
             "pass1_selected": pass1_best,
             "pass2_job_id": pass2_job, "pass2_assets": pass2_saved, "pass2_prompt": pass2_prompt,
             "pass3_job_id": pass3_job, "pass3_assets": pass3_saved, "pass3_prompt": pass3_prompt,
             "final_plate": pass3_saved[0],
-            "recipe_entry": "layered_pipeline_2026_07_02",
+            "recipe_entry": pass3_recipe_entry,
         }
-        print("[generate_room] --layered OK — final staged plate: %s" % pass3_saved[0])
+        print("[generate_room] --layered%s OK — final staged plate: %s"
+              % (" --day" if args.day else "", pass3_saved[0]))
 
     _write_meta(out_dir, meta)
     print("[generate_room] OK — room=%s job=%s assets=%d -> %s" % (args.room, job_id, len(saved), out_dir))

--- a/extensions/renderers/godot/tools/generate_room.py
+++ b/extensions/renderers/godot/tools/generate_room.py
@@ -90,22 +90,21 @@ def _render_pass_prompt(recipe: dict, room: str, pass_spec: dict, slot_key: str,
     slots = block_rc.get(slot_key)
     if not slots:
         sys.exit(
-            "[generate_room] ERROR: --layered requested for room '%s' but room_recipes.json has "
-            "no rooms.%s.%s.%s slot values (needed to fill the %s prompt template). "
-            "Add a `%s` block for this room (see rooms.crypt.layered for the pattern)."
-            % (room, room, slot_block, slot_key, slot_key, slot_block)
+            f"[generate_room] ERROR: --layered requested for room '{room}' but room_recipes.json has "
+            f"no rooms.{room}.{slot_block}.{slot_key} slot values (needed to fill the {slot_key} prompt template). "
+            f"Add a `{slot_block}` block for this room (see rooms.crypt.layered for the pattern)."
         )
     try:
         return template.format(**slots)
     except KeyError as e:
         sys.exit(
-            "[generate_room] ERROR: rooms.%s.%s.%s is missing slot %s required by the "
-            "%s prompt template." % (room, slot_block, slot_key, e, slot_key)
+            f"[generate_room] ERROR: rooms.{room}.{slot_block}.{slot_key} is missing slot {e} required by the "
+            f"{slot_key} prompt template."
         )
     except (IndexError, ValueError) as e:
         sys.exit(
-            "[generate_room] ERROR: rooms.%s.%s.%s has a malformed slot value for the "
-            "%s prompt template (%s)." % (room, slot_block, slot_key, slot_key, e)
+            f"[generate_room] ERROR: rooms.{room}.{slot_block}.{slot_key} has a malformed slot value for the "
+            f"{slot_key} prompt template ({e})."
         )
 
 
@@ -272,6 +271,16 @@ def main(argv=None) -> None:
     src_count = (1 if args.base_plate else 0) + (1 if args.refine_from else 0)
     if src_count != 1:
         ap.error("provide EXACTLY ONE of --base-plate <png> or --refine-from <asset_id>")
+
+    # Fail fast on a missing --day recipe entry BEFORE the (expensive, billed) pass1 img2img job
+    # runs — --layered --day chains pass1 -> pass2 -> pass3, and pass3's day branch is the one
+    # that actually needs layered_pipeline_day_2026_07_03; checking only at that point would
+    # burn a pass1 job on a room that was never wired for the day variant.
+    if args.layered and args.day and not recipe.get("layered_pipeline_day_2026_07_03"):
+        sys.exit(
+            f"[generate_room] ERROR: --day requested but recipe manifest has no "
+            f"layered_pipeline_day_2026_07_03 entry: {RECIPE_PATH}"
+        )
 
     positive, negative = _build_prompt(recipe, args.room, args.lighting)
     # Standalone base models (model_z-image) run img2img via POST /generate/custom/{modelId}

--- a/extensions/renderers/godot/tools/generate_room.py
+++ b/extensions/renderers/godot/tools/generate_room.py
@@ -102,6 +102,11 @@ def _render_pass_prompt(recipe: dict, room: str, pass_spec: dict, slot_key: str,
             "[generate_room] ERROR: rooms.%s.%s.%s is missing slot %s required by the "
             "%s prompt template." % (room, slot_block, slot_key, e, slot_key)
         )
+    except (IndexError, ValueError) as e:
+        sys.exit(
+            "[generate_room] ERROR: rooms.%s.%s.%s has a malformed slot value for the "
+            "%s prompt template (%s)." % (room, slot_block, slot_key, slot_key, e)
+        )
 
 
 def _run_gemini_pass(headers: dict, pass_spec: dict, image_ref: str, out_dir: str, stem: str,

--- a/extensions/renderers/godot/tools/generate_room.py
+++ b/extensions/renderers/godot/tools/generate_room.py
@@ -66,17 +66,52 @@ def _load_recipe() -> dict:
         return json.load(f)
 
 
-def _run_gemini_pass(headers: dict, pass_spec: dict, image_ref: str, out_dir: str, stem: str, timeout: int) -> tuple:
+def _render_pass_prompt(recipe: dict, room: str, pass_spec: dict, slot_key: str) -> str:
+    """Fill a layered-pipeline pass2/pass3 prompt TEMPLATE with the active room's slot values.
+
+    Fixes the tavern-turned-crypt defect: pass2_detail_populate.prompt_template and
+    pass3_staging_last.prompt_template (room_recipes.json:layered_pipeline_2026_07_02) carry
+    {room_*} placeholders instead of hardcoded crypt nouns. Each room supplies its own values
+    under rooms.<room>.layered.<slot_key> (pass2_slots|pass3_slots). Falls back to the legacy
+    unrendered "prompt" key (pre-templatization schema) if present, for forward compatibility.
+    """
+    template = pass_spec.get("prompt_template")
+    if template is None:
+        # legacy fallback: an un-templatized recipe (shouldn't happen post-fix, but fail soft)
+        return pass_spec["prompt"]
+    rooms = recipe.get("rooms", {})
+    rc = rooms.get(room, {})
+    layered_rc = rc.get("layered", {})
+    slots = layered_rc.get(slot_key)
+    if not slots:
+        sys.exit(
+            "[generate_room] ERROR: --layered requested for room '%s' but room_recipes.json has "
+            "no rooms.%s.layered.%s slot values (needed to fill the %s prompt template). "
+            "Add a `layered` block for this room (see rooms.crypt.layered for the pattern)."
+            % (room, room, slot_key, slot_key)
+        )
+    try:
+        return template.format(**slots)
+    except KeyError as e:
+        sys.exit(
+            "[generate_room] ERROR: rooms.%s.layered.%s is missing slot %s required by the "
+            "%s prompt template." % (room, slot_key, e, slot_key)
+        )
+
+
+def _run_gemini_pass(headers: dict, pass_spec: dict, image_ref: str, out_dir: str, stem: str,
+                      timeout: int, prompt: str) -> tuple:
     """Run one Gemini instruction-edit pass (detail/populate or staging) on `image_ref`.
 
     Reuses the same proven Scenario helpers as the img2img pass (_post_json/_poll_job/
     _download_job_assets) — the Gemini endpoint takes prompt+image+numSamples+resolution
-    (no strength knob; preservation is prompt-driven, see room_recipes.json).
+    (no strength knob; preservation is prompt-driven, see room_recipes.json). `prompt` is the
+    already-rendered (slot-filled) prompt string for the active room — see _render_pass_prompt.
     Returns (job_id, [asset metadata dicts: {asset_id, path, bytes}]).
     """
     model = pass_spec["model"]
     endpoint = API_BASE + CONTROLNET_PATH.format(model_id=model)
-    body = {"prompt": pass_spec["prompt"], "image": image_ref, "numSamples": 1, "resolution": "2K"}
+    body = {"prompt": prompt, "image": image_ref, "numSamples": 1, "resolution": "2K"}
     res = _post_json(endpoint, headers, body)
     job_id = _job_id_from_create(res, "%s create" % stem)
     print("[generate_room] --layered %s job submitted: %s (model=%s)" % (stem, job_id, model))
@@ -250,10 +285,12 @@ def main(argv=None) -> None:
             layered = recipe.get("layered_pipeline_2026_07_02", {})
             print("[generate_room] DRY-RUN --layered: would additionally chain pass2 (detail/populate) "
                   "then pass3 (staging-last) via %s" % layered.get("pass2_detail_populate", {}).get("model", "?"))
-            print("  pass2 prompt (verbatim, room_recipes.json:layered_pipeline_2026_07_02.pass2_detail_populate.prompt):")
-            print("    %s" % layered.get("pass2_detail_populate", {}).get("prompt", "<missing>")[:120] + " ...")
-            print("  pass3 prompt (template, room_recipes.json:layered_pipeline_2026_07_02.pass3_staging_last.prompt):")
-            print("    %s" % layered.get("pass3_staging_last", {}).get("prompt", "<missing>")[:120] + " ...")
+            pass2_prompt = _render_pass_prompt(recipe, args.room, layered.get("pass2_detail_populate", {}), "pass2_slots")
+            pass3_prompt = _render_pass_prompt(recipe, args.room, layered.get("pass3_staging_last", {}), "pass3_slots")
+            print("  pass2 prompt (rendered for room=%s, room_recipes.json:layered_pipeline_2026_07_02.pass2_detail_populate):" % args.room)
+            print("    %s" % pass2_prompt[:160] + " ...")
+            print("  pass3 prompt (rendered for room=%s, room_recipes.json:layered_pipeline_2026_07_02.pass3_staging_last):" % args.room)
+            print("    %s" % pass3_prompt[:160] + " ...")
         return
 
     out_dir = args.out or os.path.join(os.getcwd(), "room_gen_%s" % args.room)
@@ -298,9 +335,15 @@ def main(argv=None) -> None:
         pass1_best = _pick_best_pass1_sample(saved)
         pass1_ref = pass1_best["asset_id"]
 
+        # Render each pass's prompt TEMPLATE with the active room's slot values (fixes the
+        # tavern-turned-crypt defect — pass2/pass3 previously ran the crypt-hardcoded prompt
+        # unconditionally regardless of --room). See _render_pass_prompt + rooms.<room>.layered.
+        pass2_prompt = _render_pass_prompt(recipe, args.room, layered["pass2_detail_populate"], "pass2_slots")
+        pass3_prompt = _render_pass_prompt(recipe, args.room, layered["pass3_staging_last"], "pass3_slots")
+
         pass2_job, pass2_saved = _run_gemini_pass(
             headers, layered["pass2_detail_populate"], pass1_ref, out_dir,
-            "room_%s_pass2_detail" % args.room, args.timeout)
+            "room_%s_pass2_detail" % args.room, args.timeout, pass2_prompt)
         if not pass2_saved:
             sys.exit("[generate_room] ERROR: --layered pass2 (detail/populate) produced no assets")
         # Feed pass3 the REMOTE 2K asset (full resolution, no re-upload, no lossy round-trip);
@@ -309,15 +352,15 @@ def main(argv=None) -> None:
 
         pass3_job, pass3_saved = _run_gemini_pass(
             headers, layered["pass3_staging_last"], pass2_ref, out_dir,
-            "room_%s_pass3_staging" % args.room, args.timeout)
+            "room_%s_pass3_staging" % args.room, args.timeout, pass3_prompt)
         if not pass3_saved:
             sys.exit("[generate_room] ERROR: --layered pass3 (staging-last) produced no assets")
         _downscale_to_plate(pass3_saved[0]["path"], args.width, args.height)
 
         meta["layered"] = {
             "pass1_selected": pass1_best,
-            "pass2_job_id": pass2_job, "pass2_assets": pass2_saved,
-            "pass3_job_id": pass3_job, "pass3_assets": pass3_saved,
+            "pass2_job_id": pass2_job, "pass2_assets": pass2_saved, "pass2_prompt": pass2_prompt,
+            "pass3_job_id": pass3_job, "pass3_assets": pass3_saved, "pass3_prompt": pass3_prompt,
             "final_plate": pass3_saved[0],
             "recipe_entry": "layered_pipeline_2026_07_02",
         }

--- a/extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py
+++ b/extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py
@@ -20,6 +20,8 @@ import os
 import sys
 import unittest
 
+import pytest
+
 _TOOLS_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
 if _TOOLS_DIR not in sys.path:
     sys.path.insert(0, _TOOLS_DIR)
@@ -73,7 +75,7 @@ TAVERN_NOUNS_PASS3 = ["tavern", "hearth", "lantern"]
 
 class LayeredPromptTemplatingTest(unittest.TestCase):
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.recipe = generate_room._load_recipe()
         cls.layered = cls.recipe["layered_pipeline_2026_07_02"]
 
@@ -99,7 +101,7 @@ class LayeredPromptTemplatingTest(unittest.TestCase):
         )
         lowered = rendered.lower()
         for noun in TAVERN_NOUNS_PASS2:
-            self.assertIn(noun, lowered, "tavern pass2 prompt missing expected noun %r" % noun)
+            self.assertIn(noun, lowered, f"tavern pass2 prompt missing expected noun {noun!r}")
 
     def test_tavern_pass3_prompt_contains_tavern_nouns(self):
         rendered = generate_room._render_pass_prompt(
@@ -107,7 +109,7 @@ class LayeredPromptTemplatingTest(unittest.TestCase):
         )
         lowered = rendered.lower()
         for noun in TAVERN_NOUNS_PASS3:
-            self.assertIn(noun, lowered, "tavern pass3 prompt missing expected noun %r" % noun)
+            self.assertIn(noun, lowered, f"tavern pass3 prompt missing expected noun {noun!r}")
 
     def test_tavern_pass2_prompt_contains_no_crypt_nouns(self):
         rendered = generate_room._render_pass_prompt(
@@ -115,7 +117,7 @@ class LayeredPromptTemplatingTest(unittest.TestCase):
         )
         lowered = rendered.lower()
         for noun in CRYPT_ONLY_NOUNS:
-            self.assertNotIn(noun, lowered, "tavern pass2 prompt leaked crypt noun %r" % noun)
+            self.assertNotIn(noun, lowered, f"tavern pass2 prompt leaked crypt noun {noun!r}")
 
     def test_tavern_pass3_prompt_contains_no_crypt_nouns(self):
         rendered = generate_room._render_pass_prompt(
@@ -123,7 +125,7 @@ class LayeredPromptTemplatingTest(unittest.TestCase):
         )
         lowered = rendered.lower()
         for noun in CRYPT_ONLY_NOUNS:
-            self.assertNotIn(noun, lowered, "tavern pass3 prompt leaked crypt noun %r" % noun)
+            self.assertNotIn(noun, lowered, f"tavern pass3 prompt leaked crypt noun {noun!r}")
 
     def test_tavern_pass2_and_pass3_prompts_differ_from_crypt(self):
         tavern_p2 = generate_room._render_pass_prompt(
@@ -143,7 +145,7 @@ class LayeredPromptTemplatingTest(unittest.TestCase):
         rc = rooms["bosshall"]
         for key in ("key_light", "shadow_casters", "room_detail_tokens"):
             self.assertIn(key, rc)
-            self.assertTrue(rc[key], "bosshall.%s must be non-empty" % key)
+            self.assertTrue(rc[key], f"bosshall.{key} must be non-empty")
 
     def test_bosshall_layered_slots_present_and_render_without_error(self):
         rc = self.recipe["rooms"]["bosshall"]
@@ -167,7 +169,7 @@ class LayeredPromptTemplatingTest(unittest.TestCase):
         # rooms (no room-specific pass1 duplication) — build_prompt should succeed cleanly and
         # carry bosshall's own key_light/shadow_casters/room_detail_tokens + the shared
         # staging-law language adopted in #1274 (no-two-columns-identical, wall clutter).
-        positive, negative = generate_room._build_prompt(self.recipe, "bosshall")
+        positive, _negative = generate_room._build_prompt(self.recipe, "bosshall")
         self.assertIn("bosshall", positive)
         self.assertIn("carved throne", positive)
         self.assertIn("no two columns identical", positive.lower())
@@ -194,11 +196,11 @@ class LayeredPromptTemplatingTest(unittest.TestCase):
         # crypt_stair intentionally omitted here would previously fall through silently to the
         # crypt prompt; now a room with NO layered block must sys.exit with a clear error rather
         # than silently reusing another room's content.
-        recipe_copy = dict(self.recipe)
-        rooms_copy = dict(recipe_copy["rooms"])
-        rooms_copy["_no_layered_room"] = {"key_light": "x", "shadow_casters": "y", "room_detail_tokens": "z"}
-        recipe_copy["rooms"] = rooms_copy
-        with self.assertRaises(SystemExit):
+        recipe_copy = copy.deepcopy(self.recipe)
+        recipe_copy["rooms"]["_no_layered_room"] = {
+            "key_light": "x", "shadow_casters": "y", "room_detail_tokens": "z",
+        }
+        with pytest.raises(SystemExit):
             generate_room._render_pass_prompt(
                 recipe_copy, "_no_layered_room", self.layered["pass2_detail_populate"], "pass2_slots"
             )

--- a/extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py
+++ b/extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Regression tests for the layered pass2/pass3 prompt templating fix (2026-07-03).
+
+DIAGNOSED DEFECT: room_recipes.json's layered_pipeline_2026_07_02.pass2_detail_populate
+and .pass3_staging_last prompts were HARDCODED with crypt nouns ("sarcophagus effigy",
+"vast dark crypt", etc). generate_room.py --layered applied them unconditionally regardless
+of --room, so a tavern pass1 base got silently repainted into a crypt by pass2/pass3.
+
+FIX: the prompts are now `prompt_template` strings with {room_*} slots, filled per-room
+from rooms.<room>.layered.pass2_slots / pass3_slots by generate_room._render_pass_prompt.
+
+REGRESSION GUARD (mandatory per the fix spec): crypt's rendered prompts must be BYTE-IDENTICAL
+to the prior hardcoded literals, so the adopted/scored crypt path is untouched by this change.
+
+Run: python3 -m pytest extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py -q
+(no network / credentials required — pure string-templating + JSON-schema checks)
+"""
+import os
+import sys
+import unittest
+
+_TOOLS_DIR = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+if _TOOLS_DIR not in sys.path:
+    sys.path.insert(0, _TOOLS_DIR)
+
+import generate_room  # noqa: E402
+
+
+# Byte-identical to the pre-2026-07-03 hardcoded literals in room_recipes.json
+# (layered_pipeline_2026_07_02.pass2_detail_populate.prompt / pass3_staging_last.prompt,
+# as they existed before this fix — copied verbatim for the regression assertion).
+LEGACY_CRYPT_PASS2_PROMPT = (
+    "Edit this painterly isometric dungeon plate. PRESERVE the exact composition, camera, "
+    "room layout, and the dark dramatic lighting with its warm fire pools and deep shadows "
+    "— do not brighten the scene. IMPROVE only the craft: re-sculpt every carved relief, "
+    "capital, and the sarcophagus effigy so they read CRISPLY CHISELED with clean edge "
+    "highlights; make every pillar and wall panel UNIQUE (remove cloned repeats); paint any "
+    "flat gray or unfinished surfaces as weathered stone; add small environmental-storytelling "
+    "clutter along walls and edges only (bones, fallen weapons, cobwebs, toppled urns, "
+    "scattered coins, moss) keeping the open floor areas clear; deepen the black voids at the "
+    "openings. Keep the hand-painted oil-paint brushwork feel throughout. Do NOT add any text, "
+    "letters, numbers, runic writing that reads as text, labels, legends, map insets, UI "
+    "elements, frames, or borders — the plate must contain ONLY the diegetic painted scene."
+)
+
+LEGACY_CRYPT_PASS3_PROMPT = (
+    "Edit this painterly isometric dungeon plate. PRESERVE every detail exactly — the room "
+    "layout, all carved reliefs, props, bones, coins, cobwebs, pillars, the sarcophagus — "
+    "change NOTHING about the content or composition. ONLY restage the LIGHTING into dramatic "
+    "chiaroscuro: make the central fire pit the dominant warm key light with a bright hot pool "
+    "around it, let the wall torches each cast a small local warm pool with HARD directional "
+    "cast shadows from the pillars and props, and sink everything between the pools into deep "
+    "cool blue-violet shadow — corners, far rooms, and floors away from lights should fall "
+    "near-black. Steep warm-to-cool falloff, warm rim light on edges facing flames, cool bounce "
+    "on shadow-side stone. The scene must read as small pools of firelight in a vast dark "
+    "crypt, keeping the hand-painted oil feel. Do NOT add any text, letters, numbers, runic "
+    "writing that reads as text, labels, legends, map insets, UI elements, frames, or borders "
+    "— the plate must contain ONLY the diegetic painted scene."
+)
+
+# Nouns that must NOT leak into a tavern's rendered pass2/pass3 prompts (crypt-specific, not
+# generic clutter vocabulary that could legitimately appear in multiple rooms).
+CRYPT_ONLY_NOUNS = [
+    "sarcophagus", "crypt", "dungeon", "fire pit",
+]
+
+# Nouns that SHOULD appear in tavern's rendered prompts (drawn from tavern's own
+# room_detail_tokens / layered slot vocabulary).
+TAVERN_NOUNS_PASS2 = ["tavern", "bar counter", "hearth", "timber"]
+TAVERN_NOUNS_PASS3 = ["tavern", "hearth", "lantern"]
+
+
+class LayeredPromptTemplatingTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.recipe = generate_room._load_recipe()
+        cls.layered = cls.recipe["layered_pipeline_2026_07_02"]
+
+    # --- regression guard: crypt byte-identical to the pre-fix hardcoded prompt ---
+
+    def test_crypt_pass2_prompt_byte_identical_to_legacy_hardcoded(self):
+        rendered = generate_room._render_pass_prompt(
+            self.recipe, "crypt", self.layered["pass2_detail_populate"], "pass2_slots"
+        )
+        self.assertEqual(rendered, LEGACY_CRYPT_PASS2_PROMPT)
+
+    def test_crypt_pass3_prompt_byte_identical_to_legacy_hardcoded(self):
+        rendered = generate_room._render_pass_prompt(
+            self.recipe, "crypt", self.layered["pass3_staging_last"], "pass3_slots"
+        )
+        self.assertEqual(rendered, LEGACY_CRYPT_PASS3_PROMPT)
+
+    # --- defect guard: tavern must render tavern content, never crypt nouns ---
+
+    def test_tavern_pass2_prompt_contains_tavern_nouns(self):
+        rendered = generate_room._render_pass_prompt(
+            self.recipe, "tavern", self.layered["pass2_detail_populate"], "pass2_slots"
+        )
+        lowered = rendered.lower()
+        for noun in TAVERN_NOUNS_PASS2:
+            self.assertIn(noun, lowered, "tavern pass2 prompt missing expected noun %r" % noun)
+
+    def test_tavern_pass3_prompt_contains_tavern_nouns(self):
+        rendered = generate_room._render_pass_prompt(
+            self.recipe, "tavern", self.layered["pass3_staging_last"], "pass3_slots"
+        )
+        lowered = rendered.lower()
+        for noun in TAVERN_NOUNS_PASS3:
+            self.assertIn(noun, lowered, "tavern pass3 prompt missing expected noun %r" % noun)
+
+    def test_tavern_pass2_prompt_contains_no_crypt_nouns(self):
+        rendered = generate_room._render_pass_prompt(
+            self.recipe, "tavern", self.layered["pass2_detail_populate"], "pass2_slots"
+        )
+        lowered = rendered.lower()
+        for noun in CRYPT_ONLY_NOUNS:
+            self.assertNotIn(noun, lowered, "tavern pass2 prompt leaked crypt noun %r" % noun)
+
+    def test_tavern_pass3_prompt_contains_no_crypt_nouns(self):
+        rendered = generate_room._render_pass_prompt(
+            self.recipe, "tavern", self.layered["pass3_staging_last"], "pass3_slots"
+        )
+        lowered = rendered.lower()
+        for noun in CRYPT_ONLY_NOUNS:
+            self.assertNotIn(noun, lowered, "tavern pass3 prompt leaked crypt noun %r" % noun)
+
+    def test_tavern_pass2_and_pass3_prompts_differ_from_crypt(self):
+        tavern_p2 = generate_room._render_pass_prompt(
+            self.recipe, "tavern", self.layered["pass2_detail_populate"], "pass2_slots"
+        )
+        tavern_p3 = generate_room._render_pass_prompt(
+            self.recipe, "tavern", self.layered["pass3_staging_last"], "pass3_slots"
+        )
+        self.assertNotEqual(tavern_p2, LEGACY_CRYPT_PASS2_PROMPT)
+        self.assertNotEqual(tavern_p3, LEGACY_CRYPT_PASS3_PROMPT)
+
+    # --- bosshall recipe presence + wiring ---
+
+    def test_bosshall_room_recipe_exists(self):
+        rooms = self.recipe["rooms"]
+        self.assertIn("bosshall", rooms)
+        rc = rooms["bosshall"]
+        for key in ("key_light", "shadow_casters", "room_detail_tokens"):
+            self.assertIn(key, rc)
+            self.assertTrue(rc[key], "bosshall.%s must be non-empty" % key)
+
+    def test_bosshall_layered_slots_present_and_render_without_error(self):
+        rc = self.recipe["rooms"]["bosshall"]
+        self.assertIn("layered", rc)
+        self.assertIn("pass2_slots", rc["layered"])
+        self.assertIn("pass3_slots", rc["layered"])
+        p2 = generate_room._render_pass_prompt(
+            self.recipe, "bosshall", self.layered["pass2_detail_populate"], "pass2_slots"
+        )
+        p3 = generate_room._render_pass_prompt(
+            self.recipe, "bosshall", self.layered["pass3_staging_last"], "pass3_slots"
+        )
+        self.assertIn("throne", p2.lower())
+        self.assertIn("throne", p3.lower())
+        # No leftover unfilled {slot} braces after formatting.
+        self.assertNotIn("{", p2)
+        self.assertNotIn("{", p3)
+
+    def test_bosshall_base_prompt_uses_shared_staging_law_template(self):
+        # bosshall must use the same firelit_positive_template/negative machinery as the other
+        # rooms (no room-specific pass1 duplication) — build_prompt should succeed cleanly and
+        # carry bosshall's own key_light/shadow_casters/room_detail_tokens + the shared
+        # staging-law language adopted in #1274 (no-two-columns-identical, wall clutter).
+        positive, negative = generate_room._build_prompt(self.recipe, "bosshall")
+        self.assertIn("bosshall", positive)
+        self.assertIn("carved throne", positive)
+        self.assertIn("no two columns identical", positive.lower())
+        self.assertIn("environmental storytelling clutter along the walls", positive.lower())
+
+    # --- every room with a `layered` block must render cleanly (no missing-slot crashes) ---
+
+    def test_every_room_with_layered_block_renders_both_passes(self):
+        rooms = self.recipe["rooms"]
+        for room, rc in rooms.items():
+            if "layered" not in rc:
+                continue
+            with self.subTest(room=room):
+                p2 = generate_room._render_pass_prompt(
+                    self.recipe, room, self.layered["pass2_detail_populate"], "pass2_slots"
+                )
+                p3 = generate_room._render_pass_prompt(
+                    self.recipe, room, self.layered["pass3_staging_last"], "pass3_slots"
+                )
+                self.assertNotIn("{", p2)
+                self.assertNotIn("{", p3)
+
+    def test_missing_layered_block_fails_loud_not_silent(self):
+        # crypt_stair intentionally omitted here would previously fall through silently to the
+        # crypt prompt; now a room with NO layered block must sys.exit with a clear error rather
+        # than silently reusing another room's content.
+        recipe_copy = dict(self.recipe)
+        rooms_copy = dict(recipe_copy["rooms"])
+        rooms_copy["_no_layered_room"] = {"key_light": "x", "shadow_casters": "y", "room_detail_tokens": "z"}
+        recipe_copy["rooms"] = rooms_copy
+        with self.assertRaises(SystemExit):
+            generate_room._render_pass_prompt(
+                recipe_copy, "_no_layered_room", self.layered["pass2_detail_populate"], "pass2_slots"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py
+++ b/extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py
@@ -15,6 +15,7 @@ to the prior hardcoded literals, so the adopted/scored crypt path is untouched b
 Run: python3 -m pytest extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py -q
 (no network / credentials required — pure string-templating + JSON-schema checks)
 """
+import copy
 import os
 import sys
 import unittest

--- a/extensions/renderers/shared/room_recipes.json
+++ b/extensions/renderers/shared/room_recipes.json
@@ -173,7 +173,7 @@
           "room_setting_noun": "cathedral nave",
           "room_preserve_list": "stone flagstones, props, carved columns, the altar, the stained-glass shaft",
           "room_key_source": "the altar candles",
-          "room_fill_source": "the stained-glass light shaft",
+          "room_fill_source": "the stained-glass light shafts",
           "room_space_desc": "a hushed candlelit cathedral nave"
         }
       },

--- a/extensions/renderers/shared/room_recipes.json
+++ b/extensions/renderers/shared/room_recipes.json
@@ -57,6 +57,25 @@
     "sequencing_note": "Sequential jobs only (Scenario rule — concurrent paints collide/silently no-output). Each pass waits on the prior pass's terminal job status before submitting.",
     "_hallucination_note": "2026-07-02 church-run incident: the pass2 Gemini detail/populate pass HALLUCINATED a map inset + garbled legend text onto the church plate (3/5 panel scorers called it an unshippable production artifact). Root cause: Gemini instruction-edit models have no strength knob and will sometimes invent UI-chrome-like elements (insets, legends, labels) when asked to 'add environmental-storytelling detail'. Fix: both pass2_detail_populate.prompt and pass3_staging_last.prompt now end with an explicit hard negative sentence forbidding text/labels/legends/map-insets/UI-elements/frames/borders. Evidence: ~/worldos-session-notes/2026-07-02-lora-v4-eval/."
   },
+  "layered_pipeline_day_2026_07_03": {
+    "_doc": "DAY-STATE variant of layered_pipeline_2026_07_02, for issue #1291 day/night live integration (G5a — the GENERATION half; box wiring is a separate later unit). Same ORDER LAW (pass1 layout -> pass2 detail/populate -> pass3 STAGING-LAST). Pass1 uses generate_room.py --lighting daylight (daylight_positive_template/daylight_negative, already in this file) instead of the firelit template. pass2_detail_populate_day is a lighting-neutral rewrite of the night pass2 (the night pass2 text explicitly says 'do not brighten the scene' / 'deepen the black voids', which fights a day-lit pass1 base — so day gets its own pass2 prompt_template but reuses the SAME rooms.<room>.layered.pass2_slots values, since the craft/de-clone/populate targets themselves are lighting-agnostic). pass3_staging_last_day applies the DAY staging law. Wired via generate_room.py --layered --day (implies --lighting daylight for pass1; routes pass2 to pass2_detail_populate_day + rooms.<room>.layered.pass2_slots, and pass3 to pass3_staging_last_day + rooms.<room>.layered_day.pass3_slots).",
+    "pass2_detail_populate_day": {
+      "_doc": "Gemini instruction-edit detail/populate pass, DAY variant. Runs AFTER pass1 (daylit), on pass1's output asset. Same craft goals as the night pass2 but PRESERVES the bright daylit lighting instead of protecting dark chiaroscuro — reuses rooms.<room>.layered.pass2_slots (the same slot values as night; only the template text differs).",
+      "model": "model_google-gemini-3-1-flash",
+      "endpoint": "POST /v1/generate/custom/model_google-gemini-3-1-flash",
+      "body_template": {"prompt": "<PROMPT below, slots filled>", "image": "<asset id of pass1 output>", "numSamples": 1, "resolution": "2K"},
+      "prompt_template": "Edit this painterly isometric {room_setting_noun} plate. PRESERVE the exact composition, camera, room layout, and the bright DAYTIME lighting with its cool-neutral daylight key — do not darken the scene or add heavy chiaroscuro. IMPROVE only the craft: re-sculpt every {room_focal_features} so they read CRISPLY CHISELED with clean edge highlights; make every {room_repeat_elements} UNIQUE (remove cloned repeats); paint any flat gray or unfinished surfaces as weathered stone with clear daylit value modeling; add small environmental-storytelling clutter along walls and edges only ({room_clutter_vocab}) keeping the open floor areas clear. Keep the hand-painted oil-paint brushwork feel throughout. Do NOT add any text, letters, numbers, runic writing that reads as text, labels, legends, map insets, UI elements, frames, or borders — the plate must contain ONLY the diegetic painted scene.",
+      "prompt_template_note": "Reuses rooms.<room>.layered.pass2_slots (same slot values as the night pass2 — room_focal_features/room_repeat_elements/room_clutter_vocab are lighting-agnostic craft targets)."
+    },
+    "pass3_staging_last_day": {
+      "_doc": "Gemini instruction-edit DAY STAGING pass. Runs LAST, on pass2's output asset (pass2 is the SAME detail/populate pass as night — see pipeline doc above). DAY STAGING LAW (owner spec, G5a): bright directional daylight through windows/doorways as the PRIMARY light; interior ambient lifted but still painterly (not flat/museum-lit); hearth/braziers/candles still lit but SECONDARY accents; long soft shadows cast by the window/doorway light; palette shifts cool-neutral daylight vs the night plates' warm firelight. Day plates will NOT meet the night staging-law luma bands (near-black %, hot-pool %, median-L target) — that is EXPECTED and recorded as data, not a FAIL.",
+      "model": "model_google-gemini-3-1-flash",
+      "endpoint": "POST /v1/generate/custom/model_google-gemini-3-1-flash",
+      "body_template": {"prompt": "<PROMPT below, slots filled>", "image": "<asset id of pass2 output>", "numSamples": 1, "resolution": "2K"},
+      "prompt_template": "Edit this painterly isometric {room_setting_noun} plate. PRESERVE every detail exactly — the room layout, all {room_preserve_list} — change NOTHING about the content or composition. ONLY restage the LIGHTING into a DAYTIME scene: make {room_day_key_source} the dominant PRIMARY light source, bright directional daylight streaming through, with a cool-neutral daylight color temperature (not warm firelight). Lift the overall interior ambient so the room reads clearly and painterly (soft diffuse fill, NOT flat museum-lighting wash — keep gentle value modeling on every surface). Cast long SOFT directional shadows across the floor from the daylight direction. Keep {room_fill_source} still lit and glowing but now SECONDARY accents only, small warm pools that read as minor detail against the cool daylit scene, not the dominant light. The scene must read unmistakably as {room_space_desc} in daytime, keeping the hand-painted oil feel. Do NOT add any text, letters, numbers, runic writing that reads as text, labels, legends, map insets, UI elements, frames, or borders — the plate must contain ONLY the diegetic painted scene.",
+      "prompt_template_note": "slots: room_setting_noun, room_preserve_list (shared with night pass3), room_day_key_source (the daylight source noun phrase, e.g. 'the tall windows' daylight'), room_fill_source (shared with night pass3 — the secondary warm light, now demoted to accent), room_space_desc (shared with night pass3, day-appropriate phrasing implied by the prompt's own 'in daytime' clause)."
+    }
+  },
   "rooms": {
     "crypt": {
       "key_light": "brazier firelight",
@@ -124,6 +143,16 @@
           "room_fill_source": "the hanging iron lanterns",
           "room_space_desc": "a warm firelit tavern hall"
         }
+      },
+      "layered_day": {
+        "_doc": "G5a day-state variant (#1291). pass2 is shared with rooms.tavern.layered.pass2_slots; only pass3 (staging) differs — see layered_pipeline_day_2026_07_03.",
+        "pass3_slots": {
+          "room_setting_noun": "tavern",
+          "room_preserve_list": "wood floor planks, props, tankards, barrels, timber posts, the bar counter, the hearth",
+          "room_day_key_source": "bright daylight streaming in through the tavern's windows and open doorway",
+          "room_fill_source": "the hearth embers and the hanging iron lanterns",
+          "room_space_desc": "a sunlit tavern hall on a bright day"
+        }
       }
     },
     "church": {
@@ -146,6 +175,16 @@
           "room_key_source": "the altar candles",
           "room_fill_source": "the stained-glass light shaft",
           "room_space_desc": "a hushed candlelit cathedral nave"
+        }
+      },
+      "layered_day": {
+        "_doc": "G5a day-state variant (#1291). pass2 is shared with rooms.church.layered.pass2_slots; only pass3 (staging) differs — see layered_pipeline_day_2026_07_03.",
+        "pass3_slots": {
+          "room_setting_noun": "cathedral nave",
+          "room_preserve_list": "stone flagstones, props, carved columns, the altar, the stained-glass shaft",
+          "room_day_key_source": "bright daylight flooding through the tall stained-glass windows",
+          "room_fill_source": "the altar candles",
+          "room_space_desc": "a sunlit cathedral nave on a bright day"
         }
       }
     },
@@ -190,6 +229,16 @@
           "room_key_source": "the braziers flanking the dais",
           "room_fill_source": "the wall torches down the pillared hall",
           "room_space_desc": "a vast dark pillared throne hall"
+        }
+      },
+      "layered_day": {
+        "_doc": "G5a day-state variant (#1291). pass2 is shared with rooms.bosshall.layered.pass2_slots; only pass3 (staging) differs — see layered_pipeline_day_2026_07_03.",
+        "pass3_slots": {
+          "room_setting_noun": "throne hall",
+          "room_preserve_list": "carved reliefs, props, the throne, the dais, the banners, the pillars, the braziers",
+          "room_day_key_source": "bright daylight streaming in through tall clerestory windows high on the pillared hall's walls",
+          "room_fill_source": "the braziers flanking the dais and the wall torches down the hall",
+          "room_space_desc": "a vast sunlit pillared throne hall on a bright day"
         }
       }
     }

--- a/extensions/renderers/shared/room_recipes.json
+++ b/extensions/renderers/shared/room_recipes.json
@@ -38,19 +38,20 @@
       "strength_contract": "strength stays the camera-pin knob: 0.5-0.6 for the standard authored-pathing contract, 0.75 for a hero/supersampled macro pass. Low strength protects the camera-pinned composition; this knob is UNCHANGED by layering the two detail passes on top."
     },
     "pass2_detail_populate": {
-      "_doc": "Gemini instruction-edit detail/populate pass. Runs AFTER pass1, on pass1's output asset. Verbatim prompt copied from gen_layered.py:POLISH_PROMPT (2026-07-02 session).",
+      "_doc": "Gemini instruction-edit detail/populate pass. Runs AFTER pass1, on pass1's output asset. TEMPLATIZED 2026-07-03 (fix for the tavern-turned-crypt defect: this prompt was previously hardcoded with crypt nouns and applied unconditionally to every room by generate_room.py --layered, silently repainting a tavern base plate into a crypt). Slots are filled per-room from room_recipes.json:rooms.<room>.layered.pass2_slots. The crypt slot values were chosen so the RENDERED template is byte-identical to the prior hardcoded crypt prompt (regression-guarded by a unit test).",
       "model": "model_google-gemini-3-1-flash",
       "endpoint": "POST /v1/generate/custom/model_google-gemini-3-1-flash",
-      "body_template": {"prompt": "<PROMPT below>", "image": "<asset id of pass1 output>", "numSamples": 1, "resolution": "2K"},
-      "prompt": "Edit this painterly isometric dungeon plate. PRESERVE the exact composition, camera, room layout, and the dark dramatic lighting with its warm fire pools and deep shadows — do not brighten the scene. IMPROVE only the craft: re-sculpt every carved relief, capital, and the sarcophagus effigy so they read CRISPLY CHISELED with clean edge highlights; make every pillar and wall panel UNIQUE (remove cloned repeats); paint any flat gray or unfinished surfaces as weathered stone; add small environmental-storytelling clutter along walls and edges only (bones, fallen weapons, cobwebs, toppled urns, scattered coins, moss) keeping the open floor areas clear; deepen the black voids at the openings. Keep the hand-painted oil-paint brushwork feel throughout. Do NOT add any text, letters, numbers, runic writing that reads as text, labels, legends, map insets, UI elements, frames, or borders — the plate must contain ONLY the diegetic painted scene."
+      "body_template": {"prompt": "<PROMPT below, slots filled>", "image": "<asset id of pass1 output>", "numSamples": 1, "resolution": "2K"},
+      "prompt_template": "Edit this painterly isometric {room_setting_noun} plate. PRESERVE the exact composition, camera, room layout, and the dark dramatic lighting with its warm fire pools and deep shadows — do not brighten the scene. IMPROVE only the craft: re-sculpt every {room_focal_features} so they read CRISPLY CHISELED with clean edge highlights; make every {room_repeat_elements} UNIQUE (remove cloned repeats); paint any flat gray or unfinished surfaces as weathered stone; add small environmental-storytelling clutter along walls and edges only ({room_clutter_vocab}) keeping the open floor areas clear; deepen the black voids at the openings. Keep the hand-painted oil-paint brushwork feel throughout. Do NOT add any text, letters, numbers, runic writing that reads as text, labels, legends, map insets, UI elements, frames, or borders — the plate must contain ONLY the diegetic painted scene.",
+      "prompt_template_note": "slots: room_setting_noun (e.g. 'dungeon'/'tavern'/'cathedral'), room_focal_features (the crisp-carve target nouns), room_repeat_elements (the de-clone target nouns), room_clutter_vocab (comma list of wall/edge clutter items). Filled per-room from rooms.<room>.layered.pass2_slots by generate_room.py; crypt's slot values reproduce the prior hardcoded prompt byte-for-byte."
     },
     "pass3_staging_last": {
-      "_doc": "Gemini instruction-edit STAGING pass. Runs LAST, on pass2's output asset — this order is the load-bearing finding: staging must come after detail/populate, not before, because the detail pass flattens lighting and the staging pass restores it without erasing the detail gains. Prompt is a TEMPLATE — adapt the light-source nouns (fire pit / crypt / etc.) to the room's actual sources; the wording below is the crypt instance used in the 2026-07-02 eval.",
+      "_doc": "Gemini instruction-edit STAGING pass. Runs LAST, on pass2's output asset — this order is the load-bearing finding: staging must come after detail/populate, not before, because the detail pass flattens lighting and the staging pass restores it without erasing the detail gains. TEMPLATIZED 2026-07-03 (fix for the tavern-turned-crypt defect: this prompt was previously hardcoded with crypt light-source/space nouns and applied unconditionally to every room). Slots filled per-room from rooms.<room>.layered.pass3_slots; the crypt slot values reproduce the prior hardcoded crypt prompt byte-for-byte (regression-guarded by a unit test).",
       "model": "model_google-gemini-3-1-flash",
       "endpoint": "POST /v1/generate/custom/model_google-gemini-3-1-flash",
-      "body_template": {"prompt": "<PROMPT below, light-source nouns adapted to the room>", "image": "<asset id of pass2 output>", "numSamples": 1, "resolution": "2K"},
-      "prompt": "Edit this painterly isometric dungeon plate. PRESERVE every detail exactly — the room layout, all carved reliefs, props, bones, coins, cobwebs, pillars, the sarcophagus — change NOTHING about the content or composition. ONLY restage the LIGHTING into dramatic chiaroscuro: make the central fire pit the dominant warm key light with a bright hot pool around it, let the wall torches each cast a small local warm pool with HARD directional cast shadows from the pillars and props, and sink everything between the pools into deep cool blue-violet shadow — corners, far rooms, and floors away from lights should fall near-black. Steep warm-to-cool falloff, warm rim light on edges facing flames, cool bounce on shadow-side stone. The scene must read as small pools of firelight in a vast dark crypt, keeping the hand-painted oil feel. Do NOT add any text, letters, numbers, runic writing that reads as text, labels, legends, map insets, UI elements, frames, or borders — the plate must contain ONLY the diegetic painted scene.",
-      "prompt_template_note": "adapt the light-source nouns to the room's actual sources (e.g. swap 'central fire pit' / 'wall torches' / 'vast dark crypt' for the room's actual key/fill lights and space)."
+      "body_template": {"prompt": "<PROMPT below, slots filled>", "image": "<asset id of pass2 output>", "numSamples": 1, "resolution": "2K"},
+      "prompt_template": "Edit this painterly isometric {room_setting_noun} plate. PRESERVE every detail exactly — the room layout, all {room_preserve_list} — change NOTHING about the content or composition. ONLY restage the LIGHTING into dramatic chiaroscuro: make {room_key_source} the dominant warm key light with a bright hot pool around it, let {room_fill_source} each cast a small local warm pool with HARD directional cast shadows from the pillars and props, and sink everything between the pools into deep cool blue-violet shadow — corners, far rooms, and floors away from lights should fall near-black. Steep warm-to-cool falloff, warm rim light on edges facing flames, cool bounce on shadow-side stone. The scene must read as small pools of firelight in {room_space_desc}, keeping the hand-painted oil feel. Do NOT add any text, letters, numbers, runic writing that reads as text, labels, legends, map insets, UI elements, frames, or borders — the plate must contain ONLY the diegetic painted scene.",
+      "prompt_template_note": "slots: room_setting_noun, room_preserve_list (comma list of props/features to hold fixed), room_key_source (the dominant warm light noun phrase), room_fill_source (the secondary local-pool light noun phrase), room_space_desc (e.g. 'a vast dark crypt'). Filled per-room from rooms.<room>.layered.pass3_slots by generate_room.py."
     },
     "downscale_note": "If the Gemini 2K output exceeds the plate size (1344x768 contract), downscale with PIL LANCZOS to match — see generate_room.py --layered.",
     "sequencing_note": "Sequential jobs only (Scenario rule — concurrent paints collide/silently no-output). Each pass waits on the prior pass's terminal job status before submitting.",
@@ -64,20 +65,66 @@
       "base_plate": "crypt_plate_v2_s50.png",
       "canonical_plate": "crypt_firelit_v2.png",
       "backdrop_score": 7.4,
-      "status": "CURRENT BEST = crypt_dense_v1.png (2026-07-01, active on box) — produced by the gemini_polish_populate_pass on a painterly base; scored ~6.2 (robust +0.4 over the pre-polish baseline on an anchored 5-scorer panel). Supersedes the earlier eyeballed '7.4' claim (that number was inflated vs the harsh panel). Prior plate crypt_firelit_v2.png kept for reference. >=8 remains OPEN (see gemini_polish_populate_pass_2026_07_01 for the measured remaining gap + the clean-LoRA bet)."
+      "status": "CURRENT BEST = crypt_dense_v1.png (2026-07-01, active on box) — produced by the gemini_polish_populate_pass on a painterly base; scored ~6.2 (robust +0.4 over the pre-polish baseline on an anchored 5-scorer panel). Supersedes the earlier eyeballed '7.4' claim (that number was inflated vs the harsh panel). Prior plate crypt_firelit_v2.png kept for reference. >=8 remains OPEN (see gemini_polish_populate_pass_2026_07_01 for the measured remaining gap + the clean-LoRA bet).",
+      "layered": {
+        "_doc": "Slot values reproduce the pre-2026-07-03 hardcoded pass2/pass3 prompts byte-for-byte (regression-guarded).",
+        "pass2_slots": {
+          "room_setting_noun": "dungeon",
+          "room_focal_features": "carved relief, capital, and the sarcophagus effigy",
+          "room_repeat_elements": "pillar and wall panel",
+          "room_clutter_vocab": "bones, fallen weapons, cobwebs, toppled urns, scattered coins, moss"
+        },
+        "pass3_slots": {
+          "room_setting_noun": "dungeon",
+          "room_preserve_list": "carved reliefs, props, bones, coins, cobwebs, pillars, the sarcophagus",
+          "room_key_source": "the central fire pit",
+          "room_fill_source": "the wall torches",
+          "room_space_desc": "a vast dark crypt"
+        }
+      }
     },
     "crypt_stair": {
       "key_light": "brazier firelight",
       "shadow_casters": "the broad descending staircase and the pillar",
       "room_detail_tokens": "a broad descending stone staircase with worn carved steps leading down into shadow at the rear, crisp painterly flagstone mortar lines, weathered cracked stone relief, fluted pillar detail, an arched stone doorway in the back wall",
-      "_note": "a crypt STAIR-HALL room-unit (Sprint 3 composition): same firelit crypt look but the focal feature is a descending staircase (not a sarcophagus). Paired with the tomb unit via seed_gfx_crypt_2room.py."
+      "_note": "a crypt STAIR-HALL room-unit (Sprint 3 composition): same firelit crypt look but the focal feature is a descending staircase (not a sarcophagus). Paired with the tomb unit via seed_gfx_crypt_2room.py.",
+      "layered": {
+        "pass2_slots": {
+          "room_setting_noun": "dungeon",
+          "room_focal_features": "carved relief, capital, and the descending staircase's worn steps",
+          "room_repeat_elements": "pillar and wall panel",
+          "room_clutter_vocab": "bones, fallen weapons, cobwebs, toppled urns, scattered coins, moss"
+        },
+        "pass3_slots": {
+          "room_setting_noun": "dungeon",
+          "room_preserve_list": "carved reliefs, props, bones, coins, cobwebs, pillars, the descending staircase",
+          "room_key_source": "the central fire pit",
+          "room_fill_source": "the wall torches",
+          "room_space_desc": "a vast dark crypt stair-hall"
+        }
+      }
     },
     "tavern": {
       "key_light": "hearth fire and hanging iron lanterns",
       "shadow_casters": "the timber posts, the bar counter, and the tables",
       "room_detail_tokens": "worn wooden plank floor, heavy timber roof beams, ale barrels and tankards, a stone hearth with glowing embers, candlelit tables, hanging dried herbs",
       "base_plate": null,
-      "status": "TODO — needs a camera-pinned greybox/base plate (Unity render or txt2img at contract aspect)"
+      "status": "TODO — needs a camera-pinned greybox/base plate (Unity render or txt2img at contract aspect)",
+      "layered": {
+        "pass2_slots": {
+          "room_setting_noun": "tavern",
+          "room_focal_features": "timber beam joint, the bar counter's carved edge, and the hearth's stonework",
+          "room_repeat_elements": "timber post and wall plank",
+          "room_clutter_vocab": "tankards, ale barrels, hanging dried herbs, a coiled rope, spilled straw, cobwebs in the rafters"
+        },
+        "pass3_slots": {
+          "room_setting_noun": "tavern",
+          "room_preserve_list": "wood floor planks, props, tankards, barrels, timber posts, the bar counter, the hearth",
+          "room_key_source": "the stone hearth's glowing embers",
+          "room_fill_source": "the hanging iron lanterns",
+          "room_space_desc": "a warm firelit tavern hall"
+        }
+      }
     },
     "church": {
       "key_light": "altar candles and a shaft of stained-glass light",
@@ -85,13 +132,66 @@
       "shadow_casters": "the carved columns and the altar",
       "room_detail_tokens": "stone nave flagstones, fluted carved columns, a stone altar, gothic pointed arches, dust motes suspended in the light shaft",
       "base_plate": null,
-      "status": "TODO — needs a camera-pinned greybox/base plate"
+      "status": "TODO — needs a camera-pinned greybox/base plate",
+      "layered": {
+        "pass2_slots": {
+          "room_setting_noun": "cathedral nave",
+          "room_focal_features": "carved column capital, the stone altar's relief, and the gothic arch tracery",
+          "room_repeat_elements": "fluted column and pointed arch",
+          "room_clutter_vocab": "guttered candle stubs, fallen prayer beads, dust and cobwebs in the corners, a toppled candle stand, scattered hymnal pages"
+        },
+        "pass3_slots": {
+          "room_setting_noun": "cathedral nave",
+          "room_preserve_list": "stone flagstones, props, carved columns, the altar, the stained-glass shaft",
+          "room_key_source": "the altar candles",
+          "room_fill_source": "the stained-glass light shaft",
+          "room_space_desc": "a hushed candlelit cathedral nave"
+        }
+      }
     },
     "hell": {
       "key_light": "molten lava glow and gouts of flame",
       "shadow_casters": "the jagged obsidian spires and the bone piles",
       "room_detail_tokens": "rivers of molten orange lava casting hot light across the floor, jagged black volcanic obsidian rock, glowing cracks and drifting embers, sulfurous haze, charred bone piles, hanging rusted iron chains, ash falling",
-      "_note": "the depths of hell (owner north-star example) — a dramatic hellish cavern. Extreme warm lava key vs cool ash-grey shadows; tests the pipeline on an EXTREME biome beyond the proven cool-stone interiors."
+      "_note": "the depths of hell (owner north-star example) — a dramatic hellish cavern. Extreme warm lava key vs cool ash-grey shadows; tests the pipeline on an EXTREME biome beyond the proven cool-stone interiors.",
+      "layered": {
+        "pass2_slots": {
+          "room_setting_noun": "hellish cavern",
+          "room_focal_features": "jagged obsidian spire, glowing lava crack, and charred bone pile",
+          "room_repeat_elements": "obsidian spire and rusted chain",
+          "room_clutter_vocab": "charred bones, drifting embers, rusted chains, ash drifts, cracked volcanic rubble"
+        },
+        "pass3_slots": {
+          "room_setting_noun": "hellish cavern",
+          "room_preserve_list": "obsidian rock, props, bone piles, chains, glowing cracks, the lava rivers",
+          "room_key_source": "the molten lava rivers",
+          "room_fill_source": "the gouts of flame",
+          "room_space_desc": "a vast smoldering hellscape"
+        }
+      }
+    },
+    "bosshall": {
+      "key_light": "brazier firelight flanking the dais",
+      "shadow_casters": "the long pillared hall's columns, the throne, and the raised dais",
+      "room_detail_tokens": "a raised stone dais with a carved throne, tattered hanging banners along the pillared hall, tall braziers flanking the dais, worn flagstone floor, crisp painterly mortar lines, fluted pillar detail",
+      "base_plate": null,
+      "status": "greybox reference: bosshall_greybox_textured.png; incumbent render: bosshall_textured_v1.png (see ~/worldos-session-notes/). Authored 2026-07-03 for the G4 retry — mirrors the tavern/church entry structure; the staging-law pass-1 prompt language (loose oil brushstrokes, no-two-columns-identical, environmental clutter along walls) is shared via firelit_positive_template (#1274 adoption), not room-specific.",
+      "_note": "a throne hall / boss encounter room — dais + throne + banners + braziers + long pillared hall, distinct focal geometry from the crypt sarcophagus room.",
+      "layered": {
+        "pass2_slots": {
+          "room_setting_noun": "throne hall",
+          "room_focal_features": "carved relief, capital, and the throne's dais steps",
+          "room_repeat_elements": "pillar and hanging banner",
+          "room_clutter_vocab": "tattered banner tears, brazier ash, scattered coins, a discarded weapon at the dais foot, cobwebs, cracked flagstones"
+        },
+        "pass3_slots": {
+          "room_setting_noun": "throne hall",
+          "room_preserve_list": "carved reliefs, props, the throne, the dais, the banners, the pillars, the braziers",
+          "room_key_source": "the braziers flanking the dais",
+          "room_fill_source": "the wall torches down the pillared hall",
+          "room_space_desc": "a vast dark pillared throne hall"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Merge freeze — DO NOT MERGE

Opened under an active campaign freeze so the fix is reviewable/generatable from this worktree without landing on main.

## Defect (G4 overnight unit)

`extensions/renderers/shared/room_recipes.json`'s `layered_pipeline_2026_07_02` entry had pass2 (Gemini detail/populate) and pass3 (Gemini staging-last) prompts **hardcoded with crypt content** ("sarcophagus effigy", "vast dark crypt", stone reliefs). `extensions/renderers/godot/tools/generate_room.py --layered` applied these prompts unconditionally regardless of `--room`, so a tavern pass1 base plate was silently repainted into a crypt by pass2/pass3. The `rooms` dict also had no `bosshall`/throne-hall key at all, blocking the G4 boss-hall unit.

Evidence of the tavern-turned-crypt failure mode: see paths under `~/worldos-session-notes/` from the prior diagnosis pass (G4 overnight unit).

## Fix

- `pass2_detail_populate.prompt` / `pass3_staging_last.prompt` → `prompt_template` with `{room_setting_noun}`, `{room_focal_features}`, `{room_repeat_elements}`, `{room_clutter_vocab}` (pass2) and `{room_setting_noun}`, `{room_preserve_list}`, `{room_key_source}`, `{room_fill_source}`, `{room_space_desc}` (pass3).
- Each room recipe gains a `layered.pass2_slots` / `layered.pass3_slots` block supplying those values, derived from the room's existing base/pass1 vocabulary (`room_detail_tokens`).
- `generate_room.py` gains `_render_pass_prompt()` which fills the active room's slots into the template; a room with no `layered` block now fails loud (`sys.exit`) instead of silently reusing another room's content.
- **Regression guard**: crypt's slot values were chosen so the rendered pass2/pass3 prompts are **byte-identical** to the prior hardcoded literals — asserted by `test_crypt_pass{2,3}_prompt_byte_identical_to_legacy_hardcoded`. The adopted/scored crypt path is untouched.
- Added a `bosshall` room recipe (throne hall: dais, throne, banners, braziers, pillared hall), greybox reference `bosshall_greybox_textured.png`, incumbent render `bosshall_textured_v1.png` — mirrors the tavern/church entry structure and reuses the shared #1274 staging-law pass1 prompt (`firelit_positive_template`, not room-specific).

## Tests

`extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py` — 12 tests, no network/credentials required (pure template-rendering + JSON-schema checks):
- crypt pass2/pass3 byte-identical to legacy hardcoded prompt
- tavern pass2/pass3 contain tavern nouns, contain zero crypt-only nouns
- bosshall recipe present, slots render cleanly, base prompt uses the shared staging-law template
- every room with a `layered` block renders both passes without leftover `{slot}` braces
- a room missing a `layered` block fails loud (`SystemExit`), not silent

```
python3 -m pytest extensions/renderers/godot/tools/tests/test_layered_prompt_templating.py -q -p no:xdist
12 passed, 6 subtests passed
```

`qa/fast_gate.sh`: 245 passed (deterministic engine tier — unaffected by this renderer-only change, run per task spec).

## Next (this worktree, not this PR)

Sequential (never concurrent) generation retries: tavern from `tavern_greybox_wood.png`, bosshall from `bosshall_greybox_textured.png`, each followed by a control-anchored scoring panel vs incumbent. Results reported separately.