### PR TITLE
assets: wave-1 monster registry entries (#1290)

### DIFF
--- a/data/asset-registry/registry.json
+++ b/data/asset-registry/registry.json
@@ -50,6 +50,37 @@
       "default_used": false
     },
 
+    "skeleton_archer": {
+      "kind": "monster",
+      "model_ref": "Assets/chars_v2/skeleton_archer/rigged.fbx",
+      "albedo_ref": "Assets/chars_v2/skeleton_archer/albedo.jpg",
+      "anim_ref": "Assets/chars_v2/skeleton_archer/anim_idle.fbx",
+      "gen_recipe": "meshy:humanoid moveset (9-clip: idle/walk/run/attack/cast/block/dodge/hit/death), rigged.fbx imported animationType=Generic; albedo from model.glb embedded PBR (wave-1 #1290)",
+      "version": "1.0.0",
+      "critic_score": 0.0,
+      "default_used": false
+    },
+    "cultist": {
+      "kind": "monster",
+      "model_ref": "Assets/chars_v2/cultist/rigged.fbx",
+      "albedo_ref": "Assets/chars_v2/cultist/albedo.jpg",
+      "anim_ref": "Assets/chars_v2/cultist/anim_idle.fbx",
+      "gen_recipe": "meshy:humanoid moveset (9-clip), animationType=Generic; deliberately bright/pale ivory-robe albedo (#1282 light_tint probe body) (wave-1 #1290)",
+      "version": "1.0.0",
+      "critic_score": 0.0,
+      "default_used": false
+    },
+    "ghoul": {
+      "kind": "monster",
+      "model_ref": "Assets/chars_v2/ghoul/rigged.fbx",
+      "albedo_ref": "Assets/chars_v2/ghoul/albedo.jpg",
+      "anim_ref": "Assets/chars_v2/ghoul/anim_idle.fbx",
+      "gen_recipe": "tripo:text-to-model -> rig(biped, spec=mixamo) -> retarget idle+walk only (creatures support fewer biped presets); rigged.fbx imported animationType=Generic (wave-1 #1290)",
+      "version": "1.0.0",
+      "critic_score": 0.0,
+      "default_used": false
+    },
+
     "template_human": {
       "kind": "character",
       "model_ref": "Assets/painterly/models/hero.fbx",


### PR DESCRIPTION
## Wave-1 monster registry entries (#1290)

Adds 3 wave-1 monster actors to `data/asset-registry/registry.json`, mirroring the existing `goblin` entry shape (`kind: monster`, box `Assets/chars_v2/<name>/` refs). Binaries are gitignored on the box Unity tree; only this manifest is committed.

| slot | service | clips | notes |
|---|---|---|---|
| `skeleton_archer` | meshy | 9-clip moveset | armored hooded figure (Meshy read 'skeletal archer' as armored rogue — acceptable, see manifest caveat) |
| `cultist` | meshy | 9-clip moveset | bright ivory-robe albedo — the #1282 light_tint probe body |
| `ghoul` | tripo | idle + walk only | biped creature; combat clips can be retargeted later |

All 3 imported `animationType=Generic` (Meshy/Tripo bone names silently drop clips under Humanoid).

### Deployed + validated on GEX44
- Imported to box `Assets/chars_v2/{skeleton_archer,cultist,ghoul}/`, prefabs load, skinned mesh present.
- Grounded single-actor renders on the `crypt_dense_v1` plate — all pass the non-black gate, all grounded (feet at Y=0, coupled to selection ring). Renders in `~/worldos-session-notes/actors-wave1/renders/`.
- **Import finding:** these FBX import UPRIGHT in Unity (Y-up) — the `Euler(-90)` stand-up from the goblin/hero pipeline must NOT be applied (it tips them on their back); yaw-only facing is correct. The ghoul (Tripo rig) also needed `Renderer.bounds` grounding instead of `BakeMesh×localToWorldMatrix` (which double-counts scale on that rig and decoupled it from its ring).

### Tests
- `viewer/tests/test_asset_registry.py`: 11 passed
- 3 new slots resolve via the Python twin to their box paths
- `qa/fast_gate.sh`: 245 passed (T0 PASS)

### ⛔ HOLD — do not merge
Held per campaign freeze. `critic_score` left at 0.0 (not yet visual-critic scored). Additive data-only change (no renderer edits — registry resolution is exact→alias→default).