### PR TITLE
chore: gitignore nested WorldOS-worktrees/ (GitNexus re-index hygiene)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,8 @@ servers/*/.coverage
 /data/asset-registry/**
 !/data/asset-registry/
 !/data/asset-registry/registry.json
+
+# Local nested worktree checkouts (each is its own full git working tree with its own .git
+# file) — never repo content, and left unignored they get scanned as ordinary files by
+# tools like GitNexus, ballooning the node count past the embeddings cap.
+/WorldOS-worktrees/


### PR DESCRIPTION
Nested git worktrees under `WorldOS-worktrees/` were being scanned as ordinary repo content, blowing the GitNexus embeddings node cap (190,513 nodes) and forcing full rebuilds. Gitignoring the dir fixes clean incremental re-indexing. Surfaced by the merge-queue shepherd during the v1.0.5 batch re-index. Trivial, additive.