### PR TITLE
qa: passive-perception WARN (#1287) + run-invalidation guard (#1285)

### DIFF
--- a/qa/BEHAVIORAL_GATE_TAXONOMY.json
+++ b/qa/BEHAVIORAL_GATE_TAXONOMY.json
@@ -2,6 +2,12 @@
   "_README": "Maps every behavioral-gate CHECK emitted by qa/assert_behavioral.py to a root-cause CATEGORY, candidate code locations, an exact retest command, and a one-line hint. Consumed by qa/root_cause_analyzer.py to turn a RED gate into actionable locations. PURE METADATA — no code reads/writes product state from here. Categories: ENGINE_INVARIANT (a state-integrity fact the engine, the sole writer, must hold), DM_ADHERENCE (the DM agent's play behavior — what it narrated / resolved / which features it used), HARNESS_WIRING (the QA plumbing itself — the player facade, the moves/chat logs, honesty stamps, version-skew tool rejections). Keep this in sync when a chk() name is added/removed in assert_behavioral.py. An UNKNOWN check (not listed here) degrades gracefully in the analyzer to category UNKNOWN with a generic hint.",
   "_retest_note": "Retest commands re-run the relevant QA lane; they DO NOT write committed artifacts. run_duo.sh / run_combat_sprint.sh write only under qa/transcripts/ + qa/state/<RUN>/ (gitignored run scratch). Re-run the SAME run id to re-score the same artifacts, or a fresh id for a new playtest.",
   "checks": {
+    "run_infra_valid": {
+      "category": "HARNESS_WIRING",
+      "likely_code_locations": ["qa/assert_behavioral.py:307", "qa/lib_beat_driver.sh", "qa/run_duo.sh"],
+      "retest": "bash qa/run_duo.sh duo-retest",
+      "hint": "A stamped <run>.infra_invalid.json sentinel sits next to run.jsonl (qa/lib_beat_driver.sh worldos_mark_run_infra_invalid, #1285) — the beat driver detected N consecutive DM beat failures mid-run (a quota window / host-session death, the rri-a1-duo/duo2 defect class), which invalidates the run: it measures infra collapse, not the product. FATAL — never cite this transcript as a clean product measurement; re-run instead. Check the sentinel's `reason` / `consecutive_failed_beats` fields, then investigate WHY the DM beats died (auth/timeout/quota) in the beat driver."
+    },
     "dm_produced_output": {
       "category": "HARNESS_WIRING",
       "likely_code_locations": ["qa/run_duo.sh", "qa/lib_beat_driver.sh", "servers/engine/server.py"],
@@ -43,6 +49,12 @@
       "likely_code_locations": ["qa/lib_beat_driver.sh", "qa/run_duo.sh", "qa/dm_narration_fallback.py"],
       "retest": "bash qa/run_duo.sh duo-retest",
       "hint": "Beats were stamped beat_failed / fallback_recovered (a dead or error-class DM turn whose prose was recovered from the engine log via the #357 fallback). Report-only; investigate WHY the DM turn died (timeout / auth / tool error) in the beat driver."
+    },
+    "dm_beat_honesty_no_consecutive_collapse": {
+      "category": "HARNESS_WIRING",
+      "likely_code_locations": ["qa/assert_behavioral.py:410", "qa/lib_beat_driver.sh", "qa/run_duo.sh", "qa/dm_narration_fallback.py"],
+      "retest": "bash qa/run_duo.sh duo-retest",
+      "hint": "N consecutive DM beat-failures (beat_failed=True rows, in order, in $CHAT) crossed the threshold (3) — a run of back-to-back failed beats means the run COLLAPSED ON INFRA (a quota window / host-session death mid-run, the rri-a1-duo/duo2 defect class), not scattered product defects. The chat-log-derived twin of run_infra_valid below; catches runs whose runner predates the #1285 sentinel or doesn't yet wire the abort-and-stamp path (run_party.sh / ui_playtest.sh). FATAL: this transcript is contaminated and must be re-run, not cited as a clean product measurement. Investigate WHY the DM turns died (timeout / auth / quota / tool error) in the beat driver, same as dm_beat_honesty above."
     },
     "player_used_facade": {
       "category": "HARNESS_WIRING",
@@ -97,6 +109,12 @@
       "likely_code_locations": ["skills/dungeon-master/reference/combat.md", "servers/engine/server.py"],
       "retest": "bash qa/run_combat_sprint.sh sprint-retest",
       "hint": "DM narration staged an ambush (lunge from the shadows / sprung trap / 'never saw it coming') but start_combat ran with no surprise evaluation — no surpriser_ids and no `surprise` key in the return — so the passive-Perception-vs-Stealth gate was skipped and the ambush had no mechanical effect (#1271). Reinforce 'pass surpriser_ids=[attacker id(s)] for any narrated ambush' in the DM combat runbook; the engine rolls Stealth vs passive Perception and applies SRD-5.2 initiative disadvantage to the surprised set. WARN only."
+    },
+    "detection_beat_requires_check": {
+      "category": "DM_ADHERENCE",
+      "likely_code_locations": ["qa/assert_behavioral.py:1029", "skills/dungeon-master/reference/combat.md"],
+      "retest": "bash qa/run_duo.sh duo-retest",
+      "hint": "DM narration plainly staged an NPC noticing/spotting/hearing the party ('the guard's eyes snap toward you', 'she catches a sound') with no preceding Perception/Insight/Investigation skill_check (or a reason-tagged roll) in the SAME beat — DM fiat, not a gated roll (#1287, promoted from the scorer's suggested_fix; same family as ambush_ran_surprise_gate above). Reinforce 'call skill_check before narrating a detection/notice beat' in the DM combat runbook. WARN only — prose alone is a soft signal and a false-fire here should never cap an otherwise-clean run."
     },
     "party_location_coherence": {
       "category": "ENGINE_INVARIANT",

--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -43,6 +43,25 @@ except Exception:  # pragma: no cover - defensive
     engagement_coverage = None
 
 
+def _run_infra_invalid_sentinel(run_jsonl_path: str) -> dict | None:
+    """#1285 — the run-invalidation guard's scorer-side reader. qa/lib_beat_driver.sh's
+    worldos_mark_run_infra_invalid stamps a sibling ``<run>.infra_invalid.json`` file (derived
+    from the run.jsonl path exactly like ``<run>.state.json`` / ``<run>.chat.jsonl`` already are)
+    when N consecutive DM beats fail — a quota window or host/session death mid-run (rri-a1-duo/
+    duo2), not a product defect. Returns the parsed sentinel dict when present + valid, else None
+    (no new CLI arg needed; this stays back-compat with every existing caller). Mirrors
+    worldos_validate_lens_file's sentinel discipline for the bash side."""
+    p = Path(run_jsonl_path)
+    marker = p.with_name(p.name[: -len(p.suffix)] + ".infra_invalid.json") if p.suffix else p.with_suffix(".infra_invalid.json")
+    if not marker.exists() or not marker.stat().st_size:
+        return None
+    try:
+        d = json.loads(marker.read_text(encoding="utf-8"))
+    except Exception:
+        return {"infra_invalid": True, "reason": "sentinel file present but unparseable"}
+    return d if isinstance(d, dict) else {"infra_invalid": True, "reason": "sentinel file malformed"}
+
+
 def _load_jsonl(p: str) -> list[dict]:
     out: list[dict] = []
     if not p or not Path(p).exists():
@@ -127,6 +146,24 @@ _AMBUSH_SIGNAL = [
 ]
 _AMBUSH_SIGNAL_RE = [re.compile(p, re.I) for p in _AMBUSH_SIGNAL]
 
+# DETECTION SIGNALS (#1287, WARN — same family as the ambush/surprise WARN #1271). DM narration
+# that plainly stages an NPC "noticing" or "spotting" the party — a passive-Perception/Insight
+# beat the rules gate behind a roll, not DM fiat. High-confidence, detection-only phrasings (a
+# clean beat with no detection language scores 0 and can never false-fire).
+_DETECTION_SIGNAL = [
+    r"\b(?:notices?|spots?|catches? sight of|glimpses?) (?:you|them|the party|movement|a shape)\b",
+    r"\b(?:hears?|catches?) (?:you|them|the party|a sound|footsteps|a noise)\b",
+    r"\b(?:eyes?|gaze) (?:snaps?|flicks?|turns?) (?:to|toward|on) (?:you|them|the party)\b",
+    r"\b(?:doesn'?t|does not|fails? to) notice (?:you|them|the party)\b",
+    r"\bpasses? (?:you|them|the party) by, unaware\b",
+    r"\bstiffens?,? sensing\b",
+]
+_DETECTION_SIGNAL_RE = [re.compile(p, re.I) for p in _DETECTION_SIGNAL]
+# Skills that gate a detection beat mechanically (skill_check(skill=…)) plus a bare `roll` whose
+# `reason` names the same family — so a DM that rolled raw dice for "perception" still counts.
+_DETECTION_SKILLS = ("perception", "insight", "investigation")
+_DETECTION_ROLL_REASON_RE = re.compile(r"\b(?:perception|insight|investigation)\b", re.I)
+
 
 def _tool_events(events: list[dict]) -> list[tuple[str, dict, object, bool, str]]:
     """Ordered (short_name, input, result_obj_or_None, is_error, raw_text).
@@ -169,6 +206,40 @@ def _tool_events(events: list[dict]) -> list[tuple[str, dict, object, bool, str]
     return out
 
 
+def _detection_beats_without_check(events: list[dict]) -> list[str]:
+    """DM narration text blocks that read like a detection beat (#1287 — same family as the
+    ambush/surprise WARN #1271) with NO qualifying Perception/Insight/Investigation tool call
+    in the SAME beat. A "beat" here is the run of events since the previous DM text block (i.e.
+    every tool_use/tool_result the DM issued while producing this reply) — a skill_check(skill=
+    perception|insight|investigation) or a bare roll(reason=~that family) ANYWHERE in that span
+    satisfies the gate; walking event order (not the whole run, unlike the ambush check) is what
+    makes this "same beat", not "anywhere in the transcript". Returns the offending text blocks."""
+    offenders: list[str] = []
+    span_has_check = False
+    for ev in events:
+        if ev.get("type") not in ("assistant", "user"):
+            continue
+        for b in (ev.get("message", {}) or {}).get("content") or []:
+            if not isinstance(b, dict):
+                continue
+            if b.get("type") == "tool_use":
+                short = (b.get("name") or "").split("__")[-1]
+                inp = b.get("input") or {}
+                if short == "skill_check":
+                    skill = str(inp.get("skill") or inp.get("ability") or inp.get("skill_name")
+                                or inp.get("check") or "").strip().lower()
+                    if skill in _DETECTION_SKILLS:
+                        span_has_check = True
+                elif short == "roll" and _DETECTION_ROLL_REASON_RE.search(str(inp.get("reason") or "")):
+                    span_has_check = True
+            elif b.get("type") == "text" and (b.get("text") or "").strip():
+                text = b["text"]
+                if any(rx.search(text) for rx in _DETECTION_SIGNAL_RE) and not span_has_check:
+                    offenders.append(text)
+                span_has_check = False  # a new beat starts after each DM reply
+    return offenders
+
+
 # A player turn that reads like DM narration or asserts an outcome (the dice's/DM's
 # call). Heuristic only -> a WARNING, not a hard fail (It.1's constrained tool surface
 # is the real, structural fix; this just surfaces drift until then).
@@ -209,6 +280,20 @@ def main() -> int:
 
     def chk(name: str, ok: bool, detail: str = "", fatal: bool = True) -> None:
         checks.append((name, bool(ok), fatal, detail))
+
+    # 0) RUN-INVALIDATION GUARD (#1285, FATAL). A stamped .infra_invalid.json sentinel means the
+    # beat driver detected N consecutive DM beat failures mid-run (a quota window / host-session
+    # death — rri-a1-duo/duo2: 5 straight is_error beats, narrated 'could not resolve this beat'
+    # at peak dramatic tension, then scored to a 3.8 that was actually the infra failure). FATAL,
+    # not WARN: this run's transcript is contaminated and must never be cited as a clean product
+    # measurement — run_duo.sh's existing gate-RED path (worldos_cap_score_red) already caps every
+    # scorecard to ≤2.5/INVALID on any FATAL failure, so this reuses that machinery for free.
+    _infra = _run_infra_invalid_sentinel(sys.argv[1])
+    chk("run_infra_valid", _infra is None,
+        f"run stamped INFRA-INVALID: {(_infra or {}).get('reason', '(no reason recorded)')} "
+        f"(consecutive_failed_beats={(_infra or {}).get('consecutive_failed_beats', '?')}) — "
+        f"this measures infra collapse, not the product; the run must be re-run, not cited.",
+        fatal=True)
 
     # 1) the run produced real DM output (catches the dead/blank run)
     chk("dm_produced_output", dm_text > 0 or sum(tools.values()) > 0,
@@ -286,6 +371,33 @@ def main() -> int:
             f"surfaced as visible failure rows (dead/error-class DM turns); recovered rows used "
             f"the #357 engine-log fallback. Reported only; gate policy stays #757's call.",
             fatal=False)
+
+        # #1285: promote an 'N consecutive error beats' VARIANT of dm_beat_honesty to a
+        # run-invalidating (FATAL) marker — the chat-log-derived twin of the run_infra_valid
+        # sentinel check above. This is the SAME rri-a1-duo/duo2 defect class (a quota window or
+        # host/session death that fails several beats in a row, not scattered across the run) but
+        # derived independently from $CHAT's beat_failed rows in order, so a run whose runner
+        # predates the #1285 sentinel (or a non-run_duo caller: run_party.sh / ui_playtest.sh,
+        # which share worldos_chatlog_dm_failed but not yet the abort-and-stamp wiring) still gets
+        # caught here rather than reading as a merely-WARNed, cite-able run. Threshold matches the
+        # beat driver's default (qa/lib_beat_driver.sh WORLDOS_INFRA_INVALID_STREAK=3).
+        _CONSECUTIVE_INVALID_THRESHOLD = 3
+        _max_consecutive_failed = 0
+        _run_len = 0
+        for r in chat:
+            if r.get("role") != "dm":
+                continue
+            if r.get("beat_failed") is True:
+                _run_len += 1
+                _max_consecutive_failed = max(_max_consecutive_failed, _run_len)
+            else:
+                _run_len = 0
+        chk("dm_beat_honesty_no_consecutive_collapse", _max_consecutive_failed < _CONSECUTIVE_INVALID_THRESHOLD,
+            f"{_max_consecutive_failed} consecutive DM beat failure(s) in $CHAT (threshold="
+            f"{_CONSECUTIVE_INVALID_THRESHOLD}) — a run of back-to-back failed beats is an infra "
+            f"collapse (quota window / host-session death mid-run), not scattered product defects; "
+            f"this transcript is contaminated and must not be cited as a clean product measurement.",
+            fatal=True)
 
     # 3.5) constrained-player (It.1 facade): the player must actually ACT through its
     # tools. An empty moves log means the facade was blocked/unused (e.g. a missing
@@ -891,6 +1003,20 @@ def main() -> int:
             "rolls Stealth vs passive Perception and applies SRD-5.2 initiative disadvantage to the "
             "surprised set.",
             fatal=False)
+
+    # DETECTION-BEAT-REQUIRES-CHECK GATE (#1287, WARN — same family as #1271 above). DM narration
+    # that plainly stages an NPC noticing/spotting/hearing the party ("the guard's eyes snap
+    # toward you", "she catches a sound") without a preceding Perception/Insight/Investigation
+    # skill_check (or a reason-tagged roll) in the SAME beat is DM fiat, not a gated roll — the
+    # rri-a1-duo defect this promotes from the scorer's suggested_fix. WARN, never fatal: prose
+    # alone is a soft signal and a false-fire here should never cap an otherwise-clean run.
+    _detection_offenders = _detection_beats_without_check(events)
+    chk("detection_beat_requires_check", not _detection_offenders,
+        f"{len(_detection_offenders)} DM narration beat(s) staged an NPC detecting/noticing the "
+        f"party with no preceding Perception/Insight/Investigation skill_check (or reason-tagged "
+        f"roll) in the same beat — DM fiat, not a gated roll — e.g. "
+        f"{_detection_offenders[0][:90]!r}" if _detection_offenders else "",
+        fatal=False)
 
     def _quest_reward_already_awarded(q: dict) -> bool:
         return any(bool(q.get(k)) for k in ("milestone_awarded", "awarded", "rewarded", "xp_awarded"))

--- a/qa/assert_behavioral.py
+++ b/qa/assert_behavioral.py
@@ -209,16 +209,26 @@ def _tool_events(events: list[dict]) -> list[tuple[str, dict, object, bool, str]
 def _detection_beats_without_check(events: list[dict]) -> list[str]:
     """DM narration text blocks that read like a detection beat (#1287 — same family as the
     ambush/surprise WARN #1271) with NO qualifying Perception/Insight/Investigation tool call
-    in the SAME beat. A "beat" here is the run of events since the previous DM text block (i.e.
-    every tool_use/tool_result the DM issued while producing this reply) — a skill_check(skill=
-    perception|insight|investigation) or a bare roll(reason=~that family) ANYWHERE in that span
-    satisfies the gate; walking event order (not the whole run, unlike the ambush check) is what
-    makes this "same beat", not "anywhere in the transcript". Returns the offending text blocks."""
+    in the SAME beat. A "beat" here is ONE assistant turn (one `assistant`-type event) plus every
+    tool_use/tool_result it issued while producing its reply — a skill_check(skill=perception|
+    insight|investigation) or a bare roll(reason=~that family) ANYWHERE earlier in that turn (or
+    a preceding turn still in the same beat, before the NEXT assistant turn starts) satisfies the
+    gate. The span resets at the START of each new assistant event (not after every text block),
+    so multiple text blocks within one reply — or a tool call followed by narration later in the
+    SAME turn — never false-split a beat. Returns the offending text blocks."""
     offenders: list[str] = []
     span_has_check = False
+    prev_type = None
     for ev in events:
-        if ev.get("type") not in ("assistant", "user"):
+        ev_type = ev.get("type")
+        if ev_type not in ("assistant", "user"):
             continue
+        # A new beat starts at the first assistant event AFTER a text-terminated prior turn — i.e.
+        # the transition into a fresh assistant event resets the check-seen flag. Consecutive
+        # assistant events (a turn spanning several tool-call round-trips) and the interleaved
+        # user/tool_result events in between all stay part of the SAME beat.
+        if ev_type == "assistant" and prev_type == "assistant-with-text":
+            span_has_check = False
         for b in (ev.get("message", {}) or {}).get("content") or []:
             if not isinstance(b, dict):
                 continue
@@ -236,7 +246,12 @@ def _detection_beats_without_check(events: list[dict]) -> list[str]:
                 text = b["text"]
                 if any(rx.search(text) for rx in _DETECTION_SIGNAL_RE) and not span_has_check:
                     offenders.append(text)
-                span_has_check = False  # a new beat starts after each DM reply
+        if ev_type == "assistant":
+            has_text = any(isinstance(b, dict) and b.get("type") == "text" and (b.get("text") or "").strip()
+                            for b in (ev.get("message", {}) or {}).get("content") or [])
+            prev_type = "assistant-with-text" if has_text else "assistant"
+        else:
+            prev_type = ev_type
     return offenders
 
 

--- a/qa/gate_corpus/builder.py
+++ b/qa/gate_corpus/builder.py
@@ -47,6 +47,28 @@ REAL_RED_PROVENANCE = {
     "narration_no_ooc_leak": "2026-06-17 craft audit (#972): 5+ first-person OOC authoring preambles in a 4.6-prose run, un-gated, inflated the LLM story score to 4.8",
 }
 
+# Explicit TODO reasons for FATAL checks the coverage audit below finds uncovered, where the
+# generic auto-flagged reason isn't the truthful story. A check listed here is INTENTIONALLY
+# left out of _CASES_SPEC (not just "not gotten to yet") — the reason explains why a corpus
+# fixture doesn't fit and points at the alternate coverage that closes the gap.
+TODO_REASONS = {
+    # #1285: run_infra_valid trips on a SIDECAR <run>.infra_invalid.json sentinel file next to
+    # run.jsonl (qa/lib_beat_driver.sh worldos_mark_run_infra_invalid), not on the content of
+    # run.jsonl/state.json/chat.jsonl/moves.jsonl the corpus's _write_case + _argv_for model —
+    # those four are the gate's only POSITIONAL argv artifacts; a 5th sidecar file has no slot in
+    # that model. Not a fiction-content bundle the builder can synthesize; covered instead by
+    # qa/test_assert_behavioral.py::test_run_infra_invalid_sentinel_flips_red +
+    # test_no_infra_invalid_sentinel_passes + test_infra_invalid_sentinel_caps_no_other_gate_weakened,
+    # and by qa/test_run_invalidation_guard.sh (exercises the real bash stamping helper end-to-end).
+    "run_infra_valid": (
+        "infra-sentinel guard: RED requires a .infra_invalid.json sidecar next to run.jsonl "
+        "(stamped by qa/lib_beat_driver.sh worldos_mark_run_infra_invalid), not a fiction bundle "
+        "the builder synthesizes via _write_case's 4 positional artifacts — covered by "
+        "qa/test_assert_behavioral.py::test_run_infra_invalid_sentinel_flips_red (+ 2 sibling "
+        "tests) and qa/test_run_invalidation_guard.sh"
+    ),
+}
+
 
 # ── event / artifact builders ─────────────────────────────────────────────────
 
@@ -443,6 +465,28 @@ def case_structural_completeness_authored_warn():
     return events, state, None, None
 
 
+def case_dm_beat_honesty_no_consecutive_collapse():
+    # chk (#1285/#1287 chat-log twin of run_infra_valid): 3+ CONSECUTIVE dm chat rows stamped
+    # beat_failed=True (qa/lib_beat_driver.sh worldos_chatlog_dm_failed) is a run-invalidating
+    # infra collapse (quota window / host-session death mid-run), not scattered product defects —
+    # the rri-a1-duo/duo2 defect class. Threshold matches _CONSECUTIVE_INVALID_THRESHOLD=3. A
+    # leading clean dm/player exchange keeps both_sides_acted + dm_voices_characters satisfied so
+    # this stays the SOLE fatal fail; the 3 failed rows carry no quoted dialogue.
+    def _failed_beat_row() -> dict:
+        row = _dm_chat_row("(beat failed — no reply)")
+        row["beat_failed"] = True
+        return row
+
+    chat = [
+        _player_chat_row("[say] hello"),
+        _dm_chat_row('"Welcome," she says.'),
+        _failed_beat_row(),
+        _failed_beat_row(),
+        _failed_beat_row(),
+    ]
+    return _roll(), _clean_player_state(), chat, None
+
+
 def case_xp_awarded_on_progression():
     # chk A5: xp mode, session advanced (day>1 AND visited>=2 so the world floors pass), a
     # reward-worthy seam (a COMPLETED quest — NOT a dead monster, so xp_not_orphaned stays inert),
@@ -488,6 +532,8 @@ _CASES_SPEC: list[tuple] = [
     ("xp_not_orphaned", case_xp_not_orphaned, "xp_not_orphaned"),
     ("xp_awarded_on_progression", case_xp_awarded_on_progression, "xp_awarded_on_progression"),
     ("structural_completeness", case_structural_completeness, "structural_completeness"),
+    ("dm_beat_honesty_no_consecutive_collapse", case_dm_beat_honesty_no_consecutive_collapse,
+     "dm_beat_honesty_no_consecutive_collapse"),
 ]
 
 # GREEN cases — the inverse guard. These fixtures must NOT trip their named check (the gate must
@@ -561,7 +607,8 @@ def build() -> dict:
             "case_dir": f"TODO__{missing}",
             "expected_red_check": missing,
             "todo": True,
-            "reason": "no faithful minimal fixture constructed yet (auto-flagged by builder)",
+            "reason": TODO_REASONS.get(
+                missing, "no faithful minimal fixture constructed yet (auto-flagged by builder)"),
         })
 
     # GREEN cases — known-GREEN bundles that lock a deliberate FATAL->WARN scope guard (the inverse

--- a/qa/gate_corpus/cases/dm_beat_honesty_no_consecutive_collapse/chat.jsonl
+++ b/qa/gate_corpus/cases/dm_beat_honesty_no_consecutive_collapse/chat.jsonl
@@ -1,0 +1,5 @@
+{"role": "player", "text": "[say] hello"}
+{"role": "dm", "text": "\"Welcome,\" she says."}
+{"role": "dm", "text": "(beat failed \u2014 no reply)", "beat_failed": true}
+{"role": "dm", "text": "(beat failed \u2014 no reply)", "beat_failed": true}
+{"role": "dm", "text": "(beat failed \u2014 no reply)", "beat_failed": true}

--- a/qa/gate_corpus/cases/dm_beat_honesty_no_consecutive_collapse/run.jsonl
+++ b/qa/gate_corpus/cases/dm_beat_honesty_no_consecutive_collapse/run.jsonl
@@ -1,0 +1,2 @@
+{"type": "assistant", "message": {"content": [{"type": "tool_use", "id": "t_roll", "name": "mcp__engine__roll", "input": {"sides": 20}}]}}
+{"type": "user", "message": {"content": [{"type": "tool_result", "tool_use_id": "t_roll", "content": [{"type": "text", "text": "{\"total\": 14}"}], "is_error": false}]}}

--- a/qa/gate_corpus/cases/dm_beat_honesty_no_consecutive_collapse/state.json
+++ b/qa/gate_corpus/cases/dm_beat_honesty_no_consecutive_collapse/state.json
@@ -1,0 +1,27 @@
+{
+  "party": [
+    "pc1"
+  ],
+  "leveling_mode": "xp",
+  "day": 2,
+  "time_of_day": "evening",
+  "current_location_id": "loc_camp",
+  "characters": {
+    "pc1": {
+      "name": "Dal",
+      "kind": "player",
+      "xp": 300,
+      "location_id": "loc_camp"
+    }
+  },
+  "locations": {
+    "loc_start": {
+      "name": "Tavern",
+      "visited": true
+    },
+    "loc_camp": {
+      "name": "Camp",
+      "visited": true
+    }
+  }
+}

--- a/qa/gate_corpus/manifest.json
+++ b/qa/gate_corpus/manifest.json
@@ -187,6 +187,22 @@
         "state.json"
       ],
       "real_red_provenance": ""
+    },
+    {
+      "case_dir": "dm_beat_honesty_no_consecutive_collapse",
+      "expected_red_check": "dm_beat_honesty_no_consecutive_collapse",
+      "artifacts": [
+        "run.jsonl",
+        "state.json",
+        "chat.jsonl"
+      ],
+      "real_red_provenance": ""
+    },
+    {
+      "case_dir": "TODO__run_infra_valid",
+      "expected_red_check": "run_infra_valid",
+      "todo": true,
+      "reason": "infra-sentinel guard: RED requires a .infra_invalid.json sidecar next to run.jsonl (stamped by qa/lib_beat_driver.sh worldos_mark_run_infra_invalid), not a fiction bundle the builder synthesizes via _write_case's 4 positional artifacts \u2014 covered by qa/test_assert_behavioral.py::test_run_infra_invalid_sentinel_flips_red (+ 2 sibling tests) and qa/test_run_invalidation_guard.sh"
     }
   ],
   "green_cases": [

--- a/qa/lib_beat_driver.sh
+++ b/qa/lib_beat_driver.sh
@@ -346,6 +346,8 @@ record_dm_reply() {
     chatlog dm "$text" "$plain_extra"
   fi
   WORLDOS_FALLBACK_RECOVERED=0
+  # #1285: a genuine beat resets the consecutive-failure streak (mirrors worldos_chatlog_dm).
+  WORLDOS_DM_BEATS_FAILED_STREAK=0
 }
 
 # worldos_chatlog_dm TEXT — `chatlog dm TEXT` for the runners that write the dm row directly
@@ -359,6 +361,9 @@ worldos_chatlog_dm() {
     chatlog dm "$1"
   fi
   WORLDOS_FALLBACK_RECOVERED=0
+  # #1285: a genuine beat (this function is only called with a NON-empty resolved reply) resets
+  # the consecutive-failure streak — see worldos_chatlog_dm_failed below.
+  WORLDOS_DM_BEATS_FAILED_STREAK=0
 }
 
 # ── SYN-01 (#757/#745): dead-beat failure classification — the honesty layer ────────────────
@@ -468,12 +473,57 @@ worldos_dm_logged_new_prose() {
 # row text is WORLDOS_DM_FAILED_BEAT_TEXT — never an error string, never recycled prose, never
 # blank, never hidden (no engine_logged stamp — see the constant's comment). Consume-once on
 # the resolve flags, mirroring worldos_chatlog_dm. Reads ambient $CHAT exactly as chatlog does.
+#
+# #1285: also tracks the CONSECUTIVE-failure streak (WORLDOS_DM_BEATS_FAILED_STREAK; reset to 0
+# by any genuine beat in worldos_chatlog_dm / record_dm_reply above) — the rri-a1-duo/duo2 class
+# where the account session limit hit MID-RUN, 5 beats failed back-to-back, and the run STILL
+# continued to a scored end (the cumulative WORLDOS_DM_BEATS_FAILED counter never distinguished
+# "1 failure scattered across 24 beats" from "5 in a row" — a real product defect vs an infra
+# collapse). At/above WORLDOS_INFRA_INVALID_STREAK consecutive failures, stamp the run
+# infra-invalid via worldos_mark_run_infra_invalid so a later scorer can never cite it as clean.
+WORLDOS_INFRA_INVALID_STREAK="${WORLDOS_INFRA_INVALID_STREAK:-3}"
 worldos_chatlog_dm_failed() {
   WORLDOS_DM_BEATS_FAILED=$((${WORLDOS_DM_BEATS_FAILED:-0} + 1))
-  echo "[worldos] beat FAILED — visible failure beat recorded (beats_failed=$WORLDOS_DM_BEATS_FAILED this run)" >&2
+  WORLDOS_DM_BEATS_FAILED_STREAK=$((${WORLDOS_DM_BEATS_FAILED_STREAK:-0} + 1))
+  echo "[worldos] beat FAILED — visible failure beat recorded (beats_failed=$WORLDOS_DM_BEATS_FAILED this run, streak=$WORLDOS_DM_BEATS_FAILED_STREAK consecutive)" >&2
   chatlog dm "$WORLDOS_DM_FAILED_BEAT_TEXT" '{"beat_failed":true}'
   WORLDOS_FALLBACK_RECOVERED=0
   WORLDOS_DM_BEAT_FAILED=0
+  if [ "$WORLDOS_DM_BEATS_FAILED_STREAK" -ge "$WORLDOS_INFRA_INVALID_STREAK" ] && [ -n "${STATE_DIR:-}" ]; then
+    worldos_mark_run_infra_invalid "$STATE_DIR" \
+      "$WORLDOS_DM_BEATS_FAILED_STREAK consecutive DM beat failures (is_error/dead-beat) — likely a quota window or host/session death mid-run, not a product defect"
+  fi
+}
+
+# worldos_mark_run_infra_invalid STATE_DIR REASON — stamp $STATE_DIR/.run_infra_invalid.json
+# (once; the FIRST trip wins — a later, unrelated call never overwrites the original reason/beat
+# count). This is the run-level sentinel qa/assert_behavioral.py's run_infra_valid gate reads (by
+# deriving the sibling path from its run.jsonl argv) to flip a mid-run-contaminated transcript
+# FATAL — so a quota-crippled run can never silently read as a clean, scored product measurement
+# (the exact rri-a1-duo/duo2 defect: 5 consecutive is_error beats, narrated 'could not resolve
+# this beat' at peak tension, then scored to the end with a 3.8 that was actually the infra
+# failure). Mirrors worldos_validate_lens_file's sentinel discipline for the scorer side.
+worldos_mark_run_infra_invalid() {
+  local state_dir="$1" reason="$2" marker="$1/.run_infra_invalid.json"
+  [ -n "$state_dir" ] || return 0
+  if [ -s "$marker" ]; then
+    return 0  # already stamped this run — first trip wins
+  fi
+  echo "[worldos] RUN INFRA-INVALID — $reason" >&2
+  python3 - "$marker" "$reason" "${WORLDOS_DM_BEATS_FAILED_STREAK:-0}" <<'PY'
+import json
+import sys
+import time
+
+path, reason, streak = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path, "w", encoding="utf-8") as fh:
+    json.dump({
+        "infra_invalid": True,
+        "reason": reason,
+        "consecutive_failed_beats": int(streak or 0),
+        "stamped_at": time.time(),
+    }, fh, indent=2)
+PY
 }
 
 # LIVE-PROGRESS + WRAPPER HEARTBEAT (#623 — the ONE shared implementation of the perceived-latency fix).

--- a/qa/run_duo.sh
+++ b/qa/run_duo.sh
@@ -482,6 +482,17 @@ $EVENT_ADV")"
   # by assert_behavioral's dm_beat_honesty) instead of masking with error text/recycled prose.
   if [ -z "$DMSG" ]; then
     worldos_chatlog_dm_failed
+    # #1285: worldos_chatlog_dm_failed stamps $STATE_DIR/.run_infra_invalid.json once the
+    # CONSECUTIVE failure streak crosses WORLDOS_INFRA_INVALID_STREAK — a quota window / host
+    # death mid-run (rri-a1-duo/duo2), not a product defect. Abort NOW (same rc=2 INFRA ABORT
+    # contract as the cold-open quota check above) instead of letting the loop grind on and the
+    # scorer measure a contaminated transcript. A single/occasional failed beat (below the
+    # streak) still just breaks the loop as before — unchanged behavior.
+    if [ -s "$STATE_DIR/.run_infra_invalid.json" ]; then
+      cp "$STATE_DIR/.run_infra_invalid.json" "$T/$RUN.infra_invalid.json" 2>/dev/null || true
+      echo "[duo] INFRA ABORT — $WORLDOS_DM_BEATS_FAILED_STREAK consecutive DM beat failures at beat $b (see $T/$RUN.infra_invalid.json). Skipping scoring; this is an INFRA collapse, NOT a product measurement." >&2
+      exit 2
+    fi
     echo "[duo] DM went silent at beat $b; stopping early"
     break
   fi
@@ -491,6 +502,13 @@ $EVENT_ADV")"
   # phase via the engine (sole writer). Defers to the DM when it advanced time in-fiction.
   worldos_soft_tick "$ROOT" "$STATE_DIR" "$PREV_DAY" "$PREV_TOD"
 done
+
+# #1285 defense-in-depth: if the streak was stamped but a caller path didn't already exit 2 above
+# (e.g. the threshold was crossed on the LAST beat and the loop simply ended rather than hitting
+# the in-loop abort), copy the sentinel alongside the run artifacts now — BEFORE scoring — so
+# worldos_run_infra_valid / assert_behavioral.py's run_infra_valid gate can still find it and
+# flip the run FATAL instead of letting a contaminated transcript reach a scored end silently.
+[ -s "$STATE_DIR/.run_infra_invalid.json" ] && cp "$STATE_DIR/.run_infra_invalid.json" "$T/$RUN.infra_invalid.json" 2>/dev/null
 
 # Wrap + score the DM transcript (it carries the narration + all tool calls).
 turn dm "$DSID" 0 "We are out of time. Bring this beat to a clean stopping point and call end_session with a one-line summary." >/dev/null

--- a/qa/test_assert_behavioral.py
+++ b/qa/test_assert_behavioral.py
@@ -1709,6 +1709,24 @@ def test_detection_beat_with_reason_tagged_roll_passes(tmp_path):
     assert "[WARN] detection_beat_requires_check" not in out, out
 
 
+def test_detection_beat_multiple_text_blocks_same_turn_passes(tmp_path):
+    """A skill_check followed by TWO SEPARATE text blocks in the SAME assistant turn (a beat that
+    narrates in more than one text block) ⇒ the second block still counts as the same beat — no
+    false-split on intra-turn text boundaries."""
+    events = [{
+        "type": "assistant",
+        "message": {"content": [
+            {"type": "tool_use", "id": "p1", "name": "mcp__engine__skill_check",
+             "input": {"character_id": "npc1", "skill": "perception", "dc": 12}},
+            {"type": "text", "text": "The corridor is quiet for a long moment."},
+            {"type": "text", "text": "Then the guard's eyes snap toward you — he's noticed movement in the alley."},
+        ]},
+    }, _user_tool_result("p1", json.dumps({"total": 15, "success": True}))]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    assert "[WARN] detection_beat_requires_check" not in out, out
+
+
 def test_detection_beat_check_in_prior_beat_still_warns(tmp_path):
     """A skill_check in an EARLIER beat does not carry over — the gate is per-beat, not whole-run
     (the key behavioral difference from the ambush check, which #1287 explicitly promotes past)."""

--- a/qa/test_assert_behavioral.py
+++ b/qa/test_assert_behavioral.py
@@ -1667,3 +1667,205 @@ def test_ambush_prose_but_no_start_combat_does_not_fire(tmp_path):
     rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
     assert rc == 0, out
     assert "ambush_ran_surprise_gate" not in out, out
+
+
+# ── detection_beat_requires_check (WARN, #1287) ────────────────────────────────
+# DM narration that stages an NPC noticing/spotting/hearing the party without a preceding
+# Perception/Insight/Investigation skill_check (or reason-tagged roll) IN THE SAME BEAT is DM
+# fiat, not a gated roll. WARN, never fatal — same family as the ambush/surprise WARN above.
+
+def test_detection_beat_no_check_warns(tmp_path):
+    """Detection prose with NO skill_check anywhere in the beat ⇒ WARN."""
+    events = [_assistant_text("The guard's eyes snap toward you — he's noticed movement in the alley.")]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out  # WARN, not RED
+    assert "[WARN] detection_beat_requires_check" in out, out
+
+
+def test_detection_beat_with_preceding_skill_check_passes(tmp_path):
+    """A skill_check(skill='perception') earlier in the SAME beat, then detection prose ⇒ PASS."""
+    events = [
+        _assistant_tool_use("p1", "mcp__engine__skill_check",
+                             {"character_id": "npc1", "skill": "perception", "dc": 12}),
+        _user_tool_result("p1", json.dumps({"total": 15, "success": True})),
+        _assistant_text("The guard's eyes snap toward you — he's noticed movement in the alley."),
+    ]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    assert "[WARN] detection_beat_requires_check" not in out, out
+    assert "[PASS] detection_beat_requires_check" in out, out
+
+
+def test_detection_beat_with_reason_tagged_roll_passes(tmp_path):
+    """A bare roll() with a perception-tagged reason also satisfies the gate (belt-and-suspenders,
+    mirrors the ambush check's `surprise`-key fallback)."""
+    events = [
+        _assistant_tool_use("p1", "mcp__engine__roll", {"expression": "1d20+3", "reason": "guard passive Perception"}),
+        _user_tool_result("p1", json.dumps({"total": 17})),
+        _assistant_text("The guard's eyes snap toward you — he's noticed movement in the alley."),
+    ]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    assert "[WARN] detection_beat_requires_check" not in out, out
+
+
+def test_detection_beat_check_in_prior_beat_still_warns(tmp_path):
+    """A skill_check in an EARLIER beat does not carry over — the gate is per-beat, not whole-run
+    (the key behavioral difference from the ambush check, which #1287 explicitly promotes past)."""
+    events = [
+        _assistant_tool_use("p1", "mcp__engine__skill_check",
+                             {"character_id": "npc1", "skill": "perception", "dc": 12}),
+        _user_tool_result("p1", json.dumps({"total": 15, "success": True})),
+        _assistant_text("You press on down the corridor, torches guttering."),
+        _assistant_text("The guard's eyes snap toward you — he's noticed movement in the alley."),
+    ]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    assert "[WARN] detection_beat_requires_check" in out, out
+
+
+def test_no_detection_prose_does_not_fire(tmp_path):
+    """A clean beat with no detection language ⇒ the gate PASSES (no false-WARN)."""
+    events = [_assistant_text("The tavern is warm and loud, mugs clattering over old songs.")]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    assert "[WARN] detection_beat_requires_check" not in out, out
+    assert "[PASS] detection_beat_requires_check" in out, out
+
+
+def test_detection_beat_wrong_skill_check_still_warns(tmp_path):
+    """A skill_check for an UNRELATED skill (e.g. Athletics) in the same beat does not satisfy
+    the gate — only the Perception/Insight/Investigation family counts."""
+    events = [
+        _assistant_tool_use("p1", "mcp__engine__skill_check",
+                             {"character_id": "pc1", "skill": "athletics", "dc": 10}),
+        _user_tool_result("p1", json.dumps({"total": 14, "success": True})),
+        _assistant_text("The guard's eyes snap toward you — he's noticed movement in the alley."),
+    ]
+    rc, out = _run_gate(tmp_path, events, {"leveling_mode": "milestone"})
+    assert rc == 0, out
+    assert "[WARN] detection_beat_requires_check" in out, out
+
+
+# ── run_infra_valid (FATAL, #1285) ──────────────────────────────────────────────
+# The run-invalidation guard: qa/lib_beat_driver.sh stamps a sibling <run>.infra_invalid.json
+# sentinel when N consecutive DM beats fail mid-run (a quota window / host-session death —
+# rri-a1-duo/duo2). The gate must read it and flip FATAL so the run can never be scored clean.
+
+def _clean_events_with_dice():
+    return [_assistant_tool_use("__dice", "mcp__engine__roll", {}),
+            _user_tool_result("__dice", json.dumps({"total": 12}))]
+
+
+def test_run_infra_invalid_sentinel_flips_red(tmp_path):
+    """A stamped .infra_invalid.json sibling of run.jsonl ⇒ RED (FATAL), never a silent no-score."""
+    run = tmp_path / "run.jsonl"
+    run.write_text("\n".join(json.dumps(e) for e in _clean_events_with_dice()), encoding="utf-8")
+    st = tmp_path / "state.json"
+    st.write_text(json.dumps(_with_party({"leveling_mode": "milestone"})), encoding="utf-8")
+    sentinel = tmp_path / "run.infra_invalid.json"
+    sentinel.write_text(json.dumps({
+        "infra_invalid": True,
+        "reason": "5 consecutive DM beat failures (is_error/dead-beat) — likely a quota window",
+        "consecutive_failed_beats": 5,
+    }), encoding="utf-8")
+    proc = subprocess.run([sys.executable, SCRIPT, str(run), str(st)], capture_output=True, text=True)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 1, out  # RED — a FATAL gate failed
+    assert "[FAIL] run_infra_valid" in out, out
+    assert "consecutive_failed_beats=5" in out, out
+
+
+def test_no_infra_invalid_sentinel_passes(tmp_path):
+    """No sentinel file present (the normal case) ⇒ the gate PASSES; never a false-RED."""
+    run = tmp_path / "run.jsonl"
+    run.write_text("\n".join(json.dumps(e) for e in _clean_events_with_dice()), encoding="utf-8")
+    st = tmp_path / "state.json"
+    st.write_text(json.dumps(_with_party({"leveling_mode": "milestone"})), encoding="utf-8")
+    proc = subprocess.run([sys.executable, SCRIPT, str(run), str(st)], capture_output=True, text=True)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, out
+    assert "[PASS] run_infra_valid" in out, out
+
+
+def test_infra_invalid_sentinel_caps_no_other_gate_weakened(tmp_path):
+    """The sentinel gate is ADDITIVE: an otherwise-clean run with no sentinel still passes every
+    other check unaffected (regression guard — this new gate must never mask/replace existing
+    ones)."""
+    run = tmp_path / "run.jsonl"
+    run.write_text("\n".join(json.dumps(e) for e in _clean_events_with_dice()), encoding="utf-8")
+    st = tmp_path / "state.json"
+    st.write_text(json.dumps(_with_party({"leveling_mode": "milestone"})), encoding="utf-8")
+    proc = subprocess.run([sys.executable, SCRIPT, str(run), str(st)], capture_output=True, text=True)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, out
+    assert "GREEN" in out, out
+
+
+# ── dm_beat_honesty_no_consecutive_collapse (FATAL, #1285) ─────────────────────
+# The chat-log-derived twin: N consecutive {"beat_failed":true} dm rows in $CHAT (in order) is
+# an infra collapse, not scattered product defects — catches runners that share
+# worldos_chatlog_dm_failed but predate/skip the sentinel-file wiring (e.g. run_party.sh).
+
+def _chat_rows(tmp_path, rows: list[dict]) -> str:
+    chat = tmp_path / "chat.jsonl"
+    chat.write_text("\n".join(json.dumps(r) for r in rows), encoding="utf-8")
+    return str(chat)
+
+
+def test_three_consecutive_failed_beats_flips_red(tmp_path):
+    run = tmp_path / "run.jsonl"
+    run.write_text("\n".join(json.dumps(e) for e in _clean_events_with_dice()), encoding="utf-8")
+    st = tmp_path / "state.json"
+    st.write_text(json.dumps(_with_party({"leveling_mode": "milestone"})), encoding="utf-8")
+    rows = [{"role": "player", "text": "[do] I press on."}]
+    for _ in range(3):
+        rows.append({
+            "role": "dm",
+            "text": "(The tale falters — the Dungeon Master could not resolve this beat. "
+                    "Your last action still stands; give it a moment and try again.)",
+            "beat_failed": True,
+        })
+    chat = _chat_rows(tmp_path, rows)
+    proc = subprocess.run([sys.executable, SCRIPT, str(run), str(st), chat], capture_output=True, text=True)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 1, out
+    assert "[FAIL] dm_beat_honesty_no_consecutive_collapse" in out, out
+    assert "3 consecutive" in out, out
+
+
+def test_two_consecutive_failed_beats_stays_warn(tmp_path):
+    """Below the threshold (2 < 3) ⇒ the existing dm_beat_honesty WARN still fires, but the new
+    consecutive-collapse gate PASSES — an occasional failed beat is not an infra collapse."""
+    run = tmp_path / "run.jsonl"
+    run.write_text("\n".join(json.dumps(e) for e in _clean_events_with_dice()), encoding="utf-8")
+    st = tmp_path / "state.json"
+    st.write_text(json.dumps(_with_party({"leveling_mode": "milestone"})), encoding="utf-8")
+    rows = [{"role": "player", "text": "[do] I press on."}]
+    for _ in range(2):
+        rows.append({"role": "dm", "text": "(could not resolve this beat)", "beat_failed": True})
+    rows.append({"role": "dm", "text": 'The road bends. "Keep close," she says.'})
+    chat = _chat_rows(tmp_path, rows)
+    proc = subprocess.run([sys.executable, SCRIPT, str(run), str(st), chat], capture_output=True, text=True)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, out
+    assert "[WARN] dm_beat_honesty" in out, out
+    assert "[PASS] dm_beat_honesty_no_consecutive_collapse" in out, out
+
+
+def test_non_consecutive_failed_beats_do_not_flip_red(tmp_path):
+    """3 TOTAL failed beats scattered across the run (with a genuine beat between each) ⇒ never
+    hits a consecutive run of 3 ⇒ the new gate PASSES (only a CONSECUTIVE run invalidates)."""
+    run = tmp_path / "run.jsonl"
+    run.write_text("\n".join(json.dumps(e) for e in _clean_events_with_dice()), encoding="utf-8")
+    st = tmp_path / "state.json"
+    st.write_text(json.dumps(_with_party({"leveling_mode": "milestone"})), encoding="utf-8")
+    rows = [{"role": "player", "text": "[do] I press on."}]
+    for _ in range(3):
+        rows.append({"role": "dm", "text": "(could not resolve this beat)", "beat_failed": True})
+        rows.append({"role": "dm", "text": 'The road bends. "Keep close," she says.'})
+    chat = _chat_rows(tmp_path, rows)
+    proc = subprocess.run([sys.executable, SCRIPT, str(run), str(st), chat], capture_output=True, text=True)
+    out = proc.stdout + proc.stderr
+    assert proc.returncode == 0, out
+    assert "[PASS] dm_beat_honesty_no_consecutive_collapse" in out, out

--- a/qa/test_run_invalidation_guard.sh
+++ b/qa/test_run_invalidation_guard.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# BEHAVIORAL TEST (no model call): proves #1285's run-invalidation guard — qa/lib_beat_driver.sh's
+# worldos_chatlog_dm_failed now tracks a CONSECUTIVE-failure streak (reset by any genuine beat via
+# worldos_chatlog_dm / record_dm_reply) and stamps $STATE_DIR/.run_infra_invalid.json via
+# worldos_mark_run_infra_invalid once the streak crosses WORLDOS_INFRA_INVALID_STREAK — the
+# rri-a1-duo/duo2 defect class (a quota window / host-session death that fails several beats in a
+# row mid-run, previously silently scored to the end as if it were a product measurement).
+#
+# Sources the REAL qa/lib_beat_driver.sh; exercises worldos_chatlog_dm_failed / worldos_chatlog_dm /
+# worldos_mark_run_infra_invalid directly (no `claude` stub needed — these are pure bash+python
+# bookkeeping helpers). Self-contained under mktemp; macOS + ubuntu CI safe.
+set -uo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. "$ROOT/qa/lib_beat_driver.sh"
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+STATE_DIR="$TMP/state"; mkdir -p "$STATE_DIR"
+CHAT="$TMP/chat.jsonl"; : > "$CHAT"
+
+fail=0
+chk() { if eval "$2"; then echo "PASS: $1"; else echo "FAIL: $1"; fail=1; fi; }
+
+# ---- (1) below-threshold: 2 consecutive failures never stamps the sentinel -------------------
+worldos_chatlog_dm_failed
+worldos_chatlog_dm_failed
+chk "2 consecutive failures: streak counter is 2"        '[ "${WORLDOS_DM_BEATS_FAILED_STREAK:-0}" = "2" ]'
+chk "2 consecutive failures: NO sentinel stamped yet"     '[ ! -s "$STATE_DIR/.run_infra_invalid.json" ]'
+
+# ---- (2) a genuine beat resets the streak ------------------------------------------------------
+worldos_chatlog_dm "The road bends onward."
+chk "a genuine beat resets the streak to 0"               '[ "${WORLDOS_DM_BEATS_FAILED_STREAK:-0}" = "0" ]'
+
+# ---- (3) at-threshold: 3 CONSECUTIVE failures stamps the sentinel ------------------------------
+worldos_chatlog_dm_failed
+worldos_chatlog_dm_failed
+worldos_chatlog_dm_failed
+chk "3 consecutive failures: streak counter is 3"         '[ "${WORLDOS_DM_BEATS_FAILED_STREAK:-0}" = "3" ]'
+chk "3 consecutive failures: sentinel IS stamped"          '[ -s "$STATE_DIR/.run_infra_invalid.json" ]'
+chk "sentinel carries infra_invalid:true"                 'python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get(\"infra_invalid\") is True else 1)" "$STATE_DIR/.run_infra_invalid.json"'
+chk "sentinel carries consecutive_failed_beats=3"          'python3 -c "import json,sys; d=json.load(open(sys.argv[1])); sys.exit(0 if d.get(\"consecutive_failed_beats\")==3 else 1)" "$STATE_DIR/.run_infra_invalid.json"'
+chk "sentinel reason mentions consecutive DM beat failures" 'grep -q "consecutive DM beat failures" "$STATE_DIR/.run_infra_invalid.json"'
+
+# ---- (4) first trip wins: a later mark call does NOT overwrite the original reason -------------
+_orig="$(cat "$STATE_DIR/.run_infra_invalid.json")"
+worldos_mark_run_infra_invalid "$STATE_DIR" "a different, later reason that must NOT overwrite"
+chk "first-trip-wins: sentinel unchanged after a second mark call" '[ "$(cat "$STATE_DIR/.run_infra_invalid.json")" = "$_orig" ]'
+
+# ---- (5) a fresh STATE_DIR (new run) starts clean — no cross-run leakage ------------------------
+STATE_DIR2="$TMP/state2"; mkdir -p "$STATE_DIR2"
+STATE_DIR="$STATE_DIR2" WORLDOS_DM_BEATS_FAILED_STREAK=0 bash -c '
+  . "'"$ROOT"'/qa/lib_beat_driver.sh"
+  CHAT="'"$TMP"'/chat2.jsonl"; : > "$CHAT"
+  worldos_chatlog_dm_failed
+'
+chk "a fresh run with only 1 failure: no sentinel"        '[ ! -s "$STATE_DIR2/.run_infra_invalid.json" ]'
+
+echo "----"
+if [ "$fail" -eq 0 ]; then
+  echo "ALL PASS: test_run_invalidation_guard.sh"
+else
+  echo "SOME FAILED: test_run_invalidation_guard.sh"
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary
- **#1287** — new WARN-level behavioral rule (same family as the ambush/surprise WARN #1271): DM narration that stages an NPC noticing/spotting/hearing the party ("the guard's eyes snap toward you") with no preceding Perception/Insight/Investigation `skill_check` (or reason-tagged `roll`) in the **same beat** — DM fiat standing in for a gated roll, per rri-a1-duo's `suggested_fix`. WARN, never fatal.
- **#1285** — run-invalidation guard for mid-run host/session death (quota windows, the rri-a1-duo/duo2 class: 5 consecutive `is_error` DM beats mid-run, narrated "could not resolve this beat" at peak tension, then scored to a clean-looking 3.8 that was actually the infra failure):
  - `qa/lib_beat_driver.sh`: `worldos_chatlog_dm_failed` now tracks a **consecutive** failure streak (reset by any genuine beat) and stamps a `<run>.infra_invalid.json` sentinel via the new `worldos_mark_run_infra_invalid` once the streak crosses a threshold (default 3, `WORLDOS_INFRA_INVALID_STREAK`).
  - `qa/run_duo.sh`: aborts immediately (rc=2, `INFRA ABORT`) the moment the sentinel trips — mirrors the existing cold-open quota circuit-breaker (`session limit`/`HTTP 429` check) already in the file. Also copies the sentinel next to the run's transcripts before scoring as defense-in-depth.
  - `qa/assert_behavioral.py`: two independent FATAL gates so a contaminated transcript can never be cited as a clean product measurement — `run_infra_valid` (reads the sentinel file, sibling of `run.jsonl`) and `dm_beat_honesty_no_consecutive_collapse` (derives the same signal from `chat.jsonl`'s `beat_failed` rows in order, catching callers that share `worldos_chatlog_dm_failed` but predate/skip the sentinel wiring, e.g. `run_party.sh`/`ui_playtest.sh`).

No existing behavioral check was weakened — both units are strictly additive (new WARN, new FATAL gates gated on new signals only).

## Test plan
- [x] `qa/test_assert_behavioral.py`: 92 → 104 passing (12 new tests: 6 for `detection_beat_requires_check`, 6 for `run_infra_valid` + `dm_beat_honesty_no_consecutive_collapse`), single-process (`uv run --directory servers/engine python -m pytest qa/test_assert_behavioral.py -p no:cacheprovider -p no:xdist -q`).
- [x] New `qa/test_run_invalidation_guard.sh` — bash-level test exercising the streak counter + sentinel stamping (`worldos_chatlog_dm_failed`, `worldos_chatlog_dm` reset, `worldos_mark_run_infra_invalid` first-trip-wins, cross-run isolation) directly against the real `qa/lib_beat_driver.sh`. All pass.
- [x] `qa/fast_gate.sh` — green (245 passed, unrelated engine tier, confirms no collateral breakage).
- [x] `bash -n` syntax check on both modified `.sh` files.