### PR TITLE
feat(engine): #1313 Option 3 — surface the top per-beat obligation as an imperative next_action (enforcement lever, cue half)

### DIFF
--- a/servers/engine/server.py
+++ b/servers/engine/server.py
@@ -13484,7 +13484,48 @@ def _compute_beat_obligations(c: Campaign) -> list[dict]:
                 ),
             })
 
+    # #1313 Option 3: severity-sort so the SINGLE most urgent obligation is first (high>med>low),
+    # then lifted into `next_action` by the callers. STABLE (Python's sorted): within a severity
+    # tier the authored append order above is preserved, so the scannable `obligations` list reads
+    # exactly as before within a tier — only the cross-tier ordering changes. ADDITIVE: an empty
+    # digest sorts to the same empty list (byte-identical when there is nothing to do). An unknown
+    # severity sorts LAST (defensive default) rather than raising.
+    obligations.sort(key=lambda o: _SEVERITY_RANK.get(o.get("severity"), _SEVERITY_RANK_UNKNOWN))
     return obligations
+
+
+# #1313 Option 3 — severity ordering for the per-beat obligations digest. high is the load-bearing
+# payoff (act_climax_owed / companion_betrayal deep-red), so it sorts first; an unrecognized
+# severity degrades to LAST rather than raising (mirrors the digest's defensive-getattr discipline).
+_SEVERITY_RANK = {"high": 0, "med": 1, "low": 2}
+_SEVERITY_RANK_UNKNOWN = 3
+
+
+def _top_obligation(obligations: list[dict]) -> dict | None:
+    """The SINGLE highest-priority obligation this beat (the first of the severity-sorted digest),
+    or None when the digest is empty. PURE read — the list is already sorted by
+    _compute_beat_obligations; this just names 'the one thing this beat owes'."""
+    return obligations[0] if obligations else None
+
+
+def _next_action(obligations: list[dict]) -> dict | None:
+    """#1313 Option 3: lift the top obligation into an imperative single-directive `next_action`.
+
+    ADDITIVE + PURE read: derived from the already-computed obligations each beat, reusing the
+    obligation's own `detail`/`kind` text (no new copy invented). Returns None when there is no
+    obligation, so the caller omits the key and the return is byte-identical to today's shape.
+    NEVER errors — a malformed obligation degrades to the kind alone."""
+    top = _top_obligation(obligations)
+    if top is None:
+        return None
+    return {
+        "kind": top.get("kind"),
+        "severity": top.get("severity"),
+        # The imperative is the obligation's existing detail — the cue text is ALREADY imperative
+        # and single-directive; surfacing it as a named next_action (not one row of a scanned list)
+        # is the whole lever. Fall back to a minimal directive if a detail is somehow absent.
+        "imperative": top.get("detail") or f"Act on the {top.get('kind')} obligation this beat.",
+    }
 
 
 def _scene_durable_threads(c: Campaign) -> dict:
@@ -13696,6 +13737,11 @@ def _scene_durable_threads(c: Campaign) -> dict:
     obligations = _compute_beat_obligations(c)
     if obligations:
         out["obligations"] = obligations
+        # #1313 Option 3: lift the single top obligation into an imperative `next_action` so the DM
+        # acts on ONE named directive instead of scanning the list. ADDITIVE: absent when empty.
+        next_action = _next_action(obligations)
+        if next_action is not None:
+            out["next_action"] = next_action
     return out
 
 
@@ -14197,6 +14243,14 @@ def persist_beat(
                 obligations = _compute_beat_obligations(c_read)
                 if obligations:
                     out["obligations"] = obligations
+                    # #1313 Option 3: the one imperative directive this beat owes (top severity),
+                    # PLUS a lightweight `owed` list of the kinds that remain unmet after this beat
+                    # persisted — the DM sees the consequence-of-inaction carried forward. READ-ONLY
+                    # (derived from the just-loaded snapshot; no new state, no clean:false teeth).
+                    next_action = _next_action(obligations)
+                    if next_action is not None:
+                        out["next_action"] = next_action
+                    out["owed"] = [o.get("kind") for o in obligations]
         except Exception:
             pass
     return out

--- a/servers/engine/tests/test_beat_obligations.py
+++ b/servers/engine/tests/test_beat_obligations.py
@@ -1189,3 +1189,116 @@ def test_fully_progressed_snapshot_yields_no_obligations():
     arc = CompanionQuestArc(companion_id=comp.id, title="Wyll's personal thread")
     c.companion_quest_arcs[arc.id] = arc
     assert server._compute_beat_obligations(c) == []
+
+
+# --- #1313 Option 3: severity-sort + `next_action` + persist_beat `owed` -----------------------
+#
+# The engagement machinery was surfaced every beat (the full `obligations` list) and the DM
+# scanned past it (rri-a1-duo3: ZERO engagement tools across 25 clean beats). Option 3 lifts the
+# SINGLE top-severity obligation into a named, imperative `next_action` on BOTH seams, and echoes
+# the still-owed kinds back on the persist_beat return. Pure read, additive: no obligations ->
+# byte-identical to today (no next_action / owed keys).
+
+
+def _multi_severity_campaign() -> Campaign:
+    """A snapshot that fires several obligations spanning ALL severity tiers, so the sort +
+    top-lift are observable. Act 3 climax-owed = the lone `high`; a frozen gauged companion +
+    an all-objectives-done quest = `med`; a resolved-no-echo quest = `low`."""
+    comp = _companion(name="Shadowheart", attitude=0, likes=["mercy"], last_long_rest_day=4)
+    pc = Character(name="Hero", kind="player")
+    c = _campaign_with(comp, pc, day=5)
+    # Act 3 with the climax still owed -> act_climax_owed (severity "high").
+    c.narrative_arc = NarrativeArc(act=3, day_act_entered=3, beats_in_act=6,
+                                   midpoint_reversal_landed=True, climax_landed=False)
+    # med: companion_approval_frozen (gauged companion still at 0 on day 5).
+    # med: quest_resolvable (all objectives done).
+    resolvable = Quest(title="The ripe thread", objectives=["x"], completed_objectives=["x"])
+    c.quests[resolvable.id] = resolvable
+    # low: quest_no_echo (a resolved quest with empty evolves_to and no consequence).
+    stale = Quest(title="A quiet win", status="completed", objectives=["y"],
+                  completed_objectives=["y"], evolves_to="")
+    c.quests[stale.id] = stale
+    return c
+
+
+def test_obligations_are_severity_sorted_high_first():
+    """The digest is returned high>med>low so the caller can lift the top one."""
+    c = _multi_severity_campaign()
+    obligations = server._compute_beat_obligations(c)
+    severities = [o["severity"] for o in obligations]
+    # At least one of each tier is present, and they are non-increasing in urgency.
+    assert "high" in severities and "med" in severities and "low" in severities
+    rank = {"high": 0, "med": 1, "low": 2}
+    ranks = [rank[s] for s in severities]
+    assert ranks == sorted(ranks), f"obligations not severity-sorted: {severities}"
+
+
+def test_next_action_is_the_top_severity_obligation():
+    """`_next_action` lifts the single highest-priority obligation, reusing its own detail text
+    as the imperative (no invented copy)."""
+    c = _multi_severity_campaign()
+    obligations = server._compute_beat_obligations(c)
+    na = server._next_action(obligations)
+    assert na is not None
+    top = obligations[0]
+    assert na["kind"] == top["kind"] == "act_climax_owed"
+    assert na["severity"] == "high"
+    # The imperative is the obligation's existing detail verbatim (reused, not invented).
+    assert na["imperative"] == top["detail"]
+
+
+def test_next_action_is_none_when_no_obligations():
+    """No obligations -> no next_action (the additive default; empty digest -> no key)."""
+    assert server._next_action([]) is None
+
+
+def test_top_obligation_none_on_empty():
+    assert server._top_obligation([]) is None
+
+
+def test_scene_context_surfaces_next_action_when_actionable(cid):
+    _make_frozen_run(cid)
+    sc = server.scene_context(cid)
+    durable = sc["durable"]
+    assert "obligations" in durable
+    na = durable["next_action"]
+    # The lifted directive is the FIRST (top-severity) obligation, and its imperative is that
+    # obligation's own detail.
+    top = durable["obligations"][0]
+    assert na["kind"] == top["kind"]
+    assert na["imperative"] == top["detail"]
+
+
+def test_scene_context_omits_next_action_on_healthy_fixture(cid):
+    """Additive: a healthy fixture has no obligations -> no next_action key (today's shape)."""
+    _author_quest_arcs_for_party_companions(cid)
+    sc = server.scene_context(cid)
+    assert "obligations" not in sc["durable"]
+    assert "next_action" not in sc["durable"]
+
+
+def test_persist_beat_surfaces_next_action_and_owed_when_actionable(cid):
+    _make_frozen_run(cid)
+    out = server.persist_beat(cid, events=[{"kind": "narration", "text": "The beat lands."}])
+    assert "obligations" in out
+    # next_action = the top obligation, echoing its own detail as the imperative.
+    top = out["obligations"][0]
+    assert out["next_action"]["kind"] == top["kind"]
+    assert out["next_action"]["imperative"] == top["detail"]
+    # `owed` echoes back every still-unmet obligation kind (consequence-of-inaction carried
+    # forward), in the same severity-sorted order as the digest.
+    assert out["owed"] == [o["kind"] for o in out["obligations"]]
+    assert "companion_approval_frozen" in out["owed"]
+    assert "quest_resolvable" in out["owed"]
+
+
+def test_persist_beat_omits_next_action_and_owed_on_healthy_fixture(cid):
+    """The ADDITIVE / byte-identical-when-empty invariant on the persist_beat return: a healthy
+    beat carries NEITHER the obligations digest NOR the Option-3 keys — the return is exactly
+    today's four-key shape (plus optional approval_results)."""
+    _author_quest_arcs_for_party_companions(cid)
+    out = server.persist_beat(cid, events=[{"kind": "narration", "text": "A quiet beat."}])
+    assert "obligations" not in out
+    assert "next_action" not in out
+    assert "owed" not in out
+    assert set(out) <= {"logged", "remembered", "decision", "time", "approval_results"}


### PR DESCRIPTION
## What & why (#1313)

Advisory cueing has hit its ceiling. On the v1.0.5 gate run (`rri-a1-duo3`, 24-beat Opus duo @ 8a649d2f) the DM read the full per-beat `obligations` list every beat and fired **ZERO** engagement tools across 25 clean beats. The obligations are surfaced on both per-beat seams and SKILL.md step-6b already mandates acting on them — the ceiling is not the wording, it is that the DM scans past a list.

This ships **Option 3 only** (the ratified architect decision, `/tmp/decision-1313-enforcement.md`): the **cue half** of the enforcement lever. It makes the cue louder — a single named directive instead of a scanned list — **without teeth**.

## Change (additive, pure-read, invariant-legal)

1. **Severity sort** — `_compute_beat_obligations` now returns the digest sorted `high>med>low`, **stable** within a tier (Python `sorted`, so authored order is preserved within severity). Empty digest -> same empty list.
2. **`next_action`** — a new dedicated top-level key on **both** seams' returns (`scene_context.durable` and `persist_beat`), lifting the single highest-priority obligation into an imperative directive: `{kind, severity, imperative}`. The `imperative` **reuses the obligation's own `detail`** text (no new copy invented). Absent/None when there are no obligations.
3. **`owed`** on the `persist_beat` return — a lightweight list of the still-unmet obligation kinds, so the DM sees the consequence-of-inaction carried forward.

### Shape
```
scene_context.durable / persist_beat:
  next_action: { "kind": "act_climax_owed", "severity": "high",
                 "imperative": "<the obligation's existing detail>" }   # absent when no obligations
persist_beat only:
  owed: ["act_climax_owed", "companion_approval_frozen", ...]           # severity-sorted kinds; absent when none
```

## Invariants held
- **ADDITIVE ONLY** — a snapshot/beat with no obligations produces byte-identical output to today (new keys absent). Old snapshots round-trip. Covered by tests on both seams.
- **PURE READ** — no new state writes, no new `Campaign` fields, no engine mutation. `next_action`/`owed` are derived from the already-computed obligations each beat.
- **NEVER errors, never acts for the DM.** `_next_action` degrades a malformed obligation to a minimal directive rather than raising.
- **Wire contract** — new keys are additive/defaulted; no existing key reordered/renamed/retyped.

## The teeth are OWNER-HELD (not in this PR)
This is the **cue half only**. The **soft-reject / `clean:false`** half (narrow-1: an engine-owned per-obligation streak counter that withholds a clean acknowledgment on FATAL-class stalls) is deliberately **NOT** implemented — per the owner-taste flag in the decision packet, "how much teeth" is the felt-session north star and is held for the owner to decide + measure. No `clean:false`, no streak field, no `dm_advanced_time` WARN change here.

## Tests
`servers/engine/tests/test_beat_obligations.py` (+9 tests): severity-sort order (high-first, non-increasing), `next_action` = top obligation echoing its own detail, `next_action`/`_top_obligation` None when empty, both seams surface `next_action` when actionable + omit it on a healthy fixture, `persist_beat` echoes `owed`, and the additive/byte-identical-when-empty invariant on both seam returns.

- `test_beat_obligations.py`: **91 passed**
- `qa/fast_gate.sh` (Tier-0 deterministic): **257 passed → PASS**
- return-shape-sensitive suites (roundtrip / lean-reground / p3-polish / decision-approval / narrative-arc / companion-arc + obligations): **298 passed**

CI verifies the rest. **Do not merge — owner reviews + measures** (acceptance is a fresh 24-beat duo showing the engagement tools actually invoked; this cue-half may move the needle but is expected to pair with the owner-held teeth).