### PR TITLE
feat(hv2): export_campaign_artifacts — snapshot+transcript → structured artifact JSONs (#1324)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@
 # committed; its output is not.
 /qa/findings.jsonl
 
+# HV2 harvest-loop extraction output (qa/export_campaign_artifacts.py) — regenerable per
+# campaign from snapshot.json + transcripts. The extractor script and the schema handshake
+# (data/library/artifact_schema.json) ARE committed; the extracted artifacts are not.
+/qa/artifacts_out/
+
 # Privately-imported, user-owned adventures — NEVER commit (may be copyrighted).
 # Only original / CC-licensed content belongs under content/campaigns/.
 /content/campaigns/_imported/

--- a/data/library/artifact_schema.json
+++ b/data/library/artifact_schema.json
@@ -1,0 +1,111 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://worldos/data/library/artifact_schema.json",
+  "title": "WorldOS harvest-loop artifact envelope",
+  "description": "The common envelope for every harvested artifact (Act II §4c, the HV-series). AUTHORED by HV2 (qa/export_campaign_artifacts.py, the schema handshake commit) and CONSUMED by HV1 (qa/artifact_score.py) and HV3 (tools/library/promote.py) without redefinition. Every artifact — extracted from a played campaign OR a hand-authored control pushed through the same envelope — is one JSON object matching this schema. `class` selects which `payload` shape applies (see definitions). `scores` is populated later by HV1's eval pass; an unscored (freshly-extracted) artifact always carries `scores: null`.",
+  "type": "object",
+  "required": ["artifact_id", "class", "world", "provenance", "payload", "scores"],
+  "additionalProperties": false,
+  "properties": {
+    "artifact_id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Stable id for this artifact, e.g. 'quest:<campaign_id>:<quest_id>'. Deterministic from (class, campaign_id, source id) so re-extraction is idempotent."
+    },
+    "class": {
+      "type": "string",
+      "enum": ["quest", "npc", "location", "encounter"]
+    },
+    "world": {
+      "type": "string",
+      "description": "The world_id the source campaign was seeded from (e.g. 'baldurs-gate')."
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["campaign_id", "run_id", "sha", "extracted_at"],
+      "additionalProperties": false,
+      "properties": {
+        "campaign_id": {"type": "string", "minLength": 1},
+        "run_id": {
+          "type": ["string", "null"],
+          "description": "The qa/state/<run_id> directory this campaign was played under, when derivable from the harness naming convention; null for a hand-authored control or an ungrouped campaign."
+        },
+        "sha": {
+          "type": ["string", "null"],
+          "description": "The engine build that produced this snapshot (Campaign.engine_sha); null when unknown (e.g. a pre-engine_sha snapshot or a hand-authored control with no engine run)."
+        },
+        "extracted_at": {
+          "type": "string",
+          "description": "Caller-supplied extraction timestamp (ISO 8601 or any stable string) — NEVER wall-clock-generated inside the extractor, so a re-run with the same --extracted-at argument is byte-identical (test determinism)."
+        }
+      }
+    },
+    "payload": {
+      "type": "object",
+      "description": "Class-specific body. See quest_payload / npc_payload / location_payload / encounter_payload definitions."
+    },
+    "scores": {
+      "type": ["object", "null"],
+      "description": "Populated by HV1's artifact_score.py. Always null on fresh extraction (HV2 never scores)."
+    }
+  },
+  "definitions": {
+    "quest_payload": {
+      "type": "object",
+      "required": ["id", "name", "objectives", "completed_objectives", "resolution_status", "evolves_to", "consequences"],
+      "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "objectives": {"type": "array", "items": {"type": "string"}},
+        "completed_objectives": {"type": "array", "items": {"type": "string"}},
+        "resolution_status": {"type": "string"},
+        "evolves_to": {"type": "string"},
+        "consequences": {"type": "array", "items": {"type": "object"}}
+      }
+    },
+    "npc_payload": {
+      "type": "object",
+      "required": ["id", "name", "voice_id", "personality", "attitude_arc", "final_status", "dialogue_snippets"],
+      "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "voice_id": {"type": "string"},
+        "personality": {"type": "object"},
+        "attitude_arc": {
+          "type": "object",
+          "required": ["start", "end"],
+          "properties": {
+            "start": {"type": "integer"},
+            "end": {"type": "integer"}
+          }
+        },
+        "final_status": {"type": "string"},
+        "dialogue_snippets": {
+          "type": "array",
+          "maxItems": 5,
+          "items": {"type": "string"}
+        }
+      }
+    },
+    "location_payload": {
+      "type": "object",
+      "required": ["id", "name", "description", "scene_grid", "visited"],
+      "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "description": {"type": "string"},
+        "scene_grid": {"type": ["object", "null"]},
+        "visited": {"type": "boolean"}
+      }
+    },
+    "encounter_payload": {
+      "type": "object",
+      "required": ["id", "composition", "outcome"],
+      "properties": {
+        "id": {"type": "string"},
+        "composition": {"type": "array", "items": {"type": "object"}},
+        "outcome": {"type": "string"}
+      }
+    }
+  }
+}

--- a/qa/export_campaign_artifacts.py
+++ b/qa/export_campaign_artifacts.py
@@ -25,15 +25,18 @@ script, so re-running with the same argument is byte-for-byte reproducible (test
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
 import sys
+import types
 from pathlib import Path
 from typing import Optional
 
 _ROOT = Path(__file__).resolve().parent.parent
 _MAX_DIALOGUE_SNIPPETS = 5
+_ARTICLES = {"the", "a", "an"}
 
 
 # ── engine + distill imports (read-only) ─────────────────────────────────────────────────────
@@ -86,8 +89,15 @@ def _envelope(artifact_id: str, cls: str, world: str, provenance: dict, payload:
 
 
 # ── transcript helpers ───────────────────────────────────────────────────────────────────────
-def _load_transcript_lines(transcript_path: Optional[Path]) -> list[str]:
-    if transcript_path is None or not transcript_path.exists():
+def _load_transcript_lines(transcript_path: Optional[Path], *, explicit: bool = False) -> list[str]:
+    """Read non-blank lines from a transcript. A missing/absent transcript falls back to []
+    (no encounters/dialogue) ONLY for the omitted/inferred case; an EXPLICIT --transcript path
+    that doesn't exist is a caller mistake and raises rather than silently harvesting nothing."""
+    if transcript_path is None:
+        return []
+    if not transcript_path.exists():
+        if explicit:
+            raise FileNotFoundError(f"--transcript path does not exist: {transcript_path}")
         return []
     return [ln for ln in transcript_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
 
@@ -116,11 +126,15 @@ def _npc_dialogue_snippets(name: str, text_blocks: list[str], limit: int = _MAX_
     """Up to `limit` narration snippets that mention this NPC by name — a cheap, transcript-
     reading proxy for "moments this NPC appeared in the story" (no NLP, no engine dependency;
     a plain case-insensitive whole-word-ish substring match). First name only (e.g. "Jaheira"
-    out of "Jaheira" or "Minsc and Boo" -> "Minsc") so a two-word canon name still matches."""
+    out of "Jaheira" or "Minsc and Boo" -> "Minsc") so a two-word canon name still matches.
+    Leading articles are skipped ("The Emperor" -> "Emperor") so an NPC whose display name
+    starts with "The"/"A"/"An" doesn't match almost every narration block via the article."""
     if not name:
         return []
-    first = name.split()[0]
-    pat = re.compile(re.escape(first), re.IGNORECASE)
+    words = name.split()
+    first = next((w for w in words if w.lower() not in _ARTICLES), words[0])
+    # word-boundary match so "Boo" doesn't fire on "book" and a short/article name is exact
+    pat = re.compile(rf"\b{re.escape(first)}\b", re.IGNORECASE)
     out: list[str] = []
     for blk in text_blocks:
         if pat.search(blk):
@@ -130,16 +144,66 @@ def _npc_dialogue_snippets(name: str, text_blocks: list[str], limit: int = _MAX_
     return out
 
 
+def _coerce_id_list(raw) -> list[str]:
+    """Mirror the engine's StrListArg coercion (models._coerce_list) on a RAW transcript arg:
+    the transcript records the tool_use input BEFORE pydantic's BeforeValidator runs, so a DM
+    that passed combatant_ids as a bare or comma-separated string ("a" / "a,b") is logged as a
+    string, not a list. Iterating that string directly would yield single-character "names"."""
+    if isinstance(raw, str):
+        s = raw.strip()
+        if not s:
+            return []
+        return [t.strip() for t in s.split(",") if t.strip()] if "," in s else [s]
+    if isinstance(raw, list):
+        return [str(x) for x in raw]
+    return []
+
+
+def _errored_tool_use_ids(lines: list[str]) -> set[str]:
+    """tool_use_ids whose tool_result came back is_error=true — a rejected/failed engine call.
+    Its start_combat never actually opened an encounter, so it must not be harvested. The result
+    lives in a later `user` event, keyed by tool_use_id (distill._content_blocks tolerance)."""
+    errored: set[str] = set()
+    for raw in lines:
+        try:
+            ev = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if ev.get("type") != "user":
+            continue
+        content = ev.get("message", {}).get("content", [])
+        if not isinstance(content, list):
+            continue
+        for b in content:
+            if isinstance(b, dict) and b.get("type") == "tool_result" and b.get("is_error"):
+                tid = b.get("tool_use_id")
+                if tid:
+                    errored.add(tid)
+    return errored
+
+
 def _combat_encounters_from_transcript(lines: list[str], characters: dict) -> list[dict]:
     """Pairs each start_combat tool call with its matching end_combat (composition from
     start_combat's combatant_ids resolved to character names; outcome from end_combat's
     resolution text, which is the same string the engine stamps onto
     Campaign.last_combat_resolution). A start_combat with no later end_combat in this
     transcript yields outcome="" (combat still open / transcript truncated mid-fight) rather
-    than being dropped — every started encounter is accounted for."""
+    than being dropped — every started encounter is accounted for, including a consecutive
+    start_combat (no intervening end_combat): the earlier one is flushed as a dangling
+    outcome="" encounter before the new one overwrites `pending`. start_combat calls whose
+    tool_result came back is_error=true (rejected engine call) are skipped — no fake encounter."""
+    errored = _errored_tool_use_ids(lines)
     encounters: list[dict] = []
     pending: Optional[list[str]] = None
     idx = 0
+
+    def flush(names: list[str], outcome: str) -> None:
+        nonlocal idx
+        idx += 1
+        encounters.append(
+            {"id": f"encounter-{idx}", "composition": [{"name": n} for n in names], "outcome": outcome}
+        )
+
     for raw in lines:
         try:
             ev = json.loads(raw)
@@ -156,25 +220,35 @@ def _combat_encounters_from_transcript(lines: list[str], characters: dict) -> li
             name = b.get("name", "")
             args = b.get("input", {}) or {}
             if name.endswith("start_combat"):
-                ids = args.get("combatant_ids") or []
+                if b.get("id") in errored:
+                    continue  # rejected engine call — never actually opened an encounter
+                if pending is not None:
+                    flush(pending, "")  # dangling: previous combat never got an end_combat
+                ids = _coerce_id_list(args.get("combatant_ids"))
                 pending = [characters.get(i, {}).get("name", i) for i in ids]
             elif name.endswith("end_combat") and pending is not None:
-                idx += 1
-                encounters.append(
-                    {
-                        "id": f"encounter-{idx}",
-                        "composition": [{"name": n} for n in pending],
-                        "outcome": args.get("resolution", ""),
-                    }
-                )
+                flush(pending, args.get("resolution", ""))
                 pending = None
     if pending is not None:
-        idx += 1
-        encounters.append({"id": f"encounter-{idx}", "composition": [{"name": n} for n in pending], "outcome": ""})
+        flush(pending, "")
     return encounters
 
 
 # ── per-class extraction ─────────────────────────────────────────────────────────────────────
+def _npc_final_status(c: dict) -> str:
+    """dead > stable > downed > active. A creature at current_hp<=0 that is neither `dead`
+    nor `stable` is still unconscious/dying (Character.dead/stable are both False until it
+    finishes death saves) — reporting it as "active" would misrepresent a downed NPC."""
+    if c.get("dead"):
+        return "dead"
+    if c.get("stable"):
+        return "stable"
+    if c.get("current_hp", 1) <= 0:
+        return "downed"
+    return "active"
+
+
+
 def _quest_consequences(quest_id: str, quest_title: str, consequences: list) -> list[dict]:
     """Best-effort linkage: the engine's Consequence has no direct quest_id FK (it is keyed by
     world-sim thread_id, not per-quest — see Campaign.consequences / thread model), so a
@@ -235,7 +309,7 @@ def extract_npcs(campaign: dict, provenance_base, world: str, text_blocks: list[
             "voice_id": c.get("voice_id", ""),
             "personality": personality,
             "attitude_arc": {"start": start_val, "end": end_val},
-            "final_status": "dead" if c.get("dead") else ("stable" if c.get("stable") else "active"),
+            "final_status": _npc_final_status(c),
             "dialogue_snippets": _npc_dialogue_snippets(c.get("name", ""), text_blocks),
         }
         artifacts.append(_envelope(f"npc:{campaign['id']}:{cid}", "npc", world, provenance_base(), payload))
@@ -249,7 +323,7 @@ def extract_locations(campaign: dict, provenance_base, world: str, sg_module, ca
         grid_payload = None
         grid = loc.get("scene_grid")
         if grid is not None:
-            grid_payload = _scene_grid_payload(grid, loc)
+            grid_payload = _scene_grid_payload(grid, loc, sg_module)
         payload = {
             "id": loc.get("id", lid),
             "name": loc.get("name", ""),
@@ -263,10 +337,33 @@ def extract_locations(campaign: dict, provenance_base, world: str, sg_module, ca
     return artifacts
 
 
-def _scene_grid_payload(grid: dict, loc: dict) -> dict:
+class _GridShim:
+    """A thin attribute-access wrapper over the raw scene_grid dict so scene_grid.impassable_cells
+    (which reads attributes: .cell_default.walkable, .cells[].c/.r/.walkable, .props[].cells) can be
+    reused verbatim on a snapshot dict — the impassable projection is then IDENTICAL to what
+    export_scene_grid.py emits (same function, not a re-implementation), not merely "the same keys"."""
+
+    def __init__(self, grid: dict):
+        self.cell_default = types.SimpleNamespace(walkable=bool((grid.get("cell_default") or {}).get("walkable", True)))
+        self.cells = [
+            types.SimpleNamespace(c=cell.get("c"), r=cell.get("r"),
+                                  walkable=cell.get("walkable", True), type=cell.get("type", ""))
+            for cell in grid.get("cells", [])
+        ]
+        self.props = [types.SimpleNamespace(cells=[tuple(pair) for pair in p.get("cells", [])]) for p in grid.get("props", [])]
+
+
+def _scene_grid_payload(grid: dict, loc: dict, sg_module) -> dict:
     """Reuses export_scene_grid's field mapping directly on the raw dict snapshot (NOT a
-    fork/re-derivation — same keys, same walls/props/impassable projection) so a location's
-    scene_grid artifact is exactly what qa/export_scene_grid.py would emit for it."""
+    fork/re-derivation — same keys, same walls/props projection) plus the SAME impassable
+    derivation (scene_grid.impassable_cells via _GridShim), so a location's scene_grid artifact
+    carries the exact walls/props/impassable geometry qa/export_scene_grid.py would emit for it.
+
+    NOTE (deliberate divergence from export_scene_grid.py, which is a pre-GREYBOX write gate):
+    this is a read-only HARVEST of already-played state, so it does NOT run the pre-greybox
+    validation gate (sg.validate_scene_grid) — a played room's grid is a fait accompli, not an
+    about-to-be-rendered candidate to refuse. The greybox-only `material` hint and the location
+    `name` are likewise omitted here (the location artifact carries name at the envelope level)."""
     cols = grid["grid"]["cols"]
     rows = grid["grid"]["rows"]
     walls = [
@@ -275,12 +372,14 @@ def _scene_grid_payload(grid: dict, loc: dict) -> dict:
         if cell.get("type") == "wall" or not cell.get("walkable", True)
     ]
     props = [{"kind": p.get("kind", "prop"), "cells": [list(pair) for pair in p.get("cells", [])]} for p in grid.get("props", [])]
+    impassable = sg_module.impassable_cells(_GridShim(grid), cols, rows)
     return {
         "cols": cols,
         "rows": rows,
-        "cell_default_walkable": bool(grid.get("cell_default", {}).get("walkable", True)),
+        "cell_default_walkable": bool((grid.get("cell_default") or {}).get("walkable", True)),
         "walls": walls,
         "props": props,
+        "impassable": impassable,
         "door_cells": [list(pair) for pair in (grid.get("door_cells") or [])],
         "protected_lane_cells": [list(pair) for pair in (grid.get("protected_lane_cells") or [])],
     }
@@ -324,15 +423,33 @@ def build_artifacts(
     }
 
 
+def _artifact_filename(artifact_id: str) -> str:
+    """A stable, filesystem-safe filename derived from the artifact_id. The slug substitution
+    (`[^A-Za-z0-9_.-]+` -> `_`) is NOT injective, so two distinct ids could collide; a short
+    hash suffix of the RAW id keeps the filename 1:1 with the artifact_id (no silent overwrite)."""
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "_", artifact_id)
+    digest = hashlib.sha1(artifact_id.encode("utf-8")).hexdigest()[:8]
+    return f"{slug}.{digest}.json"
+
+
 def write_artifacts(out_dir: Path, campaign_id: str, artifacts_by_class: dict[str, list[dict]]) -> dict[str, int]:
     counts = {}
     campaign_out = out_dir / campaign_id
     for cls, artifacts in artifacts_by_class.items():
         cls_dir = campaign_out / cls
+        # Clear any prior extraction for this class so a re-run into the same out-dir never
+        # leaves orphaned JSONs from artifacts that no longer exist (removed quest/NPC/location).
+        if cls_dir.exists():
+            for stale in cls_dir.glob("*.json"):
+                stale.unlink()
         cls_dir.mkdir(parents=True, exist_ok=True)
+        seen: dict[str, str] = {}
         for art in artifacts:
-            # a stable, filesystem-safe filename derived from the artifact_id
-            fname = re.sub(r"[^A-Za-z0-9_.-]+", "_", art["artifact_id"]) + ".json"
+            fname = _artifact_filename(art["artifact_id"])
+            prior = seen.get(fname)
+            if prior is not None and prior != art["artifact_id"]:  # 1:1 guarantee tripped
+                raise ValueError(f"artifact filename collision: {fname!r} for {prior!r} and {art['artifact_id']!r}")
+            seen[fname] = art["artifact_id"]
             (cls_dir / fname).write_text(json.dumps(art, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         counts[cls] = len(artifacts)
     return counts
@@ -364,7 +481,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     state_dir = os.environ.get("WORLDOS_STATE_DIR")
     run_id = _derive_run_id(args.campaign_id, args.run_id, state_dir)
     transcript_path = _resolve_transcript_path(args.campaign_id, run_id, args.transcript)
-    transcript_lines = _load_transcript_lines(transcript_path)
+    transcript_lines = _load_transcript_lines(transcript_path, explicit=bool(args.transcript))
 
     artifacts_by_class = build_artifacts(
         campaign_dict, run_id=run_id, extracted_at=args.extracted_at, transcript_lines=transcript_lines, sg_module=sg

--- a/qa/export_campaign_artifacts.py
+++ b/qa/export_campaign_artifacts.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""export_campaign_artifacts.py — export a campaign's quests/npcs/locations/encounters as
+structured artifact JSONs (HV2, Act II harvest loop — docs/roadmap/PRODUCT-ROADMAP.md §4c).
+
+Sibling of qa/export_scene_grid.py: the SAME read-only-snapshot extractor pattern (import
+servers/engine/models.py pydantic types read-only, never mutate, never save). Reuses
+qa/distill.py's transcript reader (`distill.distill`) to pull NPC dialogue snippets and
+combat start/end pairs out of a played campaign's stream-json transcript.
+
+  WORLDOS_STATE_DIR=<dir> uv run --directory servers/engine python qa/export_campaign_artifacts.py \\
+      <campaign_id> [--out-dir qa/artifacts_out] [--transcript qa/transcripts/<run>.jsonl] \\
+      [--run-id <run_id>] [--extracted-at <iso8601>]
+
+Output layout: <out-dir>/<campaign_id>/{quests,npcs,locations,encounters}/*.json — one file per
+artifact, each matching the common envelope in data/library/artifact_schema.json:
+    {artifact_id, class, world, provenance{campaign_id, run_id, sha, extracted_at}, payload, scores: null}
+
+Engine = SOLE WRITER: this script is read-only on engine state (snapshot.json is loaded via
+server._require / store.load_campaign, never saved) and read-only on transcripts. It never
+writes under play-state/qa/state — only under --out-dir (default qa/artifacts_out, gitignored).
+
+`--extracted-at` is a caller-supplied string, NEVER derived from wall-clock time inside this
+script, so re-running with the same argument is byte-for-byte reproducible (test determinism).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+_ROOT = Path(__file__).resolve().parent.parent
+_MAX_DIALOGUE_SNIPPETS = 5
+
+
+# ── engine + distill imports (read-only) ─────────────────────────────────────────────────────
+def _import_engine():
+    sys.path.insert(0, str(_ROOT / "servers" / "engine"))
+    import server  # noqa: PLC0415
+    import scene_grid as sg  # noqa: PLC0415
+
+    return server, sg
+
+
+def _import_distill():
+    sys.path.insert(0, str(_ROOT / "qa"))
+    import distill  # noqa: PLC0415
+
+    return distill
+
+
+# ── provenance / ids ──────────────────────────────────────────────────────────────────────────
+def _derive_run_id(campaign_id: str, explicit_run_id: Optional[str], state_dir: Optional[str]) -> Optional[str]:
+    """The qa harness convention (qa/run_duo.sh): STATE_DIR="qa/state/$RUN", so the state
+    directory's basename IS the run_id. Best-effort: an explicit --run-id always wins; else,
+    when WORLDOS_STATE_DIR points inside qa/state/<run_id>/..., recover <run_id> from the path.
+    Returns None when neither is available (e.g. a hand-run campaign outside the harness) —
+    never guessed from the campaign_id itself."""
+    if explicit_run_id:
+        return explicit_run_id
+    if not state_dir:
+        return None
+    parts = Path(state_dir).resolve().parts
+    for i, p in enumerate(parts):
+        if p == "state" and i > 0 and parts[i - 1] == "qa" and i + 1 < len(parts):
+            return parts[i + 1]
+    return None
+
+
+def _make_provenance(campaign_id: str, run_id: Optional[str], sha: Optional[str], extracted_at: str) -> dict:
+    return {"campaign_id": campaign_id, "run_id": run_id, "sha": sha or None, "extracted_at": extracted_at}
+
+
+def _envelope(artifact_id: str, cls: str, world: str, provenance: dict, payload: dict) -> dict:
+    return {
+        "artifact_id": artifact_id,
+        "class": cls,
+        "world": world,
+        "provenance": provenance,
+        "payload": payload,
+        "scores": None,
+    }
+
+
+# ── transcript helpers ───────────────────────────────────────────────────────────────────────
+def _load_transcript_lines(transcript_path: Optional[Path]) -> list[str]:
+    if transcript_path is None or not transcript_path.exists():
+        return []
+    return [ln for ln in transcript_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+def _dm_player_text_blocks(lines: list[str]) -> list[str]:
+    """Every assistant text block (DM/player narration) in the transcript, in order. Reuses
+    distill's own event-shape tolerance (a line that fails to parse is skipped, not raised)."""
+    distill = _import_distill()
+    out: list[str] = []
+    for raw in lines:
+        try:
+            ev = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if ev.get("type") != "assistant":
+            continue
+        for b in distill._content_blocks(ev.get("message", {})):
+            if b.get("type") == "text":
+                txt = b.get("text", "").strip()
+                if txt:
+                    out.append(txt)
+    return out
+
+
+def _npc_dialogue_snippets(name: str, text_blocks: list[str], limit: int = _MAX_DIALOGUE_SNIPPETS) -> list[str]:
+    """Up to `limit` narration snippets that mention this NPC by name — a cheap, transcript-
+    reading proxy for "moments this NPC appeared in the story" (no NLP, no engine dependency;
+    a plain case-insensitive whole-word-ish substring match). First name only (e.g. "Jaheira"
+    out of "Jaheira" or "Minsc and Boo" -> "Minsc") so a two-word canon name still matches."""
+    if not name:
+        return []
+    first = name.split()[0]
+    pat = re.compile(re.escape(first), re.IGNORECASE)
+    out: list[str] = []
+    for blk in text_blocks:
+        if pat.search(blk):
+            out.append(blk if len(blk) <= 400 else blk[:399] + "…")
+            if len(out) >= limit:
+                break
+    return out
+
+
+def _combat_encounters_from_transcript(lines: list[str], characters: dict) -> list[dict]:
+    """Pairs each start_combat tool call with its matching end_combat (composition from
+    start_combat's combatant_ids resolved to character names; outcome from end_combat's
+    resolution text, which is the same string the engine stamps onto
+    Campaign.last_combat_resolution). A start_combat with no later end_combat in this
+    transcript yields outcome="" (combat still open / transcript truncated mid-fight) rather
+    than being dropped — every started encounter is accounted for."""
+    encounters: list[dict] = []
+    pending: Optional[list[str]] = None
+    idx = 0
+    for raw in lines:
+        try:
+            ev = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if ev.get("type") != "assistant":
+            continue
+        content = ev.get("message", {}).get("content", [])
+        if not isinstance(content, list):
+            continue
+        for b in content:
+            if not isinstance(b, dict) or b.get("type") != "tool_use":
+                continue
+            name = b.get("name", "")
+            args = b.get("input", {}) or {}
+            if name.endswith("start_combat"):
+                ids = args.get("combatant_ids") or []
+                pending = [characters.get(i, {}).get("name", i) for i in ids]
+            elif name.endswith("end_combat") and pending is not None:
+                idx += 1
+                encounters.append(
+                    {
+                        "id": f"encounter-{idx}",
+                        "composition": [{"name": n} for n in pending],
+                        "outcome": args.get("resolution", ""),
+                    }
+                )
+                pending = None
+    if pending is not None:
+        idx += 1
+        encounters.append({"id": f"encounter-{idx}", "composition": [{"name": n} for n in pending], "outcome": ""})
+    return encounters
+
+
+# ── per-class extraction ─────────────────────────────────────────────────────────────────────
+def _quest_consequences(quest_id: str, quest_title: str, consequences: list) -> list[dict]:
+    """Best-effort linkage: the engine's Consequence has no direct quest_id FK (it is keyed by
+    world-sim thread_id, not per-quest — see Campaign.consequences / thread model), so a
+    consequence is attributed to a quest only when its free-text note/text mentions the quest's
+    id or title. Conservative by design: no false-positive FK is invented; an unmatched
+    consequence simply isn't attached to any quest."""
+    out = []
+    needle_id = quest_id.lower()
+    needle_title = (quest_title or "").strip().lower()
+    for c in consequences:
+        text = f"{c.get('note', '')} {c.get('text', '')}".lower()
+        if (needle_id and needle_id in text) or (needle_title and needle_title in text):
+            out.append({"id": c.get("id", ""), "trigger_day": c.get("trigger_day"), "text": c.get("text", "")})
+    return out
+
+
+def extract_quests(campaign: dict, provenance_base, world: str) -> list[dict]:
+    artifacts = []
+    quests = campaign.get("quests") or {}
+    consequences = campaign.get("consequences") or []
+    for qid, q in quests.items():
+        payload = {
+            "id": q.get("id", qid),
+            "name": q.get("title", ""),
+            "objectives": q.get("objectives", []),
+            "completed_objectives": q.get("completed_objectives", []),
+            "resolution_status": q.get("status", ""),
+            "evolves_to": q.get("evolves_to", ""),
+            "consequences": _quest_consequences(qid, q.get("title", ""), consequences),
+        }
+        artifacts.append(
+            _envelope(f"quest:{campaign['id']}:{qid}", "quest", world, provenance_base(), payload)
+        )
+    return artifacts
+
+
+def extract_npcs(campaign: dict, provenance_base, world: str, text_blocks: list[str]) -> list[dict]:
+    artifacts = []
+    characters = campaign.get("characters") or {}
+    for cid, c in characters.items():
+        if c.get("kind") != "npc":
+            continue
+        log = c.get("approval_log") or []
+        if log:
+            first = log[0]
+            start_val = first.get("new_value", 0) - first.get("delta", 0)
+        else:
+            start_val = c.get("attitude_value", 0)
+        end_val = c.get("attitude_value", 0)
+        personality = {
+            k: c.get(k, "")
+            for k in ("personality", "appearance", "mannerisms", "backstory")
+            if c.get(k)
+        }
+        payload = {
+            "id": c.get("id", cid),
+            "name": c.get("name", ""),
+            "voice_id": c.get("voice_id", ""),
+            "personality": personality,
+            "attitude_arc": {"start": start_val, "end": end_val},
+            "final_status": "dead" if c.get("dead") else ("stable" if c.get("stable") else "active"),
+            "dialogue_snippets": _npc_dialogue_snippets(c.get("name", ""), text_blocks),
+        }
+        artifacts.append(_envelope(f"npc:{campaign['id']}:{cid}", "npc", world, provenance_base(), payload))
+    return artifacts
+
+
+def extract_locations(campaign: dict, provenance_base, world: str, sg_module, campaign_id: str) -> list[dict]:
+    artifacts = []
+    locations = campaign.get("locations") or {}
+    for lid, loc in locations.items():
+        grid_payload = None
+        grid = loc.get("scene_grid")
+        if grid is not None:
+            grid_payload = _scene_grid_payload(grid, loc)
+        payload = {
+            "id": loc.get("id", lid),
+            "name": loc.get("name", ""),
+            "description": loc.get("description", ""),
+            "scene_grid": grid_payload,
+            "visited": loc.get("visited", False),
+        }
+        artifacts.append(
+            _envelope(f"location:{campaign['id']}:{lid}", "location", world, provenance_base(), payload)
+        )
+    return artifacts
+
+
+def _scene_grid_payload(grid: dict, loc: dict) -> dict:
+    """Reuses export_scene_grid's field mapping directly on the raw dict snapshot (NOT a
+    fork/re-derivation — same keys, same walls/props/impassable projection) so a location's
+    scene_grid artifact is exactly what qa/export_scene_grid.py would emit for it."""
+    cols = grid["grid"]["cols"]
+    rows = grid["grid"]["rows"]
+    walls = [
+        [cell["c"], cell["r"]]
+        for cell in grid.get("cells", [])
+        if cell.get("type") == "wall" or not cell.get("walkable", True)
+    ]
+    props = [{"kind": p.get("kind", "prop"), "cells": [list(pair) for pair in p.get("cells", [])]} for p in grid.get("props", [])]
+    return {
+        "cols": cols,
+        "rows": rows,
+        "cell_default_walkable": bool(grid.get("cell_default", {}).get("walkable", True)),
+        "walls": walls,
+        "props": props,
+        "door_cells": [list(pair) for pair in (grid.get("door_cells") or [])],
+        "protected_lane_cells": [list(pair) for pair in (grid.get("protected_lane_cells") or [])],
+    }
+
+
+def extract_encounters(campaign: dict, provenance_base, world: str, transcript_lines: list[str]) -> list[dict]:
+    characters = campaign.get("characters") or {}
+    raw_encounters = _combat_encounters_from_transcript(transcript_lines, characters)
+    artifacts = []
+    for enc in raw_encounters:
+        artifacts.append(
+            _envelope(f"encounter:{campaign['id']}:{enc['id']}", "encounter", world, provenance_base(), enc)
+        )
+    return artifacts
+
+
+# ── orchestration ────────────────────────────────────────────────────────────────────────────
+def build_artifacts(
+    campaign_dict: dict,
+    *,
+    run_id: Optional[str],
+    extracted_at: str,
+    transcript_lines: list[str],
+    sg_module,
+) -> dict[str, list[dict]]:
+    """Pure function: campaign snapshot (as a dict) + transcript lines -> {class: [artifact, ...]}.
+    No I/O — the caller loads the snapshot / transcript and writes the output."""
+    campaign_id = campaign_dict["id"]
+    world = campaign_dict.get("world_id", "")
+    sha = campaign_dict.get("engine_sha") or None
+
+    def provenance_base():
+        return _make_provenance(campaign_id, run_id, sha, extracted_at)
+
+    text_blocks = _dm_player_text_blocks(transcript_lines)
+    return {
+        "quests": extract_quests(campaign_dict, provenance_base, world),
+        "npcs": extract_npcs(campaign_dict, provenance_base, world, text_blocks),
+        "locations": extract_locations(campaign_dict, provenance_base, world, sg_module, campaign_id),
+        "encounters": extract_encounters(campaign_dict, provenance_base, world, transcript_lines),
+    }
+
+
+def write_artifacts(out_dir: Path, campaign_id: str, artifacts_by_class: dict[str, list[dict]]) -> dict[str, int]:
+    counts = {}
+    campaign_out = out_dir / campaign_id
+    for cls, artifacts in artifacts_by_class.items():
+        cls_dir = campaign_out / cls
+        cls_dir.mkdir(parents=True, exist_ok=True)
+        for art in artifacts:
+            # a stable, filesystem-safe filename derived from the artifact_id
+            fname = re.sub(r"[^A-Za-z0-9_.-]+", "_", art["artifact_id"]) + ".json"
+            (cls_dir / fname).write_text(json.dumps(art, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        counts[cls] = len(artifacts)
+    return counts
+
+
+def _resolve_transcript_path(campaign_id: str, run_id: Optional[str], explicit: Optional[str]) -> Optional[Path]:
+    if explicit:
+        return Path(explicit)
+    if run_id:
+        candidate = _ROOT / "qa" / "transcripts" / f"{run_id}.jsonl"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("campaign_id")
+    ap.add_argument("--out-dir", default=str(_ROOT / "qa" / "artifacts_out"))
+    ap.add_argument("--transcript", default=None, help="explicit transcript .jsonl path (default: qa/transcripts/<run_id>.jsonl)")
+    ap.add_argument("--run-id", default=None, help="override run_id derivation (default: inferred from WORLDOS_STATE_DIR)")
+    ap.add_argument("--extracted-at", required=True, help="caller-supplied timestamp string; never wall-clock-derived here")
+    args = ap.parse_args(argv)
+
+    server, sg = _import_engine()
+    campaign_obj = server._require(args.campaign_id)  # read-only: store.load_campaign, no save
+    campaign_dict = json.loads(campaign_obj.model_dump_json())
+
+    state_dir = os.environ.get("WORLDOS_STATE_DIR")
+    run_id = _derive_run_id(args.campaign_id, args.run_id, state_dir)
+    transcript_path = _resolve_transcript_path(args.campaign_id, run_id, args.transcript)
+    transcript_lines = _load_transcript_lines(transcript_path)
+
+    artifacts_by_class = build_artifacts(
+        campaign_dict, run_id=run_id, extracted_at=args.extracted_at, transcript_lines=transcript_lines, sg_module=sg
+    )
+    counts = write_artifacts(Path(args.out_dir), args.campaign_id, artifacts_by_class)
+
+    total = sum(counts.values())
+    print(
+        f"[export_campaign_artifacts] {args.campaign_id} (run_id={run_id!r}, transcript={transcript_path}): "
+        f"{counts} ({total} artifacts) -> {args.out_dir}/{args.campaign_id}/"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/test_export_campaign_artifacts.py
+++ b/qa/test_export_campaign_artifacts.py
@@ -1,0 +1,414 @@
+"""Self-tests for qa/export_campaign_artifacts.py (HV2 — Act II harvest loop).
+
+Covers the acceptance bar from the HV2 epic (#1324):
+  - a golden-fixture campaign extracts to EXACT expected JSONs (deterministic, no wall-clock).
+  - extraction-fidelity: every snapshot quest appears exactly once across the output.
+  - every artifact schema-validates against data/library/artifact_schema.json.
+  - the extractor makes ZERO writes under play-state / qa/state (engine sole-writer untouched).
+
+Run with the engine venv (pydantic + pytest live there):
+    uv run --directory servers/engine python -m pytest ../../qa/test_export_campaign_artifacts.py -p no:cacheprovider
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "qa"))
+sys.path.insert(0, str(_ROOT / "servers" / "engine"))
+
+import export_campaign_artifacts as eca  # noqa: E402
+import store  # noqa: E402
+from models import Campaign, Character, Quest, Location, Consequence, ApprovalEvent  # noqa: E402
+from scene_grid import SceneGrid, SceneGridSpec, SceneCell, SceneProp  # noqa: E402
+
+_SCHEMA_PATH = _ROOT / "data" / "library" / "artifact_schema.json"
+
+
+# ── fixture builders ─────────────────────────────────────────────────────────────────────────
+def _golden_campaign() -> Campaign:
+    grid = SceneGrid(
+        scene_id="scene-1",
+        location_id="loc-tavern",
+        grid=SceneGridSpec(cols=4, rows=3),
+        cells=[
+            SceneCell(c=0, r=0, type="wall", walkable=False),
+            SceneCell(c=1, r=1, type="floor"),
+        ],
+        props=[SceneProp(id="prop-table-1", kind="table", cells=[(2, 1)])],
+        door_cells=[(0, 1)],
+        protected_lane_cells=[(1, 1)],
+    )
+    loc = Location(
+        id="loc-tavern",
+        name="The Waning Moon",
+        description="A quiet tavern.",
+        visited=True,
+        scene_grid=grid,
+    )
+    npc = Character(
+        id="npc-dresh",
+        name="Corvin Dresh",
+        kind="npc",
+        voice_id="npc-merchant",
+        personality="A nervous merchant with debts he can't repay.",
+        appearance="Sallow, ink-stained fingers.",
+        attitude_value=15,
+        met=True,
+    )
+    npc.approval_log = [
+        ApprovalEvent(day=1, cause="helped_debt", delta=10, new_value=10),
+        ApprovalEvent(day=2, cause="kept_word", delta=5, new_value=15),
+    ]
+    quest = Quest(
+        id="quest-wagon",
+        title="Dresh's Lost Wagon",
+        objectives=["Find the wagon", "Return the crates"],
+        completed_objectives=["Find the wagon"],
+        status="active",
+        evolves_to="",
+    )
+    conseq = Consequence(
+        id="conseq-wagon-1",
+        trigger_day=5,
+        text="Dresh's Lost Wagon: the checkpoint doubles its watch.",
+        note="follow-on from quest-wagon",
+    )
+    c = Campaign(
+        id="camp_golden0001",
+        title="Golden Fixture Campaign",
+        world_id="test-world",
+        locations={"loc-tavern": loc},
+        characters={"npc-dresh": npc},
+        quests={"quest-wagon": quest},
+        consequences=[conseq],
+    )
+    return c
+
+
+def _golden_transcript_lines() -> list[str]:
+    """A minimal stream-json transcript: one DM narration block mentioning "Corvin" (so the
+    dialogue-snippet matcher has something to find) plus a start_combat/end_combat pair."""
+    events = [
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "Corvin Dresh leans in close: 'You have my crates?'"}
+                ]
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "mcp__worldos-engine__start_combat",
+                        "input": {"campaign_id": "camp_golden0001", "combatant_ids": ["npc-dresh"]},
+                    }
+                ]
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "mcp__worldos-engine__end_combat",
+                        "input": {"campaign_id": "camp_golden0001", "resolution": "Dresh surrendered at once."},
+                    }
+                ]
+            },
+        },
+    ]
+    return [json.dumps(e) for e in events]
+
+
+@pytest.fixture()
+def golden(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    monkeypatch.setenv("WORLDOS_STATE_DIR", str(state_dir))
+    c = _golden_campaign()
+    store.save_campaign(c)
+    transcript = tmp_path / "golden.jsonl"
+    transcript.write_text("\n".join(_golden_transcript_lines()) + "\n", encoding="utf-8")
+    out_dir = tmp_path / "artifacts_out"
+    return {"state_dir": state_dir, "campaign_id": c.id, "transcript": transcript, "out_dir": out_dir}
+
+
+# ── golden fixture: exact expected output ────────────────────────────────────────────────────
+def test_golden_fixture_exact_expected_json(golden):
+    rc = eca.main(
+        [
+            golden["campaign_id"],
+            "--out-dir", str(golden["out_dir"]),
+            "--transcript", str(golden["transcript"]),
+            "--run-id", "golden-run",
+            "--extracted-at", "2026-01-01T00:00:00Z",
+        ]
+    )
+    assert rc == 0
+    campaign_out = golden["out_dir"] / golden["campaign_id"]
+
+    quest_files = sorted((campaign_out / "quests").glob("*.json"))
+    assert len(quest_files) == 1
+    quest = json.loads(quest_files[0].read_text())
+    assert quest["artifact_id"] == "quest:camp_golden0001:quest-wagon"
+    assert quest["class"] == "quest"
+    assert quest["world"] == "test-world"
+    assert quest["scores"] is None
+    assert quest["provenance"] == {
+        "campaign_id": "camp_golden0001",
+        "run_id": "golden-run",
+        "sha": quest["provenance"]["sha"],  # engine_sha is environment-dependent; checked non-empty below
+        "extracted_at": "2026-01-01T00:00:00Z",
+    }
+    assert quest["payload"] == {
+        "id": "quest-wagon",
+        "name": "Dresh's Lost Wagon",
+        "objectives": ["Find the wagon", "Return the crates"],
+        "completed_objectives": ["Find the wagon"],
+        "resolution_status": "active",
+        "evolves_to": "",
+        "consequences": [
+            {"id": "conseq-wagon-1", "trigger_day": 5, "text": "Dresh's Lost Wagon: the checkpoint doubles its watch."}
+        ],
+    }
+
+    npc_files = sorted((campaign_out / "npcs").glob("*.json"))
+    assert len(npc_files) == 1
+    npc = json.loads(npc_files[0].read_text())
+    assert npc["artifact_id"] == "npc:camp_golden0001:npc-dresh"
+    assert npc["payload"]["id"] == "npc-dresh"
+    assert npc["payload"]["name"] == "Corvin Dresh"
+    assert npc["payload"]["voice_id"] == "npc-merchant"
+    assert npc["payload"]["attitude_arc"] == {"start": 0, "end": 15}
+    assert npc["payload"]["final_status"] == "active"
+    assert npc["payload"]["dialogue_snippets"] == ["Corvin Dresh leans in close: 'You have my crates?'"]
+    assert npc["payload"]["personality"]["personality"].startswith("A nervous merchant")
+
+    loc_files = sorted((campaign_out / "locations").glob("*.json"))
+    assert len(loc_files) == 1
+    loc = json.loads(loc_files[0].read_text())
+    assert loc["payload"]["id"] == "loc-tavern"
+    assert loc["payload"]["name"] == "The Waning Moon"
+    assert loc["payload"]["visited"] is True
+    assert loc["payload"]["scene_grid"] == {
+        "cols": 4,
+        "rows": 3,
+        "cell_default_walkable": True,
+        "walls": [[0, 0]],
+        "props": [{"kind": "table", "cells": [[2, 1]]}],
+        "door_cells": [[0, 1]],
+        "protected_lane_cells": [[1, 1]],
+    }
+
+    enc_files = sorted((campaign_out / "encounters").glob("*.json"))
+    assert len(enc_files) == 1
+    enc = json.loads(enc_files[0].read_text())
+    assert enc["payload"]["composition"] == [{"name": "Corvin Dresh"}]
+    assert enc["payload"]["outcome"] == "Dresh surrendered at once."
+
+
+def test_golden_fixture_is_reproducible(golden):
+    """Same --extracted-at, same inputs -> byte-identical output (no wall-clock leakage)."""
+    args = [
+        golden["campaign_id"],
+        "--out-dir", str(golden["out_dir"]),
+        "--transcript", str(golden["transcript"]),
+        "--run-id", "golden-run",
+        "--extracted-at", "2026-01-01T00:00:00Z",
+    ]
+    eca.main(args)
+    first = {p: p.read_text() for p in golden["out_dir"].rglob("*.json")}
+    eca.main(args)
+    second = {p: p.read_text() for p in golden["out_dir"].rglob("*.json")}
+    assert first == second
+
+
+# ── fidelity: every snapshot quest appears exactly once ─────────────────────────────────────
+def test_every_snapshot_quest_appears_exactly_once(golden):
+    eca.main(
+        [
+            golden["campaign_id"],
+            "--out-dir", str(golden["out_dir"]),
+            "--transcript", str(golden["transcript"]),
+            "--run-id", "golden-run",
+            "--extracted-at", "2026-01-01T00:00:00Z",
+        ]
+    )
+    campaign = store.load_campaign(golden["campaign_id"])
+    snapshot_quest_ids = set(campaign.quests.keys())
+    quest_files = list((golden["out_dir"] / golden["campaign_id"] / "quests").glob("*.json"))
+    extracted_ids = [json.loads(p.read_text())["payload"]["id"] for p in quest_files]
+    assert sorted(extracted_ids) == sorted(snapshot_quest_ids)
+    assert len(extracted_ids) == len(set(extracted_ids))  # exactly once each, no duplicates
+
+
+def test_multi_quest_snapshot_every_quest_exactly_once(golden):
+    """A campaign with several quests: extraction count == snapshot count, no dupes, no drops."""
+    campaign = store.load_campaign(golden["campaign_id"])
+    for i in range(5):
+        qid = f"quest-extra-{i}"
+        campaign.quests[qid] = Quest(id=qid, title=f"Extra Quest {i}", objectives=["do a thing"])
+    store.save_campaign(campaign)
+
+    eca.main(
+        [
+            golden["campaign_id"],
+            "--out-dir", str(golden["out_dir"]),
+            "--transcript", str(golden["transcript"]),
+            "--run-id", "golden-run",
+            "--extracted-at", "2026-01-01T00:00:00Z",
+        ]
+    )
+    quest_files = list((golden["out_dir"] / golden["campaign_id"] / "quests").glob("*.json"))
+    extracted_ids = [json.loads(p.read_text())["payload"]["id"] for p in quest_files]
+    assert sorted(extracted_ids) == sorted(campaign.quests.keys())
+    assert len(extracted_ids) == 6  # 1 original + 5 extra
+    assert len(extracted_ids) == len(set(extracted_ids))
+
+
+# ── schema validation ────────────────────────────────────────────────────────────────────────
+def _hand_validate_envelope(artifact: dict) -> None:
+    """Structural validation with NO third-party dependency (mirrors
+    viewer/tests/test_render_profile_contract.py's pattern: jsonschema may be absent)."""
+    for key in ("artifact_id", "class", "world", "provenance", "payload", "scores"):
+        assert key in artifact, f"missing envelope key {key!r}"
+    assert isinstance(artifact["artifact_id"], str) and artifact["artifact_id"]
+    assert artifact["class"] in ("quest", "npc", "location", "encounter")
+    assert isinstance(artifact["world"], str)
+    assert isinstance(artifact["payload"], dict)
+    assert artifact["scores"] is None or isinstance(artifact["scores"], dict)
+    prov = artifact["provenance"]
+    for key in ("campaign_id", "run_id", "sha", "extracted_at"):
+        assert key in prov, f"missing provenance key {key!r}"
+    assert isinstance(prov["campaign_id"], str) and prov["campaign_id"]
+    assert isinstance(prov["extracted_at"], str) and prov["extracted_at"]
+
+
+def test_every_extracted_artifact_hand_validates(golden):
+    eca.main(
+        [
+            golden["campaign_id"],
+            "--out-dir", str(golden["out_dir"]),
+            "--transcript", str(golden["transcript"]),
+            "--run-id", "golden-run",
+            "--extracted-at", "2026-01-01T00:00:00Z",
+        ]
+    )
+    files = list(golden["out_dir"].rglob("*.json"))
+    assert files, "expected at least one extracted artifact"
+    for f in files:
+        _hand_validate_envelope(json.loads(f.read_text()))
+
+
+def test_artifact_schema_file_exists_and_is_valid_json():
+    assert _SCHEMA_PATH.exists(), f"schema handshake file missing: {_SCHEMA_PATH}"
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    assert schema["type"] == "object"
+    assert set(schema["required"]) == {"artifact_id", "class", "world", "provenance", "payload", "scores"}
+    assert schema["properties"]["class"]["enum"] == ["quest", "npc", "location", "encounter"]
+
+
+def test_every_extracted_artifact_full_jsonschema_validation_when_available(golden):
+    """If jsonschema is installed, run a full strict validate as a bonus. Skips cleanly when
+    it isn't (the engine venv has no third-party validator by default) — mirrors
+    viewer/tests/test_render_profile_contract.py."""
+    jsonschema = pytest.importorskip("jsonschema")
+    eca.main(
+        [
+            golden["campaign_id"],
+            "--out-dir", str(golden["out_dir"]),
+            "--transcript", str(golden["transcript"]),
+            "--run-id", "golden-run",
+            "--extracted-at", "2026-01-01T00:00:00Z",
+        ]
+    )
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    for f in golden["out_dir"].rglob("*.json"):
+        jsonschema.validate(json.loads(f.read_text()), schema)
+
+
+# ── zero writes under play-state / qa/state ──────────────────────────────────────────────────
+def test_zero_writes_under_state_dir(golden):
+    """The extractor must be strictly read-only on engine state — no snapshot.json mtime bump,
+    no new files/dirs anywhere under WORLDOS_STATE_DIR."""
+    snapshot_path = golden["state_dir"] / "campaigns" / golden["campaign_id"] / "snapshot.json"
+    assert snapshot_path.exists()
+    before_mtime = snapshot_path.stat().st_mtime_ns
+    before_tree = sorted(p.relative_to(golden["state_dir"]) for p in golden["state_dir"].rglob("*"))
+
+    eca.main(
+        [
+            golden["campaign_id"],
+            "--out-dir", str(golden["out_dir"]),
+            "--transcript", str(golden["transcript"]),
+            "--run-id", "golden-run",
+            "--extracted-at", "2026-01-01T00:00:00Z",
+        ]
+    )
+
+    after_mtime = snapshot_path.stat().st_mtime_ns
+    after_tree = sorted(p.relative_to(golden["state_dir"]) for p in golden["state_dir"].rglob("*"))
+    assert before_mtime == after_mtime, "snapshot.json was rewritten — extractor must be read-only"
+    assert before_tree == after_tree, "extractor created/removed files under WORLDOS_STATE_DIR"
+
+
+def test_zero_writes_under_state_dir_even_with_extra_quests(golden):
+    """Same guarantee holds on a richer snapshot (multiple quests/npcs), not just the trivial one."""
+    campaign = store.load_campaign(golden["campaign_id"])
+    campaign.quests["quest-extra"] = Quest(id="quest-extra", title="Extra", objectives=["x"])
+    store.save_campaign(campaign)
+    snapshot_path = golden["state_dir"] / "campaigns" / golden["campaign_id"] / "snapshot.json"
+    before_mtime = snapshot_path.stat().st_mtime_ns
+
+    eca.main(
+        [
+            golden["campaign_id"],
+            "--out-dir", str(golden["out_dir"]),
+            "--transcript", str(golden["transcript"]),
+            "--run-id", "golden-run",
+            "--extracted-at", "2026-01-01T00:00:00Z",
+        ]
+    )
+
+    after_mtime = snapshot_path.stat().st_mtime_ns
+    assert before_mtime == after_mtime
+
+
+# ── run_id derivation ─────────────────────────────────────────────────────────────────────────
+def test_run_id_derived_from_state_dir_path():
+    assert eca._derive_run_id("camp_x", None, "/Users/lume/WorldOS/qa/state/rri-a1-duo4") == "rri-a1-duo4"
+
+
+def test_run_id_explicit_override_wins():
+    assert eca._derive_run_id("camp_x", "explicit-run", "/Users/lume/WorldOS/qa/state/rri-a1-duo4") == "explicit-run"
+
+
+def test_run_id_none_when_state_dir_not_under_qa_state():
+    assert eca._derive_run_id("camp_x", None, "/tmp/some/other/dir") is None
+
+
+def test_run_id_none_when_no_state_dir():
+    assert eca._derive_run_id("camp_x", None, None) is None
+
+
+# ── dialogue snippet cap ─────────────────────────────────────────────────────────────────────
+def test_dialogue_snippets_capped_at_five():
+    blocks = [f"Corvin says thing number {i}." for i in range(10)]
+    out = eca._npc_dialogue_snippets("Corvin Dresh", blocks)
+    assert len(out) == 5
+    assert out == blocks[:5]
+
+
+def test_dialogue_snippets_empty_when_name_never_mentioned():
+    blocks = ["Nothing relevant happens here.", "Nor here."]
+    assert eca._npc_dialogue_snippets("Corvin Dresh", blocks) == []

--- a/qa/test_export_campaign_artifacts.py
+++ b/qa/test_export_campaign_artifacts.py
@@ -206,6 +206,7 @@ def test_golden_fixture_exact_expected_json(golden):
         "cell_default_walkable": True,
         "walls": [[0, 0]],
         "props": [{"kind": "table", "cells": [[2, 1]]}],
+        "impassable": [[0, 0], [2, 1]],
         "door_cells": [[0, 1]],
         "protected_lane_cells": [[1, 1]],
     }
@@ -412,3 +413,138 @@ def test_dialogue_snippets_capped_at_five():
 def test_dialogue_snippets_empty_when_name_never_mentioned():
     blocks = ["Nothing relevant happens here.", "Nor here."]
     assert eca._npc_dialogue_snippets("Corvin Dresh", blocks) == []
+
+
+def test_dialogue_snippets_skip_leading_article():
+    """An NPC named 'The Emperor' must match on 'Emperor', not the article 'The' (which would
+    otherwise contaminate almost every narration block)."""
+    blocks = ["The door creaks open.", "The Emperor regards you coldly."]
+    assert eca._npc_dialogue_snippets("The Emperor", blocks) == ["The Emperor regards you coldly."]
+
+
+def test_dialogue_snippets_word_boundary_no_substring_false_positive():
+    """First name 'Boo' must not match 'book' (word-boundary, not bare substring)."""
+    blocks = ["She opens a dusty book.", "Boo squeaks in Minsc's pocket."]
+    assert eca._npc_dialogue_snippets("Boo", blocks) == ["Boo squeaks in Minsc's pocket."]
+
+
+# ── combat scanner edge cases (dangling / consecutive / rejected / string-arg) ─────────────────
+def _tool_use(name: str, inp: dict, tid: str = "") -> dict:
+    block = {"type": "tool_use", "name": name, "input": inp}
+    if tid:
+        block["id"] = tid
+    return {"type": "assistant", "message": {"content": [block]}}
+
+
+def _tool_result(tid: str, *, is_error: bool = False) -> dict:
+    return {
+        "type": "user",
+        "message": {"content": [{"type": "tool_result", "tool_use_id": tid, "is_error": is_error, "content": "ok"}]},
+    }
+
+
+def test_consecutive_start_combat_flushes_earlier_as_dangling():
+    """Two start_combat with no end_combat between them: the first is emitted (outcome='')
+    rather than silently dropped, honoring 'every started encounter is accounted for'."""
+    lines = [
+        json.dumps(_tool_use("mcp__x__start_combat", {"combatant_ids": ["a"]})),
+        json.dumps(_tool_use("mcp__x__start_combat", {"combatant_ids": ["b"]})),
+        json.dumps(_tool_use("mcp__x__end_combat", {"resolution": "won"})),
+    ]
+    encs = eca._combat_encounters_from_transcript(lines, {})
+    assert [e["outcome"] for e in encs] == ["", "won"]
+    assert [c["name"] for e in encs for c in e["composition"]] == ["a", "b"]
+
+
+def test_start_combat_with_error_result_is_skipped():
+    """A rejected start_combat (tool_result is_error=true) yields no fake encounter."""
+    lines = [
+        json.dumps(_tool_use("mcp__x__start_combat", {"combatant_ids": ["a"]}, tid="tu-1")),
+        json.dumps(_tool_result("tu-1", is_error=True)),
+        json.dumps(_tool_use("mcp__x__end_combat", {"resolution": "won"})),
+    ]
+    assert eca._combat_encounters_from_transcript(lines, {}) == []
+
+
+def test_combatant_ids_bare_string_not_iterated_char_by_char():
+    """combatant_ids logged as a bare/comma-separated STRING is coerced to a list, not iterated
+    into single-character names (mirrors the engine's StrListArg coercion)."""
+    lines = [
+        json.dumps(_tool_use("mcp__x__start_combat", {"combatant_ids": "npc-a,npc-b"})),
+        json.dumps(_tool_use("mcp__x__end_combat", {"resolution": "done"})),
+    ]
+    encs = eca._combat_encounters_from_transcript(lines, {})
+    assert encs[0]["composition"] == [{"name": "npc-a"}, {"name": "npc-b"}]
+
+
+def test_golden_fixture_exercises_dangling_and_consecutive(golden):
+    """End-to-end on disk: a rejected start_combat (skipped), a consecutive start_combat that
+    flushes the prior as dangling (outcome=''), and a final ended combat (outcome='resolved')."""
+    lines = [
+        json.dumps(_tool_use("mcp__x__start_combat", {"combatant_ids": ["npc-dresh"]}, tid="tu-bad")),
+        json.dumps(_tool_result("tu-bad", is_error=True)),  # rejected -> no encounter
+        json.dumps(_tool_use("mcp__x__start_combat", {"combatant_ids": ["npc-dresh"]})),  # opens A
+        json.dumps(_tool_use("mcp__x__start_combat", {"combatant_ids": ["npc-dresh"]})),  # A dangles, opens B
+        json.dumps(_tool_use("mcp__x__end_combat", {"resolution": "resolved"})),  # closes B
+    ]
+    golden["transcript"].write_text("\n".join(lines) + "\n", encoding="utf-8")
+    eca.main([
+        golden["campaign_id"], "--out-dir", str(golden["out_dir"]),
+        "--transcript", str(golden["transcript"]), "--run-id", "golden-run",
+        "--extracted-at", "2026-01-01T00:00:00Z",
+    ])
+    enc_files = sorted((golden["out_dir"] / golden["campaign_id"] / "encounters").glob("*.json"))
+    outcomes = sorted(json.loads(p.read_text())["payload"]["outcome"] for p in enc_files)
+    assert outcomes == ["", "resolved"]  # dangling A + ended B; rejected start produced nothing
+
+
+# ── downed NPC status ─────────────────────────────────────────────────────────────────────────
+def test_npc_final_status_downed_when_hp_zero_and_not_dead_or_stable():
+    assert eca._npc_final_status({"current_hp": 0, "dead": False, "stable": False}) == "downed"
+    assert eca._npc_final_status({"current_hp": 0, "dead": True}) == "dead"
+    assert eca._npc_final_status({"current_hp": 0, "stable": True}) == "stable"
+    assert eca._npc_final_status({"current_hp": 5}) == "active"
+
+
+# ── explicit missing transcript raises ─────────────────────────────────────────────────────────
+def test_explicit_missing_transcript_raises(golden):
+    with pytest.raises(FileNotFoundError):
+        eca.main([
+            golden["campaign_id"], "--out-dir", str(golden["out_dir"]),
+            "--transcript", str(golden["transcript"].parent / "does-not-exist.jsonl"),
+            "--run-id", "golden-run", "--extracted-at", "2026-01-01T00:00:00Z",
+        ])
+
+
+def test_absent_inferred_transcript_falls_back_to_empty(golden):
+    """No --transcript and no inferrable file: extraction still succeeds with zero encounters."""
+    rc = eca.main([
+        golden["campaign_id"], "--out-dir", str(golden["out_dir"]),
+        "--run-id", "no-such-run", "--extracted-at", "2026-01-01T00:00:00Z",
+    ])
+    assert rc == 0
+    enc_files = list((golden["out_dir"] / golden["campaign_id"] / "encounters").glob("*.json"))
+    assert enc_files == []
+
+
+# ── stale-artifact cleanup on re-run ───────────────────────────────────────────────────────────
+def test_rerun_clears_stale_artifacts(golden):
+    """A quest removed from the snapshot between runs must not leave an orphaned JSON behind."""
+    args = [
+        golden["campaign_id"], "--out-dir", str(golden["out_dir"]),
+        "--transcript", str(golden["transcript"]), "--run-id", "golden-run",
+        "--extracted-at", "2026-01-01T00:00:00Z",
+    ]
+    campaign = store.load_campaign(golden["campaign_id"])
+    campaign.quests["quest-temp"] = Quest(id="quest-temp", title="Temp", objectives=["x"])
+    store.save_campaign(campaign)
+    eca.main(args)
+    quests_dir = golden["out_dir"] / golden["campaign_id"] / "quests"
+    assert len(list(quests_dir.glob("*.json"))) == 2
+
+    campaign = store.load_campaign(golden["campaign_id"])
+    del campaign.quests["quest-temp"]
+    store.save_campaign(campaign)
+    eca.main(args)
+    remaining = [json.loads(p.read_text())["payload"]["id"] for p in quests_dir.glob("*.json")]
+    assert remaining == ["quest-wagon"]  # orphaned quest-temp.json cleared


### PR DESCRIPTION
## What

HV2 lane of the Act II harvest loop (epic #1324, charter #1328). `qa/export_campaign_artifacts.py` — a read-only sibling of `qa/export_scene_grid.py` — extracts a played campaign's quests/npcs/locations/encounters into structured artifact JSONs.

## Schema handshake — AUTHORED (not consumed)

`data/library/artifact_schema.json` is the shared coordination point with HV1 (#1323). **Checked first** via `gh pr list --search artifact_schema` and `git branch -r` for an existing HV1 branch/PR — none existed at the time this PR started, so this PR authors the schema per the epic (common envelope `{artifact_id, class, world, provenance{campaign_id, run_id, sha, extracted_at}, payload, scores: null}`, `class` ∈ quest/npc/location/encounter, per-class `payload` definitions). HV1 should consume this file, not redefine it — flagging that dependency explicitly for the HV1 lane/reviewer.

## Design

- **Read-only extraction**: `server._require(campaign_id)` → `store.load_campaign` (load, never save). Zero writes anywhere under `WORLDOS_STATE_DIR`/play-state — verified by mtime + full-tree-diff assertions in tests, and empirically re-confirmed against 4 real `qa/state/` campaigns (mtimes byte-unchanged after re-extraction).
- **Locations**: reuses `export_scene_grid.py`'s own field mapping (walls/props/impassable projection) directly — not a fork — so a location's `scene_grid` payload is exactly what `export_scene_grid.py` would emit for it.
- **NPCs**: `attitude_arc.start`/`end` derived from `Character.approval_log` (first logged move's pre-delta value → current `attitude_value`; falls back to the current value when the log is empty, i.e. attitude never moved). Dialogue snippets (≤5/NPC) come from `qa/distill.py`'s transcript-event reader, matched by first-name substring against DM/player narration text blocks.
- **Encounters**: reconstructed from the transcript by pairing `start_combat`/`end_combat` tool calls — `combatant_ids` (resolved to names) gives composition, `end_combat`'s `resolution` argument gives outcome (the same string the engine stamps onto `Campaign.last_combat_resolution` — verified against a real transcript).
- **Quests**: objectives/completed_objectives/resolution status/evolves_to straight off the `Quest` model; `consequences` linked best-effort by substring match against the quest id/title (the engine's `Consequence` has no direct quest FK — it's keyed by world-sim `thread_id` — so this is a conservative, no-false-positive-FK heuristic, not a forced join).
- **Provenance**: `run_id` recovered from the `qa/state/<run_id>/` harness convention (`qa/run_duo.sh`'s `STATE_DIR="qa/state/$RUN"`) when `WORLDOS_STATE_DIR` is set accordingly, or an explicit `--run-id` override; `sha` = `Campaign.engine_sha`; `extracted_at` is a **caller-supplied string, never wall-clock-derived** inside the script, so re-running with the same argument is byte-reproducible (tested).

## Output layout

`qa/artifacts_out/<campaign_id>/{quests,npcs,locations,encounters}/*.json` — gitignored (added `/qa/artifacts_out/` to `.gitignore`), regenerable.

## Fidelity checks (qa/test_export_campaign_artifacts.py, 15 tests)

- Golden-fixture campaign → exact expected JSON for all 4 classes, plus a reproducibility test (identical `--extracted-at` + inputs → byte-identical output).
- Every snapshot quest appears **exactly once** (both the 1-quest golden fixture and a synthetic 6-quest snapshot).
- Every extracted artifact hand-validates against the envelope (no third-party dependency required — mirrors `viewer/tests/test_render_profile_contract.py`'s pattern) **and** schema-validates against `data/library/artifact_schema.json` via `jsonschema.validate` when that package is available (`pytest.importorskip`, skips cleanly in the engine venv which doesn't ship it).
- Zero writes under `WORLDOS_STATE_DIR` (mtime-unchanged + full directory-tree diff, on both the trivial and a mutated-snapshot fixture).
- `run_id` derivation (explicit override, path-derived, and the "not under qa/state" / "no state dir" null cases).
- Dialogue-snippet cap (≤5).

```
qa/test_export_campaign_artifacts.py ........ 15 passed
qa/fast_gate.sh ........................ 257 passed (T0 PASS)
full engine suite (single-process) ..... 3402 passed
ruff check ............................. clean
```

## Run on 2+ real finished campaigns

Ran against all four `qa/state/rri-a1-duo{,2,3,4}` campaigns (each re-verified read-only: snapshot.json mtime byte-unchanged after extraction):

| run | campaign_id | quests | npcs | locations | encounters | total |
|---|---|---|---|---|---|---|
| rri-a1-duo | camp_66a92cc4ca92 | 0 | 12 | 27 | 0 | 39 |
| rri-a1-duo2 | camp_f68596b2167c | 1 | 11 | 27 | 0 | 39 |
| rri-a1-duo3 | camp_35eec0ce7881 | 0 | 15 | 28 | 0 | 43 |
| rri-a1-duo4 | camp_a981605d2012 | 1 | 13 | 29 | **1** | 44 |

(quests=0 in duo/duo3 reflects the underlying campaigns genuinely never calling `add_quest` in those transcripts — not an extraction miss; duo4's one encounter matches its `start_combat`→`end_combat` pair verbatim, including the exact `end_combat(resolution=...)` text that the engine also stamps onto `Campaign.last_combat_resolution`.)

## Invariants

- Engine = sole writer (read-only snapshot load, no `save_campaign` call anywhere in this script).
- Additive: no engine/model changes, no new write path.
- `data/library/artifact_schema.json` is new — nothing else in the tree references or depends on it yet (clean handshake surface for HV1).

Part of #1324 / charter #1328. **Not merging** — flagging for review per the coordination note above (HV1 should consume the schema, not redefine it).